### PR TITLE
feat: add param docs to catalog with compact overview and detail view

### DIFF
--- a/internal/adapters/apple/imessage/adapter.go
+++ b/internal/adapters/apple/imessage/adapter.go
@@ -84,14 +84,42 @@ func (a *IMessageAdapter) ValidateCredential(_ []byte) error { return nil }
 
 // ServiceMetadata returns display and risk metadata for iMessage.
 func (a *IMessageAdapter) ServiceMetadata() adapters.ServiceMetadata {
+	maxThreads := 50
 	return adapters.ServiceMetadata{
 		DisplayName: "iMessage",
 		Description: "Search and read iMessage threads",
 		ActionMeta: map[string]adapters.ActionMeta{
-			"search_messages": {DisplayName: "Search messages", Category: "search", Sensitivity: "low", Description: "Search iMessage history"},
-			"list_threads":    {DisplayName: "List threads", Category: "read", Sensitivity: "low", Description: "List iMessage conversation threads"},
-			"get_thread":      {DisplayName: "Get thread", Category: "read", Sensitivity: "low", Description: "Read a specific iMessage thread"},
-			"send_message":    {DisplayName: "Send message", Category: "write", Sensitivity: "high", Description: "Send an iMessage (requires per-request approval)"},
+			"search_messages": {
+				DisplayName: "Search messages", Category: "search", Sensitivity: "low",
+				Description: "Search iMessage history",
+				Params: []adapters.ParamMeta{
+					{Name: "query", Type: "string", Required: true},
+					{Name: "contact", Type: "string"},
+				},
+			},
+			"list_threads": {
+				DisplayName: "List threads", Category: "read", Sensitivity: "low",
+				Description: "List iMessage conversation threads",
+				Params: []adapters.ParamMeta{
+					{Name: "max_results", Type: "int", Default: 20, Max: &maxThreads},
+				},
+			},
+			"get_thread": {
+				DisplayName: "Get thread", Category: "read", Sensitivity: "low",
+				Description: "Read a specific iMessage thread",
+				Params: []adapters.ParamMeta{
+					{Name: "contact", Type: "string"},
+					{Name: "thread_id", Type: "string"},
+				},
+			},
+			"send_message": {
+				DisplayName: "Send message", Category: "write", Sensitivity: "high",
+				Description: "Send an iMessage (requires per-request approval)",
+				Params: []adapters.ParamMeta{
+					{Name: "to", Type: "string", Required: true},
+					{Name: "text", Type: "string", Required: true},
+				},
+			},
 		},
 	}
 }

--- a/internal/adapters/definitions/google_drive.yaml
+++ b/internal/adapters/definitions/google_drive.yaml
@@ -47,16 +47,26 @@ actions:
     display_name: "Get file"
     risk: { category: read, sensitivity: low, description: "Read a specific file from Google Drive" }
     override: go
+    params:
+      file_id: { type: string, required: true }
 
   create_file:
     display_name: "Create file"
     risk: { category: write, sensitivity: medium, description: "Create a file in Google Drive" }
     override: go
+    params:
+      name: { type: string, required: true }
+      content: { type: string, required: true }
+      mime_type: { type: string }
+      parent_folder_id: { type: string }
 
   update_file:
     display_name: "Update file"
     risk: { category: write, sensitivity: medium, description: "Update a file in Google Drive" }
     override: go
+    params:
+      file_id: { type: string, required: true }
+      content: { type: string, required: true }
 
   search_files:
     display_name: "Search files"

--- a/internal/adapters/definitions/google_gmail.yaml
+++ b/internal/adapters/definitions/google_gmail.yaml
@@ -27,6 +27,9 @@ actions:
     display_name: "List messages"
     risk: { category: read, sensitivity: low, description: "List email messages" }
     override: go
+    params:
+      query: { type: string }
+      max_results: { type: int, default: 10, max: 50 }
 
   get_message:
     display_name: "Get message"
@@ -61,8 +64,18 @@ actions:
     display_name: "Send message"
     risk: { category: write, sensitivity: high, description: "Send email as the user" }
     override: go
+    params:
+      to: { type: string, required: true }
+      subject: { type: string, required: true }
+      body: { type: string }
+      in_reply_to: { type: string }
 
   create_draft:
     display_name: "Create draft"
     risk: { category: write, sensitivity: low, description: "Create an email draft (not sent)" }
     override: go
+    params:
+      to: { type: string, required: true }
+      subject: { type: string, required: true }
+      body: { type: string }
+      in_reply_to: { type: string }

--- a/internal/api/handlers/skill.go
+++ b/internal/api/handlers/skill.go
@@ -1,14 +1,15 @@
 package handlers
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"sort"
 	"strings"
 
-	"github.com/clawvisor/clawvisor/pkg/adapters"
 	"github.com/clawvisor/clawvisor/internal/api/middleware"
+	"github.com/clawvisor/clawvisor/pkg/adapters"
 	"github.com/clawvisor/clawvisor/pkg/store"
 	"github.com/clawvisor/clawvisor/pkg/vault"
 )
@@ -32,10 +33,18 @@ func NewSkillHandler(
 	}
 }
 
+// catalogEntry groups all activated aliases for a single base service.
+type catalogEntry struct {
+	baseID  string   // adapter service ID, e.g. "google.gmail"
+	aliases []string // activated display IDs (e.g. ["google.gmail", "google.gmail:personal"])
+	actions []string
+}
+
 // Catalog returns a personalized markdown document listing only the agent's
 // activated services (with restriction-filtered actions).
 //
 // GET /api/skill/catalog
+// GET /api/skill/catalog?service=google.gmail   (detailed single-service view)
 // Auth: agent bearer token
 func (h *SkillHandler) Catalog(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -56,12 +65,6 @@ func (h *SkillHandler) Catalog(w http.ResponseWriter, r *http.Request) {
 	// Load service metas for alias display.
 	metas, _ := h.st.ListServiceMetas(ctx, agent.UserID)
 
-	type catalogService struct {
-		id      string // display ID, e.g. "google.gmail" or "google.gmail:personal"
-		baseID  string // adapter service ID, e.g. "google.gmail"
-		actions []string
-	}
-
 	// Build the adapter metadata index for action descriptions.
 	adapterMeta := map[string]adapters.ServiceMetadata{} // serviceID → metadata
 	allAdapters := h.adapterReg.All()
@@ -71,108 +74,223 @@ func (h *SkillHandler) Catalog(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Only collect activated services.
-	var services []catalogService
+	// Collect activated services, grouped by base service ID.
+	entries := map[string]*catalogEntry{} // baseID → entry
 	for _, a := range allAdapters {
+		baseID := a.ServiceID()
 		credentialFree := a.ValidateCredential(nil) == nil
 		if credentialFree {
-			// Credential-free services (e.g. iMessage) require explicit
-			// activation via service_meta, same as the gateway check.
 			for _, m := range metas {
-				if m.ServiceID == a.ServiceID() {
-					services = append(services, catalogService{
-						id: a.ServiceID(), baseID: a.ServiceID(),
+				if m.ServiceID == baseID {
+					entries[baseID] = &catalogEntry{
+						baseID: baseID, aliases: []string{baseID},
 						actions: a.SupportedActions(),
-					})
+					}
 					break
 				}
 			}
 			continue
 		}
 
-		// Show each activated alias as a separate catalog entry.
 		shown := false
 		for _, m := range metas {
-			if m.ServiceID != a.ServiceID() {
+			if m.ServiceID != baseID {
 				continue
 			}
-			vKey := h.adapterReg.VaultKeyWithAlias(a.ServiceID(), m.Alias)
+			vKey := h.adapterReg.VaultKeyWithAlias(baseID, m.Alias)
 			if !keySet[vKey] {
 				continue
 			}
 			shown = true
-			displayID := a.ServiceID()
+			displayID := baseID
 			if m.Alias != "default" {
-				displayID = a.ServiceID() + ":" + m.Alias
+				displayID = baseID + ":" + m.Alias
 			}
-			services = append(services, catalogService{
-				id: displayID, baseID: a.ServiceID(),
-				actions: a.SupportedActions(),
-			})
+			if e, ok := entries[baseID]; ok {
+				e.aliases = append(e.aliases, displayID)
+			} else {
+				entries[baseID] = &catalogEntry{
+					baseID: baseID, aliases: []string{displayID},
+					actions: a.SupportedActions(),
+				}
+			}
 		}
 
-		// Fallback: check base vault key (handles pre-existing activations
-		// that may not have a service_meta row). Skip when the service uses
-		// a shared vault key (e.g. all google.* services share "google").
 		if !shown {
-			baseKey := h.adapterReg.VaultKey(a.ServiceID())
-			usesSharedKey := baseKey != a.ServiceID()
+			baseKey := h.adapterReg.VaultKey(baseID)
+			usesSharedKey := baseKey != baseID
 			if !usesSharedKey && keySet[baseKey] {
-				services = append(services, catalogService{
-					id: a.ServiceID(), baseID: a.ServiceID(),
+				entries[baseID] = &catalogEntry{
+					baseID: baseID, aliases: []string{baseID},
 					actions: a.SupportedActions(),
-				})
+				}
 			}
 		}
 	}
-	sort.Slice(services, func(i, j int) bool { return services[i].id < services[j].id })
+
+	// Sort entries by base ID.
+	sorted := make([]*catalogEntry, 0, len(entries))
+	for _, e := range entries {
+		sort.Strings(e.aliases)
+		sorted = append(sorted, e)
+	}
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].baseID < sorted[j].baseID })
+
+	// Check for ?service= filter for detailed single-service view.
+	serviceFilter := r.URL.Query().Get("service")
 
 	var buf strings.Builder
-	buf.WriteString("# Your Clawvisor Service Catalog\n\n")
 
-	if len(services) == 0 {
-		buf.WriteString("No services are currently activated.\n\n")
-		buf.WriteString("To activate a service, direct the user to the Clawvisor dashboard.\n")
+	if serviceFilter != "" {
+		h.writeServiceDetail(&buf, ctx, serviceFilter, sorted, adapterMeta, agent.UserID)
 	} else {
-		for _, svc := range services {
-			// Service heading — include description if available.
-			buf.WriteString(fmt.Sprintf("## %s\n", svc.id))
-			if meta, ok := adapterMeta[svc.baseID]; ok && meta.Description != "" {
-				buf.WriteString(fmt.Sprintf("_%s_\n", meta.Description))
-			}
-			buf.WriteString("\n")
-
-			for _, action := range svc.actions {
-				// If a restriction matches this action (exact or base service), skip it.
-				restriction, _ := h.st.MatchRestriction(ctx, agent.UserID, svc.id, action)
-				if restriction == nil && svc.id != svc.baseID {
-					restriction, _ = h.st.MatchRestriction(ctx, agent.UserID, svc.baseID, action)
-				}
-				if restriction != nil {
-					continue
-				}
-
-				// All non-restricted actions require approval unless covered by a task.
-				label := " (requires approval or task)"
-
-				// Read action metadata from MetadataProvider.
-				if meta, ok := adapterMeta[svc.baseID]; ok {
-					if am, ok := meta.ActionMeta[action]; ok {
-						desc := am.Description
-						if desc == "" {
-							desc = am.DisplayName
-						}
-						buf.WriteString(fmt.Sprintf("**%s**%s — %s\n", action, label, desc))
-						buf.WriteString(fmt.Sprintf("  Category: %s, Sensitivity: %s\n\n", am.Category, am.Sensitivity))
-						continue
-					}
-				}
-				buf.WriteString(fmt.Sprintf("**%s**%s\n\n", action, label))
-			}
-		}
+		h.writeCatalogOverview(&buf, ctx, sorted, adapterMeta, agent.UserID)
 	}
 
 	w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte(buf.String()))
+}
+
+// writeCatalogOverview renders the compact multi-service catalog.
+func (h *SkillHandler) writeCatalogOverview(buf *strings.Builder, ctx context.Context, entries []*catalogEntry, adapterMeta map[string]adapters.ServiceMetadata, userID string) {
+	buf.WriteString("# Your Clawvisor Service Catalog\n\n")
+
+	if len(entries) == 0 {
+		buf.WriteString("No services are currently activated.\n\n")
+		buf.WriteString("To activate a service, direct the user to the Clawvisor dashboard.\n")
+		return
+	}
+
+	buf.WriteString("_For detailed parameter docs, fetch `?service=<service_id>`._\n\n")
+
+	for _, entry := range entries {
+		buf.WriteString(fmt.Sprintf("## %s\n", entry.baseID))
+		if meta, ok := adapterMeta[entry.baseID]; ok && meta.Description != "" {
+			buf.WriteString(fmt.Sprintf("_%s_\n", meta.Description))
+		}
+
+		// Show aliases if more than one, or if the single alias differs from baseID.
+		if len(entry.aliases) > 1 || (len(entry.aliases) == 1 && entry.aliases[0] != entry.baseID) {
+			buf.WriteString(fmt.Sprintf("Accounts: %s\n", strings.Join(entry.aliases, ", ")))
+		}
+		buf.WriteString("\n")
+
+		for _, action := range entry.actions {
+			if h.isRestricted(ctx, userID, entry, action) {
+				continue
+			}
+
+			// Build the action line with compact param signature.
+			if meta, ok := adapterMeta[entry.baseID]; ok {
+				if am, ok := meta.ActionMeta[action]; ok {
+					desc := am.Description
+					if desc == "" {
+						desc = am.DisplayName
+					}
+					paramSig := compactParamSig(am.Params)
+					buf.WriteString(fmt.Sprintf("- **%s**%s \u2014 %s\n", action, paramSig, desc))
+					continue
+				}
+			}
+			buf.WriteString(fmt.Sprintf("- **%s** \u2014 (requires approval or task)\n", action))
+		}
+		buf.WriteString("\n")
+	}
+}
+
+// writeServiceDetail renders the detailed view for a single service.
+func (h *SkillHandler) writeServiceDetail(buf *strings.Builder, ctx context.Context, serviceID string, entries []*catalogEntry, adapterMeta map[string]adapters.ServiceMetadata, userID string) {
+	// Find the matching entry.
+	var entry *catalogEntry
+	for _, e := range entries {
+		if e.baseID == serviceID {
+			entry = e
+			break
+		}
+	}
+	if entry == nil {
+		buf.WriteString(fmt.Sprintf("Service %q is not activated or does not exist.\n", serviceID))
+		return
+	}
+
+	buf.WriteString(fmt.Sprintf("# %s\n", entry.baseID))
+	if meta, ok := adapterMeta[entry.baseID]; ok && meta.Description != "" {
+		buf.WriteString(fmt.Sprintf("_%s_\n", meta.Description))
+	}
+	if len(entry.aliases) > 1 || (len(entry.aliases) == 1 && entry.aliases[0] != entry.baseID) {
+		buf.WriteString(fmt.Sprintf("Accounts: %s\n", strings.Join(entry.aliases, ", ")))
+	}
+	buf.WriteString("\n")
+
+	for _, action := range entry.actions {
+		if h.isRestricted(ctx, userID, entry, action) {
+			continue
+		}
+
+		if meta, ok := adapterMeta[entry.baseID]; ok {
+			if am, ok := meta.ActionMeta[action]; ok {
+				desc := am.Description
+				if desc == "" {
+					desc = am.DisplayName
+				}
+				buf.WriteString(fmt.Sprintf("## %s\n", action))
+				buf.WriteString(fmt.Sprintf("%s\n", desc))
+				buf.WriteString(fmt.Sprintf("Category: %s, Sensitivity: %s\n", am.Category, am.Sensitivity))
+				if len(am.Params) > 0 {
+					buf.WriteString("Parameters:\n")
+					for _, p := range am.Params {
+						reqTag := "optional"
+						if p.Required {
+							reqTag = "**required**"
+						}
+						extras := []string{p.Type, reqTag}
+						if p.Default != nil {
+							extras = append(extras, fmt.Sprintf("default: %v", p.Default))
+						}
+						if p.Min != nil {
+							extras = append(extras, fmt.Sprintf("min: %d", *p.Min))
+						}
+						if p.Max != nil {
+							extras = append(extras, fmt.Sprintf("max: %d", *p.Max))
+						}
+						buf.WriteString(fmt.Sprintf("- `%s` (%s)\n", p.Name, strings.Join(extras, ", ")))
+					}
+				}
+				buf.WriteString("\n")
+				continue
+			}
+		}
+		buf.WriteString(fmt.Sprintf("## %s\n(requires approval or task)\n\n", action))
+	}
+}
+
+// isRestricted returns true if the action is restricted on all aliases of the entry.
+func (h *SkillHandler) isRestricted(ctx context.Context, userID string, entry *catalogEntry, action string) bool {
+	for _, alias := range entry.aliases {
+		restriction, _ := h.st.MatchRestriction(ctx, userID, alias, action)
+		if restriction == nil && alias != entry.baseID {
+			restriction, _ = h.st.MatchRestriction(ctx, userID, entry.baseID, action)
+		}
+		if restriction == nil {
+			return false
+		}
+	}
+	return true
+}
+
+// compactParamSig builds a compact inline parameter signature like "(to, subject, body?, in_reply_to?)".
+func compactParamSig(params []adapters.ParamMeta) string {
+	if len(params) == 0 {
+		return ""
+	}
+	parts := make([]string, len(params))
+	for i, p := range params {
+		if p.Required {
+			parts[i] = p.Name
+		} else {
+			parts[i] = p.Name + "?"
+		}
+	}
+	return "(" + strings.Join(parts, ", ") + ")"
 }

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -26,8 +26,8 @@ func toolDefs() []Tool {
 	return []Tool{
 		{
 			Name:        "fetch_catalog",
-			Description: "Fetch the service catalog showing all available services, actions, and their parameters for this user.",
-			InputSchema: json.RawMessage(`{"type":"object","properties":{}}`),
+			Description: "Fetch the service catalog. Returns an overview of all activated services with compact parameter signatures. Pass a service ID to get detailed parameter docs for that service.",
+			InputSchema: json.RawMessage(`{"type":"object","properties":{"service":{"type":"string","description":"Optional service ID (e.g. google.gmail) to get detailed parameter documentation for a single service"}}}`),
 		},
 		{
 			Name:        "create_task",

--- a/internal/mcp/tools_exec.go
+++ b/internal/mcp/tools_exec.go
@@ -121,7 +121,11 @@ func buildInternalRequest(toolName string, arguments json.RawMessage) (internalR
 
 	switch toolName {
 	case "fetch_catalog":
-		return internalRoute{"GET", "/api/skill/catalog", "GET /api/skill/catalog", nil}, nil, nil
+		path := "/api/skill/catalog"
+		if svc := getString("service"); svc != "" {
+			path += "?service=" + svc
+		}
+		return internalRoute{"GET", path, "GET /api/skill/catalog", nil}, nil, nil
 
 	case "create_task":
 		path := "/api/tasks"

--- a/pkg/adapters/adapters.go
+++ b/pkg/adapters/adapters.go
@@ -32,10 +32,21 @@ type ServiceMetadata struct {
 
 // ActionMeta holds display and risk metadata for a single action.
 type ActionMeta struct {
-	DisplayName string // "List customers"
-	Category    string // "read", "write", "delete", "search"
-	Sensitivity string // "low", "medium", "high"
-	Description string // "List Stripe customers" (for risk assessment)
+	DisplayName string      // "List customers"
+	Category    string      // "read", "write", "delete", "search"
+	Sensitivity string      // "low", "medium", "high"
+	Description string      // "List Stripe customers" (for risk assessment)
+	Params      []ParamMeta // ordered parameter documentation
+}
+
+// ParamMeta holds documentation metadata for a single action parameter.
+type ParamMeta struct {
+	Name     string // parameter name as passed in the request
+	Type     string // "string", "int", "bool", "object", "array"
+	Required bool
+	Default  any    // default value, nil if none
+	Min      *int   // minimum value (for int params)
+	Max      *int   // maximum value (for int params)
 }
 
 // ActionInfo is returned by the service catalog with per-action metadata.

--- a/pkg/adapters/yamlruntime/adapter.go
+++ b/pkg/adapters/yamlruntime/adapter.go
@@ -232,12 +232,42 @@ func (a *YAMLAdapter) buildAuthClient(ctx context.Context, credBytes []byte) (*h
 func (a *YAMLAdapter) ServiceMetadata() adapters.ServiceMetadata {
 	actionMeta := make(map[string]adapters.ActionMeta, len(a.def.Actions))
 	for name, action := range a.def.Actions {
-		actionMeta[name] = adapters.ActionMeta{
+		am := adapters.ActionMeta{
 			DisplayName: action.DisplayName,
 			Category:    action.Risk.Category,
 			Sensitivity: action.Risk.Sensitivity,
 			Description: action.Risk.Description,
 		}
+		// Build ordered parameter metadata from YAML params.
+		if len(action.Params) > 0 {
+			names := make([]string, 0, len(action.Params))
+			for pn := range action.Params {
+				names = append(names, pn)
+			}
+			sort.Strings(names)
+			// Put required params first, then optional, preserving alpha within each group.
+			sort.SliceStable(names, func(i, j int) bool {
+				ri := action.Params[names[i]].Required
+				rj := action.Params[names[j]].Required
+				if ri != rj {
+					return ri
+				}
+				return false
+			})
+			am.Params = make([]adapters.ParamMeta, 0, len(names))
+			for _, pn := range names {
+				p := action.Params[pn]
+				am.Params = append(am.Params, adapters.ParamMeta{
+					Name:     pn,
+					Type:     p.Type,
+					Required: p.Required,
+					Default:  p.Default,
+					Min:      p.Min,
+					Max:      p.Max,
+				})
+			}
+		}
+		actionMeta[name] = am
 	}
 
 	var vaultKey, oauthEndpoint string


### PR DESCRIPTION
## Summary
- The skill catalog now surfaces parameter names, types, defaults, and constraints for every action. The overview uses compact inline signatures like `(to, subject, body?, in_reply_to?)` and groups multi-account aliases under one service heading.
- Agents can fetch `?service=<id>` for a detailed single-service view with full parameter documentation (type, required/optional, default, min/max).
- Adds parameter metadata to Go-override actions in Gmail and Drive YAMLs, and to the iMessage Go adapter, so all actions are now documented.
- The MCP `fetch_catalog` tool accepts an optional `service` argument to access the detail view.

## Test plan
- [x] `go build` passes on all changed packages
- [x] `go test` passes for `yamlruntime`, `handlers`, and `imessage` packages
- [ ] Manual: fetch catalog without `?service=` — verify compact param sigs and alias grouping
- [ ] Manual: fetch catalog with `?service=google.gmail` — verify detailed param docs
- [ ] Manual: MCP `fetch_catalog` with `{"service": "github"}` — verify detail view

🤖 Generated with [Claude Code](https://claude.com/claude-code)