### PR TITLE
feat: warn when CLI and daemon versions differ

### DIFF
--- a/internal/daemon/status.go
+++ b/internal/daemon/status.go
@@ -9,14 +9,16 @@ import (
 	"time"
 
 	"github.com/clawvisor/clawvisor/internal/browser"
+	"github.com/clawvisor/clawvisor/pkg/version"
 )
 
 // Status holds the daemon's current state.
 type Status struct {
-	Running   bool   `json:"running"`
-	PID       int    `json:"pid,omitempty"`
-	ServerURL string `json:"server_url,omitempty"`
-	DaemonID  string `json:"daemon_id,omitempty"`
+	Running       bool   `json:"running"`
+	PID           int    `json:"pid,omitempty"`
+	ServerURL     string `json:"server_url,omitempty"`
+	DaemonID      string `json:"daemon_id,omitempty"`
+	DaemonVersion string `json:"daemon_version,omitempty"`
 }
 
 // CheckStatus reads the local session file and pings the server.
@@ -50,7 +52,8 @@ func CheckStatus() (*Status, error) {
 	if resp.StatusCode == http.StatusOK {
 		pid := readPIDFile(filepath.Join(dataDir, ".daemon.pid"))
 		daemonID, _ := readDaemonID(filepath.Join(dataDir, "config.yaml"))
-		return &Status{Running: true, ServerURL: session.ServerURL, PID: pid, DaemonID: daemonID}, nil
+		daemonVer := fetchDaemonVersion(client, session.ServerURL)
+		return &Status{Running: true, ServerURL: session.ServerURL, PID: pid, DaemonID: daemonID, DaemonVersion: daemonVer}, nil
 	}
 	return &Status{ServerURL: session.ServerURL}, nil
 }
@@ -117,6 +120,28 @@ func requestMagicToken(serverURL string) (string, error) {
 	return result.Token, nil
 }
 
+// fetchDaemonVersion queries the running daemon's /api/version endpoint and
+// returns its current version string, or empty on failure.
+func fetchDaemonVersion(client *http.Client, serverURL string) string {
+	resp, err := client.Get(serverURL + "/api/version")
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return ""
+	}
+
+	var info struct {
+		Current string `json:"current"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+		return ""
+	}
+	return info.Current
+}
+
 // PrintStatus prints the daemon status to stdout.
 func PrintStatus(s *Status) {
 	if s.Running {
@@ -127,6 +152,10 @@ func PrintStatus(s *Status) {
 		}
 		if s.DaemonID != "" {
 			fmt.Printf("  Daemon ID: %s\n", s.DaemonID)
+		}
+		cliVersion := version.GetCurrent()
+		if s.DaemonVersion != "" && cliVersion != "" && s.DaemonVersion != cliVersion {
+			fmt.Printf("  Warning: daemon is running %s but this CLI is %s — consider running 'clawvisor restart'\n", s.DaemonVersion, cliVersion)
 		}
 	} else {
 		fmt.Println("  Daemon is not running.")


### PR DESCRIPTION
## Summary
- `clawvisor status` now fetches the running daemon's version via `/api/version` and compares it to the CLI binary's version.
- If the versions differ (e.g. after updating the binary without restarting the daemon), a warning is printed suggesting `clawvisor restart`.
- Degrades gracefully — no warning if the daemon version can't be fetched (e.g. older daemon without the endpoint).

## Test plan
- [ ] Run `clawvisor status` with matching CLI/daemon versions — no warning shown
- [ ] Update the binary without restarting the daemon — warning appears with both versions
- [ ] Stop the daemon and run `clawvisor status` — no version warning, just "not running"

🤖 Generated with [Claude Code](https://claude.com/claude-code)