### PR TITLE
feat: add copy buttons to Claude Desktop setup commands

### DIFF
--- a/web/src/pages/Agents.tsx
+++ b/web/src/pages/Agents.tsx
@@ -270,7 +270,7 @@ function ConnectAgentGuide() {
       <div className="p-5">
         {tab === 'openclaw' && <OpenClawGuide setupURL={setupURL} isLocal={isLocal} copied={copied} onCopy={copyText} />}
         {tab === 'claude-code' && <ClaudeCodeGuide clawvisorURL={clawvisorURL} userIdParam={userIdParam} onCopy={copyText} />}
-        {tab === 'claude-desktop' && <ClaudeDesktopGuide isLocal={isLocal} />}
+        {tab === 'claude-desktop' && <ClaudeDesktopGuide isLocal={isLocal} onCopy={copyText} />}
         {tab === 'other' && <OtherAgentGuide setupURL={setupURL} clawvisorURL={clawvisorURL} copied={copied} onCopy={copyText} />}
       </div>
     </section>
@@ -357,8 +357,10 @@ function ClaudeCodeGuide({ clawvisorURL, userIdParam, onCopy }: {
   )
 }
 
-function ClaudeDesktopGuide({ isLocal }: { isLocal: boolean }) {
+function ClaudeDesktopGuide({ isLocal, onCopy }: { isLocal: boolean; onCopy: (text: string) => void }) {
   const pluginName = isLocal ? 'clawvisor-local@cowork-plugins' : 'clawvisor@cowork-plugins'
+  const marketplaceCmd = 'claude plugin marketplace add clawvisor/cowork-plugins'
+  const installCmd = `/plugin install ${pluginName}`
 
   return (
     <div className="space-y-5">
@@ -375,7 +377,7 @@ function ClaudeDesktopGuide({ isLocal }: { isLocal: boolean }) {
           <p className="text-xs text-text-tertiary">
             Run this in your terminal:
           </p>
-          <CodeBlock>{`claude plugin marketplace add clawvisor/cowork-plugins`}</CodeBlock>
+          <CodeBlock onCopy={() => onCopy(marketplaceCmd)}>{marketplaceCmd}</CodeBlock>
         </div>
       </div>
 
@@ -386,7 +388,7 @@ function ClaudeDesktopGuide({ isLocal }: { isLocal: boolean }) {
           <p className="text-xs text-text-tertiary">
             From within Claude Desktop:
           </p>
-          <CodeBlock>{`/plugin install ${pluginName}`}</CodeBlock>
+          <CodeBlock onCopy={() => onCopy(installCmd)}>{installCmd}</CodeBlock>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Adds clipboard copy buttons to the two code blocks in the Claude Desktop (Cowork) tab on the Agents page
- The marketplace add command and plugin install command now have hover-to-copy buttons, matching the behavior already present in the Claude Code, OpenClaw, and Other Agents tabs

## Test plan
- [ ] Open the Agents page and switch to the Claude Desktop tab
- [ ] Hover over each code block and verify the "Copy" button appears
- [ ] Click copy and verify the command is copied to clipboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)