### PR TITLE
fix: persist skill and env vars globally for session restarts

### DIFF
--- a/docs/INTEGRATE_CLAUDE_CODE.md
+++ b/docs/INTEGRATE_CLAUDE_CODE.md
@@ -14,9 +14,8 @@ When setup is complete, the user should have:
 
 1. Clawvisor running (locally or in the cloud)
 2. An agent token created for Claude Code
-3. The Clawvisor skill installed at `.claude/skills/clawvisor/SKILL.md` in
-   their project
-4. Environment variables (`CLAWVISOR_URL`, `CLAWVISOR_AGENT_TOKEN`) configured
+3. The Clawvisor skill installed globally at `~/.claude/skills/clawvisor/SKILL.md`
+4. Environment variables (`CLAWVISOR_URL`, `CLAWVISOR_AGENT_TOKEN`) in `~/.claude/settings.json`
 5. Claude Code able to make gateway requests via the skill
 
 ---
@@ -66,74 +65,29 @@ Save the `token` value from the JSON output — it is shown only once.
 
 ---
 
-## Step 3: Locate the Clawvisor skill source
+## Step 3: Install the skill globally
 
-The skill file is at `skills/clawvisor/SKILL.md` in the Clawvisor repository.
-It needs to be copied to the user's project with the OpenClaw-specific YAML
-frontmatter stripped.
-
-First, check if the Clawvisor repository is accessible locally:
+The skill is installed globally to `~/.claude/skills/clawvisor/SKILL.md` during
+`clawvisor setup` (or `clawvisor integrate`). Verify it's present:
 
 ```bash
-ls "$CLAWVISOR_REPO/skills/clawvisor/SKILL.md" 2>/dev/null
+ls ~/.claude/skills/clawvisor/SKILL.md
 ```
 
-If not, search common locations:
+If missing, re-run `clawvisor integrate` or copy it manually from the
+Clawvisor repository:
 
 ```bash
-ls -d ~/code/clawvisor/skills/clawvisor/SKILL.md 2>/dev/null \
-  || ls -d ~/clawvisor/skills/clawvisor/SKILL.md 2>/dev/null \
-  || ls -d ~/projects/clawvisor/skills/clawvisor/SKILL.md 2>/dev/null
+mkdir -p ~/.claude/skills/clawvisor
+cp "$CLAWVISOR_REPO/skills/clawvisor/SKILL.md" ~/.claude/skills/clawvisor/SKILL.md
 ```
 
-Also check for alternate naming (`clawvisor-public`, `clawvisor-oss`).
-
-If found locally, use that path. If not, you'll fetch it from GitHub in the
-next step.
+The YAML frontmatter must be preserved — Claude Code uses it to recognize the
+skill name, description, and required environment variables.
 
 ---
 
-## Step 4: Install the skill
-
-Determine the user's project root — this is where `.claude/` lives (or will
-be created). If ambiguous, ask the user.
-
-```bash
-mkdir -p "$PROJECT_ROOT/.claude/skills/clawvisor"
-```
-
-**If the Clawvisor repo is available locally:**
-
-Strip the YAML frontmatter (the `---` delimited block at the top, which
-contains OpenClaw-specific metadata) and copy:
-
-```bash
-awk 'BEGIN{s=0} /^---$/{s++;next} s>=2' "$CLAWVISOR_REPO/skills/clawvisor/SKILL.md" \
-  > "$PROJECT_ROOT/.claude/skills/clawvisor/SKILL.md"
-```
-
-**If the repo is not available locally:**
-
-Fetch from GitHub and strip frontmatter:
-
-```bash
-curl -sL https://raw.githubusercontent.com/clawvisor/clawvisor/main/skills/clawvisor/SKILL.md \
-  | awk 'BEGIN{s=0} /^---$/{s++;next} s>=2' \
-  > "$PROJECT_ROOT/.claude/skills/clawvisor/SKILL.md"
-```
-
-Verify the skill was installed:
-
-```bash
-head -5 "$PROJECT_ROOT/.claude/skills/clawvisor/SKILL.md"
-```
-
-The first line should be `# Clawvisor Skill` (not `---`). If it starts with
-`---`, the frontmatter was not stripped — re-run the sed command.
-
----
-
-## Step 5: Set environment variables
+## Step 4: Set environment variables
 
 Claude Code needs two environment variables:
 
@@ -142,40 +96,21 @@ Claude Code needs two environment variables:
 | `CLAWVISOR_URL` | The Clawvisor instance URL (e.g. `http://localhost:25297`) |
 | `CLAWVISOR_AGENT_TOKEN` | The agent bearer token from Step 2 |
 
-Ask the user how they'd like to configure them:
+### Option A: `~/.claude/settings.json` (recommended)
 
-### Option A: Project-level `.claude/.env` (recommended)
+Add both variables to the `env` object in `~/.claude/settings.json`. This
+persists across all sessions and all projects automatically:
 
-Write the variables to `.claude/.env` in the project root. This keeps them
-scoped to the project and out of the user's global shell.
-
-First, strip any previous Clawvisor-related lines to make this idempotent:
-
-```bash
-grep -v '^CLAWVISOR_' "$PROJECT_ROOT/.claude/.env" > /tmp/claude-env.tmp 2>/dev/null || true
-mv /tmp/claude-env.tmp "$PROJECT_ROOT/.claude/.env" 2>/dev/null || true
+```json
+{
+  "env": {
+    "CLAWVISOR_URL": "http://localhost:25297",
+    "CLAWVISOR_AGENT_TOKEN": "<token from Step 2>"
+  }
+}
 ```
 
-Then append:
-
-```bash
-cat >> "$PROJECT_ROOT/.claude/.env" <<EOF
-CLAWVISOR_URL=$CLAWVISOR_URL
-CLAWVISOR_AGENT_TOKEN=<token from Step 2>
-EOF
-```
-
-Check if `.claude/.env` is in `.gitignore`. If not, warn the user:
-
-```bash
-grep -q '\.claude/\.env' "$PROJECT_ROOT/.gitignore" 2>/dev/null || echo "WARNING: .claude/.env is not in .gitignore — the agent token may be committed"
-```
-
-If not ignored, offer to add it:
-
-```bash
-echo '.claude/.env' >> "$PROJECT_ROOT/.gitignore"
-```
+Merge with any existing keys in the file — do not overwrite other settings.
 
 ### Option B: Shell profile (all projects)
 
@@ -188,7 +123,7 @@ export CLAWVISOR_AGENT_TOKEN=<token from Step 2>
 
 ---
 
-## Step 6: Verify
+## Step 5: Verify
 
 Confirm Claude Code can reach Clawvisor by testing the agent token:
 
@@ -203,7 +138,7 @@ server isn't running.
 
 ---
 
-## Step 7: Summary
+## Step 6: Summary
 
 Present the user with:
 
@@ -212,8 +147,8 @@ Clawvisor + Claude Code Setup Complete
 ────────────────────────────────────────
 Clawvisor:  <CLAWVISOR_URL>
 Agent:      claude-code
-Skill:      <PROJECT_ROOT>/.claude/skills/clawvisor/SKILL.md
-Env:        <where vars were written>
+Skill:      ~/.claude/skills/clawvisor/SKILL.md
+Env:        ~/.claude/settings.json
 ```
 
 Explain how it works:

--- a/internal/daemon/claude_code.go
+++ b/internal/daemon/claude_code.go
@@ -544,6 +544,7 @@ func offerClaudeCodeCurlPermission() error {
 
 	rules := []string{
 		"Bash(curl *http://localhost:25297/*)",
+		"Bash(curl *$CLAWVISOR_URL/*)",
 		fmt.Sprintf("Bash(curl *%s/*)", relayOrigin),
 	}
 

--- a/internal/daemon/claude_code.go
+++ b/internal/daemon/claude_code.go
@@ -131,25 +131,29 @@ rm ~/.claude/commands/clawvisor-setup.md
 If they decline, remind them they can delete it later with the same command.
 `
 
-// installClaudeCodeCommand writes the /clawvisor-setup slash command to
-// ~/.claude/commands/clawvisor-setup.md and the Clawvisor skill globally to
-// ~/.claude/skills/clawvisor/SKILL.md.
-func installClaudeCodeCommand(dataDir string) error {
+// installClaudeCodeSkill writes the Clawvisor skill globally to
+// ~/.claude/skills/clawvisor/SKILL.md so it's available in all projects.
+func installClaudeCodeSkill() error {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return fmt.Errorf("resolving home directory: %w", err)
 	}
 
-	// Install the skill globally so it's available in all projects.
 	skillDir := filepath.Join(home, ".claude", "skills", "clawvisor")
 	if err := os.MkdirAll(skillDir, 0755); err != nil {
 		return fmt.Errorf("creating skill directory: %w", err)
 	}
-	if err := writeSkillWithCurlGuidance(filepath.Join(skillDir, "SKILL.md")); err != nil {
-		return fmt.Errorf("writing skill file: %w", err)
+	return writeSkillWithCurlGuidance(filepath.Join(skillDir, "SKILL.md"))
+}
+
+// installClaudeCodeSetupCommand writes the /clawvisor-setup slash command to
+// ~/.claude/commands/clawvisor-setup.md.
+func installClaudeCodeSetupCommand() error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("resolving home directory: %w", err)
 	}
 
-	// Write the setup slash command.
 	commandsDir := filepath.Join(home, ".claude", "commands")
 	if err := os.MkdirAll(commandsDir, 0755); err != nil {
 		return fmt.Errorf("creating commands directory: %w", err)
@@ -443,39 +447,61 @@ func printClaudeDesktopManualInstructions() {
 	fmt.Println()
 }
 
-// offerClaudeCodeSetup prompts the user to install the /clawvisor-setup
-// slash command for Claude Code.
-func offerClaudeCodeSetup(dataDir string) error {
+// offerClaudeCodeSetup walks the user through Claude Code integration:
+// 1. Install the Clawvisor skill globally
+// 2. Install the /clawvisor-setup slash command
+// 3. Add auto-approve rules for curl requests
+func offerClaudeCodeSetup(_ string) error {
 	fmt.Println()
 	fmt.Println(bold.Padding(0, 2).Render("Claude Code"))
 
-	install := true
+	// 1. Offer to install the skill globally.
+	installSkill := true
 	if err := huh.NewForm(
 		huh.NewGroup(
 			huh.NewConfirm().
-				Title("Install the /clawvisor-setup command for Claude Code?").
-				Description("Adds a slash command so you can run /clawvisor-setup\nin any project to connect Claude Code to this daemon.").
+				Title("Install the Clawvisor skill for Claude Code?").
+				Description("Writes the skill to ~/.claude/skills/clawvisor/SKILL.md\nso Claude Code can use Clawvisor in any project.").
 				Affirmative("Yes").
 				Negative("No").
-				Value(&install),
+				Value(&installSkill),
 		),
 	).Run(); err != nil {
 		return err
 	}
-	if !install {
+	if !installSkill {
 		return nil
 	}
 
-	if err := installClaudeCodeCommand(dataDir); err != nil {
+	if err := installClaudeCodeSkill(); err != nil {
 		return err
 	}
-
 	fmt.Println(green.Padding(0, 2).Render("  ✓ Installed Clawvisor skill to ~/.claude/skills/clawvisor/SKILL.md"))
-	fmt.Println(green.Padding(0, 2).Render("  ✓ Installed /clawvisor-setup command"))
-	fmt.Println(dim.Padding(0, 2).Render("    Run /clawvisor-setup in Claude Code to connect a project."))
+
+	// 2. Offer to install the /clawvisor-setup slash command.
+	installSetup := true
+	if err := huh.NewForm(
+		huh.NewGroup(
+			huh.NewConfirm().
+				Title("Install the /clawvisor-setup command?").
+				Description("Adds a slash command so you can run /clawvisor-setup\nin Claude Code to create an agent token and connect.").
+				Affirmative("Yes").
+				Negative("No").
+				Value(&installSetup),
+		),
+	).Run(); err != nil {
+		return err
+	}
+	if installSetup {
+		if err := installClaudeCodeSetupCommand(); err != nil {
+			return err
+		}
+		fmt.Println(green.Padding(0, 2).Render("  ✓ Installed /clawvisor-setup command"))
+		fmt.Println(dim.Padding(0, 2).Render("    Run /clawvisor-setup in Claude Code to connect."))
+	}
 	fmt.Println()
 
-	// Offer to auto-approve Clawvisor curl requests globally.
+	// 3. Offer to auto-approve Clawvisor curl requests globally.
 	if err := offerClaudeCodeCurlPermission(); err != nil {
 		return err
 	}

--- a/internal/daemon/claude_code.go
+++ b/internal/daemon/claude_code.go
@@ -434,19 +434,12 @@ func offerClaudeDesktopSetup() {
 	fmt.Println()
 }
 
-// printClaudeDesktopManualInstructions prints the fallback manual setup steps.
+// printClaudeDesktopManualInstructions prints a short pointer to the
+// dedicated integrate subcommand.
 func printClaudeDesktopManualInstructions() {
 	fmt.Println()
-	fmt.Println(dim.Padding(0, 2).Render("  To connect Claude Desktop to Clawvisor, install the cowork plugin:"))
-	fmt.Println()
-	fmt.Println(dim.Padding(0, 2).Render("  1. Download the plugin:"))
-	fmt.Println(green.Padding(0, 2).Render("     https://github.com/clawvisor/cowork-plugin"))
-	fmt.Println()
-	fmt.Println(dim.Padding(0, 2).Render("  2. In Claude Desktop: Settings → Plugins → Install from local source"))
-	fmt.Println()
-	fmt.Println(dim.Padding(0, 2).Render("  3. Restart Claude Desktop — it will prompt you to authorize via OAuth"))
-	fmt.Println()
-	fmt.Println(dim.Padding(0, 2).Render("  Full guide: https://github.com/clawvisor/clawvisor/blob/main/docs/INTEGRATE_CLAUDE_COWORK.md"))
+	fmt.Println(dim.Padding(0, 2).Render("  To set up Claude Desktop later, run:"))
+	fmt.Println(green.Padding(0, 2).Render("    clawvisor integrate claude-desktop"))
 	fmt.Println()
 }
 
@@ -477,6 +470,7 @@ func offerClaudeCodeSetup(dataDir string) error {
 		return err
 	}
 
+	fmt.Println(green.Padding(0, 2).Render("  ✓ Installed Clawvisor skill to ~/.claude/skills/clawvisor/SKILL.md"))
 	fmt.Println(green.Padding(0, 2).Render("  ✓ Installed /clawvisor-setup command"))
 	fmt.Println(dim.Padding(0, 2).Render("    Run /clawvisor-setup in Claude Code to connect a project."))
 	fmt.Println()

--- a/internal/daemon/claude_code.go
+++ b/internal/daemon/claude_code.go
@@ -1,7 +1,6 @@
 package daemon
 
 import (
-	"bufio"
 	"crypto/md5" //nolint:gosec // used only for cache key derivation matching mcp-remote's convention
 	"crypto/sha256"
 	"encoding/hex"
@@ -21,10 +20,9 @@ import (
 	"github.com/clawvisor/clawvisor/skills"
 )
 
-// claudeCodeSetupCommand is the markdown template for the Claude Code
+// claudeCodeSetupCommand is the markdown content for the Claude Code
 // /clawvisor-setup slash command. It is written to ~/.claude/commands/
-// during daemon install when Claude Code is detected. The placeholders
-// {{CLAWVISOR_BINARY}} and {{SKILL_PATH}} are replaced at install time.
+// during daemon install when Claude Code is detected.
 const claudeCodeSetupCommand = `Set up Clawvisor in the current project so Claude Code can make gated API
 requests (Gmail, Calendar, Drive, GitHub, Slack, etc.) through the Clawvisor
 gateway with task-scoped authorization and human approval.
@@ -40,50 +38,46 @@ curl -sf http://localhost:25297/ready 2>/dev/null && echo "RUNNING" || echo "NOT
 If NOT RUNNING, tell the user to start it with ` + "`clawvisor start`" + ` and wait
 for them to confirm before continuing.
 
-### 2. Create an agent token
+### 2. Connect as an agent
+
+Register with the daemon and wait for the user to approve:
 
 ` + "```bash" + `
-{{CLAWVISOR_BINARY}} agent create claude-code --replace --json
+curl -s -X POST "http://localhost:25297/api/agents/connect?wait=true&timeout=120" -H "Content-Type: application/json" -d '{"name": "claude-code", "description": "Claude Code agent"}'
 ` + "```" + `
 
-Parse the JSON output and save the ` + "`token`" + ` value — you will need it below.
-If this fails, the daemon may not be running or the binary may not be on PATH.
+This sends a connection request to the daemon. The user will be notified
+to approve. The ` + "`?wait=true`" + ` parameter makes the request block until the
+user approves (or the timeout elapses).
 
-### 3. Install the Clawvisor skill
+Parse the JSON response. If ` + "`status`" + ` is ` + "`approved`" + `, save the ` + "`token`" + `
+value — you will need it below. If the timeout elapses and ` + "`status`" + ` is
+still ` + "`pending`" + `, tell the user to approve the connection request in the
+Clawvisor dashboard and long-poll ` + "`GET /api/agents/connect/{connection_id}/status`" + `
+until it resolves.
 
-Copy the pre-installed skill file into this project:
+### 3. Set environment variables
 
-` + "```bash" + `
-mkdir -p .claude/skills/clawvisor
-cp {{SKILL_PATH}} .claude/skills/clawvisor/SKILL.md
+Save the agent token and daemon URL to ` + "`~/.claude/settings.json`" + ` so they
+persist across all Claude Code sessions and projects.
+
+Read ` + "`~/.claude/settings.json`" + ` (create it if it doesn't exist). Merge the
+following into the ` + "`env`" + ` object at the top level, preserving all other keys:
+
+` + "```json" + `
+{
+  "env": {
+    "CLAWVISOR_URL": "http://localhost:25297",
+    "CLAWVISOR_AGENT_TOKEN": "<token from step 2>"
+  }
+}
 ` + "```" + `
 
-After copying, read ` + "`.claude/skills/clawvisor/SKILL.md`" + ` so you understand how
-to use the Clawvisor skill in the smoke test later.
+Write the updated JSON back to ` + "`~/.claude/settings.json`" + `. The variables
+will be available in every future Claude Code session without any per-project
+setup.
 
-### 4. Set environment variables
-
-Write the agent token and daemon URL to ` + "`.claude/.env`" + `:
-
-` + "```bash" + `
-# Remove any previous Clawvisor lines
-grep -v '^CLAWVISOR_' .claude/.env > /tmp/claude-env.tmp 2>/dev/null || true
-mv /tmp/claude-env.tmp .claude/.env 2>/dev/null || true
-
-# Append new values
-cat >> .claude/.env <<EOF
-CLAWVISOR_URL=http://localhost:25297
-CLAWVISOR_AGENT_TOKEN=<token from step 2>
-EOF
-` + "```" + `
-
-Then ensure ` + "`.claude/.env`" + ` is in ` + "`.gitignore`" + `:
-
-` + "```bash" + `
-grep -q '\\.claude/\\.env' .gitignore 2>/dev/null || echo '.claude/.env' >> .gitignore
-` + "```" + `
-
-### 5. Verify
+### 4. Verify
 
 ` + "```bash" + `
 curl -sf -H "Authorization: Bearer $CLAWVISOR_AGENT_TOKEN" \
@@ -93,7 +87,7 @@ curl -sf -H "Authorization: Bearer $CLAWVISOR_AGENT_TOKEN" \
 This should return a JSON service catalog. If it returns 401, the token is
 wrong. If it fails to connect, the daemon is not running.
 
-### 6. End-to-end smoke test
+### 5. End-to-end smoke test
 
 Now that everything is configured, run a quick smoke test to prove the full
 flow works. Use the Clawvisor skill to:
@@ -116,7 +110,7 @@ Summarize the results: the in-scope call should have succeeded and the
 out-of-scope call should have been denied. If either result is unexpected,
 help the user debug.
 
-### 7. Done
+### 6. Done
 
 Tell the user setup is complete. The Clawvisor skill will be loaded
 automatically when relevant, or they can invoke it explicitly. Remind them to:
@@ -125,7 +119,7 @@ automatically when relevant, or they can invoke it explicitly. Remind them to:
   you to use them
 - Approve tasks in the dashboard or via mobile when you request them
 
-### 8. Offer to uninstall /clawvisor-setup (optional)
+### 7. Offer to uninstall /clawvisor-setup (optional)
 
 Now that setup is complete, ask the user if they'd like to remove the
 ` + "`/clawvisor-setup`" + ` slash command since it's no longer needed. If they agree:
@@ -138,84 +132,48 @@ If they decline, remind them they can delete it later with the same command.
 `
 
 // installClaudeCodeCommand writes the /clawvisor-setup slash command to
-// ~/.claude/commands/clawvisor-setup.md and a stripped copy of SKILL.md to
-// ~/.clawvisor/SKILL.md. It resolves the current binary path and bakes both
-// paths into the command template.
+// ~/.claude/commands/clawvisor-setup.md and the Clawvisor skill globally to
+// ~/.claude/skills/clawvisor/SKILL.md.
 func installClaudeCodeCommand(dataDir string) error {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return fmt.Errorf("resolving home directory: %w", err)
 	}
 
-	// Write the stripped SKILL.md into the daemon data directory so the
-	// slash command can copy it into projects without curling the daemon.
-	skillDest := filepath.Join(dataDir, "SKILL.md")
-	if err := writeStrippedSkill(skillDest); err != nil {
+	// Install the skill globally so it's available in all projects.
+	skillDir := filepath.Join(home, ".claude", "skills", "clawvisor")
+	if err := os.MkdirAll(skillDir, 0755); err != nil {
+		return fmt.Errorf("creating skill directory: %w", err)
+	}
+	if err := writeSkillWithCurlGuidance(filepath.Join(skillDir, "SKILL.md")); err != nil {
 		return fmt.Errorf("writing skill file: %w", err)
 	}
 
+	// Write the setup slash command.
 	commandsDir := filepath.Join(home, ".claude", "commands")
 	if err := os.MkdirAll(commandsDir, 0755); err != nil {
 		return fmt.Errorf("creating commands directory: %w", err)
 	}
 
-	// Resolve the clawvisor binary path.
-	binary, err := os.Executable()
-	if err != nil {
-		binary = "clawvisor" // fallback to PATH lookup
-	} else {
-		resolved, err := filepath.EvalSymlinks(binary)
-		if err == nil {
-			binary = resolved
-		}
-		// If this is a go-run temp binary, fall back to bare name.
-		if isGoRunBinary(binary) {
-			binary = "clawvisor"
-		}
-	}
-
-	relayOrigin := "https://relay.clawvisor.com"
-	if version.IsStaging() {
-		relayOrigin = "https://relay.staging.clawvisor.com"
-	}
-
-	content := claudeCodeSetupCommand
-	content = strings.ReplaceAll(content, "{{CLAWVISOR_BINARY}}", binary)
-	content = strings.ReplaceAll(content, "{{SKILL_PATH}}", skillDest)
-	content = strings.ReplaceAll(content, "{{RELAY_ORIGIN}}", relayOrigin)
-
 	dest := filepath.Join(commandsDir, "clawvisor-setup.md")
-	if err := os.WriteFile(dest, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(dest, []byte(claudeCodeSetupCommand), 0644); err != nil {
 		return fmt.Errorf("writing command file: %w", err)
 	}
 
 	return nil
 }
 
-// writeStrippedSkill renders the SKILL.md template for Claude Code, strips the
-// YAML frontmatter, appends Claude Code-specific guidance, and writes the
-// result to dest.
-func writeStrippedSkill(dest string) error {
+// writeSkillWithCurlGuidance renders the SKILL.md template for Claude Code,
+// preserves the YAML frontmatter (required for Claude Code to recognize the
+// skill), appends Claude Code-specific guidance, and writes the result to dest.
+func writeSkillWithCurlGuidance(dest string) error {
 	rendered, err := skills.Render(skills.TargetClaudeCode)
 	if err != nil {
 		return fmt.Errorf("rendering SKILL.md: %w", err)
 	}
 
-	// Strip YAML frontmatter (the --- delimited block at the top).
 	var b strings.Builder
-	scanner := bufio.NewScanner(strings.NewReader(rendered))
-	fences := 0
-	for scanner.Scan() {
-		line := scanner.Text()
-		if line == "---" {
-			fences++
-			continue
-		}
-		if fences >= 2 {
-			b.WriteString(line)
-			b.WriteByte('\n')
-		}
-	}
+	b.WriteString(rendered)
 
 	// Append Claude Code-specific guidance about curl formatting.
 	b.WriteString("\n## Important: Single-line curl commands\n\n")

--- a/internal/daemon/integrate.go
+++ b/internal/daemon/integrate.go
@@ -35,7 +35,10 @@ func Integrate() error {
 	fmt.Println()
 
 	if hasClaudeCode(agents) {
-		if err := IntegrateClaudeCode(); err != nil && err != huh.ErrUserAborted {
+		if err := IntegrateClaudeCode(); err != nil {
+			if err == huh.ErrUserAborted {
+				return nil
+			}
 			fmt.Println(dim.Padding(0, 2).Render("  Warning: Claude Code integration failed: " + err.Error()))
 		}
 	}

--- a/skills/clawvisor/SKILL.md.tmpl
+++ b/skills/clawvisor/SKILL.md.tmpl
@@ -35,6 +35,14 @@ description: >
 
 ## Setup
 
+**Check first:** Run `echo $CLAWVISOR_URL $CLAWVISOR_AGENT_TOKEN` to see if both
+are already set. If both values are present, **skip setup entirely** and go
+straight to [Getting Your Service Catalog](#getting-your-service-catalog).
+
+If the variables are not set, run `/clawvisor-setup` to configure them. The setup
+command writes the variables to `~/.claude/settings.json` so they persist across
+all sessions and projects automatically.
+
 ### Option A: Setup URL (recommended)
 
 If you were given a setup URL (e.g. `https://relay.clawvisor.com/d/<id>/skill/setup`), fetch it — it contains step-by-step instructions with your `CLAWVISOR_URL` pre-filled, including how to register, authenticate, and set up E2E encryption.
@@ -42,7 +50,7 @@ If you were given a setup URL (e.g. `https://relay.clawvisor.com/d/<id>/skill/se
 ### Option B: Manual setup
 
 1. Set `CLAWVISOR_URL` to your Clawvisor instance URL (e.g. `http://localhost:25297`)
-2. Create an agent in the Clawvisor dashboard, copy the token, then run: `openclaw credentials set CLAWVISOR_AGENT_TOKEN`
+2. Create an agent in the Clawvisor dashboard, copy the token, and add it to `~/.claude/settings.json` under the `env` key as `CLAWVISOR_AGENT_TOKEN`
 3. Set `OPENCLAW_HOOKS_URL` to your OpenClaw gateway's reachable URL (default `http://localhost:18789`)
 4. Activate any services you want the agent to use (Gmail, GitHub, etc.) in the dashboard under Services
 5. Set dashboard policies to require approval for write/send/delete actions — only enable `auto_execute` for read-only actions you trust the agent to perform unsupervised

--- a/skills/clawvisor/SKILL.md.tmpl
+++ b/skills/clawvisor/SKILL.md.tmpl
@@ -35,14 +35,6 @@ description: >
 
 ## Setup
 
-**Check first:** If `$CLAWVISOR_URL` and `$CLAWVISOR_AGENT_TOKEN` are both set
-in your environment, **skip setup entirely** and go straight to
-[Getting Your Service Catalog](#getting-your-service-catalog).
-
-If the variables are not set, run `/clawvisor-setup` to configure them. The setup
-command writes the variables to `~/.claude/settings.json` so they persist across
-all sessions and projects automatically.
-
 ### Option A: Setup URL (recommended)
 
 If you were given a setup URL (e.g. `https://relay.clawvisor.com/d/<id>/skill/setup`), fetch it — it contains step-by-step instructions with your `CLAWVISOR_URL` pre-filled, including how to register, authenticate, and set up E2E encryption.

--- a/skills/clawvisor/SKILL.md.tmpl
+++ b/skills/clawvisor/SKILL.md.tmpl
@@ -35,9 +35,9 @@ description: >
 
 ## Setup
 
-**Check first:** Run `echo $CLAWVISOR_URL $CLAWVISOR_AGENT_TOKEN` to see if both
-are already set. If both values are present, **skip setup entirely** and go
-straight to [Getting Your Service Catalog](#getting-your-service-catalog).
+**Check first:** If `$CLAWVISOR_URL` and `$CLAWVISOR_AGENT_TOKEN` are both set
+in your environment, **skip setup entirely** and go straight to
+[Getting Your Service Catalog](#getting-your-service-catalog).
 
 If the variables are not set, run `/clawvisor-setup` to configure them. The setup
 command writes the variables to `~/.claude/settings.json` so they persist across


### PR DESCRIPTION
## Summary

- **Skill now installs globally** to `~/.claude/skills/clawvisor/SKILL.md` with YAML frontmatter preserved, so Claude Code recognizes it as a named skill across session restarts
- **Env vars write to `~/.claude/settings.json`** under the `env` key instead of per-project `.claude/.env`, so they persist across all sessions and projects
- **Setup uses `/api/agents/connect`** instead of CLI `agent create` — the agent registers through the connection endpoint and writes its own env vars
- **No per-project file copying** — the skill and env vars are both global, eliminating the need to re-run setup in each project

## Test plan

- [ ] Run `clawvisor integrate` and verify skill is written to `~/.claude/skills/clawvisor/SKILL.md` with frontmatter intact
- [ ] Run `/clawvisor-setup` in Claude Code and verify env vars are written to `~/.claude/settings.json`
- [ ] Restart Claude Code session and verify the agent recognizes the clawvisor skill and has env vars available
- [ ] Verify the smoke test (catalog fetch, task creation, in-scope/out-of-scope requests) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)