### PR TITLE
feat: add Discord and self-hosted CTAs to waitlist success screen

### DIFF
--- a/web/src/pages/Waitlist.tsx
+++ b/web/src/pages/Waitlist.tsx
@@ -36,9 +36,17 @@ export default function Waitlist() {
           <p className="text-sm text-text-tertiary">
             We'll let you know when your account is ready. Keep an eye on <strong>{email}</strong> for updates.
           </p>
-          <Link to="/login" className="inline-block py-2 px-4 bg-brand text-surface-0 rounded font-medium hover:bg-brand-strong">
-            Back to login
-          </Link>
+          <p className="text-sm text-text-tertiary">
+            In the meantime, <a href="https://discord.gg/sZAV4xfAKd" target="_blank" rel="noopener noreferrer" className="text-brand hover:underline">join our Discord</a> to connect with the community, or get started right away with the <a href="https://github.com/clawvisor/clawvisor" target="_blank" rel="noopener noreferrer" className="text-brand hover:underline">self-hosted version</a>.
+          </p>
+          <div className="flex gap-3 justify-center">
+            <a href="https://discord.gg/sZAV4xfAKd" target="_blank" rel="noopener noreferrer" className="py-2 px-4 bg-brand text-surface-0 rounded font-medium hover:bg-brand-strong">
+              Join Discord
+            </a>
+            <Link to="/login" className="py-2 px-4 border border-border-default text-text-secondary rounded font-medium hover:bg-surface-2">
+              Back to login
+            </Link>
+          </div>
         </div>
       </div>
     )


### PR DESCRIPTION
## Summary

After joining the waitlist, users now see encouragement to join the Discord community or get started with the self-hosted version. Adds inline text links and a primary "Join Discord" button alongside the existing "Back to login" button (restyled as secondary).

## Test plan

- [ ] Join the waitlist and verify the success screen shows Discord and self-hosted links
- [ ] Verify Discord link opens https://discord.gg/sZAV4xfAKd in a new tab
- [ ] Verify self-hosted link opens the GitHub repo in a new tab
- [ ] Verify "Back to login" still works