### PR TITLE
feat(runtime): edge TLS provider, multi-tenant leaf cert cache, log redaction handler

### DIFF
--- a/pkg/runtime/proxy/edge_cert.go
+++ b/pkg/runtime/proxy/edge_cert.go
@@ -1,0 +1,147 @@
+package proxy
+
+// Phase 0.2 — edge TLS cert (the cert the listener serves on
+// proxy.clawvisor.com) is decoupled from the MITM CA path. The cloud
+// binary wires this provider so the listener's GetCertificate returns
+// a real publicly-trusted leaf, not a forged-from-internal-CA leaf.
+//
+// Reload model:
+//   - Cert+key files live at fixed paths (typically a Kubernetes Secret
+//     mounted into the pod under /etc/edge-tls/).
+//   - A periodic re-stat loop watches mtime+size; on change, reloads the
+//     cert pair and atomically swaps an atomic.Pointer[tls.Certificate].
+//   - Mid-handshake reloads are safe: GetCertificate captures the
+//     pointer once per handshake; new handshakes pick up the new cert,
+//     in-flight ones keep the old.
+//
+// fsnotify-based instant reload is the production target (cuts reload
+// latency from "<5 min" to "subsecond"). It needs the fsnotify
+// dependency, which is added at the same time the cloud binary lands;
+// for now the periodic-restat path is the fallback the plan documents.
+
+import (
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"os"
+	"sync/atomic"
+	"time"
+)
+
+// EdgeCertProvider returns the current edge TLS cert. The pointer
+// returned is safe for concurrent use; callers should NOT mutate it.
+type EdgeCertProvider interface {
+	GetCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error)
+	// Close stops any background reload loop. Safe to call multiple times.
+	Close() error
+}
+
+// FileEdgeCertProvider serves the edge cert from a cert + key file pair
+// on disk and reloads them on change.
+type FileEdgeCertProvider struct {
+	certPath string
+	keyPath  string
+	current  atomic.Pointer[tls.Certificate]
+	stop     chan struct{}
+	closed   atomic.Bool
+}
+
+// NewFileEdgeCertProvider loads the initial cert+key pair and starts a
+// periodic re-stat loop (default 60s) for reload. The reload interval is
+// configurable for tests.
+func NewFileEdgeCertProvider(certPath, keyPath string, reloadEvery time.Duration) (*FileEdgeCertProvider, error) {
+	if certPath == "" || keyPath == "" {
+		return nil, errors.New("edge cert path and key path are required")
+	}
+	if reloadEvery <= 0 {
+		reloadEvery = 60 * time.Second
+	}
+	p := &FileEdgeCertProvider{
+		certPath: certPath,
+		keyPath:  keyPath,
+		stop:     make(chan struct{}),
+	}
+	if err := p.reload(); err != nil {
+		return nil, fmt.Errorf("initial edge cert load: %w", err)
+	}
+	go p.run(reloadEvery)
+	return p, nil
+}
+
+// GetCertificate satisfies tls.Config.GetCertificate. ClientHelloInfo is
+// ignored because we serve a single SNI/host on the listener.
+func (p *FileEdgeCertProvider) GetCertificate(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	cert := p.current.Load()
+	if cert == nil {
+		return nil, errors.New("edge cert not loaded")
+	}
+	return cert, nil
+}
+
+// Close stops the background reload loop.
+func (p *FileEdgeCertProvider) Close() error {
+	if p.closed.CompareAndSwap(false, true) {
+		close(p.stop)
+	}
+	return nil
+}
+
+func (p *FileEdgeCertProvider) run(every time.Duration) {
+	t := time.NewTicker(every)
+	defer t.Stop()
+	var lastCertMod, lastKeyMod time.Time
+	var lastCertSize, lastKeySize int64
+	if certInfo, err := os.Stat(p.certPath); err == nil {
+		lastCertMod = certInfo.ModTime()
+		lastCertSize = certInfo.Size()
+	}
+	if keyInfo, err := os.Stat(p.keyPath); err == nil {
+		lastKeyMod = keyInfo.ModTime()
+		lastKeySize = keyInfo.Size()
+	}
+	for {
+		select {
+		case <-p.stop:
+			return
+		case <-t.C:
+			certInfo, err := os.Stat(p.certPath)
+			if err != nil {
+				continue
+			}
+			keyInfo, err := os.Stat(p.keyPath)
+			if err != nil {
+				continue
+			}
+			changed := !certInfo.ModTime().Equal(lastCertMod) ||
+				!keyInfo.ModTime().Equal(lastKeyMod) ||
+				certInfo.Size() != lastCertSize ||
+				keyInfo.Size() != lastKeySize
+			if !changed {
+				continue
+			}
+			if err := p.reload(); err != nil {
+				// Don't update lastMod — we want to retry next tick.
+				continue
+			}
+			lastCertMod = certInfo.ModTime()
+			lastCertSize = certInfo.Size()
+			lastKeyMod = keyInfo.ModTime()
+			lastKeySize = keyInfo.Size()
+		}
+	}
+}
+
+func (p *FileEdgeCertProvider) reload() error {
+	cert, err := tls.LoadX509KeyPair(p.certPath, p.keyPath)
+	if err != nil {
+		return err
+	}
+	p.current.Store(&cert)
+	return nil
+}
+
+// reloadOnce is exposed for tests so they don't need to wait for the
+// periodic loop.
+func (p *FileEdgeCertProvider) reloadOnce() error {
+	return p.reload()
+}

--- a/pkg/runtime/proxy/edge_cert_test.go
+++ b/pkg/runtime/proxy/edge_cert_test.go
@@ -1,0 +1,160 @@
+package proxy
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// generateLeafKeyPair creates a self-signed ECDSA P-256 cert and key,
+// writes both to the given paths in PEM form, and returns the certificate
+// bytes for assertion comparisons.
+func generateLeafKeyPair(t *testing.T, certPath, keyPath, commonName string) []byte {
+	t.Helper()
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	serial, _ := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	tmpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: commonName},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     []string{commonName},
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyDER, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	if err := os.WriteFile(certPath, certPEM, 0o600); err != nil {
+		t.Fatalf("write cert: %v", err)
+	}
+	if err := os.WriteFile(keyPath, keyPEM, 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	return certDER
+}
+
+func TestFileEdgeCertProvider_LoadAndServe(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "tls.crt")
+	keyPath := filepath.Join(dir, "tls.key")
+	wantDER := generateLeafKeyPair(t, certPath, keyPath, "edge.example.com")
+
+	p, err := NewFileEdgeCertProvider(certPath, keyPath, 100*time.Millisecond)
+	if err != nil {
+		t.Fatalf("NewFileEdgeCertProvider: %v", err)
+	}
+	defer p.Close()
+
+	cert, err := p.GetCertificate(nil)
+	if err != nil {
+		t.Fatalf("GetCertificate: %v", err)
+	}
+	if len(cert.Certificate) == 0 {
+		t.Fatal("cert.Certificate is empty")
+	}
+	if string(cert.Certificate[0]) != string(wantDER) {
+		t.Errorf("served cert does not match initial bytes")
+	}
+}
+
+func TestFileEdgeCertProvider_ReloadOnChange(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "tls.crt")
+	keyPath := filepath.Join(dir, "tls.key")
+	_ = generateLeafKeyPair(t, certPath, keyPath, "v1.example.com")
+
+	p, err := NewFileEdgeCertProvider(certPath, keyPath, 100*time.Millisecond)
+	if err != nil {
+		t.Fatalf("NewFileEdgeCertProvider: %v", err)
+	}
+	defer p.Close()
+
+	first, err := p.GetCertificate(nil)
+	if err != nil {
+		t.Fatalf("first GetCertificate: %v", err)
+	}
+
+	// Replace the cert+key with new content. Use a different DNS name so
+	// the leaf bytes definitely change.
+	newDER := generateLeafKeyPair(t, certPath, keyPath, "v2.example.com")
+	// Bump mtime explicitly to make sure the periodic loop sees it.
+	now := time.Now().Add(time.Second)
+	_ = os.Chtimes(certPath, now, now)
+	_ = os.Chtimes(keyPath, now, now)
+
+	// Wait up to 2s for reload, polling.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		current, err := p.GetCertificate(nil)
+		if err == nil && len(current.Certificate) > 0 && string(current.Certificate[0]) == string(newDER) {
+			return // reloaded successfully
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	t.Errorf("provider did not reload to new cert within 2s; first cert leaf %x...", first.Certificate[0][:8])
+}
+
+func TestFileEdgeCertProvider_ReloadFailureKeepsOldCert(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "tls.crt")
+	keyPath := filepath.Join(dir, "tls.key")
+	wantDER := generateLeafKeyPair(t, certPath, keyPath, "stable.example.com")
+
+	p, err := NewFileEdgeCertProvider(certPath, keyPath, 100*time.Millisecond)
+	if err != nil {
+		t.Fatalf("NewFileEdgeCertProvider: %v", err)
+	}
+	defer p.Close()
+
+	// Corrupt the cert file. The reload must FAIL and the previous cert
+	// must stay served.
+	if err := os.WriteFile(certPath, []byte("not a pem file"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	now := time.Now().Add(time.Second)
+	_ = os.Chtimes(certPath, now, now)
+
+	// Force a reload attempt directly (simulates the periodic loop).
+	if err := p.reloadOnce(); err == nil {
+		t.Fatal("expected reload error on corrupted cert, got nil")
+	}
+
+	cert, err := p.GetCertificate(nil)
+	if err != nil {
+		t.Fatalf("GetCertificate: %v", err)
+	}
+	if len(cert.Certificate) == 0 || string(cert.Certificate[0]) != string(wantDER) {
+		t.Errorf("expected provider to keep serving original cert after failed reload")
+	}
+}
+
+func TestFileEdgeCertProvider_RequiresPaths(t *testing.T) {
+	if _, err := NewFileEdgeCertProvider("", "/key", time.Second); err == nil {
+		t.Error("expected error when certPath empty")
+	}
+	if _, err := NewFileEdgeCertProvider("/cert", "", time.Second); err == nil {
+		t.Error("expected error when keyPath empty")
+	}
+}

--- a/pkg/runtime/proxy/log_redaction.go
+++ b/pkg/runtime/proxy/log_redaction.go
@@ -1,0 +1,155 @@
+package proxy
+
+// Phase 0.X — log redaction policy.
+//
+// The runtime proxy sees decrypted traffic for every concurrent session.
+// Logs that include request/response bodies, Authorization headers,
+// query strings, or cookie values turn the log pipeline into a
+// pseudo-decrypt-everything surface. This handler enforces a fixed
+// allowlist of structured slog attribute keys; everything else is
+// dropped.
+//
+// Use from cloud's binary wiring: wrap the slog handler at the top of
+// main.go before passing the logger into NewServer / Manager.
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+)
+
+// AllowedLogKeys is the fixed set of structured fields that may appear
+// in runtime-proxy log records. ANYTHING NOT IN THIS SET IS REDACTED.
+//
+// Adding a key requires a security review — see the on-call appendix.
+var AllowedLogKeys = map[string]struct{}{
+	// Identity (no secrets):
+	"session_id":  {},
+	"user_id":     {},
+	"agent_id":    {},
+	"org_id":      {},
+	"request_id":  {},
+	"approval_id": {},
+	"task_id":     {},
+	"lease_id":    {},
+	"tool_use_id": {},
+
+	// Request shape (no bodies, no query, no headers):
+	"method":         {},
+	"host":           {},
+	"path":           {},
+	"upstream_host":  {},
+	"upstream_path":  {},
+	"req_bytes":      {},
+	"resp_bytes":     {},
+	"status":         {},
+	"latency_ms":     {},
+	"verdict":        {},
+	"hook":           {},
+	"event_type":     {},
+	"action_kind":    {},
+	"decision":       {},
+	"outcome":        {},
+	"observation":    {},
+	"reason_kind":    {},
+	"resolution_kind": {},
+	"matched_rule":   {},
+
+	// Errors (treated as opaque strings, not bodies):
+	"err":          {},
+	"error":        {},
+	"err_class":    {},
+
+	// Context / observability metadata:
+	"phase":        {},
+	"component":    {},
+	"region":       {},
+	"pod":          {},
+	"replica":      {},
+	"version":      {},
+	"build_id":     {},
+}
+
+// RedactingHandler wraps an slog.Handler and drops any attribute whose
+// key is not in AllowedLogKeys. Group prefixes are preserved. The
+// message itself is pass-through (so callers must already have phrased
+// it free of sensitive content).
+type RedactingHandler struct {
+	wrapped slog.Handler
+	allowed map[string]struct{}
+}
+
+// NewRedactingHandler returns a handler that filters attributes against
+// the proxy log allowlist.
+func NewRedactingHandler(wrapped slog.Handler) *RedactingHandler {
+	if wrapped == nil {
+		return nil
+	}
+	return &RedactingHandler{wrapped: wrapped, allowed: AllowedLogKeys}
+}
+
+// NewRedactingHandlerWithAllowlist is for tests and for the Phase 1b
+// per-component extension where a specific component (e.g., Vertex
+// breaker) needs an additional allowed key.
+func NewRedactingHandlerWithAllowlist(wrapped slog.Handler, allowed map[string]struct{}) *RedactingHandler {
+	if wrapped == nil {
+		return nil
+	}
+	return &RedactingHandler{wrapped: wrapped, allowed: allowed}
+}
+
+func (h *RedactingHandler) Enabled(ctx context.Context, lvl slog.Level) bool {
+	return h.wrapped.Enabled(ctx, lvl)
+}
+
+func (h *RedactingHandler) Handle(ctx context.Context, r slog.Record) error {
+	filtered := slog.NewRecord(r.Time, r.Level, r.Message, r.PC)
+	r.Attrs(func(a slog.Attr) bool {
+		if h.shouldKeep(a.Key) {
+			filtered.AddAttrs(a)
+		} else {
+			filtered.AddAttrs(slog.String(a.Key, "<redacted>"))
+		}
+		return true
+	})
+	return h.wrapped.Handle(ctx, filtered)
+}
+
+func (h *RedactingHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	kept := make([]slog.Attr, 0, len(attrs))
+	for _, a := range attrs {
+		if h.shouldKeep(a.Key) {
+			kept = append(kept, a)
+		} else {
+			kept = append(kept, slog.String(a.Key, "<redacted>"))
+		}
+	}
+	return &RedactingHandler{wrapped: h.wrapped.WithAttrs(kept), allowed: h.allowed}
+}
+
+func (h *RedactingHandler) WithGroup(name string) slog.Handler {
+	return &RedactingHandler{wrapped: h.wrapped.WithGroup(name), allowed: h.allowed}
+}
+
+func (h *RedactingHandler) shouldKeep(key string) bool {
+	if h == nil || h.allowed == nil {
+		return false
+	}
+	// Defense in depth: never allow an attribute key that itself looks
+	// like it carries secrets, even if the allowlist forgot to exclude it.
+	lk := strings.ToLower(key)
+	if strings.Contains(lk, "authorization") ||
+		strings.Contains(lk, "cookie") ||
+		strings.Contains(lk, "secret") ||
+		strings.Contains(lk, "token") ||
+		strings.Contains(lk, "api_key") ||
+		strings.Contains(lk, "apikey") ||
+		strings.Contains(lk, "password") ||
+		strings.Contains(lk, "body") ||
+		strings.Contains(lk, "payload") ||
+		strings.Contains(lk, "query_string") {
+		return false
+	}
+	_, ok := h.allowed[key]
+	return ok
+}

--- a/pkg/runtime/proxy/log_redaction_test.go
+++ b/pkg/runtime/proxy/log_redaction_test.go
@@ -1,0 +1,110 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func newRedactingTextLogger(buf *bytes.Buffer) *slog.Logger {
+	base := slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	return slog.New(NewRedactingHandler(base))
+}
+
+func TestRedactingHandler_AllowlistedKeysPassThrough(t *testing.T) {
+	var buf bytes.Buffer
+	logger := newRedactingTextLogger(&buf)
+	logger.Info("ok", "session_id", "s1", "user_id", "u1", "method", "GET", "host", "api.example.com")
+
+	out := buf.String()
+	for _, want := range []string{`session_id=s1`, `user_id=u1`, `method=GET`, `host=api.example.com`} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in log; got %s", want, out)
+		}
+	}
+}
+
+func TestRedactingHandler_DenylistedKeysRedacted(t *testing.T) {
+	var buf bytes.Buffer
+	logger := newRedactingTextLogger(&buf)
+	logger.Warn("denied",
+		"authorization", "Bearer sk-real-secret",
+		"cookie", "session=abc",
+		"api_key", "sk-real",
+		"body", `{"prompt":"hello"}`,
+		"password", "hunter2",
+	)
+	out := buf.String()
+	for _, leaked := range []string{"sk-real-secret", "Bearer", "session=abc", "hello", "hunter2", "sk-real"} {
+		if strings.Contains(out, leaked) {
+			t.Errorf("LEAK: %q appears in log output: %s", leaked, out)
+		}
+	}
+	if !strings.Contains(out, "<redacted>") {
+		t.Errorf("expected <redacted> placeholder; got %s", out)
+	}
+}
+
+func TestRedactingHandler_UnknownKeyRedacted(t *testing.T) {
+	var buf bytes.Buffer
+	logger := newRedactingTextLogger(&buf)
+	logger.Info("event", "session_id", "s1", "weird_new_field", "sensitive-value")
+
+	out := buf.String()
+	if strings.Contains(out, "sensitive-value") {
+		t.Errorf("LEAK: unknown key value %q in log: %s", "sensitive-value", out)
+	}
+	if !strings.Contains(out, "session_id=s1") {
+		t.Errorf("expected session_id=s1 in log: %s", out)
+	}
+	if !strings.Contains(out, "weird_new_field=<redacted>") {
+		t.Errorf("expected redacted placeholder for unknown key: %s", out)
+	}
+}
+
+func TestRedactingHandler_WithAttrs(t *testing.T) {
+	var buf bytes.Buffer
+	base := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	h := NewRedactingHandler(base)
+	logger := slog.New(h.WithAttrs([]slog.Attr{
+		slog.String("session_id", "s1"),
+		slog.String("authorization", "Bearer leak"),
+	}))
+	logger.Info("base")
+
+	out := buf.String()
+	if strings.Contains(out, "Bearer leak") {
+		t.Errorf("LEAK: authorization in WithAttrs survived: %s", out)
+	}
+	if !strings.Contains(out, "session_id=s1") {
+		t.Errorf("expected session_id=s1 in log: %s", out)
+	}
+}
+
+func TestRedactingHandler_NilWrapped(t *testing.T) {
+	if got := NewRedactingHandler(nil); got != nil {
+		t.Errorf("NewRedactingHandler(nil) = %v, want nil", got)
+	}
+	if got := NewRedactingHandlerWithAllowlist(nil, AllowedLogKeys); got != nil {
+		t.Errorf("NewRedactingHandlerWithAllowlist(nil, …) = %v, want nil", got)
+	}
+}
+
+func TestRedactingHandler_RespectsLevel(t *testing.T) {
+	var buf bytes.Buffer
+	base := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})
+	logger := slog.New(NewRedactingHandler(base))
+	logger.Info("info-msg", "session_id", "s1")
+	logger.Warn("warn-msg", "session_id", "s1")
+
+	out := buf.String()
+	if strings.Contains(out, "info-msg") {
+		t.Errorf("Info should be filtered by base handler; got %s", out)
+	}
+	if !strings.Contains(out, "warn-msg") {
+		t.Errorf("Warn should pass through; got %s", out)
+	}
+	_ = context.Background
+}

--- a/pkg/runtime/proxy/multitenant_cache.go
+++ b/pkg/runtime/proxy/multitenant_cache.go
@@ -1,0 +1,145 @@
+package proxy
+
+// Phase 0.2 — multi-tenant leaf cert cache.
+//
+// The single-CA LeafCertCache works for daemon mode (one user, one CA per
+// proxy install). Cloud needs per-user CAs at MITM time, with leaf certs
+// keyed by (userID, caVersion, host) so:
+//   1. CA rotation/revocation evicts by (userID, caVersion) prefix —
+//      old leafs never get re-served under a new CA;
+//   2. The singleflight de-dup for leaf minting must be keyed identically
+//      so two users hitting the same host don't accidentally share work
+//      done with the wrong CA.
+//
+// This cache wraps per-(userID,caVersion) LeafCertCache instances. The
+// lookup path takes the user's CA via a CASource so the cache itself
+// doesn't have to know about CA storage / rotation policy — that's the
+// caller's concern.
+
+import (
+	"crypto/ecdsa"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"sync"
+)
+
+// CASource resolves the active CA for a user at MITM time. The cloud
+// implementation will look up the user's CA from a wrapped-DEK store
+// (per the per-user PKI plan). caVersion is monotonically increasing
+// per user; rotation bumps the version.
+type CASource interface {
+	GetUserCA(userID string) (cert *x509.Certificate, key *ecdsa.PrivateKey, caVersion int, err error)
+}
+
+// MultiUserLeafCertCache holds per-user LeafCertCache shards keyed by
+// (userID, caVersion). Each shard is a normal LeafCertCache. Eviction
+// of a (userID, caVersion) shard removes all leafs minted under it.
+type MultiUserLeafCertCache struct {
+	source       CASource
+	leafCapacity int
+
+	mu     sync.RWMutex
+	shards map[shardKey]*LeafCertCache
+}
+
+type shardKey struct {
+	userID    string
+	caVersion int
+}
+
+// NewMultiUserLeafCertCache wires a CASource and a per-shard leaf
+// capacity. leafCapacity defaults to 256 if non-positive.
+func NewMultiUserLeafCertCache(source CASource, leafCapacity int) *MultiUserLeafCertCache {
+	if leafCapacity <= 0 {
+		leafCapacity = 256
+	}
+	return &MultiUserLeafCertCache{
+		source:       source,
+		leafCapacity: leafCapacity,
+		shards:       make(map[shardKey]*LeafCertCache),
+	}
+}
+
+// Get returns a leaf cert for the (userID, host) pair, minting it via
+// the user's current CA if needed. If the user's caVersion has changed
+// since the last call, a new shard is allocated; old shards remain
+// reachable via EvictUserCAVersion (cloud calls this on rotation).
+func (m *MultiUserLeafCertCache) Get(userID, host string) (*tls.Certificate, error) {
+	if m == nil {
+		return nil, errors.New("MultiUserLeafCertCache is nil")
+	}
+	if userID == "" {
+		return nil, errors.New("userID is required")
+	}
+	if m.source == nil {
+		return nil, errors.New("CASource is required")
+	}
+	cert, key, version, err := m.source.GetUserCA(userID)
+	if err != nil {
+		return nil, err
+	}
+	shard := m.getOrCreateShard(userID, version, cert, key)
+	return shard.Get(host)
+}
+
+// EvictUserCAVersion drops all leafs minted under (userID, caVersion).
+// Call this from cloud's CA rotation path. Idempotent.
+func (m *MultiUserLeafCertCache) EvictUserCAVersion(userID string, caVersion int) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.shards, shardKey{userID: userID, caVersion: caVersion})
+}
+
+// EvictUser drops every shard for the user (all caVersions). Use on
+// user-level kill-switch.
+func (m *MultiUserLeafCertCache) EvictUser(userID string) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for k := range m.shards {
+		if k.userID == userID {
+			delete(m.shards, k)
+		}
+	}
+}
+
+// Stats returns the number of active shards and the sum of leafs across
+// all shards. Cheap to call; intended for metrics export.
+func (m *MultiUserLeafCertCache) Stats() (shards int, totalLeafs int) {
+	if m == nil {
+		return 0, 0
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, c := range m.shards {
+		c.mu.Lock()
+		totalLeafs += c.order.Len()
+		c.mu.Unlock()
+	}
+	return len(m.shards), totalLeafs
+}
+
+func (m *MultiUserLeafCertCache) getOrCreateShard(userID string, version int, cert *x509.Certificate, key *ecdsa.PrivateKey) *LeafCertCache {
+	k := shardKey{userID: userID, caVersion: version}
+	m.mu.RLock()
+	if existing, ok := m.shards[k]; ok {
+		m.mu.RUnlock()
+		return existing
+	}
+	m.mu.RUnlock()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if existing, ok := m.shards[k]; ok {
+		return existing
+	}
+	shard := NewLeafCertCache(cert, key, m.leafCapacity)
+	m.shards[k] = shard
+	return shard
+}

--- a/pkg/runtime/proxy/multitenant_cache_test.go
+++ b/pkg/runtime/proxy/multitenant_cache_test.go
@@ -1,0 +1,163 @@
+package proxy
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"errors"
+	"math/big"
+	"sync"
+	"testing"
+	"time"
+)
+
+// stubCASource is a test CASource backed by an in-memory map keyed by
+// userID. The latest version stored wins on Get.
+type stubCASource struct {
+	mu    sync.Mutex
+	users map[string]stubCA
+}
+
+type stubCA struct {
+	cert    *x509.Certificate
+	key     *ecdsa.PrivateKey
+	version int
+}
+
+func (s *stubCASource) GetUserCA(userID string) (*x509.Certificate, *ecdsa.PrivateKey, int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	ca, ok := s.users[userID]
+	if !ok {
+		return nil, nil, 0, errors.New("no CA for user")
+	}
+	return ca.cert, ca.key, ca.version, nil
+}
+
+func (s *stubCASource) set(userID string, version int) {
+	priv, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	serial, _ := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	tmpl := &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: "ca-" + userID},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, _ := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	cert, _ := x509.ParseCertificate(der)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.users[userID] = stubCA{cert: cert, key: priv, version: version}
+}
+
+func TestMultiUserLeafCertCache_PerUserIsolation(t *testing.T) {
+	src := &stubCASource{users: map[string]stubCA{}}
+	src.set("alice", 1)
+	src.set("bob", 1)
+
+	cache := NewMultiUserLeafCertCache(src, 16)
+
+	aliceCert, err := cache.Get("alice", "api.example.com")
+	if err != nil {
+		t.Fatalf("Get(alice): %v", err)
+	}
+	bobCert, err := cache.Get("bob", "api.example.com")
+	if err != nil {
+		t.Fatalf("Get(bob): %v", err)
+	}
+
+	// The leaf certs MUST chain to different CAs (since Alice and Bob
+	// have distinct CAs in the source).
+	if string(aliceCert.Certificate[1]) == string(bobCert.Certificate[1]) {
+		t.Errorf("Alice's leaf chains to the same CA as Bob's; per-user isolation failed")
+	}
+}
+
+func TestMultiUserLeafCertCache_CARotationEvicts(t *testing.T) {
+	src := &stubCASource{users: map[string]stubCA{}}
+	src.set("alice", 1)
+
+	cache := NewMultiUserLeafCertCache(src, 16)
+
+	cert1, err := cache.Get("alice", "api.example.com")
+	if err != nil {
+		t.Fatalf("Get(v1): %v", err)
+	}
+
+	// Bump to version 2 with a new CA.
+	src.set("alice", 2)
+
+	cert2, err := cache.Get("alice", "api.example.com")
+	if err != nil {
+		t.Fatalf("Get(v2): %v", err)
+	}
+
+	// Different shard ⇒ different leaf bytes.
+	if len(cert1.Certificate) > 0 && len(cert2.Certificate) > 0 &&
+		string(cert1.Certificate[0]) == string(cert2.Certificate[0]) {
+		t.Errorf("rotation should produce a new leaf; got identical bytes")
+	}
+
+	shards, _ := cache.Stats()
+	if shards < 2 {
+		t.Errorf("expected at least 2 shards after rotation, got %d", shards)
+	}
+
+	cache.EvictUserCAVersion("alice", 1)
+	shards, _ = cache.Stats()
+	if shards != 1 {
+		t.Errorf("after EvictUserCAVersion(alice,1) expected 1 shard; got %d", shards)
+	}
+}
+
+func TestMultiUserLeafCertCache_EvictUser(t *testing.T) {
+	src := &stubCASource{users: map[string]stubCA{}}
+	src.set("alice", 1)
+	src.set("alice", 2) // overwrites alice; both old and new versions accessible via direct Get
+	src.set("bob", 1)
+
+	cache := NewMultiUserLeafCertCache(src, 16)
+	if _, err := cache.Get("alice", "h1"); err != nil {
+		t.Fatalf("Get(alice): %v", err)
+	}
+	if _, err := cache.Get("bob", "h1"); err != nil {
+		t.Fatalf("Get(bob): %v", err)
+	}
+	cache.EvictUser("alice")
+	shards, _ := cache.Stats()
+	if shards != 1 {
+		t.Errorf("expected 1 shard after EvictUser(alice); got %d", shards)
+	}
+}
+
+func TestMultiUserLeafCertCache_RejectsEmptyUserID(t *testing.T) {
+	src := &stubCASource{users: map[string]stubCA{}}
+	cache := NewMultiUserLeafCertCache(src, 16)
+	if _, err := cache.Get("", "h1"); err == nil {
+		t.Error("expected error for empty userID")
+	}
+}
+
+func TestMultiUserLeafCertCache_NilSourceReturnsError(t *testing.T) {
+	cache := NewMultiUserLeafCertCache(nil, 16)
+	if _, err := cache.Get("u", "h"); err == nil {
+		t.Error("expected error when CASource is nil")
+	}
+}
+
+func TestMultiUserLeafCertCache_NilReceiver(t *testing.T) {
+	var cache *MultiUserLeafCertCache
+	if _, err := cache.Get("u", "h"); err == nil {
+		t.Error("expected error from nil receiver Get")
+	}
+	cache.EvictUser("u")     // should not panic
+	cache.EvictUserCAVersion("u", 1)
+	if shards, leafs := cache.Stats(); shards != 0 || leafs != 0 {
+		t.Errorf("nil receiver Stats = (%d, %d), want (0, 0)", shards, leafs)
+	}
+}

--- a/pkg/runtime/proxy/server.go
+++ b/pkg/runtime/proxy/server.go
@@ -35,6 +35,13 @@ type Config struct {
 	BodyTraces        bool
 	BodyTraceDir      string
 	RedisClient       *redis.Client
+
+	// Phase 0.2: when set, the listener's tls.Config.GetCertificate
+	// returns this provider's cert (the cloud-mode path: a publicly-
+	// trusted cert mounted from a cert-manager-managed Secret) instead
+	// of forging one from the MITM CA. Daemon mode leaves this nil and
+	// gets the existing single-CA behavior.
+	EdgeCert EdgeCertProvider
 }
 
 type Server struct {
@@ -318,6 +325,16 @@ func (s *Server) Shutdown(ctx context.Context) error {
 }
 
 func (s *Server) listenerTLSConfig() (*tls.Config, error) {
+	// Phase 0.2: when an EdgeCertProvider is configured (cloud mode),
+	// the listener serves the provider's cert directly. Forged-from-CA
+	// leaves stay reserved for goproxy MITM, not the listener.
+	if s.cfg.EdgeCert != nil {
+		return &tls.Config{
+			GetCertificate: s.cfg.EdgeCert.GetCertificate,
+			MinVersion:     tls.VersionTLS12,
+		}, nil
+	}
+
 	names := s.cfg.ListenerHostnames
 	if len(names) == 0 {
 		names = []string{"localhost", "127.0.0.1"}


### PR DESCRIPTION
## Summary

Three additions to `pkg/runtime/proxy` that the cloud-hosted runtime proxy depends on. All are **opt-in** and leave daemon-mode behavior unchanged.

1. **`EdgeCertProvider`** + `FileEdgeCertProvider` — serves the listener TLS cert from a cert-manager-managed Secret mount with periodic re-stat reload. New `Config.EdgeCert` field; when set (cloud mode), `listenerTLSConfig` returns the provider's cert directly. When nil (daemon mode), the existing single-CA leaf-forging path runs unchanged.

2. **`MultiUserLeafCertCache`** — per-user, per-CA-version leaf cert sharding via a `CASource` interface. Each shard is a normal `LeafCertCache`; rotation/revocation evicts by `(userID, caVersion)` prefix so old leafs never get re-served under a new CA. Decoupled from CA storage and master-key wrapping (cloud impl provides those).

3. **`RedactingHandler`** — `slog.Handler` wrapper with a fixed allowlist of structured keys + defense-in-depth deny on substrings of `authorization`/`cookie`/`secret`/`token`/`api_key`/`body`/`payload`. The runtime proxy sees decrypted traffic; without this, structured logs are a pseudo-decrypt-everything surface. Includes a known-bad-inputs integration test.

## Why opt-in

Each addition is a seam, not a rewrite. The existing single-CA `LeafCertCache` and the existing un-redacted slog path both keep working for daemon mode. Cloud wires these in at the binary boundary (`Config.EdgeCert`, custom `slog` setup) without touching daemon callers.

## Deferred to a follow-up

- CA storage / master-key wrapping (cloud-side, lives in clawvisor-cloud)
- Per-CONNECT CA selection wired into goproxy (separate PR; needs the storage to exist first)
- Redis-backed leaf-key warm cache for cross-pod restoration
- fsnotify-based instant reload (current re-stat fallback gives <60s reload latency)

## Test plan

- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test ./...` — all packages pass
- [x] `EdgeCertProvider` tested for load+serve, reload-on-change, corrupted-reload-keeps-old, required-paths
- [x] `MultiUserLeafCertCache` tested for per-user isolation, CA rotation eviction, EvictUser, nil-safety
- [x] `RedactingHandler` tested with known-bad inputs (Authorization/Cookie/api_key/body/password values) — none survive into log output
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)