### PR TITLE
Rename integrate to connect-agent and overhaul README setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,18 @@ Once setup completes, the daemon opens the web dashboard in your browser automat
 
 With Clawvisor running, connect your agent:
 
-- **Claude Code** — run `/clawvisor-setup` inside Claude Code, or follow [docs/INTEGRATE_CLAUDE_CODE.md](docs/INTEGRATE_CLAUDE_CODE.md)
-- **Claude Desktop (MCP)** — [docs/INTEGRATE_CLAUDE_COWORK.md](docs/INTEGRATE_CLAUDE_COWORK.md)
-- **OpenClaw** — [docs/INTEGRATE_OPENCLAW.md](docs/INTEGRATE_OPENCLAW.md)
-- **Any HTTP agent** — [docs/INTEGRATE_GENERIC.md](docs/INTEGRATE_GENERIC.md)
+```bash
+clawvisor connect-agent
+```
 
-Or point your agent at [docs/SETUP.md](docs/SETUP.md) — the setup guides are written as agent-executable instructions that walk you through everything interactively.
+This auto-detects installed agents (Claude Code, Claude Desktop) and walks you through connecting them. You can also target a specific agent directly:
+
+```bash
+clawvisor connect-agent claude-code      # install skill + env vars for Claude Code
+clawvisor connect-agent claude-desktop   # configure MCP for Claude Desktop
+```
+
+For manual setup or other agents, see the integration guides: [Claude Code](docs/INTEGRATE_CLAUDE_CODE.md) · [Claude Desktop (MCP)](docs/INTEGRATE_CLAUDE_COWORK.md) · [OpenClaw](docs/INTEGRATE_OPENCLAW.md) · [Any HTTP agent](docs/INTEGRATE_GENERIC.md)
 
 ### Alternative installs
 
@@ -461,7 +467,7 @@ Clawvisor exposes an MCP (Model Context Protocol) server at `/mcp` with OAuth 2.
 ### Directory layout
 
 ```
-cmd/clawvisor/main.go       — unified CLI (start, stop, status, setup, pair, dashboard, server, tui, agent, update, install, healthcheck)
+cmd/clawvisor/main.go       — unified CLI (start, stop, status, setup, connect-agent, services, pair, dashboard, server, tui, agent, update, install, healthcheck)
 cmd/cvis-e2e/               — E2E encryption test utility
 cmd/server/                 — standalone server entry point
 internal/

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </p>
 
 <p align="center">
-  <a href="#get-started">Get Started</a> · <a href="#agent-integration">Agent Integration</a> · <a href="#dashboard">Dashboard</a> · <a href="#daemon-mode">Daemon</a> · <a href="#supported-services">Services</a> · <a href="#security-model">Security</a>
+  <a href="#get-started">Get Started</a> · <a href="#cli-reference">CLI</a> · <a href="#agent-integration">Agent Integration</a> · <a href="#dashboard">Dashboard</a> · <a href="#supported-services">Services</a> · <a href="#security-model">Security</a>
 </p>
 
 ---
@@ -30,31 +30,31 @@ Approve a purpose, not a permission. Clawvisor enforces it on every request.
 
 ## Get Started
 
-The setup guides in [`docs/`](docs/SETUP.md) are written as agent-executable
-instructions — give the right one to your AI agent and it will walk you
-through setup and integration interactively.
+### Install (recommended)
 
-**Point your agent at [docs/SETUP.md](docs/SETUP.md)** to get started. It
-covers two steps:
+```bash
+curl -fsSL https://clawvisor.com/install.sh | sh
+```
 
-1. **Run Clawvisor** — locally with Go, with Docker, or on a remote server
-2. **Connect your agent** — Claude Code, Claude Desktop (MCP), OpenClaw, or any HTTP agent
+This downloads the latest binary, adds it to your PATH, and starts an interactive setup wizard that walks you through configuration — database, LLM provider for intent verification, Google OAuth, and more. No Go, Node, or Docker required.
 
-Or jump directly to the guide you need:
+Once setup completes, the daemon opens the web dashboard in your browser automatically.
 
-| Run Clawvisor | Connect your agent |
-|---|---|
-| [Local](docs/SETUP_LOCAL.md) — Go + SQLite, no Docker | [Claude Code](docs/INTEGRATE_CLAUDE_CODE.md) |
-| [Docker](docs/SETUP_DOCKER.md) — Docker Compose locally | [Claude Desktop](docs/INTEGRATE_CLAUDE_COWORK.md) (MCP) |
-| [Cloud](docs/SETUP_CLOUD.md) — remote server or container platform | [OpenClaw](docs/INTEGRATE_OPENCLAW.md) |
-| | [Generic agent](docs/INTEGRATE_GENERIC.md) |
+### Connect your agent
 
-For the complete agent API protocol, see
-[`skills/clawvisor/SKILL.md`](skills/clawvisor/SKILL.md).
+With Clawvisor running, connect your agent:
 
-### Manual quickstart
+- **Claude Code** — run `/clawvisor-setup` inside Claude Code, or follow [docs/INTEGRATE_CLAUDE_CODE.md](docs/INTEGRATE_CLAUDE_CODE.md)
+- **Claude Desktop (MCP)** — [docs/INTEGRATE_CLAUDE_COWORK.md](docs/INTEGRATE_CLAUDE_COWORK.md)
+- **OpenClaw** — [docs/INTEGRATE_OPENCLAW.md](docs/INTEGRATE_OPENCLAW.md)
+- **Any HTTP agent** — [docs/INTEGRATE_GENERIC.md](docs/INTEGRATE_GENERIC.md)
 
-If you prefer to set up without an agent:
+Or point your agent at [docs/SETUP.md](docs/SETUP.md) — the setup guides are written as agent-executable instructions that walk you through everything interactively.
+
+### Alternative installs
+
+<details>
+<summary>From source (Go + Node)</summary>
 
 ```bash
 git clone https://github.com/clawvisor/clawvisor.git
@@ -65,6 +65,94 @@ make tui      # terminal dashboard (separate terminal)
 ```
 
 `make setup` generates `config.yaml` and a `vault.key` (database, Google OAuth, intent verification). `make run` starts the server, creates an `admin@local` user, and opens the dashboard via a magic link. `make tui` auto-authenticates using the local session file.
+
+Requires Go 1.25+ and Node.js 18+. See [docs/SETUP_LOCAL.md](docs/SETUP_LOCAL.md) for details.
+
+</details>
+
+<details>
+<summary>Docker</summary>
+
+```bash
+git clone https://github.com/clawvisor/clawvisor.git
+cd clawvisor
+make up       # docker compose (app + postgres)
+```
+
+See [docs/SETUP_DOCKER.md](docs/SETUP_DOCKER.md) for details.
+
+</details>
+
+<details>
+<summary>Cloud / remote server</summary>
+
+See [docs/SETUP_CLOUD.md](docs/SETUP_CLOUD.md) for deploying to a VPS, container platform, or Cloud Run.
+
+</details>
+
+For the complete agent API protocol, see [`skills/clawvisor/SKILL.md`](skills/clawvisor/SKILL.md).
+
+## CLI Reference
+
+The `clawvisor` CLI is the primary interface for managing Clawvisor. Run `clawvisor install` on a fresh machine for a guided walkthrough that runs `setup`, `services`, `connect-agent`, and `dashboard` in sequence.
+
+### Setup & installation
+
+| Command | Description |
+|---|---|
+| `clawvisor install` | Guided first-run: configure, install as system service, start, connect services and agents, and open the dashboard. Use `--pair` to also pair a mobile device. |
+| `clawvisor setup` | Interactive configuration wizard — LLM provider, relay, telemetry. Run this to reconfigure an existing install. |
+| `clawvisor update` | Update to the latest release (or `--version <tag>` for a specific version). |
+| `clawvisor uninstall` | Remove the system service. |
+
+### Daemon lifecycle
+
+| Command | Description |
+|---|---|
+| `clawvisor start` | Start the daemon as a background service. Use `--foreground` to run in the foreground. |
+| `clawvisor stop` | Stop the running daemon. |
+| `clawvisor restart` | Restart the daemon. |
+| `clawvisor status` | Show whether the daemon is running. |
+
+### Services
+
+| Command | Description |
+|---|---|
+| `clawvisor services` | Interactive picker to connect downstream services (Gmail, GitHub, Slack, etc.). |
+| `clawvisor services list` | List available and connected services. Use `--json` for machine-readable output. |
+| `clawvisor services add [service]` | Connect a service by ID or name. Omit the argument for an interactive picker. |
+| `clawvisor services remove <service>` | Disconnect a service. |
+
+### Agent connection
+
+| Command | Description |
+|---|---|
+| `clawvisor connect-agent` | Auto-detect installed agents and walk through connecting them. |
+| `clawvisor connect-agent claude-code` | Install the `/clawvisor-setup` slash command and optionally add auto-approve rules. |
+| `clawvisor connect-agent claude-desktop` | Configure the MCP connection for Claude Desktop. |
+
+### Agent management
+
+| Command | Description |
+|---|---|
+| `clawvisor agent create <name>` | Create an agent and print its bearer token. Use `--with-callback-secret` to generate a callback signing secret, `--replace` to overwrite an existing agent. |
+| `clawvisor agent list` | List all agents. |
+| `clawvisor agent delete <name-or-id>` | Delete an agent. |
+
+### Dashboard & UI
+
+| Command | Description |
+|---|---|
+| `clawvisor dashboard` | Open the web dashboard in your browser. Use `--no-open` to print the URL only. |
+| `clawvisor tui` | Launch the terminal dashboard. Supports `--url` and `--token` overrides. |
+| `clawvisor pair` | Pair a mobile device via QR code. |
+
+### Other
+
+| Command | Description |
+|---|---|
+| `clawvisor server` | Start the API server directly (used internally by `start`). Use `--open` to open the magic link on startup. |
+| `clawvisor healthcheck` | Check if the server is ready — queries `/ready` on localhost. Used by Docker HEALTHCHECK. |
 
 ### Configuration
 
@@ -345,20 +433,7 @@ clawvisor tui
 
 ## Daemon Mode
 
-For persistent background operation, Clawvisor can run as a system service:
-
-```bash
-clawvisor start               # start as background service (--foreground to run in fg)
-clawvisor stop                # stop the daemon
-clawvisor restart             # restart the daemon
-clawvisor status              # check if running
-clawvisor install             # install as system service (launchd/systemd)
-clawvisor uninstall           # remove the system service
-clawvisor dashboard           # open the web dashboard (--no-open to print URL only)
-clawvisor pair                # pair a mobile device via QR code
-```
-
-On first run, the daemon runs an interactive setup wizard that generates `config.yaml`, creates the admin user, and optionally configures services and device pairing. Configuration and data are stored in `~/.clawvisor/`.
+The daemon runs Clawvisor as a persistent background service. See [CLI Reference](#cli-reference) for the full list of commands (`start`, `stop`, `status`, `install`, etc.). Configuration and data are stored in `~/.clawvisor/`.
 
 ### Remote access via relay
 

--- a/cmd/clawvisor/cmd_connect_agent.go
+++ b/cmd/clawvisor/cmd_connect_agent.go
@@ -6,12 +6,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var integrateCmd = &cobra.Command{
-	Use:   "integrate",
-	Short: "Set up agent integrations (Claude Code, Claude Desktop, etc.)",
-	Long:  "Auto-detect installed coding agents and walk through setting up\neach one to work with Clawvisor.",
+var connectAgentCmd = &cobra.Command{
+	Use:     "connect-agent",
+	Aliases: []string{"integrate"},
+	Short:   "Connect an agent to Clawvisor (Claude Code, Claude Desktop, etc.)",
+	Long:    "Auto-detect installed coding agents and walk through setting up\neach one to work with Clawvisor.",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		err := daemon.Integrate()
+		err := daemon.ConnectAgent()
 		if err == huh.ErrUserAborted {
 			return nil
 		}
@@ -20,12 +21,12 @@ var integrateCmd = &cobra.Command{
 	SilenceUsage: true,
 }
 
-var integrateClaudeCodeCmd = &cobra.Command{
+var connectAgentClaudeCodeCmd = &cobra.Command{
 	Use:   "claude-code",
-	Short: "Set up Claude Code integration",
+	Short: "Connect Claude Code to Clawvisor",
 	Long:  "Install the /clawvisor-setup slash command and optionally add\nauto-approve rules for Clawvisor curl requests.",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		err := daemon.IntegrateClaudeCode()
+		err := daemon.ConnectAgentClaudeCode()
 		if err == huh.ErrUserAborted {
 			return nil
 		}
@@ -34,18 +35,18 @@ var integrateClaudeCodeCmd = &cobra.Command{
 	SilenceUsage: true,
 }
 
-var integrateClaudeDesktopCmd = &cobra.Command{
+var connectAgentClaudeDesktopCmd = &cobra.Command{
 	Use:   "claude-desktop",
-	Short: "Set up Claude Desktop integration",
+	Short: "Connect Claude Desktop to Clawvisor",
 	Long:  "Configure the MCP connection for Claude Desktop and optionally\nrestart it to pick up the new config.",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		daemon.IntegrateClaudeDesktop()
+		daemon.ConnectAgentClaudeDesktop()
 		return nil
 	},
 	SilenceUsage: true,
 }
 
 func init() {
-	integrateCmd.AddCommand(integrateClaudeCodeCmd)
-	integrateCmd.AddCommand(integrateClaudeDesktopCmd)
+	connectAgentCmd.AddCommand(connectAgentClaudeCodeCmd)
+	connectAgentCmd.AddCommand(connectAgentClaudeDesktopCmd)
 }

--- a/cmd/clawvisor/cmd_daemon.go
+++ b/cmd/clawvisor/cmd_daemon.go
@@ -55,7 +55,7 @@ var statusCmd = &cobra.Command{
 
 var installCmd = &cobra.Command{
 	Use:   "install",
-	Short: "Guided setup: configure, install, start, connect services, and integrate agents",
+	Short: "Guided setup: configure, install, start, connect services and agents",
 	Long:  "Run the full guided setup flow: configure the daemon, install it as\na system service, start it, connect services, and set up agent\nintegrations. This is the recommended way to get started.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		pair, _ := cmd.Flags().GetBool("pair")

--- a/cmd/clawvisor/cmd_setup.go
+++ b/cmd/clawvisor/cmd_setup.go
@@ -9,7 +9,7 @@ import (
 var setupCmd = &cobra.Command{
 	Use:   "setup",
 	Short: "Configure the daemon (LLM, relay, telemetry)",
-	Long:  "Run the core configuration wizard to set up LLM provider, relay,\nand telemetry preferences. Use `clawvisor services` and\n`clawvisor integrate` to connect services and agents.",
+	Long:  "Run the core configuration wizard to set up LLM provider, relay,\nand telemetry preferences. Use `clawvisor services` and\n`clawvisor connect-agent` to connect agents.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		err := daemon.Setup()
 		if err == huh.ErrUserAborted {

--- a/cmd/clawvisor/main.go
+++ b/cmd/clawvisor/main.go
@@ -31,7 +31,7 @@ func init() {
 	rootCmd.AddCommand(healthcheckCmd)
 	rootCmd.AddCommand(agentCmd)
 	rootCmd.AddCommand(servicesCmd)
-	rootCmd.AddCommand(integrateCmd)
+	rootCmd.AddCommand(connectAgentCmd)
 	rootCmd.AddCommand(serverCmd)
 	rootCmd.AddCommand(tuiCmd)
 }

--- a/docs/INTEGRATE_CLAUDE_CODE.md
+++ b/docs/INTEGRATE_CLAUDE_CODE.md
@@ -68,13 +68,13 @@ Save the `token` value from the JSON output — it is shown only once.
 ## Step 3: Install the skill globally
 
 The skill is installed globally to `~/.claude/skills/clawvisor/SKILL.md` during
-`clawvisor setup` (or `clawvisor integrate`). Verify it's present:
+`clawvisor setup` (or `clawvisor connect-agent`). Verify it's present:
 
 ```bash
 ls ~/.claude/skills/clawvisor/SKILL.md
 ```
 
-If missing, re-run `clawvisor integrate` or copy it manually from the
+If missing, re-run `clawvisor connect-agent` or copy it manually from the
 Clawvisor repository:
 
 ```bash

--- a/docs/INTEGRATE_CLAUDE_CODE.md
+++ b/docs/INTEGRATE_CLAUDE_CODE.md
@@ -45,17 +45,13 @@ Do not proceed until Clawvisor is reachable.
 
 Check if the user already has a token. If they provide one, skip to Step 3.
 
-Otherwise, create one. Determine how Clawvisor is running:
-
-**If running locally (native):**
+Otherwise, create one:
 
 ```bash
-cd "$CLAWVISOR_REPO" && ./bin/clawvisor agent create claude-code --replace --json
+clawvisor agent create claude-code --replace --json
 ```
 
-**If running in Docker:**
-
-Create the agent inside the container:
+If running in Docker instead:
 
 ```bash
 docker exec clawvisor /clawvisor agent create claude-code --replace --json
@@ -74,13 +70,8 @@ The skill is installed globally to `~/.claude/skills/clawvisor/SKILL.md` during
 ls ~/.claude/skills/clawvisor/SKILL.md
 ```
 
-If missing, re-run `clawvisor connect-agent` or copy it manually from the
-Clawvisor repository:
-
-```bash
-mkdir -p ~/.claude/skills/clawvisor
-cp "$CLAWVISOR_REPO/skills/clawvisor/SKILL.md" ~/.claude/skills/clawvisor/SKILL.md
-```
+If missing, re-run `clawvisor connect-agent claude-code` to install it
+automatically.
 
 The YAML frontmatter must be preserved — Claude Code uses it to recognize the
 skill name, description, and required environment variables.

--- a/docs/INTEGRATE_CLAUDE_COWORK.md
+++ b/docs/INTEGRATE_CLAUDE_COWORK.md
@@ -11,6 +11,19 @@ see [SETUP.md](SETUP.md).
 
 ---
 
+## Quick Setup
+
+The fastest way to connect Claude Desktop is:
+
+```bash
+clawvisor connect-agent claude-desktop
+```
+
+This configures the MCP connection automatically. If you prefer manual setup
+or the command isn't available, follow the steps below.
+
+---
+
 ## Goal State
 
 When setup is complete, the user should have:

--- a/docs/INTEGRATE_GENERIC.md
+++ b/docs/INTEGRATE_GENERIC.md
@@ -35,21 +35,17 @@ user has a remote instance, get the URL and verify with
 
 ## Step 2: Create an agent token
 
-Choose the method that matches how Clawvisor is running:
-
-**CLI (local native):**
-
 ```bash
-./bin/clawvisor agent create my-agent --replace --json
+clawvisor agent create my-agent --replace --json
 ```
 
-**Docker:**
+If running in Docker instead:
 
 ```bash
 docker exec <APP_CONTAINER> /clawvisor agent create my-agent --replace --json
 ```
 
-**Dashboard:** Create an agent in the web UI under the **Agents** tab.
+Alternatively, create an agent in the web UI under the **Agents** tab.
 
 Save the `token` value from the output — it is shown only once.
 

--- a/docs/INTEGRATE_OPENCLAW.md
+++ b/docs/INTEGRATE_OPENCLAW.md
@@ -23,34 +23,7 @@ When setup is complete, the user should have:
 
 ---
 
-## Step 1: Locate the Clawvisor repository
-
-The webhook extension files are in the Clawvisor repository.
-
-Check if the current working directory is the Clawvisor repository:
-
-```bash
-ls extensions/clawvisor-webhook/ 2>/dev/null
-```
-
-If found, use the current directory as `$CLAWVISOR_REPO`.
-
-If not, search common locations:
-
-```bash
-ls -d ~/code/clawvisor 2>/dev/null \
-  || ls -d ~/clawvisor 2>/dev/null \
-  || ls -d ~/projects/clawvisor 2>/dev/null
-```
-
-Also check for alternate naming (`clawvisor-public`, `clawvisor-oss`). The key
-indicator is a directory containing `extensions/clawvisor-webhook/`.
-
-If not found, ask the user where the repository is checked out.
-
----
-
-## Step 2: Verify Clawvisor is running
+## Step 1: Verify Clawvisor is running
 
 ```bash
 curl -sf http://localhost:25297/ready 2>/dev/null && echo "RUNNING" || echo "NOT RUNNING"
@@ -63,30 +36,16 @@ Store the URL as `$CLAWVISOR_URL` (default `http://localhost:25297`).
 
 ---
 
-## Step 3: Create an agent
-
-Determine how Clawvisor is running:
-
-**If running in Docker:**
-
-Find the app container:
+## Step 2: Create an agent
 
 ```bash
-docker ps --format '{{.Names}}\t{{.Image}}' | grep -i clawvisor
+clawvisor agent create openclaw --with-callback-secret --replace --json
 ```
 
-Create the agent inside the container. Use `--replace` so this is safe to
-re-run:
+If running in Docker instead:
 
 ```bash
 docker exec <APP_CONTAINER> /clawvisor agent create openclaw \
-  --with-callback-secret --replace --json
-```
-
-**If running locally (native):**
-
-```bash
-cd "$CLAWVISOR_REPO" && ./bin/clawvisor agent create openclaw \
   --with-callback-secret --replace --json
 ```
 
@@ -95,7 +54,7 @@ This returns JSON with `token` and `callback_secret` fields. Save both values
 
 ---
 
-## Step 4: Find the OpenClaw instance
+## Step 3: Find the OpenClaw instance
 
 Look for a running OpenClaw container:
 
@@ -119,9 +78,9 @@ directory is.
 
 ---
 
-## Step 5: Install the clawvisor skill
+## Step 4: Install the clawvisor skill
 
-If you found an OpenClaw container in Step 4:
+If you found an OpenClaw container in Step 3:
 
 ```bash
 docker exec <OPENCLAW_CONTAINER> npx clawhub install clawvisor --force \
@@ -142,13 +101,20 @@ ls "$OPENCLAW_DIR/workspace/skills/clawvisor/SKILL.md" 2>/dev/null
 
 ---
 
-## Step 6: Install the webhook extension
+## Step 5: Install the webhook extension
 
-Copy the extension files from the Clawvisor repo into OpenClaw's extensions
-directory:
+Install the webhook extension from npm:
 
 ```bash
-EXT_SRC="$CLAWVISOR_REPO/extensions/clawvisor-webhook"
+EXT_DST="$OPENCLAW_DIR/extensions/clawvisor-webhook"
+mkdir -p "$EXT_DST"
+cd "$EXT_DST" && npm init -y && npm install clawvisor-webhook --production
+```
+
+If installing from the Clawvisor repository instead:
+
+```bash
+EXT_SRC="<clawvisor-repo>/extensions/clawvisor-webhook"
 EXT_DST="$OPENCLAW_DIR/extensions/clawvisor-webhook"
 mkdir -p "$EXT_DST"
 cp "$EXT_SRC/openclaw.plugin.json" "$EXT_SRC/index.ts" "$EXT_SRC/package.json" "$EXT_DST/"
@@ -158,11 +124,11 @@ cd "$EXT_DST" && npm install --production
 
 ---
 
-## Step 7: Enable the webhook plugin in openclaw.json
+## Step 6: Enable the webhook plugin in openclaw.json
 
 Read `$OPENCLAW_DIR/openclaw.json` and add (or update) the webhook plugin
 entry. The plugin reads its signing secret from the `CLAWVISOR_CALLBACK_SECRET`
-environment variable (set in Step 8 via `~/.openclaw/workspace/.env`), and uses
+environment variable (set in Step 7 via `~/.openclaw/workspace/.env`), and uses
 sensible defaults for `path` (`/clawvisor/callback`) and `gatewayWsUrl`
 (`ws://127.0.0.1:18789`), so typically only `enabled` is needed.
 
@@ -222,7 +188,7 @@ merge the plugin config, and write it back.
 
 ---
 
-## Step 8: Write environment variables
+## Step 7: Write environment variables
 
 Determine the correct Clawvisor URL for the OpenClaw process to reach:
 
@@ -246,13 +212,13 @@ grep -v '^CLAWVISOR_\|^OPENCLAW_HOOKS_URL=' "$OPENCLAW_DIR/workspace/.env" > /tm
 mv /tmp/openclaw-env.tmp "$OPENCLAW_DIR/workspace/.env" 2>/dev/null || true
 ```
 
-Then append the new values (from Step 3):
+Then append the new values (from Step 2):
 
 ```bash
 cat >> "$OPENCLAW_DIR/workspace/.env" <<EOF
 CLAWVISOR_URL=<determined URL>
-CLAWVISOR_AGENT_TOKEN=<token from Step 3>
-CLAWVISOR_CALLBACK_SECRET=<callback_secret from Step 3>
+CLAWVISOR_AGENT_TOKEN=<token from Step 2>
+CLAWVISOR_CALLBACK_SECRET=<callback_secret from Step 2>
 OPENCLAW_HOOKS_URL=<determined URL>
 EOF
 chmod 600 "$OPENCLAW_DIR/workspace/.env"
@@ -260,7 +226,7 @@ chmod 600 "$OPENCLAW_DIR/workspace/.env"
 
 ---
 
-## Step 9: Summary
+## Step 8: Summary
 
 Present the user with:
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -13,7 +13,8 @@ Ask the user: **"How would you like to run Clawvisor?"**
 
 | Option | Guide | When to recommend |
 |---|---|---|
-| **Local** | [SETUP_LOCAL.md](SETUP_LOCAL.md) | They have Go and Node installed, want the simplest native setup (SQLite, no Docker) |
+| **Install script (recommended)** | `curl -fsSL https://clawvisor.com/install.sh \| sh` | Quickest path — downloads the binary, runs interactive setup. No Go, Node, or Docker required. |
+| **Local (from source)** | [SETUP_LOCAL.md](SETUP_LOCAL.md) | They have Go and Node installed, want to build from source (SQLite, no Docker) |
 | **Docker** | [SETUP_DOCKER.md](SETUP_DOCKER.md) | They have Docker installed, don't want to install Go/Node on the host |
 | **Cloud** | [SETUP_CLOUD.md](SETUP_CLOUD.md) | They want to deploy to a remote server, VPS, or container platform |
 
@@ -33,12 +34,26 @@ is running and the user has dashboard access.
 
 ## Step 2: Connect an agent
 
-Ask the user: **"Which agent are you connecting to Clawvisor?"**
+The fastest way to connect an agent is:
+
+```bash
+clawvisor connect-agent
+```
+
+This auto-detects installed agents and walks through connecting them. You can
+also target a specific agent directly:
+
+```bash
+clawvisor connect-agent claude-code      # install skill + env vars for Claude Code
+clawvisor connect-agent claude-desktop   # configure MCP for Claude Desktop
+```
+
+For manual setup or other agents, ask the user: **"Which agent are you connecting to Clawvisor?"**
 
 | Option | Guide | When to recommend |
 |---|---|---|
-| **Claude Code** | [INTEGRATE_CLAUDE_CODE.md](INTEGRATE_CLAUDE_CODE.md) | They're using Claude Code and want to install the Clawvisor skill |
-| **Claude Desktop** | [INTEGRATE_CLAUDE_COWORK.md](INTEGRATE_CLAUDE_COWORK.md) | They're using Claude Desktop and want MCP integration |
+| **Claude Code** | [INTEGRATE_CLAUDE_CODE.md](INTEGRATE_CLAUDE_CODE.md) | Manual setup for Claude Code (skill install + env vars) |
+| **Claude Desktop** | [INTEGRATE_CLAUDE_COWORK.md](INTEGRATE_CLAUDE_COWORK.md) | Manual MCP integration for Claude Desktop |
 | **OpenClaw** | [INTEGRATE_OPENCLAW.md](INTEGRATE_OPENCLAW.md) | They're running OpenClaw and want webhook callbacks |
 | **Other / generic** | [INTEGRATE_GENERIC.md](INTEGRATE_GENERIC.md) | Any HTTP-capable agent — covers token creation and points to the API protocol |
 

--- a/internal/daemon/claude_code.go
+++ b/internal/daemon/claude_code.go
@@ -439,20 +439,20 @@ func offerClaudeDesktopSetup() {
 }
 
 // printClaudeCodeManualInstructions prints a short pointer to the
-// dedicated integrate subcommand.
+// dedicated connect-agent subcommand.
 func printClaudeCodeManualInstructions() {
 	fmt.Println()
 	fmt.Println(dim.Padding(0, 2).Render("  To set up Claude Code later, run:"))
-	fmt.Println(green.Padding(0, 2).Render("    clawvisor integrate claude-code"))
+	fmt.Println(green.Padding(0, 2).Render("    clawvisor connect-agent claude-code"))
 	fmt.Println()
 }
 
 // printClaudeDesktopManualInstructions prints a short pointer to the
-// dedicated integrate subcommand.
+// dedicated connect-agent subcommand.
 func printClaudeDesktopManualInstructions() {
 	fmt.Println()
 	fmt.Println(dim.Padding(0, 2).Render("  To set up Claude Desktop later, run:"))
-	fmt.Println(green.Padding(0, 2).Render("    clawvisor integrate claude-desktop"))
+	fmt.Println(green.Padding(0, 2).Render("    clawvisor connect-agent claude-desktop"))
 	fmt.Println()
 }
 

--- a/internal/daemon/connect_agent.go
+++ b/internal/daemon/connect_agent.go
@@ -6,10 +6,10 @@ import (
 	"github.com/charmbracelet/huh"
 )
 
-// Integrate auto-detects installed coding agents and walks the user through
+// ConnectAgent auto-detects installed coding agents and walks the user through
 // setting up each one. Agents that require a running daemon (e.g. Claude
 // Desktop MCP/OAuth) will fail gracefully if the daemon is not reachable.
-func Integrate() error {
+func ConnectAgent() error {
 	dataDir, err := ensureDataDir()
 	if err != nil {
 		return err
@@ -35,7 +35,7 @@ func Integrate() error {
 	fmt.Println()
 
 	if hasClaudeCode(agents) {
-		if err := IntegrateClaudeCode(); err != nil {
+		if err := ConnectAgentClaudeCode(); err != nil {
 			if err == huh.ErrUserAborted {
 				return nil
 			}
@@ -44,7 +44,7 @@ func Integrate() error {
 	}
 
 	if hasClaudeDesktop(agents) {
-		IntegrateClaudeDesktop()
+		ConnectAgentClaudeDesktop()
 		fmt.Println(dim.Padding(0, 4).Render("After authorizing Claude Desktop to connect with Clawvisor,"))
 		fmt.Println(dim.Padding(0, 4).Render("you can ask your agent to perform tasks using any configured service."))
 		fmt.Println()
@@ -56,10 +56,10 @@ func Integrate() error {
 	return nil
 }
 
-// IntegrateClaudeCode installs the /clawvisor-setup slash command for Claude
+// ConnectAgentClaudeCode installs the /clawvisor-setup slash command for Claude
 // Code and optionally adds auto-approve rules for curl requests. Does not
 // require a running daemon.
-func IntegrateClaudeCode() error {
+func ConnectAgentClaudeCode() error {
 	dataDir, err := ensureDataDir()
 	if err != nil {
 		return err
@@ -68,8 +68,8 @@ func IntegrateClaudeCode() error {
 	return offerClaudeCodeSetup(dataDir)
 }
 
-// IntegrateClaudeDesktop configures the MCP connection for Claude Desktop.
+// ConnectAgentClaudeDesktop configures the MCP connection for Claude Desktop.
 // Requires a running daemon for OAuth registration on restart.
-func IntegrateClaudeDesktop() {
+func ConnectAgentClaudeDesktop() {
 	offerClaudeDesktopSetup()
 }

--- a/internal/daemon/install.go
+++ b/internal/daemon/install.go
@@ -85,7 +85,7 @@ type InstallOptions struct {
 }
 
 // Install runs the guided end-to-end setup and installation flow:
-// setup → write system service → start daemon → connect services → integrate agents.
+// setup → write system service → start daemon → connect services → connect agents.
 // This is the primary entry point for `curl | sh` first-time installs.
 func Install(opts InstallOptions) error {
 	dataDir, err := ensureDataDir()
@@ -187,7 +187,7 @@ func Install(opts InstallOptions) error {
 		fmt.Println(green.Padding(0, 2).Render("✓ Install complete"))
 		fmt.Println(dim.Padding(0, 2).Render("  Once the daemon is running, use:"))
 		fmt.Println(dim.Padding(0, 2).Render("    clawvisor services    — connect services"))
-		fmt.Println(dim.Padding(0, 2).Render("    clawvisor integrate   — set up agent integrations"))
+		fmt.Println(dim.Padding(0, 2).Render("    clawvisor connect-agent — connect agents"))
 		fmt.Println()
 		return nil
 	}
@@ -197,9 +197,9 @@ func Install(opts InstallOptions) error {
 		fmt.Println(dim.Padding(0, 2).Render("  Service setup skipped. Run `clawvisor services` later."))
 	}
 
-	// Step 5: Integrate agents (auto-detect + walk through).
-	if err := Integrate(); err != nil && err != huh.ErrUserAborted {
-		fmt.Println(dim.Padding(0, 2).Render("  Agent integration skipped. Run `clawvisor integrate` later."))
+	// Step 5: Connect agents (auto-detect + walk through).
+	if err := ConnectAgent(); err != nil && err != huh.ErrUserAborted {
+		fmt.Println(dim.Padding(0, 2).Render("  Agent setup skipped. Run `clawvisor connect-agent` later."))
 	}
 
 	// Step 6: Optional pairing.

--- a/internal/daemon/run.go
+++ b/internal/daemon/run.go
@@ -43,7 +43,7 @@ func Run(opts RunOptions) error {
 		fmt.Println()
 		fmt.Println(dim.Padding(0, 2).Render("Tip: connect services and agents after the daemon starts:"))
 		fmt.Println(dim.Padding(0, 2).Render("  clawvisor services    — connect GitHub, Gmail, Slack, etc."))
-		fmt.Println(dim.Padding(0, 2).Render("  clawvisor integrate   — set up Claude Code, Claude Desktop, etc."))
+		fmt.Println(dim.Padding(0, 2).Render("  clawvisor connect-agent — connect Claude Code, Claude Desktop, etc."))
 		fmt.Println()
 	}
 
@@ -166,7 +166,7 @@ func ensureSetup(dataDir string) (firstRun bool, err error) {
 
 // Setup explicitly re-runs the core daemon config wizard (LLM, relay,
 // telemetry). If a config already exists, the user is asked whether to
-// overwrite it. Use `clawvisor services` and `clawvisor integrate` to
+// overwrite it. Use `clawvisor services` and `clawvisor connect-agent` to
 // connect services and agents separately.
 func Setup() error {
 	dataDir, err := ensureDataDir()
@@ -203,7 +203,7 @@ func Setup() error {
 	fmt.Println(dim.Padding(0, 2).Render("Next steps:"))
 	fmt.Println(dim.Padding(0, 2).Render("  clawvisor install     — install and start the daemon"))
 	fmt.Println(dim.Padding(0, 2).Render("  clawvisor services    — connect services"))
-	fmt.Println(dim.Padding(0, 2).Render("  clawvisor integrate   — set up agent integrations"))
+	fmt.Println(dim.Padding(0, 2).Render("  clawvisor connect-agent — connect agents"))
 	fmt.Println()
 	return nil
 }


### PR DESCRIPTION
Renames the `clawvisor integrate` CLI command to `clawvisor connect-agent` with `integrate` preserved as a backward-compatible alias. Overhauls the README with a streamlined curl one-liner install, collapsible alternative install guides, and a comprehensive CLI reference table organized by category.