### PR TITLE
feat: add mobile_pairing feature flag, disabled by default

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -121,6 +121,7 @@ type FeatureSet struct {
 	AdapterGen        bool `json:"adapter_gen"`
 	Billing           bool `json:"billing"`
 	LocalDaemon       bool `json:"local_daemon"`
+	MobilePairing     bool `json:"mobile_pairing"`
 }
 
 // GatewayHooks allows cloud/enterprise layers to inject additional
@@ -595,22 +596,26 @@ func (s *Server) routes() http.Handler {
 		devicesHandler.SetRelayInfo(s.daemonID, relayHost)
 	}
 	s.devicesHandler = devicesHandler
-	devicesRL := newKeyedLimiterFromBucket(config.RateLimitBucket{Limit: 5, Window: 60})
-	mux.Handle("GET /api/devices/pair/info", user(devicesHandler.PairInfo))
-	mux.Handle("POST /api/devices/pair", user(devicesHandler.StartPairing))
-	mux.Handle("POST /api/devices/pair/complete",
-		middleware.RateLimit(devicesRL, ipKeyFn, 5)(e2e(http.HandlerFunc(devicesHandler.CompletePairing))))
-	mux.Handle("GET /api/devices", user(devicesHandler.List))
-	mux.Handle("DELETE /api/devices/{id}", user(devicesHandler.Delete))
 	var requireDevice func(http.Handler) http.Handler
 	if s.replayCache != nil {
 		requireDevice = middleware.RequireDeviceWithReplayCache(s.store, s.replayCache)
 	} else {
 		requireDevice = middleware.RequireDevice(s.store)
 	}
+	// Device-to-server routes (always available for already-paired devices)
 	mux.Handle("POST /api/devices/{id}/action", requireDevice(e2e(http.HandlerFunc(devicesHandler.Action))))
 	mux.Handle("POST /api/devices/{id}/token", requireDevice(e2e(http.HandlerFunc(devicesHandler.MintToken))))
 	mux.Handle("POST /api/devices/{id}/push-to-start-token", requireDevice(e2e(http.HandlerFunc(devicesHandler.UpdatePushToStartToken))))
+	// Pairing and management routes (gated by mobile_pairing feature flag)
+	if s.features.MobilePairing {
+		devicesRL := newKeyedLimiterFromBucket(config.RateLimitBucket{Limit: 5, Window: 60})
+		mux.Handle("GET /api/devices/pair/info", user(devicesHandler.PairInfo))
+		mux.Handle("POST /api/devices/pair", user(devicesHandler.StartPairing))
+		mux.Handle("POST /api/devices/pair/complete",
+			middleware.RateLimit(devicesRL, ipKeyFn, 5)(e2e(http.HandlerFunc(devicesHandler.CompletePairing))))
+		mux.Handle("GET /api/devices", user(devicesHandler.List))
+		mux.Handle("DELETE /api/devices/{id}", user(devicesHandler.Delete))
+	}
 
 	// Guard (agent token — Claude Code permission check)
 	guardHandler := handlers.NewGuardHandler(s.store, verifier, s.adapterReg, s.logger)

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -456,6 +456,7 @@ export interface FeatureSet {
   adapter_gen: boolean
   billing: boolean
   local_daemon: boolean
+  mobile_pairing: boolean
 }
 
 export interface VersionInfo {

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -18,7 +18,7 @@ export default function Settings() {
       <DaemonInfo />
       {!features?.multi_tenant && <LLMSection />}
       {!features?.multi_tenant && <OAuthCredentialsSection />}
-      <DevicePairing />
+      {features?.mobile_pairing && <DevicePairing />}
       {features?.local_daemon && <LocalDaemonPairing />}
       <TelegramSetupSection />
       {passwordAuth && <PasswordSection />}


### PR DESCRIPTION
## Summary
- Adds a new `mobile_pairing` feature flag to `FeatureSet`, defaulting to `false`
- Gates device pairing and management API routes (`/api/devices/pair/*`, list, delete) behind the flag
- Gates the `<DevicePairing />` UI component behind `features?.mobile_pairing`
- Device-to-server routes (action, token, push-to-start-token) remain always available so already-paired devices continue to work

## Test plan
- [ ] Verify pairing routes return 404 when `mobile_pairing` is not set
- [ ] Verify pairing routes work when `MobilePairing: true` is passed via `WithFeatures`
- [ ] Verify already-paired devices can still call action/token/push-to-start-token endpoints
- [ ] Verify frontend hides DevicePairing section when flag is off