### PR TITLE
fix(mcp): url-encode service param to prevent query string injection

### DIFF
--- a/internal/mcp/tools_exec.go
+++ b/internal/mcp/tools_exec.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 )
 
@@ -123,7 +124,7 @@ func buildInternalRequest(toolName string, arguments json.RawMessage) (internalR
 	case "fetch_catalog":
 		path := "/api/skill/catalog"
 		if svc := getString("service"); svc != "" {
-			path += "?service=" + svc
+			path += "?service=" + url.QueryEscape(svc)
 		}
 		return internalRoute{"GET", path, "GET /api/skill/catalog", nil}, nil, nil
 


### PR DESCRIPTION

## Summary

Fixes a query string parameter injection vector in the `fetch_catalog` MCP tool route. Agent-controlled input was concatenated directly into a URL without encoding, allowing an agent to inject arbitrary query parameters into an internal route.

## Security Issue

The `fetch_catalog` tool accepts a `service` argument from the agent and builds an internal route URL:

```go
// before
path += "?service=" + svc
```

An agent could pass a value like `google.gmail&admin=true`, which the server would parse as two separate query parameters:

```
/api/skill/catalog?service=google.gmail&admin=true
```

The injected parameter (`admin=true`) would be invisible to the caller but visible to the internal route handler - a classic query string injection pattern.

### Why this matters

Clawvisor's core security model treats agents as untrusted. An agent that can silently inject parameters into internal routes breaks that boundary. The `fetch_catalog` handler may not act on unknown params today, but:

- Future additions to this route (pagination, filtering, access flags) would be immediately exploitable with no further changes on the agent side
- The injection point exists silently - there is no error, no log, no indication the parameter was injected
- It establishes a pattern of unencoded agent input reaching internal routing, which is wrong regardless of current impact

## Fix

Wrap the value with `url.QueryEscape` so special characters are encoded as literal data:

```go
// after
path += "?service=" + url.QueryEscape(svc)
```

`&` becomes `%26`, `=` becomes `%3D` - the handler receives a single `service` param with the full raw value, injection attempt and all. The route behaves correctly for all valid service identifiers since they contain no special characters.

