### PR TITLE
fix: hide iMessage on non-macOS and check Full Disk Access on activation

### DIFF
--- a/internal/adapters/apple/imessage/adapter.go
+++ b/internal/adapters/apple/imessage/adapter.go
@@ -48,18 +48,10 @@ func New() *IMessageAdapter {
 	}
 }
 
-// Available returns true if the adapter can operate on this host.
-// Requires macOS with chat.db readable (Full Disk Access must be granted).
+// Available returns true if the adapter should be shown on this platform.
+// iMessage only makes sense on macOS.
 func (a *IMessageAdapter) Available() bool {
-	if runtime.GOOS != "darwin" {
-		return false
-	}
-	f, err := os.Open(a.dbPath)
-	if err != nil {
-		return false
-	}
-	f.Close()
-	return true
+	return runtime.GOOS == "darwin"
 }
 
 func (a *IMessageAdapter) ServiceID() string { return serviceID }
@@ -125,8 +117,11 @@ func (a *IMessageAdapter) ServiceMetadata() adapters.ServiceMetadata {
 }
 
 func (a *IMessageAdapter) Execute(ctx context.Context, req adapters.Request) (*adapters.Result, error) {
-	if !a.Available() {
-		return nil, fmt.Errorf("imessage: not available — grant Full Disk Access to Clawvisor in System Settings → Privacy & Security → Full Disk Access, then restart")
+	if runtime.GOOS != "darwin" {
+		return nil, fmt.Errorf("imessage: only available on macOS")
+	}
+	if err := a.CheckPermissions(); err != nil {
+		return nil, err
 	}
 	switch req.Action {
 	case "search_messages":

--- a/internal/api/handlers/services.go
+++ b/internal/api/handlers/services.go
@@ -213,6 +213,9 @@ func (h *ServicesHandler) List(w http.ResponseWriter, r *http.Request) {
 
 	services := make([]serviceEntry, 0)
 	for _, a := range h.adapterReg.All() {
+		if ac, ok := a.(adapters.AvailabilityChecker); ok && !ac.Available() {
+			continue
+		}
 		credentialFree := a.ValidateCredential(nil) == nil
 
 		if credentialFree {
@@ -611,6 +614,15 @@ func (h *ServicesHandler) Activate(w http.ResponseWriter, r *http.Request) {
 
 	// Credential-free service (e.g. iMessage): create service_meta record, no vault op.
 	if adapter.ValidateCredential(nil) == nil {
+		// If the adapter supports activation checks (e.g. iMessage checking Full
+		// Disk Access), run them first. The attempt itself may trigger OS-level
+		// permission registration (macOS adds the app to Full Disk Access).
+		if ac, ok := adapter.(adapters.ActivationChecker); ok {
+			if err := ac.CheckPermissions(); err != nil {
+				writeError(w, http.StatusPreconditionFailed, "ACTIVATION_CHECK_FAILED", err.Error())
+				return
+			}
+		}
 		_ = h.st.UpsertServiceMeta(r.Context(), user.ID, serviceID, "default", time.Now())
 		h.logger.Info("credential-free service activated", "user", user.ID, "service", serviceID)
 		writeJSON(w, http.StatusOK, map[string]string{"status": "activated", "service": serviceID})

--- a/internal/api/handlers/skill.go
+++ b/internal/api/handlers/skill.go
@@ -77,6 +77,9 @@ func (h *SkillHandler) Catalog(w http.ResponseWriter, r *http.Request) {
 	// Collect activated services, grouped by base service ID.
 	entries := map[string]*catalogEntry{} // baseID → entry
 	for _, a := range allAdapters {
+		if ac, ok := a.(adapters.AvailabilityChecker); ok && !ac.Available() {
+			continue
+		}
 		baseID := a.ServiceID()
 		credentialFree := a.ValidateCredential(nil) == nil
 		if credentialFree {

--- a/pkg/adapters/adapters.go
+++ b/pkg/adapters/adapters.go
@@ -115,6 +115,23 @@ type ContactsChecker interface {
 	IsInContacts(ctx context.Context, cred []byte, email string) (bool, error)
 }
 
+// AvailabilityChecker is an optional interface adapters can implement to
+// indicate whether they should be shown on the current platform. If Available
+// returns false the adapter is hidden from the service catalog, skill catalog,
+// and dashboard. The iMessage adapter uses this to hide itself on non-macOS hosts.
+type AvailabilityChecker interface {
+	Available() bool
+}
+
+// ActivationChecker is an optional interface adapters can implement to
+// validate that the adapter can actually function before activation.
+// For example, the iMessage adapter uses this to attempt opening chat.db,
+// which triggers macOS to register the app in Full Disk Access settings.
+// If CheckPermissions returns an error, the activation is rejected with that message.
+type ActivationChecker interface {
+	CheckPermissions() error
+}
+
 // VerificationHinter is an optional interface adapters can implement to provide
 // service-specific guidance to the LLM intent verifier. The hints are included
 // in the verification prompt only when that adapter is being verified.


### PR DESCRIPTION
## Summary

- Adds `AvailabilityChecker` and `ActivationChecker` optional adapter interfaces
- Hides iMessage from the service catalog, skill catalog, and dashboard on non-macOS hosts
- On macOS, activating iMessage now probes `chat.db` first — this triggers the OS to register the app in Full Disk Access settings, and returns a clear error guiding the user to grant access
- `Execute()` also checks permissions at runtime so revoked FDA is caught

## Test plan

- [ ] Verify iMessage does not appear in service list or skill catalog on Linux
- [ ] On macOS without FDA, activate iMessage and confirm the error message guides to System Settings
- [ ] On macOS with FDA, activate iMessage and confirm it succeeds
- [ ] Existing tests pass (`go test ./internal/api/handlers/... ./internal/adapters/apple/imessage/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)