### PR TITLE
feat: load clawvisor skill before smoke test in setup flow

### DIFF
--- a/internal/api/handlers/onboarding.go
+++ b/internal/api/handlers/onboarding.go
@@ -243,7 +243,9 @@ func (h *OnboardingHandler) ClaudeCodeSetup(w http.ResponseWriter, r *http.Reque
 	stepNum++
 	fmt.Fprintf(&b, "### %d. End-to-end smoke test\n\n", stepNum)
 	b.WriteString("Now that everything is configured, run a quick smoke test to prove the full\n")
-	b.WriteString("flow works. Use the Clawvisor skill to:\n\n")
+	b.WriteString("flow works.\n\n")
+	b.WriteString("First, load the Clawvisor skill by calling the Skill tool with skill: \"clawvisor\".\n")
+	b.WriteString("Once it is loaded, use it to:\n\n")
 	b.WriteString("1. **Create a test task** — pick any connected service visible in the catalog\n")
 	b.WriteString("   (e.g. Gmail, Calendar, GitHub) and create a task with a narrow scope such as\n")
 	b.WriteString("   \"read my most recent email subject\" or \"list my GitHub notifications\".\n")


### PR DESCRIPTION
The clawvisor-setup.md endpoint now explicitly instructs the agent to load the clawvisor skill (via the Skill tool) before running the end-to-end smoke test. Previously the instructions said "Use the Clawvisor skill to:" without ensuring it was loaded first, which could cause the agent to skip using the skill entirely.