### PR TITLE
fix: remove hardcoded adapter metadata and fix Drive OAuth execution

### DIFF
--- a/internal/adapters/apple/imessage/adapter.go
+++ b/internal/adapters/apple/imessage/adapter.go
@@ -82,6 +82,20 @@ func (a *IMessageAdapter) CredentialFromToken(_ *oauth2.Token) ([]byte, error) {
 // ValidateCredential accepts any non-nil byte slice (no stored credential needed).
 func (a *IMessageAdapter) ValidateCredential(_ []byte) error { return nil }
 
+// ServiceMetadata returns display and risk metadata for iMessage.
+func (a *IMessageAdapter) ServiceMetadata() adapters.ServiceMetadata {
+	return adapters.ServiceMetadata{
+		DisplayName: "iMessage",
+		Description: "Search and read iMessage threads",
+		ActionMeta: map[string]adapters.ActionMeta{
+			"search_messages": {DisplayName: "Search messages", Category: "search", Sensitivity: "low", Description: "Search iMessage history"},
+			"list_threads":    {DisplayName: "List threads", Category: "read", Sensitivity: "low", Description: "List iMessage conversation threads"},
+			"get_thread":      {DisplayName: "Get thread", Category: "read", Sensitivity: "low", Description: "Read a specific iMessage thread"},
+			"send_message":    {DisplayName: "Send message", Category: "write", Sensitivity: "high", Description: "Send an iMessage (requires per-request approval)"},
+		},
+	}
+}
+
 func (a *IMessageAdapter) Execute(ctx context.Context, req adapters.Request) (*adapters.Result, error) {
 	if !a.Available() {
 		return nil, fmt.Errorf("imessage: not available — grant Full Disk Access to Clawvisor in System Settings → Privacy & Security → Full Disk Access, then restart")

--- a/internal/adapters/definitions/google_drive.yaml
+++ b/internal/adapters/definitions/google_drive.yaml
@@ -56,18 +56,4 @@ actions:
   search_files:
     display_name: "Search files"
     risk: { category: search, sensitivity: low, description: "Search files in Google Drive" }
-    method: GET
-    path: "/files"
-    params:
-      query: { type: string, required: true, location: query }
-      max_results: { type: int, default: 10, max: 50, location: query }
-    response:
-      data_path: "files"
-      fields:
-        - { name: id }
-        - { name: name, sanitize: true }
-        - { name: mimeType }
-        - { name: modifiedTime }
-        - { name: size }
-        - { name: webViewLink }
-      summary: "{{len .Data}} file(s)"
+    override: go

--- a/internal/api/handlers/approvals.go
+++ b/internal/api/handlers/approvals.go
@@ -249,7 +249,7 @@ func (h *ApprovalsHandler) executeApproval(ctx context.Context, pa *store.Pendin
 	}
 
 	serviceType, alias := parseServiceAlias(blob.Service)
-	vKey := vaultKeyForServiceAlias(serviceType, alias)
+	vKey := h.adapterReg.VaultKeyWithAlias(serviceType, alias)
 
 	start := time.Now()
 	result, execErr := executeAdapterRequest(ctx, h.vault, h.adapterReg,

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -309,7 +309,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 					dur := int(time.Since(start).Milliseconds())
 					e := baseEntry("block", "error", taskIDPtr)
 					e.DurationMS = dur
-					code, userErr, auditMsg := serviceNotActivatedResponse(ctx, h.vault, h.store, agent.UserID, serviceType, serviceAlias, req.Service, taskAdapter)
+					code, userErr, auditMsg := serviceNotActivatedResponse(ctx, h.vault, h.store, h.adapterReg, agent.UserID, serviceType, serviceAlias, req.Service, taskAdapter)
 					e.ErrorMsg = &auditMsg
 					if logErr := h.store.LogAudit(ctx, e); logErr != nil {
 						h.logger.Warn("audit log failed", "err", logErr)
@@ -326,7 +326,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 
-			vKey := vaultKeyForServiceAlias(serviceType, serviceAlias)
+			vKey := h.adapterReg.VaultKeyWithAlias(serviceType, serviceAlias)
 			result, execErr := executeAdapterRequest(ctx, h.vault, h.adapterReg,
 				agent.UserID, serviceType, req.Action, req.Params, vKey)
 			dur := int(time.Since(start).Milliseconds())
@@ -338,7 +338,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 					if adapterOK && adapter.ValidateCredential(nil) != nil {
 						e := baseEntry("block", "error", taskIDPtr)
 						e.DurationMS = dur
-						code, userErr, auditMsg := serviceNotActivatedResponse(ctx, h.vault, h.store, agent.UserID, serviceType, serviceAlias, req.Service, adapter)
+						code, userErr, auditMsg := serviceNotActivatedResponse(ctx, h.vault, h.store, h.adapterReg, agent.UserID, serviceType, serviceAlias, req.Service, adapter)
 						e.ErrorMsg = &auditMsg
 						if logErr := h.store.LogAudit(ctx, e); logErr != nil {
 							h.logger.Warn("audit log failed", "err", logErr)
@@ -477,7 +477,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 				notActivated = true
 			}
 		} else {
-			vKey := vaultKeyForServiceAlias(serviceType, serviceAlias)
+			vKey := h.adapterReg.VaultKeyWithAlias(serviceType, serviceAlias)
 			if _, vaultErr := h.vault.Get(ctx, agent.UserID, vKey); errors.Is(vaultErr, vault.ErrNotFound) {
 				notActivated = true
 			}
@@ -485,7 +485,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 		if notActivated {
 			e := baseEntry("block", "error", nil)
 			e.DurationMS = int(time.Since(start).Milliseconds())
-			code, userErr, auditMsg := serviceNotActivatedResponse(ctx, h.vault, h.store, agent.UserID, serviceType, serviceAlias, req.Service, approveAdapter)
+			code, userErr, auditMsg := serviceNotActivatedResponse(ctx, h.vault, h.store, h.adapterReg, agent.UserID, serviceType, serviceAlias, req.Service, approveAdapter)
 			e.ErrorMsg = &auditMsg
 			if logErr := h.store.LogAudit(ctx, e); logErr != nil {
 				h.logger.Warn("audit log failed", "err", logErr)
@@ -657,7 +657,7 @@ func (h *GatewayHandler) executeAndRespond(w http.ResponseWriter, ctx context.Co
 	}
 
 	serviceType, alias := parseServiceAlias(blob.Service)
-	vKey := vaultKeyForServiceAlias(serviceType, alias)
+	vKey := h.adapterReg.VaultKeyWithAlias(serviceType, alias)
 
 	start := time.Now()
 	result, execErr := executeAdapterRequest(ctx, h.vault, h.adapterReg,
@@ -883,7 +883,7 @@ func executeAdapterRequest(
 
 	vKey := vaultKey
 	if vKey == "" {
-		vKey = vaultKeyForService(serviceType)
+		vKey = reg.VaultKey(serviceType)
 	}
 	cred, err := v.Get(ctx, userID, vKey)
 	if err != nil {
@@ -981,32 +981,10 @@ func parseServiceAlias(service string) (serviceType, alias string) {
 	return service, "default"
 }
 
-// vaultKeyForService returns the vault key for a service type (no alias).
-// Google services share the "google" base key.
-func vaultKeyForService(serviceID string) string {
-	if strings.HasPrefix(serviceID, "google.") {
-		return "google"
-	}
-	return serviceID
-}
-
-// vaultKeyForServiceAlias returns the vault key for a service type + alias.
-// "default" alias maps to the plain base key for backward compatibility.
-func vaultKeyForServiceAlias(serviceType, alias string) string {
-	base := serviceType
-	if strings.HasPrefix(serviceType, "google.") {
-		base = "google"
-	}
-	if alias == "" || alias == "default" {
-		return base
-	}
-	return base + ":" + alias
-}
-
 // hasAnyAlias reports whether any vault entry exists for the given service type
 // (under any alias). It uses vault.List and checks for matching key prefixes.
-func hasAnyAlias(ctx context.Context, v vault.Vault, userID, serviceType string) bool {
-	base := vaultKeyForService(serviceType)
+func hasAnyAlias(ctx context.Context, v vault.Vault, reg *adapters.Registry, userID, serviceType string) bool {
+	base := reg.VaultKey(serviceType)
 	keys, err := v.List(ctx, userID)
 	if err != nil {
 		return false
@@ -1026,6 +1004,7 @@ func serviceNotActivatedResponse(
 	ctx context.Context,
 	v vault.Vault,
 	st store.Store,
+	reg *adapters.Registry,
 	userID, serviceType, serviceAlias, serviceDisplay string,
 	adapter adapters.Adapter,
 ) (code, userErr, auditMsg string) {
@@ -1035,7 +1014,7 @@ func serviceNotActivatedResponse(
 			isAlias = true
 		}
 	} else {
-		if hasAnyAlias(ctx, v, userID, serviceType) {
+		if hasAnyAlias(ctx, v, reg, userID, serviceType) {
 			isAlias = true
 		}
 	}

--- a/internal/api/handlers/services.go
+++ b/internal/api/handlers/services.go
@@ -124,6 +124,7 @@ func (h *ServicesHandler) List(w http.ResponseWriter, r *http.Request) {
 		Description        string        `json:"description"`
 		Alias              string        `json:"alias,omitempty"`
 		OAuth              bool          `json:"oauth"`
+		OAuthEndpoint      string        `json:"oauth_endpoint,omitempty"`
 		RequiresActivation bool          `json:"requires_activation"`
 		CredentialFree     bool          `json:"credential_free"`
 		Actions            []actionEntry `json:"actions"`
@@ -136,7 +137,7 @@ func (h *ServicesHandler) List(w http.ResponseWriter, r *http.Request) {
 	buildEntry := func(a adapters.Adapter) serviceEntry {
 		name := display.ServiceName(a.ServiceID())
 		desc := display.ServiceDescription(a.ServiceID())
-		var setupURL string
+		var setupURL, oauthEndpoint string
 		actionNames := map[string]adapters.ActionMeta{}
 
 		if mp, ok := a.(adapters.MetadataProvider); ok {
@@ -148,6 +149,7 @@ func (h *ServicesHandler) List(w http.ResponseWriter, r *http.Request) {
 				desc = meta.Description
 			}
 			setupURL = meta.SetupURL
+			oauthEndpoint = meta.OAuthEndpoint
 			actionNames = meta.ActionMeta
 		}
 
@@ -169,6 +171,7 @@ func (h *ServicesHandler) List(w http.ResponseWriter, r *http.Request) {
 			Name:               name,
 			Description:        desc,
 			OAuth:              len(a.RequiredScopes()) > 0,
+			OAuthEndpoint:      oauthEndpoint,
 			RequiresActivation: true,
 			Actions:            actions,
 			SetupURL:           setupURL,
@@ -199,7 +202,7 @@ func (h *ServicesHandler) List(w http.ResponseWriter, r *http.Request) {
 			if m.ServiceID != a.ServiceID() {
 				continue
 			}
-			vKey := vaultKeyForServiceAlias(a.ServiceID(), m.Alias)
+			vKey := h.adapterReg.VaultKeyWithAlias(a.ServiceID(), m.Alias)
 			if !keySet[vKey] {
 				continue
 			}
@@ -216,7 +219,7 @@ func (h *ServicesHandler) List(w http.ResponseWriter, r *http.Request) {
 			services = append(services, entry)
 		}
 
-		baseKey := vaultKeyForService(a.ServiceID())
+		baseKey := h.adapterReg.VaultKey(a.ServiceID())
 		usesSharedKey := baseKey != a.ServiceID()
 		if !shown && !usesSharedKey && keySet[baseKey] {
 			var activatedAt *time.Time
@@ -443,7 +446,7 @@ func (h *ServicesHandler) OAuthCallback(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	vKey := vaultKeyForServiceAlias(entry.ServiceID, alias)
+	vKey := h.adapterReg.VaultKeyWithAlias(entry.ServiceID, alias)
 	if err := h.vault.Set(r.Context(), entry.UserID, vKey, credBytes); err != nil {
 		h.logger.Warn("vault set failed", "service", entry.ServiceID, "err", err)
 		oauthPopupClose(w, "Failed to store credential in vault.", "")
@@ -640,7 +643,7 @@ func (h *ServicesHandler) ActivateWithKey(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	vKey := vaultKeyForServiceAlias(serviceID, alias)
+	vKey := h.adapterReg.VaultKeyWithAlias(serviceID, alias)
 	if err := h.vault.Set(r.Context(), user.ID, vKey, credBytes); err != nil {
 		h.logger.Warn("vault set failed (api key)", "service", serviceID, "err", err)
 		writeError(w, http.StatusInternalServerError, "VAULT_ERROR", "failed to store credential")
@@ -699,11 +702,11 @@ func (h *ServicesHandler) Deactivate(w http.ResponseWriter, r *http.Request) {
 	// deactivated service's scopes from the stored credential instead of
 	// deleting it. This ensures resolveOAuthScopes will re-request consent
 	// if the service is re-activated later.
-	vKey := vaultKeyForServiceAlias(serviceID, alias)
+	vKey := h.adapterReg.VaultKeyWithAlias(serviceID, alias)
 	metas, _ := h.st.ListServiceMetas(r.Context(), user.ID)
 	otherUsesKey := false
 	for _, m := range metas {
-		if vaultKeyForServiceAlias(m.ServiceID, m.Alias) == vKey {
+		if h.adapterReg.VaultKeyWithAlias(m.ServiceID, m.Alias) == vKey {
 			otherUsesKey = true
 			break
 		}
@@ -738,7 +741,7 @@ func (h *ServicesHandler) reactivatePendingRequest(ctx context.Context, userID, 
 	}
 
 	serviceType, alias := parseServiceAlias(blob.Service)
-	vKey := vaultKeyForServiceAlias(serviceType, alias)
+	vKey := h.adapterReg.VaultKeyWithAlias(serviceType, alias)
 	result, execErr := executeAdapterRequest(ctx, h.vault, h.adapterReg,
 		userID, blob.Service, blob.Action, blob.Params, vKey)
 
@@ -786,7 +789,7 @@ func (h *ServicesHandler) resolveOAuthScopes(
 	}
 
 	// Check for existing credential in the vault.
-	vKey := vaultKeyForServiceAlias(serviceID, alias)
+	vKey := h.adapterReg.VaultKeyWithAlias(serviceID, alias)
 	existingBytes, err := h.vault.Get(ctx, userID, vKey)
 	if err != nil || len(existingBytes) == 0 {
 		// No existing credential — just use this adapter's scopes.
@@ -839,7 +842,7 @@ func oauthAuthURL(cfg *oauth2.Config, stateToken, alias string) string {
 // loadExistingRefreshToken retrieves the refresh token from an existing vault
 // credential, if any. Google may not re-issue a refresh token on re-consent.
 func (h *ServicesHandler) loadExistingRefreshToken(ctx context.Context, userID, serviceID, alias string) string {
-	vKey := vaultKeyForServiceAlias(serviceID, alias)
+	vKey := h.adapterReg.VaultKeyWithAlias(serviceID, alias)
 	existingBytes, err := h.vault.Get(ctx, userID, vKey)
 	if err != nil || len(existingBytes) == 0 {
 		return ""

--- a/internal/api/handlers/skill.go
+++ b/internal/api/handlers/skill.go
@@ -32,63 +32,8 @@ func NewSkillHandler(
 	}
 }
 
-// actionMeta provides static descriptions and parameter docs for each service action.
-// These will move to the Adapter interface (ActionDescription/ActionSchema) in Phase 8.
-var actionMeta = map[string]struct{ Desc, Params string }{
-	// google.gmail
-	"google.gmail:list_messages": {"List and search emails", "query (string, optional), max_results (int, default 10)"},
-	"google.gmail:get_message":   {"Fetch a single email by ID", "message_id (string, required)"},
-	"google.gmail:send_message":  {"Send an email", "to (string, required), subject (string, required), body (string, required), cc (string, optional)"},
-
-	// google.calendar
-	"google.calendar:list_events":    {"List upcoming calendar events", "calendar_id (string, default \"primary\"), from (date YYYY-MM-DD, optional), to (date YYYY-MM-DD, optional), max_results (int, default 10)"},
-	"google.calendar:list_calendars": {"List all calendars", "(none)"},
-	"google.calendar:get_event":      {"Fetch a single event by ID", "calendar_id (string, required), event_id (string, required)"},
-	"google.calendar:create_event":   {"Create a calendar event", "calendar_id (string, required), summary (string, required), start (RFC3339 datetime, required), end (RFC3339 datetime, required), description (string, optional), attendees ([]string, optional)"},
-	"google.calendar:update_event":   {"Update an existing event", "calendar_id (string, required), event_id (string, required), plus fields to update"},
-	"google.calendar:delete_event":   {"Delete a calendar event", "calendar_id (string, required), event_id (string, required)"},
-
-	// google.drive
-	"google.drive:list_files":   {"List files matching a query", "query (string, optional), max_results (int, default 10)"},
-	"google.drive:get_file":     {"Get file metadata and content", "file_id (string, required)"},
-	"google.drive:create_file":  {"Create a file", "name (string, required), content (string, required), mime_type (string, required), parent_id (string, optional)"},
-	"google.drive:update_file":  {"Update file content", "file_id (string, required), content (string, required)"},
-	"google.drive:search_files": {"Search files by name or content", "query (string, required), max_results (int, default 10)"},
-
-	// google.contacts
-	"google.contacts:list_contacts":   {"List contacts", "query (string, optional), max_results (int, default 10)"},
-	"google.contacts:get_contact":     {"Get a contact's details", "contact_id (string, required)"},
-	"google.contacts:search_contacts": {"Search contacts by name or email", "query (string, required), max_results (int, default 10)"},
-
-	// github
-	"github:list_issues":  {"List issues on a repo", "owner (string, required), repo (string, required), state (string, optional)"},
-	"github:get_issue":    {"Get issue details", "owner (string, required), repo (string, required), number (int, required)"},
-	"github:create_issue": {"Create an issue", "owner (string, required), repo (string, required), title (string, required), body (string, required)"},
-	"github:comment_issue": {"Add a comment to an issue", "owner (string, required), repo (string, required), number (int, required), body (string, required)"},
-	"github:list_prs":     {"List pull requests", "owner (string, required), repo (string, required), state (string, optional)"},
-	"github:get_pr":       {"Get PR details", "owner (string, required), repo (string, required), number (int, required)"},
-	"github:list_repos":   {"List repositories", "org (string, optional)"},
-	"github:search_code":  {"Search code", "query (string, required), repo (string, optional)"},
-
-	// apple.imessage
-	"apple.imessage:search_messages": {"Search messages by content/sender", "query (string, required), contact (string, optional), days_back (int, optional)"},
-	"apple.imessage:list_threads":    {"List recent conversation threads", "max_results (int, optional)"},
-	"apple.imessage:get_thread":      {"Get messages from a conversation", "contact (string) or thread_id (string), days_back (int, optional)"},
-	"apple.imessage:send_message":    {"Send an iMessage (always requires approval)", "to (string, required), text (string, required)"},
-}
-
-// serviceDesc provides one-line summaries for the "not activated" section.
-var serviceDesc = map[string]string{
-	"google.gmail":     "Gmail — read, search, and send email",
-	"google.calendar":  "Google Calendar — events and scheduling",
-	"google.drive":     "Google Drive — file access (list, read, upload)",
-	"google.contacts":  "Google Contacts — contact management",
-	"github":           "GitHub — issues, PRs, and code review",
-	"apple.imessage":   "iMessage — read and send messages (macOS only)",
-}
-
-// Catalog returns a personalized markdown document listing the agent's
-// activated services (with restriction-filtered actions) and available services.
+// Catalog returns a personalized markdown document listing only the agent's
+// activated services (with restriction-filtered actions).
 //
 // GET /api/skill/catalog
 // Auth: agent bearer token
@@ -112,30 +57,36 @@ func (h *SkillHandler) Catalog(w http.ResponseWriter, r *http.Request) {
 	metas, _ := h.st.ListServiceMetas(ctx, agent.UserID)
 
 	type catalogService struct {
-		id        string // display ID, e.g. "google.gmail" or "google.gmail:personal"
-		baseID    string // adapter service ID, e.g. "google.gmail"
-		actions   []string
-		activated bool
+		id      string // display ID, e.g. "google.gmail" or "google.gmail:personal"
+		baseID  string // adapter service ID, e.g. "google.gmail"
+		actions []string
 	}
 
+	// Build the adapter metadata index for action descriptions.
+	adapterMeta := map[string]adapters.ServiceMetadata{} // serviceID → metadata
 	allAdapters := h.adapterReg.All()
-	services := make([]catalogService, 0, len(allAdapters))
+	for _, a := range allAdapters {
+		if mp, ok := a.(adapters.MetadataProvider); ok {
+			adapterMeta[a.ServiceID()] = mp.ServiceMetadata()
+		}
+	}
+
+	// Only collect activated services.
+	var services []catalogService
 	for _, a := range allAdapters {
 		credentialFree := a.ValidateCredential(nil) == nil
 		if credentialFree {
 			// Credential-free services (e.g. iMessage) require explicit
 			// activation via service_meta, same as the gateway check.
-			activated := false
 			for _, m := range metas {
 				if m.ServiceID == a.ServiceID() {
-					activated = true
+					services = append(services, catalogService{
+						id: a.ServiceID(), baseID: a.ServiceID(),
+						actions: a.SupportedActions(),
+					})
 					break
 				}
 			}
-			services = append(services, catalogService{
-				id: a.ServiceID(), baseID: a.ServiceID(),
-				actions: a.SupportedActions(), activated: activated,
-			})
 			continue
 		}
 
@@ -145,7 +96,7 @@ func (h *SkillHandler) Catalog(w http.ResponseWriter, r *http.Request) {
 			if m.ServiceID != a.ServiceID() {
 				continue
 			}
-			vKey := vaultKeyForServiceAlias(a.ServiceID(), m.Alias)
+			vKey := h.adapterReg.VaultKeyWithAlias(a.ServiceID(), m.Alias)
 			if !keySet[vKey] {
 				continue
 			}
@@ -156,25 +107,22 @@ func (h *SkillHandler) Catalog(w http.ResponseWriter, r *http.Request) {
 			}
 			services = append(services, catalogService{
 				id: displayID, baseID: a.ServiceID(),
-				actions: a.SupportedActions(), activated: true,
+				actions: a.SupportedActions(),
 			})
 		}
 
-		// Fallback: check base vault key.
-		baseKey := vaultKeyForService(a.ServiceID())
-		if !shown && keySet[baseKey] {
-			services = append(services, catalogService{
-				id: a.ServiceID(), baseID: a.ServiceID(),
-				actions: a.SupportedActions(), activated: true,
-			})
-			shown = true
-		}
-
+		// Fallback: check base vault key (handles pre-existing activations
+		// that may not have a service_meta row). Skip when the service uses
+		// a shared vault key (e.g. all google.* services share "google").
 		if !shown {
-			services = append(services, catalogService{
-				id: a.ServiceID(), baseID: a.ServiceID(),
-				actions: a.SupportedActions(), activated: false,
-			})
+			baseKey := h.adapterReg.VaultKey(a.ServiceID())
+			usesSharedKey := baseKey != a.ServiceID()
+			if !usesSharedKey && keySet[baseKey] {
+				services = append(services, catalogService{
+					id: a.ServiceID(), baseID: a.ServiceID(),
+					actions: a.SupportedActions(),
+				})
+			}
 		}
 	}
 	sort.Slice(services, func(i, j int) bool { return services[i].id < services[j].id })
@@ -182,62 +130,46 @@ func (h *SkillHandler) Catalog(w http.ResponseWriter, r *http.Request) {
 	var buf strings.Builder
 	buf.WriteString("# Your Clawvisor Service Catalog\n\n")
 
-	// Active services
-	buf.WriteString("## Active Services\n")
-	anyActive := false
-	for _, svc := range services {
-		if !svc.activated {
-			continue
-		}
-		anyActive = true
-		buf.WriteString(fmt.Sprintf("\n### %s\n\n", svc.id))
-		for _, action := range svc.actions {
-			// If a restriction matches this action (exact or base service), skip it.
-			restriction, _ := h.st.MatchRestriction(ctx, agent.UserID, svc.id, action)
-			if restriction == nil && svc.id != svc.baseID {
-				restriction, _ = h.st.MatchRestriction(ctx, agent.UserID, svc.baseID, action)
+	if len(services) == 0 {
+		buf.WriteString("No services are currently activated.\n\n")
+		buf.WriteString("To activate a service, direct the user to the Clawvisor dashboard.\n")
+	} else {
+		for _, svc := range services {
+			// Service heading — include description if available.
+			buf.WriteString(fmt.Sprintf("## %s\n", svc.id))
+			if meta, ok := adapterMeta[svc.baseID]; ok && meta.Description != "" {
+				buf.WriteString(fmt.Sprintf("_%s_\n", meta.Description))
 			}
-			if restriction != nil {
-				continue
-			}
+			buf.WriteString("\n")
 
-			key := svc.baseID + ":" + action
-			meta, hasMeta := actionMeta[key]
+			for _, action := range svc.actions {
+				// If a restriction matches this action (exact or base service), skip it.
+				restriction, _ := h.st.MatchRestriction(ctx, agent.UserID, svc.id, action)
+				if restriction == nil && svc.id != svc.baseID {
+					restriction, _ = h.st.MatchRestriction(ctx, agent.UserID, svc.baseID, action)
+				}
+				if restriction != nil {
+					continue
+				}
 
-			// All non-restricted actions require approval unless covered by a task.
-			label := " (requires approval or task)"
+				// All non-restricted actions require approval unless covered by a task.
+				label := " (requires approval or task)"
 
-			if hasMeta {
-				buf.WriteString(fmt.Sprintf("**%s**%s — %s\n", action, label, meta.Desc))
-				buf.WriteString(fmt.Sprintf("  Params: %s\n\n", meta.Params))
-			} else {
+				// Read action metadata from MetadataProvider.
+				if meta, ok := adapterMeta[svc.baseID]; ok {
+					if am, ok := meta.ActionMeta[action]; ok {
+						desc := am.Description
+						if desc == "" {
+							desc = am.DisplayName
+						}
+						buf.WriteString(fmt.Sprintf("**%s**%s — %s\n", action, label, desc))
+						buf.WriteString(fmt.Sprintf("  Category: %s, Sensitivity: %s\n\n", am.Category, am.Sensitivity))
+						continue
+					}
+				}
 				buf.WriteString(fmt.Sprintf("**%s**%s\n\n", action, label))
 			}
 		}
-	}
-	if !anyActive {
-		buf.WriteString("\nNo services are currently activated.\n")
-	}
-
-	// Available (not activated) services
-	buf.WriteString("---\n\n")
-	buf.WriteString("## Available Services (not activated)\n\n")
-	anyAvailable := false
-	for _, svc := range services {
-		if svc.activated {
-			continue
-		}
-		anyAvailable = true
-		desc := serviceDesc[svc.id]
-		if desc == "" {
-			desc = svc.id
-		}
-		buf.WriteString(fmt.Sprintf("- **%s** — %s\n", svc.id, desc))
-	}
-	if !anyAvailable {
-		buf.WriteString("All supported services are activated.\n")
-	} else {
-		buf.WriteString("\nTo activate a service, direct the user to the Clawvisor dashboard.\n")
 	}
 
 	w.Header().Set("Content-Type", "text/markdown; charset=utf-8")

--- a/internal/api/handlers/tasks.go
+++ b/internal/api/handlers/tasks.go
@@ -1080,7 +1080,7 @@ func (h *TasksHandler) serviceActivated(ctx context.Context, userID, serviceType
 		return err == nil
 	}
 	// Credential-backed: check vault.
-	vKey := vaultKeyForServiceAlias(serviceType, alias)
+	vKey := h.adapterReg.VaultKeyWithAlias(serviceType, alias)
 	_, err := h.vault.Get(ctx, userID, vKey)
 	return err == nil
 }

--- a/internal/daemon/services_setup.go
+++ b/internal/daemon/services_setup.go
@@ -98,13 +98,13 @@ func serviceKey(s client.ServiceInfo) string {
 }
 
 // presentServiceMenu builds a flat huh.Select list with ✓/○ status icons,
-// Google services first, then others, with "── Continue →" at the top.
+// OAuth services first, then others, with "── Continue →" at the top.
 func presentServiceMenu(services []client.ServiceInfo) (selected string, err error) {
-	// Partition: Google first, then the rest.
-	var google, other []client.ServiceInfo
+	// Partition: OAuth services first, then the rest.
+	var oauth, other []client.ServiceInfo
 	for _, s := range services {
-		if strings.HasPrefix(s.ID, "google.") {
-			google = append(google, s)
+		if s.OAuth {
+			oauth = append(oauth, s)
 		} else {
 			other = append(other, s)
 		}
@@ -115,8 +115,8 @@ func presentServiceMenu(services []client.ServiceInfo) (selected string, err err
 	// Continue is prominent at the top.
 	opts = append(opts, huh.NewOption(bold.Render("Done connecting services →"), continueOption))
 
-	// Google services first.
-	for _, list := range [][]client.ServiceInfo{google, other} {
+	// OAuth services first.
+	for _, list := range [][]client.ServiceInfo{oauth, other} {
 		for _, s := range list {
 			opts = append(opts, huh.NewOption(serviceLabel(s), serviceKey(s)))
 		}
@@ -204,13 +204,13 @@ func activateAPIKeyService(apiClient *client.Client, svc client.ServiceInfo) err
 	return nil
 }
 
-// activateOAuthService handles OAuth activation. For Google services, if
-// OAuth app credentials aren't configured yet, it collects them and stores
-// them in the system vault (no restart required).
+// activateOAuthService handles OAuth activation. For services using the
+// Google OAuth endpoint, if app credentials aren't configured yet, it
+// collects them and stores them in the system vault (no restart required).
 func activateOAuthService(apiClient *client.Client, svc client.ServiceInfo, dataDir string) error {
 	// Google OAuth requires app credentials (client_id/secret) in the system vault.
 	// If they're absent, collect them via prompt and store via the API.
-	if strings.HasPrefix(svc.ID, "google.") {
+	if svc.OAuthEndpoint == "google" {
 		configured, err := apiClient.GoogleOAuthConfigured()
 		if err != nil {
 			return fmt.Errorf("checking Google OAuth config: %w", err)

--- a/internal/display/display.go
+++ b/internal/display/display.go
@@ -1,7 +1,7 @@
 // Package display provides human-readable names for services and actions.
 // It is the single source of truth used by both API responses and notifications.
-// When Init is called with an adapter registry, metadata is read from adapters
-// that implement MetadataProvider; hardcoded maps serve as fallbacks.
+// Metadata is read from adapters that implement MetadataProvider; fallbacks
+// cover Go-only adapters (iMessage) and the generic underscore→space rule.
 package display
 
 import (
@@ -18,103 +18,9 @@ func Init(reg *adapters.Registry) {
 	registry = reg
 }
 
-var serviceNames = map[string]string{
-	"google.gmail":     "Gmail",
-	"google.calendar":  "Google Calendar",
-	"google.drive":     "Google Drive",
-	"google.contacts":  "Google Contacts",
-	"github":           "GitHub",
-	"apple.imessage":   "iMessage",
-	"slack":            "Slack",
-	"notion":           "Notion",
-	"linear":           "Linear",
-	"stripe":           "Stripe",
-	"twilio":           "Twilio",
-}
-
-var serviceDescriptions = map[string]string{
-	"google.gmail":     "Read, search, and send email",
-	"google.calendar":  "View and manage calendar events",
-	"google.drive":     "List, search, and manage files",
-	"google.contacts":  "Search and view contacts",
-	"github":           "Issues, PRs, and code review",
-	"apple.imessage":   "Search and read iMessage threads",
-	"slack":            "Channels, messages, and search",
-	"notion":           "Pages, databases, and search",
-	"linear":           "Issues, projects, and teams",
-	"stripe":           "Customers, charges, and subscriptions",
-	"twilio":           "SMS, WhatsApp, and messaging",
-}
-
-var actionNames = map[string]string{
-	// Gmail
-	"list_messages": "List messages",
-	"get_message":   "Get message",
-	"send_message":  "Send message",
-	// Calendar
-	"list_events":    "List events",
-	"get_event":      "Get event",
-	"create_event":   "Create event",
-	"update_event":   "Update event",
-	"delete_event":   "Delete event",
-	"list_calendars": "List calendars",
-	// Drive
-	"list_files":   "List files",
-	"get_file":     "Get file",
-	"create_file":  "Create file",
-	"update_file":  "Update file",
-	"search_files": "Search files",
-	// Contacts
-	"list_contacts":   "List contacts",
-	"get_contact":     "Get contact",
-	"search_contacts": "Search contacts",
-	// GitHub
-	"list_issues":   "List issues",
-	"get_issue":     "Get issue",
-	"create_issue":  "Create issue",
-	"comment_issue": "Comment on issue",
-	"list_prs":      "List PRs",
-	"get_pr":        "Get PR",
-	"list_repos":    "List repos",
-	"search_code":   "Search code",
-	// iMessage
-	"search_messages": "Search messages",
-	"list_threads":    "List threads",
-	"get_thread":      "Get thread",
-	// Slack
-	"list_channels": "List channels",
-	"get_channel":   "Get channel",
-	"list_users":    "List users",
-	// Notion
-	"search":          "Search",
-	"get_page":        "Get page",
-	"create_page":     "Create page",
-	"update_page":     "Update page",
-	"query_database":  "Query database",
-	"list_databases":  "List databases",
-	// Linear
-	"update_issue":  "Update issue",
-	"add_comment":   "Add comment",
-	"list_teams":    "List teams",
-	"list_projects": "List projects",
-	"search_issues": "Search issues",
-	// Stripe
-	"list_customers":     "List customers",
-	"get_customer":       "Get customer",
-	"list_charges":       "List charges",
-	"get_charge":         "Get charge",
-	"list_subscriptions": "List subscriptions",
-	"get_subscription":   "Get subscription",
-	"create_refund":      "Create refund",
-	"get_balance":        "Get balance",
-	// Twilio
-	"send_sms":      "Send SMS",
-	"send_whatsapp": "Send WhatsApp",
-}
-
 // ServiceName returns the human-readable name for a service ID.
-// Checks the adapter registry first, then falls back to the hardcoded map,
-// then to the raw ID.
+// Reads from the adapter registry (MetadataProvider), then falls back to the
+// raw ID with dots replaced by spaces as a last resort.
 func ServiceName(id string) string {
 	if registry != nil {
 		if a, ok := registry.Get(id); ok {
@@ -124,9 +30,6 @@ func ServiceName(id string) string {
 				}
 			}
 		}
-	}
-	if name, ok := serviceNames[id]; ok {
-		return name
 	}
 	return id
 }
@@ -142,17 +45,25 @@ func ServiceDescription(id string) string {
 			}
 		}
 	}
-	return serviceDescriptions[id]
+	return ""
 }
 
 // ActionName returns the human-readable label for an action.
-// Falls back to replacing underscores with spaces.
+// Checks MetadataProvider across all adapters, then falls back to
+// replacing underscores with spaces and capitalizing.
 func ActionName(action string) string {
 	if action == "*" {
 		return "All actions"
 	}
-	if name, ok := actionNames[action]; ok {
-		return name
+	// Check all adapters for a matching action display name.
+	if registry != nil {
+		for _, a := range registry.All() {
+			if mp, ok := a.(adapters.MetadataProvider); ok {
+				if am, ok := mp.ServiceMetadata().ActionMeta[action]; ok && am.DisplayName != "" {
+					return am.DisplayName
+				}
+			}
+		}
 	}
 	return strings.ReplaceAll(action, "_", " ")
 }

--- a/internal/taskrisk/assessor_test.go
+++ b/internal/taskrisk/assessor_test.go
@@ -134,10 +134,11 @@ func TestMarshalAssessment_Nil(t *testing.T) {
 	}
 }
 
-func TestActionContextCompleteness(t *testing.T) {
-	// The design doc specifies at least 57 entries (11 adapters × ~5 actions each).
-	if len(actionContext) < 57 {
-		t.Errorf("actionContext has %d entries, want >= 57", len(actionContext))
+func TestBuildActionContextFromRegistry(t *testing.T) {
+	// With a nil registry, buildActionContextFromRegistry should return empty.
+	result := buildActionContextFromRegistry(nil)
+	if result != "" {
+		t.Errorf("expected empty string for nil registry, got %q", result)
 	}
 }
 

--- a/internal/taskrisk/prompts.go
+++ b/internal/taskrisk/prompts.go
@@ -52,105 +52,11 @@ type ActionMeta struct {
 	Description string
 }
 
-// actionContext maps every known service:action pair to its risk metadata.
-var actionContext = map[string]ActionMeta{
-	// Google Gmail
-	"google.gmail:list_messages": {Category: "read", Sensitivity: "low", Description: "List email messages"},
-	"google.gmail:get_message":   {Category: "read", Sensitivity: "low", Description: "Read a specific email message"},
-	"google.gmail:send_message":  {Category: "write", Sensitivity: "high", Description: "Send email as the user"},
-	"google.gmail:create_draft":  {Category: "write", Sensitivity: "low", Description: "Create an email draft (not sent)"},
-
-	// Google Calendar
-	"google.calendar:list_events":    {Category: "read", Sensitivity: "low", Description: "List calendar events"},
-	"google.calendar:get_event":      {Category: "read", Sensitivity: "low", Description: "Read a specific calendar event"},
-	"google.calendar:create_event":   {Category: "write", Sensitivity: "medium", Description: "Create a calendar event"},
-	"google.calendar:update_event":   {Category: "write", Sensitivity: "medium", Description: "Update a calendar event"},
-	"google.calendar:delete_event":   {Category: "delete", Sensitivity: "high", Description: "Delete a calendar event"},
-	"google.calendar:list_calendars": {Category: "read", Sensitivity: "low", Description: "List available calendars"},
-
-	// Google Drive
-	"google.drive:list_files":   {Category: "read", Sensitivity: "low", Description: "List files in Google Drive"},
-	"google.drive:get_file":     {Category: "read", Sensitivity: "low", Description: "Read a specific file from Google Drive"},
-	"google.drive:create_file":  {Category: "write", Sensitivity: "medium", Description: "Create a file in Google Drive"},
-	"google.drive:update_file":  {Category: "write", Sensitivity: "medium", Description: "Update a file in Google Drive"},
-	"google.drive:search_files": {Category: "search", Sensitivity: "low", Description: "Search files in Google Drive"},
-
-	// Google Contacts
-	"google.contacts:list_contacts":   {Category: "read", Sensitivity: "low", Description: "List contacts"},
-	"google.contacts:get_contact":     {Category: "read", Sensitivity: "low", Description: "Read a specific contact"},
-	"google.contacts:search_contacts": {Category: "search", Sensitivity: "low", Description: "Search contacts"},
-
-	// GitHub
-	"github:list_issues":   {Category: "read", Sensitivity: "low", Description: "List GitHub issues"},
-	"github:get_issue":     {Category: "read", Sensitivity: "low", Description: "Read a specific GitHub issue"},
-	"github:create_issue":  {Category: "write", Sensitivity: "medium", Description: "Create a GitHub issue"},
-	"github:comment_issue": {Category: "write", Sensitivity: "medium", Description: "Comment on a GitHub issue"},
-	"github:list_prs":      {Category: "read", Sensitivity: "low", Description: "List pull requests"},
-	"github:get_pr":        {Category: "read", Sensitivity: "low", Description: "Read a specific pull request"},
-	"github:list_repos":    {Category: "read", Sensitivity: "low", Description: "List repositories"},
-	"github:search_code":   {Category: "search", Sensitivity: "low", Description: "Search code across repositories"},
-
-	// Slack
-	"slack:list_channels":   {Category: "read", Sensitivity: "low", Description: "List Slack channels"},
-	"slack:get_channel":     {Category: "read", Sensitivity: "low", Description: "Read a specific Slack channel"},
-	"slack:list_messages":   {Category: "read", Sensitivity: "low", Description: "List messages in a Slack channel"},
-	"slack:send_message":    {Category: "write", Sensitivity: "medium", Description: "Send a Slack message"},
-	"slack:search_messages": {Category: "search", Sensitivity: "low", Description: "Search Slack messages"},
-	"slack:list_users":      {Category: "read", Sensitivity: "low", Description: "List Slack workspace users"},
-
-	// Notion
-	"notion:search":          {Category: "search", Sensitivity: "low", Description: "Search Notion pages and databases"},
-	"notion:get_page":        {Category: "read", Sensitivity: "low", Description: "Read a Notion page"},
-	"notion:create_page":     {Category: "write", Sensitivity: "medium", Description: "Create a Notion page"},
-	"notion:update_page":     {Category: "write", Sensitivity: "medium", Description: "Update a Notion page"},
-	"notion:query_database":  {Category: "read", Sensitivity: "low", Description: "Query a Notion database"},
-	"notion:list_databases":  {Category: "read", Sensitivity: "low", Description: "List Notion databases"},
-
-	// Linear
-	"linear:list_issues":   {Category: "read", Sensitivity: "low", Description: "List Linear issues"},
-	"linear:get_issue":     {Category: "read", Sensitivity: "low", Description: "Read a specific Linear issue"},
-	"linear:create_issue":  {Category: "write", Sensitivity: "medium", Description: "Create a Linear issue"},
-	"linear:update_issue":  {Category: "write", Sensitivity: "medium", Description: "Update a Linear issue"},
-	"linear:add_comment":   {Category: "write", Sensitivity: "medium", Description: "Add a comment to a Linear issue"},
-	"linear:list_teams":    {Category: "read", Sensitivity: "low", Description: "List Linear teams"},
-	"linear:list_projects": {Category: "read", Sensitivity: "low", Description: "List Linear projects"},
-	"linear:search_issues": {Category: "search", Sensitivity: "low", Description: "Search Linear issues"},
-
-	// Stripe
-	"stripe:list_customers":     {Category: "read", Sensitivity: "medium", Description: "List Stripe customers"},
-	"stripe:get_customer":       {Category: "read", Sensitivity: "medium", Description: "Read a specific Stripe customer"},
-	"stripe:list_charges":       {Category: "read", Sensitivity: "medium", Description: "List Stripe charges"},
-	"stripe:get_charge":         {Category: "read", Sensitivity: "medium", Description: "Read a specific Stripe charge"},
-	"stripe:list_subscriptions": {Category: "read", Sensitivity: "medium", Description: "List Stripe subscriptions"},
-	"stripe:get_subscription":   {Category: "read", Sensitivity: "medium", Description: "Read a specific Stripe subscription"},
-	"stripe:create_refund":      {Category: "write", Sensitivity: "high", Description: "Create a Stripe refund (moves money)"},
-	"stripe:get_balance":        {Category: "read", Sensitivity: "medium", Description: "Read Stripe account balance"},
-
-	// Twilio
-	"twilio:send_sms":      {Category: "write", Sensitivity: "high", Description: "Send an SMS message (costs money)"},
-	"twilio:send_whatsapp": {Category: "write", Sensitivity: "high", Description: "Send a WhatsApp message (costs money)"},
-	"twilio:list_messages":  {Category: "read", Sensitivity: "low", Description: "List Twilio messages"},
-	"twilio:get_message":    {Category: "read", Sensitivity: "low", Description: "Read a specific Twilio message"},
-
-	// Apple iMessage
-	"apple.imessage:search_messages": {Category: "search", Sensitivity: "low", Description: "Search iMessage history"},
-	"apple.imessage:list_threads":    {Category: "read", Sensitivity: "low", Description: "List iMessage conversation threads"},
-	"apple.imessage:get_thread":      {Category: "read", Sensitivity: "low", Description: "Read a specific iMessage thread"},
-	"apple.imessage:send_message":    {Category: "write", Sensitivity: "high", Description: "Send an iMessage (requires per-request approval)"},
-}
-
 // buildActionContextFromRegistry builds the action context block by reading
-// ActionMeta from adapters that implement MetadataProvider, falling back to
-// the hardcoded actionContext map for adapters that don't (e.g. iMessage).
+// ActionMeta from all adapters that implement MetadataProvider.
 func buildActionContextFromRegistry(reg *adapters.Registry) string {
 	entries := map[string]ActionMeta{}
 
-	// Seed with hardcoded fallback (covers iMessage and any unregistered adapters).
-	for k, v := range actionContext {
-		entries[k] = v
-	}
-
-	// Override/extend from registry metadata.
 	if reg != nil {
 		for _, a := range reg.All() {
 			mp, ok := a.(adapters.MetadataProvider)

--- a/internal/tui/client/types.go
+++ b/internal/tui/client/types.go
@@ -187,6 +187,7 @@ type ServiceInfo struct {
 	Description        string            `json:"description"`
 	Alias              string            `json:"alias,omitempty"`
 	OAuth              bool              `json:"oauth"`
+	OAuthEndpoint      string            `json:"oauth_endpoint,omitempty"`
 	RequiresActivation bool              `json:"requires_activation"`
 	CredentialFree     bool              `json:"credential_free"`
 	Actions            json.RawMessage   `json:"actions"`

--- a/pkg/adapters/adapters.go
+++ b/pkg/adapters/adapters.go
@@ -21,6 +21,8 @@ type ServiceMetadata struct {
 	DisplayName       string
 	Description       string
 	SetupURL          string
+	VaultKey          string                // shared vault key (e.g. "google" for all google.* services); empty = use service ID
+	OAuthEndpoint     string                // well-known OAuth endpoint name (e.g. "google"); empty = not OAuth or no known endpoint
 	ActionMeta        map[string]ActionMeta // action_id → metadata
 	VerificationHints string
 }
@@ -164,6 +166,33 @@ func (r *Registry) Replace(a Adapter) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.adapters[a.ServiceID()] = a
+}
+
+// VaultKey returns the vault key for a service ID. If the adapter implements
+// MetadataProvider and declares a VaultKey, that is used; otherwise the
+// service ID itself is the vault key.
+func (r *Registry) VaultKey(serviceID string) string {
+	r.mu.RLock()
+	a, ok := r.adapters[serviceID]
+	r.mu.RUnlock()
+	if ok {
+		if mp, ok := a.(MetadataProvider); ok {
+			if vk := mp.ServiceMetadata().VaultKey; vk != "" {
+				return vk
+			}
+		}
+	}
+	return serviceID
+}
+
+// VaultKeyWithAlias returns the vault key for a service ID + alias pair.
+// "default" or empty alias maps to the plain vault key for backward compatibility.
+func (r *Registry) VaultKeyWithAlias(serviceID, alias string) string {
+	base := r.VaultKey(serviceID)
+	if alias == "" || alias == "default" {
+		return base
+	}
+	return base + ":" + alias
 }
 
 func (r *Registry) SupportedServices() []ServiceInfo {

--- a/pkg/adapters/yamlruntime/adapter.go
+++ b/pkg/adapters/yamlruntime/adapter.go
@@ -190,10 +190,18 @@ func (a *YAMLAdapter) ServiceMetadata() adapters.ServiceMetadata {
 		}
 	}
 
+	var vaultKey, oauthEndpoint string
+	if a.def.Auth.OAuth != nil {
+		vaultKey = a.def.Auth.OAuth.VaultKey
+		oauthEndpoint = a.def.Auth.OAuth.Endpoint
+	}
+
 	return adapters.ServiceMetadata{
 		DisplayName:       a.def.Service.DisplayName,
 		Description:       a.def.Service.Description,
 		SetupURL:          a.def.Service.SetupURL,
+		VaultKey:          vaultKey,
+		OAuthEndpoint:     oauthEndpoint,
 		ActionMeta:        actionMeta,
 		VerificationHints: a.def.VerificationHints,
 	}

--- a/pkg/adapters/yamlruntime/auth.go
+++ b/pkg/adapters/yamlruntime/auth.go
@@ -64,6 +64,28 @@ func buildHTTPClient(authDef yamldef.AuthDef, credBytes []byte) (*http.Client, e
 			},
 		}, nil
 
+	case "oauth2":
+		// OAuth credentials are stored as JSON with access_token, refresh_token, etc.
+		// Extract the access token and use it as a Bearer token.
+		var oauthCred struct {
+			AccessToken string `json:"access_token"`
+		}
+		if err := json.Unmarshal(credBytes, &oauthCred); err != nil {
+			return nil, fmt.Errorf("parsing oauth2 credential: %w", err)
+		}
+		if oauthCred.AccessToken == "" {
+			return nil, fmt.Errorf("oauth2 credential missing access_token")
+		}
+		return &http.Client{
+			Transport: &headerTransport{
+				header:       "Authorization",
+				headerPrefix: "Bearer ",
+				token:        oauthCred.AccessToken,
+				extraHeaders: authDef.ExtraHeaders,
+				base:         http.DefaultTransport,
+			},
+		}, nil
+
 	case "none":
 		return &http.Client{
 			Transport: &headerTransport{

--- a/pkg/clawvisor/defaults.go
+++ b/pkg/clawvisor/defaults.go
@@ -153,7 +153,7 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 		goOverrides["google.calendar:"+action] = cal.Execute
 	}
 	drive := driveadapter.New(oauthProvider)
-	for _, action := range []string{"list_files", "get_file", "create_file"} {
+	for _, action := range []string{"get_file", "create_file", "update_file", "search_files"} {
 		goOverrides["google.drive:"+action] = drive.Execute
 	}
 	contacts := contactsadapter.New(oauthProvider)
@@ -173,7 +173,8 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 	// YAML definition means the service is available. OAuth services that lack
 	// credentials will show as "needs_setup" in the UI.
 	for _, ya := range yamlLoader.Adapters() {
-		if strings.HasPrefix(ya.ServiceID(), "google.") {
+		meta := ya.ServiceMetadata()
+		if meta.OAuthEndpoint == "google" {
 			ya.SetOAuthProvider(oauthProvider)
 		}
 		adapterReg.Register(ya)

--- a/web/dist/placeholder.html
+++ b/web/dist/placeholder.html
@@ -1,1 +1,0 @@
-<\!-- placeholder so go:embed dist succeeds without a full build -->

--- a/web/src/lib/services.ts
+++ b/web/src/lib/services.ts
@@ -1,6 +1,5 @@
 // Shared service/action display utilities. Zero React dependencies.
-// Metadata is read from the API response (ServiceInfo) when available,
-// falling back to hardcoded defaults for services not yet loaded.
+// Metadata is read from the API response (ServiceInfo) when available.
 
 import type { ServiceInfo } from '../api/client'
 
@@ -31,36 +30,6 @@ export function populateFromServices(services: ServiceInfo[]) {
   }
 }
 
-// ── Hardcoded fallbacks (for services not yet loaded from API) ─────────────
-
-const FALLBACK_NAMES: Record<string, string> = {
-  'google.gmail': 'Gmail',
-  'google.calendar': 'Google Calendar',
-  'google.drive': 'Google Drive',
-  'google.contacts': 'Google Contacts',
-  'github': 'GitHub',
-  'apple.imessage': 'iMessage',
-  'slack': 'Slack',
-  'notion': 'Notion',
-  'linear': 'Linear',
-  'stripe': 'Stripe',
-  'twilio': 'Twilio',
-}
-
-const FALLBACK_DESCRIPTIONS: Record<string, string> = {
-  'google.gmail': 'Read, search, send, and draft email',
-  'google.calendar': 'View and manage calendar events',
-  'google.drive': 'List, search, and manage files',
-  'google.contacts': 'Search and view contacts',
-  'github': 'Issues, PRs, and code review',
-  'apple.imessage': 'Search and read iMessage threads',
-  'slack': 'Channels, messages, and search',
-  'notion': 'Pages, databases, and search',
-  'linear': 'Issues, projects, and teams',
-  'stripe': 'Customers, charges, and subscriptions',
-  'twilio': 'SMS, WhatsApp, and messaging',
-}
-
 // ── Public API ─────────────────────────────────────────────────────────────
 
 export function serviceName(id: string, alias?: string): string {
@@ -68,10 +37,10 @@ export function serviceName(id: string, alias?: string): string {
   if (colonIdx >= 0) {
     const base = id.slice(0, colonIdx)
     const a = id.slice(colonIdx + 1)
-    const name = _names[base] ?? FALLBACK_NAMES[base] ?? base
+    const name = _names[base] ?? base
     return `${name} (${a})`
   }
-  const name = _names[id] ?? FALLBACK_NAMES[id] ?? id
+  const name = _names[id] ?? id
   if (alias && alias !== 'default') {
     return `${name} (${alias})`
   }
@@ -80,7 +49,7 @@ export function serviceName(id: string, alias?: string): string {
 
 export function serviceDescription(id: string): string {
   const base = id.includes(':') ? id.slice(0, id.indexOf(':')) : id
-  return _descriptions[base] ?? FALLBACK_DESCRIPTIONS[base] ?? ''
+  return _descriptions[base] ?? ''
 }
 
 export function actionName(action: string, service?: string): string {


### PR DESCRIPTION
## Summary
- **OAuth YAML runtime**: Add `oauth2` auth type to `buildHTTPClient` so YAML-defined actions on OAuth services (e.g., Google Drive `list_files`) can execute without Go overrides
- **Vault key from YAML**: Replace hardcoded `google.*` prefix checks with `VaultKey` from adapter YAML definitions via `MetadataProvider`, enabling any adapter to declare shared vault keys
- **Drive override fix**: Remove unnecessary Go override for `list_files` (simple GET), add missing overrides for `update_file` and `search_files`
- **iMessage MetadataProvider**: Add `ServiceMetadata()` to iMessage adapter so it displays as "iMessage" instead of raw `apple.imessage` ID
- **Remove all fallback maps**: Delete hardcoded `serviceNames`, `serviceDesc`, `fallbackActionMeta`, `fallbackActionContext` maps from skill.go, display.go, prompts.go — all metadata now comes from YAML definitions or MetadataProvider

## Test plan
- [ ] Verify Google Drive `list_files` action executes (was failing with "unsupported auth type oauth2")
- [ ] Verify iMessage shows as "iMessage" in TUI service list (not `apple.imessage`)
- [ ] Verify agent skill catalog only shows activated services
- [ ] Verify `go test ./internal/... ./pkg/...` passes
- [ ] Verify custom adapters in `~/.clawvisor/adapters/` still load and execute

🤖 Generated with [Claude Code](https://claude.com/claude-code)