### PR TITLE
fix: only send Google-specific OAuth params for Google endpoints

### DIFF
--- a/internal/api/handlers/services.go
+++ b/internal/api/handlers/services.go
@@ -1279,14 +1279,21 @@ func adapterTokenPath(a adapters.Adapter) string {
 // scopeParam overrides the query parameter name for scopes (e.g. "user_scope"
 // for Slack v2). When empty, the default "scope" parameter is used.
 func oauthAuthURL(cfg *oauth2.Config, stateToken string, selectAccount bool, scopeParam string) string {
-	prompt := "consent"
-	if selectAccount {
-		prompt = "consent select_account"
-	}
 	opts := []oauth2.AuthCodeOption{
 		oauth2.AccessTypeOffline,
-		oauth2.SetAuthURLParam("include_granted_scopes", "true"),
-		oauth2.SetAuthURLParam("prompt", prompt),
+	}
+	// Google-specific parameters: include_granted_scopes for incremental
+	// authorization, and prompt for account selection. Other providers
+	// (e.g. Dropbox) reject these.
+	if strings.Contains(cfg.Endpoint.AuthURL, "google.com") {
+		prompt := "consent"
+		if selectAccount {
+			prompt = "consent select_account"
+		}
+		opts = append(opts,
+			oauth2.SetAuthURLParam("include_granted_scopes", "true"),
+			oauth2.SetAuthURLParam("prompt", prompt),
+		)
 	}
 	if scopeParam != "" && scopeParam != "scope" {
 		// Move scopes to the custom parameter (e.g. Slack v2 "user_scope")


### PR DESCRIPTION
## Summary
- `include_granted_scopes` and `prompt` are Google-specific OAuth parameters
- Dropbox rejects `include_granted_scopes=true` (expects `"user"` or `"team"`, not `"true"`)
- Only add these params when the authorize URL is a Google endpoint

## Test plan
- [ ] Verify Dropbox OAuth flow completes without error
- [ ] Verify Google OAuth services still work (incremental scopes, account selection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)