### PR TITLE
feat: agent setup guide on dashboard with local/relay-aware URLs

### DIFF
--- a/internal/api/handlers/onboarding.go
+++ b/internal/api/handlers/onboarding.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+
+	"github.com/clawvisor/clawvisor/internal/relay"
 )
 
 // OnboardingHandler serves the agent onboarding document at GET /setup.
@@ -115,6 +117,120 @@ func (h *OnboardingHandler) Setup(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(&b, "3. Create a task, wait for approval, execute the action, and complete the task\n")
 	fmt.Fprintf(&b, "4. If the result comes back with `status: \"executed\"`, you're all set\n\n")
 	fmt.Fprintf(&b, "Tell the user what you found — this is their confirmation that the integration is working.\n")
+
+	w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
+	w.Write([]byte(b.String()))
+}
+
+// resolveURL returns the best Clawvisor URL for the requesting client. When
+// the request arrives directly (not via relay), the local origin is used so
+// agents talk to the daemon without an extra hop. Relay-routed requests get
+// the public relay URL.
+func (h *OnboardingHandler) resolveURL(r *http.Request) string {
+	if !relay.ViaRelay(r.Context()) {
+		// Direct (local) access — use the request's own host.
+		scheme := "http"
+		if r.TLS != nil {
+			scheme = "https"
+		}
+		return scheme + "://" + r.Host
+	}
+	if h.daemonID != "" && h.relayHost != "" {
+		return fmt.Sprintf("https://%s/d/%s", h.relayHost, h.daemonID)
+	}
+	return "http://localhost:25297"
+}
+
+// ClaudeCodeSetup serves a Claude Code /clawvisor-setup slash command with
+// the Clawvisor URL pre-filled. Users curl this into ~/.claude/commands/ to
+// install the command, then run /clawvisor-setup in Claude Code.
+func (h *OnboardingHandler) ClaudeCodeSetup(w http.ResponseWriter, r *http.Request) {
+	clawvisorURL := h.resolveURL(r)
+	skillURL := clawvisorURL + "/skill/SKILL.md"
+
+	var b strings.Builder
+	b.WriteString("Set up Clawvisor in the current project so Claude Code can make gated API\n")
+	b.WriteString("requests (Gmail, Calendar, Drive, GitHub, Slack, etc.) through the Clawvisor\n")
+	b.WriteString("gateway with task-scoped authorization and human approval.\n\n")
+
+	b.WriteString("## Steps\n\n")
+
+	b.WriteString("### 1. Connect as an agent\n\n")
+	b.WriteString("Register with the daemon and wait for the user to approve:\n\n")
+	b.WriteString("```bash\n")
+	fmt.Fprintf(&b, "curl -s -X POST \"%s/api/agents/connect?wait=true&timeout=120\" -H \"Content-Type: application/json\" -d '{\"name\": \"claude-code\", \"description\": \"Claude Code agent\"}'\n", clawvisorURL)
+	b.WriteString("```\n\n")
+	b.WriteString("This sends a connection request to the daemon. The user will be notified\n")
+	b.WriteString("to approve. The `?wait=true` parameter makes the request block until the\n")
+	b.WriteString("user approves (or the timeout elapses).\n\n")
+	b.WriteString("Parse the JSON response. If `status` is `approved`, save the `token`\n")
+	b.WriteString("value — you will need it below. If the timeout elapses and `status` is\n")
+	b.WriteString("still `pending`, tell the user to approve the connection request in the\n")
+	b.WriteString("Clawvisor dashboard and long-poll `GET /api/agents/connect/{connection_id}/status`\n")
+	b.WriteString("until it resolves.\n\n")
+
+	b.WriteString("### 2. Set environment variables\n\n")
+	b.WriteString("Save the agent token and daemon URL to `~/.claude/settings.json` so they\n")
+	b.WriteString("persist across all Claude Code sessions and projects.\n\n")
+	b.WriteString("Read `~/.claude/settings.json` (create it if it doesn't exist). Merge the\n")
+	b.WriteString("following into the `env` object at the top level, preserving all other keys:\n\n")
+	b.WriteString("```json\n")
+	b.WriteString("{\n")
+	b.WriteString("  \"env\": {\n")
+	fmt.Fprintf(&b, "    \"CLAWVISOR_URL\": \"%s\",\n", clawvisorURL)
+	b.WriteString("    \"CLAWVISOR_AGENT_TOKEN\": \"<token from step 1>\"\n")
+	b.WriteString("  }\n")
+	b.WriteString("}\n")
+	b.WriteString("```\n\n")
+	b.WriteString("Write the updated JSON back to `~/.claude/settings.json`. The variables\n")
+	b.WriteString("will be available in every future Claude Code session without any per-project\n")
+	b.WriteString("setup.\n\n")
+
+	b.WriteString("### 3. Install the Clawvisor skill\n\n")
+	b.WriteString("Download and install the skill globally so it's available in all projects:\n\n")
+	b.WriteString("```bash\n")
+	fmt.Fprintf(&b, "mkdir -p ~/.claude/skills/clawvisor && curl -sf \"%s\" -o ~/.claude/skills/clawvisor/SKILL.md\n", skillURL)
+	b.WriteString("```\n\n")
+
+	b.WriteString("### 4. Verify\n\n")
+	b.WriteString("```bash\n")
+	fmt.Fprintf(&b, "curl -sf -H \"Authorization: Bearer $CLAWVISOR_AGENT_TOKEN\" \\\n  %s/api/skill/catalog | head -20\n", clawvisorURL)
+	b.WriteString("```\n\n")
+	b.WriteString("This should return a JSON service catalog. If it returns 401, the token is\n")
+	b.WriteString("wrong. If it fails to connect, the daemon is not running.\n\n")
+
+	b.WriteString("### 5. End-to-end smoke test\n\n")
+	b.WriteString("Now that everything is configured, run a quick smoke test to prove the full\n")
+	b.WriteString("flow works. Use the Clawvisor skill to:\n\n")
+	b.WriteString("1. **Create a test task** — pick any connected service visible in the catalog\n")
+	b.WriteString("   (e.g. Gmail, Calendar, GitHub) and create a task with a narrow scope such as\n")
+	b.WriteString("   \"read my most recent email subject\" or \"list my GitHub notifications\".\n")
+	b.WriteString("   Tell the user to approve the task in the Clawvisor dashboard or mobile app,\n")
+	b.WriteString("   then wait for approval before continuing.\n\n")
+	b.WriteString("2. **Make an in-scope request** — once approved, make a gateway call that falls\n")
+	b.WriteString("   within the task's approved scope. Show the user the successful response.\n\n")
+	b.WriteString("3. **Make an out-of-scope request** — make a second gateway call using the same\n")
+	b.WriteString("   task that is clearly outside the approved scope (e.g. sending an email when\n")
+	b.WriteString("   the task only allows reading). Show the user that this request is rejected,\n")
+	b.WriteString("   demonstrating that Clawvisor enforces task boundaries.\n\n")
+	b.WriteString("Summarize the results: the in-scope call should have succeeded and the\n")
+	b.WriteString("out-of-scope call should have been denied. If either result is unexpected,\n")
+	b.WriteString("help the user debug.\n\n")
+
+	b.WriteString("### 6. Done\n\n")
+	b.WriteString("Tell the user setup is complete. The Clawvisor skill will be loaded\n")
+	b.WriteString("automatically when relevant, or they can invoke it explicitly. Remind them to:\n\n")
+	b.WriteString("- Connect services in the Clawvisor dashboard (Services tab) before asking\n")
+	b.WriteString("  you to use them\n")
+	b.WriteString("- Approve tasks in the dashboard or via mobile when you request them\n\n")
+
+	b.WriteString("### 7. Offer to uninstall /clawvisor-setup (optional)\n\n")
+	b.WriteString("Now that setup is complete, ask the user if they'd like to remove the\n")
+	b.WriteString("`/clawvisor-setup` slash command since it's no longer needed. If they agree:\n\n")
+	b.WriteString("```bash\n")
+	b.WriteString("rm ~/.claude/commands/clawvisor-setup.md\n")
+	b.WriteString("```\n\n")
+	b.WriteString("If they decline, remind them they can delete it later with the same command.\n")
 
 	w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
 	w.Write([]byte(b.String()))

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -33,6 +33,7 @@ import (
 	"github.com/clawvisor/clawvisor/internal/taskrisk"
 	"github.com/clawvisor/clawvisor/pkg/notify"
 	"github.com/clawvisor/clawvisor/internal/ratelimit"
+	"github.com/clawvisor/clawvisor/internal/relay"
 	"github.com/clawvisor/clawvisor/pkg/store"
 	"github.com/clawvisor/clawvisor/pkg/vault"
 	skillfiles "github.com/clawvisor/clawvisor/skills"
@@ -609,9 +610,28 @@ func (s *Server) routes() http.Handler {
 		relayHost := relayHostFromCfg(s.cfg.Relay.URL)
 		onboardingHandler := handlers.NewOnboardingHandler(relayHost, s.daemonID)
 		mux.HandleFunc("GET /skill/setup", onboardingHandler.Setup)
+		mux.HandleFunc("GET /skill/clawvisor-setup.md", onboardingHandler.ClaudeCodeSetup)
 	}
+	// skillRenderOpts builds RenderOptions based on whether the request
+	// arrived directly (local) or via the relay (cloud).
+	skillRenderOpts := func(r *http.Request) skillfiles.RenderOptions {
+		viaRelay := relay.ViaRelay(r.Context())
+		var url string
+		if viaRelay && s.daemonID != "" {
+			rh := relayHostFromCfg(s.cfg.Relay.URL)
+			url = fmt.Sprintf("https://%s/d/%s", rh, s.daemonID)
+		} else {
+			scheme := "http"
+			if r.TLS != nil {
+				scheme = "https"
+			}
+			url = scheme + "://" + r.Host
+		}
+		return skillfiles.RenderOptions{ClawvisorURL: url, ViaRelay: viaRelay}
+	}
+
 	mux.HandleFunc("GET /skill/SKILL.md", func(w http.ResponseWriter, r *http.Request) {
-		rendered, err := skillfiles.Render(skillfiles.TargetClaudeCode)
+		rendered, err := skillfiles.RenderWithOptions(skillfiles.TargetClaudeCode, skillRenderOpts(r))
 		if err != nil {
 			http.Error(w, "rendering SKILL.md: "+err.Error(), http.StatusInternalServerError)
 			return
@@ -622,7 +642,7 @@ func (s *Server) routes() http.Handler {
 	mux.HandleFunc("GET /skill/skill.zip", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/zip")
 		w.Header().Set("Content-Disposition", `attachment; filename="skill.zip"`)
-		rendered, err := skillfiles.Render(skillfiles.TargetClaudeCode)
+		rendered, err := skillfiles.RenderWithOptions(skillfiles.TargetClaudeCode, skillRenderOpts(r))
 		if err != nil {
 			http.Error(w, "rendering SKILL.md: "+err.Error(), http.StatusInternalServerError)
 			return

--- a/skills/clawvisor/SKILL.md.tmpl
+++ b/skills/clawvisor/SKILL.md.tmpl
@@ -34,6 +34,23 @@ description: >
 # Clawvisor Skill
 
 ## Setup
+{{- if .ClawvisorURL }}
+
+### Option A: Setup URL (recommended)
+
+If you were given a setup URL (e.g. `{{ .ClawvisorURL }}/skill/setup`), fetch it — it contains step-by-step instructions with your `CLAWVISOR_URL` pre-filled{{ if .ViaRelay }}, including how to register, authenticate, and set up E2E encryption{{ end }}.
+
+### Option B: Manual setup
+
+1. Set `CLAWVISOR_URL` to `{{ .ClawvisorURL }}`
+2. Create an agent in the Clawvisor dashboard, copy the token, and add it to `~/.claude/settings.json` under the `env` key as `CLAWVISOR_AGENT_TOKEN`
+3. Set `OPENCLAW_HOOKS_URL` to your OpenClaw gateway's reachable URL (default `http://localhost:18789`)
+4. Activate any services you want the agent to use (Gmail, GitHub, etc.) in the dashboard under Services
+5. Set dashboard policies to require approval for write/send/delete actions — only enable `auto_execute` for read-only actions you trust the agent to perform unsupervised
+{{- if .ViaRelay }}
+6. Use the bundled `e2e.mjs` helper or `cvis-e2e` binary — all requests through the relay require E2E encryption
+{{- end }}
+{{- else }}
 
 ### Option A: Setup URL (recommended)
 
@@ -47,6 +64,7 @@ If you were given a setup URL (e.g. `https://relay.clawvisor.com/d/<id>/skill/se
 4. Activate any services you want the agent to use (Gmail, GitHub, etc.) in the dashboard under Services
 5. Set dashboard policies to require approval for write/send/delete actions — only enable `auto_execute` for read-only actions you trust the agent to perform unsupervised
 6. If connecting through the cloud relay, use the bundled `e2e.mjs` helper or `cvis-e2e` binary — all requests through the relay require E2E encryption
+{{- end }}
 
 > ⚠️ **`CLAWVISOR_AGENT_TOKEN` is a high-privilege credential.** It grants the agent access to every service activated in Clawvisor. Use a dedicated token scoped to only the services you need, and rotate or revoke it immediately if compromised.
 

--- a/skills/render.go
+++ b/skills/render.go
@@ -24,11 +24,25 @@ const (
 	TargetMCP Target = "mcp"
 )
 
+// RenderOptions holds optional overrides for template rendering.
+type RenderOptions struct {
+	// ClawvisorURL is the base URL for the Clawvisor instance. When set, the
+	// template uses it as the concrete URL in setup instructions instead of a
+	// generic placeholder. Empty means "not known at render time".
+	ClawvisorURL string
+
+	// ViaRelay is true when the skill is being served through the cloud relay.
+	// The template uses this to include E2E encryption guidance.
+	ViaRelay bool
+}
+
 // templateData holds the flags that control conditional rendering.
 type templateData struct {
-	Target    Target
-	UseCurl   bool
-	Condensed bool
+	Target       Target
+	UseCurl      bool
+	Condensed    bool
+	ClawvisorURL string // concrete instance URL, empty if unknown
+	ViaRelay     bool   // true when served through the relay
 }
 
 // dataForTarget returns the template data for the given target.
@@ -60,6 +74,12 @@ func dataForTarget(t Target) templateData {
 // Render produces the SKILL.md content for the given target by executing the
 // embedded template with the appropriate flags.
 func Render(target Target) (string, error) {
+	return RenderWithOptions(target, RenderOptions{})
+}
+
+// RenderWithOptions is like Render but accepts additional options that
+// customise the output (e.g. baking in a concrete CLAWVISOR_URL).
+func RenderWithOptions(target Target, opts RenderOptions) (string, error) {
 	raw, err := FS.ReadFile("clawvisor/SKILL.md.tmpl")
 	if err != nil {
 		return "", fmt.Errorf("reading SKILL.md.tmpl: %w", err)
@@ -70,8 +90,12 @@ func Render(target Target) (string, error) {
 		return "", fmt.Errorf("parsing SKILL.md.tmpl: %w", err)
 	}
 
+	data := dataForTarget(target)
+	data.ClawvisorURL = opts.ClawvisorURL
+	data.ViaRelay = opts.ViaRelay
+
 	var buf bytes.Buffer
-	if err := tmpl.Execute(&buf, dataForTarget(target)); err != nil {
+	if err := tmpl.Execute(&buf, data); err != nil {
 		return "", fmt.Errorf("executing SKILL.md.tmpl: %w", err)
 	}
 

--- a/web/src/pages/Agents.tsx
+++ b/web/src/pages/Agents.tsx
@@ -10,6 +10,7 @@ export default function Agents() {
   const [name, setName] = useState('')
   const [newToken, setNewToken] = useState<string | null>(null)
   const [formError, setFormError] = useState<string | null>(null)
+  const [showCreateForm, setShowCreateForm] = useState(false)
 
   const { data: agents, isLoading } = useQuery({
     queryKey: ['agents'],
@@ -28,6 +29,7 @@ export default function Agents() {
       setNewToken(agent.token ?? null)
       setName('')
       setFormError(null)
+      setShowCreateForm(false)
     },
     onError: (err: Error) => setFormError(err.message),
   })
@@ -46,6 +48,9 @@ export default function Agents() {
         An agent is any AI system (Claude, a custom bot, etc.) that you want to give controlled access to your services.
         Each agent gets a unique token — paste it into your agent's configuration to connect it to Clawvisor.
       </p>
+
+      {/* Connect an Agent guide */}
+      <ConnectAgentGuide />
 
       {/* Pending connection requests */}
       {pending.length > 0 && (
@@ -85,58 +90,396 @@ export default function Agents() {
         </div>
       )}
 
-      {/* Create form */}
-      <section className="bg-surface-1 border border-border-default rounded-md p-5 space-y-4">
-        <h2 className="text-sm font-semibold text-text-secondary">Create Agent</h2>
-        {formError && <div className="text-xs text-danger">{formError}</div>}
-        <div className="flex gap-3">
-          <input
-            value={name}
-            onChange={e => setName(e.target.value)}
-            placeholder="Agent name"
-            className="flex-1 text-sm rounded border border-border-default bg-surface-0 text-text-primary px-3 py-1.5 focus:outline-none focus:ring-1 focus:ring-brand/30 focus:border-brand placeholder:text-text-tertiary"
-          />
+      {/* Agent list */}
+      <section>
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-lg font-semibold text-text-primary">Your Agents</h2>
           <button
-            onClick={() => createMut.mutate()}
-            disabled={createMut.isPending || !name.trim()}
-            className="px-4 py-1.5 text-sm rounded bg-brand text-surface-0 hover:bg-brand-strong disabled:opacity-50"
+            onClick={() => { setShowCreateForm(!showCreateForm); setFormError(null) }}
+            className="text-sm px-3 py-1.5 rounded bg-brand text-surface-0 hover:bg-brand-strong"
           >
-            {createMut.isPending ? 'Creating…' : 'Create'}
+            {showCreateForm ? 'Cancel' : 'Add Agent'}
           </button>
+        </div>
+
+        {/* Inline create form */}
+        {showCreateForm && (
+          <div className="bg-surface-1 border border-border-default rounded-md p-4 mb-3 space-y-3">
+            {formError && <div className="text-xs text-danger">{formError}</div>}
+            <div className="flex gap-3">
+              <input
+                value={name}
+                onChange={e => setName(e.target.value)}
+                onKeyDown={e => { if (e.key === 'Enter' && name.trim()) createMut.mutate() }}
+                placeholder="Agent name"
+                autoFocus
+                className="flex-1 text-sm rounded border border-border-default bg-surface-0 text-text-primary px-3 py-1.5 focus:outline-none focus:ring-1 focus:ring-brand/30 focus:border-brand placeholder:text-text-tertiary"
+              />
+              <button
+                onClick={() => createMut.mutate()}
+                disabled={createMut.isPending || !name.trim()}
+                className="px-4 py-1.5 text-sm rounded bg-brand text-surface-0 hover:bg-brand-strong disabled:opacity-50"
+              >
+                {createMut.isPending ? 'Creating…' : 'Create'}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {isLoading && <div className="text-sm text-text-tertiary">Loading…</div>}
+
+        {!isLoading && (!agents || agents.length === 0) && !showCreateForm && (
+          <div className="text-sm text-text-tertiary text-center py-8 bg-surface-1 border border-border-default rounded-md">
+            No agents yet. Follow the setup guides above or click <strong>Add Agent</strong> to create one manually.
+          </div>
+        )}
+
+        <div className="space-y-2">
+          {agents?.map(agent => (
+            <div key={agent.id} className="bg-surface-1 border border-border-default rounded-md px-5 py-4 flex items-center justify-between">
+              <div>
+                <span className="font-medium text-text-primary">{agent.name}</span>
+                <p className="text-xs text-text-tertiary mt-0.5">
+                  Created {formatDistanceToNow(new Date(agent.created_at), { addSuffix: true })} · {agent.id}
+                </p>
+              </div>
+              <button
+                onClick={() => {
+                  if (confirm(`Revoke agent "${agent.name}"? Any running agents using this token will stop working.`)) {
+                    deleteMut.mutate(agent.id)
+                  }
+                }}
+                disabled={deleteMut.isPending}
+                className="text-xs px-3 py-1.5 rounded bg-danger/10 text-danger border border-danger/20 hover:bg-danger/20"
+              >
+                Revoke
+              </button>
+            </div>
+          ))}
         </div>
       </section>
 
-      {/* Agent list */}
-      {isLoading && <div className="text-sm text-text-tertiary">Loading…</div>}
+    </div>
+  )
+}
 
-      {!isLoading && (!agents || agents.length === 0) && (
-        <div className="text-sm text-text-tertiary text-center py-8">No agents yet. Create one above.</div>
-      )}
+// ── Connect an Agent guide ───────────────────────────────────────────────────
 
-      <div className="space-y-2">
-        {agents?.map(agent => (
-          <div key={agent.id} className="bg-surface-1 border border-border-default rounded-md px-5 py-4 flex items-center justify-between">
-            <div>
-              <span className="font-medium text-text-primary">{agent.name}</span>
-              <p className="text-xs text-text-tertiary mt-0.5">
-                Created {formatDistanceToNow(new Date(agent.created_at), { addSuffix: true })} · {agent.id}
-              </p>
-            </div>
-            <button
-              onClick={() => {
-                if (confirm(`Revoke agent "${agent.name}"? Any running agents using this token will stop working.`)) {
-                  deleteMut.mutate(agent.id)
-                }
-              }}
-              disabled={deleteMut.isPending}
-              className="text-xs px-3 py-1.5 rounded bg-danger/10 text-danger border border-danger/20 hover:bg-danger/20"
-            >
-              Revoke
-            </button>
-          </div>
+type AgentTab = 'claude-code' | 'claude-desktop' | 'other'
+
+function ConnectAgentGuide() {
+  const [tab, setTab] = useState<AgentTab>('claude-code')
+  const [copied, setCopied] = useState(false)
+
+  const { data: pairInfo } = useQuery({
+    queryKey: ['pairInfo'],
+    queryFn: () => api.devices.pairInfo(),
+  })
+
+  const isLocal = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1'
+  const hasRelay = !!(pairInfo?.daemon_id && pairInfo?.relay_host)
+
+  // When accessed locally, agents should talk to the daemon directly rather
+  // than routing through the relay. Use the relay URL only when the dashboard
+  // itself is being accessed remotely (cloud-hosted).
+  const clawvisorURL = isLocal
+    ? window.location.origin
+    : hasRelay
+      ? `https://${pairInfo!.relay_host}/d/${pairInfo!.daemon_id}`
+      : window.location.origin
+
+  const setupURL = hasRelay
+    ? `https://${pairInfo!.relay_host}/d/${pairInfo!.daemon_id}/skill/setup`
+    : null
+
+  const copyText = (text: string) => {
+    navigator.clipboard.writeText(text)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  const tabs: { id: AgentTab; label: string }[] = [
+    { id: 'claude-code', label: 'Claude Code' },
+    { id: 'claude-desktop', label: 'Claude Desktop' },
+    { id: 'other', label: 'Other Agents' },
+  ]
+
+  return (
+    <section className="bg-surface-1 border border-border-default rounded-md overflow-hidden">
+      <div className="px-5 pt-5 pb-0">
+        <h2 className="text-lg font-semibold text-text-primary">Connect an Agent</h2>
+        <p className="text-sm text-text-tertiary mt-1">
+          Follow the steps below to connect a coding agent to Clawvisor.
+        </p>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex gap-0 px-5 mt-4 border-b border-border-subtle">
+        {tabs.map(t => (
+          <button
+            key={t.id}
+            onClick={() => { setTab(t.id); setCopied(false) }}
+            className={`px-4 py-2.5 text-sm font-medium border-b-2 transition-colors ${
+              tab === t.id
+                ? 'border-brand text-brand'
+                : 'border-transparent text-text-tertiary hover:text-text-secondary'
+            }`}
+          >
+            {t.label}
+          </button>
         ))}
       </div>
 
+      <div className="p-5">
+        {tab === 'claude-code' && <ClaudeCodeGuide clawvisorURL={clawvisorURL} onCopy={copyText} />}
+        {tab === 'claude-desktop' && <ClaudeDesktopGuide clawvisorURL={clawvisorURL} />}
+        {tab === 'other' && <OtherAgentGuide setupURL={setupURL} clawvisorURL={clawvisorURL} copied={copied} onCopy={copyText} />}
+      </div>
+    </section>
+  )
+}
+
+function StepNumber({ n }: { n: number }) {
+  return (
+    <span className="flex-shrink-0 w-6 h-6 rounded-full bg-brand/10 text-brand text-xs font-bold flex items-center justify-center">
+      {n}
+    </span>
+  )
+}
+
+function CodeBlock({ children, onCopy }: { children: string; onCopy?: () => void }) {
+  return (
+    <div className="relative group">
+      <pre className="bg-surface-0 border border-border-subtle rounded px-3 py-2.5 text-xs font-mono text-text-primary overflow-x-auto whitespace-pre-wrap break-all">
+        {children}
+      </pre>
+      {onCopy && (
+        <button
+          onClick={onCopy}
+          className="absolute top-2 right-2 text-xs px-2 py-1 rounded border border-border-subtle text-text-tertiary hover:text-text-primary hover:bg-surface-1 opacity-0 group-hover:opacity-100 transition-opacity"
+        >
+          Copy
+        </button>
+      )}
+    </div>
+  )
+}
+
+function ClaudeCodeGuide({ clawvisorURL, onCopy }: {
+  clawvisorURL: string
+  onCopy: (text: string) => void
+}) {
+  const installCmd = `mkdir -p ~/.claude/commands && curl -sf "${clawvisorURL}/skill/clawvisor-setup.md" -o ~/.claude/commands/clawvisor-setup.md`
+
+  return (
+    <div className="space-y-5">
+      <p className="text-sm text-text-secondary">
+        Install a slash command, then run it in Claude Code. It handles agent registration,
+        skill installation, environment setup, and a smoke test — all interactively.
+      </p>
+
+      <div className="flex items-start gap-3">
+        <StepNumber n={1} />
+        <div className="space-y-1.5 min-w-0 flex-1">
+          <p className="text-sm font-medium text-text-primary">Install the setup command</p>
+          <p className="text-xs text-text-tertiary">
+            Run this in your terminal to install the{' '}
+            <code className="font-mono text-text-secondary">/clawvisor-setup</code> slash command:
+          </p>
+          <CodeBlock onCopy={() => onCopy(installCmd)}>{installCmd}</CodeBlock>
+        </div>
+      </div>
+
+      <div className="flex items-start gap-3">
+        <StepNumber n={2} />
+        <div className="space-y-1.5 min-w-0 flex-1">
+          <p className="text-sm font-medium text-text-primary">Run /clawvisor-setup in Claude Code</p>
+          <p className="text-xs text-text-tertiary">
+            Open Claude Code and type{' '}
+            <code className="font-mono text-text-secondary">/clawvisor-setup</code>.
+            Claude will walk you through the setup — registering as an agent, configuring
+            environment variables, and verifying the connection.
+          </p>
+        </div>
+      </div>
+
+      <div className="flex items-start gap-3">
+        <StepNumber n={3} />
+        <div className="space-y-1.5 min-w-0 flex-1">
+          <p className="text-sm font-medium text-text-primary">Approve the connection</p>
+          <p className="text-xs text-text-tertiary">
+            During setup, Claude Code sends a connection request. Approve it in the{' '}
+            <strong>Pending Connections</strong> section above. Once approved, Claude Code
+            finishes setup automatically and runs a smoke test.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function ClaudeDesktopGuide({ clawvisorURL }: { clawvisorURL: string }) {
+  const mcpURL = `${clawvisorURL}/mcp`
+  const configSnippet = `{
+  "mcpServers": {
+    "clawvisor": {
+      "command": "npx",
+      "args": ["mcp-remote", "${mcpURL}"]
+    }
+  }
+}`
+
+  return (
+    <div className="space-y-5">
+      <p className="text-sm text-text-secondary">
+        Claude Desktop connects to Clawvisor via MCP (Model Context Protocol). No token or skill install needed —
+        authorization happens through an OAuth flow in your browser.
+      </p>
+
+      <div className="flex items-start gap-3">
+        <StepNumber n={1} />
+        <div className="space-y-1.5 min-w-0 flex-1">
+          <p className="text-sm font-medium text-text-primary">Add the MCP server config</p>
+          <p className="text-xs text-text-tertiary">
+            Open Claude Desktop settings (<strong>Settings &rarr; Developer &rarr; Edit Config</strong>) and add:
+          </p>
+          <CodeBlock>{configSnippet}</CodeBlock>
+          <p className="text-xs text-text-tertiary">
+            On macOS the config file is at{' '}
+            <code className="font-mono text-text-secondary">~/Library/Application Support/Claude/claude_desktop_config.json</code>.
+            Merge with any existing servers.
+          </p>
+        </div>
+      </div>
+
+      <div className="flex items-start gap-3">
+        <StepNumber n={2} />
+        <div className="space-y-1.5 min-w-0 flex-1">
+          <p className="text-sm font-medium text-text-primary">Restart Claude Desktop</p>
+          <p className="text-xs text-text-tertiary">
+            Quit and reopen Claude Desktop so it picks up the new MCP server.
+          </p>
+        </div>
+      </div>
+
+      <div className="flex items-start gap-3">
+        <StepNumber n={3} />
+        <div className="space-y-1.5 min-w-0 flex-1">
+          <p className="text-sm font-medium text-text-primary">Authorize</p>
+          <p className="text-xs text-text-tertiary">
+            When Claude Desktop first connects, a browser window opens where you log in and approve access.
+            The agent appears in the list above automatically.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function OtherAgentGuide({ setupURL, clawvisorURL, copied, onCopy }: {
+  setupURL: string | null
+  clawvisorURL: string
+  copied: boolean
+  onCopy: (text: string) => void
+}) {
+  const prompt = setupURL
+    ? `I'd like to set up Clawvisor as the trusted gateway for using data and services. Please follow the instructions at:\n${setupURL}`
+    : null
+
+  return (
+    <div className="space-y-5">
+      <p className="text-sm text-text-secondary">
+        Any agent that can make HTTP requests can connect to Clawvisor. The fastest way is to paste the setup
+        prompt below directly into your agent's chat — it will self-register and wait for your approval.
+      </p>
+
+      {/* Paste-the-prompt approach */}
+      {prompt ? (
+        <div className="space-y-4">
+          <div className="flex items-start gap-3">
+            <StepNumber n={1} />
+            <div className="space-y-1.5 min-w-0 flex-1">
+              <p className="text-sm font-medium text-text-primary">Paste this into your agent</p>
+              <div className="relative group">
+                <pre className="bg-surface-0 border border-brand/20 rounded px-3 py-2.5 text-xs font-mono text-text-primary overflow-x-auto whitespace-pre-wrap break-all">
+                  {prompt}
+                </pre>
+                <button
+                  onClick={() => onCopy(prompt)}
+                  className="absolute top-2 right-2 text-xs px-2 py-1 rounded border border-border-subtle text-text-tertiary hover:text-text-primary hover:bg-surface-1"
+                >
+                  {copied ? 'Copied' : 'Copy'}
+                </button>
+              </div>
+              <p className="text-xs text-text-tertiary">
+                The agent will follow the setup instructions at that URL — it registers itself,
+                sets up E2E encryption, and installs the Clawvisor skill.
+              </p>
+            </div>
+          </div>
+
+          <div className="flex items-start gap-3">
+            <StepNumber n={2} />
+            <div className="space-y-1.5 min-w-0 flex-1">
+              <p className="text-sm font-medium text-text-primary">Approve the connection</p>
+              <p className="text-xs text-text-tertiary">
+                A connection request will appear in the <strong>Pending Connections</strong> section above.
+                Click <strong>Approve</strong> to grant the agent a token. It receives the token automatically
+                and is ready to go.
+              </p>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div className="bg-surface-0 border border-border-subtle rounded-md px-4 py-3">
+          <p className="text-sm text-text-tertiary">
+            The one-click setup prompt requires a relay connection. Complete the initial Clawvisor setup,
+            then reload this page. You can still use the manual setup below.
+          </p>
+        </div>
+      )}
+
+      {/* Manual path */}
+      <details className="group">
+        <summary className="text-sm font-medium text-text-secondary cursor-pointer hover:text-text-primary select-none">
+          Manual setup (token + environment variables)
+        </summary>
+        <div className="mt-4 space-y-4 pl-0">
+          <div className="flex items-start gap-3">
+            <StepNumber n={1} />
+            <div className="space-y-1.5 min-w-0 flex-1">
+              <p className="text-sm font-medium text-text-primary">Create an agent token</p>
+              <p className="text-xs text-text-tertiary">
+                Use the <strong>Create Agent</strong> form above. Copy the token — it's shown only once.
+              </p>
+            </div>
+          </div>
+
+          <div className="flex items-start gap-3">
+            <StepNumber n={2} />
+            <div className="space-y-1.5 min-w-0 flex-1">
+              <p className="text-sm font-medium text-text-primary">Configure environment variables</p>
+              <p className="text-xs text-text-tertiary">
+                Set these in your agent's environment (<code className="font-mono text-text-secondary">.env</code>, shell profile, container config, etc.):
+              </p>
+              <CodeBlock>{`CLAWVISOR_URL=${clawvisorURL}\nCLAWVISOR_AGENT_TOKEN=<your token>`}</CodeBlock>
+            </div>
+          </div>
+
+          <div className="flex items-start gap-3">
+            <StepNumber n={3} />
+            <div className="space-y-1.5 min-w-0 flex-1">
+              <p className="text-sm font-medium text-text-primary">Verify</p>
+              <CodeBlock>{`curl -sf -H "Authorization: Bearer $CLAWVISOR_AGENT_TOKEN" \\\n  "$CLAWVISOR_URL/api/skill/catalog" | head -20`}</CodeBlock>
+              <p className="text-xs text-text-tertiary">
+                Should return a JSON catalog of available services. See{' '}
+                <code className="font-mono text-text-secondary">{clawvisorURL}/skill/SKILL.md</code>{' '}
+                for the full protocol reference.
+              </p>
+            </div>
+          </div>
+        </div>
+      </details>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Adds a "Connect an Agent" section to the Agents page with tabbed guides for Claude Code, Claude Desktop, and other agents
- All URLs (curl commands, skill files, MCP config) are context-aware: local access uses `localhost` directly, relay access uses the public relay URL — no unnecessary hops
- New `GET /skill/clawvisor-setup.md` endpoint serves a URL-aware `/clawvisor-setup` slash command for Claude Code
- SKILL.md template now renders with the concrete instance URL and conditionally includes E2E encryption guidance only when served via relay
- Agent list moved below guides; "Create Agent" form replaced with a togglable "Add Agent" button

## Test plan
- [ ] Access dashboard on localhost — verify all guide URLs use `http://localhost:25297`
- [ ] Access dashboard via relay — verify URLs use the relay prefix and SKILL.md includes E2E guidance
- [ ] Curl `/skill/clawvisor-setup.md` locally and via relay, confirm URLs match access context
- [ ] Curl `/skill/SKILL.md` locally and via relay, confirm setup section adapts
- [ ] Click through Claude Code / Claude Desktop / Other Agents tabs
- [ ] Test Add Agent toggle, create flow, and revoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)