### PR TITLE
feat: add user_id to agent connection requests for multi-tenant support

### DIFF
--- a/internal/api/handlers/connections.go
+++ b/internal/api/handlers/connections.go
@@ -34,10 +34,11 @@ const (
 
 // ConnectionsHandler manages agent connection request lifecycle.
 type ConnectionsHandler struct {
-	st       store.Store
-	notifier notify.Notifier
-	eventHub events.EventHub
-	logger   *slog.Logger
+	st          store.Store
+	notifier    notify.Notifier
+	eventHub    events.EventHub
+	logger      *slog.Logger
+	multiTenant bool
 
 	// In-memory token cache: connection request ID → {raw token, approved time}.
 	// Tokens are never persisted — raw tokens must not hit the DB for security.
@@ -61,14 +62,15 @@ type approvedToken struct {
 }
 
 func NewConnectionsHandler(st store.Store, notifier notify.Notifier,
-	eventHub events.EventHub, logger *slog.Logger) *ConnectionsHandler {
+	eventHub events.EventHub, logger *slog.Logger, multiTenant bool) *ConnectionsHandler {
 	return &ConnectionsHandler{
-		st:       st,
-		notifier: notifier,
-		eventHub: eventHub,
-		logger:   logger,
-		tokens:   make(map[string]approvedToken),
-		ipPolls:  make(map[string]int),
+		st:          st,
+		notifier:    notifier,
+		eventHub:    eventHub,
+		logger:      logger,
+		multiTenant: multiTenant,
+		tokens:      make(map[string]approvedToken),
+		ipPolls:     make(map[string]int),
 	}
 }
 
@@ -79,6 +81,7 @@ func (h *ConnectionsHandler) RequestConnect(w http.ResponseWriter, r *http.Reque
 		Name        string `json:"name"`
 		Description string `json:"description"`
 		CallbackURL string `json:"callback_url"`
+		UserID      string `json:"user_id"`
 	}
 	if !decodeJSON(w, r, &body) {
 		return
@@ -99,11 +102,25 @@ func (h *ConnectionsHandler) RequestConnect(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	// Resolve daemon owner — single-user daemon uses admin@local.
-	owner, err := h.st.GetUserByEmail(r.Context(), "admin@local")
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not resolve daemon owner")
+	// Resolve the target user. In multi-tenant mode, user_id is required so
+	// the connection request is routed to the correct user. In single-tenant
+	// mode, fall back to admin@local for backward compatibility.
+	var owner *store.User
+	if body.UserID != "" {
+		owner, err = h.st.GetUserByID(r.Context(), body.UserID)
+		if err != nil {
+			writeError(w, http.StatusNotFound, "USER_NOT_FOUND", "user not found")
+			return
+		}
+	} else if h.multiTenant {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "user_id is required")
 		return
+	} else {
+		owner, err = h.st.GetUserByEmail(r.Context(), "admin@local")
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not resolve daemon owner")
+			return
+		}
 	}
 
 	req := &store.ConnectionRequest{

--- a/internal/api/handlers/onboarding.go
+++ b/internal/api/handlers/onboarding.go
@@ -3,10 +3,13 @@ package handlers
 import (
 	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
 
 	"github.com/clawvisor/clawvisor/internal/relay"
 )
+
+var validUserID = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 
 // OnboardingHandler serves the agent onboarding document at GET /setup.
 // The document is self-contained markdown that tells an agent how to register,
@@ -40,6 +43,11 @@ func (h *OnboardingHandler) Setup(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(&b, "```\n\n")
 	fmt.Fprintf(&b, "All API calls below use this URL.\n\n")
 
+	userID := r.URL.Query().Get("user_id")
+	if userID != "" && !validUserID.MatchString(userID) {
+		userID = ""
+	}
+
 	fmt.Fprintf(&b, "## 2. Register with the daemon and wait for approval\n\n")
 	fmt.Fprintf(&b, "Send a connection request with `?wait=true`. The daemon owner will be notified,\n")
 	fmt.Fprintf(&b, "and the request blocks until they approve (or the timeout elapses).\n\n")
@@ -48,6 +56,9 @@ func (h *OnboardingHandler) Setup(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(&b, "  -H \"Content-Type: application/json\" \\\n")
 	fmt.Fprintf(&b, "  -d '{\n")
 	fmt.Fprintf(&b, "    \"name\": \"<your agent name>\",\n")
+	if userID != "" {
+		fmt.Fprintf(&b, "    \"user_id\": \"%s\",\n", userID)
+	}
 	fmt.Fprintf(&b, "    \"description\": \"<brief description of what you do>\"\n")
 	fmt.Fprintf(&b, "  }'\n")
 	fmt.Fprintf(&b, "```\n\n")
@@ -147,6 +158,15 @@ func (h *OnboardingHandler) resolveURL(r *http.Request) string {
 func (h *OnboardingHandler) ClaudeCodeSetup(w http.ResponseWriter, r *http.Request) {
 	clawvisorURL := h.resolveURL(r)
 	skillURL := clawvisorURL + "/skill/SKILL.md"
+	userID := r.URL.Query().Get("user_id")
+	if userID != "" && !validUserID.MatchString(userID) {
+		userID = ""
+	}
+
+	connectBody := `{"name": "claude-code", "description": "Claude Code agent"}`
+	if userID != "" {
+		connectBody = fmt.Sprintf(`{"name": "claude-code", "description": "Claude Code agent", "user_id": "%s"}`, userID)
+	}
 
 	var b strings.Builder
 	b.WriteString("Set up Clawvisor in the current project so Claude Code can make gated API\n")
@@ -158,7 +178,7 @@ func (h *OnboardingHandler) ClaudeCodeSetup(w http.ResponseWriter, r *http.Reque
 	b.WriteString("### 1. Connect as an agent\n\n")
 	b.WriteString("Register with the daemon and wait for the user to approve:\n\n")
 	b.WriteString("```bash\n")
-	fmt.Fprintf(&b, "curl -s -X POST \"%s/api/agents/connect?wait=true&timeout=120\" -H \"Content-Type: application/json\" -d '{\"name\": \"claude-code\", \"description\": \"Claude Code agent\"}'\n", clawvisorURL)
+	fmt.Fprintf(&b, "curl -s -X POST \"%s/api/agents/connect?wait=true&timeout=120\" -H \"Content-Type: application/json\" -d '%s'\n", clawvisorURL, connectBody)
 	b.WriteString("```\n\n")
 	b.WriteString("This sends a connection request to the daemon. The user will be notified\n")
 	b.WriteString("to approve. The `?wait=true` parameter makes the request block until the\n")

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -483,7 +483,7 @@ func (s *Server) routes() http.Handler {
 	}
 
 	// Connection requests (unauthenticated — agents requesting access)
-	connectionsHandler := handlers.NewConnectionsHandler(s.store, s.notifier, s.eventHub, s.logger)
+	connectionsHandler := handlers.NewConnectionsHandler(s.store, s.notifier, s.eventHub, s.logger, s.features.MultiTenant)
 	s.connectionsHandler = connectionsHandler
 	connectionsRL := newKeyedLimiterFromBucket(config.RateLimitBucket{Limit: 10, Window: 60})
 	mux.Handle("POST /api/agents/connect",

--- a/web/src/pages/Agents.tsx
+++ b/web/src/pages/Agents.tsx
@@ -4,6 +4,7 @@ import { api } from '../api/client'
 import type { ConnectionRequest } from '../api/client'
 import { formatDistanceToNow } from 'date-fns'
 import CountdownTimer from '../components/CountdownTimer'
+import { useAuth } from '../hooks/useAuth'
 
 export default function Agents() {
   const qc = useQueryClient()
@@ -170,6 +171,7 @@ type AgentTab = 'claude-code' | 'claude-desktop' | 'other'
 function ConnectAgentGuide() {
   const [tab, setTab] = useState<AgentTab>('claude-code')
   const [copied, setCopied] = useState(false)
+  const { user } = useAuth()
 
   const { data: pairInfo } = useQuery({
     queryKey: ['pairInfo'],
@@ -188,8 +190,10 @@ function ConnectAgentGuide() {
       ? `https://${pairInfo!.relay_host}/d/${pairInfo!.daemon_id}`
       : window.location.origin
 
+  const userIdParam = user?.id ? `?user_id=${encodeURIComponent(user.id)}` : ''
+
   const setupURL = hasRelay
-    ? `https://${pairInfo!.relay_host}/d/${pairInfo!.daemon_id}/skill/setup`
+    ? `https://${pairInfo!.relay_host}/d/${pairInfo!.daemon_id}/skill/setup${userIdParam}`
     : null
 
   const copyText = (text: string) => {
@@ -231,7 +235,7 @@ function ConnectAgentGuide() {
       </div>
 
       <div className="p-5">
-        {tab === 'claude-code' && <ClaudeCodeGuide clawvisorURL={clawvisorURL} onCopy={copyText} />}
+        {tab === 'claude-code' && <ClaudeCodeGuide clawvisorURL={clawvisorURL} userIdParam={userIdParam} onCopy={copyText} />}
         {tab === 'claude-desktop' && <ClaudeDesktopGuide clawvisorURL={clawvisorURL} />}
         {tab === 'other' && <OtherAgentGuide setupURL={setupURL} clawvisorURL={clawvisorURL} copied={copied} onCopy={copyText} />}
       </div>
@@ -265,11 +269,12 @@ function CodeBlock({ children, onCopy }: { children: string; onCopy?: () => void
   )
 }
 
-function ClaudeCodeGuide({ clawvisorURL, onCopy }: {
+function ClaudeCodeGuide({ clawvisorURL, userIdParam, onCopy }: {
   clawvisorURL: string
+  userIdParam: string
   onCopy: (text: string) => void
 }) {
-  const installCmd = `mkdir -p ~/.claude/commands && curl -sf "${clawvisorURL}/skill/clawvisor-setup.md" -o ~/.claude/commands/clawvisor-setup.md`
+  const installCmd = `mkdir -p ~/.claude/commands && curl -sf "${clawvisorURL}/skill/clawvisor-setup.md${userIdParam}" -o ~/.claude/commands/clawvisor-setup.md`
 
   return (
     <div className="space-y-5">


### PR DESCRIPTION
## Summary

- `POST /api/agents/connect` now accepts `user_id` in the request body to route connection requests to the correct user in multi-tenant deployments
- In multi-tenant mode, `user_id` is required; in single-tenant mode it falls back to `admin@local` for backward compatibility
- The dashboard and onboarding setup docs (`/skill/setup`, `/skill/clawvisor-setup.md`) embed the logged-in user's ID into all generated agent setup instructions
- `user_id` values interpolated into onboarding markdown are validated against an alphanumeric pattern to prevent injection into generated curl commands

## Test plan

- [ ] `go build ./...` and `npx tsc --noEmit` pass
- [ ] Open Agents page — verify setup instructions include `user_id` in curl commands and download URLs
- [ ] `POST /api/agents/connect` with valid `user_id` creates a connection request for that user
- [ ] `POST /api/agents/connect` without `user_id` in single-tenant mode falls back to `admin@local`
- [ ] `POST /api/agents/connect` without `user_id` in multi-tenant mode returns 400
- [ ] `POST /api/agents/connect` with nonexistent `user_id` returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)