### PR TITLE
fix: use same-tab OAuth navigation on mobile

### DIFF
--- a/internal/api/handlers/services.go
+++ b/internal/api/handlers/services.go
@@ -668,7 +668,7 @@ h2{color:#16a34a;margin:0 0 8px}p{color:#6b7280;margin:0;font-size:14px}</style>
 <body><div class="card"><h2>&#10003; Authorized</h2><p>Service activated. You can close this tab.</p></div>
 <script>
 if(window.opener){try{window.opener.postMessage({type:'clawvisor_oauth_done'},'*')}catch(e){}}
-%stry{window.close()}catch(e){}
+%sif(window.opener){try{window.close()}catch(e){}}else{window.location.href='/services'}
 </script></body></html>`, cliCallbackSnippet)
 }
 

--- a/web/src/pages/Services.tsx
+++ b/web/src/pages/Services.tsx
@@ -7,6 +7,17 @@ import { serviceName, serviceDescription } from '../lib/services'
 import { useAuth } from '../hooks/useAuth'
 import { ServiceIconBadge } from '../components/ServiceIcon'
 
+const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent)
+
+function openOAuthUrl(url: string) {
+  if (isMobile) {
+    window.location.href = url
+    return
+  }
+  const popup = window.open(url, '_blank', 'width=600,height=700')
+  if (!popup) window.location.href = url
+}
+
 // ── Active Service Row ───────────────────────────────────────────────────────
 
 function ActiveServiceRow({ svc }: { svc: ServiceInfo }) {
@@ -30,8 +41,7 @@ function ActiveServiceRow({ svc }: { svc: ServiceInfo }) {
       if (svc.pkce_flow) {
         const resp = await api.services.pkceFlowStart(svc.id, alias)
         if (resp.authorize_url) {
-          const popup = window.open(resp.authorize_url, '_blank', 'width=600,height=700')
-          if (!popup) window.location.href = resp.authorize_url
+          openOAuthUrl(resp.authorize_url)
         }
       } else if (svc.device_flow) {
         const resp = await api.services.deviceFlowStart(svc.id, alias)
@@ -66,8 +76,7 @@ function ActiveServiceRow({ svc }: { svc: ServiceInfo }) {
           return
         }
         if (resp.url) {
-          const popup = window.open(resp.url, '_blank', 'width=600,height=700')
-          if (!popup) window.location.href = resp.url
+          openOAuthUrl(resp.url)
         }
       }
     } catch (e: any) {
@@ -416,8 +425,7 @@ function AddServiceModal({
         return
       }
       if (resp.url) {
-        const popup = window.open(resp.url, '_blank', 'width=600,height=700')
-        if (!popup) window.location.href = resp.url
+        openOAuthUrl(resp.url)
       }
     } catch (e: any) {
       setError(e.message ?? 'Failed to start OAuth flow')
@@ -462,8 +470,7 @@ function AddServiceModal({
     try {
       const resp = await api.services.pkceFlowStart(serviceId, alias, clientId)
       if (resp.authorize_url) {
-        const popup = window.open(resp.authorize_url, '_blank', 'width=600,height=700')
-        if (!popup) window.location.href = resp.authorize_url
+        openOAuthUrl(resp.authorize_url)
       }
     } catch (e: any) {
       setError(e.message ?? 'Failed to start authorization')


### PR DESCRIPTION
## Summary
- On mobile, OAuth flows now navigate in the same tab instead of attempting popups that get blocked or open extra tabs
- The OAuth callback page redirects back to `/services` when there's no popup opener (mobile same-tab flow), instead of showing a dead-end "close this tab" message
- Desktop popup behavior is unchanged

## Test plan
- [ ] On mobile: activate an OAuth service, verify it navigates in the same tab and returns to `/services` after auth
- [ ] On desktop: activate an OAuth service, verify the popup flow still works as before
- [ ] Verify PKCE flows also work correctly on both mobile and desktop