### PR TITLE
fix: split OAuth scope string on both comma and space

### DIFF
--- a/internal/api/handlers/services.go
+++ b/internal/api/handlers/services.go
@@ -597,14 +597,15 @@ func (h *ServicesHandler) OAuthCallback(w http.ResponseWriter, r *http.Request) 
 			return
 		}
 
-		// Use the scopes actually granted by the user. Google returns them in
-		// the token exchange response as a space-separated "scope" field. Users
-		// can deselect individual scopes on the consent screen, so the granted
-		// set may be a subset of what we requested.
+		// Use the scopes actually granted by the user. The OAuth2 spec (RFC 6749 §3.3)
+		// defines scopes as space-separated, but some providers (e.g. GitHub) return
+		// them comma-separated. Split on both to handle either format.
 		var scopes []string
 		scopesGranted := false
 		if grantedRaw, ok := token.Extra("scope").(string); ok && grantedRaw != "" {
-			scopes = strings.Split(grantedRaw, " ")
+			scopes = strings.FieldsFunc(grantedRaw, func(r rune) bool {
+				return r == ' ' || r == ','
+			})
 			sort.Strings(scopes)
 			scopesGranted = true
 		} else {


### PR DESCRIPTION
## Summary
- The OAuth callback parsed granted scopes by splitting on space only (`strings.Split(grantedRaw, " ")`), which matches Google's format but breaks for GitHub, which returns comma-separated scopes (e.g. `"repo,read:org,read:user"`)
- This caused GitHub OAuth scopes to be stored as a single concatenated string, making scope validation always fail with `MISSING_SCOPES` after connecting GitHub via OAuth2
- Fixed by using `strings.FieldsFunc` to split on both comma and space, handling either format

## Test plan
- [ ] Connect GitHub via OAuth2 (cloud deployment) and verify `list_repos` works without `MISSING_SCOPES` error
- [ ] Reconnect an existing GitHub OAuth connection and verify scopes are recognized
- [ ] Verify Google OAuth still works (space-separated scopes unaffected)
- [ ] Run `go test ./internal/api/handlers/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)