### PR TITLE
fix: correct restart command in update message

### DIFF
--- a/cmd/clawvisor/cmd_update.go
+++ b/cmd/clawvisor/cmd_update.go
@@ -117,7 +117,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 
 	// Check if daemon is running and remind user to restart.
 	if s, err := daemon.CheckStatus(); err == nil && s.Running {
-		fmt.Println("  Daemon is running — restart it with: clawvisor daemon restart")
+		fmt.Println("  Daemon is running — restart it with: clawvisor restart")
 	}
 
 	return nil


### PR DESCRIPTION
The post-update hint told users to run `clawvisor daemon restart`, but the correct command is `clawvisor restart`. This fixes the message in `cmd/clawvisor/cmd_update.go`.