### PR TITLE
feat: soft-delete agents, revoke tasks on deletion, show task stats

### DIFF
--- a/internal/api/gateway_test.go
+++ b/internal/api/gateway_test.go
@@ -110,8 +110,8 @@ func TestAgents_Delete(t *testing.T) {
 	id := str(t, body, "id")
 
 	resp = s.do("DELETE", fmt.Sprintf("/api/agents/%s", id), nil)
-	if resp.StatusCode != http.StatusNoContent {
-		t.Errorf("delete agent: expected 204, got %d", resp.StatusCode)
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("delete agent: expected 200, got %d", resp.StatusCode)
 	}
 	resp.Body.Close()
 

--- a/internal/api/handlers/agents.go
+++ b/internal/api/handlers/agents.go
@@ -1,20 +1,24 @@
 package handlers
 
 import (
+	"log/slog"
 	"net/http"
 
 	"github.com/clawvisor/clawvisor/internal/api/middleware"
 	"github.com/clawvisor/clawvisor/internal/auth"
+	"github.com/clawvisor/clawvisor/internal/events"
 	"github.com/clawvisor/clawvisor/pkg/store"
 )
 
 // AgentsHandler manages agent token lifecycle.
 type AgentsHandler struct {
-	st store.Store
+	st       store.Store
+	eventHub events.EventHub
+	logger   *slog.Logger
 }
 
-func NewAgentsHandler(st store.Store) *AgentsHandler {
-	return &AgentsHandler{st: st}
+func NewAgentsHandler(st store.Store, eventHub events.EventHub, logger *slog.Logger) *AgentsHandler {
+	return &AgentsHandler{st: st, eventHub: eventHub, logger: logger}
 }
 
 // Create registers a new agent and returns its raw bearer token (shown once).
@@ -97,19 +101,28 @@ func (h *AgentsHandler) List(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, agents)
 }
 
-// Delete removes an agent by ID.
+// Delete removes an agent by ID. Any active or pending tasks belonging to
+// the agent are revoked before the agent record is deleted.
 //
 // DELETE /api/agents/{id}
 // Auth: user JWT
 func (h *AgentsHandler) Delete(w http.ResponseWriter, r *http.Request) {
-	user := middleware.UserFromContext(r.Context())
+	ctx := r.Context()
+	user := middleware.UserFromContext(ctx)
 	if user == nil {
 		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "not authenticated")
 		return
 	}
 
 	id := r.PathValue("id")
-	if err := h.st.DeleteAgent(r.Context(), id, user.ID); err != nil {
+
+	// Revoke all active/pending tasks for this agent before deleting.
+	revokedCount, err := h.st.RevokeTasksByAgent(ctx, id, user.ID)
+	if err != nil {
+		h.logger.Warn("failed to revoke tasks for agent", "err", err, "agent_id", id)
+	}
+
+	if err := h.st.DeleteAgent(ctx, id, user.ID); err != nil {
 		if err == store.ErrNotFound {
 			writeError(w, http.StatusNotFound, "NOT_FOUND", "agent not found")
 			return
@@ -117,5 +130,13 @@ func (h *AgentsHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not delete agent")
 		return
 	}
-	w.WriteHeader(http.StatusNoContent)
+
+	if revokedCount > 0 {
+		h.eventHub.Publish(user.ID, events.Event{Type: "tasks"})
+		h.eventHub.Publish(user.ID, events.Event{Type: "queue"})
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"revoked_tasks": revokedCount,
+	})
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -340,7 +340,7 @@ func (s *Server) routes() http.Handler {
 	}
 	healthHandler := handlers.NewHealthHandler(s.store, s.vault, authMode)
 	restrictionsHandler := handlers.NewRestrictionsHandler(s.store)
-	agentsHandler := handlers.NewAgentsHandler(s.store)
+	agentsHandler := handlers.NewAgentsHandler(s.store, s.eventHub, s.logger)
 	auditHandler := handlers.NewAuditHandler(s.store)
 	// The Telegram notifier also implements TelegramPairer and GroupObserver for
 	// pairing and group chat observation flows.

--- a/internal/store/postgres/migrations/025_soft_delete_agents.sql
+++ b/internal/store/postgres/migrations/025_soft_delete_agents.sql
@@ -1,0 +1,2 @@
+-- Add soft-delete support for agents.
+ALTER TABLE agents ADD COLUMN deleted_at TIMESTAMPTZ;

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -224,7 +224,7 @@ func (s *Store) GetAgentByToken(ctx context.Context, tokenHash string) (*store.A
 	a := &store.Agent{}
 	var orgID *string
 	err := s.pool.QueryRow(ctx,
-		`SELECT id, user_id, name, token_hash, created_at, org_id FROM agents WHERE token_hash = $1`,
+		`SELECT id, user_id, name, token_hash, created_at, org_id FROM agents WHERE token_hash = $1 AND deleted_at IS NULL`,
 		tokenHash,
 	).Scan(&a.ID, &a.UserID, &a.Name, &a.TokenHash, &a.CreatedAt, &orgID)
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -237,8 +237,15 @@ func (s *Store) GetAgentByToken(ctx context.Context, tokenHash string) (*store.A
 }
 
 func (s *Store) ListAgents(ctx context.Context, userID string) ([]*store.Agent, error) {
-	rows, err := s.pool.Query(ctx,
-		`SELECT id, user_id, name, token_hash, created_at, org_id FROM agents WHERE user_id = $1 ORDER BY created_at DESC`,
+	rows, err := s.pool.Query(ctx, `
+		SELECT a.id, a.user_id, a.name, a.token_hash, a.created_at, a.org_id,
+		       COALESCE((SELECT COUNT(*) FROM tasks t
+		                 WHERE t.agent_id = a.id
+		                   AND t.status IN ('active','pending_approval','pending_scope_expansion')), 0),
+		       (SELECT MAX(t.created_at) FROM tasks t WHERE t.agent_id = a.id)
+		FROM agents a
+		WHERE a.user_id = $1 AND a.deleted_at IS NULL
+		ORDER BY a.created_at DESC`,
 		userID,
 	)
 	if err != nil {
@@ -250,7 +257,7 @@ func (s *Store) ListAgents(ctx context.Context, userID string) ([]*store.Agent, 
 
 func (s *Store) DeleteAgent(ctx context.Context, id, userID string) error {
 	tag, err := s.pool.Exec(ctx,
-		`DELETE FROM agents WHERE id = $1 AND user_id = $2`,
+		`UPDATE agents SET deleted_at = NOW() WHERE id = $1 AND user_id = $2 AND deleted_at IS NULL`,
 		id, userID,
 	)
 	if err != nil {
@@ -264,7 +271,7 @@ func (s *Store) DeleteAgent(ctx context.Context, id, userID string) error {
 
 func (s *Store) SetAgentCallbackSecret(ctx context.Context, agentID, secret string) error {
 	tag, err := s.pool.Exec(ctx,
-		`UPDATE agents SET callback_secret = $1 WHERE id = $2`,
+		`UPDATE agents SET callback_secret = $1 WHERE id = $2 AND deleted_at IS NULL`,
 		secret, agentID)
 	if err != nil {
 		return err
@@ -278,7 +285,7 @@ func (s *Store) SetAgentCallbackSecret(ctx context.Context, agentID, secret stri
 func (s *Store) GetAgentCallbackSecret(ctx context.Context, agentID string) (string, error) {
 	var secret *string
 	err := s.pool.QueryRow(ctx,
-		`SELECT callback_secret FROM agents WHERE id = $1`, agentID,
+		`SELECT callback_secret FROM agents WHERE id = $1 AND deleted_at IS NULL`, agentID,
 	).Scan(&secret)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return "", store.ErrNotFound
@@ -296,7 +303,7 @@ func (s *Store) getAgentByID(ctx context.Context, id string) (*store.Agent, erro
 	a := &store.Agent{}
 	var orgID *string
 	err := s.pool.QueryRow(ctx,
-		`SELECT id, user_id, name, token_hash, created_at, org_id FROM agents WHERE id = $1`,
+		`SELECT id, user_id, name, token_hash, created_at, org_id FROM agents WHERE id = $1 AND deleted_at IS NULL`,
 		id,
 	).Scan(&a.ID, &a.UserID, &a.Name, &a.TokenHash, &a.CreatedAt, &orgID)
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -916,6 +923,17 @@ func (s *Store) RevokeTask(ctx context.Context, id, userID string) error {
 	return nil
 }
 
+func (s *Store) RevokeTasksByAgent(ctx context.Context, agentID, userID string) (int, error) {
+	tag, err := s.pool.Exec(ctx,
+		`UPDATE tasks SET status = 'revoked'
+		 WHERE agent_id = $1 AND user_id = $2 AND status IN ('active', 'pending_approval', 'pending_scope_expansion')`,
+		agentID, userID)
+	if err != nil {
+		return 0, err
+	}
+	return int(tag.RowsAffected()), nil
+}
+
 func (s *Store) ListExpiredTasks(ctx context.Context) ([]*store.Task, error) {
 	rows, err := s.pool.Query(ctx, `
 		SELECT id, user_id, agent_id, purpose, status, authorized_actions,
@@ -1298,7 +1316,7 @@ func (s *Store) TelemetryCounts(ctx context.Context) (*store.TelemetryCounts, er
 		RequestsByService: make(map[string]int),
 	}
 
-	if err := s.pool.QueryRow(ctx, "SELECT COUNT(*) FROM agents").Scan(&c.Agents); err != nil {
+	if err := s.pool.QueryRow(ctx, "SELECT COUNT(*) FROM agents WHERE deleted_at IS NULL").Scan(&c.Agents); err != nil {
 		return nil, fmt.Errorf("counting agents: %w", err)
 	}
 
@@ -1525,7 +1543,8 @@ func scanAgents(rows pgx.Rows) ([]*store.Agent, error) {
 	for rows.Next() {
 		a := &store.Agent{}
 		var orgID *string
-		if err := rows.Scan(&a.ID, &a.UserID, &a.Name, &a.TokenHash, &a.CreatedAt, &orgID); err != nil {
+		if err := rows.Scan(&a.ID, &a.UserID, &a.Name, &a.TokenHash, &a.CreatedAt, &orgID,
+			&a.ActiveTaskCount, &a.LastTaskAt); err != nil {
 			return nil, err
 		}
 		if orgID != nil {

--- a/internal/store/sqlite/migrations/025_soft_delete_agents.sql
+++ b/internal/store/sqlite/migrations/025_soft_delete_agents.sql
@@ -1,0 +1,2 @@
+-- Add soft-delete support for agents.
+ALTER TABLE agents ADD COLUMN deleted_at TEXT;

--- a/internal/store/sqlite/store.go
+++ b/internal/store/sqlite/store.go
@@ -233,7 +233,7 @@ func (s *Store) GetAgentByToken(ctx context.Context, tokenHash string) (*store.A
 	var createdAt string
 	var orgID *string
 	err := s.db.QueryRowContext(ctx,
-		`SELECT id, user_id, name, token_hash, created_at, org_id FROM agents WHERE token_hash = ?`,
+		`SELECT id, user_id, name, token_hash, created_at, org_id FROM agents WHERE token_hash = ? AND deleted_at IS NULL`,
 		tokenHash,
 	).Scan(&a.ID, &a.UserID, &a.Name, &a.TokenHash, &createdAt, &orgID)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -250,8 +250,15 @@ func (s *Store) GetAgentByToken(ctx context.Context, tokenHash string) (*store.A
 }
 
 func (s *Store) ListAgents(ctx context.Context, userID string) ([]*store.Agent, error) {
-	rows, err := s.db.QueryContext(ctx,
-		`SELECT id, user_id, name, token_hash, created_at, org_id FROM agents WHERE user_id = ? ORDER BY created_at DESC`,
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT a.id, a.user_id, a.name, a.token_hash, a.created_at, a.org_id,
+		       COALESCE((SELECT COUNT(*) FROM tasks t
+		                 WHERE t.agent_id = a.id
+		                   AND t.status IN ('active','pending_approval','pending_scope_expansion')), 0),
+		       (SELECT MAX(t.created_at) FROM tasks t WHERE t.agent_id = a.id)
+		FROM agents a
+		WHERE a.user_id = ? AND a.deleted_at IS NULL
+		ORDER BY a.created_at DESC`,
 		userID,
 	)
 	if err != nil {
@@ -264,12 +271,18 @@ func (s *Store) ListAgents(ctx context.Context, userID string) ([]*store.Agent, 
 		a := &store.Agent{}
 		var createdAt string
 		var orgID *string
-		if err := rows.Scan(&a.ID, &a.UserID, &a.Name, &a.TokenHash, &createdAt, &orgID); err != nil {
+		var lastTaskAt *string
+		if err := rows.Scan(&a.ID, &a.UserID, &a.Name, &a.TokenHash, &createdAt, &orgID,
+			&a.ActiveTaskCount, &lastTaskAt); err != nil {
 			return nil, err
 		}
 		a.CreatedAt = parseTime(createdAt)
 		if orgID != nil {
 			a.OrgID = *orgID
+		}
+		if lastTaskAt != nil {
+			ts := parseTime(*lastTaskAt)
+			a.LastTaskAt = &ts
 		}
 		agents = append(agents, a)
 	}
@@ -278,7 +291,7 @@ func (s *Store) ListAgents(ctx context.Context, userID string) ([]*store.Agent, 
 
 func (s *Store) DeleteAgent(ctx context.Context, id, userID string) error {
 	res, err := s.db.ExecContext(ctx,
-		`DELETE FROM agents WHERE id = ? AND user_id = ?`,
+		`UPDATE agents SET deleted_at = datetime('now') WHERE id = ? AND user_id = ? AND deleted_at IS NULL`,
 		id, userID,
 	)
 	if err != nil {
@@ -293,7 +306,7 @@ func (s *Store) DeleteAgent(ctx context.Context, id, userID string) error {
 
 func (s *Store) SetAgentCallbackSecret(ctx context.Context, agentID, secret string) error {
 	res, err := s.db.ExecContext(ctx,
-		`UPDATE agents SET callback_secret = ? WHERE id = ?`,
+		`UPDATE agents SET callback_secret = ? WHERE id = ? AND deleted_at IS NULL`,
 		secret, agentID)
 	if err != nil {
 		return err
@@ -308,7 +321,7 @@ func (s *Store) SetAgentCallbackSecret(ctx context.Context, agentID, secret stri
 func (s *Store) GetAgentCallbackSecret(ctx context.Context, agentID string) (string, error) {
 	var secret *string
 	err := s.db.QueryRowContext(ctx,
-		`SELECT callback_secret FROM agents WHERE id = ?`, agentID,
+		`SELECT callback_secret FROM agents WHERE id = ? AND deleted_at IS NULL`, agentID,
 	).Scan(&secret)
 	if errors.Is(err, sql.ErrNoRows) {
 		return "", store.ErrNotFound
@@ -327,7 +340,7 @@ func (s *Store) getAgentByID(ctx context.Context, id string) (*store.Agent, erro
 	var createdAt string
 	var orgID *string
 	err := s.db.QueryRowContext(ctx,
-		`SELECT id, user_id, name, token_hash, created_at, org_id FROM agents WHERE id = ?`,
+		`SELECT id, user_id, name, token_hash, created_at, org_id FROM agents WHERE id = ? AND deleted_at IS NULL`,
 		id,
 	).Scan(&a.ID, &a.UserID, &a.Name, &a.TokenHash, &createdAt, &orgID)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -1073,6 +1086,18 @@ func (s *Store) RevokeTask(ctx context.Context, id, userID string) error {
 	return nil
 }
 
+func (s *Store) RevokeTasksByAgent(ctx context.Context, agentID, userID string) (int, error) {
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE tasks SET status = 'revoked'
+		 WHERE agent_id = ? AND user_id = ? AND status IN ('active', 'pending_approval', 'pending_scope_expansion')`,
+		agentID, userID)
+	if err != nil {
+		return 0, err
+	}
+	n, _ := res.RowsAffected()
+	return int(n), nil
+}
+
 func (s *Store) ListExpiredTasks(ctx context.Context) ([]*store.Task, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT id, user_id, agent_id, purpose, status, authorized_actions,
@@ -1682,7 +1707,7 @@ func (s *Store) TelemetryCounts(ctx context.Context) (*store.TelemetryCounts, er
 		RequestsByService: make(map[string]int),
 	}
 
-	if err := s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM agents").Scan(&c.Agents); err != nil {
+	if err := s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM agents WHERE deleted_at IS NULL").Scan(&c.Agents); err != nil {
 		return nil, fmt.Errorf("counting agents: %w", err)
 	}
 

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -89,6 +89,7 @@ type Store interface {
 	SetTaskPendingExpansion(ctx context.Context, id string, action *TaskAction, reason string) error
 	ListExpiredTasks(ctx context.Context) ([]*Task, error)
 	RevokeTask(ctx context.Context, id, userID string) error
+	RevokeTasksByAgent(ctx context.Context, agentID, userID string) (int, error)
 
 	// Pending approvals
 	SavePendingApproval(ctx context.Context, pa *PendingApproval) error
@@ -181,12 +182,14 @@ type Session struct {
 
 // Agent is an AI agent that authenticates via a long-lived bearer token.
 type Agent struct {
-	ID        string    `json:"id"`
-	UserID    string    `json:"user_id"`
-	Name      string    `json:"name"`
-	TokenHash string    `json:"-"`
-	OrgID     string    `json:"org_id,omitempty"` // set by cloud when agent belongs to an org
-	CreatedAt time.Time `json:"created_at"`
+	ID              string     `json:"id"`
+	UserID          string     `json:"user_id"`
+	Name            string     `json:"name"`
+	TokenHash       string     `json:"-"`
+	OrgID           string     `json:"org_id,omitempty"` // set by cloud when agent belongs to an org
+	CreatedAt       time.Time  `json:"created_at"`
+	ActiveTaskCount int        `json:"active_task_count"`
+	LastTaskAt      *time.Time `json:"last_task_at,omitempty"`
 }
 
 // ServiceMeta records that a user has activated a given service.

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -213,6 +213,8 @@ export interface Agent {
   name: string
   created_at: string
   token?: string // only present on creation
+  active_task_count: number
+  last_task_at?: string
 }
 
 export interface ConnectionRequest {
@@ -646,7 +648,7 @@ export const api = {
     list: () => get<Agent[]>('/api/agents'),
     create: (name: string) =>
       post<Agent>('/api/agents', { name }),
-    delete: (id: string) => del<void>(`/api/agents/${id}`),
+    delete: (id: string) => del<{ revoked_tasks: number }>(`/api/agents/${id}`),
   },
   connections: {
     list: () => get<ConnectionRequest[]>('/api/agents/connections'),
@@ -835,7 +837,7 @@ export const api = {
     createAgent: (orgId: string, name: string) =>
       post<{ agent: Agent; token: string }>(`/api/orgs/${orgId}/agents`, { name }),
     deleteAgent: (orgId: string, agentId: string) =>
-      del<void>(`/api/orgs/${orgId}/agents/${agentId}`),
+      del<{ revoked_tasks: number }>(`/api/orgs/${orgId}/agents/${agentId}`),
     revokeTask: (orgId: string, taskId: string) =>
       post<{ status: string }>(`/api/orgs/${orgId}/tasks/${taskId}/revoke`, {}),
     tasks: (orgId: string, params?: { status?: string; limit?: number; offset?: number }) => {

--- a/web/src/pages/Agents.tsx
+++ b/web/src/pages/Agents.tsx
@@ -42,7 +42,11 @@ export default function Agents() {
 
   const deleteMut = useMutation({
     mutationFn: (id: string) => orgId ? api.orgs.deleteAgent(orgId, id) : api.agents.delete(id),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['agents'] }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['agents'] })
+      qc.invalidateQueries({ queryKey: ['tasks'] })
+      qc.invalidateQueries({ queryKey: ['overview'] })
+    },
   })
 
   const pending = (!orgId ? connections : undefined) ?? []
@@ -141,27 +145,50 @@ export default function Agents() {
         )}
 
         <div className="space-y-2">
-          {agents?.map(agent => (
-            <div key={agent.id} className="bg-surface-1 border border-border-default rounded-md px-5 py-4 flex items-center justify-between">
-              <div>
-                <span className="font-medium text-text-primary">{agent.name}</span>
-                <p className="text-xs text-text-tertiary mt-0.5">
-                  Created {formatDistanceToNow(new Date(agent.created_at), { addSuffix: true })} · {agent.id}
-                </p>
-              </div>
-              <button
-                onClick={() => {
-                  if (confirm(`Revoke agent "${agent.name}"? Any running agents using this token will stop working.`)) {
-                    deleteMut.mutate(agent.id)
-                  }
-                }}
-                disabled={deleteMut.isPending}
-                className="text-xs px-3 py-1.5 rounded bg-danger/10 text-danger border border-danger/20 hover:bg-danger/20"
+          {agents?.map(agent => {
+            const hasActiveTasks = agent.active_task_count > 0
+            return (
+              <div
+                key={agent.id}
+                className={`bg-surface-1 border rounded-md px-5 py-4 flex items-center justify-between ${
+                  hasActiveTasks
+                    ? 'border-brand/40 border-l-[3px] border-l-brand'
+                    : 'border-border-default'
+                }`}
               >
-                Revoke
-              </button>
-            </div>
-          ))}
+                <div>
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium text-text-primary">{agent.name}</span>
+                    {hasActiveTasks && (
+                      <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-brand/10 text-brand">
+                        {agent.active_task_count} active {agent.active_task_count === 1 ? 'task' : 'tasks'}
+                      </span>
+                    )}
+                  </div>
+                  <p className="text-xs text-text-tertiary mt-0.5">
+                    Created {formatDistanceToNow(new Date(agent.created_at), { addSuffix: true })} · {agent.id}
+                    {agent.last_task_at && (
+                      <> · Last task {formatDistanceToNow(new Date(agent.last_task_at), { addSuffix: true })}</>
+                    )}
+                  </p>
+                </div>
+                <button
+                  onClick={() => {
+                    const taskWarning = hasActiveTasks
+                      ? `\n\n${agent.active_task_count} active ${agent.active_task_count === 1 ? 'task' : 'tasks'} will be revoked.`
+                      : ''
+                    if (confirm(`Revoke agent "${agent.name}"? Running agents using this token will stop working.${taskWarning}`)) {
+                      deleteMut.mutate(agent.id)
+                    }
+                  }}
+                  disabled={deleteMut.isPending}
+                  className="text-xs px-3 py-1.5 rounded bg-danger/10 text-danger border border-danger/20 hover:bg-danger/20"
+                >
+                  Revoke
+                </button>
+              </div>
+            )
+          })}
         </div>
       </section>
 


### PR DESCRIPTION
## Summary

- Agents are now soft-deleted (`deleted_at` column) instead of hard-deleted, so revoked tasks persist for audit rather than being CASCADE-deleted with the agent row.
- Deleting an agent first revokes all its active/pending tasks, publishes SSE events, and returns the revoked count. The confirmation dialog warns with the specific count.
- The agent list now includes `active_task_count` and `last_task_at` computed via SQL subqueries. Agents with active tasks are visually highlighted with a brand-colored border and badge.
- All agent queries (`GetAgentByToken`, `ListAgents`, `getAgentByID`, callback secret methods, telemetry counts) filter by `deleted_at IS NULL`.

## Test plan

- [ ] Delete an agent with active tasks — verify tasks show as revoked in the Tasks page
- [ ] Delete an agent with no tasks — verify clean 200 response with `revoked_tasks: 0`
- [ ] Verify soft-deleted agents no longer appear in the agent list or authenticate via token
- [ ] Verify agent cards show active task count badge and last task timestamp
- [ ] Verify agents with active tasks have highlighted border styling