### PR TITLE
feat: Gmail adapter attachment support

### DIFF
--- a/internal/adapters/definitions/google_gmail.yaml
+++ b/internal/adapters/definitions/google_gmail.yaml
@@ -1,7 +1,7 @@
 service:
   id: google.gmail
   display_name: Gmail
-  description: "Read, search, send, and draft email"
+  description: "Read, search, send, and draft email with attachment support"
   setup_url: "https://github.com/clawvisor/clawvisor/blob/main/docs/GOOGLE_OAUTH_SETUP.md"
 
 auth:
@@ -34,31 +34,17 @@ actions:
   get_message:
     display_name: "Get message"
     risk: { category: read, sensitivity: low, description: "Read a specific email message" }
-    method: GET
-    path: "/users/me/messages/{{.message_id}}"
+    override: go
     params:
-      message_id: { type: string, required: true, location: path }
-      format: { type: string, default: "full", location: query }
-    response:
-      fields:
-        - { name: id }
-        - name: from
-          expr: "findHeader(payload.headers, 'From')"
-          sanitize: true
-        - name: to
-          expr: "findHeader(payload.headers, 'To')"
-          sanitize: true
-        - name: subject
-          expr: "findHeader(payload.headers, 'Subject')"
-          sanitize: true
-        - name: date
-          expr: "findHeader(payload.headers, 'Date')"
-        - name: body
-          expr: "sanitize(extractMimeBody(payload) != '' ? extractMimeBody(payload) : snippet, 2000)"
-        - name: is_unread
-          expr: "'UNREAD' in labelIds"
-        - { name: threadId, rename: thread_id }
-      summary: "Email from {{.from}}: {{.subject}}"
+      message_id: { type: string, required: true }
+
+  get_attachment:
+    display_name: "Get attachment"
+    risk: { category: read, sensitivity: low, description: "Download an email attachment" }
+    override: go
+    params:
+      message_id: { type: string, required: true }
+      attachment_id: { type: string, required: true }
 
   send_message:
     display_name: "Send message"

--- a/internal/adapters/google/gmail/adapter.go
+++ b/internal/adapters/google/gmail/adapter.go
@@ -56,7 +56,7 @@ func New(provider adapters.OAuthCredentialProvider) *GmailAdapter {
 func (a *GmailAdapter) ServiceID() string { return serviceID }
 
 func (a *GmailAdapter) SupportedActions() []string {
-	actions := []string{"list_messages", "get_message", "send_message"}
+	actions := []string{"list_messages", "get_message", "get_attachment", "send_message"}
 	if draftsEnabled() {
 		actions = append(actions, "create_draft")
 	}
@@ -98,6 +98,8 @@ func (a *GmailAdapter) Execute(ctx context.Context, req adapters.Request) (*adap
 		return a.listMessages(ctx, client, req.Params)
 	case "get_message":
 		return a.getMessage(ctx, client, req.Params)
+	case "get_attachment":
+		return a.getAttachment(ctx, client, req.Params)
 	case "send_message":
 		return a.sendMessage(ctx, client, req.Params)
 	case "create_draft":
@@ -186,15 +188,23 @@ func (a *GmailAdapter) listMessages(ctx context.Context, client *http.Client, pa
 
 // ── get_message ───────────────────────────────────────────────────────────────
 
+type attachmentMeta struct {
+	AttachmentID string `json:"attachment_id"`
+	Filename     string `json:"filename"`
+	MimeType     string `json:"mime_type"`
+	Size         int    `json:"size"`
+}
+
 type msgDetail struct {
-	ID       string `json:"id"`
-	From     string `json:"from"`
-	To       string `json:"to"`
-	Subject  string `json:"subject"`
-	Date     string `json:"timestamp"`
-	Body     string `json:"body"`
-	IsUnread bool   `json:"is_unread"`
-	ThreadID string `json:"thread_id"`
+	ID          string           `json:"id"`
+	From        string           `json:"from"`
+	To          string           `json:"to"`
+	Subject     string           `json:"subject"`
+	Date        string           `json:"timestamp"`
+	Body        string           `json:"body"`
+	IsUnread    bool             `json:"is_unread"`
+	ThreadID    string           `json:"thread_id"`
+	Attachments []attachmentMeta `json:"attachments,omitempty"`
 }
 
 func (a *GmailAdapter) getMessage(ctx context.Context, client *http.Client, params map[string]any) (*adapters.Result, error) {
@@ -204,35 +214,7 @@ func (a *GmailAdapter) getMessage(ctx context.Context, client *http.Client, para
 	}
 
 	url := fmt.Sprintf("https://gmail.googleapis.com/gmail/v1/users/me/messages/%s?format=full", msgID)
-	var raw struct {
-		ID       string `json:"id"`
-		ThreadId string `json:"threadId"`
-		LabelIds []string `json:"labelIds"`
-		Snippet  string `json:"snippet"`
-		Payload  struct {
-			Headers []struct {
-				Name  string `json:"name"`
-				Value string `json:"value"`
-			} `json:"headers"`
-			Parts []struct {
-				MimeType string `json:"mimeType"`
-				Body     struct {
-					Data string `json:"data"`
-				} `json:"body"`
-				Parts []struct {
-					MimeType string `json:"mimeType"`
-					Body     struct {
-						Data string `json:"data"`
-					} `json:"body"`
-				} `json:"parts"`
-			} `json:"parts"`
-			Body struct {
-				Data string `json:"data"`
-			} `json:"body"`
-			MimeType string `json:"mimeType"`
-		} `json:"payload"`
-	}
-
+	var raw gmailMessage
 	if err := gmailGET(ctx, client, url, &raw); err != nil {
 		return nil, fmt.Errorf("gmail get_message: %w", err)
 	}
@@ -259,24 +241,61 @@ func (a *GmailAdapter) getMessage(ctx context.Context, client *http.Client, para
 		}
 	}
 
-	body := extractBody(raw.Payload)
+	body := extractBodyFromParts(raw.Payload)
 	if body == "" {
 		body = raw.Snippet
 	}
 
+	attachments := extractAttachments(raw.Payload)
+
 	detail := msgDetail{
-		ID:       raw.ID,
-		From:     format.SanitizeText(from, format.MaxFieldLen),
-		To:       format.SanitizeText(to, format.MaxFieldLen),
-		Subject:  format.SanitizeText(subject, format.MaxFieldLen),
-		Date:     date,
-		Body:     format.SanitizeText(body, format.MaxBodyLen),
-		IsUnread: isUnread,
-		ThreadID: raw.ThreadId,
+		ID:          raw.ID,
+		From:        format.SanitizeText(from, format.MaxFieldLen),
+		To:          format.SanitizeText(to, format.MaxFieldLen),
+		Subject:     format.SanitizeText(subject, format.MaxFieldLen),
+		Date:        date,
+		Body:        format.SanitizeText(body, format.MaxBodyLen),
+		IsUnread:    isUnread,
+		ThreadID:    raw.ThreadId,
+		Attachments: attachments,
 	}
 
 	summary := format.Summary("Email from %s: %q", detail.From, detail.Subject)
+	if len(attachments) > 0 {
+		summary = format.Summary("Email from %s: %q (%d attachments)", detail.From, detail.Subject, len(attachments))
+	}
 	return &adapters.Result{Summary: summary, Data: detail}, nil
+}
+
+// ── get_attachment ────────────────────────────────────────────────────────────
+
+func (a *GmailAdapter) getAttachment(ctx context.Context, client *http.Client, params map[string]any) (*adapters.Result, error) {
+	msgID, _ := params["message_id"].(string)
+	attachmentID, _ := params["attachment_id"].(string)
+	if msgID == "" {
+		return nil, fmt.Errorf("gmail get_attachment: message_id is required")
+	}
+	if attachmentID == "" {
+		return nil, fmt.Errorf("gmail get_attachment: attachment_id is required")
+	}
+
+	url := fmt.Sprintf("https://gmail.googleapis.com/gmail/v1/users/me/messages/%s/attachments/%s", msgID, attachmentID)
+	var raw struct {
+		Size int    `json:"size"`
+		Data string `json:"data"`
+	}
+	if err := gmailGET(ctx, client, url, &raw); err != nil {
+		return nil, fmt.Errorf("gmail get_attachment: %w", err)
+	}
+
+	result := map[string]any{
+		"message_id":    msgID,
+		"attachment_id": attachmentID,
+		"size":          raw.Size,
+		"data":          raw.Data,
+	}
+	summary := format.Summary("Attachment fetched (%d bytes)", raw.Size)
+	return &adapters.Result{Summary: summary, Data: result}, nil
 }
 
 // ── send_message ──────────────────────────────────────────────────────────────
@@ -412,6 +431,42 @@ func gmailPOST(ctx context.Context, client *http.Client, url string, payload any
 	return json.Unmarshal(body, out)
 }
 
+// ── Gmail API message types ───────────────────────────────────────────────────
+
+type gmailMessage struct {
+	ID       string       `json:"id"`
+	ThreadId string       `json:"threadId"`
+	LabelIds []string     `json:"labelIds"`
+	Snippet  string       `json:"snippet"`
+	Payload  gmailPayload `json:"payload"`
+}
+
+type gmailPayload struct {
+	MimeType string        `json:"mimeType"`
+	Headers  []gmailHeader `json:"headers"`
+	Body     gmailBody     `json:"body"`
+	Parts    []gmailPart   `json:"parts"`
+}
+
+type gmailPart struct {
+	MimeType string        `json:"mimeType"`
+	Filename string        `json:"filename"`
+	Headers  []gmailHeader `json:"headers"`
+	Body     gmailBody     `json:"body"`
+	Parts    []gmailPart   `json:"parts"`
+}
+
+type gmailHeader struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+type gmailBody struct {
+	AttachmentID string `json:"attachmentId"`
+	Size         int    `json:"size"`
+	Data         string `json:"data"`
+}
+
 // ── Message parsing helpers ───────────────────────────────────────────────────
 
 type msgMeta struct {
@@ -425,10 +480,7 @@ func fetchMessageMeta(ctx context.Context, client *http.Client, id string) (msgM
 		Snippet  string   `json:"snippet"`
 		LabelIds []string `json:"labelIds"`
 		Payload  struct {
-			Headers []struct {
-				Name  string `json:"name"`
-				Value string `json:"value"`
-			} `json:"headers"`
+			Headers []gmailHeader `json:"headers"`
 		} `json:"payload"`
 	}
 	if err := gmailGET(ctx, client, url, &raw); err != nil {
@@ -454,59 +506,61 @@ func fetchMessageMeta(ctx context.Context, client *http.Client, id string) (msgM
 	return meta, nil
 }
 
-// extractBody walks a message payload to find the text/plain part.
-func extractBody(payload struct {
-	Headers []struct {
-		Name  string `json:"name"`
-		Value string `json:"value"`
-	} `json:"headers"`
-	Parts []struct {
-		MimeType string `json:"mimeType"`
-		Body     struct {
-			Data string `json:"data"`
-		} `json:"body"`
-		Parts []struct {
-			MimeType string `json:"mimeType"`
-			Body     struct {
-				Data string `json:"data"`
-			} `json:"body"`
-		} `json:"parts"`
-	} `json:"parts"`
-	Body struct {
-		Data string `json:"data"`
-	} `json:"body"`
-	MimeType string `json:"mimeType"`
-}) string {
-	// Direct body
+// extractBodyFromParts walks a message payload to find the text/plain part.
+func extractBodyFromParts(payload gmailPayload) string {
+	// Direct body (non-multipart message)
 	if payload.MimeType == "text/plain" && payload.Body.Data != "" {
 		return decodeBase64(payload.Body.Data)
 	}
 
-	// Search parts
-	for _, part := range payload.Parts {
-		if part.MimeType == "text/plain" && part.Body.Data != "" {
-			return decodeBase64(part.Body.Data)
-		}
-		// Nested multipart
-		for _, sub := range part.Parts {
-			if sub.MimeType == "text/plain" && sub.Body.Data != "" {
-				return decodeBase64(sub.Body.Data)
-			}
-		}
+	// Search top-level parts
+	if body := findTextInParts(payload.Parts, "text/plain"); body != "" {
+		return body
 	}
 
-	// Fall back to any HTML part — strip tags before returning.
-	for _, part := range payload.Parts {
-		if part.MimeType == "text/html" && part.Body.Data != "" {
-			return stripHTML(decodeBase64(part.Body.Data))
-		}
+	// Fall back to HTML
+	if body := findTextInParts(payload.Parts, "text/html"); body != "" {
+		return stripHTML(body)
 	}
-	// Also handle direct HTML body (non-multipart).
 	if payload.MimeType == "text/html" && payload.Body.Data != "" {
 		return stripHTML(decodeBase64(payload.Body.Data))
 	}
 
 	return ""
+}
+
+// findTextInParts recursively searches MIME parts for content of the given type.
+func findTextInParts(parts []gmailPart, mimeType string) string {
+	for _, part := range parts {
+		if part.MimeType == mimeType && part.Body.Data != "" {
+			return decodeBase64(part.Body.Data)
+		}
+		if result := findTextInParts(part.Parts, mimeType); result != "" {
+			return result
+		}
+	}
+	return ""
+}
+
+// extractAttachments collects attachment metadata from MIME parts.
+func extractAttachments(payload gmailPayload) []attachmentMeta {
+	var attachments []attachmentMeta
+	collectAttachments(payload.Parts, &attachments)
+	return attachments
+}
+
+func collectAttachments(parts []gmailPart, out *[]attachmentMeta) {
+	for _, part := range parts {
+		if part.Filename != "" && part.Body.AttachmentID != "" {
+			*out = append(*out, attachmentMeta{
+				AttachmentID: part.Body.AttachmentID,
+				Filename:     part.Filename,
+				MimeType:     part.MimeType,
+				Size:         part.Body.Size,
+			})
+		}
+		collectAttachments(part.Parts, out)
+	}
 }
 
 // stripHTML removes HTML tags, style/script blocks, and decodes common entities,

--- a/internal/adapters/google/gmail/adapter_test.go
+++ b/internal/adapters/google/gmail/adapter_test.go
@@ -1,0 +1,191 @@
+package gmail
+
+import (
+	"encoding/base64"
+	"testing"
+)
+
+func b64(s string) string { return base64.URLEncoding.EncodeToString([]byte(s)) }
+
+func TestExtractBodyFromParts_DirectPlainText(t *testing.T) {
+	payload := gmailPayload{
+		MimeType: "text/plain",
+		Body:     gmailBody{Data: b64("Hello, world!")},
+	}
+	got := extractBodyFromParts(payload)
+	if got != "Hello, world!" {
+		t.Errorf("got %q, want %q", got, "Hello, world!")
+	}
+}
+
+func TestExtractBodyFromParts_DirectHTML(t *testing.T) {
+	payload := gmailPayload{
+		MimeType: "text/html",
+		Body:     gmailBody{Data: b64("<p>Hello</p>")},
+	}
+	got := extractBodyFromParts(payload)
+	if got != "Hello" {
+		t.Errorf("got %q, want %q", got, "Hello")
+	}
+}
+
+func TestExtractBodyFromParts_MultipartPreferPlain(t *testing.T) {
+	payload := gmailPayload{
+		MimeType: "multipart/alternative",
+		Parts: []gmailPart{
+			{MimeType: "text/plain", Body: gmailBody{Data: b64("plain text")}},
+			{MimeType: "text/html", Body: gmailBody{Data: b64("<b>html</b>")}},
+		},
+	}
+	got := extractBodyFromParts(payload)
+	if got != "plain text" {
+		t.Errorf("got %q, want %q", got, "plain text")
+	}
+}
+
+func TestExtractBodyFromParts_NestedMultipart(t *testing.T) {
+	payload := gmailPayload{
+		MimeType: "multipart/mixed",
+		Parts: []gmailPart{
+			{
+				MimeType: "multipart/alternative",
+				Parts: []gmailPart{
+					{MimeType: "text/plain", Body: gmailBody{Data: b64("nested plain")}},
+					{MimeType: "text/html", Body: gmailBody{Data: b64("<p>nested html</p>")}},
+				},
+			},
+			{
+				MimeType: "application/pdf",
+				Filename: "receipt.pdf",
+				Body:     gmailBody{AttachmentID: "abc123", Size: 5000},
+			},
+		},
+	}
+	got := extractBodyFromParts(payload)
+	if got != "nested plain" {
+		t.Errorf("got %q, want %q", got, "nested plain")
+	}
+}
+
+func TestExtractBodyFromParts_HTMLFallback(t *testing.T) {
+	payload := gmailPayload{
+		MimeType: "multipart/alternative",
+		Parts: []gmailPart{
+			{MimeType: "text/html", Body: gmailBody{Data: b64("<div>only html</div>")}},
+		},
+	}
+	got := extractBodyFromParts(payload)
+	if got != "only html" {
+		t.Errorf("got %q, want %q", got, "only html")
+	}
+}
+
+func TestExtractBodyFromParts_Empty(t *testing.T) {
+	payload := gmailPayload{MimeType: "multipart/mixed"}
+	got := extractBodyFromParts(payload)
+	if got != "" {
+		t.Errorf("got %q, want empty", got)
+	}
+}
+
+func TestExtractAttachments_None(t *testing.T) {
+	payload := gmailPayload{
+		MimeType: "text/plain",
+		Body:     gmailBody{Data: b64("no attachments")},
+	}
+	got := extractAttachments(payload)
+	if len(got) != 0 {
+		t.Errorf("expected no attachments, got %d", len(got))
+	}
+}
+
+func TestExtractAttachments_SingleAttachment(t *testing.T) {
+	payload := gmailPayload{
+		MimeType: "multipart/mixed",
+		Parts: []gmailPart{
+			{MimeType: "text/plain", Body: gmailBody{Data: b64("body")}},
+			{
+				MimeType: "application/pdf",
+				Filename: "invoice.pdf",
+				Body:     gmailBody{AttachmentID: "att-1", Size: 12345},
+			},
+		},
+	}
+	got := extractAttachments(payload)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 attachment, got %d", len(got))
+	}
+	if got[0].AttachmentID != "att-1" {
+		t.Errorf("attachment_id = %q, want %q", got[0].AttachmentID, "att-1")
+	}
+	if got[0].Filename != "invoice.pdf" {
+		t.Errorf("filename = %q, want %q", got[0].Filename, "invoice.pdf")
+	}
+	if got[0].MimeType != "application/pdf" {
+		t.Errorf("mime_type = %q, want %q", got[0].MimeType, "application/pdf")
+	}
+	if got[0].Size != 12345 {
+		t.Errorf("size = %d, want %d", got[0].Size, 12345)
+	}
+}
+
+func TestExtractAttachments_MultipleAndNested(t *testing.T) {
+	payload := gmailPayload{
+		MimeType: "multipart/mixed",
+		Parts: []gmailPart{
+			{
+				MimeType: "multipart/alternative",
+				Parts: []gmailPart{
+					{MimeType: "text/plain", Body: gmailBody{Data: b64("body")}},
+				},
+			},
+			{
+				MimeType: "image/png",
+				Filename: "photo.png",
+				Body:     gmailBody{AttachmentID: "att-1", Size: 1000},
+			},
+			{
+				MimeType: "application/zip",
+				Filename: "archive.zip",
+				Body:     gmailBody{AttachmentID: "att-2", Size: 50000},
+			},
+		},
+	}
+	got := extractAttachments(payload)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 attachments, got %d", len(got))
+	}
+	if got[0].Filename != "photo.png" {
+		t.Errorf("first attachment = %q, want %q", got[0].Filename, "photo.png")
+	}
+	if got[1].Filename != "archive.zip" {
+		t.Errorf("second attachment = %q, want %q", got[1].Filename, "archive.zip")
+	}
+}
+
+func TestExtractAttachments_SkipsPartsWithoutAttachmentID(t *testing.T) {
+	// Inline images may have a filename but no attachmentId when content is inline
+	payload := gmailPayload{
+		MimeType: "multipart/mixed",
+		Parts: []gmailPart{
+			{MimeType: "text/plain", Body: gmailBody{Data: b64("body")}},
+			{
+				MimeType: "image/png",
+				Filename: "inline.png",
+				Body:     gmailBody{Data: b64("inline-data")}, // no AttachmentID
+			},
+			{
+				MimeType: "application/pdf",
+				Filename: "real.pdf",
+				Body:     gmailBody{AttachmentID: "att-1", Size: 9999},
+			},
+		},
+	}
+	got := extractAttachments(payload)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 attachment, got %d", len(got))
+	}
+	if got[0].Filename != "real.pdf" {
+		t.Errorf("attachment = %q, want %q", got[0].Filename, "real.pdf")
+	}
+}

--- a/pkg/clawvisor/defaults.go
+++ b/pkg/clawvisor/defaults.go
@@ -133,12 +133,12 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 
 	// Build Go action overrides for Google services that need complex logic
 	// (MIME encoding, multipart uploads, dual API calls) beyond what YAML
-	// expressions can handle. Calendar, Contacts, Drive search_files, and
-	// Gmail get_message are now fully YAML-driven with expr-lang transforms.
+	// expressions can handle. Calendar, Contacts, and Drive search_files
+	// are fully YAML-driven with expr-lang transforms.
 	goOverrides := map[string]yamlruntime.ActionFunc{}
 
 	gmail := gmailadapter.New(oauthProvider)
-	for _, action := range []string{"list_messages", "send_message", "create_draft"} {
+	for _, action := range []string{"list_messages", "get_message", "get_attachment", "send_message", "create_draft"} {
 		goOverrides["google.gmail:"+action] = gmail.Execute
 	}
 	drive := driveadapter.New(oauthProvider)

--- a/skills/clawvisor/policies/google-workspace-safe.yaml
+++ b/skills/clawvisor/policies/google-workspace-safe.yaml
@@ -8,7 +8,7 @@ description: >
 rules:
   # Gmail — read operations allowed, send requires approval, delete blocked
   - service: google.gmail
-    actions: [list_messages, get_message]
+    actions: [list_messages, get_message, get_attachment]
     allow: true
 
   - service: google.gmail


### PR DESCRIPTION
## Summary

- Add `get_attachment` action to fetch email attachment content by message ID and attachment ID
- Update `get_message` to return attachment metadata (filename, MIME type, size, attachment ID) in responses
- Refactor MIME parsing from inline anonymous structs into proper shared types (`gmailMessage`, `gmailPayload`, `gmailPart`) with recursive traversal for arbitrarily nested multipart structures
- Register `get_message` and `get_attachment` as Go overrides in `defaults.go` (fixes `get_message` which was previously YAML-driven but switched to Go override)
- Add `get_attachment` to the safe-defaults policy as an auto-allowed read action

## Test plan

- [x] `go build ./...` passes
- [x] 10 unit tests covering body extraction (plain text, HTML, multipart, nested, fallback, empty) and attachment extraction (none, single, multiple/nested, skipping inline parts)
- [ ] Manual test: call `get_message` on an email with attachments, verify metadata is returned
- [ ] Manual test: call `get_attachment` with returned attachment_id, verify base64 data is returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)