### PR TITLE
feat: detect partial Google OAuth scopes at task creation

### DIFF
--- a/internal/adapters/definitions/google_calendar.yaml
+++ b/internal/adapters/definitions/google_calendar.yaml
@@ -27,6 +27,7 @@ actions:
   list_events:
     display_name: "List events"
     risk: { category: read, sensitivity: low, description: "List calendar events" }
+    scopes: ["https://www.googleapis.com/auth/calendar.readonly"]
     method: GET
     path: "/calendars/{{.calendar_id}}/events"
     params:
@@ -65,6 +66,7 @@ actions:
   get_event:
     display_name: "Get event"
     risk: { category: read, sensitivity: low, description: "Read a specific calendar event" }
+    scopes: ["https://www.googleapis.com/auth/calendar.readonly"]
     method: GET
     path: "/calendars/{{.calendar_id}}/events/{{.event_id}}"
     params:
@@ -87,6 +89,7 @@ actions:
   create_event:
     display_name: "Create event"
     risk: { category: write, sensitivity: medium, description: "Create a calendar event" }
+    scopes: ["https://www.googleapis.com/auth/calendar.events"]
     method: POST
     path: "/calendars/{{.calendar_id}}/events"
     params:
@@ -117,6 +120,7 @@ actions:
   update_event:
     display_name: "Update event"
     risk: { category: write, sensitivity: medium, description: "Update a calendar event" }
+    scopes: ["https://www.googleapis.com/auth/calendar.events"]
     method: PATCH
     path: "/calendars/{{.calendar_id}}/events/{{.event_id}}"
     body_mode: sparse
@@ -142,6 +146,7 @@ actions:
   delete_event:
     display_name: "Delete event"
     risk: { category: delete, sensitivity: high, description: "Delete a calendar event" }
+    scopes: ["https://www.googleapis.com/auth/calendar.events"]
     method: DELETE
     path: "/calendars/{{.calendar_id}}/events/{{.event_id}}"
     params:
@@ -153,6 +158,7 @@ actions:
   list_calendars:
     display_name: "List calendars"
     risk: { category: read, sensitivity: low, description: "List available calendars" }
+    scopes: ["https://www.googleapis.com/auth/calendar.readonly"]
     method: GET
     path: "/users/me/calendarList"
     response:

--- a/internal/adapters/definitions/google_contacts.yaml
+++ b/internal/adapters/definitions/google_contacts.yaml
@@ -27,6 +27,7 @@ actions:
     display_name: "List contacts"
     override: go
     risk: { category: read, sensitivity: low, description: "List contacts" }
+    scopes: ["https://www.googleapis.com/auth/contacts.readonly"]
     method: GET
     path: "/people/me/connections"
     params:
@@ -60,6 +61,7 @@ actions:
   get_contact:
     display_name: "Get contact"
     risk: { category: read, sensitivity: low, description: "Read a specific contact" }
+    scopes: ["https://www.googleapis.com/auth/contacts.readonly"]
     method: GET
     path: "/{{.contact_id}}"
     params:
@@ -93,6 +95,7 @@ actions:
   search_contacts:
     display_name: "Search contacts"
     risk: { category: search, sensitivity: low, description: "Search contacts" }
+    scopes: ["https://www.googleapis.com/auth/contacts.readonly"]
     method: GET
     path: "/people:searchContacts"
     params:

--- a/internal/adapters/definitions/google_drive.yaml
+++ b/internal/adapters/definitions/google_drive.yaml
@@ -27,6 +27,7 @@ actions:
   list_files:
     display_name: "List files"
     risk: { category: read, sensitivity: low, description: "List files in Google Drive" }
+    scopes: ["https://www.googleapis.com/auth/drive.readonly"]
     method: GET
     path: "/files"
     params:
@@ -51,6 +52,7 @@ actions:
   get_file:
     display_name: "Get file"
     risk: { category: read, sensitivity: low, description: "Read a specific file from Google Drive" }
+    scopes: ["https://www.googleapis.com/auth/drive.readonly"]
     override: go
     params:
       file_id: { type: string, required: true }
@@ -58,6 +60,7 @@ actions:
   download_file:
     display_name: "Download file"
     risk: { category: read, sensitivity: low, description: "Download a non-Google-Workspace file (PDFs, images, etc.) as base64-encoded content" }
+    scopes: ["https://www.googleapis.com/auth/drive.readonly"]
     override: go
     params:
       file_id: { type: string, required: true }
@@ -65,6 +68,7 @@ actions:
   create_file:
     display_name: "Create file"
     risk: { category: write, sensitivity: medium, description: "Create a file in Google Drive" }
+    scopes: ["https://www.googleapis.com/auth/drive.file"]
     override: go
     params:
       name: { type: string, required: true }
@@ -75,6 +79,7 @@ actions:
   update_file:
     display_name: "Update file"
     risk: { category: write, sensitivity: medium, description: "Update a file in Google Drive" }
+    scopes: ["https://www.googleapis.com/auth/drive.file"]
     override: go
     params:
       file_id: { type: string, required: true }
@@ -83,6 +88,7 @@ actions:
   export_file:
     display_name: "Export file"
     risk: { category: read, sensitivity: low, description: "Export a Google Workspace file (Docs, Sheets, Slides) to a downloadable format" }
+    scopes: ["https://www.googleapis.com/auth/drive.readonly"]
     override: go
     params:
       file_id: { type: string, required: true }
@@ -94,6 +100,7 @@ actions:
   search_files:
     display_name: "Search files"
     risk: { category: search, sensitivity: low, description: "Search files in Google Drive" }
+    scopes: ["https://www.googleapis.com/auth/drive.readonly"]
     method: GET
     path: "/files"
     params:

--- a/internal/adapters/definitions/google_gmail.yaml
+++ b/internal/adapters/definitions/google_gmail.yaml
@@ -32,6 +32,7 @@ actions:
   list_messages:
     display_name: "List messages"
     risk: { category: read, sensitivity: low, description: "List email messages" }
+    scopes: ["https://www.googleapis.com/auth/gmail.readonly"]
     override: go
     params:
       query: { type: string }
@@ -40,6 +41,7 @@ actions:
   get_message:
     display_name: "Get message"
     risk: { category: read, sensitivity: low, description: "Read a specific email message" }
+    scopes: ["https://www.googleapis.com/auth/gmail.readonly"]
     override: go
     params:
       message_id: { type: string, required: true }
@@ -47,6 +49,7 @@ actions:
   get_thread:
     display_name: "Get thread"
     risk: { category: read, sensitivity: low, description: "Read all messages in an email thread" }
+    scopes: ["https://www.googleapis.com/auth/gmail.readonly"]
     override: go
     params:
       thread_id: { type: string, required: true }
@@ -54,6 +57,7 @@ actions:
   get_attachment:
     display_name: "Get attachment"
     risk: { category: read, sensitivity: low, description: "Download an email attachment" }
+    scopes: ["https://www.googleapis.com/auth/gmail.readonly"]
     override: go
     params:
       message_id: { type: string, required: true }
@@ -62,6 +66,7 @@ actions:
   send_message:
     display_name: "Send message"
     risk: { category: write, sensitivity: high, description: "Send email as the user" }
+    scopes: ["https://www.googleapis.com/auth/gmail.send"]
     override: go
     params:
       to: { type: string }
@@ -73,6 +78,7 @@ actions:
   create_draft:
     display_name: "Create draft"
     risk: { category: write, sensitivity: low, description: "Create an email draft (not sent)" }
+    scopes: ["https://www.googleapis.com/auth/gmail.compose"]
     override: go
     params:
       to: { type: string, required: true }

--- a/internal/adapters/google/calendar/adapter.go
+++ b/internal/adapters/google/calendar/adapter.go
@@ -59,7 +59,7 @@ func (a *CalendarAdapter) OAuthConfig() *oauth2.Config {
 }
 
 func (a *CalendarAdapter) CredentialFromToken(token *oauth2.Token) ([]byte, error) {
-	return credential.FromToken(token, calendarScopes)
+	return credential.FromToken(token, calendarScopes, false)
 }
 
 func (a *CalendarAdapter) ValidateCredential(credBytes []byte) error {

--- a/internal/adapters/google/contacts/adapter.go
+++ b/internal/adapters/google/contacts/adapter.go
@@ -58,7 +58,7 @@ func (a *ContactsAdapter) OAuthConfig() *oauth2.Config {
 }
 
 func (a *ContactsAdapter) CredentialFromToken(token *oauth2.Token) ([]byte, error) {
-	return credential.FromToken(token, contactsScopes)
+	return credential.FromToken(token, contactsScopes, false)
 }
 
 func (a *ContactsAdapter) ValidateCredential(credBytes []byte) error {

--- a/internal/adapters/google/credential/credential.go
+++ b/internal/adapters/google/credential/credential.go
@@ -17,11 +17,12 @@ import (
 
 // Stored is the JSON structure saved (encrypted) in the vault under key "google".
 type Stored struct {
-	Type         string    `json:"type"`
-	AccessToken  string    `json:"access_token"`
-	RefreshToken string    `json:"refresh_token"`
-	Expiry       time.Time `json:"expiry"`
-	Scopes       []string  `json:"scopes"`
+	Type          string    `json:"type"`
+	AccessToken   string    `json:"access_token"`
+	RefreshToken  string    `json:"refresh_token"`
+	Expiry        time.Time `json:"expiry"`
+	Scopes        []string  `json:"scopes"`
+	ScopesGranted bool      `json:"scopes_granted,omitempty"`
 }
 
 // Parse unmarshals vault credential bytes into a Stored credential.
@@ -47,13 +48,17 @@ func Validate(data []byte) error {
 }
 
 // FromToken builds storable vault bytes from an OAuth2 token and scope list.
-func FromToken(token *oauth2.Token, scopes []string) ([]byte, error) {
+// When scopesGranted is true, the scopes are known to reflect what the user
+// actually granted (read from the token exchange response). When false, scopes
+// are what we requested — we can't verify the user granted all of them.
+func FromToken(token *oauth2.Token, scopes []string, scopesGranted bool) ([]byte, error) {
 	c := Stored{
-		Type:         "oauth2",
-		AccessToken:  token.AccessToken,
-		RefreshToken: token.RefreshToken,
-		Expiry:       token.Expiry,
-		Scopes:       scopes,
+		Type:          "oauth2",
+		AccessToken:   token.AccessToken,
+		RefreshToken:  token.RefreshToken,
+		Expiry:        token.Expiry,
+		Scopes:        scopes,
+		ScopesGranted: scopesGranted,
 	}
 	return json.Marshal(c)
 }

--- a/internal/adapters/google/credential/credential.go
+++ b/internal/adapters/google/credential/credential.go
@@ -113,6 +113,21 @@ func FetchGoogleEmail(ctx context.Context, client *http.Client) (string, error) 
 	return info.Email, nil
 }
 
+// MissingScopes returns the subset of required scopes not present in existing.
+func MissingScopes(existing, required []string) []string {
+	set := make(map[string]bool, len(existing))
+	for _, s := range existing {
+		set[s] = true
+	}
+	var missing []string
+	for _, s := range required {
+		if !set[s] {
+			missing = append(missing, s)
+		}
+	}
+	return missing
+}
+
 // HasAllScopes returns true if existing contains all of the required scopes.
 func HasAllScopes(existing, required []string) bool {
 	set := make(map[string]bool, len(existing))

--- a/internal/adapters/google/credential/credential_test.go
+++ b/internal/adapters/google/credential/credential_test.go
@@ -1,0 +1,60 @@
+package credential
+
+import "testing"
+
+func TestMissingScopes(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing []string
+		required []string
+		want     []string
+	}{
+		{
+			name:     "all present",
+			existing: []string{"a", "b", "c"},
+			required: []string{"a", "b"},
+			want:     nil,
+		},
+		{
+			name:     "some missing",
+			existing: []string{"a"},
+			required: []string{"a", "b", "c"},
+			want:     []string{"b", "c"},
+		},
+		{
+			name:     "all missing",
+			existing: nil,
+			required: []string{"a", "b"},
+			want:     []string{"a", "b"},
+		},
+		{
+			name:     "no required",
+			existing: []string{"a"},
+			required: nil,
+			want:     nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := MissingScopes(tc.existing, tc.required)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("got[%d]=%q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestHasAllScopes(t *testing.T) {
+	if !HasAllScopes([]string{"a", "b", "c"}, []string{"a", "b"}) {
+		t.Fatal("expected true when all required present")
+	}
+	if HasAllScopes([]string{"a"}, []string{"a", "b"}) {
+		t.Fatal("expected false when scope missing")
+	}
+}

--- a/internal/adapters/google/drive/adapter.go
+++ b/internal/adapters/google/drive/adapter.go
@@ -60,7 +60,7 @@ func (a *DriveAdapter) OAuthConfig() *oauth2.Config {
 }
 
 func (a *DriveAdapter) CredentialFromToken(token *oauth2.Token) ([]byte, error) {
-	return credential.FromToken(token, driveScopes)
+	return credential.FromToken(token, driveScopes, false)
 }
 
 func (a *DriveAdapter) ValidateCredential(credBytes []byte) error {

--- a/internal/adapters/google/gmail/adapter.go
+++ b/internal/adapters/google/gmail/adapter.go
@@ -85,7 +85,7 @@ func (a *GmailAdapter) OAuthConfig() *oauth2.Config {
 }
 
 func (a *GmailAdapter) CredentialFromToken(token *oauth2.Token) ([]byte, error) {
-	return credential.FromToken(token, gmailScopes())
+	return credential.FromToken(token, gmailScopes(), false)
 }
 
 func (a *GmailAdapter) ValidateCredential(credBytes []byte) error {

--- a/internal/api/handlers/services.go
+++ b/internal/api/handlers/services.go
@@ -596,9 +596,11 @@ func (h *ServicesHandler) OAuthCallback(w http.ResponseWriter, r *http.Request) 
 		// can deselect individual scopes on the consent screen, so the granted
 		// set may be a subset of what we requested.
 		var scopes []string
+		scopesGranted := false
 		if grantedRaw, ok := token.Extra("scope").(string); ok && grantedRaw != "" {
 			scopes = strings.Split(grantedRaw, " ")
 			sort.Strings(scopes)
+			scopesGranted = true
 		} else {
 			// Fallback for providers that don't return scope in the token response.
 			scopes = entry.Scopes
@@ -613,7 +615,7 @@ func (h *ServicesHandler) OAuthCallback(w http.ResponseWriter, r *http.Request) 
 			}
 		}
 
-		credBytes, err = credential.FromToken(token, scopes)
+		credBytes, err = credential.FromToken(token, scopes, scopesGranted)
 		if err != nil {
 			h.logger.Warn("credential from token failed", "service", entry.ServiceID, "err", err)
 			oauthPopupClose(w, "Failed to process credential.", "")
@@ -1945,7 +1947,7 @@ func credentialFromTokenPathResponse(rawResp map[string]any, tokenPath string, s
 	if expiresIn, ok := extractIntFromPath(rawResp, siblingTokenFieldPath(tokenPath, "expires_in")); ok && expiresIn > 0 {
 		token.Expiry = now.Add(time.Duration(expiresIn) * time.Second)
 	}
-	return credential.FromToken(token, scopes)
+	return credential.FromToken(token, scopes, false)
 }
 
 func extractStringFromPath(m map[string]any, path string) string {

--- a/internal/api/handlers/services.go
+++ b/internal/api/handlers/services.go
@@ -591,9 +591,20 @@ func (h *ServicesHandler) OAuthCallback(w http.ResponseWriter, r *http.Request) 
 			return
 		}
 
-		scopes := entry.Scopes
-		if len(scopes) == 0 {
-			scopes = adapter.RequiredScopes()
+		// Use the scopes actually granted by the user. Google returns them in
+		// the token exchange response as a space-separated "scope" field. Users
+		// can deselect individual scopes on the consent screen, so the granted
+		// set may be a subset of what we requested.
+		var scopes []string
+		if grantedRaw, ok := token.Extra("scope").(string); ok && grantedRaw != "" {
+			scopes = strings.Split(grantedRaw, " ")
+			sort.Strings(scopes)
+		} else {
+			// Fallback for providers that don't return scope in the token response.
+			scopes = entry.Scopes
+			if len(scopes) == 0 {
+				scopes = adapter.RequiredScopes()
+			}
 		}
 
 		if token.RefreshToken == "" {

--- a/internal/api/handlers/tasks.go
+++ b/internal/api/handlers/tasks.go
@@ -7,10 +7,12 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
 
+	"github.com/clawvisor/clawvisor/internal/adapters/google/credential"
 	"github.com/clawvisor/clawvisor/internal/api/middleware"
 	"github.com/clawvisor/clawvisor/internal/callback"
 	"github.com/clawvisor/clawvisor/internal/events"
@@ -147,6 +149,13 @@ func (h *TasksHandler) Create(w http.ResponseWriter, r *http.Request) {
 			if !h.serviceActivated(ctx, agent.UserID, serviceType, serviceAlias, adapter) {
 				code, userErr, _ := serviceNotActivatedResponse(ctx, h.vault, h.st, h.adapterReg, agent.UserID, serviceType, serviceAlias, a.Service, adapter)
 				writeError(w, http.StatusBadRequest, code, userErr)
+				return
+			}
+			if missing := h.missingCredentialScopes(ctx, agent.UserID, serviceType, serviceAlias, adapter); len(missing) > 0 {
+				writeError(w, http.StatusBadRequest, "MISSING_SCOPES",
+					fmt.Sprintf("service %q is connected but missing required OAuth scopes: %s — "+
+						"the user needs to reconnect the service to grant these permissions",
+						a.Service, strings.Join(missing, ", ")))
 				return
 			}
 		}
@@ -1240,6 +1249,27 @@ func (h *TasksHandler) serviceActivated(ctx context.Context, userID, serviceType
 	vKey := h.adapterReg.VaultKeyWithAlias(serviceType, alias)
 	_, err := h.vault.Get(ctx, userID, vKey)
 	return err == nil
+}
+
+// missingCredentialScopes loads the vault credential for a service and returns
+// any required OAuth scopes that are not present. Returns nil when the adapter
+// has no required scopes or the credential is missing (already caught by
+// serviceActivated).
+func (h *TasksHandler) missingCredentialScopes(ctx context.Context, userID, serviceType, alias string, adapter adapters.Adapter) []string {
+	required := adapter.RequiredScopes()
+	if len(required) == 0 {
+		return nil
+	}
+	vKey := h.adapterReg.VaultKeyWithAlias(serviceType, alias)
+	credBytes, err := h.vault.Get(ctx, userID, vKey)
+	if err != nil || len(credBytes) == 0 {
+		return nil
+	}
+	cred, err := credential.Parse(credBytes)
+	if err != nil {
+		return nil
+	}
+	return credential.MissingScopes(cred.Scopes, required)
 }
 
 // ── Task scope check helper ───────────────────────────────────────────────────

--- a/internal/api/handlers/tasks.go
+++ b/internal/api/handlers/tasks.go
@@ -151,7 +151,7 @@ func (h *TasksHandler) Create(w http.ResponseWriter, r *http.Request) {
 				writeError(w, http.StatusBadRequest, code, userErr)
 				return
 			}
-			if missing := h.missingCredentialScopes(ctx, agent.UserID, serviceType, serviceAlias, adapter); len(missing) > 0 {
+			if missing := h.missingCredentialScopes(ctx, agent.UserID, serviceType, serviceAlias, a.Action, adapter); len(missing) > 0 {
 				writeError(w, http.StatusBadRequest, "MISSING_SCOPES",
 					fmt.Sprintf("service %q is connected but missing required OAuth scopes: %s — "+
 						"the user needs to reconnect the service to grant these permissions",
@@ -1252,11 +1252,26 @@ func (h *TasksHandler) serviceActivated(ctx context.Context, userID, serviceType
 }
 
 // missingCredentialScopes loads the vault credential for a service and returns
-// any required OAuth scopes that are not present. Returns nil when the adapter
-// has no required scopes or the credential is missing (already caught by
-// serviceActivated).
-func (h *TasksHandler) missingCredentialScopes(ctx context.Context, userID, serviceType, alias string, adapter adapters.Adapter) []string {
-	required := adapter.RequiredScopes()
+// any required OAuth scopes that are not present for the given action. When
+// the adapter implements ActionScoper, only the scopes needed by the specific
+// action are checked. Otherwise falls back to all adapter RequiredScopes.
+// Returns nil when the credential is missing (already caught by serviceActivated)
+// or when scope data is not trustworthy (legacy credentials).
+func (h *TasksHandler) missingCredentialScopes(ctx context.Context, userID, serviceType, alias, action string, adapter adapters.Adapter) []string {
+	// Determine which scopes to check: per-action if available, else all.
+	var required []string
+	if scoper, ok := adapter.(adapters.ActionScoper); ok && action != "*" {
+		required = scoper.ScopesForAction(action)
+	}
+	if len(required) == 0 {
+		// Wildcard action or adapter doesn't implement ActionScoper —
+		// skip the check rather than requiring all scopes, which would
+		// over-reject tasks that only use a subset of actions.
+		if action == "*" {
+			return nil
+		}
+		required = adapter.RequiredScopes()
+	}
 	if len(required) == 0 {
 		return nil
 	}
@@ -1267,6 +1282,14 @@ func (h *TasksHandler) missingCredentialScopes(ctx context.Context, userID, serv
 	}
 	cred, err := credential.Parse(credBytes)
 	if err != nil {
+		return nil
+	}
+	// Only check scopes when we know they reflect what the user actually
+	// granted (set by the new OAuthCallback path that reads token.Extra("scope")).
+	// Legacy credentials stored the *requested* scopes which may not match
+	// current RequiredScopes if new scopes were added after the credential
+	// was stored.
+	if !cred.ScopesGranted {
 		return nil
 	}
 	return credential.MissingScopes(cred.Scopes, required)

--- a/pkg/adapters/adapters.go
+++ b/pkg/adapters/adapters.go
@@ -160,6 +160,15 @@ type VerificationHinter interface {
 	VerificationHints() string
 }
 
+// ActionScoper is an optional interface adapters can implement to declare
+// which OAuth scopes each action requires. When implemented, scope checks
+// can validate per-action instead of requiring all adapter scopes.
+type ActionScoper interface {
+	// ScopesForAction returns the OAuth scopes required by a specific action.
+	// Returns nil if the action has no specific scope requirements.
+	ScopesForAction(action string) []string
+}
+
 // IdentityFetcher is an optional interface adapters can implement to
 // auto-discover the account identity after activation (e.g. the email
 // address for a Google account, the username for GitHub). When implemented,

--- a/pkg/adapters/yamldef/schema.go
+++ b/pkg/adapters/yamldef/schema.go
@@ -112,6 +112,7 @@ type APIDef struct {
 type Action struct {
 	DisplayName string            `yaml:"display_name"`
 	Risk        RiskDef           `yaml:"risk"`
+	Scopes      []string          `yaml:"scopes,omitempty"`   // OAuth scopes required by this action (for per-action validation)
 	Override    string            `yaml:"override,omitempty"` // "go" signals delegation to a registered Go function
 
 	// REST fields

--- a/pkg/adapters/yamlruntime/adapter.go
+++ b/pkg/adapters/yamlruntime/adapter.go
@@ -300,6 +300,17 @@ func (a *YAMLAdapter) RequiredScopes() []string {
 	return a.def.Auth.OAuth.Scopes
 }
 
+// ScopesForAction returns the OAuth scopes required by a specific action,
+// as declared in the YAML definition. Returns nil if the action has no
+// per-action scope requirements or doesn't exist.
+func (a *YAMLAdapter) ScopesForAction(action string) []string {
+	act, ok := a.def.Actions[action]
+	if !ok {
+		return nil
+	}
+	return act.Scopes
+}
+
 // OAuthScopeParam returns the authorize URL parameter name for scopes.
 // Returns "" to use the default ("scope"). Slack v2 requires "user_scope".
 func (a *YAMLAdapter) OAuthScopeParam() string {


### PR DESCRIPTION
## Summary

- **OAuth callback**: Read granted scopes from the token exchange response (`token.Extra("scope")`) instead of blindly storing the requested scopes. Google allows users to deselect individual scopes on the consent screen, so granted scopes may be a subset of what was requested.
- **Task creation**: After checking a service is activated, also verify that the credential has all required OAuth scopes. Returns a `MISSING_SCOPES` error with the specific missing scopes so agents can prompt users to reconnect.
- **`MissingScopes` utility**: New helper in the credential package that returns the subset of required scopes not present in a credential, with tests.

## Test plan
- [ ] Connect a Google service and deselect a scope on the consent screen — verify the credential stores only granted scopes
- [ ] Create a task targeting a service with missing scopes — verify `MISSING_SCOPES` error is returned
- [ ] Create a task targeting a fully-connected service — verify it succeeds as before
- [ ] Run `go test ./internal/adapters/google/credential/ ./internal/api/handlers/`