### PR TITLE
feat: add Dropbox adapter

### DIFF
--- a/internal/adapters/definitions/dropbox.yaml
+++ b/internal/adapters/definitions/dropbox.yaml
@@ -1,0 +1,262 @@
+service:
+  id: dropbox
+  display_name: Dropbox
+  description: "List, search, read, and manage files and folders in Dropbox. Upload and download content, move and copy files."
+  setup_url: "https://www.dropbox.com/developers/apps"
+  icon_svg: '<svg viewBox="0 0 24 24"><path fill="#0061FF" d="M6 1.807L0 5.629l6 3.822 6-3.822zM18 1.807l-6 3.822 6 3.822 6-3.822zM0 13.274l6 3.822 6-3.822-6-3.822zM18 9.452l-6 3.822 6 3.822 6-3.822zM6 18.339l6 3.822 6-3.822-6-3.822z"/></svg>'
+  identity:
+    endpoint: "https://api.dropboxapi.com/2/users/get_current_account"
+    method: POST
+    field: "email"
+
+auth:
+  type: api_key
+  header: "Authorization"
+  header_prefix: "Bearer "
+  pkce_flow:
+    client_id: "0uyiqcfgyda77uu"
+    client_id_env: "DROPBOX_CLIENT_ID"
+    scopes: []
+    authorize_url: "https://www.dropbox.com/oauth2/authorize"
+    token_url: "https://api.dropboxapi.com/oauth2/token"
+    localhost_redirect: true
+
+api:
+  base_url: "https://api.dropboxapi.com/2"
+  type: rest
+
+verification_hints: |
+  Dropbox actions operate on the user's personal or team Dropbox storage.
+  File paths start with "" (root) or a specific folder path like "/Documents".
+  Destructive actions (delete, move) are permanent unless the user has version history enabled.
+
+actions:
+  list_folder:
+    display_name: "List folder"
+    risk: { category: read, sensitivity: low, description: "List files and folders in a Dropbox directory" }
+    method: POST
+    path: "/files/list_folder"
+    params:
+      path:
+        type: string
+        default: ""
+        location: body
+        description: "Folder path (use empty string \"\" for root)"
+      limit:
+        type: int
+        default: 25
+        max: 100
+        location: body
+    response:
+      data_path: "entries"
+      fields:
+        - { name: ".tag", rename: type }
+        - { name: name }
+        - { name: path_display, rename: path }
+        - { name: id }
+        - { name: size, nullable: true }
+        - { name: client_modified, nullable: true }
+      summary: "{{len .Data}} item(s)"
+
+  get_metadata:
+    display_name: "Get file metadata"
+    risk: { category: read, sensitivity: low, description: "Get metadata for a file or folder in Dropbox" }
+    method: POST
+    path: "/files/get_metadata"
+    params:
+      path:
+        type: string
+        required: true
+        location: body
+    response:
+      fields:
+        - { name: ".tag", rename: type }
+        - { name: name }
+        - { name: path_display, rename: path }
+        - { name: id }
+        - { name: size, nullable: true }
+        - { name: client_modified, nullable: true }
+        - { name: server_modified, nullable: true }
+        - { name: content_hash, nullable: true }
+      summary: "{{.name}}"
+
+  download_file:
+    display_name: "Download file"
+    risk: { category: read, sensitivity: low, description: "Download a file's content from Dropbox" }
+    override: go
+    params:
+      path:
+        type: string
+        required: true
+        description: "File path in Dropbox (e.g. /Documents/report.pdf)"
+
+  upload_file:
+    display_name: "Upload file"
+    risk: { category: write, sensitivity: medium, description: "Upload a file to Dropbox" }
+    override: go
+    params:
+      path:
+        type: string
+        required: true
+        description: "Destination path in Dropbox (e.g. /Documents/report.txt)"
+      content:
+        type: string
+        required: true
+        description: "File content to upload"
+      mode:
+        type: string
+        description: "Write mode: add (default, fails if exists) or overwrite"
+
+  search:
+    display_name: "Search files"
+    risk: { category: search, sensitivity: low, description: "Search for files and folders in Dropbox" }
+    method: POST
+    path: "/files/search_v2"
+    params:
+      query:
+        type: string
+        required: true
+        location: body
+      options:
+        type: object
+        location: body
+        description: "Search options (e.g. path, max_results, file_extensions)"
+    response:
+      data_path: "matches"
+      fields:
+        - { name: name, path: "metadata.metadata.name" }
+        - { name: path, path: "metadata.metadata.path_display" }
+        - { name: type, expr: 'metadata["metadata"][".tag"]' }
+        - { name: id, path: "metadata.metadata.id" }
+        - { name: size, path: "metadata.metadata.size", nullable: true }
+      summary: "{{len .Data}} match(es)"
+
+  create_folder:
+    display_name: "Create folder"
+    risk: { category: write, sensitivity: low, description: "Create a new folder in Dropbox" }
+    method: POST
+    path: "/files/create_folder_v2"
+    params:
+      path:
+        type: string
+        required: true
+        location: body
+        description: "Path of the new folder (e.g. /Documents/NewFolder)"
+      autorename:
+        type: bool
+        default: false
+        location: body
+    response:
+      data_path: "metadata"
+      fields:
+        - { name: name }
+        - { name: path_display, rename: path }
+        - { name: id }
+      summary: "Created folder {{.name}}"
+
+  delete:
+    display_name: "Delete file or folder"
+    risk: { category: delete, sensitivity: high, description: "Permanently delete a file or folder from Dropbox" }
+    method: POST
+    path: "/files/delete_v2"
+    params:
+      path:
+        type: string
+        required: true
+        location: body
+    response:
+      data_path: "metadata"
+      fields:
+        - { name: name }
+        - { name: path_display, rename: path }
+      summary: "Deleted {{.name}}"
+
+  move:
+    display_name: "Move file or folder"
+    risk: { category: write, sensitivity: medium, description: "Move a file or folder to a new location in Dropbox" }
+    method: POST
+    path: "/files/move_v2"
+    params:
+      from_path:
+        type: string
+        required: true
+        location: body
+      to_path:
+        type: string
+        required: true
+        location: body
+      autorename:
+        type: bool
+        default: false
+        location: body
+    response:
+      data_path: "metadata"
+      fields:
+        - { name: name }
+        - { name: path_display, rename: path }
+      summary: "Moved to {{.path}}"
+
+  copy:
+    display_name: "Copy file or folder"
+    risk: { category: write, sensitivity: medium, description: "Copy a file or folder to a new location in Dropbox" }
+    method: POST
+    path: "/files/copy_v2"
+    params:
+      from_path:
+        type: string
+        required: true
+        location: body
+      to_path:
+        type: string
+        required: true
+        location: body
+      autorename:
+        type: bool
+        default: false
+        location: body
+    response:
+      data_path: "metadata"
+      fields:
+        - { name: name }
+        - { name: path_display, rename: path }
+        - { name: id }
+      summary: "Copied to {{.path}}"
+
+  get_sharing_link:
+    display_name: "Create sharing link"
+    risk: { category: write, sensitivity: medium, description: "Create a shared link for a file or folder in Dropbox" }
+    method: POST
+    path: "/sharing/create_shared_link_with_settings"
+    params:
+      path:
+        type: string
+        required: true
+        location: body
+      settings:
+        type: object
+        location: body
+        description: "Sharing settings (e.g. requested_visibility, audience, access)"
+    response:
+      fields:
+        - { name: url }
+        - { name: name }
+        - { name: path_lower, rename: path }
+      summary: "{{.url}}"
+
+  list_shared_links:
+    display_name: "List shared links"
+    risk: { category: read, sensitivity: low, description: "List shared links for a file or folder" }
+    method: POST
+    path: "/sharing/list_shared_links"
+    params:
+      path:
+        type: string
+        location: body
+        description: "File or folder path (omit to list all shared links)"
+    response:
+      data_path: "links"
+      fields:
+        - { name: url }
+        - { name: name }
+        - { name: path_lower, rename: path }
+      summary: "{{len .Data}} link(s)"

--- a/internal/adapters/dropbox/adapter.go
+++ b/internal/adapters/dropbox/adapter.go
@@ -8,7 +8,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
+	"path/filepath"
 	"strings"
 
 	"github.com/clawvisor/clawvisor/internal/adapters/format"
@@ -78,8 +80,12 @@ func (a *Adapter) downloadFile(ctx context.Context, token string, params map[str
 		_ = json.Unmarshal([]byte(resultHeader), &meta)
 	}
 
-	// Determine if content is text or binary.
-	contentType := resp.Header.Get("Content-Type")
+	// Infer content type from filename — Dropbox always returns
+	// application/octet-stream regardless of actual file type.
+	contentType := mime.TypeByExtension(filepath.Ext(meta.Name))
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
 	result := map[string]any{
 		"name":         format.SanitizeText(meta.Name, format.MaxFieldLen),
 		"id":           meta.ID,

--- a/internal/adapters/dropbox/adapter.go
+++ b/internal/adapters/dropbox/adapter.go
@@ -1,0 +1,195 @@
+// Package dropbox implements the Clawvisor adapter for Dropbox file
+// upload and download operations that require the content endpoint.
+package dropbox
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/clawvisor/clawvisor/internal/adapters/format"
+	"github.com/clawvisor/clawvisor/pkg/adapters"
+)
+
+const contentURL = "https://content.dropboxapi.com/2"
+
+// Adapter handles Dropbox actions that require the content endpoint
+// (download and upload), which use Dropbox-API-Arg headers instead
+// of JSON bodies.
+type Adapter struct{}
+
+func New() *Adapter { return &Adapter{} }
+
+// Execute dispatches to the appropriate action handler.
+func (a *Adapter) Execute(ctx context.Context, req adapters.Request) (*adapters.Result, error) {
+	token, err := extractToken(req.Credential)
+	if err != nil {
+		return nil, fmt.Errorf("dropbox: %w", err)
+	}
+	switch req.Action {
+	case "download_file":
+		return a.downloadFile(ctx, token, req.Params)
+	case "upload_file":
+		return a.uploadFile(ctx, token, req.Params)
+	default:
+		return nil, fmt.Errorf("dropbox: unsupported action %q", req.Action)
+	}
+}
+
+// ── download_file ────────────────────────────────────────────────────────────
+
+func (a *Adapter) downloadFile(ctx context.Context, token string, params map[string]any) (*adapters.Result, error) {
+	path, _ := params["path"].(string)
+	if path == "" {
+		return nil, fmt.Errorf("dropbox download_file: path is required")
+	}
+
+	apiArg, _ := json.Marshal(map[string]string{"path": path})
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, contentURL+"/files/download", nil)
+	if err != nil {
+		return nil, fmt.Errorf("dropbox download_file: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Dropbox-API-Arg", string(apiArg))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("dropbox download_file: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, int64(format.MaxBodyLen)))
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("dropbox download_file: status %d: %s", resp.StatusCode, truncate(string(body), 200))
+	}
+
+	// Dropbox returns file metadata in the Dropbox-API-Result header.
+	var meta struct {
+		Name string `json:"name"`
+		ID   string `json:"id"`
+		Size int64  `json:"size"`
+	}
+	if resultHeader := resp.Header.Get("Dropbox-API-Result"); resultHeader != "" {
+		_ = json.Unmarshal([]byte(resultHeader), &meta)
+	}
+
+	// Determine if content is text or binary.
+	contentType := resp.Header.Get("Content-Type")
+	result := map[string]any{
+		"name":         format.SanitizeText(meta.Name, format.MaxFieldLen),
+		"id":           meta.ID,
+		"size":         meta.Size,
+		"content_type": contentType,
+	}
+
+	if isTextContent(contentType) {
+		result["content"] = format.SanitizeText(string(body), format.MaxBodyLen)
+	} else {
+		result["encoding"] = "base64"
+		result["content"] = base64.StdEncoding.EncodeToString(body)
+	}
+
+	return &adapters.Result{
+		Summary: format.Summary("Downloaded %s (%d bytes)", meta.Name, meta.Size),
+		Data:    result,
+	}, nil
+}
+
+// ── upload_file ──────────────────────────────────────────────────────────────
+
+func (a *Adapter) uploadFile(ctx context.Context, token string, params map[string]any) (*adapters.Result, error) {
+	path, _ := params["path"].(string)
+	content, _ := params["content"].(string)
+	if path == "" {
+		return nil, fmt.Errorf("dropbox upload_file: path is required")
+	}
+	if content == "" {
+		return nil, fmt.Errorf("dropbox upload_file: content is required")
+	}
+
+	mode := "add"
+	if m, ok := params["mode"].(string); ok && m != "" {
+		mode = m
+	}
+
+	apiArg, _ := json.Marshal(map[string]any{
+		"path":       path,
+		"mode":       mode,
+		"autorename": false,
+		"mute":       false,
+	})
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, contentURL+"/files/upload", strings.NewReader(content))
+	if err != nil {
+		return nil, fmt.Errorf("dropbox upload_file: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Dropbox-API-Arg", string(apiArg))
+	req.Header.Set("Content-Type", "application/octet-stream")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("dropbox upload_file: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("dropbox upload_file: status %d: %s", resp.StatusCode, truncate(string(body), 200))
+	}
+
+	var uploaded struct {
+		Name         string `json:"name"`
+		ID           string `json:"id"`
+		PathDisplay  string `json:"path_display"`
+		Size         int64  `json:"size"`
+		ContentHash  string `json:"content_hash"`
+	}
+	if err := json.Unmarshal(body, &uploaded); err != nil {
+		return nil, fmt.Errorf("dropbox upload_file: parsing response: %w", err)
+	}
+
+	return &adapters.Result{
+		Summary: format.Summary("Uploaded %s (%d bytes)", uploaded.Name, uploaded.Size),
+		Data: map[string]any{
+			"name":         format.SanitizeText(uploaded.Name, format.MaxFieldLen),
+			"id":           uploaded.ID,
+			"path":         uploaded.PathDisplay,
+			"size":         uploaded.Size,
+			"content_hash": uploaded.ContentHash,
+		},
+	}, nil
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+func extractToken(credBytes []byte) (string, error) {
+	var cred struct {
+		Token string `json:"token"`
+	}
+	if err := json.Unmarshal(credBytes, &cred); err != nil {
+		return "", fmt.Errorf("parsing credential: %w", err)
+	}
+	if cred.Token == "" {
+		return "", fmt.Errorf("credential missing token")
+	}
+	return cred.Token, nil
+}
+
+func isTextContent(contentType string) bool {
+	return strings.HasPrefix(contentType, "text/") ||
+		contentType == "application/json" ||
+		contentType == "application/xml"
+}
+
+func truncate(s string, max int) string {
+	if len(s) > max {
+		return s[:max] + "..."
+	}
+	return s
+}

--- a/pkg/adapters/yamlloader/loader_test.go
+++ b/pkg/adapters/yamlloader/loader_test.go
@@ -29,6 +29,7 @@ func TestLoadEmbeddedDefinitions(t *testing.T) {
 		"google.calendar":  false,
 		"google.drive":     false,
 		"google.contacts":  false,
+		"dropbox":          false,
 	}
 
 	for _, a := range adapters {

--- a/pkg/clawvisor/defaults.go
+++ b/pkg/clawvisor/defaults.go
@@ -21,6 +21,7 @@ import (
 	"github.com/clawvisor/clawvisor/internal/adapters/definitions"
 	imessageadapter "github.com/clawvisor/clawvisor/internal/adapters/apple/imessage"
 	sqladapter "github.com/clawvisor/clawvisor/internal/adapters/sql"
+	dropboxadapter "github.com/clawvisor/clawvisor/internal/adapters/dropbox"
 	driveadapter "github.com/clawvisor/clawvisor/internal/adapters/google/drive"
 	contactsadapter "github.com/clawvisor/clawvisor/internal/adapters/google/contacts"
 	gmailadapter "github.com/clawvisor/clawvisor/internal/adapters/google/gmail"
@@ -164,6 +165,11 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 	}
 	contacts := contactsadapter.New(oauthProvider)
 	goOverrides["google.contacts:list_contacts"] = contacts.Execute
+
+	dbx := dropboxadapter.New()
+	for _, action := range []string{"download_file", "upload_file"} {
+		goOverrides["dropbox:"+action] = dbx.Execute
+	}
 
 	// Build adapter loading source (for startup) and generator factory (for per-request use).
 	var adapterSource yamlloader.UserAdapterSource


### PR DESCRIPTION
## Summary
- Adds a Dropbox adapter with PKCE OAuth flow and 12 actions: list_folder, get_metadata, search, create_folder, delete, move, copy, get_sharing_link, list_shared_links (YAML-driven), plus download_file and upload_file (Go overrides via `content.dropboxapi.com`)
- Wires up Go overrides in `defaults.go` and adds Dropbox to the loader test's expected service list
- Uses `localhost_redirect: true` to skip the relay for the OAuth callback

## Test plan
- [x] `go build ./internal/adapters/dropbox/...` passes
- [x] `go vet ./internal/adapters/dropbox/...` passes
- [x] `go test ./pkg/adapters/yamlloader/...` passes (definition loads and validates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)