### PR TITLE
fix(gmail): thread draft replies and add cc/bcc support

### DIFF
--- a/internal/adapters/definitions/google_gmail.yaml
+++ b/internal/adapters/definitions/google_gmail.yaml
@@ -74,6 +74,8 @@ actions:
     override: go
     params:
       to: { type: string }
+      cc: { type: string, description: "Comma-separated CC recipients" }
+      bcc: { type: string, description: "Comma-separated BCC recipients" }
       subject: { type: string }
       body: { type: string }
       thread_id: { type: string, description: "Gmail thread ID for replying in-thread (preferred — auto-populates to/subject, quotes previous message)" }
@@ -86,6 +88,8 @@ actions:
     override: go
     params:
       to: { type: string }
+      cc: { type: string, description: "Comma-separated CC recipients" }
+      bcc: { type: string, description: "Comma-separated BCC recipients" }
       subject: { type: string }
       body: { type: string }
       thread_id: { type: string, description: "Gmail thread ID for drafting a reply in-thread (preferred — auto-populates to/subject, quotes previous message)" }

--- a/internal/adapters/definitions/google_gmail.yaml
+++ b/internal/adapters/definitions/google_gmail.yaml
@@ -79,7 +79,7 @@ actions:
       subject: { type: string }
       body: { type: string }
       thread_id: { type: string, description: "Gmail thread ID for replying in-thread (preferred — auto-populates to/subject, quotes previous message)" }
-      in_reply_to: { type: string, description: "RFC 2822 Message-ID to reply to (alternative to thread_id — will resolve the thread automatically)" }
+      in_reply_to: { type: string, description: "Gmail message ID or RFC 2822 Message-ID to reply to (alternative to thread_id — will resolve the thread automatically)" }
 
   create_draft:
     display_name: "Create draft"
@@ -93,7 +93,7 @@ actions:
       subject: { type: string }
       body: { type: string }
       thread_id: { type: string, description: "Gmail thread ID for drafting a reply in-thread (preferred — auto-populates to/subject, quotes previous message)" }
-      in_reply_to: { type: string, description: "RFC 2822 Message-ID to reply to (alternative to thread_id — will resolve the thread automatically)" }
+      in_reply_to: { type: string, description: "Gmail message ID or RFC 2822 Message-ID to reply to (alternative to thread_id — will resolve the thread automatically)" }
 
   archive_message:
     display_name: "Archive message"

--- a/internal/adapters/definitions/google_gmail.yaml
+++ b/internal/adapters/definitions/google_gmail.yaml
@@ -85,10 +85,11 @@ actions:
     scopes: ["https://www.googleapis.com/auth/gmail.compose"]
     override: go
     params:
-      to: { type: string, required: true }
-      subject: { type: string, required: true }
+      to: { type: string }
+      subject: { type: string }
       body: { type: string }
-      in_reply_to: { type: string }
+      thread_id: { type: string, description: "Gmail thread ID for drafting a reply in-thread (preferred — auto-populates to/subject, quotes previous message)" }
+      in_reply_to: { type: string, description: "RFC 2822 Message-ID to reply to (alternative to thread_id — will resolve the thread automatically)" }
 
   archive_message:
     display_name: "Archive message"

--- a/internal/adapters/google/gmail/adapter.go
+++ b/internal/adapters/google/gmail/adapter.go
@@ -540,7 +540,76 @@ func (a *GmailAdapter) createDraft(ctx context.Context, client *http.Client, par
 	to, _ := params["to"].(string)
 	subject, _ := params["subject"].(string)
 	body, _ := params["body"].(string)
-	inReplyTo, _ := params["in_reply_to"].(string)
+	threadID, _ := params["thread_id"].(string)
+	legacyInReplyTo, _ := params["in_reply_to"].(string)
+
+	// Resolve thread context for draft replies — same logic as sendMessage.
+	var inReplyTo, references, quotedBody, htmlBody string
+
+	if threadID == "" && legacyInReplyTo != "" {
+		if tid := resolveThreadFromMessageID(ctx, client, legacyInReplyTo); tid != "" {
+			threadID = tid
+		} else {
+			inReplyTo = legacyInReplyTo
+		}
+	}
+
+	if threadID != "" {
+		threadURL := fmt.Sprintf("https://gmail.googleapis.com/gmail/v1/users/me/threads/%s?format=full", threadID)
+		var threadResp struct {
+			ID       string         `json:"id"`
+			Messages []gmailMessage `json:"messages"`
+		}
+		if err := gmailGET(ctx, client, threadURL, &threadResp); err != nil {
+			return nil, fmt.Errorf("gmail create_draft: fetch thread: %w", err)
+		}
+		if len(threadResp.Messages) == 0 {
+			return nil, fmt.Errorf("gmail create_draft: thread %s has no messages", threadID)
+		}
+
+		lastMsg := threadResp.Messages[len(threadResp.Messages)-1]
+		lastDetail := parseMessageDetail(lastMsg, nil)
+
+		if to == "" {
+			to = lastDetail.ReplyTo
+		}
+		if to == "" {
+			to = lastDetail.From
+		}
+
+		if subject == "" {
+			subject = lastDetail.Subject
+			if !strings.HasPrefix(strings.ToLower(subject), "re:") {
+				subject = "Re: " + subject
+			}
+		}
+
+		inReplyTo = lastDetail.MessageID
+		references = lastDetail.References
+		if lastDetail.MessageID != "" {
+			if references != "" {
+				references += " " + lastDetail.MessageID
+			} else {
+				references = lastDetail.MessageID
+			}
+		}
+
+		if lastDetail.Body != "" {
+			var qb strings.Builder
+			qb.WriteString("\r\n\r\nOn ")
+			qb.WriteString(lastDetail.Date)
+			qb.WriteString(", ")
+			qb.WriteString(lastDetail.From)
+			qb.WriteString(" wrote:\r\n")
+			for _, line := range strings.Split(lastDetail.Body, "\n") {
+				qb.WriteString("> ")
+				qb.WriteString(strings.TrimRight(line, "\r"))
+				qb.WriteString("\r\n")
+			}
+			quotedBody = qb.String()
+			htmlBody = buildReplyHTML(body, lastDetail.Date, lastDetail.From, lastDetail.Body)
+		}
+	}
 
 	if to == "" {
 		return nil, fmt.Errorf("gmail create_draft: to is required")
@@ -551,11 +620,16 @@ func (a *GmailAdapter) createDraft(ctx context.Context, client *http.Client, par
 
 	from, _ := fetchSenderAddress(ctx, client)
 
-	raw := buildMIMEMessage(from, to, subject, body, "", inReplyTo, "")
+	fullBody := body + quotedBody
+	raw := buildMIMEMessage(from, to, subject, fullBody, htmlBody, inReplyTo, references)
 	encoded := base64.RawURLEncoding.EncodeToString([]byte(raw))
 
+	msg := map[string]string{"raw": encoded}
+	if threadID != "" {
+		msg["threadId"] = threadID
+	}
 	payload := map[string]any{
-		"message": map[string]string{"raw": encoded},
+		"message": msg,
 	}
 
 	var draftResp struct {
@@ -574,6 +648,9 @@ func (a *GmailAdapter) createDraft(ctx context.Context, client *http.Client, par
 		"message_id": draftResp.Message.ID,
 		"to":         to,
 		"subject":    subject,
+	}
+	if threadID != "" {
+		result["thread_id"] = threadID
 	}
 	summary := format.Summary("Draft created for %s (subject: %q)", to, subject)
 	return &adapters.Result{Summary: summary, Data: result}, nil

--- a/internal/adapters/google/gmail/adapter.go
+++ b/internal/adapters/google/gmail/adapter.go
@@ -385,6 +385,8 @@ func (a *GmailAdapter) getAttachment(ctx context.Context, client *http.Client, p
 
 func (a *GmailAdapter) sendMessage(ctx context.Context, client *http.Client, params map[string]any) (*adapters.Result, error) {
 	to, _ := params["to"].(string)
+	cc, _ := params["cc"].(string)
+	bcc, _ := params["bcc"].(string)
 	subject, _ := params["subject"].(string)
 	body, _ := params["body"].(string)
 	threadID, _ := params["thread_id"].(string)
@@ -478,7 +480,7 @@ func (a *GmailAdapter) sendMessage(ctx context.Context, client *http.Client, par
 	from, _ := fetchSenderAddress(ctx, client)
 
 	fullBody := body + quotedBody
-	raw := buildMIMEMessage(from, to, subject, fullBody, htmlBody, inReplyTo, references)
+	raw := buildMIMEMessage(from, to, cc, bcc, subject, fullBody, htmlBody, inReplyTo, references)
 	encoded := base64.RawURLEncoding.EncodeToString([]byte(raw))
 
 	payload := map[string]string{"raw": encoded}
@@ -538,6 +540,8 @@ func (a *GmailAdapter) requireModifyScope(credBytes []byte) error {
 
 func (a *GmailAdapter) createDraft(ctx context.Context, client *http.Client, params map[string]any) (*adapters.Result, error) {
 	to, _ := params["to"].(string)
+	cc, _ := params["cc"].(string)
+	bcc, _ := params["bcc"].(string)
 	subject, _ := params["subject"].(string)
 	body, _ := params["body"].(string)
 	threadID, _ := params["thread_id"].(string)
@@ -621,7 +625,7 @@ func (a *GmailAdapter) createDraft(ctx context.Context, client *http.Client, par
 	from, _ := fetchSenderAddress(ctx, client)
 
 	fullBody := body + quotedBody
-	raw := buildMIMEMessage(from, to, subject, fullBody, htmlBody, inReplyTo, references)
+	raw := buildMIMEMessage(from, to, cc, bcc, subject, fullBody, htmlBody, inReplyTo, references)
 	encoded := base64.RawURLEncoding.EncodeToString([]byte(raw))
 
 	msg := map[string]string{"raw": encoded}
@@ -1093,7 +1097,7 @@ func decodeBase64(s string) string {
 	return string(b)
 }
 
-func buildMIMEMessage(from, to, subject, body, htmlBody, inReplyTo, references string) string {
+func buildMIMEMessage(from, to, cc, bcc, subject, body, htmlBody, inReplyTo, references string) string {
 	var sb strings.Builder
 	if from != "" {
 		sb.WriteString("From: " + from + "\r\n")
@@ -1101,6 +1105,12 @@ func buildMIMEMessage(from, to, subject, body, htmlBody, inReplyTo, references s
 		sb.WriteString("From: me\r\n")
 	}
 	sb.WriteString("To: " + to + "\r\n")
+	if cc != "" {
+		sb.WriteString("Cc: " + cc + "\r\n")
+	}
+	if bcc != "" {
+		sb.WriteString("Bcc: " + bcc + "\r\n")
+	}
 	sb.WriteString("Subject: " + mime.QEncoding.Encode("utf-8", subject) + "\r\n")
 	if inReplyTo != "" {
 		sb.WriteString("In-Reply-To: " + inReplyTo + "\r\n")

--- a/internal/adapters/google/gmail/adapter.go
+++ b/internal/adapters/google/gmail/adapter.go
@@ -734,7 +734,21 @@ func gmailPOST(ctx context.Context, client *http.Client, url string, payload any
 // header (e.g. "<abc@mail.gmail.com>") and returns the Gmail thread ID.
 // Returns "" if the message can't be found.
 func resolveThreadFromMessageID(ctx context.Context, client *http.Client, messageID string) string {
-	// Gmail search supports rfc822msgid: operator for Message-ID lookup.
+	// If the value doesn't contain angle brackets it's likely a Gmail API
+	// message ID (e.g. "19abc123def") rather than an RFC 2822 Message-ID
+	// (e.g. "<CABx...@mail.gmail.com>"). Agents commonly pass the API ID
+	// since that's the `id` field returned by get_message/list_messages.
+	if !strings.Contains(messageID, "<") {
+		u := fmt.Sprintf("https://gmail.googleapis.com/gmail/v1/users/me/messages/%s?format=minimal", messageID)
+		var msg struct {
+			ThreadId string `json:"threadId"`
+		}
+		if err := gmailGET(ctx, client, u, &msg); err == nil && msg.ThreadId != "" {
+			return msg.ThreadId
+		}
+	}
+
+	// Fall back to rfc822msgid: search for proper RFC 2822 Message-IDs.
 	query := "rfc822msgid:" + messageID
 	url := fmt.Sprintf("https://gmail.googleapis.com/gmail/v1/users/me/messages?maxResults=1&q=%s", encodeParam(query))
 	var resp struct {

--- a/internal/adapters/google/gmail/adapter_test.go
+++ b/internal/adapters/google/gmail/adapter_test.go
@@ -278,6 +278,7 @@ func TestBuildMIMEMessage_WithReferences(t *testing.T) {
 	msg := buildMIMEMessage(
 		"Alice Smith <alice@example.com>",
 		"bob@example.com",
+		"", "",
 		"Re: Test",
 		"Reply body",
 		"",
@@ -303,7 +304,7 @@ func TestBuildMIMEMessage_WithReferences(t *testing.T) {
 }
 
 func TestBuildMIMEMessage_WithoutReferences(t *testing.T) {
-	msg := buildMIMEMessage("", "bob@example.com", "Hello", "Body", "", "", "")
+	msg := buildMIMEMessage("", "bob@example.com", "", "", "Hello", "Body", "", "", "")
 
 	if !strings.Contains(msg, "From: me") {
 		t.Error("should fall back to From: me when from is empty")
@@ -320,6 +321,7 @@ func TestBuildMIMEMessage_WithHTMLAlternative(t *testing.T) {
 	msg := buildMIMEMessage(
 		"Alice Smith <alice@example.com>",
 		"bob@example.com",
+		"", "",
 		"Re: Test",
 		"Reply body\r\n\r\nOn date, person wrote:\r\n> quoted",
 		`<div dir="ltr">Reply body</div><br><div class="gmail_quote gmail_quote_container"><blockquote class="gmail_quote">quoted</blockquote></div>`,


### PR DESCRIPTION
## Summary
- **Draft threading**: `create_draft` now resolves thread context (via `thread_id` or `in_reply_to`), sets proper `In-Reply-To`/`References` MIME headers, includes `threadId` in the API payload, and quotes the previous message — matching `send_message` behavior.
- **CC/BCC**: Added `cc` and `bcc` params to both `send_message` and `create_draft` actions, wired through `buildMIMEMessage` as `Cc:`/`Bcc:` headers.

## Test plan
- [ ] Create a draft reply via `create_draft` with `thread_id` — verify it appears in the correct Gmail thread
- [ ] Create a draft reply via `create_draft` with `in_reply_to` — verify thread resolution works
- [ ] Send a message with `cc` and `bcc` — verify recipients appear correctly
- [ ] Create a draft with `cc` and `bcc` — verify headers are set
- [ ] Existing `send_message` reply flow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)