### PR TITLE
Add /skill proxy to Vite dev server

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     allowedHosts: true,
     proxy: {
       '/api': 'http://localhost:25297',
+      '/skill': 'http://localhost:25297',
       '/health': 'http://localhost:25297',
       '/ready': 'http://localhost:25297',
       '/ws': {


### PR DESCRIPTION
## Summary
- Adds `/skill` to the Vite dev server proxy config so that `/skill/*` requests are forwarded to the backend during local development, matching the existing `/api` proxy behavior.

## Test plan
- [ ] Run `npm run dev` in `web/` and verify `/skill/*` requests are proxied to the backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)