### PR TITLE
fix: add service:account usage hint to catalog overview

### DIFF
--- a/internal/api/handlers/skill.go
+++ b/internal/api/handlers/skill.go
@@ -166,6 +166,7 @@ func (h *SkillHandler) writeCatalogOverview(buf *strings.Builder, ctx context.Co
 	}
 
 	buf.WriteString("_For detailed parameter docs, fetch `?service=<service_id>`._\n\n")
+	buf.WriteString("**Important:** When invoking any service, use the full `service:account` identifier (e.g. `google.gmail:personal`) as the `service` value in requests. Using just the service name (e.g. `google.gmail`) will fail if every entry has an account suffix.\n\n")
 
 	for _, entry := range entries {
 		buf.WriteString(fmt.Sprintf("## %s\n", entry.baseID))


### PR DESCRIPTION
## Summary
- Adds a prominent note at the top of the skill catalog instructing agents to use the full `service:account` identifier (e.g. `google.gmail:personal`) as the `service` value in requests
- Some agents were using just the service name and failing when no default account existed

## Test plan
- [ ] Verify catalog endpoint returns the new hint text
- [ ] Confirm agents use full `service:account` identifiers after seeing the updated catalog

🤖 Generated with [Claude Code](https://claude.com/claude-code)