### PR TITLE
ci: keep binary+skill jobs running when release-please errors post-release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,7 +23,7 @@ jobs:
 
   build-binaries:
     needs: release-please
-    if: needs.release-please.outputs.release_created == 'true'
+    if: always() && needs.release-please.outputs.release_created == 'true'
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -55,7 +55,7 @@ jobs:
 
   publish-skill:
     needs: release-please
-    if: needs.release-please.outputs.release_created == 'true'
+    if: always() && needs.release-please.outputs.release_created == 'true'
     uses: ./.github/workflows/publish-skill.yml
     with:
       tag: ${{ needs.release-please.outputs.tag_name }}


### PR DESCRIPTION
## Summary

- v0.9.2 shipped without binaries (and without a ClawHub skill push) because the release-please job errored in its second phase after creating the release, causing the dependent `build-binaries` and `publish-skill` jobs to be skipped.
- Guard those jobs with `always() && needs.release-please.outputs.release_created == 'true'` so they run whenever a release is cut, even if the release-please job itself ends in failure.

## Why this works

The release-please-action sets its `release_created` / `tag_name` outputs during the job's "Complete job" step, which runs even after the action errors. We confirmed this on run [25390410776](https://github.com/clawvisor/clawvisor/actions/runs/25390410776) — the outputs were emitted; only the action step itself was marked failed.

## Why not a separate workflow on tag push

Considered moving these jobs out of `release-please.yml` and triggering on `push: tags: 'v*'` or `release: published`. GitHub deliberately suppresses workflow runs from events whose initiator is the default `GITHUB_TOKEN` (loop-prevention), so release-please-action's tag push won't fire downstream workflows without a PAT or App-token. That's extra plumbing for the same outcome — the in-workflow guard achieves robustness with a 2-line change.

## Recovery for v0.9.2

Already kicked off manually:
- `gh workflow run release-binaries.yml -f version=v0.9.2`
- `gh workflow run publish-skill.yml -f tag=v0.9.2`

## Test plan

- [ ] Next release-please-cut release ships binaries even if phase-2 hits another transient API error.
- [ ] Normal happy-path release still produces binaries + skill push (no regression from `always()`).