### PR TITLE
fix: clawvisor pair mints a new magic link

### DIFF
--- a/internal/daemon/pair.go
+++ b/internal/daemon/pair.go
@@ -21,9 +21,17 @@ func Pair() error {
 	}
 
 	// Authenticate with the running daemon.
-	serverURL, magicToken, err := readLocalSession(dataDir)
+	serverURL, _, err := readLocalSession(dataDir)
 	if err != nil {
 		return fmt.Errorf("could not read local session — is the daemon running?\n  Start it with: clawvisor start")
+	}
+
+	// Mint a fresh magic token via the localhost-only endpoint so we always
+	// have a valid (unused) token — the one in .local-session may already
+	// have been consumed by a previous command.
+	magicToken, err := requestMagicToken(serverURL)
+	if err != nil {
+		return fmt.Errorf("could not get auth token: %w", err)
 	}
 
 	apiClient, err := authenticateClient(serverURL, magicToken)

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -10,10 +10,13 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
 	"github.com/clawvisor/clawvisor/pkg/config"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
 )
 
 const anthropicVersion = "2023-06-01"
@@ -28,14 +31,15 @@ type ChatMessage struct {
 	Content string `json:"content"`
 }
 
-// Client calls either an OpenAI-compatible or Anthropic chat endpoint.
+// Client calls either an OpenAI-compatible, Anthropic, or Vertex AI chat endpoint.
 type Client struct {
-	provider string
-	endpoint string
-	apiKey   string
-	model    string
-	timeout  time.Duration
-	http     *http.Client
+	provider    string
+	endpoint    string
+	apiKey      string
+	model       string
+	timeout     time.Duration
+	http        *http.Client
+	tokenSource oauth2.TokenSource // for Vertex AI (ADC)
 }
 
 // NewClient builds a Client from a provider config.
@@ -48,7 +52,8 @@ func NewClient(cfg config.LLMProviderConfig) *Client {
 	if provider == "" {
 		provider = "openai"
 	}
-	return &Client{
+
+	c := &Client{
 		provider: provider,
 		endpoint: strings.TrimRight(cfg.Endpoint, "/"),
 		apiKey:   cfg.APIKey,
@@ -56,14 +61,39 @@ func NewClient(cfg config.LLMProviderConfig) *Client {
 		timeout:  timeout,
 		http:     &http.Client{Timeout: timeout + 2*time.Second},
 	}
+
+	if provider == "vertex" {
+		ts, err := google.DefaultTokenSource(context.Background(),
+			"https://www.googleapis.com/auth/cloud-platform",
+		)
+		if err == nil {
+			c.tokenSource = ts
+		}
+		// Build the endpoint from env vars if not explicitly set.
+		if c.endpoint == "" {
+			region := os.Getenv("VERTEX_REGION")
+			projectID := os.Getenv("VERTEX_PROJECT_ID")
+			if region == "" {
+				region = "us-east5"
+			}
+			c.endpoint = fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/anthropic/models",
+				region, projectID, region)
+		}
+	}
+
+	return c
 }
 
 // Complete sends a chat completion request and returns the assistant's reply.
 func (c *Client) Complete(ctx context.Context, messages []ChatMessage) (string, error) {
-	if c.provider == "anthropic" {
+	switch c.provider {
+	case "anthropic":
 		return c.completeAnthropic(ctx, messages)
+	case "vertex":
+		return c.completeVertex(ctx, messages)
+	default:
+		return c.completeOpenAI(ctx, messages) // "openai", "ollama", "groq" use OpenAI-compatible API
 	}
-	return c.completeOpenAI(ctx, messages) // "openai" and "ollama" both use OpenAI-compatible API
 }
 
 // ── OpenAI ────────────────────────────────────────────────────────────────────
@@ -191,4 +221,86 @@ func (c *Client) completeAnthropic(ctx context.Context, messages []ChatMessage) 
 		}
 	}
 	return "", fmt.Errorf("llm: no text content in anthropic response")
+}
+
+// ── Vertex AI ────────────────────────────────────────────────────────────────
+
+func (c *Client) completeVertex(ctx context.Context, messages []ChatMessage) (string, error) {
+	if c.tokenSource == nil {
+		return "", fmt.Errorf("llm: vertex provider requires application default credentials")
+	}
+
+	// Same request body as Anthropic Messages API.
+	var system string
+	var convo []ChatMessage
+	for _, m := range messages {
+		if m.Role == "system" {
+			if system == "" {
+				system = m.Content
+			}
+			continue
+		}
+		convo = append(convo, m)
+	}
+
+	reqBody := map[string]any{
+		"model":             c.model,
+		"max_tokens":        maxTokens,
+		"messages":          convo,
+		"temperature":       0,
+		"anthropic_version": anthropicVersion,
+	}
+	if system != "" {
+		reqBody["system"] = system
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	// Endpoint: .../models/{MODEL}:rawPredict
+	url := fmt.Sprintf("%s/%s:rawPredict", c.endpoint, c.model)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+
+	token, err := c.tokenSource.Token()
+	if err != nil {
+		return "", fmt.Errorf("llm: vertex auth: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token.AccessToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return "", fmt.Errorf("llm: status %d: %s", resp.StatusCode, b)
+	}
+
+	// Response format is the same as Anthropic Messages API.
+	var out struct {
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return "", err
+	}
+	for _, block := range out.Content {
+		if block.Type == "text" {
+			return block.Text, nil
+		}
+	}
+	return "", fmt.Errorf("llm: no text content in vertex response")
 }

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -10,13 +10,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 
 	"github.com/clawvisor/clawvisor/pkg/config"
-	"golang.org/x/oauth2"
-	"golang.org/x/oauth2/google"
 )
 
 const anthropicVersion = "2023-06-01"
@@ -31,15 +28,14 @@ type ChatMessage struct {
 	Content string `json:"content"`
 }
 
-// Client calls either an OpenAI-compatible, Anthropic, or Vertex AI chat endpoint.
+// Client calls either an OpenAI-compatible or Anthropic chat endpoint.
 type Client struct {
-	provider    string
-	endpoint    string
-	apiKey      string
-	model       string
-	timeout     time.Duration
-	http        *http.Client
-	tokenSource oauth2.TokenSource // for Vertex AI (ADC)
+	provider string
+	endpoint string
+	apiKey   string
+	model    string
+	timeout  time.Duration
+	http     *http.Client
 }
 
 // NewClient builds a Client from a provider config.
@@ -52,8 +48,7 @@ func NewClient(cfg config.LLMProviderConfig) *Client {
 	if provider == "" {
 		provider = "openai"
 	}
-
-	c := &Client{
+	return &Client{
 		provider: provider,
 		endpoint: strings.TrimRight(cfg.Endpoint, "/"),
 		apiKey:   cfg.APIKey,
@@ -61,39 +56,14 @@ func NewClient(cfg config.LLMProviderConfig) *Client {
 		timeout:  timeout,
 		http:     &http.Client{Timeout: timeout + 2*time.Second},
 	}
-
-	if provider == "vertex" {
-		ts, err := google.DefaultTokenSource(context.Background(),
-			"https://www.googleapis.com/auth/cloud-platform",
-		)
-		if err == nil {
-			c.tokenSource = ts
-		}
-		// Build the endpoint from env vars if not explicitly set.
-		if c.endpoint == "" {
-			region := os.Getenv("VERTEX_REGION")
-			projectID := os.Getenv("VERTEX_PROJECT_ID")
-			if region == "" {
-				region = "us-east5"
-			}
-			c.endpoint = fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/anthropic/models",
-				region, projectID, region)
-		}
-	}
-
-	return c
 }
 
 // Complete sends a chat completion request and returns the assistant's reply.
 func (c *Client) Complete(ctx context.Context, messages []ChatMessage) (string, error) {
-	switch c.provider {
-	case "anthropic":
+	if c.provider == "anthropic" {
 		return c.completeAnthropic(ctx, messages)
-	case "vertex":
-		return c.completeVertex(ctx, messages)
-	default:
-		return c.completeOpenAI(ctx, messages) // "openai", "ollama", "groq" use OpenAI-compatible API
 	}
+	return c.completeOpenAI(ctx, messages) // "openai" and "ollama" both use OpenAI-compatible API
 }
 
 // ── OpenAI ────────────────────────────────────────────────────────────────────
@@ -221,86 +191,4 @@ func (c *Client) completeAnthropic(ctx context.Context, messages []ChatMessage) 
 		}
 	}
 	return "", fmt.Errorf("llm: no text content in anthropic response")
-}
-
-// ── Vertex AI ────────────────────────────────────────────────────────────────
-
-func (c *Client) completeVertex(ctx context.Context, messages []ChatMessage) (string, error) {
-	if c.tokenSource == nil {
-		return "", fmt.Errorf("llm: vertex provider requires application default credentials")
-	}
-
-	// Same request body as Anthropic Messages API.
-	var system string
-	var convo []ChatMessage
-	for _, m := range messages {
-		if m.Role == "system" {
-			if system == "" {
-				system = m.Content
-			}
-			continue
-		}
-		convo = append(convo, m)
-	}
-
-	reqBody := map[string]any{
-		"model":             c.model,
-		"max_tokens":        maxTokens,
-		"messages":          convo,
-		"temperature":       0,
-		"anthropic_version": anthropicVersion,
-	}
-	if system != "" {
-		reqBody["system"] = system
-	}
-
-	body, err := json.Marshal(reqBody)
-	if err != nil {
-		return "", err
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, c.timeout)
-	defer cancel()
-
-	// Endpoint: .../models/{MODEL}:rawPredict
-	url := fmt.Sprintf("%s/%s:rawPredict", c.endpoint, c.model)
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
-	if err != nil {
-		return "", err
-	}
-
-	token, err := c.tokenSource.Token()
-	if err != nil {
-		return "", fmt.Errorf("llm: vertex auth: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+token.AccessToken)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := c.http.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return "", fmt.Errorf("llm: status %d: %s", resp.StatusCode, b)
-	}
-
-	// Response format is the same as Anthropic Messages API.
-	var out struct {
-		Content []struct {
-			Type string `json:"type"`
-			Text string `json:"text"`
-		} `json:"content"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
-		return "", err
-	}
-	for _, block := range out.Content {
-		if block.Type == "text" {
-			return block.Text, nil
-		}
-	}
-	return "", fmt.Errorf("llm: no text content in vertex response")
 }


### PR DESCRIPTION
## Summary

The `clawvisor pair` command now mints a fresh magic link token from the server's localhost-only endpoint instead of reusing the stale token from `.local-session`, which may already have been consumed by a previous command.

## Changes

Modified `internal/daemon/pair.go` to call `requestMagicToken()` to obtain a valid (unused) magic token before attempting to authenticate the API client for the pairing session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)