### PR TITLE
feat: add skill version endpoint and self-update check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null | sed 's/^v//' || echo dev)
 ENVIRONMENT ?= production
-LDFLAGS := -ldflags="-s -w -X github.com/clawvisor/clawvisor/pkg/version.Version=$(VERSION) -X github.com/clawvisor/clawvisor/pkg/version.Environment=$(ENVIRONMENT)"
+BUILD_DATE ?= $(shell date -u +%Y-%m-%d)
+LDFLAGS := -ldflags="-s -w -X github.com/clawvisor/clawvisor/pkg/version.Version=$(VERSION) -X github.com/clawvisor/clawvisor/pkg/version.Environment=$(ENVIRONMENT) -X github.com/clawvisor/clawvisor/pkg/version.SkillPublishedAt=$(BUILD_DATE)"
 
 # ── Build ──────────────────────────────────────────────────────────────────────
 

--- a/internal/api/handlers/health.go
+++ b/internal/api/handlers/health.go
@@ -66,6 +66,14 @@ func (h *HealthHandler) Version(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, version.Check())
 }
 
+// SkillVersion returns the current skill version and publish date (no auth required).
+func (h *HealthHandler) SkillVersion(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]string{
+		"skill_version":      version.Version,
+		"skill_published_at": version.SkillPublishedAt,
+	})
+}
+
 // writeJSON is a shared JSON response helper used across all handlers.
 func writeJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -468,6 +468,7 @@ func (s *Server) routes() http.Handler {
 	mux.HandleFunc("GET /ready", healthHandler.Ready)
 	mux.HandleFunc("GET /api/config/public", healthHandler.ConfigPublic)
 	mux.HandleFunc("GET /api/version", healthHandler.Version)
+	mux.HandleFunc("GET /api/skill/version", healthHandler.SkillVersion)
 
 	// LLM status and runtime config update
 	configPath := os.Getenv("CONFIG_FILE")

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -14,6 +14,10 @@ import (
 // Example: go build -ldflags="-X github.com/clawvisor/clawvisor/pkg/version.Version=0.3.0"
 var Version = "dev"
 
+// SkillPublishedAt is set at build time via -ldflags. It records the date (YYYY-MM-DD)
+// the release was built so the skill can display when it was last updated.
+var SkillPublishedAt = "dev"
+
 // Environment is set at build time via -ldflags. Valid values: "production" (default), "staging".
 // Example: go build -ldflags="-X github.com/clawvisor/clawvisor/pkg/version.Environment=staging"
 var Environment = "production"

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -20,7 +20,8 @@ if [ ! -d "web/dist" ]; then
 fi
 
 MODULE="github.com/clawvisor/clawvisor/pkg/version"
-LDFLAGS="-s -w -X ${MODULE}.Version=${VERSION}"
+BUILD_DATE=$(date -u +%Y-%m-%d)
+LDFLAGS="-s -w -X ${MODULE}.Version=${VERSION} -X ${MODULE}.SkillPublishedAt=${BUILD_DATE}"
 PLATFORMS="darwin/arm64 darwin/amd64 linux/arm64 linux/amd64"
 
 rm -rf dist

--- a/skills/clawvisor/SKILL.md.tmpl
+++ b/skills/clawvisor/SKILL.md.tmpl
@@ -7,7 +7,8 @@ description: >
   Contacts, GitHub, and iMessage (macOS). Clawvisor enforces restrictions,
   manages task scopes, and injects credentials — the agent never handles
   secrets directly.
-version: 0.7.0
+version: {{ .SkillVersion }}
+published_at: {{ .SkillPublishedAt }}
 homepage: https://github.com/clawvisor/clawvisor
 metadata:
   {
@@ -456,6 +457,19 @@ without re-executing.
 
 ---
 {{ end }}
+## Troubleshooting
+
+If something isn't working as expected, check whether you have the latest version of this skill:
+
+1. Fetch `GET {{ if .ClawvisorURL }}{{ .ClawvisorURL }}{{ else }}$CLAWVISOR_URL{{ end }}/api/skill/version` — it returns:
+   ```json
+   { "skill_version": "...", "skill_published_at": "..." }
+   ```
+2. Compare the `skill_version` in the response with the version in this skill's frontmatter (`{{ .SkillVersion }}`, published {{ .SkillPublishedAt }}).
+3. If a newer version is available, re-fetch the skill from `{{ if .ClawvisorURL }}{{ .ClawvisorURL }}{{ else }}$CLAWVISOR_URL{{ end }}/skill/SKILL.md` to get the latest instructions.
+
+---
+
 ## Authorization Model Summary
 
 | Condition | Gateway `status` |

--- a/skills/render.go
+++ b/skills/render.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 	"text/template"
+
+	"github.com/clawvisor/clawvisor/pkg/version"
 )
 
 // Target identifies which rendering variant to produce.
@@ -38,11 +40,13 @@ type RenderOptions struct {
 
 // templateData holds the flags that control conditional rendering.
 type templateData struct {
-	Target       Target
-	UseCurl      bool
-	Condensed    bool
-	ClawvisorURL string // concrete instance URL, empty if unknown
-	ViaRelay     bool   // true when served through the relay
+	Target           Target
+	UseCurl          bool
+	Condensed        bool
+	ClawvisorURL     string // concrete instance URL, empty if unknown
+	ViaRelay         bool   // true when served through the relay
+	SkillVersion     string // current skill version
+	SkillPublishedAt string // date the skill version was published
 }
 
 // dataForTarget returns the template data for the given target.
@@ -93,6 +97,8 @@ func RenderWithOptions(target Target, opts RenderOptions) (string, error) {
 	data := dataForTarget(target)
 	data.ClawvisorURL = opts.ClawvisorURL
 	data.ViaRelay = opts.ViaRelay
+	data.SkillVersion = version.Version
+	data.SkillPublishedAt = version.SkillPublishedAt
 
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, data); err != nil {


### PR DESCRIPTION
## Summary

- Adds `GET /api/skill/version` (no auth) returning `skill_version` and `skill_published_at` so agents can check if their skill is outdated.
- SKILL.md.tmpl frontmatter now uses the build-time app version and publish date instead of a hardcoded version.
- Adds a Troubleshooting section to the skill instructing agents to check `/api/skill/version` and re-fetch the skill if a newer version is available.
- Makefile and `build-release.sh` pass `SkillPublishedAt` via ldflags at build time.

## Test plan

- [ ] `go build ./pkg/version/ ./skills/ ./internal/api/handlers/` compiles cleanly
- [ ] `go test ./internal/api/handlers/` passes
- [ ] `go run ./cmd/render-skill claude-code` renders version/published_at in frontmatter and Troubleshooting section
- [ ] `GET /api/skill/version` returns correct JSON when server is running

🤖 Generated with [Claude Code](https://claude.com/claude-code)