### PR TITLE
Add E2E encryption to device-authenticated endpoints

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -415,9 +415,9 @@ func (s *Server) routes() http.Handler {
 	mux.Handle("GET /api/devices", user(devicesHandler.List))
 	mux.Handle("DELETE /api/devices/{id}", user(devicesHandler.Delete))
 	requireDevice := middleware.RequireDevice(s.store)
-	mux.Handle("POST /api/devices/{id}/action", requireDevice(http.HandlerFunc(devicesHandler.Action)))
-	mux.Handle("POST /api/devices/{id}/token", requireDevice(http.HandlerFunc(devicesHandler.MintToken)))
-	mux.Handle("POST /api/devices/{id}/push-to-start-token", requireDevice(http.HandlerFunc(devicesHandler.UpdatePushToStartToken)))
+	mux.Handle("POST /api/devices/{id}/action", requireDevice(e2e(http.HandlerFunc(devicesHandler.Action))))
+	mux.Handle("POST /api/devices/{id}/token", requireDevice(e2e(http.HandlerFunc(devicesHandler.MintToken))))
+	mux.Handle("POST /api/devices/{id}/push-to-start-token", requireDevice(e2e(http.HandlerFunc(devicesHandler.UpdatePushToStartToken))))
 
 	// Guard (agent token — Claude Code permission check)
 	guardHandler := handlers.NewGuardHandler(s.store, verifier, s.adapterReg, s.logger)


### PR DESCRIPTION
## Summary

Extends E2E encryption middleware to device-authenticated endpoints for consistent encryption across all sensitive device communication. The token mint, action, and push-to-start token endpoints now require and return encrypted payloads.

## Changes

- Wrap `/api/devices/{id}/token` with e2e() middleware
- Wrap `/api/devices/{id}/action` with e2e() middleware
- Wrap `/api/devices/{id}/push-to-start-token` with e2e() middleware

🤖 Generated with [Claude Code](https://claude.com/claude-code)