### PR TITLE
fix: enable chain context extraction for planned calls

### DIFF
--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -290,6 +290,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 					Allow:           true,
 					ParamScope:      "ok",
 					ReasonCoherence: "ok",
+					ExtractContext:  true,
 					Explanation:     "Matched pre-registered planned call: " + matchedPlannedCall.Reason,
 				}
 			} else {


### PR DESCRIPTION
## Summary

- Planned call matches synthesized a verdict with `ExtractContext: false` (zero value), causing chain fact extraction to be skipped after execution
- This meant subsequent `$chain` planned calls couldn't find facts from prior results and would fall through to full LLM verification, defeating the purpose of the fast path
- One-line fix: set `ExtractContext: true` on the planned call verdict

## Test plan

- [x] Unit tests pass
- [ ] Manual test: create task with two planned calls where the second uses `$chain`, verify both skip verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)