### PR TITLE
fix(dev): pin Vite to 25297 so OAuth and stored sessions work

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -5,9 +5,12 @@ set -euo pipefail
 #
 # - Backend: `air` rebuilds and restarts on .go changes (see .air.toml).
 # - Frontend: Vite dev server with HMR; proxies API/WS calls to the backend.
-# - Ports: chosen dynamically so this won't collide with the installed daemon.
-#   Pass a port as the first arg (or via $PORT) to pin the Vite port.
-# - Config: reuses ~/.clawvisor/config.yaml (PORT/SERVER_HOST overridden via env).
+# - Ports: Vite defaults to 25297 so it matches the registered OAuth
+#   redirect_uri and shares localStorage/cookies with the installed daemon.
+#   The backend listens on a random free port. Pass a port as the first arg
+#   (or via $PORT) to override the Vite port.
+# - Config: reuses ~/.clawvisor/config.yaml (PORT/SERVER_HOST/PUBLIC_URL
+#   overridden via env so the daemon advertises the Vite origin).
 #
 # The Vite URL is the only one you need — open it in your browser.
 
@@ -46,7 +49,7 @@ find_free_port() {
     done
 }
 
-FRONTEND_PORT="${1:-${PORT:-$(find_free_port)}}"
+FRONTEND_PORT="${1:-${PORT:-25297}}"
 BACKEND_PORT="$(find_free_port "$FRONTEND_PORT")"
 
 # air's tmp_dir create is non-recursive, so make sure the parent exists.
@@ -94,13 +97,14 @@ echo "  Frontend : http://127.0.0.1:$FRONTEND_PORT  (Vite, HMR — open this URL
 echo "  Config   : ~/.clawvisor/config.yaml"
 echo ""
 
-# Rewrite ":$BACKEND_PORT" → ":$FRONTEND_PORT" in the daemon's output so the
-# printed magic-link URL points to Vite (the only URL that serves the live
-# frontend; the backend's embedded SPA is just web/dist/placeholder.html in a
-# dev checkout). Process substitution keeps $! as air's PID so cleanup works.
-PORT="$BACKEND_PORT" SERVER_HOST="127.0.0.1" air -c .air.toml \
-    > >(awk -v from=":$BACKEND_PORT" -v to=":$FRONTEND_PORT" '{gsub(from, to); print; fflush()}') \
-    2>&1 &
+# PUBLIC_URL pins the daemon's advertised origin to the Vite port, so OAuth
+# redirect URIs and printed magic links point at Vite (the only URL that
+# serves the live frontend; the backend's embedded SPA is just
+# web/dist/placeholder.html in a dev checkout). Vite proxies /api/* back to
+# the backend's actual listen port.
+PORT="$BACKEND_PORT" SERVER_HOST="127.0.0.1" \
+    PUBLIC_URL="http://localhost:$FRONTEND_PORT" \
+    air -c .air.toml &
 BACKEND_PID=$!
 
 BACKEND_PORT="$BACKEND_PORT" npm --prefix "$REPO_ROOT/web" run dev -- --port "$FRONTEND_PORT" --strictPort &


### PR DESCRIPTION
## Summary

- `scripts/dev.sh` previously picked a random Vite port AND a random backend port. The backend's OAuth `redirect_uri` is built from its own listen port (`internal/api/server.go:371`, `internal/api/handlers/services.go:117`), so Google would reject the callback as `redirect_uri_mismatch` against the registered `http://localhost:25297/api/oauth/callback`. A new random Vite port each run also meant no shared localStorage/cookies with the installed daemon.
- Pin Vite to **25297** (the registered redirect URI), let the backend grab a random free port, and set `PUBLIC_URL=http://localhost:25297` so the daemon advertises the Vite origin in OAuth redirects and printed magic links. Vite proxies `/api/*` and `/ws` back to the backend's real port.
- The awk port-rewrite trick in the daemon's stdout is no longer needed — `PUBLIC_URL` makes the daemon emit the right URL directly.

## Test plan

- [ ] `./scripts/dev.sh` starts cleanly; Vite reports `:25297`, backend reports a random port.
- [ ] Open `http://localhost:25297` in the browser; existing session from the installed daemon (if any) is reused.
- [ ] Connect Google from Services → OAuth flow completes without `redirect_uri_mismatch`.
- [ ] Magic-link URL printed by the daemon points at `:25297`.
- [ ] `./scripts/dev.sh 5174` and `PORT=5174 ./scripts/dev.sh` both override the Vite port (`--strictPort` will fail loudly if 5174 is taken).

🤖 Generated with [Claude Code](https://claude.com/claude-code)