### PR TITLE
fix(api): scope pending connection request limit per user

### DIFF
--- a/internal/api/connections_test.go
+++ b/internal/api/connections_test.go
@@ -283,16 +283,17 @@ func TestConnectionRequest_DeleteExpired(t *testing.T) {
 func TestConnectionRequest_CountPending(t *testing.T) {
 	env, _ := setupConnectionEnv(t)
 
-	count, err := env.Store.CountPendingConnectionRequests(context.Background())
+	owner, _ := env.Store.GetUserByEmail(context.Background(), "admin@local")
+
+	count, err := env.Store.CountPendingConnectionRequestsForUser(context.Background(), owner.ID)
 	if err != nil {
-		t.Fatalf("CountPendingConnectionRequests: %v", err)
+		t.Fatalf("CountPendingConnectionRequestsForUser: %v", err)
 	}
 	if count != 0 {
 		t.Errorf("expected 0 pending, got %d", count)
 	}
 
 	// Create one.
-	owner, _ := env.Store.GetUserByEmail(context.Background(), "admin@local")
 	_ = env.Store.CreateConnectionRequest(context.Background(), &store.ConnectionRequest{
 		UserID:    owner.ID,
 		Name:      "test",
@@ -300,9 +301,9 @@ func TestConnectionRequest_CountPending(t *testing.T) {
 		ExpiresAt: time.Now().Add(5 * time.Minute),
 	})
 
-	count, err = env.Store.CountPendingConnectionRequests(context.Background())
+	count, err = env.Store.CountPendingConnectionRequestsForUser(context.Background(), owner.ID)
 	if err != nil {
-		t.Fatalf("CountPendingConnectionRequests: %v", err)
+		t.Fatalf("CountPendingConnectionRequestsForUser: %v", err)
 	}
 	if count != 1 {
 		t.Errorf("expected 1 pending, got %d", count)

--- a/internal/api/handlers/connections.go
+++ b/internal/api/handlers/connections.go
@@ -94,21 +94,11 @@ func (h *ConnectionsHandler) RequestConnect(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	// Check pending count.
-	count, err := h.st.CountPendingConnectionRequests(r.Context())
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not check pending requests")
-		return
-	}
-	if count >= maxPendingRequests {
-		writeError(w, http.StatusTooManyRequests, "TOO_MANY_PENDING", "too many pending connection requests")
-		return
-	}
-
 	// Resolve the target user. In multi-tenant mode, user_id is required so
 	// the connection request is routed to the correct user. In single-tenant
 	// mode, fall back to admin@local for backward compatibility.
 	var owner *store.User
+	var err error
 	if body.UserID != "" {
 		owner, err = h.st.GetUserByID(r.Context(), body.UserID)
 		if err != nil {
@@ -124,6 +114,17 @@ func (h *ConnectionsHandler) RequestConnect(w http.ResponseWriter, r *http.Reque
 			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not resolve daemon owner")
 			return
 		}
+	}
+
+	// Check pending count for this user.
+	count, err := h.st.CountPendingConnectionRequestsForUser(r.Context(), owner.ID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not check pending requests")
+		return
+	}
+	if count >= maxPendingRequests {
+		writeError(w, http.StatusTooManyRequests, "TOO_MANY_PENDING", "too many pending connection requests")
+		return
 	}
 
 	req := &store.ConnectionRequest{

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -1484,10 +1484,10 @@ func (s *Store) DeleteExpiredConnectionRequests(ctx context.Context) error {
 	return err
 }
 
-func (s *Store) CountPendingConnectionRequests(ctx context.Context) (int, error) {
+func (s *Store) CountPendingConnectionRequestsForUser(ctx context.Context, userID string) (int, error) {
 	var count int
 	err := s.pool.QueryRow(ctx,
-		`SELECT COUNT(*) FROM connection_requests WHERE status = 'pending'`).Scan(&count)
+		`SELECT COUNT(*) FROM connection_requests WHERE status = 'pending' AND user_id = $1`, userID).Scan(&count)
 	return count, err
 }
 

--- a/internal/store/sqlite/store.go
+++ b/internal/store/sqlite/store.go
@@ -1582,10 +1582,10 @@ func (s *Store) DeleteExpiredConnectionRequests(ctx context.Context) error {
 	return err
 }
 
-func (s *Store) CountPendingConnectionRequests(ctx context.Context) (int, error) {
+func (s *Store) CountPendingConnectionRequestsForUser(ctx context.Context, userID string) (int, error) {
 	var count int
 	err := s.db.QueryRowContext(ctx,
-		`SELECT COUNT(*) FROM connection_requests WHERE status = 'pending'`).Scan(&count)
+		`SELECT COUNT(*) FROM connection_requests WHERE status = 'pending' AND user_id = ?`, userID).Scan(&count)
 	return count, err
 }
 

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -141,7 +141,7 @@ type Store interface {
 	ListPendingConnectionRequests(ctx context.Context, userID string) ([]*ConnectionRequest, error)
 	UpdateConnectionRequestStatus(ctx context.Context, id, status, agentID string) error
 	DeleteExpiredConnectionRequests(ctx context.Context) error
-	CountPendingConnectionRequests(ctx context.Context) (int, error)
+	CountPendingConnectionRequestsForUser(ctx context.Context, userID string) (int, error)
 
 	// Generated adapters (cloud-safe persistence for LLM-generated YAML definitions)
 	SaveGeneratedAdapter(ctx context.Context, userID, serviceID, yamlContent string) error


### PR DESCRIPTION
## Summary
- `CountPendingConnectionRequests` counted pending rows across the whole instance, so 10 stuck requests from any users would 429 every other agent's `RequestConnect` with `TOO_MANY_PENDING`.
- Renamed to `CountPendingConnectionRequestsForUser(ctx, userID)` and added `AND user_id = ?` in both sqlite and postgres implementations.
- Moved the cap check in `RequestConnect` to run after the owner is resolved, so the limit applies per-user.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/api/... -run TestConnectionRequest`