### PR TITLE
feat(web): ScopePill tooltips + stacked mobile layout

### DIFF
--- a/web/src/components/ScopePill.tsx
+++ b/web/src/components/ScopePill.tsx
@@ -2,6 +2,12 @@ import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 
 type Verify = 'strict' | 'lenient' | 'off'
 
+const VERIFICATION_TOOLTIPS: Record<Verify, string> = {
+  strict: 'Full intent check — each request is verified against the task\u2019s purpose',
+  lenient: 'Relaxed check — allows routine variation, still blocks clear violations',
+  off: 'No intent check — only the scope itself gates requests',
+}
+
 export type ScopePillValue = { auto: boolean; verification: Verify }
 
 export default function ScopePill({
@@ -62,12 +68,38 @@ export default function ScopePill({
   ].filter(Boolean).join(' ')
 
   return (
-    <div
-      ref={ref}
-      className={pillClass}
-      style={targetWidth !== undefined ? { width: targetWidth } : undefined}
-      onClick={handleCompactClick}
-    >
+    <>
+      <div className="md:hidden flex flex-col items-end gap-1 shrink-0">
+        <select
+          value={value.auto ? 'auto' : 'approve'}
+          onChange={(e) => onChange({ ...value, auto: e.target.value === 'auto' })}
+          disabled={disabled}
+          title={value.auto
+            ? 'Run matching requests immediately without asking you first'
+            : 'Require your approval before each matching request runs'}
+          className="text-[11px] rounded border border-border-default bg-surface-0 text-text-primary px-1.5 py-0.5 focus:outline-none focus:ring-1 focus:ring-brand/30 focus:border-brand disabled:opacity-50"
+        >
+          <option value="auto">auto</option>
+          <option value="approve">approve</option>
+        </select>
+        <select
+          value={value.verification}
+          onChange={(e) => onChange({ ...value, verification: e.target.value as Verify })}
+          disabled={disabled}
+          title={VERIFICATION_TOOLTIPS[value.verification]}
+          className={`text-[11px] rounded border bg-surface-0 text-text-primary px-1.5 py-0.5 focus:outline-none focus:ring-1 focus:ring-brand/30 focus:border-brand disabled:opacity-50 ${dangerous ? 'border-danger/60' : 'border-border-default'}`}
+        >
+          <option value="strict">strict</option>
+          <option value="lenient">lenient</option>
+          <option value="off">off</option>
+        </select>
+      </div>
+      <div
+        ref={ref}
+        className={`hidden md:inline-block ${pillClass}`}
+        style={targetWidth !== undefined ? { width: targetWidth } : undefined}
+        onClick={handleCompactClick}
+      >
       <span ref={compactRef} className="scope-pill__compact">
         <span className="scope-pill__dot" />
         <span>{label}</span>
@@ -78,11 +110,13 @@ export default function ScopePill({
             type="button"
             onClick={(e) => { e.stopPropagation(); onChange({ ...value, auto: true }) }}
             className={value.auto ? 'is-active' : ''}
+            title="Run matching requests immediately without asking you first"
           >auto</button>
           <button
             type="button"
             onClick={(e) => { e.stopPropagation(); onChange({ ...value, auto: false }) }}
             className={!value.auto ? 'is-active' : ''}
+            title="Require your approval before each matching request runs"
           >approve</button>
         </span>
         <span className="scope-pill__divider" />
@@ -93,6 +127,7 @@ export default function ScopePill({
               key={mode}
               onClick={(e) => { e.stopPropagation(); onChange({ ...value, verification: mode }) }}
               className={value.verification === mode ? 'is-active' : ''}
+              title={VERIFICATION_TOOLTIPS[mode]}
             >{mode}</button>
           ))}
         </span>
@@ -107,6 +142,7 @@ export default function ScopePill({
           </svg>
         </button>
       </span>
-    </div>
+      </div>
+    </>
   )
 }

--- a/web/src/components/ScopePill.tsx
+++ b/web/src/components/ScopePill.tsx
@@ -75,8 +75,8 @@ export default function ScopePill({
           onChange={(e) => onChange({ ...value, auto: e.target.value === 'auto' })}
           disabled={disabled}
           title={value.auto
-            ? 'Run matching requests immediately without asking you first'
-            : 'Require your approval before each matching request runs'}
+            ? 'Run this action immediately without asking you first'
+            : 'Require your approval before each run of this action'}
           className="text-[11px] rounded border border-border-default bg-surface-0 text-text-primary px-1.5 py-0.5 focus:outline-none focus:ring-1 focus:ring-brand/30 focus:border-brand disabled:opacity-50"
         >
           <option value="auto">auto</option>
@@ -110,13 +110,13 @@ export default function ScopePill({
             type="button"
             onClick={(e) => { e.stopPropagation(); onChange({ ...value, auto: true }) }}
             className={value.auto ? 'is-active' : ''}
-            title="Run matching requests immediately without asking you first"
+            title="Run this action immediately without asking you first"
           >auto</button>
           <button
             type="button"
             onClick={(e) => { e.stopPropagation(); onChange({ ...value, auto: false }) }}
             className={!value.auto ? 'is-active' : ''}
-            title="Require your approval before each matching request runs"
+            title="Require your approval before each run of this action"
           >approve</button>
         </span>
         <span className="scope-pill__divider" />


### PR DESCRIPTION
## Summary
- Adds hover tooltips to the auto/approve and strict/lenient/off controls in ScopePill, explaining what each option does.
- Below the md breakpoint, replaces the expanding pill with two stacked native selects so the control fits on mobile; danger styling (auto + off) is preserved as a red border on the verification select.

## Test plan
- [ ] Hover each segment on desktop — tooltip text matches the option.
- [ ] Shrink viewport below 768px — pill is replaced by two stacked selects that change scope values correctly.
- [ ] Set auto + off on mobile — verification select shows red border.

🤖 Generated with [Claude Code](https://claude.com/claude-code)