### PR TITLE
feat: actionable API error responses for task and gateway endpoints

### DIFF
--- a/internal/api/handlers/errors_test.go
+++ b/internal/api/handlers/errors_test.go
@@ -1,0 +1,327 @@
+package handlers
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/pkg/adapters"
+)
+
+// ── diagnoseJSONError ────────────────────────────────────────────────────────
+
+func TestDiagnoseJSONError_EmptyBody(t *testing.T) {
+	d := diagnoseJSONError(io.EOF)
+	if d.Code != "INVALID_REQUEST" {
+		t.Fatalf("expected code INVALID_REQUEST, got %s", d.Code)
+	}
+	if !strings.Contains(d.Hint, "empty") && !strings.Contains(d.Error, "empty") {
+		t.Fatalf("expected mention of empty body, got error=%q hint=%q", d.Error, d.Hint)
+	}
+}
+
+func TestDiagnoseJSONError_TruncatedBody(t *testing.T) {
+	d := diagnoseJSONError(io.ErrUnexpectedEOF)
+	if !strings.Contains(d.Error, "incomplete") {
+		t.Fatalf("expected mention of incomplete JSON, got %q", d.Error)
+	}
+	if d.Hint == "" {
+		t.Fatal("expected a hint")
+	}
+}
+
+func TestDiagnoseJSONError_SyntaxError(t *testing.T) {
+	// Trigger a real syntax error by decoding invalid JSON.
+	var v any
+	err := json.Unmarshal([]byte(`{"key": ,}`), &v)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	d := diagnoseJSONError(err)
+	if d.Code != "INVALID_REQUEST" {
+		t.Fatalf("expected code INVALID_REQUEST, got %s", d.Code)
+	}
+	if d.Hint == "" {
+		t.Fatal("expected a hint for syntax errors")
+	}
+}
+
+func TestDiagnoseJSONError_TypeMismatch(t *testing.T) {
+	var v struct {
+		Count int `json:"count"`
+	}
+	err := json.Unmarshal([]byte(`{"count": "not_a_number"}`), &v)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	d := diagnoseJSONError(err)
+	if !strings.Contains(d.Error, "count") {
+		t.Fatalf("expected field name in error, got %q", d.Error)
+	}
+	if !strings.Contains(d.Hint, "type") {
+		t.Fatalf("expected type info in hint, got %q", d.Hint)
+	}
+}
+
+func TestDiagnoseJSONError_StringInsteadOfObject(t *testing.T) {
+	var v struct {
+		Name string `json:"name"`
+	}
+	err := json.Unmarshal([]byte(`"just a string"`), &v)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	d := diagnoseJSONError(err)
+	if !strings.Contains(d.Error, "expected a JSON object") {
+		t.Fatalf("expected top-level type mismatch error, got %q", d.Error)
+	}
+	if !strings.Contains(d.Error, "string") {
+		t.Fatalf("expected error to mention 'string', got %q", d.Error)
+	}
+	if !strings.Contains(d.Hint, "object") {
+		t.Fatalf("expected hint to mention object, got %q", d.Hint)
+	}
+}
+
+func TestDiagnoseJSONError_ArrayInsteadOfObject(t *testing.T) {
+	var v struct {
+		Name string `json:"name"`
+	}
+	err := json.Unmarshal([]byte(`[1, 2, 3]`), &v)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	d := diagnoseJSONError(err)
+	if !strings.Contains(d.Error, "expected a JSON object") {
+		t.Fatalf("expected top-level type mismatch error, got %q", d.Error)
+	}
+	if !strings.Contains(d.Error, "array") {
+		t.Fatalf("expected error to mention 'array', got %q", d.Error)
+	}
+}
+
+func TestFriendlyTypeName(t *testing.T) {
+	cases := []struct {
+		goType string
+		want   string
+	}{
+		{"string", "a string"},
+		{"int", "a number"},
+		{"float64", "a number"},
+		{"bool", "a boolean"},
+		{"map[string]interface {}", "an object"},
+		{"map[string]any", "an object"},
+		{"[]string", "an array"},
+		{"[]interface {}", "an array"},
+		{"store.TaskAction", "an object (TaskAction)"},
+		{"gateway.Request", "an object (Request)"},
+	}
+	for _, c := range cases {
+		got := friendlyTypeName(c.goType)
+		if got != c.want {
+			t.Errorf("friendlyTypeName(%q) = %q, want %q", c.goType, got, c.want)
+		}
+	}
+}
+
+func TestDiagnoseJSONError_TypeMismatch_FriendlyHint(t *testing.T) {
+	// Verify the hint doesn't contain Go type syntax like "map[string]interface {}"
+	var v struct {
+		Count int `json:"count"`
+	}
+	err := json.Unmarshal([]byte(`{"count": "not_a_number"}`), &v)
+	d := diagnoseJSONError(err)
+	if strings.Contains(d.Hint, "map[") || strings.Contains(d.Hint, "interface") {
+		t.Fatalf("hint contains Go type syntax: %q", d.Hint)
+	}
+}
+
+// ── decodeJSON integration ──────────────────────────────────────────────────
+
+func TestDecodeJSON_ValidBody(t *testing.T) {
+	body := strings.NewReader(`{"name": "test"}`)
+	r := httptest.NewRequest(http.MethodPost, "/", body)
+	w := httptest.NewRecorder()
+
+	var v struct {
+		Name string `json:"name"`
+	}
+	if !decodeJSON(w, r, &v) {
+		t.Fatal("expected decodeJSON to succeed")
+	}
+	if v.Name != "test" {
+		t.Fatalf("expected name=test, got %q", v.Name)
+	}
+}
+
+func TestDecodeJSON_EmptyBody_ReturnsDetailedError(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(""))
+	w := httptest.NewRecorder()
+
+	var v any
+	if decodeJSON(w, r, &v) {
+		t.Fatal("expected decodeJSON to fail on empty body")
+	}
+
+	var resp apiErrorDetail
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode error response: %v", err)
+	}
+	if resp.Code != "INVALID_REQUEST" {
+		t.Fatalf("expected code INVALID_REQUEST, got %s", resp.Code)
+	}
+	if resp.Hint == "" {
+		t.Fatal("expected a hint in the error response")
+	}
+}
+
+func TestDecodeJSON_MalformedJSON_ReturnsHint(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"key": true,}`))
+	w := httptest.NewRecorder()
+
+	var v any
+	if decodeJSON(w, r, &v) {
+		t.Fatal("expected decodeJSON to fail on malformed JSON")
+	}
+
+	var resp apiErrorDetail
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode error response: %v", err)
+	}
+	if resp.Hint == "" {
+		t.Fatal("expected a hint for malformed JSON")
+	}
+}
+
+// ── writeDetailedError ──────────────────────────────────────────────────────
+
+func TestWriteDetailedError_IncludesAllFields(t *testing.T) {
+	w := httptest.NewRecorder()
+	writeDetailedError(w, http.StatusBadRequest, apiErrorDetail{
+		Error:         "test error",
+		Code:          "TEST_CODE",
+		Hint:          "try this instead",
+		MissingFields: []string{"field_a", "field_b"},
+		Example:       map[string]any{"field_a": "value", "field_b": 42},
+		Available:     []string{"opt1", "opt2"},
+	})
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+	if resp["error"] != "test error" {
+		t.Fatalf("wrong error: %v", resp["error"])
+	}
+	if resp["code"] != "TEST_CODE" {
+		t.Fatalf("wrong code: %v", resp["code"])
+	}
+	if resp["hint"] != "try this instead" {
+		t.Fatalf("wrong hint: %v", resp["hint"])
+	}
+	if resp["missing_fields"] == nil {
+		t.Fatal("expected missing_fields")
+	}
+	if resp["example"] == nil {
+		t.Fatal("expected example")
+	}
+	if resp["available"] == nil {
+		t.Fatal("expected available")
+	}
+}
+
+func TestWriteDetailedError_OmitsEmptyFields(t *testing.T) {
+	w := httptest.NewRecorder()
+	writeDetailedError(w, http.StatusBadRequest, apiErrorDetail{
+		Error: "minimal error",
+		Code:  "MIN",
+	})
+
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+	if _, ok := resp["hint"]; ok {
+		t.Fatal("hint should be omitted when empty")
+	}
+	if _, ok := resp["missing_fields"]; ok {
+		t.Fatal("missing_fields should be omitted when empty")
+	}
+	if _, ok := resp["example"]; ok {
+		t.Fatal("example should be omitted when empty")
+	}
+	if _, ok := resp["available"]; ok {
+		t.Fatal("available should be omitted when empty")
+	}
+}
+
+// ── validateRequestParams ───────────────────────────────────────────────────
+
+type mockParamAdapter struct {
+	adapters.Adapter // embed to satisfy interface
+	params           map[string][]adapters.ParamInfo
+}
+
+func (m *mockParamAdapter) ActionParams(action string) []adapters.ParamInfo {
+	return m.params[action]
+}
+
+func TestValidateRequestParams_AllPresent(t *testing.T) {
+	adapter := &mockParamAdapter{
+		params: map[string][]adapters.ParamInfo{
+			"send": {
+				{Name: "to", Type: "string", Required: true},
+				{Name: "body", Type: "string", Required: true},
+			},
+		},
+	}
+	result := validateRequestParams(adapter, "send", map[string]any{
+		"to":   "alice",
+		"body": "hello",
+	})
+	if result != nil {
+		t.Fatalf("expected nil, got %+v", result)
+	}
+}
+
+func TestValidateRequestParams_MissingRequired(t *testing.T) {
+	adapter := &mockParamAdapter{
+		params: map[string][]adapters.ParamInfo{
+			"send": {
+				{Name: "to", Type: "string", Required: true},
+				{Name: "body", Type: "string", Required: true},
+				{Name: "subject", Type: "string", Required: false},
+			},
+		},
+	}
+	result := validateRequestParams(adapter, "send", map[string]any{
+		"subject": "hi",
+	})
+	if result == nil {
+		t.Fatal("expected error detail for missing params")
+	}
+	if result.Code != "INVALID_PARAMS" {
+		t.Fatalf("expected code INVALID_PARAMS, got %s", result.Code)
+	}
+	if len(result.MissingFields) != 2 {
+		t.Fatalf("expected 2 missing fields, got %d: %v", len(result.MissingFields), result.MissingFields)
+	}
+	if result.Example == nil {
+		t.Fatal("expected example in error")
+	}
+}
+
+func TestValidateRequestParams_NoDescriber(t *testing.T) {
+	// An adapter that doesn't implement ActionParamDescriber should pass.
+	result := validateRequestParams(nil, "send", nil)
+	if result != nil {
+		t.Fatalf("expected nil for nil adapter, got %+v", result)
+	}
+}

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -114,7 +114,9 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Collect all missing top-level required fields.
+	// Collect missing pre-restriction required fields (service, action, reason).
+	// task_id is checked after restriction checks — restrictions can block requests
+	// before a task is created, so task_id is intentionally not required here.
 	{
 		var missing []string
 		if req.Service == "" {
@@ -126,21 +128,16 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 		if req.Reason == "" {
 			missing = append(missing, "reason")
 		}
-		if req.TaskID == "" {
-			missing = append(missing, "task_id")
-		}
 		if len(missing) > 0 {
 			code := "INVALID_REQUEST"
 			if len(missing) == 1 && missing[0] == "reason" {
 				code = "MISSING_REASON"
-			} else if len(missing) == 1 && missing[0] == "task_id" {
-				code = "TASK_REQUIRED"
 			}
 			writeDetailedError(w, http.StatusBadRequest, apiErrorDetail{
 				Error:         "missing required fields: " + strings.Join(missing, ", "),
 				Code:          code,
 				MissingFields: missing,
-				Hint:          "Every gateway request must specify the target service, action, a reason for the request, and the task_id from an approved task.",
+				Hint:          "Every gateway request must specify the target service, action, and a reason for the request.",
 				Example: map[string]any{
 					"service": "google.gmail",
 					"action":  "list_messages",
@@ -295,7 +292,23 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// ── Step 2: Task ID already validated above ─────────────────────────────
+	// ── Step 2: Task ID required ─────────────────────────────────────────────
+	if req.TaskID == "" {
+		outDecision, outOutcome = "reject", "validation_error"
+		writeDetailedError(w, http.StatusBadRequest, apiErrorDetail{
+			Error:         "missing required field: task_id",
+			Code:          "TASK_REQUIRED",
+			MissingFields: []string{"task_id"},
+			Hint:          "Create a task first via POST /api/tasks, then include the returned task_id in every gateway request.",
+			Example: map[string]any{
+				"service": "google.gmail",
+				"action":  "list_messages",
+				"reason":  "Fetch recent emails to summarize for the user",
+				"task_id": "<task_id from POST /api/tasks>",
+			},
+		})
+		return
+	}
 
 	// ── Step 3: Hardcoded approval check ─────────────────────────────────────
 	hardcoded := RequiresHardcodedApproval(serviceType, req.Action)

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -113,18 +113,49 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 	if !decodeJSON(w, r, &req) {
 		return
 	}
-	if req.Service == "" || req.Action == "" {
-		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "service and action are required")
-		return
+
+	// Collect all missing top-level required fields.
+	{
+		var missing []string
+		if req.Service == "" {
+			missing = append(missing, "service")
+		}
+		if req.Action == "" {
+			missing = append(missing, "action")
+		}
+		if req.Reason == "" {
+			missing = append(missing, "reason")
+		}
+		if req.TaskID == "" {
+			missing = append(missing, "task_id")
+		}
+		if len(missing) > 0 {
+			code := "INVALID_REQUEST"
+			if len(missing) == 1 && missing[0] == "reason" {
+				code = "MISSING_REASON"
+			} else if len(missing) == 1 && missing[0] == "task_id" {
+				code = "TASK_REQUIRED"
+			}
+			writeDetailedError(w, http.StatusBadRequest, apiErrorDetail{
+				Error:         "missing required fields: " + strings.Join(missing, ", "),
+				Code:          code,
+				MissingFields: missing,
+				Hint:          "Every gateway request must specify the target service, action, a reason for the request, and the task_id from an approved task.",
+				Example: map[string]any{
+					"service": "google.gmail",
+					"action":  "list_messages",
+					"reason":  "Fetch recent emails to summarize for the user",
+					"task_id": "<task_id from POST /api/tasks>",
+					"params":  map[string]any{"max_results": 10},
+				},
+			})
+			return
+		}
 	}
 
 	middleware.AddLogField(ctx, "service", req.Service)
 	middleware.AddLogField(ctx, "action", req.Action)
 
-	if req.Reason == "" {
-		writeError(w, http.StatusBadRequest, "MISSING_REASON", "reason is required on every gateway request")
-		return
-	}
 	if req.Context.CallbackURL != "" {
 		if err := callback.ValidateCallbackURL(req.Context.CallbackURL); err != nil {
 			h.logger.Warn("callback URL blocked by SSRF policy",
@@ -264,13 +295,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// ── Step 2: Task ID required ─────────────────────────────────────────────
-	if req.TaskID == "" {
-		outDecision, outOutcome = "reject", "validation_error"
-		writeError(w, http.StatusBadRequest, "TASK_REQUIRED",
-			"task_id is required; create a task first via POST /api/tasks")
-		return
-	}
+	// ── Step 2: Task ID already validated above ─────────────────────────────
 
 	// ── Step 3: Hardcoded approval check ─────────────────────────────────────
 	hardcoded := RequiresHardcodedApproval(serviceType, req.Action)
@@ -282,12 +307,20 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 		task, taskErr := h.store.GetTask(ctx, req.TaskID)
 		if taskErr != nil {
 			outDecision, outOutcome = "reject", "validation_error"
-			writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "task not found")
+			writeDetailedError(w, http.StatusBadRequest, apiErrorDetail{
+				Error: fmt.Sprintf("task %q not found", req.TaskID),
+				Code:  "INVALID_REQUEST",
+				Hint:  "The task_id may be incorrect, or the task may have been deleted. Create a new task via POST /api/tasks and use the returned task_id.",
+			})
 			return
 		}
 		if task.UserID != agent.UserID {
 			outDecision, outOutcome = "reject", "forbidden"
-			writeError(w, http.StatusForbidden, "FORBIDDEN", "task does not belong to this agent's user")
+			writeDetailedError(w, http.StatusForbidden, apiErrorDetail{
+				Error: "task does not belong to this agent's user",
+				Code:  "FORBIDDEN",
+				Hint:  "This agent's bearer token is associated with a different user than the task owner. Ensure you are using the correct agent token and task_id.",
+			})
 			return
 		}
 		if task.ExpiresAt != nil && time.Now().After(*task.ExpiresAt) {
@@ -295,7 +328,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			resp := map[string]any{
 				"status":  "task_expired",
 				"task_id": req.TaskID,
-				"message": "Task has expired. Use POST /api/tasks/{id}/expand to extend.",
+				"message": "Task has expired. Create a new task via POST /api/tasks, or use POST /api/tasks/{id}/expand to request an extension before expiry.",
 			}
 			h.maybeInjectNPS(ctx, resp, agent.ID)
 			writeJSON(w, http.StatusOK, resp)
@@ -303,8 +336,24 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 		}
 		if task.Status != "active" {
 			outDecision, outOutcome = "reject", "invalid_state"
-			writeError(w, http.StatusConflict, "INVALID_STATE",
-				fmt.Sprintf("task is %s, not active", task.Status))
+			hint := "Create a new task via POST /api/tasks."
+			switch task.Status {
+			case "pending_approval":
+				hint = "The task is still waiting for user approval. Poll with GET /api/tasks/{id}?wait=true or wait for the callback."
+			case "denied":
+				hint = "The user denied this task. Create a new task with a revised purpose/scope."
+			case "completed":
+				hint = "This task was already marked complete. Create a new task for additional work."
+			case "revoked":
+				hint = "The user revoked this task. Create a new task if you need to continue."
+			case "pending_scope_expansion":
+				hint = "A scope expansion is pending approval. Wait for it to be approved before making requests."
+			}
+			writeDetailedError(w, http.StatusConflict, apiErrorDetail{
+				Error: fmt.Sprintf("task is %s, not active", task.Status),
+				Code:  "INVALID_STATE",
+				Hint:  hint,
+			})
 			return
 		}
 
@@ -437,6 +486,22 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 						"error":      userErr,
 						"code":       code,
 					})
+					return
+				}
+			}
+
+			// Validate required params before execution.
+			if execAdapter, adOK := h.adapterReg.GetForUser(ctx, serviceType, agent.UserID); adOK {
+				if paramErr := validateRequestParams(execAdapter, req.Action, req.Params); paramErr != nil {
+					errMsg := paramErr.Error
+					e := baseEntry("reject", "validation_error", taskIDPtr)
+					e.DurationMS = int(time.Since(start).Milliseconds())
+					e.ErrorMsg = &errMsg
+					if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+						h.logger.Warn("audit log failed", "err", logErr)
+					}
+					h.publishAuditAndQueue(agent.UserID, req.TaskID)
+					writeDetailedError(w, http.StatusBadRequest, *paramErr)
 					return
 				}
 			}
@@ -1453,6 +1518,58 @@ func adapterSupportsAction(adapter adapters.Adapter, action string) bool {
 		}
 	}
 	return false
+}
+
+// validateRequestParams checks the request params against the adapter's
+// parameter definitions (if available). Returns an apiErrorDetail if required
+// params are missing, or nil if everything looks good.
+func validateRequestParams(adapter adapters.Adapter, action string, params map[string]any) *apiErrorDetail {
+	describer, ok := adapter.(adapters.ActionParamDescriber)
+	if !ok {
+		return nil
+	}
+	paramDefs := describer.ActionParams(action)
+	if len(paramDefs) == 0 {
+		return nil
+	}
+
+	var missing []string
+	for _, p := range paramDefs {
+		if !p.Required {
+			continue
+		}
+		if _, provided := params[p.Name]; !provided {
+			missing = append(missing, p.Name)
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+
+	// Build an example showing all params with placeholder values.
+	example := make(map[string]any, len(paramDefs))
+	for _, p := range paramDefs {
+		switch p.Type {
+		case "int":
+			example[p.Name] = 10
+		case "bool":
+			example[p.Name] = true
+		case "object":
+			example[p.Name] = map[string]any{}
+		case "array":
+			example[p.Name] = []any{}
+		default:
+			example[p.Name] = "<" + p.Type + ">"
+		}
+	}
+
+	return &apiErrorDetail{
+		Error:         fmt.Sprintf("missing required params: %s", strings.Join(missing, ", ")),
+		Code:          "INVALID_PARAMS",
+		MissingFields: missing,
+		Hint:          "These parameters are required for this action. Check the service catalog for parameter details.",
+		Example:       map[string]any{"params": example},
+	}
 }
 
 func nullableStr(s string) *string {

--- a/internal/api/handlers/health.go
+++ b/internal/api/handlers/health.go
@@ -2,7 +2,10 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
+	"strings"
 
 	"github.com/clawvisor/clawvisor/pkg/store"
 	"github.com/clawvisor/clawvisor/pkg/vault"
@@ -89,16 +92,129 @@ func writeError(w http.ResponseWriter, status int, code, message string) {
 	})
 }
 
+// apiErrorDetail is an enriched error response with actionable debugging info.
+// Fields beyond error/code are omitted when empty.
+type apiErrorDetail struct {
+	Error         string         `json:"error"`
+	Code          string         `json:"code"`
+	Hint          string         `json:"hint,omitempty"`
+	MissingFields []string       `json:"missing_fields,omitempty"`
+	Example       map[string]any `json:"example,omitempty"`
+	Available     []string       `json:"available,omitempty"`
+}
+
+// writeDetailedError writes an enriched error response with optional actionable fields.
+func writeDetailedError(w http.ResponseWriter, status int, d apiErrorDetail) {
+	writeJSON(w, status, d)
+}
+
 // maxRequestBodySize is the default limit for JSON request bodies (1 MB).
 const maxRequestBodySize = 1 << 20
 
 // decodeJSON decodes the request body into v.
-// It enforces a 1 MB body size limit. On failure it writes a 400 error and returns false.
+// It enforces a 1 MB body size limit. On failure it writes a detailed error and returns false.
 func decodeJSON(w http.ResponseWriter, r *http.Request, v any) bool {
 	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodySize)
 	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "invalid JSON body")
+		writeDetailedError(w, http.StatusBadRequest, diagnoseJSONError(err))
 		return false
 	}
 	return true
+}
+
+// diagnoseJSONError inspects a JSON decode error and returns an actionable error detail.
+func diagnoseJSONError(err error) apiErrorDetail {
+	d := apiErrorDetail{
+		Error: "invalid JSON body",
+		Code:  "INVALID_REQUEST",
+	}
+
+	switch {
+	case errors.Is(err, io.EOF):
+		d.Error = "request body is empty"
+		d.Hint = "Send a JSON object in the request body. Ensure Content-Type is application/json."
+		return d
+
+	case errors.Is(err, io.ErrUnexpectedEOF):
+		d.Error = "request body contains incomplete JSON"
+		d.Hint = "The JSON is truncated — check for missing closing braces or brackets."
+		return d
+	}
+
+	msg := err.Error()
+
+	// http.MaxBytesError
+	if strings.Contains(msg, "http: request body too large") {
+		d.Error = "request body exceeds the 1 MB size limit"
+		d.Hint = "Reduce the size of params or split into multiple requests."
+		return d
+	}
+
+	// json.SyntaxError
+	var synErr *json.SyntaxError
+	if errors.As(err, &synErr) {
+		d.Error = "JSON syntax error at byte offset " + strings.TrimPrefix(msg, "invalid character ")
+		d.Hint = diagnoseJSONSyntaxHint(msg)
+		return d
+	}
+
+	// json.UnmarshalTypeError
+	var typeErr *json.UnmarshalTypeError
+	if errors.As(err, &typeErr) {
+		if typeErr.Field == "" {
+			// Top-level type mismatch — the caller sent a string/array/number instead of an object.
+			d.Error = "expected a JSON object, got " + typeErr.Value
+			d.Hint = "The request body must be a JSON object ({...}), not a " + typeErr.Value + ". Wrap your data in an object with the required fields."
+		} else {
+			d.Error = "wrong type for field \"" + typeErr.Field + "\""
+			d.Hint = "Expected " + friendlyTypeName(typeErr.Type.String()) + " but got " + typeErr.Value + ". Check that field values match the expected types."
+		}
+		return d
+	}
+
+	// Fallback: include the raw error for anything else.
+	d.Error = "invalid JSON body: " + msg
+	d.Hint = "Ensure the body is valid JSON. Common issues: trailing commas, single quotes instead of double quotes, unquoted keys."
+	return d
+}
+
+// friendlyTypeName converts Go type names into JSON-friendly descriptions.
+func friendlyTypeName(goType string) string {
+	switch {
+	case goType == "string":
+		return "a string"
+	case goType == "int", goType == "int64", goType == "float64":
+		return "a number"
+	case goType == "bool":
+		return "a boolean"
+	case strings.HasPrefix(goType, "map["):
+		return "an object"
+	case strings.HasPrefix(goType, "[]"):
+		return "an array"
+	case strings.Contains(goType, "."):
+		// Struct types like "store.TaskAction" — strip the package prefix
+		// and convert to a friendlier form.
+		parts := strings.SplitN(goType, ".", 2)
+		return "an object (" + parts[len(parts)-1] + ")"
+	default:
+		return goType
+	}
+}
+
+// diagnoseJSONSyntaxHint returns a human-friendly hint for common JSON syntax problems.
+func diagnoseJSONSyntaxHint(msg string) string {
+	switch {
+	case strings.Contains(msg, "looking for beginning of value"):
+		return "Check for trailing commas, missing values, or a non-JSON body. Ensure Content-Type is application/json."
+	case strings.Contains(msg, "looking for beginning of object key string"):
+		return "Object keys must be double-quoted strings. Check for trailing commas after the last field or single-quoted keys."
+	case strings.Contains(msg, "after object key"):
+		return "Expected ':' after object key. Check that keys and values are separated by colons."
+	case strings.Contains(msg, "after object key:value pair"):
+		return "Expected ',' or '}' after a key-value pair. Check for missing commas between fields."
+	case strings.Contains(msg, "after array element"):
+		return "Expected ',' or ']' after an array element. Check for missing commas between elements."
+	default:
+		return "Check the JSON syntax near the reported position. Common issues: trailing commas, single quotes, unquoted keys."
+	}
 }

--- a/internal/api/handlers/tasks.go
+++ b/internal/api/handlers/tasks.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -116,17 +117,55 @@ func (h *TasksHandler) Create(w http.ResponseWriter, r *http.Request) {
 	if !decodeJSON(w, r, &req) {
 		return
 	}
+
+	// Collect all missing top-level required fields at once so the caller
+	// can fix everything in a single round-trip.
+	var missingFields []string
 	if req.Purpose == "" {
-		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "purpose is required")
-		return
+		missingFields = append(missingFields, "purpose")
 	}
 	if len(req.AuthorizedActions) == 0 {
-		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "authorized_actions is required and must be non-empty")
+		missingFields = append(missingFields, "authorized_actions")
+	}
+	if len(missingFields) > 0 {
+		writeDetailedError(w, http.StatusBadRequest, apiErrorDetail{
+			Error:         "missing required fields: " + strings.Join(missingFields, ", "),
+			Code:          "INVALID_REQUEST",
+			Hint:          "A task requires a purpose describing what the agent will do and at least one authorized action.",
+			MissingFields: missingFields,
+			Example: map[string]any{
+				"purpose": "Read and summarize recent emails",
+				"authorized_actions": []map[string]any{
+					{"service": "google.gmail", "action": "list_messages", "auto_execute": true},
+				},
+			},
+		})
 		return
 	}
 
 	// Validate each authorized action.
-	for _, a := range req.AuthorizedActions {
+	for i, a := range req.AuthorizedActions {
+		// Validate that each action entry has the required service and action fields.
+		if a.Service == "" || a.Action == "" {
+			var actionMissing []string
+			if a.Service == "" {
+				actionMissing = append(actionMissing, "service")
+			}
+			if a.Action == "" {
+				actionMissing = append(actionMissing, "action")
+			}
+			writeDetailedError(w, http.StatusBadRequest, apiErrorDetail{
+				Error:         fmt.Sprintf("authorized_actions[%d] is missing required fields: %s", i, strings.Join(actionMissing, ", ")),
+				Code:          "INVALID_REQUEST",
+				MissingFields: actionMissing,
+				Hint:          "Each authorized action must specify a service ID and an action name (or \"*\" for all actions).",
+				Example: map[string]any{
+					"service": "google.gmail", "action": "list_messages", "auto_execute": true,
+				},
+			})
+			return
+		}
+
 		serviceType, serviceAlias := parseServiceAlias(a.Service)
 
 		// Guard virtual services (file, bash, search, web, agent, unknown) are
@@ -135,13 +174,26 @@ func (h *TasksHandler) Create(w http.ResponseWriter, r *http.Request) {
 		if !isGuardVirtualService(serviceType) {
 			adapter, ok := h.adapterReg.GetForUser(ctx, serviceType, agent.UserID)
 			if !ok {
-				writeError(w, http.StatusBadRequest, "INVALID_REQUEST",
-					fmt.Sprintf("unknown service %q", a.Service))
+				available := h.adapterReg.SupportedServices()
+				var ids []string
+				for _, s := range available {
+					ids = append(ids, s.ID)
+				}
+				writeDetailedError(w, http.StatusBadRequest, apiErrorDetail{
+					Error:     fmt.Sprintf("unknown service %q in authorized_actions[%d]", a.Service, i),
+					Code:      "INVALID_REQUEST",
+					Hint:      "Use the service ID from the catalog (GET /api/skill/catalog). Service IDs look like \"google.gmail\", not display names like \"Gmail\".",
+					Available: ids,
+				})
 				return
 			}
-			if !adapterSupportsAction(adapter, a.Action) {
-				writeError(w, http.StatusBadRequest, "INVALID_REQUEST",
-					fmt.Sprintf("service %q does not support action %q", serviceType, a.Action))
+			if a.Action != "*" && !adapterSupportsAction(adapter, a.Action) {
+				writeDetailedError(w, http.StatusBadRequest, apiErrorDetail{
+					Error:     fmt.Sprintf("service %q does not support action %q", serviceType, a.Action),
+					Code:      "INVALID_REQUEST",
+					Hint:      fmt.Sprintf("Use \"*\" to authorize all actions, or pick from the supported actions for this service."),
+					Available: adapter.SupportedActions(),
+				})
 				return
 			}
 			if !h.serviceActivated(ctx, agent.UserID, serviceType, serviceAlias, adapter) {
@@ -151,21 +203,40 @@ func (h *TasksHandler) Create(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		if a.AutoExecute && RequiresHardcodedApproval(a.Service, a.Action) {
-			writeError(w, http.StatusBadRequest, "INVALID_REQUEST",
-				fmt.Sprintf("action %s:%s has hardcoded approval — auto_execute must be false", a.Service, a.Action))
+			writeDetailedError(w, http.StatusBadRequest, apiErrorDetail{
+				Error: fmt.Sprintf("action %s:%s requires per-request human approval — auto_execute must be false", a.Service, a.Action),
+				Code:  "INVALID_REQUEST",
+				Hint:  "Some actions (like sending iMessages) always require individual approval for safety. Set auto_execute to false for this action.",
+				Example: map[string]any{
+					"service": a.Service, "action": a.Action, "auto_execute": false,
+				},
+			})
 			return
 		}
 	}
 
 	// Validate planned calls: each must reference a service:action covered by authorized_actions.
-	for _, pc := range req.PlannedCalls {
-		if pc.Service == "" || pc.Action == "" {
-			writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "planned_calls entries must have service and action")
-			return
+	for i, pc := range req.PlannedCalls {
+		var pcMissing []string
+		if pc.Service == "" {
+			pcMissing = append(pcMissing, "service")
+		}
+		if pc.Action == "" {
+			pcMissing = append(pcMissing, "action")
 		}
 		if pc.Reason == "" {
-			writeError(w, http.StatusBadRequest, "INVALID_REQUEST",
-				fmt.Sprintf("planned_calls entry %s:%s must have a reason", pc.Service, pc.Action))
+			pcMissing = append(pcMissing, "reason")
+		}
+		if len(pcMissing) > 0 {
+			writeDetailedError(w, http.StatusBadRequest, apiErrorDetail{
+				Error:         fmt.Sprintf("planned_calls[%d] is missing required fields: %s", i, strings.Join(pcMissing, ", ")),
+				Code:          "INVALID_REQUEST",
+				MissingFields: pcMissing,
+				Hint:          "Each planned call must specify the service, action, and a reason explaining why this call will be made.",
+				Example: map[string]any{
+					"service": "google.gmail", "action": "send_message", "reason": "Send the daily summary email to the user",
+				},
+			})
 			return
 		}
 		covered := false
@@ -178,8 +249,16 @@ func (h *TasksHandler) Create(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		if !covered {
-			writeError(w, http.StatusBadRequest, "INVALID_REQUEST",
-				fmt.Sprintf("planned_calls entry %s:%s is not covered by authorized_actions", pc.Service, pc.Action))
+			var authorizedStrs []string
+			for _, a := range req.AuthorizedActions {
+				authorizedStrs = append(authorizedStrs, a.Service+":"+a.Action)
+			}
+			writeDetailedError(w, http.StatusBadRequest, apiErrorDetail{
+				Error:     fmt.Sprintf("planned_calls[%d] (%s:%s) is not covered by authorized_actions", i, pc.Service, pc.Action),
+				Code:      "INVALID_REQUEST",
+				Hint:      "Every planned call must match a service:action pair (or wildcard) in authorized_actions. Add the missing action or use \"*\" as the action.",
+				Available: authorizedStrs,
+			})
 			return
 		}
 	}
@@ -189,12 +268,20 @@ func (h *TasksHandler) Create(w http.ResponseWriter, r *http.Request) {
 		lifetime = "session"
 	}
 	if lifetime != "session" && lifetime != "standing" {
-		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "lifetime must be \"session\" or \"standing\"")
+		writeDetailedError(w, http.StatusBadRequest, apiErrorDetail{
+			Error:     fmt.Sprintf("invalid lifetime %q", req.Lifetime),
+			Code:      "INVALID_REQUEST",
+			Hint:      "Session tasks expire after a timeout. Standing tasks persist until revoked.",
+			Available: []string{"session", "standing"},
+		})
 		return
 	}
 	if lifetime == "standing" && req.ExpiresInSeconds > 0 {
-		writeError(w, http.StatusBadRequest, "INVALID_REQUEST",
-			"expires_in_seconds cannot be set on a standing task — standing tasks have no expiry (revoke them to deactivate)")
+		writeDetailedError(w, http.StatusBadRequest, apiErrorDetail{
+			Error: "expires_in_seconds cannot be set on a standing task",
+			Code:  "INVALID_REQUEST",
+			Hint:  "Standing tasks have no expiry — they remain active until explicitly revoked via POST /api/tasks/{id}/revoke. Remove expires_in_seconds or change lifetime to \"session\".",
+		})
 		return
 	}
 

--- a/pkg/adapters/adapters.go
+++ b/pkg/adapters/adapters.go
@@ -191,6 +191,21 @@ type Adapter interface {
 	RequiredScopes() []string
 }
 
+// ParamInfo describes a single action parameter for validation and error reporting.
+type ParamInfo struct {
+	Name     string `json:"name"`
+	Type     string `json:"type"`               // "string", "int", "bool", "object", "array"
+	Required bool   `json:"required"`
+}
+
+// ActionParamDescriber is an optional interface that adapters can implement
+// to expose parameter metadata for pre-execution validation.
+type ActionParamDescriber interface {
+	// ActionParams returns the parameter definitions for the given action.
+	// Returns nil if no param info is available.
+	ActionParams(action string) []ParamInfo
+}
+
 // ServiceInfo is returned by the service catalog endpoint.
 type ServiceInfo struct {
 	ID          string   `json:"id"`

--- a/pkg/adapters/yamlruntime/adapter.go
+++ b/pkg/adapters/yamlruntime/adapter.go
@@ -64,6 +64,25 @@ func (a *YAMLAdapter) SupportedActions() []string {
 	return actions
 }
 
+// ActionParams returns parameter definitions for the given action.
+// Implements adapters.ActionParamDescriber.
+func (a *YAMLAdapter) ActionParams(actionName string) []adapters.ParamInfo {
+	action, ok := a.def.Actions[actionName]
+	if !ok {
+		return nil
+	}
+	params := make([]adapters.ParamInfo, 0, len(action.Params))
+	for name, p := range action.Params {
+		params = append(params, adapters.ParamInfo{
+			Name:     name,
+			Type:     p.Type,
+			Required: p.Required,
+		})
+	}
+	sort.Slice(params, func(i, j int) bool { return params[i].Name < params[j].Name })
+	return params
+}
+
 func (a *YAMLAdapter) Execute(ctx context.Context, req adapters.Request) (*adapters.Result, error) {
 	action, ok := a.def.Actions[req.Action]
 	if !ok {


### PR DESCRIPTION
## Summary
- Enriches error responses across task creation and gateway request endpoints with structured `hint`, `missing_fields`, `example`, and `available` fields (all omitted when empty for backward compat)
- Detects common JSON mistakes (empty body, wrong top-level type like string instead of object, syntax errors, truncated input) and returns specific guidance
- Collects all missing required fields in one response instead of failing on the first, so callers can fix everything in a single round-trip
- Adds pre-execution param validation against adapter definitions (via new optional `ActionParamDescriber` interface) with missing-param errors that include an example
- Translates Go type names in error hints to friendly JSON terminology (e.g. `map[string]interface {}` → `an object`)
- Status-specific hints for inactive tasks (pending_approval → poll, denied → revise scope, etc.)

## Test plan
- [x] 16 new unit tests covering all error paths (JSON diagnosis, detailed error serialization, param validation, friendly type names)
- [x] All 51 existing handler tests still pass
- [x] Adapter package tests pass with new `ActionParams` method

🤖 Generated with [Claude Code](https://claude.com/claude-code)