### PR TITLE
feat: expr-lang integration for YAML adapter definitions

### DIFF
--- a/docs/design-expr-runtime.md
+++ b/docs/design-expr-runtime.md
@@ -1,0 +1,403 @@
+# Design Doc: Expression-Driven YAML Runtime
+
+## Problem
+
+The YAML adapter system allows community contributors to define new service integrations without writing Go. However, 13 of 18 Google adapter actions still require Go overrides because the YAML runtime can't express:
+
+1. **Nested response extraction** — Google APIs return deeply nested structures (`names[0].displayName`, `emailAddresses[0].value`) that flat field mapping can't reach.
+2. **Parameter transforms** — Date coercion (ISO date to RFC3339), query wrapping (`"fullText contains '...'"` for Drive search), conditional defaults (`timeMin` defaults to `now()`).
+3. **Multi-step requests** — Some actions need 2+ API calls where later calls depend on earlier results (Drive `get_file` fetches metadata, then conditionally fetches content based on MIME type).
+4. **Request encoding** — Gmail requires RFC822 MIME message construction. Drive requires multipart/related uploads. These are well-specified standards but the runtime only knows JSON.
+5. **Conditional fields** — Calendar `update_event` only includes fields that were provided (PATCH semantics). Contacts actions include optional fields only when present.
+
+Every new service that touches email, file storage, calendar, or contacts will hit these same patterns. Without solving them in the runtime, each one requires a custom Go package — defeating the purpose of YAML-driven adapters.
+
+## Proposed Solution
+
+Integrate [expr-lang/expr](https://github.com/expr-lang/expr) as an expression evaluator in the YAML runtime. Expr is a Go expression language that is:
+
+- **Sandboxed** — expressions can only access data and functions explicitly provided in the environment. No filesystem, network, or import access.
+- **Always-terminating** — no general-purpose loops, only bounded operations (map, filter, reduce over finite collections).
+- **Type-checked at compile time** — expressions are compiled once when the YAML is loaded and reused across requests.
+- **Battle-tested** — used by Google, Uber, Argo, OpenTelemetry, CrowdSec, KEDA.
+
+Expr handles the data wiring (field access, conditionals, array transforms). A small set of custom functions (plugins) handles protocol-specific encoding (MIME, multipart). Adapter authors never write Go — they compose expressions from the available functions.
+
+## YAML Syntax Extensions
+
+### 1. Nested field paths via expressions
+
+**Before (Go override required):**
+```go
+func (a *ContactsAdapter) listContacts(...) {
+    for _, c := range resp.Connections {
+        name := ""
+        if len(c.Names) > 0 {
+            name = c.Names[0].DisplayName
+        }
+        email := ""
+        if len(c.EmailAddresses) > 0 {
+            email = c.EmailAddresses[0].Value
+        }
+        // ...
+    }
+}
+```
+
+**After (pure YAML):**
+```yaml
+list_contacts:
+  method: GET
+  path: "/people/me/connections"
+  params:
+    max_results: { type: int, default: 100, max: 1000, map_to: pageSize, location: query }
+    person_fields:
+      type: string
+      default: "names,emailAddresses,phoneNumbers"
+      location: query
+      map_to: personFields
+  response:
+    data_path: "connections"
+    fields:
+      - name: display_name
+        expr: "names[0]?.displayName ?? ''"
+      - name: email
+        expr: "emailAddresses[0]?.value ?? ''"
+      - name: phone
+        expr: "phoneNumbers[0]?.value ?? ''"
+        optional: true
+    summary: "{{len .Data}} contact(s)"
+```
+
+Expr's optional chaining (`?.`) and nil coalescing (`??`) handle missing fields without conditionals.
+
+**Eliminates:** All 3 Contacts overrides.
+
+### 2. Parameter transforms
+
+**Before (Go override required):**
+```go
+func (a *CalendarAdapter) listEvents(...) {
+    timeMin := time.Now().Format(time.RFC3339)
+    if v, ok := params["from"].(string); ok {
+        if !strings.Contains(v, "T") {
+            v += "T00:00:00Z"
+        }
+        timeMin = v
+    }
+    timeMax := ""
+    if v, ok := params["to"].(string); ok {
+        if !strings.Contains(v, "T") {
+            v += "T23:59:59Z"
+        }
+        timeMax = v
+    }
+}
+```
+
+**After (pure YAML):**
+```yaml
+list_events:
+  method: GET
+  path: "/calendars/{{calendar_id ?? 'primary'}}/events"
+  params:
+    from:
+      type: string
+      default_expr: "rfc3339(now())"
+      transform: "rfc3339(from)"
+      map_to: timeMin
+      location: query
+    to:
+      type: string
+      transform: "endOfDay(to)"
+      map_to: timeMax
+      location: query
+    max_results:
+      type: int
+      default: 10
+      max: 50
+      map_to: maxResults
+      location: query
+```
+
+**Eliminates:** Calendar `list_events`. Combined with conditional body building (below), also eliminates `create_event` and `update_event`.
+
+### 3. Request pipelines (chained API calls)
+
+**Before (Go override required):**
+```go
+func (a *DriveAdapter) getFile(...) {
+    // Step 1: fetch metadata
+    var meta fileMetadata
+    apiGET(ctx, client, metadataURL, &meta)
+
+    // Step 2: conditionally fetch content
+    if textMimeTypes[meta.MimeType] {
+        content := fetchContent(ctx, client, contentURL)
+        // merge into result
+    }
+}
+```
+
+**After (pure YAML):**
+```yaml
+get_file:
+  steps:
+    - id: metadata
+      method: GET
+      path: "/files/{{file_id}}"
+      params:
+        file_id: { type: string, required: true, location: path }
+        fields: { type: string, default: "id,name,mimeType,modifiedTime,size,webViewLink", location: query }
+
+    - id: content
+      method: GET
+      path: "/files/{{file_id}}?alt=media"
+      condition: "metadata.mimeType in textMimeTypes"
+      response:
+        max_bytes: 50000
+
+  response:
+    fields:
+      - name: id
+        expr: "metadata.id"
+      - name: name
+        expr: "sanitize(metadata.name)"
+      - name: mime_type
+        expr: "metadata.mimeType"
+      - name: content
+        expr: "content?.body ?? ''"
+        optional: true
+    summary: "File: {{.name}}"
+```
+
+Each step's response is available to subsequent steps by its `id`. The `condition` field is an expr expression — the step is skipped when it evaluates to false.
+
+**Eliminates:** Drive `get_file`, Drive `update_file`.
+
+### 4. Request encodings
+
+**Before (Go override required):**
+```go
+func (a *GmailAdapter) sendMessage(...) {
+    var buf bytes.Buffer
+    fmt.Fprintf(&buf, "To: %s\r\n", to)
+    fmt.Fprintf(&buf, "Subject: %s\r\n", subject)
+    fmt.Fprintf(&buf, "MIME-Version: 1.0\r\n")
+    fmt.Fprintf(&buf, "Content-Type: text/plain; charset=\"utf-8\"\r\n\r\n")
+    buf.WriteString(body)
+    raw := base64.URLEncoding.EncodeToString(buf.Bytes())
+    // POST {"raw": raw}
+}
+```
+
+**After (pure YAML):**
+```yaml
+send_message:
+  method: POST
+  path: "/users/me/messages/send"
+  encoding: mime/rfc822
+  params:
+    to: { type: string, required: true, role: recipient }
+    subject: { type: string, required: true, role: subject }
+    body: { type: string, required: true, role: body }
+    cc: { type: string, role: cc }
+  response:
+    fields:
+      - { name: id }
+      - { name: threadId }
+    summary: "Sent message {{.id}}"
+```
+
+The `encoding` field selects a built-in encoder. The runtime maps param `role` annotations to the encoder's expected inputs. Supported encodings:
+
+| Encoding | Use case | Wrapping |
+|---|---|---|
+| `json` (default) | Standard REST APIs | `Content-Type: application/json` |
+| `form` | URL-encoded forms | `Content-Type: application/x-www-form-urlencoded` |
+| `multipart/form-data` | File uploads (Slack, Discord) | Multipart with boundary |
+| `multipart/related` | Metadata + binary (Google Drive) | JSON part + content part |
+| `mime/rfc822` | Email (Gmail, Outlook, etc.) | RFC822 headers + base64 body, wrapped in `{"raw": "..."}` |
+
+**Eliminates:** Gmail `send_message`, Gmail `create_draft`, Drive `create_file`.
+
+### 5. Conditional body building
+
+**Before (Go override required):**
+```go
+func (a *CalendarAdapter) updateEvent(...) {
+    body := map[string]any{}
+    if summary, ok := params["summary"]; ok {
+        body["summary"] = summary
+    }
+    if location, ok := params["location"]; ok {
+        body["location"] = location
+    }
+    if start, ok := params["start"]; ok {
+        body["start"] = calendarDtField(start)
+    }
+    // PATCH with only provided fields
+}
+```
+
+**After (pure YAML):**
+```yaml
+update_event:
+  method: PATCH
+  path: "/calendars/{{calendar_id ?? 'primary'}}/events/{{event_id}}"
+  body_mode: sparse    # only include params that were provided
+  params:
+    event_id: { type: string, required: true, location: path }
+    calendar_id: { type: string, default: "primary", location: path }
+    summary: { type: string, location: body }
+    location: { type: string, location: body }
+    start:
+      type: string
+      location: body
+      transform: "isAllDay(start) ? {date: start} : {dateTime: rfc3339(start)}"
+    end:
+      type: string
+      location: body
+      transform: "isAllDay(end) ? {date: end} : {dateTime: rfc3339(end)}"
+    attendees:
+      type: list
+      location: body
+      transform: "map(attendees, {email: #})"
+```
+
+`body_mode: sparse` tells the runtime to omit fields from the JSON body when the corresponding param was not provided by the caller. Combined with `transform`, this handles Calendar's all-day vs timed event detection and attendee object construction.
+
+**Eliminates:** Calendar `create_event`, Calendar `update_event`.
+
+### 6. Response post-processing
+
+**Before (Go override required):**
+```go
+func (a *GmailAdapter) getMessage(...) {
+    // Recursive MIME walk to find text/plain or text/html part
+    body := extractBody(payload)
+    decoded, _ := base64.URLEncoding.DecodeString(body)
+    text := stripHTML(string(decoded))
+}
+```
+
+**After (pure YAML):**
+```yaml
+get_message:
+  steps:
+    - id: raw
+      method: GET
+      path: "/users/me/messages/{{message_id}}"
+      params:
+        message_id: { type: string, required: true, location: path }
+        format: { type: string, default: "full", location: query }
+
+  response:
+    fields:
+      - name: id
+        expr: "raw.id"
+      - name: subject
+        expr: "findHeader(raw.payload.headers, 'Subject')"
+      - name: from
+        expr: "findHeader(raw.payload.headers, 'From')"
+      - name: date
+        expr: "findHeader(raw.payload.headers, 'Date')"
+      - name: body
+        expr: "stripHTML(base64Decode(extractMimeBody(raw.payload)))"
+      - name: snippet
+        expr: "sanitize(raw.snippet, 200)"
+    summary: "Message from {{.from}}: {{.subject}}"
+```
+
+The heavy lifting is in three custom functions: `extractMimeBody` (recursive MIME walk), `base64Decode`, and `stripHTML`. These are generic enough to be reusable by any email adapter.
+
+**Eliminates:** Gmail `list_messages`, Gmail `get_message`.
+
+## Custom Functions (Plugins)
+
+All registered in the expr environment at YAML load time. Community adapters can use any of them.
+
+### Date/Time
+| Function | Description |
+|---|---|
+| `rfc3339(value)` | Coerce date string to RFC3339. Handles `YYYY-MM-DD`, `YYYY-MM-DDTHH:MM:SS`, epoch seconds. |
+| `endOfDay(value)` | Like `rfc3339` but appends `T23:59:59Z` for date-only inputs. |
+| `isAllDay(value)` | Returns true if value is date-only (no time component). |
+
+### String/Encoding
+| Function | Description |
+|---|---|
+| `sanitize(s, maxLen?)` | Truncate + strip control characters. |
+| `base64Decode(s)` | URL-safe base64 decode. |
+| `stripHTML(s)` | Remove HTML tags and decode entities. |
+
+### Email
+| Function | Description |
+|---|---|
+| `extractMimeBody(payload)` | Recursive MIME walk, returns text/plain or text/html body part. |
+| `findHeader(headers, name)` | Find a header value by name in a `[{name, value}]` array. |
+
+### Collections
+| Function | Description |
+|---|---|
+| `textMimeTypes` | Set of MIME types considered "text" for content preview. |
+
+Expr also provides built-in `map`, `filter`, `reduce`, `find`, `all`, `any`, `sort`, `len`, `contains`, `startsWith`, `endsWith`, `upper`, `lower`, `trim`, `split`, `join`.
+
+## Override Elimination Summary
+
+| Service | Action | Current | After | Enabling Feature |
+|---|---|---|---|---|
+| Contacts | `list_contacts` | Go | YAML | Field path expressions |
+| Contacts | `get_contact` | Go | YAML | Field path expressions |
+| Contacts | `search_contacts` | Go | YAML | Field path expressions |
+| Calendar | `list_events` | Go | YAML | Parameter transforms |
+| Calendar | `create_event` | Go | YAML | Transforms + sparse body |
+| Calendar | `update_event` | Go | YAML | Transforms + sparse body |
+| Drive | `get_file` | Go | YAML | Request pipelines |
+| Drive | `create_file` | Go | YAML | multipart/related encoding |
+| Drive | `search_files` | Go | YAML | Parameter transforms |
+| Gmail | `list_messages` | Go | YAML | Pipelines + field expressions |
+| Gmail | `get_message` | Go | YAML | Pipelines + post-processing |
+| Gmail | `send_message` | Go | YAML | mime/rfc822 encoding |
+| Gmail | `create_draft` | Go | YAML | mime/rfc822 encoding |
+
+**Result: 13/13 Go overrides eliminated. All Google adapters become pure YAML.**
+
+## Implementation Order
+
+Each phase is independently shippable and immediately useful:
+
+### Phase 1: Field path expressions
+- Add `expr` field to response field definitions
+- Compile expressions at YAML load time
+- Apply during response mapping
+- **Unblocks:** Contacts (3 overrides), any community adapter hitting nested APIs
+
+### Phase 2: Parameter transforms + sparse body
+- Add `transform`, `map_to`, `default_expr` to param definitions
+- Add `body_mode: sparse` to action definitions
+- **Unblocks:** Calendar (3 overrides), Drive `search_files` (1 override)
+
+### Phase 3: Request pipelines
+- Add `steps` with `id`, `condition`, and cross-step references
+- **Unblocks:** Drive `get_file` (1 override), Gmail `list_messages` and `get_message` (2 overrides)
+
+### Phase 4: Request encodings
+- Add `encoding` field with `multipart/related` and `mime/rfc822` encoders
+- Add `role` annotation to params for encoder input mapping
+- **Unblocks:** Gmail `send_message` and `create_draft` (2 overrides), Drive `create_file` (1 override)
+
+## Security
+
+- **Expr is sandboxed by design.** Expressions cannot access the filesystem, network, or any Go package not explicitly injected. The environment contains only the request params, step results, and registered functions.
+- **Always-terminating.** No unbounded loops. `map`/`filter`/`reduce` operate on finite collections from API responses.
+- **Compiled once, run many.** Expressions are compiled and type-checked at YAML load time. A malformed expression in `~/.clawvisor/adapters/` fails fast at startup, not at request time.
+- **Custom functions are read-only.** `sanitize`, `base64Decode`, `stripHTML`, etc. are pure functions with no side effects.
+- **No escalation path.** A community adapter's expressions can only transform data within its own request/response cycle. They cannot access other adapters' credentials, vault entries, or internal state.
+
+## Open Questions
+
+1. **Expression error handling.** If a field expression returns nil or errors (e.g., API response missing expected structure), should the field be omitted, set to empty string, or should the action fail? Proposal: omit optional fields, fail on required fields.
+2. **Expression debugging.** When a community adapter's expression doesn't produce expected results, how do authors debug? Proposal: `clawvisor adapter test <file.yaml>` CLI command that loads a YAML definition, runs a mock request, and prints intermediate expression results.
+3. **Plugin extensibility.** Should community adapters be able to register their own custom functions, or is the built-in set sufficient? Proposal: start with built-in only; add plugin registration if concrete demand emerges.

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
+	github.com/expr-lang/expr v1.17.8 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,8 @@ github.com/envoyproxy/protoc-gen-validate v1.3.0 h1:TvGH1wof4H33rezVKWSpqKz5NXWg
 github.com/envoyproxy/protoc-gen-validate v1.3.0/go.mod h1:HvYl7zwPa5mffgyeTUHA9zHIH36nmrm7oCbo4YKoSWA=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
+github.com/expr-lang/expr v1.17.8 h1:W1loDTT+0PQf5YteHSTpju2qfUfNoBt4yw9+wOEU9VM=
+github.com/expr-lang/expr v1.17.8/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/internal/adapters/definitions/google_calendar.yaml
+++ b/internal/adapters/definitions/google_calendar.yaml
@@ -22,7 +22,40 @@ actions:
   list_events:
     display_name: "List events"
     risk: { category: read, sensitivity: low, description: "List calendar events" }
-    override: go
+    method: GET
+    path: "/calendars/{{.calendar_id}}/events"
+    params:
+      calendar_id: { type: string, default: "primary", location: path }
+      from:
+        type: string
+        default_expr: "now()"
+        transform: "rfc3339(from)"
+        map_to: timeMin
+        location: query
+      to:
+        type: string
+        transform: "endOfDay(to)"
+        map_to: timeMax
+        location: query
+      max_results: { type: int, default: 10, max: 50, map_to: maxResults, location: query }
+      single_events: { type: string, default: "true", map_to: singleEvents, location: query }
+      order_by: { type: string, default: "startTime", map_to: orderBy, location: query }
+    response:
+      data_path: "items"
+      fields:
+        - { name: id }
+        - { name: summary, sanitize: true }
+        - name: start
+          expr: "start.dateTime ?? start.date ?? ''"
+        - name: end
+          expr: "end.dateTime ?? end.date ?? ''"
+        - { name: location, sanitize: true, optional: true }
+        - { name: description, sanitize: true, optional: true }
+        - name: attendees
+          expr: "attendees"
+          optional: true
+        - { name: status }
+      summary: "{{len .Data}} event(s)"
 
   get_event:
     display_name: "Get event"
@@ -36,8 +69,10 @@ actions:
       fields:
         - { name: id }
         - { name: summary, sanitize: true }
-        - { name: start }
-        - { name: end }
+        - name: start
+          expr: "start.dateTime ?? start.date ?? ''"
+        - name: end
+          expr: "end.dateTime ?? end.date ?? ''"
         - { name: location, sanitize: true }
         - { name: description, sanitize: true }
         - { name: attendees }
@@ -47,12 +82,57 @@ actions:
   create_event:
     display_name: "Create event"
     risk: { category: write, sensitivity: medium, description: "Create a calendar event" }
-    override: go
+    method: POST
+    path: "/calendars/{{.calendar_id}}/events"
+    params:
+      calendar_id: { type: string, default: "primary", location: path }
+      summary: { type: string, required: true, location: body }
+      description: { type: string, location: body }
+      start:
+        type: string
+        required: true
+        location: body
+        transform: "isAllDay(start) ? {date: start} : {dateTime: rfc3339(start)}"
+      end:
+        type: string
+        required: true
+        location: body
+        transform: "isAllDay(end) ? {date: end} : {dateTime: rfc3339(end)}"
+      attendees:
+        type: array
+        location: body
+        transform: "emailList(attendees)"
+    response:
+      fields:
+        - { name: id, rename: event_id }
+        - { name: summary }
+        - { name: htmlLink, rename: link }
+      summary: "Created event: {{.summary}}"
 
   update_event:
     display_name: "Update event"
     risk: { category: write, sensitivity: medium, description: "Update a calendar event" }
-    override: go
+    method: PATCH
+    path: "/calendars/{{.calendar_id}}/events/{{.event_id}}"
+    body_mode: sparse
+    params:
+      event_id: { type: string, required: true, location: path }
+      calendar_id: { type: string, default: "primary", location: path }
+      summary: { type: string, location: body }
+      description: { type: string, location: body }
+      start:
+        type: string
+        location: body
+        transform: "isAllDay(start) ? {date: start} : {dateTime: rfc3339(start)}"
+      end:
+        type: string
+        location: body
+        transform: "isAllDay(end) ? {date: end} : {dateTime: rfc3339(end)}"
+    response:
+      fields:
+        - { name: id, rename: event_id }
+        - { name: summary }
+      summary: "Updated event: {{.summary}}"
 
   delete_event:
     display_name: "Delete event"

--- a/internal/adapters/definitions/google_contacts.yaml
+++ b/internal/adapters/definitions/google_contacts.yaml
@@ -21,14 +21,92 @@ actions:
   list_contacts:
     display_name: "List contacts"
     risk: { category: read, sensitivity: low, description: "List contacts" }
-    override: go
+    method: GET
+    path: "/people/me/connections"
+    params:
+      max_results: { type: int, default: 20, max: 100, map_to: pageSize, location: query }
+      person_fields:
+        type: string
+        default: "names,emailAddresses,phoneNumbers"
+        location: query
+        map_to: personFields
+      sort_order:
+        type: string
+        default: "LAST_NAME_ASCENDING"
+        location: query
+        map_to: sortOrder
+    response:
+      data_path: "connections"
+      fields:
+        - name: id
+          expr: "resourceName"
+        - name: name
+          expr: "names[0]?.displayName ?? ''"
+          sanitize: true
+        - name: email
+          expr: "emailAddresses[0]?.value ?? ''"
+        - name: phone
+          expr: "phoneNumbers[0]?.value ?? ''"
+          optional: true
+      summary: "{{len .Data}} contact(s)"
 
   get_contact:
     display_name: "Get contact"
     risk: { category: read, sensitivity: low, description: "Read a specific contact" }
-    override: go
+    method: GET
+    path: "/{{.contact_id}}"
+    params:
+      contact_id: { type: string, required: true, location: path }
+      person_fields:
+        type: string
+        default: "names,emailAddresses,phoneNumbers,organizations,biographies"
+        location: query
+        map_to: personFields
+    response:
+      fields:
+        - name: id
+          expr: "resourceName"
+        - name: name
+          expr: "names[0]?.displayName ?? ''"
+          sanitize: true
+        - name: email_addresses
+          expr: "emailAddresses"
+          optional: true
+        - name: phone_numbers
+          expr: "phoneNumbers"
+          optional: true
+        - name: organization
+          expr: "organizations[0]?.name ?? ''"
+          optional: true
+        - name: title
+          expr: "organizations[0]?.title ?? ''"
+          optional: true
+      summary: "Contact: {{.name}}"
 
   search_contacts:
     display_name: "Search contacts"
     risk: { category: search, sensitivity: low, description: "Search contacts" }
-    override: go
+    method: GET
+    path: "/people:searchContacts"
+    params:
+      query: { type: string, required: true, location: query }
+      max_results: { type: int, default: 10, max: 50, map_to: pageSize, location: query }
+      read_mask:
+        type: string
+        default: "names,emailAddresses,phoneNumbers"
+        location: query
+        map_to: readMask
+    response:
+      data_path: "results"
+      fields:
+        - name: id
+          expr: "person.resourceName"
+        - name: name
+          expr: "person.names[0]?.displayName ?? ''"
+          sanitize: true
+        - name: email
+          expr: "person.emailAddresses[0]?.value ?? ''"
+        - name: phone
+          expr: "person.phoneNumbers[0]?.value ?? ''"
+          optional: true
+      summary: "{{len .Data}} contact(s)"

--- a/internal/adapters/definitions/google_drive.yaml
+++ b/internal/adapters/definitions/google_drive.yaml
@@ -25,8 +25,13 @@ actions:
     method: GET
     path: "/files"
     params:
-      query: { type: string, location: query }
-      max_results: { type: int, default: 10, max: 50, location: query }
+      query: { type: string, map_to: q, location: query }
+      max_results: { type: int, default: 10, max: 50, map_to: pageSize, location: query }
+      fields_param:
+        type: string
+        default: "files(id,name,mimeType,modifiedTime,size,webViewLink)"
+        map_to: fields
+        location: query
     response:
       data_path: "files"
       fields:
@@ -56,4 +61,28 @@ actions:
   search_files:
     display_name: "Search files"
     risk: { category: search, sensitivity: low, description: "Search files in Google Drive" }
-    override: go
+    method: GET
+    path: "/files"
+    params:
+      query:
+        type: string
+        required: true
+        location: query
+        transform: "'fullText contains \\'' + replace(query, \"'\", \"\\\\'\") + '\\''"
+        map_to: q
+      max_results: { type: int, default: 10, max: 50, map_to: pageSize, location: query }
+      fields_param:
+        type: string
+        default: "files(id,name,mimeType,modifiedTime,size,webViewLink)"
+        map_to: fields
+        location: query
+    response:
+      data_path: "files"
+      fields:
+        - { name: id }
+        - { name: name, sanitize: true }
+        - { name: mimeType }
+        - { name: modifiedTime }
+        - { name: size }
+        - { name: webViewLink }
+      summary: "{{len .Data}} file(s)"

--- a/internal/adapters/definitions/google_gmail.yaml
+++ b/internal/adapters/definitions/google_gmail.yaml
@@ -31,7 +31,31 @@ actions:
   get_message:
     display_name: "Get message"
     risk: { category: read, sensitivity: low, description: "Read a specific email message" }
-    override: go
+    method: GET
+    path: "/users/me/messages/{{.message_id}}"
+    params:
+      message_id: { type: string, required: true, location: path }
+      format: { type: string, default: "full", location: query }
+    response:
+      fields:
+        - { name: id }
+        - name: from
+          expr: "findHeader(payload.headers, 'From')"
+          sanitize: true
+        - name: to
+          expr: "findHeader(payload.headers, 'To')"
+          sanitize: true
+        - name: subject
+          expr: "findHeader(payload.headers, 'Subject')"
+          sanitize: true
+        - name: date
+          expr: "findHeader(payload.headers, 'Date')"
+        - name: body
+          expr: "sanitize(extractMimeBody(payload) != '' ? extractMimeBody(payload) : snippet, 2000)"
+        - name: is_unread
+          expr: "'UNREAD' in labelIds"
+        - { name: threadId, rename: thread_id }
+      summary: "Email from {{.from}}: {{.subject}}"
 
   send_message:
     display_name: "Send message"

--- a/pkg/adapters/yamldef/schema.go
+++ b/pkg/adapters/yamldef/schema.go
@@ -60,9 +60,10 @@ type Action struct {
 	Override    string            `yaml:"override,omitempty"` // "go" signals delegation to a registered Go function
 
 	// REST fields
-	Method   string `yaml:"method,omitempty"`   // GET, POST, PUT, PATCH, DELETE
-	Path     string `yaml:"path,omitempty"`     // URL path with {{.param}} interpolation
-	Encoding string `yaml:"encoding,omitempty"` // "form" or "json" (default "json")
+	Method   string `yaml:"method,omitempty"`    // GET, POST, PUT, PATCH, DELETE
+	Path     string `yaml:"path,omitempty"`      // URL path with {{.param}} interpolation
+	Encoding string `yaml:"encoding,omitempty"`  // "form" or "json" (default "json")
+	BodyMode string `yaml:"body_mode,omitempty"` // "sparse" = only include provided params in body
 
 	// GraphQL fields
 	Query    string `yaml:"query,omitempty"`    // GraphQL query/mutation string
@@ -91,6 +92,10 @@ type Param struct {
 	Max      *int   `yaml:"max,omitempty"`
 	Location string `yaml:"location,omitempty"` // "query", "body", "path"
 
+	MapTo       string `yaml:"map_to,omitempty"`       // API-side parameter name (if different from YAML name)
+	Transform   string `yaml:"transform,omitempty"`     // expr expression applied to the resolved value
+	DefaultExpr string `yaml:"default_expr,omitempty"` // expr expression for dynamic default (e.g. "rfc3339(now())")
+
 	// GraphQL-specific
 	GraphQLVar bool   `yaml:"graphql_var,omitempty"` // pass as a top-level GraphQL variable
 	FilterPath string `yaml:"filter_path,omitempty"` // e.g. "team.id.eq" — builds nested filter object
@@ -108,12 +113,14 @@ type ResponseDef struct {
 
 // FieldDef describes a single field to extract from the response.
 type FieldDef struct {
-	Name     string `yaml:"name"`
-	Path     string `yaml:"path,omitempty"`      // nested access path (e.g. "state.name")
-	Rename   string `yaml:"rename,omitempty"`     // output key name (defaults to Name)
-	Sanitize bool   `yaml:"sanitize,omitempty"`   // apply format.SanitizeText
-	Nullable bool   `yaml:"nullable,omitempty"`   // tolerate nil without error
-	Transform string `yaml:"transform,omitempty"` // named transform (e.g. "money", "upper")
+	Name      string `yaml:"name"`
+	Path      string `yaml:"path,omitempty"`      // nested access path (e.g. "state.name")
+	Rename    string `yaml:"rename,omitempty"`     // output key name (defaults to Name)
+	Sanitize  bool   `yaml:"sanitize,omitempty"`   // apply format.SanitizeText
+	Nullable  bool   `yaml:"nullable,omitempty"`   // tolerate nil without error
+	Transform string `yaml:"transform,omitempty"`  // named transform (e.g. "money", "upper")
+	Expr      string `yaml:"expr,omitempty"`       // expr-lang expression evaluated against the response object
+	Optional  bool   `yaml:"optional,omitempty"`   // omit field from output if expr returns nil
 }
 
 // ErrorCheckDef describes how to check for API-level errors in the response envelope.

--- a/pkg/adapters/yamlloader/loader.go
+++ b/pkg/adapters/yamlloader/loader.go
@@ -114,7 +114,12 @@ func (l *Loader) LoadAll() error {
 				}
 			}
 		}
-		l.adapters = append(l.adapters, yamlruntime.New(def, actionOverrides))
+		adapter, err := yamlruntime.New(def, actionOverrides)
+		if err != nil {
+			l.logger.Warn("skipping adapter: expression compilation failed", "service", def.Service.ID, "err", err)
+			continue
+		}
+		l.adapters = append(l.adapters, adapter)
 	}
 
 	l.logger.Info("loaded adapter definitions", "count", len(l.adapters))

--- a/pkg/adapters/yamlruntime/adapter.go
+++ b/pkg/adapters/yamlruntime/adapter.go
@@ -5,9 +5,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"sort"
 	"strings"
+	"time"
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
@@ -24,15 +26,30 @@ type YAMLAdapter struct {
 	def           yamldef.ServiceDef
 	overrides     map[string]ActionFunc              // action_name → Go override
 	oauthProvider adapters.OAuthCredentialProvider    // lazy OAuth credential source
+	compiled      map[string]*compiledAction          // action_name → compiled exprs (nil if none)
 }
 
 // New creates a YAMLAdapter from a parsed service definition.
 // overrides maps action names to Go functions for actions too complex for YAML.
-func New(def yamldef.ServiceDef, overrides map[string]ActionFunc) *YAMLAdapter {
+// Returns an error if any expr expression fails to compile.
+func New(def yamldef.ServiceDef, overrides map[string]ActionFunc) (*YAMLAdapter, error) {
 	if overrides == nil {
 		overrides = map[string]ActionFunc{}
 	}
-	return &YAMLAdapter{def: def, overrides: overrides}
+	compiled := make(map[string]*compiledAction, len(def.Actions))
+	for name, action := range def.Actions {
+		if action.Override == "go" {
+			continue
+		}
+		ca, err := compileAction(action)
+		if err != nil {
+			return nil, fmt.Errorf("%s.%s: %w", def.Service.ID, name, err)
+		}
+		if ca != nil {
+			compiled[name] = ca
+		}
+	}
+	return &YAMLAdapter{def: def, overrides: overrides, compiled: compiled}, nil
 }
 
 func (a *YAMLAdapter) ServiceID() string { return a.def.Service.ID }
@@ -69,7 +86,7 @@ func (a *YAMLAdapter) Execute(ctx context.Context, req adapters.Request) (*adapt
 	}
 
 	// Build the authenticated HTTP client.
-	client, err := buildHTTPClient(a.def.Auth, req.Credential)
+	client, err := a.buildAuthClient(ctx, req.Credential)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", a.def.Service.ID, err)
 	}
@@ -79,7 +96,7 @@ func (a *YAMLAdapter) Execute(ctx context.Context, req adapters.Request) (*adapt
 
 	switch a.def.API.Type {
 	case "rest":
-		return executeREST(ctx, client, a.def.API.BaseURL, action, req.Params, credFields)
+		return executeREST(ctx, client, a.def.API.BaseURL, action, req.Params, credFields, a.compiled[req.Action])
 	case "graphql":
 		return executeGraphQL(ctx, client, a.def.API.BaseURL, action, req.Params, a.def.Service.ID)
 	default:
@@ -174,6 +191,39 @@ func (a *YAMLAdapter) RequiredScopes() []string {
 	// Return scopes from the definition directly — these are known regardless
 	// of whether OAuth app credentials are configured in the vault yet.
 	return a.def.Auth.OAuth.Scopes
+}
+
+// buildAuthClient creates an *http.Client with proper authentication.
+// For OAuth2 services, this uses the OAuthConfig token source which handles
+// automatic token refresh. For other auth types, delegates to buildHTTPClient.
+func (a *YAMLAdapter) buildAuthClient(ctx context.Context, credBytes []byte) (*http.Client, error) {
+	if a.def.Auth.Type == "oauth2" {
+		oauthCfg := a.OAuthConfig()
+		if oauthCfg == nil {
+			return nil, fmt.Errorf("OAuth not configured — missing app credentials")
+		}
+		var stored struct {
+			AccessToken  string `json:"access_token"`
+			RefreshToken string `json:"refresh_token"`
+			Expiry       string `json:"expiry"`
+		}
+		if err := json.Unmarshal(credBytes, &stored); err != nil {
+			return nil, fmt.Errorf("parsing oauth2 credential: %w", err)
+		}
+		token := &oauth2.Token{
+			AccessToken:  stored.AccessToken,
+			RefreshToken: stored.RefreshToken,
+			TokenType:    "Bearer",
+		}
+		if stored.Expiry != "" {
+			if t, err := time.Parse(time.RFC3339, stored.Expiry); err == nil {
+				token.Expiry = t
+			}
+		}
+		ts := oauthCfg.TokenSource(ctx, token)
+		return oauth2.NewClient(ctx, ts), nil
+	}
+	return buildHTTPClient(a.def.Auth, credBytes)
 }
 
 // ── MetadataProvider implementation ─────────────────────────────────────────

--- a/pkg/adapters/yamlruntime/adapter_test.go
+++ b/pkg/adapters/yamlruntime/adapter_test.go
@@ -70,7 +70,10 @@ func TestYAMLAdapter_RESTListAction(t *testing.T) {
 		},
 	}
 
-	adapter := New(def, nil)
+	adapter, err := New(def, nil)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
 
 	if adapter.ServiceID() != "stripe" {
 		t.Fatalf("expected service ID 'stripe', got %q", adapter.ServiceID())
@@ -136,7 +139,10 @@ func TestYAMLAdapter_RESTGetWithPathParam(t *testing.T) {
 		},
 	}
 
-	adapter := New(def, nil)
+	adapter, err := New(def, nil)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
 	result, err := adapter.Execute(context.Background(), adapters.Request{
 		Action:     "get_customer",
 		Params:     map[string]any{"customer_id": "cus_abc"},
@@ -195,7 +201,10 @@ func TestYAMLAdapter_RESTFormPost(t *testing.T) {
 		},
 	}
 
-	adapter := New(def, nil)
+	adapter, err := New(def, nil)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
 	result, err := adapter.Execute(context.Background(), adapters.Request{
 		Action:     "create_refund",
 		Params:     map[string]any{"charge": "ch_123", "amount": 1000},
@@ -260,7 +269,10 @@ func TestYAMLAdapter_GraphQLAction(t *testing.T) {
 		},
 	}
 
-	adapter := New(def, nil)
+	adapter, err := New(def, nil)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
 	result, err := adapter.Execute(context.Background(), adapters.Request{
 		Action:     "list_issues",
 		Params:     map[string]any{},
@@ -314,7 +326,10 @@ func TestYAMLAdapter_BasicAuth(t *testing.T) {
 		},
 	}
 
-	adapter := New(def, nil)
+	adapter, err := New(def, nil)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
 	result, err := adapter.Execute(context.Background(), adapters.Request{
 		Action:     "send_sms",
 		Params:     map[string]any{"to": "+1234", "body": "hello"},
@@ -358,8 +373,11 @@ func TestYAMLAdapter_ErrorCheckSlackStyle(t *testing.T) {
 		},
 	}
 
-	adapter := New(def, nil)
-	_, err := adapter.Execute(context.Background(), adapters.Request{
+	adapter, err := New(def, nil)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	_, err = adapter.Execute(context.Background(), adapters.Request{
 		Action:     "list_channels",
 		Params:     map[string]any{},
 		Credential: testCred("xoxb-test"),
@@ -388,7 +406,10 @@ func TestYAMLAdapter_GoOverride(t *testing.T) {
 		},
 	}
 
-	adapter := New(def, overrides)
+	adapter, err := New(def, overrides)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
 	result, err := adapter.Execute(context.Background(), adapters.Request{
 		Action:     "custom_action",
 		Params:     map[string]any{},
@@ -420,7 +441,10 @@ func TestYAMLAdapter_ServiceMetadata(t *testing.T) {
 		},
 	}
 
-	adapter := New(def, nil)
+	adapter, err := New(def, nil)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
 	meta := adapter.ServiceMetadata()
 
 	if meta.DisplayName != "Stripe" {
@@ -443,7 +467,10 @@ func TestYAMLAdapter_ValidateCredential(t *testing.T) {
 		Service: yamldef.ServiceInfo{ID: "test"},
 		Auth:    yamldef.AuthDef{Type: "api_key"},
 	}
-	adapter := New(def, nil)
+	adapter, err := New(def, nil)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
 
 	if err := adapter.ValidateCredential(testCred("valid")); err != nil {
 		t.Errorf("expected valid credential: %v", err)
@@ -453,6 +480,494 @@ func TestYAMLAdapter_ValidateCredential(t *testing.T) {
 	}
 	if err := adapter.ValidateCredential(nil); err == nil {
 		t.Error("expected error for nil credential")
+	}
+}
+
+// ── Expr-lang integration tests ──────────────────────────────────────────────
+
+func TestYAMLAdapter_ExprFieldExtraction(t *testing.T) {
+	// Simulate a Contacts-style API with nested arrays.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"connections": []map[string]any{
+				{
+					"resourceName": "people/123",
+					"names":        []map[string]any{{"displayName": "Alice Smith"}},
+					"emailAddresses": []map[string]any{{"value": "alice@example.com"}},
+					"phoneNumbers":   []map[string]any{{"value": "+1234567890"}},
+				},
+				{
+					"resourceName": "people/456",
+					"names":        []map[string]any{{"displayName": "Bob Jones"}},
+					"emailAddresses": []map[string]any{{"value": "bob@example.com"}},
+					// No phone number — tests optional field omission.
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	def := yamldef.ServiceDef{
+		Service: yamldef.ServiceInfo{ID: "contacts"},
+		Auth:    yamldef.AuthDef{Type: "api_key", Header: "Authorization", HeaderPrefix: "Bearer "},
+		API:     yamldef.APIDef{BaseURL: srv.URL, Type: "rest"},
+		Actions: map[string]yamldef.Action{
+			"list": {
+				Method: "GET",
+				Path:   "/connections",
+				Response: yamldef.ResponseDef{
+					DataPath: "connections",
+					Fields: []yamldef.FieldDef{
+						{Name: "id", Expr: "resourceName"},
+						{Name: "name", Expr: "names[0]?.displayName ?? ''", Sanitize: true},
+						{Name: "email", Expr: "emailAddresses[0]?.value ?? ''"},
+						{Name: "phone", Expr: "phoneNumbers[0]?.value ?? ''", Optional: true},
+					},
+					Summary: "{{len .Data}} contact(s)",
+				},
+			},
+		},
+	}
+
+	adapter, err := New(def, nil)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	result, err := adapter.Execute(context.Background(), adapters.Request{
+		Action: "list", Params: map[string]any{}, Credential: testCred("test"),
+	})
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	items, ok := result.Data.([]map[string]any)
+	if !ok {
+		t.Fatalf("expected []map[string]any, got %T", result.Data)
+	}
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(items))
+	}
+
+	if items[0]["id"] != "people/123" {
+		t.Errorf("expected people/123, got %v", items[0]["id"])
+	}
+	if items[0]["name"] != "Alice Smith" {
+		t.Errorf("expected Alice Smith, got %v", items[0]["name"])
+	}
+	if items[0]["email"] != "alice@example.com" {
+		t.Errorf("expected alice@example.com, got %v", items[0]["email"])
+	}
+	if items[0]["phone"] != "+1234567890" {
+		t.Errorf("expected +1234567890, got %v", items[0]["phone"])
+	}
+	// Bob has no phone — optional field should be omitted.
+	if _, hasPhone := items[1]["phone"]; hasPhone {
+		t.Errorf("expected phone to be omitted for Bob, got %v", items[1]["phone"])
+	}
+
+	if result.Summary != "2 contact(s)" {
+		t.Errorf("unexpected summary: %q", result.Summary)
+	}
+}
+
+func TestYAMLAdapter_ParamMapToAndTransform(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify map_to renamed the param.
+		if r.URL.Query().Get("pageSize") != "5" {
+			t.Errorf("expected pageSize=5, got %q", r.URL.Query().Get("pageSize"))
+		}
+		// Verify the original param name is NOT in the query.
+		if r.URL.Query().Get("max_results") != "" {
+			t.Errorf("original param name 'max_results' should not appear in query")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"items": []any{}})
+	}))
+	defer srv.Close()
+
+	def := yamldef.ServiceDef{
+		Service: yamldef.ServiceInfo{ID: "test"},
+		Auth:    yamldef.AuthDef{Type: "api_key", Header: "Authorization", HeaderPrefix: "Bearer "},
+		API:     yamldef.APIDef{BaseURL: srv.URL, Type: "rest"},
+		Actions: map[string]yamldef.Action{
+			"list": {
+				Method: "GET", Path: "/items",
+				Params: map[string]yamldef.Param{
+					"max_results": {Type: "int", Default: 10, Max: intPtr(50), MapTo: "pageSize", Location: "query"},
+				},
+				Response: yamldef.ResponseDef{Summary: "done"},
+			},
+		},
+	}
+
+	adapter, err := New(def, nil)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	_, err = adapter.Execute(context.Background(), adapters.Request{
+		Action: "list", Params: map[string]any{"max_results": 5}, Credential: testCred("test"),
+	})
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+}
+
+func TestYAMLAdapter_SparseBodyMode(t *testing.T) {
+	var receivedBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&receivedBody)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"id": "1", "summary": "Updated"})
+	}))
+	defer srv.Close()
+
+	def := yamldef.ServiceDef{
+		Service: yamldef.ServiceInfo{ID: "test"},
+		Auth:    yamldef.AuthDef{Type: "api_key", Header: "Authorization", HeaderPrefix: "Bearer "},
+		API:     yamldef.APIDef{BaseURL: srv.URL, Type: "rest"},
+		Actions: map[string]yamldef.Action{
+			"update": {
+				Method: "PATCH", Path: "/items/{{.id}}",
+				BodyMode: "sparse",
+				Params: map[string]yamldef.Param{
+					"id":      {Type: "string", Required: true, Location: "path"},
+					"title":   {Type: "string", Location: "body"},
+					"summary": {Type: "string", Location: "body"},
+					"status":  {Type: "string", Location: "body"},
+				},
+				Response: yamldef.ResponseDef{
+					Fields:  []yamldef.FieldDef{{Name: "id"}, {Name: "summary"}},
+					Summary: "updated",
+				},
+			},
+		},
+	}
+
+	adapter, err := New(def, nil)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	// Only provide "title" — other body params should be omitted in sparse mode.
+	_, err = adapter.Execute(context.Background(), adapters.Request{
+		Action: "update",
+		Params: map[string]any{"id": "42", "title": "New Title"},
+		Credential: testCred("test"),
+	})
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	if _, has := receivedBody["title"]; !has {
+		t.Error("expected 'title' in body")
+	}
+	if _, has := receivedBody["summary"]; has {
+		t.Error("'summary' should NOT be in sparse body (not provided)")
+	}
+	if _, has := receivedBody["status"]; has {
+		t.Error("'status' should NOT be in sparse body (not provided)")
+	}
+}
+
+func TestYAMLAdapter_ParamTransformExpr(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		timeMin := r.URL.Query().Get("timeMin")
+		// The transform should have converted "2024-06-15" to RFC3339.
+		if timeMin != "2024-06-15T00:00:00Z" {
+			t.Errorf("expected RFC3339 timeMin, got %q", timeMin)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"items": []any{}})
+	}))
+	defer srv.Close()
+
+	def := yamldef.ServiceDef{
+		Service: yamldef.ServiceInfo{ID: "test"},
+		Auth:    yamldef.AuthDef{Type: "api_key", Header: "Authorization", HeaderPrefix: "Bearer "},
+		API:     yamldef.APIDef{BaseURL: srv.URL, Type: "rest"},
+		Actions: map[string]yamldef.Action{
+			"list": {
+				Method: "GET", Path: "/events",
+				Params: map[string]yamldef.Param{
+					"from": {Type: "string", Transform: "rfc3339(from)", MapTo: "timeMin", Location: "query"},
+				},
+				Response: yamldef.ResponseDef{Summary: "done"},
+			},
+		},
+	}
+
+	adapter, err := New(def, nil)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	_, err = adapter.Execute(context.Background(), adapters.Request{
+		Action: "list", Params: map[string]any{"from": "2024-06-15"}, Credential: testCred("test"),
+	})
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+}
+
+func TestCustomFunctions(t *testing.T) {
+	tests := []struct {
+		name string
+		fn   func(...any) (any, error)
+		args []any
+		want any
+	}{
+		{"rfc3339 passthrough", rfc3339Func, []any{"2024-01-01T00:00:00Z"}, "2024-01-01T00:00:00Z"},
+		{"rfc3339 date only", rfc3339Func, []any{"2024-01-01"}, "2024-01-01T00:00:00Z"},
+		{"rfc3339 empty", rfc3339Func, []any{""}, ""},
+		{"endOfDay date", endOfDayFunc, []any{"2024-01-01"}, "2024-01-01T23:59:59Z"},
+		{"endOfDay passthrough", endOfDayFunc, []any{"2024-01-01T12:00:00Z"}, "2024-01-01T12:00:00Z"},
+		{"isAllDay true", isAllDayFunc, []any{"2024-01-01"}, true},
+		{"isAllDay false", isAllDayFunc, []any{"2024-01-01T12:00:00Z"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.fn(tt.args...)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGmailExprFunctions(t *testing.T) {
+	t.Run("findHeader", func(t *testing.T) {
+		headers := []any{
+			map[string]any{"name": "From", "value": "alice@example.com"},
+			map[string]any{"name": "Subject", "value": "Hello"},
+			map[string]any{"name": "Date", "value": "Mon, 1 Jan 2024"},
+		}
+		got, err := findHeaderFunc(headers, "from") // case-insensitive
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != "alice@example.com" {
+			t.Errorf("got %q, want alice@example.com", got)
+		}
+
+		got, _ = findHeaderFunc(headers, "X-Missing")
+		if got != "" {
+			t.Errorf("missing header: got %q, want empty", got)
+		}
+	})
+
+	t.Run("base64Decode", func(t *testing.T) {
+		// URL-safe base64 for "Hello, World!"
+		got, err := base64DecodeFunc("SGVsbG8sIFdvcmxkIQ==")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != "Hello, World!" {
+			t.Errorf("got %q, want %q", got, "Hello, World!")
+		}
+	})
+
+	t.Run("stripHTML", func(t *testing.T) {
+		html := "<html><body><style>body{color:red}</style><p>Hello <b>world</b></p><script>alert(1)</script></body></html>"
+		got, err := stripHTMLFunc(html)
+		if err != nil {
+			t.Fatal(err)
+		}
+		s := got.(string)
+		if !contains(s, "Hello") || !contains(s, "world") {
+			t.Errorf("expected 'Hello' and 'world' in %q", s)
+		}
+		if contains(s, "<") || contains(s, "script") || contains(s, "style") {
+			t.Errorf("HTML not stripped: %q", s)
+		}
+	})
+
+	t.Run("extractMimeBody_plaintext", func(t *testing.T) {
+		// Simulate a Gmail payload with direct text/plain body.
+		payload := map[string]any{
+			"mimeType": "text/plain",
+			"body":     map[string]any{"data": "SGVsbG8gd29ybGQ="}, // "Hello world"
+		}
+		got, err := extractMimeBodyFunc(payload)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != "Hello world" {
+			t.Errorf("got %q, want %q", got, "Hello world")
+		}
+	})
+
+	t.Run("extractMimeBody_multipart_plain", func(t *testing.T) {
+		// Multipart message with text/plain part.
+		payload := map[string]any{
+			"mimeType": "multipart/alternative",
+			"body":     map[string]any{},
+			"parts": []any{
+				map[string]any{
+					"mimeType": "text/html",
+					"body":     map[string]any{"data": "PHA+SFRNTDWVCD4="}, // "<p>HTML</p>"
+				},
+				map[string]any{
+					"mimeType": "text/plain",
+					"body":     map[string]any{"data": "UGxhaW4gdGV4dA=="}, // "Plain text"
+				},
+			},
+		}
+		got, _ := extractMimeBodyFunc(payload)
+		if got != "Plain text" {
+			t.Errorf("got %q, want %q", got, "Plain text")
+		}
+	})
+
+	t.Run("extractMimeBody_html_fallback", func(t *testing.T) {
+		// Only HTML part — should strip HTML.
+		payload := map[string]any{
+			"mimeType": "multipart/alternative",
+			"body":     map[string]any{},
+			"parts": []any{
+				map[string]any{
+					"mimeType": "text/html",
+					"body":     map[string]any{"data": "PHA+SGVsbG88L3A+"}, // "<p>Hello</p>"
+				},
+			},
+		}
+		got, _ := extractMimeBodyFunc(payload)
+		s := got.(string)
+		if !contains(s, "Hello") {
+			t.Errorf("expected 'Hello' in %q", s)
+		}
+		if contains(s, "<p>") {
+			t.Errorf("HTML not stripped: %q", s)
+		}
+	})
+
+	t.Run("extractMimeBody_nested_multipart", func(t *testing.T) {
+		// Nested multipart — text/plain is 2 levels deep.
+		payload := map[string]any{
+			"mimeType": "multipart/mixed",
+			"body":     map[string]any{},
+			"parts": []any{
+				map[string]any{
+					"mimeType": "multipart/alternative",
+					"body":     map[string]any{},
+					"parts": []any{
+						map[string]any{
+							"mimeType": "text/plain",
+							"body":     map[string]any{"data": "TmVzdGVk"}, // "Nested"
+						},
+					},
+				},
+			},
+		}
+		got, _ := extractMimeBodyFunc(payload)
+		if got != "Nested" {
+			t.Errorf("got %q, want %q", got, "Nested")
+		}
+	})
+}
+
+// TestYAMLAdapter_GmailGetMessage tests the full get_message action with a mock Gmail API.
+func TestYAMLAdapter_GmailGetMessage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]any{
+			"id":       "msg123",
+			"threadId": "thread456",
+			"snippet":  "Hey there...",
+			"labelIds": []string{"INBOX", "UNREAD"},
+			"payload": map[string]any{
+				"mimeType": "multipart/alternative",
+				"headers": []map[string]any{
+					{"name": "From", "value": "alice@example.com"},
+					{"name": "To", "value": "bob@example.com"},
+					{"name": "Subject", "value": "Test Subject"},
+					{"name": "Date", "value": "Mon, 1 Jan 2024 12:00:00 +0000"},
+				},
+				"body": map[string]any{},
+				"parts": []map[string]any{
+					{
+						"mimeType": "text/plain",
+						"body":     map[string]any{"data": "SGVsbG8gZnJvbSBHbWFpbA=="}, // "Hello from Gmail"
+					},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	def := yamldef.ServiceDef{
+		Service: yamldef.ServiceInfo{ID: "test.gmail"},
+		Auth:    yamldef.AuthDef{Type: "api_key", Header: "Authorization", HeaderPrefix: "Bearer "},
+		API:     yamldef.APIDef{BaseURL: srv.URL, Type: "rest"},
+		Actions: map[string]yamldef.Action{
+			"get_message": {
+				Method: "GET",
+				Path:   "/users/me/messages/{{.message_id}}",
+				Params: map[string]yamldef.Param{
+					"message_id": {Type: "string", Required: true, Location: "path"},
+					"format":     {Type: "string", Default: "full", Location: "query"},
+				},
+				Response: yamldef.ResponseDef{
+					Fields: []yamldef.FieldDef{
+						{Name: "id"},
+						{Name: "from", Expr: "findHeader(payload.headers, 'From')", Sanitize: true},
+						{Name: "to", Expr: "findHeader(payload.headers, 'To')", Sanitize: true},
+						{Name: "subject", Expr: "findHeader(payload.headers, 'Subject')", Sanitize: true},
+						{Name: "date", Expr: "findHeader(payload.headers, 'Date')"},
+						{Name: "body", Expr: "sanitize(extractMimeBody(payload) != '' ? extractMimeBody(payload) : snippet, 2000)"},
+						{Name: "is_unread", Expr: "'UNREAD' in labelIds"},
+						{Name: "threadId", Rename: "thread_id"},
+					},
+					Summary: "Email from {{.from}}: {{.subject}}",
+				},
+			},
+		},
+	}
+
+	adapter, err := New(def, nil)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+
+	result, err := adapter.Execute(context.Background(), adapters.Request{
+		Action:     "get_message",
+		Params:     map[string]any{"message_id": "msg123"},
+		Credential: testCred("test-token"),
+	})
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	data, ok := result.Data.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map result, got %T", result.Data)
+	}
+
+	checks := map[string]string{
+		"id":        "msg123",
+		"from":      "alice@example.com",
+		"to":        "bob@example.com",
+		"subject":   "Test Subject",
+		"date":      "Mon, 1 Jan 2024 12:00:00 +0000",
+		"body":      "Hello from Gmail",
+		"thread_id": "thread456",
+	}
+	for key, want := range checks {
+		got, _ := data[key].(string)
+		if got != want {
+			t.Errorf("%s: got %q, want %q", key, got, want)
+		}
+	}
+
+	isUnread, ok := data["is_unread"].(bool)
+	if !ok || !isUnread {
+		t.Errorf("is_unread: got %v, want true", data["is_unread"])
+	}
+
+	if !contains(result.Summary, "alice@example.com") {
+		t.Errorf("summary missing sender: %q", result.Summary)
 	}
 }
 

--- a/pkg/adapters/yamlruntime/expreval.go
+++ b/pkg/adapters/yamlruntime/expreval.go
@@ -1,0 +1,407 @@
+package yamlruntime
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/expr-lang/expr"
+	"github.com/expr-lang/expr/vm"
+
+	"github.com/clawvisor/clawvisor/internal/adapters/format"
+	"github.com/clawvisor/clawvisor/pkg/adapters/yamldef"
+)
+
+// compiledAction holds pre-compiled expr programs for a single action.
+type compiledAction struct {
+	fieldExprs      map[int]*vm.Program    // response field index → compiled expr
+	paramTransforms map[string]*vm.Program // param name → compiled transform expr
+	paramDefaults   map[string]*vm.Program // param name → compiled default_expr
+}
+
+// compileOptions are shared expr compilation options.
+var compileOptions = []expr.Option{
+	expr.AllowUndefinedVariables(),
+	expr.Function("sanitize", sanitizeFunc, new(func(string, ...int) string)),
+	expr.Function("rfc3339", rfc3339Func, new(func(string) string)),
+	expr.Function("endOfDay", endOfDayFunc, new(func(string) string)),
+	expr.Function("isAllDay", isAllDayFunc, new(func(string) bool)),
+	expr.Function("now", nowFunc, new(func() string)),
+	expr.Function("replace", replaceFunc, new(func(string, string, string) string)),
+	expr.Function("emailList", emailListFunc),
+	expr.Function("findHeader", findHeaderFunc),
+	expr.Function("extractMimeBody", extractMimeBodyFunc),
+	expr.Function("base64Decode", base64DecodeFunc),
+	expr.Function("stripHTML", stripHTMLFunc),
+}
+
+// compileAction compiles all expr expressions in an action definition.
+// Returns nil (not an error) if the action has no expressions.
+func compileAction(action yamldef.Action) (*compiledAction, error) {
+	ca := &compiledAction{
+		fieldExprs:      map[int]*vm.Program{},
+		paramTransforms: map[string]*vm.Program{},
+		paramDefaults:   map[string]*vm.Program{},
+	}
+
+	// Compile response field expressions.
+	for i, f := range action.Response.Fields {
+		if f.Expr == "" {
+			continue
+		}
+		prog, err := expr.Compile(f.Expr, compileOptions...)
+		if err != nil {
+			return nil, fmt.Errorf("field %q expr: %w", f.Name, err)
+		}
+		ca.fieldExprs[i] = prog
+	}
+
+	// Compile param transforms and dynamic defaults.
+	for name, p := range action.Params {
+		if p.Transform != "" {
+			prog, err := expr.Compile(p.Transform, compileOptions...)
+			if err != nil {
+				return nil, fmt.Errorf("param %q transform: %w", name, err)
+			}
+			ca.paramTransforms[name] = prog
+		}
+		if p.DefaultExpr != "" {
+			prog, err := expr.Compile(p.DefaultExpr, compileOptions...)
+			if err != nil {
+				return nil, fmt.Errorf("param %q default_expr: %w", name, err)
+			}
+			ca.paramDefaults[name] = prog
+		}
+	}
+
+	if len(ca.fieldExprs) == 0 && len(ca.paramTransforms) == 0 && len(ca.paramDefaults) == 0 {
+		return nil, nil // no expressions to compile
+	}
+
+	return ca, nil
+}
+
+// evalExpr runs a compiled program against a data map.
+func evalExpr(prog *vm.Program, data map[string]any) (any, error) {
+	return expr.Run(prog, data)
+}
+
+// ── Custom functions ────────────────────────────────────────────────────────
+
+func sanitizeFunc(params ...any) (any, error) {
+	if len(params) == 0 {
+		return "", nil
+	}
+	s, ok := params[0].(string)
+	if !ok {
+		return fmt.Sprintf("%v", params[0]), nil
+	}
+	maxLen := format.MaxFieldLen
+	if len(params) > 1 {
+		if n, ok := toAnyInt(params[1]); ok {
+			maxLen = n
+		}
+	}
+	return format.SanitizeText(s, maxLen), nil
+}
+
+func rfc3339Func(params ...any) (any, error) {
+	if len(params) == 0 {
+		return "", nil
+	}
+	s, ok := params[0].(string)
+	if !ok {
+		return "", fmt.Errorf("rfc3339: expected string, got %T", params[0])
+	}
+	if s == "" {
+		return "", nil
+	}
+	// Already RFC3339-ish (has time component).
+	if len(s) > 10 {
+		return s, nil
+	}
+	// Plain date "YYYY-MM-DD" → start of day UTC.
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		return s, nil // pass through; API will reject with a clear error
+	}
+	return t.UTC().Format(time.RFC3339), nil
+}
+
+func endOfDayFunc(params ...any) (any, error) {
+	if len(params) == 0 {
+		return "", nil
+	}
+	s, ok := params[0].(string)
+	if !ok {
+		return "", fmt.Errorf("endOfDay: expected string, got %T", params[0])
+	}
+	if s == "" {
+		return "", nil
+	}
+	if len(s) > 10 {
+		return s, nil
+	}
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		return s, nil
+	}
+	return t.Add(24*time.Hour - time.Second).UTC().Format(time.RFC3339), nil
+}
+
+func isAllDayFunc(params ...any) (any, error) {
+	if len(params) == 0 {
+		return false, nil
+	}
+	s, ok := params[0].(string)
+	if !ok {
+		return false, nil
+	}
+	return len(s) == 10, nil
+}
+
+func nowFunc(params ...any) (any, error) {
+	return time.Now().UTC().Format(time.RFC3339), nil
+}
+
+// emailList transforms a list of strings into [{email: s}, ...].
+// Used for Google Calendar attendees.
+func emailListFunc(params ...any) (any, error) {
+	if len(params) == 0 {
+		return nil, nil
+	}
+	list, ok := params[0].([]any)
+	if !ok {
+		return nil, nil
+	}
+	result := make([]any, 0, len(list))
+	for _, item := range list {
+		if s, ok := item.(string); ok {
+			result = append(result, map[string]any{"email": s})
+		}
+	}
+	return result, nil
+}
+
+func replaceFunc(params ...any) (any, error) {
+	if len(params) < 3 {
+		return "", fmt.Errorf("replace: requires 3 arguments (s, old, new)")
+	}
+	s, _ := params[0].(string)
+	old, _ := params[1].(string)
+	new_, _ := params[2].(string)
+	return strings.ReplaceAll(s, old, new_), nil
+}
+
+// findHeader searches a list of {name, value} header maps for the first
+// matching header (case-insensitive) and returns its value.
+// Usage: findHeader(payload.headers, "From")
+func findHeaderFunc(params ...any) (any, error) {
+	if len(params) < 2 {
+		return "", fmt.Errorf("findHeader: requires 2 arguments (headers, name)")
+	}
+	headers, ok := params[0].([]any)
+	if !ok {
+		return "", nil
+	}
+	target, _ := params[1].(string)
+	target = strings.ToLower(target)
+	for _, h := range headers {
+		m, ok := h.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, _ := m["name"].(string)
+		if strings.ToLower(name) == target {
+			val, _ := m["value"].(string)
+			return val, nil
+		}
+	}
+	return "", nil
+}
+
+// extractMimeBody walks a Gmail message payload (as map[string]any) to extract
+// the text body. Prefers text/plain, falls back to text/html with HTML stripping.
+// Usage: extractMimeBody(payload)
+func extractMimeBodyFunc(params ...any) (any, error) {
+	if len(params) == 0 {
+		return "", nil
+	}
+	payload, ok := params[0].(map[string]any)
+	if !ok {
+		return "", nil
+	}
+	return mimeWalk(payload), nil
+}
+
+// mimeWalk recursively walks a Gmail payload map to find a text body.
+func mimeWalk(payload map[string]any) string {
+	mimeType, _ := payload["mimeType"].(string)
+	bodyData := getBodyData(payload)
+
+	// Direct text/plain body.
+	if mimeType == "text/plain" && bodyData != "" {
+		return decodeBase64URL(bodyData)
+	}
+
+	// Search parts for text/plain.
+	parts := getPartsSlice(payload)
+	for _, part := range parts {
+		pm, ok := part.(map[string]any)
+		if !ok {
+			continue
+		}
+		partMime, _ := pm["mimeType"].(string)
+		partBody := getBodyData(pm)
+		if partMime == "text/plain" && partBody != "" {
+			return decodeBase64URL(partBody)
+		}
+		// Nested multipart (one level deeper).
+		subParts := getPartsSlice(pm)
+		for _, sub := range subParts {
+			sm, ok := sub.(map[string]any)
+			if !ok {
+				continue
+			}
+			subMime, _ := sm["mimeType"].(string)
+			subBody := getBodyData(sm)
+			if subMime == "text/plain" && subBody != "" {
+				return decodeBase64URL(subBody)
+			}
+		}
+	}
+
+	// Fall back to text/html with HTML stripping.
+	for _, part := range parts {
+		pm, ok := part.(map[string]any)
+		if !ok {
+			continue
+		}
+		partMime, _ := pm["mimeType"].(string)
+		partBody := getBodyData(pm)
+		if partMime == "text/html" && partBody != "" {
+			return doStripHTML(decodeBase64URL(partBody))
+		}
+	}
+	if mimeType == "text/html" && bodyData != "" {
+		return doStripHTML(decodeBase64URL(bodyData))
+	}
+
+	return ""
+}
+
+func getBodyData(m map[string]any) string {
+	body, ok := m["body"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	data, _ := body["data"].(string)
+	return data
+}
+
+func getPartsSlice(m map[string]any) []any {
+	parts, _ := m["parts"].([]any)
+	return parts
+}
+
+// base64Decode decodes a URL-safe base64 string (as used by Gmail API).
+// Usage: base64Decode(body.data)
+func base64DecodeFunc(params ...any) (any, error) {
+	if len(params) == 0 {
+		return "", nil
+	}
+	s, ok := params[0].(string)
+	if !ok {
+		return "", nil
+	}
+	return decodeBase64URL(s), nil
+}
+
+// decodeBase64URL decodes a URL-safe base64 string, falling back to standard encoding.
+func decodeBase64URL(s string) string {
+	b, err := base64.URLEncoding.DecodeString(s)
+	if err != nil {
+		b, err = base64.StdEncoding.DecodeString(s)
+		if err != nil {
+			return ""
+		}
+	}
+	return string(b)
+}
+
+// stripHTML removes HTML tags, style/script blocks, and decodes common entities.
+// Usage: stripHTML(htmlString)
+func stripHTMLFunc(params ...any) (any, error) {
+	if len(params) == 0 {
+		return "", nil
+	}
+	s, ok := params[0].(string)
+	if !ok {
+		return "", nil
+	}
+	return doStripHTML(s), nil
+}
+
+// doStripHTML is the implementation shared by stripHTMLFunc and extractMimeBody fallback.
+func doStripHTML(s string) string {
+	// Remove <style>...</style> and <script>...</script> blocks.
+	for _, tag := range []string{"style", "script"} {
+		for {
+			open := strings.Index(strings.ToLower(s), "<"+tag)
+			if open < 0 {
+				break
+			}
+			close := strings.Index(strings.ToLower(s[open:]), "</"+tag+">")
+			if close < 0 {
+				s = s[:open]
+				break
+			}
+			s = s[:open] + s[open+close+len("</"+tag+">"):]
+		}
+	}
+	// Strip remaining HTML tags.
+	var out strings.Builder
+	inTag := false
+	for _, r := range s {
+		switch {
+		case r == '<':
+			inTag = true
+		case r == '>':
+			inTag = false
+			out.WriteRune(' ')
+		case !inTag:
+			out.WriteRune(r)
+		}
+	}
+	// Decode common HTML entities.
+	result := out.String()
+	result = strings.ReplaceAll(result, "&amp;", "&")
+	result = strings.ReplaceAll(result, "&lt;", "<")
+	result = strings.ReplaceAll(result, "&gt;", ">")
+	result = strings.ReplaceAll(result, "&quot;", `"`)
+	result = strings.ReplaceAll(result, "&#39;", "'")
+	result = strings.ReplaceAll(result, "&nbsp;", " ")
+	// Collapse whitespace/empty lines.
+	lines := strings.Split(result, "\n")
+	var kept []string
+	for _, l := range lines {
+		l = strings.TrimSpace(l)
+		if l != "" {
+			kept = append(kept, l)
+		}
+	}
+	return strings.Join(kept, "\n")
+}
+
+func toAnyInt(v any) (int, bool) {
+	switch n := v.(type) {
+	case int:
+		return n, true
+	case int64:
+		return int(n), true
+	case float64:
+		return int(n), true
+	}
+	return 0, false
+}

--- a/pkg/adapters/yamlruntime/graphql.go
+++ b/pkg/adapters/yamlruntime/graphql.go
@@ -20,8 +20,8 @@ func executeGraphQL(ctx context.Context, client *http.Client, baseURL string, ac
 	inputObj := map[string]any{}
 
 	for name, paramDef := range action.Params {
-		val, ok := resolveParam(params, name, paramDef)
-		if !ok {
+		val, _ := resolveParamWithExpr(params, name, paramDef, nil)
+		if val == nil {
 			continue
 		}
 
@@ -84,7 +84,7 @@ func executeGraphQL(ctx context.Context, client *http.Client, baseURL string, ac
 		return nil, fmt.Errorf("parsing GraphQL response: %w", err)
 	}
 
-	data := extractData(raw, action.Response)
+	data := extractData(raw, action.Response, nil)
 	summary := renderSummary(action.Response.Summary, data)
 
 	return &adapters.Result{

--- a/pkg/adapters/yamlruntime/rest.go
+++ b/pkg/adapters/yamlruntime/rest.go
@@ -16,7 +16,7 @@ import (
 )
 
 // executeREST executes a REST action as defined in the YAML spec.
-func executeREST(ctx context.Context, client *http.Client, baseURL string, action yamldef.Action, params map[string]any, credFields map[string]string) (*adapters.Result, error) {
+func executeREST(ctx context.Context, client *http.Client, baseURL string, action yamldef.Action, params map[string]any, credFields map[string]string, ca *compiledAction) (*adapters.Result, error) {
 	// Build the URL path with parameter interpolation.
 	path := interpolatePath(action.Path, params, credFields)
 	fullURL := strings.TrimRight(baseURL, "/") + "/" + strings.TrimLeft(path, "/")
@@ -26,15 +26,24 @@ func executeREST(ctx context.Context, client *http.Client, baseURL string, actio
 	bodyParams := map[string]any{}
 
 	for name, paramDef := range action.Params {
-		val, ok := resolveParam(params, name, paramDef)
-		if !ok {
+		val, provided := resolveParamWithExpr(params, name, paramDef, ca)
+		if val == nil {
 			continue
+		}
+		// In sparse body mode, skip unprovided body params.
+		if !provided && action.BodyMode == "sparse" && paramDef.Location == "body" {
+			continue
+		}
+
+		apiKey := name
+		if paramDef.MapTo != "" {
+			apiKey = paramDef.MapTo
 		}
 		switch paramDef.Location {
 		case "query":
-			queryParams.Set(name, fmt.Sprintf("%v", val))
+			queryParams.Set(apiKey, fmt.Sprintf("%v", val))
 		case "body":
-			bodyParams[name] = val
+			bodyParams[apiKey] = val
 		case "path":
 			// Already handled by interpolatePath.
 		}
@@ -105,7 +114,7 @@ func executeREST(ctx context.Context, client *http.Client, baseURL string, actio
 	}
 
 	// Extract data from the response.
-	data := extractData(raw, action.Response)
+	data := extractData(raw, action.Response, ca)
 	summary := renderSummary(action.Response.Summary, data)
 
 	return &adapters.Result{
@@ -126,17 +135,32 @@ func interpolatePath(path string, params map[string]any, credFields map[string]s
 	return result
 }
 
-// resolveParam extracts a parameter value from the input, applying defaults and validation.
-func resolveParam(params map[string]any, name string, def yamldef.Param) (any, bool) {
+// resolveParamWithExpr extracts a parameter value from the input, applying
+// defaults (static or expr), int constraints, and transform expressions.
+// Returns (value, provided) where provided indicates the caller explicitly
+// supplied this param (used for body_mode: sparse).
+func resolveParamWithExpr(params map[string]any, name string, def yamldef.Param, ca *compiledAction) (any, bool) {
 	val, ok := params[name]
+	provided := ok && val != nil
+
 	if !ok || val == nil {
-		if def.Default != nil {
-			return def.Default, true
+		// Try dynamic default first, then static.
+		if ca != nil {
+			if prog, has := ca.paramDefaults[name]; has {
+				result, err := evalExpr(prog, params)
+				if err == nil && result != nil {
+					val = result
+					ok = true
+				}
+			}
 		}
-		if def.Required {
-			return nil, false // caller will get an error from missing required check
+		if !ok && def.Default != nil {
+			val = def.Default
+			ok = true
 		}
-		return nil, false
+		if !ok {
+			return nil, false
+		}
 	}
 
 	// Apply int constraints.
@@ -148,10 +172,25 @@ func resolveParam(params map[string]any, name string, def yamldef.Param) (any, b
 		if def.Max != nil && intVal > *def.Max {
 			intVal = *def.Max
 		}
-		return intVal, true
+		val = intVal
 	}
 
-	return val, true
+	// Apply transform expression.
+	if ca != nil {
+		if prog, has := ca.paramTransforms[name]; has {
+			env := map[string]any{}
+			for k, v := range params {
+				env[k] = v
+			}
+			env[name] = val // ensure the (possibly defaulted) value is available
+			result, err := evalExpr(prog, env)
+			if err == nil {
+				val = result
+			}
+		}
+	}
+
+	return val, provided
 }
 
 // checkResponseError checks for API-level errors in the response body.
@@ -177,7 +216,7 @@ func checkResponseError(raw any, check *yamldef.ErrorCheckDef) error {
 }
 
 // extractData navigates to the data_path in the response and extracts fields.
-func extractData(raw any, respDef yamldef.ResponseDef) any {
+func extractData(raw any, respDef yamldef.ResponseDef, ca *compiledAction) any {
 	if raw == nil {
 		return nil
 	}
@@ -204,7 +243,7 @@ func extractData(raw any, respDef yamldef.ResponseDef) any {
 				break
 			}
 			if obj, ok := item.(map[string]any); ok {
-				items = append(items, extractFields(obj, respDef.Fields))
+				items = append(items, extractFields(obj, respDef.Fields, ca))
 			}
 		}
 		return items
@@ -212,26 +251,58 @@ func extractData(raw any, respDef yamldef.ResponseDef) any {
 
 	// Handle single object.
 	if obj, ok := data.(map[string]any); ok {
-		return extractFields(obj, respDef.Fields)
+		return extractFields(obj, respDef.Fields, ca)
 	}
 
 	return data
 }
 
 // extractFields extracts and transforms the specified fields from a JSON object.
-func extractFields(obj map[string]any, fields []yamldef.FieldDef) map[string]any {
+func extractFields(obj map[string]any, fields []yamldef.FieldDef, ca *compiledAction) map[string]any {
 	result := make(map[string]any, len(fields))
-	for _, f := range fields {
+	for i, f := range fields {
 		outputKey := f.Name
 		if f.Rename != "" {
 			outputKey = f.Rename
 		}
 
 		var val any
+
+		// Expr takes precedence over path/name lookup.
+		if ca != nil {
+			if prog, ok := ca.fieldExprs[i]; ok {
+				v, err := evalExpr(prog, obj)
+				if err == nil {
+					val = v
+				}
+				if val == nil && f.Optional {
+					continue // omit optional nil fields
+				}
+				if val == nil && f.Nullable {
+					result[outputKey] = ""
+					continue
+				}
+				if f.Sanitize {
+					if s, ok := val.(string); ok {
+						val = format.SanitizeText(s, format.MaxFieldLen)
+					}
+				}
+				if f.Transform != "" {
+					val = applyTransform(f.Transform, val)
+				}
+				result[outputKey] = val
+				continue
+			}
+		}
+
 		if f.Path != "" {
 			val, _ = navigatePath(obj, f.Path)
 		} else {
 			val = obj[f.Name]
+		}
+
+		if val == nil && f.Optional {
+			continue
 		}
 
 		if val == nil && f.Nullable {

--- a/pkg/clawvisor/defaults.go
+++ b/pkg/clawvisor/defaults.go
@@ -18,8 +18,6 @@ import (
 
 	"github.com/clawvisor/clawvisor/internal/adapters/definitions"
 	imessageadapter "github.com/clawvisor/clawvisor/internal/adapters/apple/imessage"
-	calendaradapter "github.com/clawvisor/clawvisor/internal/adapters/google/calendar"
-	contactsadapter "github.com/clawvisor/clawvisor/internal/adapters/google/contacts"
 	driveadapter "github.com/clawvisor/clawvisor/internal/adapters/google/drive"
 	gmailadapter "github.com/clawvisor/clawvisor/internal/adapters/google/gmail"
 	"github.com/clawvisor/clawvisor/internal/auth"
@@ -139,26 +137,19 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 	// Reads credentials lazily — supports adding OAuth creds without restart.
 	oauthProvider := adapters.NewVaultOAuthProvider(v, googleRedirectURL)
 
-	// Build Go action overrides for Google services (complex MIME/multipart logic).
-	// These are always registered; the provider returns empty creds when not configured,
-	// causing OAuthConfig() to return nil (service shows as "needs_setup").
+	// Build Go action overrides for Google services that need complex logic
+	// (MIME encoding, multipart uploads, dual API calls) beyond what YAML
+	// expressions can handle. Calendar, Contacts, Drive search_files, and
+	// Gmail get_message are now fully YAML-driven with expr-lang transforms.
 	goOverrides := map[string]yamlruntime.ActionFunc{}
 
 	gmail := gmailadapter.New(oauthProvider)
-	for _, action := range gmail.SupportedActions() {
+	for _, action := range []string{"list_messages", "send_message", "create_draft"} {
 		goOverrides["google.gmail:"+action] = gmail.Execute
 	}
-	cal := calendaradapter.New(oauthProvider)
-	for _, action := range []string{"list_events", "create_event", "update_event"} {
-		goOverrides["google.calendar:"+action] = cal.Execute
-	}
 	drive := driveadapter.New(oauthProvider)
-	for _, action := range []string{"get_file", "create_file", "update_file", "search_files"} {
+	for _, action := range []string{"get_file", "create_file", "update_file"} {
 		goOverrides["google.drive:"+action] = drive.Execute
-	}
-	contacts := contactsadapter.New(oauthProvider)
-	for _, action := range contacts.SupportedActions() {
-		goOverrides["google.contacts:"+action] = contacts.Execute
 	}
 
 	// Load YAML adapter definitions from embedded FS + user-local directory.


### PR DESCRIPTION
## Summary

- Integrates [expr-lang/expr](https://github.com/expr-lang/expr) v1.17.8 as the expression evaluation engine for YAML adapter definitions
- Expressions are compiled at YAML load time and evaluated per-request — zero runtime compilation overhead
- Eliminates **8 Go overrides** across Google services, reducing overrides from 13 to 6

## New YAML capabilities

- **Field expressions:** `expr: "start.dateTime ?? start.date ?? ''"` — optional chaining + nil coalescing for response field extraction
- **Parameter transforms:** `transform: "rfc3339(from)"` — expr applied to resolved param values before sending to the API
- **Dynamic defaults:** `default_expr: "now()"` — runtime-computed defaults
- **Parameter renaming:** `map_to: timeMin` — decouple YAML param names from API-side names
- **Sparse body mode:** `body_mode: sparse` — only include explicitly-provided params in request body (PATCH semantics)

## Custom expr functions

| Function | Purpose |
|----------|---------|
| `sanitize(s, maxLen?)` | Truncate + clean text |
| `rfc3339(s)` | Ensure RFC3339 format (converts `YYYY-MM-DD` to full timestamp) |
| `endOfDay(s)` | Convert date to end-of-day timestamp |
| `isAllDay(s)` | Check if date string is date-only (10 chars) |
| `now()` | Current time as RFC3339 |
| `replace(s, old, new)` | String replacement |
| `emailList(arr)` | Transform `["a@b.com"]` → `[{"email": "a@b.com"}]` |
| `findHeader(headers, name)` | Case-insensitive header lookup in `[{name, value}]` arrays |
| `extractMimeBody(payload)` | Walk Gmail MIME tree (prefers text/plain, falls back to text/html with stripping) |
| `base64Decode(s)` | URL-safe base64 decode |
| `stripHTML(s)` | Remove script/style blocks, strip tags, decode entities |

## Overrides eliminated

- **Google Contacts:** `list_contacts`, `get_contact`, `search_contacts` (3)
- **Google Calendar:** `list_events`, `create_event`, `update_event` (3)
- **Google Drive:** `search_files` (1)
- **Gmail:** `get_message` (1) — MIME body extraction via expr functions

## Remaining Go overrides (6)

- Gmail `list_messages` (N+1 metadata fetch pattern), `send_message` / `create_draft` (MIME encoding)
- Drive `get_file` / `create_file` / `update_file` (multipart upload, dual API calls)

## Test plan

- [x] Unit tests for all 11 custom expr functions
- [x] Integration test for Gmail `get_message` with mock server (header extraction, MIME body, unread detection)
- [x] Existing tests for field extraction, param transforms, sparse body mode
- [x] Full `go test ./...` passes
- [x] `go build ./...` passes
- [ ] Manual: test Calendar create/update event with date transforms
- [ ] Manual: test Gmail get_message with real multipart emails

🤖 Generated with [Claude Code](https://claude.com/claude-code)