### PR TITLE
fix: serialize TokenPath in Redis OAuth state

### DIFF
--- a/internal/api/handlers/oauth_state_store.go
+++ b/internal/api/handlers/oauth_state_store.go
@@ -111,6 +111,7 @@ type oauthStateJSON struct {
 	CLICallback  string            `json:"cli_callback,omitempty"`
 	Scopes       []string          `json:"scopes,omitempty"`
 	Config       map[string]string `json:"config,omitempty"`
+	TokenPath    string            `json:"token_path,omitempty"`
 	ExpiresAt    time.Time         `json:"expires_at"`
 }
 
@@ -123,6 +124,7 @@ func marshalOAuthState(e oauthStateEntry) ([]byte, error) {
 		CLICallback:  e.CLICallback,
 		Scopes:       e.Scopes,
 		Config:       e.Config,
+		TokenPath:    e.TokenPath,
 		ExpiresAt:    e.ExpiresAt,
 	})
 }
@@ -140,6 +142,7 @@ func unmarshalOAuthState(data []byte) (oauthStateEntry, error) {
 		CLICallback:  j.CLICallback,
 		Scopes:       j.Scopes,
 		Config:       j.Config,
+		TokenPath:    j.TokenPath,
 		ExpiresAt:    j.ExpiresAt,
 	}, nil
 }


### PR DESCRIPTION
## Summary
- Adds `TokenPath` to `oauthStateJSON`, `marshalOAuthState`, and `unmarshalOAuthState`

## Context
#210 added `TokenPath` to `oauthStateEntry` and the in-memory store works fine (it stores the struct directly). But the Redis serialization path uses a separate `oauthStateJSON` struct that was not updated, so `TokenPath` is silently dropped during the Redis round-trip. This breaks Slack OAuth in multi-instance cloud deployments.

## Test plan
- [ ] Slack OAuth flow works in Redis-backed deployments (cloud)

🤖 Generated with [Claude Code](https://claude.com/claude-code)