### PR TITLE
feat(llm): per-sub-block timeout + opt-in request hedging

### DIFF
--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -81,6 +81,7 @@ type Client struct {
 	tokenSource       oauth2.TokenSource // for Vertex AI (ADC)
 	maxTokens         int                // 0 → use default (maxTokens const)
 	fallbackEndpoints []string           // Vertex AI: additional region endpoints to try on failure
+	hedgeDelay        time.Duration      // 0 → no hedge; otherwise fire a second request after this delay
 
 	// Gemini-specific settings.
 	geminiThinkingLevel string       // "MINIMAL" | "LOW" | "MEDIUM" | "HIGH"; "" → MINIMAL
@@ -105,6 +106,15 @@ func (c *Client) WithFallbackEndpoints(endpoints []string) *Client {
 func (c *Client) WithTokenSource(ts oauth2.TokenSource) *Client {
 	c2 := *c
 	c2.tokenSource = ts
+	return &c2
+}
+
+// WithHedgeDelay returns a shallow copy with the given hedge delay. Pass 0
+// to disable hedging. Used by tests; production wiring reads HedgeDelayMS
+// from LLMProviderConfig in NewClient.
+func (c *Client) WithHedgeDelay(d time.Duration) *Client {
+	c2 := *c
+	c2.hedgeDelay = d
 	return &c2
 }
 
@@ -144,12 +154,13 @@ func NewClient(cfg config.LLMProviderConfig) *Client {
 	}
 
 	c := &Client{
-		provider: provider,
-		endpoint: strings.TrimRight(cfg.Endpoint, "/"),
-		apiKey:   cfg.APIKey,
-		model:    cfg.Model,
-		timeout:  timeout,
-		http:     &http.Client{Timeout: timeout + 2*time.Second},
+		provider:   provider,
+		endpoint:   strings.TrimRight(cfg.Endpoint, "/"),
+		apiKey:     cfg.APIKey,
+		model:      cfg.Model,
+		timeout:    timeout,
+		http:       &http.Client{Timeout: timeout + 2*time.Second},
+		hedgeDelay: time.Duration(cfg.HedgeDelayMS) * time.Millisecond,
 	}
 
 	if provider == "vertex" {
@@ -244,6 +255,15 @@ func (c *Client) Complete(ctx context.Context, messages []ChatMessage) (string, 
 
 // CompleteWithUsage is like Complete but also returns provider usage info.
 func (c *Client) CompleteWithUsage(ctx context.Context, messages []ChatMessage) (string, *Usage, error) {
+	if c.hedgeDelay <= 0 {
+		return c.completeOnce(ctx, messages)
+	}
+	return c.completeWithHedge(ctx, messages)
+}
+
+// completeOnce dispatches a single request to the configured provider.
+// Wrapped by completeWithHedge when hedgeDelay > 0.
+func (c *Client) completeOnce(ctx context.Context, messages []ChatMessage) (string, *Usage, error) {
 	switch c.provider {
 	case "anthropic":
 		return c.completeAnthropic(ctx, messages)
@@ -254,6 +274,73 @@ func (c *Client) CompleteWithUsage(ctx context.Context, messages []ChatMessage) 
 	default:
 		return c.completeOpenAI(ctx, messages) // "openai", "ollama", "groq" use OpenAI-compatible API
 	}
+}
+
+// completeWithHedge fires a primary request and, if it hasn't returned
+// after hedgeDelay, fires a second (hedge) request. Whichever succeeds
+// first wins; the loser's context is cancelled.
+//
+// If the primary fails before the hedge fires, the error surfaces directly
+// — no point hedging against a deterministic failure (auth error, bad
+// model name, etc.). If both fail after racing, returns the most recent
+// error.
+func (c *Client) completeWithHedge(ctx context.Context, messages []ChatMessage) (string, *Usage, error) {
+	type result struct {
+		text  string
+		usage *Usage
+		err   error
+	}
+
+	primaryCtx, cancelPrimary := context.WithCancel(ctx)
+	defer cancelPrimary()
+	primaryCh := make(chan result, 1)
+	go func() {
+		text, usage, err := c.completeOnce(primaryCtx, messages)
+		primaryCh <- result{text, usage, err}
+	}()
+
+	timer := time.NewTimer(c.hedgeDelay)
+	defer timer.Stop()
+
+	select {
+	case r := <-primaryCh:
+		// Primary returned (success or failure) before hedge fired.
+		return r.text, r.usage, r.err
+	case <-ctx.Done():
+		return "", nil, ctx.Err()
+	case <-timer.C:
+		// Primary slow — fire hedge below.
+	}
+
+	hedgeCtx, cancelHedge := context.WithCancel(ctx)
+	defer cancelHedge()
+	hedgeCh := make(chan result, 1)
+	go func() {
+		text, usage, err := c.completeOnce(hedgeCtx, messages)
+		hedgeCh <- result{text, usage, err}
+	}()
+
+	// Race the two. First success wins; if one fails, wait for the other.
+	var lastErr error
+	for i := 0; i < 2; i++ {
+		select {
+		case r := <-primaryCh:
+			if r.err == nil {
+				cancelHedge()
+				return r.text, r.usage, nil
+			}
+			lastErr = r.err
+		case r := <-hedgeCh:
+			if r.err == nil {
+				cancelPrimary()
+				return r.text, r.usage, nil
+			}
+			lastErr = r.err
+		case <-ctx.Done():
+			return "", nil, ctx.Err()
+		}
+	}
+	return "", nil, lastErr
 }
 
 // ── OpenAI ────────────────────────────────────────────────────────────────────

--- a/internal/llm/gemini_test.go
+++ b/internal/llm/gemini_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -297,6 +298,131 @@ func TestClient_Gemini_NewClient_GlobalRegionUsesUnprefixedHost(t *testing.T) {
 	want := "https://aiplatform.googleapis.com/v1/projects/my-project/locations/global/publishers/google/models/gemini-3.1-flash-lite-preview:generateContent"
 	if got != want {
 		t.Errorf("global endpoint:\n  got:  %s\n  want: %s", got, want)
+	}
+}
+
+func TestClient_Hedge_FastPrimary_NoHedgeFires(t *testing.T) {
+	// When the primary returns within hedgeDelay, no hedge is fired and
+	// the server sees exactly one request.
+	var calls int32
+	_, cfg := newGeminiServer(t, func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(geminiResponse("primary", 0))
+	})
+	client := llm.NewClient(cfg).
+		WithTokenSource(staticToken{}).
+		WithHedgeDelay(500 * time.Millisecond)
+
+	got, err := client.Complete(context.Background(), []llm.ChatMessage{
+		{Role: "system", Content: "s"},
+		{Role: "user", Content: "u"},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if got != "primary" {
+		t.Errorf("got %q, want primary", got)
+	}
+	// Brief sleep so any erroneously-fired hedge would have time to land.
+	time.Sleep(50 * time.Millisecond)
+	if c := atomic.LoadInt32(&calls); c != 1 {
+		t.Errorf("expected 1 server call (no hedge), got %d", c)
+	}
+}
+
+func TestClient_Hedge_SlowPrimary_HedgeWins(t *testing.T) {
+	// Primary stalls past hedgeDelay → hedge fires and returns first.
+	var calls int32
+	_, cfg := newGeminiServer(t, func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		if n == 1 {
+			// Primary: stall well past hedgeDelay so the hedge wins.
+			// httptest doesn't reliably propagate client-side cancellation
+			// to r.Context(), so cap with a short fallback timer.
+			select {
+			case <-r.Context().Done():
+			case <-time.After(300 * time.Millisecond):
+			}
+			return
+		}
+		// Hedge: return immediately.
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(geminiResponse("hedge", 0))
+	})
+	client := llm.NewClient(cfg).
+		WithTokenSource(staticToken{}).
+		WithHedgeDelay(50 * time.Millisecond)
+
+	got, err := client.Complete(context.Background(), []llm.ChatMessage{
+		{Role: "system", Content: "s"},
+		{Role: "user", Content: "u"},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if got != "hedge" {
+		t.Errorf("got %q, want hedge", got)
+	}
+	if c := atomic.LoadInt32(&calls); c != 2 {
+		t.Errorf("expected 2 server calls, got %d", c)
+	}
+}
+
+func TestClient_Hedge_PrimaryFailsFast_NoHedge(t *testing.T) {
+	// Primary returns an error before hedgeDelay elapses. Hedge should NOT
+	// fire — there's no point hedging against a deterministic failure.
+	var calls int32
+	_, cfg := newGeminiServer(t, func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{"error":"boom"}`))
+	})
+	client := llm.NewClient(cfg).
+		WithTokenSource(staticToken{}).
+		WithHedgeDelay(500 * time.Millisecond)
+
+	_, err := client.Complete(context.Background(), []llm.ChatMessage{
+		{Role: "system", Content: "s"},
+		{Role: "user", Content: "u"},
+	})
+	if err == nil {
+		t.Fatal("expected error from 500 response")
+	}
+	time.Sleep(50 * time.Millisecond)
+	if c := atomic.LoadInt32(&calls); c != 1 {
+		t.Errorf("expected 1 server call (no hedge after fast failure), got %d", c)
+	}
+}
+
+func TestClient_Hedge_BothFail_ReturnsError(t *testing.T) {
+	// Primary stalls past hedgeDelay then fails; hedge also fails.
+	// Caller should see an error (not a hang).
+	var calls int32
+	_, cfg := newGeminiServer(t, func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		if n == 1 {
+			// Stall just long enough to let hedge fire, then return 500.
+			time.Sleep(100 * time.Millisecond)
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{"error":"boom"}`))
+	})
+	client := llm.NewClient(cfg).
+		WithTokenSource(staticToken{}).
+		WithHedgeDelay(50 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := client.Complete(ctx, []llm.ChatMessage{
+		{Role: "system", Content: "s"},
+		{Role: "user", Content: "u"},
+	})
+	if err == nil {
+		t.Fatal("expected error when both primary and hedge fail")
+	}
+	if c := atomic.LoadInt32(&calls); c != 2 {
+		t.Errorf("expected 2 server calls, got %d", c)
 	}
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -165,6 +165,15 @@ type LLMProviderConfig struct {
 	// Gemini-only knobs.
 	GeminiThinkingLevel string             `yaml:"gemini_thinking_level,omitempty"` // MINIMAL | LOW | MEDIUM | HIGH; default MINIMAL
 	GeminiCache         *GeminiCacheConfig `yaml:"gemini_cache,omitempty"`
+
+	// HedgeDelayMS, if > 0, fires a second (hedge) request after the primary
+	// has been outstanding for this many milliseconds without returning.
+	// Whichever completes successfully first wins; the loser's context is
+	// cancelled. Trades ~tail-rate × 2 LLM spend for tighter p99 — best
+	// applied to hot, latency-critical paths (intent verification) and not
+	// to one-shot calls like adapter generation. Per-sub-block; not
+	// inherited from the top-level llm: block.
+	HedgeDelayMS int `yaml:"hedge_delay_ms,omitempty"`
 }
 
 // GeminiCacheConfig configures the explicit context cache lifecycle for a
@@ -529,6 +538,16 @@ func Load(path string) (*Config, error) {
 	if v := os.Getenv("CLAWVISOR_LLM_VERIFICATION_FAIL_CLOSED"); v != "" {
 		cfg.LLM.Verification.FailClosed = v == "true" || v == "1"
 	}
+	if v := os.Getenv("CLAWVISOR_LLM_VERIFICATION_TIMEOUT_SECONDS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.LLM.Verification.TimeoutSeconds = n
+		}
+	}
+	if v := os.Getenv("CLAWVISOR_LLM_VERIFICATION_HEDGE_DELAY_MS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.LLM.Verification.HedgeDelayMS = n
+		}
+	}
 	if v := os.Getenv("CLAWVISOR_LLM_VERIFICATION_GEMINI_CACHE_ENABLED"); v != "" {
 		ensureGeminiCache(&cfg.LLM.Verification.GeminiCache).Enabled = v == "true" || v == "1"
 	}
@@ -556,6 +575,16 @@ func Load(path string) (*Config, error) {
 	if v := os.Getenv("CLAWVISOR_LLM_TASK_RISK_MODEL"); v != "" {
 		cfg.LLM.TaskRisk.Model = v
 	}
+	if v := os.Getenv("CLAWVISOR_LLM_TASK_RISK_TIMEOUT_SECONDS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.LLM.TaskRisk.TimeoutSeconds = n
+		}
+	}
+	if v := os.Getenv("CLAWVISOR_LLM_TASK_RISK_HEDGE_DELAY_MS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.LLM.TaskRisk.HedgeDelayMS = n
+		}
+	}
 
 	if v := os.Getenv("CLAWVISOR_LLM_CHAIN_CONTEXT_ENABLED"); v != "" {
 		cfg.LLM.ChainContext.Enabled = v == "true" || v == "1"
@@ -571,6 +600,16 @@ func Load(path string) (*Config, error) {
 	}
 	if v := os.Getenv("CLAWVISOR_LLM_CHAIN_CONTEXT_MODEL"); v != "" {
 		cfg.LLM.ChainContext.Model = v
+	}
+	if v := os.Getenv("CLAWVISOR_LLM_CHAIN_CONTEXT_TIMEOUT_SECONDS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.LLM.ChainContext.TimeoutSeconds = n
+		}
+	}
+	if v := os.Getenv("CLAWVISOR_LLM_CHAIN_CONTEXT_HEDGE_DELAY_MS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.LLM.ChainContext.HedgeDelayMS = n
+		}
 	}
 	if v := os.Getenv("CLAWVISOR_LLM_CHAIN_CONTEXT_GEMINI_CACHE_ENABLED"); v != "" {
 		ensureGeminiCache(&cfg.LLM.ChainContext.GeminiCache).Enabled = v == "true" || v == "1"
@@ -599,6 +638,16 @@ func Load(path string) (*Config, error) {
 	if v := os.Getenv("CLAWVISOR_LLM_ADAPTER_GEN_MODEL"); v != "" {
 		cfg.LLM.AdapterGen.Model = v
 	}
+	if v := os.Getenv("CLAWVISOR_LLM_ADAPTER_GEN_TIMEOUT_SECONDS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.LLM.AdapterGen.TimeoutSeconds = n
+		}
+	}
+	if v := os.Getenv("CLAWVISOR_LLM_ADAPTER_GEN_HEDGE_DELAY_MS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.LLM.AdapterGen.HedgeDelayMS = n
+		}
+	}
 
 	if v := os.Getenv("CLAWVISOR_LLM_FEEDBACK_REVIEW_ENABLED"); v != "" {
 		cfg.LLM.FeedbackReview.Enabled = v == "true" || v == "1"
@@ -614,6 +663,16 @@ func Load(path string) (*Config, error) {
 	}
 	if v := os.Getenv("CLAWVISOR_LLM_FEEDBACK_REVIEW_MODEL"); v != "" {
 		cfg.LLM.FeedbackReview.Model = v
+	}
+	if v := os.Getenv("CLAWVISOR_LLM_FEEDBACK_REVIEW_TIMEOUT_SECONDS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.LLM.FeedbackReview.TimeoutSeconds = n
+		}
+	}
+	if v := os.Getenv("CLAWVISOR_LLM_FEEDBACK_REVIEW_HEDGE_DELAY_MS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.LLM.FeedbackReview.HedgeDelayMS = n
+		}
 	}
 
 	if v := os.Getenv("CLAWVISOR_NPS_SAMPLE_PERCENT"); v != "" {


### PR DESCRIPTION
## Summary

- Add `HedgeDelayMS` to `LLMProviderConfig` and a hedge wrapper in `llm.Client.CompleteWithUsage`. When configured, fires a second request after the primary has been outstanding for the configured delay; whichever succeeds first wins, the loser's context is cancelled.
- Add per-sub-block `..._TIMEOUT_SECONDS` env vars (verification, task_risk, chain_context, adapter_gen, feedback_review) so the latency-critical verifier can run on a tight timeout while the extractor keeps a higher ceiling for its longer 8192-token responses.
- Add per-sub-block `..._HEDGE_DELAY_MS` env vars. Hedge is opt-in per sub-block (no top-level inheritance) since it generalizes poorly across paths.

## Why

Gemini Flash-Lite p95 is ~1.2s on the verifier hot path. With the previous shared 10s timeout and a single retry, stragglers waited ~17s before failing. Recommended production tuning (`VERIFICATION_TIMEOUT_SECONDS=3`, `VERIFICATION_HEDGE_DELAY_MS=2000`) cuts verifier p99 to ~3-5s for ~5% extra LLM spend on slow requests.

## Hedge behavior

| Scenario | Result |
|---|---|
| Primary returns inside hedgeDelay | No hedge fired |
| Primary fails fast (auth error, bad model) | Hedge NOT fired — no point hedging deterministic failures |
| Primary slow | Hedge fires; first success wins; loser cancelled |
| Both fail | Returns last error |

## Test plan

- [x] `go test ./internal/llm/... ./pkg/config/...` — all green
- [x] Unit tests for all 4 hedge scenarios above (`TestClient_Hedge_*`)
- [x] `go vet ./...` clean
- [ ] Set staging env vars (`CLAWVISOR_LLM_VERIFICATION_TIMEOUT_SECONDS=3`, `CLAWVISOR_LLM_VERIFICATION_HEDGE_DELAY_MS=2000`); confirm verifier p99 drops in real traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)