### PR TITLE
fix: resolve service alias fallback and web/dist embed for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,9 @@ vault.key
 
 # Frontend
 web/node_modules/
-web/dist/
+web/dist/*
+!web/dist/.gitkeep
+!web/dist/placeholder.html
 
 # IDE
 .idea/

--- a/e2e/smoke/harness_test.go
+++ b/e2e/smoke/harness_test.go
@@ -523,22 +523,28 @@ func (e *e2eEnv) pickActivatedReadService(t *testing.T) (svcID, action string, p
 		t.Skipf("skipping: could not parse services list")
 	}
 
-	activated := map[string]bool{}
+	// activated maps base service ID → full service ID (with alias if present).
+	activated := map[string]string{}
 	for _, raw := range list {
 		svc, ok := raw.(map[string]any)
 		if !ok {
 			continue
 		}
 		id := strOr(svc, "id", "")
+		alias := strOr(svc, "alias", "")
 		status := strOr(svc, "status", "")
 		if status == "activated" || status == "active" || status == "connected" {
-			activated[id] = true
+			fullID := id
+			if alias != "" {
+				fullID = id + ":" + alias
+			}
+			activated[id] = fullID
 		}
 	}
 
 	for _, c := range readServiceCandidates {
-		if activated[c.svcID] {
-			return c.svcID, c.action, c.params
+		if fullID, ok := activated[c.svcID]; ok {
+			return fullID, c.action, c.params
 		}
 	}
 
@@ -550,7 +556,12 @@ func (e *e2eEnv) pickActivatedReadService(t *testing.T) (svcID, action string, p
 // Returns "" if no second action is available for the service.
 func (e *e2eEnv) pickSecondAction(t *testing.T, svcID, firstAction string) string {
 	t.Helper()
-	second, ok := secondReadActions[svcID]
+	// Strip alias (e.g. "github:ericlevine" → "github") for lookup.
+	baseID := svcID
+	if idx := strings.IndexByte(svcID, ':'); idx >= 0 {
+		baseID = svcID[:idx]
+	}
+	second, ok := secondReadActions[baseID]
 	if !ok || second == firstAction {
 		return ""
 	}

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -382,23 +382,32 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			// Check activation for credential-free services before executing.
 			if taskAdapter, taskAdapterOK := h.adapterReg.GetForUser(ctx, serviceType, agent.UserID); taskAdapterOK && taskAdapter.ValidateCredential(nil) == nil {
 				if _, metaErr := h.store.GetServiceMeta(ctx, agent.UserID, serviceType, serviceAlias); metaErr != nil {
-					dur := int(time.Since(start).Milliseconds())
-					e := baseEntry("block", "error", taskIDPtr)
-					e.DurationMS = dur
-					code, userErr, auditMsg := serviceNotActivatedResponse(ctx, h.vault, h.store, h.adapterReg, agent.UserID, serviceType, serviceAlias, req.Service, taskAdapter)
-					e.ErrorMsg = &auditMsg
-					if logErr := h.store.LogAudit(ctx, e); logErr != nil {
-						h.logger.Warn("audit log failed", "err", logErr)
+					// If no alias was specified, check if any alias is activated.
+					anyActivated := false
+					if serviceAlias == "" || serviceAlias == "default" {
+						if count, cErr := h.store.CountServiceMetasByType(ctx, agent.UserID, serviceType); cErr == nil && count > 0 {
+							anyActivated = true
+						}
 					}
-					h.publishAuditAndQueue(agent.UserID, req.TaskID)
-					writeJSON(w, http.StatusBadRequest, map[string]any{
-						"status":     "error",
-						"request_id": req.RequestID,
-						"audit_id":   auditID,
-						"error":      userErr,
-						"code":       code,
-					})
-					return
+					if !anyActivated {
+						dur := int(time.Since(start).Milliseconds())
+						e := baseEntry("block", "error", taskIDPtr)
+						e.DurationMS = dur
+						code, userErr, auditMsg := serviceNotActivatedResponse(ctx, h.vault, h.store, h.adapterReg, agent.UserID, serviceType, serviceAlias, req.Service, taskAdapter)
+						e.ErrorMsg = &auditMsg
+						if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+							h.logger.Warn("audit log failed", "err", logErr)
+						}
+						h.publishAuditAndQueue(agent.UserID, req.TaskID)
+						writeJSON(w, http.StatusBadRequest, map[string]any{
+							"status":     "error",
+							"request_id": req.RequestID,
+							"audit_id":   auditID,
+							"error":      userErr,
+							"code":       code,
+						})
+						return
+					}
 				}
 			}
 
@@ -555,12 +564,26 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 		notActivated := false
 		if approveAdapter.ValidateCredential(nil) == nil {
 			if _, metaErr := h.store.GetServiceMeta(ctx, agent.UserID, serviceType, serviceAlias); metaErr != nil {
-				notActivated = true
+				// No exact match — if no alias was specified, check any alias.
+				if serviceAlias == "" || serviceAlias == "default" {
+					if count, cErr := h.store.CountServiceMetasByType(ctx, agent.UserID, serviceType); cErr != nil || count == 0 {
+						notActivated = true
+					}
+				} else {
+					notActivated = true
+				}
 			}
 		} else {
 			vKey := h.adapterReg.VaultKeyWithAliasForUser(serviceType, serviceAlias, agent.UserID)
 			if _, vaultErr := h.vault.Get(ctx, agent.UserID, vKey); errors.Is(vaultErr, vault.ErrNotFound) {
-				notActivated = true
+				// No exact match — if no alias was specified, check any alias.
+				if serviceAlias == "" || serviceAlias == "default" {
+					if !hasAnyAlias(ctx, h.vault, h.adapterReg, agent.UserID, serviceType) {
+						notActivated = true
+					}
+				} else {
+					notActivated = true
+				}
 			}
 		}
 		if notActivated {

--- a/internal/api/handlers/tasks.go
+++ b/internal/api/handlers/tasks.go
@@ -1236,13 +1236,27 @@ func (h *TasksHandler) Revoke(w http.ResponseWriter, r *http.Request) {
 func (h *TasksHandler) serviceActivated(ctx context.Context, userID, serviceType, alias string, adapter adapters.Adapter) bool {
 	if adapter.ValidateCredential(nil) == nil {
 		// Credential-free: check service_meta.
-		_, err := h.st.GetServiceMeta(ctx, userID, serviceType, alias)
-		return err == nil
+		if _, err := h.st.GetServiceMeta(ctx, userID, serviceType, alias); err == nil {
+			return true
+		}
+		// No exact match — if no alias was specified, check any alias.
+		if alias == "" || alias == "default" {
+			if count, err := h.st.CountServiceMetasByType(ctx, userID, serviceType); err == nil && count > 0 {
+				return true
+			}
+		}
+		return false
 	}
 	// Credential-backed: check vault.
 	vKey := h.adapterReg.VaultKeyWithAlias(serviceType, alias)
-	_, err := h.vault.Get(ctx, userID, vKey)
-	return err == nil
+	if _, err := h.vault.Get(ctx, userID, vKey); err == nil {
+		return true
+	}
+	// No exact match — if no alias was specified, check any alias.
+	if alias == "" || alias == "default" {
+		return hasAnyAlias(ctx, h.vault, h.adapterReg, userID, serviceType)
+	}
+	return false
 }
 
 // ── Task scope check helper ───────────────────────────────────────────────────

--- a/web/dist/placeholder.html
+++ b/web/dist/placeholder.html
@@ -1,0 +1,1 @@
+<!-- placeholder so go:embed dist works without a frontend build -->

--- a/web/src/pages/Agents.tsx
+++ b/web/src/pages/Agents.tsx
@@ -5,7 +5,6 @@ import type { ConnectionRequest } from '../api/client'
 import { useAuth } from '../hooks/useAuth'
 import { formatDistanceToNow } from 'date-fns'
 import CountdownTimer from '../components/CountdownTimer'
-import { useAuth } from '../hooks/useAuth'
 
 export default function Agents() {
   const { currentOrg } = useAuth()


### PR DESCRIPTION
## Summary
- Fixes service activation checks in task creation and gateway handlers to fall back to any alias when no specific alias is provided (e.g. `github` resolves to `github:ericlevine`)
- Adds a `web/dist/placeholder.html` tracked in git so `go:embed dist` works without a frontend build, unblocking `go test ./...`
- Updates e2e smoke test harness to include the full service:alias ID when picking activated services

## Test plan
- [x] `go test ./...` passes with all previously failing e2e/smoke tests now green
- [x] Verified `go build ./...` compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)