### PR TITLE
fix: diff against previous tag to detect skill changes

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -61,12 +61,20 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.release-please.outputs.tag_name }}
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Check for skill changes
         id: skill-changes
+        env:
+          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
         run: |
-          if git diff --name-only HEAD~1 HEAD | grep -qE '^skills/clawvisor/'; then
+          # Fetch all tags so we can find the previous release
+          git fetch --tags --quiet
+          PREV_TAG=$(git tag --sort=-v:refname | grep -E '^v[0-9]' | grep -v "^${TAG_NAME}$" | head -1)
+          if [ -z "$PREV_TAG" ]; then
+            echo "No previous tag found, treating as changed"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          elif git diff --name-only "$PREV_TAG" HEAD | grep -qE '^skills/clawvisor/'; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changed=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- The `publish-skill` job was comparing only `HEAD~1` (the release-please bot commit) to detect skill changes. That commit only touches `.release-please-manifest.json` and `CHANGELOG.md`, so skill changes from earlier commits in the release were never detected.
- Now diffs against the previous release tag (e.g. `v0.8.4..v0.8.5`) to capture all changes across the full release.
- Changed `fetch-depth` from 2 to 0 so the full history and previous tags are available.

## Test plan
- [ ] Verify next release with skill changes triggers the ClawHub publish step

🤖 Generated with [Claude Code](https://claude.com/claude-code)