### PR TITLE
fix: hide LLM config editing in cloud deployments

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -335,7 +335,11 @@ func (s *Server) routes() http.Handler {
 	}
 	llmHandler := handlers.NewLLMHandler(s.llmHealth, configPath)
 	mux.Handle("GET /api/llm/status", user(llmHandler.Status))
-	mux.Handle("PUT /api/llm", user(llmHandler.Update))
+	// Cloud (multi-tenant) deployments manage LLM config centrally;
+	// only self-hosted installs may update it through the dashboard.
+	if !s.features.MultiTenant {
+		mux.Handle("PUT /api/llm", user(llmHandler.Update))
+	}
 
 	// Auth — core routes (always registered)
 	mux.Handle("POST /api/auth/refresh", authRateLimited(authHandler.Refresh))

--- a/web/dist/placeholder.html
+++ b/web/dist/placeholder.html
@@ -1,0 +1,1 @@
+<\!-- placeholder so go:embed dist succeeds without a full build -->

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -16,7 +16,7 @@ export default function Settings() {
     <div className="p-8 space-y-10">
       <h1 className="text-2xl font-bold text-text-primary">Settings</h1>
       <DaemonInfo />
-      <LLMSection />
+      <LLMSection canEdit={!features?.multi_tenant} />
       <DevicePairing />
       <TelegramSection />
       {passwordAuth && <PasswordSection />}
@@ -69,7 +69,7 @@ function DaemonInfo() {
 
 // ── LLM configuration ───────────────────────────────────────────────────────
 
-function LLMSection() {
+function LLMSection({ canEdit = true }: { canEdit?: boolean }) {
   const qc = useQueryClient()
   const [editing, setEditing] = useState(false)
   const [provider, setProvider] = useState('')
@@ -124,7 +124,7 @@ function LLMSection() {
       {error && <div className="text-sm text-danger max-w-lg">{error}</div>}
       {success && <div className="text-sm text-success max-w-lg">LLM configuration updated.</div>}
 
-      {status?.spend_cap_exhausted && !editing && (
+      {canEdit && status?.spend_cap_exhausted && !editing && (
         <div className="max-w-lg px-4 py-2.5 rounded-md bg-warning/10 border border-warning/30 text-sm text-text-primary">
           Free LLM credit exhausted. Add your own API key to restore verification and risk assessment.
         </div>
@@ -158,12 +158,14 @@ function LLMSection() {
               </div>
             </div>
           )}
-          <button
-            onClick={startEditing}
-            className="px-4 py-1.5 text-sm rounded border border-brand/30 text-brand hover:bg-brand/10"
-          >
-            {status?.spend_cap_exhausted ? 'Configure API key' : 'Update'}
-          </button>
+          {canEdit && (
+            <button
+              onClick={startEditing}
+              className="px-4 py-1.5 text-sm rounded border border-brand/30 text-brand hover:bg-brand/10"
+            >
+              {status?.spend_cap_exhausted ? 'Configure API key' : 'Update'}
+            </button>
+          )}
         </div>
       ) : (
         <div className="bg-surface-1 border border-border-default rounded-md p-5 space-y-3 max-w-lg">


### PR DESCRIPTION
## Summary
- Cloud (multi-tenant) deployments should not allow updating LLM configuration from the dashboard. The `PUT /api/llm` endpoint is now only registered for self-hosted installs, and the dashboard hides the edit button and spend-cap prompt when `multi_tenant` is enabled.
- Adds `web/dist/placeholder.html` (force-tracked past `.gitignore`) so that `go:embed dist` succeeds without a full frontend build, fixing a recurring issue for agents and local dev.

## Test plan
- [ ] Verify self-hosted dashboard still shows the LLM "Update" button and allows config changes
- [ ] Verify cloud (multi-tenant) dashboard shows LLM status as read-only with no edit button
- [ ] Verify `PUT /api/llm` returns 404 in multi-tenant mode
- [ ] Verify `go vet ./...` passes with only the placeholder in `web/dist/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)