### PR TITLE
Add setup disclosures, terms acceptance, and fix Ctrl+C

### DIFF
--- a/cmd/clawvisor/cmd_setup.go
+++ b/cmd/clawvisor/cmd_setup.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/charmbracelet/huh"
 	"github.com/clawvisor/clawvisor/internal/daemon"
 	"github.com/spf13/cobra"
 )
@@ -10,8 +11,13 @@ var setupCmd = &cobra.Command{
 	Short: "Run the first-time setup wizard",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		pair, _ := cmd.Flags().GetBool("pair")
-		return daemon.Setup(daemon.SetupOptions{Pair: pair})
+		err := daemon.Setup(daemon.SetupOptions{Pair: pair})
+		if err == huh.ErrUserAborted {
+			return nil
+		}
+		return err
 	},
+	SilenceUsage: true,
 }
 
 func init() {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -74,7 +74,7 @@ llm:
   # created. Produces a risk level (low/medium/high/critical) shown in the dashboard.
   # Env overrides: CLAWVISOR_LLM_TASK_RISK_{ENABLED,PROVIDER,ENDPOINT,API_KEY,MODEL}
   task_risk:
-    enabled: false
+    enabled: true              # on by default; set to false to disable
     # provider, endpoint, api_key, model, timeout_seconds inherit from top-level llm
     # if not set here. Uncomment to override:
     # provider: anthropic
@@ -88,6 +88,8 @@ llm:
   # into subsequent intent verification prompts to detect when an agent targets
   # entities that didn't appear in prior results. Activated per-request by the
   # agent passing a session_id in gateway requests.
+  # NOTE: When enabled, the output of your API calls (e.g. email bodies, messages,
+  # contact details) is sent to the configured LLM provider for entity extraction.
   # Env overrides: CLAWVISOR_LLM_CHAIN_CONTEXT_{ENABLED,PROVIDER,ENDPOINT,API_KEY,MODEL}
   chain_context:
     enabled: false

--- a/internal/daemon/run.go
+++ b/internal/daemon/run.go
@@ -117,6 +117,11 @@ func runWithServiceSetup(dataDir, cfgPath string, logger *slog.Logger, phase int
 
 	// Run the interactive service setup wizard.
 	needsRestart, err := runServiceSetup(apiClient, dataDir)
+	if err == huh.ErrUserAborted {
+		cancel()
+		<-serverErrCh
+		return huh.ErrUserAborted
+	}
 	if err != nil {
 		logger.Warn("service setup error", "err", err)
 		// Non-fatal: user can configure services later via 'clawvisor setup'.

--- a/internal/daemon/services_setup.go
+++ b/internal/daemon/services_setup.go
@@ -63,7 +63,7 @@ func runServiceSetup(apiClient *client.Client, dataDir string) (needsRestart boo
 		selected, err := presentServiceMenu(services)
 		if err != nil {
 			if err == huh.ErrUserAborted {
-				return needsRestart, nil
+				return needsRestart, huh.ErrUserAborted
 			}
 			return false, err
 		}

--- a/internal/daemon/setup.go
+++ b/internal/daemon/setup.go
@@ -41,11 +41,34 @@ func runDaemonSetup(dataDir string) error {
 
 	printDaemonBanner()
 
+	fmt.Println(dim.Padding(0, 2).Render("By continuing, you agree to the Clawvisor Terms of Service"))
+	fmt.Println(dim.Padding(0, 2).Render("and Privacy Policy:"))
+	fmt.Println(dim.Padding(0, 2).Render("  https://clawvisor.com/terms"))
+	fmt.Println(dim.Padding(0, 2).Render("  https://clawvisor.com/privacy"))
+	fmt.Println()
+
+	accepted := false
+	if err := huh.NewForm(
+		huh.NewGroup(
+			huh.NewConfirm().
+				Title("Do you agree to the Terms of Service and Privacy Policy?").
+				Affirmative("I agree").
+				Negative("Cancel").
+				Value(&accepted),
+		),
+	).Run(); err != nil {
+		return err
+	}
+	if !accepted {
+		fmt.Println("\n  Setup cancelled.")
+		return nil
+	}
+
 	cfg, err := collectDaemonConfig()
 	if err != nil {
 		if err == huh.ErrUserAborted {
 			fmt.Println("\n  Aborted. No files were written.")
-			return nil
+			return huh.ErrUserAborted
 		}
 		return err
 	}
@@ -91,10 +114,27 @@ func runDaemonSetup(dataDir string) error {
 
 func printDaemonBanner() {
 	fmt.Println()
-	fmt.Println(bold.Padding(0, 2).Render("Clawvisor Daemon Setup"))
+	fmt.Println(bold.Padding(0, 2).Render("Clawvisor Setup"))
 	fmt.Println(section.Render("─────────────────────────────────────────"))
 	fmt.Println()
-	fmt.Println(dim.Padding(0, 2).Render("The daemon runs locally on this machine."))
+
+	fmt.Println(bold.Padding(0, 2).Render("How Clawvisor Works"))
+	fmt.Println(dim.Padding(0, 2).Render("Clawvisor is a credential-vaulting gateway that runs locally on this"))
+	fmt.Println(dim.Padding(0, 2).Render("machine. It stores API credentials in an encrypted local vault and"))
+	fmt.Println(dim.Padding(0, 2).Render("proxies requests from AI agents to external APIs (Google, GitHub,"))
+	fmt.Println(dim.Padding(0, 2).Render("Slack, etc.), enforcing authorization policies and human approval."))
+	fmt.Println()
+
+	fmt.Println(bold.Padding(0, 2).Render("Public Relay"))
+	fmt.Println(dim.Padding(0, 2).Render("This instance will connect to relay.clawvisor.com so you can"))
+	fmt.Println(dim.Padding(0, 2).Render("access it remotely and receive mobile push notifications."))
+	fmt.Println(dim.Padding(0, 2).Render("The relay sees connection metadata (daemon ID, public key, IP)."))
+	fmt.Println(dim.Padding(0, 2).Render("Tunnel traffic is end-to-end encrypted when your client supports"))
+	fmt.Println(dim.Padding(0, 2).Render("it, but some clients (e.g. Claude Desktop) do not yet support"))
+	fmt.Println(dim.Padding(0, 2).Render("E2E encryption — in that case traffic is TLS-encrypted in transit"))
+	fmt.Println(dim.Padding(0, 2).Render("but readable by the relay."))
+	fmt.Println()
+
 	fmt.Println(dim.Padding(0, 2).Render("SQLite, vault, and networking are auto-configured."))
 	fmt.Println(dim.Padding(0, 2).Render("You just need to provide an LLM API key."))
 	fmt.Println()
@@ -225,14 +265,8 @@ func stepDaemonLLM(cfg *daemonConfig) error {
 	return huh.NewForm(
 		huh.NewGroup(
 			huh.NewConfirm().
-				Title("Enable task risk assessment?").
-				Description("Evaluates scope and purpose coherence when tasks are created.").
-				Affirmative("Yes").
-				Negative("No").
-				Value(&cfg.taskRiskEnabled),
-			huh.NewConfirm().
 				Title("Enable chain context tracking?").
-				Description("Extracts entity references from results so multi-step tasks stay on-target.").
+				Description("Sends API call output to your LLM provider to extract entity references\n(IDs, emails, etc.) for multi-step task validation. Disable in config.yaml later.").
 				Affirmative("Yes").
 				Negative("No").
 				Value(&cfg.chainContextEnabled),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -268,6 +268,11 @@ func Default() *Config {
 				FailClosed:      true,
 				CacheTTLSeconds: 60,
 			},
+			TaskRisk: TaskRiskConfig{
+				LLMProviderConfig: LLMProviderConfig{
+					Enabled: true,
+				},
+			},
 		},
 		MCP: MCPConfig{
 			Enabled:         true,


### PR DESCRIPTION
## Summary
- Expand the setup banner with architecture overview and public relay disclosure (connection metadata, E2E encryption caveats for clients that don't support it)
- Require Terms of Service and Privacy Policy acceptance before setup proceeds
- Enable task risk assessment by default (removed interactive prompt; disable via config.yaml)
- Add explicit LLM data disclosure to the chain context tracking prompt
- Fix Ctrl+C handling: propagate `ErrUserAborted` through the entire setup flow so aborting at any point (daemon config, service connection, etc.) exits cleanly instead of falling through to later steps

## Test plan
- [ ] Run `clawvisor setup` and verify the new banner, relay disclosure, and terms acceptance prompt appear
- [ ] Decline terms and verify setup exits cleanly
- [ ] Press Ctrl+C at each setup stage (terms, LLM selection, API key, chain context, service menu) and verify clean exit
- [ ] Complete full setup and verify task_risk defaults to enabled in generated config.yaml
- [ ] Verify chain context prompt shows LLM data disclosure text

🤖 Generated with [Claude Code](https://claude.com/claude-code)