### PR TITLE
feat: make relay_pairing grant verify pairing code atomically

### DIFF
--- a/internal/api/handlers/pairing.go
+++ b/internal/api/handlers/pairing.go
@@ -65,44 +65,31 @@ func (h *PairingHandler) GenerateCode(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// VerifyCode handles POST /api/pairing/verify (no auth — only reachable via tunnel).
-// Validates and consumes the pairing code (single-use). Limited to 3 attempts
-// per code to prevent brute-force guessing.
-func (h *PairingHandler) VerifyCode(w http.ResponseWriter, r *http.Request) {
-	var body struct {
-		Code string `json:"pairing_code"`
-	}
-	if !decodeJSON(w, r, &body) {
-		return
-	}
-	if body.Code == "" {
-		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "code is required")
-		return
-	}
-
+// Verify validates and consumes the pairing code (single-use). Limited to 3
+// attempts per code to prevent brute-force guessing. Returns true if the code
+// is valid and was consumed, false otherwise.
+func (h *PairingHandler) Verify(code string) bool {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
 	// No active code or expired.
 	if h.code == "" || time.Since(h.created) > pairingCodeExpiry {
 		h.code = ""
-		writeJSON(w, http.StatusOK, map[string]any{"valid": false})
-		return
+		return false
 	}
 
 	// Wrong code — count the attempt.
-	if h.code != body.Code {
+	if h.code != code {
 		h.attempts++
 		if h.attempts >= maxPairingCodeAttempts {
 			h.code = "" // burn the code after max attempts
 		}
-		writeJSON(w, http.StatusOK, map[string]any{"valid": false})
-		return
+		return false
 	}
 
 	// Correct — consume the code.
 	h.code = ""
-	writeJSON(w, http.StatusOK, map[string]any{"valid": true})
+	return true
 }
 
 func generatePairingCode6() (string, error) {

--- a/internal/api/handlers/pairing_test.go
+++ b/internal/api/handlers/pairing_test.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -66,174 +65,66 @@ func TestPairingGenerateCodeRejectsRelay(t *testing.T) {
 
 func TestPairingVerifyValid(t *testing.T) {
 	h := NewPairingHandler("test-daemon-id")
+	code := generateAndGetCode(t, h)
 
-	// Generate a code.
-	req := httptest.NewRequest("GET", "/api/pairing/code", nil)
-	w := httptest.NewRecorder()
-	h.GenerateCode(w, req)
-
-	var genResp map[string]any
-	json.Unmarshal(w.Body.Bytes(), &genResp)
-	code := genResp["code"].(string)
-
-	// Verify with the correct code.
-	body, _ := json.Marshal(map[string]string{"pairing_code": code})
-	req = httptest.NewRequest("POST", "/api/pairing/verify", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w = httptest.NewRecorder()
-	h.VerifyCode(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
-	}
-
-	var resp map[string]any
-	json.Unmarshal(w.Body.Bytes(), &resp)
-	if resp["valid"] != true {
-		t.Error("expected valid: true")
+	if !h.Verify(code) {
+		t.Error("expected Verify to return true for correct code")
 	}
 }
 
 func TestPairingVerifyInvalidCode(t *testing.T) {
 	h := NewPairingHandler("test-daemon-id")
+	generateAndGetCode(t, h) // generate a code but don't use it
 
-	// Generate a code.
-	req := httptest.NewRequest("GET", "/api/pairing/code", nil)
-	w := httptest.NewRecorder()
-	h.GenerateCode(w, req)
-
-	// Verify with the wrong code.
-	body, _ := json.Marshal(map[string]string{"pairing_code": "000000"})
-	req = httptest.NewRequest("POST", "/api/pairing/verify", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w = httptest.NewRecorder()
-	h.VerifyCode(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d", w.Code)
-	}
-
-	var resp map[string]any
-	json.Unmarshal(w.Body.Bytes(), &resp)
-	if resp["valid"] != false {
-		t.Error("expected valid: false")
+	if h.Verify("000000") {
+		t.Error("expected Verify to return false for wrong code")
 	}
 }
 
 func TestPairingVerifyNoActiveCode(t *testing.T) {
 	h := NewPairingHandler("test-daemon-id")
 
-	// No code generated — verify should return false.
-	body, _ := json.Marshal(map[string]string{"pairing_code": "123456"})
-	req := httptest.NewRequest("POST", "/api/pairing/verify", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	h.VerifyCode(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d", w.Code)
-	}
-
-	var resp map[string]any
-	json.Unmarshal(w.Body.Bytes(), &resp)
-	if resp["valid"] != false {
-		t.Error("expected valid: false when no code active")
+	if h.Verify("123456") {
+		t.Error("expected Verify to return false when no code active")
 	}
 }
 
 func TestPairingVerifySingleUse(t *testing.T) {
 	h := NewPairingHandler("test-daemon-id")
+	code := generateAndGetCode(t, h)
 
-	// Generate a code.
-	req := httptest.NewRequest("GET", "/api/pairing/code", nil)
-	w := httptest.NewRecorder()
-	h.GenerateCode(w, req)
-
-	var genResp map[string]any
-	json.Unmarshal(w.Body.Bytes(), &genResp)
-	code := genResp["code"].(string)
-
-	// First verify — should succeed.
-	body, _ := json.Marshal(map[string]string{"pairing_code": code})
-	req = httptest.NewRequest("POST", "/api/pairing/verify", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w = httptest.NewRecorder()
-	h.VerifyCode(w, req)
-
-	var resp map[string]any
-	json.Unmarshal(w.Body.Bytes(), &resp)
-	if resp["valid"] != true {
+	if !h.Verify(code) {
 		t.Fatal("first verify should succeed")
 	}
-
-	// Second verify with same code — should fail (consumed).
-	body, _ = json.Marshal(map[string]string{"pairing_code": code})
-	req = httptest.NewRequest("POST", "/api/pairing/verify", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w = httptest.NewRecorder()
-	h.VerifyCode(w, req)
-
-	json.Unmarshal(w.Body.Bytes(), &resp)
-	if resp["valid"] != false {
+	if h.Verify(code) {
 		t.Error("second verify should fail — code was consumed")
 	}
 }
 
 func TestPairingVerifyExpired(t *testing.T) {
 	h := NewPairingHandler("test-daemon-id")
-
-	// Generate code then manually expire it.
-	req := httptest.NewRequest("GET", "/api/pairing/code", nil)
-	w := httptest.NewRecorder()
-	h.GenerateCode(w, req)
-
-	var genResp map[string]any
-	json.Unmarshal(w.Body.Bytes(), &genResp)
-	code := genResp["code"].(string)
+	code := generateAndGetCode(t, h)
 
 	h.mu.Lock()
 	h.created = time.Now().Add(-6 * time.Minute)
 	h.mu.Unlock()
 
-	body, _ := json.Marshal(map[string]string{"pairing_code": code})
-	req = httptest.NewRequest("POST", "/api/pairing/verify", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w = httptest.NewRecorder()
-	h.VerifyCode(w, req)
-
-	var resp map[string]any
-	json.Unmarshal(w.Body.Bytes(), &resp)
-	if resp["valid"] != false {
-		t.Error("expired code should return valid: false")
+	if h.Verify(code) {
+		t.Error("expired code should return false")
 	}
 }
 
 func TestPairingVerifyBruteForce(t *testing.T) {
 	h := NewPairingHandler("test-daemon-id")
+	generateAndGetCode(t, h)
 
-	// Generate a code.
-	req := httptest.NewRequest("GET", "/api/pairing/code", nil)
-	w := httptest.NewRecorder()
-	h.GenerateCode(w, req)
-
-	// Send 3 wrong codes.
 	for i := 0; i < maxPairingCodeAttempts; i++ {
-		body, _ := json.Marshal(map[string]string{"pairing_code": "000000"})
-		req = httptest.NewRequest("POST", "/api/pairing/verify", bytes.NewReader(body))
-		req.Header.Set("Content-Type", "application/json")
-		w = httptest.NewRecorder()
-		h.VerifyCode(w, req)
-
-		var resp map[string]any
-		json.Unmarshal(w.Body.Bytes(), &resp)
-		if resp["valid"] != false {
-			t.Errorf("attempt %d: expected valid: false", i+1)
+		if h.Verify("000000") {
+			t.Errorf("attempt %d: expected false for wrong code", i+1)
 		}
 	}
 
-	// Code should be burned — even the correct code should fail.
 	h.mu.Lock()
-	// The code should have been cleared.
 	if h.code != "" {
 		t.Error("code should be cleared after max attempts")
 	}
@@ -242,79 +133,22 @@ func TestPairingVerifyBruteForce(t *testing.T) {
 
 func TestPairingNewCodeInvalidatesPrevious(t *testing.T) {
 	h := NewPairingHandler("test-daemon-id")
+	code1 := generateAndGetCode(t, h)
+	code2 := generateAndGetCode(t, h)
 
-	// Generate first code.
-	req := httptest.NewRequest("GET", "/api/pairing/code", nil)
-	w := httptest.NewRecorder()
-	h.GenerateCode(w, req)
-
-	var resp1 map[string]any
-	json.Unmarshal(w.Body.Bytes(), &resp1)
-	code1 := resp1["code"].(string)
-
-	// Generate second code.
-	req = httptest.NewRequest("GET", "/api/pairing/code", nil)
-	w = httptest.NewRecorder()
-	h.GenerateCode(w, req)
-
-	var resp2 map[string]any
-	json.Unmarshal(w.Body.Bytes(), &resp2)
-	code2 := resp2["code"].(string)
-
-	// First code should be invalid.
-	body, _ := json.Marshal(map[string]string{"pairing_code": code1})
-	req = httptest.NewRequest("POST", "/api/pairing/verify", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w = httptest.NewRecorder()
-	h.VerifyCode(w, req)
-
-	var verifyResp map[string]any
-	json.Unmarshal(w.Body.Bytes(), &verifyResp)
-	if verifyResp["valid"] != false {
+	if h.Verify(code1) {
 		t.Error("first code should be invalid after generating a new one")
 	}
 
-	// Second code should work.
-	body, _ = json.Marshal(map[string]string{"pairing_code": code2})
-	req = httptest.NewRequest("POST", "/api/pairing/verify", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w = httptest.NewRecorder()
-	h.VerifyCode(w, req)
-
-	json.Unmarshal(w.Body.Bytes(), &verifyResp)
-	if verifyResp["valid"] != true {
+	if !h.Verify(code2) {
 		t.Error("second code should be valid")
-	}
-}
-
-func TestPairingVerifyEmptyCode(t *testing.T) {
-	h := NewPairingHandler("test-daemon-id")
-
-	body, _ := json.Marshal(map[string]string{"pairing_code": ""})
-	req := httptest.NewRequest("POST", "/api/pairing/verify", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	h.VerifyCode(w, req)
-
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("expected 400 for empty code, got %d", w.Code)
 	}
 }
 
 func TestPairingConcurrentVerify(t *testing.T) {
 	h := NewPairingHandler("test-daemon-id")
+	code := generateAndGetCode(t, h)
 
-	// Generate a code.
-	req := httptest.NewRequest("GET", "/api/pairing/code", nil)
-	w := httptest.NewRecorder()
-	h.GenerateCode(w, req)
-
-	var genResp map[string]any
-	json.Unmarshal(w.Body.Bytes(), &genResp)
-	code := genResp["code"].(string)
-
-	// Fire 10 concurrent verify requests with the correct code.
-	// Exactly one should succeed.
 	const n = 10
 	results := make([]bool, n)
 	var wg sync.WaitGroup
@@ -322,15 +156,7 @@ func TestPairingConcurrentVerify(t *testing.T) {
 	for i := 0; i < n; i++ {
 		go func(idx int) {
 			defer wg.Done()
-			body, _ := json.Marshal(map[string]string{"pairing_code": code})
-			r := httptest.NewRequest("POST", "/api/pairing/verify", bytes.NewReader(body))
-			r.Header.Set("Content-Type", "application/json")
-			rec := httptest.NewRecorder()
-			h.VerifyCode(rec, r)
-
-			var resp map[string]any
-			json.Unmarshal(rec.Body.Bytes(), &resp)
-			results[idx] = resp["valid"] == true
+			results[idx] = h.Verify(code)
 		}(i)
 	}
 	wg.Wait()
@@ -344,4 +170,18 @@ func TestPairingConcurrentVerify(t *testing.T) {
 	if successCount != 1 {
 		t.Errorf("expected exactly 1 successful verify, got %d", successCount)
 	}
+}
+
+// generateAndGetCode calls GenerateCode and returns the 6-digit code string.
+func generateAndGetCode(t *testing.T, h *PairingHandler) string {
+	t.Helper()
+	req := httptest.NewRequest("GET", "/api/pairing/code", nil)
+	w := httptest.NewRecorder()
+	h.GenerateCode(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GenerateCode failed: %d %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	return resp["code"].(string)
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -390,14 +390,14 @@ func (s *Server) routes() http.Handler {
 	mux.Handle("POST /api/agents/connect/{id}/deny", user(connectionsHandler.Deny))
 
 	// Pairing code (for relay MCP OAuth consent — no auth, CORS for relay origin)
+	var pairingHandler *handlers.PairingHandler
 	if s.daemonID != "" {
-		pairingHandler := handlers.NewPairingHandler(s.daemonID)
+		pairingHandler = handlers.NewPairingHandler(s.daemonID)
 		corsOrigins := []string{"https://relay.clawvisor.com", "https://app.clawvisor.com"}
 		mux.Handle("GET /api/pairing/code",
 			middleware.CORSAllowOrigins(corsOrigins, http.HandlerFunc(pairingHandler.GenerateCode)))
 		mux.Handle("OPTIONS /api/pairing/code",
 			middleware.CORSAllowOrigins(corsOrigins, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})))
-		mux.HandleFunc("POST /api/pairing/verify", pairingHandler.VerifyCode)
 	}
 
 	// Device pairing and management
@@ -537,6 +537,9 @@ func (s *Server) routes() http.Handler {
 		var oauthOpts []mcpoauth.ProviderOption
 		if s.daemonID != "" {
 			oauthOpts = append(oauthOpts, mcpoauth.WithDaemonID(s.daemonID))
+		}
+		if pairingHandler != nil {
+			oauthOpts = append(oauthOpts, mcpoauth.WithPairingVerifier(pairingHandler.Verify))
 		}
 		oauthProvider := mcpoauth.NewProvider(s.store, s.jwtSvc, baseURL, s.logger, oauthOpts...)
 		mux.HandleFunc("GET /.well-known/oauth-protected-resource", oauthProvider.ProtectedResourceMetadata)

--- a/internal/mcp/oauth/provider.go
+++ b/internal/mcp/oauth/provider.go
@@ -21,11 +21,12 @@ import (
 
 // Provider implements OAuth 2.1 endpoints for MCP client authentication.
 type Provider struct {
-	st       store.Store
-	jwtSvc   pkgauth.TokenService
-	baseURL  string
-	daemonID string // relay daemon ID, included in token responses
-	logger   *slog.Logger
+	st              store.Store
+	jwtSvc          pkgauth.TokenService
+	baseURL         string
+	daemonID        string              // relay daemon ID, included in token responses
+	logger          *slog.Logger
+	pairingVerifier func(string) bool   // verifies pairing code for relay_pairing grant
 }
 
 // NewProvider creates an OAuth provider.
@@ -43,6 +44,13 @@ type ProviderOption func(*Provider)
 // WithDaemonID sets the daemon ID included in token responses.
 func WithDaemonID(id string) ProviderOption {
 	return func(p *Provider) { p.daemonID = id }
+}
+
+// WithPairingVerifier sets the function used to verify pairing codes for the
+// relay_pairing grant type. The function should atomically validate and consume
+// the code, returning true if valid.
+func WithPairingVerifier(fn func(string) bool) ProviderOption {
+	return func(p *Provider) { p.pairingVerifier = fn }
 }
 
 // Register handles POST /oauth/register (RFC 7591 Dynamic Client Registration).
@@ -312,10 +320,22 @@ func (p *Provider) Token(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleRelayPairing creates an agent and issues a cvis_ token directly.
-// This grant type is only accepted when the request arrives via the relay tunnel.
+// This grant type is only accepted when the request arrives via the relay tunnel
+// and includes a valid pairing_code.
 func (p *Provider) handleRelayPairing(w http.ResponseWriter, r *http.Request) {
 	if !relay.ViaRelay(r.Context()) {
 		writeOAuthError(w, http.StatusForbidden, "access_denied", "relay_pairing grant is only available via relay tunnel")
+		return
+	}
+
+	// Verify the pairing code atomically.
+	pairingCode := r.FormValue("pairing_code")
+	if pairingCode == "" {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_request", "pairing_code is required")
+		return
+	}
+	if p.pairingVerifier == nil || !p.pairingVerifier(pairingCode) {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "invalid or expired pairing code")
 		return
 	}
 

--- a/internal/mcp/oauth/provider_test.go
+++ b/internal/mcp/oauth/provider_test.go
@@ -1,0 +1,139 @@
+package oauth
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/internal/relay"
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+// mockStore embeds the store.Store interface; only the methods needed for
+// relay_pairing are implemented. Calling anything else panics.
+type mockStore struct {
+	store.Store
+	user  *store.User
+	agent *store.Agent
+}
+
+func (m *mockStore) GetUserByEmail(_ context.Context, email string) (*store.User, error) {
+	if m.user != nil && m.user.Email == email {
+		return m.user, nil
+	}
+	return nil, store.ErrNotFound
+}
+
+func (m *mockStore) CreateAgent(_ context.Context, userID, name, tokenHash string) (*store.Agent, error) {
+	m.agent = &store.Agent{ID: "agent-1", UserID: userID, Name: name, TokenHash: tokenHash}
+	return m.agent, nil
+}
+
+func newTestProvider(verifier func(string) bool) *Provider {
+	st := &mockStore{
+		user: &store.User{ID: "user-1", Email: "admin@local"},
+	}
+	opts := []ProviderOption{WithDaemonID("test-daemon")}
+	if verifier != nil {
+		opts = append(opts, WithPairingVerifier(verifier))
+	}
+	return NewProvider(st, nil, "http://localhost", slog.Default(), opts...)
+}
+
+func postToken(p *Provider, viaRelay bool, params url.Values) *httptest.ResponseRecorder {
+	body := params.Encode()
+	req := httptest.NewRequest("POST", "/oauth/token", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if viaRelay {
+		req = req.WithContext(relay.WithViaRelay(req.Context()))
+	}
+	w := httptest.NewRecorder()
+	p.Token(w, req)
+	return w
+}
+
+func TestRelayPairingSuccess(t *testing.T) {
+	verifier := func(code string) bool { return code == "123456" }
+	p := newTestProvider(verifier)
+
+	w := postToken(p, true, url.Values{
+		"grant_type":   {"relay_pairing"},
+		"pairing_code": {"123456"},
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "access_token") {
+		t.Error("response should contain access_token")
+	}
+	if !strings.Contains(body, "test-daemon") {
+		t.Error("response should contain daemon_id")
+	}
+}
+
+func TestRelayPairingMissingCode(t *testing.T) {
+	p := newTestProvider(func(string) bool { return true })
+
+	w := postToken(p, true, url.Values{
+		"grant_type": {"relay_pairing"},
+	})
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "pairing_code is required") {
+		t.Error("expected pairing_code required error")
+	}
+}
+
+func TestRelayPairingWrongCode(t *testing.T) {
+	verifier := func(code string) bool { return code == "123456" }
+	p := newTestProvider(verifier)
+
+	w := postToken(p, true, url.Values{
+		"grant_type":   {"relay_pairing"},
+		"pairing_code": {"000000"},
+	})
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "invalid_grant") {
+		t.Error("expected invalid_grant error")
+	}
+}
+
+func TestRelayPairingNotViaRelay(t *testing.T) {
+	p := newTestProvider(func(string) bool { return true })
+
+	w := postToken(p, false, url.Values{
+		"grant_type":   {"relay_pairing"},
+		"pairing_code": {"123456"},
+	})
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRelayPairingNoVerifierConfigured(t *testing.T) {
+	p := newTestProvider(nil) // no verifier
+
+	w := postToken(p, true, url.Values{
+		"grant_type":   {"relay_pairing"},
+		"pairing_code": {"123456"},
+	})
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "invalid_grant") {
+		t.Error("expected invalid_grant error when no verifier configured")
+	}
+}


### PR DESCRIPTION
## Summary

Combine the separate verify and token-mint calls into a single atomic POST /oauth/token request. The relay now passes pairing_code as a required parameter in the relay_pairing grant, and the daemon verifies it atomically before minting the token.

## Changes

- Extract `Verify(code string) bool` method from PairingHandler — the existing mutex-protected, single-use, brute-force-guarded logic is now callable without an HTTP request
- Add `WithPairingVerifier` option to OAuth Provider to inject the verifier function
- Update `handleRelayPairing` to require `pairing_code` form parameter and verify it before token minting; keep ViaRelay check as defense-in-depth
- Remove `POST /api/pairing/verify` endpoint — no longer needed
- Update tests: convert verify endpoint tests to call `Verify()` directly; add comprehensive OAuth relay_pairing grant tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)