### PR TITLE
feat: Slack OAuth PKCE flow

### DIFF
--- a/internal/adapters/definitions/slack.yaml
+++ b/internal/adapters/definitions/slack.yaml
@@ -10,6 +10,13 @@ auth:
   header_prefix: "Bearer "
   extra_headers:
     Content-Type: "application/json; charset=utf-8"
+  pkce_flow:
+    client_id: "10583998234834.10816798669877"
+    client_id_env: "SLACK_CLIENT_ID"
+    scopes: ["channels:read", "channels:history", "groups:read", "groups:history", "im:read", "im:history", "chat:write", "search:read", "users:read", "reactions:write", "files:read"]
+    authorize_url: "https://slack.com/oauth/v2/authorize"
+    token_url: "https://slack.com/api/oauth.v2.access"
+    token_path: "authed_user.access_token"
 
 verification_hints: >
   Thread-level parameters (e.g. thread_ts) are within the scope of the channel

--- a/internal/api/handlers/services.go
+++ b/internal/api/handlers/services.go
@@ -2,6 +2,9 @@ package handlers
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"html"
@@ -40,6 +43,13 @@ type ServicesHandler struct {
 
 	// deviceFlows holds pending device flow entries keyed by flow ID.
 	deviceFlows sync.Map // flowID (string) → deviceFlowEntry
+
+	// pkceFlows holds pending PKCE authorization code flow entries keyed by state token.
+	pkceFlows sync.Map // stateToken (string) → pkceFlowEntry
+
+	// relayDaemonURL is the public HTTPS URL via the relay (e.g. "https://relay.clawvisor.com/d/DAEMON_ID").
+	// Used as redirect_uri for PKCE flows that require HTTPS. Empty when relay is not configured.
+	relayDaemonURL string
 }
 
 type oauthStateEntry struct {
@@ -89,6 +99,9 @@ func NewServicesHandler(st store.Store, v vault.Vault, adapterReg *adapters.Regi
 	}
 }
 
+// SetRelayDaemonURL sets the public HTTPS relay URL used for PKCE flow redirects.
+func (h *ServicesHandler) SetRelayDaemonURL(u string) { h.relayDaemonURL = u }
+
 // List returns the service catalog with per-user activation status.
 //
 // GET /api/services
@@ -130,6 +143,7 @@ func (h *ServicesHandler) List(w http.ResponseWriter, r *http.Request) {
 		OAuth              bool          `json:"oauth"`
 		OAuthEndpoint      string        `json:"oauth_endpoint,omitempty"`
 		DeviceFlow         bool          `json:"device_flow,omitempty"`
+		PKCEFlow           bool          `json:"pkce_flow,omitempty"`
 		RequiresActivation bool          `json:"requires_activation"`
 		CredentialFree     bool          `json:"credential_free"`
 		Actions            []actionEntry `json:"actions"`
@@ -171,9 +185,11 @@ func (h *ServicesHandler) List(w http.ResponseWriter, r *http.Request) {
 			actions = append(actions, ae)
 		}
 
-		var deviceFlow bool
+		var deviceFlow, pkceFlow bool
 		if mp, ok2 := a.(adapters.MetadataProvider); ok2 {
-			deviceFlow = mp.ServiceMetadata().DeviceFlow
+			meta := mp.ServiceMetadata()
+			deviceFlow = meta.DeviceFlow
+			pkceFlow = meta.PKCEFlow
 		}
 
 		return serviceEntry{
@@ -183,6 +199,7 @@ func (h *ServicesHandler) List(w http.ResponseWriter, r *http.Request) {
 			OAuth:              len(a.RequiredScopes()) > 0,
 			OAuthEndpoint:      oauthEndpoint,
 			DeviceFlow:         deviceFlow,
+			PKCEFlow:           pkceFlow,
 			RequiresActivation: true,
 			Actions:            actions,
 			SetupURL:           setupURL,
@@ -1171,6 +1188,256 @@ func (h *ServicesHandler) DeviceFlowPoll(w http.ResponseWriter, r *http.Request)
 
 	h.logger.Info("service activated via device flow", "user", entry.UserID, "service", entry.ServiceID)
 	writeJSON(w, http.StatusOK, map[string]any{"status": "complete"})
+}
+
+// ── PKCE Flow (RFC 7636) ─────────────────────────────────────────────────────
+
+type pkceFlowEntry struct {
+	UserID       string
+	ServiceID    string
+	Alias        string
+	CodeVerifier string
+	CLICallback  string
+	TokenURL     string
+	TokenPath    string // JSON path to access token (e.g. "authed_user.access_token")
+	ClientID     string
+	RedirectURI  string
+	ExpiresAt    time.Time
+}
+
+// PKCEFlowStart initiates a PKCE authorization code flow.
+//
+// POST /api/services/{serviceID}/pkce-flow/start
+// Auth: user JWT
+// Body: {"alias": "...", "cli_callback": "http://127.0.0.1:PORT/oauth-done"}
+// Response: {"authorize_url": "https://...", "state": "..."}
+func (h *ServicesHandler) PKCEFlowStart(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "not authenticated")
+		return
+	}
+
+	serviceID := r.PathValue("serviceID")
+	if serviceID == "" {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "serviceID is required")
+		return
+	}
+
+	adapter, ok := h.adapterReg.Get(serviceID)
+	if !ok {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", fmt.Sprintf("service %q not found", serviceID))
+		return
+	}
+
+	pfp, ok := adapter.(adapters.PKCEFlowProvider)
+	if !ok {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "service does not support PKCE flow")
+		return
+	}
+	pfCfg := pfp.PKCEFlowConfig()
+	if pfCfg == nil {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "PKCE flow not configured (missing client_id)")
+		return
+	}
+
+	var body struct {
+		Alias       string `json:"alias"`
+		CLICallback string `json:"cli_callback"`
+	}
+	_ = json.NewDecoder(r.Body).Decode(&body)
+	alias := body.Alias
+	if alias == "" {
+		alias = "default"
+	}
+	if !validAlias(alias) {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "alias contains invalid characters")
+		return
+	}
+
+	// Resolve client_id.
+	clientID := pfCfg.ClientID
+	if pfCfg.ClientIDEnv != "" {
+		if v := os.Getenv(pfCfg.ClientIDEnv); v != "" {
+			clientID = v
+		}
+	}
+
+	// Generate PKCE code verifier and challenge.
+	verifierBytes := make([]byte, 32)
+	if _, err := rand.Read(verifierBytes); err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to generate PKCE verifier")
+		return
+	}
+	codeVerifier := base64.RawURLEncoding.EncodeToString(verifierBytes)
+	challengeHash := sha256.Sum256([]byte(codeVerifier))
+	codeChallenge := base64.RawURLEncoding.EncodeToString(challengeHash[:])
+
+	stateToken := uuid.New().String()
+
+	// PKCE flows require HTTPS redirect URIs (e.g. Slack). Use the relay
+	// daemon URL when available, falling back to the local baseURL.
+	redirectBase := h.relayDaemonURL
+	if redirectBase == "" {
+		redirectBase = h.baseURL
+	}
+	redirectURI := redirectBase + "/api/pkce-flow/callback"
+
+	h.pkceFlows.Store(stateToken, pkceFlowEntry{
+		UserID:       user.ID,
+		ServiceID:    serviceID,
+		Alias:        alias,
+		CodeVerifier: codeVerifier,
+		CLICallback:  validateCLICallback(body.CLICallback),
+		TokenURL:     pfCfg.TokenURL,
+		TokenPath:    pfCfg.TokenPath,
+		ClientID:     clientID,
+		RedirectURI:  redirectURI,
+		ExpiresAt:    time.Now().Add(10 * time.Minute),
+	})
+
+	// Build authorize URL.
+	params := url.Values{
+		"client_id":             {clientID},
+		"scope":                 {strings.Join(pfCfg.Scopes, " ")},
+		"redirect_uri":         {redirectURI},
+		"state":                 {stateToken},
+		"code_challenge":        {codeChallenge},
+		"code_challenge_method": {"S256"},
+		"response_type":         {"code"},
+	}
+	// Slack PKCE requires user_scope instead of scope for user tokens.
+	if strings.Contains(pfCfg.AuthorizeURL, "slack.com") {
+		params.Del("scope")
+		params.Set("user_scope", strings.Join(pfCfg.Scopes, " "))
+	}
+	authorizeURL := pfCfg.AuthorizeURL + "?" + params.Encode()
+
+	writeJSON(w, http.StatusOK, map[string]string{
+		"authorize_url": authorizeURL,
+		"state":         stateToken,
+	})
+}
+
+// PKCEFlowCallback handles the OAuth redirect after user authorization.
+// It exchanges the authorization code + PKCE verifier for an access token,
+// stores the credential, and serves a success/error HTML page.
+//
+// GET /api/pkce-flow/callback?code=...&state=...
+func (h *ServicesHandler) PKCEFlowCallback(w http.ResponseWriter, r *http.Request) {
+	state := r.URL.Query().Get("state")
+	code := r.URL.Query().Get("code")
+
+	if state == "" || code == "" {
+		oauthPopupClose(w, "Missing PKCE callback parameters.", "")
+		return
+	}
+
+	val, ok := h.pkceFlows.LoadAndDelete(state)
+	if !ok {
+		oauthPopupClose(w, "Invalid or expired PKCE state. Please try again.", "")
+		return
+	}
+	entry := val.(pkceFlowEntry)
+	if time.Now().After(entry.ExpiresAt) {
+		oauthPopupClose(w, "PKCE session expired. Please try again.", "")
+		return
+	}
+
+	// Exchange authorization code for access token using PKCE.
+	form := url.Values{
+		"client_id":     {entry.ClientID},
+		"code":          {code},
+		"code_verifier": {entry.CodeVerifier},
+		"redirect_uri":  {entry.RedirectURI},
+		"grant_type":    {"authorization_code"},
+	}
+	tokenReq, err := http.NewRequestWithContext(r.Context(), "POST", entry.TokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		oauthPopupClose(w, "Failed to build token request.", "")
+		return
+	}
+	tokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	tokenReq.Header.Set("Accept", "application/json")
+
+	resp, err := http.DefaultClient.Do(tokenReq)
+	if err != nil {
+		h.logger.Warn("pkce flow: token exchange failed", "err", err)
+		oauthPopupClose(w, "Failed to contact token endpoint.", "")
+		return
+	}
+	defer resp.Body.Close()
+
+	var rawResp map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&rawResp); err != nil {
+		oauthPopupClose(w, "Invalid response from token endpoint.", "")
+		return
+	}
+
+	// Check for error in response.
+	if errVal, ok := rawResp["error"].(string); ok && errVal != "" {
+		desc, _ := rawResp["error_description"].(string)
+		if desc == "" {
+			desc = errVal
+		}
+		h.logger.Warn("pkce flow: provider returned error", "error", errVal, "desc", desc)
+		oauthPopupClose(w, "Authorization failed: "+desc, "")
+		return
+	}
+
+	// Extract access token using token_path.
+	accessToken := extractTokenFromPath(rawResp, entry.TokenPath)
+	if accessToken == "" {
+		h.logger.Warn("pkce flow: empty access token in response", "service", entry.ServiceID, "token_path", entry.TokenPath)
+		oauthPopupClose(w, "Provider returned empty access token.", "")
+		return
+	}
+
+	// Store as api_key credential (same format as device flow / PAT).
+	credBytes, err := json.Marshal(map[string]string{
+		"type":  "api_key",
+		"token": accessToken,
+	})
+	if err != nil {
+		oauthPopupClose(w, "Failed to encode credential.", "")
+		return
+	}
+
+	vKey := h.adapterReg.VaultKeyWithAlias(entry.ServiceID, entry.Alias)
+	if err := h.vault.Set(r.Context(), entry.UserID, vKey, credBytes); err != nil {
+		h.logger.Warn("pkce flow: vault set failed", "err", err)
+		oauthPopupClose(w, "Failed to store credential.", "")
+		return
+	}
+	_ = h.st.UpsertServiceMeta(r.Context(), entry.UserID, entry.ServiceID, entry.Alias, time.Now())
+
+	h.logger.Info("service activated via PKCE flow", "user", entry.UserID, "service", entry.ServiceID)
+	oauthPopupClose(w, "", entry.CLICallback)
+}
+
+// extractTokenFromPath navigates a nested map using a dot-separated path
+// and returns the string value at that path.
+func extractTokenFromPath(m map[string]any, path string) string {
+	if path == "" {
+		// Default: look for "access_token" at the top level.
+		if v, ok := m["access_token"].(string); ok {
+			return v
+		}
+		return ""
+	}
+	parts := strings.Split(path, ".")
+	var current any = m
+	for _, part := range parts {
+		obj, ok := current.(map[string]any)
+		if !ok {
+			return ""
+		}
+		current = obj[part]
+	}
+	if s, ok := current.(string); ok {
+		return s
+	}
+	return ""
 }
 
 // ── System OAuth Config ──────────────────────────────────────────────────────

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -268,6 +268,11 @@ func (s *Server) routes() http.Handler {
 		s.notifier, verifier, extractor, *s.cfg, s.logger, baseURL, s.eventHub,
 	)
 	servicesHandler := handlers.NewServicesHandler(s.store, s.vault, s.adapterReg, s.logger, baseURL)
+	// Set relay daemon URL for PKCE flows that require HTTPS redirect URIs.
+	if s.cfg.Relay.Enabled && s.cfg.Relay.URL != "" && s.cfg.Relay.DaemonID != "" {
+		relayHost := strings.TrimPrefix(strings.TrimPrefix(s.cfg.Relay.URL, "wss://"), "ws://")
+		servicesHandler.SetRelayDaemonURL(fmt.Sprintf("https://%s/d/%s", relayHost, s.cfg.Relay.DaemonID))
+	}
 	skillHandler := handlers.NewSkillHandler(s.store, s.vault, s.adapterReg, s.logger)
 	approvalsHandler := handlers.NewApprovalsHandler(s.store, s.vault, s.adapterReg, s.notifier, s.logger, s.eventHub)
 	s.approvalsHandler = approvalsHandler
@@ -468,6 +473,8 @@ func (s *Server) routes() http.Handler {
 	mux.Handle("POST /api/services/{serviceID}/deactivate", user(servicesHandler.Deactivate))
 	mux.Handle("POST /api/services/{serviceID}/device-flow/start", user(servicesHandler.DeviceFlowStart))
 	mux.Handle("POST /api/services/{serviceID}/device-flow/poll", user(servicesHandler.DeviceFlowPoll))
+	mux.Handle("POST /api/services/{serviceID}/pkce-flow/start", user(servicesHandler.PKCEFlowStart))
+	mux.HandleFunc("GET /api/pkce-flow/callback", servicesHandler.PKCEFlowCallback) // no auth: browser redirect
 
 	// System-level OAuth config (user JWT)
 	mux.Handle("GET /api/system/google-oauth", user(servicesHandler.GetGoogleOAuthConfig))

--- a/internal/daemon/services_setup.go
+++ b/internal/daemon/services_setup.go
@@ -162,6 +162,8 @@ func activateService(apiClient *client.Client, svc client.ServiceInfo, dataDir s
 		return activateOAuthService(apiClient, svc, dataDir)
 	case svc.DeviceFlow:
 		return activateDeviceFlowOrAPIKey(apiClient, svc)
+	case svc.PKCEFlow:
+		return activatePKCEFlowOrAPIKey(apiClient, svc)
 	default:
 		return activateAPIKeyService(apiClient, svc)
 	}
@@ -270,6 +272,51 @@ func activateDeviceFlowOrAPIKey(apiClient *client.Client, svc client.ServiceInfo
 			return fmt.Errorf("unexpected status: %s", pollResp.Status)
 		}
 	}
+}
+
+// activatePKCEFlowOrAPIKey lets the user choose between PKCE browser flow
+// and pasting an API key/token.
+func activatePKCEFlowOrAPIKey(apiClient *client.Client, svc client.ServiceInfo) error {
+	var method string
+	if err := huh.NewForm(
+		huh.NewGroup(
+			huh.NewSelect[string]().
+				Title(fmt.Sprintf("How would you like to connect %s?", svc.Name)).
+				Options(
+					huh.NewOption("Sign in with "+svc.Name+" (browser)", "pkce_flow"),
+					huh.NewOption("Paste an API token", "api_key"),
+				).
+				Value(&method),
+		),
+	).Run(); err != nil {
+		return err
+	}
+
+	if method == "api_key" {
+		return activateAPIKeyService(apiClient, svc)
+	}
+
+	// PKCE flow: start local listener, get authorize URL, open browser, wait.
+	port, doneCh, cleanup := startOAuthListener()
+	defer cleanup()
+
+	cliCallback := fmt.Sprintf("http://127.0.0.1:%d/oauth-done", port)
+	pkceResp, err := apiClient.PKCEFlowStart(svc.ID, "", cliCallback)
+	if err != nil {
+		return fmt.Errorf("starting PKCE flow: %w", err)
+	}
+
+	fmt.Printf("\n  Opening browser for %s authorization...\n", svc.Name)
+	if !browser.Open(pkceResp.AuthorizeURL) {
+		fmt.Println(dim.Padding(0, 2).Render("  Could not open browser. Visit the URL manually:"))
+		fmt.Println(dim.Padding(0, 2).Render("  " + pkceResp.AuthorizeURL))
+	}
+
+	fmt.Println(dim.Padding(0, 2).Render("  Waiting for authorization to complete..."))
+	<-doneCh
+
+	fmt.Printf("  %s %s connected.\n\n", green.Render("✓"), svc.Name)
+	return nil
 }
 
 // activateOAuthService handles OAuth activation. For services using the

--- a/internal/tui/client/client.go
+++ b/internal/tui/client/client.go
@@ -344,6 +344,24 @@ func (c *Client) DeviceFlowPoll(serviceID, flowID string) (*DeviceFlowPollRespon
 	return &resp, nil
 }
 
+// ── PKCE Flow ───────────────────────────────────────────────────────────────
+
+// PKCEFlowStart initiates a PKCE authorization code flow for the given service.
+func (c *Client) PKCEFlowStart(serviceID, alias, cliCallback string) (*PKCEFlowStartResponse, error) {
+	body := map[string]string{}
+	if alias != "" {
+		body["alias"] = alias
+	}
+	if cliCallback != "" {
+		body["cli_callback"] = cliCallback
+	}
+	var resp PKCEFlowStartResponse
+	if err := c.post("/api/services/"+serviceID+"/pkce-flow/start", body, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
 // ── Restrictions ────────────────────────────────────────────────────────────
 
 func (c *Client) GetRestrictions() ([]Restriction, error) {

--- a/internal/tui/client/types.go
+++ b/internal/tui/client/types.go
@@ -189,6 +189,7 @@ type ServiceInfo struct {
 	OAuth              bool              `json:"oauth"`
 	OAuthEndpoint      string            `json:"oauth_endpoint,omitempty"`
 	DeviceFlow         bool              `json:"device_flow,omitempty"`
+	PKCEFlow           bool              `json:"pkce_flow,omitempty"`
 	RequiresActivation bool              `json:"requires_activation"`
 	CredentialFree     bool              `json:"credential_free"`
 	Actions            json.RawMessage   `json:"actions"`
@@ -204,6 +205,12 @@ type DeviceFlowStartResponse struct {
 	VerificationURI string `json:"verification_uri"`
 	Interval        int    `json:"interval"`
 	ExpiresIn       int    `json:"expires_in"`
+}
+
+// PKCEFlowStartResponse is returned by PKCEFlowStart.
+type PKCEFlowStartResponse struct {
+	AuthorizeURL string `json:"authorize_url"`
+	State        string `json:"state"`
 }
 
 // DeviceFlowPollResponse is returned by DeviceFlowPoll.

--- a/internal/tui/screens/services.go
+++ b/internal/tui/screens/services.go
@@ -50,6 +50,11 @@ type deviceFlowPollMsg struct {
 	err  error
 }
 
+type pkceFlowStartedMsg struct {
+	resp *client.PKCEFlowStartResponse
+	err  error
+}
+
 // ── Input steps ─────────────────────────────────────────────────────────────
 
 const (
@@ -60,6 +65,8 @@ const (
 	stepOAuthWaiting       = 4
 	stepDeviceFlowChoice   = 5
 	stepDeviceFlowWaiting  = 6
+	stepPKCEFlowChoice     = 7
+	stepPKCEFlowWaiting    = 8
 )
 
 // ── Model ───────────────────────────────────────────────────────────────────
@@ -96,6 +103,9 @@ type ServicesScreen struct {
 	deviceFlowID       string
 	deviceFlowInterval int
 	deviceFlowChoice   int // 0 = device flow (default), 1 = API key
+
+	// PKCE flow state.
+	pkceFlowChoice int // 0 = PKCE (default), 1 = API key
 }
 
 func NewServicesScreen(c *client.Client) *ServicesScreen {
@@ -288,6 +298,64 @@ func (s *ServicesScreen) Update(msg tea.Msg) (tui.ScreenModel, tea.Cmd) {
 		}
 	}
 
+	// PKCE flow choice overlay.
+	if s.inputStep == stepPKCEFlowChoice {
+		if msg, isKey := msg.(tea.KeyMsg); isKey {
+			switch msg.String() {
+			case "esc":
+				s.resetActivation()
+				return s, nil
+			case "up", "k":
+				if s.pkceFlowChoice > 0 {
+					s.pkceFlowChoice--
+				}
+				return s, nil
+			case "down", "j":
+				if s.pkceFlowChoice < 1 {
+					s.pkceFlowChoice++
+				}
+				return s, nil
+			case "enter":
+				if s.pkceFlowChoice == 1 {
+					// API key path.
+					s.inputStep = stepKeyEntry
+					ki := textinput.New()
+					ki.Placeholder = "paste token here"
+					ki.EchoMode = textinput.EchoPassword
+					ki.Focus()
+					s.keyInput = &ki
+					return s, nil
+				}
+				// PKCE flow path: start listener, get URL from server.
+				port, done, cleanup := startOAuthListener()
+				s.oauthDoneCh = done
+				s.oauthCleanup = cleanup
+				cliCallback := fmt.Sprintf("http://127.0.0.1:%d/oauth-done", port)
+				cl := s.client
+				serviceID := s.activatingService.ID
+				alias := s.pendingAlias
+				return s, func() tea.Msg {
+					resp, err := cl.PKCEFlowStart(serviceID, alias, cliCallback)
+					return pkceFlowStartedMsg{resp: resp, err: err}
+				}
+			}
+			return s, nil
+		}
+	}
+
+	// PKCE flow waiting overlay.
+	if s.inputStep == stepPKCEFlowWaiting {
+		if msg, isKey := msg.(tea.KeyMsg); isKey {
+			switch msg.String() {
+			case "esc":
+				s.stopOAuthListener()
+				s.resetActivation()
+				return s, nil
+			}
+			return s, nil
+		}
+	}
+
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		s.width = msg.Width
@@ -394,6 +462,17 @@ func (s *ServicesScreen) Update(msg tea.Msg) (tui.ScreenModel, tea.Cmd) {
 			return s, nil
 		}
 
+	case pkceFlowStartedMsg:
+		if msg.err != nil {
+			s.err = msg.err
+			s.stopOAuthListener()
+			s.resetActivation()
+			return s, nil
+		}
+		s.inputStep = stepPKCEFlowWaiting
+		browser.Open(msg.resp.AuthorizeURL)
+		return s, s.waitForOAuth()
+
 	case svcActivatedMsg:
 		s.resetActivation()
 		if msg.err != nil {
@@ -451,6 +530,12 @@ func (s *ServicesScreen) View() string {
 	}
 	if s.inputStep == stepDeviceFlowWaiting {
 		return s.viewDeviceFlowWaiting()
+	}
+	if s.inputStep == stepPKCEFlowChoice {
+		return s.viewPKCEFlowChoice()
+	}
+	if s.inputStep == stepPKCEFlowWaiting {
+		return s.viewPKCEFlowWaiting()
 	}
 
 	var b strings.Builder
@@ -688,6 +773,52 @@ func (s *ServicesScreen) viewDeviceFlowWaiting() string {
 	return tui.StyleOverlayBorder.Width(s.overlayWidth()).Render(content)
 }
 
+func (s *ServicesScreen) viewPKCEFlowChoice() string {
+	svcName := ""
+	if s.activatingService != nil {
+		svcName = s.activatingService.Name
+	}
+	title := lipgloss.NewStyle().
+		Foreground(tui.ColorBrand).
+		Bold(true).
+		Render("Connect " + svcName)
+
+	opts := []string{"Sign in with " + svcName + " (browser)", "Paste an API token"}
+	var optLines strings.Builder
+	for i, opt := range opts {
+		cursor := "  "
+		if i == s.pkceFlowChoice {
+			cursor = tui.StyleBrand.Render("> ")
+		}
+		optLines.WriteString(cursor + opt + "\n")
+	}
+
+	content := fmt.Sprintf("%s\n\n%s\n%s",
+		title,
+		optLines.String(),
+		tui.StyleDim.Render("[enter] Select  [esc] Cancel"),
+	)
+	return tui.StyleOverlayBorder.Width(s.overlayWidth()).Render(content)
+}
+
+func (s *ServicesScreen) viewPKCEFlowWaiting() string {
+	svcName := ""
+	if s.activatingService != nil {
+		svcName = s.activatingService.Name
+	}
+	title := lipgloss.NewStyle().
+		Foreground(tui.ColorBrand).
+		Bold(true).
+		Render("Connect " + svcName)
+
+	content := fmt.Sprintf("%s\n\n%s\n\n%s",
+		title,
+		tui.StyleAmber.Render("Waiting for authorization in browser..."),
+		tui.StyleDim.Render("[esc] Cancel"),
+	)
+	return tui.StyleOverlayBorder.Width(s.overlayWidth()).Render(content)
+}
+
 func (s *ServicesScreen) pollDeviceFlow() tea.Cmd {
 	cl := s.client
 	serviceID := s.activatingService.ID
@@ -757,6 +888,13 @@ func (s *ServicesScreen) proceedAfterAlias() tea.Cmd {
 		// Show choice: device flow or API key.
 		s.inputStep = stepDeviceFlowChoice
 		s.deviceFlowChoice = 0
+		return nil
+	}
+
+	if svc.PKCEFlow {
+		// Show choice: PKCE browser flow or API key.
+		s.inputStep = stepPKCEFlowChoice
+		s.pkceFlowChoice = 0
 		return nil
 	}
 
@@ -866,6 +1004,7 @@ func (s *ServicesScreen) resetActivation() {
 	s.deviceFlowID = ""
 	s.deviceFlowInterval = 0
 	s.deviceFlowChoice = 0
+	s.pkceFlowChoice = 0
 }
 
 func (s *ServicesScreen) stopOAuthListener() {
@@ -913,6 +1052,8 @@ func (s *ServicesScreen) showDetail() {
 		b.WriteString("OAuth")
 	} else if svc.DeviceFlow {
 		b.WriteString("OAuth (device flow) or API key")
+	} else if svc.PKCEFlow {
+		b.WriteString("OAuth (PKCE) or API token")
 	} else {
 		b.WriteString("API key")
 	}

--- a/pkg/adapters/adapters.go
+++ b/pkg/adapters/adapters.go
@@ -26,6 +26,7 @@ type ServiceMetadata struct {
 	VaultKey          string                // shared vault key (e.g. "google" for all google.* services); empty = use service ID
 	OAuthEndpoint     string                // well-known OAuth endpoint name (e.g. "google"); empty = not OAuth or no known endpoint
 	DeviceFlow        bool                  // whether device flow activation is available
+	PKCEFlow          bool                  // whether PKCE authorization code flow is available
 	ActionMeta        map[string]ActionMeta // action_id → metadata
 	VerificationHints string
 }
@@ -61,6 +62,12 @@ type ActionInfo struct {
 // OAuth2 device authorization grant (RFC 8628).
 type DeviceFlowProvider interface {
 	DeviceFlowConfig() *yamldef.DeviceFlowDef
+}
+
+// PKCEFlowProvider is an optional interface for adapters that support
+// OAuth2 authorization code flow with PKCE (RFC 7636).
+type PKCEFlowProvider interface {
+	PKCEFlowConfig() *yamldef.PKCEFlowDef
 }
 
 // OAuthCredentialProvider supplies OAuth app credentials (client_id, client_secret)

--- a/pkg/adapters/yamldef/schema.go
+++ b/pkg/adapters/yamldef/schema.go
@@ -26,6 +26,7 @@ type AuthDef struct {
 	ExtraHeaders map[string]string `yaml:"extra_headers,omitempty"`
 	OAuth      *OAuthDef      `yaml:"oauth,omitempty"`
 	DeviceFlow *DeviceFlowDef `yaml:"device_flow,omitempty"`
+	PKCEFlow   *PKCEFlowDef  `yaml:"pkce_flow,omitempty"`
 
 	// For basic auth where the credential is a composite "user:pass" string.
 	// The token field is split on ":" to produce user/pass for BasicAuth.
@@ -41,6 +42,17 @@ type DeviceFlowDef struct {
 	DeviceCodeURL string   `yaml:"device_code_url"`           // e.g. "https://github.com/login/device/code"
 	TokenURL      string   `yaml:"token_url"`                 // e.g. "https://github.com/login/oauth/access_token"
 	GrantType     string   `yaml:"grant_type,omitempty"`      // default: "urn:ietf:params:oauth:grant-type:device_code"
+}
+
+// PKCEFlowDef holds configuration for OAuth2 authorization code flow with PKCE (RFC 7636).
+// This allows CLI/native apps to authenticate without shipping a client secret.
+type PKCEFlowDef struct {
+	ClientID     string   `yaml:"client_id,omitempty"`      // hardcoded client_id (public, safe to ship)
+	ClientIDEnv  string   `yaml:"client_id_env,omitempty"`  // env var name for client_id override
+	Scopes       []string `yaml:"scopes"`                   // requested OAuth scopes
+	AuthorizeURL string   `yaml:"authorize_url"`            // e.g. "https://slack.com/oauth/v2/authorize"
+	TokenURL     string   `yaml:"token_url"`                // e.g. "https://slack.com/api/oauth.v2.access"
+	TokenPath    string   `yaml:"token_path,omitempty"`     // JSON path to access token in response (e.g. "authed_user.access_token")
 }
 
 // OAuthDef holds OAuth2-specific configuration.

--- a/pkg/adapters/yamlruntime/adapter.go
+++ b/pkg/adapters/yamlruntime/adapter.go
@@ -283,6 +283,7 @@ func (a *YAMLAdapter) ServiceMetadata() adapters.ServiceMetadata {
 		VaultKey:          vaultKey,
 		OAuthEndpoint:     oauthEndpoint,
 		DeviceFlow:        a.def.Auth.DeviceFlow != nil && a.resolveDeviceFlowClientID() != "",
+		PKCEFlow:          a.def.Auth.PKCEFlow != nil && a.resolvePKCEFlowClientID() != "",
 		ActionMeta:        actionMeta,
 		VerificationHints: a.def.VerificationHints,
 	}
@@ -325,6 +326,33 @@ func (a *YAMLAdapter) resolveDeviceFlowClientID() string {
 		}
 	}
 	return df.ClientID
+}
+
+// PKCEFlowConfig returns the PKCE flow configuration if available and
+// a client_id can be resolved. Implements adapters.PKCEFlowProvider.
+func (a *YAMLAdapter) PKCEFlowConfig() *yamldef.PKCEFlowDef {
+	if a.def.Auth.PKCEFlow == nil {
+		return nil
+	}
+	if a.resolvePKCEFlowClientID() == "" {
+		return nil
+	}
+	return a.def.Auth.PKCEFlow
+}
+
+// resolvePKCEFlowClientID returns the client_id for PKCE flow,
+// checking env var first then the hardcoded value.
+func (a *YAMLAdapter) resolvePKCEFlowClientID() string {
+	pf := a.def.Auth.PKCEFlow
+	if pf == nil {
+		return ""
+	}
+	if pf.ClientIDEnv != "" {
+		if v := os.Getenv(pf.ClientIDEnv); v != "" {
+			return v
+		}
+	}
+	return pf.ClientID
 }
 
 // Def returns the underlying YAML definition (for the loader/tests).


### PR DESCRIPTION
## Summary
- Adds OAuth PKCE (S256) flow for Slack authentication, since Slack doesn't support device flow
- Routes the callback through the relay service for the HTTPS redirect URI that Slack requires
- Uses `user_scope` instead of `scope` for Slack user tokens
- Ships a default public `client_id` so it works out of the box — no client secret needed

## Changes
- **YAML schema**: new `PKCEFlowDef` type and `pkce_flow` field on `AuthDef`
- **slack.yaml**: PKCE flow config with client_id, scopes, and Slack OAuth URLs
- **Adapter layer**: `PKCEFlowProvider` interface, `PKCEFlow` flag in `ServiceMetadata`
- **API**: two new endpoints — `POST /api/services/{serviceID}/pkce-flow/start` and `GET /api/pkce-flow/callback`
- **Daemon CLI**: PKCE flow activation with browser-based authorization
- **TUI**: PKCE flow choice and waiting screen

## Test plan
- [ ] Run setup → select Slack → choose "Sign in with Slack (browser)"
- [ ] Verify authorize URL opens in browser with correct `user_scope` and PKCE challenge
- [ ] Complete authorization in browser → verify relay forwards callback to local server
- [ ] Verify Slack API calls work with the PKCE token
- [ ] Verify existing PAT/API key setup path still works for other services

🤖 Generated with [Claude Code](https://claude.com/claude-code)