### PR TITLE
fix(api): return empty arrays for remaining list endpoints

### DIFF
--- a/internal/api/handlers/connections.go
+++ b/internal/api/handlers/connections.go
@@ -514,5 +514,8 @@ func (h *ConnectionsHandler) List(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not list connection requests")
 		return
 	}
+	if requests == nil {
+		requests = []*store.ConnectionRequest{}
+	}
 	writeJSON(w, http.StatusOK, requests)
 }

--- a/internal/api/handlers/overview.go
+++ b/internal/api/handlers/overview.go
@@ -122,6 +122,12 @@ func (h *OverviewHandler) Get(w http.ResponseWriter, r *http.Request) {
 	if activity == nil {
 		activity = []store.ActivityBucket{}
 	}
+	if queueItems == nil {
+		queueItems = []queueItem{}
+	}
+	if activeTasks == nil {
+		activeTasks = []*store.Task{}
+	}
 
 	writeJSON(w, http.StatusOK, map[string]any{
 		"queue":        queueItems,

--- a/internal/api/handlers/runtime_controls.go
+++ b/internal/api/handlers/runtime_controls.go
@@ -37,6 +37,9 @@ func (h *RuntimeHandler) ListRules(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not list runtime rules")
 		return
 	}
+	if rules == nil {
+		rules = []*store.RuntimePolicyRule{}
+	}
 	writeJSON(w, http.StatusOK, map[string]any{
 		"entries": rules,
 		"total":   len(rules),


### PR DESCRIPTION
## Summary
- Follow-up to #320, which fixed `/api/agents`. Sweeping the rest of the handlers turned up three more list-shaped responses that could serialize as \`null\` when empty (Go marshals nil slices as \`null\`).
- Frontend currently uses \`?? []\` for these so they don't crash today, but they're inconsistent with the established convention in agents/devices/restrictions/notifications and would be a trap for any future caller using a destructuring default.
- Fixes: \`/api/agents/connections\` (List), \`/api/overview\` (queue + active_tasks fields), \`/api/runtime/rules\` (entries field).

## Test plan
- [ ] Existing API tests pass (\`go test ./internal/api/...\`).
- [ ] Manual: hit each endpoint as a fresh user with no data and confirm \`[]\` instead of \`null\` in JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)