### PR TITLE
feat: push notifier and device pairing with HMAC auth

### DIFF
--- a/internal/api/connections_test.go
+++ b/internal/api/connections_test.go
@@ -2,6 +2,7 @@ package api_test
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"testing"
 	"time"
@@ -11,18 +12,28 @@ import (
 
 // setupConnectionEnv creates a test environment with an admin@local user
 // and a session for approving/denying connection requests.
+// The session user IS admin@local so that ownership checks pass.
 func setupConnectionEnv(t *testing.T) (*testEnv, *testSession) {
 	t.Helper()
 	env := newTestEnv(t)
 
-	// Connection requests resolve the daemon owner as admin@local.
-	_, err := env.Store.CreateUser(context.Background(), "admin@local", "unused-hash")
-	if err != nil {
-		t.Fatalf("create admin@local: %v", err)
-	}
+	// Register admin@local through the API so the session user is the daemon owner.
+	// Connection requests are assigned to admin@local, so the approving user
+	// must be admin@local for the ownership check in ApproveByID/DenyByID.
+	const password = "TestPass123!"
+	resp := env.do("POST", "/api/auth/register", "", map[string]any{
+		"email": "admin@local", "password": password,
+	})
+	body := mustStatus(t, resp, http.StatusCreated)
+	user := nested(t, body, "user")
 
-	// Create a session for user-authenticated endpoints.
-	session := newSession(t, env)
+	session := &testSession{
+		env:          env,
+		Email:        "admin@local",
+		UserID:       str(t, user, "id"),
+		AccessToken:  str(t, body, "access_token"),
+		RefreshToken: str(t, body, "refresh_token"),
+	}
 	return env, session
 }
 
@@ -244,11 +255,19 @@ func TestConnectionRequest_List(t *testing.T) {
 	env.do("POST", "/api/agents/connect", "", map[string]any{"name": "A"})
 	env.do("POST", "/api/agents/connect", "", map[string]any{"name": "B"})
 
-	// List pending (note: these belong to admin@local, not session's user).
-	// The List endpoint returns pending requests for the authenticated user.
-	// Since session's user is different from admin@local, this tests the scoping.
+	// List pending — the session user is admin@local, who owns the requests.
 	resp := session.do("GET", "/api/agents/connections", nil)
-	mustStatus(t, resp, http.StatusOK)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	var list []any
+	if err := json.NewDecoder(resp.Body).Decode(&list); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if len(list) != 2 {
+		t.Errorf("expected 2 pending requests, got %d", len(list))
+	}
 }
 
 func TestConnectionRequest_DeleteExpired(t *testing.T) {

--- a/internal/api/handlers/connections.go
+++ b/internal/api/handlers/connections.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -13,6 +15,12 @@ import (
 	"github.com/clawvisor/clawvisor/internal/events"
 	"github.com/clawvisor/clawvisor/pkg/notify"
 	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+var (
+	errAlreadyResolved = errors.New("connection request already resolved")
+	errExpired         = errors.New("connection request expired")
+	errForbidden       = errors.New("connection request does not belong to this user")
 )
 
 const (
@@ -243,58 +251,70 @@ func (h *ConnectionsHandler) Approve(w http.ResponseWriter, r *http.Request) {
 	}
 
 	id := r.PathValue("id")
-	cr, err := h.st.GetConnectionRequest(r.Context(), id)
+	agentID, err := h.ApproveByID(r.Context(), id, user.ID)
 	if err != nil {
-		if err == store.ErrNotFound {
+		switch err {
+		case store.ErrNotFound:
 			writeError(w, http.StatusNotFound, "NOT_FOUND", "connection request not found")
-		} else {
-			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not get connection request")
+		case errForbidden:
+			writeError(w, http.StatusForbidden, "FORBIDDEN", "not your connection request")
+		case errAlreadyResolved:
+			writeError(w, http.StatusConflict, "ALREADY_RESOLVED", "connection request is not pending")
+		case errExpired:
+			writeError(w, http.StatusGone, "EXPIRED", "connection request has expired")
+		default:
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not approve connection request")
 		}
 		return
 	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"status":   "approved",
+		"agent_id": agentID,
+	})
+}
+
+// ApproveByID is the core approve logic, callable from HTTP handlers and
+// the notifier decision consumer.
+func (h *ConnectionsHandler) ApproveByID(ctx context.Context, id, userID string) (agentID string, err error) {
+	cr, err := h.st.GetConnectionRequest(ctx, id)
+	if err != nil {
+		return "", err
+	}
+	if cr.UserID != userID {
+		return "", errForbidden
+	}
 	if cr.Status != "pending" {
-		writeError(w, http.StatusConflict, "ALREADY_RESOLVED", "connection request is not pending")
-		return
+		return "", errAlreadyResolved
 	}
 	if time.Now().After(cr.ExpiresAt) {
-		_ = h.st.UpdateConnectionRequestStatus(r.Context(), id, "expired", "")
-		writeError(w, http.StatusGone, "EXPIRED", "connection request has expired")
-		return
+		_ = h.st.UpdateConnectionRequestStatus(ctx, id, "expired", "")
+		return "", errExpired
 	}
 
-	// Generate agent token.
 	rawToken, err := auth.GenerateAgentToken()
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not generate token")
-		return
+		return "", fmt.Errorf("generate token: %w", err)
 	}
 
-	agent, err := h.st.CreateAgent(r.Context(), user.ID, cr.Name, auth.HashToken(rawToken))
+	agent, err := h.st.CreateAgent(ctx, userID, cr.Name, auth.HashToken(rawToken))
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not create agent")
-		return
+		return "", fmt.Errorf("create agent: %w", err)
 	}
 
-	if err := h.st.UpdateConnectionRequestStatus(r.Context(), id, "approved", agent.ID); err != nil {
-		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not update connection request")
-		return
+	if err := h.st.UpdateConnectionRequestStatus(ctx, id, "approved", agent.ID); err != nil {
+		return "", fmt.Errorf("update status: %w", err)
 	}
 
-	// Cache token in memory for the polling window.
 	h.tokensMu.Lock()
 	h.tokens[id] = approvedToken{raw: rawToken, approvedAt: time.Now()}
 	h.tokensMu.Unlock()
 
-	// Clean up expired tokens in the background.
 	go h.cleanExpiredTokens()
 
-	// Notify via SSE so PollStatus returns immediately.
-	h.eventHub.Publish(user.ID, events.Event{Type: "queue"})
+	h.eventHub.Publish(userID, events.Event{Type: "queue"})
 
-	writeJSON(w, http.StatusOK, map[string]any{
-		"status":   "approved",
-		"agent_id": agent.ID,
-	})
+	return agent.ID, nil
 }
 
 // Deny handles POST /api/agents/connect/{id}/deny (user JWT).
@@ -306,28 +326,43 @@ func (h *ConnectionsHandler) Deny(w http.ResponseWriter, r *http.Request) {
 	}
 
 	id := r.PathValue("id")
-	cr, err := h.st.GetConnectionRequest(r.Context(), id)
-	if err != nil {
-		if err == store.ErrNotFound {
+	if err := h.DenyByID(r.Context(), id, user.ID); err != nil {
+		switch err {
+		case store.ErrNotFound:
 			writeError(w, http.StatusNotFound, "NOT_FOUND", "connection request not found")
-		} else {
-			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not get connection request")
+		case errForbidden:
+			writeError(w, http.StatusForbidden, "FORBIDDEN", "not your connection request")
+		case errAlreadyResolved:
+			writeError(w, http.StatusConflict, "ALREADY_RESOLVED", "connection request is not pending")
+		default:
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not deny connection request")
 		}
 		return
 	}
-	if cr.Status != "pending" {
-		writeError(w, http.StatusConflict, "ALREADY_RESOLVED", "connection request is not pending")
-		return
-	}
-
-	if err := h.st.UpdateConnectionRequestStatus(r.Context(), id, "denied", ""); err != nil {
-		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not update connection request")
-		return
-	}
-
-	h.eventHub.Publish(user.ID, events.Event{Type: "queue"})
 
 	writeJSON(w, http.StatusOK, map[string]any{"status": "denied"})
+}
+
+// DenyByID is the core deny logic, callable from HTTP handlers and
+// the notifier decision consumer.
+func (h *ConnectionsHandler) DenyByID(ctx context.Context, id, userID string) error {
+	cr, err := h.st.GetConnectionRequest(ctx, id)
+	if err != nil {
+		return err
+	}
+	if cr.UserID != userID {
+		return errForbidden
+	}
+	if cr.Status != "pending" {
+		return errAlreadyResolved
+	}
+
+	if err := h.st.UpdateConnectionRequestStatus(ctx, id, "denied", ""); err != nil {
+		return fmt.Errorf("update status: %w", err)
+	}
+
+	h.eventHub.Publish(userID, events.Event{Type: "queue"})
+	return nil
 }
 
 // List handles GET /api/agents/connections (user JWT).

--- a/internal/api/handlers/devices.go
+++ b/internal/api/handlers/devices.go
@@ -1,0 +1,316 @@
+package handlers
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"math/big"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/clawvisor/clawvisor/internal/api/middleware"
+	"github.com/clawvisor/clawvisor/internal/notify/push"
+	"github.com/clawvisor/clawvisor/pkg/notify"
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+const (
+	pairingExpiry     = 5 * time.Minute
+	maxPairingAttempts = 3
+)
+
+// DevicesHandler manages device pairing and action endpoints.
+type DevicesHandler struct {
+	st       store.Store
+	pushN    *push.Notifier // may be nil if push is not configured
+	logger   *slog.Logger
+	baseURL  string
+
+	pairingsMu sync.Mutex
+	pairings   map[string]*pairingSession
+}
+
+type pairingSession struct {
+	Token     string
+	UserID    string
+	Code      string // 6-digit numeric code
+	Attempts  int
+	ExpiresAt time.Time
+}
+
+func NewDevicesHandler(st store.Store, pushN *push.Notifier, logger *slog.Logger, baseURL string) *DevicesHandler {
+	return &DevicesHandler{
+		st:       st,
+		pushN:    pushN,
+		logger:   logger,
+		baseURL:  baseURL,
+		pairings: make(map[string]*pairingSession),
+	}
+}
+
+// StartPairing handles POST /api/devices/pair (user JWT).
+// Returns a pairing token and 6-digit code for the mobile App Clip to use.
+func (h *DevicesHandler) StartPairing(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "not authenticated")
+		return
+	}
+
+	token, err := generatePairingToken()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not generate pairing token")
+		return
+	}
+
+	code, err := generatePairingCode()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not generate pairing code")
+		return
+	}
+
+	session := &pairingSession{
+		Token:     token,
+		UserID:    user.ID,
+		Code:      code,
+		ExpiresAt: time.Now().Add(pairingExpiry),
+	}
+	h.pairingsMu.Lock()
+	h.pairings[token] = session
+	h.pairingsMu.Unlock()
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"pairing_token": token,
+		"code":          code,
+		"pairing_url":   h.baseURL + "/api/devices/pair/complete",
+		"expires_at":    session.ExpiresAt,
+	})
+}
+
+// CompletePairing handles POST /api/devices/pair/complete (unauthenticated, rate-limited).
+// The mobile app presents the pairing token, code, device name, and push token.
+func (h *DevicesHandler) CompletePairing(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		PairingToken string `json:"pairing_token"`
+		Code         string `json:"code"`
+		DeviceName   string `json:"device_name"`
+		DeviceToken  string `json:"device_token"`
+	}
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+	if body.PairingToken == "" || body.Code == "" || body.DeviceName == "" || body.DeviceToken == "" {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "pairing_token, code, device_name, and device_token are required")
+		return
+	}
+
+	// Hold the mutex for the entire validate-and-consume sequence to prevent
+	// concurrent requests from racing past the attempt limit or both succeeding
+	// with the correct code.
+	h.pairingsMu.Lock()
+	session, ok := h.pairings[body.PairingToken]
+	if !ok {
+		h.pairingsMu.Unlock()
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "pairing session not found or expired")
+		return
+	}
+
+	if time.Now().After(session.ExpiresAt) {
+		delete(h.pairings, body.PairingToken)
+		h.pairingsMu.Unlock()
+		writeError(w, http.StatusGone, "EXPIRED", "pairing session has expired")
+		return
+	}
+
+	if session.Code != body.Code {
+		session.Attempts++
+		if session.Attempts >= maxPairingAttempts {
+			delete(h.pairings, body.PairingToken)
+			h.pairingsMu.Unlock()
+			writeError(w, http.StatusUnauthorized, "MAX_ATTEMPTS", "too many incorrect code attempts")
+			return
+		}
+		h.pairingsMu.Unlock()
+		writeError(w, http.StatusUnauthorized, "INVALID_CODE", "incorrect pairing code")
+		return
+	}
+
+	// Code is correct — remove the session before releasing the lock.
+	delete(h.pairings, body.PairingToken)
+	h.pairingsMu.Unlock()
+
+	// Generate HMAC key (32 random bytes, hex-encoded).
+	hmacKey := make([]byte, 32)
+	if _, err := rand.Read(hmacKey); err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not generate HMAC key")
+		return
+	}
+	hmacKeyHex := hex.EncodeToString(hmacKey)
+
+	device := &store.PairedDevice{
+		UserID:        session.UserID,
+		DeviceName:    body.DeviceName,
+		DeviceToken:   body.DeviceToken,
+		DeviceHMACKey: hmacKeyHex,
+	}
+	if err := h.st.CreatePairedDevice(r.Context(), device); err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not create paired device")
+		return
+	}
+
+	// Register with push service if available.
+	if h.pushN != nil {
+		if err := h.pushN.RegisterDevice(r.Context(), body.DeviceToken); err != nil {
+			h.logger.Warn("failed to register device with push service", "err", err)
+		}
+	}
+
+	writeJSON(w, http.StatusCreated, map[string]any{
+		"device_id": device.ID,
+		"hmac_key":  hmacKeyHex,
+	})
+}
+
+// List handles GET /api/devices (user JWT).
+func (h *DevicesHandler) List(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "not authenticated")
+		return
+	}
+
+	devices, err := h.st.ListPairedDevices(r.Context(), user.ID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not list devices")
+		return
+	}
+	if devices == nil {
+		devices = []*store.PairedDevice{}
+	}
+	writeJSON(w, http.StatusOK, devices)
+}
+
+// Delete handles DELETE /api/devices/{id} (user JWT).
+func (h *DevicesHandler) Delete(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "not authenticated")
+		return
+	}
+
+	id := r.PathValue("id")
+	device, err := h.st.GetPairedDevice(r.Context(), id)
+	if err != nil {
+		if err == store.ErrNotFound {
+			writeError(w, http.StatusNotFound, "NOT_FOUND", "device not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not get device")
+		return
+	}
+	if device.UserID != user.ID {
+		writeError(w, http.StatusForbidden, "FORBIDDEN", "not your device")
+		return
+	}
+
+	// Deregister from push service before deleting.
+	if h.pushN != nil {
+		if err := h.pushN.DeregisterDevice(r.Context(), device.DeviceToken); err != nil {
+			h.logger.Warn("failed to deregister device from push service", "err", err)
+		}
+	}
+
+	if err := h.st.DeletePairedDevice(r.Context(), id); err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not delete device")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"deleted": true})
+}
+
+// Action handles POST /api/devices/{id}/action (DeviceHMAC auth).
+// The mobile app sends approve/deny decisions via this endpoint.
+func (h *DevicesHandler) Action(w http.ResponseWriter, r *http.Request) {
+	device := middleware.DeviceFromContext(r.Context())
+	if device == nil {
+		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "device not authenticated")
+		return
+	}
+
+	var body struct {
+		Action      string `json:"action"`       // "approve" or "deny"
+		TargetID    string `json:"target_id"`     // request/task/connection ID
+		RequestType string `json:"request_type"`  // "approval", "task", "scope_expansion", "connection"
+	}
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+	if body.Action == "" || body.TargetID == "" || body.RequestType == "" {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "action, target_id, and request_type are required")
+		return
+	}
+	if body.Action != "approve" && body.Action != "deny" {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "action must be 'approve' or 'deny'")
+		return
+	}
+
+	// Update last seen.
+	_ = h.st.UpdatePairedDeviceLastSeen(r.Context(), device.ID)
+
+	// Emit decision through the push notifier's channel.
+	if h.pushN == nil {
+		writeError(w, http.StatusServiceUnavailable, "PUSH_NOT_CONFIGURED", "push notification service is not configured")
+		return
+	}
+	h.pushN.EmitDecision(notify.CallbackDecision{
+		Type:     body.RequestType,
+		Action:   body.Action,
+		TargetID: body.TargetID,
+		UserID:   device.UserID,
+	})
+
+	writeJSON(w, http.StatusOK, map[string]any{"status": "received"})
+}
+
+// RunCleanup periodically sweeps expired pairing sessions.
+func (h *DevicesHandler) RunCleanup(ctx context.Context) {
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			now := time.Now()
+			h.pairingsMu.Lock()
+			for token, session := range h.pairings {
+				if now.After(session.ExpiresAt) {
+					delete(h.pairings, token)
+				}
+			}
+			h.pairingsMu.Unlock()
+		}
+	}
+}
+
+// generatePairingToken returns a 32-byte URL-safe base64 token.
+func generatePairingToken() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString(b), nil
+}
+
+// generatePairingCode returns a random 6-digit numeric code.
+func generatePairingCode() (string, error) {
+	n, err := rand.Int(rand.Reader, big.NewInt(1000000))
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%06d", n.Int64()), nil
+}

--- a/internal/api/handlers/devices_test.go
+++ b/internal/api/handlers/devices_test.go
@@ -1,0 +1,399 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/clawvisor/clawvisor/internal/api/middleware"
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+// devicesTestStore is a minimal in-memory store for device handler tests.
+type devicesTestStore struct {
+	store.Store // embed nil interface; only override needed methods
+	devices     map[string]*store.PairedDevice
+}
+
+func newDevicesTestStore() *devicesTestStore {
+	return &devicesTestStore{devices: make(map[string]*store.PairedDevice)}
+}
+
+var devicesTestCounter int
+
+func (s *devicesTestStore) CreatePairedDevice(_ context.Context, d *store.PairedDevice) error {
+	if d.ID == "" {
+		devicesTestCounter++
+		d.ID = fmt.Sprintf("dev-%d", devicesTestCounter)
+	}
+	d.PairedAt = time.Now()
+	d.LastSeenAt = time.Now()
+	s.devices[d.ID] = d
+	return nil
+}
+
+func (s *devicesTestStore) GetPairedDevice(_ context.Context, id string) (*store.PairedDevice, error) {
+	d, ok := s.devices[id]
+	if !ok {
+		return nil, store.ErrNotFound
+	}
+	return d, nil
+}
+
+func (s *devicesTestStore) ListPairedDevices(_ context.Context, userID string) ([]*store.PairedDevice, error) {
+	var result []*store.PairedDevice
+	for _, d := range s.devices {
+		if d.UserID == userID {
+			result = append(result, d)
+		}
+	}
+	return result, nil
+}
+
+func (s *devicesTestStore) DeletePairedDevice(_ context.Context, id string) error {
+	delete(s.devices, id)
+	return nil
+}
+
+func (s *devicesTestStore) UpdatePairedDeviceLastSeen(_ context.Context, id string) error {
+	if d, ok := s.devices[id]; ok {
+		d.LastSeenAt = time.Now()
+	}
+	return nil
+}
+
+func newTestDevicesHandler() *DevicesHandler {
+	return NewDevicesHandler(newDevicesTestStore(), nil, slog.Default(), "http://localhost:9090")
+}
+
+func withUser(ctx context.Context, user *store.User) context.Context {
+	return context.WithValue(ctx, middleware.UserContextKey, user)
+}
+
+func withDevice(ctx context.Context, device *store.PairedDevice) context.Context {
+	return context.WithValue(ctx, middleware.DeviceContextKey, device)
+}
+
+func TestStartPairing(t *testing.T) {
+	h := newTestDevicesHandler()
+
+	req := httptest.NewRequest("POST", "/api/devices/pair", nil)
+	req = req.WithContext(withUser(req.Context(), &store.User{ID: "u1"}))
+	w := httptest.NewRecorder()
+
+	h.StartPairing(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+
+	if resp["pairing_token"] == nil || resp["pairing_token"] == "" {
+		t.Error("expected pairing_token in response")
+	}
+	if resp["code"] == nil || resp["code"] == "" {
+		t.Error("expected code in response")
+	}
+	code := resp["code"].(string)
+	if len(code) != 6 {
+		t.Errorf("expected 6-digit code, got %q", code)
+	}
+}
+
+func TestStartPairingUnauthenticated(t *testing.T) {
+	h := newTestDevicesHandler()
+
+	req := httptest.NewRequest("POST", "/api/devices/pair", nil)
+	w := httptest.NewRecorder()
+
+	h.StartPairing(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestFullPairingFlow(t *testing.T) {
+	h := newTestDevicesHandler()
+
+	// Step 1: Start pairing.
+	req := httptest.NewRequest("POST", "/api/devices/pair", nil)
+	req = req.WithContext(withUser(req.Context(), &store.User{ID: "u1"}))
+	w := httptest.NewRecorder()
+	h.StartPairing(w, req)
+
+	var startResp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &startResp)
+	token := startResp["pairing_token"].(string)
+	code := startResp["code"].(string)
+
+	// Step 2: Complete pairing.
+	completeBody, _ := json.Marshal(map[string]string{
+		"pairing_token": token,
+		"code":          code,
+		"device_name":   "iPhone 15",
+		"device_token":  "apns-token-123",
+	})
+	req = httptest.NewRequest("POST", "/api/devices/pair/complete", bytes.NewReader(completeBody))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	h.CompletePairing(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var completeResp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &completeResp)
+	deviceID := completeResp["device_id"].(string)
+	hmacKey := completeResp["hmac_key"].(string)
+
+	if deviceID == "" {
+		t.Error("expected device_id in response")
+	}
+	if hmacKey == "" {
+		t.Error("expected hmac_key in response")
+	}
+	if len(hmacKey) != 64 { // 32 bytes = 64 hex chars
+		t.Errorf("expected 64-char hex hmac_key, got %d chars", len(hmacKey))
+	}
+
+	// Step 3: List devices.
+	req = httptest.NewRequest("GET", "/api/devices", nil)
+	req = req.WithContext(withUser(req.Context(), &store.User{ID: "u1"}))
+	w = httptest.NewRecorder()
+	h.List(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var devices []*store.PairedDevice
+	json.Unmarshal(w.Body.Bytes(), &devices)
+	if len(devices) != 1 {
+		t.Fatalf("expected 1 device, got %d", len(devices))
+	}
+	if devices[0].ID != deviceID {
+		t.Errorf("expected device ID %q, got %q", deviceID, devices[0].ID)
+	}
+
+	// Step 4: Delete device.
+	req = httptest.NewRequest("DELETE", "/api/devices/"+deviceID, nil)
+	req.SetPathValue("id", deviceID)
+	req = req.WithContext(withUser(req.Context(), &store.User{ID: "u1"}))
+	w = httptest.NewRecorder()
+	h.Delete(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Verify device is gone.
+	req = httptest.NewRequest("GET", "/api/devices", nil)
+	req = req.WithContext(withUser(req.Context(), &store.User{ID: "u1"}))
+	w = httptest.NewRecorder()
+	h.List(w, req)
+
+	json.Unmarshal(w.Body.Bytes(), &devices)
+	if len(devices) != 0 {
+		t.Errorf("expected 0 devices after delete, got %d", len(devices))
+	}
+}
+
+func TestBruteForceProtection(t *testing.T) {
+	h := newTestDevicesHandler()
+
+	// Start pairing.
+	req := httptest.NewRequest("POST", "/api/devices/pair", nil)
+	req = req.WithContext(withUser(req.Context(), &store.User{ID: "u1"}))
+	w := httptest.NewRecorder()
+	h.StartPairing(w, req)
+
+	var startResp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &startResp)
+	token := startResp["pairing_token"].(string)
+
+	// Send 3 wrong codes.
+	for i := 0; i < 3; i++ {
+		body, _ := json.Marshal(map[string]string{
+			"pairing_token": token,
+			"code":          "000000", // wrong code
+			"device_name":   "iPhone",
+			"device_token":  "tok",
+		})
+		req = httptest.NewRequest("POST", "/api/devices/pair/complete", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w = httptest.NewRecorder()
+		h.CompletePairing(w, req)
+
+		if i < 2 {
+			if w.Code != http.StatusUnauthorized {
+				t.Fatalf("attempt %d: expected 401, got %d", i+1, w.Code)
+			}
+			var errResp map[string]any
+			json.Unmarshal(w.Body.Bytes(), &errResp)
+			if errResp["code"] != "INVALID_CODE" {
+				t.Errorf("attempt %d: expected INVALID_CODE, got %v", i+1, errResp["code"])
+			}
+		} else {
+			// 3rd attempt: should be invalidated.
+			if w.Code != http.StatusUnauthorized {
+				t.Fatalf("attempt %d: expected 401, got %d", i+1, w.Code)
+			}
+			var errResp map[string]any
+			json.Unmarshal(w.Body.Bytes(), &errResp)
+			if errResp["code"] != "MAX_ATTEMPTS" {
+				t.Errorf("attempt %d: expected MAX_ATTEMPTS, got %v", i+1, errResp["code"])
+			}
+		}
+	}
+
+	// Token should be deleted — any subsequent attempt should return NOT_FOUND.
+	body, _ := json.Marshal(map[string]string{
+		"pairing_token": token,
+		"code":          "000000",
+		"device_name":   "iPhone",
+		"device_token":  "tok",
+	})
+	req = httptest.NewRequest("POST", "/api/devices/pair/complete", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	h.CompletePairing(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 after max attempts, got %d", w.Code)
+	}
+}
+
+func TestExpiredPairingSession(t *testing.T) {
+	h := newTestDevicesHandler()
+
+	// Manually insert an expired session.
+	token := "expired-token"
+	h.pairingsMu.Lock()
+	h.pairings[token] = &pairingSession{
+		Token:     token,
+		UserID:    "u1",
+		Code:      "123456",
+		ExpiresAt: time.Now().Add(-1 * time.Minute), // already expired
+	}
+	h.pairingsMu.Unlock()
+
+	body, _ := json.Marshal(map[string]string{
+		"pairing_token": token,
+		"code":          "123456",
+		"device_name":   "iPhone",
+		"device_token":  "tok",
+	})
+	req := httptest.NewRequest("POST", "/api/devices/pair/complete", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.CompletePairing(w, req)
+
+	if w.Code != http.StatusGone {
+		t.Fatalf("expected 410, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCompletePairingMissingFields(t *testing.T) {
+	h := newTestDevicesHandler()
+
+	body, _ := json.Marshal(map[string]string{
+		"pairing_token": "tok",
+		// missing code, device_name, device_token
+	})
+	req := httptest.NewRequest("POST", "/api/devices/pair/complete", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.CompletePairing(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestActionEndpointNoPush(t *testing.T) {
+	st := newDevicesTestStore()
+	st.devices["d1"] = &store.PairedDevice{
+		ID:     "d1",
+		UserID: "u1",
+	}
+	// pushN is nil — action should return 503.
+	h := NewDevicesHandler(st, nil, slog.Default(), "http://localhost:9090")
+
+	body, _ := json.Marshal(map[string]string{
+		"action":       "approve",
+		"target_id":    "req-1",
+		"request_type": "approval",
+	})
+	req := httptest.NewRequest("POST", "/api/devices/d1/action", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(withDevice(req.Context(), st.devices["d1"]))
+	w := httptest.NewRecorder()
+	h.Action(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 when push not configured, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestActionInvalidAction(t *testing.T) {
+	h := newTestDevicesHandler()
+
+	body, _ := json.Marshal(map[string]string{
+		"action":       "invalid",
+		"target_id":    "req-1",
+		"request_type": "approval",
+	})
+	req := httptest.NewRequest("POST", "/api/devices/d1/action", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(withDevice(req.Context(), &store.PairedDevice{ID: "d1", UserID: "u1"}))
+	w := httptest.NewRecorder()
+	h.Action(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestDeleteForbidden(t *testing.T) {
+	st := newDevicesTestStore()
+	st.devices["d1"] = &store.PairedDevice{
+		ID:     "d1",
+		UserID: "u1",
+	}
+	h := NewDevicesHandler(st, nil, slog.Default(), "http://localhost:9090")
+
+	req := httptest.NewRequest("DELETE", "/api/devices/d1", nil)
+	req.SetPathValue("id", "d1")
+	// Different user trying to delete.
+	req = req.WithContext(withUser(req.Context(), &store.User{ID: "u2"}))
+	w := httptest.NewRecorder()
+	h.Delete(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", w.Code)
+	}
+}
+
+func TestDeleteNotFound(t *testing.T) {
+	h := newTestDevicesHandler()
+
+	req := httptest.NewRequest("DELETE", "/api/devices/nonexistent", nil)
+	req.SetPathValue("id", "nonexistent")
+	req = req.WithContext(withUser(req.Context(), &store.User{ID: "u1"}))
+	w := httptest.NewRecorder()
+	h.Delete(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}

--- a/internal/api/middleware/device.go
+++ b/internal/api/middleware/device.go
@@ -1,0 +1,104 @@
+package middleware
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+const (
+	// DeviceContextKey is the context key for the authenticated paired device.
+	DeviceContextKey contextKey = "device"
+
+	// deviceTimestampSkew is the maximum allowed clock difference for DeviceHMAC auth.
+	deviceTimestampSkew = 5 * time.Minute
+)
+
+// DeviceFromContext retrieves the authenticated paired device from a request context.
+func DeviceFromContext(ctx context.Context) *store.PairedDevice {
+	d, _ := ctx.Value(DeviceContextKey).(*store.PairedDevice)
+	return d
+}
+
+// RequireDevice is middleware that validates a DeviceHMAC authorization header
+// and injects the paired device into the request context.
+//
+// Header format: Authorization: DeviceHMAC <device_id>:<timestamp>:<hmac_hex>
+// HMAC message:  "<method>\n<path>\n<timestamp>\n<sha256_hex(body)>"
+func RequireDevice(st store.Store) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			authHeader := r.Header.Get("Authorization")
+			const prefix = "DeviceHMAC "
+			if !strings.HasPrefix(authHeader, prefix) {
+				http.Error(w, `{"error":"missing DeviceHMAC authorization","code":"UNAUTHORIZED"}`, http.StatusUnauthorized)
+				return
+			}
+
+			parts := strings.SplitN(authHeader[len(prefix):], ":", 3)
+			if len(parts) != 3 {
+				http.Error(w, `{"error":"malformed DeviceHMAC header","code":"UNAUTHORIZED"}`, http.StatusUnauthorized)
+				return
+			}
+			deviceID, tsStr, providedHMAC := parts[0], parts[1], parts[2]
+
+			// Validate timestamp.
+			tsUnix, err := strconv.ParseInt(tsStr, 10, 64)
+			if err != nil {
+				http.Error(w, `{"error":"invalid timestamp","code":"UNAUTHORIZED"}`, http.StatusUnauthorized)
+				return
+			}
+			diff := time.Since(time.Unix(tsUnix, 0))
+			if math.Abs(diff.Seconds()) > deviceTimestampSkew.Seconds() {
+				http.Error(w, `{"error":"timestamp out of range","code":"UNAUTHORIZED"}`, http.StatusUnauthorized)
+				return
+			}
+
+			// Read body for HMAC computation, then re-attach.
+			bodyBytes, err := io.ReadAll(r.Body)
+			if err != nil {
+				http.Error(w, `{"error":"failed to read body","code":"BAD_REQUEST"}`, http.StatusBadRequest)
+				return
+			}
+			r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+
+			// Load device from store.
+			device, err := st.GetPairedDevice(r.Context(), deviceID)
+			if err != nil {
+				http.Error(w, `{"error":"unknown device","code":"UNAUTHORIZED"}`, http.StatusUnauthorized)
+				return
+			}
+
+			// Compute expected HMAC.
+			hmacKey, err := hex.DecodeString(device.DeviceHMACKey)
+			if err != nil {
+				http.Error(w, `{"error":"internal error","code":"INTERNAL"}`, http.StatusInternalServerError)
+				return
+			}
+			bodyHash := sha256.Sum256(bodyBytes)
+			message := fmt.Sprintf("%s\n%s\n%s\n%x", r.Method, r.URL.Path, tsStr, bodyHash)
+			mac := hmac.New(sha256.New, hmacKey)
+			mac.Write([]byte(message))
+			expectedMAC := hex.EncodeToString(mac.Sum(nil))
+
+			if !hmac.Equal([]byte(providedHMAC), []byte(expectedMAC)) {
+				http.Error(w, `{"error":"invalid HMAC signature","code":"UNAUTHORIZED"}`, http.StatusUnauthorized)
+				return
+			}
+
+			ctx := context.WithValue(r.Context(), DeviceContextKey, device)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/clawvisor/clawvisor/internal/events"
 	"github.com/clawvisor/clawvisor/internal/mcp"
 	mcpoauth "github.com/clawvisor/clawvisor/internal/mcp/oauth"
+	"github.com/clawvisor/clawvisor/internal/notify/push"
 	pkgauth "github.com/clawvisor/clawvisor/pkg/auth"
 	"github.com/clawvisor/clawvisor/pkg/config"
 	"github.com/clawvisor/clawvisor/internal/intent"
@@ -59,9 +60,13 @@ type Server struct {
 	daemonID     string           // relay daemon ID
 	ed25519PubB64 string          // base64-encoded Ed25519 public key for .well-known
 
-	// approvalsCleaner is used to stop the background goroutine.
-	approvalsHandler *handlers.ApprovalsHandler
-	tasksHandler     *handlers.TasksHandler
+	// Handler references for background goroutines and decision dispatch.
+	approvalsHandler   *handlers.ApprovalsHandler
+	tasksHandler       *handlers.TasksHandler
+	connectionsHandler *handlers.ConnectionsHandler
+	devicesHandler     *handlers.DevicesHandler
+
+	pushNotifier *push.Notifier // concrete push notifier; may be nil
 
 	eventHub    *events.Hub
 	mcpServer   *mcp.Server
@@ -135,6 +140,12 @@ func WithDaemonKeys(daemonID string, x25519Key *ecdh.PrivateKey) ServerOption {
 			s.x25519Key = x25519Key
 		}
 	}
+}
+
+// WithPushNotifier passes the concrete push notifier so the device handler
+// can register/deregister device tokens and emit action decisions.
+func WithPushNotifier(pn *push.Notifier) ServerOption {
+	return func(s *Server) { s.pushNotifier = pn }
 }
 
 // New creates a Server and registers all routes.
@@ -362,6 +373,7 @@ func (s *Server) routes() http.Handler {
 
 	// Connection requests (unauthenticated — agents requesting access)
 	connectionsHandler := handlers.NewConnectionsHandler(s.store, s.notifier, s.eventHub, s.logger)
+	s.connectionsHandler = connectionsHandler
 	connectionsRL := newKeyedLimiterFromBucket(config.RateLimitBucket{Limit: 10, Window: 60})
 	mux.Handle("POST /api/agents/connect",
 		middleware.RateLimit(connectionsRL, ipKeyFn, 10)(http.HandlerFunc(connectionsHandler.RequestConnect)))
@@ -371,6 +383,18 @@ func (s *Server) routes() http.Handler {
 	mux.Handle("GET /api/agents/connections", user(connectionsHandler.List))
 	mux.Handle("POST /api/agents/connect/{id}/approve", user(connectionsHandler.Approve))
 	mux.Handle("POST /api/agents/connect/{id}/deny", user(connectionsHandler.Deny))
+
+	// Device pairing and management
+	devicesHandler := handlers.NewDevicesHandler(s.store, s.pushNotifier, s.logger, baseURL)
+	s.devicesHandler = devicesHandler
+	devicesRL := newKeyedLimiterFromBucket(config.RateLimitBucket{Limit: 5, Window: 60})
+	mux.Handle("POST /api/devices/pair", user(devicesHandler.StartPairing))
+	mux.Handle("POST /api/devices/pair/complete",
+		middleware.RateLimit(devicesRL, ipKeyFn, 5)(http.HandlerFunc(devicesHandler.CompletePairing)))
+	mux.Handle("GET /api/devices", user(devicesHandler.List))
+	mux.Handle("DELETE /api/devices/{id}", user(devicesHandler.Delete))
+	requireDevice := middleware.RequireDevice(s.store)
+	mux.Handle("POST /api/devices/{id}/action", requireDevice(http.HandlerFunc(devicesHandler.Action)))
 
 	// Guard (agent token — Claude Code permission check)
 	guardHandler := handlers.NewGuardHandler(s.store, verifier, s.adapterReg, s.logger)
@@ -551,9 +575,9 @@ func (s *Server) handleClawvisorKeys(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// consumeTelegramDecisions reads from the Telegram notifier's decision channel
+// consumeNotifierDecisions reads from the notifier's decision channel
 // and routes approve/deny decisions to the appropriate handler.
-func (s *Server) consumeTelegramDecisions(ctx context.Context, ch <-chan notify.CallbackDecision) {
+func (s *Server) consumeNotifierDecisions(ctx context.Context, ch <-chan notify.CallbackDecision) {
 	for {
 		select {
 		case <-ctx.Done():
@@ -582,9 +606,15 @@ func (s *Server) consumeTelegramDecisions(ctx context.Context, ch <-chan notify.
 				} else {
 					err = s.tasksHandler.ExpandDenyByTaskID(ctx, d.TargetID, d.UserID)
 				}
+			case "connection":
+				if d.Action == "approve" {
+					_, err = s.connectionsHandler.ApproveByID(ctx, d.TargetID, d.UserID)
+				} else {
+					err = s.connectionsHandler.DenyByID(ctx, d.TargetID, d.UserID)
+				}
 			}
 			if err != nil {
-				s.logger.Warn("telegram decision failed",
+				s.logger.Warn("notifier decision failed",
 					"type", d.Type, "action", d.Action,
 					"target_id", d.TargetID, "err", err)
 			}
@@ -623,13 +653,18 @@ func (s *Server) Run(ctx context.Context) error {
 		s.mcpServer.StartCleanup(ctx.Done())
 	}
 
-	// Start Telegram inline callback consumer and token cleanup.
-	if tg, ok := s.notifier.(interface {
+	// Start notifier inline callback consumer and token cleanup.
+	if dc, ok := s.notifier.(interface {
 		DecisionChannel() <-chan notify.CallbackDecision
 		RunCleanup(context.Context)
 	}); ok {
-		go tg.RunCleanup(ctx)
-		go s.consumeTelegramDecisions(ctx, tg.DecisionChannel())
+		go dc.RunCleanup(ctx)
+		go s.consumeNotifierDecisions(ctx, dc.DecisionChannel())
+	}
+
+	// Start device pairing session cleanup.
+	if s.devicesHandler != nil {
+		go s.devicesHandler.RunCleanup(ctx)
 	}
 
 	errCh := make(chan error, 1)

--- a/internal/daemon/setup.go
+++ b/internal/daemon/setup.go
@@ -66,6 +66,21 @@ func runDaemonSetup(dataDir string) error {
 		return fmt.Errorf("generating vault key: %w", err)
 	}
 
+	// Generate relay keys (Ed25519 for auth, X25519 for E2E).
+	if err := ensureRelayKeys(dataDir); err != nil {
+		return fmt.Errorf("generating relay keys: %w", err)
+	}
+
+	// Register with relay to get daemon_id.
+	relayURL := os.Getenv("CLAWVISOR_RELAY_URL")
+	if relayURL == "" {
+		relayURL = "wss://relay.clawvisor.com"
+	}
+	if err := registerWithRelay(dataDir, relayURL); err != nil {
+		fmt.Println(dim.Padding(0, 2).Render("  Warning: relay registration failed: " + err.Error()))
+		fmt.Println(dim.Padding(0, 2).Render("  Daemon will work locally. Re-run setup to try again."))
+	}
+
 	fmt.Println()
 	fmt.Println(green.Padding(0, 2).Render("✓ Daemon configured"))
 	fmt.Println(dim.Padding(0, 2).Render("  " + configPath))
@@ -282,6 +297,14 @@ func writeDaemonConfig(cfg *daemonConfig, dataDir, jwtSecret, path string) error
 
 	fmt.Fprintf(&b, "\ntelemetry:\n")
 	fmt.Fprintf(&b, "  enabled: %t\n", cfg.telemetryEnabled)
+
+	relayURL := os.Getenv("CLAWVISOR_RELAY_URL")
+	if relayURL == "" {
+		relayURL = "wss://relay.clawvisor.com"
+	}
+	fmt.Fprintf(&b, "\nrelay:\n")
+	fmt.Fprintf(&b, "  enabled: true\n")
+	fmt.Fprintf(&b, "  url: \"%s\"\n", relayURL)
 
 	return os.WriteFile(path, []byte(b.String()), 0644)
 }

--- a/internal/notify/push/notifier.go
+++ b/internal/notify/push/notifier.go
@@ -1,0 +1,250 @@
+// Package push implements notify.Notifier using a remote push notification service.
+// It sends push notifications to all paired mobile devices for a user.
+package push
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/clawvisor/clawvisor/pkg/notify"
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+// Notifier sends push notifications via the Clawvisor push service.
+type Notifier struct {
+	store      store.Store
+	client     *http.Client
+	pushURL    string
+	daemonID   string
+	privateKey ed25519.PrivateKey
+	daemonURL  string
+	decisionCh chan notify.CallbackDecision
+	logger     *slog.Logger
+}
+
+// New creates a push Notifier.
+func New(st store.Store, pushURL, daemonID string, privateKey ed25519.PrivateKey, daemonURL string, logger *slog.Logger) *Notifier {
+	return &Notifier{
+		store:      st,
+		client:     &http.Client{Timeout: 10 * time.Second},
+		pushURL:    pushURL,
+		daemonID:   daemonID,
+		privateKey: privateKey,
+		daemonURL:  daemonURL,
+		decisionCh: make(chan notify.CallbackDecision, 32),
+		logger:     logger,
+	}
+}
+
+// DecisionChannel returns a read-only channel that emits callback decisions
+// from device action taps (approve/deny on push notifications).
+func (n *Notifier) DecisionChannel() <-chan notify.CallbackDecision {
+	return n.decisionCh
+}
+
+// EmitDecision sends a decision into the channel (called by the action handler).
+func (n *Notifier) EmitDecision(d notify.CallbackDecision) {
+	select {
+	case n.decisionCh <- d:
+	default:
+		n.logger.Warn("push: decision channel full, dropping", "type", d.Type, "target_id", d.TargetID)
+	}
+}
+
+// RegisterDevice registers a device token with the push service.
+func (n *Notifier) RegisterDevice(ctx context.Context, deviceToken string) error {
+	payload := map[string]string{
+		"daemon_id":    n.daemonID,
+		"device_token": deviceToken,
+	}
+	body, _ := json.Marshal(payload)
+	return n.signedPost(ctx, "/api/tokens/register", body)
+}
+
+// DeregisterDevice removes a device token from the push service.
+func (n *Notifier) DeregisterDevice(ctx context.Context, deviceToken string) error {
+	url := n.pushURL + "/api/tokens/" + deviceToken
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
+	if err != nil {
+		return err
+	}
+	n.signRequest(req, nil)
+	resp, err := n.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("push: deregister device: %w", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("push: deregister device: status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// ── notify.Notifier implementation ────────────────────────────────────────────
+
+func (n *Notifier) SendApprovalRequest(ctx context.Context, req notify.ApprovalRequest) (string, error) {
+	return n.sendToDevices(ctx, req.UserID, pushPayload{
+		Category: "approval_request",
+		Title:    "Approval Request",
+		Body:     fmt.Sprintf("%s wants to use %s.%s", req.AgentName, req.Service, req.Action),
+		Data: map[string]any{
+			"request_id": req.RequestID,
+			"action_url": n.daemonURL + "/api/approvals/" + req.RequestID,
+		},
+	})
+}
+
+func (n *Notifier) SendActivationRequest(ctx context.Context, req notify.ActivationRequest) error {
+	_, err := n.sendToDevices(ctx, req.UserID, pushPayload{
+		Category: "informational",
+		Title:    "Service Activation Required",
+		Body:     fmt.Sprintf("%s wants to use %s", req.AgentName, req.Service),
+		Data: map[string]any{
+			"activate_url": req.ActivateURL,
+		},
+	})
+	return err
+}
+
+func (n *Notifier) SendTaskApprovalRequest(ctx context.Context, req notify.TaskApprovalRequest) (string, error) {
+	return n.sendToDevices(ctx, req.UserID, pushPayload{
+		Category: "approval_request",
+		Title:    "Task Approval Request",
+		Body:     fmt.Sprintf("%s: %s", req.AgentName, req.Purpose),
+		Data: map[string]any{
+			"task_id":    req.TaskID,
+			"action_url": n.daemonURL + "/api/tasks/" + req.TaskID,
+		},
+	})
+}
+
+func (n *Notifier) SendScopeExpansionRequest(ctx context.Context, req notify.ScopeExpansionRequest) (string, error) {
+	return n.sendToDevices(ctx, req.UserID, pushPayload{
+		Category: "scope_expansion",
+		Title:    "Scope Expansion Request",
+		Body:     fmt.Sprintf("%s wants to expand task scope: %s", req.AgentName, req.Reason),
+		Data: map[string]any{
+			"task_id":    req.TaskID,
+			"action_url": n.daemonURL + "/api/tasks/" + req.TaskID,
+		},
+	})
+}
+
+func (n *Notifier) UpdateMessage(ctx context.Context, userID, messageID, text string) error {
+	// Push notifications are ephemeral — no update mechanism.
+	return nil
+}
+
+func (n *Notifier) SendTestMessage(ctx context.Context, userID string) error {
+	_, err := n.sendToDevices(ctx, userID, pushPayload{
+		Category: "informational",
+		Title:    "Clawvisor Test",
+		Body:     "Your push notifications are working!",
+	})
+	return err
+}
+
+func (n *Notifier) SendAlert(ctx context.Context, userID, text string) error {
+	_, err := n.sendToDevices(ctx, userID, pushPayload{
+		Category: "informational",
+		Title:    "Clawvisor Alert",
+		Body:     text,
+	})
+	return err
+}
+
+// ── Internal ──────────────────────────────────────────────────────────────────
+
+type pushPayload struct {
+	Category string         `json:"category"`
+	Title    string         `json:"title"`
+	Body     string         `json:"body"`
+	Data     map[string]any `json:"data,omitempty"`
+}
+
+type pushRequest struct {
+	DeviceTokens []string    `json:"device_tokens"`
+	Title        string      `json:"title"`
+	Body         string      `json:"body"`
+	Category     string      `json:"category"`
+	Data         map[string]any `json:"data,omitempty"`
+}
+
+func (n *Notifier) sendToDevices(ctx context.Context, userID string, p pushPayload) (string, error) {
+	devices, err := n.store.ListPairedDevices(ctx, userID)
+	if err != nil {
+		return "", fmt.Errorf("push: list devices: %w", err)
+	}
+	if len(devices) == 0 {
+		return "", nil
+	}
+
+	tokens := make([]string, len(devices))
+	for i, d := range devices {
+		tokens[i] = d.DeviceToken
+	}
+
+	reqBody := pushRequest{
+		DeviceTokens: tokens,
+		Title:        p.Title,
+		Body:         p.Body,
+		Category:     p.Category,
+		Data:         p.Data,
+	}
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", err
+	}
+
+	if err := n.signedPost(ctx, "/api/push", body); err != nil {
+		return "", err
+	}
+	return "push:" + n.daemonID, nil
+}
+
+func (n *Notifier) signedPost(ctx context.Context, path string, body []byte) error {
+	url := n.pushURL + path
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	n.signRequest(req, body)
+
+	resp, err := n.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("push: %s: %w", path, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("push: %s: status %d: %s", path, resp.StatusCode, string(respBody))
+	}
+	return nil
+}
+
+// signRequest adds the Ed25519-Sig authorization header.
+// Format: Ed25519-Sig <daemon_id>:<timestamp>:<base64(signature)>
+// Signed message: "<method>\n<path>\n<timestamp>\n<sha256(body)>"
+func (n *Notifier) signRequest(req *http.Request, body []byte) {
+	ts := fmt.Sprintf("%d", time.Now().Unix())
+	bodyHash := sha256Hex(body)
+	message := req.Method + "\n" + req.URL.Path + "\n" + ts + "\n" + bodyHash
+	sig := ed25519.Sign(n.privateKey, []byte(message))
+	req.Header.Set("Authorization",
+		fmt.Sprintf("Ed25519-Sig %s:%s:%s", n.daemonID, ts, base64.StdEncoding.EncodeToString(sig)))
+}
+
+func sha256Hex(data []byte) string {
+	h := sha256.Sum256(data)
+	return fmt.Sprintf("%x", h[:])
+}

--- a/internal/notify/push/notifier_test.go
+++ b/internal/notify/push/notifier_test.go
@@ -1,0 +1,334 @@
+package push
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/pkg/notify"
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+// mockStore embeds store.Store (nil) and overrides only the methods the push
+// notifier actually calls. Calling any unimplemented method will panic, which
+// is the desired behavior in tests — it means we're calling something unexpected.
+type mockStore struct {
+	store.Store
+	devices []*store.PairedDevice
+}
+
+func (m *mockStore) ListPairedDevices(_ context.Context, _ string) ([]*store.PairedDevice, error) {
+	return m.devices, nil
+}
+
+func testNotifier(t *testing.T, pushSrv *httptest.Server, devices []*store.PairedDevice) (*Notifier, ed25519.PublicKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	st := &mockStore{devices: devices}
+	n := New(st, pushSrv.URL, "test-daemon", priv, "http://localhost:9090", slog.Default())
+	return n, pub
+}
+
+func TestSendApprovalRequest(t *testing.T) {
+	var received pushRequest
+	var authHeader string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader = r.Header.Get("Authorization")
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &received)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	devices := []*store.PairedDevice{
+		{ID: "d1", UserID: "u1", DeviceToken: "tok1"},
+		{ID: "d2", UserID: "u1", DeviceToken: "tok2"},
+	}
+
+	n, pub := testNotifier(t, srv, devices)
+
+	msgID, err := n.SendApprovalRequest(context.Background(), notify.ApprovalRequest{
+		RequestID: "req-123",
+		UserID:    "u1",
+		AgentName: "TestAgent",
+		Service:   "github",
+		Action:    "create_issue",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if msgID != "push:test-daemon" {
+		t.Errorf("expected messageID 'push:test-daemon', got %q", msgID)
+	}
+
+	// Verify payload.
+	if len(received.DeviceTokens) != 2 {
+		t.Errorf("expected 2 device tokens, got %d", len(received.DeviceTokens))
+	}
+	if received.Category != "approval_request" {
+		t.Errorf("expected category 'approval_request', got %q", received.Category)
+	}
+	if received.Title != "Approval Request" {
+		t.Errorf("expected title 'Approval Request', got %q", received.Title)
+	}
+	if !strings.Contains(received.Body, "TestAgent") {
+		t.Errorf("body should contain agent name, got %q", received.Body)
+	}
+	if received.Data["request_id"] != "req-123" {
+		t.Errorf("expected request_id 'req-123', got %v", received.Data["request_id"])
+	}
+
+	// Verify Ed25519 signature format.
+	verifySignatureFormat(t, authHeader, pub, "test-daemon")
+}
+
+func TestSendAlert(t *testing.T) {
+	var received pushRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &received)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	devices := []*store.PairedDevice{{ID: "d1", UserID: "u1", DeviceToken: "tok1"}}
+	n, _ := testNotifier(t, srv, devices)
+
+	err := n.SendAlert(context.Background(), "u1", "Something happened")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if received.Category != "informational" {
+		t.Errorf("expected category 'informational', got %q", received.Category)
+	}
+	if received.Body != "Something happened" {
+		t.Errorf("expected body 'Something happened', got %q", received.Body)
+	}
+}
+
+func TestSendTestMessage(t *testing.T) {
+	var received pushRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &received)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	devices := []*store.PairedDevice{{ID: "d1", UserID: "u1", DeviceToken: "tok1"}}
+	n, _ := testNotifier(t, srv, devices)
+
+	err := n.SendTestMessage(context.Background(), "u1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if received.Title != "Clawvisor Test" {
+		t.Errorf("expected title 'Clawvisor Test', got %q", received.Title)
+	}
+}
+
+func TestNoDevicesPaired(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	n, _ := testNotifier(t, srv, nil) // no devices
+
+	msgID, err := n.SendApprovalRequest(context.Background(), notify.ApprovalRequest{
+		RequestID: "req-123",
+		UserID:    "u1",
+		AgentName: "Agent",
+		Service:   "github",
+		Action:    "read",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if msgID != "" {
+		t.Errorf("expected empty messageID, got %q", msgID)
+	}
+	if called {
+		t.Error("push service should not be called when no devices paired")
+	}
+}
+
+func TestRegisterDevice(t *testing.T) {
+	var receivedPath string
+	var receivedBody map[string]string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedPath = r.URL.Path
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &receivedBody)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	n, _ := testNotifier(t, srv, nil)
+
+	err := n.RegisterDevice(context.Background(), "apns-token-abc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if receivedPath != "/api/tokens/register" {
+		t.Errorf("expected path '/api/tokens/register', got %q", receivedPath)
+	}
+	if receivedBody["daemon_id"] != "test-daemon" {
+		t.Errorf("expected daemon_id 'test-daemon', got %q", receivedBody["daemon_id"])
+	}
+	if receivedBody["device_token"] != "apns-token-abc" {
+		t.Errorf("expected device_token 'apns-token-abc', got %q", receivedBody["device_token"])
+	}
+}
+
+func TestDeregisterDevice(t *testing.T) {
+	var receivedPath, receivedMethod string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedPath = r.URL.Path
+		receivedMethod = r.Method
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	n, _ := testNotifier(t, srv, nil)
+
+	err := n.DeregisterDevice(context.Background(), "apns-token-abc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if receivedMethod != "DELETE" {
+		t.Errorf("expected DELETE, got %q", receivedMethod)
+	}
+	if receivedPath != "/api/tokens/apns-token-abc" {
+		t.Errorf("expected path '/api/tokens/apns-token-abc', got %q", receivedPath)
+	}
+}
+
+func TestEmitDecision(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	n, _ := testNotifier(t, srv, nil)
+
+	d := notify.CallbackDecision{
+		Type:     "approval",
+		Action:   "approve",
+		TargetID: "req-1",
+		UserID:   "u1",
+	}
+	n.EmitDecision(d)
+
+	got := <-n.DecisionChannel()
+	if got != d {
+		t.Errorf("expected %+v, got %+v", d, got)
+	}
+}
+
+func TestPushServiceError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("internal error"))
+	}))
+	defer srv.Close()
+
+	devices := []*store.PairedDevice{{ID: "d1", UserID: "u1", DeviceToken: "tok1"}}
+	n, _ := testNotifier(t, srv, devices)
+
+	err := n.SendAlert(context.Background(), "u1", "test")
+	if err == nil {
+		t.Fatal("expected error from push service")
+	}
+	if !strings.Contains(err.Error(), "status 500") {
+		t.Errorf("expected status 500 in error, got %q", err.Error())
+	}
+}
+
+// verifySignatureFormat checks the Ed25519 signature header format and verifies
+// the signature is valid.
+func verifySignatureFormat(t *testing.T, authHeader string, pub ed25519.PublicKey, expectedDaemonID string) {
+	t.Helper()
+
+	const prefix = "Ed25519-Sig "
+	if !strings.HasPrefix(authHeader, prefix) {
+		t.Fatalf("auth header should start with %q, got %q", prefix, authHeader)
+	}
+
+	parts := strings.SplitN(authHeader[len(prefix):], ":", 3)
+	if len(parts) != 3 {
+		t.Fatalf("expected 3 colon-separated parts, got %d", len(parts))
+	}
+
+	daemonID, ts, sigB64 := parts[0], parts[1], parts[2]
+
+	if daemonID != expectedDaemonID {
+		t.Errorf("expected daemon_id %q, got %q", expectedDaemonID, daemonID)
+	}
+
+	sig, err := base64.StdEncoding.DecodeString(sigB64)
+	if err != nil {
+		t.Fatalf("invalid base64 signature: %v", err)
+	}
+
+	// We can't reconstruct the exact body here without capturing it,
+	// but we can verify the signature is 64 bytes (Ed25519 standard).
+	if len(sig) != ed25519.SignatureSize {
+		t.Errorf("expected signature of %d bytes, got %d", ed25519.SignatureSize, len(sig))
+	}
+
+	// Verify the timestamp is a valid integer string.
+	if ts == "" {
+		t.Error("timestamp should not be empty")
+	}
+
+	_ = ts // already validated by presence check
+}
+
+func TestSignatureIncludesBodyHash(t *testing.T) {
+	// Capture the auth header and body to verify the signature message includes body hash.
+	var capturedAuth string
+	var capturedBody []byte
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedAuth = r.Header.Get("Authorization")
+		capturedBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	devices := []*store.PairedDevice{{ID: "d1", UserID: "u1", DeviceToken: "tok1"}}
+	n, pub := testNotifier(t, srv, devices)
+
+	_ = n.SendAlert(context.Background(), "u1", "test body hash")
+
+	// Parse signature.
+	parts := strings.SplitN(capturedAuth[len("Ed25519-Sig "):], ":", 3)
+	ts := parts[1]
+	sig, _ := base64.StdEncoding.DecodeString(parts[2])
+
+	// Reconstruct the signed message with body hash.
+	bodyHash := sha256.Sum256(capturedBody)
+	message := fmt.Sprintf("POST\n/api/push\n%s\n%x", ts, bodyHash)
+
+	if !ed25519.Verify(pub, []byte(message), sig) {
+		t.Fatal("signature verification failed — body hash may not be included in the signed message")
+	}
+}

--- a/internal/store/postgres/migrations/015_paired_devices.sql
+++ b/internal/store/postgres/migrations/015_paired_devices.sql
@@ -1,0 +1,10 @@
+CREATE TABLE paired_devices (
+    id              TEXT PRIMARY KEY,
+    user_id         TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    device_name     TEXT NOT NULL,
+    device_token    TEXT NOT NULL,
+    device_hmac_key TEXT NOT NULL,
+    paired_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_seen_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_paired_devices_user_id ON paired_devices(user_id);

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -1217,6 +1217,79 @@ func (s *Store) CountPendingConnectionRequests(ctx context.Context) (int, error)
 	return count, err
 }
 
+// ── Paired Devices ────────────────────────────────────────────────────────────
+
+func (s *Store) CreatePairedDevice(ctx context.Context, d *store.PairedDevice) error {
+	if d.ID == "" {
+		d.ID = uuid.New().String()
+	}
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO paired_devices (id, user_id, device_name, device_token, device_hmac_key)
+		VALUES ($1, $2, $3, $4, $5)
+	`, d.ID, d.UserID, d.DeviceName, d.DeviceToken, d.DeviceHMACKey)
+	return err
+}
+
+func (s *Store) GetPairedDevice(ctx context.Context, id string) (*store.PairedDevice, error) {
+	d := &store.PairedDevice{}
+	err := s.pool.QueryRow(ctx, `
+		SELECT id, user_id, device_name, device_token, device_hmac_key, paired_at, last_seen_at
+		FROM paired_devices WHERE id = $1
+	`, id).Scan(&d.ID, &d.UserID, &d.DeviceName, &d.DeviceToken, &d.DeviceHMACKey, &d.PairedAt, &d.LastSeenAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, store.ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return d, nil
+}
+
+func (s *Store) ListPairedDevices(ctx context.Context, userID string) ([]*store.PairedDevice, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT id, user_id, device_name, device_token, device_hmac_key, paired_at, last_seen_at
+		FROM paired_devices WHERE user_id = $1 ORDER BY paired_at DESC
+	`, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var devices []*store.PairedDevice
+	for rows.Next() {
+		d := &store.PairedDevice{}
+		if err := rows.Scan(&d.ID, &d.UserID, &d.DeviceName, &d.DeviceToken, &d.DeviceHMACKey,
+			&d.PairedAt, &d.LastSeenAt); err != nil {
+			return nil, err
+		}
+		devices = append(devices, d)
+	}
+	return devices, rows.Err()
+}
+
+func (s *Store) DeletePairedDevice(ctx context.Context, id string) error {
+	tag, err := s.pool.Exec(ctx, `DELETE FROM paired_devices WHERE id = $1`, id)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return store.ErrNotFound
+	}
+	return nil
+}
+
+func (s *Store) UpdatePairedDeviceLastSeen(ctx context.Context, id string) error {
+	tag, err := s.pool.Exec(ctx,
+		`UPDATE paired_devices SET last_seen_at = NOW() WHERE id = $1`, id)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return store.ErrNotFound
+	}
+	return nil
+}
+
 func scanAgents(rows pgx.Rows) ([]*store.Agent, error) {
 	var agents []*store.Agent
 	for rows.Next() {

--- a/internal/store/sqlite/migrations/015_paired_devices.sql
+++ b/internal/store/sqlite/migrations/015_paired_devices.sql
@@ -1,0 +1,10 @@
+CREATE TABLE paired_devices (
+    id              TEXT PRIMARY KEY,
+    user_id         TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    device_name     TEXT NOT NULL,
+    device_token    TEXT NOT NULL,
+    device_hmac_key TEXT NOT NULL,
+    paired_at       TEXT NOT NULL DEFAULT (datetime('now')),
+    last_seen_at    TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX idx_paired_devices_user_id ON paired_devices(user_id);

--- a/internal/store/sqlite/store.go
+++ b/internal/store/sqlite/store.go
@@ -1324,6 +1324,87 @@ func (s *Store) CountPendingConnectionRequests(ctx context.Context) (int, error)
 	return count, err
 }
 
+// ── Paired Devices ────────────────────────────────────────────────────────────
+
+func (s *Store) CreatePairedDevice(ctx context.Context, d *store.PairedDevice) error {
+	if d.ID == "" {
+		d.ID = uuid.New().String()
+	}
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO paired_devices (id, user_id, device_name, device_token, device_hmac_key)
+		VALUES (?, ?, ?, ?, ?)
+	`, d.ID, d.UserID, d.DeviceName, d.DeviceToken, d.DeviceHMACKey)
+	return err
+}
+
+func (s *Store) GetPairedDevice(ctx context.Context, id string) (*store.PairedDevice, error) {
+	d := &store.PairedDevice{}
+	var pairedAt, lastSeenAt string
+	err := s.db.QueryRowContext(ctx, `
+		SELECT id, user_id, device_name, device_token, device_hmac_key, paired_at, last_seen_at
+		FROM paired_devices WHERE id = ?
+	`, id).Scan(&d.ID, &d.UserID, &d.DeviceName, &d.DeviceToken, &d.DeviceHMACKey, &pairedAt, &lastSeenAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, store.ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	d.PairedAt = parseTime(pairedAt)
+	d.LastSeenAt = parseTime(lastSeenAt)
+	return d, nil
+}
+
+func (s *Store) ListPairedDevices(ctx context.Context, userID string) ([]*store.PairedDevice, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, user_id, device_name, device_token, device_hmac_key, paired_at, last_seen_at
+		FROM paired_devices WHERE user_id = ? ORDER BY paired_at DESC
+	`, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var devices []*store.PairedDevice
+	for rows.Next() {
+		d := &store.PairedDevice{}
+		var pairedAt, lastSeenAt string
+		if err := rows.Scan(&d.ID, &d.UserID, &d.DeviceName, &d.DeviceToken, &d.DeviceHMACKey,
+			&pairedAt, &lastSeenAt); err != nil {
+			return nil, err
+		}
+		d.PairedAt = parseTime(pairedAt)
+		d.LastSeenAt = parseTime(lastSeenAt)
+		devices = append(devices, d)
+	}
+	return devices, rows.Err()
+}
+
+func (s *Store) DeletePairedDevice(ctx context.Context, id string) error {
+	res, err := s.db.ExecContext(ctx, `DELETE FROM paired_devices WHERE id = ?`, id)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return store.ErrNotFound
+	}
+	return nil
+}
+
+func (s *Store) UpdatePairedDeviceLastSeen(ctx context.Context, id string) error {
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE paired_devices SET last_seen_at = datetime('now') WHERE id = ?`, id)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return store.ErrNotFound
+	}
+	return nil
+}
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 func isDuplicate(err error) bool {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	Relay     RelayConfig     `yaml:"relay"`
 	Telemetry TelemetryConfig `yaml:"telemetry"`
 	Daemon    DaemonConfig    `yaml:"daemon"`
+	Push      PushConfig      `yaml:"push"`
 
 	AutoConfig AutoConfigured `yaml:"-"`
 }
@@ -51,6 +52,12 @@ type RelayConfig struct {
 type DaemonConfig struct {
 	DataDir string `yaml:"data_dir"` // defaults to ~/.clawvisor
 	LogFile string `yaml:"log_file"` // relative to data_dir, defaults to logs/daemon.log
+}
+
+// PushConfig holds settings for mobile push notifications.
+type PushConfig struct {
+	Enabled bool   `yaml:"enabled"`
+	URL     string `yaml:"url"`
 }
 
 // TelemetryConfig holds settings for anonymous usage telemetry.
@@ -287,6 +294,9 @@ func Default() *Config {
 			DataDir: "~/.clawvisor",
 			LogFile: "logs/daemon.log",
 		},
+		Push: PushConfig{
+			URL: "https://push.clawvisor.com",
+		},
 		Services: ServicesConfig{
 			GitHub:   GitHubServicesConfig{Enabled: true},
 			IMessage: IMessageServicesConfig{Enabled: true},
@@ -479,6 +489,12 @@ func Load(path string) (*Config, error) {
 	}
 	if v := os.Getenv("CLAWVISOR_RELAY_DAEMON_ID"); v != "" {
 		cfg.Relay.DaemonID = v
+	}
+	if v := os.Getenv("CLAWVISOR_PUSH_ENABLED"); v != "" {
+		cfg.Push.Enabled = v == "true" || v == "1"
+	}
+	if v := os.Getenv("CLAWVISOR_PUSH_URL"); v != "" {
+		cfg.Push.URL = v
 	}
 
 	if v := os.Getenv("CLAWVISOR_DAEMON_DATA_DIR"); v != "" {

--- a/pkg/notify/multi.go
+++ b/pkg/notify/multi.go
@@ -1,0 +1,227 @@
+package notify
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+)
+
+// MultiNotifier fans out notifications to multiple Notifier implementations.
+// Errors are logged but do not short-circuit delivery to remaining notifiers.
+type MultiNotifier struct {
+	notifiers  []Notifier
+	logger     *slog.Logger
+	decisionCh chan CallbackDecision
+
+	// Delegated interfaces discovered on construction.
+	pairer    TelegramPairer
+	decrement PollingDecrementer
+}
+
+// NewMultiNotifier creates a MultiNotifier that delegates to the given notifiers.
+// It inspects each notifier for optional interfaces (TelegramPairer, PollingDecrementer,
+// DecisionChannel) and wires them through.
+func NewMultiNotifier(logger *slog.Logger, notifiers ...Notifier) *MultiNotifier {
+	m := &MultiNotifier{
+		notifiers:  notifiers,
+		logger:     logger,
+		decisionCh: make(chan CallbackDecision, 64),
+	}
+
+	for _, n := range notifiers {
+		if p, ok := n.(TelegramPairer); ok && m.pairer == nil {
+			m.pairer = p
+		}
+		if d, ok := n.(PollingDecrementer); ok && m.decrement == nil {
+			m.decrement = d
+		}
+	}
+
+	// Fan-in all decision channels into the merged channel.
+	var wg sync.WaitGroup
+	for _, n := range notifiers {
+		type decisionSource interface {
+			DecisionChannel() <-chan CallbackDecision
+		}
+		if ds, ok := n.(decisionSource); ok {
+			ch := ds.DecisionChannel()
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for d := range ch {
+					m.decisionCh <- d
+				}
+			}()
+		}
+	}
+
+	// Close the merged channel when all inner channels close.
+	go func() {
+		wg.Wait()
+		close(m.decisionCh)
+	}()
+
+	return m
+}
+
+// Compile-time interface checks.
+var (
+	_ Notifier           = (*MultiNotifier)(nil)
+	_ TelegramPairer     = (*MultiNotifier)(nil)
+	_ PollingDecrementer = (*MultiNotifier)(nil)
+)
+
+// ── Notifier interface ────────────────────────────────────────────────────────
+
+func (m *MultiNotifier) SendApprovalRequest(ctx context.Context, req ApprovalRequest) (string, error) {
+	var messageID string
+	var errs []error
+	for _, n := range m.notifiers {
+		id, err := n.SendApprovalRequest(ctx, req)
+		if err != nil {
+			m.logger.Warn("notifier: SendApprovalRequest failed", "err", err)
+			errs = append(errs, err)
+		} else if messageID == "" && id != "" {
+			messageID = id
+		}
+	}
+	return messageID, errors.Join(errs...)
+}
+
+func (m *MultiNotifier) SendActivationRequest(ctx context.Context, req ActivationRequest) error {
+	var errs []error
+	for _, n := range m.notifiers {
+		if err := n.SendActivationRequest(ctx, req); err != nil {
+			m.logger.Warn("notifier: SendActivationRequest failed", "err", err)
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (m *MultiNotifier) SendTaskApprovalRequest(ctx context.Context, req TaskApprovalRequest) (string, error) {
+	var messageID string
+	var errs []error
+	for _, n := range m.notifiers {
+		id, err := n.SendTaskApprovalRequest(ctx, req)
+		if err != nil {
+			m.logger.Warn("notifier: SendTaskApprovalRequest failed", "err", err)
+			errs = append(errs, err)
+		} else if messageID == "" && id != "" {
+			messageID = id
+		}
+	}
+	return messageID, errors.Join(errs...)
+}
+
+func (m *MultiNotifier) SendScopeExpansionRequest(ctx context.Context, req ScopeExpansionRequest) (string, error) {
+	var messageID string
+	var errs []error
+	for _, n := range m.notifiers {
+		id, err := n.SendScopeExpansionRequest(ctx, req)
+		if err != nil {
+			m.logger.Warn("notifier: SendScopeExpansionRequest failed", "err", err)
+			errs = append(errs, err)
+		} else if messageID == "" && id != "" {
+			messageID = id
+		}
+	}
+	return messageID, errors.Join(errs...)
+}
+
+func (m *MultiNotifier) UpdateMessage(ctx context.Context, userID, messageID, text string) error {
+	var errs []error
+	for _, n := range m.notifiers {
+		if err := n.UpdateMessage(ctx, userID, messageID, text); err != nil {
+			m.logger.Warn("notifier: UpdateMessage failed", "err", err)
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (m *MultiNotifier) SendTestMessage(ctx context.Context, userID string) error {
+	var errs []error
+	for _, n := range m.notifiers {
+		if err := n.SendTestMessage(ctx, userID); err != nil {
+			m.logger.Warn("notifier: SendTestMessage failed", "err", err)
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (m *MultiNotifier) SendAlert(ctx context.Context, userID, text string) error {
+	var errs []error
+	for _, n := range m.notifiers {
+		if err := n.SendAlert(ctx, userID, text); err != nil {
+			m.logger.Warn("notifier: SendAlert failed", "err", err)
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// ── DecisionChannel + RunCleanup ──────────────────────────────────────────────
+
+// DecisionChannel returns a merged channel that receives decisions from all
+// inner notifiers that support inline callbacks.
+func (m *MultiNotifier) DecisionChannel() <-chan CallbackDecision {
+	return m.decisionCh
+}
+
+// RunCleanup delegates to each inner notifier that supports it.
+func (m *MultiNotifier) RunCleanup(ctx context.Context) {
+	type cleaner interface {
+		RunCleanup(context.Context)
+	}
+	var wg sync.WaitGroup
+	for _, n := range m.notifiers {
+		if c, ok := n.(cleaner); ok {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				c.RunCleanup(ctx)
+			}()
+		}
+	}
+	wg.Wait()
+}
+
+// ── TelegramPairer delegation ─────────────────────────────────────────────────
+
+func (m *MultiNotifier) StartPairing(ctx context.Context, userID, botToken string) (*PairingSession, error) {
+	if m.pairer == nil {
+		return nil, errors.New("telegram pairing not available")
+	}
+	return m.pairer.StartPairing(ctx, userID, botToken)
+}
+
+func (m *MultiNotifier) PairingStatus(pairingID string) (*PairingSession, error) {
+	if m.pairer == nil {
+		return nil, errors.New("telegram pairing not available")
+	}
+	return m.pairer.PairingStatus(pairingID)
+}
+
+func (m *MultiNotifier) ConfirmPairing(ctx context.Context, pairingID, code string) error {
+	if m.pairer == nil {
+		return errors.New("telegram pairing not available")
+	}
+	return m.pairer.ConfirmPairing(ctx, pairingID, code)
+}
+
+func (m *MultiNotifier) CancelPairing(pairingID string) {
+	if m.pairer != nil {
+		m.pairer.CancelPairing(pairingID)
+	}
+}
+
+// ── PollingDecrementer delegation ─────────────────────────────────────────────
+
+func (m *MultiNotifier) DecrementPolling(userID string) {
+	if m.decrement != nil {
+		m.decrement.DecrementPolling(userID)
+	}
+}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -91,6 +91,13 @@ type Store interface {
 	ListChainFacts(ctx context.Context, taskID, sessionID string, limit int) ([]*ChainFact, error)
 	DeleteChainFactsByTask(ctx context.Context, taskID string) error
 
+	// Paired devices (mobile push notifications)
+	CreatePairedDevice(ctx context.Context, d *PairedDevice) error
+	GetPairedDevice(ctx context.Context, id string) (*PairedDevice, error)
+	ListPairedDevices(ctx context.Context, userID string) ([]*PairedDevice, error)
+	DeletePairedDevice(ctx context.Context, id string) error
+	UpdatePairedDeviceLastSeen(ctx context.Context, id string) error
+
 	// Connection requests (daemon agent onboarding)
 	CreateConnectionRequest(ctx context.Context, req *ConnectionRequest) error
 	GetConnectionRequest(ctx context.Context, id string) (*ConnectionRequest, error)
@@ -288,6 +295,17 @@ type ChainFact struct {
 	FactType  string    `json:"fact_type"`
 	FactValue string    `json:"fact_value"`
 	CreatedAt time.Time `json:"created_at"`
+}
+
+// PairedDevice represents a mobile device paired for push notifications.
+type PairedDevice struct {
+	ID            string    `json:"id"`
+	UserID        string    `json:"user_id"`
+	DeviceName    string    `json:"device_name"`
+	DeviceToken   string    `json:"-"`
+	DeviceHMACKey string    `json:"-"`
+	PairedAt      time.Time `json:"paired_at"`
+	LastSeenAt    time.Time `json:"last_seen_at"`
 }
 
 // ConnectionRequest represents an agent's request to connect to this daemon.

--- a/skills/clawvisor/e2e.mjs
+++ b/skills/clawvisor/e2e.mjs
@@ -23,8 +23,9 @@ const X25519_SPKI_PREFIX = Buffer.from('302a300506032b656e032100', 'hex');
  */
 async function fetchDaemonKey(baseURL, bypassCache = false) {
   const cacheDir = tmpdir();
-  const url = new URL('/.well-known/clawvisor-keys', baseURL);
-  const cachePath = join(cacheDir, `cvis-pubkey-${url.hostname}.json`);
+  const keyURL = baseURL.replace(/\/+$/, '') + '/.well-known/clawvisor-keys';
+  const parsed = new URL(keyURL);
+  const cachePath = join(cacheDir, `cvis-pubkey-${parsed.hostname}.json`);
 
   if (!bypassCache && existsSync(cachePath)) {
     try {
@@ -33,7 +34,7 @@ async function fetchDaemonKey(baseURL, bypassCache = false) {
     } catch { /* ignore corrupt cache */ }
   }
 
-  const data = await httpGet(url.href);
+  const data = await httpGet(keyURL);
   const keys = JSON.parse(data);
   writeFileSync(cachePath, JSON.stringify(keys), { mode: 0o600 });
   return keys;
@@ -44,8 +45,8 @@ async function fetchDaemonKey(baseURL, bypassCache = false) {
  */
 function evictKeyCache(baseURL) {
   try {
-    const url = new URL('/.well-known/clawvisor-keys', baseURL);
-    const cachePath = join(tmpdir(), `cvis-pubkey-${url.hostname}.json`);
+    const parsed = new URL(baseURL);
+    const cachePath = join(tmpdir(), `cvis-pubkey-${parsed.hostname}.json`);
     if (existsSync(cachePath)) unlinkSync(cachePath);
   } catch { /* best effort */ }
 }


### PR DESCRIPTION
## Summary

Implements push notification delivery and device pairing for iOS App Clip integration:
- Push notifier sends notifications to clawvisor-push service with Ed25519 signatures
- Device pairing flow with 6-digit code validation and brute-force protection
- DeviceHMAC middleware authenticates device requests with body hash
- MultiNotifier delegates type-asserted interfaces to appropriate inner notifiers
- Connection handler extraction enables decision dispatch from multiple sources
- Comprehensive test coverage for all new functionality

All signatures include SHA-256 body hash to prevent tampering. Pairing sessions expire after 5 minutes with max 3 code attempts. The push notifier is optional and returns 503 if not configured.

## Test plan

- [x] All tests pass: device handlers (10 tests), push notifier (9 tests)
- [x] `go build ./...` compiles cleanly
- [x] `go vet ./...` passes with no warnings
- [x] Migrations created for both SQLite and Postgres
- [x] Ownership checks added to connection approval/deny
- [x] Brute-force protection prevents bypass with concurrent attempts
- [x] Action endpoint properly fails when push not configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)