### PR TITLE
fix(web): make per-request approval prompt binary

### DIFF
--- a/web/src/pages/Overview.tsx
+++ b/web/src/pages/Overview.tsx
@@ -382,7 +382,7 @@ function ApprovalCard({ item }: { item: QueueItem }) {
   }
 
   const approveMut = useMutation({
-    mutationFn: (resolution: 'allow_once' | 'allow_session' | 'allow_always') => api.approvals.approve(a.request_id, resolution),
+    mutationFn: () => api.approvals.approve(a.request_id, 'allow_once'),
     onSuccess: (res) => {
       setResult(res.status === 'executed' ? 'Approved & executed' : `Outcome: ${res.status}`)
       invalidate()
@@ -477,25 +477,11 @@ function ApprovalCard({ item }: { item: QueueItem }) {
           Deny
         </button>
         <button
-          onClick={() => approveMut.mutate('allow_once')}
-          disabled={isPending}
-          className="rounded px-4 py-1.5 text-sm font-medium border border-brand/30 text-brand hover:bg-brand/10 disabled:opacity-50"
-        >
-          {approveMut.isPending ? 'Approving...' : 'Allow Once'}
-        </button>
-        <button
-          onClick={() => approveMut.mutate('allow_session')}
-          disabled={isPending}
-          className="rounded px-4 py-1.5 text-sm font-medium border border-brand/30 text-brand hover:bg-brand/10 disabled:opacity-50"
-        >
-          Create Session Task
-        </button>
-        <button
-          onClick={() => approveMut.mutate('allow_always')}
+          onClick={() => approveMut.mutate()}
           disabled={isPending}
           className="bg-brand text-surface-0 font-medium rounded px-5 py-1.5 text-sm hover:bg-brand-strong disabled:opacity-50"
         >
-          Create Standing Task
+          {approveMut.isPending ? 'Approving...' : 'Approve'}
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- The standalone `ApprovalCard` (Overview page) now shows only **Deny** / **Approve** and always sends `allow_once`.
- Removes the "Create Session Task" / "Create Standing Task" escalation buttons from the per-request approval flow.

## Why
A per-request approval fires when the agent already holds a task scope with `auto_execute:false`. The session/standing buttons were creating a *new* auto-execute task for the same action — producing shadow tasks alongside the existing one and silently extending authority past the existing task's expiry. The lifetime axis was being repurposed to mean "how long should this exemption last," which only coincidentally aligns with task lifetime.

Escalation (flipping `auto_execute`, extending lifetime, converting session→standing) should live on the task itself, not get bolted onto an approval.

## Scope
- `web/src/pages/Runtime.tsx` (proxy/runtime event promotion) keeps all four options — no preexisting task there, so the lifetime choice is meaningful.
- Backend `allow_session` / `allow_always` resolutions in `internal/api/handlers/approvals.go` are left intact for now (still used by Runtime.tsx).

## Test plan
- [ ] Trigger a per-request approval against a task with `auto_execute:false` and confirm the card shows only Deny / Approve.
- [ ] Approve once and confirm the agent executes successfully (resolution=`allow_once`).
- [ ] Confirm Runtime page event promotion still offers Session / Standing options.
- [ ] `npx tsc --noEmit` passes (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)