### PR TITLE
feat: add Hermes to OpenClaw tab label on Agents page

### DIFF
--- a/web/src/pages/Agents.tsx
+++ b/web/src/pages/Agents.tsx
@@ -235,7 +235,7 @@ function ConnectAgentGuide() {
   }
 
   const tabs: { id: AgentTab; label: string }[] = [
-    { id: 'openclaw', label: 'OpenClaw' },
+    { id: 'openclaw', label: 'OpenClaw / Hermes' },
     { id: 'claude-code', label: 'Claude Code' },
     { id: 'claude-desktop', label: 'Claude Desktop' },
     { id: 'other', label: 'Other Agents' },


### PR DESCRIPTION
Updates the Agents page tab label from "OpenClaw" to "OpenClaw / Hermes" to reflect Hermes's growing popularity as an agent platform.