### PR TITLE
fix: include private channels and support pagination in Slack adapter

### DIFF
--- a/internal/adapters/definitions/slack.yaml
+++ b/internal/adapters/definitions/slack.yaml
@@ -34,8 +34,9 @@ actions:
     method: GET
     path: "/conversations.list"
     params:
-      limit: { type: int, default: 100, max: 1000, location: query }
-      types: { type: string, location: query }
+      limit: { type: int, default: 200, max: 1000, location: query }
+      types: { type: string, default: "public_channel,private_channel", location: query }
+      cursor: { type: string, location: query }
     error_check: { success_path: "ok", error_path: "error" }
     response:
       data_path: "channels"
@@ -74,6 +75,7 @@ actions:
       limit: { type: int, default: 50, max: 1000, location: query }
       oldest: { type: string, location: query }
       latest: { type: string, location: query }
+      cursor: { type: string, location: query }
     error_check: { success_path: "ok", error_path: "error" }
     response:
       data_path: "messages"
@@ -123,6 +125,7 @@ actions:
     path: "/users.list"
     params:
       limit: { type: int, default: 100, max: 1000, location: query }
+      cursor: { type: string, location: query }
     error_check: { success_path: "ok", error_path: "error" }
     response:
       data_path: "members"

--- a/internal/adapters/format/format.go
+++ b/internal/adapters/format/format.go
@@ -15,7 +15,7 @@ const (
 	MaxBodyLen    = 8000
 	MaxSnippetLen = 300
 	MaxFieldLen   = 500
-	MaxArrayItems = 50
+	MaxArrayItems = 200
 	MaxDataBytes  = 100 * 1024
 )
 


### PR DESCRIPTION
## Summary

- Default `types` param on `list_channels` to `public_channel,private_channel` so private channels are returned (previously only public channels due to Slack API default behavior)
- Add `cursor` query param to `list_channels`, `list_messages`, and `list_users` to enable pagination through large result sets
- Bump `MaxArrayItems` from 50 to 200 to stop silently truncating API responses client-side
- Increase `list_channels` default limit from 100 to 200

## Test plan
- [ ] Verify `list_channels` returns both public and private channels
- [ ] Verify pagination works by passing `cursor` from Slack response metadata
- [ ] Verify workspaces with >50 channels now return full results