### PR TITLE
feat: open-source the local services connector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Go
 clawvisor
+clawvisor-local
 imessage-helper
 bin/
 dist/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-staging install test run run-sqlite run-staging migrate lint clean setup tui eval-intent release test-e2e-install test-e2e test-e2e-ci
+.PHONY: build build-staging build-local install install-local test run run-sqlite run-staging migrate lint clean setup tui eval-intent release test-e2e-install test-e2e test-e2e-ci
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null | sed 's/^v//' || echo dev)
 ENVIRONMENT ?= production
@@ -17,6 +17,15 @@ build-imessage-helper:
 	mkdir -p "bin/$(IMESSAGE_HELPER_APP)/Contents/MacOS"
 	cp bin/clawvisor-imessage-helper "bin/$(IMESSAGE_HELPER_APP)/Contents/MacOS/clawvisor-imessage-helper"
 	cp cmd/imessage-helper/Info.plist "bin/$(IMESSAGE_HELPER_APP)/Contents/Info.plist"
+
+build-local:
+	go build $(LDFLAGS) -o bin/clawvisor-local ./cmd/clawvisor-local
+
+install-local: build-local
+	mkdir -p $(HOME)/.clawvisor/bin
+	cp bin/clawvisor-local $(HOME)/.clawvisor/bin/clawvisor-local
+	[ "$$(uname)" = "Darwin" ] && codesign -s - $(HOME)/.clawvisor/bin/clawvisor-local 2>/dev/null || true
+	@echo "Installed clawvisor-local to ~/.clawvisor/bin/"
 
 build-staging: web/dist
 	$(MAKE) build ENVIRONMENT=staging

--- a/cmd/clawvisor-local/main.go
+++ b/cmd/clawvisor-local/main.go
@@ -1,0 +1,616 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/clawvisor/clawvisor/internal/local/config"
+	localdaemon "github.com/clawvisor/clawvisor/internal/local/daemon"
+	"github.com/clawvisor/clawvisor/internal/local/executor"
+	"github.com/clawvisor/clawvisor/internal/local/services"
+	"github.com/clawvisor/clawvisor/internal/local/state"
+	"github.com/clawvisor/clawvisor/pkg/version"
+)
+
+var (
+	flagConfigDir string
+	flagPort      int
+)
+
+func main() {
+	rootCmd := &cobra.Command{
+		Use:   "clawvisor-local",
+		Short: "Clawvisor local daemon",
+		Long:  "A lightweight daemon that bridges local services to the Clawvisor cloud.",
+		RunE:  runDaemon,
+	}
+
+	rootCmd.PersistentFlags().StringVar(&flagConfigDir, "config", "", "config directory (default: ~/.clawvisor/local)")
+	rootCmd.PersistentFlags().IntVar(&flagPort, "port", 0, "override listen port")
+
+	rootCmd.AddCommand(
+		statusCmd(),
+		servicesCmd(),
+		unpairCmd(),
+		reloadCmd(),
+		validateCmd(),
+		runCmd(),
+		installServiceCmd(),
+		uninstallServiceCmd(),
+	)
+
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func baseDir() string {
+	if flagConfigDir != "" {
+		return flagConfigDir
+	}
+	return config.BaseDir()
+}
+
+func runDaemon(cmd *cobra.Command, args []string) error {
+	d, err := localdaemon.New(baseDir())
+	if err != nil {
+		return err
+	}
+	if flagPort > 0 {
+		d.OverridePort(flagPort)
+	}
+	return d.Run()
+}
+
+func statusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Print pairing status, connection state, services",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			dir := baseDir()
+			cfg, err := config.Load(dir)
+			if err != nil {
+				return err
+			}
+
+			// Try to reach the running daemon for live status.
+			liveURL := fmt.Sprintf("http://127.0.0.1:%d/api/status", cfg.Port)
+			if body, err := httpGet(liveURL); err == nil {
+				return printLiveStatus(body)
+			}
+
+			// Fallback: offline status from local state + service scan.
+			st, err := state.Load(dir)
+			if err != nil {
+				return err
+			}
+
+			result := services.Discover(cfg.ServiceDirs, cfg.DefaultTimeout.Duration)
+
+			fmt.Printf("Daemon ID:    %s\n", st.DaemonID)
+			fmt.Printf("Name:         %s\n", cfg.Name)
+			fmt.Printf("Version:      %s\n", version.Version)
+			fmt.Printf("Connected:    no (daemon not running)\n")
+
+			if st.IsPaired() {
+				fmt.Printf("Paired:       yes (since %s)\n", st.PairedAt.Format("2006-01-02"))
+				fmt.Printf("Cloud:        %s\n", st.CloudOrigin)
+			} else {
+				fmt.Printf("Paired:       no\n")
+			}
+
+			fmt.Printf("Services:     %d loaded, %d excluded\n\n", len(result.Services), len(result.Excluded))
+
+			w := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
+			for _, svc := range result.Services {
+				fmt.Fprintf(w, "  %s\t%s\t%d actions\t%s\n", svc.ID, svc.Name, len(svc.Actions), svc.Type)
+			}
+			w.Flush()
+
+			if len(result.Excluded) > 0 {
+				fmt.Println("\nExcluded:")
+				for _, e := range result.Excluded {
+					fmt.Printf("  [%s] %s — %s\n", e.Category, e.Path, e.Error)
+				}
+			}
+
+			return nil
+		},
+	}
+}
+
+type liveStatus struct {
+	DaemonID      string        `json:"daemon_id"`
+	Name          string        `json:"name"`
+	Version       string        `json:"version"`
+	Paired        bool          `json:"paired"`
+	Connected     bool          `json:"connected"`
+	CloudOrigin   string        `json:"cloud_origin"`
+	UptimeSeconds int           `json:"uptime_seconds"`
+	Services      []liveService `json:"services"`
+	Excluded      []struct {
+		Category string `json:"category"`
+		Path     string `json:"path"`
+		Error    string `json:"error"`
+	} `json:"excluded_services"`
+}
+
+type liveService struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Type    string `json:"type"`
+	Status  string `json:"status"`
+	Actions []struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"actions"`
+}
+
+func printLiveStatus(body string) error {
+	var status liveStatus
+	if err := json.Unmarshal([]byte(body), &status); err != nil {
+		return fmt.Errorf("parsing status response: %w", err)
+	}
+
+	fmt.Printf("Daemon ID:    %s\n", status.DaemonID)
+	fmt.Printf("Name:         %s\n", status.Name)
+	fmt.Printf("Version:      %s\n", status.Version)
+
+	if status.Paired {
+		fmt.Printf("Paired:       yes\n")
+		fmt.Printf("Connected:    %v (to %s)\n", status.Connected, status.CloudOrigin)
+	} else {
+		fmt.Printf("Paired:       no\n")
+		fmt.Printf("Connected:    no\n")
+	}
+
+	hours := status.UptimeSeconds / 3600
+	minutes := (status.UptimeSeconds % 3600) / 60
+	if hours > 0 {
+		fmt.Printf("Uptime:       %dh %dm\n", hours, minutes)
+	} else {
+		fmt.Printf("Uptime:       %dm\n", minutes)
+	}
+
+	fmt.Printf("Services:     %d loaded, %d excluded\n\n", len(status.Services), len(status.Excluded))
+
+	w := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
+	for _, svc := range status.Services {
+		typeStr := svc.Type
+		if svc.Type == "server" && svc.Status != "" {
+			typeStr = fmt.Sprintf("server (%s)", svc.Status)
+		}
+		fmt.Fprintf(w, "  %s\t%s\t%d actions\t%s\n", svc.ID, svc.Name, len(svc.Actions), typeStr)
+	}
+	w.Flush()
+
+	if len(status.Excluded) > 0 {
+		fmt.Println("\nExcluded:")
+		for _, e := range status.Excluded {
+			fmt.Printf("  [%s] %s — %s\n", e.Category, e.Path, e.Error)
+		}
+	}
+
+	return nil
+}
+
+func httpGet(url string) (string, error) {
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}
+
+func servicesCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "services",
+		Short: "List discovered services and their actions",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			dir := baseDir()
+			cfg, err := config.Load(dir)
+			if err != nil {
+				return err
+			}
+
+			result := services.Discover(cfg.ServiceDirs, cfg.DefaultTimeout.Duration)
+
+			for _, svc := range result.Services {
+				header := fmt.Sprintf("%s (%s)", svc.ID, svc.Name)
+				if svc.Type == "server" {
+					header += "  [server]"
+				}
+				fmt.Println(header)
+
+				w := tabwriter.NewWriter(os.Stdout, 2, 4, 2, ' ', 0)
+				for _, a := range svc.Actions {
+					paramStrs := make([]string, 0, len(a.Params))
+					for _, p := range a.Params {
+						s := p.Name
+						if p.Required {
+							s += "*"
+						}
+						paramStrs = append(paramStrs, s)
+					}
+					params := "(none)"
+					if len(paramStrs) > 0 {
+						params = strings.Join(paramStrs, ", ")
+					}
+					fmt.Fprintf(w, "  %s\t%s\tparams: %s\n", a.ID, a.Name, params)
+				}
+				w.Flush()
+				fmt.Println()
+			}
+
+			return nil
+		},
+	}
+}
+
+func unpairCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "unpair",
+		Short: "Clear pairing state, disconnect from cloud",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			dir := baseDir()
+			st, err := state.Load(dir)
+			if err != nil {
+				return err
+			}
+
+			if err := state.Clear(dir, st.DaemonID); err != nil {
+				return err
+			}
+
+			fmt.Println("Pairing state cleared.")
+			return nil
+		},
+	}
+}
+
+func reloadCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "reload",
+		Short: "Re-scan services directory",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			dir := baseDir()
+			cfg, err := config.Load(dir)
+			if err != nil {
+				return err
+			}
+
+			// Send reload request to running daemon.
+			url := fmt.Sprintf("http://127.0.0.1:%d/api/services/reload", cfg.Port)
+			resp, err := httpPost(url)
+			if err != nil {
+				return fmt.Errorf("reload failed (is the daemon running?): %w", err)
+			}
+			fmt.Println(resp)
+			return nil
+		},
+	}
+}
+
+func validateCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "validate [PATH]",
+		Short: "Validate a service.yaml file or all discovered services",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			dir := baseDir()
+			cfg, err := config.Load(dir)
+			if err != nil {
+				return err
+			}
+
+			if len(args) > 0 {
+				// Validate a single file.
+				path := args[0]
+				svc, err := services.ParseManifest(path, cfg.DefaultTimeout.Duration)
+				if err != nil {
+					fmt.Printf("✗ %s\n  Error: %s\n", path, err)
+					os.Exit(1)
+				}
+				fmt.Printf("✓ service.yaml is valid\n")
+				fmt.Printf("  Name: %s\n", svc.Name)
+				fmt.Printf("  Type: %s\n", svc.Type)
+				actionIDs := make([]string, len(svc.Actions))
+				for i, a := range svc.Actions {
+					actionIDs[i] = a.ID
+				}
+				fmt.Printf("  Actions: %d (%s)\n", len(svc.Actions), strings.Join(actionIDs, ", "))
+
+				// Check for warnings.
+				for _, a := range svc.Actions {
+					if svc.Type == "exec" && len(a.Run) > 0 {
+						runPath := a.Run[0]
+						if _, statErr := os.Stat(runPath); statErr == nil {
+							info, _ := os.Stat(runPath)
+							if info != nil && info.Mode()&0111 == 0 {
+								fmt.Printf("  Warnings:\n    - Action %q: %s is not executable (chmod +x?)\n", a.ID, runPath)
+							}
+						}
+					}
+				}
+				return nil
+			}
+
+			// Validate all discovered services.
+			result := services.Discover(cfg.ServiceDirs, cfg.DefaultTimeout.Duration)
+			hasErrors := false
+
+			for _, svc := range result.Services {
+				fmt.Printf("✓ %s — %d actions\n", svc.ID, len(svc.Actions))
+			}
+			for _, e := range result.Excluded {
+				switch e.Category {
+				case "unsupported":
+					fmt.Printf("~ %s [%s] — %s\n", e.Path, e.Category, e.Error)
+				default:
+					fmt.Printf("✗ %s [%s] — %s\n", e.Path, e.Category, e.Error)
+					hasErrors = true
+				}
+			}
+
+			if hasErrors {
+				os.Exit(1)
+			}
+			return nil
+		},
+	}
+}
+
+func runCmd() *cobra.Command {
+	var params []string
+
+	cmd := &cobra.Command{
+		Use:   "run SERVICE ACTION",
+		Short: "Manually invoke an action (for testing)",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			serviceID := args[0]
+			actionID := args[1]
+
+			dir := baseDir()
+			cfg, err := config.Load(dir)
+			if err != nil {
+				return err
+			}
+
+			// Discover services.
+			result := services.Discover(cfg.ServiceDirs, cfg.DefaultTimeout.Duration)
+			registry := services.NewRegistry()
+			registry.Load(result)
+
+			svc, action := registry.GetAction(serviceID, actionID)
+			if svc == nil {
+				return fmt.Errorf("unknown service: %s", serviceID)
+			}
+			if action == nil {
+				return fmt.Errorf("unknown action: %s.%s", serviceID, actionID)
+			}
+
+			// Parse --param key=value pairs.
+			paramMap := make(map[string]string)
+			for _, p := range params {
+				parts := strings.SplitN(p, "=", 2)
+				if len(parts) != 2 {
+					return fmt.Errorf("invalid param format: %q (expected key=value)", p)
+				}
+				paramMap[parts[0]] = parts[1]
+			}
+
+			if svc.Type == "exec" {
+				resp := executor.RunExec(context.Background(), svc, action, paramMap, cfg.Env, cfg.MaxOutputSize, "local")
+				out, _ := json.MarshalIndent(resp, "", "  ")
+				fmt.Println(string(out))
+			} else {
+				// Server mode: start the server, dispatch, stop.
+				serverMgr := executor.NewServerManager(dir)
+				if err := serverMgr.Init(); err != nil {
+					return err
+				}
+				serverMgr.Register(svc)
+				defer serverMgr.StopAll()
+
+				sp := serverMgr.Get(svc.ID)
+				resp := sp.Dispatch(context.Background(), action, paramMap, cfg.MaxOutputSize)
+				out, _ := json.MarshalIndent(resp, "", "  ")
+				fmt.Println(string(out))
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringArrayVar(&params, "param", nil, "action parameter (key=value)")
+
+	return cmd
+}
+
+func installServiceCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "install-service",
+		Short: "Install as launchd (macOS) or systemd (Linux) service",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			switch runtime.GOOS {
+			case "darwin":
+				return installLaunchd()
+			case "linux":
+				return installSystemd()
+			default:
+				return fmt.Errorf("unsupported platform: %s", runtime.GOOS)
+			}
+		},
+	}
+}
+
+func uninstallServiceCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "uninstall-service",
+		Short: "Remove the system service",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			switch runtime.GOOS {
+			case "darwin":
+				return uninstallLaunchd()
+			case "linux":
+				return uninstallSystemd()
+			default:
+				return fmt.Errorf("unsupported platform: %s", runtime.GOOS)
+			}
+		},
+	}
+}
+
+func installLaunchd() error {
+	exePath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("finding executable: %w", err)
+	}
+
+	home, _ := os.UserHomeDir()
+	logPath := filepath.Join(home, ".clawvisor", "local", "daemon.log")
+	plistDir := filepath.Join(home, "Library", "LaunchAgents")
+	plistPath := filepath.Join(plistDir, "com.clawvisor.local.plist")
+
+	if err := os.MkdirAll(plistDir, 0755); err != nil {
+		return err
+	}
+
+	plist := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.clawvisor.local</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>%s</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>%s</string>
+    <key>StandardErrorPath</key>
+    <string>%s</string>
+</dict>
+</plist>
+`, exePath, logPath, logPath)
+
+	if err := os.WriteFile(plistPath, []byte(plist), 0644); err != nil {
+		return fmt.Errorf("writing plist: %w", err)
+	}
+
+	if err := exec.Command("launchctl", "load", plistPath).Run(); err != nil {
+		return fmt.Errorf("loading launchd service: %w", err)
+	}
+
+	fmt.Printf("Installed and started com.clawvisor.local\n")
+	fmt.Printf("  Plist: %s\n", plistPath)
+	fmt.Printf("  Log:   %s\n", logPath)
+	return nil
+}
+
+func uninstallLaunchd() error {
+	home, _ := os.UserHomeDir()
+	plistPath := filepath.Join(home, "Library", "LaunchAgents", "com.clawvisor.local.plist")
+
+	_ = exec.Command("launchctl", "unload", plistPath).Run()
+	if err := os.Remove(plistPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing plist: %w", err)
+	}
+
+	fmt.Println("Uninstalled com.clawvisor.local")
+	return nil
+}
+
+func installSystemd() error {
+	exePath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("finding executable: %w", err)
+	}
+
+	home, _ := os.UserHomeDir()
+	unitDir := filepath.Join(home, ".config", "systemd", "user")
+	unitPath := filepath.Join(unitDir, "clawvisor-local.service")
+
+	if err := os.MkdirAll(unitDir, 0755); err != nil {
+		return err
+	}
+
+	unit := fmt.Sprintf(`[Unit]
+Description=Clawvisor Local Daemon
+After=network.target
+
+[Service]
+ExecStart=%s
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+`, exePath)
+
+	if err := os.WriteFile(unitPath, []byte(unit), 0644); err != nil {
+		return fmt.Errorf("writing unit file: %w", err)
+	}
+
+	if err := exec.Command("systemctl", "--user", "daemon-reload").Run(); err != nil {
+		return fmt.Errorf("reloading systemd: %w", err)
+	}
+	if err := exec.Command("systemctl", "--user", "enable", "--now", "clawvisor-local").Run(); err != nil {
+		return fmt.Errorf("enabling service: %w", err)
+	}
+
+	fmt.Printf("Installed and started clawvisor-local.service\n")
+	fmt.Printf("  Unit: %s\n", unitPath)
+	return nil
+}
+
+func uninstallSystemd() error {
+	_ = exec.Command("systemctl", "--user", "disable", "--now", "clawvisor-local").Run()
+
+	home, _ := os.UserHomeDir()
+	unitPath := filepath.Join(home, ".config", "systemd", "user", "clawvisor-local.service")
+
+	if err := os.Remove(unitPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing unit file: %w", err)
+	}
+
+	_ = exec.Command("systemctl", "--user", "daemon-reload").Run()
+
+	fmt.Println("Uninstalled clawvisor-local.service")
+	return nil
+}
+
+func httpPost(url string) (string, error) {
+	resp, err := http.Post(url, "", nil)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}

--- a/internal/local/config/config.go
+++ b/internal/local/config/config.go
@@ -1,0 +1,111 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config represents the daemon-level configuration from config.yaml.
+type Config struct {
+	Name                 string            `yaml:"name"`
+	Port                 int               `yaml:"port"`
+	LogLevel             string            `yaml:"log_level"`
+	ServiceDirs          []string          `yaml:"service_dirs"`
+	ScanInterval         int               `yaml:"scan_interval"`
+	DefaultTimeout       Duration          `yaml:"default_timeout"`
+	MaxOutputSize        int64             `yaml:"max_output_size"`
+	MaxConcurrentReqs    int               `yaml:"max_concurrent_requests"`
+	Env                  map[string]string `yaml:"env"`
+	AllowedCloudOrigins  []string          `yaml:"allowed_cloud_origins"`
+}
+
+// Duration wraps time.Duration for YAML unmarshalling of strings like "30s".
+type Duration struct {
+	time.Duration
+}
+
+func (d *Duration) UnmarshalYAML(value *yaml.Node) error {
+	var s string
+	if err := value.Decode(&s); err != nil {
+		return err
+	}
+	dur, err := time.ParseDuration(s)
+	if err != nil {
+		return fmt.Errorf("invalid duration %q: %w", s, err)
+	}
+	d.Duration = dur
+	return nil
+}
+
+func (d Duration) MarshalYAML() (interface{}, error) {
+	return d.Duration.String(), nil
+}
+
+// DefaultConfig returns the config with all defaults applied.
+func DefaultConfig(baseDir string) *Config {
+	hostname, _ := os.Hostname()
+	if hostname == "" {
+		hostname = "local"
+	}
+	return &Config{
+		Name:                hostname,
+		Port:                25299,
+		LogLevel:            "info",
+		ServiceDirs:         []string{filepath.Join(baseDir, "services")},
+		ScanInterval:        0,
+		DefaultTimeout:      Duration{30 * time.Second},
+		MaxOutputSize:       1048576, // 1 MB
+		MaxConcurrentReqs:   10,
+		Env:                 make(map[string]string),
+		AllowedCloudOrigins: []string{"https://app.clawvisor.com"},
+	}
+}
+
+// Load reads config.yaml from the given base directory.
+// If the file doesn't exist, returns defaults.
+func Load(baseDir string) (*Config, error) {
+	cfg := DefaultConfig(baseDir)
+
+	path := filepath.Join(baseDir, "config.yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return cfg, nil
+		}
+		return nil, fmt.Errorf("reading config: %w", err)
+	}
+
+	if err := yaml.Unmarshal(data, cfg); err != nil {
+		return nil, fmt.Errorf("parsing config.yaml: %w", err)
+	}
+
+	// Expand tildes in service dirs.
+	home, _ := os.UserHomeDir()
+	for i, dir := range cfg.ServiceDirs {
+		if len(dir) > 0 && dir[0] == '~' {
+			cfg.ServiceDirs[i] = filepath.Join(home, dir[1:])
+		}
+	}
+
+	if cfg.Port < 1 || cfg.Port > 65535 {
+		return nil, fmt.Errorf("invalid port: %d", cfg.Port)
+	}
+	if cfg.MaxConcurrentReqs < 1 {
+		cfg.MaxConcurrentReqs = 10
+	}
+	if cfg.MaxOutputSize < 1 {
+		cfg.MaxOutputSize = 1048576
+	}
+
+	return cfg, nil
+}
+
+// BaseDir returns the default base directory (~/.clawvisor/local).
+func BaseDir() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".clawvisor", "local")
+}

--- a/internal/local/daemon/daemon.go
+++ b/internal/local/daemon/daemon.go
@@ -1,0 +1,356 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/clawvisor/clawvisor/internal/local/config"
+	"github.com/clawvisor/clawvisor/internal/local/executor"
+	"github.com/clawvisor/clawvisor/internal/local/pairing"
+	"github.com/clawvisor/clawvisor/internal/local/services"
+	"github.com/clawvisor/clawvisor/internal/local/state"
+	"github.com/clawvisor/clawvisor/internal/local/tunnel"
+	"github.com/clawvisor/clawvisor/pkg/version"
+)
+
+// Daemon is the top-level orchestrator for the clawvisor local daemon.
+type Daemon struct {
+	baseDir    string
+	cfg        *config.Config
+	state      *state.State
+	registry   *services.Registry
+	serverMgr  *executor.ServerManager
+	dispatcher *executor.Dispatcher
+	pairServer *pairing.Server
+	tunnelClient *tunnel.Client
+	logger     *slog.Logger
+
+	mu        sync.RWMutex
+	startTime time.Time
+	connected bool
+}
+
+// New creates a new daemon instance.
+func New(baseDir string) (*Daemon, error) {
+	cfg, err := config.Load(baseDir)
+	if err != nil {
+		return nil, fmt.Errorf("loading config: %w", err)
+	}
+
+	st, err := state.Load(baseDir)
+	if err != nil {
+		return nil, fmt.Errorf("loading state: %w", err)
+	}
+
+	// Persist the daemon ID if it was just generated.
+	if err := state.Save(baseDir, st); err != nil {
+		return nil, fmt.Errorf("saving initial state: %w", err)
+	}
+
+	return &Daemon{
+		baseDir:  baseDir,
+		cfg:      cfg,
+		state:    st,
+		registry: services.NewRegistry(),
+		logger:   slog.Default(),
+	}, nil
+}
+
+// OverridePort overrides the configured port for the pairing server.
+func (d *Daemon) OverridePort(port int) {
+	d.cfg.Port = port
+}
+
+// Run starts the daemon and blocks until shutdown.
+func (d *Daemon) Run() error {
+	d.startTime = time.Now()
+
+	// Configure log level.
+	configureLogLevel(d.cfg.LogLevel)
+
+	d.logger.Info("starting", "version", version.Version, "daemon_id", d.state.DaemonID)
+
+	// Initialize server manager.
+	d.serverMgr = executor.NewServerManager(d.baseDir)
+	if err := d.serverMgr.Init(); err != nil {
+		return fmt.Errorf("initializing server manager: %w", err)
+	}
+
+	// Discover and load services.
+	d.reloadServices()
+
+	// Create dispatcher.
+	d.dispatcher = executor.NewDispatcher(
+		d.registry,
+		d.serverMgr,
+		d.cfg.Env,
+		d.cfg.MaxOutputSize,
+		d.cfg.MaxConcurrentReqs,
+	)
+
+	// Start pairing HTTP server.
+	d.pairServer = pairing.NewServer(pairing.ServerConfig{
+		Port:           d.cfg.Port,
+		DaemonID:       d.state.DaemonID,
+		DaemonName:     d.cfg.Name,
+		AllowedOrigins: d.cfg.AllowedCloudOrigins,
+		OnPairComplete: d.handlePairComplete,
+		StatusHandler:  d.handleStatus,
+		ReloadHandler:  d.handleReload,
+	})
+
+	if err := d.pairServer.Start(); err != nil {
+		return fmt.Errorf("starting pairing server: %w", err)
+	}
+
+	// If already paired, connect to cloud.
+	if d.state.IsPaired() {
+		d.connectTunnel()
+	}
+
+	// Set up periodic scan if configured.
+	var scanTicker *time.Ticker
+	if d.cfg.ScanInterval > 0 {
+		scanTicker = time.NewTicker(time.Duration(d.cfg.ScanInterval) * time.Second)
+		go func() {
+			for range scanTicker.C {
+				d.reloadServices()
+			}
+		}()
+	}
+
+	// Wait for shutdown signal.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	<-sigCh
+
+	d.logger.Info("shutting down")
+
+	if scanTicker != nil {
+		scanTicker.Stop()
+	}
+
+	// Stop tunnel.
+	if d.tunnelClient != nil {
+		d.tunnelClient.Close()
+	}
+
+	// Stop server processes.
+	d.serverMgr.StopAll()
+
+	// Stop pairing server.
+	d.pairServer.Stop()
+
+	return nil
+}
+
+func (d *Daemon) handlePairComplete(token, origin string) error {
+	d.state.ConnectionToken = token
+	d.state.CloudOrigin = origin
+	d.state.PairedAt = time.Now()
+
+	if err := state.Save(d.baseDir, d.state); err != nil {
+		return fmt.Errorf("saving state: %w", err)
+	}
+
+	d.logger.Info("paired with cloud", "origin", origin)
+
+	// Connect to cloud.
+	d.connectTunnel()
+
+	return nil
+}
+
+func (d *Daemon) connectTunnel() {
+	// Close any existing tunnel client to avoid duplicate connections.
+	if d.tunnelClient != nil {
+		d.tunnelClient.Close()
+	}
+
+	var client *tunnel.Client
+	client = tunnel.NewClient(tunnel.ClientConfig{
+		CloudOrigin:     d.state.CloudOrigin,
+		ConnectionToken: d.state.ConnectionToken,
+		DaemonName:      d.cfg.Name,
+		Version:         version.Version,
+		Registry:        d.registry,
+		Logger:          d.logger.With("component", "tunnel"),
+		OnRequest:       d.handleRequest,
+		OnAuthFailure: func() {
+			// Only clear state if this client is still the active one.
+			// A stale client from a previous pairing must not wipe the new token.
+			if d.tunnelClient == client {
+				d.handleAuthFailure()
+			}
+		},
+	})
+	d.tunnelClient = client
+
+	go client.Connect()
+}
+
+func (d *Daemon) handleRequest(ctx context.Context, id string, req *tunnel.RequestPayload) {
+	resp := d.dispatcher.Dispatch(ctx, req.Service, req.Action, req.Params, id)
+
+	data, _ := json.Marshal(resp.Data)
+	payload := &tunnel.ResponsePayload{
+		Success: resp.Success,
+		Data:    data,
+		Error:   resp.Error,
+	}
+
+	if err := d.tunnelClient.SendResponse(id, payload); err != nil {
+		d.logger.Warn("failed to send response", "request_id", id, "err", err)
+	}
+}
+
+func (d *Daemon) handleAuthFailure() {
+	d.logger.Warn("auth failure, clearing pairing state")
+	_ = state.Clear(d.baseDir, d.state.DaemonID)
+	d.state.ConnectionToken = ""
+	d.state.CloudOrigin = ""
+}
+
+func (d *Daemon) reloadServices() {
+	result := services.Discover(d.cfg.ServiceDirs, d.cfg.DefaultTimeout.Duration)
+
+	// Track old server hashes for restart decisions.
+	oldServices := d.registry.All()
+	oldHashes := make(map[string]string)
+	for _, svc := range oldServices {
+		if svc.Type == "server" {
+			oldHashes[svc.ID] = services.RestartHash(svc)
+		}
+	}
+
+	d.registry.Load(result)
+
+	// Manage server processes.
+	newServices := d.registry.All()
+	newIDs := make(map[string]bool)
+
+	for _, svc := range newServices {
+		newIDs[svc.ID] = true
+		if svc.Type == "server" {
+			newHash := services.RestartHash(svc)
+			if oldHash, existed := oldHashes[svc.ID]; existed {
+				if oldHash != newHash {
+					// Config changed — restart.
+					d.serverMgr.Remove(svc.ID)
+					d.serverMgr.Register(svc)
+				}
+				// Same hash — keep running.
+			} else {
+				// New service.
+				d.serverMgr.Register(svc)
+			}
+		}
+	}
+
+	// Remove servers for deleted services.
+	for id := range oldHashes {
+		if !newIDs[id] {
+			d.serverMgr.Remove(id)
+		}
+	}
+
+	d.logger.Info("services loaded", "count", len(result.Services), "excluded", len(result.Excluded))
+
+	// Send capabilities update if connected.
+	if d.tunnelClient != nil && d.tunnelClient.IsConnected() {
+		if err := d.tunnelClient.SendCapabilitiesUpdate(); err != nil {
+			d.logger.Warn("failed to send capabilities update", "err", err)
+		}
+	}
+}
+
+// serviceEntry is the JSON shape for a service in status and reload responses.
+type serviceEntry struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Type    string `json:"type"`
+	Status  string `json:"status"`
+	Actions []struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"actions"`
+}
+
+func (d *Daemon) buildServiceList() []serviceEntry {
+	svcs := d.registry.All()
+	list := make([]serviceEntry, 0, len(svcs))
+	for _, svc := range svcs {
+		s := serviceEntry{
+			ID:   svc.ID,
+			Name: svc.Name,
+			Type: svc.Type,
+		}
+		if svc.Type == "server" {
+			sp := d.serverMgr.Get(svc.ID)
+			if sp != nil {
+				s.Status = string(sp.State())
+			} else {
+				s.Status = "ok"
+			}
+		} else {
+			s.Status = "ok"
+		}
+		for _, a := range svc.Actions {
+			s.Actions = append(s.Actions, struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+			}{ID: a.ID, Name: a.Name})
+		}
+		list = append(list, s)
+	}
+	return list
+}
+
+func (d *Daemon) handleStatus() interface{} {
+	connected := d.tunnelClient != nil && d.tunnelClient.IsConnected()
+	uptime := time.Since(d.startTime).Seconds()
+
+	return map[string]interface{}{
+		"daemon_id":         d.state.DaemonID,
+		"name":              d.cfg.Name,
+		"version":           version.Version,
+		"paired":            d.state.IsPaired(),
+		"connected":         connected,
+		"cloud_origin":      d.state.CloudOrigin,
+		"uptime_seconds":    int(uptime),
+		"services":          d.buildServiceList(),
+		"excluded_services": d.registry.Excluded(),
+	}
+}
+
+func (d *Daemon) handleReload() interface{} {
+	d.reloadServices()
+	return d.buildServiceList()
+}
+
+// configureLogLevel sets the slog default logger level.
+func configureLogLevel(level string) {
+	var lvl slog.Level
+	switch level {
+	case "debug":
+		lvl = slog.LevelDebug
+	case "info":
+		lvl = slog.LevelInfo
+	case "warn":
+		lvl = slog.LevelWarn
+	case "error":
+		lvl = slog.LevelError
+	default:
+		lvl = slog.LevelInfo
+	}
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level: lvl,
+	})))
+}

--- a/internal/local/daemon/daemon.go
+++ b/internal/local/daemon/daemon.go
@@ -24,17 +24,17 @@ import (
 type Daemon struct {
 	baseDir    string
 	cfg        *config.Config
-	state      *state.State
 	registry   *services.Registry
 	serverMgr  *executor.ServerManager
 	dispatcher *executor.Dispatcher
 	pairServer *pairing.Server
-	tunnelClient *tunnel.Client
 	logger     *slog.Logger
+	startTime  time.Time
 
-	mu        sync.RWMutex
-	startTime time.Time
-	connected bool
+	// mu protects state, tunnelClient, and connected.
+	mu           sync.RWMutex
+	state        *state.State
+	tunnelClient *tunnel.Client
 }
 
 // New creates a new daemon instance.
@@ -75,7 +75,12 @@ func (d *Daemon) Run() error {
 	// Configure log level.
 	configureLogLevel(d.cfg.LogLevel)
 
-	d.logger.Info("starting", "version", version.Version, "daemon_id", d.state.DaemonID)
+	d.mu.RLock()
+	daemonID := d.state.DaemonID
+	paired := d.state.IsPaired()
+	d.mu.RUnlock()
+
+	d.logger.Info("starting", "version", version.Version, "daemon_id", daemonID)
 
 	// Initialize server manager.
 	d.serverMgr = executor.NewServerManager(d.baseDir)
@@ -98,7 +103,7 @@ func (d *Daemon) Run() error {
 	// Start pairing HTTP server.
 	d.pairServer = pairing.NewServer(pairing.ServerConfig{
 		Port:           d.cfg.Port,
-		DaemonID:       d.state.DaemonID,
+		DaemonID:       daemonID,
 		DaemonName:     d.cfg.Name,
 		AllowedOrigins: d.cfg.AllowedCloudOrigins,
 		OnPairComplete: d.handlePairComplete,
@@ -111,7 +116,7 @@ func (d *Daemon) Run() error {
 	}
 
 	// If already paired, connect to cloud.
-	if d.state.IsPaired() {
+	if paired {
 		d.connectTunnel()
 	}
 
@@ -138,8 +143,11 @@ func (d *Daemon) Run() error {
 	}
 
 	// Stop tunnel.
-	if d.tunnelClient != nil {
-		d.tunnelClient.Close()
+	d.mu.RLock()
+	tc := d.tunnelClient
+	d.mu.RUnlock()
+	if tc != nil {
+		tc.Close()
 	}
 
 	// Stop server processes.
@@ -152,11 +160,14 @@ func (d *Daemon) Run() error {
 }
 
 func (d *Daemon) handlePairComplete(token, origin string) error {
+	d.mu.Lock()
 	d.state.ConnectionToken = token
 	d.state.CloudOrigin = origin
 	d.state.PairedAt = time.Now()
+	st := d.state
+	d.mu.Unlock()
 
-	if err := state.Save(d.baseDir, d.state); err != nil {
+	if err := state.Save(d.baseDir, st); err != nil {
 		return fmt.Errorf("saving state: %w", err)
 	}
 
@@ -169,6 +180,8 @@ func (d *Daemon) handlePairComplete(token, origin string) error {
 }
 
 func (d *Daemon) connectTunnel() {
+	d.mu.Lock()
+
 	// Close any existing tunnel client to avoid duplicate connections.
 	if d.tunnelClient != nil {
 		d.tunnelClient.Close()
@@ -186,12 +199,16 @@ func (d *Daemon) connectTunnel() {
 		OnAuthFailure: func() {
 			// Only clear state if this client is still the active one.
 			// A stale client from a previous pairing must not wipe the new token.
+			d.mu.Lock()
 			if d.tunnelClient == client {
-				d.handleAuthFailure()
+				d.handleAuthFailureLocked()
 			}
+			d.mu.Unlock()
 		},
 	})
 	d.tunnelClient = client
+
+	d.mu.Unlock()
 
 	go client.Connect()
 }
@@ -206,12 +223,19 @@ func (d *Daemon) handleRequest(ctx context.Context, id string, req *tunnel.Reque
 		Error:   resp.Error,
 	}
 
-	if err := d.tunnelClient.SendResponse(id, payload); err != nil {
-		d.logger.Warn("failed to send response", "request_id", id, "err", err)
+	d.mu.RLock()
+	tc := d.tunnelClient
+	d.mu.RUnlock()
+
+	if tc != nil {
+		if err := tc.SendResponse(id, payload); err != nil {
+			d.logger.Warn("failed to send response", "request_id", id, "err", err)
+		}
 	}
 }
 
-func (d *Daemon) handleAuthFailure() {
+// handleAuthFailureLocked clears pairing state. Caller must hold d.mu.
+func (d *Daemon) handleAuthFailureLocked() {
 	d.logger.Warn("auth failure, clearing pairing state")
 	_ = state.Clear(d.baseDir, d.state.DaemonID)
 	d.state.ConnectionToken = ""
@@ -264,8 +288,11 @@ func (d *Daemon) reloadServices() {
 	d.logger.Info("services loaded", "count", len(result.Services), "excluded", len(result.Excluded))
 
 	// Send capabilities update if connected.
-	if d.tunnelClient != nil && d.tunnelClient.IsConnected() {
-		if err := d.tunnelClient.SendCapabilitiesUpdate(); err != nil {
+	d.mu.RLock()
+	tc := d.tunnelClient
+	d.mu.RUnlock()
+	if tc != nil && tc.IsConnected() {
+		if err := tc.SendCapabilitiesUpdate(); err != nil {
 			d.logger.Warn("failed to send capabilities update", "err", err)
 		}
 	}
@@ -314,16 +341,23 @@ func (d *Daemon) buildServiceList() []serviceEntry {
 }
 
 func (d *Daemon) handleStatus() interface{} {
-	connected := d.tunnelClient != nil && d.tunnelClient.IsConnected()
+	d.mu.RLock()
+	tc := d.tunnelClient
+	daemonID := d.state.DaemonID
+	paired := d.state.IsPaired()
+	cloudOrigin := d.state.CloudOrigin
+	d.mu.RUnlock()
+
+	connected := tc != nil && tc.IsConnected()
 	uptime := time.Since(d.startTime).Seconds()
 
 	return map[string]interface{}{
-		"daemon_id":         d.state.DaemonID,
+		"daemon_id":         daemonID,
 		"name":              d.cfg.Name,
 		"version":           version.Version,
-		"paired":            d.state.IsPaired(),
+		"paired":            paired,
 		"connected":         connected,
-		"cloud_origin":      d.state.CloudOrigin,
+		"cloud_origin":      cloudOrigin,
 		"uptime_seconds":    int(uptime),
 		"services":          d.buildServiceList(),
 		"excluded_services": d.registry.Excluded(),

--- a/internal/local/executor/dispatch.go
+++ b/internal/local/executor/dispatch.go
@@ -1,0 +1,118 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/clawvisor/clawvisor/internal/local/services"
+)
+
+// Dispatcher routes incoming requests to the appropriate executor.
+type Dispatcher struct {
+	registry       *services.Registry
+	serverMgr      *ServerManager
+	globalEnv      map[string]string
+	maxOutputSize  int64
+
+	// Concurrency control.
+	semaphore    chan struct{}
+	queueTimeout time.Duration
+}
+
+// NewDispatcher creates a new request dispatcher.
+func NewDispatcher(
+	registry *services.Registry,
+	serverMgr *ServerManager,
+	globalEnv map[string]string,
+	maxOutputSize int64,
+	maxConcurrent int,
+) *Dispatcher {
+	return &Dispatcher{
+		registry:      registry,
+		serverMgr:     serverMgr,
+		globalEnv:     globalEnv,
+		maxOutputSize: maxOutputSize,
+		semaphore:     make(chan struct{}, maxConcurrent),
+		queueTimeout:  30 * time.Second,
+	}
+}
+
+// Response is the generic response payload sent back to the cloud.
+type Response struct {
+	Success bool            `json:"success"`
+	Data    json.RawMessage `json:"data,omitempty"`
+	Error   string          `json:"error,omitempty"`
+}
+
+// Dispatch handles a request for a service action.
+func (d *Dispatcher) Dispatch(ctx context.Context, serviceID, actionID string, params map[string]string, requestID string) *Response {
+	svc, action := d.registry.GetAction(serviceID, actionID)
+	if svc == nil {
+		return &Response{Success: false, Error: fmt.Sprintf("unknown service: %s", serviceID)}
+	}
+	if action == nil {
+		return &Response{Success: false, Error: fmt.Sprintf("unknown action: %s.%s", serviceID, actionID)}
+	}
+
+	// Validate required params.
+	for _, p := range action.Params {
+		if p.Required {
+			if _, ok := params[p.Name]; !ok {
+				return &Response{
+					Success: false,
+					Error:   fmt.Sprintf("missing required param: %s", p.Name),
+				}
+			}
+		}
+	}
+
+	// Acquire dispatch slot with timeout. The semaphore itself enforces both
+	// concurrency and queue depth (buffered channel capacity).
+	queueCtx, queueCancel := context.WithTimeout(ctx, d.queueTimeout)
+	defer queueCancel()
+
+	select {
+	case d.semaphore <- struct{}{}:
+		defer func() { <-d.semaphore }()
+	case <-ctx.Done():
+		return &Response{Success: false, Error: "request discarded (connection closed)"}
+	case <-queueCtx.Done():
+		return &Response{Success: false, Error: "timed out waiting for dispatch slot"}
+	}
+
+	// Add request ID to env.
+	globalEnv := make(map[string]string, len(d.globalEnv)+1)
+	for k, v := range d.globalEnv {
+		globalEnv[k] = v
+	}
+
+	// Dispatch based on service type.
+	switch svc.Type {
+	case "exec":
+		result := RunExec(ctx, svc, action, params, globalEnv, d.maxOutputSize, requestID)
+		data, _ := json.Marshal(result.Data)
+		return &Response{
+			Success: result.Success,
+			Data:    data,
+			Error:   result.Error,
+		}
+
+	case "server":
+		sp := d.serverMgr.Get(svc.ID)
+		if sp == nil {
+			return &Response{Success: false, Error: fmt.Sprintf("no server process for service: %s", serviceID)}
+		}
+		result := sp.Dispatch(ctx, action, params, d.maxOutputSize)
+		data, _ := json.Marshal(result.Data)
+		return &Response{
+			Success: result.Success,
+			Data:    data,
+			Error:   result.Error,
+		}
+
+	default:
+		return &Response{Success: false, Error: fmt.Sprintf("unknown service type: %s", svc.Type)}
+	}
+}

--- a/internal/local/executor/exec.go
+++ b/internal/local/executor/exec.go
@@ -91,7 +91,7 @@ func RunExec(
 		// Context cancelled (timeout or WebSocket disconnect).
 		// Send SIGTERM, then SIGKILL after 3s grace period.
 		cancelled = true
-		killProcessGroup(cmd, doneCh, 3*time.Second)
+		killProcessGroup(cmd, 3*time.Second)
 		err = <-doneCh // Wait for process to actually exit.
 	}
 
@@ -215,9 +215,9 @@ func buildEnv(svc *services.Service, action *services.Action, params map[string]
 }
 
 // killProcessGroup sends SIGTERM to the process group, then SIGKILL after the
-// grace period. It does NOT call Wait — the caller is responsible for waiting
-// via cmd.Wait() to avoid double-Wait races.
-func killProcessGroup(cmd *exec.Cmd, doneCh <-chan error, grace time.Duration) {
+// grace period. It does NOT call Wait or read from any channel — the caller is
+// responsible for collecting the exit status via cmd.Wait().
+func killProcessGroup(cmd *exec.Cmd, grace time.Duration) {
 	if cmd.Process == nil {
 		return
 	}
@@ -226,12 +226,8 @@ func killProcessGroup(cmd *exec.Cmd, doneCh <-chan error, grace time.Duration) {
 		return
 	}
 	_ = syscall.Kill(-pgid, syscall.SIGTERM)
-	timer := time.NewTimer(grace)
-	defer timer.Stop()
-	select {
-	case <-doneCh:
-		// Process exited after SIGTERM.
-	case <-timer.C:
-		_ = syscall.Kill(-pgid, syscall.SIGKILL)
-	}
+	// Sleep for the grace period, then unconditionally SIGKILL.
+	// If the process already exited from SIGTERM, the kill is a harmless no-op.
+	time.Sleep(grace)
+	_ = syscall.Kill(-pgid, syscall.SIGKILL)
 }

--- a/internal/local/executor/exec.go
+++ b/internal/local/executor/exec.go
@@ -1,0 +1,238 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/clawvisor/clawvisor/internal/local/services"
+)
+
+// ExecResult holds the result of an exec-mode action invocation.
+type ExecResult struct {
+	Success  bool              `json:"success"`
+	Data     *ExecData         `json:"data,omitempty"`
+	Error    string            `json:"error,omitempty"`
+}
+
+// ExecData holds the output data from an exec-mode action.
+type ExecData struct {
+	Stdout         string            `json:"stdout"`
+	StdoutEncoding string            `json:"stdout_encoding,omitempty"`
+	Stderr         string            `json:"stderr"`
+	StderrEncoding string            `json:"stderr_encoding,omitempty"`
+	ExitCode       int               `json:"exit_code"`
+	Truncated      map[string]bool   `json:"truncated,omitempty"`
+}
+
+// RunExec executes an exec-mode action and returns the result.
+func RunExec(
+	ctx context.Context,
+	svc *services.Service,
+	action *services.Action,
+	params map[string]string,
+	globalEnv map[string]string,
+	maxOutputSize int64,
+	requestID string,
+) *ExecResult {
+	// Build resolved params (apply defaults).
+	resolved := resolveParams(action, params)
+
+	// Build environment.
+	env := buildEnv(svc, action, resolved, globalEnv, requestID)
+
+	// Create command — we manage cancellation manually (SIGTERM then SIGKILL)
+	// instead of using exec.CommandContext which sends SIGKILL directly.
+	cmdCtx, cancel := context.WithTimeout(ctx, action.Timeout)
+	defer cancel()
+
+	cmd := exec.Command(action.Run[0], action.Run[1:]...)
+	cmd.Dir = svc.WorkingDir
+	cmd.Env = env
+
+	// Handle stdin.
+	if action.Stdin != "" {
+		interpolated := InterpolateTemplate(action.Stdin, resolved, action.Params, "text")
+		cmd.Stdin = strings.NewReader(interpolated)
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	// Set process group so we can kill children.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	if err := cmd.Start(); err != nil {
+		return &ExecResult{
+			Success: false,
+			Error:   fmt.Sprintf("exec %s.%s: %s", svc.ID, action.ID, err),
+		}
+	}
+
+	// Watch for context cancellation (timeout or disconnect) and send SIGTERM→SIGKILL.
+	doneCh := make(chan error, 1)
+	go func() {
+		doneCh <- cmd.Wait()
+	}()
+
+	var err error
+	var cancelled bool
+	select {
+	case err = <-doneCh:
+		// Process exited normally (or with error).
+	case <-cmdCtx.Done():
+		// Context cancelled (timeout or WebSocket disconnect).
+		// Send SIGTERM, then SIGKILL after 3s grace period.
+		cancelled = true
+		killProcessGroup(cmd, 3*time.Second)
+		err = <-doneCh // Wait for process to actually exit.
+	}
+
+	// Process output.
+	outResult := ProcessOutput(stdout.Bytes(), maxOutputSize)
+	errResult := ProcessOutput(stderr.Bytes(), maxOutputSize)
+
+	if cancelled {
+		if cmdCtx.Err() == context.DeadlineExceeded {
+			return &ExecResult{
+				Success: false,
+				Error:   fmt.Sprintf("timed out after %s", action.Timeout),
+			}
+		}
+		return &ExecResult{
+			Success: false,
+			Error:   "cancelled (connection closed)",
+		}
+	}
+
+	exitCode := 0
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		} else {
+			return &ExecResult{
+				Success: false,
+				Error:   fmt.Sprintf("exec %s.%s: %s", svc.ID, action.ID, err),
+			}
+		}
+	}
+
+	data := &ExecData{
+		Stdout:   outResult.Data,
+		Stderr:   errResult.Data,
+		ExitCode: exitCode,
+	}
+
+	if outResult.Encoding != "" {
+		data.StdoutEncoding = outResult.Encoding
+	}
+	if errResult.Encoding != "" {
+		data.StderrEncoding = errResult.Encoding
+	}
+
+	truncated := make(map[string]bool)
+	if outResult.Truncated {
+		truncated["stdout"] = true
+	}
+	if errResult.Truncated {
+		truncated["stderr"] = true
+	}
+	if len(truncated) > 0 {
+		data.Truncated = truncated
+	}
+
+	success := exitCode == 0
+	var errMsg string
+	if !success {
+		errMsg = errResult.Data
+	}
+
+	return &ExecResult{
+		Success: success,
+		Data:    data,
+		Error:   errMsg,
+	}
+}
+
+func resolveParams(action *services.Action, provided map[string]string) map[string]string {
+	resolved := make(map[string]string, len(action.Params))
+	for _, p := range action.Params {
+		if v, ok := provided[p.Name]; ok {
+			resolved[p.Name] = v
+		} else if p.Default != nil {
+			resolved[p.Name] = *p.Default
+		} else {
+			resolved[p.Name] = ""
+		}
+	}
+	return resolved
+}
+
+func buildEnv(svc *services.Service, action *services.Action, params map[string]string, globalEnv map[string]string, requestID string) []string {
+	// Start with system environment.
+	env := os.Environ()
+
+	// Add global env.
+	for k, v := range globalEnv {
+		env = append(env, k+"="+v)
+	}
+
+	// Service-level env (with template interpolation).
+	for k, v := range svc.Env {
+		v = InterpolateTemplate(v, params, action.Params, "text")
+		env = append(env, k+"="+v)
+	}
+
+	// Action-level env (with template interpolation).
+	for k, v := range action.Env {
+		v = InterpolateTemplate(v, params, action.Params, "text")
+		env = append(env, k+"="+v)
+	}
+
+	// PARAM_* env vars.
+	for name, value := range params {
+		envName := "PARAM_" + strings.ToUpper(strings.ReplaceAll(name, "-", "_"))
+		env = append(env, envName+"="+value)
+	}
+
+	// Magic variables.
+	env = append(env,
+		"CLAWVISOR_SERVICE_ID="+svc.ID,
+		"CLAWVISOR_ACTION_ID="+action.ID,
+		"CLAWVISOR_SERVICE_DIR="+svc.Dir,
+		"CLAWVISOR_REQUEST_ID="+requestID,
+	)
+
+	return env
+}
+
+func killProcessGroup(cmd *exec.Cmd, grace time.Duration) {
+	if cmd.Process == nil {
+		return
+	}
+	pgid, err := syscall.Getpgid(cmd.Process.Pid)
+	if err != nil {
+		return
+	}
+	_ = syscall.Kill(-pgid, syscall.SIGTERM)
+	timer := time.NewTimer(grace)
+	defer timer.Stop()
+	done := make(chan struct{})
+	go func() {
+		_, _ = cmd.Process.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-timer.C:
+		_ = syscall.Kill(-pgid, syscall.SIGKILL)
+	}
+}

--- a/internal/local/executor/exec.go
+++ b/internal/local/executor/exec.go
@@ -89,10 +89,16 @@ func RunExec(
 		// Process exited normally (or with error).
 	case <-cmdCtx.Done():
 		// Context cancelled (timeout or WebSocket disconnect).
-		// Send SIGTERM, then SIGKILL after 3s grace period.
+		// Send SIGTERM, escalate to SIGKILL after grace period.
 		cancelled = true
-		killProcessGroup(cmd, 3*time.Second)
-		err = <-doneCh // Wait for process to actually exit.
+		signalProcessGroup(cmd, syscall.SIGTERM)
+		// Wait for exit or grace period, whichever comes first.
+		select {
+		case err = <-doneCh:
+		case <-time.After(3 * time.Second):
+			signalProcessGroup(cmd, syscall.SIGKILL)
+			err = <-doneCh
+		}
 	}
 
 	// Process output.
@@ -214,10 +220,9 @@ func buildEnv(svc *services.Service, action *services.Action, params map[string]
 	return env
 }
 
-// killProcessGroup sends SIGTERM to the process group, then SIGKILL after the
-// grace period. It does NOT call Wait or read from any channel — the caller is
-// responsible for collecting the exit status via cmd.Wait().
-func killProcessGroup(cmd *exec.Cmd, grace time.Duration) {
+// signalProcessGroup sends a signal to the process group. No-op if the
+// process is nil or the pgid can't be resolved (already exited).
+func signalProcessGroup(cmd *exec.Cmd, sig syscall.Signal) {
 	if cmd.Process == nil {
 		return
 	}
@@ -225,9 +230,5 @@ func killProcessGroup(cmd *exec.Cmd, grace time.Duration) {
 	if err != nil {
 		return
 	}
-	_ = syscall.Kill(-pgid, syscall.SIGTERM)
-	// Sleep for the grace period, then unconditionally SIGKILL.
-	// If the process already exited from SIGTERM, the kill is a harmless no-op.
-	time.Sleep(grace)
-	_ = syscall.Kill(-pgid, syscall.SIGKILL)
+	_ = syscall.Kill(-pgid, sig)
 }

--- a/internal/local/executor/exec.go
+++ b/internal/local/executor/exec.go
@@ -91,7 +91,7 @@ func RunExec(
 		// Context cancelled (timeout or WebSocket disconnect).
 		// Send SIGTERM, then SIGKILL after 3s grace period.
 		cancelled = true
-		killProcessGroup(cmd, 3*time.Second)
+		killProcessGroup(cmd, doneCh, 3*time.Second)
 		err = <-doneCh // Wait for process to actually exit.
 	}
 
@@ -214,7 +214,10 @@ func buildEnv(svc *services.Service, action *services.Action, params map[string]
 	return env
 }
 
-func killProcessGroup(cmd *exec.Cmd, grace time.Duration) {
+// killProcessGroup sends SIGTERM to the process group, then SIGKILL after the
+// grace period. It does NOT call Wait — the caller is responsible for waiting
+// via cmd.Wait() to avoid double-Wait races.
+func killProcessGroup(cmd *exec.Cmd, doneCh <-chan error, grace time.Duration) {
 	if cmd.Process == nil {
 		return
 	}
@@ -225,13 +228,9 @@ func killProcessGroup(cmd *exec.Cmd, grace time.Duration) {
 	_ = syscall.Kill(-pgid, syscall.SIGTERM)
 	timer := time.NewTimer(grace)
 	defer timer.Stop()
-	done := make(chan struct{})
-	go func() {
-		_, _ = cmd.Process.Wait()
-		close(done)
-	}()
 	select {
-	case <-done:
+	case <-doneCh:
+		// Process exited after SIGTERM.
 	case <-timer.C:
 		_ = syscall.Kill(-pgid, syscall.SIGKILL)
 	}

--- a/internal/local/executor/output.go
+++ b/internal/local/executor/output.go
@@ -1,0 +1,66 @@
+package executor
+
+import (
+	"bytes"
+	"encoding/base64"
+	"unicode/utf8"
+)
+
+// OutputResult holds captured output from a process stream.
+type OutputResult struct {
+	Data      string `json:"data"`
+	Encoding  string `json:"encoding,omitempty"` // "" for utf-8, "base64" for binary
+	Truncated bool   `json:"truncated,omitempty"`
+}
+
+// ProcessOutput processes raw captured bytes, applying size limits, binary detection,
+// and UTF-8 validation.
+func ProcessOutput(raw []byte, maxSize int64) OutputResult {
+	truncated := false
+	if int64(len(raw)) > maxSize {
+		raw = raw[:maxSize]
+		truncated = true
+	}
+
+	if isBinary(raw) {
+		return OutputResult{
+			Data:      base64.StdEncoding.EncodeToString(raw),
+			Encoding:  "base64",
+			Truncated: truncated,
+		}
+	}
+
+	// Validate UTF-8, replacing invalid bytes.
+	if !utf8.Valid(raw) {
+		raw = replaceInvalidUTF8(raw)
+	}
+
+	return OutputResult{
+		Data:      string(raw),
+		Truncated: truncated,
+	}
+}
+
+// isBinary checks if data contains null bytes in the first 512 bytes.
+func isBinary(data []byte) bool {
+	check := data
+	if len(check) > 512 {
+		check = check[:512]
+	}
+	return bytes.ContainsRune(check, 0)
+}
+
+// replaceInvalidUTF8 replaces invalid UTF-8 bytes with U+FFFD.
+func replaceInvalidUTF8(data []byte) []byte {
+	var buf bytes.Buffer
+	for len(data) > 0 {
+		r, size := utf8.DecodeRune(data)
+		if r == utf8.RuneError && size == 1 {
+			buf.WriteRune('\uFFFD')
+		} else {
+			buf.WriteRune(r)
+		}
+		data = data[size:]
+	}
+	return buf.Bytes()
+}

--- a/internal/local/executor/server.go
+++ b/internal/local/executor/server.go
@@ -37,6 +37,7 @@ type ServerProcess struct {
 	state         ServerState
 	cmd           *exec.Cmd
 	done          chan struct{} // closed when cmd.Wait() returns
+	ready         chan struct{} // closed when startLocked finishes (success or failure)
 	socketPath    string
 	httpClient    *http.Client
 	runDir        string
@@ -167,11 +168,11 @@ func (sp *ServerProcess) EnsureRunning() error {
 			}
 			return sp.startLocked()
 		case ServerStarting:
-			// Already starting — wait for it without holding the lock.
-			done := sp.done
+			// Already starting — wait for startup to complete without holding the lock.
+			ready := sp.ready
 			sp.mu.Unlock()
-			if done != nil {
-				<-done
+			if ready != nil {
+				<-ready
 			}
 			sp.mu.Lock()
 			// Recheck state — startLocked may have failed or succeeded.
@@ -209,6 +210,12 @@ func (sp *ServerProcess) start() error {
 
 func (sp *ServerProcess) startLocked() error {
 	sp.state = ServerStarting
+
+	// Create a ready channel so concurrent EnsureRunning callers can wait
+	// for startup to complete (not for the process to exit).
+	ready := make(chan struct{})
+	sp.ready = ready
+	defer close(ready)
 
 	// Clean up old socket.
 	_ = os.Remove(sp.socketPath)

--- a/internal/local/executor/server.go
+++ b/internal/local/executor/server.go
@@ -1,0 +1,448 @@
+package executor
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/clawvisor/clawvisor/internal/local/services"
+)
+
+// ServerState represents the health state of a server-mode service.
+type ServerState string
+
+const (
+	ServerStopped       ServerState = "stopped"
+	ServerStarting      ServerState = "starting"
+	ServerHealthy       ServerState = "healthy"
+	ServerStartFailed   ServerState = "starting_failed"
+	ServerUnhealthy     ServerState = "unhealthy"
+)
+
+// ServerProcess manages a long-running server-mode service process.
+type ServerProcess struct {
+	mu            sync.Mutex
+	svc           *services.Service
+	state         ServerState
+	cmd           *exec.Cmd
+	socketPath    string
+	httpClient    *http.Client
+	runDir        string
+	startFailures int
+	maxFailures   int
+}
+
+// ServerManager manages all server-mode service processes.
+type ServerManager struct {
+	mu        sync.RWMutex
+	servers   map[string]*ServerProcess
+	runDir    string
+}
+
+// NewServerManager creates a new server process manager.
+func NewServerManager(baseDir string) *ServerManager {
+	runDir := filepath.Join(baseDir, "run")
+	return &ServerManager{
+		servers: make(map[string]*ServerProcess),
+		runDir:  runDir,
+	}
+}
+
+// Init creates the run directory and cleans up stale sockets.
+func (m *ServerManager) Init() error {
+	if err := os.MkdirAll(m.runDir, 0700); err != nil {
+		return fmt.Errorf("creating run directory: %w", err)
+	}
+	// Clean stale sockets.
+	entries, _ := os.ReadDir(m.runDir)
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".sock") {
+			_ = os.Remove(filepath.Join(m.runDir, e.Name()))
+		}
+	}
+	return nil
+}
+
+// Register registers a server-mode service. If startup is eager, starts it immediately.
+func (m *ServerManager) Register(svc *services.Service) {
+	socketPath := m.socketPathFor(svc.ID)
+
+	sp := &ServerProcess{
+		svc:         svc,
+		state:       ServerStopped,
+		socketPath:  socketPath,
+		runDir:      m.runDir,
+		maxFailures: 3,
+	}
+
+	m.mu.Lock()
+	m.servers[svc.ID] = sp
+	m.mu.Unlock()
+
+	if svc.Startup == "eager" {
+		go sp.start()
+	}
+}
+
+// Remove stops and removes a server-mode service.
+func (m *ServerManager) Remove(serviceID string) {
+	m.mu.Lock()
+	sp, ok := m.servers[serviceID]
+	if ok {
+		delete(m.servers, serviceID)
+	}
+	m.mu.Unlock()
+
+	if ok {
+		sp.stop()
+	}
+}
+
+// Get returns the server process for a service, or nil.
+func (m *ServerManager) Get(serviceID string) *ServerProcess {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.servers[serviceID]
+}
+
+// StopAll stops all server processes gracefully.
+func (m *ServerManager) StopAll() {
+	m.mu.Lock()
+	servers := make([]*ServerProcess, 0, len(m.servers))
+	for _, sp := range m.servers {
+		servers = append(servers, sp)
+	}
+	m.servers = make(map[string]*ServerProcess)
+	m.mu.Unlock()
+
+	var wg sync.WaitGroup
+	for _, sp := range servers {
+		wg.Add(1)
+		go func(s *ServerProcess) {
+			defer wg.Done()
+			s.stop()
+		}(sp)
+	}
+	wg.Wait()
+}
+
+func (m *ServerManager) socketPathFor(serviceID string) string {
+	h := sha256.Sum256([]byte(serviceID))
+	name := fmt.Sprintf("%x.sock", h[:6]) // first 12 hex chars
+	return filepath.Join(m.runDir, name)
+}
+
+// EnsureRunning makes sure the server is started and healthy before dispatching a request.
+func (sp *ServerProcess) EnsureRunning() error {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+
+	switch sp.state {
+	case ServerHealthy:
+		return nil
+	case ServerStartFailed:
+		return fmt.Errorf("server failed to start after %d attempts", sp.maxFailures)
+	case ServerStopped:
+		return sp.startLocked()
+	case ServerUnhealthy:
+		// Apply backoff delay before restart: 1s, 2s, 4s, 8s, 16s, 30s (capped).
+		delay := sp.restartBackoff()
+		sp.mu.Unlock()
+		time.Sleep(delay)
+		sp.mu.Lock()
+		return sp.startLocked()
+	case ServerStarting:
+		// Already starting — unlock and wait.
+		sp.mu.Unlock()
+		err := sp.waitForHealthy()
+		sp.mu.Lock()
+		return err
+	}
+	return nil
+}
+
+// State returns the current server state.
+func (sp *ServerProcess) State() ServerState {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	return sp.state
+}
+
+func (sp *ServerProcess) restartBackoff() time.Duration {
+	// Backoff: 1s, 2s, 4s, 8s, 16s, 30s (capped).
+	delays := []time.Duration{
+		1 * time.Second, 2 * time.Second, 4 * time.Second,
+		8 * time.Second, 16 * time.Second, 30 * time.Second,
+	}
+	idx := sp.startFailures
+	if idx >= len(delays) {
+		idx = len(delays) - 1
+	}
+	return delays[idx]
+}
+
+func (sp *ServerProcess) start() error {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	return sp.startLocked()
+}
+
+func (sp *ServerProcess) startLocked() error {
+	sp.state = ServerStarting
+
+	// Clean up old socket.
+	_ = os.Remove(sp.socketPath)
+
+	argv := sp.svc.Start
+	// Resolve relative paths.
+	exe := argv[0]
+	if strings.HasPrefix(exe, "./") || strings.HasPrefix(exe, "../") {
+		exe = filepath.Join(sp.svc.Dir, exe)
+	}
+
+	cmd := exec.Command(exe, argv[1:]...)
+	cmd.Dir = sp.svc.WorkingDir
+	cmd.Env = append(os.Environ(), "CLAWVISOR_SOCKET="+sp.socketPath)
+	for k, v := range sp.svc.Env {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	if err := cmd.Start(); err != nil {
+		sp.state = ServerStartFailed
+		return fmt.Errorf("starting server: %w", err)
+	}
+
+	sp.cmd = cmd
+
+	// Set up HTTP client for Unix socket.
+	// No Timeout on the client itself — action timeouts are enforced via request contexts,
+	// and health check timeouts are enforced via the waitForHealthy deadline.
+	sp.httpClient = &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return net.DialTimeout("unix", sp.socketPath, 5*time.Second)
+			},
+		},
+	}
+
+	// Wait for health check in background (but we hold the lock here, so do it inline).
+	sp.mu.Unlock()
+	err := sp.waitForHealthy()
+	sp.mu.Lock()
+
+	if err != nil {
+		sp.startFailures++
+		if sp.startFailures >= sp.maxFailures {
+			sp.state = ServerStartFailed
+		} else {
+			sp.state = ServerUnhealthy
+		}
+		sp.killLocked()
+		return err
+	}
+
+	sp.state = ServerHealthy
+	sp.startFailures = 0
+
+	// Monitor for unexpected exit.
+	go sp.monitor()
+
+	return nil
+}
+
+func (sp *ServerProcess) waitForHealthy() error {
+	deadline := time.Now().Add(sp.svc.StartupTimeout)
+	healthURL := "http://unix" + sp.svc.HealthCheck
+
+	for time.Now().Before(deadline) {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
+		resp, err := sp.httpClient.Do(req)
+		cancel()
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == 200 {
+				return nil
+			}
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	return fmt.Errorf("server health check timed out after %s", sp.svc.StartupTimeout)
+}
+
+func (sp *ServerProcess) monitor() {
+	if sp.cmd == nil || sp.cmd.Process == nil {
+		return
+	}
+	_ = sp.cmd.Wait()
+
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+
+	if sp.state == ServerHealthy {
+		sp.state = ServerUnhealthy
+	}
+}
+
+func (sp *ServerProcess) stop() {
+	sp.mu.Lock()
+	defer sp.mu.Unlock()
+	sp.killLocked()
+	_ = os.Remove(sp.socketPath)
+}
+
+func (sp *ServerProcess) killLocked() {
+	if sp.cmd == nil || sp.cmd.Process == nil {
+		return
+	}
+
+	_ = sp.cmd.Process.Signal(syscall.SIGTERM)
+	done := make(chan struct{})
+	go func() {
+		_, _ = sp.cmd.Process.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		_ = sp.cmd.Process.Kill()
+		<-done
+	}
+	sp.cmd = nil
+}
+
+// Dispatch sends an HTTP request to the server process for a server-mode action.
+func (sp *ServerProcess) Dispatch(
+	ctx context.Context,
+	action *services.Action,
+	params map[string]string,
+	maxOutputSize int64,
+) *ServerResult {
+	if err := sp.EnsureRunning(); err != nil {
+		return &ServerResult{Success: false, Error: err.Error()}
+	}
+
+	// Apply action timeout to the request context.
+	if action.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, action.Timeout)
+		defer cancel()
+	}
+
+	// Build the HTTP request.
+	resolved := resolveParams(action, params)
+	reqURL := "http://unix" + action.Path
+
+	var bodyReader io.Reader
+	if action.Body != "" {
+		interpolated := InterpolateTemplate(action.Body, resolved, action.Params, action.BodyFormat)
+		bodyReader = strings.NewReader(interpolated)
+	}
+
+	// Add unreferenced params as query parameters.
+	// Params not mentioned in the body template are sent as query params.
+	{
+		unreferenced := make(map[string]string)
+		for name, value := range resolved {
+			if value == "" {
+				continue
+			}
+			if action.Body != "" && strings.Contains(action.Body, "{{"+name+"}}") {
+				continue
+			}
+			unreferenced[name] = value
+		}
+		if len(unreferenced) > 0 {
+			sep := "?"
+			if strings.Contains(reqURL, "?") {
+				sep = "&"
+			}
+			for name, value := range unreferenced {
+				reqURL += sep + url.QueryEscape(name) + "=" + url.QueryEscape(value)
+				sep = "&"
+			}
+		}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, action.Method, reqURL, bodyReader)
+	if err != nil {
+		return &ServerResult{Success: false, Error: fmt.Sprintf("building request: %s", err)}
+	}
+
+	// Merge service-level headers first, then action-level (action takes precedence).
+	for k, v := range sp.svc.Headers {
+		req.Header.Set(k, v)
+	}
+	for k, v := range action.Headers {
+		req.Header.Set(k, v)
+	}
+	if action.Body != "" && req.Header.Get("Content-Type") == "" {
+		if action.BodyFormat == "json" {
+			req.Header.Set("Content-Type", "application/json")
+		}
+	}
+
+	resp, err := sp.httpClient.Do(req)
+	if err != nil {
+		return &ServerResult{Success: false, Error: fmt.Sprintf("request failed: %s", err)}
+	}
+	defer resp.Body.Close()
+
+	// Read body with size limit.
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxOutputSize+1))
+	bodyResult := ProcessOutput(body, maxOutputSize)
+
+	contentType := resp.Header.Get("Content-Type")
+
+	// Forward response headers.
+	respHeaders := make(map[string]string)
+	for k := range resp.Header {
+		respHeaders[k] = resp.Header.Get(k)
+	}
+
+	result := &ServerResult{
+		Success: resp.StatusCode >= 200 && resp.StatusCode < 300,
+		Data: &ServerData{
+			Status:       resp.StatusCode,
+			Body:         bodyResult.Data,
+			BodyEncoding: bodyResult.Encoding,
+			ContentType:  contentType,
+			Headers:      respHeaders,
+		},
+	}
+
+	if !result.Success {
+		result.Error = fmt.Sprintf("HTTP %d", resp.StatusCode)
+	}
+
+	return result
+}
+
+// ServerResult holds the result of a server-mode action invocation.
+type ServerResult struct {
+	Success bool        `json:"success"`
+	Data    *ServerData `json:"data,omitempty"`
+	Error   string      `json:"error,omitempty"`
+}
+
+// ServerData holds the output data from a server-mode action.
+type ServerData struct {
+	Status       int    `json:"status"`
+	Body         string `json:"body"`
+	BodyEncoding string `json:"body_encoding,omitempty"`
+	ContentType  string `json:"content_type"`
+	Headers      map[string]string `json:"headers,omitempty"`
+}

--- a/internal/local/executor/server.go
+++ b/internal/local/executor/server.go
@@ -36,6 +36,7 @@ type ServerProcess struct {
 	svc           *services.Service
 	state         ServerState
 	cmd           *exec.Cmd
+	done          chan struct{} // closed when cmd.Wait() returns
 	socketPath    string
 	httpClient    *http.Client
 	runDir        string
@@ -148,28 +149,36 @@ func (sp *ServerProcess) EnsureRunning() error {
 	sp.mu.Lock()
 	defer sp.mu.Unlock()
 
-	switch sp.state {
-	case ServerHealthy:
+	for {
+		switch sp.state {
+		case ServerHealthy:
+			return nil
+		case ServerStartFailed:
+			return fmt.Errorf("server failed to start after %d attempts", sp.maxFailures)
+		case ServerStopped, ServerUnhealthy:
+			if sp.state == ServerUnhealthy {
+				// Apply backoff delay before restart.
+				delay := sp.restartBackoff()
+				sp.mu.Unlock()
+				time.Sleep(delay)
+				sp.mu.Lock()
+				// Recheck — another goroutine may have started it while we slept.
+				continue
+			}
+			return sp.startLocked()
+		case ServerStarting:
+			// Already starting — wait for it without holding the lock.
+			done := sp.done
+			sp.mu.Unlock()
+			if done != nil {
+				<-done
+			}
+			sp.mu.Lock()
+			// Recheck state — startLocked may have failed or succeeded.
+			continue
+		}
 		return nil
-	case ServerStartFailed:
-		return fmt.Errorf("server failed to start after %d attempts", sp.maxFailures)
-	case ServerStopped:
-		return sp.startLocked()
-	case ServerUnhealthy:
-		// Apply backoff delay before restart: 1s, 2s, 4s, 8s, 16s, 30s (capped).
-		delay := sp.restartBackoff()
-		sp.mu.Unlock()
-		time.Sleep(delay)
-		sp.mu.Lock()
-		return sp.startLocked()
-	case ServerStarting:
-		// Already starting — unlock and wait.
-		sp.mu.Unlock()
-		err := sp.waitForHealthy()
-		sp.mu.Lock()
-		return err
 	}
-	return nil
 }
 
 // State returns the current server state.
@@ -226,9 +235,16 @@ func (sp *ServerProcess) startLocked() error {
 
 	sp.cmd = cmd
 
+	// Create a done channel that closes when the process exits.
+	// This is the single Wait point — no other code should call cmd.Wait().
+	done := make(chan struct{})
+	sp.done = done
+	go func() {
+		_ = cmd.Wait()
+		close(done)
+	}()
+
 	// Set up HTTP client for Unix socket.
-	// No Timeout on the client itself — action timeouts are enforced via request contexts,
-	// and health check timeouts are enforced via the waitForHealthy deadline.
 	sp.httpClient = &http.Client{
 		Transport: &http.Transport{
 			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
@@ -237,10 +253,31 @@ func (sp *ServerProcess) startLocked() error {
 		},
 	}
 
-	// Wait for health check in background (but we hold the lock here, so do it inline).
+	// Wait for health check — release the lock so health check HTTP requests
+	// and concurrent Dispatch calls are not blocked.
 	sp.mu.Unlock()
 	err := sp.waitForHealthy()
 	sp.mu.Lock()
+
+	// Recheck: if the process exited during health check, reflect that.
+	select {
+	case <-done:
+		if sp.state == ServerStarting {
+			sp.startFailures++
+			if sp.startFailures >= sp.maxFailures {
+				sp.state = ServerStartFailed
+			} else {
+				sp.state = ServerUnhealthy
+			}
+		}
+		sp.cmd = nil
+		sp.done = nil
+		if err == nil {
+			err = fmt.Errorf("server process exited during startup")
+		}
+		return err
+	default:
+	}
 
 	if err != nil {
 		sp.startFailures++
@@ -257,7 +294,7 @@ func (sp *ServerProcess) startLocked() error {
 	sp.startFailures = 0
 
 	// Monitor for unexpected exit.
-	go sp.monitor()
+	go sp.monitor(done)
 
 	return nil
 }
@@ -282,11 +319,9 @@ func (sp *ServerProcess) waitForHealthy() error {
 	return fmt.Errorf("server health check timed out after %s", sp.svc.StartupTimeout)
 }
 
-func (sp *ServerProcess) monitor() {
-	if sp.cmd == nil || sp.cmd.Process == nil {
-		return
-	}
-	_ = sp.cmd.Wait()
+// monitor watches for process exit via the done channel (no Wait call needed).
+func (sp *ServerProcess) monitor(done <-chan struct{}) {
+	<-done
 
 	sp.mu.Lock()
 	defer sp.mu.Unlock()
@@ -303,25 +338,31 @@ func (sp *ServerProcess) stop() {
 	_ = os.Remove(sp.socketPath)
 }
 
+// killLocked sends SIGTERM, waits for exit via the done channel, then
+// SIGKILL if the grace period expires. Does not call Wait directly.
 func (sp *ServerProcess) killLocked() {
 	if sp.cmd == nil || sp.cmd.Process == nil {
 		return
 	}
 
+	done := sp.done
 	_ = sp.cmd.Process.Signal(syscall.SIGTERM)
-	done := make(chan struct{})
-	go func() {
-		_, _ = sp.cmd.Process.Wait()
-		close(done)
-	}()
 
+	// Release lock while waiting so monitor/other goroutines aren't blocked.
+	sp.mu.Unlock()
+
+	timer := time.NewTimer(5 * time.Second)
 	select {
 	case <-done:
-	case <-time.After(5 * time.Second):
+		timer.Stop()
+	case <-timer.C:
 		_ = sp.cmd.Process.Kill()
 		<-done
 	}
+
+	sp.mu.Lock()
 	sp.cmd = nil
+	sp.done = nil
 }
 
 // Dispatch sends an HTTP request to the server process for a server-mode action.

--- a/internal/local/executor/server.go
+++ b/internal/local/executor/server.go
@@ -261,9 +261,10 @@ func (sp *ServerProcess) startLocked() error {
 	}
 
 	// Wait for health check — release the lock so health check HTTP requests
-	// and concurrent Dispatch calls are not blocked.
+	// and concurrent Dispatch calls are not blocked. Pass the done channel
+	// so we bail early if the process exits during startup.
 	sp.mu.Unlock()
-	err := sp.waitForHealthy()
+	err := sp.waitForHealthy(done)
 	sp.mu.Lock()
 
 	// Recheck: if the process exited during health check, reflect that.
@@ -306,11 +307,18 @@ func (sp *ServerProcess) startLocked() error {
 	return nil
 }
 
-func (sp *ServerProcess) waitForHealthy() error {
+func (sp *ServerProcess) waitForHealthy(done <-chan struct{}) error {
 	deadline := time.Now().Add(sp.svc.StartupTimeout)
 	healthURL := "http://unix" + sp.svc.HealthCheck
 
 	for time.Now().Before(deadline) {
+		// Bail early if the process exited.
+		select {
+		case <-done:
+			return fmt.Errorf("server process exited during startup")
+		default:
+		}
+
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
 		resp, err := sp.httpClient.Do(req)

--- a/internal/local/executor/template.go
+++ b/internal/local/executor/template.go
@@ -1,0 +1,47 @@
+package executor
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/clawvisor/clawvisor/internal/local/services"
+)
+
+// InterpolateTemplate replaces {{param_name}} placeholders in a template string
+// with corresponding parameter values. Only declared params are replaced.
+func InterpolateTemplate(template string, params map[string]string, declaredParams []services.Param, format string) string {
+	if template == "" {
+		return ""
+	}
+
+	// Build set of declared param names.
+	declared := make(map[string]bool, len(declaredParams))
+	for _, p := range declaredParams {
+		declared[p.Name] = true
+	}
+
+	result := template
+	for name, value := range params {
+		if !declared[name] {
+			continue
+		}
+		placeholder := "{{" + name + "}}"
+		var replacement string
+		if format == "json" {
+			replacement = jsonEscape(value)
+		} else {
+			replacement = value
+		}
+		result = strings.ReplaceAll(result, placeholder, replacement)
+	}
+
+	return result
+}
+
+// jsonEscape escapes a string for safe inclusion in a JSON string value.
+func jsonEscape(s string) string {
+	// Marshal produces a quoted JSON string; strip the surrounding quotes.
+	b, _ := json.Marshal(s)
+	// Remove leading and trailing "
+	return string(b[1 : len(b)-1])
+}

--- a/internal/local/pairing/code.go
+++ b/internal/local/pairing/code.go
@@ -1,0 +1,77 @@
+package pairing
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"sync"
+	"time"
+)
+
+const (
+	codeLifetime = 60 * time.Second
+	codeLength   = 6
+	nonceLength  = 12 // 12 hex chars = 6 bytes
+)
+
+// CodeManager manages the generation and validation of pairing codes.
+type CodeManager struct {
+	mu      sync.Mutex
+	code    string
+	nonce   string
+	expires time.Time
+}
+
+// NewCodeManager creates a new pairing code manager.
+func NewCodeManager() *CodeManager {
+	return &CodeManager{}
+}
+
+// CurrentCode returns the current pairing code, generating a new one if needed.
+func (m *CodeManager) CurrentCode() (code, nonce string, expiresAt time.Time) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.code == "" || time.Now().After(m.expires) {
+		m.generate()
+	}
+
+	return m.code, m.nonce, m.expires
+}
+
+// Validate checks if the given code and nonce match the current active pair.
+// On success, the code is consumed (invalidated).
+func (m *CodeManager) Validate(code, nonce string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.code == "" || time.Now().After(m.expires) {
+		return false
+	}
+	if m.code != code || m.nonce != nonce {
+		return false
+	}
+
+	// Consume the code.
+	m.generate()
+	return true
+}
+
+func (m *CodeManager) generate() {
+	m.code = generateNumericCode(codeLength)
+	m.nonce = generateNonce(nonceLength)
+	m.expires = time.Now().Add(codeLifetime)
+}
+
+func generateNumericCode(length int) string {
+	max := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(length)), nil)
+	n, _ := rand.Int(rand.Reader, max)
+	return fmt.Sprintf("%0*d", length, n)
+}
+
+func generateNonce(hexLength int) string {
+	b := make([]byte, hexLength/2)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}

--- a/internal/local/pairing/server.go
+++ b/internal/local/pairing/server.go
@@ -1,0 +1,213 @@
+package pairing
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Server is the localhost HTTP server for pairing and status.
+type Server struct {
+	port            int
+	daemonID        string
+	daemonName      string
+	allowedOrigins  []string
+	codeMgr         *CodeManager
+	onPairComplete  func(token, origin string) error
+	statusHandler   func() interface{}
+	reloadHandler   func() interface{}
+	mux             *http.ServeMux
+	server          *http.Server
+}
+
+// ServerConfig holds configuration for the pairing server.
+type ServerConfig struct {
+	Port            int
+	DaemonID        string
+	DaemonName      string
+	AllowedOrigins  []string
+	OnPairComplete  func(token, origin string) error
+	StatusHandler   func() interface{}
+	ReloadHandler   func() interface{}
+}
+
+// NewServer creates a new pairing HTTP server.
+func NewServer(cfg ServerConfig) *Server {
+	s := &Server{
+		port:           cfg.Port,
+		daemonID:       cfg.DaemonID,
+		daemonName:     cfg.DaemonName,
+		allowedOrigins: cfg.AllowedOrigins,
+		codeMgr:        NewCodeManager(),
+		onPairComplete: cfg.OnPairComplete,
+		statusHandler:  cfg.StatusHandler,
+		reloadHandler:  cfg.ReloadHandler,
+		mux:            http.NewServeMux(),
+	}
+
+	s.mux.HandleFunc("/api/pairing/code", s.handleCORS(s.handlePairingCode))
+	s.mux.HandleFunc("/api/pairing/complete", s.handleCORS(s.handlePairingComplete))
+	s.mux.HandleFunc("/api/status", s.handleCORS(s.handleStatus))
+	s.mux.HandleFunc("/api/services/reload", s.handleCORS(s.handleReload))
+
+	return s
+}
+
+// Start begins listening on localhost.
+func (s *Server) Start() error {
+	addr := fmt.Sprintf("127.0.0.1:%d", s.port)
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("binding to %s: %w", addr, err)
+	}
+
+	s.server = &http.Server{
+		Handler:      s.mux,
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 10 * time.Second,
+	}
+
+	go func() {
+		if err := s.server.Serve(listener); err != nil && err != http.ErrServerClosed {
+			slog.Warn("pairing server error", "err", err)
+		}
+	}()
+
+	slog.Info("pairing server listening", "addr", addr)
+	return nil
+}
+
+// Stop gracefully shuts down the server.
+func (s *Server) Stop() {
+	if s.server != nil {
+		_ = s.server.Close()
+	}
+}
+
+func (s *Server) handlePairingCode(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	code, nonce, expiresAt := s.codeMgr.CurrentCode()
+
+	resp := map[string]interface{}{
+		"daemon_id":  s.daemonID,
+		"code":       code,
+		"nonce":      nonce,
+		"name":       s.daemonName,
+		"expires_at": expiresAt.Format(time.RFC3339),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+func (s *Server) handlePairingComplete(w http.ResponseWriter, r *http.Request) {
+	// OPTIONS is already handled by the CORS wrapper.
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Validate Origin header.
+	origin := r.Header.Get("Origin")
+	if !s.isAllowedOrigin(origin) {
+		http.Error(w, "forbidden: invalid origin", http.StatusForbidden)
+		return
+	}
+
+	var req struct {
+		Code            string `json:"code"`
+		Nonce           string `json:"nonce"`
+		ConnectionToken string `json:"connection_token"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+
+	// Validate code + nonce.
+	if !s.codeMgr.Validate(req.Code, req.Nonce) {
+		http.Error(w, "forbidden: invalid code or nonce", http.StatusForbidden)
+		return
+	}
+
+	// Derive cloud origin from the validated HTTP Origin header.
+	if s.onPairComplete != nil {
+		if err := s.onPairComplete(req.ConnectionToken, origin); err != nil {
+			http.Error(w, "internal error: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+
+func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if s.statusHandler != nil {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(s.statusHandler())
+	} else {
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+func (s *Server) handleReload(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if s.reloadHandler != nil {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(s.reloadHandler())
+	} else {
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+func (s *Server) handleCORS(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		origin := r.Header.Get("Origin")
+		if s.isAllowedOrigin(origin) {
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+			w.Header().Set("Vary", "Origin")
+		} else if origin != "" {
+			http.Error(w, "forbidden: origin not allowed", http.StatusForbidden)
+			return
+		}
+
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		next(w, r)
+	}
+}
+
+func (s *Server) isAllowedOrigin(origin string) bool {
+	if origin == "" {
+		return false
+	}
+	for _, allowed := range s.allowedOrigins {
+		if strings.EqualFold(origin, allowed) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/local/services/discovery.go
+++ b/internal/local/services/discovery.go
@@ -1,0 +1,110 @@
+package services
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// DiscoverResult holds the results of scanning service directories.
+type DiscoverResult struct {
+	Services []*Service
+	Excluded []ExcludedService
+}
+
+// Discover walks the given directories looking for service.yaml files,
+// parses them, and returns loaded services plus any that were excluded.
+func Discover(dirs []string, defaultTimeout time.Duration) *DiscoverResult {
+	result := &DiscoverResult{}
+
+	type candidate struct {
+		service *Service
+		relPath string
+		baseDir string
+	}
+
+	var candidates []candidate
+
+	for _, dir := range dirs {
+		dir = filepath.Clean(dir)
+		if _, err := os.Stat(dir); os.IsNotExist(err) {
+			continue
+		}
+
+		_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return nil
+			}
+			if info.Name() != "service.yaml" {
+				return nil
+			}
+
+			svc, parseErr := ParseManifest(path, defaultTimeout)
+			if parseErr != nil {
+				// Categorize the error.
+				cat := "invalid"
+				if _, ok := parseErr.(*PlatformMismatchError); ok {
+					cat = "unsupported"
+				}
+				rel, _ := filepath.Rel(dir, path)
+				result.Excluded = append(result.Excluded, ExcludedService{
+					Path:     rel,
+					Category: cat,
+					Error:    parseErr.Error(),
+				})
+				return nil
+			}
+
+			// Derive service ID from path if not explicitly set.
+			svcDir := filepath.Dir(path)
+			rel, _ := filepath.Rel(dir, svcDir)
+			derivedID := strings.ReplaceAll(rel, string(filepath.Separator), ".")
+
+			if svc.ID == "" {
+				svc.ID = derivedID
+			}
+
+			candidates = append(candidates, candidate{
+				service: svc,
+				relPath: rel,
+				baseDir: dir,
+			})
+			return nil
+		})
+	}
+
+	// Check for duplicate IDs.
+	idMap := make(map[string][]candidate)
+	for _, c := range candidates {
+		idMap[c.service.ID] = append(idMap[c.service.ID], c)
+	}
+
+	for id, cs := range idMap {
+		if len(cs) == 1 {
+			result.Services = append(result.Services, cs[0].service)
+		} else {
+			// All duplicates are excluded. Use relative paths for display.
+			relPaths := make([]string, len(cs))
+			for i, c := range cs {
+				relPaths[i] = filepath.Join(c.relPath, "service.yaml")
+			}
+			for i := range cs {
+				otherPaths := make([]string, 0, len(relPaths)-1)
+				for j, p := range relPaths {
+					if j != i {
+						otherPaths = append(otherPaths, p)
+					}
+				}
+				result.Excluded = append(result.Excluded, ExcludedService{
+					Path:     relPaths[i],
+					Category: "conflict",
+					Error:    fmt.Sprintf("duplicate ID: %s (also defined in %s)", id, strings.Join(otherPaths, ", ")),
+				})
+			}
+		}
+	}
+
+	return result
+}

--- a/internal/local/services/manifest.go
+++ b/internal/local/services/manifest.go
@@ -1,0 +1,363 @@
+package services
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Service represents a parsed and validated service.yaml.
+type Service struct {
+	ID          string
+	Name        string
+	Description string
+	Icon        string
+	Platform    string
+	Type        string // "exec" or "server"
+	Dir         string // absolute path to the service directory
+
+	// Server-mode fields.
+	Start          []string
+	StartupTimeout time.Duration
+	Startup        string // "lazy" or "eager"
+	HealthCheck    string
+
+	// Shared fields.
+	Env        map[string]string
+	Headers    map[string]string // Service-level headers (server mode).
+	WorkingDir string
+	Actions    []Action
+
+	// Source path for error reporting.
+	ManifestPath string
+}
+
+// Action represents an action within a service.
+type Action struct {
+	ID          string
+	Name        string
+	Description string
+
+	// Exec-mode fields.
+	Run   []string // parsed argv
+	Stdin string
+
+	// Server-mode fields.
+	Method     string
+	Path       string
+	Body       string
+	BodyFormat string // "json" or "text"
+	Headers    map[string]string
+
+	// Shared.
+	Env     map[string]string
+	Timeout time.Duration
+	Params  []Param
+}
+
+// Param represents an action parameter declaration.
+type Param struct {
+	Name        string
+	Description string
+	Type        string // "string", "number", "boolean", "json"
+	Required    bool
+	Default     *string
+}
+
+// rawManifest is the YAML structure before validation.
+type rawManifest struct {
+	Name        string            `yaml:"name"`
+	ID          string            `yaml:"id"`
+	Description string            `yaml:"description"`
+	Icon        string            `yaml:"icon"`
+	Platform    string            `yaml:"platform"`
+	Type        string            `yaml:"type"`
+	Start       interface{}       `yaml:"start"`
+	StartupTimeout int            `yaml:"startup_timeout"`
+	Startup     string            `yaml:"startup"`
+	HealthCheck string            `yaml:"health_check"`
+	Env         map[string]string `yaml:"env"`
+	Headers     map[string]string `yaml:"headers"`
+	WorkingDir  string            `yaml:"working_dir"`
+	Actions     []rawAction       `yaml:"actions"`
+}
+
+type rawAction struct {
+	ID          string            `yaml:"id"`
+	Name        string            `yaml:"name"`
+	Description string            `yaml:"description"`
+	Run         interface{}       `yaml:"run"`
+	Stdin       string            `yaml:"stdin"`
+	Method      string            `yaml:"method"`
+	Path        string            `yaml:"path"`
+	Body        string            `yaml:"body"`
+	BodyFormat  string            `yaml:"body_format"`
+	Headers     map[string]string `yaml:"headers"`
+	Env         map[string]string `yaml:"env"`
+	Timeout     string            `yaml:"timeout"`
+	Params      []rawParam        `yaml:"params"`
+}
+
+type rawParam struct {
+	Name        string  `yaml:"name"`
+	Description string  `yaml:"description"`
+	Type        string  `yaml:"type"`
+	Required    bool    `yaml:"required"`
+	Default     *string `yaml:"default"`
+}
+
+// ExcludedService represents a service that failed to load.
+type ExcludedService struct {
+	Path     string `json:"path"`
+	Category string `json:"category"` // "invalid", "conflict", "unsupported"
+	Error    string `json:"error"`
+}
+
+// ParseManifest reads and validates a service.yaml file.
+func ParseManifest(path string, defaultTimeout time.Duration) (*Service, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading manifest: %w", err)
+	}
+
+	var raw rawManifest
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parsing YAML: %w", err)
+	}
+
+	if raw.Name == "" {
+		return nil, fmt.Errorf("missing required field: name")
+	}
+
+	svcType := raw.Type
+	if svcType == "" {
+		svcType = "exec"
+	}
+	if svcType != "exec" && svcType != "server" {
+		return nil, fmt.Errorf("invalid type: %q (must be exec or server)", svcType)
+	}
+
+	// Check platform.
+	if raw.Platform != "" && raw.Platform != runtime.GOOS {
+		return nil, &PlatformMismatchError{
+			Required: raw.Platform,
+			Running:  runtime.GOOS,
+		}
+	}
+
+	dir := filepath.Dir(path)
+
+	svc := &Service{
+		ID:           raw.ID, // May be empty; discovery fills in the path-derived ID if so.
+		Name:         raw.Name,
+		Description:  raw.Description,
+		Icon:         raw.Icon,
+		Platform:     raw.Platform,
+		Type:         svcType,
+		Dir:          dir,
+		Env:          raw.Env,
+		Headers:      raw.Headers,
+		ManifestPath: path,
+	}
+
+	if svc.Env == nil {
+		svc.Env = make(map[string]string)
+	}
+	if svc.Headers == nil {
+		svc.Headers = make(map[string]string)
+	}
+
+	// Working directory.
+	if raw.WorkingDir != "" && raw.WorkingDir != "." {
+		if filepath.IsAbs(raw.WorkingDir) {
+			svc.WorkingDir = raw.WorkingDir
+		} else {
+			svc.WorkingDir = filepath.Join(dir, raw.WorkingDir)
+		}
+	} else {
+		svc.WorkingDir = dir
+	}
+
+	// Server-mode fields.
+	if svcType == "server" {
+		start, err := parseCommand(raw.Start)
+		if err != nil {
+			return nil, fmt.Errorf("parsing start command: %w", err)
+		}
+		if len(start) == 0 {
+			return nil, fmt.Errorf("server-mode service requires a start command")
+		}
+		svc.Start = start
+
+		svc.StartupTimeout = 10 * time.Second
+		if raw.StartupTimeout > 0 {
+			svc.StartupTimeout = time.Duration(raw.StartupTimeout) * time.Second
+		}
+
+		svc.Startup = "lazy"
+		if raw.Startup == "eager" {
+			svc.Startup = "eager"
+		}
+
+		svc.HealthCheck = "/health"
+		if raw.HealthCheck != "" {
+			svc.HealthCheck = raw.HealthCheck
+		}
+	}
+
+	// Parse actions.
+	if len(raw.Actions) == 0 {
+		return nil, fmt.Errorf("service must have at least one action")
+	}
+
+	seenActions := make(map[string]bool)
+	for _, ra := range raw.Actions {
+		action, err := parseAction(ra, svcType, dir, defaultTimeout)
+		if err != nil {
+			return nil, fmt.Errorf("action %q: %w", ra.ID, err)
+		}
+		if seenActions[action.ID] {
+			return nil, fmt.Errorf("duplicate action ID: %q", action.ID)
+		}
+		seenActions[action.ID] = true
+		svc.Actions = append(svc.Actions, *action)
+	}
+
+	return svc, nil
+}
+
+func parseAction(ra rawAction, svcType, svcDir string, defaultTimeout time.Duration) (*Action, error) {
+	if ra.ID == "" {
+		return nil, fmt.Errorf("missing required field: id")
+	}
+
+	a := &Action{
+		ID:          ra.ID,
+		Name:        ra.Name,
+		Description: ra.Description,
+		Stdin:       ra.Stdin,
+		Method:      ra.Method,
+		Path:        ra.Path,
+		Body:        ra.Body,
+		Headers:     ra.Headers,
+		Env:         ra.Env,
+		Timeout:     defaultTimeout,
+	}
+
+	if a.Name == "" {
+		a.Name = a.ID
+	}
+	if a.Env == nil {
+		a.Env = make(map[string]string)
+	}
+	if a.Headers == nil {
+		a.Headers = make(map[string]string)
+	}
+
+	// Body format.
+	a.BodyFormat = ra.BodyFormat
+	if a.BodyFormat == "" && a.Body != "" {
+		a.BodyFormat = "json"
+	}
+	if a.BodyFormat == "" {
+		a.BodyFormat = "text"
+	}
+
+	// Timeout.
+	if ra.Timeout != "" {
+		dur, err := time.ParseDuration(ra.Timeout)
+		if err != nil {
+			return nil, fmt.Errorf("invalid timeout %q: %w", ra.Timeout, err)
+		}
+		a.Timeout = dur
+	}
+
+	// Parse params and validate.
+	for _, rp := range ra.Params {
+		if rp.Name == "" {
+			return nil, fmt.Errorf("param missing name")
+		}
+		if rp.Required && rp.Default != nil {
+			return nil, fmt.Errorf("param %q has both required and default", rp.Name)
+		}
+		p := Param{
+			Name:        rp.Name,
+			Description: rp.Description,
+			Type:        rp.Type,
+			Required:    rp.Required,
+			Default:     rp.Default,
+		}
+		if p.Type == "" {
+			p.Type = "string"
+		}
+		a.Params = append(a.Params, p)
+	}
+
+	// Type-specific validation.
+	if svcType == "exec" {
+		run, err := parseCommand(ra.Run)
+		if err != nil {
+			return nil, fmt.Errorf("parsing run command: %w", err)
+		}
+		if len(run) == 0 {
+			return nil, fmt.Errorf("exec-mode action requires a run command")
+		}
+		// Resolve relative paths.
+		if strings.HasPrefix(run[0], "./") || strings.HasPrefix(run[0], "../") {
+			run[0] = filepath.Join(svcDir, run[0])
+		}
+		a.Run = run
+	} else {
+		// Server mode.
+		if a.Method == "" {
+			a.Method = "GET"
+		}
+		a.Method = strings.ToUpper(a.Method)
+		if a.Path == "" {
+			return nil, fmt.Errorf("server-mode action requires a path")
+		}
+	}
+
+	return a, nil
+}
+
+func parseCommand(v interface{}) ([]string, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	switch val := v.(type) {
+	case string:
+		if val == "" {
+			return nil, nil
+		}
+		return Shlex(val)
+	case []interface{}:
+		var args []string
+		for _, item := range val {
+			s, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("command array elements must be strings")
+			}
+			args = append(args, s)
+		}
+		return args, nil
+	default:
+		return nil, fmt.Errorf("command must be a string or array of strings")
+	}
+}
+
+// PlatformMismatchError indicates a service is for a different platform.
+type PlatformMismatchError struct {
+	Required string
+	Running  string
+}
+
+func (e *PlatformMismatchError) Error() string {
+	return fmt.Sprintf("platform mismatch: requires %s, running %s", e.Required, e.Running)
+}

--- a/internal/local/services/registry.go
+++ b/internal/local/services/registry.go
@@ -1,0 +1,101 @@
+package services
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"sync"
+)
+
+// Registry holds the active set of loaded services and supports atomic swap on reload.
+type Registry struct {
+	mu       sync.RWMutex
+	services map[string]*Service
+	excluded []ExcludedService
+}
+
+// NewRegistry creates an empty registry.
+func NewRegistry() *Registry {
+	return &Registry{
+		services: make(map[string]*Service),
+	}
+}
+
+// Load atomically replaces the registry contents with the given discovery result.
+func (r *Registry) Load(result *DiscoverResult) {
+	newMap := make(map[string]*Service, len(result.Services))
+	for _, svc := range result.Services {
+		newMap[svc.ID] = svc
+	}
+
+	r.mu.Lock()
+	r.services = newMap
+	r.excluded = result.Excluded
+	r.mu.Unlock()
+}
+
+// Get returns a service by ID, or nil if not found.
+func (r *Registry) Get(id string) *Service {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.services[id]
+}
+
+// GetAction returns a service and action by their IDs.
+func (r *Registry) GetAction(serviceID, actionID string) (*Service, *Action) {
+	svc := r.Get(serviceID)
+	if svc == nil {
+		return nil, nil
+	}
+	for i := range svc.Actions {
+		if svc.Actions[i].ID == actionID {
+			return svc, &svc.Actions[i]
+		}
+	}
+	return svc, nil
+}
+
+// All returns a snapshot of all loaded services.
+func (r *Registry) All() []*Service {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	result := make([]*Service, 0, len(r.services))
+	for _, svc := range r.services {
+		result = append(result, svc)
+	}
+	return result
+}
+
+// Excluded returns the list of excluded services.
+func (r *Registry) Excluded() []ExcludedService {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.excluded
+}
+
+// RestartHash computes a SHA-256 hash of all runtime-relevant fields for a server-mode service.
+// Used to determine whether a server process needs to be restarted on reload.
+func RestartHash(svc *Service) string {
+	h := sha256.New()
+	data, _ := json.Marshal(struct {
+		Start          []string
+		Env            map[string]string
+		Headers        map[string]string
+		WorkingDir     string
+		HealthCheck    string
+		StartupTimeout string
+		Platform       string
+		Actions        []Action
+	}{
+		Start:          svc.Start,
+		Env:            svc.Env,
+		Headers:        svc.Headers,
+		WorkingDir:     svc.WorkingDir,
+		HealthCheck:    svc.HealthCheck,
+		StartupTimeout: svc.StartupTimeout.String(),
+		Platform:       svc.Platform,
+		Actions:        svc.Actions,
+	})
+	h.Write(data)
+	return fmt.Sprintf("%x", h.Sum(nil))
+}

--- a/internal/local/services/shlex.go
+++ b/internal/local/services/shlex.go
@@ -1,0 +1,83 @@
+package services
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Shlex splits a string into tokens using POSIX shell tokenization rules.
+// It supports single quotes, double quotes with backslash escapes, and
+// backslash escaping outside quotes. It does NOT invoke a shell.
+func Shlex(s string) ([]string, error) {
+	var tokens []string
+	var current strings.Builder
+	inToken := false
+
+	i := 0
+	for i < len(s) {
+		ch := s[i]
+
+		switch {
+		case ch == '\'':
+			// Single-quoted string: everything until closing single quote is literal.
+			inToken = true
+			i++
+			for i < len(s) && s[i] != '\'' {
+				current.WriteByte(s[i])
+				i++
+			}
+			if i >= len(s) {
+				return nil, fmt.Errorf("unterminated single quote")
+			}
+			i++ // skip closing quote
+
+		case ch == '"':
+			// Double-quoted string: backslash escapes work inside.
+			inToken = true
+			i++
+			for i < len(s) && s[i] != '"' {
+				if s[i] == '\\' && i+1 < len(s) {
+					i++
+					current.WriteByte(s[i])
+				} else {
+					current.WriteByte(s[i])
+				}
+				i++
+			}
+			if i >= len(s) {
+				return nil, fmt.Errorf("unterminated double quote")
+			}
+			i++ // skip closing quote
+
+		case ch == '\\':
+			// Backslash outside quotes: escape next character.
+			inToken = true
+			i++
+			if i >= len(s) {
+				return nil, fmt.Errorf("trailing backslash")
+			}
+			current.WriteByte(s[i])
+			i++
+
+		case ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r':
+			// Whitespace: end current token.
+			if inToken {
+				tokens = append(tokens, current.String())
+				current.Reset()
+				inToken = false
+			}
+			i++
+
+		default:
+			inToken = true
+			current.WriteByte(ch)
+			i++
+		}
+	}
+
+	if inToken {
+		tokens = append(tokens, current.String())
+	}
+
+	return tokens, nil
+}

--- a/internal/local/state/state.go
+++ b/internal/local/state/state.go
@@ -1,0 +1,142 @@
+package state
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// State represents the persisted pairing state in state.json.
+type State struct {
+	DaemonID        string    `json:"daemon_id"`
+	CloudOrigin     string    `json:"cloud_origin,omitempty"`
+	ConnectionToken string    `json:"connection_token,omitempty"`
+	PairedAt        time.Time `json:"paired_at,omitempty"`
+}
+
+// IsPaired returns true if a connection token is present.
+func (s *State) IsPaired() bool {
+	return s.ConnectionToken != ""
+}
+
+// Load reads state.json from the base directory.
+// If the file doesn't exist, generates a new daemon ID and returns unpaired state.
+func Load(baseDir string) (*State, error) {
+	path := filepath.Join(baseDir, "state.json")
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return newState()
+		}
+		return nil, fmt.Errorf("reading state: %w", err)
+	}
+
+	// Check permissions.
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("stat state.json: %w", err)
+	}
+	if info.Mode().Perm()&0077 != 0 {
+		return nil, fmt.Errorf("state.json is world-readable (mode %o); refusing to start — fix with: chmod 600 %s", info.Mode().Perm(), path)
+	}
+
+	var s State
+	if err := json.Unmarshal(data, &s); err != nil {
+		// Corrupt file — try to salvage the daemon_id via a partial parse.
+		id := salvageDaemonID(data)
+		_ = os.Remove(path)
+		if id != "" {
+			return &State{DaemonID: id}, nil
+		}
+		return newState()
+	}
+
+	if s.DaemonID == "" {
+		// Missing daemon_id — generate a new one; the spec says generated once,
+		// but with no ID to preserve we have no choice.
+		_ = os.Remove(path)
+		return newState()
+	}
+
+	return &s, nil
+}
+
+// Save writes state.json atomically to the base directory.
+func Save(baseDir string, s *State) error {
+	if err := os.MkdirAll(baseDir, 0700); err != nil {
+		return fmt.Errorf("creating state dir: %w", err)
+	}
+
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshalling state: %w", err)
+	}
+
+	path := filepath.Join(baseDir, "state.json")
+	tmp := path + ".tmp"
+
+	if err := os.WriteFile(tmp, data, 0600); err != nil {
+		return fmt.Errorf("writing temp state: %w", err)
+	}
+
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("renaming state: %w", err)
+	}
+
+	return nil
+}
+
+// Clear removes pairing info but preserves the daemon ID.
+func Clear(baseDir string, daemonID string) error {
+	s := &State{DaemonID: daemonID}
+	return Save(baseDir, s)
+}
+
+// salvageDaemonID attempts to extract the daemon_id from corrupt JSON
+// so that a corrupted state file doesn't lose the daemon's identity.
+func salvageDaemonID(data []byte) string {
+	var partial map[string]json.RawMessage
+	if err := json.Unmarshal(data, &partial); err != nil {
+		return ""
+	}
+	raw, ok := partial["daemon_id"]
+	if !ok {
+		return ""
+	}
+	var id string
+	if json.Unmarshal(raw, &id) != nil {
+		return ""
+	}
+	return id
+}
+
+func newState() (*State, error) {
+	id, err := generateDaemonID()
+	if err != nil {
+		return nil, fmt.Errorf("generating daemon ID: %w", err)
+	}
+	return &State{DaemonID: id}, nil
+}
+
+func generateDaemonID() (string, error) {
+	b := make([]byte, 4) // 4 bytes = 8 hex chars
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// GenerateConnectionToken generates a 256-bit random connection token.
+func GenerateConnectionToken() (string, error) {
+	b := make([]byte, 32) // 32 bytes = 64 hex chars
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}

--- a/internal/local/tunnel/client.go
+++ b/internal/local/tunnel/client.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
-	"strings"
 	"sync"
 	"time"
 
@@ -350,13 +349,11 @@ func (c *Client) buildCapabilities() CapabilitiesPayload {
 	return caps
 }
 
+// authFailureCode is the WebSocket close code the cloud sends on auth failure.
+const authFailureCode = websocket.StatusCode(4001)
+
 func isAuthFailure(err error) bool {
-	// coder/websocket wraps close frames in its error messages.
-	// Auth failure is signaled by close code 4001 from the cloud.
-	if err == nil {
-		return false
-	}
-	return strings.Contains(err.Error(), "4001")
+	return websocket.CloseStatus(err) == authFailureCode
 }
 
 func generateFrameID() string {

--- a/internal/local/tunnel/client.go
+++ b/internal/local/tunnel/client.go
@@ -1,0 +1,387 @@
+package tunnel
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/coder/websocket"
+
+	"github.com/clawvisor/clawvisor/internal/local/services"
+)
+
+const (
+	pingInterval = 30 * time.Second
+	readTimeout  = 90 * time.Second
+	writeTimeout = 10 * time.Second
+	maxReadSize  = 1 << 20 // 1 MB
+)
+
+// Client manages the WebSocket connection to the cloud.
+type Client struct {
+	cloudOrigin     string
+	connectionToken string
+	daemonName      string
+	version         string
+	registry        *services.Registry
+	onRequest       func(ctx context.Context, id string, req *RequestPayload)
+	onAuthFailure   func()
+	logger          *slog.Logger
+
+	mu       sync.Mutex
+	conn     *websocket.Conn
+	connStop context.CancelFunc // cancelled when the connection drops
+
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+// ClientConfig holds configuration for the tunnel client.
+type ClientConfig struct {
+	CloudOrigin     string
+	ConnectionToken string
+	DaemonName      string
+	Version         string
+	Registry        *services.Registry
+	OnRequest       func(ctx context.Context, id string, req *RequestPayload)
+	OnAuthFailure   func()
+	Logger          *slog.Logger
+}
+
+// NewClient creates a new tunnel client.
+func NewClient(cfg ClientConfig) *Client {
+	ctx, cancel := context.WithCancel(context.Background())
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Client{
+		cloudOrigin:     cfg.CloudOrigin,
+		connectionToken: cfg.ConnectionToken,
+		daemonName:      cfg.DaemonName,
+		version:         cfg.Version,
+		registry:        cfg.Registry,
+		onRequest:       cfg.OnRequest,
+		onAuthFailure:   cfg.OnAuthFailure,
+		logger:          logger,
+		ctx:             ctx,
+		cancel:          cancel,
+	}
+}
+
+// Connect establishes and maintains the WebSocket connection with automatic reconnection.
+func (c *Client) Connect() {
+	backoff := NewBackoff()
+
+	for {
+		select {
+		case <-c.ctx.Done():
+			return
+		default:
+		}
+
+		err := c.connectOnce()
+		if err != nil {
+			if isAuthFailure(err) {
+				c.logger.Warn("tunnel: auth failure, clearing pairing state")
+				if c.onAuthFailure != nil {
+					c.onAuthFailure()
+				}
+				return
+			}
+			delay := backoff.Next()
+			c.logger.Warn("tunnel: disconnected, reconnecting", "err", err, "delay", delay)
+			select {
+			case <-time.After(delay):
+			case <-c.ctx.Done():
+				return
+			}
+		} else {
+			backoff.Reset()
+		}
+	}
+}
+
+func (c *Client) connectOnce() error {
+	u, err := url.Parse(c.cloudOrigin)
+	if err != nil {
+		return fmt.Errorf("parsing cloud origin: %w", err)
+	}
+	u.Scheme = "wss"
+	u.Path = "/ws/daemon"
+
+	conn, _, err := websocket.Dial(c.ctx, u.String(), &websocket.DialOptions{
+		HTTPHeader: http.Header{},
+	})
+	if err != nil {
+		return fmt.Errorf("websocket dial: %w", err)
+	}
+	conn.SetReadLimit(maxReadSize)
+
+	// Create a connection-scoped context that is cancelled when this connection drops.
+	connCtx, connCancel := context.WithCancel(c.ctx)
+
+	c.mu.Lock()
+	c.conn = conn
+	c.connStop = connCancel
+	c.mu.Unlock()
+
+	defer func() {
+		connCancel()
+		c.mu.Lock()
+		c.conn = nil
+		c.connStop = nil
+		c.mu.Unlock()
+		conn.Close(websocket.StatusNormalClosure, "")
+	}()
+
+	// Send auth frame.
+	if err := c.sendAuth(connCtx, conn); err != nil {
+		return err
+	}
+
+	// Send capabilities frame.
+	if err := c.sendCapabilities(connCtx, conn); err != nil {
+		return err
+	}
+
+	// Start ping loop tied to this connection's context.
+	go c.pingLoop(connCtx, connCancel)
+
+	// Read loop.
+	return c.readLoop(connCtx, conn)
+}
+
+func (c *Client) sendAuth(ctx context.Context, conn *websocket.Conn) error {
+	payload, err := json.Marshal(AuthPayload{
+		ConnectionToken: c.connectionToken,
+	})
+	if err != nil {
+		return fmt.Errorf("marshalling auth: %w", err)
+	}
+	frame := Frame{
+		Type:    FrameAuth,
+		ID:      "auth",
+		Payload: payload,
+	}
+	return c.writeJSON(ctx, conn, frame)
+}
+
+func (c *Client) sendCapabilities(ctx context.Context, conn *websocket.Conn) error {
+	caps := c.buildCapabilities()
+	payload, err := json.Marshal(caps)
+	if err != nil {
+		return fmt.Errorf("marshalling capabilities: %w", err)
+	}
+	frame := Frame{
+		Type:    FrameCapabilities,
+		ID:      generateFrameID(),
+		Payload: payload,
+	}
+	return c.writeJSON(ctx, conn, frame)
+}
+
+// SendCapabilitiesUpdate sends an updated capabilities frame (e.g., after reload).
+func (c *Client) SendCapabilitiesUpdate() error {
+	c.mu.Lock()
+	conn := c.conn
+	c.mu.Unlock()
+
+	if conn == nil {
+		return fmt.Errorf("not connected")
+	}
+
+	caps := c.buildCapabilities()
+	payload, err := json.Marshal(caps)
+	if err != nil {
+		return fmt.Errorf("marshalling capabilities: %w", err)
+	}
+	frame := Frame{
+		Type:    FrameCapabilities,
+		ID:      generateFrameID(),
+		Payload: payload,
+	}
+	return c.writeJSONLocked(frame)
+}
+
+// SendResponse sends a response frame for a given request.
+func (c *Client) SendResponse(requestID string, resp *ResponsePayload) error {
+	payload, err := json.Marshal(resp)
+	if err != nil {
+		return fmt.Errorf("marshalling response: %w", err)
+	}
+	frame := Frame{
+		Type:    FrameResponse,
+		ID:      requestID,
+		Payload: payload,
+	}
+	return c.writeJSONLocked(frame)
+}
+
+// Close disconnects the client.
+func (c *Client) Close() {
+	c.cancel()
+	c.mu.Lock()
+	if c.conn != nil {
+		c.conn.Close(websocket.StatusNormalClosure, "shutdown")
+	}
+	c.mu.Unlock()
+}
+
+// IsConnected returns whether the WebSocket is currently connected.
+func (c *Client) IsConnected() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.conn != nil
+}
+
+func (c *Client) readLoop(connCtx context.Context, conn *websocket.Conn) error {
+	for {
+		readCtx, readCancel := context.WithTimeout(connCtx, readTimeout)
+		_, data, err := conn.Read(readCtx)
+		readCancel()
+		if err != nil {
+			return fmt.Errorf("read error: %w", err)
+		}
+
+		var frame Frame
+		if err := json.Unmarshal(data, &frame); err != nil {
+			c.logger.Warn("tunnel: invalid frame", "err", err)
+			continue
+		}
+
+		switch frame.Type {
+		case FrameRequest:
+			var req RequestPayload
+			if err := json.Unmarshal(frame.Payload, &req); err != nil {
+				c.logger.Warn("tunnel: invalid request payload", "err", err)
+				continue
+			}
+			if c.onRequest != nil {
+				go c.onRequest(connCtx, frame.ID, &req)
+			}
+
+		case FramePong:
+			// Keepalive acknowledged — no action needed, read timeout is
+			// reset on each successful Read call.
+
+		default:
+			c.logger.Debug("tunnel: unknown frame type", "type", frame.Type)
+		}
+	}
+}
+
+func (c *Client) pingLoop(connCtx context.Context, connCancel context.CancelFunc) {
+	ticker := time.NewTicker(pingInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-connCtx.Done():
+			return
+		case <-ticker.C:
+			payload, _ := json.Marshal(map[string]string{})
+			frame := Frame{
+				Type:    FramePing,
+				ID:      generateFrameID(),
+				Payload: payload,
+			}
+			if err := c.writeJSONLocked(frame); err != nil {
+				c.logger.Warn("tunnel: ping write failed, closing connection", "err", err)
+				connCancel()
+				return
+			}
+		}
+	}
+}
+
+// writeJSON writes a frame to a specific connection with a write timeout.
+// Used during connection setup when we have a direct reference to the conn.
+func (c *Client) writeJSON(ctx context.Context, conn *websocket.Conn, v any) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("marshalling frame: %w", err)
+	}
+	writeCtx, cancel := context.WithTimeout(ctx, writeTimeout)
+	defer cancel()
+	return conn.Write(writeCtx, websocket.MessageText, data)
+}
+
+// writeJSONLocked writes a frame using the current connection under lock.
+// Used by SendResponse, SendCapabilitiesUpdate, and pingLoop.
+func (c *Client) writeJSONLocked(v any) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("marshalling frame: %w", err)
+	}
+
+	c.mu.Lock()
+	conn := c.conn
+	if conn == nil {
+		c.mu.Unlock()
+		return fmt.Errorf("not connected")
+	}
+	writeCtx, cancel := context.WithTimeout(context.Background(), writeTimeout)
+	writeErr := conn.Write(writeCtx, websocket.MessageText, data)
+	c.mu.Unlock()
+	cancel()
+	return writeErr
+}
+
+func (c *Client) buildCapabilities() CapabilitiesPayload {
+	svcs := c.registry.All()
+	caps := CapabilitiesPayload{
+		Version:  c.version,
+		Name:     c.daemonName,
+		Services: make([]ServiceCapability, 0, len(svcs)),
+	}
+
+	for _, svc := range svcs {
+		sc := ServiceCapability{
+			ID:          svc.ID,
+			Name:        svc.Name,
+			Description: svc.Description,
+			Icon:        svc.Icon,
+			Actions:     make([]ActionCapability, 0, len(svc.Actions)),
+		}
+		for _, a := range svc.Actions {
+			ac := ActionCapability{
+				ID:          a.ID,
+				Name:        a.Name,
+				Description: a.Description,
+				Params:      make([]ParamCapability, 0, len(a.Params)),
+			}
+			for _, p := range a.Params {
+				ac.Params = append(ac.Params, ParamCapability{
+					Name:        p.Name,
+					Type:        p.Type,
+					Required:    p.Required,
+					Description: p.Description,
+				})
+			}
+			sc.Actions = append(sc.Actions, ac)
+		}
+		caps.Services = append(caps.Services, sc)
+	}
+
+	return caps
+}
+
+func isAuthFailure(err error) bool {
+	// coder/websocket wraps close frames in its error messages.
+	// Auth failure is signaled by close code 4001 from the cloud.
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "4001")
+}
+
+func generateFrameID() string {
+	return fmt.Sprintf("%d", time.Now().UnixNano())
+}

--- a/internal/local/tunnel/client.go
+++ b/internal/local/tunnel/client.go
@@ -21,6 +21,10 @@ const (
 	readTimeout  = 90 * time.Second
 	writeTimeout = 10 * time.Second
 	maxReadSize  = 1 << 20 // 1 MB
+
+	// stableConnectionThreshold is how long a connection must stay alive
+	// before backoff is reset on disconnect.
+	stableConnectionThreshold = 60 * time.Second
 )
 
 // Client manages the WebSocket connection to the cloud.
@@ -34,9 +38,15 @@ type Client struct {
 	onAuthFailure   func()
 	logger          *slog.Logger
 
+	// mu protects conn and connStop for reading. Writes to the WebSocket use
+	// writeMu to avoid blocking readers during slow writes.
 	mu       sync.Mutex
 	conn     *websocket.Conn
-	connStop context.CancelFunc // cancelled when the connection drops
+	connStop context.CancelFunc
+
+	// writeMu serializes WebSocket writes. Held only during conn.Write, never
+	// during conn reads or status checks, so IsConnected/Close stay responsive.
+	writeMu sync.Mutex
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -86,7 +96,7 @@ func (c *Client) Connect() {
 		default:
 		}
 
-		err := c.connectOnce()
+		connectedAt, err := c.connectOnce()
 		if err != nil {
 			if isAuthFailure(err) {
 				c.logger.Warn("tunnel: auth failure, clearing pairing state")
@@ -95,6 +105,12 @@ func (c *Client) Connect() {
 				}
 				return
 			}
+
+			// Reset backoff if the connection was stable before dropping.
+			if !connectedAt.IsZero() && time.Since(connectedAt) > stableConnectionThreshold {
+				backoff.Reset()
+			}
+
 			delay := backoff.Next()
 			c.logger.Warn("tunnel: disconnected, reconnecting", "err", err, "delay", delay)
 			select {
@@ -102,16 +118,16 @@ func (c *Client) Connect() {
 			case <-c.ctx.Done():
 				return
 			}
-		} else {
-			backoff.Reset()
 		}
 	}
 }
 
-func (c *Client) connectOnce() error {
+// connectOnce returns (connectedAt, error). connectedAt is set once the
+// connection is authenticated and serving; it is zero if dial/auth failed.
+func (c *Client) connectOnce() (time.Time, error) {
 	u, err := url.Parse(c.cloudOrigin)
 	if err != nil {
-		return fmt.Errorf("parsing cloud origin: %w", err)
+		return time.Time{}, fmt.Errorf("parsing cloud origin: %w", err)
 	}
 	u.Scheme = "wss"
 	u.Path = "/ws/daemon"
@@ -120,7 +136,7 @@ func (c *Client) connectOnce() error {
 		HTTPHeader: http.Header{},
 	})
 	if err != nil {
-		return fmt.Errorf("websocket dial: %w", err)
+		return time.Time{}, fmt.Errorf("websocket dial: %w", err)
 	}
 	conn.SetReadLimit(maxReadSize)
 
@@ -142,86 +158,37 @@ func (c *Client) connectOnce() error {
 	}()
 
 	// Send auth frame.
-	if err := c.sendAuth(connCtx, conn); err != nil {
-		return err
+	if err := c.writeToConn(connCtx, conn, FrameAuth, "auth", AuthPayload{
+		ConnectionToken: c.connectionToken,
+	}); err != nil {
+		return time.Time{}, fmt.Errorf("sending auth: %w", err)
 	}
 
 	// Send capabilities frame.
-	if err := c.sendCapabilities(connCtx, conn); err != nil {
-		return err
+	caps := c.buildCapabilities()
+	if err := c.writeToConn(connCtx, conn, FrameCapabilities, generateFrameID(), caps); err != nil {
+		return time.Time{}, fmt.Errorf("sending capabilities: %w", err)
 	}
+
+	connectedAt := time.Now()
 
 	// Start ping loop tied to this connection's context.
 	go c.pingLoop(connCtx, connCancel)
 
 	// Read loop.
-	return c.readLoop(connCtx, conn)
-}
-
-func (c *Client) sendAuth(ctx context.Context, conn *websocket.Conn) error {
-	payload, err := json.Marshal(AuthPayload{
-		ConnectionToken: c.connectionToken,
-	})
-	if err != nil {
-		return fmt.Errorf("marshalling auth: %w", err)
-	}
-	frame := Frame{
-		Type:    FrameAuth,
-		ID:      "auth",
-		Payload: payload,
-	}
-	return c.writeJSON(ctx, conn, frame)
-}
-
-func (c *Client) sendCapabilities(ctx context.Context, conn *websocket.Conn) error {
-	caps := c.buildCapabilities()
-	payload, err := json.Marshal(caps)
-	if err != nil {
-		return fmt.Errorf("marshalling capabilities: %w", err)
-	}
-	frame := Frame{
-		Type:    FrameCapabilities,
-		ID:      generateFrameID(),
-		Payload: payload,
-	}
-	return c.writeJSON(ctx, conn, frame)
+	readErr := c.readLoop(connCtx, conn)
+	return connectedAt, readErr
 }
 
 // SendCapabilitiesUpdate sends an updated capabilities frame (e.g., after reload).
 func (c *Client) SendCapabilitiesUpdate() error {
-	c.mu.Lock()
-	conn := c.conn
-	c.mu.Unlock()
-
-	if conn == nil {
-		return fmt.Errorf("not connected")
-	}
-
 	caps := c.buildCapabilities()
-	payload, err := json.Marshal(caps)
-	if err != nil {
-		return fmt.Errorf("marshalling capabilities: %w", err)
-	}
-	frame := Frame{
-		Type:    FrameCapabilities,
-		ID:      generateFrameID(),
-		Payload: payload,
-	}
-	return c.writeJSONLocked(frame)
+	return c.writeFrame(FrameCapabilities, generateFrameID(), caps)
 }
 
 // SendResponse sends a response frame for a given request.
 func (c *Client) SendResponse(requestID string, resp *ResponsePayload) error {
-	payload, err := json.Marshal(resp)
-	if err != nil {
-		return fmt.Errorf("marshalling response: %w", err)
-	}
-	frame := Frame{
-		Type:    FrameResponse,
-		ID:      requestID,
-		Payload: payload,
-	}
-	return c.writeJSONLocked(frame)
+	return c.writeFrame(FrameResponse, requestID, resp)
 }
 
 // Close disconnects the client.
@@ -286,13 +253,7 @@ func (c *Client) pingLoop(connCtx context.Context, connCancel context.CancelFunc
 		case <-connCtx.Done():
 			return
 		case <-ticker.C:
-			payload, _ := json.Marshal(map[string]string{})
-			frame := Frame{
-				Type:    FramePing,
-				ID:      generateFrameID(),
-				Payload: payload,
-			}
-			if err := c.writeJSONLocked(frame); err != nil {
+			if err := c.writeFrame(FramePing, generateFrameID(), map[string]string{}); err != nil {
 				c.logger.Warn("tunnel: ping write failed, closing connection", "err", err)
 				connCancel()
 				return
@@ -301,10 +262,16 @@ func (c *Client) pingLoop(connCtx context.Context, connCancel context.CancelFunc
 	}
 }
 
-// writeJSON writes a frame to a specific connection with a write timeout.
-// Used during connection setup when we have a direct reference to the conn.
-func (c *Client) writeJSON(ctx context.Context, conn *websocket.Conn, v any) error {
-	data, err := json.Marshal(v)
+// writeToConn writes a frame to a specific connection with a write timeout.
+// Used during connection setup when we have a direct reference to the conn
+// and no other goroutines are writing yet.
+func (c *Client) writeToConn(ctx context.Context, conn *websocket.Conn, typ FrameType, id string, payload any) error {
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshalling payload: %w", err)
+	}
+	frame := Frame{Type: typ, ID: id, Payload: payloadBytes}
+	data, err := json.Marshal(frame)
 	if err != nil {
 		return fmt.Errorf("marshalling frame: %w", err)
 	}
@@ -313,24 +280,34 @@ func (c *Client) writeJSON(ctx context.Context, conn *websocket.Conn, v any) err
 	return conn.Write(writeCtx, websocket.MessageText, data)
 }
 
-// writeJSONLocked writes a frame using the current connection under lock.
-// Used by SendResponse, SendCapabilitiesUpdate, and pingLoop.
-func (c *Client) writeJSONLocked(v any) error {
-	data, err := json.Marshal(v)
+// writeFrame grabs the current connection under mu, then writes under writeMu.
+// mu is NOT held during the write itself, so IsConnected/Close remain responsive.
+func (c *Client) writeFrame(typ FrameType, id string, payload any) error {
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshalling payload: %w", err)
+	}
+	frame := Frame{Type: typ, ID: id, Payload: payloadBytes}
+	data, err := json.Marshal(frame)
 	if err != nil {
 		return fmt.Errorf("marshalling frame: %w", err)
 	}
 
+	// Grab conn reference under mu (fast).
 	c.mu.Lock()
 	conn := c.conn
+	c.mu.Unlock()
 	if conn == nil {
-		c.mu.Unlock()
 		return fmt.Errorf("not connected")
 	}
+
+	// Serialize writes under writeMu (potentially slow).
+	c.writeMu.Lock()
 	writeCtx, cancel := context.WithTimeout(context.Background(), writeTimeout)
 	writeErr := conn.Write(writeCtx, websocket.MessageText, data)
-	c.mu.Unlock()
 	cancel()
+	c.writeMu.Unlock()
+
 	return writeErr
 }
 

--- a/internal/local/tunnel/frames.go
+++ b/internal/local/tunnel/frames.go
@@ -1,0 +1,73 @@
+package tunnel
+
+import "encoding/json"
+
+// FrameType identifies the type of a WebSocket frame.
+type FrameType string
+
+const (
+	FrameAuth         FrameType = "auth"
+	FrameCapabilities FrameType = "capabilities"
+	FrameRequest      FrameType = "request"
+	FrameResponse     FrameType = "response"
+	FramePing         FrameType = "ping"
+	FramePong         FrameType = "pong"
+)
+
+// Frame is the generic envelope for all WebSocket messages.
+type Frame struct {
+	Type    FrameType       `json:"type"`
+	ID      string          `json:"id"`
+	Payload json.RawMessage `json:"payload"`
+}
+
+// AuthPayload is sent as the first frame after WebSocket upgrade.
+type AuthPayload struct {
+	ConnectionToken string `json:"connection_token"`
+}
+
+// CapabilitiesPayload declares the daemon's available services.
+type CapabilitiesPayload struct {
+	Version  string            `json:"version"`
+	Name     string            `json:"name"`
+	Services []ServiceCapability `json:"services"`
+}
+
+// ServiceCapability describes a service for the cloud.
+type ServiceCapability struct {
+	ID          string             `json:"id"`
+	Name        string             `json:"name"`
+	Description string             `json:"description,omitempty"`
+	Icon        string             `json:"icon,omitempty"`
+	Actions     []ActionCapability `json:"actions"`
+}
+
+// ActionCapability describes an action for the cloud.
+type ActionCapability struct {
+	ID          string           `json:"id"`
+	Name        string           `json:"name"`
+	Description string           `json:"description,omitempty"`
+	Params      []ParamCapability `json:"params"`
+}
+
+// ParamCapability describes a parameter for the cloud.
+type ParamCapability struct {
+	Name        string `json:"name"`
+	Type        string `json:"type"`
+	Required    bool   `json:"required"`
+	Description string `json:"description,omitempty"`
+}
+
+// RequestPayload is sent from the cloud to invoke a local service action.
+type RequestPayload struct {
+	Service string            `json:"service"`
+	Action  string            `json:"action"`
+	Params  map[string]string `json:"params"`
+}
+
+// ResponsePayload is sent from the daemon to the cloud with the action result.
+type ResponsePayload struct {
+	Success bool            `json:"success"`
+	Data    json.RawMessage `json:"data,omitempty"`
+	Error   string          `json:"error,omitempty"`
+}

--- a/internal/local/tunnel/reconnect.go
+++ b/internal/local/tunnel/reconnect.go
@@ -1,0 +1,36 @@
+package tunnel
+
+import (
+	"math"
+	"time"
+)
+
+// Backoff implements exponential backoff for reconnection.
+type Backoff struct {
+	attempt   int
+	baseDelay time.Duration
+	maxDelay  time.Duration
+}
+
+// NewBackoff creates a new backoff calculator.
+func NewBackoff() *Backoff {
+	return &Backoff{
+		baseDelay: 1 * time.Second,
+		maxDelay:  60 * time.Second,
+	}
+}
+
+// Next returns the next backoff duration and increments the attempt counter.
+func (b *Backoff) Next() time.Duration {
+	delay := time.Duration(float64(b.baseDelay) * math.Pow(2, float64(b.attempt)))
+	if delay > b.maxDelay {
+		delay = b.maxDelay
+	}
+	b.attempt++
+	return delay
+}
+
+// Reset resets the backoff counter after a successful connection.
+func (b *Backoff) Reset() {
+	b.attempt = 0
+}

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -37,6 +37,18 @@ for PLATFORM in $PLATFORMS; do
     go build -ldflags="$LDFLAGS" -o "$OUTPUT" ./cmd/clawvisor
 done
 
+# Build clawvisor-local for all platforms. This is a standalone binary with no
+# frontend dependency, so it doesn't need web/dist.
+for PLATFORM in $PLATFORMS; do
+  GOOS="${PLATFORM%/*}"
+  GOARCH="${PLATFORM#*/}"
+  OUTPUT="dist/clawvisor-local-${GOOS}-${GOARCH}"
+
+  echo "Building ${OUTPUT}..."
+  CGO_ENABLED=0 GOOS="$GOOS" GOARCH="$GOARCH" \
+    go build -ldflags="$LDFLAGS" -o "$OUTPUT" ./cmd/clawvisor-local
+done
+
 # Build the iMessage helper .app bundle for macOS only. This is a separate,
 # stable binary that holds Full Disk Access so users don't need to re-grant
 # FDA on every clawvisor update. The .app bundle structure lets macOS read


### PR DESCRIPTION
## Summary

- Moves the `clawvisor-local` daemon into this repo so users can audit the code running on their machine
- The local daemon bridges local services to Clawvisor cloud — it discovers YAML service manifests, pairs via the cloud UI, and executes actions locally (subprocess or long-running server mode)
- Adds `cmd/clawvisor-local/` (CLI) and `internal/local/` (daemon, tunnel, executor, pairing, services, config, state)

### Code quality improvements over the original

- **Websocket**: Migrated from `gorilla/websocket` to `coder/websocket` to match the relay client's patterns (context-based I/O, read limits, proper close semantics)
- **Logging**: Switched from `log` to `log/slog` for structured logging, consistent with the rest of the repo
- **Goroutine leak fix**: Ping loop now uses a connection-scoped context instead of the client-scoped one, so it exits on disconnect instead of leaking across reconnections
- **Concurrency fix**: Removed racy queue counter in dispatcher — the semaphore already enforces limits
- **Error handling**: `json.Marshal` errors checked instead of silently ignored; `errors.As` for exit errors; service/action IDs in error messages
- **Deduplication**: Extracted shared service list builder from status/reload handlers
- **Type safety**: Replaced 90 lines of `map[string]interface{}` type assertions in CLI status with typed structs

### Build

- `make build-local` — builds `bin/clawvisor-local`
- `make install-local` — installs to `~/.clawvisor/bin/`
- Release script updated to produce `clawvisor-local-{os}-{arch}` binaries

## Test plan

- [x] `go build ./cmd/clawvisor-local` compiles cleanly
- [x] `go vet ./internal/local/... ./cmd/clawvisor-local/...` passes
- [ ] Manual test: `clawvisor-local status`, `clawvisor-local services`, `clawvisor-local validate`
- [ ] Manual test: pair with cloud and verify tunnel connection
- [ ] Verify `make build-local` produces working binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)