### PR TITLE
feat: GitHub OAuth device flow

### DIFF
--- a/internal/adapters/definitions/github.yaml
+++ b/internal/adapters/definitions/github.yaml
@@ -10,6 +10,12 @@ auth:
   header_prefix: "token "
   extra_headers:
     Accept: "application/vnd.github.v3+json"
+  device_flow:
+    client_id: "Ov23lilVGK2hqWMGk9Qk"
+    client_id_env: "GITHUB_CLIENT_ID"
+    scopes: ["repo", "read:org", "read:user"]
+    device_code_url: "https://github.com/login/device/code"
+    token_url: "https://github.com/login/oauth/access_token"
 
 api:
   base_url: "https://api.github.com"
@@ -154,7 +160,7 @@ actions:
     method: GET
     path: "/search/code"
     params:
-      query: { type: string, required: true, location: query }
+      query: { type: string, required: true, location: query, map_to: "q" }
     response:
       data_path: "items"
       fields:

--- a/internal/api/handlers/services.go
+++ b/internal/api/handlers/services.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"os"
 	"regexp"
 	"sort"
 	"strings"
@@ -36,6 +37,9 @@ type ServicesHandler struct {
 
 	// oauthStates holds temporary OAuth2 state tokens (in-memory; Phase 3 only).
 	oauthStates sync.Map // stateToken (string) → oauthStateEntry
+
+	// deviceFlows holds pending device flow entries keyed by flow ID.
+	deviceFlows sync.Map // flowID (string) → deviceFlowEntry
 }
 
 type oauthStateEntry struct {
@@ -125,6 +129,7 @@ func (h *ServicesHandler) List(w http.ResponseWriter, r *http.Request) {
 		Alias              string        `json:"alias,omitempty"`
 		OAuth              bool          `json:"oauth"`
 		OAuthEndpoint      string        `json:"oauth_endpoint,omitempty"`
+		DeviceFlow         bool          `json:"device_flow,omitempty"`
 		RequiresActivation bool          `json:"requires_activation"`
 		CredentialFree     bool          `json:"credential_free"`
 		Actions            []actionEntry `json:"actions"`
@@ -166,12 +171,18 @@ func (h *ServicesHandler) List(w http.ResponseWriter, r *http.Request) {
 			actions = append(actions, ae)
 		}
 
+		var deviceFlow bool
+		if mp, ok2 := a.(adapters.MetadataProvider); ok2 {
+			deviceFlow = mp.ServiceMetadata().DeviceFlow
+		}
+
 		return serviceEntry{
 			ID:                 a.ServiceID(),
 			Name:               name,
 			Description:        desc,
 			OAuth:              len(a.RequiredScopes()) > 0,
 			OAuthEndpoint:      oauthEndpoint,
+			DeviceFlow:         deviceFlow,
 			RequiresActivation: true,
 			Actions:            actions,
 			SetupURL:           setupURL,
@@ -889,6 +900,271 @@ func (h *ServicesHandler) removeAdapterScopes(ctx context.Context, userID, vKey 
 		return
 	}
 	_ = h.vault.Set(ctx, userID, vKey, updated)
+}
+
+// ── Device Flow (RFC 8628) ───────────────────────────────────────────────────
+
+type deviceFlowEntry struct {
+	UserID     string
+	ServiceID  string
+	Alias      string
+	DeviceCode string
+	ClientID   string
+	TokenURL   string
+	GrantType  string
+	Interval   int
+	ExpiresAt  time.Time
+}
+
+// DeviceFlowStart initiates a device authorization flow.
+//
+// POST /api/services/{serviceID}/device-flow/start
+// Auth: user JWT
+// Body: {"alias": "..."} (optional)
+// Response: {"flow_id": "...", "user_code": "ABCD-1234", "verification_uri": "...", "interval": 5, "expires_in": 900}
+func (h *ServicesHandler) DeviceFlowStart(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "not authenticated")
+		return
+	}
+
+	serviceID := r.PathValue("serviceID")
+	if serviceID == "" {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "serviceID is required")
+		return
+	}
+
+	adapter, ok := h.adapterReg.Get(serviceID)
+	if !ok {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", fmt.Sprintf("service %q not found", serviceID))
+		return
+	}
+
+	dfp, ok := adapter.(adapters.DeviceFlowProvider)
+	if !ok {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "service does not support device flow")
+		return
+	}
+	dfCfg := dfp.DeviceFlowConfig()
+	if dfCfg == nil {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "device flow not configured (missing client_id)")
+		return
+	}
+
+	var body struct {
+		Alias string `json:"alias"`
+	}
+	_ = json.NewDecoder(r.Body).Decode(&body)
+	alias := body.Alias
+	if alias == "" {
+		alias = "default"
+	}
+	if !validAlias(alias) {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "alias contains invalid characters")
+		return
+	}
+
+	// Resolve client_id.
+	clientID := dfCfg.ClientID
+	if dfCfg.ClientIDEnv != "" {
+		if v := os.Getenv(dfCfg.ClientIDEnv); v != "" {
+			clientID = v
+		}
+	}
+
+	// Request device code from the provider.
+	form := url.Values{
+		"client_id": {clientID},
+		"scope":     {strings.Join(dfCfg.Scopes, " ")},
+	}
+	req, err := http.NewRequestWithContext(r.Context(), "POST", dfCfg.DeviceCodeURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to build request")
+		return
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		h.logger.Warn("device flow: request to provider failed", "err", err)
+		writeError(w, http.StatusBadGateway, "PROVIDER_ERROR", "failed to contact provider")
+		return
+	}
+	defer resp.Body.Close()
+
+	var dfResp struct {
+		DeviceCode      string `json:"device_code"`
+		UserCode        string `json:"user_code"`
+		VerificationURI string `json:"verification_uri"`
+		ExpiresIn       int    `json:"expires_in"`
+		Interval        int    `json:"interval"`
+		Error           string `json:"error"`
+		ErrorDesc       string `json:"error_description"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&dfResp); err != nil {
+		writeError(w, http.StatusBadGateway, "PROVIDER_ERROR", "invalid response from provider")
+		return
+	}
+	if dfResp.Error != "" {
+		h.logger.Warn("device flow: provider error", "error", dfResp.Error, "desc", dfResp.ErrorDesc)
+		writeError(w, http.StatusBadGateway, "PROVIDER_ERROR", dfResp.ErrorDesc)
+		return
+	}
+
+	grantType := dfCfg.GrantType
+	if grantType == "" {
+		grantType = "urn:ietf:params:oauth:grant-type:device_code"
+	}
+	interval := dfResp.Interval
+	if interval < 5 {
+		interval = 5
+	}
+
+	flowID := uuid.New().String()
+	h.deviceFlows.Store(flowID, deviceFlowEntry{
+		UserID:     user.ID,
+		ServiceID:  serviceID,
+		Alias:      alias,
+		DeviceCode: dfResp.DeviceCode,
+		ClientID:   clientID,
+		TokenURL:   dfCfg.TokenURL,
+		GrantType:  grantType,
+		Interval:   interval,
+		ExpiresAt:  time.Now().Add(time.Duration(dfResp.ExpiresIn) * time.Second),
+	})
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"flow_id":          flowID,
+		"user_code":        dfResp.UserCode,
+		"verification_uri": dfResp.VerificationURI,
+		"interval":         interval,
+		"expires_in":       dfResp.ExpiresIn,
+	})
+}
+
+// DeviceFlowPoll polls for device flow completion.
+//
+// POST /api/services/{serviceID}/device-flow/poll
+// Auth: user JWT
+// Body: {"flow_id": "..."}
+// Response: {"status": "pending|complete|expired|denied|slow_down", "interval": ...}
+func (h *ServicesHandler) DeviceFlowPoll(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "not authenticated")
+		return
+	}
+
+	var body struct {
+		FlowID string `json:"flow_id"`
+	}
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+	if body.FlowID == "" {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "flow_id is required")
+		return
+	}
+
+	val, ok := h.deviceFlows.Load(body.FlowID)
+	if !ok {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "unknown or expired flow")
+		return
+	}
+	entry := val.(deviceFlowEntry)
+
+	if entry.UserID != user.ID {
+		writeError(w, http.StatusForbidden, "FORBIDDEN", "flow does not belong to this user")
+		return
+	}
+	if time.Now().After(entry.ExpiresAt) {
+		h.deviceFlows.Delete(body.FlowID)
+		writeJSON(w, http.StatusOK, map[string]any{"status": "expired"})
+		return
+	}
+
+	// Poll the provider's token endpoint.
+	form := url.Values{
+		"client_id":   {entry.ClientID},
+		"device_code": {entry.DeviceCode},
+		"grant_type":  {entry.GrantType},
+	}
+	req, err := http.NewRequestWithContext(r.Context(), "POST", entry.TokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to build request")
+		return
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		h.logger.Warn("device flow poll: request failed", "err", err)
+		writeError(w, http.StatusBadGateway, "PROVIDER_ERROR", "failed to contact provider")
+		return
+	}
+	defer resp.Body.Close()
+
+	var tokenResp struct {
+		AccessToken string `json:"access_token"`
+		TokenType   string `json:"token_type"`
+		Scope       string `json:"scope"`
+		Error       string `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		writeError(w, http.StatusBadGateway, "PROVIDER_ERROR", "invalid response from provider")
+		return
+	}
+
+	switch tokenResp.Error {
+	case "authorization_pending":
+		writeJSON(w, http.StatusOK, map[string]any{"status": "pending"})
+		return
+	case "slow_down":
+		// Increase interval by 5 seconds per spec.
+		entry.Interval += 5
+		h.deviceFlows.Store(body.FlowID, entry)
+		writeJSON(w, http.StatusOK, map[string]any{"status": "slow_down", "interval": entry.Interval})
+		return
+	case "expired_token":
+		h.deviceFlows.Delete(body.FlowID)
+		writeJSON(w, http.StatusOK, map[string]any{"status": "expired"})
+		return
+	case "access_denied":
+		h.deviceFlows.Delete(body.FlowID)
+		writeJSON(w, http.StatusOK, map[string]any{"status": "denied"})
+		return
+	case "":
+		// Success — fall through.
+	default:
+		h.deviceFlows.Delete(body.FlowID)
+		writeJSON(w, http.StatusOK, map[string]any{"status": "error", "error": tokenResp.Error})
+		return
+	}
+
+	// Success: store the token as an api_key credential.
+	credBytes, err := json.Marshal(map[string]string{
+		"type":  "api_key",
+		"token": tokenResp.AccessToken,
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to encode credential")
+		return
+	}
+
+	vKey := h.adapterReg.VaultKeyWithAlias(entry.ServiceID, entry.Alias)
+	if err := h.vault.Set(r.Context(), entry.UserID, vKey, credBytes); err != nil {
+		h.logger.Warn("device flow: vault set failed", "err", err)
+		writeError(w, http.StatusInternalServerError, "VAULT_ERROR", "failed to store credential")
+		return
+	}
+	_ = h.st.UpsertServiceMeta(r.Context(), entry.UserID, entry.ServiceID, entry.Alias, time.Now())
+	h.deviceFlows.Delete(body.FlowID)
+
+	h.logger.Info("service activated via device flow", "user", entry.UserID, "service", entry.ServiceID)
+	writeJSON(w, http.StatusOK, map[string]any{"status": "complete"})
 }
 
 // ── System OAuth Config ──────────────────────────────────────────────────────

--- a/internal/api/handlers/services.go
+++ b/internal/api/handlers/services.go
@@ -1144,7 +1144,13 @@ func (h *ServicesHandler) DeviceFlowPoll(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Success: store the token as an api_key credential.
+	// Success: validate and store the token as an api_key credential.
+	if tokenResp.AccessToken == "" {
+		h.logger.Warn("device flow: provider returned empty access token", "service", entry.ServiceID)
+		h.deviceFlows.Delete(body.FlowID)
+		writeError(w, http.StatusBadGateway, "PROVIDER_ERROR", "provider returned empty access token")
+		return
+	}
 	credBytes, err := json.Marshal(map[string]string{
 		"type":  "api_key",
 		"token": tokenResp.AccessToken,

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -466,6 +466,8 @@ func (s *Server) routes() http.Handler {
 	mux.Handle("POST /api/services/{serviceID}/activate", user(servicesHandler.Activate))
 	mux.Handle("POST /api/services/{serviceID}/activate-key", user(servicesHandler.ActivateWithKey))
 	mux.Handle("POST /api/services/{serviceID}/deactivate", user(servicesHandler.Deactivate))
+	mux.Handle("POST /api/services/{serviceID}/device-flow/start", user(servicesHandler.DeviceFlowStart))
+	mux.Handle("POST /api/services/{serviceID}/device-flow/poll", user(servicesHandler.DeviceFlowPoll))
 
 	// System-level OAuth config (user JWT)
 	mux.Handle("GET /api/system/google-oauth", user(servicesHandler.GetGoogleOAuthConfig))

--- a/internal/daemon/services_setup.go
+++ b/internal/daemon/services_setup.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/huh"
 	"github.com/clawvisor/clawvisor/internal/browser"
@@ -159,6 +160,8 @@ func activateService(apiClient *client.Client, svc client.ServiceInfo, dataDir s
 		return activateCredentialFreeService(apiClient, svc)
 	case svc.OAuth:
 		return activateOAuthService(apiClient, svc, dataDir)
+	case svc.DeviceFlow:
+		return activateDeviceFlowOrAPIKey(apiClient, svc)
 	default:
 		return activateAPIKeyService(apiClient, svc)
 	}
@@ -202,6 +205,71 @@ func activateAPIKeyService(apiClient *client.Client, svc client.ServiceInfo) err
 	}
 	fmt.Printf("  %s %s connected.\n\n", green.Render("✓"), svc.Name)
 	return nil
+}
+
+// activateDeviceFlowOrAPIKey lets the user choose between device flow (browser)
+// and pasting a personal access token.
+func activateDeviceFlowOrAPIKey(apiClient *client.Client, svc client.ServiceInfo) error {
+	var method string
+	if err := huh.NewForm(
+		huh.NewGroup(
+			huh.NewSelect[string]().
+				Title(fmt.Sprintf("How would you like to connect %s?", svc.Name)).
+				Options(
+					huh.NewOption("Sign in with GitHub (browser)", "device_flow"),
+					huh.NewOption("Paste a Personal Access Token", "api_key"),
+				).
+				Value(&method),
+		),
+	).Run(); err != nil {
+		return err
+	}
+
+	if method == "api_key" {
+		return activateAPIKeyService(apiClient, svc)
+	}
+
+	// Device flow.
+	dfResp, err := apiClient.DeviceFlowStart(svc.ID, "")
+	if err != nil {
+		return fmt.Errorf("starting device flow: %w", err)
+	}
+
+	fmt.Println()
+	fmt.Println(bold.Padding(0, 2).Render(fmt.Sprintf("  Enter code: %s", dfResp.UserCode)))
+	fmt.Println(dim.Padding(0, 2).Render(fmt.Sprintf("  at: %s", dfResp.VerificationURI)))
+	fmt.Println()
+
+	browser.Open(dfResp.VerificationURI)
+
+	fmt.Println(dim.Padding(0, 2).Render("  Waiting for authorization..."))
+
+	interval := dfResp.Interval
+	for {
+		time.Sleep(time.Duration(interval) * time.Second)
+
+		pollResp, err := apiClient.DeviceFlowPoll(svc.ID, dfResp.FlowID)
+		if err != nil {
+			return fmt.Errorf("polling device flow: %w", err)
+		}
+
+		switch pollResp.Status {
+		case "complete":
+			fmt.Printf("  %s %s connected.\n\n", green.Render("✓"), svc.Name)
+			return nil
+		case "pending":
+			continue
+		case "slow_down":
+			interval = pollResp.Interval
+			continue
+		case "expired":
+			return fmt.Errorf("authorization expired — please try again")
+		case "denied":
+			return fmt.Errorf("authorization was denied")
+		default:
+			return fmt.Errorf("unexpected status: %s", pollResp.Status)
+		}
+	}
 }
 
 // activateOAuthService handles OAuth activation. For services using the

--- a/internal/tui/client/client.go
+++ b/internal/tui/client/client.go
@@ -319,6 +319,31 @@ func (c *Client) DeactivateService(serviceID, alias string) error {
 	return c.post("/api/services/"+serviceID+"/deactivate", body, &resp)
 }
 
+// ── Device Flow ─────────────────────────────────────────────────────────────
+
+// DeviceFlowStart initiates a device authorization flow for the given service.
+func (c *Client) DeviceFlowStart(serviceID, alias string) (*DeviceFlowStartResponse, error) {
+	body := map[string]string{}
+	if alias != "" {
+		body["alias"] = alias
+	}
+	var resp DeviceFlowStartResponse
+	if err := c.post("/api/services/"+serviceID+"/device-flow/start", body, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// DeviceFlowPoll polls for device flow completion.
+func (c *Client) DeviceFlowPoll(serviceID, flowID string) (*DeviceFlowPollResponse, error) {
+	body := map[string]string{"flow_id": flowID}
+	var resp DeviceFlowPollResponse
+	if err := c.post("/api/services/"+serviceID+"/device-flow/poll", body, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
 // ── Restrictions ────────────────────────────────────────────────────────────
 
 func (c *Client) GetRestrictions() ([]Restriction, error) {

--- a/internal/tui/client/types.go
+++ b/internal/tui/client/types.go
@@ -188,12 +188,29 @@ type ServiceInfo struct {
 	Alias              string            `json:"alias,omitempty"`
 	OAuth              bool              `json:"oauth"`
 	OAuthEndpoint      string            `json:"oauth_endpoint,omitempty"`
+	DeviceFlow         bool              `json:"device_flow,omitempty"`
 	RequiresActivation bool              `json:"requires_activation"`
 	CredentialFree     bool              `json:"credential_free"`
 	Actions            json.RawMessage   `json:"actions"`
 	Status             string            `json:"status"` // "activated" or "not_activated"
 	ActivatedAt        string            `json:"activated_at,omitempty"`
 	SetupURL           string            `json:"setup_url,omitempty"`
+}
+
+// DeviceFlowStartResponse is returned by DeviceFlowStart.
+type DeviceFlowStartResponse struct {
+	FlowID          string `json:"flow_id"`
+	UserCode        string `json:"user_code"`
+	VerificationURI string `json:"verification_uri"`
+	Interval        int    `json:"interval"`
+	ExpiresIn       int    `json:"expires_in"`
+}
+
+// DeviceFlowPollResponse is returned by DeviceFlowPoll.
+type DeviceFlowPollResponse struct {
+	Status   string `json:"status"` // "pending", "slow_down", "expired", "denied", "complete", "error"
+	Interval int    `json:"interval,omitempty"`
+	Error    string `json:"error,omitempty"`
 }
 
 // ActionDisplayNames parses the Actions field (which may be []string or []object)

--- a/internal/tui/screens/services.go
+++ b/internal/tui/screens/services.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/textinput"
@@ -39,14 +40,26 @@ type oauthURLMsg struct {
 
 type oauthDoneMsg struct{}
 
+type deviceFlowStartedMsg struct {
+	resp *client.DeviceFlowStartResponse
+	err  error
+}
+
+type deviceFlowPollMsg struct {
+	resp *client.DeviceFlowPollResponse
+	err  error
+}
+
 // ── Input steps ─────────────────────────────────────────────────────────────
 
 const (
-	stepNone         = 0
-	stepAlias        = 1
-	stepKeyEntry     = 2
-	stepOAuthConfirm = 3
-	stepOAuthWaiting = 4
+	stepNone               = 0
+	stepAlias              = 1
+	stepKeyEntry           = 2
+	stepOAuthConfirm       = 3
+	stepOAuthWaiting       = 4
+	stepDeviceFlowChoice   = 5
+	stepDeviceFlowWaiting  = 6
 )
 
 // ── Model ───────────────────────────────────────────────────────────────────
@@ -76,6 +89,13 @@ type ServicesScreen struct {
 	// OAuth completion listener.
 	oauthDoneCh chan struct{}
 	oauthCleanup func()
+
+	// Device flow state.
+	deviceFlowUserCode string
+	deviceFlowURI      string
+	deviceFlowID       string
+	deviceFlowInterval int
+	deviceFlowChoice   int // 0 = device flow (default), 1 = API key
 }
 
 func NewServicesScreen(c *client.Client) *ServicesScreen {
@@ -215,6 +235,59 @@ func (s *ServicesScreen) Update(msg tea.Msg) (tui.ScreenModel, tea.Cmd) {
 		}
 	}
 
+	// Device flow choice overlay.
+	if s.inputStep == stepDeviceFlowChoice {
+		if msg, isKey := msg.(tea.KeyMsg); isKey {
+			switch msg.String() {
+			case "esc":
+				s.resetActivation()
+				return s, nil
+			case "up", "k":
+				if s.deviceFlowChoice > 0 {
+					s.deviceFlowChoice--
+				}
+				return s, nil
+			case "down", "j":
+				if s.deviceFlowChoice < 1 {
+					s.deviceFlowChoice++
+				}
+				return s, nil
+			case "enter":
+				if s.deviceFlowChoice == 1 {
+					// API key path.
+					s.inputStep = stepKeyEntry
+					ki := textinput.New()
+					ki.Placeholder = "paste token here"
+					ki.EchoMode = textinput.EchoPassword
+					ki.Focus()
+					s.keyInput = &ki
+					return s, nil
+				}
+				// Device flow path.
+				cl := s.client
+				serviceID := s.activatingService.ID
+				alias := s.pendingAlias
+				return s, func() tea.Msg {
+					resp, err := cl.DeviceFlowStart(serviceID, alias)
+					return deviceFlowStartedMsg{resp: resp, err: err}
+				}
+			}
+			return s, nil
+		}
+	}
+
+	// Device flow waiting overlay.
+	if s.inputStep == stepDeviceFlowWaiting {
+		if msg, isKey := msg.(tea.KeyMsg); isKey {
+			switch msg.String() {
+			case "esc":
+				s.resetActivation()
+				return s, nil
+			}
+			return s, nil
+		}
+	}
+
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		s.width = msg.Width
@@ -282,6 +355,45 @@ func (s *ServicesScreen) Update(msg tea.Msg) (tui.ScreenModel, tea.Cmd) {
 		cmds = append(cmds, s.fetchServices())
 		return s, tea.Batch(cmds...)
 
+	case deviceFlowStartedMsg:
+		if msg.err != nil {
+			s.err = msg.err
+			s.resetActivation()
+			return s, nil
+		}
+		s.deviceFlowUserCode = msg.resp.UserCode
+		s.deviceFlowURI = msg.resp.VerificationURI
+		s.deviceFlowID = msg.resp.FlowID
+		s.deviceFlowInterval = msg.resp.Interval
+		s.inputStep = stepDeviceFlowWaiting
+		browser.Open(msg.resp.VerificationURI)
+		return s, s.pollDeviceFlow()
+
+	case deviceFlowPollMsg:
+		if msg.err != nil {
+			s.err = msg.err
+			s.resetActivation()
+			return s, nil
+		}
+		switch msg.resp.Status {
+		case "complete":
+			s.resetActivation()
+			cmds = append(cmds, func() tea.Msg {
+				return tui.StatusMsg("Service connected")
+			})
+			cmds = append(cmds, s.fetchServices())
+			return s, tea.Batch(cmds...)
+		case "pending":
+			return s, s.pollDeviceFlow()
+		case "slow_down":
+			s.deviceFlowInterval = msg.resp.Interval
+			return s, s.pollDeviceFlow()
+		default: // expired, denied, error
+			s.err = fmt.Errorf("device flow: %s", msg.resp.Status)
+			s.resetActivation()
+			return s, nil
+		}
+
 	case svcActivatedMsg:
 		s.resetActivation()
 		if msg.err != nil {
@@ -333,6 +445,12 @@ func (s *ServicesScreen) View() string {
 	}
 	if s.inputStep == stepOAuthWaiting {
 		return s.viewOAuthWaiting()
+	}
+	if s.inputStep == stepDeviceFlowChoice {
+		return s.viewDeviceFlowChoice()
+	}
+	if s.inputStep == stepDeviceFlowWaiting {
+		return s.viewDeviceFlowWaiting()
 	}
 
 	var b strings.Builder
@@ -522,6 +640,66 @@ func (s *ServicesScreen) viewOAuthWaiting() string {
 	return tui.StyleOverlayBorder.Width(s.overlayWidth()).Render(content)
 }
 
+func (s *ServicesScreen) viewDeviceFlowChoice() string {
+	svcName := ""
+	if s.activatingService != nil {
+		svcName = s.activatingService.Name
+	}
+	title := lipgloss.NewStyle().
+		Foreground(tui.ColorBrand).
+		Bold(true).
+		Render("Connect " + svcName)
+
+	opts := []string{"Sign in with GitHub (browser)", "Paste a Personal Access Token"}
+	var optLines strings.Builder
+	for i, opt := range opts {
+		cursor := "  "
+		if i == s.deviceFlowChoice {
+			cursor = tui.StyleBrand.Render("> ")
+		}
+		optLines.WriteString(cursor + opt + "\n")
+	}
+
+	content := fmt.Sprintf("%s\n\n%s\n%s",
+		title,
+		optLines.String(),
+		tui.StyleDim.Render("[enter] Select  [esc] Cancel"),
+	)
+	return tui.StyleOverlayBorder.Width(s.overlayWidth()).Render(content)
+}
+
+func (s *ServicesScreen) viewDeviceFlowWaiting() string {
+	svcName := ""
+	if s.activatingService != nil {
+		svcName = s.activatingService.Name
+	}
+	title := lipgloss.NewStyle().
+		Foreground(tui.ColorBrand).
+		Bold(true).
+		Render("Connect " + svcName)
+
+	content := fmt.Sprintf("%s\n\n%s\n%s\n\n%s\n\n%s",
+		title,
+		"Enter this code in your browser:",
+		lipgloss.NewStyle().Bold(true).Render("  "+s.deviceFlowUserCode),
+		tui.StyleDim.Render(s.deviceFlowURI),
+		tui.StyleAmber.Render("Waiting for authorization...  ")+tui.StyleDim.Render("[esc] Cancel"),
+	)
+	return tui.StyleOverlayBorder.Width(s.overlayWidth()).Render(content)
+}
+
+func (s *ServicesScreen) pollDeviceFlow() tea.Cmd {
+	cl := s.client
+	serviceID := s.activatingService.ID
+	flowID := s.deviceFlowID
+	interval := s.deviceFlowInterval
+	return func() tea.Msg {
+		time.Sleep(time.Duration(interval) * time.Second)
+		resp, err := cl.DeviceFlowPoll(serviceID, flowID)
+		return deviceFlowPollMsg{resp: resp, err: err}
+	}
+}
+
 // ── Activation flow ─────────────────────────────────────────────────────────
 
 func (s *ServicesScreen) startActivation() tea.Cmd {
@@ -573,6 +751,13 @@ func (s *ServicesScreen) proceedAfterAlias() tea.Cmd {
 			resp, err := cl.GetOAuthURL(serviceID, alias, cliCallback)
 			return oauthURLMsg{resp: resp, err: err}
 		}
+	}
+
+	if svc.DeviceFlow {
+		// Show choice: device flow or API key.
+		s.inputStep = stepDeviceFlowChoice
+		s.deviceFlowChoice = 0
+		return nil
 	}
 
 	// API key service — show key input.
@@ -676,6 +861,11 @@ func (s *ServicesScreen) resetActivation() {
 	s.pendingAlias = ""
 	s.pendingOAuthURL = ""
 	s.activatingService = nil
+	s.deviceFlowUserCode = ""
+	s.deviceFlowURI = ""
+	s.deviceFlowID = ""
+	s.deviceFlowInterval = 0
+	s.deviceFlowChoice = 0
 }
 
 func (s *ServicesScreen) stopOAuthListener() {
@@ -721,6 +911,8 @@ func (s *ServicesScreen) showDetail() {
 		b.WriteString("None (local)")
 	} else if svc.OAuth {
 		b.WriteString("OAuth")
+	} else if svc.DeviceFlow {
+		b.WriteString("OAuth (device flow) or API key")
 	} else {
 		b.WriteString("API key")
 	}

--- a/pkg/adapters/adapters.go
+++ b/pkg/adapters/adapters.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 
 	"golang.org/x/oauth2"
+
+	"github.com/clawvisor/clawvisor/pkg/adapters/yamldef"
 )
 
 // ── Metadata types ──────────────────────────────────────────────────────────
@@ -23,6 +25,7 @@ type ServiceMetadata struct {
 	SetupURL          string
 	VaultKey          string                // shared vault key (e.g. "google" for all google.* services); empty = use service ID
 	OAuthEndpoint     string                // well-known OAuth endpoint name (e.g. "google"); empty = not OAuth or no known endpoint
+	DeviceFlow        bool                  // whether device flow activation is available
 	ActionMeta        map[string]ActionMeta // action_id → metadata
 	VerificationHints string
 }
@@ -41,6 +44,12 @@ type ActionInfo struct {
 	DisplayName string `json:"display_name"`
 	Category    string `json:"category"`
 	Sensitivity string `json:"sensitivity"`
+}
+
+// DeviceFlowProvider is an optional interface for adapters that support
+// OAuth2 device authorization grant (RFC 8628).
+type DeviceFlowProvider interface {
+	DeviceFlowConfig() *yamldef.DeviceFlowDef
 }
 
 // OAuthCredentialProvider supplies OAuth app credentials (client_id, client_secret)

--- a/pkg/adapters/yamldef/schema.go
+++ b/pkg/adapters/yamldef/schema.go
@@ -24,11 +24,23 @@ type AuthDef struct {
 	Header       string            `yaml:"header,omitempty"`
 	HeaderPrefix string            `yaml:"header_prefix,omitempty"`
 	ExtraHeaders map[string]string `yaml:"extra_headers,omitempty"`
-	OAuth        *OAuthDef         `yaml:"oauth,omitempty"`
+	OAuth      *OAuthDef      `yaml:"oauth,omitempty"`
+	DeviceFlow *DeviceFlowDef `yaml:"device_flow,omitempty"`
 
 	// For basic auth where the credential is a composite "user:pass" string.
 	// The token field is split on ":" to produce user/pass for BasicAuth.
 	BasicSplit bool `yaml:"basic_split,omitempty"`
+}
+
+// DeviceFlowDef holds configuration for OAuth2 device authorization grant (RFC 8628).
+// This allows CLI/native apps to authenticate without a client secret.
+type DeviceFlowDef struct {
+	ClientID      string   `yaml:"client_id,omitempty"`       // hardcoded client_id (public, safe to ship)
+	ClientIDEnv   string   `yaml:"client_id_env,omitempty"`   // env var name for client_id override
+	Scopes        []string `yaml:"scopes"`                    // requested OAuth scopes
+	DeviceCodeURL string   `yaml:"device_code_url"`           // e.g. "https://github.com/login/device/code"
+	TokenURL      string   `yaml:"token_url"`                 // e.g. "https://github.com/login/oauth/access_token"
+	GrantType     string   `yaml:"grant_type,omitempty"`      // default: "urn:ietf:params:oauth:grant-type:device_code"
 }
 
 // OAuthDef holds OAuth2-specific configuration.

--- a/pkg/adapters/yamlruntime/adapter.go
+++ b/pkg/adapters/yamlruntime/adapter.go
@@ -252,6 +252,7 @@ func (a *YAMLAdapter) ServiceMetadata() adapters.ServiceMetadata {
 		SetupURL:          a.def.Service.SetupURL,
 		VaultKey:          vaultKey,
 		OAuthEndpoint:     oauthEndpoint,
+		DeviceFlow:        a.def.Auth.DeviceFlow != nil && a.resolveDeviceFlowClientID() != "",
 		ActionMeta:        actionMeta,
 		VerificationHints: a.def.VerificationHints,
 	}
@@ -267,6 +268,33 @@ func (a *YAMLAdapter) VerificationHints() string {
 // SetOAuthProvider sets the provider that supplies OAuth app credentials lazily.
 func (a *YAMLAdapter) SetOAuthProvider(p adapters.OAuthCredentialProvider) {
 	a.oauthProvider = p
+}
+
+// DeviceFlowConfig returns the device flow configuration if available and
+// a client_id can be resolved. Implements adapters.DeviceFlowProvider.
+func (a *YAMLAdapter) DeviceFlowConfig() *yamldef.DeviceFlowDef {
+	if a.def.Auth.DeviceFlow == nil {
+		return nil
+	}
+	if a.resolveDeviceFlowClientID() == "" {
+		return nil
+	}
+	return a.def.Auth.DeviceFlow
+}
+
+// resolveDeviceFlowClientID returns the client_id for device flow,
+// checking env var first then the hardcoded value.
+func (a *YAMLAdapter) resolveDeviceFlowClientID() string {
+	df := a.def.Auth.DeviceFlow
+	if df == nil {
+		return ""
+	}
+	if df.ClientIDEnv != "" {
+		if v := os.Getenv(df.ClientIDEnv); v != "" {
+			return v
+		}
+	}
+	return df.ClientID
 }
 
 // Def returns the underlying YAML definition (for the loader/tests).


### PR DESCRIPTION
## Summary
- Adds OAuth device flow (RFC 8628) as an alternative to PAT for GitHub authentication
- Ships a default public `client_id` so it works out of the box — no client secret needed, nothing sensitive in the repo
- Users choose between "Sign in with GitHub (browser)" and "Paste a Personal Access Token" during setup
- Fixes `search_code` action param mapping (`query` → `q`)

## Changes
- **YAML schema**: new `DeviceFlowDef` type and `device_flow` field on `AuthDef`
- **github.yaml**: device flow config with hardcoded client_id, scopes, and GitHub URLs
- **Adapter layer**: `DeviceFlowProvider` interface, `DeviceFlow` flag in `ServiceMetadata`
- **API**: two new endpoints — `POST /api/services/{serviceID}/device-flow/start` and `.../poll`
- **Daemon CLI**: choice prompt + poll loop for device flow activation
- **TUI**: device flow choice overlay, waiting screen with user code display, automatic polling

## Test plan
- [ ] Set `GITHUB_CLIENT_ID` or use the hardcoded default
- [ ] Run `clawvisor setup` → select GitHub → choose "Sign in with GitHub (browser)"
- [ ] Verify user code + verification URI are displayed and browser opens
- [ ] Complete authorization in browser → verify "connected" confirmation
- [ ] Verify GitHub API calls work with the device flow token
- [ ] Verify "Paste a Personal Access Token" path still works
- [ ] Verify TUI services screen shows device flow choice and waiting overlays

🤖 Generated with [Claude Code](https://claude.com/claude-code)