### PR TITLE
fix: support PKCE-sourced credentials in api_key adapters

### DIFF
--- a/pkg/adapters/yamlruntime/adapter.go
+++ b/pkg/adapters/yamlruntime/adapter.go
@@ -298,7 +298,7 @@ func (a *YAMLAdapter) ValidateCredential(credBytes []byte) error {
 	if err := json.Unmarshal(credBytes, &cred); err != nil {
 		return fmt.Errorf("%s: invalid credential: %w", a.def.Service.ID, err)
 	}
-	if cred.Token == "" {
+	if cred.Token == "" && cred.AccessToken == "" {
 		return fmt.Errorf("%s: credential missing token", a.def.Service.ID)
 	}
 
@@ -353,35 +353,77 @@ func (a *YAMLAdapter) OAuthTokenPath() string {
 
 // buildAuthClient creates an *http.Client with proper authentication.
 // For OAuth2 services, this uses the OAuthConfig token source which handles
-// automatic token refresh. For other auth types, delegates to buildHTTPClient.
+// automatic token refresh. For api_key services with PKCE flow credentials,
+// it also uses an OAuth2 token source for refresh. For other auth types,
+// delegates to buildHTTPClient.
 func (a *YAMLAdapter) buildAuthClient(ctx context.Context, credBytes []byte) (*http.Client, error) {
 	if a.def.Auth.Type == "oauth2" {
 		oauthCfg := a.OAuthConfig()
 		if oauthCfg == nil {
 			return nil, fmt.Errorf("OAuth not configured — missing app credentials")
 		}
-		var stored struct {
-			AccessToken  string `json:"access_token"`
-			RefreshToken string `json:"refresh_token"`
-			Expiry       string `json:"expiry"`
-		}
-		if err := json.Unmarshal(credBytes, &stored); err != nil {
-			return nil, fmt.Errorf("parsing oauth2 credential: %w", err)
-		}
-		token := &oauth2.Token{
-			AccessToken:  stored.AccessToken,
-			RefreshToken: stored.RefreshToken,
-			TokenType:    "Bearer",
-		}
-		if stored.Expiry != "" {
-			if t, err := time.Parse(time.RFC3339, stored.Expiry); err == nil {
-				token.Expiry = t
-			}
-		}
-		ts := oauthCfg.TokenSource(ctx, token)
-		return oauth2.NewClient(ctx, ts), nil
+		return a.buildOAuthClient(ctx, credBytes, oauthCfg)
 	}
+
+	// For api_key adapters with PKCE flow, credentials are in OAuth2 format
+	// and may have refresh tokens. Use an OAuth2 token source for auto-refresh.
+	if a.def.Auth.PKCEFlow != nil {
+		if oauthCfg := a.pkceOAuthConfig(); oauthCfg != nil {
+			if client, err := a.buildOAuthClient(ctx, credBytes, oauthCfg); err == nil {
+				return client, nil
+			}
+			// Fall through to static auth if credential isn't in OAuth2 format.
+		}
+	}
+
 	return buildHTTPClient(a.def.Auth, credBytes)
+}
+
+// buildOAuthClient creates an *http.Client using an OAuth2 token source that
+// handles automatic token refresh.
+func (a *YAMLAdapter) buildOAuthClient(ctx context.Context, credBytes []byte, oauthCfg *oauth2.Config) (*http.Client, error) {
+	var stored struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		Expiry       string `json:"expiry"`
+	}
+	if err := json.Unmarshal(credBytes, &stored); err != nil {
+		return nil, fmt.Errorf("parsing oauth2 credential: %w", err)
+	}
+	if stored.AccessToken == "" && stored.RefreshToken == "" {
+		return nil, fmt.Errorf("credential missing oauth2 tokens")
+	}
+	token := &oauth2.Token{
+		AccessToken:  stored.AccessToken,
+		RefreshToken: stored.RefreshToken,
+		TokenType:    "Bearer",
+	}
+	if stored.Expiry != "" {
+		if t, err := time.Parse(time.RFC3339, stored.Expiry); err == nil {
+			token.Expiry = t
+		}
+	}
+	ts := oauthCfg.TokenSource(ctx, token)
+	return oauth2.NewClient(ctx, ts), nil
+}
+
+// pkceOAuthConfig builds a minimal oauth2.Config from the PKCE flow definition,
+// sufficient for token refresh (which only needs client_id and token_url).
+func (a *YAMLAdapter) pkceOAuthConfig() *oauth2.Config {
+	pf := a.def.Auth.PKCEFlow
+	if pf == nil {
+		return nil
+	}
+	clientID := a.resolvePKCEFlowClientID()
+	if clientID == "" || pf.TokenURL == "" {
+		return nil
+	}
+	return &oauth2.Config{
+		ClientID: clientID,
+		Endpoint: oauth2.Endpoint{
+			TokenURL: pf.TokenURL,
+		},
+	}
 }
 
 // ── MetadataProvider implementation ─────────────────────────────────────────

--- a/pkg/adapters/yamlruntime/adapter_test.go
+++ b/pkg/adapters/yamlruntime/adapter_test.go
@@ -512,6 +512,26 @@ func TestYAMLAdapter_ValidateCredential_OAuth2(t *testing.T) {
 	}
 }
 
+func TestYAMLAdapter_ValidateCredential_APIKeyWithPKCECred(t *testing.T) {
+	// api_key adapters with pkce_flow store credentials in OAuth2 format.
+	def := yamldef.ServiceDef{
+		Service: yamldef.ServiceInfo{ID: "test"},
+		Auth:    yamldef.AuthDef{Type: "api_key"},
+	}
+	adapter, err := New(def, nil)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+
+	// PKCE-sourced credential has access_token, not token.
+	if err := adapter.ValidateCredential(testOAuthCred("pkce-access-token", "")); err != nil {
+		t.Errorf("expected PKCE credential (access_token) to validate for api_key adapter: %v", err)
+	}
+	if err := adapter.ValidateCredential(testOAuthCred("", "")); err == nil {
+		t.Error("expected error for empty credential")
+	}
+}
+
 // ── Expr-lang integration tests ──────────────────────────────────────────────
 
 func TestYAMLAdapter_ExprFieldExtraction(t *testing.T) {

--- a/pkg/adapters/yamlruntime/auth.go
+++ b/pkg/adapters/yamlruntime/auth.go
@@ -10,21 +10,29 @@ import (
 )
 
 // credential is the JSON shape stored in the vault for API-key and basic-auth services.
+// When credentials come from a PKCE flow, the token is in the access_token field instead.
 type credential struct {
-	Type  string `json:"type"`
-	Token string `json:"token"`
+	Type        string `json:"type"`
+	Token       string `json:"token"`
+	AccessToken string `json:"access_token"`
 }
 
 // extractToken parses the vault credential JSON and returns the token string.
+// Supports both direct API-key credentials ({"token": "..."}) and PKCE-sourced
+// credentials ({"access_token": "..."}).
 func extractToken(credBytes []byte) (string, error) {
 	var cred credential
 	if err := json.Unmarshal(credBytes, &cred); err != nil {
 		return "", fmt.Errorf("parsing credential: %w", err)
 	}
-	if cred.Token == "" {
+	token := cred.Token
+	if token == "" {
+		token = cred.AccessToken
+	}
+	if token == "" {
 		return "", fmt.Errorf("credential missing token")
 	}
-	return cred.Token, nil
+	return token, nil
 }
 
 // buildHTTPClient creates an *http.Client that injects authentication headers


### PR DESCRIPTION
## Summary

- **Fixes broken reconnect for Linear and Dropbox integrations.** These `api_key` adapters use PKCE OAuth flow, which stores credentials in OAuth2 format (`access_token` field), but the `api_key` code path only looked for the `token` field — causing credential validation, identity fetching, and request execution to all fail after reauthorization.
- `extractToken` and `ValidateCredential` now accept either `token` or `access_token` fields, so PKCE-sourced credentials work with `api_key` adapters.
- `buildAuthClient` now uses an OAuth2 token source for PKCE adapters, enabling automatic token refresh for providers that issue refresh tokens (e.g. Dropbox).

## Test plan

- [x] Existing yamlruntime tests pass
- [x] New test for `ValidateCredential` with PKCE-sourced credentials on `api_key` adapters
- [ ] Manual: reconnect Linear integration, verify identity is fetched and requests work
- [ ] Manual: reconnect Dropbox integration, verify identity is fetched and requests work

🤖 Generated with [Claude Code](https://claude.com/claude-code)