### PR TITLE
fix: create GitHub release before uploading binaries

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -34,6 +34,21 @@ jobs:
       - name: Build binaries and checksums
         run: scripts/build-release.sh "${{ inputs.version }}"
 
+      - name: Create release if it does not exist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if ! gh release view "${{ inputs.version }}" > /dev/null 2>&1; then
+            prerelease_flag=""
+            case "${{ inputs.version }}" in
+              *-*) prerelease_flag="--prerelease" ;;
+            esac
+            gh release create "${{ inputs.version }}" \
+              --title "${{ inputs.version }}" \
+              --generate-notes \
+              $prerelease_flag
+          fi
+
       - name: Upload release assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

The release-binaries workflow failed for beta tags (e.g. `v0.8.0-beta.1`) because `gh release upload` requires the release to already exist. Release-please only creates releases for stable versions merged to `main`.

This adds a step that creates the GitHub release on-demand if it doesn't exist, automatically marking pre-release versions (any tag containing `-`) with the `--prerelease` flag. Existing releases are left untouched.

## Test plan

- [ ] Trigger the workflow with a beta version tag and verify the release is created as a prerelease
- [ ] Trigger with a stable version tag that already has a release and verify the upload still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)