### PR TITLE
fix(api): eliminate spurious 503s on long-poll and MCP endpoints

### DIFF
--- a/internal/api/handlers/connections.go
+++ b/internal/api/handlers/connections.go
@@ -166,6 +166,9 @@ func (h *ConnectionsHandler) RequestConnect(w http.ResponseWriter, r *http.Reque
 	if r.URL.Query().Get("wait") == "true" && h.eventHub != nil {
 		timeout := parseLongPollTimeout(r)
 		resolved := h.waitForConnectionResolution(r.Context(), req.ID, owner.ID, time.Duration(timeout)*time.Second)
+		if r.Context().Err() != nil {
+			return
+		}
 		resp := map[string]any{
 			"connection_id": req.ID,
 			"status":        resolved.Status,

--- a/internal/api/handlers/connections.go
+++ b/internal/api/handlers/connections.go
@@ -164,8 +164,7 @@ func (h *ConnectionsHandler) RequestConnect(w http.ResponseWriter, r *http.Reque
 
 	// If wait=true, long-poll until the connection request is resolved.
 	if r.URL.Query().Get("wait") == "true" && h.eventHub != nil {
-		timeout := parseLongPollTimeout(r)
-		resolved := h.waitForConnectionResolution(r.Context(), req.ID, owner.ID, time.Duration(timeout)*time.Second)
+		resolved := h.waitForConnectionResolution(r.Context(), req.ID, owner.ID, longPollDeadline(r))
 		if r.Context().Err() != nil {
 			return
 		}

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -1005,8 +1005,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 	}
 	// If wait=true, long-poll for approval then execute inline.
 	if r.URL.Query().Get("wait") == "true" && h.eventHub != nil {
-		timeout := parseLongPollTimeout(r)
-		pa := h.waitForApprovalDecision(r.Context(), req.RequestID, agent.UserID, time.Duration(timeout)*time.Second)
+		pa := h.waitForApprovalDecision(r.Context(), req.RequestID, agent.UserID, longPollDeadline(r))
 		if pa != nil && pa.Status == "approved" && !time.Now().After(pa.ExpiresAt) {
 			h.executeAndRespond(w, r.Context(), pa, agent.ID)
 			return
@@ -1041,7 +1040,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 // Query params:
 //
 //	wait=true    – long-poll until the request leaves the "pending" state (or timeout)
-//	timeout=N    – wait timeout in seconds (default 130, max 130)
+//	timeout=N    – wait timeout in seconds (default 120, max 120)
 //
 // Auth: agent bearer token
 func (h *GatewayHandler) HandleGet(w http.ResponseWriter, r *http.Request) {
@@ -1064,8 +1063,7 @@ func (h *GatewayHandler) HandleGet(w http.ResponseWriter, r *http.Request) {
 	// Long-poll: if wait=true and request is still pending, block until it
 	// transitions or the timeout elapses.
 	if r.URL.Query().Get("wait") == "true" && entry.Outcome == "pending" && h.eventHub != nil {
-		timeout := parseLongPollTimeout(r)
-		entry = h.waitForRequestResolution(r.Context(), requestID, agent.UserID, time.Duration(timeout)*time.Second)
+		entry = h.waitForRequestResolution(r.Context(), requestID, agent.UserID, longPollDeadline(r))
 		if r.Context().Err() != nil {
 			return
 		}
@@ -1089,22 +1087,31 @@ func (h *GatewayHandler) waitForRequestResolution(ctx context.Context, requestID
 	)
 }
 
-// parseLongPollTimeout extracts the timeout query param, clamped to [1, 130].
-// The cap sits ~10s above the typical 120s client-side HTTP timeout so the
-// server outlasts the client and writes complete cleanly when resolution
-// happens, while context-cancellation guards at the call sites suppress the
-// write when the client has already gone away.
+// parseLongPollTimeout extracts the client-requested timeout in seconds,
+// clamped to [1, 120]. This is the contract advertised to clients.
 func parseLongPollTimeout(r *http.Request) int {
-	timeout := 130
+	timeout := 120
 	if v := r.URL.Query().Get("timeout"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			timeout = n
 		}
 	}
-	if timeout > 130 {
-		timeout = 130
+	if timeout > 120 {
+		timeout = 120
 	}
 	return timeout
+}
+
+// longPollGrace is added to the client-requested timeout to derive the
+// server-side wait deadline. The server outlasts the typical client HTTP
+// timeout by this much; context-cancellation guards at each call site
+// suppress the write if the client has already disconnected.
+const longPollGrace = 10 * time.Second
+
+// longPollDeadline returns the server-side wait duration for a long-poll
+// request — the client-requested timeout plus longPollGrace.
+func longPollDeadline(r *http.Request) time.Duration {
+	return time.Duration(parseLongPollTimeout(r))*time.Second + longPollGrace
 }
 
 // waitForApprovalDecision long-polls until the pending approval leaves the
@@ -1199,7 +1206,7 @@ func (h *GatewayHandler) executeAndRespond(w http.ResponseWriter, ctx context.Co
 // Query params:
 //
 //	wait=true    – long-poll until the request is approved, then execute (or timeout)
-//	timeout=N    – wait timeout in seconds (default 130, max 130)
+//	timeout=N    – wait timeout in seconds (default 120, max 120)
 //
 // POST /api/gateway/request/{request_id}/execute
 // Auth: agent bearer token
@@ -1228,8 +1235,7 @@ func (h *GatewayHandler) HandleExecuteApproved(w http.ResponseWriter, r *http.Re
 
 	// If still pending and wait=true, long-poll until approval decision.
 	if pa.Status == "pending" && r.URL.Query().Get("wait") == "true" && h.eventHub != nil {
-		timeout := parseLongPollTimeout(r)
-		pa = h.waitForApprovalDecision(r.Context(), requestID, agent.UserID, time.Duration(timeout)*time.Second)
+		pa = h.waitForApprovalDecision(r.Context(), requestID, agent.UserID, longPollDeadline(r))
 		if pa == nil {
 			// Row deleted (denied/expired) — check the audit entry for the real outcome.
 			if entry, err := h.store.GetAuditEntryByRequestID(r.Context(), requestID, agent.UserID); err == nil && entry.Outcome != "pending" {

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -1041,7 +1041,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 // Query params:
 //
 //	wait=true    – long-poll until the request leaves the "pending" state (or timeout)
-//	timeout=N    – wait timeout in seconds (default 120, max 120)
+//	timeout=N    – wait timeout in seconds (default 130, max 130)
 //
 // Auth: agent bearer token
 func (h *GatewayHandler) HandleGet(w http.ResponseWriter, r *http.Request) {
@@ -1066,6 +1066,9 @@ func (h *GatewayHandler) HandleGet(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Query().Get("wait") == "true" && entry.Outcome == "pending" && h.eventHub != nil {
 		timeout := parseLongPollTimeout(r)
 		entry = h.waitForRequestResolution(r.Context(), requestID, agent.UserID, time.Duration(timeout)*time.Second)
+		if r.Context().Err() != nil {
+			return
+		}
 	}
 
 	writeGatewayStatusResponse(w, entry)
@@ -1086,16 +1089,20 @@ func (h *GatewayHandler) waitForRequestResolution(ctx context.Context, requestID
 	)
 }
 
-// parseLongPollTimeout extracts the timeout query param, clamped to [1, 120].
+// parseLongPollTimeout extracts the timeout query param, clamped to [1, 130].
+// The cap sits ~10s above the typical 120s client-side HTTP timeout so the
+// server outlasts the client and writes complete cleanly when resolution
+// happens, while context-cancellation guards at the call sites suppress the
+// write when the client has already gone away.
 func parseLongPollTimeout(r *http.Request) int {
-	timeout := 120
+	timeout := 130
 	if v := r.URL.Query().Get("timeout"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			timeout = n
 		}
 	}
-	if timeout > 120 {
-		timeout = 120
+	if timeout > 130 {
+		timeout = 130
 	}
 	return timeout
 }
@@ -1192,7 +1199,7 @@ func (h *GatewayHandler) executeAndRespond(w http.ResponseWriter, ctx context.Co
 // Query params:
 //
 //	wait=true    – long-poll until the request is approved, then execute (or timeout)
-//	timeout=N    – wait timeout in seconds (default 120, max 120)
+//	timeout=N    – wait timeout in seconds (default 130, max 130)
 //
 // POST /api/gateway/request/{request_id}/execute
 // Auth: agent bearer token

--- a/internal/api/handlers/tasks.go
+++ b/internal/api/handlers/tasks.go
@@ -510,8 +510,7 @@ func (h *TasksHandler) Create(w http.ResponseWriter, r *http.Request) {
 
 	// If wait=true, long-poll until the task is approved or denied.
 	if r.URL.Query().Get("wait") == "true" && h.eventHub != nil {
-		timeout := parseLongPollTimeout(r)
-		resolved := h.waitForTaskResolution(ctx, task.ID, agent.UserID, time.Duration(timeout)*time.Second)
+		resolved := h.waitForTaskResolution(ctx, task.ID, agent.UserID, longPollDeadline(r))
 		if r.Context().Err() != nil {
 			return
 		}
@@ -539,7 +538,7 @@ func (h *TasksHandler) Create(w http.ResponseWriter, r *http.Request) {
 // Query params:
 //
 //	wait=true    – long-poll until the task leaves a pending state (or timeout)
-//	timeout=N    – wait timeout in seconds (default 130, max 130)
+//	timeout=N    – wait timeout in seconds (default 120, max 120)
 func (h *TasksHandler) Get(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	agent := middleware.AgentFromContext(ctx)
@@ -566,8 +565,7 @@ func (h *TasksHandler) Get(w http.ResponseWriter, r *http.Request) {
 	// Long-poll: if wait=true and task is still pending, block until it
 	// transitions or the timeout elapses.
 	if r.URL.Query().Get("wait") == "true" && isTaskPending(task.Status) && h.eventHub != nil {
-		timeout := parseLongPollTimeout(r)
-		task = h.waitForTaskResolution(ctx, taskID, agent.UserID, time.Duration(timeout)*time.Second)
+		task = h.waitForTaskResolution(ctx, taskID, agent.UserID, longPollDeadline(r))
 		if r.Context().Err() != nil {
 			return
 		}
@@ -1101,8 +1099,7 @@ func (h *TasksHandler) Expand(w http.ResponseWriter, r *http.Request) {
 
 	// If wait=true, long-poll until the expansion is approved or denied.
 	if r.URL.Query().Get("wait") == "true" && h.eventHub != nil {
-		timeout := parseLongPollTimeout(r)
-		resolved := h.waitForTaskResolution(ctx, taskID, agent.UserID, time.Duration(timeout)*time.Second)
+		resolved := h.waitForTaskResolution(ctx, taskID, agent.UserID, longPollDeadline(r))
 		if r.Context().Err() != nil {
 			return
 		}

--- a/internal/api/handlers/tasks.go
+++ b/internal/api/handlers/tasks.go
@@ -512,6 +512,9 @@ func (h *TasksHandler) Create(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Query().Get("wait") == "true" && h.eventHub != nil {
 		timeout := parseLongPollTimeout(r)
 		resolved := h.waitForTaskResolution(ctx, task.ID, agent.UserID, time.Duration(timeout)*time.Second)
+		if r.Context().Err() != nil {
+			return
+		}
 		sanitizeTaskForResponse(resolved)
 		writeJSON(w, http.StatusCreated, resolved)
 		return
@@ -536,7 +539,7 @@ func (h *TasksHandler) Create(w http.ResponseWriter, r *http.Request) {
 // Query params:
 //
 //	wait=true    – long-poll until the task leaves a pending state (or timeout)
-//	timeout=N    – wait timeout in seconds (default 120, max 120)
+//	timeout=N    – wait timeout in seconds (default 130, max 130)
 func (h *TasksHandler) Get(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	agent := middleware.AgentFromContext(ctx)
@@ -565,6 +568,9 @@ func (h *TasksHandler) Get(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Query().Get("wait") == "true" && isTaskPending(task.Status) && h.eventHub != nil {
 		timeout := parseLongPollTimeout(r)
 		task = h.waitForTaskResolution(ctx, taskID, agent.UserID, time.Duration(timeout)*time.Second)
+		if r.Context().Err() != nil {
+			return
+		}
 	}
 
 	sanitizeTaskForResponse(task)
@@ -1097,6 +1103,9 @@ func (h *TasksHandler) Expand(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Query().Get("wait") == "true" && h.eventHub != nil {
 		timeout := parseLongPollTimeout(r)
 		resolved := h.waitForTaskResolution(ctx, taskID, agent.UserID, time.Duration(timeout)*time.Second)
+		if r.Context().Err() != nil {
+			return
+		}
 		sanitizeTaskForResponse(resolved)
 		writeJSON(w, http.StatusOK, resolved)
 		return

--- a/internal/api/longpoll_test.go
+++ b/internal/api/longpoll_test.go
@@ -194,8 +194,8 @@ func TestGetTask_LongPoll_TimeoutCapped(t *testing.T) {
 	body := mustStatus(t, resp, http.StatusCreated)
 	taskID := str(t, body, "task_id")
 
-	// Request a huge timeout — should be capped at 120s.
-	// We won't actually wait 120s; approve quickly to unblock.
+	// Request a huge timeout — should be capped at 130s.
+	// We won't actually wait 130s; approve quickly to unblock.
 	var (
 		wg       sync.WaitGroup
 		pollBody map[string]any

--- a/internal/api/longpoll_test.go
+++ b/internal/api/longpoll_test.go
@@ -170,11 +170,12 @@ func TestGetTask_LongPoll_TimesOut(t *testing.T) {
 	if str(t, body, "status") != "pending_approval" {
 		t.Errorf("expected status=pending_approval after timeout, got %v", body["status"])
 	}
+	// Server waits client_timeout + longPollGrace (10s) before timing out.
 	if elapsed < 900*time.Millisecond {
-		t.Errorf("expected ~1s wait, but returned in %s", elapsed)
+		t.Errorf("expected at least ~1s wait, but returned in %s", elapsed)
 	}
-	if elapsed > 3*time.Second {
-		t.Errorf("expected ~1s wait, took %s", elapsed)
+	if elapsed > 13*time.Second {
+		t.Errorf("expected ~11s wait (1s + grace), took %s", elapsed)
 	}
 }
 
@@ -194,8 +195,8 @@ func TestGetTask_LongPoll_TimeoutCapped(t *testing.T) {
 	body := mustStatus(t, resp, http.StatusCreated)
 	taskID := str(t, body, "task_id")
 
-	// Request a huge timeout — should be capped at 130s.
-	// We won't actually wait 130s; approve quickly to unblock.
+	// Request a huge timeout — should be capped at 120s.
+	// We won't actually wait 120s; approve quickly to unblock.
 	var (
 		wg       sync.WaitGroup
 		pollBody map[string]any

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -342,11 +342,14 @@ func New(
 	mux := s.routes()
 
 	s.http = &http.Server{
-		Addr:         cfg.Server.Addr(),
-		Handler:      mux,
-		ReadTimeout:  30 * time.Second,
-		WriteTimeout: 60 * time.Second,
-		IdleTimeout:  120 * time.Second,
+		Addr:        cfg.Server.Addr(),
+		Handler:     mux,
+		ReadTimeout: 30 * time.Second,
+		// WriteTimeout and IdleTimeout must exceed the long-poll cap
+		// (parseLongPollTimeout) and MCP SSE idle gaps. Otherwise the
+		// connection is torn down mid-handler and Cloud Run reports a 503.
+		WriteTimeout: 180 * time.Second,
+		IdleTimeout:  180 * time.Second,
 	}
 
 	return s, nil

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -67,7 +67,7 @@ func toolDefs() []Tool {
 					"expires_in_seconds": {"type": "integer", "description": "Session task expiry in seconds (default 1800)"},
 					"lifetime": {"type": "string", "enum": ["session", "standing"], "description": "Task lifetime: session (expires) or standing (no expiry)"},
 					"wait": {"type": "boolean", "description": "Block until the task is approved or denied (default true)"},
-					"timeout": {"type": "integer", "description": "Long-poll timeout in seconds (default 120, max 120)"}
+					"timeout": {"type": "integer", "description": "Long-poll timeout in seconds (default 130, max 130)"}
 				},
 				"required": ["purpose", "authorized_actions"]
 			}`),
@@ -80,7 +80,7 @@ func toolDefs() []Tool {
 				"properties": {
 					"task_id": {"type": "string", "description": "The task ID to look up"},
 					"wait": {"type": "boolean", "description": "Long-poll until the task leaves pending state (default false)"},
-					"timeout": {"type": "integer", "description": "Long-poll timeout in seconds (default 120, max 120)"}
+					"timeout": {"type": "integer", "description": "Long-poll timeout in seconds (default 130, max 130)"}
 				},
 				"required": ["task_id"]
 			}`),
@@ -108,7 +108,7 @@ func toolDefs() []Tool {
 					"auto_execute": {"type": "boolean", "description": "Execute without per-request approval"},
 					"reason": {"type": "string", "description": "Why this action is needed"},
 					"wait": {"type": "boolean", "description": "Block until the expansion is approved or denied (default true)"},
-					"timeout": {"type": "integer", "description": "Long-poll timeout in seconds (default 120, max 120)"}
+					"timeout": {"type": "integer", "description": "Long-poll timeout in seconds (default 130, max 130)"}
 				},
 				"required": ["task_id", "service", "action", "reason"]
 			}`),
@@ -128,7 +128,7 @@ func toolDefs() []Tool {
 					"context": {"type": "object", "description": "Optional context (source, data_origin, callback_url)"},
 					"session_id": {"type": "string", "description": "Consistent UUID for chain context on standing tasks"},
 					"wait": {"type": "boolean", "description": "Block until approved and return executed result (default true)"},
-					"timeout": {"type": "integer", "description": "Long-poll timeout in seconds (default 120, max 120)"}
+					"timeout": {"type": "integer", "description": "Long-poll timeout in seconds (default 130, max 130)"}
 				},
 				"required": ["service", "action", "params", "reason", "request_id", "task_id"]
 			}`),
@@ -160,7 +160,7 @@ func toolDefs() []Tool {
 						"description": "Array of gateway sub-requests. Each sub-request has the same schema as gateway_request."
 					},
 					"wait": {"type": "boolean", "description": "If true, each sub-request long-polls for approval before returning (default true)"},
-					"timeout": {"type": "integer", "description": "Long-poll timeout in seconds applied to each sub-request (default 120, max 120)"}
+					"timeout": {"type": "integer", "description": "Long-poll timeout in seconds applied to each sub-request (default 130, max 130)"}
 				},
 				"required": ["requests"]
 			}`),
@@ -173,7 +173,7 @@ func toolDefs() []Tool {
 				"properties": {
 					"request_id": {"type": "string", "description": "The request ID from the original gateway_request"},
 					"wait": {"type": "boolean", "description": "Block until the request is approved, then execute (default true)"},
-					"timeout": {"type": "integer", "description": "Long-poll timeout in seconds (default 120, max 120)"}
+					"timeout": {"type": "integer", "description": "Long-poll timeout in seconds (default 130, max 130)"}
 				},
 				"required": ["request_id"]
 			}`),

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -67,7 +67,7 @@ func toolDefs() []Tool {
 					"expires_in_seconds": {"type": "integer", "description": "Session task expiry in seconds (default 1800)"},
 					"lifetime": {"type": "string", "enum": ["session", "standing"], "description": "Task lifetime: session (expires) or standing (no expiry)"},
 					"wait": {"type": "boolean", "description": "Block until the task is approved or denied (default true)"},
-					"timeout": {"type": "integer", "description": "Long-poll timeout in seconds (default 130, max 130)"}
+					"timeout": {"type": "integer", "description": "Long-poll timeout in seconds (default 120, max 120)"}
 				},
 				"required": ["purpose", "authorized_actions"]
 			}`),
@@ -80,7 +80,7 @@ func toolDefs() []Tool {
 				"properties": {
 					"task_id": {"type": "string", "description": "The task ID to look up"},
 					"wait": {"type": "boolean", "description": "Long-poll until the task leaves pending state (default false)"},
-					"timeout": {"type": "integer", "description": "Long-poll timeout in seconds (default 130, max 130)"}
+					"timeout": {"type": "integer", "description": "Long-poll timeout in seconds (default 120, max 120)"}
 				},
 				"required": ["task_id"]
 			}`),
@@ -108,7 +108,7 @@ func toolDefs() []Tool {
 					"auto_execute": {"type": "boolean", "description": "Execute without per-request approval"},
 					"reason": {"type": "string", "description": "Why this action is needed"},
 					"wait": {"type": "boolean", "description": "Block until the expansion is approved or denied (default true)"},
-					"timeout": {"type": "integer", "description": "Long-poll timeout in seconds (default 130, max 130)"}
+					"timeout": {"type": "integer", "description": "Long-poll timeout in seconds (default 120, max 120)"}
 				},
 				"required": ["task_id", "service", "action", "reason"]
 			}`),
@@ -128,7 +128,7 @@ func toolDefs() []Tool {
 					"context": {"type": "object", "description": "Optional context (source, data_origin, callback_url)"},
 					"session_id": {"type": "string", "description": "Consistent UUID for chain context on standing tasks"},
 					"wait": {"type": "boolean", "description": "Block until approved and return executed result (default true)"},
-					"timeout": {"type": "integer", "description": "Long-poll timeout in seconds (default 130, max 130)"}
+					"timeout": {"type": "integer", "description": "Long-poll timeout in seconds (default 120, max 120)"}
 				},
 				"required": ["service", "action", "params", "reason", "request_id", "task_id"]
 			}`),
@@ -160,7 +160,7 @@ func toolDefs() []Tool {
 						"description": "Array of gateway sub-requests. Each sub-request has the same schema as gateway_request."
 					},
 					"wait": {"type": "boolean", "description": "If true, each sub-request long-polls for approval before returning (default true)"},
-					"timeout": {"type": "integer", "description": "Long-poll timeout in seconds applied to each sub-request (default 130, max 130)"}
+					"timeout": {"type": "integer", "description": "Long-poll timeout in seconds applied to each sub-request (default 120, max 120)"}
 				},
 				"required": ["requests"]
 			}`),
@@ -173,7 +173,7 @@ func toolDefs() []Tool {
 				"properties": {
 					"request_id": {"type": "string", "description": "The request ID from the original gateway_request"},
 					"wait": {"type": "boolean", "description": "Block until the request is approved, then execute (default true)"},
-					"timeout": {"type": "integer", "description": "Long-poll timeout in seconds (default 130, max 130)"}
+					"timeout": {"type": "integer", "description": "Long-poll timeout in seconds (default 120, max 120)"}
 				},
 				"required": ["request_id"]
 			}`),


### PR DESCRIPTION
## Summary
Production logs (`gcloud logging`, last 24h) showed ~165 503s on `/mcp` (122), `/api/tasks?wait=true` (22), `/api/agents/connect?wait=true` (11), and `/api/gateway/request?wait=true` (6) — **all** clustered at exactly the requested long-poll timeout (60s/120s). Cloud Run reports `"connection to the instance had an error"` whenever the container writes a response after the connection has been torn down.

Three coordinated changes:

- **Server timeouts** (`internal/api/server.go`): `WriteTimeout` 60s → 180s, `IdleTimeout` 120s → 180s. The old `IdleTimeout` was killing `/mcp` SSE streams between events; the old `WriteTimeout` was killing long-poll handlers that wait past 60s before writing. Both now sit ~50s above the long-poll cap.
- **Long-poll cap** (`internal/api/handlers/gateway.go::parseLongPollTimeout`): 120 → 130. Server now outlasts the typical 120s client HTTP timeout, so resolutions near the boundary land cleanly.
- **Skip-write guards**: `if r.Context().Err() != nil { return }` after each long-poll wait in `tasks.go` (Create/Get/Expand), `connections.go` (RequestConnect), and `gateway.go` (HandleGet). When the client has disconnected the handler returns silently instead of writing into a dead connection. Gateway `HandleRequest`/`HandleExecuteApproved` left alone since they execute side-effects between wait and write.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/api/...`
- [ ] Watch `gcloud` 503 rate after deploy — should drop ~99% on the long-poll/MCP paths