### PR TITLE
ui: hide model name in approval queue and audit log too

### DIFF
--- a/web/src/components/TaskCard.tsx
+++ b/web/src/components/TaskCard.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { api, type Task, type TaskAction, type AuditEntry, type RiskAssessment, type ApprovalRationale, type ScopeOverride, type PlannedCall, type ExpectedTool, type ExpectedEgress } from '../api/client'
 import { format } from 'date-fns'
 import { serviceName, actionName } from '../lib/services'
+import { isLocalHost } from '../lib/env'
 import CountdownTimer from './CountdownTimer'
 import VerificationIcon from './VerificationIcon'
 import ScopePill, { type ScopePillValue } from './ScopePill'
@@ -15,9 +16,6 @@ const baseService = (s: string) => {
   const i = s.indexOf(':')
   return i >= 0 ? s.slice(0, i) : s
 }
-
-const isLocalHost = typeof window !== 'undefined' &&
-  (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1')
 
 // ── Status helpers ───────────────────────────────────────────────────────────
 

--- a/web/src/lib/env.ts
+++ b/web/src/lib/env.ts
@@ -1,0 +1,2 @@
+export const isLocalHost = typeof window !== 'undefined' &&
+  (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1')

--- a/web/src/pages/Audit.tsx
+++ b/web/src/pages/Audit.tsx
@@ -5,6 +5,7 @@ import { api, type ActivityMute, type Agent, type AuditEntry } from '../api/clie
 import { useAuth } from '../hooks/useAuth'
 import { formatDistanceToNow, format } from 'date-fns'
 import { actionName, formatServiceAction, serviceName } from '../lib/services'
+import { isLocalHost } from '../lib/env'
 import type { RuleDraft } from './Runtime'
 
 function escapeCsvField(value: string): string {
@@ -636,7 +637,7 @@ function AuditRow({
                       )}
                     </div>
                     <div className="text-text-secondary">{entry.verification.explanation}</div>
-                    <div className="text-text-tertiary text-[10px]">{entry.verification.model} &middot; {entry.verification.latency_ms}ms</div>
+                    <div className="text-text-tertiary text-[10px]">{isLocalHost ? `${entry.verification.model} · ` : ''}{entry.verification.latency_ms}ms</div>
                   </div>
                 )}
                 {(entry.session_id || entry.approval_id || entry.lease_id || entry.matched_task_id || entry.lease_task_id) && (

--- a/web/src/pages/Overview.tsx
+++ b/web/src/pages/Overview.tsx
@@ -6,6 +6,7 @@ import { filterLiveRuntimeApprovals, isActiveRuntimeSession } from './Runtime'
 import { useAuth } from '../hooks/useAuth'
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts'
 import { serviceName, actionName } from '../lib/services'
+import { isLocalHost } from '../lib/env'
 import CountdownTimer from '../components/CountdownTimer'
 import TaskCard from '../components/TaskCard'
 import VerificationIcon from '../components/VerificationIcon'
@@ -720,7 +721,7 @@ function VerificationPanel({ verification: v }: { verification: VerificationVerd
             }`}>reason: {v.reason_coherence}</span>
           </div>
           {v.explanation && <p className="text-xs text-text-secondary">{v.explanation}</p>}
-          <div className="text-[10px] font-mono text-text-tertiary">{v.model} &middot; {v.latency_ms}ms</div>
+          <div className="text-[10px] font-mono text-text-tertiary">{isLocalHost ? `${v.model} · ` : ''}{v.latency_ms}ms</div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Follow-up to #346. That PR only covered the three model displays inside `TaskCard`. The same `model · latency_ms` line also renders in two production-facing surfaces I missed: the verification panel on the Overview approval queue (`Overview.tsx`) and the per-entry audit log row (`Audit.tsx`).
- Extracts the localhost check into a shared `lib/env.ts` and applies `isLocalHost` in all three files so the model identifier disappears everywhere outside dev.

## Test plan
- [ ] On `localhost`, the model name still renders in: TaskCard panels, Overview approval cards (verification panel), and Audit log entries.
- [ ] On a deployed environment, the model name is gone in all of those; latency still shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)