### PR TITLE
feat: add long-poll support to get_task endpoint

### DIFF
--- a/internal/api/handlers/tasks.go
+++ b/internal/api/handlers/tasks.go
@@ -226,6 +226,11 @@ func (h *TasksHandler) Create(w http.ResponseWriter, r *http.Request) {
 //
 // GET /api/tasks/{id}
 // Auth: agent bearer token
+//
+// Query params:
+//
+//	wait=true    – long-poll until the task leaves a pending state (or timeout)
+//	timeout=N    – wait timeout in seconds (default 120, max 120)
 func (h *TasksHandler) Get(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	agent := middleware.AgentFromContext(ctx)
@@ -249,8 +254,79 @@ func (h *TasksHandler) Get(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Long-poll: if wait=true and task is still pending, block until it
+	// transitions or the timeout elapses.
+	if r.URL.Query().Get("wait") == "true" && isTaskPending(task.Status) && h.eventHub != nil {
+		timeout := 120
+		if v := r.URL.Query().Get("timeout"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				timeout = n
+			}
+		}
+		if timeout > 120 {
+			timeout = 120
+		}
+
+		task = h.waitForTaskResolution(ctx, taskID, agent.UserID, time.Duration(timeout)*time.Second)
+	}
+
 	sanitizeTaskForResponse(task)
 	writeJSON(w, http.StatusOK, task)
+}
+
+// isTaskPending returns true if the status represents a state that is
+// waiting on user action.
+func isTaskPending(status string) bool {
+	return status == "pending_approval" || status == "pending_scope_expansion"
+}
+
+// waitForTaskResolution subscribes to the event hub and re-fetches the task
+// each time a "tasks" event fires for the owning user. It returns as soon as
+// the task leaves a pending state or the timeout / request context expires.
+func (h *TasksHandler) waitForTaskResolution(ctx context.Context, taskID, userID string, timeout time.Duration) *store.Task {
+	ch, unsub := h.eventHub.Subscribe(userID)
+	defer unsub()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			// Client disconnected.
+			t, err := h.st.GetTask(ctx, taskID)
+			if err != nil {
+				return &store.Task{ID: taskID}
+			}
+			return t
+		case <-timer.C:
+			// Timeout — return whatever state the task is in now.
+			t, err := h.st.GetTask(context.Background(), taskID)
+			if err != nil {
+				return &store.Task{ID: taskID}
+			}
+			return t
+		case evt, ok := <-ch:
+			if !ok {
+				// Hub closed.
+				t, err := h.st.GetTask(context.Background(), taskID)
+				if err != nil {
+					return &store.Task{ID: taskID}
+				}
+				return t
+			}
+			if evt.Type != "tasks" {
+				continue
+			}
+			t, err := h.st.GetTask(ctx, taskID)
+			if err != nil {
+				continue
+			}
+			if !isTaskPending(t.Status) {
+				return t
+			}
+		}
+	}
 }
 
 // ── List ──────────────────────────────────────────────────────────────────────

--- a/internal/api/longpoll_test.go
+++ b/internal/api/longpoll_test.go
@@ -1,0 +1,283 @@
+package api_test
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+)
+
+// ── Long-poll GET /api/tasks/{id}?wait=true ──────────────────────────────────
+
+func TestGetTask_LongPoll_ReturnsImmediately_WhenAlreadyApproved(t *testing.T) {
+	adapter := newMockAdapter("mock.echo", "echo")
+	env := newTestEnv(t, adapter)
+	sc := newScenario(t, env, "bot")
+
+	taskID := sc.createApprovedTask(t, env, "mock.echo", "echo", true)
+
+	// Long-poll on an already-active task should return immediately.
+	start := time.Now()
+	resp := env.do("GET", fmt.Sprintf("/api/tasks/%s?wait=true&timeout=5", taskID), sc.AgentToken, nil)
+	elapsed := time.Since(start)
+
+	body := mustStatus(t, resp, http.StatusOK)
+	if str(t, body, "status") != "active" {
+		t.Errorf("expected status=active, got %v", body["status"])
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("expected immediate return for already-active task, took %s", elapsed)
+	}
+}
+
+func TestGetTask_LongPoll_ReturnsImmediately_WhenDenied(t *testing.T) {
+	adapter := newMockAdapter("mock.echo", "echo")
+	env := newTestEnv(t, adapter)
+	sc := newScenario(t, env, "bot")
+	sc.activateService(t, env, "mock.echo")
+
+	// Create a task but deny it.
+	resp := env.do("POST", "/api/tasks", sc.AgentToken, map[string]any{
+		"purpose": "test",
+		"authorized_actions": []map[string]any{{
+			"service": "mock.echo", "action": "echo", "auto_execute": true,
+		}},
+	})
+	body := mustStatus(t, resp, http.StatusCreated)
+	taskID := str(t, body, "task_id")
+
+	resp = sc.session.do("POST", fmt.Sprintf("/api/tasks/%s/deny", taskID), nil)
+	mustStatus(t, resp, http.StatusOK)
+
+	// Long-poll on a denied task should return immediately.
+	start := time.Now()
+	resp = env.do("GET", fmt.Sprintf("/api/tasks/%s?wait=true&timeout=5", taskID), sc.AgentToken, nil)
+	elapsed := time.Since(start)
+
+	body = mustStatus(t, resp, http.StatusOK)
+	if str(t, body, "status") != "denied" {
+		t.Errorf("expected status=denied, got %v", body["status"])
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("expected immediate return for denied task, took %s", elapsed)
+	}
+}
+
+func TestGetTask_LongPoll_WaitsForApproval(t *testing.T) {
+	adapter := newMockAdapter("mock.echo", "echo")
+	env := newTestEnv(t, adapter)
+	sc := newScenario(t, env, "bot")
+	sc.activateService(t, env, "mock.echo")
+
+	// Create a pending task.
+	resp := env.do("POST", "/api/tasks", sc.AgentToken, map[string]any{
+		"purpose": "test",
+		"authorized_actions": []map[string]any{{
+			"service": "mock.echo", "action": "echo", "auto_execute": true,
+		}},
+	})
+	body := mustStatus(t, resp, http.StatusCreated)
+	taskID := str(t, body, "task_id")
+
+	// Start long-poll in a goroutine.
+	var (
+		wg       sync.WaitGroup
+		pollBody map[string]any
+		pollErr  error
+	)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		r := env.do("GET", fmt.Sprintf("/api/tasks/%s?wait=true&timeout=10", taskID), sc.AgentToken, nil)
+		pollBody = mustStatus(t, r, http.StatusOK)
+	}()
+
+	// Give the long-poll a moment to subscribe, then approve.
+	time.Sleep(200 * time.Millisecond)
+	resp = sc.session.do("POST", fmt.Sprintf("/api/tasks/%s/approve", taskID), nil)
+	mustStatus(t, resp, http.StatusOK)
+
+	wg.Wait()
+	if pollErr != nil {
+		t.Fatalf("long-poll error: %v", pollErr)
+	}
+	if str(t, pollBody, "status") != "active" {
+		t.Errorf("expected status=active after approval, got %v", pollBody["status"])
+	}
+}
+
+func TestGetTask_LongPoll_WaitsForDenial(t *testing.T) {
+	adapter := newMockAdapter("mock.echo", "echo")
+	env := newTestEnv(t, adapter)
+	sc := newScenario(t, env, "bot")
+	sc.activateService(t, env, "mock.echo")
+
+	// Create a pending task.
+	resp := env.do("POST", "/api/tasks", sc.AgentToken, map[string]any{
+		"purpose": "test",
+		"authorized_actions": []map[string]any{{
+			"service": "mock.echo", "action": "echo", "auto_execute": true,
+		}},
+	})
+	body := mustStatus(t, resp, http.StatusCreated)
+	taskID := str(t, body, "task_id")
+
+	// Start long-poll in a goroutine.
+	var (
+		wg       sync.WaitGroup
+		pollBody map[string]any
+	)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		r := env.do("GET", fmt.Sprintf("/api/tasks/%s?wait=true&timeout=10", taskID), sc.AgentToken, nil)
+		pollBody = mustStatus(t, r, http.StatusOK)
+	}()
+
+	// Give the long-poll a moment to subscribe, then deny.
+	time.Sleep(200 * time.Millisecond)
+	resp = sc.session.do("POST", fmt.Sprintf("/api/tasks/%s/deny", taskID), nil)
+	mustStatus(t, resp, http.StatusOK)
+
+	wg.Wait()
+	if str(t, pollBody, "status") != "denied" {
+		t.Errorf("expected status=denied after denial, got %v", pollBody["status"])
+	}
+}
+
+func TestGetTask_LongPoll_TimesOut(t *testing.T) {
+	adapter := newMockAdapter("mock.echo", "echo")
+	env := newTestEnv(t, adapter)
+	sc := newScenario(t, env, "bot")
+	sc.activateService(t, env, "mock.echo")
+
+	// Create a pending task (never approve it).
+	resp := env.do("POST", "/api/tasks", sc.AgentToken, map[string]any{
+		"purpose": "test",
+		"authorized_actions": []map[string]any{{
+			"service": "mock.echo", "action": "echo", "auto_execute": true,
+		}},
+	})
+	body := mustStatus(t, resp, http.StatusCreated)
+	taskID := str(t, body, "task_id")
+
+	start := time.Now()
+	resp = env.do("GET", fmt.Sprintf("/api/tasks/%s?wait=true&timeout=1", taskID), sc.AgentToken, nil)
+	elapsed := time.Since(start)
+
+	body = mustStatus(t, resp, http.StatusOK)
+	if str(t, body, "status") != "pending_approval" {
+		t.Errorf("expected status=pending_approval after timeout, got %v", body["status"])
+	}
+	if elapsed < 900*time.Millisecond {
+		t.Errorf("expected ~1s wait, but returned in %s", elapsed)
+	}
+	if elapsed > 3*time.Second {
+		t.Errorf("expected ~1s wait, took %s", elapsed)
+	}
+}
+
+func TestGetTask_LongPoll_TimeoutCapped(t *testing.T) {
+	adapter := newMockAdapter("mock.echo", "echo")
+	env := newTestEnv(t, adapter)
+	sc := newScenario(t, env, "bot")
+	sc.activateService(t, env, "mock.echo")
+
+	// Create a pending task.
+	resp := env.do("POST", "/api/tasks", sc.AgentToken, map[string]any{
+		"purpose": "test",
+		"authorized_actions": []map[string]any{{
+			"service": "mock.echo", "action": "echo", "auto_execute": true,
+		}},
+	})
+	body := mustStatus(t, resp, http.StatusCreated)
+	taskID := str(t, body, "task_id")
+
+	// Request a huge timeout — should be capped at 120s.
+	// We won't actually wait 120s; approve quickly to unblock.
+	var (
+		wg       sync.WaitGroup
+		pollBody map[string]any
+	)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		r := env.do("GET", fmt.Sprintf("/api/tasks/%s?wait=true&timeout=9999", taskID), sc.AgentToken, nil)
+		pollBody = mustStatus(t, r, http.StatusOK)
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+	resp = sc.session.do("POST", fmt.Sprintf("/api/tasks/%s/approve", taskID), nil)
+	mustStatus(t, resp, http.StatusOK)
+
+	wg.Wait()
+	if str(t, pollBody, "status") != "active" {
+		t.Errorf("expected status=active, got %v", pollBody["status"])
+	}
+}
+
+func TestGetTask_NoWait_ReturnsPendingImmediately(t *testing.T) {
+	adapter := newMockAdapter("mock.echo", "echo")
+	env := newTestEnv(t, adapter)
+	sc := newScenario(t, env, "bot")
+	sc.activateService(t, env, "mock.echo")
+
+	// Create a pending task.
+	resp := env.do("POST", "/api/tasks", sc.AgentToken, map[string]any{
+		"purpose": "test",
+		"authorized_actions": []map[string]any{{
+			"service": "mock.echo", "action": "echo", "auto_execute": true,
+		}},
+	})
+	body := mustStatus(t, resp, http.StatusCreated)
+	taskID := str(t, body, "task_id")
+
+	// Without wait param, should return immediately with pending status.
+	start := time.Now()
+	resp = env.do("GET", fmt.Sprintf("/api/tasks/%s", taskID), sc.AgentToken, nil)
+	elapsed := time.Since(start)
+
+	body = mustStatus(t, resp, http.StatusOK)
+	if str(t, body, "status") != "pending_approval" {
+		t.Errorf("expected status=pending_approval, got %v", body["status"])
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("expected immediate return without wait, took %s", elapsed)
+	}
+}
+
+func TestGetTask_LongPoll_ScopeExpansionApproval(t *testing.T) {
+	adapter := newMockAdapter("mock.echo", "echo", "ping")
+	env := newTestEnv(t, adapter)
+	sc := newScenario(t, env, "bot")
+
+	taskID := sc.createApprovedTask(t, env, "mock.echo", "echo", true)
+
+	// Request scope expansion.
+	resp := env.do("POST", fmt.Sprintf("/api/tasks/%s/expand", taskID), sc.AgentToken, map[string]any{
+		"service": "mock.echo", "action": "ping", "reason": "need ping",
+	})
+	mustStatus(t, resp, http.StatusAccepted)
+
+	// Long-poll while pending_scope_expansion.
+	var (
+		wg       sync.WaitGroup
+		pollBody map[string]any
+	)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		r := env.do("GET", fmt.Sprintf("/api/tasks/%s?wait=true&timeout=10", taskID), sc.AgentToken, nil)
+		pollBody = mustStatus(t, r, http.StatusOK)
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+	resp = sc.session.do("POST", fmt.Sprintf("/api/tasks/%s/expand/approve", taskID), nil)
+	mustStatus(t, resp, http.StatusOK)
+
+	wg.Wait()
+	if str(t, pollBody, "status") != "active" {
+		t.Errorf("expected status=active after expansion approval, got %v", pollBody["status"])
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -58,11 +58,13 @@ func toolDefs() []Tool {
 		},
 		{
 			Name:        "get_task",
-			Description: "Get the current status and details of a task.",
+			Description: "Get the current status and details of a task. Use wait=true to long-poll until the task is approved or denied instead of returning immediately.",
 			InputSchema: json.RawMessage(`{
 				"type": "object",
 				"properties": {
-					"task_id": {"type": "string", "description": "The task ID to look up"}
+					"task_id": {"type": "string", "description": "The task ID to look up"},
+					"wait": {"type": "boolean", "description": "Long-poll until the task leaves pending state (default false)"},
+					"timeout": {"type": "integer", "description": "Long-poll timeout in seconds (default 120, max 120)"}
 				},
 				"required": ["task_id"]
 			}`),

--- a/internal/mcp/tools_exec.go
+++ b/internal/mcp/tools_exec.go
@@ -131,7 +131,19 @@ func buildInternalRequest(toolName string, arguments json.RawMessage) (internalR
 		if err := validatePathParam(id, "task_id"); err != nil {
 			return internalRoute{}, nil, err
 		}
-		return internalRoute{"GET", "/api/tasks/" + id, "GET /api/tasks/{id}",
+		path := "/api/tasks/" + id
+		// Forward optional long-poll query params.
+		var qp []string
+		if w := getString("wait"); w == "true" {
+			qp = append(qp, "wait=true")
+		}
+		if t := getString("timeout"); t != "" {
+			qp = append(qp, "timeout="+t)
+		}
+		if len(qp) > 0 {
+			path += "?" + strings.Join(qp, "&")
+		}
+		return internalRoute{"GET", path, "GET /api/tasks/{id}",
 			map[string]string{"id": id}}, nil, nil
 
 	case "complete_task":

--- a/skills/clawvisor/SKILL.md
+++ b/skills/clawvisor/SKILL.md
@@ -50,7 +50,7 @@ The authorization model has two layers — applied in order:
 
 1. Fetch the catalog — confirm the service is active and the action isn't restricted
 2. Create a task declaring your purpose and the actions you need
-3. Tell the user to approve it; call `get_task` with `wait: true` to long-poll until approved
+3. Tell the user to approve it; long-poll `GET /api/tasks/{id}?wait=true` until approved
 4. Make gateway requests under the task — in-scope actions execute automatically
 5. Mark the task complete when done
 
@@ -95,10 +95,10 @@ curl -s -X POST "$CLAWVISOR_URL/api/tasks" \
 - **`expected_use`** — per-action description of how you'll use it. Shown during approval and checked by intent verification against your actual request params. Be specific: "Fetch today's calendar events" is better than "Use the calendar API."
 - **`auto_execute`** — `true` runs in-scope requests immediately; `false` still requires per-request approval (use for destructive actions like `send_message`).
 - **`expires_in_seconds`** — task TTL. Omit and set `"lifetime": "standing"` for a task that persists until the user revokes it (see below).
-- **`callback_url`** — *(optional, only if callbacks are configured)* Clawvisor posts task lifecycle events here. Otherwise, use `get_task` with `wait: true` to long-poll.
+- **`callback_url`** — *(optional, only if callbacks are configured)* Clawvisor posts task lifecycle events here. Otherwise, long-poll with `GET /api/tasks/{id}?wait=true`.
 
 All tasks start as `pending_approval` — the user is notified to approve the
-scope before it becomes active. Call `get_task` with `wait: true` to long-poll
+scope before it becomes active. Long-poll `GET /api/tasks/{id}?wait=true`
 until `status` changes to `active` (or `denied`).
 
 ### Standing tasks
@@ -235,7 +235,7 @@ Every response has a `status` field. Handle each case as follows:
 | `pending` | Awaiting human approval | Tell the user: "I've requested approval for [action]." Poll with the same `request_id` until resolved. Do **not** send a new request. |
 | `blocked` | A restriction blocks this action | Tell the user: "I wasn't allowed to [action] — [reason]." Do **not** retry or attempt a workaround. |
 | `restricted` | Intent verification rejected the request | Your params or reason were inconsistent with the task's approved purpose. Adjust and retry with a new `request_id`. |
-| `pending_task_approval` | Task not yet approved | Tell the user and call `get_task` with `wait: true` until approved. |
+| `pending_task_approval` | Task not yet approved | Tell the user and long-poll `GET /api/tasks/{id}?wait=true` until approved. |
 | `pending_scope_expansion` | Request outside task scope | Call `POST /api/tasks/{id}/expand` with the new action. |
 | `task_expired` | Task has passed its expiry | Expand the task to extend, or create a new task. |
 | `error` (`SERVICE_NOT_CONFIGURED`) | Service not yet connected | Tell the user: "[Service] isn't activated yet. Connect it in the Clawvisor dashboard." |
@@ -246,13 +246,12 @@ Every response has a `status` field. Handle each case as follows:
 
 ## Waiting for approval
 
-**Tasks (preferred — long-poll):** Call `get_task` with `wait: true` to
-long-poll until the task leaves `pending_approval` / `pending_scope_expansion`.
-The request blocks server-side (up to `timeout` seconds, default & max 120) and
-returns the task as soon as it is approved, denied, or the timeout elapses.
+**Tasks (preferred — long-poll):** `GET /api/tasks/{id}?wait=true` blocks
+server-side until the task leaves `pending_approval` / `pending_scope_expansion`.
+Add `&timeout=N` to control the wait (default & max 120 seconds).
 
-```json
-{ "task_id": "abc-123", "wait": true, "timeout": 120 }
+```
+GET /api/tasks/{id}?wait=true&timeout=120
 ```
 
 If the timeout elapses while still pending, the response is a normal 200 with

--- a/skills/clawvisor/SKILL.md
+++ b/skills/clawvisor/SKILL.md
@@ -50,7 +50,7 @@ The authorization model has two layers — applied in order:
 
 1. Fetch the catalog — confirm the service is active and the action isn't restricted
 2. Create a task declaring your purpose and the actions you need
-3. Tell the user to approve it; poll `GET /api/tasks/{id}` until approved
+3. Tell the user to approve it; call `get_task` with `wait: true` to long-poll until approved
 4. Make gateway requests under the task — in-scope actions execute automatically
 5. Mark the task complete when done
 
@@ -95,11 +95,11 @@ curl -s -X POST "$CLAWVISOR_URL/api/tasks" \
 - **`expected_use`** — per-action description of how you'll use it. Shown during approval and checked by intent verification against your actual request params. Be specific: "Fetch today's calendar events" is better than "Use the calendar API."
 - **`auto_execute`** — `true` runs in-scope requests immediately; `false` still requires per-request approval (use for destructive actions like `send_message`).
 - **`expires_in_seconds`** — task TTL. Omit and set `"lifetime": "standing"` for a task that persists until the user revokes it (see below).
-- **`callback_url`** — *(optional, only if callbacks are configured)* Clawvisor posts task lifecycle events here. Otherwise, poll `GET /api/tasks/{id}`.
+- **`callback_url`** — *(optional, only if callbacks are configured)* Clawvisor posts task lifecycle events here. Otherwise, use `get_task` with `wait: true` to long-poll.
 
 All tasks start as `pending_approval` — the user is notified to approve the
-scope before it becomes active. Poll `GET /api/tasks/{id}` until `status`
-changes to `active` (or `denied`).
+scope before it becomes active. Call `get_task` with `wait: true` to long-poll
+until `status` changes to `active` (or `denied`).
 
 ### Standing tasks
 
@@ -235,7 +235,7 @@ Every response has a `status` field. Handle each case as follows:
 | `pending` | Awaiting human approval | Tell the user: "I've requested approval for [action]." Poll with the same `request_id` until resolved. Do **not** send a new request. |
 | `blocked` | A restriction blocks this action | Tell the user: "I wasn't allowed to [action] — [reason]." Do **not** retry or attempt a workaround. |
 | `restricted` | Intent verification rejected the request | Your params or reason were inconsistent with the task's approved purpose. Adjust and retry with a new `request_id`. |
-| `pending_task_approval` | Task not yet approved | Tell the user and poll `GET /api/tasks/{id}` until approved. |
+| `pending_task_approval` | Task not yet approved | Tell the user and call `get_task` with `wait: true` until approved. |
 | `pending_scope_expansion` | Request outside task scope | Call `POST /api/tasks/{id}/expand` with the new action. |
 | `task_expired` | Task has passed its expiry | Expand the task to extend, or create a new task. |
 | `error` (`SERVICE_NOT_CONFIGURED`) | Service not yet connected | Tell the user: "[Service] isn't activated yet. Connect it in the Clawvisor dashboard." |
@@ -244,12 +244,22 @@ Every response has a `status` field. Handle each case as follows:
 
 ---
 
-## Polling
+## Waiting for approval
 
-Polling is the primary mechanism for waiting on approvals.
+**Tasks (preferred — long-poll):** Call `get_task` with `wait: true` to
+long-poll until the task leaves `pending_approval` / `pending_scope_expansion`.
+The request blocks server-side (up to `timeout` seconds, default & max 120) and
+returns the task as soon as it is approved, denied, or the timeout elapses.
 
-**Tasks:** Poll `GET /api/tasks/{id}` until `status` changes from
-`pending_approval` to `active` (or `denied`).
+```json
+{ "task_id": "abc-123", "wait": true, "timeout": 120 }
+```
+
+If the timeout elapses while still pending, the response is a normal 200 with
+the current (still-pending) task — just call again to keep waiting.
+
+**Tasks (legacy polling):** Poll `GET /api/tasks/{id}` until `status` changes
+from `pending_approval` to `active` (or `denied`).
 
 **Gateway requests:** Re-send the same gateway request with the same
 `request_id`. Clawvisor recognizes the duplicate and returns the current status


### PR DESCRIPTION
## Summary
- Adds `wait=true` and `timeout=N` query params to `GET /api/tasks/{id}` for long-polling
- When a task is pending approval/expansion, the request blocks server-side until the task is resolved or the timeout elapses (default & max 120s)
- Exposes `wait` and `timeout` as optional params on the `get_task` MCP tool
- Updates SKILL.md to recommend long-polling over repeated polling

## Test plan
- [x] 8 integration tests covering: immediate return for resolved tasks, blocking until approval/denial, timeout behavior, timeout capping, backward compat without `wait`, and scope expansion approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)