### PR TITLE
fix(audit): record retries as audit rows; allow cross-task request_id reuse

### DIFF
--- a/internal/api/dedup_callback_test.go
+++ b/internal/api/dedup_callback_test.go
@@ -29,8 +29,10 @@ func registerCallbackSecret(t *testing.T, env *testEnv, agentToken string) strin
 // ── request_id deduplication ──────────────────────────────────────────────────
 
 func TestGateway_Dedup_BlockedRequest(t *testing.T) {
-	// A blocked request, when resubmitted with the same request_id, should return
-	// the existing outcome without creating a duplicate audit entry.
+	// A blocked request, when resubmitted with the same request_id, should
+	// return the canonical outcome without re-running the block check, while
+	// landing the retry as its own dedup-attempt audit row pointing at the
+	// canonical entry. This keeps every retry visible in the audit UI.
 	env := newTestEnv(t)
 	sc := newScenario(t, env, "dedup-block")
 	sc.createRestriction(t, "mock.svc", "run", "blocked by test")
@@ -57,20 +59,31 @@ func TestGateway_Dedup_BlockedRequest(t *testing.T) {
 		t.Errorf("dedup: request_id mismatch: got %v", second["request_id"])
 	}
 	if second["audit_id"] != first["audit_id"] {
-		t.Errorf("dedup: audit_id should match original: got %v, want %v", second["audit_id"], first["audit_id"])
+		t.Errorf("dedup: audit_id should match original canonical: got %v, want %v", second["audit_id"], first["audit_id"])
 	}
 
-	// Exactly one audit entry should exist for this request_id.
+	// Two audit entries should exist for this request_id: the canonical
+	// (decision="block", deduped_of=NULL) and the retry attempt
+	// (decision="dedup", deduped_of=canonical's id).
 	resp := sc.session.do("GET", "/api/audit", nil)
 	body := mustStatus(t, resp, http.StatusOK)
-	count := 0
+	var canonical, attempt int
 	for _, e := range arr(t, body, "entries") {
-		if e.(map[string]any)["request_id"] == reqID {
-			count++
+		entry := e.(map[string]any)
+		if entry["request_id"] != reqID {
+			continue
+		}
+		if entry["deduped_of"] == nil || entry["deduped_of"] == "" {
+			canonical++
+		} else {
+			attempt++
 		}
 	}
-	if count != 1 {
-		t.Errorf("dedup: expected 1 audit entry, got %d", count)
+	if canonical != 1 {
+		t.Errorf("dedup: expected 1 canonical audit row, got %d", canonical)
+	}
+	if attempt != 1 {
+		t.Errorf("dedup: expected 1 dedup-attempt audit row, got %d", attempt)
 	}
 }
 
@@ -202,6 +215,26 @@ func TestGateway_Dedup_SameRequestID_DifferentTask_NotDeduplicated(t *testing.T)
 	// Fresh execution should include result data.
 	if second["result"] == nil {
 		t.Error("cross-task reuse: result should be present (not dedup cache)")
+	}
+
+	// Two canonical audit rows should exist for this request_id, one per task —
+	// this is the bug the partial unique index fixes: previously the second
+	// canonical insert silently violated UNIQUE(request_id, user_id) and the
+	// audit row was lost while the agent still got a fresh audit_id back.
+	resp := sc.session.do("GET", "/api/audit", nil)
+	body := mustStatus(t, resp, http.StatusOK)
+	canonicals := 0
+	for _, e := range arr(t, body, "entries") {
+		entry := e.(map[string]any)
+		if entry["request_id"] != reqID {
+			continue
+		}
+		if entry["deduped_of"] == nil || entry["deduped_of"] == "" {
+			canonicals++
+		}
+	}
+	if canonicals != 2 {
+		t.Errorf("cross-task reuse: expected 2 canonical audit rows (one per task), got %d", canonicals)
 	}
 }
 

--- a/internal/api/handlers/feedback.go
+++ b/internal/api/handlers/feedback.go
@@ -62,11 +62,22 @@ func (h *FeedbackHandler) ReportBug(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Look up referenced request and task to give the reviewer full context.
+	// When the agent supplies task_id, prefer the task-scoped lookup so the
+	// reviewer sees the canonical row that actually fired in the agent's task
+	// (rather than an unrelated pre-task or cross-task canonical that happens
+	// to share the request_id).
 	var auditEntry *store.AuditEntry
 	var task *store.Task
 	if req.RequestID != "" {
-		if e, err := h.store.GetAuditEntryByRequestID(ctx, req.RequestID, agent.UserID); err == nil {
-			auditEntry = e
+		if req.TaskID != "" {
+			if e, err := h.store.GetAuditEntryByRequestIDAndTask(ctx, req.RequestID, agent.UserID, req.TaskID); err == nil {
+				auditEntry = e
+			}
+		}
+		if auditEntry == nil {
+			if e, err := h.store.GetAuditEntryByRequestID(ctx, req.RequestID, agent.UserID); err == nil {
+				auditEntry = e
+			}
 		}
 	}
 	if req.TaskID != "" {

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -1272,8 +1272,17 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 		// approval pending for this request_id. Surface the existing approval's
 		// status and demote our just-inserted canonical to a dedup-attempt so
 		// polling returns the row that actually owns the request_id.
-		existing, lookupErr := h.store.GetAuditEntryByRequestID(ctx, req.RequestID, agent.UserID)
-		if lookupErr == nil {
+		//
+		// Resolve the sibling canonical via pending_approvals.audit_id rather
+		// than GetAuditEntryByRequestID — the latter orders by timestamp DESC
+		// and would return *our* just-inserted row, producing a self-loop in
+		// deduped_of and stranding the response on a row with no live approval.
+		var existing *store.AuditEntry
+		pa, paErr := h.store.GetPendingApproval(ctx, req.RequestID)
+		if paErr == nil && pa.AuditID != "" {
+			existing, _ = h.store.GetAuditEntry(ctx, pa.AuditID, agent.UserID)
+		}
+		if existing != nil && existing.ID != e.ID {
 			if mErr := h.store.MarkAuditDeduped(ctx, e.ID, existing.ID, existing.Outcome); mErr != nil {
 				h.logger.Warn("mark audit deduped after approval conflict failed", "err", mErr)
 			} else {
@@ -1288,7 +1297,8 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			})
 			return
 		}
-		h.logger.Warn("approval conflict; canonical lookup failed", "err", lookupErr)
+		h.logger.Warn("approval conflict; sibling canonical lookup failed",
+			"pending_lookup_err", paErr, "request_id", req.RequestID)
 		// Fall through to the pending response — at least the wait=true path
 		// can still resolve via the existing approval.
 	} else if routeErr != nil {

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -1685,14 +1685,37 @@ func (h *GatewayHandler) recoverApprovalConflict(
 	e *store.AuditEntry,
 	userID, requestID, publishTaskID, dedupMessage string,
 ) bool {
-	pa, paErr := h.store.GetPendingApproval(ctx, requestID)
+	// First try: live pending approval. Catches concurrent same-task races and
+	// cross-task collisions while the approval is still pending. The
+	// pending_approvals.audit_id reference points straight at the sibling
+	// canonical (no risk of returning our just-inserted loser).
 	var existing *store.AuditEntry
+	pa, paErr := h.store.GetPendingApproval(ctx, requestID)
 	if paErr == nil && pa.AuditID != "" {
 		existing, _ = h.store.GetAuditEntry(ctx, pa.AuditID, userID)
 	}
+	// Second try: long-resolved approval_record. pending_approvals is deleted
+	// on deny/expire/execute, but approval_records.request_id stays populated,
+	// so a much-later cross-task reuse hits ErrConflict here even though no
+	// pending row exists. Resolve the sibling canonical via the resolved
+	// record's task_id — GetAuditEntryByRequestIDAndTask filters on that
+	// task, so our loser (different task) is excluded by the WHERE clause and
+	// can't self-loop.
+	var recErr error
+	if existing == nil || existing.ID == e.ID {
+		var rec *store.ApprovalRecord
+		rec, recErr = h.store.GetApprovalRecordByRequestID(ctx, requestID)
+		if recErr == nil {
+			recTaskID := ""
+			if rec.TaskID != nil {
+				recTaskID = *rec.TaskID
+			}
+			existing, _ = h.store.GetAuditEntryByRequestIDAndTask(ctx, requestID, userID, recTaskID)
+		}
+	}
 	if existing == nil || existing.ID == e.ID {
 		h.logger.Warn("approval conflict; sibling canonical lookup failed",
-			"pending_lookup_err", paErr, "request_id", requestID)
+			"pending_lookup_err", paErr, "record_lookup_err", recErr, "request_id", requestID)
 		return false
 	}
 	if mErr := h.store.MarkAuditDeduped(ctx, e.ID, existing.ID, existing.Outcome); mErr != nil {

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -249,29 +249,9 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 	// Parse alias from service field (e.g. "google.gmail:personal" → type="google.gmail", alias="personal").
 	serviceType, serviceAlias := parseServiceAlias(req.Service)
 
-	if req.RequestID == "" {
+	requestIDProvided := req.RequestID != ""
+	if !requestIDProvided {
 		req.RequestID = uuid.New().String()
-	} else {
-		// Dedup: if this request_id was already processed under the same task,
-		// return the existing outcome without re-processing. This prevents
-		// duplicate audit entries and re-execution of side-effect actions when
-		// the agent retries after a network timeout.
-		//
-		// The dedup is scoped to the same task_id so that reusing a request_id
-		// across different tasks/sessions is treated as a fresh request.
-		// Pre-task outcomes (e.g. "blocked" by restriction) have no task_id
-		// and are always dedup'd since they're stateless checks.
-		if existing, err := h.store.GetAuditEntryByRequestID(ctx, req.RequestID, agent.UserID); err == nil {
-			preTask := existing.TaskID == nil // blocked/error before task scope
-			sameTask := req.TaskID != "" && existing.TaskID != nil && *existing.TaskID == req.TaskID
-			if preTask || sameTask {
-				writeGatewayStatusResponse(w, existing, gatewayStatusResponseOptions{
-					Deduped: true,
-					Message: "Duplicate request_id reused; returning the existing result. Use a new request_id for a new request.",
-				})
-				return
-			}
-		}
 	}
 	middleware.AddLogField(ctx, "request_id", req.RequestID)
 
@@ -279,17 +259,26 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 
 	auditID := uuid.New().String()
 
-	// Backup log: append-only record of every gateway request. Written after
-	// the response so it captures the outcome. If the primary audit insert is
-	// ever silently dropped, this table retains full visibility.
+	// Backup log: append-only record of every gateway request, including dedup
+	// attempts. Written after the response so it captures the outcome. If the
+	// primary audit insert is ever silently dropped, this table retains full
+	// visibility.
 	//
 	// The timeout is generous (30s) so that a temporarily slow database does
 	// not silently lose log rows; the prior 5s deadline dropped writes under
 	// load that would otherwise have completed.
-	var outDecision, outOutcome string
+	//
+	// We read decision/outcome from the most recently produced audit entry so
+	// that race recovery — which mutates the entry to "dedup"/winner.Outcome
+	// after a unique-violation — is reflected in the backup log too.
+	var lastAudit *store.AuditEntry
 	defer func() {
 		logCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
+		var decision, outcome string
+		if lastAudit != nil {
+			decision, outcome = lastAudit.Decision, lastAudit.Outcome
+		}
 		if logErr := h.store.LogGatewayRequest(logCtx, &store.GatewayRequestLog{
 			AuditID:    auditID,
 			RequestID:  req.RequestID,
@@ -299,19 +288,18 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			Action:     req.Action,
 			TaskID:     req.TaskID,
 			Reason:     req.Reason,
-			Decision:   outDecision,
-			Outcome:    outOutcome,
+			Decision:   decision,
+			Outcome:    outcome,
 			DurationMS: int(time.Since(start).Milliseconds()),
 		}); logErr != nil {
 			h.logger.Warn("backup request log failed", "err", logErr)
 		}
 	}()
 
-	// baseEntry builds an AuditEntry with fields common to all outcomes.
-	// It also records the decision/outcome for the deferred backup log.
+	// baseEntry builds an AuditEntry with fields common to all outcomes and
+	// stashes a pointer in lastAudit for the deferred backup log to read.
 	baseEntry := func(decision, outcome string, taskID *string) *store.AuditEntry {
-		outDecision, outOutcome = decision, outcome
-		return &store.AuditEntry{
+		e := &store.AuditEntry{
 			ID:         auditID,
 			UserID:     agent.UserID,
 			AgentID:    &agent.ID,
@@ -327,6 +315,36 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			DataOrigin: req.Context.DataOrigin,
 			ContextSrc: nullableStr(req.Context.Source),
 		}
+		lastAudit = e
+		return e
+	}
+
+	// Dedup: if this request_id already has a canonical audit row in the same
+	// scope, record this attempt as a dedup row (deduped_of → canonical) and
+	// return the canonical's outcome without re-processing. This prevents
+	// re-execution of side-effect actions on retry while keeping every attempt
+	// visible in the audit log. Pre-task canonicals win over task-scoped ones
+	// for the same request_id (FindDedupCandidate handles precedence).
+	//
+	// Only run the lookup when the agent supplied request_id — a freshly
+	// generated UUID has no prior canonical to match.
+	if requestIDProvided {
+		if existing, err := h.store.FindDedupCandidate(ctx, req.RequestID, agent.UserID, req.TaskID); err == nil {
+			e := baseEntry("dedup", existing.Outcome, existing.TaskID)
+			e.DedupedOf = &existing.ID
+			e.DurationMS = int(time.Since(start).Milliseconds())
+			// Plain LogAudit: dedup-attempt rows have deduped_of != NULL so
+			// they're outside the partial unique index — no race recovery needed.
+			if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+				h.logger.Warn("audit log failed", "err", logErr)
+			}
+			h.publishAuditAndQueue(agent.UserID, "")
+			writeGatewayStatusResponse(w, existing, gatewayStatusResponseOptions{
+				Deduped: true,
+				Message: "Duplicate request_id reused; returning the existing result. Use a new request_id for a new request.",
+			})
+			return
+		}
 	}
 
 	// ── Step 0: Cloud gateway hooks (org-level restrictions) ────────────────
@@ -336,7 +354,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			middleware.AddLogField(ctx, "outcome", "blocked")
 			e := baseEntry("block", "blocked", nil)
 			e.DurationMS = int(time.Since(start).Milliseconds())
-			if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+			if _, logErr := h.logAuditCanonical(ctx, e); logErr != nil {
 				h.logger.Warn("audit log failed", "err", logErr)
 			}
 			h.publishAuditAndQueue(agent.UserID, "")
@@ -371,7 +389,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			e.RuleID = &serviceRule.ID
 		}
 		e.DurationMS = int(time.Since(start).Milliseconds())
-		if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+		if _, logErr := h.logAuditCanonical(ctx, e); logErr != nil {
 			h.logger.Warn("audit log failed", "err", logErr)
 		}
 		h.publishAuditAndQueue(agent.UserID, "")
@@ -416,7 +434,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			e.DurationMS = int(time.Since(start).Milliseconds())
 			errMsg := "missing required field: task_id"
 			e.ErrorMsg = &errMsg
-			if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+			if _, logErr := h.logAuditCanonical(ctx, e); logErr != nil {
 				h.logger.Warn("audit log failed", "err", logErr)
 			}
 			writeDetailedError(w, http.StatusBadRequest, apiErrorDetail{
@@ -463,7 +481,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			e.DurationMS = int(time.Since(start).Milliseconds())
 			errMsg := "request matches multiple active tasks; specify task_id explicitly"
 			e.ErrorMsg = &errMsg
-			if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+			if _, logErr := h.logAuditCanonical(ctx, e); logErr != nil {
 				h.logger.Warn("audit log failed", "err", logErr)
 			}
 			h.publishAuditAndQueue(agent.UserID, "")
@@ -484,7 +502,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			middleware.AddLogField(ctx, "outcome", "pending")
 			e := baseEntry("approve", "pending", nil)
 			e.DurationMS = int(time.Since(start).Milliseconds())
-			if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+			if _, logErr := h.logAuditCanonical(ctx, e); logErr != nil {
 				h.logger.Warn("audit log failed", "err", logErr)
 			}
 			h.publishAuditAndQueue(agent.UserID, "")
@@ -525,7 +543,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			e.DurationMS = int(time.Since(start).Milliseconds())
 			errMsg := "missing required field: task_id"
 			e.ErrorMsg = &errMsg
-			if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+			if _, logErr := h.logAuditCanonical(ctx, e); logErr != nil {
 				h.logger.Warn("audit log failed", "err", logErr)
 			}
 			writeDetailedError(w, http.StatusBadRequest, apiErrorDetail{
@@ -558,7 +576,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			e.DurationMS = int(time.Since(start).Milliseconds())
 			errMsg := fmt.Sprintf("task %q not found", req.TaskID)
 			e.ErrorMsg = &errMsg
-			if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+			if _, logErr := h.logAuditCanonical(ctx, e); logErr != nil {
 				h.logger.Warn("audit log failed", "err", logErr)
 			}
 			writeDetailedError(w, http.StatusBadRequest, apiErrorDetail{
@@ -574,7 +592,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			e.DurationMS = int(time.Since(start).Milliseconds())
 			errMsg := "task does not belong to this agent's user"
 			e.ErrorMsg = &errMsg
-			if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+			if _, logErr := h.logAuditCanonical(ctx, e); logErr != nil {
 				h.logger.Warn("audit log failed", "err", logErr)
 			}
 			writeDetailedError(w, http.StatusForbidden, apiErrorDetail{
@@ -595,7 +613,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			e.DurationMS = int(time.Since(start).Milliseconds())
 			errMsg := "task belongs to a different agent"
 			e.ErrorMsg = &errMsg
-			if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+			if _, logErr := h.logAuditCanonical(ctx, e); logErr != nil {
 				h.logger.Warn("audit log failed", "err", logErr)
 			}
 			writeDetailedError(w, http.StatusForbidden, apiErrorDetail{
@@ -609,7 +627,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			taskIDPtr := &req.TaskID
 			e := baseEntry("reject", "task_expired", taskIDPtr)
 			e.DurationMS = int(time.Since(start).Milliseconds())
-			if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+			if _, logErr := h.logAuditCanonical(ctx, e); logErr != nil {
 				h.logger.Warn("audit log failed", "err", logErr)
 			}
 			resp := map[string]any{
@@ -640,7 +658,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			e := baseEntry("reject", "invalid_state", taskIDPtr)
 			e.DurationMS = int(time.Since(start).Milliseconds())
 			e.ErrorMsg = &errMsg
-			if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+			if _, logErr := h.logAuditCanonical(ctx, e); logErr != nil {
 				h.logger.Warn("audit log failed", "err", logErr)
 			}
 			writeDetailedError(w, http.StatusConflict, apiErrorDetail{
@@ -657,7 +675,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			e.DurationMS = int(time.Since(start).Milliseconds())
 			errMsg := "session_id is required for standing task requests"
 			e.ErrorMsg = &errMsg
-			if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+			if _, logErr := h.logAuditCanonical(ctx, e); logErr != nil {
 				h.logger.Warn("audit log failed", "err", logErr)
 			}
 			writeDetailedError(w, http.StatusBadRequest, apiErrorDetail{
@@ -690,7 +708,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 				e := baseEntry("unknown_action", "blocked", taskIDPtr)
 				e.DurationMS = int(time.Since(start).Milliseconds())
 				e.ErrorMsg = &msg
-				if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+				if _, logErr := h.logAuditCanonical(ctx, e); logErr != nil {
 					h.logger.Warn("audit log failed", "err", logErr)
 				}
 				h.publishAuditAndQueue(agent.UserID, req.TaskID)
@@ -710,7 +728,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 				e := baseEntry("unknown_action", "blocked", taskIDPtr)
 				e.DurationMS = int(time.Since(start).Milliseconds())
 				e.ErrorMsg = &msg
-				if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+				if _, logErr := h.logAuditCanonical(ctx, e); logErr != nil {
 					h.logger.Warn("audit log failed", "err", logErr)
 				}
 				h.publishAuditAndQueue(agent.UserID, req.TaskID)
@@ -737,7 +755,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			e := baseEntry("out_of_scope", "blocked", taskIDPtr)
 			e.DurationMS = int(time.Since(start).Milliseconds())
 			e.ErrorMsg = &msg
-			if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+			if _, logErr := h.logAuditCanonical(ctx, e); logErr != nil {
 				h.logger.Warn("audit log failed", "err", logErr)
 			}
 			h.publishAuditAndQueue(agent.UserID, req.TaskID)
@@ -772,7 +790,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 					e.DurationMS = dur
 					errMsg := "local services are not available in this deployment"
 					e.ErrorMsg = &errMsg
-					if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+					if _, logErr := h.logAuditCanonical(ctx, e); logErr != nil {
 						h.logger.Warn("audit log failed", "err", logErr)
 					}
 					h.publishAuditAndQueue(agent.UserID, req.TaskID)
@@ -828,7 +846,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 					e := baseEntry("verify", "restricted", taskIDPtr)
 					e.DurationMS = dur
 					e.Verification = intent.MarshalVerdict(verdict)
-					if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+					if _, logErr := h.logAuditCanonical(ctx, e); logErr != nil {
 						h.logger.Warn("audit log failed", "err", logErr)
 					}
 					h.publishAuditAndQueue(agent.UserID, req.TaskID)
@@ -911,7 +929,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 					e := baseEntry("verify", "restricted", taskIDPtr)
 					e.DurationMS = dur
 					e.Verification = intent.MarshalVerdict(verdict)
-					if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+					if _, logErr := h.logAuditCanonical(ctx, e); logErr != nil {
 						h.logger.Warn("audit log failed", "err", logErr)
 					}
 					h.publishAuditAndQueue(agent.UserID, req.TaskID)
@@ -952,7 +970,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 						e.DurationMS = dur
 						code, userErr, auditMsg := serviceNotActivatedResponse(ctx, h.vault, h.store, h.adapterReg, agent.UserID, serviceType, serviceAlias, req.Service, taskAdapter)
 						e.ErrorMsg = &auditMsg
-						if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+						if _, logErr := h.logAuditCanonical(ctx, e); logErr != nil {
 							h.logger.Warn("audit log failed", "err", logErr)
 						}
 						h.publishAuditAndQueue(agent.UserID, req.TaskID)
@@ -976,7 +994,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 						e := baseEntry("reject", "validation_error", taskIDPtr)
 						e.DurationMS = int(time.Since(start).Milliseconds())
 						e.ErrorMsg = &errMsg
-						if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+						if _, logErr := h.logAuditCanonical(ctx, e); logErr != nil {
 							h.logger.Warn("audit log failed", "err", logErr)
 						}
 						h.publishAuditAndQueue(agent.UserID, req.TaskID)
@@ -998,7 +1016,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 						e.DurationMS = dur
 						code, userErr, auditMsg := serviceNotActivatedResponse(ctx, h.vault, h.store, h.adapterReg, agent.UserID, serviceType, serviceAlias, req.Service, adapter)
 						e.ErrorMsg = &auditMsg
-						if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+						if _, logErr := h.logAuditCanonical(ctx, e); logErr != nil {
 							h.logger.Warn("audit log failed", "err", logErr)
 						}
 						h.publishAuditAndQueue(agent.UserID, req.TaskID)
@@ -1023,7 +1041,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 				e := baseEntry("execute", "error", taskIDPtr)
 				e.DurationMS = dur
 				e.ErrorMsg = &errMsg
-				if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+				if _, logErr := h.logAuditCanonical(ctx, e); logErr != nil {
 					h.logger.Warn("audit log failed", "err", logErr)
 				}
 				h.publishAuditAndQueue(agent.UserID, req.TaskID)
@@ -1053,7 +1071,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			if verdict != nil {
 				e.Verification = intent.MarshalVerdict(verdict)
 			}
-			if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+			if _, logErr := h.logAuditCanonical(ctx, e); logErr != nil {
 				h.logger.Warn("audit log failed", "err", logErr)
 			}
 			h.publishAuditAndQueue(agent.UserID, req.TaskID)
@@ -1158,7 +1176,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			e.DurationMS = int(time.Since(start).Milliseconds())
 			errMsg := fmt.Sprintf("unknown service %q", serviceType)
 			e.ErrorMsg = &errMsg
-			if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+			if _, logErr := h.logAuditCanonical(ctx, e); logErr != nil {
 				h.logger.Warn("audit log failed", "err", logErr)
 			}
 			h.publishAuditAndQueue(agent.UserID, "")
@@ -1190,7 +1208,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 				e.DurationMS = int(time.Since(start).Milliseconds())
 				code, userErr, auditMsg := serviceNotActivatedResponse(ctx, h.vault, h.store, h.adapterReg, agent.UserID, serviceType, serviceAlias, req.Service, approveAdapter)
 				e.ErrorMsg = &auditMsg
-				if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+				if _, logErr := h.logAuditCanonical(ctx, e); logErr != nil {
 					h.logger.Warn("audit log failed", "err", logErr)
 				}
 				h.publishAuditAndQueue(agent.UserID, "")
@@ -1213,8 +1231,21 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 	e := baseEntry("approve", "pending", taskIDPtr)
 	e.DurationMS = int(time.Since(start).Milliseconds())
 	e.Verification = intent.MarshalVerdict(advisoryVerdict)
-	if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+	winner, logErr := h.logAuditCanonical(ctx, e)
+	if logErr != nil {
 		h.logger.Warn("audit log failed", "err", logErr)
+	}
+	if winner != nil {
+		// Lost the canonical-insert race against a concurrent worker. e was
+		// rewritten as a dedup-attempt; do not enqueue a duplicate approval —
+		// surface the winning row's status the same way the early-dedup branch
+		// would have if we'd seen it during FindDedupCandidate.
+		h.publishAuditAndQueue(agent.UserID, "")
+		writeGatewayStatusResponse(w, winner, gatewayStatusResponseOptions{
+			Deduped: true,
+			Message: "Duplicate request_id reused; returning the existing result. Use a new request_id for a new request.",
+		})
+		return
 	}
 	h.publishAuditAndQueue(agent.UserID, req.TaskID)
 	expiresAt := time.Now().Add(time.Duration(h.cfg.Approval.Timeout) * time.Second)
@@ -1553,6 +1584,42 @@ func (h *GatewayHandler) maybeInjectNPS(ctx context.Context, resp map[string]any
 			"task_id":  taskID,
 		},
 	}
+}
+
+// logAuditCanonical writes an audit row with the partial-unique canonical
+// constraint in mind. On a unique-violation race (concurrent inserts for the
+// same (user_id, request_id, task_id)), it refetches the winning canonical,
+// rewrites the entry as a dedup-attempt row pointing at the winner, and
+// returns the winner so callers that gate side effects on canonical insertion
+// (currently the approval routing path) can short-circuit instead of
+// double-handling the request.
+//
+// Returned winner is non-nil iff race recovery rewrote the entry. e is mutated
+// in place (DedupedOf/Decision/Outcome) so callers reading e see the same
+// shape that landed in the database. err is the final insert error, if any.
+//
+// Use this for every canonical insert site: per-request approval, blocked,
+// executed, validation_error — anywhere a fresh row is meant to be the
+// authoritative record for this (request_id, scope). Dedup-attempt rows
+// (deduped_of != NULL) are outside the partial unique index, so callers that
+// already build attempt rows can use plain LogAudit.
+func (h *GatewayHandler) logAuditCanonical(ctx context.Context, e *store.AuditEntry) (*store.AuditEntry, error) {
+	err := h.store.LogAudit(ctx, e)
+	if err == nil || !errors.Is(err, store.ErrConflict) {
+		return nil, err
+	}
+	taskID := ""
+	if e.TaskID != nil {
+		taskID = *e.TaskID
+	}
+	winner, lookupErr := h.store.FindDedupCandidate(ctx, e.RequestID, e.UserID, taskID)
+	if lookupErr != nil {
+		return nil, fmt.Errorf("dedup candidate lookup after race: %w", lookupErr)
+	}
+	e.DedupedOf = &winner.ID
+	e.Decision = "dedup"
+	e.Outcome = winner.Outcome
+	return winner, h.store.LogAudit(ctx, e)
 }
 
 // writeGatewayStatusResponse writes a consistent status payload for a resolved audit entry.

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -330,7 +330,15 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 	// generated UUID has no prior canonical to match.
 	if requestIDProvided {
 		if existing, err := h.store.FindDedupCandidate(ctx, req.RequestID, agent.UserID, req.TaskID); err == nil {
-			e := baseEntry("dedup", existing.Outcome, existing.TaskID)
+			// The attempt row records *where the retry happened* (req.TaskID),
+			// not where the canonical lives. When a pre-task canonical absorbs
+			// a task-scoped retry the two diverge, and tagging the attempt with
+			// the canonical's task hides it from the retry's task-scoped feed.
+			var attemptTaskID *string
+			if req.TaskID != "" {
+				attemptTaskID = &req.TaskID
+			}
+			e := baseEntry("dedup", existing.Outcome, attemptTaskID)
 			e.DedupedOf = &existing.ID
 			e.DurationMS = int(time.Since(start).Milliseconds())
 			// Plain LogAudit: dedup-attempt rows have deduped_of != NULL so
@@ -338,7 +346,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			if logErr := h.store.LogAudit(ctx, e); logErr != nil {
 				h.logger.Warn("audit log failed", "err", logErr)
 			}
-			h.publishAuditAndQueue(agent.UserID, "")
+			h.publishAuditAndQueue(agent.UserID, req.TaskID)
 			writeGatewayStatusResponse(w, existing, gatewayStatusResponseOptions{
 				Deduped: true,
 				Message: "Duplicate request_id reused; returning the existing result. Use a new request_id for a new request.",
@@ -1255,8 +1263,35 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 	if hardcoded {
 		reason = "iMessage send_message always requires human approval"
 	}
-	if routeErr := h.routeToApproval(ctx, agent.UserID, blob, auditID,
-		req.Context.CallbackURL, expiresAt, reason, advisoryVerdict); routeErr != nil {
+	routeErr := h.routeToApproval(ctx, agent.UserID, blob, auditID,
+		req.Context.CallbackURL, expiresAt, reason, advisoryVerdict)
+	if errors.Is(routeErr, store.ErrConflict) {
+		// Cross-task duplicate: pending_approvals/approval_records are still
+		// globally unique by request_id even though audit_log now allows one
+		// canonical per (user, request_id, task). Another task already has an
+		// approval pending for this request_id. Surface the existing approval's
+		// status and demote our just-inserted canonical to a dedup-attempt so
+		// polling returns the row that actually owns the request_id.
+		existing, lookupErr := h.store.GetAuditEntryByRequestID(ctx, req.RequestID, agent.UserID)
+		if lookupErr == nil {
+			if mErr := h.store.MarkAuditDeduped(ctx, e.ID, existing.ID, existing.Outcome); mErr != nil {
+				h.logger.Warn("mark audit deduped after approval conflict failed", "err", mErr)
+			} else {
+				e.DedupedOf = &existing.ID
+				e.Decision = "dedup"
+				e.Outcome = existing.Outcome
+			}
+			h.publishAuditAndQueue(agent.UserID, req.TaskID)
+			writeGatewayStatusResponse(w, existing, gatewayStatusResponseOptions{
+				Deduped: true,
+				Message: "Duplicate request_id reused; awaiting the existing approval. Use a new request_id for a new request.",
+			})
+			return
+		}
+		h.logger.Warn("approval conflict; canonical lookup failed", "err", lookupErr)
+		// Fall through to the pending response — at least the wait=true path
+		// can still resolve via the existing approval.
+	} else if routeErr != nil {
 		h.logger.Warn("route to approval failed", "err", routeErr)
 	}
 	// If wait=true, long-poll for approval then execute inline.
@@ -1603,6 +1638,18 @@ func (h *GatewayHandler) maybeInjectNPS(ctx context.Context, resp map[string]any
 // authoritative record for this (request_id, scope). Dedup-attempt rows
 // (deduped_of != NULL) are outside the partial unique index, so callers that
 // already build attempt rows can use plain LogAudit.
+//
+// Known limitation — auto-execute idempotency: callers in the auto-execute
+// path invoke the adapter *before* calling this helper. Two concurrent
+// requests with the same (user, request_id, task_id) can both miss the early
+// FindDedupCandidate, both perform the side effect, and only collide here on
+// the audit insert. This helper recovers the audit shape (one canonical, one
+// dedup-attempt) but cannot un-fire a side effect the adapter already
+// executed. The same race window existed under the prior UNIQUE+early-return
+// design; closing it requires an insert-canonical-before-execute reservation
+// pattern that is intentionally out of scope for this change. The early
+// FindDedupCandidate still catches the common case (sequential retries); the
+// race is narrow (two near-simultaneous identical requests).
 func (h *GatewayHandler) logAuditCanonical(ctx context.Context, e *store.AuditEntry) (*store.AuditEntry, error) {
 	err := h.store.LogAudit(ctx, e)
 	if err == nil || !errors.Is(err, store.ErrConflict) {

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -510,8 +510,20 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			middleware.AddLogField(ctx, "outcome", "pending")
 			e := baseEntry("approve", "pending", nil)
 			e.DurationMS = int(time.Since(start).Milliseconds())
-			if _, logErr := h.logAuditCanonical(ctx, e); logErr != nil {
+			winner, logErr := h.logAuditCanonical(ctx, e)
+			if logErr != nil {
 				h.logger.Warn("audit log failed", "err", logErr)
+			}
+			if winner != nil {
+				// Lost the canonical-insert race: another worker already
+				// wrote the canonical for this (request_id, NULL task) scope.
+				// Don't enqueue a duplicate approval — surface the winner.
+				h.publishAuditAndQueue(agent.UserID, "")
+				writeGatewayStatusResponse(w, winner, gatewayStatusResponseOptions{
+					Deduped: true,
+					Message: "Duplicate request_id reused; returning the existing result. Use a new request_id for a new request.",
+				})
+				return
 			}
 			h.publishAuditAndQueue(agent.UserID, "")
 			expiresAt := time.Now().Add(time.Duration(h.cfg.Approval.Timeout) * time.Second)
@@ -520,7 +532,14 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			if classification.Kind == runtimepolicy.ClassificationNeedsNewTask {
 				reason = "request is outside every active task and may need a new task"
 			}
-			if routeErr := h.routeToApproval(ctx, agent.UserID, blob, auditID, req.Context.CallbackURL, expiresAt, reason, nil); routeErr != nil {
+			routeErr := h.routeToApproval(ctx, agent.UserID, blob, auditID, req.Context.CallbackURL, expiresAt, reason, nil)
+			if errors.Is(routeErr, store.ErrConflict) {
+				if h.recoverApprovalConflict(ctx, w, e, agent.UserID, req.RequestID, "",
+					"Duplicate request_id reused; awaiting the existing approval. Use a new request_id for a new request.") {
+					return
+				}
+				// Fell through to the wait/pending path below.
+			} else if routeErr != nil {
 				h.logger.Warn("route to approval failed", "err", routeErr)
 			}
 			if r.URL.Query().Get("wait") == "true" && h.eventHub != nil {
@@ -1266,41 +1285,12 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 	routeErr := h.routeToApproval(ctx, agent.UserID, blob, auditID,
 		req.Context.CallbackURL, expiresAt, reason, advisoryVerdict)
 	if errors.Is(routeErr, store.ErrConflict) {
-		// Cross-task duplicate: pending_approvals/approval_records are still
-		// globally unique by request_id even though audit_log now allows one
-		// canonical per (user, request_id, task). Another task already has an
-		// approval pending for this request_id. Surface the existing approval's
-		// status and demote our just-inserted canonical to a dedup-attempt so
-		// polling returns the row that actually owns the request_id.
-		//
-		// Resolve the sibling canonical via pending_approvals.audit_id rather
-		// than GetAuditEntryByRequestID — the latter orders by timestamp DESC
-		// and would return *our* just-inserted row, producing a self-loop in
-		// deduped_of and stranding the response on a row with no live approval.
-		var existing *store.AuditEntry
-		pa, paErr := h.store.GetPendingApproval(ctx, req.RequestID)
-		if paErr == nil && pa.AuditID != "" {
-			existing, _ = h.store.GetAuditEntry(ctx, pa.AuditID, agent.UserID)
-		}
-		if existing != nil && existing.ID != e.ID {
-			if mErr := h.store.MarkAuditDeduped(ctx, e.ID, existing.ID, existing.Outcome); mErr != nil {
-				h.logger.Warn("mark audit deduped after approval conflict failed", "err", mErr)
-			} else {
-				e.DedupedOf = &existing.ID
-				e.Decision = "dedup"
-				e.Outcome = existing.Outcome
-			}
-			h.publishAuditAndQueue(agent.UserID, req.TaskID)
-			writeGatewayStatusResponse(w, existing, gatewayStatusResponseOptions{
-				Deduped: true,
-				Message: "Duplicate request_id reused; awaiting the existing approval. Use a new request_id for a new request.",
-			})
+		if h.recoverApprovalConflict(ctx, w, e, agent.UserID, req.RequestID, req.TaskID,
+			"Duplicate request_id reused; awaiting the existing approval. Use a new request_id for a new request.") {
 			return
 		}
-		h.logger.Warn("approval conflict; sibling canonical lookup failed",
-			"pending_lookup_err", paErr, "request_id", req.RequestID)
-		// Fall through to the pending response — at least the wait=true path
-		// can still resolve via the existing approval.
+		// Fell through: the wait=true long-poll can still resolve via the
+		// existing approval, so continue to the pending response.
 	} else if routeErr != nil {
 		h.logger.Warn("route to approval failed", "err", routeErr)
 	}
@@ -1677,6 +1667,47 @@ func (h *GatewayHandler) logAuditCanonical(ctx context.Context, e *store.AuditEn
 	e.Decision = "dedup"
 	e.Outcome = winner.Outcome
 	return winner, h.store.LogAudit(ctx, e)
+}
+
+// recoverApprovalConflict handles a store.ErrConflict from routeToApproval —
+// the cross-task duplicate case where pending_approvals/approval_records are
+// still globally unique by request_id even though audit_log permits one
+// canonical per (user, request_id, task). Resolves the sibling canonical via
+// pending_approvals.audit_id (NOT GetAuditEntryByRequestID, which would order
+// by timestamp DESC and return the just-inserted loser, producing a self-loop
+// in MarkAuditDeduped), demotes e to a dedup-attempt pointing at the sibling,
+// and writes a deduped status response. Returns true iff recovery succeeded;
+// on false the caller should fall through to its normal pending-response path
+// (the wait=true long-poll can still resolve via the existing approval).
+func (h *GatewayHandler) recoverApprovalConflict(
+	ctx context.Context,
+	w http.ResponseWriter,
+	e *store.AuditEntry,
+	userID, requestID, publishTaskID, dedupMessage string,
+) bool {
+	pa, paErr := h.store.GetPendingApproval(ctx, requestID)
+	var existing *store.AuditEntry
+	if paErr == nil && pa.AuditID != "" {
+		existing, _ = h.store.GetAuditEntry(ctx, pa.AuditID, userID)
+	}
+	if existing == nil || existing.ID == e.ID {
+		h.logger.Warn("approval conflict; sibling canonical lookup failed",
+			"pending_lookup_err", paErr, "request_id", requestID)
+		return false
+	}
+	if mErr := h.store.MarkAuditDeduped(ctx, e.ID, existing.ID, existing.Outcome); mErr != nil {
+		h.logger.Warn("mark audit deduped after approval conflict failed", "err", mErr)
+	} else {
+		e.DedupedOf = &existing.ID
+		e.Decision = "dedup"
+		e.Outcome = existing.Outcome
+	}
+	h.publishAuditAndQueue(userID, publishTaskID)
+	writeGatewayStatusResponse(w, existing, gatewayStatusResponseOptions{
+		Deduped: true,
+		Message: dedupMessage,
+	})
+	return true
 }
 
 // writeGatewayStatusResponse writes a consistent status payload for a resolved audit entry.

--- a/internal/api/handlers/gateway_audit_dedup_test.go
+++ b/internal/api/handlers/gateway_audit_dedup_test.go
@@ -1,0 +1,143 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+// raceRecoveryStore stages a simulated unique-violation race: the first
+// LogAudit call returns ErrConflict; the next FindDedupCandidate returns the
+// "winner" canonical; the second LogAudit call (the rewritten dedup-attempt
+// row) succeeds.
+type raceRecoveryStore struct {
+	store.Store
+	winner *store.AuditEntry
+
+	callsLogAudit       int
+	callsFindCandidate  int
+	lastInserted        *store.AuditEntry
+	failFirstLogAuditAs error
+	failCandidateAs     error
+}
+
+func (s *raceRecoveryStore) LogAudit(_ context.Context, e *store.AuditEntry) error {
+	s.callsLogAudit++
+	if s.callsLogAudit == 1 && s.failFirstLogAuditAs != nil {
+		return s.failFirstLogAuditAs
+	}
+	// On the recovery insert, capture the rewritten entry for assertions.
+	copyOf := *e
+	s.lastInserted = &copyOf
+	return nil
+}
+
+func (s *raceRecoveryStore) FindDedupCandidate(_ context.Context, _, _, _ string) (*store.AuditEntry, error) {
+	s.callsFindCandidate++
+	if s.failCandidateAs != nil {
+		return nil, s.failCandidateAs
+	}
+	return s.winner, nil
+}
+
+// TestLogAuditCanonical_RaceRecovery covers the unique-violation race: when
+// two workers both miss FindDedupCandidate and both try to insert canonical,
+// the loser must rewrite its row as a dedup-attempt pointing at the winner.
+// The mutated row's Decision/Outcome must match the canonical's outcome so
+// the audit UI shows a consistent story.
+func TestLogAuditCanonical_RaceRecovery(t *testing.T) {
+	winnerTaskID := "task-A"
+	winner := &store.AuditEntry{
+		ID:       "winner-id",
+		UserID:   "user-1",
+		TaskID:   &winnerTaskID,
+		Decision: "execute",
+		Outcome:  "executed",
+	}
+	st := &raceRecoveryStore{
+		winner:              winner,
+		failFirstLogAuditAs: store.ErrConflict,
+	}
+	h := &GatewayHandler{store: st}
+
+	loserTaskID := winnerTaskID
+	loser := &store.AuditEntry{
+		ID:        "loser-id",
+		UserID:    "user-1",
+		RequestID: "req-1",
+		TaskID:    &loserTaskID,
+		Decision:  "execute",
+		Outcome:   "executed",
+	}
+
+	if _, err := h.logAuditCanonical(context.Background(), loser); err != nil {
+		t.Fatalf("logAuditCanonical: %v", err)
+	}
+
+	if st.callsLogAudit != 2 {
+		t.Errorf("expected 2 LogAudit calls (1 conflict + 1 attempt), got %d", st.callsLogAudit)
+	}
+	if st.callsFindCandidate != 1 {
+		t.Errorf("expected 1 FindDedupCandidate call, got %d", st.callsFindCandidate)
+	}
+	if st.lastInserted == nil {
+		t.Fatal("expected a recovery LogAudit insert, got none")
+	}
+	if st.lastInserted.DedupedOf == nil || *st.lastInserted.DedupedOf != winner.ID {
+		t.Errorf("DedupedOf: got %v, want pointer to %q", st.lastInserted.DedupedOf, winner.ID)
+	}
+	if st.lastInserted.Decision != "dedup" {
+		t.Errorf("Decision: got %q, want %q", st.lastInserted.Decision, "dedup")
+	}
+	if st.lastInserted.Outcome != winner.Outcome {
+		t.Errorf("Outcome: got %q, want %q (snapshot of canonical)", st.lastInserted.Outcome, winner.Outcome)
+	}
+	if st.lastInserted.ID != loser.ID {
+		t.Errorf("attempt row ID: got %q, want %q (loser's own audit ID)", st.lastInserted.ID, loser.ID)
+	}
+}
+
+// TestLogAuditCanonical_NonConflictError ensures non-conflict errors propagate
+// directly — only ErrConflict triggers race recovery.
+func TestLogAuditCanonical_NonConflictError(t *testing.T) {
+	dbErr := errors.New("database is down")
+	st := &raceRecoveryStore{failFirstLogAuditAs: dbErr}
+	h := &GatewayHandler{store: st}
+
+	taskID := "task-A"
+	e := &store.AuditEntry{ID: "id-1", UserID: "u", RequestID: "r", TaskID: &taskID, Decision: "execute", Outcome: "executed"}
+	_, err := h.logAuditCanonical(context.Background(), e)
+	if !errors.Is(err, dbErr) {
+		t.Fatalf("expected db error to propagate, got %v", err)
+	}
+	if st.callsFindCandidate != 0 {
+		t.Errorf("FindDedupCandidate should not be called for non-conflict errors, got %d", st.callsFindCandidate)
+	}
+}
+
+// TestLogAuditCanonical_HappyPath verifies the no-conflict case: a single
+// successful LogAudit with no candidate lookup.
+func TestLogAuditCanonical_HappyPath(t *testing.T) {
+	st := &raceRecoveryStore{} // no failure staged
+	h := &GatewayHandler{store: st}
+
+	taskID := "task-A"
+	e := &store.AuditEntry{ID: "id-1", UserID: "u", RequestID: "r", TaskID: &taskID, Decision: "execute", Outcome: "executed"}
+	if _, err := h.logAuditCanonical(context.Background(), e); err != nil {
+		t.Fatalf("logAuditCanonical: %v", err)
+	}
+	if st.callsLogAudit != 1 {
+		t.Errorf("expected 1 LogAudit call, got %d", st.callsLogAudit)
+	}
+	if st.callsFindCandidate != 0 {
+		t.Errorf("expected 0 FindDedupCandidate calls, got %d", st.callsFindCandidate)
+	}
+	if e.DedupedOf != nil {
+		t.Errorf("happy path should not mutate DedupedOf, got %v", e.DedupedOf)
+	}
+	if e.Decision != "execute" {
+		t.Errorf("happy path should not mutate Decision, got %q", e.Decision)
+	}
+}

--- a/internal/api/handlers/local_service_test.go
+++ b/internal/api/handlers/local_service_test.go
@@ -116,6 +116,14 @@ func (s *localTestStore) GetAuditEntryByRequestID(_ context.Context, _, _ string
 	return nil, store.ErrNotFound
 }
 
+func (s *localTestStore) GetAuditEntryByRequestIDAndTask(_ context.Context, _, _, _ string) (*store.AuditEntry, error) {
+	return nil, store.ErrNotFound
+}
+
+func (s *localTestStore) FindDedupCandidate(_ context.Context, _, _, _ string) (*store.AuditEntry, error) {
+	return nil, store.ErrNotFound
+}
+
 func (s *localTestStore) ListChainFacts(_ context.Context, _, _ string, _ int) ([]*store.ChainFact, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/pkg/store/postgres/migrations/042_audit_dedup_attempts.sql
+++ b/pkg/store/postgres/migrations/042_audit_dedup_attempts.sql
@@ -1,4 +1,4 @@
--- See pkg/store/sqlite/migrations/041_audit_dedup_attempts.sql for the full
+-- See pkg/store/sqlite/migrations/042_audit_dedup_attempts.sql for the full
 -- rationale. Summary: drop the (request_id, user_id) UNIQUE constraint, add a
 -- deduped_of column, and replace the constraint with a partial unique index
 -- scoped to canonical (deduped_of IS NULL) rows. Per-scope uniqueness is

--- a/pkg/store/postgres/migrations/042_audit_dedup_attempts.sql
+++ b/pkg/store/postgres/migrations/042_audit_dedup_attempts.sql
@@ -1,0 +1,13 @@
+-- See pkg/store/sqlite/migrations/041_audit_dedup_attempts.sql for the full
+-- rationale. Summary: drop the (request_id, user_id) UNIQUE constraint, add a
+-- deduped_of column, and replace the constraint with a partial unique index
+-- scoped to canonical (deduped_of IS NULL) rows. Per-scope uniqueness is
+-- enforced in SQL; cross-scope precedence (pre-task beats task-scoped) is
+-- enforced by FindDedupCandidate ordering at read time.
+
+ALTER TABLE audit_log DROP CONSTRAINT IF EXISTS audit_log_request_id_user_id_key;
+ALTER TABLE audit_log ADD COLUMN deduped_of TEXT;
+
+CREATE UNIQUE INDEX idx_audit_canonical_dedup
+    ON audit_log(user_id, request_id, COALESCE(task_id, ''))
+    WHERE deduped_of IS NULL;

--- a/pkg/store/postgres/store.go
+++ b/pkg/store/postgres/store.go
@@ -717,6 +717,13 @@ func (s *Store) UpdateAuditOutcome(ctx context.Context, id, outcome, errMsg stri
 	return err
 }
 
+func (s *Store) MarkAuditDeduped(ctx context.Context, id, canonicalID, snapshotOutcome string) error {
+	_, err := s.pool.Exec(ctx,
+		`UPDATE audit_log SET decision = 'dedup', outcome = $1, deduped_of = $2 WHERE id = $3`,
+		snapshotOutcome, canonicalID, id)
+	return err
+}
+
 func (s *Store) GetAuditEntry(ctx context.Context, id, userID string) (*store.AuditEntry, error) {
 	row := s.pool.QueryRow(ctx,
 		`SELECT `+auditEntryColumns+` FROM audit_log WHERE id = $1 AND user_id = $2`,
@@ -1634,6 +1641,9 @@ func (s *Store) CreateApprovalRecordWithPending(ctx context.Context, rec *store.
 	`, rec.ID, rec.Kind, rec.UserID, rec.AgentID, rec.RequestID, rec.TaskID, rec.SessionID, rec.Status,
 		rec.Surface, rawJSONOrDefaultBytes(rec.SummaryJSON, "{}"), rawJSONOrDefaultBytes(rec.PayloadJSON, "{}"),
 		rec.ResolutionTransport, rec.ExpiresAt, rec.ResolvedAt, rec.Resolution); err != nil {
+		if isDuplicate(err) {
+			return store.ErrConflict
+		}
 		return err
 	}
 	if _, err = tx.Exec(ctx, `
@@ -1641,6 +1651,9 @@ func (s *Store) CreateApprovalRecordWithPending(ctx context.Context, rec *store.
 		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
 	`, pa.ID, pa.UserID, pa.RequestID, pa.AuditID, pa.ApprovalRecordID, []byte(pa.RequestBlob),
 		pa.CallbackURL, pa.Status, pa.ExpiresAt); err != nil {
+		if isDuplicate(err) {
+			return store.ErrConflict
+		}
 		return err
 	}
 	return tx.Commit(ctx)

--- a/pkg/store/postgres/store.go
+++ b/pkg/store/postgres/store.go
@@ -689,8 +689,8 @@ func (s *Store) LogAudit(ctx context.Context, e *store.AuditEntry) error {
 			intent_verdict, used_active_task_context, used_lease_bias, used_conv_judge_resolution,
 			would_block, would_review, would_prompt_inline,
 			safety_flagged, safety_reason, reason, data_origin, context_src,
-			duration_ms, filters_applied, verification, error_msg
-		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32,$33,$34,$35,$36)
+			duration_ms, filters_applied, verification, error_msg, deduped_of
+		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32,$33,$34,$35,$36,$37)
 	`, e.ID, e.UserID, e.AgentID, e.RequestID, e.TaskID, e.SessionID, e.ApprovalID, e.LeaseID,
 		e.ToolUseID, e.MatchedTaskID, e.LeaseTaskID, e.Timestamp,
 		e.Service, e.Action, []byte(paramsSafe), e.Decision, e.Outcome,
@@ -699,7 +699,10 @@ func (s *Store) LogAudit(ctx context.Context, e *store.AuditEntry) error {
 		e.WouldBlock, e.WouldReview, e.WouldPromptInline,
 		e.SafetyFlagged, e.SafetyReason, e.Reason,
 		e.DataOrigin, e.ContextSrc, e.DurationMS, nilIfEmpty(e.FiltersApplied),
-		nilIfEmpty(e.Verification), e.ErrorMsg)
+		nilIfEmpty(e.Verification), e.ErrorMsg, e.DedupedOf)
+	if isDuplicate(err) {
+		return store.ErrConflict
+	}
 	return err
 }
 
@@ -715,77 +718,74 @@ func (s *Store) UpdateAuditOutcome(ctx context.Context, id, outcome, errMsg stri
 }
 
 func (s *Store) GetAuditEntry(ctx context.Context, id, userID string) (*store.AuditEntry, error) {
-	e := &store.AuditEntry{}
-	var paramsSafe, filtersApplied, verification []byte
-	err := s.pool.QueryRow(ctx, `
-		SELECT id, user_id, agent_id, request_id, task_id, session_id, approval_id, lease_id,
-		       tool_use_id, matched_task_id, lease_task_id, timestamp, service, action,
-		       params_safe, decision, outcome, policy_id, rule_id, resolution_confidence,
-		       intent_verdict, used_active_task_context, used_lease_bias, used_conv_judge_resolution,
-		       would_block, would_review, would_prompt_inline,
-		       safety_flagged, safety_reason, reason, data_origin, context_src,
-		       duration_ms, filters_applied, verification, error_msg
-		FROM audit_log WHERE id = $1 AND user_id = $2
-	`, id, userID).Scan(
-		&e.ID, &e.UserID, &e.AgentID, &e.RequestID, &e.TaskID, &e.SessionID, &e.ApprovalID, &e.LeaseID,
-		&e.ToolUseID, &e.MatchedTaskID, &e.LeaseTaskID, &e.Timestamp,
-		&e.Service, &e.Action, &paramsSafe, &e.Decision, &e.Outcome,
-		&e.PolicyID, &e.RuleID, &e.ResolutionConfidence, &e.IntentVerdict,
-		&e.UsedActiveTaskContext, &e.UsedLeaseBias, &e.UsedConvJudgeResolution,
-		&e.WouldBlock, &e.WouldReview, &e.WouldPromptInline,
-		&e.SafetyFlagged, &e.SafetyReason, &e.Reason,
-		&e.DataOrigin, &e.ContextSrc, &e.DurationMS, &filtersApplied, &verification, &e.ErrorMsg)
+	row := s.pool.QueryRow(ctx,
+		`SELECT `+auditEntryColumns+` FROM audit_log WHERE id = $1 AND user_id = $2`,
+		id, userID)
+	e, err := scanAuditEntryPg(row)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, store.ErrNotFound
 	}
-	if err != nil {
-		return nil, err
-	}
-	e.ParamsSafe = json.RawMessage(paramsSafe)
-	if filtersApplied != nil {
-		e.FiltersApplied = json.RawMessage(filtersApplied)
-	}
-	if verification != nil {
-		e.Verification = json.RawMessage(verification)
-	}
-	return e, nil
+	return e, err
 }
 
 func (s *Store) GetAuditEntryByRequestID(ctx context.Context, requestID, userID string) (*store.AuditEntry, error) {
-	e := &store.AuditEntry{}
-	var paramsSafe, filtersApplied, verification []byte
-	err := s.pool.QueryRow(ctx, `
-		SELECT id, user_id, agent_id, request_id, task_id, session_id, approval_id, lease_id,
-		       tool_use_id, matched_task_id, lease_task_id, timestamp, service, action,
-		       params_safe, decision, outcome, policy_id, rule_id, resolution_confidence,
-		       intent_verdict, used_active_task_context, used_lease_bias, used_conv_judge_resolution,
-		       would_block, would_review, would_prompt_inline,
-		       safety_flagged, safety_reason, reason, data_origin, context_src,
-		       duration_ms, filters_applied, verification, error_msg
-		FROM audit_log WHERE request_id = $1 AND user_id = $2
-	`, requestID, userID).Scan(
-		&e.ID, &e.UserID, &e.AgentID, &e.RequestID, &e.TaskID, &e.SessionID, &e.ApprovalID, &e.LeaseID,
-		&e.ToolUseID, &e.MatchedTaskID, &e.LeaseTaskID, &e.Timestamp,
-		&e.Service, &e.Action, &paramsSafe, &e.Decision, &e.Outcome,
-		&e.PolicyID, &e.RuleID, &e.ResolutionConfidence, &e.IntentVerdict,
-		&e.UsedActiveTaskContext, &e.UsedLeaseBias, &e.UsedConvJudgeResolution,
-		&e.WouldBlock, &e.WouldReview, &e.WouldPromptInline,
-		&e.SafetyFlagged, &e.SafetyReason, &e.Reason,
-		&e.DataOrigin, &e.ContextSrc, &e.DurationMS, &filtersApplied, &verification, &e.ErrorMsg)
+	row := s.pool.QueryRow(ctx,
+		`SELECT `+auditEntryColumns+`
+		 FROM audit_log
+		 WHERE request_id = $1 AND user_id = $2 AND deduped_of IS NULL
+		 ORDER BY timestamp DESC LIMIT 1`,
+		requestID, userID)
+	e, err := scanAuditEntryPg(row)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, store.ErrNotFound
 	}
-	if err != nil {
-		return nil, err
+	return e, err
+}
+
+func (s *Store) GetAuditEntryByRequestIDAndTask(ctx context.Context, requestID, userID, taskID string) (*store.AuditEntry, error) {
+	// Read-time precedence is inverted from FindDedupCandidate: the feedback
+	// handler wants the row that actually fired *in the agent's task*, so an
+	// exact task_id match wins over a pre-task canonical for the same
+	// request_id. Pre-task remains the fallback when no task-scoped row
+	// exists. (FindDedupCandidate keeps the opposite ordering at write time
+	// so a pre-task canonical correctly absorbs later task-scoped retries.)
+	row := s.pool.QueryRow(ctx,
+		`SELECT `+auditEntryColumns+`
+		 FROM audit_log
+		 WHERE request_id = $1 AND user_id = $2 AND deduped_of IS NULL
+		   AND (task_id IS NULL OR task_id = $3)
+		 ORDER BY (task_id IS NULL) ASC, timestamp ASC LIMIT 1`,
+		requestID, userID, taskID)
+	e, err := scanAuditEntryPg(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, store.ErrNotFound
 	}
-	e.ParamsSafe = json.RawMessage(paramsSafe)
-	if filtersApplied != nil {
-		e.FiltersApplied = json.RawMessage(filtersApplied)
+	return e, err
+}
+
+func (s *Store) FindDedupCandidate(ctx context.Context, requestID, userID, taskID string) (*store.AuditEntry, error) {
+	var row pgx.Row
+	if taskID == "" {
+		row = s.pool.QueryRow(ctx,
+			`SELECT `+auditEntryColumns+`
+			 FROM audit_log
+			 WHERE request_id = $1 AND user_id = $2 AND deduped_of IS NULL AND task_id IS NULL
+			 ORDER BY timestamp ASC LIMIT 1`,
+			requestID, userID)
+	} else {
+		row = s.pool.QueryRow(ctx,
+			`SELECT `+auditEntryColumns+`
+			 FROM audit_log
+			 WHERE request_id = $1 AND user_id = $2 AND deduped_of IS NULL
+			   AND (task_id IS NULL OR task_id = $3)
+			 ORDER BY (task_id IS NULL) DESC, timestamp ASC LIMIT 1`,
+			requestID, userID, taskID)
 	}
-	if verification != nil {
-		e.Verification = json.RawMessage(verification)
+	e, err := scanAuditEntryPg(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, store.ErrNotFound
 	}
-	return e, nil
+	return e, err
 }
 
 func (s *Store) ListAuditEntries(ctx context.Context, userID string, filter store.AuditFilter) ([]*store.AuditEntry, int, error) {
@@ -840,14 +840,7 @@ func (s *Store) ListAuditEntries(ctx context.Context, userID string, filter stor
 		return nil, 0, err
 	}
 
-	dataQuery := `SELECT id, user_id, agent_id, request_id, task_id, session_id, approval_id, lease_id,
-		tool_use_id, matched_task_id, lease_task_id, timestamp, service, action,
-		params_safe, decision, outcome, policy_id, rule_id, resolution_confidence,
-		intent_verdict, used_active_task_context, used_lease_bias, used_conv_judge_resolution,
-		would_block, would_review, would_prompt_inline,
-		safety_flagged, safety_reason, reason, data_origin, context_src,
-		duration_ms, filters_applied, verification, error_msg
-		FROM audit_log ` + where +
+	dataQuery := `SELECT ` + auditEntryColumns + ` FROM audit_log ` + where +
 		fmt.Sprintf(" ORDER BY timestamp DESC LIMIT $%d OFFSET $%d", i, i+1)
 	args = append(args, limit, filter.Offset)
 
@@ -1465,29 +1458,51 @@ func containsStr(s, sub string) bool {
 	return false
 }
 
+// auditEntryColumns is the canonical SELECT list for audit_log rows. Kept in
+// one place so adding a column doesn't require touching four queries.
+const auditEntryColumns = `id, user_id, agent_id, request_id, task_id, session_id, approval_id, lease_id,
+		tool_use_id, matched_task_id, lease_task_id, timestamp, service, action,
+		params_safe, decision, outcome, policy_id, rule_id, resolution_confidence,
+		intent_verdict, used_active_task_context, used_lease_bias, used_conv_judge_resolution,
+		would_block, would_review, would_prompt_inline,
+		safety_flagged, safety_reason, reason, data_origin, context_src,
+		duration_ms, filters_applied, verification, error_msg, deduped_of`
+
+type pgAuditScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanAuditEntryPg(row pgAuditScanner) (*store.AuditEntry, error) {
+	e := &store.AuditEntry{}
+	var paramsSafe, filtersApplied, verification []byte
+	if err := row.Scan(
+		&e.ID, &e.UserID, &e.AgentID, &e.RequestID, &e.TaskID, &e.SessionID, &e.ApprovalID, &e.LeaseID,
+		&e.ToolUseID, &e.MatchedTaskID, &e.LeaseTaskID, &e.Timestamp,
+		&e.Service, &e.Action, &paramsSafe, &e.Decision, &e.Outcome,
+		&e.PolicyID, &e.RuleID, &e.ResolutionConfidence, &e.IntentVerdict,
+		&e.UsedActiveTaskContext, &e.UsedLeaseBias, &e.UsedConvJudgeResolution,
+		&e.WouldBlock, &e.WouldReview, &e.WouldPromptInline,
+		&e.SafetyFlagged, &e.SafetyReason, &e.Reason,
+		&e.DataOrigin, &e.ContextSrc, &e.DurationMS, &filtersApplied, &verification, &e.ErrorMsg, &e.DedupedOf,
+	); err != nil {
+		return nil, err
+	}
+	e.ParamsSafe = json.RawMessage(paramsSafe)
+	if filtersApplied != nil {
+		e.FiltersApplied = json.RawMessage(filtersApplied)
+	}
+	if verification != nil {
+		e.Verification = json.RawMessage(verification)
+	}
+	return e, nil
+}
+
 func scanAuditEntries(rows pgx.Rows) ([]*store.AuditEntry, error) {
 	var entries []*store.AuditEntry
 	for rows.Next() {
-		e := &store.AuditEntry{}
-		var paramsSafe, filtersApplied, verification []byte
-		if err := rows.Scan(
-			&e.ID, &e.UserID, &e.AgentID, &e.RequestID, &e.TaskID, &e.SessionID, &e.ApprovalID, &e.LeaseID,
-			&e.ToolUseID, &e.MatchedTaskID, &e.LeaseTaskID, &e.Timestamp,
-			&e.Service, &e.Action, &paramsSafe, &e.Decision, &e.Outcome,
-			&e.PolicyID, &e.RuleID, &e.ResolutionConfidence, &e.IntentVerdict,
-			&e.UsedActiveTaskContext, &e.UsedLeaseBias, &e.UsedConvJudgeResolution,
-			&e.WouldBlock, &e.WouldReview, &e.WouldPromptInline,
-			&e.SafetyFlagged, &e.SafetyReason, &e.Reason,
-			&e.DataOrigin, &e.ContextSrc, &e.DurationMS, &filtersApplied, &verification, &e.ErrorMsg,
-		); err != nil {
+		e, err := scanAuditEntryPg(rows)
+		if err != nil {
 			return nil, err
-		}
-		e.ParamsSafe = json.RawMessage(paramsSafe)
-		if filtersApplied != nil {
-			e.FiltersApplied = json.RawMessage(filtersApplied)
-		}
-		if verification != nil {
-			e.Verification = json.RawMessage(verification)
 		}
 		entries = append(entries, e)
 	}

--- a/pkg/store/sqlite/migrations/042_audit_dedup_attempts.sql
+++ b/pkg/store/sqlite/migrations/042_audit_dedup_attempts.sql
@@ -1,0 +1,119 @@
+-- Replace the inline UNIQUE(request_id, user_id) constraint with a partial
+-- unique index scoped to canonical rows only, and add a deduped_of column
+-- so retry attempts can be recorded as their own audit_log rows pointing
+-- at the canonical entry.
+--
+-- Why: the existing UNIQUE blocked legitimate retries from landing in the
+-- audit log entirely. The handler's dedup branch returned early without
+-- inserting, so an operator scanning audit history could not see that an
+-- agent had retried. It also caused a latent bug: cross-task reuse of a
+-- request_id was *intended* to land a second canonical row (see
+-- TestGateway_Dedup_SameRequestID_DifferentTask_NotDeduplicated), but the
+-- second LogAudit silently violated UNIQUE while the handler still
+-- returned a fresh audit_id to the agent.
+--
+-- New shape:
+--   * deduped_of NULL → canonical row (one per dedup scope)
+--   * deduped_of NOT NULL → retry attempt; references the canonical's id
+--   * Per-scope uniqueness (user_id, request_id, COALESCE(task_id,'')) is
+--     enforced in SQL; cross-scope precedence (pre-task beats task-scoped)
+--     is enforced by FindDedupCandidate ordering at read time. A
+--     task-scoped canonical that lands after a pre-task canonical for the
+--     same request_id is allowed but never re-wins dedup.
+--
+-- SQLite cannot drop the inline UNIQUE constraint; we recreate the table
+-- the same way migration 028 did, copying every current column.
+--
+-- Blocking time: this is a full-table rewrite (see migrations/README.md).
+-- INSERT INTO audit_log_new SELECT … FROM audit_log copies every existing
+-- audit row plus its chain_facts companion, holding an exclusive write lock
+-- for the duration. Expect roughly the same window as 028 — fast on fresh
+-- installs, several seconds on installs with months of audit history.
+--
+-- Foreign-key safety: chain_facts.audit_id references audit_log(id) ON DELETE
+-- CASCADE. PRAGMA defer_foreign_keys = ON only defers the *constraint check*
+-- to COMMIT — it does not suppress cascade actions. DROP TABLE audit_log fires
+-- an implicit DELETE FROM audit_log, which cascades to chain_facts and empties
+-- it. PRAGMA foreign_keys = OFF would suppress cascades but cannot be toggled
+-- inside a transaction (and the migration runner wraps each migration in one).
+-- Workaround: snapshot chain_facts to a TEMP TABLE before the rebuild and
+-- restore it afterwards. The new audit_log keeps the same ids, so the FK
+-- references resolve at COMMIT.
+
+PRAGMA defer_foreign_keys = ON;
+
+CREATE TEMP TABLE chain_facts_backup AS SELECT * FROM chain_facts;
+
+CREATE TABLE audit_log_new (
+    id                          TEXT PRIMARY KEY,
+    user_id                     TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    agent_id                    TEXT REFERENCES agents(id) ON DELETE SET NULL,
+    request_id                  TEXT NOT NULL,
+    task_id                     TEXT,
+    session_id                  TEXT,
+    approval_id                 TEXT,
+    lease_id                    TEXT,
+    tool_use_id                 TEXT,
+    matched_task_id             TEXT,
+    lease_task_id               TEXT,
+    timestamp                   TEXT NOT NULL DEFAULT (datetime('now')),
+    service                     TEXT NOT NULL,
+    action                      TEXT NOT NULL,
+    params_safe                 TEXT NOT NULL DEFAULT '{}',
+    decision                    TEXT NOT NULL,
+    outcome                     TEXT NOT NULL,
+    policy_id                   TEXT,
+    rule_id                     TEXT,
+    resolution_confidence       TEXT,
+    intent_verdict              TEXT,
+    used_active_task_context    INTEGER NOT NULL DEFAULT 0,
+    used_lease_bias             INTEGER NOT NULL DEFAULT 0,
+    used_conv_judge_resolution  INTEGER NOT NULL DEFAULT 0,
+    would_block                 INTEGER NOT NULL DEFAULT 0,
+    would_review                INTEGER NOT NULL DEFAULT 0,
+    would_prompt_inline         INTEGER NOT NULL DEFAULT 0,
+    safety_flagged              INTEGER NOT NULL DEFAULT 0,
+    safety_reason               TEXT,
+    reason                      TEXT,
+    data_origin                 TEXT,
+    context_src                 TEXT,
+    duration_ms                 INTEGER NOT NULL DEFAULT 0,
+    filters_applied             TEXT,
+    verification                TEXT,
+    error_msg                   TEXT,
+    deduped_of                  TEXT
+);
+
+INSERT INTO audit_log_new SELECT
+    id, user_id, agent_id, request_id, task_id, session_id, approval_id, lease_id,
+    tool_use_id, matched_task_id, lease_task_id, timestamp, service, action,
+    params_safe, decision, outcome, policy_id, rule_id, resolution_confidence,
+    intent_verdict, used_active_task_context, used_lease_bias, used_conv_judge_resolution,
+    would_block, would_review, would_prompt_inline,
+    safety_flagged, safety_reason, reason, data_origin, context_src,
+    duration_ms, filters_applied, verification, error_msg,
+    NULL
+FROM audit_log;
+
+DROP TABLE audit_log;
+ALTER TABLE audit_log_new RENAME TO audit_log;
+
+-- chain_facts was emptied by the cascade during DROP TABLE audit_log; restore
+-- it now that the new audit_log has the same row ids the references point at.
+INSERT INTO chain_facts SELECT * FROM chain_facts_backup;
+DROP TABLE chain_facts_backup;
+
+CREATE INDEX idx_audit_user_time ON audit_log(user_id, timestamp DESC);
+CREATE INDEX idx_audit_outcome   ON audit_log(user_id, outcome);
+CREATE INDEX idx_audit_service   ON audit_log(user_id, service);
+CREATE INDEX idx_audit_runtime_host_path
+    ON audit_log(
+        user_id,
+        service,
+        COALESCE(json_extract(params_safe, '$.host'), ''),
+        COALESCE(json_extract(params_safe, '$.path'), '')
+    );
+
+CREATE UNIQUE INDEX idx_audit_canonical_dedup
+    ON audit_log(user_id, request_id, COALESCE(task_id, ''))
+    WHERE deduped_of IS NULL;

--- a/pkg/store/sqlite/store.go
+++ b/pkg/store/sqlite/store.go
@@ -861,6 +861,13 @@ func (s *Store) UpdateAuditOutcome(ctx context.Context, id, outcome, errMsg stri
 	return err
 }
 
+func (s *Store) MarkAuditDeduped(ctx context.Context, id, canonicalID, snapshotOutcome string) error {
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE audit_log SET decision = 'dedup', outcome = ?, deduped_of = ? WHERE id = ?`,
+		snapshotOutcome, canonicalID, id)
+	return err
+}
+
 // auditEntryColumns is the canonical SELECT list for audit_log rows. Kept in
 // one place so adding a column doesn't require touching four queries.
 const auditEntryColumns = `id, user_id, agent_id, request_id, task_id, session_id, approval_id, lease_id,
@@ -1800,6 +1807,9 @@ func (s *Store) CreateApprovalRecordWithPending(ctx context.Context, rec *store.
 	`, rec.ID, rec.Kind, rec.UserID, rec.AgentID, rec.RequestID, rec.TaskID, rec.SessionID, rec.Status,
 		rec.Surface, rawJSONOrDefault(rec.SummaryJSON, "{}"), rawJSONOrDefault(rec.PayloadJSON, "{}"),
 		rec.ResolutionTransport, formatNullableTime(rec.ExpiresAt), formatNullableTime(rec.ResolvedAt), rec.Resolution); err != nil {
+		if isDuplicate(err) {
+			return store.ErrConflict
+		}
 		return err
 	}
 	if _, err = tx.ExecContext(ctx, `
@@ -1807,6 +1817,9 @@ func (s *Store) CreateApprovalRecordWithPending(ctx context.Context, rec *store.
 		VALUES (?,?,?,?,?,?,?,?,?)
 	`, pa.ID, pa.UserID, pa.RequestID, pa.AuditID, pa.ApprovalRecordID, string(pa.RequestBlob),
 		pa.CallbackURL, pa.Status, pa.ExpiresAt.UTC().Format(time.RFC3339)); err != nil {
+		if isDuplicate(err) {
+			return store.ErrConflict
+		}
 		return err
 	}
 	return tx.Commit()

--- a/pkg/store/sqlite/store.go
+++ b/pkg/store/sqlite/store.go
@@ -834,8 +834,8 @@ func (s *Store) LogAudit(ctx context.Context, e *store.AuditEntry) error {
 			intent_verdict, used_active_task_context, used_lease_bias, used_conv_judge_resolution,
 			would_block, would_review, would_prompt_inline,
 			safety_flagged, safety_reason, reason, data_origin, context_src,
-			duration_ms, filters_applied, verification, error_msg
-		) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+			duration_ms, filters_applied, verification, error_msg, deduped_of
+		) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
 	`, e.ID, e.UserID, e.AgentID, e.RequestID, e.TaskID, e.SessionID, e.ApprovalID, e.LeaseID,
 		e.ToolUseID, e.MatchedTaskID, e.LeaseTaskID, e.Timestamp.UTC().Format(time.RFC3339),
 		e.Service, e.Action, paramsSafe, e.Decision, e.Outcome,
@@ -843,7 +843,10 @@ func (s *Store) LogAudit(ctx context.Context, e *store.AuditEntry) error {
 		usedActiveTaskContext, usedLeaseBias, usedConvJudgeResolution,
 		wouldBlock, wouldReview, wouldPromptInline,
 		safetyFlagged, e.SafetyReason, e.Reason,
-		e.DataOrigin, e.ContextSrc, e.DurationMS, filtersApplied, verification, e.ErrorMsg)
+		e.DataOrigin, e.ContextSrc, e.DurationMS, filtersApplied, verification, e.ErrorMsg, e.DedupedOf)
+	if isDuplicate(err) {
+		return store.ErrConflict
+	}
 	return err
 }
 
@@ -858,21 +861,27 @@ func (s *Store) UpdateAuditOutcome(ctx context.Context, id, outcome, errMsg stri
 	return err
 }
 
-func (s *Store) GetAuditEntry(ctx context.Context, id, userID string) (*store.AuditEntry, error) {
-	e := &store.AuditEntry{}
-	var timestamp, paramsSafe string
-	var safetyFlagged, usedActiveTaskContext, usedLeaseBias, usedConvJudgeResolution, wouldBlock, wouldReview, wouldPromptInline int
-	var filtersApplied, verification *string
-	err := s.db.QueryRowContext(ctx, `
-		SELECT id, user_id, agent_id, request_id, task_id, session_id, approval_id, lease_id,
+// auditEntryColumns is the canonical SELECT list for audit_log rows. Kept in
+// one place so adding a column doesn't require touching four queries.
+const auditEntryColumns = `id, user_id, agent_id, request_id, task_id, session_id, approval_id, lease_id,
 		       tool_use_id, matched_task_id, lease_task_id, timestamp, service, action,
 		       params_safe, decision, outcome, policy_id, rule_id, resolution_confidence,
 		       intent_verdict, used_active_task_context, used_lease_bias, used_conv_judge_resolution,
 		       would_block, would_review, would_prompt_inline,
 		       safety_flagged, safety_reason, reason, data_origin, context_src,
-		       duration_ms, filters_applied, verification, error_msg
-		FROM audit_log WHERE id = ? AND user_id = ?
-	`, id, userID).Scan(
+		       duration_ms, filters_applied, verification, error_msg, deduped_of`
+
+// scanRow binds a single audit_log row scanned in auditEntryColumns order.
+type auditScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanAuditEntry(row auditScanner) (*store.AuditEntry, error) {
+	e := &store.AuditEntry{}
+	var timestamp, paramsSafe string
+	var safetyFlagged, usedActiveTaskContext, usedLeaseBias, usedConvJudgeResolution, wouldBlock, wouldReview, wouldPromptInline int
+	var filtersApplied, verification *string
+	err := row.Scan(
 		&e.ID, &e.UserID, &e.AgentID, &e.RequestID, &e.TaskID, &e.SessionID, &e.ApprovalID, &e.LeaseID,
 		&e.ToolUseID, &e.MatchedTaskID, &e.LeaseTaskID, &timestamp,
 		&e.Service, &e.Action, &paramsSafe, &e.Decision, &e.Outcome,
@@ -880,10 +889,7 @@ func (s *Store) GetAuditEntry(ctx context.Context, id, userID string) (*store.Au
 		&usedActiveTaskContext, &usedLeaseBias, &usedConvJudgeResolution,
 		&wouldBlock, &wouldReview, &wouldPromptInline,
 		&safetyFlagged, &e.SafetyReason, &e.Reason,
-		&e.DataOrigin, &e.ContextSrc, &e.DurationMS, &filtersApplied, &verification, &e.ErrorMsg)
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil, store.ErrNotFound
-	}
+		&e.DataOrigin, &e.ContextSrc, &e.DurationMS, &filtersApplied, &verification, &e.ErrorMsg, &e.DedupedOf)
 	if err != nil {
 		return nil, err
 	}
@@ -905,51 +911,79 @@ func (s *Store) GetAuditEntry(ctx context.Context, id, userID string) (*store.Au
 	return e, nil
 }
 
-func (s *Store) GetAuditEntryByRequestID(ctx context.Context, requestID, userID string) (*store.AuditEntry, error) {
-	e := &store.AuditEntry{}
-	var timestamp, paramsSafe string
-	var safetyFlagged, usedActiveTaskContext, usedLeaseBias, usedConvJudgeResolution, wouldBlock, wouldReview, wouldPromptInline int
-	var filtersApplied, verification *string
-	err := s.db.QueryRowContext(ctx, `
-		SELECT id, user_id, agent_id, request_id, task_id, session_id, approval_id, lease_id,
-		       tool_use_id, matched_task_id, lease_task_id, timestamp, service, action,
-		       params_safe, decision, outcome, policy_id, rule_id, resolution_confidence,
-		       intent_verdict, used_active_task_context, used_lease_bias, used_conv_judge_resolution,
-		       would_block, would_review, would_prompt_inline,
-		       safety_flagged, safety_reason, reason, data_origin, context_src,
-		       duration_ms, filters_applied, verification, error_msg
-		FROM audit_log WHERE request_id = ? AND user_id = ?
-	`, requestID, userID).Scan(
-		&e.ID, &e.UserID, &e.AgentID, &e.RequestID, &e.TaskID, &e.SessionID, &e.ApprovalID, &e.LeaseID,
-		&e.ToolUseID, &e.MatchedTaskID, &e.LeaseTaskID, &timestamp,
-		&e.Service, &e.Action, &paramsSafe, &e.Decision, &e.Outcome,
-		&e.PolicyID, &e.RuleID, &e.ResolutionConfidence, &e.IntentVerdict,
-		&usedActiveTaskContext, &usedLeaseBias, &usedConvJudgeResolution,
-		&wouldBlock, &wouldReview, &wouldPromptInline,
-		&safetyFlagged, &e.SafetyReason, &e.Reason,
-		&e.DataOrigin, &e.ContextSrc, &e.DurationMS, &filtersApplied, &verification, &e.ErrorMsg)
+func (s *Store) GetAuditEntry(ctx context.Context, id, userID string) (*store.AuditEntry, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT `+auditEntryColumns+` FROM audit_log WHERE id = ? AND user_id = ?`,
+		id, userID)
+	e, err := scanAuditEntry(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, store.ErrNotFound
 	}
-	if err != nil {
-		return nil, err
+	return e, err
+}
+
+func (s *Store) GetAuditEntryByRequestID(ctx context.Context, requestID, userID string) (*store.AuditEntry, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT `+auditEntryColumns+`
+		 FROM audit_log
+		 WHERE request_id = ? AND user_id = ? AND deduped_of IS NULL
+		 ORDER BY timestamp DESC LIMIT 1`,
+		requestID, userID)
+	e, err := scanAuditEntry(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, store.ErrNotFound
 	}
-	e.Timestamp = parseTime(timestamp)
-	e.SafetyFlagged = safetyFlagged != 0
-	e.UsedActiveTaskContext = usedActiveTaskContext != 0
-	e.UsedLeaseBias = usedLeaseBias != 0
-	e.UsedConvJudgeResolution = usedConvJudgeResolution != 0
-	e.WouldBlock = wouldBlock != 0
-	e.WouldReview = wouldReview != 0
-	e.WouldPromptInline = wouldPromptInline != 0
-	e.ParamsSafe = json.RawMessage(paramsSafe)
-	if filtersApplied != nil {
-		e.FiltersApplied = json.RawMessage(*filtersApplied)
+	return e, err
+}
+
+func (s *Store) GetAuditEntryByRequestIDAndTask(ctx context.Context, requestID, userID, taskID string) (*store.AuditEntry, error) {
+	// Read-time precedence is inverted from FindDedupCandidate: the feedback
+	// handler wants the row that actually fired *in the agent's task*, so an
+	// exact task_id match wins over a pre-task canonical for the same
+	// request_id. Pre-task remains the fallback when no task-scoped row
+	// exists. (FindDedupCandidate keeps the opposite ordering at write time
+	// so a pre-task canonical correctly absorbs later task-scoped retries.)
+	row := s.db.QueryRowContext(ctx,
+		`SELECT `+auditEntryColumns+`
+		 FROM audit_log
+		 WHERE request_id = ? AND user_id = ? AND deduped_of IS NULL
+		   AND (task_id IS NULL OR task_id = ?)
+		 ORDER BY (task_id IS NULL) ASC, timestamp ASC LIMIT 1`,
+		requestID, userID, taskID)
+	e, err := scanAuditEntry(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, store.ErrNotFound
 	}
-	if verification != nil {
-		e.Verification = json.RawMessage(*verification)
+	return e, err
+}
+
+func (s *Store) FindDedupCandidate(ctx context.Context, requestID, userID, taskID string) (*store.AuditEntry, error) {
+	// taskID == "" means no task context yet (runtime classification path);
+	// only pre-task rows can match, so we never compare task_id against ''.
+	var (
+		row *sql.Row
+	)
+	if taskID == "" {
+		row = s.db.QueryRowContext(ctx,
+			`SELECT `+auditEntryColumns+`
+			 FROM audit_log
+			 WHERE request_id = ? AND user_id = ? AND deduped_of IS NULL AND task_id IS NULL
+			 ORDER BY timestamp ASC LIMIT 1`,
+			requestID, userID)
+	} else {
+		row = s.db.QueryRowContext(ctx,
+			`SELECT `+auditEntryColumns+`
+			 FROM audit_log
+			 WHERE request_id = ? AND user_id = ? AND deduped_of IS NULL
+			   AND (task_id IS NULL OR task_id = ?)
+			 ORDER BY (task_id IS NULL) DESC, timestamp ASC LIMIT 1`,
+			requestID, userID, taskID)
 	}
-	return e, nil
+	e, err := scanAuditEntry(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, store.ErrNotFound
+	}
+	return e, err
 }
 
 func (s *Store) ListAuditEntries(ctx context.Context, userID string, filter store.AuditFilter) ([]*store.AuditEntry, int, error) {
@@ -999,15 +1033,9 @@ func (s *Store) ListAuditEntries(ctx context.Context, userID string, filter stor
 	}
 
 	dataArgs := append(args, limit, filter.Offset)
-	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, user_id, agent_id, request_id, task_id, session_id, approval_id, lease_id,
-		       tool_use_id, matched_task_id, lease_task_id, timestamp, service, action,
-		       params_safe, decision, outcome, policy_id, rule_id, resolution_confidence,
-		       intent_verdict, used_active_task_context, used_lease_bias, used_conv_judge_resolution,
-		       would_block, would_review, would_prompt_inline,
-		       safety_flagged, safety_reason, reason, data_origin, context_src,
-		       duration_ms, filters_applied, verification, error_msg
-		FROM audit_log `+where+` ORDER BY timestamp DESC LIMIT ? OFFSET ?`, dataArgs...)
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT `+auditEntryColumns+` FROM audit_log `+where+` ORDER BY timestamp DESC LIMIT ? OFFSET ?`,
+		dataArgs...)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -1015,36 +1043,9 @@ func (s *Store) ListAuditEntries(ctx context.Context, userID string, filter stor
 
 	var entries []*store.AuditEntry
 	for rows.Next() {
-		e := &store.AuditEntry{}
-		var timestamp, paramsSafe string
-		var safetyFlagged, usedActiveTaskContext, usedLeaseBias, usedConvJudgeResolution, wouldBlock, wouldReview, wouldPromptInline int
-		var filtersApplied, verification *string
-		if err := rows.Scan(
-			&e.ID, &e.UserID, &e.AgentID, &e.RequestID, &e.TaskID, &e.SessionID, &e.ApprovalID, &e.LeaseID,
-			&e.ToolUseID, &e.MatchedTaskID, &e.LeaseTaskID, &timestamp,
-			&e.Service, &e.Action, &paramsSafe, &e.Decision, &e.Outcome,
-			&e.PolicyID, &e.RuleID, &e.ResolutionConfidence, &e.IntentVerdict,
-			&usedActiveTaskContext, &usedLeaseBias, &usedConvJudgeResolution,
-			&wouldBlock, &wouldReview, &wouldPromptInline,
-			&safetyFlagged, &e.SafetyReason, &e.Reason,
-			&e.DataOrigin, &e.ContextSrc, &e.DurationMS, &filtersApplied, &verification, &e.ErrorMsg,
-		); err != nil {
+		e, err := scanAuditEntry(rows)
+		if err != nil {
 			return nil, 0, err
-		}
-		e.Timestamp = parseTime(timestamp)
-		e.SafetyFlagged = safetyFlagged != 0
-		e.UsedActiveTaskContext = usedActiveTaskContext != 0
-		e.UsedLeaseBias = usedLeaseBias != 0
-		e.UsedConvJudgeResolution = usedConvJudgeResolution != 0
-		e.WouldBlock = wouldBlock != 0
-		e.WouldReview = wouldReview != 0
-		e.WouldPromptInline = wouldPromptInline != 0
-		e.ParamsSafe = json.RawMessage(paramsSafe)
-		if filtersApplied != nil {
-			e.FiltersApplied = json.RawMessage(*filtersApplied)
-		}
-		if verification != nil {
-			e.Verification = json.RawMessage(*verification)
 		}
 		entries = append(entries, e)
 	}

--- a/pkg/store/sqlite/store_audit_dedup_test.go
+++ b/pkg/store/sqlite/store_audit_dedup_test.go
@@ -1,0 +1,206 @@
+package sqlite
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+// auditDedupFixture sets up a user/agent and returns the store ready for
+// audit_log writes scoped to that user.
+type auditDedupFixture struct {
+	st     *Store
+	userID string
+	agent  *store.Agent
+}
+
+func newAuditDedupFixture(t *testing.T) *auditDedupFixture {
+	t.Helper()
+	ctx := context.Background()
+	db, err := New(ctx, filepath.Join(t.TempDir(), "clawvisor.db"))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	st := NewStore(db)
+	user, err := st.CreateUser(ctx, "audit-dedup@example.com", "hash")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	agent, err := st.CreateAgent(ctx, user.ID, "audit-dedup-agent", "tok")
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+	return &auditDedupFixture{st: st, userID: user.ID, agent: agent}
+}
+
+func (f *auditDedupFixture) makeEntry(id, requestID string, taskID *string, decision, outcome string, ts time.Time) *store.AuditEntry {
+	return &store.AuditEntry{
+		ID:         id,
+		UserID:     f.userID,
+		AgentID:    &f.agent.ID,
+		RequestID:  requestID,
+		TaskID:     taskID,
+		Timestamp:  ts,
+		Service:    "mock.svc",
+		Action:     "run",
+		ParamsSafe: []byte(`{}`),
+		Decision:   decision,
+		Outcome:    outcome,
+	}
+}
+
+// TestAuditDedup_PerScopeUniqueConstraint asserts that two canonical inserts
+// with the same (user_id, request_id, task_id) collide, and that a third
+// canonical for the same request_id but a different task_id lands cleanly.
+func TestAuditDedup_PerScopeUniqueConstraint(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	f := newAuditDedupFixture(t)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	taskA, taskB := "task-A", "task-B"
+
+	// First canonical for (request, taskA) — succeeds.
+	first := f.makeEntry("audit-1", "req-1", &taskA, "execute", "executed", now)
+	if err := f.st.LogAudit(ctx, first); err != nil {
+		t.Fatalf("LogAudit first: %v", err)
+	}
+
+	// Second canonical for the same scope — must collide with ErrConflict.
+	collide := f.makeEntry("audit-2", "req-1", &taskA, "execute", "executed", now.Add(time.Second))
+	err := f.st.LogAudit(ctx, collide)
+	if !errors.Is(err, store.ErrConflict) {
+		t.Fatalf("LogAudit duplicate: got %v, want ErrConflict", err)
+	}
+
+	// Same request_id under a different task — different scope, should land.
+	crossTask := f.makeEntry("audit-3", "req-1", &taskB, "execute", "executed", now.Add(2*time.Second))
+	if err := f.st.LogAudit(ctx, crossTask); err != nil {
+		t.Fatalf("LogAudit cross-task: %v", err)
+	}
+
+	// Dedup-attempt row (deduped_of != NULL) is outside the partial unique
+	// index — many can coexist for the same scope.
+	for i := range 3 {
+		attempt := f.makeEntry("attempt-"+string(rune('a'+i)), "req-1", &taskA, "dedup", "executed", now.Add(time.Duration(3+i)*time.Second))
+		attempt.DedupedOf = &first.ID
+		if err := f.st.LogAudit(ctx, attempt); err != nil {
+			t.Fatalf("LogAudit attempt %d: %v", i, err)
+		}
+	}
+}
+
+// TestAuditDedup_FindDedupCandidatePrecedence asserts the read-time precedence:
+// a pre-task canonical (task_id IS NULL) wins over any task-scoped canonical
+// for the same request_id. Within a tier, oldest wins.
+func TestAuditDedup_FindDedupCandidatePrecedence(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	f := newAuditDedupFixture(t)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	taskA := "task-A"
+
+	// Land a task-scoped canonical first.
+	taskScoped := f.makeEntry("audit-task", "req-1", &taskA, "execute", "executed", now)
+	if err := f.st.LogAudit(ctx, taskScoped); err != nil {
+		t.Fatalf("LogAudit task-scoped: %v", err)
+	}
+
+	// FindDedupCandidate(taskID=taskA) should return the task-scoped row.
+	got, err := f.st.FindDedupCandidate(ctx, "req-1", f.userID, taskA)
+	if err != nil {
+		t.Fatalf("FindDedupCandidate task-scoped: %v", err)
+	}
+	if got.ID != taskScoped.ID {
+		t.Errorf("FindDedupCandidate: got %q, want %q", got.ID, taskScoped.ID)
+	}
+
+	// Now land a pre-task canonical for the same request_id (task_id IS NULL).
+	// The partial unique index treats these as different scopes, so insert succeeds.
+	preTask := f.makeEntry("audit-pre", "req-1", nil, "block", "blocked", now.Add(time.Second))
+	if err := f.st.LogAudit(ctx, preTask); err != nil {
+		t.Fatalf("LogAudit pre-task: %v", err)
+	}
+
+	// Pre-task wins over task-scoped: even though the task-scoped row is older,
+	// FindDedupCandidate(taskID=taskA) should now return the pre-task row.
+	got, err = f.st.FindDedupCandidate(ctx, "req-1", f.userID, taskA)
+	if err != nil {
+		t.Fatalf("FindDedupCandidate after pre-task: %v", err)
+	}
+	if got.ID != preTask.ID {
+		t.Errorf("FindDedupCandidate after pre-task: got %q, want %q (pre-task should win)", got.ID, preTask.ID)
+	}
+
+	// taskID == "" means no task context — only pre-task rows match.
+	got, err = f.st.FindDedupCandidate(ctx, "req-1", f.userID, "")
+	if err != nil {
+		t.Fatalf("FindDedupCandidate no-task: %v", err)
+	}
+	if got.ID != preTask.ID {
+		t.Errorf("FindDedupCandidate no-task: got %q, want %q", got.ID, preTask.ID)
+	}
+
+	// GetAuditEntryByRequestIDAndTask inverts precedence vs FindDedupCandidate:
+	// the feedback handler wants the row that fired *in the agent's task*, so
+	// a task-scoped match wins over a pre-task canonical. Pre-task is only
+	// returned as a fallback when no task-scoped row exists.
+	got, err = f.st.GetAuditEntryByRequestIDAndTask(ctx, "req-1", f.userID, taskA)
+	if err != nil {
+		t.Fatalf("GetAuditEntryByRequestIDAndTask: %v", err)
+	}
+	if got.ID != taskScoped.ID {
+		t.Errorf("GetAuditEntryByRequestIDAndTask: got %q, want %q (task-scoped should win)", got.ID, taskScoped.ID)
+	}
+
+	// With taskID="" only pre-task matches; it wins by being the only candidate.
+	got, err = f.st.GetAuditEntryByRequestIDAndTask(ctx, "req-1", f.userID, "")
+	if err != nil {
+		t.Fatalf("GetAuditEntryByRequestIDAndTask no-task: %v", err)
+	}
+	if got.ID != preTask.ID {
+		t.Errorf("GetAuditEntryByRequestIDAndTask no-task: got %q, want %q (pre-task fallback)", got.ID, preTask.ID)
+	}
+}
+
+// TestAuditDedup_GetAuditEntryByRequestID_LatestCanonical asserts that the
+// polling endpoint returns the most recent canonical row, never a dedup
+// attempt — agents poll right after submitting and want the result of their
+// latest canonical attempt.
+func TestAuditDedup_GetAuditEntryByRequestID_LatestCanonical(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	f := newAuditDedupFixture(t)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	taskA, taskB := "task-A", "task-B"
+
+	older := f.makeEntry("audit-older", "req-1", &taskA, "execute", "executed", now)
+	if err := f.st.LogAudit(ctx, older); err != nil {
+		t.Fatalf("LogAudit older: %v", err)
+	}
+	newer := f.makeEntry("audit-newer", "req-1", &taskB, "block", "blocked", now.Add(time.Second))
+	if err := f.st.LogAudit(ctx, newer); err != nil {
+		t.Fatalf("LogAudit newer: %v", err)
+	}
+	attempt := f.makeEntry("audit-attempt", "req-1", &taskB, "dedup", "blocked", now.Add(2*time.Second))
+	attempt.DedupedOf = &newer.ID
+	if err := f.st.LogAudit(ctx, attempt); err != nil {
+		t.Fatalf("LogAudit attempt: %v", err)
+	}
+
+	got, err := f.st.GetAuditEntryByRequestID(ctx, "req-1", f.userID)
+	if err != nil {
+		t.Fatalf("GetAuditEntryByRequestID: %v", err)
+	}
+	// Skips the attempt row (deduped_of != NULL); returns newest canonical.
+	if got.ID != newer.ID {
+		t.Errorf("GetAuditEntryByRequestID: got %q, want %q (newest canonical)", got.ID, newer.ID)
+	}
+}

--- a/pkg/store/sqlite/store_audit_dedup_test.go
+++ b/pkg/store/sqlite/store_audit_dedup_test.go
@@ -260,3 +260,70 @@ func TestAuditDedup_MarkAuditDeduped(t *testing.T) {
 		t.Errorf("DedupedOf: got %v, want pointer to %q", demoted.DedupedOf, canonical.ID)
 	}
 }
+
+// TestAuditDedup_ApprovalConflictSiblingLookup pins down the lookup the handler
+// must use when recovering from an approval-table conflict. The approval-conflict
+// recovery path inserts a fresh canonical *before* it discovers the conflict, so
+// the just-inserted row is the newest by timestamp. GetAuditEntryByRequestID
+// would return the just-inserted row and produce a self-loop; the handler must
+// resolve the sibling via pending_approvals.audit_id so polling lands on the row
+// that actually owns the live approval.
+func TestAuditDedup_ApprovalConflictSiblingLookup(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	f := newAuditDedupFixture(t)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	taskA, taskB := "task-A", "task-B"
+
+	// Sibling canonical that already owns a pending approval (older by timestamp).
+	sibling := f.makeEntry("sibling-canonical", "req-1", &taskA, "approve", "pending", now)
+	if err := f.st.LogAudit(ctx, sibling); err != nil {
+		t.Fatalf("LogAudit sibling: %v", err)
+	}
+	pa := &store.PendingApproval{
+		ID:        "pending-1",
+		UserID:    f.userID,
+		RequestID: "req-1",
+		AuditID:   sibling.ID,
+		Status:    "pending",
+		ExpiresAt: now.Add(time.Hour),
+	}
+	if err := f.st.SavePendingApproval(ctx, pa); err != nil {
+		t.Fatalf("SavePendingApproval: %v", err)
+	}
+
+	// Loser canonical inserted by the handler before it discovered the
+	// approval-table conflict — newer by timestamp, same request_id, different task.
+	loser := f.makeEntry("loser-canonical", "req-1", &taskB, "approve", "pending", now.Add(time.Second))
+	if err := f.st.LogAudit(ctx, loser); err != nil {
+		t.Fatalf("LogAudit loser: %v", err)
+	}
+
+	// The newest-by-timestamp lookup picks the wrong row — this is the bug
+	// the handler avoids by going through pending_approvals instead.
+	wrong, err := f.st.GetAuditEntryByRequestID(ctx, "req-1", f.userID)
+	if err != nil {
+		t.Fatalf("GetAuditEntryByRequestID: %v", err)
+	}
+	if wrong.ID != loser.ID {
+		t.Fatalf("setup invariant: GetAuditEntryByRequestID should pick the newest (loser) row, got %q", wrong.ID)
+	}
+
+	// The correct lookup: pending_approvals.audit_id → GetAuditEntry. This is
+	// what the handler does and must keep doing.
+	got, err := f.st.GetPendingApproval(ctx, "req-1")
+	if err != nil {
+		t.Fatalf("GetPendingApproval: %v", err)
+	}
+	siblingFound, err := f.st.GetAuditEntry(ctx, got.AuditID, f.userID)
+	if err != nil {
+		t.Fatalf("GetAuditEntry: %v", err)
+	}
+	if siblingFound.ID != sibling.ID {
+		t.Errorf("sibling lookup: got %q, want %q (must resolve via pending_approvals.audit_id, not timestamp)", siblingFound.ID, sibling.ID)
+	}
+	if siblingFound.ID == loser.ID {
+		t.Error("sibling lookup returned the loser row — would self-loop in MarkAuditDeduped")
+	}
+}

--- a/pkg/store/sqlite/store_audit_dedup_test.go
+++ b/pkg/store/sqlite/store_audit_dedup_test.go
@@ -327,3 +327,79 @@ func TestAuditDedup_ApprovalConflictSiblingLookup(t *testing.T) {
 		t.Error("sibling lookup returned the loser row — would self-loop in MarkAuditDeduped")
 	}
 }
+
+// TestAuditDedup_ResolvedApprovalConflictFallback covers the lifecycle
+// asymmetry: pending_approvals is deleted on deny/expire/execute but
+// approval_records.request_id stays populated indefinitely. A later cross-task
+// reuse of the same request_id hits ErrConflict on approval_records, by which
+// time GetPendingApproval returns nothing — the recovery helper must fall back
+// through GetApprovalRecordByRequestID + GetAuditEntryByRequestIDAndTask
+// (scoped to the resolved record's task_id) to land on the resolved sibling
+// canonical, not on the just-inserted loser.
+func TestAuditDedup_ResolvedApprovalConflictFallback(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	f := newAuditDedupFixture(t)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	taskB := "task-B"
+
+	// Resolved sibling canonical: pre-task approval that was approved + executed
+	// long ago. Pre-task (task_id=NULL) keeps the test free of the tasks(id)
+	// FK while still exercising the resolved-record lookup chain.
+	sibling := f.makeEntry("sibling-canonical", "req-1", nil, "approve", "executed", now)
+	if err := f.st.LogAudit(ctx, sibling); err != nil {
+		t.Fatalf("LogAudit sibling: %v", err)
+	}
+	reqID := "req-1"
+	expiresAt := now.Add(time.Hour)
+	resolvedAt := now.Add(time.Minute)
+	rec := &store.ApprovalRecord{
+		ID:                  "approval-rec-1",
+		Kind:                "request_once",
+		UserID:              f.userID,
+		RequestID:           &reqID,
+		Status:              "approved",
+		Surface:             "dashboard",
+		ResolutionTransport: "execute_pending_request",
+		ExpiresAt:           &expiresAt,
+		ResolvedAt:          &resolvedAt,
+		Resolution:          "approved",
+	}
+	if err := f.st.CreateApprovalRecord(ctx, rec); err != nil {
+		t.Fatalf("CreateApprovalRecord: %v", err)
+	}
+	// Note: no pending_approvals row — it was deleted on resolve. This is the
+	// scenario the lifecycle asymmetry creates.
+
+	// Loser canonical: cross-task reuse much later, in a different task.
+	loser := f.makeEntry("loser-canonical", "req-1", &taskB, "approve", "pending", now.Add(time.Hour))
+	if err := f.st.LogAudit(ctx, loser); err != nil {
+		t.Fatalf("LogAudit loser: %v", err)
+	}
+
+	// First-try lookup (live pending) returns nothing.
+	if _, err := f.st.GetPendingApproval(ctx, "req-1"); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("GetPendingApproval: expected ErrNotFound, got %v", err)
+	}
+
+	// Second-try lookup must land on the resolved sibling, not on the loser.
+	got, err := f.st.GetApprovalRecordByRequestID(ctx, "req-1")
+	if err != nil {
+		t.Fatalf("GetApprovalRecordByRequestID: %v", err)
+	}
+	recTaskID := ""
+	if got.TaskID != nil {
+		recTaskID = *got.TaskID
+	}
+	siblingFound, err := f.st.GetAuditEntryByRequestIDAndTask(ctx, "req-1", f.userID, recTaskID)
+	if err != nil {
+		t.Fatalf("GetAuditEntryByRequestIDAndTask: %v", err)
+	}
+	if siblingFound.ID != sibling.ID {
+		t.Errorf("resolved-record fallback: got %q, want %q", siblingFound.ID, sibling.ID)
+	}
+	if siblingFound.ID == loser.ID {
+		t.Error("resolved-record fallback returned the loser — would self-loop")
+	}
+}

--- a/pkg/store/sqlite/store_audit_dedup_test.go
+++ b/pkg/store/sqlite/store_audit_dedup_test.go
@@ -204,3 +204,59 @@ func TestAuditDedup_GetAuditEntryByRequestID_LatestCanonical(t *testing.T) {
 		t.Errorf("GetAuditEntryByRequestID: got %q, want %q (newest canonical)", got.ID, newer.ID)
 	}
 }
+
+// TestAuditDedup_MarkAuditDeduped covers the demote-canonical-to-attempt path
+// used when a downstream conflict (e.g. approval-table uniqueness) makes a
+// just-inserted canonical the wrong row to surface for polling. After the
+// demotion, GetAuditEntryByRequestID must skip the demoted row and return the
+// canonical it now points at.
+func TestAuditDedup_MarkAuditDeduped(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	f := newAuditDedupFixture(t)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	taskA, taskB := "task-A", "task-B"
+
+	// Existing canonical (pre-task-1 approval, still pending).
+	canonical := f.makeEntry("canonical", "req-1", &taskA, "approve", "pending", now)
+	if err := f.st.LogAudit(ctx, canonical); err != nil {
+		t.Fatalf("LogAudit canonical: %v", err)
+	}
+
+	// Cross-task duplicate canonical that loses the approval-table race.
+	loser := f.makeEntry("loser", "req-1", &taskB, "approve", "pending", now.Add(time.Second))
+	if err := f.st.LogAudit(ctx, loser); err != nil {
+		t.Fatalf("LogAudit loser: %v", err)
+	}
+
+	// Demote loser to dedup-attempt pointing at the canonical, snapshotting
+	// the canonical's outcome.
+	if err := f.st.MarkAuditDeduped(ctx, loser.ID, canonical.ID, canonical.Outcome); err != nil {
+		t.Fatalf("MarkAuditDeduped: %v", err)
+	}
+
+	// Polling by request_id must now return the canonical, not the demoted row.
+	got, err := f.st.GetAuditEntryByRequestID(ctx, "req-1", f.userID)
+	if err != nil {
+		t.Fatalf("GetAuditEntryByRequestID: %v", err)
+	}
+	if got.ID != canonical.ID {
+		t.Errorf("GetAuditEntryByRequestID: got %q, want %q (demoted row should be skipped)", got.ID, canonical.ID)
+	}
+
+	// The demoted row itself must reflect the new shape.
+	demoted, err := f.st.GetAuditEntry(ctx, loser.ID, f.userID)
+	if err != nil {
+		t.Fatalf("GetAuditEntry: %v", err)
+	}
+	if demoted.Decision != "dedup" {
+		t.Errorf("Decision: got %q, want %q", demoted.Decision, "dedup")
+	}
+	if demoted.Outcome != canonical.Outcome {
+		t.Errorf("Outcome: got %q, want %q (snapshot)", demoted.Outcome, canonical.Outcome)
+	}
+	if demoted.DedupedOf == nil || *demoted.DedupedOf != canonical.ID {
+		t.Errorf("DedupedOf: got %v, want pointer to %q", demoted.DedupedOf, canonical.ID)
+	}
+}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -100,7 +100,24 @@ type Store interface {
 	LogAudit(ctx context.Context, entry *AuditEntry) error
 	UpdateAuditOutcome(ctx context.Context, id, outcome, errMsg string, durationMS int) error
 	GetAuditEntry(ctx context.Context, id, userID string) (*AuditEntry, error)
+	// GetAuditEntryByRequestID returns the latest canonical (deduped_of IS NULL)
+	// audit entry for (request_id, user_id). Used by the polling endpoint and
+	// other callers that don't have task context. Newer canonicals shadow older
+	// ones — agents almost always poll right after submitting, where "latest"
+	// is the entry they care about.
 	GetAuditEntryByRequestID(ctx context.Context, requestID, userID string) (*AuditEntry, error)
+	// GetAuditEntryByRequestIDAndTask returns the canonical audit entry for
+	// (request_id, user_id, task_id). Pre-task canonicals (task_id IS NULL) win
+	// over task-scoped ones, matching FindDedupCandidate precedence so callers
+	// see the same row the dedup write path matched against.
+	GetAuditEntryByRequestIDAndTask(ctx context.Context, requestID, userID, taskID string) (*AuditEntry, error)
+	// FindDedupCandidate returns the canonical audit entry that a new
+	// (request_id, user_id, task_id) request should dedup against, or
+	// ErrNotFound if no candidate exists. Pre-task canonicals (task_id IS NULL)
+	// always win over task-scoped canonicals for the same request_id; within a
+	// tier the oldest row wins. taskID == "" means the caller has no task
+	// context yet (runtime classification path) and only pre-task rows match.
+	FindDedupCandidate(ctx context.Context, requestID, userID, taskID string) (*AuditEntry, error)
 	ListAuditEntries(ctx context.Context, userID string, filter AuditFilter) ([]*AuditEntry, int, error)
 	AuditActivityBuckets(ctx context.Context, userID string, since time.Time, bucketMinutes int) ([]ActivityBucket, error)
 	CreateActivityMute(ctx context.Context, mute *ActivityMute) error
@@ -436,6 +453,9 @@ type AuditEntry struct {
 	FiltersApplied          json.RawMessage `json:"filters_applied,omitempty"`
 	Verification            json.RawMessage `json:"verification,omitempty"`
 	ErrorMsg                *string         `json:"error_msg,omitempty"`
+	// DedupedOf is set on retry attempt rows to the id of the canonical
+	// audit entry they shadow. Canonical rows have DedupedOf == nil.
+	DedupedOf *string `json:"deduped_of,omitempty"`
 }
 
 // ActivityMute suppresses noisy runtime egress rows from the activity feed.

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -107,9 +107,11 @@ type Store interface {
 	// is the entry they care about.
 	GetAuditEntryByRequestID(ctx context.Context, requestID, userID string) (*AuditEntry, error)
 	// GetAuditEntryByRequestIDAndTask returns the canonical audit entry for
-	// (request_id, user_id, task_id). Pre-task canonicals (task_id IS NULL) win
-	// over task-scoped ones, matching FindDedupCandidate precedence so callers
-	// see the same row the dedup write path matched against.
+	// (request_id, user_id, task_id). Inverts FindDedupCandidate's precedence:
+	// an exact task_id match wins over a pre-task (task_id IS NULL) canonical,
+	// because callers (the feedback handler) want the row that actually fired
+	// in the agent's task. Pre-task is the fallback when no task-scoped row
+	// exists.
 	GetAuditEntryByRequestIDAndTask(ctx context.Context, requestID, userID, taskID string) (*AuditEntry, error)
 	// FindDedupCandidate returns the canonical audit entry that a new
 	// (request_id, user_id, task_id) request should dedup against, or
@@ -118,6 +120,13 @@ type Store interface {
 	// tier the oldest row wins. taskID == "" means the caller has no task
 	// context yet (runtime classification path) and only pre-task rows match.
 	FindDedupCandidate(ctx context.Context, requestID, userID, taskID string) (*AuditEntry, error)
+	// MarkAuditDeduped converts an existing canonical audit row into a dedup
+	// attempt pointing at canonicalID, snapshotting the canonical's outcome.
+	// Used to resolve cross-table conflicts (e.g. approval-table uniqueness)
+	// after the audit row has already been written: instead of leaving an
+	// orphan canonical with a stale "pending" outcome, demote it so polling
+	// returns the row that actually owns the request.
+	MarkAuditDeduped(ctx context.Context, id, canonicalID, snapshotOutcome string) error
 	ListAuditEntries(ctx context.Context, userID string, filter AuditFilter) ([]*AuditEntry, int, error)
 	AuditActivityBuckets(ctx context.Context, userID string, since time.Time, bucketMinutes int) ([]ActivityBucket, error)
 	CreateActivityMute(ctx context.Context, mute *ActivityMute) error


### PR DESCRIPTION
## Summary
- Replaces `UNIQUE(request_id, user_id)` on `audit_log` with a partial unique index on canonical rows and adds a `deduped_of` column so retries land as their own visible audit rows pointing at the canonical entry.
- Fixes a latent bug where cross-task reuse of a `request_id` silently violated the old constraint while the handler still returned a fresh `audit_id`.
- Race-recovers two distinct conflicts: (a) audit-row insert race rewrites the loser as a dedup-attempt; (b) approval-table conflict (cross-task reuse where `pending_approvals.request_id` is still globally unique) demotes the just-inserted canonical and surfaces the existing approval's status.
- Splits read paths: `FindDedupCandidate` (write-time, pre-task wins) vs. `GetAuditEntryByRequestIDAndTask` (read-time, exact-task wins) so the feedback handler sees the row that actually fired in the agent's task.

## Known limitation — auto-execute idempotency
For auto-execute paths the adapter is invoked *before* the canonical audit insert. Two concurrent identical requests can both miss `FindDedupCandidate`, both perform the side effect, and only collide on the audit insert — recovery preserves audit shape (one canonical, one dedup-attempt) but cannot un-fire the side effect. The same race window existed under the prior `UNIQUE`+early-return design; closing it requires an insert-canonical-before-execute reservation pattern that is intentionally out of scope here. Documented inline above `logAuditCanonical`.

## Test plan
- [ ] `go test ./...` passes locally.
- [ ] Inspect a fresh-install upgrade: `audit_log` and `chain_facts` rows survive migration 042 (SQLite full-table rebuild + chain_facts TEMP-table backup).
- [ ] Two concurrent identical requests under per-request approval produce one canonical row + one dedup-attempt row, and only one pending approval is enqueued.
- [ ] Same `request_id` under different `task_id` lands two canonical rows; polling returns the newest.
- [ ] Same `request_id` under different `task_id` for an approval-required action returns the existing approval's status; the second canonical is demoted to a dedup-attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)