### PR TITLE
fix(twilio): make the Twilio adapter work end-to-end

### DIFF
--- a/docs/INTEGRATION_YAML_SPEC.md
+++ b/docs/INTEGRATION_YAML_SPEC.md
@@ -82,7 +82,20 @@ auth:
   type: basic
 ```
 
-No additional fields are needed — `header` and `header_prefix` are ignored for basic auth.
+For services where the username is a non-secret account identifier (e.g. Twilio's Account SID), use `user_var` to pull it from a variable instead of asking the user to paste `user:pass`. The vaulted credential is then just the password.
+
+```yaml
+auth:
+  type: basic
+  user_var: account_sid
+
+variables:
+  account_sid:
+    display_name: "Account SID"
+    required: true
+```
+
+`header` and `header_prefix` are ignored for basic auth.
 
 ### PKCE Flow (Recommended for OAuth)
 

--- a/internal/adapters/definitions/twilio.yaml
+++ b/internal/adapters/definitions/twilio.yaml
@@ -3,13 +3,21 @@ service:
   display_name: Twilio
   description: "Send and receive SMS and WhatsApp messages, check delivery status, and manage conversations via Twilio."
   setup_url: "https://console.twilio.com"
+  key_hint: "Twilio Auth Token"
   icon_url: "/logos/twilio.svg"
 
 auth:
   type: basic
+  user_var: account_sid
+
+variables:
+  account_sid:
+    display_name: "Account SID"
+    description: "Your Twilio Account SID (starts with AC...)"
+    required: true
 
 api:
-  base_url: "https://api.twilio.com/2010-04-01/Accounts/{{.credential.sid}}"
+  base_url: "https://api.twilio.com/2010-04-01/Accounts/{{.var.account_sid}}"
   type: rest
 
 actions:
@@ -20,9 +28,9 @@ actions:
     path: "/Messages.json"
     encoding: form
     params:
-      to: { type: string, required: true, location: body }
-      body: { type: string, required: true, location: body }
-      from: { type: string, location: body }
+      to:   { type: string, required: true, location: body, map_to: To }
+      body: { type: string, required: true, location: body, map_to: Body }
+      from: { type: string, location: body, map_to: From }
     response:
       fields:
         - { name: sid }
@@ -38,9 +46,9 @@ actions:
     path: "/Messages.json"
     encoding: form
     params:
-      to: { type: string, required: true, location: body }
-      body: { type: string, required: true, location: body }
-      from: { type: string, location: body }
+      to:   { type: string, required: true, location: body, map_to: To }
+      body: { type: string, required: true, location: body, map_to: Body }
+      from: { type: string, location: body, map_to: From }
     response:
       fields:
         - { name: sid }
@@ -55,10 +63,10 @@ actions:
     method: GET
     path: "/Messages.json"
     params:
-      page_size: { type: int, default: 20, max: 1000, location: query }
-      page: { type: int, default: 0, location: query }
-      to: { type: string, location: query }
-      from: { type: string, location: query }
+      page_size: { type: int, default: 20, max: 1000, location: query, map_to: PageSize }
+      page:      { type: int, default: 0, location: query, map_to: Page }
+      to:        { type: string, location: query, map_to: To }
+      from:      { type: string, location: query, map_to: From }
     response:
       data_path: "messages"
       fields:
@@ -70,6 +78,44 @@ actions:
         - { name: direction }
         - { name: date_sent }
       summary: "{{len .Data}} message(s)"
+
+  make_call:
+    display_name: "Make phone call"
+    risk: { category: write, sensitivity: high, description: "Place an outbound phone call (costs money)" }
+    method: POST
+    path: "/Calls.json"
+    encoding: form
+    params:
+      to:    { type: string, required: true, location: body, map_to: To }
+      from:  { type: string, required: true, location: body, map_to: From }
+      twiml: { type: string, location: body, map_to: Twiml }
+      url:   { type: string, location: body, map_to: Url }
+    response:
+      fields:
+        - { name: sid }
+        - { name: status }
+        - { name: to }
+        - { name: from }
+        - { name: direction }
+        - { name: date_created }
+      summary: "Call placed to {{.to}} (status: {{.status}})"
+
+  list_phone_numbers:
+    display_name: "List phone numbers"
+    risk: { category: read, sensitivity: low, description: "List Twilio phone numbers owned by this account" }
+    method: GET
+    path: "/IncomingPhoneNumbers.json"
+    params:
+      page_size: { type: int, default: 50, max: 1000, location: query, map_to: PageSize }
+      page:      { type: int, default: 0, location: query, map_to: Page }
+    response:
+      data_path: "incoming_phone_numbers"
+      fields:
+        - { name: sid }
+        - { name: phone_number }
+        - { name: friendly_name }
+        - { name: capabilities }
+      summary: "{{len .Data}} phone number(s)"
 
   get_message:
     display_name: "Get message"

--- a/pkg/adapters/yamldef/schema.go
+++ b/pkg/adapters/yamldef/schema.go
@@ -48,9 +48,13 @@ type AuthDef struct {
 	Header       string            `yaml:"header,omitempty"`
 	HeaderPrefix string            `yaml:"header_prefix,omitempty"`
 	ExtraHeaders map[string]string `yaml:"extra_headers,omitempty"`
+	// UserVar (basic auth only): name of a variable that holds the username
+	// portion. When set, the credential is used as the password directly
+	// instead of being split on ":" into user:pass.
+	UserVar    string         `yaml:"user_var,omitempty"`
 	OAuth      *OAuthDef      `yaml:"oauth,omitempty"`
 	DeviceFlow *DeviceFlowDef `yaml:"device_flow,omitempty"`
-	PKCEFlow   *PKCEFlowDef  `yaml:"pkce_flow,omitempty"`
+	PKCEFlow   *PKCEFlowDef   `yaml:"pkce_flow,omitempty"`
 }
 
 // DeviceFlowDef holds configuration for OAuth2 device authorization grant (RFC 8628).

--- a/pkg/adapters/yamlruntime/adapter.go
+++ b/pkg/adapters/yamlruntime/adapter.go
@@ -109,16 +109,16 @@ func (a *YAMLAdapter) Execute(ctx context.Context, req adapters.Request) (*adapt
 	}
 
 	// Build the authenticated HTTP client.
-	client, err := a.buildAuthClient(ctx, req.Credential)
+	client, err := a.buildAuthClient(ctx, req.Credential, req.Config)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", a.def.Service.ID, err)
 	}
 
-	// Get credential fields for path interpolation.
+	// Get credential fields for path and base-URL interpolation.
 	credFields, _ := credentialFields(a.def.Auth, req.Credential)
 
 	// Resolve variables in base_url.
-	baseURL, err := a.resolvedBaseURL(req.Config)
+	baseURL, err := a.resolvedBaseURL(req.Config, credFields)
 	if err != nil {
 		return nil, err
 	}
@@ -141,12 +141,13 @@ func (a *YAMLAdapter) FetchIdentity(ctx context.Context, credBytes []byte, confi
 		return "", nil
 	}
 
-	client, err := a.buildAuthClient(ctx, credBytes)
+	client, err := a.buildAuthClient(ctx, credBytes, config)
 	if err != nil {
 		return "", fmt.Errorf("%s: identity fetch: %w", a.def.Service.ID, err)
 	}
 
-	baseURL, err := a.resolvedBaseURL(config)
+	credFields, _ := credentialFields(a.def.Auth, credBytes)
+	baseURL, err := a.resolvedBaseURL(config, credFields)
 	if err != nil {
 		return "", fmt.Errorf("%s: identity fetch: %w", a.def.Service.ID, err)
 	}
@@ -302,8 +303,9 @@ func (a *YAMLAdapter) ValidateCredential(credBytes []byte) error {
 		return fmt.Errorf("%s: credential missing token", a.def.Service.ID)
 	}
 
-	// Additional validation for basic auth credentials.
-	if a.def.Auth.Type == "basic" {
+	// Additional validation for basic auth credentials. When user_var is set,
+	// the credential is just the password; the username comes from config.
+	if a.def.Auth.Type == "basic" && a.def.Auth.UserVar == "" {
 		parts := strings.SplitN(cred.Token, ":", 2)
 		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 			return fmt.Errorf("%s: credential must be in format 'user:pass'", a.def.Service.ID)
@@ -356,7 +358,7 @@ func (a *YAMLAdapter) OAuthTokenPath() string {
 // automatic token refresh. For api_key services with PKCE flow credentials,
 // it also uses an OAuth2 token source for refresh. For other auth types,
 // delegates to buildHTTPClient.
-func (a *YAMLAdapter) buildAuthClient(ctx context.Context, credBytes []byte) (*http.Client, error) {
+func (a *YAMLAdapter) buildAuthClient(ctx context.Context, credBytes []byte, config map[string]string) (*http.Client, error) {
 	if a.def.Auth.Type == "oauth2" {
 		oauthCfg := a.OAuthConfig()
 		if oauthCfg == nil {
@@ -376,7 +378,7 @@ func (a *YAMLAdapter) buildAuthClient(ctx context.Context, credBytes []byte) (*h
 		}
 	}
 
-	return buildHTTPClient(a.def.Auth, credBytes)
+	return buildHTTPClient(a.def.Auth, credBytes, a.mergedConfig(config))
 }
 
 // buildOAuthClient creates an *http.Client using an OAuth2 token source that
@@ -582,15 +584,19 @@ func (a *YAMLAdapter) resolvePKCEFlowClientID() string {
 	return pf.ClientID
 }
 
-// resolvedBaseURL returns the API base URL with any {{.var.X}} placeholders
-// replaced by values from config. It validates that all required variables
-// have values.
-func (a *YAMLAdapter) resolvedBaseURL(config map[string]string) (string, error) {
+// resolvedBaseURL returns the API base URL with any {{.var.X}} and
+// {{.credential.X}} placeholders replaced by values from config and the
+// parsed credential. It validates that all required variables have values.
+func (a *YAMLAdapter) resolvedBaseURL(config map[string]string, credFields map[string]string) (string, error) {
 	if err := a.validateVariables(config); err != nil {
 		return "", err
 	}
 	merged := a.mergedConfig(config)
-	return resolveVariables(a.def.API.BaseURL, merged), nil
+	resolved := resolveVariables(a.def.API.BaseURL, merged)
+	for k, v := range credFields {
+		resolved = strings.ReplaceAll(resolved, "{{.credential."+k+"}}", v)
+	}
+	return resolved, nil
 }
 
 // mergedConfig returns config with any missing keys filled in from variable defaults.

--- a/pkg/adapters/yamlruntime/adapter_test.go
+++ b/pkg/adapters/yamlruntime/adapter_test.go
@@ -351,6 +351,52 @@ func TestYAMLAdapter_BasicAuth(t *testing.T) {
 	}
 }
 
+func TestYAMLAdapter_BasicAuthUserVar(t *testing.T) {
+	// Twilio-style: the Account SID is collected as a non-secret variable
+	// and used both as the basic-auth username and in base_url. The vaulted
+	// credential is just the Auth Token.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, pass, ok := r.BasicAuth()
+		if !ok || user != "AC123" || pass != "authtoken" {
+			t.Errorf("expected basic auth AC123:authtoken, got %s:%s (ok=%v)", user, pass, ok)
+		}
+		if r.URL.Path != "/Accounts/AC123/Messages.json" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"messages": []map[string]any{}})
+	}))
+	defer srv.Close()
+
+	def := yamldef.ServiceDef{
+		Service:   yamldef.ServiceInfo{ID: "twilio"},
+		Auth:      yamldef.AuthDef{Type: "basic", UserVar: "account_sid"},
+		Variables: map[string]yamldef.VariableDef{"account_sid": {DisplayName: "Account SID", Required: true}},
+		API:       yamldef.APIDef{BaseURL: srv.URL + "/Accounts/{{.var.account_sid}}", Type: "rest"},
+		Actions: map[string]yamldef.Action{
+			"list_messages": {
+				Method: "GET",
+				Path:   "/Messages.json",
+				Response: yamldef.ResponseDef{
+					DataPath: "messages",
+				},
+			},
+		},
+	}
+
+	adapter, err := New(def, nil)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	if _, err := adapter.Execute(context.Background(), adapters.Request{
+		Action:     "list_messages",
+		Config:     map[string]string{"account_sid": "AC123"},
+		Credential: testCred("authtoken"),
+	}); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+}
+
 func TestYAMLAdapter_ErrorCheckSlackStyle(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/pkg/adapters/yamlruntime/auth.go
+++ b/pkg/adapters/yamlruntime/auth.go
@@ -36,8 +36,9 @@ func extractToken(credBytes []byte) (string, error) {
 }
 
 // buildHTTPClient creates an *http.Client that injects authentication headers
-// based on the YAML auth definition.
-func buildHTTPClient(authDef yamldef.AuthDef, credBytes []byte) (*http.Client, error) {
+// based on the YAML auth definition. config carries variables collected at
+// activation time (used for basic auth's user_var).
+func buildHTTPClient(authDef yamldef.AuthDef, credBytes []byte, config map[string]string) (*http.Client, error) {
 	switch authDef.Type {
 	case "api_key":
 		token, err := extractToken(credBytes)
@@ -59,14 +60,24 @@ func buildHTTPClient(authDef yamldef.AuthDef, credBytes []byte) (*http.Client, e
 		if err != nil {
 			return nil, err
 		}
-		parts := strings.SplitN(token, ":", 2)
-		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-			return nil, fmt.Errorf("basic auth credential must be in format 'user:pass'")
+		var user, pass string
+		if authDef.UserVar != "" {
+			user = config[authDef.UserVar]
+			if user == "" {
+				return nil, fmt.Errorf("basic auth: variable %q has no value", authDef.UserVar)
+			}
+			pass = token
+		} else {
+			parts := strings.SplitN(token, ":", 2)
+			if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+				return nil, fmt.Errorf("basic auth credential must be in format 'user:pass'")
+			}
+			user, pass = parts[0], parts[1]
 		}
 		return &http.Client{
 			Transport: &basicAuthTransport{
-				user:         parts[0],
-				pass:         parts[1],
+				user:         user,
+				pass:         pass,
 				extraHeaders: authDef.ExtraHeaders,
 				base:         http.DefaultTransport,
 			},
@@ -145,17 +156,17 @@ func (t *basicAuthTransport) RoundTrip(req *http.Request) (*http.Response, error
 }
 
 // credentialFields returns the parsed credential fields as a map for template interpolation.
-// For basic auth, it includes "user" and "pass" fields; for api_key, just "token".
+// For basic auth with a user:pass token, it includes "user" and "pass"; for
+// api_key (or basic auth with user_var), just "token".
 func credentialFields(authDef yamldef.AuthDef, credBytes []byte) (map[string]string, error) {
 	token, err := extractToken(credBytes)
 	if err != nil {
 		return nil, err
 	}
 	fields := map[string]string{"token": token}
-	if authDef.Type == "basic" {
+	if authDef.Type == "basic" && authDef.UserVar == "" {
 		parts := strings.SplitN(token, ":", 2)
 		if len(parts) == 2 {
-			fields["sid"] = parts[0] // Twilio convention
 			fields["user"] = parts[0]
 			fields["pass"] = parts[1]
 		}


### PR DESCRIPTION
## Summary
- Fix the Twilio adapter: `base_url` now interpolates `{{.credential.X}}` and `{{.var.X}}` so the Account SID actually makes it into the URL, and all action params use `map_to` so Twilio's PascalCase form fields (`To`/`From`/`Body`/`PageSize`/`Page`) are sent correctly.
- Add `auth.user_var` to the YAML spec so basic-auth services can collect the username as a non-secret variable (Twilio Account SID) while vaulting only the Auth Token — removes the awkward `SID:token` colon trick.
- Twilio adapter now exposes `make_call` and `list_phone_numbers` in addition to SMS/WhatsApp, with a proper `key_hint` and an `account_sid` variable.

## Test plan
- [x] `go test ./...`
- [ ] Reconnect Twilio in the dashboard, paste only the Auth Token, enter Account SID in the new variable field.
- [ ] `list_phone_numbers` returns the account's numbers.
- [ ] `send_sms` with a verified destination + registered/trial `from` delivers successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes https://github.com/clawvisor/clawvisor/issues/276