### PR TITLE
feat: rome v2 — iMessage FDA helper, auto-update, Redis stores, onboarding

### DIFF
--- a/internal/adapters/apple/imessage/adapter.go
+++ b/internal/adapters/apple/imessage/adapter.go
@@ -194,11 +194,28 @@ func (a *IMessageAdapter) ensureHelper() error {
 
 	a.helperPath = installed
 
+	// Attempt to open chat.db so macOS registers the helper in the FDA list.
+	// This will fail with a permission error (which is expected), but the
+	// attempt is what causes the helper to appear in System Settings →
+	// Privacy & Security → Full Disk Access.
+	_ = a.runCheckPermissions()
+
 	if path == "" {
 		return fmt.Errorf("imessage helper installed — grant Full Disk Access to %q in System Settings → Privacy & Security → Full Disk Access", helperBinaryName)
 	}
 	// Replaced an existing binary — FDA needs re-granting.
 	return fmt.Errorf("imessage helper updated (protocol version changed) — re-grant Full Disk Access to %q in System Settings → Privacy & Security → Full Disk Access", helperBinaryName)
+}
+
+// runCheckPermissions calls the helper's check_permissions action, which
+// attempts to open chat.db. The result is ignored — the purpose is to trigger
+// macOS to register the binary for the FDA list.
+func (a *IMessageAdapter) runCheckPermissions() error {
+	reqBody, _ := json.Marshal(helperRequest{Action: "check_permissions"})
+	cmd := exec.Command(a.helperPath)
+	cmd.Stdin = bytes.NewReader(reqBody)
+	_, err := cmd.Output()
+	return err
 }
 
 // findHelper looks for an existing helper binary in standard locations.


### PR DESCRIPTION
## Summary
- **iMessage FDA helper binary**: Extract iMessage integration into a separate `clawvisor-imessage-helper` binary that holds Full Disk Access, so users don't need to re-grant FDA on every clawvisor update. Installed on-demand with protocol versioning. Runs `check_permissions` after install to register the helper for FDA in System Settings.
- **Opt-in auto-update**: Self-hosted deployments can enable automatic binary updates via config or CLI.
- **Redis-backed stores**: Extract in-memory stores (OAuth state, pairing, dedup cache, rate limiting, ticket, intent cache, group chat buffer, Telegram tokens/groups) behind interfaces with Redis implementations for multi-instance deployments.
- **Onboarding & auth improvements**: Unified onboarding and MFA login flow, magic link improvements, OAuth callback page, security setup page.
- **Soft-delete agents**: Agents are soft-deleted and their tasks revoked on deletion.
- **Audit durability**: Backup `gateway_request_log` table for audit trail.
- **SKILL.md versioning**: Skill version endpoint and self-update check.
- **Security hardening**: Harden error handling, fix swallowed errors, update vulnerable dependencies.

## Test plan
- [ ] Verify iMessage helper installs on demand when adapter is first activated on macOS
- [ ] Verify helper appears in System Settings → Privacy & Security → Full Disk Access after install
- [ ] Verify helper protocol version check skips replacement when version matches
- [ ] Verify auto-update opt-in works via `clawvisor auto-update enable`
- [ ] Verify Redis store implementations work alongside in-memory defaults
- [ ] Verify soft-delete agents flow and task revocation
- [ ] Run full test suite: `go test ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)