### PR TITLE
fix: data race on Version variable in Apply()

### DIFF
--- a/pkg/version/update.go
+++ b/pkg/version/update.go
@@ -17,7 +17,7 @@ import (
 // replaces the current binary. It returns the old and new version strings.
 // The caller is responsible for any restart logic (daemon restart, process re-exec, etc.).
 func Apply(targetVersion string) (oldVersion, newVersion string, err error) {
-	oldVersion = Version
+	oldVersion = GetCurrent()
 	newVersion = strings.TrimPrefix(targetVersion, "v")
 	tag := "v" + newVersion
 


### PR DESCRIPTION
## Summary

- Fixes a data race in `Apply()` where the package-level `Version` variable was read without holding `cacheMu`, while the auto-updater writes it under the lock.
- Replaces `oldVersion = Version` with `oldVersion = GetCurrent()` to read through the lock-protected accessor.
- Consistent with the prior fix in commit `5b69d9a6` that addressed other data races on the same variable.

## Test plan

- [ ] Run `go test -race ./pkg/version/...` to confirm no race detector warnings
- [ ] Verify `Apply()` still returns the correct old version string