### PR TITLE
feat: add waitlist signup flow to frontend

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -90,7 +90,7 @@ async function request<T>(
     })
     if (!retryRes.ok) {
       const err = await retryRes.json().catch(() => ({ error: retryRes.statusText }))
-      throw new APIError(retryRes.status, err.error ?? retryRes.statusText, err.code)
+      throw new APIError(retryRes.status, err.error ?? retryRes.statusText, err.code, err)
     }
     if (retryRes.status === 204) return undefined as T
     return retryRes.json()
@@ -98,7 +98,7 @@ async function request<T>(
 
   if (!res.ok) {
     const err = await res.json().catch(() => ({ error: res.statusText }))
-    throw new APIError(res.status, err.error ?? res.statusText, err.code)
+    throw new APIError(res.status, err.error ?? res.statusText, err.code, err)
   }
 
   if (res.status === 204) return undefined as T
@@ -143,9 +143,14 @@ export class APIError extends Error {
     public readonly status: number,
     message: string,
     public readonly code?: string,
+    public readonly extra?: Record<string, unknown>,
   ) {
     super(message)
     this.name = 'APIError'
+  }
+
+  get waitlistAvailable(): boolean {
+    return this.extra?.waitlist_available === true
   }
 }
 
@@ -673,6 +678,8 @@ export const api = {
   auth: {
     register: (email: string, password: string) =>
       post<RegisterResult>('/api/auth/register', { email, password }),
+    joinWaitlist: (email: string) =>
+      post<{ status: 'waitlisted' }>('/api/auth/waitlist', { email }),
     login: (email: string, password: string) =>
       post<LoginResult>('/api/auth/login', { email, password }),
     refresh: (refreshToken: string) =>

--- a/web/src/pages/OAuthCallback.tsx
+++ b/web/src/pages/OAuthCallback.tsx
@@ -47,6 +47,10 @@ export default function OAuthCallback() {
         setDestination('/onboarding')
       })
       .catch((err) => {
+        if (err instanceof APIError && err.waitlistAvailable) {
+          navigate('/register?waitlist=1', { replace: true })
+          return
+        }
         setError(err instanceof APIError ? err.message : 'Failed to sign in')
       })
   }, [searchParams, setSession, navigate])

--- a/web/src/pages/Register.tsx
+++ b/web/src/pages/Register.tsx
@@ -1,14 +1,17 @@
 import { useState, FormEvent } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import { api, APIError } from '../api/client'
 
 export default function Register() {
 
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [showWaitlist, setShowWaitlist] = useState(searchParams.get('waitlist') === '1')
+  const [waitlistJoined, setWaitlistJoined] = useState(false)
 
 
   async function handleGoogleRegister() {
@@ -26,7 +29,11 @@ export default function Register() {
       })
       window.location.href = `https://accounts.google.com/o/oauth2/v2/auth?${params}`
     } catch (err: any) {
-      setError(err instanceof APIError ? err.message : 'Google sign-up is not available')
+      if (err instanceof APIError && err.waitlistAvailable) {
+        setShowWaitlist(true)
+      } else {
+        setError(err instanceof APIError ? err.message : 'Google sign-up is not available')
+      }
       setIsSubmitting(false)
     }
   }
@@ -39,6 +46,25 @@ export default function Register() {
       await api.auth.register(email, password)
       navigate('/check-email', { state: { email } })
     } catch (err) {
+      if (err instanceof APIError && err.waitlistAvailable) {
+        setShowWaitlist(true)
+      } else if (err instanceof APIError) {
+        setError(err.message)
+      } else {
+        setError('An unexpected error occurred')
+      }
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  async function handleJoinWaitlist() {
+    setError(null)
+    setIsSubmitting(true)
+    try {
+      await api.auth.joinWaitlist(email)
+      setWaitlistJoined(true)
+    } catch (err) {
       if (err instanceof APIError) {
         setError(err.message)
       } else {
@@ -47,6 +73,23 @@ export default function Register() {
     } finally {
       setIsSubmitting(false)
     }
+  }
+
+  if (waitlistJoined) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-surface-0">
+        <div className="max-w-md w-full p-8 bg-surface-1 border border-border-default rounded-md text-center space-y-4">
+          <h1 className="text-3xl font-bold text-text-primary">Clawvisor</h1>
+          <h2 className="text-lg text-text-secondary">You're on the waitlist!</h2>
+          <p className="text-sm text-text-tertiary">
+            We'll let you know when your account is ready. Keep an eye on <strong>{email}</strong> for updates.
+          </p>
+          <Link to="/login" className="inline-block py-2 px-4 bg-brand text-surface-0 rounded font-medium hover:bg-brand-strong">
+            Back to login
+          </Link>
+        </div>
+      </div>
+    )
   }
 
   return (
@@ -59,6 +102,21 @@ export default function Register() {
 
         {error && (
           <div className="p-3 bg-danger/10 text-danger rounded text-sm">{error}</div>
+        )}
+
+        {showWaitlist && (
+          <div className="p-4 bg-brand/5 border border-brand/20 rounded space-y-3">
+            <p className="text-sm text-text-secondary">
+              Registration is currently closed. Join the waitlist and we'll notify you when a spot opens up.
+            </p>
+            <button
+              onClick={handleJoinWaitlist}
+              disabled={isSubmitting || !email}
+              className="w-full py-2 px-4 bg-brand text-surface-0 rounded font-medium hover:bg-brand-strong disabled:opacity-50"
+            >
+              {isSubmitting ? 'Joining...' : 'Join the waitlist'}
+            </button>
+          </div>
         )}
 
         <div className="space-y-3">


### PR DESCRIPTION
## Summary
- `APIError` now carries the full error body and exposes a `waitlistAvailable` getter
- Register page detects `REGISTRATION_DISABLED` with `waitlist_available: true` and shows a join-the-waitlist prompt + confirmation screen
- OAuth callback redirects to `/register?waitlist=1` when waitlist is available
- Added `api.auth.joinWaitlist()` API method

Companion to clawvisor/cloud#31.

## Test plan
- [ ] Register with a non-allowlisted email when registration is closed — should see waitlist prompt
- [ ] Enter email and click "Join the waitlist" — should see confirmation screen
- [ ] Google OAuth with non-allowlisted email — should redirect to register with waitlist prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)