### PR TITLE
fix: remove redundant model field from Vertex request body

### DIFF
--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -278,7 +278,6 @@ func (c *Client) completeVertex(ctx context.Context, messages []ChatMessage) (st
 	}
 
 	reqBody := map[string]any{
-		"model":             c.model,
 		"max_tokens":        c.effectiveMaxTokens(),
 		"messages":          convo,
 		"temperature":       0,


### PR DESCRIPTION
Remove the `model` field from the Vertex AI completion request body. The model is already specified in the Vertex AI endpoint URL, so including it in the request body is redundant.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>