### PR TITLE
feat(gateway): batch endpoint and structured error codes

### DIFF
--- a/coworkplugin/plugin/CLAUDE.md
+++ b/coworkplugin/plugin/CLAUDE.md
@@ -6,13 +6,14 @@ This plugin provides MCP tools for interacting with Clawvisor and commands for c
 
 ## MCP Tools
 
-The `clawvisor-local` MCP server provides six tools:
+The `clawvisor-local` MCP server provides these tools:
 - `fetch_catalog` — See available services, actions, and restrictions
 - `create_task` — Declare your purpose and the actions you need
 - `get_task` — Check task status (supports long-polling with `wait: true`)
 - `complete_task` — Mark a task as completed
 - `expand_task` — Add new actions to an existing task scope
-- `gateway_request` — Execute service actions under an approved task
+- `gateway_request` — Execute a single service action under an approved task
+- `gateway_batch` — Execute up to 20 gateway requests in a single round-trip (fan-out reads across services/accounts)
 
 ## Commands
 

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -292,6 +292,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 				"status":     "blocked",
 				"request_id": req.RequestID,
 				"audit_id":   auditID,
+				"code":       gateway.CodeRestricted,
 				"reason":     err.Error(),
 			}
 			h.maybeInjectNPS(ctx, resp, agent.ID)
@@ -323,6 +324,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			"status":     "blocked",
 			"request_id": req.RequestID,
 			"audit_id":   auditID,
+			"code":       gateway.CodeRestricted,
 			"reason":     reason,
 		}
 		h.maybeInjectNPS(ctx, resp, agent.ID)
@@ -532,6 +534,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			h.publishAuditAndQueue(agent.UserID, req.TaskID)
 			resp := map[string]any{
 				"status":     "pending_scope_expansion",
+				"code":       gateway.CodeScopeMismatch,
 				"task_id":    req.TaskID,
 				"request_id": req.RequestID,
 				"audit_id":   auditID,
@@ -569,7 +572,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 						"request_id": req.RequestID,
 						"audit_id":   auditID,
 						"error":      errMsg,
-						"code":       "LOCAL_SERVICE_UNAVAILABLE",
+						"code":       gateway.CodeLocalServiceUnavailable,
 					})
 					return
 				}
@@ -620,6 +623,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 					}
 					resp := map[string]any{
 						"status":       "restricted",
+						"code":         verdictErrorCode(verdict),
 						"request_id":   req.RequestID,
 						"audit_id":     auditID,
 						"reason":       verdict.Explanation,
@@ -690,6 +694,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 					}
 					resp := map[string]any{
 						"status":       "restricted",
+						"code":         verdictErrorCode(verdict),
 						"request_id":   req.RequestID,
 						"audit_id":     auditID,
 						"reason":       verdict.Explanation,
@@ -802,7 +807,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 					"request_id": req.RequestID,
 					"audit_id":   auditID,
 					"error":      errMsg,
-					"code":       "EXECUTION_ERROR",
+					"code":       gateway.CodeAdapterError,
 				}
 				h.maybeInjectNPS(ctx, resp, agent.ID)
 				writeJSON(w, http.StatusOK, resp)
@@ -918,7 +923,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 				"request_id": req.RequestID,
 				"audit_id":   auditID,
 				"error":      fmt.Sprintf("unknown service %q: not a supported service", serviceType),
-				"code":       "UNKNOWN_SERVICE",
+				"code":       gateway.CodeUnknownService,
 			})
 			return
 		}
@@ -1228,6 +1233,24 @@ func (h *GatewayHandler) HandleExecuteApproved(w http.ResponseWriter, r *http.Re
 	}
 
 	h.executeAndRespond(w, r.Context(), pa, agent.ID)
+}
+
+// verdictErrorCode maps an intent verifier verdict that denied a request to
+// the canonical error code clients should switch on. Reason-coherence failures
+// take precedence over param-scope ones: if the agent can't even explain why
+// it wants to do something, that's the more actionable signal.
+func verdictErrorCode(v *intent.VerificationVerdict) string {
+	if v == nil {
+		return gateway.CodeRestricted
+	}
+	switch v.ReasonCoherence {
+	case "incoherent", "insufficient":
+		return gateway.CodeReasonTooVague
+	}
+	if v.ParamScope == "violation" {
+		return gateway.CodeParamViolation
+	}
+	return gateway.CodeRestricted
 }
 
 // maybeInjectNPS probabilistically adds an NPS survey prompt to a gateway response.

--- a/internal/api/handlers/gateway_batch.go
+++ b/internal/api/handlers/gateway_batch.go
@@ -1,0 +1,149 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+
+	"github.com/clawvisor/clawvisor/internal/api/middleware"
+	"github.com/clawvisor/clawvisor/pkg/gateway"
+)
+
+// maxBatchSize caps how many sub-requests a single batch may carry. Chosen to
+// bound worst-case fan-out (LLM calls, adapter HTTP calls) per round-trip.
+const maxBatchSize = 20
+
+// HandleBatch accepts N gateway requests and returns N results in a single
+// round-trip. Each sub-request runs through the existing single-request
+// pipeline (HandleRequest) — auth, restrictions, task scope, intent
+// verification, audit — so behavior is identical to calling the single
+// endpoint N times.
+//
+// Sub-requests execute concurrently, bounded by maxBatchSize. A failure in
+// one sub-request never aborts the batch; each result carries its own
+// status/code. Ordering of results matches the input ordering.
+//
+// POST /api/gateway/batch
+// Auth: agent bearer token (same as single-request endpoint)
+// Query params: wait=true&timeout=N are forwarded to each sub-request.
+func (h *GatewayHandler) HandleBatch(w http.ResponseWriter, r *http.Request) {
+	agent := middleware.AgentFromContext(r.Context())
+	if agent == nil {
+		writeError(w, http.StatusUnauthorized, gateway.CodeUnauthorized, "not authenticated")
+		return
+	}
+
+	var batch gateway.BatchRequest
+	if !decodeJSON(w, r, &batch) {
+		return
+	}
+
+	if len(batch.Requests) == 0 {
+		writeDetailedError(w, http.StatusBadRequest, apiErrorDetail{
+			Error: "batch contains no requests",
+			Code:  gateway.CodeBatchEmpty,
+			Hint:  "Send at least one sub-request in the \"requests\" array.",
+		})
+		return
+	}
+	if len(batch.Requests) > maxBatchSize {
+		writeDetailedError(w, http.StatusBadRequest, apiErrorDetail{
+			Error: "batch exceeds the maximum size",
+			Code:  gateway.CodeBatchTooLarge,
+			Hint:  "Split the batch into smaller chunks. Each batch may contain at most " + strconv.Itoa(maxBatchSize) + " sub-requests.",
+		})
+		return
+	}
+
+	// Preserve caller-provided wait/timeout query params so each sub-request
+	// inherits the same long-poll behavior as a direct call would.
+	subQuery := ""
+	if q := r.URL.RawQuery; q != "" {
+		subQuery = "?" + q
+	}
+
+	results := make([]map[string]any, len(batch.Requests))
+	var wg sync.WaitGroup
+	for i := range batch.Requests {
+		wg.Add(1)
+		go func(idx int, sub gateway.Request) {
+			defer wg.Done()
+			// Per-goroutine recover: middleware.Recover wraps the outer
+			// handler but cannot catch panics from child goroutines — an
+			// unrecovered panic here would crash the whole process.
+			defer func() {
+				if rec := recover(); rec != nil {
+					h.logger.Error("batch sub-request panicked",
+						"panic", rec,
+						"request_id", sub.RequestID,
+						"service", sub.Service,
+						"action", sub.Action,
+					)
+					results[idx] = map[string]any{
+						"status":     "error",
+						"request_id": sub.RequestID,
+						"error":      "internal error processing sub-request",
+						"code":       gateway.CodeInternalError,
+					}
+				}
+			}()
+			results[idx] = h.invokeSingle(r, sub, subQuery)
+		}(i, batch.Requests[i])
+	}
+	wg.Wait()
+
+	writeJSON(w, http.StatusOK, gateway.BatchResponse{Results: results})
+}
+
+// invokeSingle dispatches one sub-request through HandleRequest using a
+// synthetic http.Request that carries the original authenticated context.
+// The response is captured, decoded as JSON, and returned as a generic map
+// so it can be passed through the batch response verbatim.
+func (h *GatewayHandler) invokeSingle(orig *http.Request, sub gateway.Request, query string) map[string]any {
+	body, err := json.Marshal(sub)
+	if err != nil {
+		return map[string]any{
+			"status":     "error",
+			"request_id": sub.RequestID,
+			"error":      "failed to re-encode sub-request: " + err.Error(),
+			"code":       gateway.CodeInternalError,
+		}
+	}
+
+	subReq, err := http.NewRequestWithContext(
+		orig.Context(),
+		http.MethodPost,
+		"/api/gateway/request"+query,
+		bytes.NewReader(body),
+	)
+	if err != nil {
+		return map[string]any{
+			"status":     "error",
+			"request_id": sub.RequestID,
+			"error":      err.Error(),
+			"code":       gateway.CodeInternalError,
+		}
+	}
+	subReq.Header.Set("Content-Type", "application/json")
+
+	rec := httptest.NewRecorder()
+	h.HandleRequest(rec, subReq)
+
+	var out map[string]any
+	if dErr := json.Unmarshal(rec.Body.Bytes(), &out); dErr != nil {
+		return map[string]any{
+			"status":     "error",
+			"request_id": sub.RequestID,
+			"error":      "sub-response was not JSON: " + dErr.Error(),
+			"code":       gateway.CodeInternalError,
+		}
+	}
+	if _, ok := out["request_id"]; !ok && sub.RequestID != "" {
+		out["request_id"] = sub.RequestID
+	}
+	return out
+}
+

--- a/internal/api/handlers/gateway_batch_test.go
+++ b/internal/api/handlers/gateway_batch_test.go
@@ -1,0 +1,303 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/internal/intent"
+	"github.com/clawvisor/clawvisor/pkg/adapters"
+	"github.com/clawvisor/clawvisor/pkg/gateway"
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+// ── verdictErrorCode ────────────────────────────────────────────────────────
+
+func TestVerdictErrorCode_ReasonIncoherent(t *testing.T) {
+	got := verdictErrorCode(&intent.VerificationVerdict{ReasonCoherence: "incoherent"})
+	if got != gateway.CodeReasonTooVague {
+		t.Fatalf("expected REASON_TOO_VAGUE for incoherent, got %q", got)
+	}
+}
+
+func TestVerdictErrorCode_ReasonInsufficient(t *testing.T) {
+	got := verdictErrorCode(&intent.VerificationVerdict{ReasonCoherence: "insufficient"})
+	if got != gateway.CodeReasonTooVague {
+		t.Fatalf("expected REASON_TOO_VAGUE for insufficient, got %q", got)
+	}
+}
+
+func TestVerdictErrorCode_ParamViolation(t *testing.T) {
+	got := verdictErrorCode(&intent.VerificationVerdict{
+		ReasonCoherence: "ok",
+		ParamScope:      "violation",
+	})
+	if got != gateway.CodeParamViolation {
+		t.Fatalf("expected PARAM_VIOLATION, got %q", got)
+	}
+}
+
+func TestVerdictErrorCode_ReasonTakesPrecedenceOverParams(t *testing.T) {
+	got := verdictErrorCode(&intent.VerificationVerdict{
+		ReasonCoherence: "incoherent",
+		ParamScope:      "violation",
+	})
+	if got != gateway.CodeReasonTooVague {
+		t.Fatalf("reason coherence should beat param scope; got %q", got)
+	}
+}
+
+func TestVerdictErrorCode_NilFallback(t *testing.T) {
+	if got := verdictErrorCode(nil); got != gateway.CodeRestricted {
+		t.Fatalf("expected RESTRICTED for nil verdict, got %q", got)
+	}
+}
+
+// ── Batch handler ───────────────────────────────────────────────────────────
+
+func makeBatchRequest(t *testing.T, h *GatewayHandler, body map[string]any) *httptest.ResponseRecorder {
+	t.Helper()
+	b, _ := json.Marshal(body)
+	req := httptest.NewRequest("POST", "/api/gateway/batch", bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(withAgent(req.Context(), testAgent))
+	w := httptest.NewRecorder()
+	h.HandleBatch(w, req)
+	return w
+}
+
+func TestBatch_Empty(t *testing.T) {
+	st := newLocalTestStore()
+	h := newTestGatewayHandler(st, nil, nil, &mockVerifier{})
+
+	w := makeBatchRequest(t, h, map[string]any{"requests": []any{}})
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["code"] != gateway.CodeBatchEmpty {
+		t.Fatalf("expected BATCH_EMPTY, got %v", resp["code"])
+	}
+}
+
+func TestBatch_TooLarge(t *testing.T) {
+	st := newLocalTestStore()
+	h := newTestGatewayHandler(st, nil, nil, &mockVerifier{})
+
+	reqs := make([]map[string]any, maxBatchSize+1)
+	for i := range reqs {
+		reqs[i] = map[string]any{
+			"service":    "local.files",
+			"action":     "read_file",
+			"reason":     "r",
+			"task_id":    "task-1",
+			"request_id": "r" + string(rune('a'+i%26)),
+		}
+	}
+	w := makeBatchRequest(t, h, map[string]any{"requests": reqs})
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["code"] != gateway.CodeBatchTooLarge {
+		t.Fatalf("expected BATCH_TOO_LARGE, got %v", resp["code"])
+	}
+}
+
+func TestBatch_FanOut_MixedOutcomes(t *testing.T) {
+	st := newLocalTestStore()
+	st.tasks["task-1"] = &store.Task{
+		ID: "task-1", UserID: "user-1", AgentID: "agent-1", Status: "active",
+		AuthorizedActions: []store.TaskAction{
+			{Service: "local.files", Action: "read_file", AutoExecute: true},
+		},
+	}
+
+	provider := &mockLocalProvider{services: testServices()}
+	executor := &mockLocalExecutor{result: &adapters.Result{Summary: "ok"}}
+	verifier := &mockVerifier{
+		verdict: &intent.VerificationVerdict{
+			Allow: true, ParamScope: "ok", ReasonCoherence: "ok", ExtractContext: false,
+		},
+	}
+
+	h := newTestGatewayHandler(st, provider, executor, verifier)
+
+	w := makeBatchRequest(t, h, map[string]any{
+		"requests": []map[string]any{
+			// Sub-request 1: valid, should execute.
+			{
+				"service":    "local.files",
+				"action":     "read_file",
+				"reason":     "read config",
+				"task_id":    "task-1",
+				"request_id": "req-1",
+				"params":     map[string]any{"path": "/etc/hosts"},
+			},
+			// Sub-request 2: unknown action, should fail with UNKNOWN_ACTION.
+			{
+				"service":    "local.files",
+				"action":     "delete_file",
+				"reason":     "delete something",
+				"task_id":    "task-1",
+				"request_id": "req-2",
+			},
+			// Sub-request 3: out of scope (write_file not in authorized actions).
+			{
+				"service":    "local.files",
+				"action":     "write_file",
+				"reason":     "write something",
+				"task_id":    "task-1",
+				"request_id": "req-3",
+				"params":     map[string]any{"path": "/tmp/x", "content": "y"},
+			},
+		},
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp gateway.BatchResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(resp.Results))
+	}
+
+	// Results must be aligned with input order via request_id.
+	byID := map[string]map[string]any{}
+	for _, r := range resp.Results {
+		id, _ := r["request_id"].(string)
+		byID[id] = r
+	}
+
+	r1 := byID["req-1"]
+	if r1 == nil || r1["status"] != "executed" {
+		t.Fatalf("req-1 expected executed, got %v", r1)
+	}
+	r2 := byID["req-2"]
+	if r2 == nil || r2["code"] != gateway.CodeUnknownAction {
+		t.Fatalf("req-2 expected UNKNOWN_ACTION, got %v", r2)
+	}
+	r3 := byID["req-3"]
+	if r3 == nil || r3["code"] != gateway.CodeScopeMismatch {
+		t.Fatalf("req-3 expected SCOPE_MISMATCH, got %v", r3)
+	}
+}
+
+func TestBatch_ResultsPreserveOrder(t *testing.T) {
+	st := newLocalTestStore()
+	st.tasks["task-1"] = &store.Task{
+		ID: "task-1", UserID: "user-1", AgentID: "agent-1", Status: "active",
+		AuthorizedActions: []store.TaskAction{
+			{Service: "local.files", Action: "read_file", AutoExecute: true},
+		},
+	}
+	provider := &mockLocalProvider{services: testServices()}
+	executor := &mockLocalExecutor{result: &adapters.Result{Summary: "ok"}}
+	verifier := &mockVerifier{
+		verdict: &intent.VerificationVerdict{Allow: true, ParamScope: "ok", ReasonCoherence: "ok"},
+	}
+	h := newTestGatewayHandler(st, provider, executor, verifier)
+
+	reqs := make([]map[string]any, 5)
+	for i := range reqs {
+		reqs[i] = map[string]any{
+			"service":    "local.files",
+			"action":     "read_file",
+			"reason":     "read config",
+			"task_id":    "task-1",
+			"request_id": "req-" + string(rune('1'+i)),
+			"params":     map[string]any{"path": "/etc/hosts"},
+		}
+	}
+	w := makeBatchRequest(t, h, map[string]any{"requests": reqs})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp gateway.BatchResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if len(resp.Results) != 5 {
+		t.Fatalf("expected 5 results, got %d", len(resp.Results))
+	}
+	for i, r := range resp.Results {
+		want := "req-" + string(rune('1'+i))
+		if got, _ := r["request_id"].(string); got != want {
+			t.Fatalf("result[%d] request_id=%q, want %q", i, got, want)
+		}
+	}
+}
+
+func TestBatch_SubRequestPanic_RecoveredPerGoroutine(t *testing.T) {
+	// A panic in a sub-request goroutine must not take down the process.
+	// It should be recovered, produce an INTERNAL_ERROR result for the
+	// failing sub-request, and leave the rest of the batch intact.
+	st := newLocalTestStore()
+	st.tasks["task-1"] = &store.Task{
+		ID: "task-1", UserID: "user-1", AgentID: "agent-1", Status: "active",
+		AuthorizedActions: []store.TaskAction{
+			{Service: "local.files", Action: "read_file", AutoExecute: true},
+		},
+	}
+	provider := &mockLocalProvider{services: testServices()}
+	executor := &mockLocalExecutor{result: &adapters.Result{Summary: "ok"}}
+	// Panic from inside the single-request pipeline.
+	verifier := &mockVerifier{panicWith: "synthetic panic for test"}
+
+	h := newTestGatewayHandler(st, provider, executor, verifier)
+
+	w := makeBatchRequest(t, h, map[string]any{
+		"requests": []map[string]any{
+			{
+				"service":    "local.files",
+				"action":     "read_file",
+				"reason":     "read config",
+				"task_id":    "task-1",
+				"request_id": "req-panic",
+				"params":     map[string]any{"path": "/etc/hosts"},
+			},
+		},
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("batch response must be 200 even if a sub-request panicked, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp gateway.BatchResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if len(resp.Results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(resp.Results))
+	}
+	r := resp.Results[0]
+	if r["code"] != gateway.CodeInternalError {
+		t.Fatalf("expected INTERNAL_ERROR after panic recovery, got %v", r["code"])
+	}
+	if r["request_id"] != "req-panic" {
+		t.Fatalf("expected request_id preserved, got %v", r["request_id"])
+	}
+}
+
+func TestBatch_Unauthenticated(t *testing.T) {
+	st := newLocalTestStore()
+	h := newTestGatewayHandler(st, nil, nil, &mockVerifier{})
+
+	// No agent in context.
+	req := httptest.NewRequest("POST", "/api/gateway/batch",
+		strings.NewReader(`{"requests":[{"service":"x","action":"y","reason":"z","task_id":"t","request_id":"r"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.HandleBatch(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}

--- a/internal/api/handlers/local_service_test.go
+++ b/internal/api/handlers/local_service_test.go
@@ -118,13 +118,17 @@ func (s *localTestStore) ListServiceMetas(_ context.Context, _ string) ([]*store
 
 // mockVerifier allows tests to control intent verification outcomes.
 type mockVerifier struct {
-	verdict *intent.VerificationVerdict
-	err     error
-	called  bool
+	verdict   *intent.VerificationVerdict
+	err       error
+	called    bool
+	panicWith string // if non-empty, Verify panics with this value (for recovery tests)
 }
 
 func (m *mockVerifier) Verify(_ context.Context, _ intent.VerifyRequest) (*intent.VerificationVerdict, error) {
 	m.called = true
+	if m.panicWith != "" {
+		panic(m.panicWith)
+	}
 	return m.verdict, m.err
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -678,6 +678,10 @@ func (s *Server) routes() http.Handler {
 		e2e(http.HandlerFunc(gatewayHandler.HandleGet)))))
 	mux.Handle("POST /api/gateway/request/{request_id}/execute", requireAgent(middleware.RateLimit(gatewayRL, agentKeyFn, rlCfg.Gateway.Limit)(
 		e2e(http.HandlerFunc(gatewayHandler.HandleExecuteApproved)))))
+	// Batch endpoint: N sub-requests in one round-trip. Rate-limited like the
+	// single-request endpoint (each batch consumes one token).
+	mux.Handle("POST /api/gateway/batch", requireAgent(middleware.RateLimit(gatewayRL, agentKeyFn, rlCfg.Gateway.Limit)(
+		e2e(http.HandlerFunc(gatewayHandler.HandleBatch)))))
 
 	// Adapter generation (user JWT for dashboard, agent token for MCP)
 	if s.llmCfg.AdapterGen.Enabled && s.adapterGenFactory != nil {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -134,6 +134,38 @@ func toolDefs() []Tool {
 			}`),
 		},
 		{
+			Name:        "gateway_batch",
+			Description: "Execute multiple gateway requests in a single round-trip. Each sub-request runs through the same pipeline as gateway_request (auth, task scope, intent verification, audit) and carries its own status/code — a failure in one sub-request does not abort the others. Sub-requests run concurrently. Results are returned in the same order as the input. Useful for fan-out reads across accounts/services (e.g. list unread mail + check calendar + list Slack mentions in one call). Maximum 20 sub-requests per batch.",
+			InputSchema: json.RawMessage(`{
+				"type": "object",
+				"properties": {
+					"requests": {
+						"type": "array",
+						"minItems": 1,
+						"maxItems": 20,
+						"items": {
+							"type": "object",
+							"properties": {
+								"service": {"type": "string"},
+								"action": {"type": "string"},
+								"params": {"type": "object"},
+								"reason": {"type": "string"},
+								"request_id": {"type": "string"},
+								"task_id": {"type": "string"},
+								"context": {"type": "object"},
+								"session_id": {"type": "string"}
+							},
+							"required": ["service", "action", "params", "reason", "request_id", "task_id"]
+						},
+						"description": "Array of gateway sub-requests. Each sub-request has the same schema as gateway_request."
+					},
+					"wait": {"type": "boolean", "description": "If true, each sub-request long-polls for approval before returning (default true)"},
+					"timeout": {"type": "integer", "description": "Long-poll timeout in seconds applied to each sub-request (default 120, max 120)"}
+				},
+				"required": ["requests"]
+			}`),
+		},
+		{
 			Name:        "execute_request",
 			Description: "Execute a previously approved gateway request and return the result. Use this when a gateway_request returned status=pending and has since been approved. Supports wait=true to block until approved.",
 			InputSchema: json.RawMessage(`{

--- a/internal/mcp/tools_exec.go
+++ b/internal/mcp/tools_exec.go
@@ -172,6 +172,12 @@ func buildInternalRequest(toolName string, arguments json.RawMessage) (internalR
 		body := stripKeys(args, "wait", "timeout")
 		return internalRoute{"POST", path, "POST /api/gateway/request", nil}, body, nil
 
+	case "gateway_batch":
+		path := "/api/gateway/batch"
+		path += buildWaitQuery(args, getString, true)
+		body := stripKeys(args, "wait", "timeout")
+		return internalRoute{"POST", path, "POST /api/gateway/batch", nil}, body, nil
+
 	case "execute_request":
 		id := getString("request_id")
 		if err := validatePathParam(id, "request_id"); err != nil {

--- a/pkg/gateway/errorcodes.go
+++ b/pkg/gateway/errorcodes.go
@@ -1,0 +1,51 @@
+package gateway
+
+// Error codes returned to gateway clients in the "code" field of error/non-OK
+// responses. Clients should switch on these codes rather than parsing the
+// human-readable "error" or "reason" prose, which may change without notice.
+//
+// Codes are grouped by category. Adding a new code is backwards-compatible;
+// renaming or removing a code is not.
+const (
+	// Request validation — the request was malformed or missing fields.
+	CodeInvalidRequest     = "INVALID_REQUEST"
+	CodeInvalidParams      = "INVALID_PARAMS"
+	CodeInvalidCallbackURL = "INVALID_CALLBACK_URL"
+	CodeMissingReason      = "MISSING_REASON"
+	CodeMissingSessionID   = "MISSING_SESSION_ID"
+	CodeTaskRequired       = "TASK_REQUIRED"
+
+	// Auth / ownership.
+	CodeUnauthorized = "UNAUTHORIZED"
+	CodeForbidden    = "FORBIDDEN"
+
+	// Addressing — the named service or action does not exist.
+	CodeUnknownService = "UNKNOWN_SERVICE"
+	CodeUnknownAction  = "UNKNOWN_ACTION"
+
+	// State — the target task/approval is not in a state that permits this action.
+	CodeInvalidState      = "INVALID_STATE"
+	CodeNotFound          = "NOT_FOUND"
+	CodeAlreadyExecuting  = "ALREADY_EXECUTING"
+	CodeNotApproved       = "NOT_APPROVED"
+	CodeApprovalExpired   = "APPROVAL_EXPIRED"
+
+	// Policy — the request is syntactically fine but blocked by authorization.
+	CodeScopeMismatch  = "SCOPE_MISMATCH"  // outside the approved task scope
+	CodeReasonTooVague = "REASON_TOO_VAGUE" // intent verifier found reason incoherent/insufficient
+	CodeParamViolation = "PARAM_VIOLATION"  // params inconsistent with task scope / chain context
+	CodeRestricted     = "RESTRICTED"       // user restriction or org policy blocked the action
+	CodeMissingScopes  = "MISSING_SCOPES"   // activation is missing OAuth scopes required for this action
+
+	// Execution — downstream failure during or after dispatch.
+	CodeAdapterError            = "ADAPTER_ERROR"
+	CodeLocalServiceUnavailable = "LOCAL_SERVICE_UNAVAILABLE"
+
+	// Operational.
+	CodeRateLimited  = "RATE_LIMITED"
+	CodeInternalError = "INTERNAL_ERROR"
+
+	// Batch — aggregate endpoint specific.
+	CodeBatchTooLarge = "BATCH_TOO_LARGE"
+	CodeBatchEmpty    = "BATCH_EMPTY"
+)

--- a/pkg/gateway/types.go
+++ b/pkg/gateway/types.go
@@ -18,3 +18,20 @@ type RequestContext struct {
 	DataOrigin  *string `json:"data_origin"`
 	CallbackURL string  `json:"callback_url"`
 }
+
+// BatchRequest is the payload sent by an agent to POST /api/gateway/batch.
+// Each sub-request is handled by the same single-request pipeline (auth,
+// task scope, intent verification, audit), and results are returned in the
+// same order. A sub-request failure never fails the whole batch — each
+// sub-result carries its own status/code.
+type BatchRequest struct {
+	Requests []Request `json:"requests"`
+}
+
+// BatchResponse is the aggregated response from POST /api/gateway/batch.
+// Each entry mirrors the shape of a single-request response (status,
+// request_id, result/error, code, etc.), preserved as-is so clients can
+// reuse the same parser for both endpoints.
+type BatchResponse struct {
+	Results []map[string]any `json:"results"`
+}

--- a/skills/clawvisor/SKILL.md.tmpl
+++ b/skills/clawvisor/SKILL.md.tmpl
@@ -318,6 +318,54 @@ the data origin — set it.
 
 ---
 
+## Batch Requests
+
+When you need to make several independent gateway calls — fanning out across
+accounts or services (e.g. list unread email + check calendar + check Slack
+mentions) — use the batch endpoint instead of N sequential single requests.
+Sub-requests run concurrently on the server and are returned in one response,
+saving one round-trip per sub-request.
+{{ if .UseCurl }}
+```bash
+curl -s -X POST "$CLAWVISOR_URL/api/gateway/batch?wait=true" \
+  -H "Authorization: Bearer $CLAWVISOR_AGENT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"requests": [
+    {"service": "google.gmail:user@example.com", "action": "list_messages", "params": {"q": "is:unread", "max_results": 10}, "reason": "Morning triage: list unread mail", "request_id": "r-1", "task_id": "<task-id>"},
+    {"service": "google.calendar:user@example.com", "action": "list_events",  "params": {"from": "2026-04-20T00:00:00Z", "to": "2026-04-21T00:00:00Z"}, "reason": "Morning triage: today's calendar", "request_id": "r-2", "task_id": "<task-id>"}
+  ]}'
+```
+{{ else }}
+Use `gateway_batch` with a `requests` array. Each entry has the same shape as
+a `gateway_request` call.
+{{ end }}
+**Rules:**
+
+- **Max 20 sub-requests per batch.** Split larger fan-outs into multiple batches.
+- **Each sub-request is independent.** It runs through the full single-request pipeline (auth, task scope, intent verification, audit). `task_id`, `reason`, and `request_id` are required on *every* sub-request — just like a single call.
+- **One sub-request failing does not abort the batch.** The batch returns HTTP 200 with an ordered `results` array; each entry carries its own `status` / `code` / `error` or `result`. Read each sub-result individually.
+- **Ordering is preserved.** `results[i]` corresponds to `requests[i]`.
+- **Not all sub-requests need the same task.** Each sub-request names its own `task_id`. You can fan out across multiple active tasks in one batch.
+- **Approval flows still apply.** A sub-request that needs human approval returns `status: pending` — follow up with {{ if .UseCurl }}`POST /api/gateway/request/{request_id}/execute?wait=true`{{ else }}`execute_request`{{ end }} for that specific request_id, not by re-batching.
+- **Don't use batch for dependent calls.** If request B needs data from request A's result (e.g. get_event needs event_id from list_events), call them sequentially — batch runs everything concurrently.
+
+**Response shape:**
+
+```json
+{
+  "results": [
+    {"status": "executed", "request_id": "r-1", "audit_id": "...", "result": {...}},
+    {"status": "executed", "request_id": "r-2", "audit_id": "...", "result": {...}}
+  ]
+}
+```
+
+If the top-level request is malformed (empty array, over 20 entries, bad JSON),
+the whole batch fails with a single error envelope carrying `BATCH_EMPTY`,
+`BATCH_TOO_LARGE`, or `INVALID_REQUEST`.
+
+---
+
 ## Handling Responses
 
 Every {{ if .UseCurl -}} response has a `status` field. Handle each case as follows
@@ -334,10 +382,29 @@ Every {{ if .UseCurl -}} response has a `status` field. Handle each case as foll
 | `pending_scope_expansion` | {{ if .UseCurl }}Request outside{{ else }}Action outside{{ end }} task scope | {{ if .UseCurl }}Call `POST /api/tasks/{id}/expand` with the new action{{ else }}Use expand_task{{ end }}. |
 | `task_expired` | Task {{ if .UseCurl }}has passed its expiry{{ else }}TTL exceeded{{ end }} | Expand{{ if .UseCurl }} the task to extend,{{ end }} or create a new task. |
 | `error` (`SERVICE_NOT_CONFIGURED`) | Service not {{ if .UseCurl }}yet {{ end }}connected | Tell the user{{ if .UseCurl }}: "[Service] isn't activated yet. Connect it in the Clawvisor dashboard."{{ else }} to connect it in the Clawvisor dashboard{{ end }}. |
-| `error` (`EXECUTION_ERROR`) | Adapter failed | Report the error{{ if .UseCurl }} to the user{{ end }}. Do not silently retry. |
+| `error` (`ADAPTER_ERROR`) | Downstream adapter call failed | Report the error{{ if .UseCurl }} to the user{{ end }}. Do not silently retry. |
 | `error` (other) | Something went wrong | Report the error{{ if .UseCurl }} message to the user{{ end }}. Do not silently retry. |
 
 **Warnings:** Responses may include a `"warnings"` array with actionable messages about misconfiguration. Always check for and act on warnings.
+
+### Machine-parseable error codes
+
+Every non-`executed` response includes a stable `code` field (in addition to the human-readable `reason`/`error`/`message` prose). **Switch on `code`, not on the prose** — prose may change without notice.
+
+| Code | Emitted when | Typical `status` |
+|---|---|---|
+| `RESTRICTED` | A user restriction or org policy blocked the action | `blocked` |
+| `SCOPE_MISMATCH` | Action not covered by the approved task scope | `pending_scope_expansion` |
+| `REASON_TOO_VAGUE` | Intent verifier judged the `reason` field incoherent or insufficient | `restricted` |
+| `PARAM_VIOLATION` | Params inconsistent with task scope or chain context | `restricted` |
+| `ADAPTER_ERROR` | Downstream service call failed | `error` |
+| `RATE_LIMITED` | Per-agent rate limit exceeded (HTTP 429) | — |
+| `UNKNOWN_SERVICE` / `UNKNOWN_ACTION` | Service or action not recognized | `error` |
+| `INVALID_REQUEST` / `INVALID_PARAMS` / `MISSING_REASON` / `TASK_REQUIRED` | Request validation failed | — |
+| `MISSING_SESSION_ID` | Standing task request without `session_id` | — |
+| `INTERNAL_ERROR` | Unexpected server error | `error` |
+
+When `code` is `REASON_TOO_VAGUE`, rewrite your `reason` to be more specific (see *Writing Effective Reasons*). When it's `SCOPE_MISMATCH`, use `expand_task`{{ if .UseCurl }} / `POST /api/tasks/{id}/expand`{{ end }}. When it's `ADAPTER_ERROR`, the downstream service is at fault — report to the user and stop; don't retry.
 
 **Pagination:** Results may be paginated. Check `result.meta` for continuation fields (e.g. `next_page_token`, `cursor`, `has_more`) and pass them as params in a follow-up gateway request to fetch the next page.
 {{ if not .Condensed }}


### PR DESCRIPTION
## Summary
- Adds `POST /api/gateway/batch` and a `gateway_batch` MCP tool that fan out up to 20 gateway requests concurrently in a single round-trip, with per-sub-request panic recovery so one bad request can't crash the process.
- Introduces a canonical error-code taxonomy in `pkg/gateway/errorcodes.go` (e.g. `REASON_TOO_VAGUE`, `SCOPE_MISMATCH`, `PARAM_VIOLATION`, `ADAPTER_ERROR`, `RATE_LIMITED`, `BATCH_TOO_LARGE`) and stamps a machine-parseable `code` onto blocked, restricted, pending-scope-expansion, and error responses.
- Updates the clawvisor skill template and plugin `CLAUDE.md` to document batch usage, per-result ordering, partial-failure semantics, and the new code table.

## Test plan
- [x] `go test ./internal/api/handlers/... ./pkg/gateway/...`
- [ ] Manual: send a 3-request batch against a live instance and confirm ordered results + per-entry codes

🤖 Generated with [Claude Code](https://claude.com/claude-code)