### PR TITLE
feat: unify onboarding and MFA login flow

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { Component, type ErrorInfo, type ReactNode } from 'react'
-import { Navigate, Route, Routes } from 'react-router-dom'
+import { Navigate, Route, Routes, useLocation } from 'react-router-dom'
 import { useAuth } from './hooks/useAuth'
 import Login from './pages/Login'
 import Register from './pages/Register'
@@ -10,6 +10,9 @@ import SetupAuth from './pages/SetupAuth'
 import TOTPVerify from './pages/TOTPVerify'
 import Dashboard from './pages/Dashboard'
 import OAuthAuthorize from './pages/OAuthAuthorize'
+import OAuthCallback from './pages/OAuthCallback'
+import MFAVerify from './pages/MFAVerify'
+import SecuritySetup from './pages/SecuritySetup'
 
 class ErrorBoundary extends Component<{ children: ReactNode }, { hasError: boolean }> {
   constructor(props: { children: ReactNode }) {
@@ -44,10 +47,14 @@ class ErrorBoundary extends Component<{ children: ReactNode }, { hasError: boole
 }
 
 function RequireAuth({ children }: { children: React.ReactNode }) {
-  const { isAuthenticated, isLoading, authMode } = useAuth()
+  const { isAuthenticated, isLoading, authMode, onboardingComplete } = useAuth()
+  const location = useLocation()
   if (isLoading) return <div className="min-h-screen flex items-center justify-center">Loading...</div>
   if (!isAuthenticated) {
     return <Navigate to={authMode === 'magic_link' ? '/magic-link' : '/login'} replace />
+  }
+  if (onboardingComplete === false && location.pathname !== '/onboarding') {
+    return <Navigate to="/onboarding" replace />
   }
   return <>{children}</>
 }
@@ -78,6 +85,16 @@ export default function App() {
       <Route path="/verify-email" element={<VerifyEmail />} />
       <Route path="/setup-auth" element={<SetupAuth />} />
       <Route path="/totp-verify" element={<TOTPVerify />} />
+      <Route path="/login/oauth/callback" element={<OAuthCallback />} />
+      <Route path="/mfa-verify" element={<MFAVerify />} />
+      <Route
+        path="/onboarding"
+        element={
+          <RequireAuth>
+            <SecuritySetup />
+          </RequireAuth>
+        }
+      />
       <Route
         path="/oauth/authorize"
         element={

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -164,33 +164,42 @@ export interface AuthResponse {
   refresh_token: string
 }
 
+export interface GoogleAuthResult {
+  // Full login (no MFA)
+  user?: User
+  access_token?: string
+  refresh_token?: string
+  // MFA required
+  status?: 'requires_mfa'
+  pending_token?: string
+  mfa_methods?: {
+    has_totp: boolean
+    passkey_count: number
+    has_backup_codes: boolean
+  }
+}
+
 // Login may return one of these instead of a full AuthResponse
 export interface LoginResult {
   // Normal login
   user?: User
   access_token?: string
   refresh_token?: string
-  // TOTP required
-  status?: 'requires_totp' | 'setup_required'
+  // MFA required
+  status?: 'requires_mfa'
   pending_token?: string
-  setup_token?: string
+  mfa_methods?: {
+    has_totp: boolean
+    passkey_count: number
+    has_backup_codes: boolean
+  }
 }
 
 export interface RegisterResult {
-  user?: User
-  // Local mode: full tokens
-  access_token?: string
-  refresh_token?: string
-  // Non-local mode without email verification: setup token
-  setup_token?: string
-  // Non-local mode with email verification: status
-  status?: 'verify_email'
+  status: 'verify_email'
 }
 
-export interface VerifyEmailResult {
-  setup_token: string
-  email: string
-}
+export type VerifyEmailResult = AuthResponse
 
 export interface WebAuthnCredential {
   id: string
@@ -204,7 +213,19 @@ export interface WebAuthnCredential {
 export interface UserAuthMethods {
   has_password: boolean
   has_totp: boolean
+  has_google: boolean
+  has_backup_codes: boolean
   passkey_count: number
+}
+
+export interface OnboardingStatus {
+  has_security_method: boolean
+  has_backup_codes: boolean
+  onboarding_completed: boolean
+}
+
+export interface BackupCodesResponse {
+  codes: string[]
 }
 
 export interface Agent {
@@ -596,7 +617,7 @@ export interface CustomMCPServer {
 
 export const api = {
   auth: {
-    register: (email: string, password?: string) =>
+    register: (email: string, password: string) =>
       post<RegisterResult>('/api/auth/register', { email, password }),
     login: (email: string, password: string) =>
       post<LoginResult>('/api/auth/login', { email, password }),
@@ -627,6 +648,10 @@ export const api = {
         post<{ challenge_id: string; options: any }>('/api/auth/passkey/login/begin', {}),
       loginFinish: (challengeId: string, credential: any) =>
         post<AuthResponse>('/api/auth/passkey/login/finish', { challenge_id: challengeId, credential }),
+      verifyBegin: (pendingToken: string) =>
+        requestWithToken<{ challenge_id: string; options: any }>('POST', '/api/auth/passkey/verify/begin', pendingToken, {}),
+      verifyFinish: (pendingToken: string, challengeId: string, credential: any) =>
+        requestWithToken<AuthResponse>('POST', '/api/auth/passkey/verify/finish', pendingToken, { challenge_id: challengeId, credential }),
       list: () => get<WebAuthnCredential[]>('/api/auth/passkeys'),
       addBegin: () =>
         post<{ challenge_id: string; options: any }>('/api/auth/passkeys/add/begin', {}),
@@ -642,6 +667,20 @@ export const api = {
         requestWithToken<AuthResponse>('POST', '/api/auth/totp/verify', pendingToken, { code }),
       status: () => get<{ enabled: boolean }>('/api/auth/totp'),
       disable: (password: string) => del<void>('/api/auth/totp', { password }),
+    },
+    google: {
+      exchange: (code: string, redirectUri: string) =>
+        post<GoogleAuthResult>('/api/auth/google', { code, redirect_uri: redirectUri }),
+      clientId: () => get<{ client_id: string }>('/api/auth/google/client-id'),
+    },
+    backupCode: {
+      verify: (pendingToken: string, code: string) =>
+        requestWithToken<AuthResponse>('POST', '/api/auth/backup-codes/mfa-verify', pendingToken, { code }),
+    },
+    onboarding: {
+      status: () => get<OnboardingStatus>('/api/auth/onboarding/status'),
+      generateBackupCodes: () => post<BackupCodesResponse>('/api/auth/onboarding/backup-codes', {}),
+      complete: () => post<{ completed: boolean }>('/api/auth/onboarding/complete', {}),
     },
   },
   agents: {

--- a/web/src/hooks/useAuth.tsx
+++ b/web/src/hooks/useAuth.tsx
@@ -16,8 +16,10 @@ interface AuthContextValue {
   features: FeatureSet | null
   currentOrg: Org | null
   setCurrentOrg: (org: Org | null) => void
+  onboardingComplete: boolean | null
+  refreshOnboarding: () => Promise<void>
   login: (email: string, password: string) => Promise<LoginResult>
-  register: (email: string, password?: string) => Promise<RegisterResult>
+  register: (email: string, password: string) => Promise<RegisterResult>
   logout: () => Promise<void>
   /** Set session tokens directly (used by pages that handle multi-step auth flows) */
   setSession: (accessToken: string, refreshToken: string, user: User) => void
@@ -30,6 +32,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [isLoading, setIsLoading] = useState(true)
   const [authMode, setAuthMode] = useState<'magic_link' | 'password' | 'passkey' | null>(null)
   const [features, setFeatures] = useState<FeatureSet | null>(null)
+  const [onboardingComplete, setOnboardingComplete] = useState<boolean | null>(null)
   const [currentOrg, setCurrentOrgState] = useState<Org | null>(() => {
     try {
       const stored = localStorage.getItem(CURRENT_ORG_KEY)
@@ -46,6 +49,21 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // Prevents React StrictMode's intentional double-invoke from burning the
   // single-use refresh token twice on the initial session restore.
   const didInit = useRef(false)
+
+  const checkOnboarding = useCallback(() => {
+    api.auth.onboarding.status()
+      .then((s) => setOnboardingComplete(s.onboarding_completed))
+      .catch(() => setOnboardingComplete(null))
+  }, [])
+
+  const refreshOnboarding = useCallback(async () => {
+    try {
+      const s = await api.auth.onboarding.status()
+      setOnboardingComplete(s.onboarding_completed)
+    } catch {
+      // ignore
+    }
+  }, [])
 
   const setCurrentOrg = useCallback((org: Org | null) => {
     setCurrentOrgState(org)
@@ -80,6 +98,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             setAccessToken(resp.access_token)
             safeSetItem(REFRESH_TOKEN_KEY, resp.refresh_token)
             setUser(resp.user)
+            // Check onboarding status now that we have a valid token.
+            checkOnboarding()
           })
           .catch((e) => {
             console.warn('useAuth: token refresh failed', e)
@@ -118,7 +138,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setAccessToken(at)
     safeSetItem(REFRESH_TOKEN_KEY, rt)
     setUser(u)
-  }, [])
+    checkOnboarding()
+  }, [checkOnboarding])
 
   const login = useCallback(async (email: string, password: string): Promise<LoginResult> => {
     const resp = await api.auth.login(email, password)
@@ -127,19 +148,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setAccessToken(resp.access_token)
       safeSetItem(REFRESH_TOKEN_KEY, resp.refresh_token)
       setUser(resp.user)
+      checkOnboarding()
     }
     return resp
-  }, [])
+  }, [checkOnboarding])
 
-  const register = useCallback(async (email: string, password?: string): Promise<RegisterResult> => {
-    const resp = await api.auth.register(email, password)
-    // Only set session if we got full tokens back (local mode)
-    if (resp.access_token && resp.refresh_token) {
-      setAccessToken(resp.access_token)
-      safeSetItem(REFRESH_TOKEN_KEY, resp.refresh_token)
-      setUser(resp.user ?? null)
-    }
-    return resp
+  const register = useCallback(async (email: string, password: string): Promise<RegisterResult> => {
+    return api.auth.register(email, password)
   }, [])
 
   const logout = useCallback(async () => {
@@ -151,10 +166,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setCurrentOrgId(null)
     setCurrentOrgState(null)
     setUser(null)
+    setOnboardingComplete(null)
   }, [])
 
   return (
-    <AuthContext.Provider value={{ user, isLoading, isAuthenticated: user !== null, authMode, features, currentOrg, setCurrentOrg, login, register, logout, setSession }}>
+    <AuthContext.Provider value={{ user, isLoading, isAuthenticated: user !== null, authMode, features, currentOrg, setCurrentOrg, onboardingComplete, refreshOnboarding, login, register, logout, setSession }}>
       {children}
     </AuthContext.Provider>
   )

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -14,6 +14,26 @@ export default function Login() {
 
   const passkeysEnabled = features?.passkeys && isWebAuthnAvailable()
 
+  async function handleGoogleLogin() {
+    setError(null)
+    setIsSubmitting(true)
+    try {
+      const { client_id } = await api.auth.google.clientId()
+      const redirectUri = `${window.location.origin}/login/oauth/callback`
+      const params = new URLSearchParams({
+        client_id,
+        redirect_uri: redirectUri,
+        response_type: 'code',
+        scope: 'openid email profile',
+        prompt: 'select_account',
+      })
+      window.location.href = `https://accounts.google.com/o/oauth2/v2/auth?${params}`
+    } catch (err: any) {
+      setError(err instanceof APIError ? err.message : 'Google sign-in is not available')
+      setIsSubmitting(false)
+    }
+  }
+
   async function handlePasskeyLogin() {
     setError(null)
     setIsSubmitting(true)
@@ -42,10 +62,14 @@ export default function Login() {
     setIsSubmitting(true)
     try {
       const resp = await login(email, password)
-      if (resp.status === 'requires_totp') {
-        navigate('/totp-verify', { state: { pending_token: resp.pending_token } })
-      } else if (resp.status === 'setup_required') {
-        navigate('/setup-auth', { state: { setup_token: resp.setup_token, upgrade: true } })
+      if (resp.status === 'requires_mfa') {
+        navigate('/mfa-verify', {
+          state: {
+            pending_token: resp.pending_token,
+            mfa_methods: resp.mfa_methods,
+          },
+          replace: true,
+        })
       } else {
         navigate('/dashboard')
       }
@@ -72,8 +96,8 @@ export default function Login() {
           <div className="p-3 bg-danger/10 text-danger rounded text-sm">{error}</div>
         )}
 
-        {passkeysEnabled && (
-          <div className="space-y-3">
+        <div className="space-y-3">
+          {passkeysEnabled && (
             <button
               onClick={handlePasskeyLogin}
               disabled={isSubmitting}
@@ -81,16 +105,24 @@ export default function Login() {
             >
               {isSubmitting ? 'Authenticating...' : 'Sign in with passkey'}
             </button>
-            <div className="relative">
-              <div className="absolute inset-0 flex items-center">
-                <div className="w-full border-t border-border-subtle" />
-              </div>
-              <div className="relative flex justify-center text-sm">
-                <span className="px-2 bg-surface-1 text-text-tertiary">or sign in with password</span>
-              </div>
+          )}
+          <button
+            onClick={handleGoogleLogin}
+            disabled={isSubmitting}
+            className="w-full py-3 px-4 bg-surface-2 text-text-primary rounded font-medium hover:bg-surface-3 disabled:opacity-50 flex items-center justify-center gap-2"
+          >
+            <svg className="w-5 h-5" viewBox="0 0 24 24"><path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4"/><path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/><path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/><path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/></svg>
+            Sign in with Google
+          </button>
+          <div className="relative">
+            <div className="absolute inset-0 flex items-center">
+              <div className="w-full border-t border-border-subtle" />
+            </div>
+            <div className="relative flex justify-center text-sm">
+              <span className="px-2 bg-surface-1 text-text-tertiary">or sign in with password</span>
             </div>
           </div>
-        )}
+        </div>
 
         <form className="space-y-4" onSubmit={handleSubmit}>
           <div>

--- a/web/src/pages/MFAVerify.tsx
+++ b/web/src/pages/MFAVerify.tsx
@@ -1,0 +1,248 @@
+import { useState, FormEvent } from 'react'
+import { useNavigate, useLocation } from 'react-router-dom'
+import { api, APIError } from '../api/client'
+import { useAuth } from '../hooks/useAuth'
+import { startAuthentication } from '../lib/webauthn'
+
+interface MFAState {
+  pending_token: string
+  mfa_methods: {
+    has_totp: boolean
+    passkey_count: number
+    has_backup_codes: boolean
+  }
+}
+
+export default function MFAVerify() {
+  const { setSession } = useAuth()
+  const navigate = useNavigate()
+  const location = useLocation()
+  const state = location.state as MFAState | null
+
+  const [error, setError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [totpCode, setTotpCode] = useState('')
+  const [backupCode, setBackupCode] = useState('')
+  const [showBackupCode, setShowBackupCode] = useState(false)
+
+  const pendingToken = state?.pending_token ?? ''
+  const hasTOTP = state?.mfa_methods?.has_totp ?? false
+  const hasPasskeys = (state?.mfa_methods?.passkey_count ?? 0) > 0
+  const hasBackupCodes = state?.mfa_methods?.has_backup_codes ?? false
+
+  async function handlePasskey() {
+    setError(null)
+    setIsSubmitting(true)
+    try {
+      const beginResp = await api.auth.passkey.verifyBegin(pendingToken)
+      const credential = await startAuthentication(beginResp.options)
+      const finishResp = await api.auth.passkey.verifyFinish(pendingToken, beginResp.challenge_id, credential)
+      setSession(finishResp.access_token, finishResp.refresh_token, finishResp.user)
+      navigate('/dashboard', { replace: true })
+    } catch (err: any) {
+      if (err?.name === 'NotAllowedError') {
+        setError('Passkey verification was cancelled')
+      } else if (err instanceof APIError) {
+        setError(err.message)
+      } else {
+        setError(err?.message ?? 'Passkey verification failed')
+      }
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  async function handleTOTP(e: FormEvent) {
+    e.preventDefault()
+    setError(null)
+    setIsSubmitting(true)
+    try {
+      const resp = await api.auth.totp.verify(pendingToken, totpCode)
+      setSession(resp.access_token, resp.refresh_token, resp.user)
+      navigate('/dashboard', { replace: true })
+    } catch (err: any) {
+      setError(err instanceof APIError ? err.message : 'Invalid code')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  async function handleBackupCode(e: FormEvent) {
+    e.preventDefault()
+    setError(null)
+    setIsSubmitting(true)
+    try {
+      const resp = await api.auth.backupCode.verify(pendingToken, backupCode)
+      setSession(resp.access_token, resp.refresh_token, resp.user)
+      navigate('/dashboard', { replace: true })
+    } catch (err: any) {
+      setError(err instanceof APIError ? err.message : 'Invalid backup code')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  if (!pendingToken) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-surface-0">
+        <div className="max-w-md w-full p-8 bg-surface-1 border border-border-default rounded-md text-center">
+          <h2 className="text-lg font-semibold text-text-primary mb-2">Session expired</h2>
+          <p className="text-sm text-text-secondary mb-4">Please sign in again.</p>
+          <button
+            onClick={() => navigate('/login')}
+            className="py-2 px-4 bg-brand text-surface-0 rounded font-medium hover:bg-brand-strong"
+          >
+            Go to login
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  if (showBackupCode) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-surface-0">
+        <div className="max-w-md w-full space-y-6 p-8 bg-surface-1 border border-border-default rounded-md">
+          <div>
+            <h1 className="text-3xl font-bold text-text-primary">Clawvisor</h1>
+            <h2 className="mt-2 text-lg text-text-secondary">Use a backup code</h2>
+            <p className="mt-1 text-sm text-text-tertiary">
+              Enter one of your backup codes to sign in. Each code can only be used once.
+            </p>
+          </div>
+
+          {error && (
+            <div className="p-3 bg-danger/10 text-danger rounded text-sm">{error}</div>
+          )}
+
+          <form className="space-y-4" onSubmit={handleBackupCode}>
+            <div>
+              <label htmlFor="backup-code" className="block text-sm font-medium text-text-secondary">
+                Backup code
+              </label>
+              <input
+                id="backup-code"
+                type="text"
+                required
+                value={backupCode}
+                onChange={(e) => setBackupCode(e.target.value)}
+                placeholder="xxxx-xxxx"
+                className="mt-1 block w-full rounded border border-border-default bg-surface-0 text-text-primary px-3 py-3 text-center text-2xl tracking-widest focus:outline-none focus:ring-1 focus:ring-brand/30 focus:border-brand placeholder:text-text-tertiary"
+                autoComplete="off"
+              />
+            </div>
+            <button
+              type="submit"
+              disabled={isSubmitting || backupCode.length < 8}
+              className="w-full py-2 px-4 bg-brand text-surface-0 rounded font-medium hover:bg-brand-strong disabled:opacity-50"
+            >
+              {isSubmitting ? 'Verifying...' : 'Verify'}
+            </button>
+          </form>
+
+          <button
+            onClick={() => { setShowBackupCode(false); setError(null); setBackupCode('') }}
+            className="w-full py-2 text-sm text-text-tertiary hover:text-text-primary"
+          >
+            Back to other methods
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-surface-0">
+      <div className="max-w-md w-full space-y-6 p-8 bg-surface-1 border border-border-default rounded-md">
+        <div>
+          <h1 className="text-3xl font-bold text-text-primary">Clawvisor</h1>
+          <h2 className="mt-2 text-lg text-text-secondary">Verify your identity</h2>
+          <p className="mt-1 text-sm text-text-tertiary">
+            Choose a verification method to complete sign-in.
+          </p>
+        </div>
+
+        {error && (
+          <div className="p-3 bg-danger/10 text-danger rounded text-sm">{error}</div>
+        )}
+
+        {hasPasskeys && (
+          <button
+            onClick={handlePasskey}
+            disabled={isSubmitting}
+            className="w-full py-3 px-4 bg-brand text-surface-0 rounded font-medium hover:bg-brand-strong disabled:opacity-50"
+          >
+            {isSubmitting ? 'Verifying...' : 'Verify with passkey'}
+          </button>
+        )}
+
+        {hasTOTP && hasPasskeys && (
+          <div className="relative">
+            <div className="absolute inset-0 flex items-center">
+              <div className="w-full border-t border-border-subtle" />
+            </div>
+            <div className="relative flex justify-center text-sm">
+              <span className="px-2 bg-surface-1 text-text-tertiary">or use authenticator</span>
+            </div>
+          </div>
+        )}
+
+        {hasTOTP && (
+          <form className="space-y-4" onSubmit={handleTOTP}>
+            <div>
+              <label htmlFor="totp-code" className="block text-sm font-medium text-text-secondary">
+                Authenticator code
+              </label>
+              <input
+                id="totp-code"
+                type="text"
+                inputMode="numeric"
+                pattern="[0-9]{6}"
+                maxLength={6}
+                required
+                value={totpCode}
+                onChange={(e) => setTotpCode(e.target.value.replace(/\D/g, ''))}
+                placeholder="000000"
+                className="mt-1 block w-full rounded border border-border-default bg-surface-0 text-text-primary px-3 py-3 text-center text-2xl tracking-widest focus:outline-none focus:ring-1 focus:ring-brand/30 focus:border-brand placeholder:text-text-tertiary"
+                autoComplete="one-time-code"
+              />
+            </div>
+            <button
+              type="submit"
+              disabled={isSubmitting || totpCode.length !== 6}
+              className="w-full py-2 px-4 bg-brand text-surface-0 rounded font-medium hover:bg-brand-strong disabled:opacity-50"
+            >
+              {isSubmitting ? 'Verifying...' : 'Verify'}
+            </button>
+          </form>
+        )}
+
+        {hasBackupCodes && (
+          <>
+            <div className="relative">
+              <div className="absolute inset-0 flex items-center">
+                <div className="w-full border-t border-border-subtle" />
+              </div>
+              <div className="relative flex justify-center text-sm">
+                <span className="px-2 bg-surface-1 text-text-tertiary">lost your device?</span>
+              </div>
+            </div>
+            <button
+              onClick={() => { setShowBackupCode(true); setError(null) }}
+              className="w-full py-2 px-4 bg-surface-2 text-text-primary rounded font-medium hover:bg-surface-3"
+            >
+              Use a backup code
+            </button>
+          </>
+        )}
+
+        <button
+          onClick={() => navigate('/login')}
+          className="w-full py-2 text-sm text-text-tertiary hover:text-text-primary"
+        >
+          Back to login
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/web/src/pages/OAuthCallback.tsx
+++ b/web/src/pages/OAuthCallback.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useState, useRef } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import { api, APIError } from '../api/client'
+import { useAuth } from '../hooks/useAuth'
+
+export default function OAuthCallback() {
+  const { setSession, isAuthenticated } = useAuth()
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const [error, setError] = useState<string | null>(null)
+  const [destination, setDestination] = useState<string | null>(null)
+  const didExchange = useRef(false)
+
+  // Step 1: Exchange the code with the backend.
+  useEffect(() => {
+    if (didExchange.current) return
+    didExchange.current = true
+
+    const code = searchParams.get('code')
+    const errorParam = searchParams.get('error')
+
+    if (errorParam) {
+      setError(errorParam === 'access_denied' ? 'Sign-in was cancelled' : `OAuth error: ${errorParam}`)
+      return
+    }
+
+    if (!code) {
+      setError('No authorization code received')
+      return
+    }
+
+    const redirectUri = `${window.location.origin}/login/oauth/callback`
+    api.auth.google.exchange(code, redirectUri)
+      .then((resp) => {
+        if (resp.status === 'requires_mfa') {
+          navigate('/mfa-verify', {
+            state: {
+              pending_token: resp.pending_token,
+              mfa_methods: resp.mfa_methods,
+            },
+            replace: true,
+          })
+          return
+        }
+        // Set session — navigate after isAuthenticated becomes true.
+        setSession(resp.access_token!, resp.refresh_token!, resp.user!)
+        setDestination('/onboarding')
+      })
+      .catch((err) => {
+        setError(err instanceof APIError ? err.message : 'Failed to sign in')
+      })
+  }, [searchParams, setSession, navigate])
+
+  // Step 2: Navigate once React state has settled and user is authenticated.
+  useEffect(() => {
+    if (destination && isAuthenticated) {
+      navigate(destination, { replace: true })
+    }
+  }, [destination, isAuthenticated, navigate])
+
+  if (error) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-surface-0">
+        <div className="max-w-md w-full p-8 bg-surface-1 border border-border-default rounded-md text-center space-y-4">
+          <h2 className="text-lg font-semibold text-text-primary">Sign-in failed</h2>
+          <div className="p-3 bg-danger/10 text-danger rounded text-sm">{error}</div>
+          <button
+            onClick={() => navigate('/login')}
+            className="py-2 px-4 bg-brand text-surface-0 rounded font-medium hover:bg-brand-strong"
+          >
+            Back to login
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-surface-0">
+      <div className="text-text-secondary">Signing in...</div>
+    </div>
+  )
+}

--- a/web/src/pages/Register.tsx
+++ b/web/src/pages/Register.tsx
@@ -1,38 +1,43 @@
 import { useState, FormEvent } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
-import { useAuth } from '../hooks/useAuth'
-import { api, APIError, setAccessToken } from '../api/client'
-
-const REFRESH_TOKEN_KEY = 'clawvisor_refresh_token'
+import { api, APIError } from '../api/client'
 
 export default function Register() {
-  const { authMode } = useAuth()
+
   const navigate = useNavigate()
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
 
-  const isPasskeyMode = authMode === 'passkey'
+
+  async function handleGoogleRegister() {
+    setError(null)
+    setIsSubmitting(true)
+    try {
+      const { client_id } = await api.auth.google.clientId()
+      const redirectUri = `${window.location.origin}/login/oauth/callback`
+      const params = new URLSearchParams({
+        client_id,
+        redirect_uri: redirectUri,
+        response_type: 'code',
+        scope: 'openid email profile',
+        prompt: 'select_account',
+      })
+      window.location.href = `https://accounts.google.com/o/oauth2/v2/auth?${params}`
+    } catch (err: any) {
+      setError(err instanceof APIError ? err.message : 'Google sign-up is not available')
+      setIsSubmitting(false)
+    }
+  }
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault()
     setError(null)
     setIsSubmitting(true)
     try {
-      const resp = await api.auth.register(email, isPasskeyMode ? undefined : password)
-      if (resp.status === 'verify_email') {
-        // Non-local with email verification: check your email
-        navigate('/check-email', { state: { email } })
-      } else if (resp.setup_token) {
-        // Non-local without email verification: direct to auth setup
-        navigate('/setup-auth', { state: { setup_token: resp.setup_token } })
-      } else if (resp.access_token) {
-        // Local mode: direct login
-        setAccessToken(resp.access_token)
-        localStorage.setItem(REFRESH_TOKEN_KEY, resp.refresh_token!)
-        navigate('/dashboard')
-      }
+      await api.auth.register(email, password)
+      navigate('/check-email', { state: { email } })
     } catch (err) {
       if (err instanceof APIError) {
         setError(err.message)
@@ -52,11 +57,30 @@ export default function Register() {
           <h2 className="mt-2 text-lg text-text-secondary">Create your account</h2>
         </div>
 
-        <form className="space-y-4" onSubmit={handleSubmit}>
-          {error && (
-            <div className="p-3 bg-danger/10 text-danger rounded text-sm">{error}</div>
-          )}
+        {error && (
+          <div className="p-3 bg-danger/10 text-danger rounded text-sm">{error}</div>
+        )}
 
+        <div className="space-y-3">
+          <button
+            onClick={handleGoogleRegister}
+            disabled={isSubmitting}
+            className="w-full py-3 px-4 bg-surface-2 text-text-primary rounded font-medium hover:bg-surface-3 disabled:opacity-50 flex items-center justify-center gap-2"
+          >
+            <svg className="w-5 h-5" viewBox="0 0 24 24"><path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4"/><path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/><path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/><path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/></svg>
+            Sign up with Google
+          </button>
+          <div className="relative">
+            <div className="absolute inset-0 flex items-center">
+              <div className="w-full border-t border-border-subtle" />
+            </div>
+            <div className="relative flex justify-center text-sm">
+              <span className="px-2 bg-surface-1 text-text-tertiary">or create with email</span>
+            </div>
+          </div>
+        </div>
+
+        <form className="space-y-4" onSubmit={handleSubmit}>
           <div>
             <label htmlFor="email" className="block text-sm font-medium text-text-secondary">
               Email
@@ -71,23 +95,21 @@ export default function Register() {
             />
           </div>
 
-          {!isPasskeyMode && (
-            <div>
-              <label htmlFor="password" className="block text-sm font-medium text-text-secondary">
-                Password
-              </label>
-              <input
-                id="password"
-                type="password"
-                required
-                minLength={8}
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                className="mt-1 block w-full rounded border border-border-default bg-surface-0 text-text-primary px-3 py-2 focus:outline-none focus:ring-1 focus:ring-brand/30 focus:border-brand"
-              />
-              <p className="mt-1 text-xs text-text-tertiary">Minimum 8 characters</p>
-            </div>
-          )}
+          <div>
+            <label htmlFor="password" className="block text-sm font-medium text-text-secondary">
+              Password
+            </label>
+            <input
+              id="password"
+              type="password"
+              required
+              minLength={8}
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="mt-1 block w-full rounded border border-border-default bg-surface-0 text-text-primary px-3 py-2 focus:outline-none focus:ring-1 focus:ring-brand/30 focus:border-brand"
+            />
+            <p className="mt-1 text-xs text-text-tertiary">Minimum 8 characters</p>
+          </div>
 
           <button
             type="submit"

--- a/web/src/pages/SecuritySetup.tsx
+++ b/web/src/pages/SecuritySetup.tsx
@@ -1,0 +1,334 @@
+import { useState, useEffect, FormEvent } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { api, APIError, type OnboardingStatus } from '../api/client'
+import { useAuth } from '../hooks/useAuth'
+import { isWebAuthnAvailable, startRegistration } from '../lib/webauthn'
+
+type Step = 'loading' | 'security' | 'passkey' | 'totp' | 'totp-confirm' | 'backup-codes' | 'done'
+
+export default function SecuritySetup() {
+  const { user, refreshOnboarding } = useAuth()
+  const navigate = useNavigate()
+  const [step, setStep] = useState<Step>('loading')
+  const [error, setError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [status, setStatus] = useState<OnboardingStatus | null>(null)
+
+  // TOTP state
+  const [totpQR, setTotpQR] = useState<string | null>(null)
+  const [totpSecret, setTotpSecret] = useState<string | null>(null)
+  const [totpCode, setTotpCode] = useState('')
+
+  // Backup codes state
+  const [backupCodes, setBackupCodes] = useState<string[] | null>(null)
+  const [codesDownloaded, setCodesDownloaded] = useState(false)
+
+  useEffect(() => {
+    loadStatus()
+  }, [])
+
+  async function loadStatus() {
+    try {
+      const s = await api.auth.onboarding.status()
+      setStatus(s)
+      if (s.onboarding_completed) {
+        navigate('/dashboard', { replace: true })
+      } else if (s.has_security_method && s.has_backup_codes) {
+        setStep('done')
+      } else if (s.has_security_method) {
+        setStep('backup-codes')
+      } else {
+        setStep('security')
+      }
+    } catch {
+      setStep('security')
+    }
+  }
+
+  // ── Passkey registration ──────────────────────────────────────────────────
+
+  async function handleAddPasskey() {
+    setError(null)
+    setIsSubmitting(true)
+    try {
+      const beginResp = await api.auth.passkey.addBegin()
+      const credential = await startRegistration(beginResp.options)
+      await api.auth.passkey.addFinish(beginResp.challenge_id, credential)
+      await loadStatus()
+    } catch (err: any) {
+      if (err?.name === 'NotAllowedError') {
+        setError('Passkey registration was cancelled')
+      } else {
+        setError(err instanceof APIError ? err.message : 'Passkey registration failed')
+      }
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  // ── TOTP setup ────────────────────────────────────────────────────────────
+
+  async function handleStartTOTP() {
+    setError(null)
+    setIsSubmitting(true)
+    try {
+      const totp = await api.auth.totp.setup()
+      setTotpQR(totp.qr_data_url)
+      setTotpSecret(totp.secret)
+      setStep('totp')
+    } catch (err: any) {
+      setError(err instanceof APIError ? err.message : 'Failed to start TOTP setup')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  async function handleConfirmTOTP(e: FormEvent) {
+    e.preventDefault()
+    setError(null)
+    setIsSubmitting(true)
+    try {
+      await api.auth.totp.confirm(totpCode)
+      await loadStatus()
+    } catch (err: any) {
+      setError(err instanceof APIError ? err.message : 'Invalid TOTP code')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  // ── Backup codes ──────────────────────────────────────────────────────────
+
+  async function handleGenerateBackupCodes() {
+    setError(null)
+    setIsSubmitting(true)
+    try {
+      const resp = await api.auth.onboarding.generateBackupCodes()
+      setBackupCodes(resp.codes)
+    } catch (err: any) {
+      setError(err instanceof APIError ? err.message : 'Failed to generate backup codes')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  function handleDownloadCodes() {
+    if (!backupCodes) return
+    const text = [
+      'Clawvisor Backup Codes',
+      `Generated: ${new Date().toISOString()}`,
+      `Account: ${user?.email ?? ''}`,
+      '',
+      'Keep these codes in a safe place. Each code can only be used once.',
+      '',
+      ...backupCodes.map((code, i) => `${i + 1}. ${code}`),
+    ].join('\n')
+    const blob = new Blob([text], { type: 'text/plain' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'clawvisor-backup-codes.txt'
+    a.click()
+    URL.revokeObjectURL(url)
+    setCodesDownloaded(true)
+  }
+
+  async function handleContinueAfterCodes() {
+    await loadStatus()
+    if (status?.has_security_method && status?.has_backup_codes) {
+      setStep('done')
+    }
+  }
+
+  // ── Complete onboarding ───────────────────────────────────────────────────
+
+  async function handleComplete() {
+    setError(null)
+    setIsSubmitting(true)
+    try {
+      await api.auth.onboarding.complete()
+      await refreshOnboarding()
+      navigate('/dashboard', { replace: true })
+    } catch (err: any) {
+      setError(err instanceof APIError ? err.message : 'Failed to complete onboarding')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  // ── Render ────────────────────────────────────────────────────────────────
+
+  if (step === 'loading') {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-surface-0">
+        <div className="text-text-secondary">Loading...</div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-surface-0">
+      <div className="max-w-md w-full space-y-6 p-8 bg-surface-1 border border-border-default rounded-md">
+        <div>
+          <h1 className="text-3xl font-bold text-text-primary">Clawvisor</h1>
+          <h2 className="mt-2 text-lg text-text-secondary">Secure your account</h2>
+          <div className="mt-3 flex gap-2">
+            {['Security', 'Backup codes', 'Done'].map((label, i) => {
+              const stepIndex = step === 'security' || step === 'passkey' || step === 'totp' || step === 'totp-confirm' ? 0
+                : step === 'backup-codes' ? 1
+                : 2
+              return (
+                <div key={label} className="flex-1">
+                  <div className={`h-1 rounded-full ${i <= stepIndex ? 'bg-brand' : 'bg-surface-3'}`} />
+                  <p className={`text-xs mt-1 ${i <= stepIndex ? 'text-brand' : 'text-text-tertiary'}`}>{label}</p>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+
+        {error && (
+          <div className="p-3 bg-danger/10 text-danger rounded text-sm">{error}</div>
+        )}
+
+        {/* Step: Choose security method */}
+        {step === 'security' && (
+          <div className="space-y-3">
+            <p className="text-sm text-text-secondary">
+              Set up at least one security method to protect your account.
+            </p>
+            {isWebAuthnAvailable() && (
+              <button
+                onClick={handleAddPasskey}
+                disabled={isSubmitting}
+                className="w-full py-3 px-4 bg-brand text-surface-0 rounded font-medium hover:bg-brand-strong disabled:opacity-50 text-left"
+              >
+                <div className="font-medium">Add a passkey</div>
+                <div className="text-sm text-surface-0/70 mt-0.5">Recommended &mdash; use Face ID, Touch ID, or a security key</div>
+              </button>
+            )}
+            <button
+              onClick={handleStartTOTP}
+              disabled={isSubmitting}
+              className="w-full py-3 px-4 bg-surface-2 text-text-primary rounded font-medium hover:bg-surface-3 disabled:opacity-50 text-left"
+            >
+              <div className="font-medium">Set up authenticator app</div>
+              <div className="text-sm text-text-tertiary mt-0.5">Use Google Authenticator, 1Password, or similar</div>
+            </button>
+          </div>
+        )}
+
+        {/* Step: TOTP QR scan */}
+        {step === 'totp' && (
+          <form className="space-y-4" onSubmit={handleConfirmTOTP}>
+            <p className="text-sm text-text-secondary">
+              Scan this QR code with your authenticator app.
+            </p>
+            {totpQR && (
+              <div className="flex justify-center">
+                <img src={totpQR} alt="TOTP QR Code" className="w-48 h-48" />
+              </div>
+            )}
+            {totpSecret && (
+              <div className="text-center">
+                <p className="text-xs text-text-tertiary mb-1">Or enter this code manually:</p>
+                <code className="text-sm bg-surface-2 px-3 py-1 rounded font-mono select-all">{totpSecret}</code>
+              </div>
+            )}
+            <div>
+              <label htmlFor="totp-code" className="block text-sm font-medium text-text-secondary">
+                Enter 6-digit code
+              </label>
+              <input
+                id="totp-code"
+                type="text"
+                inputMode="numeric"
+                pattern="[0-9]{6}"
+                maxLength={6}
+                required
+                value={totpCode}
+                onChange={(e) => setTotpCode(e.target.value.replace(/\D/g, ''))}
+                className="mt-1 block w-full rounded border border-border-default bg-surface-0 text-text-primary px-3 py-2 text-center text-2xl tracking-widest focus:outline-none focus:ring-1 focus:ring-brand/30 focus:border-brand"
+                autoComplete="one-time-code"
+              />
+            </div>
+            <button
+              type="submit"
+              disabled={isSubmitting || totpCode.length !== 6}
+              className="w-full py-2 px-4 bg-brand text-surface-0 rounded font-medium hover:bg-brand-strong disabled:opacity-50"
+            >
+              {isSubmitting ? 'Verifying...' : 'Verify'}
+            </button>
+            <button
+              type="button"
+              onClick={() => { setStep('security'); setError(null) }}
+              className="w-full py-2 text-sm text-text-tertiary hover:text-text-primary"
+            >
+              Back
+            </button>
+          </form>
+        )}
+
+        {/* Step: Backup codes */}
+        {step === 'backup-codes' && (
+          <div className="space-y-4">
+            <p className="text-sm text-text-secondary">
+              Download your backup codes. You'll need these to recover your account if you lose access to your security method.
+            </p>
+            {!backupCodes ? (
+              <button
+                onClick={handleGenerateBackupCodes}
+                disabled={isSubmitting}
+                className="w-full py-2 px-4 bg-brand text-surface-0 rounded font-medium hover:bg-brand-strong disabled:opacity-50"
+              >
+                {isSubmitting ? 'Generating...' : 'Generate backup codes'}
+              </button>
+            ) : (
+              <>
+                <div className="bg-surface-0 border border-border-default rounded p-4">
+                  <div className="grid grid-cols-2 gap-2">
+                    {backupCodes.map((code, i) => (
+                      <div key={i} className="font-mono text-sm text-text-primary bg-surface-2 px-3 py-1.5 rounded text-center">
+                        {code}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+                <button
+                  onClick={handleDownloadCodes}
+                  className="w-full py-2 px-4 bg-surface-2 text-text-primary rounded font-medium hover:bg-surface-3"
+                >
+                  Download as text file
+                </button>
+                <button
+                  onClick={handleContinueAfterCodes}
+                  disabled={!codesDownloaded}
+                  className="w-full py-2 px-4 bg-brand text-surface-0 rounded font-medium hover:bg-brand-strong disabled:opacity-50"
+                >
+                  {codesDownloaded ? 'Continue' : 'Download codes first'}
+                </button>
+              </>
+            )}
+          </div>
+        )}
+
+        {/* Step: Complete */}
+        {step === 'done' && (
+          <div className="space-y-4 text-center">
+            <div className="text-4xl">&#10003;</div>
+            <p className="text-sm text-text-secondary">
+              Your account is secured. You're ready to go!
+            </p>
+            <button
+              onClick={handleComplete}
+              disabled={isSubmitting}
+              className="w-full py-2 px-4 bg-brand text-surface-0 rounded font-medium hover:bg-brand-strong disabled:opacity-50"
+            >
+              {isSubmitting ? 'Finishing...' : 'Go to dashboard'}
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/web/src/pages/VerifyEmail.tsx
+++ b/web/src/pages/VerifyEmail.tsx
@@ -1,13 +1,17 @@
 import { useEffect, useState } from 'react'
 import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import { api, APIError } from '../api/client'
+import { useAuth } from '../hooks/useAuth'
 
 export default function VerifyEmail() {
   const [searchParams] = useSearchParams()
   const navigate = useNavigate()
+  const { setSession } = useAuth()
   const token = searchParams.get('token') ?? ''
   const [error, setError] = useState<string | null>(null)
   const [verifying, setVerifying] = useState(true)
+  const [destination, setDestination] = useState<string | null>(null)
+  const { isAuthenticated } = useAuth()
 
   useEffect(() => {
     if (!token) {
@@ -21,7 +25,8 @@ export default function VerifyEmail() {
       try {
         const result = await api.auth.verifyEmail(token)
         if (!cancelled) {
-          navigate('/setup-auth', { state: { setup_token: result.setup_token }, replace: true })
+          setSession(result.access_token, result.refresh_token, result.user)
+          setDestination('/onboarding')
         }
       } catch (err) {
         if (!cancelled) {
@@ -36,7 +41,11 @@ export default function VerifyEmail() {
     }
     verify()
     return () => { cancelled = true }
-  }, [token, navigate])
+  }, [token, setSession])
+
+  useEffect(() => {
+    if (destination && isAuthenticated) navigate(destination, { replace: true })
+  }, [destination, isAuthenticated, navigate])
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-surface-0">


### PR DESCRIPTION
## Summary
- Add Google OAuth login/register with redirect-based authorization code flow
- Add unified MFA verification page supporting passkey, TOTP, and backup code methods
- Add security setup onboarding page (passkey/TOTP registration + backup code download)
- Add onboarding gate in `RequireAuth` that redirects unonboarded users to `/onboarding`
- Rewrite registration to always collect password upfront and navigate to email verification
- Update API client types for unified `requires_mfa` response format across password and Google login

## Test plan
- [ ] Register with email/password → verify email → onboarding security setup → dashboard
- [ ] Register with Google OAuth → onboarding security setup → dashboard
- [ ] Login with password + TOTP MFA
- [ ] Login with password + passkey MFA
- [ ] Login with password + backup code MFA
- [ ] Login with Google OAuth + MFA verification
- [ ] Verify onboarding gate redirects unonboarded users to `/onboarding`

🤖 Generated with [Claude Code](https://claude.com/claude-code)