### PR TITLE
fix: rotate agent token on --replace instead of delete+recreate

### DIFF
--- a/cmd/clawvisor/cmd_agent.go
+++ b/cmd/clawvisor/cmd_agent.go
@@ -33,14 +33,32 @@ var agentCreateCmd = &cobra.Command{
 			return err
 		}
 
-		// If --replace, delete any existing agent with the same name first.
+		// If --replace and an agent with the same name exists, rotate its
+		// token instead of deleting and recreating. This preserves the
+		// agent ID, active tasks, and group pairings.
 		if agentCreateReplace {
 			existing, _ := cl.GetAgents()
 			for _, a := range existing {
 				if a.Name == name {
-					_ = cl.DeleteAgent(a.ID)
+					rotated, err := cl.RotateAgentToken(a.ID)
+					if err != nil {
+						return fmt.Errorf("rotating token: %w", err)
+					}
+					if agentCreateJSON {
+						out := map[string]string{
+							"id":    rotated.ID,
+							"name":  name,
+							"token": rotated.Token,
+						}
+						enc := json.NewEncoder(os.Stdout)
+						return enc.Encode(out)
+					}
+					fmt.Printf("Agent token rotated: %s (id: %s)\n", name, rotated.ID)
+					fmt.Printf("Token: %s\n", rotated.Token)
+					return nil
 				}
 			}
+			// No existing agent found — fall through to create.
 		}
 
 		agent, err := cl.CreateAgentWithOpts(name, agentCreateWithCallback)
@@ -148,7 +166,7 @@ var agentDeleteCmd = &cobra.Command{
 func init() {
 	agentCreateCmd.Flags().BoolVar(&agentCreateJSON, "json", false, "Output in JSON format")
 	agentCreateCmd.Flags().BoolVar(&agentCreateWithCallback, "with-callback-secret", false, "Generate and register a callback signing secret")
-	agentCreateCmd.Flags().BoolVar(&agentCreateReplace, "replace", false, "Delete existing agent with same name before creating")
+	agentCreateCmd.Flags().BoolVar(&agentCreateReplace, "replace", false, "Rotate token for existing agent with same name, or create if not found")
 
 	agentListCmd.Flags().BoolVar(&agentListJSON, "json", false, "Output in JSON format")
 

--- a/internal/api/handlers/agents.go
+++ b/internal/api/handlers/agents.go
@@ -101,6 +101,41 @@ func (h *AgentsHandler) List(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, agents)
 }
 
+// RotateToken generates a new token for an existing agent without deleting
+// the agent record, preserving the agent ID, tasks, and group pairings.
+//
+// POST /api/agents/{id}/rotate
+// Auth: user JWT
+func (h *AgentsHandler) RotateToken(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "not authenticated")
+		return
+	}
+
+	id := r.PathValue("id")
+
+	rawToken, err := auth.GenerateAgentToken()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not generate token")
+		return
+	}
+
+	if err := h.st.RotateAgentToken(r.Context(), id, user.ID, auth.HashToken(rawToken)); err != nil {
+		if err == store.ErrNotFound {
+			writeError(w, http.StatusNotFound, "NOT_FOUND", "agent not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not rotate token")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"id":    id,
+		"token": rawToken,
+	})
+}
+
 // Delete removes an agent by ID. Any active or pending tasks belonging to
 // the agent are revoked before the agent record is deleted.
 //

--- a/internal/api/middleware/agent.go
+++ b/internal/api/middleware/agent.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"context"
+	"errors"
 	"net/http"
 
 	"github.com/clawvisor/clawvisor/internal/auth"
@@ -29,7 +30,14 @@ func RequireAgent(st store.Store) func(http.Handler) http.Handler {
 			hash := auth.HashToken(token)
 			agent, err := st.GetAgentByToken(r.Context(), hash)
 			if err != nil {
-				http.Error(w, `{"error":"invalid agent token","code":"UNAUTHORIZED"}`, http.StatusUnauthorized)
+				if errors.Is(err, store.ErrNotFound) {
+					http.Error(w, `{"error":"invalid agent token","code":"UNAUTHORIZED"}`, http.StatusUnauthorized)
+				} else {
+					// Transient database error (e.g. SQLite busy) — return 503
+					// so agents know to retry instead of assuming their token
+					// was revoked.
+					http.Error(w, `{"error":"temporary service error, please retry","code":"SERVICE_UNAVAILABLE"}`, http.StatusServiceUnavailable)
+				}
 				return
 			}
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -525,6 +525,7 @@ func (s *Server) routes() http.Handler {
 	// Agents (user JWT)
 	mux.Handle("GET /api/agents", user(agentsHandler.List))
 	mux.Handle("POST /api/agents", user(agentsHandler.Create))
+	mux.Handle("POST /api/agents/{id}/rotate", user(agentsHandler.RotateToken))
 	mux.Handle("DELETE /api/agents/{id}", user(agentsHandler.Delete))
 
 	// Notifications (user JWT)

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -269,6 +269,20 @@ func (s *Store) DeleteAgent(ctx context.Context, id, userID string) error {
 	return nil
 }
 
+func (s *Store) RotateAgentToken(ctx context.Context, id, userID, newTokenHash string) error {
+	tag, err := s.pool.Exec(ctx,
+		`UPDATE agents SET token_hash = $1 WHERE id = $2 AND user_id = $3 AND deleted_at IS NULL`,
+		newTokenHash, id, userID,
+	)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return store.ErrNotFound
+	}
+	return nil
+}
+
 func (s *Store) SetAgentCallbackSecret(ctx context.Context, agentID, secret string) error {
 	tag, err := s.pool.Exec(ctx,
 		`UPDATE agents SET callback_secret = $1 WHERE id = $2 AND deleted_at IS NULL`,

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -30,8 +30,14 @@ func New(ctx context.Context, path string) (*sql.DB, error) {
 		return nil, fmt.Errorf("pinging sqlite: %w", err)
 	}
 
-	// Enable WAL mode and foreign keys for every connection
+	// Enable WAL mode, foreign keys, and a busy timeout so concurrent
+	// readers (agent auth) don't fail immediately when the single
+	// connection is held by a dashboard write.
 	if _, err := db.ExecContext(ctx, `PRAGMA journal_mode = WAL`); err != nil {
+		db.Close()
+		return nil, err
+	}
+	if _, err := db.ExecContext(ctx, `PRAGMA busy_timeout = 5000`); err != nil {
 		db.Close()
 		return nil, err
 	}

--- a/internal/store/sqlite/store.go
+++ b/internal/store/sqlite/store.go
@@ -304,6 +304,21 @@ func (s *Store) DeleteAgent(ctx context.Context, id, userID string) error {
 	return nil
 }
 
+func (s *Store) RotateAgentToken(ctx context.Context, id, userID, newTokenHash string) error {
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE agents SET token_hash = ? WHERE id = ? AND user_id = ? AND deleted_at IS NULL`,
+		newTokenHash, id, userID,
+	)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return store.ErrNotFound
+	}
+	return nil
+}
+
 func (s *Store) SetAgentCallbackSecret(ctx context.Context, agentID, secret string) error {
 	res, err := s.db.ExecContext(ctx,
 		`UPDATE agents SET callback_secret = ? WHERE id = ? AND deleted_at IS NULL`,

--- a/internal/tui/client/client.go
+++ b/internal/tui/client/client.go
@@ -448,6 +448,16 @@ func (c *Client) DeleteAgent(id string) error {
 	return c.delete("/api/agents/" + id)
 }
 
+// RotateAgentToken generates a new token for an existing agent, preserving
+// the agent ID, tasks, and group pairings.
+func (c *Client) RotateAgentToken(id string) (*Agent, error) {
+	var resp Agent
+	if err := c.post("/api/agents/"+id+"/rotate", nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
 // ── Health ──────────────────────────────────────────────────────────────────
 
 func (c *Client) Health() error {

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -36,6 +36,7 @@ type Store interface {
 	GetAgentByToken(ctx context.Context, tokenHash string) (*Agent, error)
 	ListAgents(ctx context.Context, userID string) ([]*Agent, error)
 	DeleteAgent(ctx context.Context, id, userID string) error
+	RotateAgentToken(ctx context.Context, id, userID, newTokenHash string) error
 	SetAgentCallbackSecret(ctx context.Context, agentID, secret string) error
 	GetAgentCallbackSecret(ctx context.Context, agentID string) (string, error)
 


### PR DESCRIPTION
The `--replace` flag on `agent create` was deleting and recreating the agent, which wiped the agent ID, active tasks, and group pairings. This changes it to rotate the token in-place via a new `RotateAgentToken` store method and `POST /api/agents/{id}/rotate` endpoint.

Also improves SQLite resilience by adding a 5s `busy_timeout` pragma to prevent transient failures under concurrent access, and returns 503 (instead of 401) from agent auth middleware on transient DB errors so agents know to retry instead of assuming their token was revoked.