### PR TITLE
fix(mcp): drop top-level anyOf from create_task schema

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -31,7 +31,7 @@ func toolDefs() []Tool {
 		},
 		{
 			Name:        "create_task",
-			Description: "Create a new task for scoped authorization. Use wait=true (recommended) to block until the user approves or denies.",
+			Description: "Create a new task for scoped authorization. Use wait=true (recommended) to block until the user approves or denies. Must include at least one of: authorized_actions, expected_tools_json, or expected_egress_json.",
 			InputSchema: json.RawMessage(`{
 				"type": "object",
 				"properties": {
@@ -104,12 +104,7 @@ func toolDefs() []Tool {
 					"wait": {"type": "boolean", "description": "Block until the task is approved or denied (default true)"},
 					"timeout": {"type": "integer", "description": "Long-poll timeout in seconds (default 120, max 120)"}
 				},
-				"required": ["purpose"],
-				"anyOf": [
-					{"required": ["authorized_actions"]},
-					{"required": ["expected_tools_json"]},
-					{"required": ["expected_egress_json"]}
-				]
+				"required": ["purpose"]
 			}`),
 		},
 		{


### PR DESCRIPTION
## Summary
Anthropic's API rejects `oneOf`/`allOf`/`anyOf` at the top level of an MCP tool's `input_schema`, which caused Cowork to error out forwarding our tool list (`tools.9.custom.input_schema: input_schema does not support oneOf, allOf, or anyOf at the top level`). The constraint that a task must include one of `authorized_actions`, `expected_tools_json`, or `expected_egress_json` is already enforced server-side at `internal/api/handlers/tasks.go:145` with a clearer error message, so the schema-level `anyOf` was redundant — moved the requirement into the tool description.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./internal/mcp/... ./internal/api/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)