### PR TITLE
fix: Google Calendar create/update missing transparency, visibility, attendees

### DIFF
--- a/internal/adapters/definitions/google_calendar.yaml
+++ b/internal/adapters/definitions/google_calendar.yaml
@@ -96,6 +96,10 @@ actions:
         - { name: location, sanitize: true }
         - { name: description, sanitize: true }
         - { name: attendees }
+        - name: transparency
+          expr: "transparency ?? 'opaque'"
+        - name: visibility
+          expr: "visibility ?? 'default'"
         - { name: status }
       summary: "Event: {{.summary}}"
 
@@ -107,6 +111,7 @@ actions:
     path: "/calendars/{{.calendar_id}}/events"
     params:
       calendar_id: { type: string, default: "primary", location: path }
+      send_updates: { type: string, default: "none", location: query, map_to: sendUpdates }
       summary: { type: string, required: true, location: body }
       description: { type: string, location: body }
       start:
@@ -123,6 +128,14 @@ actions:
         type: array
         location: body
         transform: "emailList(attendees)"
+      transparency:
+        type: string
+        location: body
+        description: "Whether the event blocks time on the calendar. 'opaque' (default/busy) or 'transparent' (free)."
+      visibility:
+        type: string
+        location: body
+        description: "Visibility of the event. 'default', 'public', 'private', or 'confidential'."
     response:
       fields:
         - { name: id, rename: event_id }
@@ -140,6 +153,7 @@ actions:
     params:
       event_id: { type: string, required: true, location: path }
       calendar_id: { type: string, default: "primary", location: path }
+      send_updates: { type: string, default: "none", location: query, map_to: sendUpdates }
       summary: { type: string, location: body }
       description: { type: string, location: body }
       start:
@@ -150,6 +164,18 @@ actions:
         type: string
         location: body
         transform: "isAllDay(end) ? {date: end} : {dateTime: rfc3339(end)}"
+      attendees:
+        type: array
+        location: body
+        transform: "emailList(attendees)"
+      transparency:
+        type: string
+        location: body
+        description: "Whether the event blocks time on the calendar. 'opaque' (default/busy) or 'transparent' (free)."
+      visibility:
+        type: string
+        location: body
+        description: "Visibility of the event. 'default', 'public', 'private', or 'confidential'."
     response:
       fields:
         - { name: id, rename: event_id }

--- a/pkg/adapters/yamlruntime/expreval.go
+++ b/pkg/adapters/yamlruntime/expreval.go
@@ -177,8 +177,12 @@ func emailListFunc(params ...any) (any, error) {
 	}
 	result := make([]any, 0, len(list))
 	for _, item := range list {
-		if s, ok := item.(string); ok {
-			result = append(result, map[string]any{"email": s})
+		switch v := item.(type) {
+		case string:
+			result = append(result, map[string]any{"email": v})
+		case map[string]any:
+			// Already in object form (e.g. {"email": "..."}); pass through.
+			result = append(result, v)
 		}
 	}
 	return result, nil


### PR DESCRIPTION
## Summary
- Adds `transparency`, `visibility`, and `attendees` params to `create_event` and `update_event` YAML definitions, fixing silent drops reported in the bug report from Wintermute.
- Adds `sendUpdates=none` query param to both write actions so Google Calendar API correctly applies attendee changes.
- Fixes `emailListFunc` to handle object-form attendees (`{"email": "..."}`) in addition to plain strings — the prior code returned an empty array for object inputs, which sent `"attendees": []` to Google and wiped existing attendees on update.
- Adds `transparency` and `visibility` to the `get_event` response with defaults (`"opaque"` / `"default"`) so Google's omission of default values doesn't surface as null.

## Test plan
- [x] Verified `create_event` with transparency, visibility, and attendees — all read back correctly
- [x] Verified `update_event` with transparency and visibility — read back correctly
- [x] Verified `update_event` with attendees in object form no longer wipes the attendee list
- [x] `go build ./...` and `go test ./pkg/adapters/yamlruntime/ ./pkg/adapters/yamlloader/` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)