### PR TITLE
fix: retry LLM verification on overload with jittered backoff

### DIFF
--- a/internal/intent/verifier.go
+++ b/internal/intent/verifier.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
+	"math/rand/v2"
 	"time"
 
 	"github.com/clawvisor/clawvisor/internal/llm"
@@ -115,6 +116,16 @@ func (v *LLMVerifier) Verify(ctx context.Context, req VerifyRequest) (*Verificat
 				break // no point retrying a spend cap error
 			}
 			if attempt == 0 {
+				// Jittered backoff: 2s ± 1s (uniform [1s, 3s]).
+				jitter := time.Duration(1000+rand.IntN(2001)) * time.Millisecond
+				t := time.NewTimer(jitter)
+				select {
+				case <-t.C:
+				case <-ctx.Done():
+					t.Stop()
+					lastErr = ctx.Err()
+					break // breaks select; next Complete call will fail fast on cancelled ctx
+				}
 				continue
 			}
 			break

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -25,6 +25,10 @@ import (
 // user-facing prompt to provide their own API key.
 var ErrSpendCapExhausted = errors.New("haiku proxy spend cap exhausted")
 
+// ErrOverloaded is returned when the LLM provider signals it is overloaded
+// (HTTP 529 or 503). Callers can check with errors.Is to apply back-off.
+var ErrOverloaded = errors.New("llm provider overloaded")
+
 const anthropicVersion       = "2023-06-01"
 const vertexAnthropicVersion = "vertex-2023-10-16"
 
@@ -114,6 +118,9 @@ func (c *Client) statusError(statusCode int, body []byte) error {
 	base := fmt.Errorf("llm: %s %s status %d: %s", c.provider, c.model, statusCode, body)
 	if strings.HasPrefix(c.apiKey, "hkp_") && (statusCode == http.StatusPaymentRequired || statusCode == http.StatusTooManyRequests) {
 		return fmt.Errorf("%w: %w", ErrSpendCapExhausted, base)
+	}
+	if statusCode == 529 || statusCode == http.StatusServiceUnavailable {
+		return fmt.Errorf("%w: %w", ErrOverloaded, base)
 	}
 	return base
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -256,7 +256,7 @@ func Default() *Config {
 			TimeoutSeconds: 10,
 			Verification: VerificationConfig{
 				LLMProviderConfig: LLMProviderConfig{
-					TimeoutSeconds: 5,
+					TimeoutSeconds: 15,
 				},
 				FailClosed:      true,
 				CacheTTLSeconds: 60,


### PR DESCRIPTION
## Summary

Vertex AI (us-east5) has been returning HTTP 529 (overloaded) and timing out under load, causing fail-closed intent verification to silently block gateway requests for users. This adds resilience to the verification path:

- Adds `ErrOverloaded` sentinel error for HTTP 529/503 responses
- Adds jittered backoff (1-3s) and retry on first verification failure
- Bumps verification timeout from 5s to 15s to accommodate retry + slow Vertex responses

## Test plan
- [ ] Verify gateway requests succeed under normal Vertex latency
- [ ] Simulate 529 from Vertex and confirm retry recovers
- [ ] Confirm context cancellation during backoff exits cleanly
- [ ] Check that spend-cap errors still skip retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)