### PR TITLE
fix: return JSON content type for E2E error responses

### DIFF
--- a/internal/api/middleware/e2e.go
+++ b/internal/api/middleware/e2e.go
@@ -15,6 +15,15 @@ import (
 	"golang.org/x/crypto/hkdf"
 )
 
+// e2eError writes a JSON error response with the correct content type so that
+// clients using content-type sniffing can detect and retry E2E failures.
+func e2eError(w http.ResponseWriter, body string, code int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	w.Write([]byte(body))
+	w.Write([]byte("\n"))
+}
+
 // E2E wraps a gateway handler to transparently decrypt E2E-encrypted request
 // bodies and encrypt response bodies. The gateway handler is unaware of E2E —
 // it sees plaintext requests and writes plaintext responses.
@@ -25,7 +34,7 @@ func E2E(x25519Key *ecdh.PrivateKey) func(http.Handler) http.Handler {
 
 			if r.Header.Get("X-Clawvisor-E2E") == "" {
 				if viaRelay {
-					http.Error(w, `{"error":"E2E encryption required for requests through relay","code":"E2E_REQUIRED"}`, http.StatusForbidden)
+					e2eError(w, `{"error":"E2E encryption required for requests through relay","code":"E2E_REQUIRED"}`, http.StatusForbidden)
 					return
 				}
 				next.ServeHTTP(w, r)
@@ -35,31 +44,31 @@ func E2E(x25519Key *ecdh.PrivateKey) func(http.Handler) http.Handler {
 			// Read ephemeral public key from header.
 			ephKeyB64 := r.Header.Get("X-Clawvisor-Ephemeral-Key")
 			if ephKeyB64 == "" {
-				http.Error(w, `{"error":"missing X-Clawvisor-Ephemeral-Key header","code":"E2E_ERROR"}`, http.StatusBadRequest)
+				e2eError(w, `{"error":"missing X-Clawvisor-Ephemeral-Key header","code":"E2E_ERROR"}`, http.StatusBadRequest)
 				return
 			}
 
 			ephKeyBytes, err := base64.StdEncoding.DecodeString(ephKeyB64)
 			if err != nil {
-				http.Error(w, `{"error":"invalid ephemeral key encoding","code":"E2E_ERROR"}`, http.StatusBadRequest)
+				e2eError(w, `{"error":"invalid ephemeral key encoding","code":"E2E_ERROR"}`, http.StatusBadRequest)
 				return
 			}
 
 			ephPub, err := ecdh.X25519().NewPublicKey(ephKeyBytes)
 			if err != nil {
-				http.Error(w, `{"error":"invalid ephemeral public key","code":"E2E_ERROR"}`, http.StatusBadRequest)
+				e2eError(w, `{"error":"invalid ephemeral public key","code":"E2E_ERROR"}`, http.StatusBadRequest)
 				return
 			}
 
 			// ECDH → shared secret → HKDF derived key.
 			rawShared, err := x25519Key.ECDH(ephPub)
 			if err != nil {
-				http.Error(w, `{"error":"ECDH key exchange failed","code":"E2E_ERROR"}`, http.StatusInternalServerError)
+				e2eError(w, `{"error":"ECDH key exchange failed","code":"E2E_ERROR"}`, http.StatusInternalServerError)
 				return
 			}
 			shared := make([]byte, 32)
 			if _, err := io.ReadFull(hkdf.New(sha256.New, rawShared, nil, []byte("clawvisor-e2e-v1")), shared); err != nil {
-				http.Error(w, `{"error":"key derivation failed","code":"E2E_ERROR"}`, http.StatusInternalServerError)
+				e2eError(w, `{"error":"key derivation failed","code":"E2E_ERROR"}`, http.StatusInternalServerError)
 				return
 			}
 
@@ -68,7 +77,7 @@ func E2E(x25519Key *ecdh.PrivateKey) func(http.Handler) http.Handler {
 			if r.Body != nil && r.ContentLength != 0 {
 				ciphertextB64, err := io.ReadAll(r.Body)
 				if err != nil {
-					http.Error(w, `{"error":"failed to read request body","code":"E2E_ERROR"}`, http.StatusBadRequest)
+					e2eError(w, `{"error":"failed to read request body","code":"E2E_ERROR"}`, http.StatusBadRequest)
 					return
 				}
 				r.Body.Close()
@@ -76,12 +85,12 @@ func E2E(x25519Key *ecdh.PrivateKey) func(http.Handler) http.Handler {
 				if len(ciphertextB64) > 0 {
 					ciphertext, err := base64.StdEncoding.DecodeString(string(ciphertextB64))
 					if err != nil {
-						http.Error(w, `{"error":"invalid ciphertext encoding","code":"E2E_ERROR"}`, http.StatusBadRequest)
+						e2eError(w, `{"error":"invalid ciphertext encoding","code":"E2E_ERROR"}`, http.StatusBadRequest)
 						return
 					}
 
 					if len(ciphertext) < 12+16 {
-						http.Error(w, `{"error":"ciphertext too short","code":"E2E_ERROR"}`, http.StatusBadRequest)
+						e2eError(w, `{"error":"ciphertext too short","code":"E2E_ERROR"}`, http.StatusBadRequest)
 						return
 					}
 
@@ -90,18 +99,18 @@ func E2E(x25519Key *ecdh.PrivateKey) func(http.Handler) http.Handler {
 
 					block, err := aes.NewCipher(shared)
 					if err != nil {
-						http.Error(w, `{"error":"cipher init failed","code":"E2E_ERROR"}`, http.StatusInternalServerError)
+						e2eError(w, `{"error":"cipher init failed","code":"E2E_ERROR"}`, http.StatusInternalServerError)
 						return
 					}
 					gcm, err := cipher.NewGCM(block)
 					if err != nil {
-						http.Error(w, `{"error":"GCM init failed","code":"E2E_ERROR"}`, http.StatusInternalServerError)
+						e2eError(w, `{"error":"GCM init failed","code":"E2E_ERROR"}`, http.StatusInternalServerError)
 						return
 					}
 
 					plaintext, err := gcm.Open(nil, nonce, encData, nil)
 					if err != nil {
-						http.Error(w, `{"error":"decryption failed","code":"E2E_ERROR"}`, http.StatusBadRequest)
+						e2eError(w, `{"error":"decryption failed","code":"E2E_ERROR"}`, http.StatusBadRequest)
 						return
 					}
 

--- a/internal/api/middleware/e2e_test.go
+++ b/internal/api/middleware/e2e_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -188,5 +189,72 @@ func TestE2E_MissingEphemeralKey(t *testing.T) {
 
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status: got %d, want 400", rec.Code)
+	}
+}
+
+func TestE2E_ErrorResponsesAreJSON(t *testing.T) {
+	// E2E error responses must have Content-Type: application/json so that
+	// clients using content-type sniffing can JSON.parse and detect the
+	// E2E_ERROR code for retry logic.
+	daemonKey, _ := ecdh.X25519().GenerateKey(rand.Reader)
+	handler := E2E(daemonKey)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("handler should not be called")
+	}))
+
+	tests := []struct {
+		name    string
+		setup   func(r *http.Request)
+		wantCT  string
+		wantKey string // expected "code" field in JSON response
+	}{
+		{
+			name: "missing ephemeral key",
+			setup: func(r *http.Request) {
+				r.Header.Set("X-Clawvisor-E2E", "aes-256-gcm")
+			},
+			wantCT:  "application/json",
+			wantKey: "E2E_ERROR",
+		},
+		{
+			name: "invalid ephemeral key encoding",
+			setup: func(r *http.Request) {
+				r.Header.Set("X-Clawvisor-E2E", "aes-256-gcm")
+				r.Header.Set("X-Clawvisor-Ephemeral-Key", "not-valid-base64!!!")
+			},
+			wantCT:  "application/json",
+			wantKey: "E2E_ERROR",
+		},
+		{
+			name: "relay without E2E",
+			setup: func(r *http.Request) {
+				ctx := relay.WithViaRelay(r.Context())
+				*r = *r.WithContext(ctx)
+			},
+			wantCT:  "application/json",
+			wantKey: "E2E_REQUIRED",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("POST", "/api/gateway/request", bytes.NewReader([]byte("test")))
+			tt.setup(req)
+
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			ct := rec.Header().Get("Content-Type")
+			if ct != tt.wantCT {
+				t.Errorf("Content-Type: got %q, want %q", ct, tt.wantCT)
+			}
+
+			var resp map[string]string
+			if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("response is not valid JSON: %v\nbody: %s", err, rec.Body.String())
+			}
+			if resp["code"] != tt.wantKey {
+				t.Errorf("code: got %q, want %q", resp["code"], tt.wantKey)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- E2E middleware error responses used `http.Error()` which sets `Content-Type: text/plain`, but the bodies are JSON. Clients that check content type before calling `JSON.parse` (e.g. the e2e.mjs skill, which needs to support non-JSON endpoints like the catalog) would skip parsing, causing `result?.code === 'E2E_ERROR'` to fail on the raw string. This broke the stale-key retry logic.
- Introduces an `e2eError()` helper that sets `Content-Type: application/json` on all E2E error responses.
- Adds `TestE2E_ErrorResponsesAreJSON` to verify error responses are parseable JSON with the correct content type.

## Test plan
- [x] All existing E2E middleware tests pass
- [x] New `TestE2E_ErrorResponsesAreJSON` covers missing ephemeral key, invalid encoding, and relay-without-E2E cases
- [x] Manual test: `node e2e.mjs` against relay successfully encrypts/decrypts round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)