### PR TITLE
fix: configure web-dev to use port 8080 and host 127.0.0.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,8 +99,8 @@ db-down:
 web-install:
 	cd web && npm install
 
-web-dev:
-	cd web && npm run dev
+web-dev: web-install
+	cd web && npm run dev -- --port 8080 --host 127.0.0.1
 
 web-build:
 	cd web && npm run build


### PR DESCRIPTION
Update `make web-dev` to run the Vite dev server on port 8080 and host 127.0.0.1. Also adds `web-install` as a prerequisite so dependencies are installed automatically before starting the dev server.