### PR TITLE
fix(llm): retry on Vertex Gemini cache-expired (400 INVALID_ARGUMENT)

### DIFF
--- a/internal/intent/extractor.go
+++ b/internal/intent/extractor.go
@@ -83,6 +83,10 @@ type LLMExtractor struct {
 	// Attached to every per-call llm.Client so the cache is referenced on
 	// Gemini provider requests.
 	geminiCacheNameFn func() string
+	// geminiCacheInvalidator drops the in-process cache name and
+	// triggers an async refresh when a server-side cache reference
+	// fails. Wired alongside geminiCacheNameFn when a manager is in use.
+	geminiCacheInvalidator func(string)
 	// geminiCacheMgr owns the cache lifecycle when StartGeminiCache was
 	// used. Nil when no cache was set up.
 	geminiCacheMgr *llm.GeminiCacheManager
@@ -102,12 +106,13 @@ func (e *LLMExtractor) StartGeminiCache(ctx context.Context, cfg llm.GeminiCache
 	if cfg.Logger == nil {
 		cfg.Logger = e.logger
 	}
-	mgr, nameFn, err := llm.StartCachedSystemPrompt(ctx, cfg, extractionSystemPrompt)
+	mgr, nameFn, invalidator, err := llm.StartCachedSystemPrompt(ctx, cfg, extractionSystemPrompt)
 	if err != nil {
 		return fmt.Errorf("extractor gemini cache: %w", err)
 	}
 	e.geminiCacheMgr = mgr
 	e.geminiCacheNameFn = nameFn
+	e.geminiCacheInvalidator = invalidator
 	return nil
 }
 
@@ -513,6 +518,12 @@ func (e *LLMExtractor) ExtractLLM(ctx context.Context, req ExtractRequest, exist
 	client := llm.NewClient(cfg.LLMProviderConfig).WithMaxTokens(8192)
 	if e.geminiCacheNameFn != nil {
 		client.AttachGeminiCacheNameFn(e.geminiCacheNameFn)
+		if e.geminiCacheInvalidator != nil {
+			client.AttachGeminiCacheInvalidator(e.geminiCacheInvalidator)
+		}
+	}
+	if e.logger != nil {
+		client = client.WithLogger(e.logger)
 	}
 	messages := []llm.ChatMessage{
 		{Role: "system", Content: extractionSystemPrompt, CacheControl: true},

--- a/internal/intent/verifier.go
+++ b/internal/intent/verifier.go
@@ -70,6 +70,12 @@ type LLMVerifier struct {
 	// at app startup. Attached to every per-call llm.Client so the cache
 	// is referenced on Gemini provider requests.
 	geminiCacheNameFn func() string
+	// geminiCacheInvalidator drops the in-process cache name and
+	// triggers an async refresh when a server-side cache reference
+	// fails (404 or 400 expired). Wired alongside geminiCacheNameFn
+	// when a manager is in use; nil when SetGeminiCacheNameFn was
+	// called directly (e.g. by tests).
+	geminiCacheInvalidator func(string)
 	// geminiCacheMgr owns the cache lifecycle when StartGeminiCache was
 	// used. Nil when SetGeminiCacheNameFn was used directly (e.g. by tests).
 	geminiCacheMgr *llm.GeminiCacheManager
@@ -131,12 +137,13 @@ func (v *LLMVerifier) StartGeminiCache(ctx context.Context, cfg llm.GeminiCacheM
 	if cfg.Logger == nil {
 		cfg.Logger = v.logger
 	}
-	mgr, nameFn, err := llm.StartCachedSystemPrompt(ctx, cfg, verificationSystemPrompt)
+	mgr, nameFn, invalidator, err := llm.StartCachedSystemPrompt(ctx, cfg, verificationSystemPrompt)
 	if err != nil {
 		return fmt.Errorf("verifier gemini cache: %w", err)
 	}
 	v.geminiCacheMgr = mgr
 	v.geminiCacheNameFn = nameFn
+	v.geminiCacheInvalidator = invalidator
 	return nil
 }
 
@@ -162,6 +169,12 @@ func (v *LLMVerifier) Verify(ctx context.Context, req VerifyRequest) (*Verificat
 	// cache so the full system prompt is inlined.
 	if v.geminiCacheNameFn != nil && !req.Lenient {
 		client.AttachGeminiCacheNameFn(v.geminiCacheNameFn)
+		if v.geminiCacheInvalidator != nil {
+			client.AttachGeminiCacheInvalidator(v.geminiCacheInvalidator)
+		}
+	}
+	if v.logger != nil {
+		client = client.WithLogger(v.logger)
 	}
 	userMsg := buildVerificationUserMessage(req)
 	systemPrompt := verificationSystemPrompt

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"os"
 	"strings"
@@ -84,8 +85,29 @@ type Client struct {
 	hedgeDelay        time.Duration      // 0 → no hedge; otherwise fire a second request after this delay
 
 	// Gemini-specific settings.
-	geminiThinkingLevel string       // "MINIMAL" | "LOW" | "MEDIUM" | "HIGH"; "" → MINIMAL
-	geminiCacheNameFn   func() string // returns current Gemini cachedContents resource name; "" = uncached path
+	geminiThinkingLevel    string             // "MINIMAL" | "LOW" | "MEDIUM" | "HIGH"; "" → MINIMAL
+	geminiCacheNameFn      func() string      // returns current Gemini cachedContents resource name; "" = uncached path
+	geminiCacheInvalidator func(name string)  // called when a cache reference fails server-side; manager drops the matching name and refreshes
+	slogger                *slog.Logger       // optional; defaults to slog.Default() via logger()
+}
+
+// logger returns the client's structured logger, defaulting to slog.Default()
+// when WithLogger has not been called. Used by the Gemini provider path to
+// emit cache-fallback events without callers needing to wire a logger.
+func (c *Client) logger() *slog.Logger {
+	if c.slogger != nil {
+		return c.slogger
+	}
+	return slog.Default()
+}
+
+// WithLogger returns a shallow copy with a custom structured logger. Used
+// by the Gemini cache-fallback path to emit a warn-level event when a
+// referenced cachedContent fails server-side. Pass nil to clear.
+func (c *Client) WithLogger(l *slog.Logger) *Client {
+	c2 := *c
+	c2.slogger = l
+	return &c2
 }
 
 // WithMaxTokens returns a shallow copy of the client with a custom max_tokens limit.
@@ -140,6 +162,19 @@ func (c *Client) Endpoint() string {
 // must call this on each new instance.
 func (c *Client) AttachGeminiCacheNameFn(fn func() string) {
 	c.geminiCacheNameFn = fn
+}
+
+// AttachGeminiCacheInvalidator registers a callback the client invokes
+// when a cachedContent reference fails server-side (404 not-found or 400
+// "is expired"). The callback receives the failed cache name; the
+// implementation (typically GeminiCacheManager.InvalidateIfMatches) drops
+// the in-process name if it still matches and triggers an async refresh,
+// so concurrent and subsequent requests don't all hit the same dead
+// reference. Optional — without it, the client still falls back to the
+// uncached path for the failing request, but every other in-flight
+// request keeps using the stale name until the next refresh tick.
+func (c *Client) AttachGeminiCacheInvalidator(fn func(name string)) {
+	c.geminiCacheInvalidator = fn
 }
 
 // NewClient builds a Client from a provider config.

--- a/internal/llm/gemini.go
+++ b/internal/llm/gemini.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 )
 
 // ErrGeminiCacheNotFound is wrapped by doGeminiRequest when Vertex returns
@@ -27,6 +28,15 @@ import (
 // resource manually deleted, refresh failure) doesn't turn into a
 // user-visible error. Cache manager refresh continues independently.
 var ErrGeminiCacheNotFound = errors.New("gemini: cached content not found")
+
+// ErrGeminiCacheExpired is wrapped by doGeminiRequest when Vertex returns
+// status 400 INVALID_ARGUMENT with a "Cache content … is expired" message
+// on a request that referenced a cachedContent resource. Vertex serves
+// this — not 404 — when the resource still exists in metadata but its
+// TTL has elapsed. Treated identically to ErrGeminiCacheNotFound by
+// completeGemini: drop the stale name (if an invalidator is attached)
+// and retry once with systemInstruction inlined.
+var ErrGeminiCacheExpired = errors.New("gemini: cached content expired")
 
 // completeGemini sends generateContent to Vertex Gemini and returns text + usage.
 //
@@ -63,12 +73,24 @@ func (c *Client) completeGemini(ctx context.Context, messages []ChatMessage) (st
 	}
 
 	text, usage, err := c.doGeminiRequest(ctx, system, convo, cacheName)
-	if err != nil && cacheName != "" && errors.Is(err, ErrGeminiCacheNotFound) {
-		// The cached resource is gone server-side — TTL elapsed before our
-		// next refresh tick succeeded, or the manager's refresh has been
-		// failing. Retry once with the system prompt inlined; the next
-		// successful refresh will repopulate the cache and subsequent
-		// calls go back to the cached path.
+	if err != nil && cacheName != "" && (errors.Is(err, ErrGeminiCacheNotFound) || errors.Is(err, ErrGeminiCacheExpired)) {
+		// The cached resource is unusable server-side — either gone (404)
+		// or its TTL has elapsed (400 INVALID_ARGUMENT "is expired").
+		// Drop the stale name from the cache manager so concurrent and
+		// subsequent callers skip it immediately (otherwise they all
+		// repeat this dance until the next refresh tick), then retry
+		// once with the system prompt inlined. The manager's async
+		// refresh repopulates the name; subsequent calls return to the
+		// cached path.
+		cause := "not_found"
+		if errors.Is(err, ErrGeminiCacheExpired) {
+			cause = "expired"
+		}
+		c.logger().Warn("gemini cache fallback to inline systemInstruction",
+			"cause", cause, "cache_name", cacheName, "err", err)
+		if c.geminiCacheInvalidator != nil {
+			c.geminiCacheInvalidator(cacheName)
+		}
 		return c.doGeminiRequest(ctx, system, convo, "")
 	}
 	return text, usage, err
@@ -137,6 +159,12 @@ func (c *Client) doGeminiRequest(ctx context.Context, system string, convo []Cha
 				resp.Header.Get("Server"), resp.Header.Get("Via"),
 				resp.Header.Get("Content-Type"), respBody)
 		}
+		if resp.StatusCode == http.StatusBadRequest && cacheName != "" && isCacheExpiredBody(respBody) {
+			return "", nil, fmt.Errorf("%w: url=%s body_len=%d server=%q via=%q content_type=%q body=%s",
+				ErrGeminiCacheExpired, c.endpoint, len(respBody),
+				resp.Header.Get("Server"), resp.Header.Get("Via"),
+				resp.Header.Get("Content-Type"), respBody)
+		}
 		return "", nil, fmt.Errorf("%w url=%s body_len=%d server=%q via=%q content_type=%q",
 			c.statusError(resp.StatusCode, respBody),
 			c.endpoint, len(respBody),
@@ -152,6 +180,28 @@ func (c *Client) doGeminiRequest(ctx context.Context, system string, convo []Cha
 		return "", nil, fmt.Errorf("llm: read gemini response: %w", err)
 	}
 	return decodeGeminiResponse(respBody)
+}
+
+// isCacheExpiredBody reports whether a Vertex 400 response body indicates
+// that the referenced cachedContent resource has expired. Vertex returns
+// status INVALID_ARGUMENT with a message like:
+//
+//	"Cache content projects/.../cachedContents/12345 is expired"
+//
+// when a cache reference is used past its TTL. We don't unmarshal — Vertex's
+// envelope nests under {"error":{"message":...,"status":"INVALID_ARGUMENT"}},
+// but a literal substring scan is robust against shape drift and avoids
+// allocating just to read a known phrase.
+func isCacheExpiredBody(body []byte) bool {
+	s := string(body)
+	if !strings.Contains(s, "is expired") {
+		return false
+	}
+	// Belt-and-suspenders: only treat as cache-expired if "cache" appears
+	// somewhere in the body, so an unrelated 400 mentioning the phrase
+	// "is expired" doesn't accidentally trip the fallback path.
+	ls := strings.ToLower(s)
+	return strings.Contains(ls, "cache content") || strings.Contains(ls, "cachedcontent")
 }
 
 // buildGeminiContents converts ChatMessage convo turns into the Gemini

--- a/internal/llm/gemini_cache.go
+++ b/internal/llm/gemini_cache.go
@@ -35,6 +35,11 @@ type GeminiCacheManager struct {
 	// cacheName is updated atomically so reads from CacheName() never lock.
 	cacheName atomic.Value // string
 
+	// refreshInFlight is set while an InvalidateIfMatches-triggered
+	// async refresh is running, so a thundering herd of failing
+	// requests doesn't mint dozens of caches in parallel.
+	refreshInFlight atomic.Bool
+
 	stopOnce sync.Once
 	stopCh   chan struct{}
 	doneCh   chan struct{}
@@ -117,20 +122,23 @@ func (m *GeminiCacheManager) Start(ctx context.Context) error {
 
 // StartCachedSystemPrompt is a convenience constructor that fills cfg's
 // SystemPrompt, builds a GeminiCacheManager, and starts it in one call.
-// Returns the manager (for shutdown control if needed) and a function
-// that returns the current cache resource name (suitable for passing to
-// Client.AttachGeminiCacheNameFn). Used by service-level Start helpers
-// to deduplicate the build-and-start dance.
-func StartCachedSystemPrompt(ctx context.Context, cfg GeminiCacheManagerConfig, systemPrompt string) (*GeminiCacheManager, func() string, error) {
+// Returns the manager (for shutdown control if needed), a function that
+// returns the current cache resource name (suitable for passing to
+// Client.AttachGeminiCacheNameFn), and an invalidator (suitable for
+// Client.AttachGeminiCacheInvalidator) that drops the in-process name
+// and triggers an async refresh when a cache reference fails server-side.
+// Used by service-level Start helpers to deduplicate the build-and-start
+// dance.
+func StartCachedSystemPrompt(ctx context.Context, cfg GeminiCacheManagerConfig, systemPrompt string) (*GeminiCacheManager, func() string, func(string), error) {
 	cfg.SystemPrompt = systemPrompt
 	mgr, err := NewGeminiCacheManager(cfg)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	if err := mgr.Start(ctx); err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
-	return mgr, mgr.CacheName, nil
+	return mgr, mgr.CacheName, mgr.InvalidateIfMatches, nil
 }
 
 // CacheName returns the current cache resource name, or "" if no cache is
@@ -138,6 +146,58 @@ func StartCachedSystemPrompt(ctx context.Context, cfg GeminiCacheManagerConfig, 
 func (m *GeminiCacheManager) CacheName() string {
 	v, _ := m.cacheName.Load().(string)
 	return v
+}
+
+// SetCacheNameForTest seeds the in-process cache name without going through
+// Start (which performs a real HTTP create). Test-only helper exposed so
+// invalidation behavior can be exercised against a pre-seeded name.
+func (m *GeminiCacheManager) SetCacheNameForTest(name string) {
+	m.cacheName.Store(name)
+}
+
+// InvalidateIfMatches drops the in-process cache name if it equals failed
+// and kicks off a single async refresh. Called by the LLM client when a
+// cachedContent reference fails server-side (404 or 400-expired). The
+// match check skips the work when a refresh has already swapped in a new
+// name since the failing request was issued, so we don't trash a fresh
+// cache because of in-flight requests using the old one.
+//
+// The async refresh is debounced via refreshInFlight: at most one
+// invalidation-triggered create runs at a time. Failures are logged and
+// non-fatal — the next scheduled refresh tick will try again, and
+// requests fall through to the uncached path until then.
+//
+// Safe for concurrent use.
+func (m *GeminiCacheManager) InvalidateIfMatches(failed string) {
+	if failed == "" {
+		return
+	}
+	current, _ := m.cacheName.Load().(string)
+	if current != failed {
+		return
+	}
+	if !m.cacheName.CompareAndSwap(failed, "") {
+		return // someone else swapped first
+	}
+	m.logger.Warn("gemini cache invalidated by client; triggering async refresh",
+		"name", failed)
+	if !m.refreshInFlight.CompareAndSwap(false, true) {
+		return // a refresh is already running
+	}
+	go func() {
+		defer m.refreshInFlight.Store(false)
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		newName, err := m.create(ctx)
+		if err != nil {
+			m.logger.Warn("gemini cache async refresh after invalidation failed",
+				"err", err)
+			return
+		}
+		m.cacheName.Store(newName)
+		m.logger.Info("gemini cache repopulated after invalidation",
+			"name", newName)
+	}()
 }
 
 // Stop signals the refresh loop to exit and best-effort-deletes the

--- a/internal/llm/gemini_test.go
+++ b/internal/llm/gemini_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -247,6 +248,175 @@ func TestClient_Gemini_404OnCachedRequest_RetriesWithInlineSystem(t *testing.T) 
 	}
 }
 
+func TestClient_Gemini_400CacheExpired_RetriesWithInlineSystem(t *testing.T) {
+	// Vertex returns 400 INVALID_ARGUMENT — not 404 — when a cachedContent
+	// reference is used past its TTL. Client must classify this as
+	// ErrGeminiCacheExpired and retry once with systemInstruction inlined.
+	// Without this, the verifier hard-fails for every concurrent caller
+	// holding the same stale ID until process restart.
+	var bodies []map[string]any
+	_, cfg := newGeminiServer(t, func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &body)
+		bodies = append(bodies, body)
+		w.Header().Set("Content-Type", "application/json")
+		if len(bodies) == 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			// Real-world Vertex error envelope shape.
+			w.Write([]byte(`{"error":{"code":400,"status":"INVALID_ARGUMENT","message":"Cache content projects/p/locations/global/cachedContents/abc is expired"}}`))
+			return
+		}
+		w.Write(geminiResponse("recovered", 0))
+	})
+
+	client := llm.NewClient(cfg).WithTokenSource(staticToken{})
+	client.AttachGeminiCacheNameFn(func() string {
+		return "projects/p/locations/global/cachedContents/abc"
+	})
+
+	got, err := client.Complete(context.Background(), []llm.ChatMessage{
+		{Role: "system", Content: "system text"},
+		{Role: "user", Content: "user text"},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if got != "recovered" {
+		t.Errorf("got %q, want recovered", got)
+	}
+	if len(bodies) != 2 {
+		t.Fatalf("expected 2 requests (cached attempt + inline retry), got %d", len(bodies))
+	}
+	if _, has := bodies[0]["cachedContent"]; !has {
+		t.Error("first request should have set cachedContent")
+	}
+	if _, has := bodies[1]["cachedContent"]; has {
+		t.Error("retry should NOT have set cachedContent")
+	}
+	if _, has := bodies[1]["systemInstruction"]; !has {
+		t.Error("retry should have inlined systemInstruction")
+	}
+}
+
+func TestClient_Gemini_400CacheExpired_FiresInvalidator(t *testing.T) {
+	// When an invalidator is attached, the failed cache name must be
+	// passed to it so the manager can drop the in-process name and
+	// concurrent callers stop hitting the same dead reference.
+	const failingName = "projects/p/locations/global/cachedContents/abc"
+	calls := 0
+	_, cfg := newGeminiServer(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		if calls == 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(`{"error":{"code":400,"status":"INVALID_ARGUMENT","message":"Cache content ` + failingName + ` is expired"}}`))
+			return
+		}
+		w.Write(geminiResponse("ok", 0))
+	})
+
+	client := llm.NewClient(cfg).WithTokenSource(staticToken{})
+	client.AttachGeminiCacheNameFn(func() string { return failingName })
+
+	var invalidated []string
+	client.AttachGeminiCacheInvalidator(func(name string) {
+		invalidated = append(invalidated, name)
+	})
+
+	if _, err := client.Complete(context.Background(), []llm.ChatMessage{
+		{Role: "system", Content: "s"},
+		{Role: "user", Content: "u"},
+	}); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if len(invalidated) != 1 || invalidated[0] != failingName {
+		t.Errorf("invalidator: got %v, want [%s]", invalidated, failingName)
+	}
+}
+
+func TestClient_Gemini_400Uncached_NotClassifiedAsCacheExpired(t *testing.T) {
+	// A 400 on a request that was NOT cached must not trigger the
+	// cache-expired fallback — there's no cache to invalidate, and the
+	// real error (e.g. malformed contents) should surface to the caller.
+	_, cfg := newGeminiServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error":{"code":400,"status":"INVALID_ARGUMENT","message":"Invalid contents"}}`))
+	})
+	client := llm.NewClient(cfg).WithTokenSource(staticToken{})
+
+	_, err := client.Complete(context.Background(), []llm.ChatMessage{
+		{Role: "system", Content: "s"},
+		{Role: "user", Content: "u"},
+	})
+	if err == nil {
+		t.Fatal("expected 400 error to surface")
+	}
+}
+
+func TestClient_Gemini_400Cached_UnrelatedError_NotMisclassified(t *testing.T) {
+	// 400 on a cached request that is NOT a cache-expired error must
+	// surface as-is, without retry. The substring check requires both
+	// "is expired" AND a "cache content" / "cachedContent" mention.
+	calls := 0
+	_, cfg := newGeminiServer(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error":{"code":400,"status":"INVALID_ARGUMENT","message":"Invalid contents: parts is empty"}}`))
+	})
+	client := llm.NewClient(cfg).WithTokenSource(staticToken{})
+	client.AttachGeminiCacheNameFn(func() string {
+		return "projects/p/locations/global/cachedContents/abc"
+	})
+
+	_, err := client.Complete(context.Background(), []llm.ChatMessage{
+		{Role: "system", Content: "s"},
+		{Role: "user", Content: "u"},
+	})
+	if err == nil {
+		t.Fatal("expected 400 error to surface")
+	}
+	if calls != 1 {
+		t.Errorf("expected exactly 1 call (no fallback retry), got %d", calls)
+	}
+}
+
+func TestClient_Gemini_404OnCachedRequest_FiresInvalidator(t *testing.T) {
+	// The 404 path should also invoke the invalidator (parity with the
+	// 400-expired path). Otherwise concurrent callers keep hitting the
+	// same stale name until the next refresh tick.
+	const failingName = "projects/p/locations/global/cachedContents/abc"
+	calls := 0
+	_, cfg := newGeminiServer(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		if calls == 1 {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"error":{"code":404,"message":"cached content gone"}}`))
+			return
+		}
+		w.Write(geminiResponse("ok", 0))
+	})
+
+	client := llm.NewClient(cfg).WithTokenSource(staticToken{})
+	client.AttachGeminiCacheNameFn(func() string { return failingName })
+
+	var invalidated []string
+	client.AttachGeminiCacheInvalidator(func(name string) {
+		invalidated = append(invalidated, name)
+	})
+
+	if _, err := client.Complete(context.Background(), []llm.ChatMessage{
+		{Role: "system", Content: "s"},
+		{Role: "user", Content: "u"},
+	}); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if len(invalidated) != 1 || invalidated[0] != failingName {
+		t.Errorf("invalidator: got %v, want [%s]", invalidated, failingName)
+	}
+}
+
 func TestClient_Gemini_404Uncached_NoRetry(t *testing.T) {
 	// 404 on a request that was already uncached should NOT retry — there's
 	// nothing to fall back to. The error surfaces to the caller.
@@ -424,6 +594,108 @@ func TestClient_Hedge_BothFail_ReturnsError(t *testing.T) {
 	if c := atomic.LoadInt32(&calls); c != 2 {
 		t.Errorf("expected 2 server calls, got %d", c)
 	}
+}
+
+// fakeRoundTripper intercepts cachedContents create/delete calls so the
+// manager can be exercised without hitting the real Vertex API. Returns
+// canned 200 OK responses with the supplied body.
+type fakeRoundTripper struct {
+	mu       sync.Mutex
+	requests []*http.Request
+	respBody string
+}
+
+func (f *fakeRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	f.mu.Lock()
+	f.requests = append(f.requests, r)
+	body := f.respBody
+	f.mu.Unlock()
+	return &http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+		Request:    r,
+	}, nil
+}
+
+func (f *fakeRoundTripper) requestCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.requests)
+}
+
+func TestGeminiCacheManager_InvalidateIfMatches(t *testing.T) {
+	t.Run("empty name is no-op", func(t *testing.T) {
+		mgr := newTestCacheManager(t, &fakeRoundTripper{})
+		mgr.SetCacheNameForTest("X")
+		mgr.InvalidateIfMatches("")
+		if got := mgr.CacheName(); got != "X" {
+			t.Errorf("expected unchanged name X, got %q", got)
+		}
+	})
+
+	t.Run("non-matching name is no-op", func(t *testing.T) {
+		// A successful refresh between the failing request and the
+		// invalidation arriving means the current name is already a
+		// fresh one — invalidating would trash a good cache.
+		rt := &fakeRoundTripper{}
+		mgr := newTestCacheManager(t, rt)
+		mgr.SetCacheNameForTest("FRESH")
+		mgr.InvalidateIfMatches("STALE")
+		if got := mgr.CacheName(); got != "FRESH" {
+			t.Errorf("expected unchanged name FRESH, got %q", got)
+		}
+		if rt.requestCount() != 0 {
+			t.Errorf("expected no HTTP calls (no refresh on mismatch), got %d", rt.requestCount())
+		}
+	})
+
+	t.Run("matching name drops cache and refreshes", func(t *testing.T) {
+		rt := &fakeRoundTripper{
+			respBody: `{"name":"projects/p/locations/global/cachedContents/NEW"}`,
+		}
+		mgr := newTestCacheManager(t, rt)
+		mgr.SetCacheNameForTest("OLD")
+		mgr.InvalidateIfMatches("OLD")
+		// Immediately after invalidate, name is dropped — concurrent
+		// callers stop hitting the dead reference.
+		if got := mgr.CacheName(); got != "" {
+			t.Errorf("expected name dropped to empty after invalidate, got %q", got)
+		}
+		// Async refresh repopulates within a short window.
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			if mgr.CacheName() != "" {
+				break
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		if got := mgr.CacheName(); got == "" {
+			t.Fatal("expected async refresh to repopulate cache name")
+		}
+		if !strings.HasSuffix(mgr.CacheName(), "/NEW") {
+			t.Errorf("expected refreshed name ending /NEW, got %q", mgr.CacheName())
+		}
+	})
+}
+
+// newTestCacheManager builds a manager wired to the supplied transport so
+// create/delete calls don't hit the real Vertex API.
+func newTestCacheManager(t *testing.T, rt http.RoundTripper) *llm.GeminiCacheManager {
+	t.Helper()
+	mgr, err := llm.NewGeminiCacheManager(llm.GeminiCacheManagerConfig{
+		Project:      "p",
+		Region:       "global",
+		Model:        "gemini-test",
+		SystemPrompt: "sys",
+		TTL:          30 * time.Minute,
+		HTTPClient:   &http.Client{Transport: rt},
+		TokenSource:  staticToken{},
+	})
+	if err != nil {
+		t.Fatalf("NewGeminiCacheManager: %v", err)
+	}
+	return mgr
 }
 
 func TestNewGeminiCacheManager_RejectsNegativeTTL(t *testing.T) {


### PR DESCRIPTION
## Summary
- Vertex returns `400 INVALID_ARGUMENT: Cache content X is expired` (not 404) when a `cachedContent` reference is used past its TTL. The existing 404→inline-systemInstruction fallback in `completeGemini` didn't trigger, so the verifier hard-failed for every concurrent caller holding the same in-process cache name until process restart.
- Classify the expired-cache 400 as `ErrGeminiCacheExpired` and route it through the same fallback path as 404. Add an invalidator the client invokes with the failed name; the manager atomic-CAS-drops it (no-op if a refresh already swapped) and triggers a debounced async create so concurrent callers stop hitting the dead reference.
- Wired through `StartCachedSystemPrompt` → `AttachGeminiCacheInvalidator`, attached by both verifier and extractor. `WithLogger` lets the fallback warn-log carry the calling component's logger.

## Test plan
- [x] `go test ./...` — all packages green
- [x] New unit tests in `internal/llm/gemini_test.go`:
  - `400CacheExpired_RetriesWithInlineSystem` — full request flow against a real-looking Vertex error envelope
  - `400CacheExpired_FiresInvalidator` — failed name is propagated
  - `400Uncached_NotClassifiedAsCacheExpired` and `400Cached_UnrelatedError_NotMisclassified` — no false positives
  - `404OnCachedRequest_FiresInvalidator` — parity with the new path
  - `GeminiCacheManager_InvalidateIfMatches` — empty / mismatch / match (with mock RoundTripper for the async refresh)
- [ ] Manual check in staging on the next cache-TTL cycle: confirm the structured `gemini cache fallback to inline systemInstruction` warn fires once (not per concurrent caller) and `gemini cache repopulated after invalidation` follows shortly after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)