### PR TITLE
feat: add Autosana E2E testing CI workflow

### DIFF
--- a/.github/workflows/autosana.yml
+++ b/.github/workflows/autosana.yml
@@ -1,0 +1,28 @@
+name: Autosana E2E Tests
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  e2e:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Register with Autosana
+        uses: autosana/autosana-ci@main
+        with:
+          api-key: ${{ secrets.AUTOSANA_KEY }}
+          platform: web
+          app-id: clawvisor-staging
+          url: https://app.staging.clawvisor.com
+          name: Clawvisor
+          environment: staging
+          # Uncomment to auto-run suites after registration:
+          # suite-ids: <suite-id-1>,<suite-id-2>


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/autosana.yml` that registers `app.staging.clawvisor.com` with Autosana
- Triggers on push/PR to main and manual dispatch
- Requires `AUTOSANA_KEY` GitHub secret

## Test plan
- [ ] Set `AUTOSANA_KEY` secret in repo settings
- [ ] Verify workflow runs on PR and registers the staging URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)