### PR TITLE
fix: audit log early gateway rejections, scope request_id uniqueness per user, add local service routing

### DIFF
--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -321,9 +321,15 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 
 	// ── Step 2: Task ID required ─────────────────────────────────────────────
 	if req.TaskID == "" {
-		outDecision, outOutcome = "reject", "validation_error"
+		e := baseEntry("reject", "validation_error", nil)
+		e.DurationMS = int(time.Since(start).Milliseconds())
+		errMsg := "missing required field: task_id"
+		e.ErrorMsg = &errMsg
+		if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+			h.logger.Warn("audit log failed", "err", logErr)
+		}
 		writeDetailedError(w, http.StatusBadRequest, apiErrorDetail{
-			Error:         "missing required field: task_id",
+			Error:         errMsg,
 			Code:          "TASK_REQUIRED",
 			MissingFields: []string{"task_id"},
 			Hint:          "Create a task first via POST /api/tasks, then include the returned task_id in every gateway request.",
@@ -346,25 +352,44 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 	{
 		task, taskErr := h.store.GetTask(ctx, req.TaskID)
 		if taskErr != nil {
-			outDecision, outOutcome = "reject", "validation_error"
+			taskIDPtr := &req.TaskID
+			e := baseEntry("reject", "validation_error", taskIDPtr)
+			e.DurationMS = int(time.Since(start).Milliseconds())
+			errMsg := fmt.Sprintf("task %q not found", req.TaskID)
+			e.ErrorMsg = &errMsg
+			if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+				h.logger.Warn("audit log failed", "err", logErr)
+			}
 			writeDetailedError(w, http.StatusBadRequest, apiErrorDetail{
-				Error: fmt.Sprintf("task %q not found", req.TaskID),
+				Error: errMsg,
 				Code:  "INVALID_REQUEST",
 				Hint:  "The task_id may be incorrect, or the task may have been deleted. Create a new task via POST /api/tasks and use the returned task_id.",
 			})
 			return
 		}
 		if task.UserID != agent.UserID {
-			outDecision, outOutcome = "reject", "forbidden"
+			taskIDPtr := &req.TaskID
+			e := baseEntry("reject", "forbidden", taskIDPtr)
+			e.DurationMS = int(time.Since(start).Milliseconds())
+			errMsg := "task does not belong to this agent's user"
+			e.ErrorMsg = &errMsg
+			if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+				h.logger.Warn("audit log failed", "err", logErr)
+			}
 			writeDetailedError(w, http.StatusForbidden, apiErrorDetail{
-				Error: "task does not belong to this agent's user",
+				Error: errMsg,
 				Code:  "FORBIDDEN",
 				Hint:  "This agent's bearer token is associated with a different user than the task owner. Ensure you are using the correct agent token and task_id.",
 			})
 			return
 		}
 		if task.ExpiresAt != nil && time.Now().After(*task.ExpiresAt) {
-			outDecision, outOutcome = "reject", "task_expired"
+			taskIDPtr := &req.TaskID
+			e := baseEntry("reject", "task_expired", taskIDPtr)
+			e.DurationMS = int(time.Since(start).Milliseconds())
+			if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+				h.logger.Warn("audit log failed", "err", logErr)
+			}
 			resp := map[string]any{
 				"status":  "task_expired",
 				"task_id": req.TaskID,
@@ -375,7 +400,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if task.Status != "active" {
-			outDecision, outOutcome = "reject", "invalid_state"
+			taskIDPtr := &req.TaskID
 			hint := "Create a new task via POST /api/tasks."
 			switch task.Status {
 			case "pending_approval":
@@ -389,8 +414,15 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			case "pending_scope_expansion":
 				hint = "A scope expansion is pending approval. Wait for it to be approved before making requests."
 			}
+			errMsg := fmt.Sprintf("task is %s, not active", task.Status)
+			e := baseEntry("reject", "invalid_state", taskIDPtr)
+			e.DurationMS = int(time.Since(start).Milliseconds())
+			e.ErrorMsg = &errMsg
+			if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+				h.logger.Warn("audit log failed", "err", logErr)
+			}
 			writeDetailedError(w, http.StatusConflict, apiErrorDetail{
-				Error: fmt.Sprintf("task is %s, not active", task.Status),
+				Error: errMsg,
 				Code:  "INVALID_STATE",
 				Hint:  hint,
 			})
@@ -398,8 +430,16 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if task.Lifetime == "standing" && req.SessionID == "" {
+			taskIDPtr := &req.TaskID
+			e := baseEntry("reject", "validation_error", taskIDPtr)
+			e.DurationMS = int(time.Since(start).Milliseconds())
+			errMsg := "session_id is required for standing task requests"
+			e.ErrorMsg = &errMsg
+			if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+				h.logger.Warn("audit log failed", "err", logErr)
+			}
 			writeDetailedError(w, http.StatusBadRequest, apiErrorDetail{
-				Error: "session_id is required for standing task requests",
+				Error: errMsg,
 				Code:  "MISSING_SESSION_ID",
 				Hint:  "Standing tasks require a session_id on every gateway request to enable chain context verification. Generate a UUID per workflow invocation and pass it as session_id.",
 			})

--- a/internal/store/postgres/migrations/028_audit_request_id_user_unique.sql
+++ b/internal/store/postgres/migrations/028_audit_request_id_user_unique.sql
@@ -1,0 +1,6 @@
+-- The original UNIQUE constraint on request_id alone causes silent drops
+-- when different users happen to reuse the same request_id (e.g. smoke tests).
+-- Scope the uniqueness to (request_id, user_id) so each user's request_ids
+-- are independent.
+ALTER TABLE audit_log DROP CONSTRAINT IF EXISTS audit_log_request_id_key;
+ALTER TABLE audit_log ADD CONSTRAINT audit_log_request_id_user_id_key UNIQUE (request_id, user_id);

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -576,7 +576,6 @@ func (s *Store) LogAudit(ctx context.Context, e *store.AuditEntry) error {
 			safety_flagged, safety_reason, reason, data_origin, context_src,
 			duration_ms, filters_applied, verification, error_msg
 		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22)
-		ON CONFLICT (request_id) DO NOTHING
 	`, e.ID, e.UserID, e.AgentID, e.RequestID, e.TaskID, e.Timestamp,
 		e.Service, e.Action, []byte(paramsSafe), e.Decision, e.Outcome,
 		e.PolicyID, e.RuleID, e.SafetyFlagged, e.SafetyReason, e.Reason,

--- a/internal/store/sqlite/migrations/028_audit_request_id_user_unique.sql
+++ b/internal/store/sqlite/migrations/028_audit_request_id_user_unique.sql
@@ -1,0 +1,42 @@
+-- SQLite cannot drop inline UNIQUE constraints, so we recreate the table
+-- to change UNIQUE(request_id) → UNIQUE(request_id, user_id).
+
+CREATE TABLE audit_log_new (
+    id              TEXT PRIMARY KEY,
+    user_id         TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    agent_id        TEXT REFERENCES agents(id) ON DELETE SET NULL,
+    request_id      TEXT NOT NULL,
+    task_id         TEXT,
+    timestamp       TEXT NOT NULL DEFAULT (datetime('now')),
+    service         TEXT NOT NULL,
+    action          TEXT NOT NULL,
+    params_safe     TEXT NOT NULL DEFAULT '{}',
+    decision        TEXT NOT NULL,
+    outcome         TEXT NOT NULL,
+    policy_id       TEXT,
+    rule_id         TEXT,
+    safety_flagged  INTEGER NOT NULL DEFAULT 0,
+    safety_reason   TEXT,
+    reason          TEXT,
+    data_origin     TEXT,
+    context_src     TEXT,
+    duration_ms     INTEGER NOT NULL DEFAULT 0,
+    filters_applied TEXT,
+    error_msg       TEXT,
+    verification    TEXT,
+    UNIQUE(request_id, user_id)
+);
+
+INSERT INTO audit_log_new SELECT
+    id, user_id, agent_id, request_id, task_id, timestamp, service, action,
+    params_safe, decision, outcome, policy_id, rule_id,
+    safety_flagged, safety_reason, reason, data_origin, context_src,
+    duration_ms, filters_applied, error_msg, verification
+FROM audit_log;
+
+DROP TABLE audit_log;
+ALTER TABLE audit_log_new RENAME TO audit_log;
+
+CREATE INDEX idx_audit_user_time ON audit_log(user_id, timestamp DESC);
+CREATE INDEX idx_audit_outcome   ON audit_log(user_id, outcome);
+CREATE INDEX idx_audit_service   ON audit_log(user_id, service);

--- a/internal/store/sqlite/store.go
+++ b/internal/store/sqlite/store.go
@@ -652,7 +652,6 @@ func (s *Store) LogAudit(ctx context.Context, e *store.AuditEntry) error {
 			safety_flagged, safety_reason, reason, data_origin, context_src,
 			duration_ms, filters_applied, verification, error_msg
 		) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
-		ON CONFLICT (request_id) DO NOTHING
 	`, e.ID, e.UserID, e.AgentID, e.RequestID, e.TaskID, e.Timestamp.UTC().Format(time.RFC3339),
 		e.Service, e.Action, paramsSafe, e.Decision, e.Outcome,
 		e.PolicyID, e.RuleID, safetyFlagged, e.SafetyReason, e.Reason,


### PR DESCRIPTION
## Summary

- Adds explicit `LogAudit` calls to all early-return gateway rejection paths (missing task_id, task not found, forbidden, expired, invalid state, missing session_id) that previously only appeared in the backup log.
- Changes the `audit_log` unique constraint from `UNIQUE(request_id)` to `UNIQUE(request_id, user_id)` and removes `ON CONFLICT DO NOTHING`, fixing silent audit drops when different users reuse the same request_id.
- Routes `local.*` services through a new `LocalServiceExecutor` interface with full intent verification, action validation via `LocalServiceProvider`, and proper audit logging.
- Hardens standing task `session_id` enforcement from a warning to a hard 400 error, removing the now-unreachable `ChainContextOptOut` code path.

## Test plan

- [ ] Verify early rejection paths (missing task_id, expired task, etc.) now produce audit_log entries
- [ ] Confirm different users can reuse the same request_id without silent drops
- [ ] Test local service gateway requests route through `LocalServiceExecutor` with intent verification
- [ ] Confirm standing tasks without session_id return 400 instead of a warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)