### PR TITLE
feat: publish skill to ClawHub on release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -52,3 +52,50 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload "${{ needs.release-please.outputs.tag_name }}" dist/* --clobber
+
+  publish-skill:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
+          fetch-depth: 2
+
+      - name: Check for skill changes
+        id: skill-changes
+        run: |
+          if git diff --name-only HEAD~1 HEAD | grep -qE '^skills/clawvisor/'; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup Go
+        if: steps.skill-changes.outputs.changed == 'true'
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Setup Node.js
+        if: steps.skill-changes.outputs.changed == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Prepare skill folder
+        if: steps.skill-changes.outputs.changed == 'true'
+        run: |
+          mkdir -p dist/skill
+          go run ./cmd/render-skill claude-code > dist/skill/SKILL.md
+          cp skills/clawvisor/README.md dist/skill/README.md
+          cp -r skills/clawvisor/policies dist/skill/policies
+
+      - name: Publish to ClawHub
+        if: steps.skill-changes.outputs.changed == 'true'
+        env:
+          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
+        run: |
+          VERSION=$(jq -r '."."' .release-please-manifest.json)
+          npx clawhub publish dist/skill --slug clawvisor --version "$VERSION"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -98,4 +98,4 @@ jobs:
           CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
         run: |
           VERSION=$(jq -r '."."' .release-please-manifest.json)
-          npx clawhub publish dist/skill --slug clawvisor --version "$VERSION"
+          npx clawhub publish "$GITHUB_WORKSPACE/dist/skill" --slug clawvisor --version "$VERSION"

--- a/cmd/render-skill/main.go
+++ b/cmd/render-skill/main.go
@@ -1,0 +1,24 @@
+// Command render-skill renders SKILL.md.tmpl for a given target and writes the
+// result to stdout. Used by CI to prepare the skill folder for clawhub publish.
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/clawvisor/clawvisor/skills"
+)
+
+func main() {
+	target := skills.TargetClaudeCode
+	if len(os.Args) > 1 {
+		target = skills.Target(os.Args[1])
+	}
+
+	out, err := skills.Render(target)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "render-skill: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Print(out)
+}


### PR DESCRIPTION
## Summary

- Adds a `publish-skill` job to the release-please workflow that publishes the ClawHub skill when a release is created and `skills/clawvisor/` files changed
- Adds `cmd/render-skill` — a small Go CLI that renders `SKILL.md.tmpl` for a given target, used by CI to produce the `SKILL.md` for publishing
- The published artifact includes `SKILL.md`, `README.md`, and `policies/`, with the version pulled from `.release-please-manifest.json`
- Requires a `CLAWHUB_TOKEN` repo secret for authentication

## Test plan

- [ ] Verify `go run ./cmd/render-skill claude-code` renders correctly
- [ ] Add `CLAWHUB_TOKEN` secret to the repo
- [ ] Merge a release PR that includes a skill file change and confirm the skill is published to ClawHub