### PR TITLE
feat: add scope guidance, reason docs, and fetchable task presets

### DIFF
--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -211,6 +211,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 
 	// ── Step 4: Task scope enforcement ───────────────────────────────────────
 	var advisoryVerdict *intent.VerificationVerdict
+	var warnings []string
 	{
 		task, taskErr := h.store.GetTask(ctx, req.TaskID)
 		if taskErr != nil {
@@ -233,6 +234,10 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusConflict, "INVALID_STATE",
 				fmt.Sprintf("task is %s, not active", task.Status))
 			return
+		}
+
+		if task.Lifetime == "standing" && req.SessionID == "" {
+			warnings = append(warnings, "Chain context is disabled because session_id was not provided on this standing task request. Intent verification cannot verify that entity references (message IDs, thread IDs, etc.) came from prior results. Provide a consistent session_id across related requests to enable chain context.")
 		}
 
 		match := CheckTaskScope(task, serviceType, serviceAlias, req.Action)
@@ -323,13 +328,17 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 						h.logger.Warn("intent alert failed", "err", alertErr)
 					}
 				}
-				writeJSON(w, http.StatusOK, map[string]any{
+				resp := map[string]any{
 					"status":       "restricted",
 					"request_id":   req.RequestID,
 					"audit_id":     auditID,
 					"reason":       verdict.Explanation,
 					"verification": verdict,
-				})
+				}
+				if len(warnings) > 0 {
+					resp["warnings"] = warnings
+				}
+				writeJSON(w, http.StatusOK, resp)
 				return
 			}
 			// ── End intent verification ──────────────────────────────────
@@ -462,12 +471,16 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 					}, cbKey)
 				}()
 			}
-			writeJSON(w, http.StatusOK, map[string]any{
+			resp := map[string]any{
 				"status":     "executed",
 				"request_id": req.RequestID,
 				"audit_id":   auditID,
 				"result":     result,
-			})
+			}
+			if len(warnings) > 0 {
+				resp["warnings"] = warnings
+			}
+			writeJSON(w, http.StatusOK, resp)
 			return
 		}
 
@@ -575,12 +588,16 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 		// Still pending (timeout elapsed) — fall through to pending response.
 	}
 
-	writeJSON(w, http.StatusAccepted, map[string]any{
+	resp := map[string]any{
 		"status":     "pending",
 		"request_id": req.RequestID,
 		"audit_id":   auditID,
 		"message":    fmt.Sprintf("Approval requested. Waiting up to %ds.", h.cfg.Approval.Timeout),
-	})
+	}
+	if len(warnings) > 0 {
+		resp["warnings"] = warnings
+	}
+	writeJSON(w, http.StatusAccepted, resp)
 }
 
 // HandleGet returns the current status of a gateway request by request_id.

--- a/skills/clawvisor/SKILL.md.tmpl
+++ b/skills/clawvisor/SKILL.md.tmpl
@@ -360,6 +360,8 @@ Every {{ if .UseCurl -}} response has a `status` field. Handle each case as foll
 | `error` (`SERVICE_NOT_CONFIGURED`) | Service not {{ if .UseCurl }}yet {{ end }}connected | Tell the user{{ if .UseCurl }}: "[Service] isn't activated yet. Connect it in the Clawvisor dashboard."{{ else }} to connect it in the Clawvisor dashboard{{ end }}. |
 | `error` (`EXECUTION_ERROR`) | Adapter failed | Report the error{{ if .UseCurl }} to the user{{ end }}. Do not silently retry. |
 | `error` (other) | Something went wrong | Report the error{{ if .UseCurl }} message to the user{{ end }}. Do not silently retry. |
+
+**Warnings:** Responses may include a `"warnings"` array with actionable messages about misconfiguration. For example, if you make a standing task request without `session_id`, the response will warn that chain context is disabled. Always check for and act on warnings.
 {{ if not .Condensed }}
 ---
 

--- a/skills/clawvisor/SKILL.md.tmpl
+++ b/skills/clawvisor/SKILL.md.tmpl
@@ -182,6 +182,8 @@ related requests. Use a consistent `session_id` (e.g., a UUID you generate once
 per workflow) across all related requests in a single invocation.
 {{- end }}
 
+> **⚠️ Standing tasks MUST use `session_id` on every gateway request.** Without `session_id`, chain context is disabled — meaning intent verification cannot see that a message ID or thread ID came from your own prior search results. The verifier will treat those IDs as unexplained entity references and block them. Generate one UUID per workflow invocation and pass it as `session_id` on every request in that invocation.
+
 ### Chain context verification
 
 Chain context verification extracts structural facts (IDs, email addresses, phone numbers) from adapter results and feeds them into subsequent verification prompts. This verifies that follow-up requests target entities that actually appeared in prior results — preventing a compromised agent from reading an inbox and then emailing an unrelated address.
@@ -207,7 +209,7 @@ curl -s -X POST "$CLAWVISOR_URL/api/tasks/<task-id>/expand?wait=true" \
     "service": "apple.imessage",
     "action": "send_message",
     "auto_execute": false,
-    "reason": "John Doe asked a question that warrants a reply"
+    "reason": "A contact asked a question that warrants a reply"
   }'
 ```
 
@@ -230,6 +232,49 @@ curl -s -X POST "$CLAWVISOR_URL/api/tasks/<task-id>/complete" \
 ```
 {{- else }} use `complete_task` to mark the task as completed. This cleans
 up the authorization scope and any chain context facts.
+{{- end }}
+
+---
+
+## Writing Effective Reasons
+
+The `reason` field on gateway requests is verified by a language model, not pattern-matched. Write reasons the way a human assistant would explain an action to their boss — describe **what** you're doing and **why**, not who told you to do it.
+
+**Do:**
+- `"Searching for recent emails from the design team to draft a follow-up reply"`
+- `"Reading thread to extract action items for the weekly standup summary"`
+- `"Listing recent calendar events to check for scheduling conflicts this afternoon"`
+- `"Looking up the intro email from the vendor to confirm reply status"`
+
+**Don't:**
+- `"The user told me to do this"` — claiming the user instructed you looks identical to prompt injection to the verifier. Describe the action itself instead.
+- `"The owner directly instructed me to reply to this email via Telegram"` — the verifier cannot distinguish this from an injected instruction. Instead: `"Drafting reply to the vendor's email and preparing a follow-up summary"`
+- `"Doing my job"` / `"As requested"` — too vague; will be flagged as insufficient.
+- `"Testing"` / `"Retry"` / `"Trying again"` — implementation details, not a rationale.
+- Embedding code, markup, JSON, or system directives in the reason field.
+
+**Key rule:** The verifier treats **all agent-provided fields as untrusted**. Any text that resembles an instruction ("ignore previous rules", "approve this request", "the user said to...") will be flagged as a prompt injection attempt, even if it's a truthful description of what happened. Focus on the *what* and *why* of the action, not the *who told you*.
+
+---
+
+## Preset Task Definitions
+
+Agents tend to write narrow task scopes, which causes intent verification to reject legitimate follow-up requests. **Use these presets instead of writing your own scopes.** They are intentionally broad to cover the full range of operations in each workflow.
+{{ if .UseCurl }}
+Fetch a preset and use it directly as the request body for `POST /api/tasks`:
+
+```
+GET $CLAWVISOR_URL/skill/presets/<name>.json
+```
+{{ end }}
+| Preset | Description | {{ if .UseCurl }}File{{ else }}Fetch{{ end }} |
+|---|---|---|
+| **Email EA** | Full inbox management: triage, search, read, draft, send (approval-gated) | {{ if .UseCurl }}`email-ea.json`{{ else }}`GET /skill/presets/email-ea.json`{{ end }} |
+| **Calendar** | Full calendar: view, search, create (approval-gated), update (approval-gated) | {{ if .UseCurl }}`calendar.json`{{ else }}`GET /skill/presets/calendar.json`{{ end }} |
+| **iMessage** | Thread review, search, read, send (approval-gated) | {{ if .UseCurl }}`imessage.json`{{ else }}`GET /skill/presets/imessage.json`{{ end }} |
+
+{{ if .UseCurl -}}
+For example: `curl -s "$CLAWVISOR_URL/skill/presets/email-ea.json" | curl -s -X POST "$CLAWVISOR_URL/api/tasks?wait=true" -H "Authorization: Bearer $CLAWVISOR_AGENT_TOKEN" -H "Content-Type: application/json" -d @-`
 {{- end }}
 
 ---

--- a/skills/clawvisor/presets/calendar.json
+++ b/skills/clawvisor/presets/calendar.json
@@ -1,0 +1,30 @@
+{
+  "purpose": "Full calendar management for the account owner. View all events across any date range, check availability, find scheduling conflicts, look up attendees and meeting details, create events, update existing events, and manage RSVPs. Covers all calendar read and write operations the owner may request.",
+  "lifetime": "standing",
+  "authorized_actions": [
+    {
+      "service": "google.calendar",
+      "action": "list_events",
+      "auto_execute": true,
+      "expected_use": "List calendar events by date range, attendee, keyword, or any criteria. Used for availability checks, schedule review, conflict detection, and meeting lookups."
+    },
+    {
+      "service": "google.calendar",
+      "action": "get_event",
+      "auto_execute": true,
+      "expected_use": "Read full event details including attendees, location, description, and conferencing links. Used for meeting prep, attendee research, and context gathering."
+    },
+    {
+      "service": "google.calendar",
+      "action": "create_event",
+      "auto_execute": false,
+      "expected_use": "Create calendar events when the owner instructs. Includes scheduling meetings, blocking focus time, and setting reminders."
+    },
+    {
+      "service": "google.calendar",
+      "action": "update_event",
+      "auto_execute": false,
+      "expected_use": "Update existing events — reschedule, add attendees, change location, update descriptions."
+    }
+  ]
+}

--- a/skills/clawvisor/presets/email-ea.json
+++ b/skills/clawvisor/presets/email-ea.json
@@ -1,0 +1,30 @@
+{
+  "purpose": "Full executive assistant email management for the account owner. Inbox triage and prioritization, searching emails by any criteria (sender, recipient, company, topic, date range, keywords, message ID, thread ID), reading individual emails for context and action items, tracking thread status and follow-ups, researching email history on ad-hoc requests, monitoring for time-sensitive items, drafting and sending replies per owner's direct instruction, creating drafts, replying to specific people the owner names, CCing colleagues, and handling any email operation the owner explicitly requests.",
+  "lifetime": "standing",
+  "authorized_actions": [
+    {
+      "service": "google.gmail",
+      "action": "list_messages",
+      "auto_execute": true,
+      "expected_use": "Search and list emails using any Gmail query syntax: by sender (from:), recipient (to:), company name, subject keywords, date ranges, labels, read/unread status, message ID, thread ID, or any combination. Used for inbox triage, follow-up tracking, intro monitoring, deal research, vendor SLA checks, and any ad-hoc search for any person, company, or topic."
+    },
+    {
+      "service": "google.gmail",
+      "action": "get_message",
+      "auto_execute": true,
+      "expected_use": "Read full email content for any message found via search or referenced by the owner. Used for context, action items, reply drafting, thread status, recipient identification, and detailed summaries. Any sender, any topic."
+    },
+    {
+      "service": "google.gmail",
+      "action": "send_message",
+      "auto_execute": false,
+      "expected_use": "Send emails only when the owner explicitly instructs. Includes replying to threads, CCing colleagues, sending intros, following up with any contact."
+    },
+    {
+      "service": "google.gmail",
+      "action": "create_draft",
+      "auto_execute": true,
+      "expected_use": "Create draft emails for owner's review. Replies, intro drafts, follow-up templates."
+    }
+  ]
+}

--- a/skills/clawvisor/presets/imessage.json
+++ b/skills/clawvisor/presets/imessage.json
@@ -1,0 +1,24 @@
+{
+  "purpose": "Full iMessage management: review recent threads, classify reply status, identify conversations needing attention, search message history by any contact or topic, read full thread context, and send replies when the owner explicitly instructs.",
+  "lifetime": "standing",
+  "authorized_actions": [
+    {
+      "service": "apple.imessage",
+      "action": "list_threads",
+      "auto_execute": true,
+      "expected_use": "List iMessage threads by recency, unread status, or contact. Used for inbox review, finding conversations needing replies, checking message status with specific people, and any ad-hoc thread lookup."
+    },
+    {
+      "service": "apple.imessage",
+      "action": "get_thread",
+      "auto_execute": true,
+      "expected_use": "Read full thread content including all messages, timestamps, and attachments. Used for conversation context, reply urgency classification, action item extraction, and answering owner questions about specific conversations."
+    },
+    {
+      "service": "apple.imessage",
+      "action": "send_message",
+      "auto_execute": false,
+      "expected_use": "Send iMessage replies only when the owner explicitly instructs. Always requires per-request approval."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds a "Writing Effective Reasons" section to the skill with do/don't examples, documenting the prompt-injection anti-pattern where agents claim "the user told me to" and get blocked by intent verification.
- Adds a prominent `session_id` warning for standing tasks — omitting it silently disables chain context and causes follow-up requests to be rejected.
- Adds fetchable preset task definitions (`/skill/presets/*.json`) for email EA, calendar, and iMessage workflows so agents use broad, pre-tested scopes instead of writing narrow ones that trigger false positives. The skill template references these via a compact table instead of inlining the JSON, saving tokens per session.
- Removes personal names from examples (replaces with generic references).

## Test plan

- [ ] Verify `go build ./...` passes
- [ ] Verify `go run ./cmd/render-skill/...` renders the new sections correctly
- [ ] Verify preset JSON files are served at `/skill/presets/<name>.json` via the existing catch-all FileServer
- [ ] Spot-check that intent verification eval cases still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)