### PR TITLE
fix: show 'clawvisor update' in update banner

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -363,8 +363,8 @@ func (a *App) renderStatusBar(hints []string) string {
 		content = StyleRed.Render("Reconnecting...") + sep + content
 	}
 
-	if a.updateAvail && a.upgradeCmd != "" {
-		content = StyleGreen.Render("Update: "+a.upgradeCmd) + sep + content
+	if a.updateAvail && a.latestVersion != "" {
+		content = StyleGreen.Render("Update available ("+a.latestVersion+") — run `clawvisor update` to get the latest version") + sep + content
 	}
 
 	if a.status != "" {

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -131,11 +131,9 @@ export default function Dashboard() {
               {versionData.current && <span className="text-text-secondary"> (current: v{versionData.current})</span>}
             </span>
             <span className="flex items-center gap-3">
-              {versionData.upgrade_command && (
-                <code className="text-xs bg-surface-2 px-2 py-1 rounded text-text-secondary font-mono">
-                  {versionData.upgrade_command}
-                </code>
-              )}
+              <span className="text-text-secondary">
+                Run <code className="text-xs bg-surface-2 px-2 py-1 rounded font-mono">clawvisor update</code> to get the latest version
+              </span>
               {versionData.release_url && (
                 <a
                   href={versionData.release_url}


### PR DESCRIPTION
## Summary
- Replace the raw `go install ...` command in the update banner with a user-friendly message: "Run `clawvisor update` to get the latest version"
- Updated in both the TUI status bar and the web dashboard banner

## Test plan
- [ ] Verify TUI status bar shows the new update message when an update is available
- [ ] Verify web dashboard banner shows the new update message when an update is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)