### PR TITLE
fix: return UNKNOWN_ACTION for non-existent adapter actions

### DIFF
--- a/internal/adapters/definitions/google_gmail.yaml
+++ b/internal/adapters/definitions/google_gmail.yaml
@@ -36,7 +36,7 @@ actions:
     override: go
     params:
       query: { type: string }
-      max_results: { type: int, default: 10, max: 50 }
+      max_results: { type: int, default: 10, max: 200 }
       page_token: { type: string }
 
   get_message:

--- a/internal/adapters/google/gmail/adapter.go
+++ b/internal/adapters/google/gmail/adapter.go
@@ -155,7 +155,7 @@ func (a *GmailAdapter) listMessages(ctx context.Context, client *http.Client, pa
 	query, _ := params["query"].(string)
 	maxResults := 10
 	if v, ok := paramInt(params, "max_results"); ok {
-		if v > 0 && v <= 50 {
+		if v > 0 && v <= 200 {
 			maxResults = v
 		}
 	}

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -374,6 +374,41 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			warnings = append(warnings, "Chain context is disabled because session_id was not provided on this standing task request. Intent verification cannot verify that entity references (message IDs, thread IDs, etc.) came from prior results. Provide a consistent session_id across related requests to enable chain context.")
 		}
 
+		// Check whether the action exists on the adapter before checking task scope.
+		// This prevents confusing "out of scope" errors when the real issue is a
+		// non-existent action (e.g. calling search_messages on Gmail instead of list_messages).
+		if adp, adpOK := h.adapterReg.GetForUser(ctx, serviceType, agent.UserID); adpOK {
+			supported := adp.SupportedActions()
+			found := false
+			for _, a := range supported {
+				if a == req.Action {
+					found = true
+					break
+				}
+			}
+			if !found {
+				_ = h.store.IncrementTaskRequestCount(ctx, req.TaskID)
+				msg := fmt.Sprintf(
+					"Action %q does not exist on service %s. Available actions: %s",
+					req.Action, serviceType, strings.Join(supported, ", "),
+				)
+				taskIDPtr := &req.TaskID
+				e := baseEntry("unknown_action", "blocked", taskIDPtr)
+				e.DurationMS = int(time.Since(start).Milliseconds())
+				e.ErrorMsg = &msg
+				if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+					h.logger.Warn("audit log failed", "err", logErr)
+				}
+				h.publishAuditAndQueue(agent.UserID, req.TaskID)
+				writeDetailedError(w, http.StatusBadRequest, apiErrorDetail{
+					Error: msg,
+					Code:  "UNKNOWN_ACTION",
+					Hint:  fmt.Sprintf("This service does not have a %q action. Check the available actions listed above and use the correct one.", req.Action),
+				})
+				return
+			}
+		}
+
 		match := CheckTaskScope(task, serviceType, serviceAlias, req.Action)
 
 		if !match.InScope {


### PR DESCRIPTION
## Summary
- When an agent calls an action that doesn't exist on the adapter (e.g. `search_messages` on Gmail instead of `list_messages`), the gateway now returns a clear `400 UNKNOWN_ACTION` error listing available actions
- Previously this fell through to the task scope check, producing a misleading "outside this standing task's scope" error that caused agents to retry or create new tasks instead of fixing the action name
- Also bumps Gmail `list_messages` `max_results` cap from 50 → 200 for audit/compliance workflows

## Context
Discovered via a production user running a compliance audit across multiple Gmail accounts. The agent kept calling `search_messages` (a Slack-only action) on Gmail and getting scope mismatch errors, when the real fix was to use `list_messages` with a `query` param.

## Test plan
- [ ] Existing gateway handler tests pass
- [ ] Gmail adapter tests pass
- [ ] Verify `search_messages` on Gmail returns `UNKNOWN_ACTION` with available actions list
- [ ] Verify legitimate `list_messages` calls still work with `max_results` up to 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)