### PR TITLE
feat: refactor config path handling and improve robustness

### DIFF
--- a/internal/daemon/run.go
+++ b/internal/daemon/run.go
@@ -39,15 +39,14 @@ func Run(opts RunOptions) error {
 		return err
 	}
 
-	// Point the server at the daemon's config file.
-	os.Setenv("CONFIG_FILE", filepath.Join(dataDir, "config.yaml"))
+	cfgPath := filepath.Join(dataDir, "config.yaml")
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
 
 	if firstRun {
 		// Phase 1 (and optionally Phase 2 for Google OAuth restart):
 		// start server in background, run service setup, then hand off.
-		if err := runWithServiceSetup(dataDir, logger, 1); err != nil {
+		if err := runWithServiceSetup(dataDir, cfgPath, logger, 1); err != nil {
 			return err
 		}
 		fmt.Println()
@@ -64,7 +63,7 @@ func Run(opts RunOptions) error {
 	defer os.Remove(pidPath)
 
 	// Final production run — blocks until SIGINT/SIGTERM.
-	return server.Run(logger, server.RunOptions{})
+	return server.Run(logger, server.RunOptions{ConfigPath: cfgPath})
 }
 
 // runWithServiceSetup starts the server with a cancellable context, waits for
@@ -72,12 +71,12 @@ func Run(opts RunOptions) error {
 // down cleanly. phase should be 1 on first call; 2 on the restart triggered
 // by Google OAuth credential collection. Passing phase >= 2 disables further
 // restarts, preventing infinite loops if something goes wrong.
-func runWithServiceSetup(dataDir string, logger *slog.Logger, phase int) error {
+func runWithServiceSetup(dataDir, cfgPath string, logger *slog.Logger, phase int) error {
 	// Re-read DefaultOptions so the server picks up any config changes (e.g.
 	// Google creds written between phases). Use a discarding logger so server
 	// request logs don't clutter the interactive setup output.
 	quietLogger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	srvOpts, err := clawvisor.DefaultOptions(quietLogger)
+	srvOpts, err := clawvisor.DefaultOptions(quietLogger, cfgPath)
 	if err != nil {
 		return fmt.Errorf("building server options: %w", err)
 	}
@@ -139,7 +138,7 @@ func runWithServiceSetup(dataDir string, logger *slog.Logger, phase int) error {
 		fmt.Println()
 		fmt.Println(dim.Padding(0, 2).Render("  Restarting with updated configuration..."))
 		fmt.Println()
-		return runWithServiceSetup(dataDir, logger, phase+1)
+		return runWithServiceSetup(dataDir, cfgPath, logger, phase+1)
 	}
 
 	return nil
@@ -148,9 +147,10 @@ func runWithServiceSetup(dataDir string, logger *slog.Logger, phase int) error {
 // waitForServer polls the /health endpoint until it returns 200 or the
 // deadline (10 seconds) is exceeded.
 func waitForServer(serverURL string) error {
+	client := &http.Client{Timeout: 2 * time.Second}
 	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {
-		resp, err := http.Get(serverURL + "/health") //nolint:noctx
+		resp, err := client.Get(serverURL + "/health") //nolint:noctx
 		if err == nil {
 			resp.Body.Close()
 			if resp.StatusCode == http.StatusOK {
@@ -293,15 +293,12 @@ func Setup(opts SetupOptions) error {
 		return err
 	}
 
-	// Point the server at the freshly written config file.
-	os.Setenv("CONFIG_FILE", cfgPath)
-
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
 
 	// Start a temporary server and run the service setup wizard against it,
 	// just like the first-run path. This avoids depending on a running daemon
 	// that may have stale config.
-	if err := runWithServiceSetup(dataDir, logger, 1); err != nil {
+	if err := runWithServiceSetup(dataDir, cfgPath, logger, 1); err != nil {
 		return err
 	}
 

--- a/internal/daemon/services_setup.go
+++ b/internal/daemon/services_setup.go
@@ -396,53 +396,81 @@ func googleCredsPresent(configPath string) (bool, error) {
 	return strings.TrimSpace(id) != "", nil
 }
 
-// patchGoogleConfig inserts Google OAuth credentials into config.yaml using
-// line-level editing to avoid the corruption caused by YAML round-tripping
-// through map[string]interface{} (which re-encodes all values and can mangle
-// strings containing special characters).
+// patchGoogleConfig inserts or replaces the google: block under services: in
+// the daemon config file. Uses yaml.Node to make structural edits while
+// preserving comments and formatting of unrelated sections.
 func patchGoogleConfig(configPath, clientID, clientSecret string) error {
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		return err
 	}
 
-	content := string(data)
-	googleBlock := fmt.Sprintf("  google:\n    client_id: \"%s\"\n    client_secret: \"%s\"\n", clientID, clientSecret)
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return fmt.Errorf("parsing config YAML: %w", err)
+	}
+	if doc.Kind != yaml.DocumentNode || len(doc.Content) == 0 {
+		return fmt.Errorf("unexpected YAML structure in %s", configPath)
+	}
+	root := doc.Content[0] // mapping node
 
-	// If there's already a google: section under services:, replace it.
-	// Otherwise, append it after the services: line.
-	if strings.Contains(content, "  google:") {
-		// Replace existing google block (from "  google:" to next top-level or peer key).
-		lines := strings.Split(content, "\n")
-		var out []string
-		inGoogle := false
-		for _, line := range lines {
-			if strings.HasPrefix(line, "  google:") {
-				inGoogle = true
-				out = append(out, strings.TrimRight(googleBlock, "\n"))
-				continue
-			}
-			if inGoogle {
-				// Still inside google block if indented deeper than 2 spaces.
-				trimmed := strings.TrimLeft(line, " ")
-				indent := len(line) - len(trimmed)
-				if indent > 2 && trimmed != "" {
-					continue // skip old google sub-keys
-				}
-				inGoogle = false
-			}
-			out = append(out, line)
-		}
-		content = strings.Join(out, "\n")
-	} else if strings.Contains(content, "services:") {
-		// Append google block after services: line.
-		content = strings.Replace(content, "services:\n", "services:\n"+googleBlock, 1)
-	} else {
-		// No services section — append one.
-		content += "\nservices:\n" + googleBlock
+	// Find or create the "services" key.
+	servicesNode := yamlMapGet(root, "services")
+	if servicesNode == nil {
+		root.Content = append(root.Content,
+			&yaml.Node{Kind: yaml.ScalarNode, Value: "services"},
+			&yaml.Node{Kind: yaml.MappingNode},
+		)
+		servicesNode = root.Content[len(root.Content)-1]
 	}
 
-	return os.WriteFile(configPath, []byte(content), 0600)
+	// Find or create the "google" key under services.
+	googleNode := yamlMapGet(servicesNode, "google")
+	if googleNode == nil {
+		servicesNode.Content = append(servicesNode.Content,
+			&yaml.Node{Kind: yaml.ScalarNode, Value: "google"},
+			&yaml.Node{Kind: yaml.MappingNode},
+		)
+		googleNode = servicesNode.Content[len(servicesNode.Content)-1]
+	}
+
+	// Set client_id and client_secret.
+	yamlMapSet(googleNode, "client_id", clientID)
+	yamlMapSet(googleNode, "client_secret", clientSecret)
+
+	out, err := yaml.Marshal(&doc)
+	if err != nil {
+		return fmt.Errorf("marshaling config YAML: %w", err)
+	}
+	return os.WriteFile(configPath, out, 0600)
+}
+
+// yamlMapGet returns the value node for the given key in a mapping node,
+// or nil if not found.
+func yamlMapGet(mapping *yaml.Node, key string) *yaml.Node {
+	if mapping.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		if mapping.Content[i].Value == key {
+			return mapping.Content[i+1]
+		}
+	}
+	return nil
+}
+
+// yamlMapSet sets or inserts a scalar key-value pair in a mapping node.
+func yamlMapSet(mapping *yaml.Node, key, value string) {
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		if mapping.Content[i].Value == key {
+			mapping.Content[i+1] = &yaml.Node{Kind: yaml.ScalarNode, Value: value}
+			return
+		}
+	}
+	mapping.Content = append(mapping.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Value: key},
+		&yaml.Node{Kind: yaml.ScalarNode, Value: value},
+	)
 }
 
 // injectMissingGoogleServices prepends known Google services to the list if

--- a/internal/daemon/setup.go
+++ b/internal/daemon/setup.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/lipgloss"
+	"gopkg.in/yaml.v3"
 )
 
 var (
@@ -253,6 +254,13 @@ func stepDaemonTelemetry(cfg *daemonConfig) error {
 	).Run()
 }
 
+// yamlQuote safely quotes a string for use as a YAML scalar value,
+// handling special characters that would otherwise corrupt the config.
+func yamlQuote(s string) string {
+	out, _ := yaml.Marshal(s)
+	return strings.TrimSpace(string(out))
+}
+
 func writeDaemonConfig(cfg *daemonConfig, dataDir, jwtSecret, path string) error {
 	var b strings.Builder
 
@@ -265,14 +273,14 @@ func writeDaemonConfig(cfg *daemonConfig, dataDir, jwtSecret, path string) error
 
 	fmt.Fprintf(&b, "\ndatabase:\n")
 	fmt.Fprintf(&b, "  driver: \"sqlite\"\n")
-	fmt.Fprintf(&b, "  sqlite_path: \"%s\"\n", filepath.Join(dataDir, "clawvisor.db"))
+	fmt.Fprintf(&b, "  sqlite_path: %s\n", yamlQuote(filepath.Join(dataDir, "clawvisor.db")))
 
 	fmt.Fprintf(&b, "\nvault:\n")
 	fmt.Fprintf(&b, "  backend: \"local\"\n")
-	fmt.Fprintf(&b, "  local_key_file: \"%s\"\n", filepath.Join(dataDir, "vault.key"))
+	fmt.Fprintf(&b, "  local_key_file: %s\n", yamlQuote(filepath.Join(dataDir, "vault.key")))
 
 	fmt.Fprintf(&b, "\nauth:\n")
-	fmt.Fprintf(&b, "  jwt_secret: \"%s\"\n", jwtSecret)
+	fmt.Fprintf(&b, "  jwt_secret: %s\n", yamlQuote(jwtSecret))
 
 	fmt.Fprintf(&b, "\nservices:\n")
 	fmt.Fprintf(&b, "  imessage:\n")
@@ -285,7 +293,7 @@ func writeDaemonConfig(cfg *daemonConfig, dataDir, jwtSecret, path string) error
 	fmt.Fprintf(&b, "\nllm:\n")
 	fmt.Fprintf(&b, "  provider: %s\n", cfg.llmProvider)
 	fmt.Fprintf(&b, "  endpoint: %s\n", cfg.llmEndpoint)
-	fmt.Fprintf(&b, "  api_key: \"%s\"\n", cfg.llmAPIKey)
+	fmt.Fprintf(&b, "  api_key: %s\n", yamlQuote(cfg.llmAPIKey))
 	fmt.Fprintf(&b, "  model: %s\n", cfg.llmModel)
 	fmt.Fprintf(&b, "  verification:\n")
 	fmt.Fprintf(&b, "    enabled: true\n")
@@ -310,15 +318,15 @@ func writeDaemonConfig(cfg *daemonConfig, dataDir, jwtSecret, path string) error
 	}
 	fmt.Fprintf(&b, "\npush:\n")
 	fmt.Fprintf(&b, "  enabled: true\n")
-	fmt.Fprintf(&b, "  url: \"%s\"\n", pushURL)
+	fmt.Fprintf(&b, "  url: %s\n", yamlQuote(pushURL))
 
 	fmt.Fprintf(&b, "\nrelay:\n")
 	fmt.Fprintf(&b, "  enabled: true\n")
-	fmt.Fprintf(&b, "  url: \"%s\"\n", relayURL)
-	fmt.Fprintf(&b, "  key_file: \"%s\"\n", filepath.Join(dataDir, "daemon-ed25519.key"))
-	fmt.Fprintf(&b, "  e2e_key_file: \"%s\"\n", filepath.Join(dataDir, "daemon-x25519.key"))
+	fmt.Fprintf(&b, "  url: %s\n", yamlQuote(relayURL))
+	fmt.Fprintf(&b, "  key_file: %s\n", yamlQuote(filepath.Join(dataDir, "daemon-ed25519.key")))
+	fmt.Fprintf(&b, "  e2e_key_file: %s\n", yamlQuote(filepath.Join(dataDir, "daemon-x25519.key")))
 
-	return os.WriteFile(path, []byte(b.String()), 0644)
+	return os.WriteFile(path, []byte(b.String()), 0600)
 }
 
 

--- a/internal/relay/client.go
+++ b/internal/relay/client.go
@@ -335,11 +335,11 @@ func (c *Client) sendFrame(typ FrameType, id string, payload any) error {
 		c.mu.Unlock()
 		return errors.New("not connected")
 	}
-	c.mu.Unlock()
-
 	writeCtx, cancel := context.WithTimeout(context.Background(), writeTimeout)
-	defer cancel()
-	return conn.Write(writeCtx, websocket.MessageText, data)
+	err := conn.Write(writeCtx, websocket.MessageText, data)
+	c.mu.Unlock()
+	cancel()
+	return err
 }
 
 // sendResponse sends an HTTP response frame back to the relay.

--- a/internal/server/run.go
+++ b/internal/server/run.go
@@ -22,6 +22,7 @@ import (
 // RunOptions holds optional flags for the server entrypoint.
 type RunOptions struct {
 	OpenBrowser bool
+	ConfigPath  string // If set, passed to DefaultOptions instead of using env var.
 }
 
 // LocalAuthResult holds the outputs of SetupLocalAuth.
@@ -105,7 +106,7 @@ func SetupLocalAuth(opts *clawvisor.ServerOptions, logger *slog.Logger) (*LocalA
 // Run starts the Clawvisor API server. This is the main entrypoint called
 // from cmd/clawvisor/cmd_server.go.
 func Run(logger *slog.Logger, ropts RunOptions) error {
-	opts, err := clawvisor.DefaultOptions(logger)
+	opts, err := clawvisor.DefaultOptions(logger, ropts.ConfigPath)
 	if err != nil {
 		return err
 	}

--- a/pkg/clawvisor/defaults.go
+++ b/pkg/clawvisor/defaults.go
@@ -53,12 +53,17 @@ import (
 //	opts.Store = tenancy.Wrap(opts.Store)
 //	opts.Features.PasswordAuth = true
 //	clawvisor.Run(opts)
-func DefaultOptions(logger *slog.Logger) (*ServerOptions, error) {
+// DefaultOptions builds a ServerOptions from config. If configPath is provided,
+// it is used directly; otherwise CONFIG_FILE env var is consulted, falling back
+// to "config.yaml".
+func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, error) {
 	ctx := context.Background()
 
 	// ── Config ─────────────────────────────────────────────────────────────
 	cfgPath := "config.yaml"
-	if p := os.Getenv("CONFIG_FILE"); p != "" {
+	if len(configPath) > 0 && configPath[0] != "" {
+		cfgPath = configPath[0]
+	} else if p := os.Getenv("CONFIG_FILE"); p != "" {
 		cfgPath = p
 	}
 	cfg, err := config.Load(cfgPath)
@@ -211,7 +216,7 @@ func DefaultOptions(logger *slog.Logger) (*ServerOptions, error) {
 	if pushN != nil {
 		notifiers = append(notifiers, pushN)
 	}
-	var notifier notify.Notifier = notify.NewMultiNotifier(logger, notifiers...)
+	var notifier notify.Notifier = notify.NewMultiNotifier(ctx, logger, notifiers...)
 
 	// ── Auth mode ──────────────────────────────────────────────────────────
 	// Default is magic-link. Set auth_mode: "password" in config.yaml

--- a/pkg/notify/multi.go
+++ b/pkg/notify/multi.go
@@ -22,7 +22,7 @@ type MultiNotifier struct {
 // NewMultiNotifier creates a MultiNotifier that delegates to the given notifiers.
 // It inspects each notifier for optional interfaces (TelegramPairer, PollingDecrementer,
 // DecisionChannel) and wires them through.
-func NewMultiNotifier(logger *slog.Logger, notifiers ...Notifier) *MultiNotifier {
+func NewMultiNotifier(ctx context.Context, logger *slog.Logger, notifiers ...Notifier) *MultiNotifier {
 	m := &MultiNotifier{
 		notifiers:  notifiers,
 		logger:     logger,
@@ -49,14 +49,22 @@ func NewMultiNotifier(logger *slog.Logger, notifiers ...Notifier) *MultiNotifier
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				for d := range ch {
-					m.decisionCh <- d
+				for {
+					select {
+					case d, ok := <-ch:
+						if !ok {
+							return
+						}
+						m.decisionCh <- d
+					case <-ctx.Done():
+						return
+					}
 				}
 			}()
 		}
 	}
 
-	// Close the merged channel when all inner channels close.
+	// Close the merged channel when all inner channels close or ctx cancels.
 	go func() {
 		wg.Wait()
 		close(m.decisionCh)

--- a/web/src/components/CountdownTimer.tsx
+++ b/web/src/components/CountdownTimer.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react'
 import { differenceInSeconds } from 'date-fns'
 
 interface Props {
@@ -6,7 +7,20 @@ interface Props {
 }
 
 export default function CountdownTimer({ expiresAt, showLabel = false }: Props) {
-  const secs = Math.max(0, differenceInSeconds(new Date(expiresAt), new Date()))
+  const [secs, setSecs] = useState(() =>
+    Math.max(0, differenceInSeconds(new Date(expiresAt), new Date()))
+  )
+
+  useEffect(() => {
+    if (secs <= 0) return
+    const id = setInterval(() => {
+      const remaining = Math.max(0, differenceInSeconds(new Date(expiresAt), new Date()))
+      setSecs(remaining)
+      if (remaining <= 0) clearInterval(id)
+    }, 1000)
+    return () => clearInterval(id)
+  }, [expiresAt]) // eslint-disable-line react-hooks/exhaustive-deps
+
   if (secs <= 0) return <span className="text-xs text-danger font-medium">Expired</span>
   const mins = Math.floor(secs / 60)
   const s = secs % 60

--- a/web/src/hooks/useEventStream.ts
+++ b/web/src/hooks/useEventStream.ts
@@ -30,6 +30,8 @@ async function fetchTicket(): Promise<string | null> {
  * Connects to the SSE event stream and invalidates React Query caches
  * on server-pushed events. Uses a single-use ticket for authentication
  * instead of sending the JWT as a query parameter.
+ *
+ * Automatically reconnects with exponential backoff on connection loss.
  */
 export function useEventStream() {
   const qc = useQueryClient()
@@ -37,12 +39,17 @@ export function useEventStream() {
   useEffect(() => {
     let es: EventSource | null = null
     let cancelled = false
+    let retryDelay = 1000
 
     async function connect() {
       const ticket = await fetchTicket()
       if (cancelled || !ticket) return
 
       es = new EventSource(`/api/events?ticket=${encodeURIComponent(ticket)}`)
+
+      es.onopen = () => {
+        retryDelay = 1000 // reset backoff on successful connection
+      }
 
       es.addEventListener('queue', () => {
         qc.invalidateQueries({ queryKey: ['overview'] })
@@ -67,6 +74,16 @@ export function useEventStream() {
         }
         qc.invalidateQueries({ queryKey: ['overview'] })
       })
+
+      es.onerror = () => {
+        es?.close()
+        es = null
+        if (cancelled) return
+        setTimeout(() => {
+          if (!cancelled) connect()
+        }, retryDelay)
+        retryDelay = Math.min(retryDelay * 2, 30_000) // cap at 30s
+      }
     }
 
     connect()

--- a/web/src/pages/Tasks.tsx
+++ b/web/src/pages/Tasks.tsx
@@ -75,10 +75,17 @@ export default function Tasks() {
 
   const { data, isLoading, refetch } = useQuery({
     queryKey: ['tasks', { filter, offset }],
-    queryFn: () => {
+    queryFn: async () => {
       if (filter === 'actionable') {
-        // Fetch all active tasks (no pagination — actionable set is small)
-        return api.tasks.list({ status: 'pending_approval', limit: PAGE_SIZE, offset })
+        // Fetch both pending statuses and merge (no pagination — actionable set is small)
+        const [approvals, expansions] = await Promise.all([
+          api.tasks.list({ status: 'pending_approval', limit: PAGE_SIZE, offset }),
+          api.tasks.list({ status: 'pending_scope_expansion', limit: PAGE_SIZE, offset }),
+        ])
+        return {
+          tasks: [...(approvals.tasks ?? []), ...(expansions.tasks ?? [])],
+          total: (approvals.total ?? 0) + (expansions.total ?? 0),
+        }
       }
       return api.tasks.list(queryParams)
     },


### PR DESCRIPTION
Improves daemon configuration handling, WebSocket reliability, and UI responsiveness. Removes reliance on mutable environment variables, hardens YAML parsing against special characters, fixes a relay client race condition, and adds exponential backoff reconnection for the event stream.

**Key improvements:**
- Config path passed explicitly instead of via env var
- YAML scalar values quoted to prevent corruption from special characters
- Config files restricted to 0600 permissions
- Relay client mutex race condition fixed
- SSE stream auto-reconnects with exponential backoff
- Countdown timer now ticks every second
- Actionable tasks filter includes pending_scope_expansion requests

No breaking changes. All modifications are internal improvements to robustness and behavior.