### PR TITLE
fix: pass bundle_id to push service for correct APNs topic

### DIFF
--- a/internal/api/handlers/devices.go
+++ b/internal/api/handlers/devices.go
@@ -136,6 +136,7 @@ func (h *DevicesHandler) CompletePairing(w http.ResponseWriter, r *http.Request)
 		Code         string `json:"code"`
 		DeviceName   string `json:"device_name"`
 		DeviceToken  string `json:"device_token"`
+		BundleID     string `json:"bundle_id"`
 	}
 	if !decodeJSON(w, r, &body) {
 		return
@@ -198,6 +199,10 @@ func (h *DevicesHandler) CompletePairing(w http.ResponseWriter, r *http.Request)
 		}
 	}
 
+	bundleID := body.BundleID
+	if bundleID == "" {
+		bundleID = "com.clawvisor.app"
+	}
 	device := &store.PairedDevice{
 		UserID:        session.UserID,
 		DeviceName:    body.DeviceName,
@@ -211,7 +216,7 @@ func (h *DevicesHandler) CompletePairing(w http.ResponseWriter, r *http.Request)
 
 	// Register with push service if available.
 	if h.pushN != nil {
-		if err := h.pushN.RegisterDevice(r.Context(), body.DeviceToken); err != nil {
+		if err := h.pushN.RegisterDevice(r.Context(), body.DeviceToken, bundleID); err != nil {
 			h.logger.Warn("failed to register device with push service", "err", err)
 		}
 	}

--- a/internal/notify/push/notifier.go
+++ b/internal/notify/push/notifier.go
@@ -62,10 +62,11 @@ func (n *Notifier) EmitDecision(d notify.CallbackDecision) {
 }
 
 // RegisterDevice registers a device token with the push service.
-func (n *Notifier) RegisterDevice(ctx context.Context, deviceToken string) error {
+func (n *Notifier) RegisterDevice(ctx context.Context, deviceToken, bundleID string) error {
 	payload := map[string]string{
 		"daemon_id":    n.daemonID,
 		"device_token": deviceToken,
+		"bundle_id":    bundleID,
 	}
 	body, _ := json.Marshal(payload)
 	return n.signedPost(ctx, "/api/tokens/register", body)

--- a/internal/notify/push/notifier_test.go
+++ b/internal/notify/push/notifier_test.go
@@ -185,7 +185,7 @@ func TestRegisterDevice(t *testing.T) {
 
 	n, _ := testNotifier(t, srv, nil)
 
-	err := n.RegisterDevice(context.Background(), "apns-token-abc")
+	err := n.RegisterDevice(context.Background(), "apns-token-abc", "com.clawvisor.app.Clip")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -197,6 +197,9 @@ func TestRegisterDevice(t *testing.T) {
 	}
 	if receivedBody["device_token"] != "apns-token-abc" {
 		t.Errorf("expected device_token 'apns-token-abc', got %q", receivedBody["device_token"])
+	}
+	if receivedBody["bundle_id"] != "com.clawvisor.app.Clip" {
+		t.Errorf("expected bundle_id 'com.clawvisor.app.Clip', got %q", receivedBody["bundle_id"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- Accept `bundle_id` from the mobile app during device pairing (`POST /api/devices/pair/complete`) and forward it to the push service at token registration time
- Defaults to `com.clawvisor.app` if not provided, maintaining backwards compatibility with existing clients
- The push service uses this to set the correct `apns-topic` header, fixing push notification delivery for app clips

## Test plan
- [x] Existing push notifier tests pass
- [ ] Pair a device from the main app (no `bundle_id` sent) — verify push notifications still work
- [ ] Pair a device from the app clip (`bundle_id: com.clawvisor.app.Clip`) — verify push notifications are delivered

🤖 Generated with [Claude Code](https://claude.com/claude-code)