### PR TITLE
feat: batch approval with rich rendering and click-to-edit fields

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -38,6 +38,8 @@ The agent sends a POST to `/api/gateway/request` with a bearer token. The reques
 
 The `reason` field is always required — it's shown to the human in approval requests and logged in the audit trail. The `request_id` is used for idempotency (enforced by a UNIQUE constraint in the database). The `context.data_origin` tracks what external content influenced this request, which is critical for detecting prompt injection.
 
+Optional `batch_id` groups multiple requests for batch review — the user sees them as a group and can approve/deny all at once. The agent closes the batch with `POST /api/gateway/batch/{batch_id}/close` after submitting all requests.
+
 ### 2.2 Authentication
 
 The `RequireAgent` middleware extracts the bearer token, computes its SHA-256 hash, and looks up the agent record by that hash. The raw token is never stored — only the hash exists in the database. If the lookup fails, the request gets a 401 immediately.
@@ -393,7 +395,7 @@ Migrations are embedded in the binary and run automatically on startup. Each mig
 - `vault_entries` — encrypted credentials. Unique on `(user_id, service_id)`.
 
 **Approval queue:**
-- `pending_approvals` — serialized request blobs awaiting human decision. Includes callback URL, status (`pending` or `approved`), expiry, and audit ID. Unique on `request_id`.
+- `pending_approvals` — serialized request blobs awaiting human decision. Includes callback URL, batch ID (for grouped approvals), rendered fields (adapter-produced human-readable display), status (`pending` or `approved`), expiry, and audit ID. Unique on `request_id`.
 
 **Audit:**
 - `audit_log` — every gateway request. Includes service, action, sanitized params, decision, outcome, verification verdict, duration, and error messages. Legacy columns (`safety_flagged`, `safety_reason`, `filters_applied`) are retained for backward compatibility but no longer populated. `request_id` has a UNIQUE constraint. Indexed on `(user_id, timestamp)`, `(user_id, outcome)`, `(user_id, service)`.

--- a/internal/adapters/google/gmail/adapter.go
+++ b/internal/adapters/google/gmail/adapter.go
@@ -614,3 +614,51 @@ func truncate(s string, max int) string {
 	}
 	return s
 }
+
+// ── Approval rendering & editing ─────────────────────────────────────────────
+
+func paramStr(params map[string]any, key string) string {
+	v, ok := params[key]
+	if !ok {
+		return ""
+	}
+	s, _ := v.(string)
+	return s
+}
+
+// RenderForApproval implements adapters.ApprovalRenderer.
+func (a *GmailAdapter) RenderForApproval(action string, params map[string]any) ([]adapters.RenderedField, error) {
+	switch action {
+	case "send_message", "create_draft":
+		fields := []adapters.RenderedField{
+			{Key: "to", Label: "To", Value: paramStr(params, "to"), Editable: true, Format: "text"},
+			{Key: "subject", Label: "Subject", Value: paramStr(params, "subject"), Editable: true, Format: "text"},
+			{Key: "body", Label: "Body", Value: paramStr(params, "body"), Editable: true, Multiline: true, Format: "text"},
+		}
+		if inReplyTo := paramStr(params, "in_reply_to"); inReplyTo != "" {
+			fields = append(fields, adapters.RenderedField{
+				Key: "in_reply_to", Label: "In Reply To", Value: inReplyTo, Editable: false, Format: "text",
+			})
+		}
+		return fields, nil
+	default:
+		return nil, nil
+	}
+}
+
+// ApplyEdits implements adapters.ApprovalEditor.
+func (a *GmailAdapter) ApplyEdits(action string, params map[string]any, edits map[string]string) (map[string]any, error) {
+	switch action {
+	case "send_message", "create_draft":
+		allowed := map[string]bool{"to": true, "subject": true, "body": true}
+		for k, v := range edits {
+			if !allowed[k] {
+				return nil, fmt.Errorf("field %q is not editable", k)
+			}
+			params[k] = v
+		}
+		return params, nil
+	default:
+		return nil, fmt.Errorf("action %q does not support editing", action)
+	}
+}

--- a/internal/api/handlers/approvals.go
+++ b/internal/api/handlers/approvals.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"time"
@@ -86,6 +87,12 @@ func (h *ApprovalsHandler) Approve(w http.ResponseWriter, r *http.Request) {
 	}
 	if time.Now().After(pa.ExpiresAt) {
 		writeError(w, http.StatusGone, "APPROVAL_EXPIRED", "this approval request has expired")
+		return
+	}
+
+	// Apply user edits if provided.
+	if err := h.applyEditsIfPresent(r, pa); err != nil {
+		writeError(w, http.StatusBadRequest, "EDIT_FAILED", err.Error())
 		return
 	}
 
@@ -238,6 +245,155 @@ func (h *ApprovalsHandler) Deny(w http.ResponseWriter, r *http.Request) {
 		"request_id": requestID,
 		"audit_id":   pa.AuditID,
 	})
+}
+
+// BatchApprove approves all pending requests in a batch.
+//
+// POST /api/approvals/batch/{batch_id}/approve
+// Auth: user JWT
+func (h *ApprovalsHandler) BatchApprove(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "not authenticated")
+		return
+	}
+
+	batchID := r.PathValue("batch_id")
+	pas, err := h.st.ListPendingApprovalsByBatch(r.Context(), user.ID, batchID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not list batch approvals")
+		return
+	}
+	if len(pas) == 0 {
+		writeError(w, http.StatusNotFound, "BATCH_EMPTY", "no pending approvals found for this batch")
+		return
+	}
+
+	var approved []string
+	for _, pa := range pas {
+		if time.Now().After(pa.ExpiresAt) {
+			continue
+		}
+		h.markApproved(r.Context(), pa)
+		h.publishQueueAndAudit(user.ID, pa.AuditID)
+		approved = append(approved, pa.RequestID)
+	}
+
+	h.updateNotificationMsg(r.Context(), "batch", batchID, user.ID, "✅ <b>Batch approved</b> — all requests approved.")
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"status":      "approved",
+		"batch_id":    batchID,
+		"approved":    approved,
+		"total":       len(approved),
+	})
+}
+
+// BatchDeny denies all pending requests in a batch.
+//
+// POST /api/approvals/batch/{batch_id}/deny
+// Auth: user JWT
+func (h *ApprovalsHandler) BatchDeny(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "not authenticated")
+		return
+	}
+
+	batchID := r.PathValue("batch_id")
+	pas, err := h.st.ListPendingApprovalsByBatch(r.Context(), user.ID, batchID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not list batch approvals")
+		return
+	}
+	if len(pas) == 0 {
+		writeError(w, http.StatusNotFound, "BATCH_EMPTY", "no pending approvals found for this batch")
+		return
+	}
+
+	var denied []string
+	for _, pa := range pas {
+		var denyBlob pendingRequestBlob
+		_ = json.Unmarshal(pa.RequestBlob, &denyBlob)
+
+		_ = h.st.UpdateAuditOutcome(r.Context(), pa.AuditID, "denied", "", 0)
+		_ = h.st.DeletePendingApproval(r.Context(), pa.RequestID)
+		h.decrementNotifierPolling(pa.UserID)
+		h.publishQueueAndAudit(user.ID, pa.AuditID)
+
+		if pa.CallbackURL != nil && *pa.CallbackURL != "" {
+			cbKey, _ := h.st.GetAgentCallbackSecret(r.Context(), denyBlob.AgentID)
+			requestID := pa.RequestID
+			auditID := pa.AuditID
+			callbackURL := *pa.CallbackURL
+			go func() {
+				_ = callback.DeliverResult(context.Background(), callbackURL, &callback.Payload{
+					Type:      "request",
+					RequestID: requestID,
+					Status:    "denied",
+					AuditID:   auditID,
+				}, cbKey)
+			}()
+		}
+		denied = append(denied, pa.RequestID)
+	}
+
+	h.updateNotificationMsg(r.Context(), "batch", batchID, user.ID, "❌ <b>Batch denied</b> — all requests rejected.")
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"status":   "denied",
+		"batch_id": batchID,
+		"denied":   denied,
+		"total":    len(denied),
+	})
+}
+
+// applyEditsIfPresent parses optional edited_fields from the request body,
+// applies them to the pending approval's params via the adapter's ApplyEdits,
+// and updates the stored RequestBlob.
+func (h *ApprovalsHandler) applyEditsIfPresent(r *http.Request, pa *store.PendingApproval) error {
+	if r.Body == nil || r.ContentLength == 0 {
+		return nil
+	}
+	var body struct {
+		EditedFields map[string]string `json:"edited_fields"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		return nil // not JSON or empty — no edits
+	}
+	if len(body.EditedFields) == 0 {
+		return nil
+	}
+
+	var blob pendingRequestBlob
+	if err := json.Unmarshal(pa.RequestBlob, &blob); err != nil {
+		return fmt.Errorf("invalid request blob: %w", err)
+	}
+
+	serviceType, _ := parseServiceAlias(blob.Service)
+	adapter, ok := h.adapterReg.Get(serviceType)
+	if !ok {
+		return fmt.Errorf("service %q not found", serviceType)
+	}
+	editor, ok := adapter.(adapters.ApprovalEditor)
+	if !ok {
+		return fmt.Errorf("service %q does not support editing", serviceType)
+	}
+
+	edited, err := editor.ApplyEdits(blob.Action, blob.Params, body.EditedFields)
+	if err != nil {
+		return err
+	}
+	blob.Params = edited
+
+	blobBytes, err := json.Marshal(&blob)
+	if err != nil {
+		return fmt.Errorf("re-marshal request blob: %w", err)
+	}
+	pa.RequestBlob = json.RawMessage(blobBytes)
+
+	// Persist the updated blob so that executeApproval uses edited params.
+	return h.st.UpdatePendingApprovalBlob(r.Context(), pa.RequestID, pa.RequestBlob)
 }
 
 // executeApproval runs the adapter request for an approved pending approval

--- a/internal/api/handlers/approvals.go
+++ b/internal/api/handlers/approvals.go
@@ -359,7 +359,7 @@ func (h *ApprovalsHandler) applyEditsIfPresent(r *http.Request, pa *store.Pendin
 		EditedFields map[string]string `json:"edited_fields"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		return nil // not JSON or empty — no edits
+		return fmt.Errorf("invalid request body: %w", err)
 	}
 	if len(body.EditedFields) == 0 {
 		return nil

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -38,6 +38,7 @@ type pendingRequestBlob struct {
 	AgentName   string         `json:"agent_name"`
 	RequestID   string         `json:"request_id"`
 	TaskID      string         `json:"task_id"`
+	BatchID     string         `json:"batch_id,omitempty"`
 	Reason      string         `json:"reason"`
 	CallbackURL  string                    `json:"callback_url"`
 	Verification *intent.VerificationVerdict `json:"verification,omitempty"`
@@ -929,8 +930,29 @@ func (h *GatewayHandler) routeToApproval(
 	if callbackURL != "" {
 		pa.CallbackURL = &callbackURL
 	}
+	if blob.BatchID != "" {
+		pa.BatchID = &blob.BatchID
+	}
+
+	// Render human-readable fields if the adapter supports it.
+	serviceType, _ := parseServiceAlias(blob.Service)
+	if adapter, ok := h.adapterReg.Get(serviceType); ok {
+		if renderer, ok := adapter.(adapters.ApprovalRenderer); ok {
+			if fields, err := renderer.RenderForApproval(blob.Action, blob.Params); err == nil && fields != nil {
+				if rendered, err := json.Marshal(fields); err == nil {
+					pa.RenderedFields = json.RawMessage(rendered)
+				}
+			}
+		}
+	}
 	if err := h.store.SavePendingApproval(ctx, pa); err != nil {
 		return fmt.Errorf("save pending approval: %w", err)
+	}
+
+	// When part of a batch, skip individual notification — the agent will
+	// close the batch later which triggers a single grouped notification.
+	if blob.BatchID != "" {
+		return nil
 	}
 
 	if h.notifier == nil {
@@ -968,6 +990,78 @@ func (h *GatewayHandler) routeToApproval(
 
 	_ = h.store.SaveNotificationMessage(ctx, "approval", blob.RequestID, "telegram", msgID)
 	return nil
+}
+
+// HandleBatchClose marks a batch as ready for review and sends a single
+// grouped notification instead of per-request notifications.
+//
+// POST /api/gateway/batch/{batch_id}/close
+// Auth: agent bearer token
+func (h *GatewayHandler) HandleBatchClose(w http.ResponseWriter, r *http.Request) {
+	agent := middleware.AgentFromContext(r.Context())
+	if agent == nil {
+		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "not authenticated")
+		return
+	}
+
+	batchID := r.PathValue("batch_id")
+	if batchID == "" {
+		writeError(w, http.StatusBadRequest, "MISSING_BATCH_ID", "batch_id is required")
+		return
+	}
+
+	pas, err := h.store.ListPendingApprovalsByBatch(r.Context(), agent.UserID, batchID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not list batch approvals")
+		return
+	}
+	if len(pas) == 0 {
+		writeError(w, http.StatusNotFound, "BATCH_EMPTY", "no pending approvals found for this batch")
+		return
+	}
+
+	// Send a single grouped notification for the batch.
+	if h.notifier != nil {
+		// Use the first approval's expiry for the notification.
+		expiresIn := fmt.Sprintf("%d minutes", int(time.Until(pas[0].ExpiresAt).Minutes()))
+		approveURL := fmt.Sprintf("%s/dashboard?action=approve_batch&batch_id=%s", h.baseURL, batchID)
+		denyURL := fmt.Sprintf("%s/dashboard?action=deny_batch&batch_id=%s", h.baseURL, batchID)
+
+		// Summarise what's in the batch.
+		var firstBlob pendingRequestBlob
+		_ = json.Unmarshal(pas[0].RequestBlob, &firstBlob)
+
+		approvalReq := notify.ApprovalRequest{
+			PendingID:    pas[0].ID,
+			RequestID:    batchID,
+			UserID:       agent.UserID,
+			AgentName:    firstBlob.AgentName,
+			Service:      firstBlob.Service,
+			Action:       fmt.Sprintf("batch (%d requests)", len(pas)),
+			Reason:       firstBlob.Reason,
+			PolicyReason: fmt.Sprintf("Batch of %d requests awaiting approval", len(pas)),
+			ExpiresIn:    expiresIn,
+			ApproveURL:   approveURL,
+			DenyURL:      denyURL,
+		}
+		msgID, err := h.notifier.SendApprovalRequest(r.Context(), approvalReq)
+		if err != nil {
+			h.logger.Warn("batch notification failed", "err", err)
+		} else {
+			_ = h.store.SaveNotificationMessage(r.Context(), "batch", batchID, "telegram", msgID)
+		}
+	}
+
+	// Publish queue event so the frontend refreshes.
+	if h.eventHub != nil {
+		h.eventHub.Publish(agent.UserID, events.Event{Type: "queue"})
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"status":   "closed",
+		"batch_id": batchID,
+		"count":    len(pas),
+	})
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -1038,6 +1132,7 @@ func buildRequestBlob(req gateway.Request, agent *store.Agent) *pendingRequestBl
 		AgentName:   agent.Name,
 		RequestID:   req.RequestID,
 		TaskID:      req.TaskID,
+		BatchID:     req.BatchID,
 		Reason:      req.Reason,
 		CallbackURL: req.Context.CallbackURL,
 	}

--- a/internal/api/handlers/overview.go
+++ b/internal/api/handlers/overview.go
@@ -52,12 +52,14 @@ func (h *OverviewHandler) Get(w http.ResponseWriter, r *http.Request) {
 
 		exp := pa.ExpiresAt
 		qa := &queueApproval{
-			RequestID: pa.RequestID,
-			AuditID:   pa.AuditID,
-			Service:   blob.Service,
-			Action:    blob.Action,
-			Params:    blob.Params,
-			Reason:    blob.Reason,
+			RequestID:      pa.RequestID,
+			AuditID:        pa.AuditID,
+			Service:        blob.Service,
+			Action:         blob.Action,
+			Params:         blob.Params,
+			Reason:         blob.Reason,
+			BatchID:        blob.BatchID,
+			RenderedFields: pa.RenderedFields,
 		}
 		if blob.Verification != nil {
 			b, _ := json.Marshal(blob.Verification)

--- a/internal/api/handlers/queue.go
+++ b/internal/api/handlers/queue.go
@@ -20,13 +20,15 @@ func NewQueueHandler(st store.Store) *QueueHandler {
 }
 
 type queueApproval struct {
-	RequestID    string         `json:"request_id"`
-	AuditID      string         `json:"audit_id"`
-	Service      string         `json:"service"`
-	Action       string         `json:"action"`
-	Params       map[string]any `json:"params"`
-	Reason       string         `json:"reason,omitempty"`
-	Verification map[string]any `json:"verification,omitempty"`
+	RequestID      string          `json:"request_id"`
+	AuditID        string          `json:"audit_id"`
+	Service        string          `json:"service"`
+	Action         string          `json:"action"`
+	Params         map[string]any  `json:"params"`
+	Reason         string          `json:"reason,omitempty"`
+	BatchID        string          `json:"batch_id,omitempty"`
+	RenderedFields json.RawMessage `json:"rendered_fields,omitempty"`
+	Verification   map[string]any  `json:"verification,omitempty"`
 }
 
 type queueItem struct {
@@ -70,12 +72,14 @@ func (h *QueueHandler) List(w http.ResponseWriter, r *http.Request) {
 
 		exp := pa.ExpiresAt
 		qa := &queueApproval{
-			RequestID: pa.RequestID,
-			AuditID:   pa.AuditID,
-			Service:   blob.Service,
-			Action:    blob.Action,
-			Params:    blob.Params,
-			Reason:    blob.Reason,
+			RequestID:      pa.RequestID,
+			AuditID:        pa.AuditID,
+			Service:        blob.Service,
+			Action:         blob.Action,
+			Params:         blob.Params,
+			Reason:         blob.Reason,
+			BatchID:        blob.BatchID,
+			RenderedFields: pa.RenderedFields,
 		}
 		if blob.Verification != nil {
 			b, _ := json.Marshal(blob.Verification)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -460,6 +460,9 @@ func (s *Server) routes() http.Handler {
 	mux.Handle("POST /api/gateway/request/{request_id}/execute", requireAgent(middleware.RateLimit(gatewayRL, agentKeyFn, rlCfg.Gateway.Limit)(
 		e2e(http.HandlerFunc(gatewayHandler.HandleExecuteApproved)))))
 
+	// Batch close (agent token)
+	mux.Handle("POST /api/gateway/batch/{batch_id}/close", requireAgent(e2e(http.HandlerFunc(gatewayHandler.HandleBatchClose))))
+
 	// Callback secret registration (agent token)
 	mux.Handle("POST /api/callbacks/register", requireAgent(e2e(http.HandlerFunc(gatewayHandler.RegisterCallback))))
 
@@ -487,6 +490,8 @@ func (s *Server) routes() http.Handler {
 	mux.Handle("GET /api/approvals", user(approvalsHandler.List))
 	mux.Handle("POST /api/approvals/{request_id}/approve", user(approvalsHandler.Approve))
 	mux.Handle("POST /api/approvals/{request_id}/deny", user(approvalsHandler.Deny))
+	mux.Handle("POST /api/approvals/batch/{batch_id}/approve", user(approvalsHandler.BatchApprove))
+	mux.Handle("POST /api/approvals/batch/{batch_id}/deny", user(approvalsHandler.BatchDeny))
 
 	// Unified queue (user JWT)
 	queueHandler := handlers.NewQueueHandler(s.store)
@@ -593,6 +598,7 @@ func (s *Server) routes() http.Handler {
 			"POST /api/tasks/{id}/expand":                      http.HandlerFunc(tasksHandler.Expand),
 			"POST /api/gateway/request":                        http.HandlerFunc(gatewayHandler.HandleRequest),
 			"POST /api/gateway/request/{request_id}/execute":   http.HandlerFunc(gatewayHandler.HandleExecuteApproved),
+			"POST /api/gateway/batch/{batch_id}/close":         http.HandlerFunc(gatewayHandler.HandleBatchClose),
 		}
 
 		mcpServer := mcp.NewServer(s.store, sessionTTL, mcpHandlers, s.logger)

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -113,10 +113,22 @@ func toolDefs() []Tool {
 					"task_id": {"type": "string", "description": "Task ID authorizing this request"},
 					"context": {"type": "object", "description": "Optional context (source, data_origin, callback_url)"},
 					"session_id": {"type": "string", "description": "Consistent UUID for chain context on standing tasks"},
+					"batch_id": {"type": "string", "description": "Optional batch ID to group multiple requests for batch approval. Generate a UUID and include it on all requests in the batch, then close the batch."},
 					"wait": {"type": "boolean", "description": "Block until approved and return executed result (default true)"},
 					"timeout": {"type": "integer", "description": "Long-poll timeout in seconds (default 120, max 120)"}
 				},
 				"required": ["service", "action", "params", "reason", "request_id", "task_id"]
+			}`),
+		},
+		{
+			Name:        "close_batch",
+			Description: "Close a batch of gateway requests, triggering a single grouped notification to the user. Call this after submitting all requests in a batch (those sharing the same batch_id).",
+			InputSchema: json.RawMessage(`{
+				"type": "object",
+				"properties": {
+					"batch_id": {"type": "string", "description": "The batch ID shared by all requests in this batch"}
+				},
+				"required": ["batch_id"]
 			}`),
 		},
 		{

--- a/internal/mcp/tools_exec.go
+++ b/internal/mcp/tools_exec.go
@@ -172,6 +172,15 @@ func buildInternalRequest(toolName string, arguments json.RawMessage) (internalR
 		body := stripKeys(args, "wait", "timeout")
 		return internalRoute{"POST", path, "POST /api/gateway/request", nil}, body, nil
 
+	case "close_batch":
+		id := getString("batch_id")
+		if err := validatePathParam(id, "batch_id"); err != nil {
+			return internalRoute{}, nil, err
+		}
+		return internalRoute{"POST", "/api/gateway/batch/" + id + "/close",
+			"POST /api/gateway/batch/{batch_id}/close",
+			map[string]string{"batch_id": id}}, nil, nil
+
 	case "execute_request":
 		id := getString("request_id")
 		if err := validatePathParam(id, "request_id"); err != nil {

--- a/internal/store/postgres/migrations/020_batch_id.sql
+++ b/internal/store/postgres/migrations/020_batch_id.sql
@@ -1,1 +1,2 @@
 ALTER TABLE pending_approvals ADD COLUMN batch_id TEXT;
+ALTER TABLE pending_approvals ADD COLUMN rendered_fields TEXT;

--- a/internal/store/postgres/migrations/020_batch_id.sql
+++ b/internal/store/postgres/migrations/020_batch_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE pending_approvals ADD COLUMN batch_id TEXT;

--- a/internal/store/postgres/migrations/021_rendered_fields.sql
+++ b/internal/store/postgres/migrations/021_rendered_fields.sql
@@ -1,1 +1,0 @@
-ALTER TABLE pending_approvals ADD COLUMN rendered_fields TEXT;

--- a/internal/store/postgres/migrations/021_rendered_fields.sql
+++ b/internal/store/postgres/migrations/021_rendered_fields.sql
@@ -1,0 +1,1 @@
+ALTER TABLE pending_approvals ADD COLUMN rendered_fields TEXT;

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -854,23 +854,29 @@ func (s *Store) SavePendingApproval(ctx context.Context, pa *store.PendingApprov
 	if pa.Status == "" {
 		pa.Status = "pending"
 	}
+	var renderedFields *string
+	if pa.RenderedFields != nil {
+		s := string(pa.RenderedFields)
+		renderedFields = &s
+	}
 	_, err := s.pool.Exec(ctx, `
-		INSERT INTO pending_approvals (id, user_id, request_id, audit_id, request_blob, callback_url, status, expires_at)
-		VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+		INSERT INTO pending_approvals (id, user_id, request_id, audit_id, request_blob, callback_url, batch_id, rendered_fields, status, expires_at)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
 	`, pa.ID, pa.UserID, pa.RequestID, pa.AuditID, []byte(pa.RequestBlob),
-		pa.CallbackURL, pa.Status, pa.ExpiresAt)
+		pa.CallbackURL, pa.BatchID, renderedFields, pa.Status, pa.ExpiresAt)
 	return err
 }
 
 func (s *Store) GetPendingApproval(ctx context.Context, requestID string) (*store.PendingApproval, error) {
 	pa := &store.PendingApproval{}
 	var requestBlob []byte
+	var renderedFields *string
 	err := s.pool.QueryRow(ctx, `
-		SELECT id, user_id, request_id, audit_id, request_blob, callback_url, status, expires_at, created_at
+		SELECT id, user_id, request_id, audit_id, request_blob, callback_url, batch_id, rendered_fields, status, expires_at, created_at
 		FROM pending_approvals WHERE request_id = $1
 	`, requestID).Scan(
 		&pa.ID, &pa.UserID, &pa.RequestID, &pa.AuditID, &requestBlob,
-		&pa.CallbackURL, &pa.Status, &pa.ExpiresAt, &pa.CreatedAt)
+		&pa.CallbackURL, &pa.BatchID, &renderedFields, &pa.Status, &pa.ExpiresAt, &pa.CreatedAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, store.ErrNotFound
 	}
@@ -878,6 +884,9 @@ func (s *Store) GetPendingApproval(ctx context.Context, requestID string) (*stor
 		return nil, err
 	}
 	pa.RequestBlob = json.RawMessage(requestBlob)
+	if renderedFields != nil {
+		pa.RenderedFields = json.RawMessage(*renderedFields)
+	}
 	return pa, nil
 }
 
@@ -889,7 +898,7 @@ func (s *Store) DeletePendingApproval(ctx context.Context, requestID string) err
 
 func (s *Store) ListPendingApprovals(ctx context.Context, userID string) ([]*store.PendingApproval, error) {
 	rows, err := s.pool.Query(ctx, `
-		SELECT id, user_id, request_id, audit_id, request_blob, callback_url, status, expires_at, created_at
+		SELECT id, user_id, request_id, audit_id, request_blob, callback_url, batch_id, rendered_fields, status, expires_at, created_at
 		FROM pending_approvals WHERE user_id = $1 AND status = 'pending' AND expires_at > NOW() ORDER BY created_at ASC`, userID)
 	if err != nil {
 		return nil, err
@@ -900,8 +909,19 @@ func (s *Store) ListPendingApprovals(ctx context.Context, userID string) ([]*sto
 
 func (s *Store) ListExpiredPendingApprovals(ctx context.Context) ([]*store.PendingApproval, error) {
 	rows, err := s.pool.Query(ctx, `
-		SELECT id, user_id, request_id, audit_id, request_blob, callback_url, status, expires_at, created_at
+		SELECT id, user_id, request_id, audit_id, request_blob, callback_url, batch_id, rendered_fields, status, expires_at, created_at
 		FROM pending_approvals WHERE status = 'pending' AND expires_at < NOW()`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanPendingApprovals(rows)
+}
+
+func (s *Store) ListPendingApprovalsByBatch(ctx context.Context, userID, batchID string) ([]*store.PendingApproval, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT id, user_id, request_id, audit_id, request_blob, callback_url, batch_id, rendered_fields, status, expires_at, created_at
+		FROM pending_approvals WHERE user_id = $1 AND batch_id = $2 AND status = 'pending' AND expires_at > NOW() ORDER BY created_at ASC`, userID, batchID)
 	if err != nil {
 		return nil, err
 	}
@@ -1034,16 +1054,26 @@ func scanPendingApprovals(rows pgx.Rows) ([]*store.PendingApproval, error) {
 	for rows.Next() {
 		pa := &store.PendingApproval{}
 		var requestBlob []byte
+		var renderedFields *string
 		if err := rows.Scan(
 			&pa.ID, &pa.UserID, &pa.RequestID, &pa.AuditID, &requestBlob,
-			&pa.CallbackURL, &pa.Status, &pa.ExpiresAt, &pa.CreatedAt,
+			&pa.CallbackURL, &pa.BatchID, &renderedFields, &pa.Status, &pa.ExpiresAt, &pa.CreatedAt,
 		); err != nil {
 			return nil, err
 		}
 		pa.RequestBlob = json.RawMessage(requestBlob)
+		if renderedFields != nil {
+			pa.RenderedFields = json.RawMessage(*renderedFields)
+		}
 		pas = append(pas, pa)
 	}
 	return pas, rows.Err()
+}
+
+func (s *Store) UpdatePendingApprovalBlob(ctx context.Context, requestID string, blob json.RawMessage) error {
+	_, err := s.pool.Exec(ctx,
+		`UPDATE pending_approvals SET request_blob = $1 WHERE request_id = $2`, []byte(blob), requestID)
+	return err
 }
 
 func (s *Store) UpdatePendingApprovalStatus(ctx context.Context, requestID, status string) error {

--- a/internal/store/sqlite/migrations/020_batch_id.sql
+++ b/internal/store/sqlite/migrations/020_batch_id.sql
@@ -1,1 +1,2 @@
 ALTER TABLE pending_approvals ADD COLUMN batch_id TEXT;
+ALTER TABLE pending_approvals ADD COLUMN rendered_fields TEXT;

--- a/internal/store/sqlite/migrations/020_batch_id.sql
+++ b/internal/store/sqlite/migrations/020_batch_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE pending_approvals ADD COLUMN batch_id TEXT;

--- a/internal/store/sqlite/migrations/021_rendered_fields.sql
+++ b/internal/store/sqlite/migrations/021_rendered_fields.sql
@@ -1,1 +1,0 @@
-ALTER TABLE pending_approvals ADD COLUMN rendered_fields TEXT;

--- a/internal/store/sqlite/migrations/021_rendered_fields.sql
+++ b/internal/store/sqlite/migrations/021_rendered_fields.sql
@@ -1,0 +1,1 @@
+ALTER TABLE pending_approvals ADD COLUMN rendered_fields TEXT;

--- a/internal/store/sqlite/store.go
+++ b/internal/store/sqlite/store.go
@@ -1010,23 +1010,29 @@ func (s *Store) SavePendingApproval(ctx context.Context, pa *store.PendingApprov
 	if pa.Status == "" {
 		pa.Status = "pending"
 	}
+	var renderedFields *string
+	if pa.RenderedFields != nil {
+		s := string(pa.RenderedFields)
+		renderedFields = &s
+	}
 	_, err := s.db.ExecContext(ctx, `
-		INSERT INTO pending_approvals (id, user_id, request_id, audit_id, request_blob, callback_url, status, expires_at)
-		VALUES (?,?,?,?,?,?,?,?)
+		INSERT INTO pending_approvals (id, user_id, request_id, audit_id, request_blob, callback_url, batch_id, rendered_fields, status, expires_at)
+		VALUES (?,?,?,?,?,?,?,?,?,?)
 	`, pa.ID, pa.UserID, pa.RequestID, pa.AuditID, string(pa.RequestBlob),
-		pa.CallbackURL, pa.Status, pa.ExpiresAt.UTC().Format(time.RFC3339))
+		pa.CallbackURL, pa.BatchID, renderedFields, pa.Status, pa.ExpiresAt.UTC().Format(time.RFC3339))
 	return err
 }
 
 func (s *Store) GetPendingApproval(ctx context.Context, requestID string) (*store.PendingApproval, error) {
 	pa := &store.PendingApproval{}
 	var requestBlob, expiresAt, createdAt string
+	var renderedFields *string
 	err := s.db.QueryRowContext(ctx, `
-		SELECT id, user_id, request_id, audit_id, request_blob, callback_url, status, expires_at, created_at
+		SELECT id, user_id, request_id, audit_id, request_blob, callback_url, batch_id, rendered_fields, status, expires_at, created_at
 		FROM pending_approvals WHERE request_id = ?
 	`, requestID).Scan(
 		&pa.ID, &pa.UserID, &pa.RequestID, &pa.AuditID, &requestBlob,
-		&pa.CallbackURL, &pa.Status, &expiresAt, &createdAt)
+		&pa.CallbackURL, &pa.BatchID, &renderedFields, &pa.Status, &expiresAt, &createdAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, store.ErrNotFound
 	}
@@ -1034,6 +1040,9 @@ func (s *Store) GetPendingApproval(ctx context.Context, requestID string) (*stor
 		return nil, err
 	}
 	pa.RequestBlob = json.RawMessage(requestBlob)
+	if renderedFields != nil {
+		pa.RenderedFields = json.RawMessage(*renderedFields)
+	}
 	pa.ExpiresAt = parseTime(expiresAt)
 	pa.CreatedAt = parseTime(createdAt)
 	return pa, nil
@@ -1047,7 +1056,7 @@ func (s *Store) DeletePendingApproval(ctx context.Context, requestID string) err
 
 func (s *Store) ListPendingApprovals(ctx context.Context, userID string) ([]*store.PendingApproval, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, user_id, request_id, audit_id, request_blob, callback_url, status, expires_at, created_at
+		SELECT id, user_id, request_id, audit_id, request_blob, callback_url, batch_id, rendered_fields, status, expires_at, created_at
 		FROM pending_approvals WHERE user_id = ? AND status = 'pending' AND expires_at > datetime('now') ORDER BY created_at ASC`, userID)
 	if err != nil {
 		return nil, err
@@ -1058,7 +1067,7 @@ func (s *Store) ListPendingApprovals(ctx context.Context, userID string) ([]*sto
 
 func (s *Store) ListExpiredPendingApprovals(ctx context.Context) ([]*store.PendingApproval, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, user_id, request_id, audit_id, request_blob, callback_url, status, expires_at, created_at
+		SELECT id, user_id, request_id, audit_id, request_blob, callback_url, batch_id, rendered_fields, status, expires_at, created_at
 		FROM pending_approvals WHERE status = 'pending' AND expires_at < datetime('now')`)
 	if err != nil {
 		return nil, err
@@ -1072,18 +1081,39 @@ func scanSQLitePendingApprovals(rows *sql.Rows) ([]*store.PendingApproval, error
 	for rows.Next() {
 		pa := &store.PendingApproval{}
 		var requestBlob, expiresAt, createdAt string
+		var renderedFields *string
 		if err := rows.Scan(
 			&pa.ID, &pa.UserID, &pa.RequestID, &pa.AuditID, &requestBlob,
-			&pa.CallbackURL, &pa.Status, &expiresAt, &createdAt,
+			&pa.CallbackURL, &pa.BatchID, &renderedFields, &pa.Status, &expiresAt, &createdAt,
 		); err != nil {
 			return nil, err
 		}
 		pa.RequestBlob = json.RawMessage(requestBlob)
+		if renderedFields != nil {
+			pa.RenderedFields = json.RawMessage(*renderedFields)
+		}
 		pa.ExpiresAt = parseTime(expiresAt)
 		pa.CreatedAt = parseTime(createdAt)
 		pas = append(pas, pa)
 	}
 	return pas, rows.Err()
+}
+
+func (s *Store) ListPendingApprovalsByBatch(ctx context.Context, userID, batchID string) ([]*store.PendingApproval, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, user_id, request_id, audit_id, request_blob, callback_url, batch_id, rendered_fields, status, expires_at, created_at
+		FROM pending_approvals WHERE user_id = ? AND batch_id = ? AND status = 'pending' AND expires_at > datetime('now') ORDER BY created_at ASC`, userID, batchID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanSQLitePendingApprovals(rows)
+}
+
+func (s *Store) UpdatePendingApprovalBlob(ctx context.Context, requestID string, blob json.RawMessage) error {
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE pending_approvals SET request_blob = ? WHERE request_id = ?`, string(blob), requestID)
+	return err
 }
 
 func (s *Store) UpdatePendingApprovalStatus(ctx context.Context, requestID, status string) error {

--- a/pkg/adapters/adapters.go
+++ b/pkg/adapters/adapters.go
@@ -125,6 +125,29 @@ type VerificationHinter interface {
 	VerificationHints() string
 }
 
+// RenderedField is a human-readable representation of a request parameter,
+// produced by adapters that implement ApprovalRenderer.
+type RenderedField struct {
+	Key       string `json:"key"`       // param path, e.g. "to", "subject", "body"
+	Label     string `json:"label"`     // display label
+	Value     string `json:"value"`     // human-readable rendered value
+	Editable  bool   `json:"editable"`  // can the user modify this?
+	Multiline bool   `json:"multiline"` // render as textarea vs input
+	Format    string `json:"format"`    // "text", "markdown", "html"
+}
+
+// ApprovalRenderer is an optional interface adapters can implement to provide
+// human-readable rendering of request params for the approval UI.
+type ApprovalRenderer interface {
+	RenderForApproval(action string, params map[string]any) ([]RenderedField, error)
+}
+
+// ApprovalEditor is an optional interface adapters can implement to apply
+// user edits back to the raw request params before execution.
+type ApprovalEditor interface {
+	ApplyEdits(action string, params map[string]any, edits map[string]string) (map[string]any, error)
+}
+
 // Adapter is the interface every service adapter implements.
 type Adapter interface {
 	// ServiceID returns the adapter's canonical service identifier (e.g. "google.gmail").

--- a/pkg/adapters/yamlruntime/adapter.go
+++ b/pkg/adapters/yamlruntime/adapter.go
@@ -23,10 +23,12 @@ type ActionFunc func(ctx context.Context, req adapters.Request) (*adapters.Resul
 
 // YAMLAdapter implements adapters.Adapter from a YAML service definition.
 type YAMLAdapter struct {
-	def           yamldef.ServiceDef
-	overrides     map[string]ActionFunc              // action_name → Go override
-	oauthProvider adapters.OAuthCredentialProvider    // lazy OAuth credential source
-	compiled      map[string]*compiledAction          // action_name → compiled exprs (nil if none)
+	def              yamldef.ServiceDef
+	overrides        map[string]ActionFunc              // action_name → Go override
+	oauthProvider    adapters.OAuthCredentialProvider    // lazy OAuth credential source
+	compiled         map[string]*compiledAction          // action_name → compiled exprs (nil if none)
+	approvalRenderer adapters.ApprovalRenderer           // optional, set via SetApprovalRenderer
+	approvalEditor   adapters.ApprovalEditor             // optional, set via SetApprovalEditor
 }
 
 // New creates a YAMLAdapter from a parsed service definition.
@@ -313,6 +315,34 @@ func (a *YAMLAdapter) VerificationHints() string {
 // SetOAuthProvider sets the provider that supplies OAuth app credentials lazily.
 func (a *YAMLAdapter) SetOAuthProvider(p adapters.OAuthCredentialProvider) {
 	a.oauthProvider = p
+}
+
+// SetApprovalRenderer sets an optional ApprovalRenderer that will be used
+// to render human-readable fields for the approval UI.
+func (a *YAMLAdapter) SetApprovalRenderer(r adapters.ApprovalRenderer) {
+	a.approvalRenderer = r
+}
+
+// SetApprovalEditor sets an optional ApprovalEditor that will be used
+// to apply user edits back to request params before execution.
+func (a *YAMLAdapter) SetApprovalEditor(e adapters.ApprovalEditor) {
+	a.approvalEditor = e
+}
+
+// RenderForApproval delegates to the registered ApprovalRenderer, if any.
+func (a *YAMLAdapter) RenderForApproval(action string, params map[string]any) ([]adapters.RenderedField, error) {
+	if a.approvalRenderer == nil {
+		return nil, nil
+	}
+	return a.approvalRenderer.RenderForApproval(action, params)
+}
+
+// ApplyEdits delegates to the registered ApprovalEditor, if any.
+func (a *YAMLAdapter) ApplyEdits(action string, params map[string]any, edits map[string]string) (map[string]any, error) {
+	if a.approvalEditor == nil {
+		return nil, fmt.Errorf("adapter does not support editing")
+	}
+	return a.approvalEditor.ApplyEdits(action, params, edits)
 }
 
 // DeviceFlowConfig returns the device flow configuration if available and

--- a/pkg/clawvisor/defaults.go
+++ b/pkg/clawvisor/defaults.go
@@ -162,6 +162,12 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 		if meta.OAuthEndpoint == "google" {
 			ya.SetOAuthProvider(oauthProvider)
 		}
+		// Wire Go-implemented approval rendering/editing for adapters that have it.
+		switch ya.ServiceID() {
+		case "google.gmail":
+			ya.SetApprovalRenderer(gmail)
+			ya.SetApprovalEditor(gmail)
+		}
 		adapterReg.Register(ya)
 	}
 

--- a/pkg/gateway/types.go
+++ b/pkg/gateway/types.go
@@ -9,6 +9,7 @@ type Request struct {
 	Context   RequestContext `json:"context"`
 	RequestID string         `json:"request_id"` // optional; generated if empty
 	TaskID    string         `json:"task_id,omitempty"`
+	BatchID   string         `json:"batch_id,omitempty"`
 	SessionID string         `json:"session_id,omitempty"`
 }
 

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -86,6 +86,8 @@ type Store interface {
 	// from "approved" to "executing". Returns true if the caller won the claim,
 	// false if another caller already claimed it (or the row is not "approved").
 	ClaimPendingApprovalForExecution(ctx context.Context, requestID string) (bool, error)
+	ListPendingApprovalsByBatch(ctx context.Context, userID, batchID string) ([]*PendingApproval, error)
+	UpdatePendingApprovalBlob(ctx context.Context, requestID string, blob json.RawMessage) error
 
 	// Notification messages (cross-channel message tracking)
 	SaveNotificationMessage(ctx context.Context, targetType, targetID, channel, messageID string) error
@@ -259,15 +261,17 @@ type Task struct {
 
 // PendingApproval is a gateway request awaiting human approval.
 type PendingApproval struct {
-	ID            string          `json:"id"`
-	UserID        string          `json:"user_id"`
-	RequestID     string          `json:"request_id"`
-	AuditID       string          `json:"audit_id"`
-	RequestBlob   json.RawMessage `json:"request_blob"`
-	CallbackURL   *string         `json:"callback_url,omitempty"`
-	Status        string          `json:"status"` // "pending" or "approved"
-	ExpiresAt     time.Time       `json:"expires_at"`
-	CreatedAt     time.Time       `json:"created_at"`
+	ID             string          `json:"id"`
+	UserID         string          `json:"user_id"`
+	RequestID      string          `json:"request_id"`
+	AuditID        string          `json:"audit_id"`
+	RequestBlob    json.RawMessage `json:"request_blob"`
+	CallbackURL    *string         `json:"callback_url,omitempty"`
+	BatchID        *string         `json:"batch_id,omitempty"`
+	RenderedFields json.RawMessage `json:"rendered_fields,omitempty"`
+	Status         string          `json:"status"` // "pending" or "approved"
+	ExpiresAt      time.Time       `json:"expires_at"`
+	CreatedAt      time.Time       `json:"created_at"`
 }
 
 // TaskFilter controls which tasks are returned by ListTasks.

--- a/skills/clawvisor/SKILL.md.tmpl
+++ b/skills/clawvisor/SKILL.md.tmpl
@@ -263,6 +263,27 @@ Use `gateway_request` for each action. Required fields:
 | `request_id` | A unique ID you generate (e.g. UUID). Must be unique across all your requests. |
 | `task_id` | The approved task ID this request belongs to. |
 | `session_id` | *(Standing tasks only)* A consistent UUID across related requests in a single invocation.{{ if .UseCurl }} Required for chain context on standing tasks. Not needed for ephemeral tasks (chain context is automatic).{{ end }} |
+| `batch_id` | *(Optional)* When you have multiple non-auto-execute requests to submit together (e.g. sending 5 email replies), generate a single batch ID (e.g. UUID) and include it on all of them. After submitting all requests, close the batch (see below). The user reviews and approves/denies them as a group. |
+
+### Batch requests
+
+When you need to submit multiple requests that should be reviewed together:
+
+1. Generate a unique `batch_id` (e.g. UUID)
+2. Include `batch_id` on every gateway request in the batch
+3. Submit all requests (in parallel or sequentially)
+4. Close the batch:
+{{ if .UseCurl -}}
+```bash
+curl -s -X POST "$CLAWVISOR_URL/api/gateway/batch/<batch_id>/close" \
+  -H "Authorization: Bearer $CLAWVISOR_AGENT_TOKEN"
+```
+{{ else -}}
+
+Use `POST /api/gateway/batch/<batch_id>/close` with your agent token.
+{{ end -}}
+
+The user receives a single notification for the entire batch and can approve or deny all requests at once, or individually. Individual requests within a batch also support the normal `?wait=true` long-poll pattern.
 
 ### Context fields
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -403,6 +403,15 @@ export interface OverviewData {
   activity: ActivityBucket[]
 }
 
+export interface RenderedField {
+  key: string
+  label: string
+  value: string
+  editable: boolean
+  multiline: boolean
+  format: string // "text", "markdown", "html"
+}
+
 export interface QueueApproval {
   request_id: string
   audit_id: string
@@ -410,6 +419,8 @@ export interface QueueApproval {
   action: string
   params: Record<string, unknown>
   reason?: string
+  batch_id?: string
+  rendered_fields?: RenderedField[]
   verification?: VerificationVerdict
 }
 
@@ -547,12 +558,18 @@ export const api = {
   },
   approvals: {
     list: () => get<{ entries: PendingApproval[]; total: number }>('/api/approvals'),
-    approve: (requestId: string) =>
+    approve: (requestId: string, editedFields?: Record<string, string>) =>
       post<{ status: string; request_id: string; audit_id: string; result?: unknown }>
-        (`/api/approvals/${requestId}/approve`, {}),
+        (`/api/approvals/${requestId}/approve`, editedFields ? { edited_fields: editedFields } : {}),
     deny: (requestId: string) =>
       post<{ status: string; request_id: string; audit_id: string }>
         (`/api/approvals/${requestId}/deny`, {}),
+    batchApprove: (batchId: string) =>
+      post<{ status: string; batch_id: string; approved: string[]; total: number }>
+        (`/api/approvals/batch/${batchId}/approve`, {}),
+    batchDeny: (batchId: string) =>
+      post<{ status: string; batch_id: string; denied: string[]; total: number }>
+        (`/api/approvals/batch/${batchId}/deny`, {}),
   },
   notifications: {
     list: () => get<NotificationConfig[]>('/api/notifications'),

--- a/web/src/pages/Overview.tsx
+++ b/web/src/pages/Overview.tsx
@@ -31,17 +31,36 @@ export default function Overview() {
     },
     onError: (err: Error) => setDeepLinkResult(`Deny failed: ${err.message}`),
   })
+  const deepApproveBatch = useMutation({
+    mutationFn: (batchId: string) => api.approvals.batchApprove(batchId),
+    onSuccess: (data) => {
+      setDeepLinkResult(`Batch approved (${data.total} requests).`)
+      qc.invalidateQueries({ queryKey: ['overview'] })
+    },
+    onError: (err: Error) => setDeepLinkResult(`Batch approve failed: ${err.message}`),
+  })
+  const deepDenyBatch = useMutation({
+    mutationFn: (batchId: string) => api.approvals.batchDeny(batchId),
+    onSuccess: (data) => {
+      setDeepLinkResult(`Batch denied (${data.total} requests).`)
+      qc.invalidateQueries({ queryKey: ['overview'] })
+    },
+    onError: (err: Error) => setDeepLinkResult(`Batch deny failed: ${err.message}`),
+  })
 
   // Handle deep link actions for approvals
   useEffect(() => {
     const action = searchParams.get('action')
     const requestId = searchParams.get('request_id')
-    if (!action || !requestId) return
+    const batchId = searchParams.get('batch_id')
+    if (!action) return
 
     setSearchParams({}, { replace: true })
 
-    if (action === 'approve') deepApproveRequest.mutate(requestId)
-    else if (action === 'deny') deepDenyRequest.mutate(requestId)
+    if (action === 'approve' && requestId) deepApproveRequest.mutate(requestId)
+    else if (action === 'deny' && requestId) deepDenyRequest.mutate(requestId)
+    else if (action === 'approve_batch' && batchId) deepApproveBatch.mutate(batchId)
+    else if (action === 'deny_batch' && batchId) deepDenyBatch.mutate(batchId)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
@@ -102,7 +121,38 @@ export default function Overview() {
     }
   }, [services, agentsData, notificationsData])
 
-  const queueItems = overview?.queue ?? []
+  const rawQueueItems = overview?.queue ?? []
+
+  // Group approval items by batch_id; non-batched items pass through individually.
+  const queueItems = useMemo(() => {
+    const batches = new Map<string, QueueItem[]>()
+    const standalone: QueueItem[] = []
+    for (const item of rawQueueItems) {
+      const batchId = item.type === 'approval' ? item.approval?.batch_id : undefined
+      if (batchId) {
+        const group = batches.get(batchId) ?? []
+        group.push(item)
+        batches.set(batchId, group)
+      } else {
+        standalone.push(item)
+      }
+    }
+    // Insert batch groups as synthetic items at the position of the first member.
+    const result: (QueueItem | { type: 'batch'; batch_id: string; items: QueueItem[] })[] = []
+    const insertedBatches = new Set<string>()
+    for (const item of rawQueueItems) {
+      const batchId = item.type === 'approval' ? item.approval?.batch_id : undefined
+      if (batchId) {
+        if (!insertedBatches.has(batchId)) {
+          insertedBatches.add(batchId)
+          result.push({ type: 'batch', batch_id: batchId, items: batches.get(batchId)! })
+        }
+      } else {
+        result.push(item)
+      }
+    }
+    return result
+  }, [rawQueueItems])
   const activeTasks = overview?.active_tasks ?? []
   const activity = overview?.activity ?? []
 
@@ -184,15 +234,17 @@ export default function Overview() {
         ) : (
           <div className="space-y-3">
             {queueItems.map(item =>
-              item.type === 'approval' ? (
-                <ApprovalCard key={item.id} item={item} />
-              ) : item.type === 'connection' && item.connection ? (
-                <ConnectionQueueCard key={item.id} connection={item.connection} />
-              ) : item.task ? (
+              'batch_id' in item && item.type === 'batch' ? (
+                <BatchCard key={item.batch_id} batchId={item.batch_id} items={item.items} />
+              ) : 'id' in item && item.type === 'approval' ? (
+                <ApprovalCard key={item.id} item={item as QueueItem} />
+              ) : 'id' in item && item.type === 'connection' && (item as QueueItem).connection ? (
+                <ConnectionQueueCard key={(item as QueueItem).id} connection={(item as QueueItem).connection!} />
+              ) : 'id' in item && (item as QueueItem).task ? (
                 <TaskCard
-                  key={item.id}
-                  task={item.task}
-                  agentName={agentMap.get(item.task.agent_id) ?? item.task.agent_id.slice(0, 8)}
+                  key={(item as QueueItem).id}
+                  task={(item as QueueItem).task!}
+                  agentName={agentMap.get((item as QueueItem).task!.agent_id) ?? (item as QueueItem).task!.agent_id.slice(0, 8)}
                 />
               ) : null
             )}
@@ -341,6 +393,286 @@ function ActivityChart({ data }: { data: ActivityBucket[] }) {
   )
 }
 
+// ── Batch card (grouped request approvals) ───────────────────────────────────
+
+// ── Editable fields display (shared between ApprovalCard and BatchCard) ──────
+
+function ClickToEditFields({
+  rendered,
+  edits,
+  onEdit,
+}: {
+  rendered: import('../api/client').RenderedField[]
+  edits: Record<string, string>
+  onEdit: (key: string, value: string) => void
+}) {
+  const [editing, setEditing] = useState<Record<string, boolean>>({})
+
+  return (
+    <div className="bg-surface-0 border border-border-subtle rounded overflow-hidden">
+      <table className="w-full text-xs">
+        <tbody>
+          {rendered.map((field, i) => (
+            <tr key={field.key} className={i < rendered.length - 1 ? 'border-b border-border-subtle' : ''}>
+              <td className="px-3 py-1.5 font-mono text-text-tertiary w-28 align-top">{field.label}</td>
+              <td className="px-3 py-1.5 font-mono text-text-primary break-all">
+                {field.editable && editing[field.key] ? (
+                  field.multiline ? (
+                    <textarea
+                      autoFocus
+                      value={edits[field.key] ?? field.value}
+                      onChange={e => onEdit(field.key, e.target.value)}
+                      onBlur={() => setEditing(prev => ({ ...prev, [field.key]: false }))}
+                      rows={4}
+                      className="w-full rounded border border-brand bg-surface-0 px-2 py-1 text-xs font-mono text-text-primary focus:outline-none resize-y -my-0.5"
+                    />
+                  ) : (
+                    <input
+                      autoFocus
+                      type="text"
+                      value={edits[field.key] ?? field.value}
+                      onChange={e => onEdit(field.key, e.target.value)}
+                      onBlur={() => setEditing(prev => ({ ...prev, [field.key]: false }))}
+                      className="w-full rounded border border-brand bg-surface-0 px-2 py-0.5 text-xs font-mono text-text-primary focus:outline-none -my-0.5"
+                    />
+                  )
+                ) : (
+                  <span
+                    onClick={field.editable ? () => setEditing(prev => ({ ...prev, [field.key]: true })) : undefined}
+                    className={field.editable ? 'cursor-pointer hover:text-brand' : ''}
+                    title={field.editable ? 'Click to edit' : undefined}
+                  >
+                    {(edits[field.key] ?? field.value) || '\u00A0'}
+                  </span>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function EditableFields({
+  rendered,
+  params,
+  edits,
+  onEdit,
+}: {
+  rendered?: import('../api/client').RenderedField[]
+  params: Record<string, unknown>
+  edits: Record<string, string>
+  onEdit: (key: string, value: string) => void
+}) {
+  if (rendered && rendered.length > 0) {
+    return <ClickToEditFields rendered={rendered} edits={edits} onEdit={onEdit} />
+  }
+
+  const paramEntries = Object.entries(params)
+  if (paramEntries.length === 0) return null
+
+  return (
+    <div className="bg-surface-0 border border-border-subtle rounded overflow-hidden">
+      <table className="w-full text-xs">
+        <tbody>
+          {paramEntries.map(([key, value], i) => (
+            <tr key={key} className={i < paramEntries.length - 1 ? 'border-b border-border-subtle' : ''}>
+              <td className="px-3 py-1.5 font-mono text-text-tertiary w-28 align-top">{key}</td>
+              <td className="px-3 py-1.5 font-mono text-text-primary break-all">
+                {typeof value === 'string' ? value : JSON.stringify(value)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function useFieldEdits(rendered?: import('../api/client').RenderedField[]) {
+  const [edits, setEdits] = useState<Record<string, string>>(() => {
+    if (!rendered) return {}
+    const initial: Record<string, string> = {}
+    for (const f of rendered) {
+      if (f.editable) initial[f.key] = f.value
+    }
+    return initial
+  })
+
+  const onEdit = useCallback((key: string, value: string) => {
+    setEdits(prev => ({ ...prev, [key]: value }))
+  }, [])
+
+  const getEditedFields = useCallback((): Record<string, string> | undefined => {
+    if (!rendered) return undefined
+    const changed: Record<string, string> = {}
+    for (const f of rendered) {
+      if (f.editable && edits[f.key] !== f.value) {
+        changed[f.key] = edits[f.key]
+      }
+    }
+    return Object.keys(changed).length > 0 ? changed : undefined
+  }, [rendered, edits])
+
+  return { edits, onEdit, getEditedFields }
+}
+
+// ── Batch card (grouped request approvals) ───────────────────────────────────
+
+function BatchCard({ batchId, items }: { batchId: string; items: QueueItem[] }) {
+  const qc = useQueryClient()
+  const [result, setResult] = useState<string | null>(null)
+  const [expanded, setExpanded] = useState(true)
+
+  const approveMut = useMutation({
+    mutationFn: () => api.approvals.batchApprove(batchId),
+    onSuccess: (res) => {
+      setResult(`Batch approved (${res.total} requests)`)
+      qc.invalidateQueries({ queryKey: ['overview'] })
+    },
+  })
+
+  const denyMut = useMutation({
+    mutationFn: () => api.approvals.batchDeny(batchId),
+    onSuccess: (res) => {
+      setResult(`Batch denied (${res.total} requests)`)
+      qc.invalidateQueries({ queryKey: ['overview'] })
+    },
+  })
+
+  const isPending = approveMut.isPending || denyMut.isPending
+
+  if (result) {
+    return (
+      <div className="border border-border-default rounded-md bg-surface-1 p-5">
+        <div className="p-3 bg-surface-2 rounded text-sm text-text-tertiary">{result}</div>
+      </div>
+    )
+  }
+
+  const firstApproval = items[0]?.approval
+  const service = firstApproval ? serviceName(firstApproval.service) : 'Unknown'
+
+  return (
+    <div className="bg-surface-1 border border-border-default rounded-md border-l-[3px] border-l-warning overflow-hidden">
+      {/* Header */}
+      <div className="px-5 pt-5 pb-4">
+        <div className="flex items-center justify-between">
+          <span className="font-mono text-lg font-semibold text-text-primary">{service} · batch</span>
+          <div className="flex items-center gap-2">
+            <span className="inline-flex items-center gap-1.5 text-xs font-mono font-medium px-2 py-0.5 rounded bg-warning/15 text-warning">
+              <span className="w-1.5 h-1.5 rounded-full bg-warning" />
+              {items.length} requests
+            </span>
+          </div>
+        </div>
+        {firstApproval?.reason && (
+          <p className="text-sm text-text-secondary mt-1.5">{firstApproval.reason}</p>
+        )}
+      </div>
+
+      {/* Expandable list of individual items */}
+      <div className="px-5 pb-3">
+        <button
+          onClick={() => setExpanded(o => !o)}
+          className="flex items-center gap-1.5 text-xs text-text-tertiary hover:text-text-secondary"
+        >
+          <svg className={`w-3 h-3 transition-transform ${expanded ? 'rotate-90' : ''}`} fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M9 5l7 7-7 7"/></svg>
+          <span className="font-medium">{expanded ? 'Hide' : 'Show'} individual requests</span>
+        </button>
+      </div>
+
+      {expanded && (
+        <div className="px-5 pb-3 space-y-2">
+          {items.map(item => (
+            <BatchItemCard key={item.id} item={item} />
+          ))}
+        </div>
+      )}
+
+      {/* Batch actions */}
+      <div className="px-4 py-3 border-t border-border-subtle flex items-center justify-end gap-2">
+        <button
+          onClick={() => denyMut.mutate()}
+          disabled={isPending}
+          className="rounded px-4 py-1.5 text-sm font-medium bg-danger/10 text-danger border border-danger/20 hover:bg-danger/20 disabled:opacity-50"
+        >
+          Deny All
+        </button>
+        <button
+          onClick={() => approveMut.mutate()}
+          disabled={isPending}
+          className="bg-brand text-surface-0 font-medium rounded px-5 py-1.5 text-sm hover:bg-brand-strong disabled:opacity-50"
+        >
+          {approveMut.isPending ? 'Approving...' : 'Approve All'}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function BatchItemCard({ item }: { item: QueueItem }) {
+  const qc = useQueryClient()
+  const a = item.approval!
+  const { edits, onEdit, getEditedFields } = useFieldEdits(a.rendered_fields)
+  const [done, setDone] = useState<string | null>(null)
+
+  const approveMut = useMutation({
+    mutationFn: () => api.approvals.approve(a.request_id, getEditedFields()),
+    onSuccess: () => { setDone('Approved'); qc.invalidateQueries({ queryKey: ['overview'] }) },
+  })
+  const denyMut = useMutation({
+    mutationFn: () => api.approvals.deny(a.request_id),
+    onSuccess: () => { setDone('Denied'); qc.invalidateQueries({ queryKey: ['overview'] }) },
+  })
+
+  if (done) {
+    return (
+      <div className="bg-surface-0 border border-border-subtle rounded p-3">
+        <span className="text-xs text-text-tertiary">{done}</span>
+      </div>
+    )
+  }
+
+  const isPending = approveMut.isPending || denyMut.isPending
+
+  return (
+    <div className="bg-surface-0 border border-border-subtle rounded p-3">
+      <div className="flex items-center justify-between mb-2">
+        <span className="font-mono text-sm text-text-primary">
+          {actionName(a.action)}
+        </span>
+        <div className="flex gap-1.5">
+          <button
+            onClick={() => denyMut.mutate()}
+            disabled={isPending}
+            className="text-xs px-2 py-0.5 rounded bg-danger/10 text-danger hover:bg-danger/20 disabled:opacity-50"
+          >
+            {denyMut.isPending ? '...' : 'Deny'}
+          </button>
+          <button
+            onClick={() => approveMut.mutate()}
+            disabled={isPending}
+            className="text-xs px-2 py-0.5 rounded bg-brand/10 text-brand hover:bg-brand/20 disabled:opacity-50"
+          >
+            {approveMut.isPending ? '...' : 'Approve'}
+          </button>
+        </div>
+      </div>
+      {a.reason && (
+        <p className="text-xs text-text-tertiary mb-2">{a.reason}</p>
+      )}
+      <EditableFields
+        rendered={a.rendered_fields}
+        params={a.params ?? {}}
+        edits={edits}
+        onEdit={onEdit}
+      />
+    </div>
+  )
+}
+
 // ── Approval card (standalone request approvals) ─────────────────────────────
 
 function ApprovalCard({ item }: { item: QueueItem }) {
@@ -348,9 +680,31 @@ function ApprovalCard({ item }: { item: QueueItem }) {
   const [result, setResult] = useState<string | null>(null)
   const [verifyOpen, setVerifyOpen] = useState(false)
   const a = item.approval!
+  const rendered = a.rendered_fields
+
+  // Track edits for editable rendered fields
+  const [edits, setEdits] = useState<Record<string, string>>(() => {
+    if (!rendered) return {}
+    const initial: Record<string, string> = {}
+    for (const f of rendered) {
+      if (f.editable) initial[f.key] = f.value
+    }
+    return initial
+  })
+
+  const getEditedFields = (): Record<string, string> | undefined => {
+    if (!rendered) return undefined
+    const changed: Record<string, string> = {}
+    for (const f of rendered) {
+      if (f.editable && edits[f.key] !== f.value) {
+        changed[f.key] = edits[f.key]
+      }
+    }
+    return Object.keys(changed).length > 0 ? changed : undefined
+  }
 
   const approveMut = useMutation({
-    mutationFn: () => api.approvals.approve(a.request_id),
+    mutationFn: () => api.approvals.approve(a.request_id, getEditedFields()),
     onSuccess: (res) => {
       setResult(res.status === 'executed' ? 'Approved & executed' : `Outcome: ${res.status}`)
       qc.invalidateQueries({ queryKey: ['overview'] })
@@ -369,7 +723,6 @@ function ApprovalCard({ item }: { item: QueueItem }) {
   const params = a.params ?? {}
   const paramEntries = Object.entries(params)
   const hasIssue = a.verification ? hasVerificationIssue(a.verification) : false
-  // Auto-expand when there's a problem
   const showPanel = a.verification && (hasIssue || verifyOpen)
 
   if (result) {
@@ -415,8 +768,12 @@ function ApprovalCard({ item }: { item: QueueItem }) {
         <VerificationPanel verification={a.verification!} />
       )}
 
-      {/* Parameters */}
-      {paramEntries.length > 0 && (
+      {/* Rendered fields (click-to-edit) or raw params fallback */}
+      {rendered && rendered.length > 0 ? (
+        <div className="px-5 pb-3">
+          <ClickToEditFields rendered={rendered} edits={edits} onEdit={(k, v) => setEdits(prev => ({ ...prev, [k]: v }))} />
+        </div>
+      ) : paramEntries.length > 0 ? (
         <div className="px-5 pb-3">
           <div className="bg-surface-0 border border-border-subtle rounded overflow-hidden">
             <table className="w-full text-xs">
@@ -433,7 +790,7 @@ function ApprovalCard({ item }: { item: QueueItem }) {
             </table>
           </div>
         </div>
-      )}
+      ) : null}
 
       {/* Actions */}
       <div className="px-4 py-3 border-t border-border-subtle flex items-center justify-end gap-2">


### PR DESCRIPTION
## Summary

- **Batch grouping**: Agents can submit multiple gateway requests with a shared `batch_id` and close the batch to trigger a single grouped notification. Batch approve/deny endpoints act on all requests in a batch at once. Frontend groups batched approvals into collapsible cards.
- **Rich rendering**: New `ApprovalRenderer` adapter interface translates raw params into human-readable `RenderedField` objects. Gmail adapter renders To/Subject/Body fields. YAML adapters delegate to Go implementations via `SetApprovalRenderer`.
- **Click-to-edit fields**: Editable rendered fields display as a compact read-only table; clicking a value expands it inline to an input/textarea. On approve, edited fields are sent to a new `ApprovalEditor` adapter interface that applies edits back to raw params before execution.
- New MCP `close_batch` tool, DB migrations for `batch_id` and `rendered_fields` columns (SQLite + Postgres), SKILL docs updated with batch usage patterns.

## Test plan

- [ ] Submit multiple gateway requests with the same `batch_id`, verify they group in the dashboard
- [ ] Close a batch via MCP tool, verify grouped notification fires
- [ ] Batch approve/deny, verify all requests in the batch are resolved
- [ ] Verify Gmail approvals show rendered To/Subject/Body fields
- [ ] Click an editable field value, verify it expands to an input; blur to collapse
- [ ] Edit a field and approve, verify the edited value is used for execution
- [ ] Verify non-batch approvals still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)