### PR TITLE
fix: Cross-tenant adapter overwrite in generated adapter installation

### DIFF
--- a/internal/adaptergen/generator.go
+++ b/internal/adaptergen/generator.go
@@ -158,7 +158,7 @@ func (g *Generator) Install(ctx context.Context, yamlContent string) (*GenerateR
 // Update regenerates an existing adapter from new source material.
 // The old adapter is replaced in-place.
 func (g *Generator) Update(ctx context.Context, serviceID string, src Source) (*GenerateResult, error) {
-	if _, ok := g.registry.Get(serviceID); !ok {
+	if _, ok := g.registry.GetForUser(ctx, serviceID, g.userID); !ok {
 		return nil, fmt.Errorf("adapter %q not found in registry", serviceID)
 	}
 
@@ -243,6 +243,15 @@ func (g *Generator) classifyRisk(ctx context.Context, rawYAML string) (string, e
 
 // install persists the YAML via the adapter store and hot-loads the adapter into the registry.
 func (g *Generator) install(ctx context.Context, def yamldef.ServiceDef, yamlContent string) error {
+	// In per-user (cloud/tenant) mode, refuse to overwrite a built-in service ID.
+	// The shared registry is populated with built-ins at startup, so any hit here
+	// means the user is attempting to shadow a built-in adapter for every tenant.
+	if g.userID != "" {
+		if _, ok := g.registry.Get(def.Service.ID); ok {
+			return fmt.Errorf("service ID %q conflicts with a built-in adapter", def.Service.ID)
+		}
+	}
+
 	if err := g.store.Save(ctx, def.Service.ID, yamlContent); err != nil {
 		return fmt.Errorf("saving adapter: %w", err)
 	}
@@ -252,7 +261,11 @@ func (g *Generator) install(ctx context.Context, def yamldef.ServiceDef, yamlCon
 	if err != nil {
 		return fmt.Errorf("building adapter from definition: %w", err)
 	}
+	if g.userID != "" {
+		g.registry.ReplaceForUser(def.Service.ID, g.userID, adapter)
+	} else {
 	g.registry.Replace(adapter)
+	}
 
 	return nil
 }

--- a/pkg/adapters/adapters.go
+++ b/pkg/adapters/adapters.go
@@ -353,6 +353,18 @@ func (r *Registry) Replace(a Adapter) {
 	r.adapters[a.ServiceID()] = a
 }
 
+// ReplaceForUser stores (or replaces) a user-scoped adapter in the per-user
+// cache. Used for hot-reload of user-generated (per-tenant) adapters without
+// leaking them into the shared registry.
+func (r *Registry) ReplaceForUser(serviceID, userID string, a Adapter) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.userAdapters[userID] == nil {
+		r.userAdapters[userID] = make(map[string]Adapter)
+	}
+	r.userAdapters[userID][serviceID] = a
+}
+
 // Remove deletes an adapter from the shared registry by service ID.
 func (r *Registry) Remove(serviceID string) {
 	r.mu.Lock()


### PR DESCRIPTION
Closes #301

## Summary

Automated security fix for **Cross-tenant adapter overwrite in generated adapter installation** (Critical).

**CWE**: CWE-CWE-284
**OWASP**: A01:2021-Broken Access Control
**Fix Confidence**: high

## What Changed
Fixes cross-tenant adapter overwrite in cloud (per-user) mode.

1. `pkg/adapters/adapters.go`: Added `ReplaceForUser(serviceID, userID, adapter)` that stores a hot-loaded adapter only in the per-user map, never in the shared registry.

2. `internal/adaptergen/generator.go`:
   - `install()` now routes to `ReplaceForUser` whenever `g.userID != ""`, so a cloud user's generated adapter cannot take over the shared registry that every tenant resolves through. It also rejects any service ID that collides with an existing built-in (shared) adapter, preventing a user from shadowing e.g. `google.gmail` or `github` for their own account or abusing the shared codepath.
   - `Update()` now uses `GetForUser` so the existence check still works after per-user adapters are kept out of the shared registry.

`Remove()` already used per-user removal; combined with the install-side change, the removal scope now matches the installation scope.

## Caveats
- The fix assumes any built-in adapter is already registered in the shared registry before a user-scoped Install is called. Built-ins are registered at server startup in pkg/clawvisor/defaults.go, which precedes any HTTP install call, so this invariant holds.
- Existing poisoned entries in the shared registry (if any already replaced a built-in via the pre-patch install path) will not be cleaned up automatically; a process restart reloads built-ins from disk/embedded FS and clears them.
- Two different users can still pick the same non-built-in service ID in their own DBStore; they are now isolated per-user in both the store and the registry cache, so this is no longer a cross-tenant issue.

## Verification Checklist

- [ ] Review the code change
- [ ] Run tests to verify no regression
- [x] Verify the vulnerability is addressed — *already verified by Cerberus Sentinel*

---
*Created by [Cerberus](https://github.com/Donjon-Cerberus) Merlin*
