### PR TITLE
fix(gateway): prevent spurious chain rejects from cross-instance extraction race

### DIFF
--- a/internal/api/handlers/chain_fallback_test.go
+++ b/internal/api/handlers/chain_fallback_test.go
@@ -3,7 +3,9 @@ package handlers
 import (
 	"context"
 	"log/slog"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/clawvisor/clawvisor/internal/intent"
 	"github.com/clawvisor/clawvisor/pkg/store"
@@ -13,10 +15,39 @@ import (
 type chainFallbackTestStore struct {
 	store.Store // embed nil interface; only override needed methods
 	facts       map[string]bool
+
+	// After `appearAfter` calls to ChainFactValueExists, `lateFact` becomes
+	// present. Simulates an async extraction landing mid-poll.
+	lateFact    string
+	appearAfter int32
+	calls       int32
 }
 
 func (s *chainFallbackTestStore) ChainFactValueExists(_ context.Context, taskID, sessionID, value string) (bool, error) {
+	n := atomic.AddInt32(&s.calls, 1)
+	if s.lateFact != "" && value == s.lateFact && n > s.appearAfter {
+		return true, nil
+	}
 	return s.facts[taskID+"|"+sessionID+"|"+value], nil
+}
+
+// fakeTracker reports a fixed pending state. `drainAfter` decrements the
+// pending count so HasPending eventually returns false; this simulates the
+// other server's extraction completing.
+type fakeTracker struct {
+	pending    int32
+	drainAfter int32
+	calls      int32
+}
+
+func (t *fakeTracker) MarkPending(_ context.Context, _, _, _ string)   {}
+func (t *fakeTracker) MarkDone(_ context.Context, _, _, _ string)      {}
+func (t *fakeTracker) HasPending(_ context.Context, _, _ string) bool {
+	n := atomic.AddInt32(&t.calls, 1)
+	if t.drainAfter > 0 && n > t.drainAfter {
+		return false
+	}
+	return atomic.LoadInt32(&t.pending) > 0
 }
 
 func makeViolationVerdict(missing ...string) *intent.VerificationVerdict {
@@ -35,7 +66,7 @@ func TestChainContextFallback_FoundInLoadedFacts(t *testing.T) {
 	task := &store.Task{Lifetime: "session"}
 	loaded := []store.ChainFact{{FactValue: "msg_001"}, {FactValue: "msg_002"}, {FactValue: "msg_003"}}
 
-	v := chainContextFallback(context.Background(), st, logger, makeViolationVerdict("msg_002"), loaded, "task-1", task, "")
+	v := chainContextFallback(context.Background(), st, nil, logger, makeViolationVerdict("msg_002"), loaded, "task-1", task, "")
 	if !v.Allow {
 		t.Error("expected allow after finding value in loaded facts")
 	}
@@ -47,7 +78,7 @@ func TestChainContextFallback_MultipleValuesAllInLoaded(t *testing.T) {
 	task := &store.Task{Lifetime: "session"}
 	loaded := []store.ChainFact{{FactValue: "msg_001"}, {FactValue: "msg_002"}, {FactValue: "msg_003"}}
 
-	v := chainContextFallback(context.Background(), st, logger, makeViolationVerdict("msg_001", "msg_003"), loaded, "task-1", task, "")
+	v := chainContextFallback(context.Background(), st, nil, logger, makeViolationVerdict("msg_001", "msg_003"), loaded, "task-1", task, "")
 	if !v.Allow {
 		t.Error("expected allow after finding all values in loaded facts")
 	}
@@ -60,7 +91,7 @@ func TestChainContextFallback_FoundInDB(t *testing.T) {
 	logger := slog.Default()
 	task := &store.Task{Lifetime: "session"}
 
-	v := chainContextFallback(context.Background(), st, logger, makeViolationVerdict("msg_099"), nil, "task-1", task, "")
+	v := chainContextFallback(context.Background(), st, nil, logger, makeViolationVerdict("msg_099"), nil, "task-1", task, "")
 	if !v.Allow {
 		t.Error("expected allow after finding value in DB")
 	}
@@ -74,7 +105,7 @@ func TestChainContextFallback_MixedLoadedAndDB(t *testing.T) {
 	task := &store.Task{Lifetime: "session"}
 	loaded := []store.ChainFact{{FactValue: "msg_001"}}
 
-	v := chainContextFallback(context.Background(), st, logger, makeViolationVerdict("msg_001", "msg_099"), loaded, "task-1", task, "")
+	v := chainContextFallback(context.Background(), st, nil, logger, makeViolationVerdict("msg_001", "msg_099"), loaded, "task-1", task, "")
 	if !v.Allow {
 		t.Error("expected allow with one in loaded, one in DB")
 	}
@@ -87,7 +118,7 @@ func TestChainContextFallback_ExplicitSession(t *testing.T) {
 	logger := slog.Default()
 	task := &store.Task{Lifetime: "standing"}
 
-	v := chainContextFallback(context.Background(), st, logger, makeViolationVerdict("msg_099"), nil, "task-1", task, "sess-abc")
+	v := chainContextFallback(context.Background(), st, nil, logger, makeViolationVerdict("msg_099"), nil, "task-1", task, "sess-abc")
 	if !v.Allow {
 		t.Error("expected allow with explicit session")
 	}
@@ -106,7 +137,7 @@ func TestChainContextFallback_MissingValueRejectsDespiteOtherFacts(t *testing.T)
 	task := &store.Task{Lifetime: "session"}
 	loaded := []store.ChainFact{{FactValue: "msg_001"}, {FactValue: "msg_002"}}
 
-	v := chainContextFallback(context.Background(), st, logger, makeViolationVerdict("msg_unknown"), loaded, "task-1", task, "")
+	v := chainContextFallback(context.Background(), st, nil, logger, makeViolationVerdict("msg_unknown"), loaded, "task-1", task, "")
 	if v.Allow {
 		t.Error("expected reject when specific missing value not in facts (even if other facts exist)")
 	}
@@ -120,7 +151,7 @@ func TestChainContextFallback_PartialMatchStillRejects(t *testing.T) {
 	task := &store.Task{Lifetime: "session"}
 	loaded := []store.ChainFact{{FactValue: "msg_001"}, {FactValue: "msg_002"}}
 
-	v := chainContextFallback(context.Background(), st, logger, makeViolationVerdict("msg_001", "msg_not_extracted"), loaded, "task-1", task, "")
+	v := chainContextFallback(context.Background(), st, nil, logger, makeViolationVerdict("msg_001", "msg_not_extracted"), loaded, "task-1", task, "")
 	if v.Allow {
 		t.Error("expected reject when not all missing values are found")
 	}
@@ -134,7 +165,7 @@ func TestChainContextFallback_GenuineViolation_NoChainFacts(t *testing.T) {
 	logger := slog.Default()
 	task := &store.Task{Lifetime: "session"}
 
-	v := chainContextFallback(context.Background(), st, logger, makeViolationVerdict("msg_unknown"), nil, "task-1", task, "")
+	v := chainContextFallback(context.Background(), st, nil, logger, makeViolationVerdict("msg_unknown"), nil, "task-1", task, "")
 	if v.Allow {
 		t.Error("expected reject with no chain facts at all")
 	}
@@ -145,8 +176,90 @@ func TestChainContextFallback_StandingTaskNoSession(t *testing.T) {
 	logger := slog.Default()
 	task := &store.Task{Lifetime: "standing"}
 
-	v := chainContextFallback(context.Background(), st, logger, makeViolationVerdict("msg_001"), nil, "task-1", task, "")
+	v := chainContextFallback(context.Background(), st, nil, logger, makeViolationVerdict("msg_001"), nil, "task-1", task, "")
 	if v.Allow {
 		t.Error("expected reject for standing task without session_id")
+	}
+}
+
+// --- Tracker-driven polling behavior ---
+
+func TestChainContextFallback_NoPending_RejectsImmediately(t *testing.T) {
+	// Tracker reports no pending extraction → do not poll, reject now.
+	st := &chainFallbackTestStore{facts: map[string]bool{}}
+	tracker := &fakeTracker{pending: 0}
+	logger := slog.Default()
+	task := &store.Task{Lifetime: "session"}
+
+	start := time.Now()
+	v := chainContextFallback(context.Background(), st, tracker, logger, makeViolationVerdict("msg_x"), nil, "task-1", task, "")
+	elapsed := time.Since(start)
+
+	if v.Allow {
+		t.Error("expected reject when nothing pending")
+	}
+	if elapsed > 100*time.Millisecond {
+		t.Errorf("expected immediate reject, took %v", elapsed)
+	}
+}
+
+func TestChainContextFallback_Pending_FactLandsMidPoll(t *testing.T) {
+	// Tracker reports pending; the fact appears in DB after a couple of
+	// polls. Fallback should allow without exhausting the full poll window.
+	st := &chainFallbackTestStore{
+		facts:       map[string]bool{},
+		lateFact:    "msg_late",
+		appearAfter: 2, // first two DB queries miss; third hits.
+	}
+	tracker := &fakeTracker{pending: 1}
+	logger := slog.Default()
+	task := &store.Task{Lifetime: "session"}
+
+	v := chainContextFallback(context.Background(), st, tracker, logger, makeViolationVerdict("msg_late"), nil, "task-1", task, "")
+	if !v.Allow {
+		t.Error("expected allow after fact lands mid-poll")
+	}
+}
+
+func TestChainContextFallback_Pending_PollTimeoutRejects(t *testing.T) {
+	// Tracker keeps reporting pending but fact never lands → reject after
+	// poll window elapses.
+	st := &chainFallbackTestStore{facts: map[string]bool{}}
+	tracker := &fakeTracker{pending: 1}
+	logger := slog.Default()
+	task := &store.Task{Lifetime: "session"}
+
+	start := time.Now()
+	v := chainContextFallback(context.Background(), st, tracker, logger, makeViolationVerdict("msg_never"), nil, "task-1", task, "")
+	elapsed := time.Since(start)
+
+	if v.Allow {
+		t.Error("expected reject after poll timeout")
+	}
+	if elapsed < extractionPollInterval {
+		t.Errorf("expected at least one poll interval to elapse, got %v", elapsed)
+	}
+	if elapsed > extractionPollMaxWait+extractionPollInterval {
+		t.Errorf("elapsed %v exceeded max wait + one interval", elapsed)
+	}
+}
+
+func TestChainContextFallback_Pending_DrainsBeforeTimeout(t *testing.T) {
+	// Tracker reports pending initially, then drains. Fallback does one
+	// final DB check after drain, which still misses → reject.
+	st := &chainFallbackTestStore{facts: map[string]bool{}}
+	tracker := &fakeTracker{pending: 1, drainAfter: 2}
+	logger := slog.Default()
+	task := &store.Task{Lifetime: "session"}
+
+	start := time.Now()
+	v := chainContextFallback(context.Background(), st, tracker, logger, makeViolationVerdict("msg_x"), nil, "task-1", task, "")
+	elapsed := time.Since(start)
+
+	if v.Allow {
+		t.Error("expected reject when pending drains without fact landing")
+	}
+	if elapsed >= extractionPollMaxWait {
+		t.Errorf("expected early exit after pending drained, took %v", elapsed)
 	}
 }

--- a/internal/api/handlers/extraction_tracker.go
+++ b/internal/api/handlers/extraction_tracker.go
@@ -1,0 +1,94 @@
+package handlers
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// ExtractionTracker tracks in-flight chain context extractions so that a
+// request arriving on server B can tell whether server A is still writing
+// facts for the same session. Without this, the 300ms-gap follow-up call
+// races the extraction goroutine and spuriously rejects on chain-context.
+//
+// Keyed by (taskID, sessionID). Multiple concurrent extractions per session
+// are tracked by auditID so a late MarkDone doesn't clear an unrelated one.
+type ExtractionTracker interface {
+	MarkPending(ctx context.Context, taskID, sessionID, auditID string)
+	MarkDone(ctx context.Context, taskID, sessionID, auditID string)
+	HasPending(ctx context.Context, taskID, sessionID string) bool
+}
+
+// memoryExtractionTracker is the default single-instance implementation.
+type memoryExtractionTracker struct {
+	mu       sync.Mutex
+	pending  map[string]map[string]time.Time // sessionKey → auditID → deadline
+	entryTTL time.Duration
+}
+
+// NewMemoryExtractionTracker creates an in-memory tracker. Entries older
+// than ttl are treated as expired (handles orphaned entries from crashed
+// goroutines).
+func NewMemoryExtractionTracker(ttl time.Duration) ExtractionTracker {
+	if ttl <= 0 {
+		ttl = 60 * time.Second
+	}
+	return &memoryExtractionTracker{
+		pending:  make(map[string]map[string]time.Time),
+		entryTTL: ttl,
+	}
+}
+
+func (t *memoryExtractionTracker) MarkPending(_ context.Context, taskID, sessionID, auditID string) {
+	if taskID == "" || sessionID == "" || auditID == "" {
+		return
+	}
+	key := taskID + "|" + sessionID
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	m := t.pending[key]
+	if m == nil {
+		m = make(map[string]time.Time)
+		t.pending[key] = m
+	}
+	m[auditID] = time.Now().Add(t.entryTTL)
+}
+
+func (t *memoryExtractionTracker) MarkDone(_ context.Context, taskID, sessionID, auditID string) {
+	if taskID == "" || sessionID == "" || auditID == "" {
+		return
+	}
+	key := taskID + "|" + sessionID
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if m := t.pending[key]; m != nil {
+		delete(m, auditID)
+		if len(m) == 0 {
+			delete(t.pending, key)
+		}
+	}
+}
+
+func (t *memoryExtractionTracker) HasPending(_ context.Context, taskID, sessionID string) bool {
+	if taskID == "" || sessionID == "" {
+		return false
+	}
+	key := taskID + "|" + sessionID
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	m := t.pending[key]
+	if len(m) == 0 {
+		return false
+	}
+	now := time.Now()
+	for auditID, deadline := range m {
+		if deadline.After(now) {
+			return true
+		}
+		delete(m, auditID)
+	}
+	if len(m) == 0 {
+		delete(t.pending, key)
+	}
+	return false
+}

--- a/internal/api/handlers/extraction_tracker_redis.go
+++ b/internal/api/handlers/extraction_tracker_redis.go
@@ -1,0 +1,70 @@
+package handlers
+
+import (
+	"context"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const redisExtractionPendingPrefix = "clawvisor:extract:pending:"
+
+// redisExtractionTracker is a Redis-backed ExtractionTracker for
+// multi-instance deployments. Pending extractions are stored as a set per
+// (taskID, sessionID) with a safety TTL so crashed instances don't orphan
+// entries.
+type redisExtractionTracker struct {
+	rdb *redis.Client
+	ttl time.Duration
+}
+
+// NewRedisExtractionTracker creates a Redis-backed extraction tracker.
+// ttl should exceed the extraction timeout + save timeout (i.e. > 40s).
+func NewRedisExtractionTracker(rdb *redis.Client, ttl time.Duration) ExtractionTracker {
+	if ttl <= 0 {
+		ttl = 60 * time.Second
+	}
+	return &redisExtractionTracker{rdb: rdb, ttl: ttl}
+}
+
+func (t *redisExtractionTracker) key(taskID, sessionID string) string {
+	return redisExtractionPendingPrefix + taskID + ":" + sessionID
+}
+
+func (t *redisExtractionTracker) MarkPending(ctx context.Context, taskID, sessionID, auditID string) {
+	if taskID == "" || sessionID == "" || auditID == "" {
+		return
+	}
+	opCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	key := t.key(taskID, sessionID)
+	pipe := t.rdb.Pipeline()
+	pipe.SAdd(opCtx, key, auditID)
+	pipe.Expire(opCtx, key, t.ttl)
+	_, _ = pipe.Exec(opCtx)
+}
+
+func (t *redisExtractionTracker) MarkDone(ctx context.Context, taskID, sessionID, auditID string) {
+	if taskID == "" || sessionID == "" || auditID == "" {
+		return
+	}
+	opCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	_ = t.rdb.SRem(opCtx, t.key(taskID, sessionID), auditID).Err()
+}
+
+func (t *redisExtractionTracker) HasPending(ctx context.Context, taskID, sessionID string) bool {
+	if taskID == "" || sessionID == "" {
+		return false
+	}
+	opCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	n, err := t.rdb.SCard(opCtx, t.key(taskID, sessionID)).Result()
+	if err != nil {
+		return false
+	}
+	return n > 0
+}
+
+var _ ExtractionTracker = (*memoryExtractionTracker)(nil)
+var _ ExtractionTracker = (*redisExtractionTracker)(nil)

--- a/internal/api/handlers/extraction_tracker_test.go
+++ b/internal/api/handlers/extraction_tracker_test.go
@@ -1,0 +1,117 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestMemoryExtractionTracker_BasicLifecycle(t *testing.T) {
+	tr := NewMemoryExtractionTracker(time.Minute)
+	ctx := context.Background()
+
+	if tr.HasPending(ctx, "task-1", "sess-1") {
+		t.Fatal("fresh tracker should have no pending")
+	}
+
+	tr.MarkPending(ctx, "task-1", "sess-1", "audit-1")
+	if !tr.HasPending(ctx, "task-1", "sess-1") {
+		t.Error("expected pending after MarkPending")
+	}
+
+	tr.MarkDone(ctx, "task-1", "sess-1", "audit-1")
+	if tr.HasPending(ctx, "task-1", "sess-1") {
+		t.Error("expected no pending after MarkDone")
+	}
+}
+
+func TestMemoryExtractionTracker_MultipleConcurrentPerSession(t *testing.T) {
+	// Two extractions can overlap for the same session (e.g. list + get).
+	// HasPending should return true while ANY entry is pending, and only
+	// flip to false once all are done.
+	tr := NewMemoryExtractionTracker(time.Minute)
+	ctx := context.Background()
+
+	tr.MarkPending(ctx, "task-1", "sess-1", "audit-1")
+	tr.MarkPending(ctx, "task-1", "sess-1", "audit-2")
+
+	if !tr.HasPending(ctx, "task-1", "sess-1") {
+		t.Error("expected pending with 2 entries")
+	}
+
+	tr.MarkDone(ctx, "task-1", "sess-1", "audit-1")
+	if !tr.HasPending(ctx, "task-1", "sess-1") {
+		t.Error("expected pending after only 1 of 2 done")
+	}
+
+	tr.MarkDone(ctx, "task-1", "sess-1", "audit-2")
+	if tr.HasPending(ctx, "task-1", "sess-1") {
+		t.Error("expected no pending after both done")
+	}
+}
+
+func TestMemoryExtractionTracker_SessionIsolation(t *testing.T) {
+	// Work on one session should not register as pending for another.
+	tr := NewMemoryExtractionTracker(time.Minute)
+	ctx := context.Background()
+
+	tr.MarkPending(ctx, "task-1", "sess-1", "audit-1")
+	if tr.HasPending(ctx, "task-1", "sess-2") {
+		t.Error("sess-2 should not see sess-1's pending")
+	}
+	if tr.HasPending(ctx, "task-2", "sess-1") {
+		t.Error("task-2 should not see task-1's pending")
+	}
+}
+
+func TestMemoryExtractionTracker_TTLExpires(t *testing.T) {
+	// Orphaned entries (crashed instance) eventually expire.
+	tr := NewMemoryExtractionTracker(50 * time.Millisecond)
+	ctx := context.Background()
+
+	tr.MarkPending(ctx, "task-1", "sess-1", "audit-orphan")
+	if !tr.HasPending(ctx, "task-1", "sess-1") {
+		t.Fatal("expected pending immediately after MarkPending")
+	}
+
+	time.Sleep(75 * time.Millisecond)
+	if tr.HasPending(ctx, "task-1", "sess-1") {
+		t.Error("expected pending to expire after TTL")
+	}
+}
+
+func TestMemoryExtractionTracker_IgnoresEmptyKeys(t *testing.T) {
+	// Defensive: empty taskID/sessionID/auditID should not register as
+	// pending (nothing to correlate them with).
+	tr := NewMemoryExtractionTracker(time.Minute)
+	ctx := context.Background()
+
+	tr.MarkPending(ctx, "", "sess-1", "audit-1")
+	tr.MarkPending(ctx, "task-1", "", "audit-1")
+	tr.MarkPending(ctx, "task-1", "sess-1", "")
+
+	if tr.HasPending(ctx, "", "sess-1") {
+		t.Error("empty taskID: HasPending should be false")
+	}
+	if tr.HasPending(ctx, "task-1", "") {
+		t.Error("empty sessionID: HasPending should be false")
+	}
+	if tr.HasPending(ctx, "task-1", "sess-1") {
+		t.Error("entries with any empty field should not register as pending")
+	}
+}
+
+func TestMemoryExtractionTracker_MarkDoneUnknownAudit(t *testing.T) {
+	// MarkDone for an auditID that was never pending should be a no-op,
+	// not a panic.
+	tr := NewMemoryExtractionTracker(time.Minute)
+	ctx := context.Background()
+
+	tr.MarkDone(ctx, "task-1", "sess-1", "never-existed")
+
+	tr.MarkPending(ctx, "task-1", "sess-1", "audit-1")
+	tr.MarkDone(ctx, "task-1", "sess-1", "never-existed")
+	if !tr.HasPending(ctx, "task-1", "sess-1") {
+		t.Error("spurious MarkDone should not affect unrelated pending entry")
+	}
+}

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -74,6 +74,7 @@ type GatewayHandler struct {
 	notifier     notify.Notifier // may be nil if Telegram not configured
 	verifier     intent.Verifier
 	extractor    intent.Extractor
+	extractTrack ExtractionTracker // tracks in-flight async extractions; never nil
 	cfg          config.Config
 	logger       *slog.Logger
 	baseURL      string
@@ -98,8 +99,18 @@ func NewGatewayHandler(
 	return &GatewayHandler{
 		store: st, vault: v, adapterReg: adapterReg,
 		notifier: notifier, verifier: verifier, extractor: extractor,
+		extractTrack: NewMemoryExtractionTracker(60 * time.Second),
 		cfg: cfg, logger: logger, baseURL: baseURL,
 		eventHub: eventHub,
+	}
+}
+
+// SetExtractionTracker overrides the default in-memory tracker. Use the
+// Redis-backed tracker in multi-instance deployments so that a request
+// arriving on server B can see that server A is still extracting.
+func (h *GatewayHandler) SetExtractionTracker(t ExtractionTracker) {
+	if t != nil {
+		h.extractTrack = t
 	}
 }
 
@@ -585,7 +596,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 					verdict = h.runVerification(ctx, task, match.MatchedAction, req, serviceType, agent.UserID, chainFacts)
 				}
 				if verdict != nil && !verdict.Allow && verdict.ParamScope == "violation" && len(verdict.MissingChainValues) > 0 {
-					verdict = chainContextFallback(ctx, h.store, h.logger, verdict, chainFacts, req.TaskID, task, req.SessionID)
+					verdict = chainContextFallback(ctx, h.store, h.extractTrack, h.logger, verdict, chainFacts, req.TaskID, task, req.SessionID)
 				}
 				if verdict != nil && !verdict.Allow {
 					dur := int(time.Since(start).Milliseconds())
@@ -654,7 +665,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 				// check programmatically — the LLM may have missed it in a long
 				// table, or it may exist beyond the loaded fact limit.
 				if verdict != nil && !verdict.Allow && verdict.ParamScope == "violation" && len(verdict.MissingChainValues) > 0 {
-					verdict = chainContextFallback(ctx, h.store, h.logger, verdict, chainFacts, req.TaskID, task, req.SessionID)
+					verdict = chainContextFallback(ctx, h.store, h.extractTrack, h.logger, verdict, chainFacts, req.TaskID, task, req.SessionID)
 				}
 				if verdict != nil && !verdict.Allow {
 					dur := int(time.Since(start).Milliseconds())
@@ -818,7 +829,18 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			}
 			if chainSessionID != "" && verdict != nil && verdict.ExtractContext {
 				resultJSON, _ := json.Marshal(result)
+				// Mark synchronously (before returning to the agent) so a
+				// follow-up request sees the pending flag even if it arrives
+				// before the goroutine is scheduled.
+				markCtx, markCancel := context.WithTimeout(context.Background(), 2*time.Second)
+				h.extractTrack.MarkPending(markCtx, req.TaskID, chainSessionID, auditID)
+				markCancel()
 				go func() {
+					defer func() {
+						doneCtx, doneCancel := context.WithTimeout(context.Background(), 2*time.Second)
+						h.extractTrack.MarkDone(doneCtx, req.TaskID, chainSessionID, auditID)
+						doneCancel()
+					}()
 					extractCtx, extractCancel := context.WithTimeout(context.Background(), 30*time.Second)
 					defer extractCancel()
 					facts, err := h.extractor.Extract(extractCtx, intent.ExtractRequest{
@@ -1456,21 +1478,38 @@ func valueInChainFacts(v any, facts []store.ChainFact) bool {
 	return false
 }
 
+// extractionPollInterval and extractionPollMaxWait bound how long a
+// chain-context rejection is delayed while waiting for an in-flight
+// extraction on another instance to write its facts.
+const (
+	extractionPollInterval = 250 * time.Millisecond
+	extractionPollMaxWait  = 1500 * time.Millisecond
+)
+
 // chainContextFallback handles chain context violations by checking whether
-// the missing values actually exist in the chain facts. Two outcomes:
+// the missing values actually exist in the chain facts. Three outcomes:
 //
 //  1. All missing values found (in loaded slice or DB) → override to allow.
-//  2. Any missing value not found → genuine violation, keep reject.
+//  2. Missing values not found but an extraction for this session is still
+//     in flight (possibly on another instance) → poll the DB briefly and
+//     re-check; allow if the facts land before the poll window elapses.
+//  3. Missing values not found and no pending extraction → genuine
+//     violation, keep reject.
 //
-// Historically there was a third branch that allowed when *any* chain facts
+// Historically there was a branch that allowed when *any* chain facts
 // existed for the session on the theory that extraction is lossy (4KB
 // truncation / 50-fact cap). That blanket allow was too permissive — an
 // agent could run a `list_*` call to populate chain facts and then make
 // out-of-scope writes. The specific missing value must be found; the
 // presence of unrelated facts is not a substitute.
+//
+// tracker may be nil (e.g. the guard handler, which does not trigger
+// extractions). When nil, step 2 is skipped and behavior matches the
+// pre-tracker code path.
 func chainContextFallback(
 	ctx context.Context,
 	st store.Store,
+	tracker ExtractionTracker,
 	logger *slog.Logger,
 	verdict *intent.VerificationVerdict,
 	loadedFacts []store.ChainFact,
@@ -1483,27 +1522,36 @@ func chainContextFallback(
 		chainSessionID = taskID
 	}
 
-	allFound := true
-	for _, value := range verdict.MissingChainValues {
-		if value == "" {
-			continue
+	allFound, dbErr := checkMissingValues(ctx, st, verdict.MissingChainValues, loadedFacts, taskID, chainSessionID, logger)
+
+	// Poll while an extraction for this session is still in flight. Only
+	// enter the loop if the initial check failed (not DB error — a DB
+	// problem isn't fixed by waiting), a session is set, and the tracker
+	// reports pending work.
+	if !allFound && dbErr == nil && chainSessionID != "" && tracker != nil && tracker.HasPending(ctx, taskID, chainSessionID) {
+		deadline := time.Now().Add(extractionPollMaxWait)
+		for time.Now().Before(deadline) {
+			select {
+			case <-ctx.Done():
+				return verdict
+			case <-time.After(extractionPollInterval):
+			}
+			allFound, dbErr = checkMissingValues(ctx, st, verdict.MissingChainValues, loadedFacts, taskID, chainSessionID, logger)
+			if allFound || dbErr != nil {
+				break
+			}
+			if !tracker.HasPending(ctx, taskID, chainSessionID) {
+				// No in-flight extraction remains — one more check, then stop.
+				allFound, dbErr = checkMissingValues(ctx, st, verdict.MissingChainValues, loadedFacts, taskID, chainSessionID, logger)
+				break
+			}
 		}
-		if chainFactInSlice(value, loadedFacts) {
-			continue
-		}
-		if chainSessionID == "" {
-			allFound = false
-			break
-		}
-		found, err := st.ChainFactValueExists(ctx, taskID, chainSessionID, value)
-		if err != nil {
-			logger.Warn("chain fact fallback DB query failed", "err", err, "task_id", taskID)
-			allFound = false
-			break
-		}
-		if !found {
-			allFound = false
-			break
+		if allFound {
+			logger.Info("chain context fallback: values landed after waiting for in-flight extraction",
+				"task_id", taskID,
+				"session_id", chainSessionID,
+				"missing_values", verdict.MissingChainValues,
+			)
 		}
 	}
 
@@ -1529,6 +1577,39 @@ func chainContextFallback(
 		)
 	}
 	return verdict
+}
+
+// checkMissingValues reports whether every missing value is present either
+// in the loaded slice or the DB. Returns a DB error if one occurred so the
+// caller can decide not to retry.
+func checkMissingValues(
+	ctx context.Context,
+	st store.Store,
+	missing []string,
+	loadedFacts []store.ChainFact,
+	taskID, chainSessionID string,
+	logger *slog.Logger,
+) (bool, error) {
+	for _, value := range missing {
+		if value == "" {
+			continue
+		}
+		if chainFactInSlice(value, loadedFacts) {
+			continue
+		}
+		if chainSessionID == "" {
+			return false, nil
+		}
+		found, err := st.ChainFactValueExists(ctx, taskID, chainSessionID, value)
+		if err != nil {
+			logger.Warn("chain fact fallback DB query failed", "err", err, "task_id", taskID)
+			return false, err
+		}
+		if !found {
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
 // chainFactInSlice checks if a value exists in the loaded chain facts slice.

--- a/internal/api/handlers/guard.go
+++ b/internal/api/handlers/guard.go
@@ -154,7 +154,7 @@ func (h *GuardHandler) Check(w http.ResponseWriter, r *http.Request) {
 
 		// Chain context fallback: same as gateway handler.
 		if verdict != nil && !verdict.Allow && verdict.ParamScope == "violation" && len(verdict.MissingChainValues) > 0 {
-			verdict = chainContextFallback(ctx, h.store, h.logger, verdict, chainFacts, req.TaskID, task, req.SessionID)
+			verdict = chainContextFallback(ctx, h.store, nil, h.logger, verdict, chainFacts, req.TaskID, task, req.SessionID)
 		}
 		if verdict != nil && !verdict.Allow {
 			respond("deny", verdict.Explanation, taskID, verdict)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -96,6 +96,7 @@ type Server struct {
 	pairingCodeStore   handlers.PairingCodeStore
 	dedupCache         handlers.DedupCache
 	verdictCache       intent.VerdictCacher
+	extractionTracker  handlers.ExtractionTracker
 
 	adapterGenFactory handlers.GeneratorFactory // per-request Generator factory; set via option
 }
@@ -281,6 +282,12 @@ func WithVerdictCache(vc intent.VerdictCacher) ServerOption {
 	return func(s *Server) { s.verdictCache = vc }
 }
 
+// WithExtractionTracker overrides the default in-memory extraction tracker.
+// Use the Redis-backed tracker in multi-instance deployments.
+func WithExtractionTracker(t handlers.ExtractionTracker) ServerOption {
+	return func(s *Server) { s.extractionTracker = t }
+}
+
 // New creates a Server and registers all routes.
 // magicStore may be nil when magic link auth is not enabled.
 func New(
@@ -415,6 +422,9 @@ func (s *Server) routes() http.Handler {
 		s.store, s.vault, s.adapterReg,
 		s.notifier, verifier, extractor, *s.cfg, s.logger, baseURL, s.eventHub,
 	)
+	if s.extractionTracker != nil {
+		gatewayHandler.SetExtractionTracker(s.extractionTracker)
+	}
 	if s.gatewayHooks != nil {
 		gatewayHandler.SetGatewayHooks(&handlers.GatewayHooks{
 			BeforeAuthorize: s.gatewayHooks.BeforeAuthorize,

--- a/internal/intent/extractor.go
+++ b/internal/intent/extractor.go
@@ -130,62 +130,7 @@ func (e *LLMExtractor) Extract(ctx context.Context, req ExtractRequest) ([]*stor
 		}
 	}
 
-	// Validate direct facts via substring match against the full result.
-	seen := make(map[string]bool)
-	var facts []*store.ChainFact
-	var dropped int
-	for _, ef := range directFacts {
-		if ef.FactType == "" || ef.FactValue == "" {
-			dropped++
-			continue
-		}
-		if !substringMatch(req.Result, ef.FactValue, ef.FactType) {
-			dropped++
-			continue
-		}
-		key := ef.FactType + "|" + ef.FactValue
-		if seen[key] {
-			continue
-		}
-		seen[key] = true
-		facts = append(facts, &store.ChainFact{
-			ID:        uuid.New().String(),
-			TaskID:    req.TaskID,
-			SessionID: req.SessionID,
-			AuditID:   req.AuditID,
-			Service:   req.Service,
-			Action:    req.Action,
-			FactType:  ef.FactType,
-			FactValue: ef.FactValue,
-		})
-	}
-
-	// Run regex patterns against the FULL result to capture entities beyond
-	// the 4KB window the LLM saw, or to provide extraction when the LLM is unavailable.
-	if len(patterns) > 0 && (truncated || llmFailed || len(directFacts) == 0) {
-		regexFacts := runExtractionPatterns(patterns, req.Result, e.logger, req.TaskID)
-		for _, rf := range regexFacts {
-			key := rf.factType + "|" + rf.factValue
-			if seen[key] {
-				continue
-			}
-			seen[key] = true
-			facts = append(facts, &store.ChainFact{
-				ID:        uuid.New().String(),
-				TaskID:    req.TaskID,
-				SessionID: req.SessionID,
-				AuditID:   req.AuditID,
-				Service:   req.Service,
-				Action:    req.Action,
-				FactType:  rf.factType,
-				FactValue: rf.factValue,
-			})
-		}
-	}
-
-	if len(facts) > maxExtractedFacts {
-		facts = facts[:maxExtractedFacts]
-	}
+	facts, dropped := mergeExtractionResults(directFacts, patterns, req, e.logger)
 
 	e.logger.Debug("chain context extraction complete",
 		"task_id", req.TaskID,
@@ -198,6 +143,66 @@ func (e *LLMExtractor) Extract(ctx context.Context, req ExtractRequest) ([]*stor
 	)
 
 	return facts, nil
+}
+
+// mergeExtractionResults validates direct facts against the full result and
+// augments them with regex-pattern matches, deduped by (fact_type, fact_value).
+//
+// Regex always runs when patterns exist. An earlier version gated regex on
+// "truncated || llm_failed || no direct facts", but that caused silent
+// misses on small list responses: the LLM's 20-direct-fact soft cap could
+// omit an ID the response contained, and regex — the only mechanism that
+// would have caught it — was skipped because nothing looked wrong. Facts
+// are deduped and capped, so there's no double-counting or overflow cost.
+func mergeExtractionResults(
+	directFacts []extractedFact,
+	patterns []extractionPattern,
+	req ExtractRequest,
+	logger *slog.Logger,
+) (facts []*store.ChainFact, dropped int) {
+	seen := make(map[string]bool)
+
+	appendFact := func(factType, factValue string) {
+		key := factType + "|" + factValue
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		facts = append(facts, &store.ChainFact{
+			ID:        uuid.New().String(),
+			TaskID:    req.TaskID,
+			SessionID: req.SessionID,
+			AuditID:   req.AuditID,
+			Service:   req.Service,
+			Action:    req.Action,
+			FactType:  factType,
+			FactValue: factValue,
+		})
+	}
+
+	for _, ef := range directFacts {
+		if ef.FactType == "" || ef.FactValue == "" {
+			dropped++
+			continue
+		}
+		if !substringMatch(req.Result, ef.FactValue, ef.FactType) {
+			dropped++
+			continue
+		}
+		appendFact(ef.FactType, ef.FactValue)
+	}
+
+	if len(patterns) > 0 {
+		regexFacts := runExtractionPatterns(patterns, req.Result, logger, req.TaskID)
+		for _, rf := range regexFacts {
+			appendFact(rf.factType, rf.factValue)
+		}
+	}
+
+	if len(facts) > maxExtractedFacts {
+		facts = facts[:maxExtractedFacts]
+	}
+	return facts, dropped
 }
 
 type extractedFact struct {

--- a/internal/intent/extractor_test.go
+++ b/internal/intent/extractor_test.go
@@ -1,8 +1,11 @@
 package intent
 
 import (
+	"fmt"
 	"log/slog"
 	"testing"
+
+	"github.com/clawvisor/clawvisor/pkg/store"
 )
 
 func TestParseExtractionResponse_NewFormat(t *testing.T) {
@@ -193,5 +196,197 @@ func TestRunExtractionPatterns_CapsAtMaxMatches(t *testing.T) {
 	matches := runExtractionPatterns(patterns, string(sb), slog.Default(), "test")
 	if len(matches) > maxRegexMatches {
 		t.Errorf("expected at most %d matches, got %d", maxRegexMatches, len(matches))
+	}
+}
+
+// --- mergeExtractionResults: post-LLM merge logic ---
+
+// factValues collects fact_values for a given fact_type from a ChainFact slice.
+func factValues(facts []*store.ChainFact, factType string) []string {
+	var out []string
+	for _, f := range facts {
+		if f.FactType == factType {
+			out = append(out, f.FactValue)
+		}
+	}
+	return out
+}
+
+func makeMergeReq(result string) ExtractRequest {
+	return ExtractRequest{
+		TaskID:    "task-1",
+		SessionID: "sess-1",
+		AuditID:   "audit-1",
+		Service:   "google.gmail",
+		Action:    "list_messages",
+		Result:    result,
+	}
+}
+
+func TestMergeExtractionResults_DirectFactsOnly(t *testing.T) {
+	// No patterns → only direct facts land. Substring validation against
+	// the full result gates entry.
+	result := `{"messages":[{"id":"aabbccddee112233"},{"id":"ffee112233445566"}]}`
+	direct := []extractedFact{
+		{FactType: "message_id", FactValue: "aabbccddee112233"},
+		{FactType: "message_id", FactValue: "ffee112233445566"},
+	}
+
+	facts, dropped := mergeExtractionResults(direct, nil, makeMergeReq(result), slog.Default())
+	if dropped != 0 {
+		t.Errorf("expected 0 dropped, got %d", dropped)
+	}
+	got := factValues(facts, "message_id")
+	if len(got) != 2 {
+		t.Fatalf("expected 2 message_ids, got %d: %v", len(got), got)
+	}
+}
+
+func TestMergeExtractionResults_RegexFillsInMissedIDs(t *testing.T) {
+	// This is the core fix: the LLM returned only 2 of 3 message_ids in its
+	// direct facts, and the result is NOT truncated. Previously regex would
+	// be skipped; now it runs and fills in the missing ID.
+	result := `{"messages":[` +
+		`{"id":"aabbccddee112233"},` +
+		`{"id":"ffee112233445566"},` +
+		`{"id":"112233445566778a"}` +
+		`]}`
+	direct := []extractedFact{
+		{FactType: "message_id", FactValue: "aabbccddee112233"},
+		{FactType: "message_id", FactValue: "ffee112233445566"},
+		// "112233445566778a" was silently omitted by the LLM.
+	}
+	patterns := []extractionPattern{
+		{FactType: "message_id", Regex: `"id":\s*"([a-f0-9]{16})"`},
+	}
+
+	facts, _ := mergeExtractionResults(direct, patterns, makeMergeReq(result), slog.Default())
+	got := factValues(facts, "message_id")
+	if len(got) != 3 {
+		t.Fatalf("expected all 3 message_ids after regex fill-in, got %d: %v", len(got), got)
+	}
+	// Verify the missed ID is there.
+	found := false
+	for _, v := range got {
+		if v == "112233445566778a" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected missed ID 112233445566778a to be rescued by regex, got %v", got)
+	}
+}
+
+func TestMergeExtractionResults_DedupOverlap(t *testing.T) {
+	// LLM direct facts and regex matches overlap on the same IDs. Dedup
+	// keeps exactly one of each — no double-count.
+	result := `{"messages":[{"id":"aabbccddee112233"},{"id":"ffee112233445566"}]}`
+	direct := []extractedFact{
+		{FactType: "message_id", FactValue: "aabbccddee112233"},
+		{FactType: "message_id", FactValue: "ffee112233445566"},
+	}
+	patterns := []extractionPattern{
+		{FactType: "message_id", Regex: `"id":\s*"([a-f0-9]{16})"`},
+	}
+
+	facts, _ := mergeExtractionResults(direct, patterns, makeMergeReq(result), slog.Default())
+	got := factValues(facts, "message_id")
+	if len(got) != 2 {
+		t.Fatalf("expected 2 unique message_ids after dedup, got %d: %v", len(got), got)
+	}
+}
+
+func TestMergeExtractionResults_SubstringValidationDrops(t *testing.T) {
+	// LLM hallucinated a value that doesn't appear in the raw result —
+	// drop it. This is a security property: we never record facts the LLM
+	// invented from thin air.
+	result := `{"messages":[{"id":"aabbccddee112233"}]}`
+	direct := []extractedFact{
+		{FactType: "message_id", FactValue: "aabbccddee112233"},  // legit
+		{FactType: "message_id", FactValue: "deadbeefdeadbeef"},  // hallucinated
+	}
+
+	facts, dropped := mergeExtractionResults(direct, nil, makeMergeReq(result), slog.Default())
+	if dropped != 1 {
+		t.Errorf("expected 1 dropped (hallucinated value), got %d", dropped)
+	}
+	got := factValues(facts, "message_id")
+	if len(got) != 1 || got[0] != "aabbccddee112233" {
+		t.Errorf("expected only the legit ID, got %v", got)
+	}
+}
+
+func TestMergeExtractionResults_CapsAtMaxExtractedFacts(t *testing.T) {
+	// Generate a result with 60 distinct message IDs — more than the 50
+	// fact cap. The final list is truncated to maxExtractedFacts.
+	var result []byte
+	result = append(result, []byte(`{"messages":[`)...)
+	for i := 0; i < 60; i++ {
+		if i > 0 {
+			result = append(result, ',')
+		}
+		// 16-hex-char IDs, distinct.
+		result = append(result, []byte(fmt.Sprintf(`{"id":"%016x"}`, 0xaabbcc000000+i))...)
+	}
+	result = append(result, []byte(`]}`)...)
+
+	patterns := []extractionPattern{
+		{FactType: "message_id", Regex: `"id":\s*"([a-f0-9]{16})"`},
+	}
+
+	facts, _ := mergeExtractionResults(nil, patterns, makeMergeReq(string(result)), slog.Default())
+	if len(facts) > maxExtractedFacts {
+		t.Errorf("expected at most %d facts, got %d", maxExtractedFacts, len(facts))
+	}
+	if len(facts) != maxExtractedFacts {
+		t.Errorf("expected exactly %d facts at the cap, got %d", maxExtractedFacts, len(facts))
+	}
+}
+
+func TestMergeExtractionResults_SkipsEmptyFields(t *testing.T) {
+	// Direct facts with empty type or value are dropped rather than stored.
+	direct := []extractedFact{
+		{FactType: "", FactValue: "something"},
+		{FactType: "message_id", FactValue: ""},
+		{FactType: "message_id", FactValue: "aabbccddee112233"},
+	}
+	result := `{"id":"aabbccddee112233"}`
+
+	facts, dropped := mergeExtractionResults(direct, nil, makeMergeReq(result), slog.Default())
+	if dropped != 2 {
+		t.Errorf("expected 2 dropped (empty fields), got %d", dropped)
+	}
+	if len(facts) != 1 {
+		t.Fatalf("expected 1 surviving fact, got %d", len(facts))
+	}
+}
+
+func TestMergeExtractionResults_PatternsOnly(t *testing.T) {
+	// No direct facts (LLM failed or returned nothing), patterns run
+	// against full result.
+	result := `{"messages":[{"id":"aabbccddee112233"},{"id":"ffee112233445566"}]}`
+	patterns := []extractionPattern{
+		{FactType: "message_id", Regex: `"id":\s*"([a-f0-9]{16})"`},
+	}
+
+	facts, dropped := mergeExtractionResults(nil, patterns, makeMergeReq(result), slog.Default())
+	if dropped != 0 {
+		t.Errorf("expected 0 dropped, got %d", dropped)
+	}
+	got := factValues(facts, "message_id")
+	if len(got) != 2 {
+		t.Errorf("expected 2 message_ids from patterns, got %v", got)
+	}
+}
+
+func TestMergeExtractionResults_NoPatternsNoDirect(t *testing.T) {
+	// Empty inputs → empty output, no panic.
+	facts, dropped := mergeExtractionResults(nil, nil, makeMergeReq("irrelevant"), slog.Default())
+	if dropped != 0 {
+		t.Errorf("expected 0 dropped, got %d", dropped)
+	}
+	if len(facts) != 0 {
+		t.Errorf("expected 0 facts, got %d", len(facts))
 	}
 }

--- a/pkg/clawvisor/defaults.go
+++ b/pkg/clawvisor/defaults.go
@@ -322,6 +322,7 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 	var pairingCodeStore handlers.PairingCodeStore
 	var dedupCache handlers.DedupCache
 	var verdictCache intent.VerdictCacher
+	var extractionTracker handlers.ExtractionTracker
 	if cfg.Redis.URL != "" {
 		rdb, err := intredis.Connect(ctx, cfg.Redis.URL)
 		if err != nil {
@@ -350,6 +351,10 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 			verdictTTL = 60 * time.Second
 		}
 		verdictCache = intent.NewRedisVerdictCache(rdb, verdictTTL)
+
+		// Safety TTL exceeds the 30s extraction timeout + 10s save timeout
+		// so a crashed instance doesn't orphan entries.
+		extractionTracker = handlers.NewRedisExtractionTracker(rdb, 60*time.Second)
 
 		// Redis-backed group chat buffer.
 		msgBuffer = groupchat.NewRedisMessageBuffer(rdb, 20, 15*time.Minute)
@@ -393,6 +398,7 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 		PairingCodeStore:   pairingCodeStore,
 		DedupCache:         dedupCache,
 		VerdictCache:       verdictCache,
+		ExtractionTracker:  extractionTracker,
 	}
 
 	// Wire relay client when configured.

--- a/pkg/clawvisor/options.go
+++ b/pkg/clawvisor/options.go
@@ -131,6 +131,7 @@ type ServerOptions struct {
 	PairingCodeStore  handlers.PairingCodeStore
 	DedupCache        handlers.DedupCache
 	VerdictCache      intent.VerdictCacher
+	ExtractionTracker handlers.ExtractionTracker
 }
 
 // Dependencies is passed to ExtraRoutes so extension handlers can access shared services.

--- a/pkg/clawvisor/run.go
+++ b/pkg/clawvisor/run.go
@@ -124,6 +124,9 @@ func RunWithContext(ctx context.Context, opts *ServerOptions) error {
 	if opts.VerdictCache != nil {
 		apiOpts = append(apiOpts, api.WithVerdictCache(opts.VerdictCache))
 	}
+	if opts.ExtractionTracker != nil {
+		apiOpts = append(apiOpts, api.WithExtractionTracker(opts.ExtractionTracker))
+	}
 	if opts.LocalServiceProvider != nil {
 		apiOpts = append(apiOpts, api.WithLocalServiceProvider(&localSvcAdapter{opts.LocalServiceProvider}))
 	}


### PR DESCRIPTION
## Summary
- Introduce an `ExtractionTracker` (in-memory default, Redis variant for multi-instance) that marks chain extractions in-flight per `(taskID, sessionID)`. `chainContextFallback` now polls briefly (250ms × up to 1.5s) when the tracker reports a pending extraction, eliminating false chain-context rejects when a follow-up request lands on a different instance before the prior one's async extraction has persisted facts.
- Drop the gate on regex extraction in `internal/intent/extractor.go` so regex always supplements LLM facts (the 20-fact soft cap could silently drop IDs on non-truncated LLM responses); refactor merge logic into a testable `mergeExtractionResults` helper.
- Wire the tracker through `ServerOptions.ExtractionTracker` → `WithExtractionTracker` → `GatewayHandler.SetExtractionTracker`; Redis tracker is constructed in `defaults.go` only when Redis is configured.

## Test plan
- [ ] `go test ./internal/api/handlers/... ./internal/intent/...`
- [ ] Deploy to multi-instance staging and verify no spurious chain rejects under rapid follow-up requests
- [ ] Confirm single-instance deployments still work (default in-memory tracker, no config change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)