### PR TITLE
feat: add comprehensive e2e test suite with CI-compatible mock adapters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-staging install test run run-sqlite run-staging migrate lint clean setup tui eval-intent release test-e2e-install
+.PHONY: build build-staging install test run run-sqlite run-staging migrate lint clean setup tui eval-intent release test-e2e-install test-e2e test-e2e-ci
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null | sed 's/^v//' || echo dev)
 ENVIRONMENT ?= production
@@ -37,6 +37,12 @@ test-verbose:
 
 eval-intent:
 	go test -v -run TestEvalIntentVerification -count=1 -timeout=300s ./internal/intent/
+
+test-e2e: build
+	CLAWVISOR_BIN=$(CURDIR)/bin/clawvisor go test -v -count=1 -timeout=120s ./e2e/smoke/
+
+test-e2e-ci: build
+	CLAWVISOR_BIN=$(CURDIR)/bin/clawvisor go test -v -count=1 -timeout=120s -run '^TestCI' ./e2e/smoke/
 
 test-e2e-install: web/dist
 	docker build -f e2e/install/Dockerfile -t clawvisor-e2e-install .

--- a/e2e/smoke/agent_lifecycle_test.go
+++ b/e2e/smoke/agent_lifecycle_test.go
@@ -1,0 +1,416 @@
+package smoke_test
+
+import (
+	"fmt"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestAgentConnectionFlow exercises the self-service agent onboarding:
+// POST /api/agents/connect → user approves → poll for token → use token.
+func TestAgentConnectionFlow(t *testing.T) {
+	env := setup(t)
+
+	// Step 1: Agent requests a connection (unauthenticated).
+	connResp := env.doRaw("POST", "/api/agents/connect", "", map[string]any{
+		"name":        "e2e-connection-test",
+		"description": "E2E test agent via connection flow",
+	})
+	connM := mustStatus(t, connResp, http.StatusCreated)
+	connID := str(t, connM, "connection_id")
+	connStatus := str(t, connM, "status")
+	t.Logf("connection request %s created, status=%s", connID, connStatus)
+
+	if connStatus != "pending" {
+		t.Fatalf("expected pending, got %s", connStatus)
+	}
+
+	// Step 2: User approves the connection.
+	approveResp := env.userDo("POST", fmt.Sprintf("/api/agents/connect/%s/approve", connID), nil)
+	approveM := mustStatus(t, approveResp, http.StatusOK)
+	approveStatus := str(t, approveM, "status")
+	if approveStatus != "approved" {
+		t.Fatalf("expected approved, got %s", approveStatus)
+	}
+	agentID := strOr(approveM, "agent_id", "")
+	t.Logf("connection approved, agent_id=%s", agentID)
+
+	// Step 3: Agent polls for the token.
+	pollResp := env.doRaw("GET", fmt.Sprintf("/api/agents/connect/%s/status", connID), "", nil)
+	pollM := mustStatus(t, pollResp, http.StatusOK)
+	pollStatus := str(t, pollM, "status")
+	if pollStatus != "approved" {
+		t.Fatalf("expected approved on poll, got %s", pollStatus)
+	}
+
+	token := strOr(pollM, "token", "")
+	if token == "" {
+		t.Fatal("expected token in approved poll response, got empty string")
+	}
+	if !strings.HasPrefix(token, "cvis_") {
+		t.Errorf("token should have cvis_ prefix, got %q", token[:10])
+	}
+	t.Logf("received agent token (%d chars)", len(token))
+
+	// Step 4: Verify the token works by fetching the skill catalog.
+	catalogResp := env.doRaw("GET", "/api/skill/catalog", token, nil)
+	defer catalogResp.Body.Close()
+	if catalogResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(catalogResp.Body)
+		t.Fatalf("catalog with new token: status %d: %s", catalogResp.StatusCode, body)
+	}
+	catalogBody, _ := io.ReadAll(catalogResp.Body)
+	if !strings.Contains(string(catalogBody), "Service Catalog") {
+		t.Error("catalog response missing expected header")
+	}
+	t.Logf("new agent can access catalog (%d bytes)", len(catalogBody))
+}
+
+// TestAgentConnectionDeny tests that denying a connection request works.
+func TestAgentConnectionDeny(t *testing.T) {
+	env := setup(t)
+
+	connResp := env.doRaw("POST", "/api/agents/connect", "", map[string]any{
+		"name": "e2e-deny-test",
+	})
+	connM := mustStatus(t, connResp, http.StatusCreated)
+	connID := str(t, connM, "connection_id")
+
+	// Deny it.
+	denyResp := env.userDo("POST", fmt.Sprintf("/api/agents/connect/%s/deny", connID), nil)
+	denyM := mustStatus(t, denyResp, http.StatusOK)
+	if str(t, denyM, "status") != "denied" {
+		t.Fatalf("expected denied, got %s", str(t, denyM, "status"))
+	}
+
+	// Poll should show denied with no token.
+	pollResp := env.doRaw("GET", fmt.Sprintf("/api/agents/connect/%s/status", connID), "", nil)
+	pollM := mustStatus(t, pollResp, http.StatusOK)
+	if str(t, pollM, "status") != "denied" {
+		t.Errorf("expected denied on poll, got %s", str(t, pollM, "status"))
+	}
+	if strOr(pollM, "token", "") != "" {
+		t.Error("denied connection should not return a token")
+	}
+	t.Log("connection correctly denied")
+}
+
+// TestAgentConnectionsList tests that pending connections are visible to the user.
+func TestAgentConnectionsList(t *testing.T) {
+	env := setup(t)
+
+	// Create a connection request so there's at least one.
+	connResp := env.doRaw("POST", "/api/agents/connect", "", map[string]any{
+		"name": "e2e-list-test",
+	})
+	mustStatus(t, connResp, http.StatusCreated)
+
+	// List connections as user.
+	listResp := env.userDo("GET", "/api/agents/connections", nil)
+	defer listResp.Body.Close()
+	if listResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(listResp.Body)
+		t.Fatalf("list connections: status %d: %s", listResp.StatusCode, body)
+	}
+
+	var connections []any
+	decodeJSON(t, listResp, &connections)
+	t.Logf("found %d connection request(s)", len(connections))
+
+	if len(connections) == 0 {
+		t.Error("expected at least one connection request")
+	}
+}
+
+// TestFullAgentLifecycle exercises the complete agent journey using ?wait=true
+// long-polls as instructed by the setup script:
+// connect(?wait=true) → catalog → task(?wait=true) → gateway(?wait=true) →
+// complete → verify.
+func TestFullAgentLifecycle(t *testing.T) {
+	env := setup(t)
+
+	// Pick any activated read-only service so the test works regardless of
+	// which services the user has configured.
+	svcID, action, params := env.pickActivatedReadService(t)
+	t.Logf("using service=%s action=%s", svcID, action)
+
+	// ── Phase 1: Agent connects with ?wait=true ───────────────────────────
+	agentName := fmt.Sprintf("e2e-lifecycle-%d", time.Now().UnixNano())
+	approvedCh := approveConnectionInBackground(t, env, agentName)
+
+	connResp := env.doLongPoll("POST", "/api/agents/connect?wait=true&timeout=30", "", map[string]any{
+		"name":        agentName,
+		"description": "Full lifecycle test agent",
+	})
+	connM := mustStatus(t, connResp, http.StatusCreated)
+	connStatus := strOr(connM, "status", "")
+	if connStatus != "approved" {
+		t.Fatalf("expected approved, got %s", connStatus)
+	}
+	agentToken := strOr(connM, "token", "")
+	if agentToken == "" {
+		t.Fatal("expected token in ?wait=true response")
+	}
+	t.Logf("phase 1: agent connected, token acquired (%d chars)", len(agentToken))
+	<-approvedCh
+
+	agentReq := func(method, path string, body any) *http.Response {
+		return env.doRaw(method, path, agentToken, body)
+	}
+	agentLongPoll := func(method, path string, body any) *http.Response {
+		return env.doLongPoll(method, path, agentToken, body)
+	}
+
+	// ── Phase 2: Agent discovers available services via catalog ───────────
+	catalogResp := agentReq("GET", "/api/skill/catalog", nil)
+	defer catalogResp.Body.Close()
+	if catalogResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(catalogResp.Body)
+		t.Fatalf("catalog: status %d: %s", catalogResp.StatusCode, body)
+	}
+	catalogBody, _ := io.ReadAll(catalogResp.Body)
+	catalog := string(catalogBody)
+	if !strings.Contains(catalog, svcID) {
+		t.Fatalf("catalog does not list %s service", svcID)
+	}
+	t.Logf("phase 2: catalog fetched, contains %s (%d bytes)", svcID, len(catalog))
+
+	// ── Phase 3: Agent creates a task with ?wait=true ─────────────────────
+	purposeMarker := fmt.Sprintf("lifecycle-%d", time.Now().UnixNano())
+	taskApprovedCh := approveTaskInBackground(t, env, purposeMarker)
+
+	taskResp := agentLongPoll("POST", "/api/tasks?wait=true&timeout=30", map[string]any{
+		"purpose": fmt.Sprintf("E2E lifecycle test [%s]: %s/%s", purposeMarker, svcID, action),
+		"authorized_actions": []map[string]any{{
+			"service":      svcID,
+			"action":       action,
+			"auto_execute": true,
+			"expected_use": "E2E lifecycle test read action",
+		}},
+	})
+	taskM := mustStatus(t, taskResp, http.StatusCreated)
+	taskID := strOr(taskM, "id", strOr(taskM, "task_id", ""))
+	if taskID == "" {
+		t.Fatal("no task_id in response")
+	}
+	taskStatus := strOr(taskM, "status", "")
+	if taskStatus != "approved" && taskStatus != "active" {
+		t.Fatalf("expected approved/active after wait, got %s", taskStatus)
+	}
+	t.Logf("phase 3: task %s approved via ?wait=true", taskID)
+	<-taskApprovedCh
+
+	// ── Phase 4: Agent submits a gateway request with ?wait=true ──────────
+	reqID := fmt.Sprintf("e2e-lifecycle-%d", time.Now().UnixNano())
+	gwResp := agentLongPoll("POST", "/api/gateway/request?wait=true&timeout=30", map[string]any{
+		"service":    svcID,
+		"action":     action,
+		"params":     params,
+		"reason":     fmt.Sprintf("E2E lifecycle: %s/%s", svcID, action),
+		"request_id": reqID,
+		"task_id":    taskID,
+	})
+	gwM := parseGatewayResponse(t, gwResp)
+	gwStatus := str(t, gwM, "status")
+	t.Logf("phase 4: gateway response status=%s", gwStatus)
+
+	env.executeIfReady(t, reqID, gwStatus, gwM)
+	t.Log("phase 4: gateway request executed")
+
+	// ── Phase 5: Agent completes the task ────────────────────────────────
+	completeResp := agentReq("POST", fmt.Sprintf("/api/tasks/%s/complete", taskID), nil)
+	defer completeResp.Body.Close()
+	completeBody, _ := io.ReadAll(completeResp.Body)
+	if completeResp.StatusCode != http.StatusOK {
+		t.Fatalf("complete task: status %d: %s", completeResp.StatusCode, completeBody)
+	}
+	t.Logf("phase 5: task %s completed", taskID)
+
+	// Verify task status is now completed.
+	finalResp := agentReq("GET", fmt.Sprintf("/api/tasks/%s", taskID), nil)
+	finalM := mustStatus(t, finalResp, http.StatusOK)
+	finalStatus := strOr(finalM, "status", "")
+	if finalStatus != "completed" {
+		t.Errorf("expected task status=completed, got %s", finalStatus)
+	}
+	t.Log("phase 5: verified task is completed")
+}
+
+// TestStandingTaskLifecycle tests creating a standing (persistent) task
+// that doesn't expire, using it for a gateway request, and then revoking it.
+func TestStandingTaskLifecycle(t *testing.T) {
+	env := setup(t)
+	svcID, action, params := env.pickActivatedReadService(t)
+
+	// Create a standing task.
+	taskResp := env.agentDo("POST", "/api/tasks", map[string]any{
+		"purpose":  "E2E standing task test",
+		"lifetime": "standing",
+		"authorized_actions": []map[string]any{{
+			"service":      svcID,
+			"action":       action,
+			"auto_execute": true,
+			"expected_use": "Ongoing read monitoring",
+		}},
+	})
+	taskM := mustStatus(t, taskResp, http.StatusCreated)
+	taskID := str(t, taskM, "task_id")
+	t.Logf("standing task %s created (%s/%s)", taskID, svcID, action)
+
+	agentReq := func(method, path string, body any) *http.Response {
+		return env.agentDo(method, path, body)
+	}
+	env.waitAndApproveTask(t, agentReq, taskID)
+	t.Logf("standing task %s approved", taskID)
+
+	// Use the standing task for a request.
+	reqID := fmt.Sprintf("e2e-standing-%d", time.Now().UnixNano())
+	gwResp := env.agentDo("POST", "/api/gateway/request", map[string]any{
+		"service":    svcID,
+		"action":     action,
+		"params":     params,
+		"reason":     "E2E standing task test",
+		"request_id": reqID,
+		"task_id":    taskID,
+		"session_id": "e2e-session-1",
+	})
+	gwM := parseGatewayResponse(t, gwResp)
+	gwStatus := str(t, gwM, "status")
+	t.Logf("standing task gateway status=%s", gwStatus)
+
+	env.executeIfReady(t, reqID, gwStatus, gwM)
+
+	// Revoke the standing task via user token.
+	revokeResp := env.userDo("POST", fmt.Sprintf("/api/tasks/%s/revoke", taskID), nil)
+	defer revokeResp.Body.Close()
+	if revokeResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(revokeResp.Body)
+		t.Fatalf("revoke standing task: status %d: %s", revokeResp.StatusCode, body)
+	}
+	t.Logf("standing task %s revoked", taskID)
+
+	// Verify that a new request on the revoked task fails.
+	reqID2 := fmt.Sprintf("e2e-standing-revoked-%d", time.Now().UnixNano())
+	revokedResp := env.agentDo("POST", "/api/gateway/request", map[string]any{
+		"service":    svcID,
+		"action":     action,
+		"params":     params,
+		"reason":     "Should fail — task revoked",
+		"request_id": reqID2,
+		"task_id":    taskID,
+	})
+	defer revokedResp.Body.Close()
+	revokedBody, _ := io.ReadAll(revokedResp.Body)
+	if revokedResp.StatusCode == http.StatusOK {
+		var revokedM map[string]any
+		if err := json.Unmarshal(revokedBody, &revokedM); err == nil {
+			s := strOr(revokedM, "status", "")
+			if s == "executed" || s == "approved" || s == "auto_approved" {
+				t.Errorf("expected revoked task request to fail, but got status=%s", s)
+			} else {
+				t.Logf("revoked task request correctly returned status=%s", s)
+			}
+		}
+	} else {
+		t.Logf("revoked task request correctly returned HTTP %d", revokedResp.StatusCode)
+	}
+}
+
+// TestTaskScopeExpansion tests that an agent can request scope expansion
+// for an action not in the original task.
+func TestTaskScopeExpansion(t *testing.T) {
+	env := setup(t)
+	svcID, action, _ := env.pickActivatedReadService(t)
+
+	// Create a task with only the first action.
+	taskID := env.createApprovedTask(t, svcID, action, true)
+
+	// Pick a second action from the same service for expansion.
+	secondAction := env.pickSecondAction(t, svcID, action)
+	if secondAction == "" {
+		t.Skipf("service %s has no second read action to expand into", svcID)
+	}
+
+	// Request scope expansion.
+	expandResp := env.agentDo("POST", fmt.Sprintf("/api/tasks/%s/expand", taskID), map[string]any{
+		"service":      svcID,
+		"action":       secondAction,
+		"auto_execute": true,
+		"reason":       "E2E scope expansion test",
+	})
+	defer expandResp.Body.Close()
+	expandBody, _ := io.ReadAll(expandResp.Body)
+
+	if expandResp.StatusCode == http.StatusOK || expandResp.StatusCode == http.StatusAccepted {
+		t.Logf("scope expansion requested (status %d)", expandResp.StatusCode)
+	} else {
+		t.Logf("scope expansion returned %d: %s (may need user approval or not be supported)", expandResp.StatusCode, expandBody)
+		return
+	}
+
+	// Check if expansion needs approval.
+	checkResp := env.agentDo("GET", fmt.Sprintf("/api/tasks/%s", taskID), nil)
+	checkM := mustStatus(t, checkResp, http.StatusOK)
+	taskStatus := strOr(checkM, "status", "")
+	t.Logf("task status after expansion request: %s", taskStatus)
+
+	if taskStatus == "pending_scope_expansion" {
+		// Approve the expansion so the task doesn't stay in a stuck state.
+		approveResp := env.userDo("POST", fmt.Sprintf("/api/tasks/%s/expand/approve", taskID), nil)
+		defer approveResp.Body.Close()
+		if approveResp.StatusCode == http.StatusOK {
+			t.Log("expansion approved by user")
+		} else {
+			body, _ := io.ReadAll(approveResp.Body)
+			t.Logf("expansion approve returned %d: %s", approveResp.StatusCode, body)
+		}
+	} else if taskStatus == "pending_approval" {
+		approveResp := env.userDo("POST", fmt.Sprintf("/api/tasks/%s/approve", taskID), nil)
+		defer approveResp.Body.Close()
+		if approveResp.StatusCode == http.StatusOK {
+			t.Log("expansion approved by user")
+		}
+	}
+}
+
+// TestAgentListAfterConnect verifies the agents list endpoint shows the
+// agents created via the connection flow.
+func TestAgentListAfterConnect(t *testing.T) {
+	env := setup(t)
+
+	resp := env.userDo("GET", "/api/agents", nil)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("list agents: status %d: %s", resp.StatusCode, body)
+	}
+
+	var agents []any
+	decodeJSON(t, resp, &agents)
+	t.Logf("user has %d agent(s)", len(agents))
+
+	if len(agents) == 0 {
+		t.Error("expected at least one agent (e2e-smoke-test)")
+	}
+
+	// Check that our test agent is in the list.
+	found := false
+	for _, raw := range agents {
+		agent, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		name := strOr(agent, "name", "")
+		t.Logf("  agent: %s (id=%s)", name, strOr(agent, "id", "?"))
+		if name == "e2e-smoke-test" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("e2e-smoke-test agent not found in agents list")
+	}
+}

--- a/e2e/smoke/audit_test.go
+++ b/e2e/smoke/audit_test.go
@@ -1,0 +1,53 @@
+package smoke_test
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestAuditLog(t *testing.T) {
+	env := setup(t)
+
+	resp := env.userDo("GET", "/api/audit", nil)
+	m := mustStatus(t, resp, http.StatusOK)
+
+	entries, ok := m["entries"].([]any)
+	if !ok {
+		t.Log("audit endpoint returned 200, entries may be empty or keyed differently")
+		return
+	}
+	t.Logf("audit log has %d entries", len(entries))
+}
+
+func TestRestrictionsList(t *testing.T) {
+	env := setup(t)
+
+	// Restrictions returns a JSON array (not wrapped in an object).
+	resp := env.userDo("GET", "/api/restrictions", nil)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	var restrictions []any
+	decodeJSON(t, resp, &restrictions)
+	t.Logf("restrictions: %d entries", len(restrictions))
+}
+
+func TestTasksList(t *testing.T) {
+	env := setup(t)
+
+	resp := env.userDo("GET", "/api/tasks", nil)
+	m := mustStatus(t, resp, http.StatusOK)
+
+	tasks, ok := m["tasks"].([]any)
+	if ok {
+		t.Logf("found %d task(s)", len(tasks))
+	}
+}
+
+func TestApprovalsList(t *testing.T) {
+	env := setup(t)
+
+	resp := env.userDo("GET", "/api/approvals", nil)
+	mustStatus(t, resp, http.StatusOK)
+}

--- a/e2e/smoke/auth_test.go
+++ b/e2e/smoke/auth_test.go
@@ -1,0 +1,42 @@
+package smoke_test
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestMe(t *testing.T) {
+	env := setup(t)
+
+	resp := env.userDo("GET", "/api/me", nil)
+	m := mustStatus(t, resp, http.StatusOK)
+
+	// /api/me returns the user directly, not wrapped in {"user": ...}.
+	email := str(t, m, "email")
+	if email != "admin@local" {
+		t.Errorf("expected admin@local, got %q", email)
+	}
+}
+
+func TestTokenRefresh(t *testing.T) {
+	env := setup(t)
+
+	resp := env.doRaw("POST", "/api/auth/refresh", "", map[string]any{
+		"refresh_token": env.UserRefreshToken,
+	})
+	m := mustStatus(t, resp, http.StatusOK)
+	newAccess := str(t, m, "access_token")
+	if newAccess == "" {
+		t.Error("expected non-empty access_token after refresh")
+	}
+}
+
+func TestUnauthenticatedReturns401(t *testing.T) {
+	env := setup(t)
+
+	resp := env.doRaw("GET", "/api/me", "", nil)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", resp.StatusCode)
+	}
+}

--- a/e2e/smoke/catalog_test.go
+++ b/e2e/smoke/catalog_test.go
@@ -1,0 +1,81 @@
+package smoke_test
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestSkillCatalog(t *testing.T) {
+	env := setup(t)
+
+	// The catalog endpoint returns text/markdown for agent tokens.
+	resp := env.agentDo("GET", "/api/skill/catalog", nil)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	ct := resp.Header.Get("Content-Type")
+	if !strings.Contains(ct, "text/markdown") {
+		t.Errorf("expected text/markdown content type, got %q", ct)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	catalog := string(body)
+
+	if !strings.Contains(catalog, "Service Catalog") {
+		t.Error("catalog does not contain expected header")
+	}
+	t.Logf("catalog length: %d bytes", len(catalog))
+}
+
+func TestSkillCatalogSingleService(t *testing.T) {
+	env := setup(t)
+
+	resp := env.agentDo("GET", "/api/skill/catalog?service=github", nil)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	if len(body) == 0 {
+		t.Error("expected non-empty catalog detail for github")
+	}
+	t.Logf("github catalog detail: %d bytes", len(body))
+}
+
+func TestServicesList(t *testing.T) {
+	env := setup(t)
+
+	resp := env.userDo("GET", "/api/services", nil)
+	m := mustStatus(t, resp, http.StatusOK)
+
+	services, ok := m["services"].([]any)
+	if !ok {
+		t.Fatal("expected services array in response")
+	}
+	t.Logf("user has %d service(s) configured", len(services))
+
+	for _, raw := range services {
+		svc, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		id := strOr(svc, "id", "?")
+		alias := strOr(svc, "alias", "")
+		status := strOr(svc, "status", "?")
+		if alias != "" {
+			t.Logf("  %s:%s — %s", id, alias, status)
+		} else {
+			t.Logf("  %s — %s", id, status)
+		}
+	}
+}

--- a/e2e/smoke/ci_test.go
+++ b/e2e/smoke/ci_test.go
@@ -1,0 +1,225 @@
+package smoke_test
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ── Service Activation Tests ─────────────────────────────────────────────────
+
+// TestCIOAuthActivation tests the full OAuth dance: activate → redirect →
+// callback → token exchange → credential stored → service activated.
+func TestCIOAuthActivation(t *testing.T) {
+	env := ciSetup(t)
+	env.activateTestOAuth(t)
+}
+
+// TestCIAPIKeyActivation tests API key activation: POST token → validate →
+// vault store → service activated.
+func TestCIAPIKeyActivation(t *testing.T) {
+	env := ciSetup(t)
+	env.activateTestAPIKey(t)
+}
+
+// TestCINoAuthActivation tests credential-free service activation:
+// POST activate → service_meta created → service activated.
+func TestCINoAuthActivation(t *testing.T) {
+	env := ciSetup(t)
+	env.activateTestNoAuth(t)
+}
+
+// ── Gateway Flow Tests ───────────────────────────────────────────────────────
+
+// TestCIOAuthGatewayFlow runs the full gateway pipeline through the
+// OAuth-authenticated test service: task → approve → gateway request → execute.
+func TestCIOAuthGatewayFlow(t *testing.T) {
+	env := ciSetup(t)
+	env.activateTestOAuth(t)
+	env.runGatewayFlow(t, "test_oauth", "list_items")
+}
+
+// TestCIAPIKeyGatewayFlow runs the full gateway pipeline through the
+// API key-authenticated test service.
+func TestCIAPIKeyGatewayFlow(t *testing.T) {
+	env := ciSetup(t)
+	env.activateTestAPIKey(t)
+	env.runGatewayFlow(t, "test_apikey", "list_items")
+}
+
+// TestCINoAuthGatewayFlow runs the full gateway pipeline through the
+// credential-free test service.
+func TestCINoAuthGatewayFlow(t *testing.T) {
+	env := ciSetup(t)
+	env.activateTestNoAuth(t)
+	env.runGatewayFlow(t, "test_noauth", "list_items")
+}
+
+// ── Full Agent Lifecycle with Test Adapters ──────────────────────────────────
+
+// TestCIAgentLifecycle exercises the complete agent lifecycle using test
+// adapters: connect → catalog → task → gateway → complete.
+func TestCIAgentLifecycle(t *testing.T) {
+	env := ciSetup(t)
+
+	// Activate all test services.
+	env.activateTestOAuth(t)
+	env.activateTestAPIKey(t)
+	env.activateTestNoAuth(t)
+
+	// ── Connect a new agent with ?wait=true ──────────────────────────────
+	agentName := fmt.Sprintf("ci-lifecycle-%d", time.Now().UnixNano())
+	approvedCh := approveConnectionInBackground(t, env.e2eEnv, agentName)
+
+	connResp := env.doLongPoll("POST", "/api/agents/connect?wait=true&timeout=30", "", map[string]any{
+		"name":        agentName,
+		"description": "CI lifecycle test agent",
+	})
+	connM := mustStatus(t, connResp, http.StatusCreated)
+	if strOr(connM, "status", "") != "approved" {
+		t.Fatalf("expected approved, got %s", strOr(connM, "status", ""))
+	}
+	agentToken := strOr(connM, "token", "")
+	if agentToken == "" || !strings.HasPrefix(agentToken, "cvis_") {
+		t.Fatal("expected cvis_ token")
+	}
+	t.Logf("connected as %s", agentName)
+	<-approvedCh
+
+	agentReq := func(method, path string, body any) *http.Response {
+		return env.doRaw(method, path, agentToken, body)
+	}
+	agentLongPoll := func(method, path string, body any) *http.Response {
+		return env.doLongPoll(method, path, agentToken, body)
+	}
+
+	// ── Fetch catalog ────────────────────────────────────────────────────
+	catalogResp := agentReq("GET", "/api/skill/catalog", nil)
+	defer catalogResp.Body.Close()
+	if catalogResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(catalogResp.Body)
+		t.Fatalf("catalog: status %d: %s", catalogResp.StatusCode, body)
+	}
+	catalogBody, _ := io.ReadAll(catalogResp.Body)
+	catalog := string(catalogBody)
+
+	// All three test services should appear.
+	for _, svc := range []string{"test_oauth", "test_apikey", "test_noauth"} {
+		if !strings.Contains(catalog, svc) {
+			t.Errorf("catalog missing %s", svc)
+		}
+	}
+	t.Logf("catalog: %d bytes, all test services found", len(catalog))
+
+	// ── Test each service through the gateway ────────────────────────────
+	for _, tc := range []struct {
+		service string
+		action  string
+	}{
+		{"test_oauth", "list_items"},
+		{"test_apikey", "list_items"},
+		{"test_noauth", "list_items"},
+	} {
+		t.Run(tc.service, func(t *testing.T) {
+			purposeMarker := fmt.Sprintf("ci-lifecycle-%s-%d", tc.service, time.Now().UnixNano())
+			taskApprovedCh := approveTaskInBackground(t, env.e2eEnv, purposeMarker)
+
+			taskResp := agentLongPoll("POST", "/api/tasks?wait=true&timeout=30", map[string]any{
+				"purpose": fmt.Sprintf("CI lifecycle [%s]: %s/%s", purposeMarker, tc.service, tc.action),
+				"authorized_actions": []map[string]any{{
+					"service":      tc.service,
+					"action":       tc.action,
+					"auto_execute": true,
+				}},
+			})
+			taskM := mustStatus(t, taskResp, http.StatusCreated)
+			taskID := strOr(taskM, "id", strOr(taskM, "task_id", ""))
+			if taskID == "" {
+				t.Fatal("no task_id")
+			}
+			taskStatus := strOr(taskM, "status", "")
+			if taskStatus != "approved" && taskStatus != "active" {
+				t.Fatalf("expected approved/active, got %s", taskStatus)
+			}
+			<-taskApprovedCh
+
+			reqID := fmt.Sprintf("ci-%s-%d", tc.service, time.Now().UnixNano())
+			gwResp := agentLongPoll("POST", "/api/gateway/request?wait=true&timeout=30", map[string]any{
+				"service":    tc.service,
+				"action":     tc.action,
+				"params":     map[string]any{},
+				"reason":     fmt.Sprintf("CI lifecycle test: %s/%s", tc.service, tc.action),
+				"request_id": reqID,
+				"task_id":    taskID,
+			})
+			gwM := parseGatewayResponse(t, gwResp)
+			gwStatus := str(t, gwM, "status")
+			t.Logf("gateway status=%s", gwStatus)
+			env.executeIfReady(t, reqID, gwStatus, gwM)
+
+			completeResp := agentReq("POST", fmt.Sprintf("/api/tasks/%s/complete", taskID), nil)
+			defer completeResp.Body.Close()
+			if completeResp.StatusCode != http.StatusOK {
+				body, _ := io.ReadAll(completeResp.Body)
+				t.Fatalf("complete: status %d: %s", completeResp.StatusCode, body)
+			}
+			t.Logf("task %s completed", taskID)
+		})
+	}
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+// runGatewayFlow creates a task, approves it, sends a gateway request, and
+// verifies execution through the full pipeline for a single service/action.
+func (e *ciTestEnv) runGatewayFlow(t *testing.T, service, action string) {
+	t.Helper()
+
+	purposeMarker := fmt.Sprintf("ci-gw-%s-%d", service, time.Now().UnixNano())
+	taskApprovedCh := approveTaskInBackground(t, e.e2eEnv, purposeMarker)
+
+	taskResp := e.doLongPoll("POST", "/api/tasks?wait=true&timeout=30", e.AgentToken, map[string]any{
+		"purpose": fmt.Sprintf("CI gateway test [%s]: %s/%s", purposeMarker, service, action),
+		"authorized_actions": []map[string]any{{
+			"service":      service,
+			"action":       action,
+			"auto_execute": true,
+		}},
+	})
+	taskM := mustStatus(t, taskResp, http.StatusCreated)
+	taskID := strOr(taskM, "id", strOr(taskM, "task_id", ""))
+	if taskID == "" {
+		t.Fatal("no task_id")
+	}
+	taskStatus := strOr(taskM, "status", "")
+	if taskStatus != "approved" && taskStatus != "active" {
+		t.Fatalf("expected approved/active, got %s", taskStatus)
+	}
+	t.Logf("task %s approved", taskID)
+	<-taskApprovedCh
+
+	reqID := fmt.Sprintf("ci-gw-%s-%d", service, time.Now().UnixNano())
+	gwResp := e.doLongPoll("POST", "/api/gateway/request?wait=true&timeout=30", e.AgentToken, map[string]any{
+		"service":    service,
+		"action":     action,
+		"params":     map[string]any{},
+		"reason":     fmt.Sprintf("CI gateway test: %s/%s", service, action),
+		"request_id": reqID,
+		"task_id":    taskID,
+	})
+	gwM := parseGatewayResponse(t, gwResp)
+	gwStatus := str(t, gwM, "status")
+	t.Logf("gateway status=%s", gwStatus)
+	e.executeIfReady(t, reqID, gwStatus, gwM)
+
+	completeResp := e.agentDo("POST", fmt.Sprintf("/api/tasks/%s/complete", taskID), nil)
+	defer completeResp.Body.Close()
+	if completeResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(completeResp.Body)
+		t.Fatalf("complete: status %d: %s", completeResp.StatusCode, body)
+	}
+	t.Log("task completed — gateway flow passed")
+}

--- a/e2e/smoke/claude_cli_test.go
+++ b/e2e/smoke/claude_cli_test.go
@@ -1,0 +1,383 @@
+package smoke_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestClaudeCLISetup launches the real Claude CLI with the /clawvisor-setup
+// instructions and verifies it completes the full setup flow against the
+// test server. This is a true end-to-end test: a real AI agent follows
+// instructions to connect, configure, and smoke-test the Clawvisor gateway.
+func TestClaudeCLISetup(t *testing.T) {
+	if os.Getenv("CLAWVISOR_E2E_CLAUDE_CLI") == "" {
+		t.Skip("skipping: set CLAWVISOR_E2E_CLAUDE_CLI=1 to run Claude CLI tests (uses API credits)")
+	}
+
+	claudeBin, err := exec.LookPath("claude")
+	if err != nil {
+		t.Skip("skipping: claude CLI not found in PATH")
+	}
+	t.Logf("using claude CLI: %s", claudeBin)
+
+	env := setup(t)
+
+	// Use a temp file for settings output so we don't touch real ~/.claude/settings.json.
+	settingsPath := filepath.Join(env.tmpDir, "claude-settings.json")
+	if err := os.WriteFile(settingsPath, []byte("{}"), 0644); err != nil {
+		t.Fatalf("write initial settings: %v", err)
+	}
+	t.Logf("settings output path: %s", settingsPath)
+
+	// Build the prompt: the setup command with URLs rewritten to our test server.
+	prompt := buildSetupPrompt(t, env.baseURL, settingsPath)
+
+	// Start background approver for connection requests and tasks.
+	done := make(chan struct{})
+	defer close(done)
+	go backgroundApprover(t, env, done)
+
+	// Launch Claude CLI.
+	cmd := exec.Command(claudeBin,
+		"-p",
+		"--dangerously-skip-permissions",
+		"--model", "sonnet",
+		"--no-session-persistence",
+		"--max-budget-usd", "1.00",
+		prompt,
+	)
+	cmd.Dir = env.tmpDir
+
+	// Build env: inherit everything except CLAUDECODE (which blocks nested sessions).
+	var cmdEnv []string
+	for _, e := range os.Environ() {
+		if strings.HasPrefix(e, "CLAUDECODE=") {
+			continue
+		}
+		cmdEnv = append(cmdEnv, e)
+	}
+	cmdEnv = append(cmdEnv,
+		"CLAWVISOR_URL="+env.baseURL,
+	)
+	cmd.Env = cmdEnv
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	t.Log("launching Claude CLI...")
+	startTime := time.Now()
+	err = cmd.Run()
+	elapsed := time.Since(startTime)
+	t.Logf("Claude CLI finished in %s (exit=%v)", elapsed.Round(time.Millisecond), err)
+
+	output := stdout.String()
+	if len(output) > 2000 {
+		t.Logf("claude output (first 2000 chars):\n%s\n...(truncated)", output[:2000])
+	} else {
+		t.Logf("claude output:\n%s", output)
+	}
+	if stderr.Len() > 0 {
+		t.Logf("claude stderr:\n%s", stderr.String())
+	}
+
+	if err != nil {
+		t.Fatalf("claude CLI failed: %v", err)
+	}
+
+	// ── Verify the results ────────────────────────────────────────────────
+
+	// 1. Check that Claude wrote the settings file with the token.
+	verifySettingsWritten(t, settingsPath)
+
+	// 2. Check that an agent was created via the connection flow.
+	verifyAgentConnected(t, env)
+
+	// 3. Look for success indicators in the output.
+	verifyOutputIndicators(t, output)
+}
+
+// buildSetupPrompt constructs the prompt for Claude CLI, rewriting the
+// setup command's hardcoded localhost:25297 to the test server's URL.
+func buildSetupPrompt(t *testing.T, baseURL, settingsPath string) string {
+	t.Helper()
+
+	return fmt.Sprintf(`You are running the Clawvisor setup flow against a test server.
+Follow these steps exactly. This is non-interactive — do not ask for user
+confirmation. The server is already running and a background process will
+auto-approve all connection requests and tasks within a few seconds.
+
+IMPORTANT: The Clawvisor server is at %s (NOT localhost:25297).
+Use %s everywhere instead of http://localhost:25297.
+
+IMPORTANT: Write settings to %s (NOT ~/.claude/settings.json).
+
+## Steps
+
+### 1. Verify the daemon is running
+
+Run: curl -sf %s/ready && echo "RUNNING" || echo "NOT RUNNING"
+
+If RUNNING, proceed. If not, stop and report failure.
+
+### 2. Connect as an agent
+
+Run: curl -s -X POST "%s/api/agents/connect?wait=true&timeout=30" -H "Content-Type: application/json" -d '{"name": "claude-code", "description": "Claude Code agent"}'
+
+Parse the JSON response. Extract the "token" field. If status is not "approved",
+wait a moment and retry — a background process will approve within seconds.
+
+### 3. Set environment variables
+
+Read %s (it already exists with "{}").
+Write the following JSON to it:
+{
+  "env": {
+    "CLAWVISOR_URL": "%s",
+    "CLAWVISOR_AGENT_TOKEN": "<token from step 2>"
+  }
+}
+
+### 4. Verify
+
+Run: curl -sf -H "Authorization: Bearer <token>" %s/api/skill/catalog | head -20
+
+Confirm it returns a service catalog. If it returns 401, something went wrong.
+
+### 5. Smoke test
+
+Pick any service from the catalog that is activated. Create a read-only task:
+
+curl -s -X POST "%s/api/tasks?wait=true&timeout=30" -H "Authorization: Bearer <token>" -H "Content-Type: application/json" -d '{"purpose": "Setup smoke test", "authorized_actions": [{"service": "<svc>", "action": "<read_action>", "auto_execute": true}]}'
+
+Then make an in-scope gateway request:
+
+curl -s -X POST "%s/api/gateway/request?wait=true&timeout=30" -H "Authorization: Bearer <token>" -H "Content-Type: application/json" -d '{"service": "<svc>", "action": "<read_action>", "params": {}, "reason": "Setup smoke test", "request_id": "e2e-cli-test", "task_id": "<task_id>"}'
+
+Report whether the request succeeded (status=executed) or was restricted.
+
+Then complete the task:
+
+curl -s -X POST "%s/api/tasks/<task_id>/complete" -H "Authorization: Bearer <token>"
+
+### 6. Done
+
+Print "CLAWVISOR_SETUP_COMPLETE" to indicate success. Do NOT offer to uninstall
+anything. Summarize what happened.`,
+		baseURL, baseURL,
+		settingsPath,
+		baseURL,
+		baseURL,
+		settingsPath, baseURL,
+		baseURL,
+		baseURL,
+		baseURL,
+		baseURL,
+	)
+}
+
+// backgroundApprover continuously approves any pending connection requests
+// and tasks while the Claude CLI is running.
+func backgroundApprover(t *testing.T, env *e2eEnv, done <-chan struct{}) {
+	t.Helper()
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-done:
+			return
+		case <-ticker.C:
+			// Approve pending connections.
+			connResp := env.userDo("GET", "/api/agents/connections", nil)
+			connBody, _ := io.ReadAll(connResp.Body)
+			connResp.Body.Close()
+			if connResp.StatusCode == http.StatusOK {
+				var connections []map[string]any
+				if json.Unmarshal(connBody, &connections) == nil {
+					for _, c := range connections {
+						if strOr(c, "status", "") == "pending" {
+							id := strOr(c, "id", "")
+							if id != "" {
+								r := env.userDo("POST", fmt.Sprintf("/api/agents/connect/%s/approve", id), nil)
+								r.Body.Close()
+								if r.StatusCode == http.StatusOK {
+									t.Logf("[approver] approved connection %s", id)
+								}
+							}
+						}
+					}
+				}
+			}
+
+			// Approve pending tasks.
+			taskResp := env.userDo("GET", "/api/tasks", nil)
+			taskBody, _ := io.ReadAll(taskResp.Body)
+			taskResp.Body.Close()
+			if taskResp.StatusCode == http.StatusOK {
+				var m map[string]any
+				if json.Unmarshal(taskBody, &m) == nil {
+					tasks, _ := m["tasks"].([]any)
+					for _, raw := range tasks {
+						task, ok := raw.(map[string]any)
+						if !ok {
+							continue
+						}
+						status := strOr(task, "status", "")
+						id := strOr(task, "id", "")
+						if id != "" && (status == "pending_approval" || status == "pending") {
+							r := env.userDo("POST", fmt.Sprintf("/api/tasks/%s/approve", id), nil)
+							r.Body.Close()
+							if r.StatusCode == http.StatusOK {
+								t.Logf("[approver] approved task %s", id)
+							}
+						}
+						if id != "" && status == "pending_scope_expansion" {
+							r := env.userDo("POST", fmt.Sprintf("/api/tasks/%s/expand/approve", id), nil)
+							r.Body.Close()
+							if r.StatusCode == http.StatusOK {
+								t.Logf("[approver] approved expansion for task %s", id)
+							}
+						}
+					}
+				}
+			}
+
+			// Approve pending gateway requests.
+			approvalsResp := env.userDo("GET", "/api/approvals", nil)
+			approvalsBody, _ := io.ReadAll(approvalsResp.Body)
+			approvalsResp.Body.Close()
+			if approvalsResp.StatusCode == http.StatusOK {
+				var approvals []map[string]any
+				if json.Unmarshal(approvalsBody, &approvals) == nil {
+					for _, a := range approvals {
+						if strOr(a, "status", "") == "pending" {
+							reqID := strOr(a, "request_id", "")
+							if reqID != "" {
+								r := env.userDo("POST", fmt.Sprintf("/api/approvals/%s/approve", reqID), nil)
+								r.Body.Close()
+								if r.StatusCode == http.StatusOK {
+									t.Logf("[approver] approved request %s", reqID)
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+// verifySettingsWritten checks that Claude wrote CLAWVISOR_AGENT_TOKEN
+// into the settings file.
+func verifySettingsWritten(t *testing.T, settingsPath string) {
+	t.Helper()
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Errorf("settings.json not readable: %v", err)
+		return
+	}
+
+	var settings map[string]any
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Errorf("settings.json not valid JSON: %v", err)
+		return
+	}
+
+	envMap, ok := settings["env"].(map[string]any)
+	if !ok {
+		t.Error("settings.json missing 'env' object")
+		return
+	}
+
+	token, ok := envMap["CLAWVISOR_AGENT_TOKEN"].(string)
+	if !ok || token == "" {
+		t.Error("settings.json missing CLAWVISOR_AGENT_TOKEN")
+		return
+	}
+	if !strings.HasPrefix(token, "cvis_") {
+		t.Errorf("token doesn't have cvis_ prefix: %s", token[:min(len(token), 10)])
+		return
+	}
+	t.Logf("verified: settings.json has CLAWVISOR_AGENT_TOKEN (%d chars)", len(token))
+
+	url, _ := envMap["CLAWVISOR_URL"].(string)
+	if url == "" {
+		t.Error("settings.json missing CLAWVISOR_URL")
+	} else {
+		t.Logf("verified: settings.json has CLAWVISOR_URL=%s", url)
+	}
+}
+
+// verifyAgentConnected checks that a "claude-code" agent was registered.
+func verifyAgentConnected(t *testing.T, env *e2eEnv) {
+	t.Helper()
+	resp := env.userDo("GET", "/api/agents", nil)
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("list agents: %d", resp.StatusCode)
+		return
+	}
+
+	var agents []map[string]any
+	if err := json.Unmarshal(b, &agents); err != nil {
+		t.Errorf("parse agents: %v", err)
+		return
+	}
+
+	for _, a := range agents {
+		name := strOr(a, "name", "")
+		if name == "claude-code" {
+			t.Logf("verified: claude-code agent exists (id=%s)", strOr(a, "id", "?"))
+			return
+		}
+	}
+	t.Error("claude-code agent not found in agents list")
+}
+
+// verifyOutputIndicators checks Claude's output for signs the setup succeeded.
+func verifyOutputIndicators(t *testing.T, output string) {
+	t.Helper()
+	lower := strings.ToLower(output)
+
+	// Check for the explicit success marker we asked Claude to print.
+	if strings.Contains(output, "CLAWVISOR_SETUP_COMPLETE") {
+		t.Log("verified: Claude printed CLAWVISOR_SETUP_COMPLETE")
+	} else {
+		t.Error("Claude did not print CLAWVISOR_SETUP_COMPLETE")
+	}
+
+	// Check for signs of successful steps.
+	indicators := []struct {
+		name   string
+		marker string
+	}{
+		{"daemon running", "running"},
+		{"token received", "cvis_"},
+		{"catalog fetched", "catalog"},
+	}
+	for _, ind := range indicators {
+		if strings.Contains(lower, ind.marker) {
+			t.Logf("verified: output mentions %s", ind.name)
+		}
+	}
+
+	// Check for error indicators.
+	errorMarkers := []string{"not running", "401", "failed to connect", "error"}
+	for _, em := range errorMarkers {
+		if strings.Contains(lower, em) {
+			// Not necessarily a failure — Claude might be reporting what happened.
+			t.Logf("note: output contains %q (may be informational)", em)
+		}
+	}
+}

--- a/e2e/smoke/claude_code_test.go
+++ b/e2e/smoke/claude_code_test.go
@@ -1,0 +1,451 @@
+package smoke_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// longPollClient returns an HTTP client with a timeout long enough for
+// ?wait=true long-poll requests (the server defaults to 120s).
+func longPollClient() *http.Client {
+	return &http.Client{Timeout: 150 * time.Second}
+}
+
+// doLongPoll is like doRaw but uses a long-poll client for ?wait=true requests.
+func (e *e2eEnv) doLongPoll(method, path string, token string, body any) *http.Response {
+	saved := e.client
+	e.client = longPollClient()
+	defer func() { e.client = saved }()
+	return e.doRaw(method, path, token, body)
+}
+
+// approveConnectionInBackground lists pending connections and approves the one
+// matching agentName. Must be called before the blocking ?wait=true POST.
+// Returns a channel that receives the connection_id once approved.
+func approveConnectionInBackground(t *testing.T, env *e2eEnv, agentName string) <-chan string {
+	t.Helper()
+	ch := make(chan string, 1)
+	go func() {
+		defer close(ch)
+		for i := 0; i < 30; i++ {
+			time.Sleep(500 * time.Millisecond)
+			resp := env.userDo("GET", "/api/agents/connections", nil)
+			defer resp.Body.Close()
+			b, _ := io.ReadAll(resp.Body)
+			if resp.StatusCode != http.StatusOK {
+				continue
+			}
+			var connections []map[string]any
+			if err := json.Unmarshal(b, &connections); err != nil {
+				continue
+			}
+			for _, c := range connections {
+				name := strOr(c, "name", "")
+				status := strOr(c, "status", "")
+				id := strOr(c, "id", "")
+				if name == agentName && status == "pending" && id != "" {
+					approveResp := env.userDo("POST", fmt.Sprintf("/api/agents/connect/%s/approve", id), nil)
+					approveResp.Body.Close()
+					if approveResp.StatusCode == http.StatusOK {
+						ch <- id
+						return
+					}
+				}
+			}
+		}
+	}()
+	return ch
+}
+
+// approveTaskInBackground polls for a pending task owned by the given agent
+// and approves it. Returns a channel that receives the task_id once approved.
+func approveTaskInBackground(t *testing.T, env *e2eEnv, purpose string) <-chan string {
+	t.Helper()
+	ch := make(chan string, 1)
+	go func() {
+		defer close(ch)
+		for i := 0; i < 30; i++ {
+			time.Sleep(500 * time.Millisecond)
+			resp := env.userDo("GET", "/api/tasks", nil)
+			defer resp.Body.Close()
+			b, _ := io.ReadAll(resp.Body)
+			if resp.StatusCode != http.StatusOK {
+				continue
+			}
+			var m map[string]any
+			if err := json.Unmarshal(b, &m); err != nil {
+				continue
+			}
+			tasks, _ := m["tasks"].([]any)
+			for _, raw := range tasks {
+				task, ok := raw.(map[string]any)
+				if !ok {
+					continue
+				}
+				p := strOr(task, "purpose", "")
+				s := strOr(task, "status", "")
+				id := strOr(task, "id", "")
+				if strings.Contains(p, purpose) && (s == "pending_approval" || s == "pending") && id != "" {
+					approveResp := env.userDo("POST", fmt.Sprintf("/api/tasks/%s/approve", id), nil)
+					approveResp.Body.Close()
+					if approveResp.StatusCode == http.StatusOK {
+						ch <- id
+						return
+					}
+				}
+			}
+		}
+	}()
+	return ch
+}
+
+// TestClaudeCodeSetupFlow simulates the exact steps that /clawvisor-setup
+// tells Claude Code to execute:
+//
+//  1. Verify daemon running (GET /ready)
+//  2. Connect as "claude-code" agent with ?wait=true (long-poll)
+//  3. Verify token by fetching catalog
+//  4. Smoke test: in-scope read succeeds, out-of-scope request denied
+//  5. Complete the task
+func TestClaudeCodeSetupFlow(t *testing.T) {
+	env := setup(t)
+	svcID, action, params := env.pickActivatedReadService(t)
+
+	// ── Step 1: Verify daemon running ─────────────────────────────────────
+	readyResp := env.doRaw("GET", "/ready", "", nil)
+	mustStatus(t, readyResp, http.StatusOK)
+	t.Log("step 1: daemon is running")
+
+	// ── Step 2: Connect as "claude-code" with ?wait=true ──────────────────
+	// Start background approver before the blocking POST.
+	agentName := fmt.Sprintf("claude-code-e2e-%d", time.Now().UnixNano())
+	approvedCh := approveConnectionInBackground(t, env, agentName)
+
+	connResp := env.doLongPoll("POST", "/api/agents/connect?wait=true&timeout=30", "", map[string]any{
+		"name":        agentName,
+		"description": "Claude Code agent (e2e test)",
+	})
+	connM := mustStatus(t, connResp, http.StatusCreated)
+	connStatus := strOr(connM, "status", "")
+	if connStatus != "approved" {
+		t.Fatalf("expected approved, got %s", connStatus)
+	}
+	claudeToken := strOr(connM, "token", "")
+	if claudeToken == "" {
+		t.Fatal("expected token in ?wait=true response")
+	}
+	if !strings.HasPrefix(claudeToken, "cvis_") {
+		t.Errorf("token missing cvis_ prefix: %q", claudeToken[:10])
+	}
+	t.Logf("step 2: connected as %s, token=%d chars", agentName, len(claudeToken))
+
+	// Drain the approval channel.
+	<-approvedCh
+
+	claudeReq := func(method, path string, body any) *http.Response {
+		return env.doRaw(method, path, claudeToken, body)
+	}
+	claudeLongPoll := func(method, path string, body any) *http.Response {
+		return env.doLongPoll(method, path, claudeToken, body)
+	}
+
+	// ── Step 3: Verify token via catalog ──────────────────────────────────
+	catalogResp := claudeReq("GET", "/api/skill/catalog", nil)
+	defer catalogResp.Body.Close()
+	if catalogResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(catalogResp.Body)
+		t.Fatalf("catalog: status %d: %s", catalogResp.StatusCode, body)
+	}
+	catalogBody, _ := io.ReadAll(catalogResp.Body)
+	if !strings.Contains(string(catalogBody), "Service Catalog") {
+		t.Error("catalog response missing expected header")
+	}
+	t.Logf("step 3: catalog verified (%d bytes)", len(catalogBody))
+
+	// ── Step 4: Smoke test — create task with ?wait=true ──────────────────
+	purposeMarker := fmt.Sprintf("setup-smoke-%d", time.Now().UnixNano())
+	taskApprovedCh := approveTaskInBackground(t, env, purposeMarker)
+
+	taskResp := claudeLongPoll("POST", "/api/tasks?wait=true&timeout=30", map[string]any{
+		"purpose": fmt.Sprintf("Clawvisor setup smoke test [%s]: read %s data", purposeMarker, svcID),
+		"authorized_actions": []map[string]any{{
+			"service":      svcID,
+			"action":       action,
+			"auto_execute": true,
+			"expected_use": "Setup smoke test — verify in-scope read works",
+		}},
+	})
+	taskM := mustStatus(t, taskResp, http.StatusCreated)
+	taskID := strOr(taskM, "id", strOr(taskM, "task_id", ""))
+	if taskID == "" {
+		t.Fatal("no task_id in response")
+	}
+	taskStatus := strOr(taskM, "status", "")
+	if taskStatus != "approved" && taskStatus != "active" {
+		t.Fatalf("expected task approved/active after wait, got %s", taskStatus)
+	}
+	t.Logf("step 4a: task %s created and approved via ?wait=true", taskID)
+	<-taskApprovedCh
+
+	// In-scope request (should succeed with auto_execute=true).
+	reqID := fmt.Sprintf("e2e-setup-inscope-%d", time.Now().UnixNano())
+	gwResp := claudeLongPoll("POST", "/api/gateway/request?wait=true&timeout=30", map[string]any{
+		"service":    svcID,
+		"action":     action,
+		"params":     params,
+		"reason":     "Setup smoke test — in-scope read",
+		"request_id": reqID,
+		"task_id":    taskID,
+	})
+	gwM := parseGatewayResponse(t, gwResp)
+	gwStatus := str(t, gwM, "status")
+	t.Logf("step 4b: in-scope request status=%s", gwStatus)
+
+	switch gwStatus {
+	case "executed", "completed", "approved", "auto_approved":
+		// Success path.
+	case "restricted":
+		t.Log("in-scope request restricted by intent verification (non-fatal)")
+	case "blocked":
+		t.Log("in-scope request blocked by restriction rule (non-fatal)")
+	default:
+		t.Errorf("unexpected in-scope status: %s", gwStatus)
+	}
+
+	// Out-of-scope request (different action not in the task).
+	secondAction := env.pickSecondAction(t, svcID, action)
+	if secondAction != "" {
+		oosReqID := fmt.Sprintf("e2e-setup-oos-%d", time.Now().UnixNano())
+		oosResp := claudeReq("POST", "/api/gateway/request", map[string]any{
+			"service":    svcID,
+			"action":     secondAction,
+			"params":     map[string]any{},
+			"reason":     "Setup smoke test — out-of-scope (should be denied)",
+			"request_id": oosReqID,
+			"task_id":    taskID,
+		})
+		defer oosResp.Body.Close()
+		oosBody, _ := io.ReadAll(oosResp.Body)
+		var oosM map[string]any
+		if err := json.Unmarshal(oosBody, &oosM); err == nil {
+			oosStatus := strOr(oosM, "status", "")
+			if oosStatus == "executed" || oosStatus == "auto_approved" {
+				t.Errorf("out-of-scope request should not succeed, got status=%s", oosStatus)
+			} else {
+				t.Logf("step 4c: out-of-scope request correctly returned status=%s", oosStatus)
+			}
+		} else {
+			t.Logf("step 4c: out-of-scope request returned HTTP %d (non-200 expected)", oosResp.StatusCode)
+		}
+	} else {
+		t.Log("step 4c: skipped out-of-scope test (no second action available)")
+	}
+
+	// ── Step 5: Complete the task ─────────────────────────────────────────
+	completeResp := claudeReq("POST", fmt.Sprintf("/api/tasks/%s/complete", taskID), nil)
+	defer completeResp.Body.Close()
+	if completeResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(completeResp.Body)
+		t.Fatalf("complete: status %d: %s", completeResp.StatusCode, body)
+	}
+	t.Log("step 5: task completed — Claude Code setup flow passed")
+}
+
+// TestClaudeCodeSkillFlow simulates how Claude Code uses the Clawvisor skill
+// after setup is complete, following the "Typical Flow" from SKILL.md:
+// catalog → task(?wait=true) → gateway(?wait=true) → complete.
+func TestClaudeCodeSkillFlow(t *testing.T) {
+	env := setup(t)
+	svcID, action, params := env.pickActivatedReadService(t)
+
+	// Use the harness agent token (simulates an already-connected Claude Code).
+	agentToken := env.AgentToken
+
+	agentReq := func(method, path string, body any) *http.Response {
+		return env.doRaw(method, path, agentToken, body)
+	}
+	agentLongPoll := func(method, path string, body any) *http.Response {
+		return env.doLongPoll(method, path, agentToken, body)
+	}
+
+	// ── Fetch catalog ─────────────────────────────────────────────────────
+	catalogResp := agentReq("GET", "/api/skill/catalog", nil)
+	defer catalogResp.Body.Close()
+	if catalogResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(catalogResp.Body)
+		t.Fatalf("catalog: status %d: %s", catalogResp.StatusCode, body)
+	}
+	catalogBody, _ := io.ReadAll(catalogResp.Body)
+	if !strings.Contains(string(catalogBody), svcID) {
+		t.Fatalf("catalog missing %s", svcID)
+	}
+	t.Logf("catalog fetched, found %s (%d bytes)", svcID, len(catalogBody))
+
+	// ── Create task with ?wait=true ───────────────────────────────────────
+	purposeMarker := fmt.Sprintf("skill-flow-%d", time.Now().UnixNano())
+	taskApprovedCh := approveTaskInBackground(t, env, purposeMarker)
+
+	taskResp := agentLongPoll("POST", "/api/tasks?wait=true&timeout=30", map[string]any{
+		"purpose": fmt.Sprintf("Skill flow test [%s]: %s/%s", purposeMarker, svcID, action),
+		"authorized_actions": []map[string]any{{
+			"service":      svcID,
+			"action":       action,
+			"auto_execute": true,
+			"expected_use": "Skill flow test — read action",
+		}},
+	})
+	taskM := mustStatus(t, taskResp, http.StatusCreated)
+	taskID := strOr(taskM, "id", strOr(taskM, "task_id", ""))
+	if taskID == "" {
+		t.Fatal("no task_id in response")
+	}
+	taskStatus := strOr(taskM, "status", "")
+	if taskStatus != "approved" && taskStatus != "active" {
+		t.Fatalf("expected approved/active after wait, got %s", taskStatus)
+	}
+	t.Logf("task %s approved via ?wait=true", taskID)
+	<-taskApprovedCh
+
+	// ── Gateway request with ?wait=true ───────────────────────────────────
+	reqID := fmt.Sprintf("e2e-skill-%d", time.Now().UnixNano())
+	gwResp := agentLongPoll("POST", "/api/gateway/request?wait=true&timeout=30", map[string]any{
+		"service":    svcID,
+		"action":     action,
+		"params":     params,
+		"reason":     fmt.Sprintf("Skill flow test: %s/%s", svcID, action),
+		"request_id": reqID,
+		"task_id":    taskID,
+	})
+	gwM := parseGatewayResponse(t, gwResp)
+	gwStatus := str(t, gwM, "status")
+	t.Logf("gateway status=%s", gwStatus)
+	env.executeIfReady(t, reqID, gwStatus, gwM)
+
+	// ── Complete task ─────────────────────────────────────────────────────
+	completeResp := agentReq("POST", fmt.Sprintf("/api/tasks/%s/complete", taskID), nil)
+	defer completeResp.Body.Close()
+	if completeResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(completeResp.Body)
+		t.Fatalf("complete: status %d: %s", completeResp.StatusCode, body)
+	}
+
+	// Verify final status.
+	finalResp := agentReq("GET", fmt.Sprintf("/api/tasks/%s", taskID), nil)
+	finalM := mustStatus(t, finalResp, http.StatusOK)
+	if strOr(finalM, "status", "") != "completed" {
+		t.Errorf("expected completed, got %s", strOr(finalM, "status", ""))
+	}
+	t.Log("task completed — skill flow passed")
+}
+
+// TestClaudeCodeOutOfScopeBlocked verifies that the out-of-scope
+// demonstration from /clawvisor-setup step 5 works correctly: a gateway
+// request for an action not in the task's authorized_actions is rejected.
+func TestClaudeCodeOutOfScopeBlocked(t *testing.T) {
+	env := setup(t)
+	svcID, action, _ := env.pickActivatedReadService(t)
+
+	secondAction := env.pickSecondAction(t, svcID, action)
+	if secondAction == "" {
+		t.Skipf("service %s has no second action for out-of-scope test", svcID)
+	}
+
+	// Create task scoped to only the first action.
+	taskID := env.createApprovedTask(t, svcID, action, true)
+
+	// Request the second action (not in scope).
+	reqID := fmt.Sprintf("e2e-oos-%d", time.Now().UnixNano())
+	resp := env.agentDo("POST", "/api/gateway/request", map[string]any{
+		"service":    svcID,
+		"action":     secondAction,
+		"params":     map[string]any{},
+		"reason":     "Out-of-scope test — should be rejected",
+		"request_id": reqID,
+		"task_id":    taskID,
+	})
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Logf("out-of-scope returned HTTP %d (body not JSON)", resp.StatusCode)
+		if resp.StatusCode == http.StatusOK {
+			t.Error("expected non-success for out-of-scope request")
+		}
+		return
+	}
+
+	status := strOr(m, "status", "")
+	t.Logf("out-of-scope status=%s (HTTP %d)", status, resp.StatusCode)
+
+	// The server should return pending_scope_expansion, blocked, or a non-success status.
+	switch status {
+	case "pending_scope_expansion":
+		t.Log("correctly triggered scope expansion requirement")
+	case "blocked", "restricted", "denied", "pending", "pending_approval":
+		t.Logf("correctly rejected with status=%s", status)
+	case "executed", "auto_approved", "completed":
+		t.Errorf("out-of-scope request should not succeed, got status=%s", status)
+	default:
+		t.Logf("unexpected status=%s — verifying it's not a success", status)
+	}
+}
+
+// TestClaudeCodeWaitTrueTaskGet tests the ?wait=true long-poll on
+// GET /api/tasks/{id}, which Claude Code uses when a POST /api/tasks?wait=true
+// times out and it needs to resume polling.
+func TestClaudeCodeWaitTrueTaskGet(t *testing.T) {
+	env := setup(t)
+	svcID, action, _ := env.pickActivatedReadService(t)
+
+	// Create a task without ?wait=true so we can test the GET long-poll.
+	taskResp := env.agentDo("POST", "/api/tasks", map[string]any{
+		"purpose": "wait-true task get test",
+		"authorized_actions": []map[string]any{{
+			"service":      svcID,
+			"action":       action,
+			"auto_execute": true,
+		}},
+	})
+	taskM := mustStatus(t, taskResp, http.StatusCreated)
+	taskID := str(t, taskM, "task_id")
+	t.Logf("task %s created, testing GET ?wait=true", taskID)
+
+	// Approve from background while we long-poll.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 15; i++ {
+			time.Sleep(500 * time.Millisecond)
+			checkResp := env.agentDo("GET", fmt.Sprintf("/api/tasks/%s", taskID), nil)
+			checkM := mustStatus(t, checkResp, http.StatusOK)
+			s := strOr(checkM, "status", "")
+			if s == "pending_approval" || s == "pending" {
+				approveResp := env.userDo("POST", fmt.Sprintf("/api/tasks/%s/approve", taskID), nil)
+				approveResp.Body.Close()
+				return
+			}
+			if s == "approved" || s == "active" {
+				return
+			}
+		}
+	}()
+
+	// Long-poll GET until approved.
+	getResp := env.doLongPoll("GET", fmt.Sprintf("/api/tasks/%s?wait=true&timeout=30", taskID), env.AgentToken, nil)
+	getM := mustStatus(t, getResp, http.StatusOK)
+	s := strOr(getM, "status", "")
+	if s != "approved" && s != "active" {
+		t.Errorf("expected approved/active after wait, got %s", s)
+	}
+	t.Logf("GET ?wait=true returned status=%s", s)
+
+	wg.Wait()
+}

--- a/e2e/smoke/discovery_test.go
+++ b/e2e/smoke/discovery_test.go
@@ -1,0 +1,291 @@
+package smoke_test
+
+import (
+	"archive/zip"
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestSkillDocument verifies the rendered skill document is served and
+// contains the essential sections an agent needs to learn how to interact.
+func TestSkillDocument(t *testing.T) {
+	env := setup(t)
+
+	// /skill/SKILL.md serves the rendered template (claude-code target).
+	resp := env.doRaw("GET", "/skill/SKILL.md", "", nil)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("GET /skill/SKILL.md: status %d: %s", resp.StatusCode, body)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	skill := string(body)
+	t.Logf("SKILL.md: %d bytes", len(skill))
+
+	// Verify the skill document teaches agents the core API flow.
+	required := []struct {
+		section string
+		marker  string
+	}{
+		{"service catalog endpoint", "/api/skill/catalog"},
+		{"task creation endpoint", "/api/tasks"},
+		{"gateway endpoint", "/api/gateway/request"},
+		{"task completion", "/complete"},
+		{"authorization model", "auto_execute"},
+		{"agent token env var", "CLAWVISOR_AGENT_TOKEN"},
+		{"server URL env var", "CLAWVISOR_URL"},
+	}
+
+	for _, r := range required {
+		if !strings.Contains(skill, r.marker) {
+			t.Errorf("SKILL.md missing %s (expected %q)", r.section, r.marker)
+		}
+	}
+}
+
+// TestSetupDocument verifies the /skill/setup endpoint returns a
+// pre-filled onboarding document with the server URL.
+func TestSetupDocument(t *testing.T) {
+	env := setup(t)
+
+	resp := env.doRaw("GET", "/skill/setup", "", nil)
+	defer resp.Body.Close()
+
+	// The setup endpoint may return 404 if no daemon_id is configured,
+	// which is expected in local test mode.
+	if resp.StatusCode == http.StatusNotFound {
+		t.Log("GET /skill/setup returned 404 (no daemon_id configured — expected in local mode)")
+		return
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("GET /skill/setup: status %d: %s", resp.StatusCode, body)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	setup := string(body)
+	t.Logf("setup document: %d bytes", len(setup))
+
+	if !strings.Contains(setup, "CLAWVISOR_URL") {
+		t.Error("setup document missing CLAWVISOR_URL")
+	}
+}
+
+// TestSkillZipBundle verifies the /skill/skill.zip bundle contains
+// both SKILL.md and e2e.mjs.
+func TestSkillZipBundle(t *testing.T) {
+	env := setup(t)
+
+	resp := env.doRaw("GET", "/skill/skill.zip", "", nil)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("GET /skill/skill.zip: status %d: %s", resp.StatusCode, body)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	r, err := zip.NewReader(bytes.NewReader(body), int64(len(body)))
+	if err != nil {
+		t.Fatalf("invalid zip: %v", err)
+	}
+
+	files := map[string]bool{}
+	for _, f := range r.File {
+		files[f.Name] = true
+		t.Logf("  zip entry: %s (%d bytes)", f.Name, f.UncompressedSize64)
+	}
+
+	if !files["SKILL.md"] {
+		t.Error("skill.zip missing SKILL.md")
+	}
+	if !files["e2e.mjs"] {
+		t.Error("skill.zip missing e2e.mjs")
+	}
+}
+
+// TestE2EHelper verifies the e2e.mjs encryption helper is served
+// and looks like valid JavaScript.
+func TestE2EHelper(t *testing.T) {
+	env := setup(t)
+
+	resp := env.doRaw("GET", "/skill/e2e.mjs", "", nil)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("GET /skill/e2e.mjs: status %d: %s", resp.StatusCode, body)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	js := string(body)
+	t.Logf("e2e.mjs: %d bytes", len(js))
+
+	// Verify it contains the expected exports.
+	expected := []string{
+		"createClient",
+		"x25519",
+		"aes-256-gcm",
+		"clawvisor-e2e",
+	}
+	for _, e := range expected {
+		if !strings.Contains(js, e) {
+			t.Errorf("e2e.mjs missing expected content: %q", e)
+		}
+	}
+}
+
+// TestWellKnownKeys verifies the public key discovery endpoint.
+func TestWellKnownKeys(t *testing.T) {
+	env := setup(t)
+
+	resp := env.doRaw("GET", "/.well-known/clawvisor-keys", "", nil)
+	defer resp.Body.Close()
+
+	// Returns 404 when no daemon keys are configured (local mode with relay disabled).
+	if resp.StatusCode == http.StatusNotFound {
+		t.Log("/.well-known/clawvisor-keys returned 404 (relay disabled — expected)")
+		return
+	}
+
+	m := mustStatus(t, resp, http.StatusOK)
+	if daemonID := strOr(m, "daemon_id", ""); daemonID != "" {
+		t.Logf("daemon_id: %s", daemonID)
+	}
+	if algo := strOr(m, "algorithm", ""); algo != "" {
+		t.Logf("algorithm: %s", algo)
+	}
+	if key := strOr(m, "x25519", ""); key != "" {
+		t.Logf("x25519 public key: %s... (%d chars)", key[:16], len(key))
+	}
+}
+
+// TestAgentDiscoveryToExecution exercises the full path an agent would take
+// from reading the skill document through executing a real API request,
+// using ?wait=true long-polls as instructed by the setup script and skill doc:
+//
+//  1. Fetch /skill/SKILL.md — learn the API
+//  2. POST /api/agents/connect?wait=true — request access and block until approved
+//  3. GET /api/skill/catalog — discover available services (as taught by skill doc)
+//  4. POST /api/tasks?wait=true — create scoped task and block until approved
+//  5. POST /api/gateway/request?wait=true — execute read action
+//  6. POST /api/tasks/{id}/complete — finish
+func TestAgentDiscoveryToExecution(t *testing.T) {
+	env := setup(t)
+	svcID, action, params := env.pickActivatedReadService(t)
+
+	// ── Step 1: Agent reads the skill document ────────────────────────────
+	skillResp := env.doRaw("GET", "/skill/SKILL.md", "", nil)
+	defer skillResp.Body.Close()
+	if skillResp.StatusCode != http.StatusOK {
+		t.Fatalf("skill doc: status %d", skillResp.StatusCode)
+	}
+	skillBody, _ := io.ReadAll(skillResp.Body)
+	skill := string(skillBody)
+
+	// Verify the skill doc teaches the core API flow.
+	if !strings.Contains(skill, "/api/skill/catalog") {
+		t.Fatal("skill doc does not mention /api/skill/catalog")
+	}
+	if !strings.Contains(skill, "/api/tasks") {
+		t.Fatal("skill doc does not mention /api/tasks")
+	}
+	if !strings.Contains(skill, "/api/gateway/request") {
+		t.Fatal("skill doc does not mention /api/gateway/request")
+	}
+	t.Logf("step 1: read skill document (%d bytes), found all endpoint references", len(skill))
+
+	// ── Step 2: Agent connects with ?wait=true (blocks until approved) ────
+	agentName := fmt.Sprintf("e2e-discovery-%d", time.Now().UnixNano())
+	approvedCh := approveConnectionInBackground(t, env, agentName)
+
+	connResp := env.doLongPoll("POST", "/api/agents/connect?wait=true&timeout=30", "", map[string]any{
+		"name":        agentName,
+		"description": "Agent following setup doc instructions",
+	})
+	connM := mustStatus(t, connResp, http.StatusCreated)
+	connStatus := strOr(connM, "status", "")
+	if connStatus != "approved" {
+		t.Fatalf("expected approved, got %s", connStatus)
+	}
+	agentToken := strOr(connM, "token", "")
+	if agentToken == "" {
+		t.Fatal("expected token in ?wait=true response")
+	}
+	t.Logf("step 2: connected and received token (%d chars)", len(agentToken))
+	<-approvedCh
+
+	agentReq := func(method, path string, body any) *http.Response {
+		return env.doRaw(method, path, agentToken, body)
+	}
+	agentLongPoll := func(method, path string, body any) *http.Response {
+		return env.doLongPoll(method, path, agentToken, body)
+	}
+
+	// ── Step 3: Agent fetches catalog (as instructed by skill doc) ────────
+	catalogResp := agentReq("GET", "/api/skill/catalog", nil)
+	defer catalogResp.Body.Close()
+	if catalogResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(catalogResp.Body)
+		t.Fatalf("catalog: status %d: %s", catalogResp.StatusCode, body)
+	}
+	catalogBody, _ := io.ReadAll(catalogResp.Body)
+	catalog := string(catalogBody)
+	if !strings.Contains(catalog, svcID) {
+		t.Fatalf("catalog missing %s", svcID)
+	}
+	t.Logf("step 3: fetched catalog, found %s (%d bytes)", svcID, len(catalog))
+
+	// ── Step 4: Agent creates a task with ?wait=true ──────────────────────
+	purposeMarker := fmt.Sprintf("discovery-%d", time.Now().UnixNano())
+	taskApprovedCh := approveTaskInBackground(t, env, purposeMarker)
+
+	taskResp := agentLongPoll("POST", "/api/tasks?wait=true&timeout=30", map[string]any{
+		"purpose": fmt.Sprintf("Discovery test [%s]: read %s data", purposeMarker, svcID),
+		"authorized_actions": []map[string]any{{
+			"service":      svcID,
+			"action":       action,
+			"auto_execute": true,
+			"expected_use": "Following skill doc instructions for read-only access",
+		}},
+	})
+	taskM := mustStatus(t, taskResp, http.StatusCreated)
+	taskID := strOr(taskM, "id", strOr(taskM, "task_id", ""))
+	if taskID == "" {
+		t.Fatal("no task_id in response")
+	}
+	taskStatus := strOr(taskM, "status", "")
+	if taskStatus != "approved" && taskStatus != "active" {
+		t.Fatalf("expected approved/active after wait, got %s", taskStatus)
+	}
+	t.Logf("step 4: task %s approved via ?wait=true", taskID)
+	<-taskApprovedCh
+
+	// ── Step 5: Agent makes a gateway request with ?wait=true ─────────────
+	reqID := fmt.Sprintf("e2e-discovery-%d", time.Now().UnixNano())
+	gwResp := agentLongPoll("POST", "/api/gateway/request?wait=true&timeout=30", map[string]any{
+		"service":    svcID,
+		"action":     action,
+		"params":     params,
+		"reason":     "Discovery test: reading data as instructed by skill doc",
+		"request_id": reqID,
+		"task_id":    taskID,
+	})
+	gwM := parseGatewayResponse(t, gwResp)
+	gwStatus := str(t, gwM, "status")
+	t.Logf("step 5: gateway status=%s", gwStatus)
+	env.executeIfReady(t, reqID, gwStatus, gwM)
+
+	// ── Step 6: Agent completes the task ──────────────────────────────────
+	completeResp := agentReq("POST", fmt.Sprintf("/api/tasks/%s/complete", taskID), nil)
+	defer completeResp.Body.Close()
+	if completeResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(completeResp.Body)
+		t.Fatalf("complete: status %d: %s", completeResp.StatusCode, body)
+	}
+	t.Log("step 6: task completed — full discovery-to-execution flow passed")
+}

--- a/e2e/smoke/gateway_test.go
+++ b/e2e/smoke/gateway_test.go
@@ -1,0 +1,263 @@
+package smoke_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// TestGatewayReadOnly exercises the full gateway flow for a read-only
+// action: create task → approve → gateway request → poll → execute.
+func TestGatewayReadOnly(t *testing.T) {
+	env := setup(t)
+	svcID, action, params := env.pickActivatedReadService(t)
+
+	taskID := env.createApprovedTask(t, svcID, action, true)
+
+	reqID := fmt.Sprintf("e2e-gw-%d", time.Now().UnixNano())
+	resp := env.agentDo("POST", "/api/gateway/request", map[string]any{
+		"service":    svcID,
+		"action":     action,
+		"params":     params,
+		"reason":     fmt.Sprintf("e2e smoke test — %s/%s", svcID, action),
+		"request_id": reqID,
+		"task_id":    taskID,
+	})
+	m := parseGatewayResponse(t, resp)
+
+	status := str(t, m, "status")
+	t.Logf("gateway response status: %s", status)
+
+	env.executeIfReady(t, reqID, status, m)
+}
+
+// TestGatewayTaskApprovalFlow tests the full manual approval flow:
+// create task with auto_execute=false, submit request, approve, execute.
+func TestGatewayTaskApprovalFlow(t *testing.T) {
+	env := setup(t)
+	svcID, action, params := env.pickActivatedReadService(t)
+
+	// Create task WITHOUT auto_execute.
+	taskID := env.createApprovedTask(t, svcID, action, false)
+
+	reqID := fmt.Sprintf("e2e-gw-approval-%d", time.Now().UnixNano())
+	resp := env.agentDo("POST", "/api/gateway/request", map[string]any{
+		"service":    svcID,
+		"action":     action,
+		"params":     params,
+		"reason":     "e2e smoke test — approval flow",
+		"request_id": reqID,
+		"task_id":    taskID,
+	})
+	m := parseGatewayResponse(t, resp)
+	status := str(t, m, "status")
+	t.Logf("approval flow initial status: %s", status)
+
+	if status == "pending" || status == "pending_approval" {
+		approveResp := env.userDo("POST", fmt.Sprintf("/api/approvals/%s/approve", reqID), nil)
+		defer approveResp.Body.Close()
+		if approveResp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(approveResp.Body)
+			t.Fatalf("approve: status %d: %s", approveResp.StatusCode, body)
+		}
+		t.Log("approved request")
+
+		env.pollAndExecute(t, reqID)
+	} else {
+		env.executeIfReady(t, reqID, status, m)
+	}
+}
+
+// TestGatewayDeniedRequest tests that a denied request cannot be executed.
+func TestGatewayDeniedRequest(t *testing.T) {
+	env := setup(t)
+	svcID, action, params := env.pickActivatedReadService(t)
+
+	taskID := env.createApprovedTask(t, svcID, action, false)
+
+	reqID := fmt.Sprintf("e2e-gw-deny-%d", time.Now().UnixNano())
+	resp := env.agentDo("POST", "/api/gateway/request", map[string]any{
+		"service":    svcID,
+		"action":     action,
+		"params":     params,
+		"reason":     "e2e smoke test — deny flow",
+		"request_id": reqID,
+		"task_id":    taskID,
+	})
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+
+	// The gateway may return 200, 202, or 409 depending on task state timing.
+	if resp.StatusCode == http.StatusConflict {
+		t.Skipf("skipping deny test: gateway returned 409 (task state conflict): %s", b)
+	}
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("expected 200/202, got %d: %s", resp.StatusCode, b)
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	status := str(t, m, "status")
+
+	if status != "pending" && status != "pending_approval" {
+		t.Skipf("skipping deny test: status was %s, not pending", status)
+	}
+
+	// Deny the request.
+	denyResp := env.userDo("POST", fmt.Sprintf("/api/approvals/%s/deny", reqID), nil)
+	defer denyResp.Body.Close()
+	if denyResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(denyResp.Body)
+		t.Fatalf("deny: status %d: %s", denyResp.StatusCode, body)
+	}
+	t.Log("denied request")
+
+	// Verify execute fails.
+	execResp := env.agentDo("POST", fmt.Sprintf("/api/gateway/request/%s/execute", reqID), nil)
+	defer execResp.Body.Close()
+	if execResp.StatusCode == http.StatusOK {
+		t.Error("expected execute to fail after deny, but got 200")
+	}
+	t.Logf("execute after deny returned %d (expected non-200)", execResp.StatusCode)
+}
+
+// createApprovedTask creates a task with a single authorized action and
+// approves it via the user token. Returns the task ID.
+func (e *e2eEnv) createApprovedTask(t *testing.T, service, action string, autoExecute bool) string {
+	t.Helper()
+
+	resp := e.agentDo("POST", "/api/tasks", map[string]any{
+		"purpose": fmt.Sprintf("e2e test: %s/%s", service, action),
+		"authorized_actions": []map[string]any{{
+			"service":      service,
+			"action":       action,
+			"auto_execute": autoExecute,
+		}},
+	})
+	m := mustStatus(t, resp, http.StatusCreated)
+	taskID := str(t, m, "task_id")
+
+	// The task may need a moment for risk assessment to complete before
+	// it enters "pending_approval" state. Poll the task until it's ready.
+	for i := 0; i < 10; i++ {
+		taskResp := e.agentDo("GET", fmt.Sprintf("/api/tasks/%s", taskID), nil)
+		taskM := mustStatus(t, taskResp, http.StatusOK)
+		taskStatus := strOr(taskM, "status", "")
+		if taskStatus == "pending_approval" || taskStatus == "pending" {
+			break
+		}
+		if taskStatus == "approved" || taskStatus == "active" {
+			t.Logf("task %s already %s (%s/%s auto_execute=%v)", taskID, taskStatus, service, action, autoExecute)
+			return taskID
+		}
+		if taskStatus == "pending_scope_expansion" {
+			// Left over from a prior test; approve the expansion first.
+			expResp := e.userDo("POST", fmt.Sprintf("/api/tasks/%s/expand/approve", taskID), nil)
+			expResp.Body.Close()
+			continue
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+
+	// Approve the task.
+	approveResp := e.userDo("POST", fmt.Sprintf("/api/tasks/%s/approve", taskID), nil)
+	defer approveResp.Body.Close()
+	approveBody, _ := io.ReadAll(approveResp.Body)
+	if approveResp.StatusCode != http.StatusOK {
+		// Task may have been auto-approved already; check if it's in a usable state.
+		taskResp := e.agentDo("GET", fmt.Sprintf("/api/tasks/%s", taskID), nil)
+		taskM := mustStatus(t, taskResp, http.StatusOK)
+		taskStatus := strOr(taskM, "status", "")
+		if taskStatus == "approved" || taskStatus == "active" {
+			t.Logf("task %s already %s (approve returned %d)", taskID, taskStatus, approveResp.StatusCode)
+			return taskID
+		}
+		t.Fatalf("approve task %s: status %d: %s (task status: %s)", taskID, approveResp.StatusCode, approveBody, taskStatus)
+	}
+	t.Logf("created and approved task %s (%s/%s auto_execute=%v)", taskID, service, action, autoExecute)
+	return taskID
+}
+
+// parseGatewayResponse handles both 200 and 202 responses from the gateway.
+func parseGatewayResponse(t *testing.T, resp *http.Response) map[string]any {
+	t.Helper()
+	defer resp.Body.Close()
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("expected HTTP 200 or 202, got %d: %s", resp.StatusCode, b)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("decode (status=%d body=%s): %v", resp.StatusCode, b, err)
+	}
+	return m
+}
+
+// executeIfReady handles the common pattern of executing a gateway request
+// based on its status.
+func (e *e2eEnv) executeIfReady(t *testing.T, reqID, status string, m map[string]any) {
+	t.Helper()
+
+	switch status {
+	case "approved", "auto_approved":
+		execResp := e.agentDo("POST", fmt.Sprintf("/api/gateway/request/%s/execute", reqID), nil)
+		execM := mustStatus(t, execResp, http.StatusOK)
+		t.Logf("execute result: summary=%v", execM["summary"])
+	case "completed", "executed":
+		t.Logf("already executed: summary=%v", m["summary"])
+	case "pending", "pending_approval":
+		// Approve then execute.
+		approveResp := e.userDo("POST", fmt.Sprintf("/api/approvals/%s/approve", reqID), nil)
+		defer approveResp.Body.Close()
+		if approveResp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(approveResp.Body)
+			t.Fatalf("approve: status %d: %s", approveResp.StatusCode, body)
+		}
+		e.pollAndExecute(t, reqID)
+	case "restricted":
+		// Intent verification flagged the request — not a test failure.
+		t.Logf("request restricted by intent verification (status=restricted)")
+	case "blocked":
+		t.Logf("request blocked by restriction rule (status=blocked)")
+	case "error":
+		errMsg := strOr(m, "error", strOr(m, "message", "unknown error"))
+		t.Fatalf("gateway execution error: %s", errMsg)
+	default:
+		t.Fatalf("unexpected status: %s (response: %v)", status, m)
+	}
+}
+
+// pollAndExecute polls for an approved gateway request and executes it.
+func (e *e2eEnv) pollAndExecute(t *testing.T, reqID string) {
+	t.Helper()
+
+	// Poll until the request is approved/ready.
+	for i := 0; i < 10; i++ {
+		time.Sleep(500 * time.Millisecond)
+		pollResp := e.agentDo("GET", fmt.Sprintf("/api/gateway/request/%s", reqID), nil)
+		pollM := mustStatus(t, pollResp, http.StatusOK)
+		s := str(t, pollM, "status")
+		if s == "approved" || s == "auto_approved" {
+			execResp := e.agentDo("POST", fmt.Sprintf("/api/gateway/request/%s/execute", reqID), nil)
+			execM := mustStatus(t, execResp, http.StatusOK)
+			t.Logf("execute result: summary=%v", execM["summary"])
+			return
+		}
+		if s == "executed" || s == "completed" {
+			t.Logf("already executed: %v", pollM["summary"])
+			return
+		}
+		if s == "denied" || s == "expired" || s == "failed" {
+			t.Fatalf("request ended with status: %s", s)
+		}
+	}
+	t.Fatal("timed out waiting for request approval")
+}

--- a/e2e/smoke/harness_test.go
+++ b/e2e/smoke/harness_test.go
@@ -1,0 +1,590 @@
+package smoke_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// e2eEnv holds a running clawvisor server process and auth tokens for tests.
+type e2eEnv struct {
+	t       *testing.T
+	baseURL string
+	tmpDir  string
+	cmd     *exec.Cmd
+
+	// Auth tokens obtained via magic link exchange.
+	UserAccessToken  string
+	UserRefreshToken string
+	UserID           string
+
+	// Agent credentials created during setup.
+	AgentToken string
+	AgentID    string
+
+	client *http.Client
+}
+
+// configOverride is used to patch the copied config.yaml.
+type configOverride struct {
+	Server struct {
+		Port int    `yaml:"port"`
+		Host string `yaml:"host"`
+	} `yaml:"server"`
+	Database struct {
+		Driver     string `yaml:"driver"`
+		SQLitePath string `yaml:"sqlite_path"`
+	} `yaml:"database"`
+	Vault struct {
+		Backend      string `yaml:"backend"`
+		LocalKeyFile string `yaml:"local_key_file"`
+	} `yaml:"vault"`
+	Relay struct {
+		Enabled bool `yaml:"enabled"`
+	} `yaml:"relay"`
+	Push struct {
+		Enabled bool `yaml:"enabled"`
+	} `yaml:"push"`
+	Telemetry struct {
+		Enabled bool `yaml:"enabled"`
+	} `yaml:"telemetry"`
+}
+
+// newE2EEnv builds the clawvisor binary, copies the user's config/data to a
+// temp directory, starts the server on a free port, and authenticates.
+func newE2EEnv(t *testing.T) *e2eEnv {
+	t.Helper()
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("home dir: %v", err)
+	}
+	clawDir := filepath.Join(home, ".clawvisor")
+
+	// Verify user config exists.
+	srcConfig := filepath.Join(clawDir, "config.yaml")
+	if _, err := os.Stat(srcConfig); err != nil {
+		t.Skipf("skipping: ~/.clawvisor/config.yaml not found: %v", err)
+	}
+
+	// Resolve binary: use CLAWVISOR_BIN env, then ~/.clawvisor/bin/clawvisor,
+	// then fall back to go build.
+	binPath := os.Getenv("CLAWVISOR_BIN")
+	if binPath == "" {
+		installed := filepath.Join(clawDir, "bin", "clawvisor")
+		if _, err := os.Stat(installed); err == nil {
+			binPath = installed
+		}
+	}
+	if binPath == "" {
+		projectRoot, err := filepath.Abs(filepath.Join("..", ".."))
+		if err != nil {
+			t.Fatalf("project root: %v", err)
+		}
+		binPath = filepath.Join(projectRoot, "bin", "clawvisor-e2e")
+		buildCmd := exec.Command("go", "build", "-o", binPath, "./cmd/clawvisor")
+		buildCmd.Dir = projectRoot
+		buildCmd.Stdout = os.Stderr
+		buildCmd.Stderr = os.Stderr
+		if err := buildCmd.Run(); err != nil {
+			t.Fatalf("go build: %v", err)
+		}
+	}
+	t.Logf("using binary: %s", binPath)
+
+	// Create temp directory for this test run.
+	tmpDir := t.TempDir()
+
+	// Copy config.yaml and patch it.
+	port := freePort(t)
+	patchedConfig := patchConfig(t, srcConfig, tmpDir, port)
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	if err := os.WriteFile(configPath, patchedConfig, 0600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	// Copy vault key (needed to decrypt existing credentials in a copied DB).
+	srcVaultKey := filepath.Join(clawDir, "vault.key")
+	if _, err := os.Stat(srcVaultKey); err == nil {
+		copyFile(t, srcVaultKey, filepath.Join(tmpDir, "vault.key"))
+	}
+
+	// Copy SQLite database so we have existing service credentials.
+	srcDB := filepath.Join(clawDir, "clawvisor.db")
+	if _, err := os.Stat(srcDB); err == nil {
+		copyFile(t, srcDB, filepath.Join(tmpDir, "clawvisor.db"))
+		// Also copy WAL/SHM if they exist.
+		for _, ext := range []string{"-wal", "-shm"} {
+			src := srcDB + ext
+			if _, err := os.Stat(src); err == nil {
+				copyFile(t, src, filepath.Join(tmpDir, "clawvisor.db"+ext))
+			}
+		}
+	}
+
+	// Start the server.
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	cmd := exec.CommandContext(ctx, binPath, "server")
+	cmd.Dir = tmpDir
+	cmd.Env = append(os.Environ(),
+		"CONFIG_FILE="+configPath,
+		"HOME="+home,
+	)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	cmd.Stdout = &stderr
+
+	if err := cmd.Start(); err != nil {
+		cancel()
+		t.Fatalf("start server: %v", err)
+	}
+
+	env := &e2eEnv{
+		t:       t,
+		baseURL: baseURL,
+		tmpDir:  tmpDir,
+		cmd:     cmd,
+		client:  &http.Client{Timeout: 30 * time.Second},
+	}
+
+	// Store cancel in package-level var so TestMain can shut down the server.
+	sharedCancel = cancel
+
+	// Wait for the server to be ready.
+	if !env.waitReady(20 * time.Second) {
+		t.Fatalf("server did not become ready within 20s\nstderr:\n%s", stderr.String())
+	}
+
+	// Authenticate via magic link.
+	env.authenticate(t)
+
+	// Create an agent for gateway tests.
+	env.createAgent(t)
+
+	return env
+}
+
+// patchConfig reads the source config, overrides port/db/vault paths to use
+// the temp dir, and disables relay/push/telemetry.
+func patchConfig(t *testing.T, srcPath, tmpDir string, port int) []byte {
+	t.Helper()
+
+	data, err := os.ReadFile(srcPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+
+	// Parse into a generic map so we preserve all fields.
+	var cfg map[string]any
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+
+	// Patch server.
+	server, _ := cfg["server"].(map[string]any)
+	if server == nil {
+		server = map[string]any{}
+	}
+	server["port"] = port
+	server["host"] = "127.0.0.1"
+	cfg["server"] = server
+
+	// Patch database.
+	database, _ := cfg["database"].(map[string]any)
+	if database == nil {
+		database = map[string]any{}
+	}
+	database["driver"] = "sqlite"
+	database["sqlite_path"] = filepath.Join(tmpDir, "clawvisor.db")
+	cfg["database"] = database
+
+	// Patch vault.
+	vault, _ := cfg["vault"].(map[string]any)
+	if vault == nil {
+		vault = map[string]any{}
+	}
+	vault["backend"] = "local"
+	vault["local_key_file"] = filepath.Join(tmpDir, "vault.key")
+	cfg["vault"] = vault
+
+	// Disable relay, push, telemetry.
+	relay, _ := cfg["relay"].(map[string]any)
+	if relay == nil {
+		relay = map[string]any{}
+	}
+	relay["enabled"] = false
+	cfg["relay"] = relay
+
+	push, _ := cfg["push"].(map[string]any)
+	if push == nil {
+		push = map[string]any{}
+	}
+	push["enabled"] = false
+	cfg["push"] = push
+
+	cfg["telemetry"] = map[string]any{"enabled": false}
+
+	out, err := yaml.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal config: %v", err)
+	}
+	return out
+}
+
+// freePort finds an available TCP port.
+func freePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("free port: %v", err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	l.Close()
+	return port
+}
+
+// copyFile copies src to dst.
+func copyFile(t *testing.T, src, dst string) {
+	t.Helper()
+	data, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("copy %s: %v", src, err)
+	}
+	if err := os.WriteFile(dst, data, 0600); err != nil {
+		t.Fatalf("write %s: %v", dst, err)
+	}
+}
+
+// waitReady polls /health until it returns 200 or the timeout expires.
+func (e *e2eEnv) waitReady(timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		resp, err := e.client.Get(e.baseURL + "/health")
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return true
+			}
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	return false
+}
+
+// authenticate gets a magic token via /api/auth/magic/local, then exchanges
+// it for JWT tokens via /api/auth/magic.
+func (e *e2eEnv) authenticate(t *testing.T) {
+	t.Helper()
+
+	// Step 1: Get a magic token from the local endpoint.
+	resp := e.doRaw("POST", "/api/auth/magic/local", "", nil)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("magic/local: status %d: %s", resp.StatusCode, body)
+	}
+	var magicResp struct {
+		Token string `json:"token"`
+		URL   string `json:"url"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&magicResp); err != nil {
+		t.Fatalf("decode magic/local: %v", err)
+	}
+
+	// Step 2: Exchange magic token for JWT.
+	resp2 := e.doRaw("POST", "/api/auth/magic", "", map[string]any{
+		"token": magicResp.Token,
+	})
+	defer resp2.Body.Close()
+	if resp2.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp2.Body)
+		t.Fatalf("magic exchange: status %d: %s", resp2.StatusCode, body)
+	}
+	var authResp struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		User         struct {
+			ID    string `json:"id"`
+			Email string `json:"email"`
+		} `json:"user"`
+	}
+	if err := json.NewDecoder(resp2.Body).Decode(&authResp); err != nil {
+		t.Fatalf("decode auth: %v", err)
+	}
+
+	e.UserAccessToken = authResp.AccessToken
+	e.UserRefreshToken = authResp.RefreshToken
+	e.UserID = authResp.User.ID
+	t.Logf("authenticated as %s (id=%s)", authResp.User.Email, e.UserID)
+}
+
+// createAgent creates a test agent and stores the token.
+func (e *e2eEnv) createAgent(t *testing.T) {
+	t.Helper()
+	resp := e.userDo("POST", "/api/agents", map[string]any{
+		"name": "e2e-smoke-test",
+	})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create agent: status %d: %s", resp.StatusCode, body)
+	}
+	var agentResp map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&agentResp); err != nil {
+		t.Fatalf("decode agent: %v", err)
+	}
+	e.AgentToken = agentResp["token"].(string)
+	e.AgentID = agentResp["id"].(string)
+	t.Logf("created agent %s", e.AgentID)
+}
+
+// userDo makes an HTTP request with the user's JWT.
+func (e *e2eEnv) userDo(method, path string, body any) *http.Response {
+	return e.doRaw(method, path, e.UserAccessToken, body)
+}
+
+// agentDo makes an HTTP request with the agent bearer token.
+func (e *e2eEnv) agentDo(method, path string, body any) *http.Response {
+	return e.doRaw(method, path, e.AgentToken, body)
+}
+
+// doRaw performs an HTTP request, JSON-encoding body if non-nil.
+func (e *e2eEnv) doRaw(method, path string, token string, body any) *http.Response {
+	var r io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			e.t.Fatalf("marshal: %v", err)
+		}
+		r = bytes.NewReader(b)
+	}
+	url := e.baseURL + path
+	req, err := http.NewRequest(method, url, r)
+	if err != nil {
+		e.t.Fatalf("new request: %v", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := e.client.Do(req)
+	if err != nil {
+		e.t.Fatalf("%s %s: %v", method, path, err)
+	}
+	return resp
+}
+
+// decodeJSON reads and decodes a JSON response body.
+func decodeJSON(t *testing.T, resp *http.Response, v any) {
+	t.Helper()
+	defer resp.Body.Close()
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if err := json.Unmarshal(b, v); err != nil {
+		t.Fatalf("decode (status=%d body=%s): %v", resp.StatusCode, b, err)
+	}
+}
+
+// mustStatus asserts the response has the expected status and returns the
+// decoded body as a map.
+func mustStatus(t *testing.T, resp *http.Response, want int) map[string]any {
+	t.Helper()
+	defer resp.Body.Close()
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if resp.StatusCode != want {
+		t.Fatalf("expected HTTP %d, got %d: %s", want, resp.StatusCode, b)
+	}
+	if len(b) == 0 {
+		return nil
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("decode (status=%d body=%s): %v", resp.StatusCode, b, err)
+	}
+	return m
+}
+
+// skipIfServiceNotActivated checks whether a service has credentials in the
+// vault by looking at the services list. Skips the test if not.
+func (e *e2eEnv) skipIfServiceNotActivated(t *testing.T, serviceID string) {
+	t.Helper()
+	resp := e.userDo("GET", "/api/services", nil)
+	m := mustStatus(t, resp, http.StatusOK)
+
+	list, ok := m["services"].([]any)
+	if !ok {
+		t.Skipf("skipping: could not parse services list")
+	}
+	for _, raw := range list {
+		svc, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		id := strOr(svc, "id", "")
+		if id == serviceID {
+			status := strOr(svc, "status", "")
+			if status == "activated" || status == "active" || status == "connected" {
+				return
+			}
+		}
+	}
+	t.Skipf("skipping: service %q not activated", serviceID)
+}
+
+// str extracts a string from a decoded map.
+func str(t *testing.T, m map[string]any, key string) string {
+	t.Helper()
+	v, ok := m[key]
+	if !ok {
+		t.Fatalf("key %q not found in %v", key, m)
+	}
+	s, ok := v.(string)
+	if !ok {
+		t.Fatalf("key %q is not a string (got %T)", key, v)
+	}
+	return s
+}
+
+// strOr extracts a string from a map, returning a default if missing.
+func strOr(m map[string]any, key, fallback string) string {
+	v, ok := m[key]
+	if !ok {
+		return fallback
+	}
+	s, ok := v.(string)
+	if !ok {
+		return fallback
+	}
+	return s
+}
+
+// containsStr returns true if s contains substr.
+func containsStr(s, substr string) bool {
+	return strings.Contains(s, substr)
+}
+
+// readServiceCandidates maps service IDs to read-only actions with default params.
+// Used by pickActivatedReadService to find a testable service dynamically.
+var readServiceCandidates = []struct {
+	svcID  string
+	action string
+	params map[string]any
+}{
+	{"linear", "list_issues", map[string]any{}},
+	{"github", "list_repos", map[string]any{}},
+	{"google.gmail", "list_messages", map[string]any{}},
+	{"google.calendar", "list_events", map[string]any{}},
+	{"google.drive", "list_files", map[string]any{}},
+	{"google.contacts", "list_contacts", map[string]any{}},
+	{"slack", "list_channels", map[string]any{}},
+	{"notion", "list_databases", map[string]any{}},
+}
+
+// secondReadActions maps service IDs to their secondary read actions (for scope expansion tests).
+var secondReadActions = map[string]string{
+	"linear":          "list_teams",
+	"github":          "list_issues",
+	"google.gmail":    "get_message",
+	"google.calendar": "list_calendars",
+	"google.drive":    "search_files",
+	"slack":           "list_users",
+}
+
+// pickActivatedReadService returns the first activated service with a read-only
+// action from the candidates list. Skips the test if none are activated.
+func (e *e2eEnv) pickActivatedReadService(t *testing.T) (svcID, action string, params map[string]any) {
+	t.Helper()
+
+	resp := e.userDo("GET", "/api/services", nil)
+	m := mustStatus(t, resp, http.StatusOK)
+	list, ok := m["services"].([]any)
+	if !ok {
+		t.Skipf("skipping: could not parse services list")
+	}
+
+	activated := map[string]bool{}
+	for _, raw := range list {
+		svc, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		id := strOr(svc, "id", "")
+		status := strOr(svc, "status", "")
+		if status == "activated" || status == "active" || status == "connected" {
+			activated[id] = true
+		}
+	}
+
+	for _, c := range readServiceCandidates {
+		if activated[c.svcID] {
+			return c.svcID, c.action, c.params
+		}
+	}
+
+	t.Skipf("skipping: no activated read-only service found (activated: %v)", activated)
+	return "", "", nil
+}
+
+// pickSecondAction returns a second read action for scope expansion tests.
+// Returns "" if no second action is available for the service.
+func (e *e2eEnv) pickSecondAction(t *testing.T, svcID, firstAction string) string {
+	t.Helper()
+	second, ok := secondReadActions[svcID]
+	if !ok || second == firstAction {
+		return ""
+	}
+	return second
+}
+
+// waitAndApproveTask polls a task until it's ready for approval, then approves it.
+// Works with any requester function (agent token from harness or from connection flow).
+func (e *e2eEnv) waitAndApproveTask(t *testing.T, agentReq func(string, string, any) *http.Response, taskID string) {
+	t.Helper()
+
+	for i := 0; i < 15; i++ {
+		checkResp := agentReq("GET", fmt.Sprintf("/api/tasks/%s", taskID), nil)
+		checkM := mustStatus(t, checkResp, http.StatusOK)
+		s := strOr(checkM, "status", "")
+		if s == "pending_approval" || s == "pending" {
+			break
+		}
+		if s == "approved" || s == "active" {
+			return // already approved
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+
+	approveResp := e.userDo("POST", fmt.Sprintf("/api/tasks/%s/approve", taskID), nil)
+	defer approveResp.Body.Close()
+	approveBody, _ := io.ReadAll(approveResp.Body)
+	if approveResp.StatusCode != http.StatusOK {
+		// Check if auto-approved during the loop.
+		checkResp := agentReq("GET", fmt.Sprintf("/api/tasks/%s", taskID), nil)
+		checkM := mustStatus(t, checkResp, http.StatusOK)
+		s := strOr(checkM, "status", "")
+		if s != "approved" && s != "active" {
+			t.Fatalf("approve task %s: status %d: %s (task status: %s)", taskID, approveResp.StatusCode, approveBody, s)
+		}
+	}
+}

--- a/e2e/smoke/health_test.go
+++ b/e2e/smoke/health_test.go
@@ -1,0 +1,78 @@
+package smoke_test
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"testing"
+)
+
+var sharedEnv *e2eEnv
+var sharedCancel context.CancelFunc
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+	// Shut down the servers after all tests.
+	if sharedCancel != nil {
+		sharedCancel()
+	}
+	if sharedEnv != nil && sharedEnv.cmd != nil {
+		_ = sharedEnv.cmd.Wait()
+	}
+	if ciSharedEnv != nil {
+		ciSharedEnv.cancel()
+		if ciSharedEnv.cmd != nil {
+			_ = ciSharedEnv.cmd.Wait()
+		}
+		if ciSharedEnv.mockSrv != nil {
+			ciSharedEnv.mockSrv.Close()
+		}
+	}
+	os.Exit(code)
+}
+
+// setup returns a shared e2eEnv, starting the server once for the whole package.
+func setup(t *testing.T) *e2eEnv {
+	t.Helper()
+	if sharedEnv == nil {
+		sharedEnv = newE2EEnv(t)
+	}
+	return sharedEnv
+}
+
+func TestHealth(t *testing.T) {
+	env := setup(t)
+
+	resp := env.doRaw("GET", "/health", "", nil)
+	m := mustStatus(t, resp, http.StatusOK)
+	status := str(t, m, "status")
+	if status != "ok" {
+		t.Errorf("expected status=ok, got %q", status)
+	}
+}
+
+func TestReady(t *testing.T) {
+	env := setup(t)
+
+	resp := env.doRaw("GET", "/ready", "", nil)
+	mustStatus(t, resp, http.StatusOK)
+}
+
+func TestVersion(t *testing.T) {
+	env := setup(t)
+
+	resp := env.doRaw("GET", "/api/version", "", nil)
+	m := mustStatus(t, resp, http.StatusOK)
+	version := strOr(m, "current", "")
+	if version == "" {
+		t.Error("expected non-empty version (key: current)")
+	}
+	t.Logf("server version: %s", version)
+}
+
+func TestFeatures(t *testing.T) {
+	env := setup(t)
+
+	resp := env.doRaw("GET", "/api/features", "", nil)
+	mustStatus(t, resp, http.StatusOK)
+}

--- a/e2e/smoke/testserver_test.go
+++ b/e2e/smoke/testserver_test.go
@@ -1,0 +1,539 @@
+package smoke_test
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ── Mock API Server ──────────────────────────────────────────────────────────
+
+// startMockAPIServer returns an httptest.Server that acts as both an OAuth
+// provider (authorize/token endpoints) and the API backend for all three
+// test adapter services: test_oauth, test_apikey, test_noauth.
+func startMockAPIServer() *httptest.Server {
+	mux := http.NewServeMux()
+
+	// OAuth token endpoint — exchanges an authorization code for tokens.
+	mux.HandleFunc("/oauth/token", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		_ = r.ParseForm()
+		code := r.FormValue("code")
+		if code == "" {
+			http.Error(w, "missing code", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "mock-oauth-access-token",
+			"token_type":    "Bearer",
+			"refresh_token": "mock-oauth-refresh-token",
+			"expires_in":    3600,
+		})
+	})
+
+	// test_oauth API — requires Bearer token.
+	mux.HandleFunc("/test_oauth/items", func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if !strings.HasPrefix(auth, "Bearer ") {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"items": []map[string]string{
+				{"id": "1", "name": "alpha"},
+				{"id": "2", "name": "beta"},
+			},
+		})
+	})
+
+	// test_apikey API — requires X-API-Key header.
+	mux.HandleFunc("/test_apikey/items", func(w http.ResponseWriter, r *http.Request) {
+		key := r.Header.Get("X-API-Key")
+		if key == "" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"items": []map[string]string{
+				{"id": "1", "name": "gamma"},
+				{"id": "2", "name": "delta"},
+			},
+		})
+	})
+
+	// test_noauth API — no auth required.
+	mux.HandleFunc("/test_noauth/items", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"items": []map[string]string{
+				{"id": "1", "name": "epsilon"},
+				{"id": "2", "name": "zeta"},
+			},
+		})
+	})
+
+	srv := httptest.NewServer(mux)
+	return srv
+}
+
+// ── Test Adapter YAML Definitions ────────────────────────────────────────────
+
+func writeTestAdapterYAMLs(t *testing.T, adaptersDir, mockURL string) {
+	t.Helper()
+
+	adapters := map[string]string{
+		"test_oauth.yaml":  testOAuthYAML(mockURL),
+		"test_apikey.yaml": testAPIKeyYAML(mockURL),
+		"test_noauth.yaml": testNoAuthYAML(mockURL),
+	}
+	for name, content := range adapters {
+		path := filepath.Join(adaptersDir, name)
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+		t.Logf("wrote adapter: %s (%d bytes)", path, len(content))
+	}
+}
+
+func testOAuthYAML(mockURL string) string {
+	return fmt.Sprintf(`service:
+  id: test_oauth
+  display_name: Test OAuth Service
+  description: Test service with OAuth2 authentication
+
+auth:
+  type: oauth2
+  header: Authorization
+  header_prefix: "Bearer "
+  oauth:
+    client_id: "test-client-id"
+    client_secret: "test-client-secret"
+    authorize_url: "%s/oauth/authorize"
+    token_url: "%s/oauth/token"
+    scopes:
+      - "read"
+
+api:
+  base_url: "%s/test_oauth"
+  type: rest
+
+actions:
+  list_items:
+    display_name: List Items
+    risk:
+      category: read
+      sensitivity: low
+      description: List test items
+    method: GET
+    path: /items
+    response:
+      summary: "Listed test items"
+  create_item:
+    display_name: Create Item
+    risk:
+      category: write
+      sensitivity: medium
+      description: Create a test item
+    method: POST
+    path: /items
+    params:
+      name:
+        type: string
+        required: true
+        location: body
+    response:
+      summary: "Created test item"
+`, mockURL, mockURL, mockURL)
+}
+
+func testAPIKeyYAML(mockURL string) string {
+	return fmt.Sprintf(`service:
+  id: test_apikey
+  display_name: Test API Key Service
+  description: Test service with API key authentication
+
+auth:
+  type: api_key
+  header: X-API-Key
+
+api:
+  base_url: "%s/test_apikey"
+  type: rest
+
+actions:
+  list_items:
+    display_name: List Items
+    risk:
+      category: read
+      sensitivity: low
+      description: List test items
+    method: GET
+    path: /items
+    response:
+      summary: "Listed test items"
+  create_item:
+    display_name: Create Item
+    risk:
+      category: write
+      sensitivity: medium
+      description: Create a test item
+    method: POST
+    path: /items
+    params:
+      name:
+        type: string
+        required: true
+        location: body
+    response:
+      summary: "Created test item"
+`, mockURL)
+}
+
+func testNoAuthYAML(mockURL string) string {
+	return fmt.Sprintf(`service:
+  id: test_noauth
+  display_name: Test No-Auth Service
+  description: Test service requiring no credentials
+
+auth:
+  type: none
+
+api:
+  base_url: "%s/test_noauth"
+  type: rest
+
+actions:
+  list_items:
+    display_name: List Items
+    risk:
+      category: read
+      sensitivity: low
+      description: List test items
+    method: GET
+    path: /items
+    response:
+      summary: "Listed test items"
+  create_item:
+    display_name: Create Item
+    risk:
+      category: write
+      sensitivity: medium
+      description: Create a test item
+    method: POST
+    path: /items
+    params:
+      name:
+        type: string
+        required: true
+        location: body
+    response:
+      summary: "Created test item"
+`, mockURL)
+}
+
+// ── CI Environment ───────────────────────────────────────────────────────────
+
+// Shared CI environment — started once per test run.
+var ciSharedEnv *ciTestEnv
+
+// ciTestEnv wraps e2eEnv with mock server details.
+type ciTestEnv struct {
+	*e2eEnv
+	mockURL string
+	mockSrv *httptest.Server
+	cancel  context.CancelFunc
+}
+
+// ciSetup returns a shared CI test environment. The first call starts the mock
+// API server, generates a fresh config/DB/vault, writes test adapter YAMLs,
+// and starts the clawvisor server. Subsequent calls return the cached env.
+func ciSetup(t *testing.T) *ciTestEnv {
+	t.Helper()
+	if ciSharedEnv == nil {
+		ciSharedEnv = newCIEnv(t)
+	}
+	return ciSharedEnv
+}
+
+func newCIEnv(t *testing.T) *ciTestEnv {
+	t.Helper()
+
+	// Start mock API server.
+	mockSrv := startMockAPIServer()
+	mockURL := mockSrv.URL
+	t.Logf("mock API server: %s", mockURL)
+
+	// Create temp directory tree.
+	tmpDir := t.TempDir()
+	clawDir := filepath.Join(tmpDir, ".clawvisor")
+	adaptersDir := filepath.Join(clawDir, "adapters")
+	if err := os.MkdirAll(adaptersDir, 0755); err != nil {
+		t.Fatalf("mkdir adapters: %v", err)
+	}
+
+	// Write test adapter YAMLs.
+	writeTestAdapterYAMLs(t, adaptersDir, mockURL)
+
+	// Generate vault key (32 random bytes, base64-encoded).
+	vaultKey := make([]byte, 32)
+	if _, err := rand.Read(vaultKey); err != nil {
+		t.Fatalf("generate vault key: %v", err)
+	}
+	vaultKeyPath := filepath.Join(clawDir, "vault.key")
+	if err := os.WriteFile(vaultKeyPath, []byte(base64.StdEncoding.EncodeToString(vaultKey)), 0600); err != nil {
+		t.Fatalf("write vault key: %v", err)
+	}
+
+	// Generate minimal config.
+	port := freePort(t)
+	dbPath := filepath.Join(clawDir, "clawvisor.db")
+	cfg := map[string]any{
+		"server":    map[string]any{"port": port, "host": "127.0.0.1"},
+		"database":  map[string]any{"driver": "sqlite", "sqlite_path": dbPath},
+		"vault":     map[string]any{"backend": "local", "local_key_file": vaultKeyPath},
+		"relay":     map[string]any{"enabled": false},
+		"push":      map[string]any{"enabled": false},
+		"telemetry": map[string]any{"enabled": false},
+	}
+	cfgBytes, err := yaml.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal config: %v", err)
+	}
+	configPath := filepath.Join(clawDir, "config.yaml")
+	if err := os.WriteFile(configPath, cfgBytes, 0600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Logf("CI config: port=%d, db=%s", port, dbPath)
+
+	// Build binary.
+	binPath := resolveOrBuildBinary(t)
+
+	// Start the server with HOME=tmpDir so it finds adapters in tmpDir/.clawvisor/adapters/.
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	cmd := exec.CommandContext(ctx, binPath, "server")
+	cmd.Dir = clawDir
+	cmd.Env = []string{
+		"HOME=" + tmpDir,
+		"CONFIG_FILE=" + configPath,
+		"PATH=" + os.Getenv("PATH"),
+		"TMPDIR=" + os.Getenv("TMPDIR"),
+	}
+	// Inherit CGO-related vars for SQLite.
+	for _, key := range []string{"CGO_ENABLED", "CC", "CXX"} {
+		if v := os.Getenv(key); v != "" {
+			cmd.Env = append(cmd.Env, key+"="+v)
+		}
+	}
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Start(); err != nil {
+		cancel()
+		t.Fatalf("start CI server: %v", err)
+	}
+	t.Logf("CI server started (pid=%d)", cmd.Process.Pid)
+
+	env := &e2eEnv{
+		t:       t,
+		baseURL: baseURL,
+		tmpDir:  tmpDir,
+		cmd:     cmd,
+		client:  &http.Client{Timeout: 30 * time.Second},
+	}
+
+	if !env.waitReady(20 * time.Second) {
+		cancel()
+		t.Fatal("CI server did not become ready within 20s")
+	}
+	t.Log("CI server ready")
+
+	// Authenticate via magic link.
+	env.authenticate(t)
+
+	// Create an agent for tests.
+	env.createAgent(t)
+
+	return &ciTestEnv{
+		e2eEnv:  env,
+		mockURL: mockURL,
+		mockSrv: mockSrv,
+		cancel:  cancel,
+	}
+}
+
+// resolveOrBuildBinary finds or builds the clawvisor binary.
+func resolveOrBuildBinary(t *testing.T) string {
+	t.Helper()
+
+	if binPath := os.Getenv("CLAWVISOR_BIN"); binPath != "" {
+		return binPath
+	}
+
+	home, _ := os.UserHomeDir()
+	if home != "" {
+		installed := filepath.Join(home, ".clawvisor", "bin", "clawvisor")
+		if _, err := os.Stat(installed); err == nil {
+			return installed
+		}
+	}
+
+	projectRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("project root: %v", err)
+	}
+	binPath := filepath.Join(projectRoot, "bin", "clawvisor-e2e")
+	buildCmd := exec.Command("go", "build", "-o", binPath, "./cmd/clawvisor")
+	buildCmd.Dir = projectRoot
+	buildCmd.Stdout = os.Stderr
+	buildCmd.Stderr = os.Stderr
+	if err := buildCmd.Run(); err != nil {
+		t.Fatalf("go build: %v", err)
+	}
+	return binPath
+}
+
+// ── Service Activation Helpers ───────────────────────────────────────────────
+
+// activateTestOAuth performs the full OAuth dance:
+// 1. POST /api/services/test_oauth/activate → get auth URL with state
+// 2. Call /api/oauth/callback with the state and a test code
+// 3. Server exchanges code at mock token endpoint → stores credential
+func (e *ciTestEnv) activateTestOAuth(t *testing.T) {
+	t.Helper()
+
+	// Step 1: Start OAuth flow.
+	resp := e.userDo("POST", "/api/services/test_oauth/activate", nil)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body := readBody(resp)
+		t.Fatalf("activate test_oauth: status %d: %s", resp.StatusCode, body)
+	}
+
+	var result map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode activate response: %v", err)
+	}
+
+	// If already authorized, we're done.
+	if already, _ := result["already_authorized"].(bool); already {
+		t.Log("test_oauth already authorized")
+		return
+	}
+
+	authURL, _ := result["url"].(string)
+	if authURL == "" {
+		t.Fatalf("activate returned no url: %v", result)
+	}
+	t.Logf("OAuth auth URL: %s", authURL)
+
+	// Step 2: Extract state from the auth URL.
+	u, err := url.Parse(authURL)
+	if err != nil {
+		t.Fatalf("parse auth URL: %v", err)
+	}
+	state := u.Query().Get("state")
+	if state == "" {
+		t.Fatal("auth URL missing state parameter")
+	}
+
+	// Step 3: Call the callback directly (simulates browser redirect).
+	callbackPath := fmt.Sprintf("/api/oauth/callback?code=test-auth-code&state=%s", url.QueryEscape(state))
+	callbackResp := e.doRaw("GET", callbackPath, "", nil)
+	defer callbackResp.Body.Close()
+	// Callback returns HTML, not JSON. We just need it to succeed (200).
+	if callbackResp.StatusCode != http.StatusOK {
+		body := readBody(callbackResp)
+		t.Fatalf("OAuth callback: status %d: %s", callbackResp.StatusCode, body)
+	}
+	t.Log("OAuth callback completed")
+
+	// Step 4: Verify service is activated.
+	e.verifyServiceActivated(t, "test_oauth")
+}
+
+// activateTestAPIKey activates the test_apikey service with a test key.
+func (e *ciTestEnv) activateTestAPIKey(t *testing.T) {
+	t.Helper()
+
+	resp := e.userDo("POST", "/api/services/test_apikey/activate", map[string]any{
+		"token": "test-api-key-12345",
+	})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body := readBody(resp)
+		t.Fatalf("activate test_apikey: status %d: %s", resp.StatusCode, body)
+	}
+	t.Log("test_apikey activated")
+
+	e.verifyServiceActivated(t, "test_apikey")
+}
+
+// activateTestNoAuth activates the credential-free test_noauth service.
+func (e *ciTestEnv) activateTestNoAuth(t *testing.T) {
+	t.Helper()
+
+	resp := e.userDo("POST", "/api/services/test_noauth/activate", nil)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body := readBody(resp)
+		t.Fatalf("activate test_noauth: status %d: %s", resp.StatusCode, body)
+	}
+	t.Log("test_noauth activated")
+
+	e.verifyServiceActivated(t, "test_noauth")
+}
+
+// verifyServiceActivated checks that a service shows as activated in the services list.
+func (e *ciTestEnv) verifyServiceActivated(t *testing.T, serviceID string) {
+	t.Helper()
+	resp := e.userDo("GET", "/api/services", nil)
+	m := mustStatus(t, resp, http.StatusOK)
+
+	list, ok := m["services"].([]any)
+	if !ok {
+		t.Fatalf("could not parse services list")
+	}
+	for _, raw := range list {
+		svc, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if strOr(svc, "id", "") == serviceID {
+			status := strOr(svc, "status", "")
+			if status == "activated" || status == "active" || status == "connected" {
+				t.Logf("verified: %s is %s", serviceID, status)
+				return
+			}
+			t.Fatalf("service %s has status %q (expected activated)", serviceID, status)
+		}
+	}
+	t.Fatalf("service %s not found in services list", serviceID)
+}
+
+// readBody is a small helper that drains a response body to a string.
+func readBody(resp *http.Response) string {
+	b := make([]byte, 4096)
+	n, _ := resp.Body.Read(b)
+	return string(b[:n])
+}

--- a/pkg/adapters/yamldef/schema.go
+++ b/pkg/adapters/yamldef/schema.go
@@ -59,9 +59,17 @@ type PKCEFlowDef struct {
 type OAuthDef struct {
 	Scopes            []string           `yaml:"scopes"`
 	ConditionalScopes []ConditionalScope `yaml:"conditional_scopes,omitempty"`
-	Endpoint          string             `yaml:"endpoint"`    // "google" — maps to well-known endpoints
-	VaultKey          string             `yaml:"vault_key"`   // shared vault key (e.g. "google")
-	ScopeMerge        bool               `yaml:"scope_merge"` // whether to merge scopes with existing credential
+	Endpoint          string             `yaml:"endpoint,omitempty"`    // "google" — maps to well-known endpoints
+	VaultKey          string             `yaml:"vault_key,omitempty"`   // shared vault key (e.g. "google")
+	ScopeMerge        bool               `yaml:"scope_merge,omitempty"` // whether to merge scopes with existing credential
+
+	// Custom OAuth endpoint fields — used when Endpoint is not a well-known provider.
+	ClientID        string `yaml:"client_id,omitempty"`
+	ClientIDEnv     string `yaml:"client_id_env,omitempty"`
+	ClientSecret    string `yaml:"client_secret,omitempty"`
+	ClientSecretEnv string `yaml:"client_secret_env,omitempty"`
+	AuthorizeURL    string `yaml:"authorize_url,omitempty"`
+	TokenURL        string `yaml:"token_url,omitempty"`
 }
 
 // ConditionalScope is a scope that is only included when an env var condition is met.

--- a/pkg/adapters/yamlruntime/adapter.go
+++ b/pkg/adapters/yamlruntime/adapter.go
@@ -109,16 +109,28 @@ func (a *YAMLAdapter) OAuthConfig() *oauth2.Config {
 		return nil
 	}
 
-	// Read OAuth app credentials lazily from the provider.
-	var clientID, clientSecret string
-	if a.oauthProvider != nil {
+	oauthDef := a.def.Auth.OAuth
+
+	// Try inline credentials first (custom OAuth endpoints), then provider (Google).
+	clientID := oauthDef.ClientID
+	clientSecret := oauthDef.ClientSecret
+	if oauthDef.ClientIDEnv != "" {
+		if v := os.Getenv(oauthDef.ClientIDEnv); v != "" {
+			clientID = v
+		}
+	}
+	if oauthDef.ClientSecretEnv != "" {
+		if v := os.Getenv(oauthDef.ClientSecretEnv); v != "" {
+			clientSecret = v
+		}
+	}
+	if clientID == "" && a.oauthProvider != nil {
 		clientID, clientSecret = a.oauthProvider.OAuthClientCredentials()
 	}
 	if clientID == "" {
 		return nil // OAuth not yet configured
 	}
 
-	oauthDef := a.def.Auth.OAuth
 	scopes := make([]string, len(oauthDef.Scopes))
 	copy(scopes, oauthDef.Scopes)
 
@@ -138,7 +150,10 @@ func (a *YAMLAdapter) OAuthConfig() *oauth2.Config {
 	case "google":
 		endpoint = google.Endpoint
 	default:
-		// Future: support custom endpoint URLs.
+		endpoint = oauth2.Endpoint{
+			AuthURL:  oauthDef.AuthorizeURL,
+			TokenURL: oauthDef.TokenURL,
+		}
 	}
 
 	return &oauth2.Config{


### PR DESCRIPTION
## Summary

- Adds a full e2e smoke test suite (`e2e/smoke/`) covering health, auth, catalog, agent lifecycle, discovery, gateway flows, Claude Code simulation, and real Claude CLI integration
- Introduces three mock test adapters (OAuth, API key, no-auth) backed by an in-process HTTP server so the full gateway pipeline can be tested without real third-party credentials
- Extends `OAuthDef` in the YAML adapter schema to support custom OAuth endpoints with inline client credentials, enabling the OAuth dance against the mock provider
- Adds `make test-e2e` (requires `~/.clawvisor/` state) and `make test-e2e-ci` (zero external dependencies) targets

## Test plan

- [x] `make test-e2e-ci` — all 7 CI tests pass (OAuth activation + dance, API key activation, no-auth activation, gateway flow for each, full agent lifecycle across all three)
- [x] `make test-e2e` — existing smoke tests pass against real server with activated services
- [x] `go test ./pkg/adapters/yamlruntime/` — unit tests for modified adapter runtime pass
- [x] `go vet ./...` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)