### PR TITLE
fix: serve /skill/setup route on cloud deployments

### DIFF
--- a/internal/api/handlers/onboarding.go
+++ b/internal/api/handlers/onboarding.go
@@ -26,12 +26,7 @@ func NewOnboardingHandler(relayHost, daemonID string, isLocal bool) *OnboardingH
 
 // Setup serves the onboarding markdown document.
 func (h *OnboardingHandler) Setup(w http.ResponseWriter, r *http.Request) {
-	if h.daemonID == "" || h.relayHost == "" {
-		http.Error(w, "Daemon not registered with relay. Re-run `clawvisor setup`.", http.StatusServiceUnavailable)
-		return
-	}
-
-	clawvisorURL := fmt.Sprintf("https://%s/d/%s", h.relayHost, h.daemonID)
+	clawvisorURL := h.resolveURL(r)
 
 	var b strings.Builder
 	fmt.Fprintf(&b, "# Clawvisor Agent Setup\n\n")

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -719,9 +719,7 @@ func (s *Server) routes() http.Handler {
 	{
 		relayHost := relayHostFromCfg(s.cfg.Relay.URL)
 		onboardingHandler := handlers.NewOnboardingHandler(relayHost, s.daemonID, s.cfg.Server.IsLocal())
-		if s.daemonID != "" {
-			mux.HandleFunc("GET /skill/setup", onboardingHandler.Setup)
-		}
+		mux.HandleFunc("GET /skill/setup", onboardingHandler.Setup)
 		mux.HandleFunc("GET /skill/clawvisor-setup.md", onboardingHandler.ClaudeCodeSetup)
 	}
 	// skillRenderOpts builds RenderOptions based on whether the request


### PR DESCRIPTION
## Summary
- The `/skill/setup` route was gated behind a `daemonID != ""` check, so it was never registered on cloud/staging deployments
- Removed the guard so the route is always registered, matching `/skill/clawvisor-setup.md`
- Switched the handler from hardcoding the relay URL to using `resolveURL(r)`, which already handles both local and cloud contexts correctly

## Test plan
- [ ] Verify `https://app.staging.clawvisor.com/skill/setup?user_id=...` returns the setup markdown
- [ ] Verify local daemon still serves `/skill/setup` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)