### PR TITLE
fix: separate TUI config from daemon config

### DIFF
--- a/cmd/clawvisor/cmd_tui.go
+++ b/cmd/clawvisor/cmd_tui.go
@@ -149,7 +149,7 @@ func readLocalSession() (*localSessionFile, error) {
 	return &sess, nil
 }
 
-// saveRefreshToken persists the refresh token to ~/.clawvisor/config.yaml
+// saveRefreshToken persists the refresh token to ~/.clawvisor/tui.yaml
 // so subsequent TUI launches can use it directly.
 func saveRefreshToken(serverURL, refreshToken string) {
 	cfgPath, err := tuiconfig.DefaultPath()

--- a/docs/SETUP_LOCAL.md
+++ b/docs/SETUP_LOCAL.md
@@ -103,7 +103,7 @@ This covers:
 - **iMessage** — macOS only, reads the local `chat.db`
 
 The wizard generates `config.yaml` in the repository root and writes
-`~/.clawvisor/config.yaml` with the server URL so the TUI knows where to
+`~/.clawvisor/tui.yaml` with the server URL so the TUI knows where to
 connect.
 
 **If the setup wizard cannot run** (e.g. no interactive terminal), skip to the
@@ -180,12 +180,12 @@ cd "$CLAWVISOR_REPO" && make tui
 
 The TUI auto-authenticates using `~/.clawvisor/.local-session` written by the
 server in Step 4. On first launch it exchanges the session token for a refresh
-token and saves it to `~/.clawvisor/config.yaml` for future use.
+token and saves it to `~/.clawvisor/tui.yaml` for future use.
 
 Verify it connects:
 
 ```bash
-ls ~/.clawvisor/config.yaml 2>/dev/null
+ls ~/.clawvisor/tui.yaml 2>/dev/null
 ```
 
 ---

--- a/internal/tui/config/config.go
+++ b/internal/tui/config/config.go
@@ -14,7 +14,7 @@ type Profile struct {
 	Token     string `yaml:"token"`
 }
 
-// Config is the TUI configuration file (~/.clawvisor/config.yaml).
+// Config is the TUI configuration file (~/.clawvisor/tui.yaml).
 type Config struct {
 	Profiles      map[string]Profile `yaml:"profiles"`
 	ActiveProfile string             `yaml:"active_profile"`
@@ -30,13 +30,13 @@ func DefaultDir() (string, error) {
 	return filepath.Join(home, ".clawvisor"), nil
 }
 
-// DefaultPath returns ~/.clawvisor/config.yaml.
+// DefaultPath returns ~/.clawvisor/tui.yaml.
 func DefaultPath() (string, error) {
 	dir, err := DefaultDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(dir, "config.yaml"), nil
+	return filepath.Join(dir, "tui.yaml"), nil
 }
 
 // Load reads the config file at path. Returns an error if the file doesn't exist.


### PR DESCRIPTION
Closes #304

## Summary
Move the TUI client config off `~/.clawvisor/config.yaml` and onto `~/.clawvisor/tui.yaml`.

## Why
The daemon/server config and the TUI config currently use incompatible schemas but share the same path. Running the TUI can overwrite daemon config with TUI profile data.

## Changes
- change TUI default config path to `~/.clawvisor/tui.yaml`
- update TUI refresh-token persistence comment
- update setup docs to reference the new TUI config file

## Notes
I did not add migration logic in this patch. In the current broken state, running the TUI already rewrites the old path, so separating the files is the urgent fix with the smallest diff.

## Verification
- `go test ./internal/tui/config ./cmd/clawvisor/...`