### PR TITLE
fix: guard verify-email against StrictMode double-invoke

### DIFF
--- a/web/src/pages/VerifyEmail.tsx
+++ b/web/src/pages/VerifyEmail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import { api, APIError } from '../api/client'
 import { useAuth } from '../hooks/useAuth'
@@ -12,6 +12,9 @@ export default function VerifyEmail() {
   const [verifying, setVerifying] = useState(true)
   const [destination, setDestination] = useState<string | null>(null)
   const { isAuthenticated } = useAuth()
+  // Prevents React StrictMode's double-invoke from firing two concurrent
+  // verify requests for the same single-use token.
+  const didVerify = useRef(false)
 
   useEffect(() => {
     if (!token) {
@@ -19,6 +22,8 @@ export default function VerifyEmail() {
       setVerifying(false)
       return
     }
+    if (didVerify.current) return
+    didVerify.current = true
 
     let cancelled = false
     async function verify() {


### PR DESCRIPTION
## Summary
- React StrictMode double-fires the `useEffect` in `VerifyEmail.tsx`, causing two concurrent `POST /api/auth/verify-email` requests for the same single-use token
- The second request races the first and hits a 500 when the pending registration has already been consumed
- Adds a `useRef` guard to ensure the verify call only fires once — same pattern already used in `useAuth` for refresh token restoration

## Test plan
- [ ] Register a new account and verify via email link — should succeed without 500 errors in the server log
- [ ] Verify that re-clicking the verification link still works (existing double-click handling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)