### PR TITLE
Add HKDF key derivation to E2E encryption

### DIFF
--- a/internal/api/middleware/e2e.go
+++ b/internal/api/middleware/e2e.go
@@ -6,11 +6,13 @@ import (
 	"crypto/cipher"
 	"crypto/ecdh"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
 	"io"
 	"net/http"
 
 	"github.com/clawvisor/clawvisor/internal/relay"
+	"golang.org/x/crypto/hkdf"
 )
 
 // E2E wraps a gateway handler to transparently decrypt E2E-encrypted request
@@ -49,10 +51,15 @@ func E2E(x25519Key *ecdh.PrivateKey) func(http.Handler) http.Handler {
 				return
 			}
 
-			// ECDH → shared secret.
-			shared, err := x25519Key.ECDH(ephPub)
+			// ECDH → shared secret → HKDF derived key.
+			rawShared, err := x25519Key.ECDH(ephPub)
 			if err != nil {
 				http.Error(w, `{"error":"ECDH key exchange failed","code":"E2E_ERROR"}`, http.StatusInternalServerError)
+				return
+			}
+			shared := make([]byte, 32)
+			if _, err := io.ReadFull(hkdf.New(sha256.New, rawShared, nil, []byte("clawvisor-e2e-v1")), shared); err != nil {
+				http.Error(w, `{"error":"key derivation failed","code":"E2E_ERROR"}`, http.StatusInternalServerError)
 				return
 			}
 

--- a/internal/api/middleware/e2e_test.go
+++ b/internal/api/middleware/e2e_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/cipher"
 	"crypto/ecdh"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
 	"io"
 	"net/http"
@@ -13,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/clawvisor/clawvisor/internal/relay"
+	"golang.org/x/crypto/hkdf"
 )
 
 func TestE2E_PlaintextLocal(t *testing.T) {
@@ -76,7 +78,9 @@ func TestE2E_EncryptDecryptRoundTrip(t *testing.T) {
 
 	// Agent side: encrypt the request.
 	agentKey, _ := ecdh.X25519().GenerateKey(rand.Reader)
-	shared, _ := agentKey.ECDH(daemonKey.PublicKey())
+	rawShared, _ := agentKey.ECDH(daemonKey.PublicKey())
+	shared := make([]byte, 32)
+	io.ReadFull(hkdf.New(sha256.New, rawShared, nil, []byte("clawvisor-e2e-v1")), shared)
 
 	block, _ := aes.NewCipher(shared)
 	gcm, _ := cipher.NewGCM(block)
@@ -133,7 +137,9 @@ func TestE2E_GETStatusViaRelay(t *testing.T) {
 
 	// Agent generates ephemeral key for response decryption.
 	agentKey, _ := ecdh.X25519().GenerateKey(rand.Reader)
-	shared, _ := agentKey.ECDH(daemonKey.PublicKey())
+	rawShared, _ := agentKey.ECDH(daemonKey.PublicKey())
+	shared := make([]byte, 32)
+	io.ReadFull(hkdf.New(sha256.New, rawShared, nil, []byte("clawvisor-e2e-v1")), shared)
 
 	req := httptest.NewRequest("GET", "/api/gateway/request/abc/status", nil)
 	ctx := relay.WithViaRelay(req.Context())

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -411,7 +411,7 @@ func (s *Server) routes() http.Handler {
 	mux.Handle("GET /api/devices/pair/info", user(devicesHandler.PairInfo))
 	mux.Handle("POST /api/devices/pair", user(devicesHandler.StartPairing))
 	mux.Handle("POST /api/devices/pair/complete",
-		middleware.RateLimit(devicesRL, ipKeyFn, 5)(http.HandlerFunc(devicesHandler.CompletePairing)))
+		middleware.RateLimit(devicesRL, ipKeyFn, 5)(e2e(http.HandlerFunc(devicesHandler.CompletePairing))))
 	mux.Handle("GET /api/devices", user(devicesHandler.List))
 	mux.Handle("DELETE /api/devices/{id}", user(devicesHandler.Delete))
 	requireDevice := middleware.RequireDevice(s.store)


### PR DESCRIPTION
## Summary

Adds HKDF-SHA256 key derivation with "clawvisor-e2e-v1" salt to the E2E encryption flow, matching the iOS client implementation. The AES key is now derived from the raw ECDH shared secret instead of using it directly. Also wraps the pair/complete endpoint with E2E middleware for additional security.

## Changes

- Derive AES keys via HKDF after ECDH shared secret computation
- Wrap `/api/devices/pair/complete` endpoint with E2E middleware 
- Update E2E tests to use HKDF-derived keys instead of raw shared secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)