### PR TITLE
feat: replace free trial with permanent free tier

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -627,6 +627,8 @@ export interface BillingPlan {
   max_connections: number
   included_requests: number
   overage_per_request?: number
+  soft_cap_note?: string
+  features?: string[]
   contact_us?: boolean
 }
 
@@ -637,8 +639,6 @@ export interface BillingStatus {
   current_period_start?: string
   current_period_end?: string
   cancel_at_period_end?: boolean
-  trial_ends_at?: string
-  trial_days_remaining?: number
   stripe_publishable_key?: string
   usage?: {
     requests: { used: number; limit: number }
@@ -663,11 +663,6 @@ export interface PromoValidation {
 
 export interface BillingPlansResponse {
   plans: BillingPlan[]
-  trial: {
-    duration_days: number
-    included_requests: number
-    max_connections: number
-  }
 }
 
 // ── Org types ─────────────────────────────────────────────────────────────────
@@ -1056,8 +1051,8 @@ export const api = {
       post<{ status: string }>('/api/billing/promo', { code }),
     validatePromo: (code: string) =>
       post<PromoValidation>('/api/billing/promo/validate', { code }),
-    startTrial: (promoCode?: string) =>
-      post<{ status: string }>('/api/billing/trial', { promo_code: promoCode || '' }),
+    activateFreeTier: () =>
+      post<{ status: string }>('/api/billing/activate', {}),
   },
   oauthApprove: (params: {
     client_id: string

--- a/web/src/pages/Billing.tsx
+++ b/web/src/pages/Billing.tsx
@@ -55,8 +55,7 @@ export default function Billing() {
   const planDisplay = status?.plan_display_name ?? plan
   const subStatus = status?.status ?? 'none'
   const isGrandfathered = plan === 'grandfathered'
-  const isTrialing = subStatus === 'trialing'
-  const isActive = subStatus === 'active' || subStatus === 'trialing'
+  const isActive = subStatus === 'active'
   const isPastDue = subStatus === 'past_due'
   const isCanceled = subStatus === 'canceled' || subStatus === 'unpaid'
   const isCanceling = !!(status?.cancel_at_period_end && isActive)
@@ -85,12 +84,6 @@ export default function Billing() {
               <StatusBadge status={subStatus} />
             </div>
           </div>
-
-          {isTrialing && status?.trial_days_remaining != null && !status?.discount && (
-            <div className="text-sm text-text-secondary">
-              Trial ends in <span className="font-medium text-text-primary">{status.trial_days_remaining} day{status.trial_days_remaining !== 1 ? 's' : ''}</span>
-            </div>
-          )}
 
           {isPastDue && (
             <div className="text-sm text-warning">
@@ -131,7 +124,7 @@ export default function Billing() {
                   {portalMut.isPending ? 'Opening...' : 'Manage subscription'}
                 </button>
               )}
-              {(!hasSubscription || (isTrialing && !status?.discount) || isCanceled) && (
+              {(!hasSubscription || isCanceled || plan === 'free') && (
                 <button
                   onClick={() => navigate('/pricing')}
                   className="px-3 py-1.5 text-sm font-medium rounded-md bg-brand text-surface-0 hover:bg-brand-strong transition-colors"
@@ -260,14 +253,12 @@ export default function Billing() {
 function StatusBadge({ status }: { status: string }) {
   const colors: Record<string, string> = {
     active: 'bg-success/10 text-success',
-    trialing: 'bg-brand-muted text-brand',
     past_due: 'bg-warning/10 text-warning',
     canceled: 'bg-danger/10 text-danger',
     unpaid: 'bg-danger/10 text-danger',
   }
   const labels: Record<string, string> = {
     active: 'Active',
-    trialing: 'Trial',
     past_due: 'Past due',
     canceled: 'Canceled',
     unpaid: 'Unpaid',

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -74,7 +74,7 @@ export default function Dashboard() {
     queryFn: () => api.llm.status(),
   })
 
-  // Billing status (for trial banner and expired state) — only when billing is enabled.
+  // Billing status (for expired state banner) — only when billing is enabled.
   const billingEnabled = !!features?.billing
   const { data: billingStatus, isLoading: billingLoading } = useQuery({
     queryKey: ['billing-status'],
@@ -282,21 +282,7 @@ export default function Dashboard() {
             </NavLink>
           </div>
         )}
-        {billingStatus?.status === 'trialing' && billingStatus.trial_days_remaining != null && !billingStatus.discount && (
-          <div className="mx-4 mt-3 px-4 py-2.5 rounded-md bg-brand-muted border border-brand/30 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 text-sm">
-            <span className="text-text-primary">
-              <span className="font-medium">{billingStatus.trial_days_remaining} day{billingStatus.trial_days_remaining !== 1 ? 's' : ''} left in your free trial.</span>
-              <span className="text-text-secondary"> Choose a plan to keep using Clawvisor.</span>
-            </span>
-            <NavLink
-              to="/pricing"
-              className="text-brand hover:text-brand/80 font-medium transition-colors whitespace-nowrap"
-            >
-              Choose a plan
-            </NavLink>
-          </div>
-        )}
-        {billingStatus && !['trialing', 'active', 'past_due', 'none'].includes(billingStatus.status) && billingStatus.plan !== 'none' && (
+        {billingStatus && !['active', 'past_due', 'none'].includes(billingStatus.status) && billingStatus.plan !== 'none' && (
           <div className="mx-4 mt-3 px-4 py-2.5 rounded-md bg-danger/10 border border-danger/30 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 text-sm">
             <span className="text-text-primary">
               <span className="font-medium">Your subscription has expired.</span>

--- a/web/src/pages/Pricing.tsx
+++ b/web/src/pages/Pricing.tsx
@@ -51,7 +51,10 @@ function PlanCard({ plan, isCurrent, onSelect, loading }: {
         </li>
         <li className="flex items-start gap-2">
           {checkIcon}
-          <span>{plan.included_requests < 0 ? 'Unlimited' : plan.included_requests.toLocaleString()} requests/month</span>
+          <span>
+            {plan.included_requests < 0 ? 'Unlimited' : plan.included_requests.toLocaleString()} requests/month
+            {plan.soft_cap_note && <span className="block text-xs text-text-tertiary mt-0.5">{plan.soft_cap_note}</span>}
+          </span>
         </li>
         {plan.overage_per_request != null && plan.overage_per_request > 0 && (
           <li className="flex items-start gap-2">
@@ -142,21 +145,9 @@ export default function Pricing() {
         <div className="text-center mb-12">
           <h1 className="text-3xl font-bold text-text-primary mb-3">Choose your plan</h1>
           <p className="text-text-secondary max-w-lg mx-auto">
-            Start with a free 7-day trial. No credit card required.
+            Get started for free. Upgrade when you need more.
           </p>
         </div>
-
-        {/* Trial banner */}
-        {(!isAuthenticated || currentPlan === 'none') && (
-          <div className="mb-10 text-center">
-            <div className="inline-flex items-center gap-2 bg-brand-muted text-brand text-sm font-medium px-4 py-2 rounded-full">
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-                <path d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
-              7-day free trial with Pro plan features
-            </div>
-          </div>
-        )}
 
         {isLoading ? (
           <div className="text-center text-text-tertiary py-12">Loading plans...</div>

--- a/web/src/pages/Pricing.tsx
+++ b/web/src/pages/Pricing.tsx
@@ -52,8 +52,14 @@ function PlanCard({ plan, isCurrent, onSelect, loading }: {
         <li className="flex items-start gap-2">
           {checkIcon}
           <span>
-            {plan.included_requests < 0 ? 'Unlimited' : plan.included_requests.toLocaleString()} requests/month
-            {plan.soft_cap_note && <span className="block text-xs text-text-tertiary mt-0.5">{plan.soft_cap_note}</span>}
+            {plan.soft_cap_note ? (
+              <>
+                <span className="line-through text-text-tertiary">{plan.included_requests.toLocaleString()} requests/month</span>{' '}
+                <span className="text-brand font-medium text-sm">Uncapped during early access</span>
+              </>
+            ) : (
+              <>{plan.included_requests < 0 ? 'Unlimited' : plan.included_requests.toLocaleString()} requests/month</>
+            )}
           </span>
         </li>
         {plan.overage_per_request != null && plan.overage_per_request > 0 && (

--- a/web/src/pages/Services.tsx
+++ b/web/src/pages/Services.tsx
@@ -334,9 +334,6 @@ function AddServiceModal({
   })
   const connectionLimit = billingStatus?.usage?.connections?.limit ?? -1
   const atConnectionLimit = connectionLimit >= 0 && activeConnectionCount >= connectionLimit
-  const STARTER_CONNECTION_LIMIT = 5
-  const isTrialing = billingStatus?.status === 'trialing'
-  const trialExceedsStarter = isTrialing && activeConnectionCount >= STARTER_CONNECTION_LIMIT
 
   // Search filter
   const [search, setSearch] = useState('')
@@ -647,12 +644,6 @@ function AddServiceModal({
               <span className="text-text-secondary"> ({activeConnectionCount}/{connectionLimit}). </span>
               <a href="/pricing" className="text-brand hover:text-brand/80 font-medium">Upgrade your plan</a>
               <span className="text-text-secondary"> for more connections.</span>
-            </div>
-          )}
-          {!atConnectionLimit && trialExceedsStarter && (
-            <div className="mb-3 px-3 py-2.5 rounded-md bg-brand-muted border border-brand/30 text-sm">
-              <span className="font-medium text-text-primary">Heads up:</span>
-              <span className="text-text-secondary"> You have {activeConnectionCount} connections. The Starter plan only allows {STARTER_CONNECTION_LIMIT}. If you choose Starter after your trial, you won't be able to create new tasks or make any requests until you're under the limit.</span>
             </div>
           )}
           {error && <p className="text-xs text-danger mb-3">{error}</p>}

--- a/web/src/pages/Welcome.tsx
+++ b/web/src/pages/Welcome.tsx
@@ -47,7 +47,7 @@ export default function Welcome() {
               </li>
               <li className="flex items-center gap-2">
                 <svg className="w-4 h-4 text-success shrink-0" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M20 6L9 17l-5-5" /></svg>
-                1,000 gateway requests/month (degraded performance above limit)
+                1,000 gateway requests/month
               </li>
               <li className="flex items-center gap-2">
                 <svg className="w-4 h-4 text-success shrink-0" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M20 6L9 17l-5-5" /></svg>

--- a/web/src/pages/Welcome.tsx
+++ b/web/src/pages/Welcome.tsx
@@ -1,14 +1,10 @@
-import { useState } from 'react'
 import { Navigate, useNavigate } from 'react-router-dom'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { api, type PromoValidation } from '../api/client'
+import { api } from '../api/client'
 
 export default function Welcome() {
   const navigate = useNavigate()
   const qc = useQueryClient()
-  const [promoCode, setPromoCode] = useState('')
-  const [promoError, setPromoError] = useState<string | null>(null)
-  const [validatedPromo, setValidatedPromo] = useState<PromoValidation | null>(null)
 
   // If the user already has an active plan (e.g. grandfathered), skip welcome.
   const { data: billingStatus, isLoading } = useQuery({
@@ -20,39 +16,13 @@ export default function Welcome() {
     return <Navigate to="/dashboard" replace />
   }
 
-  const validateMut = useMutation({
-    mutationFn: (code: string) => api.billing.validatePromo(code),
-    onSuccess: (data) => {
-      setValidatedPromo(data)
-      setPromoError(null)
-    },
-    onError: () => {
-      setValidatedPromo(null)
-      setPromoError('Invalid or expired promo code')
-    },
-  })
-
-  const trialMut = useMutation({
-    mutationFn: (promo?: string) => api.billing.startTrial(promo),
+  const activateMut = useMutation({
+    mutationFn: () => api.billing.activateFreeTier(),
     onSuccess: async () => {
       await qc.invalidateQueries({ queryKey: ['billing-status'] })
       navigate('/dashboard')
     },
   })
-
-  const handleApplyPromo = () => {
-    const code = promoCode.trim()
-    if (!code) return
-    validateMut.mutate(code)
-  }
-
-  const handleStart = () => {
-    trialMut.mutate(validatedPromo ? promoCode.trim() : undefined)
-  }
-
-  const promoDescription = validatedPromo
-    ? formatPromo(validatedPromo)
-    : null
 
   return (
     <div className="min-h-screen bg-surface-0 flex items-center justify-center">
@@ -63,13 +33,13 @@ export default function Welcome() {
           </div>
           <h1 className="text-2xl font-bold text-text-primary">Welcome to Clawvisor</h1>
           <p className="text-text-secondary mt-2">
-            Start your free 7-day trial with full Pro plan features. No credit card required.
+            Get started for free. No credit card required.
           </p>
         </div>
 
         <div className="bg-surface-1 border border-border-default rounded-lg p-6 space-y-5">
           <div className="space-y-3">
-            <h3 className="text-sm font-semibold text-text-primary">Your trial includes:</h3>
+            <h3 className="text-sm font-semibold text-text-primary">Your free plan includes:</h3>
             <ul className="space-y-2 text-sm text-text-secondary">
               <li className="flex items-center gap-2">
                 <svg className="w-4 h-4 text-success shrink-0" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M20 6L9 17l-5-5" /></svg>
@@ -77,81 +47,32 @@ export default function Welcome() {
               </li>
               <li className="flex items-center gap-2">
                 <svg className="w-4 h-4 text-success shrink-0" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M20 6L9 17l-5-5" /></svg>
-                10,000 gateway requests/month
+                1,000 gateway requests/month (degraded performance above limit)
               </li>
               <li className="flex items-center gap-2">
                 <svg className="w-4 h-4 text-success shrink-0" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M20 6L9 17l-5-5" /></svg>
-                7 days free, cancel anytime
+                Free forever, upgrade anytime
               </li>
             </ul>
           </div>
 
-          <div className="space-y-2">
-            <label className="text-sm font-medium text-text-primary">Promo code <span className="text-text-tertiary font-normal">(optional)</span></label>
-            <div className="flex gap-2">
-              <input
-                type="text"
-                value={promoCode}
-                onChange={(e) => {
-                  setPromoCode(e.target.value)
-                  setPromoError(null)
-                  if (validatedPromo) setValidatedPromo(null)
-                }}
-                placeholder="Enter promo code"
-                className="flex-1 px-3 py-2 text-sm rounded-md border border-border-default bg-surface-0 text-text-primary placeholder:text-text-tertiary focus:outline-none focus:border-brand"
-              />
-              <button
-                onClick={handleApplyPromo}
-                disabled={!promoCode.trim() || validateMut.isPending}
-                className="px-3 py-2 text-sm rounded-md border border-border-default text-text-primary hover:bg-surface-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {validateMut.isPending ? 'Checking...' : 'Apply'}
-              </button>
-            </div>
-            {promoError && <p className="text-xs text-danger">{promoError}</p>}
-            {promoDescription && (
-              <p className="text-xs text-success font-medium">{promoDescription}</p>
-            )}
-          </div>
-
           <button
-            onClick={handleStart}
-            disabled={trialMut.isPending}
+            onClick={() => activateMut.mutate()}
+            disabled={activateMut.isPending}
             className="w-full py-2.5 px-4 rounded-md bg-brand text-surface-0 text-sm font-medium hover:bg-brand-strong transition-colors disabled:opacity-70"
           >
-            {trialMut.isPending
-              ? 'Starting...'
-              : validatedPromo
-                ? `Start with ${validatedPromo.name}`
-                : 'Start free trial'}
+            {activateMut.isPending ? 'Activating...' : 'Get started'}
           </button>
 
-          {trialMut.isError && (
-            <p className="text-xs text-danger text-center">Failed to start trial. Please try again.</p>
+          {activateMut.isError && (
+            <p className="text-xs text-danger text-center">Something went wrong. Please try again.</p>
           )}
         </div>
 
         <p className="text-center text-xs text-text-tertiary mt-4">
-          After your trial ends, choose a plan starting at $19/month.
+          Need more? Upgrade to Pro for $199/month.
         </p>
       </div>
     </div>
   )
-}
-
-function formatPromo(promo: PromoValidation): string {
-  const parts: string[] = []
-  if (promo.percent_off === 100) {
-    parts.push('100% off')
-  } else if (promo.percent_off) {
-    parts.push(`${promo.percent_off}% off`)
-  } else if (promo.amount_off) {
-    parts.push(`$${(promo.amount_off / 100).toFixed(0)} off`)
-  }
-  if (promo.duration_months) {
-    parts.push(`for ${promo.duration_months} months`)
-  } else if (promo.duration === 'forever') {
-    parts.push('forever')
-  }
-  return `${promo.name} applied — ${parts.join(' ')}`
 }

--- a/web/src/pages/Welcome.tsx
+++ b/web/src/pages/Welcome.tsx
@@ -47,7 +47,8 @@ export default function Welcome() {
               </li>
               <li className="flex items-center gap-2">
                 <svg className="w-4 h-4 text-success shrink-0" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M20 6L9 17l-5-5" /></svg>
-                1,000 gateway requests/month
+                <span className="line-through text-text-tertiary">1,000 gateway requests/month</span>{' '}
+                <span className="text-brand font-medium">Uncapped during early access</span>
               </li>
               <li className="flex items-center gap-2">
                 <svg className="w-4 h-4 text-success shrink-0" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M20 6L9 17l-5-5" /></svg>


### PR DESCRIPTION
## Summary
- Remove trial countdown banners, promo code input, and trial-specific status handling from all pages
- Update API client to use `/api/billing/activate` endpoint instead of `/api/billing/trial`
- Add `soft_cap_note` and `features` fields to `BillingPlan` type
- Update Welcome page copy for free tier (1,000 requests/month, no credit card, upgrade anytime)

## Test plan
- [ ] Verify Welcome page renders correctly with free tier copy
- [ ] Verify free tier activation works via the new endpoint
- [ ] Verify Billing page shows "Choose a plan" for free users
- [ ] Verify Pricing page shows soft cap note and no trial banner
- [ ] Verify Dashboard has no trial countdown banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)