### PR TITLE
feat: add Get Started page with LLM-generated task suggestions

### DIFF
--- a/internal/api/handlers/welcome.go
+++ b/internal/api/handlers/welcome.go
@@ -79,14 +79,26 @@ type taskSuggestion struct {
 	Risk     string   `json:"risk,omitempty"`     // "low" | "medium" | "high"
 }
 
+// walkthroughExample personalises the "here's what a task looks like" flow
+// using a coherent pairing of the user's connected services. Frontend falls
+// back to a hardcoded Gmail/Linear example when this is absent.
+type walkthroughExample struct {
+	UserPrompt   string   `json:"user_prompt"`           // what the user would ask, e.g. "Triage my Gmail…"
+	AgentTask    string   `json:"agent_task"`            // what the agent declares, e.g. "read Gmail…, create Linear issues"
+	PrimaryName  string   `json:"primary_name"`          // the main service name, for the subtitle
+	SecondaryName string  `json:"secondary_name"`        // the paired service name, for the subtitle
+	Services     []string `json:"services,omitempty"`    // service IDs referenced
+}
+
 // welcomeResponse is the payload for GET /api/welcome/suggestions.
 type welcomeResponse struct {
-	Ready       bool             `json:"ready"`        // true when ≥1 service + ≥1 agent
-	Services    []welcomeService `json:"services"`
-	Agents      []welcomeAgent   `json:"agents"`
-	Suggestions []taskSuggestion `json:"suggestions"`  // may be empty
-	LLMUsed     bool             `json:"llm_used"`     // true if suggestions came from LLM
-	LLMStatus   string           `json:"llm_status"`   // "ok" | "unconfigured" | "exhausted" | "error"
+	Ready       bool                `json:"ready"`        // true when ≥1 service + ≥1 agent
+	Services    []welcomeService    `json:"services"`
+	Agents      []welcomeAgent      `json:"agents"`
+	Suggestions []taskSuggestion    `json:"suggestions"`  // may be empty
+	Walkthrough *walkthroughExample `json:"walkthrough,omitempty"`
+	LLMUsed     bool                `json:"llm_used"`     // true if suggestions came from LLM
+	LLMStatus   string              `json:"llm_status"`   // "ok" | "unconfigured" | "exhausted" | "error"
 }
 
 // Suggestions returns the welcome-page payload.
@@ -145,7 +157,7 @@ func (h *WelcomeHandler) Suggestions(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	suggestions, err := h.generateSuggestions(ctx, cfg, services, agentSummaries)
+	suggestions, walkthrough, err := h.generateSuggestions(ctx, cfg, services, agentSummaries)
 	if err != nil {
 		if errors.Is(err, llm.ErrSpendCapExhausted) {
 			h.llmHealth.SetSpendCapExhausted()
@@ -159,6 +171,7 @@ func (h *WelcomeHandler) Suggestions(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp.Suggestions = suggestions
+	resp.Walkthrough = walkthrough
 	resp.LLMUsed = true
 	resp.LLMStatus = "ok"
 	writeJSON(w, http.StatusOK, resp)
@@ -292,9 +305,10 @@ func (h *WelcomeHandler) listActivatedServices(ctx context.Context, userID strin
 	return out, nil
 }
 
-// generateSuggestions asks the LLM for 3-5 task ideas tailored to the user's
-// connected services and agent names. Returns an error if the LLM call fails.
-func (h *WelcomeHandler) generateSuggestions(ctx context.Context, llmCfg config.LLMConfig, services []welcomeService, agents []welcomeAgent) ([]taskSuggestion, error) {
+// generateSuggestions asks the LLM for 3-5 task ideas and a walkthrough example
+// tailored to the user's connected services and agent names. Returns an error
+// if the LLM call fails.
+func (h *WelcomeHandler) generateSuggestions(ctx context.Context, llmCfg config.LLMConfig, services []welcomeService, agents []welcomeAgent) ([]taskSuggestion, *walkthroughExample, error) {
 	providerCfg := config.LLMProviderConfig{
 		Provider:       llmCfg.Provider,
 		Endpoint:       llmCfg.Endpoint,
@@ -303,7 +317,7 @@ func (h *WelcomeHandler) generateSuggestions(ctx context.Context, llmCfg config.
 		TimeoutSeconds: llmCfg.TimeoutSeconds,
 	}
 
-	client := llm.NewClient(providerCfg).WithMaxTokens(1200)
+	client := llm.NewClient(providerCfg).WithMaxTokens(1400)
 
 	userMsg := buildSuggestionUserMessage(services, agents)
 
@@ -323,18 +337,18 @@ func (h *WelcomeHandler) generateSuggestions(ctx context.Context, llmCfg config.
 		if err != nil {
 			lastErr = err
 			if errors.Is(err, llm.ErrSpendCapExhausted) {
-				return nil, err
+				return nil, nil, err
 			}
 			if attempt == 0 {
 				continue
 			}
-			return nil, err
+			return nil, nil, err
 		}
 		raw = r
 		break
 	}
 	if raw == "" {
-		return nil, lastErr
+		return nil, nil, lastErr
 	}
 
 	return parseSuggestionResponse(raw)
@@ -349,25 +363,37 @@ You will be given (a) each connected service with its supported actions tagged w
 Produce 3-5 concrete, copy-pasteable task prompts tailored to this user's exact setup.
 
 Rules:
-- Reference a specific agent by name ("Ask <agent> to …") so the user learns which agent is which. Pick the most appropriate agent per suggestion.
+- Pick the most appropriate agent per suggestion and put its name in the "agent" field.
+- The "prompt" field is the direct instruction the user would paste into the agent chat. Write it as a direct imperative addressed to the agent ("Search my Gmail for …", "Find the most recent …"). DO NOT prefix it with "Ask <agent> to …" — the UI renders that framing separately from the agent field.
 - Lead with read-mostly workflows before destructive ones. At most one suggestion should involve high-sensitivity writes.
 - Favor combinations across services when natural (e.g. "read Gmail + create Linear issues for anything actionable").
 - Be specific: reference concrete fields, recent time windows, or named topics. No vague "summarize stuff".
 - Each prompt should be 1-2 sentences the user could literally paste into a chat with the agent.
 
+Also produce ONE walkthrough example illustrating the task → approval → enforcement flow using a coherent pairing of the user's services (e.g. an inbox/messaging service as the source and a task-tracker or notes service as the destination). Pick services that pair naturally; never pair an inbox with a calendar as the "destination". If no coherent pair is possible, use the single best service.
+
 Return ONLY a JSON object — no prose, no markdown fences:
 
-{"suggestions": [
-  {
-    "title": "Short headline (<=50 chars)",
-    "prompt": "Full example prompt the user can paste",
-    "agent": "agent name from the input, or empty",
-    "services": ["service.id.1", "service.id.2"],
-    "risk": "low" | "medium" | "high"
+{
+  "suggestions": [
+    {
+      "title": "Short headline (<=50 chars)",
+      "prompt": "Full example prompt the user can paste",
+      "agent": "agent name from the input, or empty",
+      "services": ["service.id.1", "service.id.2"],
+      "risk": "low" | "medium" | "high"
+    }
+  ],
+  "walkthrough": {
+    "user_prompt": "The quoted one-line natural-language ask, e.g. \"Triage my Gmail and add anything actionable to Linear.\"",
+    "agent_task": "One sentence describing what the agent declares, e.g. \"read Gmail messages received in the last 72 hours, create items in Linear.\"",
+    "primary_name": "Gmail",
+    "secondary_name": "Linear",
+    "services": ["service.id.primary", "service.id.secondary"]
   }
-]}
+}
 
-Use service IDs and agent names EXACTLY as given in the input. Return between 3 and 5 suggestions.`
+Use service IDs and agent names EXACTLY as given in the input. Return between 3 and 5 suggestions. Always include the walkthrough object.`
 
 // buildSuggestionUserMessage renders the context for the LLM.
 func buildSuggestionUserMessage(services []welcomeService, agents []welcomeAgent) string {
@@ -413,9 +439,43 @@ func buildSuggestionUserMessage(services []welcomeService, agents []welcomeAgent
 	return b.String()
 }
 
-// parseSuggestionResponse extracts the suggestions array from the LLM output.
-// It tolerates markdown code fences around the JSON.
-func parseSuggestionResponse(raw string) ([]taskSuggestion, error) {
+// stripAskPrefix removes a leading "Ask <agent> to " (case-insensitive) from a
+// prompt, along with any surrounding quote marks, and re-capitalizes the first
+// letter. The UI renders the "Ask <agent>:" framing separately.
+func stripAskPrefix(s string) string {
+	trimmed := strings.TrimSpace(s)
+	// Strip outer quotes if the whole thing is quoted.
+	if len(trimmed) >= 2 {
+		first, last := trimmed[0], trimmed[len(trimmed)-1]
+		if (first == '"' && last == '"') || (first == '\'' && last == '\'') {
+			trimmed = trimmed[1 : len(trimmed)-1]
+			trimmed = strings.TrimSpace(trimmed)
+		}
+	}
+	lower := strings.ToLower(trimmed)
+	if !strings.HasPrefix(lower, "ask ") {
+		return trimmed
+	}
+	rest := trimmed[4:]
+	// Find " to " after the agent name.
+	idx := strings.Index(strings.ToLower(rest), " to ")
+	if idx < 0 {
+		return trimmed
+	}
+	remainder := strings.TrimSpace(rest[idx+4:])
+	if remainder == "" {
+		return trimmed
+	}
+	// Capitalize first letter.
+	r := []rune(remainder)
+	r[0] = []rune(strings.ToUpper(string(r[0])))[0]
+	return string(r)
+}
+
+// parseSuggestionResponse extracts the suggestions array and the walkthrough
+// example from the LLM output. Tolerates markdown code fences around the JSON.
+// The walkthrough is optional — returned as nil if malformed.
+func parseSuggestionResponse(raw string) ([]taskSuggestion, *walkthroughExample, error) {
 	raw = strings.TrimSpace(raw)
 	raw = strings.TrimPrefix(raw, "```json")
 	raw = strings.TrimPrefix(raw, "```")
@@ -423,22 +483,36 @@ func parseSuggestionResponse(raw string) ([]taskSuggestion, error) {
 	raw = strings.TrimSpace(raw)
 
 	var out struct {
-		Suggestions []taskSuggestion `json:"suggestions"`
+		Suggestions []taskSuggestion    `json:"suggestions"`
+		Walkthrough *walkthroughExample `json:"walkthrough"`
 	}
 	if err := json.Unmarshal([]byte(raw), &out); err != nil {
-		return nil, fmt.Errorf("parse suggestion response: %w", err)
+		return nil, nil, fmt.Errorf("parse suggestion response: %w", err)
 	}
 
-	// Filter out malformed entries.
+	// Filter out malformed entries and strip any leaked "Ask <agent> to …"
+	// prefix — the UI renders that framing from the agent field.
 	cleaned := make([]taskSuggestion, 0, len(out.Suggestions))
 	for _, s := range out.Suggestions {
 		if strings.TrimSpace(s.Title) == "" || strings.TrimSpace(s.Prompt) == "" {
 			continue
 		}
+		s.Prompt = stripAskPrefix(s.Prompt)
 		cleaned = append(cleaned, s)
 	}
 	if len(cleaned) == 0 {
-		return nil, fmt.Errorf("no valid suggestions in response")
+		return nil, nil, fmt.Errorf("no valid suggestions in response")
 	}
-	return cleaned, nil
+
+	walkthrough := out.Walkthrough
+	if walkthrough != nil {
+		if strings.TrimSpace(walkthrough.UserPrompt) == "" ||
+			strings.TrimSpace(walkthrough.AgentTask) == "" ||
+			strings.TrimSpace(walkthrough.PrimaryName) == "" ||
+			strings.TrimSpace(walkthrough.SecondaryName) == "" {
+			walkthrough = nil
+		}
+	}
+
+	return cleaned, walkthrough, nil
 }

--- a/internal/api/handlers/welcome.go
+++ b/internal/api/handlers/welcome.go
@@ -1,0 +1,444 @@
+// Package handlers — welcome.go serves the "What is Clawvisor?" page.
+//
+// It reports the user's setup state (connected services + agents) and, when
+// both are present, asks the LLM to suggest personalized first tasks the user
+// could hand their agent. Suggestions are best-effort: when the LLM is not
+// configured, exhausted, or errors out, we return an empty list and let the
+// frontend fall back to a static explainer.
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/clawvisor/clawvisor/internal/api/middleware"
+	"github.com/clawvisor/clawvisor/internal/display"
+	"github.com/clawvisor/clawvisor/internal/llm"
+	"github.com/clawvisor/clawvisor/pkg/adapters"
+	"github.com/clawvisor/clawvisor/pkg/config"
+	"github.com/clawvisor/clawvisor/pkg/store"
+	"github.com/clawvisor/clawvisor/pkg/vault"
+)
+
+// WelcomeHandler serves the "what is Clawvisor" explainer page data.
+type WelcomeHandler struct {
+	st         store.Store
+	vault      vault.Vault
+	adapterReg *adapters.Registry
+	llmHealth  *llm.Health
+	logger     *slog.Logger
+}
+
+// NewWelcomeHandler builds a WelcomeHandler.
+func NewWelcomeHandler(st store.Store, v vault.Vault, adapterReg *adapters.Registry, h *llm.Health, logger *slog.Logger) *WelcomeHandler {
+	return &WelcomeHandler{st: st, vault: v, adapterReg: adapterReg, llmHealth: h, logger: logger}
+}
+
+// welcomeAction is one action the connected service supports. Categories and
+// sensitivities come from adapter metadata and help the LLM (and the UI) bias
+// suggestions toward low-risk reads first.
+type welcomeAction struct {
+	ID          string `json:"id"`
+	DisplayName string `json:"display_name"`
+	Category    string `json:"category,omitempty"`    // "read" | "write" | "delete" | "search"
+	Sensitivity string `json:"sensitivity,omitempty"` // "low" | "medium" | "high"
+}
+
+// welcomeService summarises one connected service for the LLM prompt and UI.
+type welcomeService struct {
+	ID          string          `json:"id"`
+	Name        string          `json:"name"`
+	Alias       string          `json:"alias,omitempty"`
+	Description string          `json:"description,omitempty"`
+	IconURL     string          `json:"icon_url,omitempty"`
+	IconSVG     string          `json:"icon_svg,omitempty"`
+	Actions     []welcomeAction `json:"actions,omitempty"`
+}
+
+// welcomeAgent summarises one registered agent.
+type welcomeAgent struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// taskSuggestion is one LLM-generated idea for a task the user could hand
+// their agent. Kept deliberately small — the frontend renders a prompt the
+// user can copy/paste.
+type taskSuggestion struct {
+	Title    string   `json:"title"`              // short headline, e.g. "Triage inbox"
+	Prompt   string   `json:"prompt"`             // example natural-language prompt to hand the agent
+	Agent    string   `json:"agent,omitempty"`    // recommended agent name, if any
+	Services []string `json:"services"`           // service IDs the prompt involves
+	Risk     string   `json:"risk,omitempty"`     // "low" | "medium" | "high"
+}
+
+// welcomeResponse is the payload for GET /api/welcome/suggestions.
+type welcomeResponse struct {
+	Ready       bool             `json:"ready"`        // true when ≥1 service + ≥1 agent
+	Services    []welcomeService `json:"services"`
+	Agents      []welcomeAgent   `json:"agents"`
+	Suggestions []taskSuggestion `json:"suggestions"`  // may be empty
+	LLMUsed     bool             `json:"llm_used"`     // true if suggestions came from LLM
+	LLMStatus   string           `json:"llm_status"`   // "ok" | "unconfigured" | "exhausted" | "error"
+}
+
+// Suggestions returns the welcome-page payload.
+//
+// GET /api/welcome/suggestions
+// Auth: user JWT
+func (h *WelcomeHandler) Suggestions(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	user := middleware.UserFromContext(ctx)
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "not authenticated")
+		return
+	}
+
+	services, err := h.listActivatedServices(ctx, user.ID)
+	if err != nil {
+		h.logger.Warn("welcome: failed to list services", "err", err)
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not list services")
+		return
+	}
+
+	agents, err := h.st.ListAgents(ctx, user.ID)
+	if err != nil {
+		h.logger.Warn("welcome: failed to list agents", "err", err)
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not list agents")
+		return
+	}
+	agentSummaries := make([]welcomeAgent, 0, len(agents))
+	for _, a := range agents {
+		agentSummaries = append(agentSummaries, welcomeAgent{ID: a.ID, Name: a.Name})
+	}
+
+	resp := welcomeResponse{
+		Ready:       len(services) > 0 && len(agents) > 0,
+		Services:    services,
+		Agents:      agentSummaries,
+		Suggestions: []taskSuggestion{},
+	}
+
+	if !resp.Ready {
+		resp.LLMStatus = "ok"
+		writeJSON(w, http.StatusOK, resp)
+		return
+	}
+
+	// Decide whether to call the LLM.
+	cfg := h.llmHealth.LLMConfig()
+	if cfg.APIKey == "" {
+		resp.LLMStatus = "unconfigured"
+		writeJSON(w, http.StatusOK, resp)
+		return
+	}
+	if h.llmHealth.SpendCapExhausted() {
+		resp.LLMStatus = "exhausted"
+		writeJSON(w, http.StatusOK, resp)
+		return
+	}
+
+	suggestions, err := h.generateSuggestions(ctx, cfg, services, agentSummaries)
+	if err != nil {
+		if errors.Is(err, llm.ErrSpendCapExhausted) {
+			h.llmHealth.SetSpendCapExhausted()
+			resp.LLMStatus = "exhausted"
+		} else {
+			h.logger.Warn("welcome: suggestion generation failed", "err", err)
+			resp.LLMStatus = "error"
+		}
+		writeJSON(w, http.StatusOK, resp)
+		return
+	}
+
+	resp.Suggestions = suggestions
+	resp.LLMUsed = true
+	resp.LLMStatus = "ok"
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// listActivatedServices returns the user's activated services, with display
+// names, descriptions, and action IDs the agent can take. This mirrors the
+// activated-branch of ServicesHandler.List but keeps only the fields the
+// welcome page (and the LLM prompt) needs.
+func (h *WelcomeHandler) listActivatedServices(ctx context.Context, userID string) ([]welcomeService, error) {
+	activatedKeys, err := h.vault.List(ctx, userID)
+	if err != nil && !errors.Is(err, vault.ErrNotFound) {
+		return nil, err
+	}
+	keySet := make(map[string]bool, len(activatedKeys))
+	for _, k := range activatedKeys {
+		keySet[k] = true
+	}
+
+	metas, err := h.st.ListServiceMetas(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]welcomeService, 0)
+	seen := make(map[string]bool)
+
+	buildEntry := func(a adapters.Adapter, alias string) welcomeService {
+		name := display.ServiceName(a.ServiceID())
+		desc := display.ServiceDescription(a.ServiceID())
+		var iconURL, iconSVG string
+		actionMetaByID := map[string]adapters.ActionMeta{}
+		if mp, ok := a.(adapters.MetadataProvider); ok {
+			meta := mp.ServiceMetadata()
+			if meta.DisplayName != "" {
+				name = meta.DisplayName
+			}
+			if meta.Description != "" {
+				desc = meta.Description
+			}
+			iconURL = meta.IconURL
+			iconSVG = meta.IconSVG
+			actionMetaByID = meta.ActionMeta
+		}
+		actions := make([]welcomeAction, 0, len(a.SupportedActions()))
+		for _, actionID := range a.SupportedActions() {
+			label := display.ActionName(actionID)
+			var category, sensitivity string
+			if am, ok := actionMetaByID[actionID]; ok {
+				if am.DisplayName != "" {
+					label = am.DisplayName
+				}
+				category = am.Category
+				sensitivity = am.Sensitivity
+			}
+			actions = append(actions, welcomeAction{
+				ID:          actionID,
+				DisplayName: label,
+				Category:    category,
+				Sensitivity: sensitivity,
+			})
+		}
+		entry := welcomeService{
+			ID:          a.ServiceID(),
+			Name:        name,
+			Description: desc,
+			IconURL:     iconURL,
+			IconSVG:     iconSVG,
+			Actions:     actions,
+		}
+		if alias != "" && alias != "default" {
+			entry.Alias = alias
+		}
+		return entry
+	}
+
+	for _, a := range h.adapterReg.All() {
+		if ac, ok := a.(adapters.AvailabilityChecker); ok && !ac.Available() {
+			continue
+		}
+		credentialFree := a.ValidateCredential(nil) == nil
+
+		if credentialFree {
+			for _, m := range metas {
+				if m.ServiceID != a.ServiceID() {
+					continue
+				}
+				key := a.ServiceID() + ":" + m.Alias
+				if seen[key] {
+					continue
+				}
+				seen[key] = true
+				out = append(out, buildEntry(a, m.Alias))
+			}
+			continue
+		}
+
+		for _, m := range metas {
+			if m.ServiceID != a.ServiceID() {
+				continue
+			}
+			vKey := h.adapterReg.VaultKeyWithAlias(a.ServiceID(), m.Alias)
+			if !keySet[vKey] {
+				continue
+			}
+			key := a.ServiceID() + ":" + m.Alias
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			out = append(out, buildEntry(a, m.Alias))
+		}
+
+		baseKey := h.adapterReg.VaultKey(a.ServiceID())
+		usesSharedKey := baseKey != a.ServiceID()
+		if !usesSharedKey && keySet[baseKey] {
+			key := a.ServiceID() + ":default"
+			if !seen[key] {
+				seen[key] = true
+				out = append(out, buildEntry(a, ""))
+			}
+		}
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].ID != out[j].ID {
+			return out[i].ID < out[j].ID
+		}
+		return out[i].Alias < out[j].Alias
+	})
+	return out, nil
+}
+
+// generateSuggestions asks the LLM for 3-5 task ideas tailored to the user's
+// connected services and agent names. Returns an error if the LLM call fails.
+func (h *WelcomeHandler) generateSuggestions(ctx context.Context, llmCfg config.LLMConfig, services []welcomeService, agents []welcomeAgent) ([]taskSuggestion, error) {
+	providerCfg := config.LLMProviderConfig{
+		Provider:       llmCfg.Provider,
+		Endpoint:       llmCfg.Endpoint,
+		APIKey:         llmCfg.APIKey,
+		Model:          llmCfg.Model,
+		TimeoutSeconds: llmCfg.TimeoutSeconds,
+	}
+
+	client := llm.NewClient(providerCfg).WithMaxTokens(1200)
+
+	userMsg := buildSuggestionUserMessage(services, agents)
+
+	// Run with a bounded timeout on top of the client's own.
+	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+
+	messages := []llm.ChatMessage{
+		{Role: "system", Content: suggestionSystemPrompt},
+		{Role: "user", Content: userMsg},
+	}
+
+	var raw string
+	var lastErr error
+	for attempt := range 2 {
+		r, err := client.Complete(ctx, messages)
+		if err != nil {
+			lastErr = err
+			if errors.Is(err, llm.ErrSpendCapExhausted) {
+				return nil, err
+			}
+			if attempt == 0 {
+				continue
+			}
+			return nil, err
+		}
+		raw = r
+		break
+	}
+	if raw == "" {
+		return nil, lastErr
+	}
+
+	return parseSuggestionResponse(raw)
+}
+
+const suggestionSystemPrompt = `You help Clawvisor users discover useful first tasks to hand to their AI agents.
+
+Clawvisor is a gateway between AI agents and external APIs. Users connect services (Gmail, GitHub, Linear, Slack, etc.) and register agents that act through Clawvisor. Agents declare tasks; the user approves scopes once; individual destructive actions can still require per-request approval.
+
+You will be given (a) each connected service with its supported actions tagged with category (read/write/delete/search) and sensitivity (low/medium/high), and (b) the names of registered agents.
+
+Produce 3-5 concrete, copy-pasteable task prompts tailored to this user's exact setup.
+
+Rules:
+- Reference a specific agent by name ("Ask <agent> to …") so the user learns which agent is which. Pick the most appropriate agent per suggestion.
+- Lead with read-mostly workflows before destructive ones. At most one suggestion should involve high-sensitivity writes.
+- Favor combinations across services when natural (e.g. "read Gmail + create Linear issues for anything actionable").
+- Be specific: reference concrete fields, recent time windows, or named topics. No vague "summarize stuff".
+- Each prompt should be 1-2 sentences the user could literally paste into a chat with the agent.
+
+Return ONLY a JSON object — no prose, no markdown fences:
+
+{"suggestions": [
+  {
+    "title": "Short headline (<=50 chars)",
+    "prompt": "Full example prompt the user can paste",
+    "agent": "agent name from the input, or empty",
+    "services": ["service.id.1", "service.id.2"],
+    "risk": "low" | "medium" | "high"
+  }
+]}
+
+Use service IDs and agent names EXACTLY as given in the input. Return between 3 and 5 suggestions.`
+
+// buildSuggestionUserMessage renders the context for the LLM.
+func buildSuggestionUserMessage(services []welcomeService, agents []welcomeAgent) string {
+	var b strings.Builder
+
+	b.WriteString("# Connected services\n\n")
+	for _, s := range services {
+		name := s.Name
+		if s.Alias != "" {
+			name = fmt.Sprintf("%s (%s)", s.Name, s.Alias)
+		}
+		fmt.Fprintf(&b, "- **%s** (id: `%s`)", name, s.ID)
+		if s.Description != "" {
+			fmt.Fprintf(&b, " — %s", s.Description)
+		}
+		b.WriteString("\n")
+		if len(s.Actions) > 0 {
+			actions := s.Actions
+			if len(actions) > 12 {
+				actions = actions[:12]
+			}
+			labels := make([]string, 0, len(actions))
+			for _, act := range actions {
+				l := act.DisplayName
+				if act.Category != "" || act.Sensitivity != "" {
+					tag := strings.TrimSpace(act.Category + " " + act.Sensitivity)
+					if tag != "" {
+						l = fmt.Sprintf("%s [%s]", l, tag)
+					}
+				}
+				labels = append(labels, l)
+			}
+			fmt.Fprintf(&b, "  Supported actions: %s\n", strings.Join(labels, ", "))
+		}
+	}
+
+	b.WriteString("\n# Registered agents\n\n")
+	for _, a := range agents {
+		fmt.Fprintf(&b, "- `%s`\n", a.Name)
+	}
+
+	b.WriteString("\nSuggest 3-5 first tasks. Respond with JSON only.")
+	return b.String()
+}
+
+// parseSuggestionResponse extracts the suggestions array from the LLM output.
+// It tolerates markdown code fences around the JSON.
+func parseSuggestionResponse(raw string) ([]taskSuggestion, error) {
+	raw = strings.TrimSpace(raw)
+	raw = strings.TrimPrefix(raw, "```json")
+	raw = strings.TrimPrefix(raw, "```")
+	raw = strings.TrimSuffix(raw, "```")
+	raw = strings.TrimSpace(raw)
+
+	var out struct {
+		Suggestions []taskSuggestion `json:"suggestions"`
+	}
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		return nil, fmt.Errorf("parse suggestion response: %w", err)
+	}
+
+	// Filter out malformed entries.
+	cleaned := make([]taskSuggestion, 0, len(out.Suggestions))
+	for _, s := range out.Suggestions {
+		if strings.TrimSpace(s.Title) == "" || strings.TrimSpace(s.Prompt) == "" {
+			continue
+		}
+		cleaned = append(cleaned, s)
+	}
+	if len(cleaned) == 0 {
+		return nil, fmt.Errorf("no valid suggestions in response")
+	}
+	return cleaned, nil
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -732,6 +732,10 @@ func (s *Server) routes() http.Handler {
 	overviewHandler := handlers.NewOverviewHandler(s.store)
 	mux.Handle("GET /api/overview", user(overviewHandler.Get))
 
+	// Welcome / "What is Clawvisor?" page (user JWT)
+	welcomeHandler := handlers.NewWelcomeHandler(s.store, s.vault, s.adapterReg, s.llmHealth, s.logger)
+	mux.Handle("GET /api/welcome/suggestions", user(welcomeHandler.Suggestions))
+
 	// Tasks (agent auth)
 	mux.Handle("POST /api/tasks", requireAgent(e2e(http.HandlerFunc(tasksHandler.Create))))
 	mux.Handle("GET /api/tasks/{id}", requireAgent(e2e(http.HandlerFunc(tasksHandler.Get))))

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -536,11 +536,20 @@ export interface TaskSuggestion {
   risk?: 'low' | 'medium' | 'high'
 }
 
+export interface WalkthroughExample {
+  user_prompt: string
+  agent_task: string
+  primary_name: string
+  secondary_name: string
+  services?: string[]
+}
+
 export interface WelcomeData {
   ready: boolean
   services: WelcomeService[]
   agents: WelcomeAgent[]
   suggestions: TaskSuggestion[]
+  walkthrough?: WalkthroughExample
   llm_used: boolean
   llm_status: 'ok' | 'unconfigured' | 'exhausted' | 'error'
 }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -506,6 +506,45 @@ export interface OverviewData {
   activity: ActivityBucket[]
 }
 
+export interface WelcomeAction {
+  id: string
+  display_name: string
+  category?: string
+  sensitivity?: string
+}
+
+export interface WelcomeService {
+  id: string
+  name: string
+  alias?: string
+  description?: string
+  icon_url?: string
+  icon_svg?: string
+  actions?: WelcomeAction[]
+}
+
+export interface WelcomeAgent {
+  id: string
+  name: string
+}
+
+export interface TaskSuggestion {
+  title: string
+  prompt: string
+  agent?: string
+  services: string[]
+  risk?: 'low' | 'medium' | 'high'
+}
+
+export interface WelcomeData {
+  ready: boolean
+  services: WelcomeService[]
+  agents: WelcomeAgent[]
+  suggestions: TaskSuggestion[]
+  llm_used: boolean
+  llm_status: 'ok' | 'unconfigured' | 'exhausted' | 'error'
+}
+
 export interface QueueApproval {
   request_id: string
   audit_id: string
@@ -981,6 +1020,9 @@ export const api = {
   },
   overview: {
     get: () => get<OverviewData>('/api/overview'),
+  },
+  welcome: {
+    suggestions: () => get<WelcomeData>('/api/welcome/suggestions'),
   },
   devices: {
     list: () => get<PairedDevice[]>('/api/devices'),

--- a/web/src/hooks/useEventStream.ts
+++ b/web/src/hooks/useEventStream.ts
@@ -55,6 +55,7 @@ export function useEventStream() {
         qc.invalidateQueries({ queryKey: ['overview'] })
         qc.invalidateQueries({ queryKey: ['queue'] })
         qc.invalidateQueries({ queryKey: ['connections'] })
+        qc.invalidateQueries({ queryKey: ['welcome'] })
       })
 
       es.addEventListener('tasks', () => {

--- a/web/src/pages/Agents.tsx
+++ b/web/src/pages/Agents.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { api } from '../api/client'
 import type { ConnectionRequest } from '../api/client'
@@ -32,6 +33,7 @@ export default function Agents() {
       : api.agents.create(name).then(agent => ({ agent, token: agent.token ?? '' })),
     onSuccess: (result) => {
       qc.invalidateQueries({ queryKey: ['agents'] })
+      qc.invalidateQueries({ queryKey: ['welcome'] })
       setNewToken(result.token ?? null)
       setName('')
       setFormError(null)
@@ -46,6 +48,7 @@ export default function Agents() {
       qc.invalidateQueries({ queryKey: ['agents'] })
       qc.invalidateQueries({ queryKey: ['tasks'] })
       qc.invalidateQueries({ queryKey: ['overview'] })
+      qc.invalidateQueries({ queryKey: ['welcome'] })
     },
   })
 
@@ -200,8 +203,20 @@ export default function Agents() {
 
 type AgentTab = 'openclaw' | 'claude-code' | 'claude-desktop' | 'other'
 
+const AGENT_TABS: AgentTab[] = ['openclaw', 'claude-code', 'claude-desktop', 'other']
+
 function ConnectAgentGuide() {
-  const [tab, setTab] = useState<AgentTab>('openclaw')
+  const [searchParams, setSearchParams] = useSearchParams()
+  const initialTab = (AGENT_TABS.includes(searchParams.get('agent') as AgentTab)
+    ? (searchParams.get('agent') as AgentTab)
+    : 'openclaw')
+  const [tab, setTabState] = useState<AgentTab>(initialTab)
+  const setTab = (next: AgentTab) => {
+    setTabState(next)
+    const params = new URLSearchParams(searchParams)
+    params.set('agent', next)
+    setSearchParams(params, { replace: true })
+  }
   const [copied, setCopied] = useState(false)
   const { user } = useAuth()
 
@@ -621,6 +636,7 @@ function ConnectionCard({ request: cr }: { request: ConnectionRequest }) {
       qc.invalidateQueries({ queryKey: ['connections'] })
       qc.invalidateQueries({ queryKey: ['agents'] })
       qc.invalidateQueries({ queryKey: ['overview'] })
+      qc.invalidateQueries({ queryKey: ['welcome'] })
     },
     onError: (err: Error) => setResult(`Failed: ${err.message}`),
   })

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -11,6 +11,7 @@ import Audit from './Audit'
 import Agents from './Agents'
 import Settings from './Settings'
 import Overview from './Overview'
+import GetStarted from './GetStarted'
 import Tasks from './Tasks'
 import AdapterGen from './AdapterGen'
 import OrgSettings from './OrgSettings'
@@ -23,6 +24,7 @@ import OnboardingBanner from '../components/OnboardingBanner'
 
 const navItems = [
   { to: '/dashboard', label: 'Dashboard', end: true, icon: <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg> },
+  { to: '/dashboard/get-started', label: 'Get Started', icon: <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 015.83 1c0 2-3 3-3 3"/><path d="M12 17h.01"/></svg> },
   { to: '/dashboard/tasks', label: 'Tasks', icon: <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg> },
   { to: '/dashboard/services', label: 'Services', icon: <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M4 6h16M4 12h16M4 18h16"/></svg> },
   { to: '/dashboard/restrictions', label: 'Restrictions', icon: <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg> },
@@ -312,6 +314,7 @@ export default function Dashboard() {
         )}
         <Routes>
           <Route index element={<Overview />} />
+          <Route path="get-started" element={<GetStarted />} />
           <Route path="tasks" element={<Tasks />} />
           <Route path="services" element={<Services />} />
           <Route path="restrictions" element={<Restrictions />} />

--- a/web/src/pages/GetStarted.tsx
+++ b/web/src/pages/GetStarted.tsx
@@ -21,9 +21,11 @@ export default function GetStarted() {
 
   return (
     <div className="p-4 sm:p-8 space-y-10 max-w-5xl">
-      <Hero ready={ready} services={services} agents={agents} />
+      <Hero ready={ready} services={services} agents={agents} isLoading={isLoading} />
 
-      {ready ? (
+      {isLoading ? (
+        <LoadingState />
+      ) : ready ? (
         <>
           <SuggestionsSection data={data} isLoading={isLoading} isFetching={isFetching} onRefresh={() => refetch()} />
           <YourSetupSection services={services} agents={agents} />
@@ -39,9 +41,72 @@ export default function GetStarted() {
   )
 }
 
+function LoadingState() {
+  return (
+    <div className="space-y-10" aria-busy="true" aria-live="polite">
+      <section>
+        <div className="flex items-center gap-2 mb-3">
+          <LoadingSpinner />
+          <h2 className="text-xl font-semibold text-text-primary">Checking your setup&hellip;</h2>
+        </div>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <SkeletonCard label="Services" />
+          <SkeletonCard label="Agents" />
+        </div>
+      </section>
+      <section>
+        <div className="flex items-center gap-2 mb-3">
+          <LoadingSpinner />
+          <h2 className="text-xl font-semibold text-text-primary">Generating task ideas&hellip;</h2>
+        </div>
+        <SuggestionsLoading />
+      </section>
+    </div>
+  )
+}
+
+function SkeletonCard({ label }: { label: string }) {
+  return (
+    <div className="rounded-lg border border-border-subtle bg-surface-1 p-4 animate-pulse">
+      <div className="text-xs font-medium uppercase tracking-wider text-text-tertiary mb-3">{label}</div>
+      <div className="flex flex-wrap gap-2">
+        <div className="h-6 w-24 bg-surface-2 rounded-md" />
+        <div className="h-6 w-28 bg-surface-2 rounded-md" />
+        <div className="h-6 w-20 bg-surface-2 rounded-md" />
+      </div>
+    </div>
+  )
+}
+
+function LoadingSpinner() {
+  return (
+    <svg
+      className="w-4 h-4 animate-spin text-brand"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      viewBox="0 0 24 24"
+      aria-hidden
+    >
+      <circle cx="12" cy="12" r="10" opacity="0.25" />
+      <path d="M22 12a10 10 0 01-10 10" />
+    </svg>
+  )
+}
+
 // ── Hero ──────────────────────────────────────────────────────────────────────
 
-function Hero({ ready, services, agents }: { ready: boolean; services: WelcomeService[]; agents: WelcomeAgent[] }) {
+function Hero({
+  ready,
+  services,
+  agents,
+  isLoading,
+}: {
+  ready: boolean
+  services: WelcomeService[]
+  agents: WelcomeAgent[]
+  isLoading: boolean
+}) {
   return (
     <header className="space-y-3">
       <h1 className="text-3xl sm:text-4xl font-bold text-text-primary tracking-tight">
@@ -53,12 +118,14 @@ function Hero({ ready, services, agents }: { ready: boolean; services: WelcomeSe
         approve the scope once, and Clawvisor handles credential injection, execution, and audit
         logging for every request.
       </p>
-      {ready && (
+      {isLoading ? (
+        <p className="text-sm text-text-tertiary">Loading your setup&hellip;</p>
+      ) : ready ? (
         <p className="text-sm text-text-tertiary">
           {services.length} service{services.length === 1 ? '' : 's'} connected · {agents.length}{' '}
           agent{agents.length === 1 ? '' : 's'} registered
         </p>
-      )}
+      ) : null}
     </header>
   )
 }
@@ -333,7 +400,10 @@ function SuggestionsSection({
       {isLoading ? (
         <SuggestionsLoading />
       ) : suggestions.length > 0 ? (
-        <div className="grid gap-3 md:grid-cols-2">
+        <div
+          className={`grid gap-3 md:grid-cols-2 transition-opacity ${isFetching ? 'opacity-50' : ''}`}
+          aria-busy={isFetching}
+        >
           {suggestions.map((s, i) => (
             <SuggestionCard key={i} suggestion={s} serviceById={serviceById} />
           ))}

--- a/web/src/pages/GetStarted.tsx
+++ b/web/src/pages/GetStarted.tsx
@@ -1,7 +1,7 @@
 import { useState, type ReactNode } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Link } from 'react-router-dom'
-import { api, type TaskSuggestion, type WelcomeData, type WelcomeService, type WelcomeAgent } from '../api/client'
+import { api, type TaskSuggestion, type WelcomeData, type WelcomeService, type WelcomeAgent, type WalkthroughExample } from '../api/client'
 import { ServiceIcon } from '../components/ServiceIcon'
 
 // GetStarted — the "What is Clawvisor?" page. It's context-aware: users with
@@ -9,7 +9,7 @@ import { ServiceIcon } from '../components/ServiceIcon'
 // set up lead with personalized LLM-generated task ideas.
 export default function GetStarted() {
   const { data, isLoading, refetch, isFetching } = useQuery({
-    queryKey: ['welcome-suggestions'],
+    queryKey: ['welcome'],
     queryFn: () => api.welcome.suggestions(),
     staleTime: 5 * 60_000,
     refetchOnWindowFocus: false,
@@ -27,12 +27,12 @@ export default function GetStarted() {
         <>
           <SuggestionsSection data={data} isLoading={isLoading} isFetching={isFetching} onRefresh={() => refetch()} />
           <YourSetupSection services={services} agents={agents} />
-          <ExampleWalkthrough services={services} compact />
+          <ExampleWalkthrough example={data?.walkthrough} />
         </>
       ) : (
         <>
           <SetupSteps services={services} agents={agents} isLoading={isLoading} />
-          <ExampleWalkthrough services={services} />
+          <ExampleWalkthrough example={data?.walkthrough} />
         </>
       )}
     </div>
@@ -44,10 +44,6 @@ export default function GetStarted() {
 function Hero({ ready, services, agents }: { ready: boolean; services: WelcomeService[]; agents: WelcomeAgent[] }) {
   return (
     <header className="space-y-3">
-      <div className="inline-flex items-center gap-2 text-xs font-mono uppercase tracking-wider text-brand bg-brand-muted px-2 py-1 rounded">
-        <img src="/favicon.svg" alt="" className="w-3.5 h-3.5" />
-        Clawvisor
-      </div>
       <h1 className="text-3xl sm:text-4xl font-bold text-text-primary tracking-tight">
         Your agents act. You stay in control.
       </h1>
@@ -102,7 +98,7 @@ function SetupSteps({
               <PopularService id="github" label="GitHub" />
               <PopularService id="linear" label="Linear" />
               <PopularService id="slack" label="Slack" />
-              <PopularService id="google.calendar" label="Calendar" />
+              <PopularService id="google.calendar" label="Google Calendar" />
               <Link
                 to="/dashboard/services"
                 className="inline-flex items-center gap-1 text-sm font-medium text-brand hover:text-brand-strong px-3 py-1.5 rounded-md border border-brand/40 bg-brand-muted transition-colors"
@@ -118,43 +114,19 @@ function SetupSteps({
 
         <SetupStepCard num={2} done={hasAgent} title="Connect an agent" loading={isLoading}>
           <p className="text-sm text-text-secondary mb-3">
-            Your agent gets a bearer token that lets it make requests through Clawvisor. Run one of
-            these commands to auto-install:
+            Pair an AI agent (Claude Code, Claude Desktop, OpenClaw, or any HTTP client) with
+            Clawvisor so it can create tasks on your behalf.
           </p>
           {hasAgent ? (
             <ConnectedAgentsStrip agents={agents} />
           ) : (
-            <div className="grid gap-2 sm:grid-cols-2">
-              <AgentInstallCard
-                name="Claude Code"
-                description="Install the Clawvisor skill so Claude Code can create tasks."
-                command="clawvisor connect-agent claude-code"
-              />
-              <AgentInstallCard
-                name="Claude Desktop"
-                description="Configure MCP so Claude Desktop routes tool calls via Clawvisor."
-                command="clawvisor connect-agent claude-desktop"
-              />
-              <AgentInstallCard
-                name="OpenClaw"
-                description="Pair an OpenClaw daemon over the relay."
-                command="clawvisor connect-agent openclaw"
-              />
-              <AgentInstallCard
-                name="Any HTTP agent"
-                description="Mint a raw token to use with any client."
-                command="clawvisor connect-agent"
-              />
+            <div className="flex flex-wrap gap-2">
+              <PopularAgent tab="claude-code" label="Claude Code" />
+              <PopularAgent tab="claude-desktop" label="Claude Desktop" />
+              <PopularAgent tab="openclaw" label="OpenClaw" />
+              <PopularAgent tab="other" label="Other agents" />
             </div>
           )}
-          <div className="mt-3">
-            <Link
-              to="/dashboard/agents"
-              className="text-sm text-brand hover:text-brand-strong font-medium"
-            >
-              Or create a token in the dashboard →
-            </Link>
-          </div>
         </SetupStepCard>
       </div>
     </section>
@@ -217,45 +189,14 @@ function PopularService({ id, label }: { id: string; label: string }) {
   )
 }
 
-function AgentInstallCard({
-  name,
-  description,
-  command,
-}: {
-  name: string
-  description: string
-  command: string
-}) {
-  const [copied, setCopied] = useState(false)
-  function copy() {
-    navigator.clipboard.writeText(command).then(() => {
-      setCopied(true)
-      setTimeout(() => setCopied(false), 1500)
-    })
-  }
+function PopularAgent({ tab, label }: { tab: string; label: string }) {
   return (
-    <div className="rounded-md border border-border-subtle bg-surface-0 p-3">
-      <div className="font-medium text-sm text-text-primary">{name}</div>
-      <div className="text-xs text-text-secondary mb-2">{description}</div>
-      <button
-        onClick={copy}
-        className="w-full flex items-center justify-between gap-2 text-left font-mono text-xs text-text-primary bg-surface-2 hover:bg-surface-3 px-2.5 py-1.5 rounded border border-border-subtle transition-colors"
-      >
-        <span className="truncate">$ {command}</span>
-        <span className="shrink-0 text-text-tertiary">
-          {copied ? (
-            <svg className="w-3.5 h-3.5 text-success" fill="none" stroke="currentColor" strokeWidth="2.5" viewBox="0 0 24 24">
-              <path d="M5 13l4 4L19 7" />
-            </svg>
-          ) : (
-            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-              <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
-              <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
-            </svg>
-          )}
-        </span>
-      </button>
-    </div>
+    <Link
+      to={`/dashboard/agents?agent=${encodeURIComponent(tab)}`}
+      className="inline-flex items-center gap-1.5 text-sm text-text-primary bg-surface-2 hover:bg-surface-3 px-3 py-1.5 rounded-md border border-border-subtle transition-colors"
+    >
+      {label}
+    </Link>
   )
 }
 
@@ -427,22 +368,19 @@ function SuggestionCard({
         {suggestion.risk && <RiskBadge level={suggestion.risk} />}
       </div>
 
-      <p className="text-sm text-text-secondary leading-relaxed whitespace-pre-wrap">
-        {suggestion.prompt}
-      </p>
+      <div className="space-y-1.5">
+        {suggestion.agent && (
+          <div className="text-xs text-text-tertiary">
+            Ask <span className="font-mono text-brand">{suggestion.agent}</span> to:
+          </div>
+        )}
+        <blockquote className="text-sm text-text-primary leading-relaxed whitespace-pre-wrap border-l-2 border-brand/40 pl-3 italic">
+          {suggestion.prompt}
+        </blockquote>
+      </div>
 
       <div className="flex items-end justify-between gap-3 mt-auto pt-1">
         <div className="flex flex-wrap gap-1.5">
-          {suggestion.agent && (
-            <span className="inline-flex items-center gap-1 text-xs font-mono px-2 py-0.5 rounded bg-brand-muted text-brand">
-              <svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-                <rect x="3" y="11" width="18" height="10" rx="2" ry="2" />
-                <circle cx="12" cy="5" r="2" />
-                <path d="M12 7v4" />
-              </svg>
-              {suggestion.agent}
-            </span>
-          )}
           {suggestion.services.map(id => {
             const svc = serviceById.get(id)
             return (
@@ -536,28 +474,26 @@ function SuggestionsFallback({ status }: { status?: string }) {
 
 // ── Example walkthrough ───────────────────────────────────────────────────────
 
-function ExampleWalkthrough({
-  services,
-  compact = false,
-}: {
-  services: WelcomeService[]
-  compact?: boolean
-}) {
-  // Prefer concrete services from the user's actual setup; fall back to Gmail.
-  const primary = pickExampleService(services, ['google.gmail', 'gmail', 'imap', 'outlook'])
-  const secondary = pickExampleService(services, ['linear', 'github', 'jira', 'notion'], primary?.id)
+const DEFAULT_WALKTHROUGH: WalkthroughExample = {
+  user_prompt: 'Triage my Gmail and add anything actionable to Linear.',
+  agent_task:
+    'read Gmail messages received in the last 72 hours, create items in Linear.',
+  primary_name: 'Gmail',
+  secondary_name: 'Linear',
+}
 
-  const primaryName = primary?.name ?? 'Gmail'
-  const secondaryName = secondary?.name ?? 'Linear'
+function ExampleWalkthrough({ example }: { example?: WalkthroughExample }) {
+  const ex = example ?? DEFAULT_WALKTHROUGH
+  const personalized = !!example
 
   const steps: { label: string; body: string; detail?: string }[] = [
     {
       label: 'You ask',
-      body: `"Triage my ${primaryName} and add anything actionable to ${secondaryName}."`,
+      body: `"${ex.user_prompt}"`,
     },
     {
       label: 'Agent declares a task',
-      body: `The agent creates a Clawvisor task: read ${primaryName}, create ${secondaryName} issues, ask before sending replies.`,
+      body: `The agent creates a Clawvisor task: ${ex.agent_task}`,
       detail: 'The agent never holds credentials. It just says what it needs to do.',
     },
     {
@@ -574,12 +510,12 @@ function ExampleWalkthrough({
   return (
     <section>
       <h2 className="text-xl font-semibold text-text-primary mb-1">
-        {compact ? 'How it works' : 'Here\u2019s what a task looks like'}
+        Here&rsquo;s what a task looks like
       </h2>
       <p className="text-sm text-text-secondary mb-4">
-        {compact
-          ? 'Quick refresher on the flow:'
-          : `Using your connected ${primaryName} and ${secondaryName} as an example:`}
+        {personalized
+          ? `Using your connected ${ex.primary_name} and ${ex.secondary_name} as an example:`
+          : `Here\u2019s an example using ${ex.primary_name} and ${ex.secondary_name}:`}
       </p>
       <ol className="space-y-0 relative">
         {steps.map((step, i) => (
@@ -618,14 +554,3 @@ function ExampleWalkthrough({
   )
 }
 
-function pickExampleService(
-  services: WelcomeService[],
-  preferredIds: string[],
-  excludeId?: string,
-): WelcomeService | undefined {
-  for (const id of preferredIds) {
-    const match = services.find(s => s.id === id && s.id !== excludeId)
-    if (match) return match
-  }
-  return services.find(s => s.id !== excludeId)
-}

--- a/web/src/pages/GetStarted.tsx
+++ b/web/src/pages/GetStarted.tsx
@@ -1,0 +1,631 @@
+import { useState, type ReactNode } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { Link } from 'react-router-dom'
+import { api, type TaskSuggestion, type WelcomeData, type WelcomeService, type WelcomeAgent } from '../api/client'
+import { ServiceIcon } from '../components/ServiceIcon'
+
+// GetStarted — the "What is Clawvisor?" page. It's context-aware: users with
+// nothing connected are steered through setup, while users who are already
+// set up lead with personalized LLM-generated task ideas.
+export default function GetStarted() {
+  const { data, isLoading, refetch, isFetching } = useQuery({
+    queryKey: ['welcome-suggestions'],
+    queryFn: () => api.welcome.suggestions(),
+    staleTime: 5 * 60_000,
+    refetchOnWindowFocus: false,
+  })
+
+  const ready = !!data?.ready
+  const services = data?.services ?? []
+  const agents = data?.agents ?? []
+
+  return (
+    <div className="p-4 sm:p-8 space-y-10 max-w-5xl">
+      <Hero ready={ready} services={services} agents={agents} />
+
+      {ready ? (
+        <>
+          <SuggestionsSection data={data} isLoading={isLoading} isFetching={isFetching} onRefresh={() => refetch()} />
+          <YourSetupSection services={services} agents={agents} />
+          <ExampleWalkthrough services={services} compact />
+        </>
+      ) : (
+        <>
+          <SetupSteps services={services} agents={agents} isLoading={isLoading} />
+          <ExampleWalkthrough services={services} />
+        </>
+      )}
+    </div>
+  )
+}
+
+// ── Hero ──────────────────────────────────────────────────────────────────────
+
+function Hero({ ready, services, agents }: { ready: boolean; services: WelcomeService[]; agents: WelcomeAgent[] }) {
+  return (
+    <header className="space-y-3">
+      <div className="inline-flex items-center gap-2 text-xs font-mono uppercase tracking-wider text-brand bg-brand-muted px-2 py-1 rounded">
+        <img src="/favicon.svg" alt="" className="w-3.5 h-3.5" />
+        Clawvisor
+      </div>
+      <h1 className="text-3xl sm:text-4xl font-bold text-text-primary tracking-tight">
+        Your agents act. You stay in control.
+      </h1>
+      <p className="text-lg text-text-secondary max-w-3xl leading-relaxed">
+        Clawvisor is the gatekeeper between your AI agents and the APIs they act on. Agents never
+        hold credentials — they declare <strong className="text-text-primary">tasks</strong>, you
+        approve the scope once, and Clawvisor handles credential injection, execution, and audit
+        logging for every request.
+      </p>
+      {ready && (
+        <p className="text-sm text-text-tertiary">
+          {services.length} service{services.length === 1 ? '' : 's'} connected · {agents.length}{' '}
+          agent{agents.length === 1 ? '' : 's'} registered
+        </p>
+      )}
+    </header>
+  )
+}
+
+// ── Setup steps (not-ready state) ─────────────────────────────────────────────
+
+function SetupSteps({
+  services,
+  agents,
+  isLoading,
+}: {
+  services: WelcomeService[]
+  agents: WelcomeAgent[]
+  isLoading: boolean
+}) {
+  const hasService = services.length > 0
+  const hasAgent = agents.length > 0
+
+  return (
+    <section>
+      <h2 className="text-xl font-semibold text-text-primary mb-1">Let's get you set up</h2>
+      <p className="text-sm text-text-secondary mb-4">
+        Two quick steps and your agents will be able to act on your behalf — safely.
+      </p>
+
+      <div className="space-y-3">
+        <SetupStepCard num={1} done={hasService} title="Connect a service" loading={isLoading}>
+          <p className="text-sm text-text-secondary mb-3">
+            Link an API like Gmail, GitHub, Slack, or Linear so your agents have something to act
+            on. Credentials stay in Clawvisor's vault — agents never see them.
+          </p>
+          {hasService ? (
+            <ConnectedServicesStrip services={services} />
+          ) : (
+            <div className="flex flex-wrap gap-2">
+              <PopularService id="google.gmail" label="Gmail" />
+              <PopularService id="github" label="GitHub" />
+              <PopularService id="linear" label="Linear" />
+              <PopularService id="slack" label="Slack" />
+              <PopularService id="google.calendar" label="Calendar" />
+              <Link
+                to="/dashboard/services"
+                className="inline-flex items-center gap-1 text-sm font-medium text-brand hover:text-brand-strong px-3 py-1.5 rounded-md border border-brand/40 bg-brand-muted transition-colors"
+              >
+                Browse all services
+                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                  <path d="M9 5l7 7-7 7" />
+                </svg>
+              </Link>
+            </div>
+          )}
+        </SetupStepCard>
+
+        <SetupStepCard num={2} done={hasAgent} title="Connect an agent" loading={isLoading}>
+          <p className="text-sm text-text-secondary mb-3">
+            Your agent gets a bearer token that lets it make requests through Clawvisor. Run one of
+            these commands to auto-install:
+          </p>
+          {hasAgent ? (
+            <ConnectedAgentsStrip agents={agents} />
+          ) : (
+            <div className="grid gap-2 sm:grid-cols-2">
+              <AgentInstallCard
+                name="Claude Code"
+                description="Install the Clawvisor skill so Claude Code can create tasks."
+                command="clawvisor connect-agent claude-code"
+              />
+              <AgentInstallCard
+                name="Claude Desktop"
+                description="Configure MCP so Claude Desktop routes tool calls via Clawvisor."
+                command="clawvisor connect-agent claude-desktop"
+              />
+              <AgentInstallCard
+                name="OpenClaw"
+                description="Pair an OpenClaw daemon over the relay."
+                command="clawvisor connect-agent openclaw"
+              />
+              <AgentInstallCard
+                name="Any HTTP agent"
+                description="Mint a raw token to use with any client."
+                command="clawvisor connect-agent"
+              />
+            </div>
+          )}
+          <div className="mt-3">
+            <Link
+              to="/dashboard/agents"
+              className="text-sm text-brand hover:text-brand-strong font-medium"
+            >
+              Or create a token in the dashboard →
+            </Link>
+          </div>
+        </SetupStepCard>
+      </div>
+    </section>
+  )
+}
+
+function SetupStepCard({
+  num,
+  done,
+  title,
+  loading,
+  children,
+}: {
+  num: number
+  done: boolean
+  title: string
+  loading: boolean
+  children: ReactNode
+}) {
+  return (
+    <div
+      className={`rounded-lg border px-5 py-4 ${
+        done ? 'border-success/30 bg-success/5' : 'border-border-subtle bg-surface-1'
+      }`}
+    >
+      <div className="flex items-center gap-3 mb-3">
+        <div
+          className={`w-7 h-7 rounded-full shrink-0 flex items-center justify-center ${
+            done ? 'bg-success text-surface-0' : 'bg-brand-muted text-brand'
+          }`}
+        >
+          {done ? (
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="3" viewBox="0 0 24 24">
+              <path d="M5 13l4 4L19 7" />
+            </svg>
+          ) : (
+            <span className="text-sm font-bold">{num}</span>
+          )}
+        </div>
+        <h3 className="font-semibold text-text-primary text-base flex-1">{title}</h3>
+        {loading ? (
+          <span className="text-xs text-text-tertiary">checking…</span>
+        ) : done ? (
+          <span className="text-xs font-medium text-success uppercase tracking-wider">Done</span>
+        ) : null}
+      </div>
+      {children}
+    </div>
+  )
+}
+
+function PopularService({ id, label }: { id: string; label: string }) {
+  return (
+    <Link
+      to={`/dashboard/services?search=${encodeURIComponent(id)}`}
+      className="inline-flex items-center gap-1.5 text-sm text-text-primary bg-surface-2 hover:bg-surface-3 px-3 py-1.5 rounded-md border border-border-subtle transition-colors"
+    >
+      {label}
+    </Link>
+  )
+}
+
+function AgentInstallCard({
+  name,
+  description,
+  command,
+}: {
+  name: string
+  description: string
+  command: string
+}) {
+  const [copied, setCopied] = useState(false)
+  function copy() {
+    navigator.clipboard.writeText(command).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    })
+  }
+  return (
+    <div className="rounded-md border border-border-subtle bg-surface-0 p-3">
+      <div className="font-medium text-sm text-text-primary">{name}</div>
+      <div className="text-xs text-text-secondary mb-2">{description}</div>
+      <button
+        onClick={copy}
+        className="w-full flex items-center justify-between gap-2 text-left font-mono text-xs text-text-primary bg-surface-2 hover:bg-surface-3 px-2.5 py-1.5 rounded border border-border-subtle transition-colors"
+      >
+        <span className="truncate">$ {command}</span>
+        <span className="shrink-0 text-text-tertiary">
+          {copied ? (
+            <svg className="w-3.5 h-3.5 text-success" fill="none" stroke="currentColor" strokeWidth="2.5" viewBox="0 0 24 24">
+              <path d="M5 13l4 4L19 7" />
+            </svg>
+          ) : (
+            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+              <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+              <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
+            </svg>
+          )}
+        </span>
+      </button>
+    </div>
+  )
+}
+
+function ConnectedServicesStrip({ services }: { services: WelcomeService[] }) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {services.map(s => (
+        <div
+          key={`${s.id}:${s.alias ?? ''}`}
+          className="flex items-center gap-2 bg-surface-0 border border-border-subtle px-2.5 py-1.5 rounded-md"
+        >
+          <ServiceIcon iconUrl={s.icon_url} iconSvg={s.icon_svg} serviceId={s.id} size={16} />
+          <span className="text-sm text-text-primary">{s.name}</span>
+          {s.alias && <span className="text-xs text-text-tertiary">({s.alias})</span>}
+        </div>
+      ))}
+      <Link
+        to="/dashboard/services"
+        className="text-sm text-brand hover:text-brand-strong font-medium px-2.5 py-1.5"
+      >
+        Connect another →
+      </Link>
+    </div>
+  )
+}
+
+function ConnectedAgentsStrip({ agents }: { agents: WelcomeAgent[] }) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {agents.map(a => (
+        <div
+          key={a.id}
+          className="flex items-center gap-2 bg-surface-0 border border-border-subtle px-2.5 py-1.5 rounded-md"
+        >
+          <svg className="w-4 h-4 text-text-tertiary" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+            <rect x="3" y="11" width="18" height="10" rx="2" ry="2" />
+            <circle cx="12" cy="5" r="2" />
+            <path d="M12 7v4M8 16h.01M16 16h.01" />
+          </svg>
+          <span className="text-sm font-mono text-text-primary">{a.name}</span>
+        </div>
+      ))}
+      <Link
+        to="/dashboard/agents"
+        className="text-sm text-brand hover:text-brand-strong font-medium px-2.5 py-1.5"
+      >
+        Connect another →
+      </Link>
+    </div>
+  )
+}
+
+// ── "Your setup" recap (ready state) ──────────────────────────────────────────
+
+function YourSetupSection({ services, agents }: { services: WelcomeService[]; agents: WelcomeAgent[] }) {
+  return (
+    <section>
+      <h2 className="text-xl font-semibold text-text-primary mb-3">Your setup</h2>
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="rounded-lg border border-border-subtle bg-surface-1 p-4">
+          <div className="flex items-baseline justify-between mb-3">
+            <h3 className="font-medium text-text-primary">Services</h3>
+            <Link to="/dashboard/services" className="text-xs text-brand hover:text-brand-strong font-medium">
+              Manage →
+            </Link>
+          </div>
+          <ConnectedServicesStrip services={services} />
+        </div>
+        <div className="rounded-lg border border-border-subtle bg-surface-1 p-4">
+          <div className="flex items-baseline justify-between mb-3">
+            <h3 className="font-medium text-text-primary">Agents</h3>
+            <Link to="/dashboard/agents" className="text-xs text-brand hover:text-brand-strong font-medium">
+              Manage →
+            </Link>
+          </div>
+          <ConnectedAgentsStrip agents={agents} />
+        </div>
+      </div>
+    </section>
+  )
+}
+
+// ── Suggestions ───────────────────────────────────────────────────────────────
+
+function SuggestionsSection({
+  data,
+  isLoading,
+  isFetching,
+  onRefresh,
+}: {
+  data?: WelcomeData
+  isLoading: boolean
+  isFetching: boolean
+  onRefresh: () => void
+}) {
+  const suggestions = data?.suggestions ?? []
+  const llmStatus = data?.llm_status
+  const services = data?.services ?? []
+
+  const serviceById = new Map<string, WelcomeService>()
+  for (const s of services) serviceById.set(s.id, s)
+
+  return (
+    <section>
+      <div className="flex items-baseline justify-between mb-4">
+        <div>
+          <h2 className="text-xl font-semibold text-text-primary">Things to try</h2>
+          {data?.llm_used && (
+            <p className="text-sm text-text-tertiary mt-0.5">
+              Personalized for your setup · copy a prompt and paste it into your agent
+            </p>
+          )}
+        </div>
+        {data?.llm_used && (
+          <button
+            onClick={onRefresh}
+            disabled={isFetching}
+            className="text-xs font-medium text-text-secondary hover:text-text-primary disabled:opacity-50 transition-colors flex items-center gap-1.5"
+          >
+            <svg
+              className={`w-3.5 h-3.5 ${isFetching ? 'animate-spin' : ''}`}
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              viewBox="0 0 24 24"
+            >
+              <path d="M23 4v6h-6M1 20v-6h6" />
+              <path d="M3.51 9a9 9 0 0114.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0020.49 15" />
+            </svg>
+            New ideas
+          </button>
+        )}
+      </div>
+      {isLoading ? (
+        <SuggestionsLoading />
+      ) : suggestions.length > 0 ? (
+        <div className="grid gap-3 md:grid-cols-2">
+          {suggestions.map((s, i) => (
+            <SuggestionCard key={i} suggestion={s} serviceById={serviceById} />
+          ))}
+        </div>
+      ) : (
+        <SuggestionsFallback status={llmStatus} />
+      )}
+    </section>
+  )
+}
+
+function SuggestionCard({
+  suggestion,
+  serviceById,
+}: {
+  suggestion: TaskSuggestion
+  serviceById: Map<string, WelcomeService>
+}) {
+  const [copied, setCopied] = useState(false)
+
+  function copy() {
+    navigator.clipboard.writeText(suggestion.prompt).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    })
+  }
+
+  return (
+    <div className="rounded-lg border border-border-subtle bg-surface-1 p-4 flex flex-col gap-3">
+      <div className="flex items-start justify-between gap-3">
+        <h3 className="font-semibold text-text-primary leading-snug">{suggestion.title}</h3>
+        {suggestion.risk && <RiskBadge level={suggestion.risk} />}
+      </div>
+
+      <p className="text-sm text-text-secondary leading-relaxed whitespace-pre-wrap">
+        {suggestion.prompt}
+      </p>
+
+      <div className="flex items-end justify-between gap-3 mt-auto pt-1">
+        <div className="flex flex-wrap gap-1.5">
+          {suggestion.agent && (
+            <span className="inline-flex items-center gap-1 text-xs font-mono px-2 py-0.5 rounded bg-brand-muted text-brand">
+              <svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                <rect x="3" y="11" width="18" height="10" rx="2" ry="2" />
+                <circle cx="12" cy="5" r="2" />
+                <path d="M12 7v4" />
+              </svg>
+              {suggestion.agent}
+            </span>
+          )}
+          {suggestion.services.map(id => {
+            const svc = serviceById.get(id)
+            return (
+              <span
+                key={id}
+                className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded bg-surface-2 text-text-tertiary"
+                title={svc?.name ?? id}
+              >
+                {svc && <ServiceIcon iconUrl={svc.icon_url} iconSvg={svc.icon_svg} serviceId={id} size={12} />}
+                <span>{svc?.name ?? id}</span>
+              </span>
+            )
+          })}
+        </div>
+
+        <button
+          onClick={copy}
+          className="shrink-0 inline-flex items-center gap-1 text-xs font-medium text-text-secondary hover:text-text-primary transition-colors"
+        >
+          {copied ? (
+            <>
+              <svg className="w-3.5 h-3.5 text-success" fill="none" stroke="currentColor" strokeWidth="2.5" viewBox="0 0 24 24">
+                <path d="M5 13l4 4L19 7" />
+              </svg>
+              Copied
+            </>
+          ) : (
+            <>
+              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+                <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
+              </svg>
+              Copy prompt
+            </>
+          )}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function RiskBadge({ level }: { level: 'low' | 'medium' | 'high' }) {
+  const styles = {
+    low: 'bg-success/10 text-success border-success/30',
+    medium: 'bg-warning/10 text-warning border-warning/30',
+    high: 'bg-danger/10 text-danger border-danger/30',
+  }[level]
+  return (
+    <span className={`shrink-0 text-[10px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded border ${styles}`}>
+      {level} risk
+    </span>
+  )
+}
+
+function SuggestionsLoading() {
+  return (
+    <div className="grid gap-3 md:grid-cols-2">
+      {[0, 1, 2, 3].map(i => (
+        <div key={i} className="rounded-lg border border-border-subtle bg-surface-1 p-4 animate-pulse">
+          <div className="h-4 bg-surface-2 rounded w-1/2 mb-3" />
+          <div className="h-3 bg-surface-2 rounded w-full mb-1.5" />
+          <div className="h-3 bg-surface-2 rounded w-5/6 mb-1.5" />
+          <div className="h-3 bg-surface-2 rounded w-3/4" />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function SuggestionsFallback({ status }: { status?: string }) {
+  const message =
+    status === 'unconfigured'
+      ? "Personalized task suggestions need an LLM API key. Add one in Settings to see ideas tailored to what you've connected."
+      : status === 'exhausted'
+        ? 'The free LLM credit is exhausted. Add your own API key in Settings to keep seeing personalized suggestions.'
+        : "Couldn't generate suggestions right now — try refreshing in a minute."
+  return (
+    <div className="rounded-lg border border-border-subtle bg-surface-1 px-4 py-5 text-sm text-text-secondary">
+      {message}
+      {(status === 'unconfigured' || status === 'exhausted') && (
+        <>
+          {' '}
+          <Link to="/dashboard/settings" className="text-brand hover:text-brand-strong font-medium">
+            Open Settings
+          </Link>
+        </>
+      )}
+    </div>
+  )
+}
+
+// ── Example walkthrough ───────────────────────────────────────────────────────
+
+function ExampleWalkthrough({
+  services,
+  compact = false,
+}: {
+  services: WelcomeService[]
+  compact?: boolean
+}) {
+  // Prefer concrete services from the user's actual setup; fall back to Gmail.
+  const primary = pickExampleService(services, ['google.gmail', 'gmail', 'imap', 'outlook'])
+  const secondary = pickExampleService(services, ['linear', 'github', 'jira', 'notion'], primary?.id)
+
+  const primaryName = primary?.name ?? 'Gmail'
+  const secondaryName = secondary?.name ?? 'Linear'
+
+  const steps: { label: string; body: string; detail?: string }[] = [
+    {
+      label: 'You ask',
+      body: `"Triage my ${primaryName} and add anything actionable to ${secondaryName}."`,
+    },
+    {
+      label: 'Agent declares a task',
+      body: `The agent creates a Clawvisor task: read ${primaryName}, create ${secondaryName} issues, ask before sending replies.`,
+      detail: 'The agent never holds credentials. It just says what it needs to do.',
+    },
+    {
+      label: 'You approve the scope once',
+      body: 'Clawvisor shows the scope + an LLM-powered risk assessment; you approve it in one click.',
+      detail: 'High-risk or destructive actions can require per-request approval instead.',
+    },
+    {
+      label: 'Clawvisor enforces it on every request',
+      body: 'Every gateway call is checked against restrictions, task scope, and approvals. Everything is audited.',
+    },
+  ]
+
+  return (
+    <section>
+      <h2 className="text-xl font-semibold text-text-primary mb-1">
+        {compact ? 'How it works' : 'Here\u2019s what a task looks like'}
+      </h2>
+      <p className="text-sm text-text-secondary mb-4">
+        {compact
+          ? 'Quick refresher on the flow:'
+          : `Using your connected ${primaryName} and ${secondaryName} as an example:`}
+      </p>
+      <ol className="space-y-0 relative">
+        {steps.map((step, i) => (
+          <li key={i} className="flex gap-4 pb-5 last:pb-0 relative">
+            {/* Connector line */}
+            {i < steps.length - 1 && (
+              <span
+                aria-hidden
+                className="absolute left-[15px] top-8 bottom-0 w-px bg-border-subtle"
+              />
+            )}
+            <div className="w-8 h-8 shrink-0 rounded-full bg-brand-muted text-brand text-xs font-bold flex items-center justify-center relative z-10">
+              {i + 1}
+            </div>
+            <div className="flex-1 pt-1">
+              <div className="text-xs font-medium uppercase tracking-wider text-text-tertiary">
+                {step.label}
+              </div>
+              <div className="text-text-primary mt-0.5 leading-relaxed">{step.body}</div>
+              {step.detail && (
+                <div className="text-sm text-text-secondary mt-1">{step.detail}</div>
+              )}
+            </div>
+          </li>
+        ))}
+      </ol>
+      <div className="mt-4 rounded-md border border-border-subtle bg-surface-1 p-3 text-sm text-text-secondary">
+        <strong className="text-text-primary">Three layers of control</strong> check every request,
+        in order: <span className="text-text-primary">restrictions</span> (hard blocks you
+        configure), <span className="text-text-primary">task scopes</span> (what the agent
+        declared and you approved), and{' '}
+        <span className="text-text-primary">per-request approval</span> (anything outside the
+        scope goes to your queue).
+      </div>
+    </section>
+  )
+}
+
+function pickExampleService(
+  services: WelcomeService[],
+  preferredIds: string[],
+  excludeId?: string,
+): WelcomeService | undefined {
+  for (const id of preferredIds) {
+    const match = services.find(s => s.id === id && s.id !== excludeId)
+    if (match) return match
+  }
+  return services.find(s => s.id !== excludeId)
+}

--- a/web/src/pages/Overview.tsx
+++ b/web/src/pages/Overview.tsx
@@ -480,6 +480,7 @@ function ConnectionQueueCard({ connection: cr }: { connection: ConnectionRequest
       qc.invalidateQueries({ queryKey: ['overview'] })
       qc.invalidateQueries({ queryKey: ['queue'] })
       qc.invalidateQueries({ queryKey: ['agents'] })
+      qc.invalidateQueries({ queryKey: ['welcome'] })
     },
     onError: (err: Error) => setResult(`Failed: ${err.message}`),
   })


### PR DESCRIPTION
## Summary
- Adds a Get Started dashboard page that explains Clawvisor, walks new users through connecting a service + agent, and — once set up — suggests copy-pasteable first tasks generated by the LLM from the user's actual connected services and agents.
- Adds a single LLM call (via \`GET /api/welcome/suggestions\`) that returns both the 3–5 task suggestions and a personalized \"here's what a task looks like\" walkthrough, with a Gmail/Linear fallback until the LLM response arrives.
- Wires agent-state invalidation (create/delete/approve/deny + SSE queue events) so the page stays fresh without a manual refresh.

## Test plan
- [ ] Open \`/dashboard/get-started\` with nothing connected — setup checklist + Gmail/Linear walkthrough render
- [ ] Connect a service + agent — suggestions and a personalized walkthrough appear; service/agent chips link to the right places
- [ ] Refresh button regenerates suggestions
- [ ] Approve a connection from the Agents or Overview page — Get Started refetches automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)