### PR TITLE
Fix Slack OAuth token_path credential storage

### DIFF
--- a/internal/api/handlers/services.go
+++ b/internal/api/handlers/services.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"html"
 	"log/slog"
@@ -14,6 +15,7 @@ import (
 	"os"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -24,8 +26,8 @@ import (
 	"github.com/clawvisor/clawvisor/internal/api/middleware"
 	"github.com/clawvisor/clawvisor/internal/callback"
 	"github.com/clawvisor/clawvisor/internal/display"
-	"github.com/clawvisor/clawvisor/pkg/adapters"
 	"github.com/clawvisor/clawvisor/internal/events"
+	"github.com/clawvisor/clawvisor/pkg/adapters"
 	"github.com/clawvisor/clawvisor/pkg/adapters/yamldef"
 	"github.com/clawvisor/clawvisor/pkg/store"
 	"github.com/clawvisor/clawvisor/pkg/vault"
@@ -60,6 +62,8 @@ type oauthStateEntry struct {
 	TokenPath    string            // JSON path to access token in token response (e.g. "authed_user.access_token")
 	ExpiresAt    time.Time
 }
+
+var errEmptyAccessToken = errors.New("oauth token response missing access token")
 
 // validAliasRe matches safe alias values: alphanumeric, underscores, hyphens,
 // dots, spaces, and @ (to support auto-detected identities like emails and workspace names).
@@ -147,24 +151,24 @@ func (h *ServicesHandler) List(w http.ResponseWriter, r *http.Request) {
 	}
 
 	type serviceEntry struct {
-		ID                 string        `json:"id"`
-		Name               string        `json:"name"`
-		Description        string        `json:"description"`
-		IconSVG            string        `json:"icon_svg,omitempty"`
-		Alias              string        `json:"alias,omitempty"`
-		OAuth              bool          `json:"oauth"`
-		OAuthEndpoint      string        `json:"oauth_endpoint,omitempty"`
-		DeviceFlow         bool          `json:"device_flow,omitempty"`
-		PKCEFlow              bool          `json:"pkce_flow,omitempty"`
-		PKCEClientIDRequired  bool          `json:"pkce_client_id_required,omitempty"`
-		AutoIdentity          bool          `json:"auto_identity,omitempty"`
-		RequiresActivation bool          `json:"requires_activation"`
-		CredentialFree     bool          `json:"credential_free"`
-		Actions            []actionEntry          `json:"actions"`
-		Variables          []adapters.VariableMeta `json:"variables,omitempty"`
-		Status             string                 `json:"status"`
-		ActivatedAt        *time.Time             `json:"activated_at,omitempty"`
-		SetupURL           string                 `json:"setup_url,omitempty"`
+		ID                   string                  `json:"id"`
+		Name                 string                  `json:"name"`
+		Description          string                  `json:"description"`
+		IconSVG              string                  `json:"icon_svg,omitempty"`
+		Alias                string                  `json:"alias,omitempty"`
+		OAuth                bool                    `json:"oauth"`
+		OAuthEndpoint        string                  `json:"oauth_endpoint,omitempty"`
+		DeviceFlow           bool                    `json:"device_flow,omitempty"`
+		PKCEFlow             bool                    `json:"pkce_flow,omitempty"`
+		PKCEClientIDRequired bool                    `json:"pkce_client_id_required,omitempty"`
+		AutoIdentity         bool                    `json:"auto_identity,omitempty"`
+		RequiresActivation   bool                    `json:"requires_activation"`
+		CredentialFree       bool                    `json:"credential_free"`
+		Actions              []actionEntry           `json:"actions"`
+		Variables            []adapters.VariableMeta `json:"variables,omitempty"`
+		Status               string                  `json:"status"`
+		ActivatedAt          *time.Time              `json:"activated_at,omitempty"`
+		SetupURL             string                  `json:"setup_url,omitempty"`
 	}
 
 	// buildEntry creates a serviceEntry from an adapter, using MetadataProvider when available.
@@ -220,20 +224,20 @@ func (h *ServicesHandler) List(w http.ResponseWriter, r *http.Request) {
 		}
 
 		return serviceEntry{
-			ID:                    a.ServiceID(),
-			Name:                  name,
-			Description:           desc,
-			IconSVG:               iconSVG,
-			OAuth:                 len(a.RequiredScopes()) > 0,
-			OAuthEndpoint:         oauthEndpoint,
-			DeviceFlow:            deviceFlow,
-			PKCEFlow:              pkceFlowDefined, // show PKCE option if defined, even without client ID
-			PKCEClientIDRequired:  pkceFlowDefined && !pkceFlow, // client ID still needed
-			AutoIdentity:          autoIdentity,
-			RequiresActivation:    true,
-			Actions:               actions,
-			Variables:             variables,
-			SetupURL:              setupURL,
+			ID:                   a.ServiceID(),
+			Name:                 name,
+			Description:          desc,
+			IconSVG:              iconSVG,
+			OAuth:                len(a.RequiredScopes()) > 0,
+			OAuthEndpoint:        oauthEndpoint,
+			DeviceFlow:           deviceFlow,
+			PKCEFlow:             pkceFlowDefined,              // show PKCE option if defined, even without client ID
+			PKCEClientIDRequired: pkceFlowDefined && !pkceFlow, // client ID still needed
+			AutoIdentity:         autoIdentity,
+			RequiresActivation:   true,
+			Actions:              actions,
+			Variables:            variables,
+			SetupURL:             setupURL,
 		}
 	}
 
@@ -562,19 +566,20 @@ func (h *ServicesHandler) OAuthCallback(w http.ResponseWriter, r *http.Request) 
 			return
 		}
 
-		accessToken := extractTokenFromPath(rawResp, entry.TokenPath)
-		if accessToken == "" {
-			h.logger.Warn("oauth token exchange: empty access token", "service", entry.ServiceID, "token_path", entry.TokenPath)
-			oauthPopupClose(w, "Provider returned empty access token.", "")
-			return
+		scopes := entry.Scopes
+		if len(scopes) == 0 {
+			scopes = adapter.RequiredScopes()
 		}
-
-		credBytes, err = json.Marshal(map[string]string{
-			"type":  "api_key",
-			"token": accessToken,
-		})
+		existingRefreshToken := h.loadExistingRefreshToken(r.Context(), entry.UserID, entry.ServiceID, alias)
+		credBytes, err = credentialFromTokenPathResponse(rawResp, entry.TokenPath, scopes, existingRefreshToken, time.Now())
 		if err != nil {
-			oauthPopupClose(w, "Failed to encode credential.", "")
+			if errors.Is(err, errEmptyAccessToken) {
+				h.logger.Warn("oauth token exchange: empty access token", "service", entry.ServiceID, "token_path", entry.TokenPath)
+				oauthPopupClose(w, "Provider returned empty access token.", "")
+				return
+			}
+			h.logger.Warn("credential from token_path response failed", "service", entry.ServiceID, "err", err)
+			oauthPopupClose(w, "Failed to process credential.", "")
 			return
 		}
 	} else {
@@ -1769,7 +1774,7 @@ func (h *ServicesHandler) PKCEFlowStart(w http.ResponseWriter, r *http.Request) 
 	params := url.Values{
 		"client_id":             {clientID},
 		"scope":                 {strings.Join(pfCfg.Scopes, " ")},
-		"redirect_uri":         {redirectURI},
+		"redirect_uri":          {redirectURI},
 		"state":                 {stateToken},
 		"code_challenge":        {codeChallenge},
 		"code_challenge_method": {"S256"},
@@ -1810,6 +1815,16 @@ func (h *ServicesHandler) PKCEFlowCallback(w http.ResponseWriter, r *http.Reques
 	if time.Now().After(entry.ExpiresAt) {
 		oauthPopupClose(w, "PKCE session expired. Please try again.", "")
 		return
+	}
+
+	adapter, ok := h.adapterReg.Get(entry.ServiceID)
+	if !ok {
+		oauthPopupClose(w, "Service not found.", "")
+		return
+	}
+	alias := entry.Alias
+	if alias == "" {
+		alias = "default"
 	}
 
 	// Exchange authorization code for access token using PKCE.
@@ -1853,26 +1868,26 @@ func (h *ServicesHandler) PKCEFlowCallback(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// Extract access token using token_path.
-	accessToken := extractTokenFromPath(rawResp, entry.TokenPath)
-	if accessToken == "" {
-		h.logger.Warn("pkce flow: empty access token in response", "service", entry.ServiceID, "token_path", entry.TokenPath)
-		oauthPopupClose(w, "Provider returned empty access token.", "")
-		return
-	}
-
-	// Store as api_key credential (same format as device flow / PAT).
-	credBytes, err := json.Marshal(map[string]string{
-		"type":  "api_key",
-		"token": accessToken,
-	})
+	credBytes, err := credentialFromTokenPathResponse(
+		rawResp,
+		entry.TokenPath,
+		adapter.RequiredScopes(),
+		h.loadExistingRefreshToken(r.Context(), entry.UserID, entry.ServiceID, alias),
+		time.Now(),
+	)
 	if err != nil {
-		oauthPopupClose(w, "Failed to encode credential.", "")
+		if errors.Is(err, errEmptyAccessToken) {
+			h.logger.Warn("pkce flow: empty access token in response", "service", entry.ServiceID, "token_path", entry.TokenPath)
+			oauthPopupClose(w, "Provider returned empty access token.", "")
+			return
+		}
+		h.logger.Warn("pkce flow: failed to process token response", "service", entry.ServiceID, "err", err)
+		oauthPopupClose(w, "Failed to process credential.", "")
 		return
 	}
 
 	// Auto-detect identity before storing.
-	alias := h.resolveIdentityAlias(r.Context(), entry.ServiceID, entry.Alias, credBytes, entry.Config)
+	alias = h.resolveIdentityAlias(r.Context(), entry.ServiceID, alias, credBytes, entry.Config)
 
 	vKey := h.adapterReg.VaultKeyWithAlias(entry.ServiceID, alias)
 	if err := h.vault.Set(r.Context(), entry.UserID, vKey, credBytes); err != nil {
@@ -1895,11 +1910,34 @@ func (h *ServicesHandler) PKCEFlowCallback(w http.ResponseWriter, r *http.Reques
 func extractTokenFromPath(m map[string]any, path string) string {
 	if path == "" {
 		// Default: look for "access_token" at the top level.
-		if v, ok := m["access_token"].(string); ok {
-			return v
-		}
-		return ""
+		return extractStringFromPath(m, "access_token")
 	}
+	return extractStringFromPath(m, path)
+}
+
+func credentialFromTokenPathResponse(rawResp map[string]any, tokenPath string, scopes []string, existingRefreshToken string, now time.Time) ([]byte, error) {
+	accessToken := extractTokenFromPath(rawResp, tokenPath)
+	if accessToken == "" {
+		return nil, errEmptyAccessToken
+	}
+
+	refreshToken := extractStringFromPath(rawResp, siblingTokenFieldPath(tokenPath, "refresh_token"))
+	if refreshToken == "" {
+		refreshToken = existingRefreshToken
+	}
+
+	token := &oauth2.Token{
+		AccessToken:  accessToken,
+		RefreshToken: refreshToken,
+		TokenType:    "Bearer",
+	}
+	if expiresIn, ok := extractIntFromPath(rawResp, siblingTokenFieldPath(tokenPath, "expires_in")); ok && expiresIn > 0 {
+		token.Expiry = now.Add(time.Duration(expiresIn) * time.Second)
+	}
+	return credential.FromToken(token, scopes)
+}
+
+func extractStringFromPath(m map[string]any, path string) string {
 	parts := strings.Split(path, ".")
 	var current any = m
 	for _, part := range parts {
@@ -1913,6 +1951,53 @@ func extractTokenFromPath(m map[string]any, path string) string {
 		return s
 	}
 	return ""
+}
+
+func extractIntFromPath(m map[string]any, path string) (int, bool) {
+	parts := strings.Split(path, ".")
+	var current any = m
+	for _, part := range parts {
+		obj, ok := current.(map[string]any)
+		if !ok {
+			return 0, false
+		}
+		current = obj[part]
+	}
+	switch v := current.(type) {
+	case int:
+		return v, true
+	case int32:
+		return int(v), true
+	case int64:
+		return int(v), true
+	case float64:
+		return int(v), true
+	case json.Number:
+		i, err := v.Int64()
+		if err != nil {
+			return 0, false
+		}
+		return int(i), true
+	case string:
+		i, err := strconv.Atoi(v)
+		if err != nil {
+			return 0, false
+		}
+		return i, true
+	default:
+		return 0, false
+	}
+}
+
+func siblingTokenFieldPath(tokenPath, field string) string {
+	if tokenPath == "" {
+		return field
+	}
+	lastDot := strings.LastIndex(tokenPath, ".")
+	if lastDot == -1 {
+		return field
+	}
+	return tokenPath[:lastDot+1] + field
 }
 
 // ── System OAuth Config ──────────────────────────────────────────────────────

--- a/internal/api/handlers/services_oauth_test.go
+++ b/internal/api/handlers/services_oauth_test.go
@@ -1,0 +1,90 @@
+package handlers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/clawvisor/clawvisor/internal/adapters/google/credential"
+)
+
+func TestCredentialFromTokenPathResponse_PreservesRotatedTokens(t *testing.T) {
+	now := time.Date(2026, 4, 13, 12, 0, 0, 0, time.UTC)
+	rawResp := map[string]any{
+		"authed_user": map[string]any{
+			"access_token":  "xoxp-access",
+			"refresh_token": "xoxe-refresh",
+			"expires_in":    float64(43200),
+		},
+	}
+
+	credBytes, err := credentialFromTokenPathResponse(
+		rawResp,
+		"authed_user.access_token",
+		[]string{"channels:read"},
+		"",
+		now,
+	)
+	if err != nil {
+		t.Fatalf("credentialFromTokenPathResponse failed: %v", err)
+	}
+
+	stored, err := credential.Parse(credBytes)
+	if err != nil {
+		t.Fatalf("credential.Parse failed: %v", err)
+	}
+	if stored.Type != "oauth2" {
+		t.Fatalf("expected oauth2 credential type, got %q", stored.Type)
+	}
+	if stored.AccessToken != "xoxp-access" {
+		t.Fatalf("expected access token to be preserved, got %q", stored.AccessToken)
+	}
+	if stored.RefreshToken != "xoxe-refresh" {
+		t.Fatalf("expected refresh token to be preserved, got %q", stored.RefreshToken)
+	}
+	if got, want := stored.Expiry, now.Add(12*time.Hour); !got.Equal(want) {
+		t.Fatalf("expected expiry %s, got %s", want.Format(time.RFC3339), got.Format(time.RFC3339))
+	}
+	if len(stored.Scopes) != 1 || stored.Scopes[0] != "channels:read" {
+		t.Fatalf("expected scopes to be preserved, got %#v", stored.Scopes)
+	}
+}
+
+func TestCredentialFromTokenPathResponse_FallsBackToExistingRefreshToken(t *testing.T) {
+	rawResp := map[string]any{
+		"authed_user": map[string]any{
+			"access_token": "xoxp-access",
+		},
+	}
+
+	credBytes, err := credentialFromTokenPathResponse(
+		rawResp,
+		"authed_user.access_token",
+		nil,
+		"xoxe-existing",
+		time.Date(2026, 4, 13, 12, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatalf("credentialFromTokenPathResponse failed: %v", err)
+	}
+
+	stored, err := credential.Parse(credBytes)
+	if err != nil {
+		t.Fatalf("credential.Parse failed: %v", err)
+	}
+	if stored.RefreshToken != "xoxe-existing" {
+		t.Fatalf("expected existing refresh token fallback, got %q", stored.RefreshToken)
+	}
+}
+
+func TestCredentialFromTokenPathResponse_RequiresAccessToken(t *testing.T) {
+	_, err := credentialFromTokenPathResponse(
+		map[string]any{"authed_user": map[string]any{}},
+		"authed_user.access_token",
+		nil,
+		"",
+		time.Date(2026, 4, 13, 12, 0, 0, 0, time.UTC),
+	)
+	if err != errEmptyAccessToken {
+		t.Fatalf("expected errEmptyAccessToken, got %v", err)
+	}
+}

--- a/pkg/adapters/yamlruntime/adapter.go
+++ b/pkg/adapters/yamlruntime/adapter.go
@@ -25,9 +25,9 @@ type ActionFunc func(ctx context.Context, req adapters.Request) (*adapters.Resul
 // YAMLAdapter implements adapters.Adapter from a YAML service definition.
 type YAMLAdapter struct {
 	def           yamldef.ServiceDef
-	overrides     map[string]ActionFunc              // action_name → Go override
-	oauthProvider adapters.OAuthCredentialProvider    // lazy OAuth credential source
-	compiled      map[string]*compiledAction          // action_name → compiled exprs (nil if none)
+	overrides     map[string]ActionFunc            // action_name → Go override
+	oauthProvider adapters.OAuthCredentialProvider // lazy OAuth credential source
+	compiled      map[string]*compiledAction       // action_name → compiled exprs (nil if none)
 }
 
 // New creates a YAMLAdapter from a parsed service definition.
@@ -257,6 +257,21 @@ func (a *YAMLAdapter) ValidateCredential(credBytes []byte) error {
 	if credBytes == nil {
 		return fmt.Errorf("%s: credential required", a.def.Service.ID)
 	}
+
+	if a.def.Auth.Type == "oauth2" {
+		var cred struct {
+			AccessToken  string `json:"access_token"`
+			RefreshToken string `json:"refresh_token"`
+		}
+		if err := json.Unmarshal(credBytes, &cred); err != nil {
+			return fmt.Errorf("%s: invalid credential: %w", a.def.Service.ID, err)
+		}
+		if cred.AccessToken == "" && cred.RefreshToken == "" {
+			return fmt.Errorf("%s: oauth2 credential missing access_token and refresh_token", a.def.Service.ID)
+		}
+		return nil
+	}
+
 	var cred credential
 	if err := json.Unmarshal(credBytes, &cred); err != nil {
 		return fmt.Errorf("%s: invalid credential: %w", a.def.Service.ID, err)

--- a/pkg/adapters/yamlruntime/adapter_test.go
+++ b/pkg/adapters/yamlruntime/adapter_test.go
@@ -18,6 +18,14 @@ func testCred(token string) []byte {
 	return b
 }
 
+func testOAuthCred(accessToken, refreshToken string) []byte {
+	b, _ := json.Marshal(map[string]string{
+		"access_token":  accessToken,
+		"refresh_token": refreshToken,
+	})
+	return b
+}
+
 func TestYAMLAdapter_RESTListAction(t *testing.T) {
 	// Mock API server.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -483,6 +491,27 @@ func TestYAMLAdapter_ValidateCredential(t *testing.T) {
 	}
 }
 
+func TestYAMLAdapter_ValidateCredential_OAuth2(t *testing.T) {
+	def := yamldef.ServiceDef{
+		Service: yamldef.ServiceInfo{ID: "test"},
+		Auth:    yamldef.AuthDef{Type: "oauth2"},
+	}
+	adapter, err := New(def, nil)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+
+	if err := adapter.ValidateCredential(testOAuthCred("access", "")); err != nil {
+		t.Fatalf("expected access-token oauth2 credential to validate: %v", err)
+	}
+	if err := adapter.ValidateCredential(testOAuthCred("", "refresh")); err != nil {
+		t.Fatalf("expected refresh-token oauth2 credential to validate: %v", err)
+	}
+	if err := adapter.ValidateCredential(testOAuthCred("", "")); err == nil {
+		t.Fatal("expected error for oauth2 credential with no tokens")
+	}
+}
+
 // ── Expr-lang integration tests ──────────────────────────────────────────────
 
 func TestYAMLAdapter_ExprFieldExtraction(t *testing.T) {
@@ -492,14 +521,14 @@ func TestYAMLAdapter_ExprFieldExtraction(t *testing.T) {
 		json.NewEncoder(w).Encode(map[string]any{
 			"connections": []map[string]any{
 				{
-					"resourceName": "people/123",
-					"names":        []map[string]any{{"displayName": "Alice Smith"}},
+					"resourceName":   "people/123",
+					"names":          []map[string]any{{"displayName": "Alice Smith"}},
 					"emailAddresses": []map[string]any{{"value": "alice@example.com"}},
 					"phoneNumbers":   []map[string]any{{"value": "+1234567890"}},
 				},
 				{
-					"resourceName": "people/456",
-					"names":        []map[string]any{{"displayName": "Bob Jones"}},
+					"resourceName":   "people/456",
+					"names":          []map[string]any{{"displayName": "Bob Jones"}},
 					"emailAddresses": []map[string]any{{"value": "bob@example.com"}},
 					// No phone number — tests optional field omission.
 				},
@@ -650,8 +679,8 @@ func TestYAMLAdapter_SparseBodyMode(t *testing.T) {
 	}
 	// Only provide "title" — other body params should be omitted in sparse mode.
 	_, err = adapter.Execute(context.Background(), adapters.Request{
-		Action: "update",
-		Params: map[string]any{"id": "42", "title": "New Title"},
+		Action:     "update",
+		Params:     map[string]any{"id": "42", "title": "New Title"},
 		Credential: testCred("test"),
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary
- store nested `token_path` OAuth responses as refreshable oauth2 credentials instead of static api keys
- preserve nested refresh tokens and convert `expires_in` into stored expiry, with fallback to an existing refresh token
- update YAML oauth2 credential validation and add focused regression tests

## Testing
- go test ./internal/api/handlers ./pkg/adapters/yamlruntime