### PR TITLE
feat: user-configurable variables in adapter YAML specs

### DIFF
--- a/cmd/clawvisor/cmd_validate.go
+++ b/cmd/clawvisor/cmd_validate.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/clawvisor/clawvisor/pkg/adapters/yamlloader"
+	"github.com/clawvisor/clawvisor/pkg/adapters/yamlvalidate"
+)
+
+var validateCmd = &cobra.Command{
+	Use:   "validate [file.yaml ...]",
+	Short: "Validate adapter YAML definitions",
+	Long: `Validate one or more adapter YAML files for structural correctness.
+
+If no files are specified, validates all .yaml files in ~/.clawvisor/adapters/.`,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		files, err := resolveValidateFiles(args)
+		if err != nil {
+			return err
+		}
+		if len(files) == 0 {
+			fmt.Println("No adapter YAML files found.")
+			return nil
+		}
+
+		hasErrors := false
+		for _, path := range files {
+			def, err := yamlloader.LoadFile(path)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "\033[31m✗\033[0m %s\n  parse error: %v\n\n", path, err)
+				hasErrors = true
+				continue
+			}
+
+			result := yamlvalidate.Validate(&def)
+			if result.OK() && len(result.Warnings) == 0 {
+				fmt.Printf("\033[32m✓\033[0m %s (%s)\n", path, def.Service.ID)
+				continue
+			}
+
+			if !result.OK() {
+				hasErrors = true
+				fmt.Fprintf(os.Stderr, "\033[31m✗\033[0m %s (%s)\n", path, def.Service.ID)
+				for _, e := range result.Errors {
+					fmt.Fprintf(os.Stderr, "  \033[31merror:\033[0m %s\n", e)
+				}
+			} else {
+				fmt.Printf("\033[33m⚠\033[0m %s (%s)\n", path, def.Service.ID)
+			}
+			for _, w := range result.Warnings {
+				fmt.Fprintf(os.Stderr, "  \033[33mwarn:\033[0m  %s\n", w)
+			}
+			fmt.Println()
+		}
+
+		if hasErrors {
+			return fmt.Errorf("validation failed")
+		}
+		return nil
+	},
+}
+
+// resolveValidateFiles returns the list of YAML files to validate.
+// If args are given, uses those paths directly.
+// Otherwise scans ~/.clawvisor/adapters/.
+func resolveValidateFiles(args []string) ([]string, error) {
+	if len(args) > 0 {
+		return args, nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("could not determine home directory: %w", err)
+	}
+	dir := filepath.Join(home, ".clawvisor", "adapters")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading %s: %w", dir, err)
+	}
+
+	var files []string
+	for _, entry := range entries {
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".yaml") {
+			files = append(files, filepath.Join(dir, entry.Name()))
+		}
+	}
+	return files, nil
+}

--- a/cmd/clawvisor/main.go
+++ b/cmd/clawvisor/main.go
@@ -34,6 +34,7 @@ func init() {
 	rootCmd.AddCommand(connectAgentCmd)
 	rootCmd.AddCommand(serverCmd)
 	rootCmd.AddCommand(tuiCmd)
+	rootCmd.AddCommand(validateCmd)
 }
 
 func main() {

--- a/docs/INTEGRATION_YAML_SPEC.md
+++ b/docs/INTEGRATION_YAML_SPEC.md
@@ -31,8 +31,15 @@ auth:
   oauth: ...        # Traditional OAuth2 (requires client secret)
 
 api:
-  base_url: <string>  # e.g. "https://api.github.com"
+  base_url: <string>  # e.g. "https://api.github.com" (supports {{.var.X}} interpolation)
   type: <"rest" | "graphql">
+
+variables:           # optional: user-configurable variables collected at activation time
+  <variable_name>:
+    display_name: <string>
+    description: <string>     # optional
+    required: <bool>          # optional, default false
+    default: <string>         # optional
 
 # Optional: natural-language guidance for the intent verification system.
 # Helps the verifier understand nuances of this service's actions.
@@ -173,6 +180,38 @@ auth:
 ```
 
 `extra_headers` still works with `type: none` for APIs that need non-auth headers.
+
+## Variables
+
+Variables let each user provide instance-specific values (like a base URL) at activation time. They are stored in the database and interpolated into fields like `base_url` at runtime using `{{.var.<name>}}` placeholders.
+
+```yaml
+variables:
+  instance_url:
+    display_name: "Instance URL"
+    description: "Your Atlassian Cloud URL (e.g. https://yourteam.atlassian.net)"
+    required: true
+  workspace_id:
+    display_name: "Workspace ID"
+    default: "default"
+```
+
+Reference variables in `base_url` (or any other field that supports interpolation):
+
+```yaml
+api:
+  base_url: "{{.var.instance_url}}"
+  type: rest
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `display_name` | string | Label shown to the user during activation |
+| `description` | string | Optional help text explaining what to enter |
+| `required` | bool | If true, activation fails without a value (unless `default` is set) |
+| `default` | string | Pre-filled default value; satisfies `required` if the user leaves it blank |
+
+Variables are collected in the TUI, daemon setup CLI, and web dashboard when the user connects the service. They are persisted per-user in a `service_configs` table, separate from credentials.
 
 ## Actions
 
@@ -366,8 +405,14 @@ auth:
   header_prefix: "Bearer "
 
 api:
-  base_url: "https://api.acme.com/v1"
+  base_url: "{{.var.instance_url}}/v1"
   type: rest
+
+variables:
+  instance_url:
+    display_name: "Instance URL"
+    description: "Your Acme instance (e.g. https://mycompany.acme.com)"
+    required: true
 
 actions:
   list_widgets:

--- a/internal/adaptergen/generator_test.go
+++ b/internal/adaptergen/generator_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/clawvisor/clawvisor/pkg/adapters"
+	"github.com/clawvisor/clawvisor/pkg/adapters/yamlvalidate"
 	"github.com/clawvisor/clawvisor/pkg/config"
 )
 
@@ -394,9 +395,9 @@ func TestValidate_ServiceIDFormat(t *testing.T) {
 		{".leading.dot", false},
 	}
 	for _, tc := range cases {
-		got := safeServiceIDPattern.MatchString(tc.id)
+		got := yamlvalidate.SafeServiceIDPattern.MatchString(tc.id)
 		if got != tc.valid {
-			t.Errorf("safeServiceIDPattern(%q): got %v, want %v", tc.id, got, tc.valid)
+			t.Errorf("yamlvalidate.SafeServiceIDPattern(%q): got %v, want %v", tc.id, got, tc.valid)
 		}
 	}
 }
@@ -437,18 +438,18 @@ actions:
 	foundCategory := false
 	foundSensitivity := false
 	for _, w := range warnings {
-		if strings.Contains(w, "risk category 'delete'") {
+		if strings.Contains(w, "risk category") && strings.Contains(w, "delete") {
 			foundCategory = true
 		}
-		if strings.Contains(w, "cannot have 'low' sensitivity") {
+		if strings.Contains(w, "sensitivity") && strings.Contains(w, "DELETE") {
 			foundSensitivity = true
 		}
 	}
 	if !foundCategory {
-		t.Error("expected warning about DELETE needing 'delete' category")
+		t.Errorf("expected warning about DELETE needing 'delete' category, got warnings: %v", warnings)
 	}
 	if !foundSensitivity {
-		t.Error("expected warning about DELETE not allowing 'low' sensitivity")
+		t.Errorf("expected warning about DELETE not allowing 'low' sensitivity, got warnings: %v", warnings)
 	}
 }
 

--- a/internal/adaptergen/validator.go
+++ b/internal/adaptergen/validator.go
@@ -2,91 +2,46 @@ package adaptergen
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 
 	"gopkg.in/yaml.v3"
 
 	"github.com/clawvisor/clawvisor/pkg/adapters/yamldef"
+	"github.com/clawvisor/clawvisor/pkg/adapters/yamlvalidate"
 )
-
-// safeServiceIDPattern matches only valid service IDs: lowercase alphanumeric
-// segments separated by dots (e.g. "jira", "google.gmail", "pagerduty").
-// No path separators, no "..", no whitespace.
-var safeServiceIDPattern = regexp.MustCompile(`^[a-z][a-z0-9]*(\.[a-z][a-z0-9]*)*$`)
-
-// validRiskCategories is the set of allowed risk categories.
-var validRiskCategories = map[string]bool{
-	"read": true, "write": true, "delete": true, "search": true,
-}
-
-// validSensitivities is the set of allowed sensitivity levels.
-var validSensitivities = map[string]bool{
-	"low": true, "medium": true, "high": true,
-}
-
-// validAuthTypes is the set of allowed authentication types.
-var validAuthTypes = map[string]bool{
-	"api_key": true, "oauth2": true, "basic": true, "none": true,
-}
-
-// validHTTPMethods is the set of allowed HTTP methods.
-var validHTTPMethods = map[string]bool{
-	"GET": true, "POST": true, "PUT": true, "PATCH": true, "DELETE": true,
-}
-
-// validateResult holds both hard errors (service-level) and soft warnings (dropped actions).
-type validateResult struct {
-	Errors   []string // fatal — prevent installation
-	Warnings []string // informational — incomplete actions that were dropped
-}
 
 // validate checks a parsed ServiceDef for structural correctness and risk sanity.
 // Incomplete actions (e.g. from LLM output truncation) are removed from the def
 // and reported as warnings rather than blocking the entire generation.
-func validate(def *yamldef.ServiceDef) validateResult {
-	var result validateResult
+func validate(def *yamldef.ServiceDef) yamlvalidate.Result {
+	// Run the shared validator first (non-mutating).
+	result := yamlvalidate.Validate(def)
 
-	// Service metadata.
-	if def.Service.ID == "" {
-		result.Errors = append(result.Errors, "service.id is required")
-	} else if !safeServiceIDPattern.MatchString(def.Service.ID) {
-		result.Errors = append(result.Errors, fmt.Sprintf("service.id %q contains invalid characters (must be lowercase alphanumeric segments separated by dots)", def.Service.ID))
-	}
-	if def.Service.DisplayName == "" {
-		result.Errors = append(result.Errors, "service.display_name is required")
-	}
-
-	// Auth type.
-	if def.Auth.Type != "" && !validAuthTypes[def.Auth.Type] {
-		result.Errors = append(result.Errors, fmt.Sprintf("invalid auth type: %q", def.Auth.Type))
-	}
-
-	// If the LLM set oauth2 but didn't include any flow config, the user will
-	// be prompted for an API key with no way to do OAuth. Warn about this.
+	// LLM-specific: downgrade oauth2 → api_key when no flow is configured.
 	if def.Auth.Type == "oauth2" && def.Auth.OAuth == nil && def.Auth.DeviceFlow == nil && def.Auth.PKCEFlow == nil {
 		def.Auth.Type = "api_key"
 		result.Warnings = append(result.Warnings, "auth type downgraded from oauth2 to api_key — no OAuth flow was configured (missing pkce_flow/device_flow section with scopes and URLs)")
 	}
 
-	// API.
-	if def.API.BaseURL == "" {
-		result.Errors = append(result.Errors, "api.base_url is required")
-	}
-
-	// Validate each action — drop incomplete ones instead of failing.
-	if len(def.Actions) == 0 {
-		result.Errors = append(result.Errors, "at least one action is required")
-	}
-
-	for name, action := range def.Actions {
-		actionErrs := validateAction(name, action, def.API.Type)
-		if len(actionErrs) > 0 {
-			result.Warnings = append(result.Warnings,
-				fmt.Sprintf("dropped incomplete action %q: %s", name, strings.Join(actionErrs, "; ")))
-			delete(def.Actions, name)
+	// LLM-specific: drop incomplete actions instead of failing the whole def.
+	// Collect action-level errors from the shared validator and convert to warnings.
+	actionPrefix := "action "
+	var keptErrors []string
+	droppedActions := map[string]bool{}
+	for _, e := range result.Errors {
+		if strings.HasPrefix(e, actionPrefix) {
+			// Extract action name from 'action "foo": ...' format.
+			name := extractActionName(e)
+			if name != "" && !droppedActions[name] {
+				droppedActions[name] = true
+				delete(def.Actions, name)
+			}
+			result.Warnings = append(result.Warnings, "dropped incomplete "+e)
+		} else {
+			keptErrors = append(keptErrors, e)
 		}
 	}
+	result.Errors = keptErrors
 
 	// After dropping bad actions, we might have zero left.
 	if len(def.Actions) == 0 && len(result.Errors) == 0 {
@@ -96,47 +51,17 @@ func validate(def *yamldef.ServiceDef) validateResult {
 	return result
 }
 
-// validateAction checks a single action for completeness and returns any errors.
-func validateAction(name string, action yamldef.Action, apiType string) []string {
-	var errs []string
-
-	if action.DisplayName == "" {
-		errs = append(errs, "display_name is required")
+// extractActionName pulls the action name from an error string like `action "foo": some error`.
+func extractActionName(e string) string {
+	start := strings.Index(e, `"`)
+	if start < 0 {
+		return ""
 	}
-
-	// Risk validation.
-	if !validRiskCategories[action.Risk.Category] {
-		errs = append(errs, fmt.Sprintf("risk.category %q is invalid", action.Risk.Category))
+	end := strings.Index(e[start+1:], `"`)
+	if end < 0 {
+		return ""
 	}
-	if !validSensitivities[action.Risk.Sensitivity] {
-		errs = append(errs, fmt.Sprintf("risk.sensitivity %q is invalid", action.Risk.Sensitivity))
-	}
-
-	// Risk sanity checks.
-	if action.Method == "DELETE" && action.Risk.Category != "delete" {
-		errs = append(errs, fmt.Sprintf("DELETE method should have risk category 'delete', got %q", action.Risk.Category))
-	}
-	if action.Method == "DELETE" && action.Risk.Sensitivity == "low" {
-		errs = append(errs, "DELETE method cannot have 'low' sensitivity")
-	}
-	if (action.Method == "POST" || action.Method == "PUT" || action.Method == "PATCH") &&
-		action.Risk.Category == "read" {
-		errs = append(errs, fmt.Sprintf("%s method should not have risk category 'read'", action.Method))
-	}
-
-	// Method validation (REST only).
-	if apiType != "graphql" {
-		if action.Method == "" {
-			errs = append(errs, "method is required for REST actions")
-		} else if !validHTTPMethods[action.Method] {
-			errs = append(errs, fmt.Sprintf("method %q is invalid", action.Method))
-		}
-		if action.Path == "" {
-			errs = append(errs, "path is required for REST actions")
-		}
-	}
-
-	return errs
+	return e[start+1 : start+1+end]
 }
 
 // parseAndValidate parses raw YAML into a ServiceDef, validates it, drops

--- a/internal/adapters/google/calendar/adapter.go
+++ b/internal/adapters/google/calendar/adapter.go
@@ -67,7 +67,7 @@ func (a *CalendarAdapter) ValidateCredential(credBytes []byte) error {
 }
 
 // FetchIdentity returns the Google account email for auto-alias detection.
-func (a *CalendarAdapter) FetchIdentity(ctx context.Context, credBytes []byte) (string, error) {
+func (a *CalendarAdapter) FetchIdentity(ctx context.Context, credBytes []byte, _ map[string]string) (string, error) {
 	client, err := a.httpClient(ctx, credBytes)
 	if err != nil {
 		return "", err

--- a/internal/adapters/google/contacts/adapter.go
+++ b/internal/adapters/google/contacts/adapter.go
@@ -66,7 +66,7 @@ func (a *ContactsAdapter) ValidateCredential(credBytes []byte) error {
 }
 
 // FetchIdentity returns the Google account email for auto-alias detection.
-func (a *ContactsAdapter) FetchIdentity(ctx context.Context, credBytes []byte) (string, error) {
+func (a *ContactsAdapter) FetchIdentity(ctx context.Context, credBytes []byte, _ map[string]string) (string, error) {
 	client, err := a.httpClient(ctx, credBytes)
 	if err != nil {
 		return "", err

--- a/internal/adapters/google/drive/adapter.go
+++ b/internal/adapters/google/drive/adapter.go
@@ -67,7 +67,7 @@ func (a *DriveAdapter) ValidateCredential(credBytes []byte) error {
 }
 
 // FetchIdentity returns the Google account email for auto-alias detection.
-func (a *DriveAdapter) FetchIdentity(ctx context.Context, credBytes []byte) (string, error) {
+func (a *DriveAdapter) FetchIdentity(ctx context.Context, credBytes []byte, _ map[string]string) (string, error) {
 	client, err := a.httpClient(ctx, credBytes)
 	if err != nil {
 		return "", err

--- a/internal/adapters/google/gmail/adapter.go
+++ b/internal/adapters/google/gmail/adapter.go
@@ -88,7 +88,7 @@ func (a *GmailAdapter) ValidateCredential(credBytes []byte) error {
 }
 
 // FetchIdentity returns the Google account email for auto-alias detection.
-func (a *GmailAdapter) FetchIdentity(ctx context.Context, credBytes []byte) (string, error) {
+func (a *GmailAdapter) FetchIdentity(ctx context.Context, credBytes []byte, _ map[string]string) (string, error) {
 	client, err := a.httpClient(ctx, credBytes)
 	if err != nil {
 		return "", err

--- a/internal/api/handlers/approvals.go
+++ b/internal/api/handlers/approvals.go
@@ -252,7 +252,7 @@ func (h *ApprovalsHandler) executeApproval(ctx context.Context, pa *store.Pendin
 	vKey := h.adapterReg.VaultKeyWithAlias(serviceType, alias)
 
 	start := time.Now()
-	result, execErr := executeAdapterRequest(ctx, h.vault, h.adapterReg,
+	result, execErr := executeAdapterRequest(ctx, h.vault, h.adapterReg, h.st,
 		pa.UserID, blob.Service, blob.Action, blob.Params, vKey)
 	dur := int(time.Since(start).Milliseconds())
 

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -403,7 +403,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			}
 
 			vKey := h.adapterReg.VaultKeyWithAliasForUser(serviceType, serviceAlias, agent.UserID)
-			result, execErr := executeAdapterRequest(ctx, h.vault, h.adapterReg,
+			result, execErr := executeAdapterRequest(ctx, h.vault, h.adapterReg, h.store,
 				agent.UserID, serviceType, req.Action, req.Params, vKey)
 			dur := int(time.Since(start).Milliseconds())
 
@@ -747,7 +747,7 @@ func (h *GatewayHandler) executeAndRespond(w http.ResponseWriter, ctx context.Co
 	vKey := h.adapterReg.VaultKeyWithAliasForUser(serviceType, alias, pa.UserID)
 
 	start := time.Now()
-	result, execErr := executeAdapterRequest(ctx, h.vault, h.adapterReg,
+	result, execErr := executeAdapterRequest(ctx, h.vault, h.adapterReg, h.store,
 		pa.UserID, blob.Service, blob.Action, blob.Params, vKey)
 	dur := int(time.Since(start).Milliseconds())
 
@@ -1129,11 +1129,12 @@ func executeAdapterRequest(
 	ctx context.Context,
 	v vault.Vault,
 	reg *adapters.Registry,
+	st store.Store,
 	userID, service, action string,
 	params map[string]any,
 	vaultKey string,
 ) (*adapters.Result, error) {
-	serviceType, _ := parseServiceAlias(service)
+	serviceType, serviceAlias := parseServiceAlias(service)
 	adapter, ok := reg.GetForUser(ctx, serviceType, userID)
 	if !ok {
 		return nil, fmt.Errorf("service %q is not supported", serviceType)
@@ -1152,10 +1153,23 @@ func executeAdapterRequest(
 		}
 	}
 
+	// Fetch per-user service config (variable values) if stored.
+	var config map[string]string
+	if st != nil {
+		alias := serviceAlias
+		if alias == "" {
+			alias = "default"
+		}
+		if sc, err := st.GetServiceConfig(ctx, userID, serviceType, alias); err == nil {
+			_ = json.Unmarshal(sc.Config, &config)
+		}
+	}
+
 	result, err := adapter.Execute(ctx, adapters.Request{
 		Action:     action,
 		Params:     params,
 		Credential: cred,
+		Config:     config,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("adapter %s: %w", service, err)

--- a/internal/api/handlers/services.go
+++ b/internal/api/handlers/services.go
@@ -56,10 +56,11 @@ type ServicesHandler struct {
 type oauthStateEntry struct {
 	UserID       string
 	ServiceID    string
-	Alias        string   // "default" when not specified
-	PendingReqID string   // pending_request_id query param (may be empty)
-	CLICallback  string   // TUI local server callback URL (may be empty)
-	Scopes       []string // merged scopes for this OAuth flow
+	Alias        string            // "default" when not specified
+	PendingReqID string            // pending_request_id query param (may be empty)
+	CLICallback  string            // TUI local server callback URL (may be empty)
+	Scopes       []string          // merged scopes for this OAuth flow
+	Config       map[string]string // per-service variable values (may be nil)
 	ExpiresAt    time.Time
 }
 
@@ -156,10 +157,11 @@ func (h *ServicesHandler) List(w http.ResponseWriter, r *http.Request) {
 		AutoIdentity          bool          `json:"auto_identity,omitempty"`
 		RequiresActivation bool          `json:"requires_activation"`
 		CredentialFree     bool          `json:"credential_free"`
-		Actions            []actionEntry `json:"actions"`
-		Status             string        `json:"status"`
-		ActivatedAt        *time.Time    `json:"activated_at,omitempty"`
-		SetupURL           string        `json:"setup_url,omitempty"`
+		Actions            []actionEntry          `json:"actions"`
+		Variables          []adapters.VariableMeta `json:"variables,omitempty"`
+		Status             string                 `json:"status"`
+		ActivatedAt        *time.Time             `json:"activated_at,omitempty"`
+		SetupURL           string                 `json:"setup_url,omitempty"`
 	}
 
 	// buildEntry creates a serviceEntry from an adapter, using MetadataProvider when available.
@@ -167,6 +169,7 @@ func (h *ServicesHandler) List(w http.ResponseWriter, r *http.Request) {
 		name := display.ServiceName(a.ServiceID())
 		desc := display.ServiceDescription(a.ServiceID())
 		var setupURL, oauthEndpoint, iconSVG string
+		var variables []adapters.VariableMeta
 		actionNames := map[string]adapters.ActionMeta{}
 
 		if mp, ok := a.(adapters.MetadataProvider); ok {
@@ -181,6 +184,7 @@ func (h *ServicesHandler) List(w http.ResponseWriter, r *http.Request) {
 			iconSVG = meta.IconSVG
 			oauthEndpoint = meta.OAuthEndpoint
 			actionNames = meta.ActionMeta
+			variables = meta.Variables
 		}
 
 		actions := make([]actionEntry, 0, len(a.SupportedActions()))
@@ -225,6 +229,7 @@ func (h *ServicesHandler) List(w http.ResponseWriter, r *http.Request) {
 			AutoIdentity:          autoIdentity,
 			RequiresActivation:    true,
 			Actions:               actions,
+			Variables:             variables,
 			SetupURL:              setupURL,
 		}
 	}
@@ -381,6 +386,12 @@ func (h *ServicesHandler) OAuthGetURL(w http.ResponseWriter, r *http.Request) {
 		alias = "default"
 	}
 
+	// Parse optional config variables from query param.
+	var flowConfig map[string]string
+	if raw := r.URL.Query().Get("config"); raw != "" {
+		_ = json.Unmarshal([]byte(raw), &flowConfig)
+	}
+
 	stateToken := uuid.New().String()
 	h.oauthStates.Store(stateToken, oauthStateEntry{
 		UserID:       user.ID,
@@ -388,6 +399,7 @@ func (h *ServicesHandler) OAuthGetURL(w http.ResponseWriter, r *http.Request) {
 		Alias:        alias,
 		PendingReqID: r.URL.Query().Get("pending_request_id"),
 		CLICallback:  validateCLICallback(r.URL.Query().Get("cli_callback")),
+		Config:       flowConfig,
 		Scopes:       mergedScopes,
 		ExpiresAt:    time.Now().Add(10 * time.Minute),
 	})
@@ -440,12 +452,18 @@ func (h *ServicesHandler) OAuthStart(w http.ResponseWriter, r *http.Request) {
 
 	mergedScopes, _ := h.resolveOAuthScopes(r.Context(), user.ID, serviceID, alias, adapter)
 
+	var flowConfig map[string]string
+	if raw := r.URL.Query().Get("config"); raw != "" {
+		_ = json.Unmarshal([]byte(raw), &flowConfig)
+	}
+
 	stateToken := uuid.New().String()
 	h.oauthStates.Store(stateToken, oauthStateEntry{
 		UserID:       user.ID,
 		ServiceID:    serviceID,
 		Alias:        alias,
 		PendingReqID: r.URL.Query().Get("pending_request_id"),
+		Config:       flowConfig,
 		Scopes:       mergedScopes,
 		ExpiresAt:    time.Now().Add(10 * time.Minute),
 	})
@@ -524,7 +542,7 @@ func (h *ServicesHandler) OAuthCallback(w http.ResponseWriter, r *http.Request) 
 	}
 
 	// Auto-detect identity (e.g. email) before storing so the vault key is correct.
-	alias = h.resolveIdentityAlias(r.Context(), entry.ServiceID, alias, credBytes)
+	alias = h.resolveIdentityAlias(r.Context(), entry.ServiceID, alias, credBytes, entry.Config)
 
 	vKey := h.adapterReg.VaultKeyWithAlias(entry.ServiceID, alias)
 	if err := h.vault.Set(r.Context(), entry.UserID, vKey, credBytes); err != nil {
@@ -534,6 +552,13 @@ func (h *ServicesHandler) OAuthCallback(w http.ResponseWriter, r *http.Request) 
 	}
 
 	_ = h.st.UpsertServiceMeta(r.Context(), entry.UserID, entry.ServiceID, alias, time.Now())
+
+	// Store per-service config (variable values) if provided during OAuth flow start.
+	if len(entry.Config) > 0 {
+		configJSON, _ := json.Marshal(entry.Config)
+		_ = h.st.UpsertServiceConfig(r.Context(), entry.UserID, entry.ServiceID, alias, configJSON)
+	}
+
 	h.logger.Info("service activated", "user", entry.UserID, "service", entry.ServiceID, "alias", alias)
 
 	// Re-execute any pending request that was waiting for this activation.
@@ -613,8 +638,9 @@ func (h *ServicesHandler) Activate(w http.ResponseWriter, r *http.Request) {
 	if adapter.OAuthConfig() != nil {
 		// OAuth service: generate state token and return the consent URL as JSON.
 		var body struct {
-			PendingRequestID string `json:"pending_request_id"`
-			Alias            string `json:"alias"`
+			PendingRequestID string            `json:"pending_request_id"`
+			Alias            string            `json:"alias"`
+			Config           map[string]string `json:"config,omitempty"`
 		}
 		_ = json.NewDecoder(r.Body).Decode(&body) // body is optional
 		alias := body.Alias
@@ -642,6 +668,7 @@ func (h *ServicesHandler) Activate(w http.ResponseWriter, r *http.Request) {
 			ServiceID:    serviceID,
 			Alias:        alias,
 			PendingReqID: body.PendingRequestID,
+			Config:       body.Config,
 			Scopes:       mergedScopes,
 			ExpiresAt:    time.Now().Add(10 * time.Minute),
 		})
@@ -703,8 +730,9 @@ func (h *ServicesHandler) ActivateWithKey(w http.ResponseWriter, r *http.Request
 	}
 
 	var body struct {
-		Token string `json:"token"`
-		Alias string `json:"alias"`
+		Token  string            `json:"token"`
+		Alias  string            `json:"alias"`
+		Config map[string]string `json:"config,omitempty"`
 	}
 	if !decodeJSON(w, r, &body) {
 		return
@@ -734,7 +762,7 @@ func (h *ServicesHandler) ActivateWithKey(w http.ResponseWriter, r *http.Request
 	}
 
 	// Auto-detect identity (e.g. GitHub username) before storing.
-	alias = h.resolveIdentityAlias(r.Context(), serviceID, alias, credBytes)
+	alias = h.resolveIdentityAlias(r.Context(), serviceID, alias, credBytes, body.Config)
 
 	vKey := h.adapterReg.VaultKeyWithAlias(serviceID, alias)
 	if err := h.vault.Set(r.Context(), user.ID, vKey, credBytes); err != nil {
@@ -743,6 +771,13 @@ func (h *ServicesHandler) ActivateWithKey(w http.ResponseWriter, r *http.Request
 		return
 	}
 	_ = h.st.UpsertServiceMeta(r.Context(), user.ID, serviceID, alias, time.Now())
+
+	// Store per-service config (variable values) if provided.
+	if len(body.Config) > 0 {
+		configJSON, _ := json.Marshal(body.Config)
+		_ = h.st.UpsertServiceConfig(r.Context(), user.ID, serviceID, alias, configJSON)
+	}
+
 	h.logger.Info("service activated via api key", "user", user.ID, "service", serviceID, "alias", alias)
 
 	writeJSON(w, http.StatusOK, map[string]string{"status": "activated", "service": serviceID, "alias": alias})
@@ -779,8 +814,9 @@ func (h *ServicesHandler) Deactivate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Remove the service_meta record first.
+	// Remove the service_meta and service_config records first.
 	_ = h.st.DeleteServiceMeta(r.Context(), user.ID, serviceID, alias)
+	_ = h.st.DeleteServiceConfig(r.Context(), user.ID, serviceID, alias)
 
 	// Credential-free services have no vault credential to clean up.
 	adapter, ok := h.adapterReg.Get(serviceID)
@@ -915,7 +951,7 @@ func (h *ServicesHandler) RenameAlias(w http.ResponseWriter, r *http.Request) {
 // it fetches the identity and returns it as the new alias. On failure or if the
 // adapter doesn't support identity fetching, it returns the original alias unchanged.
 func (h *ServicesHandler) resolveIdentityAlias(
-	ctx context.Context, serviceID, currentAlias string, credBytes []byte,
+	ctx context.Context, serviceID, currentAlias string, credBytes []byte, config map[string]string,
 ) string {
 	if currentAlias != "default" {
 		return currentAlias // user explicitly chose an alias
@@ -931,7 +967,7 @@ func (h *ServicesHandler) resolveIdentityAlias(
 		return currentAlias
 	}
 
-	identity, err := fetcher.FetchIdentity(ctx, credBytes)
+	identity, err := fetcher.FetchIdentity(ctx, credBytes, config)
 	if err != nil || identity == "" {
 		if err != nil {
 			h.logger.Warn("identity fetch failed, using default alias",
@@ -967,7 +1003,7 @@ func (h *ServicesHandler) reactivatePendingRequest(ctx context.Context, userID, 
 
 	serviceType, alias := parseServiceAlias(blob.Service)
 	vKey := h.adapterReg.VaultKeyWithAlias(serviceType, alias)
-	result, execErr := executeAdapterRequest(ctx, h.vault, h.adapterReg,
+	result, execErr := executeAdapterRequest(ctx, h.vault, h.adapterReg, h.st,
 		userID, blob.Service, blob.Action, blob.Params, vKey)
 
 	outcome := "executed"
@@ -1123,6 +1159,7 @@ type deviceFlowEntry struct {
 	UserID     string
 	ServiceID  string
 	Alias      string
+	Config     map[string]string // per-service variable values (may be nil)
 	DeviceCode string
 	ClientID   string
 	TokenURL   string
@@ -1168,7 +1205,8 @@ func (h *ServicesHandler) DeviceFlowStart(w http.ResponseWriter, r *http.Request
 	}
 
 	var body struct {
-		Alias string `json:"alias"`
+		Alias  string            `json:"alias"`
+		Config map[string]string `json:"config,omitempty"`
 	}
 	_ = json.NewDecoder(r.Body).Decode(&body)
 	alias := body.Alias
@@ -1242,6 +1280,7 @@ func (h *ServicesHandler) DeviceFlowStart(w http.ResponseWriter, r *http.Request
 		UserID:     user.ID,
 		ServiceID:  serviceID,
 		Alias:      alias,
+		Config:     body.Config,
 		DeviceCode: dfResp.DeviceCode,
 		ClientID:   clientID,
 		TokenURL:   dfCfg.TokenURL,
@@ -1376,7 +1415,7 @@ func (h *ServicesHandler) DeviceFlowPoll(w http.ResponseWriter, r *http.Request)
 	}
 
 	// Auto-detect identity before storing.
-	alias := h.resolveIdentityAlias(r.Context(), entry.ServiceID, entry.Alias, credBytes)
+	alias := h.resolveIdentityAlias(r.Context(), entry.ServiceID, entry.Alias, credBytes, entry.Config)
 
 	vKey := h.adapterReg.VaultKeyWithAlias(entry.ServiceID, alias)
 	if err := h.vault.Set(r.Context(), entry.UserID, vKey, credBytes); err != nil {
@@ -1385,6 +1424,10 @@ func (h *ServicesHandler) DeviceFlowPoll(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	_ = h.st.UpsertServiceMeta(r.Context(), entry.UserID, entry.ServiceID, alias, time.Now())
+	if len(entry.Config) > 0 {
+		configJSON, _ := json.Marshal(entry.Config)
+		_ = h.st.UpsertServiceConfig(r.Context(), entry.UserID, entry.ServiceID, alias, configJSON)
+	}
 	h.deviceFlows.Delete(body.FlowID)
 
 	h.logger.Info("service activated via device flow", "user", entry.UserID, "service", entry.ServiceID, "alias", alias)
@@ -1397,6 +1440,7 @@ type pkceFlowEntry struct {
 	UserID       string
 	ServiceID    string
 	Alias        string
+	Config       map[string]string // per-service variable values (may be nil)
 	CodeVerifier string
 	CLICallback  string
 	TokenURL     string
@@ -1438,9 +1482,10 @@ func (h *ServicesHandler) PKCEFlowStart(w http.ResponseWriter, r *http.Request) 
 	}
 
 	var body struct {
-		Alias       string `json:"alias"`
-		CLICallback string `json:"cli_callback"`
-		ClientID    string `json:"client_id"`
+		Alias       string            `json:"alias"`
+		CLICallback string            `json:"cli_callback"`
+		ClientID    string            `json:"client_id"`
+		Config      map[string]string `json:"config,omitempty"`
 	}
 	_ = json.NewDecoder(r.Body).Decode(&body)
 	alias := body.Alias
@@ -1527,6 +1572,7 @@ func (h *ServicesHandler) PKCEFlowStart(w http.ResponseWriter, r *http.Request) 
 		UserID:       user.ID,
 		ServiceID:    serviceID,
 		Alias:        alias,
+		Config:       body.Config,
 		CodeVerifier: codeVerifier,
 		CLICallback:  validateCLICallback(body.CLICallback),
 		TokenURL:     pfCfg.TokenURL,
@@ -1644,7 +1690,7 @@ func (h *ServicesHandler) PKCEFlowCallback(w http.ResponseWriter, r *http.Reques
 	}
 
 	// Auto-detect identity before storing.
-	alias := h.resolveIdentityAlias(r.Context(), entry.ServiceID, entry.Alias, credBytes)
+	alias := h.resolveIdentityAlias(r.Context(), entry.ServiceID, entry.Alias, credBytes, entry.Config)
 
 	vKey := h.adapterReg.VaultKeyWithAlias(entry.ServiceID, alias)
 	if err := h.vault.Set(r.Context(), entry.UserID, vKey, credBytes); err != nil {
@@ -1653,6 +1699,10 @@ func (h *ServicesHandler) PKCEFlowCallback(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	_ = h.st.UpsertServiceMeta(r.Context(), entry.UserID, entry.ServiceID, alias, time.Now())
+	if len(entry.Config) > 0 {
+		configJSON, _ := json.Marshal(entry.Config)
+		_ = h.st.UpsertServiceConfig(r.Context(), entry.UserID, entry.ServiceID, alias, configJSON)
+	}
 
 	h.logger.Info("service activated via PKCE flow", "user", entry.UserID, "service", entry.ServiceID, "alias", alias)
 	oauthPopupClose(w, "", entry.CLICallback)

--- a/internal/daemon/services_setup.go
+++ b/internal/daemon/services_setup.go
@@ -185,6 +185,9 @@ func activateAPIKeyService(apiClient *client.Client, svc client.ServiceInfo) err
 		fmt.Println(dim.Padding(0, 2).Render(fmt.Sprintf("  Create an API key at: %s", svc.SetupURL)))
 	}
 
+	// Collect user-configurable variables (e.g. site URL) before the API key.
+	config := collectVariables(svc)
+
 	var token string
 	if err := huh.NewForm(
 		huh.NewGroup(
@@ -202,11 +205,42 @@ func activateAPIKeyService(apiClient *client.Client, svc client.ServiceInfo) err
 	}
 
 	fmt.Printf("\n  Connecting %s...\n", svc.Name)
-	if err := apiClient.ActivateWithKey(svc.ID, token, ""); err != nil {
+	if err := apiClient.ActivateWithKey(svc.ID, token, "", config); err != nil {
 		return err
 	}
 	fmt.Printf("  %s %s connected.\n\n", green.Render("✓"), svc.Name)
 	return nil
+}
+
+// collectVariables prompts the user for any required adapter variables.
+func collectVariables(svc client.ServiceInfo) map[string]string {
+	if len(svc.Variables) == 0 {
+		return nil
+	}
+	config := make(map[string]string, len(svc.Variables))
+	for _, v := range svc.Variables {
+		var val string
+		title := v.DisplayName
+		if title == "" {
+			title = v.Name
+		}
+		input := huh.NewInput().Title(title)
+		if v.Description != "" {
+			input = input.Description(v.Description)
+		}
+		if v.Default != "" {
+			val = v.Default
+		}
+		input = input.Value(&val)
+		if err := huh.NewForm(huh.NewGroup(input)).Run(); err != nil {
+			break
+		}
+		val = strings.TrimSpace(val)
+		if val != "" {
+			config[v.Name] = val
+		}
+	}
+	return config
 }
 
 // activateDeviceFlowOrAPIKey lets the user choose between device flow (browser)

--- a/internal/store/postgres/migrations/024_service_configs.sql
+++ b/internal/store/postgres/migrations/024_service_configs.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS service_configs (
+    id         TEXT PRIMARY KEY,
+    user_id    TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    service_id TEXT NOT NULL,
+    alias      TEXT NOT NULL DEFAULT 'default',
+    config     JSONB NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(user_id, service_id, alias)
+);

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -415,6 +415,50 @@ func (s *Store) CountServiceMetasByType(ctx context.Context, userID, serviceID s
 	return count, err
 }
 
+// ── Service Configs ──────────────────────────────────────────────────────────
+
+func (s *Store) UpsertServiceConfig(ctx context.Context, userID, serviceID, alias string, config json.RawMessage) error {
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO service_configs (id, user_id, service_id, alias, config)
+		VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (user_id, service_id, alias) DO UPDATE SET
+			config     = EXCLUDED.config,
+			updated_at = NOW()
+	`, uuid.New().String(), userID, serviceID, alias, config)
+	return err
+}
+
+func (s *Store) GetServiceConfig(ctx context.Context, userID, serviceID, alias string) (*store.ServiceConfig, error) {
+	sc := &store.ServiceConfig{}
+	var configJSON []byte
+	err := s.pool.QueryRow(ctx,
+		`SELECT id, user_id, service_id, alias, config, created_at, updated_at FROM service_configs WHERE user_id = $1 AND service_id = $2 AND alias = $3`,
+		userID, serviceID, alias,
+	).Scan(&sc.ID, &sc.UserID, &sc.ServiceID, &sc.Alias, &configJSON, &sc.CreatedAt, &sc.UpdatedAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, store.ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	sc.Config = json.RawMessage(configJSON)
+	return sc, nil
+}
+
+func (s *Store) DeleteServiceConfig(ctx context.Context, userID, serviceID, alias string) error {
+	res, err := s.pool.Exec(ctx,
+		`DELETE FROM service_configs WHERE user_id = $1 AND service_id = $2 AND alias = $3`,
+		userID, serviceID, alias,
+	)
+	if err != nil {
+		return err
+	}
+	if res.RowsAffected() == 0 {
+		return store.ErrNotFound
+	}
+	return nil
+}
+
 // ── Notification Configs ──────────────────────────────────────────────────────
 
 func (s *Store) UpsertNotificationConfig(ctx context.Context, userID, channel string, config json.RawMessage) error {

--- a/internal/store/sqlite/migrations/024_service_configs.sql
+++ b/internal/store/sqlite/migrations/024_service_configs.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS service_configs (
+    id         TEXT PRIMARY KEY,
+    user_id    TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    service_id TEXT NOT NULL,
+    alias      TEXT NOT NULL DEFAULT 'default',
+    config     TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(user_id, service_id, alias)
+);

--- a/internal/store/sqlite/store.go
+++ b/internal/store/sqlite/store.go
@@ -462,6 +462,53 @@ func (s *Store) CountServiceMetasByType(ctx context.Context, userID, serviceID s
 	return count, err
 }
 
+// ── Service Configs ──────────────────────────────────────────────────────────
+
+func (s *Store) UpsertServiceConfig(ctx context.Context, userID, serviceID, alias string, config json.RawMessage) error {
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO service_configs (id, user_id, service_id, alias, config)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT (user_id, service_id, alias) DO UPDATE SET
+			config     = excluded.config,
+			updated_at = CURRENT_TIMESTAMP
+	`, uuid.New().String(), userID, serviceID, alias, string(config))
+	return err
+}
+
+func (s *Store) GetServiceConfig(ctx context.Context, userID, serviceID, alias string) (*store.ServiceConfig, error) {
+	sc := &store.ServiceConfig{}
+	var configStr, createdAt, updatedAt string
+	err := s.db.QueryRowContext(ctx,
+		`SELECT id, user_id, service_id, alias, config, created_at, updated_at FROM service_configs WHERE user_id = ? AND service_id = ? AND alias = ?`,
+		userID, serviceID, alias,
+	).Scan(&sc.ID, &sc.UserID, &sc.ServiceID, &sc.Alias, &configStr, &createdAt, &updatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, store.ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	sc.Config = json.RawMessage(configStr)
+	sc.CreatedAt = parseTime(createdAt)
+	sc.UpdatedAt = parseTime(updatedAt)
+	return sc, nil
+}
+
+func (s *Store) DeleteServiceConfig(ctx context.Context, userID, serviceID, alias string) error {
+	res, err := s.db.ExecContext(ctx,
+		`DELETE FROM service_configs WHERE user_id = ? AND service_id = ? AND alias = ?`,
+		userID, serviceID, alias,
+	)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return store.ErrNotFound
+	}
+	return nil
+}
+
 // ── Notification Configs ──────────────────────────────────────────────────────
 
 func (s *Store) UpsertNotificationConfig(ctx context.Context, userID, channel string, config json.RawMessage) error {

--- a/internal/tui/client/client.go
+++ b/internal/tui/client/client.go
@@ -294,10 +294,13 @@ func (c *Client) GetOAuthURL(serviceID, alias, cliCallback string) (*OAuthURLRes
 }
 
 // ActivateWithKey activates a non-OAuth service using an API key / token.
-func (c *Client) ActivateWithKey(serviceID, token, alias string) error {
-	body := map[string]string{"token": token}
+func (c *Client) ActivateWithKey(serviceID, token, alias string, config map[string]string) error {
+	body := map[string]any{"token": token}
 	if alias != "" {
 		body["alias"] = alias
+	}
+	if len(config) > 0 {
+		body["config"] = config
 	}
 	var resp map[string]string
 	return c.post("/api/services/"+serviceID+"/activate-key", body, &resp)

--- a/internal/tui/client/types.go
+++ b/internal/tui/client/types.go
@@ -193,9 +193,19 @@ type ServiceInfo struct {
 	RequiresActivation bool              `json:"requires_activation"`
 	CredentialFree     bool              `json:"credential_free"`
 	Actions            json.RawMessage   `json:"actions"`
+	Variables          []VariableMeta    `json:"variables,omitempty"`
 	Status             string            `json:"status"` // "activated" or "not_activated"
 	ActivatedAt        string            `json:"activated_at,omitempty"`
 	SetupURL           string            `json:"setup_url,omitempty"`
+}
+
+// VariableMeta holds metadata for a user-configurable adapter variable.
+type VariableMeta struct {
+	Name        string `json:"name"`
+	DisplayName string `json:"display_name"`
+	Description string `json:"description,omitempty"`
+	Required    bool   `json:"required"`
+	Default     string `json:"default,omitempty"`
 }
 
 // DeviceFlowStartResponse is returned by DeviceFlowStart.

--- a/internal/tui/screens/services.go
+++ b/internal/tui/screens/services.go
@@ -67,6 +67,7 @@ const (
 	stepDeviceFlowWaiting  = 6
 	stepPKCEFlowChoice     = 7
 	stepPKCEFlowWaiting    = 8
+	stepVariables          = 9
 )
 
 // ── Model ───────────────────────────────────────────────────────────────────
@@ -86,7 +87,10 @@ type ServicesScreen struct {
 	inputStep         int
 	aliasInput        *textinput.Model
 	keyInput          *textinput.Model
+	varInputs         []textinput.Model // one per variable
+	varNames          []string          // variable names in order
 	pendingAlias      string
+	pendingConfig     map[string]string // collected variable values
 	pendingOAuthURL   string
 	activatingService *client.ServiceInfo
 
@@ -189,6 +193,45 @@ func (s *ServicesScreen) Update(msg tea.Msg) (tui.ScreenModel, tea.Cmd) {
 		var cmd tea.Cmd
 		*s.aliasInput, cmd = s.aliasInput.Update(msg)
 		return s, cmd
+	}
+
+	// Variable collection overlay.
+	if s.inputStep == stepVariables && len(s.varInputs) > 0 {
+		switch msg := msg.(type) {
+		case tea.KeyMsg:
+			switch msg.String() {
+			case "esc":
+				s.resetActivation()
+				return s, nil
+			case "tab", "enter":
+				// Find the focused input and advance to the next one.
+				for i := range s.varInputs {
+					if s.varInputs[i].Focused() {
+						s.varInputs[i].Blur()
+						if i+1 < len(s.varInputs) {
+							s.varInputs[i+1].Focus()
+							return s, nil
+						}
+						// Last variable — collect values and proceed.
+						s.pendingConfig = make(map[string]string, len(s.varInputs))
+						for j, name := range s.varNames {
+							if v := s.varInputs[j].Value(); v != "" {
+								s.pendingConfig[name] = v
+							}
+						}
+						return s, s.proceedAfterAlias()
+					}
+				}
+			}
+		}
+		for i := range s.varInputs {
+			if s.varInputs[i].Focused() {
+				var cmd tea.Cmd
+				s.varInputs[i], cmd = s.varInputs[i].Update(msg)
+				return s, cmd
+			}
+		}
+		return s, nil
 	}
 
 	// Key entry overlay.
@@ -516,6 +559,9 @@ func (s *ServicesScreen) View() string {
 	if s.inputStep == stepAlias && s.aliasInput != nil {
 		return s.viewAliasInput()
 	}
+	if s.inputStep == stepVariables && len(s.varInputs) > 0 {
+		return s.viewVariableInputs()
+	}
 	if s.inputStep == stepKeyEntry && s.keyInput != nil {
 		return s.viewKeyInput()
 	}
@@ -663,6 +709,34 @@ func (s *ServicesScreen) viewAliasInput() string {
 		tui.StyleDim.Render("Alias (leave blank for default):"),
 		"  "+s.aliasInput.View(),
 		tui.StyleDim.Render("[enter] Continue  [esc] Cancel"),
+	)
+	return tui.StyleOverlayBorder.Width(s.overlayWidth()).Render(content)
+}
+
+func (s *ServicesScreen) viewVariableInputs() string {
+	svcName := ""
+	if s.activatingService != nil {
+		svcName = s.activatingService.Name
+	}
+	title := lipgloss.NewStyle().
+		Foreground(tui.ColorBrand).
+		Bold(true).
+		Render("Configure " + svcName)
+
+	var lines []string
+	for i, v := range s.activatingService.Variables {
+		label := v.DisplayName
+		if label == "" {
+			label = v.Name
+		}
+		lines = append(lines, tui.StyleDim.Render(label+":"))
+		lines = append(lines, "  "+s.varInputs[i].View())
+	}
+
+	content := fmt.Sprintf("%s\n\n%s\n\n%s",
+		title,
+		strings.Join(lines, "\n"),
+		tui.StyleDim.Render("[tab] Next  [enter] Continue  [esc] Cancel"),
 	)
 	return tui.StyleOverlayBorder.Width(s.overlayWidth()).Render(content)
 }
@@ -869,6 +943,11 @@ func (s *ServicesScreen) proceedAfterAlias() tea.Cmd {
 		return nil
 	}
 
+	// If the service declares variables and we haven't collected them yet, do so now.
+	if len(svc.Variables) > 0 && s.pendingConfig == nil {
+		return s.startVariableCollection()
+	}
+
 	if svc.OAuth {
 		// Start local listener, then fetch OAuth URL.
 		port, done, cleanup := startOAuthListener()
@@ -908,16 +987,41 @@ func (s *ServicesScreen) proceedAfterAlias() tea.Cmd {
 	return nil
 }
 
+func (s *ServicesScreen) startVariableCollection() tea.Cmd {
+	svc := s.activatingService
+	s.inputStep = stepVariables
+	s.varNames = make([]string, 0, len(svc.Variables))
+	s.varInputs = make([]textinput.Model, 0, len(svc.Variables))
+	for _, v := range svc.Variables {
+		s.varNames = append(s.varNames, v.Name)
+		ti := textinput.New()
+		label := v.DisplayName
+		if label == "" {
+			label = v.Name
+		}
+		ti.Placeholder = label
+		if v.Default != "" {
+			ti.SetValue(v.Default)
+		}
+		s.varInputs = append(s.varInputs, ti)
+	}
+	if len(s.varInputs) > 0 {
+		s.varInputs[0].Focus()
+	}
+	return nil
+}
+
 func (s *ServicesScreen) activateWithKey(keyVal string) tea.Cmd {
 	svc := s.activatingService
 	if svc == nil {
 		return nil
 	}
 	alias := s.pendingAlias
+	cfg := s.pendingConfig
 	serviceID := svc.ID
 	cl := s.client
 	return func() tea.Msg {
-		err := cl.ActivateWithKey(serviceID, keyVal, alias)
+		err := cl.ActivateWithKey(serviceID, keyVal, alias, cfg)
 		return svcActivatedMsg{err: err}
 	}
 }
@@ -997,6 +1101,9 @@ func (s *ServicesScreen) resetActivation() {
 	s.aliasInput = nil
 	s.keyInput = nil
 	s.pendingAlias = ""
+	s.pendingConfig = nil
+	s.varInputs = nil
+	s.varNames = nil
 	s.pendingOAuthURL = ""
 	s.activatingService = nil
 	s.deviceFlowUserCode = ""

--- a/pkg/adapters/adapters.go
+++ b/pkg/adapters/adapters.go
@@ -32,6 +32,16 @@ type ServiceMetadata struct {
 	AutoIdentity        bool                  // whether the adapter can auto-detect account identity
 	ActionMeta        map[string]ActionMeta // action_id → metadata
 	VerificationHints string
+	Variables         []VariableMeta // user-configurable variables declared by the adapter
+}
+
+// VariableMeta holds metadata for a single user-configurable variable.
+type VariableMeta struct {
+	Name        string `json:"name"`
+	DisplayName string `json:"display_name"`
+	Description string `json:"description,omitempty"`
+	Required    bool   `json:"required"`
+	Default     string `json:"default,omitempty"`
 }
 
 // ActionMeta holds display and risk metadata for a single action.
@@ -104,7 +114,8 @@ const SystemVaultKeyPKCEPrefix = "pkce."
 type Request struct {
 	Action     string
 	Params     map[string]any
-	Credential []byte // decrypted from vault
+	Credential []byte            // decrypted from vault
+	Config     map[string]string // resolved variable values from service_configs
 }
 
 // Result is the semantic output of an adapter action.
@@ -157,7 +168,7 @@ type IdentityFetcher interface {
 	// FetchIdentity uses the stored credential to query the service for a
 	// human-readable account identifier (e.g. "levine.eric.j@gmail.com",
 	// "octocat"). Returns an empty string if identity cannot be determined.
-	FetchIdentity(ctx context.Context, credential []byte) (string, error)
+	FetchIdentity(ctx context.Context, credential []byte, config map[string]string) (string, error)
 }
 
 // Adapter is the interface every service adapter implements.

--- a/pkg/adapters/yamldef/schema.go
+++ b/pkg/adapters/yamldef/schema.go
@@ -3,11 +3,21 @@ package yamldef
 
 // ServiceDef is the top-level structure of a YAML adapter definition file.
 type ServiceDef struct {
-	Service           ServiceInfo       `yaml:"service"`
-	Auth              AuthDef           `yaml:"auth"`
-	API               APIDef            `yaml:"api"`
-	VerificationHints string            `yaml:"verification_hints,omitempty"`
-	Actions           map[string]Action `yaml:"actions"`
+	Service           ServiceInfo                `yaml:"service"`
+	Auth              AuthDef                    `yaml:"auth"`
+	API               APIDef                     `yaml:"api"`
+	Variables         map[string]VariableDef     `yaml:"variables,omitempty"`
+	VerificationHints string                     `yaml:"verification_hints,omitempty"`
+	Actions           map[string]Action          `yaml:"actions"`
+}
+
+// VariableDef defines a user-configurable variable that is collected during
+// service activation and interpolated into fields like base_url at runtime.
+type VariableDef struct {
+	DisplayName string `yaml:"display_name"`
+	Description string `yaml:"description,omitempty"`
+	Required    bool   `yaml:"required,omitempty"`
+	Default     string `yaml:"default,omitempty"`
 }
 
 // ServiceInfo contains display and identification metadata.

--- a/pkg/adapters/yamlloader/loader.go
+++ b/pkg/adapters/yamlloader/loader.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/clawvisor/clawvisor/pkg/adapters/yamldef"
 	"github.com/clawvisor/clawvisor/pkg/adapters/yamlruntime"
+	"github.com/clawvisor/clawvisor/pkg/adapters/yamlvalidate"
 )
 
 // UserAdapterSource loads user-generated adapter YAML definitions.
@@ -74,6 +75,14 @@ func (l *Loader) LoadAll() error {
 				l.logger.Warn("skipping embedded adapter definition", "file", entry.Name(), "err", err)
 				continue
 			}
+			if vr := yamlvalidate.Validate(&def); !vr.OK() {
+				l.logger.Warn("skipping embedded adapter definition: validation failed", "file", entry.Name(), "errors", vr.Errors)
+				continue
+			} else {
+				for _, w := range vr.Warnings {
+					l.logger.Warn("embedded adapter definition warning", "file", entry.Name(), "warning", w)
+				}
+			}
 			defs[def.Service.ID] = def
 			l.logger.Debug("loaded embedded adapter definition", "service", def.Service.ID)
 		}
@@ -90,6 +99,14 @@ func (l *Loader) LoadAll() error {
 				if err != nil {
 					l.logger.Warn("skipping user adapter definition", "service", serviceID, "err", err)
 					continue
+				}
+				if vr := yamlvalidate.Validate(&def); !vr.OK() {
+					l.logger.Warn("skipping user adapter definition: validation failed", "service", serviceID, "errors", vr.Errors)
+					continue
+				} else {
+					for _, w := range vr.Warnings {
+						l.logger.Warn("user adapter definition warning", "service", serviceID, "warning", w)
+					}
 				}
 				defs[def.Service.ID] = def
 				l.logger.Info("loaded user adapter definition (override)", "service", def.Service.ID)

--- a/pkg/adapters/yamlruntime/adapter.go
+++ b/pkg/adapters/yamlruntime/adapter.go
@@ -95,11 +95,17 @@ func (a *YAMLAdapter) Execute(ctx context.Context, req adapters.Request) (*adapt
 	// Get credential fields for path interpolation.
 	credFields, _ := credentialFields(a.def.Auth, req.Credential)
 
+	// Resolve variables in base_url.
+	baseURL, err := a.resolvedBaseURL(req.Config)
+	if err != nil {
+		return nil, err
+	}
+
 	switch a.def.API.Type {
 	case "rest":
-		return executeREST(ctx, client, a.def.API.BaseURL, action, req.Params, credFields, a.compiled[req.Action])
+		return executeREST(ctx, client, baseURL, action, req.Params, credFields, a.compiled[req.Action])
 	case "graphql":
-		return executeGraphQL(ctx, client, a.def.API.BaseURL, action, req.Params, a.def.Service.ID)
+		return executeGraphQL(ctx, client, baseURL, action, req.Params, a.def.Service.ID)
 	default:
 		return nil, fmt.Errorf("%s: unsupported API type %q", a.def.Service.ID, a.def.API.Type)
 	}
@@ -107,7 +113,7 @@ func (a *YAMLAdapter) Execute(ctx context.Context, req adapters.Request) (*adapt
 
 // FetchIdentity makes a request to the configured identity endpoint and
 // extracts the account identifier from the JSON response.
-func (a *YAMLAdapter) FetchIdentity(ctx context.Context, credBytes []byte) (string, error) {
+func (a *YAMLAdapter) FetchIdentity(ctx context.Context, credBytes []byte, config map[string]string) (string, error) {
 	idDef := a.def.Service.Identity
 	if idDef == nil {
 		return "", nil
@@ -118,9 +124,14 @@ func (a *YAMLAdapter) FetchIdentity(ctx context.Context, credBytes []byte) (stri
 		return "", fmt.Errorf("%s: identity fetch: %w", a.def.Service.ID, err)
 	}
 
+	baseURL, err := a.resolvedBaseURL(config)
+	if err != nil {
+		return "", fmt.Errorf("%s: identity fetch: %w", a.def.Service.ID, err)
+	}
+
 	endpoint := idDef.Endpoint
 	if !strings.HasPrefix(endpoint, "http") {
-		endpoint = strings.TrimRight(a.def.API.BaseURL, "/") + "/" + strings.TrimLeft(endpoint, "/")
+		endpoint = strings.TrimRight(baseURL, "/") + "/" + strings.TrimLeft(endpoint, "/")
 	}
 
 	method := idDef.Method
@@ -357,6 +368,27 @@ func (a *YAMLAdapter) ServiceMetadata() adapters.ServiceMetadata {
 		oauthEndpoint = a.def.Auth.OAuth.Endpoint
 	}
 
+	// Build ordered variable metadata from YAML variables.
+	var variables []adapters.VariableMeta
+	if len(a.def.Variables) > 0 {
+		varNames := make([]string, 0, len(a.def.Variables))
+		for vn := range a.def.Variables {
+			varNames = append(varNames, vn)
+		}
+		sort.Strings(varNames)
+		variables = make([]adapters.VariableMeta, 0, len(varNames))
+		for _, vn := range varNames {
+			v := a.def.Variables[vn]
+			variables = append(variables, adapters.VariableMeta{
+				Name:        vn,
+				DisplayName: v.DisplayName,
+				Description: v.Description,
+				Required:    v.Required,
+				Default:     v.Default,
+			})
+		}
+	}
+
 	return adapters.ServiceMetadata{
 		DisplayName:       a.def.Service.DisplayName,
 		Description:       a.def.Service.Description,
@@ -370,6 +402,7 @@ func (a *YAMLAdapter) ServiceMetadata() adapters.ServiceMetadata {
 		AutoIdentity:      a.def.Service.Identity != nil,
 		ActionMeta:        actionMeta,
 		VerificationHints: a.def.VerificationHints,
+		Variables:         variables,
 	}
 }
 
@@ -437,6 +470,57 @@ func (a *YAMLAdapter) resolvePKCEFlowClientID() string {
 		}
 	}
 	return pf.ClientID
+}
+
+// resolvedBaseURL returns the API base URL with any {{.var.X}} placeholders
+// replaced by values from config. It validates that all required variables
+// have values.
+func (a *YAMLAdapter) resolvedBaseURL(config map[string]string) (string, error) {
+	if err := a.validateVariables(config); err != nil {
+		return "", err
+	}
+	merged := a.mergedConfig(config)
+	return resolveVariables(a.def.API.BaseURL, merged), nil
+}
+
+// mergedConfig returns config with any missing keys filled in from variable defaults.
+func (a *YAMLAdapter) mergedConfig(config map[string]string) map[string]string {
+	merged := make(map[string]string, len(config)+len(a.def.Variables))
+	for name, def := range a.def.Variables {
+		if def.Default != "" {
+			merged[name] = def.Default
+		}
+	}
+	for k, v := range config {
+		merged[k] = v
+	}
+	return merged
+}
+
+// resolveVariables replaces {{.var.KEY}} placeholders in s with values from config.
+func resolveVariables(s string, config map[string]string) string {
+	for k, v := range config {
+		s = strings.ReplaceAll(s, "{{.var."+k+"}}", v)
+	}
+	return s
+}
+
+// validateVariables checks that all required variables defined in the adapter
+// spec have values in config.
+func (a *YAMLAdapter) validateVariables(config map[string]string) error {
+	for name, def := range a.def.Variables {
+		if !def.Required {
+			continue
+		}
+		if v, ok := config[name]; ok && v != "" {
+			continue
+		}
+		if def.Default != "" {
+			continue
+		}
+		return fmt.Errorf("%s: missing required configuration variable %q — please reconfigure the service", a.def.Service.ID, name)
+	}
+	return nil
 }
 
 // Def returns the underlying YAML definition (for the loader/tests).

--- a/pkg/adapters/yamlruntime/identity_test.go
+++ b/pkg/adapters/yamlruntime/identity_test.go
@@ -44,7 +44,7 @@ func TestFetchIdentity_Success(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	identity, err := adapter.FetchIdentity(context.Background(), testCred("ghp_test"))
+	identity, err := adapter.FetchIdentity(context.Background(), testCred("ghp_test"), nil)
 	if err != nil {
 		t.Fatalf("FetchIdentity failed: %v", err)
 	}
@@ -79,7 +79,7 @@ func TestFetchIdentity_NestedField(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	identity, err := adapter.FetchIdentity(context.Background(), testCred("tok"))
+	identity, err := adapter.FetchIdentity(context.Background(), testCred("tok"), nil)
 	if err != nil {
 		t.Fatalf("FetchIdentity failed: %v", err)
 	}
@@ -101,7 +101,7 @@ func TestFetchIdentity_NoIdentityDef(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	identity, err := adapter.FetchIdentity(context.Background(), testCred("tok"))
+	identity, err := adapter.FetchIdentity(context.Background(), testCred("tok"), nil)
 	if err != nil {
 		t.Fatalf("FetchIdentity failed: %v", err)
 	}
@@ -134,7 +134,7 @@ func TestFetchIdentity_AbsoluteURL(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	identity, err := adapter.FetchIdentity(context.Background(), testCred("tok"))
+	identity, err := adapter.FetchIdentity(context.Background(), testCred("tok"), nil)
 	if err != nil {
 		t.Fatalf("FetchIdentity failed: %v", err)
 	}
@@ -184,7 +184,7 @@ func TestFetchIdentity_GraphQLBody(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	identity, err := adapter.FetchIdentity(context.Background(), testCred("lin_api_test"))
+	identity, err := adapter.FetchIdentity(context.Background(), testCred("lin_api_test"), nil)
 	if err != nil {
 		t.Fatalf("FetchIdentity failed: %v", err)
 	}

--- a/pkg/adapters/yamlvalidate/validate.go
+++ b/pkg/adapters/yamlvalidate/validate.go
@@ -1,0 +1,274 @@
+// Package yamlvalidate checks YAML adapter definitions for structural correctness,
+// variable consistency, path param references, and risk sanity.
+package yamlvalidate
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/clawvisor/clawvisor/pkg/adapters/yamldef"
+)
+
+// SafeServiceIDPattern matches only valid service IDs: lowercase alphanumeric
+// segments separated by dots (e.g. "jira", "google.gmail", "pagerduty").
+var SafeServiceIDPattern = regexp.MustCompile(`^[a-z][a-z0-9]*(\.[a-z][a-z0-9]*)*$`)
+
+// varPlaceholderRe matches {{.var.NAME}} placeholders.
+var varPlaceholderRe = regexp.MustCompile(`\{\{\.var\.(\w+)\}\}`)
+
+// pathParamRe matches {{.NAME}} placeholders in action paths (but not {{.var.NAME}}).
+var pathParamRe = regexp.MustCompile(`\{\{\.(\w+)\}\}`)
+
+// ValidRiskCategories is the set of allowed risk categories.
+var ValidRiskCategories = map[string]bool{
+	"read": true, "write": true, "delete": true, "search": true,
+}
+
+// ValidSensitivities is the set of allowed sensitivity levels.
+var ValidSensitivities = map[string]bool{
+	"low": true, "medium": true, "high": true,
+}
+
+// ValidAuthTypes is the set of allowed authentication types.
+var ValidAuthTypes = map[string]bool{
+	"api_key": true, "oauth2": true, "basic": true, "none": true,
+}
+
+// ValidHTTPMethods is the set of allowed HTTP methods.
+var ValidHTTPMethods = map[string]bool{
+	"GET": true, "POST": true, "PUT": true, "PATCH": true, "DELETE": true,
+}
+
+// validParamTypes is the set of allowed parameter types.
+var validParamTypes = map[string]bool{
+	"string": true, "int": true, "bool": true, "object": true, "array": true,
+}
+
+// validParamLocations is the set of allowed parameter locations.
+var validParamLocations = map[string]bool{
+	"query": true, "body": true, "path": true,
+}
+
+// validAPITypes is the set of allowed API types.
+var validAPITypes = map[string]bool{
+	"rest": true, "graphql": true,
+}
+
+// Result holds both hard errors and soft warnings from validation.
+type Result struct {
+	Errors   []string // fatal — prevent loading/installation
+	Warnings []string // informational — adapter still loads
+}
+
+// OK returns true if there are no errors.
+func (r Result) OK() bool { return len(r.Errors) == 0 }
+
+// Validate checks a parsed ServiceDef for structural correctness and returns
+// errors and warnings. It does NOT mutate the def.
+func Validate(def *yamldef.ServiceDef) Result {
+	var r Result
+
+	// ── Service metadata ────────────────────────────────────────────────
+	if def.Service.ID == "" {
+		r.Errors = append(r.Errors, "service.id is required")
+	} else if !SafeServiceIDPattern.MatchString(def.Service.ID) {
+		r.Errors = append(r.Errors, fmt.Sprintf("service.id %q contains invalid characters (must be lowercase alphanumeric segments separated by dots)", def.Service.ID))
+	}
+	if def.Service.DisplayName == "" {
+		r.Errors = append(r.Errors, "service.display_name is required")
+	}
+
+	// ── Auth ────────────────────────────────────────────────────────────
+	if def.Auth.Type != "" && !ValidAuthTypes[def.Auth.Type] {
+		r.Errors = append(r.Errors, fmt.Sprintf("invalid auth.type: %q", def.Auth.Type))
+	}
+	if def.Auth.Type == "oauth2" && def.Auth.OAuth == nil && def.Auth.DeviceFlow == nil && def.Auth.PKCEFlow == nil {
+		r.Warnings = append(r.Warnings, "auth.type is oauth2 but no OAuth flow is configured (missing pkce_flow/device_flow/oauth section)")
+	}
+
+	// ── API ─────────────────────────────────────────────────────────────
+	if def.API.BaseURL == "" {
+		r.Errors = append(r.Errors, "api.base_url is required")
+	}
+	if def.API.Type != "" && !validAPITypes[def.API.Type] {
+		r.Errors = append(r.Errors, fmt.Sprintf("invalid api.type: %q (must be \"rest\" or \"graphql\")", def.API.Type))
+	}
+
+	// ── Variables ───────────────────────────────────────────────────────
+	referencedVars := extractVarPlaceholders(def.API.BaseURL)
+	definedVars := map[string]bool{}
+	for name := range def.Variables {
+		definedVars[name] = true
+	}
+
+	// Every {{.var.X}} in base_url must be defined.
+	for _, name := range referencedVars {
+		if !definedVars[name] {
+			r.Errors = append(r.Errors, fmt.Sprintf("base_url references {{.var.%s}} but no variable %q is defined", name, name))
+		}
+	}
+
+	// Orphan variables (defined but not referenced in base_url).
+	referencedSet := map[string]bool{}
+	for _, name := range referencedVars {
+		referencedSet[name] = true
+	}
+	for name := range def.Variables {
+		if !referencedSet[name] {
+			r.Warnings = append(r.Warnings, fmt.Sprintf("variable %q is defined but not referenced in base_url", name))
+		}
+	}
+
+	// Required variables should have a display_name.
+	for name, v := range def.Variables {
+		if v.Required && v.DisplayName == "" {
+			r.Warnings = append(r.Warnings, fmt.Sprintf("variable %q is required but has no display_name", name))
+		}
+	}
+
+	// ── Actions ─────────────────────────────────────────────────────────
+	if len(def.Actions) == 0 {
+		r.Errors = append(r.Errors, "at least one action is required")
+	}
+
+	for name, action := range def.Actions {
+		for _, e := range validateAction(name, action, def.API.Type) {
+			r.Errors = append(r.Errors, fmt.Sprintf("action %q: %s", name, e))
+		}
+		for _, w := range validateActionWarnings(name, action) {
+			r.Warnings = append(r.Warnings, fmt.Sprintf("action %q: %s", name, w))
+		}
+	}
+
+	return r
+}
+
+// validateAction checks a single action for errors.
+func validateAction(_ string, action yamldef.Action, apiType string) []string {
+	var errs []string
+
+	if action.DisplayName == "" {
+		errs = append(errs, "display_name is required")
+	}
+
+	// Risk validation.
+	if !ValidRiskCategories[action.Risk.Category] {
+		errs = append(errs, fmt.Sprintf("risk.category %q is invalid", action.Risk.Category))
+	}
+	if !ValidSensitivities[action.Risk.Sensitivity] {
+		errs = append(errs, fmt.Sprintf("risk.sensitivity %q is invalid", action.Risk.Sensitivity))
+	}
+
+	// Risk sanity checks.
+	if action.Method == "DELETE" && action.Risk.Category != "delete" {
+		errs = append(errs, fmt.Sprintf("DELETE method should have risk category \"delete\", got %q", action.Risk.Category))
+	}
+	if action.Method == "DELETE" && action.Risk.Sensitivity == "low" {
+		errs = append(errs, "DELETE method cannot have \"low\" sensitivity")
+	}
+	// PUT/PATCH with "read" is almost certainly wrong; POST with "read" is common
+	// for search/query endpoints (e.g. Notion), so we only warn for POST.
+	if (action.Method == "PUT" || action.Method == "PATCH") && action.Risk.Category == "read" {
+		errs = append(errs, fmt.Sprintf("%s method should not have risk category \"read\"", action.Method))
+	}
+
+	// Go-override actions delegate to compiled code — skip method/path/query checks.
+	if action.Override != "go" {
+		// REST validation.
+		if apiType != "graphql" {
+			if action.Method == "" {
+				errs = append(errs, "method is required for REST actions")
+			} else if !ValidHTTPMethods[action.Method] {
+				errs = append(errs, fmt.Sprintf("method %q is invalid", action.Method))
+			}
+			if action.Path == "" {
+				errs = append(errs, "path is required for REST actions")
+			}
+		}
+
+		// GraphQL validation.
+		if apiType == "graphql" && action.Query == "" && action.Method == "" {
+			errs = append(errs, "query is required for GraphQL actions")
+		}
+	}
+
+	// Param validation.
+	for pname, param := range action.Params {
+		if param.Type != "" && !validParamTypes[param.Type] {
+			errs = append(errs, fmt.Sprintf("param %q has invalid type %q", pname, param.Type))
+		}
+		if param.Location != "" && !validParamLocations[param.Location] {
+			errs = append(errs, fmt.Sprintf("param %q has invalid location %q", pname, param.Location))
+		}
+	}
+
+	// Path param consistency: every {{.X}} in path must have a matching param with location: path.
+	if action.Path != "" {
+		for _, ref := range extractPathParams(action.Path) {
+			param, ok := action.Params[ref]
+			if !ok {
+				errs = append(errs, fmt.Sprintf("path references {{.%s}} but no param %q is defined", ref, ref))
+			} else if param.Location != "path" {
+				errs = append(errs, fmt.Sprintf("param %q is referenced in path but has location %q instead of \"path\"", ref, param.Location))
+			}
+		}
+	}
+
+	return errs
+}
+
+// validateActionWarnings checks a single action for non-fatal issues.
+func validateActionWarnings(_ string, action yamldef.Action) []string {
+	var warns []string
+
+	// POST with "read" category is unusual but legitimate (e.g. Notion search).
+	if action.Method == "POST" && action.Risk.Category == "read" {
+		warns = append(warns, fmt.Sprintf("POST method with risk category \"read\" is unusual — verify this is a read-only endpoint"))
+	}
+
+	// Orphan path params: location: path but not referenced in the path.
+	if action.Path != "" {
+		referencedInPath := map[string]bool{}
+		for _, ref := range extractPathParams(action.Path) {
+			referencedInPath[ref] = true
+		}
+		for pname, param := range action.Params {
+			if param.Location == "path" && !referencedInPath[pname] {
+				warns = append(warns, fmt.Sprintf("param %q has location \"path\" but is not referenced in path %q", pname, action.Path))
+			}
+		}
+	}
+
+	return warns
+}
+
+// extractVarPlaceholders returns variable names from {{.var.NAME}} placeholders.
+func extractVarPlaceholders(s string) []string {
+	matches := varPlaceholderRe.FindAllStringSubmatch(s, -1)
+	names := make([]string, 0, len(matches))
+	for _, m := range matches {
+		names = append(names, m[1])
+	}
+	return names
+}
+
+// extractPathParams returns param names from {{.NAME}} placeholders, excluding {{.var.NAME}}.
+func extractPathParams(s string) []string {
+	// First remove all {{.var.X}} so they don't match as path params.
+	cleaned := varPlaceholderRe.ReplaceAllString(s, "")
+	matches := pathParamRe.FindAllStringSubmatch(cleaned, -1)
+	names := make([]string, 0, len(matches))
+	seen := map[string]bool{}
+	for _, m := range matches {
+		name := m[1]
+		if strings.HasPrefix(name, "var.") {
+			continue
+		}
+		if !seen[name] {
+			seen[name] = true
+			names = append(names, name)
+		}
+	}
+	return names
+}

--- a/pkg/adapters/yamlvalidate/validate.go
+++ b/pkg/adapters/yamlvalidate/validate.go
@@ -11,8 +11,8 @@ import (
 )
 
 // SafeServiceIDPattern matches only valid service IDs: lowercase alphanumeric
-// segments separated by dots (e.g. "jira", "google.gmail", "pagerduty").
-var SafeServiceIDPattern = regexp.MustCompile(`^[a-z][a-z0-9]*(\.[a-z][a-z0-9]*)*$`)
+// (plus underscores/hyphens) segments separated by dots (e.g. "jira", "google.gmail", "test_oauth").
+var SafeServiceIDPattern = regexp.MustCompile(`^[a-z][a-z0-9_-]*(\.[a-z][a-z0-9_-]*)*$`)
 
 // varPlaceholderRe matches {{.var.NAME}} placeholders.
 var varPlaceholderRe = regexp.MustCompile(`\{\{\.var\.(\w+)\}\}`)
@@ -73,7 +73,7 @@ func Validate(def *yamldef.ServiceDef) Result {
 	if def.Service.ID == "" {
 		r.Errors = append(r.Errors, "service.id is required")
 	} else if !SafeServiceIDPattern.MatchString(def.Service.ID) {
-		r.Errors = append(r.Errors, fmt.Sprintf("service.id %q contains invalid characters (must be lowercase alphanumeric segments separated by dots)", def.Service.ID))
+		r.Errors = append(r.Errors, fmt.Sprintf("service.id %q contains invalid characters (must be lowercase alphanumeric, underscores, or hyphens, separated by dots)", def.Service.ID))
 	}
 	if def.Service.DisplayName == "" {
 		r.Errors = append(r.Errors, "service.display_name is required")

--- a/pkg/adapters/yamlvalidate/validate_test.go
+++ b/pkg/adapters/yamlvalidate/validate_test.go
@@ -1,0 +1,359 @@
+package yamlvalidate
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/pkg/adapters/yamldef"
+)
+
+// minimalValidDef returns a minimal valid ServiceDef for testing.
+func minimalValidDef() yamldef.ServiceDef {
+	return yamldef.ServiceDef{
+		Service: yamldef.ServiceInfo{
+			ID:          "test",
+			DisplayName: "Test Service",
+		},
+		Auth: yamldef.AuthDef{Type: "api_key"},
+		API:  yamldef.APIDef{BaseURL: "https://api.test.com", Type: "rest"},
+		Actions: map[string]yamldef.Action{
+			"list_items": {
+				DisplayName: "List items",
+				Risk:        yamldef.RiskDef{Category: "read", Sensitivity: "low", Description: "List items"},
+				Method:      "GET",
+				Path:        "/items",
+			},
+		},
+	}
+}
+
+func TestValidate_MinimalValid(t *testing.T) {
+	def := minimalValidDef()
+	r := Validate(&def)
+	if !r.OK() {
+		t.Errorf("expected no errors, got: %v", r.Errors)
+	}
+	if len(r.Warnings) > 0 {
+		t.Errorf("expected no warnings, got: %v", r.Warnings)
+	}
+}
+
+func TestValidate_MissingServiceID(t *testing.T) {
+	def := minimalValidDef()
+	def.Service.ID = ""
+	r := Validate(&def)
+	if r.OK() {
+		t.Fatal("expected error for missing service.id")
+	}
+	if !containsStr(r.Errors, "service.id is required") {
+		t.Errorf("expected 'service.id is required' error, got: %v", r.Errors)
+	}
+}
+
+func TestValidate_InvalidServiceID(t *testing.T) {
+	def := minimalValidDef()
+	def.Service.ID = "HAS SPACES"
+	r := Validate(&def)
+	if r.OK() {
+		t.Fatal("expected error for invalid service.id")
+	}
+	if !containsStr(r.Errors, "invalid characters") {
+		t.Errorf("expected 'invalid characters' error, got: %v", r.Errors)
+	}
+}
+
+func TestValidate_MissingDisplayName(t *testing.T) {
+	def := minimalValidDef()
+	def.Service.DisplayName = ""
+	r := Validate(&def)
+	if r.OK() {
+		t.Fatal("expected error for missing display_name")
+	}
+}
+
+func TestValidate_InvalidAuthType(t *testing.T) {
+	def := minimalValidDef()
+	def.Auth.Type = "magic"
+	r := Validate(&def)
+	if r.OK() {
+		t.Fatal("expected error for invalid auth type")
+	}
+}
+
+func TestValidate_InvalidAPIType(t *testing.T) {
+	def := minimalValidDef()
+	def.API.Type = "soap"
+	r := Validate(&def)
+	if r.OK() {
+		t.Fatal("expected error for invalid api.type")
+	}
+}
+
+func TestValidate_MissingBaseURL(t *testing.T) {
+	def := minimalValidDef()
+	def.API.BaseURL = ""
+	r := Validate(&def)
+	if r.OK() {
+		t.Fatal("expected error for missing base_url")
+	}
+}
+
+func TestValidate_NoActions(t *testing.T) {
+	def := minimalValidDef()
+	def.Actions = map[string]yamldef.Action{}
+	r := Validate(&def)
+	if r.OK() {
+		t.Fatal("expected error for zero actions")
+	}
+}
+
+// ── Variable checks ─────────────────────────────────────────────────────────
+
+func TestValidate_VarReferencedButNotDefined(t *testing.T) {
+	def := minimalValidDef()
+	def.API.BaseURL = "{{.var.instance_url}}/api"
+	// No variables defined.
+	r := Validate(&def)
+	if r.OK() {
+		t.Fatal("expected error for undefined variable reference")
+	}
+	if !containsStr(r.Errors, "instance_url") {
+		t.Errorf("expected error mentioning 'instance_url', got: %v", r.Errors)
+	}
+}
+
+func TestValidate_VarDefinedAndReferenced(t *testing.T) {
+	def := minimalValidDef()
+	def.API.BaseURL = "{{.var.instance_url}}/api"
+	def.Variables = map[string]yamldef.VariableDef{
+		"instance_url": {DisplayName: "Instance URL", Required: true},
+	}
+	r := Validate(&def)
+	if !r.OK() {
+		t.Errorf("expected no errors, got: %v", r.Errors)
+	}
+}
+
+func TestValidate_OrphanVariable(t *testing.T) {
+	def := minimalValidDef()
+	def.Variables = map[string]yamldef.VariableDef{
+		"unused_var": {DisplayName: "Unused"},
+	}
+	r := Validate(&def)
+	if !r.OK() {
+		t.Errorf("orphan variable should be warning not error, got errors: %v", r.Errors)
+	}
+	if !containsStr(r.Warnings, "unused_var") {
+		t.Errorf("expected warning about orphan variable, got: %v", r.Warnings)
+	}
+}
+
+func TestValidate_RequiredVarNoDisplayName(t *testing.T) {
+	def := minimalValidDef()
+	def.API.BaseURL = "{{.var.site}}/api"
+	def.Variables = map[string]yamldef.VariableDef{
+		"site": {Required: true}, // no display_name
+	}
+	r := Validate(&def)
+	if !containsStr(r.Warnings, "display_name") {
+		t.Errorf("expected warning about missing display_name, got: %v", r.Warnings)
+	}
+}
+
+// ── Path param checks ───────────────────────────────────────────────────────
+
+func TestValidate_PathParamNotDefined(t *testing.T) {
+	def := minimalValidDef()
+	def.Actions["get_item"] = yamldef.Action{
+		DisplayName: "Get item",
+		Risk:        yamldef.RiskDef{Category: "read", Sensitivity: "low", Description: "Get item"},
+		Method:      "GET",
+		Path:        "/items/{{.item_id}}",
+		// No params defined.
+	}
+	r := Validate(&def)
+	if r.OK() {
+		t.Fatal("expected error for missing path param")
+	}
+	if !containsStr(r.Errors, "item_id") {
+		t.Errorf("expected error mentioning 'item_id', got: %v", r.Errors)
+	}
+}
+
+func TestValidate_PathParamWrongLocation(t *testing.T) {
+	def := minimalValidDef()
+	def.Actions["get_item"] = yamldef.Action{
+		DisplayName: "Get item",
+		Risk:        yamldef.RiskDef{Category: "read", Sensitivity: "low", Description: "Get item"},
+		Method:      "GET",
+		Path:        "/items/{{.item_id}}",
+		Params: map[string]yamldef.Param{
+			"item_id": {Type: "string", Location: "query"}, // wrong location
+		},
+	}
+	r := Validate(&def)
+	if r.OK() {
+		t.Fatal("expected error for path param with wrong location")
+	}
+	if !containsStr(r.Errors, "\"path\"") {
+		t.Errorf("expected error about location, got: %v", r.Errors)
+	}
+}
+
+func TestValidate_PathParamCorrect(t *testing.T) {
+	def := minimalValidDef()
+	def.Actions["get_item"] = yamldef.Action{
+		DisplayName: "Get item",
+		Risk:        yamldef.RiskDef{Category: "read", Sensitivity: "low", Description: "Get item"},
+		Method:      "GET",
+		Path:        "/items/{{.item_id}}",
+		Params: map[string]yamldef.Param{
+			"item_id": {Type: "string", Required: true, Location: "path"},
+		},
+	}
+	r := Validate(&def)
+	if !r.OK() {
+		t.Errorf("expected no errors, got: %v", r.Errors)
+	}
+}
+
+func TestValidate_OrphanPathParam(t *testing.T) {
+	def := minimalValidDef()
+	def.Actions["list_items"] = yamldef.Action{
+		DisplayName: "List items",
+		Risk:        yamldef.RiskDef{Category: "read", Sensitivity: "low", Description: "List items"},
+		Method:      "GET",
+		Path:        "/items",
+		Params: map[string]yamldef.Param{
+			"orphan": {Type: "string", Location: "path"}, // location: path but not in path
+		},
+	}
+	r := Validate(&def)
+	if !containsStr(r.Warnings, "orphan") {
+		t.Errorf("expected warning about orphan path param, got: %v", r.Warnings)
+	}
+}
+
+// ── Param type/location checks ──────────────────────────────────────────────
+
+func TestValidate_InvalidParamType(t *testing.T) {
+	def := minimalValidDef()
+	a := def.Actions["list_items"]
+	a.Params = map[string]yamldef.Param{"bad": {Type: "float", Location: "query"}}
+	def.Actions["list_items"] = a
+
+	r := Validate(&def)
+	if r.OK() {
+		t.Fatal("expected error for invalid param type")
+	}
+	if !containsStr(r.Errors, "float") {
+		t.Errorf("expected error mentioning 'float', got: %v", r.Errors)
+	}
+}
+
+func TestValidate_InvalidParamLocation(t *testing.T) {
+	def := minimalValidDef()
+	a := def.Actions["list_items"]
+	a.Params = map[string]yamldef.Param{"bad": {Type: "string", Location: "header"}}
+	def.Actions["list_items"] = a
+
+	r := Validate(&def)
+	if r.OK() {
+		t.Fatal("expected error for invalid param location")
+	}
+	if !containsStr(r.Errors, "header") {
+		t.Errorf("expected error mentioning 'header', got: %v", r.Errors)
+	}
+}
+
+// ── Risk sanity checks ──────────────────────────────────────────────────────
+
+func TestValidate_DeleteMethodReadCategory(t *testing.T) {
+	def := minimalValidDef()
+	def.Actions["bad_delete"] = yamldef.Action{
+		DisplayName: "Bad delete",
+		Risk:        yamldef.RiskDef{Category: "read", Sensitivity: "high", Description: "Bad"},
+		Method:      "DELETE",
+		Path:        "/items/{{.id}}",
+		Params:      map[string]yamldef.Param{"id": {Type: "string", Required: true, Location: "path"}},
+	}
+	r := Validate(&def)
+	if r.OK() {
+		t.Fatal("expected error for DELETE with read category")
+	}
+}
+
+func TestValidate_DeleteMethodLowSensitivity(t *testing.T) {
+	def := minimalValidDef()
+	def.Actions["bad_delete"] = yamldef.Action{
+		DisplayName: "Bad delete",
+		Risk:        yamldef.RiskDef{Category: "delete", Sensitivity: "low", Description: "Bad"},
+		Method:      "DELETE",
+		Path:        "/items/{{.id}}",
+		Params:      map[string]yamldef.Param{"id": {Type: "string", Required: true, Location: "path"}},
+	}
+	r := Validate(&def)
+	if r.OK() {
+		t.Fatal("expected error for DELETE with low sensitivity")
+	}
+}
+
+// ── Full Jira-like def ──────────────────────────────────────────────────────
+
+func TestValidate_JiraLikeDef(t *testing.T) {
+	def := yamldef.ServiceDef{
+		Service: yamldef.ServiceInfo{
+			ID:          "jira",
+			DisplayName: "Jira Cloud",
+			Description: "Manage Jira issues.",
+			Identity:    &yamldef.IdentityDef{Endpoint: "/rest/api/3/myself", Field: "emailAddress"},
+		},
+		Auth: yamldef.AuthDef{Type: "basic"},
+		API:  yamldef.APIDef{BaseURL: "{{.var.instance_url}}", Type: "rest"},
+		Variables: map[string]yamldef.VariableDef{
+			"instance_url": {
+				DisplayName: "Instance URL",
+				Description: "Your Atlassian Cloud URL",
+				Required:    true,
+			},
+		},
+		Actions: map[string]yamldef.Action{
+			"search_issues": {
+				DisplayName: "Search issues",
+				Risk:        yamldef.RiskDef{Category: "search", Sensitivity: "low", Description: "Search issues"},
+				Method:      "GET",
+				Path:        "/rest/api/3/search",
+				Params: map[string]yamldef.Param{
+					"jql": {Type: "string", Required: true, Location: "query"},
+				},
+			},
+			"get_issue": {
+				DisplayName: "Get issue",
+				Risk:        yamldef.RiskDef{Category: "read", Sensitivity: "low", Description: "Get issue"},
+				Method:      "GET",
+				Path:        "/rest/api/3/issue/{{.issue_key}}",
+				Params: map[string]yamldef.Param{
+					"issue_key": {Type: "string", Required: true, Location: "path"},
+				},
+			},
+		},
+	}
+	r := Validate(&def)
+	if !r.OK() {
+		t.Errorf("expected Jira-like def to be valid, got errors: %v", r.Errors)
+	}
+	if len(r.Warnings) > 0 {
+		t.Errorf("expected no warnings, got: %v", r.Warnings)
+	}
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+func containsStr(ss []string, substr string) bool {
+	for _, s := range ss {
+		if strings.Contains(s, substr) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -59,6 +59,11 @@ type Store interface {
 	DeleteServiceMeta(ctx context.Context, userID, serviceID, alias string) error
 	CountServiceMetasByType(ctx context.Context, userID, serviceID string) (int, error)
 
+	// Service configs (per-user variable values for configurable adapters)
+	UpsertServiceConfig(ctx context.Context, userID, serviceID, alias string, config json.RawMessage) error
+	GetServiceConfig(ctx context.Context, userID, serviceID, alias string) (*ServiceConfig, error)
+	DeleteServiceConfig(ctx context.Context, userID, serviceID, alias string) error
+
 	// Notification configs
 	UpsertNotificationConfig(ctx context.Context, userID, channel string, config json.RawMessage) error
 	GetNotificationConfig(ctx context.Context, userID, channel string) (*NotificationConfig, error)
@@ -203,6 +208,17 @@ type Restriction struct {
 	Action    string    `json:"action"`
 	Reason    string    `json:"reason"`
 	CreatedAt time.Time `json:"created_at"`
+}
+
+// ServiceConfig stores per-user, per-service variable values for configurable adapters.
+type ServiceConfig struct {
+	ID        string          `json:"id"`
+	UserID    string          `json:"user_id"`
+	ServiceID string          `json:"service_id"`
+	Alias     string          `json:"alias"`
+	Config    json.RawMessage `json:"config"`
+	CreatedAt time.Time       `json:"created_at"`
+	UpdatedAt time.Time       `json:"updated_at"`
 }
 
 // NotificationConfig stores per-user, per-channel notification settings.

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -249,9 +249,18 @@ export interface ServiceInfo {
   requires_activation?: boolean
   credential_free?: boolean
   actions: ServiceActionInfo[]
+  variables?: VariableMeta[]
   status: 'activated' | 'not_activated'
   activated_at?: string
   setup_url?: string
+}
+
+export interface VariableMeta {
+  name: string
+  display_name: string
+  description?: string
+  required: boolean
+  default?: string
 }
 
 export interface Restriction {
@@ -639,10 +648,11 @@ export const api = {
       }),
     activate: (serviceID: string) =>
       post<{ status: string; service: string }>(`/api/services/${serviceID}/activate`, {}),
-    activateWithKey: (serviceID: string, token: string, alias?: string) =>
+    activateWithKey: (serviceID: string, token: string, alias?: string, config?: Record<string, string>) =>
       post<{ status: string; service: string }>(`/api/services/${serviceID}/activate-key`, {
         token,
         ...(alias ? { alias } : {}),
+        ...(config && Object.keys(config).length > 0 ? { config } : {}),
       }),
     deactivate: (serviceID: string, alias?: string) =>
       post<{ status: string; service: string }>(`/api/services/${serviceID}/deactivate`, {

--- a/web/src/pages/Onboarding.tsx
+++ b/web/src/pages/Onboarding.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { useMutation, useQueryClient, useQuery } from '@tanstack/react-query'
-import { api, type ServiceInfo, type ServiceActionInfo } from '../api/client'
+import { api, type ServiceInfo, type ServiceActionInfo, type VariableMeta } from '../api/client'
 import { serviceName, serviceDescription } from '../lib/services'
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -9,6 +9,7 @@ interface ServiceType {
   baseId: string
   oauth: boolean
   actions: ServiceActionInfo[]
+  variables?: VariableMeta[]
   activatedCount: number
 }
 
@@ -86,6 +87,7 @@ function OnboardingServices({
   const [keyInputFor, setKeyInputFor] = useState<string | null>(null)
   const [keyValue, setKeyValue] = useState('')
   const [keyAlias, setKeyAlias] = useState<string | undefined>(undefined)
+  const [keyConfig, setKeyConfig] = useState<Record<string, string>>({})
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -122,6 +124,7 @@ function OnboardingServices({
         baseId: svc.id,
         oauth: svc.oauth,
         actions: svc.actions,
+        variables: svc.variables,
         activatedCount: svc.status === 'activated' ? 1 : 0,
       })
     }
@@ -150,10 +153,11 @@ function OnboardingServices({
     setSaving(true)
     setError(null)
     try {
-      await api.services.activateWithKey(keyInputFor, keyValue.trim(), keyAlias)
+      await api.services.activateWithKey(keyInputFor, keyValue.trim(), keyAlias, Object.keys(keyConfig).length > 0 ? keyConfig : undefined)
       setKeyValue('')
       setKeyInputFor(null)
       setKeyAlias(undefined)
+      setKeyConfig({})
       qc.invalidateQueries({ queryKey: ['services'] })
     } catch (e: any) {
       setError(e.message ?? 'Failed to save API key')
@@ -179,6 +183,13 @@ function OnboardingServices({
     } else {
       setKeyInputFor(st.baseId)
       setKeyAlias(alias)
+      const defaults: Record<string, string> = {}
+      if (st.variables) {
+        for (const v of st.variables) {
+          defaults[v.name] = v.default ?? ''
+        }
+      }
+      setKeyConfig(defaults)
     }
   }
 
@@ -265,31 +276,51 @@ function OnboardingServices({
                 </div>
               )}
 
-              {/* API key input */}
+              {/* API key input (with optional variable fields) */}
               {keyInputFor === st.baseId && (
-                <div className="flex gap-2">
-                  <input
-                    type="password"
-                    value={keyValue}
-                    onChange={e => setKeyValue(e.target.value)}
-                    onKeyDown={e => e.key === 'Enter' && handleSaveKey()}
-                    placeholder="Paste your token…"
-                    className="flex-1 text-xs px-2 py-1.5 border border-border-default bg-surface-0 text-text-primary rounded focus:outline-none focus:ring-1 focus:ring-brand/30 focus:border-brand placeholder:text-text-tertiary"
-                    autoFocus
-                  />
-                  <button
-                    onClick={handleSaveKey}
-                    disabled={saving || !keyValue.trim()}
-                    className="text-xs px-3 py-1.5 rounded bg-brand text-surface-0 hover:bg-brand-strong disabled:opacity-50"
-                  >
-                    {saving ? 'Saving…' : 'Save'}
-                  </button>
-                  <button
-                    onClick={() => { setKeyInputFor(null); setKeyValue('') }}
-                    className="text-xs px-3 py-1.5 rounded border border-border-strong text-text-primary hover:bg-surface-2"
-                  >
-                    Cancel
-                  </button>
+                <div className="space-y-2">
+                  {st.variables && st.variables.length > 0 && st.variables.map(v => (
+                    <div key={v.name}>
+                      <label className="block text-xs text-text-secondary mb-0.5">
+                        {v.display_name || v.name}
+                        {v.required && <span className="text-danger ml-0.5">*</span>}
+                      </label>
+                      {v.description && (
+                        <p className="text-[10px] text-text-tertiary mb-1">{v.description}</p>
+                      )}
+                      <input
+                        type="text"
+                        value={keyConfig[v.name] ?? ''}
+                        onChange={e => setKeyConfig(prev => ({ ...prev, [v.name]: e.target.value }))}
+                        placeholder={v.default || v.display_name || v.name}
+                        className="w-full text-xs px-2 py-1.5 border border-border-default bg-surface-0 text-text-primary rounded focus:outline-none focus:ring-1 focus:ring-brand/30 focus:border-brand placeholder:text-text-tertiary"
+                      />
+                    </div>
+                  ))}
+                  <div className="flex gap-2">
+                    <input
+                      type="password"
+                      value={keyValue}
+                      onChange={e => setKeyValue(e.target.value)}
+                      onKeyDown={e => e.key === 'Enter' && handleSaveKey()}
+                      placeholder="Paste your token…"
+                      className="flex-1 text-xs px-2 py-1.5 border border-border-default bg-surface-0 text-text-primary rounded focus:outline-none focus:ring-1 focus:ring-brand/30 focus:border-brand placeholder:text-text-tertiary"
+                      autoFocus={!st.variables || st.variables.length === 0}
+                    />
+                    <button
+                      onClick={handleSaveKey}
+                      disabled={saving || !keyValue.trim()}
+                      className="text-xs px-3 py-1.5 rounded bg-brand text-surface-0 hover:bg-brand-strong disabled:opacity-50"
+                    >
+                      {saving ? 'Saving…' : 'Save'}
+                    </button>
+                    <button
+                      onClick={() => { setKeyInputFor(null); setKeyValue(''); setKeyConfig({}) }}
+                      className="text-xs px-3 py-1.5 rounded border border-border-strong text-text-primary hover:bg-surface-2"
+                    >
+                      Cancel
+                    </button>
+                  </div>
                 </div>
               )}
 

--- a/web/src/pages/Services.tsx
+++ b/web/src/pages/Services.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { NavLink } from 'react-router-dom'
-import { api, type ServiceInfo, type ServiceActionInfo } from '../api/client'
+import { api, type ServiceInfo, type ServiceActionInfo, type VariableMeta } from '../api/client'
 import { formatDistanceToNow } from 'date-fns'
 import { serviceName, serviceDescription } from '../lib/services'
 import { useAuth } from '../hooks/useAuth'
@@ -276,6 +276,7 @@ interface ServiceType {
   requiresActivation: boolean
   credentialFree: boolean
   actions: ServiceActionInfo[]
+  variables?: VariableMeta[]
   activatedCount: number
   description: string
   setupUrl?: string
@@ -296,6 +297,7 @@ function AddServiceModal({
   const [keyInputFor, setKeyInputFor] = useState<string | null>(null)
   const [keyValue, setKeyValue] = useState('')
   const [keyAlias, setKeyAlias] = useState<string | undefined>(undefined)
+  const [keyConfig, setKeyConfig] = useState<Record<string, string>>({})
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -359,6 +361,7 @@ function AddServiceModal({
         requiresActivation: svc.requires_activation ?? true,
         credentialFree: svc.credential_free ?? false,
         actions: svc.actions,
+        variables: svc.variables,
         activatedCount: svc.status === 'activated' ? 1 : 0,
         description: svc.description || serviceDescription(svc.id),
         setupUrl: svc.setup_url,
@@ -398,10 +401,11 @@ function AddServiceModal({
     setSaving(true)
     setError(null)
     try {
-      await api.services.activateWithKey(keyInputFor, keyValue.trim(), keyAlias)
+      await api.services.activateWithKey(keyInputFor, keyValue.trim(), keyAlias, Object.keys(keyConfig).length > 0 ? keyConfig : undefined)
       setKeyValue('')
       setKeyInputFor(null)
       setKeyAlias(undefined)
+      setKeyConfig({})
       qc.invalidateQueries({ queryKey: ['services'] })
       onClose()
     } catch (e: any) {
@@ -539,6 +543,14 @@ function AddServiceModal({
     } else {
       setKeyInputFor(st.baseId)
       setKeyAlias(alias)
+      // Initialize config with variable defaults
+      const defaults: Record<string, string> = {}
+      if (st.variables) {
+        for (const v of st.variables) {
+          defaults[v.name] = v.default ?? ''
+        }
+      }
+      setKeyConfig(defaults)
     }
   }
 
@@ -671,9 +683,27 @@ function AddServiceModal({
                       </div>
                     )}
 
-                    {/* API key input */}
+                    {/* API key input (with optional variable fields) */}
                     {keyInputFor === st.baseId && (
                       <div className="space-y-2 text-left">
+                        {st.variables && st.variables.length > 0 && st.variables.map(v => (
+                          <div key={v.name}>
+                            <label className="block text-xs text-text-secondary mb-0.5">
+                              {v.display_name || v.name}
+                              {v.required && <span className="text-danger ml-0.5">*</span>}
+                            </label>
+                            {v.description && (
+                              <p className="text-[10px] text-text-tertiary mb-1">{v.description}</p>
+                            )}
+                            <input
+                              type="text"
+                              value={keyConfig[v.name] ?? ''}
+                              onChange={e => setKeyConfig(prev => ({ ...prev, [v.name]: e.target.value }))}
+                              placeholder={v.default || v.display_name || v.name}
+                              className="w-full text-xs px-2.5 py-1.5 border border-border-default bg-surface-0 text-text-primary rounded-lg focus:outline-none focus:ring-1 focus:ring-brand/30 focus:border-brand placeholder:text-text-tertiary"
+                            />
+                          </div>
+                        ))}
                         <input
                           type="password"
                           value={keyValue}
@@ -681,7 +711,7 @@ function AddServiceModal({
                           onKeyDown={e => e.key === 'Enter' && handleSaveKey()}
                           placeholder="Paste your token…"
                           className="w-full text-xs px-2.5 py-1.5 border border-border-default bg-surface-0 text-text-primary rounded-lg focus:outline-none focus:ring-1 focus:ring-brand/30 focus:border-brand placeholder:text-text-tertiary"
-                          autoFocus
+                          autoFocus={!st.variables || st.variables.length === 0}
                         />
                         <div className="flex gap-2">
                           <button
@@ -692,7 +722,7 @@ function AddServiceModal({
                             {saving ? 'Saving…' : 'Save'}
                           </button>
                           <button
-                            onClick={() => { setKeyInputFor(null); setKeyValue('') }}
+                            onClick={() => { setKeyInputFor(null); setKeyValue(''); setKeyConfig({}) }}
                             className="text-xs px-3 py-1.5 rounded-lg border border-border-strong text-text-primary hover:bg-surface-2"
                           >
                             Cancel


### PR DESCRIPTION
## Summary

- Adds a `variables` section to adapter YAML definitions so users can provide instance-specific values (e.g. Jira Cloud URL) at activation time, stored in a new `service_configs` DB table and interpolated into `base_url` via `{{.var.X}}` placeholders at runtime
- Config is collected across all activation flows (API key, OAuth, PKCE, device flow) in the TUI, daemon CLI, and web dashboard (Services + Onboarding pages)
- Introduces a shared `pkg/adapters/yamlvalidate` package that checks variable consistency, path param references, param types/locations, and risk sanity — wired into the YAML loader at startup and exposed as a `clawvisor validate` CLI command for adapter authors
- Refactors `internal/adaptergen/validator.go` to delegate to the shared validator, keeping LLM-specific action-dropping behavior local
- Updates `INTEGRATION_YAML_SPEC.md` with variables documentation and examples

## Test plan

- [x] `go test ./pkg/adapters/yamlvalidate/...` — 21 new unit tests pass
- [x] `go test ./internal/adaptergen/...` — existing tests updated and passing
- [x] `go test ./pkg/adapters/yamlloader/...` — loader tests pass with validation wired in
- [x] `go test ./pkg/adapters/yamlruntime/...` — runtime tests pass
- [x] `go test ./internal/api/handlers/...` — handler tests pass
- [x] `go vet ./...` clean (minus pre-existing web/embed issue)
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [ ] Manual: activate Jira with instance_url variable via web dashboard
- [ ] Manual: `clawvisor validate` against user adapter directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)