### PR TITLE
fix: fall back to default relay URL when config omits it

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -417,7 +417,7 @@ func (s *Server) routes() http.Handler {
 	// Device pairing and management
 	devicesHandler := handlers.NewDevicesHandler(s.store, s.pushNotifier, s.eventHub, s.logger, baseURL, s.jwtSvc)
 	if s.daemonID != "" {
-		relayHost := strings.TrimPrefix(strings.TrimPrefix(s.cfg.Relay.URL, "wss://"), "ws://")
+		relayHost := relayHostFromCfg(s.cfg.Relay.URL)
 		devicesHandler.SetRelayInfo(s.daemonID, relayHost)
 	}
 	s.devicesHandler = devicesHandler
@@ -504,12 +504,7 @@ func (s *Server) routes() http.Handler {
 		http.Redirect(w, r, "/skill/SKILL.md", http.StatusFound)
 	})
 	if s.daemonID != "" {
-		relayHost := ""
-		if s.cfg.Relay.URL != "" {
-			relayHost = s.cfg.Relay.URL
-			relayHost = strings.TrimPrefix(relayHost, "wss://")
-			relayHost = strings.TrimPrefix(relayHost, "ws://")
-		}
+		relayHost := relayHostFromCfg(s.cfg.Relay.URL)
 		onboardingHandler := handlers.NewOnboardingHandler(relayHost, s.daemonID)
 		mux.HandleFunc("GET /skill/setup", onboardingHandler.Setup)
 	}
@@ -786,4 +781,14 @@ func newKeyedLimiterFromBucket(b config.RateLimitBucket) *ratelimit.KeyedLimiter
 		rate.Limit(float64(b.Limit)/float64(b.Window)),
 		b.Limit,
 	)
+}
+
+// relayHostFromCfg returns the relay hostname, falling back to the default
+// relay URL when config.yaml omits the relay url field.
+func relayHostFromCfg(cfgURL string) string {
+	u := cfgURL
+	if u == "" {
+		u = version.RelayURL()
+	}
+	return strings.TrimPrefix(strings.TrimPrefix(u, "wss://"), "ws://")
 }

--- a/internal/daemon/pair.go
+++ b/internal/daemon/pair.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/clawvisor/clawvisor/pkg/version"
 	qrterminal "github.com/mdp/qrterminal/v3"
 	"gopkg.in/yaml.v3"
 )
@@ -137,9 +138,13 @@ func readRelayConfig(dataDir string) (daemonID, relayHost string, err error) {
 	}
 
 	// Extract host from relay URL (strip scheme).
-	host := cfg.Relay.URL
-	host = strings.TrimPrefix(host, "wss://")
-	host = strings.TrimPrefix(host, "ws://")
+	// Fall back to the default relay URL when config.yaml omits it
+	// (setup only writes daemon_id, not the relay URL).
+	relayURL := cfg.Relay.URL
+	if relayURL == "" {
+		relayURL = version.RelayURL()
+	}
+	host := strings.TrimPrefix(strings.TrimPrefix(relayURL, "wss://"), "ws://")
 
 	return cfg.Relay.DaemonID, host, nil
 }


### PR DESCRIPTION
## Summary
- `clawvisor setup` writes only `daemon_id` under the `relay:` config section but never the `url` field, so all relay host lookups returned an empty string
- This caused `clawvisor pair` to print `https:///authorize` (missing hostname), and `clawvisor start`/`clawvisor install` to silently skip printing the agent setup URL
- Adds a fallback to `version.RelayURL()` in both `readRelayConfig` (used by pair/start/install) and a new `relayHostFromCfg` helper in `server.go` (used by the pairing API and onboarding handler)

## Test plan
- [ ] Run `clawvisor pair` and verify the authorize URL includes the relay hostname
- [ ] Run `clawvisor start` and verify the agent setup URL is printed
- [ ] Set `CLAWVISOR_RELAY_URL` or add `url:` under `relay:` in config.yaml and verify it takes precedence over the default

🤖 Generated with [Claude Code](https://claude.com/claude-code)