### PR TITLE
feat: add connect-src CSP for local daemon pairing

### DIFF
--- a/internal/api/middleware/security.go
+++ b/internal/api/middleware/security.go
@@ -10,7 +10,7 @@ func Security(isLocal bool) func(http.Handler) http.Handler {
 			h.Set("X-Content-Type-Options", "nosniff")
 			h.Set("X-Frame-Options", "DENY")
 			h.Set("Referrer-Policy", "strict-origin-when-cross-origin")
-			h.Set("Content-Security-Policy", "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; frame-ancestors 'none'; form-action 'self'")
+			h.Set("Content-Security-Policy", "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' http://localhost:25299; frame-ancestors 'none'; form-action 'self'")
 			if !isLocal {
 				h.Set("Strict-Transport-Security", "max-age=63072000; includeSubDomains")
 			}


### PR DESCRIPTION
## Summary
- Adds `connect-src 'self' http://localhost:25299` to the global CSP in the security middleware
- The Settings page probes `http://localhost:25299/api/status` to detect a running clawvisor-local daemon, but the previous CSP had no `connect-src` directive, so it fell back to `default-src 'self'` which blocked the cross-origin fetch

## Test plan
- [ ] Verify the Settings page can successfully probe a running local daemon on port 25299
- [ ] Verify no other cross-origin requests are unintentionally allowed

🤖 Generated with [Claude Code](https://claude.com/claude-code)