### PR TITLE
feat: add create_draft action to Gmail adapter

### DIFF
--- a/internal/adapters/google/gmail/adapter.go
+++ b/internal/adapters/google/gmail/adapter.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"mime"
 	"net/http"
+	"os"
 	"strings"
 
 	"golang.org/x/oauth2"
@@ -21,10 +22,26 @@ import (
 
 const serviceID = "google.gmail"
 
-// gmailScopes are the OAuth scopes required by the Gmail adapter.
-var gmailScopes = []string{
+// gmailBaseScopes are always requested.
+var gmailBaseScopes = []string{
 	"https://www.googleapis.com/auth/gmail.readonly",
 	"https://www.googleapis.com/auth/gmail.send",
+}
+
+// draftsEnabled reports whether the create_draft action is available.
+// Set GMAIL_DRAFTS_ENABLED=false to disable in environments where the
+// gmail.compose scope has not yet been approved.
+func draftsEnabled() bool {
+	return os.Getenv("GMAIL_DRAFTS_ENABLED") != "false"
+}
+
+// gmailScopes returns the scopes to request, including gmail.compose
+// only when drafts are enabled.
+func gmailScopes() []string {
+	if !draftsEnabled() {
+		return gmailBaseScopes
+	}
+	return append(gmailBaseScopes, "https://www.googleapis.com/auth/gmail.compose")
 }
 
 // GmailAdapter implements adapters.Adapter for Gmail.
@@ -45,23 +62,27 @@ func New(clientID, clientSecret, redirectURL string) *GmailAdapter {
 func (a *GmailAdapter) ServiceID() string { return serviceID }
 
 func (a *GmailAdapter) SupportedActions() []string {
-	return []string{"list_messages", "get_message", "send_message"}
+	actions := []string{"list_messages", "get_message", "send_message"}
+	if draftsEnabled() {
+		actions = append(actions, "create_draft")
+	}
+	return actions
 }
 
-func (a *GmailAdapter) RequiredScopes() []string { return gmailScopes }
+func (a *GmailAdapter) RequiredScopes() []string { return gmailScopes() }
 
 func (a *GmailAdapter) OAuthConfig() *oauth2.Config {
 	return &oauth2.Config{
 		ClientID:     a.clientID,
 		ClientSecret: a.clientSecret,
 		RedirectURL:  a.redirectURL,
-		Scopes:       gmailScopes,
+		Scopes:       gmailScopes(),
 		Endpoint:     google.Endpoint,
 	}
 }
 
 func (a *GmailAdapter) CredentialFromToken(token *oauth2.Token) ([]byte, error) {
-	return credential.FromToken(token, gmailScopes)
+	return credential.FromToken(token, gmailScopes())
 }
 
 func (a *GmailAdapter) ValidateCredential(credBytes []byte) error {
@@ -82,6 +103,11 @@ func (a *GmailAdapter) Execute(ctx context.Context, req adapters.Request) (*adap
 		return a.getMessage(ctx, client, req.Params)
 	case "send_message":
 		return a.sendMessage(ctx, client, req.Params)
+	case "create_draft":
+		if err := a.requireComposeScope(req.Credential); err != nil {
+			return nil, err
+		}
+		return a.createDraft(ctx, client, req.Params)
 	default:
 		return nil, fmt.Errorf("gmail: unsupported action %q", req.Action)
 	}
@@ -288,6 +314,63 @@ func (a *GmailAdapter) sendMessage(ctx context.Context, client *http.Client, par
 		"subject":    subject,
 	}
 	summary := format.Summary("Email sent to %s (subject: %q)", to, subject)
+	return &adapters.Result{Summary: summary, Data: result}, nil
+}
+
+// requireComposeScope checks whether the stored credential includes the
+// gmail.compose scope. Legacy tokens that only have gmail.send will fail
+// with a descriptive error prompting the user to reconnect.
+func (a *GmailAdapter) requireComposeScope(credBytes []byte) error {
+	cred, err := credential.Parse(credBytes)
+	if err != nil {
+		return fmt.Errorf("gmail create_draft: %w", err)
+	}
+	if !credential.HasAllScopes(cred.Scopes, []string{"https://www.googleapis.com/auth/gmail.compose"}) {
+		return fmt.Errorf("gmail create_draft: the gmail.compose scope is required — please reconnect your Google account to grant draft permissions")
+	}
+	return nil
+}
+
+// ── create_draft ──────────────────────────────────────────────────────────────
+
+func (a *GmailAdapter) createDraft(ctx context.Context, client *http.Client, params map[string]any) (*adapters.Result, error) {
+	to, _ := params["to"].(string)
+	subject, _ := params["subject"].(string)
+	body, _ := params["body"].(string)
+	inReplyTo, _ := params["in_reply_to"].(string)
+
+	if to == "" {
+		return nil, fmt.Errorf("gmail create_draft: to is required")
+	}
+	if subject == "" {
+		return nil, fmt.Errorf("gmail create_draft: subject is required")
+	}
+
+	raw := buildMIMEMessage(to, subject, body, inReplyTo)
+	encoded := base64.URLEncoding.EncodeToString([]byte(raw))
+
+	payload := map[string]any{
+		"message": map[string]string{"raw": encoded},
+	}
+
+	var draftResp struct {
+		ID      string `json:"id"`
+		Message struct {
+			ID string `json:"id"`
+		} `json:"message"`
+	}
+	if err := gmailPOST(ctx, client, "https://gmail.googleapis.com/gmail/v1/users/me/drafts",
+		payload, &draftResp); err != nil {
+		return nil, fmt.Errorf("gmail create_draft: %w", err)
+	}
+
+	result := map[string]string{
+		"draft_id":   draftResp.ID,
+		"message_id": draftResp.Message.ID,
+		"to":         to,
+		"subject":    subject,
+	}
+	summary := format.Summary("Draft created for %s (subject: %q)", to, subject)
 	return &adapters.Result{Summary: summary, Data: result}, nil
 }
 

--- a/internal/taskrisk/prompts.go
+++ b/internal/taskrisk/prompts.go
@@ -56,6 +56,7 @@ var actionContext = map[string]ActionMeta{
 	"google.gmail:list_messages": {Category: "read", Sensitivity: "low", Description: "List email messages"},
 	"google.gmail:get_message":   {Category: "read", Sensitivity: "low", Description: "Read a specific email message"},
 	"google.gmail:send_message":  {Category: "write", Sensitivity: "high", Description: "Send email as the user"},
+	"google.gmail:create_draft":  {Category: "write", Sensitivity: "low", Description: "Create an email draft (not sent)"},
 
 	// Google Calendar
 	"google.calendar:list_events":    {Category: "read", Sensitivity: "low", Description: "List calendar events"},

--- a/web/src/lib/services.ts
+++ b/web/src/lib/services.ts
@@ -101,7 +101,7 @@ export const SERVICE_BRAND_COLORS: Record<string, {
 }
 
 export const SERVICE_DESCRIPTIONS: Record<string, string> = {
-  'google.gmail': 'Read, search, and send email',
+  'google.gmail': 'Read, search, send, and draft email',
   'google.calendar': 'View and manage calendar events',
   'google.drive': 'List, search, and manage files',
   'google.contacts': 'Search and view contacts',
@@ -124,6 +124,7 @@ export const ACTION_DISPLAY_NAMES: Record<string, string> = {
   list_messages: 'List messages',
   get_message: 'Get message',
   send_message: 'Send message',
+  create_draft: 'Create draft',
   // Calendar
   list_events: 'List events',
   get_event: 'Get event',


### PR DESCRIPTION
## Summary
- Adds a `create_draft` Gmail action that creates email drafts via the Gmail API drafts endpoint.
- Requests `gmail.compose` scope alongside existing `gmail.send` so legacy tokens continue working for send_message.
- Legacy tokens missing `gmail.compose` get a clear error prompting reconnection.
- Gated by `GMAIL_DRAFTS_ENABLED=false` env var to disable in cloud until the compose scope is approved by Google.
- Adds risk classification (write/low), UI display name, and updated service description.

## Test plan
- [ ] Verify `create_draft` works with a fresh OAuth token (has both scopes)
- [ ] Verify `send_message` still works with a legacy token (only `gmail.send`)
- [ ] Verify `create_draft` returns a clear error with a legacy token
- [ ] Verify `GMAIL_DRAFTS_ENABLED=false` hides the action and omits `gmail.compose` from requested scopes
- [ ] Run `go test ./internal/taskrisk/ ./internal/intent/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)