### PR TITLE
fix: use IsLocal() for cloud-only auto-approve step

### DIFF
--- a/internal/api/handlers/onboarding.go
+++ b/internal/api/handlers/onboarding.go
@@ -17,10 +17,11 @@ var validUserID = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 type OnboardingHandler struct {
 	relayHost string // e.g. "relay.clawvisor.com"
 	daemonID  string // relay daemon ID
+	isLocal   bool   // true when bound to loopback (not a cloud deployment)
 }
 
-func NewOnboardingHandler(relayHost, daemonID string) *OnboardingHandler {
-	return &OnboardingHandler{relayHost: relayHost, daemonID: daemonID}
+func NewOnboardingHandler(relayHost, daemonID string, isLocal bool) *OnboardingHandler {
+	return &OnboardingHandler{relayHost: relayHost, daemonID: daemonID, isLocal: isLocal}
 }
 
 // Setup serves the onboarding markdown document.
@@ -210,7 +211,7 @@ func (h *OnboardingHandler) ClaudeCodeSetup(w http.ResponseWriter, r *http.Reque
 	b.WriteString("setup.\n\n")
 
 	stepNum := 3
-	if relay.ViaRelay(r.Context()) {
+	if !h.isLocal {
 		fmt.Fprintf(&b, "### %d. Add auto-approve permission rules\n\n", stepNum)
 		b.WriteString("Add a permission rule so Claude Code doesn't prompt for approval on every\n")
 		b.WriteString("curl request to Clawvisor. Read `~/.claude/settings.json` and append the\n")

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -620,7 +620,7 @@ func (s *Server) routes() http.Handler {
 	})
 	{
 		relayHost := relayHostFromCfg(s.cfg.Relay.URL)
-		onboardingHandler := handlers.NewOnboardingHandler(relayHost, s.daemonID)
+		onboardingHandler := handlers.NewOnboardingHandler(relayHost, s.daemonID, s.cfg.Server.IsLocal())
 		if s.daemonID != "" {
 			mux.HandleFunc("GET /skill/setup", onboardingHandler.Setup)
 		}


### PR DESCRIPTION
## Summary
- Fixes #158's auto-approve permission step to only appear for cloud deployments, not relay-routed local ones
- Replaces `relay.ViaRelay()` check with `ServerConfig.IsLocal()` — relay is still a local deployment, cloud is when the server binds to a non-loopback address
- Passes `isLocal` through the `OnboardingHandler` constructor from the server config

## Test plan
- [ ] Cloud deployment (e.g. app.staging.clawvisor.com) shows the auto-approve step
- [ ] Local deployment with relay still skips the auto-approve step
- [ ] Local deployment without relay still skips the auto-approve step

🤖 Generated with [Claude Code](https://claude.com/claude-code)