### PR TITLE
fix: pass LocalDaemon feature flag through to API server

### DIFF
--- a/pkg/clawvisor/run.go
+++ b/pkg/clawvisor/run.go
@@ -25,6 +25,7 @@ func RunWithContext(ctx context.Context, opts *ServerOptions) error {
 		UsageMetering:     opts.Features.UsageMetering,
 		PasswordAuth:      opts.Features.PasswordAuth,
 		Billing:           opts.Features.Billing,
+		LocalDaemon:       opts.Features.LocalDaemon,
 	}))
 
 	if opts.ExtraRoutes != nil {


### PR DESCRIPTION
## Summary
- The `LocalDaemon` flag was set in `opts.Features` but never mapped into the `api.FeatureSet` in `RunWithContext`, so `/api/features` always returned `local_daemon: false` even when enabled by the cloud binary.

## Test plan
- [ ] Start cloud server, verify `/api/features` returns `local_daemon: true`
- [ ] Confirm local daemon pairing UI appears in Settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)