### PR TITLE
fix(api): return empty array for agents list when none exist

### DIFF
--- a/internal/api/handlers/agents.go
+++ b/internal/api/handlers/agents.go
@@ -110,6 +110,9 @@ func (h *AgentsHandler) List(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not list agents")
 		return
 	}
+	if agents == nil {
+		agents = []*store.Agent{}
+	}
 	writeJSON(w, http.StatusOK, agents)
 }
 


### PR DESCRIPTION
## Summary
- The policy page crashed on staging with `Cannot read properties of null (reading 'map')` inside a `useMemo`.
- Root cause: `GET /api/agents` returned `null` for users with no agents (Go marshals nil slices as `null`), which bypassed the frontend's `data: agents = []` destructuring default (only fires for `undefined`).
- Fix: ensure the handler always returns `[]` instead of nil. Also protects Overview, Runtime, Agents, and Tasks pages that hit the same endpoint.

## Test plan
- [ ] Load the policy page as a user with no agents and confirm it renders without the render error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)