### PR TITLE
feat: add permalink and channel fields to Slack adapter responses

### DIFF
--- a/internal/adapters/definitions/slack.yaml
+++ b/internal/adapters/definitions/slack.yaml
@@ -83,6 +83,7 @@ actions:
         - { name: user }
         - { name: text, sanitize: true }
         - { name: ts }
+        - { name: thread_ts, optional: true }
       summary: "{{len .Data}} message(s)"
 
   send_message:
@@ -116,6 +117,9 @@ actions:
         - { name: text, sanitize: true }
         - { name: ts }
         - { name: username }
+        - { name: permalink }
+        - { name: channel_id, path: "channel.id" }
+        - { name: channel_name, path: "channel.name" }
       summary: "{{len .Data}} result(s)"
 
   list_users:


### PR DESCRIPTION
Adds missing fields to the Slack adapter's response definitions. `search_messages` now returns `permalink`, `channel_id`, and `channel_name` from the Slack search API. `list_messages` now includes `thread_ts` (optional) for thread context. This addresses reports that ClawVisor was normalizing Slack responses too aggressively, stripping fields needed to construct message links.