### PR TITLE
fix: use optimistic update for daemon unpair to prevent stale UI

### DIFF
--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -1579,7 +1579,20 @@ function LocalDaemonPairing() {
 
   const deleteMut = useMutation({
     mutationFn: (id: string) => api.localDaemon.delete(id),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['local-daemons'] }),
+    onMutate: async (id) => {
+      await qc.cancelQueries({ queryKey: ['local-daemons'] })
+      const prev = qc.getQueryData<(LocalDaemon & { connected: boolean })[]>(['local-daemons'])
+      qc.setQueryData<(LocalDaemon & { connected: boolean })[]>(['local-daemons'], old => old?.filter(d => d.id !== id))
+      return { prev }
+    },
+    onError: (_err, _id, context) => {
+      if (context?.prev) qc.setQueryData(['local-daemons'], context.prev)
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: ['local-daemons'] })
+      qc.invalidateQueries({ queryKey: ['local-daemon-probe'] })
+      qc.invalidateQueries({ queryKey: ['enabled-local-services'] })
+    },
   })
 
   async function startPairing() {


### PR DESCRIPTION
## Summary

After unpairing a local daemon, the UI would show stale state because only the `local-daemons` query was invalidated on success. This switches the delete mutation to an optimistic update pattern: the daemon is removed from the cache immediately on mutate, rolled back on error, and on settle all related caches (`local-daemons`, `local-daemon-probe`, `enabled-local-services`) are invalidated to ensure consistent UI state.

## Test plan

- [ ] Unpair a local daemon and verify it disappears from the list immediately
- [ ] Verify probe status and enabled services update after unpair
- [ ] Simulate a network error during unpair and verify the daemon reappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)