### PR TITLE
fix: return proper JSON error for dashboard token endpoint

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -329,10 +329,11 @@ func (s *Server) routes() http.Handler {
 	mux.Handle("POST /api/auth/logout", user(authHandler.Logout))
 	mux.Handle("GET /api/me", user(authHandler.Me))
 
-	// Magic link auth (local mode only)
+	// Magic link auth — /local is always registered so the CLI gets a
+	// proper JSON error instead of the SPA HTML when magic links are disabled.
+	mux.Handle("POST /api/auth/magic/local", authRateLimited(authHandler.GenerateMagicLocal))
 	if s.magicStore != nil {
 		mux.Handle("POST /api/auth/magic", authRateLimited(authHandler.ExchangeMagic))
-		mux.Handle("POST /api/auth/magic/local", authRateLimited(authHandler.GenerateMagicLocal))
 	}
 
 	// Password auth routes are registered only when the PasswordAuth feature is enabled

--- a/internal/daemon/status.go
+++ b/internal/daemon/status.go
@@ -3,9 +3,11 @@ package daemon
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/clawvisor/clawvisor/internal/browser"
@@ -101,20 +103,42 @@ func requestMagicToken(serverURL string) (string, error) {
 	}
 	defer resp.Body.Close()
 
+	// Read the body up-front so we can include it in error messages.
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+
 	if resp.StatusCode != http.StatusOK {
+		// Try to extract a JSON error message from the response.
+		var apiErr struct {
+			Message string `json:"message"`
+		}
+		if json.Unmarshal(body, &apiErr) == nil && apiErr.Message != "" {
+			return "", fmt.Errorf("server returned %d: %s", resp.StatusCode, apiErr.Message)
+		}
 		return "", fmt.Errorf("server returned %d", resp.StatusCode)
+	}
+
+	ct := resp.Header.Get("Content-Type")
+	if ct != "" && !strings.HasPrefix(ct, "application/json") {
+		return "", fmt.Errorf("server returned unexpected content type %q (is the daemon up to date?)", ct)
 	}
 
 	var result struct {
 		Token string `json:"token"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return "", fmt.Errorf("decoding response: %w", err)
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", fmt.Errorf("unexpected response from server (expected JSON, got %q); is the daemon up to date?", truncate(string(body), 80))
 	}
 	if result.Token == "" {
 		return "", fmt.Errorf("server returned empty token")
 	}
 	return result.Token, nil
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
 }
 
 // PrintStatus prints the daemon status to stdout.


### PR DESCRIPTION
## Summary
- Always register `POST /api/auth/magic/local` so it returns a proper JSON error instead of falling through to the SPA HTML when magic links are disabled or the daemon is outdated
- Improve `requestMagicToken` client-side error handling: check Content-Type, extract JSON error messages, and surface actionable hints (e.g. "is the daemon up to date?") instead of the cryptic `invalid character '<'` decode error

## Test plan
- [ ] Run `clawvisor dashboard` against a running daemon — should work as before
- [ ] Run `clawvisor dashboard` against a daemon with magic links disabled — should show a clear error message
- [ ] Run `clawvisor dashboard` against an older daemon serving SPA HTML — should show "is the daemon up to date?" hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)