### PR TITLE
Deduplicate identical task creation requests

### DIFF
--- a/internal/api/dedup_task_test.go
+++ b/internal/api/dedup_task_test.go
@@ -1,0 +1,107 @@
+package api_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+func TestTask_ContentDedup_IdenticalCreation(t *testing.T) {
+	// Two identical task creation requests from the same agent should return
+	// the same task_id — only one task should be created.
+	adapter := newMockAdapter("mock.taskdedup", "run")
+	env := newTestEnv(t, adapter)
+	sc := newScenario(t, env, "taskdedup-ident")
+	sc.activateService(t, env, "mock.taskdedup")
+
+	body := map[string]any{
+		"purpose": "dedup test task",
+		"authorized_actions": []map[string]any{{
+			"service": "mock.taskdedup", "action": "run", "auto_execute": true,
+		}},
+	}
+
+	resp1 := env.do("POST", "/api/tasks", sc.AgentToken, body)
+	b1 := mustStatus(t, resp1, http.StatusCreated)
+	if b1["status"] != "pending_approval" {
+		t.Fatalf("first: expected pending_approval, got %v", b1["status"])
+	}
+	taskID1 := str(t, b1, "task_id")
+
+	resp2 := env.do("POST", "/api/tasks", sc.AgentToken, body)
+	b2 := mustStatus(t, resp2, http.StatusCreated)
+	taskID2 := str(t, b2, "task_id")
+
+	if taskID1 != taskID2 {
+		t.Errorf("expected same task_id for identical requests, got %q and %q", taskID1, taskID2)
+	}
+
+	// Only one task should exist.
+	resp := sc.session.do("GET", "/api/tasks", nil)
+	tasksBody := mustStatus(t, resp, http.StatusOK)
+	count := 0
+	for _, e := range arr(t, tasksBody, "tasks") {
+		task := e.(map[string]any)
+		if task["purpose"] == "dedup test task" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected 1 task, got %d", count)
+	}
+}
+
+func TestTask_ContentDedup_DifferentPurpose_NotDeduped(t *testing.T) {
+	// Tasks with different purposes should not be deduped.
+	adapter := newMockAdapter("mock.taskdedup2", "run")
+	env := newTestEnv(t, adapter)
+	sc := newScenario(t, env, "taskdedup-diff")
+	sc.activateService(t, env, "mock.taskdedup2")
+
+	resp1 := env.do("POST", "/api/tasks", sc.AgentToken, map[string]any{
+		"purpose": fmt.Sprintf("purpose A %s", randSuffix()),
+		"authorized_actions": []map[string]any{{
+			"service": "mock.taskdedup2", "action": "run", "auto_execute": true,
+		}},
+	})
+	b1 := mustStatus(t, resp1, http.StatusCreated)
+
+	resp2 := env.do("POST", "/api/tasks", sc.AgentToken, map[string]any{
+		"purpose": fmt.Sprintf("purpose B %s", randSuffix()),
+		"authorized_actions": []map[string]any{{
+			"service": "mock.taskdedup2", "action": "run", "auto_execute": true,
+		}},
+	})
+	b2 := mustStatus(t, resp2, http.StatusCreated)
+
+	if b1["task_id"] == b2["task_id"] {
+		t.Error("different purposes should produce different tasks")
+	}
+}
+
+func TestTask_ContentDedup_DifferentAgents_NotDeduped(t *testing.T) {
+	// Different agents creating identical tasks should not be deduped.
+	adapter := newMockAdapter("mock.taskdedup3", "run")
+	env := newTestEnv(t, adapter)
+	sc1 := newScenario(t, env, "taskdedup-ag1")
+	sc2 := newScenario(t, env, "taskdedup-ag2")
+	sc1.activateService(t, env, "mock.taskdedup3")
+	sc2.activateService(t, env, "mock.taskdedup3")
+
+	body := map[string]any{
+		"purpose": "shared purpose task",
+		"authorized_actions": []map[string]any{{
+			"service": "mock.taskdedup3", "action": "run", "auto_execute": true,
+		}},
+	}
+
+	resp1 := env.do("POST", "/api/tasks", sc1.AgentToken, body)
+	b1 := mustStatus(t, resp1, http.StatusCreated)
+
+	resp2 := env.do("POST", "/api/tasks", sc2.AgentToken, body)
+	b2 := mustStatus(t, resp2, http.StatusCreated)
+
+	if b1["task_id"] == b2["task_id"] {
+		t.Error("different agents should produce different tasks")
+	}
+}

--- a/internal/api/handlers/dedup_cache.go
+++ b/internal/api/handlers/dedup_cache.go
@@ -1,0 +1,99 @@
+package handlers
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+)
+
+type dedupKey string
+
+type dedupEntry struct {
+	value     any
+	expiresAt time.Time
+}
+
+// dedupCache is a short-lived, in-memory cache keyed by content hash.
+// It deduplicates identical requests that arrive within a configurable TTL window.
+type dedupCache struct {
+	mu      sync.Mutex
+	entries map[dedupKey]dedupEntry
+	ttl     time.Duration
+	done    chan struct{}
+}
+
+func newDedupCache(ttl time.Duration) *dedupCache {
+	c := &dedupCache{
+		entries: make(map[dedupKey]dedupEntry),
+		ttl:     ttl,
+		done:    make(chan struct{}),
+	}
+	go c.cleanupLoop()
+	return c
+}
+
+// Get returns a cached value if one exists and hasn't expired.
+func (c *dedupCache) Get(key dedupKey) (any, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	entry, ok := c.entries[key]
+	if !ok {
+		return nil, false
+	}
+	if time.Now().After(entry.expiresAt) {
+		delete(c.entries, key)
+		return nil, false
+	}
+	return entry.value, true
+}
+
+// Put stores a value in the cache.
+func (c *dedupCache) Put(key dedupKey, value any) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.entries[key] = dedupEntry{
+		value:     value,
+		expiresAt: time.Now().Add(c.ttl),
+	}
+}
+
+// Stop stops the background cleanup goroutine.
+func (c *dedupCache) Stop() {
+	close(c.done)
+}
+
+func (c *dedupCache) cleanupLoop() {
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			c.cleanup()
+		case <-c.done:
+			return
+		}
+	}
+}
+
+func (c *dedupCache) cleanup() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := time.Now()
+	for k, v := range c.entries {
+		if now.After(v.expiresAt) {
+			delete(c.entries, k)
+		}
+	}
+}
+
+// buildDedupKey builds a cache key by hashing all provided parts.
+func buildDedupKey(parts ...any) dedupKey {
+	b, _ := json.Marshal(parts)
+	h := sha256.Sum256(b)
+	return dedupKey(fmt.Sprintf("%x", h[:16]))
+}

--- a/internal/api/handlers/dedup_cache_test.go
+++ b/internal/api/handlers/dedup_cache_test.go
@@ -1,0 +1,100 @@
+package handlers
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestDedupCache_PutAndGet(t *testing.T) {
+	c := newDedupCache(5 * time.Second)
+	defer c.Stop()
+
+	key := buildDedupKey("agent1", "svc", "act", map[string]any{"k": "v"})
+	c.Put(key, "cached-value")
+
+	got, ok := c.Get(key)
+	if !ok {
+		t.Fatal("expected cache hit")
+	}
+	if got != "cached-value" {
+		t.Errorf("got %v, want %q", got, "cached-value")
+	}
+}
+
+func TestDedupCache_Miss(t *testing.T) {
+	c := newDedupCache(5 * time.Second)
+	defer c.Stop()
+
+	key := buildDedupKey("agent1", "svc", "act")
+	if _, ok := c.Get(key); ok {
+		t.Fatal("expected cache miss")
+	}
+}
+
+func TestDedupCache_Expiry(t *testing.T) {
+	c := newDedupCache(10 * time.Millisecond)
+	defer c.Stop()
+
+	key := buildDedupKey("agent1", "svc", "act")
+	c.Put(key, "value")
+
+	time.Sleep(20 * time.Millisecond)
+
+	if _, ok := c.Get(key); ok {
+		t.Fatal("expected cache miss after expiry")
+	}
+}
+
+func TestDedupCache_DifferentKeys(t *testing.T) {
+	c := newDedupCache(5 * time.Second)
+	defer c.Stop()
+
+	k1 := buildDedupKey("agent1", "svc", "act", map[string]any{"k": "v1"})
+	k2 := buildDedupKey("agent1", "svc", "act", map[string]any{"k": "v2"})
+	k3 := buildDedupKey("agent2", "svc", "act", map[string]any{"k": "v1"})
+
+	c.Put(k1, "r1")
+
+	if _, ok := c.Get(k2); ok {
+		t.Error("different params should not match")
+	}
+	if _, ok := c.Get(k3); ok {
+		t.Error("different agent should not match")
+	}
+}
+
+func TestDedupCache_Cleanup(t *testing.T) {
+	c := newDedupCache(10 * time.Millisecond)
+	defer c.Stop()
+
+	key := buildDedupKey("agent1", "svc", "act")
+	c.Put(key, "value")
+
+	time.Sleep(20 * time.Millisecond)
+	c.cleanup()
+
+	c.mu.Lock()
+	count := len(c.entries)
+	c.mu.Unlock()
+	if count != 0 {
+		t.Errorf("expected 0 entries after cleanup, got %d", count)
+	}
+}
+
+func TestDedupCache_ThreadSafety(t *testing.T) {
+	c := newDedupCache(5 * time.Second)
+	defer c.Stop()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			key := buildDedupKey("agent1", "svc", "act")
+			c.Put(key, "value")
+			c.Get(key)
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -43,16 +43,16 @@ type pendingRequestBlob struct {
 
 // GatewayHandler handles POST /api/gateway/request.
 type GatewayHandler struct {
-	store      store.Store
-	vault      vault.Vault
-	adapterReg *adapters.Registry
-	notifier   notify.Notifier // may be nil if Telegram not configured
-	verifier   intent.Verifier
-	extractor  intent.Extractor
-	cfg        config.Config
-	logger     *slog.Logger
-	baseURL    string
-	eventHub   *events.Hub
+	store        store.Store
+	vault        vault.Vault
+	adapterReg   *adapters.Registry
+	notifier     notify.Notifier // may be nil if Telegram not configured
+	verifier     intent.Verifier
+	extractor    intent.Extractor
+	cfg          config.Config
+	logger       *slog.Logger
+	baseURL  string
+	eventHub *events.Hub
 }
 
 func NewGatewayHandler(

--- a/internal/api/handlers/tasks.go
+++ b/internal/api/handlers/tasks.go
@@ -35,15 +35,16 @@ func RequiresHardcodedApproval(service, action string) bool {
 
 // TasksHandler manages task-scoped authorization.
 type TasksHandler struct {
-	st         store.Store
-	vault      vault.Vault
-	adapterReg *adapters.Registry
-	notifier   notify.Notifier
-	cfg        config.Config
-	logger     *slog.Logger
-	baseURL    string
-	eventHub   *events.Hub
-	assessor   taskrisk.Assessor
+	st           store.Store
+	vault        vault.Vault
+	adapterReg   *adapters.Registry
+	notifier     notify.Notifier
+	cfg          config.Config
+	logger       *slog.Logger
+	baseURL      string
+	eventHub     *events.Hub
+	assessor     taskrisk.Assessor
+	contentDedup *dedupCache
 }
 
 func NewTasksHandler(
@@ -57,9 +58,14 @@ func NewTasksHandler(
 	eventHub *events.Hub,
 	assessor taskrisk.Assessor,
 ) *TasksHandler {
+	dedupTTL := time.Duration(cfg.Gateway.ContentDedupTTLSeconds) * time.Second
+	if dedupTTL <= 0 {
+		dedupTTL = 5 * time.Second
+	}
 	return &TasksHandler{
 		st: st, vault: v, adapterReg: adapterReg, notifier: notifier, cfg: cfg, logger: logger, baseURL: baseURL,
 		eventHub: eventHub, assessor: assessor,
+		contentDedup: newDedupCache(dedupTTL),
 	}
 }
 
@@ -144,6 +150,15 @@ func (h *TasksHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Content-based dedup: if an identical task creation request was recently made
+	// by the same agent, return the existing task instead of creating a duplicate.
+	taskDedupKey := buildDedupKey("task", agent.ID, req.Purpose, req.AuthorizedActions, lifetime)
+	if cached, ok := h.contentDedup.Get(taskDedupKey); ok {
+		resp := cached.(map[string]any)
+		writeJSON(w, http.StatusCreated, resp)
+		return
+	}
+
 	expiresIn := req.ExpiresInSeconds
 	if expiresIn <= 0 {
 		expiresIn = h.cfg.Task.DefaultExpirySeconds
@@ -214,11 +229,13 @@ func (h *TasksHandler) Create(w http.ResponseWriter, r *http.Request) {
 
 	h.publishTasksAndQueue(agent.UserID)
 
-	writeJSON(w, http.StatusCreated, map[string]any{
+	resp := map[string]any{
 		"task_id": task.ID,
 		"status":  "pending_approval",
 		"message": "Task approval requested. Waiting for human review.",
-	})
+	}
+	h.contentDedup.Put(taskDedupKey, resp)
+	writeJSON(w, http.StatusCreated, resp)
 }
 
 // ── Get ───────────────────────────────────────────────────────────────────────

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	Approval  ApprovalConfig  `yaml:"approval"`
 	Callback  CallbackConfig  `yaml:"callback"`
 	Task      TaskConfig      `yaml:"task"`
+	Gateway   GatewayConfig   `yaml:"gateway"`
 	LLM       LLMConfig       `yaml:"llm"`
 	MCP       MCPConfig       `yaml:"mcp"`
 	Services  ServicesConfig  `yaml:"services"`
@@ -37,6 +38,11 @@ type Config struct {
 	Push      PushConfig      `yaml:"push"`
 
 	AutoConfig AutoConfigured `yaml:"-"`
+}
+
+// GatewayConfig holds settings for the gateway request handler.
+type GatewayConfig struct {
+	ContentDedupTTLSeconds int `yaml:"content_dedup_ttl_seconds"` // default: 5
 }
 
 // RelayConfig holds settings for the cloud relay connection.
@@ -257,6 +263,9 @@ func Default() *Config {
 		},
 		Task: TaskConfig{
 			DefaultExpirySeconds: 1800,
+		},
+		Gateway: GatewayConfig{
+			ContentDedupTTLSeconds: 5,
 		},
 		LLM: LLMConfig{
 			Provider:       "anthropic",


### PR DESCRIPTION
## Summary

- Adds a short-lived content-based cache to the task creation endpoint that deduplicates identical requests arriving within a configurable time window (default 5s)
- Solves an issue where agents like Perplexity issue multiple identical task creation requests in rapid succession, causing duplicate notifications and approval queue entries
- Removes the previous gateway-level content dedup (was too broad) and scopes dedup to task creation only

## Test plan

- [x] Unit tests for dedup cache (`dedup_cache_test.go`)
- [x] Integration test for task creation dedup (`dedup_task_test.go`)
- [ ] Manual test with Perplexity agent issuing rapid duplicate task requests
- [ ] Verify single notification/approval entry per deduplicated batch

🤖 Generated with [Claude Code](https://claude.com/claude-code)