### PR TITLE
ci: sync SKILL.md to cowork-plugin repo on release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -108,3 +108,57 @@ jobs:
           npx clawhub auth login --token "$CLAWHUB_TOKEN" --no-browser
           VERSION=$(jq -r '."."' .release-please-manifest.json)
           npx clawhub publish "$GITHUB_WORKSPACE/dist/skill" --slug clawvisor --version "$VERSION"
+
+  sync-cowork-plugin:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
+          fetch-depth: 0
+
+      - name: Check for skill changes
+        id: skill-changes
+        env:
+          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+        run: |
+          git fetch --tags --quiet
+          PREV_TAG=$(git tag --sort=-v:refname | grep -E '^v[0-9]' | grep -v "^${TAG_NAME}$" | head -1)
+          if [ -z "$PREV_TAG" ]; then
+            echo "No previous tag found, treating as changed"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          elif git diff --name-only "$PREV_TAG" HEAD | grep -qE '^skills/clawvisor/'; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup Go
+        if: steps.skill-changes.outputs.changed == 'true'
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Render SKILL.md for cowork target
+        if: steps.skill-changes.outputs.changed == 'true'
+        run: go run ./cmd/render-skill cowork > /tmp/SKILL.md
+
+      - name: Push to cowork-plugin repo
+        if: steps.skill-changes.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.COWORK_PLUGIN_TOKEN }}
+        run: |
+          git clone https://x-access-token:${GH_TOKEN}@github.com/clawvisor/cowork-plugin.git /tmp/cowork-plugin
+          cp /tmp/SKILL.md /tmp/cowork-plugin/skills/clawvisor/SKILL.md
+          cd /tmp/cowork-plugin
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet; then
+            echo "No changes to SKILL.md, skipping"
+          else
+            git add skills/clawvisor/SKILL.md
+            git commit -m "chore: sync SKILL.md from cayenne ${{ needs.release-please.outputs.tag_name }}"
+            git push
+          fi

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -109,7 +109,7 @@ jobs:
           VERSION=$(jq -r '."."' .release-please-manifest.json)
           npx clawhub publish "$GITHUB_WORKSPACE/dist/skill" --slug clawvisor --version "$VERSION"
 
-  sync-cowork-plugin:
+  sync-cowork-plugins:
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
     runs-on: ubuntu-latest
@@ -145,20 +145,21 @@ jobs:
         if: steps.skill-changes.outputs.changed == 'true'
         run: go run ./cmd/render-skill cowork > /tmp/SKILL.md
 
-      - name: Push to cowork-plugin repo
+      - name: Push to cowork-plugins repo
         if: steps.skill-changes.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.COWORK_PLUGIN_TOKEN }}
+          GH_TOKEN: ${{ secrets.COWORK_PLUGINS_TOKEN }}
         run: |
-          git clone https://x-access-token:${GH_TOKEN}@github.com/clawvisor/cowork-plugin.git /tmp/cowork-plugin
-          cp /tmp/SKILL.md /tmp/cowork-plugin/skills/clawvisor/SKILL.md
-          cd /tmp/cowork-plugin
+          git clone https://x-access-token:${GH_TOKEN}@github.com/clawvisor/cowork-plugins.git /tmp/cowork-plugins
+          cp /tmp/SKILL.md /tmp/cowork-plugins/plugins/clawvisor/skills/clawvisor/SKILL.md
+          cp /tmp/SKILL.md /tmp/cowork-plugins/plugins/clawvisor-local/skills/clawvisor/SKILL.md
+          cd /tmp/cowork-plugins
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           if git diff --quiet; then
             echo "No changes to SKILL.md, skipping"
           else
-            git add skills/clawvisor/SKILL.md
+            git add plugins/clawvisor/skills/clawvisor/SKILL.md plugins/clawvisor-local/skills/clawvisor/SKILL.md
             git commit -m "chore: sync SKILL.md from cayenne ${{ needs.release-please.outputs.tag_name }}"
             git push
           fi

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -141,16 +141,23 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Generate GitHub App token
+        if: steps.skill-changes.outputs.changed == 'true'
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          repositories: cowork-plugins
+
       - name: Render SKILL.md for cowork target
         if: steps.skill-changes.outputs.changed == 'true'
         run: go run ./cmd/render-skill cowork > /tmp/SKILL.md
 
       - name: Push to cowork-plugins repo
         if: steps.skill-changes.outputs.changed == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.COWORK_PLUGINS_TOKEN }}
         run: |
-          git clone https://x-access-token:${GH_TOKEN}@github.com/clawvisor/cowork-plugins.git /tmp/cowork-plugins
+          git clone https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/clawvisor/cowork-plugins.git /tmp/cowork-plugins
           cp /tmp/SKILL.md /tmp/cowork-plugins/plugins/clawvisor/skills/clawvisor/SKILL.md
           cp /tmp/SKILL.md /tmp/cowork-plugins/plugins/clawvisor-local/skills/clawvisor/SKILL.md
           cd /tmp/cowork-plugins


### PR DESCRIPTION
Adds a `sync-cowork-plugin` job to the release workflow that renders SKILL.md using the `cowork` target and pushes it to `clawvisor/cowork-plugin`. The job only runs when `skills/clawvisor/` files change between releases, matching the existing `publish-skill` behavior. Requires a `COWORK_PLUGIN_TOKEN` repo secret with write access to the cowork-plugin repo.