### PR TITLE
fix: build darwin clawvisor-local releases on macOS

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,7 +24,7 @@ jobs:
   build-binaries:
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -23,6 +23,7 @@ MODULE="github.com/clawvisor/clawvisor/pkg/version"
 BUILD_DATE=$(date -u +%Y-%m-%d)
 LDFLAGS="-s -w -X ${MODULE}.Version=${VERSION} -X ${MODULE}.SkillPublishedAt=${BUILD_DATE}"
 PLATFORMS="darwin/arm64 darwin/amd64 linux/arm64 linux/amd64"
+HOST_OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
 
 rm -rf dist
 mkdir -p dist
@@ -45,8 +46,17 @@ for PLATFORM in $PLATFORMS; do
   OUTPUT="dist/clawvisor-local-${GOOS}-${GOARCH}"
 
   echo "Building ${OUTPUT}..."
-  CGO_ENABLED=0 GOOS="$GOOS" GOARCH="$GOARCH" \
-    go build -ldflags="$LDFLAGS" -o "$OUTPUT" ./cmd/clawvisor-local
+  if [ "$GOOS" = "darwin" ]; then
+    if [ "$HOST_OS" != "darwin" ]; then
+      echo "Error: darwin clawvisor-local builds require a macOS runner" >&2
+      exit 1
+    fi
+    CGO_ENABLED=1 GOOS="$GOOS" GOARCH="$GOARCH" \
+      go build -ldflags="$LDFLAGS" -o "$OUTPUT" ./cmd/clawvisor-local
+  else
+    CGO_ENABLED=0 GOOS="$GOOS" GOARCH="$GOARCH" \
+      go build -ldflags="$LDFLAGS" -o "$OUTPUT" ./cmd/clawvisor-local
+  fi
 done
 
 # Build the iMessage helper .app bundle for macOS only. This is a separate,


### PR DESCRIPTION
Moves the release binary jobs to macOS runners and updates the release script so darwin `clawvisor-local` builds use CGO instead of forcing `CGO_ENABLED=0`. This fixes the `systray` linker failure when generating `clawvisor-local-darwin-*` artifacts. Verified locally with the full `scripts/build-release.sh v0.8.10` flow.