### PR TITLE
Critical security & correctness fixes from stress test (9 findings)

### DIFF
--- a/internal/adapters/apple/imessage/adapter.go
+++ b/internal/adapters/apple/imessage/adapter.go
@@ -22,6 +22,8 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -299,8 +301,17 @@ func (a *IMessageAdapter) queryHelperVersion(helperPath string) (string, error) 
 }
 
 // downloadHelper downloads the helper .app bundle from the GitHub release
-// matching the current clawvisor version.
+// matching the current clawvisor version. The tarball is verified against
+// the SHA-256 baked into this clawvisor binary at build time before any
+// bytes are extracted or executed — protecting against tampered or
+// substituted release artifacts.
 func (a *IMessageAdapter) downloadHelper(installDir string) (string, error) {
+	osArch := runtime.GOOS + "/" + runtime.GOARCH
+	expectedSHA := version.IMessageHelperSHA(osArch)
+	if expectedSHA == "" {
+		return "", fmt.Errorf("no pinned helper SHA for %s in this build — refusing unverified download (build a release binary or side-load the helper into PATH)", osArch)
+	}
+
 	tag := "v" + version.Version
 	assetName := fmt.Sprintf("clawvisor-imessage-helper-%s-%s.tar.gz", runtime.GOOS, runtime.GOARCH)
 	url := fmt.Sprintf("https://github.com/%s/%s/releases/download/%s/%s",
@@ -316,6 +327,16 @@ func (a *IMessageAdapter) downloadHelper(installDir string) (string, error) {
 		return "", fmt.Errorf("download: HTTP %d from %s", resp.StatusCode, url)
 	}
 
+	tarball, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("download: %w", err)
+	}
+	sum := sha256.Sum256(tarball)
+	gotSHA := hex.EncodeToString(sum[:])
+	if !strings.EqualFold(gotSHA, expectedSHA) {
+		return "", fmt.Errorf("helper integrity check failed for %s: expected sha256 %s, got %s — refusing to install", assetName, expectedSHA, gotSHA)
+	}
+
 	if err := os.MkdirAll(installDir, 0755); err != nil {
 		return "", err
 	}
@@ -327,7 +348,7 @@ func (a *IMessageAdapter) downloadHelper(installDir string) (string, error) {
 	}
 	defer os.RemoveAll(tmpDir) // clean up on failure
 
-	if err := extractTarGz(resp.Body, tmpDir); err != nil {
+	if err := extractTarGz(bytes.NewReader(tarball), tmpDir); err != nil {
 		return "", fmt.Errorf("extract: %w", err)
 	}
 

--- a/internal/adapters/apple/imessage/adapter_test.go
+++ b/internal/adapters/apple/imessage/adapter_test.go
@@ -3,7 +3,10 @@ package imessage
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/clawvisor/clawvisor/pkg/version"
 )
 
 func TestFindHelper_NotFound(t *testing.T) {
@@ -56,6 +59,41 @@ func TestFindHelper_CachedPath(t *testing.T) {
 	got := a.findHelper()
 	if got != helperPath {
 		t.Errorf("got %q, want %q", got, helperPath)
+	}
+}
+
+// TestDownloadHelper_RefusesWithoutPinnedSHA proves that a clawvisor binary
+// without an embedded helper SHA (i.e. a dev build) refuses to download
+// before it ever opens a network connection. This is the regression guard
+// against running an unverified helper as the user.
+func TestDownloadHelper_RefusesWithoutPinnedSHA(t *testing.T) {
+	prev := version.IMessageHelperSHA256
+	version.IMessageHelperSHA256 = ""
+	t.Cleanup(func() { version.IMessageHelperSHA256 = prev })
+
+	a := &IMessageAdapter{}
+	_, err := a.downloadHelper(t.TempDir())
+	if err == nil {
+		t.Fatalf("expected refusal when no helper SHA is pinned in the build")
+	}
+	if !strings.Contains(err.Error(), "no pinned helper SHA") {
+		t.Fatalf("wrong error: %v", err)
+	}
+}
+
+func TestIMessageHelperSHA_ParsesEmbeddedList(t *testing.T) {
+	prev := version.IMessageHelperSHA256
+	t.Cleanup(func() { version.IMessageHelperSHA256 = prev })
+
+	version.IMessageHelperSHA256 = "darwin/arm64=abc,darwin/amd64=def"
+	if got := version.IMessageHelperSHA("darwin/arm64"); got != "abc" {
+		t.Errorf("darwin/arm64: got %q want abc", got)
+	}
+	if got := version.IMessageHelperSHA("darwin/amd64"); got != "def" {
+		t.Errorf("darwin/amd64: got %q want def", got)
+	}
+	if got := version.IMessageHelperSHA("linux/amd64"); got != "" {
+		t.Errorf("linux/amd64 should be unset, got %q", got)
 	}
 }
 

--- a/internal/api/agent_isolation_test.go
+++ b/internal/api/agent_isolation_test.go
@@ -1,0 +1,45 @@
+package api_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+// TestGateway_TaskRejectsCrossAgent ensures that when a task is created by
+// agent A under user U, agent B (also under user U) cannot use that task to
+// authorize gateway calls. This protects against cross-agent scope reuse:
+// a low-trust agent should not be able to ride on a higher-trust peer's
+// approved scope just because they share an owner.
+func TestGateway_TaskRejectsCrossAgent(t *testing.T) {
+	adapter := newMockAdapter("mock.echo", "echo").
+		withResult("ok", map[string]any{"msg": "hello"})
+	env := newTestEnv(t, adapter)
+
+	sc := newScenario(t, env, "agent-a")
+	if err := env.Vault.Set(context.Background(), sc.session.UserID, "mock.echo", []byte("cred")); err != nil {
+		t.Fatalf("vault seed: %v", err)
+	}
+
+	taskID := sc.createApprovedTask(t, env, "mock.echo", "echo", true)
+
+	// Same user creates a second agent and tries to call against agent A's task.
+	resp := sc.session.do("POST", "/api/agents", map[string]any{"name": "agent-b"})
+	body := mustStatus(t, resp, http.StatusCreated)
+	agentBToken := str(t, body, "token")
+
+	reqID := fmt.Sprintf("xagent-%s", randSuffix())
+	resp = env.do("POST", "/api/gateway/request", agentBToken, map[string]any{
+		"service":    "mock.echo",
+		"action":     "echo",
+		"params":     map[string]any{"msg": "hi"},
+		"reason":     "cross-agent attempt",
+		"request_id": reqID,
+		"task_id":    taskID,
+	})
+	got := mustStatus(t, resp, http.StatusForbidden)
+	if got["code"] != "FORBIDDEN" {
+		t.Fatalf("expected code=FORBIDDEN, got %v (full: %v)", got["code"], got)
+	}
+}

--- a/internal/api/handlers/adaptergen.go
+++ b/internal/api/handlers/adaptergen.go
@@ -64,6 +64,9 @@ type updateAdapterRequest struct {
 const maxFetchBytes = 2 * 1024 * 1024 // 2 MB limit for fetched specs
 
 // ssrfRanges are private/internal CIDR blocks that must not be targeted.
+// Loopback (127.0.0.0/8, ::1/128) is intentionally separate so OAuth token
+// exchanges — which validateTokenEndpoint allows over http://localhost for
+// dev/test — can opt in via ssrfSafeOAuthClient without re-listing every range.
 var ssrfRanges = func() []*net.IPNet {
 	cidrs := []string{
 		"0.0.0.0/8",     // "this" network (includes 0.0.0.0)
@@ -71,8 +74,6 @@ var ssrfRanges = func() []*net.IPNet {
 		"172.16.0.0/12",
 		"192.168.0.0/16",
 		"169.254.0.0/16", // link-local / cloud metadata
-		"127.0.0.0/8",
-		"::1/128",
 		"fc00::/7",
 		"fe80::/10",
 	}
@@ -84,43 +85,71 @@ var ssrfRanges = func() []*net.IPNet {
 	return nets
 }()
 
-// ssrfSafeClient is an HTTP client that blocks requests to private/internal IPs,
-// resolving DNS at dial time to prevent rebinding attacks. Used both for adapter
-// generation source fetches and for OAuth token-endpoint exchanges in services.go.
-var ssrfSafeClient = &http.Client{
-	Timeout: 30 * time.Second,
-	Transport: &http.Transport{
-		DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
-			host, port, err := net.SplitHostPort(address)
-			if err != nil {
-				return nil, fmt.Errorf("invalid address %q: %w", address, err)
-			}
-			ips, err := net.DefaultResolver.LookupHost(ctx, host)
-			if err != nil {
-				return nil, fmt.Errorf("cannot resolve host %q: %w", host, err)
-			}
-			for _, ipStr := range ips {
-				ip := net.ParseIP(ipStr)
-				if ip == nil {
-					continue
+var ssrfLoopbackRanges = func() []*net.IPNet {
+	cidrs := []string{"127.0.0.0/8", "::1/128"}
+	nets := make([]*net.IPNet, 0, len(cidrs))
+	for _, cidr := range cidrs {
+		_, n, _ := net.ParseCIDR(cidr)
+		nets = append(nets, n)
+	}
+	return nets
+}()
+
+// newSSRFSafeClient builds an HTTP client that resolves DNS at dial time and
+// rejects connections to internal IPs. When allowLoopback is true, 127.0.0.0/8
+// and ::1 are not treated as SSRF targets — used for OAuth token endpoints,
+// which validateTokenEndpoint already restricts to https or loopback http.
+func newSSRFSafeClient(allowLoopback bool) *http.Client {
+	return &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
+				host, port, err := net.SplitHostPort(address)
+				if err != nil {
+					return nil, fmt.Errorf("invalid address %q: %w", address, err)
 				}
-				for _, n := range ssrfRanges {
-					if n.Contains(ip) {
-						return nil, fmt.Errorf("host %q resolves to blocked IP %s", host, ipStr)
+				ips, err := net.DefaultResolver.LookupHost(ctx, host)
+				if err != nil {
+					return nil, fmt.Errorf("cannot resolve host %q: %w", host, err)
+				}
+				for _, ipStr := range ips {
+					ip := net.ParseIP(ipStr)
+					if ip == nil {
+						continue
 					}
+					for _, n := range ssrfRanges {
+						if n.Contains(ip) {
+							return nil, fmt.Errorf("host %q resolves to blocked IP %s", host, ipStr)
+						}
+					}
+					if !allowLoopback {
+						for _, n := range ssrfLoopbackRanges {
+							if n.Contains(ip) {
+								return nil, fmt.Errorf("host %q resolves to blocked IP %s", host, ipStr)
+							}
+						}
+					}
+					return (&net.Dialer{Timeout: 5 * time.Second}).DialContext(ctx, network, net.JoinHostPort(ipStr, port))
 				}
-				return (&net.Dialer{Timeout: 5 * time.Second}).DialContext(ctx, network, net.JoinHostPort(ipStr, port))
-			}
-			return nil, fmt.Errorf("no safe IPs found for host %q", host)
+				return nil, fmt.Errorf("no safe IPs found for host %q", host)
+			},
 		},
-	},
-	CheckRedirect: func(req *http.Request, via []*http.Request) error {
-		if len(via) >= 5 {
-			return fmt.Errorf("too many redirects")
-		}
-		return nil
-	},
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 5 {
+				return fmt.Errorf("too many redirects")
+			}
+			return nil
+		},
+	}
 }
+
+// ssrfSafeClient blocks all internal ranges including loopback. Used for
+// adapter spec fetches, where there's no legitimate dev-time loopback case.
+var ssrfSafeClient = newSSRFSafeClient(false)
+
+// ssrfSafeOAuthClient mirrors validateTokenEndpoint's loopback exemption so
+// http://localhost OAuth token endpoints used in tests/dev still work.
+var ssrfSafeOAuthClient = newSSRFSafeClient(true)
 
 // fetchSourceURL downloads content from a URL with optional headers. Returns the body as a string.
 func fetchSourceURL(ctx context.Context, rawURL string, headers map[string]string) (string, error) {

--- a/internal/api/handlers/adaptergen.go
+++ b/internal/api/handlers/adaptergen.go
@@ -85,7 +85,8 @@ var ssrfRanges = func() []*net.IPNet {
 }()
 
 // ssrfSafeClient is an HTTP client that blocks requests to private/internal IPs,
-// resolving DNS at dial time to prevent rebinding attacks.
+// resolving DNS at dial time to prevent rebinding attacks. Used both for adapter
+// generation source fetches and for OAuth token-endpoint exchanges in services.go.
 var ssrfSafeClient = &http.Client{
 	Timeout: 30 * time.Second,
 	Transport: &http.Transport{

--- a/internal/api/handlers/approvals.go
+++ b/internal/api/handlers/approvals.go
@@ -392,6 +392,12 @@ func (h *ApprovalsHandler) executeApproval(ctx context.Context, pa *store.Pendin
 	return result, outcome, errMsg
 }
 
+// executingLeaseTTL is how long a row may sit in 'executing' before the
+// expiry sweeper assumes the executor crashed and recovers it. Five minutes
+// comfortably covers the slowest synchronous adapter call (typically <60s)
+// while still freeing the user to retry within a single sweep cycle.
+const executingLeaseTTL = 5 * time.Minute
+
 // RunExpiryCleanup runs in a background goroutine to expire timed-out approvals.
 // Call as: go handler.RunExpiryCleanup(ctx)
 func (h *ApprovalsHandler) RunExpiryCleanup(ctx context.Context) {
@@ -412,6 +418,18 @@ func (h *ApprovalsHandler) expireTimedOut(ctx context.Context) {
 	if err != nil {
 		h.logger.Warn("expiry cleanup: list failed", "err", err)
 		return
+	}
+	// Recover rows stranded in 'executing' by a daemon crash. Without this
+	// they would stay in the table forever, blocking the user from re-issuing
+	// the request because GetPendingApproval still returns the stale row.
+	stalled, err := h.st.ListStalledExecutingApprovals(ctx, executingLeaseTTL)
+	if err != nil {
+		h.logger.Warn("expiry cleanup: stalled-executing list failed", "err", err)
+	} else {
+		for _, pa := range stalled {
+			h.logger.Warn("recovering stalled executing approval", "request_id", pa.RequestID, "user_id", pa.UserID)
+			expired = append(expired, pa)
+		}
 	}
 	for _, pa := range expired {
 		h.resolveCanonicalApproval(ctx, pa, "deny", "expired")

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -547,6 +547,27 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			})
 			return
 		}
+		// Tasks are owned by the agent that created them. A different agent
+		// belonging to the same user cannot execute against another agent's
+		// task scope — that would let a low-trust agent reuse a higher-trust
+		// peer's authorization. Empty AgentID means a legacy task before the
+		// AgentID column existed and is left permissive for now.
+		if task.AgentID != "" && task.AgentID != agent.ID {
+			taskIDPtr := &req.TaskID
+			e := baseEntry("reject", "forbidden", taskIDPtr)
+			e.DurationMS = int(time.Since(start).Milliseconds())
+			errMsg := "task belongs to a different agent"
+			e.ErrorMsg = &errMsg
+			if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+				h.logger.Warn("audit log failed", "err", logErr)
+			}
+			writeDetailedError(w, http.StatusForbidden, apiErrorDetail{
+				Error: errMsg,
+				Code:  "FORBIDDEN",
+				Hint:  "Tasks are scoped to the agent that created them. Create a new task with this agent, or have the owning agent execute the request.",
+			})
+			return
+		}
 		if task.ExpiresAt != nil && time.Now().After(*task.ExpiresAt) {
 			taskIDPtr := &req.TaskID
 			e := baseEntry("reject", "task_expired", taskIDPtr)
@@ -1381,6 +1402,19 @@ func (h *GatewayHandler) HandleExecuteApproved(w http.ResponseWriter, r *http.Re
 
 	if pa.UserID != agent.UserID {
 		writeError(w, http.StatusForbidden, "FORBIDDEN", "not your approval")
+		return
+	}
+	// Pending approvals are owned by the agent that originated the request.
+	// Block sibling agents on the same user from executing each other's
+	// approved requests — the approval was scoped to a specific task created
+	// by a specific agent.
+	var paBlob pendingRequestBlob
+	if err := json.Unmarshal(pa.RequestBlob, &paBlob); err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "invalid request blob")
+		return
+	}
+	if paBlob.AgentID != "" && paBlob.AgentID != agent.ID {
+		writeError(w, http.StatusForbidden, "FORBIDDEN", "approval belongs to a different agent")
 		return
 	}
 

--- a/internal/api/handlers/notifications.go
+++ b/internal/api/handlers/notifications.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -9,6 +10,52 @@ import (
 	"github.com/clawvisor/clawvisor/pkg/notify"
 	"github.com/clawvisor/clawvisor/pkg/store"
 )
+
+// fallbackTelegramConfigStore is used when the configured notifier does not
+// implement notify.TelegramConfigStore (e.g. in tests with notifier=nil).
+// It writes/reads the legacy plaintext JSON column directly and never
+// touches the vault. Production deployments always use the notifier-backed
+// implementation, which encrypts the bot token at rest.
+type fallbackTelegramConfigStore struct {
+	st store.Store
+}
+
+func (f *fallbackTelegramConfigStore) SaveTelegramConfig(ctx context.Context, userID, botToken, chatID string) error {
+	cfg, err := json.Marshal(map[string]string{"bot_token": botToken, "chat_id": chatID})
+	if err != nil {
+		return err
+	}
+	return f.st.UpsertNotificationConfig(ctx, userID, "telegram", cfg)
+}
+
+func (f *fallbackTelegramConfigStore) TelegramConfig(ctx context.Context, userID string) (string, string, error) {
+	nc, err := f.st.GetNotificationConfig(ctx, userID, "telegram")
+	if err != nil {
+		return "", "", err
+	}
+	var c struct {
+		BotToken string `json:"bot_token"`
+		ChatID   string `json:"chat_id"`
+	}
+	if err := json.Unmarshal(nc.Config, &c); err != nil {
+		return "", "", err
+	}
+	return c.BotToken, c.ChatID, nil
+}
+
+func (f *fallbackTelegramConfigStore) DeleteTelegramConfig(ctx context.Context, userID string) error {
+	return f.st.DeleteNotificationConfig(ctx, userID, "telegram")
+}
+
+// telegramConfigStore returns the active TelegramConfigStore: the notifier's
+// vault-backed implementation when available, or a plaintext fallback for
+// test setups that pass notifier=nil.
+func (h *NotificationsHandler) telegramConfigStore() notify.TelegramConfigStore {
+	if cs, ok := h.notifier.(notify.TelegramConfigStore); ok {
+		return cs
+	}
+	return &fallbackTelegramConfigStore{st: h.st}
+}
 
 // sanitizeNotificationConfig redacts secret fields (bot_token) from a
 // notification config before returning it to the browser.
@@ -100,16 +147,7 @@ func (h *NotificationsHandler) UpsertTelegram(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	cfgBytes, err := json.Marshal(map[string]string{
-		"bot_token": body.BotToken,
-		"chat_id":   body.ChatID,
-	})
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not encode config")
-		return
-	}
-
-	if err := h.st.UpsertNotificationConfig(r.Context(), user.ID, "telegram", cfgBytes); err != nil {
+	if err := h.telegramConfigStore().SaveTelegramConfig(r.Context(), user.ID, body.BotToken, body.ChatID); err != nil {
 		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not save notification config")
 		return
 	}
@@ -134,7 +172,7 @@ func (h *NotificationsHandler) DeleteTelegram(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	if err := h.st.DeleteNotificationConfig(r.Context(), user.ID, "telegram"); err != nil {
+	if err := h.telegramConfigStore().DeleteTelegramConfig(r.Context(), user.ID); err != nil {
 		if err == store.ErrNotFound {
 			w.WriteHeader(http.StatusNoContent)
 			return
@@ -321,8 +359,9 @@ func (h *NotificationsHandler) UpsertTelegramGroup(w http.ResponseWriter, r *htt
 		return
 	}
 
-	// Read existing Telegram config to get bot token for observation.
-	nc, err := h.st.GetNotificationConfig(r.Context(), user.ID, "telegram")
+	// Resolve bot token + DM chat ID for this user. Goes through the
+	// vault-aware store rather than reading the JSON column directly.
+	botToken, chatID, err := h.telegramConfigStore().TelegramConfig(r.Context(), user.ID)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, "NOT_CONFIGURED", "Telegram notifications must be configured first")
 		return
@@ -341,12 +380,7 @@ func (h *NotificationsHandler) UpsertTelegramGroup(w http.ResponseWriter, r *htt
 
 	// Start group observation.
 	if h.groupObs != nil {
-		var cfgMap map[string]any
-		if json.Unmarshal(nc.Config, &cfgMap) == nil {
-			botToken, _ := cfgMap["bot_token"].(string)
-			chatID, _ := cfgMap["chat_id"].(string)
-			h.groupObs.EnsureGroupObservation(user.ID, botToken, chatID, body.GroupChatID)
-		}
+		h.groupObs.EnsureGroupObservation(user.ID, botToken, chatID, body.GroupChatID)
 	}
 	// Remove from pending list now that it's been enabled.
 	if h.groupDetector != nil {
@@ -668,8 +702,8 @@ func (h *NotificationsHandler) AddGroupManually(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	// Read existing Telegram config to get bot token for observation.
-	nc, err := h.st.GetNotificationConfig(r.Context(), user.ID, "telegram")
+	// Resolve bot token + DM chat ID for this user via the vault-aware store.
+	botToken, chatID, err := h.telegramConfigStore().TelegramConfig(r.Context(), user.ID)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, "NOT_CONFIGURED", "Telegram notifications must be configured first")
 		return
@@ -688,12 +722,7 @@ func (h *NotificationsHandler) AddGroupManually(w http.ResponseWriter, r *http.R
 
 	// Start group observation.
 	if h.groupObs != nil {
-		var cfgMap map[string]any
-		if json.Unmarshal(nc.Config, &cfgMap) == nil {
-			botToken, _ := cfgMap["bot_token"].(string)
-			chatID, _ := cfgMap["chat_id"].(string)
-			h.groupObs.EnsureGroupObservation(user.ID, botToken, chatID, info.ChatID)
-		}
+		h.groupObs.EnsureGroupObservation(user.ID, botToken, chatID, info.ChatID)
 	}
 	// Remove from pending list if it was there.
 	if h.groupDetector != nil {

--- a/internal/api/handlers/services.go
+++ b/internal/api/handlers/services.go
@@ -106,6 +106,31 @@ func validateTokenEndpoint(raw string) error {
 	return fmt.Errorf("token_url must use http or https (got %q)", u.Scheme)
 }
 
+// checkPendingRequestOwnership verifies that pendingReqID — if non-empty —
+// belongs to userID before it gets stashed in OAuth state. Without this an
+// attacker who knows another user's pending_request_id could pass it on the
+// OAuth init step; the OAuth flow would then reactivate that pending request
+// under the attacker's freshly minted credential when the callback completes.
+// reactivatePendingRequest re-checks ownership at callback time as defense in
+// depth, but this helper is the upstream guard. Returns true on success;
+// returns false (and writes the HTTP error) on any failure.
+func (h *ServicesHandler) checkPendingRequestOwnership(w http.ResponseWriter, r *http.Request, userID, pendingReqID string) bool {
+	if pendingReqID == "" {
+		return true
+	}
+	pa, err := h.st.GetPendingApproval(r.Context(), pendingReqID)
+	if err != nil || pa.UserID != userID {
+		h.logger.Warn("rejected oauth init with cross-user pending_request_id",
+			"caller_user_id", userID,
+			"pending_request_id", pendingReqID,
+			"err", err,
+		)
+		writeError(w, http.StatusForbidden, "FORBIDDEN", "pending_request_id does not belong to this user")
+		return false
+	}
+	return true
+}
+
 // validateCLICallback checks that a CLI callback URL is safe — it must be
 // http-only and point to localhost or 127.0.0.1. Returns "" if invalid.
 func validateCLICallback(raw string) string {
@@ -437,12 +462,17 @@ func (h *ServicesHandler) OAuthGetURL(w http.ResponseWriter, r *http.Request) {
 		_ = json.Unmarshal([]byte(raw), &flowConfig)
 	}
 
+	pendingReqID := r.URL.Query().Get("pending_request_id")
+	if !h.checkPendingRequestOwnership(w, r, user.ID, pendingReqID) {
+		return
+	}
+
 	stateToken := uuid.New().String()
 	h.oauthStore.StoreOAuth(stateToken, oauthStateEntry{
 		UserID:       user.ID,
 		ServiceID:    serviceID,
 		Alias:        alias,
-		PendingReqID: r.URL.Query().Get("pending_request_id"),
+		PendingReqID: pendingReqID,
 		CLICallback:  validateCLICallback(r.URL.Query().Get("cli_callback")),
 		Config:       flowConfig,
 		Scopes:       mergedScopes,
@@ -503,12 +533,17 @@ func (h *ServicesHandler) OAuthStart(w http.ResponseWriter, r *http.Request) {
 		_ = json.Unmarshal([]byte(raw), &flowConfig)
 	}
 
+	pendingReqID := r.URL.Query().Get("pending_request_id")
+	if !h.checkPendingRequestOwnership(w, r, user.ID, pendingReqID) {
+		return
+	}
+
 	stateToken := uuid.New().String()
 	h.oauthStore.StoreOAuth(stateToken, oauthStateEntry{
 		UserID:       user.ID,
 		ServiceID:    serviceID,
 		Alias:        alias,
-		PendingReqID: r.URL.Query().Get("pending_request_id"),
+		PendingReqID: pendingReqID,
 		Config:       flowConfig,
 		Scopes:       mergedScopes,
 		TokenPath:    adapterTokenPath(adapter),
@@ -784,22 +819,8 @@ func (h *ServicesHandler) Activate(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		// If the caller passed a pending_request_id, verify they own it before
-		// stashing it in OAuth state. Otherwise an attacker could supply
-		// another user's pending request ID and trigger reactivation of that
-		// pending request under their own credentials when the OAuth flow
-		// completes.
-		if body.PendingRequestID != "" {
-			pa, err := h.st.GetPendingApproval(r.Context(), body.PendingRequestID)
-			if err != nil || pa.UserID != user.ID {
-				h.logger.Warn("rejected oauth init with cross-user pending_request_id",
-					"caller_user_id", user.ID,
-					"pending_request_id", body.PendingRequestID,
-					"err", err,
-				)
-				writeError(w, http.StatusForbidden, "FORBIDDEN", "pending_request_id does not belong to this user")
-				return
-			}
+		if !h.checkPendingRequestOwnership(w, r, user.ID, body.PendingRequestID) {
+			return
 		}
 
 		mergedScopes, alreadyAuthorized := h.resolveOAuthScopes(r.Context(), user.ID, serviceID, alias, adapter)

--- a/internal/api/handlers/services.go
+++ b/internal/api/handlers/services.go
@@ -74,6 +74,37 @@ func validAlias(s string) bool {
 	return validAliasRe.MatchString(s)
 }
 
+// validateTokenEndpoint checks that an OAuth token (or device-code) URL is
+// safe to dial: parseable, https-only (or http for localhost dev), and not
+// using userinfo or a fragment. IP-level SSRF checks happen at connect time
+// in ssrfSafeClient's DialContext, which prevents DNS rebinding.
+func validateTokenEndpoint(raw string) error {
+	if raw == "" {
+		return fmt.Errorf("token_url is empty")
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("token_url is not a valid URL: %w", err)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("token_url is missing a host")
+	}
+	if u.User != nil {
+		return fmt.Errorf("token_url must not embed userinfo")
+	}
+	if u.Scheme == "https" {
+		return nil
+	}
+	if u.Scheme == "http" {
+		host := u.Hostname()
+		if host == "localhost" || host == "127.0.0.1" || host == "::1" {
+			return nil
+		}
+		return fmt.Errorf("token_url must use https (http only allowed for localhost)")
+	}
+	return fmt.Errorf("token_url must use http or https (got %q)", u.Scheme)
+}
+
 // validateCLICallback checks that a CLI callback URL is safe — it must be
 // http-only and point to localhost or 127.0.0.1. Returns "" if invalid.
 func validateCLICallback(raw string) string {
@@ -541,6 +572,11 @@ func (h *ServicesHandler) OAuthCallback(w http.ResponseWriter, r *http.Request) 
 			"redirect_uri":  {oauthCfg.RedirectURL},
 			"grant_type":    {"authorization_code"},
 		}
+		if err := validateTokenEndpoint(oauthCfg.Endpoint.TokenURL); err != nil {
+			h.logger.Warn("oauth token exchange: invalid token_url", "service", entry.ServiceID, "err", err)
+			oauthPopupClose(w, "Provider token endpoint is not allowed.", "")
+			return
+		}
 		tokenReq, err := http.NewRequestWithContext(r.Context(), "POST", oauthCfg.Endpoint.TokenURL, strings.NewReader(form.Encode()))
 		if err != nil {
 			oauthPopupClose(w, "Failed to build token request.", "")
@@ -549,7 +585,7 @@ func (h *ServicesHandler) OAuthCallback(w http.ResponseWriter, r *http.Request) 
 		tokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		tokenReq.Header.Set("Accept", "application/json")
 
-		resp, err := http.DefaultClient.Do(tokenReq)
+		resp, err := ssrfSafeClient.Do(tokenReq)
 		if err != nil {
 			h.logger.Warn("oauth token exchange failed", "service", entry.ServiceID, "err", err)
 			oauthPopupClose(w, "Token exchange with provider failed.", "")
@@ -589,8 +625,14 @@ func (h *ServicesHandler) OAuthCallback(w http.ResponseWriter, r *http.Request) 
 			return
 		}
 	} else {
-		// Standard OAuth2 token exchange.
-		token, err := oauthCfg.Exchange(r.Context(), code)
+		// Standard OAuth2 token exchange — route through the SSRF-safe client.
+		if err := validateTokenEndpoint(oauthCfg.Endpoint.TokenURL); err != nil {
+			h.logger.Warn("oauth token exchange: invalid token_url", "service", entry.ServiceID, "err", err)
+			oauthPopupClose(w, "Provider token endpoint is not allowed.", "")
+			return
+		}
+		exchangeCtx := context.WithValue(r.Context(), oauth2.HTTPClient, ssrfSafeClient)
+		token, err := oauthCfg.Exchange(exchangeCtx, code)
 		if err != nil {
 			h.logger.Warn("oauth token exchange failed", "service", entry.ServiceID, "err", err)
 			oauthPopupClose(w, "Token exchange with provider failed.", "")
@@ -1475,6 +1517,11 @@ func (h *ServicesHandler) DeviceFlowStart(w http.ResponseWriter, r *http.Request
 		"client_id": {clientID},
 		"scope":     {strings.Join(dfCfg.Scopes, " ")},
 	}
+	if err := validateTokenEndpoint(dfCfg.DeviceCodeURL); err != nil {
+		h.logger.Warn("device flow: invalid device_code_url", "service", serviceID, "err", err)
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "device_code_url is not allowed")
+		return
+	}
 	req, err := http.NewRequestWithContext(r.Context(), "POST", dfCfg.DeviceCodeURL, strings.NewReader(form.Encode()))
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to build request")
@@ -1483,7 +1530,7 @@ func (h *ServicesHandler) DeviceFlowStart(w http.ResponseWriter, r *http.Request
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := ssrfSafeClient.Do(req)
 	if err != nil {
 		h.logger.Warn("device flow: request to provider failed", "err", err)
 		writeError(w, http.StatusBadGateway, "PROVIDER_ERROR", "failed to contact provider")
@@ -1588,6 +1635,11 @@ func (h *ServicesHandler) DeviceFlowPoll(w http.ResponseWriter, r *http.Request)
 		"device_code": {entry.DeviceCode},
 		"grant_type":  {entry.GrantType},
 	}
+	if err := validateTokenEndpoint(entry.TokenURL); err != nil {
+		h.logger.Warn("device flow poll: invalid token_url", "service", entry.ServiceID, "err", err)
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "token_url is not allowed")
+		return
+	}
 	req, err := http.NewRequestWithContext(r.Context(), "POST", entry.TokenURL, strings.NewReader(form.Encode()))
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to build request")
@@ -1596,7 +1648,7 @@ func (h *ServicesHandler) DeviceFlowPoll(w http.ResponseWriter, r *http.Request)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := ssrfSafeClient.Do(req)
 	if err != nil {
 		h.logger.Warn("device flow poll: request failed", "err", err)
 		writeError(w, http.StatusBadGateway, "PROVIDER_ERROR", "failed to contact provider")
@@ -1891,6 +1943,11 @@ func (h *ServicesHandler) PKCEFlowCallback(w http.ResponseWriter, r *http.Reques
 		"redirect_uri":  {entry.RedirectURI},
 		"grant_type":    {"authorization_code"},
 	}
+	if err := validateTokenEndpoint(entry.TokenURL); err != nil {
+		h.logger.Warn("pkce flow: invalid token_url", "service", entry.ServiceID, "err", err)
+		oauthPopupClose(w, "Provider token endpoint is not allowed.", "")
+		return
+	}
 	tokenReq, err := http.NewRequestWithContext(r.Context(), "POST", entry.TokenURL, strings.NewReader(form.Encode()))
 	if err != nil {
 		oauthPopupClose(w, "Failed to build token request.", "")
@@ -1899,7 +1956,7 @@ func (h *ServicesHandler) PKCEFlowCallback(w http.ResponseWriter, r *http.Reques
 	tokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	tokenReq.Header.Set("Accept", "application/json")
 
-	resp, err := http.DefaultClient.Do(tokenReq)
+	resp, err := ssrfSafeClient.Do(tokenReq)
 	if err != nil {
 		h.logger.Warn("pkce flow: token exchange failed", "err", err)
 		oauthPopupClose(w, "Failed to contact token endpoint.", "")

--- a/internal/api/handlers/services.go
+++ b/internal/api/handlers/services.go
@@ -741,6 +741,24 @@ func (h *ServicesHandler) Activate(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		// If the caller passed a pending_request_id, verify they own it before
+		// stashing it in OAuth state. Otherwise an attacker could supply
+		// another user's pending request ID and trigger reactivation of that
+		// pending request under their own credentials when the OAuth flow
+		// completes.
+		if body.PendingRequestID != "" {
+			pa, err := h.st.GetPendingApproval(r.Context(), body.PendingRequestID)
+			if err != nil || pa.UserID != user.ID {
+				h.logger.Warn("rejected oauth init with cross-user pending_request_id",
+					"caller_user_id", user.ID,
+					"pending_request_id", body.PendingRequestID,
+					"err", err,
+				)
+				writeError(w, http.StatusForbidden, "FORBIDDEN", "pending_request_id does not belong to this user")
+				return
+			}
+		}
+
 		mergedScopes, alreadyAuthorized := h.resolveOAuthScopes(r.Context(), user.ID, serviceID, alias, adapter)
 		if alreadyAuthorized {
 			_ = h.st.UpsertServiceMeta(r.Context(), user.ID, serviceID, alias, time.Now())
@@ -1173,6 +1191,17 @@ func (h *ServicesHandler) reactivatePendingRequest(ctx context.Context, userID, 
 	pa, err := h.st.GetPendingApproval(ctx, requestID)
 	if err != nil {
 		h.logger.Warn("reactivate: pending approval not found", "request_id", requestID, "err", err)
+		return
+	}
+	// Defense in depth: even though OAuth init verifies ownership before
+	// stashing the request_id, refuse to act on a pending approval that does
+	// not belong to the user whose OAuth flow we just completed.
+	if pa.UserID != userID {
+		h.logger.Warn("reactivate: refusing cross-user pending approval",
+			"request_id", requestID,
+			"oauth_user_id", userID,
+			"pending_user_id", pa.UserID,
+		)
 		return
 	}
 

--- a/internal/api/handlers/services.go
+++ b/internal/api/handlers/services.go
@@ -77,7 +77,8 @@ func validAlias(s string) bool {
 // validateTokenEndpoint checks that an OAuth token (or device-code) URL is
 // safe to dial: parseable, https-only (or http for localhost dev), and not
 // using userinfo or a fragment. IP-level SSRF checks happen at connect time
-// in ssrfSafeClient's DialContext, which prevents DNS rebinding.
+// in ssrfSafeOAuthClient's DialContext, which prevents DNS rebinding while
+// still allowing the loopback exemption documented below.
 func validateTokenEndpoint(raw string) error {
 	if raw == "" {
 		return fmt.Errorf("token_url is empty")
@@ -585,7 +586,7 @@ func (h *ServicesHandler) OAuthCallback(w http.ResponseWriter, r *http.Request) 
 		tokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		tokenReq.Header.Set("Accept", "application/json")
 
-		resp, err := ssrfSafeClient.Do(tokenReq)
+		resp, err := ssrfSafeOAuthClient.Do(tokenReq)
 		if err != nil {
 			h.logger.Warn("oauth token exchange failed", "service", entry.ServiceID, "err", err)
 			oauthPopupClose(w, "Token exchange with provider failed.", "")
@@ -631,7 +632,7 @@ func (h *ServicesHandler) OAuthCallback(w http.ResponseWriter, r *http.Request) 
 			oauthPopupClose(w, "Provider token endpoint is not allowed.", "")
 			return
 		}
-		exchangeCtx := context.WithValue(r.Context(), oauth2.HTTPClient, ssrfSafeClient)
+		exchangeCtx := context.WithValue(r.Context(), oauth2.HTTPClient, ssrfSafeOAuthClient)
 		token, err := oauthCfg.Exchange(exchangeCtx, code)
 		if err != nil {
 			h.logger.Warn("oauth token exchange failed", "service", entry.ServiceID, "err", err)
@@ -1530,7 +1531,7 @@ func (h *ServicesHandler) DeviceFlowStart(w http.ResponseWriter, r *http.Request
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
 
-	resp, err := ssrfSafeClient.Do(req)
+	resp, err := ssrfSafeOAuthClient.Do(req)
 	if err != nil {
 		h.logger.Warn("device flow: request to provider failed", "err", err)
 		writeError(w, http.StatusBadGateway, "PROVIDER_ERROR", "failed to contact provider")
@@ -1648,7 +1649,7 @@ func (h *ServicesHandler) DeviceFlowPoll(w http.ResponseWriter, r *http.Request)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
 
-	resp, err := ssrfSafeClient.Do(req)
+	resp, err := ssrfSafeOAuthClient.Do(req)
 	if err != nil {
 		h.logger.Warn("device flow poll: request failed", "err", err)
 		writeError(w, http.StatusBadGateway, "PROVIDER_ERROR", "failed to contact provider")
@@ -1956,7 +1957,7 @@ func (h *ServicesHandler) PKCEFlowCallback(w http.ResponseWriter, r *http.Reques
 	tokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	tokenReq.Header.Set("Accept", "application/json")
 
-	resp, err := ssrfSafeClient.Do(tokenReq)
+	resp, err := ssrfSafeOAuthClient.Do(tokenReq)
 	if err != nil {
 		h.logger.Warn("pkce flow: token exchange failed", "err", err)
 		oauthPopupClose(w, "Failed to contact token endpoint.", "")

--- a/internal/api/handlers/services_pending_hijack_test.go
+++ b/internal/api/handlers/services_pending_hijack_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -80,6 +82,66 @@ func TestReactivatePendingRequest_RejectsCrossUserHijack(t *testing.T) {
 	}
 	if got.Status != "pending" {
 		t.Fatalf("victim's pending approval status changed to %q", got.Status)
+	}
+}
+
+// TestCheckPendingRequestOwnership_RejectsCrossUser exercises the upstream
+// guard used by every OAuth init path (POST /api/oauth/init, GET /api/oauth/url,
+// GET /api/oauth/start). The downstream reactivatePendingRequest check is
+// separately covered above; this guard makes sure attacker-controlled IDs
+// never get stashed in OAuth state in the first place.
+func TestCheckPendingRequestOwnership_RejectsCrossUser(t *testing.T) {
+	ctx := context.Background()
+
+	db, err := sqlitestore.New(ctx, t.TempDir()+"/test.db")
+	if err != nil {
+		t.Fatalf("sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	st := sqlitestore.NewStore(db)
+	victim, _ := st.CreateUser(ctx, "v@test", "h")
+	attacker, _ := st.CreateUser(ctx, "a@test", "h")
+
+	pa := &store.PendingApproval{
+		ID:        "pa-x",
+		UserID:    victim.ID,
+		RequestID: "req-x",
+		AuditID:   "audit-x",
+		Status:    "pending",
+		ExpiresAt: time.Now().Add(5 * time.Minute),
+	}
+	if err := st.SavePendingApproval(ctx, pa); err != nil {
+		t.Fatalf("SavePendingApproval: %v", err)
+	}
+
+	h := NewServicesHandler(st, nil, adapters.NewRegistry(),
+		slog.New(slog.NewTextHandler(discardWriter{}, nil)), "", nil)
+
+	cases := []struct {
+		name       string
+		callerID   string
+		pendingID  string
+		wantOK     bool
+		wantStatus int
+	}{
+		{"empty pending id is allowed", attacker.ID, "", true, 0},
+		{"victim's id rejected for attacker", attacker.ID, "req-x", false, http.StatusForbidden},
+		{"unknown id rejected", attacker.ID, "does-not-exist", false, http.StatusForbidden},
+		{"victim's id allowed for victim", victim.ID, "req-x", true, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/api/oauth/start", nil)
+			ok := h.checkPendingRequestOwnership(rec, req, tc.callerID, tc.pendingID)
+			if ok != tc.wantOK {
+				t.Fatalf("ok=%v want=%v", ok, tc.wantOK)
+			}
+			if !tc.wantOK && rec.Code != tc.wantStatus {
+				t.Fatalf("status=%d want=%d", rec.Code, tc.wantStatus)
+			}
+		})
 	}
 }
 

--- a/internal/api/handlers/services_pending_hijack_test.go
+++ b/internal/api/handlers/services_pending_hijack_test.go
@@ -1,0 +1,88 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+	"time"
+
+	sqlitestore "github.com/clawvisor/clawvisor/internal/store/sqlite"
+	"github.com/clawvisor/clawvisor/pkg/adapters"
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+// TestReactivatePendingRequest_RejectsCrossUserHijack verifies that
+// reactivatePendingRequest refuses to act on a pending approval that belongs
+// to a different user than the one whose OAuth flow just completed.
+//
+// The vulnerability: services.go previously fetched the pending approval by
+// request_id alone, then executed against the OAuth user's credentials.
+// An attacker could supply victim's pending_request_id during their own
+// OAuth init; on callback, the victim's pending row would be deleted and
+// the victim's audit trail mutated — even though the actual execution would
+// run with the attacker's vault credential.
+func TestReactivatePendingRequest_RejectsCrossUserHijack(t *testing.T) {
+	ctx := context.Background()
+
+	db, err := sqlitestore.New(ctx, t.TempDir()+"/test.db")
+	if err != nil {
+		t.Fatalf("sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	st := sqlitestore.NewStore(db)
+	victim, err := st.CreateUser(ctx, "victim@test.example", "hash")
+	if err != nil {
+		t.Fatalf("CreateUser victim: %v", err)
+	}
+	attacker, err := st.CreateUser(ctx, "attacker@test.example", "hash")
+	if err != nil {
+		t.Fatalf("CreateUser attacker: %v", err)
+	}
+
+	// Create a pending approval owned by the victim.
+	blob, _ := json.Marshal(map[string]any{
+		"service": "mock.echo",
+		"action":  "echo",
+		"params":  map[string]any{"msg": "victim secret"},
+		"user_id": victim.ID,
+	})
+	pa := &store.PendingApproval{
+		ID:          "pa-victim-1",
+		UserID:      victim.ID,
+		RequestID:   "req-victim-1",
+		AuditID:     "audit-victim-1",
+		RequestBlob: blob,
+		Status:      "pending",
+		ExpiresAt:   time.Now().Add(5 * time.Minute),
+	}
+	// Audit row referenced by AuditID must exist for UpdateAuditOutcome to be
+	// observable; we don't insert one because we want to *prove* nothing gets
+	// touched.
+	if err := st.SavePendingApproval(ctx, pa); err != nil {
+		t.Fatalf("SavePendingApproval: %v", err)
+	}
+
+	h := NewServicesHandler(st, nil, adapters.NewRegistry(),
+		slog.New(slog.NewTextHandler(discardWriter{}, nil)), "", nil)
+
+	// Attacker just completed OAuth; reactivate is invoked with attacker.ID
+	// but victim's request_id. Must be a no-op.
+	h.reactivatePendingRequest(ctx, attacker.ID, "req-victim-1")
+
+	got, err := st.GetPendingApproval(ctx, "req-victim-1")
+	if err != nil {
+		t.Fatalf("victim's pending approval was deleted by cross-user reactivation: %v", err)
+	}
+	if got.UserID != victim.ID {
+		t.Fatalf("victim's pending approval mutated: user_id=%q want %q", got.UserID, victim.ID)
+	}
+	if got.Status != "pending" {
+		t.Fatalf("victim's pending approval status changed to %q", got.Status)
+	}
+}
+
+type discardWriter struct{}
+
+func (discardWriter) Write(p []byte) (int, error) { return len(p), nil }

--- a/internal/api/handlers/services_token_endpoint_test.go
+++ b/internal/api/handlers/services_token_endpoint_test.go
@@ -1,0 +1,79 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestValidateTokenEndpoint covers the scheme/host policy that gates which
+// URLs the OAuth and PKCE flows are willing to dial. Combined with
+// ssrfSafeClient's connect-time IP check, this is the SSRF defense for
+// adapter-supplied token endpoints.
+func TestValidateTokenEndpoint(t *testing.T) {
+	cases := []struct {
+		name    string
+		url     string
+		wantErr bool
+	}{
+		{"valid https", "https://provider.example.com/oauth/token", false},
+		{"localhost http allowed for dev", "http://localhost:8080/token", false},
+		{"127.0.0.1 http allowed for dev", "http://127.0.0.1:8080/token", false},
+		{"::1 http allowed for dev", "http://[::1]:8080/token", false},
+		{"http external rejected", "http://provider.example.com/token", true},
+		{"empty rejected", "", true},
+		{"missing host rejected", "https://", true},
+		{"unsupported scheme rejected", "file:///etc/passwd", true},
+		{"gopher rejected", "gopher://provider.example.com/", true},
+		{"userinfo rejected", "https://user:pass@provider.example.com/token", true},
+		{"unparseable", "://broken", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateTokenEndpoint(tc.url)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("validateTokenEndpoint(%q) err=%v wantErr=%v", tc.url, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestSSRFSafeClient_BlocksPrivateIPs verifies that the shared HTTP client
+// used by all OAuth token exchanges refuses to dial RFC1918 / link-local /
+// loopback / cloud-metadata addresses, even when the URL is otherwise
+// well-formed and reachable.
+func TestSSRFSafeClient_BlocksPrivateIPs(t *testing.T) {
+	// Use a real listener so we know there's nothing to TOCTOU with — the
+	// dialer must reject before any TCP connect is attempted.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	blocked := []string{
+		"http://127.0.0.1:1/x",          // loopback
+		"http://10.0.0.1:80/x",          // RFC1918
+		"http://192.168.1.1:80/x",       // RFC1918
+		"http://169.254.169.254/latest", // cloud metadata
+		"http://172.16.0.1:80/x",        // RFC1918
+		"http://[::1]:1/x",              // ipv6 loopback
+	}
+	for _, raw := range blocked {
+		t.Run(raw, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, raw, nil)
+			if err != nil {
+				t.Fatalf("NewRequest: %v", err)
+			}
+			resp, err := ssrfSafeClient.Do(req)
+			if err == nil {
+				resp.Body.Close()
+				t.Fatalf("expected SSRF-safe client to reject %q, got status %d", raw, resp.StatusCode)
+			}
+			// The dialer reports either "blocked IP" or "no safe IPs found".
+			if !strings.Contains(err.Error(), "blocked IP") && !strings.Contains(err.Error(), "no safe IPs") {
+				t.Fatalf("unexpected error for %q: %v", raw, err)
+			}
+		})
+	}
+}

--- a/internal/api/handlers/services_token_endpoint_test.go
+++ b/internal/api/handlers/services_token_endpoint_test.go
@@ -39,10 +39,11 @@ func TestValidateTokenEndpoint(t *testing.T) {
 	}
 }
 
-// TestSSRFSafeClient_BlocksPrivateIPs verifies that the shared HTTP client
-// used by all OAuth token exchanges refuses to dial RFC1918 / link-local /
-// loopback / cloud-metadata addresses, even when the URL is otherwise
-// well-formed and reachable.
+// TestSSRFSafeClient_BlocksPrivateIPs verifies that the spec-fetch HTTP client
+// refuses to dial RFC1918 / link-local / loopback / cloud-metadata addresses,
+// even when the URL is otherwise well-formed and reachable. OAuth uses a
+// looser sibling client (ssrfSafeOAuthClient) that exempts loopback to match
+// validateTokenEndpoint — covered by TestSSRFSafeOAuthClient_AllowsLoopback.
 func TestSSRFSafeClient_BlocksPrivateIPs(t *testing.T) {
 	// Use a real listener so we know there's nothing to TOCTOU with — the
 	// dialer must reject before any TCP connect is attempted.
@@ -71,6 +72,52 @@ func TestSSRFSafeClient_BlocksPrivateIPs(t *testing.T) {
 				t.Fatalf("expected SSRF-safe client to reject %q, got status %d", raw, resp.StatusCode)
 			}
 			// The dialer reports either "blocked IP" or "no safe IPs found".
+			if !strings.Contains(err.Error(), "blocked IP") && !strings.Contains(err.Error(), "no safe IPs") {
+				t.Fatalf("unexpected error for %q: %v", raw, err)
+			}
+		})
+	}
+}
+
+// TestSSRFSafeOAuthClient_AllowsLoopback ensures that the OAuth-specific
+// client lets http://localhost / 127.0.0.1 / ::1 endpoints through (since
+// validateTokenEndpoint already allows them), while still rejecting RFC1918,
+// link-local, and cloud-metadata ranges.
+func TestSSRFSafeOAuthClient_AllowsLoopback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	t.Run("loopback allowed", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+		if err != nil {
+			t.Fatalf("NewRequest: %v", err)
+		}
+		resp, err := ssrfSafeOAuthClient.Do(req)
+		if err != nil {
+			t.Fatalf("oauth client should accept loopback %q: %v", srv.URL, err)
+		}
+		resp.Body.Close()
+	})
+
+	blocked := []string{
+		"http://10.0.0.1:80/x",          // RFC1918
+		"http://192.168.1.1:80/x",       // RFC1918
+		"http://169.254.169.254/latest", // cloud metadata
+		"http://172.16.0.1:80/x",        // RFC1918
+	}
+	for _, raw := range blocked {
+		t.Run("blocked "+raw, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, raw, nil)
+			if err != nil {
+				t.Fatalf("NewRequest: %v", err)
+			}
+			resp, err := ssrfSafeOAuthClient.Do(req)
+			if err == nil {
+				resp.Body.Close()
+				t.Fatalf("expected oauth client to reject %q, got status %d", raw, resp.StatusCode)
+			}
 			if !strings.Contains(err.Error(), "blocked IP") && !strings.Contains(err.Error(), "no safe IPs") {
 				t.Fatalf("unexpected error for %q: %v", raw, err)
 			}

--- a/internal/callback/callback_test.go
+++ b/internal/callback/callback_test.go
@@ -1,0 +1,243 @@
+package callback
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// resetInit restores package globals after a test mutates them via Init.
+func resetInit(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() { Init(nil, false, false) })
+}
+
+func TestValidateCallbackURL(t *testing.T) {
+	resetInit(t)
+	Init(nil, true, false)
+
+	cases := []struct {
+		name    string
+		url     string
+		wantErr bool
+	}{
+		{"valid https", "https://example.com/cb", false},
+		{"localhost http allowed", "http://localhost:8080/cb", false},
+		{"127.0.0.1 http allowed", "http://127.0.0.1:8080/cb", false},
+		{"http external rejected", "http://example.com/cb", true},
+		{"unknown scheme rejected", "ftp://example.com/cb", true},
+		{"unparseable", "://broken", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateCallbackURL(tc.url)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("ValidateCallbackURL(%q) err=%v wantErr=%v", tc.url, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestIsSSRFTarget(t *testing.T) {
+	resetInit(t)
+	Init(nil, false, true)
+
+	blocked := []string{
+		"10.0.0.1",
+		"172.16.5.5",
+		"192.168.1.1",
+		"169.254.169.254", // cloud metadata
+		"fc00::1",
+		"fe80::1",
+		"127.0.0.1",
+		"::1",
+	}
+	for _, ipStr := range blocked {
+		t.Run("blocked/"+ipStr, func(t *testing.T) {
+			ip := net.ParseIP(ipStr)
+			if ip == nil {
+				t.Fatalf("parse %q failed", ipStr)
+			}
+			if !isSSRFTarget(ip) {
+				t.Fatalf("expected %s to be blocked", ipStr)
+			}
+		})
+	}
+
+	allowed := []string{
+		"8.8.8.8",
+		"203.0.113.5",
+		"2001:db8::1",
+	}
+	for _, ipStr := range allowed {
+		t.Run("allowed/"+ipStr, func(t *testing.T) {
+			ip := net.ParseIP(ipStr)
+			if ip == nil {
+				t.Fatalf("parse %q failed", ipStr)
+			}
+			if isSSRFTarget(ip) {
+				t.Fatalf("expected %s to be allowed", ipStr)
+			}
+		})
+	}
+}
+
+func TestIsSSRFTarget_LoopbackBlockedOnlyWhenConfigured(t *testing.T) {
+	resetInit(t)
+	Init(nil, false, false)
+	if isSSRFTarget(net.ParseIP("127.0.0.1")) {
+		t.Fatalf("loopback should NOT be blocked when blockLoopback=false")
+	}
+	Init(nil, false, true)
+	if !isSSRFTarget(net.ParseIP("127.0.0.1")) {
+		t.Fatalf("loopback SHOULD be blocked when blockLoopback=true")
+	}
+}
+
+func TestIsSSRFTarget_AllowlistOverridesBlock(t *testing.T) {
+	resetInit(t)
+	Init([]string{"10.0.0.0/8"}, false, false)
+	if isSSRFTarget(net.ParseIP("10.1.2.3")) {
+		t.Fatalf("explicitly allowlisted CIDR should not be blocked")
+	}
+	if !isSSRFTarget(net.ParseIP("192.168.0.1")) {
+		t.Fatalf("non-allowlisted private range should remain blocked")
+	}
+}
+
+func TestDeliverResult_NoURL_NoOp(t *testing.T) {
+	resetInit(t)
+	if err := DeliverResult(context.Background(), "", &Payload{}, ""); err != nil {
+		t.Fatalf("expected nil error for empty callback URL, got %v", err)
+	}
+}
+
+func TestDeliverResult_HMACSignatureMatchesBody(t *testing.T) {
+	resetInit(t)
+	Init(nil, false, false)
+
+	const secret = "agent-bearer-token-xyz"
+
+	var seenSig string
+	var seenBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenSig = r.Header.Get("X-Clawvisor-Signature")
+		body, _ := io.ReadAll(r.Body)
+		seenBody = body
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	payload := &Payload{Type: "request", RequestID: "req-1", Status: "approved"}
+	if err := DeliverResult(context.Background(), srv.URL, payload, secret); err != nil {
+		t.Fatalf("DeliverResult: %v", err)
+	}
+
+	// Recompute the expected HMAC from the body the server actually saw.
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(seenBody)
+	expected := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+	if seenSig != expected {
+		t.Fatalf("signature mismatch: got %q want %q", seenSig, expected)
+	}
+
+	// Confirm body shape.
+	var got Payload
+	if err := json.Unmarshal(seenBody, &got); err != nil {
+		t.Fatalf("invalid JSON body: %v", err)
+	}
+	if got.RequestID != payload.RequestID || got.Status != payload.Status {
+		t.Fatalf("payload mismatch: %+v", got)
+	}
+}
+
+func TestDeliverResult_OmitsSignatureWhenNoSecret(t *testing.T) {
+	resetInit(t)
+	Init(nil, false, false)
+
+	var sig string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sig = r.Header.Get("X-Clawvisor-Signature")
+	}))
+	t.Cleanup(srv.Close)
+
+	if err := DeliverResult(context.Background(), srv.URL, &Payload{Type: "request", RequestID: "r"}, ""); err != nil {
+		t.Fatalf("DeliverResult: %v", err)
+	}
+	if sig != "" {
+		t.Fatalf("expected no signature header when secret is empty, got %q", sig)
+	}
+}
+
+func TestDeliverResult_NonSuccessReturnsError(t *testing.T) {
+	resetInit(t)
+	Init(nil, false, false)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("kaboom"))
+	}))
+	t.Cleanup(srv.Close)
+
+	err := DeliverResult(context.Background(), srv.URL, &Payload{Type: "request", RequestID: "r"}, "")
+	if err == nil || !strings.Contains(err.Error(), "500") {
+		t.Fatalf("expected 500 error, got %v", err)
+	}
+}
+
+func TestDeliverResult_BlocksSSRFTargets(t *testing.T) {
+	resetInit(t)
+	// Block loopback so an httptest server (which binds to 127.0.0.1) will
+	// be rejected by the SSRF dialer. This proves the dialer enforces blocks
+	// even when ValidateCallbackURL accepted the host.
+	Init(nil, false, true)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	err := DeliverResult(context.Background(), srv.URL, &Payload{Type: "request", RequestID: "r"}, "")
+	if err == nil {
+		t.Fatalf("expected SSRF block error, got nil")
+	}
+	if !strings.Contains(err.Error(), "blocked IP") && !strings.Contains(err.Error(), "no safe IPs") {
+		t.Fatalf("expected SSRF block error, got %v", err)
+	}
+}
+
+func TestDeliverResult_ConcurrencySafe(t *testing.T) {
+	resetInit(t)
+	Init(nil, false, false)
+
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	const n = 16
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			_ = DeliverResult(context.Background(), srv.URL, &Payload{Type: "request", RequestID: "r"}, "k")
+		}()
+	}
+	wg.Wait()
+	if got := hits.Load(); got != n {
+		t.Fatalf("expected %d hits, got %d", n, got)
+	}
+}

--- a/internal/intent/failmode_test.go
+++ b/internal/intent/failmode_test.go
@@ -1,0 +1,86 @@
+package intent
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/internal/llm"
+	"github.com/clawvisor/clawvisor/pkg/config"
+)
+
+// brokenServer always returns 500 so the LLM client treats every attempt as a
+// transport failure, exercising the verifier's fail-open / fail-closed branch.
+func brokenServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, `{"error":"boom"}`)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func newVerifierWithCfg(t *testing.T, failClosed bool) *LLMVerifier {
+	t.Helper()
+	srv := brokenServer(t)
+	cfg := config.LLMConfig{
+		Verification: config.VerificationConfig{
+			LLMProviderConfig: config.LLMProviderConfig{
+				Enabled:        true,
+				Provider:       "openai",
+				Endpoint:       srv.URL,
+				APIKey:         "test-key",
+				Model:          "test-model",
+				TimeoutSeconds: 1,
+			},
+			FailClosed:      failClosed,
+			CacheTTLSeconds: 60,
+		},
+	}
+	health := llm.NewHealth(cfg)
+	return NewLLMVerifier(health, slog.New(slog.NewTextHandler(io.Discard, nil)))
+}
+
+func sampleVerifyReq() VerifyRequest {
+	return VerifyRequest{
+		TaskPurpose: "test purpose",
+		Service:     "google.gmail",
+		Action:      "list",
+		Params:      map[string]any{"q": "is:unread"},
+		Reason:      "fetch unread email",
+		TaskID:      "task-fail-mode",
+	}
+}
+
+func TestVerify_FailClosed_BlocksOnLLMError(t *testing.T) {
+	v := newVerifierWithCfg(t, true)
+	verdict, err := v.Verify(context.Background(), sampleVerifyReq())
+	if err != nil {
+		t.Fatalf("Verify returned error (should swallow into verdict): %v", err)
+	}
+	if verdict == nil {
+		t.Fatalf("expected blocking verdict when FailClosed=true, got nil (fail-open)")
+	}
+	if verdict.Allow {
+		t.Fatalf("expected Allow=false when FailClosed=true, got Allow=true")
+	}
+	if verdict.ParamScope != "n/a" || verdict.ReasonCoherence != "n/a" {
+		t.Fatalf("expected n/a scope/reason on fail-closed, got scope=%q reason=%q",
+			verdict.ParamScope, verdict.ReasonCoherence)
+	}
+}
+
+func TestVerify_FailOpen_DegradesToNilVerdict(t *testing.T) {
+	v := newVerifierWithCfg(t, false)
+	verdict, err := v.Verify(context.Background(), sampleVerifyReq())
+	if err != nil {
+		t.Fatalf("Verify returned error (should swallow into nil verdict): %v", err)
+	}
+	if verdict != nil {
+		t.Fatalf("expected nil verdict when FailClosed=false (verifier degrades), got %+v", verdict)
+	}
+}

--- a/internal/intent/verifier.go
+++ b/internal/intent/verifier.go
@@ -158,7 +158,14 @@ func (v *LLMVerifier) Verify(ctx context.Context, req VerifyRequest) (*Verificat
 		"service", req.Service,
 		"action", req.Action,
 		"task_id", req.TaskID,
+		"fail_closed", cfg.FailClosed,
 	)
+	if !cfg.FailClosed {
+		// Fail open: degrade to "no verification performed" so the request is
+		// not blocked on LLM availability. The gateway treats nil verdict the
+		// same as the NoopVerifier ‒ proceed without a verification check.
+		return nil, nil
+	}
 	return &VerificationVerdict{
 		Allow:           false,
 		ParamScope:      "n/a",

--- a/internal/notify/telegram/pairing.go
+++ b/internal/notify/telegram/pairing.go
@@ -187,16 +187,10 @@ func (n *Notifier) ConfirmPairing(ctx context.Context, pairingID, code string) e
 		return fmt.Errorf("invalid pairing code")
 	}
 
-	// Save to store.
-	cfgBytes, err := json.Marshal(map[string]string{
-		"bot_token": s.BotToken,
-		"chat_id":   s.ChatID,
-	})
-	if err != nil {
-		return fmt.Errorf("marshal config: %w", err)
-	}
-	if err := n.store.UpsertNotificationConfig(ctx, s.UserID, "telegram", cfgBytes); err != nil {
-		return fmt.Errorf("save notification config: %w", err)
+	// Persist via the vault-aware writer so the bot token never lands in
+	// the notification_configs.config JSON column.
+	if err := n.SaveTelegramConfig(ctx, s.UserID, s.BotToken, s.ChatID); err != nil {
+		return err
 	}
 
 	s.Status = "confirmed"

--- a/internal/notify/telegram/polling.go
+++ b/internal/notify/telegram/polling.go
@@ -145,16 +145,12 @@ func (n *Notifier) BootstrapGroupObservation(ctx context.Context) {
 	for _, g := range groups {
 		bi, ok := configCache[g.UserID]
 		if !ok {
-			nc, err := n.store.GetNotificationConfig(ctx, g.UserID, "telegram")
+			botToken, chatID, err := n.userConfig(ctx, g.UserID)
 			if err != nil {
-				continue
-			}
-			var cfg telegramCfg
-			if err := json.Unmarshal(nc.Config, &cfg); err != nil || cfg.BotToken == "" || cfg.ChatID == "" {
 				configCache[g.UserID] = nil
 				continue
 			}
-			bi = &botInfo{botToken: cfg.BotToken, chatID: cfg.ChatID}
+			bi = &botInfo{botToken: botToken, chatID: chatID}
 			configCache[g.UserID] = bi
 		}
 		if bi == nil {

--- a/internal/notify/telegram/secret_test.go
+++ b/internal/notify/telegram/secret_test.go
@@ -1,0 +1,135 @@
+package telegram
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	sqlitestore "github.com/clawvisor/clawvisor/internal/store/sqlite"
+	intvault "github.com/clawvisor/clawvisor/internal/vault"
+)
+
+// TestSaveTelegramConfig_EncryptsBotToken verifies that when a vault is
+// configured, SaveTelegramConfig writes the bot token to the vault and
+// leaves the notification_configs.config JSON column free of any plaintext
+// copy. This is the regression guard for the prior bug where the bot token
+// was stored unencrypted in a database column.
+func TestSaveTelegramConfig_EncryptsBotToken(t *testing.T) {
+	ctx := context.Background()
+
+	db, err := sqlitestore.New(ctx, t.TempDir()+"/test.db")
+	if err != nil {
+		t.Fatalf("sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	st := sqlitestore.NewStore(db)
+	user, err := st.CreateUser(ctx, "encrypt@test.example", "hash")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	v, err := intvault.NewLocalVault(t.TempDir()+"/vault.key", db, "sqlite")
+	if err != nil {
+		t.Fatalf("vault: %v", err)
+	}
+
+	n := New(st, ctx)
+	n.SetVault(v)
+
+	const botToken = "1234567:VERY-SECRET-TOKEN"
+	const chatID = "99999"
+
+	if err := n.SaveTelegramConfig(ctx, user.ID, botToken, chatID); err != nil {
+		t.Fatalf("SaveTelegramConfig: %v", err)
+	}
+
+	// 1. The notification_configs row exists, contains the chat_id, and does
+	//    not contain the bot token in any form.
+	nc, err := st.GetNotificationConfig(ctx, user.ID, "telegram")
+	if err != nil {
+		t.Fatalf("GetNotificationConfig: %v", err)
+	}
+	raw := string(nc.Config)
+	if !strings.Contains(raw, `"chat_id":"`+chatID+`"`) {
+		t.Errorf("expected chat_id in config row, got %q", raw)
+	}
+	if strings.Contains(raw, botToken) {
+		t.Fatalf("bot token leaked into notification_configs.config: %q", raw)
+	}
+	if strings.Contains(raw, "VERY-SECRET-TOKEN") {
+		t.Fatalf("bot token substring leaked into notification_configs.config: %q", raw)
+	}
+
+	// 2. The vault holds the encrypted bot token and decrypts it back.
+	stored, err := v.Get(ctx, user.ID, vaultBotTokenKey)
+	if err != nil {
+		t.Fatalf("vault.Get: %v", err)
+	}
+	if string(stored) != botToken {
+		t.Fatalf("vault round-trip mismatch: got %q want %q", stored, botToken)
+	}
+
+	// 3. userConfig pulls from the vault and reassembles the original config.
+	gotToken, gotChat, err := n.userConfig(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("userConfig: %v", err)
+	}
+	if gotToken != botToken || gotChat != chatID {
+		t.Fatalf("userConfig mismatch: got (%q, %q) want (%q, %q)", gotToken, gotChat, botToken, chatID)
+	}
+
+	// 4. Delete clears both the row and the vault entry.
+	if err := n.DeleteTelegramConfig(ctx, user.ID); err != nil {
+		t.Fatalf("DeleteTelegramConfig: %v", err)
+	}
+	if _, err := st.GetNotificationConfig(ctx, user.ID, "telegram"); err == nil {
+		t.Fatalf("expected notification config to be deleted")
+	}
+	if _, err := v.Get(ctx, user.ID, vaultBotTokenKey); err == nil {
+		t.Fatalf("expected vault entry to be deleted")
+	}
+}
+
+// TestUserConfig_LegacyPlaintextRowFallback proves that pre-encryption rows
+// (where bot_token sits inside the JSON column) still resolve correctly so
+// upgrades don't lock users out. Once SaveTelegramConfig is called again,
+// the next read pulls from the vault and the JSON column should no longer
+// be required.
+func TestUserConfig_LegacyPlaintextRowFallback(t *testing.T) {
+	ctx := context.Background()
+
+	db, err := sqlitestore.New(ctx, t.TempDir()+"/test.db")
+	if err != nil {
+		t.Fatalf("sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	st := sqlitestore.NewStore(db)
+	user, err := st.CreateUser(ctx, "legacy@test.example", "hash")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	v, err := intvault.NewLocalVault(t.TempDir()+"/vault.key", db, "sqlite")
+	if err != nil {
+		t.Fatalf("vault: %v", err)
+	}
+
+	// Simulate a pre-fix row: token sits in the JSON column with no vault entry.
+	if err := st.UpsertNotificationConfig(ctx, user.ID, "telegram",
+		[]byte(`{"bot_token":"legacy-token","chat_id":"7"}`)); err != nil {
+		t.Fatalf("UpsertNotificationConfig: %v", err)
+	}
+
+	n := New(st, ctx)
+	n.SetVault(v)
+
+	tok, chat, err := n.userConfig(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("userConfig (legacy fallback): %v", err)
+	}
+	if tok != "legacy-token" || chat != "7" {
+		t.Fatalf("legacy fallback mismatch: got (%q, %q)", tok, chat)
+	}
+}

--- a/internal/notify/telegram/telegram.go
+++ b/internal/notify/telegram/telegram.go
@@ -21,11 +21,20 @@ import (
 	"github.com/clawvisor/clawvisor/internal/groupchat"
 	"github.com/clawvisor/clawvisor/pkg/notify"
 	"github.com/clawvisor/clawvisor/pkg/store"
+	"github.com/clawvisor/clawvisor/pkg/vault"
 )
+
+// vaultBotTokenKey is the key under which a user's Telegram bot token is
+// encrypted in the credential vault. The legacy plaintext copy in
+// notification_configs.config.bot_token is kept readable for backward
+// compatibility with rows written before this protection landed; new
+// writes always store an empty string in the JSON blob.
+const vaultBotTokenKey = "notify.telegram.bot_token"
 
 // Notifier sends Telegram messages for approval and service-activation requests.
 type Notifier struct {
 	store         store.Store
+	vault         vault.Vault // optional; when set, bot tokens are encrypted at rest
 	client        *http.Client
 	pairingClient *http.Client // longer timeout for long-poll getUpdates
 	pairings      sync.Map     // pairing ID → *pairingSession
@@ -62,6 +71,14 @@ func New(st store.Store, serverCtx context.Context) *Notifier {
 // SetMessageBuffer sets the message buffer used for group chat observation.
 func (n *Notifier) SetMessageBuffer(buf groupchat.Buffer) {
 	n.msgBuffer = buf
+}
+
+// SetVault wires the credential vault into the notifier. Once set, bot
+// tokens are written via vault.Set rather than embedded in the
+// notification_configs JSON column. Call before the server starts handling
+// pairing or upsert traffic.
+func (n *Notifier) SetVault(v vault.Vault) {
+	n.vault = v
 }
 
 // SetRedisStores configures Redis-backed stores for multi-instance deployments.
@@ -948,6 +965,9 @@ type telegramCfg struct {
 }
 
 // userConfig fetches the per-user bot_token and chat_id from the store.
+// When a vault is configured, the bot token is read from the vault and the
+// JSON column's bot_token field acts only as a legacy fallback for rows
+// written before encryption was introduced.
 func (n *Notifier) userConfig(ctx context.Context, userID string) (botToken, chatID string, err error) {
 	nc, err := n.store.GetNotificationConfig(ctx, userID, "telegram")
 	if errors.Is(err, store.ErrNotFound) {
@@ -960,6 +980,11 @@ func (n *Notifier) userConfig(ctx context.Context, userID string) (botToken, cha
 	if err := json.Unmarshal(nc.Config, &cfg); err != nil {
 		return "", "", fmt.Errorf("telegram: invalid config for user %s: %w", userID, err)
 	}
+	if cfg.BotToken == "" && n.vault != nil {
+		if data, vErr := n.vault.Get(ctx, userID, vaultBotTokenKey); vErr == nil {
+			cfg.BotToken = string(data)
+		}
+	}
 	if cfg.BotToken == "" {
 		return "", "", fmt.Errorf("telegram: user %s config missing bot_token", userID)
 	}
@@ -968,3 +993,60 @@ func (n *Notifier) userConfig(ctx context.Context, userID string) (botToken, cha
 	}
 	return cfg.BotToken, cfg.ChatID, nil
 }
+
+// SaveTelegramConfig persists a user's Telegram bot token and DM chat ID.
+// When a vault is configured the bot token is stored encrypted; otherwise
+// it falls back to the JSON column (used in tests and pre-vault setups).
+// Implements notify.TelegramConfigStore.
+func (n *Notifier) SaveTelegramConfig(ctx context.Context, userID, botToken, chatID string) error {
+	if userID == "" {
+		return fmt.Errorf("telegram: user_id is required")
+	}
+	if botToken == "" {
+		return fmt.Errorf("telegram: bot_token is required")
+	}
+	if chatID == "" {
+		return fmt.Errorf("telegram: chat_id is required")
+	}
+	jsonToken := botToken
+	if n.vault != nil {
+		if err := n.vault.Set(ctx, userID, vaultBotTokenKey, []byte(botToken)); err != nil {
+			return fmt.Errorf("telegram: persist bot_token: %w", err)
+		}
+		jsonToken = "" // do not duplicate the secret into the JSON column
+	}
+	cfgBytes, err := json.Marshal(map[string]string{
+		"bot_token": jsonToken,
+		"chat_id":   chatID,
+	})
+	if err != nil {
+		return fmt.Errorf("telegram: marshal config: %w", err)
+	}
+	if err := n.store.UpsertNotificationConfig(ctx, userID, "telegram", cfgBytes); err != nil {
+		// Roll back the vault write so we don't leave a token without a corresponding row.
+		if n.vault != nil {
+			_ = n.vault.Delete(ctx, userID, vaultBotTokenKey)
+		}
+		return fmt.Errorf("telegram: save notification config: %w", err)
+	}
+	return nil
+}
+
+// TelegramConfig returns the user's bot token and DM chat ID.
+// Implements notify.TelegramConfigStore.
+func (n *Notifier) TelegramConfig(ctx context.Context, userID string) (botToken, chatID string, err error) {
+	return n.userConfig(ctx, userID)
+}
+
+// DeleteTelegramConfig removes the user's Telegram bot token from the
+// vault (if configured) and the notification config row from the store.
+// Implements notify.TelegramConfigStore.
+func (n *Notifier) DeleteTelegramConfig(ctx context.Context, userID string) error {
+	if n.vault != nil {
+		_ = n.vault.Delete(ctx, userID, vaultBotTokenKey)
+	}
+	return n.store.DeleteNotificationConfig(ctx, userID, "telegram")
+}
+
+// Compile-time check that *Notifier satisfies notify.TelegramConfigStore.
+var _ notify.TelegramConfigStore = (*Notifier)(nil)

--- a/internal/store/postgres/migrations/039_executing_lease.sql
+++ b/internal/store/postgres/migrations/039_executing_lease.sql
@@ -1,0 +1,4 @@
+-- Track when a pending approval was claimed for execution so a daemon crash
+-- mid-execution doesn't strand the row in 'executing' forever. The expiry
+-- sweeper recovers rows whose lease has elapsed.
+ALTER TABLE pending_approvals ADD COLUMN executing_since TIMESTAMPTZ;

--- a/internal/store/postgres/store.go
+++ b/internal/store/postgres/store.go
@@ -1441,11 +1441,28 @@ func (s *Store) UpdatePendingApprovalStatus(ctx context.Context, requestID, stat
 
 func (s *Store) ClaimPendingApprovalForExecution(ctx context.Context, requestID string) (bool, error) {
 	tag, err := s.pool.Exec(ctx,
-		`UPDATE pending_approvals SET status = 'executing' WHERE request_id = $1 AND status = 'approved'`, requestID)
+		`UPDATE pending_approvals SET status = 'executing', executing_since = NOW()
+		 WHERE request_id = $1 AND status = 'approved'`, requestID)
 	if err != nil {
 		return false, err
 	}
 	return tag.RowsAffected() > 0, nil
+}
+
+// ListStalledExecutingApprovals returns rows that were claimed for execution
+// but never completed within leaseTTL. This is the recovery hook for daemon
+// crashes that strand a row in 'executing' — without it, the user would be
+// permanently locked out of re-approving the same request.
+func (s *Store) ListStalledExecutingApprovals(ctx context.Context, leaseTTL time.Duration) ([]*store.PendingApproval, error) {
+	cutoff := time.Now().UTC().Add(-leaseTTL)
+	rows, err := s.pool.Query(ctx, `
+		SELECT id, user_id, request_id, audit_id, approval_record_id, request_blob, callback_url, status, expires_at, created_at
+		FROM pending_approvals WHERE status = 'executing' AND executing_since IS NOT NULL AND executing_since < $1`, cutoff)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanPendingApprovals(rows)
 }
 
 // ── Canonical Approval Records ───────────────────────────────────────────────

--- a/internal/store/sqlite/migrations/039_executing_lease.sql
+++ b/internal/store/sqlite/migrations/039_executing_lease.sql
@@ -1,0 +1,8 @@
+-- Track when a pending approval was claimed for execution so a daemon crash
+-- mid-execution doesn't strand the row in 'executing' forever. The expiry
+-- sweeper recovers rows whose lease has elapsed.
+--
+-- Stored as TEXT in 'YYYY-MM-DD HH:MM:SS' (UTC) to match the project's other
+-- timestamp columns and to keep lexical comparison against datetime('now')
+-- correct under the modernc sqlite driver.
+ALTER TABLE pending_approvals ADD COLUMN executing_since TEXT;

--- a/internal/store/sqlite/store.go
+++ b/internal/store/sqlite/store.go
@@ -1571,7 +1571,8 @@ func (s *Store) UpdatePendingApprovalStatus(ctx context.Context, requestID, stat
 
 func (s *Store) ClaimPendingApprovalForExecution(ctx context.Context, requestID string) (bool, error) {
 	res, err := s.db.ExecContext(ctx,
-		`UPDATE pending_approvals SET status = 'executing' WHERE request_id = ? AND status = 'approved'`, requestID)
+		`UPDATE pending_approvals SET status = 'executing', executing_since = CURRENT_TIMESTAMP
+		 WHERE request_id = ? AND status = 'approved'`, requestID)
 	if err != nil {
 		return false, err
 	}
@@ -1580,6 +1581,27 @@ func (s *Store) ClaimPendingApprovalForExecution(ctx context.Context, requestID 
 		return false, err
 	}
 	return n > 0, nil
+}
+
+// ListStalledExecutingApprovals returns rows that were claimed for execution
+// but never completed within leaseTTL. This is the recovery hook for daemon
+// crashes that strand a row in 'executing' — without it, the user would be
+// permanently locked out of re-approving the same request.
+func (s *Store) ListStalledExecutingApprovals(ctx context.Context, leaseTTL time.Duration) ([]*store.PendingApproval, error) {
+	leaseSeconds := int64(leaseTTL.Seconds())
+	if leaseSeconds < 0 {
+		leaseSeconds = 0
+	}
+	modifier := fmt.Sprintf("-%d seconds", leaseSeconds)
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, user_id, request_id, audit_id, approval_record_id, request_blob, callback_url, status, expires_at, created_at
+		FROM pending_approvals
+		WHERE status = 'executing' AND executing_since IS NOT NULL AND executing_since < datetime('now', ?)`, modifier)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanSQLitePendingApprovals(rows)
 }
 
 // ── Canonical Approval Records ───────────────────────────────────────────────

--- a/internal/store/sqlite/store_runtime_test.go
+++ b/internal/store/sqlite/store_runtime_test.go
@@ -419,3 +419,83 @@ func TestRuntimeUnificationRoundTrip(t *testing.T) {
 func strPtr(v string) *string {
 	return &v
 }
+
+// TestPendingApproval_StalledExecutingRecovery proves that a row stranded in
+// 'executing' (the daemon-crash scenario) is detectable via
+// ListStalledExecutingApprovals once the lease elapses, and that the row's
+// continued presence does NOT block recovery — the user is no longer locked
+// out. This is the regression guard for the "executing forever" bug.
+func TestPendingApproval_StalledExecutingRecovery(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db, err := New(ctx, filepath.Join(t.TempDir(), "clawvisor.db"))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	st := NewStore(db)
+	user, err := st.CreateUser(ctx, "stall@example.com", "hash")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	requestID := "req-stall-1"
+	pa := &store.PendingApproval{
+		UserID:      user.ID,
+		RequestID:   requestID,
+		AuditID:     "audit-stall-1",
+		RequestBlob: []byte(`{"request_id":"req-stall-1"}`),
+		Status:      "pending",
+		ExpiresAt:   time.Now().UTC().Add(30 * time.Minute),
+	}
+	if err := st.SavePendingApproval(ctx, pa); err != nil {
+		t.Fatalf("SavePendingApproval: %v", err)
+	}
+
+	// Promote pending → approved → executing (the legitimate hot path).
+	if err := st.UpdatePendingApprovalStatus(ctx, requestID, "approved"); err != nil {
+		t.Fatalf("UpdatePendingApprovalStatus(approved): %v", err)
+	}
+	claimed, err := st.ClaimPendingApprovalForExecution(ctx, requestID)
+	if err != nil {
+		t.Fatalf("ClaimPendingApprovalForExecution: %v", err)
+	}
+	if !claimed {
+		t.Fatal("expected claim to succeed")
+	}
+
+	// A short lease should not yet flag the row as stalled.
+	stalled, err := st.ListStalledExecutingApprovals(ctx, time.Hour)
+	if err != nil {
+		t.Fatalf("ListStalledExecutingApprovals(fresh): %v", err)
+	}
+	if len(stalled) != 0 {
+		t.Fatalf("expected no stalled rows under generous lease, got %d", len(stalled))
+	}
+
+	// A lease shorter than the time since claim must surface the row. Sleep
+	// > 2s so executing_since is firmly past the 1-second cutoff at sqlite's
+	// second-granularity timestamp resolution.
+	time.Sleep(2200 * time.Millisecond)
+	stalled, err = st.ListStalledExecutingApprovals(ctx, time.Second)
+	if err != nil {
+		t.Fatalf("ListStalledExecutingApprovals(stalled): %v", err)
+	}
+	if len(stalled) != 1 || stalled[0].RequestID != requestID {
+		t.Fatalf("expected stalled row %q, got %+v", requestID, stalled)
+	}
+
+	// Recovery: deleting the stale row frees the user to re-issue the request.
+	if err := st.DeletePendingApproval(ctx, requestID); err != nil {
+		t.Fatalf("DeletePendingApproval: %v", err)
+	}
+	stalled, err = st.ListStalledExecutingApprovals(ctx, time.Second)
+	if err != nil {
+		t.Fatalf("ListStalledExecutingApprovals(after delete): %v", err)
+	}
+	if len(stalled) != 0 {
+		t.Fatalf("expected zero stalled rows after recovery, got %d", len(stalled))
+	}
+}

--- a/internal/vault/gcp.go
+++ b/internal/vault/gcp.go
@@ -56,7 +56,7 @@ func (v *GCPVault) secretName(userID, serviceID string) string {
 }
 
 func (v *GCPVault) Set(ctx context.Context, userID, serviceID string, credential []byte) error {
-	encrypted, iv, authTag, err := v.localVault.encrypt(credential)
+	encrypted, iv, authTag, err := v.localVault.encrypt(credential, rowAAD(userID, serviceID))
 	if err != nil {
 		return fmt.Errorf("gcp vault encrypt: %w", err)
 	}
@@ -120,7 +120,16 @@ func (v *GCPVault) Get(ctx context.Context, userID, serviceID string) ([]byte, e
 	}
 	encrypted, iv, authTag = parts[0], parts[1], parts[2]
 
-	return v.localVault.decrypt(encrypted, iv, authTag)
+	aad := rowAAD(userID, serviceID)
+	plaintext, err := v.localVault.decrypt(encrypted, iv, authTag, aad)
+	if err == nil {
+		return plaintext, nil
+	}
+	// Lazy migration for rows written before AAD-binding shipped.
+	if legacy, legacyErr := v.localVault.decrypt(encrypted, iv, authTag, nil); legacyErr == nil {
+		return legacy, nil
+	}
+	return nil, err
 }
 
 func (v *GCPVault) Delete(ctx context.Context, userID, serviceID string) error {

--- a/internal/vault/local.go
+++ b/internal/vault/local.go
@@ -56,7 +56,7 @@ func (v *LocalVault) ph(n int) string {
 }
 
 func (v *LocalVault) Set(ctx context.Context, userID, serviceID string, credential []byte) error {
-	encrypted, iv, authTag, err := v.encrypt(credential)
+	encrypted, iv, authTag, err := v.encrypt(credential, rowAAD(userID, serviceID))
 	if err != nil {
 		return fmt.Errorf("vault encrypt: %w", err)
 	}
@@ -99,7 +99,18 @@ func (v *LocalVault) Get(ctx context.Context, userID, serviceID string) ([]byte,
 	if err != nil {
 		return nil, fmt.Errorf("vault get: %w", err)
 	}
-	return v.decrypt(encrypted, iv, authTag)
+	plaintext, err := v.decrypt(encrypted, iv, authTag, rowAAD(userID, serviceID))
+	if err == nil {
+		return plaintext, nil
+	}
+	// Lazy migration: rows written before AAD-binding shipped were sealed with
+	// empty AAD. Retry once so existing deployments don't lock users out. The
+	// next Set rewrites the row with the bound AAD.
+	legacy, legacyErr := v.decrypt(encrypted, iv, authTag, nil)
+	if legacyErr == nil {
+		return legacy, nil
+	}
+	return nil, err
 }
 
 func (v *LocalVault) Delete(ctx context.Context, userID, serviceID string) error {
@@ -133,17 +144,24 @@ func (v *LocalVault) List(ctx context.Context, userID string) ([]string, error) 
 	return services, rows.Err()
 }
 
-// Encrypt and Decrypt are exported so GCPVault can reuse the AES logic.
-
-func (v *LocalVault) Encrypt(plaintext []byte) (encrypted, iv, authTag string, err error) {
-	return v.encrypt(plaintext)
+// rowAAD binds an AES-GCM seal to its (user_id, service_id) row coordinates so
+// a DB-write attacker can't shuffle ciphertexts between rows undetected.
+func rowAAD(userID, serviceID string) []byte {
+	return []byte(userID + "|" + serviceID)
 }
 
-func (v *LocalVault) Decrypt(encrypted, iv, authTag string) ([]byte, error) {
-	return v.decrypt(encrypted, iv, authTag)
+// Encrypt and Decrypt are exported so GCPVault can reuse the AES logic. The
+// aad parameter MUST be the same on both sides or Open returns an auth error.
+
+func (v *LocalVault) Encrypt(plaintext, aad []byte) (encrypted, iv, authTag string, err error) {
+	return v.encrypt(plaintext, aad)
 }
 
-func (v *LocalVault) encrypt(plaintext []byte) (encrypted, iv, authTag string, err error) {
+func (v *LocalVault) Decrypt(encrypted, iv, authTag string, aad []byte) ([]byte, error) {
+	return v.decrypt(encrypted, iv, authTag, aad)
+}
+
+func (v *LocalVault) encrypt(plaintext, aad []byte) (encrypted, iv, authTag string, err error) {
 	block, err := aes.NewCipher(v.key)
 	if err != nil {
 		return "", "", "", err
@@ -157,7 +175,7 @@ func (v *LocalVault) encrypt(plaintext []byte) (encrypted, iv, authTag string, e
 		return "", "", "", err
 	}
 	// Seal appends auth tag after ciphertext
-	sealed := gcm.Seal(nil, nonce, plaintext, nil)
+	sealed := gcm.Seal(nil, nonce, plaintext, aad)
 	tagSize := gcm.Overhead()
 	cipherBytes := sealed[:len(sealed)-tagSize]
 	tagBytes := sealed[len(sealed)-tagSize:]
@@ -168,7 +186,7 @@ func (v *LocalVault) encrypt(plaintext []byte) (encrypted, iv, authTag string, e
 		nil
 }
 
-func (v *LocalVault) decrypt(encrypted, iv, authTag string) ([]byte, error) {
+func (v *LocalVault) decrypt(encrypted, iv, authTag string, aad []byte) ([]byte, error) {
 	ciphertext, err := base64.StdEncoding.DecodeString(encrypted)
 	if err != nil {
 		return nil, fmt.Errorf("decode ciphertext: %w", err)
@@ -190,7 +208,7 @@ func (v *LocalVault) decrypt(encrypted, iv, authTag string) ([]byte, error) {
 		return nil, err
 	}
 	sealed := append(ciphertext, tag...) //nolint:gocritic
-	plaintext, err := gcm.Open(nil, nonce, sealed, nil)
+	plaintext, err := gcm.Open(nil, nonce, sealed, aad)
 	if err != nil {
 		return nil, fmt.Errorf("vault decrypt (tampered data?): %w", err)
 	}

--- a/internal/vault/local_test.go
+++ b/internal/vault/local_test.go
@@ -1,0 +1,287 @@
+package vault
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	_ "modernc.org/sqlite"
+
+	pkgvault "github.com/clawvisor/clawvisor/pkg/vault"
+)
+
+func newKey(t *testing.T) []byte {
+	t.Helper()
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i)
+	}
+	return key
+}
+
+func TestLocalVault_EncryptDecryptRoundTrip(t *testing.T) {
+	v, err := NewLocalVaultFromKey(newKey(t))
+	if err != nil {
+		t.Fatalf("NewLocalVaultFromKey: %v", err)
+	}
+
+	cases := [][]byte{
+		[]byte("hello"),
+		[]byte(""),
+		bytes.Repeat([]byte{0xAB}, 4096),
+		[]byte(`{"token":"sk_test_abcdef"}`),
+	}
+	for _, plaintext := range cases {
+		enc, iv, tag, err := v.Encrypt(plaintext)
+		if err != nil {
+			t.Fatalf("Encrypt: %v", err)
+		}
+		got, err := v.Decrypt(enc, iv, tag)
+		if err != nil {
+			t.Fatalf("Decrypt: %v", err)
+		}
+		if !bytes.Equal(got, plaintext) {
+			t.Fatalf("round-trip mismatch: want %q got %q", plaintext, got)
+		}
+	}
+}
+
+func TestLocalVault_EncryptUsesFreshNonce(t *testing.T) {
+	v, err := NewLocalVaultFromKey(newKey(t))
+	if err != nil {
+		t.Fatalf("NewLocalVaultFromKey: %v", err)
+	}
+	plaintext := []byte("same plaintext, different ciphertexts please")
+	_, iv1, _, err := v.Encrypt(plaintext)
+	if err != nil {
+		t.Fatalf("Encrypt 1: %v", err)
+	}
+	_, iv2, _, err := v.Encrypt(plaintext)
+	if err != nil {
+		t.Fatalf("Encrypt 2: %v", err)
+	}
+	if iv1 == iv2 {
+		t.Fatalf("nonces must differ across encryptions, both = %q", iv1)
+	}
+}
+
+func TestLocalVault_TamperedCiphertextFails(t *testing.T) {
+	v, err := NewLocalVaultFromKey(newKey(t))
+	if err != nil {
+		t.Fatalf("NewLocalVaultFromKey: %v", err)
+	}
+	enc, iv, tag, err := v.Encrypt([]byte("secret"))
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	raw, err := base64.StdEncoding.DecodeString(enc)
+	if err != nil {
+		t.Fatalf("decode enc: %v", err)
+	}
+	if len(raw) == 0 {
+		raw = []byte{0x00}
+	}
+	raw[0] ^= 0x01
+	tampered := base64.StdEncoding.EncodeToString(raw)
+	if _, err := v.Decrypt(tampered, iv, tag); err == nil {
+		t.Fatalf("expected decrypt error for tampered ciphertext")
+	}
+}
+
+func TestLocalVault_TamperedAuthTagFails(t *testing.T) {
+	v, err := NewLocalVaultFromKey(newKey(t))
+	if err != nil {
+		t.Fatalf("NewLocalVaultFromKey: %v", err)
+	}
+	enc, iv, tag, err := v.Encrypt([]byte("secret"))
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	raw, err := base64.StdEncoding.DecodeString(tag)
+	if err != nil {
+		t.Fatalf("decode tag: %v", err)
+	}
+	raw[0] ^= 0x01
+	bad := base64.StdEncoding.EncodeToString(raw)
+	if _, err := v.Decrypt(enc, iv, bad); err == nil {
+		t.Fatalf("expected decrypt error for tampered auth tag")
+	}
+}
+
+func TestLocalVault_WrongKeyFails(t *testing.T) {
+	plaintext := []byte("cross-key isolation matters")
+	keyA := newKey(t)
+	keyB := append([]byte(nil), keyA...)
+	keyB[0] ^= 0xFF
+
+	a, err := NewLocalVaultFromKey(keyA)
+	if err != nil {
+		t.Fatalf("vault A: %v", err)
+	}
+	b, err := NewLocalVaultFromKey(keyB)
+	if err != nil {
+		t.Fatalf("vault B: %v", err)
+	}
+	enc, iv, tag, err := a.Encrypt(plaintext)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	if _, err := b.Decrypt(enc, iv, tag); err == nil {
+		t.Fatalf("expected decrypt to fail under a different key")
+	}
+}
+
+func TestNewLocalVaultFromKey_RejectsWrongLength(t *testing.T) {
+	for _, n := range []int{0, 16, 24, 31, 33, 64} {
+		key := make([]byte, n)
+		if _, err := NewLocalVaultFromKey(key); err == nil {
+			t.Errorf("expected error for key length %d", n)
+		}
+	}
+}
+
+func TestResolveKey_PrioritisesEnvOverFile(t *testing.T) {
+	dir := t.TempDir()
+	keyFile := filepath.Join(dir, "vault.key")
+	fileKey := bytes.Repeat([]byte{0xAA}, 32)
+	if err := os.WriteFile(keyFile, []byte(base64.StdEncoding.EncodeToString(fileKey)), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	envKey := bytes.Repeat([]byte{0xBB}, 32)
+	got, err := ResolveKey(base64.StdEncoding.EncodeToString(envKey), keyFile)
+	if err != nil {
+		t.Fatalf("ResolveKey: %v", err)
+	}
+	if !bytes.Equal(got, envKey) {
+		t.Fatalf("expected env key to win over file key")
+	}
+}
+
+func TestResolveKey_FailsWhenAbsent(t *testing.T) {
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "does-not-exist.key")
+	if _, err := ResolveKey("", missing); err == nil {
+		t.Fatalf("expected error for missing key file with no env override")
+	}
+}
+
+func TestLoadOrCreateKey_RejectsWorldReadable(t *testing.T) {
+	dir := t.TempDir()
+	keyFile := filepath.Join(dir, "vault.key")
+	key := bytes.Repeat([]byte{0xCC}, 32)
+	if err := os.WriteFile(keyFile, []byte(base64.StdEncoding.EncodeToString(key)), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	_, err := loadOrCreateKey(keyFile)
+	if err == nil || !strings.Contains(err.Error(), "insecure permissions") {
+		t.Fatalf("expected insecure-permissions error, got %v", err)
+	}
+}
+
+func TestLoadOrCreateKey_GeneratesNewKeyWith0600(t *testing.T) {
+	dir := t.TempDir()
+	keyFile := filepath.Join(dir, "vault.key")
+	key, err := loadOrCreateKey(keyFile)
+	if err != nil {
+		t.Fatalf("loadOrCreateKey: %v", err)
+	}
+	if len(key) != 32 {
+		t.Fatalf("expected 32-byte key, got %d", len(key))
+	}
+	info, err := os.Stat(keyFile)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("expected key file permissions 0600, got %04o", perm)
+	}
+}
+
+// TestLocalVault_DBBacked_RoundTrip exercises Set/Get/Delete/List against a
+// minimal in-memory SQLite schema that mirrors the production vault_entries
+// table.
+func TestLocalVault_DBBacked_RoundTrip(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx, `
+		CREATE TABLE vault_entries (
+			id         TEXT PRIMARY KEY,
+			user_id    TEXT NOT NULL,
+			service_id TEXT NOT NULL,
+			encrypted  TEXT NOT NULL,
+			iv         TEXT NOT NULL,
+			auth_tag   TEXT NOT NULL,
+			created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			UNIQUE(user_id, service_id)
+		);
+	`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+
+	v, err := NewLocalVaultFromKeyWithDB(newKey(t), db, "sqlite")
+	if err != nil {
+		t.Fatalf("vault: %v", err)
+	}
+
+	plaintext := []byte(`{"access_token":"secret-value"}`)
+	if err := v.Set(ctx, "u1", "gmail", plaintext); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	got, err := v.Get(ctx, "u1", "gmail")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !bytes.Equal(got, plaintext) {
+		t.Fatalf("Get mismatch: want %q got %q", plaintext, got)
+	}
+
+	// Overwrite path exercises ON CONFLICT DO UPDATE.
+	updated := []byte(`{"access_token":"rotated-value"}`)
+	if err := v.Set(ctx, "u1", "gmail", updated); err != nil {
+		t.Fatalf("Set (update): %v", err)
+	}
+	got, err = v.Get(ctx, "u1", "gmail")
+	if err != nil {
+		t.Fatalf("Get after update: %v", err)
+	}
+	if !bytes.Equal(got, updated) {
+		t.Fatalf("update not visible: want %q got %q", updated, got)
+	}
+
+	// Cross-user isolation.
+	if _, err := v.Get(ctx, "u2", "gmail"); err == nil {
+		t.Fatalf("expected ErrNotFound for other user, got nil")
+	} else if err != pkgvault.ErrNotFound {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+
+	if err := v.Set(ctx, "u1", "calendar", []byte("c")); err != nil {
+		t.Fatalf("Set calendar: %v", err)
+	}
+	services, err := v.List(ctx, "u1")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(services) != 2 || services[0] != "calendar" || services[1] != "gmail" {
+		t.Fatalf("List returned %v, want [calendar gmail]", services)
+	}
+
+	if err := v.Delete(ctx, "u1", "calendar"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := v.Get(ctx, "u1", "calendar"); err != pkgvault.ErrNotFound {
+		t.Fatalf("after delete expected ErrNotFound, got %v", err)
+	}
+}

--- a/internal/vault/local_test.go
+++ b/internal/vault/local_test.go
@@ -37,11 +37,12 @@ func TestLocalVault_EncryptDecryptRoundTrip(t *testing.T) {
 		[]byte(`{"token":"sk_test_abcdef"}`),
 	}
 	for _, plaintext := range cases {
-		enc, iv, tag, err := v.Encrypt(plaintext)
+		aad := []byte("u|svc")
+		enc, iv, tag, err := v.Encrypt(plaintext, aad)
 		if err != nil {
 			t.Fatalf("Encrypt: %v", err)
 		}
-		got, err := v.Decrypt(enc, iv, tag)
+		got, err := v.Decrypt(enc, iv, tag, aad)
 		if err != nil {
 			t.Fatalf("Decrypt: %v", err)
 		}
@@ -57,11 +58,12 @@ func TestLocalVault_EncryptUsesFreshNonce(t *testing.T) {
 		t.Fatalf("NewLocalVaultFromKey: %v", err)
 	}
 	plaintext := []byte("same plaintext, different ciphertexts please")
-	_, iv1, _, err := v.Encrypt(plaintext)
+	aad := []byte("u|svc")
+	_, iv1, _, err := v.Encrypt(plaintext, aad)
 	if err != nil {
 		t.Fatalf("Encrypt 1: %v", err)
 	}
-	_, iv2, _, err := v.Encrypt(plaintext)
+	_, iv2, _, err := v.Encrypt(plaintext, aad)
 	if err != nil {
 		t.Fatalf("Encrypt 2: %v", err)
 	}
@@ -75,7 +77,8 @@ func TestLocalVault_TamperedCiphertextFails(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewLocalVaultFromKey: %v", err)
 	}
-	enc, iv, tag, err := v.Encrypt([]byte("secret"))
+	aad := []byte("u|svc")
+	enc, iv, tag, err := v.Encrypt([]byte("secret"), aad)
 	if err != nil {
 		t.Fatalf("Encrypt: %v", err)
 	}
@@ -88,7 +91,7 @@ func TestLocalVault_TamperedCiphertextFails(t *testing.T) {
 	}
 	raw[0] ^= 0x01
 	tampered := base64.StdEncoding.EncodeToString(raw)
-	if _, err := v.Decrypt(tampered, iv, tag); err == nil {
+	if _, err := v.Decrypt(tampered, iv, tag, aad); err == nil {
 		t.Fatalf("expected decrypt error for tampered ciphertext")
 	}
 }
@@ -98,7 +101,8 @@ func TestLocalVault_TamperedAuthTagFails(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewLocalVaultFromKey: %v", err)
 	}
-	enc, iv, tag, err := v.Encrypt([]byte("secret"))
+	aad := []byte("u|svc")
+	enc, iv, tag, err := v.Encrypt([]byte("secret"), aad)
 	if err != nil {
 		t.Fatalf("Encrypt: %v", err)
 	}
@@ -108,7 +112,7 @@ func TestLocalVault_TamperedAuthTagFails(t *testing.T) {
 	}
 	raw[0] ^= 0x01
 	bad := base64.StdEncoding.EncodeToString(raw)
-	if _, err := v.Decrypt(enc, iv, bad); err == nil {
+	if _, err := v.Decrypt(enc, iv, bad, aad); err == nil {
 		t.Fatalf("expected decrypt error for tampered auth tag")
 	}
 }
@@ -127,11 +131,12 @@ func TestLocalVault_WrongKeyFails(t *testing.T) {
 	if err != nil {
 		t.Fatalf("vault B: %v", err)
 	}
-	enc, iv, tag, err := a.Encrypt(plaintext)
+	aad := []byte("u|svc")
+	enc, iv, tag, err := a.Encrypt(plaintext, aad)
 	if err != nil {
 		t.Fatalf("Encrypt: %v", err)
 	}
-	if _, err := b.Decrypt(enc, iv, tag); err == nil {
+	if _, err := b.Decrypt(enc, iv, tag, aad); err == nil {
 		t.Fatalf("expected decrypt to fail under a different key")
 	}
 }
@@ -283,5 +288,118 @@ func TestLocalVault_DBBacked_RoundTrip(t *testing.T) {
 	}
 	if _, err := v.Get(ctx, "u1", "calendar"); err != pkgvault.ErrNotFound {
 		t.Fatalf("after delete expected ErrNotFound, got %v", err)
+	}
+}
+
+// TestLocalVault_CrossRowSwapFails proves that a DB-write attacker who copies
+// (encrypted, iv, auth_tag) from user A's row into user B's row cannot trick
+// Get into returning A's plaintext. The AAD binding makes the swap detectable.
+func TestLocalVault_CrossRowSwapFails(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx, `
+		CREATE TABLE vault_entries (
+			id         TEXT PRIMARY KEY,
+			user_id    TEXT NOT NULL,
+			service_id TEXT NOT NULL,
+			encrypted  TEXT NOT NULL,
+			iv         TEXT NOT NULL,
+			auth_tag   TEXT NOT NULL,
+			created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			UNIQUE(user_id, service_id)
+		);
+	`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+
+	v, err := NewLocalVaultFromKeyWithDB(newKey(t), db, "sqlite")
+	if err != nil {
+		t.Fatalf("vault: %v", err)
+	}
+
+	if err := v.Set(ctx, "alice", "gmail", []byte("alice-token")); err != nil {
+		t.Fatalf("Set alice: %v", err)
+	}
+	if err := v.Set(ctx, "bob", "gmail", []byte("bob-token")); err != nil {
+		t.Fatalf("Set bob: %v", err)
+	}
+
+	// Simulate a privileged-DB attacker copying alice's ciphertext into bob's row.
+	if _, err := db.ExecContext(ctx, `
+		UPDATE vault_entries
+		   SET encrypted = (SELECT encrypted FROM vault_entries WHERE user_id = 'alice' AND service_id = 'gmail'),
+		       iv        = (SELECT iv        FROM vault_entries WHERE user_id = 'alice' AND service_id = 'gmail'),
+		       auth_tag  = (SELECT auth_tag  FROM vault_entries WHERE user_id = 'alice' AND service_id = 'gmail')
+		 WHERE user_id = 'bob' AND service_id = 'gmail'
+	`); err != nil {
+		t.Fatalf("swap: %v", err)
+	}
+
+	// Bob's Get must now fail rather than return alice's plaintext.
+	got, err := v.Get(ctx, "bob", "gmail")
+	if err == nil {
+		t.Fatalf("expected swap to fail decryption; got plaintext %q", got)
+	}
+	if bytes.Equal(got, []byte("alice-token")) {
+		t.Fatalf("AAD binding broken: bob's Get returned alice's plaintext")
+	}
+}
+
+// TestLocalVault_LegacyRowMigratesLazily simulates a row written before the
+// AAD binding shipped (sealed with empty AAD) and proves Get still resolves it
+// so existing deployments don't lock users out.
+func TestLocalVault_LegacyRowMigratesLazily(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx, `
+		CREATE TABLE vault_entries (
+			id         TEXT PRIMARY KEY,
+			user_id    TEXT NOT NULL,
+			service_id TEXT NOT NULL,
+			encrypted  TEXT NOT NULL,
+			iv         TEXT NOT NULL,
+			auth_tag   TEXT NOT NULL,
+			created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			UNIQUE(user_id, service_id)
+		);
+	`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+
+	v, err := NewLocalVaultFromKeyWithDB(newKey(t), db, "sqlite")
+	if err != nil {
+		t.Fatalf("vault: %v", err)
+	}
+
+	// Encrypt with empty AAD to mimic a pre-fix row.
+	enc, iv, tag, err := v.Encrypt([]byte("legacy-secret"), nil)
+	if err != nil {
+		t.Fatalf("Encrypt legacy: %v", err)
+	}
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO vault_entries (id, user_id, service_id, encrypted, iv, auth_tag) VALUES (?, ?, ?, ?, ?, ?)`,
+		"legacy-id", "alice", "gmail", enc, iv, tag,
+	); err != nil {
+		t.Fatalf("insert legacy row: %v", err)
+	}
+
+	got, err := v.Get(ctx, "alice", "gmail")
+	if err != nil {
+		t.Fatalf("Get legacy: %v", err)
+	}
+	if !bytes.Equal(got, []byte("legacy-secret")) {
+		t.Fatalf("legacy plaintext mismatch: %q", got)
 	}
 }

--- a/pkg/clawvisor/defaults.go
+++ b/pkg/clawvisor/defaults.go
@@ -281,6 +281,7 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 	// ── Notifier ─────────────────────────────────────────────────────────────
 	telegramN := telegramnotify.New(st, ctx)
 	telegramN.SetMessageBuffer(msgBuffer)
+	telegramN.SetVault(v)
 
 	var pushN *pushnotify.Notifier
 	if cfg.Push.Enabled && ed25519Key != nil {

--- a/pkg/notify/notify.go
+++ b/pkg/notify/notify.go
@@ -111,6 +111,17 @@ type TelegramPairer interface {
 	CancelPairing(pairingID string)
 }
 
+// TelegramConfigStore persists and retrieves a user's Telegram bot
+// configuration. Implementations are expected to encrypt the bot token at
+// rest (e.g. via the credential vault) — the token never appears in any
+// API response and should never be written into a plaintext database
+// column.
+type TelegramConfigStore interface {
+	SaveTelegramConfig(ctx context.Context, userID, botToken, chatID string) error
+	TelegramConfig(ctx context.Context, userID string) (botToken, chatID string, err error)
+	DeleteTelegramConfig(ctx context.Context, userID string) error
+}
+
 // CallbackDecision is sent by the Telegram notifier when a user taps an
 // inline Approve/Deny button. The server routes this to the appropriate handler.
 type CallbackDecision struct {

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -121,6 +121,9 @@ type Store interface {
 	// from "approved" to "executing". Returns true if the caller won the claim,
 	// false if another caller already claimed it (or the row is not "approved").
 	ClaimPendingApprovalForExecution(ctx context.Context, requestID string) (bool, error)
+	// ListStalledExecutingApprovals returns rows stuck in "executing" beyond
+	// leaseTTL — the recovery hook for daemon crashes mid-execution.
+	ListStalledExecutingApprovals(ctx context.Context, leaseTTL time.Duration) ([]*PendingApproval, error)
 
 	// Canonical approval records
 	CreateApprovalRecord(ctx context.Context, rec *ApprovalRecord) error

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -14,6 +14,29 @@ import (
 // Example: go build -ldflags="-X github.com/clawvisor/clawvisor/pkg/version.Version=0.3.0"
 var Version = "dev"
 
+// IMessageHelperSHA256 is a comma-separated list of "os/arch=sha256" entries
+// pinning the expected SHA-256 of each iMessage helper tarball in this
+// release. Populated at build time via -ldflags so a tampered or substituted
+// helper download fails verification before installation. Empty in dev
+// builds; the imessage adapter refuses to download unless this is set, but
+// developers can side-load via PATH or the standard install location.
+var IMessageHelperSHA256 = ""
+
+// IMessageHelperSHA returns the expected SHA-256 for the helper tarball that
+// matches osArch (e.g. "darwin/arm64"), or empty string if not pinned.
+func IMessageHelperSHA(osArch string) string {
+	for _, pair := range strings.Split(IMessageHelperSHA256, ",") {
+		k, v, ok := strings.Cut(pair, "=")
+		if !ok {
+			continue
+		}
+		if strings.TrimSpace(k) == osArch {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}
+
 // SkillPublishedAt is set at build time via -ldflags. It records the date (YYYY-MM-DD)
 // the release was built so the skill can display when it was last updated.
 var SkillPublishedAt = "dev"

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -21,12 +21,47 @@ fi
 
 MODULE="github.com/clawvisor/clawvisor/pkg/version"
 BUILD_DATE=$(date -u +%Y-%m-%d)
-LDFLAGS="-s -w -X ${MODULE}.Version=${VERSION} -X ${MODULE}.SkillPublishedAt=${BUILD_DATE}"
 PLATFORMS="darwin/arm64 darwin/amd64 linux/arm64 linux/amd64"
 HOST_OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
 
 rm -rf dist
 mkdir -p dist
+
+# Build the iMessage helper FIRST so we can hash its tarballs and embed those
+# SHAs into the clawvisor binary via -ldflags. The adapter refuses to install
+# any helper whose hash doesn't match this baked-in pin, blocking tampered or
+# substituted release artifacts.
+HELPER_APP="Clawvisor iMessage Helper.app"
+HELPER_PLATFORMS="darwin/arm64 darwin/amd64"
+HELPER_LDFLAGS="-s -w -X ${MODULE}.Version=${VERSION} -X ${MODULE}.SkillPublishedAt=${BUILD_DATE}"
+HELPER_SHAS=""
+for PLATFORM in $HELPER_PLATFORMS; do
+  GOOS="${PLATFORM%/*}"
+  GOARCH="${PLATFORM#*/}"
+  TARBALL="dist/clawvisor-imessage-helper-${GOOS}-${GOARCH}.tar.gz"
+
+  echo "Building ${TARBALL}..."
+  CGO_ENABLED=0 GOOS="$GOOS" GOARCH="$GOARCH" \
+    go build -ldflags="$HELPER_LDFLAGS" -o "dist/.helper-tmp" ./cmd/imessage-helper
+
+  mkdir -p "dist/${HELPER_APP}/Contents/MacOS"
+  mv "dist/.helper-tmp" "dist/${HELPER_APP}/Contents/MacOS/clawvisor-imessage-helper"
+  cp cmd/imessage-helper/Info.plist "dist/${HELPER_APP}/Contents/Info.plist"
+  tar -czf "$TARBALL" -C dist "${HELPER_APP}"
+  rm -rf "dist/${HELPER_APP}"
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    SHA=$(sha256sum "$TARBALL" | awk '{print $1}')
+  else
+    SHA=$(shasum -a 256 "$TARBALL" | awk '{print $1}')
+  fi
+  if [ -n "$HELPER_SHAS" ]; then
+    HELPER_SHAS="${HELPER_SHAS},"
+  fi
+  HELPER_SHAS="${HELPER_SHAS}${PLATFORM}=${SHA}"
+done
+
+LDFLAGS="-s -w -X ${MODULE}.Version=${VERSION} -X ${MODULE}.SkillPublishedAt=${BUILD_DATE} -X ${MODULE}.IMessageHelperSHA256=${HELPER_SHAS}"
 
 for PLATFORM in $PLATFORMS; do
   GOOS="${PLATFORM%/*}"
@@ -57,28 +92,6 @@ for PLATFORM in $PLATFORMS; do
     CGO_ENABLED=0 GOOS="$GOOS" GOARCH="$GOARCH" \
       go build -ldflags="$LDFLAGS" -o "$OUTPUT" ./cmd/clawvisor-local
   fi
-done
-
-# Build the iMessage helper .app bundle for macOS only. This is a separate,
-# stable binary that holds Full Disk Access so users don't need to re-grant
-# FDA on every clawvisor update. The .app bundle structure lets macOS read
-# Info.plist for the display name in FDA settings, no CGO required.
-HELPER_APP="Clawvisor iMessage Helper.app"
-HELPER_PLATFORMS="darwin/arm64 darwin/amd64"
-for PLATFORM in $HELPER_PLATFORMS; do
-  GOOS="${PLATFORM%/*}"
-  GOARCH="${PLATFORM#*/}"
-  TARBALL="dist/clawvisor-imessage-helper-${GOOS}-${GOARCH}.tar.gz"
-
-  echo "Building ${TARBALL}..."
-  CGO_ENABLED=0 GOOS="$GOOS" GOARCH="$GOARCH" \
-    go build -ldflags="$LDFLAGS" -o "dist/.helper-tmp" ./cmd/imessage-helper
-
-  mkdir -p "dist/${HELPER_APP}/Contents/MacOS"
-  mv "dist/.helper-tmp" "dist/${HELPER_APP}/Contents/MacOS/clawvisor-imessage-helper"
-  cp cmd/imessage-helper/Info.plist "dist/${HELPER_APP}/Contents/Info.plist"
-  tar -czf "$TARBALL" -C dist "${HELPER_APP}"
-  rm -rf "dist/${HELPER_APP}"
 done
 
 echo "Generating checksums..."


### PR DESCRIPTION
## Summary

Implements fixes for the 9 confirmed-critical findings from the repo stress test in `.context/stress-tests/SUMMARY.md`. Each finding gets its own commit so they're easy to revert in isolation.

## Fixes

- **Cross-agent task/approval scoping** — gateway now refuses one agent reading or acting on another agent's tasks/pending requests under the same user.
- **fail_closed honored on intent verifier** — LLM verifier outages now reject when configured, instead of silent fall-through.
- **Cross-user `pending_request_id` hijack at OAuth init** — all three intake paths (POST `/api/oauth/init`, GET `/api/oauth/url`, GET `/api/oauth/start`) now reject pending IDs that don't belong to the caller, with a downstream defense-in-depth check at callback time.
- **SSRF guard on adapter-supplied OAuth/PKCE token endpoints** — dial-time IP filtering blocks RFC1918 / link-local / cloud-metadata; OAuth gets a sibling client that exempts loopback to match `validateTokenEndpoint`.
- **Telegram bot token vaulting** — bot tokens now go through the credential vault on read with lazy migration of any existing plaintext rows.
- **Vault AAD bound to (user_id, service_id)** — prevents cross-row credential swap attacks; legacy rows decrypt with nil AAD then re-save bound on next write.
- **iMessage helper SHA pinning** — release builds embed per-arch tarball SHA-256 via LDFLAGS; download refuses without a pinned SHA. Dev builds can't install the helper.
- **Executing-lease + recovery for stalled approvals** — daemon-crash mid-execution no longer strands rows in `executing` forever; sweeper reclaims after 5-min lease.
- **New unit-test coverage** — vault crypto round-trips, callback SSRF guard, intent fail_closed behavior, agent isolation, and the OAuth pending-request guard.

## Behavioral notes

- 5-min cap on `executing` state — any single gateway request that takes longer will be reclaimed and reported as a callback failure.
- OAuth token URLs that resolve to private IPs are blocked; on-prem OAuth providers behind RFC1918 will be rejected.
- iMessage helper installs require the new release build pipeline; `go build` of the daemon can't fetch the helper.
- `fail_closed: true` configs will see more rejections during LLM verifier outages (correct behavior, but visible).

## Test plan

- [x] Full `go test ./...` passes
- [x] Previously-failing e2e tests (`TestCIOAuthActivation`, `TestCIOAuthGatewayFlow`, `TestCIAgentLifecycle`) pass after SSRF dialer split
- [ ] Verify migrations apply cleanly on a non-empty production-shaped DB
- [ ] Smoke-test an OAuth activation flow end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)