### PR TITLE
fix: detect OAuth services with empty scopes in service list

### DIFF
--- a/internal/api/handlers/services.go
+++ b/internal/api/handlers/services.go
@@ -228,7 +228,7 @@ func (h *ServicesHandler) List(w http.ResponseWriter, r *http.Request) {
 			Name:                 name,
 			Description:          desc,
 			IconSVG:              iconSVG,
-			OAuth:                len(a.RequiredScopes()) > 0,
+			OAuth:                a.RequiredScopes() != nil,
 			OAuthEndpoint:        oauthEndpoint,
 			DeviceFlow:           deviceFlow,
 			PKCEFlow:             pkceFlowDefined,              // show PKCE option if defined, even without client ID


### PR DESCRIPTION
## Summary
- Fix service list handler reporting OAuth services as non-OAuth when their scopes list is empty
- Change `len(a.RequiredScopes()) > 0` to `a.RequiredScopes() != nil`
- `RequiredScopes()` returns `nil` for non-OAuth services and `[]string{}` for OAuth with empty scopes, so `!= nil` correctly distinguishes them

This fixes Dropbox (and any future OAuth service with app-level rather than token-level permissions) showing a "paste your token" prompt instead of the OAuth connect flow.

## Test plan
- [ ] Verify Dropbox shows OAuth connect button instead of token paste prompt
- [ ] Verify existing OAuth services (Google, Slack, Linear, GitHub) still show OAuth flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)