### PR TITLE
feat: local service integration for cloud-hosted agents

### DIFF
--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -465,10 +465,14 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 		if match.AutoExecute && !hardcoded {
 			taskIDPtr := &req.TaskID
 
-			// ── Local service shortcut ───────────────────────────────────
-			// Local services skip intent verification and adapter lookup;
-			// the daemon handles execution directly.
+			var result *adapters.Result
+			var execErr error
+			var verdict *intent.VerificationVerdict
+
 			if isLocalService(serviceType) {
+				// ── Local service shortcut ───────────────────────────────
+				// Local services skip intent verification and adapter
+				// lookup; the daemon handles execution directly.
 				if h.localExec == nil {
 					dur := int(time.Since(start).Milliseconds())
 					e := baseEntry("execute", "error", taskIDPtr)
@@ -488,192 +492,127 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 					})
 					return
 				}
-				result, execErr := h.localExec.Execute(ctx, agent.UserID, serviceType, req.Action, req.Params)
-				dur := int(time.Since(start).Milliseconds())
-				if execErr != nil {
-					errMsg := execErr.Error()
-					e := baseEntry("execute", "error", taskIDPtr)
+				result, execErr = h.localExec.Execute(ctx, agent.UserID, serviceType, req.Action, req.Params)
+			} else {
+				// ── Intent verification ──────────────────────────────────
+				// Load chain facts (needed for both planned call matching and verification).
+				chainFacts := h.loadChainFacts(ctx, task, req)
+
+				// Check if the request matches a pre-registered planned call.
+				// If so, skip LLM-based intent verification entirely — the call
+				// was evaluated during task risk assessment and approved by the user.
+				matchedPlannedCall := matchPlannedCall(task.PlannedCalls, req.Service, req.Action, req.Params, chainFacts)
+
+				if matchedPlannedCall != nil {
+					h.logger.Info("request matches planned call — skipping intent verification",
+						"task_id", req.TaskID,
+						"service", req.Service,
+						"action", req.Action,
+						"planned_reason", matchedPlannedCall.Reason,
+					)
+					verdict = &intent.VerificationVerdict{
+						Allow:           true,
+						ParamScope:      "ok",
+						ReasonCoherence: "ok",
+						ExtractContext:  true,
+						Explanation:     "Matched pre-registered planned call: " + matchedPlannedCall.Reason,
+					}
+				} else {
+					verdict = h.runVerification(ctx, task, match.MatchedAction, req, serviceType, agent.UserID, chainFacts)
+				}
+				// Chain context fallback: if the LLM flagged a missing entity,
+				// check programmatically — the LLM may have missed it in a long
+				// table, or it may exist beyond the loaded fact limit.
+				if verdict != nil && !verdict.Allow && verdict.ParamScope == "violation" && len(verdict.MissingChainValues) > 0 {
+					verdict = chainContextFallback(ctx, h.store, h.logger, verdict, chainFacts, req.TaskID, task, req.SessionID)
+				}
+				if verdict != nil && !verdict.Allow {
+					dur := int(time.Since(start).Milliseconds())
+					e := baseEntry("verify", "restricted", taskIDPtr)
 					e.DurationMS = dur
-					e.ErrorMsg = &errMsg
+					e.Verification = intent.MarshalVerdict(verdict)
 					if logErr := h.store.LogAudit(ctx, e); logErr != nil {
 						h.logger.Warn("audit log failed", "err", logErr)
 					}
 					h.publishAuditAndQueue(agent.UserID, req.TaskID)
-					if req.Context.CallbackURL != "" {
-						cbKey, _ := h.store.GetAgentCallbackSecret(ctx, agent.ID)
-						go func() {
-							cbCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-							defer cancel()
-							_ = callback.DeliverResult(cbCtx, req.Context.CallbackURL, &callback.Payload{
-								Type: "request", RequestID: req.RequestID, Status: "error", Error: errMsg, AuditID: auditID,
-							}, cbKey)
-						}()
+					// Alert on incoherent reason
+					if verdict.ReasonCoherence == "incoherent" && h.notifier != nil {
+						alertText := fmt.Sprintf(
+							"⚠️ <b>Clawvisor — Intent Alert</b>\n\n"+
+								"<b>Task:</b> %s\n"+
+								"<b>Agent reason:</b> %s\n"+
+								"<b>Verdict:</b> %s",
+							task.Purpose, req.Reason, verdict.Explanation)
+						if alertErr := h.notifier.SendAlert(ctx, agent.UserID, alertText); alertErr != nil {
+							h.logger.Warn("intent alert failed", "err", alertErr)
+						}
 					}
 					resp := map[string]any{
-						"status":     "error",
-						"request_id": req.RequestID,
-						"audit_id":   auditID,
-						"error":      errMsg,
-						"code":       "EXECUTION_ERROR",
+						"status":       "restricted",
+						"request_id":   req.RequestID,
+						"audit_id":     auditID,
+						"reason":       verdict.Explanation,
+						"verification": verdict,
+					}
+					if len(warnings) > 0 {
+						resp["warnings"] = warnings
 					}
 					h.maybeInjectNPS(ctx, resp, agent.ID)
 					writeJSON(w, http.StatusOK, resp)
 					return
 				}
-				// Success
-				middleware.AddLogField(ctx, "decision", "execute")
-				middleware.AddLogField(ctx, "outcome", "executed")
-				e := baseEntry("execute", "executed", taskIDPtr)
-				e.DurationMS = dur
-				if logErr := h.store.LogAudit(ctx, e); logErr != nil {
-					h.logger.Warn("audit log failed", "err", logErr)
-				}
-				h.publishAuditAndQueue(agent.UserID, req.TaskID)
-				if req.Context.CallbackURL != "" {
-					cbKey, _ := h.store.GetAgentCallbackSecret(ctx, agent.ID)
-					go func() {
-						cbCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-						defer cancel()
-						_ = callback.DeliverResult(cbCtx, req.Context.CallbackURL, &callback.Payload{
-							Type: "request", RequestID: req.RequestID, Status: "executed", Result: result, AuditID: auditID,
-						}, cbKey)
-					}()
-				}
-				resp := map[string]any{
-					"status":     "executed",
-					"request_id": req.RequestID,
-					"audit_id":   auditID,
-					"result":     result,
-				}
-				if len(warnings) > 0 {
-					resp["warnings"] = warnings
-				}
-				h.maybeInjectNPS(ctx, resp, agent.ID)
-				writeJSON(w, http.StatusOK, resp)
-				return
-			}
+				// ── End intent verification ──────────────────────────────
 
-			// ── Intent verification ──────────────────────────────────────
-			// Load chain facts (needed for both planned call matching and verification).
-			chainFacts := h.loadChainFacts(ctx, task, req)
-
-			// Check if the request matches a pre-registered planned call.
-			// If so, skip LLM-based intent verification entirely — the call
-			// was evaluated during task risk assessment and approved by the user.
-			matchedPlannedCall := matchPlannedCall(task.PlannedCalls, req.Service, req.Action, req.Params, chainFacts)
-
-			var verdict *intent.VerificationVerdict
-			if matchedPlannedCall != nil {
-				h.logger.Info("request matches planned call — skipping intent verification",
-					"task_id", req.TaskID,
-					"service", req.Service,
-					"action", req.Action,
-					"planned_reason", matchedPlannedCall.Reason,
-				)
-				verdict = &intent.VerificationVerdict{
-					Allow:           true,
-					ParamScope:      "ok",
-					ReasonCoherence: "ok",
-					ExtractContext:  true,
-					Explanation:     "Matched pre-registered planned call: " + matchedPlannedCall.Reason,
-				}
-			} else {
-				verdict = h.runVerification(ctx, task, match.MatchedAction, req, serviceType, agent.UserID, chainFacts)
-			}
-			// Chain context fallback: if the LLM flagged a missing entity,
-			// check programmatically — the LLM may have missed it in a long
-			// table, or it may exist beyond the loaded fact limit.
-			if verdict != nil && !verdict.Allow && verdict.ParamScope == "violation" && len(verdict.MissingChainValues) > 0 {
-				verdict = chainContextFallback(ctx, h.store, h.logger, verdict, chainFacts, req.TaskID, task, req.SessionID)
-			}
-			if verdict != nil && !verdict.Allow {
-				dur := int(time.Since(start).Milliseconds())
-				e := baseEntry("verify", "restricted", taskIDPtr)
-				e.DurationMS = dur
-				e.Verification = intent.MarshalVerdict(verdict)
-				if logErr := h.store.LogAudit(ctx, e); logErr != nil {
-					h.logger.Warn("audit log failed", "err", logErr)
-				}
-				h.publishAuditAndQueue(agent.UserID, req.TaskID)
-				// Alert on incoherent reason
-				if verdict.ReasonCoherence == "incoherent" && h.notifier != nil {
-					alertText := fmt.Sprintf(
-						"⚠️ <b>Clawvisor — Intent Alert</b>\n\n"+
-							"<b>Task:</b> %s\n"+
-							"<b>Agent reason:</b> %s\n"+
-							"<b>Verdict:</b> %s",
-						task.Purpose, req.Reason, verdict.Explanation)
-					if alertErr := h.notifier.SendAlert(ctx, agent.UserID, alertText); alertErr != nil {
-						h.logger.Warn("intent alert failed", "err", alertErr)
+				// Check activation for credential-free services before executing.
+				if taskAdapter, taskAdapterOK := h.adapterReg.GetForUser(ctx, serviceType, agent.UserID); taskAdapterOK && taskAdapter.ValidateCredential(nil) == nil {
+					if _, metaErr := h.store.GetServiceMeta(ctx, agent.UserID, serviceType, serviceAlias); metaErr != nil {
+						dur := int(time.Since(start).Milliseconds())
+						e := baseEntry("block", "error", taskIDPtr)
+						e.DurationMS = dur
+						code, userErr, auditMsg := serviceNotActivatedResponse(ctx, h.vault, h.store, h.adapterReg, agent.UserID, serviceType, serviceAlias, req.Service, taskAdapter)
+						e.ErrorMsg = &auditMsg
+						if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+							h.logger.Warn("audit log failed", "err", logErr)
+						}
+						h.publishAuditAndQueue(agent.UserID, req.TaskID)
+						writeJSON(w, http.StatusBadRequest, map[string]any{
+							"status":     "error",
+							"request_id": req.RequestID,
+							"audit_id":   auditID,
+							"error":      userErr,
+							"code":       code,
+						})
+						return
 					}
 				}
-				resp := map[string]any{
-					"status":       "restricted",
-					"request_id":   req.RequestID,
-					"audit_id":     auditID,
-					"reason":       verdict.Explanation,
-					"verification": verdict,
-				}
-				if len(warnings) > 0 {
-					resp["warnings"] = warnings
-				}
-				h.maybeInjectNPS(ctx, resp, agent.ID)
-				writeJSON(w, http.StatusOK, resp)
-				return
-			}
-			// ── End intent verification ──────────────────────────────────
 
-			// Check activation for credential-free services before executing.
-			if taskAdapter, taskAdapterOK := h.adapterReg.GetForUser(ctx, serviceType, agent.UserID); taskAdapterOK && taskAdapter.ValidateCredential(nil) == nil {
-				if _, metaErr := h.store.GetServiceMeta(ctx, agent.UserID, serviceType, serviceAlias); metaErr != nil {
-					dur := int(time.Since(start).Milliseconds())
-					e := baseEntry("block", "error", taskIDPtr)
-					e.DurationMS = dur
-					code, userErr, auditMsg := serviceNotActivatedResponse(ctx, h.vault, h.store, h.adapterReg, agent.UserID, serviceType, serviceAlias, req.Service, taskAdapter)
-					e.ErrorMsg = &auditMsg
-					if logErr := h.store.LogAudit(ctx, e); logErr != nil {
-						h.logger.Warn("audit log failed", "err", logErr)
+				// Validate required params before execution.
+				if execAdapter, adOK := h.adapterReg.GetForUser(ctx, serviceType, agent.UserID); adOK {
+					paramErr, paramWarnings := validateRequestParams(execAdapter, req.Action, req.Params)
+					warnings = append(warnings, paramWarnings...)
+					if paramErr != nil {
+						errMsg := paramErr.Error
+						e := baseEntry("reject", "validation_error", taskIDPtr)
+						e.DurationMS = int(time.Since(start).Milliseconds())
+						e.ErrorMsg = &errMsg
+						if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+							h.logger.Warn("audit log failed", "err", logErr)
+						}
+						h.publishAuditAndQueue(agent.UserID, req.TaskID)
+						writeDetailedError(w, http.StatusBadRequest, *paramErr)
+						return
 					}
-					h.publishAuditAndQueue(agent.UserID, req.TaskID)
-					writeJSON(w, http.StatusBadRequest, map[string]any{
-						"status":     "error",
-						"request_id": req.RequestID,
-						"audit_id":   auditID,
-						"error":      userErr,
-						"code":       code,
-					})
-					return
 				}
-			}
 
-			// Validate required params before execution.
-			if execAdapter, adOK := h.adapterReg.GetForUser(ctx, serviceType, agent.UserID); adOK {
-				paramErr, paramWarnings := validateRequestParams(execAdapter, req.Action, req.Params)
-				warnings = append(warnings, paramWarnings...)
-				if paramErr != nil {
-					errMsg := paramErr.Error
-					e := baseEntry("reject", "validation_error", taskIDPtr)
-					e.DurationMS = int(time.Since(start).Milliseconds())
-					e.ErrorMsg = &errMsg
-					if logErr := h.store.LogAudit(ctx, e); logErr != nil {
-						h.logger.Warn("audit log failed", "err", logErr)
-					}
-					h.publishAuditAndQueue(agent.UserID, req.TaskID)
-					writeDetailedError(w, http.StatusBadRequest, *paramErr)
-					return
-				}
-			}
+				vKey := h.adapterReg.VaultKeyWithAliasForUser(serviceType, serviceAlias, agent.UserID)
+				result, execErr = executeAdapterRequest(ctx, h.vault, h.adapterReg, h.store,
+					agent.UserID, serviceType, req.Action, req.Params, vKey)
 
-			vKey := h.adapterReg.VaultKeyWithAliasForUser(serviceType, serviceAlias, agent.UserID)
-			result, execErr := executeAdapterRequest(ctx, h.vault, h.adapterReg, h.store,
-				agent.UserID, serviceType, req.Action, req.Params, vKey)
-			dur := int(time.Since(start).Milliseconds())
-
-			if execErr != nil {
-				if errors.Is(execErr, vault.ErrNotFound) {
-					// Vault credential missing — fail immediately.
+				// Vault credential missing — return activation error.
+				if execErr != nil && errors.Is(execErr, vault.ErrNotFound) {
 					adapter, adapterOK := h.adapterReg.GetForUser(ctx, serviceType, agent.UserID)
 					if adapterOK && adapter.ValidateCredential(nil) != nil {
+						dur := int(time.Since(start).Milliseconds())
 						e := baseEntry("block", "error", taskIDPtr)
 						e.DurationMS = dur
 						code, userErr, auditMsg := serviceNotActivatedResponse(ctx, h.vault, h.store, h.adapterReg, agent.UserID, serviceType, serviceAlias, req.Service, adapter)
@@ -692,6 +631,13 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 				}
+			}
+
+			// ── Shared execution result handling (local + cloud) ────────
+
+			dur := int(time.Since(start).Milliseconds())
+
+			if execErr != nil {
 				errMsg := execErr.Error()
 				e := baseEntry("execute", "error", taskIDPtr)
 				e.DurationMS = dur
@@ -735,7 +681,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			}
 			h.publishAuditAndQueue(agent.UserID, req.TaskID)
 
-			// Chain context extraction (async — after response is written)
+			// Chain context extraction (async — cloud services only, guarded by verdict != nil)
 			chainSessionID := req.SessionID
 			if chainSessionID == "" && task.Lifetime != "standing" {
 				chainSessionID = req.TaskID
@@ -1023,8 +969,12 @@ func (h *GatewayHandler) executeAndRespond(w http.ResponseWriter, ctx context.Co
 	var execErr error
 	start := time.Now()
 
-	if isLocalService(serviceType) && h.localExec != nil {
-		result, execErr = h.localExec.Execute(ctx, pa.UserID, serviceType, blob.Action, blob.Params)
+	if isLocalService(serviceType) {
+		if h.localExec == nil {
+			execErr = fmt.Errorf("local services are not available in this deployment")
+		} else {
+			result, execErr = h.localExec.Execute(ctx, pa.UserID, serviceType, blob.Action, blob.Params)
+		}
 	} else {
 		// Resolve (and cache) the adapter before VaultKeyWithAliasForUser and executeAdapterRequest.
 		h.adapterReg.GetForUser(ctx, serviceType, pa.UserID)

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -52,6 +52,20 @@ type GatewayHooks struct {
 	BeforeAuthorize func(ctx context.Context, agentID, userID, service, action string) error
 }
 
+// LocalServiceExecutor handles execution of local daemon service requests.
+// Implemented by the cloud layer; nil in self-hosted mode.
+type LocalServiceExecutor interface {
+	// Execute forwards a request to the appropriate local daemon.
+	// The service should include the "local." prefix (e.g. "local.my_service").
+	// The caller has already enforced restrictions and task scope.
+	Execute(ctx context.Context, userID, service, action string, params map[string]any) (*adapters.Result, error)
+}
+
+// isLocalService returns true for services provided by local daemons.
+func isLocalService(serviceType string) bool {
+	return strings.HasPrefix(serviceType, "local.")
+}
+
 // GatewayHandler handles POST /api/gateway/request.
 type GatewayHandler struct {
 	store        store.Store
@@ -64,7 +78,8 @@ type GatewayHandler struct {
 	logger       *slog.Logger
 	baseURL      string
 	eventHub     events.EventHub
-	gatewayHooks *GatewayHooks // cloud-injected authorization hooks; may be nil
+	gatewayHooks *GatewayHooks        // cloud-injected authorization hooks; may be nil
+	localExec    LocalServiceExecutor  // cloud-injected local service executor; may be nil
 }
 
 func NewGatewayHandler(
@@ -91,6 +106,11 @@ func NewGatewayHandler(
 // Must be called before any requests are handled.
 func (h *GatewayHandler) SetGatewayHooks(hooks *GatewayHooks) {
 	h.gatewayHooks = hooks
+}
+
+// SetLocalServiceExecutor configures the local daemon service executor.
+func (h *GatewayHandler) SetLocalServiceExecutor(e LocalServiceExecutor) {
+	h.localExec = e
 }
 
 // HandleRequest is the main gateway entry point.
@@ -445,6 +465,94 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 		if match.AutoExecute && !hardcoded {
 			taskIDPtr := &req.TaskID
 
+			// ── Local service shortcut ───────────────────────────────────
+			// Local services skip intent verification and adapter lookup;
+			// the daemon handles execution directly.
+			if isLocalService(serviceType) {
+				if h.localExec == nil {
+					dur := int(time.Since(start).Milliseconds())
+					e := baseEntry("execute", "error", taskIDPtr)
+					e.DurationMS = dur
+					errMsg := "local services are not available in this deployment"
+					e.ErrorMsg = &errMsg
+					if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+						h.logger.Warn("audit log failed", "err", logErr)
+					}
+					h.publishAuditAndQueue(agent.UserID, req.TaskID)
+					writeJSON(w, http.StatusOK, map[string]any{
+						"status":     "error",
+						"request_id": req.RequestID,
+						"audit_id":   auditID,
+						"error":      errMsg,
+						"code":       "LOCAL_SERVICE_UNAVAILABLE",
+					})
+					return
+				}
+				result, execErr := h.localExec.Execute(ctx, agent.UserID, serviceType, req.Action, req.Params)
+				dur := int(time.Since(start).Milliseconds())
+				if execErr != nil {
+					errMsg := execErr.Error()
+					e := baseEntry("execute", "error", taskIDPtr)
+					e.DurationMS = dur
+					e.ErrorMsg = &errMsg
+					if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+						h.logger.Warn("audit log failed", "err", logErr)
+					}
+					h.publishAuditAndQueue(agent.UserID, req.TaskID)
+					if req.Context.CallbackURL != "" {
+						cbKey, _ := h.store.GetAgentCallbackSecret(ctx, agent.ID)
+						go func() {
+							cbCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+							defer cancel()
+							_ = callback.DeliverResult(cbCtx, req.Context.CallbackURL, &callback.Payload{
+								Type: "request", RequestID: req.RequestID, Status: "error", Error: errMsg, AuditID: auditID,
+							}, cbKey)
+						}()
+					}
+					resp := map[string]any{
+						"status":     "error",
+						"request_id": req.RequestID,
+						"audit_id":   auditID,
+						"error":      errMsg,
+						"code":       "EXECUTION_ERROR",
+					}
+					h.maybeInjectNPS(ctx, resp, agent.ID)
+					writeJSON(w, http.StatusOK, resp)
+					return
+				}
+				// Success
+				middleware.AddLogField(ctx, "decision", "execute")
+				middleware.AddLogField(ctx, "outcome", "executed")
+				e := baseEntry("execute", "executed", taskIDPtr)
+				e.DurationMS = dur
+				if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+					h.logger.Warn("audit log failed", "err", logErr)
+				}
+				h.publishAuditAndQueue(agent.UserID, req.TaskID)
+				if req.Context.CallbackURL != "" {
+					cbKey, _ := h.store.GetAgentCallbackSecret(ctx, agent.ID)
+					go func() {
+						cbCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+						defer cancel()
+						_ = callback.DeliverResult(cbCtx, req.Context.CallbackURL, &callback.Payload{
+							Type: "request", RequestID: req.RequestID, Status: "executed", Result: result, AuditID: auditID,
+						}, cbKey)
+					}()
+				}
+				resp := map[string]any{
+					"status":     "executed",
+					"request_id": req.RequestID,
+					"audit_id":   auditID,
+					"result":     result,
+				}
+				if len(warnings) > 0 {
+					resp["warnings"] = warnings
+				}
+				h.maybeInjectNPS(ctx, resp, agent.ID)
+				writeJSON(w, http.StatusOK, resp)
+				return
+			}
+
 			// ── Intent verification ──────────────────────────────────────
 			// Load chain facts (needed for both planned call matching and verification).
 			chainFacts := h.loadChainFacts(ctx, task, req)
@@ -694,45 +802,15 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 	// ── Step 5: Per-request approval ─────────────────────────────────────────
 	// Task in-scope but not auto-execute, or hardcoded approval.
 
-	// Reject unknown services immediately.
-	approveAdapter, ok := h.adapterReg.GetForUser(ctx, serviceType, agent.UserID)
-	if !ok {
-		e := baseEntry("approve", "error", nil)
-		e.DurationMS = int(time.Since(start).Milliseconds())
-		errMsg := fmt.Sprintf("unknown service %q", serviceType)
-		e.ErrorMsg = &errMsg
-		if logErr := h.store.LogAudit(ctx, e); logErr != nil {
-			h.logger.Warn("audit log failed", "err", logErr)
-		}
-		h.publishAuditAndQueue(agent.UserID, "")
-		writeJSON(w, http.StatusBadRequest, map[string]any{
-			"status":     "error",
-			"request_id": req.RequestID,
-			"audit_id":   auditID,
-			"error":      fmt.Sprintf("unknown service %q: not a supported service", serviceType),
-			"code":       "UNKNOWN_SERVICE",
-		})
-		return
-	}
-
-	// Check if service needs activation.
-	{
-		notActivated := false
-		if approveAdapter.ValidateCredential(nil) == nil {
-			if _, metaErr := h.store.GetServiceMeta(ctx, agent.UserID, serviceType, serviceAlias); metaErr != nil {
-				notActivated = true
-			}
-		} else {
-			vKey := h.adapterReg.VaultKeyWithAliasForUser(serviceType, serviceAlias, agent.UserID)
-			if _, vaultErr := h.vault.Get(ctx, agent.UserID, vKey); errors.Is(vaultErr, vault.ErrNotFound) {
-				notActivated = true
-			}
-		}
-		if notActivated {
-			e := baseEntry("block", "error", nil)
+	// Local services skip adapter/activation checks — the daemon validates.
+	if !isLocalService(serviceType) {
+		// Reject unknown services immediately.
+		approveAdapter, ok := h.adapterReg.GetForUser(ctx, serviceType, agent.UserID)
+		if !ok {
+			e := baseEntry("approve", "error", nil)
 			e.DurationMS = int(time.Since(start).Milliseconds())
-			code, userErr, auditMsg := serviceNotActivatedResponse(ctx, h.vault, h.store, h.adapterReg, agent.UserID, serviceType, serviceAlias, req.Service, approveAdapter)
-			e.ErrorMsg = &auditMsg
+			errMsg := fmt.Sprintf("unknown service %q", serviceType)
+			e.ErrorMsg = &errMsg
 			if logErr := h.store.LogAudit(ctx, e); logErr != nil {
 				h.logger.Warn("audit log failed", "err", logErr)
 			}
@@ -741,10 +819,43 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 				"status":     "error",
 				"request_id": req.RequestID,
 				"audit_id":   auditID,
-				"error":      userErr,
-				"code":       code,
+				"error":      fmt.Sprintf("unknown service %q: not a supported service", serviceType),
+				"code":       "UNKNOWN_SERVICE",
 			})
 			return
+		}
+
+		// Check if service needs activation.
+		{
+			notActivated := false
+			if approveAdapter.ValidateCredential(nil) == nil {
+				if _, metaErr := h.store.GetServiceMeta(ctx, agent.UserID, serviceType, serviceAlias); metaErr != nil {
+					notActivated = true
+				}
+			} else {
+				vKey := h.adapterReg.VaultKeyWithAliasForUser(serviceType, serviceAlias, agent.UserID)
+				if _, vaultErr := h.vault.Get(ctx, agent.UserID, vKey); errors.Is(vaultErr, vault.ErrNotFound) {
+					notActivated = true
+				}
+			}
+			if notActivated {
+				e := baseEntry("block", "error", nil)
+				e.DurationMS = int(time.Since(start).Milliseconds())
+				code, userErr, auditMsg := serviceNotActivatedResponse(ctx, h.vault, h.store, h.adapterReg, agent.UserID, serviceType, serviceAlias, req.Service, approveAdapter)
+				e.ErrorMsg = &auditMsg
+				if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+					h.logger.Warn("audit log failed", "err", logErr)
+				}
+				h.publishAuditAndQueue(agent.UserID, "")
+				writeJSON(w, http.StatusBadRequest, map[string]any{
+					"status":     "error",
+					"request_id": req.RequestID,
+					"audit_id":   auditID,
+					"error":      userErr,
+					"code":       code,
+				})
+				return
+			}
 		}
 	}
 
@@ -907,13 +1018,20 @@ func (h *GatewayHandler) executeAndRespond(w http.ResponseWriter, ctx context.Co
 	}
 
 	serviceType, alias := parseServiceAlias(blob.Service)
-	// Resolve (and cache) the adapter before VaultKeyWithAliasForUser and executeAdapterRequest.
-	h.adapterReg.GetForUser(ctx, serviceType, pa.UserID)
-	vKey := h.adapterReg.VaultKeyWithAliasForUser(serviceType, alias, pa.UserID)
 
+	var result *adapters.Result
+	var execErr error
 	start := time.Now()
-	result, execErr := executeAdapterRequest(ctx, h.vault, h.adapterReg, h.store,
-		pa.UserID, blob.Service, blob.Action, blob.Params, vKey)
+
+	if isLocalService(serviceType) && h.localExec != nil {
+		result, execErr = h.localExec.Execute(ctx, pa.UserID, serviceType, blob.Action, blob.Params)
+	} else {
+		// Resolve (and cache) the adapter before VaultKeyWithAliasForUser and executeAdapterRequest.
+		h.adapterReg.GetForUser(ctx, serviceType, pa.UserID)
+		vKey := h.adapterReg.VaultKeyWithAliasForUser(serviceType, alias, pa.UserID)
+		result, execErr = executeAdapterRequest(ctx, h.vault, h.adapterReg, h.store,
+			pa.UserID, blob.Service, blob.Action, blob.Params, vKey)
+	}
 	dur := int(time.Since(start).Milliseconds())
 
 	outcome := "executed"

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -78,8 +78,9 @@ type GatewayHandler struct {
 	logger       *slog.Logger
 	baseURL      string
 	eventHub     events.EventHub
-	gatewayHooks *GatewayHooks        // cloud-injected authorization hooks; may be nil
-	localExec    LocalServiceExecutor  // cloud-injected local service executor; may be nil
+	gatewayHooks     *GatewayHooks        // cloud-injected authorization hooks; may be nil
+	localExec        LocalServiceExecutor  // cloud-injected local service executor; may be nil
+	localSvcProvider LocalServiceProvider  // cloud-injected local service catalog; may be nil
 }
 
 func NewGatewayHandler(
@@ -111,6 +112,12 @@ func (h *GatewayHandler) SetGatewayHooks(hooks *GatewayHooks) {
 // SetLocalServiceExecutor configures the local daemon service executor.
 func (h *GatewayHandler) SetLocalServiceExecutor(e LocalServiceExecutor) {
 	h.localExec = e
+}
+
+// SetLocalServiceProvider configures the local service catalog provider for
+// request-time action validation.
+func (h *GatewayHandler) SetLocalServiceProvider(p LocalServiceProvider) {
+	h.localSvcProvider = p
 }
 
 // HandleRequest is the main gateway entry point.
@@ -424,6 +431,26 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 					Error: msg,
 					Code:  "UNKNOWN_ACTION",
 					Hint:  fmt.Sprintf("This service does not have a %q action. Check the available actions listed above and use the correct one.", req.Action),
+				})
+				return
+			}
+		} else if isLocalService(serviceType) && h.localSvcProvider != nil {
+			// Validate action exists on the local service (mirrors cloud adapter check above).
+			if localErr := h.validateLocalAction(ctx, agent.UserID, serviceType, req.Action); localErr != nil {
+				_ = h.store.IncrementTaskRequestCount(ctx, req.TaskID)
+				msg := localErr.Error()
+				taskIDPtr := &req.TaskID
+				e := baseEntry("unknown_action", "blocked", taskIDPtr)
+				e.DurationMS = int(time.Since(start).Milliseconds())
+				e.ErrorMsg = &msg
+				if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+					h.logger.Warn("audit log failed", "err", logErr)
+				}
+				h.publishAuditAndQueue(agent.UserID, req.TaskID)
+				writeDetailedError(w, http.StatusBadRequest, apiErrorDetail{
+					Error: msg,
+					Code:  "UNKNOWN_ACTION",
+					Hint:  fmt.Sprintf("This local service does not have a %q action. Check the available actions listed above and use the correct one.", req.Action),
 				})
 				return
 			}
@@ -1237,6 +1264,35 @@ func (h *GatewayHandler) loadChainFacts(ctx context.Context, task *store.Task, r
 		}
 	}
 	return chainFacts
+}
+
+// validateLocalAction checks that a local service action exists at request time.
+// Returns nil if the action is valid or the service is not found (let execution
+// handle that). Returns an error with available actions if the action is unknown.
+func (h *GatewayHandler) validateLocalAction(ctx context.Context, userID, serviceType, action string) error {
+	active, err := h.localSvcProvider.ActiveLocalServices(ctx, userID)
+	if err != nil {
+		return nil // can't validate — let execution handle it
+	}
+	svcID := strings.TrimPrefix(serviceType, "local.")
+	for _, svc := range active {
+		if svc.ServiceID == svcID {
+			for _, a := range svc.Actions {
+				if a.ID == action {
+					return nil
+				}
+			}
+			available := make([]string, len(svc.Actions))
+			for i, a := range svc.Actions {
+				available[i] = a.ID
+			}
+			return fmt.Errorf(
+				"Action %q does not exist on service %s. Available actions: %s",
+				action, serviceType, strings.Join(available, ", "),
+			)
+		}
+	}
+	return nil // service not found — let execution handle it
 }
 
 // Returns nil if the verifier is a no-op or if verification fails.

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -470,9 +470,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			var verdict *intent.VerificationVerdict
 
 			if isLocalService(serviceType) {
-				// ── Local service shortcut ───────────────────────────────
-				// Local services skip intent verification and adapter
-				// lookup; the daemon handles execution directly.
+				// ── Local service execution ──────────────────────────────
 				if h.localExec == nil {
 					dur := int(time.Since(start).Milliseconds())
 					e := baseEntry("execute", "error", taskIDPtr)
@@ -492,6 +490,66 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 					})
 					return
 				}
+
+				// ── Intent verification (same pipeline as cloud services) ──
+				chainFacts := h.loadChainFacts(ctx, task, req)
+
+				matchedPlannedCall := matchPlannedCall(task.PlannedCalls, req.Service, req.Action, req.Params, chainFacts)
+				if matchedPlannedCall != nil {
+					h.logger.Info("request matches planned call — skipping intent verification",
+						"task_id", req.TaskID,
+						"service", req.Service,
+						"action", req.Action,
+						"planned_reason", matchedPlannedCall.Reason,
+					)
+					verdict = &intent.VerificationVerdict{
+						Allow:           true,
+						ParamScope:      "ok",
+						ReasonCoherence: "ok",
+						ExtractContext:  true,
+						Explanation:     "Matched pre-registered planned call: " + matchedPlannedCall.Reason,
+					}
+				} else {
+					verdict = h.runVerification(ctx, task, match.MatchedAction, req, serviceType, agent.UserID, chainFacts)
+				}
+				if verdict != nil && !verdict.Allow && verdict.ParamScope == "violation" && len(verdict.MissingChainValues) > 0 {
+					verdict = chainContextFallback(ctx, h.store, h.logger, verdict, chainFacts, req.TaskID, task, req.SessionID)
+				}
+				if verdict != nil && !verdict.Allow {
+					dur := int(time.Since(start).Milliseconds())
+					e := baseEntry("verify", "restricted", taskIDPtr)
+					e.DurationMS = dur
+					e.Verification = intent.MarshalVerdict(verdict)
+					if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+						h.logger.Warn("audit log failed", "err", logErr)
+					}
+					h.publishAuditAndQueue(agent.UserID, req.TaskID)
+					if verdict.ReasonCoherence == "incoherent" && h.notifier != nil {
+						alertText := fmt.Sprintf(
+							"⚠️ <b>Clawvisor — Intent Alert</b>\n\n"+
+								"<b>Task:</b> %s\n"+
+								"<b>Agent reason:</b> %s\n"+
+								"<b>Verdict:</b> %s",
+							task.Purpose, req.Reason, verdict.Explanation)
+						if alertErr := h.notifier.SendAlert(ctx, agent.UserID, alertText); alertErr != nil {
+							h.logger.Warn("intent alert failed", "err", alertErr)
+						}
+					}
+					resp := map[string]any{
+						"status":       "restricted",
+						"request_id":   req.RequestID,
+						"audit_id":     auditID,
+						"reason":       verdict.Explanation,
+						"verification": verdict,
+					}
+					if len(warnings) > 0 {
+						resp["warnings"] = warnings
+					}
+					h.maybeInjectNPS(ctx, resp, agent.ID)
+					writeJSON(w, http.StatusOK, resp)
+					return
+				}
+
 				result, execErr = h.localExec.Execute(ctx, agent.UserID, serviceType, req.Action, req.Params)
 			} else {
 				// ── Intent verification ──────────────────────────────────

--- a/internal/api/handlers/local_service_test.go
+++ b/internal/api/handlers/local_service_test.go
@@ -1,0 +1,1013 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/clawvisor/clawvisor/internal/events"
+	"github.com/clawvisor/clawvisor/internal/intent"
+	"github.com/clawvisor/clawvisor/pkg/adapters"
+	"github.com/clawvisor/clawvisor/pkg/config"
+	"github.com/clawvisor/clawvisor/pkg/store"
+	"github.com/clawvisor/clawvisor/pkg/vault"
+)
+
+// ── Test mocks ──────────────────────────────────────────────────────────────
+
+// mockLocalProvider is a configurable LocalServiceProvider for tests.
+type mockLocalProvider struct {
+	services []LocalCatalogService
+	err      error
+}
+
+func (m *mockLocalProvider) ActiveLocalServices(_ context.Context, _ string) ([]LocalCatalogService, error) {
+	return m.services, m.err
+}
+
+// mockLocalExecutor is a configurable LocalServiceExecutor for tests.
+type mockLocalExecutor struct {
+	result  *adapters.Result
+	err     error
+	called  bool
+	service string
+	action  string
+}
+
+func (m *mockLocalExecutor) Execute(_ context.Context, _, service, action string, _ map[string]any) (*adapters.Result, error) {
+	m.called = true
+	m.service = service
+	m.action = action
+	return m.result, m.err
+}
+
+// localTestStore is a minimal store for local service handler tests.
+type localTestStore struct {
+	store.Store // embed nil interface; only override needed methods
+
+	tasks          map[string]*store.Task
+	restrictions   map[string]*store.Restriction
+	auditEntries   []*store.AuditEntry
+	gatewayLogs    []*store.GatewayRequestLog
+	serviceMetas   []*store.ServiceMeta
+	chainFacts     []*store.ChainFact
+	requestCounts  map[string]int
+}
+
+func newLocalTestStore() *localTestStore {
+	return &localTestStore{
+		tasks:         make(map[string]*store.Task),
+		restrictions:  make(map[string]*store.Restriction),
+		requestCounts: make(map[string]int),
+	}
+}
+
+func (s *localTestStore) GetTask(_ context.Context, id string) (*store.Task, error) {
+	t, ok := s.tasks[id]
+	if !ok {
+		return nil, store.ErrNotFound
+	}
+	return t, nil
+}
+
+func (s *localTestStore) MatchRestriction(_ context.Context, _, _, _ string) (*store.Restriction, error) {
+	return nil, nil
+}
+
+func (s *localTestStore) LogAudit(_ context.Context, entry *store.AuditEntry) error {
+	s.auditEntries = append(s.auditEntries, entry)
+	return nil
+}
+
+func (s *localTestStore) LogGatewayRequest(_ context.Context, entry *store.GatewayRequestLog) error {
+	s.gatewayLogs = append(s.gatewayLogs, entry)
+	return nil
+}
+
+func (s *localTestStore) IncrementTaskRequestCount(_ context.Context, id string) error {
+	s.requestCounts[id]++
+	return nil
+}
+
+func (s *localTestStore) GetAuditEntryByRequestID(_ context.Context, _, _ string) (*store.AuditEntry, error) {
+	return nil, store.ErrNotFound
+}
+
+func (s *localTestStore) ListChainFacts(_ context.Context, _, _ string, _ int) ([]*store.ChainFact, error) {
+	return s.chainFacts, nil
+}
+
+func (s *localTestStore) SaveChainFacts(_ context.Context, _ []*store.ChainFact) error {
+	return nil
+}
+
+func (s *localTestStore) ChainFactValueExists(_ context.Context, _, _, _ string) (bool, error) {
+	return false, nil
+}
+
+func (s *localTestStore) ListServiceMetas(_ context.Context, _ string) ([]*store.ServiceMeta, error) {
+	return s.serviceMetas, nil
+}
+
+// mockVerifier allows tests to control intent verification outcomes.
+type mockVerifier struct {
+	verdict *intent.VerificationVerdict
+	err     error
+	called  bool
+}
+
+func (m *mockVerifier) Verify(_ context.Context, _ intent.VerifyRequest) (*intent.VerificationVerdict, error) {
+	m.called = true
+	return m.verdict, m.err
+}
+
+// testVault is a minimal vault for tests — never stores or retrieves anything.
+type testVault struct{}
+
+func (testVault) Set(_ context.Context, _, _ string, _ []byte) error    { return nil }
+func (testVault) Get(_ context.Context, _, _ string) ([]byte, error)    { return nil, vault.ErrNotFound }
+func (testVault) Delete(_ context.Context, _, _ string) error           { return nil }
+func (testVault) List(_ context.Context, _ string) ([]string, error)    { return nil, nil }
+
+// testServices returns a standard set of local services for testing.
+func testServices() []LocalCatalogService {
+	return []LocalCatalogService{
+		{
+			ServiceID:   "files",
+			DaemonName:  "my-mac",
+			Name:        "File System",
+			Description: "Read and write files on the local filesystem.",
+			Actions: []LocalCatalogAction{
+				{ID: "read_file", Name: "Read File", Description: "Read a file", Params: []LocalCatalogParam{
+					{Name: "path", Type: "string", Required: true, Description: "File path"},
+				}},
+				{ID: "write_file", Name: "Write File", Description: "Write a file", Params: []LocalCatalogParam{
+					{Name: "path", Type: "string", Required: true, Description: "File path"},
+					{Name: "content", Type: "string", Required: true, Description: "File content"},
+				}},
+				{ID: "list_dir", Name: "List Directory", Description: "List directory contents"},
+			},
+		},
+		{
+			ServiceID:   "browser",
+			DaemonName:  "my-mac",
+			Name:        "Browser",
+			Description: "Browser navigation and automation.",
+			Actions: []LocalCatalogAction{
+				{ID: "navigate", Name: "Navigate", Description: "Navigate to a URL"},
+				{ID: "screenshot", Name: "Screenshot", Description: "Take a screenshot"},
+			},
+		},
+	}
+}
+
+func withAgent(ctx context.Context, agent *store.Agent) context.Context {
+	return store.WithAgent(ctx, agent)
+}
+
+var testAgent = &store.Agent{ID: "agent-1", UserID: "user-1", Name: "test-agent"}
+
+// ── Gateway: validateLocalAction unit tests ─────────────────────────────────
+
+func TestValidateLocalAction_ValidAction(t *testing.T) {
+	h := &GatewayHandler{
+		localSvcProvider: &mockLocalProvider{services: testServices()},
+	}
+	err := h.validateLocalAction(context.Background(), "user-1", "local.files", "read_file")
+	if err != nil {
+		t.Fatalf("expected no error for valid action, got: %v", err)
+	}
+}
+
+func TestValidateLocalAction_InvalidAction(t *testing.T) {
+	h := &GatewayHandler{
+		localSvcProvider: &mockLocalProvider{services: testServices()},
+	}
+	err := h.validateLocalAction(context.Background(), "user-1", "local.files", "delete_file")
+	if err == nil {
+		t.Fatal("expected error for invalid action")
+	}
+	if !strings.Contains(err.Error(), "delete_file") {
+		t.Fatalf("error should mention the invalid action, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "read_file") {
+		t.Fatalf("error should list available actions, got: %v", err)
+	}
+}
+
+func TestValidateLocalAction_UnknownService(t *testing.T) {
+	h := &GatewayHandler{
+		localSvcProvider: &mockLocalProvider{services: testServices()},
+	}
+	// Unknown service returns nil — let execution handle the error.
+	err := h.validateLocalAction(context.Background(), "user-1", "local.unknown", "anything")
+	if err != nil {
+		t.Fatalf("expected nil for unknown service (deferred to execution), got: %v", err)
+	}
+}
+
+func TestValidateLocalAction_ProviderError(t *testing.T) {
+	h := &GatewayHandler{
+		localSvcProvider: &mockLocalProvider{err: fmt.Errorf("provider down")},
+	}
+	// Provider errors return nil — let execution handle it.
+	err := h.validateLocalAction(context.Background(), "user-1", "local.files", "read_file")
+	if err != nil {
+		t.Fatalf("expected nil on provider error (deferred to execution), got: %v", err)
+	}
+}
+
+func TestValidateLocalAction_DifferentService(t *testing.T) {
+	h := &GatewayHandler{
+		localSvcProvider: &mockLocalProvider{services: testServices()},
+	}
+	// "navigate" exists on browser but not on files.
+	err := h.validateLocalAction(context.Background(), "user-1", "local.files", "navigate")
+	if err == nil {
+		t.Fatal("expected error for action that exists on a different service")
+	}
+}
+
+// ── Gateway: HandleRequest integration tests for local services ─────────────
+
+func newTestGatewayHandler(st *localTestStore, provider *mockLocalProvider, executor *mockLocalExecutor, verifier *mockVerifier) *GatewayHandler {
+	h := NewGatewayHandler(
+		st,
+		testVault{},
+		adapters.NewRegistry(),
+		nil,                  // notifier
+		verifier,             // intent verifier
+		intent.NoopExtractor{}, // extractor
+		config.Config{},
+		slog.Default(),
+		"http://localhost:9090",
+		events.NewHub(),
+	)
+	if provider != nil {
+		h.SetLocalServiceProvider(provider)
+	}
+	if executor != nil {
+		h.SetLocalServiceExecutor(executor)
+	}
+	return h
+}
+
+func makeGatewayRequest(t *testing.T, h *GatewayHandler, body map[string]any) *httptest.ResponseRecorder {
+	t.Helper()
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest("POST", "/api/gateway/request", bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(withAgent(req.Context(), testAgent))
+	w := httptest.NewRecorder()
+	h.HandleRequest(w, req)
+	return w
+}
+
+func TestGateway_LocalService_UnknownAction_Rejected(t *testing.T) {
+	st := newLocalTestStore()
+	st.tasks["task-1"] = &store.Task{
+		ID: "task-1", UserID: "user-1", AgentID: "agent-1", Status: "active",
+		AuthorizedActions: []store.TaskAction{
+			{Service: "local.files", Action: "*", AutoExecute: true},
+		},
+	}
+
+	provider := &mockLocalProvider{services: testServices()}
+	executor := &mockLocalExecutor{result: &adapters.Result{Summary: "ok"}}
+	verifier := &mockVerifier{} // no verification needed — should be rejected before
+
+	h := newTestGatewayHandler(st, provider, executor, verifier)
+
+	w := makeGatewayRequest(t, h, map[string]any{
+		"service": "local.files",
+		"action":  "delete_file",
+		"reason":  "delete a temp file",
+		"task_id": "task-1",
+	})
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["code"] != "UNKNOWN_ACTION" {
+		t.Fatalf("expected UNKNOWN_ACTION code, got %v", resp["code"])
+	}
+	if executor.called {
+		t.Fatal("executor should not have been called for unknown action")
+	}
+}
+
+func TestGateway_LocalService_ValidAction_Executes(t *testing.T) {
+	st := newLocalTestStore()
+	st.tasks["task-1"] = &store.Task{
+		ID: "task-1", UserID: "user-1", AgentID: "agent-1", Status: "active",
+		AuthorizedActions: []store.TaskAction{
+			{Service: "local.files", Action: "read_file", AutoExecute: true},
+		},
+	}
+
+	provider := &mockLocalProvider{services: testServices()}
+	executor := &mockLocalExecutor{result: &adapters.Result{Summary: "file contents here"}}
+	verifier := &mockVerifier{
+		verdict: &intent.VerificationVerdict{
+			Allow: true, ParamScope: "ok", ReasonCoherence: "ok", ExtractContext: true,
+		},
+	}
+
+	h := newTestGatewayHandler(st, provider, executor, verifier)
+
+	w := makeGatewayRequest(t, h, map[string]any{
+		"service": "local.files",
+		"action":  "read_file",
+		"reason":  "read config file",
+		"task_id": "task-1",
+		"params":  map[string]any{"path": "/etc/hosts"},
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !executor.called {
+		t.Fatal("executor should have been called")
+	}
+	if executor.action != "read_file" {
+		t.Fatalf("executor called with action %q, want read_file", executor.action)
+	}
+}
+
+func TestGateway_LocalService_IntentVerification_Blocks(t *testing.T) {
+	st := newLocalTestStore()
+	st.tasks["task-1"] = &store.Task{
+		ID: "task-1", UserID: "user-1", AgentID: "agent-1", Status: "active",
+		AuthorizedActions: []store.TaskAction{
+			{Service: "local.files", Action: "*", AutoExecute: true},
+		},
+	}
+
+	provider := &mockLocalProvider{services: testServices()}
+	executor := &mockLocalExecutor{result: &adapters.Result{Summary: "ok"}}
+	verifier := &mockVerifier{
+		verdict: &intent.VerificationVerdict{
+			Allow:           false,
+			ParamScope:      "violation",
+			ReasonCoherence: "incoherent",
+			Explanation:     "Request does not match task purpose.",
+		},
+	}
+
+	h := newTestGatewayHandler(st, provider, executor, verifier)
+
+	w := makeGatewayRequest(t, h, map[string]any{
+		"service": "local.files",
+		"action":  "write_file",
+		"reason":  "writing something suspicious",
+		"task_id": "task-1",
+		"params":  map[string]any{"path": "/etc/passwd", "content": "hacked"},
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 (restricted status), got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["status"] != "restricted" {
+		t.Fatalf("expected restricted status, got %v", resp["status"])
+	}
+	if executor.called {
+		t.Fatal("executor should NOT have been called when intent verification fails")
+	}
+	if !verifier.called {
+		t.Fatal("verifier should have been called for local service")
+	}
+}
+
+func TestGateway_LocalService_PlannedCall_SkipsVerification(t *testing.T) {
+	st := newLocalTestStore()
+	st.tasks["task-1"] = &store.Task{
+		ID: "task-1", UserID: "user-1", AgentID: "agent-1", Status: "active",
+		AuthorizedActions: []store.TaskAction{
+			{Service: "local.files", Action: "read_file", AutoExecute: true},
+		},
+		PlannedCalls: []store.PlannedCall{
+			{Service: "local.files", Action: "read_file", Params: map[string]any{"path": "/etc/hosts"}, Reason: "Read hosts file"},
+		},
+	}
+
+	provider := &mockLocalProvider{services: testServices()}
+	executor := &mockLocalExecutor{result: &adapters.Result{Summary: "127.0.0.1 localhost"}}
+	verifier := &mockVerifier{
+		// If this were called, it would block. But planned call should skip it.
+		verdict: &intent.VerificationVerdict{
+			Allow: false, ParamScope: "violation", Explanation: "should not be reached",
+		},
+	}
+
+	h := newTestGatewayHandler(st, provider, executor, verifier)
+
+	w := makeGatewayRequest(t, h, map[string]any{
+		"service": "local.files",
+		"action":  "read_file",
+		"reason":  "Read hosts file",
+		"task_id": "task-1",
+		"params":  map[string]any{"path": "/etc/hosts"},
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !executor.called {
+		t.Fatal("executor should have been called — planned call matches")
+	}
+	// Verifier should NOT have been called (planned call bypasses it).
+	if verifier.called {
+		t.Fatal("verifier should not be called when planned call matches")
+	}
+}
+
+func TestGateway_LocalService_NoProvider_SkipsValidation(t *testing.T) {
+	st := newLocalTestStore()
+	st.tasks["task-1"] = &store.Task{
+		ID: "task-1", UserID: "user-1", AgentID: "agent-1", Status: "active",
+		AuthorizedActions: []store.TaskAction{
+			{Service: "local.files", Action: "read_file", AutoExecute: true},
+		},
+	}
+
+	// No provider — self-hosted mode. Should skip action validation.
+	executor := &mockLocalExecutor{result: &adapters.Result{Summary: "ok"}}
+	verifier := &mockVerifier{
+		verdict: &intent.VerificationVerdict{Allow: true, ParamScope: "ok", ReasonCoherence: "ok"},
+	}
+
+	h := newTestGatewayHandler(st, nil, executor, verifier)
+
+	w := makeGatewayRequest(t, h, map[string]any{
+		"service": "local.files",
+		"action":  "read_file",
+		"reason":  "read a file",
+		"task_id": "task-1",
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !executor.called {
+		t.Fatal("executor should have been called without provider")
+	}
+}
+
+func TestGateway_LocalService_NoExecutor_ReturnsError(t *testing.T) {
+	st := newLocalTestStore()
+	st.tasks["task-1"] = &store.Task{
+		ID: "task-1", UserID: "user-1", AgentID: "agent-1", Status: "active",
+		AuthorizedActions: []store.TaskAction{
+			{Service: "local.files", Action: "read_file", AutoExecute: true},
+		},
+	}
+
+	provider := &mockLocalProvider{services: testServices()}
+	verifier := &mockVerifier{
+		verdict: &intent.VerificationVerdict{Allow: true, ParamScope: "ok", ReasonCoherence: "ok"},
+	}
+
+	// No executor configured.
+	h := newTestGatewayHandler(st, provider, nil, verifier)
+
+	w := makeGatewayRequest(t, h, map[string]any{
+		"service": "local.files",
+		"action":  "read_file",
+		"reason":  "read a file",
+		"task_id": "task-1",
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 (error status), got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["code"] != "LOCAL_SERVICE_UNAVAILABLE" {
+		t.Fatalf("expected LOCAL_SERVICE_UNAVAILABLE, got %v", resp["code"])
+	}
+}
+
+func TestGateway_LocalService_OutOfScope_Rejected(t *testing.T) {
+	st := newLocalTestStore()
+	st.tasks["task-1"] = &store.Task{
+		ID: "task-1", UserID: "user-1", AgentID: "agent-1", Status: "active",
+		AuthorizedActions: []store.TaskAction{
+			{Service: "local.files", Action: "read_file", AutoExecute: true},
+		},
+	}
+
+	provider := &mockLocalProvider{services: testServices()}
+	executor := &mockLocalExecutor{result: &adapters.Result{Summary: "ok"}}
+	verifier := &mockVerifier{}
+
+	h := newTestGatewayHandler(st, provider, executor, verifier)
+
+	// write_file is a valid action on the service, but NOT in the task scope.
+	w := makeGatewayRequest(t, h, map[string]any{
+		"service": "local.files",
+		"action":  "write_file",
+		"reason":  "write a file",
+		"task_id": "task-1",
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	// Out of scope returns pending_scope_expansion for session tasks.
+	if resp["status"] != "pending_scope_expansion" {
+		t.Fatalf("expected pending_scope_expansion, got %v", resp["status"])
+	}
+	if executor.called {
+		t.Fatal("executor should not have been called for out-of-scope action")
+	}
+}
+
+// ── Tasks: validateLocalService unit tests ──────────────────────────────────
+
+func TestValidateLocalService_ValidServiceAndAction(t *testing.T) {
+	h := &TasksHandler{
+		localSvcProvider: &mockLocalProvider{services: testServices()},
+	}
+	err := h.validateLocalService(context.Background(), "user-1", "local.files", "read_file")
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestValidateLocalService_ValidServiceWildcardAction(t *testing.T) {
+	h := &TasksHandler{
+		localSvcProvider: &mockLocalProvider{services: testServices()},
+	}
+	err := h.validateLocalService(context.Background(), "user-1", "local.files", "*")
+	if err != nil {
+		t.Fatalf("expected no error for wildcard action, got: %v", err)
+	}
+}
+
+func TestValidateLocalService_ValidServiceInvalidAction(t *testing.T) {
+	h := &TasksHandler{
+		localSvcProvider: &mockLocalProvider{services: testServices()},
+	}
+	err := h.validateLocalService(context.Background(), "user-1", "local.files", "delete_file")
+	if err == nil {
+		t.Fatal("expected error for invalid action")
+	}
+	if !strings.Contains(err.Error(), "delete_file") {
+		t.Fatalf("error should mention the invalid action, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "read_file") {
+		t.Fatalf("error should list available actions, got: %v", err)
+	}
+}
+
+func TestValidateLocalService_UnknownService(t *testing.T) {
+	h := &TasksHandler{
+		localSvcProvider: &mockLocalProvider{services: testServices()},
+	}
+	err := h.validateLocalService(context.Background(), "user-1", "local.unknown", "anything")
+	if err == nil {
+		t.Fatal("expected error for unknown service")
+	}
+	if !strings.Contains(err.Error(), "not enabled") {
+		t.Fatalf("error should say not enabled, got: %v", err)
+	}
+}
+
+func TestValidateLocalService_NoProvider(t *testing.T) {
+	h := &TasksHandler{
+		localSvcProvider: nil,
+	}
+	err := h.validateLocalService(context.Background(), "user-1", "local.files", "read_file")
+	if err != nil {
+		t.Fatalf("expected nil when no provider (self-hosted), got: %v", err)
+	}
+}
+
+func TestValidateLocalService_ProviderError(t *testing.T) {
+	h := &TasksHandler{
+		localSvcProvider: &mockLocalProvider{err: fmt.Errorf("connection refused")},
+	}
+	err := h.validateLocalService(context.Background(), "user-1", "local.files", "read_file")
+	if err == nil {
+		t.Fatal("expected error when provider fails")
+	}
+	if !strings.Contains(err.Error(), "unable to verify") {
+		t.Fatalf("error should indicate verification failure, got: %v", err)
+	}
+}
+
+func TestValidateLocalService_ActionOnDifferentService(t *testing.T) {
+	h := &TasksHandler{
+		localSvcProvider: &mockLocalProvider{services: testServices()},
+	}
+	// "navigate" exists on browser, not files.
+	err := h.validateLocalService(context.Background(), "user-1", "local.files", "navigate")
+	if err == nil {
+		t.Fatal("expected error for action that belongs to a different service")
+	}
+}
+
+func TestValidateLocalService_EmptyAction(t *testing.T) {
+	h := &TasksHandler{
+		localSvcProvider: &mockLocalProvider{services: testServices()},
+	}
+	// Empty action should pass (treated like wildcard).
+	err := h.validateLocalService(context.Background(), "user-1", "local.files", "")
+	if err != nil {
+		t.Fatalf("expected no error for empty action, got: %v", err)
+	}
+}
+
+// ── Catalog: local service rendering tests ──────────────────────────────────
+
+func newTestSkillHandler(provider *mockLocalProvider) *SkillHandler {
+	h := NewSkillHandler(
+		newLocalTestStore(),
+		testVault{},
+		adapters.NewRegistry(),
+		slog.Default(),
+	)
+	if provider != nil {
+		h.SetLocalServiceProvider(provider)
+	}
+	return h
+}
+
+func TestCatalogOverview_IncludesLocalServices(t *testing.T) {
+	provider := &mockLocalProvider{services: testServices()}
+	h := newTestSkillHandler(provider)
+
+	var buf strings.Builder
+	entries := []*catalogEntry{} // no cloud services
+	adapterMeta := map[string]adapters.ServiceMetadata{}
+	h.writeCatalogOverview(&buf, context.Background(), entries, adapterMeta, "user-1")
+
+	output := buf.String()
+
+	// Should include the local services section.
+	if !strings.Contains(output, "Local Services") {
+		t.Fatal("catalog should contain Local Services section")
+	}
+	if !strings.Contains(output, "File System") {
+		t.Fatalf("catalog should list File System service, got:\n%s", output)
+	}
+	if !strings.Contains(output, "Browser") {
+		t.Fatalf("catalog should list Browser service, got:\n%s", output)
+	}
+	if !strings.Contains(output, "local.files") {
+		t.Fatal("catalog should show service ID with local. prefix")
+	}
+	if !strings.Contains(output, "read_file") {
+		t.Fatal("catalog should list actions")
+	}
+	if !strings.Contains(output, "one daemon at a time") {
+		t.Fatal("catalog should mention single-daemon constraint")
+	}
+}
+
+func TestCatalogOverview_NoLocalServices_OmitsSection(t *testing.T) {
+	provider := &mockLocalProvider{services: nil}
+	h := newTestSkillHandler(provider)
+
+	var buf strings.Builder
+	h.writeCatalogOverview(&buf, context.Background(), nil, nil, "user-1")
+
+	if strings.Contains(buf.String(), "Local Services") {
+		t.Fatal("catalog should not contain Local Services section when no services exist")
+	}
+}
+
+func TestCatalogOverview_NoProvider_OmitsSection(t *testing.T) {
+	h := newTestSkillHandler(nil)
+
+	var buf strings.Builder
+	h.writeCatalogOverview(&buf, context.Background(), nil, nil, "user-1")
+
+	if strings.Contains(buf.String(), "Local Services") {
+		t.Fatal("catalog should not contain Local Services section when provider is nil")
+	}
+}
+
+func TestCatalogOverview_LocalServicesWithNoCloudServices(t *testing.T) {
+	provider := &mockLocalProvider{services: testServices()}
+	h := newTestSkillHandler(provider)
+
+	var buf strings.Builder
+	h.writeCatalogOverview(&buf, context.Background(), nil, nil, "user-1")
+
+	output := buf.String()
+	// Should still show local services even with no cloud services.
+	if !strings.Contains(output, "Local Services") {
+		t.Fatal("local services should appear even when no cloud services are connected")
+	}
+	// Should show the "no cloud services" message.
+	if !strings.Contains(output, "No cloud services") {
+		t.Fatal("should show no cloud services message")
+	}
+}
+
+func TestCatalogOverview_ProviderError_ShowsCloudOnly(t *testing.T) {
+	provider := &mockLocalProvider{err: fmt.Errorf("daemon offline")}
+	h := newTestSkillHandler(provider)
+
+	var buf strings.Builder
+	h.writeCatalogOverview(&buf, context.Background(), nil, nil, "user-1")
+
+	// Should not crash, and should not show Local Services section.
+	if strings.Contains(buf.String(), "Local Services") {
+		t.Fatal("should not show Local Services section when provider errors")
+	}
+}
+
+func TestCatalogDetail_LocalService(t *testing.T) {
+	provider := &mockLocalProvider{services: testServices()}
+	h := newTestSkillHandler(provider)
+
+	var buf strings.Builder
+	h.writeLocalServiceDetail(&buf, context.Background(), "local.files", "user-1")
+
+	output := buf.String()
+	if !strings.Contains(output, "File System") {
+		t.Fatalf("detail should show service name, got:\n%s", output)
+	}
+	if !strings.Contains(output, "local.files") {
+		t.Fatal("detail should show service ID")
+	}
+	if !strings.Contains(output, "my-mac") {
+		t.Fatal("detail should show daemon name")
+	}
+	if !strings.Contains(output, "read_file") {
+		t.Fatal("detail should list actions")
+	}
+	if !strings.Contains(output, "path") {
+		t.Fatal("detail should list params")
+	}
+	if !strings.Contains(output, "**required**") {
+		t.Fatal("detail should mark required params")
+	}
+}
+
+func TestCatalogDetail_LocalService_NotFound(t *testing.T) {
+	provider := &mockLocalProvider{services: testServices()}
+	h := newTestSkillHandler(provider)
+
+	var buf strings.Builder
+	h.writeLocalServiceDetail(&buf, context.Background(), "local.unknown", "user-1")
+
+	if !strings.Contains(buf.String(), "not enabled") {
+		t.Fatalf("should say service not enabled, got: %s", buf.String())
+	}
+}
+
+func TestCatalogDetail_LocalService_NoProvider(t *testing.T) {
+	h := newTestSkillHandler(nil)
+
+	var buf strings.Builder
+	h.writeLocalServiceDetail(&buf, context.Background(), "local.files", "user-1")
+
+	if !strings.Contains(buf.String(), "not available") {
+		t.Fatalf("should say not available, got: %s", buf.String())
+	}
+}
+
+func TestCatalogDetail_RoutesLocalPrefix(t *testing.T) {
+	provider := &mockLocalProvider{services: testServices()}
+	h := newTestSkillHandler(provider)
+
+	var buf strings.Builder
+	// writeServiceDetail should detect local. prefix and route to writeLocalServiceDetail.
+	entries := []*catalogEntry{}
+	adapterMeta := map[string]adapters.ServiceMetadata{}
+	h.writeServiceDetail(&buf, context.Background(), "local.files", entries, adapterMeta, "user-1")
+
+	if !strings.Contains(buf.String(), "File System") {
+		t.Fatal("writeServiceDetail should route local.* to writeLocalServiceDetail")
+	}
+}
+
+func TestCatalogDetail_NonLocal_DoesNotRoute(t *testing.T) {
+	h := newTestSkillHandler(nil)
+
+	var buf strings.Builder
+	entries := []*catalogEntry{}
+	h.writeServiceDetail(&buf, context.Background(), "google.gmail", entries, nil, "user-1")
+
+	// Should say not activated (not route to local handler).
+	if strings.Contains(buf.String(), "not available in this deployment") {
+		t.Fatal("non-local service should not be routed to local handler")
+	}
+	if !strings.Contains(buf.String(), "not activated") {
+		t.Fatalf("should say not activated, got: %s", buf.String())
+	}
+}
+
+// ── Integration: audit trail for local service requests ─────────────────────
+
+func TestGateway_LocalService_AuditLogged(t *testing.T) {
+	st := newLocalTestStore()
+	st.tasks["task-1"] = &store.Task{
+		ID: "task-1", UserID: "user-1", AgentID: "agent-1", Status: "active",
+		AuthorizedActions: []store.TaskAction{
+			{Service: "local.files", Action: "read_file", AutoExecute: true},
+		},
+	}
+
+	provider := &mockLocalProvider{services: testServices()}
+	executor := &mockLocalExecutor{result: &adapters.Result{Summary: "file contents"}}
+	verifier := &mockVerifier{
+		verdict: &intent.VerificationVerdict{Allow: true, ParamScope: "ok", ReasonCoherence: "ok"},
+	}
+
+	h := newTestGatewayHandler(st, provider, executor, verifier)
+	_ = makeGatewayRequest(t, h, map[string]any{
+		"service": "local.files",
+		"action":  "read_file",
+		"reason":  "read a config file",
+		"task_id": "task-1",
+	})
+
+	if len(st.auditEntries) == 0 {
+		t.Fatal("expected at least one audit entry")
+	}
+	entry := st.auditEntries[len(st.auditEntries)-1]
+	if entry.Service != "local.files" {
+		t.Fatalf("audit entry should have service local.files, got %s", entry.Service)
+	}
+	if entry.Decision != "execute" {
+		t.Fatalf("audit entry should have decision execute, got %s", entry.Decision)
+	}
+}
+
+func TestGateway_LocalService_UnknownAction_AuditLogged(t *testing.T) {
+	st := newLocalTestStore()
+	st.tasks["task-1"] = &store.Task{
+		ID: "task-1", UserID: "user-1", AgentID: "agent-1", Status: "active",
+		AuthorizedActions: []store.TaskAction{
+			{Service: "local.files", Action: "*", AutoExecute: true},
+		},
+	}
+
+	provider := &mockLocalProvider{services: testServices()}
+	h := newTestGatewayHandler(st, provider, nil, &mockVerifier{})
+
+	_ = makeGatewayRequest(t, h, map[string]any{
+		"service": "local.files",
+		"action":  "nonexistent",
+		"reason":  "testing",
+		"task_id": "task-1",
+	})
+
+	if len(st.auditEntries) == 0 {
+		t.Fatal("expected audit entry for unknown action")
+	}
+	entry := st.auditEntries[0]
+	if entry.Decision != "unknown_action" {
+		t.Fatalf("audit decision should be unknown_action, got %s", entry.Decision)
+	}
+}
+
+// ── Edge cases ──────────────────────────────────────────────────────────────
+
+func TestGateway_LocalService_ExecutorError_ReturnsError(t *testing.T) {
+	st := newLocalTestStore()
+	st.tasks["task-1"] = &store.Task{
+		ID: "task-1", UserID: "user-1", AgentID: "agent-1", Status: "active",
+		AuthorizedActions: []store.TaskAction{
+			{Service: "local.files", Action: "read_file", AutoExecute: true},
+		},
+	}
+
+	provider := &mockLocalProvider{services: testServices()}
+	executor := &mockLocalExecutor{err: fmt.Errorf("daemon timed out")}
+	verifier := &mockVerifier{
+		verdict: &intent.VerificationVerdict{Allow: true, ParamScope: "ok", ReasonCoherence: "ok"},
+	}
+
+	h := newTestGatewayHandler(st, provider, executor, verifier)
+
+	w := makeGatewayRequest(t, h, map[string]any{
+		"service": "local.files",
+		"action":  "read_file",
+		"reason":  "read a file",
+		"task_id": "task-1",
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 (error status), got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["status"] != "error" {
+		t.Fatalf("expected error status, got %v", resp["status"])
+	}
+}
+
+func TestGateway_LocalService_WildcardTask_ValidAction(t *testing.T) {
+	st := newLocalTestStore()
+	st.tasks["task-1"] = &store.Task{
+		ID: "task-1", UserID: "user-1", AgentID: "agent-1", Status: "active",
+		AuthorizedActions: []store.TaskAction{
+			{Service: "local.files", Action: "*", AutoExecute: true},
+		},
+	}
+
+	provider := &mockLocalProvider{services: testServices()}
+	executor := &mockLocalExecutor{result: &adapters.Result{Summary: "ok"}}
+	verifier := &mockVerifier{
+		verdict: &intent.VerificationVerdict{Allow: true, ParamScope: "ok", ReasonCoherence: "ok"},
+	}
+
+	h := newTestGatewayHandler(st, provider, executor, verifier)
+
+	// All three valid actions should work with wildcard scope.
+	for _, action := range []string{"read_file", "write_file", "list_dir"} {
+		executor.called = false
+		w := makeGatewayRequest(t, h, map[string]any{
+			"service": "local.files",
+			"action":  action,
+			"reason":  "testing " + action,
+			"task_id": "task-1",
+		})
+		if w.Code != http.StatusOK {
+			t.Fatalf("action %s: expected 200, got %d: %s", action, w.Code, w.Body.String())
+		}
+		if !executor.called {
+			t.Fatalf("action %s: executor should have been called", action)
+		}
+	}
+}
+
+func TestCatalogOverview_ActionParams(t *testing.T) {
+	provider := &mockLocalProvider{services: testServices()}
+	h := newTestSkillHandler(provider)
+
+	var buf strings.Builder
+	h.writeCatalogOverview(&buf, context.Background(), nil, nil, "user-1")
+
+	output := buf.String()
+	// Compact param signatures should appear.
+	if !strings.Contains(output, "(path)") {
+		t.Fatal("read_file should show param signature (path)")
+	}
+	if !strings.Contains(output, "(path, content)") {
+		t.Fatal("write_file should show param signature (path, content)")
+	}
+}
+
+func TestCatalogDetail_AllParamTypes(t *testing.T) {
+	services := []LocalCatalogService{{
+		ServiceID:  "test",
+		DaemonName: "daemon",
+		Name:       "Test Service",
+		Actions: []LocalCatalogAction{{
+			ID: "test_action", Name: "Test", Description: "A test action",
+			Params: []LocalCatalogParam{
+				{Name: "required_param", Type: "string", Required: true, Description: "A required param"},
+				{Name: "optional_param", Type: "integer", Required: false, Description: "An optional param"},
+			},
+		}},
+	}}
+
+	provider := &mockLocalProvider{services: services}
+	h := newTestSkillHandler(provider)
+
+	var buf strings.Builder
+	h.writeLocalServiceDetail(&buf, context.Background(), "local.test", "user-1")
+
+	output := buf.String()
+	if !strings.Contains(output, "required_param") {
+		t.Fatal("should show required param")
+	}
+	if !strings.Contains(output, "optional_param") {
+		t.Fatal("should show optional param")
+	}
+	if !strings.Contains(output, "**required**") {
+		t.Fatal("should mark required params")
+	}
+	if !strings.Contains(output, "optional") {
+		t.Fatal("should mark optional params")
+	}
+	if !strings.Contains(output, "string") {
+		t.Fatal("should show param type")
+	}
+	if !strings.Contains(output, "integer") {
+		t.Fatal("should show param type")
+	}
+}
+
+// Verify that the catalog handles the time import (ensures test compiles
+// with all necessary imports).
+var _ = time.Now

--- a/internal/api/handlers/skill.go
+++ b/internal/api/handlers/skill.go
@@ -246,7 +246,7 @@ func (h *SkillHandler) writeCatalogOverview(buf *strings.Builder, ctx context.Co
 		} else if len(localServices) > 0 {
 			buf.WriteString("---\n\n")
 			buf.WriteString("# Local Services\n\n")
-			buf.WriteString("_These services run on your locally paired daemon(s)._\n\n")
+			buf.WriteString("_These services run on your locally paired daemon(s). Each service can only be enabled on one daemon at a time._\n\n")
 
 			for _, svc := range localServices {
 				buf.WriteString(fmt.Sprintf("## %s\n", svc.Name))
@@ -269,8 +269,70 @@ func (h *SkillHandler) writeCatalogOverview(buf *strings.Builder, ctx context.Co
 	}
 }
 
+// writeLocalServiceDetail renders the detailed view for a single local service.
+func (h *SkillHandler) writeLocalServiceDetail(buf *strings.Builder, ctx context.Context, serviceID, userID string) {
+	if h.localSvcProvider == nil {
+		buf.WriteString(fmt.Sprintf("Service %q is not available in this deployment.\n", serviceID))
+		return
+	}
+	localServices, err := h.localSvcProvider.ActiveLocalServices(ctx, userID)
+	if err != nil {
+		buf.WriteString(fmt.Sprintf("Unable to load local service %q.\n", serviceID))
+		return
+	}
+	svcID := strings.TrimPrefix(serviceID, "local.")
+	var found *LocalCatalogService
+	for i := range localServices {
+		if localServices[i].ServiceID == svcID {
+			found = &localServices[i]
+			break
+		}
+	}
+	if found == nil {
+		buf.WriteString(fmt.Sprintf("Local service %q is not enabled or does not exist.\n", serviceID))
+		return
+	}
+
+	buf.WriteString(fmt.Sprintf("# %s\n", found.Name))
+	if found.Description != "" {
+		buf.WriteString(fmt.Sprintf("_%s_\n", found.Description))
+	}
+	buf.WriteString(fmt.Sprintf("Service: `local.%s` (via %s)\n\n", found.ServiceID, found.DaemonName))
+	buf.WriteString("_This service runs on a locally paired daemon._\n\n")
+
+	for _, action := range found.Actions {
+		desc := action.Description
+		if desc == "" {
+			desc = action.Name
+		}
+		buf.WriteString(fmt.Sprintf("## %s\n", action.ID))
+		buf.WriteString(fmt.Sprintf("%s\n", desc))
+		if len(action.Params) > 0 {
+			buf.WriteString("Parameters:\n")
+			for _, p := range action.Params {
+				reqTag := "optional"
+				if p.Required {
+					reqTag = "**required**"
+				}
+				extras := []string{p.Type, reqTag}
+				buf.WriteString(fmt.Sprintf("- `%s` (%s)\n", p.Name, strings.Join(extras, ", ")))
+				if p.Description != "" {
+					buf.WriteString(fmt.Sprintf("  %s\n", p.Description))
+				}
+			}
+		}
+		buf.WriteString("\n")
+	}
+}
+
 // writeServiceDetail renders the detailed view for a single service.
 func (h *SkillHandler) writeServiceDetail(buf *strings.Builder, ctx context.Context, serviceID string, entries []*catalogEntry, adapterMeta map[string]adapters.ServiceMetadata, userID string) {
+	// Check if this is a local service request.
+	if strings.HasPrefix(serviceID, "local.") {
+		h.writeLocalServiceDetail(buf, ctx, serviceID, userID)
+		return
+	}
+
 	// Find the matching entry.
 	var entry *catalogEntry
 	for _, e := range entries {

--- a/internal/api/handlers/skill.go
+++ b/internal/api/handlers/skill.go
@@ -14,12 +14,49 @@ import (
 	"github.com/clawvisor/clawvisor/pkg/vault"
 )
 
+// LocalServiceProvider supplies local daemon services for the agent catalog.
+// Implemented by the cloud layer; nil in self-hosted mode.
+type LocalServiceProvider interface {
+	ActiveLocalServices(ctx context.Context, userID string) ([]LocalCatalogService, error)
+}
+
+// LocalCatalogService describes a local daemon service for the agent catalog.
+type LocalCatalogService struct {
+	ServiceID   string
+	DaemonName  string
+	Name        string
+	Description string
+	Actions     []LocalCatalogAction
+}
+
+// LocalCatalogAction describes an action within a local service.
+type LocalCatalogAction struct {
+	ID          string
+	Name        string
+	Description string
+	Params      []LocalCatalogParam
+}
+
+// LocalCatalogParam describes a parameter for a local action.
+type LocalCatalogParam struct {
+	Name        string
+	Type        string
+	Required    bool
+	Description string
+}
+
 // SkillHandler serves the dynamic skill catalog endpoint.
 type SkillHandler struct {
-	st         store.Store
-	vault      vault.Vault
-	adapterReg *adapters.Registry
-	logger     *slog.Logger
+	st               store.Store
+	vault            vault.Vault
+	adapterReg       *adapters.Registry
+	logger           *slog.Logger
+	localSvcProvider LocalServiceProvider
+}
+
+// SetLocalServiceProvider configures the local daemon service provider.
+func (h *SkillHandler) SetLocalServiceProvider(p LocalServiceProvider) {
+	h.localSvcProvider = p
 }
 
 func NewSkillHandler(
@@ -201,6 +238,36 @@ func (h *SkillHandler) writeCatalogOverview(buf *strings.Builder, ctx context.Co
 		}
 		buf.WriteString("\n")
 	}
+
+	// Append local daemon services if provider is configured.
+	if h.localSvcProvider != nil {
+		localServices, err := h.localSvcProvider.ActiveLocalServices(ctx, userID)
+		if err != nil {
+			h.logger.Warn("failed to fetch local services for catalog", "err", err)
+		} else if len(localServices) > 0 {
+			buf.WriteString("---\n\n")
+			buf.WriteString("# Local Services\n\n")
+			buf.WriteString("_These services run on your locally paired daemon(s)._\n\n")
+
+			for _, svc := range localServices {
+				buf.WriteString(fmt.Sprintf("## %s\n", svc.Name))
+				if svc.Description != "" {
+					buf.WriteString(fmt.Sprintf("_%s_\n", svc.Description))
+				}
+				buf.WriteString(fmt.Sprintf("Service: `local.%s` (via %s)\n\n", svc.ServiceID, svc.DaemonName))
+
+				for _, action := range svc.Actions {
+					paramSig := compactLocalParamSig(action.Params)
+					desc := action.Description
+					if desc == "" {
+						desc = action.Name
+					}
+					buf.WriteString(fmt.Sprintf("- **%s**%s \u2014 %s\n", action.ID, paramSig, desc))
+				}
+				buf.WriteString("\n")
+			}
+		}
+	}
 }
 
 // writeServiceDetail renders the detailed view for a single service.
@@ -285,6 +352,22 @@ func (h *SkillHandler) isRestricted(ctx context.Context, userID string, entry *c
 
 // compactParamSig builds a compact inline parameter signature like "(to, subject, body?, in_reply_to?)".
 func compactParamSig(params []adapters.ParamMeta) string {
+	if len(params) == 0 {
+		return ""
+	}
+	parts := make([]string, len(params))
+	for i, p := range params {
+		if p.Required {
+			parts[i] = p.Name
+		} else {
+			parts[i] = p.Name + "?"
+		}
+	}
+	return "(" + strings.Join(parts, ", ") + ")"
+}
+
+// compactLocalParamSig builds a compact inline parameter signature for local service actions.
+func compactLocalParamSig(params []LocalCatalogParam) string {
 	if len(params) == 0 {
 		return ""
 	}

--- a/internal/api/handlers/skill.go
+++ b/internal/api/handlers/skill.go
@@ -197,13 +197,12 @@ func (h *SkillHandler) writeCatalogOverview(buf *strings.Builder, ctx context.Co
 	buf.WriteString("# Your Clawvisor Service Catalog\n\n")
 
 	if len(entries) == 0 {
-		buf.WriteString("No services are currently activated.\n\n")
-		buf.WriteString("To activate a service, direct the user to the Clawvisor dashboard.\n")
-		return
+		buf.WriteString("No cloud services are currently activated.\n\n")
+		buf.WriteString("To activate a service, direct the user to the Clawvisor dashboard.\n\n")
+	} else {
+		buf.WriteString("_For detailed parameter docs, fetch `?service=<service_id>`._\n\n")
+		buf.WriteString("**Important:** When invoking any service, use the full `service:account` identifier (e.g. `google.gmail:personal`) as the `service` value in requests. Using just the service name (e.g. `google.gmail`) will fail if every entry has an account suffix.\n\n")
 	}
-
-	buf.WriteString("_For detailed parameter docs, fetch `?service=<service_id>`._\n\n")
-	buf.WriteString("**Important:** When invoking any service, use the full `service:account` identifier (e.g. `google.gmail:personal`) as the `service` value in requests. Using just the service name (e.g. `google.gmail`) will fail if every entry has an account suffix.\n\n")
 
 	for _, entry := range entries {
 		buf.WriteString(fmt.Sprintf("## %s\n", entry.baseID))

--- a/internal/api/handlers/tasks.go
+++ b/internal/api/handlers/tasks.go
@@ -178,7 +178,7 @@ func (h *TasksHandler) Create(w http.ResponseWriter, r *http.Request) {
 
 		// Validate local daemon services against the active service list.
 		if isLocalService(serviceType) {
-			if err := h.validateLocalService(ctx, agent.UserID, serviceType); err != nil {
+			if err := h.validateLocalService(ctx, agent.UserID, serviceType, a.Action); err != nil {
 				writeError(w, http.StatusBadRequest, "INVALID_REQUEST", err.Error())
 				return
 			}
@@ -870,7 +870,7 @@ func (h *TasksHandler) Expand(w http.ResponseWriter, r *http.Request) {
 	// Validate service and action exist.
 	serviceType, serviceAlias := parseServiceAlias(req.Service)
 	if isLocalService(serviceType) {
-		if err := h.validateLocalService(ctx, agent.UserID, serviceType); err != nil {
+		if err := h.validateLocalService(ctx, agent.UserID, serviceType, req.Action); err != nil {
 			writeError(w, http.StatusBadRequest, "INVALID_REQUEST", err.Error())
 			return
 		}
@@ -1347,10 +1347,11 @@ func (h *TasksHandler) Revoke(w http.ResponseWriter, r *http.Request) {
 // Credential-free services check service_meta; credential-backed services check the vault.
 // It requires an exact alias match — callers should use serviceNotActivatedResponse
 // to produce a helpful error listing available connections when this returns false.
-// validateLocalService checks that a local.* service is real and enabled for the user.
+// validateLocalService checks that a local.* service is real, enabled for the
+// user, and (when action is not "*") that the requested action exists.
 // Returns nil if the provider is not configured (self-hosted mode where all local
-// services are allowed) or if the service is found in the active list.
-func (h *TasksHandler) validateLocalService(ctx context.Context, userID, serviceType string) error {
+// services are allowed) or if the service and action are found in the active list.
+func (h *TasksHandler) validateLocalService(ctx context.Context, userID, serviceType, action string) error {
 	if h.localSvcProvider == nil {
 		return nil // no provider — skip validation (self-hosted)
 	}
@@ -1362,7 +1363,21 @@ func (h *TasksHandler) validateLocalService(ctx context.Context, userID, service
 	svcID := strings.TrimPrefix(serviceType, "local.")
 	for _, svc := range active {
 		if svc.ServiceID == svcID {
-			return nil
+			// Service found — validate action if not wildcard.
+			if action == "*" || action == "" {
+				return nil
+			}
+			for _, a := range svc.Actions {
+				if a.ID == action {
+					return nil
+				}
+			}
+			available := make([]string, len(svc.Actions))
+			for i, a := range svc.Actions {
+				available[i] = a.ID
+			}
+			return fmt.Errorf("local service %q does not support action %q — available actions: %s",
+				serviceType, action, strings.Join(available, ", "))
 		}
 	}
 	return fmt.Errorf("local service %q is not enabled or does not exist — enable it from the Services page", serviceType)

--- a/internal/api/handlers/tasks.go
+++ b/internal/api/handlers/tasks.go
@@ -169,10 +169,9 @@ func (h *TasksHandler) Create(w http.ResponseWriter, r *http.Request) {
 
 		serviceType, serviceAlias := parseServiceAlias(a.Service)
 
-		// Guard virtual services (file, bash, search, web, agent, unknown) are
-		// scope-only markers used by permission hooks — they never execute
-		// through adapters, so skip adapter/activation validation.
-		if !isGuardVirtualService(serviceType) {
+		// Guard virtual services and local daemon services skip adapter/activation
+		// validation — they don't have adapters in the registry.
+		if !isGuardVirtualService(serviceType) && !isLocalService(serviceType) {
 			adapter, ok := h.adapterReg.GetForUser(ctx, serviceType, agent.UserID)
 			if !ok {
 				available := h.adapterReg.SupportedServices()
@@ -853,9 +852,9 @@ func (h *TasksHandler) Expand(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate service and action exist (skip for guard virtual services).
+	// Validate service and action exist (skip for guard virtual and local services).
 	serviceType, serviceAlias := parseServiceAlias(req.Service)
-	if !isGuardVirtualService(serviceType) {
+	if !isGuardVirtualService(serviceType) && !isLocalService(serviceType) {
 		adapter, ok := h.adapterReg.GetForUser(ctx, serviceType, agent.UserID)
 		if !ok {
 			writeError(w, http.StatusBadRequest, "INVALID_REQUEST",

--- a/internal/api/handlers/tasks.go
+++ b/internal/api/handlers/tasks.go
@@ -41,19 +41,26 @@ func RequiresHardcodedApproval(service, action string) bool {
 
 // TasksHandler manages task-scoped authorization.
 type TasksHandler struct {
-	st           store.Store
-	vault        vault.Vault
-	adapterReg   *adapters.Registry
-	notifier     notify.Notifier
-	cfg          config.Config
-	logger       *slog.Logger
-	baseURL      string
-	eventHub     events.EventHub
-	assessor     taskrisk.Assessor
-	contentDedup DedupCache
-	msgBuffer    groupchat.Buffer // may be nil; set via SetGroupApproval
-	llmHealth    *llm.Health              // may be nil; needed for approval check LLM calls
-	agentPairer  notify.AgentGroupPairer  // may be nil; set via SetGroupApproval
+	st               store.Store
+	vault            vault.Vault
+	adapterReg       *adapters.Registry
+	notifier         notify.Notifier
+	cfg              config.Config
+	logger           *slog.Logger
+	baseURL          string
+	eventHub         events.EventHub
+	assessor         taskrisk.Assessor
+	contentDedup     DedupCache
+	msgBuffer        groupchat.Buffer         // may be nil; set via SetGroupApproval
+	llmHealth        *llm.Health              // may be nil; needed for approval check LLM calls
+	agentPairer      notify.AgentGroupPairer  // may be nil; set via SetGroupApproval
+	localSvcProvider LocalServiceProvider     // may be nil; set via SetLocalServiceProvider
+}
+
+// SetLocalServiceProvider configures the local daemon service provider for
+// validating local service names during task creation and expansion.
+func (h *TasksHandler) SetLocalServiceProvider(p LocalServiceProvider) {
+	h.localSvcProvider = p
 }
 
 func NewTasksHandler(
@@ -168,6 +175,14 @@ func (h *TasksHandler) Create(w http.ResponseWriter, r *http.Request) {
 		}
 
 		serviceType, serviceAlias := parseServiceAlias(a.Service)
+
+		// Validate local daemon services against the active service list.
+		if isLocalService(serviceType) {
+			if err := h.validateLocalService(ctx, agent.UserID, serviceType); err != nil {
+				writeError(w, http.StatusBadRequest, "INVALID_REQUEST", err.Error())
+				return
+			}
+		}
 
 		// Guard virtual services and local daemon services skip adapter/activation
 		// validation — they don't have adapters in the registry.
@@ -852,8 +867,14 @@ func (h *TasksHandler) Expand(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate service and action exist (skip for guard virtual and local services).
+	// Validate service and action exist.
 	serviceType, serviceAlias := parseServiceAlias(req.Service)
+	if isLocalService(serviceType) {
+		if err := h.validateLocalService(ctx, agent.UserID, serviceType); err != nil {
+			writeError(w, http.StatusBadRequest, "INVALID_REQUEST", err.Error())
+			return
+		}
+	}
 	if !isGuardVirtualService(serviceType) && !isLocalService(serviceType) {
 		adapter, ok := h.adapterReg.GetForUser(ctx, serviceType, agent.UserID)
 		if !ok {
@@ -1326,6 +1347,27 @@ func (h *TasksHandler) Revoke(w http.ResponseWriter, r *http.Request) {
 // Credential-free services check service_meta; credential-backed services check the vault.
 // It requires an exact alias match — callers should use serviceNotActivatedResponse
 // to produce a helpful error listing available connections when this returns false.
+// validateLocalService checks that a local.* service is real and enabled for the user.
+// Returns nil if the provider is not configured (self-hosted mode where all local
+// services are allowed) or if the service is found in the active list.
+func (h *TasksHandler) validateLocalService(ctx context.Context, userID, serviceType string) error {
+	if h.localSvcProvider == nil {
+		return nil // no provider — skip validation (self-hosted)
+	}
+	active, err := h.localSvcProvider.ActiveLocalServices(ctx, userID)
+	if err != nil {
+		return fmt.Errorf("unable to verify local service availability")
+	}
+	// serviceType is "local.<service_id>"; strip the prefix.
+	svcID := strings.TrimPrefix(serviceType, "local.")
+	for _, svc := range active {
+		if svc.ServiceID == svcID {
+			return nil
+		}
+	}
+	return fmt.Errorf("local service %q is not enabled or does not exist — enable it from the Services page", serviceType)
+}
+
 func (h *TasksHandler) serviceActivated(ctx context.Context, userID, serviceType, alias string, adapter adapters.Adapter) bool {
 	if adapter.ValidateCredential(nil) == nil {
 		_, err := h.st.GetServiceMeta(ctx, userID, serviceType, alias)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -441,6 +441,9 @@ func (s *Server) routes() http.Handler {
 	if s.msgBuffer != nil {
 		tasksHandler.SetGroupApproval(s.msgBuffer, s.llmHealth, agentPairer)
 	}
+	if s.localServiceProvider != nil {
+		tasksHandler.SetLocalServiceProvider(s.localServiceProvider)
+	}
 	s.tasksHandler = tasksHandler
 	if s.ticketStore == nil {
 		s.ticketStore = intauth.NewTicketStore()

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -76,10 +76,12 @@ type Server struct {
 	connectionsHandler *handlers.ConnectionsHandler
 	devicesHandler     *handlers.DevicesHandler
 
-	pushNotifier *push.Notifier     // concrete push notifier; may be nil
-	msgBuffer    groupchat.Buffer   // group chat message buffer; may be nil
-	decisionBus  notify.DecisionBus // cross-instance decision delivery; may be nil
-	gatewayHooks *GatewayHooks      // cloud-injected gateway authorization hooks; may be nil
+	pushNotifier         *push.Notifier                 // concrete push notifier; may be nil
+	msgBuffer            groupchat.Buffer               // group chat message buffer; may be nil
+	decisionBus          notify.DecisionBus             // cross-instance decision delivery; may be nil
+	gatewayHooks         *GatewayHooks                  // cloud-injected gateway authorization hooks; may be nil
+	localServiceProvider handlers.LocalServiceProvider  // cloud-injected local daemon service provider; may be nil
+	localServiceExecutor handlers.LocalServiceExecutor  // cloud-injected local service executor; may be nil
 
 	eventHub    events.EventHub
 	mcpServer   *mcp.Server
@@ -213,6 +215,18 @@ func WithAdapterGenFactory(f handlers.GeneratorFactory) ServerOption {
 // WithGatewayHooks injects additional authorization logic into the gateway.
 func WithGatewayHooks(hooks *GatewayHooks) ServerOption {
 	return func(s *Server) { s.gatewayHooks = hooks }
+}
+
+// WithLocalServiceProvider injects a provider of local daemon services into
+// the skill catalog.
+func WithLocalServiceProvider(p handlers.LocalServiceProvider) ServerOption {
+	return func(s *Server) { s.localServiceProvider = p }
+}
+
+// WithLocalServiceExecutor injects a local daemon service executor into
+// the gateway for routing agent requests to connected daemons.
+func WithLocalServiceExecutor(e handlers.LocalServiceExecutor) ServerOption {
+	return func(s *Server) { s.localServiceExecutor = e }
 }
 
 // WithTicketStore overrides the default in-memory SSE ticket store.
@@ -394,6 +408,9 @@ func (s *Server) routes() http.Handler {
 			BeforeAuthorize: s.gatewayHooks.BeforeAuthorize,
 		})
 	}
+	if s.localServiceExecutor != nil {
+		gatewayHandler.SetLocalServiceExecutor(s.localServiceExecutor)
+	}
 	servicesHandler := handlers.NewServicesHandler(s.store, s.vault, s.adapterReg, s.logger, baseURL, s.eventHub)
 	if s.oauthStateStore != nil {
 		servicesHandler.SetOAuthStateStore(s.oauthStateStore)
@@ -404,6 +421,9 @@ func (s *Server) routes() http.Handler {
 		servicesHandler.SetRelayDaemonURL(fmt.Sprintf("https://%s/d/%s", relayHost, s.cfg.Relay.DaemonID))
 	}
 	skillHandler := handlers.NewSkillHandler(s.store, s.vault, s.adapterReg, s.logger)
+	if s.localServiceProvider != nil {
+		skillHandler.SetLocalServiceProvider(s.localServiceProvider)
+	}
 	approvalsHandler := handlers.NewApprovalsHandler(s.store, s.vault, s.adapterReg, s.notifier, s.logger, s.eventHub)
 	s.approvalsHandler = approvalsHandler
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -411,6 +411,9 @@ func (s *Server) routes() http.Handler {
 	if s.localServiceExecutor != nil {
 		gatewayHandler.SetLocalServiceExecutor(s.localServiceExecutor)
 	}
+	if s.localServiceProvider != nil {
+		gatewayHandler.SetLocalServiceProvider(s.localServiceProvider)
+	}
 	servicesHandler := handlers.NewServicesHandler(s.store, s.vault, s.adapterReg, s.logger, baseURL, s.eventHub)
 	if s.oauthStateStore != nil {
 		servicesHandler.SetOAuthStateStore(s.oauthStateStore)

--- a/pkg/clawvisor/options.go
+++ b/pkg/clawvisor/options.go
@@ -99,6 +99,14 @@ type ServerOptions struct {
 	// Used by cloud for org-level restrictions, policies, etc.
 	GatewayHooks *GatewayHooks
 
+	// LocalServiceProvider supplies local daemon services for the agent catalog.
+	// Set by the cloud layer; nil in self-hosted mode.
+	LocalServiceProvider LocalServiceProvider
+
+	// LocalServiceExecutor routes agent gateway requests to local daemons.
+	// Set by the cloud layer; nil in self-hosted mode.
+	LocalServiceExecutor LocalServiceExecutor
+
 	// Quiet suppresses user-facing messages and sets server log level to WARN.
 	// Used during daemon setup when a temporary server runs in the background.
 	Quiet bool
@@ -123,6 +131,43 @@ type Dependencies struct {
 	Notifier   notify.Notifier
 	Logger     *slog.Logger
 	BaseURL    string
+}
+
+// LocalServiceProvider supplies local daemon services for the agent catalog.
+// Implemented by the cloud layer; nil in self-hosted mode.
+type LocalServiceProvider interface {
+	ActiveLocalServices(ctx context.Context, userID string) ([]LocalCatalogService, error)
+}
+
+// LocalServiceExecutor routes agent gateway requests to local daemons.
+// Implemented by the cloud layer; nil in self-hosted mode.
+type LocalServiceExecutor interface {
+	Execute(ctx context.Context, userID, service, action string, params map[string]any) (*adapters.Result, error)
+}
+
+// LocalCatalogService describes a local daemon service for the agent catalog.
+type LocalCatalogService struct {
+	ServiceID   string
+	DaemonName  string
+	Name        string
+	Description string
+	Actions     []LocalCatalogAction
+}
+
+// LocalCatalogAction describes an action within a local service.
+type LocalCatalogAction struct {
+	ID          string
+	Name        string
+	Description string
+	Params      []LocalCatalogParam
+}
+
+// LocalCatalogParam describes a parameter for a local action.
+type LocalCatalogParam struct {
+	Name        string
+	Type        string
+	Required    bool
+	Description string
 }
 
 // FeatureSet tells the frontend (and API consumers) which capabilities are available.

--- a/pkg/clawvisor/run.go
+++ b/pkg/clawvisor/run.go
@@ -7,6 +7,8 @@ import (
 	"syscall"
 
 	"github.com/clawvisor/clawvisor/internal/api"
+	"github.com/clawvisor/clawvisor/internal/api/handlers"
+	"github.com/clawvisor/clawvisor/pkg/adapters"
 )
 
 // RunWithContext starts the Clawvisor server using the provided context for
@@ -116,6 +118,12 @@ func RunWithContext(ctx context.Context, opts *ServerOptions) error {
 	if opts.VerdictCache != nil {
 		apiOpts = append(apiOpts, api.WithVerdictCache(opts.VerdictCache))
 	}
+	if opts.LocalServiceProvider != nil {
+		apiOpts = append(apiOpts, api.WithLocalServiceProvider(&localSvcAdapter{opts.LocalServiceProvider}))
+	}
+	if opts.LocalServiceExecutor != nil {
+		apiOpts = append(apiOpts, api.WithLocalServiceExecutor(&localExecAdapter{opts.LocalServiceExecutor}))
+	}
 
 	srv, err := api.New(
 		opts.Config, opts.Store, opts.Vault, opts.JWTService,
@@ -146,4 +154,51 @@ func Run(opts *ServerOptions) error {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 	return RunWithContext(ctx, opts)
+}
+
+// localSvcAdapter wraps the public LocalServiceProvider to implement
+// handlers.LocalServiceProvider by converting between type systems.
+type localSvcAdapter struct {
+	inner LocalServiceProvider
+}
+
+func (a *localSvcAdapter) ActiveLocalServices(ctx context.Context, userID string) ([]handlers.LocalCatalogService, error) {
+	svcs, err := a.inner.ActiveLocalServices(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]handlers.LocalCatalogService, len(svcs))
+	for i, s := range svcs {
+		actions := make([]handlers.LocalCatalogAction, len(s.Actions))
+		for j, act := range s.Actions {
+			params := make([]handlers.LocalCatalogParam, len(act.Params))
+			for k, p := range act.Params {
+				params[k] = handlers.LocalCatalogParam{
+					Name: p.Name, Type: p.Type,
+					Required: p.Required, Description: p.Description,
+				}
+			}
+			actions[j] = handlers.LocalCatalogAction{
+				ID: act.ID, Name: act.Name,
+				Description: act.Description, Params: params,
+			}
+		}
+		out[i] = handlers.LocalCatalogService{
+			ServiceID: s.ServiceID, DaemonName: s.DaemonName,
+			Name: s.Name, Description: s.Description,
+			Actions: actions,
+		}
+	}
+	return out, nil
+}
+
+// localExecAdapter wraps the public LocalServiceExecutor to implement
+// handlers.LocalServiceExecutor. Since both use *adapters.Result, no
+// type conversion is needed.
+type localExecAdapter struct {
+	inner LocalServiceExecutor
+}
+
+func (a *localExecAdapter) Execute(ctx context.Context, userID, service, action string, params map[string]any) (*adapters.Result, error) {
+	return a.inner.Execute(ctx, userID, service, action, params)
 }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -582,6 +582,14 @@ export interface LocalServiceParam {
   description?: string
 }
 
+export interface EnabledLocalService {
+  id: string
+  user_id: string
+  daemon_id: string
+  service_id: string
+  enabled_at: string
+}
+
 export interface AdapterGenParamPreview {
   name: string
   type: string
@@ -974,6 +982,14 @@ export const api = {
     services: (id: string) => get<LocalDaemonServices>(`/api/daemon/${id}/services`),
     request: (id: string, service: string, action: string, params?: Record<string, string>) =>
       post<{ success: boolean; data?: unknown; error?: string }>(`/api/daemon/${id}/request`, { service, action, params }),
+    rename: (id: string, name: string) =>
+      put<LocalDaemon>(`/api/daemon/${id}`, { name }),
+    enableService: (daemonId: string, serviceId: string) =>
+      post<EnabledLocalService>(`/api/daemon/${daemonId}/services/${serviceId}/enable`, {}),
+    disableService: (daemonId: string, serviceId: string) =>
+      post<void>(`/api/daemon/${daemonId}/services/${serviceId}/disable`, {}),
+    listEnabledServices: () =>
+      get<EnabledLocalService[]>('/api/daemon/services/enabled'),
   },
   orgs: {
     list: () => get<OrgMembership[]>('/api/orgs'),

--- a/web/src/pages/Services.tsx
+++ b/web/src/pages/Services.tsx
@@ -981,7 +981,6 @@ function LocalServicesSection() {
 
   if (!daemons || daemons.length === 0) return null
 
-  const enabledSet = new Set((enabledServices ?? []).map(s => s.service_id))
   const enabledByDaemon = new Map<string, Set<string>>()
   for (const s of enabledServices ?? []) {
     if (!enabledByDaemon.has(s.daemon_id)) enabledByDaemon.set(s.daemon_id, new Set())
@@ -1031,11 +1030,15 @@ function LocalServicesSection() {
             {daemonServices.length > 0 && (
               <div className="divide-y divide-border-subtle">
                 {daemonServices.map(svc => {
-                  const enabled = enabledSet.has(svc.id)
-                  const toggling = enableMut.isPending || disableMut.isPending
+                  const daemonEnabled = enabledByDaemon.get(daemon.id)
+                  const enabled = daemonEnabled?.has(svc.id) ?? false
+                  const mutKey = `${daemon.id}:${svc.id}`
+                  const toggling =
+                    (enableMut.isPending && enableMut.variables?.daemonId === daemon.id && enableMut.variables?.serviceId === svc.id) ||
+                    (disableMut.isPending && disableMut.variables?.daemonId === daemon.id && disableMut.variables?.serviceId === svc.id)
 
                   return (
-                    <div key={svc.id} className="px-5 py-3 flex items-center justify-between">
+                    <div key={mutKey} className="px-5 py-3 flex items-center justify-between">
                       <div className="min-w-0">
                         <div className="flex items-center gap-2">
                           <span className="text-sm font-medium text-text-primary">{svc.name}</span>
@@ -1075,9 +1078,11 @@ function LocalServicesSection() {
               </div>
             )}
 
-            {enableMut.isError && (
+            {(enableMut.isError || disableMut.isError) && (
               <div className="px-5 py-2 text-xs text-danger bg-danger/5 border-t border-border-subtle">
-                Failed to enable service: {(enableMut.error as Error).message}
+                {enableMut.isError
+                  ? `Failed to enable service: ${(enableMut.error as Error).message}`
+                  : `Failed to disable service: ${(disableMut.error as Error).message}`}
               </div>
             )}
           </div>

--- a/web/src/pages/Services.tsx
+++ b/web/src/pages/Services.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
-import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useQuery, useQueryClient, useMutation } from '@tanstack/react-query'
 import { NavLink } from 'react-router-dom'
-import { api, type ServiceInfo, type ServiceActionInfo, type VariableMeta } from '../api/client'
+import { api, type ServiceInfo, type ServiceActionInfo, type VariableMeta, type LocalService } from '../api/client'
 import { formatDistanceToNow } from 'date-fns'
 import { serviceName, serviceDescription } from '../lib/services'
 import { useAuth } from '../hooks/useAuth'
@@ -930,6 +930,163 @@ function OrgServicesView({ orgId, orgName }: { orgId: string; orgName: string })
   )
 }
 
+// ── Local Services Section ────────────────────────────────────────────────────
+
+function LocalServicesSection() {
+  const qc = useQueryClient()
+
+  const { data: daemons } = useQuery({
+    queryKey: ['local-daemons'],
+    queryFn: () => api.localDaemon.list(),
+  })
+
+  const { data: enabledServices } = useQuery({
+    queryKey: ['enabled-local-services'],
+    queryFn: () => api.localDaemon.listEnabledServices(),
+  })
+
+  // Fetch capabilities for each connected daemon.
+  const connectedDaemons = (daemons ?? []).filter(d => d.connected)
+  const daemonCaps = useQuery({
+    queryKey: ['all-daemon-caps', connectedDaemons.map(d => d.id).join(',')],
+    queryFn: async () => {
+      const results: Record<string, LocalService[]> = {}
+      for (const d of connectedDaemons) {
+        try {
+          const caps = await api.localDaemon.services(d.id)
+          results[d.id] = caps.services
+        } catch { /* daemon may have disconnected */ }
+      }
+      return results
+    },
+    enabled: connectedDaemons.length > 0,
+    staleTime: 30000,
+  })
+
+  const enableMut = useMutation({
+    mutationFn: ({ daemonId, serviceId }: { daemonId: string; serviceId: string }) =>
+      api.localDaemon.enableService(daemonId, serviceId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['enabled-local-services'] })
+    },
+  })
+
+  const disableMut = useMutation({
+    mutationFn: ({ daemonId, serviceId }: { daemonId: string; serviceId: string }) =>
+      api.localDaemon.disableService(daemonId, serviceId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['enabled-local-services'] })
+    },
+  })
+
+  if (!daemons || daemons.length === 0) return null
+
+  const enabledSet = new Set((enabledServices ?? []).map(s => s.service_id))
+  const enabledByDaemon = new Map<string, Set<string>>()
+  for (const s of enabledServices ?? []) {
+    if (!enabledByDaemon.has(s.daemon_id)) enabledByDaemon.set(s.daemon_id, new Set())
+    enabledByDaemon.get(s.daemon_id)!.add(s.service_id)
+  }
+
+  const caps = daemonCaps.data ?? {}
+  const hasAnyServices = Object.values(caps).some(svcs => svcs.length > 0)
+
+  if (!hasAnyServices && connectedDaemons.length === 0) return null
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <h2 className="text-lg font-semibold text-text-primary">Local Services</h2>
+        <p className="text-xs text-text-tertiary mt-0.5">
+          Services from your paired local computers. Enable services to make them available to your agents.
+        </p>
+      </div>
+
+      {daemons.map(daemon => {
+        const daemonServices = caps[daemon.id] ?? []
+        if (!daemon.connected && !enabledByDaemon.has(daemon.id)) return null
+
+        return (
+          <div key={daemon.id} className="bg-surface-1 border border-border-default rounded-lg overflow-hidden">
+            <div className="px-5 py-3 flex items-center gap-2 border-b border-border-subtle">
+              <span className={`inline-block w-2 h-2 rounded-full ${daemon.connected ? 'bg-success' : 'bg-text-tertiary'}`} />
+              <span className="font-medium text-text-primary text-sm">{daemon.name || 'Local Computer'}</span>
+              {!daemon.connected && (
+                <span className="text-xs text-text-tertiary">(offline)</span>
+              )}
+            </div>
+
+            {!daemon.connected && (
+              <div className="px-5 py-4 text-sm text-text-tertiary">
+                Daemon is offline. Enabled services will become available when it reconnects.
+              </div>
+            )}
+
+            {daemon.connected && daemonServices.length === 0 && (
+              <div className="px-5 py-4 text-sm text-text-tertiary">
+                No services reported by this daemon.
+              </div>
+            )}
+
+            {daemonServices.length > 0 && (
+              <div className="divide-y divide-border-subtle">
+                {daemonServices.map(svc => {
+                  const enabled = enabledSet.has(svc.id)
+                  const toggling = enableMut.isPending || disableMut.isPending
+
+                  return (
+                    <div key={svc.id} className="px-5 py-3 flex items-center justify-between">
+                      <div className="min-w-0">
+                        <div className="flex items-center gap-2">
+                          <span className="text-sm font-medium text-text-primary">{svc.name}</span>
+                          <span className="text-xs text-text-tertiary font-mono">local.{svc.id}</span>
+                        </div>
+                        {svc.description && (
+                          <p className="text-xs text-text-tertiary mt-0.5">{svc.description}</p>
+                        )}
+                        <div className="flex flex-wrap gap-1 mt-1">
+                          {svc.actions.map(act => (
+                            <span key={act.id} className="text-xs px-1.5 py-0.5 rounded bg-surface-2 text-text-secondary">
+                              {act.name}
+                            </span>
+                          ))}
+                        </div>
+                      </div>
+                      <button
+                        disabled={toggling}
+                        onClick={() => {
+                          if (enabled) {
+                            disableMut.mutate({ daemonId: daemon.id, serviceId: svc.id })
+                          } else {
+                            enableMut.mutate({ daemonId: daemon.id, serviceId: svc.id })
+                          }
+                        }}
+                        className={`ml-4 shrink-0 text-xs px-3 py-1.5 rounded border font-medium transition-colors ${
+                          enabled
+                            ? 'bg-success/10 text-success border-success/20 hover:bg-success/20'
+                            : 'bg-surface-2 text-text-secondary border-border-default hover:bg-surface-3'
+                        }`}
+                      >
+                        {enabled ? 'Enabled' : 'Enable'}
+                      </button>
+                    </div>
+                  )
+                })}
+              </div>
+            )}
+
+            {enableMut.isError && (
+              <div className="px-5 py-2 text-xs text-danger bg-danger/5 border-t border-border-subtle">
+                Failed to enable service: {(enableMut.error as Error).message}
+              </div>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
 // ── Main Page ────────────────────────────────────────────────────────────────
 
 export default function Services() {
@@ -1072,6 +1229,8 @@ export default function Services() {
           ))}
         </div>
       )}
+
+      {features?.local_daemon && <LocalServicesSection />}
 
       {showModal && (
         <AddServiceModal

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -1500,7 +1500,12 @@ function LocalDaemonPairing() {
     queryFn: () => api.localDaemon.listEnabledServices(),
   })
 
-  const enabledServiceIds = new Set((enabledServices ?? []).map(s => s.service_id))
+  const enabledByDaemon = new Map<string, Set<string>>()
+  for (const s of enabledServices ?? []) {
+    let set = enabledByDaemon.get(s.daemon_id)
+    if (!set) { set = new Set(); enabledByDaemon.set(s.daemon_id, set) }
+    set.add(s.service_id)
+  }
 
   // Probe localhost to see if a daemon is running and get its ID.
   const { data: localDaemonId } = useQuery({
@@ -1601,7 +1606,7 @@ function LocalDaemonPairing() {
       {!isLoading && (daemons ?? []).length > 0 && (
         <div className="space-y-3">
           {daemons!.map(daemon => (
-            <DaemonCard key={daemon.id} daemon={daemon} onDelete={() => deleteMut.mutate(daemon.id)} deleting={deleteMut.isPending} enabledServiceIds={enabledServiceIds} />
+            <DaemonCard key={daemon.id} daemon={daemon} onDelete={() => deleteMut.mutate(daemon.id)} deleting={deleteMut.isPending} enabledServiceIds={enabledByDaemon.get(daemon.id) ?? new Set()} />
           ))}
         </div>
       )}

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -1380,16 +1380,30 @@ function DevicePairing() {
 
 // ── Local daemon pairing ──────────────────────────────────────────────────────
 
-function DaemonCard({ daemon, onDelete, deleting }: {
+function DaemonCard({ daemon, onDelete, deleting, enabledServiceIds }: {
   daemon: LocalDaemon & { connected: boolean }
   onDelete: () => void
   deleting: boolean
+  enabledServiceIds: Set<string>
 }) {
+  const qc = useQueryClient()
+  const [editing, setEditing] = useState(false)
+  const [newName, setNewName] = useState(daemon.name || '')
+  const navigate = useNavigate()
+
   const { data: caps } = useQuery({
     queryKey: ['daemon-services', daemon.id],
     queryFn: () => api.localDaemon.services(daemon.id),
     enabled: daemon.connected,
     refetchInterval: 30000,
+  })
+
+  const renameMut = useMutation({
+    mutationFn: (name: string) => api.localDaemon.rename(daemon.id, name),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['local-daemons'] })
+      setEditing(false)
+    },
   })
 
   const services = caps?.services ?? []
@@ -1399,7 +1413,25 @@ function DaemonCard({ daemon, onDelete, deleting }: {
       <div className="flex items-center justify-between">
         <div>
           <div className="flex items-center gap-2">
-            <span className="font-medium text-text-primary">{daemon.name || 'Local Computer'}</span>
+            {editing ? (
+              <form onSubmit={e => { e.preventDefault(); if (newName.trim()) renameMut.mutate(newName.trim()) }} className="flex items-center gap-1.5">
+                <input
+                  autoFocus
+                  value={newName}
+                  onChange={e => setNewName(e.target.value)}
+                  className="text-sm font-medium px-2 py-0.5 rounded border border-border-default bg-surface-0 text-text-primary w-40"
+                />
+                <button type="submit" disabled={renameMut.isPending} className="text-xs text-brand hover:underline">Save</button>
+                <button type="button" onClick={() => { setEditing(false); setNewName(daemon.name || '') }} className="text-xs text-text-tertiary hover:underline">Cancel</button>
+              </form>
+            ) : (
+              <>
+                <span className="font-medium text-text-primary">{daemon.name || 'Local Computer'}</span>
+                <button onClick={() => setEditing(true)} className="text-xs text-text-tertiary hover:text-text-primary" title="Rename">
+                  <svg width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M8.5 1.5l2 2-7 7H1.5V8.5l7-7z" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round"/></svg>
+                </button>
+              </>
+            )}
             <span className={`inline-block w-2 h-2 rounded-full ${daemon.connected ? 'bg-success' : 'bg-text-tertiary'}`} />
             <span className="text-xs text-text-tertiary">{daemon.connected ? 'Connected' : 'Disconnected'}</span>
           </div>
@@ -1423,19 +1455,23 @@ function DaemonCard({ daemon, onDelete, deleting }: {
 
       {daemon.connected && services.length > 0 && (
         <div className="mt-3 pt-3 border-t border-border-default">
-          <p className="text-xs font-medium text-text-secondary mb-2">Services</p>
+          <div className="flex items-center justify-between mb-2">
+            <p className="text-xs font-medium text-text-secondary">Services</p>
+            <button
+              onClick={() => navigate('/dashboard/services')}
+              className="text-xs text-brand hover:underline"
+            >
+              Manage services
+            </button>
+          </div>
           <div className="space-y-1.5">
             {services.map(svc => (
-              <div key={svc.id} className="text-sm">
+              <div key={svc.id} className="text-sm flex items-center gap-2">
                 <span className="text-text-primary">{svc.name}</span>
-                {svc.description && <span className="text-text-tertiary ml-1.5">— {svc.description}</span>}
-                <div className="flex flex-wrap gap-1.5 mt-0.5">
-                  {svc.actions.map(act => (
-                    <span key={act.id} className="text-xs px-1.5 py-0.5 rounded bg-surface-2 text-text-secondary">
-                      {act.name}
-                    </span>
-                  ))}
-                </div>
+                {enabledServiceIds.has(svc.id) && (
+                  <span className="text-[10px] px-1.5 py-0.5 rounded bg-success/15 text-success font-medium">Enabled</span>
+                )}
+                {svc.description && <span className="text-text-tertiary">— {svc.description}</span>}
               </div>
             ))}
           </div>
@@ -1458,6 +1494,13 @@ function LocalDaemonPairing() {
     queryKey: ['local-daemons'],
     queryFn: () => api.localDaemon.list(),
   })
+
+  const { data: enabledServices } = useQuery({
+    queryKey: ['enabled-local-services'],
+    queryFn: () => api.localDaemon.listEnabledServices(),
+  })
+
+  const enabledServiceIds = new Set((enabledServices ?? []).map(s => s.service_id))
 
   // Probe localhost to see if a daemon is running and get its ID.
   const { data: localDaemonId } = useQuery({
@@ -1558,7 +1601,7 @@ function LocalDaemonPairing() {
       {!isLoading && (daemons ?? []).length > 0 && (
         <div className="space-y-3">
           {daemons!.map(daemon => (
-            <DaemonCard key={daemon.id} daemon={daemon} onDelete={() => deleteMut.mutate(daemon.id)} deleting={deleteMut.isPending} />
+            <DaemonCard key={daemon.id} daemon={daemon} onDelete={() => deleteMut.mutate(daemon.id)} deleting={deleteMut.isPending} enabledServiceIds={enabledServiceIds} />
           ))}
         </div>
       )}


### PR DESCRIPTION
## Summary
- Add `LocalServiceProvider` and `LocalServiceExecutor` interfaces so cloud-hosted agents can discover and invoke services running on paired local daemons
- Gateway handler routes `local.*` service requests to the correct daemon via WebSocket tunnel
- Skill handler resolves local services in catalog responses
- Services page shows enable/disable controls with daemon capability awareness
- Settings page adds daemon rename support

## Test plan
- [ ] Verify gateway correctly routes `local.*` requests to the paired daemon
- [ ] Verify enable/disable toggles work on the Services page
- [ ] Verify daemon rename from Settings page
- [ ] Verify catalog includes only enabled services from connected daemons

🤖 Generated with [Claude Code](https://claude.com/claude-code)