### PR TITLE
feat: add pagination to Google Contacts list_contacts

### DIFF
--- a/internal/adapters/definitions/google_contacts.yaml
+++ b/internal/adapters/definitions/google_contacts.yaml
@@ -20,11 +20,13 @@ api:
 actions:
   list_contacts:
     display_name: "List contacts"
+    override: go
     risk: { category: read, sensitivity: low, description: "List contacts" }
     method: GET
     path: "/people/me/connections"
     params:
-      max_results: { type: int, default: 20, max: 100, map_to: pageSize, location: query }
+      page_size: { type: int, default: 50, max: 50, map_to: pageSize, location: query }
+      page_token: { type: string, optional: true, map_to: pageToken, location: query }
       person_fields:
         type: string
         default: "names,emailAddresses,phoneNumbers"
@@ -90,7 +92,7 @@ actions:
     path: "/people:searchContacts"
     params:
       query: { type: string, required: true, location: query }
-      max_results: { type: int, default: 10, max: 50, map_to: pageSize, location: query }
+      max_results: { type: int, default: 10, max: 30, map_to: pageSize, location: query }
       read_mask:
         type: string
         default: "names,emailAddresses,phoneNumbers"

--- a/internal/adapters/google/contacts/adapter.go
+++ b/internal/adapters/google/contacts/adapter.go
@@ -140,16 +140,25 @@ type contactItem struct {
 	Phone string `json:"phone,omitempty"`
 }
 
+type listContactsResponse struct {
+	Contacts      []contactItem `json:"contacts"`
+	NextPageToken string        `json:"next_page_token,omitempty"`
+	TotalPeople   int           `json:"total_people,omitempty"`
+}
+
 func (a *ContactsAdapter) listContacts(ctx context.Context, client *http.Client, params map[string]any) (*adapters.Result, error) {
-	maxResults := 20
-	if v, ok := paramInt(params, "max_results"); ok && v > 0 && v <= 100 {
-		maxResults = v
+	pageSize := 50
+	if v, ok := paramInt(params, "page_size"); ok && v > 0 && v <= 50 {
+		pageSize = v
 	}
 
 	q := url.Values{}
-	q.Set("pageSize", fmt.Sprintf("%d", maxResults))
+	q.Set("pageSize", fmt.Sprintf("%d", pageSize))
 	q.Set("personFields", "names,emailAddresses,phoneNumbers")
 	q.Set("sortOrder", "LAST_NAME_ASCENDING")
+	if pt, _ := params["page_token"].(string); pt != "" {
+		q.Set("pageToken", pt)
+	}
 
 	apiURL := "https://people.googleapis.com/v1/people/me/connections?" + q.Encode()
 	var resp struct {
@@ -165,7 +174,8 @@ func (a *ContactsAdapter) listContacts(ctx context.Context, client *http.Client,
 				Value string `json:"value"`
 			} `json:"phoneNumbers"`
 		} `json:"connections"`
-		TotalPeople int `json:"totalPeople"`
+		NextPageToken string `json:"nextPageToken"`
+		TotalPeople   int    `json:"totalPeople"`
 	}
 	if err := apiGET(ctx, client, apiURL, &resp); err != nil {
 		return nil, fmt.Errorf("contacts list_contacts: %w", err)
@@ -185,9 +195,14 @@ func (a *ContactsAdapter) listContacts(ctx context.Context, client *http.Client,
 		}
 		items = append(items, item)
 	}
+
 	return &adapters.Result{
 		Summary: format.Summary("%d contact(s)", len(items)),
-		Data:    items,
+		Data: listContactsResponse{
+			Contacts:      items,
+			NextPageToken: resp.NextPageToken,
+			TotalPeople:   resp.TotalPeople,
+		},
 	}, nil
 }
 
@@ -265,7 +280,7 @@ func (a *ContactsAdapter) searchContacts(ctx context.Context, client *http.Clien
 		return nil, fmt.Errorf("contacts search_contacts: query is required")
 	}
 	maxResults := 10
-	if v, ok := paramInt(params, "max_results"); ok && v > 0 && v <= 50 {
+	if v, ok := paramInt(params, "max_results"); ok && v > 0 && v <= 30 {
 		maxResults = v
 	}
 

--- a/pkg/clawvisor/defaults.go
+++ b/pkg/clawvisor/defaults.go
@@ -20,6 +20,7 @@ import (
 	imessageadapter "github.com/clawvisor/clawvisor/internal/adapters/apple/imessage"
 	sqladapter "github.com/clawvisor/clawvisor/internal/adapters/sql"
 	driveadapter "github.com/clawvisor/clawvisor/internal/adapters/google/drive"
+	contactsadapter "github.com/clawvisor/clawvisor/internal/adapters/google/contacts"
 	gmailadapter "github.com/clawvisor/clawvisor/internal/adapters/google/gmail"
 	"github.com/clawvisor/clawvisor/internal/auth"
 	"github.com/clawvisor/clawvisor/internal/callback"
@@ -145,6 +146,8 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 	for _, action := range []string{"get_file", "create_file", "update_file"} {
 		goOverrides["google.drive:"+action] = drive.Execute
 	}
+	contacts := contactsadapter.New(oauthProvider)
+	goOverrides["google.contacts:list_contacts"] = contacts.Execute
 
 	// Load YAML adapter definitions from embedded FS + user-local directory.
 	home, _ := os.UserHomeDir()


### PR DESCRIPTION
## Summary

- Add caller-controlled pagination to `list_contacts` via `page_token` / `next_page_token`, replacing the old single-page `max_results` approach
- Register `list_contacts` as a Go override (`override: go`) so the response can include both the contacts array and pagination metadata (`next_page_token`, `total_people`)
- Fix `search_contacts` max from 50 to 30 to match the actual Google People API cap

## Test plan

- [ ] Call `list_contacts` with default params — should return up to 50 contacts with `next_page_token` if more exist
- [ ] Pass `page_token` from a previous response — should return the next page
- [ ] Verify `total_people` reflects the full contact count
- [ ] Call `search_contacts` with `max_results: 31` — should cap at 30

🤖 Generated with [Claude Code](https://claude.com/claude-code)