### PR TITLE
feat: make webapp responsive for mobile devices

### DIFF
--- a/web/src/pages/AdapterGen.tsx
+++ b/web/src/pages/AdapterGen.tsx
@@ -314,7 +314,7 @@ export default function AdapterGen() {
   })
 
   return (
-    <div className="p-8 space-y-6 max-w-5xl">
+    <div className="p-4 sm:p-8 space-y-6 max-w-5xl">
       <div>
         <h1 className="text-2xl font-bold text-text-primary">Generate Integration</h1>
         <p className="text-sm text-text-tertiary mt-1">

--- a/web/src/pages/Agents.tsx
+++ b/web/src/pages/Agents.tsx
@@ -52,7 +52,7 @@ export default function Agents() {
   const pending = (!orgId ? connections : undefined) ?? []
 
   return (
-    <div className="p-8 space-y-8">
+    <div className="p-4 sm:p-8 space-y-8">
       <h1 className="text-2xl font-bold text-text-primary">Agents</h1>
       <p className="text-sm text-text-tertiary">
         An agent is any AI system (Claude, a custom bot, etc.) that you want to give controlled access to your services.
@@ -150,7 +150,7 @@ export default function Agents() {
             return (
               <div
                 key={agent.id}
-                className={`bg-surface-1 border rounded-md px-5 py-4 flex items-center justify-between ${
+                className={`bg-surface-1 border rounded-md px-5 py-4 flex flex-col sm:flex-row sm:items-center justify-between gap-3 ${
                   hasActiveTasks
                     ? 'border-brand/40 border-l-[3px] border-l-brand'
                     : 'border-border-default'
@@ -251,7 +251,7 @@ function ConnectAgentGuide() {
       </div>
 
       {/* Tabs */}
-      <div className="flex gap-0 px-5 mt-4 border-b border-border-subtle">
+      <div className="flex gap-0 px-5 mt-4 border-b border-border-subtle overflow-x-auto">
         {tabs.map(t => (
           <button
             key={t.id}

--- a/web/src/pages/Agents.tsx
+++ b/web/src/pages/Agents.tsx
@@ -287,19 +287,29 @@ function StepNumber({ n }: { n: number }) {
 
 function CodeBlock({ children, onCopy }: { children: string; onCopy?: () => void }) {
   return (
-    <div className="bg-surface-0 border border-border-subtle rounded overflow-hidden">
+    <div className="relative group bg-surface-0 border border-border-subtle rounded overflow-hidden">
       <pre className="px-3 py-2.5 text-xs font-mono text-text-primary overflow-x-auto whitespace-pre-wrap break-all">
         {children}
       </pre>
       {onCopy && (
-        <div className="border-t border-border-subtle px-3 py-1.5 flex justify-end bg-surface-0">
+        <>
+          {/* Desktop: inline overlay */}
           <button
             onClick={onCopy}
-            className="text-xs px-2.5 py-1 rounded border border-border-subtle text-text-tertiary hover:text-text-primary hover:bg-surface-1"
+            className="hidden sm:block absolute top-2 right-2 text-xs px-2 py-1 rounded border border-border-subtle text-text-tertiary hover:text-text-primary hover:bg-surface-1 opacity-0 group-hover:opacity-100 transition-opacity"
           >
             Copy
           </button>
-        </div>
+          {/* Mobile: footer bar */}
+          <div className="sm:hidden border-t border-border-subtle px-3 py-1.5 flex justify-end">
+            <button
+              onClick={onCopy}
+              className="text-xs px-2.5 py-1 rounded border border-border-subtle text-text-tertiary hover:text-text-primary hover:bg-surface-1"
+            >
+              Copy
+            </button>
+          </div>
+        </>
       )}
     </div>
   )
@@ -445,11 +455,17 @@ function OpenClawGuide({ setupURL, isLocal, copied, onCopy }: {
           <StepNumber n={1} />
           <div className="space-y-1.5 min-w-0 flex-1">
             <p className="text-sm font-medium text-text-primary">Paste this into your agent</p>
-            <div className="bg-surface-0 border border-brand/20 rounded overflow-hidden">
+            <div className="relative group bg-surface-0 border border-brand/20 rounded overflow-hidden">
               <pre className="px-3 py-2.5 text-xs font-mono text-text-primary overflow-x-auto whitespace-pre-wrap break-all">
                 {prompt}
               </pre>
-              <div className="border-t border-brand/20 px-3 py-1.5 flex justify-end">
+              <button
+                onClick={() => onCopy(prompt)}
+                className="hidden sm:block absolute top-2 right-2 text-xs px-2 py-1 rounded border border-border-subtle text-text-tertiary hover:text-text-primary hover:bg-surface-1"
+              >
+                {copied ? 'Copied' : 'Copy'}
+              </button>
+              <div className="sm:hidden border-t border-brand/20 px-3 py-1.5 flex justify-end">
                 <button
                   onClick={() => onCopy(prompt)}
                   className="text-xs px-2.5 py-1 rounded border border-border-subtle text-text-tertiary hover:text-text-primary hover:bg-surface-1"
@@ -510,11 +526,17 @@ function OtherAgentGuide({ setupURL, clawvisorURL, copied, onCopy }: {
           <StepNumber n={1} />
           <div className="space-y-1.5 min-w-0 flex-1">
             <p className="text-sm font-medium text-text-primary">Paste this into your agent</p>
-            <div className="bg-surface-0 border border-brand/20 rounded overflow-hidden">
+            <div className="relative group bg-surface-0 border border-brand/20 rounded overflow-hidden">
               <pre className="px-3 py-2.5 text-xs font-mono text-text-primary overflow-x-auto whitespace-pre-wrap break-all">
                 {prompt}
               </pre>
-              <div className="border-t border-brand/20 px-3 py-1.5 flex justify-end">
+              <button
+                onClick={() => onCopy(prompt)}
+                className="hidden sm:block absolute top-2 right-2 text-xs px-2 py-1 rounded border border-border-subtle text-text-tertiary hover:text-text-primary hover:bg-surface-1"
+              >
+                {copied ? 'Copied' : 'Copy'}
+              </button>
+              <div className="sm:hidden border-t border-brand/20 px-3 py-1.5 flex justify-end">
                 <button
                   onClick={() => onCopy(prompt)}
                   className="text-xs px-2.5 py-1 rounded border border-border-subtle text-text-tertiary hover:text-text-primary hover:bg-surface-1"

--- a/web/src/pages/Agents.tsx
+++ b/web/src/pages/Agents.tsx
@@ -287,17 +287,19 @@ function StepNumber({ n }: { n: number }) {
 
 function CodeBlock({ children, onCopy }: { children: string; onCopy?: () => void }) {
   return (
-    <div className="relative group">
-      <pre className="bg-surface-0 border border-border-subtle rounded px-3 py-2.5 text-xs font-mono text-text-primary overflow-x-auto whitespace-pre-wrap break-all">
+    <div className="bg-surface-0 border border-border-subtle rounded overflow-hidden">
+      <pre className="px-3 py-2.5 text-xs font-mono text-text-primary overflow-x-auto whitespace-pre-wrap break-all">
         {children}
       </pre>
       {onCopy && (
-        <button
-          onClick={onCopy}
-          className="absolute top-2 right-2 text-xs px-2 py-1 rounded border border-border-subtle text-text-tertiary hover:text-text-primary hover:bg-surface-1 opacity-0 group-hover:opacity-100 transition-opacity"
-        >
-          Copy
-        </button>
+        <div className="border-t border-border-subtle px-3 py-1.5 flex justify-end bg-surface-0">
+          <button
+            onClick={onCopy}
+            className="text-xs px-2.5 py-1 rounded border border-border-subtle text-text-tertiary hover:text-text-primary hover:bg-surface-1"
+          >
+            Copy
+          </button>
+        </div>
       )}
     </div>
   )
@@ -443,16 +445,18 @@ function OpenClawGuide({ setupURL, isLocal, copied, onCopy }: {
           <StepNumber n={1} />
           <div className="space-y-1.5 min-w-0 flex-1">
             <p className="text-sm font-medium text-text-primary">Paste this into your agent</p>
-            <div className="relative group">
-              <pre className="bg-surface-0 border border-brand/20 rounded px-3 py-2.5 text-xs font-mono text-text-primary overflow-x-auto whitespace-pre-wrap break-all">
+            <div className="bg-surface-0 border border-brand/20 rounded overflow-hidden">
+              <pre className="px-3 py-2.5 text-xs font-mono text-text-primary overflow-x-auto whitespace-pre-wrap break-all">
                 {prompt}
               </pre>
-              <button
-                onClick={() => onCopy(prompt)}
-                className="absolute top-2 right-2 text-xs px-2 py-1 rounded border border-border-subtle text-text-tertiary hover:text-text-primary hover:bg-surface-1"
-              >
-                {copied ? 'Copied' : 'Copy'}
-              </button>
+              <div className="border-t border-brand/20 px-3 py-1.5 flex justify-end">
+                <button
+                  onClick={() => onCopy(prompt)}
+                  className="text-xs px-2.5 py-1 rounded border border-border-subtle text-text-tertiary hover:text-text-primary hover:bg-surface-1"
+                >
+                  {copied ? 'Copied' : 'Copy'}
+                </button>
+              </div>
             </div>
             <p className="text-xs text-text-tertiary">
               Your OpenClaw agent will follow the setup instructions — registering itself
@@ -506,16 +510,18 @@ function OtherAgentGuide({ setupURL, clawvisorURL, copied, onCopy }: {
           <StepNumber n={1} />
           <div className="space-y-1.5 min-w-0 flex-1">
             <p className="text-sm font-medium text-text-primary">Paste this into your agent</p>
-            <div className="relative group">
-              <pre className="bg-surface-0 border border-brand/20 rounded px-3 py-2.5 text-xs font-mono text-text-primary overflow-x-auto whitespace-pre-wrap break-all">
+            <div className="bg-surface-0 border border-brand/20 rounded overflow-hidden">
+              <pre className="px-3 py-2.5 text-xs font-mono text-text-primary overflow-x-auto whitespace-pre-wrap break-all">
                 {prompt}
               </pre>
-              <button
-                onClick={() => onCopy(prompt)}
-                className="absolute top-2 right-2 text-xs px-2 py-1 rounded border border-border-subtle text-text-tertiary hover:text-text-primary hover:bg-surface-1"
-              >
-                {copied ? 'Copied' : 'Copy'}
-              </button>
+              <div className="border-t border-brand/20 px-3 py-1.5 flex justify-end">
+                <button
+                  onClick={() => onCopy(prompt)}
+                  className="text-xs px-2.5 py-1 rounded border border-border-subtle text-text-tertiary hover:text-text-primary hover:bg-surface-1"
+                >
+                  {copied ? 'Copied' : 'Copy'}
+                </button>
+              </div>
             </div>
             <p className="text-xs text-text-tertiary">
               The agent will follow the setup instructions at that URL — it registers itself,

--- a/web/src/pages/Audit.tsx
+++ b/web/src/pages/Audit.tsx
@@ -92,7 +92,7 @@ function AuditRow({ entry }: { entry: AuditEntry }) {
       {expanded && (
         <tr className="border-t border-border-default bg-surface-2">
           <td colSpan={7} className="px-4 py-3">
-            <div className="grid grid-cols-2 gap-4 text-xs">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-xs">
               <div>
                 <div className="text-text-tertiary font-medium mb-1">
                   {formatServiceAction(entry.service, entry.action)}
@@ -213,8 +213,8 @@ export default function Audit() {
   }, [outcomeFilter, serviceFilter, orgId])
 
   return (
-    <div className="p-8 space-y-4">
-      <div className="flex items-center justify-between">
+    <div className="p-4 sm:p-8 space-y-4">
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2">
         <h1 className="text-2xl font-bold text-text-primary">{orgId ? `${currentOrg!.name} Gateway Log` : 'Gateway Log'}</h1>
         <div className="flex items-center gap-3">
           <button
@@ -264,8 +264,8 @@ export default function Audit() {
       )}
 
       {entries.length > 0 && (
-        <div className="bg-surface-1 border border-border-default rounded-md overflow-hidden">
-          <table className="w-full">
+        <div className="bg-surface-1 border border-border-default rounded-md overflow-x-auto">
+          <table className="w-full min-w-[640px]">
             <thead className="bg-surface-2 text-xs text-text-tertiary font-medium">
               <tr>
                 <th className="px-4 py-2 text-left">Time</th>
@@ -286,7 +286,7 @@ export default function Audit() {
 
       {/* Pagination */}
       {total > PAGE_SIZE && (
-        <div className="flex items-center justify-between text-sm text-text-tertiary">
+        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 text-sm text-text-tertiary">
           <span>Showing {offset + 1}–{Math.min(offset + PAGE_SIZE, total)} of {total}</span>
           <div className="flex gap-2">
             <button

--- a/web/src/pages/Billing.tsx
+++ b/web/src/pages/Billing.tsx
@@ -44,7 +44,7 @@ export default function Billing() {
 
   if (isLoading) {
     return (
-      <div className="p-8">
+      <div className="p-4 sm:p-8">
         <h1 className="text-2xl font-bold text-text-primary mb-6">Billing</h1>
         <div className="text-text-tertiary">Loading billing info...</div>
       </div>
@@ -68,7 +68,7 @@ export default function Billing() {
   const requestsPct = requestsLimit > 0 ? Math.min(100, (requestsUsed / requestsLimit) * 100) : 0
 
   return (
-    <div className="p-8 space-y-10">
+    <div className="p-4 sm:p-8 space-y-10">
       <h1 className="text-2xl font-bold text-text-primary">Billing</h1>
 
       {/* Plan Overview */}

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -1,4 +1,5 @@
-import { NavLink, Routes, Route, Navigate } from 'react-router-dom'
+import { useState, useEffect } from 'react'
+import { NavLink, Routes, Route, Navigate, useLocation } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { useAuth } from '../hooks/useAuth'
 import { useEventStream } from '../hooks/useEventStream'
@@ -42,6 +43,11 @@ const orgNavItems = [
 export default function Dashboard() {
   const { user, logout, features, currentOrg } = useAuth()
   const { resolvedTheme, setTheme } = useTheme()
+  const [sidebarOpen, setSidebarOpen] = useState(false)
+  const location = useLocation()
+
+  // Close sidebar on route change (mobile)
+  useEffect(() => { setSidebarOpen(false) }, [location.pathname])
 
   // SSE event stream for instant dashboard updates
   useEventStream()
@@ -84,8 +90,36 @@ export default function Dashboard() {
 
   return (
     <div className="min-h-screen bg-surface-0 flex">
+      {/* Mobile header */}
+      <div className="fixed top-0 left-0 right-0 z-40 flex items-center gap-3 px-4 py-3 bg-surface-1 border-b border-border-default md:hidden">
+        <button
+          onClick={() => setSidebarOpen(true)}
+          className="text-text-primary p-1 -ml-1"
+          aria-label="Open menu"
+        >
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M4 6h16M4 12h16M4 18h16"/></svg>
+        </button>
+        <span className="font-bold text-lg tracking-tight text-text-primary flex items-center gap-2">
+          <img src="/favicon.svg" alt="" className="w-5 h-5" />
+          Clawvisor
+        </span>
+        {queueCount > 0 && (
+          <span className="text-xs font-mono font-medium px-1.5 py-0.5 rounded bg-warning text-surface-0 ml-auto">
+            {queueCount > 9 ? '9+' : queueCount}
+          </span>
+        )}
+      </div>
+
+      {/* Sidebar overlay (mobile) */}
+      {sidebarOpen && (
+        <div
+          className="fixed inset-0 z-40 bg-black/40 md:hidden"
+          onClick={() => setSidebarOpen(false)}
+        />
+      )}
+
       {/* Sidebar */}
-      <nav className="w-56 bg-surface-1 border-r border-border-default flex flex-col shrink-0 sticky top-0 h-screen">
+      <nav className={`fixed inset-y-0 left-0 z-50 w-56 bg-surface-1 border-r border-border-default flex flex-col shrink-0 transform transition-transform duration-200 ease-in-out md:sticky md:top-0 md:h-screen md:translate-x-0 ${sidebarOpen ? 'translate-x-0' : '-translate-x-full'}`}>
         <div className="px-4 py-5 border-b border-border-default">
           <span className="font-bold text-lg tracking-tight text-text-primary flex items-center gap-2">
             <img src="/favicon.svg" alt="" className="w-5 h-5" />
@@ -199,9 +233,9 @@ export default function Dashboard() {
       </nav>
 
       {/* Main content */}
-      <main className="flex-1 min-w-0 overflow-auto">
+      <main className="flex-1 min-w-0 overflow-auto pt-14 md:pt-0">
         {versionData?.update_available && (
-          <div className="mx-4 mt-3 px-4 py-2.5 rounded-md bg-brand-muted border border-brand/30 flex items-center justify-between text-sm">
+          <div className="mx-4 mt-3 px-4 py-2.5 rounded-md bg-brand-muted border border-brand/30 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 text-sm">
             <span className="text-text-primary">
               <span className="font-medium">Clawvisor v{versionData.latest}</span> is available
               {versionData.current && <span className="text-text-secondary"> (current: v{versionData.current})</span>}
@@ -231,56 +265,56 @@ export default function Dashboard() {
         )}
         <OnboardingBanner />
         {llmStatus?.spend_cap_exhausted && (
-          <div className="mx-4 mt-3 px-4 py-2.5 rounded-md bg-warning/10 border border-warning/30 flex items-center justify-between text-sm">
+          <div className="mx-4 mt-3 px-4 py-2.5 rounded-md bg-warning/10 border border-warning/30 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 text-sm">
             <span className="text-text-primary">
               <span className="font-medium">Free LLM credit exhausted</span>
               <span className="text-text-secondary"> — verification and risk assessment are paused. Add your own API key to restore them.</span>
             </span>
             <NavLink
               to="/dashboard/settings"
-              className="text-brand hover:text-brand/80 font-medium transition-colors whitespace-nowrap ml-3"
+              className="text-brand hover:text-brand/80 font-medium transition-colors whitespace-nowrap"
             >
               Configure API key
             </NavLink>
           </div>
         )}
         {billingStatus?.status === 'trialing' && billingStatus.trial_days_remaining != null && !billingStatus.discount && (
-          <div className="mx-4 mt-3 px-4 py-2.5 rounded-md bg-brand-muted border border-brand/30 flex items-center justify-between text-sm">
+          <div className="mx-4 mt-3 px-4 py-2.5 rounded-md bg-brand-muted border border-brand/30 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 text-sm">
             <span className="text-text-primary">
               <span className="font-medium">{billingStatus.trial_days_remaining} day{billingStatus.trial_days_remaining !== 1 ? 's' : ''} left in your free trial.</span>
               <span className="text-text-secondary"> Choose a plan to keep using Clawvisor.</span>
             </span>
             <NavLink
               to="/pricing"
-              className="text-brand hover:text-brand/80 font-medium transition-colors whitespace-nowrap ml-3"
+              className="text-brand hover:text-brand/80 font-medium transition-colors whitespace-nowrap"
             >
               Choose a plan
             </NavLink>
           </div>
         )}
         {billingStatus && !['trialing', 'active', 'past_due', 'none'].includes(billingStatus.status) && billingStatus.plan !== 'none' && (
-          <div className="mx-4 mt-3 px-4 py-2.5 rounded-md bg-danger/10 border border-danger/30 flex items-center justify-between text-sm">
+          <div className="mx-4 mt-3 px-4 py-2.5 rounded-md bg-danger/10 border border-danger/30 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 text-sm">
             <span className="text-text-primary">
               <span className="font-medium">Your subscription has expired.</span>
               <span className="text-text-secondary"> Choose a plan to continue using Clawvisor.</span>
             </span>
             <NavLink
               to="/pricing"
-              className="text-danger hover:text-danger/80 font-medium transition-colors whitespace-nowrap ml-3"
+              className="text-danger hover:text-danger/80 font-medium transition-colors whitespace-nowrap"
             >
               Choose a plan
             </NavLink>
           </div>
         )}
         {billingStatus?.status === 'past_due' && (
-          <div className="mx-4 mt-3 px-4 py-2.5 rounded-md bg-warning/10 border border-warning/30 flex items-center justify-between text-sm">
+          <div className="mx-4 mt-3 px-4 py-2.5 rounded-md bg-warning/10 border border-warning/30 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 text-sm">
             <span className="text-text-primary">
               <span className="font-medium">Payment past due.</span>
               <span className="text-text-secondary"> Please update your payment method to avoid service interruption.</span>
             </span>
             <NavLink
               to="/dashboard/billing"
-              className="text-warning hover:text-warning/80 font-medium transition-colors whitespace-nowrap ml-3"
+              className="text-warning hover:text-warning/80 font-medium transition-colors whitespace-nowrap"
             >
               Manage billing
             </NavLink>

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { NavLink, Routes, Route, Navigate, useLocation } from 'react-router-dom'
+import { NavLink, Routes, Route, Navigate, useLocation, useNavigate } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { useAuth } from '../hooks/useAuth'
 import { useEventStream } from '../hooks/useEventStream'
@@ -45,6 +45,7 @@ export default function Dashboard() {
   const { resolvedTheme, setTheme } = useTheme()
   const [sidebarOpen, setSidebarOpen] = useState(false)
   const location = useLocation()
+  const navigate = useNavigate()
 
   // Close sidebar on route change (mobile)
   useEffect(() => { setSidebarOpen(false) }, [location.pathname])
@@ -104,9 +105,12 @@ export default function Dashboard() {
           Clawvisor
         </span>
         {queueCount > 0 && (
-          <span className="text-xs font-mono font-medium px-1.5 py-0.5 rounded bg-warning text-surface-0 ml-auto">
+          <button
+            onClick={() => navigate('/dashboard')}
+            className="text-xs font-mono font-medium px-1.5 py-0.5 rounded bg-warning text-surface-0 ml-auto"
+          >
             {queueCount > 9 ? '9+' : queueCount}
-          </span>
+          </button>
         )}
       </div>
 

--- a/web/src/pages/Overview.tsx
+++ b/web/src/pages/Overview.tsx
@@ -105,7 +105,7 @@ export default function Overview() {
   }, [])
 
   return (
-    <div className="p-8 space-y-8">
+    <div className="p-4 sm:p-8 space-y-8">
       <h1 className="text-2xl font-bold text-text-primary">Dashboard</h1>
 
       {/* Deep link result banner */}

--- a/web/src/pages/Restrictions.tsx
+++ b/web/src/pages/Restrictions.tsx
@@ -190,7 +190,7 @@ function WildcardToggle({
         Block all actions
       </span>
       {showReason && !isBlocked && (
-        <div className="flex items-center gap-2 ml-2">
+        <div className="flex flex-wrap items-center gap-2 ml-2">
           <input
             type="text"
             value={reason}
@@ -292,7 +292,7 @@ export default function Restrictions() {
   const unactivated = allServices.filter(s => s.status !== 'activated')
 
   return (
-    <div className="p-8 space-y-6">
+    <div className="p-4 sm:p-8 space-y-6">
       <h1 className="text-2xl font-bold text-text-primary">Restrictions</h1>
       <p className="text-sm text-text-tertiary">
         Block specific service actions. Any agent request matching a restriction is rejected immediately.

--- a/web/src/pages/Services.tsx
+++ b/web/src/pages/Services.tsx
@@ -129,27 +129,29 @@ function ActiveServiceRow({ svc }: { svc: ServiceInfo }) {
 
   return (
     <div className="group">
-      <div className="flex items-center gap-4 px-5 py-4">
-        {/* Icon */}
-        <ServiceIconBadge iconSvg={svc.icon_svg} serviceId={svc.id} size={28} />
+      <div className="flex flex-col sm:flex-row sm:items-center gap-3 px-5 py-4">
+        <div className="flex items-center gap-3 min-w-0 flex-1">
+          {/* Icon */}
+          <ServiceIconBadge iconSvg={svc.icon_svg} serviceId={svc.id} size={28} />
 
-        {/* Name + description */}
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2">
-            <span className="font-medium text-text-primary text-sm truncate">{serviceName(svc.id, svc.alias)}</span>
-            <span className="w-1.5 h-1.5 rounded-full bg-success shrink-0" title="Connected" />
-            <button
-              onClick={() => { setRenaming(true); setRenameValue(svc.alias && svc.alias !== 'default' ? svc.alias : '') }}
-              className="text-xs text-text-tertiary hover:text-text-secondary opacity-0 group-hover:opacity-100"
-            >
-              rename
-            </button>
+          {/* Name + description */}
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <span className="font-medium text-text-primary text-sm truncate">{serviceName(svc.id, svc.alias)}</span>
+              <span className="w-1.5 h-1.5 rounded-full bg-success shrink-0" title="Connected" />
+              <button
+                onClick={() => { setRenaming(true); setRenameValue(svc.alias && svc.alias !== 'default' ? svc.alias : '') }}
+                className="text-xs text-text-tertiary hover:text-text-secondary opacity-0 group-hover:opacity-100"
+              >
+                rename
+              </button>
+            </div>
+            {desc && <p className="text-xs text-text-tertiary mt-0.5">{desc}</p>}
           </div>
-          {desc && <p className="text-xs text-text-tertiary mt-0.5 truncate">{desc}</p>}
         </div>
 
         {/* Actions + connected time */}
-        <div className="shrink-0 flex flex-col items-end gap-1">
+        <div className="shrink-0 flex flex-col items-end gap-1 ml-auto sm:ml-0">
           {svc.requires_activation !== false && (
             <div className="flex gap-1.5">
               {!svc.credential_free && (svc.oauth || svc.pkce_flow || svc.device_flow ? (

--- a/web/src/pages/Services.tsx
+++ b/web/src/pages/Services.tsx
@@ -646,7 +646,7 @@ function AddServiceModal({
           )}
           {error && <p className="text-xs text-danger mb-3">{error}</p>}
 
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             {serviceTypes.map(st => {
               const isActivated = st.activatedCount > 0
               const isGoogleBlocked = googleOAuthMissing && isGoogleService(st.baseId)
@@ -884,7 +884,7 @@ function OrgServicesView({ orgId, orgName }: { orgId: string; orgName: string })
   const services = data?.services ?? []
 
   return (
-    <div className="p-8 space-y-6">
+    <div className="p-4 sm:p-8 space-y-6">
       <div>
         <h1 className="text-2xl font-bold text-text-primary">{orgName} Services</h1>
         <p className="text-sm text-text-tertiary mt-1">
@@ -972,8 +972,8 @@ export default function Services() {
   const googleOAuthMissing = !features?.multi_tenant && hasGoogleServices && googleOAuth != null && !googleOAuth.configured
 
   return (
-    <div className="p-8 space-y-6">
-      <div className="flex items-center justify-between">
+    <div className="p-4 sm:p-8 space-y-6">
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
         <div>
           <h1 className="text-2xl font-bold text-text-primary">Services</h1>
           <p className="text-sm text-text-tertiary mt-1">

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -13,7 +13,7 @@ export default function Settings() {
   const passwordAuth = features?.password_auth ?? false
 
   return (
-    <div className="p-8 space-y-10">
+    <div className="p-4 sm:p-8 space-y-10">
       <h1 className="text-2xl font-bold text-text-primary">Settings</h1>
       <DaemonInfo />
       {!features?.multi_tenant && <LLMSection />}

--- a/web/src/pages/Tasks.tsx
+++ b/web/src/pages/Tasks.tsx
@@ -125,7 +125,7 @@ export default function Tasks() {
   })
 
   return (
-    <div className="p-8 space-y-4">
+    <div className="p-4 sm:p-8 space-y-4">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
           <h1 className="text-2xl font-bold text-text-primary">Tasks</h1>
@@ -189,7 +189,7 @@ export default function Tasks() {
 
       {/* Pagination */}
       {total > PAGE_SIZE && (
-        <div className="flex items-center justify-between text-sm text-text-tertiary">
+        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 text-sm text-text-tertiary">
           <span>Showing {offset + 1}–{Math.min(offset + PAGE_SIZE, total)} of {total}</span>
           <div className="flex gap-2">
             <button


### PR DESCRIPTION
## Summary
- Add collapsible sidebar with hamburger menu, overlay backdrop, and auto-close on navigation for mobile (`< md` breakpoint)
- Add fixed mobile header bar with branding and queue badge
- Make all dashboard page padding responsive (`p-4 sm:p-8`)
- Make notification banners, page headers, pagination controls, agent cards, and audit table details stack/wrap on small screens
- Add horizontal scroll for the gateway log table on mobile

## Test plan
- [ ] Resize browser below 768px — sidebar should collapse, hamburger menu appears
- [ ] Tap hamburger — sidebar slides in with overlay, tap overlay or nav link to close
- [ ] Verify all pages (Dashboard, Tasks, Services, Restrictions, Agents, Audit, Settings, Billing) have comfortable padding on mobile
- [ ] Check audit table scrolls horizontally on narrow screens
- [ ] Verify banners stack vertically on small screens
- [ ] Confirm desktop layout is unchanged at `md` and above

🤖 Generated with [Claude Code](https://claude.com/claude-code)