### PR TITLE
fix: make audit log insert idempotent on request_id conflict

### DIFF
--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -542,6 +542,7 @@ func (s *Store) LogAudit(ctx context.Context, e *store.AuditEntry) error {
 			safety_flagged, safety_reason, reason, data_origin, context_src,
 			duration_ms, filters_applied, verification, error_msg
 		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22)
+		ON CONFLICT (request_id) DO NOTHING
 	`, e.ID, e.UserID, e.AgentID, e.RequestID, e.TaskID, e.Timestamp,
 		e.Service, e.Action, []byte(paramsSafe), e.Decision, e.Outcome,
 		e.PolicyID, e.RuleID, e.SafetyFlagged, e.SafetyReason, e.Reason,

--- a/internal/store/sqlite/store.go
+++ b/internal/store/sqlite/store.go
@@ -605,7 +605,7 @@ func (s *Store) LogAudit(ctx context.Context, e *store.AuditEntry) error {
 		safetyFlagged = 1
 	}
 	_, err := s.db.ExecContext(ctx, `
-		INSERT INTO audit_log (
+		INSERT OR IGNORE INTO audit_log (
 			id, user_id, agent_id, request_id, task_id, timestamp, service, action,
 			params_safe, decision, outcome, policy_id, rule_id,
 			safety_flagged, safety_reason, reason, data_origin, context_src,


### PR DESCRIPTION
## Summary

- Fixes `duplicate key value violates unique constraint "audit_log_request_id_key"` errors in the audit log
- When concurrent requests share the same `request_id` (e.g. agent retries during slow intent verification), both can pass the in-memory dedup check before either commits, causing a UNIQUE constraint violation on insert
- Uses `ON CONFLICT (request_id) DO NOTHING` (Postgres) and `INSERT OR IGNORE` (SQLite) so the first insert wins and duplicates silently no-op

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/api/...` passes
- [ ] Verify no more `audit log failed` warnings in production logs after deploy