### PR TITLE
Add Telegram buttons for connection approvals

### DIFF
--- a/internal/api/handlers/connections.go
+++ b/internal/api/handlers/connections.go
@@ -25,11 +25,11 @@ var (
 )
 
 const (
-	connectionRequestExpiry   = 5 * time.Minute
-	connectionTokenWindow     = 5 * time.Minute
-	maxPendingRequests        = 10
-	pollTimeout               = 30 * time.Second
-	maxConcurrentPolls  int64 = 50
+	connectionRequestExpiry       = 5 * time.Minute
+	connectionTokenWindow         = 5 * time.Minute
+	maxPendingRequests            = 10
+	pollTimeout                   = 30 * time.Second
+	maxConcurrentPolls      int64 = 50
 )
 
 // ConnectionsHandler manages agent connection request lifecycle.
@@ -38,6 +38,7 @@ type ConnectionsHandler struct {
 	notifier    notify.Notifier
 	eventHub    events.EventHub
 	logger      *slog.Logger
+	baseURL     string
 	multiTenant bool
 
 	// Token cache for approved agent tokens. Backed by either in-memory
@@ -58,12 +59,13 @@ type approvedToken struct {
 }
 
 func NewConnectionsHandler(st store.Store, notifier notify.Notifier,
-	eventHub events.EventHub, logger *slog.Logger, multiTenant bool) *ConnectionsHandler {
+	eventHub events.EventHub, logger *slog.Logger, baseURL string, multiTenant bool) *ConnectionsHandler {
 	return &ConnectionsHandler{
 		st:          st,
 		notifier:    notifier,
 		eventHub:    eventHub,
 		logger:      logger,
+		baseURL:     baseURL,
 		multiTenant: multiTenant,
 		tokenCache:  newMemoryTokenCache(connectionTokenWindow),
 		ipPolls:     make(map[string]int),
@@ -143,13 +145,19 @@ func (h *ConnectionsHandler) RequestConnect(w http.ResponseWriter, r *http.Reque
 		h.eventHub.Publish(owner.ID, events.Event{Type: "queue"})
 	}
 	if h.notifier != nil {
-		if _, err := h.notifier.SendConnectionRequest(r.Context(), notify.ConnectionRequest{
+		approveURL := fmt.Sprintf("%s/dashboard/agents?action=approve&connection_id=%s", h.baseURL, req.ID)
+		denyURL := fmt.Sprintf("%s/dashboard/agents?action=deny&connection_id=%s", h.baseURL, req.ID)
+		if msgID, err := h.notifier.SendConnectionRequest(r.Context(), notify.ConnectionRequest{
 			ConnectionID: req.ID,
 			UserID:       owner.ID,
 			AgentName:    body.Name,
 			IPAddress:    r.RemoteAddr,
+			ApproveURL:   approveURL,
+			DenyURL:      denyURL,
 		}); err != nil {
 			h.logger.Warn("failed to send connection request notification", "err", err)
+		} else if msgID != "" {
+			_ = h.st.SaveNotificationMessage(r.Context(), "connection", req.ID, "telegram", msgID)
 		}
 	}
 
@@ -198,8 +206,9 @@ func (h *ConnectionsHandler) PollStatus(w http.ResponseWriter, r *http.Request) 
 
 		// Check expiry.
 		if cr.Status == "pending" && time.Now().After(cr.ExpiresAt) {
-			_ = h.st.UpdateConnectionRequestStatus(r.Context(), id, "expired", "")
-			cr.Status = "expired"
+			if err := h.expireByID(r.Context(), id, cr.UserID); err == nil {
+				cr.Status = "expired"
+			}
 		}
 
 		if cr.Status == "pending" {
@@ -303,8 +312,9 @@ func (h *ConnectionsHandler) waitForConnectionResolution(ctx context.Context, co
 				return &store.ConnectionRequest{ID: connID, Status: "pending"}, false
 			}
 			if cr.Status == "pending" && time.Now().After(cr.ExpiresAt) {
-				_ = h.st.UpdateConnectionRequestStatus(c, connID, "expired", "")
-				cr.Status = "expired"
+				if err := h.expireByID(c, connID, cr.UserID); err == nil {
+					cr.Status = "expired"
+				}
 			}
 			return cr, cr.Status != "pending"
 		},
@@ -357,7 +367,7 @@ func (h *ConnectionsHandler) ApproveByID(ctx context.Context, id, userID string)
 		return "", errAlreadyResolved
 	}
 	if time.Now().After(cr.ExpiresAt) {
-		_ = h.st.UpdateConnectionRequestStatus(ctx, id, "expired", "")
+		_ = h.expireByID(ctx, id, userID)
 		return "", errExpired
 	}
 
@@ -376,6 +386,8 @@ func (h *ConnectionsHandler) ApproveByID(ctx context.Context, id, userID string)
 	}
 
 	h.tokenCache.Store(id, rawToken)
+	h.decrementNotifierPolling(userID)
+	h.updateNotificationMsg(ctx, id, userID, "✅ <b>Approved</b> — agent connected.")
 
 	if h.eventHub != nil {
 		h.eventHub.Publish(userID, events.Event{Type: "queue"})
@@ -428,10 +440,47 @@ func (h *ConnectionsHandler) DenyByID(ctx context.Context, id, userID string) er
 		return fmt.Errorf("update status: %w", err)
 	}
 
+	h.decrementNotifierPolling(userID)
+	h.updateNotificationMsg(ctx, id, userID, "❌ <b>Denied</b> — connection rejected.")
+
 	if h.eventHub != nil {
 		h.eventHub.Publish(userID, events.Event{Type: "queue"})
 	}
 	return nil
+}
+
+func (h *ConnectionsHandler) expireByID(ctx context.Context, id, userID string) error {
+	if err := h.st.UpdateConnectionRequestStatus(ctx, id, "expired", ""); err != nil {
+		return err
+	}
+	h.decrementNotifierPolling(userID)
+	h.updateNotificationMsg(ctx, id, userID, "⏰ <b>Expired</b> — connection request timed out.")
+	if h.eventHub != nil {
+		h.eventHub.Publish(userID, events.Event{Type: "queue"})
+	}
+	return nil
+}
+
+func (h *ConnectionsHandler) decrementNotifierPolling(userID string) {
+	if h.notifier == nil {
+		return
+	}
+	if pd, ok := h.notifier.(notify.PollingDecrementer); ok {
+		pd.DecrementPolling(userID)
+	}
+}
+
+func (h *ConnectionsHandler) updateNotificationMsg(ctx context.Context, targetID, userID, text string) {
+	if h.notifier == nil {
+		return
+	}
+	msgID, err := h.st.GetNotificationMessage(ctx, "connection", targetID, "telegram")
+	if err != nil {
+		return
+	}
+	if err := h.notifier.UpdateMessage(ctx, userID, msgID, text); err != nil {
+		h.logger.Warn("telegram message update failed", "err", err, "target_type", "connection", "target_id", targetID)
+	}
 }
 
 // List handles GET /api/agents/connections (user JWT).
@@ -449,4 +498,3 @@ func (h *ConnectionsHandler) List(w http.ResponseWriter, r *http.Request) {
 	}
 	writeJSON(w, http.StatusOK, requests)
 }
-

--- a/internal/api/handlers/connections_test.go
+++ b/internal/api/handlers/connections_test.go
@@ -1,0 +1,150 @@
+package handlers
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	sqlitestore "github.com/clawvisor/clawvisor/internal/store/sqlite"
+	"github.com/clawvisor/clawvisor/pkg/notify"
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+type testNotifier struct {
+	decremented int
+	updated     []string
+}
+
+func (n *testNotifier) SendApprovalRequest(context.Context, notify.ApprovalRequest) (string, error) {
+	return "", nil
+}
+
+func (n *testNotifier) SendActivationRequest(context.Context, notify.ActivationRequest) error {
+	return nil
+}
+
+func (n *testNotifier) SendTaskApprovalRequest(context.Context, notify.TaskApprovalRequest) (string, error) {
+	return "", nil
+}
+
+func (n *testNotifier) SendScopeExpansionRequest(context.Context, notify.ScopeExpansionRequest) (string, error) {
+	return "", nil
+}
+
+func (n *testNotifier) UpdateMessage(_ context.Context, _ string, _ string, text string) error {
+	n.updated = append(n.updated, text)
+	return nil
+}
+
+func (n *testNotifier) SendTestMessage(context.Context, string) error {
+	return nil
+}
+
+func (n *testNotifier) SendConnectionRequest(context.Context, notify.ConnectionRequest) (string, error) {
+	return "", nil
+}
+
+func (n *testNotifier) SendAlert(context.Context, string, string) error {
+	return nil
+}
+
+func (n *testNotifier) DecrementPolling(string) {
+	n.decremented++
+}
+
+func TestConnectionsHandlerApproveUpdatesNotificationState(t *testing.T) {
+	ctx := context.Background()
+
+	db, err := sqlitestore.New(ctx, t.TempDir()+"/test.db")
+	if err != nil {
+		t.Fatalf("sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	st := sqlitestore.NewStore(db)
+	user, err := st.CreateUser(ctx, "owner@test.example", "hash")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	req := &store.ConnectionRequest{
+		UserID:    user.ID,
+		Name:      "Claude Code",
+		Status:    "pending",
+		ExpiresAt: time.Now().Add(5 * time.Minute),
+	}
+	if err := st.CreateConnectionRequest(ctx, req); err != nil {
+		t.Fatalf("CreateConnectionRequest: %v", err)
+	}
+	if err := st.SaveNotificationMessage(ctx, "connection", req.ID, "telegram", "msg-1"); err != nil {
+		t.Fatalf("SaveNotificationMessage: %v", err)
+	}
+
+	notifier := &testNotifier{}
+	h := NewConnectionsHandler(st, notifier, nil, slog.Default(), "http://example.com", false)
+
+	agentID, err := h.ApproveByID(ctx, req.ID, user.ID)
+	if err != nil {
+		t.Fatalf("ApproveByID: %v", err)
+	}
+	if agentID == "" {
+		t.Fatal("expected agent ID")
+	}
+	if notifier.decremented != 1 {
+		t.Fatalf("expected polling decrement once, got %d", notifier.decremented)
+	}
+	if len(notifier.updated) != 1 || notifier.updated[0] != "✅ <b>Approved</b> — agent connected." {
+		t.Fatalf("unexpected notification updates: %#v", notifier.updated)
+	}
+}
+
+func TestConnectionsHandlerExpireUpdatesNotificationState(t *testing.T) {
+	ctx := context.Background()
+
+	db, err := sqlitestore.New(ctx, t.TempDir()+"/test.db")
+	if err != nil {
+		t.Fatalf("sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	st := sqlitestore.NewStore(db)
+	user, err := st.CreateUser(ctx, "owner@test.example", "hash")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	req := &store.ConnectionRequest{
+		UserID:    user.ID,
+		Name:      "Claude Code",
+		Status:    "pending",
+		ExpiresAt: time.Now().Add(-time.Minute),
+	}
+	if err := st.CreateConnectionRequest(ctx, req); err != nil {
+		t.Fatalf("CreateConnectionRequest: %v", err)
+	}
+	if err := st.SaveNotificationMessage(ctx, "connection", req.ID, "telegram", "msg-1"); err != nil {
+		t.Fatalf("SaveNotificationMessage: %v", err)
+	}
+
+	notifier := &testNotifier{}
+	h := NewConnectionsHandler(st, notifier, nil, slog.Default(), "http://example.com", false)
+
+	if err := h.expireByID(ctx, req.ID, user.ID); err != nil {
+		t.Fatalf("expireByID: %v", err)
+	}
+
+	got, err := st.GetConnectionRequest(ctx, req.ID)
+	if err != nil {
+		t.Fatalf("GetConnectionRequest: %v", err)
+	}
+	if got.Status != "expired" {
+		t.Fatalf("expected expired status, got %q", got.Status)
+	}
+	if notifier.decremented != 1 {
+		t.Fatalf("expected polling decrement once, got %d", notifier.decremented)
+	}
+	if len(notifier.updated) != 1 || notifier.updated[0] != "⏰ <b>Expired</b> — connection request timed out." {
+		t.Fatalf("unexpected notification updates: %#v", notifier.updated)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1,42 +1,42 @@
 package api
 
 import (
+	"archive/zip"
 	"context"
 	"crypto/ecdh"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
-	"archive/zip"
 	"io/fs"
 	"log/slog"
 	"net"
 	"net/http"
-	"strings"
 	"os"
+	"strings"
 	"time"
 
-	"github.com/clawvisor/clawvisor/pkg/adapters"
 	"github.com/clawvisor/clawvisor/internal/api/handlers"
 	"github.com/clawvisor/clawvisor/internal/api/middleware"
 	intauth "github.com/clawvisor/clawvisor/internal/auth"
 	"github.com/clawvisor/clawvisor/internal/events"
 	"github.com/clawvisor/clawvisor/internal/feedback"
-	"github.com/clawvisor/clawvisor/internal/llm"
 	"github.com/clawvisor/clawvisor/internal/groupchat"
+	"github.com/clawvisor/clawvisor/internal/intent"
+	"github.com/clawvisor/clawvisor/internal/llm"
 	"github.com/clawvisor/clawvisor/internal/mcp"
 	mcpoauth "github.com/clawvisor/clawvisor/internal/mcp/oauth"
 	"github.com/clawvisor/clawvisor/internal/notify/push"
-	pkgauth "github.com/clawvisor/clawvisor/pkg/auth"
-	"github.com/clawvisor/clawvisor/pkg/config"
-	"github.com/clawvisor/clawvisor/pkg/version"
-	"github.com/clawvisor/clawvisor/internal/intent"
-	"github.com/clawvisor/clawvisor/internal/taskrisk"
-	"github.com/clawvisor/clawvisor/pkg/notify"
 	"github.com/clawvisor/clawvisor/internal/ratelimit"
 	"github.com/clawvisor/clawvisor/internal/relay"
+	"github.com/clawvisor/clawvisor/internal/taskrisk"
+	"github.com/clawvisor/clawvisor/pkg/adapters"
+	pkgauth "github.com/clawvisor/clawvisor/pkg/auth"
+	"github.com/clawvisor/clawvisor/pkg/config"
+	"github.com/clawvisor/clawvisor/pkg/notify"
 	"github.com/clawvisor/clawvisor/pkg/store"
 	"github.com/clawvisor/clawvisor/pkg/vault"
+	"github.com/clawvisor/clawvisor/pkg/version"
 	skillfiles "github.com/clawvisor/clawvisor/skills"
 	webfs "github.com/clawvisor/clawvisor/web"
 
@@ -59,16 +59,16 @@ type Server struct {
 	magicStore pkgauth.MagicTokenStore
 
 	// Extension points for open-core customization.
-	extraRoutes func(*http.ServeMux, Dependencies)
-	wrapRoutes  func(http.Handler) http.Handler
+	extraRoutes           func(*http.ServeMux, Dependencies)
+	wrapRoutes            func(http.Handler) http.Handler
 	features              FeatureSet
 	skipBuiltinAuthRoutes bool
 	quiet                 bool // suppress user-facing messages (e.g. during daemon setup)
 
 	// Relay/E2E keys.
-	x25519Key    *ecdh.PrivateKey // X25519 key for E2E encryption of gateway requests
-	daemonID     string           // relay daemon ID
-	ed25519PubB64 string          // base64-encoded Ed25519 public key for .well-known
+	x25519Key     *ecdh.PrivateKey // X25519 key for E2E encryption of gateway requests
+	daemonID      string           // relay daemon ID
+	ed25519PubB64 string           // base64-encoded Ed25519 public key for .well-known
 
 	// Handler references for background goroutines and decision dispatch.
 	approvalsHandler   *handlers.ApprovalsHandler
@@ -76,10 +76,10 @@ type Server struct {
 	connectionsHandler *handlers.ConnectionsHandler
 	devicesHandler     *handlers.DevicesHandler
 
-	pushNotifier *push.Notifier                // concrete push notifier; may be nil
-	msgBuffer    groupchat.Buffer // group chat message buffer; may be nil
-	decisionBus  notify.DecisionBus      // cross-instance decision delivery; may be nil
-	gatewayHooks *GatewayHooks  // cloud-injected gateway authorization hooks; may be nil
+	pushNotifier *push.Notifier     // concrete push notifier; may be nil
+	msgBuffer    groupchat.Buffer   // group chat message buffer; may be nil
+	decisionBus  notify.DecisionBus // cross-instance decision delivery; may be nil
+	gatewayHooks *GatewayHooks      // cloud-injected gateway authorization hooks; may be nil
 
 	eventHub    events.EventHub
 	mcpServer   *mcp.Server
@@ -557,7 +557,7 @@ func (s *Server) routes() http.Handler {
 	}
 
 	// Connection requests (unauthenticated — agents requesting access)
-	connectionsHandler := handlers.NewConnectionsHandler(s.store, s.notifier, s.eventHub, s.logger, s.features.MultiTenant)
+	connectionsHandler := handlers.NewConnectionsHandler(s.store, s.notifier, s.eventHub, s.logger, baseURL, s.features.MultiTenant)
 	if s.tokenCache != nil {
 		connectionsHandler.SetTokenCache(s.tokenCache)
 	}
@@ -654,9 +654,9 @@ func (s *Server) routes() http.Handler {
 
 	// Services / OAuth (user JWT, rate-limited)
 	mux.Handle("GET /api/services", user(servicesHandler.List))
-	mux.Handle("GET /api/oauth/url", userOAuthRL(servicesHandler.OAuthGetURL))     // fetch → returns {"url":"..."}
-	mux.Handle("GET /api/oauth/start", userOAuthRL(servicesHandler.OAuthStart))    // kept for compat
-	mux.HandleFunc("GET /api/oauth/callback", servicesHandler.OAuthCallback) // no auth: browser redirect
+	mux.Handle("GET /api/oauth/url", userOAuthRL(servicesHandler.OAuthGetURL))  // fetch → returns {"url":"..."}
+	mux.Handle("GET /api/oauth/start", userOAuthRL(servicesHandler.OAuthStart)) // kept for compat
+	mux.HandleFunc("GET /api/oauth/callback", servicesHandler.OAuthCallback)    // no auth: browser redirect
 	mux.Handle("POST /api/services/{serviceID}/activate", user(servicesHandler.Activate))
 	mux.Handle("POST /api/services/{serviceID}/activate-key", user(servicesHandler.ActivateWithKey))
 	mux.Handle("POST /api/services/{serviceID}/deactivate", user(servicesHandler.Deactivate))
@@ -802,13 +802,13 @@ func (s *Server) routes() http.Handler {
 		// No auth middleware here: the MCP handler already authenticates the agent
 		// and injects it into the context before tool execution.
 		mcpHandlers := map[string]http.Handler{
-			"GET /api/skill/catalog":                           http.HandlerFunc(skillHandler.Catalog),
-			"POST /api/tasks":                                  http.HandlerFunc(tasksHandler.Create),
-			"GET /api/tasks/{id}":                              http.HandlerFunc(tasksHandler.Get),
-			"POST /api/tasks/{id}/complete":                    http.HandlerFunc(tasksHandler.Complete),
-			"POST /api/tasks/{id}/expand":                      http.HandlerFunc(tasksHandler.Expand),
-			"POST /api/gateway/request":                        http.HandlerFunc(gatewayHandler.HandleRequest),
-			"POST /api/gateway/request/{request_id}/execute":   http.HandlerFunc(gatewayHandler.HandleExecuteApproved),
+			"GET /api/skill/catalog":                         http.HandlerFunc(skillHandler.Catalog),
+			"POST /api/tasks":                                http.HandlerFunc(tasksHandler.Create),
+			"GET /api/tasks/{id}":                            http.HandlerFunc(tasksHandler.Get),
+			"POST /api/tasks/{id}/complete":                  http.HandlerFunc(tasksHandler.Complete),
+			"POST /api/tasks/{id}/expand":                    http.HandlerFunc(tasksHandler.Expand),
+			"POST /api/gateway/request":                      http.HandlerFunc(gatewayHandler.HandleRequest),
+			"POST /api/gateway/request/{request_id}/execute": http.HandlerFunc(gatewayHandler.HandleExecuteApproved),
 		}
 
 		// Register adapter generation routes in MCP handler map if enabled.

--- a/internal/notify/telegram/telegram.go
+++ b/internal/notify/telegram/telegram.go
@@ -35,8 +35,8 @@ type Notifier struct {
 	decisionCh    chan notify.CallbackDecision
 	serverCtx     context.Context
 	msgBuffer     groupchat.Buffer // may be nil; set via SetMessageBuffer
-	pendingGroups sync.Map                // userID → *pendingGroupList (in-memory fallback)
-	groupPairings sync.Map                // sessionID → *groupPairingSession (in-memory fallback)
+	pendingGroups sync.Map         // userID → *pendingGroupList (in-memory fallback)
+	groupPairings sync.Map         // sessionID → *groupPairingSession (in-memory fallback)
 
 	// Redis-backed stores for multi-instance mode. When nil, in-memory fallbacks are used.
 	pendingGroupStore PendingGroupStore
@@ -454,12 +454,32 @@ func (n *Notifier) SendConnectionRequest(ctx context.Context, req notify.Connect
 	if err != nil {
 		return "", err
 	}
-	text := fmt.Sprintf("🔗 <b>Agent Connection Request</b>\n\nAgent <b>%s</b> is requesting to connect from %s.",
-		req.AgentName, req.IPAddress)
-	msgID, err := n.sendMessage(ctx, botToken, chatID, text, nil)
+
+	text := formatConnectionRequestMessage(req)
+
+	approveID, denyID, tokenErr := n.cbTokens.Generate("connection", req.ConnectionID, req.UserID, chatID, 6*time.Minute)
+	var keyboard any
+	if tokenErr == nil {
+		keyboard = inlineKeyboard([][]inlineButton{{
+			{Text: "✅ Approve Connection", CallbackData: "a:" + approveID},
+			{Text: "❌ Deny Connection", CallbackData: "d:" + denyID},
+		}})
+	} else {
+		keyboard = inlineKeyboard([][]inlineButton{{
+			{Text: "✅ Approve Connection", URL: req.ApproveURL},
+			{Text: "❌ Deny Connection", URL: req.DenyURL},
+		}})
+	}
+
+	msgID, err := n.sendMessage(ctx, botToken, chatID, text, keyboard)
 	if err != nil {
 		return "", fmt.Errorf("telegram: send connection request: %w", err)
 	}
+
+	if tokenErr == nil {
+		n.ensurePolling(req.UserID, botToken, chatID)
+	}
+
 	return msgID, nil
 }
 
@@ -746,6 +766,16 @@ func formatScopeExpansionMessage(req notify.ScopeExpansionRequest) string {
 	}
 
 	return sb.String()
+}
+
+func formatConnectionRequestMessage(req notify.ConnectionRequest) string {
+	return fmt.Sprintf(
+		"🔗 <b>Agent Connection Request</b>\n\n"+
+			"<b>Agent:</b> %s\n"+
+			"<b>Source:</b> %s",
+		html.EscapeString(req.AgentName),
+		html.EscapeString(req.IPAddress),
+	)
 }
 
 // hasVerificationWarning returns true if the approval request contains a non-clean verification result.

--- a/internal/notify/telegram/telegram_test.go
+++ b/internal/notify/telegram/telegram_test.go
@@ -1,0 +1,110 @@
+package telegram
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	sqlitestore "github.com/clawvisor/clawvisor/internal/store/sqlite"
+	"github.com/clawvisor/clawvisor/pkg/notify"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestSendConnectionRequestAddsInlineButtons(t *testing.T) {
+	ctx := context.Background()
+
+	db, err := sqlitestore.New(ctx, t.TempDir()+"/test.db")
+	if err != nil {
+		t.Fatalf("sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	st := sqlitestore.NewStore(db)
+	user, err := st.CreateUser(ctx, "notify@test.example", "hash")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	cfg, _ := json.Marshal(map[string]string{
+		"bot_token": "test-token",
+		"chat_id":   "42",
+	})
+	if err := st.UpsertNotificationConfig(ctx, user.ID, "telegram", cfg); err != nil {
+		t.Fatalf("UpsertNotificationConfig: %v", err)
+	}
+
+	serverCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	n := New(st, serverCtx)
+
+	var payload struct {
+		ReplyMarkup struct {
+			InlineKeyboard [][]struct {
+				Text         string `json:"text"`
+				CallbackData string `json:"callback_data"`
+			} `json:"inline_keyboard"`
+		} `json:"reply_markup"`
+	}
+
+	n.client = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if !strings.Contains(req.URL.Path, "/sendMessage") {
+				t.Fatalf("unexpected telegram API call: %s", req.URL.Path)
+			}
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("ReadAll: %v", err)
+			}
+			if err := json.Unmarshal(body, &payload); err != nil {
+				t.Fatalf("Unmarshal payload: %v", err)
+			}
+			resp := `{"ok":true,"result":{"message_id":123}}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(resp)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+
+	msgID, err := n.SendConnectionRequest(ctx, notifyConnectionRequest(user.ID))
+	if err != nil {
+		t.Fatalf("SendConnectionRequest: %v", err)
+	}
+	if msgID != "123" {
+		t.Fatalf("expected message ID 123, got %q", msgID)
+	}
+
+	if len(payload.ReplyMarkup.InlineKeyboard) != 1 || len(payload.ReplyMarkup.InlineKeyboard[0]) != 2 {
+		t.Fatalf("expected one row with two buttons, got %#v", payload.ReplyMarkup.InlineKeyboard)
+	}
+
+	approve := payload.ReplyMarkup.InlineKeyboard[0][0]
+	deny := payload.ReplyMarkup.InlineKeyboard[0][1]
+	if approve.Text != "✅ Approve Connection" || !strings.HasPrefix(approve.CallbackData, "a:") {
+		t.Fatalf("unexpected approve button: %+v", approve)
+	}
+	if deny.Text != "❌ Deny Connection" || !strings.HasPrefix(deny.CallbackData, "d:") {
+		t.Fatalf("unexpected deny button: %+v", deny)
+	}
+}
+
+func notifyConnectionRequest(userID string) notify.ConnectionRequest {
+	return notify.ConnectionRequest{
+		ConnectionID: "conn-123",
+		UserID:       userID,
+		AgentName:    "Claude Code",
+		IPAddress:    "127.0.0.1:4321",
+		ApproveURL:   "http://example.com/approve",
+		DenyURL:      "http://example.com/deny",
+	}
+}

--- a/internal/notify/telegram/tokens.go
+++ b/internal/notify/telegram/tokens.go
@@ -16,7 +16,7 @@ var (
 
 // callbackEntry is one pair of approve/deny tokens for a single target.
 type callbackEntry struct {
-	Type      string // "approval", "task", "scope_expansion"
+	Type      string // "approval", "task", "scope_expansion", "connection"
 	TargetID  string
 	UserID    string
 	ChatID    string

--- a/pkg/notify/notify.go
+++ b/pkg/notify/notify.go
@@ -52,10 +52,10 @@ type ActivationRequest struct {
 
 // CallbackPayload is posted to the agent's callback URL when a pending request resolves.
 type CallbackPayload struct {
-	RequestID string          `json:"request_id"`
-	Status    string          `json:"status"` // "executed" | "denied" | "timeout"
+	RequestID string           `json:"request_id"`
+	Status    string           `json:"status"` // "executed" | "denied" | "timeout"
 	Result    *adapters.Result `json:"result,omitempty"`
-	AuditID   string          `json:"audit_id"`
+	AuditID   string           `json:"audit_id"`
 }
 
 // TaskApprovalRequest carries the data needed to ask the user to approve a task scope.
@@ -90,6 +90,8 @@ type ConnectionRequest struct {
 	UserID       string
 	AgentName    string
 	IPAddress    string
+	ApproveURL   string
+	DenyURL      string
 }
 
 // PairingSession represents an in-progress Telegram bot pairing.
@@ -112,7 +114,7 @@ type TelegramPairer interface {
 // CallbackDecision is sent by the Telegram notifier when a user taps an
 // inline Approve/Deny button. The server routes this to the appropriate handler.
 type CallbackDecision struct {
-	Type     string // "approval", "task", "scope_expansion"
+	Type     string // "approval", "task", "scope_expansion", "connection"
 	Action   string // "approve" or "deny"
 	TargetID string
 	UserID   string


### PR DESCRIPTION
This adds approve/deny buttons to Telegram connection request notifications so they behave like the existing approval and task flows. It also stores connection notification message IDs and updates Telegram messages when a connection is approved, denied, or expires outside the inline callback path. The notifier contract now carries connection approve/deny URLs and recognizes connection callback decisions. Tests cover both the Telegram payload and the connection handler notification lifecycle.