### PR TITLE
feat(api): per-user FeaturesHook for plan-based feature gating

### DIFF
--- a/internal/api/middleware/auth.go
+++ b/internal/api/middleware/auth.go
@@ -68,6 +68,37 @@ func RequireUser(jwtSvc auth.TokenService, st store.Store) func(http.Handler) ht
 	}
 }
 
+// OptionalUser is middleware that validates a user JWT if present and injects
+// the user into the request context. Unlike RequireUser it never rejects the
+// request: missing, invalid, or purpose-restricted tokens cause the handler
+// to run without a user in context. Use this for routes that must be reachable
+// pre-login but want to vary their response when a user is authenticated
+// (e.g. /api/features for per-user feature gating).
+func OptionalUser(jwtSvc auth.TokenService, st store.Store) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			token := bearerToken(r)
+			if token == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+			claims, err := jwtSvc.ValidateToken(token)
+			if err != nil || claims.Purpose != "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+			user, err := st.GetUserByID(r.Context(), claims.UserID)
+			if err != nil {
+				next.ServeHTTP(w, r)
+				return
+			}
+			ctx := context.WithValue(r.Context(), UserContextKey, user)
+			AddLogField(ctx, "user_id", user.ID)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
 // RequireUserOrTicket is middleware that first tries JWT auth (via Authorization
 // header), then falls back to a single-use ticket query parameter. This is used
 // for SSE endpoints where EventSource cannot set custom headers.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -82,6 +82,7 @@ type Server struct {
 	decisionBus          notify.DecisionBus            // cross-instance decision delivery; may be nil
 	gatewayHooks         *GatewayHooks                 // cloud-injected gateway authorization hooks; may be nil
 	feedbackHooks        *FeedbackHooks                // cloud-injected feedback event hooks; may be nil
+	featuresHook         FeaturesHook                  // cloud-injected per-user feature overrides; may be nil
 	localServiceProvider handlers.LocalServiceProvider // cloud-injected local daemon service provider; may be nil
 	localServiceExecutor handlers.LocalServiceExecutor // cloud-injected local service executor; may be nil
 
@@ -149,6 +150,14 @@ type FeedbackHooks struct {
 	// AfterBugReport is called after a bug report is successfully saved.
 	AfterBugReport func(report *store.FeedbackReport)
 }
+
+// FeaturesHook lets cloud/enterprise layers override the FeatureSet returned
+// by /api/features on a per-user basis (e.g. gating features by billing plan).
+// The /api/features route runs OptionalUser middleware before the hook, so
+// `user` is non-nil when the request carries a valid JWT and nil otherwise
+// (the pre-login bootstrap call). Hooks should return the unmodified set when
+// `user` is nil.
+type FeaturesHook func(ctx context.Context, user *store.User, fs FeatureSet) FeatureSet
 
 // ServerOption configures optional behavior on the Server.
 type ServerOption func(*Server)
@@ -235,6 +244,12 @@ func WithGatewayHooks(hooks *GatewayHooks) ServerOption {
 // WithFeedbackHooks injects callbacks for feedback events (e.g. bug reports).
 func WithFeedbackHooks(hooks *FeedbackHooks) ServerOption {
 	return func(s *Server) { s.feedbackHooks = hooks }
+}
+
+// WithFeaturesHook registers a hook that may override the FeatureSet returned
+// by /api/features on a per-user basis.
+func WithFeaturesHook(hook FeaturesHook) ServerOption {
+	return func(s *Server) { s.featuresHook = hook }
 }
 
 // WithLocalServiceProvider injects a provider of local daemon services into
@@ -578,8 +593,11 @@ func (s *Server) routes() http.Handler {
 		mux.Handle("DELETE /api/me", user(authHandler.DeleteMe))
 	}
 
-	// Features endpoint (always registered, returns the active FeatureSet)
-	mux.HandleFunc("GET /api/features", s.handleFeatures)
+	// Features endpoint (always registered, returns the active FeatureSet).
+	// OptionalUser populates the request user if a valid token is present so
+	// the FeaturesHook can return a per-user FeatureSet; pre-login callers see
+	// the deployment-level set.
+	mux.Handle("GET /api/features", middleware.OptionalUser(s.jwtSvc, s.store)(http.HandlerFunc(s.handleFeatures)))
 
 	// Restrictions (rate-limited writes)
 	mux.Handle("GET /api/restrictions", user(restrictionsHandler.List))
@@ -1001,8 +1019,12 @@ func (s *Server) routes() http.Handler {
 
 // handleFeatures returns the active feature set as JSON.
 func (s *Server) handleFeatures(w http.ResponseWriter, r *http.Request) {
+	fs := s.features
+	if s.featuresHook != nil {
+		fs = s.featuresHook(r.Context(), middleware.UserFromContext(r.Context()), fs)
+	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(s.features)
+	json.NewEncoder(w).Encode(fs)
 }
 
 // handleClawvisorKeys returns the daemon's public keys for E2E encryption.

--- a/pkg/clawvisor/options.go
+++ b/pkg/clawvisor/options.go
@@ -42,6 +42,13 @@ type FeedbackHooks struct {
 	AfterBugReport func(report *store.FeedbackReport)
 }
 
+// FeaturesHook lets cloud/enterprise layers override the FeatureSet returned
+// by /api/features on a per-user basis (e.g. gating features by billing plan).
+// `user` is non-nil when the request carries a valid JWT and nil for the
+// pre-login bootstrap call. Hooks should return the unmodified set when
+// `user` is nil.
+type FeaturesHook func(ctx context.Context, user *store.User, fs FeatureSet) FeatureSet
+
 // ServerOptions holds everything needed to start a Clawvisor server.
 // Use DefaultOptions to get the standard open-source defaults, then
 // selectively override fields before passing to Run.
@@ -110,6 +117,11 @@ type ServerOptions struct {
 	// FeedbackHooks allows cloud/enterprise layers to react to feedback events
 	// (e.g. sending Slack alerts on bug reports).
 	FeedbackHooks *FeedbackHooks
+
+	// FeaturesHook overrides the FeatureSet returned by /api/features on a
+	// per-user basis. Set by the cloud layer for plan-based gating; nil in
+	// self-hosted mode.
+	FeaturesHook FeaturesHook
 
 	// LocalServiceProvider supplies local daemon services for the agent catalog.
 	// Set by the cloud layer; nil in self-hosted mode.

--- a/pkg/clawvisor/run.go
+++ b/pkg/clawvisor/run.go
@@ -20,6 +20,7 @@ import (
 	runtimeproxy "github.com/clawvisor/clawvisor/pkg/runtime/proxy"
 	runtimereview "github.com/clawvisor/clawvisor/pkg/runtime/review"
 	"github.com/clawvisor/clawvisor/pkg/adapters"
+	"github.com/clawvisor/clawvisor/pkg/store"
 )
 
 // RunWithContext starts the Clawvisor server using the provided context for
@@ -243,6 +244,45 @@ func RunWithContext(ctx context.Context, opts *ServerOptions) error {
 	if opts.FeedbackHooks != nil {
 		apiOpts = append(apiOpts, api.WithFeedbackHooks(&api.FeedbackHooks{
 			AfterBugReport: opts.FeedbackHooks.AfterBugReport,
+		}))
+	}
+
+	if opts.FeaturesHook != nil {
+		hook := opts.FeaturesHook
+		apiOpts = append(apiOpts, api.WithFeaturesHook(func(ctx context.Context, user *store.User, fs api.FeatureSet) api.FeatureSet {
+			modified := hook(ctx, user, FeatureSet{
+				MultiTenant:       fs.MultiTenant,
+				EmailVerification: fs.EmailVerification,
+				Passkeys:          fs.Passkeys,
+				SSO:               fs.SSO,
+				Teams:             fs.Teams,
+				UsageMetering:     fs.UsageMetering,
+				PasswordAuth:      fs.PasswordAuth,
+				Billing:           fs.Billing,
+				LocalDaemon:       fs.LocalDaemon,
+				RuntimeProxy:      fs.RuntimeProxy,
+				SecretVault:       fs.SecretVault,
+				RuntimePolicyUI:   fs.RuntimePolicyUI,
+				RuntimeActivity:   fs.RuntimeActivity,
+				AgentLiveSessions: fs.AgentLiveSessions,
+				ServicePresets:    fs.ServicePresets,
+			})
+			fs.MultiTenant = modified.MultiTenant
+			fs.EmailVerification = modified.EmailVerification
+			fs.Passkeys = modified.Passkeys
+			fs.SSO = modified.SSO
+			fs.Teams = modified.Teams
+			fs.UsageMetering = modified.UsageMetering
+			fs.PasswordAuth = modified.PasswordAuth
+			fs.Billing = modified.Billing
+			fs.LocalDaemon = modified.LocalDaemon
+			fs.RuntimeProxy = modified.RuntimeProxy
+			fs.SecretVault = modified.SecretVault
+			fs.RuntimePolicyUI = modified.RuntimePolicyUI
+			fs.RuntimeActivity = modified.RuntimeActivity
+			fs.AgentLiveSessions = modified.AgentLiveSessions
+			fs.ServicePresets = modified.ServicePresets
+			return fs
 		}))
 	}
 

--- a/web/src/hooks/useAuth.tsx
+++ b/web/src/hooks/useAuth.tsx
@@ -111,6 +111,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     Promise.all([configPromise, featuresPromise, authPromise]).finally(() => setIsLoading(false))
   }, [])
 
+  // Refetch features whenever the authenticated user changes. The bootstrap
+  // call above runs anonymously; once auth resolves (refresh-on-mount or
+  // login), we re-fetch so the server can return per-user feature gates
+  // (e.g. plan-based gating). On logout (user → null), this refetch returns
+  // to the deployment defaults.
+  useEffect(() => {
+    if (!didInit.current) return
+    api.features.get()
+      .then((f) => setFeatures(f))
+      .catch((e) => console.warn('useAuth: failed to refetch features', e))
+  }, [user])
+
   // Register a refresh callback so the API client can silently handle 401s on
   // data endpoints (expired access token) without logging the user out.
   useEffect(() => {

--- a/web/src/hooks/useAuth.tsx
+++ b/web/src/hooks/useAuth.tsx
@@ -81,14 +81,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     if (didInit.current) return
     didInit.current = true
 
-    // Fetch auth mode, features, and refresh token in parallel.
+    // Fetch auth mode and refresh token in parallel. Features are fetched
+    // separately by the user-dependent effect below so we can return a
+    // per-user FeatureSet (e.g. plan-based gating) once the user is known.
     const configPromise = api.config.public()
       .then((cfg) => setAuthMode(cfg.auth_mode))
       .catch((e) => console.warn('useAuth: failed to fetch config', e)) // default stays null → treated like password mode
-
-    const featuresPromise = api.features.get()
-      .then((f) => setFeatures(f))
-      .catch((e) => console.warn('useAuth: failed to fetch features', e)) // default stays null
 
     const storedRefresh = localStorage.getItem(REFRESH_TOKEN_KEY)
     const authPromise = storedRefresh
@@ -108,19 +106,20 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           })
       : Promise.resolve()
 
-    Promise.all([configPromise, featuresPromise, authPromise]).finally(() => setIsLoading(false))
+    Promise.all([configPromise, authPromise]).finally(() => setIsLoading(false))
   }, [])
 
-  // Refetch features whenever the authenticated user changes. The bootstrap
-  // call above runs anonymously; once auth resolves (refresh-on-mount or
-  // login), we re-fetch so the server can return per-user feature gates
-  // (e.g. plan-based gating). On logout (user → null), this refetch returns
-  // to the deployment defaults.
+  // Fetch features on mount and whenever the authenticated user changes, so
+  // the server can return per-user feature gates (e.g. plan-based gating).
+  // The cancel flag drops stale responses if `user` changes again before the
+  // in-flight request resolves — without it a slow anonymous request could
+  // clobber a fast per-user response on login.
   useEffect(() => {
-    if (!didInit.current) return
+    let cancelled = false
     api.features.get()
-      .then((f) => setFeatures(f))
-      .catch((e) => console.warn('useAuth: failed to refetch features', e))
+      .then((f) => { if (!cancelled) setFeatures(f) })
+      .catch((e) => console.warn('useAuth: failed to fetch features', e))
+    return () => { cancelled = true }
   }, [user])
 
   // Register a refresh callback so the API client can silently handle 401s on

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -12,19 +12,6 @@ export default function Settings() {
   const { features } = useAuth()
   const passwordAuth = features?.password_auth ?? false
 
-  const billingEnabled = features?.billing ?? false
-  const { data: billingStatus } = useQuery({
-    queryKey: ['billing-status'],
-    queryFn: () => api.billing.status(),
-    enabled: billingEnabled,
-  })
-  const PAID_PLANS = ['pro', 'enterprise', 'grandfathered']
-  const ACTIVE_STATUSES = ['active', 'past_due']
-  const onPaidPlan = !billingEnabled || (
-    PAID_PLANS.includes(billingStatus?.plan ?? '') &&
-    ACTIVE_STATUSES.includes(billingStatus?.status ?? '')
-  )
-
   return (
     <div className="p-4 sm:p-8 space-y-10">
       <h1 className="text-2xl font-bold text-text-primary">Settings</h1>
@@ -32,7 +19,7 @@ export default function Settings() {
       {!features?.multi_tenant && <LLMSection />}
       {!features?.multi_tenant && <OAuthCredentialsSection />}
       {features?.mobile_pairing && <DevicePairing />}
-      {features?.local_daemon && onPaidPlan && <LocalDaemonPairing />}
+      {features?.local_daemon && <LocalDaemonPairing />}
       <TelegramSetupSection />
       {passwordAuth && <PasswordSection />}
       {passwordAuth && <DangerZone />}


### PR DESCRIPTION
## Summary

Replace the frontend-only plan check from #347 with a server-side mechanism so any consumer of `features.local_daemon` (Settings, Services, etc.) gets the correct gate without duplicating billing logic in the UI.

- Add a `FeaturesHook` option on `pkg/clawvisor.ServerOptions` that lets a cloud/enterprise layer override the `FeatureSet` returned by `/api/features` on a per-user basis.
- Add a new `OptionalUser` middleware (`internal/api/middleware/auth.go`) that populates the request user when a valid JWT is present and falls through silently otherwise. Wire it onto `/api/features` so the bootstrap (pre-login) call still works.
- Frontend (`web/src/hooks/useAuth.tsx`) refetches features whenever the authenticated user changes, so the per-user response replaces the anonymous bootstrap value after login (and resets on logout).
- Revert `Settings.tsx` to a plain `features?.local_daemon` check — the server is now authoritative.

The cloud-side hook implementation (gating `LocalDaemon` on plan + `LOCAL_DAEMON_EMAILS` allowlist) lives in `clawvisor/cloud` and will land alongside this.

## Stacking

This PR is based on `ericlevine/gate-local-daemon-ui-pro` (#347). Once #347 merges, GitHub will retarget this PR to `main` and the only remaining commit will be the FeaturesHook addition (the Settings.tsx revert becomes a no-op against post-#347 main).

## Test plan

- [ ] `go test ./...` passes (verified locally).
- [ ] `tsc --noEmit` and `vite build` clean.
- [ ] Manual: free-tier cloud user sees the local daemon section disappear after login (was visible during anonymous bootstrap).
- [ ] Manual: pro / enterprise / grandfathered users still see the section.
- [ ] Manual: self-hosted (no `FeaturesHook` registered) is unchanged.
- [ ] Manual: logout returns the FeatureSet to deployment defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)