### PR TITLE
fix(calendar): surface attachments and hangoutLink in event responses

### DIFF
--- a/internal/adapters/definitions/google_calendar.yaml
+++ b/internal/adapters/definitions/google_calendar.yaml
@@ -57,6 +57,7 @@ actions:
       page_token: { type: string, map_to: pageToken, location: query }
       single_events: { type: string, default: "true", map_to: singleEvents, location: query }
       order_by: { type: string, default: "startTime", map_to: orderBy, location: query }
+      supports_attachments: { type: bool, default: true, map_to: supportsAttachments, location: query }
     response:
       data_path: "items"
       fields:
@@ -70,6 +71,12 @@ actions:
         - { name: description, sanitize: true, optional: true }
         - name: attendees
           expr: "attendees"
+          optional: true
+        - name: attachments
+          expr: "attachments"
+          optional: true
+        - name: hangoutLink
+          expr: "hangoutLink"
           optional: true
         - { name: status }
       meta:
@@ -85,6 +92,7 @@ actions:
     params:
       event_id: { type: string, required: true, location: path }
       calendar_id: { type: string, default: "primary", location: path }
+      supports_attachments: { type: bool, default: true, map_to: supportsAttachments, location: query }
     response:
       fields:
         - { name: id }
@@ -96,6 +104,12 @@ actions:
         - { name: location, sanitize: true }
         - { name: description, sanitize: true }
         - { name: attendees }
+        - name: attachments
+          expr: "attachments"
+          optional: true
+        - name: hangoutLink
+          expr: "hangoutLink"
+          optional: true
         - name: transparency
           expr: "transparency ?? 'opaque'"
         - name: visibility


### PR DESCRIPTION
## Summary

Google Calendar's `list_events` and `get_event` were stripping attachments and `hangoutLink` from responses, so doc/meeting links attached to events surfaced as empty `{}` downstream. This PR:

- Adds `attachments` and `hangoutLink` to the response schemas of both actions
- Adds a `supports_attachments=true` query param that maps to Google's `supportsAttachments` — required for the API to actually include attachment metadata in the response (it's omitted by default)

Reported by a power user on the YC team whose agent kept seeing `{}` where Google Doc links should have appeared in event descriptions.

## Test plan

- [ ] Create a calendar event with a Google Doc attachment
- [ ] Call `list_events` and verify the `attachments` field is populated with the doc URL
- [ ] Call `get_event` for that event and verify the same
- [ ] Confirm `hangoutLink` populates on events with a Meet link

🤖 Generated with [Claude Code](https://claude.com/claude-code)