### PR TITLE
feat: warn about affected tasks before disconnecting a service

### DIFF
--- a/internal/api/handlers/services.go
+++ b/internal/api/handlers/services.go
@@ -816,6 +816,17 @@ func (h *ServicesHandler) Deactivate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Dry-run mode: return the number of active tasks that would be revoked
+	// without actually deactivating.
+	if r.URL.Query().Get("dry_run") == "true" {
+		count := h.countTasksForService(r.Context(), user.ID, serviceID, alias)
+		writeJSON(w, http.StatusOK, map[string]any{
+			"service":             serviceID,
+			"affected_task_count": count,
+		})
+		return
+	}
+
 	// Remove the service_meta and service_config records first.
 	_ = h.st.DeleteServiceMeta(r.Context(), user.ID, serviceID, alias)
 	_ = h.st.DeleteServiceConfig(r.Context(), user.ID, serviceID, alias)
@@ -860,6 +871,34 @@ func (h *ServicesHandler) Deactivate(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "deactivated", "service": serviceID})
 }
 
+// serviceMatchStrings returns the base service and optional service:alias
+// strings used to match tasks against a service+alias pair.
+func serviceMatchStrings(serviceID, alias string) (base, withAlias string) {
+	base = serviceID
+	if alias != "" && alias != "default" {
+		withAlias = serviceID + ":" + alias
+	}
+	return
+}
+
+// countTasksForService returns the number of active tasks that reference the
+// given service and alias.
+func (h *ServicesHandler) countTasksForService(ctx context.Context, userID, serviceID, alias string) int {
+	tasks, _, err := h.st.ListTasks(ctx, userID, store.TaskFilter{ActiveOnly: true})
+	if err != nil {
+		h.logger.Warn("failed to list tasks for service count", "err", err, "user", userID)
+		return 0
+	}
+	base, withAlias := serviceMatchStrings(serviceID, alias)
+	count := 0
+	for _, t := range tasks {
+		if taskReferencesService(t, base, withAlias) {
+			count++
+		}
+	}
+	return count
+}
+
 // revokeTasksForService revokes all active tasks that have authorized actions
 // referencing the given service and alias.
 func (h *ServicesHandler) revokeTasksForService(ctx context.Context, userID, serviceID, alias string) {
@@ -869,16 +908,10 @@ func (h *ServicesHandler) revokeTasksForService(ctx context.Context, userID, ser
 		return
 	}
 
-	// Build the service strings that would appear in authorized_actions.
-	// Tasks store service as "google.gmail" (default alias) or "google.gmail:personal" (named alias).
-	matchService := serviceID
-	matchServiceAlias := ""
-	if alias != "" && alias != "default" {
-		matchServiceAlias = serviceID + ":" + alias
-	}
+	base, withAlias := serviceMatchStrings(serviceID, alias)
 
 	for _, t := range tasks {
-		if taskReferencesService(t, matchService, matchServiceAlias) {
+		if taskReferencesService(t, base, withAlias) {
 			if err := h.st.RevokeTask(ctx, t.ID, userID); err != nil {
 				h.logger.Warn("failed to revoke task for deactivated service", "err", err, "task_id", t.ID)
 				continue

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -679,6 +679,10 @@ export const api = {
         ...(alias ? { alias } : {}),
         ...(config && Object.keys(config).length > 0 ? { config } : {}),
       }),
+    deactivatePreflight: (serviceID: string, alias?: string) =>
+      post<{ service: string; affected_task_count: number }>(`/api/services/${serviceID}/deactivate?dry_run=true`, {
+        ...(alias ? { alias } : {}),
+      }),
     deactivate: (serviceID: string, alias?: string) =>
       post<{ status: string; service: string }>(`/api/services/${serviceID}/deactivate`, {
         ...(alias ? { alias } : {}),

--- a/web/src/pages/Services.tsx
+++ b/web/src/pages/Services.tsx
@@ -91,9 +91,14 @@ function ActiveServiceRow({ svc }: { svc: ServiceInfo }) {
   }
 
   async function handleDeactivate() {
-    if (!confirm(`Deactivate ${serviceName(svc.id, svc.alias)}? Your agents will lose access.`)) return
     setError(null)
     try {
+      const { affected_task_count } = await api.services.deactivatePreflight(svc.id, alias)
+      const name = serviceName(svc.id, svc.alias)
+      const taskWarning = affected_task_count > 0
+        ? `\n\nThis will revoke ${affected_task_count} active task${affected_task_count === 1 ? '' : 's'} that use${affected_task_count === 1 ? 's' : ''} this service.`
+        : ''
+      if (!confirm(`Deactivate ${name}? Your agents will lose access.${taskWarning}`)) return
       await api.services.deactivate(svc.id, alias)
       qc.invalidateQueries({ queryKey: ['services'] })
     } catch (e: any) {


### PR DESCRIPTION
## Summary
- Adds `?dry_run=true` query param to the deactivate endpoint, returning the count of active tasks that would be revoked without performing any changes
- Frontend now calls the preflight check before showing the confirmation dialog, warning the user (e.g. "This will revoke 3 active tasks that use this service")
- Extracts shared `serviceMatchStrings` helper used by both counting and revocation logic

## Test plan
- [ ] Click "Disconnect" on a service with active tasks — confirm dialog shows task count
- [ ] Click "Disconnect" on a service with no active tasks — confirm dialog shows no task warning
- [ ] Cancel the confirmation — verify nothing is deactivated or revoked
- [ ] Confirm the deactivation — verify service is deactivated and tasks are revoked

🤖 Generated with [Claude Code](https://claude.com/claude-code)