### PR TITLE
feat(runtime): thread org_id through runtime sessions + agent context

### DIFF
--- a/internal/api/handlers/runtime.go
+++ b/internal/api/handlers/runtime.go
@@ -23,7 +23,7 @@ import (
 )
 
 type RuntimeManager interface {
-	CreateRuntimeSession(ctx context.Context, agentID, userID string, req runtimeproxy.CreateSessionRequest) (*runtimeproxy.CreateSessionResult, error)
+	CreateRuntimeSession(ctx context.Context, agent *store.Agent, req runtimeproxy.CreateSessionRequest) (*runtimeproxy.CreateSessionResult, error)
 	ListRuntimeSessionsForUser(ctx context.Context, userID string) ([]*store.RuntimeSession, error)
 	RevokeRuntimeSession(ctx context.Context, sessionID string) error
 	ProxyURL() string
@@ -70,7 +70,7 @@ func (h *RuntimeHandler) CreateSession(w http.ResponseWriter, r *http.Request) {
 		req.ObservationMode = &observe
 	}
 	req.Metadata = mergeRuntimeSessionMetadata(req.Metadata, *settings)
-	result, err := h.manager.CreateRuntimeSession(r.Context(), agent.ID, agent.UserID, runtimeproxy.CreateSessionRequest{
+	result, err := h.manager.CreateRuntimeSession(r.Context(), agent, runtimeproxy.CreateSessionRequest{
 		Mode:            req.Mode,
 		ObservationMode: req.ObservationMode,
 		TTLSeconds:      req.TTLSeconds,

--- a/internal/store/postgres/migrations/039_runtime_session_org_id.sql
+++ b/internal/store/postgres/migrations/039_runtime_session_org_id.sql
@@ -1,0 +1,15 @@
+-- Phase 0.4: per-runtime-session org_id, populated from agent.org_id at
+-- session creation. Empty string = "no org" (same convention as
+-- agents.org_id). Backfill existing rows from agents in a single statement;
+-- this is safe even on a large table because the column is added with a
+-- default first, then backfilled with a single UPDATE.
+
+ALTER TABLE runtime_sessions ADD COLUMN org_id TEXT NOT NULL DEFAULT '';
+
+UPDATE runtime_sessions s
+   SET org_id = COALESCE(a.org_id, '')
+  FROM agents a
+ WHERE s.agent_id = a.id
+   AND s.org_id = '';
+
+CREATE INDEX IF NOT EXISTS idx_runtime_sessions_org_agent ON runtime_sessions (org_id, agent_id);

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -1566,30 +1566,30 @@ func (s *Store) CreateRuntimeSession(ctx context.Context, sess *store.RuntimeSes
 	}
 	_, err := s.pool.Exec(ctx, `
 		INSERT INTO runtime_sessions (
-			id, user_id, agent_id, mode, proxy_bearer_secret_hash, observation_mode, metadata_json, expires_at, revoked_at
-		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
-	`, sess.ID, sess.UserID, sess.AgentID, sess.Mode, sess.ProxyBearerSecretHash, sess.ObservationMode,
+			id, user_id, agent_id, org_id, mode, proxy_bearer_secret_hash, observation_mode, metadata_json, expires_at, revoked_at
+		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+	`, sess.ID, sess.UserID, sess.AgentID, sess.OrgID, sess.Mode, sess.ProxyBearerSecretHash, sess.ObservationMode,
 		rawJSONOrDefaultBytes(sess.MetadataJSON, "{}"), sess.ExpiresAt, sess.RevokedAt)
 	return err
 }
 
 func (s *Store) GetRuntimeSession(ctx context.Context, id string) (*store.RuntimeSession, error) {
 	return s.getRuntimeSession(ctx, `
-		SELECT id, user_id, agent_id, mode, proxy_bearer_secret_hash, observation_mode, metadata_json, expires_at, created_at, revoked_at
+		SELECT id, user_id, agent_id, org_id, mode, proxy_bearer_secret_hash, observation_mode, metadata_json, expires_at, created_at, revoked_at
 		FROM runtime_sessions WHERE id = $1
 	`, id)
 }
 
 func (s *Store) GetRuntimeSessionByProxyBearerSecretHash(ctx context.Context, secretHash string) (*store.RuntimeSession, error) {
 	return s.getRuntimeSession(ctx, `
-		SELECT id, user_id, agent_id, mode, proxy_bearer_secret_hash, observation_mode, metadata_json, expires_at, created_at, revoked_at
+		SELECT id, user_id, agent_id, org_id, mode, proxy_bearer_secret_hash, observation_mode, metadata_json, expires_at, created_at, revoked_at
 		FROM runtime_sessions WHERE proxy_bearer_secret_hash = $1
 	`, secretHash)
 }
 
 func (s *Store) ListRuntimeSessionsByAgent(ctx context.Context, agentID string) ([]*store.RuntimeSession, error) {
 	rows, err := s.pool.Query(ctx, `
-		SELECT id, user_id, agent_id, mode, proxy_bearer_secret_hash, observation_mode, metadata_json, expires_at, created_at, revoked_at
+		SELECT id, user_id, agent_id, org_id, mode, proxy_bearer_secret_hash, observation_mode, metadata_json, expires_at, created_at, revoked_at
 		FROM runtime_sessions WHERE agent_id = $1 ORDER BY created_at DESC
 	`, agentID)
 	if err != nil {
@@ -1609,7 +1609,7 @@ func (s *Store) ListRuntimeSessionsByAgent(ctx context.Context, agentID string) 
 
 func (s *Store) ListRuntimeSessionsByAgentAndLaunchID(ctx context.Context, agentID, launchID string) ([]*store.RuntimeSession, error) {
 	rows, err := s.pool.Query(ctx, `
-		SELECT id, user_id, agent_id, mode, proxy_bearer_secret_hash, observation_mode, metadata_json, expires_at, created_at, revoked_at
+		SELECT id, user_id, agent_id, org_id, mode, proxy_bearer_secret_hash, observation_mode, metadata_json, expires_at, created_at, revoked_at
 		FROM runtime_sessions
 		WHERE agent_id = $1
 		  AND COALESCE(metadata_json->>'launch_id', '') = $2
@@ -1919,7 +1919,7 @@ func (s *Store) getRuntimeSession(ctx context.Context, query string, arg any) (*
 func scanRuntimeSession(scanner interface{ Scan(dest ...any) error }) (*store.RuntimeSession, error) {
 	sess := &store.RuntimeSession{}
 	var metadataJSON []byte
-	if err := scanner.Scan(&sess.ID, &sess.UserID, &sess.AgentID, &sess.Mode, &sess.ProxyBearerSecretHash,
+	if err := scanner.Scan(&sess.ID, &sess.UserID, &sess.AgentID, &sess.OrgID, &sess.Mode, &sess.ProxyBearerSecretHash,
 		&sess.ObservationMode, &metadataJSON, &sess.ExpiresAt, &sess.CreatedAt, &sess.RevokedAt); err != nil {
 		return nil, err
 	}

--- a/internal/store/sqlite/migrations/039_runtime_session_org_id.sql
+++ b/internal/store/sqlite/migrations/039_runtime_session_org_id.sql
@@ -1,0 +1,9 @@
+-- Phase 0.4: per-runtime-session org_id, populated from agent.org_id at
+-- session creation. Empty string = "no org".
+ALTER TABLE runtime_sessions ADD COLUMN org_id TEXT NOT NULL DEFAULT '';
+
+UPDATE runtime_sessions
+   SET org_id = COALESCE((SELECT org_id FROM agents WHERE agents.id = runtime_sessions.agent_id), '')
+ WHERE org_id = '';
+
+CREATE INDEX IF NOT EXISTS idx_runtime_sessions_org_agent ON runtime_sessions (org_id, agent_id);

--- a/internal/store/sqlite/store.go
+++ b/internal/store/sqlite/store.go
@@ -1718,10 +1718,10 @@ func (s *Store) CreateRuntimeSession(ctx context.Context, sess *store.RuntimeSes
 	}
 	_, err := s.db.ExecContext(ctx, `
 		INSERT INTO runtime_sessions (
-			id, user_id, agent_id, mode, proxy_bearer_secret_hash, observation_mode,
+			id, user_id, agent_id, org_id, mode, proxy_bearer_secret_hash, observation_mode,
 			metadata_json, expires_at, revoked_at
-		) VALUES (?,?,?,?,?,?,?,?,?)
-	`, sess.ID, sess.UserID, sess.AgentID, sess.Mode, sess.ProxyBearerSecretHash,
+		) VALUES (?,?,?,?,?,?,?,?,?,?)
+	`, sess.ID, sess.UserID, sess.AgentID, sess.OrgID, sess.Mode, sess.ProxyBearerSecretHash,
 		boolToInt(sess.ObservationMode), rawJSONOrDefault(sess.MetadataJSON, "{}"),
 		sess.ExpiresAt.UTC().Format(time.RFC3339), formatNullableTime(sess.RevokedAt))
 	return err
@@ -1729,21 +1729,21 @@ func (s *Store) CreateRuntimeSession(ctx context.Context, sess *store.RuntimeSes
 
 func (s *Store) GetRuntimeSession(ctx context.Context, id string) (*store.RuntimeSession, error) {
 	return s.getRuntimeSession(ctx, `
-		SELECT id, user_id, agent_id, mode, proxy_bearer_secret_hash, observation_mode, metadata_json, expires_at, created_at, revoked_at
+		SELECT id, user_id, agent_id, org_id, mode, proxy_bearer_secret_hash, observation_mode, metadata_json, expires_at, created_at, revoked_at
 		FROM runtime_sessions WHERE id = ?
 	`, id)
 }
 
 func (s *Store) GetRuntimeSessionByProxyBearerSecretHash(ctx context.Context, secretHash string) (*store.RuntimeSession, error) {
 	return s.getRuntimeSession(ctx, `
-		SELECT id, user_id, agent_id, mode, proxy_bearer_secret_hash, observation_mode, metadata_json, expires_at, created_at, revoked_at
+		SELECT id, user_id, agent_id, org_id, mode, proxy_bearer_secret_hash, observation_mode, metadata_json, expires_at, created_at, revoked_at
 		FROM runtime_sessions WHERE proxy_bearer_secret_hash = ?
 	`, secretHash)
 }
 
 func (s *Store) ListRuntimeSessionsByAgent(ctx context.Context, agentID string) ([]*store.RuntimeSession, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, user_id, agent_id, mode, proxy_bearer_secret_hash, observation_mode, metadata_json, expires_at, created_at, revoked_at
+		SELECT id, user_id, agent_id, org_id, mode, proxy_bearer_secret_hash, observation_mode, metadata_json, expires_at, created_at, revoked_at
 		FROM runtime_sessions WHERE agent_id = ? ORDER BY created_at DESC
 	`, agentID)
 	if err != nil {
@@ -1763,7 +1763,7 @@ func (s *Store) ListRuntimeSessionsByAgent(ctx context.Context, agentID string) 
 
 func (s *Store) ListRuntimeSessionsByAgentAndLaunchID(ctx context.Context, agentID, launchID string) ([]*store.RuntimeSession, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, user_id, agent_id, mode, proxy_bearer_secret_hash, observation_mode, metadata_json, expires_at, created_at, revoked_at
+		SELECT id, user_id, agent_id, org_id, mode, proxy_bearer_secret_hash, observation_mode, metadata_json, expires_at, created_at, revoked_at
 		FROM runtime_sessions
 		WHERE agent_id = ?
 		  AND COALESCE(json_extract(metadata_json, '$.launch_id'), '') = ?
@@ -2093,7 +2093,7 @@ func scanSQLiteRuntimeSession(scanner interface{ Scan(dest ...any) error }) (*st
 	var metadataJSON, expiresAt, createdAt string
 	var observationMode int
 	var revokedAt *string
-	if err := scanner.Scan(&sess.ID, &sess.UserID, &sess.AgentID, &sess.Mode, &sess.ProxyBearerSecretHash,
+	if err := scanner.Scan(&sess.ID, &sess.UserID, &sess.AgentID, &sess.OrgID, &sess.Mode, &sess.ProxyBearerSecretHash,
 		&observationMode, &metadataJSON, &expiresAt, &createdAt, &revokedAt); err != nil {
 		return nil, err
 	}

--- a/pkg/runtime/proxy/auth.go
+++ b/pkg/runtime/proxy/auth.go
@@ -197,6 +197,7 @@ func (a *Authenticator) getOrCreateAgentRuntimeSession(ctx context.Context, agen
 		ID:                    uuid.NewString(),
 		UserID:                agent.UserID,
 		AgentID:               agent.ID,
+		OrgID:                 agent.OrgID,
 		Mode:                  "proxy",
 		ProxyBearerSecretHash: HashProxyBearerSecret(secret),
 		ObservationMode:       wantObservation,

--- a/pkg/runtime/proxy/manager.go
+++ b/pkg/runtime/proxy/manager.go
@@ -38,9 +38,12 @@ type CreateSessionResult struct {
 	ObservationMode bool                  `json:"observation_mode"`
 }
 
-func (m *Manager) CreateRuntimeSession(ctx context.Context, agentID, userID string, req CreateSessionRequest) (*CreateSessionResult, error) {
+func (m *Manager) CreateRuntimeSession(ctx context.Context, agent *store.Agent, req CreateSessionRequest) (*CreateSessionResult, error) {
 	if m.Config == nil {
 		return nil, fmt.Errorf("runtime config is unavailable")
+	}
+	if agent == nil {
+		return nil, fmt.Errorf("agent is required")
 	}
 	if req.Mode == "" {
 		req.Mode = "proxy"
@@ -66,8 +69,9 @@ func (m *Manager) CreateRuntimeSession(ctx context.Context, agentID, userID stri
 	}
 	session := &store.RuntimeSession{
 		ID:                    uuid.NewString(),
-		UserID:                userID,
-		AgentID:               agentID,
+		UserID:                agent.UserID,
+		AgentID:               agent.ID,
+		OrgID:                 agent.OrgID,
 		Mode:                  req.Mode,
 		ProxyBearerSecretHash: HashProxyBearerSecret(secret),
 		ObservationMode:       observation,

--- a/pkg/runtime/proxy/manager_test.go
+++ b/pkg/runtime/proxy/manager_test.go
@@ -55,7 +55,7 @@ func TestManagerCreateRuntimeSession(t *testing.T) {
 		Config: cfg,
 		Proxy:  srv,
 	}
-	result, err := manager.CreateRuntimeSession(ctx, agent.ID, user.ID, CreateSessionRequest{})
+	result, err := manager.CreateRuntimeSession(ctx, agent, CreateSessionRequest{})
 	if err != nil {
 		t.Fatalf("CreateRuntimeSession: %v", err)
 	}

--- a/pkg/runtime/proxy/session_guard.go
+++ b/pkg/runtime/proxy/session_guard.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/elazarl/goproxy"
+
+	"github.com/clawvisor/clawvisor/pkg/store"
 )
 
 func (s *Server) InstallSessionGuard(auth *Authenticator) {
@@ -19,6 +21,7 @@ func (s *Server) InstallSessionGuard(auth *Authenticator) {
 		ctx.Req.Header.Del(internalBypassHeader)
 		st := EnsureState(ctx)
 		st.Session = sess
+		ctx.Req = withSessionAgent(ctx.Req, sess)
 		ctx.Req = s.attachTimingRecorder(ctx.Req, st)
 		s.recordTimingSpan(ctx.Req, "session_guard.auth", t0)
 		return goproxy.MitmConnect, host
@@ -27,6 +30,7 @@ func (s *Server) InstallSessionGuard(auth *Authenticator) {
 		st := StateOf(ctx)
 		if st != nil && st.Session != nil && st.Session.ID != "" {
 			req.Header.Del(internalBypassHeader)
+			req = withSessionAgent(req, st.Session)
 			req = s.attachTimingRecorder(req, st)
 			if ctx != nil && ctx.Req != nil {
 				ctx.Req = req
@@ -44,6 +48,7 @@ func (s *Server) InstallSessionGuard(auth *Authenticator) {
 		}
 		st = EnsureState(ctx)
 		st.Session = sess
+		req = withSessionAgent(req, sess)
 		req = s.attachTimingRecorder(req, st)
 		s.recordTimingSpan(req, "session_guard.auth", t0)
 		if ctx != nil && ctx.Req != nil {
@@ -51,6 +56,26 @@ func (s *Server) InstallSessionGuard(auth *Authenticator) {
 		}
 		return req, nil
 	})
+}
+
+// withSessionAgent attaches a minimal Agent value to the request context so
+// downstream OrgAwareVault.Resolve (and any other store.AgentFromContext
+// reader) can resolve org-scoped state without an extra DB lookup. The
+// synthesized Agent carries IDs only — other fields are intentionally empty.
+func withSessionAgent(req *http.Request, sess *store.RuntimeSession) *http.Request {
+	if req == nil || sess == nil {
+		return req
+	}
+	ctx := req.Context()
+	if store.AgentFromContext(ctx) != nil {
+		return req
+	}
+	agent := &store.Agent{
+		ID:     sess.AgentID,
+		UserID: sess.UserID,
+		OrgID:  sess.OrgID,
+	}
+	return req.WithContext(store.WithAgent(ctx, agent))
 }
 
 func authRequiredResponse(req *http.Request, err error) *http.Response {

--- a/pkg/runtime/proxy/session_guard_test.go
+++ b/pkg/runtime/proxy/session_guard_test.go
@@ -7,8 +7,12 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"testing"
+	"time"
+
+	"github.com/elazarl/goproxy"
 
 	"github.com/clawvisor/clawvisor/internal/store/sqlite"
+	"github.com/clawvisor/clawvisor/pkg/store"
 )
 
 func TestSessionGuardStripsInternalBypassHeader(t *testing.T) {
@@ -55,5 +59,90 @@ func TestSessionGuardStripsInternalBypassHeader(t *testing.T) {
 	}
 	if seenBypass != "" {
 		t.Fatalf("expected internal bypass header to be stripped, got %q", seenBypass)
+	}
+}
+
+// TestSessionGuardPropagatesAgentContext verifies that authenticated requests
+// carry a synthesized *store.Agent in the request context (UserID, AgentID,
+// OrgID from the runtime session), so downstream hooks like
+// OrgAwareVault.Resolve can reach org-shared credentials without an extra DB
+// lookup. Phase 0.4 deliverable.
+//
+// We capture the context from a goproxy OnRequest hook installed AFTER the
+// session guard, since that's the surface where downstream hook code reads
+// it. (The upstream HTTP test server can't observe Go context — only headers
+// — so its request scope is unsuitable for this assertion.)
+func TestSessionGuardPropagatesAgentContext(t *testing.T) {
+	ctx := context.Background()
+	db, err := sqlite.New(ctx, filepath.Join(t.TempDir(), "agent-ctx.db"))
+	if err != nil {
+		t.Fatalf("sqlite.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	st := sqlite.NewStore(db)
+
+	userID, agentID := seedRuntimePrincipal(t, st)
+
+	const wantOrgID = "org-alpha"
+	secret := "ctx-secret"
+	sess := &store.RuntimeSession{
+		ID:                    "ctx-session",
+		UserID:                userID,
+		AgentID:               agentID,
+		OrgID:                 wantOrgID,
+		Mode:                  "proxy",
+		ProxyBearerSecretHash: HashProxyBearerSecret(secret),
+		ExpiresAt:             time.Now().UTC().Add(30 * time.Minute),
+	}
+	if err := st.CreateRuntimeSession(ctx, sess); err != nil {
+		t.Fatalf("CreateRuntimeSession: %v", err)
+	}
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	srv, err := NewServer(Config{DataDir: t.TempDir(), Addr: "127.0.0.1:0"}, nil)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	srv.InstallSessionGuard(&Authenticator{Store: st})
+
+	var seenAgent *store.Agent
+	// Install a downstream hook that captures context.
+	srv.GoProxy().OnRequest().DoFunc(func(req *http.Request, _ *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+		seenAgent = store.AgentFromContext(req.Context())
+		return req, nil
+	})
+
+	if err := srv.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = srv.Shutdown(ctx) }()
+
+	client := proxyHTTPClient(t, srv)
+	req, _ := http.NewRequest(http.MethodGet, upstream.URL, nil)
+	req.Header.Set("Proxy-Authorization", "Bearer "+secret)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("proxy request: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK || string(body) != "ok" {
+		t.Fatalf("expected upstream success, got %d %q", resp.StatusCode, string(body))
+	}
+	if seenAgent == nil {
+		t.Fatal("expected downstream hook to observe an Agent in context, got nil")
+	}
+	if seenAgent.UserID != userID {
+		t.Errorf("agent UserID = %q, want %q", seenAgent.UserID, userID)
+	}
+	if seenAgent.ID != agentID {
+		t.Errorf("agent ID = %q, want %q", seenAgent.ID, agentID)
+	}
+	if seenAgent.OrgID != wantOrgID {
+		t.Errorf("agent OrgID = %q, want %q", seenAgent.OrgID, wantOrgID)
 	}
 }

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -503,6 +503,7 @@ type RuntimeSession struct {
 	ID                    string          `json:"id"`
 	UserID                string          `json:"user_id"`
 	AgentID               string          `json:"agent_id"`
+	OrgID                 string          `json:"org_id,omitempty"`
 	Mode                  string          `json:"mode"`
 	ProxyBearerSecretHash string          `json:"proxy_bearer_secret_hash"`
 	ObservationMode       bool            `json:"observation_mode"`


### PR DESCRIPTION
## Summary

Adds `OrgID` to `store.RuntimeSession` and injects a synthesized `*store.Agent` into the request context inside `session_guard`. Downstream `OrgAwareVault.Resolve` and any other `store.AgentFromContext` reader now sees the session's user/agent/org IDs without an extra DB lookup.

## Why

`OrgAwareVault.Resolve` only checks org-shared credentials when `store.AgentFromContext(ctx)` returns a non-nil agent with a populated `OrgID`. The runtime proxy does not currently inject an `Agent` into the request context — `session_guard` stores a `RuntimeSession`, and `RuntimeSession` had no `OrgID` field. Without this fix, **all org-shared credential lookups silently fall through to the user-scope path**, even for users who belong to an org.

This is the prerequisite for cloud's per-org credential resolution to work correctly through the runtime proxy.

## Changes

- **Schema**: `runtime_sessions.org_id TEXT NOT NULL DEFAULT ''` — new column, populated from `agents.org_id` at session create. Backfill UPDATE included in the migration; expected to run in <30s on any sane row count. See `internal/store/{postgres,sqlite}/migrations/039_runtime_session_org_id.sql`.
- **Struct**: `store.RuntimeSession.OrgID` field (with `omitempty` JSON).
- **API change**: `Manager.CreateRuntimeSession(ctx, agentID, userID, req)` → `Manager.CreateRuntimeSession(ctx, agent *store.Agent, req)`. Two callsites updated. The new signature carries `OrgID` into the new session row directly. Agent-token reuse path (`auth.go`) similarly populates `OrgID` from `agent.OrgID`.
- **Context wiring**: new `withSessionAgent` helper in `session_guard.go` attaches a minimal `Agent` value (UserID/ID/OrgID only) to `req.Context()` on both CONNECT and direct paths.
- **Test**: `TestSessionGuardPropagatesAgentContext` asserts the synthesized Agent surfaces in downstream hooks with the right `OrgID`.

## Migration safety

- `ALTER TABLE … ADD COLUMN … NOT NULL DEFAULT ''` on Postgres 11+ does NOT rewrite the table — only an `ACCESS EXCLUSIVE` lock during the metadata change. The backfill `UPDATE` runs in a separate step and only updates rows that need it.
- Old binaries (no `OrgID` field on the struct) coexist with the migrated schema: writes get column `DEFAULT ''`, reads ignore the new column. No application downtime needed.
- During the backfill window, sessions whose `org_id` hasn't been written yet fall back to the user-scope vault path. This is the same behavior as today (graceful degradation), bounded by backfill duration.

## Test plan

- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test ./...` — all packages pass, including the new context-propagation test in `pkg/runtime/proxy/session_guard_test.go`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)