### PR TITLE
Expired task filtering and daemon binary path sync

### DIFF
--- a/internal/api/handlers/tasks.go
+++ b/internal/api/handlers/tasks.go
@@ -371,7 +371,11 @@ func (h *TasksHandler) List(w http.ResponseWriter, r *http.Request) {
 		tasks = []*store.Task{}
 	}
 	for _, t := range tasks {
-		sanitizeTaskForResponse(t)
+		if sanitizeTaskForResponse(t) {
+			// Opportunistically mark expired tasks in the DB so the
+			// background sweep doesn't have to catch them later.
+			_ = h.st.UpdateTaskStatus(ctx, t.ID, "expired")
+		}
 	}
 
 	writeJSON(w, http.StatusOK, map[string]any{
@@ -384,15 +388,17 @@ func (h *TasksHandler) List(w http.ResponseWriter, r *http.Request) {
 //   - Standing tasks: nil out the sentinel expiry so it doesn't leak.
 //   - Active session tasks past their expiry: report status as "expired"
 //     even if the background cleanup goroutine hasn't swept them yet.
-func sanitizeTaskForResponse(t *store.Task) {
+func sanitizeTaskForResponse(t *store.Task) (nowExpired bool) {
 	if t.Lifetime == "standing" {
 		t.ExpiresAt = nil
 		t.ExpiresInSeconds = 0
-		return
+		return false
 	}
 	if t.Status == "active" && t.ExpiresAt != nil && t.ExpiresAt.Before(time.Now()) {
 		t.Status = "expired"
+		return true
 	}
+	return false
 }
 
 // ── Approve ───────────────────────────────────────────────────────────────────

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -643,6 +643,8 @@ func (s *Server) Handler() http.Handler {
 
 // Run starts the HTTP server and blocks until the context is cancelled.
 func (s *Server) Run(ctx context.Context) error {
+	s.logger.Info("server running", "expired_task_filter", true)
+
 	// Start background expiry cleanup.
 	go s.approvalsHandler.RunExpiryCleanup(ctx)
 

--- a/internal/daemon/install.go
+++ b/internal/daemon/install.go
@@ -148,6 +148,38 @@ func installLaunchd(home string, data installData) error {
 	return nil
 }
 
+// updatePlistBinary rewrites ProgramArguments[0] in the plist to match the
+// currently running executable. This ensures `daemon start` after an upgrade
+// always launches the freshly built binary.
+func updatePlistBinary(plistPath string) error {
+	binary, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolving executable: %w", err)
+	}
+	binary, err = filepath.EvalSymlinks(binary)
+	if err != nil {
+		return fmt.Errorf("resolving symlinks: %w", err)
+	}
+	if isGoRunBinary(binary) {
+		return nil // don't persist a go-run temp path
+	}
+
+	// Read current value to avoid unnecessary writes.
+	out, err := exec.Command("/usr/libexec/PlistBuddy", "-c", "Print :ProgramArguments:0", plistPath).Output()
+	if err != nil {
+		return fmt.Errorf("reading plist: %w", err)
+	}
+	if strings.TrimSpace(string(out)) == binary {
+		return nil // already correct
+	}
+
+	if err := exec.Command("/usr/libexec/PlistBuddy", "-c",
+		fmt.Sprintf("Set :ProgramArguments:0 %s", binary), plistPath).Run(); err != nil {
+		return fmt.Errorf("updating plist: %w", err)
+	}
+	return nil
+}
+
 func installSystemd(home string, data installData) error {
 	unitDir := filepath.Join(home, ".config", "systemd", "user")
 	if err := os.MkdirAll(unitDir, 0755); err != nil {
@@ -210,6 +242,8 @@ func Uninstall() error {
 }
 
 // Start activates the installed daemon service.
+// On macOS it also updates the plist binary path to match the current
+// executable so that upgrades take effect without a separate install step.
 func Start() error {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -222,6 +256,13 @@ func Start() error {
 		if _, err := os.Stat(plistPath); os.IsNotExist(err) {
 			return fmt.Errorf("daemon not installed; run `clawvisor daemon install` first")
 		}
+
+		// Update the plist binary path to the current executable so that
+		// upgrades (build + restart) pick up the new binary automatically.
+		if err := updatePlistBinary(plistPath); err != nil {
+			fmt.Printf("  Warning: could not update plist binary path: %v\n", err)
+		}
+
 		// Unload first in case an old/stale plist was already loaded.
 		exec.Command("launchctl", "unload", plistPath).Run() //nolint:errcheck
 		out, err := exec.Command("launchctl", "load", plistPath).CombinedOutput()

--- a/internal/server/run.go
+++ b/internal/server/run.go
@@ -121,6 +121,10 @@ func Run(logger *slog.Logger, ropts RunOptions) error {
 		printBanner(opts.Config, authResult.MagicURL)
 	}
 
+	if opts.PushNotifier != nil {
+		logger.Info("push notifier enabled", "push_url", opts.Config.Push.URL, "daemon_id", opts.Config.Relay.DaemonID)
+	}
+
 	if ropts.OpenBrowser && authResult.MagicURL != "" {
 		browser.Open(authResult.MagicURL)
 	}

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -681,6 +681,8 @@ func (s *Store) ListTasks(ctx context.Context, userID string, filter store.TaskF
 		where += fmt.Sprintf(" AND status IN ($%d, $%d, $%d)", argIdx, argIdx+1, argIdx+2)
 		args = append(args, "active", "pending_approval", "pending_scope_expansion")
 		argIdx += 3
+		// Exclude session tasks that have expired but haven't been swept yet.
+		where += " AND NOT (status = 'active' AND lifetime = 'session' AND expires_at IS NOT NULL AND expires_at < NOW())"
 	}
 
 	// Count total matching rows.

--- a/internal/store/sqlite/store.go
+++ b/internal/store/sqlite/store.go
@@ -792,6 +792,8 @@ func (s *Store) ListTasks(ctx context.Context, userID string, filter store.TaskF
 	if filter.ActiveOnly {
 		where += " AND status IN (?, ?, ?)"
 		args = append(args, "active", "pending_approval", "pending_scope_expansion")
+		// Exclude session tasks that have expired but haven't been swept yet.
+		where += " AND NOT (status = 'active' AND lifetime = 'session' AND expires_at IS NOT NULL AND expires_at < datetime('now'))"
 	}
 
 	// Count total matching rows.

--- a/pkg/clawvisor/defaults.go
+++ b/pkg/clawvisor/defaults.go
@@ -199,7 +199,6 @@ func DefaultOptions(logger *slog.Logger) (*ServerOptions, error) {
 			daemonURL = fmt.Sprintf("http://%s:%d", cfg.Server.Host, cfg.Server.Port)
 		}
 		pushN = pushnotify.New(st, cfg.Push.URL, cfg.Relay.DaemonID, ed25519Key, daemonURL, logger)
-		logger.Info("push notifier enabled", "push_url", cfg.Push.URL, "daemon_id", cfg.Relay.DaemonID)
 
 		// Register daemon's public key with the push service (idempotent).
 		if err := pushN.RegisterDaemon(ctx); err != nil {


### PR DESCRIPTION
## Summary

Fixes two issues:
1. **Expired task filtering**: Detect and exclude expired session tasks from active_only queries. Also opportunistically mark them in the DB when fetching, reducing the load on the background sweep.
2. **Daemon binary path sync**: Update the launchd plist with the current executable path on daemon start, ensuring upgrades automatically pick up the new binary without requiring a separate install step.

Also fixes log ordering so "push notifier enabled" prints after the startup banner instead of before.