### PR TITLE
feat: opt-in auto-update for self-hosted deployments

### DIFF
--- a/cmd/clawvisor/cmd_auto_update.go
+++ b/cmd/clawvisor/cmd_auto_update.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/clawvisor/clawvisor/internal/daemon"
+)
+
+var autoUpdateCmd = &cobra.Command{
+	Use:   "auto-update",
+	Short: "Manage automatic binary updates",
+	Long:  "Enable, disable, or check the status of automatic binary updates.\nWhen enabled, Clawvisor periodically checks GitHub for new releases\nand applies them automatically.",
+}
+
+var autoUpdateEnableCmd = &cobra.Command{
+	Use:   "enable",
+	Short: "Enable automatic updates",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := daemon.SetAutoUpdate(true); err != nil {
+			return err
+		}
+		fmt.Println("  Auto-update enabled. Restart the daemon for changes to take effect.")
+		return nil
+	},
+}
+
+var autoUpdateDisableCmd = &cobra.Command{
+	Use:   "disable",
+	Short: "Disable automatic updates",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := daemon.SetAutoUpdate(false); err != nil {
+			return err
+		}
+		fmt.Println("  Auto-update disabled.")
+		return nil
+	},
+}
+
+var autoUpdateStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show auto-update configuration",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		enabled, interval, err := daemon.AutoUpdateStatus()
+		if err != nil {
+			return err
+		}
+		if enabled {
+			fmt.Printf("  Auto-update: enabled (check interval: %s)\n", interval)
+		} else {
+			fmt.Println("  Auto-update: disabled")
+			fmt.Println("  Run `clawvisor auto-update enable` to opt in.")
+		}
+		return nil
+	},
+}
+
+func init() {
+	autoUpdateCmd.AddCommand(autoUpdateEnableCmd)
+	autoUpdateCmd.AddCommand(autoUpdateDisableCmd)
+	autoUpdateCmd.AddCommand(autoUpdateStatusCmd)
+}

--- a/cmd/clawvisor/cmd_update.go
+++ b/cmd/clawvisor/cmd_update.go
@@ -1,16 +1,8 @@
 package main
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
-	"io"
-	"net/http"
-	"os"
-	"path/filepath"
-	"runtime"
 	"strings"
-	"time"
 
 	"github.com/spf13/cobra"
 
@@ -32,10 +24,9 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	pinned, _ := cmd.Flags().GetString("version")
 
 	// Determine target version.
-	var targetVersion, tag string
+	var targetVersion string
 	if pinned != "" {
 		targetVersion = strings.TrimPrefix(pinned, "v")
-		tag = "v" + targetVersion
 	} else {
 		fmt.Println("  Checking for updates...")
 		info := version.Check()
@@ -47,73 +38,17 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 			return nil
 		}
 		targetVersion = info.Latest
-		tag = "v" + targetVersion
 	}
 
 	current := version.GetCurrent()
 	fmt.Printf("  Updating v%s → v%s\n", current, targetVersion)
 
-	// Build asset name and download URL.
-	assetName := fmt.Sprintf("clawvisor-%s-%s", runtime.GOOS, runtime.GOARCH)
-	baseURL := fmt.Sprintf("https://github.com/clawvisor/clawvisor/releases/download/%s", tag)
-	binaryURL := baseURL + "/" + assetName
-	checksumsURL := baseURL + "/checksums.txt"
-
-	client := &http.Client{Timeout: 2 * time.Minute}
-
-	// Download checksums.
-	fmt.Println("  Downloading checksums...")
-	checksumsBody, err := httpGet(client, checksumsURL)
-	if err != nil {
-		return fmt.Errorf("downloading checksums: %w", err)
-	}
-	expectedHash, err := findChecksum(string(checksumsBody), assetName)
+	oldVer, newVer, err := version.Apply(targetVersion)
 	if err != nil {
 		return err
 	}
 
-	// Download binary to temp file.
-	fmt.Println("  Downloading binary...")
-	tmpDir, err := os.MkdirTemp("", "clawvisor-update-*")
-	if err != nil {
-		return fmt.Errorf("creating temp dir: %w", err)
-	}
-	defer os.RemoveAll(tmpDir)
-
-	tmpBinary := filepath.Join(tmpDir, assetName)
-	if err := httpDownload(client, binaryURL, tmpBinary); err != nil {
-		return fmt.Errorf("downloading binary: %w", err)
-	}
-
-	// Verify checksum.
-	fmt.Println("  Verifying checksum...")
-	actualHash, err := sha256File(tmpBinary)
-	if err != nil {
-		return fmt.Errorf("computing checksum: %w", err)
-	}
-	if actualHash != expectedHash {
-		return fmt.Errorf("checksum mismatch:\n  expected: %s\n  got:      %s", expectedHash, actualHash)
-	}
-
-	// Make executable and atomic-replace the current binary.
-	if err := os.Chmod(tmpBinary, 0755); err != nil {
-		return fmt.Errorf("chmod: %w", err)
-	}
-
-	exe, err := os.Executable()
-	if err != nil {
-		return fmt.Errorf("resolving current binary: %w", err)
-	}
-	exe, err = filepath.EvalSymlinks(exe)
-	if err != nil {
-		return fmt.Errorf("resolving symlinks: %w", err)
-	}
-
-	if err := os.Rename(tmpBinary, exe); err != nil {
-		return fmt.Errorf("replacing binary: %w", err)
-	}
-
-	fmt.Printf("  Updated successfully: v%s → v%s\n", current, targetVersion)
+	fmt.Printf("  Updated successfully: v%s → v%s\n", oldVer, newVer)
 
 	// Restart daemon automatically if it was running.
 	if s, err := daemon.CheckStatus(); err == nil && s.Running {
@@ -128,65 +63,4 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
-}
-
-func httpGet(client *http.Client, url string) ([]byte, error) {
-	resp, err := client.Get(url)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("HTTP %d from %s", resp.StatusCode, url)
-	}
-	return io.ReadAll(resp.Body)
-}
-
-func httpDownload(client *http.Client, url, dest string) error {
-	resp, err := client.Get(url)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("HTTP %d from %s", resp.StatusCode, url)
-	}
-
-	f, err := os.Create(dest)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	_, err = io.Copy(f, resp.Body)
-	return err
-}
-
-func sha256File(path string) (string, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return "", err
-	}
-	defer f.Close()
-
-	h := sha256.New()
-	if _, err := io.Copy(h, f); err != nil {
-		return "", err
-	}
-	return hex.EncodeToString(h.Sum(nil)), nil
-}
-
-func findChecksum(checksums, assetName string) (string, error) {
-	for _, line := range strings.Split(checksums, "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		// Format: "<hash>  <filename>" or "<hash> <filename>"
-		parts := strings.Fields(line)
-		if len(parts) == 2 && parts[1] == assetName {
-			return parts[0], nil
-		}
-	}
-	return "", fmt.Errorf("no checksum found for %s in checksums.txt", assetName)
 }

--- a/cmd/clawvisor/main.go
+++ b/cmd/clawvisor/main.go
@@ -28,6 +28,7 @@ func init() {
 	rootCmd.AddCommand(installCmd)
 	rootCmd.AddCommand(uninstallCmd)
 	rootCmd.AddCommand(updateCmd)
+	rootCmd.AddCommand(autoUpdateCmd)
 	rootCmd.AddCommand(healthcheckCmd)
 	rootCmd.AddCommand(agentCmd)
 	rootCmd.AddCommand(servicesCmd)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -102,6 +102,13 @@ llm:
     # model: claude-haiku-4-5-20251001
     # timeout_seconds: 10
 
+auto_update:
+  enabled: false           # opt-in automatic binary updates. Env: CLAWVISOR_AUTO_UPDATE_ENABLED
+                           # when enabled, Clawvisor periodically checks GitHub for new releases,
+                           # downloads and verifies the binary, and restarts the server automatically.
+                           # only takes effect for self-hosted (non-multi-tenant) deployments.
+  check_interval: "6h"    # how often to check for updates. Env: CLAWVISOR_AUTO_UPDATE_CHECK_INTERVAL
+
 telemetry:
   enabled: false           # opt-in anonymous usage telemetry. Env: CLAWVISOR_TELEMETRY_ENABLED
                            # sends: OS, arch, db driver, agent count (bucketed), requests per service (bucketed)

--- a/internal/daemon/auto_update.go
+++ b/internal/daemon/auto_update.go
@@ -1,0 +1,93 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// AutoUpdateStatus reads config.yaml and returns the auto-update settings.
+func AutoUpdateStatus() (enabled bool, checkInterval string, err error) {
+	dataDir, err := ensureDataDir()
+	if err != nil {
+		return false, "", err
+	}
+
+	cfgPath := filepath.Join(dataDir, "config.yaml")
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		return false, "", fmt.Errorf("reading config: %w", err)
+	}
+
+	var raw map[string]interface{}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return false, "", fmt.Errorf("parsing config: %w", err)
+	}
+
+	au, ok := raw["auto_update"].(map[string]interface{})
+	if !ok {
+		return false, "6h", nil
+	}
+	if e, ok := au["enabled"].(bool); ok {
+		enabled = e
+	}
+	interval := "6h"
+	if ci, ok := au["check_interval"].(string); ok && ci != "" {
+		interval = ci
+	}
+	return enabled, interval, nil
+}
+
+// SetAutoUpdate patches config.yaml to enable or disable auto-update.
+// Uses line-level editing to avoid corrupting other values via YAML round-trip.
+func SetAutoUpdate(enable bool) error {
+	dataDir, err := ensureDataDir()
+	if err != nil {
+		return err
+	}
+
+	cfgPath := filepath.Join(dataDir, "config.yaml")
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		return fmt.Errorf("reading config: %w", err)
+	}
+
+	content := string(data)
+	enabledLine := fmt.Sprintf("  enabled: %t", enable)
+
+	if strings.Contains(content, "auto_update:") {
+		// Section exists — find and replace the enabled line.
+		lines := strings.Split(content, "\n")
+		inSection := false
+		replaced := false
+		for i, line := range lines {
+			trimmed := strings.TrimSpace(line)
+			// Detect section headers (top-level keys with no indentation).
+			if len(line) > 0 && line[0] != ' ' && line[0] != '#' && strings.HasSuffix(trimmed, ":") {
+				inSection = trimmed == "auto_update:"
+			}
+			if inSection && strings.HasPrefix(trimmed, "enabled:") {
+				lines[i] = enabledLine
+				replaced = true
+				break
+			}
+		}
+		if !replaced {
+			// Section exists but no enabled key — insert after the header.
+			content = strings.Replace(content, "auto_update:\n", "auto_update:\n"+enabledLine+"\n", 1)
+		} else {
+			content = strings.Join(lines, "\n")
+		}
+	} else {
+		// No auto_update section — append one.
+		if !strings.HasSuffix(content, "\n") {
+			content += "\n"
+		}
+		content += "\nauto_update:\n" + enabledLine + "\n  check_interval: \"6h\"\n"
+	}
+
+	return os.WriteFile(cfgPath, []byte(content), 0600)
+}

--- a/internal/daemon/auto_update.go
+++ b/internal/daemon/auto_update.go
@@ -66,8 +66,9 @@ func SetAutoUpdate(enable bool) error {
 		for i, line := range lines {
 			trimmed := strings.TrimSpace(line)
 			// Detect section headers (top-level keys with no indentation).
-			if len(line) > 0 && line[0] != ' ' && line[0] != '#' && strings.HasSuffix(trimmed, ":") {
-				inSection = trimmed == "auto_update:"
+			// Use HasPrefix to handle trailing comments like "auto_update:  # note".
+			if len(line) > 0 && line[0] != ' ' && line[0] != '#' && strings.Contains(trimmed, ":") {
+				inSection = strings.HasPrefix(trimmed, "auto_update:")
 			}
 			if inSection && strings.HasPrefix(trimmed, "enabled:") {
 				lines[i] = enabledLine
@@ -76,11 +77,15 @@ func SetAutoUpdate(enable bool) error {
 			}
 		}
 		if !replaced {
-			// Section exists but no enabled key — insert after the header.
-			content = strings.Replace(content, "auto_update:\n", "auto_update:\n"+enabledLine+"\n", 1)
-		} else {
-			content = strings.Join(lines, "\n")
+			// Section exists but no enabled key — insert after the header line.
+			for i, line := range lines {
+				if strings.HasPrefix(strings.TrimSpace(line), "auto_update:") {
+					lines = append(lines[:i+1], append([]string{enabledLine}, lines[i+1:]...)...)
+					break
+				}
+			}
 		}
+		content = strings.Join(lines, "\n")
 	} else {
 		// No auto_update section — append one.
 		if !strings.HasSuffix(content, "\n") {

--- a/internal/server/run.go
+++ b/internal/server/run.go
@@ -18,6 +18,7 @@ import (
 	"github.com/clawvisor/clawvisor/internal/telemetry"
 	"github.com/clawvisor/clawvisor/pkg/clawvisor"
 	"github.com/clawvisor/clawvisor/pkg/config"
+	"github.com/clawvisor/clawvisor/pkg/version"
 )
 
 // RunOptions holds optional flags for the server entrypoint.
@@ -136,6 +137,18 @@ func Run(logger *slog.Logger, ropts RunOptions) error {
 
 	if ropts.OpenBrowser && authResult.MagicURL != "" {
 		browser.Open(authResult.MagicURL)
+	}
+
+	// ── Auto-update (self-hosted opt-in) ─────────────────────────────────
+	autoUpdateActive := opts.Config.AutoUpdate.Enabled && !opts.Features.MultiTenant
+	version.SetAutoUpdate(autoUpdateActive)
+	if autoUpdateActive {
+		interval, err := opts.Config.AutoUpdate.CheckIntervalDuration()
+		if err != nil {
+			logger.Warn("auto-update: invalid check_interval, using default 6h", "err", err)
+			interval = 6 * time.Hour
+		}
+		version.StartAutoUpdater(context.Background(), interval, logger)
 	}
 
 	// ── Telemetry ──────────────────────────────────────────────────────────

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,8 +34,9 @@ type Config struct {
 	Relay     RelayConfig     `yaml:"relay"`
 	Telemetry TelemetryConfig `yaml:"telemetry"`
 	Daemon    DaemonConfig    `yaml:"daemon"`
-	Push      PushConfig      `yaml:"push"`
-	Redis     RedisConfig     `yaml:"redis"`
+	Push       PushConfig       `yaml:"push"`
+	AutoUpdate AutoUpdateConfig `yaml:"auto_update"`
+	Redis      RedisConfig      `yaml:"redis"`
 
 	AutoConfig AutoConfigured `yaml:"-"`
 }
@@ -66,6 +67,21 @@ type DaemonConfig struct {
 type PushConfig struct {
 	Enabled bool   `yaml:"enabled"`
 	URL     string `yaml:"url"`
+}
+
+// AutoUpdateConfig holds settings for automatic binary updates.
+// Disabled by default — self-hosted users must opt in.
+type AutoUpdateConfig struct {
+	Enabled       bool   `yaml:"enabled"`        // default: false (explicit opt-in)
+	CheckInterval string `yaml:"check_interval"` // default: "6h"
+}
+
+// CheckIntervalDuration parses the configured check interval.
+func (a AutoUpdateConfig) CheckIntervalDuration() (time.Duration, error) {
+	if a.CheckInterval == "" {
+		return 6 * time.Hour, nil
+	}
+	return time.ParseDuration(a.CheckInterval)
 }
 
 // RedisConfig holds settings for Redis (used in cloud/multi-instance deployments).
@@ -277,6 +293,10 @@ func Default() *Config {
 		Push: PushConfig{
 			URL: version.PushURL(),
 		},
+		AutoUpdate: AutoUpdateConfig{
+			Enabled:       false,
+			CheckInterval: "6h",
+		},
 	}
 }
 
@@ -474,6 +494,13 @@ func Load(path string) (*Config, error) {
 
 	if v := os.Getenv("REDIS_URL"); v != "" {
 		cfg.Redis.URL = v
+	}
+
+	if v := os.Getenv("CLAWVISOR_AUTO_UPDATE_ENABLED"); v != "" {
+		cfg.AutoUpdate.Enabled = v == "true" || v == "1"
+	}
+	if v := os.Getenv("CLAWVISOR_AUTO_UPDATE_CHECK_INTERVAL"); v != "" {
+		cfg.AutoUpdate.CheckInterval = v
 	}
 
 	if v := os.Getenv("CLAWVISOR_DAEMON_DATA_DIR"); v != "" {

--- a/pkg/version/autoupdate.go
+++ b/pkg/version/autoupdate.go
@@ -15,7 +15,7 @@ import (
 //
 // The goroutine exits when ctx is cancelled. It is a no-op for dev builds.
 func StartAutoUpdater(ctx context.Context, interval time.Duration, logger *slog.Logger) {
-	if Version == "dev" || Version == "" {
+	if v := GetCurrent(); v == "dev" || v == "" {
 		logger.Debug("auto-update: skipping for dev build")
 		return
 	}
@@ -73,10 +73,10 @@ func checkAndApply(logger *slog.Logger) bool {
 	logger.Info("auto-update: binary replaced, restarting",
 		"old_version", oldVer, "new_version", newVer)
 
-	// Update the in-memory version so any Check() calls between now and
-	// process exit don't consider this version "newer" again.
-	Version = newVer
+	// Update the in-memory version under the cache lock so any concurrent
+	// Check() / GetCurrent() calls see the new value without a data race.
 	cacheMu.Lock()
+	Version = newVer
 	cachedInfo = nil
 	cacheMu.Unlock()
 

--- a/pkg/version/autoupdate.go
+++ b/pkg/version/autoupdate.go
@@ -1,0 +1,93 @@
+package version
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"syscall"
+	"time"
+)
+
+// StartAutoUpdater runs a background goroutine that periodically checks for
+// new releases and applies them. After a successful update, the process is
+// gracefully restarted by sending itself SIGTERM (which the server's signal
+// handler catches for graceful shutdown) followed by an exec of the new binary.
+//
+// The goroutine exits when ctx is cancelled. It is a no-op for dev builds.
+func StartAutoUpdater(ctx context.Context, interval time.Duration, logger *slog.Logger) {
+	if Version == "dev" || Version == "" {
+		logger.Debug("auto-update: skipping for dev build")
+		return
+	}
+
+	logger.Info("auto-update: enabled", "check_interval", interval)
+
+	go func() {
+		// Stagger the first check so it doesn't fire immediately on startup.
+		firstCheck := interval
+		if firstCheck > 5*time.Minute {
+			firstCheck = 5 * time.Minute
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(firstCheck):
+		}
+
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		for {
+			if applied := checkAndApply(logger); applied {
+				return // Binary replaced, SIGTERM sent — stop the goroutine.
+			}
+
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
+		}
+	}()
+}
+
+// checkAndApply checks for a newer version and applies it. Returns true if
+// an update was successfully applied and SIGTERM was sent.
+func checkAndApply(logger *slog.Logger) bool {
+	info := Check()
+	if !info.UpdateAvail || info.Latest == "" {
+		logger.Debug("auto-update: no update available", "current", info.Current, "latest", info.Latest)
+		return false
+	}
+
+	logger.Info("auto-update: new version available, applying",
+		"current", info.Current, "target", info.Latest)
+
+	oldVer, newVer, err := Apply(info.Latest)
+	if err != nil {
+		logger.Error("auto-update: failed to apply update", "error", err)
+		return false
+	}
+
+	logger.Info("auto-update: binary replaced, restarting",
+		"old_version", oldVer, "new_version", newVer)
+
+	// Update the in-memory version so any Check() calls between now and
+	// process exit don't consider this version "newer" again.
+	Version = newVer
+	cacheMu.Lock()
+	cachedInfo = nil
+	cacheMu.Unlock()
+
+	// Send SIGTERM to self for graceful shutdown. The process manager
+	// (systemd, Docker, etc.) will restart with the new binary.
+	//
+	// We send SIGTERM rather than calling os.Exit directly so the server's
+	// existing signal handler can drain connections gracefully.
+	p, err := os.FindProcess(os.Getpid())
+	if err == nil {
+		_ = p.Signal(syscall.SIGTERM)
+	}
+	return true
+}

--- a/pkg/version/update.go
+++ b/pkg/version/update.go
@@ -1,0 +1,141 @@
+package version
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// Apply downloads the target version, verifies its checksum, and atomically
+// replaces the current binary. It returns the old and new version strings.
+// The caller is responsible for any restart logic (daemon restart, process re-exec, etc.).
+func Apply(targetVersion string) (oldVersion, newVersion string, err error) {
+	oldVersion = Version
+	newVersion = strings.TrimPrefix(targetVersion, "v")
+	tag := "v" + newVersion
+
+	assetName := fmt.Sprintf("clawvisor-%s-%s", runtime.GOOS, runtime.GOARCH)
+	baseURL := fmt.Sprintf("https://github.com/clawvisor/clawvisor/releases/download/%s", tag)
+	binaryURL := baseURL + "/" + assetName
+	checksumsURL := baseURL + "/checksums.txt"
+
+	client := &http.Client{Timeout: 2 * time.Minute}
+
+	// Download checksums.
+	checksumsBody, err := httpGet(client, checksumsURL)
+	if err != nil {
+		return oldVersion, newVersion, fmt.Errorf("downloading checksums: %w", err)
+	}
+	expectedHash, err := findChecksum(string(checksumsBody), assetName)
+	if err != nil {
+		return oldVersion, newVersion, err
+	}
+
+	// Download binary to temp file.
+	tmpDir, err := os.MkdirTemp("", "clawvisor-update-*")
+	if err != nil {
+		return oldVersion, newVersion, fmt.Errorf("creating temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	tmpBinary := filepath.Join(tmpDir, assetName)
+	if err := httpDownload(client, binaryURL, tmpBinary); err != nil {
+		return oldVersion, newVersion, fmt.Errorf("downloading binary: %w", err)
+	}
+
+	// Verify checksum.
+	actualHash, err := sha256File(tmpBinary)
+	if err != nil {
+		return oldVersion, newVersion, fmt.Errorf("computing checksum: %w", err)
+	}
+	if actualHash != expectedHash {
+		return oldVersion, newVersion, fmt.Errorf("checksum mismatch: expected %s, got %s", expectedHash, actualHash)
+	}
+
+	// Make executable and atomic-replace the current binary.
+	if err := os.Chmod(tmpBinary, 0755); err != nil {
+		return oldVersion, newVersion, fmt.Errorf("chmod: %w", err)
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		return oldVersion, newVersion, fmt.Errorf("resolving current binary: %w", err)
+	}
+	exe, err = filepath.EvalSymlinks(exe)
+	if err != nil {
+		return oldVersion, newVersion, fmt.Errorf("resolving symlinks: %w", err)
+	}
+
+	if err := os.Rename(tmpBinary, exe); err != nil {
+		return oldVersion, newVersion, fmt.Errorf("replacing binary: %w", err)
+	}
+
+	return oldVersion, newVersion, nil
+}
+
+func httpGet(client *http.Client, url string) ([]byte, error) {
+	resp, err := client.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d from %s", resp.StatusCode, url)
+	}
+	return io.ReadAll(resp.Body)
+}
+
+func httpDownload(client *http.Client, url, dest string) error {
+	resp, err := client.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("HTTP %d from %s", resp.StatusCode, url)
+	}
+
+	f, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = io.Copy(f, resp.Body)
+	return err
+}
+
+func sha256File(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func findChecksum(checksums, assetName string) (string, error) {
+	for _, line := range strings.Split(checksums, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) == 2 && parts[1] == assetName {
+			return parts[0], nil
+		}
+	}
+	return "", fmt.Errorf("no checksum found for %s in checksums.txt", assetName)
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -116,7 +116,10 @@ func Check() *Info {
 
 // GetCurrent returns the current version without checking for updates.
 func GetCurrent() string {
-	return Version
+	cacheMu.Lock()
+	v := Version
+	cacheMu.Unlock()
+	return v
 }
 
 // fetchLatestRelease queries the GitHub API for the latest release tag.

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -69,13 +69,23 @@ type Info struct {
 	UpdateAvail   bool   `json:"update_available"`
 	ReleaseURL    string `json:"release_url,omitempty"`
 	UpgradeCmd    string `json:"upgrade_command,omitempty"`
+	AutoUpdate    bool   `json:"auto_update"`
 }
 
 var (
-	cacheMu     sync.Mutex
-	cachedInfo  *Info
-	cachedAt    time.Time
+	cacheMu        sync.Mutex
+	cachedInfo     *Info
+	cachedAt       time.Time
+	autoUpdateFlag bool
 )
+
+// SetAutoUpdate records whether auto-update is enabled so Check() can
+// include this in the Info response.
+func SetAutoUpdate(enabled bool) {
+	cacheMu.Lock()
+	autoUpdateFlag = enabled
+	cacheMu.Unlock()
+}
 
 // Check returns version info, fetching latest from GitHub if cache is stale.
 func Check() *Info {
@@ -89,6 +99,7 @@ func Check() *Info {
 	info := &Info{
 		Current:    Version,
 		UpgradeCmd: "go install github.com/clawvisor/clawvisor/cmd/clawvisor@latest",
+		AutoUpdate: autoUpdateFlag,
 	}
 
 	latest, url, err := fetchLatestRelease()

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -446,6 +446,7 @@ export interface VersionInfo {
   update_available: boolean
   release_url?: string
   upgrade_command?: string
+  auto_update: boolean
 }
 
 export interface LLMUsage {

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -189,9 +189,15 @@ export default function Dashboard() {
               {versionData.current && <span className="text-text-secondary"> (current: v{versionData.current})</span>}
             </span>
             <span className="flex items-center gap-3">
-              <span className="text-text-secondary">
-                Run <code className="text-xs bg-surface-2 px-2 py-1 rounded font-mono">clawvisor update</code> to get the latest version
-              </span>
+              {versionData.auto_update ? (
+                <span className="text-text-secondary">
+                  Auto-update is enabled — this update will be applied automatically
+                </span>
+              ) : (
+                <span className="text-text-secondary">
+                  Run <code className="text-xs bg-surface-2 px-2 py-1 rounded font-mono">clawvisor update</code> to get the latest version
+                </span>
+              )}
               {versionData.release_url && (
                 <a
                   href={versionData.release_url}


### PR DESCRIPTION
## Summary
- Adds a background auto-updater that self-hosted users can opt into via `auto_update.enabled: true` in config or `CLAWVISOR_AUTO_UPDATE_ENABLED=true` env var. Periodically checks GitHub for new releases, downloads/verifies the binary, replaces it atomically, and sends SIGTERM for graceful restart.
- Adds `clawvisor auto-update {enable,disable,status}` CLI commands that patch `~/.clawvisor/config.yaml` using line-level editing.
- Extracts shared download/verify/replace logic from `cmd_update.go` into `pkg/version/update.go` so both the manual CLI and background updater reuse it.
- Updates the `/api/version` response and dashboard banner to reflect auto-update status.
- Auto-update is disabled by default, skipped for dev builds and multi-tenant deployments.

## Test plan
- [ ] Verify `clawvisor auto-update enable` patches config.yaml correctly
- [ ] Verify `clawvisor auto-update status` reads back the setting
- [ ] Verify `clawvisor auto-update disable` reverts it
- [ ] Verify auto-updater starts on daemon boot when enabled (check logs for "auto-update: enabled")
- [ ] Verify auto-updater does not start for multi-tenant or dev builds
- [ ] Verify `/api/version` includes `auto_update: true` when enabled
- [ ] Verify dashboard banner shows auto-update messaging when enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)