### PR TITLE
fix(e2e): update harness to new CreateRuntimeSession signature

### DIFF
--- a/internal/e2e/harness/session.go
+++ b/internal/e2e/harness/session.go
@@ -31,7 +31,7 @@ func (s *Server) CreateSession(ctx context.Context, p *Principal) (*SessionHandl
 	if p == nil || p.Agent == nil || p.User == nil {
 		return nil, fmt.Errorf("harness: principal is required")
 	}
-	res, err := s.Manager.CreateRuntimeSession(ctx, p.Agent.ID, p.User.ID, runtimeproxy.CreateSessionRequest{
+	res, err := s.Manager.CreateRuntimeSession(ctx, p.Agent, runtimeproxy.CreateSessionRequest{
 		Mode: "proxy",
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary
- `CreateRuntimeSession` now takes `*store.Agent` (after the org_id threading work in #327); the e2e harness was still passing the old `agent.ID, user.ID` pair, breaking `go vet ./...`.

## Test plan
- [x] `go vet ./...`