### PR TITLE
fix: resolve path param defaults before URL interpolation in YAML runtime

### DIFF
--- a/pkg/adapters/yamlruntime/adapter_test.go
+++ b/pkg/adapters/yamlruntime/adapter_test.go
@@ -971,6 +971,91 @@ func TestYAMLAdapter_GmailGetMessage(t *testing.T) {
 	}
 }
 
+func TestYAMLAdapter_PathParamDefault(t *testing.T) {
+	// Regression: when a path param has a default and the caller omits it,
+	// the placeholder must still be replaced (was causing 404s for Calendar).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v3/calendars/primary/events" {
+			t.Errorf("unexpected path: %s (want /v3/calendars/primary/events)", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"items": []any{},
+		})
+	}))
+	defer srv.Close()
+
+	def := yamldef.ServiceDef{
+		Service: yamldef.ServiceInfo{ID: "google.calendar"},
+		Auth:    yamldef.AuthDef{Type: "api_key", Header: "Authorization", HeaderPrefix: "Bearer "},
+		API:     yamldef.APIDef{BaseURL: srv.URL + "/v3", Type: "rest"},
+		Actions: map[string]yamldef.Action{
+			"list_events": {
+				Method: "GET",
+				Path:   "/calendars/{{.calendar_id}}/events",
+				Params: map[string]yamldef.Param{
+					"calendar_id": {Type: "string", Default: "primary", Location: "path"},
+					"max_results": {Type: "int", Default: 10, MapTo: "maxResults", Location: "query"},
+				},
+				Response: yamldef.ResponseDef{
+					DataPath: "items",
+					Summary:  "{{len .Data}} event(s)",
+				},
+			},
+		},
+	}
+
+	adapter, err := New(def, nil)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	// Call WITHOUT calendar_id — should default to "primary".
+	_, err = adapter.Execute(context.Background(), adapters.Request{
+		Action:     "list_events",
+		Params:     map[string]any{},
+		Credential: testCred("test-token"),
+	})
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+}
+
+func TestYAMLAdapter_UnresolvedPathParam(t *testing.T) {
+	// When a required path param is missing and has no default, the error
+	// should mention the parameter name, not silently send a broken URL.
+	def := yamldef.ServiceDef{
+		Service: yamldef.ServiceInfo{ID: "test.svc"},
+		Auth:    yamldef.AuthDef{Type: "api_key", Header: "Authorization", HeaderPrefix: "Bearer "},
+		API:     yamldef.APIDef{BaseURL: "http://unused", Type: "rest"},
+		Actions: map[string]yamldef.Action{
+			"get_item": {
+				Method: "GET",
+				Path:   "/items/{{.item_id}}",
+				Params: map[string]yamldef.Param{
+					"item_id": {Type: "string", Location: "path"},
+				},
+				Response: yamldef.ResponseDef{},
+			},
+		},
+	}
+
+	adapter, err := New(def, nil)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	_, err = adapter.Execute(context.Background(), adapters.Request{
+		Action:     "get_item",
+		Params:     map[string]any{},
+		Credential: testCred("test-token"),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing path param, got nil")
+	}
+	if !contains(err.Error(), "item_id") {
+		t.Errorf("error should mention 'item_id', got: %s", err.Error())
+	}
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsHelper(s, substr))
 }

--- a/pkg/adapters/yamlruntime/rest.go
+++ b/pkg/adapters/yamlruntime/rest.go
@@ -17,8 +17,31 @@ import (
 
 // executeREST executes a REST action as defined in the YAML spec.
 func executeREST(ctx context.Context, client *http.Client, baseURL string, action yamldef.Action, params map[string]any, credFields map[string]string, ca *compiledAction) (*adapters.Result, error) {
+	// Resolve path-parameter defaults before interpolation so that callers
+	// who omit a path param with a default (e.g. calendar_id="primary") still
+	// get the placeholder replaced.
+	pathParams := make(map[string]any, len(params))
+	for k, v := range params {
+		pathParams[k] = v
+	}
+	for name, paramDef := range action.Params {
+		if paramDef.Location != "path" {
+			continue
+		}
+		if _, ok := pathParams[name]; ok {
+			continue // caller provided it
+		}
+		val, _ := resolveParamWithExpr(params, name, paramDef, ca)
+		if val != nil {
+			pathParams[name] = val
+		}
+	}
+
 	// Build the URL path with parameter interpolation.
-	path := interpolatePath(action.Path, params, credFields)
+	path := interpolatePath(action.Path, pathParams, credFields)
+	if unresolved := findUnresolvedPlaceholders(path); len(unresolved) > 0 {
+		return nil, fmt.Errorf("missing required path parameter(s): %s", strings.Join(unresolved, ", "))
+	}
 	fullURL := strings.TrimRight(baseURL, "/") + "/" + strings.TrimLeft(path, "/")
 
 	// Separate params by location.
@@ -45,7 +68,7 @@ func executeREST(ctx context.Context, client *http.Client, baseURL string, actio
 		case "body":
 			bodyParams[apiKey] = val
 		case "path":
-			// Already handled by interpolatePath.
+			// Already handled above.
 		}
 	}
 
@@ -366,6 +389,27 @@ func toInt(v any) int {
 		return int(n)
 	}
 	return 0
+}
+
+// findUnresolvedPlaceholders returns the names of any {{.xxx}} placeholders
+// still present in path after interpolation. An empty slice means all
+// placeholders were resolved.
+func findUnresolvedPlaceholders(path string) []string {
+	var names []string
+	for rest := path; ; {
+		start := strings.Index(rest, "{{.")
+		if start < 0 {
+			break
+		}
+		end := strings.Index(rest[start:], "}}")
+		if end < 0 {
+			break
+		}
+		name := rest[start+3 : start+end]
+		names = append(names, name)
+		rest = rest[start+end+2:]
+	}
+	return names
 }
 
 func truncate(s string, max int) string {


### PR DESCRIPTION
## Summary

- YAML runtime's `interpolatePath` ran before param defaults were resolved, so path params with defaults (e.g. `calendar_id="primary"`) were left as literal `{{.calendar_id}}` in the URL — causing 404s from Google Calendar after the Go-to-YAML migration in #93
- Resolves path-param defaults into the interpolation map before building the URL
- Adds an explicit error when any `{{.placeholder}}` remains unresolved, so future issues surface clearly instead of producing opaque 404s
- Adds regression tests for both the default-resolution fix and the unresolved-placeholder error

## Test plan

- [x] `TestYAMLAdapter_PathParamDefault` — verifies omitted `calendar_id` defaults to `"primary"` in the URL
- [x] `TestYAMLAdapter_UnresolvedPathParam` — verifies a clear error mentioning the param name
- [x] Full `yamlruntime` test suite passes (17/17)

🤖 Generated with [Claude Code](https://claude.com/claude-code)