### PR TITLE
feat: automate Claude Desktop MCP setup in installer

### DIFF
--- a/internal/daemon/claude_code.go
+++ b/internal/daemon/claude_code.go
@@ -2,9 +2,14 @@ package daemon
 
 import (
 	"bufio"
+	"crypto/md5" //nolint:gosec // used only for cache key derivation matching mcp-remote's convention
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/charmbracelet/huh"
@@ -186,11 +191,225 @@ func hasClaudeDesktop(agents []knownAgent) bool {
 	return false
 }
 
-// offerClaudeDesktopSetup prints instructions for installing the Clawvisor
-// cowork plugin in Claude Desktop.
+// claudeDesktopConfigPath returns the platform-specific path to
+// claude_desktop_config.json, or "" if unsupported.
+func claudeDesktopConfigPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	switch runtime.GOOS {
+	case "darwin":
+		return filepath.Join(home, "Library", "Application Support", "Claude", "claude_desktop_config.json")
+	case "linux":
+		// XDG default for Claude Desktop on Linux.
+		if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+			return filepath.Join(xdg, "Claude", "claude_desktop_config.json")
+		}
+		return filepath.Join(home, ".config", "Claude", "claude_desktop_config.json")
+	default:
+		return ""
+	}
+}
+
+// installClaudeDesktopMCPConfig adds the clawvisor-local MCP server entry to
+// Claude Desktop's config file, merging with any existing configuration.
+func installClaudeDesktopMCPConfig(configPath string) error {
+	// Read existing config or start with an empty object.
+	existing := make(map[string]json.RawMessage)
+	if data, err := os.ReadFile(configPath); err == nil {
+		if err := json.Unmarshal(data, &existing); err != nil {
+			return fmt.Errorf("parsing existing config: %w", err)
+		}
+	}
+
+	// Parse existing mcpServers or start fresh.
+	servers := make(map[string]json.RawMessage)
+	if raw, ok := existing["mcpServers"]; ok {
+		if err := json.Unmarshal(raw, &servers); err != nil {
+			return fmt.Errorf("parsing mcpServers: %w", err)
+		}
+	}
+
+	// Add/overwrite the clawvisor-local entry.
+	entry := map[string]any{
+		"command": "npx",
+		"args":    []string{"mcp-remote", "http://localhost:25297/mcp"},
+	}
+	entryJSON, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("marshalling MCP entry: %w", err)
+	}
+	servers["clawvisor-local"] = json.RawMessage(entryJSON)
+
+	// Write servers back into the top-level config.
+	serversJSON, err := json.Marshal(servers)
+	if err != nil {
+		return fmt.Errorf("marshalling mcpServers: %w", err)
+	}
+	existing["mcpServers"] = json.RawMessage(serversJSON)
+
+	// Ensure the parent directory exists.
+	if err := os.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
+		return fmt.Errorf("creating config directory: %w", err)
+	}
+
+	out, err := json.MarshalIndent(existing, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshalling config: %w", err)
+	}
+	return os.WriteFile(configPath, append(out, '\n'), 0644)
+}
+
+// clearMCPRemoteCache removes mcp-remote's cached OAuth state for the local
+// daemon. mcp-remote caches client_info, tokens, and lock files under
+// ~/.mcp-auth/<version>/<md5(server_url)>_*.json. If the daemon's database
+// was recreated, the cached client_id becomes stale and causes "unknown
+// client_id" errors during OAuth authorization. Clearing forces mcp-remote
+// to re-register via /oauth/register on next startup.
+func clearMCPRemoteCache() {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return
+	}
+
+	authDir := filepath.Join(home, ".mcp-auth")
+	entries, err := os.ReadDir(authDir)
+	if err != nil {
+		return
+	}
+
+	// MD5 of the MCP endpoint URL, matching mcp-remote's key derivation.
+	h := md5.Sum([]byte("http://localhost:25297/mcp")) //nolint:gosec
+	prefix := hex.EncodeToString(h[:]) + "_"
+
+	for _, versionDir := range entries {
+		if !versionDir.IsDir() {
+			continue
+		}
+		dir := filepath.Join(authDir, versionDir.Name())
+		files, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, f := range files {
+			if strings.HasPrefix(f.Name(), prefix) {
+				_ = os.Remove(filepath.Join(dir, f.Name()))
+			}
+		}
+	}
+}
+
+// restartClaudeDesktop kills and relaunches Claude Desktop so it picks up
+// the new MCP config.
+func restartClaudeDesktop() error {
+	switch runtime.GOOS {
+	case "darwin":
+		// Quit gracefully via AppleScript, then reopen.
+		_ = exec.Command("osascript", "-e", `tell application "Claude" to quit`).Run()
+		// Brief pause to let the process exit.
+		exec.Command("sleep", "1").Run()
+		return exec.Command("open", "-a", "Claude").Start()
+	case "linux":
+		_ = exec.Command("pkill", "-f", "claude-desktop").Run()
+		exec.Command("sleep", "1").Run()
+		return exec.Command("claude-desktop").Start()
+	default:
+		return fmt.Errorf("unsupported platform")
+	}
+}
+
+// offerClaudeDesktopSetup interactively configures the MCP connection for
+// Claude Desktop. It writes the MCP server entry to claude_desktop_config.json
+// and optionally restarts Claude Desktop. The user only needs to click
+// "Authorize" on the OAuth prompt that appears after restart.
 func offerClaudeDesktopSetup() {
+	if nonInteractive() {
+		configPath := claudeDesktopConfigPath()
+		if configPath == "" {
+			return
+		}
+		if err := installClaudeDesktopMCPConfig(configPath); err != nil {
+			fmt.Println(dim.Padding(0, 2).Render("  Warning: could not configure Claude Desktop: " + err.Error()))
+			return
+		}
+		fmt.Println(green.Padding(0, 2).Render("  ✓ Configured Claude Desktop MCP"))
+		fmt.Println(dim.Padding(0, 2).Render("  Restart Claude Desktop and authorize when prompted."))
+		return
+	}
+
+	configPath := claudeDesktopConfigPath()
+	if configPath == "" {
+		// Unsupported platform — fall back to manual instructions.
+		printClaudeDesktopManualInstructions()
+		return
+	}
+
 	fmt.Println()
 	fmt.Println(bold.Padding(0, 2).Render("Claude Desktop"))
+
+	configure := true
+	if err := huh.NewForm(
+		huh.NewGroup(
+			huh.NewConfirm().
+				Title("Configure Claude Desktop to connect via MCP?").
+				Description("Adds the Clawvisor MCP server to Claude Desktop's config.\nAfter restart, Claude Desktop will prompt you to authorize via OAuth.").
+				Affirmative("Yes").
+				Negative("No").
+				Value(&configure),
+		),
+	).Run(); err != nil || !configure {
+		if !configure {
+			printClaudeDesktopManualInstructions()
+		}
+		return
+	}
+
+	if err := installClaudeDesktopMCPConfig(configPath); err != nil {
+		fmt.Println(yellow.Padding(0, 2).Render("  Could not write config: " + err.Error()))
+		fmt.Println()
+		printClaudeDesktopManualInstructions()
+		return
+	}
+
+	fmt.Println(green.Padding(0, 2).Render("  ✓ MCP server added to Claude Desktop config"))
+	fmt.Println(dim.Padding(0, 2).Render("  " + configPath))
+	fmt.Println()
+
+	// Offer to restart Claude Desktop.
+	restart := true
+	if err := huh.NewForm(
+		huh.NewGroup(
+			huh.NewConfirm().
+				Title("Restart Claude Desktop now?").
+				Description("Claude Desktop needs to restart to pick up the new config.\nIt will prompt you to authorize Clawvisor via OAuth.").
+				Affirmative("Yes").
+				Negative("I'll restart later").
+				Value(&restart),
+		),
+	).Run(); err != nil || !restart {
+		fmt.Println(dim.Padding(0, 2).Render("  Restart Claude Desktop when you're ready — it will prompt you to authorize."))
+		fmt.Println()
+		return
+	}
+
+	// Clear stale mcp-remote OAuth cache so it re-registers with the
+	// current daemon instead of reusing a client_id from a previous DB.
+	clearMCPRemoteCache()
+
+	if err := restartClaudeDesktop(); err != nil {
+		fmt.Println(yellow.Padding(0, 2).Render("  Could not restart: " + err.Error()))
+		fmt.Println(dim.Padding(0, 2).Render("  Restart Claude Desktop manually — it will prompt you to authorize."))
+	} else {
+		fmt.Println(green.Padding(0, 2).Render("  ✓ Claude Desktop restarting"))
+		fmt.Println(dim.Padding(0, 2).Render("  Authorize Clawvisor when the OAuth prompt appears."))
+	}
+	fmt.Println()
+}
+
+// printClaudeDesktopManualInstructions prints the fallback manual setup steps.
+func printClaudeDesktopManualInstructions() {
+	fmt.Println()
 	fmt.Println(dim.Padding(0, 2).Render("  To connect Claude Desktop to Clawvisor, install the cowork plugin:"))
 	fmt.Println()
 	fmt.Println(dim.Padding(0, 2).Render("  1. Download the plugin:"))

--- a/internal/daemon/install.go
+++ b/internal/daemon/install.go
@@ -425,14 +425,25 @@ func printAgentSetupInstructions(dataDir string) {
 		fmt.Println()
 	}
 
-	// Check if Claude Desktop was detected during setup.
+	// Offer to configure Claude Desktop MCP if detected. We wait for the
+	// daemon to be healthy first so that mcp-remote can register an OAuth
+	// client when Claude Desktop restarts.
 	for _, a := range appBundleAgents {
 		if a.Binary != "claude-desktop" {
 			continue
 		}
 		for _, p := range a.Paths {
 			if _, err := os.Stat(p); err == nil {
-				offerClaudeDesktopSetup()
+				serverURL, _, _ := readLocalSession(dataDir)
+				if serverURL == "" {
+					serverURL = "http://127.0.0.1:25297"
+				}
+				if err := waitForServer(serverURL); err != nil {
+					// Daemon not ready — fall back to manual instructions.
+					printClaudeDesktopManualInstructions()
+				} else {
+					offerClaudeDesktopSetup()
+				}
 				break
 			}
 		}

--- a/internal/daemon/setup.go
+++ b/internal/daemon/setup.go
@@ -358,6 +358,10 @@ func runDaemonSetup(dataDir string) error {
 		}
 	}
 
+	// Claude Desktop MCP setup is deferred to printAgentSetupInstructions
+	// (after the daemon is fully running) so that mcp-remote can register
+	// via OAuth when Claude Desktop restarts.
+
 	fmt.Println()
 	fmt.Println(green.Padding(0, 2).Render("✓ Daemon configured"))
 	fmt.Println(dim.Padding(0, 2).Render("  " + configPath))

--- a/internal/mcp/prompts.go
+++ b/internal/mcp/prompts.go
@@ -1,0 +1,111 @@
+package mcp
+
+// Prompt is an MCP prompt definition.
+type Prompt struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
+// PromptMessage is a message in a prompt response.
+type PromptMessage struct {
+	Role    string        `json:"role"`
+	Content ToolContent   `json:"content"`
+}
+
+// promptDefs returns the static list of MCP prompts.
+func promptDefs() []Prompt {
+	return []Prompt{
+		{
+			Name:        "clawvisor-workflow",
+			Description: "How to use Clawvisor's task-scoped authorization, gateway requests, and service catalog. Read this before making your first request.",
+		},
+	}
+}
+
+// promptContent returns the messages for the named prompt.
+func promptContent(name string) (string, []PromptMessage, bool) {
+	switch name {
+	case "clawvisor-workflow":
+		return "Clawvisor workflow instructions", []PromptMessage{
+			{
+				Role: "user",
+				Content: ToolContent{Type: "text", Text: workflowPrompt},
+			},
+		}, true
+	default:
+		return "", nil, false
+	}
+}
+
+const workflowPrompt = `# Clawvisor Workflow
+
+You are connected to Clawvisor via MCP. Clawvisor is a gatekeeper between you and external services (Gmail, Calendar, Drive, GitHub, Slack, iMessage, etc.). Every action goes through Clawvisor, which checks restrictions, validates task scopes, injects credentials, optionally routes to the user for approval, and returns a clean result. You never hold API keys.
+
+## Authorization Model
+
+Two layers, applied in order:
+1. **Restrictions** — hard blocks the user sets. If a restriction matches, the action is blocked immediately.
+2. **Tasks** — scopes you declare. Every request must be attached to an approved task. Actions with ` + "`auto_execute: true`" + ` run without per-request approval. Actions with ` + "`auto_execute: false`" + ` still require per-request approval within the task.
+
+## Typical Flow
+
+1. **Fetch the catalog** — use the ` + "`fetch_catalog`" + ` tool to see available services, actions, and restrictions
+2. **Create a task** — use ` + "`create_task`" + ` to declare your purpose and the actions you need
+3. **Wait for approval** — use ` + "`get_task`" + ` with ` + "`wait: true`" + ` to long-poll until the user approves (or denies) the task
+4. **Make gateway requests** — use ` + "`gateway_request`" + ` for each action, under the approved task scope
+5. **Complete the task** — use ` + "`complete_task`" + ` when done
+
+## Creating Tasks
+
+When calling ` + "`create_task`" + `:
+- **` + "`purpose`" + `** — shown to the user during approval. Be specific: "Review last 30 iMessage threads and classify reply status" is better than "Use iMessage."
+- **` + "`authorized_actions`" + `** — list each service + action pair you need, with:
+  - ` + "`auto_execute: true`" + ` for read-only actions you want to run immediately
+  - ` + "`auto_execute: false`" + ` for destructive actions (send, delete, etc.) that should require per-request approval
+  - ` + "`expected_use`" + ` — describe how you'll use each action. Shown during approval and verified against your actual requests.
+- **` + "`lifetime`" + `** — ` + "`\"session\"`" + ` (default, expires) or ` + "`\"standing\"`" + ` (no expiry, persists until revoked)
+- **` + "`expires_in_seconds`" + `** — TTL for session tasks (default 1800)
+
+All tasks start as ` + "`pending_approval`" + `. Long-poll with ` + "`get_task`" + ` (` + "`wait: true`" + `) until status changes to ` + "`active`" + ` or ` + "`denied`" + `.
+
+### Standing Tasks
+
+For recurring workflows, set ` + "`lifetime: \"standing\"`" + `. Standing tasks require a ` + "`session_id`" + ` in gateway requests to enable chain context verification across related requests.
+
+### Scope Expansion
+
+If you need an action not in the original task scope, use ` + "`expand_task`" + ` with the new action and a reason. The user will be prompted to approve.
+
+## Gateway Requests
+
+When calling ` + "`gateway_request`" + `:
+- **` + "`service`" + `** and **` + "`action`" + `** — from the catalog
+- **` + "`params`" + `** — action-specific parameters (documented in the catalog)
+- **` + "`reason`" + `** — one sentence explaining why. Be specific.
+- **` + "`request_id`" + `** — a unique ID you generate (e.g. UUID). Must be unique across all your requests.
+- **` + "`task_id`" + `** — the approved task ID this request belongs to
+
+## Handling Responses
+
+Every gateway response has a ` + "`status`" + ` field:
+
+| Status | Meaning | What to do |
+|---|---|---|
+| ` + "`executed`" + ` | Action completed | Use the result. Report to the user. |
+| ` + "`pending`" + ` | Awaiting human approval | Tell the user. Re-send same request_id to poll. |
+| ` + "`blocked`" + ` | A restriction blocks this | Tell the user. Do not retry or work around it. |
+| ` + "`restricted`" + ` | Intent verification rejected | Your params/reason were inconsistent with the task purpose. Adjust and retry with a new request_id. |
+| ` + "`pending_task_approval`" + ` | Task not yet approved | Long-poll get_task until approved. |
+| ` + "`pending_scope_expansion`" + ` | Action outside task scope | Use expand_task. |
+| ` + "`task_expired`" + ` | Task TTL exceeded | Expand or create a new task. |
+| ` + "`error`" + ` | Something went wrong | Report the error to the user. Do not silently retry. |
+
+## Important Rules
+
+- Always fetch the catalog first to know what's available and restricted
+- Never attempt to bypass restrictions — they are hard blocks set by the user
+- Always create a task before making gateway requests
+- Use ` + "`auto_execute: false`" + ` for any action that sends, modifies, or deletes data
+- Generate unique request_ids for every gateway request
+- Complete tasks when done to clean up authorization scope
+`

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -44,7 +44,7 @@ func (s *Server) HandleJSONRPC(w http.ResponseWriter, r *http.Request, req *Requ
 			s.logger.Warn("notifications/initialized with invalid session", "session_id", sessionID)
 		}
 		return nil
-	case "ping", "tools/list", "tools/call":
+	case "ping", "tools/list", "tools/call", "prompts/list", "prompts/get":
 		sessionID := r.Header.Get("Mcp-Session-Id")
 		if !s.sessions.Valid(r.Context(), sessionID) {
 			return newErrorResponse(req.ID, CodeInvalidRequest, "invalid or expired session")
@@ -56,6 +56,10 @@ func (s *Server) HandleJSONRPC(w http.ResponseWriter, r *http.Request, req *Requ
 			return s.handleToolsList(req)
 		case "tools/call":
 			return s.handleToolsCall(r, req)
+		case "prompts/list":
+			return s.handlePromptsList(req)
+		case "prompts/get":
+			return s.handlePromptsGet(req)
 		}
 		return nil // unreachable
 	default:
@@ -74,18 +78,45 @@ func (s *Server) handleInitialize(w http.ResponseWriter, r *http.Request, req *R
 	return newResponse(req.ID, map[string]any{
 		"protocolVersion": "2025-06-18",
 		"capabilities": map[string]any{
-			"tools": map[string]any{},
+			"tools":   map[string]any{},
+			"prompts": map[string]any{},
 		},
 		"serverInfo": map[string]any{
 			"name":    "clawvisor",
 			"version": "1.0.0",
 		},
+		"instructions": workflowPrompt,
 	})
 }
 
 func (s *Server) handleToolsList(req *Request) *Response {
 	return newResponse(req.ID, map[string]any{
 		"tools": toolDefs(),
+	})
+}
+
+func (s *Server) handlePromptsList(req *Request) *Response {
+	return newResponse(req.ID, map[string]any{
+		"prompts": promptDefs(),
+	})
+}
+
+func (s *Server) handlePromptsGet(req *Request) *Response {
+	var params struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return newErrorResponse(req.ID, CodeInvalidParams, "invalid prompt params")
+	}
+
+	description, messages, ok := promptContent(params.Name)
+	if !ok {
+		return newErrorResponse(req.ID, CodeInvalidParams, "unknown prompt: "+params.Name)
+	}
+
+	return newResponse(req.ID, map[string]any{
+		"description": description,
+		"messages":    messages,
 	})
 }
 


### PR DESCRIPTION
## Summary

- Adds interactive Claude Desktop MCP configuration to the install wizard — writes the `clawvisor-local` MCP server entry to `claude_desktop_config.json`, offers to restart Claude Desktop, and clears stale `mcp-remote` OAuth cache (`~/.mcp-auth/`) to prevent "unknown client_id" errors from cached registrations against previous daemon databases.
- Defers Claude Desktop setup to after the daemon is healthy (moved from `runDaemonSetup` to `printAgentSetupInstructions`) so `mcp-remote` can successfully register via `/oauth/register` when Claude Desktop restarts.
- Exposes Clawvisor workflow instructions to MCP clients via the `instructions` field in the `initialize` response, plus `prompts/list` and `prompts/get` support, so Claude Desktop automatically knows how to use the task-scoped authorization workflow.

## Test plan

- [ ] Run `clawvisor setup` with Claude Desktop installed — verify it offers MCP config, writes to `claude_desktop_config.json`, and restarts Claude Desktop
- [ ] After restart, verify Claude Desktop's OAuth authorize flow completes without "unknown client_id"
- [ ] Verify Claude Desktop receives workflow instructions and knows how to use Clawvisor tools
- [ ] Run `clawvisor setup` without Claude Desktop installed — verify no errors or prompts related to it
- [ ] Verify non-interactive mode writes config without prompting

🤖 Generated with [Claude Code](https://claude.com/claude-code)