### PR TITLE
feat: Gmail thread support, reply threading, and sender display name

### DIFF
--- a/internal/adapters/definitions/google_gmail.yaml
+++ b/internal/adapters/definitions/google_gmail.yaml
@@ -15,6 +15,7 @@ auth:
       - "https://www.googleapis.com/auth/gmail.readonly"
       - "https://www.googleapis.com/auth/gmail.send"
       - "https://www.googleapis.com/auth/userinfo.email"
+      - "https://www.googleapis.com/auth/userinfo.profile"
     conditional_scopes:
       - scope: "https://www.googleapis.com/auth/gmail.compose"
         env_gate: "GMAIL_DRAFTS_ENABLED"
@@ -43,6 +44,13 @@ actions:
     params:
       message_id: { type: string, required: true }
 
+  get_thread:
+    display_name: "Get thread"
+    risk: { category: read, sensitivity: low, description: "Read all messages in an email thread" }
+    override: go
+    params:
+      thread_id: { type: string, required: true }
+
   get_attachment:
     display_name: "Get attachment"
     risk: { category: read, sensitivity: low, description: "Download an email attachment" }
@@ -56,10 +64,10 @@ actions:
     risk: { category: write, sensitivity: high, description: "Send email as the user" }
     override: go
     params:
-      to: { type: string, required: true }
-      subject: { type: string, required: true }
+      to: { type: string }
+      subject: { type: string }
       body: { type: string }
-      in_reply_to: { type: string }
+      thread_id: { type: string }
 
   create_draft:
     display_name: "Create draft"

--- a/internal/adapters/definitions/google_gmail.yaml
+++ b/internal/adapters/definitions/google_gmail.yaml
@@ -67,7 +67,8 @@ actions:
       to: { type: string }
       subject: { type: string }
       body: { type: string }
-      thread_id: { type: string }
+      thread_id: { type: string, description: "Gmail thread ID for replying in-thread (preferred — auto-populates to/subject, quotes previous message)" }
+      in_reply_to: { type: string, description: "RFC 2822 Message-ID to reply to (alternative to thread_id — will resolve the thread automatically)" }
 
   create_draft:
     display_name: "Create draft"

--- a/internal/adapters/format/format.go
+++ b/internal/adapters/format/format.go
@@ -32,6 +32,19 @@ func SanitizeText(s string, maxLen int) string {
 	return s
 }
 
+// SanitizeHeader removes dangerous Unicode and truncates, but does NOT strip
+// HTML. Use this for email header fields (From, To, Cc, Reply-To) where
+// angle-bracket addresses like <user@example.com> must be preserved.
+func SanitizeHeader(s string, maxLen int) string {
+	s = removeDangerousUnicode(s)
+	s = strings.TrimSpace(s)
+	if maxLen > 0 && utf8.RuneCountInString(s) > maxLen {
+		runes := []rune(s)
+		s = string(runes[:maxLen]) + " [truncated]"
+	}
+	return s
+}
+
 // Summary builds a one-line summary using fmt.Sprintf-style formatting.
 func Summary(template string, args ...any) string {
 	if len(args) == 0 {

--- a/internal/adapters/google/gmail/adapter.go
+++ b/internal/adapters/google/gmail/adapter.go
@@ -2,13 +2,17 @@
 package gmail
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"html"
 	"io"
 	"mime"
+	"mime/quotedprintable"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 
@@ -383,7 +387,7 @@ func (a *GmailAdapter) sendMessage(ctx context.Context, client *http.Client, par
 	// Resolve thread context for replies. Prefer thread_id (full context);
 	// fall back to in_reply_to (legacy — search for the referenced message
 	// to discover its thread).
-	var inReplyTo, references, quotedBody string
+	var inReplyTo, references, quotedBody, htmlBody string
 
 	// If we have in_reply_to but no thread_id, search for the message to
 	// discover its thread_id so we get full threading + quoting.
@@ -453,6 +457,7 @@ func (a *GmailAdapter) sendMessage(ctx context.Context, client *http.Client, par
 				qb.WriteString("\r\n")
 			}
 			quotedBody = qb.String()
+			htmlBody = buildReplyHTML(body, lastDetail.Date, lastDetail.From, lastDetail.Body)
 		}
 	}
 
@@ -467,7 +472,7 @@ func (a *GmailAdapter) sendMessage(ctx context.Context, client *http.Client, par
 	from, _ := fetchSenderAddress(ctx, client)
 
 	fullBody := body + quotedBody
-	raw := buildMIMEMessage(from, to, subject, fullBody, inReplyTo, references)
+	raw := buildMIMEMessage(from, to, subject, fullBody, htmlBody, inReplyTo, references)
 	encoded := base64.RawURLEncoding.EncodeToString([]byte(raw))
 
 	payload := map[string]string{"raw": encoded}
@@ -526,7 +531,7 @@ func (a *GmailAdapter) createDraft(ctx context.Context, client *http.Client, par
 
 	from, _ := fetchSenderAddress(ctx, client)
 
-	raw := buildMIMEMessage(from, to, subject, body, inReplyTo, "")
+	raw := buildMIMEMessage(from, to, subject, body, "", inReplyTo, "")
 	encoded := base64.RawURLEncoding.EncodeToString([]byte(raw))
 
 	payload := map[string]any{
@@ -608,7 +613,10 @@ func resolveThreadFromMessageID(ctx context.Context, client *http.Client, messag
 			ThreadId string `json:"threadId"`
 		} `json:"messages"`
 	}
-	if err := gmailGET(ctx, client, url, &resp); err != nil || len(resp.Messages) == 0 {
+	if err := gmailGET(ctx, client, url, &resp); err != nil {
+		return ""
+	}
+	if len(resp.Messages) == 0 {
 		return ""
 	}
 	return resp.Messages[0].ThreadId
@@ -881,17 +889,23 @@ func stripHTML(s string) string {
 
 func decodeBase64(s string) string {
 	// Gmail uses URL-safe base64
-	b, err := base64.URLEncoding.DecodeString(s)
+	b, err := base64.RawURLEncoding.DecodeString(s)
+	if err != nil {
+		b, err = base64.URLEncoding.DecodeString(s)
+	}
+	if err != nil {
+		b, err = base64.RawStdEncoding.DecodeString(s)
+	}
 	if err != nil {
 		b, err = base64.StdEncoding.DecodeString(s)
-		if err != nil {
-			return ""
-		}
+	}
+	if err != nil {
+		return ""
 	}
 	return string(b)
 }
 
-func buildMIMEMessage(from, to, subject, body, inReplyTo, references string) string {
+func buildMIMEMessage(from, to, subject, body, htmlBody, inReplyTo, references string) string {
 	var sb strings.Builder
 	if from != "" {
 		sb.WriteString("From: " + from + "\r\n")
@@ -907,14 +921,57 @@ func buildMIMEMessage(from, to, subject, body, inReplyTo, references string) str
 		sb.WriteString("References: " + references + "\r\n")
 	}
 	sb.WriteString("MIME-Version: 1.0\r\n")
+	if htmlBody != "" {
+		boundary := "clawvisor-alt"
+		sb.WriteString(`Content-Type: multipart/alternative; boundary="` + boundary + `"` + "\r\n")
+		sb.WriteString("\r\n")
+		sb.WriteString("--" + boundary + "\r\n")
+		sb.WriteString("Content-Type: text/plain; charset=\"UTF-8\"\r\n")
+		sb.WriteString("Content-Transfer-Encoding: quoted-printable\r\n")
+		sb.WriteString("\r\n")
+		sb.WriteString(quotePrintable(body))
+		sb.WriteString("\r\n--" + boundary + "\r\n")
+		sb.WriteString("Content-Type: text/html; charset=\"UTF-8\"\r\n")
+		sb.WriteString("Content-Transfer-Encoding: quoted-printable\r\n")
+		sb.WriteString("\r\n")
+		sb.WriteString(quotePrintable(htmlBody))
+		sb.WriteString("\r\n--" + boundary + "--\r\n")
+		return sb.String()
+	}
 	sb.WriteString("Content-Type: text/plain; charset=utf-8\r\n")
 	sb.WriteString("\r\n")
 	sb.WriteString(body)
 	return sb.String()
 }
 
+func buildReplyHTML(body, date, from, quotedText string) string {
+	var sb strings.Builder
+	sb.WriteString(`<div dir="ltr">`)
+	sb.WriteString(textToHTML(body))
+	sb.WriteString(`</div><br><div class="gmail_quote gmail_quote_container"><div dir="ltr" class="gmail_attr">On `)
+	sb.WriteString(html.EscapeString(date))
+	sb.WriteString(`, `)
+	sb.WriteString(html.EscapeString(from))
+	sb.WriteString(` wrote:<br></div><blockquote class="gmail_quote" style="margin:0px 0px 0px 0.8ex;border-left:1px solid rgb(204,204,204);padding-left:1ex">`)
+	sb.WriteString(textToHTML(quotedText))
+	sb.WriteString(`</blockquote></div>`)
+	return sb.String()
+}
+
+func textToHTML(s string) string {
+	return strings.ReplaceAll(html.EscapeString(s), "\n", "<br>\n")
+}
+
+func quotePrintable(s string) string {
+	var buf bytes.Buffer
+	w := quotedprintable.NewWriter(&buf)
+	_, _ = io.WriteString(w, strings.ReplaceAll(s, "\n", "\r\n"))
+	_ = w.Close()
+	return buf.String()
+}
+
 func encodeParam(s string) string {
-	return strings.ReplaceAll(s, " ", "+")
+	return url.QueryEscape(s)
 }
 
 func paramInt(params map[string]any, key string) (int, bool) {

--- a/internal/adapters/google/gmail/adapter.go
+++ b/internal/adapters/google/gmail/adapter.go
@@ -27,6 +27,7 @@ var gmailBaseScopes = []string{
 	"https://www.googleapis.com/auth/gmail.readonly",
 	"https://www.googleapis.com/auth/gmail.send",
 	"https://www.googleapis.com/auth/userinfo.email",
+	"https://www.googleapis.com/auth/userinfo.profile",
 }
 
 // draftsEnabled reports whether the create_draft action is available.
@@ -57,7 +58,7 @@ func New(provider adapters.OAuthCredentialProvider) *GmailAdapter {
 func (a *GmailAdapter) ServiceID() string { return serviceID }
 
 func (a *GmailAdapter) SupportedActions() []string {
-	actions := []string{"list_messages", "get_message", "get_attachment", "send_message"}
+	actions := []string{"list_messages", "get_message", "get_thread", "get_attachment", "send_message"}
 	if draftsEnabled() {
 		actions = append(actions, "create_draft")
 	}
@@ -108,6 +109,8 @@ func (a *GmailAdapter) Execute(ctx context.Context, req adapters.Request) (*adap
 		return a.listMessages(ctx, client, req.Params)
 	case "get_message":
 		return a.getMessage(ctx, client, req.Params)
+	case "get_thread":
+		return a.getThread(ctx, client, req.Params)
 	case "get_attachment":
 		return a.getAttachment(ctx, client, req.Params)
 	case "send_message":
@@ -175,7 +178,7 @@ func (a *GmailAdapter) listMessages(ctx context.Context, client *http.Client, pa
 		}
 		item := msgListItem{
 			ID:       m.ID,
-			From:     format.SanitizeText(meta.from, format.MaxFieldLen),
+			From:     format.SanitizeHeader(meta.from, format.MaxFieldLen),
 			Subject:  format.SanitizeText(meta.subject, format.MaxFieldLen),
 			Snippet:  format.SanitizeText(meta.snippet, format.MaxSnippetLen),
 			Date:     meta.date,
@@ -209,11 +212,15 @@ type msgDetail struct {
 	ID          string           `json:"id"`
 	From        string           `json:"from"`
 	To          string           `json:"to"`
+	Cc          string           `json:"cc,omitempty"`
+	ReplyTo     string           `json:"reply_to,omitempty"`
 	Subject     string           `json:"subject"`
 	Date        string           `json:"timestamp"`
 	Body        string           `json:"body"`
 	IsUnread    bool             `json:"is_unread"`
 	ThreadID    string           `json:"thread_id"`
+	MessageID   string           `json:"message_id_header,omitempty"`
+	References  string           `json:"references,omitempty"`
 	Attachments []attachmentMeta `json:"attachments,omitempty"`
 }
 
@@ -229,18 +236,76 @@ func (a *GmailAdapter) getMessage(ctx context.Context, client *http.Client, para
 		return nil, fmt.Errorf("gmail get_message: %w", err)
 	}
 
-	// Extract headers
-	var from, to, subject, date string
+	detail := parseMessageDetail(raw)
+
+	summary := format.Summary("Email from %s: %q", detail.From, detail.Subject)
+	if len(detail.Attachments) > 0 {
+		summary = format.Summary("Email from %s: %q (%d attachments)", detail.From, detail.Subject, len(detail.Attachments))
+	}
+	return &adapters.Result{Summary: summary, Data: detail}, nil
+}
+
+// ── get_thread ────────────────────────────────────────────────────────────────
+
+type threadDetail struct {
+	ThreadID string      `json:"thread_id"`
+	Messages []msgDetail `json:"messages"`
+}
+
+func (a *GmailAdapter) getThread(ctx context.Context, client *http.Client, params map[string]any) (*adapters.Result, error) {
+	threadID, _ := params["thread_id"].(string)
+	if threadID == "" {
+		return nil, fmt.Errorf("gmail get_thread: thread_id is required")
+	}
+
+	url := fmt.Sprintf("https://gmail.googleapis.com/gmail/v1/users/me/threads/%s?format=full", threadID)
+	var raw struct {
+		ID       string         `json:"id"`
+		Messages []gmailMessage `json:"messages"`
+	}
+	if err := gmailGET(ctx, client, url, &raw); err != nil {
+		return nil, fmt.Errorf("gmail get_thread: %w", err)
+	}
+
+	messages := make([]msgDetail, 0, len(raw.Messages))
+	for _, msg := range raw.Messages {
+		detail := parseMessageDetail(msg)
+		messages = append(messages, detail)
+	}
+
+	result := threadDetail{
+		ThreadID: raw.ID,
+		Messages: messages,
+	}
+
+	summary := format.Summary("Thread %s: %d messages", threadID, len(messages))
+	if len(messages) > 0 {
+		summary = format.Summary("Thread %s: %d messages (subject: %q)", threadID, len(messages), messages[0].Subject)
+	}
+	return &adapters.Result{Summary: summary, Data: result}, nil
+}
+
+// parseMessageDetail extracts a msgDetail from a raw gmailMessage.
+func parseMessageDetail(raw gmailMessage) msgDetail {
+	var from, to, cc, replyTo, subject, date, messageID, references string
 	for _, h := range raw.Payload.Headers {
 		switch strings.ToLower(h.Name) {
 		case "from":
 			from = h.Value
 		case "to":
 			to = h.Value
+		case "cc":
+			cc = h.Value
+		case "reply-to":
+			replyTo = h.Value
 		case "subject":
 			subject = h.Value
 		case "date":
 			date = h.Value
+		case "message-id":
+			messageID = h.Value
+		case "references":
+			references = h.Value
 		}
 	}
 
@@ -258,23 +323,21 @@ func (a *GmailAdapter) getMessage(ctx context.Context, client *http.Client, para
 
 	attachments := extractAttachments(raw.Payload)
 
-	detail := msgDetail{
+	return msgDetail{
 		ID:          raw.ID,
-		From:        format.SanitizeText(from, format.MaxFieldLen),
-		To:          format.SanitizeText(to, format.MaxFieldLen),
+		From:        format.SanitizeHeader(from, format.MaxFieldLen),
+		To:          format.SanitizeHeader(to, format.MaxFieldLen),
+		Cc:          format.SanitizeHeader(cc, format.MaxFieldLen),
+		ReplyTo:     format.SanitizeHeader(replyTo, format.MaxFieldLen),
 		Subject:     format.SanitizeText(subject, format.MaxFieldLen),
 		Date:        date,
 		Body:        format.SanitizeText(body, format.MaxBodyLen),
 		IsUnread:    isUnread,
 		ThreadID:    raw.ThreadId,
+		MessageID:   messageID,
+		References:  references,
 		Attachments: attachments,
 	}
-
-	summary := format.Summary("Email from %s: %q", detail.From, detail.Subject)
-	if len(attachments) > 0 {
-		summary = format.Summary("Email from %s: %q (%d attachments)", detail.From, detail.Subject, len(attachments))
-	}
-	return &adapters.Result{Summary: summary, Data: detail}, nil
 }
 
 // ── get_attachment ────────────────────────────────────────────────────────────
@@ -314,7 +377,69 @@ func (a *GmailAdapter) sendMessage(ctx context.Context, client *http.Client, par
 	to, _ := params["to"].(string)
 	subject, _ := params["subject"].(string)
 	body, _ := params["body"].(string)
-	inReplyTo, _ := params["in_reply_to"].(string)
+	threadID, _ := params["thread_id"].(string)
+
+	// When thread_id is provided, this is a reply — fetch thread context.
+	var inReplyTo, references, quotedBody string
+	if threadID != "" {
+		threadURL := fmt.Sprintf("https://gmail.googleapis.com/gmail/v1/users/me/threads/%s?format=full", threadID)
+		var threadResp struct {
+			ID       string         `json:"id"`
+			Messages []gmailMessage `json:"messages"`
+		}
+		if err := gmailGET(ctx, client, threadURL, &threadResp); err != nil {
+			return nil, fmt.Errorf("gmail send_message: fetch thread: %w", err)
+		}
+		if len(threadResp.Messages) == 0 {
+			return nil, fmt.Errorf("gmail send_message: thread %s has no messages", threadID)
+		}
+
+		lastMsg := threadResp.Messages[len(threadResp.Messages)-1]
+		lastDetail := parseMessageDetail(lastMsg)
+
+		// Derive recipient from thread if not explicitly provided.
+		if to == "" {
+			to = lastDetail.ReplyTo
+		}
+		if to == "" {
+			to = lastDetail.From
+		}
+
+		// Derive subject from thread if not explicitly provided.
+		if subject == "" {
+			subject = lastDetail.Subject
+			if !strings.HasPrefix(strings.ToLower(subject), "re:") {
+				subject = "Re: " + subject
+			}
+		}
+
+		// Build threading headers.
+		inReplyTo = lastDetail.MessageID
+		references = lastDetail.References
+		if lastDetail.MessageID != "" {
+			if references != "" {
+				references += " " + lastDetail.MessageID
+			} else {
+				references = lastDetail.MessageID
+			}
+		}
+
+		// Quote the previous message.
+		if lastDetail.Body != "" {
+			var qb strings.Builder
+			qb.WriteString("\r\n\r\nOn ")
+			qb.WriteString(lastDetail.Date)
+			qb.WriteString(", ")
+			qb.WriteString(lastDetail.From)
+			qb.WriteString(" wrote:\r\n")
+			for _, line := range strings.Split(lastDetail.Body, "\n") {
+				qb.WriteString("> ")
+				qb.WriteString(strings.TrimRight(line, "\r"))
+				qb.WriteString("\r\n")
+			}
+			quotedBody = qb.String()
+		}
+	}
 
 	if to == "" {
 		return nil, fmt.Errorf("gmail send_message: to is required")
@@ -323,14 +448,23 @@ func (a *GmailAdapter) sendMessage(ctx context.Context, client *http.Client, par
 		return nil, fmt.Errorf("gmail send_message: subject is required")
 	}
 
-	raw := buildMIMEMessage(to, subject, body, inReplyTo)
+	// Fetch the sender's address for a proper From header.
+	from, _ := fetchSenderAddress(ctx, client)
+
+	fullBody := body + quotedBody
+	raw := buildMIMEMessage(from, to, subject, fullBody, inReplyTo, references)
 	encoded := base64.URLEncoding.EncodeToString([]byte(raw))
+
+	payload := map[string]string{"raw": encoded}
+	if threadID != "" {
+		payload["threadId"] = threadID
+	}
 
 	var sendResp struct {
 		ID string `json:"id"`
 	}
 	if err := gmailPOST(ctx, client, "https://gmail.googleapis.com/gmail/v1/users/me/messages/send",
-		map[string]string{"raw": encoded}, &sendResp); err != nil {
+		payload, &sendResp); err != nil {
 		return nil, fmt.Errorf("gmail send_message: %w", err)
 	}
 
@@ -338,6 +472,9 @@ func (a *GmailAdapter) sendMessage(ctx context.Context, client *http.Client, par
 		"message_id": sendResp.ID,
 		"to":         to,
 		"subject":    subject,
+	}
+	if threadID != "" {
+		result["thread_id"] = threadID
 	}
 	summary := format.Summary("Email sent to %s (subject: %q)", to, subject)
 	return &adapters.Result{Summary: summary, Data: result}, nil
@@ -372,7 +509,9 @@ func (a *GmailAdapter) createDraft(ctx context.Context, client *http.Client, par
 		return nil, fmt.Errorf("gmail create_draft: subject is required")
 	}
 
-	raw := buildMIMEMessage(to, subject, body, inReplyTo)
+	from, _ := fetchSenderAddress(ctx, client)
+
+	raw := buildMIMEMessage(from, to, subject, body, inReplyTo, "")
 	encoded := base64.URLEncoding.EncodeToString([]byte(raw))
 
 	payload := map[string]any{
@@ -439,6 +578,72 @@ func gmailPOST(ctx context.Context, client *http.Client, url string, payload any
 		return fmt.Errorf("gmail API POST %s: %d: %s", url, resp.StatusCode, truncate(string(body), 200))
 	}
 	return json.Unmarshal(body, out)
+}
+
+// fetchSenderAddress resolves the authenticated user's display name and email
+// for the From header (e.g. "Eric Levine <eric@clawvisor.com>").
+//
+// Strategy:
+//  1. Try Gmail sendAs settings (has display name + email together).
+//  2. If sendAs returns a bare email (no display name), supplement with Google
+//     userinfo which reliably has the account name.
+//  3. Returns "" on complete failure so callers can fall back to "me".
+func fetchSenderAddress(ctx context.Context, client *http.Client) (string, error) {
+	var email, displayName string
+
+	// Try sendAs first — it has the canonical send-from address.
+	var sendAsResp struct {
+		SendAs []struct {
+			SendAsEmail string `json:"sendAsEmail"`
+			DisplayName string `json:"displayName"`
+			IsDefault   bool   `json:"isDefault"`
+			IsPrimary   bool   `json:"isPrimary"`
+		} `json:"sendAs"`
+	}
+	if err := gmailGET(ctx, client, "https://gmail.googleapis.com/gmail/v1/users/me/settings/sendAs", &sendAsResp); err == nil {
+		for _, sa := range sendAsResp.SendAs {
+			if sa.IsDefault {
+				email = sa.SendAsEmail
+				displayName = sa.DisplayName
+				break
+			}
+		}
+		if email == "" && len(sendAsResp.SendAs) > 0 {
+			email = sendAsResp.SendAs[0].SendAsEmail
+			displayName = sendAsResp.SendAs[0].DisplayName
+		}
+	}
+
+	// If we still don't have a display name, try Google userinfo.
+	if displayName == "" {
+		if name, addr, err := fetchGoogleProfile(ctx, client); err == nil {
+			displayName = name
+			if email == "" {
+				email = addr
+			}
+		}
+	}
+
+	if email == "" {
+		return "", fmt.Errorf("could not determine sender address")
+	}
+	if displayName != "" {
+		return fmt.Sprintf("%s <%s>", displayName, email), nil
+	}
+	return email, nil
+}
+
+// fetchGoogleProfile returns the user's name and email from the Google
+// userinfo endpoint (requires the userinfo.email scope we already request).
+func fetchGoogleProfile(ctx context.Context, client *http.Client) (name, email string, err error) {
+	var info struct {
+		Name  string `json:"name"`
+		Email string `json:"email"`
+	}
+	if err := gmailGET(ctx, client, "https://www.googleapis.com/oauth2/v2/userinfo", &info); err != nil {
+		return "", "", err
+	}
+	return info.Name, info.Email, nil
 }
 
 // ── Gmail API message types ───────────────────────────────────────────────────
@@ -652,13 +857,20 @@ func decodeBase64(s string) string {
 	return string(b)
 }
 
-func buildMIMEMessage(to, subject, body, inReplyTo string) string {
+func buildMIMEMessage(from, to, subject, body, inReplyTo, references string) string {
 	var sb strings.Builder
-	sb.WriteString("From: me\r\n")
+	if from != "" {
+		sb.WriteString("From: " + from + "\r\n")
+	} else {
+		sb.WriteString("From: me\r\n")
+	}
 	sb.WriteString("To: " + to + "\r\n")
 	sb.WriteString("Subject: " + mime.QEncoding.Encode("utf-8", subject) + "\r\n")
 	if inReplyTo != "" {
 		sb.WriteString("In-Reply-To: " + inReplyTo + "\r\n")
+	}
+	if references != "" {
+		sb.WriteString("References: " + references + "\r\n")
 	}
 	sb.WriteString("MIME-Version: 1.0\r\n")
 	sb.WriteString("Content-Type: text/plain; charset=utf-8\r\n")

--- a/internal/adapters/google/gmail/adapter.go
+++ b/internal/adapters/google/gmail/adapter.go
@@ -378,9 +378,24 @@ func (a *GmailAdapter) sendMessage(ctx context.Context, client *http.Client, par
 	subject, _ := params["subject"].(string)
 	body, _ := params["body"].(string)
 	threadID, _ := params["thread_id"].(string)
+	legacyInReplyTo, _ := params["in_reply_to"].(string)
 
-	// When thread_id is provided, this is a reply — fetch thread context.
+	// Resolve thread context for replies. Prefer thread_id (full context);
+	// fall back to in_reply_to (legacy — search for the referenced message
+	// to discover its thread).
 	var inReplyTo, references, quotedBody string
+
+	// If we have in_reply_to but no thread_id, search for the message to
+	// discover its thread_id so we get full threading + quoting.
+	if threadID == "" && legacyInReplyTo != "" {
+		if tid := resolveThreadFromMessageID(ctx, client, legacyInReplyTo); tid != "" {
+			threadID = tid
+		} else {
+			// Can't find the thread — use the Message-ID as a bare In-Reply-To header.
+			inReplyTo = legacyInReplyTo
+		}
+	}
+
 	if threadID != "" {
 		threadURL := fmt.Sprintf("https://gmail.googleapis.com/gmail/v1/users/me/threads/%s?format=full", threadID)
 		var threadResp struct {
@@ -578,6 +593,25 @@ func gmailPOST(ctx context.Context, client *http.Client, url string, payload any
 		return fmt.Errorf("gmail API POST %s: %d: %s", url, resp.StatusCode, truncate(string(body), 200))
 	}
 	return json.Unmarshal(body, out)
+}
+
+// resolveThreadFromMessageID searches for a message by its RFC 2822 Message-ID
+// header (e.g. "<abc@mail.gmail.com>") and returns the Gmail thread ID.
+// Returns "" if the message can't be found.
+func resolveThreadFromMessageID(ctx context.Context, client *http.Client, messageID string) string {
+	// Gmail search supports rfc822msgid: operator for Message-ID lookup.
+	query := "rfc822msgid:" + messageID
+	url := fmt.Sprintf("https://gmail.googleapis.com/gmail/v1/users/me/messages?maxResults=1&q=%s", encodeParam(query))
+	var resp struct {
+		Messages []struct {
+			ID       string `json:"id"`
+			ThreadId string `json:"threadId"`
+		} `json:"messages"`
+	}
+	if err := gmailGET(ctx, client, url, &resp); err != nil || len(resp.Messages) == 0 {
+		return ""
+	}
+	return resp.Messages[0].ThreadId
 }
 
 // fetchSenderAddress resolves the authenticated user's display name and email

--- a/internal/adapters/google/gmail/adapter.go
+++ b/internal/adapters/google/gmail/adapter.go
@@ -453,7 +453,7 @@ func (a *GmailAdapter) sendMessage(ctx context.Context, client *http.Client, par
 
 	fullBody := body + quotedBody
 	raw := buildMIMEMessage(from, to, subject, fullBody, inReplyTo, references)
-	encoded := base64.URLEncoding.EncodeToString([]byte(raw))
+	encoded := base64.RawURLEncoding.EncodeToString([]byte(raw))
 
 	payload := map[string]string{"raw": encoded}
 	if threadID != "" {
@@ -512,7 +512,7 @@ func (a *GmailAdapter) createDraft(ctx context.Context, client *http.Client, par
 	from, _ := fetchSenderAddress(ctx, client)
 
 	raw := buildMIMEMessage(from, to, subject, body, inReplyTo, "")
-	encoded := base64.URLEncoding.EncodeToString([]byte(raw))
+	encoded := base64.RawURLEncoding.EncodeToString([]byte(raw))
 
 	payload := map[string]any{
 		"message": map[string]string{"raw": encoded},

--- a/internal/adapters/google/gmail/adapter_test.go
+++ b/internal/adapters/google/gmail/adapter_test.go
@@ -2,6 +2,7 @@ package gmail
 
 import (
 	"encoding/base64"
+	"strings"
 	"testing"
 )
 
@@ -187,5 +188,104 @@ func TestExtractAttachments_SkipsPartsWithoutAttachmentID(t *testing.T) {
 	}
 	if got[0].Filename != "real.pdf" {
 		t.Errorf("attachment = %q, want %q", got[0].Filename, "real.pdf")
+	}
+}
+
+func TestParseMessageDetail_ExtractsAllHeaders(t *testing.T) {
+	msg := gmailMessage{
+		ID:       "msg-1",
+		ThreadId: "thread-1",
+		LabelIds: []string{"INBOX", "UNREAD"},
+		Payload: gmailPayload{
+			MimeType: "text/plain",
+			Headers: []gmailHeader{
+				{Name: "From", Value: "alice@example.com"},
+				{Name: "To", Value: "bob@example.com"},
+				{Name: "Cc", Value: "charlie@example.com"},
+				{Name: "Reply-To", Value: "alice-reply@example.com"},
+				{Name: "Subject", Value: "Test subject"},
+				{Name: "Date", Value: "Mon, 7 Apr 2026 12:00:00 +0000"},
+				{Name: "Message-ID", Value: "<abc123@mail.gmail.com>"},
+				{Name: "References", Value: "<ref1@mail.gmail.com> <ref2@mail.gmail.com>"},
+			},
+			Body: gmailBody{Data: b64("Hello!")},
+		},
+	}
+
+	detail := parseMessageDetail(msg)
+
+	if detail.ID != "msg-1" {
+		t.Errorf("ID = %q, want %q", detail.ID, "msg-1")
+	}
+	if detail.ThreadID != "thread-1" {
+		t.Errorf("ThreadID = %q, want %q", detail.ThreadID, "thread-1")
+	}
+	if detail.From != "alice@example.com" {
+		t.Errorf("From = %q, want %q", detail.From, "alice@example.com")
+	}
+	if detail.To != "bob@example.com" {
+		t.Errorf("To = %q, want %q", detail.To, "bob@example.com")
+	}
+	if detail.Cc != "charlie@example.com" {
+		t.Errorf("Cc = %q, want %q", detail.Cc, "charlie@example.com")
+	}
+	if detail.ReplyTo != "alice-reply@example.com" {
+		t.Errorf("ReplyTo = %q, want %q", detail.ReplyTo, "alice-reply@example.com")
+	}
+	if detail.Subject != "Test subject" {
+		t.Errorf("Subject = %q, want %q", detail.Subject, "Test subject")
+	}
+	if detail.MessageID != "<abc123@mail.gmail.com>" {
+		t.Errorf("MessageID = %q, want %q", detail.MessageID, "<abc123@mail.gmail.com>")
+	}
+	if detail.References != "<ref1@mail.gmail.com> <ref2@mail.gmail.com>" {
+		t.Errorf("References = %q, want %q", detail.References, "<ref1@mail.gmail.com> <ref2@mail.gmail.com>")
+	}
+	if !detail.IsUnread {
+		t.Error("IsUnread should be true")
+	}
+	if detail.Body != "Hello!" {
+		t.Errorf("Body = %q, want %q", detail.Body, "Hello!")
+	}
+}
+
+func TestBuildMIMEMessage_WithReferences(t *testing.T) {
+	msg := buildMIMEMessage(
+		"Alice Smith <alice@example.com>",
+		"bob@example.com",
+		"Re: Test",
+		"Reply body",
+		"<orig@mail.gmail.com>",
+		"<ref1@mail.gmail.com> <orig@mail.gmail.com>",
+	)
+
+	if !strings.Contains(msg, "From: Alice Smith <alice@example.com>") {
+		t.Error("missing From header with display name")
+	}
+	if !strings.Contains(msg, "In-Reply-To: <orig@mail.gmail.com>") {
+		t.Error("missing In-Reply-To header")
+	}
+	if !strings.Contains(msg, "References: <ref1@mail.gmail.com> <orig@mail.gmail.com>") {
+		t.Error("missing References header")
+	}
+	if !strings.Contains(msg, "To: bob@example.com") {
+		t.Error("missing To header")
+	}
+	if !strings.Contains(msg, "Reply body") {
+		t.Error("missing body")
+	}
+}
+
+func TestBuildMIMEMessage_WithoutReferences(t *testing.T) {
+	msg := buildMIMEMessage("", "bob@example.com", "Hello", "Body", "", "")
+
+	if !strings.Contains(msg, "From: me") {
+		t.Error("should fall back to From: me when from is empty")
+	}
+	if strings.Contains(msg, "In-Reply-To:") {
+		t.Error("should not have In-Reply-To header")
+	}
+	if strings.Contains(msg, "References:") {
+		t.Error("should not have References header")
 	}
 }

--- a/internal/adapters/google/gmail/adapter_test.go
+++ b/internal/adapters/google/gmail/adapter_test.go
@@ -1,12 +1,23 @@
 package gmail
 
 import (
+	"context"
 	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
 	"strings"
 	"testing"
 )
 
 func b64(s string) string { return base64.URLEncoding.EncodeToString([]byte(s)) }
+func rawB64(s string) string { return base64.RawURLEncoding.EncodeToString([]byte(s)) }
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
 
 func TestExtractBodyFromParts_DirectPlainText(t *testing.T) {
 	payload := gmailPayload{
@@ -16,6 +27,17 @@ func TestExtractBodyFromParts_DirectPlainText(t *testing.T) {
 	got := extractBodyFromParts(payload)
 	if got != "Hello, world!" {
 		t.Errorf("got %q, want %q", got, "Hello, world!")
+	}
+}
+
+func TestExtractBodyFromParts_DirectPlainTextRawURLBase64(t *testing.T) {
+	payload := gmailPayload{
+		MimeType: "text/plain",
+		Body:     gmailBody{Data: rawB64("Hello, raw world!")},
+	}
+	got := extractBodyFromParts(payload)
+	if got != "Hello, raw world!" {
+		t.Errorf("got %q, want %q", got, "Hello, raw world!")
 	}
 }
 
@@ -255,6 +277,7 @@ func TestBuildMIMEMessage_WithReferences(t *testing.T) {
 		"bob@example.com",
 		"Re: Test",
 		"Reply body",
+		"",
 		"<orig@mail.gmail.com>",
 		"<ref1@mail.gmail.com> <orig@mail.gmail.com>",
 	)
@@ -277,7 +300,7 @@ func TestBuildMIMEMessage_WithReferences(t *testing.T) {
 }
 
 func TestBuildMIMEMessage_WithoutReferences(t *testing.T) {
-	msg := buildMIMEMessage("", "bob@example.com", "Hello", "Body", "", "")
+	msg := buildMIMEMessage("", "bob@example.com", "Hello", "Body", "", "", "")
 
 	if !strings.Contains(msg, "From: me") {
 		t.Error("should fall back to From: me when from is empty")
@@ -287,5 +310,220 @@ func TestBuildMIMEMessage_WithoutReferences(t *testing.T) {
 	}
 	if strings.Contains(msg, "References:") {
 		t.Error("should not have References header")
+	}
+}
+
+func TestBuildMIMEMessage_WithHTMLAlternative(t *testing.T) {
+	msg := buildMIMEMessage(
+		"Alice Smith <alice@example.com>",
+		"bob@example.com",
+		"Re: Test",
+		"Reply body\r\n\r\nOn date, person wrote:\r\n> quoted",
+		`<div dir="ltr">Reply body</div><br><div class="gmail_quote gmail_quote_container"><blockquote class="gmail_quote">quoted</blockquote></div>`,
+		"<orig@mail.gmail.com>",
+		"<ref1@mail.gmail.com> <orig@mail.gmail.com>",
+	)
+
+	if !strings.Contains(msg, `Content-Type: multipart/alternative; boundary="clawvisor-alt"`) {
+		t.Errorf("missing multipart content type: %s", msg)
+	}
+	if !strings.Contains(msg, "Content-Type: text/plain; charset=\"UTF-8\"") {
+		t.Errorf("missing text/plain part: %s", msg)
+	}
+	if !strings.Contains(msg, "Content-Type: text/html; charset=\"UTF-8\"") {
+		t.Errorf("missing text/html part: %s", msg)
+	}
+	if !strings.Contains(msg, "gmail_quote") {
+		t.Errorf("missing gmail quote HTML: %s", msg)
+	}
+}
+
+func TestSendMessage_WithThreadID_QuotesPreviousMessage(t *testing.T) {
+	var sentPayload struct {
+		Raw      string `json:"raw"`
+		ThreadID string `json:"threadId"`
+	}
+
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			var body string
+			switch {
+			case req.Method == http.MethodGet && strings.Contains(req.URL.Path, "/threads/thread-123"):
+				body = `{
+					"id":"thread-123",
+					"messages":[{
+						"id":"msg-1",
+						"threadId":"thread-123",
+						"payload":{
+							"headers":[
+								{"name":"From","value":"alice@example.com"},
+								{"name":"To","value":"bob@example.com"},
+								{"name":"Subject","value":"Original subject"},
+								{"name":"Date","value":"Mon, 7 Apr 2026 12:00:00 +0000"},
+								{"name":"Message-ID","value":"<orig@mail.gmail.com>"},
+								{"name":"References","value":"<root@mail.gmail.com>"}
+							],
+							"mimeType":"text/plain",
+							"body":{"data":"` + rawB64("Original line 1\nOriginal line 2") + `"}
+						}
+					}]
+				}`
+			case req.Method == http.MethodGet && strings.Contains(req.URL.Path, "/settings/sendAs"):
+				body = `{"sendAs":[{"sendAsEmail":"sender@example.com","displayName":"Sender","isDefault":true,"isPrimary":true}]}`
+			case req.Method == http.MethodPost && strings.Contains(req.URL.Path, "/messages/send"):
+				data, err := io.ReadAll(req.Body)
+				if err != nil {
+					t.Fatalf("read request body: %v", err)
+				}
+				if err := json.Unmarshal(data, &sentPayload); err != nil {
+					t.Fatalf("unmarshal send payload: %v", err)
+				}
+				body = `{"id":"sent-1"}`
+			default:
+				t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(body)),
+			}, nil
+		}),
+	}
+
+	adapter := &GmailAdapter{}
+	result, err := adapter.sendMessage(context.Background(), client, map[string]any{
+		"thread_id": "thread-123",
+		"body":      "My reply",
+	})
+	if err != nil {
+		t.Fatalf("sendMessage error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("sendMessage returned nil result")
+	}
+	if sentPayload.ThreadID != "thread-123" {
+		t.Fatalf("threadId = %q, want %q", sentPayload.ThreadID, "thread-123")
+	}
+
+	raw, err := base64.RawURLEncoding.DecodeString(sentPayload.Raw)
+	if err != nil {
+		t.Fatalf("decode raw MIME: %v", err)
+	}
+	msg := string(raw)
+	if !strings.Contains(msg, `Content-Type: multipart/alternative; boundary="clawvisor-alt"`) {
+		t.Errorf("missing multipart content type in MIME: %s", msg)
+	}
+	if !strings.Contains(msg, "Subject: Re: Original subject") {
+		t.Errorf("missing derived reply subject in MIME: %s", msg)
+	}
+	if !strings.Contains(msg, "In-Reply-To: <orig@mail.gmail.com>") {
+		t.Errorf("missing In-Reply-To header in MIME: %s", msg)
+	}
+	if !strings.Contains(msg, "References: <root@mail.gmail.com> <orig@mail.gmail.com>") {
+		t.Errorf("missing References header in MIME: %s", msg)
+	}
+	if !strings.Contains(msg, "My reply") || !strings.Contains(msg, "On Mon, 7 Apr 2026 12:00:00 +0000, alice@example.com wrote:") || !strings.Contains(msg, "> Original line 1") || !strings.Contains(msg, "> Original line 2") {
+		t.Errorf("missing quoted original body in MIME: %s", msg)
+	}
+	if !strings.Contains(msg, "gmail_quote") {
+		t.Errorf("missing gmail quote HTML in MIME: %s", msg)
+	}
+}
+
+func TestSendMessage_WithInReplyTo_ResolvesThreadAndQuotesPreviousMessage(t *testing.T) {
+	var sentPayload struct {
+		Raw      string `json:"raw"`
+		ThreadID string `json:"threadId"`
+	}
+	const messageID = "<CAGGMS=RZG7QFRkNRZ99ofzMn+rEX_WyWV0foyLzSf0n6m=fT8w@mail.gmail.com>"
+
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			var body string
+			switch {
+			case req.Method == http.MethodGet && strings.Contains(req.URL.Path, "/messages"):
+				if got := req.URL.Query().Get("q"); got != "rfc822msgid:"+messageID {
+					t.Fatalf("search query = %q, want %q", got, "rfc822msgid:"+messageID)
+				}
+				body = `{"messages":[{"id":"msg-1","threadId":"thread-123"}]}`
+			case req.Method == http.MethodGet && strings.Contains(req.URL.Path, "/threads/thread-123"):
+				body = `{
+					"id":"thread-123",
+					"messages":[{
+						"id":"msg-1",
+						"threadId":"thread-123",
+						"payload":{
+							"headers":[
+								{"name":"From","value":"alice@example.com"},
+								{"name":"Subject","value":"Original subject"},
+								{"name":"Date","value":"Mon, 7 Apr 2026 12:00:00 +0000"},
+								{"name":"Message-ID","value":"` + messageID + `"},
+								{"name":"References","value":"<root@mail.gmail.com>"}
+							],
+							"mimeType":"text/plain",
+							"body":{"data":"` + rawB64("Original line 1\nOriginal line 2") + `"}
+						}
+					}]
+				}`
+			case req.Method == http.MethodGet && strings.Contains(req.URL.Path, "/settings/sendAs"):
+				body = `{"sendAs":[{"sendAsEmail":"sender@example.com","displayName":"Sender","isDefault":true,"isPrimary":true}]}`
+			case req.Method == http.MethodPost && strings.Contains(req.URL.Path, "/messages/send"):
+				data, err := io.ReadAll(req.Body)
+				if err != nil {
+					t.Fatalf("read request body: %v", err)
+				}
+				if err := json.Unmarshal(data, &sentPayload); err != nil {
+					t.Fatalf("unmarshal send payload: %v", err)
+				}
+				body = `{"id":"sent-1"}`
+			default:
+				t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(body)),
+			}, nil
+		}),
+	}
+
+	adapter := &GmailAdapter{}
+	result, err := adapter.sendMessage(context.Background(), client, map[string]any{
+		"to":          "eric@levine.tech",
+		"subject":     "Re: Sender name test #4",
+		"body":        "Reply #5 -- another threading check.",
+		"in_reply_to": messageID,
+	})
+	if err != nil {
+		t.Fatalf("sendMessage error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("sendMessage returned nil result")
+	}
+	if sentPayload.ThreadID != "thread-123" {
+		t.Fatalf("threadId = %q, want %q", sentPayload.ThreadID, "thread-123")
+	}
+
+	raw, err := base64.RawURLEncoding.DecodeString(sentPayload.Raw)
+	if err != nil {
+		t.Fatalf("decode raw MIME: %v", err)
+	}
+	msg := string(raw)
+	if !strings.Contains(msg, `Content-Type: multipart/alternative; boundary="clawvisor-alt"`) {
+		t.Errorf("missing multipart content type in MIME: %s", msg)
+	}
+	if !strings.Contains(msg, "In-Reply-To: "+messageID) {
+		t.Errorf("missing resolved In-Reply-To header in MIME: %s", msg)
+	}
+	if !strings.Contains(msg, "References: <root@mail.gmail.com> "+messageID) {
+		t.Errorf("missing References header in MIME: %s", msg)
+	}
+	if !strings.Contains(msg, "Reply #5 -- another threading check.") || !strings.Contains(msg, "On Mon, 7 Apr 2026 12:00:00 +0000, alice@example.com wrote:") || !strings.Contains(msg, "> Original line 1") || !strings.Contains(msg, "> Original line 2") {
+		t.Errorf("missing quoted original body in MIME: %s", msg)
+	}
+	if !strings.Contains(msg, "gmail_quote") {
+		t.Errorf("missing gmail quote HTML in MIME: %s", msg)
 	}
 }

--- a/pkg/clawvisor/defaults.go
+++ b/pkg/clawvisor/defaults.go
@@ -155,7 +155,7 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 	goOverrides := map[string]yamlruntime.ActionFunc{}
 
 	gmail := gmailadapter.New(oauthProvider)
-	for _, action := range []string{"list_messages", "get_message", "get_attachment", "send_message", "create_draft"} {
+	for _, action := range []string{"list_messages", "get_message", "get_thread", "get_attachment", "send_message", "create_draft"} {
 		goOverrides["google.gmail:"+action] = gmail.Execute
 	}
 	drive := driveadapter.New(oauthProvider)

--- a/skills/clawvisor/policies/google-workspace-safe.yaml
+++ b/skills/clawvisor/policies/google-workspace-safe.yaml
@@ -8,7 +8,7 @@ description: >
 rules:
   # Gmail — read operations allowed, send requires approval, delete blocked
   - service: google.gmail
-    actions: [list_messages, get_message, get_attachment]
+    actions: [list_messages, get_message, get_thread, get_attachment]
     allow: true
 
   - service: google.gmail

--- a/skills/clawvisor/presets/email-ea.json
+++ b/skills/clawvisor/presets/email-ea.json
@@ -16,9 +16,15 @@
     },
     {
       "service": "google.gmail",
+      "action": "get_thread",
+      "auto_execute": true,
+      "expected_use": "Read all messages in an email thread to understand the full conversation context. Used for thread summaries, tracking back-and-forth exchanges, identifying all participants, and building context before composing a reply. Any thread referenced by the owner or discovered via search."
+    },
+    {
+      "service": "google.gmail",
       "action": "send_message",
       "auto_execute": false,
-      "expected_use": "Send emails only when the owner explicitly instructs. Includes replying to threads, CCing colleagues, sending intros, following up with any contact."
+      "expected_use": "Send emails only when the owner explicitly instructs. Includes composing new emails and replying to threads (pass thread_id to reply in-thread with proper threading headers and quoted content). CCing colleagues, sending intros, following up with any contact."
     },
     {
       "service": "google.gmail",


### PR DESCRIPTION
## Summary
- Add `get_thread` action to fetch all messages in a thread at once with full metadata (Cc, Reply-To, Message-ID, References headers)
- Enhance `send_message` to support in-thread replies with proper threading headers (In-Reply-To, References, threadId) and quoted previous message content
- Fix sender From header to show display name (e.g. "Eric Levine <eric@clawvisor.com>") by falling back to Google userinfo profile when sendAs displayName is empty
- Add `userinfo.profile` OAuth scope (existing users must reconnect to get display name support)
- Update skill definitions, policies, and presets for new actions

## Test plan
- [x] All 13 unit tests pass (including new tests for `parseMessageDetail` and `buildMIMEMessage`)
- [x] Manually verified sender display name fix via live send (required reconnecting Google account for new scope)
- [ ] Verify `get_thread` returns all messages with correct metadata
- [ ] Verify `send_message` with `thread_id` produces properly threaded replies in Gmail

🤖 Generated with [Claude Code](https://claude.com/claude-code)