### PR TITLE
fix(settings): hide local daemon section for non-paid plans

### DIFF
--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -12,6 +12,19 @@ export default function Settings() {
   const { features } = useAuth()
   const passwordAuth = features?.password_auth ?? false
 
+  const billingEnabled = features?.billing ?? false
+  const { data: billingStatus } = useQuery({
+    queryKey: ['billing-status'],
+    queryFn: () => api.billing.status(),
+    enabled: billingEnabled,
+  })
+  const PAID_PLANS = ['pro', 'enterprise', 'grandfathered']
+  const ACTIVE_STATUSES = ['active', 'past_due']
+  const onPaidPlan = !billingEnabled || (
+    PAID_PLANS.includes(billingStatus?.plan ?? '') &&
+    ACTIVE_STATUSES.includes(billingStatus?.status ?? '')
+  )
+
   return (
     <div className="p-4 sm:p-8 space-y-10">
       <h1 className="text-2xl font-bold text-text-primary">Settings</h1>
@@ -19,7 +32,7 @@ export default function Settings() {
       {!features?.multi_tenant && <LLMSection />}
       {!features?.multi_tenant && <OAuthCredentialsSection />}
       {features?.mobile_pairing && <DevicePairing />}
-      {features?.local_daemon && <LocalDaemonPairing />}
+      {features?.local_daemon && onPaidPlan && <LocalDaemonPairing />}
       <TelegramSetupSection />
       {passwordAuth && <PasswordSection />}
       {passwordAuth && <DangerZone />}


### PR DESCRIPTION
## Summary
- The local daemon API routes are gated server-side by `RequireProOrAllowlist` in cloud, but the Settings page rendered `<LocalDaemonPairing />` based only on the deployment-level `local_daemon` feature flag.
- Free-tier cloud users were seeing a pairing UI that 402s as soon as they try to use it.
- This mirrors the server-side gate in the frontend: render only when `plan ∈ {pro, enterprise, grandfathered}` and `status ∈ {active, past_due}`. Self-hosted deploys (`features.billing === false`) are unchanged.

## Test plan
- [ ] Verify free-tier cloud user does not see the "Local Computer" section on Settings.
- [ ] Verify pro / enterprise / grandfathered users still see the section and can pair.
- [ ] Verify self-hosted (billing disabled) still shows the section.
- [ ] `tsc --noEmit` clean, `vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)