### PR TITLE
fix: serve clawvisor-setup.md in cloud deployments

### DIFF
--- a/internal/api/handlers/onboarding.go
+++ b/internal/api/handlers/onboarding.go
@@ -144,6 +144,9 @@ func (h *OnboardingHandler) resolveURL(r *http.Request) string {
 		if r.TLS != nil {
 			scheme = "https"
 		}
+		if fp := r.Header.Get("X-Forwarded-Proto"); fp != "" {
+			scheme = fp
+		}
 		return scheme + "://" + r.Host
 	}
 	if h.daemonID != "" && h.relayHost != "" {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -618,10 +618,12 @@ func (s *Server) routes() http.Handler {
 	mux.HandleFunc("GET /skill", func(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/skill/SKILL.md", http.StatusFound)
 	})
-	if s.daemonID != "" {
+	{
 		relayHost := relayHostFromCfg(s.cfg.Relay.URL)
 		onboardingHandler := handlers.NewOnboardingHandler(relayHost, s.daemonID)
-		mux.HandleFunc("GET /skill/setup", onboardingHandler.Setup)
+		if s.daemonID != "" {
+			mux.HandleFunc("GET /skill/setup", onboardingHandler.Setup)
+		}
 		mux.HandleFunc("GET /skill/clawvisor-setup.md", onboardingHandler.ClaudeCodeSetup)
 	}
 	// skillRenderOpts builds RenderOptions based on whether the request


### PR DESCRIPTION
## Summary
- Register the `GET /skill/clawvisor-setup.md` route unconditionally instead of gating it behind `s.daemonID != ""`. Cloud deployments have no daemon ID, so the dynamic handler was never registered and requests fell through to the static file server which returned a generic version with hardcoded localhost URLs.
- Respect `X-Forwarded-Proto` header in `resolveURL` so the correct HTTPS scheme is used behind a TLS-terminating load balancer (e.g. Cloud Run).
- The `/skill/setup` (full onboarding doc) remains gated behind daemon ID since it requires relay connectivity.

## Test plan
- [ ] Deploy to staging and verify `curl https://app.staging.clawvisor.com/skill/clawvisor-setup.md?user_id=<id>` returns markdown with the correct `https://app.staging.clawvisor.com` base URL
- [ ] Verify local daemon still works: `curl http://localhost:25297/skill/clawvisor-setup.md` returns localhost-based URLs
- [ ] Verify relay-routed requests still resolve to the relay URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)