### PR TITLE
fix: prefer exact service ID match over base service in CheckTaskScope

### DIFF
--- a/internal/api/handlers/tasks.go
+++ b/internal/api/handlers/tasks.go
@@ -1102,10 +1102,21 @@ func CheckTaskScope(task *store.Task, serviceType, alias, action string) TaskSco
 	if alias != "" && alias != "default" {
 		fullService = serviceType + ":" + alias
 	}
+	// First pass: look for an exact match on the full service (including alias).
 	for i := range task.AuthorizedActions {
 		a := &task.AuthorizedActions[i]
-		if (a.Service == fullService || a.Service == serviceType) && (a.Action == action || a.Action == "*") {
+		if a.Service == fullService && (a.Action == action || a.Action == "*") {
 			return TaskScopeMatch{InScope: true, AutoExecute: a.AutoExecute, MatchedAction: a}
+		}
+	}
+	// Second pass: fall back to base service type only when the request
+	// didn't include an alias or no exact match was found.
+	if fullService != serviceType {
+		for i := range task.AuthorizedActions {
+			a := &task.AuthorizedActions[i]
+			if a.Service == serviceType && (a.Action == action || a.Action == "*") {
+				return TaskScopeMatch{InScope: true, AutoExecute: a.AutoExecute, MatchedAction: a}
+			}
 		}
 	}
 	return TaskScopeMatch{InScope: false}

--- a/internal/api/handlers/tasks_scope_test.go
+++ b/internal/api/handlers/tasks_scope_test.go
@@ -1,0 +1,83 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+func TestCheckTaskScope_WorkVariantMatchesExact(t *testing.T) {
+	// When both google.calendar and google.calendar:work are authorized,
+	// a request for google.calendar:work must match the :work entry.
+	task := &store.Task{
+		AuthorizedActions: []store.TaskAction{
+			{Service: "google.calendar", Action: "*", ExpectedUse: "personal calendar"},
+			{Service: "google.calendar:work", Action: "*", ExpectedUse: "work calendar"},
+		},
+	}
+
+	match := CheckTaskScope(task, "google.calendar", "work", "list")
+	if !match.InScope {
+		t.Fatal("expected request to be in scope")
+	}
+	if match.MatchedAction.Service != "google.calendar:work" {
+		t.Fatalf("expected match on google.calendar:work, got %s", match.MatchedAction.Service)
+	}
+	if match.MatchedAction.ExpectedUse != "work calendar" {
+		t.Fatalf("expected ExpectedUse='work calendar', got %q", match.MatchedAction.ExpectedUse)
+	}
+}
+
+func TestCheckTaskScope_WorkVariantMatchesExact_ReversedOrder(t *testing.T) {
+	// Same test but with :work entry listed first — should still work.
+	task := &store.Task{
+		AuthorizedActions: []store.TaskAction{
+			{Service: "google.calendar:work", Action: "*", ExpectedUse: "work calendar"},
+			{Service: "google.calendar", Action: "*", ExpectedUse: "personal calendar"},
+		},
+	}
+
+	match := CheckTaskScope(task, "google.calendar", "work", "list")
+	if !match.InScope {
+		t.Fatal("expected request to be in scope")
+	}
+	if match.MatchedAction.Service != "google.calendar:work" {
+		t.Fatalf("expected match on google.calendar:work, got %s", match.MatchedAction.Service)
+	}
+}
+
+func TestCheckTaskScope_BaseServiceStillMatches(t *testing.T) {
+	// A request for the base service (no alias) should still match the base entry.
+	task := &store.Task{
+		AuthorizedActions: []store.TaskAction{
+			{Service: "google.calendar", Action: "*", ExpectedUse: "personal calendar"},
+			{Service: "google.calendar:work", Action: "*", ExpectedUse: "work calendar"},
+		},
+	}
+
+	match := CheckTaskScope(task, "google.calendar", "", "list")
+	if !match.InScope {
+		t.Fatal("expected request to be in scope")
+	}
+	if match.MatchedAction.Service != "google.calendar" {
+		t.Fatalf("expected match on google.calendar, got %s", match.MatchedAction.Service)
+	}
+}
+
+func TestCheckTaskScope_AliasFallsBackToBase(t *testing.T) {
+	// When only the base service is authorized, an aliased request should
+	// still match (fallback behavior).
+	task := &store.Task{
+		AuthorizedActions: []store.TaskAction{
+			{Service: "google.calendar", Action: "*", ExpectedUse: "calendar access"},
+		},
+	}
+
+	match := CheckTaskScope(task, "google.calendar", "work", "list")
+	if !match.InScope {
+		t.Fatal("expected aliased request to fall back to base service")
+	}
+	if match.MatchedAction.Service != "google.calendar" {
+		t.Fatalf("expected fallback match on google.calendar, got %s", match.MatchedAction.Service)
+	}
+}


### PR DESCRIPTION
## Summary

When a task authorizes both a base service (e.g. `google.calendar`) and its `:work` variant (`google.calendar:work`), gateway requests targeting the `:work` variant could match the base service entry first. This passed the wrong `expected_use` to intent verification, causing spurious "restricted" verdicts.

The fix splits `CheckTaskScope` into two passes: first an exact match on the full service ID (including alias), then a fallback to the base service type. This ensures the correct `expected_use` is always used for verification.

## Test plan

- [x] Added 4 unit tests covering exact match (both orderings), base service match, and alias-to-base fallback
- [x] Existing `TestApproval_AliasPreserved` integration test passes
- [x] Full `./internal/api/...` test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)