### PR TITLE
feat: package iMessage helper as .app bundle for macOS FDA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,13 @@ LDFLAGS := -ldflags="-s -w -X github.com/clawvisor/clawvisor/pkg/version.Version
 build: web/dist
 	go build $(LDFLAGS) -o bin/clawvisor ./cmd/clawvisor
 
-IMESSAGE_HELPER_PLIST := cmd/imessage-helper/Info.plist
-IMESSAGE_HELPER_LDFLAGS := -ldflags="-s -w -X github.com/clawvisor/clawvisor/pkg/version.Version=$(VERSION) -linkmode external -extldflags '-sectcreate __TEXT __info_plist $(IMESSAGE_HELPER_PLIST)'"
+IMESSAGE_HELPER_APP := Clawvisor iMessage Helper.app
 
 build-imessage-helper:
-	CGO_ENABLED=1 go build $(IMESSAGE_HELPER_LDFLAGS) -o bin/clawvisor-imessage-helper ./cmd/imessage-helper
+	go build $(LDFLAGS) -o bin/clawvisor-imessage-helper ./cmd/imessage-helper
+	mkdir -p "bin/$(IMESSAGE_HELPER_APP)/Contents/MacOS"
+	cp bin/clawvisor-imessage-helper "bin/$(IMESSAGE_HELPER_APP)/Contents/MacOS/clawvisor-imessage-helper"
+	cp cmd/imessage-helper/Info.plist "bin/$(IMESSAGE_HELPER_APP)/Contents/Info.plist"
 
 build-staging: web/dist
 	$(MAKE) build ENVIRONMENT=staging
@@ -34,19 +36,21 @@ install: build
 	@echo ""
 	@echo 'Add to your PATH: export PATH="$$HOME/.clawvisor/bin:$$PATH"'
 
-# Install the iMessage helper binary separately. It holds Full Disk Access
+# Install the iMessage helper .app bundle separately. It holds Full Disk Access
 # and is codesigned independently so that updating the main binary does not
 # invalidate the FDA grant.
 install-imessage-helper: build-imessage-helper
 	mkdir -p $(HOME)/.clawvisor/bin
 	@# Only replace the helper if the binary actually changed, to preserve the
 	@# existing FDA grant and codesign.
-	@if [ -f $(HOME)/.clawvisor/bin/clawvisor-imessage-helper ] && \
-	    cmp -s bin/clawvisor-imessage-helper $(HOME)/.clawvisor/bin/clawvisor-imessage-helper; then \
+	@if [ -f "$(HOME)/.clawvisor/bin/$(IMESSAGE_HELPER_APP)/Contents/MacOS/clawvisor-imessage-helper" ] && \
+	    cmp -s "bin/$(IMESSAGE_HELPER_APP)/Contents/MacOS/clawvisor-imessage-helper" \
+	           "$(HOME)/.clawvisor/bin/$(IMESSAGE_HELPER_APP)/Contents/MacOS/clawvisor-imessage-helper"; then \
 		echo "imessage-helper: unchanged, skipping install (FDA preserved)"; \
 	else \
-		cp bin/clawvisor-imessage-helper $(HOME)/.clawvisor/bin/clawvisor-imessage-helper; \
-		[ "$$(uname)" = "Darwin" ] && codesign -s - $(HOME)/.clawvisor/bin/clawvisor-imessage-helper 2>/dev/null || true; \
+		rm -rf "$(HOME)/.clawvisor/bin/$(IMESSAGE_HELPER_APP)"; \
+		cp -R "bin/$(IMESSAGE_HELPER_APP)" "$(HOME)/.clawvisor/bin/$(IMESSAGE_HELPER_APP)"; \
+		[ "$$(uname)" = "Darwin" ] && codesign -s - "$(HOME)/.clawvisor/bin/$(IMESSAGE_HELPER_APP)/Contents/MacOS/clawvisor-imessage-helper" 2>/dev/null || true; \
 		echo "imessage-helper: installed and codesigned"; \
 	fi
 

--- a/cmd/imessage-helper/Info.plist
+++ b/cmd/imessage-helper/Info.plist
@@ -4,9 +4,13 @@
 <dict>
 	<key>CFBundleIdentifier</key>
 	<string>com.clawvisor.imessage-helper</string>
+	<key>CFBundleExecutable</key>
+	<string>clawvisor-imessage-helper</string>
 	<key>CFBundleName</key>
 	<string>Clawvisor iMessage Helper</string>
 	<key>CFBundleDisplayName</key>
 	<string>Clawvisor iMessage Helper</string>
+	<key>LSUIElement</key>
+	<true/>
 </dict>
 </plist>

--- a/internal/adapters/apple/imessage/adapter.go
+++ b/internal/adapters/apple/imessage/adapter.go
@@ -18,7 +18,9 @@
 package imessage
 
 import (
+	"archive/tar"
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -38,8 +40,14 @@ import (
 
 const serviceID = "apple.imessage"
 
-// helperBinaryName is the name of the FDA-holding helper binary.
+// helperAppName is the .app bundle that holds Full Disk Access.
+const helperAppName = "Clawvisor iMessage Helper.app"
+
+// helperBinaryName is the executable inside the .app bundle.
 const helperBinaryName = "clawvisor-imessage-helper"
+
+// helperRelBinary is the path from the .app root to the executable.
+const helperRelBinary = "Contents/MacOS/clawvisor-imessage-helper"
 
 // requiredProtocolVersion must match the helper's ProtocolVersion constant.
 // Bump this when a new helper binary is needed (new actions, changed behavior).
@@ -201,25 +209,40 @@ func (a *IMessageAdapter) ensureHelper() error {
 	_ = a.runCheckPermissions()
 
 	if path == "" {
-		return fmt.Errorf("imessage helper installed — grant Full Disk Access to %q in System Settings → Privacy & Security → Full Disk Access", helperBinaryName)
+		return fmt.Errorf("imessage helper installed — grant Full Disk Access to %q in System Settings → Privacy & Security → Full Disk Access", helperAppName)
 	}
 	// Replaced an existing binary — FDA needs re-granting.
-	return fmt.Errorf("imessage helper updated (protocol version changed) — re-grant Full Disk Access to %q in System Settings → Privacy & Security → Full Disk Access", helperBinaryName)
+	return fmt.Errorf("imessage helper updated (protocol version changed) — re-grant Full Disk Access to %q in System Settings → Privacy & Security → Full Disk Access", helperAppName)
 }
 
 // runCheckPermissions calls the helper's check_permissions action, which
 // attempts to open chat.db. The result is ignored — the purpose is to trigger
-// macOS to register the binary for the FDA list.
+// macOS to register the .app bundle in the FDA list.
 func (a *IMessageAdapter) runCheckPermissions() error {
 	reqBody, _ := json.Marshal(helperRequest{Action: "check_permissions"})
-	cmd := exec.Command(a.helperPath)
-	cmd.Stdin = bytes.NewReader(reqBody)
-	_, err := cmd.Output()
+	_, err := a.execHelper(context.Background(), reqBody)
 	return err
 }
 
+// helperAppDir returns the .app bundle path for the given binary path.
+// If the binary is not inside a .app bundle, returns empty string.
+func helperAppDir(binaryPath string) string {
+	// binaryPath is like /path/to/Clawvisor iMessage Helper.app/Contents/MacOS/clawvisor-imessage-helper
+	// Walk up to find the .app directory.
+	dir := binaryPath
+	for {
+		dir = filepath.Dir(dir)
+		if dir == "/" || dir == "." {
+			return ""
+		}
+		if filepath.Ext(dir) == ".app" {
+			return dir
+		}
+	}
+}
+
 // findHelper looks for an existing helper binary in standard locations.
-// Returns the path if found, empty string otherwise.
+// Returns the path to the binary inside the .app bundle if found, empty string otherwise.
 func (a *IMessageAdapter) findHelper() string {
 	// 1. Cached from a previous call.
 	if a.helperPath != "" {
@@ -229,9 +252,9 @@ func (a *IMessageAdapter) findHelper() string {
 		a.helperPath = ""
 	}
 
-	// 2. Next to the running binary.
+	// 2. Next to the running binary (as .app bundle).
 	if exe, err := os.Executable(); err == nil {
-		candidate := filepath.Join(filepath.Dir(exe), helperBinaryName)
+		candidate := filepath.Join(filepath.Dir(exe), helperAppName, helperRelBinary)
 		if _, err := os.Stat(candidate); err == nil {
 			return candidate
 		}
@@ -239,13 +262,13 @@ func (a *IMessageAdapter) findHelper() string {
 
 	// 3. Standard install location.
 	if home, err := os.UserHomeDir(); err == nil {
-		candidate := filepath.Join(home, ".clawvisor", "bin", helperBinaryName)
+		candidate := filepath.Join(home, ".clawvisor", "bin", helperAppName, helperRelBinary)
 		if _, err := os.Stat(candidate); err == nil {
 			return candidate
 		}
 	}
 
-	// 4. PATH lookup.
+	// 4. PATH lookup (dev convenience — bare binary without .app bundle).
 	if p, err := exec.LookPath(helperBinaryName); err == nil {
 		return p
 	}
@@ -274,11 +297,11 @@ func (a *IMessageAdapter) queryHelperVersion(helperPath string) (string, error) 
 	return resp.Data.ProtocolVersion, nil
 }
 
-// downloadHelper downloads the helper binary from the GitHub release matching
-// the current clawvisor version.
+// downloadHelper downloads the helper .app bundle from the GitHub release
+// matching the current clawvisor version.
 func (a *IMessageAdapter) downloadHelper(installDir string) (string, error) {
 	tag := "v" + version.Version
-	assetName := fmt.Sprintf("clawvisor-imessage-helper-%s-%s", runtime.GOOS, runtime.GOARCH)
+	assetName := fmt.Sprintf("clawvisor-imessage-helper-%s-%s.tar.gz", runtime.GOOS, runtime.GOARCH)
 	url := fmt.Sprintf("https://github.com/%s/%s/releases/download/%s/%s",
 		githubOwner, githubRepo, tag, assetName)
 
@@ -296,38 +319,73 @@ func (a *IMessageAdapter) downloadHelper(installDir string) (string, error) {
 		return "", err
 	}
 
-	// Write to a temp file in the same directory, then atomic-rename.
-	tmpFile, err := os.CreateTemp(installDir, helperBinaryName+"-*")
+	// Extract to a temp dir, then atomic-rename into place.
+	tmpDir, err := os.MkdirTemp(installDir, ".helper-install-*")
 	if err != nil {
 		return "", err
 	}
-	tmpPath := tmpFile.Name()
+	defer os.RemoveAll(tmpDir) // clean up on failure
 
-	if _, err := io.Copy(tmpFile, resp.Body); err != nil {
-		tmpFile.Close()
-		os.Remove(tmpPath)
-		return "", err
-	}
-	tmpFile.Close()
-
-	if err := os.Chmod(tmpPath, 0755); err != nil {
-		os.Remove(tmpPath)
-		return "", err
+	if err := extractTarGz(resp.Body, tmpDir); err != nil {
+		return "", fmt.Errorf("extract: %w", err)
 	}
 
-	// Ad-hoc codesign on macOS (required for FDA registration).
-	if out, err := exec.Command("codesign", "-s", "-", tmpPath).CombinedOutput(); err != nil {
-		os.Remove(tmpPath)
+	// Codesign the binary inside the .app bundle.
+	binaryPath := filepath.Join(tmpDir, helperAppName, helperRelBinary)
+	if out, err := exec.Command("codesign", "-s", "-", binaryPath).CombinedOutput(); err != nil {
 		return "", fmt.Errorf("codesign: %w — %s", err, out)
 	}
 
-	dest := filepath.Join(installDir, helperBinaryName)
-	if err := os.Rename(tmpPath, dest); err != nil {
-		os.Remove(tmpPath)
+	// Atomic swap: remove old .app, rename new one into place.
+	destApp := filepath.Join(installDir, helperAppName)
+	os.RemoveAll(destApp)
+	if err := os.Rename(filepath.Join(tmpDir, helperAppName), destApp); err != nil {
 		return "", err
 	}
 
-	return dest, nil
+	return filepath.Join(destApp, helperRelBinary), nil
+}
+
+// extractTarGz extracts a gzipped tar archive into destDir.
+func extractTarGz(r io.Reader, destDir string) error {
+	gz, err := gzip.NewReader(r)
+	if err != nil {
+		return err
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+
+		target := filepath.Join(destDir, filepath.Clean(hdr.Name))
+
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, os.FileMode(hdr.Mode)); err != nil {
+				return err
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+				return err
+			}
+			f, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(hdr.Mode))
+			if err != nil {
+				return err
+			}
+			if _, err := io.Copy(f, tr); err != nil {
+				f.Close()
+				return err
+			}
+			f.Close()
+		}
+	}
 }
 
 // helperInstallDir returns ~/.clawvisor/bin, creating it if needed.
@@ -368,31 +426,65 @@ func (a *IMessageAdapter) callHelper(ctx context.Context, action string, params 
 		return nil, fmt.Errorf("imessage: marshal request: %w", err)
 	}
 
-	cmd := exec.CommandContext(ctx, a.helperPath)
-	cmd.Stdin = bytes.NewReader(reqBody)
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	if err := cmd.Run(); err != nil {
+	stdout, err := a.execHelper(ctx, reqBody)
+	if err != nil {
 		// If the helper wrote a JSON error to stdout before exiting, use that.
-		if stdout.Len() > 0 {
+		if len(stdout) > 0 {
 			var resp helperResponse
-			if json.Unmarshal(stdout.Bytes(), &resp) == nil && resp.Error != "" {
+			if json.Unmarshal(stdout, &resp) == nil && resp.Error != "" {
 				return nil, fmt.Errorf("imessage: %s", resp.Error)
 			}
 		}
-		return nil, fmt.Errorf("imessage: helper failed: %w — %s", err, truncate(stderr.String(), 200))
+		return nil, fmt.Errorf("imessage: helper failed: %w", err)
 	}
 
 	var resp helperResponse
-	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
+	if err := json.Unmarshal(stdout, &resp); err != nil {
 		return nil, fmt.Errorf("imessage: parse helper response: %w", err)
 	}
 	if resp.Error != "" {
 		return nil, fmt.Errorf("imessage: %s", resp.Error)
 	}
 	return &resp, nil
+}
+
+// execHelper launches the helper and returns its stdout. Uses `open` for .app
+// bundles so macOS TCC attributes file access to the helper, not clawvisor.
+func (a *IMessageAdapter) execHelper(ctx context.Context, reqBody []byte) ([]byte, error) {
+	appDir := helperAppDir(a.helperPath)
+	if appDir == "" {
+		// Bare binary (dev/PATH fallback) — exec directly.
+		cmd := exec.CommandContext(ctx, a.helperPath)
+		cmd.Stdin = bytes.NewReader(reqBody)
+		return cmd.Output()
+	}
+
+	// Write request to a temp file for stdin.
+	stdinFile, err := os.CreateTemp("", "clawvisor-helper-req-*")
+	if err != nil {
+		return nil, err
+	}
+	defer os.Remove(stdinFile.Name())
+	if _, err := stdinFile.Write(reqBody); err != nil {
+		stdinFile.Close()
+		return nil, err
+	}
+	stdinFile.Close()
+
+	// Capture stdout via temp file.
+	stdoutFile, err := os.CreateTemp("", "clawvisor-helper-resp-*")
+	if err != nil {
+		return nil, err
+	}
+	defer os.Remove(stdoutFile.Name())
+	stdoutFile.Close()
+
+	cmd := exec.CommandContext(ctx, "open", "-W", "-g", "-j", "-i", stdinFile.Name(), "-o", stdoutFile.Name(), appDir)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("%w — %s", err, truncate(string(out), 200))
+	}
+
+	return os.ReadFile(stdoutFile.Name())
 }
 
 func truncate(s string, max int) string {

--- a/internal/adapters/apple/imessage/adapter_test.go
+++ b/internal/adapters/apple/imessage/adapter_test.go
@@ -24,8 +24,8 @@ func TestFindHelper_StandardLocation(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
-	// Create fake helper in ~/.clawvisor/bin/
-	binDir := filepath.Join(tmpDir, ".clawvisor", "bin")
+	// Create fake helper inside .app bundle at ~/.clawvisor/bin/
+	binDir := filepath.Join(tmpDir, ".clawvisor", "bin", helperAppName, "Contents", "MacOS")
 	if err := os.MkdirAll(binDir, 0755); err != nil {
 		t.Fatal(err)
 	}
@@ -43,7 +43,11 @@ func TestFindHelper_StandardLocation(t *testing.T) {
 
 func TestFindHelper_CachedPath(t *testing.T) {
 	tmpDir := t.TempDir()
-	helperPath := filepath.Join(tmpDir, helperBinaryName)
+	appBinDir := filepath.Join(tmpDir, helperAppName, "Contents", "MacOS")
+	if err := os.MkdirAll(appBinDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	helperPath := filepath.Join(appBinDir, helperBinaryName)
 	if err := os.WriteFile(helperPath, []byte("#!/bin/sh\n"), 0755); err != nil {
 		t.Fatal(err)
 	}
@@ -56,7 +60,7 @@ func TestFindHelper_CachedPath(t *testing.T) {
 }
 
 func TestFindHelper_CachedPathStale(t *testing.T) {
-	a := &IMessageAdapter{helperPath: "/nonexistent/clawvisor-imessage-helper"}
+	a := &IMessageAdapter{helperPath: "/nonexistent/Clawvisor iMessage Helper.app/Contents/MacOS/clawvisor-imessage-helper"}
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 	t.Setenv("PATH", tmpDir)

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -37,19 +37,26 @@ for PLATFORM in $PLATFORMS; do
     go build -ldflags="$LDFLAGS" -o "$OUTPUT" ./cmd/clawvisor
 done
 
-# Build the iMessage helper for macOS only. This is a separate, stable binary
-# that holds Full Disk Access so users don't need to re-grant FDA on every
-# clawvisor update. The Info.plist (display name in FDA settings) can only be
-# embedded when building on macOS; CI cross-compilation omits it.
+# Build the iMessage helper .app bundle for macOS only. This is a separate,
+# stable binary that holds Full Disk Access so users don't need to re-grant
+# FDA on every clawvisor update. The .app bundle structure lets macOS read
+# Info.plist for the display name in FDA settings, no CGO required.
+HELPER_APP="Clawvisor iMessage Helper.app"
 HELPER_PLATFORMS="darwin/arm64 darwin/amd64"
 for PLATFORM in $HELPER_PLATFORMS; do
   GOOS="${PLATFORM%/*}"
   GOARCH="${PLATFORM#*/}"
-  OUTPUT="dist/clawvisor-imessage-helper-${GOOS}-${GOARCH}"
+  TARBALL="dist/clawvisor-imessage-helper-${GOOS}-${GOARCH}.tar.gz"
 
-  echo "Building ${OUTPUT}..."
+  echo "Building ${TARBALL}..."
   CGO_ENABLED=0 GOOS="$GOOS" GOARCH="$GOARCH" \
-    go build -ldflags="$LDFLAGS" -o "$OUTPUT" ./cmd/imessage-helper
+    go build -ldflags="$LDFLAGS" -o "dist/.helper-tmp" ./cmd/imessage-helper
+
+  mkdir -p "dist/${HELPER_APP}/Contents/MacOS"
+  mv "dist/.helper-tmp" "dist/${HELPER_APP}/Contents/MacOS/clawvisor-imessage-helper"
+  cp cmd/imessage-helper/Info.plist "dist/${HELPER_APP}/Contents/Info.plist"
+  tar -czf "$TARBALL" -C dist "${HELPER_APP}"
+  rm -rf "dist/${HELPER_APP}"
 done
 
 echo "Generating checksums..."


### PR DESCRIPTION
## Summary
- Package the iMessage helper as a `.app` bundle instead of a flat binary with embedded Info.plist
- Launch helper via `open -W -g -j` so macOS TCC attributes Full Disk Access to the helper (not the parent clawvisor process)
- Release artifacts are now `.tar.gz` archives containing the `.app` bundle, built without CGO
- Adds `CFBundleExecutable` and `LSUIElement` to Info.plist for proper `open` support

**Why:** macOS TCC tracks the "responsible process" — when clawvisor exec'd the helper directly, FDA was attributed to clawvisor. Wrapping in a `.app` and launching via `open` makes the helper its own responsible process, so FDA persists across clawvisor updates.

## Test plan
- [x] `make install-imessage-helper` builds and installs the `.app` bundle
- [x] Helper appears as "Clawvisor iMessage Helper" in FDA settings
- [x] `check_permissions` succeeds after granting FDA to the `.app`
- [x] Direct exec still fails (confirms responsible process fix is needed)
- [ ] Verify `scripts/build-release.sh` produces correct `.tar.gz` artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)