### PR TITLE
fix(linear): map issue_id to $id and add strict assignee filters

### DIFF
--- a/docs/INTEGRATION_YAML_SPEC.md
+++ b/docs/INTEGRATION_YAML_SPEC.md
@@ -310,7 +310,7 @@ actions:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `graphql_var` | bool | Pass as a top-level GraphQL variable |
+| `graphql_var` | bool | Pass as a top-level GraphQL variable. Combine with `map_to` to use a different variable name than the user-facing param (e.g. `issue_id` → `$id`). |
 | `filter_path` | string | Dot-delimited path to build a nested filter object (e.g. `"team.id.eq"`) |
 | `input_field` | string | Maps param to a field in the `$input` mutation variable (e.g. `"teamId"`) |
 

--- a/internal/adapters/definitions/linear.yaml
+++ b/internal/adapters/definitions/linear.yaml
@@ -53,6 +53,7 @@ actions:
       team_id: { type: string, filter_path: "team.id.eq" }
       state: { type: string, filter_path: "state.name.eq" }
       assignee_id: { type: string, filter_path: "assignee.id.eq" }
+      assignee_is_me: { type: bool, filter_path: "assignee.isMe.eq" }
     response:
       data_path: "data.issues.nodes"
       fields:
@@ -86,7 +87,7 @@ actions:
         }
       }
     params:
-      issue_id: { type: string, required: true, graphql_var: true }
+      issue_id: { type: string, required: true, graphql_var: true, map_to: "id" }
     response:
       data_path: "data.issue"
       fields:
@@ -142,7 +143,7 @@ actions:
         }
       }
     params:
-      issue_id: { type: string, required: true, graphql_var: true }
+      issue_id: { type: string, required: true, graphql_var: true, map_to: "id" }
       title: { type: string, input_field: "title" }
       description: { type: string, input_field: "description" }
       state_id: { type: string, input_field: "stateId" }
@@ -233,8 +234,8 @@ actions:
     display_name: "Search issues"
     risk: { category: search, sensitivity: low, description: "Search Linear issues" }
     query: |
-      query($query: String!, $first: Int, $after: String, $includeComments: Boolean) {
-        searchIssues(term: $query, first: $first, after: $after, includeComments: $includeComments) {
+      query($query: String!, $first: Int, $after: String, $includeComments: Boolean, $filter: IssueFilter) {
+        searchIssues(term: $query, first: $first, after: $after, includeComments: $includeComments, filter: $filter) {
           nodes {
             id identifier title
             state { name }
@@ -251,6 +252,10 @@ actions:
       first: { type: int, default: 20, max: 250, graphql_var: true }
       after: { type: string, graphql_var: true }
       includeComments: { type: bool, default: true, graphql_var: true }
+      team_id: { type: string, filter_path: "team.id.eq" }
+      state: { type: string, filter_path: "state.name.eq" }
+      assignee_id: { type: string, filter_path: "assignee.id.eq" }
+      assignee_is_me: { type: bool, filter_path: "assignee.isMe.eq" }
     response:
       data_path: "data.searchIssues.nodes"
       fields:

--- a/pkg/adapters/yamlruntime/adapter_test.go
+++ b/pkg/adapters/yamlruntime/adapter_test.go
@@ -232,6 +232,66 @@ func TestYAMLAdapter_RESTFormPost(t *testing.T) {
 	}
 }
 
+func TestYAMLAdapter_GraphQLVarMapTo(t *testing.T) {
+	// Verify map_to renames a graphql_var param so the variable key in the
+	// payload matches what the GraphQL query expects (e.g. user-facing
+	// issue_id → $id).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode payload: %v", err)
+		}
+		vars, _ := payload["variables"].(map[string]any)
+		if vars == nil {
+			t.Fatalf("expected variables in payload, got %v", payload)
+		}
+		if _, has := vars["issue_id"]; has {
+			t.Errorf("variables should not contain raw param name 'issue_id': %v", vars)
+		}
+		if got := vars["id"]; got != "abc-123" {
+			t.Errorf("expected variables.id == abc-123, got %v", vars["id"])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"issue": map[string]any{"id": "abc-123", "identifier": "LIN-1", "title": "x"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	def := yamldef.ServiceDef{
+		Service: yamldef.ServiceInfo{ID: "linear"},
+		Auth:    yamldef.AuthDef{Type: "api_key", Header: "Authorization"},
+		API:     yamldef.APIDef{BaseURL: srv.URL, Type: "graphql"},
+		Actions: map[string]yamldef.Action{
+			"get_issue": {
+				Query: `query($id: String!) { issue(id: $id) { id identifier title } }`,
+				Params: map[string]yamldef.Param{
+					"issue_id": {Type: "string", Required: true, GraphQLVar: true, MapTo: "id"},
+				},
+				Response: yamldef.ResponseDef{
+					DataPath: "data.issue",
+					Fields:   []yamldef.FieldDef{{Name: "id"}, {Name: "identifier"}, {Name: "title"}},
+					Summary:  "{{.identifier}}",
+				},
+			},
+		},
+	}
+
+	adapter, err := New(def, nil)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	if _, err := adapter.Execute(context.Background(), adapters.Request{
+		Action:     "get_issue",
+		Params:     map[string]any{"issue_id": "abc-123"},
+		Credential: testCred("lin_api_test"),
+	}); err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+}
+
 func TestYAMLAdapter_GraphQLAction(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var payload map[string]any

--- a/pkg/adapters/yamlruntime/graphql.go
+++ b/pkg/adapters/yamlruntime/graphql.go
@@ -27,7 +27,11 @@ func executeGraphQL(ctx context.Context, client *http.Client, baseURL string, ac
 
 		switch {
 		case paramDef.GraphQLVar:
-			variables[name] = val
+			varName := name
+			if paramDef.MapTo != "" {
+				varName = paramDef.MapTo
+			}
+			variables[varName] = val
 		case paramDef.FilterPath != "":
 			setNestedValue(filter, paramDef.FilterPath, val)
 		case paramDef.InputField != "":


### PR DESCRIPTION
## Summary

- **`get_issue` / `update_issue`**: requests failed with `Variable $id of required type String! was not provided` because the catalog documents `issue_id` but the GraphQL queries declare `$id`. The YAML runtime's GraphQL path didn't honor `map_to` for `graphql_var` params (REST did). Wired it through and set `map_to: "id"` on the Linear params.
- **Strict assignee filtering**: `search_issues` only took a free-text term, so `assignee:Jerric` matched by subscriber/mentions/comments. `list_issues` had no shorthand for "assigned to me", forcing workspace-wide pagination to find the viewer's UUID. Added `assignee_is_me: bool` (`assignee.isMe.eq`) to both actions, and let `search_issues` combine the term with structured `team_id` / `state` / `assignee_id` / `assignee_is_me` filters via `$filter: IssueFilter`.

## Test plan

- [x] `go test ./pkg/adapters/yamlruntime/...` — added `TestYAMLAdapter_GraphQLVarMapTo` covering the runtime fix
- [x] `go build ./...`
- [x] Live Linear smoke: `get_issue` with `issue_id` returns the issue (no GraphQL error)
- [x] Live Linear smoke: `list_issues` with `assignee_is_me: true` returns only viewer's issues
- [ ] Live Linear smoke: `search_issues` with a shared term plus `assignee_is_me: true` returns a strict subset assigned to viewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)