### PR TITLE
fix: harden IsLocal, rate-limit keying, callback init, and HMAC replay

### DIFF
--- a/internal/api/handlers/connections.go
+++ b/internal/api/handlers/connections.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"sync"
 	"sync/atomic"
@@ -209,7 +210,10 @@ func (h *ConnectionsHandler) PollStatus(w http.ResponseWriter, r *http.Request) 
 	}
 
 	// Per-IP concurrent poll limit (max 3).
-	ip := r.RemoteAddr
+	ip, _, _ := net.SplitHostPort(r.RemoteAddr)
+	if ip == "" {
+		ip = r.RemoteAddr
+	}
 	h.ipPollsMu.Lock()
 	if h.ipPolls[ip] >= 3 {
 		h.ipPollsMu.Unlock()

--- a/internal/api/middleware/device.go
+++ b/internal/api/middleware/device.go
@@ -12,10 +12,30 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/clawvisor/clawvisor/pkg/store"
 )
+
+var replayCache sync.Map
+
+func init() {
+	go evictExpiredReplays()
+}
+
+func evictExpiredReplays() {
+	for {
+		time.Sleep(time.Minute)
+		cutoff := time.Now().Add(-2 * deviceTimestampSkew)
+		replayCache.Range(func(key, value any) bool {
+			if value.(time.Time).Before(cutoff) {
+				replayCache.Delete(key)
+			}
+			return true
+		})
+	}
+}
 
 const (
 	// DeviceContextKey is the context key for the authenticated paired device.
@@ -62,6 +82,13 @@ func RequireDevice(st store.Store) func(http.Handler) http.Handler {
 			diff := time.Since(time.Unix(tsUnix, 0))
 			if math.Abs(diff.Seconds()) > deviceTimestampSkew.Seconds() {
 				http.Error(w, `{"error":"timestamp out of range","code":"UNAUTHORIZED"}`, http.StatusUnauthorized)
+				return
+			}
+
+			// Replay protection: reject duplicate (device, timestamp, hmac) tuples.
+			cacheKey := deviceID + ":" + tsStr + ":" + providedHMAC
+			if _, loaded := replayCache.LoadOrStore(cacheKey, time.Now()); loaded {
+				http.Error(w, `{"error":"replayed request","code":"UNAUTHORIZED"}`, http.StatusUnauthorized)
 				return
 			}
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -10,8 +10,9 @@ import (
 	"archive/zip"
 	"io/fs"
 	"log/slog"
-	"strings"
+	"net"
 	"net/http"
+	"strings"
 	"os"
 	"time"
 
@@ -297,7 +298,11 @@ func (s *Server) routes() http.Handler {
 	authRL := newKeyedLimiterFromBucket(rlCfg.Auth)
 
 	ipKeyFn := func(r *http.Request) string {
-		return r.RemoteAddr
+		host, _, err := net.SplitHostPort(r.RemoteAddr)
+		if err != nil {
+			return r.RemoteAddr
+		}
+		return host
 	}
 	agentKeyFn := func(r *http.Request) string {
 		if a := middleware.AgentFromContext(r.Context()); a != nil {

--- a/internal/server/run.go
+++ b/internal/server/run.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/clawvisor/clawvisor/internal/auth"
 	"github.com/clawvisor/clawvisor/internal/browser"
+	"github.com/clawvisor/clawvisor/internal/callback"
 	"github.com/clawvisor/clawvisor/internal/telemetry"
 	"github.com/clawvisor/clawvisor/pkg/clawvisor"
 	"github.com/clawvisor/clawvisor/pkg/config"
@@ -116,6 +117,13 @@ func Run(logger *slog.Logger, ropts RunOptions) error {
 	if err != nil {
 		return err
 	}
+
+	// ── Callback security ──────────────────────────────────────────────────
+	callback.Init(
+		opts.Config.Callback.AllowPrivateCIDRs,
+		!opts.Config.Server.IsLocal(), // require HTTPS in non-local mode
+		!opts.Config.Server.IsLocal(), // block loopback in non-local mode
+	)
 
 	// ── Banner ─────────────────────────────────────────────────────────────
 	if opts.Config.Server.IsLocal() {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -486,9 +486,11 @@ func (a AuthConfig) RefreshTokenDuration() (time.Duration, error) {
 	return time.ParseDuration(a.RefreshTokenTTL)
 }
 
-// IsLocal returns true when the server is bound to a loopback or wildcard address.
+// IsLocal returns true when the server is bound to a loopback address.
+// Note: empty host and "0.0.0.0" bind all interfaces (including public ones)
+// and are intentionally excluded.
 func (s ServerConfig) IsLocal() bool {
-	return s.Host == "" || s.Host == "localhost" || s.Host == "127.0.0.1" || s.Host == "0.0.0.0"
+	return s.Host == "localhost" || s.Host == "127.0.0.1"
 }
 
 // Addr returns the server listen address.


### PR DESCRIPTION
## Summary
- **IsLocal()**: Remove `0.0.0.0` and empty host from the local check — both bind all interfaces and should not grant local-mode security relaxations.
- **Rate-limit keying**: Strip the port from `RemoteAddr` in the IP-based rate limiter and per-IP poll tracker so connections from the same IP share one bucket.
- **callback.Init**: Call it at server startup so non-local deployments enforce HTTPS callbacks and block loopback targets.
- **DeviceHMAC replay protection**: Add a `sync.Map` replay cache that rejects duplicate `(device, timestamp, hmac)` tuples within the skew window, with background eviction at `2× deviceTimestampSkew` to cover future-dated timestamps.

## Test plan
- [x] `go vet` and `go test` pass on all changed packages
- [ ] Verify server with `host: ""` no longer gets magic-link auth or relaxed CORS
- [ ] Confirm rate limiting correctly buckets by IP regardless of ephemeral port
- [ ] Test that replayed DeviceHMAC requests return 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)