### PR TITLE
fix: authenticate clawhub CLI before publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -105,5 +105,6 @@ jobs:
         env:
           CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
         run: |
+          npx clawhub auth login --token "$CLAWHUB_TOKEN" --no-browser
           VERSION=$(jq -r '."."' .release-please-manifest.json)
           npx clawhub publish "$GITHUB_WORKSPACE/dist/skill" --slug clawvisor --version "$VERSION"


### PR DESCRIPTION
## Summary

- Adds `clawhub auth login --token` step before `clawhub publish` in the release workflow
- Fixes "Not logged in" error — setting `CLAWHUB_TOKEN` as an env var isn't enough, the CLI requires an explicit auth call

## Test plan

- [ ] Merge and trigger a release with skill file changes, verify publish succeeds