### PR TITLE
feat(imessage): pin helper SHA in source so go install can install it

### DIFF
--- a/.github/workflows/release-imessage-helper.yml
+++ b/.github/workflows/release-imessage-helper.yml
@@ -1,0 +1,177 @@
+name: Release iMessage Helper
+
+# Builds and releases the iMessage helper, and opens a PR updating the
+# source-pinned tag + SHAs in pkg/version/imessage_helper.go.
+#
+# Manual trigger only — every helper release forces all users to re-grant
+# Full Disk Access, so we want a human gate. The job additionally short-
+# circuits when the helper's ProtocolVersion hasn't changed since the
+# currently-pinned tag, unless `force` is set.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Helper release tag (e.g. v0.10.0)"
+        required: true
+      force:
+        description: "Build even if ProtocolVersion is unchanged"
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  protocol-check:
+    runs-on: ubuntu-latest
+    outputs:
+      should_build: ${{ steps.check.outputs.should_build }}
+      reason: ${{ steps.check.outputs.reason }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Compare ProtocolVersion against pinned tag
+        id: check
+        env:
+          FORCE: ${{ inputs.force }}
+        run: |
+          set -eu
+          PINNED_TAG=$(grep '^const IMessageHelperReleaseTag' pkg/version/imessage_helper.go | cut -d'"' -f2)
+          CURRENT_PV=$(grep '^const ProtocolVersion' cmd/imessage-helper/main.go | cut -d'"' -f2)
+
+          if ! git rev-parse --verify "refs/tags/${PINNED_TAG}" >/dev/null 2>&1; then
+            echo "Pinned tag ${PINNED_TAG} not found locally — proceeding (treating as changed)"
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+            echo "reason=pinned tag ${PINNED_TAG} not in repo history" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          PINNED_PV=$(git show "${PINNED_TAG}:cmd/imessage-helper/main.go" | grep '^const ProtocolVersion' | cut -d'"' -f2)
+          echo "Current ProtocolVersion: ${CURRENT_PV}"
+          echo "Pinned (${PINNED_TAG}) ProtocolVersion: ${PINNED_PV}"
+
+          if [ "$CURRENT_PV" != "$PINNED_PV" ]; then
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+            echo "reason=ProtocolVersion ${PINNED_PV} → ${CURRENT_PV}" >> "$GITHUB_OUTPUT"
+          elif [ "$FORCE" = "true" ]; then
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+            echo "reason=force=true (ProtocolVersion unchanged at ${CURRENT_PV})" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_build=false" >> "$GITHUB_OUTPUT"
+            echo "reason=ProtocolVersion unchanged at ${CURRENT_PV}; pass force=true to override" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Summary
+        run: |
+          echo "should_build = ${{ steps.check.outputs.should_build }}"
+          echo "reason       = ${{ steps.check.outputs.reason }}"
+
+  build-and-release:
+    needs: protocol-check
+    if: needs.protocol-check.outputs.should_build == 'true'
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      # Helper builds are not bit-reproducible (Mach-O timestamps + build IDs),
+      # so re-running this workflow against a tag that already has helper
+      # assets would silently rewrite their bytes and SHAs — invalidating any
+      # clawvisor binary already in the wild that pinned the old SHA. Refuse
+      # before we even build, and recover via "delete-and-redo" rather than
+      # clobber-in-place.
+      - name: Refuse if helper assets already exist on tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -eu
+          if ! gh release view "$TAG" > /dev/null 2>&1; then
+            echo "Release ${TAG} does not exist yet — will be created."
+            exit 0
+          fi
+          EXISTING=$(gh release view "$TAG" --json assets --jq '.assets[].name' \
+            | grep '^clawvisor-imessage-helper-.*\.tar\.gz$' || true)
+          if [ -n "$EXISTING" ]; then
+            echo "::error::Release ${TAG} already has helper assets attached:"
+            echo "$EXISTING" | sed 's/^/  - /'
+            echo "::error::Refusing to overwrite — clawvisor builds in the wild may pin the existing SHAs."
+            echo "To redo this release: delete the assets (gh release delete-asset ${TAG} <name>) or pick a new tag, then re-run."
+            exit 1
+          fi
+          echo "Release ${TAG} exists but has no helper assets — safe to upload."
+
+      - name: Build helper tarballs and rewrite pin
+        run: scripts/release-imessage-helper.sh "${{ inputs.tag }}"
+
+      - name: Create GitHub release if it does not exist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -eu
+          if ! gh release view "${{ inputs.tag }}" > /dev/null 2>&1; then
+            prerelease_flag=""
+            case "${{ inputs.tag }}" in
+              *-*) prerelease_flag="--prerelease" ;;
+            esac
+            gh release create "${{ inputs.tag }}" \
+              --title "${{ inputs.tag }} (iMessage helper)" \
+              --notes "iMessage helper release. Pinned in \`pkg/version/imessage_helper.go\`. Reason: ${{ needs.protocol-check.outputs.reason }}" \
+              $prerelease_flag
+          fi
+
+      - name: Upload helper tarballs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ inputs.tag }}" dist/clawvisor-imessage-helper-*.tar.gz
+
+      - name: Open PR with pin rewrite
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+          REASON: ${{ needs.protocol-check.outputs.reason }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -eu
+          BRANCH="release/imessage-helper-${TAG}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add pkg/version/imessage_helper.go
+
+          COMMIT_MSG=$(printf 'chore(imessage): pin helper to %s\n\n%s\n' "$TAG" "$REASON")
+          git commit -m "$COMMIT_MSG"
+          git push -u origin "$BRANCH"
+
+          PR_BODY=$(cat <<EOF
+          Pins the iMessage helper to [\`${TAG}\`](https://github.com/${REPO}/releases/tag/${TAG}), whose tarballs were just uploaded by the \`Release iMessage Helper\` workflow.
+
+          **Reason:** ${REASON}
+
+          Merging this PR makes \`go install\`, source builds, and future clawvisor releases fetch and verify the new helper. Users will need to re-grant Full Disk Access on next iMessage use.
+          EOF
+          )
+          gh pr create \
+            --title "chore(imessage): pin helper to ${TAG}" \
+            --body "$PR_BODY" \
+            --base main \
+            --head "$BRANCH"
+
+  skipped:
+    needs: protocol-check
+    if: needs.protocol-check.outputs.should_build != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip notice
+        run: |
+          echo "Skipping helper release: ${{ needs.protocol-check.outputs.reason }}"
+          echo "Re-run with force=true to build anyway."

--- a/internal/adapters/apple/imessage/adapter.go
+++ b/internal/adapters/apple/imessage/adapter.go
@@ -300,19 +300,18 @@ func (a *IMessageAdapter) queryHelperVersion(helperPath string) (string, error) 
 	return resp.Data.ProtocolVersion, nil
 }
 
-// downloadHelper downloads the helper .app bundle from the GitHub release
-// matching the current clawvisor version. The tarball is verified against
-// the SHA-256 baked into this clawvisor binary at build time before any
-// bytes are extracted or executed — protecting against tampered or
-// substituted release artifacts.
+// downloadHelper downloads the helper .app bundle from the pinned GitHub
+// release. The tarball is verified against the SHA-256 pinned in source
+// (pkg/version.IMessageHelperSHAs) before any bytes are extracted or
+// executed — protecting against tampered or substituted release artifacts.
 func (a *IMessageAdapter) downloadHelper(installDir string) (string, error) {
 	osArch := runtime.GOOS + "/" + runtime.GOARCH
 	expectedSHA := version.IMessageHelperSHA(osArch)
 	if expectedSHA == "" {
-		return "", fmt.Errorf("no pinned helper SHA for %s in this build — refusing unverified download (build a release binary or side-load the helper into PATH)", osArch)
+		return "", fmt.Errorf("no pinned helper SHA for %s — iMessage helper is only published for darwin/arm64 and darwin/amd64", osArch)
 	}
 
-	tag := "v" + version.Version
+	tag := version.IMessageHelperReleaseTag
 	assetName := fmt.Sprintf("clawvisor-imessage-helper-%s-%s.tar.gz", runtime.GOOS, runtime.GOARCH)
 	url := fmt.Sprintf("https://github.com/%s/%s/releases/download/%s/%s",
 		githubOwner, githubRepo, tag, assetName)

--- a/internal/adapters/apple/imessage/adapter_test.go
+++ b/internal/adapters/apple/imessage/adapter_test.go
@@ -62,14 +62,14 @@ func TestFindHelper_CachedPath(t *testing.T) {
 	}
 }
 
-// TestDownloadHelper_RefusesWithoutPinnedSHA proves that a clawvisor binary
-// without an embedded helper SHA (i.e. a dev build) refuses to download
-// before it ever opens a network connection. This is the regression guard
-// against running an unverified helper as the user.
+// TestDownloadHelper_RefusesWithoutPinnedSHA proves that downloads for
+// platforms without a pinned helper SHA are refused before any network
+// connection is opened. This is the regression guard against running an
+// unverified helper as the user.
 func TestDownloadHelper_RefusesWithoutPinnedSHA(t *testing.T) {
-	prev := version.IMessageHelperSHA256
-	version.IMessageHelperSHA256 = ""
-	t.Cleanup(func() { version.IMessageHelperSHA256 = prev })
+	prev := version.IMessageHelperSHAs
+	version.IMessageHelperSHAs = map[string]string{}
+	t.Cleanup(func() { version.IMessageHelperSHAs = prev })
 
 	a := &IMessageAdapter{}
 	_, err := a.downloadHelper(t.TempDir())
@@ -81,11 +81,14 @@ func TestDownloadHelper_RefusesWithoutPinnedSHA(t *testing.T) {
 	}
 }
 
-func TestIMessageHelperSHA_ParsesEmbeddedList(t *testing.T) {
-	prev := version.IMessageHelperSHA256
-	t.Cleanup(func() { version.IMessageHelperSHA256 = prev })
+func TestIMessageHelperSHA_ReadsPinnedMap(t *testing.T) {
+	prev := version.IMessageHelperSHAs
+	t.Cleanup(func() { version.IMessageHelperSHAs = prev })
 
-	version.IMessageHelperSHA256 = "darwin/arm64=abc,darwin/amd64=def"
+	version.IMessageHelperSHAs = map[string]string{
+		"darwin/arm64": "abc",
+		"darwin/amd64": "def",
+	}
 	if got := version.IMessageHelperSHA("darwin/arm64"); got != "abc" {
 		t.Errorf("darwin/arm64: got %q want abc", got)
 	}
@@ -94,6 +97,20 @@ func TestIMessageHelperSHA_ParsesEmbeddedList(t *testing.T) {
 	}
 	if got := version.IMessageHelperSHA("linux/amd64"); got != "" {
 		t.Errorf("linux/amd64 should be unset, got %q", got)
+	}
+}
+
+// TestIMessageHelperPin_PopulatedForDarwin proves the source-pinned values
+// are present for the platforms iMessage actually supports — a guard against
+// an empty pin sneaking past code review and breaking self-host installs.
+func TestIMessageHelperPin_PopulatedForDarwin(t *testing.T) {
+	if version.IMessageHelperReleaseTag == "" {
+		t.Fatal("IMessageHelperReleaseTag is empty — set it in pkg/version/imessage_helper.go")
+	}
+	for _, osArch := range []string{"darwin/arm64", "darwin/amd64"} {
+		if got := version.IMessageHelperSHA(osArch); got == "" {
+			t.Errorf("no pinned SHA for %s", osArch)
+		}
 	}
 }
 

--- a/pkg/version/imessage_helper.go
+++ b/pkg/version/imessage_helper.go
@@ -1,0 +1,28 @@
+package version
+
+// Pinned reference to the iMessage helper tarballs hosted on GitHub Releases.
+//
+// Decoupled from clawvisor's own Version: most clawvisor releases reuse the
+// same helper, so this points at a known-good release tag and SHA-256 per
+// platform. Any build path — official release, `go install`, or local
+// `go build` — has identical pin data and can verify a download.
+//
+// To rotate (after a real helper change, e.g. protocol bump):
+//  1. Run `scripts/release-imessage-helper.sh`. It builds the helper for both
+//     darwin arches, computes SHAs, and rewrites this file.
+//  2. Commit the rewrite, tag/release with the new helper tarballs uploaded.
+const IMessageHelperReleaseTag = "v0.9.3"
+
+// IMessageHelperSHAs maps GOOS/GOARCH to the SHA-256 of the helper tarball
+// hosted at IMessageHelperReleaseTag. Only darwin platforms are populated;
+// iMessage is macOS-only.
+var IMessageHelperSHAs = map[string]string{
+	"darwin/arm64": "c8a68c2eb809a69ea954c1af161245f64bab6caec3dec893fe26962a022d6bf8",
+	"darwin/amd64": "abdbdf656f47678f89719cb946afd3107232602d0c588b155558478c660b5139",
+}
+
+// IMessageHelperSHA returns the expected SHA-256 for the helper tarball that
+// matches osArch (e.g. "darwin/arm64"), or empty string if not pinned.
+func IMessageHelperSHA(osArch string) string {
+	return IMessageHelperSHAs[osArch]
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -14,29 +14,6 @@ import (
 // Example: go build -ldflags="-X github.com/clawvisor/clawvisor/pkg/version.Version=0.3.0"
 var Version = "dev"
 
-// IMessageHelperSHA256 is a comma-separated list of "os/arch=sha256" entries
-// pinning the expected SHA-256 of each iMessage helper tarball in this
-// release. Populated at build time via -ldflags so a tampered or substituted
-// helper download fails verification before installation. Empty in dev
-// builds; the imessage adapter refuses to download unless this is set, but
-// developers can side-load via PATH or the standard install location.
-var IMessageHelperSHA256 = ""
-
-// IMessageHelperSHA returns the expected SHA-256 for the helper tarball that
-// matches osArch (e.g. "darwin/arm64"), or empty string if not pinned.
-func IMessageHelperSHA(osArch string) string {
-	for _, pair := range strings.Split(IMessageHelperSHA256, ",") {
-		k, v, ok := strings.Cut(pair, "=")
-		if !ok {
-			continue
-		}
-		if strings.TrimSpace(k) == osArch {
-			return strings.TrimSpace(v)
-		}
-	}
-	return ""
-}
-
 // SkillPublishedAt is set at build time via -ldflags. It records the date (YYYY-MM-DD)
 // the release was built so the skill can display when it was last updated.
 var SkillPublishedAt = "dev"

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -27,41 +27,12 @@ HOST_OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
 rm -rf dist
 mkdir -p dist
 
-# Build the iMessage helper FIRST so we can hash its tarballs and embed those
-# SHAs into the clawvisor binary via -ldflags. The adapter refuses to install
-# any helper whose hash doesn't match this baked-in pin, blocking tampered or
-# substituted release artifacts.
-HELPER_APP="Clawvisor iMessage Helper.app"
-HELPER_PLATFORMS="darwin/arm64 darwin/amd64"
-HELPER_LDFLAGS="-s -w -X ${MODULE}.Version=${VERSION} -X ${MODULE}.SkillPublishedAt=${BUILD_DATE}"
-HELPER_SHAS=""
-for PLATFORM in $HELPER_PLATFORMS; do
-  GOOS="${PLATFORM%/*}"
-  GOARCH="${PLATFORM#*/}"
-  TARBALL="dist/clawvisor-imessage-helper-${GOOS}-${GOARCH}.tar.gz"
+# The iMessage helper is released separately and pinned in pkg/version/
+# imessage_helper.go. Run scripts/release-imessage-helper.sh when the helper
+# itself changes; clawvisor releases reuse the pinned helper and don't rebuild
+# or re-upload helper tarballs.
 
-  echo "Building ${TARBALL}..."
-  CGO_ENABLED=0 GOOS="$GOOS" GOARCH="$GOARCH" \
-    go build -ldflags="$HELPER_LDFLAGS" -o "dist/.helper-tmp" ./cmd/imessage-helper
-
-  mkdir -p "dist/${HELPER_APP}/Contents/MacOS"
-  mv "dist/.helper-tmp" "dist/${HELPER_APP}/Contents/MacOS/clawvisor-imessage-helper"
-  cp cmd/imessage-helper/Info.plist "dist/${HELPER_APP}/Contents/Info.plist"
-  tar -czf "$TARBALL" -C dist "${HELPER_APP}"
-  rm -rf "dist/${HELPER_APP}"
-
-  if command -v sha256sum >/dev/null 2>&1; then
-    SHA=$(sha256sum "$TARBALL" | awk '{print $1}')
-  else
-    SHA=$(shasum -a 256 "$TARBALL" | awk '{print $1}')
-  fi
-  if [ -n "$HELPER_SHAS" ]; then
-    HELPER_SHAS="${HELPER_SHAS},"
-  fi
-  HELPER_SHAS="${HELPER_SHAS}${PLATFORM}=${SHA}"
-done
-
-LDFLAGS="-s -w -X ${MODULE}.Version=${VERSION} -X ${MODULE}.SkillPublishedAt=${BUILD_DATE} -X ${MODULE}.IMessageHelperSHA256=${HELPER_SHAS}"
+LDFLAGS="-s -w -X ${MODULE}.Version=${VERSION} -X ${MODULE}.SkillPublishedAt=${BUILD_DATE}"
 
 for PLATFORM in $PLATFORMS; do
   GOOS="${PLATFORM%/*}"

--- a/scripts/release-imessage-helper.sh
+++ b/scripts/release-imessage-helper.sh
@@ -1,0 +1,95 @@
+#!/bin/sh
+# Build the iMessage helper for darwin/{arm64,amd64}, compute SHAs, and
+# rewrite pkg/version/imessage_helper.go with the new pin. Run this only when
+# the helper itself changes (e.g. protocol bump in cmd/imessage-helper).
+#
+# Usage: scripts/release-imessage-helper.sh <tag>
+#   e.g. scripts/release-imessage-helper.sh v0.10.0
+#
+# After this runs:
+#   1. Review and commit the changes to pkg/version/imessage_helper.go.
+#   2. Tag and release <tag> with the dist/ tarballs uploaded as assets.
+set -eu
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <tag>" >&2
+  echo "  e.g. $0 v0.10.0" >&2
+  exit 1
+fi
+
+TAG="$1"
+VERSION="${TAG#v}"
+
+MODULE="github.com/clawvisor/clawvisor/pkg/version"
+BUILD_DATE=$(date -u +%Y-%m-%d)
+HELPER_APP="Clawvisor iMessage Helper.app"
+HELPER_PLATFORMS="darwin/arm64 darwin/amd64"
+HELPER_LDFLAGS="-s -w -X ${MODULE}.Version=${VERSION} -X ${MODULE}.SkillPublishedAt=${BUILD_DATE}"
+
+mkdir -p dist
+SHA_ARM64=""
+SHA_AMD64=""
+for PLATFORM in $HELPER_PLATFORMS; do
+  GOOS="${PLATFORM%/*}"
+  GOARCH="${PLATFORM#*/}"
+  TARBALL="dist/clawvisor-imessage-helper-${GOOS}-${GOARCH}.tar.gz"
+
+  echo "Building ${TARBALL}..."
+  CGO_ENABLED=0 GOOS="$GOOS" GOARCH="$GOARCH" \
+    go build -ldflags="$HELPER_LDFLAGS" -o "dist/.helper-tmp" ./cmd/imessage-helper
+
+  rm -rf "dist/${HELPER_APP}"
+  mkdir -p "dist/${HELPER_APP}/Contents/MacOS"
+  mv "dist/.helper-tmp" "dist/${HELPER_APP}/Contents/MacOS/clawvisor-imessage-helper"
+  cp cmd/imessage-helper/Info.plist "dist/${HELPER_APP}/Contents/Info.plist"
+  tar -czf "$TARBALL" -C dist "${HELPER_APP}"
+  rm -rf "dist/${HELPER_APP}"
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    SHA=$(sha256sum "$TARBALL" | awk '{print $1}')
+  else
+    SHA=$(shasum -a 256 "$TARBALL" | awk '{print $1}')
+  fi
+
+  case "$GOARCH" in
+    arm64) SHA_ARM64="$SHA" ;;
+    amd64) SHA_AMD64="$SHA" ;;
+  esac
+done
+
+PIN_FILE="pkg/version/imessage_helper.go"
+echo "Rewriting ${PIN_FILE}..."
+
+# Replace the tag and SHAs in place. Using awk for portable in-place edit.
+TMP=$(mktemp)
+awk -v tag="$TAG" -v arm64="$SHA_ARM64" -v amd64="$SHA_AMD64" '
+  /^const IMessageHelperReleaseTag =/ {
+    print "const IMessageHelperReleaseTag = \"" tag "\""
+    next
+  }
+  /"darwin\/arm64":/ {
+    print "\t\"darwin/arm64\": \"" arm64 "\","
+    next
+  }
+  /"darwin\/amd64":/ {
+    print "\t\"darwin/amd64\": \"" amd64 "\","
+    next
+  }
+  { print }
+' "$PIN_FILE" > "$TMP"
+mv "$TMP" "$PIN_FILE"
+
+cat <<EOF
+
+Done. Pinned ${PIN_FILE} to:
+  tag:           ${TAG}
+  darwin/arm64:  ${SHA_ARM64}
+  darwin/amd64:  ${SHA_AMD64}
+
+Next steps:
+  1. git diff ${PIN_FILE}    # review the rewrite
+  2. git add ${PIN_FILE} && git commit
+  3. Tag and release ${TAG}, uploading:
+       dist/clawvisor-imessage-helper-darwin-arm64.tar.gz
+       dist/clawvisor-imessage-helper-darwin-amd64.tar.gz
+EOF


### PR DESCRIPTION
## Summary

Moves the iMessage helper's release tag and per-arch SHA-256s from `-ldflags`-injected build-time strings into a checked-in source file (`pkg/version/imessage_helper.go`). Self-hosters running `go install` or building from source now get a valid pin and can install the helper without producing a full release binary — fixing the "no pinned helper SHA for darwin/arm64 in this build" failure.

The helper release is decoupled from clawvisor's own version (it only changes on protocol bumps), so a new `scripts/release-imessage-helper.sh` and a manual `Release iMessage Helper` GitHub Actions workflow handle helper-only releases. The workflow guards on a `ProtocolVersion`-changed check (`force` overrides), refuses to clobber assets on a tag that already has helper bytes — their SHAs may be pinned in clawvisor binaries already in the wild — and opens a PR rewriting the source pin to match what was just uploaded.

## Test plan

- [x] `go test ./internal/adapters/apple/imessage/... ./pkg/version/...` passes
- [x] Workflow YAML parses (`yaml.safe_load`)
- [x] Awk pin-rewrite produces a clean diff against the current pin file
- [x] Initial pinned SHAs match the live `v0.9.3` helper assets on GitHub Releases
- [ ] Dry-run the `Release iMessage Helper` workflow against a throwaway tag to confirm the asset-precheck and PR-open paths