### PR TITLE
fix: build release binaries inline and add make install

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,9 +1,6 @@
 name: Release Binaries
 
 on:
-  push:
-    tags:
-      - "v*"
   workflow_dispatch:
     inputs:
       version:
@@ -34,21 +31,10 @@ jobs:
       - name: Build frontend
         run: cd web && npm ci && npm run build
 
-      - name: Determine version tag
-        id: tag
-        run: echo "version=${{ github.ref_name || inputs.version }}" >> "$GITHUB_OUTPUT"
-
       - name: Build binaries and checksums
-        run: scripts/build-release.sh "${{ steps.tag.outputs.version }}"
+        run: scripts/build-release.sh "${{ inputs.version }}"
 
       - name: Upload release assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Wait for release-please to create the GitHub Release (may lag behind the tag)
-          for i in 1 2 3 4 5; do
-            gh release view "${{ steps.tag.outputs.version }}" && break
-            echo "Release not found yet, retrying in 30s... ($i/5)"
-            sleep 30
-          done
-          gh release upload "${{ steps.tag.outputs.version }}" dist/* --clobber
+        run: gh release upload "${{ inputs.version }}" dist/* --clobber

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,6 +27,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
 
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,8 +11,42 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  build-binaries:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Build frontend
+        run: cd web && npm ci && npm run build
+
+      - name: Build binaries and checksums
+        run: scripts/build-release.sh "${{ needs.release-please.outputs.tag_name }}"
+
+      - name: Upload release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ needs.release-please.outputs.tag_name }}" dist/* --clobber

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test run run-sqlite migrate lint clean setup tui eval-intent release
+.PHONY: build install test run run-sqlite migrate lint clean setup tui eval-intent release
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null | sed 's/^v//' || echo dev)
 LDFLAGS := -ldflags="-s -w -X github.com/clawvisor/clawvisor/pkg/version.Version=$(VERSION)"
@@ -14,6 +14,13 @@ build-server: web/dist
 web/dist: $(shell find web/src -type f)
 	cd web && npm install && npm run build
 	@touch web/dist
+
+install: build
+	mkdir -p $(HOME)/.clawvisor/bin $(HOME)/.clawvisor/logs
+	cp bin/clawvisor $(HOME)/.clawvisor/bin/clawvisor
+	@echo "Installed to $(HOME)/.clawvisor/bin/clawvisor"
+	@echo 'Add to your PATH: export PATH="$$HOME/.clawvisor/bin:$$PATH"'
+	$(HOME)/.clawvisor/bin/clawvisor install
 
 # ── Test ───────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Move release binary builds into the release-please workflow as a second job, fixing the issue where `GITHUB_TOKEN`-created tag pushes don't trigger other workflows
- Simplify `release-binaries.yml` to workflow_dispatch-only (for manual reruns)
- Checkout the tagged commit in the build job so binaries match the release
- Add `make install` target for installing from source

## Test plan
- [ ] Merge and verify the next release-please run builds and uploads binaries
- [ ] Run `make install` from a fresh clone and verify it works
- [ ] Manually trigger `Release Binaries` workflow for v0.7.0 to backfill

🤖 Generated with [Claude Code](https://claude.com/claude-code)