### PR TITLE
feat: add backup gateway_request_log table for audit durability

### DIFF
--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -166,8 +166,32 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 
 	auditID := uuid.New().String()
 
+	// Backup log: append-only record of every gateway request. Written after
+	// the response so it captures the outcome. If the primary audit insert is
+	// ever silently dropped, this table retains full visibility.
+	var outDecision, outOutcome string
+	defer func() {
+		if logErr := h.store.LogGatewayRequest(context.Background(), &store.GatewayRequestLog{
+			AuditID:    auditID,
+			RequestID:  req.RequestID,
+			AgentID:    agent.ID,
+			UserID:     agent.UserID,
+			Service:    req.Service,
+			Action:     req.Action,
+			TaskID:     req.TaskID,
+			Reason:     req.Reason,
+			Decision:   outDecision,
+			Outcome:    outOutcome,
+			DurationMS: int(time.Since(start).Milliseconds()),
+		}); logErr != nil {
+			h.logger.Warn("backup request log failed", "err", logErr)
+		}
+	}()
+
 	// baseEntry builds an AuditEntry with fields common to all outcomes.
+	// It also records the decision/outcome for the deferred backup log.
 	baseEntry := func(decision, outcome string, taskID *string) *store.AuditEntry {
+		outDecision, outOutcome = decision, outcome
 		return &store.AuditEntry{
 			ID:         auditID,
 			UserID:     agent.UserID,
@@ -237,6 +261,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 
 	// ── Step 2: Task ID required ─────────────────────────────────────────────
 	if req.TaskID == "" {
+		outDecision, outOutcome = "reject", "validation_error"
 		writeError(w, http.StatusBadRequest, "TASK_REQUIRED",
 			"task_id is required; create a task first via POST /api/tasks")
 		return
@@ -251,14 +276,17 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 	{
 		task, taskErr := h.store.GetTask(ctx, req.TaskID)
 		if taskErr != nil {
+			outDecision, outOutcome = "reject", "validation_error"
 			writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "task not found")
 			return
 		}
 		if task.UserID != agent.UserID {
+			outDecision, outOutcome = "reject", "forbidden"
 			writeError(w, http.StatusForbidden, "FORBIDDEN", "task does not belong to this agent's user")
 			return
 		}
 		if task.ExpiresAt != nil && time.Now().After(*task.ExpiresAt) {
+			outDecision, outOutcome = "reject", "task_expired"
 			writeJSON(w, http.StatusOK, map[string]any{
 				"status":  "task_expired",
 				"task_id": req.TaskID,
@@ -267,6 +295,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if task.Status != "active" {
+			outDecision, outOutcome = "reject", "invalid_state"
 			writeError(w, http.StatusConflict, "INVALID_STATE",
 				fmt.Sprintf("task is %s, not active", task.Status))
 			return

--- a/internal/store/postgres/migrations/026_request_log.sql
+++ b/internal/store/postgres/migrations/026_request_log.sql
@@ -1,0 +1,17 @@
+CREATE TABLE gateway_request_log (
+    id          BIGSERIAL PRIMARY KEY,
+    audit_id    TEXT NOT NULL,
+    request_id  TEXT NOT NULL,
+    agent_id    TEXT NOT NULL,
+    user_id     TEXT NOT NULL,
+    service     TEXT NOT NULL,
+    action      TEXT NOT NULL,
+    task_id     TEXT NOT NULL DEFAULT '',
+    reason      TEXT NOT NULL DEFAULT '',
+    decision    TEXT NOT NULL DEFAULT '',
+    outcome     TEXT NOT NULL DEFAULT '',
+    duration_ms INTEGER NOT NULL DEFAULT 0,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_request_log_user_time ON gateway_request_log(user_id, created_at DESC);
+CREATE INDEX idx_request_log_audit_id  ON gateway_request_log(audit_id);

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -532,6 +532,19 @@ func (s *Store) DeleteNotificationConfig(ctx context.Context, userID, channel st
 	return nil
 }
 
+// ── Gateway Request Log (append-only backup) ─────────────────────────────────
+
+func (s *Store) LogGatewayRequest(ctx context.Context, e *store.GatewayRequestLog) error {
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO gateway_request_log (
+			audit_id, request_id, agent_id, user_id, service, action,
+			task_id, reason, decision, outcome, duration_ms
+		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
+	`, e.AuditID, e.RequestID, e.AgentID, e.UserID, e.Service, e.Action,
+		e.TaskID, e.Reason, e.Decision, e.Outcome, e.DurationMS)
+	return err
+}
+
 // ── Audit Log ─────────────────────────────────────────────────────────────────
 
 func (s *Store) LogAudit(ctx context.Context, e *store.AuditEntry) error {

--- a/internal/store/sqlite/migrations/026_request_log.sql
+++ b/internal/store/sqlite/migrations/026_request_log.sql
@@ -1,0 +1,17 @@
+CREATE TABLE gateway_request_log (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    audit_id    TEXT NOT NULL,
+    request_id  TEXT NOT NULL,
+    agent_id    TEXT NOT NULL,
+    user_id     TEXT NOT NULL,
+    service     TEXT NOT NULL,
+    action      TEXT NOT NULL,
+    task_id     TEXT NOT NULL DEFAULT '',
+    reason      TEXT NOT NULL DEFAULT '',
+    decision    TEXT NOT NULL DEFAULT '',
+    outcome     TEXT NOT NULL DEFAULT '',
+    duration_ms INTEGER NOT NULL DEFAULT 0,
+    created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX idx_request_log_user_time ON gateway_request_log(user_id, created_at DESC);
+CREATE INDEX idx_request_log_audit_id  ON gateway_request_log(audit_id);

--- a/internal/store/sqlite/store.go
+++ b/internal/store/sqlite/store.go
@@ -593,6 +593,19 @@ func (s *Store) DeleteNotificationConfig(ctx context.Context, userID, channel st
 	return nil
 }
 
+// ── Gateway Request Log (append-only backup) ─────────────────────────────────
+
+func (s *Store) LogGatewayRequest(ctx context.Context, e *store.GatewayRequestLog) error {
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO gateway_request_log (
+			audit_id, request_id, agent_id, user_id, service, action,
+			task_id, reason, decision, outcome, duration_ms
+		) VALUES (?,?,?,?,?,?,?,?,?,?,?)
+	`, e.AuditID, e.RequestID, e.AgentID, e.UserID, e.Service, e.Action,
+		e.TaskID, e.Reason, e.Decision, e.Outcome, e.DurationMS)
+	return err
+}
+
 // ── Audit Log ─────────────────────────────────────────────────────────────────
 
 func (s *Store) LogAudit(ctx context.Context, e *store.AuditEntry) error {
@@ -618,12 +631,13 @@ func (s *Store) LogAudit(ctx context.Context, e *store.AuditEntry) error {
 		safetyFlagged = 1
 	}
 	_, err := s.db.ExecContext(ctx, `
-		INSERT OR IGNORE INTO audit_log (
+		INSERT INTO audit_log (
 			id, user_id, agent_id, request_id, task_id, timestamp, service, action,
 			params_safe, decision, outcome, policy_id, rule_id,
 			safety_flagged, safety_reason, reason, data_origin, context_src,
 			duration_ms, filters_applied, verification, error_msg
 		) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+		ON CONFLICT (request_id) DO NOTHING
 	`, e.ID, e.UserID, e.AgentID, e.RequestID, e.TaskID, e.Timestamp.UTC().Format(time.RFC3339),
 		e.Service, e.Action, paramsSafe, e.Decision, e.Outcome,
 		e.PolicyID, e.RuleID, safetyFlagged, e.SafetyReason, e.Reason,

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -70,6 +70,9 @@ type Store interface {
 	DeleteNotificationConfig(ctx context.Context, userID, channel string) error
 	ListNotificationConfigsByChannel(ctx context.Context, channel string) ([]NotificationConfig, error)
 
+	// Gateway request log (append-only backup)
+	LogGatewayRequest(ctx context.Context, entry *GatewayRequestLog) error
+
 	// Audit log
 	LogAudit(ctx context.Context, entry *AuditEntry) error
 	UpdateAuditOutcome(ctx context.Context, id, outcome, errMsg string, durationMS int) error
@@ -232,6 +235,23 @@ type NotificationConfig struct {
 	Config    json.RawMessage `json:"config"`
 	CreatedAt time.Time       `json:"created_at"`
 	UpdatedAt time.Time       `json:"updated_at"`
+}
+
+// GatewayRequestLog is an append-only backup record of every gateway request.
+// Written before the primary audit insert so we retain visibility even if that
+// insert is silently dropped.
+type GatewayRequestLog struct {
+	AuditID    string
+	RequestID  string
+	AgentID    string
+	UserID     string
+	Service    string
+	Action     string
+	TaskID     string
+	Reason     string
+	Decision   string
+	Outcome    string
+	DurationMS int
 }
 
 // AuditEntry is one row in the audit_log table.


### PR DESCRIPTION
## Summary

Adds an append-only `gateway_request_log` table (migration 026) for both Postgres and SQLite as a backup audit trail. Every gateway request is logged via a deferred write in `HandleRequest`, capturing audit ID, request metadata, decision, outcome, and duration — ensuring visibility even if the primary `audit_log` insert is silently dropped. Also makes SQLite audit_log conflict handling explicit with `ON CONFLICT (request_id) DO NOTHING`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)