### PR TITLE
docs(backcompat): multi-replica Redis warning + migration tx convention

### DIFF
--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -36,6 +36,22 @@ func runMigrations(ctx context.Context, pool *pgxpool.Pool) error {
 	return runMigrationsFS(ctx, pool, migrationsFS)
 }
 
+// runMigrationsFS applies every unapplied .sql file under migrations/ in
+// lexicographic order. Each file runs inside its own transaction together
+// with the matching schema_migrations row insert, so a partial failure
+// rolls back the entire file.
+//
+// Convention for new migration files:
+//   - Do NOT include BEGIN/COMMIT — the runner already wraps each file in a
+//     transaction and an explicit BEGIN inside one will fail.
+//   - Do NOT use statements that cannot run inside a transaction
+//     (e.g. CREATE INDEX CONCURRENTLY, ALTER SYSTEM). If you need one,
+//     split it into its own file and wrap it in a way the runner can detect
+//     — at present the runner has no escape hatch, so prefer the regular
+//     non-CONCURRENTLY index for now.
+//   - File names should be NNN_name.sql with NNN strictly increasing; the
+//     name is used as the schema_migrations primary key, so renaming an
+//     already-applied file will reapply it.
 func runMigrationsFS(ctx context.Context, pool *pgxpool.Pool, migrations fs.FS) error {
 	// Create migrations tracking table
 	_, err := pool.Exec(ctx, `

--- a/pkg/clawvisor/run.go
+++ b/pkg/clawvisor/run.go
@@ -100,6 +100,11 @@ func RunWithContext(ctx context.Context, opts *ServerOptions) error {
 		reviewCache = runtimereview.NewApprovalCache()
 		if opts.RedisClient != nil {
 			reviewCache = runtimereview.NewRedisApprovalCache(opts.RedisClient)
+		} else if opts.Logger != nil {
+			// In-memory approval cache is correct only for single-instance deploys.
+			// On a multi-replica setup, an approval held on one replica is invisible
+			// to others and the proxy will block forever on the second instance.
+			opts.Logger.Warn("runtime proxy: RedisClient not configured — held-approval cache is process-local; running multiple replicas will desync approvals")
 		}
 		contextJudge := runtimepolicy.NewLLMRuntimeContextJudge(llm.NewHealth(opts.Config.LLM), opts.Logger)
 		runtimeSrv.InstallToolUseInterceptors(runtimeproxy.ToolUseHooks{


### PR DESCRIPTION
## Summary

Two operator-facing follow-ups to the runtime-controls release (#310). Neither blocks the proxy → main merge; both make existing constraints discoverable instead of footguns.

- **`pkg/clawvisor/run.go` — startup warning when proxy is enabled without Redis.** The held-approval cache silently falls back to an in-memory implementation when `RedisClient` is nil. This is correct for single-instance deploys but desyncs across replicas with no failure signal. The new `Warn` line surfaces the constraint at startup so multi-replica operators don't discover it from a stuck approval flow in production.

- **`internal/store/postgres/postgres.go` — document the migration runner's transactional convention.** The runner wraps each `.sql` file in its own transaction together with the `schema_migrations` row insert. Authors of future migrations need to know:
  - Don't include `BEGIN`/`COMMIT` (the inner one fails).
  - Don't use statements that can't run inside a transaction (`CREATE INDEX CONCURRENTLY`, `ALTER SYSTEM`).
  - File names use `NNN_name.sql`; renaming an applied file reapplies it.

  Putting this in a doc comment on `runMigrationsFS` is where the next person will look.

## What this does *not* include

- **CHANGELOG entries** — the changelog is generated by release-please from conventional commit messages, so manual edits would be overwritten. The approval-response shape additions in #310 are additive and non-breaking on the wire.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/clawvisor/... ./internal/store/postgres/... ./internal/api/...`
- [ ] Spot-check the warn line fires on a `runtime_proxy.enabled=true` config with no Redis configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)