### PR TITLE
feat: add feedback hooks for cloud-layer event callbacks

### DIFF
--- a/internal/api/handlers/feedback.go
+++ b/internal/api/handlers/feedback.go
@@ -15,13 +15,19 @@ import (
 
 // FeedbackHandler handles agent feedback endpoints: bug reports and NPS.
 type FeedbackHandler struct {
-	store    store.Store
-	reviewer feedback.Reviewer
-	logger   *slog.Logger
+	store          store.Store
+	reviewer       feedback.Reviewer
+	logger         *slog.Logger
+	afterBugReport func(report *store.FeedbackReport)
 }
 
 func NewFeedbackHandler(st store.Store, reviewer feedback.Reviewer, logger *slog.Logger) *FeedbackHandler {
 	return &FeedbackHandler{store: st, reviewer: reviewer, logger: logger}
+}
+
+// SetAfterBugReport registers a callback invoked (in a goroutine) after a bug report is saved.
+func (h *FeedbackHandler) SetAfterBugReport(fn func(report *store.FeedbackReport)) {
+	h.afterBugReport = fn
 }
 
 // ── Report Bug ──────────────────────────────────────────────────────────
@@ -110,6 +116,10 @@ func (h *FeedbackHandler) ReportBug(w http.ResponseWriter, r *http.Request) {
 		"severity", reviewResult.Severity,
 		"is_valid", reviewResult.IsValid,
 	)
+
+	if h.afterBugReport != nil {
+		go h.afterBugReport(report)
+	}
 
 	writeJSON(w, http.StatusOK, map[string]any{
 		"id":       report.ID,

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -80,6 +80,7 @@ type Server struct {
 	msgBuffer            groupchat.Buffer               // group chat message buffer; may be nil
 	decisionBus          notify.DecisionBus             // cross-instance decision delivery; may be nil
 	gatewayHooks         *GatewayHooks                  // cloud-injected gateway authorization hooks; may be nil
+	feedbackHooks        *FeedbackHooks                 // cloud-injected feedback event hooks; may be nil
 	localServiceProvider handlers.LocalServiceProvider  // cloud-injected local daemon service provider; may be nil
 	localServiceExecutor handlers.LocalServiceExecutor  // cloud-injected local service executor; may be nil
 
@@ -133,6 +134,12 @@ type GatewayHooks struct {
 	// The agent (including OrgID) is available via middleware.AgentFromContext(ctx).
 	// Return a non-nil error to block the request (treated as an org policy block).
 	BeforeAuthorize func(ctx context.Context, agentID, userID, service, action string) error
+}
+
+// FeedbackHooks allows cloud/enterprise layers to react to feedback events.
+type FeedbackHooks struct {
+	// AfterBugReport is called after a bug report is successfully saved.
+	AfterBugReport func(report *store.FeedbackReport)
 }
 
 // ServerOption configures optional behavior on the Server.
@@ -215,6 +222,11 @@ func WithAdapterGenFactory(f handlers.GeneratorFactory) ServerOption {
 // WithGatewayHooks injects additional authorization logic into the gateway.
 func WithGatewayHooks(hooks *GatewayHooks) ServerOption {
 	return func(s *Server) { s.gatewayHooks = hooks }
+}
+
+// WithFeedbackHooks injects callbacks for feedback events (e.g. bug reports).
+func WithFeedbackHooks(hooks *FeedbackHooks) ServerOption {
+	return func(s *Server) { s.feedbackHooks = hooks }
 }
 
 // WithLocalServiceProvider injects a provider of local daemon services into
@@ -672,6 +684,9 @@ func (s *Server) routes() http.Handler {
 		feedbackReviewer = feedback.NewLLMReviewer(s.llmHealth, s.logger)
 	}
 	feedbackHandler := handlers.NewFeedbackHandler(s.store, feedbackReviewer, s.logger)
+	if s.feedbackHooks != nil && s.feedbackHooks.AfterBugReport != nil {
+		feedbackHandler.SetAfterBugReport(s.feedbackHooks.AfterBugReport)
+	}
 	mux.Handle("POST /api/feedback/report", requireAgent(e2e(http.HandlerFunc(feedbackHandler.ReportBug))))
 	mux.Handle("POST /api/feedback/nps", requireAgent(e2e(http.HandlerFunc(feedbackHandler.SubmitNPS))))
 	mux.Handle("GET /api/feedback/reports", user(feedbackHandler.ListReports))

--- a/pkg/clawvisor/options.go
+++ b/pkg/clawvisor/options.go
@@ -34,6 +34,13 @@ type GatewayHooks struct {
 	BeforeAuthorize func(ctx context.Context, agentID, userID, service, action string) error
 }
 
+// FeedbackHooks allows cloud/enterprise layers to react to feedback events.
+type FeedbackHooks struct {
+	// AfterBugReport is called after a bug report is successfully saved.
+	// It runs in a goroutine so it does not block the HTTP response.
+	AfterBugReport func(report *store.FeedbackReport)
+}
+
 // ServerOptions holds everything needed to start a Clawvisor server.
 // Use DefaultOptions to get the standard open-source defaults, then
 // selectively override fields before passing to Run.
@@ -98,6 +105,10 @@ type ServerOptions struct {
 	// GatewayHooks injects additional authorization logic into the gateway flow.
 	// Used by cloud for org-level restrictions, policies, etc.
 	GatewayHooks *GatewayHooks
+
+	// FeedbackHooks allows cloud/enterprise layers to react to feedback events
+	// (e.g. sending Slack alerts on bug reports).
+	FeedbackHooks *FeedbackHooks
 
 	// LocalServiceProvider supplies local daemon services for the agent catalog.
 	// Set by the cloud layer; nil in self-hosted mode.

--- a/pkg/clawvisor/run.go
+++ b/pkg/clawvisor/run.go
@@ -93,6 +93,12 @@ func RunWithContext(ctx context.Context, opts *ServerOptions) error {
 		}))
 	}
 
+	if opts.FeedbackHooks != nil {
+		apiOpts = append(apiOpts, api.WithFeedbackHooks(&api.FeedbackHooks{
+			AfterBugReport: opts.FeedbackHooks.AfterBugReport,
+		}))
+	}
+
 	// Multi-instance Redis-backed stores.
 	if opts.TicketStore != nil {
 		apiOpts = append(apiOpts, api.WithTicketStore(opts.TicketStore))


### PR DESCRIPTION
## Summary
- Adds `FeedbackHooks` extension point (parallel to `GatewayHooks`) so the cloud layer can react to feedback events
- Wires up `AfterBugReport` callback on `FeedbackHandler`, invoked in a goroutine after a bug report is saved
- Plumbed through `ServerOptions` → `api.Server` → `FeedbackHandler`

## Test plan
- [ ] Verify existing bug report endpoint still returns correct response
- [ ] Verify `AfterBugReport` callback fires after successful bug report save
- [ ] Verify nil hooks / nil callback does not panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)