### PR TITLE
fix: pass --foreground to daemon start in service templates

### DIFF
--- a/internal/daemon/install.go
+++ b/internal/daemon/install.go
@@ -24,6 +24,7 @@ const launchdPlist = `<?xml version="1.0" encoding="UTF-8"?>
     <array>
         <string>{{.Binary}}</string>
         <string>start</string>
+        <string>--foreground</string>
     </array>
     <key>RunAtLoad</key>
     <true/>
@@ -51,7 +52,7 @@ Description=Clawvisor Daemon
 After=network-online.target
 
 [Service]
-ExecStart={{.Binary}} start
+ExecStart={{.Binary}} start --foreground
 Restart=always
 RestartSec=5
 Environment=CONFIG_FILE={{.DataDir}}/config.yaml


### PR DESCRIPTION
The launchd plist and systemd unit templates were invoking 'clawvisor start' without the --foreground flag, causing the daemon to fail to start. When launchd/systemd ran the command, daemon.Start() would try to load itself again via launchctl instead of running the server process, creating a circular no-op.

This fix adds the --foreground flag to both templates so the service manager actually runs the server process in the foreground.

Users who already have the daemon installed will need to reinstall with `clawvisor install` to apply this fix.