### PR TITLE
docs(skill): modernize task examples and drop installed-time setup

### DIFF
--- a/skills/clawvisor/SKILL.md.tmpl
+++ b/skills/clawvisor/SKILL.md.tmpl
@@ -34,43 +34,6 @@ description: >
 {{ if eq .Target "claude-code" -}}
 # Clawvisor Skill
 
-## Setup
-{{- if .ClawvisorURL }}
-
-### Option A: Setup URL (recommended)
-
-If you were given a setup URL (e.g. `{{ .ClawvisorURL }}/skill/setup`), fetch it — it contains step-by-step instructions with your `CLAWVISOR_URL` pre-filled{{ if .ViaRelay }}, including how to register, authenticate, and set up E2E encryption{{ end }}.
-
-### Option B: Manual setup
-
-1. Set `CLAWVISOR_URL` to `{{ .ClawvisorURL }}`
-2. Create an agent in the Clawvisor dashboard, copy the token, and add it to `~/.claude/settings.json` under the `env` key as `CLAWVISOR_AGENT_TOKEN`
-3. Set `OPENCLAW_HOOKS_URL` to your OpenClaw gateway's reachable URL (default `http://localhost:18789`)
-4. Activate any services you want the agent to use (Gmail, GitHub, etc.) in the dashboard under Services
-5. Set dashboard policies to require approval for write/send/delete actions — only enable `auto_execute` for read-only actions you trust the agent to perform unsupervised
-{{- if .ViaRelay }}
-6. Use the bundled `e2e.mjs` helper or `cvis-e2e` binary — all requests through the relay require E2E encryption
-{{- end }}
-{{- else }}
-
-### Option A: Setup URL (recommended)
-
-If you were given a setup URL (e.g. `https://relay.clawvisor.com/d/<id>/skill/setup`), fetch it — it contains step-by-step instructions with your `CLAWVISOR_URL` pre-filled, including how to register, authenticate, and set up E2E encryption.
-
-### Option B: Manual setup
-
-1. Set `CLAWVISOR_URL` to your Clawvisor instance URL (e.g. `http://localhost:25297`)
-2. Create an agent in the Clawvisor dashboard, copy the token, and add it to `~/.claude/settings.json` under the `env` key as `CLAWVISOR_AGENT_TOKEN`
-3. Set `OPENCLAW_HOOKS_URL` to your OpenClaw gateway's reachable URL (default `http://localhost:18789`)
-4. Activate any services you want the agent to use (Gmail, GitHub, etc.) in the dashboard under Services
-5. Set dashboard policies to require approval for write/send/delete actions — only enable `auto_execute` for read-only actions you trust the agent to perform unsupervised
-6. If connecting through the cloud relay, use the bundled `e2e.mjs` helper or `cvis-e2e` binary — all requests through the relay require E2E encryption
-{{- end }}
-
-> ⚠️ **`CLAWVISOR_AGENT_TOKEN` is a high-privilege credential.** It grants the agent access to every service activated in Clawvisor. Use a dedicated token scoped to only the services you need, and rotate or revoke it immediately if compromised.
-
----
-
 ## Overview
 
 {{ else -}}
@@ -142,14 +105,14 @@ curl -s -X POST "$CLAWVISOR_URL/api/tasks?wait=true" \
   -H "Authorization: Bearer $CLAWVISOR_AGENT_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
-    "purpose": "Review recent iMessage threads and classify which ones need a reply",
+    "purpose": "Check the calendar for today and fetch details for the next upcoming meeting",
     "authorized_actions": [
-      {"service": "apple.imessage", "action": "list_threads", "auto_execute": true, "expected_use": "List recent iMessage threads, optionally filtered by unread status, to identify ones needing attention"},
-      {"service": "apple.imessage", "action": "get_thread", "auto_execute": true, "expected_use": "Read full thread content for threads surfaced by list_threads to classify reply urgency and extract context"}
+      {"service": "google.calendar:user@example.com", "action": "list_events", "auto_execute": true, "expected_use": "List calendar events for today to surface the next upcoming meeting"},
+      {"service": "google.calendar:user@example.com", "action": "get_event", "auto_execute": true, "expected_use": "Fetch full details (attendees, location, description) for the next event identified in the listing"}
     ],
     "planned_calls": [
-      {"service": "apple.imessage", "action": "list_threads", "params": {"limit": 30}, "reason": "List the 30 most recent threads to review inbox state"},
-      {"service": "apple.imessage", "action": "get_thread", "params": {"thread_id": "$chain"}, "reason": "Read full thread content for conversations identified in the listing"}
+      {"service": "google.calendar:user@example.com", "action": "list_events", "params": {"time_min": "2026-04-16T00:00:00Z", "time_max": "2026-04-17T00:00:00Z", "max_results": 10}, "reason": "List calendar events for today to find the next meeting"},
+      {"service": "google.calendar:user@example.com", "action": "get_event", "params": {"event_id": "$chain"}, "reason": "Fetch full details of the next meeting surfaced by the listing"}
     ],
     "expires_in_seconds": 1800
   }'
@@ -167,7 +130,7 @@ actions you need using `create_task`:
 
 Scope should cover operations likely *within this task's lifecycle* — no more. Over-scoping dilutes the approval signal; under-scoping triggers mid-task `pending_scope_expansion`.
 
-- **Simple** ("check my email for the last 72 hours"): tight. See the iMessage example above.
+- **Simple** ("check my email for the last 72 hours"): tight. See the calendar example above.
 - **Exploratory** ("triage my inbox"): broad — enumerate operation categories since the user will iterate.
 - **Standing** (persist across invocations): exhaustive capability charter. See the Gmail example below.
 
@@ -196,8 +159,8 @@ curl -s -X POST "$CLAWVISOR_URL/api/tasks" \
     "purpose": "Full executive assistant email management. Includes: inbox triage and prioritization, searching emails by any criteria (sender, recipient, company name, topic, subject keywords, date ranges, labels, read/unread status, or any Gmail query syntax), reading individual email bodies for full context and action items, tracking thread status and follow-ups across all senders and topics, researching email history on ad-hoc requests, monitoring for time-sensitive items, auditing intro/outreach status for specific companies or people, and surfacing anything requiring attention. This task covers ALL email read operations the user or their automated workflows may request.",
     "lifetime": "standing",
     "authorized_actions": [
-      {"service": "google.gmail", "action": "list_messages", "auto_execute": true, "expected_use": "Search and list emails using any Gmail query syntax: by sender, recipient, company name, subject keywords, date ranges (newer_than, older_than, before, after), labels, read/unread status, thread ID, or any combination. Used for inbox triage, follow-ups on hiring, intro status monitoring, deal research, investor correspondence tracking, scheduling and thread discovery, and any ad-hoc email search for any company, person, or topic at any time."},
-      {"service": "google.gmail", "action": "get_message", "auto_execute": true, "expected_use": "Read full email content for any message found via list_messages or referenced by message ID. Used to understand full context, extract action items, check reply status, draft summaries, track intro chains, audit follow-ups, and provide detailed email content to the user on request. Will read emails from any sender, about any topic, at any time as needed for triage, research, and executive assistant workflows."}
+      {"service": "google.gmail:user@example.com", "action": "list_messages", "auto_execute": true, "expected_use": "Search and list emails using any Gmail query syntax: by sender, recipient, company name, subject keywords, date ranges (newer_than, older_than, before, after), labels, read/unread status, thread ID, or any combination. Used for inbox triage, follow-ups on hiring, intro status monitoring, deal research, investor correspondence tracking, scheduling and thread discovery, and any ad-hoc email search for any company, person, or topic at any time."},
+      {"service": "google.gmail:user@example.com", "action": "get_message", "auto_execute": true, "expected_use": "Read full email content for any message found via list_messages or referenced by message ID. Used to understand full context, extract action items, check reply status, draft summaries, track intro chains, audit follow-ups, and provide detailed email content to the user on request. Will read emails from any sender, about any topic, at any time as needed for triage, research, and executive assistant workflows."}
     ]
   }'
 ```
@@ -233,10 +196,10 @@ curl -s -X POST "$CLAWVISOR_URL/api/tasks/<task-id>/expand?wait=true" \
   -H "Authorization: Bearer $CLAWVISOR_AGENT_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
-    "service": "apple.imessage",
+    "service": "google.gmail:user@example.com",
     "action": "send_message",
     "auto_execute": false,
-    "reason": "A contact asked a question that warrants a reply"
+    "reason": "Urgent thread surfaced during triage needs a same-day reply"
   }'
 ```
 

--- a/skills/clawvisor/SKILL.md.tmpl
+++ b/skills/clawvisor/SKILL.md.tmpl
@@ -34,6 +34,14 @@ description: >
 {{ if eq .Target "claude-code" -}}
 # Clawvisor Skill
 
+## Setup
+
+This skill assumes Clawvisor is already running and your agent has `CLAWVISOR_URL` and `CLAWVISOR_AGENT_TOKEN` configured. If you don't yet have Clawvisor running, sign up at [clawvisor.com](https://clawvisor.com) for hosted access, or self-host from the [GitHub repo](https://github.com/clawvisor/clawvisor).
+
+> ⚠️ **`CLAWVISOR_AGENT_TOKEN` is a high-privilege credential.** It grants the agent access to every service activated in Clawvisor. Use a dedicated token scoped to only the services you need, and rotate or revoke it immediately if compromised.
+
+---
+
 ## Overview
 
 {{ else -}}


### PR DESCRIPTION
## Summary
- Drop the Setup section from the SKILL.md template — by the time an agent has the skill loaded, setup has already happened, so the instructions were noise.
- Replace the iMessage simple-task example with Google Calendar so cloud users (who have no iMessage access) see a workflow they can actually run.
- Show a realistic `service:account` alias form (`:user@example.com`) in every example, consistent with the catalog's `service:account` guidance.

## Test plan
- [x] `go run ./cmd/render-skill claude-code` renders cleanly with the new examples and no Setup section