### PR TITLE
feat(gmail): add archive_message action and gate write scopes

### DIFF
--- a/internal/adapters/definitions/google_gmail.yaml
+++ b/internal/adapters/definitions/google_gmail.yaml
@@ -20,6 +20,9 @@ auth:
       - scope: "https://www.googleapis.com/auth/gmail.compose"
         env_gate: "GMAIL_DRAFTS_ENABLED"
         default: true
+      - scope: "https://www.googleapis.com/auth/gmail.modify"
+        env_gate: "GMAIL_ARCHIVE_ENABLED"
+        default: true
     endpoint: google
     vault_key: google
     scope_merge: true
@@ -86,3 +89,11 @@ actions:
       subject: { type: string, required: true }
       body: { type: string }
       in_reply_to: { type: string }
+
+  archive_message:
+    display_name: "Archive message"
+    risk: { category: write, sensitivity: low, description: "Archive a message (remove the INBOX label)" }
+    scopes: ["https://www.googleapis.com/auth/gmail.modify"]
+    override: go
+    params:
+      message_id: { type: string, required: true }

--- a/internal/adapters/google/gmail/adapter.go
+++ b/internal/adapters/google/gmail/adapter.go
@@ -41,13 +41,24 @@ func draftsEnabled() bool {
 	return os.Getenv("GMAIL_DRAFTS_ENABLED") != "false"
 }
 
-// gmailScopes returns the scopes to request, including gmail.compose
-// only when drafts are enabled.
+// archiveEnabled reports whether the archive_message action is available.
+// Set GMAIL_ARCHIVE_ENABLED=false to disable in environments where the
+// gmail.modify scope has not yet been approved.
+func archiveEnabled() bool {
+	return os.Getenv("GMAIL_ARCHIVE_ENABLED") != "false"
+}
+
+// gmailScopes returns the scopes to request, including gmail.compose and
+// gmail.modify only when their respective gates are enabled.
 func gmailScopes() []string {
-	if !draftsEnabled() {
-		return gmailBaseScopes
+	scopes := append([]string{}, gmailBaseScopes...)
+	if draftsEnabled() {
+		scopes = append(scopes, "https://www.googleapis.com/auth/gmail.compose")
 	}
-	return append(gmailBaseScopes, "https://www.googleapis.com/auth/gmail.compose")
+	if archiveEnabled() {
+		scopes = append(scopes, "https://www.googleapis.com/auth/gmail.modify")
+	}
+	return scopes
 }
 
 // GmailAdapter implements adapters.Adapter for Gmail.
@@ -65,6 +76,9 @@ func (a *GmailAdapter) SupportedActions() []string {
 	actions := []string{"list_messages", "get_message", "get_thread", "get_attachment", "send_message"}
 	if draftsEnabled() {
 		actions = append(actions, "create_draft")
+	}
+	if archiveEnabled() {
+		actions = append(actions, "archive_message")
 	}
 	return actions
 }
@@ -124,6 +138,11 @@ func (a *GmailAdapter) Execute(ctx context.Context, req adapters.Request) (*adap
 			return nil, err
 		}
 		return a.createDraft(ctx, client, req.Params)
+	case "archive_message":
+		if err := a.requireModifyScope(req.Credential); err != nil {
+			return nil, err
+		}
+		return a.archiveMessage(ctx, client, req.Params)
 	default:
 		return nil, fmt.Errorf("gmail: unsupported action %q", req.Action)
 	}
@@ -529,6 +548,20 @@ func (a *GmailAdapter) requireComposeScope(credBytes []byte) error {
 	return nil
 }
 
+// requireModifyScope checks whether the stored credential includes the
+// gmail.modify scope. Legacy tokens lacking it will fail with a descriptive
+// error prompting the user to reconnect.
+func (a *GmailAdapter) requireModifyScope(credBytes []byte) error {
+	cred, err := credential.Parse(credBytes)
+	if err != nil {
+		return fmt.Errorf("gmail archive_message: %w", err)
+	}
+	if !credential.HasAllScopes(cred.Scopes, []string{"https://www.googleapis.com/auth/gmail.modify"}) {
+		return fmt.Errorf("gmail archive_message: the gmail.modify scope is required — please reconnect your Google account to grant label-modification permissions")
+	}
+	return nil
+}
+
 // ── create_draft ──────────────────────────────────────────────────────────────
 
 func (a *GmailAdapter) createDraft(ctx context.Context, client *http.Client, params map[string]any) (*adapters.Result, error) {
@@ -571,6 +604,35 @@ func (a *GmailAdapter) createDraft(ctx context.Context, client *http.Client, par
 		"subject":    subject,
 	}
 	summary := format.Summary("Draft created for %s (subject: %q)", to, subject)
+	return &adapters.Result{Summary: summary, Data: result}, nil
+}
+
+// ── archive_message ───────────────────────────────────────────────────────────
+
+func (a *GmailAdapter) archiveMessage(ctx context.Context, client *http.Client, params map[string]any) (*adapters.Result, error) {
+	msgID, _ := params["message_id"].(string)
+	if msgID == "" {
+		return nil, fmt.Errorf("gmail archive_message: message_id is required")
+	}
+
+	url := fmt.Sprintf("https://gmail.googleapis.com/gmail/v1/users/me/messages/%s/modify", msgID)
+	payload := map[string][]string{"removeLabelIds": {"INBOX"}}
+
+	var modifyResp struct {
+		ID       string   `json:"id"`
+		ThreadId string   `json:"threadId"`
+		LabelIds []string `json:"labelIds"`
+	}
+	if err := gmailPOST(ctx, client, url, payload, &modifyResp); err != nil {
+		return nil, fmt.Errorf("gmail archive_message: %w", err)
+	}
+
+	result := map[string]any{
+		"message_id": modifyResp.ID,
+		"thread_id":  modifyResp.ThreadId,
+		"labels":     modifyResp.LabelIds,
+	}
+	summary := format.Summary("Archived message %s", msgID)
 	return &adapters.Result{Summary: summary, Data: result}, nil
 }
 

--- a/internal/adapters/google/gmail/adapter.go
+++ b/internal/adapters/google/gmail/adapter.go
@@ -13,7 +13,6 @@ import (
 	"mime/quotedprintable"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 
 	"golang.org/x/oauth2"
@@ -26,39 +25,16 @@ import (
 
 const serviceID = "google.gmail"
 
-// gmailBaseScopes are always requested.
-var gmailBaseScopes = []string{
+// gmailScopes is the full set of scopes Gmail can use. The YAML definition is
+// the source of truth for OAuth URL generation and action gating; this list
+// is only consumed by the in-process token-source builder below.
+var gmailScopes = []string{
 	"https://www.googleapis.com/auth/gmail.readonly",
 	"https://www.googleapis.com/auth/gmail.send",
+	"https://www.googleapis.com/auth/gmail.compose",
+	"https://www.googleapis.com/auth/gmail.modify",
 	"https://www.googleapis.com/auth/userinfo.email",
 	"https://www.googleapis.com/auth/userinfo.profile",
-}
-
-// draftsEnabled reports whether the create_draft action is available.
-// Set GMAIL_DRAFTS_ENABLED=false to disable in environments where the
-// gmail.compose scope has not yet been approved.
-func draftsEnabled() bool {
-	return os.Getenv("GMAIL_DRAFTS_ENABLED") != "false"
-}
-
-// archiveEnabled reports whether the archive_message action is available.
-// Set GMAIL_ARCHIVE_ENABLED=false to disable in environments where the
-// gmail.modify scope has not yet been approved.
-func archiveEnabled() bool {
-	return os.Getenv("GMAIL_ARCHIVE_ENABLED") != "false"
-}
-
-// gmailScopes returns the scopes to request, including gmail.compose and
-// gmail.modify only when their respective gates are enabled.
-func gmailScopes() []string {
-	scopes := append([]string{}, gmailBaseScopes...)
-	if draftsEnabled() {
-		scopes = append(scopes, "https://www.googleapis.com/auth/gmail.compose")
-	}
-	if archiveEnabled() {
-		scopes = append(scopes, "https://www.googleapis.com/auth/gmail.modify")
-	}
-	return scopes
 }
 
 // GmailAdapter implements adapters.Adapter for Gmail.
@@ -73,17 +49,13 @@ func New(provider adapters.OAuthCredentialProvider) *GmailAdapter {
 func (a *GmailAdapter) ServiceID() string { return serviceID }
 
 func (a *GmailAdapter) SupportedActions() []string {
-	actions := []string{"list_messages", "get_message", "get_thread", "get_attachment", "send_message"}
-	if draftsEnabled() {
-		actions = append(actions, "create_draft")
+	return []string{
+		"list_messages", "get_message", "get_thread", "get_attachment",
+		"send_message", "create_draft", "archive_message",
 	}
-	if archiveEnabled() {
-		actions = append(actions, "archive_message")
-	}
-	return actions
 }
 
-func (a *GmailAdapter) RequiredScopes() []string { return gmailScopes() }
+func (a *GmailAdapter) RequiredScopes() []string { return gmailScopes }
 
 func (a *GmailAdapter) OAuthConfig() *oauth2.Config {
 	clientID, clientSecret := a.oauthProvider.OAuthClientCredentials()
@@ -93,13 +65,13 @@ func (a *GmailAdapter) OAuthConfig() *oauth2.Config {
 	return &oauth2.Config{
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
-		Scopes:       gmailScopes(),
+		Scopes:       gmailScopes,
 		Endpoint:     google.Endpoint,
 	}
 }
 
 func (a *GmailAdapter) CredentialFromToken(token *oauth2.Token) ([]byte, error) {
-	return credential.FromToken(token, gmailScopes(), false)
+	return credential.FromToken(token, gmailScopes, false)
 }
 
 func (a *GmailAdapter) ValidateCredential(credBytes []byte) error {

--- a/internal/adapters/google/gmail/adapter_test.go
+++ b/internal/adapters/google/gmail/adapter_test.go
@@ -434,6 +434,53 @@ func TestSendMessage_WithThreadID_QuotesPreviousMessage(t *testing.T) {
 	}
 }
 
+func TestArchiveMessage_RemovesInboxLabel(t *testing.T) {
+	var sentPayload struct {
+		RemoveLabelIDs []string `json:"removeLabelIds"`
+	}
+
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if req.Method != http.MethodPost || !strings.HasSuffix(req.URL.Path, "/messages/msg-1/modify") {
+				t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			}
+			data, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("read request body: %v", err)
+			}
+			if err := json.Unmarshal(data, &sentPayload); err != nil {
+				t.Fatalf("unmarshal modify payload: %v", err)
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"id":"msg-1","threadId":"thread-1","labelIds":["UNREAD"]}`)),
+			}, nil
+		}),
+	}
+
+	adapter := &GmailAdapter{}
+	result, err := adapter.archiveMessage(context.Background(), client, map[string]any{
+		"message_id": "msg-1",
+	})
+	if err != nil {
+		t.Fatalf("archiveMessage error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("archiveMessage returned nil result")
+	}
+	if len(sentPayload.RemoveLabelIDs) != 1 || sentPayload.RemoveLabelIDs[0] != "INBOX" {
+		t.Fatalf("removeLabelIds = %v, want [INBOX]", sentPayload.RemoveLabelIDs)
+	}
+}
+
+func TestArchiveMessage_RequiresMessageID(t *testing.T) {
+	adapter := &GmailAdapter{}
+	if _, err := adapter.archiveMessage(context.Background(), &http.Client{}, map[string]any{}); err == nil {
+		t.Fatal("expected error when message_id missing")
+	}
+}
+
 func TestSendMessage_WithInReplyTo_ResolvesThreadAndQuotesPreviousMessage(t *testing.T) {
 	var sentPayload struct {
 		Raw      string `json:"raw"`

--- a/pkg/adapters/yamlruntime/adapter.go
+++ b/pkg/adapters/yamlruntime/adapter.go
@@ -59,8 +59,12 @@ func (a *YAMLAdapter) ServiceID() string { return a.def.Service.ID }
 func (a *YAMLAdapter) Overrides() map[string]ActionFunc { return a.overrides }
 
 func (a *YAMLAdapter) SupportedActions() []string {
+	active := scopeSet(a.activeScopes())
 	actions := make([]string, 0, len(a.def.Actions))
-	for name := range a.def.Actions {
+	for name, action := range a.def.Actions {
+		if !actionScopesEnabled(action, active) {
+			continue
+		}
 		actions = append(actions, name)
 	}
 	sort.Strings(actions)
@@ -90,6 +94,11 @@ func (a *YAMLAdapter) Execute(ctx context.Context, req adapters.Request) (*adapt
 	action, ok := a.def.Actions[req.Action]
 	if !ok {
 		return nil, fmt.Errorf("%s: unsupported action %q", a.def.Service.ID, req.Action)
+	}
+
+	if missing := actionDisabledScopes(action, scopeSet(a.activeScopes())); len(missing) > 0 {
+		return nil, fmt.Errorf("%s: action %q is disabled (scopes not enabled: %s)",
+			a.def.Service.ID, req.Action, strings.Join(missing, ", "))
 	}
 
 	// Check for Go override.
@@ -232,19 +241,7 @@ func (a *YAMLAdapter) OAuthConfig() *oauth2.Config {
 		return nil // OAuth not yet configured
 	}
 
-	scopes := make([]string, len(oauthDef.Scopes))
-	copy(scopes, oauthDef.Scopes)
-
-	for _, cs := range oauthDef.ConditionalScopes {
-		envVal := os.Getenv(cs.EnvGate)
-		include := cs.Default
-		if envVal != "" {
-			include = !strings.EqualFold(envVal, "false")
-		}
-		if include {
-			scopes = append(scopes, cs.Scope)
-		}
-	}
+	scopes := a.activeScopes()
 
 	var endpoint oauth2.Endpoint
 	switch oauthDef.Endpoint {
@@ -319,9 +316,80 @@ func (a *YAMLAdapter) RequiredScopes() []string {
 	if a.def.Auth.Type != "oauth2" || a.def.Auth.OAuth == nil {
 		return nil
 	}
-	// Return scopes from the definition directly — these are known regardless
-	// of whether OAuth app credentials are configured in the vault yet.
-	return a.def.Auth.OAuth.Scopes
+	// Return base + currently-enabled conditional scopes so callers (auth URL
+	// generation, vault scope merging, etc.) request consent for everything
+	// the active actions need — not just the unconditional base set.
+	return a.activeScopes()
+}
+
+// activeScopes returns the deduplicated scopes currently in effect: base
+// scopes plus any conditional_scopes whose env_gate evaluates to true.
+func (a *YAMLAdapter) activeScopes() []string {
+	if a.def.Auth.OAuth == nil {
+		return nil
+	}
+	oauthDef := a.def.Auth.OAuth
+	out := make([]string, 0, len(oauthDef.Scopes)+len(oauthDef.ConditionalScopes))
+	seen := make(map[string]bool, cap(out))
+	for _, s := range oauthDef.Scopes {
+		if !seen[s] {
+			seen[s] = true
+			out = append(out, s)
+		}
+	}
+	for _, cs := range oauthDef.ConditionalScopes {
+		if !conditionalScopeEnabled(cs) {
+			continue
+		}
+		if !seen[cs.Scope] {
+			seen[cs.Scope] = true
+			out = append(out, cs.Scope)
+		}
+	}
+	return out
+}
+
+// conditionalScopeEnabled evaluates a conditional scope's env_gate.
+// Unset env var → cs.Default. Set to "false" (case-insensitive) → false.
+// Any other value → true.
+func conditionalScopeEnabled(cs yamldef.ConditionalScope) bool {
+	envVal := os.Getenv(cs.EnvGate)
+	if envVal == "" {
+		return cs.Default
+	}
+	return !strings.EqualFold(envVal, "false")
+}
+
+// scopeSet builds a lookup set from a slice of scopes.
+func scopeSet(scopes []string) map[string]bool {
+	m := make(map[string]bool, len(scopes))
+	for _, s := range scopes {
+		m[s] = true
+	}
+	return m
+}
+
+// actionScopesEnabled reports whether every scope an action declares is
+// currently active. Actions with no declared scopes are always enabled.
+func actionScopesEnabled(action yamldef.Action, active map[string]bool) bool {
+	for _, s := range action.Scopes {
+		if !active[s] {
+			return false
+		}
+	}
+	return true
+}
+
+// actionDisabledScopes returns the scopes an action declares that are not
+// currently active. Empty result means the action is enabled.
+func actionDisabledScopes(action yamldef.Action, active map[string]bool) []string {
+	var missing []string
+	for _, s := range action.Scopes {
+		if !active[s] {
+			missing = append(missing, s)
+		}
+	}
+	return missing
 }
 
 // ScopesForAction returns the OAuth scopes required by a specific action,

--- a/pkg/adapters/yamlruntime/adapter_test.go
+++ b/pkg/adapters/yamlruntime/adapter_test.go
@@ -1488,3 +1488,70 @@ func containsHelper(s, substr string) bool {
 	}
 	return false
 }
+
+func TestYAMLAdapter_ConditionalScopes_GateOnAndOff(t *testing.T) {
+	def := yamldef.ServiceDef{
+		Service: yamldef.ServiceInfo{ID: "demo.svc"},
+		Auth: yamldef.AuthDef{
+			Type: "oauth2",
+			OAuth: &yamldef.OAuthDef{
+				Scopes: []string{"https://example.com/auth/base"},
+				ConditionalScopes: []yamldef.ConditionalScope{
+					{Scope: "https://example.com/auth/write", EnvGate: "DEMO_WRITE_ENABLED", Default: true},
+				},
+			},
+		},
+		API: yamldef.APIDef{BaseURL: "https://example.com", Type: "rest"},
+		Actions: map[string]yamldef.Action{
+			"read":  {Override: "go", Scopes: []string{"https://example.com/auth/base"}},
+			"write": {Override: "go", Scopes: []string{"https://example.com/auth/write"}},
+		},
+	}
+
+	adapter, err := New(def, map[string]ActionFunc{
+		"read":  func(context.Context, adapters.Request) (*adapters.Result, error) { return &adapters.Result{}, nil },
+		"write": func(context.Context, adapters.Request) (*adapters.Result, error) { return &adapters.Result{}, nil },
+	})
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+
+	// Default true → write scope active, write action listed.
+	t.Setenv("DEMO_WRITE_ENABLED", "")
+	if got := adapter.RequiredScopes(); !containsString(got,"https://example.com/auth/write") {
+		t.Errorf("RequiredScopes missing conditional scope when gate defaults true: %v", got)
+	}
+	if got := adapter.SupportedActions(); !containsString(got,"write") {
+		t.Errorf("SupportedActions missing 'write' when gate defaults true: %v", got)
+	}
+	if _, err := adapter.Execute(context.Background(), adapters.Request{Action: "write"}); err != nil {
+		t.Errorf("Execute(write) should succeed when gate is on: %v", err)
+	}
+
+	// Explicitly false → scope dropped, action hidden, execute rejected.
+	t.Setenv("DEMO_WRITE_ENABLED", "false")
+	if got := adapter.RequiredScopes(); containsString(got,"https://example.com/auth/write") {
+		t.Errorf("RequiredScopes should drop conditional scope when gate is false: %v", got)
+	}
+	if got := adapter.SupportedActions(); containsString(got,"write") {
+		t.Errorf("SupportedActions should hide 'write' when gate is false: %v", got)
+	}
+	_, err = adapter.Execute(context.Background(), adapters.Request{Action: "write"})
+	if err == nil {
+		t.Errorf("Execute(write) should fail when gate is false")
+	}
+
+	// Read action remains unaffected by the gate.
+	if got := adapter.SupportedActions(); !containsString(got,"read") {
+		t.Errorf("SupportedActions should always include 'read': %v", got)
+	}
+}
+
+func containsString(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/clawvisor/defaults.go
+++ b/pkg/clawvisor/defaults.go
@@ -157,7 +157,7 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 	goOverrides := map[string]yamlruntime.ActionFunc{}
 
 	gmail := gmailadapter.New(oauthProvider)
-	for _, action := range []string{"list_messages", "get_message", "get_thread", "get_attachment", "send_message", "create_draft"} {
+	for _, action := range []string{"list_messages", "get_message", "get_thread", "get_attachment", "send_message", "create_draft", "archive_message"} {
 		goOverrides["google.gmail:"+action] = gmail.Execute
 	}
 	drive := driveadapter.New(oauthProvider)

--- a/skills/clawvisor/policies/google-workspace-safe.yaml
+++ b/skills/clawvisor/policies/google-workspace-safe.yaml
@@ -17,6 +17,11 @@ rules:
     reason: Sending email requires your approval
 
   - service: google.gmail
+    actions: [archive_message]
+    require_approval: true
+    reason: Archiving email requires your approval
+
+  - service: google.gmail
     actions: [delete_message]
     allow: false
     reason: Email deletion is disabled for safety


### PR DESCRIPTION
## Summary

- Adds an `archive_message` Gmail action (POSTs to `messages/{id}/modify` with `removeLabelIds: [INBOX]`).
- Adds a new `GMAIL_ARCHIVE_ENABLED` env gate parallel to the existing `GMAIL_DRAFTS_ENABLED`. Both control whether their respective sensitive scopes (`gmail.modify`, `gmail.compose`) are requested and whether the matching action (`archive_message`, `create_draft`) is exposed. Default `true`; staging keeps them on, prod sets them `false` until Google verifies the scopes.
- Updates the `google-workspace-safe` policy to require human approval before archiving.

## Verification rollout

`gmail.compose` and `gmail.modify` are both still pending Google OAuth verification. Plan:

1. Land this PR.
2. Deploy to staging with both gates on (default).
3. Record the verification video covering compose + modify use.
4. Submit for verification.
5. Once approved, set `GMAIL_DRAFTS_ENABLED=true` / `GMAIL_ARCHIVE_ENABLED=true` (or unset, since they default true) in prod.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/adapters/google/gmail/...` — new tests cover archive payload + missing `message_id`
- [x] `go test ./...` — full suite green
- [ ] Manual: archive a message in staging once the env vars are flipped on

🤖 Generated with [Claude Code](https://claude.com/claude-code)