### PR TITLE
fix(backcompat): must-fix safety nets for #310 (audit/gateway/restrictions/tasks)

### DIFF
--- a/internal/api/handlers/audit.go
+++ b/internal/api/handlers/audit.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/clawvisor/clawvisor/internal/api/middleware"
 	"github.com/clawvisor/clawvisor/pkg/store"
@@ -326,17 +327,67 @@ func stripSecretsNode(value any) any {
 	}
 }
 
+// looksSecretKey reports whether a JSON key likely contains a credential.
+//
+// The matcher splits the key on separators and camelCase boundaries, then
+// matches whole tokens against a small allowlist. This avoids the false
+// positives the prior substring matcher produced (e.g. it stripped
+// "oauth_endpoint" because it contained "auth", and "author" for the same
+// reason). "oauth" alone is not treated as a secret marker — it's the
+// protocol name; "oauth_token" still matches because the "token" token does.
 func looksSecretKey(key string) bool {
-	lower := strings.ToLower(strings.TrimSpace(key))
-	for _, pattern := range []string{
-		"token", "secret", "password", "passwd", "credential", "auth",
-		"api_key", "apikey", "access_key", "private_key", "bearer",
-	} {
-		if strings.Contains(lower, pattern) {
+	tokens := tokenizeSecretKey(key)
+	for _, t := range tokens {
+		switch t {
+		case "token", "tokens",
+			"secret", "secrets",
+			"password", "passwd",
+			"credential", "credentials",
+			"auth", "authorization",
+			"bearer",
+			"apikey", "accesskey", "privatekey":
+			return true
+		}
+	}
+	for i := 0; i < len(tokens)-1; i++ {
+		if tokens[i+1] != "key" {
+			continue
+		}
+		switch tokens[i] {
+		case "api", "access", "private":
 			return true
 		}
 	}
 	return false
+}
+
+// tokenizeSecretKey splits a JSON key into lowercase tokens, treating both
+// non-alphanumeric separators ("_", "-", ".", " ") and camelCase boundaries
+// ("apiKey" → "api","key") as token splits.
+func tokenizeSecretKey(key string) []string {
+	var tokens []string
+	var cur []rune
+	var prev rune
+	flush := func() {
+		if len(cur) > 0 {
+			tokens = append(tokens, strings.ToLower(string(cur)))
+			cur = cur[:0]
+		}
+	}
+	for i, r := range key {
+		switch {
+		case !unicode.IsLetter(r) && !unicode.IsDigit(r):
+			flush()
+		case i > 0 && unicode.IsUpper(r) && unicode.IsLower(prev):
+			flush()
+			cur = append(cur, r)
+		default:
+			cur = append(cur, r)
+		}
+		prev = r
+	}
+	flush()
+	return tokens
 }
 
 func compactParts(values ...string) []string {

--- a/internal/api/handlers/audit.go
+++ b/internal/api/handlers/audit.go
@@ -361,9 +361,12 @@ func looksSecretKey(key string) bool {
 	return false
 }
 
-// tokenizeSecretKey splits a JSON key into lowercase tokens, treating both
-// non-alphanumeric separators ("_", "-", ".", " ") and camelCase boundaries
-// ("apiKey" → "api","key") as token splits.
+// tokenizeSecretKey splits a JSON key into lowercase tokens at separator,
+// camelCase, and letter↔digit boundaries so that names like "apiKey",
+// "oauth2Token", or "api_v2_token" all surface their semantic words for
+// allowlist matching. Without the digit-boundary split, "oauth2Token"
+// would collapse to a single token "oauth2token" and bypass the "token"
+// match.
 func tokenizeSecretKey(key string) []string {
 	var tokens []string
 	var cur []rune
@@ -379,6 +382,10 @@ func tokenizeSecretKey(key string) []string {
 		case !unicode.IsLetter(r) && !unicode.IsDigit(r):
 			flush()
 		case i > 0 && unicode.IsUpper(r) && unicode.IsLower(prev):
+			flush()
+			cur = append(cur, r)
+		case i > 0 && unicode.IsLetter(r) && unicode.IsDigit(prev),
+			i > 0 && unicode.IsDigit(r) && unicode.IsLetter(prev):
 			flush()
 			cur = append(cur, r)
 		default:

--- a/internal/api/handlers/audit_test.go
+++ b/internal/api/handlers/audit_test.go
@@ -172,6 +172,49 @@ func TestAuditHandlerNormalizesRuntimeToolUseURLSummary(t *testing.T) {
 	}
 }
 
+func TestLooksSecretKeyTokenBoundary(t *testing.T) {
+	cases := []struct {
+		key  string
+		want bool
+	}{
+		// Should match — direct credential keys.
+		{"token", true},
+		{"access_token", true},
+		{"refresh_token", true},
+		{"oauth_token", true},
+		{"Authorization", true},
+		{"authorization", true},
+		{"auth", true},
+		{"auth_header", true},
+		{"api_key", true},
+		{"apiKey", true},
+		{"x-api-key", true},
+		{"access_key", true},
+		{"private_key", true},
+		{"privateKey", true},
+		{"client_secret", true},
+		{"password", true},
+		{"bearer", true},
+
+		// Should NOT match — historical false positives from substring matcher.
+		{"oauth_endpoint", false},
+		{"oauth_url", false},
+		{"oauth_state", false},
+		{"author", false},
+		{"authority", false},
+		{"authentication_method", false}, // method name, not secret
+		{"keypath", false},
+		{"keyboard", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.key, func(t *testing.T) {
+			if got := looksSecretKey(tc.key); got != tc.want {
+				t.Fatalf("looksSecretKey(%q) = %v, want %v", tc.key, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestAuditHandlerStripsSecretsFromLegacyParamsSafeAtReadTime(t *testing.T) {
 	ctx := context.Background()
 	db, err := sqlite.New(ctx, filepath.Join(t.TempDir(), "audit-redaction.db"))

--- a/internal/api/handlers/audit_test.go
+++ b/internal/api/handlers/audit_test.go
@@ -196,6 +196,13 @@ func TestLooksSecretKeyTokenBoundary(t *testing.T) {
 		{"password", true},
 		{"bearer", true},
 
+		// Versioned key names — must split on letter↔digit boundaries so
+		// the semantic word still surfaces to the allowlist.
+		{"oauth2Token", true},
+		{"oauth2_token", true},
+		{"v2AccessToken", true},
+		{"oauth2_password", true},
+
 		// Should NOT match — historical false positives from substring matcher.
 		{"oauth_endpoint", false},
 		{"oauth_url", false},

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -361,10 +361,16 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 
 	// ── Step 2: Task context resolution ──────────────────────────────────────
 	if req.TaskID == "" {
-		// When classification is gated off (the default), a missing task_id is
-		// always a 400. Skip the classifier — older clients depend on the
-		// TASK_REQUIRED error contract.
-		if !h.cfg.Gateway.ClassifyMissingTaskID {
+		// Behavior change in #310: when the runtime proxy is enabled, a missing
+		// task_id triggers task classification instead of an immediate 400.
+		// Classification can reuse an active task, return 409 ambiguous_task,
+		// or return 202 pending while routing the request to approval.
+		//
+		// When the runtime proxy is disabled (legacy gateway-only deploys),
+		// keep the long-standing TASK_REQUIRED contract so older clients that
+		// always send task_id and treat its absence as a programmer error
+		// continue to work without surprise.
+		if !h.cfg.RuntimeProxy.Enabled {
 			e := baseEntry("reject", "validation_error", nil)
 			e.DurationMS = int(time.Since(start).Milliseconds())
 			errMsg := "missing required field: task_id"

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -361,6 +361,32 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 
 	// ── Step 2: Task context resolution ──────────────────────────────────────
 	if req.TaskID == "" {
+		// When classification is gated off (the default), a missing task_id is
+		// always a 400. Skip the classifier — older clients depend on the
+		// TASK_REQUIRED error contract.
+		if !h.cfg.Gateway.ClassifyMissingTaskID {
+			e := baseEntry("reject", "validation_error", nil)
+			e.DurationMS = int(time.Since(start).Milliseconds())
+			errMsg := "missing required field: task_id"
+			e.ErrorMsg = &errMsg
+			if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+				h.logger.Warn("audit log failed", "err", logErr)
+			}
+			writeDetailedError(w, http.StatusBadRequest, apiErrorDetail{
+				Error:         errMsg,
+				Code:          "TASK_REQUIRED",
+				MissingFields: []string{"task_id"},
+				Hint:          "Create a task first via POST /api/tasks, then include the returned task_id in every gateway request.",
+				Example: map[string]any{
+					"service": "google.gmail",
+					"action":  "list_messages",
+					"reason":  "Fetch recent emails to summarize for the user",
+					"task_id": "<task_id from POST /api/tasks>",
+				},
+			})
+			return
+		}
+
 		tasks, _, err := h.store.ListTasks(ctx, agent.UserID, store.TaskFilter{ActiveOnly: true})
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not load active tasks")

--- a/internal/api/handlers/restrictions.go
+++ b/internal/api/handlers/restrictions.go
@@ -119,6 +119,19 @@ func (h *RestrictionsHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Dual-write to the legacy restrictions table so a downgrade to a pre-merge
+	// build still sees rules created on this version. Best-effort: a duplicate
+	// row in the legacy table is fine, and any other failure is non-fatal.
+	if _, err := h.st.CreateRestriction(r.Context(), &store.Restriction{
+		ID:      rule.ID,
+		UserID:  user.ID,
+		Service: req.Service,
+		Action:  req.Action,
+		Reason:  rule.Reason,
+	}); err != nil && err != store.ErrConflict {
+		// Do not fail the request — the runtime policy rule is the source of truth.
+	}
+
 	created, err := h.st.GetRuntimePolicyRule(r.Context(), rule.ID)
 	if err != nil {
 		writeJSON(w, http.StatusCreated, serviceRuleToRestriction(rule))
@@ -161,6 +174,9 @@ func (h *RestrictionsHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not delete restriction")
 		return
 	}
+
+	// Best-effort: also delete the dual-written legacy row if present.
+	_ = h.st.DeleteRestriction(r.Context(), id, user.ID)
 
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/internal/api/handlers/tasks.go
+++ b/internal/api/handlers/tasks.go
@@ -161,12 +161,42 @@ func (h *TasksHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if len(req.PlannedCalls) > 0 && len(req.AuthorizedActions) == 0 {
-		writeDetailedError(w, http.StatusBadRequest, apiErrorDetail{
-			Error: "planned_calls requires authorized_actions",
-			Code:  "INVALID_REQUEST",
-			Hint:  "planned_calls are matched against authorized_actions and are only supported on adapter-backed task scopes.",
-		})
-		return
+		// Pre-merge the gateway tolerated planned_calls without authorized_actions
+		// (the planned calls were stored as risk-assessment metadata and the
+		// scope was inferred elsewhere). To avoid breaking existing clients,
+		// auto-derive a scope from the planned call (service, action) pairs and
+		// log a deprecation. Callers should send authorized_actions explicitly —
+		// this fallback may be removed in a future release.
+		seen := make(map[string]struct{}, len(req.PlannedCalls))
+		for _, pc := range req.PlannedCalls {
+			service := strings.TrimSpace(pc.Service)
+			action := strings.TrimSpace(pc.Action)
+			if service == "" || action == "" {
+				continue
+			}
+			key := service + ":" + action
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			req.AuthorizedActions = append(req.AuthorizedActions, store.TaskAction{
+				Service:     service,
+				Action:      action,
+				AutoExecute: false,
+			})
+		}
+		if len(req.AuthorizedActions) == 0 {
+			writeDetailedError(w, http.StatusBadRequest, apiErrorDetail{
+				Error: "planned_calls requires authorized_actions",
+				Code:  "INVALID_REQUEST",
+				Hint:  "Each planned_call must have non-empty service and action, or set authorized_actions explicitly.",
+			})
+			return
+		}
+		h.logger.Warn("deprecated: task created with planned_calls but no authorized_actions; deriving scope from planned_calls",
+			"agent_id", agent.ID,
+			"derived_scope_count", len(req.AuthorizedActions),
+		)
 	}
 
 	schemaVersion := req.SchemaVersion

--- a/internal/api/testutil_test.go
+++ b/internal/api/testutil_test.go
@@ -79,9 +79,10 @@ func newTestEnvWithLLM(t *testing.T, llmCfg config.LLMConfig, extra ...adapters.
 		Approval: config.ApprovalConfig{Timeout: 300, OnTimeout: "fail"},
 		Task:     config.TaskConfig{DefaultExpirySeconds: 3600},
 		// Tests cover the missing-task_id classification path (TestGateway_NoTaskID_*),
-		// which is opt-in in production. Enable it here so the existing tests exercise
-		// the feature without needing per-test config plumbing.
-		Gateway: config.GatewayConfig{ClassifyMissingTaskID: true},
+		// which only runs when the runtime proxy is enabled. Flip the bit so the
+		// existing tests exercise the feature; we don't actually start a proxy
+		// listener in these tests, only the gateway handler reads the flag.
+		RuntimeProxy: config.RuntimeProxyConfig{Enabled: true},
 	}
 
 	// Tests use password auth so Register/Login routes are available.
@@ -144,9 +145,10 @@ func newMagicLinkTestEnv(t *testing.T) *magicLinkTestEnv {
 		Approval: config.ApprovalConfig{Timeout: 300, OnTimeout: "fail"},
 		Task:     config.TaskConfig{DefaultExpirySeconds: 3600},
 		// Tests cover the missing-task_id classification path (TestGateway_NoTaskID_*),
-		// which is opt-in in production. Enable it here so the existing tests exercise
-		// the feature without needing per-test config plumbing.
-		Gateway: config.GatewayConfig{ClassifyMissingTaskID: true},
+		// which only runs when the runtime proxy is enabled. Flip the bit so the
+		// existing tests exercise the feature; we don't actually start a proxy
+		// listener in these tests, only the gateway handler reads the flag.
+		RuntimeProxy: config.RuntimeProxyConfig{Enabled: true},
 	}
 
 	ms := auth.NewMagicTokenStore()

--- a/internal/api/testutil_test.go
+++ b/internal/api/testutil_test.go
@@ -78,6 +78,10 @@ func newTestEnvWithLLM(t *testing.T, llmCfg config.LLMConfig, extra ...adapters.
 		},
 		Approval: config.ApprovalConfig{Timeout: 300, OnTimeout: "fail"},
 		Task:     config.TaskConfig{DefaultExpirySeconds: 3600},
+		// Tests cover the missing-task_id classification path (TestGateway_NoTaskID_*),
+		// which is opt-in in production. Enable it here so the existing tests exercise
+		// the feature without needing per-test config plumbing.
+		Gateway: config.GatewayConfig{ClassifyMissingTaskID: true},
 	}
 
 	// Tests use password auth so Register/Login routes are available.
@@ -139,6 +143,10 @@ func newMagicLinkTestEnv(t *testing.T) *magicLinkTestEnv {
 		},
 		Approval: config.ApprovalConfig{Timeout: 300, OnTimeout: "fail"},
 		Task:     config.TaskConfig{DefaultExpirySeconds: 3600},
+		// Tests cover the missing-task_id classification path (TestGateway_NoTaskID_*),
+		// which is opt-in in production. Enable it here so the existing tests exercise
+		// the feature without needing per-test config plumbing.
+		Gateway: config.GatewayConfig{ClassifyMissingTaskID: true},
 	}
 
 	ms := auth.NewMagicTokenStore()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -48,6 +48,13 @@ type Config struct {
 type GatewayConfig struct {
 	ContentDedupTTLSeconds int `yaml:"content_dedup_ttl_seconds"` // default: 5
 	NPSSamplePercent       int `yaml:"nps_sample_percent"`        // 0-100, default: 1
+	// ClassifyMissingTaskID controls behavior when a gateway request omits task_id.
+	// When false (default), the request is rejected with 400 TASK_REQUIRED — the
+	// long-standing behavior, preserved on upgrade so older clients keep working.
+	// When true, the gateway runs task classification: it may reuse an active task,
+	// return 409 ambiguous_task, or 202 pending while routing the request to
+	// approval. Opt in only when downstream clients are prepared for the new shape.
+	ClassifyMissingTaskID bool `yaml:"classify_missing_task_id"`
 }
 
 // RelayConfig holds settings for the cloud relay connection.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -48,13 +48,6 @@ type Config struct {
 type GatewayConfig struct {
 	ContentDedupTTLSeconds int `yaml:"content_dedup_ttl_seconds"` // default: 5
 	NPSSamplePercent       int `yaml:"nps_sample_percent"`        // 0-100, default: 1
-	// ClassifyMissingTaskID controls behavior when a gateway request omits task_id.
-	// When false (default), the request is rejected with 400 TASK_REQUIRED — the
-	// long-standing behavior, preserved on upgrade so older clients keep working.
-	// When true, the gateway runs task classification: it may reuse an active task,
-	// return 409 ambiguous_task, or 202 pending while routing the request to
-	// approval. Opt in only when downstream clients are prepared for the new shape.
-	ClassifyMissingTaskID bool `yaml:"classify_missing_task_id"`
 }
 
 // RelayConfig holds settings for the cloud relay connection.


### PR DESCRIPTION
## Summary

Four backwards-compatibility fixes for the runtime-controls work landed in #310, making it safer to merge `proxy` into `main`. Companion PRs B and C ship the smaller ergonomic and docs items.

### 1. Audit `params_safe` redaction: token-boundary matcher
`looksSecretKey` now splits keys on separators, camelCase, and letter↔digit boundaries, then matches whole tokens against an explicit allowlist (`token`, `secret`, `password`, `auth`, `authorization`, `apikey`, `accesskey`, `privatekey`, `bearer`, etc.). The previous substring matcher stripped `oauth_endpoint` (because of `auth`), `author`, and any field name that happened to contain a credential keyword as a substring. Authorization headers and other real secrets are still stripped — `oauth_token`, `apiKey`, and versioned names like `oauth2Token` continue to match.

### 2. Gateway missing-task_id classification gated on `runtime_proxy.enabled`
\#310 made a gateway request without `task_id` run through task classification (auto-bind, 409 ambiguous_task, 202 pending). That's a real behavior change for clients that always sent `task_id` and treated its absence as a programmer error.

This PR ties the new path to the existing `runtime_proxy.enabled` flag rather than introducing a separate config knob:

- **`runtime_proxy.enabled = false`** (legacy / gateway-only deploys): a missing `task_id` returns `400 TASK_REQUIRED` exactly as before #310.
- **`runtime_proxy.enabled = true`** (the runtime-controls world): classification is engaged, since that's the deployment that introduced and depends on it.

The two settings travel together — task classification only makes sense when the runtime proxy is the thing deciding whether to admit a tool call — so a separate flag would just be extra ceremony for operators. The `TestGateway_NoTaskID_*` integration tests set `RuntimeProxy.Enabled: true` in `newTestEnv` so they exercise the new path; the gate site has an expanded comment documenting the behavior change.

### 3. Restrictions handler dual-writes to legacy `restrictions` table
`POST /api/restrictions` now inserts into both `runtime_policy_rules` (the new source of truth) and `restrictions` (the legacy table) using the same row ID. `DELETE /api/restrictions/{id}` deletes from both. This means a downgrade from a build with #310 back to a pre-#310 build still sees restrictions created on the new version. The legacy table is still preserved by migration 037, so existing data is unaffected.

### 4. Soften v2 `planned_calls` without `authorized_actions`
Pre-#310 the gateway tolerated tasks with `planned_calls` but no `authorized_actions`; #310 made this a 400 `INVALID_REQUEST`. To keep existing clients working, the handler now auto-derives `authorized_actions` from the planned (service, action) pairs and logs a deprecation warning. Callers should still send `authorized_actions` explicitly — the fallback may be removed in a later release.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (all packages green; `TestGateway_NoTaskID_*` updated to enable the runtime proxy)
- [x] Tokenizer test cases cover separator, camelCase, and letter↔digit boundaries (including `oauth2Token`, `v2AccessToken`, `oauth_endpoint`, `author`, `keyboard`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)