### PR TITLE
Escape YAML adapter path params

### DIFF
--- a/pkg/adapters/yamlruntime/adapter_test.go
+++ b/pkg/adapters/yamlruntime/adapter_test.go
@@ -1020,6 +1020,55 @@ func TestYAMLAdapter_PathParamDefault(t *testing.T) {
 	}
 }
 
+func TestYAMLAdapter_PathParamEscapesReservedChars(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		want := "/v3/calendars/en.usa%23holiday@group.v.calendar.google.com/events"
+		if r.URL.EscapedPath() != want {
+			t.Errorf("unexpected escaped path: %s (want %s)", r.URL.EscapedPath(), want)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"items": []any{},
+		})
+	}))
+	defer srv.Close()
+
+	def := yamldef.ServiceDef{
+		Service: yamldef.ServiceInfo{ID: "google.calendar"},
+		Auth:    yamldef.AuthDef{Type: "api_key", Header: "Authorization", HeaderPrefix: "Bearer "},
+		API:     yamldef.APIDef{BaseURL: srv.URL + "/v3", Type: "rest"},
+		Actions: map[string]yamldef.Action{
+			"list_events": {
+				Method: "GET",
+				Path:   "/calendars/{{.calendar_id}}/events",
+				Params: map[string]yamldef.Param{
+					"calendar_id": {Type: "string", Default: "primary", Location: "path"},
+				},
+				Response: yamldef.ResponseDef{
+					DataPath: "items",
+					Summary:  "{{len .Data}} event(s)",
+				},
+			},
+		},
+	}
+
+	adapter, err := New(def, nil)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+
+	_, err = adapter.Execute(context.Background(), adapters.Request{
+		Action: "list_events",
+		Params: map[string]any{
+			"calendar_id": "en.usa#holiday@group.v.calendar.google.com",
+		},
+		Credential: testCred("test-token"),
+	})
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+}
+
 func TestYAMLAdapter_UnresolvedPathParam(t *testing.T) {
 	// When a required path param is missing and has no default, the error
 	// should mention the parameter name, not silently send a broken URL.

--- a/pkg/adapters/yamlruntime/rest.go
+++ b/pkg/adapters/yamlruntime/rest.go
@@ -150,10 +150,10 @@ func executeREST(ctx context.Context, client *http.Client, baseURL string, actio
 func interpolatePath(path string, params map[string]any, credFields map[string]string) string {
 	result := path
 	for k, v := range params {
-		result = strings.ReplaceAll(result, "{{."+k+"}}", fmt.Sprintf("%v", v))
+		result = strings.ReplaceAll(result, "{{."+k+"}}", url.PathEscape(fmt.Sprintf("%v", v)))
 	}
 	for k, v := range credFields {
-		result = strings.ReplaceAll(result, "{{.credential."+k+"}}", v)
+		result = strings.ReplaceAll(result, "{{.credential."+k+"}}", url.PathEscape(v))
 	}
 	return result
 }


### PR DESCRIPTION
This escapes interpolated path parameters in the YAML REST runtime before building request URLs.
It fixes cases like Google Calendar `calendar_id` values containing reserved characters such as `#`, which otherwise produce broken paths and 404s.
The PR also adds a regression test covering a calendar ID with `#` and asserting the escaped request path.
Verification: `go test ./pkg/adapters/yamlruntime`.