### PR TITLE
feat: add --open flag to auto-open magic link in browser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,9 @@ eval-intent:
 # ── Run ────────────────────────────────────────────────────────────────────────
 
 # Run locally (rebuilds frontend if web/src changed, then builds + runs)
+# Use OPEN=1 to auto-open the magic link in a browser: make run OPEN=1
 run: web/dist
-	@go build -o bin/clawvisor ./cmd/clawvisor && bin/clawvisor server
+	@go build -o bin/clawvisor ./cmd/clawvisor && bin/clawvisor server $(if $(OPEN),--open,)
 
 run-sqlite:
 	@go build -o bin/clawvisor ./cmd/clawvisor && bin/clawvisor server

--- a/cmd/clawvisor/cmd_server.go
+++ b/cmd/clawvisor/cmd_server.go
@@ -13,6 +13,11 @@ var serverCmd = &cobra.Command{
 	Short: "Start the Clawvisor API server",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
-		return server.Run(logger)
+		openBrowser, _ := cmd.Flags().GetBool("open")
+		return server.Run(logger, server.RunOptions{OpenBrowser: openBrowser})
 	},
+}
+
+func init() {
+	serverCmd.Flags().Bool("open", false, "Open the magic link in the default browser on startup")
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -10,7 +10,7 @@ import (
 func main() {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
 
-	if err := server.Run(logger); err != nil {
+	if err := server.Run(logger, server.RunOptions{}); err != nil {
 		logger.Error("fatal", "err", err)
 		os.Exit(1)
 	}

--- a/internal/server/run.go
+++ b/internal/server/run.go
@@ -13,13 +13,19 @@ import (
 	"time"
 
 	"github.com/clawvisor/clawvisor/internal/auth"
+	"github.com/clawvisor/clawvisor/internal/browser"
 	"github.com/clawvisor/clawvisor/pkg/clawvisor"
 	"github.com/clawvisor/clawvisor/pkg/config"
 )
 
+// RunOptions holds optional flags for the server entrypoint.
+type RunOptions struct {
+	OpenBrowser bool
+}
+
 // Run starts the Clawvisor API server. This is the main entrypoint called
 // from cmd/clawvisor/cmd_server.go.
-func Run(logger *slog.Logger) error {
+func Run(logger *slog.Logger, ropts RunOptions) error {
 	opts, err := clawvisor.DefaultOptions(logger)
 	if err != nil {
 		return err
@@ -85,6 +91,10 @@ func Run(logger *slog.Logger) error {
 	// ── Banner ─────────────────────────────────────────────────────────────
 	if opts.Config.Server.IsLocal() {
 		printBanner(opts.Config, magicURL)
+	}
+
+	if ropts.OpenBrowser && magicURL != "" {
+		browser.Open(magicURL)
 	}
 
 	return clawvisor.Run(opts)


### PR DESCRIPTION
## Summary
- Adds `--open` flag to `clawvisor server` that opens the magic link URL in the default browser on startup
- Adds `OPEN=1` variable to `make run` for convenience (`make run OPEN=1`)
- No behavior change without the flag

## Test plan
- [ ] `make run` still works without opening a browser
- [ ] `make run OPEN=1` opens the magic link in the default browser
- [ ] `bin/clawvisor server --open` opens the browser
- [ ] `bin/clawvisor server` does not open the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)