### PR TITLE
fix: release binaries, make install, and CI type errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,10 @@ web/dist: $(shell find web/src -type f)
 install: build
 	mkdir -p $(HOME)/.clawvisor/bin $(HOME)/.clawvisor/logs
 	cp bin/clawvisor $(HOME)/.clawvisor/bin/clawvisor
-	@echo "Installed to $(HOME)/.clawvisor/bin/clawvisor"
-	@echo 'Add to your PATH: export PATH="$$HOME/.clawvisor/bin:$$PATH"'
+	[ "$$(uname)" = "Darwin" ] && codesign -s - $(HOME)/.clawvisor/bin/clawvisor 2>/dev/null || true
 	$(HOME)/.clawvisor/bin/clawvisor install
+	@echo ""
+	@echo 'Add to your PATH: export PATH="$$HOME/.clawvisor/bin:$$PATH"'
 
 # ── Test ───────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Moves release binary builds into the release-please workflow as a second job, fixing the issue where GITHUB_TOKEN tag pushes don't trigger separate workflows
- Simplifies release-binaries.yml to workflow_dispatch only (for manual reruns)
- Adds `make install` target for installing from source, with ad-hoc codesigning on macOS to avoid Gatekeeper kills
- Adds missing `vite-env.d.ts` to fix TS2882 CI error on CSS side-effect imports

## Test plan
- [ ] Merge and verify next release-please run builds and uploads binaries
- [ ] Run `make install` from a clean clone on macOS
- [ ] Verify CI passes (tsc no longer fails on CSS import)

🤖 Generated with [Claude Code](https://claude.com/claude-code)