### PR TITLE
fix: use absolute URL for YAML spec in generate-integration skill

### DIFF
--- a/skills/clawvisor-generate-integration.md
+++ b/skills/clawvisor-generate-integration.md
@@ -6,7 +6,7 @@ You are generating a Clawvisor integration definition. Follow these steps:
 
 ### Step 1: Read the YAML specification
 
-Read `docs/INTEGRATION_YAML_SPEC.md` in this repository. This is your authoritative reference for the YAML format, field types, and conventions.
+Fetch and read `https://raw.githubusercontent.com/clawvisor/clawvisor/main/docs/INTEGRATION_YAML_SPEC.md`. This is your authoritative reference for the YAML format, field types, and conventions.
 
 ### Step 2: Find and read the official API reference
 


### PR DESCRIPTION
## Summary
- Replaces the relative path `docs/INTEGRATION_YAML_SPEC.md` with the absolute raw GitHub URL in the `clawvisor-generate-integration` skill
- The skill gets installed to `~/.claude/commands/` and runs from the user's project directory, so the relative path never resolves

## Test plan
- [ ] Run `/clawvisor-generate-integration <service>` and verify it successfully fetches and reads the YAML spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)