### PR TITLE
fix: planned call UI visibility and Telegram risk level

### DIFF
--- a/internal/notify/telegram/telegram.go
+++ b/internal/notify/telegram/telegram.go
@@ -311,6 +311,10 @@ func formatTaskApprovalMessage(req notify.TaskApprovalRequest) string {
 	sb.WriteString("📋 <b>Clawvisor — Task Approval Request</b>\n\n")
 	sb.WriteString(fmt.Sprintf("<b>Agent:</b> %s\n", html.EscapeString(req.AgentName)))
 	sb.WriteString(fmt.Sprintf("<b>Purpose:</b> %s\n", html.EscapeString(req.Purpose)))
+	if req.RiskLevel != "" && req.RiskLevel != "unknown" {
+		emoji := riskEmoji(req.RiskLevel)
+		sb.WriteString(fmt.Sprintf("<b>Risk:</b> %s %s\n", emoji, html.EscapeString(req.RiskLevel)))
+	}
 	sb.WriteString(fmt.Sprintf("<b>Time:</b> %s\n", time.Now().UTC().Format("Mon Jan 2 2006, 3:04 PM MST")))
 
 	sb.WriteString("\n<b>Requested actions:</b>\n")
@@ -364,6 +368,22 @@ func hasVerificationWarning(req notify.ApprovalRequest) bool {
 		return false // verification not run
 	}
 	return req.VerifyParamScope != "ok" || req.VerifyReasonCoherence != "ok"
+}
+
+// riskEmoji returns an emoji for the given risk level.
+func riskEmoji(level string) string {
+	switch level {
+	case "low":
+		return "🟢"
+	case "medium":
+		return "🟡"
+	case "high":
+		return "🟠"
+	case "critical":
+		return "🔴"
+	default:
+		return ""
+	}
 }
 
 // paramValue converts a param value to a display string, truncated at 100 chars.

--- a/web/src/components/TaskCard.tsx
+++ b/web/src/components/TaskCard.tsx
@@ -237,8 +237,11 @@ export default function TaskCard({
 
       {/* Expanded scopes for non-actionable states */}
       {scopesOpen && !isActionable && (
-        <div className="px-4 pb-3">
+        <div className="px-4 pb-3 space-y-2">
           <ScopeGroupTables autoActions={autoActions} manualActions={manualActions} />
+          {task.planned_calls && task.planned_calls.length > 0 && (
+            <PlannedCallsTable calls={task.planned_calls} />
+          )}
         </div>
       )}
 


### PR DESCRIPTION
## Summary

- Show planned calls in the expanded scopes section for all task states (active, completed, expired, etc.), not just during pending approval
- Surface risk level (e.g. 🟡 medium) in Telegram task approval notifications — it was passed in the request struct but never rendered

## Test plan

- [ ] Verify planned calls appear when expanding scopes on a completed task in the dashboard
- [ ] Verify Telegram task approval notification includes the risk level line

🤖 Generated with [Claude Code](https://claude.com/claude-code)