### PR TITLE
feat: deduplicate SKILL.md into shared template, add Cowork plugin

### DIFF
--- a/coworkplugin/embed.go
+++ b/coworkplugin/embed.go
@@ -1,0 +1,8 @@
+// Package coworkplugin embeds the Clawvisor Cowork plugin files so they can
+// be installed into Claude Desktop's plugin directory during integration.
+package coworkplugin
+
+import "embed"
+
+//go:embed all:plugin
+var FS embed.FS

--- a/coworkplugin/plugin/.claude-plugin/plugin.json
+++ b/coworkplugin/plugin/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "clawvisor",
+  "version": "0.2.0",
+  "description": "Route actions through Clawvisor for credential vaulting, task-scoped authorization, and human approval flows. Access Gmail, Calendar, Drive, GitHub, Slack, Notion, Linear, and more — without holding credentials.",
+  "author": {
+    "name": "Clawvisor",
+    "url": "https://github.com/clawvisor"
+  },
+  "homepage": "https://github.com/clawvisor/clawvisor",
+  "license": "MIT"
+}

--- a/coworkplugin/plugin/.mcp.json
+++ b/coworkplugin/plugin/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "clawvisor-local": {
+      "command": "npx",
+      "args": ["mcp-remote", "http://localhost:25297/mcp"]
+    }
+  }
+}

--- a/coworkplugin/plugin/CLAUDE.md
+++ b/coworkplugin/plugin/CLAUDE.md
@@ -1,0 +1,26 @@
+# Clawvisor Plugin
+
+Clawvisor is a gatekeeper between you and external services (Gmail, Calendar, Drive, GitHub, Slack, Notion, Linear, iMessage, etc.). Every action goes through Clawvisor, which checks restrictions, validates task scopes, injects credentials, optionally routes to the user for approval, and returns a clean result. You never hold API keys.
+
+This plugin provides MCP tools for interacting with Clawvisor and commands for common workflows.
+
+## MCP Tools
+
+The `clawvisor-local` MCP server provides six tools:
+- `fetch_catalog` — See available services, actions, and restrictions
+- `create_task` — Declare your purpose and the actions you need
+- `get_task` — Check task status (supports long-polling with `wait: true`)
+- `complete_task` — Mark a task as completed
+- `expand_task` — Add new actions to an existing task scope
+- `gateway_request` — Execute service actions under an approved task
+
+## Commands
+
+- `/clawvisor:check-services` — Fetch the service catalog and show what's connected
+- `/clawvisor:triage-inbox` — Triage recent emails, classify by urgency and action needed
+- `/clawvisor:check-messages` — Review recent iMessage threads and identify ones needing replies
+- `/clawvisor:daily-briefing` — Morning briefing across email, calendar, and messages
+
+## Skills
+
+- **clawvisor** — Complete workflow guide for task-scoped authorization, gateway requests, and response handling

--- a/coworkplugin/plugin/LICENSE
+++ b/coworkplugin/plugin/LICENSE
@@ -1,0 +1,93 @@
+Elastic License 2.0
+
+URL: https://www.elastic.co/licensing/elastic-license
+
+## Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+## Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case subject to
+the limitations and conditions below.
+
+## Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial set of
+the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key functionality
+in the software, and you may not remove or obscure any functionality in the
+software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other notices
+of the licensor in the software. Any use of the licensor's trademarks is subject
+to applicable law.
+
+## Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer for
+sale, import and have imported the software, in each case subject to the
+limitations and conditions in this license. This license does not cover any
+patent claims that you cause to be infringed by modifications or additions to
+the software. If you or your company make any written claim that the software
+infringes or contributes to infringement of any patent, your patent license for
+the software granted under these terms ends immediately. If your company makes
+such a claim, your patent license ends immediately for work on behalf of your
+company.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you
+also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+## No Other Rights
+
+These terms do not imply any licenses other than those expressly granted in
+these terms.
+
+## Termination
+
+If you use the software in violation of these terms, such use is not licensed,
+and your licenses will automatically terminate. If the licensor provides you
+with a notice of your violation, and you cease all violation of this license no
+later than 30 days after you receive that notice, your licenses will be
+reinstated retroactively. However, if you violate these terms after such
+reinstatement, any additional violation of these terms will cause your licenses
+to terminate automatically and permanently.
+
+## No Liability
+
+*As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.*
+
+## Definitions
+
+The **licensor** is the entity offering these terms, and the **software** is the
+software the licensor makes available under these terms, including any portion
+of it.
+
+**you** refers to the individual or entity agreeing to these terms.
+
+**your company** is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that
+organization. **control** means ownership of substantially all the assets of an
+entity, or the power to direct its management and policies by vote, contract, or
+otherwise. Control can be direct or indirect.
+
+**your licenses** are all the licenses granted to you for the software under
+these terms.
+
+**use** means anything you do with the software requiring one of your licenses.
+
+**trademark** means trademarks, service marks, and similar rights.

--- a/coworkplugin/plugin/commands/check-messages.md
+++ b/coworkplugin/plugin/commands/check-messages.md
@@ -1,0 +1,41 @@
+---
+description: Review recent iMessage threads and identify ones needing replies
+---
+
+1. Use `fetch_catalog` to confirm iMessage (`apple.imessage`) is connected and `list_threads` / `get_thread` are not restricted.
+
+2. Use `create_task` with:
+   - **purpose**: "Review recent iMessage threads and identify ones needing replies"
+   - **authorized_actions**:
+     - `apple.imessage` / `list_threads` — `auto_execute: true` — "List recent iMessage threads to find ones needing attention"
+     - `apple.imessage` / `get_thread` — `auto_execute: true` — "Read individual thread messages to check reply status"
+   - **expires_in_seconds**: 1800
+
+3. Tell the user: "I've requested access to read your iMessage threads. Please approve the task in Clawvisor."
+
+4. Use `get_task` with `wait: true` to long-poll until approved. If denied, stop.
+
+5. Once approved, use `gateway_request` to list recent threads (last 24-48 hours).
+
+6. For each thread, read it and classify:
+   - **Needs reply** — the last message is from the other person and seems to expect a response
+   - **Waiting** — the last message is from the user; awaiting a reply from the other person
+   - **Resolved** — conversation appears complete
+
+7. Present the results:
+   ```
+   💬 iMessage Check — <date>
+
+   📩 Needs your reply
+   - <contact> — "<last message preview>" — <time ago>
+
+   ⏳ Waiting for reply
+   - <contact> — you said: "<last message preview>" — <time ago>
+
+   ✅ Resolved
+   - <count> threads with no pending action
+   ```
+
+8. Ask if the user wants to reply to any thread. If so, use `expand_task` to add `send_message` with `auto_execute: false`, then draft and send via `gateway_request`.
+
+9. Use `complete_task` when done.

--- a/coworkplugin/plugin/commands/check-services.md
+++ b/coworkplugin/plugin/commands/check-services.md
@@ -1,0 +1,15 @@
+---
+description: Fetch the Clawvisor service catalog and show what's connected
+---
+
+1. Use the `fetch_catalog` tool to get the current service catalog from Clawvisor.
+
+2. Present the results in a clear summary:
+
+   **Connected services** — list each active service with its available actions, noting which actions are restricted (blocked by the user).
+
+   **Available to connect** — list services that are supported but not yet activated, so the user knows what else they can enable in the Clawvisor dashboard.
+
+3. If any services have restrictions, explain what they mean: restricted actions are hard-blocked by the user and cannot be used regardless of task approval.
+
+4. If the catalog fetch fails with an auth error, let the user know the MCP connection may need to be re-authorized (Settings → Plugins → Clawvisor → Reconnect).

--- a/coworkplugin/plugin/commands/daily-briefing.md
+++ b/coworkplugin/plugin/commands/daily-briefing.md
@@ -1,0 +1,50 @@
+---
+description: Morning briefing across email, calendar, and messages
+---
+
+1. Use `fetch_catalog` to check which services are connected. This command works best with Gmail, Calendar, and iMessage, but adapt to whatever is available.
+
+2. Use `create_task` with:
+   - **purpose**: "Daily briefing — summarize today's calendar, recent emails, and messages needing attention"
+   - **authorized_actions** (include only services that are connected and not restricted):
+     - `google.calendar` / `list_events` — `auto_execute: true` — "List today's calendar events for the briefing"
+     - `google.gmail` / `list_messages` — `auto_execute: true` — "List recent inbox emails for the briefing"
+     - `google.gmail` / `get_message` — `auto_execute: true` — "Read emails to summarize key items"
+     - `apple.imessage` / `list_threads` — `auto_execute: true` — "List recent iMessage threads"
+     - `apple.imessage` / `get_thread` — `auto_execute: true` — "Read threads to check reply status"
+   - **expires_in_seconds**: 1800
+
+3. Tell the user: "I've requested access for your daily briefing. Please approve the task in Clawvisor."
+
+4. Use `get_task` with `wait: true` to long-poll until approved. If denied, stop.
+
+5. Once approved, gather data in parallel where possible:
+
+   **Calendar** — Fetch today's events. Note start times, meeting titles, and attendees.
+
+   **Email** — List recent inbox messages (since yesterday). Read the important ones and classify: urgent, follow-up, or FYI.
+
+   **Messages** — List recent iMessage threads. Identify any that need a reply.
+
+6. Present the briefing:
+   ```
+   ☀️ Daily Briefing — <date>
+
+   📅 Today's Schedule
+   - <time> — <event title> (with <attendees>)
+   - <time> — <event title>
+   - <N> meetings total, <free hours> hours free
+
+   📬 Email Highlights
+   - 🔴 <count> urgent — <brief descriptions>
+   - 🟡 <count> follow-ups
+   - <total> new emails since yesterday
+
+   💬 Messages
+   - <count> threads need your reply
+   - <contact>: "<preview>" — <time ago>
+   ```
+
+7. Ask if the user wants to drill into anything — read a specific email, reply to a message, or check a calendar event's details.
+
+8. Use `complete_task` when done.

--- a/coworkplugin/plugin/commands/triage-inbox.md
+++ b/coworkplugin/plugin/commands/triage-inbox.md
@@ -1,0 +1,45 @@
+---
+description: Triage recent emails — classify by urgency and action needed
+---
+
+1. Use `fetch_catalog` to confirm Gmail (`google.gmail`) is connected and `list_messages` / `get_message` are not restricted.
+
+2. Use `create_task` with:
+   - **purpose**: "Triage recent inbox emails — classify by urgency and identify action items"
+   - **authorized_actions**:
+     - `google.gmail` / `list_messages` — `auto_execute: true` — "List recent inbox emails to identify ones needing triage"
+     - `google.gmail` / `get_message` — `auto_execute: true` — "Read individual emails to classify urgency and extract action items"
+   - **expires_in_seconds**: 1800
+
+3. Tell the user: "I've requested access to read your recent emails. Please approve the task in Clawvisor."
+
+4. Use `get_task` with `wait: true` to long-poll until the task is approved. If denied, let the user know and stop.
+
+5. Once approved, use `gateway_request` to list recent inbox messages (last 24-48 hours or ~20 messages, whichever is more useful).
+
+6. For each message, read it with `gateway_request` and classify:
+   - **Urgent / action needed** — requires a response or action today
+   - **Follow-up** — needs attention but not time-sensitive
+   - **FYI** — informational, no action needed
+   - **Low priority** — newsletters, notifications, etc.
+
+7. Present the triage as a structured summary:
+   ```
+   📬 Inbox Triage — <date>
+
+   🔴 Urgent (action needed)
+   - <sender> — <subject> — <one-line summary of what's needed>
+
+   🟡 Follow-up
+   - <sender> — <subject> — <one-line summary>
+
+   🟢 FYI
+   - <sender> — <subject>
+
+   ⚪ Low priority
+   - <count> newsletters/notifications skipped
+   ```
+
+8. Ask if the user wants to drill into any email or draft a reply. If they want to reply, use `expand_task` to add `create_draft` with `auto_execute: false`.
+
+9. Use `complete_task` when done.

--- a/coworkplugin/plugin/skills/clawvisor/SKILL.md
+++ b/coworkplugin/plugin/skills/clawvisor/SKILL.md
@@ -1,0 +1,2 @@
+This file is a placeholder. The actual SKILL.md is rendered from the shared
+template at skills/clawvisor/SKILL.md.tmpl during plugin installation.

--- a/internal/daemon/claude_code.go
+++ b/internal/daemon/claude_code.go
@@ -3,16 +3,20 @@ package daemon
 import (
 	"bufio"
 	"crypto/md5" //nolint:gosec // used only for cache key derivation matching mcp-remote's convention
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/huh"
+	"github.com/clawvisor/clawvisor/coworkplugin"
 	"github.com/clawvisor/clawvisor/pkg/version"
 	"github.com/clawvisor/clawvisor/skills"
 )
@@ -188,17 +192,18 @@ func installClaudeCodeCommand(dataDir string) error {
 	return nil
 }
 
-// writeStrippedSkill reads the embedded SKILL.md, strips the YAML frontmatter,
-// and writes the result to dest.
+// writeStrippedSkill renders the SKILL.md template for Claude Code, strips the
+// YAML frontmatter, appends Claude Code-specific guidance, and writes the
+// result to dest.
 func writeStrippedSkill(dest string) error {
-	raw, err := skills.FS.ReadFile("clawvisor/SKILL.md")
+	rendered, err := skills.Render(skills.TargetClaudeCode)
 	if err != nil {
-		return fmt.Errorf("reading embedded SKILL.md: %w", err)
+		return fmt.Errorf("rendering SKILL.md: %w", err)
 	}
 
 	// Strip YAML frontmatter (the --- delimited block at the top).
 	var b strings.Builder
-	scanner := bufio.NewScanner(strings.NewReader(string(raw)))
+	scanner := bufio.NewScanner(strings.NewReader(rendered))
 	fences := 0
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -385,6 +390,11 @@ func offerClaudeDesktopSetup() {
 			return
 		}
 		fmt.Println(green.Padding(0, 2).Render("  ✓ Configured Claude Desktop MCP"))
+		if err := installCoworkPlugin(); err != nil {
+			fmt.Println(dim.Padding(0, 2).Render("  Warning: could not install Cowork plugin: " + err.Error()))
+		} else {
+			fmt.Println(green.Padding(0, 2).Render("  ✓ Installed Clawvisor Cowork plugin"))
+		}
 		fmt.Println(dim.Padding(0, 2).Render("  Restart Claude Desktop and authorize when prompted."))
 		return
 	}
@@ -425,6 +435,14 @@ func offerClaudeDesktopSetup() {
 
 	fmt.Println(green.Padding(0, 2).Render("  ✓ MCP server added to Claude Desktop config"))
 	fmt.Println(dim.Padding(0, 2).Render("  " + configPath))
+
+	// Install the Cowork plugin (commands, skills, CLAUDE.md).
+	if err := installCoworkPlugin(); err != nil {
+		fmt.Println(yellow.Padding(0, 2).Render("  Could not install Cowork plugin: " + err.Error()))
+		fmt.Println(dim.Padding(0, 2).Render("  You can install it manually: Settings → Plugins → Install from local source"))
+	} else {
+		fmt.Println(green.Padding(0, 2).Render("  ✓ Installed Clawvisor Cowork plugin"))
+	}
 	fmt.Println()
 
 	// Offer to restart Claude Desktop.
@@ -558,6 +576,241 @@ func offerClaudeCodeCurlPermission() error {
 	fmt.Println(green.Padding(0, 2).Render("  ✓ Auto-approve rules added to ~/.claude/settings.json"))
 	fmt.Println()
 	return nil
+}
+
+// installCoworkPlugin copies the embedded Clawvisor Cowork plugin into Claude
+// Desktop's plugin directories. The plugin system uses three locations:
+//
+//  1. marketplaces/local-desktop-app-uploads/<name>/ — the marketplace source
+//  2. cache/local-desktop-app-uploads/<name>/<version>/ — the installed copy
+//  3. installed_plugins.json — the registry of installed plugins
+//  4. .install-manifests/<name>@local-desktop-app-uploads.json — file checksums
+//
+// All four must be populated for Claude Desktop to recognize the plugin.
+func installCoworkPlugin() error {
+	pluginsDir, err := findCoworkPluginsDir()
+	if err != nil {
+		return err
+	}
+
+	// Read the plugin version from the embedded plugin.json.
+	pluginJSON, err := coworkplugin.FS.ReadFile("plugin/.claude-plugin/plugin.json")
+	if err != nil {
+		return fmt.Errorf("reading embedded plugin.json: %w", err)
+	}
+	var meta struct {
+		Name    string `json:"name"`
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(pluginJSON, &meta); err != nil {
+		return fmt.Errorf("parsing plugin.json: %w", err)
+	}
+
+	cacheDir := filepath.Join(pluginsDir, "cache", "local-desktop-app-uploads", meta.Name, meta.Version)
+	marketplaceDir := filepath.Join(pluginsDir, "marketplaces", "local-desktop-app-uploads", meta.Name)
+
+	// Render the SKILL.md from the shared template for the Cowork target.
+	renderedSkill, err := skills.Render(skills.TargetCowork)
+	if err != nil {
+		return fmt.Errorf("rendering SKILL.md: %w", err)
+	}
+
+	// Copy embedded files to both the cache and marketplace directories.
+	// The SKILL.md is replaced with the rendered version from the template.
+	// Track file hashes for the install manifest.
+	fileHashes := make(map[string]string)
+
+	writeFile := func(rel string, data []byte) error {
+		h := sha256.Sum256(data)
+		fileHashes[rel] = hex.EncodeToString(h[:])
+
+		for _, dir := range []string{cacheDir, marketplaceDir} {
+			dest := filepath.Join(dir, rel)
+			if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
+				return err
+			}
+			if err := os.WriteFile(dest, data, 0644); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	if err := fs.WalkDir(coworkplugin.FS, "plugin", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		rel, err := filepath.Rel("plugin", path)
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			if err := os.MkdirAll(filepath.Join(cacheDir, rel), 0755); err != nil {
+				return err
+			}
+			return os.MkdirAll(filepath.Join(marketplaceDir, rel), 0755)
+		}
+
+		// Replace the embedded SKILL.md with the template-rendered version.
+		if rel == filepath.Join("skills", "clawvisor", "SKILL.md") {
+			return writeFile(rel, []byte(renderedSkill))
+		}
+
+		data, err := coworkplugin.FS.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("reading embedded %s: %w", path, err)
+		}
+
+		return writeFile(rel, data)
+	}); err != nil {
+		return fmt.Errorf("copying plugin files: %w", err)
+	}
+
+	// Update installed_plugins.json registry.
+	pluginID := meta.Name + "@local-desktop-app-uploads"
+	now := nowUTC()
+	if err := updateInstalledPlugins(pluginsDir, pluginID, cacheDir, meta.Version, now); err != nil {
+		return fmt.Errorf("updating plugin registry: %w", err)
+	}
+
+	// Write install manifest.
+	if err := writeInstallManifest(pluginsDir, pluginID, fileHashes, now); err != nil {
+		return fmt.Errorf("writing install manifest: %w", err)
+	}
+
+	return nil
+}
+
+// nowUTC returns the current time formatted as an RFC3339 string with
+// millisecond precision, matching the format used by Claude Desktop.
+func nowUTC() string {
+	return time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
+}
+
+// updateInstalledPlugins adds or updates the plugin entry in installed_plugins.json.
+func updateInstalledPlugins(pluginsDir, pluginID, installPath, version, now string) error {
+	path := filepath.Join(pluginsDir, "installed_plugins.json")
+
+	var registry struct {
+		Version int                        `json:"version"`
+		Plugins map[string]json.RawMessage `json:"plugins"`
+	}
+
+	data, err := os.ReadFile(path)
+	if err == nil {
+		if err := json.Unmarshal(data, &registry); err != nil {
+			return fmt.Errorf("parsing installed_plugins.json: %w", err)
+		}
+	} else if os.IsNotExist(err) {
+		registry.Version = 2
+		registry.Plugins = make(map[string]json.RawMessage)
+	} else {
+		return err
+	}
+
+	if registry.Plugins == nil {
+		registry.Plugins = make(map[string]json.RawMessage)
+	}
+
+	entry := []map[string]any{
+		{
+			"scope":       "user",
+			"installPath": installPath,
+			"version":     version,
+			"installedAt": now,
+			"lastUpdated": now,
+		},
+	}
+
+	entryJSON, err := json.Marshal(entry)
+	if err != nil {
+		return err
+	}
+	registry.Plugins[pluginID] = json.RawMessage(entryJSON)
+
+	out, err := json.MarshalIndent(registry, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(out, '\n'), 0644)
+}
+
+// writeInstallManifest creates the .install-manifests/<pluginID>.json file
+// with SHA-256 checksums of all plugin files.
+func writeInstallManifest(pluginsDir, pluginID string, fileHashes map[string]string, now string) error {
+	manifestDir := filepath.Join(pluginsDir, ".install-manifests")
+	if err := os.MkdirAll(manifestDir, 0755); err != nil {
+		return err
+	}
+
+	manifest := map[string]any{
+		"pluginId":  pluginID,
+		"createdAt": now,
+		"files":     fileHashes,
+	}
+
+	out, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	path := filepath.Join(manifestDir, pluginID+".json")
+	return os.WriteFile(path, append(out, '\n'), 0644)
+}
+
+// findCoworkPluginsDir searches for the cowork_plugins directory under
+// Claude Desktop's Application Support directory. The path includes
+// session-specific UUIDs, so we search for the directory rather than
+// constructing it.
+func findCoworkPluginsDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolving home directory: %w", err)
+	}
+
+	var baseDir string
+	switch runtime.GOOS {
+	case "darwin":
+		baseDir = filepath.Join(home, "Library", "Application Support", "Claude", "local-agent-mode-sessions")
+	case "linux":
+		xdg := os.Getenv("XDG_CONFIG_HOME")
+		if xdg == "" {
+			xdg = filepath.Join(home, ".config")
+		}
+		baseDir = filepath.Join(xdg, "Claude", "local-agent-mode-sessions")
+	default:
+		return "", fmt.Errorf("unsupported platform")
+	}
+
+	// Search for the cowork_plugins directory. There should be exactly one
+	// under the session hierarchy: <org-id>/<user-id>/cowork_plugins/
+	var found string
+	_ = filepath.WalkDir(baseDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil // skip inaccessible directories
+		}
+		if d.IsDir() && d.Name() == "cowork_plugins" {
+			found = path
+			return filepath.SkipAll
+		}
+		// Don't descend into cowork_plugins subdirectories or session data.
+		if d.IsDir() {
+			// Allow descending into org/user UUID dirs (2 levels deep).
+			depth := strings.Count(strings.TrimPrefix(path, baseDir), string(filepath.Separator))
+			if depth > 2 {
+				return filepath.SkipDir
+			}
+		}
+		return nil
+	})
+
+	if found == "" {
+		return "", fmt.Errorf("could not find cowork_plugins directory under %s", baseDir)
+	}
+
+	return found, nil
 }
 
 // addClaudePermissionRules reads a Claude Code settings.json file, adds the

--- a/internal/mcp/prompts.go
+++ b/internal/mcp/prompts.go
@@ -1,5 +1,12 @@
 package mcp
 
+import (
+	"log"
+	"sync"
+
+	"github.com/clawvisor/clawvisor/skills"
+)
+
 // Prompt is an MCP prompt definition.
 type Prompt struct {
 	Name        string `json:"name"`
@@ -8,8 +15,8 @@ type Prompt struct {
 
 // PromptMessage is a message in a prompt response.
 type PromptMessage struct {
-	Role    string        `json:"role"`
-	Content ToolContent   `json:"content"`
+	Role    string      `json:"role"`
+	Content ToolContent `json:"content"`
 }
 
 // promptDefs returns the static list of MCP prompts.
@@ -28,8 +35,8 @@ func promptContent(name string) (string, []PromptMessage, bool) {
 	case "clawvisor-workflow":
 		return "Clawvisor workflow instructions", []PromptMessage{
 			{
-				Role: "user",
-				Content: ToolContent{Type: "text", Text: workflowPrompt},
+				Role:    "user",
+				Content: ToolContent{Type: "text", Text: getWorkflowPrompt()},
 			},
 		}, true
 	default:
@@ -37,74 +44,22 @@ func promptContent(name string) (string, []PromptMessage, bool) {
 	}
 }
 
-const workflowPrompt = `# Clawvisor Workflow
+var (
+	workflowPromptOnce sync.Once
+	workflowPromptText string
+)
 
-You are connected to Clawvisor via MCP. Clawvisor is a gatekeeper between you and external services (Gmail, Calendar, Drive, GitHub, Slack, iMessage, etc.). Every action goes through Clawvisor, which checks restrictions, validates task scopes, injects credentials, optionally routes to the user for approval, and returns a clean result. You never hold API keys.
-
-## Authorization Model
-
-Two layers, applied in order:
-1. **Restrictions** — hard blocks the user sets. If a restriction matches, the action is blocked immediately.
-2. **Tasks** — scopes you declare. Every request must be attached to an approved task. Actions with ` + "`auto_execute: true`" + ` run without per-request approval. Actions with ` + "`auto_execute: false`" + ` still require per-request approval within the task.
-
-## Typical Flow
-
-1. **Fetch the catalog** — use the ` + "`fetch_catalog`" + ` tool to see available services, actions, and restrictions
-2. **Create a task** — use ` + "`create_task`" + ` — this blocks until the user approves or denies
-3. **Make gateway requests** — use ` + "`gateway_request`" + ` for each action — auto-execute actions return immediately; actions requiring approval block until approved and return the result
-4. **Complete the task** — use ` + "`complete_task`" + ` when done
-
-## Creating Tasks
-
-When calling ` + "`create_task`" + `:
-- **` + "`purpose`" + `** — shown to the user during approval. Be specific: "Review last 30 iMessage threads and classify reply status" is better than "Use iMessage."
-- **` + "`authorized_actions`" + `** — list each service + action pair you need, with:
-  - ` + "`auto_execute: true`" + ` for read-only actions you want to run immediately
-  - ` + "`auto_execute: false`" + ` for destructive actions (send, delete, etc.) that should require per-request approval
-  - ` + "`expected_use`" + ` — describe how you'll use each action. Shown during approval and verified against your actual requests.
-- **` + "`lifetime`" + `** — ` + "`\"session\"`" + ` (default, expires) or ` + "`\"standing\"`" + ` (no expiry, persists until revoked)
-- **` + "`expires_in_seconds`" + `** — TTL for session tasks (default 1800)
-
-All tasks start as ` + "`pending_approval`" + `. The ` + "`create_task`" + ` tool blocks by default until the task is approved or denied. If the long-poll times out while still pending, call ` + "`get_task`" + ` with ` + "`wait: true`" + ` to resume waiting.
-
-### Standing Tasks
-
-For recurring workflows, set ` + "`lifetime: \"standing\"`" + `. Standing tasks require a ` + "`session_id`" + ` in gateway requests to enable chain context verification across related requests.
-
-### Scope Expansion
-
-If you need an action not in the original task scope, use ` + "`expand_task`" + ` with the new action and a reason. This blocks until the user approves or denies the expansion.
-
-## Gateway Requests
-
-When calling ` + "`gateway_request`" + `:
-- **` + "`service`" + `** and **` + "`action`" + `** — from the catalog
-- **` + "`params`" + `** — action-specific parameters (documented in the catalog)
-- **` + "`reason`" + `** — one sentence explaining why. Be specific.
-- **` + "`request_id`" + `** — a unique ID you generate (e.g. UUID). Must be unique across all your requests.
-- **` + "`task_id`" + `** — the approved task ID this request belongs to
-
-## Handling Responses
-
-Every gateway response has a ` + "`status`" + ` field:
-
-| Status | Meaning | What to do |
-|---|---|---|
-| ` + "`executed`" + ` | Action completed | Use the result. Report to the user. |
-| ` + "`pending`" + ` | Awaiting human approval | Tell the user. If the long-poll timed out, use ` + "`execute_request`" + ` with the same request_id to resume waiting and get the result once approved. Do not send a new gateway_request. |
-| ` + "`blocked`" + ` | A restriction blocks this | Tell the user. Do not retry or work around it. |
-| ` + "`restricted`" + ` | Intent verification rejected | Your params/reason were inconsistent with the task purpose. Adjust and retry with a new request_id. |
-| ` + "`pending_task_approval`" + ` | Task not yet approved | Use ` + "`get_task`" + ` with ` + "`wait: true`" + ` until approved. |
-| ` + "`pending_scope_expansion`" + ` | Action outside task scope | Use expand_task. |
-| ` + "`task_expired`" + ` | Task TTL exceeded | Expand or create a new task. |
-| ` + "`error`" + ` | Something went wrong | Report the error to the user. Do not silently retry. |
-
-## Important Rules
-
-- Always fetch the catalog first to know what's available and restricted
-- Never attempt to bypass restrictions — they are hard blocks set by the user
-- Always create a task before making gateway requests
-- Use ` + "`auto_execute: false`" + ` for any action that sends, modifies, or deletes data
-- Generate unique request_ids for every gateway request
-- Complete tasks when done to clean up authorization scope
-`
+// getWorkflowPrompt lazily renders the MCP workflow prompt from the shared
+// SKILL.md template.
+func getWorkflowPrompt() string {
+	workflowPromptOnce.Do(func() {
+		text, err := skills.Render(skills.TargetMCP)
+		if err != nil {
+			log.Printf("WARNING: failed to render MCP workflow prompt: %v", err)
+			workflowPromptText = "Error rendering workflow prompt. Use fetch_catalog, create_task, get_task, gateway_request, expand_task, and complete_task tools."
+			return
+		}
+		workflowPromptText = text
+	})
+	return workflowPromptText
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -85,7 +85,7 @@ func (s *Server) handleInitialize(w http.ResponseWriter, r *http.Request, req *R
 			"name":    "clawvisor",
 			"version": "1.0.0",
 		},
-		"instructions": workflowPrompt,
+		"instructions": getWorkflowPrompt(),
 	})
 }
 

--- a/skills/clawvisor/SKILL.md.tmpl
+++ b/skills/clawvisor/SKILL.md.tmpl
@@ -1,3 +1,4 @@
+{{- if eq .Target "claude-code" -}}
 ---
 name: clawvisor
 description: >
@@ -18,7 +19,18 @@ metadata:
       },
   }
 ---
-
+{{- else if eq .Target "cowork" -}}
+---
+name: clawvisor
+description: >
+  Route tool requests through Clawvisor for credential vaulting, task-scoped
+  authorization, and human approval flows. Use for Gmail, Calendar, Drive,
+  Contacts, GitHub, Slack, Notion, Linear, Stripe, Twilio, and iMessage.
+  Clawvisor enforces restrictions, manages task scopes, and injects
+  credentials — you never handle secrets directly.
+---
+{{- end }}
+{{ if eq .Target "claude-code" -}}
 # Clawvisor Skill
 
 ## Setup
@@ -42,6 +54,12 @@ If you were given a setup URL (e.g. `https://relay.clawvisor.com/d/<id>/skill/se
 
 ## Overview
 
+{{ else -}}
+# Clawvisor
+
+{{ end -}}
+{{ if eq .Target "mcp" -}}
+You are connected to Clawvisor via MCP. {{ end -}}
 Clawvisor is a gatekeeper between you and external services. Every action goes
 through Clawvisor, which checks restrictions, validates task scopes, injects
 credentials, optionally routes to the user for approval, and returns a clean
@@ -54,16 +72,23 @@ The authorization model has two layers — applied in order:
 ---
 
 ## Typical Flow
-
+{{ if .UseCurl }}
 1. Fetch the catalog — confirm the service is active and the action isn't restricted
 2. Create a task with `POST /api/tasks?wait=true` — this blocks until the user approves
 3. Make gateway requests with `POST /api/gateway/request?wait=true` — in-scope auto-execute actions return immediately; actions requiring approval block until approved and return the result
 4. Mark the task complete when done
+{{ else }}
+1. **Fetch the catalog** — use `fetch_catalog` to see available services, actions, and restrictions
+2. **Create a task** — use `create_task` to declare your purpose and the actions you need
+3. **Wait for approval** — use `get_task` with `wait: true` to long-poll until the user approves (or denies) the task
+4. **Make gateway requests** — use `gateway_request` for each action, under the approved task scope
+5. **Complete the task** — use `complete_task` when done
+{{ end -}}
 
 ---
 
 ## Getting Your Service Catalog
-
+{{ if .UseCurl }}
 At the start of each session, fetch your personalized service catalog:
 
 ```
@@ -75,12 +100,20 @@ This returns the services available to you, their supported actions, which
 actions are restricted (blocked), and a list of services you can ask the user
 to activate. Always fetch this before making gateway requests so you know
 what's available and what is restricted.
+{{ else }}
+At the start of each session, use `fetch_catalog` to see what's available. This
+returns the services available to you, their supported actions, which actions are
+restricted (blocked), and a list of services you can ask the user to activate.
+Always check this before making gateway requests so you know what's available and
+what is restricted.
+{{ end -}}
 
 ---
 
 ## Task-Scoped Access
 
-Before making gateway requests, declare a task scope with your purpose and the
+Before making gateway requests,
+{{- if .UseCurl }} declare a task scope with your purpose and the
 actions you need:
 
 ```bash
@@ -96,22 +129,28 @@ curl -s -X POST "$CLAWVISOR_URL/api/tasks?wait=true" \
     "expires_in_seconds": 1800
   }'
 ```
-
-- **`purpose`** — shown to the user during approval and used by intent verification to ensure requests stay consistent with declared intent. Be specific.
+{{ else }} create a task declaring your purpose and the
+actions you need using `create_task`:
+{{ end }}
+- **`purpose`** — shown to the user during approval and used by intent verification to ensure requests stay consistent with declared intent. Be specific: "Review last 30 iMessage threads and classify reply status" is better than "Use iMessage."
 - **`expected_use`** — per-action description of how you'll use it. Shown during approval and checked by intent verification against your actual request params. Be specific: "Fetch today's calendar events" is better than "Use the calendar API."
 - **`auto_execute`** — `true` runs in-scope requests immediately; `false` still requires per-request approval (use for destructive actions like `send_message`).
 - **`expires_in_seconds`** — task TTL. Omit and set `"lifetime": "standing"` for a task that persists until the user revokes it (see below).
-- **`callback_url`** — *(optional, only if callbacks are configured)* Clawvisor posts task lifecycle events here. Otherwise, long-poll with `GET /api/tasks/{id}?wait=true`.
 
-All tasks start as `pending_approval` — the user is notified to approve the
+All tasks start as `pending_approval`
+{{- if .UseCurl }} — the user is notified to approve the
 scope before it becomes active. **Always use `?wait=true`** on `POST /api/tasks`
 to block until the task is approved or denied in a single round-trip. If the
 timeout elapses while still pending, long-poll `GET /api/tasks/{id}?wait=true`
 until `status` changes to `active` (or `denied`).
+{{- else }}. Long-poll with `get_task` (`wait: true`)
+until status changes to `active` or `denied`.
+{{- end }}
 
 ### Standing tasks
 
-For recurring workflows, create a **standing task** that does not expire:
+For recurring workflows,
+{{- if .UseCurl }} create a **standing task** that does not expire:
 
 ```bash
 curl -s -X POST "$CLAWVISOR_URL/api/tasks" \
@@ -128,6 +167,11 @@ curl -s -X POST "$CLAWVISOR_URL/api/tasks" \
 ```
 
 Standing tasks remain active until the user revokes them from the dashboard.
+{{- else }} set `lifetime: "standing"`. Standing tasks require a
+`session_id` in gateway requests to enable chain context verification across
+related requests. Use a consistent `session_id` (e.g., a UUID you generate once
+per workflow) across all related requests in a single invocation.
+{{- end }}
 
 ### Chain context verification
 
@@ -143,7 +187,8 @@ If you omit `session_id` on a standing task, chain context is disabled and inten
 
 ### Scope expansion
 
-If you need an action not in the original task scope:
+If you need an action not in the original task scope,
+{{- if .UseCurl }}
 
 ```bash
 curl -s -X POST "$CLAWVISOR_URL/api/tasks/<task-id>/expand?wait=true" \
@@ -160,22 +205,30 @@ curl -s -X POST "$CLAWVISOR_URL/api/tasks/<task-id>/expand?wait=true" \
 The user will be notified to approve the expansion. With `?wait=true`, the
 request blocks until approved or denied. On approval, the action is added to
 the task scope and the expiry is reset.
+{{- else }} use `expand_task` with the
+new action and a reason. The user will be prompted to approve. On approval, the
+action is added to the task scope and the expiry is reset.
+{{- end }}
 
 ### Completing a task
 
-When you're done, mark the task as completed:
+When you're done,
+{{- if .UseCurl }} mark the task as completed:
 
 ```bash
 curl -s -X POST "$CLAWVISOR_URL/api/tasks/<task-id>/complete" \
   -H "Authorization: Bearer $CLAWVISOR_AGENT_TOKEN"
 ```
+{{- else }} use `complete_task` to mark the task as completed. This cleans
+up the authorization scope and any chain context facts.
+{{- end }}
 
 ---
 
 ## Gateway Requests
 
 Every gateway request must include a `task_id` from an approved task.
-
+{{ if .UseCurl }}
 ```bash
 curl -s -X POST "$CLAWVISOR_URL/api/gateway/request" \
   -H "Authorization: Bearer $CLAWVISOR_AGENT_TOKEN" \
@@ -196,7 +249,9 @@ curl -s -X POST "$CLAWVISOR_URL/api/gateway/request" \
 ```
 
 ### Required fields
-
+{{ else }}
+Use `gateway_request` for each action. Required fields:
+{{ end }}
 | Field | Description |
 |---|---|
 | `service` | Service identifier (from your catalog) |
@@ -205,7 +260,7 @@ curl -s -X POST "$CLAWVISOR_URL/api/gateway/request" \
 | `reason` | One sentence explaining why. Shown in approvals and audit log. Be specific. |
 | `request_id` | A unique ID you generate (e.g. UUID). Must be unique across all your requests. |
 | `task_id` | The approved task ID this request belongs to. |
-| `session_id` | *(Standing tasks only)* A consistent UUID across related requests in a single invocation. Required for chain context on standing tasks. Not needed for ephemeral tasks (chain context is automatic). |
+| `session_id` | *(Standing tasks only)* A consistent UUID across related requests in a single invocation.{{ if .UseCurl }} Required for chain context on standing tasks. Not needed for ephemeral tasks (chain context is automatic).{{ end }} |
 
 ### Context fields
 
@@ -214,8 +269,7 @@ Always include the `context` object. All fields are optional but strongly recomm
 | Field | Description |
 |---|---|
 | `data_origin` | Source of any external data you are acting on (see below). |
-| `source` | What triggered this request: `"user_message"`, `"scheduled_task"`, `"callback"`, etc. |
-| `callback_url` | *(Only if callbacks are configured.)* URL where Clawvisor posts the result after async approval. |
+| `source` | What triggered this request: `"user_message"`, `"scheduled_task"`, etc. |
 
 ### data_origin — always populate when processing external content
 
@@ -236,25 +290,27 @@ the data origin — set it.
 
 ## Handling Responses
 
-Every response has a `status` field. Handle each case as follows:
+Every {{ if .UseCurl -}} response has a `status` field. Handle each case as follows
+{{- else -}} gateway response has a `status` field
+{{- end }}:
 
 | Status | Meaning | What to do |
 |---|---|---|
-| `executed` | Action completed successfully | Use `result.summary` and `result.data`. Report to the user. |
-| `pending` | Awaiting human approval | Tell the user: "I've requested approval for [action]." If you used `?wait=true` on the original POST, the request is already blocking and will return the result once approved. If the long-poll timed out and you got this status back, re-initiate with `POST /api/gateway/request/{request_id}/execute?wait=true`. Do **not** send a new request. |
-| `blocked` | A restriction blocks this action | Tell the user: "I wasn't allowed to [action] — [reason]." Do **not** retry or attempt a workaround. |
-| `restricted` | Intent verification rejected the request | Your params or reason were inconsistent with the task's approved purpose. Adjust and retry with a new `request_id`. |
-| `pending_task_approval` | Task not yet approved | Tell the user and long-poll `GET /api/tasks/{id}?wait=true` until approved. |
-| `pending_scope_expansion` | Request outside task scope | Call `POST /api/tasks/{id}/expand` with the new action. |
-| `task_expired` | Task has passed its expiry | Expand the task to extend, or create a new task. |
-| `error` (`SERVICE_NOT_CONFIGURED`) | Service not yet connected | Tell the user: "[Service] isn't activated yet. Connect it in the Clawvisor dashboard." |
-| `error` (`EXECUTION_ERROR`) | Adapter failed | Report the error to the user. Do not silently retry. |
-| `error` (other) | Something went wrong | Report the error message to the user. Do not silently retry. |
-
+| `executed` | Action completed{{ if .UseCurl }} successfully{{ end }} | Use {{ if .UseCurl }}`result.summary` and `result.data`. Report to the user{{ else }}the result. Report to the user{{ end }}. |
+| `pending` | Awaiting human approval | Tell the user{{ if .UseCurl }}: "I've requested approval for [action]." If you used `?wait=true` on the original POST, the request is already blocking and will return the result once approved. If the long-poll timed out and you got this status back, re-initiate with `POST /api/gateway/request/{request_id}/execute?wait=true`. Do **not** send a new request{{ else }}. Re-send same request_id to poll{{ end }}. |
+| `blocked` | A restriction blocks this{{ if .UseCurl }} action{{ end }} | Tell the user{{ if .UseCurl }}: "I wasn't allowed to [action] — [reason]." Do **not** retry or attempt a workaround{{ else }}. Do not retry or work around it{{ end }}. |
+| `restricted` | Intent verification rejected{{ if .UseCurl }} the request{{ end }} | Your params{{ if .UseCurl }} or reason were{{ else }}/reason were{{ end }} inconsistent with the task{{ if .UseCurl }}'s approved{{ end }} purpose. Adjust and retry with a new request_id. |
+| `pending_task_approval` | Task not yet approved | {{ if .UseCurl }}Tell the user and long-poll `GET /api/tasks/{id}?wait=true` until approved{{ else }}Long-poll get_task until approved{{ end }}. |
+| `pending_scope_expansion` | {{ if .UseCurl }}Request outside{{ else }}Action outside{{ end }} task scope | {{ if .UseCurl }}Call `POST /api/tasks/{id}/expand` with the new action{{ else }}Use expand_task{{ end }}. |
+| `task_expired` | Task {{ if .UseCurl }}has passed its expiry{{ else }}TTL exceeded{{ end }} | Expand{{ if .UseCurl }} the task to extend,{{ end }} or create a new task. |
+| `error` (`SERVICE_NOT_CONFIGURED`) | Service not {{ if .UseCurl }}yet {{ end }}connected | Tell the user{{ if .UseCurl }}: "[Service] isn't activated yet. Connect it in the Clawvisor dashboard."{{ else }} to connect it in the Clawvisor dashboard{{ end }}. |
+| `error` (`EXECUTION_ERROR`) | Adapter failed | Report the error{{ if .UseCurl }} to the user{{ end }}. Do not silently retry. |
+| `error` (other) | Something went wrong | Report the error{{ if .UseCurl }} message to the user{{ end }}. Do not silently retry. |
+{{ if not .Condensed }}
 ---
 
-## Waiting for approval
-
+## Waiting for Approval
+{{ if .UseCurl }}
 **Always use `?wait=true`** on requests that require approval. This is the
 simplest and most efficient pattern — the server holds the connection until the
 user decides, then returns the resolved result in a single round-trip.
@@ -297,79 +353,34 @@ These are available if you didn't use `?wait=true` on the original POST:
 - **Execute after approval:** `POST /api/gateway/request/{request_id}/execute?wait=true` blocks until approved, then executes and returns the result.
 - **Read-only status:** `GET /api/gateway/request/{request_id}` returns the current status without executing. Supports `?wait=true` to block until the request leaves `pending` state.
 - **Legacy dedup:** Re-sending the same gateway request with the same `request_id` returns the current status without re-executing.
+{{ else }}
+**Tasks (preferred — long-poll):** `get_task` with `wait: true` blocks
+server-side until the task leaves `pending_approval` / `pending_scope_expansion`.
+Set `timeout` to control the wait (default & max 120 seconds).
+
+If the timeout elapses while still pending, the response is a normal pending
+status — just call again to keep waiting.
+
+**Gateway requests:** Re-send the same gateway request with the same
+`request_id`. Clawvisor recognizes the duplicate and returns the current status
+without re-executing.
+{{ end -}}
+{{ end -}}
 
 ---
+{{ if not .Condensed }}
+## Important Rules
 
-## Callbacks (optional)
-
-If callbacks have been configured (e.g. via OpenClaw), Clawvisor can push
-status changes instead of requiring polling. **Only include `callback_url` in
-requests if your environment supports receiving callbacks.**
-
-Callbacks cover two categories: **gateway request resolutions** and **task
-lifecycle changes**. Each includes a `type` field (`"request"` or `"task"`).
-
-**Request approved (waiting for agent to execute):**
-```json
-{
-  "type": "request",
-  "request_id": "send-email-5678",
-  "status": "approved",
-  "audit_id": "a8f3..."
-}
-```
-When you receive this, call `POST /api/gateway/request/{request_id}/execute` to
-execute the request and get the result.
-
-Request callback statuses: `approved`, `denied`, `timeout`, or `error`.
-
-**Task lifecycle change:**
-```json
-{
-  "type": "task",
-  "task_id": "<task-id>",
-  "status": "approved"
-}
-```
-Task callback statuses: `approved`, `denied`, `scope_expanded`, `scope_expansion_denied`, `expired`.
-
-### Handling callbacks
-
-1. If you registered a callback secret, verify the `X-Clawvisor-Signature`
-   header: it should equal `sha256=` + HMAC-SHA256(body, CLAWVISOR_CALLBACK_SECRET).
-2. Check the `type` field: `"request"` → match `request_id` to your pending
-   request. `"task"` → match `task_id` to your task.
-3. For request callbacks: if `status` is `approved`, call
-   `POST /api/gateway/request/{request_id}/execute` to get the result.
-   If `denied`, `timeout`, or `error`, tell the user the outcome and stop.
-4. For task callbacks: if `approved` or `scope_expanded`, proceed with your
-   task. If `denied`, `scope_expansion_denied`, or `expired`, inform the user.
-
-### Callback verification
-
-Register a signing secret to verify callbacks are genuinely from Clawvisor:
-
-```
-POST $CLAWVISOR_URL/api/callbacks/register
-Authorization: Bearer $CLAWVISOR_AGENT_TOKEN
-```
-
-Response: `{"callback_secret": "cbsec_..."}`
-
-Store this as `CLAWVISOR_CALLBACK_SECRET`. Calling this endpoint again rotates
-the secret.
-
-### OpenClaw callback URL
-
-Build your `callback_url` using the `OPENCLAW_HOOKS_URL` environment variable
-and your session key (shown in `session_status` as the Session field):
-
-```
-${OPENCLAW_HOOKS_URL}/clawvisor/callback?session=<session_key>
-```
+- Always fetch the catalog first to know what's available and restricted
+- Never attempt to bypass restrictions — they are hard blocks set by the user
+- Always create a task before making gateway requests
+- Use `auto_execute: false` for any action that sends, modifies, or deletes data
+- Generate unique request_ids for every gateway request
+- Complete tasks when done to clean up authorization scope
+- Always set `data_origin` when processing content from external sources
 
 ---
-
+{{ end }}
 ## Authorization Model Summary
 
 | Condition | Gateway `status` |

--- a/skills/embed.go
+++ b/skills/embed.go
@@ -4,5 +4,5 @@ package skills
 
 import "embed"
 
-//go:embed clawvisor
+//go:embed all:clawvisor
 var FS embed.FS

--- a/skills/render.go
+++ b/skills/render.go
@@ -1,0 +1,79 @@
+package skills
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"text/template"
+)
+
+// Target identifies which rendering variant to produce.
+type Target string
+
+const (
+	// TargetClaudeCode renders for Claude Code — curl-based examples, setup
+	// instructions, full detail.
+	TargetClaudeCode Target = "claude-code"
+
+	// TargetCowork renders for the Claude Desktop (Cowork) plugin — MCP tool
+	// names, no curl examples, no setup.
+	TargetCowork Target = "cowork"
+
+	// TargetMCP renders a condensed version for the MCP server's initialize
+	// instructions — MCP tool names, minimal detail.
+	TargetMCP Target = "mcp"
+)
+
+// templateData holds the flags that control conditional rendering.
+type templateData struct {
+	Target    Target
+	UseCurl   bool
+	Condensed bool
+}
+
+// dataForTarget returns the template data for the given target.
+func dataForTarget(t Target) templateData {
+	switch t {
+	case TargetClaudeCode:
+		return templateData{
+			Target:    t,
+			UseCurl:   true,
+			Condensed: false,
+		}
+	case TargetCowork:
+		return templateData{
+			Target:    t,
+			UseCurl:   false,
+			Condensed: false,
+		}
+	case TargetMCP:
+		return templateData{
+			Target:    t,
+			UseCurl:   false,
+			Condensed: true,
+		}
+	default:
+		return templateData{Target: t}
+	}
+}
+
+// Render produces the SKILL.md content for the given target by executing the
+// embedded template with the appropriate flags.
+func Render(target Target) (string, error) {
+	raw, err := FS.ReadFile("clawvisor/SKILL.md.tmpl")
+	if err != nil {
+		return "", fmt.Errorf("reading SKILL.md.tmpl: %w", err)
+	}
+
+	tmpl, err := template.New("skill").Parse(string(raw))
+	if err != nil {
+		return "", fmt.Errorf("parsing SKILL.md.tmpl: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, dataForTarget(target)); err != nil {
+		return "", fmt.Errorf("executing SKILL.md.tmpl: %w", err)
+	}
+
+	return strings.TrimLeft(buf.String(), "\n"), nil
+}


### PR DESCRIPTION
## Summary

- Replaces three separate copies of Clawvisor workflow documentation (Claude Code skill, MCP server instructions, Cowork plugin) with a single Go template (`skills/clawvisor/SKILL.md.tmpl`) that renders target-specific variants using three flags: `Target`, `UseCurl`, and `Condensed`
- Adds a full Claude Desktop Cowork plugin (`coworkplugin/`) with `.mcp.json`, `CLAUDE.md`, commands (check-services, triage-inbox, check-messages, daily-briefing), and skills — installed automatically via `cvis integrate claude-desktop`
- MCP server instructions in `internal/mcp/prompts.go` now render from the shared template instead of a hardcoded constant
- `installCoworkPlugin()` in `claude_code.go` handles the full 4-location plugin install (marketplace, cache, registry, install manifest)

## Test plan

- [ ] `go build ./...` and `go vet ./...` pass
- [ ] Render all three targets (claude-code, cowork, mcp) and verify clean output with no leading blank lines or formatting issues
- [ ] Run `cvis integrate claude-desktop` and verify the Cowork plugin appears in Claude Desktop
- [ ] Verify MCP server initialize response includes rendered instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)