### PR TITLE
fix: deduplicate paired devices by device_token during pairing

### DIFF
--- a/internal/api/handlers/devices.go
+++ b/internal/api/handlers/devices.go
@@ -189,7 +189,19 @@ func (h *DevicesHandler) CompletePairing(w http.ResponseWriter, r *http.Request)
 	}
 	hmacKeyHex := hex.EncodeToString(hmacKey)
 
-	// Remove stale devices (and their push tokens) before creating the new one.
+	// Deduplicate by device_token: remove any existing registrations for this
+	// physical device (across all users) so we don't accumulate stale entries
+	// that cause duplicate push notifications.
+	if existing, err := h.st.ListPairedDevicesByDeviceToken(r.Context(), body.DeviceToken); err == nil {
+		for _, old := range existing {
+			if h.pushN != nil {
+				_ = h.pushN.DeregisterDevice(r.Context(), old.DeviceToken)
+			}
+			_ = h.st.DeletePairedDevice(r.Context(), old.ID)
+		}
+	}
+
+	// Remove any remaining devices for this user (different tokens).
 	if existing, err := h.st.ListPairedDevices(r.Context(), session.UserID); err == nil {
 		for _, old := range existing {
 			if h.pushN != nil {

--- a/internal/api/handlers/devices_test.go
+++ b/internal/api/handlers/devices_test.go
@@ -57,6 +57,16 @@ func (s *devicesTestStore) ListPairedDevices(_ context.Context, userID string) (
 	return result, nil
 }
 
+func (s *devicesTestStore) ListPairedDevicesByDeviceToken(_ context.Context, deviceToken string) ([]*store.PairedDevice, error) {
+	var result []*store.PairedDevice
+	for _, d := range s.devices {
+		if d.DeviceToken == deviceToken {
+			result = append(result, d)
+		}
+	}
+	return result, nil
+}
+
 func (s *devicesTestStore) DeletePairedDevice(_ context.Context, id string) error {
 	delete(s.devices, id)
 	return nil
@@ -382,6 +392,56 @@ func TestDeleteForbidden(t *testing.T) {
 
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("expected 403, got %d", w.Code)
+	}
+}
+
+func TestCompletePairingDeduplicatesByDeviceToken(t *testing.T) {
+	st := newDevicesTestStore()
+	h := NewDevicesHandler(st, nil, events.NewHub(), slog.Default(), "http://localhost:9090", nil)
+
+	// Pre-seed a device for a different user with the same device_token.
+	st.devices["old-dev"] = &store.PairedDevice{
+		ID:          "old-dev",
+		UserID:      "other-user",
+		DeviceName:  "Old iPhone",
+		DeviceToken: "shared-apns-token",
+	}
+
+	// Start pairing for user u1.
+	req := httptest.NewRequest("POST", "/api/devices/pair", nil)
+	req = req.WithContext(withUser(req.Context(), &store.User{ID: "u1"}))
+	w := httptest.NewRecorder()
+	h.StartPairing(w, req)
+
+	var startResp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &startResp)
+	token := startResp["pairing_token"].(string)
+	code := startResp["code"].(string)
+
+	// Complete pairing with the same device_token.
+	completeBody, _ := json.Marshal(map[string]string{
+		"pairing_token": token,
+		"code":          code,
+		"device_name":   "New iPhone",
+		"device_token":  "shared-apns-token",
+	})
+	req = httptest.NewRequest("POST", "/api/devices/pair/complete", bytes.NewReader(completeBody))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	h.CompletePairing(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// The old device should have been removed.
+	if _, ok := st.devices["old-dev"]; ok {
+		t.Error("expected old device with same device_token to be removed")
+	}
+
+	// Only one device should remain (the new one).
+	if len(st.devices) != 1 {
+		t.Errorf("expected 1 device, got %d", len(st.devices))
 	}
 }
 

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -1311,6 +1311,28 @@ func (s *Store) ListPairedDevices(ctx context.Context, userID string) ([]*store.
 	return devices, rows.Err()
 }
 
+func (s *Store) ListPairedDevicesByDeviceToken(ctx context.Context, deviceToken string) ([]*store.PairedDevice, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT id, user_id, device_name, device_token, device_hmac_key, push_to_start_token, paired_at, last_seen_at
+		FROM paired_devices WHERE device_token = $1 ORDER BY paired_at DESC
+	`, deviceToken)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var devices []*store.PairedDevice
+	for rows.Next() {
+		d := &store.PairedDevice{}
+		if err := rows.Scan(&d.ID, &d.UserID, &d.DeviceName, &d.DeviceToken, &d.DeviceHMACKey, &d.PushToStartToken,
+			&d.PairedAt, &d.LastSeenAt); err != nil {
+			return nil, err
+		}
+		devices = append(devices, d)
+	}
+	return devices, rows.Err()
+}
+
 func (s *Store) DeletePairedDevice(ctx context.Context, id string) error {
 	tag, err := s.pool.Exec(ctx, `DELETE FROM paired_devices WHERE id = $1`, id)
 	if err != nil {

--- a/internal/store/sqlite/store.go
+++ b/internal/store/sqlite/store.go
@@ -1389,6 +1389,31 @@ func (s *Store) ListPairedDevices(ctx context.Context, userID string) ([]*store.
 	return devices, rows.Err()
 }
 
+func (s *Store) ListPairedDevicesByDeviceToken(ctx context.Context, deviceToken string) ([]*store.PairedDevice, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, user_id, device_name, device_token, device_hmac_key, push_to_start_token, paired_at, last_seen_at
+		FROM paired_devices WHERE device_token = ? ORDER BY paired_at DESC
+	`, deviceToken)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var devices []*store.PairedDevice
+	for rows.Next() {
+		d := &store.PairedDevice{}
+		var pairedAt, lastSeenAt string
+		if err := rows.Scan(&d.ID, &d.UserID, &d.DeviceName, &d.DeviceToken, &d.DeviceHMACKey, &d.PushToStartToken,
+			&pairedAt, &lastSeenAt); err != nil {
+			return nil, err
+		}
+		d.PairedAt = parseTime(pairedAt)
+		d.LastSeenAt = parseTime(lastSeenAt)
+		devices = append(devices, d)
+	}
+	return devices, rows.Err()
+}
+
 func (s *Store) DeletePairedDevice(ctx context.Context, id string) error {
 	res, err := s.db.ExecContext(ctx, `DELETE FROM paired_devices WHERE id = ?`, id)
 	if err != nil {

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -96,6 +96,7 @@ type Store interface {
 	GetPairedDevice(ctx context.Context, id string) (*PairedDevice, error)
 	ListPairedDevices(ctx context.Context, userID string) ([]*PairedDevice, error)
 	DeletePairedDevice(ctx context.Context, id string) error
+	ListPairedDevicesByDeviceToken(ctx context.Context, deviceToken string) ([]*PairedDevice, error)
 	UpdatePairedDeviceLastSeen(ctx context.Context, id string) error
 	UpdatePairedDevicePushToStartToken(ctx context.Context, id, token string) error
 


### PR DESCRIPTION
## Summary

- Re-pairing the same physical device accumulated multiple device registrations with the same APNs token, causing duplicate push notifications for every approval request.
- `CompletePairing` now looks up and removes any existing device entries sharing the incoming `device_token` (across all users) before creating the new registration.
- Adds `ListPairedDevicesByDeviceToken` to the store interface with SQLite and Postgres implementations.

## Test plan

- [x] New test `TestCompletePairingDeduplicatesByDeviceToken` verifies a pre-existing device under a different user with the same token is removed on re-pair
- [ ] Existing pairing tests continue to pass
- [ ] Manual: pair a device, re-pair the same device, verify only one device entry exists and push notifications are not duplicated

🤖 Generated with [Claude Code](https://claude.com/claude-code)