### PR TITLE
refactor: merge internal/vault into pkg/vault

### DIFF
--- a/internal/api/handlers/runtime_test.go
+++ b/internal/api/handlers/runtime_test.go
@@ -15,7 +15,7 @@ import (
 	runtimeproxy "github.com/clawvisor/clawvisor/pkg/runtime/proxy"
 	runtimereview "github.com/clawvisor/clawvisor/pkg/runtime/review"
 	"github.com/clawvisor/clawvisor/pkg/store/sqlite"
-	intvault "github.com/clawvisor/clawvisor/internal/vault"
+	intvault "github.com/clawvisor/clawvisor/pkg/vault"
 	"github.com/clawvisor/clawvisor/pkg/config"
 	"github.com/clawvisor/clawvisor/pkg/store"
 	"github.com/google/uuid"

--- a/internal/api/org_test.go
+++ b/internal/api/org_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/clawvisor/clawvisor/pkg/adapters"
 	"github.com/clawvisor/clawvisor/pkg/config"
 	sqlitestore "github.com/clawvisor/clawvisor/pkg/store/sqlite"
-	intvault "github.com/clawvisor/clawvisor/internal/vault"
+	intvault "github.com/clawvisor/clawvisor/pkg/vault"
 	"github.com/clawvisor/clawvisor/pkg/vault"
 	"github.com/clawvisor/clawvisor/pkg/store"
 )

--- a/internal/api/testutil_test.go
+++ b/internal/api/testutil_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/clawvisor/clawvisor/internal/api"
 	"github.com/clawvisor/clawvisor/internal/auth"
 	sqlitestore "github.com/clawvisor/clawvisor/pkg/store/sqlite"
-	intvault "github.com/clawvisor/clawvisor/internal/vault"
+	intvault "github.com/clawvisor/clawvisor/pkg/vault"
 	"github.com/clawvisor/clawvisor/pkg/adapters"
 	"github.com/clawvisor/clawvisor/pkg/config"
 	"github.com/clawvisor/clawvisor/pkg/store"

--- a/internal/e2e/harness/server.go
+++ b/internal/e2e/harness/server.go
@@ -30,7 +30,7 @@ import (
 	runtimeproxy "github.com/clawvisor/clawvisor/pkg/runtime/proxy"
 	runtimereview "github.com/clawvisor/clawvisor/pkg/runtime/review"
 	"github.com/clawvisor/clawvisor/pkg/store/sqlite"
-	intvault "github.com/clawvisor/clawvisor/internal/vault"
+	intvault "github.com/clawvisor/clawvisor/pkg/vault"
 	"github.com/clawvisor/clawvisor/pkg/config"
 	"github.com/clawvisor/clawvisor/pkg/store"
 )

--- a/internal/notify/telegram/secret_test.go
+++ b/internal/notify/telegram/secret_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	sqlitestore "github.com/clawvisor/clawvisor/pkg/store/sqlite"
-	intvault "github.com/clawvisor/clawvisor/internal/vault"
+	intvault "github.com/clawvisor/clawvisor/pkg/vault"
 )
 
 // TestSaveTelegramConfig_EncryptsBotToken verifies that when a vault is

--- a/pkg/clawvisor/defaults.go
+++ b/pkg/clawvisor/defaults.go
@@ -42,7 +42,7 @@ import (
 	"github.com/clawvisor/clawvisor/internal/relay"
 	pgstore "github.com/clawvisor/clawvisor/pkg/store/postgres"
 	sqlitestore "github.com/clawvisor/clawvisor/pkg/store/sqlite"
-	intvault "github.com/clawvisor/clawvisor/internal/vault"
+	intvault "github.com/clawvisor/clawvisor/pkg/vault"
 
 	"github.com/clawvisor/clawvisor/internal/adaptergen"
 	"github.com/clawvisor/clawvisor/pkg/adapters"

--- a/pkg/runtime/proxy/inbound_secret_runtime_test.go
+++ b/pkg/runtime/proxy/inbound_secret_runtime_test.go
@@ -13,7 +13,7 @@ import (
 
 	runtimetiming "github.com/clawvisor/clawvisor/internal/runtime/timing"
 	"github.com/clawvisor/clawvisor/pkg/store/sqlite"
-	intvault "github.com/clawvisor/clawvisor/internal/vault"
+	intvault "github.com/clawvisor/clawvisor/pkg/vault"
 	"github.com/clawvisor/clawvisor/pkg/config"
 )
 

--- a/pkg/runtime/proxy/placeholder_runtime_test.go
+++ b/pkg/runtime/proxy/placeholder_runtime_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/clawvisor/clawvisor/internal/runtime/autovault"
 	"github.com/clawvisor/clawvisor/pkg/store/sqlite"
-	intvault "github.com/clawvisor/clawvisor/internal/vault"
+	intvault "github.com/clawvisor/clawvisor/pkg/vault"
 	"github.com/clawvisor/clawvisor/pkg/config"
 	"github.com/clawvisor/clawvisor/pkg/store"
 )

--- a/pkg/vault/gcp.go
+++ b/pkg/vault/gcp.go
@@ -8,7 +8,7 @@ import (
 
 	secretmanager "cloud.google.com/go/secretmanager/apiv1"
 	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
-	pkgvault "github.com/clawvisor/clawvisor/pkg/vault"
+
 	"google.golang.org/api/iterator"
 
 	"google.golang.org/grpc/codes"
@@ -20,8 +20,8 @@ import (
 // is a second layer, not the primary encryption.
 // Secret naming: clawvisor-{userID}-{serviceID}
 type GCPVault struct {
-	client    *secretmanager.Client
-	project   string
+	client     *secretmanager.Client
+	project    string
 	localVault *LocalVault // for encryption/decryption
 }
 
@@ -106,7 +106,7 @@ func (v *GCPVault) Get(ctx context.Context, userID, serviceID string) ([]byte, e
 	})
 	if err != nil {
 		if status.Code(err) == codes.NotFound {
-			return nil, pkgvault.ErrNotFound
+			return nil, ErrNotFound
 		}
 		return nil, fmt.Errorf("accessing secret: %w", err)
 	}

--- a/pkg/vault/local.go
+++ b/pkg/vault/local.go
@@ -13,8 +13,6 @@ import (
 	"os"
 
 	"github.com/google/uuid"
-
-	pkgvault "github.com/clawvisor/clawvisor/pkg/vault"
 )
 
 // LocalVault encrypts credentials with AES-256-GCM and stores them in the
@@ -94,7 +92,7 @@ func (v *LocalVault) Get(ctx context.Context, userID, serviceID string) ([]byte,
 	var encrypted, iv, authTag string
 	err := v.db.QueryRowContext(ctx, q, userID, serviceID).Scan(&encrypted, &iv, &authTag)
 	if errors.Is(err, sql.ErrNoRows) {
-		return nil, pkgvault.ErrNotFound
+		return nil, ErrNotFound
 	}
 	if err != nil {
 		return nil, fmt.Errorf("vault get: %w", err)

--- a/pkg/vault/local_test.go
+++ b/pkg/vault/local_test.go
@@ -11,8 +11,6 @@ import (
 	"testing"
 
 	_ "modernc.org/sqlite"
-
-	pkgvault "github.com/clawvisor/clawvisor/pkg/vault"
 )
 
 func newKey(t *testing.T) []byte {
@@ -268,7 +266,7 @@ func TestLocalVault_DBBacked_RoundTrip(t *testing.T) {
 	// Cross-user isolation.
 	if _, err := v.Get(ctx, "u2", "gmail"); err == nil {
 		t.Fatalf("expected ErrNotFound for other user, got nil")
-	} else if err != pkgvault.ErrNotFound {
+	} else if err != ErrNotFound {
 		t.Fatalf("expected ErrNotFound, got %v", err)
 	}
 
@@ -286,7 +284,7 @@ func TestLocalVault_DBBacked_RoundTrip(t *testing.T) {
 	if err := v.Delete(ctx, "u1", "calendar"); err != nil {
 		t.Fatalf("Delete: %v", err)
 	}
-	if _, err := v.Get(ctx, "u1", "calendar"); err != pkgvault.ErrNotFound {
+	if _, err := v.Get(ctx, "u1", "calendar"); err != ErrNotFound {
 		t.Fatalf("after delete expected ErrNotFound, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Merges `internal/vault/{local.go, gcp.go, local_test.go}` into the existing `pkg/vault/` package. Same Phase 0.1 pattern as #326 (proxy), #335 (leases + review), #336 (postgres + sqlite stores).

## Why

The `Vault` interface and `ErrNotFound` already live in `pkg/vault/vault.go`, but the only concrete implementations (`LocalVault`, `GCPVault`) lived under `internal/vault/`. External consumers (specifically the upcoming clawvisor-cloud `cmd/proxy-server/` binary, which wires a master-keyed `LocalVault` as the OrgAwareVault fallback) couldn't construct any `Vault` without going through `clawvisor.DefaultOptions` — the heavy daemon-mode bootstrapper.

This is the last `internal/` gap blocking `cmd/proxy-server/` in clawvisor-cloud.

## Scope

- `git mv internal/vault/local.go pkg/vault/local.go`
- `git mv internal/vault/gcp.go pkg/vault/gcp.go`
- `git mv internal/vault/local_test.go pkg/vault/local_test.go`
- Drop the `pkgvault "github.com/clawvisor/clawvisor/pkg/vault"` self-import in the moved files (the merged package owns those symbols directly now).
- Convert `pkgvault.ErrNotFound` → `ErrNotFound` (3 callsites; same package now).
- `gofmt` to clean up resulting import blocks.
- Caller import updates across 8 files: `pkg/clawvisor/defaults.go`, `pkg/runtime/proxy/{inbound_secret_runtime_test.go, placeholder_runtime_test.go}`, `internal/api/handlers/runtime_test.go`, `internal/api/{org_test.go, testutil_test.go}`, `internal/notify/telegram/secret_test.go`, `internal/e2e/harness/server.go`.

## Out of scope

- API or behavior changes — none. Same exported types, same signatures: `LocalVault`, `NewLocalVault`, `NewLocalVaultFromKey`, `NewLocalVaultFromKeyWithDB`, `GCPVault`, `NewGCPVault`, `ResolveKey`.
- Vault interface changes — `pkg/vault/vault.go` is unchanged.

## Test plan

- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test ./...` — all packages pass, including `pkg/vault` (which gains the moved `local_test.go`)
- [ ] CI green

## Companion PRs

- #326: proxy package
- #335: leases + review packages
- #336: postgres + sqlite store packages
- This PR: vault implementations

After this lands, clawvisor-cloud can complete `cmd/proxy-server/` with no `internal/` import violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)