### PR TITLE
feat: gate generate-integration behind feature flag

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -108,6 +108,7 @@ type FeatureSet struct {
 	Teams             bool `json:"teams"`
 	UsageMetering     bool `json:"usage_metering"`
 	PasswordAuth      bool `json:"password_auth"`
+	AdapterGen        bool `json:"adapter_gen"`
 }
 
 // GatewayHooks allows cloud/enterprise layers to inject additional
@@ -539,6 +540,7 @@ func (s *Server) routes() http.Handler {
 
 	// Adapter generation (user JWT for dashboard, agent token for MCP)
 	if s.llmCfg.AdapterGen.Enabled && s.adapterGenFactory != nil {
+		s.features.AdapterGen = true
 		adapterGenHandler := handlers.NewAdapterGenHandler(s.adapterGenFactory, s.logger)
 		mux.Handle("POST /api/adapters/generate", user(adapterGenHandler.Create))
 		mux.Handle("POST /api/adapters/install", user(adapterGenHandler.Install))

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -414,6 +414,7 @@ export interface FeatureSet {
   teams: boolean
   usage_metering: boolean
   password_auth: boolean
+  adapter_gen: boolean
 }
 
 export interface VersionInfo {

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -223,7 +223,7 @@ export default function Dashboard() {
           <Route path="tasks" element={<Tasks />} />
           <Route path="services" element={<Services />} />
           <Route path="restrictions" element={<Restrictions />} />
-          <Route path="adapter-gen" element={<AdapterGen />} />
+          {features?.adapter_gen && <Route path="adapter-gen" element={<AdapterGen />} />}
           <Route path="audit" element={<Audit />} />
           <Route path="agents" element={<Agents />} />
           <Route path="settings" element={<Settings />} />

--- a/web/src/pages/Services.tsx
+++ b/web/src/pages/Services.tsx
@@ -921,12 +921,14 @@ export default function Services() {
           </p>
         </div>
         <div className="flex items-center gap-3">
-          <NavLink
-            to="/dashboard/adapter-gen"
-            className="px-4 py-2 rounded-md border border-border-strong text-text-primary text-sm font-medium hover:bg-surface-2 transition-colors"
-          >
-            Generate integration
-          </NavLink>
+          {features?.adapter_gen && (
+            <NavLink
+              to="/dashboard/adapter-gen"
+              className="px-4 py-2 rounded-md border border-border-strong text-text-primary text-sm font-medium hover:bg-surface-2 transition-colors"
+            >
+              Generate integration
+            </NavLink>
+          )}
           <button
             onClick={() => setShowModal(true)}
             className="px-4 py-2 rounded-md bg-brand text-surface-0 text-sm font-medium hover:bg-brand-strong shadow-sm"


### PR DESCRIPTION
## Summary
- Adds `adapter_gen` to the `FeatureSet` struct so the frontend can query whether adapter generation is available
- The flag is auto-set to `true` when `AdapterGen.Enabled` and the generator factory are both present during route setup
- Gates the "Generate integration" button on the Services page and the `/dashboard/adapter-gen` route behind the new flag