### PR TITLE
feat: split setup into composable subcommands (services, integrate)

### DIFF
--- a/cmd/clawvisor/cmd_daemon.go
+++ b/cmd/clawvisor/cmd_daemon.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/charmbracelet/huh"
 	"github.com/clawvisor/clawvisor/internal/daemon"
 	"github.com/spf13/cobra"
 )
@@ -54,10 +55,17 @@ var statusCmd = &cobra.Command{
 
 var installCmd = &cobra.Command{
 	Use:   "install",
-	Short: "Install the daemon as a system service (launchd on macOS, systemd on Linux)",
+	Short: "Guided setup: configure, install, start, connect services, and integrate agents",
+	Long:  "Run the full guided setup flow: configure the daemon, install it as\na system service, start it, connect services, and set up agent\nintegrations. This is the recommended way to get started.",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return daemon.Install()
+		pair, _ := cmd.Flags().GetBool("pair")
+		err := daemon.Install(daemon.InstallOptions{Pair: pair})
+		if err == huh.ErrUserAborted {
+			return nil
+		}
+		return err
 	},
+	SilenceUsage: true,
 }
 
 var uninstallCmd = &cobra.Command{
@@ -87,5 +95,6 @@ var dashboardCmd = &cobra.Command{
 
 func init() {
 	startCmd.Flags().Bool("foreground", false, "Run in the foreground instead of starting the background service")
+	installCmd.Flags().Bool("pair", false, "Pair a mobile device after install and print the agent setup URL")
 	dashboardCmd.Flags().Bool("no-open", false, "Print the URL instead of opening the browser")
 }

--- a/cmd/clawvisor/cmd_integrate.go
+++ b/cmd/clawvisor/cmd_integrate.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"github.com/charmbracelet/huh"
+	"github.com/clawvisor/clawvisor/internal/daemon"
+	"github.com/spf13/cobra"
+)
+
+var integrateCmd = &cobra.Command{
+	Use:   "integrate",
+	Short: "Set up agent integrations (Claude Code, Claude Desktop, etc.)",
+	Long:  "Auto-detect installed coding agents and walk through setting up\neach one to work with Clawvisor.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		err := daemon.Integrate()
+		if err == huh.ErrUserAborted {
+			return nil
+		}
+		return err
+	},
+	SilenceUsage: true,
+}
+
+var integrateClaudeCodeCmd = &cobra.Command{
+	Use:   "claude-code",
+	Short: "Set up Claude Code integration",
+	Long:  "Install the /clawvisor-setup slash command and optionally add\nauto-approve rules for Clawvisor curl requests.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		err := daemon.IntegrateClaudeCode()
+		if err == huh.ErrUserAborted {
+			return nil
+		}
+		return err
+	},
+	SilenceUsage: true,
+}
+
+var integrateClaudeDesktopCmd = &cobra.Command{
+	Use:   "claude-desktop",
+	Short: "Set up Claude Desktop integration",
+	Long:  "Configure the MCP connection for Claude Desktop and optionally\nrestart it to pick up the new config.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		daemon.IntegrateClaudeDesktop()
+		return nil
+	},
+	SilenceUsage: true,
+}
+
+func init() {
+	integrateCmd.AddCommand(integrateClaudeCodeCmd)
+	integrateCmd.AddCommand(integrateClaudeDesktopCmd)
+}

--- a/cmd/clawvisor/cmd_services.go
+++ b/cmd/clawvisor/cmd_services.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"github.com/charmbracelet/huh"
+	"github.com/clawvisor/clawvisor/internal/daemon"
+	"github.com/spf13/cobra"
+)
+
+var servicesCmd = &cobra.Command{
+	Use:   "services",
+	Short: "Manage service connections (GitHub, Gmail, Slack, etc.)",
+	Long:  "Connect, list, and manage the external services that Clawvisor\nproxies on behalf of your agents. Requires a running daemon.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		err := daemon.Services()
+		if err == huh.ErrUserAborted {
+			return nil
+		}
+		return err
+	},
+	SilenceUsage: true,
+}
+
+var servicesListJSON bool
+
+var servicesListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List available and connected services",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return daemon.ServicesList(servicesListJSON)
+	},
+	SilenceUsage: true,
+}
+
+var servicesAddCmd = &cobra.Command{
+	Use:   "add [service]",
+	Short: "Connect a service",
+	Long:  "Connect a service by ID or name. If no service is specified,\nan interactive picker is shown.",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		serviceID := ""
+		if len(args) > 0 {
+			serviceID = args[0]
+		}
+		err := daemon.ServicesAdd(serviceID)
+		if err == huh.ErrUserAborted {
+			return nil
+		}
+		return err
+	},
+	SilenceUsage: true,
+}
+
+var servicesRemoveCmd = &cobra.Command{
+	Use:   "remove <service>",
+	Short: "Disconnect a service",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return daemon.ServicesRemove(args[0])
+	},
+	SilenceUsage: true,
+}
+
+func init() {
+	servicesListCmd.Flags().BoolVar(&servicesListJSON, "json", false, "Output in JSON format")
+
+	servicesCmd.AddCommand(servicesListCmd)
+	servicesCmd.AddCommand(servicesAddCmd)
+	servicesCmd.AddCommand(servicesRemoveCmd)
+}

--- a/cmd/clawvisor/cmd_setup.go
+++ b/cmd/clawvisor/cmd_setup.go
@@ -8,18 +8,14 @@ import (
 
 var setupCmd = &cobra.Command{
 	Use:   "setup",
-	Short: "Run the first-time setup wizard",
+	Short: "Configure the daemon (LLM, relay, telemetry)",
+	Long:  "Run the core configuration wizard to set up LLM provider, relay,\nand telemetry preferences. Use `clawvisor services` and\n`clawvisor integrate` to connect services and agents.",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		pair, _ := cmd.Flags().GetBool("pair")
-		err := daemon.Setup(daemon.SetupOptions{Pair: pair})
+		err := daemon.Setup()
 		if err == huh.ErrUserAborted {
 			return nil
 		}
 		return err
 	},
 	SilenceUsage: true,
-}
-
-func init() {
-	setupCmd.Flags().Bool("pair", false, "Pair a mobile device after setup and print the agent setup URL")
 }

--- a/cmd/clawvisor/main.go
+++ b/cmd/clawvisor/main.go
@@ -30,6 +30,8 @@ func init() {
 	rootCmd.AddCommand(updateCmd)
 	rootCmd.AddCommand(healthcheckCmd)
 	rootCmd.AddCommand(agentCmd)
+	rootCmd.AddCommand(servicesCmd)
+	rootCmd.AddCommand(integrateCmd)
 	rootCmd.AddCommand(serverCmd)
 	rootCmd.AddCommand(tuiCmd)
 }

--- a/internal/daemon/claude_code.go
+++ b/internal/daemon/claude_code.go
@@ -477,6 +477,9 @@ func printClaudeDesktopManualInstructions() {
 // offerClaudeCodeSetup prompts the user to install the /clawvisor-setup
 // slash command for Claude Code.
 func offerClaudeCodeSetup(dataDir string) error {
+	fmt.Println()
+	fmt.Println(bold.Padding(0, 2).Render("Claude Code"))
+
 	install := true
 	if err := huh.NewForm(
 		huh.NewGroup(

--- a/internal/daemon/install.go
+++ b/internal/daemon/install.go
@@ -2,6 +2,8 @@ package daemon
 
 import (
 	"fmt"
+	"io"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,6 +14,8 @@ import (
 	"time"
 
 	"github.com/charmbracelet/huh"
+	"github.com/clawvisor/clawvisor/internal/server"
+	"github.com/clawvisor/clawvisor/pkg/clawvisor"
 )
 
 const launchdLabel = "com.clawvisor.daemon"
@@ -143,25 +147,50 @@ func Install(opts InstallOptions) error {
 		return fmt.Errorf("auto-install is supported on macOS and Linux; start the daemon manually with `clawvisor start`")
 	}
 
-	// Step 3: Start the daemon.
-	if err := Start(); err != nil {
-		return err
+	// Step 3: Set up local auth (creates admin user, writes .local-session).
+	// This must happen before the daemon starts so the magic token matches
+	// the JWT secret in config.yaml.
+	cfgPath := filepath.Join(dataDir, "config.yaml")
+	quietLogger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	if srvOpts, err := clawvisor.DefaultOptions(quietLogger, cfgPath); err == nil {
+		if _, err := server.SetupLocalAuth(srvOpts, quietLogger); err != nil {
+			fmt.Println(dim.Padding(0, 2).Render("  Warning: could not set up local auth: " + err.Error()))
+		}
 	}
 
-	// Wait for the daemon to be healthy before running interactive steps.
-	serverURL, _, _ := readLocalSession(dataDir)
-	if serverURL == "" {
-		serverURL = "http://127.0.0.1:25297"
+	// Step 4: Start the daemon. This may fail in environments without a
+	// service manager (e.g. Docker) — that's OK, the user can start it
+	// manually with `clawvisor start --foreground`.
+	daemonRunning := false
+	if err := Start(); err != nil {
+		fmt.Println(dim.Padding(0, 2).Render("  Could not start daemon via service manager: " + err.Error()))
+		fmt.Println(dim.Padding(0, 2).Render("  Start manually with: clawvisor start --foreground"))
+	} else {
+		// Wait for the daemon to be healthy before running interactive steps.
+		serverURL, _, _ := readLocalSession(dataDir)
+		if serverURL == "" {
+			serverURL = "http://127.0.0.1:25297"
+		}
+		fmt.Println(dim.Padding(0, 2).Render("  Waiting for daemon..."))
+		if err := waitForServer(serverURL); err != nil {
+			fmt.Println(dim.Padding(0, 2).Render("  Daemon not ready yet. You can connect services later with: clawvisor services"))
+		} else {
+			daemonRunning = true
+			fmt.Println()
+			fmt.Println(green.Padding(0, 2).Render("✓ Daemon running"))
+			fmt.Println()
+		}
 	}
-	fmt.Println(dim.Padding(0, 2).Render("  Waiting for daemon..."))
-	if err := waitForServer(serverURL); err != nil {
-		fmt.Println(yellow.Padding(0, 2).Render("  Daemon not ready yet. You can connect services later with: clawvisor services"))
+
+	if !daemonRunning {
+		fmt.Println()
+		fmt.Println(green.Padding(0, 2).Render("✓ Install complete"))
+		fmt.Println(dim.Padding(0, 2).Render("  Once the daemon is running, use:"))
+		fmt.Println(dim.Padding(0, 2).Render("    clawvisor services    — connect services"))
+		fmt.Println(dim.Padding(0, 2).Render("    clawvisor integrate   — set up agent integrations"))
+		fmt.Println()
 		return nil
 	}
-
-	fmt.Println()
-	fmt.Println(green.Padding(0, 2).Render("✓ Daemon running"))
-	fmt.Println()
 
 	// Step 4: Connect services (interactive).
 	if err := Services(); err != nil && err != huh.ErrUserAborted {

--- a/internal/daemon/install.go
+++ b/internal/daemon/install.go
@@ -2,7 +2,6 @@ package daemon
 
 import (
 	"fmt"
-	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -76,33 +75,34 @@ func isGoRunBinary(path string) bool {
 	return strings.Contains(path, "go-build") || strings.Contains(path, "/exe/")
 }
 
-// Install writes a service definition so the daemon starts at login.
-// If no config.yaml exists in ~/.clawvisor, the setup wizard runs first.
-func Install() error {
+// InstallOptions configures the guided install flow.
+type InstallOptions struct {
+	Pair bool // chain into device pairing after install
+}
+
+// Install runs the guided end-to-end setup and installation flow:
+// setup → write system service → start daemon → connect services → integrate agents.
+// This is the primary entry point for `curl | sh` first-time installs.
+func Install(opts InstallOptions) error {
 	dataDir, err := ensureDataDir()
 	if err != nil {
 		return err
 	}
-	firstRun, err := ensureSetup(dataDir)
+
+	// Step 1: Core config (if not already configured).
+	_, err = ensureSetup(dataDir)
 	if err != nil {
 		return fmt.Errorf("setup: %w", err)
 	}
 
-	if firstRun {
-		// Stop any running daemon so the setup-phase server can bind the
-		// port and the magic token matches the new in-memory store.
-		_ = Stop()
-
-		cfgPath := filepath.Join(dataDir, "config.yaml")
-		logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
-		if err := runWithServiceSetup(dataDir, cfgPath, logger, 1); err != nil {
-			return fmt.Errorf("service setup: %w", err)
-		}
-		fmt.Println()
-		fmt.Println(green.Padding(0, 2).Render("✓ Setup complete"))
-		fmt.Println()
+	// Skip daemon install/start when running inside a container — there's
+	// no launchd/systemd and the server will be started via docker compose.
+	if os.Getenv("CLAWVISOR_CONTAINER") == "1" {
+		fmt.Println(green.Padding(0, 2).Render("✓ Setup complete (container mode)"))
+		return nil
 	}
 
+	// Step 2: Write system service definition.
 	binary, err := os.Executable()
 	if err != nil {
 		return fmt.Errorf("resolving executable path: %w", err)
@@ -143,12 +143,48 @@ func Install() error {
 		return fmt.Errorf("auto-install is supported on macOS and Linux; start the daemon manually with `clawvisor start`")
 	}
 
-	// Start the daemon and print the agent setup URL.
+	// Step 3: Start the daemon.
 	if err := Start(); err != nil {
 		return err
 	}
-	printAgentSetupInstructions(dataDir)
+
+	// Wait for the daemon to be healthy before running interactive steps.
+	serverURL, _, _ := readLocalSession(dataDir)
+	if serverURL == "" {
+		serverURL = "http://127.0.0.1:25297"
+	}
+	fmt.Println(dim.Padding(0, 2).Render("  Waiting for daemon..."))
+	if err := waitForServer(serverURL); err != nil {
+		fmt.Println(yellow.Padding(0, 2).Render("  Daemon not ready yet. You can connect services later with: clawvisor services"))
+		return nil
+	}
+
+	fmt.Println()
+	fmt.Println(green.Padding(0, 2).Render("✓ Daemon running"))
+	fmt.Println()
+
+	// Step 4: Connect services (interactive).
+	if err := Services(); err != nil && err != huh.ErrUserAborted {
+		fmt.Println(dim.Padding(0, 2).Render("  Service setup skipped. Run `clawvisor services` later."))
+	}
+
+	// Step 5: Integrate agents (auto-detect + walk through).
+	if err := Integrate(); err != nil && err != huh.ErrUserAborted {
+		fmt.Println(dim.Padding(0, 2).Render("  Agent integration skipped. Run `clawvisor integrate` later."))
+	}
+
+	// Step 6: Optional pairing.
+	if opts.Pair {
+		time.Sleep(2 * time.Second)
+		if err := Pair(); err != nil {
+			return err
+		}
+		printAgentSetupURL(dataDir)
+	}
+
+	// Step 7: Offer to open dashboard.
 	promptDashboardOpen(dataDir)
+
 	return nil
 }
 
@@ -174,8 +210,6 @@ func installLaunchd(home string, data installData) error {
 	}
 
 	fmt.Printf("  Installed launch agent: %s\n", plistPath)
-	fmt.Println("  To start now: clawvisor start")
-	fmt.Println("  To stop:      clawvisor stop")
 	return nil
 }
 
@@ -236,8 +270,6 @@ func installSystemd(home string, data installData) error {
 	exec.Command("systemctl", "--user", "daemon-reload").Run()
 
 	fmt.Printf("  Installed systemd user service: %s\n", unitPath)
-	fmt.Println("  To start now: clawvisor start")
-	fmt.Println("  To stop:      clawvisor stop")
 	return nil
 }
 
@@ -271,14 +303,11 @@ func promptDashboardOpen(dataDir string) {
 	}
 
 	// The daemon was just started via the service manager — wait for it to
-	// actually be healthy before requesting a magic token. We can't just
-	// check for .local-session because the setup-phase server already wrote
-	// one that's now stale.
+	// actually be healthy before requesting a magic token.
 	serverURL, _, _ := readLocalSession(dataDir)
 	if serverURL == "" {
 		serverURL = "http://127.0.0.1:25297"
 	}
-	fmt.Println(dim.Padding(0, 2).Render("Waiting for daemon to start..."))
 	if err := waitForServer(serverURL); err != nil {
 		fmt.Println(dim.Padding(0, 2).Render("Daemon hasn't started yet. Run `clawvisor dashboard` once it's ready."))
 		return
@@ -405,61 +434,4 @@ func Stop() error {
 
 	fmt.Println("  Daemon stopped.")
 	return nil
-}
-
-// printAgentSetupInstructions prints instructions for connecting agents.
-// If the Claude Code slash command is installed, it mentions /clawvisor-setup.
-// Otherwise, if the relay is configured, it prints the setup URL.
-func printAgentSetupInstructions(dataDir string) {
-	fmt.Println()
-	fmt.Println(green.Padding(0, 2).Render("✓ Installation complete"))
-	fmt.Println()
-
-	home, _ := os.UserHomeDir()
-
-	// Check if the Claude Code command was installed.
-	claudeCmdPath := filepath.Join(home, ".claude", "commands", "clawvisor-setup.md")
-	if _, err := os.Stat(claudeCmdPath); err == nil {
-		fmt.Println(bold.Padding(0, 2).Render("Connect Claude Code"))
-		fmt.Println(dim.Padding(0, 2).Render("  Run /clawvisor-setup in any Claude Code project."))
-		fmt.Println()
-	}
-
-	// Offer to configure Claude Desktop MCP if detected. We wait for the
-	// daemon to be healthy first so that mcp-remote can register an OAuth
-	// client when Claude Desktop restarts.
-	for _, a := range appBundleAgents {
-		if a.Binary != "claude-desktop" {
-			continue
-		}
-		for _, p := range a.Paths {
-			if _, err := os.Stat(p); err == nil {
-				serverURL, _, _ := readLocalSession(dataDir)
-				if serverURL == "" {
-					serverURL = "http://127.0.0.1:25297"
-				}
-				if err := waitForServer(serverURL); err != nil {
-					// Daemon not ready — fall back to manual instructions.
-					printClaudeDesktopManualInstructions()
-				} else {
-					offerClaudeDesktopSetup()
-				}
-				break
-			}
-		}
-		break
-	}
-
-	daemonID, relayHost, err := readRelayConfig(dataDir)
-	if err != nil || daemonID == "" || relayHost == "" {
-		return
-	}
-
-	setupURL := fmt.Sprintf("https://%s/d/%s/skill/setup", relayHost, daemonID)
-	fmt.Println(bold.Padding(0, 2).Render("Connect other agents"))
-	fmt.Println(dim.Padding(0, 2).Render("  Copy the following to your AI agent:"))
-	fmt.Println()
-	fmt.Println(dim.Padding(0, 4).Render("I'd like to set up Clawvisor. Please navigate to the following URL and follow the setup instructions:"))
-	fmt.Println(green.Padding(0, 4).Render(setupURL))
-	fmt.Println()
 }

--- a/internal/daemon/integrate.go
+++ b/internal/daemon/integrate.go
@@ -1,0 +1,71 @@
+package daemon
+
+import (
+	"fmt"
+
+	"github.com/charmbracelet/huh"
+)
+
+// Integrate auto-detects installed coding agents and walks the user through
+// setting up each one. Agents that require a running daemon (e.g. Claude
+// Desktop MCP/OAuth) will fail gracefully if the daemon is not reachable.
+func Integrate() error {
+	dataDir, err := ensureDataDir()
+	if err != nil {
+		return err
+	}
+
+	agents := detectAgents()
+
+	fmt.Println()
+	fmt.Println(bold.Padding(0, 2).Render("Agent Integrations"))
+
+	if len(agents) == 0 {
+		fmt.Println(dim.Padding(0, 2).Render("No known agents detected on this machine."))
+		fmt.Println()
+		return nil
+	}
+
+	fmt.Println(dim.Padding(0, 2).Render("Detected the following agents:"))
+	fmt.Println()
+	for _, a := range agents {
+		fmt.Println(green.Padding(0, 2).Render("  ✓ " + a.DisplayName))
+	}
+	fmt.Println()
+
+	if hasClaudeCode(agents) {
+		if err := IntegrateClaudeCode(); err != nil && err != huh.ErrUserAborted {
+			fmt.Println(dim.Padding(0, 2).Render("  Warning: Claude Code integration failed: " + err.Error()))
+		}
+	}
+
+	if hasClaudeDesktop(agents) {
+		IntegrateClaudeDesktop()
+		fmt.Println(dim.Padding(0, 4).Render("After authorizing Claude Desktop to connect with Clawvisor,"))
+		fmt.Println(dim.Padding(0, 4).Render("you can ask your agent to perform tasks using any configured service."))
+		fmt.Println()
+	}
+
+	// Print relay-based setup prompt for other agents.
+	printAgentSetupPrompt(dataDir)
+
+	return nil
+}
+
+// IntegrateClaudeCode installs the /clawvisor-setup slash command for Claude
+// Code and optionally adds auto-approve rules for curl requests. Does not
+// require a running daemon.
+func IntegrateClaudeCode() error {
+	dataDir, err := ensureDataDir()
+	if err != nil {
+		return err
+	}
+
+	return offerClaudeCodeSetup(dataDir)
+}
+
+// IntegrateClaudeDesktop configures the MCP connection for Claude Desktop.
+// Requires a running daemon for OAuth registration on restart.
+func IntegrateClaudeDesktop() {
+	offerClaudeDesktopSetup()
+}

--- a/internal/daemon/run.go
+++ b/internal/daemon/run.go
@@ -1,24 +1,20 @@
 package daemon
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"os"
-	"os/signal"
 	"path/filepath"
 	"runtime"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/charmbracelet/huh"
 	"github.com/clawvisor/clawvisor/internal/server"
 	"github.com/clawvisor/clawvisor/internal/tui/client"
-	"github.com/clawvisor/clawvisor/pkg/clawvisor"
+	"github.com/clawvisor/clawvisor/pkg/version"
 )
 
 // RunOptions controls daemon startup behavior.
@@ -44,14 +40,10 @@ func Run(opts RunOptions) error {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
 
 	if firstRun {
-		// Phase 1 (and optionally Phase 2 for Google OAuth restart):
-		// start server in background, run service setup, then hand off.
-		if err := runWithServiceSetup(dataDir, cfgPath, logger, 1); err != nil {
-			return err
-		}
 		fmt.Println()
-		fmt.Println(green.Padding(0, 2).Render("✓ Setup complete"))
-		fmt.Println(dim.Padding(0, 2).Render("  Starting daemon..."))
+		fmt.Println(dim.Padding(0, 2).Render("Tip: connect services and agents after the daemon starts:"))
+		fmt.Println(dim.Padding(0, 2).Render("  clawvisor services    — connect GitHub, Gmail, Slack, etc."))
+		fmt.Println(dim.Padding(0, 2).Render("  clawvisor integrate   — set up Claude Code, Claude Desktop, etc."))
 		fmt.Println()
 	}
 
@@ -64,89 +56,6 @@ func Run(opts RunOptions) error {
 
 	// Final production run — blocks until SIGINT/SIGTERM.
 	return server.Run(logger, server.RunOptions{ConfigPath: cfgPath})
-}
-
-// runWithServiceSetup starts the server with a cancellable context, waits for
-// it to be healthy, runs the interactive service-setup wizard, then shuts it
-// down cleanly. phase should be 1 on first call; 2 on the restart triggered
-// by Google OAuth credential collection. Passing phase >= 2 disables further
-// restarts, preventing infinite loops if something goes wrong.
-func runWithServiceSetup(dataDir, cfgPath string, logger *slog.Logger, phase int) error {
-	// Re-read DefaultOptions so the server picks up any config changes (e.g.
-	// Google creds written between phases). Use a discarding logger so server
-	// request logs don't clutter the interactive setup output.
-	quietLogger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	srvOpts, err := clawvisor.DefaultOptions(quietLogger, cfgPath)
-	if err != nil {
-		return fmt.Errorf("building server options: %w", err)
-	}
-	srvOpts.Quiet = true
-
-	// Set up local auth: create admin@local, write .local-session.
-	authResult, err := server.SetupLocalAuth(srvOpts, logger)
-	if err != nil {
-		return fmt.Errorf("local auth setup: %w", err)
-	}
-
-	// Start server in background with a caller-controlled context.
-	ctx, cancel := context.WithCancel(context.Background())
-
-	// Also cancel on SIGINT/SIGTERM so Ctrl+C during setup is clean.
-	sigCtx, sigStop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
-	defer sigStop()
-
-	serverErrCh := make(chan error, 1)
-	go func() {
-		serverErrCh <- clawvisor.RunWithContext(sigCtx, srvOpts)
-	}()
-
-	// Wait for the server to be healthy before running the setup wizard.
-	if err := waitForServer(authResult.ServerURL); err != nil {
-		cancel()
-		<-serverErrCh
-		return fmt.Errorf("server failed to start: %w", err)
-	}
-
-	// Create an authenticated API client using the local magic token.
-	apiClient, err := authenticateClient(authResult.ServerURL, authResult.MagicToken)
-	if err != nil {
-		cancel()
-		<-serverErrCh
-		return fmt.Errorf("authenticating API client: %w", err)
-	}
-
-	// Run the interactive service setup wizard.
-	needsRestart, err := runServiceSetup(apiClient, dataDir)
-	if err == huh.ErrUserAborted {
-		cancel()
-		<-serverErrCh
-		return huh.ErrUserAborted
-	}
-	if err != nil {
-		logger.Warn("service setup error", "err", err)
-		// Non-fatal: user can configure services later via 'clawvisor setup'.
-	}
-
-	// Shut down the setup-phase server cleanly.
-	cancel()
-	if srvErr := <-serverErrCh; srvErr != nil && srvErr != context.Canceled {
-		logger.Warn("server error during setup phase", "err", srvErr)
-	}
-
-	if needsRestart {
-		if phase >= 2 {
-			// Guard: do not restart again. The user can finish Google OAuth
-			// from the dashboard. Log a warning but continue.
-			logger.Warn("Google OAuth config written but server restart capped at phase 2 — complete OAuth from the dashboard")
-			return nil
-		}
-		fmt.Println()
-		fmt.Println(dim.Padding(0, 2).Render("  Restarting with updated configuration..."))
-		fmt.Println()
-		return runWithServiceSetup(dataDir, cfgPath, logger, phase+1)
-	}
-
-	return nil
 }
 
 // waitForServer polls the /health endpoint until it returns 200 or the
@@ -255,16 +164,11 @@ func ensureSetup(dataDir string) (firstRun bool, err error) {
 	return true, runDaemonSetup(dataDir)
 }
 
-// SetupOptions configures the daemon setup wizard.
-type SetupOptions struct {
-	Pair bool // chain into device pairing after setup and print agent setup URL
-}
-
-// Setup explicitly re-runs the full daemon setup wizard (config + services)
-// from the top. If a config already exists, the user is asked whether to
-// overwrite it. It spins up a temporary server for service setup, so it
-// works identically whether or not a daemon is already running.
-func Setup(opts SetupOptions) error {
+// Setup explicitly re-runs the core daemon config wizard (LLM, relay,
+// telemetry). If a config already exists, the user is asked whether to
+// overwrite it. Use `clawvisor services` and `clawvisor integrate` to
+// connect services and agents separately.
+func Setup() error {
 	dataDir, err := ensureDataDir()
 	if err != nil {
 		return err
@@ -290,89 +194,65 @@ func Setup(opts SetupOptions) error {
 		}
 	}
 
-	// Stop any running daemon so the setup-phase server can bind the port
-	// and the magic token matches the new JWT secret.
-	_ = Stop()
-
 	if err := runDaemonSetup(dataDir); err != nil {
 		return err
 	}
 
-	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
-
-	// Start a temporary server and run the service setup wizard against it,
-	// just like the first-run path. This avoids depending on a running daemon
-	// that may have stale config.
-	if err := runWithServiceSetup(dataDir, cfgPath, logger, 1); err != nil {
-		return err
-	}
-
-	fmt.Println()
 	fmt.Println(green.Padding(0, 2).Render("✓ Setup complete"))
 	fmt.Println()
-
-	// Skip daemon install/start when running inside a container — there's
-	// no launchd/systemd and the server will be started via docker compose.
-	if os.Getenv("CLAWVISOR_CONTAINER") == "1" {
-		return nil
-	}
-
-	// Offer to install and start the daemon as a background service.
-	install := true
-	if err := huh.NewForm(
-		huh.NewGroup(
-			huh.NewConfirm().
-				Title("Install and start the daemon as a background service?").
-				Affirmative("Yes").
-				Negative("No").
-				Value(&install),
-		),
-	).Run(); err != nil {
-		return err
-	}
-	if !install {
-		fmt.Println(dim.Padding(0, 2).Render("  You can install later with: clawvisor install"))
-		fmt.Println()
-		return nil
-	}
-
-	if err := Install(); err != nil {
-		return fmt.Errorf("installing daemon: %w", err)
-	}
-	if err := Start(); err != nil {
-		return err
-	}
-
-	if opts.Pair {
-		// Wait briefly for the daemon to be ready before starting the pair flow.
-		time.Sleep(2 * time.Second)
-
-		if err := Pair(); err != nil {
-			return err
-		}
-
-		// Print the agent setup URL.
-		printAgentSetupURL(dataDir)
-	}
-
+	fmt.Println(dim.Padding(0, 2).Render("Next steps:"))
+	fmt.Println(dim.Padding(0, 2).Render("  clawvisor install     — install and start the daemon"))
+	fmt.Println(dim.Padding(0, 2).Render("  clawvisor services    — connect services"))
+	fmt.Println(dim.Padding(0, 2).Render("  clawvisor integrate   — set up agent integrations"))
+	fmt.Println()
 	return nil
 }
 
-// printAgentSetupURL reads the relay config and prints the setup URL
-// that users should give to their agent.
-func printAgentSetupURL(dataDir string) {
+// relaySetupURL returns the setup URL for agents that connect via the relay.
+func relaySetupURL(dataDir string) (string, bool) {
 	daemonID, relayHost, err := readRelayConfig(dataDir)
-	if err != nil || daemonID == "" || relayHost == "" {
+	if err != nil || daemonID == "" {
+		return "", false
+	}
+
+	// config.yaml doesn't store the relay URL — derive it from the build-time default.
+	if relayHost == "" {
+		relayHost = strings.TrimPrefix(version.RelayURL(), "wss://")
+		relayHost = strings.TrimPrefix(relayHost, "ws://")
+	}
+
+	return fmt.Sprintf("https://%s/d/%s/skill/setup", relayHost, daemonID), true
+}
+
+// printAgentSetupPrompt prints a pasteable prompt that users can give to
+// any other coding agent to complete Clawvisor setup.
+func printAgentSetupPrompt(dataDir string) {
+	setupURL, ok := relaySetupURL(dataDir)
+	if !ok {
+		return
+	}
+
+	fmt.Println(bold.Padding(0, 2).Render("For all other agents"))
+	fmt.Println(dim.Padding(0, 2).Render("Paste the following to your agent to complete setup:"))
+	fmt.Println()
+	fmt.Println(green.Padding(0, 4).Render(fmt.Sprintf(
+		"I'd like to set up Clawvisor as the trusted gateway for using data\n"+
+			"and services. Please follow the instructions at:\n"+
+			"%s", setupURL)))
+	fmt.Println()
+}
+
+// printAgentSetupURL prints the raw setup URL for use in non-interactive
+// contexts (e.g. after pairing).
+func printAgentSetupURL(dataDir string) {
+	setupURL, ok := relaySetupURL(dataDir)
+	if !ok {
 		fmt.Println(dim.Padding(0, 2).Render("  Could not determine agent setup URL — relay not configured."))
 		return
 	}
 
-	setupURL := fmt.Sprintf("https://%s/d/%s/skill/setup", relayHost, daemonID)
-
 	fmt.Println()
-	fmt.Println(bold.Padding(0, 2).Render("Connect an agent"))
-	fmt.Println(dim.Padding(0, 2).Render("Copy this to your agent:"))
-	fmt.Println()
-	fmt.Printf("  Follow the instructions at %s\n", green.Render(setupURL))
+	fmt.Println(bold.Padding(0, 2).Render("Agent setup URL"))
+	fmt.Printf("  %s\n", green.Render(setupURL))
 	fmt.Println()
 }

--- a/internal/daemon/services_cmd.go
+++ b/internal/daemon/services_cmd.go
@@ -1,0 +1,239 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/charmbracelet/huh"
+)
+
+// Services runs the interactive service connection menu. Requires a running
+// daemon. If Google OAuth credentials are collected, the daemon is restarted
+// automatically so the new adapters are loaded.
+func Services() error {
+	dataDir, err := ensureDataDir()
+	if err != nil {
+		return err
+	}
+
+	apiClient, err := NewAPIClient()
+	if err != nil {
+		return err
+	}
+
+	needsRestart, err := runServiceSetup(apiClient, dataDir)
+	if err == huh.ErrUserAborted {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	if needsRestart {
+		fmt.Println()
+		fmt.Println(dim.Padding(0, 2).Render("  Restarting daemon with updated configuration..."))
+		if err := restartDaemon(); err != nil {
+			return fmt.Errorf("restarting daemon: %w", err)
+		}
+
+		// Wait for the daemon to be fully healthy before reconnecting.
+		serverURL, _, _ := readLocalSession(dataDir)
+		if serverURL == "" {
+			serverURL = "http://127.0.0.1:25297"
+		}
+		if err := waitForServer(serverURL); err != nil {
+			return fmt.Errorf("daemon did not become healthy after restart: %w", err)
+		}
+
+		fmt.Println(green.Padding(0, 2).Render("  ✓ Daemon restarted"))
+		fmt.Println()
+
+		// Re-authenticate after restart and resume service setup.
+		apiClient, err = NewAPIClient()
+		if err != nil {
+			return fmt.Errorf("reconnecting after restart: %w", err)
+		}
+		if _, err := runServiceSetup(apiClient, dataDir); err != nil && err != huh.ErrUserAborted {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ServicesList prints connected and available services.
+func ServicesList(asJSON bool) error {
+	apiClient, err := NewAPIClient()
+	if err != nil {
+		return err
+	}
+
+	resp, err := apiClient.GetServices()
+	if err != nil {
+		return fmt.Errorf("fetching services: %w", err)
+	}
+
+	services := injectMissingGoogleServices(resp.Services)
+
+	if asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(services)
+	}
+
+	if len(services) == 0 {
+		fmt.Println("No services available.")
+		return nil
+	}
+
+	fmt.Printf("%-20s  %-12s  %s\n", "SERVICE", "STATUS", "DESCRIPTION")
+	for _, s := range services {
+		status := s.Status
+		if status == "activated" {
+			status = green.Render("connected")
+		} else {
+			status = dim.Render("available")
+		}
+		name := s.Name
+		if s.Alias != "" {
+			name += dim.Render(" (" + s.Alias + ")")
+		}
+		fmt.Printf("%-20s  %-12s  %s\n", name, status, s.Description)
+	}
+	return nil
+}
+
+// ServicesAdd connects a service. If serviceID is empty, an interactive picker
+// is shown. Requires a running daemon.
+func ServicesAdd(serviceID string) error {
+	dataDir, err := ensureDataDir()
+	if err != nil {
+		return err
+	}
+
+	apiClient, err := NewAPIClient()
+	if err != nil {
+		return err
+	}
+
+	resp, err := apiClient.GetServices()
+	if err != nil {
+		return fmt.Errorf("fetching services: %w", err)
+	}
+
+	services := injectMissingGoogleServices(resp.Services)
+
+	if serviceID == "" {
+		// Interactive picker — show only unconnected services.
+		var opts []huh.Option[string]
+		for _, s := range services {
+			if s.Status != "activated" {
+				opts = append(opts, huh.NewOption(serviceLabel(s), serviceKey(s)))
+			}
+		}
+		if len(opts) == 0 {
+			fmt.Println("All services are already connected.")
+			return nil
+		}
+
+		var choice string
+		if err := huh.NewForm(
+			huh.NewGroup(
+				huh.NewSelect[string]().
+					Title("Select a service to connect").
+					Options(opts...).
+					Value(&choice),
+			),
+		).Run(); err != nil {
+			if err == huh.ErrUserAborted {
+				return nil
+			}
+			return err
+		}
+		serviceID = choice
+	}
+
+	// Find the service.
+	var found bool
+	for _, s := range services {
+		if serviceKey(s) == serviceID || s.ID == serviceID || strings.EqualFold(s.Name, serviceID) {
+			needsRestart, err := activateService(apiClient, s, dataDir)
+			if err != nil {
+				return fmt.Errorf("connecting %s: %w", s.Name, err)
+			}
+			if needsRestart {
+				fmt.Println(dim.Padding(0, 2).Render("  Restarting daemon with updated configuration..."))
+				if err := restartDaemon(); err != nil {
+					return fmt.Errorf("restarting daemon: %w", err)
+				}
+
+				serverURL, _, _ := readLocalSession(dataDir)
+				if serverURL == "" {
+					serverURL = "http://127.0.0.1:25297"
+				}
+				if err := waitForServer(serverURL); err != nil {
+					return fmt.Errorf("daemon did not become healthy after restart: %w", err)
+				}
+
+				fmt.Println(green.Padding(0, 2).Render("  ✓ Daemon restarted"))
+				fmt.Println()
+
+				// Re-authenticate and activate the service now that creds are loaded.
+				apiClient, err = NewAPIClient()
+				if err != nil {
+					return fmt.Errorf("reconnecting after restart: %w", err)
+				}
+				if _, activateErr := activateService(apiClient, s, dataDir); activateErr != nil {
+					return fmt.Errorf("connecting %s after restart: %w", s.Name, activateErr)
+				}
+			}
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return fmt.Errorf("service %q not found", serviceID)
+	}
+	return nil
+}
+
+// ServicesRemove disconnects a service. Requires a running daemon.
+func ServicesRemove(serviceID string) error {
+	apiClient, err := NewAPIClient()
+	if err != nil {
+		return err
+	}
+
+	resp, err := apiClient.GetServices()
+	if err != nil {
+		return fmt.Errorf("fetching services: %w", err)
+	}
+
+	// Find the service by ID, key, or name.
+	for _, s := range resp.Services {
+		if serviceKey(s) == serviceID || s.ID == serviceID || strings.EqualFold(s.Name, serviceID) {
+			if s.Status != "activated" {
+				return fmt.Errorf("%s is not connected", s.Name)
+			}
+			if err := apiClient.DeactivateService(s.ID, s.Alias); err != nil {
+				return fmt.Errorf("disconnecting %s: %w", s.Name, err)
+			}
+			fmt.Printf("  %s disconnected.\n", s.Name)
+			return nil
+		}
+	}
+
+	return fmt.Errorf("service %q not found", serviceID)
+}
+
+// restartDaemon stops and starts the daemon service so it picks up config
+// changes (e.g. new Google OAuth credentials).
+func restartDaemon() error {
+	if err := Stop(); err != nil {
+		return err
+	}
+	return Start()
+}

--- a/internal/daemon/setup.go
+++ b/internal/daemon/setup.go
@@ -271,7 +271,6 @@ func nonInteractive() bool {
 func runDaemonSetup(dataDir string) error {
 	configPath := filepath.Join(dataDir, "config.yaml")
 
-	var agents []knownAgent
 	relayEnabled := true
 
 	if nonInteractive() {
@@ -286,17 +285,8 @@ func runDaemonSetup(dataDir string) error {
 			return err
 		}
 
-		// Step 1: detect and manage agents.
+		// Step 1: relay opt-in.
 		var err error
-		agents, err = stepAgents()
-		if err != nil {
-			if err == huh.ErrUserAborted {
-				fmt.Println("\n  Aborted. No files were written.")
-			}
-			return err
-		}
-
-		// Step 2: relay opt-in.
 		relayEnabled, err = stepRelayOptIn()
 		if err != nil {
 			if err == huh.ErrUserAborted {
@@ -350,17 +340,6 @@ func runDaemonSetup(dataDir string) error {
 			fmt.Println(dim.Padding(0, 2).Render("  Daemon will work locally. Re-run setup to try again."))
 		}
 	}
-
-	// Offer to install the Claude Code slash command if detected.
-	if hasClaudeCode(agents) {
-		if err := offerClaudeCodeSetup(dataDir); err != nil && err != huh.ErrUserAborted {
-			fmt.Println(dim.Padding(0, 2).Render("  Warning: could not install Claude Code command: " + err.Error()))
-		}
-	}
-
-	// Claude Desktop MCP setup is deferred to printAgentSetupInstructions
-	// (after the daemon is fully running) so that mcp-remote can register
-	// via OAuth when Claude Desktop restarts.
 
 	fmt.Println()
 	fmt.Println(green.Padding(0, 2).Render("✓ Daemon configured"))


### PR DESCRIPTION
## Summary

- Splits the monolithic `setup`/`install` wizards into composable, independently re-runnable subcommands: `clawvisor services [list|add|remove]` and `clawvisor integrate [claude-code|claude-desktop]`
- Reworks `clawvisor install` as the guided end-to-end orchestrator (setup → install service → start daemon → services → integrate → dashboard) so `curl | sh` users still get a seamless walkthrough
- Slims `clawvisor setup` down to core config only (LLM, relay, telemetry)
- Removes the `runWithServiceSetup` temp server pattern — services and integrate now talk to the real running daemon, with Google OAuth auto-restart preserved via `Stop()`+`Start()`
- Adds per-agent section headers and richer copy in the integrate output (Claude Code, Claude Desktop, other agents)

## Test plan

- [ ] `clawvisor install` walks through full guided flow end-to-end
- [ ] `clawvisor setup` only configures LLM/relay/telemetry
- [ ] `clawvisor services list` prints connected/available services
- [ ] `clawvisor services add github` connects GitHub (with daemon running)
- [ ] `clawvisor services` shows interactive menu and handles Google OAuth restart
- [ ] `clawvisor integrate` auto-detects agents and shows per-agent sections
- [ ] `clawvisor integrate claude-code` installs slash command standalone

🤖 Generated with [Claude Code](https://claude.com/claude-code)