### PR TITLE
docs: size clawvisor task scope by complexity instead of always-verbose

### DIFF
--- a/skills/clawvisor/SKILL.md.tmpl
+++ b/skills/clawvisor/SKILL.md.tmpl
@@ -142,14 +142,14 @@ curl -s -X POST "$CLAWVISOR_URL/api/tasks?wait=true" \
   -H "Authorization: Bearer $CLAWVISOR_AGENT_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
-    "purpose": "Full iMessage management: review recent threads, classify reply status, identify conversations needing attention, search message history by contact or topic, and read full thread context for any follow-up questions. Covers all iMessage read operations the user may request during this session.",
+    "purpose": "Review recent iMessage threads and classify which ones need a reply",
     "authorized_actions": [
-      {"service": "apple.imessage", "action": "list_threads", "auto_execute": true, "expected_use": "List iMessage threads by recency, unread status, or contact. Used for inbox review, finding conversations needing replies, checking message status with specific people, and any ad-hoc thread lookup the user requests."},
-      {"service": "apple.imessage", "action": "get_thread", "auto_execute": true, "expected_use": "Read full thread content including all messages, timestamps, and attachments. Used to understand conversation context, classify reply urgency, extract action items, answer user questions about specific conversations, and provide summaries."}
+      {"service": "apple.imessage", "action": "list_threads", "auto_execute": true, "expected_use": "List recent iMessage threads, optionally filtered by unread status, to identify ones needing attention"},
+      {"service": "apple.imessage", "action": "get_thread", "auto_execute": true, "expected_use": "Read full thread content for threads surfaced by list_threads to classify reply urgency and extract context"}
     ],
     "planned_calls": [
-      {"service": "apple.imessage", "action": "list_threads", "params": {"limit": 30}, "reason": "List the 30 most recent threads to review inbox state and identify conversations needing attention"},
-      {"service": "apple.imessage", "action": "get_thread", "params": {"thread_id": "$chain"}, "reason": "Read full thread content for each conversation that needs review or that the user asks about"}
+      {"service": "apple.imessage", "action": "list_threads", "params": {"limit": 30}, "reason": "List the 30 most recent threads to review inbox state"},
+      {"service": "apple.imessage", "action": "get_thread", "params": {"thread_id": "$chain"}, "reason": "Read full thread content for conversations identified in the listing"}
     ],
     "expires_in_seconds": 1800
   }'
@@ -157,13 +157,19 @@ curl -s -X POST "$CLAWVISOR_URL/api/tasks?wait=true" \
 {{ else }} create a task declaring your purpose and the
 actions you need using `create_task`:
 {{ end }}
-- **`purpose`** — shown to the user during approval and checked by intent verification. **Scope broadly:** describe the full workflow as a capability statement, not a single action. Enumerate every category of operation the task covers. Narrow purposes like "Check emails" cause intent verification to reject legitimate follow-up requests. See the examples above.
-- **`expected_use`** — per-action description checked by intent verification against your actual request params. **Enumerate all use cases** — every scenario, parameter type, and reason you'd invoke this action. A narrow expected_use like "List recent emails" will reject searches by sender or keyword.
+- **`purpose`** — shown at approval and checked by intent verification. Capability statement covering the workflow's natural follow-ups. Size to task complexity (see below).
+- **`expected_use`** — per-action description checked against your actual request params. Cover the scenarios you'll use in this task.
 - **`auto_execute`** — `true` runs in-scope requests immediately; `false` still requires per-request approval (use for destructive actions like `send_message`).
 - **`expires_in_seconds`** — task TTL. Omit and set `"lifetime": "standing"` for a task that persists until the user revokes it (see below).
 - **`planned_calls`** *(optional)* — pre-register specific API calls you know you'll make. Planned calls are shown to the user during approval, evaluated as part of risk assessment, and **skip intent verification at runtime** when they match. This reduces latency for predictable workflows. Each entry must be covered by `authorized_actions` and must include `params`. Use exact values for known params, or `"$chain"` for values that will come from a prior call's results (e.g. `{"thread_id": "$chain"}`). Calls without params cannot skip verification.
 
-**Always request the broadest reasonable scope upfront.** The user reviews scope once at task creation; mid-task `pending_scope_expansion` interrupts their flow. Scope for the full range of operations the request could entail — not just the first step.
+### Sizing scope to task complexity
+
+Scope should cover operations likely *within this task's lifecycle* — no more. Over-scoping dilutes the approval signal; under-scoping triggers mid-task `pending_scope_expansion`.
+
+- **Simple** ("check my email for the last 72 hours"): tight. See the iMessage example above.
+- **Exploratory** ("triage my inbox"): broad — enumerate operation categories since the user will iterate.
+- **Standing** (persist across invocations): exhaustive capability charter. See the Gmail example below.
 
 For examples of well-scoped tasks and effective gateway requests, see the [Task & Request Examples](https://github.com/clawvisor/clawvisor/blob/main/docs/TASK_EXAMPLES.md).
 


### PR DESCRIPTION
## Summary
Replace the "always request the broadest reasonable scope" directive in the Clawvisor SKILL.md with a three-tier rule (simple / exploratory / standing). The previous always-verbose guidance bloated `purpose` and `expected_use` on tight tasks, diluting the approval signal and training users to rubber-stamp.

The iMessage ephemeral example is tightened to be the "simple" exemplar; the Gmail standing example continues as the exhaustive exemplar. Net: the skill file is shorter than before.

## Test plan
- [ ] Render the template and sanity-check the rendered SKILL.md reads well
- [ ] Verify intent verification still accepts the tightened iMessage example's natural follow-ups

🤖 Generated with [Claude Code](https://claude.com/claude-code)