### PR TITLE
fix: remove cancelled flag that blocks verify in StrictMode

### DIFF
--- a/web/src/pages/VerifyEmail.tsx
+++ b/web/src/pages/VerifyEmail.tsx
@@ -25,27 +25,21 @@ export default function VerifyEmail() {
     if (didVerify.current) return
     didVerify.current = true
 
-    let cancelled = false
     async function verify() {
       try {
         const result = await api.auth.verifyEmail(token)
-        if (!cancelled) {
-          setSession(result.access_token, result.refresh_token, result.user)
-          setDestination('/onboarding')
-        }
+        setSession(result.access_token, result.refresh_token, result.user)
+        setDestination('/onboarding')
       } catch (err) {
-        if (!cancelled) {
-          if (err instanceof APIError) {
-            setError(err.message)
-          } else {
-            setError('Verification failed. The link may have expired.')
-          }
-          setVerifying(false)
+        if (err instanceof APIError) {
+          setError(err.message)
+        } else {
+          setError('Verification failed. The link may have expired.')
         }
+        setVerifying(false)
       }
     }
     verify()
-    return () => { cancelled = true }
   }, [token, setSession])
 
   useEffect(() => {

--- a/web/src/pages/VerifyEmail.tsx
+++ b/web/src/pages/VerifyEmail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import { api, APIError } from '../api/client'
 import { useAuth } from '../hooks/useAuth'
@@ -12,6 +12,9 @@ export default function VerifyEmail() {
   const [verifying, setVerifying] = useState(true)
   const [destination, setDestination] = useState<string | null>(null)
   const { isAuthenticated } = useAuth()
+  // Prevents React StrictMode's double-invoke from firing two concurrent
+  // verify requests for the same single-use token.
+  const didVerify = useRef(false)
 
   useEffect(() => {
     if (!token) {
@@ -19,6 +22,8 @@ export default function VerifyEmail() {
       setVerifying(false)
       return
     }
+    if (didVerify.current) return
+    didVerify.current = true
 
     let cancelled = false
     async function verify() {


### PR DESCRIPTION
## Summary
- Follow-up to #236: the `useRef` guard prevents double-firing, but StrictMode's cleanup still set `cancelled = true` on the only request that actually fired
- This prevented state from ever updating, leaving the page stuck on "Verifying your email..."
- Since the ref already ensures single execution, the `cancelled` flag is redundant — remove it

## Test plan
- [ ] Register a new account and click the verification link — should advance past "Verifying your email..." to onboarding

🤖 Generated with [Claude Code](https://claude.com/claude-code)