### PR TITLE
feat: Redis-backed stores for all in-memory state (multi-instance support)

### DIFF
--- a/internal/api/handlers/connections.go
+++ b/internal/api/handlers/connections.go
@@ -40,13 +40,9 @@ type ConnectionsHandler struct {
 	logger      *slog.Logger
 	multiTenant bool
 
-	// In-memory token cache: connection request ID → {raw token, approved time}.
-	// Tokens are never persisted — raw tokens must not hit the DB for security.
-	// This is a hard single-instance assumption: Approve and PollStatus must
-	// run in the same process. This is fine for the local daemon; if the server
-	// ever runs multi-instance, this needs a shared secret store or signed JWT.
-	tokensMu sync.RWMutex
-	tokens   map[string]approvedToken
+	// Token cache for approved agent tokens. Backed by either in-memory
+	// or Redis, depending on server configuration.
+	tokenCache TokenCache
 
 	// Active long-poll count.
 	activePolls atomic.Int64
@@ -69,9 +65,14 @@ func NewConnectionsHandler(st store.Store, notifier notify.Notifier,
 		eventHub:    eventHub,
 		logger:      logger,
 		multiTenant: multiTenant,
-		tokens:      make(map[string]approvedToken),
+		tokenCache:  newMemoryTokenCache(connectionTokenWindow),
 		ipPolls:     make(map[string]int),
 	}
+}
+
+// SetTokenCache overrides the default in-memory token cache.
+func (h *ConnectionsHandler) SetTokenCache(tc TokenCache) {
+	h.tokenCache = tc
 }
 
 // RequestConnect handles POST /api/agents/connect (unauthenticated).
@@ -162,11 +163,8 @@ func (h *ConnectionsHandler) RequestConnect(w http.ResponseWriter, r *http.Reque
 			"expires_at":    resolved.ExpiresAt,
 		}
 		if resolved.Status == "approved" {
-			h.tokensMu.RLock()
-			tok, ok := h.tokens[req.ID]
-			h.tokensMu.RUnlock()
-			if ok && time.Since(tok.approvedAt) < connectionTokenWindow {
-				resp["token"] = tok.raw
+			if raw, ok := h.tokenCache.Load(req.ID); ok {
+				resp["token"] = raw
 			}
 		}
 		writeJSON(w, http.StatusCreated, resp)
@@ -210,11 +208,8 @@ func (h *ConnectionsHandler) PollStatus(w http.ResponseWriter, r *http.Request) 
 
 		resp := map[string]any{"status": cr.Status}
 		if cr.Status == "approved" {
-			h.tokensMu.RLock()
-			tok, ok := h.tokens[id]
-			h.tokensMu.RUnlock()
-			if ok && time.Since(tok.approvedAt) < connectionTokenWindow {
-				resp["token"] = tok.raw
+			if raw, ok := h.tokenCache.Load(id); ok {
+				resp["token"] = raw
 			}
 		}
 		writeJSON(w, http.StatusOK, resp)
@@ -380,11 +375,7 @@ func (h *ConnectionsHandler) ApproveByID(ctx context.Context, id, userID string)
 		return "", fmt.Errorf("update status: %w", err)
 	}
 
-	h.tokensMu.Lock()
-	h.tokens[id] = approvedToken{raw: rawToken, approvedAt: time.Now()}
-	h.tokensMu.Unlock()
-
-	go h.cleanExpiredTokens()
+	h.tokenCache.Store(id, rawToken)
 
 	if h.eventHub != nil {
 		h.eventHub.Publish(userID, events.Event{Type: "queue"})
@@ -459,14 +450,3 @@ func (h *ConnectionsHandler) List(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, requests)
 }
 
-// cleanExpiredTokens removes tokens older than the token window.
-func (h *ConnectionsHandler) cleanExpiredTokens() {
-	h.tokensMu.Lock()
-	defer h.tokensMu.Unlock()
-	now := time.Now()
-	for id, tok := range h.tokens {
-		if now.Sub(tok.approvedAt) > connectionTokenWindow {
-			delete(h.tokens, id)
-		}
-	}
-}

--- a/internal/api/handlers/dedup_cache_iface.go
+++ b/internal/api/handlers/dedup_cache_iface.go
@@ -1,0 +1,9 @@
+package handlers
+
+// DedupCache is the interface for request content deduplication.
+// Both in-memory and Redis implementations satisfy this.
+type DedupCache interface {
+	Get(key dedupKey) (any, bool)
+	Put(key dedupKey, value any)
+	Stop()
+}

--- a/internal/api/handlers/dedup_cache_redis.go
+++ b/internal/api/handlers/dedup_cache_redis.go
@@ -1,0 +1,50 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const redisDedupPrefix = "clawvisor:dedup:"
+
+// redisDedupCache is a Redis-backed dedup cache for cross-instance
+// request deduplication.
+type redisDedupCache struct {
+	rdb *redis.Client
+	ttl time.Duration
+}
+
+// NewRedisDedupCache creates a Redis-backed dedup cache.
+func NewRedisDedupCache(rdb *redis.Client, ttl time.Duration) DedupCache {
+	return &redisDedupCache{rdb: rdb, ttl: ttl}
+}
+
+func (c *redisDedupCache) Get(key dedupKey) (any, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	data, err := c.rdb.Get(ctx, redisDedupPrefix+string(key)).Bytes()
+	if errors.Is(err, redis.Nil) || err != nil {
+		return nil, false
+	}
+	var value any
+	if err := json.Unmarshal(data, &value); err != nil {
+		return nil, false
+	}
+	return value, true
+}
+
+func (c *redisDedupCache) Put(key dedupKey, value any) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	data, err := json.Marshal(value)
+	if err != nil {
+		return
+	}
+	_ = c.rdb.Set(ctx, redisDedupPrefix+string(key), data, c.ttl).Err()
+}
+
+func (c *redisDedupCache) Stop() {}

--- a/internal/api/handlers/device_pairing_store.go
+++ b/internal/api/handlers/device_pairing_store.go
@@ -1,0 +1,103 @@
+package handlers
+
+import (
+	"encoding/json"
+	"sync"
+	"time"
+)
+
+// DevicePairingStore abstracts device pairing session storage.
+type DevicePairingStore interface {
+	Store(token string, session *pairingSession)
+	// LoadAndLock loads a session for atomic validation. Returns the session
+	// and a function to call when done. The done function accepts whether
+	// the session should be deleted.
+	LoadAndLock(token string) (session *pairingSession, found bool, done func(delete bool))
+	RunCleanup(done <-chan struct{})
+}
+
+// memoryDevicePairingStore is the default in-memory implementation.
+type memoryDevicePairingStore struct {
+	mu       sync.Mutex
+	pairings map[string]*pairingSession
+}
+
+func newMemoryDevicePairingStore() *memoryDevicePairingStore {
+	return &memoryDevicePairingStore{
+		pairings: make(map[string]*pairingSession),
+	}
+}
+
+func (s *memoryDevicePairingStore) Store(token string, session *pairingSession) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pairings[token] = session
+}
+
+func (s *memoryDevicePairingStore) LoadAndLock(token string) (*pairingSession, bool, func(bool)) {
+	s.mu.Lock()
+	session, ok := s.pairings[token]
+	if !ok {
+		s.mu.Unlock()
+		return nil, false, nil
+	}
+	return session, true, func(del bool) {
+		if del {
+			delete(s.pairings, token)
+		}
+		s.mu.Unlock()
+	}
+}
+
+func (s *memoryDevicePairingStore) RunCleanup(done <-chan struct{}) {
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-done:
+			return
+		case <-ticker.C:
+			now := time.Now()
+			s.mu.Lock()
+			for token, session := range s.pairings {
+				if now.After(session.ExpiresAt) {
+					delete(s.pairings, token)
+				}
+			}
+			s.mu.Unlock()
+		}
+	}
+}
+
+// pairingSessionJSON is the JSON-serializable form of pairingSession for Redis.
+type pairingSessionJSON struct {
+	Token     string    `json:"token"`
+	UserID    string    `json:"user_id"`
+	Code      string    `json:"code"`
+	Attempts  int       `json:"attempts"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+func marshalPairingSession(s *pairingSession) ([]byte, error) {
+	return json.Marshal(pairingSessionJSON{
+		Token:     s.Token,
+		UserID:    s.UserID,
+		Code:      s.Code,
+		Attempts:  s.Attempts,
+		ExpiresAt: s.ExpiresAt,
+	})
+}
+
+func unmarshalPairingSession(data []byte) (*pairingSession, error) {
+	var j pairingSessionJSON
+	if err := json.Unmarshal(data, &j); err != nil {
+		return nil, err
+	}
+	return &pairingSession{
+		Token:     j.Token,
+		UserID:    j.UserID,
+		Code:      j.Code,
+		Attempts:  j.Attempts,
+		ExpiresAt: j.ExpiresAt,
+	}, nil
+}

--- a/internal/api/handlers/device_pairing_store_redis.go
+++ b/internal/api/handlers/device_pairing_store_redis.go
@@ -1,0 +1,104 @@
+package handlers
+
+import (
+	"context"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	redisDevicePairingPrefix = "clawvisor:devicepairing:"
+	redisDevicePairingLock   = "clawvisor:devicepairing:lock:"
+	pairingLockTTL           = 10 * time.Second
+	pairingLockRetryDelay    = 50 * time.Millisecond
+	pairingLockMaxRetries    = 20 // 20 × 50ms = 1s max wait
+)
+
+// RedisDevicePairingStore stores device pairing sessions in Redis.
+type RedisDevicePairingStore struct {
+	rdb *redis.Client
+}
+
+// NewRedisDevicePairingStore creates a Redis-backed device pairing store.
+func NewRedisDevicePairingStore(rdb *redis.Client) *RedisDevicePairingStore {
+	return &RedisDevicePairingStore{rdb: rdb}
+}
+
+func (s *RedisDevicePairingStore) Store(token string, session *pairingSession) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	data, err := marshalPairingSession(session)
+	if err != nil {
+		return
+	}
+	ttl := time.Until(session.ExpiresAt)
+	if ttl <= 0 {
+		ttl = pairingExpiry
+	}
+	_ = s.rdb.Set(ctx, redisDevicePairingPrefix+token, data, ttl).Err()
+}
+
+func (s *RedisDevicePairingStore) LoadAndLock(token string) (*pairingSession, bool, func(bool)) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Acquire a distributed lock for this token to prevent concurrent
+	// CompletePairing requests from racing past the attempt limit.
+	lockKey := redisDevicePairingLock + token
+	acquired := false
+	for i := 0; i < pairingLockMaxRetries; i++ {
+		ok, err := s.rdb.SetNX(ctx, lockKey, "1", pairingLockTTL).Result()
+		if err != nil {
+			return nil, false, nil
+		}
+		if ok {
+			acquired = true
+			break
+		}
+		time.Sleep(pairingLockRetryDelay)
+	}
+	if !acquired {
+		return nil, false, nil
+	}
+
+	data, err := s.rdb.Get(ctx, redisDevicePairingPrefix+token).Bytes()
+	if err != nil {
+		// Release lock if session not found.
+		_ = s.rdb.Del(ctx, lockKey).Err()
+		return nil, false, nil
+	}
+	session, err := unmarshalPairingSession(data)
+	if err != nil {
+		_ = s.rdb.Del(ctx, lockKey).Err()
+		return nil, false, nil
+	}
+
+	done := func(del bool) {
+		dctx, dcancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer dcancel()
+		// Always release the lock when done.
+		defer s.rdb.Del(dctx, lockKey)
+		if del {
+			_ = s.rdb.Del(dctx, redisDevicePairingPrefix+token).Err()
+		} else {
+			// Write back updated session (e.g. incremented attempts).
+			updated, err := marshalPairingSession(session)
+			if err == nil {
+				ttl := time.Until(session.ExpiresAt)
+				if ttl <= 0 {
+					_ = s.rdb.Del(dctx, redisDevicePairingPrefix+token).Err()
+				} else {
+					_ = s.rdb.Set(dctx, redisDevicePairingPrefix+token, updated, ttl).Err()
+				}
+			}
+		}
+	}
+	return session, true, done
+}
+
+// RunCleanup is a no-op — Redis TTL handles expiry automatically.
+func (s *RedisDevicePairingStore) RunCleanup(done <-chan struct{}) {}
+
+var _ DevicePairingStore = (*RedisDevicePairingStore)(nil)
+var _ DevicePairingStore = (*memoryDevicePairingStore)(nil)

--- a/internal/api/handlers/devices.go
+++ b/internal/api/handlers/devices.go
@@ -9,7 +9,6 @@ import (
 	"log/slog"
 	"math/big"
 	"net/http"
-	"sync"
 	"time"
 
 	"github.com/clawvisor/clawvisor/internal/api/middleware"
@@ -38,8 +37,7 @@ type DevicesHandler struct {
 	daemonID  string
 	relayHost string
 
-	pairingsMu sync.Mutex
-	pairings   map[string]*pairingSession
+	pairingStore DevicePairingStore
 }
 
 // SetRelayInfo sets daemon_id and relay host so the web dashboard can construct
@@ -59,14 +57,19 @@ type pairingSession struct {
 
 func NewDevicesHandler(st store.Store, pushN *push.Notifier, eventHub events.EventHub, logger *slog.Logger, baseURL string, jwtSvc pkgauth.TokenService) *DevicesHandler {
 	return &DevicesHandler{
-		st:       st,
-		pushN:    pushN,
-		eventHub: eventHub,
-		logger:   logger,
-		baseURL:  baseURL,
-		jwtSvc:   jwtSvc,
-		pairings: make(map[string]*pairingSession),
+		st:           st,
+		pushN:        pushN,
+		eventHub:     eventHub,
+		logger:       logger,
+		baseURL:      baseURL,
+		jwtSvc:       jwtSvc,
+		pairingStore: newMemoryDevicePairingStore(),
 	}
+}
+
+// SetPairingStore overrides the default in-memory pairing store.
+func (h *DevicesHandler) SetPairingStore(ps DevicePairingStore) {
+	h.pairingStore = ps
 }
 
 // StartPairing handles POST /api/devices/pair (user JWT).
@@ -96,9 +99,7 @@ func (h *DevicesHandler) StartPairing(w http.ResponseWriter, r *http.Request) {
 		Code:      code,
 		ExpiresAt: time.Now().Add(pairingExpiry),
 	}
-	h.pairingsMu.Lock()
-	h.pairings[token] = session
-	h.pairingsMu.Unlock()
+	h.pairingStore.Store(token, session)
 
 	writeJSON(w, http.StatusOK, map[string]any{
 		"pairing_token": token,
@@ -146,20 +147,17 @@ func (h *DevicesHandler) CompletePairing(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Hold the mutex for the entire validate-and-consume sequence to prevent
+	// Hold the lock for the entire validate-and-consume sequence to prevent
 	// concurrent requests from racing past the attempt limit or both succeeding
 	// with the correct code.
-	h.pairingsMu.Lock()
-	session, ok := h.pairings[body.PairingToken]
+	session, ok, done := h.pairingStore.LoadAndLock(body.PairingToken)
 	if !ok {
-		h.pairingsMu.Unlock()
 		writeError(w, http.StatusNotFound, "NOT_FOUND", "pairing session not found or expired")
 		return
 	}
 
 	if time.Now().After(session.ExpiresAt) {
-		delete(h.pairings, body.PairingToken)
-		h.pairingsMu.Unlock()
+		done(true) // delete
 		writeError(w, http.StatusGone, "EXPIRED", "pairing session has expired")
 		return
 	}
@@ -167,19 +165,17 @@ func (h *DevicesHandler) CompletePairing(w http.ResponseWriter, r *http.Request)
 	if session.Code != body.Code {
 		session.Attempts++
 		if session.Attempts >= maxPairingAttempts {
-			delete(h.pairings, body.PairingToken)
-			h.pairingsMu.Unlock()
+			done(true) // delete
 			writeError(w, http.StatusUnauthorized, "MAX_ATTEMPTS", "too many incorrect code attempts")
 			return
 		}
-		h.pairingsMu.Unlock()
+		done(false) // write back updated attempts
 		writeError(w, http.StatusUnauthorized, "INVALID_CODE", "incorrect pairing code")
 		return
 	}
 
-	// Code is correct — remove the session before releasing the lock.
-	delete(h.pairings, body.PairingToken)
-	h.pairingsMu.Unlock()
+	// Code is correct — remove the session.
+	done(true)
 
 	// Generate HMAC key (32 random bytes, hex-encoded).
 	hmacKey := make([]byte, 32)
@@ -385,23 +381,12 @@ func (h *DevicesHandler) UpdatePushToStartToken(w http.ResponseWriter, r *http.R
 
 // RunCleanup periodically sweeps expired pairing sessions.
 func (h *DevicesHandler) RunCleanup(ctx context.Context) {
-	ticker := time.NewTicker(time.Minute)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-			now := time.Now()
-			h.pairingsMu.Lock()
-			for token, session := range h.pairings {
-				if now.After(session.ExpiresAt) {
-					delete(h.pairings, token)
-				}
-			}
-			h.pairingsMu.Unlock()
-		}
-	}
+	done := make(chan struct{})
+	go func() {
+		<-ctx.Done()
+		close(done)
+	}()
+	h.pairingStore.RunCleanup(done)
 }
 
 // generatePairingToken returns a 32-byte URL-safe base64 token.

--- a/internal/api/handlers/devices_test.go
+++ b/internal/api/handlers/devices_test.go
@@ -287,16 +287,14 @@ func TestBruteForceProtection(t *testing.T) {
 func TestExpiredPairingSession(t *testing.T) {
 	h := newTestDevicesHandler()
 
-	// Manually insert an expired session.
+	// Insert an expired session via the pairing store.
 	token := "expired-token"
-	h.pairingsMu.Lock()
-	h.pairings[token] = &pairingSession{
+	h.pairingStore.Store(token, &pairingSession{
 		Token:     token,
 		UserID:    "u1",
 		Code:      "123456",
 		ExpiresAt: time.Now().Add(-1 * time.Minute), // already expired
-	}
-	h.pairingsMu.Unlock()
+	})
 
 	body, _ := json.Marshal(map[string]string{
 		"pairing_token": token,

--- a/internal/api/handlers/events.go
+++ b/internal/api/handlers/events.go
@@ -14,11 +14,11 @@ import (
 // EventsHandler serves the SSE event stream.
 type EventsHandler struct {
 	hub     events.EventHub
-	tickets *auth.TicketStore
+	tickets auth.TicketStorer
 }
 
 // NewEventsHandler creates a new SSE handler.
-func NewEventsHandler(hub events.EventHub, tickets *auth.TicketStore) *EventsHandler {
+func NewEventsHandler(hub events.EventHub, tickets auth.TicketStorer) *EventsHandler {
 	return &EventsHandler{hub: hub, tickets: tickets}
 }
 

--- a/internal/api/handlers/oauth_state_redis.go
+++ b/internal/api/handlers/oauth_state_redis.go
@@ -1,0 +1,126 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	redisOAuthStatePrefix  = "clawvisor:oauth:"
+	redisDeviceFlowPrefix  = "clawvisor:deviceflow:"
+	redisPKCEFlowPrefix    = "clawvisor:pkceflow:"
+	defaultOAuthStateTTL   = 15 * time.Minute
+)
+
+// RedisOAuthStateStore stores OAuth flow state in Redis for cross-instance access.
+type RedisOAuthStateStore struct {
+	rdb *redis.Client
+}
+
+// NewRedisOAuthStateStore creates a Redis-backed OAuth state store.
+func NewRedisOAuthStateStore(rdb *redis.Client) *RedisOAuthStateStore {
+	return &RedisOAuthStateStore{rdb: rdb}
+}
+
+func (s *RedisOAuthStateStore) StoreOAuth(state string, entry oauthStateEntry) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	data, err := marshalOAuthState(entry)
+	if err != nil {
+		return
+	}
+	ttl := time.Until(entry.ExpiresAt)
+	if ttl <= 0 {
+		ttl = defaultOAuthStateTTL
+	}
+	_ = s.rdb.Set(ctx, redisOAuthStatePrefix+state, data, ttl).Err()
+}
+
+func (s *RedisOAuthStateStore) LoadAndDeleteOAuth(state string) (oauthStateEntry, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	data, err := s.rdb.GetDel(ctx, redisOAuthStatePrefix+state).Bytes()
+	if errors.Is(err, redis.Nil) || err != nil {
+		return oauthStateEntry{}, false
+	}
+	entry, err := unmarshalOAuthState(data)
+	if err != nil {
+		return oauthStateEntry{}, false
+	}
+	return entry, true
+}
+
+func (s *RedisOAuthStateStore) StoreDeviceFlow(flowID string, entry deviceFlowEntry) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return
+	}
+	ttl := time.Until(entry.ExpiresAt)
+	if ttl <= 0 {
+		ttl = defaultOAuthStateTTL
+	}
+	_ = s.rdb.Set(ctx, redisDeviceFlowPrefix+flowID, data, ttl).Err()
+}
+
+func (s *RedisOAuthStateStore) LoadDeviceFlow(flowID string) (deviceFlowEntry, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	data, err := s.rdb.Get(ctx, redisDeviceFlowPrefix+flowID).Bytes()
+	if errors.Is(err, redis.Nil) || err != nil {
+		return deviceFlowEntry{}, false
+	}
+	var entry deviceFlowEntry
+	if err := json.Unmarshal(data, &entry); err != nil {
+		return deviceFlowEntry{}, false
+	}
+	return entry, true
+}
+
+func (s *RedisOAuthStateStore) UpdateDeviceFlow(flowID string, entry deviceFlowEntry) {
+	s.StoreDeviceFlow(flowID, entry)
+}
+
+func (s *RedisOAuthStateStore) DeleteDeviceFlow(flowID string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = s.rdb.Del(ctx, redisDeviceFlowPrefix+flowID).Err()
+}
+
+func (s *RedisOAuthStateStore) StorePKCE(state string, entry pkceFlowEntry) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return
+	}
+	ttl := time.Until(entry.ExpiresAt)
+	if ttl <= 0 {
+		ttl = defaultOAuthStateTTL
+	}
+	_ = s.rdb.Set(ctx, redisPKCEFlowPrefix+state, data, ttl).Err()
+}
+
+func (s *RedisOAuthStateStore) LoadAndDeletePKCE(state string) (pkceFlowEntry, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	data, err := s.rdb.GetDel(ctx, redisPKCEFlowPrefix+state).Bytes()
+	if errors.Is(err, redis.Nil) || err != nil {
+		return pkceFlowEntry{}, false
+	}
+	var entry pkceFlowEntry
+	if err := json.Unmarshal(data, &entry); err != nil {
+		return pkceFlowEntry{}, false
+	}
+	return entry, true
+}
+
+// Cleanup is a no-op — Redis TTL handles expiry automatically.
+func (s *RedisOAuthStateStore) Cleanup() {}
+
+var _ OAuthStateStore = (*RedisOAuthStateStore)(nil)

--- a/internal/api/handlers/oauth_state_store.go
+++ b/internal/api/handlers/oauth_state_store.go
@@ -1,0 +1,135 @@
+package handlers
+
+import (
+	"encoding/json"
+	"sync"
+	"time"
+)
+
+// OAuthStateStore abstracts storage of pending OAuth flow state (standard
+// OAuth, device flows, PKCE flows) so it works across multiple instances.
+type OAuthStateStore interface {
+	StoreOAuth(state string, entry oauthStateEntry)
+	LoadAndDeleteOAuth(state string) (oauthStateEntry, bool)
+
+	StoreDeviceFlow(flowID string, entry deviceFlowEntry)
+	LoadDeviceFlow(flowID string) (deviceFlowEntry, bool)
+	UpdateDeviceFlow(flowID string, entry deviceFlowEntry)
+	DeleteDeviceFlow(flowID string)
+
+	StorePKCE(state string, entry pkceFlowEntry)
+	LoadAndDeletePKCE(state string) (pkceFlowEntry, bool)
+
+	// Cleanup removes expired entries. No-op for Redis (TTL handles it).
+	Cleanup()
+}
+
+// memoryOAuthStateStore is the default in-memory implementation.
+type memoryOAuthStateStore struct {
+	oauthStates sync.Map
+	deviceFlows sync.Map
+	pkceFlows   sync.Map
+}
+
+func newMemoryOAuthStateStore() *memoryOAuthStateStore {
+	return &memoryOAuthStateStore{}
+}
+
+func (s *memoryOAuthStateStore) StoreOAuth(state string, entry oauthStateEntry) {
+	s.oauthStates.Store(state, entry)
+}
+
+func (s *memoryOAuthStateStore) LoadAndDeleteOAuth(state string) (oauthStateEntry, bool) {
+	val, ok := s.oauthStates.LoadAndDelete(state)
+	if !ok {
+		return oauthStateEntry{}, false
+	}
+	return val.(oauthStateEntry), true
+}
+
+func (s *memoryOAuthStateStore) StoreDeviceFlow(flowID string, entry deviceFlowEntry) {
+	s.deviceFlows.Store(flowID, entry)
+}
+
+func (s *memoryOAuthStateStore) LoadDeviceFlow(flowID string) (deviceFlowEntry, bool) {
+	val, ok := s.deviceFlows.Load(flowID)
+	if !ok {
+		return deviceFlowEntry{}, false
+	}
+	return val.(deviceFlowEntry), true
+}
+
+func (s *memoryOAuthStateStore) UpdateDeviceFlow(flowID string, entry deviceFlowEntry) {
+	s.deviceFlows.Store(flowID, entry)
+}
+
+func (s *memoryOAuthStateStore) DeleteDeviceFlow(flowID string) {
+	s.deviceFlows.Delete(flowID)
+}
+
+func (s *memoryOAuthStateStore) StorePKCE(state string, entry pkceFlowEntry) {
+	s.pkceFlows.Store(state, entry)
+}
+
+func (s *memoryOAuthStateStore) LoadAndDeletePKCE(state string) (pkceFlowEntry, bool) {
+	val, ok := s.pkceFlows.LoadAndDelete(state)
+	if !ok {
+		return pkceFlowEntry{}, false
+	}
+	return val.(pkceFlowEntry), true
+}
+
+func (s *memoryOAuthStateStore) Cleanup() {
+	now := time.Now()
+	s.oauthStates.Range(func(key, value any) bool {
+		if value.(oauthStateEntry).ExpiresAt.Before(now) {
+			s.oauthStates.Delete(key)
+		}
+		return true
+	})
+}
+
+// oauthStateJSON / deviceFlowJSON / pkceFlowJSON are the JSON-serializable
+// forms for Redis storage.
+type oauthStateJSON struct {
+	UserID       string            `json:"user_id"`
+	ServiceID    string            `json:"service_id"`
+	Alias        string            `json:"alias"`
+	PendingReqID string            `json:"pending_req_id,omitempty"`
+	CLICallback  string            `json:"cli_callback,omitempty"`
+	Scopes       []string          `json:"scopes,omitempty"`
+	Config       map[string]string `json:"config,omitempty"`
+	ExpiresAt    time.Time         `json:"expires_at"`
+}
+
+func marshalOAuthState(e oauthStateEntry) ([]byte, error) {
+	return json.Marshal(oauthStateJSON{
+		UserID:       e.UserID,
+		ServiceID:    e.ServiceID,
+		Alias:        e.Alias,
+		PendingReqID: e.PendingReqID,
+		CLICallback:  e.CLICallback,
+		Scopes:       e.Scopes,
+		Config:       e.Config,
+		ExpiresAt:    e.ExpiresAt,
+	})
+}
+
+func unmarshalOAuthState(data []byte) (oauthStateEntry, error) {
+	var j oauthStateJSON
+	if err := json.Unmarshal(data, &j); err != nil {
+		return oauthStateEntry{}, err
+	}
+	return oauthStateEntry{
+		UserID:       j.UserID,
+		ServiceID:    j.ServiceID,
+		Alias:        j.Alias,
+		PendingReqID: j.PendingReqID,
+		CLICallback:  j.CLICallback,
+		Scopes:       j.Scopes,
+		Config:       j.Config,
+		ExpiresAt:    j.ExpiresAt,
+	}, nil
+}
+
+var _ OAuthStateStore = (*memoryOAuthStateStore)(nil)

--- a/internal/api/handlers/pairing.go
+++ b/internal/api/handlers/pairing.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math/big"
 	"net/http"
-	"sync"
 	"time"
 
 	"github.com/clawvisor/clawvisor/internal/relay"
@@ -20,16 +19,20 @@ const (
 // MCP OAuth consent page. Only one active code at a time.
 type PairingHandler struct {
 	daemonID string
-
-	mu       sync.Mutex
-	code     string
-	created  time.Time
-	attempts int
+	store    PairingCodeStore
 }
 
 // NewPairingHandler creates a PairingHandler for the given daemon ID.
 func NewPairingHandler(daemonID string) *PairingHandler {
-	return &PairingHandler{daemonID: daemonID}
+	return &PairingHandler{
+		daemonID: daemonID,
+		store:    newMemoryPairingCodeStore(pairingCodeExpiry, maxPairingCodeAttempts),
+	}
+}
+
+// SetPairingCodeStore overrides the default in-memory pairing code store.
+func (h *PairingHandler) SetPairingCodeStore(s PairingCodeStore) {
+	h.store = s
 }
 
 // GenerateCode handles GET /api/pairing/code (no auth — localhost is the security boundary).
@@ -46,17 +49,12 @@ func (h *PairingHandler) GenerateCode(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.mu.Lock()
 	code, err := generatePairingCode6()
 	if err != nil {
-		h.mu.Unlock()
 		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not generate pairing code")
 		return
 	}
-	h.code = code
-	h.created = time.Now()
-	h.attempts = 0
-	h.mu.Unlock()
+	h.store.Set(code)
 
 	writeJSON(w, http.StatusOK, map[string]any{
 		"daemon_id":  h.daemonID,
@@ -69,27 +67,7 @@ func (h *PairingHandler) GenerateCode(w http.ResponseWriter, r *http.Request) {
 // attempts per code to prevent brute-force guessing. Returns true if the code
 // is valid and was consumed, false otherwise.
 func (h *PairingHandler) Verify(code string) bool {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-
-	// No active code or expired.
-	if h.code == "" || time.Since(h.created) > pairingCodeExpiry {
-		h.code = ""
-		return false
-	}
-
-	// Wrong code — count the attempt.
-	if h.code != code {
-		h.attempts++
-		if h.attempts >= maxPairingCodeAttempts {
-			h.code = "" // burn the code after max attempts
-		}
-		return false
-	}
-
-	// Correct — consume the code.
-	h.code = ""
-	return true
+	return h.store.Verify(code)
 }
 
 func generatePairingCode6() (string, error) {

--- a/internal/api/handlers/pairing_store.go
+++ b/internal/api/handlers/pairing_store.go
@@ -1,0 +1,55 @@
+package handlers
+
+import (
+	"sync"
+	"time"
+)
+
+// PairingCodeStore abstracts the single-code MCP pairing flow so it can be
+// backed by either in-memory state or Redis.
+type PairingCodeStore interface {
+	// Set stores a new pairing code, replacing any existing one.
+	Set(code string)
+	// Verify validates and consumes the code (single-use). Returns true on success.
+	Verify(code string) bool
+}
+
+// memoryPairingCodeStore is the default in-memory implementation.
+type memoryPairingCodeStore struct {
+	mu       sync.Mutex
+	code     string
+	created  time.Time
+	attempts int
+	expiry   time.Duration
+	maxAttempts int
+}
+
+func newMemoryPairingCodeStore(expiry time.Duration, maxAttempts int) *memoryPairingCodeStore {
+	return &memoryPairingCodeStore{expiry: expiry, maxAttempts: maxAttempts}
+}
+
+func (s *memoryPairingCodeStore) Set(code string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.code = code
+	s.created = time.Now()
+	s.attempts = 0
+}
+
+func (s *memoryPairingCodeStore) Verify(code string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.code == "" || time.Since(s.created) > s.expiry {
+		s.code = ""
+		return false
+	}
+	if s.code != code {
+		s.attempts++
+		if s.attempts >= s.maxAttempts {
+			s.code = ""
+		}
+		return false
+	}
+	s.code = ""
+	return true
+}

--- a/internal/api/handlers/pairing_store_redis.go
+++ b/internal/api/handlers/pairing_store_redis.go
@@ -1,0 +1,81 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	redisPairingCodeKey     = "clawvisor:pairingcode:code"
+	redisPairingAttemptsKey = "clawvisor:pairingcode:attempts"
+)
+
+// RedisPairingCodeStore stores the MCP pairing code in Redis so generation
+// and verification can happen on different instances.
+type RedisPairingCodeStore struct {
+	rdb         *redis.Client
+	expiry      time.Duration
+	maxAttempts int
+}
+
+// NewRedisPairingCodeStore creates a Redis-backed pairing code store.
+func NewRedisPairingCodeStore(rdb *redis.Client, expiry time.Duration, maxAttempts int) *RedisPairingCodeStore {
+	return &RedisPairingCodeStore{rdb: rdb, expiry: expiry, maxAttempts: maxAttempts}
+}
+
+func (s *RedisPairingCodeStore) Set(code string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	pipe := s.rdb.Pipeline()
+	pipe.Set(ctx, redisPairingCodeKey, code, s.expiry)
+	pipe.Set(ctx, redisPairingAttemptsKey, "0", s.expiry)
+	_, _ = pipe.Exec(ctx)
+}
+
+func (s *RedisPairingCodeStore) Verify(code string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Use a Lua script for atomic check-and-consume.
+	script := redis.NewScript(`
+		local stored = redis.call('GET', KEYS[1])
+		if not stored then return 0 end
+		if stored == ARGV[1] then
+			redis.call('DEL', KEYS[1])
+			redis.call('DEL', KEYS[2])
+			return 1
+		end
+		local attempts = redis.call('INCR', KEYS[2])
+		if tonumber(attempts) >= tonumber(ARGV[2]) then
+			redis.call('DEL', KEYS[1])
+			redis.call('DEL', KEYS[2])
+		end
+		return 0
+	`)
+
+	result, err := script.Run(ctx, s.rdb,
+		[]string{redisPairingCodeKey, redisPairingAttemptsKey},
+		code, strconv.Itoa(s.maxAttempts),
+	).Int()
+	if err != nil {
+		return false
+	}
+	return result == 1
+}
+
+// Ensure RedisPairingCodeStore satisfies the interface.
+var _ PairingCodeStore = (*RedisPairingCodeStore)(nil)
+var _ PairingCodeStore = (*memoryPairingCodeStore)(nil)
+
+// Ensure RedisTokenCache satisfies the interface.
+var _ TokenCache = (*RedisTokenCache)(nil)
+var _ TokenCache = (*memoryTokenCache)(nil)
+
+// devicePairingStoreRedis is declared in device_pairing_store_redis.go.
+// oauthStateStoreRedis is declared in oauth_state_redis.go.
+// Verify replay cache interface satisfaction.
+var _ error = errors.New("") // keep errors import

--- a/internal/api/handlers/pairing_test.go
+++ b/internal/api/handlers/pairing_test.go
@@ -103,11 +103,11 @@ func TestPairingVerifySingleUse(t *testing.T) {
 
 func TestPairingVerifyExpired(t *testing.T) {
 	h := NewPairingHandler("test-daemon-id")
+	// Use a very short expiry to test expiration.
+	h.SetPairingCodeStore(newMemoryPairingCodeStore(1*time.Millisecond, maxPairingCodeAttempts))
 	code := generateAndGetCode(t, h)
 
-	h.mu.Lock()
-	h.created = time.Now().Add(-6 * time.Minute)
-	h.mu.Unlock()
+	time.Sleep(5 * time.Millisecond)
 
 	if h.Verify(code) {
 		t.Error("expired code should return false")
@@ -116,7 +116,7 @@ func TestPairingVerifyExpired(t *testing.T) {
 
 func TestPairingVerifyBruteForce(t *testing.T) {
 	h := NewPairingHandler("test-daemon-id")
-	generateAndGetCode(t, h)
+	code := generateAndGetCode(t, h)
 
 	for i := 0; i < maxPairingCodeAttempts; i++ {
 		if h.Verify("000000") {
@@ -124,11 +124,11 @@ func TestPairingVerifyBruteForce(t *testing.T) {
 		}
 	}
 
-	h.mu.Lock()
-	if h.code != "" {
-		t.Error("code should be cleared after max attempts")
+	// After max wrong attempts the code should be invalidated,
+	// so even the correct code should fail.
+	if h.Verify(code) {
+		t.Error("correct code should fail after max brute-force attempts")
 	}
-	h.mu.Unlock()
 }
 
 func TestPairingNewCodeInvalidatesPrevious(t *testing.T) {

--- a/internal/api/handlers/services.go
+++ b/internal/api/handlers/services.go
@@ -15,7 +15,6 @@ import (
 	"regexp"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -41,14 +40,9 @@ type ServicesHandler struct {
 	baseURL    string
 	eventHub   events.EventHub
 
-	// oauthStates holds temporary OAuth2 state tokens (in-memory; Phase 3 only).
-	oauthStates sync.Map // stateToken (string) → oauthStateEntry
-
-	// deviceFlows holds pending device flow entries keyed by flow ID.
-	deviceFlows sync.Map // flowID (string) → deviceFlowEntry
-
-	// pkceFlows holds pending PKCE authorization code flow entries keyed by state token.
-	pkceFlows sync.Map // stateToken (string) → pkceFlowEntry
+	// oauthStore holds temporary OAuth flow state (standard, device, PKCE).
+	// Backed by either in-memory or Redis, depending on server configuration.
+	oauthStore OAuthStateStore
 
 	// relayDaemonURL is the public HTTPS URL via the relay (e.g. "https://relay.clawvisor.com/d/DAEMON_ID").
 	// Used as redirect_uri for PKCE flows that require HTTPS. Empty when relay is not configured.
@@ -101,7 +95,13 @@ func validateCLICallback(raw string) string {
 func NewServicesHandler(st store.Store, v vault.Vault, adapterReg *adapters.Registry, logger *slog.Logger, baseURL string, eventHub events.EventHub) *ServicesHandler {
 	return &ServicesHandler{
 		st: st, vault: v, adapterReg: adapterReg, logger: logger, baseURL: baseURL, eventHub: eventHub,
+		oauthStore: newMemoryOAuthStateStore(),
 	}
+}
+
+// SetOAuthStateStore overrides the default in-memory OAuth state store.
+func (h *ServicesHandler) SetOAuthStateStore(s OAuthStateStore) {
+	h.oauthStore = s
 }
 
 // SetRelayDaemonURL sets the public HTTPS relay URL used for PKCE flow redirects.
@@ -395,7 +395,7 @@ func (h *ServicesHandler) OAuthGetURL(w http.ResponseWriter, r *http.Request) {
 	}
 
 	stateToken := uuid.New().String()
-	h.oauthStates.Store(stateToken, oauthStateEntry{
+	h.oauthStore.StoreOAuth(stateToken, oauthStateEntry{
 		UserID:       user.ID,
 		ServiceID:    serviceID,
 		Alias:        alias,
@@ -460,7 +460,7 @@ func (h *ServicesHandler) OAuthStart(w http.ResponseWriter, r *http.Request) {
 	}
 
 	stateToken := uuid.New().String()
-	h.oauthStates.Store(stateToken, oauthStateEntry{
+	h.oauthStore.StoreOAuth(stateToken, oauthStateEntry{
 		UserID:       user.ID,
 		ServiceID:    serviceID,
 		Alias:        alias,
@@ -489,12 +489,11 @@ func (h *ServicesHandler) OAuthCallback(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	val, ok := h.oauthStates.LoadAndDelete(state)
+	entry, ok := h.oauthStore.LoadAndDeleteOAuth(state)
 	if !ok {
 		oauthPopupClose(w, "Invalid or expired OAuth state. Please try again.", "")
 		return
 	}
-	entry := val.(oauthStateEntry)
 	if time.Now().After(entry.ExpiresAt) {
 		oauthPopupClose(w, "OAuth session expired. Please try again.", "")
 		return
@@ -665,7 +664,7 @@ func (h *ServicesHandler) Activate(w http.ResponseWriter, r *http.Request) {
 		}
 
 		stateToken := uuid.New().String()
-		h.oauthStates.Store(stateToken, oauthStateEntry{
+		h.oauthStore.StoreOAuth(stateToken, oauthStateEntry{
 			UserID:       user.ID,
 			ServiceID:    serviceID,
 			Alias:        alias,
@@ -1168,14 +1167,7 @@ func (h *ServicesHandler) resolveOAuthScopes(
 // sweepExpiredOAuthStates removes OAuth state entries older than 10 minutes.
 // Called lazily on each new OAuth URL generation.
 func (h *ServicesHandler) sweepExpiredOAuthStates() {
-	now := time.Now()
-	h.oauthStates.Range(func(key, value any) bool {
-		entry := value.(oauthStateEntry)
-		if now.After(entry.ExpiresAt) {
-			h.oauthStates.Delete(key)
-		}
-		return true
-	})
+	h.oauthStore.Cleanup()
 }
 
 // oauthAuthURL builds the OAuth2 authorization URL. When selectAccount is true
@@ -1369,7 +1361,7 @@ func (h *ServicesHandler) DeviceFlowStart(w http.ResponseWriter, r *http.Request
 	}
 
 	flowID := uuid.New().String()
-	h.deviceFlows.Store(flowID, deviceFlowEntry{
+	h.oauthStore.StoreDeviceFlow(flowID, deviceFlowEntry{
 		UserID:     user.ID,
 		ServiceID:  serviceID,
 		Alias:      alias,
@@ -1415,19 +1407,18 @@ func (h *ServicesHandler) DeviceFlowPoll(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	val, ok := h.deviceFlows.Load(body.FlowID)
+	entry, ok := h.oauthStore.LoadDeviceFlow(body.FlowID)
 	if !ok {
 		writeError(w, http.StatusNotFound, "NOT_FOUND", "unknown or expired flow")
 		return
 	}
-	entry := val.(deviceFlowEntry)
 
 	if entry.UserID != user.ID {
 		writeError(w, http.StatusForbidden, "FORBIDDEN", "flow does not belong to this user")
 		return
 	}
 	if time.Now().After(entry.ExpiresAt) {
-		h.deviceFlows.Delete(body.FlowID)
+		h.oauthStore.DeleteDeviceFlow(body.FlowID)
 		writeJSON(w, http.StatusOK, map[string]any{"status": "expired"})
 		return
 	}
@@ -1472,21 +1463,21 @@ func (h *ServicesHandler) DeviceFlowPoll(w http.ResponseWriter, r *http.Request)
 	case "slow_down":
 		// Increase interval by 5 seconds per spec.
 		entry.Interval += 5
-		h.deviceFlows.Store(body.FlowID, entry)
+		h.oauthStore.UpdateDeviceFlow(body.FlowID, entry)
 		writeJSON(w, http.StatusOK, map[string]any{"status": "slow_down", "interval": entry.Interval})
 		return
 	case "expired_token":
-		h.deviceFlows.Delete(body.FlowID)
+		h.oauthStore.DeleteDeviceFlow(body.FlowID)
 		writeJSON(w, http.StatusOK, map[string]any{"status": "expired"})
 		return
 	case "access_denied":
-		h.deviceFlows.Delete(body.FlowID)
+		h.oauthStore.DeleteDeviceFlow(body.FlowID)
 		writeJSON(w, http.StatusOK, map[string]any{"status": "denied"})
 		return
 	case "":
 		// Success — fall through.
 	default:
-		h.deviceFlows.Delete(body.FlowID)
+		h.oauthStore.DeleteDeviceFlow(body.FlowID)
 		writeJSON(w, http.StatusOK, map[string]any{"status": "error", "error": tokenResp.Error})
 		return
 	}
@@ -1494,7 +1485,7 @@ func (h *ServicesHandler) DeviceFlowPoll(w http.ResponseWriter, r *http.Request)
 	// Success: validate and store the token as an api_key credential.
 	if tokenResp.AccessToken == "" {
 		h.logger.Warn("device flow: provider returned empty access token", "service", entry.ServiceID)
-		h.deviceFlows.Delete(body.FlowID)
+		h.oauthStore.DeleteDeviceFlow(body.FlowID)
 		writeError(w, http.StatusBadGateway, "PROVIDER_ERROR", "provider returned empty access token")
 		return
 	}
@@ -1521,7 +1512,7 @@ func (h *ServicesHandler) DeviceFlowPoll(w http.ResponseWriter, r *http.Request)
 		configJSON, _ := json.Marshal(entry.Config)
 		_ = h.st.UpsertServiceConfig(r.Context(), entry.UserID, entry.ServiceID, alias, configJSON)
 	}
-	h.deviceFlows.Delete(body.FlowID)
+	h.oauthStore.DeleteDeviceFlow(body.FlowID)
 
 	h.logger.Info("service activated via device flow", "user", entry.UserID, "service", entry.ServiceID, "alias", alias)
 	writeJSON(w, http.StatusOK, map[string]any{"status": "complete", "alias": alias})
@@ -1662,7 +1653,7 @@ func (h *ServicesHandler) PKCEFlowStart(w http.ResponseWriter, r *http.Request) 
 	}
 	redirectURI := redirectBase + "/api/pkce-flow/callback"
 
-	h.pkceFlows.Store(stateToken, pkceFlowEntry{
+	h.oauthStore.StorePKCE(stateToken, pkceFlowEntry{
 		UserID:       user.ID,
 		ServiceID:    serviceID,
 		Alias:        alias,
@@ -1713,12 +1704,11 @@ func (h *ServicesHandler) PKCEFlowCallback(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	val, ok := h.pkceFlows.LoadAndDelete(state)
+	entry, ok := h.oauthStore.LoadAndDeletePKCE(state)
 	if !ok {
 		oauthPopupClose(w, "Invalid or expired PKCE state. Please try again.", "")
 		return
 	}
-	entry := val.(pkceFlowEntry)
 	if time.Now().After(entry.ExpiresAt) {
 		oauthPopupClose(w, "PKCE session expired. Please try again.", "")
 		return

--- a/internal/api/handlers/tasks.go
+++ b/internal/api/handlers/tasks.go
@@ -48,8 +48,8 @@ type TasksHandler struct {
 	baseURL      string
 	eventHub     events.EventHub
 	assessor     taskrisk.Assessor
-	contentDedup *dedupCache
-	msgBuffer    *groupchat.MessageBuffer // may be nil; set via SetGroupApproval
+	contentDedup DedupCache
+	msgBuffer    groupchat.Buffer // may be nil; set via SetGroupApproval
 	llmHealth    *llm.Health              // may be nil; needed for approval check LLM calls
 	agentPairer  notify.AgentGroupPairer  // may be nil; set via SetGroupApproval
 }
@@ -78,7 +78,12 @@ func NewTasksHandler(
 
 // SetGroupApproval configures the message buffer, LLM health, and agent-group
 // pairer used for on-demand group chat approval checks during task creation.
-func (h *TasksHandler) SetGroupApproval(buf *groupchat.MessageBuffer, health *llm.Health, pairer notify.AgentGroupPairer) {
+// SetDedupCache overrides the default in-memory content dedup cache.
+func (h *TasksHandler) SetDedupCache(dc DedupCache) {
+	h.contentDedup = dc
+}
+
+func (h *TasksHandler) SetGroupApproval(buf groupchat.Buffer, health *llm.Health, pairer notify.AgentGroupPairer) {
 	h.msgBuffer = buf
 	h.llmHealth = health
 	h.agentPairer = pairer

--- a/internal/api/handlers/token_cache.go
+++ b/internal/api/handlers/token_cache.go
@@ -1,0 +1,56 @@
+package handlers
+
+import (
+	"sync"
+	"time"
+)
+
+// TokenCache stores short-lived approved agent tokens. The in-memory
+// implementation is used in single-instance mode; a Redis-backed
+// implementation is used in multi-instance mode.
+type TokenCache interface {
+	Store(id string, rawToken string)
+	Load(id string) (rawToken string, ok bool)
+}
+
+// memoryTokenCache is the default in-memory token cache.
+type memoryTokenCache struct {
+	mu     sync.RWMutex
+	tokens map[string]approvedToken
+	window time.Duration
+}
+
+func newMemoryTokenCache(window time.Duration) *memoryTokenCache {
+	return &memoryTokenCache{
+		tokens: make(map[string]approvedToken),
+		window: window,
+	}
+}
+
+func (c *memoryTokenCache) Store(id string, rawToken string) {
+	c.mu.Lock()
+	c.tokens[id] = approvedToken{raw: rawToken, approvedAt: time.Now()}
+	c.mu.Unlock()
+	go c.cleanup()
+}
+
+func (c *memoryTokenCache) Load(id string) (string, bool) {
+	c.mu.RLock()
+	tok, ok := c.tokens[id]
+	c.mu.RUnlock()
+	if !ok || time.Since(tok.approvedAt) > c.window {
+		return "", false
+	}
+	return tok.raw, true
+}
+
+func (c *memoryTokenCache) cleanup() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	now := time.Now()
+	for id, tok := range c.tokens {
+		if now.Sub(tok.approvedAt) > c.window {
+			delete(c.tokens, id)
+		}
+	}
+}

--- a/internal/api/handlers/token_cache_redis.go
+++ b/internal/api/handlers/token_cache_redis.go
@@ -1,0 +1,39 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const redisTokenCachePrefix = "clawvisor:conntoken:"
+
+// RedisTokenCache stores approved agent tokens in Redis so any instance
+// can serve the PollStatus request after a different instance approved.
+type RedisTokenCache struct {
+	rdb    *redis.Client
+	window time.Duration
+}
+
+// NewRedisTokenCache creates a Redis-backed token cache.
+func NewRedisTokenCache(rdb *redis.Client, window time.Duration) *RedisTokenCache {
+	return &RedisTokenCache{rdb: rdb, window: window}
+}
+
+func (c *RedisTokenCache) Store(id string, rawToken string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = c.rdb.Set(ctx, redisTokenCachePrefix+id, rawToken, c.window).Err()
+}
+
+func (c *RedisTokenCache) Load(id string) (string, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	val, err := c.rdb.Get(ctx, redisTokenCachePrefix+id).Result()
+	if errors.Is(err, redis.Nil) || err != nil {
+		return "", false
+	}
+	return val, true
+}

--- a/internal/api/middleware/auth.go
+++ b/internal/api/middleware/auth.go
@@ -63,7 +63,7 @@ func RequireUser(jwtSvc auth.TokenService, st store.Store) func(http.Handler) ht
 // RequireUserOrTicket is middleware that first tries JWT auth (via Authorization
 // header), then falls back to a single-use ticket query parameter. This is used
 // for SSE endpoints where EventSource cannot set custom headers.
-func RequireUserOrTicket(jwtSvc auth.TokenService, st store.Store, tickets *intauth.TicketStore) func(http.Handler) http.Handler {
+func RequireUserOrTicket(jwtSvc auth.TokenService, st store.Store, tickets intauth.TicketStorer) func(http.Handler) http.Handler {
 	jwtMiddleware := RequireUser(jwtSvc, st)
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/middleware/device.go
+++ b/internal/api/middleware/device.go
@@ -52,11 +52,18 @@ func DeviceFromContext(ctx context.Context) *store.PairedDevice {
 }
 
 // RequireDevice is middleware that validates a DeviceHMAC authorization header
-// and injects the paired device into the request context.
+// and injects the paired device into the request context. Uses in-memory replay
+// cache by default. Use RequireDeviceWithReplayCache for multi-instance deployments.
 //
 // Header format: Authorization: DeviceHMAC <device_id>:<timestamp>:<hmac_hex>
 // HMAC message:  "<method>\n<path>\n<timestamp>\n<sha256_hex(body)>"
 func RequireDevice(st store.Store) func(http.Handler) http.Handler {
+	return RequireDeviceWithReplayCache(st, NewMemoryReplayCache())
+}
+
+// RequireDeviceWithReplayCache creates the RequireDevice middleware with
+// a custom replay cache implementation (e.g. Redis-backed).
+func RequireDeviceWithReplayCache(st store.Store, rc ReplayCache) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			authHeader := r.Header.Get("Authorization")
@@ -87,7 +94,7 @@ func RequireDevice(st store.Store) func(http.Handler) http.Handler {
 
 			// Replay protection: reject duplicate (device, timestamp, hmac) tuples.
 			cacheKey := deviceID + ":" + tsStr + ":" + providedHMAC
-			if _, loaded := replayCache.LoadOrStore(cacheKey, time.Now()); loaded {
+			if rc.Check(cacheKey) {
 				http.Error(w, `{"error":"replayed request","code":"UNAUTHORIZED"}`, http.StatusUnauthorized)
 				return
 			}

--- a/internal/api/middleware/ratelimit.go
+++ b/internal/api/middleware/ratelimit.go
@@ -14,7 +14,7 @@ import (
 // provided KeyedLimiter. keyFunc extracts the rate-limit key from the request
 // (e.g. agent ID or user ID from context). If keyFunc returns "", the request
 // is not rate-limited (unauthenticated). A nil limiter disables rate limiting.
-func RateLimit(limiter *ratelimit.KeyedLimiter, keyFunc func(*http.Request) string, limit int) func(http.Handler) http.Handler {
+func RateLimit(limiter ratelimit.Limiter, keyFunc func(*http.Request) string, limit int) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if limiter == nil {

--- a/internal/api/middleware/replay_cache.go
+++ b/internal/api/middleware/replay_cache.go
@@ -1,0 +1,24 @@
+package middleware
+
+import "time"
+
+// ReplayCache detects replayed DeviceHMAC requests. The in-memory sync.Map
+// implementation is the default; a Redis-backed implementation is used in
+// multi-instance mode.
+type ReplayCache interface {
+	// Check returns true if the key has already been seen (replay detected).
+	// Otherwise it stores the key and returns false.
+	Check(key string) bool
+}
+
+// memoryReplayCache wraps the existing package-level sync.Map.
+type memoryReplayCache struct{}
+
+func NewMemoryReplayCache() ReplayCache {
+	return memoryReplayCache{}
+}
+
+func (memoryReplayCache) Check(key string) bool {
+	_, loaded := replayCache.LoadOrStore(key, time.Now())
+	return loaded
+}

--- a/internal/api/middleware/replay_cache_redis.go
+++ b/internal/api/middleware/replay_cache_redis.go
@@ -1,0 +1,38 @@
+package middleware
+
+import (
+	"context"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const redisReplayCachePrefix = "clawvisor:replay:"
+
+// RedisReplayCache stores HMAC nonces in Redis for cross-instance replay
+// protection. Uses SET NX with TTL for atomic check-and-store.
+type RedisReplayCache struct {
+	rdb *redis.Client
+	ttl time.Duration
+}
+
+// NewRedisReplayCache creates a Redis-backed replay cache.
+// TTL should match 2 * deviceTimestampSkew (10 minutes).
+func NewRedisReplayCache(rdb *redis.Client) *RedisReplayCache {
+	return &RedisReplayCache{rdb: rdb, ttl: 2 * deviceTimestampSkew}
+}
+
+func (c *RedisReplayCache) Check(key string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	// SET NX returns false if the key already exists → replay detected.
+	set, err := c.rdb.SetNX(ctx, redisReplayCachePrefix+key, "1", c.ttl).Result()
+	if err != nil {
+		// On Redis error, fall through (allow the request rather than blocking).
+		return false
+	}
+	return !set // set==false means key existed → replay
+}
+
+var _ ReplayCache = (*RedisReplayCache)(nil)
+var _ ReplayCache = memoryReplayCache{}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -76,13 +76,22 @@ type Server struct {
 	devicesHandler     *handlers.DevicesHandler
 
 	pushNotifier *push.Notifier                // concrete push notifier; may be nil
-	msgBuffer    *groupchat.MessageBuffer // group chat message buffer; may be nil
+	msgBuffer    groupchat.Buffer // group chat message buffer; may be nil
 	decisionBus  notify.DecisionBus      // cross-instance decision delivery; may be nil
 	gatewayHooks *GatewayHooks  // cloud-injected gateway authorization hooks; may be nil
 
 	eventHub    events.EventHub
 	mcpServer   *mcp.Server
-	ticketStore *intauth.TicketStore
+	ticketStore intauth.TicketStorer
+
+	// Multi-instance stores (set via options; nil = use defaults).
+	replayCache        middleware.ReplayCache
+	tokenCache         handlers.TokenCache
+	devicePairingStore handlers.DevicePairingStore
+	oauthStateStore    handlers.OAuthStateStore
+	pairingCodeStore   handlers.PairingCodeStore
+	dedupCache         handlers.DedupCache
+	verdictCache       intent.VerdictCacher
 
 	adapterGenFactory handlers.GeneratorFactory // per-request Generator factory; set via option
 }
@@ -175,7 +184,7 @@ func WithPushNotifier(pn *push.Notifier) ServerOption {
 // WithGroupChatBuffer sets the message buffer for Telegram group chat
 // observation. When set, task creation checks recent messages for user
 // approval via LLM analysis.
-func WithGroupChatBuffer(buf *groupchat.MessageBuffer) ServerOption {
+func WithGroupChatBuffer(buf groupchat.Buffer) ServerOption {
 	return func(s *Server) { s.msgBuffer = buf }
 }
 
@@ -200,6 +209,46 @@ func WithAdapterGenFactory(f handlers.GeneratorFactory) ServerOption {
 // WithGatewayHooks injects additional authorization logic into the gateway.
 func WithGatewayHooks(hooks *GatewayHooks) ServerOption {
 	return func(s *Server) { s.gatewayHooks = hooks }
+}
+
+// WithTicketStore overrides the default in-memory SSE ticket store.
+func WithTicketStore(ts intauth.TicketStorer) ServerOption {
+	return func(s *Server) { s.ticketStore = ts }
+}
+
+// WithReplayCache overrides the default in-memory HMAC replay cache.
+func WithReplayCache(rc middleware.ReplayCache) ServerOption {
+	return func(s *Server) { s.replayCache = rc }
+}
+
+// WithTokenCache overrides the default in-memory connection token cache.
+func WithTokenCache(tc handlers.TokenCache) ServerOption {
+	return func(s *Server) { s.tokenCache = tc }
+}
+
+// WithDevicePairingStore overrides the default in-memory device pairing store.
+func WithDevicePairingStore(ps handlers.DevicePairingStore) ServerOption {
+	return func(s *Server) { s.devicePairingStore = ps }
+}
+
+// WithOAuthStateStore overrides the default in-memory OAuth state store.
+func WithOAuthStateStore(os handlers.OAuthStateStore) ServerOption {
+	return func(s *Server) { s.oauthStateStore = os }
+}
+
+// WithPairingCodeStore overrides the default in-memory MCP pairing code store.
+func WithPairingCodeStore(ps handlers.PairingCodeStore) ServerOption {
+	return func(s *Server) { s.pairingCodeStore = ps }
+}
+
+// WithDedupCache overrides the default in-memory content dedup cache.
+func WithDedupCache(dc handlers.DedupCache) ServerOption {
+	return func(s *Server) { s.dedupCache = dc }
+}
+
+// WithVerdictCache overrides the default in-memory intent verdict cache.
+func WithVerdictCache(vc intent.VerdictCacher) ServerOption {
+	return func(s *Server) { s.verdictCache = vc }
 }
 
 // New creates a Server and registers all routes.
@@ -315,7 +364,11 @@ func (s *Server) routes() http.Handler {
 	// Construct intent verifier (noop if disabled).
 	var verifier intent.Verifier = intent.NoopVerifier{}
 	if s.llmCfg.Verification.Enabled {
-		verifier = intent.NewLLMVerifier(s.llmHealth, s.logger)
+		v := intent.NewLLMVerifier(s.llmHealth, s.logger)
+		if s.verdictCache != nil {
+			v.SetVerdictCache(s.verdictCache)
+		}
+		verifier = v
 	}
 
 	// Construct chain context extractor (noop if disabled).
@@ -334,6 +387,9 @@ func (s *Server) routes() http.Handler {
 		})
 	}
 	servicesHandler := handlers.NewServicesHandler(s.store, s.vault, s.adapterReg, s.logger, baseURL, s.eventHub)
+	if s.oauthStateStore != nil {
+		servicesHandler.SetOAuthStateStore(s.oauthStateStore)
+	}
 	// Set relay daemon URL for PKCE flows that require HTTPS redirect URIs.
 	if s.cfg.Relay.Enabled && s.cfg.Relay.URL != "" && s.cfg.Relay.DaemonID != "" {
 		relayHost := strings.TrimPrefix(strings.TrimPrefix(s.cfg.Relay.URL, "wss://"), "ws://")
@@ -351,11 +407,16 @@ func (s *Server) routes() http.Handler {
 
 	tasksHandler := handlers.NewTasksHandler(s.store, s.vault, s.adapterReg,
 		s.notifier, *s.cfg, s.logger, baseURL, s.eventHub, assessor)
+	if s.dedupCache != nil {
+		tasksHandler.SetDedupCache(s.dedupCache)
+	}
 	if s.msgBuffer != nil {
 		tasksHandler.SetGroupApproval(s.msgBuffer, s.llmHealth, agentPairer)
 	}
 	s.tasksHandler = tasksHandler
-	s.ticketStore = intauth.NewTicketStore()
+	if s.ticketStore == nil {
+		s.ticketStore = intauth.NewTicketStore()
+	}
 	eventsHandler := handlers.NewEventsHandler(s.eventHub, s.ticketStore)
 
 	// Middleware
@@ -485,6 +546,9 @@ func (s *Server) routes() http.Handler {
 
 	// Connection requests (unauthenticated — agents requesting access)
 	connectionsHandler := handlers.NewConnectionsHandler(s.store, s.notifier, s.eventHub, s.logger, s.features.MultiTenant)
+	if s.tokenCache != nil {
+		connectionsHandler.SetTokenCache(s.tokenCache)
+	}
 	s.connectionsHandler = connectionsHandler
 	connectionsRL := newKeyedLimiterFromBucket(config.RateLimitBucket{Limit: 10, Window: 60})
 	mux.Handle("POST /api/agents/connect",
@@ -500,6 +564,9 @@ func (s *Server) routes() http.Handler {
 	var pairingHandler *handlers.PairingHandler
 	if s.daemonID != "" {
 		pairingHandler = handlers.NewPairingHandler(s.daemonID)
+		if s.pairingCodeStore != nil {
+			pairingHandler.SetPairingCodeStore(s.pairingCodeStore)
+		}
 		corsOrigins := version.CORSOrigins()
 		mux.Handle("GET /api/pairing/code",
 			middleware.CORSAllowOrigins(corsOrigins, http.HandlerFunc(pairingHandler.GenerateCode)))
@@ -509,6 +576,9 @@ func (s *Server) routes() http.Handler {
 
 	// Device pairing and management
 	devicesHandler := handlers.NewDevicesHandler(s.store, s.pushNotifier, s.eventHub, s.logger, baseURL, s.jwtSvc)
+	if s.devicePairingStore != nil {
+		devicesHandler.SetPairingStore(s.devicePairingStore)
+	}
 	if s.daemonID != "" {
 		relayHost := relayHostFromCfg(s.cfg.Relay.URL)
 		devicesHandler.SetRelayInfo(s.daemonID, relayHost)
@@ -521,7 +591,12 @@ func (s *Server) routes() http.Handler {
 		middleware.RateLimit(devicesRL, ipKeyFn, 5)(e2e(http.HandlerFunc(devicesHandler.CompletePairing))))
 	mux.Handle("GET /api/devices", user(devicesHandler.List))
 	mux.Handle("DELETE /api/devices/{id}", user(devicesHandler.Delete))
-	requireDevice := middleware.RequireDevice(s.store)
+	var requireDevice func(http.Handler) http.Handler
+	if s.replayCache != nil {
+		requireDevice = middleware.RequireDeviceWithReplayCache(s.store, s.replayCache)
+	} else {
+		requireDevice = middleware.RequireDevice(s.store)
+	}
 	mux.Handle("POST /api/devices/{id}/action", requireDevice(e2e(http.HandlerFunc(devicesHandler.Action))))
 	mux.Handle("POST /api/devices/{id}/token", requireDevice(e2e(http.HandlerFunc(devicesHandler.MintToken))))
 	mux.Handle("POST /api/devices/{id}/push-to-start-token", requireDevice(e2e(http.HandlerFunc(devicesHandler.UpdatePushToStartToken))))
@@ -989,7 +1064,7 @@ func (s *Server) Run(ctx context.Context) error {
 
 // newKeyedLimiterFromBucket creates a KeyedLimiter from a config bucket.
 // Returns nil when the bucket has zero values (unconfigured).
-func newKeyedLimiterFromBucket(b config.RateLimitBucket) *ratelimit.KeyedLimiter {
+func newKeyedLimiterFromBucket(b config.RateLimitBucket) ratelimit.Limiter {
 	if b.Limit <= 0 || b.Window <= 0 {
 		return nil
 	}

--- a/internal/auth/ticket_iface.go
+++ b/internal/auth/ticket_iface.go
@@ -1,0 +1,9 @@
+package auth
+
+// TicketStorer is the interface for SSE ticket stores. The in-memory
+// TicketStore and RedisTicketStore both implement it.
+type TicketStorer interface {
+	Generate(userID string) (string, error)
+	Validate(ticket string) (string, error)
+	Cleanup()
+}

--- a/internal/auth/ticket_redis.go
+++ b/internal/auth/ticket_redis.go
@@ -1,0 +1,60 @@
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const redisTicketPrefix = "clawvisor:ticket:"
+
+// RedisTicketStore implements TicketStorer using Redis.
+// Token expiry is handled by Redis TTL; Cleanup is a no-op.
+type RedisTicketStore struct {
+	rdb *redis.Client
+}
+
+// NewRedisTicketStore creates a Redis-backed ticket store.
+func NewRedisTicketStore(rdb *redis.Client) *RedisTicketStore {
+	return &RedisTicketStore{rdb: rdb}
+}
+
+// Generate creates a new SSE ticket for the given user, stored in Redis
+// with a 30-second TTL.
+func (s *RedisTicketStore) Generate(userID string) (string, error) {
+	b := make([]byte, ticketBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	ticket := hex.EncodeToString(b)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := s.rdb.Set(ctx, redisTicketPrefix+ticket, userID, ticketExpiry).Err(); err != nil {
+		return "", err
+	}
+	return ticket, nil
+}
+
+// Validate atomically reads and deletes a ticket (single-use).
+func (s *RedisTicketStore) Validate(ticket string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	userID, err := s.rdb.GetDel(ctx, redisTicketPrefix+ticket).Result()
+	if errors.Is(err, redis.Nil) {
+		return "", errors.New("ticket: not found or expired")
+	}
+	if err != nil {
+		return "", err
+	}
+	return userID, nil
+}
+
+// Cleanup is a no-op — Redis TTL handles expiry automatically.
+func (s *RedisTicketStore) Cleanup() {}

--- a/internal/groupchat/buffer_iface.go
+++ b/internal/groupchat/buffer_iface.go
@@ -1,0 +1,11 @@
+package groupchat
+
+import "context"
+
+// Buffer is the interface for group chat message buffering.
+// Both in-memory (MessageBuffer) and Redis (RedisMessageBuffer) satisfy this.
+type Buffer interface {
+	Append(groupChatID string, msg BufferedMessage)
+	Messages(groupChatID string) []BufferedMessage
+	RunCleanup(ctx context.Context)
+}

--- a/internal/groupchat/buffer_redis.go
+++ b/internal/groupchat/buffer_redis.go
@@ -1,0 +1,100 @@
+package groupchat
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const redisBufferPrefix = "clawvisor:groupbuf:"
+
+// RedisMessageBuffer stores group chat messages in Redis sorted sets (scored
+// by Unix timestamp) for cross-instance access.
+type RedisMessageBuffer struct {
+	rdb      *redis.Client
+	maxCount int
+	maxAge   time.Duration
+}
+
+// NewRedisMessageBuffer creates a Redis-backed message buffer.
+func NewRedisMessageBuffer(rdb *redis.Client, maxCount int, maxAge time.Duration) *RedisMessageBuffer {
+	return &RedisMessageBuffer{rdb: rdb, maxCount: maxCount, maxAge: maxAge}
+}
+
+type bufferedMessageJSON struct {
+	Text       string `json:"text"`
+	SenderID   string `json:"sender_id"`
+	SenderName string `json:"sender_name"`
+	Timestamp  int64  `json:"ts"`
+}
+
+// Append adds a message to the group's buffer in Redis.
+func (b *RedisMessageBuffer) Append(groupChatID string, msg BufferedMessage) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	data, err := json.Marshal(bufferedMessageJSON{
+		Text:       msg.Text,
+		SenderID:   msg.SenderID,
+		SenderName: msg.SenderName,
+		Timestamp:  msg.Timestamp.UnixMilli(),
+	})
+	if err != nil {
+		return
+	}
+
+	key := redisBufferPrefix + groupChatID
+	pipe := b.rdb.Pipeline()
+
+	// Add with score = timestamp millis.
+	pipe.ZAdd(ctx, key, redis.Z{
+		Score:  float64(msg.Timestamp.UnixMilli()),
+		Member: string(data),
+	})
+
+	// Trim to maxCount (keep highest scores = most recent).
+	pipe.ZRemRangeByRank(ctx, key, 0, int64(-b.maxCount-1))
+
+	// Set TTL to maxAge so stale groups are cleaned up automatically.
+	pipe.Expire(ctx, key, b.maxAge+time.Minute)
+
+	_, _ = pipe.Exec(ctx)
+}
+
+// Messages returns recent messages for the group within maxAge.
+func (b *RedisMessageBuffer) Messages(groupChatID string) []BufferedMessage {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	key := redisBufferPrefix + groupChatID
+	cutoff := time.Now().Add(-b.maxAge).UnixMilli()
+
+	results, err := b.rdb.ZRangeByScore(ctx, key, &redis.ZRangeBy{
+		Min: strconv.FormatInt(cutoff, 10),
+		Max: "+inf",
+	}).Result()
+	if err != nil || len(results) == 0 {
+		return nil
+	}
+
+	msgs := make([]BufferedMessage, 0, len(results))
+	for _, raw := range results {
+		var j bufferedMessageJSON
+		if err := json.Unmarshal([]byte(raw), &j); err != nil {
+			continue
+		}
+		msgs = append(msgs, BufferedMessage{
+			Text:       j.Text,
+			SenderID:   j.SenderID,
+			SenderName: j.SenderName,
+			Timestamp:  time.UnixMilli(j.Timestamp),
+		})
+	}
+	return msgs
+}
+
+// RunCleanup is a no-op — Redis TTL and ZREMRANGEBYSCORE handle expiry.
+func (b *RedisMessageBuffer) RunCleanup(ctx context.Context) {}

--- a/internal/intent/cache_iface.go
+++ b/internal/intent/cache_iface.go
@@ -1,0 +1,9 @@
+package intent
+
+// VerdictCacher is the interface for intent verification verdict caching.
+// Both in-memory and Redis implementations satisfy this.
+type VerdictCacher interface {
+	Get(key cacheKey) (*VerificationVerdict, bool)
+	Put(key cacheKey, verdict *VerificationVerdict)
+	Cleanup()
+}

--- a/internal/intent/cache_redis.go
+++ b/internal/intent/cache_redis.go
@@ -1,0 +1,52 @@
+package intent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const redisVerdictPrefix = "clawvisor:verdict:"
+
+// redisVerdictCache stores intent verification verdicts in Redis for
+// cross-instance sharing, avoiding redundant LLM calls.
+type redisVerdictCache struct {
+	rdb *redis.Client
+	ttl time.Duration
+}
+
+// NewRedisVerdictCache creates a Redis-backed verdict cache.
+func NewRedisVerdictCache(rdb *redis.Client, ttl time.Duration) VerdictCacher {
+	return &redisVerdictCache{rdb: rdb, ttl: ttl}
+}
+
+func (c *redisVerdictCache) Get(key cacheKey) (*VerificationVerdict, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	data, err := c.rdb.Get(ctx, redisVerdictPrefix+string(key)).Bytes()
+	if errors.Is(err, redis.Nil) || err != nil {
+		return nil, false
+	}
+	var verdict VerificationVerdict
+	if err := json.Unmarshal(data, &verdict); err != nil {
+		return nil, false
+	}
+	// Return a copy so callers can mutate (e.g. set Cached=true).
+	cp := verdict
+	return &cp, true
+}
+
+func (c *redisVerdictCache) Put(key cacheKey, verdict *VerificationVerdict) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	data, err := json.Marshal(verdict)
+	if err != nil {
+		return
+	}
+	_ = c.rdb.Set(ctx, redisVerdictPrefix+string(key), data, c.ttl).Err()
+}
+
+func (c *redisVerdictCache) Cleanup() {} // Redis TTL handles expiry.

--- a/internal/intent/verifier.go
+++ b/internal/intent/verifier.go
@@ -60,7 +60,7 @@ func (NoopVerifier) Verify(_ context.Context, _ VerifyRequest) (*VerificationVer
 type LLMVerifier struct {
 	health *llm.Health
 	logger *slog.Logger
-	cache  *verdictCache
+	cache  VerdictCacher
 }
 
 // NewLLMVerifier creates an LLM-backed intent verifier.
@@ -77,6 +77,11 @@ func NewLLMVerifier(health *llm.Health, logger *slog.Logger) *LLMVerifier {
 		logger: logger,
 		cache:  newVerdictCache(ttl),
 	}
+}
+
+// SetVerdictCache overrides the default in-memory verdict cache.
+func (v *LLMVerifier) SetVerdictCache(c VerdictCacher) {
+	v.cache = c
 }
 
 func (v *LLMVerifier) Verify(ctx context.Context, req VerifyRequest) (*VerificationVerdict, error) {

--- a/internal/notify/telegram/groups_redis.go
+++ b/internal/notify/telegram/groups_redis.go
@@ -1,0 +1,192 @@
+package telegram
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+
+	"github.com/clawvisor/clawvisor/pkg/notify"
+)
+
+const (
+	redisPendingGroupsPrefix  = "clawvisor:tgpg:"
+	redisGroupPairingsPrefix  = "clawvisor:tggp:"
+)
+
+// PendingGroupStore abstracts storage of detected Telegram groups awaiting
+// user approval.
+type PendingGroupStore interface {
+	Add(userID string, pg notify.PendingGroup)
+	List(userID string) []notify.PendingGroup
+	Remove(userID, chatID string)
+}
+
+// GroupPairingStore abstracts storage of agent-to-group pairing sessions.
+type GroupPairingStore interface {
+	Store(sessionID string, session *groupPairingSession)
+	Load(sessionID string) (*groupPairingSession, bool)
+	Delete(sessionID string)
+}
+
+// memoryPendingGroupStore wraps the existing sync.Map-based implementation.
+type memoryPendingGroupStore struct {
+	n *Notifier
+}
+
+func (s *memoryPendingGroupStore) Add(userID string, pg notify.PendingGroup) {
+	s.n.addPendingGroupMemory(userID, pg)
+}
+
+func (s *memoryPendingGroupStore) List(userID string) []notify.PendingGroup {
+	return s.n.pendingGroupsMemory(userID)
+}
+
+func (s *memoryPendingGroupStore) Remove(userID, chatID string) {
+	s.n.removePendingGroupMemory(userID, chatID)
+}
+
+// memoryGroupPairingStore wraps the existing sync.Map-based implementation.
+type memoryGroupPairingStore struct {
+	n *Notifier
+}
+
+func (s *memoryGroupPairingStore) Store(sessionID string, session *groupPairingSession) {
+	s.n.groupPairings.Store(sessionID, session)
+	go func() {
+		time.Sleep(5 * time.Minute)
+		s.n.groupPairings.Delete(sessionID)
+	}()
+}
+
+func (s *memoryGroupPairingStore) Load(sessionID string) (*groupPairingSession, bool) {
+	val, ok := s.n.groupPairings.Load(sessionID)
+	if !ok {
+		return nil, false
+	}
+	return val.(*groupPairingSession), true
+}
+
+func (s *memoryGroupPairingStore) Delete(sessionID string) {
+	s.n.groupPairings.Delete(sessionID)
+}
+
+// redisPendingGroupStore stores pending groups in Redis.
+type redisPendingGroupStore struct {
+	rdb *redis.Client
+}
+
+// NewRedisPendingGroupStore creates a Redis-backed pending group store.
+func NewRedisPendingGroupStore(rdb *redis.Client) PendingGroupStore {
+	return &redisPendingGroupStore{rdb: rdb}
+}
+
+func (s *redisPendingGroupStore) Add(userID string, pg notify.PendingGroup) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	key := redisPendingGroupsPrefix + userID
+
+	// Check for duplicates by loading existing.
+	existing := s.List(userID)
+	for _, g := range existing {
+		if g.ChatID == pg.ChatID {
+			return
+		}
+	}
+
+	data, err := json.Marshal(pg)
+	if err != nil {
+		return
+	}
+	_ = s.rdb.RPush(ctx, key, data).Err()
+	// Keep pending groups for 24 hours.
+	_ = s.rdb.Expire(ctx, key, 24*time.Hour).Err()
+}
+
+func (s *redisPendingGroupStore) List(userID string) []notify.PendingGroup {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	key := redisPendingGroupsPrefix + userID
+	results, err := s.rdb.LRange(ctx, key, 0, -1).Result()
+	if err != nil || len(results) == 0 {
+		return nil
+	}
+
+	groups := make([]notify.PendingGroup, 0, len(results))
+	for _, raw := range results {
+		var pg notify.PendingGroup
+		if err := json.Unmarshal([]byte(raw), &pg); err != nil {
+			continue
+		}
+		groups = append(groups, pg)
+	}
+	return groups
+}
+
+func (s *redisPendingGroupStore) Remove(userID, chatID string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	key := redisPendingGroupsPrefix + userID
+	results, err := s.rdb.LRange(ctx, key, 0, -1).Result()
+	if err != nil {
+		return
+	}
+	for _, raw := range results {
+		var pg notify.PendingGroup
+		if err := json.Unmarshal([]byte(raw), &pg); err != nil {
+			continue
+		}
+		if pg.ChatID == chatID {
+			_ = s.rdb.LRem(ctx, key, 1, raw).Err()
+		}
+	}
+}
+
+// redisGroupPairingStore stores agent-group pairings in Redis with TTL.
+type redisGroupPairingStore struct {
+	rdb *redis.Client
+}
+
+// NewRedisGroupPairingStore creates a Redis-backed group pairing store.
+func NewRedisGroupPairingStore(rdb *redis.Client) GroupPairingStore {
+	return &redisGroupPairingStore{rdb: rdb}
+}
+
+func (s *redisGroupPairingStore) Store(sessionID string, session *groupPairingSession) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	data, _ := json.Marshal(session)
+	_ = s.rdb.Set(ctx, redisGroupPairingsPrefix+sessionID, data, 5*time.Minute).Err()
+}
+
+func (s *redisGroupPairingStore) Load(sessionID string) (*groupPairingSession, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	data, err := s.rdb.Get(ctx, redisGroupPairingsPrefix+sessionID).Bytes()
+	if err != nil {
+		return nil, false
+	}
+	var session groupPairingSession
+	if err := json.Unmarshal(data, &session); err != nil {
+		return nil, false
+	}
+	return &session, true
+}
+
+func (s *redisGroupPairingStore) Delete(sessionID string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = s.rdb.Del(ctx, redisGroupPairingsPrefix+sessionID).Err()
+}
+
+// Compile-time checks.
+var _ PendingGroupStore = (*redisPendingGroupStore)(nil)
+var _ GroupPairingStore = (*redisGroupPairingStore)(nil)
+
+// Ensure errors can be used.
+var _ = fmt.Errorf

--- a/internal/notify/telegram/polling.go
+++ b/internal/notify/telegram/polling.go
@@ -145,9 +145,17 @@ func (n *Notifier) BootstrapGroupObservation(ctx context.Context) {
 func (n *Notifier) pollForCallbacks(ctx context.Context, ps *pollingSession) {
 	defer func() {
 		n.pollers.Delete(ps.userID)
+		n.pollingLock.Release(ctx, ps.userID)
 	}()
 
 	logger := slog.Default()
+
+	// Acquire distributed lock before polling. Only one instance should
+	// call getUpdates per bot token.
+	if !n.pollingLock.Acquire(ctx, ps.userID) {
+		logger.Debug("callback polling: lock not acquired, another instance is polling", "user_id", ps.userID)
+		return
+	}
 
 	// Drain old updates to get current offset.
 	updates, err := n.getUpdates(ctx, ps.botToken, 0, 0)
@@ -166,6 +174,9 @@ func (n *Notifier) pollForCallbacks(ctx context.Context, ps *pollingSession) {
 			return
 		default:
 		}
+
+		// Renew the distributed lock before each long-poll.
+		n.pollingLock.Renew(ctx, ps.userID)
 
 		updates, err := n.getUpdates(ctx, ps.botToken, offset, 10)
 		if err != nil {

--- a/internal/notify/telegram/polling_lock.go
+++ b/internal/notify/telegram/polling_lock.go
@@ -1,0 +1,76 @@
+package telegram
+
+import (
+	"context"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	redisPollingLockPrefix = "clawvisor:tgpoll:"
+	pollingLockTTL         = 35 * time.Second // slightly longer than getUpdates timeout
+)
+
+// PollingLock coordinates Telegram polling across instances. Only one
+// instance should call getUpdates per bot token at a time.
+type PollingLock interface {
+	// Acquire tries to take the polling lock for the given user.
+	// Returns true if this instance now holds the lock.
+	Acquire(ctx context.Context, userID string) bool
+
+	// Renew extends the lock TTL. Call periodically while polling.
+	Renew(ctx context.Context, userID string)
+
+	// Release gives up the lock.
+	Release(ctx context.Context, userID string)
+}
+
+// noopPollingLock always acquires — used in single-instance mode.
+type noopPollingLock struct{}
+
+func (noopPollingLock) Acquire(context.Context, string) bool { return true }
+func (noopPollingLock) Renew(context.Context, string)        {}
+func (noopPollingLock) Release(context.Context, string)      {}
+
+// redisPollingLock uses SET NX with TTL for distributed mutual exclusion.
+type redisPollingLock struct {
+	rdb      *redis.Client
+	instanceID string
+}
+
+// NewRedisPollingLock creates a Redis-backed distributed polling lock.
+func NewRedisPollingLock(rdb *redis.Client, instanceID string) PollingLock {
+	return &redisPollingLock{rdb: rdb, instanceID: instanceID}
+}
+
+func (l *redisPollingLock) Acquire(ctx context.Context, userID string) bool {
+	ok, err := l.rdb.SetNX(ctx, redisPollingLockPrefix+userID, l.instanceID, pollingLockTTL).Result()
+	if err != nil {
+		return false
+	}
+	return ok
+}
+
+func (l *redisPollingLock) Renew(ctx context.Context, userID string) {
+	// Only renew if we still own the lock.
+	script := redis.NewScript(`
+		if redis.call('GET', KEYS[1]) == ARGV[1] then
+			return redis.call('PEXPIRE', KEYS[1], ARGV[2])
+		end
+		return 0
+	`)
+	_, _ = script.Run(ctx, l.rdb, []string{redisPollingLockPrefix + userID},
+		l.instanceID, int(pollingLockTTL.Milliseconds())).Result()
+}
+
+func (l *redisPollingLock) Release(ctx context.Context, userID string) {
+	// Only delete if we own the lock.
+	script := redis.NewScript(`
+		if redis.call('GET', KEYS[1]) == ARGV[1] then
+			return redis.call('DEL', KEYS[1])
+		end
+		return 0
+	`)
+	_, _ = script.Run(ctx, l.rdb, []string{redisPollingLockPrefix + userID}, l.instanceID).Result()
+}

--- a/internal/notify/telegram/telegram.go
+++ b/internal/notify/telegram/telegram.go
@@ -30,31 +30,55 @@ type Notifier struct {
 	pairingClient *http.Client // longer timeout for long-poll getUpdates
 	pairings      sync.Map     // pairing ID → *pairingSession
 
-	cbTokens      *callbackTokenStore
+	cbTokens      CallbackTokenStorer
 	pollers       sync.Map // userID → *pollingSession
 	decisionCh    chan notify.CallbackDecision
 	serverCtx     context.Context
-	msgBuffer     *groupchat.MessageBuffer // may be nil; set via SetMessageBuffer
-	pendingGroups sync.Map                // userID → *pendingGroupList
-	groupPairings sync.Map                // sessionID → *groupPairingSession
+	msgBuffer     groupchat.Buffer // may be nil; set via SetMessageBuffer
+	pendingGroups sync.Map                // userID → *pendingGroupList (in-memory fallback)
+	groupPairings sync.Map                // sessionID → *groupPairingSession (in-memory fallback)
+
+	// Redis-backed stores for multi-instance mode. When nil, in-memory fallbacks are used.
+	pendingGroupStore PendingGroupStore
+	groupPairingStore GroupPairingStore
+	pollingLock       PollingLock
 }
 
 // New creates a Telegram Notifier that reads per-user bot tokens from the store.
 // serverCtx is the server's top-level context; polling goroutines respect its cancellation.
 func New(st store.Store, serverCtx context.Context) *Notifier {
-	return &Notifier{
+	n := &Notifier{
 		store:         st,
 		client:        &http.Client{Timeout: 10 * time.Second},
 		pairingClient: &http.Client{Timeout: 30 * time.Second},
 		cbTokens:      newCallbackTokenStore(),
 		decisionCh:    make(chan notify.CallbackDecision, 32),
 		serverCtx:     serverCtx,
+		pollingLock:   noopPollingLock{},
 	}
+	return n
 }
 
 // SetMessageBuffer sets the message buffer used for group chat observation.
-func (n *Notifier) SetMessageBuffer(buf *groupchat.MessageBuffer) {
+func (n *Notifier) SetMessageBuffer(buf groupchat.Buffer) {
 	n.msgBuffer = buf
+}
+
+// SetRedisStores configures Redis-backed stores for multi-instance deployments.
+// Call before the server starts handling requests.
+func (n *Notifier) SetRedisStores(cbTokens CallbackTokenStorer, pgStore PendingGroupStore, gpStore GroupPairingStore, pollLock PollingLock) {
+	if cbTokens != nil {
+		n.cbTokens = cbTokens
+	}
+	if pgStore != nil {
+		n.pendingGroupStore = pgStore
+	}
+	if gpStore != nil {
+		n.groupPairingStore = gpStore
+	}
+	if pollLock != nil {
+		n.pollingLock = pollLock
+	}
 }
 
 // ── Agent-to-group pairing ────────────────────────────────────────────────────
@@ -77,27 +101,42 @@ func (n *Notifier) StartGroupPairing(_ context.Context, userID, groupChatID, _ s
 		GroupChatID: groupChatID,
 		CreatedAt:   time.Now(),
 	}
-	n.groupPairings.Store(sessionID, session)
-
-	// Auto-expire after 5 minutes.
-	go func() {
-		time.Sleep(5 * time.Minute)
-		n.groupPairings.Delete(sessionID)
-	}()
+	if n.groupPairingStore != nil {
+		n.groupPairingStore.Store(sessionID, session)
+	} else {
+		n.groupPairings.Store(sessionID, session)
+		go func() {
+			time.Sleep(5 * time.Minute)
+			n.groupPairings.Delete(sessionID)
+		}()
+	}
 
 	return sessionID, nil
 }
 
 // CompleteGroupPairing validates a pairing session and persists the agent-group mapping.
 func (n *Notifier) CompleteGroupPairing(ctx context.Context, sessionID, agentID, agentUserID string) error {
-	val, ok := n.groupPairings.Load(sessionID)
-	if !ok {
-		return fmt.Errorf("pairing session not found or expired")
+	var session *groupPairingSession
+	if n.groupPairingStore != nil {
+		s, ok := n.groupPairingStore.Load(sessionID)
+		if !ok {
+			return fmt.Errorf("pairing session not found or expired")
+		}
+		session = s
+	} else {
+		val, ok := n.groupPairings.Load(sessionID)
+		if !ok {
+			return fmt.Errorf("pairing session not found or expired")
+		}
+		session = val.(*groupPairingSession)
 	}
-	session := val.(*groupPairingSession)
 
 	if time.Since(session.CreatedAt) > 5*time.Minute {
-		n.groupPairings.Delete(sessionID)
+		if n.groupPairingStore != nil {
+			n.groupPairingStore.Delete(sessionID)
+		} else {
+			n.groupPairings.Delete(sessionID)
+		}
 		return fmt.Errorf("pairing session expired")
 	}
 	if agentUserID != session.UserID {
@@ -107,7 +146,11 @@ func (n *Notifier) CompleteGroupPairing(ctx context.Context, sessionID, agentID,
 	if err := n.store.CreateAgentGroupPairing(ctx, session.UserID, agentID, session.GroupChatID); err != nil {
 		return fmt.Errorf("persisting agent-group pairing: %w", err)
 	}
-	n.groupPairings.Delete(sessionID)
+	if n.groupPairingStore != nil {
+		n.groupPairingStore.Delete(sessionID)
+	} else {
+		n.groupPairings.Delete(sessionID)
+	}
 	return nil
 }
 
@@ -134,6 +177,14 @@ type pendingGroupList struct {
 
 // AddPendingGroup stores a detected group for the user, deduplicating by ChatID.
 func (n *Notifier) AddPendingGroup(userID string, pg notify.PendingGroup) {
+	if n.pendingGroupStore != nil {
+		n.pendingGroupStore.Add(userID, pg)
+		return
+	}
+	n.addPendingGroupMemory(userID, pg)
+}
+
+func (n *Notifier) addPendingGroupMemory(userID string, pg notify.PendingGroup) {
 	val, _ := n.pendingGroups.LoadOrStore(userID, &pendingGroupList{})
 	pgl := val.(*pendingGroupList)
 	pgl.mu.Lock()
@@ -149,6 +200,13 @@ func (n *Notifier) AddPendingGroup(userID string, pg notify.PendingGroup) {
 // PendingGroups returns the list of groups the bot has been added to but
 // observation has not been enabled for.
 func (n *Notifier) PendingGroups(userID string) []notify.PendingGroup {
+	if n.pendingGroupStore != nil {
+		return n.pendingGroupStore.List(userID)
+	}
+	return n.pendingGroupsMemory(userID)
+}
+
+func (n *Notifier) pendingGroupsMemory(userID string) []notify.PendingGroup {
 	val, ok := n.pendingGroups.Load(userID)
 	if !ok {
 		return nil
@@ -163,6 +221,14 @@ func (n *Notifier) PendingGroups(userID string) []notify.PendingGroup {
 
 // RemovePendingGroup removes a group from the pending list (after approval or dismissal).
 func (n *Notifier) RemovePendingGroup(userID, chatID string) {
+	if n.pendingGroupStore != nil {
+		n.pendingGroupStore.Remove(userID, chatID)
+		return
+	}
+	n.removePendingGroupMemory(userID, chatID)
+}
+
+func (n *Notifier) removePendingGroupMemory(userID, chatID string) {
 	val, ok := n.pendingGroups.Load(userID)
 	if !ok {
 		return

--- a/internal/notify/telegram/tokens_iface.go
+++ b/internal/notify/telegram/tokens_iface.go
@@ -1,0 +1,14 @@
+package telegram
+
+import "time"
+
+// CallbackTokenStorer abstracts storage of Telegram inline callback tokens
+// so it can be backed by either in-memory state or Redis.
+type CallbackTokenStorer interface {
+	Generate(entryType, targetID, userID, chatID string, ttl time.Duration) (approveID, denyID string, err error)
+	Consume(shortID string) (*callbackEntry, error)
+	Cleanup()
+}
+
+// Verify both implementations satisfy the interface.
+var _ CallbackTokenStorer = (*callbackTokenStore)(nil)

--- a/internal/notify/telegram/tokens_redis.go
+++ b/internal/notify/telegram/tokens_redis.go
@@ -1,0 +1,111 @@
+package telegram
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const redisCBTokenPrefix = "clawvisor:tgcb:"
+
+// callbackEntryJSON is the JSON form for Redis storage.
+type callbackEntryJSON struct {
+	Type      string `json:"type"`
+	TargetID  string `json:"target_id"`
+	UserID    string `json:"user_id"`
+	ChatID    string `json:"chat_id"`
+	ExpiresAt int64  `json:"expires_at"`
+}
+
+// redisCallbackTokenStore stores Telegram callback tokens in Redis for
+// cross-instance access.
+type redisCallbackTokenStore struct {
+	rdb *redis.Client
+}
+
+// NewRedisCallbackTokenStore creates a Redis-backed callback token store.
+func NewRedisCallbackTokenStore(rdb *redis.Client) CallbackTokenStorer {
+	return &redisCallbackTokenStore{rdb: rdb}
+}
+
+func (s *redisCallbackTokenStore) Generate(entryType, targetID, userID, chatID string, ttl time.Duration) (string, string, error) {
+	approveID, err := redisRandomShortID()
+	if err != nil {
+		return "", "", err
+	}
+	denyID, err := redisRandomShortID()
+	if err != nil {
+		return "", "", err
+	}
+
+	data, err := json.Marshal(callbackEntryJSON{
+		Type:      entryType,
+		TargetID:  targetID,
+		UserID:    userID,
+		ChatID:    chatID,
+		ExpiresAt: time.Now().Add(ttl).UnixMilli(),
+	})
+	if err != nil {
+		return "", "", err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	pipe := s.rdb.Pipeline()
+	pipe.Set(ctx, redisCBTokenPrefix+approveID, data, ttl)
+	pipe.Set(ctx, redisCBTokenPrefix+denyID, data, ttl)
+	if _, err := pipe.Exec(ctx); err != nil {
+		return "", "", err
+	}
+
+	return approveID, denyID, nil
+}
+
+func (s *redisCallbackTokenStore) Consume(shortID string) (*callbackEntry, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Atomically get and delete.
+	data, err := s.rdb.GetDel(ctx, redisCBTokenPrefix+shortID).Bytes()
+	if errors.Is(err, redis.Nil) {
+		return nil, errTokenNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var j callbackEntryJSON
+	if err := json.Unmarshal(data, &j); err != nil {
+		return nil, errTokenNotFound
+	}
+
+	if time.Now().UnixMilli() > j.ExpiresAt {
+		return nil, errTokenExpired
+	}
+
+	return &callbackEntry{
+		Type:      j.Type,
+		TargetID:  j.TargetID,
+		UserID:    j.UserID,
+		ChatID:    j.ChatID,
+		ExpiresAt: time.UnixMilli(j.ExpiresAt),
+	}, nil
+}
+
+func (s *redisCallbackTokenStore) Cleanup() {} // Redis TTL handles expiry.
+
+func redisRandomShortID() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+var _ CallbackTokenStorer = (*redisCallbackTokenStore)(nil)

--- a/internal/ratelimit/ratelimit_redis.go
+++ b/internal/ratelimit/ratelimit_redis.go
@@ -1,0 +1,90 @@
+package ratelimit
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const redisRateLimitPrefix = "clawvisor:rl:"
+
+// RedisKeyedLimiter implements a sliding-window rate limiter using Redis.
+// Each key maps to a Redis key with an expiring counter. This ensures rate
+// limits are enforced across all server instances.
+type RedisKeyedLimiter struct {
+	rdb    *redis.Client
+	r      float64 // rate (events/second)
+	burst  int
+	window time.Duration
+}
+
+// NewRedisKeyedLimiter creates a Redis-backed rate limiter.
+func NewRedisKeyedLimiter(rdb *redis.Client, r float64, burst int, window time.Duration) *RedisKeyedLimiter {
+	return &RedisKeyedLimiter{rdb: rdb, r: r, burst: burst, window: window}
+}
+
+// Allow checks whether an event for the given key is allowed using a
+// fixed-window counter in Redis. Returns the same signature as KeyedLimiter
+// for drop-in compatibility.
+func (rl *RedisKeyedLimiter) Allow(key string) (allowed bool, remaining int, resetTime time.Time) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	rkey := redisRateLimitPrefix + key
+
+	// Lua script: INCR + conditional EXPIRE, returns [count, ttl].
+	script := redis.NewScript(`
+		local count = redis.call('INCR', KEYS[1])
+		if count == 1 then
+			redis.call('EXPIRE', KEYS[1], ARGV[1])
+		end
+		local ttl = redis.call('TTL', KEYS[1])
+		return {count, ttl}
+	`)
+
+	result, err := script.Run(ctx, rl.rdb, []string{rkey}, int(rl.window.Seconds())).Int64Slice()
+	if err != nil {
+		// On Redis error, allow the request (fail-open).
+		return true, rl.burst, time.Now().Add(rl.window)
+	}
+
+	count := int(result[0])
+	ttl := time.Duration(result[1]) * time.Second
+
+	allowed = count <= rl.burst
+	remaining = rl.burst - count
+	if remaining < 0 {
+		remaining = 0
+	}
+	resetTime = time.Now().Add(ttl)
+	return
+}
+
+// Stop is a no-op for Redis-backed limiter.
+func (rl *RedisKeyedLimiter) Stop() {}
+
+// Limiter is the interface satisfied by both KeyedLimiter and RedisKeyedLimiter.
+type Limiter interface {
+	Allow(key string) (allowed bool, remaining int, resetTime time.Time)
+	Stop()
+}
+
+// Compile-time interface verification.
+var _ Limiter = (*KeyedLimiter)(nil)
+var _ Limiter = (*RedisKeyedLimiter)(nil)
+
+// Conversion helper for config. Called when building the rate limiter for
+// use in NewRedisKeyedLimiter.
+func WindowFromRateAndBurst(r float64, burst int) time.Duration {
+	if r <= 0 {
+		return time.Minute
+	}
+	return time.Duration(float64(burst)/r) * time.Second
+}
+
+// TokensString is used for debugging / header output.
+func TokensString(remaining int) string {
+	return strconv.Itoa(remaining)
+}

--- a/pkg/clawvisor/defaults.go
+++ b/pkg/clawvisor/defaults.go
@@ -24,9 +24,12 @@ import (
 	driveadapter "github.com/clawvisor/clawvisor/internal/adapters/google/drive"
 	contactsadapter "github.com/clawvisor/clawvisor/internal/adapters/google/contacts"
 	gmailadapter "github.com/clawvisor/clawvisor/internal/adapters/google/gmail"
+	"github.com/clawvisor/clawvisor/internal/api/handlers"
+	"github.com/clawvisor/clawvisor/internal/api/middleware"
 	"github.com/clawvisor/clawvisor/internal/auth"
 	"github.com/clawvisor/clawvisor/internal/callback"
 	"github.com/clawvisor/clawvisor/internal/events"
+	"github.com/clawvisor/clawvisor/internal/intent"
 	intnotify "github.com/clawvisor/clawvisor/internal/notify"
 	intredis "github.com/clawvisor/clawvisor/internal/redis"
 	"github.com/clawvisor/clawvisor/internal/display"
@@ -39,7 +42,6 @@ import (
 	sqlitestore "github.com/clawvisor/clawvisor/internal/store/sqlite"
 
 	"github.com/clawvisor/clawvisor/internal/adaptergen"
-	"github.com/clawvisor/clawvisor/internal/api/handlers"
 	"github.com/clawvisor/clawvisor/pkg/adapters"
 	"github.com/clawvisor/clawvisor/pkg/adapters/yamldef"
 	"github.com/clawvisor/clawvisor/pkg/adapters/yamlloader"
@@ -258,7 +260,7 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 	}
 
 	// ── Group chat message buffer ────────────────────────────────────────────
-	msgBuffer := groupchat.NewMessageBuffer(20, 15*time.Minute)
+	var msgBuffer groupchat.Buffer = groupchat.NewMessageBuffer(20, 15*time.Minute)
 
 	// ── Notifier ─────────────────────────────────────────────────────────────
 	telegramN := telegramnotify.New(st, ctx)
@@ -298,6 +300,14 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 	// ── Redis (cloud/multi-instance) ────────────────────────────────────────
 	var eventHub events.EventHub
 	var decisionBus notify.DecisionBus
+	var ticketStore auth.TicketStorer
+	var replayCache middleware.ReplayCache
+	var tokenCache handlers.TokenCache
+	var devicePairingStore handlers.DevicePairingStore
+	var oauthStateStore handlers.OAuthStateStore
+	var pairingCodeStore handlers.PairingCodeStore
+	var dedupCache handlers.DedupCache
+	var verdictCache intent.VerdictCacher
 	if cfg.Redis.URL != "" {
 		rdb, err := intredis.Connect(ctx, cfg.Redis.URL)
 		if err != nil {
@@ -306,6 +316,39 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 		eventHub = events.NewRedisHub(ctx, rdb, logger)
 		magicStore = auth.NewRedisMagicTokenStore(rdb)
 		decisionBus = intnotify.NewRedisDecisionBus(rdb, logger)
+
+		// Multi-instance stores.
+		ticketStore = auth.NewRedisTicketStore(rdb)
+		replayCache = middleware.NewRedisReplayCache(rdb)
+		tokenCache = handlers.NewRedisTokenCache(rdb, 5*time.Minute)
+		devicePairingStore = handlers.NewRedisDevicePairingStore(rdb)
+		oauthStateStore = handlers.NewRedisOAuthStateStore(rdb)
+		pairingCodeStore = handlers.NewRedisPairingCodeStore(rdb, 5*time.Minute, 3)
+
+		dedupTTL := time.Duration(cfg.Gateway.ContentDedupTTLSeconds) * time.Second
+		if dedupTTL <= 0 {
+			dedupTTL = 5 * time.Second
+		}
+		dedupCache = handlers.NewRedisDedupCache(rdb, dedupTTL)
+
+		verdictTTL := time.Duration(cfg.LLM.Verification.CacheTTLSeconds) * time.Second
+		if verdictTTL <= 0 {
+			verdictTTL = 60 * time.Second
+		}
+		verdictCache = intent.NewRedisVerdictCache(rdb, verdictTTL)
+
+		// Redis-backed group chat buffer.
+		msgBuffer = groupchat.NewRedisMessageBuffer(rdb, 20, 15*time.Minute)
+
+		// Telegram multi-instance stores.
+		instanceID, _ := os.Hostname()
+		telegramN.SetRedisStores(
+			telegramnotify.NewRedisCallbackTokenStore(rdb),
+			telegramnotify.NewRedisPendingGroupStore(rdb),
+			telegramnotify.NewRedisGroupPairingStore(rdb),
+			telegramnotify.NewRedisPollingLock(rdb, instanceID),
+		)
+
 		logger.Info("redis connected", "addr", rdb.Options().Addr)
 	}
 
@@ -314,20 +357,28 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 	}
 
 	opts := &ServerOptions{
-		Logger:           logger,
-		Config:           cfg,
-		Store:            st,
-		Vault:            v,
-		JWTService:       jwtSvc,
-		AdapterReg:       adapterReg,
-		Notifier:         notifier,
-		PushNotifier:     pushN,
-		MessageBuffer:    msgBuffer,
-		AdapterGenFactory: adapterGenFactory,
-		MagicStore:       magicStore,
-		EventHub:         eventHub,
-		DecisionBus:      decisionBus,
-		Features:         features,
+		Logger:             logger,
+		Config:             cfg,
+		Store:              st,
+		Vault:              v,
+		JWTService:         jwtSvc,
+		AdapterReg:         adapterReg,
+		Notifier:           notifier,
+		PushNotifier:       pushN,
+		MessageBuffer:      msgBuffer,
+		AdapterGenFactory:  adapterGenFactory,
+		MagicStore:         magicStore,
+		EventHub:           eventHub,
+		DecisionBus:        decisionBus,
+		Features:           features,
+		TicketStore:        ticketStore,
+		ReplayCache:        replayCache,
+		TokenCache:         tokenCache,
+		DevicePairingStore: devicePairingStore,
+		OAuthStateStore:    oauthStateStore,
+		PairingCodeStore:   pairingCodeStore,
+		DedupCache:         dedupCache,
+		VerdictCache:       verdictCache,
 	}
 
 	// Wire relay client when configured.

--- a/pkg/clawvisor/options.go
+++ b/pkg/clawvisor/options.go
@@ -10,8 +10,11 @@ import (
 	"net/http"
 
 	"github.com/clawvisor/clawvisor/internal/api/handlers"
+	"github.com/clawvisor/clawvisor/internal/api/middleware"
+	intauth "github.com/clawvisor/clawvisor/internal/auth"
 	"github.com/clawvisor/clawvisor/internal/events"
 	"github.com/clawvisor/clawvisor/internal/groupchat"
+	"github.com/clawvisor/clawvisor/internal/intent"
 	"github.com/clawvisor/clawvisor/internal/notify/push"
 	"github.com/clawvisor/clawvisor/internal/relay"
 	"github.com/clawvisor/clawvisor/pkg/adapters"
@@ -60,7 +63,7 @@ type ServerOptions struct {
 
 	// MessageBuffer stores recent group chat messages for on-demand LLM
 	// approval checking. Set when group observation is enabled.
-	MessageBuffer *groupchat.MessageBuffer
+	MessageBuffer groupchat.Buffer
 
 	// AdapterGenFactory creates a per-request Generator scoped to the authenticated user.
 	// For local mode, returns the same generator for all users.
@@ -99,6 +102,16 @@ type ServerOptions struct {
 	// Quiet suppresses user-facing messages and sets server log level to WARN.
 	// Used during daemon setup when a temporary server runs in the background.
 	Quiet bool
+
+	// Multi-instance Redis-backed stores. When nil, in-memory defaults are used.
+	TicketStore       intauth.TicketStorer
+	ReplayCache       middleware.ReplayCache
+	TokenCache        handlers.TokenCache
+	DevicePairingStore handlers.DevicePairingStore
+	OAuthStateStore   handlers.OAuthStateStore
+	PairingCodeStore  handlers.PairingCodeStore
+	DedupCache        handlers.DedupCache
+	VerdictCache      intent.VerdictCacher
 }
 
 // Dependencies is passed to ExtraRoutes so extension handlers can access shared services.

--- a/pkg/clawvisor/run.go
+++ b/pkg/clawvisor/run.go
@@ -89,6 +89,32 @@ func RunWithContext(ctx context.Context, opts *ServerOptions) error {
 		}))
 	}
 
+	// Multi-instance Redis-backed stores.
+	if opts.TicketStore != nil {
+		apiOpts = append(apiOpts, api.WithTicketStore(opts.TicketStore))
+	}
+	if opts.ReplayCache != nil {
+		apiOpts = append(apiOpts, api.WithReplayCache(opts.ReplayCache))
+	}
+	if opts.TokenCache != nil {
+		apiOpts = append(apiOpts, api.WithTokenCache(opts.TokenCache))
+	}
+	if opts.DevicePairingStore != nil {
+		apiOpts = append(apiOpts, api.WithDevicePairingStore(opts.DevicePairingStore))
+	}
+	if opts.OAuthStateStore != nil {
+		apiOpts = append(apiOpts, api.WithOAuthStateStore(opts.OAuthStateStore))
+	}
+	if opts.PairingCodeStore != nil {
+		apiOpts = append(apiOpts, api.WithPairingCodeStore(opts.PairingCodeStore))
+	}
+	if opts.DedupCache != nil {
+		apiOpts = append(apiOpts, api.WithDedupCache(opts.DedupCache))
+	}
+	if opts.VerdictCache != nil {
+		apiOpts = append(apiOpts, api.WithVerdictCache(opts.VerdictCache))
+	}
+
 	srv, err := api.New(
 		opts.Config, opts.Store, opts.Vault, opts.JWTService,
 		opts.AdapterReg, opts.Notifier, opts.Config.LLM, opts.MagicStore,


### PR DESCRIPTION
## Summary

- Extracts all 13+ in-memory single-process stores behind interfaces (SSE tickets, HMAC replay cache, connection tokens, device pairing sessions, OAuth flow state, MCP pairing codes, content dedup cache, intent verdict cache, group chat message buffer, rate limiters, Telegram callback tokens, pending groups, group pairings, and polling locks)
- Adds Redis-backed implementations for each store using appropriate primitives (SET/GETDEL for single-use tokens, Lua scripts for atomic operations, sorted sets for message buffers, SET NX for distributed locks)
- Wires everything through `ServerOptions` and `defaults.go` — when `cfg.Redis.URL` is set, all stores are automatically swapped to Redis; otherwise in-memory defaults are used unchanged
- Adds distributed lock to `RedisDevicePairingStore.LoadAndLock` to prevent concurrent brute-force bypass
- Updates tests to work through interfaces instead of accessing private struct fields

## Test plan

- [x] `go vet ./internal/... ./pkg/...` passes clean
- [x] `go test ./internal/... ./pkg/...` all pass
- [ ] Manual test: verify single-instance mode still works with no Redis configured
- [ ] Manual test: verify multi-instance mode with Redis configured shares state correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)