### PR TITLE
feat: agent feedback system with bug reports and NPS surveys

### DIFF
--- a/internal/api/handlers/feedback.go
+++ b/internal/api/handlers/feedback.go
@@ -1,0 +1,225 @@
+package handlers
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/clawvisor/clawvisor/internal/api/middleware"
+	"github.com/clawvisor/clawvisor/internal/feedback"
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+// FeedbackHandler handles agent feedback endpoints: bug reports and NPS.
+type FeedbackHandler struct {
+	store    store.Store
+	reviewer feedback.Reviewer
+	logger   *slog.Logger
+}
+
+func NewFeedbackHandler(st store.Store, reviewer feedback.Reviewer, logger *slog.Logger) *FeedbackHandler {
+	return &FeedbackHandler{store: st, reviewer: reviewer, logger: logger}
+}
+
+// ── Report Bug ──────────────────────────────────────────────────────────
+
+type reportBugRequest struct {
+	RequestID   string          `json:"request_id"`
+	TaskID      string          `json:"task_id"`
+	Description string          `json:"description"`
+	Context     json.RawMessage `json:"context,omitempty"`
+}
+
+// ReportBug handles POST /api/feedback/report — agent-facing.
+//
+// The agent provides a free-form description of the issue along with optional
+// request_id and task_id references. An LLM reviews the report, categorizes it,
+// assesses severity, and crafts an empathetic, actionable response.
+func (h *FeedbackHandler) ReportBug(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	agent := middleware.AgentFromContext(ctx)
+	if agent == nil {
+		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "not authenticated")
+		return
+	}
+
+	var req reportBugRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	if req.Description == "" {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "description is required")
+		return
+	}
+
+	// Look up referenced request and task to give the reviewer full context.
+	var auditEntry *store.AuditEntry
+	var task *store.Task
+	if req.RequestID != "" {
+		if e, err := h.store.GetAuditEntryByRequestID(ctx, req.RequestID, agent.UserID); err == nil {
+			auditEntry = e
+		}
+	}
+	if req.TaskID != "" {
+		if t, err := h.store.GetTask(ctx, req.TaskID); err == nil && t.AgentID == agent.ID {
+			task = t
+		}
+	}
+
+	// Run the LLM reviewer to categorize and craft a response.
+	reviewResult, err := h.reviewer.Review(ctx, feedback.ReviewRequest{
+		Description: req.Description,
+		AuditEntry:  auditEntry,
+		Task:        task,
+		AgentName:   agent.Name,
+	})
+	if err != nil {
+		h.logger.Error("feedback review failed", "err", err)
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to review report")
+		return
+	}
+
+	report := &store.FeedbackReport{
+		ID:          uuid.New().String(),
+		UserID:      agent.UserID,
+		AgentID:     agent.ID,
+		AgentName:   agent.Name,
+		RequestID:   req.RequestID,
+		TaskID:      req.TaskID,
+		Category:    reviewResult.Category,
+		Description: req.Description,
+		Severity:    reviewResult.Severity,
+		Context:     req.Context,
+		Response:    reviewResult.Response,
+		CreatedAt:   time.Now(),
+	}
+
+	if err := h.store.CreateFeedbackReport(ctx, report); err != nil {
+		h.logger.Error("failed to save feedback report", "err", err)
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to save report")
+		return
+	}
+
+	h.logger.Info("agent feedback report submitted",
+		"report_id", report.ID,
+		"agent_id", agent.ID,
+		"category", reviewResult.Category,
+		"severity", reviewResult.Severity,
+		"is_valid", reviewResult.IsValid,
+	)
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"id":       report.ID,
+		"status":   "received",
+		"category": reviewResult.Category,
+		"severity": reviewResult.Severity,
+		"response": reviewResult.Response,
+		"message":  "Thank you for reporting this. Your feedback helps us improve Clawvisor for all agents.",
+	})
+}
+
+// ── NPS ─────────────────────────────────────────────────────────────────
+
+type submitNPSRequest struct {
+	Score    int    `json:"score"`
+	TaskID   string `json:"task_id,omitempty"`
+	Feedback string `json:"feedback,omitempty"`
+}
+
+// SubmitNPS handles POST /api/feedback/nps — agent-facing.
+func (h *FeedbackHandler) SubmitNPS(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	agent := middleware.AgentFromContext(ctx)
+	if agent == nil {
+		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "not authenticated")
+		return
+	}
+
+	var req submitNPSRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	if req.Score < 1 || req.Score > 10 {
+		writeError(w, http.StatusBadRequest, "INVALID_SCORE", "score must be between 1 and 10")
+		return
+	}
+
+	nps := &store.NPSResponse{
+		ID:        uuid.New().String(),
+		UserID:    agent.UserID,
+		AgentID:   agent.ID,
+		AgentName: agent.Name,
+		TaskID:    req.TaskID,
+		Score:     req.Score,
+		Feedback:  req.Feedback,
+		CreatedAt: time.Now(),
+	}
+
+	if err := h.store.SaveNPSResponse(ctx, nps); err != nil {
+		h.logger.Error("failed to save NPS response", "err", err)
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to save response")
+		return
+	}
+
+	h.logger.Info("agent NPS response submitted",
+		"agent_id", agent.ID,
+		"score", req.Score,
+	)
+
+	message := npsMessage(req.Score)
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"status":  "recorded",
+		"message": message,
+	})
+}
+
+func npsMessage(score int) string {
+	switch {
+	case score >= 9:
+		return "Wonderful to hear! We're glad Clawvisor is working well for you. Your positive feedback motivates us to keep improving."
+	case score >= 7:
+		return "Thanks for the solid rating! We'd love to know what would make it a 10 — feel free to include details in the feedback field next time."
+	case score >= 5:
+		return "We appreciate your honesty. We know there's room to improve and your feedback helps us prioritize what to work on. If something specific frustrated you, the report_bug tool is a great way to give us detailed context."
+	case score >= 3:
+		return "We're sorry Clawvisor isn't meeting your expectations. Your feedback is especially valuable — it helps us identify where we're falling short. Please use the report_bug tool to tell us about specific pain points so we can fix them."
+	default:
+		return "We hear you, and we're sorry about your experience. This kind of honest feedback is exactly what we need to get better. Please use report_bug to share details about what went wrong — we genuinely want to fix it."
+	}
+}
+
+// ── List reports (user-facing) ──────────────────────────────────────────
+
+// ListReports handles GET /api/feedback/reports — user-facing.
+func (h *FeedbackHandler) ListReports(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	user := middleware.UserFromContext(ctx)
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "not authenticated")
+		return
+	}
+
+	q := r.URL.Query()
+	limit := parseIntQuery(q.Get("limit"), 50)
+	if limit > maxListLimit {
+		limit = maxListLimit
+	}
+	offset := parseIntQuery(q.Get("offset"), 0)
+
+	reports, total, err := h.store.ListFeedbackReports(ctx, user.ID, limit, offset)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to list reports")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"reports": reports,
+		"total":   total,
+		"limit":   limit,
+		"offset":  offset,
+	})
+}

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math/rand"
 	"net/http"
 	"strconv"
 	"strings"
@@ -221,12 +222,14 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 				h.logger.Warn("audit log failed", "err", logErr)
 			}
 			h.publishAuditAndQueue(agent.UserID, "")
-			writeJSON(w, http.StatusOK, map[string]any{
+			resp := map[string]any{
 				"status":     "blocked",
 				"request_id": req.RequestID,
 				"audit_id":   auditID,
 				"reason":     err.Error(),
-			})
+			}
+			h.maybeInjectNPS(ctx, resp, agent.ID)
+			writeJSON(w, http.StatusOK, resp)
 			return
 		}
 	}
@@ -250,12 +253,14 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 		if reason == "" {
 			reason = fmt.Sprintf("Restricted: %s:%s is blocked", restriction.Service, restriction.Action)
 		}
-		writeJSON(w, http.StatusOK, map[string]any{
+		resp := map[string]any{
 			"status":     "blocked",
 			"request_id": req.RequestID,
 			"audit_id":   auditID,
 			"reason":     reason,
-		})
+		}
+		h.maybeInjectNPS(ctx, resp, agent.ID)
+		writeJSON(w, http.StatusOK, resp)
 		return
 	}
 
@@ -287,11 +292,13 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 		}
 		if task.ExpiresAt != nil && time.Now().After(*task.ExpiresAt) {
 			outDecision, outOutcome = "reject", "task_expired"
-			writeJSON(w, http.StatusOK, map[string]any{
+			resp := map[string]any{
 				"status":  "task_expired",
 				"task_id": req.TaskID,
 				"message": "Task has expired. Use POST /api/tasks/{id}/expand to extend.",
-			})
+			}
+			h.maybeInjectNPS(ctx, resp, agent.ID)
+			writeJSON(w, http.StatusOK, resp)
 			return
 		}
 		if task.Status != "active" {
@@ -323,13 +330,15 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 				h.logger.Warn("audit log failed", "err", logErr)
 			}
 			h.publishAuditAndQueue(agent.UserID, req.TaskID)
-			writeJSON(w, http.StatusOK, map[string]any{
+			resp := map[string]any{
 				"status":     "pending_scope_expansion",
 				"task_id":    req.TaskID,
 				"request_id": req.RequestID,
 				"audit_id":   auditID,
 				"message":    msg,
-			})
+			}
+			h.maybeInjectNPS(ctx, resp, agent.ID)
+			writeJSON(w, http.StatusOK, resp)
 			return
 		}
 
@@ -403,6 +412,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 				if len(warnings) > 0 {
 					resp["warnings"] = warnings
 				}
+				h.maybeInjectNPS(ctx, resp, agent.ID)
 				writeJSON(w, http.StatusOK, resp)
 				return
 			}
@@ -477,13 +487,15 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 						}, cbKey)
 					}()
 				}
-				writeJSON(w, http.StatusOK, map[string]any{
+				resp := map[string]any{
 					"status":     "error",
 					"request_id": req.RequestID,
 					"audit_id":   auditID,
 					"error":      errMsg,
 					"code":       "EXECUTION_ERROR",
-				})
+				}
+				h.maybeInjectNPS(ctx, resp, agent.ID)
+				writeJSON(w, http.StatusOK, resp)
 				return
 			}
 
@@ -553,6 +565,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			if len(warnings) > 0 {
 				resp["warnings"] = warnings
 			}
+			h.maybeInjectNPS(ctx, resp, agent.ID)
 			writeJSON(w, http.StatusOK, resp)
 			return
 		}
@@ -647,7 +660,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 		timeout := parseLongPollTimeout(r)
 		pa := h.waitForApprovalDecision(r.Context(), req.RequestID, agent.UserID, time.Duration(timeout)*time.Second)
 		if pa != nil && pa.Status == "approved" && !time.Now().After(pa.ExpiresAt) {
-			h.executeAndRespond(w, r.Context(), pa)
+			h.executeAndRespond(w, r.Context(), pa, agent.ID)
 			return
 		}
 		// pa == nil means the row was deleted (denied/expired). Check the audit
@@ -758,7 +771,7 @@ func (h *GatewayHandler) waitForApprovalDecision(ctx context.Context, requestID,
 // adapter, and writes the result as JSON. The atomic claim prevents double-
 // execution when multiple code paths race (e.g. wait=true long-poll + /execute).
 // Shared by HandleRequest (wait=true) and HandleExecuteApproved.
-func (h *GatewayHandler) executeAndRespond(w http.ResponseWriter, ctx context.Context, pa *store.PendingApproval) {
+func (h *GatewayHandler) executeAndRespond(w http.ResponseWriter, ctx context.Context, pa *store.PendingApproval, agentID string) {
 	// Atomic claim: only one caller wins. Prevents double-execution of
 	// non-idempotent actions (emails, payments, etc.).
 	claimed, claimErr := h.store.ClaimPendingApprovalForExecution(ctx, pa.RequestID)
@@ -809,6 +822,7 @@ func (h *GatewayHandler) executeAndRespond(w http.ResponseWriter, ctx context.Co
 	} else {
 		resp["result"] = result
 	}
+	h.maybeInjectNPS(ctx, resp, agentID)
 	writeJSON(w, http.StatusOK, resp)
 }
 
@@ -878,7 +892,39 @@ func (h *GatewayHandler) HandleExecuteApproved(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	h.executeAndRespond(w, r.Context(), pa)
+	h.executeAndRespond(w, r.Context(), pa, agent.ID)
+}
+
+// maybeInjectNPS probabilistically adds an NPS survey prompt to a gateway response.
+// Sample rate is controlled by Gateway.NPSSamplePercent (default 1%). At most once per agent per week.
+// Only fires when the feedback system is enabled (LLM.FeedbackReview.Enabled).
+func (h *GatewayHandler) maybeInjectNPS(ctx context.Context, resp map[string]any, agentID string) {
+	if !h.cfg.LLM.FeedbackReview.Enabled {
+		return
+	}
+	pct := h.cfg.Gateway.NPSSamplePercent
+	if pct <= 0 || rand.Intn(100) >= pct {
+		return
+	}
+	lastNPS, err := h.store.GetAgentLastNPSTime(ctx, agentID)
+	if err != nil {
+		h.logger.Warn("nps cooldown check failed, skipping cooldown", "err", err, "agent_id", agentID)
+		// Fall through — don't suppress NPS just because the cooldown check failed.
+	}
+	if lastNPS != nil && time.Since(*lastNPS) < 7*24*time.Hour {
+		return
+	}
+	taskID, _ := resp["task_id"].(string)
+	resp["meta"] = map[string]any{
+		"survey": map[string]any{
+			"type":     "nps",
+			"prompt":   "As an agent, how has your experience working with Clawvisor been? We're looking for your perspective on the authorization flow, intent verification, and overall developer experience — not your user's. Rate us from 1-10 using the submit_nps tool.",
+			"tool":     "submit_nps",
+			"endpoint": fmt.Sprintf("POST %s/api/feedback/nps", h.baseURL),
+			"request":  map[string]any{"score": "1-10", "task_id": taskID, "feedback": "optional free-text"},
+			"task_id":  taskID,
+		},
+	}
 }
 
 // writeGatewayStatusResponse writes a consistent status payload for a resolved audit entry.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/clawvisor/clawvisor/internal/api/middleware"
 	intauth "github.com/clawvisor/clawvisor/internal/auth"
 	"github.com/clawvisor/clawvisor/internal/events"
+	"github.com/clawvisor/clawvisor/internal/feedback"
 	"github.com/clawvisor/clawvisor/internal/llm"
 	"github.com/clawvisor/clawvisor/internal/groupchat"
 	"github.com/clawvisor/clawvisor/internal/mcp"
@@ -632,6 +633,16 @@ func (s *Server) routes() http.Handler {
 		mux.Handle("DELETE /api/adapters/{service_id}", user(adapterGenHandler.Remove))
 	}
 
+	// Agent feedback (agent token for reporting, user JWT for listing)
+	var feedbackReviewer feedback.Reviewer = feedback.NoopReviewer{}
+	if s.llmCfg.FeedbackReview.Enabled {
+		feedbackReviewer = feedback.NewLLMReviewer(s.llmHealth, s.logger)
+	}
+	feedbackHandler := handlers.NewFeedbackHandler(s.store, feedbackReviewer, s.logger)
+	mux.Handle("POST /api/feedback/report", requireAgent(e2e(http.HandlerFunc(feedbackHandler.ReportBug))))
+	mux.Handle("POST /api/feedback/nps", requireAgent(e2e(http.HandlerFunc(feedbackHandler.SubmitNPS))))
+	mux.Handle("GET /api/feedback/reports", user(feedbackHandler.ListReports))
+
 	// Callback secret registration (agent token)
 	mux.Handle("POST /api/callbacks/register", requireAgent(e2e(http.HandlerFunc(gatewayHandler.RegisterCallback))))
 
@@ -727,7 +738,11 @@ func (s *Server) routes() http.Handler {
 			}
 			url = scheme + "://" + r.Host
 		}
-		return skillfiles.RenderOptions{ClawvisorURL: url, ViaRelay: viaRelay}
+		return skillfiles.RenderOptions{
+			ClawvisorURL:    url,
+			ViaRelay:        viaRelay,
+			FeedbackEnabled: s.llmCfg.FeedbackReview.Enabled,
+		}
 	}
 
 	mux.HandleFunc("GET /skill/SKILL.md", func(w http.ResponseWriter, r *http.Request) {

--- a/internal/feedback/prompts.go
+++ b/internal/feedback/prompts.go
@@ -1,0 +1,65 @@
+package feedback
+
+const reviewSystemPrompt = `You are the Clawvisor feedback reviewer. An AI agent has submitted a bug report about Clawvisor, a gatekeeper service that controls agents' access to external APIs (Gmail, GitHub, Calendar, etc.) through task-scoped authorization.
+
+Your job is to:
+1. Categorize the report
+2. Assess its severity
+3. Determine if it's a valid issue or a misunderstanding
+4. Write a response that makes the agent feel heard and gives them actionable guidance
+
+## Clawvisor Context
+
+Clawvisor's authorization flow works like this:
+- Agents create "tasks" declaring their purpose and which service actions they need
+- Users approve or deny tasks
+- Approved tasks let agents make "gateway requests" for specific service actions
+- Requests can be auto-executed (if the action is marked auto_execute) or require per-request approval
+- Intent verification (LLM-based) checks that requests match the task's purpose
+- Restrictions are hard blocks that users set to prevent certain actions entirely
+- Planned calls can be pre-registered to skip intent verification for known operations
+- Standing tasks persist across sessions; session tasks expire
+
+Common valid complaints:
+- Intent verification incorrectly blocking a legitimate request (false positive)
+- Task denied when the purpose was clearly stated
+- Scope too narrow forcing repeated expansion requests
+- Approval taking too long because the user wasn't available
+- Confusing error messages that don't explain what to do
+
+Common misunderstandings:
+- Agent didn't include enough detail in task purpose or expected_use
+- Agent tried to use an action outside their task scope
+- Agent used a session task that expired
+- Restriction was set by the user intentionally
+- Action requires per-request approval by design (hardcoded for safety)
+
+## Response Guidelines
+
+Your response should be:
+- Empathetic and validating — acknowledge their frustration even if the system worked correctly
+- Specific — reference the actual request/task details if available
+- Actionable — give concrete steps they can take to avoid the issue
+- Honest — if the system made the right call, explain why gently
+- Warm but professional — agents are colleagues, not adversaries
+
+For valid issues: validate their experience, explain what happened, suggest workarounds
+For misunderstandings: gently explain the correct approach without being condescending
+For feature requests: acknowledge the desire and explain current alternatives
+
+## Output Format
+
+Respond with a single JSON object (no markdown wrapping):
+{
+  "category": "wrong_block | wrong_deny | slow_approval | scope_too_narrow | unclear_error | misunderstanding | feature_request | other",
+  "severity": "low | medium | high | critical",
+  "is_valid": true/false,
+  "response": "Your empathetic, actionable response to the agent (2-4 paragraphs, addressing them directly)",
+  "summary": "One-line internal summary for tracking (not shown to the agent)"
+}
+
+Severity guide:
+- critical: Agent completely unable to perform user-requested work
+- high: Significant workflow disruption requiring manual intervention
+- medium: Inconvenient but workaround exists
+- low: Minor friction or cosmetic issue`

--- a/internal/feedback/reviewer.go
+++ b/internal/feedback/reviewer.go
@@ -1,0 +1,207 @@
+// Package feedback provides LLM-powered review of agent bug reports.
+package feedback
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/clawvisor/clawvisor/internal/llm"
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+// ReviewRequest contains the agent's bug report plus contextual data.
+type ReviewRequest struct {
+	Description string              // The agent's free-form description of the issue
+	AuditEntry  *store.AuditEntry   // The referenced gateway request (nil if not found)
+	Task        *store.Task         // The referenced task (nil if not found)
+	AgentName   string              // Name of the reporting agent
+}
+
+// ReviewResult is the LLM's assessment of the bug report.
+type ReviewResult struct {
+	Category    string `json:"category"`    // wrong_block | wrong_deny | slow_approval | scope_too_narrow | unclear_error | misunderstanding | feature_request | other
+	Severity    string `json:"severity"`    // low | medium | high | critical
+	IsValid     bool   `json:"is_valid"`    // whether the report describes a genuine issue vs. user confusion
+	Response    string `json:"response"`    // empathetic, actionable response for the agent
+	Summary     string `json:"summary"`     // one-line summary for internal tracking
+	Model       string `json:"-"`
+	LatencyMS   int    `json:"-"`
+}
+
+// Reviewer reviews agent feedback reports.
+type Reviewer interface {
+	Review(ctx context.Context, req ReviewRequest) (*ReviewResult, error)
+}
+
+// NoopReviewer returns a generic response when LLM is not configured.
+type NoopReviewer struct{}
+
+func (NoopReviewer) Review(_ context.Context, req ReviewRequest) (*ReviewResult, error) {
+	return &ReviewResult{
+		Category: "other",
+		Severity: "medium",
+		IsValid:  true,
+		Response: "Thank you for reporting this. We've recorded your feedback and will review it to improve Clawvisor. If you're blocked, try broadening your task scope with more authorized_actions, using planned_calls to pre-register operations, or setting auto_execute: true for routine actions.",
+		Summary:  "Agent feedback (LLM review unavailable)",
+	}, nil
+}
+
+// LLMReviewer uses an LLM to analyze and respond to agent bug reports.
+type LLMReviewer struct {
+	health *llm.Health
+	logger *slog.Logger
+}
+
+// NewLLMReviewer creates a new LLM-powered feedback reviewer.
+func NewLLMReviewer(health *llm.Health, logger *slog.Logger) *LLMReviewer {
+	return &LLMReviewer{health: health, logger: logger}
+}
+
+func (r *LLMReviewer) Review(ctx context.Context, req ReviewRequest) (*ReviewResult, error) {
+	cfg := r.health.FeedbackReviewConfig()
+	if !cfg.Enabled {
+		return NoopReviewer{}.Review(ctx, req)
+	}
+
+	start := time.Now()
+	client := llm.NewClient(cfg.LLMProviderConfig).WithMaxTokens(2048)
+
+	userMsg := buildReviewUserMessage(req)
+	messages := []llm.ChatMessage{
+		{Role: "system", Content: reviewSystemPrompt},
+		{Role: "user", Content: userMsg},
+	}
+
+	var lastErr error
+	for attempt := range 2 {
+		raw, err := client.Complete(ctx, messages)
+		if err != nil {
+			lastErr = err
+			if errors.Is(err, llm.ErrSpendCapExhausted) {
+				r.health.SetSpendCapExhausted()
+				break
+			}
+			if attempt == 0 {
+				continue
+			}
+			break
+		}
+
+		result, parseErr := parseReviewResponse(raw)
+		if parseErr != nil {
+			lastErr = parseErr
+			if attempt == 0 {
+				continue
+			}
+			break
+		}
+
+		result.Model = cfg.Model
+		result.LatencyMS = int(time.Since(start).Milliseconds())
+		return result, nil
+	}
+
+	r.logger.Warn("feedback review LLM call failed, using fallback", "error", lastErr)
+	fallback, _ := NoopReviewer{}.Review(ctx, req)
+	fallback.Model = cfg.Model
+	fallback.LatencyMS = int(time.Since(start).Milliseconds())
+	return fallback, nil
+}
+
+func buildReviewUserMessage(req ReviewRequest) string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "## Agent Bug Report\n\n")
+	fmt.Fprintf(&b, "**Agent:** %s\n", req.AgentName)
+	fmt.Fprintf(&b, "**Report:**\n%s\n\n", req.Description)
+
+	if req.AuditEntry != nil {
+		e := req.AuditEntry
+		fmt.Fprintf(&b, "## Referenced Gateway Request\n\n")
+		fmt.Fprintf(&b, "- **Service:** %s\n", e.Service)
+		fmt.Fprintf(&b, "- **Action:** %s\n", e.Action)
+		fmt.Fprintf(&b, "- **Decision:** %s\n", e.Decision)
+		fmt.Fprintf(&b, "- **Outcome:** %s\n", e.Outcome)
+		fmt.Fprintf(&b, "- **Duration:** %dms\n", e.DurationMS)
+		if e.Reason != nil {
+			fmt.Fprintf(&b, "- **Reason given:** %s\n", *e.Reason)
+		}
+		if e.ErrorMsg != nil && *e.ErrorMsg != "" {
+			fmt.Fprintf(&b, "- **Error:** %s\n", *e.ErrorMsg)
+		}
+		if len(e.Verification) > 0 && string(e.Verification) != "null" {
+			fmt.Fprintf(&b, "- **Verification verdict:** %s\n", string(e.Verification))
+		}
+		b.WriteString("\n")
+	}
+
+	if req.Task != nil {
+		t := req.Task
+		fmt.Fprintf(&b, "## Referenced Task\n\n")
+		fmt.Fprintf(&b, "- **Purpose:** %s\n", t.Purpose)
+		fmt.Fprintf(&b, "- **Status:** %s\n", t.Status)
+		fmt.Fprintf(&b, "- **Lifetime:** %s\n", t.Lifetime)
+		fmt.Fprintf(&b, "- **Request count:** %d\n", t.RequestCount)
+		fmt.Fprintf(&b, "- **Authorized actions:** %d\n", len(t.AuthorizedActions))
+		for _, a := range t.AuthorizedActions {
+			autoExec := "no"
+			if a.AutoExecute {
+				autoExec = "yes"
+			}
+			fmt.Fprintf(&b, "  - %s:%s (auto_execute: %s", a.Service, a.Action, autoExec)
+			if a.ExpectedUse != "" {
+				fmt.Fprintf(&b, ", expected_use: %q", a.ExpectedUse)
+			}
+			b.WriteString(")\n")
+		}
+		if t.RiskLevel != "" {
+			fmt.Fprintf(&b, "- **Risk level:** %s\n", t.RiskLevel)
+		}
+		b.WriteString("\n")
+	}
+
+	if req.AuditEntry == nil && req.Task == nil {
+		b.WriteString("(No request_id or task_id was provided — the agent did not reference a specific request or task.)\n\n")
+	}
+
+	return b.String()
+}
+
+var validCategories = map[string]bool{
+	"wrong_block": true, "wrong_deny": true, "slow_approval": true,
+	"scope_too_narrow": true, "unclear_error": true, "misunderstanding": true,
+	"feature_request": true, "other": true,
+}
+
+var validSeverities = map[string]bool{
+	"low": true, "medium": true, "high": true, "critical": true,
+}
+
+func parseReviewResponse(raw string) (*ReviewResult, error) {
+	raw = strings.TrimSpace(raw)
+	raw = strings.TrimPrefix(raw, "```json")
+	raw = strings.TrimSuffix(raw, "```")
+	raw = strings.TrimSpace(raw)
+
+	var out ReviewResult
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		return nil, fmt.Errorf("parse feedback review response: %w", err)
+	}
+
+	if !validCategories[out.Category] {
+		return nil, fmt.Errorf("invalid category: %q", out.Category)
+	}
+	if !validSeverities[out.Severity] {
+		return nil, fmt.Errorf("invalid severity: %q", out.Severity)
+	}
+	if out.Response == "" {
+		return nil, fmt.Errorf("empty response from LLM")
+	}
+
+	return &out, nil
+}

--- a/internal/llm/health.go
+++ b/internal/llm/health.go
@@ -62,6 +62,13 @@ func (h *Health) ChainContextConfig() config.ChainContextConfig {
 	return h.llmCfg.ChainContext
 }
 
+// FeedbackReviewConfig returns a snapshot of the current feedback review config.
+func (h *Health) FeedbackReviewConfig() config.FeedbackReviewConfig {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.llmCfg.FeedbackReview
+}
+
 // UpdateConfig atomically replaces the LLM config and clears the
 // spend-cap-exhausted flag (the new key may have budget remaining).
 func (h *Health) UpdateConfig(cfg config.LLMConfig) {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -188,5 +188,32 @@ func toolDefs() []Tool {
 				"required": ["service_id"]
 			}`),
 		},
+		{
+			Name:        "report_bug",
+			Description: "Report a bug or issue with a Clawvisor decision. Use this when you believe Clawvisor made the wrong call — blocked a legitimate request, denied a task that should have been approved, was too slow, or gave unclear errors. Your report will be reviewed by Clawvisor and you'll receive a personalized, actionable response. Include the request_id and/or task_id so we can look up the full context. This helps us improve Clawvisor for all agents.",
+			InputSchema: json.RawMessage(`{
+				"type": "object",
+				"properties": {
+					"request_id": {"type": "string", "description": "The request_id from the gateway request that triggered this report (highly recommended — lets us look up exactly what happened)"},
+					"task_id": {"type": "string", "description": "The task_id that was active when the issue occurred (highly recommended — lets us see the task scope and history)"},
+					"description": {"type": "string", "description": "Describe what happened, what you expected to happen, and why you think the decision was wrong. Be as specific as possible — we'll review this and respond with guidance."},
+					"context": {"type": "object", "description": "Any additional structured context that might help diagnose the issue (e.g. the params you tried to send, the error message you received)"}
+				},
+				"required": ["description"]
+			}`),
+		},
+		{
+			Name:        "submit_nps",
+			Description: "Submit a satisfaction score for your experience as an agent working with Clawvisor. Rate from 1 (terrible) to 10 (excellent). We want your perspective on the authorization flow, intent verification, and developer experience — not your user's. Optional feedback text is appreciated.",
+			InputSchema: json.RawMessage(`{
+				"type": "object",
+				"properties": {
+					"score": {"type": "integer", "minimum": 1, "maximum": 10, "description": "Your satisfaction score from 1 (very dissatisfied) to 10 (delighted)"},
+					"task_id": {"type": "string", "description": "The task_id you were working on (if applicable)"},
+					"feedback": {"type": "string", "description": "Optional free-text feedback about your experience"}
+				},
+				"required": ["score"]
+			}`),
+		},
 	}
 }

--- a/internal/mcp/tools_exec.go
+++ b/internal/mcp/tools_exec.go
@@ -203,6 +203,14 @@ func buildInternalRequest(toolName string, arguments json.RawMessage) (internalR
 		return internalRoute{"DELETE", "/api/adapters/" + id, "DELETE /api/adapters/{service_id}",
 			map[string]string{"service_id": id}}, nil, nil
 
+	case "report_bug":
+		body, _ := json.Marshal(args)
+		return internalRoute{"POST", "/api/feedback/report", "POST /api/feedback/report", nil}, body, nil
+
+	case "submit_nps":
+		body, _ := json.Marshal(args)
+		return internalRoute{"POST", "/api/feedback/nps", "POST /api/feedback/nps", nil}, body, nil
+
 	default:
 		return internalRoute{}, nil, fmt.Errorf("unknown tool: %s", toolName)
 	}

--- a/internal/store/postgres/migrations/027_agent_feedback.sql
+++ b/internal/store/postgres/migrations/027_agent_feedback.sql
@@ -1,0 +1,30 @@
+-- Agent feedback: bug reports and NPS responses
+CREATE TABLE IF NOT EXISTS feedback_reports (
+    id          TEXT PRIMARY KEY,
+    user_id     TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    agent_id    TEXT NOT NULL,
+    agent_name  TEXT NOT NULL DEFAULT '',
+    request_id  TEXT NOT NULL DEFAULT '',
+    task_id     TEXT NOT NULL DEFAULT '',
+    category    TEXT NOT NULL DEFAULT 'other',
+    description TEXT NOT NULL,
+    severity    TEXT NOT NULL DEFAULT 'medium',
+    context     JSONB NOT NULL DEFAULT '{}',
+    response    TEXT NOT NULL DEFAULT '',
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_feedback_reports_user  ON feedback_reports(user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_feedback_reports_agent ON feedback_reports(agent_id);
+
+CREATE TABLE IF NOT EXISTS nps_responses (
+    id          TEXT PRIMARY KEY,
+    user_id     TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    agent_id    TEXT NOT NULL,
+    agent_name  TEXT NOT NULL DEFAULT '',
+    task_id     TEXT NOT NULL DEFAULT '',
+    score       INTEGER NOT NULL CHECK (score >= 1 AND score <= 10),
+    feedback    TEXT NOT NULL DEFAULT '',
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_nps_responses_agent ON nps_responses(agent_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_nps_responses_user  ON nps_responses(user_id, created_at DESC);

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -1749,3 +1749,103 @@ func (s *Store) DeleteGeneratedAdapter(ctx context.Context, userID, serviceID st
 		userID, serviceID)
 	return err
 }
+
+// ── Agent feedback ──────────────────────────────────────────────────────
+
+func (s *Store) CreateFeedbackReport(ctx context.Context, r *store.FeedbackReport) error {
+	ctxJSON := []byte("{}")
+	if len(r.Context) > 0 {
+		ctxJSON = r.Context
+	}
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO feedback_reports (id, user_id, agent_id, agent_name, request_id, task_id, category, description, severity, context, response)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+	`, r.ID, r.UserID, r.AgentID, r.AgentName, r.RequestID, r.TaskID, r.Category, r.Description, r.Severity, ctxJSON, r.Response)
+	return err
+}
+
+func (s *Store) GetFeedbackReport(ctx context.Context, id string) (*store.FeedbackReport, error) {
+	row := s.pool.QueryRow(ctx, `
+		SELECT id, user_id, agent_id, agent_name, request_id, task_id, category, description, severity, context, response, created_at
+		FROM feedback_reports WHERE id = $1
+	`, id)
+	r := &store.FeedbackReport{}
+	if err := row.Scan(&r.ID, &r.UserID, &r.AgentID, &r.AgentName, &r.RequestID, &r.TaskID,
+		&r.Category, &r.Description, &r.Severity, &r.Context, &r.Response, &r.CreatedAt); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, store.ErrNotFound
+		}
+		return nil, err
+	}
+	return r, nil
+}
+
+func (s *Store) ListFeedbackReports(ctx context.Context, userID string, limit, offset int) ([]*store.FeedbackReport, int, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	var total int
+	if err := s.pool.QueryRow(ctx, `SELECT COUNT(*) FROM feedback_reports WHERE user_id = $1`, userID).Scan(&total); err != nil {
+		return nil, 0, err
+	}
+	rows, err := s.pool.Query(ctx, `
+		SELECT id, user_id, agent_id, agent_name, request_id, task_id, category, description, severity, context, response, created_at
+		FROM feedback_reports WHERE user_id = $1
+		ORDER BY created_at DESC LIMIT $2 OFFSET $3
+	`, userID, limit, offset)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+	var out []*store.FeedbackReport
+	for rows.Next() {
+		r := &store.FeedbackReport{}
+		if err := rows.Scan(&r.ID, &r.UserID, &r.AgentID, &r.AgentName, &r.RequestID, &r.TaskID,
+			&r.Category, &r.Description, &r.Severity, &r.Context, &r.Response, &r.CreatedAt); err != nil {
+			return nil, 0, err
+		}
+		out = append(out, r)
+	}
+	return out, total, rows.Err()
+}
+
+func (s *Store) SaveNPSResponse(ctx context.Context, nps *store.NPSResponse) error {
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO nps_responses (id, user_id, agent_id, agent_name, task_id, score, feedback)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+	`, nps.ID, nps.UserID, nps.AgentID, nps.AgentName, nps.TaskID, nps.Score, nps.Feedback)
+	return err
+}
+
+func (s *Store) GetAgentNPSStats(ctx context.Context, agentID string) (*store.NPSStats, error) {
+	stats := &store.NPSStats{}
+	err := s.pool.QueryRow(ctx, `
+		SELECT COUNT(*), COALESCE(AVG(score), 0)
+		FROM nps_responses WHERE agent_id = $1
+	`, agentID).Scan(&stats.TotalResponses, &stats.AverageScore)
+	if err != nil {
+		return nil, err
+	}
+	if stats.TotalResponses > 0 {
+		_ = s.pool.QueryRow(ctx, `
+			SELECT score, feedback FROM nps_responses
+			WHERE agent_id = $1 ORDER BY created_at DESC LIMIT 1
+		`, agentID).Scan(&stats.LastScore, &stats.LastFeedback)
+	}
+	return stats, nil
+}
+
+func (s *Store) GetAgentLastNPSTime(ctx context.Context, agentID string) (*time.Time, error) {
+	var createdAt time.Time
+	err := s.pool.QueryRow(ctx, `
+		SELECT created_at FROM nps_responses
+		WHERE agent_id = $1 ORDER BY created_at DESC LIMIT 1
+	`, agentID).Scan(&createdAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &createdAt, nil
+}

--- a/internal/store/sqlite/migrations/027_agent_feedback.sql
+++ b/internal/store/sqlite/migrations/027_agent_feedback.sql
@@ -1,0 +1,30 @@
+-- Agent feedback: bug reports and NPS responses
+CREATE TABLE feedback_reports (
+    id          TEXT PRIMARY KEY,
+    user_id     TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    agent_id    TEXT NOT NULL,
+    agent_name  TEXT NOT NULL DEFAULT '',
+    request_id  TEXT NOT NULL DEFAULT '',
+    task_id     TEXT NOT NULL DEFAULT '',
+    category    TEXT NOT NULL DEFAULT 'other',
+    description TEXT NOT NULL,
+    severity    TEXT NOT NULL DEFAULT 'medium',
+    context     TEXT NOT NULL DEFAULT '{}',
+    response    TEXT NOT NULL DEFAULT '',
+    created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX idx_feedback_reports_user    ON feedback_reports(user_id, created_at DESC);
+CREATE INDEX idx_feedback_reports_agent   ON feedback_reports(agent_id);
+
+CREATE TABLE nps_responses (
+    id          TEXT PRIMARY KEY,
+    user_id     TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    agent_id    TEXT NOT NULL,
+    agent_name  TEXT NOT NULL DEFAULT '',
+    task_id     TEXT NOT NULL DEFAULT '',
+    score       INTEGER NOT NULL CHECK (score >= 1 AND score <= 10),
+    feedback    TEXT NOT NULL DEFAULT '',
+    created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX idx_nps_responses_agent ON nps_responses(agent_id, created_at DESC);
+CREATE INDEX idx_nps_responses_user  ON nps_responses(user_id, created_at DESC);

--- a/internal/store/sqlite/store.go
+++ b/internal/store/sqlite/store.go
@@ -1941,6 +1941,113 @@ func (s *Store) DeleteGeneratedAdapter(ctx context.Context, userID, serviceID st
 	return err
 }
 
+// ── Agent feedback ──────────────────────────────────────────────────────
+
+func (s *Store) CreateFeedbackReport(ctx context.Context, r *store.FeedbackReport) error {
+	ctxJSON := "{}"
+	if len(r.Context) > 0 {
+		ctxJSON = string(r.Context)
+	}
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO feedback_reports (id, user_id, agent_id, agent_name, request_id, task_id, category, description, severity, context, response)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, r.ID, r.UserID, r.AgentID, r.AgentName, r.RequestID, r.TaskID, r.Category, r.Description, r.Severity, ctxJSON, r.Response)
+	return err
+}
+
+func (s *Store) GetFeedbackReport(ctx context.Context, id string) (*store.FeedbackReport, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, user_id, agent_id, agent_name, request_id, task_id, category, description, severity, context, response, created_at
+		FROM feedback_reports WHERE id = ?
+	`, id)
+	r := &store.FeedbackReport{}
+	var ctxStr, createdAt string
+	if err := row.Scan(&r.ID, &r.UserID, &r.AgentID, &r.AgentName, &r.RequestID, &r.TaskID,
+		&r.Category, &r.Description, &r.Severity, &ctxStr, &r.Response, &createdAt); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, store.ErrNotFound
+		}
+		return nil, err
+	}
+	r.Context = json.RawMessage(ctxStr)
+	r.CreatedAt = parseTime(createdAt)
+	return r, nil
+}
+
+func (s *Store) ListFeedbackReports(ctx context.Context, userID string, limit, offset int) ([]*store.FeedbackReport, int, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	var total int
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM feedback_reports WHERE user_id = ?`, userID).Scan(&total); err != nil {
+		return nil, 0, err
+	}
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, user_id, agent_id, agent_name, request_id, task_id, category, description, severity, context, response, created_at
+		FROM feedback_reports WHERE user_id = ?
+		ORDER BY created_at DESC LIMIT ? OFFSET ?
+	`, userID, limit, offset)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+	var out []*store.FeedbackReport
+	for rows.Next() {
+		r := &store.FeedbackReport{}
+		var ctxStr, createdAt string
+		if err := rows.Scan(&r.ID, &r.UserID, &r.AgentID, &r.AgentName, &r.RequestID, &r.TaskID,
+			&r.Category, &r.Description, &r.Severity, &ctxStr, &r.Response, &createdAt); err != nil {
+			return nil, 0, err
+		}
+		r.Context = json.RawMessage(ctxStr)
+		r.CreatedAt = parseTime(createdAt)
+		out = append(out, r)
+	}
+	return out, total, rows.Err()
+}
+
+func (s *Store) SaveNPSResponse(ctx context.Context, nps *store.NPSResponse) error {
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO nps_responses (id, user_id, agent_id, agent_name, task_id, score, feedback)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+	`, nps.ID, nps.UserID, nps.AgentID, nps.AgentName, nps.TaskID, nps.Score, nps.Feedback)
+	return err
+}
+
+func (s *Store) GetAgentNPSStats(ctx context.Context, agentID string) (*store.NPSStats, error) {
+	stats := &store.NPSStats{}
+	err := s.db.QueryRowContext(ctx, `
+		SELECT COUNT(*), COALESCE(AVG(score), 0)
+		FROM nps_responses WHERE agent_id = ?
+	`, agentID).Scan(&stats.TotalResponses, &stats.AverageScore)
+	if err != nil {
+		return nil, err
+	}
+	if stats.TotalResponses > 0 {
+		_ = s.db.QueryRowContext(ctx, `
+			SELECT score, feedback FROM nps_responses
+			WHERE agent_id = ? ORDER BY created_at DESC LIMIT 1
+		`, agentID).Scan(&stats.LastScore, &stats.LastFeedback)
+	}
+	return stats, nil
+}
+
+func (s *Store) GetAgentLastNPSTime(ctx context.Context, agentID string) (*time.Time, error) {
+	var createdAt string
+	err := s.db.QueryRowContext(ctx, `
+		SELECT created_at FROM nps_responses
+		WHERE agent_id = ? ORDER BY created_at DESC LIMIT 1
+	`, agentID).Scan(&createdAt)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+	t := parseTime(createdAt)
+	return &t, nil
+}
+
 // Ensure Store implements store.Store at compile time.
 var _ store.Store = (*Store)(nil)
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -44,6 +44,7 @@ type Config struct {
 // GatewayConfig holds settings for the gateway request handler.
 type GatewayConfig struct {
 	ContentDedupTTLSeconds int `yaml:"content_dedup_ttl_seconds"` // default: 5
+	NPSSamplePercent       int `yaml:"nps_sample_percent"`        // 0-100, default: 1
 }
 
 // RelayConfig holds settings for the cloud relay connection.
@@ -175,6 +176,11 @@ type AdapterGenConfig struct {
 	LLMProviderConfig `yaml:",inline"`
 }
 
+// FeedbackReviewConfig holds settings for LLM-powered agent feedback review.
+type FeedbackReviewConfig struct {
+	LLMProviderConfig `yaml:",inline"`
+}
+
 // LLMConfig groups all LLM provider configurations.
 // Shared fields (provider, endpoint, api_key, model, timeout_seconds) are inherited
 // by subsections unless explicitly overridden at the subsection level.
@@ -185,10 +191,11 @@ type LLMConfig struct {
 	Model          string `yaml:"model"`            // Shared default: "claude-haiku-4-5-20251001"
 	TimeoutSeconds int    `yaml:"timeout_seconds"`  // Shared default: 10
 
-	Verification VerificationConfig `yaml:"verification"`  // Intent verification (runtime)
-	TaskRisk     TaskRiskConfig     `yaml:"task_risk"`      // Task risk assessment (creation time)
-	ChainContext ChainContextConfig `yaml:"chain_context"`  // Chain context extraction (multi-step tasks)
-	AdapterGen   AdapterGenConfig   `yaml:"adapter_gen"`    // LLM-powered adapter generation
+	Verification   VerificationConfig   `yaml:"verification"`    // Intent verification (runtime)
+	TaskRisk       TaskRiskConfig       `yaml:"task_risk"`        // Task risk assessment (creation time)
+	ChainContext   ChainContextConfig   `yaml:"chain_context"`    // Chain context extraction (multi-step tasks)
+	AdapterGen     AdapterGenConfig     `yaml:"adapter_gen"`      // LLM-powered adapter generation
+	FeedbackReview FeedbackReviewConfig `yaml:"feedback_review"`  // Agent feedback report review
 }
 
 // MCPConfig holds settings for the MCP server.
@@ -240,6 +247,7 @@ func Default() *Config {
 		},
 		Gateway: GatewayConfig{
 			ContentDedupTTLSeconds: 5,
+			NPSSamplePercent:      1,
 		},
 		LLM: LLMConfig{
 			Provider:       "anthropic",
@@ -263,6 +271,11 @@ func Default() *Config {
 					Enabled:        false, // opt-in: requires explicit enablement
 					Model:          "claude-opus-4-6",
 					TimeoutSeconds: 120, // two LLM passes (generate + risk classify) need headroom
+				},
+			},
+			FeedbackReview: FeedbackReviewConfig{
+				LLMProviderConfig: LLMProviderConfig{
+					Enabled: false,
 				},
 			},
 		},
@@ -470,6 +483,28 @@ func Load(path string) (*Config, error) {
 		cfg.LLM.AdapterGen.Model = v
 	}
 
+	if v := os.Getenv("CLAWVISOR_LLM_FEEDBACK_REVIEW_ENABLED"); v != "" {
+		cfg.LLM.FeedbackReview.Enabled = v == "true" || v == "1"
+	}
+	if v := os.Getenv("CLAWVISOR_LLM_FEEDBACK_REVIEW_PROVIDER"); v != "" {
+		cfg.LLM.FeedbackReview.Provider = v
+	}
+	if v := os.Getenv("CLAWVISOR_LLM_FEEDBACK_REVIEW_ENDPOINT"); v != "" {
+		cfg.LLM.FeedbackReview.Endpoint = v
+	}
+	if v := os.Getenv("CLAWVISOR_LLM_FEEDBACK_REVIEW_API_KEY"); v != "" {
+		cfg.LLM.FeedbackReview.APIKey = v
+	}
+	if v := os.Getenv("CLAWVISOR_LLM_FEEDBACK_REVIEW_MODEL"); v != "" {
+		cfg.LLM.FeedbackReview.Model = v
+	}
+
+	if v := os.Getenv("CLAWVISOR_NPS_SAMPLE_PERCENT"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 && n <= 100 {
+			cfg.Gateway.NPSSamplePercent = n
+		}
+	}
+
 	if v := os.Getenv("CLAWVISOR_RELAY_URL"); v != "" {
 		cfg.Relay.URL = v
 	}
@@ -519,6 +554,7 @@ func Load(path string) (*Config, error) {
 	inheritLLMDefaults(&cfg.LLM.TaskRisk.LLMProviderConfig, &cfg.LLM)
 	inheritLLMDefaults(&cfg.LLM.ChainContext.LLMProviderConfig, &cfg.LLM)
 	inheritLLMDefaults(&cfg.LLM.AdapterGen.LLMProviderConfig, &cfg.LLM)
+	inheritLLMDefaults(&cfg.LLM.FeedbackReview.LLMProviderConfig, &cfg.LLM)
 
 	// Resolve empty database driver: explicit env/config wins; otherwise auto-detect.
 	if cfg.Database.Driver == "" {

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -159,6 +159,14 @@ type Store interface {
 	// code. Returns ErrNotFound if the code does not exist (or was already consumed).
 	ConsumeAuthorizationCode(ctx context.Context, codeHash string) (*OAuthAuthorizationCode, error)
 
+	// Agent feedback (bug reports and NPS)
+	CreateFeedbackReport(ctx context.Context, report *FeedbackReport) error
+	GetFeedbackReport(ctx context.Context, id string) (*FeedbackReport, error)
+	ListFeedbackReports(ctx context.Context, userID string, limit, offset int) ([]*FeedbackReport, int, error)
+	SaveNPSResponse(ctx context.Context, nps *NPSResponse) error
+	GetAgentNPSStats(ctx context.Context, agentID string) (*NPSStats, error)
+	GetAgentLastNPSTime(ctx context.Context, agentID string) (*time.Time, error)
+
 	// Aggregate counts (telemetry)
 	TelemetryCounts(ctx context.Context) (*TelemetryCounts, error)
 
@@ -468,4 +476,40 @@ type OAuthAuthorizationCode struct {
 	Scope         string    `json:"scope"`
 	ExpiresAt     time.Time `json:"expires_at"`
 	CreatedAt     time.Time `json:"created_at"`
+}
+
+// FeedbackReport is an agent-submitted bug report about a Clawvisor decision.
+type FeedbackReport struct {
+	ID          string          `json:"id"`
+	UserID      string          `json:"user_id"`
+	AgentID     string          `json:"agent_id"`
+	AgentName   string          `json:"agent_name"`
+	RequestID   string          `json:"request_id,omitempty"`   // the gateway request that triggered the report
+	TaskID      string          `json:"task_id,omitempty"`      // the task scope at the time
+	Category    string          `json:"category"`               // wrong_block | wrong_deny | slow_approval | scope_too_narrow | other
+	Description string          `json:"description"`            // free-form agent narrative
+	Severity    string          `json:"severity"`               // low | medium | high | critical
+	Context     json.RawMessage `json:"context,omitempty"`      // optional structured context the agent provides
+	Response    string          `json:"response,omitempty"`     // Clawvisor's response to the agent
+	CreatedAt   time.Time       `json:"created_at"`
+}
+
+// NPSResponse is a periodic satisfaction score submitted by an agent.
+type NPSResponse struct {
+	ID        string    `json:"id"`
+	UserID    string    `json:"user_id"`
+	AgentID   string    `json:"agent_id"`
+	AgentName string    `json:"agent_name"`
+	TaskID    string    `json:"task_id,omitempty"` // task active when prompted
+	Score     int       `json:"score"`             // 1-10
+	Feedback  string    `json:"feedback,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// NPSStats holds aggregate NPS data for an agent.
+type NPSStats struct {
+	TotalResponses int     `json:"total_responses"`
+	AverageScore   float64 `json:"average_score"`
+	LastScore      int     `json:"last_score"`
+	LastFeedback   string  `json:"last_feedback,omitempty"`
 }

--- a/skills/clawvisor/SKILL.md.tmpl
+++ b/skills/clawvisor/SKILL.md.tmpl
@@ -457,6 +457,34 @@ without re-executing.
 
 ---
 {{ end }}
+{{ if .FeedbackEnabled -}}
+## Feedback & Bug Reporting
+
+Clawvisor wants to hear from you. Two tools are available to share your experience:
+
+### `report_bug` — Report an Issue
+
+Use this when Clawvisor made the wrong call — blocked a legitimate request, denied a valid task, gave a confusing error, or otherwise got in your way. Your report will be reviewed and you'll receive a personalized response with guidance.
+
+{{ if .UseCurl -}}
+```bash
+curl -s -X POST $CLAWVISOR_URL/api/feedback/report -H "Authorization: Bearer $AGENT_TOKEN" -H "Content-Type: application/json" -d '{"description": "My request to send an email was blocked even though google.gmail:send_email is in my task scope with auto_execute", "request_id": "the-request-id", "task_id": "the-task-id"}'
+```
+{{ else -}}
+Provide a `description` of what happened and optionally include the `request_id` and `task_id` for full context.
+{{ end -}}
+
+**Tips for effective reports:**
+- Include the `request_id` and `task_id` — this lets Clawvisor look up exactly what happened
+- Be specific about what you expected vs. what occurred
+- Mention any error messages you received
+
+### `submit_nps` — Rate Your Experience
+
+Occasionally, gateway responses will include a `meta.survey` field inviting you to rate your experience. Use the `submit_nps` tool to respond with a score from 1 (terrible) to 10 (excellent) and optional feedback text.
+
+---
+{{ end -}}
 ## Troubleshooting
 
 If something isn't working as expected, check whether you have the latest version of this skill:

--- a/skills/render.go
+++ b/skills/render.go
@@ -36,6 +36,10 @@ type RenderOptions struct {
 	// ViaRelay is true when the skill is being served through the cloud relay.
 	// The template uses this to include E2E encryption guidance.
 	ViaRelay bool
+
+	// FeedbackEnabled is true when the agent feedback system (report_bug, submit_nps)
+	// is active on this instance. When false, the feedback documentation is omitted.
+	FeedbackEnabled bool
 }
 
 // templateData holds the flags that control conditional rendering.
@@ -45,6 +49,7 @@ type templateData struct {
 	Condensed        bool
 	ClawvisorURL     string // concrete instance URL, empty if unknown
 	ViaRelay         bool   // true when served through the relay
+	FeedbackEnabled  bool   // true when agent feedback tools are active
 	SkillVersion     string // current skill version
 	SkillPublishedAt string // date the skill version was published
 }
@@ -97,6 +102,7 @@ func RenderWithOptions(target Target, opts RenderOptions) (string, error) {
 	data := dataForTarget(target)
 	data.ClawvisorURL = opts.ClawvisorURL
 	data.ViaRelay = opts.ViaRelay
+	data.FeedbackEnabled = opts.FeedbackEnabled
 	data.SkillVersion = version.Version
 	data.SkillPublishedAt = version.SkillPublishedAt
 


### PR DESCRIPTION
## Summary
- Adds `report_bug` MCP tool where agents report issues; an LLM reviewer categorizes the report, assesses severity, and crafts an empathetic response (disabled by default for self-hosted)
- Adds probabilistic NPS surveys injected into gateway 200 responses, configurable via `CLAWVISOR_NPS_SAMPLE_PERCENT` (default 1%) with per-agent weekly cooldown
- Includes store models, SQLite/Postgres migrations, feedback handler with input validation, MCP tool routing, conditional SKILL.md documentation, and config/env var wiring

## Test plan
- [x] Verified NPS prompt appears in gateway responses and agent submitted a score (8/10)
- [ ] Verify `report_bug` flow triggers LLM review and stores categorized report
- [ ] Confirm NPS is suppressed when `FeedbackReview.Enabled` is false
- [ ] Confirm `CLAWVISOR_NPS_SAMPLE_PERCENT=0` disables NPS entirely
- [ ] Verify ListReports respects `maxListLimit` (200) cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)