### PR TITLE
fix: interpolate credential fields in base_url

### DIFF
--- a/pkg/adapters/yamlruntime/adapter.go
+++ b/pkg/adapters/yamlruntime/adapter.go
@@ -123,6 +123,9 @@ func (a *YAMLAdapter) Execute(ctx context.Context, req adapters.Request) (*adapt
 		return nil, err
 	}
 
+	// Interpolate credential fields in base_url (e.g. {{.credential.sid}} for Twilio).
+	baseURL = interpolatePath(baseURL, nil, credFields)
+
 	switch a.def.API.Type {
 	case "rest":
 		return executeREST(ctx, client, baseURL, action, req.Params, credFields, a.compiled[req.Action])
@@ -150,6 +153,10 @@ func (a *YAMLAdapter) FetchIdentity(ctx context.Context, credBytes []byte, confi
 	if err != nil {
 		return "", fmt.Errorf("%s: identity fetch: %w", a.def.Service.ID, err)
 	}
+
+	// Interpolate credential fields in base_url (e.g. {{.credential.sid}} for Twilio).
+	credFields, _ := credentialFields(a.def.Auth, credBytes)
+	baseURL = interpolatePath(baseURL, nil, credFields)
 
 	endpoint := idDef.Endpoint
 	if !strings.HasPrefix(endpoint, "http") {


### PR DESCRIPTION
## Summary

- Interpolate credential fields (`{{.credential.sid}}`, `{{.credential.user}}`, etc.) in `base_url` before making API requests
- Fixes the Twilio adapter where `base_url` contains `{{.credential.sid}}` but was never resolved

## Problem

The YAML runtime's `resolvedBaseURL()` only resolves config variables, not credential fields. The Twilio adapter's `base_url` uses `{{.credential.sid}}` which was passed literally to the Twilio API, causing 404 errors:

```
/2010-04-01/Accounts/{{.credential.sid}}/Messages.json → 404
```

`credentialFields()` already extracts `sid` from basic auth credentials (auth.go:158), and `interpolatePath()` already handles `{{.credential.*}}` placeholders (rest.go:152-158). The fields just weren't applied to the base URL.

## Fix

Two lines added in each of the two code paths (`Execute` and `FetchIdentity`):

```go
baseURL = interpolatePath(baseURL, nil, credFields)
```

This reuses existing functions with no signature changes.

## Test plan

- [ ] Twilio `list_messages` returns messages instead of 404
- [ ] Other adapters (Gmail, Calendar, GitHub) unaffected (their base_urls don't use credential templates)
- [ ] `FetchIdentity` path also works for services with credential-templated base URLs

Fixes #276