### PR TITLE
fix: skip smoke tests using local config unless env var is set

### DIFF
--- a/e2e/smoke/harness_test.go
+++ b/e2e/smoke/harness_test.go
@@ -67,6 +67,10 @@ type configOverride struct {
 func newE2EEnv(t *testing.T) *e2eEnv {
 	t.Helper()
 
+	if os.Getenv("CLAWVISOR_LOCAL_CONFIG") == "" {
+		t.Skip("skipping: set CLAWVISOR_LOCAL_CONFIG=1 to run tests that use ~/.clawvisor/config.yaml")
+	}
+
 	home, err := os.UserHomeDir()
 	if err != nil {
 		t.Fatalf("home dir: %v", err)


### PR DESCRIPTION
Smoke tests that use `~/.clawvisor/config.yaml` (via `newE2EEnv`) now require `CLAWVISOR_LOCAL_CONFIG=1` to run. Without it, they are skipped. CI tests using their own generated config are unaffected.