### PR TITLE
feat(adapters): SQL connect via pasted DSN + richer credential prompt

### DIFF
--- a/docs/INTEGRATION_YAML_SPEC.md
+++ b/docs/INTEGRATION_YAML_SPEC.md
@@ -11,8 +11,10 @@ service:
   id: <string>           # unique lowercase identifier (e.g. "jira", "stripe")
   display_name: <string> # human-readable name
   description: <string>  # one-line description
-  setup_url: <string>    # optional: link to API key / OAuth app setup page
-  key_hint: <string>     # optional: placeholder text for API key input (e.g. "Stripe secret key (sk_...)")
+  setup_url: <string>          # optional: link to API key / OAuth app setup page
+  key_hint: <string>           # optional: placeholder text for API key input (e.g. "Stripe secret key (sk_...)")
+  key_display_name: <string>   # optional: label rendered above the API key input (e.g. "Connection string"). Defaults to no label.
+  key_description: <string>    # optional: helper text rendered under the label. Newlines are preserved, so multi-line guidance is fine.
   icon_svg: <string>     # optional: inline SVG markup (good for small, self-contained glyphs)
   icon_url: <string>     # optional: URL to the icon (absolute or site-relative, e.g. "/logos/stripe.svg"). Prefer this for larger official brand assets already served as static files. If both are set, icon_url takes precedence.
   identity:              # optional: auto-detect account identity after activation

--- a/internal/adapters/sql/adapter.go
+++ b/internal/adapters/sql/adapter.go
@@ -11,6 +11,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"golang.org/x/oauth2"
@@ -53,6 +54,54 @@ func (a *Adapter) CredentialFromToken(_ *oauth2.Token) ([]byte, error) {
 	return nil, fmt.Errorf("sql: no token exchange — uses connection string")
 }
 
+// CredentialFromAPIKey converts a single pasted DSN into the {driver, dsn}
+// credential JSON. Drivers are sniffed from the URI scheme:
+//   - "postgres://" or "postgresql://" → postgres
+//   - "mysql://"                       → mysql
+//   - "sqlite:" prefix or a bare path  → sqlite
+//
+// The pasted string may also already be a {driver, dsn} JSON object, in which
+// case it's passed through after validation.
+func (a *Adapter) CredentialFromAPIKey(token string) ([]byte, error) {
+	s := strings.TrimSpace(token)
+	if s == "" {
+		return nil, fmt.Errorf("sql: connection string is required")
+	}
+
+	// Pass-through: caller pasted a full {driver, dsn} JSON object.
+	if strings.HasPrefix(s, "{") {
+		var c credential
+		if err := json.Unmarshal([]byte(s), &c); err == nil && c.Driver != "" && c.DSN != "" {
+			return []byte(s), nil
+		}
+	}
+
+	driver, dsn, err := sniffDriver(s)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(credential{Driver: driver, DSN: dsn})
+}
+
+// sniffDriver inspects a connection string and returns the matching driver name
+// plus the DSN to hand to database/sql. Each driver expects its own native form:
+//   - postgres: pgx accepts the postgres:// URI as-is.
+//   - mysql:   go-sql-driver wants user:pass@tcp(host:port)/db (no URI scheme).
+//   - sqlite:  a file path (or :memory:); the "sqlite:" prefix is stripped.
+func sniffDriver(s string) (driver, dsn string, err error) {
+	switch {
+	case strings.HasPrefix(s, "postgres://"), strings.HasPrefix(s, "postgresql://"):
+		return "postgres", s, nil
+	case strings.HasPrefix(s, "sqlite://"):
+		return "sqlite", strings.TrimPrefix(s, "sqlite://"), nil
+	case strings.HasPrefix(s, "sqlite:"):
+		return "sqlite", strings.TrimPrefix(s, "sqlite:"), nil
+	case strings.Contains(s, "@tcp("), strings.Contains(s, "@unix("):
+		return "mysql", s, nil
+	}
+	return "", "", fmt.Errorf("sql: cannot determine driver — expected postgres://…, sqlite:…, or user:pass@tcp(host:port)/db (mysql)")
+}
+
 func (a *Adapter) ValidateCredential(credBytes []byte) error {
 	var c credential
 	if err := json.Unmarshal(credBytes, &c); err != nil {
@@ -73,8 +122,11 @@ func (a *Adapter) ValidateCredential(credBytes []byte) error {
 func (a *Adapter) ServiceMetadata() adapters.ServiceMetadata {
 	maxRowsVal := maxRows
 	return adapters.ServiceMetadata{
-		DisplayName: "SQL Database",
-		Description: "Query and modify SQL databases (PostgreSQL, MySQL, SQLite)",
+		DisplayName:    "SQL Database",
+		Description:    "Query and modify SQL databases (PostgreSQL, MySQL, SQLite)",
+		KeyDisplayName: "Connection string",
+		KeyDescription: "Paste a connection string. The driver is detected automatically:\n• PostgreSQL — postgres://user:pass@host:5432/db\n• SQLite     — sqlite:/absolute/path/to.db\n• MySQL      — user:pass@tcp(host:3306)/db",
+		KeyHint:        "postgres://user:pass@host:5432/db",
 		ActionMeta: map[string]adapters.ActionMeta{
 			"query": {
 				DisplayName: "Run query",
@@ -511,8 +563,9 @@ func init() {
 
 // Ensure interface compliance at compile time.
 var (
-	_ adapters.Adapter            = (*Adapter)(nil)
-	_ adapters.MetadataProvider   = (*Adapter)(nil)
-	_ adapters.VerificationHinter = (*Adapter)(nil)
+	_ adapters.Adapter                = (*Adapter)(nil)
+	_ adapters.MetadataProvider       = (*Adapter)(nil)
+	_ adapters.VerificationHinter     = (*Adapter)(nil)
+	_ adapters.APIKeyCredentialBuilder = (*Adapter)(nil)
 )
 

--- a/internal/adapters/sql/adapter_test.go
+++ b/internal/adapters/sql/adapter_test.go
@@ -90,6 +90,51 @@ func TestValidateCredential(t *testing.T) {
 	}
 }
 
+func TestCredentialFromAPIKey(t *testing.T) {
+	a := New()
+
+	tests := []struct {
+		name       string
+		input      string
+		wantDriver string
+		wantDSN    string
+		wantErr    bool
+	}{
+		{"postgres uri", "postgres://u:p@host:5432/db", "postgres", "postgres://u:p@host:5432/db", false},
+		{"postgresql uri", "postgresql://u:p@host/db", "postgres", "postgresql://u:p@host/db", false},
+		{"mysql tcp dsn", "u:p@tcp(host:3306)/db", "mysql", "u:p@tcp(host:3306)/db", false},
+		{"mysql unix dsn", "u:p@unix(/tmp/mysql.sock)/db", "mysql", "u:p@unix(/tmp/mysql.sock)/db", false},
+		{"sqlite scheme", "sqlite:/tmp/test.db", "sqlite", "/tmp/test.db", false},
+		{"sqlite double-slash", "sqlite:///tmp/test.db", "sqlite", "/tmp/test.db", false},
+		{"trims whitespace", "  postgres://localhost/db  ", "postgres", "postgres://localhost/db", false},
+		{"passthrough json", `{"driver":"postgres","dsn":"postgres://localhost/db"}`, "postgres", "postgres://localhost/db", false},
+		{"empty", "", "", "", true},
+		{"unknown form", "just-a-token", "", "", true},
+		{"mysql uri rejected", "mysql://u:p@host:3306/db", "", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := a.CredentialFromAPIKey(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err=%v wantErr=%v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			var c credential
+			if err := json.Unmarshal(out, &c); err != nil {
+				t.Fatalf("output is not valid JSON: %v (%s)", err, out)
+			}
+			if c.Driver != tt.wantDriver || c.DSN != tt.wantDSN {
+				t.Errorf("got {%q, %q}, want {%q, %q}", c.Driver, c.DSN, tt.wantDriver, tt.wantDSN)
+			}
+			if err := a.ValidateCredential(out); err != nil {
+				t.Errorf("ValidateCredential rejected output: %v", err)
+			}
+		})
+	}
+}
+
 func TestQuery(t *testing.T) {
 	cred := setupTestDB(t)
 	a := New()

--- a/internal/api/handlers/services.go
+++ b/internal/api/handlers/services.go
@@ -228,13 +228,15 @@ func (h *ServicesHandler) List(w http.ResponseWriter, r *http.Request) {
 		ActivatedAt          *time.Time              `json:"activated_at,omitempty"`
 		SetupURL             string                  `json:"setup_url,omitempty"`
 		KeyHint              string                  `json:"key_hint,omitempty"`
+		KeyDisplayName       string                  `json:"key_display_name,omitempty"`
+		KeyDescription       string                  `json:"key_description,omitempty"`
 	}
 
 	// buildEntry creates a serviceEntry from an adapter, using MetadataProvider when available.
 	buildEntry := func(a adapters.Adapter) serviceEntry {
 		name := display.ServiceName(a.ServiceID())
 		desc := display.ServiceDescription(a.ServiceID())
-		var setupURL, oauthEndpoint, iconSVG, iconURL, keyHint string
+		var setupURL, oauthEndpoint, iconSVG, iconURL, keyHint, keyDisplayName, keyDescription string
 		var variables []adapters.VariableMeta
 		actionNames := map[string]adapters.ActionMeta{}
 
@@ -251,6 +253,8 @@ func (h *ServicesHandler) List(w http.ResponseWriter, r *http.Request) {
 			iconURL = meta.IconURL
 			oauthEndpoint = meta.OAuthEndpoint
 			keyHint = meta.KeyHint
+			keyDisplayName = meta.KeyDisplayName
+			keyDescription = meta.KeyDescription
 			actionNames = meta.ActionMeta
 			variables = meta.Variables
 		}
@@ -301,6 +305,8 @@ func (h *ServicesHandler) List(w http.ResponseWriter, r *http.Request) {
 			Variables:            variables,
 			SetupURL:             setupURL,
 			KeyHint:              keyHint,
+			KeyDisplayName:       keyDisplayName,
+			KeyDescription:       keyDescription,
 		}
 	}
 
@@ -922,11 +928,25 @@ func (h *ServicesHandler) ActivateWithKey(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// Build and validate the credential bytes.
-	credBytes, err := json.Marshal(map[string]string{"type": "api_key", "token": body.Token})
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to encode credential")
-		return
+	// Build and validate the credential bytes. Adapters that need a structured
+	// credential (e.g. SQL: {driver, dsn}) can opt into APIKeyCredentialBuilder
+	// to convert the pasted string into their preferred shape.
+	var (
+		credBytes []byte
+		err       error
+	)
+	if b, ok := adapter.(adapters.APIKeyCredentialBuilder); ok {
+		credBytes, err = b.CredentialFromAPIKey(body.Token)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "INVALID_CREDENTIAL", err.Error())
+			return
+		}
+	} else {
+		credBytes, err = json.Marshal(map[string]string{"type": "api_key", "token": body.Token})
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to encode credential")
+			return
+		}
 	}
 	if err := adapter.ValidateCredential(credBytes); err != nil {
 		writeError(w, http.StatusBadRequest, "INVALID_CREDENTIAL", err.Error())

--- a/pkg/adapters/adapters.go
+++ b/pkg/adapters/adapters.go
@@ -23,7 +23,9 @@ type ServiceMetadata struct {
 	DisplayName       string
 	Description       string
 	SetupURL          string
-	KeyHint           string
+	KeyHint           string // placeholder text for the credential input
+	KeyDisplayName    string // label rendered above the credential input (e.g. "Connection string")
+	KeyDescription    string // helper text shown under the label; supports newlines
 	IconSVG           string                // inline SVG markup for the service icon (mutually exclusive with IconURL)
 	IconURL           string                // absolute or site-relative URL to the service icon (e.g. "/logos/github.svg")
 	VaultKey          string                // shared vault key (e.g. "google" for all google.* services); empty = use service ID
@@ -151,6 +153,18 @@ type AvailabilityChecker interface {
 // If CheckPermissions returns an error, the activation is rejected with that message.
 type ActivationChecker interface {
 	CheckPermissions() error
+}
+
+// APIKeyCredentialBuilder is an optional interface adapters can implement to
+// transform a single pasted string from the API-key activation flow into the
+// adapter's preferred credential JSON. Adapters that need a structured
+// credential (e.g. the SQL adapter, which expects {driver, dsn}) implement this
+// to keep the single-input UX while emitting the right vault payload. When not
+// implemented, the activation handler stores the default {"type":"api_key","token":...} envelope.
+type APIKeyCredentialBuilder interface {
+	// CredentialFromAPIKey converts a user-supplied string (e.g. a connection
+	// string) into the credential bytes that ValidateCredential will accept.
+	CredentialFromAPIKey(token string) ([]byte, error)
 }
 
 // VerificationHinter is an optional interface adapters can implement to provide

--- a/pkg/adapters/yamldef/schema.go
+++ b/pkg/adapters/yamldef/schema.go
@@ -25,8 +25,10 @@ type ServiceInfo struct {
 	ID          string       `yaml:"id"`
 	DisplayName string       `yaml:"display_name"`
 	Description string       `yaml:"description"`
-	SetupURL    string       `yaml:"setup_url,omitempty"`
-	KeyHint     string       `yaml:"key_hint,omitempty"`
+	SetupURL       string `yaml:"setup_url,omitempty"`
+	KeyHint        string `yaml:"key_hint,omitempty"`         // placeholder text inside the credential input
+	KeyDisplayName string `yaml:"key_display_name,omitempty"` // label rendered above the credential input
+	KeyDescription string `yaml:"key_description,omitempty"`  // helper text under the label; newlines preserved
 	IconSVG     string       `yaml:"icon_svg,omitempty"` // optional: inline SVG markup (mutually exclusive with icon_url)
 	IconURL     string       `yaml:"icon_url,omitempty"` // optional: absolute or site-relative URL to the icon (e.g. "/logos/github.svg")
 	Identity    *IdentityDef `yaml:"identity,omitempty"`

--- a/pkg/adapters/yamlruntime/adapter.go
+++ b/pkg/adapters/yamlruntime/adapter.go
@@ -572,6 +572,8 @@ func (a *YAMLAdapter) ServiceMetadata() adapters.ServiceMetadata {
 		Description:       a.def.Service.Description,
 		SetupURL:          a.def.Service.SetupURL,
 		KeyHint:           a.def.Service.KeyHint,
+		KeyDisplayName:    a.def.Service.KeyDisplayName,
+		KeyDescription:    a.def.Service.KeyDescription,
 		IconSVG:           a.def.Service.IconSVG,
 		IconURL:           a.def.Service.IconURL,
 		VaultKey:          vaultKey,

--- a/skills/clawvisor-generate-integration.md
+++ b/skills/clawvisor-generate-integration.md
@@ -37,6 +37,7 @@ From the API reference, extract:
 - If the API uses API keys or Bearer tokens, use `type: api_key`
 - Include `setup_url` pointing to the API key creation page or OAuth app setup page
 - Include `key_hint` with a short description of the expected token format (e.g. `"Acme API key (ak_...)"`) — this is shown as placeholder text in the key input field
+- For richer prompts, also set `key_display_name` (a label rendered above the input, e.g. `"API key"`) and `key_description` (multi-line helper text under the label, e.g. format examples or where to find the value). Both are optional; use them when the placeholder isn't enough context.
 
 ### Step 4: Generate the YAML
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -303,6 +303,8 @@ export interface ServiceInfo {
   activated_at?: string
   setup_url?: string
   key_hint?: string
+  key_display_name?: string
+  key_description?: string
 }
 
 export interface VariableMeta {

--- a/web/src/pages/Services.tsx
+++ b/web/src/pages/Services.tsx
@@ -490,23 +490,34 @@ function ActiveServiceRow({ svc }: { svc: ServiceInfo }) {
       )}
 
       {showKeyInput && (
-        <div className="flex gap-2 px-5 pb-4 ml-16">
-          <input
-            type="password"
-            value={apiKeyInput}
-            onChange={e => setApiKeyInput(e.target.value)}
-            onKeyDown={e => e.key === 'Enter' && handleSaveKey()}
-            placeholder={svc.key_hint || "Paste your token…"}
-            className="flex-1 text-xs px-2 py-1.5 border border-border-default bg-surface-0 text-text-primary rounded focus:outline-none focus:ring-1 focus:ring-brand/30 focus:border-brand placeholder:text-text-tertiary"
-            autoFocus
-          />
-          <button
-            onClick={handleSaveKey}
-            disabled={saving || !apiKeyInput.trim()}
-            className="text-xs px-3 py-1.5 rounded bg-brand text-surface-0 hover:bg-brand-strong disabled:opacity-50"
-          >
-            {saving ? 'Saving…' : 'Save'}
-          </button>
+        <div className="px-5 pb-4 ml-16 space-y-1.5">
+          {svc.key_display_name && (
+            <label className="block text-xs text-text-secondary">
+              {svc.key_display_name}
+              <span className="text-danger ml-0.5">*</span>
+            </label>
+          )}
+          {svc.key_description && (
+            <p className="text-[10px] text-text-tertiary whitespace-pre-line">{svc.key_description}</p>
+          )}
+          <div className="flex gap-2">
+            <input
+              type="password"
+              value={apiKeyInput}
+              onChange={e => setApiKeyInput(e.target.value)}
+              onKeyDown={e => e.key === 'Enter' && handleSaveKey()}
+              placeholder={svc.key_hint || "Paste your token…"}
+              className="flex-1 text-xs px-2 py-1.5 border border-border-default bg-surface-0 text-text-primary rounded focus:outline-none focus:ring-1 focus:ring-brand/30 focus:border-brand placeholder:text-text-tertiary"
+              autoFocus
+            />
+            <button
+              onClick={handleSaveKey}
+              disabled={saving || !apiKeyInput.trim()}
+              className="text-xs px-3 py-1.5 rounded bg-brand text-surface-0 hover:bg-brand-strong disabled:opacity-50"
+            >
+              {saving ? 'Saving…' : 'Save'}
+            </button>
+          </div>
         </div>
       )}
     </div>
@@ -532,6 +543,8 @@ interface ServiceType {
   description: string
   setupUrl?: string
   keyHint?: string
+  keyDisplayName?: string
+  keyDescription?: string
 }
 
 function AddServiceModal({
@@ -635,6 +648,8 @@ function AddServiceModal({
         description: svc.description || serviceDescription(svc.id),
         setupUrl: svc.setup_url,
         keyHint: svc.key_hint,
+        keyDisplayName: svc.key_display_name,
+        keyDescription: svc.key_description,
       })
     }
   }
@@ -992,15 +1007,26 @@ function AddServiceModal({
                             />
                           </div>
                         ))}
-                        <input
-                          type="password"
-                          value={keyValue}
-                          onChange={e => setKeyValue(e.target.value)}
-                          onKeyDown={e => e.key === 'Enter' && handleSaveKey()}
-                          placeholder={st.keyHint || "Paste your token…"}
-                          className="w-full text-xs px-2.5 py-1.5 border border-border-default bg-surface-0 text-text-primary rounded-lg focus:outline-none focus:ring-1 focus:ring-brand/30 focus:border-brand placeholder:text-text-tertiary"
-                          autoFocus={!st.variables || st.variables.length === 0}
-                        />
+                        <div>
+                          {st.keyDisplayName && (
+                            <label className="block text-xs text-text-secondary mb-0.5">
+                              {st.keyDisplayName}
+                              <span className="text-danger ml-0.5">*</span>
+                            </label>
+                          )}
+                          {st.keyDescription && (
+                            <p className="text-[10px] text-text-tertiary mb-1 whitespace-pre-line">{st.keyDescription}</p>
+                          )}
+                          <input
+                            type="password"
+                            value={keyValue}
+                            onChange={e => setKeyValue(e.target.value)}
+                            onKeyDown={e => e.key === 'Enter' && handleSaveKey()}
+                            placeholder={st.keyHint || "Paste your token…"}
+                            className="w-full text-xs px-2.5 py-1.5 border border-border-default bg-surface-0 text-text-primary rounded-lg focus:outline-none focus:ring-1 focus:ring-brand/30 focus:border-brand placeholder:text-text-tertiary"
+                            autoFocus={!st.variables || st.variables.length === 0}
+                          />
+                        </div>
                         <div className="flex gap-2">
                           <button
                             onClick={handleSaveKey}


### PR DESCRIPTION
## Summary

- Connecting the SQL service via the API-key flow never produced a valid credential — the adapter expects `{driver, dsn}` JSON, but the activation handler always wrapped pasted input as `{type, token}`. New optional `APIKeyCredentialBuilder` interface lets adapters convert a single pasted string into their preferred credential JSON; the SQL adapter sniffs the URI scheme (`postgres://`, `sqlite:`, MySQL `@tcp(...)` DSN) and emits the right envelope.
- `ServiceMetadata` gains `KeyDisplayName` and `KeyDescription`, plumbed through the YAML schema, API, and `Services.tsx` so the credential input renders a labeled, multi-line helper above the password field — same visual pattern Twilio's `account_sid` variable already uses. The SQL adapter ships those strings with the supported connection-string formats; YAML adapters can opt in via `key_display_name` / `key_description`.

## Test plan

- [x] `go test ./internal/adapters/sql/...` — new `TestCredentialFromAPIKey` covers postgres / sqlite / mysql / passthrough JSON / rejection of `mysql://` URIs
- [x] `go test ./internal/api/handlers/...` and `./pkg/adapters/...` pass
- [x] `npx tsc --noEmit` (frontend types)
- [x] Verified end-to-end against `~/.clawvisor/clawvisor.db`: `sqlite:` prefix → `list_tables` → `describe_table` → `SELECT *` all returned data
- [ ] Click through the Services modal and confirm the SQL connect prompt now shows "Connection string" + the format examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)