### PR TITLE
fix: list available connections when no matching account exists

### DIFF
--- a/internal/api/gateway_test.go
+++ b/internal/api/gateway_test.go
@@ -254,8 +254,8 @@ func TestTaskCreate_InactiveService_Rejected(t *testing.T) {
 		}},
 	})
 	body := mustStatus(t, resp, http.StatusBadRequest)
-	if body["code"] != "INVALID_REQUEST" {
-		t.Errorf("expected code=INVALID_REQUEST, got %v", body["code"])
+	if body["code"] != "SERVICE_NOT_CONFIGURED" {
+		t.Errorf("expected code=SERVICE_NOT_CONFIGURED, got %v", body["code"])
 	}
 	msg, _ := body["error"].(string)
 	strContains(t, msg, "not activated", "error message")
@@ -321,8 +321,8 @@ func TestGateway_AliasNotFound(t *testing.T) {
 		if !strings.Contains(errMsg, "nonexistent") {
 			t.Errorf("error should mention the alias name, got: %s", errMsg)
 		}
-		if !strings.Contains(errMsg, "GET /api/skill/catalog") {
-			t.Errorf("error should direct agent to the catalog endpoint, got: %s", errMsg)
+		if !strings.Contains(errMsg, "Available connections") {
+			t.Errorf("error should list available connections, got: %s", errMsg)
 		}
 	})
 
@@ -346,8 +346,11 @@ func TestGateway_AliasNotFound(t *testing.T) {
 			t.Errorf("expected code=ALIAS_NOT_FOUND, got %v (full: %v)", result["code"], result)
 		}
 		errMsg, _ := result["error"].(string)
-		if !strings.Contains(errMsg, "default") {
-			t.Errorf("error should mention the alias name, got: %s", errMsg)
+		if !strings.Contains(errMsg, "No default account") {
+			t.Errorf("error should mention the default alias, got: %s", errMsg)
+		}
+		if !strings.Contains(errMsg, "mock.echo:work") {
+			t.Errorf("error should list available connections including :work, got: %s", errMsg)
 		}
 	})
 }

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -382,32 +382,23 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			// Check activation for credential-free services before executing.
 			if taskAdapter, taskAdapterOK := h.adapterReg.GetForUser(ctx, serviceType, agent.UserID); taskAdapterOK && taskAdapter.ValidateCredential(nil) == nil {
 				if _, metaErr := h.store.GetServiceMeta(ctx, agent.UserID, serviceType, serviceAlias); metaErr != nil {
-					// If no alias was specified, check if any alias is activated.
-					anyActivated := false
-					if serviceAlias == "" || serviceAlias == "default" {
-						if count, cErr := h.store.CountServiceMetasByType(ctx, agent.UserID, serviceType); cErr == nil && count > 0 {
-							anyActivated = true
-						}
+					dur := int(time.Since(start).Milliseconds())
+					e := baseEntry("block", "error", taskIDPtr)
+					e.DurationMS = dur
+					code, userErr, auditMsg := serviceNotActivatedResponse(ctx, h.vault, h.store, h.adapterReg, agent.UserID, serviceType, serviceAlias, req.Service, taskAdapter)
+					e.ErrorMsg = &auditMsg
+					if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+						h.logger.Warn("audit log failed", "err", logErr)
 					}
-					if !anyActivated {
-						dur := int(time.Since(start).Milliseconds())
-						e := baseEntry("block", "error", taskIDPtr)
-						e.DurationMS = dur
-						code, userErr, auditMsg := serviceNotActivatedResponse(ctx, h.vault, h.store, h.adapterReg, agent.UserID, serviceType, serviceAlias, req.Service, taskAdapter)
-						e.ErrorMsg = &auditMsg
-						if logErr := h.store.LogAudit(ctx, e); logErr != nil {
-							h.logger.Warn("audit log failed", "err", logErr)
-						}
-						h.publishAuditAndQueue(agent.UserID, req.TaskID)
-						writeJSON(w, http.StatusBadRequest, map[string]any{
-							"status":     "error",
-							"request_id": req.RequestID,
-							"audit_id":   auditID,
-							"error":      userErr,
-							"code":       code,
-						})
-						return
-					}
+					h.publishAuditAndQueue(agent.UserID, req.TaskID)
+					writeJSON(w, http.StatusBadRequest, map[string]any{
+						"status":     "error",
+						"request_id": req.RequestID,
+						"audit_id":   auditID,
+						"error":      userErr,
+						"code":       code,
+					})
+					return
 				}
 			}
 
@@ -564,26 +555,12 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 		notActivated := false
 		if approveAdapter.ValidateCredential(nil) == nil {
 			if _, metaErr := h.store.GetServiceMeta(ctx, agent.UserID, serviceType, serviceAlias); metaErr != nil {
-				// No exact match — if no alias was specified, check any alias.
-				if serviceAlias == "" || serviceAlias == "default" {
-					if count, cErr := h.store.CountServiceMetasByType(ctx, agent.UserID, serviceType); cErr != nil || count == 0 {
-						notActivated = true
-					}
-				} else {
-					notActivated = true
-				}
+				notActivated = true
 			}
 		} else {
 			vKey := h.adapterReg.VaultKeyWithAliasForUser(serviceType, serviceAlias, agent.UserID)
 			if _, vaultErr := h.vault.Get(ctx, agent.UserID, vKey); errors.Is(vaultErr, vault.ErrNotFound) {
-				// No exact match — if no alias was specified, check any alias.
-				if serviceAlias == "" || serviceAlias == "default" {
-					if !hasAnyAlias(ctx, h.vault, h.adapterReg, agent.UserID, serviceType) {
-						notActivated = true
-					}
-				} else {
-					notActivated = true
-				}
+				notActivated = true
 			}
 		}
 		if notActivated {
@@ -1292,9 +1269,50 @@ func hasAnyAlias(ctx context.Context, v vault.Vault, reg *adapters.Registry, use
 	return false
 }
 
+// listServiceAliases returns the known aliases for a service type.
+// Credential-free services check service_meta; credential-backed services check the vault.
+func listServiceAliases(
+	ctx context.Context,
+	v vault.Vault,
+	st store.Store,
+	reg *adapters.Registry,
+	userID, serviceType string,
+	adapter adapters.Adapter,
+) []string {
+	if adapter.ValidateCredential(nil) == nil {
+		metas, err := st.ListServiceMetas(ctx, userID)
+		if err != nil {
+			return nil
+		}
+		var aliases []string
+		for _, m := range metas {
+			if m.ServiceID == serviceType {
+				aliases = append(aliases, m.Alias)
+			}
+		}
+		return aliases
+	}
+	base := reg.VaultKey(serviceType)
+	keys, err := v.List(ctx, userID)
+	if err != nil {
+		return nil
+	}
+	var aliases []string
+	for _, k := range keys {
+		if k == base {
+			aliases = append(aliases, "default")
+		} else if strings.HasPrefix(k, base+":") {
+			aliases = append(aliases, strings.TrimPrefix(k, base+":"))
+		}
+	}
+	return aliases
+}
+
 // serviceNotActivatedResponse returns the error code and message for a missing
 // service or alias. It distinguishes ALIAS_NOT_FOUND (service exists under
 // other aliases) from SERVICE_NOT_CONFIGURED (service not activated at all).
+// When other aliases exist, the error message lists available connections so the
+// agent can fix the request by specifying a valid :account identifier.
 func serviceNotActivatedResponse(
 	ctx context.Context,
 	v vault.Vault,
@@ -1303,19 +1321,26 @@ func serviceNotActivatedResponse(
 	userID, serviceType, serviceAlias, serviceDisplay string,
 	adapter adapters.Adapter,
 ) (code, userErr, auditMsg string) {
-	isAlias := false
-	if adapter.ValidateCredential(nil) == nil {
-		if count, cErr := st.CountServiceMetasByType(ctx, userID, serviceType); cErr == nil && count > 0 {
-			isAlias = true
+	aliases := listServiceAliases(ctx, v, st, reg, userID, serviceType, adapter)
+	if len(aliases) > 0 {
+		qualified := make([]string, len(aliases))
+		for i, a := range aliases {
+			qualified[i] = fmt.Sprintf("%s:%s", serviceType, a)
 		}
-	} else {
-		if hasAnyAlias(ctx, v, reg, userID, serviceType) {
-			isAlias = true
+		connList := strings.Join(qualified, ", ")
+		var msg string
+		if serviceAlias == "" || serviceAlias == "default" {
+			msg = fmt.Sprintf(
+				"No default account exists for service %q. Available connections: [%s]. Retry your request using one of these identifiers as the service field (e.g. %q).",
+				serviceType, connList, qualified[0],
+			)
+		} else {
+			msg = fmt.Sprintf(
+				"Account %q does not exist for service %q. Available connections: [%s]. Retry your request using one of these identifiers as the service field (e.g. %q).",
+				serviceAlias, serviceType, connList, qualified[0],
+			)
 		}
-	}
-	if isAlias {
-		return "ALIAS_NOT_FOUND",
-			fmt.Sprintf("Alias %q does not exist for service %q. Review the available services and aliases via GET /api/skill/catalog.", serviceAlias, serviceType),
+		return "ALIAS_NOT_FOUND", msg,
 			fmt.Sprintf("alias %q not found for service %q", serviceAlias, serviceType)
 	}
 	return "SERVICE_NOT_CONFIGURED",

--- a/internal/api/handlers/tasks.go
+++ b/internal/api/handlers/tasks.go
@@ -140,8 +140,8 @@ func (h *TasksHandler) Create(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			if !h.serviceActivated(ctx, agent.UserID, serviceType, serviceAlias, adapter) {
-				writeError(w, http.StatusBadRequest, "INVALID_REQUEST",
-					fmt.Sprintf("service %q is not activated — connect it in the Clawvisor dashboard first", a.Service))
+				code, userErr, _ := serviceNotActivatedResponse(ctx, h.vault, h.st, h.adapterReg, agent.UserID, serviceType, serviceAlias, a.Service, adapter)
+				writeError(w, http.StatusBadRequest, code, userErr)
 				return
 			}
 		}
@@ -776,8 +776,8 @@ func (h *TasksHandler) Expand(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if !h.serviceActivated(ctx, agent.UserID, serviceType, serviceAlias, adapter) {
-			writeError(w, http.StatusBadRequest, "INVALID_REQUEST",
-				fmt.Sprintf("service %q is not activated — connect it in the Clawvisor dashboard first", req.Service))
+			code, userErr, _ := serviceNotActivatedResponse(ctx, h.vault, h.st, h.adapterReg, agent.UserID, serviceType, serviceAlias, req.Service, adapter)
+			writeError(w, http.StatusBadRequest, code, userErr)
 			return
 		}
 	}
@@ -1233,30 +1233,16 @@ func (h *TasksHandler) Revoke(w http.ResponseWriter, r *http.Request) {
 
 // serviceActivated checks whether a service (with alias) has been activated.
 // Credential-free services check service_meta; credential-backed services check the vault.
+// It requires an exact alias match — callers should use serviceNotActivatedResponse
+// to produce a helpful error listing available connections when this returns false.
 func (h *TasksHandler) serviceActivated(ctx context.Context, userID, serviceType, alias string, adapter adapters.Adapter) bool {
 	if adapter.ValidateCredential(nil) == nil {
-		// Credential-free: check service_meta.
-		if _, err := h.st.GetServiceMeta(ctx, userID, serviceType, alias); err == nil {
-			return true
-		}
-		// No exact match — if no alias was specified, check any alias.
-		if alias == "" || alias == "default" {
-			if count, err := h.st.CountServiceMetasByType(ctx, userID, serviceType); err == nil && count > 0 {
-				return true
-			}
-		}
-		return false
+		_, err := h.st.GetServiceMeta(ctx, userID, serviceType, alias)
+		return err == nil
 	}
-	// Credential-backed: check vault.
 	vKey := h.adapterReg.VaultKeyWithAlias(serviceType, alias)
-	if _, err := h.vault.Get(ctx, userID, vKey); err == nil {
-		return true
-	}
-	// No exact match — if no alias was specified, check any alias.
-	if alias == "" || alias == "default" {
-		return hasAnyAlias(ctx, h.vault, h.adapterReg, userID, serviceType)
-	}
-	return false
+	_, err := h.vault.Get(ctx, userID, vKey)
+	return err == nil
 }
 
 // ── Task scope check helper ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- When a gateway request or task creation targets a service without an `:account` identifier and no default account exists, the error now lists all available connections with instructions for the agent to retry with a valid identifier (e.g. `google.gmail:personal`).
- Removes the "any alias" fallthrough logic that silently proceeded past activation checks and failed later with a confusing error.
- Task creation errors now use the same `serviceNotActivatedResponse` helper, returning `ALIAS_NOT_FOUND` or `SERVICE_NOT_CONFIGURED` with actionable details instead of a generic `INVALID_REQUEST`.

## Test plan
- [x] All existing tests pass (updated assertions to match new error codes/messages)
- [x] `TestGateway_AliasNotFound` verifies connection list is included in error
- [x] `TestTaskCreate_InactiveService_Rejected` verifies correct error code

🤖 Generated with [Claude Code](https://claude.com/claude-code)