### PR TITLE
Add credential usage disclaimer to Services page

### DIFF
--- a/web/src/pages/Services.tsx
+++ b/web/src/pages/Services.tsx
@@ -919,6 +919,11 @@ export default function Services() {
               ? `${activeServices.length} connected service${activeServices.length !== 1 ? 's' : ''}`
               : 'Connect services so your agents can take actions.'}
           </p>
+          <p className="text-xs text-text-tertiary mt-2 max-w-xl">
+            Your credentials are only used when your AI agent takes actions on your behalf.
+            Clawvisor itself never accesses your accounts beyond fetching basic info
+            (like your name or email) to label connections.
+          </p>
         </div>
         <div className="flex items-center gap-3">
           {features?.adapter_gen && (


### PR DESCRIPTION
Adds a short disclaimer below the header on the Services page clarifying that credentials are only used by the user's AI agent on their behalf, and that Clawvisor itself doesn't access connected accounts beyond fetching basic identifying info to label connections.