### PR TITLE
fix: trigger release binaries on tag push instead of release event

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,8 +1,9 @@
 name: Release Binaries
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "v*"
   workflow_dispatch:
     inputs:
       version:
@@ -33,10 +34,21 @@ jobs:
       - name: Build frontend
         run: cd web && npm ci && npm run build
 
+      - name: Determine version tag
+        id: tag
+        run: echo "version=${{ github.ref_name || inputs.version }}" >> "$GITHUB_OUTPUT"
+
       - name: Build binaries and checksums
-        run: scripts/build-release.sh "${{ github.event.release.tag_name || inputs.version }}"
+        run: scripts/build-release.sh "${{ steps.tag.outputs.version }}"
 
       - name: Upload release assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "${{ github.event.release.tag_name || inputs.version }}" dist/*
+        run: |
+          # Wait for release-please to create the GitHub Release (may lag behind the tag)
+          for i in 1 2 3 4 5; do
+            gh release view "${{ steps.tag.outputs.version }}" && break
+            echo "Release not found yet, retrying in 30s... ($i/5)"
+            sleep 30
+          done
+          gh release upload "${{ steps.tag.outputs.version }}" dist/* --clobber


### PR DESCRIPTION
## Summary
- Switches the release-binaries workflow trigger from `release: published` to `push: tags: v*`, because events created by `GITHUB_TOKEN` (like release-please's release) don't trigger other workflows.
- Adds a retry loop before uploading assets to handle the race between the tag push and release-please creating the GitHub Release.
- Uses `--clobber` on upload for safe re-runs.

## Test plan
- [ ] Merge and verify the next release-please tag push triggers the release-binaries workflow
- [ ] Verify binaries are uploaded to the GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)