### PR TITLE
fix: remove unnecessary polling for queue and LLM status

### DIFF
--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -29,11 +29,10 @@ export default function Dashboard() {
   // SSE event stream for instant dashboard updates
   useEventStream()
 
-  // Poll queue count for sidebar badge (fallback; SSE pushes invalidations)
+  // Queue count for sidebar badge (SSE pushes invalidations)
   const { data: queueData } = useQuery({
     queryKey: ['queue'],
     queryFn: () => api.queue.list(),
-    refetchInterval: 60_000,
   })
   const queueCount = queueData?.total ?? 0
 
@@ -49,8 +48,6 @@ export default function Dashboard() {
   const { data: llmStatus } = useQuery({
     queryKey: ['llm-status'],
     queryFn: () => api.llm.status(),
-    refetchInterval: 60_000,
-    staleTime: 30_000,
   })
 
   return (

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -82,8 +82,6 @@ function LLMSection() {
   const { data: status } = useQuery({
     queryKey: ['llm-status'],
     queryFn: () => api.llm.status(),
-    refetchInterval: 60_000,
-    staleTime: 30_000,
   })
 
   const updateMut = useMutation({


### PR DESCRIPTION
## Summary
- Removes 60s `refetchInterval` polling from the `/api/queue` and `/api/llm/status` queries in Dashboard and Settings
- Queue badge updates are already handled by SSE push invalidations, making the polling redundant
- LLM status (spend cap, provider info) rarely changes and doesn't need live polling — fetching once on mount is sufficient

## Test plan
- [ ] Verify the sidebar queue badge still updates when approval requests arrive (via SSE)
- [ ] Verify the LLM spend cap banner still shows on initial dashboard load
- [ ] Verify the Settings page still displays current LLM status on navigation
- [ ] Confirm no `/api/queue` or `/api/llm/status` requests in Network tab after initial load (only `/api/overview` should poll)