### PR TITLE
fix: prevent Vertex provider from using Anthropic API endpoint

### DIFF
--- a/internal/api/handlers/llm.go
+++ b/internal/api/handlers/llm.go
@@ -100,18 +100,30 @@ func (h *LLMHandler) Update(w http.ResponseWriter, r *http.Request) {
 	if req.Provider == "" {
 		req.Provider = "anthropic"
 	}
-	if req.Endpoint == "" {
-		if req.Provider == "anthropic" {
+	switch req.Provider {
+	case "anthropic":
+		if req.Endpoint == "" {
 			req.Endpoint = "https://api.anthropic.com/v1"
-		} else {
+		}
+		if req.Model == "" {
+			req.Model = "claude-haiku-4-5-20251001"
+		}
+	case "vertex":
+		// Clear any non-vertex endpoint (e.g. leftover anthropic URL).
+		// NewClient auto-constructs the Vertex endpoint from VERTEX_REGION
+		// and VERTEX_PROJECT_ID env vars.
+		if !strings.Contains(req.Endpoint, "aiplatform.googleapis.com") {
+			req.Endpoint = ""
+		}
+		if req.Model == "" {
+			req.Model = "claude-haiku-4-5-20251001"
+		}
+	default:
+		if req.Endpoint == "" {
 			writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "endpoint is required for non-anthropic providers")
 			return
 		}
-	}
-	if req.Model == "" {
-		if req.Provider == "anthropic" {
-			req.Model = "claude-haiku-4-5-20251001"
-		} else {
+		if req.Model == "" {
 			writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "model is required for non-anthropic providers")
 			return
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -363,6 +363,9 @@ func Load(path string) (*Config, error) {
 	// Shared LLM overrides (inherited by all subsections)
 	if v := os.Getenv("CLAWVISOR_LLM_PROVIDER"); v != "" {
 		cfg.LLM.Provider = v
+		if v == "vertex" && cfg.LLM.Endpoint == "https://api.anthropic.com/v1" {
+			cfg.LLM.Endpoint = ""
+		}
 	}
 	if v := os.Getenv("CLAWVISOR_LLM_ENDPOINT"); v != "" {
 		cfg.LLM.Endpoint = v


### PR DESCRIPTION
## Summary
- The LLM Update handler had no `vertex` case, so when switching providers to Vertex it would either reject the request (empty endpoint) or pass through a stale `https://api.anthropic.com/v1` URL, causing Vertex requests to hit the wrong API.
- Adds a `vertex` case that clears non-Vertex endpoints so `NewClient` auto-constructs the correct `aiplatform.googleapis.com` URL from `VERTEX_REGION` and `VERTEX_PROJECT_ID` env vars.
- Also defaults the model for Vertex like it does for Anthropic.