### PR TITLE
fix: skip localhost daemon probe when no daemons are paired

### DIFF
--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -1508,6 +1508,9 @@ function LocalDaemonPairing() {
   }
 
   // Probe localhost to see if a daemon is running and get its ID.
+  // Only probe when there are already paired daemons — avoids unnecessary
+  // localhost requests (and CSP/network errors) when no daemon exists.
+  const hasDaemons = (daemons ?? []).length > 0
   const { data: localDaemonId } = useQuery({
     queryKey: ['local-daemon-probe'],
     queryFn: async () => {
@@ -1519,6 +1522,7 @@ function LocalDaemonPairing() {
       } catch { return null }
     },
     staleTime: 30000,
+    enabled: hasDaemons,
   })
 
   const localAlreadyPaired = !!(localDaemonId && daemons?.some(d => d.daemon_id === localDaemonId))


### PR DESCRIPTION
The settings page was unconditionally probing `localhost:25299` to detect a running local daemon, even when no daemons have ever been paired. This caused unnecessary network requests and CSP/console errors for users who don't use the local daemon feature. The probe query is now gated behind `enabled: hasDaemons`, so it only fires when at least one paired daemon exists. On-click pairing still works normally for first-time setup.