### PR TITLE
feat: add Overrides() getter to YAMLAdapter

### DIFF
--- a/internal/adapters/definitions/dropbox.yaml
+++ b/internal/adapters/definitions/dropbox.yaml
@@ -10,13 +10,16 @@ service:
     field: "email"
 
 auth:
-  type: oauth2
-  oauth:
-    client_id_env: DROPBOX_CLIENT_ID
-    client_secret_env: DROPBOX_CLIENT_SECRET
+  type: api_key
+  header: "Authorization"
+  header_prefix: "Bearer "
+  pkce_flow:
+    client_id: "0uyiqcfgyda77uu"
+    client_id_env: "DROPBOX_CLIENT_ID"
+    scopes: []
     authorize_url: "https://www.dropbox.com/oauth2/authorize"
     token_url: "https://api.dropboxapi.com/oauth2/token"
-    scopes: []
+    localhost_redirect: true
 
 api:
   base_url: "https://api.dropboxapi.com/2"

--- a/internal/adapters/definitions/dropbox.yaml
+++ b/internal/adapters/definitions/dropbox.yaml
@@ -10,16 +10,13 @@ service:
     field: "email"
 
 auth:
-  type: api_key
-  header: "Authorization"
-  header_prefix: "Bearer "
-  pkce_flow:
-    client_id: "0uyiqcfgyda77uu"
-    client_id_env: "DROPBOX_CLIENT_ID"
-    scopes: []
+  type: oauth2
+  oauth:
+    client_id_env: DROPBOX_CLIENT_ID
+    client_secret_env: DROPBOX_CLIENT_SECRET
     authorize_url: "https://www.dropbox.com/oauth2/authorize"
     token_url: "https://api.dropboxapi.com/oauth2/token"
-    localhost_redirect: true
+    scopes: []
 
 api:
   base_url: "https://api.dropboxapi.com/2"

--- a/pkg/adapters/yamlruntime/adapter.go
+++ b/pkg/adapters/yamlruntime/adapter.go
@@ -55,6 +55,9 @@ func New(def yamldef.ServiceDef, overrides map[string]ActionFunc) (*YAMLAdapter,
 
 func (a *YAMLAdapter) ServiceID() string { return a.def.Service.ID }
 
+// Overrides returns the Go action override functions registered on this adapter.
+func (a *YAMLAdapter) Overrides() map[string]ActionFunc { return a.overrides }
+
 func (a *YAMLAdapter) SupportedActions() []string {
 	actions := make([]string, 0, len(a.def.Actions))
 	for name := range a.def.Actions {


### PR DESCRIPTION
## Summary
- Add `Overrides()` method to `YAMLAdapter` that exposes the Go action override map
- Allows cloud override loader to carry forward Go overrides (e.g. Dropbox download/upload) when replacing an adapter's YAML definition with a cloud-specific version

This keeps Dropbox using PKCE locally while letting the cloud swap auth to OAuth2 without losing Go action implementations.

## Test plan
- [x] `yamlruntime` tests pass
- [x] `yamlloader` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)