### PR TITLE
refactor: decouple OAuth redirect URL from credential provider

### DIFF
--- a/internal/adapters/google/calendar/adapter.go
+++ b/internal/adapters/google/calendar/adapter.go
@@ -45,14 +45,13 @@ func (a *CalendarAdapter) SupportedActions() []string {
 func (a *CalendarAdapter) RequiredScopes() []string { return calendarScopes }
 
 func (a *CalendarAdapter) OAuthConfig() *oauth2.Config {
-	clientID, clientSecret, redirectURL := a.oauthProvider.OAuthClientCredentials()
+	clientID, clientSecret := a.oauthProvider.OAuthClientCredentials()
 	if clientID == "" {
 		return nil
 	}
 	return &oauth2.Config{
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
-		RedirectURL:  redirectURL,
 		Scopes:       calendarScopes,
 		Endpoint:     google.Endpoint,
 	}

--- a/internal/adapters/google/contacts/adapter.go
+++ b/internal/adapters/google/contacts/adapter.go
@@ -44,14 +44,13 @@ func (a *ContactsAdapter) SupportedActions() []string {
 func (a *ContactsAdapter) RequiredScopes() []string { return contactsScopes }
 
 func (a *ContactsAdapter) OAuthConfig() *oauth2.Config {
-	clientID, clientSecret, redirectURL := a.oauthProvider.OAuthClientCredentials()
+	clientID, clientSecret := a.oauthProvider.OAuthClientCredentials()
 	if clientID == "" {
 		return nil
 	}
 	return &oauth2.Config{
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
-		RedirectURL:  redirectURL,
 		Scopes:       contactsScopes,
 		Endpoint:     google.Endpoint,
 	}

--- a/internal/adapters/google/drive/adapter.go
+++ b/internal/adapters/google/drive/adapter.go
@@ -45,14 +45,13 @@ func (a *DriveAdapter) SupportedActions() []string {
 func (a *DriveAdapter) RequiredScopes() []string { return driveScopes }
 
 func (a *DriveAdapter) OAuthConfig() *oauth2.Config {
-	clientID, clientSecret, redirectURL := a.oauthProvider.OAuthClientCredentials()
+	clientID, clientSecret := a.oauthProvider.OAuthClientCredentials()
 	if clientID == "" {
 		return nil
 	}
 	return &oauth2.Config{
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
-		RedirectURL:  redirectURL,
 		Scopes:       driveScopes,
 		Endpoint:     google.Endpoint,
 	}

--- a/internal/adapters/google/gmail/adapter.go
+++ b/internal/adapters/google/gmail/adapter.go
@@ -66,14 +66,13 @@ func (a *GmailAdapter) SupportedActions() []string {
 func (a *GmailAdapter) RequiredScopes() []string { return gmailScopes() }
 
 func (a *GmailAdapter) OAuthConfig() *oauth2.Config {
-	clientID, clientSecret, redirectURL := a.oauthProvider.OAuthClientCredentials()
+	clientID, clientSecret := a.oauthProvider.OAuthClientCredentials()
 	if clientID == "" {
 		return nil
 	}
 	return &oauth2.Config{
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
-		RedirectURL:  redirectURL,
 		Scopes:       gmailScopes(),
 		Endpoint:     google.Endpoint,
 	}

--- a/internal/api/handlers/services.go
+++ b/internal/api/handlers/services.go
@@ -102,6 +102,11 @@ func NewServicesHandler(st store.Store, v vault.Vault, adapterReg *adapters.Regi
 // SetRelayDaemonURL sets the public HTTPS relay URL used for PKCE flow redirects.
 func (h *ServicesHandler) SetRelayDaemonURL(u string) { h.relayDaemonURL = u }
 
+// oauthRedirectURL returns the OAuth callback URL derived from the server's base URL.
+func (h *ServicesHandler) oauthRedirectURL() string {
+	return strings.TrimRight(h.baseURL, "/") + "/api/oauth/callback"
+}
+
 // List returns the service catalog with per-user activation status.
 //
 // GET /api/services
@@ -313,6 +318,7 @@ func (h *ServicesHandler) OAuthGetURL(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "service does not use OAuth2")
 		return
 	}
+	oauthCfg.RedirectURL = h.oauthRedirectURL()
 
 	alias := r.URL.Query().Get("alias")
 	if alias == "" {
@@ -380,6 +386,7 @@ func (h *ServicesHandler) OAuthStart(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "service does not use OAuth2")
 		return
 	}
+	oauthCfg.RedirectURL = h.oauthRedirectURL()
 
 	alias := r.URL.Query().Get("alias")
 	if alias == "" {
@@ -439,6 +446,7 @@ func (h *ServicesHandler) OAuthCallback(w http.ResponseWriter, r *http.Request) 
 	}
 
 	oauthCfg := adapter.OAuthConfig()
+	oauthCfg.RedirectURL = h.oauthRedirectURL()
 	// Use the merged scopes stored during URL generation.
 	if len(entry.Scopes) > 0 {
 		oauthCfg.Scopes = entry.Scopes
@@ -594,6 +602,7 @@ func (h *ServicesHandler) Activate(w http.ResponseWriter, r *http.Request) {
 			ExpiresAt:    time.Now().Add(10 * time.Minute),
 		})
 		oauthCfg := adapter.OAuthConfig()
+		oauthCfg.RedirectURL = h.oauthRedirectURL()
 		oauthCfg.Scopes = mergedScopes
 		authURL := oauthAuthURL(oauthCfg, stateToken, alias)
 		writeJSON(w, http.StatusOK, map[string]string{"url": authURL})

--- a/pkg/adapters/adapters.go
+++ b/pkg/adapters/adapters.go
@@ -74,16 +74,16 @@ type PKCEFlowProvider interface {
 // on demand. This allows the server to read credentials from the vault lazily
 // instead of requiring them at startup.
 type OAuthCredentialProvider interface {
-	// OAuthClientCredentials returns (clientID, clientSecret, redirectURL).
+	// OAuthClientCredentials returns (clientID, clientSecret).
 	// Returns empty strings if not yet configured.
-	OAuthClientCredentials() (clientID, clientSecret, redirectURL string)
+	OAuthClientCredentials() (clientID, clientSecret string)
 }
 
 // NoopOAuthProvider is a provider that always returns empty credentials.
 // Useful in tests where OAuth configuration is not needed.
 type NoopOAuthProvider struct{}
 
-func (NoopOAuthProvider) OAuthClientCredentials() (string, string, string) { return "", "", "" }
+func (NoopOAuthProvider) OAuthClientCredentials() (string, string) { return "", "" }
 
 // SystemUserID is the well-known user ID for system-level vault entries
 // (e.g. Google OAuth app credentials). Not a real user.

--- a/pkg/adapters/oauth_provider.go
+++ b/pkg/adapters/oauth_provider.go
@@ -18,33 +18,32 @@ type googleOAuthCred struct {
 // system user. Falls back to env vars (GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET)
 // for backward compatibility with Docker Compose deployments.
 type VaultOAuthProvider struct {
-	vault       vault.Vault
-	redirectURL string // derived from server host:port, not a secret
+	vault vault.Vault
 }
 
 // NewVaultOAuthProvider creates a provider that reads Google OAuth creds from the vault.
-func NewVaultOAuthProvider(v vault.Vault, redirectURL string) *VaultOAuthProvider {
-	return &VaultOAuthProvider{vault: v, redirectURL: redirectURL}
+func NewVaultOAuthProvider(v vault.Vault) *VaultOAuthProvider {
+	return &VaultOAuthProvider{vault: v}
 }
 
-func (p *VaultOAuthProvider) OAuthClientCredentials() (clientID, clientSecret, redirectURL string) {
+func (p *VaultOAuthProvider) OAuthClientCredentials() (clientID, clientSecret string) {
 	// Check env vars first (backward compat for Docker/CI).
 	if id := os.Getenv("GOOGLE_CLIENT_ID"); id != "" {
-		return id, os.Getenv("GOOGLE_CLIENT_SECRET"), p.redirectURL
+		return id, os.Getenv("GOOGLE_CLIENT_SECRET")
 	}
 
 	// Read from vault.
 	data, err := p.vault.Get(context.Background(), SystemUserID, SystemVaultKeyGoogleOAuth)
 	if err != nil || len(data) == 0 {
-		return "", "", ""
+		return "", ""
 	}
 
 	var cred googleOAuthCred
 	if err := json.Unmarshal(data, &cred); err != nil {
-		return "", "", ""
+		return "", ""
 	}
 
-	return cred.ClientID, cred.ClientSecret, p.redirectURL
+	return cred.ClientID, cred.ClientSecret
 }
 
 // SetGoogleOAuthCredentials stores Google OAuth app credentials in the system vault.

--- a/pkg/adapters/yamlruntime/adapter.go
+++ b/pkg/adapters/yamlruntime/adapter.go
@@ -110,9 +110,9 @@ func (a *YAMLAdapter) OAuthConfig() *oauth2.Config {
 	}
 
 	// Read OAuth app credentials lazily from the provider.
-	var clientID, clientSecret, redirectURL string
+	var clientID, clientSecret string
 	if a.oauthProvider != nil {
-		clientID, clientSecret, redirectURL = a.oauthProvider.OAuthClientCredentials()
+		clientID, clientSecret = a.oauthProvider.OAuthClientCredentials()
 	}
 	if clientID == "" {
 		return nil // OAuth not yet configured
@@ -144,7 +144,6 @@ func (a *YAMLAdapter) OAuthConfig() *oauth2.Config {
 	return &oauth2.Config{
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
-		RedirectURL:  redirectURL,
 		Scopes:       scopes,
 		Endpoint:     endpoint,
 	}

--- a/pkg/clawvisor/defaults.go
+++ b/pkg/clawvisor/defaults.go
@@ -127,16 +127,9 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 	// ── Adapter Registry ─────────────────────────────────────────────────────
 	adapterReg := adapters.NewRegistry()
 
-	// Build the Google OAuth redirect URL (used for all Google services).
-	host := cfg.Server.Host
-	if host == "0.0.0.0" || host == "127.0.0.1" || host == "" {
-		host = "localhost"
-	}
-	googleRedirectURL := fmt.Sprintf("http://%s:%d/api/oauth/callback", host, cfg.Server.Port)
-
 	// Create a vault-backed OAuth provider for Google services.
 	// Reads credentials lazily — supports adding OAuth creds without restart.
-	oauthProvider := adapters.NewVaultOAuthProvider(v, googleRedirectURL)
+	oauthProvider := adapters.NewVaultOAuthProvider(v)
 
 	// Build Go action overrides for Google services that need complex logic
 	// (MIME encoding, multipart uploads, dual API calls) beyond what YAML


### PR DESCRIPTION
## Summary

The OAuth redirect URL (`/api/oauth/callback`) was bundled into `OAuthCredentialProvider` and hardcoded in `defaults.go` using host:port, ignoring the `public_url` config. This refactor removes the redirect URL from the credential provider interface and instead derives it from `baseURL` in `ServicesHandler`, which already respects `public_url`. This makes the abstraction cleaner for future non-Google OAuth providers and fixes the public URL bug.

- `OAuthCredentialProvider.OAuthClientCredentials()` now returns `(clientID, clientSecret)` only
- `VaultOAuthProvider` no longer carries a redirect URL
- `ServicesHandler.oauthRedirectURL()` derives the callback URL from `baseURL` at the 4 handler call sites that need it
- Removed duplicate URL construction logic from `defaults.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)