### PR TITLE
fix: keep web/dist embed working without a frontend build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 /clawvisor-local
 /imessage-helper
 bin/
-dist/
+/dist/
 *.test
 *.out
 coverage.html

--- a/Makefile
+++ b/Makefile
@@ -158,4 +158,6 @@ release: web/dist
 	scripts/build-release.sh v$(VERSION)
 
 clean:
-	rm -rf bin/ web/dist/ dist/
+	rm -rf bin/ dist/
+	@# Preserve web/dist/{.gitkeep,placeholder.html} so go:embed still works after clean.
+	@if [ -d web/dist ]; then find web/dist -mindepth 1 -not -name '.gitkeep' -not -name 'placeholder.html' -delete; fi

--- a/web/dist/placeholder.html
+++ b/web/dist/placeholder.html
@@ -1,0 +1,1 @@
+<!-- placeholder so go:embed dist works without a frontend build. do not delete. -->

--- a/web/package.json
+++ b/web/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc -b && vite build && touch dist/.gitkeep dist/placeholder.html",
     "preview": "vite preview",
     "lint": "tsc --noEmit"
   },


### PR DESCRIPTION
## Summary
- `go build` was failing on fresh clones with `web/embed.go:7:12: pattern dist: no matching files found` because the `web/dist/.gitkeep` and `web/dist/placeholder.html` placeholders that backstop `//go:embed dist` had been deleted (originally by anthropics/clawvisor#170) and could not be re-added: an unanchored `dist/` rule in `.gitignore` was shadowing `web/dist/` entirely, so the `!web/dist/.gitkeep` exception never took effect.
- Anchors the gitignore rule to `/dist/`, restores both placeholder files, has the npm `build` script `touch` them after `vite build` (which empties `outDir` by default and would otherwise leave them staged-as-deleted), and updates `make clean` to preserve them instead of nuking the whole `web/dist/`.

## Test plan
- [x] `go build ./pkg/... ./internal/api/... ./internal/adapters/...` succeeds
- [x] `make clean` followed by another `go build` still succeeds (placeholders preserved)
- [x] `git check-ignore` confirms `web/dist/.gitkeep` and `web/dist/placeholder.html` are now trackable

🤖 Generated with [Claude Code](https://claude.com/claude-code)