### PR TITLE
Escape YAML path params safely

### DIFF
--- a/pkg/adapters/yamlruntime/adapter_test.go
+++ b/pkg/adapters/yamlruntime/adapter_test.go
@@ -1098,6 +1098,57 @@ func TestYAMLAdapter_PathParamEscapesReservedChars(t *testing.T) {
 	}
 }
 
+func TestYAMLAdapter_PathParamPreservesSlashes(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		want := "/v1/people/123"
+		if r.URL.EscapedPath() != want {
+			t.Errorf("unexpected escaped path: %s (want %s)", r.URL.EscapedPath(), want)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"resourceName": "people/123",
+		})
+	}))
+	defer srv.Close()
+
+	def := yamldef.ServiceDef{
+		Service: yamldef.ServiceInfo{ID: "google.contacts"},
+		Auth:    yamldef.AuthDef{Type: "api_key", Header: "Authorization", HeaderPrefix: "Bearer "},
+		API:     yamldef.APIDef{BaseURL: srv.URL + "/v1", Type: "rest"},
+		Actions: map[string]yamldef.Action{
+			"get_contact": {
+				Method: "GET",
+				Path:   "/{{.contact_id}}",
+				Params: map[string]yamldef.Param{
+					"contact_id": {Type: "string", Required: true, Location: "path"},
+				},
+				Response: yamldef.ResponseDef{
+					Fields: []yamldef.FieldDef{
+						{Name: "resourceName"},
+					},
+					Summary: "Contact {{.resourceName}}",
+				},
+			},
+		},
+	}
+
+	adapter, err := New(def, nil)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+
+	_, err = adapter.Execute(context.Background(), adapters.Request{
+		Action: "get_contact",
+		Params: map[string]any{
+			"contact_id": "people/123",
+		},
+		Credential: testCred("test-token"),
+	})
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+}
+
 func TestYAMLAdapter_UnresolvedPathParam(t *testing.T) {
 	// When a required path param is missing and has no default, the error
 	// should mention the parameter name, not silently send a broken URL.

--- a/pkg/adapters/yamlruntime/rest.go
+++ b/pkg/adapters/yamlruntime/rest.go
@@ -150,12 +150,19 @@ func executeREST(ctx context.Context, client *http.Client, baseURL string, actio
 func interpolatePath(path string, params map[string]any, credFields map[string]string) string {
 	result := path
 	for k, v := range params {
-		result = strings.ReplaceAll(result, "{{."+k+"}}", url.PathEscape(fmt.Sprintf("%v", v)))
+		result = strings.ReplaceAll(result, "{{."+k+"}}", escapePathValue(fmt.Sprintf("%v", v)))
 	}
 	for k, v := range credFields {
-		result = strings.ReplaceAll(result, "{{.credential."+k+"}}", url.PathEscape(v))
+		result = strings.ReplaceAll(result, "{{.credential."+k+"}}", escapePathValue(v))
 	}
 	return result
+}
+
+// escapePathValue encodes reserved characters inside a path placeholder while
+// preserving literal "/" so adapters can keep using multi-segment resource
+// names like "people/123".
+func escapePathValue(v string) string {
+	return strings.ReplaceAll(url.PathEscape(v), "%2F", "/")
 }
 
 // resolveParamWithExpr extracts a parameter value from the input, applying


### PR DESCRIPTION
This updates YAML REST path interpolation to escape reserved characters inside path placeholders while preserving literal `/` for multi-segment resource names.
It fixes Google Calendar `calendar_id` values containing `#` without breaking adapters like Google Contacts that use resource names such as `people/123` in path params.
The branch includes regression tests for both cases.
Verification: `go test ./pkg/adapters/yamlruntime`.
Supersedes #221.