### PR TITLE
fix: emit generic agent setup prompt when no agents detected

### DIFF
--- a/internal/daemon/integrate.go
+++ b/internal/daemon/integrate.go
@@ -23,6 +23,7 @@ func Integrate() error {
 	if len(agents) == 0 {
 		fmt.Println(dim.Padding(0, 2).Render("No known agents detected on this machine."))
 		fmt.Println()
+		printAgentSetupPrompt(dataDir)
 		return nil
 	}
 


### PR DESCRIPTION
## Summary
- When `clawvisor integrate` (or the integrate step of `clawvisor install`) finds no known agents on the machine, it now prints the generic pasteable setup prompt instead of silently returning.
- Previously users with unrecognized agents got a dead-end "No known agents detected" message with no next steps.

## Test plan
- [ ] Run `clawvisor integrate` on a machine with no known agents installed and verify the relay-based setup prompt is printed
- [ ] Run `clawvisor integrate` on a machine with agents installed and verify behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)