### PR TITLE
feat: pre-registered planned calls to skip intent verification

### DIFF
--- a/coworkplugin/plugin/commands/check-messages.md
+++ b/coworkplugin/plugin/commands/check-messages.md
@@ -9,6 +9,9 @@ description: Review recent iMessage threads and identify ones needing replies
    - **authorized_actions**:
      - `apple.imessage` / `list_threads` — `auto_execute: true` — "List recent iMessage threads to find ones needing attention"
      - `apple.imessage` / `get_thread` — `auto_execute: true` — "Read individual thread messages to check reply status"
+   - **planned_calls**:
+     - `apple.imessage` / `list_threads` — params: `{"limit": 30}` — "List recent threads"
+     - `apple.imessage` / `get_thread` — params: `{"thread_id": "$chain"}` — "Read each thread from the listing"
    - **expires_in_seconds**: 1800
 
 3. Tell the user: "I've requested access to read your iMessage threads. Please approve the task in Clawvisor."

--- a/coworkplugin/plugin/commands/daily-briefing.md
+++ b/coworkplugin/plugin/commands/daily-briefing.md
@@ -12,6 +12,12 @@ description: Morning briefing across email, calendar, and messages
      - `google.gmail` / `get_message` — `auto_execute: true` — "Read emails to summarize key items"
      - `apple.imessage` / `list_threads` — `auto_execute: true` — "List recent iMessage threads"
      - `apple.imessage` / `get_thread` — `auto_execute: true` — "Read threads to check reply status"
+   - **planned_calls** (include only for connected services):
+     - `google.calendar` / `list_events` — params: `{"time_min": "<today 00:00 ISO>", "time_max": "<today 23:59 ISO>"}` — "Fetch today's calendar events"
+     - `google.gmail` / `list_messages` — params: `{"query": "newer_than:1d"}` — "List emails since yesterday"
+     - `google.gmail` / `get_message` — params: `{"message_id": "$chain"}` — "Read emails from the listing"
+     - `apple.imessage` / `list_threads` — params: `{"limit": 20}` — "List recent threads"
+     - `apple.imessage` / `get_thread` — params: `{"thread_id": "$chain"}` — "Read threads from the listing"
    - **expires_in_seconds**: 1800
 
 3. Tell the user: "I've requested access for your daily briefing. Please approve the task in Clawvisor."

--- a/coworkplugin/plugin/commands/triage-inbox.md
+++ b/coworkplugin/plugin/commands/triage-inbox.md
@@ -9,6 +9,9 @@ description: Triage recent emails — classify by urgency and action needed
    - **authorized_actions**:
      - `google.gmail` / `list_messages` — `auto_execute: true` — "List recent inbox emails to identify ones needing triage"
      - `google.gmail` / `get_message` — `auto_execute: true` — "Read individual emails to classify urgency and extract action items"
+   - **planned_calls**:
+     - `google.gmail` / `list_messages` — params: `{"query": "newer_than:2d", "max_results": 20}` — "List recent inbox emails for triage"
+     - `google.gmail` / `get_message` — params: `{"message_id": "$chain"}` — "Read each email from the listing to classify urgency"
    - **expires_in_seconds**: 1800
 
 3. Tell the user: "I've requested access to read your recent emails. Please approve the task in Clawvisor."

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -270,7 +270,31 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			taskIDPtr := &req.TaskID
 
 			// ── Intent verification ──────────────────────────────────────
-			verdict := h.runVerification(ctx, task, match.MatchedAction, req, serviceType)
+			// Load chain facts (needed for both planned call matching and verification).
+			chainFacts := h.loadChainFacts(ctx, task, req)
+
+			// Check if the request matches a pre-registered planned call.
+			// If so, skip LLM-based intent verification entirely — the call
+			// was evaluated during task risk assessment and approved by the user.
+			matchedPlannedCall := matchPlannedCall(task.PlannedCalls, req.Service, req.Action, req.Params, chainFacts)
+
+			var verdict *intent.VerificationVerdict
+			if matchedPlannedCall != nil {
+				h.logger.Info("request matches planned call — skipping intent verification",
+					"task_id", req.TaskID,
+					"service", req.Service,
+					"action", req.Action,
+					"planned_reason", matchedPlannedCall.Reason,
+				)
+				verdict = &intent.VerificationVerdict{
+					Allow:           true,
+					ParamScope:      "ok",
+					ReasonCoherence: "ok",
+					Explanation:     "Matched pre-registered planned call: " + matchedPlannedCall.Reason,
+				}
+			} else {
+				verdict = h.runVerification(ctx, task, match.MatchedAction, req, serviceType)
+			}
 			if verdict != nil && !verdict.Allow {
 				dur := int(time.Since(start).Milliseconds())
 				e := baseEntry("verify", "restricted", taskIDPtr)
@@ -812,6 +836,22 @@ func (h *GatewayHandler) publishAuditAndQueue(userID, taskID string) {
 }
 
 // runVerification runs intent verification for a request and returns the verdict.
+// loadChainFacts fetches chain context facts for the given task and request.
+func (h *GatewayHandler) loadChainFacts(ctx context.Context, task *store.Task, req gateway.Request) []store.ChainFact {
+	chainSessionID := req.SessionID
+	if chainSessionID == "" && task.Lifetime != "standing" {
+		chainSessionID = req.TaskID
+	}
+	var chainFacts []store.ChainFact
+	if chainSessionID != "" {
+		facts, _ := h.store.ListChainFacts(ctx, req.TaskID, chainSessionID, 50)
+		for _, f := range facts {
+			chainFacts = append(chainFacts, *f)
+		}
+	}
+	return chainFacts
+}
+
 // Returns nil if the verifier is a no-op or if verification fails.
 func (h *GatewayHandler) runVerification(
 	ctx context.Context,
@@ -831,19 +871,7 @@ func (h *GatewayHandler) runVerification(
 			serviceHints = hinter.VerificationHints()
 		}
 	}
-	// Chain context: ephemeral tasks use task_id as implicit session;
-	// standing tasks require an explicit session_id to scope facts.
-	chainSessionID := req.SessionID
-	if chainSessionID == "" && task.Lifetime != "standing" {
-		chainSessionID = req.TaskID
-	}
-	var chainFacts []store.ChainFact
-	if chainSessionID != "" {
-		facts, _ := h.store.ListChainFacts(ctx, req.TaskID, chainSessionID, 50)
-		for _, f := range facts {
-			chainFacts = append(chainFacts, *f)
-		}
-	}
+	chainFacts := h.loadChainFacts(ctx, task, req)
 	chainContextOptOut := task.Lifetime == "standing" && req.SessionID == ""
 	verdict, _ := h.verifier.Verify(ctx, intent.VerifyRequest{
 		TaskPurpose:         task.Purpose,
@@ -860,6 +888,84 @@ func (h *GatewayHandler) runVerification(
 		ChainContextEnabled: h.cfg.LLM.ChainContext.Enabled,
 	})
 	return verdict
+}
+
+// ── Planned call matching ─────────────────────────────────────────────────────
+
+// matchPlannedCall checks whether a gateway request matches one of the task's
+// pre-registered planned calls. Returns the matched PlannedCall, or nil.
+//
+// Matching rules:
+//   - Service (base type, ignoring alias) and action must match exactly.
+//   - Planned call must have non-empty params (calls without params never match
+//     because we can't verify what entity they target).
+//   - Each planned param is checked against actual params:
+//   - "$chain" values match any actual value found in chainFacts.
+//   - All other values must match exactly (JSON-normalized).
+func matchPlannedCall(planned []store.PlannedCall, service, action string, params map[string]any, chainFacts []store.ChainFact) *store.PlannedCall {
+	reqServiceType, _ := parseServiceAlias(service)
+	for i := range planned {
+		pc := &planned[i]
+		if len(pc.Params) == 0 {
+			continue // params required for matching
+		}
+		pcServiceType, _ := parseServiceAlias(pc.Service)
+		if pcServiceType != reqServiceType || pc.Action != action {
+			continue
+		}
+		if plannedParamsMatch(pc.Params, params, chainFacts) {
+			return pc
+		}
+	}
+	return nil
+}
+
+// plannedParamsMatch returns true if every key/value in planned appears in actual.
+// A planned value of "$chain" matches if the actual value appears in any chain fact.
+// All other values are compared via JSON round-trip for type-safe deep equality.
+func plannedParamsMatch(planned, actual map[string]any, chainFacts []store.ChainFact) bool {
+	for k, pv := range planned {
+		av, ok := actual[k]
+		if !ok {
+			return false
+		}
+		// Check for $chain template marker.
+		if s, ok := pv.(string); ok && s == "$chain" {
+			if !valueInChainFacts(av, chainFacts) {
+				return false
+			}
+			continue
+		}
+		// Exact match via JSON normalization.
+		pj, _ := json.Marshal(pv)
+		aj, _ := json.Marshal(av)
+		if string(pj) != string(aj) {
+			return false
+		}
+	}
+	return true
+}
+
+// valueInChainFacts returns true if the given value (as a string) appears
+// in any chain fact's FactValue.
+func valueInChainFacts(v any, facts []store.ChainFact) bool {
+	var s string
+	switch val := v.(type) {
+	case string:
+		s = val
+	default:
+		b, _ := json.Marshal(val)
+		s = strings.Trim(string(b), `"`)
+	}
+	if s == "" {
+		return false
+	}
+	for _, f := range facts {
+		if f.FactValue == s {
+			return true
+		}
+	}
+	return false
 }
 
 // ── Shared execution logic ────────────────────────────────────────────────────

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -293,7 +293,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 					Explanation:     "Matched pre-registered planned call: " + matchedPlannedCall.Reason,
 				}
 			} else {
-				verdict = h.runVerification(ctx, task, match.MatchedAction, req, serviceType)
+				verdict = h.runVerification(ctx, task, match.MatchedAction, req, serviceType, chainFacts)
 			}
 			if verdict != nil && !verdict.Allow {
 				dur := int(time.Since(start).Milliseconds())
@@ -466,7 +466,8 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 
 		// In scope + (!auto_execute || hardcoded) → falls through to per-request approval below.
 		// Run advisory verification so the human sees warnings in the approval UI.
-		advisoryVerdict = h.runVerification(ctx, task, match.MatchedAction, req, serviceType)
+		advisoryFacts := h.loadChainFacts(ctx, task, req)
+		advisoryVerdict = h.runVerification(ctx, task, match.MatchedAction, req, serviceType, advisoryFacts)
 	}
 
 	// ── Step 5: Per-request approval ─────────────────────────────────────────
@@ -859,6 +860,7 @@ func (h *GatewayHandler) runVerification(
 	matchedAction *store.TaskAction,
 	req gateway.Request,
 	serviceType string,
+	chainFacts []store.ChainFact,
 ) *intent.VerificationVerdict {
 	var expectedUse, expansionRationale string
 	if matchedAction != nil {
@@ -871,7 +873,6 @@ func (h *GatewayHandler) runVerification(
 			serviceHints = hinter.VerificationHints()
 		}
 	}
-	chainFacts := h.loadChainFacts(ctx, task, req)
 	chainContextOptOut := task.Lifetime == "standing" && req.SessionID == ""
 	verdict, _ := h.verifier.Verify(ctx, intent.VerifyRequest{
 		TaskPurpose:         task.Purpose,

--- a/internal/api/handlers/tasks.go
+++ b/internal/api/handlers/tasks.go
@@ -72,11 +72,12 @@ func NewTasksHandler(
 // ── Create ────────────────────────────────────────────────────────────────────
 
 type createTaskRequest struct {
-	Purpose           string             `json:"purpose"`
-	AuthorizedActions []store.TaskAction `json:"authorized_actions"`
-	ExpiresInSeconds  int                `json:"expires_in_seconds"`
-	CallbackURL       string             `json:"callback_url"`
-	Lifetime          string             `json:"lifetime"` // "session" (default) or "standing"
+	Purpose           string              `json:"purpose"`
+	AuthorizedActions []store.TaskAction  `json:"authorized_actions"`
+	PlannedCalls      []store.PlannedCall `json:"planned_calls,omitempty"`
+	ExpiresInSeconds  int                 `json:"expires_in_seconds"`
+	CallbackURL       string              `json:"callback_url"`
+	Lifetime          string              `json:"lifetime"` // "session" (default) or "standing"
 }
 
 // Create declares a new task scope.
@@ -136,6 +137,33 @@ func (h *TasksHandler) Create(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Validate planned calls: each must reference a service:action covered by authorized_actions.
+	for _, pc := range req.PlannedCalls {
+		if pc.Service == "" || pc.Action == "" {
+			writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "planned_calls entries must have service and action")
+			return
+		}
+		if pc.Reason == "" {
+			writeError(w, http.StatusBadRequest, "INVALID_REQUEST",
+				fmt.Sprintf("planned_calls entry %s:%s must have a reason", pc.Service, pc.Action))
+			return
+		}
+		covered := false
+		pcServiceType, _ := parseServiceAlias(pc.Service)
+		for _, a := range req.AuthorizedActions {
+			aServiceType, _ := parseServiceAlias(a.Service)
+			if aServiceType == pcServiceType && (a.Action == pc.Action || a.Action == "*") {
+				covered = true
+				break
+			}
+		}
+		if !covered {
+			writeError(w, http.StatusBadRequest, "INVALID_REQUEST",
+				fmt.Sprintf("planned_calls entry %s:%s is not covered by authorized_actions", pc.Service, pc.Action))
+			return
+		}
+	}
+
 	lifetime := req.Lifetime
 	if lifetime == "" {
 		lifetime = "session"
@@ -173,6 +201,7 @@ func (h *TasksHandler) Create(w http.ResponseWriter, r *http.Request) {
 		Status:            "pending_approval",
 		Lifetime:          lifetime,
 		AuthorizedActions: req.AuthorizedActions,
+		PlannedCalls:      req.PlannedCalls,
 		ExpiresInSeconds:  expiresIn,
 	}
 	if req.CallbackURL != "" {
@@ -184,6 +213,7 @@ func (h *TasksHandler) Create(w http.ResponseWriter, r *http.Request) {
 		assessment, err := h.assessor.Assess(ctx, taskrisk.AssessRequest{
 			Purpose:           req.Purpose,
 			AuthorizedActions: req.AuthorizedActions,
+			PlannedCalls:      req.PlannedCalls,
 			AgentName:         agent.Name,
 		})
 		if err != nil {
@@ -211,15 +241,16 @@ func (h *TasksHandler) Create(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if msgID, err := h.notifier.SendTaskApprovalRequest(ctx, notify.TaskApprovalRequest{
-			TaskID:     task.ID,
-			UserID:     agent.UserID,
-			AgentName:  agent.Name,
-			Purpose:    req.Purpose,
-			Actions:    req.AuthorizedActions,
-			RiskLevel:  task.RiskLevel,
-			ApproveURL: approveURL,
-			DenyURL:    denyURL,
-			ExpiresIn:  expiresInStr,
+			TaskID:       task.ID,
+			UserID:       agent.UserID,
+			AgentName:    agent.Name,
+			Purpose:      req.Purpose,
+			Actions:      req.AuthorizedActions,
+			PlannedCalls: req.PlannedCalls,
+			RiskLevel:    task.RiskLevel,
+			ApproveURL:   approveURL,
+			DenyURL:      denyURL,
+			ExpiresIn:    expiresInStr,
 		}); err != nil {
 			h.logger.Warn("failed to send task approval notification", "task_id", task.ID, "err", err)
 		} else if msgID != "" {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -50,6 +50,20 @@ func toolDefs() []Tool {
 						},
 						"description": "Actions this task is authorized to perform"
 					},
+					"planned_calls": {
+						"type": "array",
+						"items": {
+							"type": "object",
+							"properties": {
+								"service": {"type": "string", "description": "Service ID"},
+								"action": {"type": "string", "description": "Action name"},
+								"params": {"type": "object", "description": "Expected params. Use exact values for known params. Use \"$chain\" as a value to match any value that appeared in a prior call's results (e.g. {\"thread_id\": \"$chain\"})."},
+								"reason": {"type": "string", "description": "Why this call will be made"}
+							},
+							"required": ["service", "action", "reason"]
+						},
+						"description": "Optional pre-registered calls. Calls matching a planned call skip per-request intent verification. Each must be covered by authorized_actions and must include params."
+					},
 					"expires_in_seconds": {"type": "integer", "description": "Session task expiry in seconds (default 1800)"},
 					"lifetime": {"type": "string", "enum": ["session", "standing"], "description": "Task lifetime: session (expires) or standing (no expiry)"},
 					"wait": {"type": "boolean", "description": "Block until the task is approved or denied (default true)"},

--- a/internal/notify/telegram/telegram.go
+++ b/internal/notify/telegram/telegram.go
@@ -324,6 +324,15 @@ func formatTaskApprovalMessage(req notify.TaskApprovalRequest) string {
 			mode))
 	}
 
+	if len(req.PlannedCalls) > 0 {
+		sb.WriteString("\n<b>Planned calls:</b>\n")
+		for _, pc := range req.PlannedCalls {
+			sb.WriteString(fmt.Sprintf("  • %s — %s\n",
+				html.EscapeString(display.FormatServiceAction(pc.Service, pc.Action)),
+				html.EscapeString(pc.Reason)))
+		}
+	}
+
 	sb.WriteString(fmt.Sprintf("\n<i>Expires in %s</i>", html.EscapeString(req.ExpiresIn)))
 	return sb.String()
 }

--- a/internal/store/postgres/migrations/020_planned_calls.sql
+++ b/internal/store/postgres/migrations/020_planned_calls.sql
@@ -1,0 +1,1 @@
+ALTER TABLE tasks ADD COLUMN planned_calls JSONB NOT NULL DEFAULT '[]';

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -617,6 +617,10 @@ func (s *Store) CreateTask(ctx context.Context, task *store.Task) error {
 	if err != nil {
 		return err
 	}
+	plannedCallsJSON, err := json.Marshal(task.PlannedCalls)
+	if err != nil {
+		return err
+	}
 	var pendingActionJSON []byte
 	if task.PendingAction != nil {
 		pendingActionJSON, _ = json.Marshal(task.PendingAction)
@@ -626,12 +630,12 @@ func (s *Store) CreateTask(ctx context.Context, task *store.Task) error {
 		riskDetails = []byte(task.RiskDetails)
 	}
 	_, err = s.pool.Exec(ctx, `
-		INSERT INTO tasks (id, user_id, agent_id, purpose, status, authorized_actions, callback_url,
+		INSERT INTO tasks (id, user_id, agent_id, purpose, status, authorized_actions, planned_calls, callback_url,
 			expires_in_seconds, approved_at, expires_at, pending_action, pending_reason, lifetime,
 			risk_level, risk_details)
-		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16)
 	`, task.ID, task.UserID, task.AgentID, task.Purpose, task.Status,
-		actionsJSON, task.CallbackURL, task.ExpiresInSeconds,
+		actionsJSON, plannedCallsJSON, task.CallbackURL, task.ExpiresInSeconds,
 		task.ApprovedAt, task.ExpiresAt,
 		nilIfEmpty(pendingActionJSON), task.PendingReason, task.Lifetime,
 		task.RiskLevel, string(riskDetails))
@@ -640,15 +644,15 @@ func (s *Store) CreateTask(ctx context.Context, task *store.Task) error {
 
 func (s *Store) GetTask(ctx context.Context, id string) (*store.Task, error) {
 	t := &store.Task{}
-	var actionsJSON, pendingActionJSON []byte
+	var actionsJSON, plannedCallsJSON, pendingActionJSON []byte
 	var riskDetailsStr string
 	err := s.pool.QueryRow(ctx, `
-		SELECT id, user_id, agent_id, purpose, status, authorized_actions, callback_url,
+		SELECT id, user_id, agent_id, purpose, status, authorized_actions, planned_calls, callback_url,
 		       created_at, approved_at, expires_at, expires_in_seconds, request_count,
 		       pending_action, pending_reason, lifetime, risk_level, risk_details
 		FROM tasks WHERE id = $1
 	`, id).Scan(&t.ID, &t.UserID, &t.AgentID, &t.Purpose, &t.Status, &actionsJSON,
-		&t.CallbackURL, &t.CreatedAt, &t.ApprovedAt, &t.ExpiresAt, &t.ExpiresInSeconds,
+		&plannedCallsJSON, &t.CallbackURL, &t.CreatedAt, &t.ApprovedAt, &t.ExpiresAt, &t.ExpiresInSeconds,
 		&t.RequestCount, &pendingActionJSON, &t.PendingReason, &t.Lifetime,
 		&t.RiskLevel, &riskDetailsStr)
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -659,6 +663,9 @@ func (s *Store) GetTask(ctx context.Context, id string) (*store.Task, error) {
 	}
 	if err := json.Unmarshal(actionsJSON, &t.AuthorizedActions); err != nil {
 		return nil, fmt.Errorf("unmarshal authorized_actions: %w", err)
+	}
+	if plannedCallsJSON != nil {
+		_ = json.Unmarshal(plannedCallsJSON, &t.PlannedCalls)
 	}
 	if pendingActionJSON != nil {
 		var pa store.TaskAction
@@ -700,7 +707,7 @@ func (s *Store) ListTasks(ctx context.Context, userID string, filter store.TaskF
 		return nil, 0, err
 	}
 
-	query := `SELECT id, user_id, agent_id, purpose, status, authorized_actions, callback_url,
+	query := `SELECT id, user_id, agent_id, purpose, status, authorized_actions, planned_calls, callback_url,
 		       created_at, approved_at, expires_at, expires_in_seconds, request_count,
 		       pending_action, pending_reason, lifetime, risk_level, risk_details
 		FROM tasks ` + where + ` ORDER BY created_at DESC`
@@ -822,15 +829,18 @@ func scanTasks(rows pgx.Rows) ([]*store.Task, error) {
 	var tasks []*store.Task
 	for rows.Next() {
 		t := &store.Task{}
-		var actionsJSON, pendingActionJSON []byte
+		var actionsJSON, plannedCallsJSON, pendingActionJSON []byte
 		var riskDetailsStr string
 		if err := rows.Scan(&t.ID, &t.UserID, &t.AgentID, &t.Purpose, &t.Status, &actionsJSON,
-			&t.CallbackURL, &t.CreatedAt, &t.ApprovedAt, &t.ExpiresAt, &t.ExpiresInSeconds,
+			&plannedCallsJSON, &t.CallbackURL, &t.CreatedAt, &t.ApprovedAt, &t.ExpiresAt, &t.ExpiresInSeconds,
 			&t.RequestCount, &pendingActionJSON, &t.PendingReason, &t.Lifetime,
 			&t.RiskLevel, &riskDetailsStr); err != nil {
 			return nil, err
 		}
 		_ = json.Unmarshal(actionsJSON, &t.AuthorizedActions)
+		if plannedCallsJSON != nil {
+			_ = json.Unmarshal(plannedCallsJSON, &t.PlannedCalls)
+		}
 		if pendingActionJSON != nil {
 			var pa store.TaskAction
 			if err := json.Unmarshal(pendingActionJSON, &pa); err == nil {

--- a/internal/store/sqlite/migrations/020_planned_calls.sql
+++ b/internal/store/sqlite/migrations/020_planned_calls.sql
@@ -1,0 +1,1 @@
+ALTER TABLE tasks ADD COLUMN planned_calls TEXT NOT NULL DEFAULT '[]';

--- a/internal/store/sqlite/store.go
+++ b/internal/store/sqlite/store.go
@@ -710,6 +710,10 @@ func (s *Store) CreateTask(ctx context.Context, task *store.Task) error {
 	if err != nil {
 		return err
 	}
+	plannedCallsJSON, err := json.Marshal(task.PlannedCalls)
+	if err != nil {
+		return err
+	}
 	var pendingActionJSON *string
 	if task.PendingAction != nil {
 		b, err := json.Marshal(task.PendingAction)
@@ -730,12 +734,12 @@ func (s *Store) CreateTask(ctx context.Context, task *store.Task) error {
 	}
 	riskDetails := string(task.RiskDetails)
 	_, err = s.db.ExecContext(ctx, `
-		INSERT INTO tasks (id, user_id, agent_id, purpose, status, authorized_actions, callback_url,
+		INSERT INTO tasks (id, user_id, agent_id, purpose, status, authorized_actions, planned_calls, callback_url,
 			expires_in_seconds, approved_at, expires_at, pending_action, pending_reason, lifetime,
 			risk_level, risk_details)
-		VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+		VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
 	`, task.ID, task.UserID, task.AgentID, task.Purpose, task.Status,
-		string(actionsJSON), task.CallbackURL, task.ExpiresInSeconds,
+		string(actionsJSON), string(plannedCallsJSON), task.CallbackURL, task.ExpiresInSeconds,
 		approvedAt, expiresAt, pendingActionJSON, task.PendingReason, task.Lifetime,
 		task.RiskLevel, riskDetails)
 	return err
@@ -743,16 +747,16 @@ func (s *Store) CreateTask(ctx context.Context, task *store.Task) error {
 
 func (s *Store) GetTask(ctx context.Context, id string) (*store.Task, error) {
 	t := &store.Task{}
-	var actionsStr, createdAt string
+	var actionsStr, plannedCallsStr, createdAt string
 	var approvedAt, expiresAt, pendingActionStr *string
 	var riskDetailsStr string
 	err := s.db.QueryRowContext(ctx, `
-		SELECT id, user_id, agent_id, purpose, status, authorized_actions, callback_url,
+		SELECT id, user_id, agent_id, purpose, status, authorized_actions, planned_calls, callback_url,
 		       created_at, approved_at, expires_at, expires_in_seconds, request_count,
 		       pending_action, pending_reason, lifetime, risk_level, risk_details
 		FROM tasks WHERE id = ?
 	`, id).Scan(&t.ID, &t.UserID, &t.AgentID, &t.Purpose, &t.Status, &actionsStr,
-		&t.CallbackURL, &createdAt, &approvedAt, &expiresAt, &t.ExpiresInSeconds,
+		&plannedCallsStr, &t.CallbackURL, &createdAt, &approvedAt, &expiresAt, &t.ExpiresInSeconds,
 		&t.RequestCount, &pendingActionStr, &t.PendingReason, &t.Lifetime,
 		&t.RiskLevel, &riskDetailsStr)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -772,6 +776,9 @@ func (s *Store) GetTask(ctx context.Context, id string) (*store.Task, error) {
 	}
 	if err := json.Unmarshal([]byte(actionsStr), &t.AuthorizedActions); err != nil {
 		return nil, fmt.Errorf("unmarshal authorized_actions: %w", err)
+	}
+	if plannedCallsStr != "" {
+		_ = json.Unmarshal([]byte(plannedCallsStr), &t.PlannedCalls)
 	}
 	if pendingActionStr != nil {
 		var pa store.TaskAction
@@ -809,7 +816,7 @@ func (s *Store) ListTasks(ctx context.Context, userID string, filter store.TaskF
 		return nil, 0, err
 	}
 
-	query := `SELECT id, user_id, agent_id, purpose, status, authorized_actions, callback_url,
+	query := `SELECT id, user_id, agent_id, purpose, status, authorized_actions, planned_calls, callback_url,
 		       created_at, approved_at, expires_at, expires_in_seconds, request_count,
 		       pending_action, pending_reason, lifetime, risk_level, risk_details
 		FROM tasks ` + where + ` ORDER BY created_at DESC`
@@ -828,11 +835,11 @@ func (s *Store) ListTasks(ctx context.Context, userID string, filter store.TaskF
 	var tasks []*store.Task
 	for rows.Next() {
 		t := &store.Task{}
-		var actionsStr, createdAt string
+		var actionsStr, plannedCallsStr, createdAt string
 		var approvedAt, expiresAt, pendingActionStr *string
 		var riskDetailsStr string
 		if err := rows.Scan(&t.ID, &t.UserID, &t.AgentID, &t.Purpose, &t.Status, &actionsStr,
-			&t.CallbackURL, &createdAt, &approvedAt, &expiresAt, &t.ExpiresInSeconds,
+			&plannedCallsStr, &t.CallbackURL, &createdAt, &approvedAt, &expiresAt, &t.ExpiresInSeconds,
 			&t.RequestCount, &pendingActionStr, &t.PendingReason, &t.Lifetime,
 			&t.RiskLevel, &riskDetailsStr); err != nil {
 			return nil, 0, err
@@ -847,6 +854,9 @@ func (s *Store) ListTasks(ctx context.Context, userID string, filter store.TaskF
 			t.ExpiresAt = &ts
 		}
 		_ = json.Unmarshal([]byte(actionsStr), &t.AuthorizedActions)
+		if plannedCallsStr != "" {
+			_ = json.Unmarshal([]byte(plannedCallsStr), &t.PlannedCalls)
+		}
 		if pendingActionStr != nil {
 			var pa store.TaskAction
 			if err := json.Unmarshal([]byte(*pendingActionStr), &pa); err == nil {

--- a/internal/taskrisk/assessor.go
+++ b/internal/taskrisk/assessor.go
@@ -27,6 +27,7 @@ type Assessor interface {
 type AssessRequest struct {
 	Purpose           string
 	AuthorizedActions []store.TaskAction
+	PlannedCalls      []store.PlannedCall
 	AgentName         string
 }
 

--- a/internal/taskrisk/prompts.go
+++ b/internal/taskrisk/prompts.go
@@ -1,6 +1,7 @@
 package taskrisk
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -18,6 +19,8 @@ Evaluate three dimensions:
 2. **Purpose-scope alignment.** Does the stated purpose justify the requested scope? A task claiming "check my calendar" but requesting gmail:send_email is suspicious. Unrelated services in the same task are a signal.
 
 3. **Internal coherence.** Are the expected_use reasons for each action consistent with the purpose and with each other? A task with purpose "summarize my inbox" but expected_use "send automated replies" on gmail:send_email has an internal conflict. Actions that don't logically relate to each other in the same task are a signal.
+
+4. **Planned calls.** The agent may declare specific API calls it intends to make. These calls will skip per-request intent verification if they match at runtime, so evaluate them carefully. Parameters may be exact values or "$chain" (meaning the actual value will come from a prior call's results via context chaining). Evaluate whether each call is consistent with the stated purpose, whether exact parameters are reasonable, and whether "$chain" references make sense given the call sequence. Planned calls that contradict the purpose or authorized scope are a conflict.
 
 Use this action context to understand what each action does:
 
@@ -107,6 +110,20 @@ func buildAssessUserMessage(req AssessRequest) string {
 			fmt.Fprintf(&b, " — expected_use: %q", a.ExpectedUse)
 		}
 		b.WriteString("\n")
+	}
+
+	if len(req.PlannedCalls) > 0 {
+		fmt.Fprintf(&b, "\nPlanned calls (%d) — these skip per-request intent verification when matched:\n", len(req.PlannedCalls))
+		for i, pc := range req.PlannedCalls {
+			fmt.Fprintf(&b, "  %d. %s:%s — reason: %q", i+1, pc.Service, pc.Action, pc.Reason)
+			if len(pc.Params) > 0 {
+				paramsJSON, _ := json.Marshal(pc.Params)
+				fmt.Fprintf(&b, " — params: %s (\"$chain\" = value from a prior call's results)", paramsJSON)
+			} else {
+				b.WriteString(" — params: none (will NOT skip verification)")
+			}
+			b.WriteString("\n")
+		}
 	}
 
 	return b.String()

--- a/pkg/notify/notify.go
+++ b/pkg/notify/notify.go
@@ -60,15 +60,16 @@ type CallbackPayload struct {
 
 // TaskApprovalRequest carries the data needed to ask the user to approve a task scope.
 type TaskApprovalRequest struct {
-	TaskID     string
-	UserID     string
-	AgentName  string
-	Purpose    string
-	Actions    []store.TaskAction
-	RiskLevel  string // "low", "medium", "high", "critical"
-	ApproveURL string
-	DenyURL    string
-	ExpiresIn  string
+	TaskID       string
+	UserID       string
+	AgentName    string
+	Purpose      string
+	Actions      []store.TaskAction
+	PlannedCalls []store.PlannedCall
+	RiskLevel    string // "low", "medium", "high", "critical"
+	ApproveURL   string
+	DenyURL      string
+	ExpiresIn    string
 }
 
 // ScopeExpansionRequest is sent when an agent needs to expand a task's scope.

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -234,6 +234,27 @@ type TaskAction struct {
 	ExpansionRationale string          `json:"expansion_rationale,omitempty"` // set from PendingReason when scope expansion is approved
 }
 
+// PlannedCall is a concrete or templated API call that an agent declares at task
+// creation time. Planned calls are evaluated during task risk assessment and shown
+// to the user at approval time. At request time, calls that match a planned call
+// skip intent verification.
+//
+// Matching rules:
+//   - Service and Action must match exactly.
+//   - Params must be non-empty (calls without params cannot skip verification
+//     because we don't know what entity they target).
+//   - Each param value is matched against the actual request:
+//   - Literal value: must match exactly (JSON-normalized).
+//   - "$chain": the actual value must appear in the task's chain context facts.
+//     This lets agents template calls like {"thread_id": "$chain"} to mean
+//     "any thread_id that was returned by a prior call in this task".
+type PlannedCall struct {
+	Service string         `json:"service"`
+	Action  string         `json:"action"`
+	Params  map[string]any `json:"params,omitempty"` // required for matching; "$chain" values match chain context
+	Reason  string         `json:"reason"`           // why this call will be made
+}
+
 // Task represents a task-scoped authorization.
 type Task struct {
 	ID                string       `json:"id"`
@@ -242,8 +263,9 @@ type Task struct {
 	Purpose           string       `json:"purpose"`
 	Status            string       `json:"status"` // pending_approval | active | completed | expired | denied | cancelled | pending_scope_expansion | revoked
 	Lifetime          string       `json:"lifetime"` // session | standing
-	AuthorizedActions []TaskAction `json:"authorized_actions"`
-	CallbackURL       *string      `json:"callback_url,omitempty"`
+	AuthorizedActions []TaskAction  `json:"authorized_actions"`
+	PlannedCalls      []PlannedCall `json:"planned_calls,omitempty"`
+	CallbackURL       *string       `json:"callback_url,omitempty"`
 	CreatedAt         time.Time    `json:"created_at"`
 	ApprovedAt        *time.Time   `json:"approved_at,omitempty"`
 	ExpiresAt         *time.Time   `json:"expires_at,omitempty"`

--- a/skills/clawvisor/SKILL.md.tmpl
+++ b/skills/clawvisor/SKILL.md.tmpl
@@ -128,6 +128,10 @@ curl -s -X POST "$CLAWVISOR_URL/api/tasks?wait=true" \
       {"service": "apple.imessage", "action": "list_threads", "auto_execute": true, "expected_use": "List recent iMessage threads to find ones needing replies"},
       {"service": "apple.imessage", "action": "get_thread", "auto_execute": true, "expected_use": "Read individual thread messages to classify reply status"}
     ],
+    "planned_calls": [
+      {"service": "apple.imessage", "action": "list_threads", "params": {"limit": 30}, "reason": "List the 30 most recent threads"},
+      {"service": "apple.imessage", "action": "get_thread", "params": {"thread_id": "$chain"}, "reason": "Read each thread from the listing"}
+    ],
     "expires_in_seconds": 1800
   }'
 ```
@@ -138,6 +142,7 @@ actions you need using `create_task`:
 - **`expected_use`** — per-action description of how you'll use it. Shown during approval and checked by intent verification against your actual request params. Be specific: "Fetch today's calendar events" is better than "Use the calendar API."
 - **`auto_execute`** — `true` runs in-scope requests immediately; `false` still requires per-request approval (use for destructive actions like `send_message`).
 - **`expires_in_seconds`** — task TTL. Omit and set `"lifetime": "standing"` for a task that persists until the user revokes it (see below).
+- **`planned_calls`** *(optional)* — pre-register specific API calls you know you'll make. Planned calls are shown to the user during approval, evaluated as part of risk assessment, and **skip intent verification at runtime** when they match. This reduces latency for predictable workflows. Each entry must be covered by `authorized_actions` and must include `params`. Use exact values for known params, or `"$chain"` for values that will come from a prior call's results (e.g. `{"thread_id": "$chain"}`). Calls without params cannot skip verification.
 
 All tasks start as `pending_approval`
 {{- if .UseCurl }} — the user is notified to approve the
@@ -389,6 +394,7 @@ without re-executing.
 | Condition | Gateway `status` |
 |---|---|
 | Restriction matches | `blocked` |
+| Task in scope + `auto_execute` + matches planned call | `executed` (skips verification) |
 | Task in scope + `auto_execute` + verification passes | `executed` |
 | Task in scope + `auto_execute` + verification fails | `restricted` |
 | Task in scope + `auto_execute: false` | `pending` (per-request approval) |

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -321,6 +321,13 @@ export interface TaskAction {
   expected_use?: string
 }
 
+export interface PlannedCall {
+  service: string
+  action: string
+  params?: Record<string, unknown>
+  reason: string
+}
+
 export interface Task {
   id: string
   user_id: string
@@ -329,6 +336,7 @@ export interface Task {
   lifetime: 'session' | 'standing'
   status: 'pending_approval' | 'pending_scope_expansion' | 'active' | 'completed' | 'expired' | 'denied' | 'revoked'
   authorized_actions: TaskAction[]
+  planned_calls?: PlannedCall[]
   callback_url?: string
   created_at: string
   approved_at?: string

--- a/web/src/components/TaskCard.tsx
+++ b/web/src/components/TaskCard.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { api, type Task, type AuditEntry, type RiskAssessment } from '../api/client'
+import { api, type Task, type PlannedCall, type AuditEntry, type RiskAssessment } from '../api/client'
 import { format } from 'date-fns'
 import { serviceName, actionName } from '../lib/services'
 import CountdownTimer from './CountdownTimer'
@@ -214,9 +214,12 @@ export default function TaskCard({
           )}
         </>
       ) : isActionable && !result ? (
-        /* New task: show grouped scope tables */
+        /* New task: show grouped scope tables + planned calls */
         <div className="px-4 space-y-2 pb-3">
           <ScopeGroupTables autoActions={autoActions} manualActions={manualActions} />
+          {task.planned_calls && task.planned_calls.length > 0 && (
+            <PlannedCallsTable calls={task.planned_calls} />
+          )}
         </div>
       ) : (
         /* Active / completed / other: collapsible scopes */
@@ -371,6 +374,38 @@ function ScopeGroupTables({ autoActions, manualActions }: {
         </div>
       )}
     </>
+  )
+}
+
+// ── Planned calls table ──────────────────────────────────────────────────────
+
+function PlannedCallsTable({ calls }: { calls: PlannedCall[] }) {
+  return (
+    <div className="bg-surface-0 border border-border-subtle rounded overflow-hidden mt-2">
+      <div className="px-3 py-1.5 border-b border-border-subtle flex items-center gap-1.5" style={{ background: 'var(--color-brand-tint, rgba(59,130,246,0.05))' }}>
+        <span className="w-1.5 h-1.5 rounded-full bg-brand" />
+        <span className="text-[10px] font-medium text-brand uppercase tracking-wider">Planned calls</span>
+      </div>
+      <table className="w-full text-sm">
+        <tbody>
+          {calls.map((pc, i) => (
+            <tr key={`${pc.service}|${pc.action}|${i}`} className={i < calls.length - 1 ? 'border-b border-border-subtle' : ''}>
+              <td className="px-3 py-2 font-mono text-text-primary w-40">{serviceName(pc.service)} · {actionName(pc.action)}</td>
+              <td className="px-3 py-2 text-sm text-text-secondary">
+                {pc.reason}
+                {pc.params && Object.keys(pc.params).length > 0 && (
+                  <span className="ml-2 text-xs font-mono text-text-tertiary">
+                    ({Object.entries(pc.params).map(([k, v]) =>
+                      v === '$chain' ? `${k}=\u27e8from prior call\u27e9` : `${k}=${JSON.stringify(v)}`
+                    ).join(', ')})
+                  </span>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   )
 }
 


### PR DESCRIPTION
## Summary

- Agents can declare `planned_calls` at task creation — specific API calls they know they'll make, with exact or `$chain`-templated params
- Planned calls are evaluated during risk assessment and shown to the user at approval time
- At runtime, requests matching a planned call skip intent verification, reducing latency for predictable read-heavy workflows
- `$chain` template values match any param value that appeared in a prior call's chain context, so follow-up calls (e.g. `get_message` with a `message_id` from `list_messages`) can also skip verification safely
- Updated SKILL.md, MCP tool schema, cowork plugin commands, Telegram notifications, and the web dashboard to support and surface planned calls

## Test plan

- [x] All unit tests pass (`internal/api/handlers`, `internal/taskrisk`, `internal/intent`)
- [x] All e2e smoke tests pass
- [ ] Manual test: create task with planned_calls, verify they appear in approval notification and dashboard
- [ ] Manual test: make a request matching a planned call, verify intent verification is skipped
- [ ] Manual test: make a request with `$chain` param, verify it matches after chain context is populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)