### PR TITLE
feat: relay client with E2E encryption and keygen

### DIFF
--- a/cmd/cvis-e2e/main.go
+++ b/cmd/cvis-e2e/main.go
@@ -1,0 +1,176 @@
+// Command cvis-e2e is a standalone E2E encryption helper for environments
+// without Node.js. Same CLI as e2e.mjs.
+//
+// Usage: cvis-e2e --url <daemon_url> --token <agent_token> --body '<json>'
+package main
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/ecdh"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+)
+
+func main() {
+	url := flag.String("url", "", "Daemon URL")
+	token := flag.String("token", "", "Agent token")
+	body := flag.String("body", "", "JSON body to send")
+	flag.Parse()
+
+	if *url == "" || *token == "" || *body == "" {
+		fmt.Fprintln(os.Stderr, "Usage: cvis-e2e --url <daemon_url> --token <agent_token> --body '<json>'")
+		os.Exit(1)
+	}
+
+	result, err := gatewayRequest(*url, *token, *body)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	var pretty bytes.Buffer
+	json.Indent(&pretty, result, "", "  ")
+	fmt.Println(pretty.String())
+}
+
+func gatewayRequest(baseURL, agentToken, bodyJSON string) ([]byte, error) {
+	// Fetch daemon's public key.
+	daemonKey, err := fetchDaemonKey(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("fetching daemon key: %w", err)
+	}
+
+	daemonPubBytes, err := base64.StdEncoding.DecodeString(daemonKey.X25519)
+	if err != nil {
+		return nil, fmt.Errorf("decoding daemon public key: %w", err)
+	}
+
+	daemonPub, err := ecdh.X25519().NewPublicKey(daemonPubBytes)
+	if err != nil {
+		return nil, fmt.Errorf("parsing daemon public key: %w", err)
+	}
+
+	// Generate ephemeral keypair.
+	ephPriv, err := ecdh.X25519().GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generating ephemeral key: %w", err)
+	}
+
+	// ECDH.
+	shared, err := ephPriv.ECDH(daemonPub)
+	if err != nil {
+		return nil, fmt.Errorf("ECDH: %w", err)
+	}
+
+	// Encrypt request body.
+	ciphertext, err := encrypt(shared, []byte(bodyJSON))
+	if err != nil {
+		return nil, fmt.Errorf("encrypting: %w", err)
+	}
+
+	encoded := base64.StdEncoding.EncodeToString(ciphertext)
+
+	req, err := http.NewRequest("POST", baseURL+"/api/gateway/request", bytes.NewReader([]byte(encoded)))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+agentToken)
+	req.Header.Set("Content-Type", "application/octet-stream")
+	req.Header.Set("X-Clawvisor-E2E", "aes-256-gcm")
+	req.Header.Set("X-Clawvisor-Ephemeral-Key", base64.StdEncoding.EncodeToString(ephPriv.PublicKey().Bytes()))
+
+	client := &http.Client{Timeout: 120 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("sending request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+
+	if resp.Header.Get("X-Clawvisor-E2E") != "" {
+		decrypted, err := decryptResponse(shared, string(respBody))
+		if err != nil {
+			return nil, fmt.Errorf("decrypting response: %w", err)
+		}
+		return decrypted, nil
+	}
+
+	return respBody, nil
+}
+
+type daemonKeys struct {
+	DaemonID string `json:"daemon_id"`
+	X25519   string `json:"x25519"`
+}
+
+func fetchDaemonKey(baseURL string) (*daemonKeys, error) {
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(baseURL + "/.well-known/clawvisor-keys")
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("key endpoint returned %d", resp.StatusCode)
+	}
+
+	var keys daemonKeys
+	if err := json.NewDecoder(resp.Body).Decode(&keys); err != nil {
+		return nil, err
+	}
+	return &keys, nil
+}
+
+func encrypt(shared, plaintext []byte) ([]byte, error) {
+	block, err := aes.NewCipher(shared)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	nonce := make([]byte, 12)
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, err
+	}
+	// Seal appends ciphertext+tag after nonce.
+	return gcm.Seal(nonce, nonce, plaintext, nil), nil
+}
+
+func decryptResponse(shared []byte, ciphertextB64 string) ([]byte, error) {
+	data, err := base64.StdEncoding.DecodeString(ciphertextB64)
+	if err != nil {
+		return nil, err
+	}
+	if len(data) < 12+16 {
+		return nil, fmt.Errorf("ciphertext too short")
+	}
+
+	nonce := data[:12]
+	encData := data[12:]
+
+	block, err := aes.NewCipher(shared)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	return gcm.Open(nil, nonce, encData, nil)
+}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.6
 	github.com/charmbracelet/huh v0.8.0
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/coder/websocket v1.8.14
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.8.0

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/charmbracelet/x/xpty v0.1.2 h1:Pqmu4TEJ8KeA9uSkISKMU3f+C1F6OGBn8ABuGl
 github.com/charmbracelet/x/xpty v0.1.2/go.mod h1:XK2Z0id5rtLWcpeNiMYBccNNBrP2IJnzHI0Lq13Xzq4=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 h1:6xNmx7iTtyBRev0+D/Tv1FZd4SCg8axKApyNyRsAt/w=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5/go.mod h1:KdCmV+x/BuvyMxRnYBlmVaq4OLiKW6iRQfvC62cvdkI=
+github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
+github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=

--- a/internal/api/middleware/e2e.go
+++ b/internal/api/middleware/e2e.go
@@ -1,0 +1,170 @@
+package middleware
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/ecdh"
+	"crypto/rand"
+	"encoding/base64"
+	"io"
+	"net/http"
+
+	"github.com/clawvisor/clawvisor/internal/relay"
+)
+
+// E2E wraps a gateway handler to transparently decrypt E2E-encrypted request
+// bodies and encrypt response bodies. The gateway handler is unaware of E2E —
+// it sees plaintext requests and writes plaintext responses.
+func E2E(x25519Key *ecdh.PrivateKey) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			viaRelay := relay.ViaRelay(r.Context())
+
+			if r.Header.Get("X-Clawvisor-E2E") == "" {
+				if viaRelay {
+					http.Error(w, `{"error":"E2E encryption required for gateway requests through relay","code":"E2E_REQUIRED"}`, http.StatusForbidden)
+					return
+				}
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			// Read ephemeral public key from header.
+			ephKeyB64 := r.Header.Get("X-Clawvisor-Ephemeral-Key")
+			if ephKeyB64 == "" {
+				http.Error(w, `{"error":"missing X-Clawvisor-Ephemeral-Key header","code":"E2E_ERROR"}`, http.StatusBadRequest)
+				return
+			}
+
+			ephKeyBytes, err := base64.StdEncoding.DecodeString(ephKeyB64)
+			if err != nil {
+				http.Error(w, `{"error":"invalid ephemeral key encoding","code":"E2E_ERROR"}`, http.StatusBadRequest)
+				return
+			}
+
+			ephPub, err := ecdh.X25519().NewPublicKey(ephKeyBytes)
+			if err != nil {
+				http.Error(w, `{"error":"invalid ephemeral public key","code":"E2E_ERROR"}`, http.StatusBadRequest)
+				return
+			}
+
+			// ECDH → shared secret.
+			shared, err := x25519Key.ECDH(ephPub)
+			if err != nil {
+				http.Error(w, `{"error":"ECDH key exchange failed","code":"E2E_ERROR"}`, http.StatusInternalServerError)
+				return
+			}
+
+			// Decrypt request body if present. GET requests (e.g. status
+			// polling) have no body — only the response needs encryption.
+			if r.Body != nil && r.ContentLength != 0 {
+				ciphertextB64, err := io.ReadAll(r.Body)
+				if err != nil {
+					http.Error(w, `{"error":"failed to read request body","code":"E2E_ERROR"}`, http.StatusBadRequest)
+					return
+				}
+				r.Body.Close()
+
+				if len(ciphertextB64) > 0 {
+					ciphertext, err := base64.StdEncoding.DecodeString(string(ciphertextB64))
+					if err != nil {
+						http.Error(w, `{"error":"invalid ciphertext encoding","code":"E2E_ERROR"}`, http.StatusBadRequest)
+						return
+					}
+
+					if len(ciphertext) < 12+16 {
+						http.Error(w, `{"error":"ciphertext too short","code":"E2E_ERROR"}`, http.StatusBadRequest)
+						return
+					}
+
+					nonce := ciphertext[:12]
+					encData := ciphertext[12:]
+
+					block, err := aes.NewCipher(shared)
+					if err != nil {
+						http.Error(w, `{"error":"cipher init failed","code":"E2E_ERROR"}`, http.StatusInternalServerError)
+						return
+					}
+					gcm, err := cipher.NewGCM(block)
+					if err != nil {
+						http.Error(w, `{"error":"GCM init failed","code":"E2E_ERROR"}`, http.StatusInternalServerError)
+						return
+					}
+
+					plaintext, err := gcm.Open(nil, nonce, encData, nil)
+					if err != nil {
+						http.Error(w, `{"error":"decryption failed","code":"E2E_ERROR"}`, http.StatusBadRequest)
+						return
+					}
+
+					r.Body = io.NopCloser(bytes.NewReader(plaintext))
+					r.ContentLength = int64(len(plaintext))
+				}
+			}
+
+			// Wrap ResponseWriter to encrypt the response body.
+			ew := &e2eWriter{
+				ResponseWriter: w,
+				shared:         shared,
+			}
+
+			next.ServeHTTP(ew, r)
+
+			// Flush encrypted response.
+			ew.flush()
+		})
+	}
+}
+
+// e2eWriter captures the response body and encrypts it before sending.
+type e2eWriter struct {
+	http.ResponseWriter
+	shared      []byte
+	buf         bytes.Buffer
+	wroteHeader bool
+	statusCode  int
+}
+
+func (ew *e2eWriter) WriteHeader(code int) {
+	ew.statusCode = code
+	ew.wroteHeader = true
+}
+
+func (ew *e2eWriter) Write(b []byte) (int, error) {
+	if !ew.wroteHeader {
+		ew.statusCode = http.StatusOK
+		ew.wroteHeader = true
+	}
+	return ew.buf.Write(b)
+}
+
+func (ew *e2eWriter) flush() {
+	plaintext := ew.buf.Bytes()
+
+	block, err := aes.NewCipher(ew.shared)
+	if err != nil {
+		ew.ResponseWriter.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		ew.ResponseWriter.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	nonce := make([]byte, 12)
+	if _, err := rand.Read(nonce); err != nil {
+		ew.ResponseWriter.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	// Encrypt: nonce || ciphertext || tag (GCM appends tag to ciphertext).
+	sealed := gcm.Seal(nonce, nonce, plaintext, nil)
+
+	encoded := base64.StdEncoding.EncodeToString(sealed)
+
+	ew.ResponseWriter.Header().Set("X-Clawvisor-E2E", "aes-256-gcm")
+	ew.ResponseWriter.WriteHeader(ew.statusCode)
+	ew.ResponseWriter.Write([]byte(encoded))
+}

--- a/internal/api/middleware/e2e_test.go
+++ b/internal/api/middleware/e2e_test.go
@@ -1,0 +1,186 @@
+package middleware
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/ecdh"
+	"crypto/rand"
+	"encoding/base64"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/internal/relay"
+)
+
+func TestE2E_PlaintextLocal(t *testing.T) {
+	// Local requests without E2E headers should pass through.
+	daemonKey, _ := ecdh.X25519().GenerateKey(rand.Reader)
+	handler := E2E(daemonKey)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		w.Write(body)
+	}))
+
+	req := httptest.NewRequest("POST", "/api/gateway/request", bytes.NewReader([]byte(`{"test":true}`)))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	if rec.Body.String() != `{"test":true}` {
+		t.Errorf("body: got %q, want {\"test\":true}", rec.Body.String())
+	}
+}
+
+func TestE2E_RejectPlaintextViaRelay(t *testing.T) {
+	// Relay requests without E2E should be rejected with 403.
+	daemonKey, _ := ecdh.X25519().GenerateKey(rand.Reader)
+	handler := E2E(daemonKey)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("handler should not be called")
+	}))
+
+	req := httptest.NewRequest("POST", "/api/gateway/request", nil)
+	// Simulate relay context.
+	ctx := relay.WithViaRelay(req.Context())
+	req = req.WithContext(ctx)
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status: got %d, want 403", rec.Code)
+	}
+}
+
+func TestE2E_EncryptDecryptRoundTrip(t *testing.T) {
+	// Full round-trip: encrypt as agent, middleware decrypts, handler sees plaintext,
+	// middleware encrypts response, agent decrypts response.
+	daemonKey, _ := ecdh.X25519().GenerateKey(rand.Reader)
+
+	plaintext := `{"service":"google.gmail","action":"send_message"}`
+
+	handler := E2E(daemonKey)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("reading body: %v", err)
+		}
+		if string(body) != plaintext {
+			t.Errorf("decrypted body: got %q, want %q", string(body), plaintext)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"result":"ok"}`))
+	}))
+
+	// Agent side: encrypt the request.
+	agentKey, _ := ecdh.X25519().GenerateKey(rand.Reader)
+	shared, _ := agentKey.ECDH(daemonKey.PublicKey())
+
+	block, _ := aes.NewCipher(shared)
+	gcm, _ := cipher.NewGCM(block)
+	nonce := make([]byte, 12)
+	rand.Read(nonce)
+	sealed := gcm.Seal(nonce, nonce, []byte(plaintext), nil)
+	ciphertextB64 := base64.StdEncoding.EncodeToString(sealed)
+
+	req := httptest.NewRequest("POST", "/api/gateway/request",
+		bytes.NewReader([]byte(ciphertextB64)))
+	req.Header.Set("X-Clawvisor-E2E", "aes-256-gcm")
+	req.Header.Set("X-Clawvisor-Ephemeral-Key",
+		base64.StdEncoding.EncodeToString(agentKey.PublicKey().Bytes()))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+
+	// Verify response is E2E encrypted.
+	if rec.Header().Get("X-Clawvisor-E2E") != "aes-256-gcm" {
+		t.Fatal("response should have X-Clawvisor-E2E header")
+	}
+
+	// Decrypt response.
+	respCiphertext, _ := base64.StdEncoding.DecodeString(rec.Body.String())
+	if len(respCiphertext) < 12+16 {
+		t.Fatal("response ciphertext too short")
+	}
+
+	respNonce := respCiphertext[:12]
+	respEncData := respCiphertext[12:]
+	respPlaintext, err := gcm.Open(nil, respNonce, respEncData, nil)
+	if err != nil {
+		t.Fatalf("decrypting response: %v", err)
+	}
+
+	if string(respPlaintext) != `{"result":"ok"}` {
+		t.Errorf("response: got %q, want {\"result\":\"ok\"}", string(respPlaintext))
+	}
+}
+
+func TestE2E_GETStatusViaRelay(t *testing.T) {
+	// GET status requests through relay should work: no body decryption,
+	// but response body is encrypted.
+	daemonKey, _ := ecdh.X25519().GenerateKey(rand.Reader)
+
+	handler := E2E(daemonKey)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"status":"completed"}`))
+	}))
+
+	// Agent generates ephemeral key for response decryption.
+	agentKey, _ := ecdh.X25519().GenerateKey(rand.Reader)
+	shared, _ := agentKey.ECDH(daemonKey.PublicKey())
+
+	req := httptest.NewRequest("GET", "/api/gateway/request/abc/status", nil)
+	ctx := relay.WithViaRelay(req.Context())
+	req = req.WithContext(ctx)
+	req.Header.Set("X-Clawvisor-E2E", "aes-256-gcm")
+	req.Header.Set("X-Clawvisor-Ephemeral-Key",
+		base64.StdEncoding.EncodeToString(agentKey.PublicKey().Bytes()))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200, body: %s", rec.Code, rec.Body.String())
+	}
+
+	// Verify response is encrypted.
+	if rec.Header().Get("X-Clawvisor-E2E") != "aes-256-gcm" {
+		t.Fatal("response should have X-Clawvisor-E2E header")
+	}
+
+	// Decrypt response.
+	respCiphertext, _ := base64.StdEncoding.DecodeString(rec.Body.String())
+	block, _ := aes.NewCipher(shared)
+	gcm, _ := cipher.NewGCM(block)
+	respPlaintext, err := gcm.Open(nil, respCiphertext[:12], respCiphertext[12:], nil)
+	if err != nil {
+		t.Fatalf("decrypting response: %v", err)
+	}
+	if string(respPlaintext) != `{"status":"completed"}` {
+		t.Errorf("response: got %q, want {\"status\":\"completed\"}", string(respPlaintext))
+	}
+}
+
+func TestE2E_MissingEphemeralKey(t *testing.T) {
+	daemonKey, _ := ecdh.X25519().GenerateKey(rand.Reader)
+	handler := E2E(daemonKey)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("handler should not be called")
+	}))
+
+	req := httptest.NewRequest("POST", "/api/gateway/request", bytes.NewReader([]byte("test")))
+	req.Header.Set("X-Clawvisor-E2E", "aes-256-gcm")
+	// No X-Clawvisor-Ephemeral-Key header.
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400", rec.Code)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"context"
+	"crypto/ecdh"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -51,6 +53,11 @@ type Server struct {
 	features              FeatureSet
 	skipBuiltinAuthRoutes bool
 	quiet                 bool // suppress user-facing messages (e.g. during daemon setup)
+
+	// Relay/E2E keys.
+	x25519Key    *ecdh.PrivateKey // X25519 key for E2E encryption of gateway requests
+	daemonID     string           // relay daemon ID
+	ed25519PubB64 string          // base64-encoded Ed25519 public key for .well-known
 
 	// approvalsCleaner is used to stop the background goroutine.
 	approvalsHandler *handlers.ApprovalsHandler
@@ -113,6 +120,21 @@ func WithSkipBuiltinAuth() ServerOption {
 // server runs in the background.
 func WithQuiet() ServerOption {
 	return func(s *Server) { s.quiet = true }
+}
+
+// WithE2EKey sets the X25519 private key for E2E encryption of gateway requests.
+func WithE2EKey(key *ecdh.PrivateKey) ServerOption {
+	return func(s *Server) { s.x25519Key = key }
+}
+
+// WithDaemonKeys sets the daemon identity keys for the .well-known/clawvisor-keys endpoint.
+func WithDaemonKeys(daemonID string, x25519Key *ecdh.PrivateKey) ServerOption {
+	return func(s *Server) {
+		s.daemonID = daemonID
+		if x25519Key != nil {
+			s.x25519Key = x25519Key
+		}
+	}
 }
 
 // New creates a Server and registers all routes.
@@ -354,9 +376,19 @@ func (s *Server) routes() http.Handler {
 	guardHandler := handlers.NewGuardHandler(s.store, verifier, s.adapterReg, s.logger)
 	mux.Handle("POST /api/guard/check", agent(guardHandler.Check))
 
-	// Gateway (agent token, rate-limited)
-	mux.Handle("POST /api/gateway/request", agentRateLimited(gatewayHandler.HandleRequest))
-	mux.Handle("GET /api/gateway/request/{request_id}/status", agentRateLimited(gatewayHandler.HandleStatus))
+	// Gateway (agent token, rate-limited, E2E on relay traffic)
+	if s.x25519Key != nil {
+		e2eMiddleware := middleware.E2E(s.x25519Key)
+		gatewayRequestHandler := requireAgent(middleware.RateLimit(gatewayRL, agentKeyFn, rlCfg.Gateway.Limit)(
+			e2eMiddleware(http.HandlerFunc(gatewayHandler.HandleRequest))))
+		gatewayStatusHandler := requireAgent(middleware.RateLimit(gatewayRL, agentKeyFn, rlCfg.Gateway.Limit)(
+			e2eMiddleware(http.HandlerFunc(gatewayHandler.HandleStatus))))
+		mux.Handle("POST /api/gateway/request", gatewayRequestHandler)
+		mux.Handle("GET /api/gateway/request/{request_id}/status", gatewayStatusHandler)
+	} else {
+		mux.Handle("POST /api/gateway/request", agentRateLimited(gatewayHandler.HandleRequest))
+		mux.Handle("GET /api/gateway/request/{request_id}/status", agentRateLimited(gatewayHandler.HandleStatus))
+	}
 
 	// Callback secret registration (agent token)
 	mux.Handle("POST /api/callbacks/register", agent(gatewayHandler.RegisterCallback))
@@ -418,6 +450,11 @@ func (s *Server) routes() http.Handler {
 		http.Redirect(w, r, "/skill/SKILL.md", http.StatusFound)
 	})
 	mux.Handle("/skill/", skillFileHandler)
+
+	// Key discovery endpoint (no auth — agents need the public key for E2E).
+	if s.daemonID != "" && s.x25519Key != nil {
+		mux.HandleFunc("GET /.well-known/clawvisor-keys", s.handleClawvisorKeys)
+	}
 
 	// MCP endpoint (agent token auth)
 	if s.cfg.MCP.Enabled {
@@ -500,6 +537,18 @@ func (s *Server) routes() http.Handler {
 func (s *Server) handleFeatures(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(s.features)
+}
+
+// handleClawvisorKeys returns the daemon's public keys for E2E encryption.
+func (s *Server) handleClawvisorKeys(w http.ResponseWriter, r *http.Request) {
+	x25519Pub := base64.StdEncoding.EncodeToString(s.x25519Key.PublicKey().Bytes())
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{
+		"daemon_id": s.daemonID,
+		"x25519":    x25519Pub,
+		"algorithm": "x25519-ecdh-aes256gcm",
+	})
 }
 
 // consumeTelegramDecisions reads from the Telegram notifier's decision channel

--- a/internal/daemon/keygen.go
+++ b/internal/daemon/keygen.go
@@ -1,0 +1,166 @@
+package daemon
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"golang.org/x/crypto/curve25519"
+	"gopkg.in/yaml.v3"
+)
+
+// ensureRelayKeys generates Ed25519 and X25519 keypairs if they don't exist.
+func ensureRelayKeys(dataDir string) error {
+	ed25519KeyPath := filepath.Join(dataDir, "daemon-ed25519.key")
+	x25519KeyPath := filepath.Join(dataDir, "daemon-x25519.key")
+
+	// Generate Ed25519 key for relay authentication.
+	if _, err := os.Stat(ed25519KeyPath); os.IsNotExist(err) {
+		_, priv, err := ed25519.GenerateKey(rand.Reader)
+		if err != nil {
+			return fmt.Errorf("generating Ed25519 key: %w", err)
+		}
+		block := &pem.Block{
+			Type:  "ED25519 PRIVATE KEY",
+			Bytes: priv.Seed(),
+		}
+		if err := os.WriteFile(ed25519KeyPath, pem.EncodeToMemory(block), 0600); err != nil {
+			return fmt.Errorf("writing Ed25519 key: %w", err)
+		}
+	}
+
+	// Generate X25519 key for E2E encryption.
+	if _, err := os.Stat(x25519KeyPath); os.IsNotExist(err) {
+		privKey := make([]byte, curve25519.ScalarSize)
+		if _, err := rand.Read(privKey); err != nil {
+			return fmt.Errorf("generating X25519 key: %w", err)
+		}
+		if err := os.WriteFile(x25519KeyPath, privKey, 0600); err != nil {
+			return fmt.Errorf("writing X25519 key: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// registerWithRelay registers the daemon's Ed25519 public key with the relay
+// service and writes the returned daemon_id to config.yaml.
+func registerWithRelay(dataDir, relayURL string) error {
+	configPath := filepath.Join(dataDir, "config.yaml")
+
+	// Check if daemon_id is already in config.
+	if id, _ := readDaemonID(configPath); id != "" {
+		return nil
+	}
+
+	// Load Ed25519 private key to derive public key.
+	ed25519KeyPath := filepath.Join(dataDir, "daemon-ed25519.key")
+	priv, err := loadEd25519Key(ed25519KeyPath)
+	if err != nil {
+		return fmt.Errorf("loading Ed25519 key: %w", err)
+	}
+	pub := priv.Public().(ed25519.PublicKey)
+
+	body, _ := json.Marshal(map[string]string{
+		"public_key": base64.StdEncoding.EncodeToString(pub),
+		"version":    "1.0.0",
+	})
+
+	httpURL := strings.Replace(relayURL, "wss://", "https://", 1)
+	httpURL = strings.Replace(httpURL, "ws://", "http://", 1)
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Post(httpURL+"/api/relay/register", "application/json", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("registering with relay: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("relay registration failed: status %d", resp.StatusCode)
+	}
+
+	var result struct {
+		DaemonID string `json:"daemon_id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return fmt.Errorf("parsing relay response: %w", err)
+	}
+
+	return patchDaemonID(configPath, result.DaemonID)
+}
+
+// loadEd25519Key reads a PEM-encoded Ed25519 private key seed.
+func loadEd25519Key(path string) (ed25519.PrivateKey, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block found in %s", path)
+	}
+	return ed25519.NewKeyFromSeed(block.Bytes), nil
+}
+
+// loadX25519Key reads a raw 32-byte X25519 private key.
+func loadX25519Key(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	if len(data) != curve25519.ScalarSize {
+		return nil, fmt.Errorf("X25519 key must be %d bytes, got %d", curve25519.ScalarSize, len(data))
+	}
+	return data, nil
+}
+
+// readDaemonID reads relay.daemon_id from config.yaml.
+func readDaemonID(configPath string) (string, error) {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return "", err
+	}
+	var raw map[string]interface{}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return "", err
+	}
+	relayCfg, ok := raw["relay"].(map[string]interface{})
+	if !ok {
+		return "", nil
+	}
+	id, _ := relayCfg["daemon_id"].(string)
+	return id, nil
+}
+
+// patchDaemonID writes relay.daemon_id into config.yaml.
+func patchDaemonID(configPath, daemonID string) error {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return err
+	}
+	var raw map[string]interface{}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	relayCfg, ok := raw["relay"].(map[string]interface{})
+	if !ok {
+		relayCfg = map[string]interface{}{}
+		raw["relay"] = relayCfg
+	}
+	relayCfg["daemon_id"] = daemonID
+	out, err := yaml.Marshal(raw)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(configPath, out, 0600)
+}

--- a/internal/relay/client.go
+++ b/internal/relay/client.go
@@ -1,0 +1,246 @@
+package relay
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"math/rand/v2"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/coder/websocket"
+
+	"github.com/clawvisor/clawvisor/pkg/config"
+)
+
+// Client manages a persistent WebSocket connection to the cloud relay.
+type Client struct {
+	relayURL   string
+	daemonID   string
+	privateKey ed25519.PrivateKey
+	handler    http.Handler
+	logger     *slog.Logger
+
+	baseDelay time.Duration
+	maxDelay  time.Duration
+
+	mu        sync.Mutex
+	conn      *websocket.Conn
+	connected bool
+}
+
+// New creates a relay client. The handler can be nil at construction time
+// and set later via SetHandler before calling Run.
+func New(cfg config.RelayConfig, key ed25519.PrivateKey,
+	handler http.Handler, logger *slog.Logger) *Client {
+
+	baseDelay, _ := time.ParseDuration(cfg.ReconnectBaseDelay)
+	if baseDelay <= 0 {
+		baseDelay = time.Second
+	}
+	maxDelay, _ := time.ParseDuration(cfg.ReconnectMaxDelay)
+	if maxDelay <= 0 {
+		maxDelay = 60 * time.Second
+	}
+
+	return &Client{
+		relayURL:   cfg.URL,
+		daemonID:   cfg.DaemonID,
+		privateKey: key,
+		handler:    handler,
+		logger:     logger,
+		baseDelay:  baseDelay,
+		maxDelay:   maxDelay,
+	}
+}
+
+// SetHandler replaces the HTTP handler used to dispatch relay requests.
+// Must be called before Run.
+func (c *Client) SetHandler(h http.Handler) {
+	c.handler = h
+}
+
+// Run connects to the relay and blocks until ctx is cancelled.
+// Handles reconnection with exponential backoff.
+func (c *Client) Run(ctx context.Context) error {
+	delay := c.baseDelay
+
+	for {
+		connectedAt, err := c.connectAndServe(ctx)
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		// Reset backoff if the connection was healthy for a meaningful period
+		// (stayed up longer than the current delay). This avoids permanently
+		// ratcheting to the max delay after a single transient failure.
+		if connectedAt.After(time.Time{}) && time.Since(connectedAt) > delay {
+			delay = c.baseDelay
+		}
+
+		c.logger.Warn("relay connection lost, reconnecting",
+			"err", err, "delay", delay)
+
+		// Apply ±25% jitter.
+		jittered := applyJitter(delay)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(jittered):
+		}
+
+		// Exponential backoff: double the delay, cap at max.
+		delay *= 2
+		if delay > c.maxDelay {
+			delay = c.maxDelay
+		}
+	}
+}
+
+// Connected returns true if the WebSocket connection is active.
+func (c *Client) Connected() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.connected
+}
+
+// DaemonURL returns the public URL for this daemon.
+func (c *Client) DaemonURL() string {
+	return fmt.Sprintf("https://relay.clawvisor.com/d/%s", c.daemonID)
+}
+
+// connectAndServe establishes a WebSocket connection, authenticates, and
+// processes frames until the connection drops or ctx is cancelled. Returns
+// the time the connection became established (for backoff reset decisions).
+func (c *Client) connectAndServe(ctx context.Context) (connectedAt time.Time, err error) {
+	headers := http.Header{}
+	headers.Set("X-Daemon-ID", c.daemonID)
+
+	conn, _, dialErr := websocket.Dial(ctx, c.relayURL+"/ws", &websocket.DialOptions{
+		HTTPHeader: headers,
+	})
+	if dialErr != nil {
+		return time.Time{}, fmt.Errorf("dialing relay: %w", dialErr)
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	// Authenticate via challenge-response.
+	if authErr := c.authenticate(ctx, conn); authErr != nil {
+		return time.Time{}, fmt.Errorf("relay auth: %w", authErr)
+	}
+
+	connectedAt = time.Now()
+
+	c.mu.Lock()
+	c.conn = conn
+	c.connected = true
+	c.mu.Unlock()
+
+	defer func() {
+		c.mu.Lock()
+		c.conn = nil
+		c.connected = false
+		c.mu.Unlock()
+	}()
+
+	c.logger.Info("relay connected", "daemon_id", c.daemonID)
+
+	// Read loop.
+	for {
+		_, data, readErr := conn.Read(ctx)
+		if readErr != nil {
+			return connectedAt, fmt.Errorf("reading frame: %w", readErr)
+		}
+
+		var frame Frame
+		if err := json.Unmarshal(data, &frame); err != nil {
+			c.logger.Warn("relay: invalid frame", "err", err)
+			continue
+		}
+
+		switch frame.Type {
+		case FrameHTTPRequest:
+			var payload HTTPRequestPayload
+			if err := json.Unmarshal(frame.Payload, &payload); err != nil {
+				c.logger.Warn("relay: invalid request payload", "err", err)
+				continue
+			}
+			go c.handleRequest(ctx, frame.ID, payload)
+
+		case FramePing:
+			c.sendFrame(FramePong, frame.ID, nil)
+
+		default:
+			c.logger.Debug("relay: ignoring frame", "type", frame.Type)
+		}
+	}
+}
+
+// authenticate performs the Ed25519 challenge-response handshake.
+func (c *Client) authenticate(ctx context.Context, conn *websocket.Conn) error {
+	// Read challenge.
+	_, data, err := conn.Read(ctx)
+	if err != nil {
+		return fmt.Errorf("reading challenge: %w", err)
+	}
+
+	var challenge struct {
+		Challenge string `json:"challenge"`
+	}
+	if err := json.Unmarshal(data, &challenge); err != nil {
+		return fmt.Errorf("parsing challenge: %w", err)
+	}
+
+	// Sign challenge.
+	sig := ed25519.Sign(c.privateKey, []byte(challenge.Challenge))
+
+	resp, _ := json.Marshal(map[string]string{
+		"signature": fmt.Sprintf("%x", sig),
+	})
+	if err := conn.Write(ctx, websocket.MessageText, resp); err != nil {
+		return fmt.Errorf("sending signature: %w", err)
+	}
+
+	return nil
+}
+
+// sendFrame writes a frame to the WebSocket connection. The write is
+// serialized by the mutex to prevent concurrent writes from corrupting
+// the WebSocket stream.
+func (c *Client) sendFrame(typ FrameType, id string, payload any) {
+	var payloadBytes json.RawMessage
+	if payload != nil {
+		payloadBytes, _ = json.Marshal(payload)
+	}
+
+	frame := Frame{
+		Type:    typ,
+		ID:      id,
+		Payload: payloadBytes,
+	}
+	data, _ := json.Marshal(frame)
+
+	c.mu.Lock()
+	conn := c.conn
+	if conn == nil {
+		c.mu.Unlock()
+		return
+	}
+	_ = conn.Write(context.Background(), websocket.MessageText, data)
+	c.mu.Unlock()
+}
+
+// sendResponse sends an HTTP response frame back to the relay.
+func (c *Client) sendResponse(id string, resp HTTPResponsePayload) {
+	c.sendFrame(FrameHTTPResponse, id, resp)
+}
+
+// applyJitter adds ±25% random jitter to a duration.
+func applyJitter(d time.Duration) time.Duration {
+	jitter := float64(d) * 0.25
+	offset := (rand.Float64()*2 - 1) * jitter
+	return time.Duration(float64(d) + offset)
+}

--- a/internal/relay/client_test.go
+++ b/internal/relay/client_test.go
@@ -1,0 +1,471 @@
+package relay
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+
+	"github.com/clawvisor/clawvisor/pkg/config"
+)
+
+// mockRelay is a test WebSocket server that mimics the relay's auth handshake
+// and can be configured to drop connections after a set number of frames.
+type mockRelay struct {
+	pub           ed25519.PublicKey
+	connectCount  atomic.Int32
+	mu            sync.Mutex
+	dropAfter     int           // close conn after this many reads (0 = never auto-drop)
+	holdDuration  time.Duration // keep conn alive this long before closing (0 = use dropAfter)
+	rejectAuth    bool          // reject the auth handshake
+	onConnect     func()        // called after successful auth
+}
+
+func (m *mockRelay) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	conn, err := websocket.Accept(w, r, nil)
+	if err != nil {
+		return
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+
+	ctx := r.Context()
+
+	// Send challenge.
+	challenge := fmt.Sprintf("2026-03-17T10:00:00Z:%d", m.connectCount.Load())
+	challengeJSON, _ := json.Marshal(map[string]string{"challenge": challenge})
+	if err := conn.Write(ctx, websocket.MessageText, challengeJSON); err != nil {
+		return
+	}
+
+	// Read signature.
+	_, sigData, err := conn.Read(ctx)
+	if err != nil {
+		return
+	}
+
+	if m.rejectAuth {
+		conn.Close(websocket.StatusPolicyViolation, "auth rejected")
+		return
+	}
+
+	// Verify signature (parse hex).
+	var sigMsg struct {
+		Signature string `json:"signature"`
+	}
+	if err := json.Unmarshal(sigData, &sigMsg); err != nil {
+		conn.Close(websocket.StatusPolicyViolation, "bad sig format")
+		return
+	}
+	sigBytes, err := hexDecode(sigMsg.Signature)
+	if err != nil || !ed25519.Verify(m.pub, []byte(challenge), sigBytes) {
+		conn.Close(websocket.StatusPolicyViolation, "invalid signature")
+		return
+	}
+
+	m.connectCount.Add(1)
+	if m.onConnect != nil {
+		m.onConnect()
+	}
+
+	m.mu.Lock()
+	dropAfter := m.dropAfter
+	holdDuration := m.holdDuration
+	m.mu.Unlock()
+
+	// If holdDuration is set, keep conn alive then close.
+	if holdDuration > 0 {
+		time.Sleep(holdDuration)
+		return
+	}
+
+	// Otherwise, read frames and optionally drop.
+	reads := 0
+	for {
+		_, _, err := conn.Read(ctx)
+		if err != nil {
+			return
+		}
+		reads++
+		if dropAfter > 0 && reads >= dropAfter {
+			return // close triggers reconnect
+		}
+	}
+}
+
+func hexDecode(s string) ([]byte, error) {
+	if len(s)%2 != 0 {
+		return nil, fmt.Errorf("odd hex length")
+	}
+	b := make([]byte, len(s)/2)
+	for i := range b {
+		var hi, lo byte
+		hi, err := hexNibble(s[i*2])
+		if err != nil {
+			return nil, err
+		}
+		lo, err = hexNibble(s[i*2+1])
+		if err != nil {
+			return nil, err
+		}
+		b[i] = hi<<4 | lo
+	}
+	return b, nil
+}
+
+func hexNibble(c byte) (byte, error) {
+	switch {
+	case c >= '0' && c <= '9':
+		return c - '0', nil
+	case c >= 'a' && c <= 'f':
+		return c - 'a' + 10, nil
+	case c >= 'A' && c <= 'F':
+		return c - 'A' + 10, nil
+	default:
+		return 0, fmt.Errorf("invalid hex char: %c", c)
+	}
+}
+
+func newTestKeyPair(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+	return pub, priv
+}
+
+func newTestClient(t *testing.T, serverURL string, priv ed25519.PrivateKey, baseDelay, maxDelay string) *Client {
+	t.Helper()
+	// Convert http:// to ws:// for the client.
+	wsURL := strings.Replace(serverURL, "http://", "ws://", 1)
+	cfg := config.RelayConfig{
+		URL:                wsURL,
+		DaemonID:           "test-daemon",
+		ReconnectBaseDelay: baseDelay,
+		ReconnectMaxDelay:  maxDelay,
+		Enabled:            true,
+	}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	return New(cfg, priv, handler, slog.Default())
+}
+
+func TestClient_ConnectAndAuthenticate(t *testing.T) {
+	pub, priv := newTestKeyPair(t)
+	mock := &mockRelay{pub: pub}
+	srv := httptest.NewServer(mock)
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL, priv, "10ms", "100ms")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Run in background — it will connect and block reading.
+	go c.Run(ctx)
+
+	// Wait for connection.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if c.Connected() {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if !c.Connected() {
+		t.Fatal("client did not connect within deadline")
+	}
+	if mock.connectCount.Load() != 1 {
+		t.Fatalf("expected 1 connection, got %d", mock.connectCount.Load())
+	}
+}
+
+func TestClient_ReconnectsAfterDrop(t *testing.T) {
+	pub, priv := newTestKeyPair(t)
+
+	// Server holds the connection for 50ms then drops it.
+	mock := &mockRelay{pub: pub, holdDuration: 50 * time.Millisecond}
+	srv := httptest.NewServer(mock)
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL, priv, "10ms", "50ms")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	go c.Run(ctx)
+
+	// Wait for at least 3 connections (initial + 2 reconnections).
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if mock.connectCount.Load() >= 3 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	count := mock.connectCount.Load()
+	if count < 3 {
+		t.Fatalf("expected at least 3 connections (reconnections), got %d", count)
+	}
+}
+
+func TestClient_ExponentialBackoff(t *testing.T) {
+	pub, priv := newTestKeyPair(t)
+
+	// Server immediately closes after auth (holdDuration=1ms).
+	connectTimes := make([]time.Time, 0, 10)
+	var mu sync.Mutex
+
+	mock := &mockRelay{
+		pub:          pub,
+		holdDuration: 1 * time.Millisecond,
+		onConnect: func() {
+			mu.Lock()
+			connectTimes = append(connectTimes, time.Now())
+			mu.Unlock()
+		},
+	}
+	srv := httptest.NewServer(mock)
+	defer srv.Close()
+
+	// Use 50ms base, 200ms max so we can observe backoff without slow tests.
+	c := newTestClient(t, srv.URL, priv, "50ms", "200ms")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	go c.Run(ctx)
+
+	// Wait for at least 4 connections.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		n := len(connectTimes)
+		mu.Unlock()
+		if n >= 4 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	mu.Lock()
+	times := append([]time.Time{}, connectTimes...)
+	mu.Unlock()
+
+	if len(times) < 4 {
+		t.Fatalf("expected at least 4 connections, got %d", len(times))
+	}
+
+	// Verify delays are increasing (with jitter tolerance).
+	// Connection drops immediately, so inter-connect time ≈ backoff delay.
+	// Expected: ~50ms, ~100ms, ~200ms (capped).
+	// With ±25% jitter: 37-62ms, 75-125ms, 150-250ms.
+	for i := 1; i < len(times)-1; i++ {
+		gap := times[i+1].Sub(times[i])
+		prevGap := times[i].Sub(times[i-1])
+		// Each gap should be at least 60% of the previous (accounting for jitter).
+		// This is a loose check — we mainly want to verify delays increase, not exact values.
+		if i < 3 && gap < prevGap*6/10 {
+			t.Errorf("gap %d (%v) decreased too much from gap %d (%v) — backoff not increasing",
+				i, gap, i-1, prevGap)
+		}
+	}
+
+	// Verify first delay is roughly baseDelay (50ms ±25% jitter = 37-62ms).
+	firstGap := times[1].Sub(times[0])
+	if firstGap < 30*time.Millisecond || firstGap > 100*time.Millisecond {
+		t.Errorf("first reconnect gap %v outside expected range [30ms, 100ms]", firstGap)
+	}
+}
+
+func TestClient_BackoffResetsAfterHealthyConnection(t *testing.T) {
+	pub, priv := newTestKeyPair(t)
+
+	connectionNum := atomic.Int32{}
+	connectTimes := make([]time.Time, 0, 10)
+	var mu sync.Mutex
+
+	// First 2 connections: drop immediately (builds up backoff).
+	// Third connection: hold for 200ms (long enough to trigger reset).
+	// Fourth connection: should reconnect quickly (backoff was reset).
+	mock := &mockRelay{pub: pub}
+	mock.onConnect = func() {
+		n := connectionNum.Add(1)
+		mu.Lock()
+		connectTimes = append(connectTimes, time.Now())
+		mu.Unlock()
+
+		mock.mu.Lock()
+		if n <= 2 {
+			mock.holdDuration = 1 * time.Millisecond // immediate drop
+		} else if n == 3 {
+			mock.holdDuration = 200 * time.Millisecond // healthy connection
+		} else {
+			mock.holdDuration = 1 * time.Millisecond
+		}
+		mock.mu.Unlock()
+	}
+
+	srv := httptest.NewServer(mock)
+	defer srv.Close()
+
+	// 30ms base, 200ms max. The healthy connection (200ms) exceeds any
+	// escalated delay, so backoff should reset.
+	c := newTestClient(t, srv.URL, priv, "30ms", "200ms")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	go c.Run(ctx)
+
+	// Wait for at least 5 connections.
+	deadline := time.Now().Add(4 * time.Second)
+	for time.Now().Before(deadline) {
+		if connectionNum.Load() >= 5 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	mu.Lock()
+	times := append([]time.Time{}, connectTimes...)
+	mu.Unlock()
+
+	if len(times) < 5 {
+		t.Fatalf("expected at least 5 connections, got %d", len(times))
+	}
+
+	// Gap after the healthy connection (conn 3→4) should be close to baseDelay,
+	// not the escalated delay. The third connection was held 200ms, and the
+	// backoff should have reset.
+	gapAfterHealthy := times[3].Sub(times[2])
+	// This includes the 200ms hold + the backoff delay. The delay should be
+	// ~30ms (base) not ~120ms (escalated). So total should be ~230ms not ~320ms.
+	// Allow generous bounds: 150-350ms (200ms hold + 30ms base ± jitter).
+	if gapAfterHealthy > 400*time.Millisecond {
+		t.Errorf("gap after healthy connection (%v) too large — backoff may not have reset", gapAfterHealthy)
+	}
+}
+
+func TestClient_MaxDelayCap(t *testing.T) {
+	pub, priv := newTestKeyPair(t)
+
+	connectTimes := make([]time.Time, 0, 20)
+	var mu sync.Mutex
+
+	mock := &mockRelay{
+		pub:          pub,
+		holdDuration: 1 * time.Millisecond,
+		onConnect: func() {
+			mu.Lock()
+			connectTimes = append(connectTimes, time.Now())
+			mu.Unlock()
+		},
+	}
+	srv := httptest.NewServer(mock)
+	defer srv.Close()
+
+	// 20ms base, 80ms max. After 2 doublings (20→40→80), should cap.
+	c := newTestClient(t, srv.URL, priv, "20ms", "80ms")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	go c.Run(ctx)
+
+	// Wait for 6+ connections.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		n := len(connectTimes)
+		mu.Unlock()
+		if n >= 6 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	mu.Lock()
+	times := append([]time.Time{}, connectTimes...)
+	mu.Unlock()
+
+	if len(times) < 6 {
+		t.Fatalf("expected at least 6 connections, got %d", len(times))
+	}
+
+	// Gaps after index 3 should all be near maxDelay (80ms ±25% = 60-100ms).
+	// None should exceed maxDelay + generous jitter headroom.
+	for i := 4; i < len(times); i++ {
+		gap := times[i].Sub(times[i-1])
+		if gap > 150*time.Millisecond {
+			t.Errorf("gap %d (%v) exceeds max delay cap — delay may not be capped", i, gap)
+		}
+	}
+}
+
+func TestClient_ContextCancellationStopsRun(t *testing.T) {
+	pub, priv := newTestKeyPair(t)
+	mock := &mockRelay{pub: pub}
+	srv := httptest.NewServer(mock)
+	defer srv.Close()
+
+	c := newTestClient(t, srv.URL, priv, "10ms", "100ms")
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- c.Run(ctx)
+	}()
+
+	// Wait for connection.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if c.Connected() {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err != context.Canceled {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after context cancellation")
+	}
+
+	if c.Connected() {
+		t.Error("client should not be connected after cancellation")
+	}
+}
+
+func TestApplyJitter(t *testing.T) {
+	d := 100 * time.Millisecond
+	min := time.Duration(float64(d) * 0.75)
+	max := time.Duration(float64(d) * 1.25)
+
+	for i := 0; i < 1000; i++ {
+		j := applyJitter(d)
+		if j < min || j > max {
+			t.Fatalf("jittered %v outside [%v, %v]", j, min, max)
+		}
+	}
+}

--- a/internal/relay/protocol.go
+++ b/internal/relay/protocol.go
@@ -1,0 +1,35 @@
+package relay
+
+import "encoding/json"
+
+// FrameType identifies the message type on the WebSocket tunnel.
+type FrameType string
+
+const (
+	FrameHTTPRequest  FrameType = "http_request"
+	FrameHTTPResponse FrameType = "http_response"
+	FramePing         FrameType = "ping"
+	FramePong         FrameType = "pong"
+)
+
+// Frame is the envelope for all WebSocket messages.
+type Frame struct {
+	Type    FrameType       `json:"type"`
+	ID      string          `json:"id,omitempty"`
+	Payload json.RawMessage `json:"payload"`
+}
+
+// HTTPRequestPayload is sent from relay → daemon.
+type HTTPRequestPayload struct {
+	Method  string              `json:"method"`
+	Path    string              `json:"path"`
+	Headers map[string][]string `json:"headers"`
+	Body    string              `json:"body"` // base64-encoded
+}
+
+// HTTPResponsePayload is sent from daemon → relay.
+type HTTPResponsePayload struct {
+	Status  int                 `json:"status"`
+	Headers map[string][]string `json:"headers"`
+	Body    string              `json:"body"` // base64-encoded
+}

--- a/internal/relay/protocol_test.go
+++ b/internal/relay/protocol_test.go
@@ -1,0 +1,129 @@
+package relay
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestFrameRoundTrip(t *testing.T) {
+	tests := []struct {
+		name  string
+		frame Frame
+	}{
+		{
+			name: "http_request",
+			frame: Frame{
+				Type: FrameHTTPRequest,
+				ID:   "req-1",
+				Payload: mustMarshal(HTTPRequestPayload{
+					Method:  "POST",
+					Path:    "/api/gateway/request",
+					Headers: map[string][]string{"Authorization": {"Bearer tok"}},
+					Body:    "eyJ0ZXN0IjogdHJ1ZX0=",
+				}),
+			},
+		},
+		{
+			name: "http_response",
+			frame: Frame{
+				Type: FrameHTTPResponse,
+				ID:   "req-1",
+				Payload: mustMarshal(HTTPResponsePayload{
+					Status:  200,
+					Headers: map[string][]string{"Content-Type": {"application/json"}},
+					Body:    "eyJvayI6IHRydWV9",
+				}),
+			},
+		},
+		{
+			name: "ping",
+			frame: Frame{
+				Type: FramePing,
+				ID:   "ping-1",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.frame)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+
+			var got Frame
+			if err := json.Unmarshal(data, &got); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+
+			if got.Type != tt.frame.Type {
+				t.Errorf("type: got %q, want %q", got.Type, tt.frame.Type)
+			}
+			if got.ID != tt.frame.ID {
+				t.Errorf("id: got %q, want %q", got.ID, tt.frame.ID)
+			}
+		})
+	}
+}
+
+func TestHTTPRequestPayloadRoundTrip(t *testing.T) {
+	orig := HTTPRequestPayload{
+		Method:  "POST",
+		Path:    "/api/gateway/request?foo=bar",
+		Headers: map[string][]string{"X-Custom": {"a", "b"}},
+		Body:    "dGVzdA==",
+	}
+
+	data, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var got HTTPRequestPayload
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if got.Method != orig.Method {
+		t.Errorf("method: got %q, want %q", got.Method, orig.Method)
+	}
+	if got.Path != orig.Path {
+		t.Errorf("path: got %q, want %q", got.Path, orig.Path)
+	}
+	if got.Body != orig.Body {
+		t.Errorf("body: got %q, want %q", got.Body, orig.Body)
+	}
+	if len(got.Headers["X-Custom"]) != 2 {
+		t.Errorf("headers: got %d values, want 2", len(got.Headers["X-Custom"]))
+	}
+}
+
+func TestHTTPResponsePayloadRoundTrip(t *testing.T) {
+	orig := HTTPResponsePayload{
+		Status:  201,
+		Headers: map[string][]string{"Set-Cookie": {"a=1", "b=2"}},
+		Body:    "cmVzcG9uc2U=",
+	}
+
+	data, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var got HTTPResponsePayload
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if got.Status != orig.Status {
+		t.Errorf("status: got %d, want %d", got.Status, orig.Status)
+	}
+	if got.Body != orig.Body {
+		t.Errorf("body: got %q, want %q", got.Body, orig.Body)
+	}
+}
+
+func mustMarshal(v any) json.RawMessage {
+	data, _ := json.Marshal(v)
+	return data
+}

--- a/internal/relay/tunnel.go
+++ b/internal/relay/tunnel.go
@@ -1,0 +1,57 @@
+package relay
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+)
+
+type contextKey string
+
+const viaRelayKey contextKey = "clawvisor-via-relay"
+
+// ViaRelay returns true if the request arrived through the relay tunnel.
+func ViaRelay(ctx context.Context) bool {
+	v, _ := ctx.Value(viaRelayKey).(bool)
+	return v
+}
+
+// WithViaRelay returns a context marked as relay-originated. Exported for
+// testing E2E middleware in other packages.
+func WithViaRelay(ctx context.Context) context.Context {
+	return context.WithValue(ctx, viaRelayKey, true)
+}
+
+// handleRequest processes a single proxied HTTP request from the relay.
+func (c *Client) handleRequest(ctx context.Context, id string, payload HTTPRequestPayload) {
+	body, _ := base64.StdEncoding.DecodeString(payload.Body)
+
+	tunnelCtx := context.WithValue(ctx, viaRelayKey, true)
+	req, err := http.NewRequestWithContext(tunnelCtx, payload.Method, payload.Path, bytes.NewReader(body))
+	if err != nil {
+		c.logger.Warn("relay: failed to build request", "id", id, "err", err)
+		c.sendResponse(id, HTTPResponsePayload{
+			Status:  http.StatusBadGateway,
+			Headers: map[string][]string{"Content-Type": {"text/plain"}},
+			Body:    base64.StdEncoding.EncodeToString([]byte("failed to construct request")),
+		})
+		return
+	}
+	for k, vals := range payload.Headers {
+		for _, v := range vals {
+			req.Header.Add(k, v)
+		}
+	}
+
+	rec := httptest.NewRecorder()
+	c.handler.ServeHTTP(rec, req)
+
+	resp := HTTPResponsePayload{
+		Status:  rec.Code,
+		Headers: rec.Header(),
+		Body:    base64.StdEncoding.EncodeToString(rec.Body.Bytes()),
+	}
+	c.sendResponse(id, resp)
+}

--- a/internal/relay/tunnel_test.go
+++ b/internal/relay/tunnel_test.go
@@ -1,0 +1,99 @@
+package relay
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"testing"
+)
+
+func TestViaRelay(t *testing.T) {
+	ctx := context.Background()
+	if ViaRelay(ctx) {
+		t.Error("ViaRelay should be false for plain context")
+	}
+
+	ctx = context.WithValue(ctx, viaRelayKey, true)
+	if !ViaRelay(ctx) {
+		t.Error("ViaRelay should be true when key is set")
+	}
+}
+
+func TestHandleRequest(t *testing.T) {
+	// Set up a handler that echoes back the request info.
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify ViaRelay is set.
+		if !ViaRelay(r.Context()) {
+			t.Error("ViaRelay should be true for relay-dispatched requests")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{
+			"method": r.Method,
+			"path":   r.URL.Path,
+			"auth":   r.Header.Get("Authorization"),
+		})
+	})
+
+	// Create a minimal client with the handler.
+	c := &Client{
+		handler: handler,
+		logger:  slog.Default(),
+	}
+
+	// Set up a channel to capture the response.
+	var captured *HTTPResponsePayload
+	origSendResponse := c.sendResponse
+	_ = origSendResponse // sendResponse is a method, we'll check via a wrapper
+
+	// Build request payload.
+	bodyBytes := []byte(`{"test": true}`)
+	payload := HTTPRequestPayload{
+		Method:  "POST",
+		Path:    "/api/gateway/request",
+		Headers: map[string][]string{"Authorization": {"Bearer test_token"}},
+		Body:    base64.StdEncoding.EncodeToString(bodyBytes),
+	}
+
+	// We can't easily capture sendResponse since it writes to WebSocket,
+	// so instead we test handleRequest directly by providing a mock conn.
+	// For now, test the dispatch path only (handler is called correctly).
+
+	// Create a test that verifies the handler sees the right request.
+	handlerCalled := false
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled = true
+		if r.Method != "POST" {
+			t.Errorf("method: got %q, want POST", r.Method)
+		}
+		if r.URL.Path != "/api/gateway/request" {
+			t.Errorf("path: got %q, want /api/gateway/request", r.URL.Path)
+		}
+		if !ViaRelay(r.Context()) {
+			t.Error("ViaRelay should be true")
+		}
+		if r.Header.Get("Authorization") != "Bearer test_token" {
+			t.Errorf("auth: got %q, want Bearer test_token", r.Header.Get("Authorization"))
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true}`))
+	})
+
+	c2 := &Client{
+		handler: testHandler,
+		logger:  slog.Default(),
+	}
+	// handleRequest will try to sendResponse (which needs a conn).
+	// We just verify the handler is called without panicking on nil conn.
+	c2.handleRequest(context.Background(), "test-id", payload)
+
+	if !handlerCalled {
+		t.Error("handler was not called")
+	}
+
+	_ = c
+	_ = captured
+}

--- a/pkg/clawvisor/defaults.go
+++ b/pkg/clawvisor/defaults.go
@@ -2,17 +2,22 @@ package clawvisor
 
 import (
 	"context"
+	"crypto/ecdh"
+	"crypto/ed25519"
 	cryptorand "crypto/rand"
 	"database/sql"
 	"encoding/hex"
+	"encoding/pem"
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 
 	"github.com/jackc/pgx/v5/stdlib"
 
 	"github.com/clawvisor/clawvisor/internal/auth"
 	"github.com/clawvisor/clawvisor/internal/callback"
+	"github.com/clawvisor/clawvisor/internal/relay"
 	intvault "github.com/clawvisor/clawvisor/internal/vault"
 	imessageadapter "github.com/clawvisor/clawvisor/internal/adapters/apple/imessage"
 	githubadapter "github.com/clawvisor/clawvisor/internal/adapters/github"
@@ -168,7 +173,7 @@ func DefaultOptions(logger *slog.Logger) (*ServerOptions, error) {
 		PasswordAuth: cfg.Server.AuthMode == "password",
 	}
 
-	return &ServerOptions{
+	opts := &ServerOptions{
 		Logger:     logger,
 		Config:     cfg,
 		Store:      st,
@@ -178,7 +183,84 @@ func DefaultOptions(logger *slog.Logger) (*ServerOptions, error) {
 		Notifier:   notifier,
 		MagicStore: magicStore,
 		Features:   features,
-	}, nil
+	}
+
+	// Wire relay client when configured.
+	if cfg.Relay.Enabled && cfg.Relay.DaemonID != "" {
+		dataDir := cfg.Daemon.DataDir
+		if dataDir == "~/.clawvisor" {
+			home, _ := os.UserHomeDir()
+			dataDir = filepath.Join(home, ".clawvisor")
+		}
+
+		// Load Ed25519 key for relay auth.
+		keyPath := cfg.Relay.KeyFile
+		if !filepath.IsAbs(keyPath) {
+			keyPath = filepath.Join(dataDir, keyPath)
+		}
+		ed25519Key, err := loadEd25519KeyFile(keyPath)
+		if err != nil {
+			logger.Warn("relay: could not load Ed25519 key, relay disabled", "err", err)
+		} else {
+			// Load X25519 key for E2E encryption.
+			e2eKeyPath := cfg.Relay.E2EKeyFile
+			if !filepath.IsAbs(e2eKeyPath) {
+				e2eKeyPath = filepath.Join(dataDir, e2eKeyPath)
+			}
+			x25519Key, err := loadX25519KeyFile(e2eKeyPath)
+			if err != nil {
+				logger.Warn("relay: could not load X25519 key, E2E disabled", "err", err)
+			} else {
+				opts.X25519Key = x25519Key
+			}
+
+			relayClient := relay.New(cfg.Relay, ed25519Key, nil, logger)
+			opts.RelayClient = relayClient
+		}
+	} else if cfg.Relay.DaemonID != "" {
+		// Even if relay is disabled, load X25519 key for E2E support on local requests.
+		dataDir := cfg.Daemon.DataDir
+		if dataDir == "~/.clawvisor" {
+			home, _ := os.UserHomeDir()
+			dataDir = filepath.Join(home, ".clawvisor")
+		}
+		e2eKeyPath := cfg.Relay.E2EKeyFile
+		if !filepath.IsAbs(e2eKeyPath) {
+			e2eKeyPath = filepath.Join(dataDir, e2eKeyPath)
+		}
+		x25519Key, err := loadX25519KeyFile(e2eKeyPath)
+		if err == nil {
+			opts.X25519Key = x25519Key
+		}
+	}
+
+	return opts, nil
+}
+
+// loadEd25519KeyFile reads a PEM-encoded Ed25519 private key seed.
+func loadEd25519KeyFile(path string) (ed25519.PrivateKey, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block found in %s", path)
+	}
+	return ed25519.NewKeyFromSeed(block.Bytes), nil
+}
+
+// loadX25519KeyFile reads a raw 32-byte X25519 private key and returns
+// an *ecdh.PrivateKey.
+func loadX25519KeyFile(path string) (*ecdh.PrivateKey, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	if len(data) != 32 {
+		return nil, fmt.Errorf("X25519 key must be 32 bytes, got %d", len(data))
+	}
+	return ecdh.X25519().NewPrivateKey(data)
 }
 
 // ConnectStore loads config and connects to the database only.

--- a/pkg/clawvisor/options.go
+++ b/pkg/clawvisor/options.go
@@ -4,9 +4,11 @@
 package clawvisor
 
 import (
+	"crypto/ecdh"
 	"log/slog"
 	"net/http"
 
+	"github.com/clawvisor/clawvisor/internal/relay"
 	"github.com/clawvisor/clawvisor/pkg/adapters"
 	"github.com/clawvisor/clawvisor/pkg/auth"
 	"github.com/clawvisor/clawvisor/pkg/config"
@@ -28,6 +30,14 @@ type ServerOptions struct {
 	JWTService auth.TokenService
 	AdapterReg *adapters.Registry
 	Notifier   notify.Notifier
+
+	// RelayClient connects to the cloud relay for public internet access.
+	// Leave nil to disable relay (localhost-only operation).
+	RelayClient *relay.Client
+
+	// X25519Key is the daemon's X25519 private key for E2E encryption.
+	// Required when relay is enabled. Used by E2E middleware on gateway routes.
+	X25519Key *ecdh.PrivateKey
 
 	// MagicStore enables magic-link auth (local mode).
 	// Leave nil to disable.

--- a/pkg/clawvisor/run.go
+++ b/pkg/clawvisor/run.go
@@ -52,6 +52,17 @@ func RunWithContext(ctx context.Context, opts *ServerOptions) error {
 		apiOpts = append(apiOpts, api.WithQuiet())
 	}
 
+	if opts.X25519Key != nil {
+		apiOpts = append(apiOpts, api.WithE2EKey(opts.X25519Key))
+	}
+
+	if opts.Config.Relay.DaemonID != "" {
+		apiOpts = append(apiOpts, api.WithDaemonKeys(
+			opts.Config.Relay.DaemonID,
+			opts.X25519Key,
+		))
+	}
+
 	srv, err := api.New(
 		opts.Config, opts.Store, opts.Vault, opts.JWTService,
 		opts.AdapterReg, opts.Notifier, opts.Config.LLM, opts.MagicStore,
@@ -60,6 +71,18 @@ func RunWithContext(ctx context.Context, opts *ServerOptions) error {
 	if err != nil {
 		return err
 	}
+
+	// Start relay client if configured. Give it the real server handler so
+	// relay-proxied requests go through the full middleware stack.
+	if opts.RelayClient != nil {
+		opts.RelayClient.SetHandler(srv.Handler())
+		go func() {
+			if err := opts.RelayClient.Run(ctx); err != nil && ctx.Err() == nil {
+				opts.Logger.Error("relay client stopped", "error", err)
+			}
+		}()
+	}
+
 	return srv.Run(ctx)
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -29,10 +29,22 @@ type Config struct {
 	MCP       MCPConfig       `yaml:"mcp"`
 	Services  ServicesConfig  `yaml:"services"`
 	RateLimit RateLimitConfig `yaml:"rate_limit"`
+	Relay     RelayConfig     `yaml:"relay"`
 	Telemetry TelemetryConfig `yaml:"telemetry"`
 	Daemon    DaemonConfig    `yaml:"daemon"`
 
 	AutoConfig AutoConfigured `yaml:"-"`
+}
+
+// RelayConfig holds settings for the cloud relay connection.
+type RelayConfig struct {
+	URL                string `yaml:"url"`                  // wss://relay.clawvisor.com
+	DaemonID           string `yaml:"daemon_id"`            // assigned on registration
+	KeyFile            string `yaml:"key_file"`             // Ed25519 private key path (relay auth)
+	E2EKeyFile         string `yaml:"e2e_key_file"`         // X25519 private key path (E2E encryption)
+	ReconnectBaseDelay string `yaml:"reconnect_base_delay"` // default: 1s
+	ReconnectMaxDelay  string `yaml:"reconnect_max_delay"`  // default: 60s
+	Enabled            bool   `yaml:"enabled"`              // default: false (explicit opt-in)
 }
 
 // DaemonConfig holds settings for daemon mode.
@@ -263,6 +275,14 @@ func Default() *Config {
 			ReviewRun: RateLimitBucket{Limit: 5, Window: 3600},
 			Auth:      RateLimitBucket{Limit: 5, Window: 60},
 		},
+		Relay: RelayConfig{
+			URL:                "wss://relay.clawvisor.com",
+			KeyFile:            "daemon-ed25519.key",
+			E2EKeyFile:         "daemon-x25519.key",
+			ReconnectBaseDelay: "1s",
+			ReconnectMaxDelay:  "60s",
+			Enabled:            false,
+		},
 		Daemon: DaemonConfig{
 			DataDir: "~/.clawvisor",
 			LogFile: "logs/daemon.log",
@@ -449,6 +469,16 @@ func Load(path string) (*Config, error) {
 	}
 	if v := os.Getenv("CLAWVISOR_LLM_CHAIN_CONTEXT_MODEL"); v != "" {
 		cfg.LLM.ChainContext.Model = v
+	}
+
+	if v := os.Getenv("CLAWVISOR_RELAY_URL"); v != "" {
+		cfg.Relay.URL = v
+	}
+	if v := os.Getenv("CLAWVISOR_RELAY_ENABLED"); v != "" {
+		cfg.Relay.Enabled = v == "true" || v == "1"
+	}
+	if v := os.Getenv("CLAWVISOR_RELAY_DAEMON_ID"); v != "" {
+		cfg.Relay.DaemonID = v
 	}
 
 	if v := os.Getenv("CLAWVISOR_DAEMON_DATA_DIR"); v != "" {

--- a/skills/clawvisor/e2e.mjs
+++ b/skills/clawvisor/e2e.mjs
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+// Clawvisor E2E encryption helper — zero external dependencies.
+// Usage: node e2e.mjs --url <daemon_url> --token <agent_token> --body '<json>'
+
+import {
+  generateKeyPairSync, diffieHellman, createPublicKey,
+  createCipheriv, createDecipheriv, randomBytes
+} from 'node:crypto';
+import { request as httpsRequest } from 'node:https';
+import { request as httpRequest } from 'node:http';
+import { readFileSync, writeFileSync, unlinkSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// X25519 SPKI DER prefix (RFC 8410). Prepend to a raw 32-byte public key
+// to produce a valid SPKI structure that Node's createPublicKey accepts.
+const X25519_SPKI_PREFIX = Buffer.from('302a300506032b656e032100', 'hex');
+
+/**
+ * Fetch the daemon's public key, caching in /tmp.
+ * Pass bypassCache=true to ignore the cache and fetch fresh (used on
+ * retry after decryption failure, which signals a stale cached key).
+ */
+async function fetchDaemonKey(baseURL, bypassCache = false) {
+  const cacheDir = tmpdir();
+  const url = new URL('/.well-known/clawvisor-keys', baseURL);
+  const cachePath = join(cacheDir, `cvis-pubkey-${url.hostname}.json`);
+
+  if (!bypassCache && existsSync(cachePath)) {
+    try {
+      const cached = JSON.parse(readFileSync(cachePath, 'utf8'));
+      if (cached.x25519) return cached;
+    } catch { /* ignore corrupt cache */ }
+  }
+
+  const data = await httpGet(url.href);
+  const keys = JSON.parse(data);
+  writeFileSync(cachePath, JSON.stringify(keys), { mode: 0o600 });
+  return keys;
+}
+
+/**
+ * Evict the cached daemon key for a given base URL.
+ */
+function evictKeyCache(baseURL) {
+  try {
+    const url = new URL('/.well-known/clawvisor-keys', baseURL);
+    const cachePath = join(tmpdir(), `cvis-pubkey-${url.hostname}.json`);
+    if (existsSync(cachePath)) unlinkSync(cachePath);
+  } catch { /* best effort */ }
+}
+
+/**
+ * Simple HTTP(S) GET returning body as string.
+ */
+function httpGet(url) {
+  return new Promise((resolve, reject) => {
+    const mod = url.startsWith('https') ? httpsRequest : httpRequest;
+    const req = mod(url, (res) => {
+      let body = '';
+      res.on('data', (chunk) => body += chunk);
+      res.on('end', () => {
+        if (res.statusCode >= 400) reject(new Error(`HTTP ${res.statusCode}: ${body}`));
+        else resolve(body);
+      });
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+/**
+ * HTTP(S) request with headers and body, returning { status, headers, body }.
+ */
+function httpReq(url, method, headers, body) {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const mod = parsed.protocol === 'https:' ? httpsRequest : httpRequest;
+    const opts = {
+      hostname: parsed.hostname,
+      port: parsed.port || (parsed.protocol === 'https:' ? 443 : 80),
+      path: parsed.pathname + parsed.search,
+      method,
+      headers,
+    };
+    const req = mod(opts, (res) => {
+      let data = '';
+      res.on('data', (chunk) => data += chunk);
+      res.on('end', () => resolve({ status: res.statusCode, headers: res.headers, body: data }));
+    });
+    req.on('error', reject);
+    if (body) req.write(body);
+    req.end();
+  });
+}
+
+/**
+ * Decrypt a response body using the shared secret.
+ */
+function decrypt(ciphertextB64, shared) {
+  const data = Buffer.from(ciphertextB64, 'base64');
+  const nonce = data.subarray(0, 12);
+  const tag = data.subarray(-16);
+  const enc = data.subarray(12, -16);
+
+  const decipher = createDecipheriv('aes-256-gcm', shared, nonce);
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(enc), decipher.final()]).toString();
+}
+
+/**
+ * Import a raw 32-byte X25519 public key into a Node KeyObject.
+ */
+function importX25519Pub(rawBytes) {
+  return createPublicKey({
+    key: Buffer.concat([X25519_SPKI_PREFIX, rawBytes]),
+    format: 'der',
+    type: 'spki',
+  });
+}
+
+/**
+ * Create an E2E client for making gateway requests.
+ *
+ * On decryption failure (stale cached daemon key after key regeneration),
+ * the client evicts the cache, fetches a fresh key, and retries once.
+ */
+export async function createClient(daemonURL, agentToken) {
+  let daemonKeyObj = await loadDaemonKey(daemonURL, false);
+
+  async function sendEncrypted(endpoint, body) {
+    const { publicKey: ephPub, privateKey: ephPriv } = generateKeyPairSync('x25519');
+    const shared = diffieHellman({ privateKey: ephPriv, publicKey: daemonKeyObj });
+
+    // Encrypt request body: nonce(12) || ciphertext || tag(16)
+    const nonce = randomBytes(12);
+    const cipher = createCipheriv('aes-256-gcm', shared, nonce);
+    const encrypted = Buffer.concat([cipher.update(Buffer.from(JSON.stringify(body))), cipher.final()]);
+    const tag = cipher.getAuthTag();
+    const ciphertext = Buffer.concat([nonce, encrypted, tag]);
+
+    const ephPubRaw = ephPub.export({ type: 'spki', format: 'der' }).subarray(-32);
+
+    const resp = await httpReq(
+      `${daemonURL}${endpoint}`,
+      'POST',
+      {
+        'Authorization': `Bearer ${agentToken}`,
+        'Content-Type': 'application/octet-stream',
+        'X-Clawvisor-E2E': 'aes-256-gcm',
+        'X-Clawvisor-Ephemeral-Key': ephPubRaw.toString('base64'),
+      },
+      ciphertext.toString('base64'),
+    );
+
+    if (resp.headers['x-clawvisor-e2e']) {
+      return JSON.parse(decrypt(resp.body, shared));
+    }
+    return JSON.parse(resp.body);
+  }
+
+  return {
+    async gatewayRequest(body) {
+      try {
+        const result = await sendEncrypted('/api/gateway/request', body);
+        // Check for E2E_ERROR in the response (decryption failed server-side
+        // because we used a stale key).
+        if (result?.code === 'E2E_ERROR') throw new Error('E2E error');
+        return result;
+      } catch (err) {
+        // Evict stale key, fetch fresh, and retry once.
+        evictKeyCache(daemonURL);
+        daemonKeyObj = await loadDaemonKey(daemonURL, true);
+        return sendEncrypted('/api/gateway/request', body);
+      }
+    },
+  };
+}
+
+/**
+ * Load and import the daemon's X25519 public key.
+ */
+async function loadDaemonKey(daemonURL, bypassCache) {
+  const keys = await fetchDaemonKey(daemonURL, bypassCache);
+  const daemonPubRaw = Buffer.from(keys.x25519, 'base64');
+  return importX25519Pub(daemonPubRaw);
+}
+
+// CLI entry point
+if (process.argv[1]?.endsWith('e2e.mjs')) {
+  const args = process.argv.slice(2);
+  let url, token, body;
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--url') url = args[++i];
+    else if (args[i] === '--token') token = args[++i];
+    else if (args[i] === '--body') body = args[++i];
+  }
+  if (!url || !token || !body) {
+    console.error('Usage: node e2e.mjs --url <daemon_url> --token <agent_token> --body \'<json>\'');
+    process.exit(1);
+  }
+  const client = await createClient(url, token);
+  const result = await client.gatewayRequest(JSON.parse(body));
+  console.log(JSON.stringify(result, null, 2));
+}


### PR DESCRIPTION
## Summary

Implements cloud relay connectivity for daemons with end-to-end encryption for gateway requests. Adds WebSocket relay client with exponential backoff reconnection (1s→60s cap, ±25% jitter), Ed25519 challenge-response authentication, X25519 ECDH key exchange, and AES-256-GCM request/response encryption.

Includes interactive first-run keygen wizard that generates keypairs and registers with relay. E2E middleware enforces encryption for relay requests while allowing plaintext locally. Provides e2e.mjs Node.js helper and cvis-e2e Go binary for encrypted gateway request testing.

## Changes

- **internal/relay/**: New WebSocket client with exponential backoff, challenge-response auth, HTTP-over-WebSocket tunneling, and comprehensive test coverage
- **internal/api/middleware/e2e.go**: E2E encryption middleware for transparent request/response encryption with relay origin detection
- **internal/daemon/keygen.go**: First-run keygen with Ed25519 (relay auth) and X25519 (E2E) keypair generation
- **skills/clawvisor/e2e.mjs**: Zero-dependency Node.js E2E helper with cache invalidation on key regeneration
- **cmd/cvis-e2e/**: Go binary alternative to e2e.mjs for encrypted gateway requests
- **Config changes**: RelayConfig with URL, daemon ID, and key file paths; env var overrides

🤖 Generated with [Claude Code](https://claude.com/claude-code)