### PR TITLE
feat: add build-time staging environment support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,16 @@
-.PHONY: build install test run run-sqlite migrate lint clean setup tui eval-intent release test-e2e-install
+.PHONY: build build-staging install test run run-sqlite run-staging migrate lint clean setup tui eval-intent release test-e2e-install
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null | sed 's/^v//' || echo dev)
-LDFLAGS := -ldflags="-s -w -X github.com/clawvisor/clawvisor/pkg/version.Version=$(VERSION)"
+ENVIRONMENT ?= production
+LDFLAGS := -ldflags="-s -w -X github.com/clawvisor/clawvisor/pkg/version.Version=$(VERSION) -X github.com/clawvisor/clawvisor/pkg/version.Environment=$(ENVIRONMENT)"
 
 # ── Build ──────────────────────────────────────────────────────────────────────
 
 build: web/dist
 	go build $(LDFLAGS) -o bin/clawvisor ./cmd/clawvisor
+
+build-staging: web/dist
+	$(MAKE) build ENVIRONMENT=staging
 
 build-server: web/dist
 	go build $(LDFLAGS) -o bin/clawvisor-server ./cmd/server
@@ -45,6 +49,9 @@ test-e2e-install: web/dist
 # Use OPEN=1 to auto-open the magic link in a browser: make run OPEN=1
 run: web/dist
 	@go build $(LDFLAGS) -o bin/clawvisor ./cmd/clawvisor && bin/clawvisor server $(if $(OPEN),--open,)
+
+run-staging: web/dist
+	@$(MAKE) run ENVIRONMENT=staging
 
 run-sqlite:
 	@go build $(LDFLAGS) -o bin/clawvisor ./cmd/clawvisor && bin/clawvisor server

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/clawvisor/clawvisor/internal/notify/push"
 	pkgauth "github.com/clawvisor/clawvisor/pkg/auth"
 	"github.com/clawvisor/clawvisor/pkg/config"
+	"github.com/clawvisor/clawvisor/pkg/version"
 	"github.com/clawvisor/clawvisor/internal/intent"
 	"github.com/clawvisor/clawvisor/internal/taskrisk"
 	"github.com/clawvisor/clawvisor/pkg/notify"
@@ -394,7 +395,7 @@ func (s *Server) routes() http.Handler {
 	var pairingHandler *handlers.PairingHandler
 	if s.daemonID != "" {
 		pairingHandler = handlers.NewPairingHandler(s.daemonID)
-		corsOrigins := []string{"https://relay.clawvisor.com", "https://app.clawvisor.com"}
+		corsOrigins := version.CORSOrigins()
 		mux.Handle("GET /api/pairing/code",
 			middleware.CORSAllowOrigins(corsOrigins, http.HandlerFunc(pairingHandler.GenerateCode)))
 		mux.Handle("OPTIONS /api/pairing/code",

--- a/internal/daemon/setup.go
+++ b/internal/daemon/setup.go
@@ -13,6 +13,8 @@ import (
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/lipgloss"
 	"gopkg.in/yaml.v3"
+
+	"github.com/clawvisor/clawvisor/pkg/version"
 )
 
 var (
@@ -340,7 +342,7 @@ func runDaemonSetup(dataDir string) error {
 		// Register with relay to get daemon_id.
 		relayURL := os.Getenv("CLAWVISOR_RELAY_URL")
 		if relayURL == "" {
-			relayURL = "wss://relay.clawvisor.com"
+			relayURL = version.RelayURL()
 		}
 		if err := registerWithRelay(dataDir, relayURL); err != nil {
 			fmt.Println(dim.Padding(0, 2).Render("  Warning: relay registration failed: " + err.Error()))
@@ -714,21 +716,11 @@ func writeDaemonConfig(cfg *daemonConfig, dataDir, jwtSecret, path string) error
 	fmt.Fprintf(&b, "  enabled: %t\n", cfg.telemetryEnabled)
 
 	if cfg.relayEnabled {
-		relayURL := os.Getenv("CLAWVISOR_RELAY_URL")
-		if relayURL == "" {
-			relayURL = "wss://relay.clawvisor.com"
-		}
-		pushURL := os.Getenv("CLAWVISOR_PUSH_URL")
-		if pushURL == "" {
-			pushURL = "https://push.clawvisor.com"
-		}
 		fmt.Fprintf(&b, "\npush:\n")
 		fmt.Fprintf(&b, "  enabled: true\n")
-		fmt.Fprintf(&b, "  url: %s\n", yamlQuote(pushURL))
 
 		fmt.Fprintf(&b, "\nrelay:\n")
 		fmt.Fprintf(&b, "  enabled: true\n")
-		fmt.Fprintf(&b, "  url: %s\n", yamlQuote(relayURL))
 		fmt.Fprintf(&b, "  key_file: %s\n", yamlQuote(filepath.Join(dataDir, "daemon-ed25519.key")))
 		fmt.Fprintf(&b, "  e2e_key_file: %s\n", yamlQuote(filepath.Join(dataDir, "daemon-x25519.key")))
 	} else {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/clawvisor/clawvisor/pkg/version"
 )
 
 // AutoConfigured tracks which settings were auto-resolved (not explicitly set).
@@ -287,7 +289,7 @@ func Default() *Config {
 			Auth:      RateLimitBucket{Limit: 5, Window: 60},
 		},
 		Relay: RelayConfig{
-			URL:                "wss://relay.clawvisor.com",
+			URL:                version.RelayURL(),
 			KeyFile:            "daemon-ed25519.key",
 			E2EKeyFile:         "daemon-x25519.key",
 			ReconnectBaseDelay: "1s",
@@ -299,7 +301,7 @@ func Default() *Config {
 			LogFile: "logs/daemon.log",
 		},
 		Push: PushConfig{
-			URL: "https://push.clawvisor.com",
+			URL: version.PushURL(),
 		},
 		Services: ServicesConfig{
 			GitHub:   GitHubServicesConfig{Enabled: true},

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -14,6 +14,39 @@ import (
 // Example: go build -ldflags="-X github.com/clawvisor/clawvisor/pkg/version.Version=0.3.0"
 var Version = "dev"
 
+// Environment is set at build time via -ldflags. Valid values: "production" (default), "staging".
+// Example: go build -ldflags="-X github.com/clawvisor/clawvisor/pkg/version.Environment=staging"
+var Environment = "production"
+
+// IsStaging returns true when the binary was built for the staging environment.
+func IsStaging() bool {
+	return Environment == "staging"
+}
+
+// RelayURL returns the default relay WebSocket URL for the current environment.
+func RelayURL() string {
+	if IsStaging() {
+		return "wss://relay.staging.clawvisor.com"
+	}
+	return "wss://relay.clawvisor.com"
+}
+
+// PushURL returns the default push service URL for the current environment.
+func PushURL() string {
+	if IsStaging() {
+		return "https://push.staging.clawvisor.com"
+	}
+	return "https://push.clawvisor.com"
+}
+
+// CORSOrigins returns the allowed CORS origins for the current environment.
+func CORSOrigins() []string {
+	if IsStaging() {
+		return []string{"https://relay.staging.clawvisor.com", "https://app.staging.clawvisor.com"}
+	}
+	return []string{"https://relay.clawvisor.com", "https://app.clawvisor.com"}
+}
+
 const (
 	githubOwner = "clawvisor"
 	githubRepo  = "clawvisor"

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -6,6 +6,9 @@ set -euo pipefail
 #
 # By default, discovers the installed binary path from the launchd plist
 # (macOS) or systemd unit (Linux). Override with CLAWVISOR_BIN.
+#
+# Set CLAWVISOR_ENV to "staging" to build against staging services.
+# Example: CLAWVISOR_ENV=staging ./scripts/upgrade.sh
 
 PLIST="$HOME/Library/LaunchAgents/com.clawvisor.daemon.plist"
 SYSTEMD_UNIT="$HOME/.config/systemd/user/clawvisor.service"
@@ -59,8 +62,12 @@ if [[ -f "$WEBDIR/package.json" ]]; then
     cp -R "$WEBDIR/dist/." "$FRONTEND_INSTALL_DIR/"
 fi
 
-echo "  Building backend from $REPO_ROOT ..."
-(cd "$REPO_ROOT" && go build -o "$BIN" ./cmd/clawvisor/)
+ENVIRONMENT="${CLAWVISOR_ENV:-production}"
+VERSION="$(cd "$REPO_ROOT" && git describe --tags --always --dirty 2>/dev/null | sed 's/^v//' || echo dev)"
+LDFLAGS="-s -w -X github.com/clawvisor/clawvisor/pkg/version.Version=${VERSION} -X github.com/clawvisor/clawvisor/pkg/version.Environment=${ENVIRONMENT}"
+
+echo "  Building backend from $REPO_ROOT (env=$ENVIRONMENT) ..."
+(cd "$REPO_ROOT" && go build -ldflags="$LDFLAGS" -o "$BIN" ./cmd/clawvisor/)
 echo "  Built $(${BIN} --version 2>/dev/null || echo 'ok')"
 
 echo "  Restarting daemon..."


### PR DESCRIPTION
## Summary
- Adds a build-time `Environment` variable (set via ldflags) that switches relay, push, and CORS defaults between production and staging (`*.staging.clawvisor.com`).
- `clawvisor setup` no longer writes relay/push URLs to config.yaml — the binary's built-in defaults apply, and users can still override via config.yaml or env vars.
- Adds `make build-staging` / `make run-staging` targets, and `CLAWVISOR_ENV=staging` support in `scripts/upgrade.sh`.

## Test plan
- [ ] `make build` produces a binary with production URLs
- [ ] `make build-staging` produces a binary with staging URLs
- [ ] `CLAWVISOR_ENV=staging ./scripts/upgrade.sh` builds with staging defaults
- [ ] `clawvisor setup` generates config.yaml without relay/push URL entries
- [ ] Existing config.yaml with explicit URLs still overrides built-in defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)