### PR TITLE
fix(e2e): update proxy imports to pkg/ after package move

### DIFF
--- a/internal/e2e/harness/server.go
+++ b/internal/e2e/harness/server.go
@@ -27,7 +27,7 @@ import (
 	"sync"
 
 	"github.com/clawvisor/clawvisor/internal/api/handlers"
-	runtimeproxy "github.com/clawvisor/clawvisor/internal/runtime/proxy"
+	runtimeproxy "github.com/clawvisor/clawvisor/pkg/runtime/proxy"
 	runtimereview "github.com/clawvisor/clawvisor/internal/runtime/review"
 	"github.com/clawvisor/clawvisor/internal/store/sqlite"
 	intvault "github.com/clawvisor/clawvisor/internal/vault"

--- a/internal/e2e/harness/session.go
+++ b/internal/e2e/harness/session.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"net/url"
 
-	runtimeproxy "github.com/clawvisor/clawvisor/internal/runtime/proxy"
+	runtimeproxy "github.com/clawvisor/clawvisor/pkg/runtime/proxy"
 )
 
 // SessionHandle bundles everything the responder needs to talk through the

--- a/internal/e2e/harness/upstreams.go
+++ b/internal/e2e/harness/upstreams.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"sync"
 
-	runtimeproxy "github.com/clawvisor/clawvisor/internal/runtime/proxy"
+	runtimeproxy "github.com/clawvisor/clawvisor/pkg/runtime/proxy"
 )
 
 // Upstreams installs in-process httptest mocks behind hostnames and rewires

--- a/internal/e2e/roles/approver.go
+++ b/internal/e2e/roles/approver.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	runtimeproxy "github.com/clawvisor/clawvisor/internal/runtime/proxy"
+	runtimeproxy "github.com/clawvisor/clawvisor/pkg/runtime/proxy"
 	"github.com/clawvisor/clawvisor/pkg/store"
 )
 

--- a/internal/e2e/scenario/approver.go
+++ b/internal/e2e/scenario/approver.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	runtimeproxy "github.com/clawvisor/clawvisor/internal/runtime/proxy"
+	runtimeproxy "github.com/clawvisor/clawvisor/pkg/runtime/proxy"
 	"github.com/clawvisor/clawvisor/pkg/store"
 )
 

--- a/internal/e2e/scenario/approver_test.go
+++ b/internal/e2e/scenario/approver_test.go
@@ -4,7 +4,7 @@ import (
 	"math"
 	"testing"
 
-	runtimeproxy "github.com/clawvisor/clawvisor/internal/runtime/proxy"
+	runtimeproxy "github.com/clawvisor/clawvisor/pkg/runtime/proxy"
 )
 
 func TestProbabilisticDeciderDeterministicWithSeed(t *testing.T) {


### PR DESCRIPTION
## Summary
- The e2e harness PR (#325) merged after the proxy package move (#326) but kept stale `internal/runtime/proxy` import paths, breaking `go vet` on `main`.
- Updates 6 files under `internal/e2e/` to import from `pkg/runtime/proxy`.

## Test plan
- [x] `go vet ./...` passes clean