### PR TITLE
feat(runtime): per-session overrides for InlineApproval, lease TTL, harness allowlist

### DIFF
--- a/pkg/runtime/proxy/policy_hook.go
+++ b/pkg/runtime/proxy/policy_hook.go
@@ -70,7 +70,7 @@ func (s *Server) InstallEgressPolicy(hooks PolicyHooks) {
 		req.ContentLength = int64(len(bodyBytes))
 
 		host := requestHost(req)
-		if isHarnessAllowlisted(hooks.Config, host) {
+		if isHarnessAllowlistedForSession(st.Session, hooks.Config, host) {
 			return req, nil
 		}
 		reqFingerprint := fingerprintRequest(st.Session.AgentID, req, bodyBytes)
@@ -730,6 +730,14 @@ func firstNonEmpty(values ...string) string {
 }
 
 func isHarnessAllowlisted(cfg *config.Config, host string) bool {
+	return isHarnessAllowlistedForSession(nil, cfg, host)
+}
+
+// isHarnessAllowlistedForSession returns whether the given host is on the
+// harness allowlist for this session. Per-session allowlist override (when
+// non-empty) takes precedence over cfg.RuntimePolicy.HarnessAllowlist; the
+// LLM endpoint and the built-in defaults always pass through regardless.
+func isHarnessAllowlistedForSession(session *store.RuntimeSession, cfg *config.Config, host string) bool {
 	host = strings.ToLower(strings.TrimSpace(host))
 	if host == "" {
 		return false
@@ -738,14 +746,14 @@ func isHarnessAllowlisted(cfg *config.Config, host string) bool {
 		if endpointHost := normalizedEndpointHost(cfg.LLM.Endpoint); endpointHost != "" && host == endpointHost {
 			return true
 		}
-		for _, allowed := range cfg.RuntimePolicy.HarnessAllowlist {
-			allowed = strings.ToLower(strings.TrimSpace(allowed))
-			if allowed == "" {
-				continue
-			}
-			if host == allowed || strings.HasSuffix(host, "."+allowed) {
-				return true
-			}
+	}
+	for _, allowed := range sessionHarnessAllowlist(session, cfg) {
+		allowed = strings.ToLower(strings.TrimSpace(allowed))
+		if allowed == "" {
+			continue
+		}
+		if host == allowed || strings.HasSuffix(host, "."+allowed) {
+			return true
 		}
 	}
 	switch host {

--- a/pkg/runtime/proxy/session_settings.go
+++ b/pkg/runtime/proxy/session_settings.go
@@ -20,9 +20,17 @@ type sessionRuntimeSettings struct {
 	// only from cfg.RuntimePolicy. Cloud realizes these from per-org
 	// policy at session-create time; daemon mode leaves them zero and
 	// the accessors fall back to the global cfg value.
-	InlineApprovalEnabled   *bool    `json:"inline_approval_enabled,omitempty"`
-	ToolLeaseTimeoutSeconds int      `json:"tool_lease_timeout_seconds,omitempty"`
-	HarnessAllowlist        []string `json:"harness_allowlist,omitempty"`
+	//
+	// HarnessAllowlist uses *[]string so a tenant can explicitly express
+	// "empty allowlist" — i.e. the override is `[]`, which means only
+	// the built-in defaults (api.anthropic.com etc.) and cfg.LLM.Endpoint
+	// pass. A `nil` pointer means "no override; use cfg." Without the
+	// pointer, an empty slice is indistinguishable from absent in JSON
+	// round-trips, and the allowlist override silently degrades to the
+	// global cfg.
+	InlineApprovalEnabled   *bool     `json:"inline_approval_enabled,omitempty"`
+	ToolLeaseTimeoutSeconds int       `json:"tool_lease_timeout_seconds,omitempty"`
+	HarnessAllowlist        *[]string `json:"harness_allowlist,omitempty"`
 }
 
 func mergedAgentRuntimeSettings(agent *store.Agent, cfg *config.Config) sessionRuntimeSettings {
@@ -77,7 +85,7 @@ func sessionRuntimeSettingsFromMetadata(session *store.RuntimeSession, cfg *conf
 	if parsed.ToolLeaseTimeoutSeconds > 0 {
 		settings.ToolLeaseTimeoutSeconds = parsed.ToolLeaseTimeoutSeconds
 	}
-	if len(parsed.HarnessAllowlist) > 0 {
+	if parsed.HarnessAllowlist != nil {
 		settings.HarnessAllowlist = parsed.HarnessAllowlist
 	}
 	return settings
@@ -122,11 +130,13 @@ func sessionToolLeaseTTL(session *store.RuntimeSession, cfg *config.Config) time
 }
 
 // sessionHarnessAllowlist returns the harness allowlist for this session.
-// Per-session override (non-empty) wins; otherwise falls back to cfg.
+// A non-nil per-session override wins (including an explicit empty list,
+// which means "deny everything except the built-in defaults"). A nil
+// override falls back to cfg.RuntimePolicy.HarnessAllowlist.
 func sessionHarnessAllowlist(session *store.RuntimeSession, cfg *config.Config) []string {
 	settings := sessionRuntimeSettingsFromMetadata(session, cfg)
-	if len(settings.HarnessAllowlist) > 0 {
-		return settings.HarnessAllowlist
+	if settings.HarnessAllowlist != nil {
+		return *settings.HarnessAllowlist
 	}
 	if cfg == nil {
 		return nil

--- a/pkg/runtime/proxy/session_settings.go
+++ b/pkg/runtime/proxy/session_settings.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"encoding/json"
 	"strings"
+	"time"
 
 	"github.com/clawvisor/clawvisor/pkg/config"
 	"github.com/clawvisor/clawvisor/pkg/store"
@@ -14,6 +15,14 @@ type sessionRuntimeSettings struct {
 	StarterProfile         string `json:"starter_profile"`
 	OutboundCredentialMode string `json:"outbound_credential_mode"`
 	InjectStoredBearer     bool   `json:"inject_stored_bearer"`
+
+	// Phase 0.6: per-session overrides for fields previously sourced
+	// only from cfg.RuntimePolicy. Cloud realizes these from per-org
+	// policy at session-create time; daemon mode leaves them zero and
+	// the accessors fall back to the global cfg value.
+	InlineApprovalEnabled   *bool    `json:"inline_approval_enabled,omitempty"`
+	ToolLeaseTimeoutSeconds int      `json:"tool_lease_timeout_seconds,omitempty"`
+	HarnessAllowlist        []string `json:"harness_allowlist,omitempty"`
 }
 
 func mergedAgentRuntimeSettings(agent *store.Agent, cfg *config.Config) sessionRuntimeSettings {
@@ -62,6 +71,15 @@ func sessionRuntimeSettingsFromMetadata(session *store.RuntimeSession, cfg *conf
 	if hasMetadataBool(session.MetadataJSON, "inject_stored_bearer") {
 		settings.InjectStoredBearer = parsed.InjectStoredBearer
 	}
+	if parsed.InlineApprovalEnabled != nil {
+		settings.InlineApprovalEnabled = parsed.InlineApprovalEnabled
+	}
+	if parsed.ToolLeaseTimeoutSeconds > 0 {
+		settings.ToolLeaseTimeoutSeconds = parsed.ToolLeaseTimeoutSeconds
+	}
+	if len(parsed.HarnessAllowlist) > 0 {
+		settings.HarnessAllowlist = parsed.HarnessAllowlist
+	}
 	return settings
 }
 
@@ -80,6 +98,40 @@ func sessionAutovaultMode(session *store.RuntimeSession, cfg *config.Config) str
 func sessionShouldInjectStoredBearer(session *store.RuntimeSession, cfg *config.Config) bool {
 	settings := sessionRuntimeSettingsFromMetadata(session, cfg)
 	return settings.InjectStoredBearer
+}
+
+// sessionInlineApprovalEnabled returns whether inline approval is enabled
+// for this session. Per-session override (when set) wins; otherwise falls
+// back to cfg.RuntimePolicy.InlineApprovalEnabled.
+func sessionInlineApprovalEnabled(session *store.RuntimeSession, cfg *config.Config) bool {
+	settings := sessionRuntimeSettingsFromMetadata(session, cfg)
+	if settings.InlineApprovalEnabled != nil {
+		return *settings.InlineApprovalEnabled
+	}
+	return cfg != nil && cfg.RuntimePolicy.InlineApprovalEnabled
+}
+
+// sessionToolLeaseTTL returns the lease TTL for this session. Per-session
+// override (positive value) wins; otherwise falls back to cfg.
+func sessionToolLeaseTTL(session *store.RuntimeSession, cfg *config.Config) time.Duration {
+	settings := sessionRuntimeSettingsFromMetadata(session, cfg)
+	if settings.ToolLeaseTimeoutSeconds > 0 {
+		return time.Duration(settings.ToolLeaseTimeoutSeconds) * time.Second
+	}
+	return toolLeaseTTL(cfg)
+}
+
+// sessionHarnessAllowlist returns the harness allowlist for this session.
+// Per-session override (non-empty) wins; otherwise falls back to cfg.
+func sessionHarnessAllowlist(session *store.RuntimeSession, cfg *config.Config) []string {
+	settings := sessionRuntimeSettingsFromMetadata(session, cfg)
+	if len(settings.HarnessAllowlist) > 0 {
+		return settings.HarnessAllowlist
+	}
+	if cfg == nil {
+		return nil
+	}
+	return cfg.RuntimePolicy.HarnessAllowlist
 }
 
 func firstNonEmptyLower(values ...string) string {

--- a/pkg/runtime/proxy/session_settings_test.go
+++ b/pkg/runtime/proxy/session_settings_test.go
@@ -2,9 +2,11 @@ package proxy
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/clawvisor/clawvisor/internal/runtime/review"
 	"github.com/clawvisor/clawvisor/pkg/config"
 	"github.com/clawvisor/clawvisor/pkg/store"
 )
@@ -70,12 +72,66 @@ func TestSessionHarnessAllowlist_Override(t *testing.T) {
 		t.Errorf("no-override fallback: got %v", got)
 	}
 
-	// Override wins
+	// Populated override wins
 	raw, _ := json.Marshal(map[string]any{"harness_allowlist": []string{"override.example"}})
 	sess := &store.RuntimeSession{MetadataJSON: raw}
 	got := sessionHarnessAllowlist(sess, cfg)
 	if len(got) != 1 || got[0] != "override.example" {
-		t.Errorf("override: got %v", got)
+		t.Errorf("populated override: got %v", got)
+	}
+
+	// Explicit empty override wins — must NOT silently fall back to cfg.
+	// This is the case a tenant uses to express "deny everything except
+	// the built-in defaults and cfg.LLM.Endpoint."
+	rawEmpty, _ := json.Marshal(map[string]any{"harness_allowlist": []string{}})
+	sessEmpty := &store.RuntimeSession{MetadataJSON: rawEmpty}
+	gotEmpty := sessionHarnessAllowlist(sessEmpty, cfg)
+	if gotEmpty == nil {
+		t.Errorf("explicit empty override should yield non-nil empty slice, got nil")
+	}
+	if len(gotEmpty) != 0 {
+		t.Errorf("explicit empty override should yield empty slice, got %v (silently fell back to cfg?)", gotEmpty)
+	}
+}
+
+// TestApprovalSurface_RespectsSessionOverride confirms that the
+// held-approval Surface field and the rendered prompt text both honor
+// the per-session InlineApproval override, not just the global cfg.
+// Without this, a session-level disable of inline approvals (or a
+// session-level enable when cfg has it off) produces an inconsistent
+// approval experience: cfg says "dashboard" but session says "inline",
+// or vice versa.
+func TestApprovalSurface_RespectsSessionOverride(t *testing.T) {
+	cfgInline := &config.Config{}
+	cfgInline.RuntimePolicy.InlineApprovalEnabled = true
+	cfgDashboard := &config.Config{}
+	cfgDashboard.RuntimePolicy.InlineApprovalEnabled = false
+
+	inlineOn := true
+	inlineOff := false
+	rawInlineOn, _ := json.Marshal(map[string]any{"inline_approval_enabled": true})
+	rawInlineOff, _ := json.Marshal(map[string]any{"inline_approval_enabled": false})
+	sessInlineOn := &store.RuntimeSession{MetadataJSON: rawInlineOn}
+	sessInlineOff := &store.RuntimeSession{MetadataJSON: rawInlineOff}
+	_ = inlineOn
+	_ = inlineOff
+
+	// cfg=dashboard, session=inline → inline wins
+	if got := approvalSurface(sessInlineOn, cfgDashboard); got != "inline" {
+		t.Errorf("session=inline, cfg=dashboard → approvalSurface=%q, want inline", got)
+	}
+	// cfg=inline, session=dashboard → dashboard wins
+	if got := approvalSurface(sessInlineOff, cfgInline); got != "dashboard" {
+		t.Errorf("session=dashboard, cfg=inline → approvalSurface=%q, want dashboard", got)
+	}
+
+	// Held-approval prompt rendering follows the same rule.
+	held := &review.HeldApproval{ID: "abc", ToolName: "Bash", ToolInput: map[string]any{"cmd": "ls"}}
+	if got := renderHeldToolUsePrompt(held, sessInlineOn, cfgDashboard); !strings.Contains(got, "Reply `approve`") {
+		t.Errorf("session=inline override should produce inline prompt; got %q", got)
+	}
+	if got := renderHeldToolUsePrompt(held, sessInlineOff, cfgInline); !strings.Contains(got, "Pending approval in the dashboard") {
+		t.Errorf("session=dashboard override should produce dashboard prompt; got %q", got)
 	}
 }
 
@@ -99,5 +155,19 @@ func TestIsHarnessAllowlistedForSession_OverrideAndDefaults(t *testing.T) {
 	}
 	if isHarnessAllowlistedForSession(sess, cfg, "elsewhere.example") {
 		t.Errorf("per-session override should not allow elsewhere.example")
+	}
+
+	// Explicit empty allowlist: built-in defaults still pass, but cfg
+	// fallback must NOT kick in (the tenant deliberately wanted no
+	// extra allowed hosts beyond the built-ins).
+	cfgWithGlobal := &config.Config{}
+	cfgWithGlobal.RuntimePolicy.HarnessAllowlist = []string{"global.example"}
+	rawEmpty, _ := json.Marshal(map[string]any{"harness_allowlist": []string{}})
+	sessEmpty := &store.RuntimeSession{MetadataJSON: rawEmpty}
+	if !isHarnessAllowlistedForSession(sessEmpty, cfgWithGlobal, "api.anthropic.com") {
+		t.Errorf("built-in defaults must still pass under explicit empty override")
+	}
+	if isHarnessAllowlistedForSession(sessEmpty, cfgWithGlobal, "global.example") {
+		t.Errorf("explicit empty override must NOT silently fall back to cfg allowlist")
 	}
 }

--- a/pkg/runtime/proxy/session_settings_test.go
+++ b/pkg/runtime/proxy/session_settings_test.go
@@ -1,0 +1,103 @@
+package proxy
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/clawvisor/clawvisor/pkg/config"
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+func TestSessionInlineApprovalEnabled_Override(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.RuntimePolicy.InlineApprovalEnabled = false
+
+	tt := []struct {
+		name     string
+		metadata map[string]any
+		want     bool
+	}{
+		{name: "no override → falls through to cfg false", metadata: map[string]any{}, want: false},
+		{name: "explicit true override wins over cfg false", metadata: map[string]any{"inline_approval_enabled": true}, want: true},
+		{name: "explicit false override wins over cfg true (after toggle below)", metadata: map[string]any{"inline_approval_enabled": false}, want: false},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, err := json.Marshal(tc.metadata)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			sess := &store.RuntimeSession{MetadataJSON: raw, ExpiresAt: time.Now().Add(time.Hour)}
+			got := sessionInlineApprovalEnabled(sess, cfg)
+			if got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+
+	// Confirm cfg fallback when metadata says nothing.
+	cfg.RuntimePolicy.InlineApprovalEnabled = true
+	if !sessionInlineApprovalEnabled(&store.RuntimeSession{}, cfg) {
+		t.Errorf("expected cfg fallback to surface true")
+	}
+}
+
+func TestSessionToolLeaseTTL_Override(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.RuntimePolicy.ToolLeaseTimeoutSeconds = 60
+
+	// No override → cfg value
+	if got := sessionToolLeaseTTL(&store.RuntimeSession{}, cfg); got != 60*time.Second {
+		t.Errorf("no-override fallback: got %v, want 60s", got)
+	}
+
+	// Override wins
+	raw, _ := json.Marshal(map[string]any{"tool_lease_timeout_seconds": 300})
+	sess := &store.RuntimeSession{MetadataJSON: raw}
+	if got := sessionToolLeaseTTL(sess, cfg); got != 300*time.Second {
+		t.Errorf("override: got %v, want 300s", got)
+	}
+}
+
+func TestSessionHarnessAllowlist_Override(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.RuntimePolicy.HarnessAllowlist = []string{"global.example"}
+
+	// No override → cfg value
+	if got := sessionHarnessAllowlist(&store.RuntimeSession{}, cfg); len(got) != 1 || got[0] != "global.example" {
+		t.Errorf("no-override fallback: got %v", got)
+	}
+
+	// Override wins
+	raw, _ := json.Marshal(map[string]any{"harness_allowlist": []string{"override.example"}})
+	sess := &store.RuntimeSession{MetadataJSON: raw}
+	got := sessionHarnessAllowlist(sess, cfg)
+	if len(got) != 1 || got[0] != "override.example" {
+		t.Errorf("override: got %v", got)
+	}
+}
+
+func TestIsHarnessAllowlistedForSession_OverrideAndDefaults(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.RuntimePolicy.HarnessAllowlist = nil
+
+	// Built-in defaults always pass
+	if !isHarnessAllowlistedForSession(nil, cfg, "api.anthropic.com") {
+		t.Errorf("api.anthropic.com should always be allowed")
+	}
+
+	// Per-session override
+	raw, _ := json.Marshal(map[string]any{"harness_allowlist": []string{"my.org"}})
+	sess := &store.RuntimeSession{MetadataJSON: raw}
+	if !isHarnessAllowlistedForSession(sess, cfg, "my.org") {
+		t.Errorf("per-session override should allow my.org")
+	}
+	if !isHarnessAllowlistedForSession(sess, cfg, "sub.my.org") {
+		t.Errorf("per-session override should allow sub.my.org as suffix match")
+	}
+	if isHarnessAllowlistedForSession(sess, cfg, "elsewhere.example") {
+		t.Errorf("per-session override should not allow elsewhere.example")
+	}
+}

--- a/pkg/runtime/proxy/tooluse_runtime.go
+++ b/pkg/runtime/proxy/tooluse_runtime.go
@@ -714,7 +714,7 @@ func (s *Server) ensureHeldToolUseApprovalWithKind(ctx context.Context, hooks To
 			TaskID:              taskIDPtr(reviewTask),
 			SessionID:           &session.ID,
 			Status:              "pending",
-			Surface:             approvalSurface(hooks.Config),
+			Surface:             approvalSurface(session, hooks.Config),
 			SummaryJSON:         summaryJSON,
 			PayloadJSON:         payloadJSON,
 			ResolutionTransport: "release_held_tool_use",
@@ -726,10 +726,10 @@ func (s *Server) ensureHeldToolUseApprovalWithKind(ctx context.Context, hooks To
 
 	held, ok := hooks.ReviewCache.Hold(session.ID, rec.ID, taskIDOrEmpty(reviewTask), tu.ID, tu.Name, input, reason)
 	if ok {
-		return rec, held, renderHeldToolUsePrompt(held, hooks.Config)
+		return rec, held, renderHeldToolUsePrompt(held, session, hooks.Config)
 	}
 	existing := hooks.ReviewCache.GetByApprovalRecord(session.ID, rec.ID)
-	return rec, existing, renderExistingHeldPrompt(existing, hooks.Config)
+	return rec, existing, renderExistingHeldPrompt(existing, session, hooks.Config)
 }
 
 func loadRuntimeCandidateTasks(ctx context.Context, st store.Store, session *store.RuntimeSession) ([]*store.Task, error) {
@@ -804,26 +804,26 @@ func decodeToolInput(raw json.RawMessage) map[string]any {
 	return out
 }
 
-func renderHeldToolUsePrompt(held *review.HeldApproval, cfg *config.Config) string {
+func renderHeldToolUsePrompt(held *review.HeldApproval, session *store.RuntimeSession, cfg *config.Config) string {
 	if held == nil {
 		return "Tool use requires runtime approval in Clawvisor before it can run."
 	}
 	subject := summarizeToolUse(held.ToolName, held.ToolInput)
-	if cfg != nil && cfg.RuntimePolicy.InlineApprovalEnabled {
+	if sessionInlineApprovalEnabled(session, cfg) {
 		return "Clawvisor paused:\n\n" + subject + "\n\nReply `approve` to run it or `deny` to block it. You can also approve it from the Clawvisor dashboard."
 	}
 	return "Clawvisor paused:\n\n" + subject + "\n\nPending approval in the dashboard.\nApproval ID: " + held.ID
 }
 
-func renderExistingHeldPrompt(held *review.HeldApproval, cfg *config.Config) string {
+func renderExistingHeldPrompt(held *review.HeldApproval, session *store.RuntimeSession, cfg *config.Config) string {
 	if held == nil {
 		return "Clawvisor already has a pending runtime approval for this session."
 	}
-	return renderHeldToolUsePrompt(held, cfg)
+	return renderHeldToolUsePrompt(held, session, cfg)
 }
 
-func approvalSurface(cfg *config.Config) string {
-	if cfg != nil && cfg.RuntimePolicy.InlineApprovalEnabled {
+func approvalSurface(session *store.RuntimeSession, cfg *config.Config) string {
+	if sessionInlineApprovalEnabled(session, cfg) {
 		return "inline"
 	}
 	return "dashboard"

--- a/pkg/runtime/proxy/tooluse_runtime.go
+++ b/pkg/runtime/proxy/tooluse_runtime.go
@@ -94,7 +94,7 @@ func (s *Server) installHeldApprovalRelease(hooks ToolUseHooks) {
 			return s.syntheticHeldToolUseResponse(req, st.Session, hooks, resolved, allowed, reason, body)
 		}
 
-		if hooks.Config == nil || !hooks.Config.RuntimePolicy.InlineApprovalEnabled {
+		if !sessionInlineApprovalEnabled(st.Session, hooks.Config) {
 			return req, nil
 		}
 		inlineStartedAt := time.Now()
@@ -157,7 +157,7 @@ func (s *Server) syntheticHeldToolUseResponse(req *http.Request, session *store.
 	var leaseID *string
 	usedActiveTaskContext := false
 	if allow && held.TaskID != "" {
-		lease, err := hooks.Leases.Open(req.Context(), session.ID, held.TaskID, held.ToolUseID, held.ToolName, toolLeaseTTL(hooks.Config))
+		lease, err := hooks.Leases.Open(req.Context(), session.ID, held.TaskID, held.ToolUseID, held.ToolName, sessionToolLeaseTTL(session, hooks.Config))
 		if err == nil && lease != nil {
 			leaseID = &lease.LeaseID
 			emitRuntimeEvent(req.Context(), hooks.Store, session, nil, runtimeEventOptions{
@@ -351,7 +351,7 @@ func (s *Server) handleToolUseBlockedResponse(resp *http.Response, ctx *goproxy.
 						Rule:              matchedRule,
 						Task:              reviewTask,
 						WouldReview:       true,
-						WouldPromptInline: hooks.Config != nil && hooks.Config.RuntimePolicy.InlineApprovalEnabled,
+						WouldPromptInline: sessionInlineApprovalEnabled(st.Session, hooks.Config),
 					}
 					return conversation.ToolUseVerdict{Allowed: true, Reason: reviewReason}
 				}
@@ -362,7 +362,7 @@ func (s *Server) handleToolUseBlockedResponse(resp *http.Response, ctx *goproxy.
 						Task:              reviewTask,
 						ApprovalID:        &rec.ID,
 						WouldReview:       true,
-						WouldPromptInline: hooks.Config != nil && hooks.Config.RuntimePolicy.InlineApprovalEnabled,
+						WouldPromptInline: sessionInlineApprovalEnabled(st.Session, hooks.Config),
 						Held:              held,
 					}
 				} else {
@@ -426,7 +426,7 @@ func (s *Server) handleToolUseBlockedResponse(resp *http.Response, ctx *goproxy.
 				Task:                  reviewTask,
 				UsedActiveTaskContext: reviewTask != nil && usedActiveTaskSelection(ctx.Req.Context(), hooks.Store, st.Session.ID, reviewTask),
 				WouldReview:           true,
-				WouldPromptInline:     hooks.Config != nil && hooks.Config.RuntimePolicy.InlineApprovalEnabled,
+				WouldPromptInline:     sessionInlineApprovalEnabled(st.Session, hooks.Config),
 			}
 			return conversation.ToolUseVerdict{Allowed: true, Reason: "observation mode: tool use would require runtime approval"}
 		}
@@ -442,7 +442,7 @@ func (s *Server) handleToolUseBlockedResponse(resp *http.Response, ctx *goproxy.
 				Task:                    reviewTask,
 				ApprovalID:              &rec.ID,
 				WouldReview:             true,
-				WouldPromptInline:       hooks.Config != nil && hooks.Config.RuntimePolicy.InlineApprovalEnabled,
+				WouldPromptInline:       sessionInlineApprovalEnabled(st.Session, hooks.Config),
 				Held:                    held,
 				UsedConvJudgeResolution: judgment.Kind != "",
 			}
@@ -512,7 +512,7 @@ func (s *Server) applyToolUseDecision(ctx context.Context, hooks ToolUseHooks, s
 	if decision.Verdict.Allowed {
 		var leaseID *string
 		if state.Task != nil {
-			lease, err := hooks.Leases.Open(ctx, st.Session.ID, state.Task.ID, decision.ToolUse.ID, decision.ToolUse.Name, toolLeaseTTL(hooks.Config))
+			lease, err := hooks.Leases.Open(ctx, st.Session.ID, state.Task.ID, decision.ToolUse.ID, decision.ToolUse.Name, sessionToolLeaseTTL(st.Session, hooks.Config))
 			if err == nil && lease != nil {
 				leaseID = &lease.LeaseID
 				emitRuntimeEvent(ctx, hooks.Store, st.Session, st, runtimeEventOptions{

--- a/pkg/runtime/proxy/tooluse_runtime_test.go
+++ b/pkg/runtime/proxy/tooluse_runtime_test.go
@@ -32,7 +32,7 @@ func TestRenderHeldToolUsePromptPlacesSubjectOnOwnLine(t *testing.T) {
 		},
 	}
 
-	got := renderHeldToolUsePrompt(held, cfg)
+	got := renderHeldToolUsePrompt(held, nil, cfg)
 	if !strings.Contains(got, "Clawvisor paused:\n\nBash python3 /tmp/hello_world.py") {
 		t.Fatalf("expected paused subject on its own line, got %q", got)
 	}


### PR DESCRIPTION
## Summary

Extends `sessionRuntimeSettings` with three new optional fields realized from session metadata, each falling back to `cfg.RuntimePolicy.X` when unset:

- `InlineApprovalEnabled *bool` — gates inline-approval response parsing + `WouldPromptInline` event metadata
- `ToolLeaseTimeoutSeconds int` — per-session lease TTL override
- `HarnessAllowlist []string` — per-session host allowlist (replaces, doesn't augment, the cfg list)

## Why

The current proxy reads these values from `*config.Config` only — they're effectively global. Multi-tenant deployments (cloud-hosted runtime proxy) need per-org policy realized into per-session metadata at session-create time so a single binary serves users with different inline-approval, lease, and allowlist policies without a config reload.

Daemon mode is unaffected: when the metadata fields are absent (the common case for daemon-issued sessions), the accessors return the global cfg value, exactly as today.

## Changes

- `sessionRuntimeSettings` gains three new fields, all `omitempty`. Wire-compatible with existing serialized sessions — old metadata blobs parse cleanly, new fields default to "use cfg".
- New accessors: `sessionInlineApprovalEnabled`, `sessionToolLeaseTTL`, `sessionHarnessAllowlist`. Each takes `(*store.RuntimeSession, *config.Config)` and returns the per-session override when set, cfg fallback otherwise.
- Switched call sites in `tooluse_runtime.go` (6 InlineApproval reads, 2 lease TTL reads).
- `policy_hook.go`'s `isHarnessAllowlisted` now delegates to a new session-aware variant (`isHarnessAllowlistedForSession`); built-in defaults (anthropic.com/openai.com/chatgpt.com) and `cfg.LLM.Endpoint` still pass regardless.
- `session_settings_test.go` covers each accessor + override-vs-fallback semantics.

## Open semantic question

`HarnessAllowlist` per-session override **replaces** rather than augments the global. Rationale: enterprise customers set tight allowlists and need the override to be authoritative. Hobbyists who set their own allowlist on top of defaults can include the defaults explicitly. Open to feedback if "augment" is the better semantic.

## Test plan

- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test ./...` — all packages pass, including the new `session_settings_test.go`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)