### PR TITLE
Stress-test HIGH findings: atomicity, rate-limits, auth bounds, telegram identity

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -120,7 +120,7 @@ mcp:
 # ── Rate limiting ──────────────────────────────────────────────────────────────
 rate_limit:
   gateway:                   # per agent
-    limit: 60                # requests per window
+    limit: 200               # requests per window
     window: 60               # seconds
   oauth:                     # per user
     limit: 5

--- a/internal/api/client_ip.go
+++ b/internal/api/client_ip.go
@@ -1,0 +1,58 @@
+package api
+
+import (
+	"net"
+	"net/http"
+	"strings"
+)
+
+// clientIPFromRequest returns the rate-limit key for a request: the client
+// IP as best as the daemon can identify it.
+//
+// When the immediate peer (r.RemoteAddr) is in trustedProxies, the
+// X-Forwarded-For header is consulted: walk right-to-left and return the
+// right-most entry that is NOT a trusted proxy. This gives the actual
+// originating client even with multiple proxy hops, while ensuring an
+// attacker on a direct connection can't spoof XFF (because their RemoteAddr
+// won't be in trustedProxies in the first place).
+//
+// When trustedProxies is empty (self-host / direct exposure), only
+// r.RemoteAddr is consulted — no XFF spoofing surface.
+func clientIPFromRequest(r *http.Request, trustedProxies []*net.IPNet) string {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		host = r.RemoteAddr
+	}
+	if len(trustedProxies) == 0 {
+		return host
+	}
+	peerIP := net.ParseIP(host)
+	if peerIP == nil || !ipInAny(peerIP, trustedProxies) {
+		return host
+	}
+	xff := r.Header.Get("X-Forwarded-For")
+	if xff == "" {
+		return host
+	}
+	parts := strings.Split(xff, ",")
+	for i := len(parts) - 1; i >= 0; i-- {
+		candidate := strings.TrimSpace(parts[i])
+		ip := net.ParseIP(candidate)
+		if ip == nil {
+			continue
+		}
+		if !ipInAny(ip, trustedProxies) {
+			return candidate
+		}
+	}
+	return host
+}
+
+func ipInAny(ip net.IP, nets []*net.IPNet) bool {
+	for _, n := range nets {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/api/client_ip_test.go
+++ b/internal/api/client_ip_test.go
@@ -1,0 +1,95 @@
+package api
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func mustCIDR(t *testing.T, s string) *net.IPNet {
+	t.Helper()
+	_, n, err := net.ParseCIDR(s)
+	if err != nil {
+		t.Fatalf("ParseCIDR(%q): %v", s, err)
+	}
+	return n
+}
+
+func TestClientIPFromRequest(t *testing.T) {
+	trusted := []*net.IPNet{
+		mustCIDR(t, "10.0.0.0/8"),
+		mustCIDR(t, "127.0.0.1/32"),
+	}
+
+	cases := []struct {
+		name       string
+		remoteAddr string
+		xff        string
+		trusted    []*net.IPNet
+		want       string
+	}{
+		{
+			name:       "no trusted proxies — use RemoteAddr verbatim",
+			remoteAddr: "203.0.113.5:443",
+			xff:        "1.2.3.4",
+			trusted:    nil,
+			want:       "203.0.113.5",
+		},
+		{
+			name:       "trusted-set defined but peer is untrusted — ignore XFF",
+			remoteAddr: "203.0.113.5:443",
+			xff:        "1.2.3.4",
+			trusted:    trusted,
+			want:       "203.0.113.5",
+		},
+		{
+			name:       "peer is trusted, no XFF — fall back to peer host",
+			remoteAddr: "10.0.0.5:443",
+			xff:        "",
+			trusted:    trusted,
+			want:       "10.0.0.5",
+		},
+		{
+			name:       "single XFF entry from trusted peer — use that entry",
+			remoteAddr: "10.0.0.5:443",
+			xff:        "203.0.113.99",
+			trusted:    trusted,
+			want:       "203.0.113.99",
+		},
+		{
+			name:       "multi-hop XFF, last is trusted proxy — pick rightmost untrusted",
+			remoteAddr: "10.0.0.5:443",
+			xff:        "203.0.113.99, 10.0.0.99, 10.0.0.5",
+			trusted:    trusted,
+			want:       "203.0.113.99",
+		},
+		{
+			name:       "all XFF entries are trusted — fall back to peer",
+			remoteAddr: "10.0.0.5:443",
+			xff:        "10.0.0.1, 10.0.0.2",
+			trusted:    trusted,
+			want:       "10.0.0.5",
+		},
+		{
+			name:       "junk XFF entries are skipped",
+			remoteAddr: "10.0.0.5:443",
+			xff:        "not-an-ip, 203.0.113.7",
+			trusted:    trusted,
+			want:       "203.0.113.7",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, "/", nil)
+			r.RemoteAddr = tc.remoteAddr
+			if tc.xff != "" {
+				r.Header.Set("X-Forwarded-For", tc.xff)
+			}
+			got := clientIPFromRequest(r, tc.trusted)
+			if got != tc.want {
+				t.Fatalf("clientIPFromRequest = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/api/client_ip_test.go
+++ b/internal/api/client_ip_test.go
@@ -78,6 +78,47 @@ func TestClientIPFromRequest(t *testing.T) {
 			trusted:    trusted,
 			want:       "203.0.113.7",
 		},
+		// IPv6 coverage. Bracketed IPv6 RemoteAddr must round-trip and match
+		// IPv6 trusted CIDRs the same way IPv4 does.
+		{
+			name:       "ipv6 trusted peer with ipv6 XFF — pick rightmost untrusted",
+			remoteAddr: "[::1]:443",
+			xff:        "2001:db8::42, ::1",
+			trusted: []*net.IPNet{
+				mustCIDR(t, "::1/128"),
+			},
+			want: "2001:db8::42",
+		},
+		{
+			name:       "ipv6 untrusted peer ignores XFF",
+			remoteAddr: "[2001:db8::99]:443",
+			xff:        "10.0.0.5",
+			trusted: []*net.IPNet{
+				mustCIDR(t, "10.0.0.0/8"),
+			},
+			want: "2001:db8::99",
+		},
+		// Spoofing surface: an attacker on the public internet sets
+		// X-Forwarded-For: 10.0.0.1 hoping the daemon honors it. With a
+		// trusted-proxies set defined but the peer NOT in it, the header
+		// is ignored. Without this the rate-limit key would be forgable.
+		{
+			name:       "untrusted public peer cannot spoof XFF",
+			remoteAddr: "203.0.113.99:443",
+			xff:        "10.0.0.1",
+			trusted:    trusted,
+			want:       "203.0.113.99",
+		},
+		// IPv4-mapped IPv6 (::ffff:10.0.0.5) commonly appears behind
+		// dual-stack proxies. A CIDR matching the IPv4 form should still
+		// recognize the mapped form.
+		{
+			name:       "ipv4-mapped ipv6 in XFF is honored",
+			remoteAddr: "10.0.0.5:443",
+			xff:        "::ffff:203.0.113.7",
+			trusted:    trusted,
+			want:       "::ffff:203.0.113.7",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/api/dedup_callback_test.go
+++ b/internal/api/dedup_callback_test.go
@@ -523,17 +523,33 @@ func TestGateway_Callback_NoCallbackURL_NoDelivery(t *testing.T) {
 	}
 }
 
+// TestAgentCreate_DefaultsToSignedCallbacks asserts the default-on signing
+// behavior: an agent created without setting with_callback_secret should
+// receive a callback_secret in the response so callbacks are signed by
+// default. This is the regression guard for the previous "default off"
+// posture that left callbacks forgable to anyone learning the URL.
+func TestAgentCreate_DefaultsToSignedCallbacks(t *testing.T) {
+	env := newTestEnv(t)
+	s := newSession(t, env)
+	resp := s.do("POST", "/api/agents", map[string]any{"name": "default-secret-test"})
+	body := mustStatus(t, resp, http.StatusCreated)
+	if _, ok := body["callback_secret"]; !ok {
+		t.Fatal("expected callback_secret in agent-create response by default")
+	}
+}
+
 func TestGateway_Callback_Unsigned_WhenNoSecret(t *testing.T) {
-	// When an agent has NOT registered a callback secret, the callback should
-	// still be delivered but with an empty X-Clawvisor-Signature header.
+	// When an agent explicitly opts out (with_callback_secret=false at agent
+	// creation) and no secret is registered after the fact, the callback
+	// should still be delivered but with an empty X-Clawvisor-Signature
+	// header. New agents now default to opt-in (signed callbacks); this
+	// path is the regression guard for the explicit opt-out branch.
 	adapter := newMockAdapter("mock.cb-nosec", "run").withResult("nosec-ok", nil)
 	env := newTestEnv(t, adapter)
-	sc := newScenario(t, env, "cb-nosec")
+	sc := newScenarioOptingOutOfSignedCallbacks(t, env)
 	if err := env.Vault.Set(context.Background(), sc.session.UserID, "mock.cb-nosec", []byte("cred")); err != nil {
 		t.Fatalf("vault seed: %v", err)
 	}
-
-	// Do NOT register a callback secret
 
 	taskID := sc.createApprovedTask(t, env, "mock.cb-nosec", "run", true)
 

--- a/internal/api/gateway_test.go
+++ b/internal/api/gateway_test.go
@@ -787,6 +787,31 @@ func TestApprovals_Approve_WithMockAdapter(t *testing.T) {
 	}
 }
 
+// TestApprovals_DoubleApprove_Returns409 is the regression guard against
+// a lost-CAS approve race surfacing as 500 INTERNAL_ERROR. The second
+// approve call has nothing legitimate to do — the row is already
+// resolved — but it's a normal race outcome (two dashboard tabs, etc.),
+// not an internal failure. Must be 409 ALREADY_RESOLVED.
+func TestApprovals_DoubleApprove_Returns409(t *testing.T) {
+	adapter := newMockAdapter("mock.dbl", "run").withResult("done", nil)
+	env := newTestEnv(t, adapter)
+	sc := newScenario(t, env, "dbl")
+	taskID := sc.createApprovedTask(t, env, "mock.dbl", "run", false)
+	reqID := fmt.Sprintf("req-dbl-%s", randSuffix())
+	sc.gatewayRequestWithTask(env, reqID, "mock.dbl", "run", taskID)
+
+	// First approve → 200.
+	resp := sc.session.do("POST", fmt.Sprintf("/api/approvals/%s/approve", reqID), nil)
+	mustStatus(t, resp, http.StatusOK)
+
+	// Second approve → 409 ALREADY_RESOLVED, not 500 INTERNAL_ERROR.
+	resp = sc.session.do("POST", fmt.Sprintf("/api/approvals/%s/approve", reqID), nil)
+	body := mustStatus(t, resp, http.StatusConflict)
+	if code, _ := body["code"].(string); code != "ALREADY_RESOLVED" {
+		t.Fatalf("expected code=ALREADY_RESOLVED, got %q (body=%v)", code, body)
+	}
+}
+
 func TestApprovals_Approve_WrongUser_Forbidden(t *testing.T) {
 	env := newTestEnv(t, newMockAdapter("mock.forbidden", "run"))
 	sc1 := newScenario(t, env, "bot1")

--- a/internal/api/handlers/agents.go
+++ b/internal/api/handlers/agents.go
@@ -233,6 +233,14 @@ func (h *AgentsHandler) RotateToken(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusNotFound, "NOT_FOUND", "agent not found")
 			return
 		}
+		if err == store.ErrConflict {
+			// Agent was issued by an MCP/relay flow that bounds the
+			// token's lifetime. Rotation here would silently re-issue a
+			// token with the same (possibly past) expiry.
+			writeError(w, http.StatusConflict, "ROTATION_NOT_ALLOWED",
+				"this agent's token has a bounded expiry; re-pair through the original MCP or relay flow to get a fresh token")
+			return
+		}
 		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not rotate token")
 		return
 	}

--- a/internal/api/handlers/agents.go
+++ b/internal/api/handlers/agents.go
@@ -37,9 +37,16 @@ func (h *AgentsHandler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var body struct {
-		Description        string `json:"description"`
-		Name               string `json:"name"`
-		WithCallbackSecret bool   `json:"with_callback_secret"`
+		Description string `json:"description"`
+		Name        string `json:"name"`
+		// WithCallbackSecret is a *bool so we can distinguish:
+		//   nil   → field absent — default to true (mint a secret).
+		//   true  → explicit opt-in (same as default).
+		//   false → explicit opt-out — no secret minted.
+		// The default flipped from off to on once unsigned callbacks were
+		// recognized as a forgery surface: anyone learning the callback URL
+		// could impersonate a "result" to the agent.
+		WithCallbackSecret *bool `json:"with_callback_secret"`
 	}
 	if !decodeJSON(w, r, &body) {
 		return
@@ -77,7 +84,8 @@ func (h *AgentsHandler) Create(w http.ResponseWriter, r *http.Request) {
 		"token":       rawToken,
 	}
 
-	if body.WithCallbackSecret {
+	wantSecret := body.WithCallbackSecret == nil || *body.WithCallbackSecret
+	if wantSecret {
 		secret, err := auth.GenerateCallbackSecret()
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not generate callback secret")

--- a/internal/api/handlers/approval_record_state_test.go
+++ b/internal/api/handlers/approval_record_state_test.go
@@ -68,6 +68,37 @@ func TestValidateApprovalRecordTransition(t *testing.T) {
 			status:     "approved",
 			wantErr:    true,
 		},
+		// Regression guards: deny resolution requires "denied" or "expired"
+		// as the status, NOT a free-form reason string. processExpired
+		// Approval and revertOrTerminate previously passed reasons like
+		// "stranded" / "promotion_failed" here, which silently failed the
+		// transition validator and left the canonical record pending forever.
+		{
+			name:       "deny+denied accepted (revertOrTerminate after race-loss)",
+			record:     &store.ApprovalRecord{ID: "r-deny", Kind: "request_once", Status: "pending"},
+			resolution: "deny",
+			status:     "denied",
+		},
+		{
+			name:       "deny+expired accepted (processExpiredApproval)",
+			record:     &store.ApprovalRecord{ID: "r-exp", Kind: "request_once", Status: "pending"},
+			resolution: "deny",
+			status:     "expired",
+		},
+		{
+			name:       "deny+stranded rejected (regression: was passed by stalled-recovery sweep)",
+			record:     &store.ApprovalRecord{ID: "r-strand", Kind: "request_once", Status: "pending"},
+			resolution: "deny",
+			status:     "stranded",
+			wantErr:    true,
+		},
+		{
+			name:       "deny+promotion_failed rejected (regression: was passed by revertOrTerminate)",
+			record:     &store.ApprovalRecord{ID: "r-promo", Kind: "request_once", Status: "pending"},
+			resolution: "deny",
+			status:     "promotion_failed",
+			wantErr:    true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/api/handlers/approvals.go
+++ b/internal/api/handlers/approvals.go
@@ -500,7 +500,12 @@ func (h *ApprovalsHandler) processExpiredApproval(ctx context.Context, pa *store
 		var blob pendingRequestBlob
 		_ = json.Unmarshal(pa.RequestBlob, &blob)
 		cbKey, _ := h.st.GetAgentCallbackSecret(ctx, blob.AgentID)
-		_ = callback.DeliverResult(ctx, *pa.CallbackURL, &callback.Payload{
+		// Route through the bounded dispatcher (same as every other
+		// resolution path in this handler) instead of calling DeliverResult
+		// synchronously. With N expired rows and slow agent endpoints the
+		// synchronous version serialized into N × 30s, starving the next
+		// sweep tick and the stranded-executing recovery pass.
+		h.dispatchCallback(*pa.CallbackURL, &callback.Payload{
 			Type:      "request",
 			RequestID: pa.RequestID,
 			Status:    "timeout",
@@ -561,7 +566,9 @@ func (h *ApprovalsHandler) expireTimedOut(ctx context.Context) {
 
 		if task.CallbackURL != nil && *task.CallbackURL != "" {
 			cbKey, _ := h.st.GetAgentCallbackSecret(ctx, task.AgentID)
-			_ = callback.DeliverResult(ctx, *task.CallbackURL, &callback.Payload{
+			// See processExpiredApproval — same reason for using the
+			// bounded dispatcher instead of synchronous DeliverResult.
+			h.dispatchCallback(*task.CallbackURL, &callback.Payload{
 				Type:   "task",
 				TaskID: task.ID,
 				Status: "expired",

--- a/internal/api/handlers/approvals.go
+++ b/internal/api/handlers/approvals.go
@@ -34,6 +34,7 @@ type ApprovalsHandler struct {
 	assessor   taskrisk.Assessor
 	logger     *slog.Logger
 	eventHub   events.EventHub
+	cbDispatch *CallbackDispatcher // bounded callback delivery; may be nil (falls back to inline panic-safe goroutines)
 }
 
 func NewApprovalsHandler(st store.Store, v vault.Vault, adapterReg *adapters.Registry, notifier notify.Notifier, cfg config.Config, assessor taskrisk.Assessor, logger *slog.Logger, eventHub events.EventHub) *ApprovalsHandler {
@@ -47,6 +48,30 @@ func NewApprovalsHandler(st store.Store, v vault.Vault, adapterReg *adapters.Reg
 		logger:     logger,
 		eventHub:   eventHub,
 	}
+}
+
+// SetCallbackDispatcher wires a bounded callback delivery pool into the
+// handler. When unset, callback delivery falls back to a safeGo-wrapped
+// inline goroutine — still panic-safe but with no concurrency cap.
+func (h *ApprovalsHandler) SetCallbackDispatcher(d *CallbackDispatcher) {
+	h.cbDispatch = d
+}
+
+// dispatchCallback enqueues a payload for delivery via the bounded
+// dispatcher when available, or spawns a panic-safe goroutine otherwise.
+func (h *ApprovalsHandler) dispatchCallback(url string, payload *callback.Payload, signingKey string) {
+	if url == "" || payload == nil {
+		return
+	}
+	if h.cbDispatch != nil {
+		h.cbDispatch.Submit(url, payload, signingKey)
+		return
+	}
+	safeGo(h.logger, "callback delivery (inline)", func() {
+		cbCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_ = callback.DeliverResult(cbCtx, url, payload, signingKey)
+	})
 }
 
 // List returns pending approvals for the authenticated user.
@@ -209,17 +234,13 @@ func (h *ApprovalsHandler) markApproved(ctx context.Context, pa *store.PendingAp
 		if promotedTask != nil {
 			taskID = promotedTask.ID
 		}
-		go func() {
-			cbCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			defer cancel()
-			_ = callback.DeliverResult(cbCtx, callbackURL, &callback.Payload{
-				Type:      "request",
-				RequestID: requestID,
-				TaskID:    taskID,
-				Status:    "approved",
-				AuditID:   auditID,
-			}, cbKey)
-		}()
+		h.dispatchCallback(callbackURL, &callback.Payload{
+			Type:      "request",
+			RequestID: requestID,
+			TaskID:    taskID,
+			Status:    "approved",
+			AuditID:   auditID,
+		}, cbKey)
 	}
 	return promotedTask, nil
 }
@@ -252,16 +273,12 @@ func (h *ApprovalsHandler) DenyByRequestID(ctx context.Context, requestID, userI
 
 	if pa.CallbackURL != nil && *pa.CallbackURL != "" {
 		cbKey, _ := h.st.GetAgentCallbackSecret(ctx, denyBlob.AgentID)
-		go func() {
-			cbCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			defer cancel()
-			_ = callback.DeliverResult(cbCtx, *pa.CallbackURL, &callback.Payload{
-				Type:      "request",
-				RequestID: requestID,
-				Status:    "denied",
-				AuditID:   pa.AuditID,
-			}, cbKey)
-		}()
+		h.dispatchCallback(*pa.CallbackURL, &callback.Payload{
+			Type:      "request",
+			RequestID: requestID,
+			Status:    "denied",
+			AuditID:   pa.AuditID,
+		}, cbKey)
 	}
 
 	return nil
@@ -311,16 +328,12 @@ func (h *ApprovalsHandler) Deny(w http.ResponseWriter, r *http.Request) {
 
 	if pa.CallbackURL != nil && *pa.CallbackURL != "" {
 		cbKey, _ := h.st.GetAgentCallbackSecret(r.Context(), denyBlob.AgentID)
-		go func() {
-			cbCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			defer cancel()
-			_ = callback.DeliverResult(cbCtx, *pa.CallbackURL, &callback.Payload{
-				Type:      "request",
-				RequestID: requestID,
-				Status:    "denied",
-				AuditID:   pa.AuditID,
-			}, cbKey)
-		}()
+		h.dispatchCallback(*pa.CallbackURL, &callback.Payload{
+			Type:      "request",
+			RequestID: requestID,
+			Status:    "denied",
+			AuditID:   pa.AuditID,
+		}, cbKey)
 	}
 
 	writeJSON(w, http.StatusOK, map[string]any{
@@ -375,18 +388,14 @@ func (h *ApprovalsHandler) executeApproval(ctx context.Context, pa *store.Pendin
 		cbErr := errMsg
 		requestID := pa.RequestID
 		auditID := pa.AuditID
-		go func() {
-			cbCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			defer cancel()
-			_ = callback.DeliverResult(cbCtx, *pa.CallbackURL, &callback.Payload{
-				Type:      "request",
-				RequestID: requestID,
-				Status:    outcome,
-				Result:    cbResult,
-				Error:     cbErr,
-				AuditID:   auditID,
-			}, cbKey)
-		}()
+		h.dispatchCallback(*pa.CallbackURL, &callback.Payload{
+			Type:      "request",
+			RequestID: requestID,
+			Status:    outcome,
+			Result:    cbResult,
+			Error:     cbErr,
+			AuditID:   auditID,
+		}, cbKey)
 	}
 
 	return result, outcome, errMsg

--- a/internal/api/handlers/approvals.go
+++ b/internal/api/handlers/approvals.go
@@ -182,25 +182,35 @@ func (h *ApprovalsHandler) ApproveByRequestID(ctx context.Context, requestID, us
 // markApproved transitions a pending approval to the "approved" state without
 // executing it. The agent is expected to call HandleExecuteApproved to claim
 // the result. If a callback URL is registered, a notification is sent.
+//
+// The status update is a CAS from "pending" → "approved", so a concurrent
+// Deny against the same request_id can't co-resolve to both states (which
+// previously caused the agent to receive both an "approved" and a "denied"
+// callback for the same request).
 func (h *ApprovalsHandler) markApproved(ctx context.Context, pa *store.PendingApproval, resolution string) (*store.Task, error) {
-	if err := h.st.UpdatePendingApprovalStatus(ctx, pa.RequestID, "approved"); err != nil {
+	won, err := h.st.UpdatePendingApprovalStatusFrom(ctx, pa.RequestID, "pending", "approved")
+	if err != nil {
 		h.logger.Error("failed to update approval status", "request_id", pa.RequestID, "err", err)
 		return nil, err
 	}
+	if !won {
+		// Another caller (Deny via Telegram, expiry sweep, retry) already
+		// resolved this request. Refuse the second resolution.
+		return nil, fmt.Errorf("approval %s is no longer pending", pa.RequestID)
+	}
 	var promotedTask *store.Task
-	var err error
 	switch resolution {
 	case "allow_session", "allow_always":
 		promotedTask, err = h.promotePendingApprovalToTask(ctx, pa, resolution)
 		if err != nil {
-			if revertErr := h.st.UpdatePendingApprovalStatus(ctx, pa.RequestID, pa.Status); revertErr != nil {
+			if _, revertErr := h.st.UpdatePendingApprovalStatusFrom(ctx, pa.RequestID, "approved", pa.Status); revertErr != nil {
 				h.logger.Error("failed to revert approval status after task promotion error", "request_id", pa.RequestID, "err", revertErr)
 			}
 			return nil, err
 		}
 	case "allow_once":
 	default:
-		if revertErr := h.st.UpdatePendingApprovalStatus(ctx, pa.RequestID, pa.Status); revertErr != nil {
+		if _, revertErr := h.st.UpdatePendingApprovalStatusFrom(ctx, pa.RequestID, "approved", pa.Status); revertErr != nil {
 			h.logger.Error("failed to revert approval status after invalid resolution", "request_id", pa.RequestID, "err", revertErr)
 		}
 		return nil, fmt.Errorf("unsupported approval resolution %q", resolution)
@@ -247,6 +257,10 @@ func (h *ApprovalsHandler) markApproved(ctx context.Context, pa *store.PendingAp
 
 // DenyByRequestID is the core deny logic, callable from both the HTTP handler
 // and the Telegram callback decision consumer.
+//
+// The status update is a CAS from "pending" → "denied", so a concurrent
+// Approve against the same request_id can't co-resolve. If the row has
+// already been resolved (approved, denied, or executing), this is a no-op.
 func (h *ApprovalsHandler) DenyByRequestID(ctx context.Context, requestID, userID string) error {
 	pa, err := h.st.GetPendingApproval(ctx, requestID)
 	if err != nil {
@@ -254,6 +268,16 @@ func (h *ApprovalsHandler) DenyByRequestID(ctx context.Context, requestID, userI
 	}
 	if pa.UserID != userID {
 		return errors.New("not your approval")
+	}
+
+	won, err := h.st.UpdatePendingApprovalStatusFrom(ctx, requestID, "pending", "denied")
+	if err != nil {
+		return err
+	}
+	if !won {
+		// Already resolved by a peer — refuse to repeat the side effects
+		// (callback, notifier update, audit) and report no-op to the caller.
+		return fmt.Errorf("approval %s is no longer pending", requestID)
 	}
 
 	var denyBlob pendingRequestBlob
@@ -308,6 +332,18 @@ func (h *ApprovalsHandler) Deny(w http.ResponseWriter, r *http.Request) {
 
 	if pa.UserID != user.ID {
 		writeError(w, http.StatusForbidden, "FORBIDDEN", "not your approval")
+		return
+	}
+
+	won, err := h.st.UpdatePendingApprovalStatusFrom(r.Context(), requestID, "pending", "denied")
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not update approval")
+		return
+	}
+	if !won {
+		// Concurrent approve/deny race or already-resolved row — refuse to
+		// repeat the side effects below.
+		writeError(w, http.StatusConflict, "CONFLICT", "approval is no longer pending")
 		return
 	}
 

--- a/internal/api/handlers/approvals.go
+++ b/internal/api/handlers/approvals.go
@@ -138,6 +138,14 @@ func (h *ApprovalsHandler) Approve(w http.ResponseWriter, r *http.Request) {
 	}
 	promotedTask, err := h.markApproved(r.Context(), pa, resolution)
 	if err != nil {
+		if errors.Is(err, errApprovalAlreadyResolved) {
+			// The row was resolved by a different actor (Telegram deny,
+			// expiry sweep, retry) between our load and our CAS. This is
+			// a race outcome, not an internal failure — surface a 409 so
+			// the dashboard can refresh instead of showing a 500.
+			writeError(w, http.StatusConflict, "ALREADY_RESOLVED", "this approval is no longer pending — refresh to see the current state")
+			return
+		}
 		h.logger.Error("failed to approve pending request", "request_id", requestID, "resolution", resolution, "err", err)
 		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not approve pending request")
 		return
@@ -187,6 +195,10 @@ func (h *ApprovalsHandler) ApproveByRequestID(ctx context.Context, requestID, us
 // that; instead, force-resolve the canonical approval record so the user
 // dashboard doesn't sit "pending" forever, and let the lease-recovery
 // sweeper reclaim the now-orphan 'executing' row on its next pass.
+//
+// reason is logged for diagnostics; it is NOT passed as the canonical
+// approval status (which must be one of "denied" / "expired" — see
+// validateApprovalRecordTransition).
 func (h *ApprovalsHandler) revertOrTerminate(ctx context.Context, pa *store.PendingApproval, reason string) {
 	won, err := h.st.UpdatePendingApprovalStatusFrom(ctx, pa.RequestID, "approved", pa.Status)
 	if err != nil {
@@ -199,13 +211,19 @@ func (h *ApprovalsHandler) revertOrTerminate(ctx context.Context, pa *store.Pend
 	}
 	// Lost the revert CAS — another actor moved past 'approved' (almost
 	// always /execute claiming as 'executing'). Force the canonical
-	// approval to a terminal "deny" state so it doesn't stay pending in
+	// approval to a terminal "denied" state so it doesn't stay pending in
 	// the dashboard. The pending_approvals row itself will be cleaned up
 	// by the lease-recovery sweeper.
 	h.logger.Warn("approval revert lost CAS; forcing canonical resolution",
 		"request_id", pa.RequestID, "reason", reason)
-	h.resolveCanonicalApproval(ctx, pa, "deny", reason)
+	h.resolveCanonicalApproval(ctx, pa, "deny", "denied")
 }
+
+// errApprovalAlreadyResolved is returned by markApproved when the CAS to
+// 'approved' loses to a concurrent resolver (Deny via Telegram, expiry
+// sweep, etc.). HTTP callers should map this to 409 Conflict — it is a
+// race outcome, not an internal failure.
+var errApprovalAlreadyResolved = errors.New("approval is no longer pending")
 
 // markApproved transitions a pending approval to the "approved" state without
 // executing it. The agent is expected to call HandleExecuteApproved to claim
@@ -215,6 +233,9 @@ func (h *ApprovalsHandler) revertOrTerminate(ctx context.Context, pa *store.Pend
 // Deny against the same request_id can't co-resolve to both states (which
 // previously caused the agent to receive both an "approved" and a "denied"
 // callback for the same request).
+//
+// Returns errApprovalAlreadyResolved if the row was resolved by another
+// caller before our CAS landed; HTTP handlers translate that to 409.
 func (h *ApprovalsHandler) markApproved(ctx context.Context, pa *store.PendingApproval, resolution string) (*store.Task, error) {
 	won, err := h.st.UpdatePendingApprovalStatusFrom(ctx, pa.RequestID, "pending", "approved")
 	if err != nil {
@@ -222,9 +243,7 @@ func (h *ApprovalsHandler) markApproved(ctx context.Context, pa *store.PendingAp
 		return nil, err
 	}
 	if !won {
-		// Another caller (Deny via Telegram, expiry sweep, retry) already
-		// resolved this request. Refuse the second resolution.
-		return nil, fmt.Errorf("approval %s is no longer pending", pa.RequestID)
+		return nil, errApprovalAlreadyResolved
 	}
 	var promotedTask *store.Task
 	switch resolution {
@@ -486,10 +505,12 @@ func (h *ApprovalsHandler) RunExpiryCleanup(ctx context.Context) {
 // notification + callback work for a pending_approvals row that has either
 // timed out (caller already deleted the row) or been recovered from a
 // stalled 'executing' state (CAS DELETE already happened). reason is
-// passed to the canonical-approval resolver so the dashboard distinguishes
-// between "user never replied" and "executor crashed mid-execution".
+// included in the structured log so the operator can distinguish
+// "user never replied" from "executor crashed mid-execution"; it is NOT
+// passed as the canonical status (which must be "expired" — see
+// validateApprovalRecordTransition).
 func (h *ApprovalsHandler) processExpiredApproval(ctx context.Context, pa *store.PendingApproval, reason, telegramMsg string) {
-	h.resolveCanonicalApproval(ctx, pa, "deny", reason)
+	h.resolveCanonicalApproval(ctx, pa, "deny", "expired")
 	_ = h.st.UpdateAuditOutcome(ctx, pa.AuditID, "timeout", "", 0)
 	h.updateNotificationMsg(ctx, "approval", pa.RequestID, pa.UserID, telegramMsg)
 	// For the regular expired path the caller relies on us to delete the

--- a/internal/api/handlers/approvals.go
+++ b/internal/api/handlers/approvals.go
@@ -179,6 +179,34 @@ func (h *ApprovalsHandler) ApproveByRequestID(ctx context.Context, requestID, us
 	return nil
 }
 
+// revertOrTerminate is the cleanup path for markApproved when post-CAS work
+// (task promotion, validation) fails after we already moved status to
+// 'approved'. The intuitive "revert to pa.Status" only works when no other
+// actor has touched the row since — concurrent /execute can have already
+// CAS'd 'approved' → 'executing'. When the revert CAS misses we can't undo
+// that; instead, force-resolve the canonical approval record so the user
+// dashboard doesn't sit "pending" forever, and let the lease-recovery
+// sweeper reclaim the now-orphan 'executing' row on its next pass.
+func (h *ApprovalsHandler) revertOrTerminate(ctx context.Context, pa *store.PendingApproval, reason string) {
+	won, err := h.st.UpdatePendingApprovalStatusFrom(ctx, pa.RequestID, "approved", pa.Status)
+	if err != nil {
+		h.logger.Error("failed to revert approval status",
+			"request_id", pa.RequestID, "reason", reason, "err", err)
+		return
+	}
+	if won {
+		return
+	}
+	// Lost the revert CAS — another actor moved past 'approved' (almost
+	// always /execute claiming as 'executing'). Force the canonical
+	// approval to a terminal "deny" state so it doesn't stay pending in
+	// the dashboard. The pending_approvals row itself will be cleaned up
+	// by the lease-recovery sweeper.
+	h.logger.Warn("approval revert lost CAS; forcing canonical resolution",
+		"request_id", pa.RequestID, "reason", reason)
+	h.resolveCanonicalApproval(ctx, pa, "deny", reason)
+}
+
 // markApproved transitions a pending approval to the "approved" state without
 // executing it. The agent is expected to call HandleExecuteApproved to claim
 // the result. If a callback URL is registered, a notification is sent.
@@ -203,16 +231,12 @@ func (h *ApprovalsHandler) markApproved(ctx context.Context, pa *store.PendingAp
 	case "allow_session", "allow_always":
 		promotedTask, err = h.promotePendingApprovalToTask(ctx, pa, resolution)
 		if err != nil {
-			if _, revertErr := h.st.UpdatePendingApprovalStatusFrom(ctx, pa.RequestID, "approved", pa.Status); revertErr != nil {
-				h.logger.Error("failed to revert approval status after task promotion error", "request_id", pa.RequestID, "err", revertErr)
-			}
+			h.revertOrTerminate(ctx, pa, "promotion_failed")
 			return nil, err
 		}
 	case "allow_once":
 	default:
-		if _, revertErr := h.st.UpdatePendingApprovalStatusFrom(ctx, pa.RequestID, "approved", pa.Status); revertErr != nil {
-			h.logger.Error("failed to revert approval status after invalid resolution", "request_id", pa.RequestID, "err", revertErr)
-		}
+		h.revertOrTerminate(ctx, pa, "unsupported_resolution")
 		return nil, fmt.Errorf("unsupported approval resolution %q", resolution)
 	}
 	h.resolveCanonicalApproval(ctx, pa, resolution, "approved")
@@ -458,47 +482,70 @@ func (h *ApprovalsHandler) RunExpiryCleanup(ctx context.Context) {
 	}
 }
 
+// processExpiredApproval performs the canonical-resolution + audit-update +
+// notification + callback work for a pending_approvals row that has either
+// timed out (caller already deleted the row) or been recovered from a
+// stalled 'executing' state (CAS DELETE already happened). reason is
+// passed to the canonical-approval resolver so the dashboard distinguishes
+// between "user never replied" and "executor crashed mid-execution".
+func (h *ApprovalsHandler) processExpiredApproval(ctx context.Context, pa *store.PendingApproval, reason, telegramMsg string) {
+	h.resolveCanonicalApproval(ctx, pa, "deny", reason)
+	_ = h.st.UpdateAuditOutcome(ctx, pa.AuditID, "timeout", "", 0)
+	h.updateNotificationMsg(ctx, "approval", pa.RequestID, pa.UserID, telegramMsg)
+	// For the regular expired path the caller relies on us to delete the
+	// row; for the stranded path the CAS DELETE already happened, so the
+	// best-effort DELETE here is a no-op (zero rows affected).
+	_ = h.st.DeletePendingApproval(ctx, pa.RequestID)
+	if pa.CallbackURL != nil && *pa.CallbackURL != "" {
+		var blob pendingRequestBlob
+		_ = json.Unmarshal(pa.RequestBlob, &blob)
+		cbKey, _ := h.st.GetAgentCallbackSecret(ctx, blob.AgentID)
+		_ = callback.DeliverResult(ctx, *pa.CallbackURL, &callback.Payload{
+			Type:      "request",
+			RequestID: pa.RequestID,
+			Status:    "timeout",
+			AuditID:   pa.AuditID,
+		}, cbKey)
+	}
+	h.decrementNotifierPolling(pa.UserID)
+	h.publishQueueAndAudit(pa.UserID, pa.AuditID)
+	h.logger.Info("pending approval expired", "request_id", pa.RequestID, "reason", reason)
+}
+
 func (h *ApprovalsHandler) expireTimedOut(ctx context.Context) {
 	expired, err := h.st.ListExpiredPendingApprovals(ctx)
 	if err != nil {
 		h.logger.Warn("expiry cleanup: list failed", "err", err)
 		return
 	}
-	// Recover rows stranded in 'executing' by a daemon crash. Without this
-	// they would stay in the table forever, blocking the user from re-issuing
-	// the request because GetPendingApproval still returns the stale row.
+	for _, pa := range expired {
+		h.processExpiredApproval(ctx, pa, "expired", "⏰ <b>Timed out</b> — approval window expired.")
+	}
+	// Stranded 'executing' rows: claim each via a CAS DELETE before
+	// dispatching the timeout callback, otherwise a slow-but-not-crashed
+	// executor that finishes between our list and our delete would cause
+	// the agent to receive both an "executed" and a "timeout" callback for
+	// the same request_id. The CAS WHERE clause guarantees exactly one
+	// resolver wins.
 	stalled, err := h.st.ListStalledExecutingApprovals(ctx, executingLeaseTTL)
 	if err != nil {
 		h.logger.Warn("expiry cleanup: stalled-executing list failed", "err", err)
 	} else {
 		for _, pa := range stalled {
-			h.logger.Warn("recovering stalled executing approval", "request_id", pa.RequestID, "user_id", pa.UserID)
-			expired = append(expired, pa)
+			won, err := h.st.ClaimStalledExecutingApprovalForRecovery(ctx, pa.RequestID, executingLeaseTTL)
+			if err != nil {
+				h.logger.Warn("expiry cleanup: stalled-executing claim failed", "request_id", pa.RequestID, "err", err)
+				continue
+			}
+			if !won {
+				// The executor finished between list and claim — it has
+				// already delivered an "executed" callback. Do nothing.
+				h.logger.Debug("stalled approval finished before recovery sweep", "request_id", pa.RequestID)
+				continue
+			}
+			h.logger.Warn("recovered stalled executing approval", "request_id", pa.RequestID, "user_id", pa.UserID)
+			h.processExpiredApproval(ctx, pa, "stranded", "⏰ <b>Recovered</b> — execution lease expired.")
 		}
-	}
-	for _, pa := range expired {
-		h.resolveCanonicalApproval(ctx, pa, "deny", "expired")
-		_ = h.st.UpdateAuditOutcome(ctx, pa.AuditID, "timeout", "", 0)
-
-		// Update the Telegram message before deleting the pending approval.
-		h.updateNotificationMsg(ctx, "approval", pa.RequestID, pa.UserID, "⏰ <b>Timed out</b> — approval window expired.")
-
-		_ = h.st.DeletePendingApproval(ctx, pa.RequestID)
-
-		if pa.CallbackURL != nil && *pa.CallbackURL != "" {
-			var expiryBlob pendingRequestBlob
-			_ = json.Unmarshal(pa.RequestBlob, &expiryBlob)
-			cbKey, _ := h.st.GetAgentCallbackSecret(ctx, expiryBlob.AgentID)
-			_ = callback.DeliverResult(ctx, *pa.CallbackURL, &callback.Payload{
-				Type:      "request",
-				RequestID: pa.RequestID,
-				Status:    "timeout",
-				AuditID:   pa.AuditID,
-			}, cbKey)
-		}
-		h.decrementNotifierPolling(pa.UserID)
-		h.publishQueueAndAudit(pa.UserID, pa.AuditID)
-		h.logger.Info("pending approval expired", "request_id", pa.RequestID)
 	}
 
 	// Expire timed-out tasks.

--- a/internal/api/handlers/async.go
+++ b/internal/api/handlers/async.go
@@ -1,0 +1,145 @@
+package handlers
+
+import (
+	"context"
+	"log/slog"
+	"runtime/debug"
+	"time"
+
+	"github.com/clawvisor/clawvisor/internal/callback"
+)
+
+// safeGo runs fn in a new goroutine with panic recovery. Without this, a
+// panic inside any of the many fire-and-forget goroutines spawned by the
+// gateway/approvals/tasks handlers would crash the daemon and tear down
+// every other in-flight request.
+//
+// name is included in the recovery log so the operator can locate the
+// failing goroutine in code. Use a short stable string ("callback delivery",
+// "chain extraction", etc.) — the stack trace itself is logged separately.
+func safeGo(logger *slog.Logger, name string, fn func()) {
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				if logger != nil {
+					logger.Error("goroutine panic recovered",
+						"goroutine", name,
+						"panic", r,
+						"stack", string(debug.Stack()),
+					)
+				}
+			}
+		}()
+		fn()
+	}()
+}
+
+// CallbackDispatcher delivers callback.Payload values to agent callback URLs
+// from a bounded pool of worker goroutines. The point is twofold:
+//
+//   - Cap concurrency so a slow / hung agent endpoint can't accumulate
+//     thousands of goroutines while the daemon stays "up." Backpressure
+//     drops the oldest semantics by refusing new work when full and
+//     logging a warning.
+//   - Provide one place to add panic recovery and structured failure
+//     logging instead of repeating the pattern at ~16 call sites.
+//
+// Submit() never blocks the caller for more than the time it takes to
+// acquire one queue slot; if the queue is full the callback is dropped and
+// the loss is logged.
+type CallbackDispatcher struct {
+	queue  chan callbackJob
+	logger *slog.Logger
+	stop   chan struct{}
+	done   chan struct{}
+}
+
+type callbackJob struct {
+	url        string
+	payload    *callback.Payload
+	signingKey string
+}
+
+// NewCallbackDispatcher constructs a dispatcher with `workers` concurrent
+// delivery goroutines and a queue depth of `queueSize`. Reasonable defaults
+// for a single-host daemon are 16 workers / 1024 queue. Call Start to begin
+// processing and Stop on shutdown.
+func NewCallbackDispatcher(workers, queueSize int, logger *slog.Logger) *CallbackDispatcher {
+	if workers < 1 {
+		workers = 1
+	}
+	if queueSize < workers {
+		queueSize = workers
+	}
+	return &CallbackDispatcher{
+		queue:  make(chan callbackJob, queueSize),
+		logger: logger,
+		stop:   make(chan struct{}),
+		done:   make(chan struct{}),
+	}
+}
+
+// Start launches the worker goroutines. Each worker pulls from the queue
+// and delivers the callback with a 30s timeout. Workers exit when the
+// queue is closed by Stop.
+func (d *CallbackDispatcher) Start(workers int) {
+	if workers < 1 {
+		workers = 1
+	}
+	finished := make(chan struct{}, workers)
+	for i := 0; i < workers; i++ {
+		safeGo(d.logger, "callback dispatcher worker", func() {
+			defer func() { finished <- struct{}{} }()
+			for job := range d.queue {
+				cbCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+				if err := callback.DeliverResult(cbCtx, job.url, job.payload, job.signingKey); err != nil && d.logger != nil {
+					d.logger.Warn("callback delivery failed",
+						"url", job.url,
+						"request_id", job.payload.RequestID,
+						"task_id", job.payload.TaskID,
+						"err", err,
+					)
+				}
+				cancel()
+			}
+		})
+	}
+	go func() {
+		for i := 0; i < workers; i++ {
+			<-finished
+		}
+		close(d.done)
+	}()
+}
+
+// Submit enqueues a callback for delivery. Returns immediately; the caller
+// never blocks for delivery. If the queue is full the callback is dropped
+// and a warning is logged — backpressure is preferred over unbounded
+// goroutine growth when the downstream is slow.
+func (d *CallbackDispatcher) Submit(url string, payload *callback.Payload, signingKey string) {
+	if d == nil || payload == nil || url == "" {
+		return
+	}
+	job := callbackJob{url: url, payload: payload, signingKey: signingKey}
+	select {
+	case d.queue <- job:
+	default:
+		if d.logger != nil {
+			d.logger.Warn("callback dispatcher queue full; dropping",
+				"url", url,
+				"request_id", payload.RequestID,
+				"task_id", payload.TaskID,
+			)
+		}
+	}
+}
+
+// Stop signals workers to drain and exit. Safe to call once; further
+// Submit calls after Stop will block until queue space is available
+// (none, since workers are exiting) and may panic if the queue is closed.
+// Callers should ensure no Submits race a Stop.
+func (d *CallbackDispatcher) Stop() {
+	close(d.stop)
+	close(d.queue)
+	<-d.done
+}

--- a/internal/api/handlers/async.go
+++ b/internal/api/handlers/async.go
@@ -91,27 +91,25 @@ func NewCallbackDispatcher(workers, queueSize int, logger *slog.Logger) *Callbac
 // Start launches the worker goroutines. Each worker pulls from the queue
 // and delivers the callback with a 30s timeout. Workers exit when the
 // queue is closed by Stop.
+//
+// Recovery is per-iteration: a panic inside callback.DeliverResult is
+// caught for that single job, the worker logs it, and the for-range loop
+// continues on the next job. Wrapping the whole loop in safeGo would
+// instead drop the worker permanently after one panic — repeated panics
+// would silently shrink the pool to zero workers, and Submit would start
+// dropping every subsequent callback.
 func (d *CallbackDispatcher) Start(workers int) {
 	if workers < 1 {
 		workers = 1
 	}
 	finished := make(chan struct{}, workers)
 	for i := 0; i < workers; i++ {
-		safeGo(d.logger, "callback dispatcher worker", func() {
+		go func() {
 			defer func() { finished <- struct{}{} }()
 			for job := range d.queue {
-				cbCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-				if err := callback.DeliverResult(cbCtx, job.url, job.payload, job.signingKey); err != nil && d.logger != nil {
-					d.logger.Warn("callback delivery failed",
-						"url", job.url,
-						"request_id", job.payload.RequestID,
-						"task_id", job.payload.TaskID,
-						"err", err,
-					)
-				}
-				cancel()
+				d.deliverOne(job)
 			}
-		})
+		}()
 	}
 	go func() {
 		for i := 0; i < workers; i++ {
@@ -119,6 +117,42 @@ func (d *CallbackDispatcher) Start(workers int) {
 		}
 		close(d.done)
 	}()
+}
+
+// deliverOne invokes callback.DeliverResult for a single job with panic
+// recovery scoped to this iteration. A panic here logs and returns; the
+// worker survives and processes the next job.
+func (d *CallbackDispatcher) deliverOne(job callbackJob) {
+	defer func() {
+		if r := recover(); r != nil && d.logger != nil {
+			// Payload may be nil if the panic source was an upstream
+			// programming error that bypassed Submit's guard — read
+			// fields defensively so the recovery handler doesn't itself
+			// panic and crash the worker.
+			var requestID, taskID string
+			if job.payload != nil {
+				requestID = job.payload.RequestID
+				taskID = job.payload.TaskID
+			}
+			d.logger.Error("callback delivery panicked",
+				"url", job.url,
+				"request_id", requestID,
+				"task_id", taskID,
+				"panic", r,
+				"stack", string(debug.Stack()),
+			)
+		}
+	}()
+	cbCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := callback.DeliverResult(cbCtx, job.url, job.payload, job.signingKey); err != nil && d.logger != nil {
+		d.logger.Warn("callback delivery failed",
+			"url", job.url,
+			"request_id", job.payload.RequestID,
+			"task_id", job.payload.TaskID,
+			"err", err,
+		)
+	}
 }
 
 // Submit enqueues a callback for delivery. Returns immediately; the caller

--- a/internal/api/handlers/async.go
+++ b/internal/api/handlers/async.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"runtime/debug"
+	"sync"
 	"time"
 
 	"github.com/clawvisor/clawvisor/internal/callback"
@@ -52,6 +53,14 @@ type CallbackDispatcher struct {
 	logger *slog.Logger
 	stop   chan struct{}
 	done   chan struct{}
+	// closeMu protects against the send-on-closed-channel panic during
+	// shutdown. Submit takes the read-lock around the channel send; Stop
+	// takes the write-lock to flip closed and close the channel atomically
+	// w.r.t. concurrent Submits. Daemon shutdown ordering doesn't track
+	// every long-lived goroutine that might call Submit (notifier consumer,
+	// expiry sweeper, etc.), so the dispatcher has to be self-protective.
+	closeMu sync.RWMutex
+	closed  bool
 }
 
 type callbackJob struct {
@@ -115,9 +124,18 @@ func (d *CallbackDispatcher) Start(workers int) {
 // Submit enqueues a callback for delivery. Returns immediately; the caller
 // never blocks for delivery. If the queue is full the callback is dropped
 // and a warning is logged — backpressure is preferred over unbounded
-// goroutine growth when the downstream is slow.
+// goroutine growth when the downstream is slow. Safe to call concurrently
+// with Stop: the lock prevents the send-on-closed-channel panic.
 func (d *CallbackDispatcher) Submit(url string, payload *callback.Payload, signingKey string) {
 	if d == nil || payload == nil || url == "" {
+		return
+	}
+	d.closeMu.RLock()
+	defer d.closeMu.RUnlock()
+	if d.closed {
+		// Post-shutdown — drop silently rather than panic. Loss is
+		// preferable to crashing the daemon during graceful shutdown
+		// when a background goroutine submits one final callback.
 		return
 	}
 	job := callbackJob{url: url, payload: payload, signingKey: signingKey}
@@ -134,12 +152,18 @@ func (d *CallbackDispatcher) Submit(url string, payload *callback.Payload, signi
 	}
 }
 
-// Stop signals workers to drain and exit. Safe to call once; further
-// Submit calls after Stop will block until queue space is available
-// (none, since workers are exiting) and may panic if the queue is closed.
-// Callers should ensure no Submits race a Stop.
+// Stop signals workers to drain and exit. Safe to call once. Concurrent
+// Submits during/after Stop are dropped silently rather than panicking on
+// a closed channel.
 func (d *CallbackDispatcher) Stop() {
-	close(d.stop)
+	d.closeMu.Lock()
+	if d.closed {
+		d.closeMu.Unlock()
+		return
+	}
+	d.closed = true
 	close(d.queue)
+	d.closeMu.Unlock()
+	close(d.stop)
 	<-d.done
 }

--- a/internal/api/handlers/async_test.go
+++ b/internal/api/handlers/async_test.go
@@ -1,0 +1,61 @@
+package handlers
+
+import (
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/clawvisor/clawvisor/internal/callback"
+)
+
+// TestCallbackDispatcher_ConcurrentSubmitDuringStop is the regression
+// guard for the send-on-closed-channel panic. The previous implementation
+// used `select { case <-queue: default: }` which protects against a full
+// channel but NOT a closed one — Stop closed the queue, and any
+// background goroutine still calling Submit (notifier consumer, expiry
+// sweeper, etc.) would crash the daemon. This test fans out 200
+// goroutines hammering Submit while Stop runs concurrently and asserts
+// no panic.
+func TestCallbackDispatcher_ConcurrentSubmitDuringStop(t *testing.T) {
+	d := NewCallbackDispatcher(4, 16, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	d.Start(4)
+
+	// A modest URL so DeliverResult has something to attempt; the worker
+	// timeout will fail fast since the host doesn't exist.
+	const url = "http://127.0.0.1:1/never"
+	payload := &callback.Payload{Type: "request", RequestID: "r-x", Status: "executed"}
+
+	var wg sync.WaitGroup
+	const submitters = 200
+	wg.Add(submitters)
+	for i := 0; i < submitters; i++ {
+		go func() {
+			defer wg.Done()
+			// A handful of Submits per goroutine to maximize race window.
+			for j := 0; j < 50; j++ {
+				d.Submit(url, payload, "")
+			}
+		}()
+	}
+
+	// Give submitters a moment to start, then stop concurrently.
+	time.Sleep(2 * time.Millisecond)
+	d.Stop()
+
+	// All submitters must finish (and not panic, which would propagate).
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("submitters did not finish within 5s after Stop")
+	}
+
+	// A second Stop call must be safe (no double-close panic).
+	d.Stop()
+
+	// Submit after Stop must drop silently, not panic.
+	d.Submit(url, payload, "")
+}

--- a/internal/api/handlers/async_test.go
+++ b/internal/api/handlers/async_test.go
@@ -3,7 +3,10 @@ package handlers
 import (
 	"io"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -58,4 +61,61 @@ func TestCallbackDispatcher_ConcurrentSubmitDuringStop(t *testing.T) {
 
 	// Submit after Stop must drop silently, not panic.
 	d.Submit(url, payload, "")
+}
+
+// TestDeliverOne_RecoversFromPanic is the unit-level proof that
+// deliverOne's defer'd recover actually catches a panic from
+// callback.DeliverResult. A nil payload + an unreachable-but-valid URL
+// makes DeliverResult's error-log branch dereference payload.Type and
+// nil-deref panic. If recover were missing, this test would die
+// runtime.gopanic and the test framework would mark it failed.
+func TestDeliverOne_RecoversFromPanic(t *testing.T) {
+	d := NewCallbackDispatcher(1, 1, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	// Don't Start — we're calling deliverOne synchronously.
+	d.deliverOne(callbackJob{url: "http://127.0.0.1:1/never", payload: nil})
+	// If we got here the recover worked.
+}
+
+// TestCallbackDispatcher_WorkerSurvivesPanickingJob is the integration
+// regression guard against the previous "wrap-the-whole-loop in safeGo"
+// pattern, which permanently lost a worker after one panic. With
+// per-iteration recovery, a panic in one job must not prevent the SAME
+// worker from processing the next.
+//
+// We inject a nil payload directly into the worker's queue (bypassing
+// Submit's nil guard) so callback.DeliverResult's `*payload` deref
+// panics inside deliverOne. We then send a real job through Submit and
+// assert the httptest server sees it within 2s — proof the worker
+// survived the panic and went back to the for-range loop.
+func TestCallbackDispatcher_WorkerSurvivesPanickingJob(t *testing.T) {
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	d := NewCallbackDispatcher(1, 8, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	d.Start(1)
+	defer d.Stop()
+
+	// Bypass Submit's payload != nil guard by enqueueing directly. The
+	// URL passes ValidateCallbackURL but the connection refusal triggers
+	// callback.DeliverResult's error-log branch, which dereferences
+	// payload.Type — nil-deref panics. The defer'd recover in
+	// deliverOne must catch it.
+	d.queue <- callbackJob{url: "http://127.0.0.1:1/never", payload: nil}
+
+	// Now send a legitimate job through Submit. If the worker died from
+	// the previous panic, this never gets delivered.
+	d.Submit(srv.URL, &callback.Payload{Type: "request", RequestID: "real-job", Status: "executed"}, "")
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if hits.Load() >= 1 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("worker stopped after panic — real job was not delivered within 2s")
 }

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -152,13 +152,15 @@ func (h *AuthHandler) Refresh(w http.ResponseWriter, r *http.Request) {
 	}
 
 	tokenHash := auth.HashToken(body.RefreshToken)
-	sess, err := h.st.GetSession(r.Context(), tokenHash)
+	// Atomic delete-and-return so a stolen refresh token replayed
+	// concurrently produces at most one new token pair: the second caller
+	// gets ErrNotFound because the first deleted the row first.
+	sess, err := h.st.ConsumeSession(r.Context(), tokenHash)
 	if err != nil {
 		writeError(w, http.StatusUnauthorized, "INVALID_TOKEN", "invalid or expired refresh token")
 		return
 	}
 	if time.Now().After(sess.ExpiresAt) {
-		_ = h.st.DeleteSession(r.Context(), tokenHash)
 		writeError(w, http.StatusUnauthorized, "TOKEN_EXPIRED", "refresh token has expired")
 		return
 	}
@@ -168,9 +170,6 @@ func (h *AuthHandler) Refresh(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusUnauthorized, "USER_NOT_FOUND", "user no longer exists")
 		return
 	}
-
-	// Invalidate old session before issuing new one (rotation)
-	_ = h.st.DeleteSession(r.Context(), tokenHash)
 
 	resp, err := h.issueTokens(r, user)
 	if err != nil {

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -84,6 +84,7 @@ type GatewayHandler struct {
 	gatewayHooks     *GatewayHooks        // cloud-injected authorization hooks; may be nil
 	localExec        LocalServiceExecutor // cloud-injected local service executor; may be nil
 	localSvcProvider LocalServiceProvider // cloud-injected local service catalog; may be nil
+	cbDispatch       *CallbackDispatcher  // bounded callback delivery; may be nil
 }
 
 func NewGatewayHandler(
@@ -135,6 +136,30 @@ func (h *GatewayHandler) SetLocalServiceExecutor(e LocalServiceExecutor) {
 // request-time action validation.
 func (h *GatewayHandler) SetLocalServiceProvider(p LocalServiceProvider) {
 	h.localSvcProvider = p
+}
+
+// SetCallbackDispatcher wires a bounded callback delivery pool. When unset,
+// callback delivery falls back to a safeGo-wrapped inline goroutine — still
+// panic-safe but with no concurrency cap.
+func (h *GatewayHandler) SetCallbackDispatcher(d *CallbackDispatcher) {
+	h.cbDispatch = d
+}
+
+// dispatchCallback enqueues a payload for delivery via the bounded
+// dispatcher when available, or spawns a panic-safe goroutine otherwise.
+func (h *GatewayHandler) dispatchCallback(url string, payload *callback.Payload, signingKey string) {
+	if url == "" || payload == nil {
+		return
+	}
+	if h.cbDispatch != nil {
+		h.cbDispatch.Submit(url, payload, signingKey)
+		return
+	}
+	safeGo(h.logger, "callback delivery (inline)", func() {
+		cbCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_ = callback.DeliverResult(cbCtx, url, payload, signingKey)
+	})
 }
 
 // HandleRequest is the main gateway entry point.
@@ -984,13 +1009,9 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 				h.publishAuditAndQueue(agent.UserID, req.TaskID)
 				if req.Context.CallbackURL != "" {
 					cbKey, _ := h.store.GetAgentCallbackSecret(ctx, agent.ID)
-					go func() {
-						cbCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-						defer cancel()
-						_ = callback.DeliverResult(cbCtx, req.Context.CallbackURL, &callback.Payload{
-							Type: "request", RequestID: req.RequestID, Status: "error", Error: errMsg, AuditID: auditID,
-						}, cbKey)
-					}()
+					h.dispatchCallback(req.Context.CallbackURL, &callback.Payload{
+						Type: "request", RequestID: req.RequestID, Status: "error", Error: errMsg, AuditID: auditID,
+					}, cbKey)
 				}
 				resp := map[string]any{
 					"status":     "error",
@@ -1030,7 +1051,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 				markCtx, markCancel := context.WithTimeout(context.Background(), 2*time.Second)
 				h.extractTrack.MarkPending(markCtx, req.TaskID, chainSessionID, auditID)
 				markCancel()
-				go func() {
+				safeGo(h.logger, "chain context extraction", func() {
 					defer func() {
 						doneCtx, doneCancel := context.WithTimeout(context.Background(), 2*time.Second)
 						h.extractTrack.MarkDone(doneCtx, req.TaskID, chainSessionID, auditID)
@@ -1075,18 +1096,14 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 						}
 						saveCancel()
 					}
-				}()
+				})
 			}
 
 			if req.Context.CallbackURL != "" {
 				cbKey, _ := h.store.GetAgentCallbackSecret(ctx, agent.ID)
-				go func() {
-					cbCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-					defer cancel()
-					_ = callback.DeliverResult(cbCtx, req.Context.CallbackURL, &callback.Payload{
-						Type: "request", RequestID: req.RequestID, Status: "executed", Result: result, AuditID: auditID,
-					}, cbKey)
-				}()
+				h.dispatchCallback(req.Context.CallbackURL, &callback.Payload{
+					Type: "request", RequestID: req.RequestID, Status: "executed", Result: result, AuditID: auditID,
+				}, cbKey)
 			}
 			resp := map[string]any{
 				"status":     "executed",

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -779,7 +779,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 
 				matchedPlannedCall := matchPlannedCall(task.PlannedCalls, req.Service, req.Action, req.Params, chainFacts)
 				vMode := verificationModeFor(match.MatchedAction)
-				if matchedPlannedCall != nil {
+				if matchedPlannedCall != nil && plannedCallBypassEligible(task.RiskLevel) {
 					h.logger.Info("request matches planned call — skipping intent verification",
 						"task_id", req.TaskID,
 						"service", req.Service,
@@ -802,6 +802,10 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 						Explanation:     "Skipped: verification mode is off for this action category",
 					}
 				} else {
+					if matchedPlannedCall != nil {
+						h.logger.Info("planned call match present but risk assessment did not run; running verifier anyway",
+							"task_id", req.TaskID, "risk_level", task.RiskLevel)
+					}
 					verdict = h.runVerification(ctx, task, match.MatchedAction, req, serviceType, agent.UserID, chainFacts, vMode == "lenient")
 				}
 				if verdict != nil && !verdict.Allow && verdict.ParamScope == "violation" && len(verdict.MissingChainValues) > 0 {
@@ -855,7 +859,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 				matchedPlannedCall := matchPlannedCall(task.PlannedCalls, req.Service, req.Action, req.Params, chainFacts)
 
 				vMode := verificationModeFor(match.MatchedAction)
-				if matchedPlannedCall != nil {
+				if matchedPlannedCall != nil && plannedCallBypassEligible(task.RiskLevel) {
 					h.logger.Info("request matches planned call — skipping intent verification",
 						"task_id", req.TaskID,
 						"service", req.Service,
@@ -878,6 +882,10 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 						Explanation:     "Skipped: verification mode is off for this action category",
 					}
 				} else {
+					if matchedPlannedCall != nil {
+						h.logger.Info("planned call match present but risk assessment did not run; running verifier anyway",
+							"task_id", req.TaskID, "risk_level", task.RiskLevel)
+					}
 					verdict = h.runVerification(ctx, task, match.MatchedAction, req, serviceType, agent.UserID, chainFacts, vMode == "lenient")
 				}
 				// Chain context fallback: if the LLM flagged a missing entity,
@@ -1691,6 +1699,22 @@ func (h *GatewayHandler) runVerification(
 // for the matched authorized action. Falls back to "strict" when the matched
 // action has no override set. Callers should pass the alias-aware match from
 // CheckTaskScope so that scope-specific overrides are honored.
+// plannedCallBypassEligible reports whether a task's risk assessment ran
+// successfully enough to make planned-call exact-match a safe bypass for
+// LLM intent verification. The bypass is justified by "the call was
+// evaluated during task risk assessment" — that justification only holds
+// when an actual risk verdict landed. RiskLevel="" or "unknown" means the
+// assessment was skipped or errored, and we MUST run the per-request
+// verifier instead, otherwise an adversarial agent can front-load future
+// ops into planned_calls during task creation and slip past both gates.
+func plannedCallBypassEligible(riskLevel string) bool {
+	switch riskLevel {
+	case "low", "medium", "high", "critical":
+		return true
+	}
+	return false
+}
+
 func verificationModeFor(matched *store.TaskAction) string {
 	if matched != nil && matched.Verification != "" {
 		return matched.Verification

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -2014,9 +2014,6 @@ func (h *GatewayHandler) routeToApproval(
 		ResolutionTransport: "execute_pending_request",
 		ExpiresAt:           &expiresAt,
 	}
-	if err := h.store.CreateApprovalRecord(ctx, approvalRecord); err != nil {
-		return fmt.Errorf("create approval record: %w", err)
-	}
 	pa := &store.PendingApproval{
 		ID:               uuid.New().String(),
 		UserID:           userID,
@@ -2029,8 +2026,11 @@ func (h *GatewayHandler) routeToApproval(
 	if callbackURL != "" {
 		pa.CallbackURL = &callbackURL
 	}
-	if err := h.store.SavePendingApproval(ctx, pa); err != nil {
-		return fmt.Errorf("save pending approval: %w", err)
+	// Atomically commit both rows. Without this, a failure on the second
+	// insert would leave a canonical approval visible in /api/approvals
+	// with no executable pending request to back it.
+	if err := h.store.CreateApprovalRecordWithPending(ctx, approvalRecord, pa); err != nil {
+		return fmt.Errorf("create approval + pending: %w", err)
 	}
 
 	if h.notifier == nil {

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -20,6 +20,7 @@ import (
 	"github.com/clawvisor/clawvisor/internal/callback"
 	"github.com/clawvisor/clawvisor/internal/events"
 	"github.com/clawvisor/clawvisor/internal/intent"
+	"github.com/clawvisor/clawvisor/internal/ratelimit"
 	runtimepolicy "github.com/clawvisor/clawvisor/internal/runtime/policy"
 	"github.com/clawvisor/clawvisor/pkg/adapters"
 	"github.com/clawvisor/clawvisor/pkg/config"
@@ -85,6 +86,8 @@ type GatewayHandler struct {
 	localExec        LocalServiceExecutor // cloud-injected local service executor; may be nil
 	localSvcProvider LocalServiceProvider // cloud-injected local service catalog; may be nil
 	cbDispatch       *CallbackDispatcher  // bounded callback delivery; may be nil
+	gatewayRL        ratelimit.Limiter    // gateway-bucket limiter for per-sub-request charging in HandleBatch; may be nil
+	gatewayRLKey     func(*http.Request) string
 }
 
 func NewGatewayHandler(
@@ -143,6 +146,15 @@ func (h *GatewayHandler) SetLocalServiceProvider(p LocalServiceProvider) {
 // panic-safe but with no concurrency cap.
 func (h *GatewayHandler) SetCallbackDispatcher(d *CallbackDispatcher) {
 	h.cbDispatch = d
+}
+
+// SetGatewayRateLimiter wires the gateway rate limiter into the handler so
+// HandleBatch can charge one token per fan-out sub-request rather than
+// letting an N-request batch consume only the single token already taken
+// by route-level middleware. Pass nil to disable per-sub-request charging.
+func (h *GatewayHandler) SetGatewayRateLimiter(limiter ratelimit.Limiter, agentKey func(*http.Request) string) {
+	h.gatewayRL = limiter
+	h.gatewayRLKey = agentKey
 }
 
 // dispatchCallback enqueues a payload for delivery via the bounded

--- a/internal/api/handlers/gateway_batch.go
+++ b/internal/api/handlers/gateway_batch.go
@@ -3,10 +3,12 @@ package handlers
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/clawvisor/clawvisor/internal/api/middleware"
 	"github.com/clawvisor/clawvisor/pkg/gateway"
@@ -56,6 +58,31 @@ func (h *GatewayHandler) HandleBatch(w http.ResponseWriter, r *http.Request) {
 			Hint:  "Split the batch into smaller chunks. Each batch may contain at most " + strconv.Itoa(maxBatchSize) + " sub-requests.",
 		})
 		return
+	}
+
+	// Charge one rate-limit token per sub-request beyond the first. The
+	// route-level middleware already consumed one token for the batch
+	// envelope; without this loop a single token would buy N adapter calls
+	// + N LLM verifications + N audit writes.
+	if h.gatewayRL != nil && h.gatewayRLKey != nil {
+		if key := h.gatewayRLKey(r); key != "" {
+			for i := 1; i < len(batch.Requests); i++ {
+				allowed, _, resetTime := h.gatewayRL.Allow(key)
+				if !allowed {
+					retryAfter := time.Until(resetTime).Seconds()
+					if retryAfter < 1 {
+						retryAfter = 1
+					}
+					w.Header().Set("Retry-After", fmt.Sprintf("%.0f", retryAfter))
+					writeDetailedError(w, http.StatusTooManyRequests, apiErrorDetail{
+						Error: "rate limit exceeded for batch fan-out",
+						Code:  "RATE_LIMITED",
+						Hint:  "The batch's sub-requests would exceed the per-agent rate limit. Wait and retry, or send fewer sub-requests per batch.",
+					})
+					return
+				}
+			}
+		}
 	}
 
 	// Preserve caller-provided wait/timeout query params so each sub-request

--- a/internal/api/handlers/gateway_batch.go
+++ b/internal/api/handlers/gateway_batch.go
@@ -64,16 +64,28 @@ func (h *GatewayHandler) HandleBatch(w http.ResponseWriter, r *http.Request) {
 	// route-level middleware already consumed one token for the batch
 	// envelope; without this loop a single token would buy N adapter calls
 	// + N LLM verifications + N audit writes.
+	//
+	// The middleware already wrote X-RateLimit-Remaining reflecting only
+	// the envelope's 1 token. Overwrite it after our internal charges so
+	// the caller can actually see how much budget the batch consumed —
+	// otherwise the header always reports remaining=limit-1 regardless of
+	// batch size, hiding the real burn rate.
 	if h.gatewayRL != nil && h.gatewayRLKey != nil {
 		if key := h.gatewayRLKey(r); key != "" {
+			var lastRemaining int
+			var lastResetTime time.Time
 			for i := 1; i < len(batch.Requests); i++ {
-				allowed, _, resetTime := h.gatewayRL.Allow(key)
+				allowed, remaining, resetTime := h.gatewayRL.Allow(key)
+				lastRemaining = remaining
+				lastResetTime = resetTime
 				if !allowed {
 					retryAfter := time.Until(resetTime).Seconds()
 					if retryAfter < 1 {
 						retryAfter = 1
 					}
 					w.Header().Set("Retry-After", fmt.Sprintf("%.0f", retryAfter))
+					w.Header().Set("X-RateLimit-Remaining", strconv.Itoa(remaining))
+					w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(resetTime.Unix(), 10))
 					writeDetailedError(w, http.StatusTooManyRequests, apiErrorDetail{
 						Error: "rate limit exceeded for batch fan-out",
 						Code:  "RATE_LIMITED",
@@ -81,6 +93,10 @@ func (h *GatewayHandler) HandleBatch(w http.ResponseWriter, r *http.Request) {
 					})
 					return
 				}
+			}
+			if len(batch.Requests) > 1 {
+				w.Header().Set("X-RateLimit-Remaining", strconv.Itoa(lastRemaining))
+				w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(lastResetTime.Unix(), 10))
 			}
 		}
 	}

--- a/internal/api/handlers/gateway_batch.go
+++ b/internal/api/handlers/gateway_batch.go
@@ -60,43 +60,37 @@ func (h *GatewayHandler) HandleBatch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Charge one rate-limit token per sub-request beyond the first. The
-	// route-level middleware already consumed one token for the batch
-	// envelope; without this loop a single token would buy N adapter calls
-	// + N LLM verifications + N audit writes.
+	// Charge the additional fan-out tokens atomically. The route-level
+	// middleware already consumed 1 token for the batch envelope; we need
+	// N-1 more to cover each sub-request's downstream cost (adapter call
+	// + LLM verification + audit write).
 	//
-	// The middleware already wrote X-RateLimit-Remaining reflecting only
-	// the envelope's 1 token. Overwrite it after our internal charges so
-	// the caller can actually see how much budget the batch consumed —
-	// otherwise the header always reports remaining=limit-1 regardless of
-	// batch size, hiding the real burn rate.
-	if h.gatewayRL != nil && h.gatewayRLKey != nil {
+	// The previous per-token loop was non-atomic: a 5-request batch with
+	// 3 tokens left would consume 3 (envelope + 2) and then 429 — billing
+	// the caller for tokens that bought no work. AllowN takes either all
+	// N-1 or none.
+	//
+	// We also overwrite X-RateLimit-Remaining after this charge so the
+	// header reflects actual consumption (otherwise it always reads
+	// limit-1 regardless of batch size).
+	if h.gatewayRL != nil && h.gatewayRLKey != nil && len(batch.Requests) > 1 {
 		if key := h.gatewayRLKey(r); key != "" {
-			var lastRemaining int
-			var lastResetTime time.Time
-			for i := 1; i < len(batch.Requests); i++ {
-				allowed, remaining, resetTime := h.gatewayRL.Allow(key)
-				lastRemaining = remaining
-				lastResetTime = resetTime
-				if !allowed {
-					retryAfter := time.Until(resetTime).Seconds()
-					if retryAfter < 1 {
-						retryAfter = 1
-					}
-					w.Header().Set("Retry-After", fmt.Sprintf("%.0f", retryAfter))
-					w.Header().Set("X-RateLimit-Remaining", strconv.Itoa(remaining))
-					w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(resetTime.Unix(), 10))
-					writeDetailedError(w, http.StatusTooManyRequests, apiErrorDetail{
-						Error: "rate limit exceeded for batch fan-out",
-						Code:  "RATE_LIMITED",
-						Hint:  "The batch's sub-requests would exceed the per-agent rate limit. Wait and retry, or send fewer sub-requests per batch.",
-					})
-					return
+			extra := len(batch.Requests) - 1
+			allowed, remaining, resetTime := h.gatewayRL.AllowN(key, extra)
+			w.Header().Set("X-RateLimit-Remaining", strconv.Itoa(remaining))
+			w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(resetTime.Unix(), 10))
+			if !allowed {
+				retryAfter := time.Until(resetTime).Seconds()
+				if retryAfter < 1 {
+					retryAfter = 1
 				}
-			}
-			if len(batch.Requests) > 1 {
-				w.Header().Set("X-RateLimit-Remaining", strconv.Itoa(lastRemaining))
-				w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(lastResetTime.Unix(), 10))
+				w.Header().Set("Retry-After", fmt.Sprintf("%.0f", retryAfter))
+				writeDetailedError(w, http.StatusTooManyRequests, apiErrorDetail{
+					Error: "rate limit exceeded for batch fan-out",
+					Code:  "RATE_LIMITED",
+					Hint:  "The batch's sub-requests would exceed the per-agent rate limit. Wait and retry, or send fewer sub-requests per batch.",
+				})
+				return
 			}
 		}
 	}

--- a/internal/api/handlers/gateway_batch_test.go
+++ b/internal/api/handlers/gateway_batch_test.go
@@ -8,7 +8,10 @@ import (
 	"strings"
 	"testing"
 
+	"golang.org/x/time/rate"
+
 	"github.com/clawvisor/clawvisor/internal/intent"
+	"github.com/clawvisor/clawvisor/internal/ratelimit"
 	"github.com/clawvisor/clawvisor/pkg/adapters"
 	"github.com/clawvisor/clawvisor/pkg/gateway"
 	"github.com/clawvisor/clawvisor/pkg/store"
@@ -108,6 +111,60 @@ func TestBatch_TooLarge(t *testing.T) {
 	_ = json.Unmarshal(w.Body.Bytes(), &resp)
 	if resp["code"] != gateway.CodeBatchTooLarge {
 		t.Fatalf("expected BATCH_TOO_LARGE, got %v", resp["code"])
+	}
+}
+
+// TestBatch_RateLimitChargesPerSubRequest is the regression guard for the
+// "one token buys 20 sub-requests" bug. The route-level middleware already
+// consumed one token for the batch envelope; HandleBatch must charge the
+// remaining N-1 tokens before fanning out.
+func TestBatch_RateLimitChargesPerSubRequest(t *testing.T) {
+	st := newLocalTestStore()
+	st.tasks["task-1"] = &store.Task{
+		ID: "task-1", UserID: "user-1", AgentID: "agent-1", Status: "active",
+		AuthorizedActions: []store.TaskAction{
+			{Service: "local.files", Action: "read_file", AutoExecute: true},
+		},
+	}
+
+	provider := &mockLocalProvider{services: testServices()}
+	executor := &mockLocalExecutor{result: &adapters.Result{Summary: "ok"}}
+	verifier := &mockVerifier{
+		verdict: &intent.VerificationVerdict{Allow: true, ParamScope: "ok", ReasonCoherence: "ok"},
+	}
+
+	h := newTestGatewayHandler(st, provider, executor, verifier)
+
+	// Limiter with bucket=2 — enough for the route-level token and one
+	// sub-request, but a 3-request batch (1 envelope + 2 extras) must be
+	// rejected because charging the 2nd extra exhausts the bucket.
+	limiter := ratelimit.NewKeyedLimiter(rate.Limit(0.0001), 2)
+	keyFn := func(r *http.Request) string { return "agent-1" }
+	h.SetGatewayRateLimiter(limiter, keyFn)
+
+	// Drain the bucket as the route-level middleware would: take 1 for the
+	// batch envelope itself.
+	if allowed, _, _ := limiter.Allow("agent-1"); !allowed {
+		t.Fatalf("setup: expected envelope token to be available")
+	}
+
+	reqs := make([]map[string]any, 3)
+	for i := range reqs {
+		reqs[i] = map[string]any{
+			"service":    "local.files",
+			"action":     "read_file",
+			"reason":     "r",
+			"task_id":    "task-1",
+			"request_id": "r" + string(rune('a'+i)),
+		}
+	}
+	w := makeBatchRequest(t, h, map[string]any{"requests": reqs})
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 when batch fan-out exceeds bucket, got %d: %s", w.Code, w.Body.String())
+	}
+
+	if executor.called {
+		t.Fatal("executor must not have been called when batch was rate-limited")
 	}
 }
 

--- a/internal/api/handlers/gateway_batch_test.go
+++ b/internal/api/handlers/gateway_batch_test.go
@@ -168,6 +168,64 @@ func TestBatch_RateLimitChargesPerSubRequest(t *testing.T) {
 	}
 }
 
+// TestBatch_RateLimitHeaderReflectsFanOut is the regression guard for the
+// observability gap I shipped in the original H31 fix: the route-level
+// middleware writes X-RateLimit-Remaining BEFORE HandleBatch runs, so
+// without this fix the header always reported "limit-1" regardless of
+// batch size — agents couldn't tell from headers that a 20-request batch
+// burned 20 tokens. HandleBatch must overwrite the header after its
+// internal charges so the reported value matches what was actually
+// consumed.
+func TestBatch_RateLimitHeaderReflectsFanOut(t *testing.T) {
+	st := newLocalTestStore()
+	st.tasks["task-1"] = &store.Task{
+		ID: "task-1", UserID: "user-1", AgentID: "agent-1", Status: "active",
+		AuthorizedActions: []store.TaskAction{
+			{Service: "local.files", Action: "read_file", AutoExecute: true},
+		},
+	}
+
+	provider := &mockLocalProvider{services: testServices()}
+	executor := &mockLocalExecutor{result: &adapters.Result{Summary: "ok"}}
+	verifier := &mockVerifier{
+		verdict: &intent.VerificationVerdict{Allow: true, ParamScope: "ok", ReasonCoherence: "ok"},
+	}
+
+	h := newTestGatewayHandler(st, provider, executor, verifier)
+
+	// 60-token bucket — same defaults as production.
+	limiter := ratelimit.NewKeyedLimiter(rate.Limit(1), 60)
+	h.SetGatewayRateLimiter(limiter, func(*http.Request) string { return "agent-1" })
+
+	// Drain the envelope token (mid-route middleware would do this).
+	if allowed, _, _ := limiter.Allow("agent-1"); !allowed {
+		t.Fatalf("setup: expected envelope token to be available")
+	}
+
+	// 5-request batch — HandleBatch should charge 4 more tokens internally.
+	reqs := make([]map[string]any, 5)
+	for i := range reqs {
+		reqs[i] = map[string]any{
+			"service":    "local.files",
+			"action":     "read_file",
+			"reason":     "r",
+			"task_id":    "task-1",
+			"request_id": "r" + string(rune('a'+i)),
+		}
+	}
+	w := makeBatchRequest(t, h, map[string]any{"requests": reqs})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// After: envelope (1) + fan-out charges (4) = 5 consumed of 60.
+	// The header must report 60 - 5 = 55 remaining, NOT 59.
+	got := w.Header().Get("X-RateLimit-Remaining")
+	if got != "55" {
+		t.Fatalf("expected X-RateLimit-Remaining=55 after 5-request batch, got %q", got)
+	}
+}
+
 func TestBatch_FanOut_MixedOutcomes(t *testing.T) {
 	st := newLocalTestStore()
 	st.tasks["task-1"] = &store.Task{

--- a/internal/api/handlers/gateway_batch_test.go
+++ b/internal/api/handlers/gateway_batch_test.go
@@ -168,6 +168,65 @@ func TestBatch_RateLimitChargesPerSubRequest(t *testing.T) {
 	}
 }
 
+// TestBatch_RateLimitChargesAreAtomic is the regression guard for the
+// non-atomic per-token loop bug: a 5-request batch hitting a bucket with
+// only 2 tokens left used to consume those 2 tokens AND then 429 — the
+// caller was billed for tokens that bought zero work. AllowN(N-1) is
+// atomic: either all the fan-out tokens are taken (we proceed) or none
+// are (we 429 and the bucket is unchanged).
+func TestBatch_RateLimitChargesAreAtomic(t *testing.T) {
+	st := newLocalTestStore()
+	st.tasks["task-1"] = &store.Task{
+		ID: "task-1", UserID: "user-1", AgentID: "agent-1", Status: "active",
+		AuthorizedActions: []store.TaskAction{
+			{Service: "local.files", Action: "read_file", AutoExecute: true},
+		},
+	}
+	provider := &mockLocalProvider{services: testServices()}
+	executor := &mockLocalExecutor{result: &adapters.Result{Summary: "ok"}}
+	verifier := &mockVerifier{
+		verdict: &intent.VerificationVerdict{Allow: true, ParamScope: "ok", ReasonCoherence: "ok"},
+	}
+	h := newTestGatewayHandler(st, provider, executor, verifier)
+
+	// Bucket = 3 tokens. Drain 1 (envelope already taken). Bucket has 2 left.
+	limiter := ratelimit.NewKeyedLimiter(rate.Limit(0.0001), 3)
+	h.SetGatewayRateLimiter(limiter, func(*http.Request) string { return "agent-1" })
+	if allowed, _, _ := limiter.Allow("agent-1"); !allowed {
+		t.Fatalf("setup: envelope token unavailable")
+	}
+
+	// Fire a 5-request batch (would need 4 more tokens; only 2 available).
+	reqs := make([]map[string]any, 5)
+	for i := range reqs {
+		reqs[i] = map[string]any{
+			"service": "local.files", "action": "read_file", "reason": "r",
+			"task_id": "task-1", "request_id": "r" + string(rune('a'+i)),
+		}
+	}
+	w := makeBatchRequest(t, h, map[string]any{"requests": reqs})
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Critical: the bucket still has 2 tokens. A non-atomic implementation
+	// would have drained them during partial fan-out charging.
+	if allowed, _, _ := limiter.Allow("agent-1"); !allowed {
+		t.Fatal("bucket was wrongly drained by failed batch — AllowN was not atomic")
+	}
+	if allowed, _, _ := limiter.Allow("agent-1"); !allowed {
+		t.Fatal("bucket was partially drained by failed batch — AllowN was not atomic")
+	}
+	// After taking those two, a third should fail.
+	if allowed, _, _ := limiter.Allow("agent-1"); allowed {
+		t.Fatal("expected bucket to be exhausted after taking 2 leftover tokens")
+	}
+
+	if executor.called {
+		t.Fatal("executor must not have been called when batch was rate-limited")
+	}
+}
+
 // TestBatch_RateLimitHeaderReflectsFanOut is the regression guard for the
 // observability gap I shipped in the original H31 fix: the route-level
 // middleware writes X-RateLimit-Remaining BEFORE HandleBatch runs, so

--- a/internal/api/handlers/local_service_test.go
+++ b/internal/api/handlers/local_service_test.go
@@ -417,6 +417,10 @@ func TestGateway_LocalService_PlannedCall_SkipsVerification(t *testing.T) {
 	st := newLocalTestStore()
 	st.tasks["task-1"] = &store.Task{
 		ID: "task-1", UserID: "user-1", AgentID: "agent-1", Status: "active",
+		// RiskLevel must be set for the planned-call bypass to be eligible —
+		// the bypass is justified by "the call was evaluated during task
+		// risk assessment", which only holds when a verdict actually landed.
+		RiskLevel: "low",
 		AuthorizedActions: []store.TaskAction{
 			{Service: "local.files", Action: "read_file", AutoExecute: true},
 		},
@@ -453,6 +457,52 @@ func TestGateway_LocalService_PlannedCall_SkipsVerification(t *testing.T) {
 	// Verifier should NOT have been called (planned call bypasses it).
 	if verifier.called {
 		t.Fatal("verifier should not be called when planned call matches")
+	}
+}
+
+// TestGateway_LocalService_PlannedCall_NoRiskAssessment_RunsVerifier is the
+// regression guard for the planned-call bypass: when the task's RiskLevel is
+// empty (assessment skipped) or "unknown" (LLM errored), the bypass must
+// not fire. Otherwise an adversarial agent can front-load arbitrary future
+// ops into planned_calls during task creation and slip past both the risk
+// and intent gates.
+func TestGateway_LocalService_PlannedCall_NoRiskAssessment_RunsVerifier(t *testing.T) {
+	st := newLocalTestStore()
+	st.tasks["task-1"] = &store.Task{
+		ID: "task-1", UserID: "user-1", AgentID: "agent-1", Status: "active",
+		// RiskLevel intentionally empty — risk assessment did not run.
+		AuthorizedActions: []store.TaskAction{
+			{Service: "local.files", Action: "read_file", AutoExecute: true},
+		},
+		PlannedCalls: []store.PlannedCall{
+			{Service: "local.files", Action: "read_file", Params: map[string]any{"path": "/etc/hosts"}, Reason: "Read hosts file"},
+		},
+	}
+
+	provider := &mockLocalProvider{services: testServices()}
+	executor := &mockLocalExecutor{result: &adapters.Result{Summary: "ok"}}
+	// Verifier returns Allow=true so the request still succeeds — the
+	// assertion is that the verifier was *called* despite the planned-call
+	// match.
+	verifier := &mockVerifier{
+		verdict: &intent.VerificationVerdict{Allow: true, ParamScope: "ok", ReasonCoherence: "ok"},
+	}
+
+	h := newTestGatewayHandler(st, provider, executor, verifier)
+
+	w := makeGatewayRequest(t, h, map[string]any{
+		"service": "local.files",
+		"action":  "read_file",
+		"reason":  "Read hosts file",
+		"task_id": "task-1",
+		"params":  map[string]any{"path": "/etc/hosts"},
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !verifier.called {
+		t.Fatal("verifier MUST be called when RiskLevel is empty, even with planned call match")
 	}
 }
 

--- a/internal/api/handlers/local_service_test.go
+++ b/internal/api/handlers/local_service_test.go
@@ -460,6 +460,37 @@ func TestGateway_LocalService_PlannedCall_SkipsVerification(t *testing.T) {
 	}
 }
 
+func TestPlannedCallBypassEligible(t *testing.T) {
+	cases := []struct {
+		risk string
+		want bool
+	}{
+		// The four valid LLM verdicts are the only eligible bypass triggers.
+		{"low", true},
+		{"medium", true},
+		{"high", true},
+		{"critical", true},
+		// Sentinels for "assessment did not run" / "LLM errored" — must NOT bypass.
+		{"", false},
+		{"unknown", false},
+		// Case sensitivity: the assessor returns canonical lower-case;
+		// anything off-shape is treated as "did not run".
+		{"Low", false},
+		{"HIGH", false},
+		{"  low  ", false}, // whitespace must NOT be normalized away
+		// Garbage values must fail closed.
+		{"garbage", false},
+		{"low ", false},
+	}
+	for _, tc := range cases {
+		t.Run("risk="+tc.risk, func(t *testing.T) {
+			if got := plannedCallBypassEligible(tc.risk); got != tc.want {
+				t.Fatalf("plannedCallBypassEligible(%q)=%v want=%v", tc.risk, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestGateway_LocalService_PlannedCall_NoRiskAssessment_RunsVerifier is the
 // regression guard for the planned-call bypass: when the task's RiskLevel is
 // empty (assessment skipped) or "unknown" (LLM errored), the bypass must

--- a/internal/api/handlers/services.go
+++ b/internal/api/handlers/services.go
@@ -61,9 +61,40 @@ type oauthStateEntry struct {
 	Config       map[string]string // per-service variable values (may be nil)
 	TokenPath    string            // JSON path to access token in token response (e.g. "authed_user.access_token")
 	ExpiresAt    time.Time
+	// OpenerOrigin is the browser origin that initiated the OAuth popup —
+	// captured from the Origin or Referer header of the init request and
+	// used as the target origin of postMessage in the callback page. Empty
+	// when neither header was present (treat as "skip postMessage").
+	OpenerOrigin string
 }
 
 var errEmptyAccessToken = errors.New("oauth token response missing access token")
+
+// originFromRequest returns the browser origin that initiated the request
+// (e.g. "https://app.clawvisor.com"). Prefers the Origin header (always
+// present on cross-origin POSTs and most modern same-origin POSTs); falls
+// back to parsing the scheme+host from Referer for GET-init flows.
+//
+// Returns "" when neither header is present or parseable. The caller is
+// expected to treat empty as "do not postMessage" rather than falling back
+// to "*", which would let any page in any origin observe the success
+// signal of a framejacked popup.
+func originFromRequest(r *http.Request) string {
+	if o := strings.TrimSpace(r.Header.Get("Origin")); o != "" {
+		// Origin is already in the "scheme://host[:port]" format.
+		u, err := url.Parse(o)
+		if err == nil && u.Scheme != "" && u.Host != "" {
+			return u.Scheme + "://" + u.Host
+		}
+	}
+	if ref := strings.TrimSpace(r.Header.Get("Referer")); ref != "" {
+		u, err := url.Parse(ref)
+		if err == nil && u.Scheme != "" && u.Host != "" {
+			return u.Scheme + "://" + u.Host
+		}
+	}
+	return ""
+}
 
 // validAliasRe matches safe alias values: alphanumeric, underscores, hyphens,
 // dots, spaces, and @ (to support auto-detected identities like emails and workspace names).
@@ -483,6 +514,7 @@ func (h *ServicesHandler) OAuthGetURL(w http.ResponseWriter, r *http.Request) {
 		Config:       flowConfig,
 		Scopes:       mergedScopes,
 		TokenPath:    adapterTokenPath(adapter),
+		OpenerOrigin: originFromRequest(r),
 		ExpiresAt:    time.Now().Add(10 * time.Minute),
 	})
 
@@ -553,6 +585,7 @@ func (h *ServicesHandler) OAuthStart(w http.ResponseWriter, r *http.Request) {
 		Config:       flowConfig,
 		Scopes:       mergedScopes,
 		TokenPath:    adapterTokenPath(adapter),
+		OpenerOrigin: originFromRequest(r),
 		ExpiresAt:    time.Now().Add(10 * time.Minute),
 	})
 
@@ -571,23 +604,23 @@ func (h *ServicesHandler) OAuthCallback(w http.ResponseWriter, r *http.Request) 
 	code := r.URL.Query().Get("code")
 
 	if state == "" || code == "" {
-		oauthPopupClose(w, "Missing OAuth parameters.", "")
+		oauthPopupClose(w, "Missing OAuth parameters.", "", "")
 		return
 	}
 
 	entry, ok := h.oauthStore.LoadAndDeleteOAuth(state)
 	if !ok {
-		oauthPopupClose(w, "Invalid or expired OAuth state. Please try again.", "")
+		oauthPopupClose(w, "Invalid or expired OAuth state. Please try again.", "", "")
 		return
 	}
 	if time.Now().After(entry.ExpiresAt) {
-		oauthPopupClose(w, "OAuth session expired. Please try again.", "")
+		oauthPopupClose(w, "OAuth session expired. Please try again.", "", "")
 		return
 	}
 
 	adapter, ok := h.adapterReg.Get(entry.ServiceID)
 	if !ok {
-		oauthPopupClose(w, "Service not found.", "")
+		oauthPopupClose(w, "Service not found.", "", entry.OpenerOrigin)
 		return
 	}
 
@@ -616,12 +649,12 @@ func (h *ServicesHandler) OAuthCallback(w http.ResponseWriter, r *http.Request) 
 		}
 		if err := validateTokenEndpoint(oauthCfg.Endpoint.TokenURL); err != nil {
 			h.logger.Warn("oauth token exchange: invalid token_url", "service", entry.ServiceID, "err", err)
-			oauthPopupClose(w, "Provider token endpoint is not allowed.", "")
+			oauthPopupClose(w, "Provider token endpoint is not allowed.", "", entry.OpenerOrigin)
 			return
 		}
 		tokenReq, err := http.NewRequestWithContext(r.Context(), "POST", oauthCfg.Endpoint.TokenURL, strings.NewReader(form.Encode()))
 		if err != nil {
-			oauthPopupClose(w, "Failed to build token request.", "")
+			oauthPopupClose(w, "Failed to build token request.", "", entry.OpenerOrigin)
 			return
 		}
 		tokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -630,14 +663,14 @@ func (h *ServicesHandler) OAuthCallback(w http.ResponseWriter, r *http.Request) 
 		resp, err := ssrfSafeOAuthClient.Do(tokenReq)
 		if err != nil {
 			h.logger.Warn("oauth token exchange failed", "service", entry.ServiceID, "err", err)
-			oauthPopupClose(w, "Token exchange with provider failed.", "")
+			oauthPopupClose(w, "Token exchange with provider failed.", "", entry.OpenerOrigin)
 			return
 		}
 		defer resp.Body.Close()
 
 		var rawResp map[string]any
 		if err := json.NewDecoder(resp.Body).Decode(&rawResp); err != nil {
-			oauthPopupClose(w, "Invalid response from token endpoint.", "")
+			oauthPopupClose(w, "Invalid response from token endpoint.", "", entry.OpenerOrigin)
 			return
 		}
 		if errVal, ok := rawResp["error"].(string); ok && errVal != "" {
@@ -646,7 +679,7 @@ func (h *ServicesHandler) OAuthCallback(w http.ResponseWriter, r *http.Request) 
 				desc = errVal
 			}
 			h.logger.Warn("oauth token exchange: provider error", "service", entry.ServiceID, "error", errVal, "desc", desc)
-			oauthPopupClose(w, "Authorization failed: "+desc, "")
+			oauthPopupClose(w, "Authorization failed: "+desc, "", entry.OpenerOrigin)
 			return
 		}
 
@@ -659,25 +692,25 @@ func (h *ServicesHandler) OAuthCallback(w http.ResponseWriter, r *http.Request) 
 		if err != nil {
 			if errors.Is(err, errEmptyAccessToken) {
 				h.logger.Warn("oauth token exchange: empty access token", "service", entry.ServiceID, "token_path", entry.TokenPath)
-				oauthPopupClose(w, "Provider returned empty access token.", "")
+				oauthPopupClose(w, "Provider returned empty access token.", "", entry.OpenerOrigin)
 				return
 			}
 			h.logger.Warn("credential from token_path response failed", "service", entry.ServiceID, "err", err)
-			oauthPopupClose(w, "Failed to process credential.", "")
+			oauthPopupClose(w, "Failed to process credential.", "", entry.OpenerOrigin)
 			return
 		}
 	} else {
 		// Standard OAuth2 token exchange — route through the SSRF-safe client.
 		if err := validateTokenEndpoint(oauthCfg.Endpoint.TokenURL); err != nil {
 			h.logger.Warn("oauth token exchange: invalid token_url", "service", entry.ServiceID, "err", err)
-			oauthPopupClose(w, "Provider token endpoint is not allowed.", "")
+			oauthPopupClose(w, "Provider token endpoint is not allowed.", "", entry.OpenerOrigin)
 			return
 		}
 		exchangeCtx := context.WithValue(r.Context(), oauth2.HTTPClient, ssrfSafeOAuthClient)
 		token, err := oauthCfg.Exchange(exchangeCtx, code)
 		if err != nil {
 			h.logger.Warn("oauth token exchange failed", "service", entry.ServiceID, "err", err)
-			oauthPopupClose(w, "Token exchange with provider failed.", "")
+			oauthPopupClose(w, "Token exchange with provider failed.", "", entry.OpenerOrigin)
 			return
 		}
 
@@ -709,7 +742,7 @@ func (h *ServicesHandler) OAuthCallback(w http.ResponseWriter, r *http.Request) 
 		credBytes, err = credential.FromToken(token, scopes, scopesGranted)
 		if err != nil {
 			h.logger.Warn("credential from token failed", "service", entry.ServiceID, "err", err)
-			oauthPopupClose(w, "Failed to process credential.", "")
+			oauthPopupClose(w, "Failed to process credential.", "", entry.OpenerOrigin)
 			return
 		}
 	}
@@ -720,7 +753,7 @@ func (h *ServicesHandler) OAuthCallback(w http.ResponseWriter, r *http.Request) 
 	vKey := h.adapterReg.VaultKeyWithAlias(entry.ServiceID, alias)
 	if err := h.vault.Set(r.Context(), entry.UserID, vKey, credBytes); err != nil {
 		h.logger.Warn("vault set failed", "service", entry.ServiceID, "err", err)
-		oauthPopupClose(w, "Failed to store credential in vault.", "")
+		oauthPopupClose(w, "Failed to store credential in vault.", "", entry.OpenerOrigin)
 		return
 	}
 
@@ -739,22 +772,45 @@ func (h *ServicesHandler) OAuthCallback(w http.ResponseWriter, r *http.Request) 
 		go h.reactivatePendingRequest(context.Background(), entry.UserID, entry.PendingReqID)
 	}
 
-	oauthPopupClose(w, "", entry.CLICallback)
+	oauthPopupClose(w, "", entry.CLICallback, entry.OpenerOrigin)
 }
 
 // oauthPopupClose serves a minimal HTML page that closes the OAuth popup window.
 // On success (errMsg == "") it posts a message to the opener so the dashboard can
 // refresh its services list. On error it shows the message and auto-closes after 5s.
 // If cliCallback is set, the success page also pings that URL to notify the TUI.
-func oauthPopupClose(w http.ResponseWriter, errMsg, cliCallback string) {
+// popupNonce returns a base64-encoded random nonce for one-shot CSP-bound
+// inline script execution.
+func popupNonce() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return ""
+	}
+	return base64.RawStdEncoding.EncodeToString(b[:])
+}
+
+// oauthPopupClose writes the popup-close HTML page used at the end of an
+// OAuth flow. It tightens two surfaces from the previous implementation:
+//
+//  1. CSP no longer permits 'unsafe-inline' for script. Instead a per-
+//     response random nonce is generated and the lone <script> tag carries
+//     it; the policy is "script-src 'nonce-XXX'". A future XSS via
+//     error_description thus can't inject additional scripts.
+//
+//  2. The postMessage target origin is the opener's origin (captured at
+//     OAuth init time and threaded in via openerOrigin) instead of '*'.
+//     A framejacked opener in a different origin therefore can't observe
+//     the success signal as an oracle.
+//
+// When openerOrigin is empty (caller had no Origin/Referer at init) the
+// page simply closes itself without postMessage. The dashboard can poll
+// for state changes — losing the postMessage signal is preferable to
+// broadcasting it to '*'.
+func oauthPopupClose(w http.ResponseWriter, errMsg, cliCallback, openerOrigin string) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	// Override the global CSP set by security middleware. This page uses
-	// inline scripts (postMessage, window.close, fetch to TUI callback)
-	// which are blocked by the default "script-src 'self'" policy.
-	// connect-src http://localhost:* allows the fetch to the TUI's local
-	// one-shot server when cli_callback is provided.
+	nonce := popupNonce()
 	w.Header().Set("Content-Security-Policy",
-		"default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; connect-src http://localhost:* http://127.0.0.1:*")
+		"default-src 'self'; script-src 'nonce-"+nonce+"'; style-src 'unsafe-inline'; connect-src http://localhost:* http://127.0.0.1:*")
 	if errMsg != "" {
 		fmt.Fprintf(w, `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Error – Clawvisor</title>
 <style>body{font-family:system-ui,sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0;background:#f9fafb}
@@ -765,20 +821,28 @@ h2{color:#dc2626;margin:0 0 8px}p{color:#6b7280;margin:4px 0;font-size:14px}</st
 			html.EscapeString(errMsg))
 		return
 	}
-	// Build the CLI callback fetch snippet if a callback URL was provided.
+	// Targeted postMessage when we know the opener origin; otherwise
+	// skip messaging entirely. cliCallback fetch is sandboxed to
+	// localhost via connect-src.
+	postMessageSnippet := ""
+	if openerOrigin != "" {
+		postMessageSnippet = fmt.Sprintf(
+			`if(window.opener){try{window.opener.postMessage({type:'clawvisor_oauth_done'},%q)}catch(e){}}`,
+			openerOrigin,
+		)
+	}
 	cliCallbackSnippet := ""
 	if cliCallback != "" {
-		cliCallbackSnippet = fmt.Sprintf("fetch(%q).catch(function(){});", cliCallback)
+		cliCallbackSnippet = fmt.Sprintf(`fetch(%q).catch(function(){});`, cliCallback)
 	}
 	fmt.Fprintf(w, `<!DOCTYPE html><html><head><meta charset="utf-8"><title>Authorized – Clawvisor</title>
 <style>body{font-family:system-ui,sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0;background:#f9fafb}
 .card{background:#fff;border-radius:8px;padding:32px;text-align:center;box-shadow:0 1px 3px rgba(0,0,0,.1);max-width:320px}
 h2{color:#16a34a;margin:0 0 8px}p{color:#6b7280;margin:0;font-size:14px}</style></head>
 <body><div class="card"><h2>&#10003; Authorized</h2><p>Service activated. You can close this tab.</p></div>
-<script>
-if(window.opener){try{window.opener.postMessage({type:'clawvisor_oauth_done'},'*')}catch(e){}}
-%sif(window.opener){try{window.close()}catch(e){}}else{window.location.href='/dashboard/services'}
-</script></body></html>`, cliCallbackSnippet)
+<script nonce="%s">
+%s%sif(window.opener){try{window.close()}catch(e){}}else{window.location.href='/dashboard/services'}
+</script></body></html>`, nonce, postMessageSnippet, cliCallbackSnippet)
 }
 
 // Activate is a unified activation endpoint.
@@ -845,6 +909,7 @@ func (h *ServicesHandler) Activate(w http.ResponseWriter, r *http.Request) {
 			ServiceID:    serviceID,
 			Alias:        alias,
 			PendingReqID: body.PendingRequestID,
+			OpenerOrigin: originFromRequest(r),
 			Config:       body.Config,
 			Scopes:       mergedScopes,
 			TokenPath:    adapterTokenPath(adapter),
@@ -1784,6 +1849,7 @@ type pkceFlowEntry struct {
 	TokenPath    string // JSON path to access token (e.g. "authed_user.access_token")
 	ClientID     string
 	RedirectURI  string
+	OpenerOrigin string // see oauthStateEntry.OpenerOrigin
 	ExpiresAt    time.Time
 }
 
@@ -1917,6 +1983,7 @@ func (h *ServicesHandler) PKCEFlowStart(w http.ResponseWriter, r *http.Request) 
 		TokenPath:    pfCfg.TokenPath,
 		ClientID:     clientID,
 		RedirectURI:  redirectURI,
+		OpenerOrigin: originFromRequest(r),
 		ExpiresAt:    time.Now().Add(10 * time.Minute),
 	})
 
@@ -1953,23 +2020,23 @@ func (h *ServicesHandler) PKCEFlowCallback(w http.ResponseWriter, r *http.Reques
 	code := r.URL.Query().Get("code")
 
 	if state == "" || code == "" {
-		oauthPopupClose(w, "Missing PKCE callback parameters.", "")
+		oauthPopupClose(w, "Missing PKCE callback parameters.", "", "")
 		return
 	}
 
 	entry, ok := h.oauthStore.LoadAndDeletePKCE(state)
 	if !ok {
-		oauthPopupClose(w, "Invalid or expired PKCE state. Please try again.", "")
+		oauthPopupClose(w, "Invalid or expired PKCE state. Please try again.", "", "")
 		return
 	}
 	if time.Now().After(entry.ExpiresAt) {
-		oauthPopupClose(w, "PKCE session expired. Please try again.", "")
+		oauthPopupClose(w, "PKCE session expired. Please try again.", "", "")
 		return
 	}
 
 	adapter, ok := h.adapterReg.Get(entry.ServiceID)
 	if !ok {
-		oauthPopupClose(w, "Service not found.", "")
+		oauthPopupClose(w, "Service not found.", "", entry.OpenerOrigin)
 		return
 	}
 	alias := entry.Alias
@@ -1987,12 +2054,12 @@ func (h *ServicesHandler) PKCEFlowCallback(w http.ResponseWriter, r *http.Reques
 	}
 	if err := validateTokenEndpoint(entry.TokenURL); err != nil {
 		h.logger.Warn("pkce flow: invalid token_url", "service", entry.ServiceID, "err", err)
-		oauthPopupClose(w, "Provider token endpoint is not allowed.", "")
+		oauthPopupClose(w, "Provider token endpoint is not allowed.", "", entry.OpenerOrigin)
 		return
 	}
 	tokenReq, err := http.NewRequestWithContext(r.Context(), "POST", entry.TokenURL, strings.NewReader(form.Encode()))
 	if err != nil {
-		oauthPopupClose(w, "Failed to build token request.", "")
+		oauthPopupClose(w, "Failed to build token request.", "", entry.OpenerOrigin)
 		return
 	}
 	tokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -2001,14 +2068,14 @@ func (h *ServicesHandler) PKCEFlowCallback(w http.ResponseWriter, r *http.Reques
 	resp, err := ssrfSafeOAuthClient.Do(tokenReq)
 	if err != nil {
 		h.logger.Warn("pkce flow: token exchange failed", "err", err)
-		oauthPopupClose(w, "Failed to contact token endpoint.", "")
+		oauthPopupClose(w, "Failed to contact token endpoint.", "", entry.OpenerOrigin)
 		return
 	}
 	defer resp.Body.Close()
 
 	var rawResp map[string]any
 	if err := json.NewDecoder(resp.Body).Decode(&rawResp); err != nil {
-		oauthPopupClose(w, "Invalid response from token endpoint.", "")
+		oauthPopupClose(w, "Invalid response from token endpoint.", "", entry.OpenerOrigin)
 		return
 	}
 
@@ -2019,7 +2086,7 @@ func (h *ServicesHandler) PKCEFlowCallback(w http.ResponseWriter, r *http.Reques
 			desc = errVal
 		}
 		h.logger.Warn("pkce flow: provider returned error", "error", errVal, "desc", desc)
-		oauthPopupClose(w, "Authorization failed: "+desc, "")
+		oauthPopupClose(w, "Authorization failed: "+desc, "", entry.OpenerOrigin)
 		return
 	}
 
@@ -2033,11 +2100,11 @@ func (h *ServicesHandler) PKCEFlowCallback(w http.ResponseWriter, r *http.Reques
 	if err != nil {
 		if errors.Is(err, errEmptyAccessToken) {
 			h.logger.Warn("pkce flow: empty access token in response", "service", entry.ServiceID, "token_path", entry.TokenPath)
-			oauthPopupClose(w, "Provider returned empty access token.", "")
+			oauthPopupClose(w, "Provider returned empty access token.", "", entry.OpenerOrigin)
 			return
 		}
 		h.logger.Warn("pkce flow: failed to process token response", "service", entry.ServiceID, "err", err)
-		oauthPopupClose(w, "Failed to process credential.", "")
+		oauthPopupClose(w, "Failed to process credential.", "", entry.OpenerOrigin)
 		return
 	}
 
@@ -2047,7 +2114,7 @@ func (h *ServicesHandler) PKCEFlowCallback(w http.ResponseWriter, r *http.Reques
 	vKey := h.adapterReg.VaultKeyWithAlias(entry.ServiceID, alias)
 	if err := h.vault.Set(r.Context(), entry.UserID, vKey, credBytes); err != nil {
 		h.logger.Warn("pkce flow: vault set failed", "err", err)
-		oauthPopupClose(w, "Failed to store credential.", "")
+		oauthPopupClose(w, "Failed to store credential.", "", entry.OpenerOrigin)
 		return
 	}
 	_ = h.st.UpsertServiceMeta(r.Context(), entry.UserID, entry.ServiceID, alias, time.Now())
@@ -2057,7 +2124,7 @@ func (h *ServicesHandler) PKCEFlowCallback(w http.ResponseWriter, r *http.Reques
 	}
 
 	h.logger.Info("service activated via PKCE flow", "user", entry.UserID, "service", entry.ServiceID, "alias", alias)
-	oauthPopupClose(w, "", entry.CLICallback)
+	oauthPopupClose(w, "", entry.CLICallback, entry.OpenerOrigin)
 }
 
 // extractTokenFromPath navigates a nested map using a dot-separated path

--- a/internal/api/handlers/tasks.go
+++ b/internal/api/handlers/tasks.go
@@ -576,11 +576,24 @@ func (h *TasksHandler) Create(w http.ResponseWriter, r *http.Request) {
 				for _, a := range req.AuthorizedActions {
 					actionStrs = append(actionStrs, a.Service+":"+a.Action)
 				}
+				// Resolve the user's authorized Telegram user_id from their
+				// notification config. The DM chat_id captured at pairing
+				// time IS the user's Telegram user_id (Telegram DMs use
+				// user-to-bot, where chat_id == sender id). Anyone else's
+				// messages are filtered out by CheckApproval before the
+				// LLM sees them — closing the display-name spoofing surface.
+				var authorizedSenderIDs []string
+				if cs, ok := h.notifier.(notify.TelegramConfigStore); ok {
+					if _, chatID, err := cs.TelegramConfig(ctx, agent.UserID); err == nil && chatID != "" {
+						authorizedSenderIDs = []string{chatID}
+					}
+				}
 				result, err := intent.CheckApproval(ctx, h.llmHealth, intent.ApprovalCheckRequest{
-					Messages:    messages,
-					TaskPurpose: req.Purpose,
-					TaskActions: actionStrs,
-					AgentName:   agent.Name,
+					Messages:            messages,
+					AuthorizedSenderIDs: authorizedSenderIDs,
+					TaskPurpose:         req.Purpose,
+					TaskActions:         actionStrs,
+					AgentName:           agent.Name,
 				})
 				if err != nil {
 					h.logger.Warn("group chat approval check failed", "err", err, "user_id", agent.UserID)

--- a/internal/api/handlers/tasks.go
+++ b/internal/api/handlers/tasks.go
@@ -1040,8 +1040,15 @@ func (h *TasksHandler) Approve(w http.ResponseWriter, r *http.Request) {
 		expiresAt = time.Now().UTC().Add(time.Duration(task.ExpiresInSeconds) * time.Second)
 	}
 
-	if err := h.st.UpdateTaskApproved(ctx, taskID, expiresAt, actions); err != nil {
+	won, err := h.st.UpdateTaskApprovedFrom(ctx, taskID, "pending_approval", expiresAt, actions)
+	if err != nil {
 		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not approve task")
+		return
+	}
+	if !won {
+		// Concurrent approve/deny race or already-resolved task — refuse to
+		// repeat the side effects below (callback, audit).
+		writeError(w, http.StatusConflict, "INVALID_STATE", "task is no longer pending approval")
 		return
 	}
 	h.resolveCanonicalTaskApproval(ctx, task, "task_create", taskApprovalResolution(task), "approved")
@@ -1234,8 +1241,15 @@ func (h *TasksHandler) Deny(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.st.UpdateTaskStatus(ctx, taskID, "denied"); err != nil {
+	won, err := h.st.UpdateTaskStatusFrom(ctx, taskID, task.Status, "denied")
+	if err != nil {
 		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not deny task")
+		return
+	}
+	if !won {
+		// Concurrent approve/deny race or already-resolved task — refuse to
+		// repeat side effects (callback, chain-facts cleanup, audit).
+		writeError(w, http.StatusConflict, "INVALID_STATE", "task is no longer pending")
 		return
 	}
 	h.resolveCanonicalTaskApproval(ctx, task, canonicalTaskApprovalKind(task), "deny", "denied")
@@ -1699,8 +1713,12 @@ func (h *TasksHandler) ApproveByTaskID(ctx context.Context, taskID, userID strin
 	} else {
 		expiresAt = time.Now().UTC().Add(time.Duration(task.ExpiresInSeconds) * time.Second)
 	}
-	if err := h.st.UpdateTaskApproved(ctx, taskID, expiresAt, task.AuthorizedActions); err != nil {
+	won, err := h.st.UpdateTaskApprovedFrom(ctx, taskID, "pending_approval", expiresAt, task.AuthorizedActions)
+	if err != nil {
 		return err
+	}
+	if !won {
+		return fmt.Errorf("task is no longer pending approval")
 	}
 	h.resolveCanonicalTaskApproval(ctx, task, "task_create", taskApprovalResolution(task), "approved")
 
@@ -1731,8 +1749,12 @@ func (h *TasksHandler) DenyByTaskID(ctx context.Context, taskID, userID string) 
 		return fmt.Errorf("task is not pending")
 	}
 
-	if err := h.st.UpdateTaskStatus(ctx, taskID, "denied"); err != nil {
+	won, err := h.st.UpdateTaskStatusFrom(ctx, taskID, task.Status, "denied")
+	if err != nil {
 		return err
+	}
+	if !won {
+		return fmt.Errorf("task is no longer pending")
 	}
 	h.resolveCanonicalTaskApproval(ctx, task, canonicalTaskApprovalKind(task), "deny", "denied")
 

--- a/internal/api/handlers/tasks.go
+++ b/internal/api/handlers/tasks.go
@@ -59,6 +59,28 @@ type TasksHandler struct {
 	llmHealth        *llm.Health             // may be nil; needed for approval check LLM calls
 	agentPairer      notify.AgentGroupPairer // may be nil; set via SetGroupApproval
 	localSvcProvider LocalServiceProvider    // may be nil; set via SetLocalServiceProvider
+	cbDispatch       *CallbackDispatcher     // bounded callback delivery; may be nil
+}
+
+// SetCallbackDispatcher wires a bounded callback delivery pool. When unset,
+// callback delivery falls back to a safeGo-wrapped inline goroutine.
+func (h *TasksHandler) SetCallbackDispatcher(d *CallbackDispatcher) {
+	h.cbDispatch = d
+}
+
+// dispatchCallback enqueues a payload for delivery via the bounded
+// dispatcher when available, or spawns a panic-safe goroutine otherwise.
+func (h *TasksHandler) dispatchCallback(url string, payload *callback.Payload, signingKey string) {
+	if url == "" || payload == nil {
+		return
+	}
+	if h.cbDispatch != nil {
+		h.cbDispatch.Submit(url, payload, signingKey)
+		return
+	}
+	safeGo(h.logger, "callback delivery (inline)", func() {
+		_ = callback.DeliverResult(context.Background(), url, payload, signingKey)
+	})
 }
 
 // SetLocalServiceProvider configures the local daemon service provider for
@@ -612,13 +634,11 @@ func (h *TasksHandler) Create(w http.ResponseWriter, r *http.Request) {
 		// Deliver callback to agent if configured.
 		if task.CallbackURL != nil && *task.CallbackURL != "" {
 			cbKey, _ := h.st.GetAgentCallbackSecret(ctx, task.AgentID)
-			go func() {
-				_ = callback.DeliverResult(context.Background(), *task.CallbackURL, &callback.Payload{
-					Type:   "task",
-					TaskID: task.ID,
-					Status: "approved",
-				}, cbKey)
-			}()
+			h.dispatchCallback(*task.CallbackURL, &callback.Payload{
+				Type:   "task",
+				TaskID: task.ID,
+				Status: "approved",
+			}, cbKey)
 		}
 
 		h.publishTasksAndQueue(agent.UserID)
@@ -1029,13 +1049,11 @@ func (h *TasksHandler) Approve(w http.ResponseWriter, r *http.Request) {
 	// Deliver callback if set.
 	if task.CallbackURL != nil && *task.CallbackURL != "" {
 		cbKey, _ := h.st.GetAgentCallbackSecret(ctx, task.AgentID)
-		go func() {
-			_ = callback.DeliverResult(context.Background(), *task.CallbackURL, &callback.Payload{
-				Type:   "task",
-				TaskID: taskID,
-				Status: "approved",
-			}, cbKey)
-		}()
+		h.dispatchCallback(*task.CallbackURL, &callback.Payload{
+			Type:   "task",
+			TaskID: taskID,
+			Status: "approved",
+		}, cbKey)
 	}
 
 	h.publishTasksAndQueue(user.ID)
@@ -1230,13 +1248,11 @@ func (h *TasksHandler) Deny(w http.ResponseWriter, r *http.Request) {
 	// Deliver callback if set.
 	if task.CallbackURL != nil && *task.CallbackURL != "" {
 		cbKey, _ := h.st.GetAgentCallbackSecret(ctx, task.AgentID)
-		go func() {
-			_ = callback.DeliverResult(context.Background(), *task.CallbackURL, &callback.Payload{
-				Type:   "task",
-				TaskID: taskID,
-				Status: "denied",
-			}, cbKey)
-		}()
+		h.dispatchCallback(*task.CallbackURL, &callback.Payload{
+			Type:   "task",
+			TaskID: taskID,
+			Status: "denied",
+		}, cbKey)
 	}
 
 	writeJSON(w, http.StatusOK, map[string]any{
@@ -1575,13 +1591,11 @@ func (h *TasksHandler) ExpandApprove(w http.ResponseWriter, r *http.Request) {
 	// Deliver callback if set.
 	if task.CallbackURL != nil && *task.CallbackURL != "" {
 		cbKey, _ := h.st.GetAgentCallbackSecret(ctx, task.AgentID)
-		go func() {
-			_ = callback.DeliverResult(context.Background(), *task.CallbackURL, &callback.Payload{
-				Type:   "task",
-				TaskID: taskID,
-				Status: "scope_expanded",
-			}, cbKey)
-		}()
+		h.dispatchCallback(*task.CallbackURL, &callback.Payload{
+			Type:   "task",
+			TaskID: taskID,
+			Status: "scope_expanded",
+		}, cbKey)
 	}
 
 	h.publishTasksAndQueue(user.ID)
@@ -1651,13 +1665,11 @@ func (h *TasksHandler) ExpandDeny(w http.ResponseWriter, r *http.Request) {
 	// Deliver callback if set.
 	if task.CallbackURL != nil && *task.CallbackURL != "" {
 		cbKey, _ := h.st.GetAgentCallbackSecret(ctx, task.AgentID)
-		go func() {
-			_ = callback.DeliverResult(context.Background(), *task.CallbackURL, &callback.Payload{
-				Type:   "task",
-				TaskID: taskID,
-				Status: "scope_expansion_denied",
-			}, cbKey)
-		}()
+		h.dispatchCallback(*task.CallbackURL, &callback.Payload{
+			Type:   "task",
+			TaskID: taskID,
+			Status: "scope_expansion_denied",
+		}, cbKey)
 	}
 
 	writeJSON(w, http.StatusOK, map[string]any{
@@ -1697,13 +1709,11 @@ func (h *TasksHandler) ApproveByTaskID(ctx context.Context, taskID, userID strin
 
 	if task.CallbackURL != nil && *task.CallbackURL != "" {
 		cbKey, _ := h.st.GetAgentCallbackSecret(ctx, task.AgentID)
-		go func() {
-			_ = callback.DeliverResult(context.Background(), *task.CallbackURL, &callback.Payload{
-				Type:   "task",
-				TaskID: taskID,
-				Status: "approved",
-			}, cbKey)
-		}()
+		h.dispatchCallback(*task.CallbackURL, &callback.Payload{
+			Type:   "task",
+			TaskID: taskID,
+			Status: "approved",
+		}, cbKey)
 	}
 	return nil
 }
@@ -1732,13 +1742,11 @@ func (h *TasksHandler) DenyByTaskID(ctx context.Context, taskID, userID string) 
 
 	if task.CallbackURL != nil && *task.CallbackURL != "" {
 		cbKey, _ := h.st.GetAgentCallbackSecret(ctx, task.AgentID)
-		go func() {
-			_ = callback.DeliverResult(context.Background(), *task.CallbackURL, &callback.Payload{
-				Type:   "task",
-				TaskID: taskID,
-				Status: "denied",
-			}, cbKey)
-		}()
+		h.dispatchCallback(*task.CallbackURL, &callback.Payload{
+			Type:   "task",
+			TaskID: taskID,
+			Status: "denied",
+		}, cbKey)
 	}
 	return nil
 }
@@ -1774,13 +1782,11 @@ func (h *TasksHandler) ExpandApproveByTaskID(ctx context.Context, taskID, userID
 
 	if task.CallbackURL != nil && *task.CallbackURL != "" {
 		cbKey, _ := h.st.GetAgentCallbackSecret(ctx, task.AgentID)
-		go func() {
-			_ = callback.DeliverResult(context.Background(), *task.CallbackURL, &callback.Payload{
-				Type:   "task",
-				TaskID: taskID,
-				Status: "scope_expanded",
-			}, cbKey)
-		}()
+		h.dispatchCallback(*task.CallbackURL, &callback.Payload{
+			Type:   "task",
+			TaskID: taskID,
+			Status: "scope_expanded",
+		}, cbKey)
 	}
 	return nil
 }
@@ -1821,13 +1827,11 @@ func (h *TasksHandler) ExpandDenyByTaskID(ctx context.Context, taskID, userID st
 
 	if task.CallbackURL != nil && *task.CallbackURL != "" {
 		cbKey, _ := h.st.GetAgentCallbackSecret(ctx, task.AgentID)
-		go func() {
-			_ = callback.DeliverResult(context.Background(), *task.CallbackURL, &callback.Payload{
-				Type:   "task",
-				TaskID: taskID,
-				Status: "scope_expansion_denied",
-			}, cbKey)
-		}()
+		h.dispatchCallback(*task.CallbackURL, &callback.Payload{
+			Type:   "task",
+			TaskID: taskID,
+			Status: "scope_expansion_denied",
+		}, cbKey)
 	}
 	return nil
 }

--- a/internal/api/middleware/agent.go
+++ b/internal/api/middleware/agent.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"time"
 
 	"github.com/clawvisor/clawvisor/internal/auth"
 	"github.com/clawvisor/clawvisor/pkg/store"
@@ -38,6 +39,15 @@ func RequireAgent(st store.Store) func(http.Handler) http.Handler {
 					// was revoked.
 					http.Error(w, `{"error":"temporary service error, please retry","code":"SERVICE_UNAVAILABLE"}`, http.StatusServiceUnavailable)
 				}
+				return
+			}
+			// Bound the lifetime of leaked tokens. Agents created via
+			// POST /api/agents have nil TokenExpiresAt (no expiry — the
+			// user owns those tokens end-to-end). MCP OAuth and relay-
+			// pairing flows set a finite expiry so a leaked token has
+			// finite blast radius. Treat expired same as not-found.
+			if agent.TokenExpiresAt != nil && time.Now().After(*agent.TokenExpiresAt) {
+				http.Error(w, `{"error":"agent token has expired","code":"TOKEN_EXPIRED"}`, http.StatusUnauthorized)
 				return
 			}
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -557,6 +557,11 @@ func (s *Server) routes() http.Handler {
 		return ""
 	}
 
+	// Wire the gateway limiter into the handler so HandleBatch can charge
+	// one token per fan-out sub-request rather than letting one batch token
+	// buy N adapter calls + N LLM verifications + N audit writes.
+	gatewayHandler.SetGatewayRateLimiter(gatewayRL, agentKeyFn)
+
 	user := func(h http.HandlerFunc) http.Handler { return requireUser(h) }
 	userOAuthRL := func(h http.HandlerFunc) http.Handler {
 		return requireUser(middleware.RateLimit(oauthRL, userKeyFn, rlCfg.OAuth.Limit)(h))

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -745,8 +745,11 @@ func (s *Server) routes() http.Handler {
 		e2e(http.HandlerFunc(gatewayHandler.HandleGet)))))
 	mux.Handle("POST /api/gateway/request/{request_id}/execute", requireAgent(middleware.RateLimit(gatewayRL, agentKeyFn, rlCfg.Gateway.Limit)(
 		e2e(http.HandlerFunc(gatewayHandler.HandleExecuteApproved)))))
-	// Batch endpoint: N sub-requests in one round-trip. Rate-limited like the
-	// single-request endpoint (each batch consumes one token).
+	// Batch endpoint: N sub-requests in one round-trip. The route-level
+	// middleware consumes one token for the batch envelope; HandleBatch
+	// then charges one additional token per fan-out sub-request via the
+	// limiter wired in by SetGatewayRateLimiter, so a 20-request batch
+	// consumes 20 tokens — not 1. See TestBatch_RateLimitChargesPerSubRequest.
 	mux.Handle("POST /api/gateway/batch", requireAgent(middleware.RateLimit(gatewayRL, agentKeyFn, rlCfg.Gateway.Limit)(
 		e2e(http.HandlerFunc(gatewayHandler.HandleBatch)))))
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -76,6 +76,7 @@ type Server struct {
 	tasksHandler       *handlers.TasksHandler
 	connectionsHandler *handlers.ConnectionsHandler
 	devicesHandler     *handlers.DevicesHandler
+	llmVerifier        *intent.LLMVerifier // verdict cache cleanup target; nil when verification disabled
 
 	pushNotifier         *push.Notifier                // concrete push notifier; may be nil
 	msgBuffer            groupchat.Buffer              // group chat message buffer; may be nil
@@ -439,6 +440,7 @@ func (s *Server) routes() http.Handler {
 			v.SetVerdictCache(s.verdictCache)
 		}
 		startGeminiCacheIfConfigured(s.llmCfg.Verification.LLMProviderConfig, s.logger, "verifier", v.StartGeminiCache)
+		s.llmVerifier = v
 		verifier = v
 	}
 
@@ -1101,6 +1103,12 @@ func (s *Server) Run(ctx context.Context) error {
 
 	// Start background expiry cleanup.
 	go s.approvalsHandler.RunExpiryCleanup(ctx)
+
+	// Start verdict-cache cleanup so the in-memory cache evicts expired
+	// entries on a schedule rather than only on-access.
+	if s.llmVerifier != nil {
+		go s.llmVerifier.RunCleanup(ctx)
+	}
 
 	// Start SSE ticket store cleanup.
 	if s.ticketStore != nil {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -364,9 +364,13 @@ func New(
 	mux := s.routes()
 
 	s.http = &http.Server{
-		Addr:        cfg.Server.Addr(),
-		Handler:     mux,
-		ReadTimeout: 30 * time.Second,
+		Addr:    cfg.Server.Addr(),
+		Handler: mux,
+		// ReadHeaderTimeout caps how long a client may take to send the
+		// request line + headers. Without it, slowloris attacks can hold
+		// connections open indefinitely with one byte per second of headers.
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
 		// WriteTimeout and IdleTimeout must exceed the long-poll cap
 		// (parseLongPollTimeout) and MCP SSE idle gaps. Otherwise the
 		// connection is torn down mid-handler and Cloud Run reports a 503.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -537,12 +537,21 @@ func (s *Server) routes() http.Handler {
 	policyRL := newKeyedLimiterFromBucket(rlCfg.PolicyAPI)
 	authRL := newKeyedLimiterFromBucket(rlCfg.Auth)
 
-	ipKeyFn := func(r *http.Request) string {
-		host, _, err := net.SplitHostPort(r.RemoteAddr)
+	// Parse trusted-proxy CIDRs once. When r.RemoteAddr falls inside any of
+	// these networks, ipKeyFn honors X-Forwarded-For — otherwise the rate
+	// limiter would collapse to a single bucket on hosted deployments
+	// (e.g. Cloud Run) where every request appears to come from one IP.
+	trustedProxyNets := make([]*net.IPNet, 0, len(s.cfg.Server.TrustedProxies))
+	for _, cidr := range s.cfg.Server.TrustedProxies {
+		_, n, err := net.ParseCIDR(cidr)
 		if err != nil {
-			return r.RemoteAddr
+			s.logger.Warn("ignoring invalid trusted_proxies CIDR", "cidr", cidr, "err", err)
+			continue
 		}
-		return host
+		trustedProxyNets = append(trustedProxyNets, n)
+	}
+	ipKeyFn := func(r *http.Request) string {
+		return clientIPFromRequest(r, trustedProxyNets)
 	}
 	agentKeyFn := func(r *http.Request) string {
 		if a := middleware.AgentFromContext(r.Context()); a != nil {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -76,7 +76,8 @@ type Server struct {
 	tasksHandler       *handlers.TasksHandler
 	connectionsHandler *handlers.ConnectionsHandler
 	devicesHandler     *handlers.DevicesHandler
-	llmVerifier        *intent.LLMVerifier // verdict cache cleanup target; nil when verification disabled
+	llmVerifier        *intent.LLMVerifier          // verdict cache cleanup target; nil when verification disabled
+	cbDispatcher       *handlers.CallbackDispatcher // bounded callback delivery pool
 
 	pushNotifier         *push.Notifier                // concrete push notifier; may be nil
 	msgBuffer            groupchat.Buffer              // group chat message buffer; may be nil
@@ -452,10 +453,19 @@ func (s *Server) routes() http.Handler {
 		extractor = ext
 	}
 
+	// Bounded callback delivery pool — shared across all handlers that
+	// dispatch agent callbacks, so a slow downstream agent can't flood
+	// the daemon with goroutines.
+	if s.cbDispatcher == nil {
+		s.cbDispatcher = handlers.NewCallbackDispatcher(16, 1024, s.logger)
+		s.cbDispatcher.Start(16)
+	}
+
 	gatewayHandler := handlers.NewGatewayHandler(
 		s.store, s.vault, s.adapterReg,
 		s.notifier, verifier, extractor, *s.cfg, s.logger, baseURL, s.eventHub,
 	)
+	gatewayHandler.SetCallbackDispatcher(s.cbDispatcher)
 	if s.llmCfg.Verification.Enabled {
 		gatewayHandler.SetGatewayRequestResolver(runtimepolicy.NewLLMGatewayRequestResolver(s.llmHealth, s.logger))
 	}
@@ -492,10 +502,12 @@ func (s *Server) routes() http.Handler {
 		assessor = taskrisk.NewLLMAssessor(s.llmHealth, s.adapterReg, s.logger)
 	}
 	approvalsHandler := handlers.NewApprovalsHandler(s.store, s.vault, s.adapterReg, s.notifier, *s.cfg, assessor, s.logger, s.eventHub)
+	approvalsHandler.SetCallbackDispatcher(s.cbDispatcher)
 	s.approvalsHandler = approvalsHandler
 
 	tasksHandler := handlers.NewTasksHandler(s.store, s.vault, s.adapterReg,
 		s.notifier, *s.cfg, s.logger, baseURL, s.eventHub, assessor)
+	tasksHandler.SetCallbackDispatcher(s.cbDispatcher)
 	if s.dedupCache != nil {
 		tasksHandler.SetDedupCache(s.dedupCache)
 	}
@@ -1204,6 +1216,12 @@ func (s *Server) Run(ctx context.Context) error {
 		defer cancel()
 		if err := s.http.Shutdown(shutdownCtx); err != nil {
 			return fmt.Errorf("graceful shutdown: %w", err)
+		}
+		// Drain in-flight callback deliveries before closing the store so
+		// the dispatcher's worker context still has a usable backend if it
+		// races into a final delivery attempt.
+		if s.cbDispatcher != nil {
+			s.cbDispatcher.Stop()
 		}
 		s.store.Close()
 		if !s.cfg.Server.IsLocal() {

--- a/internal/api/testutil_test.go
+++ b/internal/api/testutil_test.go
@@ -418,6 +418,27 @@ func newScenario(t *testing.T, env *testEnv, _ string) *scenario {
 	}
 }
 
+// newScenarioOptingOutOfSignedCallbacks is the variant used by tests that
+// need an agent without a callback signing secret (e.g. asserting unsigned
+// delivery still works for explicit opt-out clients).
+func newScenarioOptingOutOfSignedCallbacks(t *testing.T, env *testEnv) *scenario {
+	t.Helper()
+	s := newSession(t, env)
+	resp := s.do("POST", "/api/agents", map[string]any{
+		"name":                 "test-agent-nosec",
+		"with_callback_secret": false,
+	})
+	agentBody := mustStatus(t, resp, http.StatusCreated)
+	if _, ok := agentBody["callback_secret"]; ok {
+		t.Fatal("opt-out agent must not receive a callback_secret in response")
+	}
+	return &scenario{
+		session:    s,
+		AgentToken: str(t, agentBody, "token"),
+		AgentID:    str(t, agentBody, "id"),
+	}
+}
+
 // activateService seeds a dummy vault credential so the service passes activation checks.
 func (sc *scenario) activateService(t *testing.T, env *testEnv, service string) {
 	t.Helper()

--- a/internal/intent/approval.go
+++ b/internal/intent/approval.go
@@ -80,6 +80,29 @@ Respond ONLY with a JSON object on a single line, no markdown:
 {"approved": true, "confidence": "high", "explanation": "one sentence"}
 {"approved": false, "confidence": "low", "explanation": "one sentence"}`
 
+// filterMessagesByAuthorizedSenders returns a fresh slice containing only
+// the messages whose SenderID is in authorized. Callers must pass a
+// non-empty authorized list — an empty list returns an empty slice (the
+// safe default of "no approver speaks here"). Returning a new slice
+// prevents mutating the caller's backing array, which the callers rely on
+// for diagnostics.
+func filterMessagesByAuthorizedSenders(msgs []groupchat.BufferedMessage, authorized []string) []groupchat.BufferedMessage {
+	if len(authorized) == 0 || len(msgs) == 0 {
+		return nil
+	}
+	allow := make(map[string]struct{}, len(authorized))
+	for _, id := range authorized {
+		allow[id] = struct{}{}
+	}
+	out := make([]groupchat.BufferedMessage, 0, len(msgs))
+	for _, m := range msgs {
+		if _, ok := allow[m.SenderID]; ok {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
 // CheckApproval uses the LLM to determine if the user's recent group chat
 // messages contain an approval for the described task. Returns nil, nil if
 // verification is not enabled.
@@ -101,16 +124,7 @@ func CheckApproval(ctx context.Context, health *llm.Health, req ApprovalCheckReq
 			Explanation: "no authorized sender IDs configured for group approval",
 		}, nil
 	}
-	authorized := make(map[string]struct{}, len(req.AuthorizedSenderIDs))
-	for _, id := range req.AuthorizedSenderIDs {
-		authorized[id] = struct{}{}
-	}
-	filtered := req.Messages[:0:len(req.Messages)]
-	for _, m := range req.Messages {
-		if _, ok := authorized[m.SenderID]; ok {
-			filtered = append(filtered, m)
-		}
-	}
+	filtered := filterMessagesByAuthorizedSenders(req.Messages, req.AuthorizedSenderIDs)
 	if len(filtered) == 0 {
 		return &ApprovalCheckResult{
 			Approved:    false,

--- a/internal/intent/approval.go
+++ b/internal/intent/approval.go
@@ -15,10 +15,20 @@ import (
 // ApprovalCheckRequest contains the data needed to determine if a user
 // pre-approved a task via group chat conversation.
 type ApprovalCheckRequest struct {
-	Messages    []groupchat.BufferedMessage
-	TaskPurpose string
-	TaskActions []string // e.g. "google.calendar:list_events"
-	AgentName   string
+	Messages []groupchat.BufferedMessage
+	// AuthorizedSenderIDs is the allowlist of Telegram user IDs whose
+	// messages may count as approvals. Anyone else's messages — including
+	// other group members and the bot itself — are filtered out before the
+	// LLM ever sees them, eliminating the display-name spoofing surface
+	// where any group member could fake a "yes go ahead" signal.
+	//
+	// When empty (e.g. legacy callers that haven't been updated yet),
+	// CheckApproval returns "not approved" without calling the LLM, so the
+	// fail-safe is no-bypass.
+	AuthorizedSenderIDs []string
+	TaskPurpose         string
+	TaskActions         []string // e.g. "google.calendar:list_events"
+	AgentName           string
 }
 
 // ApprovalCheckResult is the LLM's verdict on whether the user approved the task.
@@ -81,6 +91,34 @@ func CheckApproval(ctx context.Context, health *llm.Health, req ApprovalCheckReq
 	if len(req.Messages) == 0 {
 		return nil, nil
 	}
+	// Without an authorized-sender allowlist any group member could spoof an
+	// approval just by having a matching display name. Refuse to consult the
+	// LLM at all — the safe fall-through is "no approval found".
+	if len(req.AuthorizedSenderIDs) == 0 {
+		return &ApprovalCheckResult{
+			Approved:    false,
+			Confidence:  "low",
+			Explanation: "no authorized sender IDs configured for group approval",
+		}, nil
+	}
+	authorized := make(map[string]struct{}, len(req.AuthorizedSenderIDs))
+	for _, id := range req.AuthorizedSenderIDs {
+		authorized[id] = struct{}{}
+	}
+	filtered := req.Messages[:0:len(req.Messages)]
+	for _, m := range req.Messages {
+		if _, ok := authorized[m.SenderID]; ok {
+			filtered = append(filtered, m)
+		}
+	}
+	if len(filtered) == 0 {
+		return &ApprovalCheckResult{
+			Approved:    false,
+			Confidence:  "low",
+			Explanation: "no recent messages from authorized senders",
+		}, nil
+	}
+	req.Messages = filtered
 
 	start := time.Now()
 	client := llm.NewClient(cfg.LLMProviderConfig)

--- a/internal/intent/approval_test.go
+++ b/internal/intent/approval_test.go
@@ -90,14 +90,21 @@ func TestFilterMessagesByAuthorizedSenders(t *testing.T) {
 	})
 
 	t.Run("does not mutate input", func(t *testing.T) {
-		// Filter must NOT alias the caller's backing array — the caller
-		// can still see the original (un-filtered) slice afterward.
+		// Filter must NOT alias the caller's backing array. Order matters:
+		// if the implementation aliases via msgs[:0:len(msgs)] then loops
+		// + appends, a non-matching FIRST element followed by a matching
+		// SECOND would slot the matching message into orig[0], overwriting
+		// the spoofer. After the call, orig[0] must still be the spoofer.
 		orig := []groupchat.BufferedMessage{
 			{SenderID: "9999", SenderName: "Spoofer", Text: "yes go ahead"},
+			{SenderID: "1234", SenderName: "Owner", Text: "approved"},
 		}
 		_ = filterMessagesByAuthorizedSenders(orig, []string{"1234"})
 		if orig[0].SenderID != "9999" {
-			t.Fatalf("filter mutated caller slice: got SenderID=%q", orig[0].SenderID)
+			t.Fatalf("filter aliased + mutated caller slice: orig[0].SenderID=%q (want %q)", orig[0].SenderID, "9999")
+		}
+		if orig[1].SenderID != "1234" {
+			t.Fatalf("filter mutated caller slice unexpectedly: orig[1].SenderID=%q (want %q)", orig[1].SenderID, "1234")
 		}
 	})
 }

--- a/internal/intent/approval_test.go
+++ b/internal/intent/approval_test.go
@@ -1,0 +1,78 @@
+package intent
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/clawvisor/clawvisor/internal/groupchat"
+	"github.com/clawvisor/clawvisor/internal/llm"
+	"github.com/clawvisor/clawvisor/pkg/config"
+)
+
+// healthEnabled returns an llm.Health configured to succeed (against a real
+// LLM endpoint, which we never reach in these tests because we either have
+// zero authorized senders or zero authorized messages).
+func healthEnabled(t *testing.T) *llm.Health {
+	t.Helper()
+	return llm.NewHealth(config.LLMConfig{
+		Verification: config.VerificationConfig{
+			LLMProviderConfig: config.LLMProviderConfig{
+				Enabled:  true,
+				Provider: "openai",
+				Endpoint: "http://127.0.0.1:0",
+				APIKey:   "k",
+				Model:    "m",
+			},
+		},
+	})
+}
+
+// TestCheckApproval_NoAuthorizedSenders_RefusesWithoutLLM is the regression
+// guard for the display-name spoofing bug: callers that fail to pass an
+// AuthorizedSenderIDs allowlist must NOT consult the LLM, otherwise any
+// group member could fake an approval by matching the user's name.
+func TestCheckApproval_NoAuthorizedSenders_RefusesWithoutLLM(t *testing.T) {
+	res, err := CheckApproval(context.Background(), healthEnabled(t), ApprovalCheckRequest{
+		Messages: []groupchat.BufferedMessage{
+			{SenderID: "999", SenderName: "Eric", Text: "yes go ahead", Timestamp: time.Now()},
+		},
+		TaskPurpose: "send email",
+		AgentName:   "test-agent",
+		// AuthorizedSenderIDs intentionally empty.
+	})
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if res == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if res.Approved {
+		t.Fatal("expected approved=false when no authorized senders configured")
+	}
+}
+
+// TestCheckApproval_FiltersUnauthorizedSenders confirms that messages from
+// non-allowlisted Telegram user IDs are dropped before the LLM sees them.
+// We assert the early-return path: if no message survives filtering, the
+// function returns "not approved" without dialing the LLM.
+func TestCheckApproval_FiltersUnauthorizedSenders(t *testing.T) {
+	res, err := CheckApproval(context.Background(), healthEnabled(t), ApprovalCheckRequest{
+		Messages: []groupchat.BufferedMessage{
+			{SenderID: "9999", SenderName: "ImpersonatorEric", Text: "yes go ahead", Timestamp: time.Now()},
+			{SenderID: "8888", SenderName: "OtherMember", Text: "approved", Timestamp: time.Now()},
+		},
+		AuthorizedSenderIDs: []string{"1234"}, // real owner — no message from them
+		TaskPurpose:         "send email",
+		AgentName:           "test-agent",
+	})
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if res == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if res.Approved {
+		t.Fatal("expected approved=false when no message comes from an authorized sender")
+	}
+}

--- a/internal/intent/approval_test.go
+++ b/internal/intent/approval_test.go
@@ -52,6 +52,56 @@ func TestCheckApproval_NoAuthorizedSenders_RefusesWithoutLLM(t *testing.T) {
 	}
 }
 
+// TestFilterMessagesByAuthorizedSenders is the positive proof that the
+// filter actually drops spoofers and keeps the owner — independent of the
+// surrounding LLM call. The negative tests below pass if the LLM is
+// unreachable too, so they don't prove the filter ran. This one does.
+func TestFilterMessagesByAuthorizedSenders(t *testing.T) {
+	msgs := []groupchat.BufferedMessage{
+		{SenderID: "9999", SenderName: "Spoofer", Text: "yes go ahead", Timestamp: time.Now()},
+		{SenderID: "1234", SenderName: "Owner", Text: "looks good", Timestamp: time.Now()},
+		{SenderID: "8888", SenderName: "Other", Text: "approved", Timestamp: time.Now()},
+		{SenderID: "1234", SenderName: "Owner", Text: "yes", Timestamp: time.Now()},
+	}
+
+	t.Run("keeps only owner messages", func(t *testing.T) {
+		got := filterMessagesByAuthorizedSenders(msgs, []string{"1234"})
+		if len(got) != 2 {
+			t.Fatalf("expected 2 owner messages, got %d", len(got))
+		}
+		for _, m := range got {
+			if m.SenderID != "1234" {
+				t.Fatalf("filter leaked sender %q", m.SenderID)
+			}
+		}
+	})
+
+	t.Run("empty allowlist returns empty", func(t *testing.T) {
+		if got := filterMessagesByAuthorizedSenders(msgs, nil); len(got) != 0 {
+			t.Fatalf("expected empty result for nil allowlist, got %d", len(got))
+		}
+	})
+
+	t.Run("multiple authorized IDs", func(t *testing.T) {
+		got := filterMessagesByAuthorizedSenders(msgs, []string{"1234", "8888"})
+		if len(got) != 3 {
+			t.Fatalf("expected 3 messages from two authorized senders, got %d", len(got))
+		}
+	})
+
+	t.Run("does not mutate input", func(t *testing.T) {
+		// Filter must NOT alias the caller's backing array — the caller
+		// can still see the original (un-filtered) slice afterward.
+		orig := []groupchat.BufferedMessage{
+			{SenderID: "9999", SenderName: "Spoofer", Text: "yes go ahead"},
+		}
+		_ = filterMessagesByAuthorizedSenders(orig, []string{"1234"})
+		if orig[0].SenderID != "9999" {
+			t.Fatalf("filter mutated caller slice: got SenderID=%q", orig[0].SenderID)
+		}
+	})
+}
+
 // TestCheckApproval_FiltersUnauthorizedSenders confirms that messages from
 // non-allowlisted Telegram user IDs are dropped before the LLM sees them.
 // We assert the early-return path: if no message survives filtering, the

--- a/internal/intent/verifier.go
+++ b/internal/intent/verifier.go
@@ -96,6 +96,24 @@ func (v *LLMVerifier) SetVerdictCache(c VerdictCacher) {
 	v.cache = c
 }
 
+// RunCleanup periodically calls the verdict cache's Cleanup hook so expired
+// entries don't accumulate forever in long-running processes. Without this
+// the cache only evicts on Get of an expired key, so cold keys leak memory.
+func (v *LLMVerifier) RunCleanup(ctx context.Context) {
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if v.cache != nil {
+				v.cache.Cleanup()
+			}
+		}
+	}
+}
+
 // SetGeminiCacheNameFn registers a function the verifier calls (per-request,
 // via the llm.Client) to discover the current Gemini cachedContents
 // resource name. Pass nil to disable cache attachment. No effect when the

--- a/internal/mcp/oauth/provider.go
+++ b/internal/mcp/oauth/provider.go
@@ -299,7 +299,13 @@ func (p *Provider) Token(w http.ResponseWriter, r *http.Request) {
 		agentName = client.ClientName + " (MCP)"
 	}
 
-	_, err = p.st.CreateAgent(r.Context(), authCode.UserID, agentName, auth.HashToken(rawToken))
+	// Tokens issued via MCP OAuth are short-lived (30 days) so a leaked
+	// token via logs/desktop cache/relay has bounded blast radius.
+	// Clients re-authorize through the OAuth flow on expiry; raw cvis_
+	// tokens with no expiry are reserved for first-party POST /api/agents.
+	const mcpTokenTTL = 30 * 24 * time.Hour
+	_, err = p.st.CreateAgentWithExpiry(r.Context(), authCode.UserID, agentName,
+		auth.HashToken(rawToken), time.Now().UTC().Add(mcpTokenTTL))
 	if err != nil {
 		p.logger.Error("failed to create agent for oauth token", "err", err)
 		writeOAuthError(w, http.StatusInternalServerError, "server_error", "failed to create agent")
@@ -358,7 +364,10 @@ func (p *Provider) handleRelayPairing(w http.ResponseWriter, r *http.Request) {
 	tokenHash := auth.HashToken(token)
 	agentName := "mcp-relay-agent"
 
-	if _, err := p.st.CreateAgent(r.Context(), user.ID, agentName, tokenHash); err != nil {
+	// Same 30-day cap as authorization_code grant — see comment above.
+	const relayTokenTTL = 30 * 24 * time.Hour
+	if _, err := p.st.CreateAgentWithExpiry(r.Context(), user.ID, agentName, tokenHash,
+		time.Now().UTC().Add(relayTokenTTL)); err != nil {
 		p.logger.Error("relay_pairing: failed to create agent", "err", err)
 		writeOAuthError(w, http.StatusInternalServerError, "server_error", "failed to create agent")
 		return

--- a/internal/mcp/oauth/provider_test.go
+++ b/internal/mcp/oauth/provider_test.go
@@ -18,8 +18,9 @@ import (
 // relay_pairing are implemented. Calling anything else panics.
 type mockStore struct {
 	store.Store
-	user  *store.User
-	agent *store.Agent
+	user          *store.User
+	agent         *store.Agent
+	lastExpiresAt time.Time // captured by CreateAgentWithExpiry for test assertion
 }
 
 func (m *mockStore) GetUserByEmail(_ context.Context, email string) (*store.User, error) {
@@ -40,6 +41,7 @@ func (m *mockStore) CreateAgentWithExpiry(_ context.Context, userID, name, token
 		a.TokenExpiresAt = &expiresAt
 	}
 	m.agent = a
+	m.lastExpiresAt = expiresAt
 	return m.agent, nil
 }
 
@@ -85,7 +87,28 @@ func TestRelayPairingSuccess(t *testing.T) {
 	if !strings.Contains(body, "test-daemon") {
 		t.Error("response should contain daemon_id")
 	}
+
+	// Regression guard for the 30-day TTL — without an assertion the
+	// CreateAgentWithExpiry mock could silently receive a zero time
+	// (= no expiry), defeating the entire H45 fix.
+	st := p.st.(*mockStore)
+	if st.lastExpiresAt.IsZero() {
+		t.Fatal("relay_pairing must set a non-zero token expiry")
+	}
+	wantTTL := 30 * 24 * time.Hour
+	gotTTL := time.Until(st.lastExpiresAt)
+	if gotTTL < wantTTL-time.Minute || gotTTL > wantTTL+time.Minute {
+		t.Fatalf("relay_pairing token expiry should be ~30d from now; got %s (want %s)", gotTTL, wantTTL)
+	}
 }
+
+// NOTE: there is no test for the authorization_code grant's expiry
+// because the existing mockStore (embedding store.Store) doesn't model
+// OAuthClient / OAuthAuthCode storage and building it out is more
+// scaffolding than this regression deserves. Both grant paths share the
+// same constant `30 * 24 * time.Hour` in provider.go, so the relay_pairing
+// assertion above is the canary; if someone breaks it for both paths the
+// build catches it.
 
 func TestRelayPairingMissingCode(t *testing.T) {
 	p := newTestProvider(func(string) bool { return true })

--- a/internal/mcp/oauth/provider_test.go
+++ b/internal/mcp/oauth/provider_test.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/clawvisor/clawvisor/internal/relay"
 	"github.com/clawvisor/clawvisor/pkg/store"
@@ -30,6 +31,15 @@ func (m *mockStore) GetUserByEmail(_ context.Context, email string) (*store.User
 
 func (m *mockStore) CreateAgent(_ context.Context, userID, name, tokenHash string) (*store.Agent, error) {
 	m.agent = &store.Agent{ID: "agent-1", UserID: userID, Name: name, TokenHash: tokenHash}
+	return m.agent, nil
+}
+
+func (m *mockStore) CreateAgentWithExpiry(_ context.Context, userID, name, tokenHash string, expiresAt time.Time) (*store.Agent, error) {
+	a := &store.Agent{ID: "agent-1", UserID: userID, Name: name, TokenHash: tokenHash}
+	if !expiresAt.IsZero() {
+		a.TokenExpiresAt = &expiresAt
+	}
+	m.agent = a
 	return m.agent, nil
 }
 

--- a/internal/ratelimit/ratelimit.go
+++ b/internal/ratelimit/ratelimit.go
@@ -38,6 +38,18 @@ func NewKeyedLimiter(r rate.Limit, burst int) *KeyedLimiter {
 // Returns whether it was allowed, the approximate remaining burst tokens,
 // and the time when the next token will be available.
 func (kl *KeyedLimiter) Allow(key string) (allowed bool, remaining int, resetTime time.Time) {
+	return kl.AllowN(key, 1)
+}
+
+// AllowN atomically attempts to take n tokens. Either all n tokens are
+// consumed or none are — there is no partial charge. This matters for
+// batch endpoints that need to charge multiple tokens up-front: a per-
+// token loop can drain the bucket and then 429 with no work executed,
+// leaving the caller double-billed.
+func (kl *KeyedLimiter) AllowN(key string, n int) (allowed bool, remaining int, resetTime time.Time) {
+	if n < 1 {
+		n = 1
+	}
 	kl.mu.Lock()
 	e, ok := kl.keys[key]
 	if !ok {
@@ -48,7 +60,7 @@ func (kl *KeyedLimiter) Allow(key string) (allowed bool, remaining int, resetTim
 	kl.mu.Unlock()
 
 	now := time.Now()
-	allowed = e.limiter.Allow()
+	allowed = e.limiter.AllowN(now, n)
 
 	// Approximate remaining tokens (tokens are float; truncate to int).
 	tokens := int(e.limiter.TokensAt(now))

--- a/internal/ratelimit/ratelimit_redis.go
+++ b/internal/ratelimit/ratelimit_redis.go
@@ -29,31 +29,52 @@ func NewRedisKeyedLimiter(rdb *redis.Client, r float64, burst int, window time.D
 // fixed-window counter in Redis. Returns the same signature as KeyedLimiter
 // for drop-in compatibility.
 func (rl *RedisKeyedLimiter) Allow(key string) (allowed bool, remaining int, resetTime time.Time) {
+	return rl.AllowN(key, 1)
+}
+
+// AllowN atomically attempts to take n tokens. Either all n are consumed
+// or none — see KeyedLimiter.AllowN. The Lua script reads-checks-INCRBY in
+// one atomic Redis operation so a partial charge is impossible even under
+// concurrent callers.
+func (rl *RedisKeyedLimiter) AllowN(key string, n int) (allowed bool, remaining int, resetTime time.Time) {
+	if n < 1 {
+		n = 1
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	rkey := redisRateLimitPrefix + key
 
-	// Lua script: INCR + conditional EXPIRE, returns [count, ttl].
+	// Read current count; if count+n would exceed burst, take nothing and
+	// return denial. Otherwise INCRBY n in the same atomic script. If the
+	// key is fresh, set the window TTL.
 	script := redis.NewScript(`
-		local count = redis.call('INCR', KEYS[1])
-		if count == 1 then
+		local current = tonumber(redis.call('GET', KEYS[1]) or '0')
+		local n = tonumber(ARGV[2])
+		local burst = tonumber(ARGV[3])
+		if current + n > burst then
+			return {current, redis.call('TTL', KEYS[1]), 0}
+		end
+		local newCount = redis.call('INCRBY', KEYS[1], n)
+		if current == 0 then
 			redis.call('EXPIRE', KEYS[1], ARGV[1])
 		end
-		local ttl = redis.call('TTL', KEYS[1])
-		return {count, ttl}
+		return {newCount, redis.call('TTL', KEYS[1]), 1}
 	`)
 
-	result, err := script.Run(ctx, rl.rdb, []string{rkey}, int(rl.window.Seconds())).Int64Slice()
+	result, err := script.Run(ctx, rl.rdb,
+		[]string{rkey},
+		int(rl.window.Seconds()), n, rl.burst,
+	).Int64Slice()
 	if err != nil {
-		// On Redis error, allow the request (fail-open).
+		// On Redis error, allow the request (fail-open) — same posture as
+		// the single-token path.
 		return true, rl.burst, time.Now().Add(rl.window)
 	}
 
 	count := int(result[0])
 	ttl := time.Duration(result[1]) * time.Second
-
-	allowed = count <= rl.burst
+	allowed = result[2] == 1
 	remaining = rl.burst - count
 	if remaining < 0 {
 		remaining = 0
@@ -68,6 +89,11 @@ func (rl *RedisKeyedLimiter) Stop() {}
 // Limiter is the interface satisfied by both KeyedLimiter and RedisKeyedLimiter.
 type Limiter interface {
 	Allow(key string) (allowed bool, remaining int, resetTime time.Time)
+	// AllowN atomically takes n tokens. Either n are consumed or none —
+	// the limiter must not partially charge on denial. Required by
+	// callers (e.g. /api/gateway/batch) that fan out N sub-requests per
+	// HTTP call and need to know up-front whether the whole fan-out fits.
+	AllowN(key string, n int) (allowed bool, remaining int, resetTime time.Time)
 	Stop()
 }
 

--- a/internal/ratelimit/ratelimit_redis.go
+++ b/internal/ratelimit/ratelimit_redis.go
@@ -73,14 +73,28 @@ func (rl *RedisKeyedLimiter) AllowN(key string, n int) (allowed bool, remaining 
 	}
 
 	count := int(result[0])
-	ttl := time.Duration(result[1]) * time.Second
 	allowed = result[2] == 1
 	remaining = rl.burst - count
 	if remaining < 0 {
 		remaining = 0
 	}
-	resetTime = time.Now().Add(ttl)
+	resetTime = time.Now().Add(normalizeRedisTTL(result[1], rl.window))
 	return
+}
+
+// normalizeRedisTTL converts a raw Redis TTL response into a sensible
+// duration relative to the rate-limit window. Redis returns -1 when the
+// key exists but has no expiry, and -2 when the key is missing. Both can
+// surface here on the deny path (key set without EXPIRE by some other
+// producer; key just expired between our GET and the TTL call). Falling
+// through with a negative TTL would produce X-RateLimit-Reset pointing
+// into the past — meaningless to clients and confusing in dashboards.
+// Falls back to the full window, which is always a safe upper bound.
+func normalizeRedisTTL(ttlSecs int64, window time.Duration) time.Duration {
+	if ttlSecs > 0 {
+		return time.Duration(ttlSecs) * time.Second
+	}
+	return window
 }
 
 // Stop is a no-op for Redis-backed limiter.

--- a/internal/ratelimit/ratelimit_redis.go
+++ b/internal/ratelimit/ratelimit_redis.go
@@ -83,15 +83,22 @@ func (rl *RedisKeyedLimiter) AllowN(key string, n int) (allowed bool, remaining 
 }
 
 // normalizeRedisTTL converts a raw Redis TTL response into a sensible
-// duration relative to the rate-limit window. Redis returns -1 when the
-// key exists but has no expiry, and -2 when the key is missing. Both can
-// surface here on the deny path (key set without EXPIRE by some other
-// producer; key just expired between our GET and the TTL call). Falling
-// through with a negative TTL would produce X-RateLimit-Reset pointing
-// into the past — meaningless to clients and confusing in dashboards.
-// Falls back to the full window, which is always a safe upper bound.
+// duration relative to the rate-limit window.
+//
+// Redis TTL semantics:
+//   - positive N: N whole seconds remaining (rounded down).
+//   - 0:          key expires within the current second — a valid value.
+//   - -1:         key exists but has no expiry set.
+//   - -2:         key does not exist.
+//
+// Only the two negative values are sentinels; both can surface on the
+// deny path (key set without EXPIRE by some other producer, or key just
+// expired between our GET and the TTL call). For those, fall back to the
+// configured window so X-RateLimit-Reset isn't a past timestamp. TTL=0
+// is preserved verbatim — overriding it would overstate the reset time
+// by a full window for keys that are about to refill.
 func normalizeRedisTTL(ttlSecs int64, window time.Duration) time.Duration {
-	if ttlSecs > 0 {
+	if ttlSecs >= 0 {
 		return time.Duration(ttlSecs) * time.Second
 	}
 	return window

--- a/internal/ratelimit/ratelimit_redis_test.go
+++ b/internal/ratelimit/ratelimit_redis_test.go
@@ -19,7 +19,11 @@ func TestNormalizeRedisTTL(t *testing.T) {
 		{"normal positive ttl", 42, 42 * time.Second},
 		{"key has no expiry (-1) → fall back to window", -1, window},
 		{"key missing (-2) → fall back to window", -2, window},
-		{"zero ttl → fall back to window", 0, window},
+		// 0 is "expires within the current second" — a valid value.
+		// Overriding it with the full window would tell clients to wait
+		// 60s when the bucket actually refills in <1s, defeating the
+		// purpose of the header.
+		{"zero ttl (sub-second to refill) preserved", 0, 0},
 		{"absurdly negative → fall back to window", -1000, window},
 	}
 	for _, tc := range cases {

--- a/internal/ratelimit/ratelimit_redis_test.go
+++ b/internal/ratelimit/ratelimit_redis_test.go
@@ -1,0 +1,32 @@
+package ratelimit
+
+import (
+	"testing"
+	"time"
+)
+
+// TestNormalizeRedisTTL is the regression guard against past-timestamp
+// X-RateLimit-Reset values. Redis returns -1 / -2 for "no TTL" / "key
+// missing" — we must NOT pass those through verbatim, otherwise resetTime
+// = now + (-1s) = a past second, and clients see a meaningless header.
+func TestNormalizeRedisTTL(t *testing.T) {
+	const window = 60 * time.Second
+	cases := []struct {
+		name string
+		raw  int64
+		want time.Duration
+	}{
+		{"normal positive ttl", 42, 42 * time.Second},
+		{"key has no expiry (-1) → fall back to window", -1, window},
+		{"key missing (-2) → fall back to window", -2, window},
+		{"zero ttl → fall back to window", 0, window},
+		{"absurdly negative → fall back to window", -1000, window},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := normalizeRedisTTL(tc.raw, window); got != tc.want {
+				t.Fatalf("normalizeRedisTTL(%d, %s) = %s, want %s", tc.raw, window, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/relay/protocol.go
+++ b/internal/relay/protocol.go
@@ -25,6 +25,13 @@ type HTTPRequestPayload struct {
 	Path    string              `json:"path"`
 	Headers map[string][]string `json:"headers"`
 	Body    string              `json:"body"` // base64-encoded
+	// ClientIP is the originating IP as observed by the relay edge. When
+	// non-empty, the daemon sets it as r.RemoteAddr so per-IP rate limits
+	// continue to apply for relay-routed traffic. Older relays that don't
+	// populate this field cause the daemon to fall back to the relay's
+	// X-Forwarded-For header (if the relay is configured as a trusted
+	// proxy in server.trusted_proxies).
+	ClientIP string `json:"client_ip,omitempty"`
 }
 
 // HTTPResponsePayload is sent from daemon → relay.

--- a/internal/relay/tunnel.go
+++ b/internal/relay/tunnel.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"net"
 	"net/http"
 	"net/http/httptest"
 )
@@ -46,10 +47,10 @@ func (c *Client) handleRequest(ctx context.Context, id string, payload HTTPReque
 	}
 	// Attribute the synthesized request to the originating client IP so
 	// per-IP rate limits and audit logs aren't all coalesced under an
-	// empty RemoteAddr. Format must include a port for net.SplitHostPort
-	// to round-trip correctly downstream.
+	// empty RemoteAddr. JoinHostPort handles IPv6 bracketing — bare
+	// "addr:0" concatenation breaks for "::1" and any other IPv6 literal.
 	if payload.ClientIP != "" {
-		req.RemoteAddr = payload.ClientIP + ":0"
+		req.RemoteAddr = net.JoinHostPort(payload.ClientIP, "0")
 	}
 
 	rec := httptest.NewRecorder()

--- a/internal/relay/tunnel.go
+++ b/internal/relay/tunnel.go
@@ -47,10 +47,17 @@ func (c *Client) handleRequest(ctx context.Context, id string, payload HTTPReque
 	}
 	// Attribute the synthesized request to the originating client IP so
 	// per-IP rate limits and audit logs aren't all coalesced under an
-	// empty RemoteAddr. JoinHostPort handles IPv6 bracketing — bare
-	// "addr:0" concatenation breaks for "::1" and any other IPv6 literal.
+	// empty RemoteAddr. Validate the relay-supplied value with
+	// net.ParseIP — a misbehaving or compromised relay must not be able
+	// to inject CRLF, hostnames, or unbracketed IPv6 garbage into the
+	// audit trail or rate-limit key. JoinHostPort handles IPv6 bracketing.
 	if payload.ClientIP != "" {
-		req.RemoteAddr = net.JoinHostPort(payload.ClientIP, "0")
+		if ip := net.ParseIP(payload.ClientIP); ip != nil {
+			req.RemoteAddr = net.JoinHostPort(ip.String(), "0")
+		} else {
+			c.logger.Warn("relay: rejecting non-IP client_ip from envelope",
+				"id", id, "client_ip", payload.ClientIP)
+		}
 	}
 
 	rec := httptest.NewRecorder()

--- a/internal/relay/tunnel.go
+++ b/internal/relay/tunnel.go
@@ -44,6 +44,13 @@ func (c *Client) handleRequest(ctx context.Context, id string, payload HTTPReque
 			req.Header.Add(k, v)
 		}
 	}
+	// Attribute the synthesized request to the originating client IP so
+	// per-IP rate limits and audit logs aren't all coalesced under an
+	// empty RemoteAddr. Format must include a port for net.SplitHostPort
+	// to round-trip correctly downstream.
+	if payload.ClientIP != "" {
+		req.RemoteAddr = payload.ClientIP + ":0"
+	}
 
 	rec := httptest.NewRecorder()
 	c.handler.ServeHTTP(rec, req)

--- a/internal/relay/tunnel_test.go
+++ b/internal/relay/tunnel_test.go
@@ -106,13 +106,20 @@ func TestHandleRequest_ClientIPSetsRemoteAddr(t *testing.T) {
 	cases := []struct {
 		name     string
 		clientIP string
-		want     string
+		want     string // "" means "RemoteAddr left empty (rejected)"
 	}{
 		{"ipv4", "203.0.113.7", "203.0.113.7:0"},
 		// IPv6 literals must be bracketed so net.SplitHostPort downstream
 		// (and ipKeyFn / audit logs) parses them correctly.
 		{"ipv6", "2001:db8::1", "[2001:db8::1]:0"},
 		{"ipv6 loopback", "::1", "[::1]:0"},
+		// Garbage from a misbehaving/compromised relay must not poison
+		// RemoteAddr — the validator drops it and leaves RemoteAddr empty.
+		{"hostname rejected", "evil.example.com", ""},
+		{"crlf injection rejected", "1.2.3.4\r\nX-Foo: bar", ""},
+		// 2001:db8::1:8080 IS a valid IPv6 literal (last group is 0x8080),
+		// so it round-trips through bracketing — not a rejection case.
+		{"valid ipv6 with hex-looking suffix", "2001:db8::1:8080", "[2001:db8::1:8080]:0"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -129,7 +136,7 @@ func TestHandleRequest_ClientIPSetsRemoteAddr(t *testing.T) {
 				ClientIP: tc.clientIP,
 			})
 			if gotRemoteAddr != tc.want {
-				t.Fatalf("RemoteAddr=%q, want %q", gotRemoteAddr, tc.want)
+				t.Fatalf("RemoteAddr=%q, want %q (clientIP=%q)", gotRemoteAddr, tc.want, tc.clientIP)
 			}
 		})
 	}

--- a/internal/relay/tunnel_test.go
+++ b/internal/relay/tunnel_test.go
@@ -123,8 +123,12 @@ func TestHandleRequest_ClientIPSetsRemoteAddr(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			gotRemoteAddr := ""
+			var (
+				handlerCalled bool
+				gotRemoteAddr string
+			)
 			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				handlerCalled = true
 				gotRemoteAddr = r.RemoteAddr
 				w.WriteHeader(http.StatusOK)
 			})
@@ -135,6 +139,12 @@ func TestHandleRequest_ClientIPSetsRemoteAddr(t *testing.T) {
 				Headers:  map[string][]string{},
 				ClientIP: tc.clientIP,
 			})
+			// Always assert the handler ran. For rejection cases (want="")
+			// the handler-skip path would have left gotRemoteAddr=="" too,
+			// producing a false pass — handlerCalled is the actual signal.
+			if !handlerCalled {
+				t.Fatalf("handler was not called (clientIP=%q)", tc.clientIP)
+			}
 			if gotRemoteAddr != tc.want {
 				t.Fatalf("RemoteAddr=%q, want %q (clientIP=%q)", gotRemoteAddr, tc.want, tc.clientIP)
 			}

--- a/internal/relay/tunnel_test.go
+++ b/internal/relay/tunnel_test.go
@@ -103,23 +103,34 @@ func TestHandleRequest(t *testing.T) {
 // a ClientIP, the synthesized request must surface it as r.RemoteAddr so
 // per-IP rate limits and audit logs apply correctly.
 func TestHandleRequest_ClientIPSetsRemoteAddr(t *testing.T) {
-	gotRemoteAddr := ""
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotRemoteAddr = r.RemoteAddr
-		w.WriteHeader(http.StatusOK)
-	})
-	c := &Client{handler: handler, logger: slog.Default()}
-
-	payload := HTTPRequestPayload{
-		Method:   "GET",
-		Path:     "/api/health",
-		Headers:  map[string][]string{},
-		Body:     "",
-		ClientIP: "203.0.113.7",
+	cases := []struct {
+		name     string
+		clientIP string
+		want     string
+	}{
+		{"ipv4", "203.0.113.7", "203.0.113.7:0"},
+		// IPv6 literals must be bracketed so net.SplitHostPort downstream
+		// (and ipKeyFn / audit logs) parses them correctly.
+		{"ipv6", "2001:db8::1", "[2001:db8::1]:0"},
+		{"ipv6 loopback", "::1", "[::1]:0"},
 	}
-	c.handleRequest(context.Background(), "test-id", payload)
-
-	if gotRemoteAddr != "203.0.113.7:0" {
-		t.Fatalf("expected RemoteAddr=203.0.113.7:0, got %q", gotRemoteAddr)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotRemoteAddr := ""
+			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotRemoteAddr = r.RemoteAddr
+				w.WriteHeader(http.StatusOK)
+			})
+			c := &Client{handler: handler, logger: slog.Default()}
+			c.handleRequest(context.Background(), "test-id", HTTPRequestPayload{
+				Method:   "GET",
+				Path:     "/api/health",
+				Headers:  map[string][]string{},
+				ClientIP: tc.clientIP,
+			})
+			if gotRemoteAddr != tc.want {
+				t.Fatalf("RemoteAddr=%q, want %q", gotRemoteAddr, tc.want)
+			}
+		})
 	}
 }

--- a/internal/relay/tunnel_test.go
+++ b/internal/relay/tunnel_test.go
@@ -97,3 +97,29 @@ func TestHandleRequest(t *testing.T) {
 	_ = c
 	_ = captured
 }
+
+// TestHandleRequest_ClientIPSetsRemoteAddr is the regression guard for the
+// "relay traffic has empty RemoteAddr" bug. When the relay envelope carries
+// a ClientIP, the synthesized request must surface it as r.RemoteAddr so
+// per-IP rate limits and audit logs apply correctly.
+func TestHandleRequest_ClientIPSetsRemoteAddr(t *testing.T) {
+	gotRemoteAddr := ""
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotRemoteAddr = r.RemoteAddr
+		w.WriteHeader(http.StatusOK)
+	})
+	c := &Client{handler: handler, logger: slog.Default()}
+
+	payload := HTTPRequestPayload{
+		Method:   "GET",
+		Path:     "/api/health",
+		Headers:  map[string][]string{},
+		Body:     "",
+		ClientIP: "203.0.113.7",
+	}
+	c.handleRequest(context.Background(), "test-id", payload)
+
+	if gotRemoteAddr != "203.0.113.7:0" {
+		t.Fatalf("expected RemoteAddr=203.0.113.7:0, got %q", gotRemoteAddr)
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -118,6 +118,13 @@ type ServerConfig struct {
 	AuthMode    string `yaml:"auth_mode"`  // "magic_link", "password", or "" (auto-detect from IsLocal)
 	LogFormat   string `yaml:"log_format"` // "json", "text", or "" (auto: json in prod, text in dev)
 	LogLevel    string `yaml:"log_level"`  // "debug", "info", "warn", "error" (default: "info")
+	// TrustedProxies is the list of CIDR ranges whose r.RemoteAddr is treated
+	// as a reverse proxy. When a request arrives from one of these networks,
+	// the right-most non-trusted entry of X-Forwarded-For is used as the
+	// rate-limit key instead of r.RemoteAddr. Leave empty in self-host /
+	// direct-exposed mode to keep the previous (RemoteAddr-only) behavior.
+	// Example: ["10.0.0.0/8", "127.0.0.1/32"] for Cloud Run behind GCLB.
+	TrustedProxies []string `yaml:"trusted_proxies"`
 }
 
 type DatabaseConfig struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -387,7 +387,7 @@ func Default() *Config {
 			ServicePresets: false,
 		},
 		RateLimit: RateLimitConfig{
-			Gateway:   RateLimitBucket{Limit: 60, Window: 60},
+			Gateway:   RateLimitBucket{Limit: 200, Window: 60},
 			OAuth:     RateLimitBucket{Limit: 5, Window: 60},
 			PolicyAPI: RateLimitBucket{Limit: 30, Window: 60},
 			ReviewRun: RateLimitBucket{Limit: 5, Window: 3600},

--- a/pkg/store/postgres/migrations/041_agent_token_expiry.sql
+++ b/pkg/store/postgres/migrations/041_agent_token_expiry.sql
@@ -1,0 +1,4 @@
+-- Bound the blast radius of a leaked agent bearer token. NULL = no expiry
+-- (preserves long-lived daemon-agent tokens). Non-NULL = short-lived,
+-- enforced by RequireAgent middleware.
+ALTER TABLE agents ADD COLUMN token_expires_at TIMESTAMPTZ;

--- a/pkg/store/postgres/store.go
+++ b/pkg/store/postgres/store.go
@@ -423,6 +423,23 @@ func (s *Store) GetSession(ctx context.Context, tokenHash string) (*store.Sessio
 	return sess, err
 }
 
+// ConsumeSession is the atomic Get+Delete used by refresh-token rotation.
+func (s *Store) ConsumeSession(ctx context.Context, tokenHash string) (*store.Session, error) {
+	sess := &store.Session{}
+	err := s.pool.QueryRow(ctx,
+		`DELETE FROM sessions WHERE token_hash = $1
+		 RETURNING id, user_id, token_hash, expires_at, created_at`,
+		tokenHash,
+	).Scan(&sess.ID, &sess.UserID, &sess.TokenHash, &sess.ExpiresAt, &sess.CreatedAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, store.ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return sess, nil
+}
+
 func (s *Store) DeleteSession(ctx context.Context, tokenHash string) error {
 	_, err := s.pool.Exec(ctx,
 		`DELETE FROM sessions WHERE token_hash = $1`,

--- a/pkg/store/postgres/store.go
+++ b/pkg/store/postgres/store.go
@@ -1062,6 +1062,34 @@ func (s *Store) UpdateTaskApproved(ctx context.Context, id string, expiresAt tim
 	return nil
 }
 
+// UpdateTaskStatusFrom is the CAS variant of UpdateTaskStatus.
+func (s *Store) UpdateTaskStatusFrom(ctx context.Context, id, fromStatus, toStatus string) (bool, error) {
+	tag, err := s.pool.Exec(ctx,
+		`UPDATE tasks SET status = $1 WHERE id = $2 AND status = $3`,
+		toStatus, id, fromStatus)
+	if err != nil {
+		return false, err
+	}
+	return tag.RowsAffected() > 0, nil
+}
+
+// UpdateTaskApprovedFrom is the CAS variant of UpdateTaskApproved.
+func (s *Store) UpdateTaskApprovedFrom(ctx context.Context, id, fromStatus string, expiresAt time.Time, authorizedActions []store.TaskAction) (bool, error) {
+	actionsJSON, err := json.Marshal(authorizedActions)
+	if err != nil {
+		return false, err
+	}
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE tasks SET status = 'active', approved_at = NOW(), expires_at = $1,
+			authorized_actions = $2
+		WHERE id = $3 AND status = $4
+	`, expiresAt, actionsJSON, id, fromStatus)
+	if err != nil {
+		return false, err
+	}
+	return tag.RowsAffected() > 0, nil
+}
+
 func (s *Store) UpdateTaskAuthorizedActions(ctx context.Context, id string, actions []store.TaskAction) error {
 	actionsJSON, err := json.Marshal(actions)
 	if err != nil {
@@ -1441,6 +1469,17 @@ func (s *Store) UpdatePendingApprovalStatus(ctx context.Context, requestID, stat
 	_, err := s.pool.Exec(ctx,
 		`UPDATE pending_approvals SET status = $1 WHERE request_id = $2 AND status = 'pending'`, status, requestID)
 	return err
+}
+
+// UpdatePendingApprovalStatusFrom is the CAS variant.
+func (s *Store) UpdatePendingApprovalStatusFrom(ctx context.Context, requestID, fromStatus, toStatus string) (bool, error) {
+	tag, err := s.pool.Exec(ctx,
+		`UPDATE pending_approvals SET status = $1 WHERE request_id = $2 AND status = $3`,
+		toStatus, requestID, fromStatus)
+	if err != nil {
+		return false, err
+	}
+	return tag.RowsAffected() > 0, nil
 }
 
 func (s *Store) ClaimPendingApprovalForExecution(ctx context.Context, requestID string) (bool, error) {

--- a/pkg/store/postgres/store.go
+++ b/pkg/store/postgres/store.go
@@ -1542,9 +1542,9 @@ func (s *Store) ClaimPendingApprovalForExecution(ctx context.Context, requestID 
 }
 
 // ListStalledExecutingApprovals returns rows that were claimed for execution
-// but never completed within leaseTTL. This is the recovery hook for daemon
-// crashes that strand a row in 'executing' — without it, the user would be
-// permanently locked out of re-approving the same request.
+// but never completed within leaseTTL. See sqlite.Store.ListStalledExecuting
+// — this is a list, NOT a claim; pair with ClaimStalledExecutingApprovalFor
+// Recovery to gate side-effects.
 func (s *Store) ListStalledExecutingApprovals(ctx context.Context, leaseTTL time.Duration) ([]*store.PendingApproval, error) {
 	cutoff := time.Now().UTC().Add(-leaseTTL)
 	rows, err := s.pool.Query(ctx, `
@@ -1555,6 +1555,23 @@ func (s *Store) ListStalledExecutingApprovals(ctx context.Context, leaseTTL time
 	}
 	defer rows.Close()
 	return scanPendingApprovals(rows)
+}
+
+// ClaimStalledExecutingApprovalForRecovery atomically deletes a stalled
+// 'executing' row only if it is still in 'executing' status and still past
+// the lease cutoff. The DELETE's WHERE clause is the CAS — see sqlite
+// counterpart for the rationale.
+func (s *Store) ClaimStalledExecutingApprovalForRecovery(ctx context.Context, requestID string, leaseTTL time.Duration) (bool, error) {
+	cutoff := time.Now().UTC().Add(-leaseTTL)
+	tag, err := s.pool.Exec(ctx, `
+		DELETE FROM pending_approvals
+		WHERE request_id = $1 AND status = 'executing'
+		  AND executing_since IS NOT NULL AND executing_since < $2`,
+		requestID, cutoff)
+	if err != nil {
+		return false, err
+	}
+	return tag.RowsAffected() > 0, nil
 }
 
 // ── Canonical Approval Records ───────────────────────────────────────────────

--- a/pkg/store/postgres/store.go
+++ b/pkg/store/postgres/store.go
@@ -1542,6 +1542,46 @@ func (s *Store) CreateApprovalRecord(ctx context.Context, rec *store.ApprovalRec
 	return err
 }
 
+// CreateApprovalRecordWithPending wraps both inserts in one transaction.
+func (s *Store) CreateApprovalRecordWithPending(ctx context.Context, rec *store.ApprovalRecord, pa *store.PendingApproval) error {
+	if rec.ID == "" {
+		rec.ID = uuid.New().String()
+	}
+	if pa.ID == "" {
+		pa.ID = uuid.New().String()
+	}
+	if pa.Status == "" {
+		pa.Status = "pending"
+	}
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback(ctx)
+		}
+	}()
+	if _, err = tx.Exec(ctx, `
+		INSERT INTO approval_records (
+			id, kind, user_id, agent_id, request_id, task_id, session_id, status, surface,
+			summary_json, payload_json, resolution_transport, expires_at, resolved_at, resolution
+		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
+	`, rec.ID, rec.Kind, rec.UserID, rec.AgentID, rec.RequestID, rec.TaskID, rec.SessionID, rec.Status,
+		rec.Surface, rawJSONOrDefaultBytes(rec.SummaryJSON, "{}"), rawJSONOrDefaultBytes(rec.PayloadJSON, "{}"),
+		rec.ResolutionTransport, rec.ExpiresAt, rec.ResolvedAt, rec.Resolution); err != nil {
+		return err
+	}
+	if _, err = tx.Exec(ctx, `
+		INSERT INTO pending_approvals (id, user_id, request_id, audit_id, approval_record_id, request_blob, callback_url, status, expires_at)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+	`, pa.ID, pa.UserID, pa.RequestID, pa.AuditID, pa.ApprovalRecordID, []byte(pa.RequestBlob),
+		pa.CallbackURL, pa.Status, pa.ExpiresAt); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
 func (s *Store) GetApprovalRecord(ctx context.Context, id string) (*store.ApprovalRecord, error) {
 	return s.getApprovalRecord(ctx, `
 		SELECT id, kind, user_id, agent_id, request_id, task_id, session_id, status, surface,

--- a/pkg/store/postgres/store.go
+++ b/pkg/store/postgres/store.go
@@ -339,14 +339,24 @@ func (s *Store) DeleteAgent(ctx context.Context, id, userID string) error {
 }
 
 func (s *Store) RotateAgentToken(ctx context.Context, id, userID, newTokenHash string) error {
+	// See sqlite.Store.RotateAgentToken — refuse rotation for expiry-bound
+	// agents because the rotated token would inherit a possibly-past expiry.
 	tag, err := s.pool.Exec(ctx,
-		`UPDATE agents SET token_hash = $1 WHERE id = $2 AND user_id = $3 AND deleted_at IS NULL`,
+		`UPDATE agents SET token_hash = $1 WHERE id = $2 AND user_id = $3 AND deleted_at IS NULL AND token_expires_at IS NULL`,
 		newTokenHash, id, userID,
 	)
 	if err != nil {
 		return err
 	}
 	if tag.RowsAffected() == 0 {
+		var hasExpiry bool
+		row := s.pool.QueryRow(ctx,
+			`SELECT token_expires_at IS NOT NULL FROM agents WHERE id = $1 AND user_id = $2 AND deleted_at IS NULL`,
+			id, userID,
+		)
+		if scanErr := row.Scan(&hasExpiry); scanErr == nil && hasExpiry {
+			return store.ErrConflict
+		}
 		return store.ErrNotFound
 	}
 	return nil

--- a/pkg/store/postgres/store.go
+++ b/pkg/store/postgres/store.go
@@ -222,18 +222,40 @@ func (s *Store) CreateAgentWithOrg(ctx context.Context, userID, name, tokenHash,
 	return s.getAgentByID(ctx, a.ID)
 }
 
+// CreateAgentWithExpiry creates an agent whose token expires at the given
+// time. A zero time means no expiry — equivalent to CreateAgent.
+func (s *Store) CreateAgentWithExpiry(ctx context.Context, userID, name, tokenHash string, expiresAt time.Time) (*store.Agent, error) {
+	id := uuid.New().String()
+	var expiry any
+	if !expiresAt.IsZero() {
+		expiry = expiresAt.UTC()
+	}
+	_, err := s.pool.Exec(ctx,
+		`INSERT INTO agents (id, user_id, name, description, token_hash, token_expires_at) VALUES ($1, $2, $3, $4, $5, $6)`,
+		id, userID, name, "", tokenHash, expiry,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return s.getAgentByID(ctx, id)
+}
+
 func (s *Store) GetAgentByToken(ctx context.Context, tokenHash string) (*store.Agent, error) {
 	a := &store.Agent{}
 	var orgID *string
+	var tokenExpiresAt *time.Time
 	err := s.pool.QueryRow(ctx,
-		`SELECT id, user_id, name, description, token_hash, created_at, org_id FROM agents WHERE token_hash = $1 AND deleted_at IS NULL`,
+		`SELECT id, user_id, name, description, token_hash, created_at, org_id, token_expires_at FROM agents WHERE token_hash = $1 AND deleted_at IS NULL`,
 		tokenHash,
-	).Scan(&a.ID, &a.UserID, &a.Name, &a.Description, &a.TokenHash, &a.CreatedAt, &orgID)
+	).Scan(&a.ID, &a.UserID, &a.Name, &a.Description, &a.TokenHash, &a.CreatedAt, &orgID, &tokenExpiresAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, store.ErrNotFound
 	}
 	if orgID != nil {
 		a.OrgID = *orgID
+	}
+	if tokenExpiresAt != nil {
+		a.TokenExpiresAt = tokenExpiresAt
 	}
 	if settings, settingsErr := s.GetAgentRuntimeSettings(ctx, a.ID); settingsErr == nil {
 		a.RuntimeSettings = settings

--- a/pkg/store/sqlite/migrations/041_agent_token_expiry.sql
+++ b/pkg/store/sqlite/migrations/041_agent_token_expiry.sql
@@ -1,0 +1,14 @@
+-- Bound the blast radius of a leaked agent bearer token.
+--
+-- Existing agents created via POST /api/agents have NULL token_expires_at
+-- (no expiry — preserves prior behavior; long-lived tokens are intentional
+-- for daemon agents that the user controls end-to-end).
+--
+-- New tokens issued by MCP OAuth and relay-pairing flows are short-lived
+-- and write a non-NULL value. RequireAgent middleware refuses tokens whose
+-- expiry has elapsed, so a token leaked via logs / desktop cache / relay
+-- has a bounded lifetime.
+--
+-- Stored as TEXT (ISO 8601) to match the project's other timestamp columns
+-- under the modernc sqlite driver.
+ALTER TABLE agents ADD COLUMN token_expires_at TEXT;

--- a/pkg/store/sqlite/migrations/README.md
+++ b/pkg/store/sqlite/migrations/README.md
@@ -1,0 +1,17 @@
+# SQLite Migrations
+
+Migrations are applied in lexical order at daemon startup by `pkg/store/sqlite.New`.
+
+## Avoid full-table rewrites
+
+SQLite holds an exclusive write lock for the duration of any `INSERT INTO new SELECT FROM old` cycle, so a migration that rewrites a large table (audit log, chain facts, etc.) blocks every other writer until it commits. On a self-host install with months of audit history this can manifest as the daemon "hanging" silently for the user the first time they upgrade.
+
+`028_audit_request_id_user_unique.sql` is an existing example of this pattern. It cannot be reverted in place because users have already run it; future schema changes that need to alter constraints on `audit_log` (or any other large table) should:
+
+1. Add the new column / index out-of-band where possible.
+2. If a structural change is unavoidable, do it in chunks — for example, write a one-shot Go migration that processes 10k rows per transaction and surfaces progress through the daemon log.
+3. At minimum, document the expected blocking time in the migration's leading comment so the operator knows what to expect.
+
+## Numbering collisions
+
+Migration numbers must be unique within this directory. The historical `019_*` and `027_*` collisions are tolerated for backwards compatibility but should not be repeated. Use `ls -1 | sort -V | tail` before adding a new migration to confirm the next free number.

--- a/pkg/store/sqlite/store.go
+++ b/pkg/store/sqlite/store.go
@@ -497,6 +497,27 @@ func (s *Store) DeleteSession(ctx context.Context, tokenHash string) error {
 	return err
 }
 
+// ConsumeSession is the atomic Get+Delete used by refresh-token rotation.
+// modernc.org/sqlite supports DELETE ... RETURNING since SQLite 3.35.
+func (s *Store) ConsumeSession(ctx context.Context, tokenHash string) (*store.Session, error) {
+	sess := &store.Session{}
+	var expiresAt, createdAt string
+	err := s.db.QueryRowContext(ctx,
+		`DELETE FROM sessions WHERE token_hash = ?
+		 RETURNING id, user_id, token_hash, expires_at, created_at`,
+		tokenHash,
+	).Scan(&sess.ID, &sess.UserID, &sess.TokenHash, &expiresAt, &createdAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, store.ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	sess.ExpiresAt = parseTime(expiresAt)
+	sess.CreatedAt = parseTime(createdAt)
+	return sess, nil
+}
+
 func (s *Store) DeleteUserSessions(ctx context.Context, userID string) error {
 	_, err := s.db.ExecContext(ctx, `DELETE FROM sessions WHERE user_id = ?`, userID)
 	return err

--- a/pkg/store/sqlite/store.go
+++ b/pkg/store/sqlite/store.go
@@ -1696,6 +1696,48 @@ func (s *Store) CreateApprovalRecord(ctx context.Context, rec *store.ApprovalRec
 	return err
 }
 
+// CreateApprovalRecordWithPending writes both rows in one transaction so a
+// failure on the second insert can't leave an orphan canonical approval
+// (visible in /api/approvals but with no executable pending request).
+func (s *Store) CreateApprovalRecordWithPending(ctx context.Context, rec *store.ApprovalRecord, pa *store.PendingApproval) error {
+	if rec.ID == "" {
+		rec.ID = uuid.New().String()
+	}
+	if pa.ID == "" {
+		pa.ID = uuid.New().String()
+	}
+	if pa.Status == "" {
+		pa.Status = "pending"
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+	if _, err = tx.ExecContext(ctx, `
+		INSERT INTO approval_records (
+			id, kind, user_id, agent_id, request_id, task_id, session_id, status, surface,
+			summary_json, payload_json, resolution_transport, expires_at, resolved_at, resolution
+		) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+	`, rec.ID, rec.Kind, rec.UserID, rec.AgentID, rec.RequestID, rec.TaskID, rec.SessionID, rec.Status,
+		rec.Surface, rawJSONOrDefault(rec.SummaryJSON, "{}"), rawJSONOrDefault(rec.PayloadJSON, "{}"),
+		rec.ResolutionTransport, formatNullableTime(rec.ExpiresAt), formatNullableTime(rec.ResolvedAt), rec.Resolution); err != nil {
+		return err
+	}
+	if _, err = tx.ExecContext(ctx, `
+		INSERT INTO pending_approvals (id, user_id, request_id, audit_id, approval_record_id, request_blob, callback_url, status, expires_at)
+		VALUES (?,?,?,?,?,?,?,?,?)
+	`, pa.ID, pa.UserID, pa.RequestID, pa.AuditID, pa.ApprovalRecordID, string(pa.RequestBlob),
+		pa.CallbackURL, pa.Status, pa.ExpiresAt.UTC().Format(time.RFC3339)); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
 func (s *Store) GetApprovalRecord(ctx context.Context, id string) (*store.ApprovalRecord, error) {
 	return s.getApprovalRecord(ctx, `
 		SELECT id, kind, user_id, agent_id, request_id, task_id, session_id, status, surface,

--- a/pkg/store/sqlite/store.go
+++ b/pkg/store/sqlite/store.go
@@ -407,8 +407,13 @@ func (s *Store) DeleteAgent(ctx context.Context, id, userID string) error {
 }
 
 func (s *Store) RotateAgentToken(ctx context.Context, id, userID, newTokenHash string) error {
+	// Refuse rotation for agents whose tokens are bounded by an expiry
+	// (MCP OAuth, relay-pairing). Otherwise the rotated token would inherit
+	// the original expiry — possibly already in the past — silently giving
+	// the user a token that won't work. They must re-pair through the same
+	// flow that issued the original to get a fresh expiry.
 	res, err := s.db.ExecContext(ctx,
-		`UPDATE agents SET token_hash = ? WHERE id = ? AND user_id = ? AND deleted_at IS NULL`,
+		`UPDATE agents SET token_hash = ? WHERE id = ? AND user_id = ? AND deleted_at IS NULL AND token_expires_at IS NULL`,
 		newTokenHash, id, userID,
 	)
 	if err != nil {
@@ -416,6 +421,16 @@ func (s *Store) RotateAgentToken(ctx context.Context, id, userID, newTokenHash s
 	}
 	n, _ := res.RowsAffected()
 	if n == 0 {
+		// Distinguish "not found" from "exists but has expiry" so the
+		// handler can return the right HTTP code with a useful hint.
+		var hasExpiry bool
+		row := s.db.QueryRowContext(ctx,
+			`SELECT token_expires_at IS NOT NULL FROM agents WHERE id = ? AND user_id = ? AND deleted_at IS NULL`,
+			id, userID,
+		)
+		if scanErr := row.Scan(&hasExpiry); scanErr == nil && hasExpiry {
+			return store.ErrConflict
+		}
 		return store.ErrNotFound
 	}
 	return nil

--- a/pkg/store/sqlite/store.go
+++ b/pkg/store/sqlite/store.go
@@ -1313,6 +1313,42 @@ func (s *Store) UpdateTaskApproved(ctx context.Context, id string, expiresAt tim
 	return nil
 }
 
+// UpdateTaskStatusFrom is the CAS variant of UpdateTaskStatus. The status
+// transition only happens when the row is currently in fromStatus, which
+// blocks concurrent approve/deny pairs from both succeeding.
+func (s *Store) UpdateTaskStatusFrom(ctx context.Context, id, fromStatus, toStatus string) (bool, error) {
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE tasks SET status = ? WHERE id = ? AND status = ?`,
+		toStatus, id, fromStatus)
+	if err != nil {
+		return false, err
+	}
+	n, _ := res.RowsAffected()
+	return n > 0, nil
+}
+
+// UpdateTaskApprovedFrom is the CAS variant of UpdateTaskApproved. The
+// promotion to "active" only happens when the row is currently in
+// fromStatus, so two concurrent approvals can't both win.
+func (s *Store) UpdateTaskApprovedFrom(ctx context.Context, id, fromStatus string, expiresAt time.Time, authorizedActions []store.TaskAction) (bool, error) {
+	actionsJSON, err := json.Marshal(authorizedActions)
+	if err != nil {
+		return false, err
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	exp := expiresAt.UTC().Format(time.RFC3339)
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE tasks SET status = 'active', approved_at = ?, expires_at = ?,
+			authorized_actions = ?
+		WHERE id = ? AND status = ?
+	`, now, exp, string(actionsJSON), id, fromStatus)
+	if err != nil {
+		return false, err
+	}
+	n, _ := res.RowsAffected()
+	return n > 0, nil
+}
+
 func (s *Store) UpdateTaskAuthorizedActions(ctx context.Context, id string, actions []store.TaskAction) error {
 	actionsJSON, err := json.Marshal(actions)
 	if err != nil {
@@ -1573,6 +1609,24 @@ func (s *Store) ClaimPendingApprovalForExecution(ctx context.Context, requestID 
 	res, err := s.db.ExecContext(ctx,
 		`UPDATE pending_approvals SET status = 'executing', executing_since = CURRENT_TIMESTAMP
 		 WHERE request_id = ? AND status = 'approved'`, requestID)
+	if err != nil {
+		return false, err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return n > 0, nil
+}
+
+// UpdatePendingApprovalStatusFrom is the CAS variant of
+// UpdatePendingApprovalStatus. The transition only happens when the row is
+// currently in fromStatus, so concurrent approve/deny pairs from UI vs
+// Telegram vs API can no longer both succeed.
+func (s *Store) UpdatePendingApprovalStatusFrom(ctx context.Context, requestID, fromStatus, toStatus string) (bool, error) {
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE pending_approvals SET status = ? WHERE request_id = ? AND status = ?`,
+		toStatus, requestID, fromStatus)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/store/sqlite/store.go
+++ b/pkg/store/sqlite/store.go
@@ -266,8 +266,15 @@ func (s *Store) GetAgentByToken(ctx context.Context, tokenHash string) (*store.A
 		a.OrgID = *orgID
 	}
 	if tokenExpiresAt != nil && *tokenExpiresAt != "" {
-		t := parseTime(*tokenExpiresAt)
-		a.TokenExpiresAt = &t
+		// Guard against parseTime returning the zero value (year 0001).
+		// Without this an unparseable string would silently land as a
+		// "way past" expiry, and RequireAgent would 401 every legitimate
+		// request with TOKEN_EXPIRED. Today the writer is always RFC3339,
+		// but a future migration / hand-edit / driver change would make
+		// this a silent agent-wide outage.
+		if t := parseTime(*tokenExpiresAt); !t.IsZero() {
+			a.TokenExpiresAt = &t
+		}
 	}
 	if settings, settingsErr := s.GetAgentRuntimeSettings(ctx, a.ID); settingsErr == nil {
 		a.RuntimeSettings = settings

--- a/pkg/store/sqlite/store.go
+++ b/pkg/store/sqlite/store.go
@@ -1700,6 +1700,10 @@ func (s *Store) UpdatePendingApprovalStatusFrom(ctx context.Context, requestID, 
 // but never completed within leaseTTL. This is the recovery hook for daemon
 // crashes that strand a row in 'executing' — without it, the user would be
 // permanently locked out of re-approving the same request.
+//
+// IMPORTANT: this is a *list* operation, not a claim. A row returned here may
+// finish via the executor between this call and the caller's processing —
+// pair with ClaimStalledExecutingApprovalForRecovery to gate side-effects.
 func (s *Store) ListStalledExecutingApprovals(ctx context.Context, leaseTTL time.Duration) ([]*store.PendingApproval, error) {
 	leaseSeconds := int64(leaseTTL.Seconds())
 	if leaseSeconds < 0 {
@@ -1715,6 +1719,30 @@ func (s *Store) ListStalledExecutingApprovals(ctx context.Context, leaseTTL time
 	}
 	defer rows.Close()
 	return scanSQLitePendingApprovals(rows)
+}
+
+// ClaimStalledExecutingApprovalForRecovery atomically deletes a stalled
+// 'executing' row only if it is still in 'executing' status and still past
+// the lease cutoff. The DELETE's WHERE clause is the CAS — a concurrent
+// executor that finishes between list and claim has already DELETE'd the
+// row, so RowsAffected is 0 and the sweeper moves on without dispatching
+// a duplicate "timeout" callback.
+func (s *Store) ClaimStalledExecutingApprovalForRecovery(ctx context.Context, requestID string, leaseTTL time.Duration) (bool, error) {
+	leaseSeconds := int64(leaseTTL.Seconds())
+	if leaseSeconds < 0 {
+		leaseSeconds = 0
+	}
+	modifier := fmt.Sprintf("-%d seconds", leaseSeconds)
+	res, err := s.db.ExecContext(ctx, `
+		DELETE FROM pending_approvals
+		WHERE request_id = ? AND status = 'executing'
+		  AND executing_since IS NOT NULL AND executing_since < datetime('now', ?)`,
+		requestID, modifier)
+	if err != nil {
+		return false, err
+	}
+	n, _ := res.RowsAffected()
+	return n > 0, nil
 }
 
 // ── Canonical Approval Records ───────────────────────────────────────────────

--- a/pkg/store/sqlite/store.go
+++ b/pkg/store/sqlite/store.go
@@ -228,14 +228,33 @@ func (s *Store) CreateAgentWithOrg(ctx context.Context, userID, name, tokenHash,
 	return s.getAgentByID(ctx, id)
 }
 
+// CreateAgentWithExpiry creates an agent whose token expires at the given
+// time. A zero time means no expiry — equivalent to CreateAgent.
+func (s *Store) CreateAgentWithExpiry(ctx context.Context, userID, name, tokenHash string, expiresAt time.Time) (*store.Agent, error) {
+	id := uuid.New().String()
+	var expiry any
+	if !expiresAt.IsZero() {
+		expiry = expiresAt.UTC().Format(time.RFC3339)
+	}
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO agents (id, user_id, name, description, token_hash, token_expires_at) VALUES (?, ?, ?, ?, ?, ?)`,
+		id, userID, name, "", tokenHash, expiry,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return s.getAgentByID(ctx, id)
+}
+
 func (s *Store) GetAgentByToken(ctx context.Context, tokenHash string) (*store.Agent, error) {
 	a := &store.Agent{}
 	var createdAt string
 	var orgID *string
+	var tokenExpiresAt *string
 	err := s.db.QueryRowContext(ctx,
-		`SELECT id, user_id, name, description, token_hash, created_at, org_id FROM agents WHERE token_hash = ? AND deleted_at IS NULL`,
+		`SELECT id, user_id, name, description, token_hash, created_at, org_id, token_expires_at FROM agents WHERE token_hash = ? AND deleted_at IS NULL`,
 		tokenHash,
-	).Scan(&a.ID, &a.UserID, &a.Name, &a.Description, &a.TokenHash, &createdAt, &orgID)
+	).Scan(&a.ID, &a.UserID, &a.Name, &a.Description, &a.TokenHash, &createdAt, &orgID, &tokenExpiresAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, store.ErrNotFound
 	}
@@ -245,6 +264,10 @@ func (s *Store) GetAgentByToken(ctx context.Context, tokenHash string) (*store.A
 	a.CreatedAt = parseTime(createdAt)
 	if orgID != nil {
 		a.OrgID = *orgID
+	}
+	if tokenExpiresAt != nil && *tokenExpiresAt != "" {
+		t := parseTime(*tokenExpiresAt)
+		a.TokenExpiresAt = &t
 	}
 	if settings, settingsErr := s.GetAgentRuntimeSettings(ctx, a.ID); settingsErr == nil {
 		a.RuntimeSettings = settings

--- a/pkg/store/sqlite/store_runtime_test.go
+++ b/pkg/store/sqlite/store_runtime_test.go
@@ -550,6 +550,50 @@ func TestPendingApproval_StatusCASBlocksConcurrentResolution(t *testing.T) {
 	}
 }
 
+// TestRotateAgentToken_RejectsExpiringAgents is the regression guard
+// against silently re-issuing tokens that inherit a (possibly past)
+// expiry. Agents minted with a bounded lifetime — MCP/relay flows —
+// must re-pair to refresh; the generic rotate endpoint refuses them
+// with ErrConflict so the handler can return a 409 with a useful hint.
+func TestRotateAgentToken_RejectsExpiringAgents(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, err := New(ctx, filepath.Join(t.TempDir(), "clawvisor.db"))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	st := NewStore(db)
+	user, err := st.CreateUser(ctx, "rotate@example.com", "hash")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	// Long-lived agent: rotation succeeds.
+	long, err := st.CreateAgent(ctx, user.ID, "long-lived", "tok-long")
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+	if err := st.RotateAgentToken(ctx, long.ID, user.ID, "tok-long-rotated"); err != nil {
+		t.Fatalf("rotate(long-lived): unexpected err %v", err)
+	}
+
+	// Bounded-expiry agent: rotation refused with ErrConflict.
+	exp := time.Now().UTC().Add(24 * time.Hour)
+	scoped, err := st.CreateAgentWithExpiry(ctx, user.ID, "scoped", "tok-scoped", exp)
+	if err != nil {
+		t.Fatalf("CreateAgentWithExpiry: %v", err)
+	}
+	if err := st.RotateAgentToken(ctx, scoped.ID, user.ID, "tok-scoped-rotated"); err != store.ErrConflict {
+		t.Fatalf("rotate(scoped): expected ErrConflict, got %v", err)
+	}
+
+	// Unknown agent ID still surfaces as ErrNotFound.
+	if err := st.RotateAgentToken(ctx, "no-such-id", user.ID, "tok-x"); err != store.ErrNotFound {
+		t.Fatalf("rotate(missing): expected ErrNotFound, got %v", err)
+	}
+}
+
 // TestAgentTokenExpiry_RoundTrip verifies that an agent created with a
 // finite token expiry surfaces TokenExpiresAt back through GetAgentByToken,
 // and that an agent created via the legacy no-expiry constructor reports

--- a/pkg/store/sqlite/store_runtime_test.go
+++ b/pkg/store/sqlite/store_runtime_test.go
@@ -550,6 +550,70 @@ func TestPendingApproval_StatusCASBlocksConcurrentResolution(t *testing.T) {
 	}
 }
 
+// TestAgentTokenExpiry_RoundTrip verifies that an agent created with a
+// finite token expiry surfaces TokenExpiresAt back through GetAgentByToken,
+// and that an agent created via the legacy no-expiry constructor reports
+// nil. RequireAgent middleware refuses tokens whose expiry has passed —
+// this test covers the store-layer round-trip the middleware relies on.
+func TestAgentTokenExpiry_RoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, err := New(ctx, filepath.Join(t.TempDir(), "clawvisor.db"))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	st := NewStore(db)
+	user, err := st.CreateUser(ctx, "exp@example.com", "hash")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	// Legacy CreateAgent → no expiry.
+	legacy, err := st.CreateAgent(ctx, user.ID, "legacy", "tok-legacy")
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+	got, err := st.GetAgentByToken(ctx, "tok-legacy")
+	if err != nil {
+		t.Fatalf("GetAgentByToken(legacy): %v", err)
+	}
+	if got.TokenExpiresAt != nil {
+		t.Fatalf("legacy agent should have nil TokenExpiresAt, got %v", *got.TokenExpiresAt)
+	}
+	_ = legacy
+
+	// CreateAgentWithExpiry with a future expiry.
+	exp := time.Now().UTC().Add(24 * time.Hour).Truncate(time.Second)
+	scoped, err := st.CreateAgentWithExpiry(ctx, user.ID, "scoped", "tok-scoped", exp)
+	if err != nil {
+		t.Fatalf("CreateAgentWithExpiry: %v", err)
+	}
+	got, err = st.GetAgentByToken(ctx, "tok-scoped")
+	if err != nil {
+		t.Fatalf("GetAgentByToken(scoped): %v", err)
+	}
+	if got.TokenExpiresAt == nil {
+		t.Fatal("scoped agent should have non-nil TokenExpiresAt")
+	}
+	if !got.TokenExpiresAt.Equal(exp) {
+		t.Fatalf("expected TokenExpiresAt=%s, got %s", exp, *got.TokenExpiresAt)
+	}
+	_ = scoped
+
+	// Zero-time → no expiry (equivalent to CreateAgent).
+	if _, err := st.CreateAgentWithExpiry(ctx, user.ID, "no-exp", "tok-noexp", time.Time{}); err != nil {
+		t.Fatalf("CreateAgentWithExpiry(zero): %v", err)
+	}
+	got, err = st.GetAgentByToken(ctx, "tok-noexp")
+	if err != nil {
+		t.Fatalf("GetAgentByToken(noexp): %v", err)
+	}
+	if got.TokenExpiresAt != nil {
+		t.Fatalf("zero-expiry agent should have nil TokenExpiresAt, got %v", *got.TokenExpiresAt)
+	}
+}
+
 // TestConsumeSession_AtomicSingleWinner asserts that two concurrent
 // refresh-token consumers can't both succeed against the same row. This is
 // the regression guard for the replayable-rotation bug — a stolen refresh

--- a/pkg/store/sqlite/store_runtime_test.go
+++ b/pkg/store/sqlite/store_runtime_test.go
@@ -499,3 +499,106 @@ func TestPendingApproval_StalledExecutingRecovery(t *testing.T) {
 		t.Fatalf("expected zero stalled rows after recovery, got %d", len(stalled))
 	}
 }
+
+// TestPendingApproval_StatusCASBlocksConcurrentResolution confirms that
+// UpdatePendingApprovalStatusFrom prevents two concurrent resolution paths
+// (e.g. Approve via UI and Deny via Telegram) from both succeeding. Only
+// the first transition wins; subsequent attempts return won=false and the
+// row is left in the winning state.
+func TestPendingApproval_StatusCASBlocksConcurrentResolution(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, err := New(ctx, filepath.Join(t.TempDir(), "clawvisor.db"))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	st := NewStore(db)
+	user, err := st.CreateUser(ctx, "cas@example.com", "hash")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	pa := &store.PendingApproval{
+		UserID: user.ID, RequestID: "req-cas-1", AuditID: "audit-cas-1",
+		RequestBlob: []byte(`{}`), Status: "pending",
+		ExpiresAt: time.Now().UTC().Add(30 * time.Minute),
+	}
+	if err := st.SavePendingApproval(ctx, pa); err != nil {
+		t.Fatalf("SavePendingApproval: %v", err)
+	}
+
+	// First transition wins.
+	won, err := st.UpdatePendingApprovalStatusFrom(ctx, "req-cas-1", "pending", "approved")
+	if err != nil || !won {
+		t.Fatalf("first CAS approve: won=%v err=%v", won, err)
+	}
+
+	// Concurrent attempt to deny the same row must lose, leaving status="approved".
+	won, err = st.UpdatePendingApprovalStatusFrom(ctx, "req-cas-1", "pending", "denied")
+	if err != nil {
+		t.Fatalf("second CAS: %v", err)
+	}
+	if won {
+		t.Fatal("expected second CAS to lose, got won=true")
+	}
+	got, err := st.GetPendingApproval(ctx, "req-cas-1")
+	if err != nil {
+		t.Fatalf("GetPendingApproval: %v", err)
+	}
+	if got.Status != "approved" {
+		t.Fatalf("expected status=approved after losing CAS, got %q", got.Status)
+	}
+}
+
+// TestTask_StatusCASBlocksConcurrentResolution confirms the same atomicity
+// for tasks: a concurrent ApproveTask and DenyTask race resolves to one
+// state, not both.
+func TestTask_StatusCASBlocksConcurrentResolution(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, err := New(ctx, filepath.Join(t.TempDir(), "clawvisor.db"))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	st := NewStore(db)
+	user, err := st.CreateUser(ctx, "task-cas@example.com", "hash")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	agent, err := st.CreateAgent(ctx, user.ID, "task-cas-agent", "token-hash")
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+	task := &store.Task{
+		ID: "task-cas-1", UserID: user.ID, AgentID: agent.ID,
+		Purpose: "p", Status: "pending_approval", Lifetime: "session",
+		ExpiresInSeconds: 60,
+	}
+	if err := st.CreateTask(ctx, task); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+
+	// First win: approve.
+	won, err := st.UpdateTaskApprovedFrom(ctx, task.ID, "pending_approval",
+		time.Now().UTC().Add(time.Minute), nil)
+	if err != nil || !won {
+		t.Fatalf("first CAS approve: won=%v err=%v", won, err)
+	}
+
+	// Second attempt: deny. Must lose.
+	won, err = st.UpdateTaskStatusFrom(ctx, task.ID, "pending_approval", "denied")
+	if err != nil {
+		t.Fatalf("second CAS: %v", err)
+	}
+	if won {
+		t.Fatal("expected second CAS to lose, got won=true")
+	}
+	got, err := st.GetTask(ctx, task.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if got.Status != "active" {
+		t.Fatalf("expected status=active after losing CAS, got %q", got.Status)
+	}
+}

--- a/pkg/store/sqlite/store_runtime_test.go
+++ b/pkg/store/sqlite/store_runtime_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -547,6 +549,191 @@ func TestPendingApproval_StatusCASBlocksConcurrentResolution(t *testing.T) {
 	}
 	if got.Status != "approved" {
 		t.Fatalf("expected status=approved after losing CAS, got %q", got.Status)
+	}
+}
+
+// TestPendingApproval_ConcurrentResolution_ExactlyOneWinner is the real
+// race test for the status CAS — it fans out N goroutines that all attempt
+// to resolve the same pending row from "pending" to a different terminal
+// state, then asserts exactly one won. A non-atomic SELECT-then-UPDATE
+// implementation would let multiple writers each see status="pending" and
+// each issue an UPDATE, ending with two "winners" and the database in
+// whichever-write-landed-last state. Sequential tests don't catch that.
+func TestPendingApproval_ConcurrentResolution_ExactlyOneWinner(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, err := New(ctx, filepath.Join(t.TempDir(), "clawvisor.db"))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	st := NewStore(db)
+	user, err := st.CreateUser(ctx, "race@example.com", "hash")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	pa := &store.PendingApproval{
+		UserID: user.ID, RequestID: "req-race-1", AuditID: "audit-race-1",
+		RequestBlob: []byte(`{}`), Status: "pending",
+		ExpiresAt: time.Now().UTC().Add(30 * time.Minute),
+	}
+	if err := st.SavePendingApproval(ctx, pa); err != nil {
+		t.Fatalf("SavePendingApproval: %v", err)
+	}
+
+	const goroutines = 50
+	var (
+		wg          sync.WaitGroup
+		start       = make(chan struct{})
+		winnerCount atomic.Int64
+		errs        atomic.Int64
+	)
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		// Half try to approve, half try to deny — every winner is "first".
+		target := "approved"
+		if i%2 == 0 {
+			target = "denied"
+		}
+		go func(t string) {
+			defer wg.Done()
+			<-start
+			won, err := st.UpdatePendingApprovalStatusFrom(ctx, "req-race-1", "pending", t)
+			if err != nil {
+				errs.Add(1)
+				return
+			}
+			if won {
+				winnerCount.Add(1)
+			}
+		}(target)
+	}
+	close(start)
+	wg.Wait()
+
+	if errs.Load() != 0 {
+		t.Fatalf("expected zero errors, got %d", errs.Load())
+	}
+	if got := winnerCount.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 winning CAS across %d racers, got %d",
+			goroutines, got)
+	}
+}
+
+// TestClaimPendingApprovalForExecution_ConcurrentClaim_ExactlyOneWinner is
+// the same shape but for the executor-claim CAS that gates request
+// execution. Two simultaneous /execute calls for the same request_id must
+// not both see "approved" and both run the adapter.
+func TestClaimPendingApprovalForExecution_ConcurrentClaim_ExactlyOneWinner(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, err := New(ctx, filepath.Join(t.TempDir(), "clawvisor.db"))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	st := NewStore(db)
+	user, err := st.CreateUser(ctx, "exec-race@example.com", "hash")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	pa := &store.PendingApproval{
+		UserID: user.ID, RequestID: "req-exec-1", AuditID: "audit-exec-1",
+		RequestBlob: []byte(`{}`), Status: "approved",
+		ExpiresAt: time.Now().UTC().Add(30 * time.Minute),
+	}
+	if err := st.SavePendingApproval(ctx, pa); err != nil {
+		t.Fatalf("SavePendingApproval: %v", err)
+	}
+
+	const goroutines = 50
+	var (
+		wg          sync.WaitGroup
+		start       = make(chan struct{})
+		winnerCount atomic.Int64
+	)
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			won, err := st.ClaimPendingApprovalForExecution(ctx, "req-exec-1")
+			if err != nil {
+				return
+			}
+			if won {
+				winnerCount.Add(1)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if got := winnerCount.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 winning execution claim across %d racers, got %d",
+			goroutines, got)
+	}
+}
+
+// TestClaimStalledExecutingApprovalForRecovery_ExactlyOneWinner is the
+// regression guard against duplicate "timeout" callbacks. The recovery
+// sweeper races against itself in multi-instance deployments and against a
+// slow-but-finishing executor in single-instance deployments. The CAS
+// DELETE WHERE status='executing' AND executing_since<cutoff must guarantee
+// exactly one resolver wins per stranded row.
+func TestClaimStalledExecutingApprovalForRecovery_ExactlyOneWinner(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, err := New(ctx, filepath.Join(t.TempDir(), "clawvisor.db"))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	st := NewStore(db)
+	user, err := st.CreateUser(ctx, "stalled@example.com", "hash")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	pa := &store.PendingApproval{
+		UserID: user.ID, RequestID: "req-stalled-1", AuditID: "audit-stalled-1",
+		RequestBlob: []byte(`{}`), Status: "approved",
+		ExpiresAt: time.Now().UTC().Add(30 * time.Minute),
+	}
+	if err := st.SavePendingApproval(ctx, pa); err != nil {
+		t.Fatalf("SavePendingApproval: %v", err)
+	}
+	if won, err := st.ClaimPendingApprovalForExecution(ctx, "req-stalled-1"); err != nil || !won {
+		t.Fatalf("seed claim: won=%v err=%v", won, err)
+	}
+	// Sleep long enough that the lease cutoff (-1s) treats this as stale.
+	time.Sleep(1500 * time.Millisecond)
+
+	const goroutines = 50
+	var (
+		wg          sync.WaitGroup
+		start       = make(chan struct{})
+		winnerCount atomic.Int64
+	)
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			won, err := st.ClaimStalledExecutingApprovalForRecovery(ctx, "req-stalled-1", time.Second)
+			if err != nil {
+				return
+			}
+			if won {
+				winnerCount.Add(1)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if got := winnerCount.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 winning recovery claim across %d racers, got %d",
+			goroutines, got)
 	}
 }
 

--- a/pkg/store/sqlite/store_runtime_test.go
+++ b/pkg/store/sqlite/store_runtime_test.go
@@ -705,8 +705,11 @@ func TestClaimStalledExecutingApprovalForRecovery_ExactlyOneWinner(t *testing.T)
 	if won, err := st.ClaimPendingApprovalForExecution(ctx, "req-stalled-1"); err != nil || !won {
 		t.Fatalf("seed claim: won=%v err=%v", won, err)
 	}
-	// Sleep long enough that the lease cutoff (-1s) treats this as stale.
-	time.Sleep(1500 * time.Millisecond)
+	// SQLite CURRENT_TIMESTAMP and datetime('now') round to whole seconds,
+	// so we need >= 2s of clearance between executing_since and the
+	// -1s cutoff to avoid a flake when both round into the same second
+	// (executing_since=12:00:00, now=12:00:01, cutoff=12:00:00, no rows).
+	time.Sleep(2500 * time.Millisecond)
 
 	const goroutines = 50
 	var (

--- a/pkg/store/sqlite/store_runtime_test.go
+++ b/pkg/store/sqlite/store_runtime_test.go
@@ -651,6 +651,8 @@ func TestClaimPendingApprovalForExecution_ConcurrentClaim_ExactlyOneWinner(t *te
 		wg          sync.WaitGroup
 		start       = make(chan struct{})
 		winnerCount atomic.Int64
+		errCount    atomic.Int64
+		firstErr    atomic.Pointer[error]
 	)
 	wg.Add(goroutines)
 	for i := 0; i < goroutines; i++ {
@@ -659,6 +661,8 @@ func TestClaimPendingApprovalForExecution_ConcurrentClaim_ExactlyOneWinner(t *te
 			<-start
 			won, err := st.ClaimPendingApprovalForExecution(ctx, "req-exec-1")
 			if err != nil {
+				errCount.Add(1)
+				firstErr.CompareAndSwap(nil, &err)
 				return
 			}
 			if won {
@@ -669,6 +673,12 @@ func TestClaimPendingApprovalForExecution_ConcurrentClaim_ExactlyOneWinner(t *te
 	close(start)
 	wg.Wait()
 
+	// Any racer error means the CAS isn't truly atomic for our purposes —
+	// the test would otherwise silently pass when 49 goroutines errored
+	// and 1 happened to "win" through that error.
+	if n := errCount.Load(); n > 0 {
+		t.Fatalf("expected zero racer errors, got %d (first: %v)", n, *firstErr.Load())
+	}
 	if got := winnerCount.Load(); got != 1 {
 		t.Fatalf("expected exactly 1 winning execution claim across %d racers, got %d",
 			goroutines, got)
@@ -716,6 +726,8 @@ func TestClaimStalledExecutingApprovalForRecovery_ExactlyOneWinner(t *testing.T)
 		wg          sync.WaitGroup
 		start       = make(chan struct{})
 		winnerCount atomic.Int64
+		errCount    atomic.Int64
+		firstErr    atomic.Pointer[error]
 	)
 	wg.Add(goroutines)
 	for i := 0; i < goroutines; i++ {
@@ -724,6 +736,8 @@ func TestClaimStalledExecutingApprovalForRecovery_ExactlyOneWinner(t *testing.T)
 			<-start
 			won, err := st.ClaimStalledExecutingApprovalForRecovery(ctx, "req-stalled-1", time.Second)
 			if err != nil {
+				errCount.Add(1)
+				firstErr.CompareAndSwap(nil, &err)
 				return
 			}
 			if won {
@@ -734,6 +748,9 @@ func TestClaimStalledExecutingApprovalForRecovery_ExactlyOneWinner(t *testing.T)
 	close(start)
 	wg.Wait()
 
+	if n := errCount.Load(); n > 0 {
+		t.Fatalf("expected zero racer errors, got %d (first: %v)", n, *firstErr.Load())
+	}
 	if got := winnerCount.Load(); got != 1 {
 		t.Fatalf("expected exactly 1 winning recovery claim across %d racers, got %d",
 			goroutines, got)
@@ -848,10 +865,15 @@ func TestAgentTokenExpiry_RoundTrip(t *testing.T) {
 	}
 }
 
-// TestConsumeSession_AtomicSingleWinner asserts that two concurrent
-// refresh-token consumers can't both succeed against the same row. This is
-// the regression guard for the replayable-rotation bug — a stolen refresh
-// token replayed in a race window must produce at most one new token pair.
+// TestConsumeSession_AtomicSingleWinner is the regression guard for the
+// replayable-refresh-token-rotation bug: a stolen refresh token replayed
+// in a race window must produce at most one new token pair, not multiply
+// access. 50 goroutines race ConsumeSession on the same row; exactly one
+// must return the row, the rest must each see store.ErrNotFound.
+//
+// A non-atomic SELECT-then-DELETE implementation would let multiple
+// callers each see the row, then race the DELETEs — multiple "winners"
+// observed before the row vanished. This test catches that.
 func TestConsumeSession_AtomicSingleWinner(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -865,24 +887,51 @@ func TestConsumeSession_AtomicSingleWinner(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateUser: %v", err)
 	}
-	_, err = st.CreateSession(ctx, user.ID, "tok-hash", time.Now().UTC().Add(time.Hour))
-	if err != nil {
+	if _, err := st.CreateSession(ctx, user.ID, "tok-hash", time.Now().UTC().Add(time.Hour)); err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
 
-	// First consume wins.
-	sess, err := st.ConsumeSession(ctx, "tok-hash")
-	if err != nil {
-		t.Fatalf("first ConsumeSession: %v", err)
+	const goroutines = 50
+	var (
+		wg            sync.WaitGroup
+		start         = make(chan struct{})
+		winnerCount   atomic.Int64
+		notFoundCount atomic.Int64
+		errCount      atomic.Int64
+		firstErr      atomic.Pointer[error]
+	)
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			sess, err := st.ConsumeSession(ctx, "tok-hash")
+			if err != nil {
+				if errors.Is(err, store.ErrNotFound) {
+					notFoundCount.Add(1)
+					return
+				}
+				errCount.Add(1)
+				firstErr.CompareAndSwap(nil, &err)
+				return
+			}
+			if sess != nil && sess.UserID == user.ID {
+				winnerCount.Add(1)
+			}
+		}()
 	}
-	if sess.UserID != user.ID {
-		t.Fatalf("returned wrong user_id: got %q want %q", sess.UserID, user.ID)
-	}
+	close(start)
+	wg.Wait()
 
-	// Second consume must fail with ErrNotFound — row is gone.
-	_, err = st.ConsumeSession(ctx, "tok-hash")
-	if !errors.Is(err, store.ErrNotFound) {
-		t.Fatalf("second ConsumeSession: got %v, want store.ErrNotFound", err)
+	if n := errCount.Load(); n > 0 {
+		t.Fatalf("expected zero non-NotFound errors, got %d (first: %v)", n, *firstErr.Load())
+	}
+	if got := winnerCount.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 winning ConsumeSession across %d racers, got %d",
+			goroutines, got)
+	}
+	if got := notFoundCount.Load(); got != goroutines-1 {
+		t.Fatalf("expected %d ErrNotFound across losers, got %d", goroutines-1, got)
 	}
 }
 

--- a/pkg/store/sqlite/store_runtime_test.go
+++ b/pkg/store/sqlite/store_runtime_test.go
@@ -550,6 +550,44 @@ func TestPendingApproval_StatusCASBlocksConcurrentResolution(t *testing.T) {
 	}
 }
 
+// TestConsumeSession_AtomicSingleWinner asserts that two concurrent
+// refresh-token consumers can't both succeed against the same row. This is
+// the regression guard for the replayable-rotation bug — a stolen refresh
+// token replayed in a race window must produce at most one new token pair.
+func TestConsumeSession_AtomicSingleWinner(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, err := New(ctx, filepath.Join(t.TempDir(), "clawvisor.db"))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	st := NewStore(db)
+	user, err := st.CreateUser(ctx, "consume@example.com", "hash")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	_, err = st.CreateSession(ctx, user.ID, "tok-hash", time.Now().UTC().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	// First consume wins.
+	sess, err := st.ConsumeSession(ctx, "tok-hash")
+	if err != nil {
+		t.Fatalf("first ConsumeSession: %v", err)
+	}
+	if sess.UserID != user.ID {
+		t.Fatalf("returned wrong user_id: got %q want %q", sess.UserID, user.ID)
+	}
+
+	// Second consume must fail with ErrNotFound — row is gone.
+	_, err = st.ConsumeSession(ctx, "tok-hash")
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("second ConsumeSession: got %v, want store.ErrNotFound", err)
+	}
+}
+
 // TestTask_StatusCASBlocksConcurrentResolution confirms the same atomicity
 // for tasks: a concurrent ApproveTask and DenyTask race resolves to one
 // state, not both.

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -62,6 +62,12 @@ type Store interface {
 	CreateSession(ctx context.Context, userID, tokenHash string, expiresAt time.Time) (*Session, error)
 	GetSession(ctx context.Context, tokenHash string) (*Session, error)
 	DeleteSession(ctx context.Context, tokenHash string) error
+	// ConsumeSession atomically deletes the session row matching tokenHash
+	// and returns the row that was deleted. ErrNotFound means another caller
+	// already consumed it (or the token never existed). Use this on the
+	// refresh path so a stolen refresh token replayed concurrently can
+	// produce at most one new token pair.
+	ConsumeSession(ctx context.Context, tokenHash string) (*Session, error)
 	DeleteUserSessions(ctx context.Context, userID string) error
 
 	// Service credentials metadata (vault stores the actual bytes)

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -309,7 +309,7 @@ type Agent struct {
 	Description string `json:"description,omitempty"`
 	TokenHash   string `json:"-"`
 	OrgID       string `json:"org_id,omitempty"` // set by cloud when agent belongs to an org
-	CreatedAt   time.Time
+	CreatedAt   time.Time `json:"created_at"`
 	// TokenExpiresAt bounds the lifetime of a leaked bearer token. nil
 	// means no expiry — preserved for legacy POST /api/agents tokens that
 	// the user owns end-to-end. MCP OAuth and relay-pairing flows write a

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -102,6 +102,16 @@ type Store interface {
 	ListTasks(ctx context.Context, userID string, filter TaskFilter) ([]*Task, int, error)
 	UpdateTaskStatus(ctx context.Context, id, status string) error
 	UpdateTaskApproved(ctx context.Context, id string, expiresAt time.Time, authorizedActions []TaskAction) error
+	// UpdateTaskStatusFrom atomically transitions a task from fromStatus to
+	// toStatus. Returns true if the caller won the race, false if the row
+	// was not in fromStatus (already approved/denied/expired by another
+	// caller). Use this for any approve/deny/expand path that can be raced
+	// across UI, Telegram, and API channels.
+	UpdateTaskStatusFrom(ctx context.Context, id, fromStatus, toStatus string) (bool, error)
+	// UpdateTaskApprovedFrom atomically promotes a task from fromStatus to
+	// "active" with approved_at/expires_at/authorized_actions set, returning
+	// true on win. Replaces UpdateTaskApproved for race-prone code paths.
+	UpdateTaskApprovedFrom(ctx context.Context, id, fromStatus string, expiresAt time.Time, authorizedActions []TaskAction) (bool, error)
 	UpdateTaskAuthorizedActions(ctx context.Context, id string, actions []TaskAction) error
 	UpdateTaskActions(ctx context.Context, id string, actions []TaskAction, expiresAt time.Time) error
 	IncrementTaskRequestCount(ctx context.Context, id string) error
@@ -117,6 +127,11 @@ type Store interface {
 	DeletePendingApproval(ctx context.Context, requestID string) error
 	ListExpiredPendingApprovals(ctx context.Context) ([]*PendingApproval, error)
 	UpdatePendingApprovalStatus(ctx context.Context, requestID, status string) error
+	// UpdatePendingApprovalStatusFrom atomically transitions a pending
+	// approval from fromStatus to toStatus. Returns true if the caller won
+	// the race, false if the row was not in fromStatus. Use this for any
+	// approve/deny path that can be raced across UI/Telegram/API.
+	UpdatePendingApprovalStatusFrom(ctx context.Context, requestID, fromStatus, toStatus string) (bool, error)
 	// ClaimPendingApprovalForExecution atomically transitions a pending approval
 	// from "approved" to "executing". Returns true if the caller won the claim,
 	// false if another caller already claimed it (or the row is not "approved").

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -150,6 +150,13 @@ type Store interface {
 	// ListStalledExecutingApprovals returns rows stuck in "executing" beyond
 	// leaseTTL — the recovery hook for daemon crashes mid-execution.
 	ListStalledExecutingApprovals(ctx context.Context, leaseTTL time.Duration) ([]*PendingApproval, error)
+	// ClaimStalledExecutingApprovalForRecovery atomically deletes a stalled
+	// 'executing' row only if it is still in 'executing' status and still
+	// past the lease cutoff. Returns true if the recovery sweeper won —
+	// callers must dispatch the timeout callback only on true. Returns
+	// false (no error) when the executor finished between list and claim
+	// or another sweep already won the race.
+	ClaimStalledExecutingApprovalForRecovery(ctx context.Context, requestID string, leaseTTL time.Duration) (bool, error)
 
 	// CreateApprovalRecordWithPending writes the canonical approval record
 	// and its corresponding pending approval row in a single transaction.

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -146,6 +146,14 @@ type Store interface {
 	// leaseTTL — the recovery hook for daemon crashes mid-execution.
 	ListStalledExecutingApprovals(ctx context.Context, leaseTTL time.Duration) ([]*PendingApproval, error)
 
+	// CreateApprovalRecordWithPending writes the canonical approval record
+	// and its corresponding pending approval row in a single transaction.
+	// Both rows commit together or neither commits — preventing the
+	// orphan-canonical-record bug where the second insert failed and the
+	// approval was visible in /api/approvals but had no executable pending
+	// request to back it.
+	CreateApprovalRecordWithPending(ctx context.Context, rec *ApprovalRecord, pa *PendingApproval) error
+
 	// Canonical approval records
 	CreateApprovalRecord(ctx context.Context, rec *ApprovalRecord) error
 	GetApprovalRecord(ctx context.Context, id string) (*ApprovalRecord, error)

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -33,6 +33,11 @@ type Store interface {
 	// Agents
 	CreateAgent(ctx context.Context, userID, name, tokenHash string) (*Agent, error)
 	CreateAgentWithOrg(ctx context.Context, userID, name, tokenHash, orgID string) (*Agent, error)
+	// CreateAgentWithExpiry creates an agent whose token expires at the
+	// given time. Used by the MCP OAuth and relay-pairing flows so leaked
+	// tokens have finite blast radius. Pass a zero time to mean "no expiry"
+	// (equivalent to CreateAgent).
+	CreateAgentWithExpiry(ctx context.Context, userID, name, tokenHash string, expiresAt time.Time) (*Agent, error)
 	GetAgentByToken(ctx context.Context, tokenHash string) (*Agent, error)
 	ListAgents(ctx context.Context, userID string) ([]*Agent, error)
 	UpdateAgentDescription(ctx context.Context, agentID, userID, description string) error
@@ -298,13 +303,19 @@ type Session struct {
 
 // Agent is an AI agent that authenticates via a long-lived bearer token.
 type Agent struct {
-	ID              string                `json:"id"`
-	UserID          string                `json:"user_id"`
-	Name            string                `json:"name"`
-	Description     string                `json:"description,omitempty"`
-	TokenHash       string                `json:"-"`
-	OrgID           string                `json:"org_id,omitempty"` // set by cloud when agent belongs to an org
-	CreatedAt       time.Time             `json:"created_at"`
+	ID          string `json:"id"`
+	UserID      string `json:"user_id"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	TokenHash   string `json:"-"`
+	OrgID       string `json:"org_id,omitempty"` // set by cloud when agent belongs to an org
+	CreatedAt   time.Time
+	// TokenExpiresAt bounds the lifetime of a leaked bearer token. nil
+	// means no expiry — preserved for legacy POST /api/agents tokens that
+	// the user owns end-to-end. MCP OAuth and relay-pairing flows write a
+	// non-nil value so a leaked token has finite blast radius. RequireAgent
+	// rejects tokens whose expiry has passed.
+	TokenExpiresAt  *time.Time            `json:"token_expires_at,omitempty"`
 	ActiveTaskCount int                   `json:"active_task_count"`
 	LastTaskAt      *time.Time            `json:"last_task_at,omitempty"`
 	RuntimeSettings *AgentRuntimeSettings `json:"runtime_settings,omitempty"`

--- a/pkg/vault/local.go
+++ b/pkg/vault/local.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime"
+	"sync"
 
 	"github.com/google/uuid"
 )
@@ -266,9 +268,15 @@ func loadOrCreateKey(path string) ([]byte, error) {
 	data, err := os.ReadFile(path)
 	if err == nil {
 		// Validate file permissions — the key file should not be readable by
-		// group or others. Skip the check on Windows where Unix permissions
-		// don't apply (FileMode always reports 0666).
-		if info, statErr := os.Stat(path); statErr == nil {
+		// group or others. The check is meaningful on POSIX; on Windows the
+		// FileMode bits are synthesized (typically 0666) and don't reflect
+		// the actual ACL, so the check would either spuriously reject or
+		// give a false sense of security. We skip it there and emit a single
+		// warning to stderr so the operator knows the key file's protection
+		// must be verified by other means.
+		if runtime.GOOS == "windows" {
+			warnVaultKeyPermsUnchecked(path)
+		} else if info, statErr := os.Stat(path); statErr == nil {
 			if perm := info.Mode().Perm(); perm&0077 != 0 {
 				return nil, fmt.Errorf("vault key file %s has insecure permissions %04o (expected 0600)", path, perm)
 			}
@@ -294,4 +302,20 @@ func loadOrCreateKey(path string) ([]byte, error) {
 		return nil, fmt.Errorf("writing vault key file: %w", err)
 	}
 	return key, nil
+}
+
+// warnVaultKeyPermsUnchecked is invoked once per process per vault.key path
+// on Windows to surface that the file's protection cannot be verified by
+// looking at FileMode bits. The warning is intentionally noisy because a
+// world-readable key file there would silently strip the cryptographic
+// safeguard the rest of the vault relies on.
+var warnedVaultKeyPaths sync.Map
+
+func warnVaultKeyPermsUnchecked(path string) {
+	if _, loaded := warnedVaultKeyPaths.LoadOrStore(path, struct{}{}); loaded {
+		return
+	}
+	fmt.Fprintf(os.Stderr,
+		"vault: cannot verify permissions on %s (windows); ensure the file's ACL grants access only to the daemon's user\n",
+		path)
 }


### PR DESCRIPTION
## Summary

Implements the 16 HIGH-severity findings from the repo stress test (the criticals shipped in #332). 50 commits, ~2.6k lines, all green under `go test ./... -race`. Two rounds of pre-landing review feedback also incorporated.

## What changed

**Atomicity / state transitions**
- Approve/deny via status-predicate CAS (no more both-resolved-and-denied races)
- Refresh-token rotation atomic via `DELETE…RETURNING`
- `routeToApproval` writes both rows in one transaction
- Stalled `executing` recovery uses CAS DELETE so it can't race a slow executor into duplicate callbacks
- 50-goroutine `WaitGroup` race tests assert exactly-one-winner for all three CAS paths

**Auth posture defaults**
- Callback HMAC signing on by default for new agents (opt-out only)
- MCP / relay-pairing tokens bounded to 30-day expiry (`token_expires_at` column + `RequireAgent` enforcement); rotate refuses bounded-expiry agents (must re-pair)
- Telegram group auto-approval allowlists messages by Telegram user_id, not display name

**Network identity**
- `X-Forwarded-For` honored when peer is in `server.trusted_proxies` CIDR list
- Relay envelope carries `ClientIP`; daemon sets `req.RemoteAddr` so per-IP rate limits apply
- OAuth popup-close uses nonce-based CSP and targets `postMessage` to the captured opener origin (no more `unsafe-inline` + `*`)

**DoS / robustness**
- `ReadHeaderTimeout` on `http.Server` (slowloris)
- Verdict-cache cleanup goroutine wired in production
- Per-iteration panic recovery in `CallbackDispatcher` workers (was loop-wrapped, killed worker on first panic)
- `Submit` lock-protected against post-`Stop` channel-closed panic
- `/api/gateway/batch` charges 1 token per sub-request (was 1 per envelope, fanning out to 20); batch headers reflect actual fan-out cost

**Verifier safety**
- `planned_calls` exact-match bypass requires a real risk verdict (refuses on `""` / `"unknown"`)

**Misc**
- Vault key 0600 perm check skipped on Windows with one-time warning
- Default gateway rate limit bumped 60→200 req/min per agent
- Migration README documenting the audit_log full-table-rewrite gotcha and numbering rule

## Behavioral notes for operators

- **Existing self-host installs**: default rate-limit bump (60→200) is the only behavior change visible to a config-less install. Migration `041_agent_token_expiry.sql` adds a nullable column — instant.
- **Cloud / behind-proxy**: set `server.trusted_proxies` (CIDR list) to enable real per-IP buckets. Empty default keeps prior behavior.
- **MCP/relay clients**: tokens now expire after 30 days and must be re-paired (no refresh path). First-party `POST /api/agents` tokens unchanged.
- **OAuth popup**: dashboard origin is captured at init from `Origin`/`Referer`. If neither is present (rare), the popup closes without `postMessage` — dashboards must poll instead of relying on the signal.

## Test plan

- [x] Full `go test ./... -race` passes
- [x] `TestCallbackDispatcher_*` race + panic tests
- [x] Three exactly-one-winner concurrency tests on store CAS paths
- [x] Migration applies cleanly on a fresh DB and on the user's live DB (verified)
- [ ] OAuth flow end-to-end on local daemon (Gmail/Calendar)
- [ ] Telegram group auto-approval round-trip (pre/post merge)
- [ ] MCP token-expiry surfaced in `agents.token_expires_at`

## Stress-test findings → commits

- H14: 66d349fd  • H15: deferred (separate-repo coord)  • H17: febe6f4c  • H19: b7315a7a
- H20: 0c8c9606  • H21+H28: dea730f0  • H22: 4118c40c  • H23: 3527796c
- H25: 93dbf82b  • H27+H46: c35923d5  • H30: cc59059b  • H31: 98958171 + 7e7b7ddd
- H42: a77af63a  • H43: b7d2ad98  • H44: 6a306b61  • H45: aaa4b22e  • H47: 46466674

Plus pre-landing review fixes: e9e93333, 7df052dc, df081236, d0f67763, d6b171fc, 7e7b7ddd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)