### PR TITLE
feat: prompt to open dashboard after install

### DIFF
--- a/internal/daemon/install.go
+++ b/internal/daemon/install.go
@@ -11,6 +11,8 @@ import (
 	"syscall"
 	"text/template"
 	"time"
+
+	"github.com/charmbracelet/huh"
 )
 
 const launchdLabel = "com.clawvisor.daemon"
@@ -146,6 +148,7 @@ func Install() error {
 		return err
 	}
 	printAgentSetupInstructions(dataDir)
+	promptDashboardOpen(dataDir)
 	return nil
 }
 
@@ -236,6 +239,52 @@ func installSystemd(home string, data installData) error {
 	fmt.Println("  To start now: clawvisor start")
 	fmt.Println("  To stop:      clawvisor stop")
 	return nil
+}
+
+// promptDashboardOpen asks the user whether they want to open the dashboard
+// now, and either opens it or prints the command to do so later.
+func promptDashboardOpen(dataDir string) {
+	openNow := true
+	err := huh.NewForm(
+		huh.NewGroup(
+			huh.NewConfirm().
+				Title("Open the dashboard now?").
+				Affirmative("Yes").
+				Negative("No").
+				Value(&openNow),
+		),
+	).Run()
+	if err != nil {
+		// User aborted or input error — just print the hint.
+		fmt.Println(dim.Padding(0, 2).Render("Run `clawvisor dashboard` to open the dashboard."))
+		return
+	}
+
+	if !openNow {
+		fmt.Println(dim.Padding(0, 2).Render("Run `clawvisor dashboard` to open the dashboard."))
+		return
+	}
+
+	// The daemon was just started via the service manager — wait for it to
+	// become ready and write the local session file before requesting a token.
+	fmt.Println(dim.Padding(0, 2).Render("Waiting for daemon to start..."))
+	ready := false
+	for i := 0; i < 30; i++ {
+		if serverURL, _, err := readLocalSession(dataDir); err == nil && serverURL != "" {
+			ready = true
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	if !ready {
+		fmt.Println(dim.Padding(0, 2).Render("Daemon hasn't started yet. Run `clawvisor dashboard` once it's ready."))
+		return
+	}
+
+	if err := Dashboard(false); err != nil {
+		fmt.Println(dim.Padding(0, 2).Render("Could not open dashboard: " + err.Error()))
+		fmt.Println(dim.Padding(0, 2).Render("Run `clawvisor dashboard` to try again."))
+	}
 }
 
 // Uninstall removes the service definition.


### PR DESCRIPTION
## Summary
- After `clawvisor install` completes, prompts the user to open the dashboard immediately in their browser
- If declined (or on error), prints `clawvisor dashboard` as a hint so users know the command exists
- Waits up to 15s for the daemon to become ready before opening, with graceful fallback

## Test plan
- [ ] Run `clawvisor install` on a fresh setup and verify the "Open the dashboard now?" prompt appears after the agent setup URL
- [ ] Select "Yes" and confirm the dashboard opens in the browser
- [ ] Select "No" and confirm the `clawvisor dashboard` hint is printed

🤖 Generated with [Claude Code](https://claude.com/claude-code)