### PR TITLE
Fresh dashboard token on each request

### DIFF
--- a/cmd/clawvisor/cmd_daemon.go
+++ b/cmd/clawvisor/cmd_daemon.go
@@ -99,7 +99,7 @@ var daemonPairCmd = &cobra.Command{
 
 var daemonDashboardCmd = &cobra.Command{
 	Use:   "dashboard",
-	Short: "Open the daemon dashboard in your browser",
+	Short: "Open the Clawvisor dashboard in your browser",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		noOpen, _ := cmd.Flags().GetBool("no-open")
 		return daemon.Dashboard(noOpen)

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -341,6 +341,47 @@ func (h *AuthHandler) ExchangeMagic(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
+// GenerateMagicLocal generates a fresh magic token for the admin@local user.
+// This endpoint is restricted to localhost connections and requires no auth,
+// so the CLI can always get a valid token to open the dashboard.
+//
+// POST /api/auth/magic/local
+func (h *AuthHandler) GenerateMagicLocal(w http.ResponseWriter, r *http.Request) {
+	if h.magicStore == nil {
+		writeError(w, http.StatusBadRequest, "NOT_ENABLED", "magic link auth is not enabled")
+		return
+	}
+
+	// Only allow requests from localhost.
+	host := r.RemoteAddr
+	// RemoteAddr is "host:port"; strip the port.
+	if idx := strings.LastIndex(host, ":"); idx != -1 {
+		host = host[:idx]
+	}
+	// Strip brackets from IPv6 addresses (e.g. "[::1]" → "::1").
+	host = strings.TrimPrefix(host, "[")
+	host = strings.TrimSuffix(host, "]")
+	if host != "127.0.0.1" && host != "::1" && host != "localhost" {
+		writeError(w, http.StatusForbidden, "FORBIDDEN", "this endpoint is only available from localhost")
+		return
+	}
+
+	const localEmail = "admin@local"
+	user, err := h.st.GetUserByEmail(r.Context(), localEmail)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "local user not found")
+		return
+	}
+
+	token, err := h.magicStore.Generate(user.ID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not generate token")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"token": token})
+}
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 func (h *AuthHandler) issueTokens(r *http.Request, user *store.User) (*authResponse, error) {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -332,6 +332,7 @@ func (s *Server) routes() http.Handler {
 	// Magic link auth (local mode only)
 	if s.magicStore != nil {
 		mux.Handle("POST /api/auth/magic", authRateLimited(authHandler.ExchangeMagic))
+		mux.Handle("POST /api/auth/magic/local", authRateLimited(authHandler.GenerateMagicLocal))
 	}
 
 	// Password auth routes are registered only when the PasswordAuth feature is enabled

--- a/internal/daemon/status.go
+++ b/internal/daemon/status.go
@@ -64,12 +64,14 @@ func Dashboard(noOpen bool) error {
 	}
 
 	dataDir := filepath.Join(home, ".clawvisor")
-	serverURL, magicToken, err := readLocalSession(dataDir)
-	if err != nil {
+	serverURL, _, err := readLocalSession(dataDir)
+	if err != nil || serverURL == "" {
 		return fmt.Errorf("no local session found — is the daemon running?")
 	}
-	if serverURL == "" || magicToken == "" {
-		return fmt.Errorf("incomplete local session — try restarting the daemon")
+
+	magicToken, err := requestMagicToken(serverURL)
+	if err != nil {
+		return fmt.Errorf("could not get dashboard token: %w", err)
 	}
 
 	dashURL := fmt.Sprintf("%s/magic-link?token=%s", serverURL, magicToken)
@@ -85,8 +87,34 @@ func Dashboard(noOpen bool) error {
 		return nil
 	}
 
-	fmt.Println("  Opening dashboard in browser...")
+	fmt.Println("  Opening Clawvisor dashboard in browser...")
 	return nil
+}
+
+// requestMagicToken asks the running server for a fresh magic token via the
+// localhost-only endpoint.
+func requestMagicToken(serverURL string) (string, error) {
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Post(serverURL+"/api/auth/magic/local", "application/json", nil)
+	if err != nil {
+		return "", fmt.Errorf("contacting server: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("server returned %d", resp.StatusCode)
+	}
+
+	var result struct {
+		Token string `json:"token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("decoding response: %w", err)
+	}
+	if result.Token == "" {
+		return "", fmt.Errorf("server returned empty token")
+	}
+	return result.Token, nil
 }
 
 // PrintStatus prints the daemon status to stdout.


### PR DESCRIPTION
## Summary

Ensures the dashboard token never expires by minting a fresh token on each `clawvisor daemon dashboard` invocation. Adds a new localhost-only endpoint `/api/auth/magic/local` that generates a fresh magic token for the admin@local user. Also clarifies the UI by renaming "daemon dashboard" to "Clawvisor dashboard".

## Changes

- **New endpoint**: `POST /api/auth/magic/local` generates fresh magic tokens, restricted to localhost connections only
- **CLI updates**: `clawvisor daemon dashboard` now calls the server endpoint instead of using the stale token from `.local-session`
- **UX improvement**: Updated references from "daemon dashboard" to "Clawvisor dashboard" for clarity

🤖 Generated with [Claude Code](https://claude.com/claude-code)