### PR TITLE
feat: symmetric (user, request_id, task_id) dedup scope

### DIFF
--- a/internal/api/dedup_callback_test.go
+++ b/internal/api/dedup_callback_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 )
@@ -348,6 +349,71 @@ func TestGateway_Dedup_SameRequestID_DifferentTask_ApprovalRequired_IndependentA
 	mustStatus(t, resp, http.StatusOK)
 	resp = sc.session.do("POST", fmt.Sprintf("/api/approvals/%s/deny?task_id=%s", reqID, taskID2), nil)
 	mustStatus(t, resp, http.StatusOK)
+}
+
+// TestGateway_Dedup_ConcurrentSameScope_RecoversCanonical guards the
+// same-scope race recovery: two concurrent identical requests must end with
+// exactly one canonical audit row and the loser's response must reflect the
+// winner's outcome (deduped:true, same audit_id) instead of a fresh
+// executed row whose canonical insert silently failed. Pre-fix this test
+// would either see two canonical rows (impossible under the unique index)
+// or one canonical + one orphan loser whose LogAudit silently logged and
+// fell through to a regular "executed" response, leaving the agent unaware
+// of the dedup.
+//
+// Note the adapter STILL fires twice — closing that window requires an
+// insert-canonical-before-execute reservation that's out of scope here;
+// this test only locks in the audit-shape + response-shape recovery
+// (see logAuditCanonical's "Known limitation" docstring).
+func TestGateway_Dedup_ConcurrentSameScope_RecoversCanonical(t *testing.T) {
+	adapter := newMockAdapter("mock.race-recover", "run").withResult("ok", nil)
+	env := newTestEnv(t, adapter)
+	sc := newScenario(t, env, "race-recover")
+	if err := env.Vault.Set(context.Background(), sc.session.UserID, "mock.race-recover", []byte("cred")); err != nil {
+		t.Fatalf("vault seed: %v", err)
+	}
+	taskID := sc.createApprovedTask(t, env, "mock.race-recover", "run", true)
+	reqID := fmt.Sprintf("race-recover-%s", randSuffix())
+
+	const goroutines = 8
+	var (
+		wg      sync.WaitGroup
+		results = make([]map[string]any, goroutines)
+		start   = make(chan struct{})
+	)
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			<-start
+			results[idx] = sc.gatewayRequestWithTask(env, reqID, "mock.race-recover", "run", taskID)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	// Exactly one canonical audit row should exist for (user, reqID, task).
+	// All N callers must return the SAME audit_id; N-1 must report deduped:true.
+	auditIDs := map[string]int{}
+	dedupCount := 0
+	for _, r := range results {
+		if r == nil {
+			t.Fatal("nil result")
+		}
+		if r["status"] != "executed" {
+			t.Fatalf("expected status=executed, got %v (full: %+v)", r["status"], r)
+		}
+		auditIDs[str(t, r, "audit_id")]++
+		if r["deduped"] == true {
+			dedupCount++
+		}
+	}
+	if len(auditIDs) != 1 {
+		t.Fatalf("expected all %d racers to converge on a single canonical audit_id, got %d distinct: %v", goroutines, len(auditIDs), auditIDs)
+	}
+	if dedupCount != goroutines-1 {
+		t.Fatalf("expected %d racers to report deduped=true, got %d", goroutines-1, dedupCount)
+	}
 }
 
 // TestGateway_Status_TaskScoped guards the status / long-poll endpoint

--- a/internal/api/dedup_callback_test.go
+++ b/internal/api/dedup_callback_test.go
@@ -205,6 +205,271 @@ func TestGateway_Dedup_SameRequestID_DifferentTask_NotDeduplicated(t *testing.T)
 	}
 }
 
+// TestGateway_Dedup_AfterCrossTaskReuse_RetryHitsOwnCanonical guards the
+// pre-LogAudit dedup check at gateway.go:264 against the cross-task-reuse
+// shadowing bug. Sequence: task A executes reqID=X, task B (different task)
+// executes reqID=X (independent canonical, allowed under symmetric scope),
+// task A retries reqID=X. The pre-LogAudit check must dedup to task A's
+// canonical, not task B's "latest" canonical — otherwise the retry falls
+// through, the side effect re-fires, and LogAudit hits the partial-unique
+// after the damage is done. FindDedupCandidate's same-task precedence is
+// the only thing that prevents that.
+func TestGateway_Dedup_AfterCrossTaskReuse_RetryHitsOwnCanonical(t *testing.T) {
+	adapter := newMockAdapter("mock.crosstask-retry", "run").withResult("ok", nil)
+	env := newTestEnv(t, adapter)
+	sc := newScenario(t, env, "crosstask-retry")
+	if err := env.Vault.Set(context.Background(), sc.session.UserID, "mock.crosstask-retry", []byte("cred")); err != nil {
+		t.Fatalf("vault seed: %v", err)
+	}
+
+	reqID := fmt.Sprintf("crosstask-retry-%s", randSuffix())
+
+	// Task A: auto-execute → canonical AC_A.
+	taskA := sc.createApprovedTask(t, env, "mock.crosstask-retry", "run", true)
+	first := sc.gatewayRequestWithTask(env, reqID, "mock.crosstask-retry", "run", taskA)
+	if first["status"] != "executed" {
+		t.Fatalf("task A first: expected executed, got %v", first["status"])
+	}
+	auditA := str(t, first, "audit_id")
+
+	// Task B (different task, different purpose): also auto-execute, same
+	// request_id. Under symmetric scope this lands its own canonical AC_B.
+	time.Sleep(10 * time.Millisecond) // content-dedup TTL separation
+	taskResp := env.do("POST", "/api/tasks", sc.AgentToken, map[string]any{
+		"purpose": "task B with different purpose",
+		"authorized_actions": []map[string]any{{
+			"service": "mock.crosstask-retry", "action": "run", "auto_execute": true,
+		}},
+	})
+	taskBody := mustStatus(t, taskResp, http.StatusCreated)
+	taskB := str(t, taskBody, "task_id")
+	taskResp = sc.session.do("POST", fmt.Sprintf("/api/tasks/%s/approve", taskB), nil)
+	mustStatus(t, taskResp, http.StatusOK)
+	second := sc.gatewayRequestWithTask(env, reqID, "mock.crosstask-retry", "run", taskB)
+	if second["status"] != "executed" {
+		t.Fatalf("task B: expected executed, got %v", second["status"])
+	}
+	auditB := str(t, second, "audit_id")
+	if auditA == auditB {
+		t.Fatalf("task B should have its own canonical, got same audit_id as task A: %q", auditA)
+	}
+
+	// Task A retries reqID=X. Must dedup to AC_A (its own canonical), NOT
+	// AC_B (the latest canonical for reqID=X). A request_id-only audit
+	// lookup at the dedup gate would return AC_B and the retry would fall
+	// through.
+	retry := sc.gatewayRequestWithTask(env, reqID, "mock.crosstask-retry", "run", taskA)
+	if retry["deduped"] != true {
+		t.Fatalf("task A retry: expected deduped=true, got %v (full response: %+v)", retry["deduped"], retry)
+	}
+	if got := str(t, retry, "audit_id"); got != auditA {
+		t.Fatalf("task A retry: should dedup to AC_A %q, got %q (AC_B was %q)", auditA, got, auditB)
+	}
+}
+
+// TestGateway_Dedup_SameRequestID_DifferentTask_ApprovalRequired_IndependentApprovals
+// pins the symmetric-dedup behavior change: when two tasks reuse the same
+// request_id and both fall under approval-required, each task gets its own
+// pending approval rather than the second being silently dedup'd to the first
+// task's approval.
+//
+// Before symmetric scoping, pending_approvals.UNIQUE(request_id) forced the
+// second insert to hit ErrConflict and the handler demoted the second audit
+// row to a dedup-attempt pointing at the first task's pending. The
+// user-visible effect was "two tasks share one approval queue entry," which
+// is incoherent with the auto-execute case where each task gets an
+// independent execution.
+//
+// After symmetric scoping, both inserts succeed under distinct
+// (user_id, request_id, task_id) keys, so the queue shows two entries and
+// denying one leaves the other pending.
+func TestGateway_Dedup_SameRequestID_DifferentTask_ApprovalRequired_IndependentApprovals(t *testing.T) {
+	env := newTestEnv(t, newMockAdapter("mock.crosstask-appr", "run"))
+	sc := newScenario(t, env, "crosstask-appr")
+
+	reqID := fmt.Sprintf("crosstask-appr-%s", randSuffix())
+
+	// First task: approval-required → first pending approval.
+	taskID1 := sc.createApprovedTask(t, env, "mock.crosstask-appr", "run", false)
+	first := sc.gatewayRequestWithTask(env, reqID, "mock.crosstask-appr", "run", taskID1)
+	if first["status"] != "pending" {
+		t.Fatalf("first request: expected pending, got %v", first["status"])
+	}
+	firstAuditID := str(t, first, "audit_id")
+
+	// Second task with a different purpose to avoid task-content dedup,
+	// same request_id, also approval-required.
+	taskResp := env.do("POST", "/api/tasks", sc.AgentToken, map[string]any{
+		"purpose": "second task with different purpose",
+		"authorized_actions": []map[string]any{{
+			"service": "mock.crosstask-appr", "action": "run", "auto_execute": false,
+		}},
+	})
+	taskBody := mustStatus(t, taskResp, http.StatusCreated)
+	taskID2 := str(t, taskBody, "task_id")
+	taskResp = sc.session.do("POST", fmt.Sprintf("/api/tasks/%s/approve", taskID2), nil)
+	mustStatus(t, taskResp, http.StatusOK)
+	second := sc.gatewayRequestWithTask(env, reqID, "mock.crosstask-appr", "run", taskID2)
+	if second["status"] != "pending" {
+		t.Fatalf("second request: expected pending, got %v", second["status"])
+	}
+	if second["deduped"] == true {
+		t.Errorf("cross-task approval-required: second request should NOT be dedup'd, got deduped=true")
+	}
+	secondAuditID := str(t, second, "audit_id")
+	if secondAuditID == firstAuditID {
+		t.Errorf("cross-task approval-required: expected fresh audit_id, got same as first")
+	}
+
+	// /api/approvals should list two distinct pending entries, both with our
+	// reqID, AND each must carry its task_id so the dashboard can resolve the
+	// specific sibling via ?task_id= without hitting AMBIGUOUS.
+	resp := sc.session.do("GET", "/api/approvals", nil)
+	apBody := mustStatus(t, resp, http.StatusOK)
+	gotTaskIDs := map[string]bool{}
+	for _, e := range arr(t, apBody, "entries") {
+		m := e.(map[string]any)
+		if m["request_id"] != reqID {
+			continue
+		}
+		taskID, ok := m["task_id"].(string)
+		if !ok || taskID == "" {
+			t.Fatalf("pending approval is missing task_id: %v", m)
+		}
+		gotTaskIDs[taskID] = true
+	}
+	if !gotTaskIDs[taskID1] || !gotTaskIDs[taskID2] {
+		t.Fatalf("expected pending entries for both tasks, got task_ids %v (want %q + %q)", gotTaskIDs, taskID1, taskID2)
+	}
+
+	// Dashboard-style disambiguated approve via ?task_id= resolves the
+	// specific sibling for each task.
+	resp = sc.session.do("POST", fmt.Sprintf("/api/approvals/%s/approve?task_id=%s", reqID, taskID1), nil)
+	mustStatus(t, resp, http.StatusOK)
+	resp = sc.session.do("POST", fmt.Sprintf("/api/approvals/%s/deny?task_id=%s", reqID, taskID2), nil)
+	mustStatus(t, resp, http.StatusOK)
+}
+
+// TestGateway_Status_TaskScoped guards the status / long-poll endpoint
+// against sibling-task shadowing. Under symmetric dedup, two tasks can land
+// distinct canonicals for the same request_id; the polling endpoint must
+// return the row that matches the caller's task_id when supplied, not just
+// "latest canonical for this request_id".
+func TestGateway_Status_TaskScoped(t *testing.T) {
+	adapter := newMockAdapter("mock.status-task", "run").withResult("ok", nil)
+	env := newTestEnv(t, adapter)
+	sc := newScenario(t, env, "status-task")
+	if err := env.Vault.Set(context.Background(), sc.session.UserID, "mock.status-task", []byte("cred")); err != nil {
+		t.Fatalf("vault seed: %v", err)
+	}
+
+	reqID := fmt.Sprintf("status-task-%s", randSuffix())
+
+	taskA := sc.createApprovedTask(t, env, "mock.status-task", "run", true)
+	first := sc.gatewayRequestWithTask(env, reqID, "mock.status-task", "run", taskA)
+	if first["status"] != "executed" {
+		t.Fatalf("task A: expected executed, got %v", first["status"])
+	}
+	auditA := str(t, first, "audit_id")
+
+	// Task B also executes the same request_id (independent canonical under
+	// symmetric scope). With ?task_id= each task's poll must resolve to that
+	// task's own canonical, not whichever happens to be "latest". SQLite
+	// stores audit timestamps at second granularity, so "latest" is unstable
+	// for nearly-simultaneous rows — only the task-scoped contract is
+	// deterministic enough to assert here.
+	taskResp := env.do("POST", "/api/tasks", sc.AgentToken, map[string]any{
+		"purpose": "task B status scope",
+		"authorized_actions": []map[string]any{{
+			"service": "mock.status-task", "action": "run", "auto_execute": true,
+		}},
+	})
+	taskBody := mustStatus(t, taskResp, http.StatusCreated)
+	taskB := str(t, taskBody, "task_id")
+	taskResp = sc.session.do("POST", fmt.Sprintf("/api/tasks/%s/approve", taskB), nil)
+	mustStatus(t, taskResp, http.StatusOK)
+	second := sc.gatewayRequestWithTask(env, reqID, "mock.status-task", "run", taskB)
+	if second["status"] != "executed" {
+		t.Fatalf("task B: expected executed, got %v", second["status"])
+	}
+	auditB := str(t, second, "audit_id")
+	if auditA == auditB {
+		t.Fatalf("expected distinct canonicals for two tasks, got same audit_id %q", auditA)
+	}
+
+	// Task-scoped status returns each task's own row regardless of which is
+	// "newer" under second-granularity timestamps.
+	resp := env.do("GET", fmt.Sprintf("/api/gateway/request/%s?task_id=%s", reqID, taskA), sc.AgentToken, nil)
+	got := mustStatus(t, resp, http.StatusOK)
+	if got["audit_id"] != auditA {
+		t.Fatalf("task-scoped status (A): expected %q, got %q", auditA, got["audit_id"])
+	}
+	resp = env.do("GET", fmt.Sprintf("/api/gateway/request/%s?task_id=%s", reqID, taskB), sc.AgentToken, nil)
+	got = mustStatus(t, resp, http.StatusOK)
+	if got["audit_id"] != auditB {
+		t.Fatalf("task-scoped status (B): expected %q, got %q", auditB, got["audit_id"])
+	}
+}
+
+// TestApprovals_Ambiguous_Returns409 covers the AMBIGUOUS disambiguation
+// contract for the request_id-only HTTP routes. Two pending approvals share
+// the same request_id (because they belong to different tasks); approving by
+// request_id alone must surface 409 AMBIGUOUS with candidate_task_ids, and
+// providing ?task_id= must resolve the correct row.
+func TestApprovals_Ambiguous_Returns409(t *testing.T) {
+	env := newTestEnv(t, newMockAdapter("mock.ambiguous", "run"))
+	sc := newScenario(t, env, "ambiguous")
+
+	reqID := fmt.Sprintf("ambig-%s", randSuffix())
+
+	taskID1 := sc.createApprovedTask(t, env, "mock.ambiguous", "run", false)
+	first := sc.gatewayRequestWithTask(env, reqID, "mock.ambiguous", "run", taskID1)
+	if first["status"] != "pending" {
+		t.Fatalf("first request: expected pending, got %v", first["status"])
+	}
+
+	taskResp := env.do("POST", "/api/tasks", sc.AgentToken, map[string]any{
+		"purpose": "second task ambiguous test",
+		"authorized_actions": []map[string]any{{
+			"service": "mock.ambiguous", "action": "run", "auto_execute": false,
+		}},
+	})
+	taskBody := mustStatus(t, taskResp, http.StatusCreated)
+	taskID2 := str(t, taskBody, "task_id")
+	taskResp = sc.session.do("POST", fmt.Sprintf("/api/tasks/%s/approve", taskID2), nil)
+	mustStatus(t, taskResp, http.StatusOK)
+	second := sc.gatewayRequestWithTask(env, reqID, "mock.ambiguous", "run", taskID2)
+	if second["status"] != "pending" {
+		t.Fatalf("second request: expected pending, got %v", second["status"])
+	}
+
+	// request_id-only approve hits 409 AMBIGUOUS with candidate task_ids.
+	resp := sc.session.do("POST", fmt.Sprintf("/api/approvals/%s/approve", reqID), nil)
+	body := mustStatus(t, resp, http.StatusConflict)
+	if body["code"] != "AMBIGUOUS" {
+		t.Fatalf("expected code=AMBIGUOUS, got %v", body["code"])
+	}
+	candidates := arr(t, body, "candidate_task_ids")
+	if len(candidates) != 2 {
+		t.Fatalf("expected 2 candidate_task_ids, got %d", len(candidates))
+	}
+	gotTasks := map[string]bool{}
+	for _, c := range candidates {
+		gotTasks[c.(string)] = true
+	}
+	if !gotTasks[taskID1] || !gotTasks[taskID2] {
+		t.Fatalf("candidate_task_ids missing one of %q/%q, got %v", taskID1, taskID2, candidates)
+	}
+
+	// Disambiguated approve via ?task_id= resolves the right row.
+	resp = sc.session.do("POST", fmt.Sprintf("/api/approvals/%s/approve?task_id=%s", reqID, taskID1), nil)
+	mustStatus(t, resp, http.StatusOK)
+
+	// The other pending approval is still there; approve it explicitly.
+	resp = sc.session.do("POST", fmt.Sprintf("/api/approvals/%s/approve?task_id=%s", reqID, taskID2), nil)
+	mustStatus(t, resp, http.StatusOK)
+}
+
 // ── GET /api/gateway/request/{request_id} ────────────────────────────────────
 
 func TestGateway_Status_NotFound(t *testing.T) {

--- a/internal/api/dedup_callback_test.go
+++ b/internal/api/dedup_callback_test.go
@@ -361,10 +361,9 @@ func TestGateway_Dedup_SameRequestID_DifferentTask_ApprovalRequired_IndependentA
 // fell through to a regular "executed" response, leaving the agent unaware
 // of the dedup.
 //
-// Note the adapter STILL fires twice — closing that window requires an
-// insert-canonical-before-execute reservation that's out of scope here;
-// this test only locks in the audit-shape + response-shape recovery
-// (see logAuditCanonical's "Known limitation" docstring).
+// This test only locks in the audit-shape + response-shape recovery; see
+// TestGateway_Dedup_ConcurrentSameScope_DoesNotDoubleExecuteAdapter for the
+// stronger idempotency expectation.
 func TestGateway_Dedup_ConcurrentSameScope_RecoversCanonical(t *testing.T) {
 	adapter := newMockAdapter("mock.race-recover", "run").withResult("ok", nil)
 	env := newTestEnv(t, adapter)
@@ -413,6 +412,62 @@ func TestGateway_Dedup_ConcurrentSameScope_RecoversCanonical(t *testing.T) {
 	}
 	if dedupCount != goroutines-1 {
 		t.Fatalf("expected %d racers to report deduped=true, got %d", goroutines-1, dedupCount)
+	}
+}
+
+func TestGateway_Dedup_ConcurrentSameScope_DoesNotDoubleExecuteAdapter(t *testing.T) {
+	firstExecute := make(chan struct{}, 1)
+	releaseExecute := make(chan struct{})
+	adapter := newMockAdapter("mock.race-idempotent", "run").
+		withResult("ok", nil).
+		withExecuteHook(func() {
+			select {
+			case firstExecute <- struct{}{}:
+			default:
+			}
+			<-releaseExecute
+		})
+	env := newTestEnv(t, adapter)
+	sc := newScenario(t, env, "race-idempotent")
+	if err := env.Vault.Set(context.Background(), sc.session.UserID, "mock.race-idempotent", []byte("cred")); err != nil {
+		t.Fatalf("vault seed: %v", err)
+	}
+	taskID := sc.createApprovedTask(t, env, "mock.race-idempotent", "run", true)
+	reqID := fmt.Sprintf("race-idempotent-%s", randSuffix())
+
+	const goroutines = 8
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	results := make([]map[string]any, goroutines)
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			<-start
+			results[idx] = sc.gatewayRequestWithTask(env, reqID, "mock.race-idempotent", "run", taskID)
+		}(i)
+	}
+	close(start)
+
+	select {
+	case <-firstExecute:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first adapter execution")
+	}
+	time.Sleep(100 * time.Millisecond)
+	close(releaseExecute)
+	wg.Wait()
+
+	for _, r := range results {
+		if r == nil {
+			t.Fatal("nil result")
+		}
+		if r["status"] != "executed" {
+			t.Fatalf("expected status=executed, got %v (full: %+v)", r["status"], r)
+		}
+	}
+	if got := adapter.executeCount(); got != 1 {
+		t.Fatalf("duplicate request_id should execute adapter once, got %d executions", got)
 	}
 }
 

--- a/internal/api/dedup_callback_test.go
+++ b/internal/api/dedup_callback_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/clawvisor/clawvisor/pkg/store"
+	vaultpkg "github.com/clawvisor/clawvisor/pkg/vault"
 )
 
 // registerCallbackSecret calls POST /api/callbacks/register and returns the secret.
@@ -556,6 +557,117 @@ func TestGateway_Dedup_CanceledClientStillFinalizesExecuteReservation(t *testing
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
+}
+
+func TestGateway_Dedup_CanceledClientStillFinalizesMissingCredentialReservation(t *testing.T) {
+	vaultGate := &blockingMissingCredentialVault{
+		serviceID: "mock.cancel-missing-cred",
+		entered:   make(chan struct{}, 1),
+		release:   make(chan struct{}),
+	}
+	adapter := newMockAdapter("mock.cancel-missing-cred", "run").withResult("ok", nil)
+	env := newTestEnvWithVaultWrapper(t, func(v vaultpkg.Vault) vaultpkg.Vault {
+		vaultGate.Vault = v
+		return vaultGate
+	}, adapter)
+	sc := newScenario(t, env, "cancel-missing-cred")
+	vaultGate.enabled = false
+	sc.activateService(t, env, "mock.cancel-missing-cred")
+
+	// Create and approve the task while the service is activated, then remove
+	// the credential. The gateway reserves execute/pending before it discovers
+	// vault.ErrNotFound during the adapter execution path.
+	resp := env.do("POST", "/api/tasks", sc.AgentToken, map[string]any{
+		"purpose": "test missing credential finalization",
+		"authorized_actions": []map[string]any{{
+			"service": "mock.cancel-missing-cred", "action": "run", "auto_execute": true,
+		}},
+	})
+	body := mustStatus(t, resp, http.StatusCreated)
+	taskID := str(t, body, "task_id")
+	resp = sc.session.do("POST", fmt.Sprintf("/api/tasks/%s/approve", taskID), nil)
+	mustStatus(t, resp, http.StatusOK)
+	if err := env.Vault.Delete(context.Background(), sc.session.UserID, "mock.cancel-missing-cred"); err != nil {
+		t.Fatalf("vault delete: %v", err)
+	}
+	vaultGate.enabled = true
+
+	reqID := fmt.Sprintf("cancel-missing-cred-%s", randSuffix())
+	reqBody, err := json.Marshal(map[string]any{
+		"request_id": reqID,
+		"service":    "mock.cancel-missing-cred",
+		"action":     "run",
+		"task_id":    taskID,
+		"reason":     "exercise canceled client missing credential finalization",
+	})
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, env.url("/api/gateway/request"), bytes.NewReader(reqBody))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+sc.AgentToken)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		env.ts.Config.Handler.ServeHTTP(httptest.NewRecorder(), req)
+	}()
+
+	select {
+	case <-vaultGate.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for gateway credential lookup")
+	}
+	cancel()
+	close(vaultGate.release)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for canceled client request to return")
+	}
+
+	deadline := time.Now().Add(500 * time.Millisecond)
+	var last *store.AuditEntry
+	for {
+		entry, err := env.Store.GetAuditEntryByRequestIDAndTask(context.Background(), reqID, sc.session.UserID, taskID)
+		if err == nil {
+			last = entry
+			if entry.Outcome == "error" {
+				return
+			}
+		}
+		if time.Now().After(deadline) {
+			if last == nil {
+				t.Fatalf("expected terminal audit row for canceled missing-credential request, lookup did not succeed")
+			}
+			t.Fatalf("expected canceled missing-credential reservation to finalize as error, got decision=%q outcome=%q audit_id=%s", last.Decision, last.Outcome, last.ID)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+type blockingMissingCredentialVault struct {
+	vaultpkg.Vault
+	serviceID string
+	enabled   bool
+	entered   chan struct{}
+	release   chan struct{}
+}
+
+func (v *blockingMissingCredentialVault) Get(ctx context.Context, userID, serviceID string) ([]byte, error) {
+	if v.enabled && serviceID == v.serviceID {
+		select {
+		case v.entered <- struct{}{}:
+		default:
+		}
+		<-v.release
+		return nil, vaultpkg.ErrNotFound
+	}
+	return v.Vault.Get(ctx, userID, serviceID)
 }
 
 // TestGateway_Status_TaskScoped guards the status / long-poll endpoint

--- a/internal/api/dedup_callback_test.go
+++ b/internal/api/dedup_callback_test.go
@@ -1,6 +1,7 @@
 package api_test
 
 import (
+	"bytes"
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
@@ -13,6 +14,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/clawvisor/clawvisor/pkg/store"
 )
 
 // registerCallbackSecret calls POST /api/callbacks/register and returns the secret.
@@ -454,7 +457,14 @@ func TestGateway_Dedup_ConcurrentSameScope_DoesNotDoubleExecuteAdapter(t *testin
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for first adapter execution")
 	}
-	time.Sleep(100 * time.Millisecond)
+	// No fixed sleep before releasing: every loser converges to
+	// status="executed" regardless of where it arrives in the race —
+	// reservation-conflict + reserveExecAndWaitLoser, early-dedup on the
+	// in-flight reservation + wait there, or early-dedup after
+	// UpdateAuditOutcome and immediate return. The two invariants
+	// (executeCount == 1 and every result is "executed") hold across
+	// all three paths, so a fixed sleep would only add flakiness without
+	// strengthening the assertion.
 	close(releaseExecute)
 	wg.Wait()
 
@@ -468,6 +478,83 @@ func TestGateway_Dedup_ConcurrentSameScope_DoesNotDoubleExecuteAdapter(t *testin
 	}
 	if got := adapter.executeCount(); got != 1 {
 		t.Fatalf("duplicate request_id should execute adapter once, got %d executions", got)
+	}
+}
+
+func TestGateway_Dedup_CanceledClientStillFinalizesExecuteReservation(t *testing.T) {
+	firstExecute := make(chan struct{}, 1)
+	releaseExecute := make(chan struct{})
+	adapter := newMockAdapter("mock.cancel-finalize", "run").
+		withResult("ok", nil).
+		withExecuteHook(func() {
+			select {
+			case firstExecute <- struct{}{}:
+			default:
+			}
+			<-releaseExecute
+		})
+	env := newTestEnv(t, adapter)
+	sc := newScenario(t, env, "cancel-finalize")
+	if err := env.Vault.Set(context.Background(), sc.session.UserID, "mock.cancel-finalize", []byte("cred")); err != nil {
+		t.Fatalf("vault seed: %v", err)
+	}
+	taskID := sc.createApprovedTask(t, env, "mock.cancel-finalize", "run", true)
+	reqID := fmt.Sprintf("cancel-finalize-%s", randSuffix())
+
+	body, err := json.Marshal(map[string]any{
+		"request_id": reqID,
+		"service":    "mock.cancel-finalize",
+		"action":     "run",
+		"task_id":    taskID,
+		"reason":     "exercise canceled client finalization",
+	})
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, env.url("/api/gateway/request"), bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+sc.AgentToken)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		env.ts.Config.Handler.ServeHTTP(httptest.NewRecorder(), req)
+	}()
+
+	select {
+	case <-firstExecute:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for adapter execution")
+	}
+	cancel()
+	close(releaseExecute)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for canceled client request to return")
+	}
+
+	deadline := time.Now().Add(500 * time.Millisecond)
+	var last *store.AuditEntry
+	for {
+		entry, err := env.Store.GetAuditEntryByRequestIDAndTask(context.Background(), reqID, sc.session.UserID, taskID)
+		if err == nil {
+			last = entry
+			if entry.Outcome == "executed" {
+				return
+			}
+		}
+		if time.Now().After(deadline) {
+			if last == nil {
+				t.Fatalf("expected terminal audit row for canceled request, lookup did not succeed")
+			}
+			t.Fatalf("expected canceled request reservation to finalize as executed, got decision=%q outcome=%q audit_id=%s", last.Decision, last.Outcome, last.ID)
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }
 

--- a/internal/api/gateway_test.go
+++ b/internal/api/gateway_test.go
@@ -290,6 +290,104 @@ func TestGateway_NoTaskID_UncoveredRoutesToApproval(t *testing.T) {
 	}
 }
 
+func TestGateway_NoTaskID_ConcurrentApprovalRaceReturnsCanonicalPending(t *testing.T) {
+	const goroutines = 6
+	arrivedAtResolver := make(chan struct{}, goroutines)
+	releaseResolver := make(chan struct{})
+	llmSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&map[string]any{})
+		arrivedAtResolver <- struct{}{}
+		<-releaseResolver
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{
+				{"message": map[string]any{"content": `{"kind":"one_off"}`}},
+			},
+		})
+	}))
+	defer llmSrv.Close()
+
+	adapter := newMockAdapter("mock.no-task-race", "run")
+	env := newTestEnvWithLLM(t, testGatewayResolverLLMConfig(llmSrv.URL), adapter, newMockAdapter("mock.no-task-race-other", "run"))
+	sc := newScenario(t, env, "bot")
+	if err := env.Vault.Set(context.Background(), sc.session.UserID, "mock.no-task-race", []byte("cred")); err != nil {
+		t.Fatalf("vault seed: %v", err)
+	}
+	_ = sc.createApprovedTask(t, env, "mock.no-task-race-other", "run", true)
+	reqID := fmt.Sprintf("req-no-task-race-%s", randSuffix())
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	results := make([]map[string]any, goroutines)
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			<-start
+			results[idx] = sc.gatewayRequest(env, reqID, "mock.no-task-race", "run")
+		}(i)
+	}
+	close(start)
+	arrivals := 0
+	select {
+	case <-arrivedAtResolver:
+		arrivals++
+	case <-time.After(3 * time.Second):
+		close(releaseResolver)
+		t.Fatal("timed out waiting for first resolver request")
+	}
+	collectWindow := time.NewTimer(250 * time.Millisecond)
+collectArrivals:
+	for arrivals < goroutines {
+		select {
+		case <-arrivedAtResolver:
+			arrivals++
+		case <-collectWindow.C:
+			break collectArrivals
+		}
+	}
+	if !collectWindow.Stop() {
+		select {
+		case <-collectWindow.C:
+		default:
+		}
+	}
+	close(releaseResolver)
+	wg.Wait()
+
+	auditIDs := map[string]int{}
+	dedupCount := 0
+	for _, r := range results {
+		if r == nil {
+			t.Fatal("nil result")
+		}
+		if r["status"] != "pending" {
+			t.Fatalf("expected status=pending, got %v (full: %+v)", r["status"], r)
+		}
+		auditIDs[str(t, r, "audit_id")]++
+		if r["deduped"] == true {
+			dedupCount++
+		}
+	}
+	if len(auditIDs) != 1 {
+		t.Fatalf("expected all racers to return canonical audit_id, got %d distinct: %v", len(auditIDs), auditIDs)
+	}
+	if dedupCount != goroutines-1 {
+		t.Fatalf("expected %d racers to report deduped=true, got %d", goroutines-1, dedupCount)
+	}
+
+	resp := sc.session.do("GET", "/api/approvals", nil)
+	body := mustStatus(t, resp, http.StatusOK)
+	count := 0
+	for _, e := range arr(t, body, "entries") {
+		if e.(map[string]any)["request_id"] == reqID {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly one pending approval for raced request_id, got %d", count)
+	}
+}
+
 func TestGateway_NoTaskID_LLMResolvesAmbiguousTask(t *testing.T) {
 	var llmResponse string
 	llmSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers/approvals.go
+++ b/internal/api/handlers/approvals.go
@@ -99,6 +99,84 @@ func (h *ApprovalsHandler) List(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// resolvePendingForRequest returns the single pending approval matching
+// (request_id, user_id). When the optional ?task_id= query param is present
+// it disambiguates by exact task scope; otherwise the unique row is returned,
+// or — if more than one row matches — the helper writes 409 AMBIGUOUS with
+// candidate task_ids and returns nil (caller should return). Returning
+// ([nil, false]) means the helper already wrote a response.
+//
+// Symmetric dedup permits two pending approvals to share a request_id when
+// they belong to different tasks; the HTTP routes deliberately stay
+// request_id-keyed for backwards compatibility, so disambiguation only
+// surfaces when it actually has to.
+func (h *ApprovalsHandler) resolvePendingForRequest(w http.ResponseWriter, r *http.Request, userID string) (*store.PendingApproval, bool) {
+	requestID := r.PathValue("request_id")
+	taskID := r.URL.Query().Get("task_id")
+	if taskID != "" {
+		pa, err := h.st.GetPendingApprovalByTask(r.Context(), requestID, userID, taskID)
+		if err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				writeError(w, http.StatusNotFound, "NOT_FOUND", "pending approval not found")
+				return nil, false
+			}
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not get pending approval")
+			return nil, false
+		}
+		return pa, true
+	}
+	pa, err := h.st.GetPendingApproval(r.Context(), requestID, userID)
+	if err == nil {
+		return pa, true
+	}
+	if errors.Is(err, store.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "pending approval not found")
+		return nil, false
+	}
+	if errors.Is(err, store.ErrAmbiguous) {
+		h.writeAmbiguousPending(w, r.Context(), requestID, userID)
+		return nil, false
+	}
+	writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not get pending approval")
+	return nil, false
+}
+
+// writeAmbiguousPending emits the 409 response shape that clients retry with
+// an explicit ?task_id= query param. The candidate list comes straight from
+// the store; if the lookup fails we fall back to a generic 409.
+func (h *ApprovalsHandler) writeAmbiguousPending(w http.ResponseWriter, ctx context.Context, requestID, userID string) {
+	candidates, err := h.st.ListPendingApprovalsByRequestID(ctx, requestID, userID)
+	if err != nil {
+		writeError(w, http.StatusConflict, "AMBIGUOUS", "multiple pending approvals share this request_id; retry with ?task_id=<id>")
+		return
+	}
+	taskIDs := make([]string, 0, len(candidates))
+	for _, c := range candidates {
+		t := ""
+		if c.TaskID != nil {
+			t = *c.TaskID
+		}
+		taskIDs = append(taskIDs, t)
+	}
+	writeJSON(w, http.StatusConflict, map[string]any{
+		"error":              "multiple pending approvals share this request_id",
+		"code":               "AMBIGUOUS",
+		"hint":               "retry with ?task_id=<one of candidate_task_ids>",
+		"request_id":         requestID,
+		"candidate_task_ids": taskIDs,
+	})
+}
+
+// paTaskID extracts a PendingApproval's task_id for use in scope-keyed
+// mutations. Returns "" when TaskID is nil (the pre-task scope, which maps
+// to task_id IS NULL in the store).
+func paTaskID(pa *store.PendingApproval) string {
+	if pa == nil || pa.TaskID == nil {
+		return ""
+	}
+	return *pa.TaskID
+}
+
 // Approve marks a pending request as approved. The agent is expected to call
 // POST /api/gateway/request/{request_id}/execute to claim the result. If the
 // agent registered a callback URL, a notification is also delivered there.
@@ -112,16 +190,11 @@ func (h *ApprovalsHandler) Approve(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	requestID := r.PathValue("request_id")
-	pa, err := h.st.GetPendingApproval(r.Context(), requestID)
-	if err != nil {
-		if errors.Is(err, store.ErrNotFound) {
-			writeError(w, http.StatusNotFound, "NOT_FOUND", "pending approval not found")
-			return
-		}
-		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not get pending approval")
+	pa, ok := h.resolvePendingForRequest(w, r, user.ID)
+	if !ok {
 		return
 	}
+	requestID := pa.RequestID
 
 	if pa.UserID != user.ID {
 		writeError(w, http.StatusForbidden, "FORBIDDEN", "not your approval")
@@ -166,10 +239,23 @@ func (h *ApprovalsHandler) Approve(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
-// ApproveByRequestID is the core approve logic, callable from both the HTTP handler
-// and the Telegram callback decision consumer.
-func (h *ApprovalsHandler) ApproveByRequestID(ctx context.Context, requestID, userID string) error {
-	pa, err := h.st.GetPendingApproval(ctx, requestID)
+// ApproveByRequestID is the core approve logic, callable from both the HTTP
+// handler and the Telegram callback decision consumer. taskID is the
+// symmetric-dedup disambiguator; pass "" when the caller has no task scope
+// (pre-task approvals, legacy clients). When taskID is empty and more than
+// one pending approval shares (request_id, user_id) the store returns
+// ErrAmbiguous and this function propagates it — callers should surface that
+// back rather than approving an arbitrary candidate.
+func (h *ApprovalsHandler) ApproveByRequestID(ctx context.Context, requestID, userID, taskID string) error {
+	var (
+		pa  *store.PendingApproval
+		err error
+	)
+	if taskID != "" {
+		pa, err = h.st.GetPendingApprovalByTask(ctx, requestID, userID, taskID)
+	} else {
+		pa, err = h.st.GetPendingApproval(ctx, requestID, userID)
+	}
 	if err != nil {
 		return err
 	}
@@ -200,7 +286,7 @@ func (h *ApprovalsHandler) ApproveByRequestID(ctx context.Context, requestID, us
 // approval status (which must be one of "denied" / "expired" — see
 // validateApprovalRecordTransition).
 func (h *ApprovalsHandler) revertOrTerminate(ctx context.Context, pa *store.PendingApproval, reason string) {
-	won, err := h.st.UpdatePendingApprovalStatusFrom(ctx, pa.RequestID, "approved", pa.Status)
+	won, err := h.st.UpdatePendingApprovalStatusFrom(ctx, pa.RequestID, pa.UserID, paTaskID(pa), "approved", pa.Status)
 	if err != nil {
 		h.logger.Error("failed to revert approval status",
 			"request_id", pa.RequestID, "reason", reason, "err", err)
@@ -237,7 +323,7 @@ var errApprovalAlreadyResolved = errors.New("approval is no longer pending")
 // Returns errApprovalAlreadyResolved if the row was resolved by another
 // caller before our CAS landed; HTTP handlers translate that to 409.
 func (h *ApprovalsHandler) markApproved(ctx context.Context, pa *store.PendingApproval, resolution string) (*store.Task, error) {
-	won, err := h.st.UpdatePendingApprovalStatusFrom(ctx, pa.RequestID, "pending", "approved")
+	won, err := h.st.UpdatePendingApprovalStatusFrom(ctx, pa.RequestID, pa.UserID, paTaskID(pa), "pending", "approved")
 	if err != nil {
 		h.logger.Error("failed to update approval status", "request_id", pa.RequestID, "err", err)
 		return nil, err
@@ -271,7 +357,7 @@ func (h *ApprovalsHandler) markApproved(ctx context.Context, pa *store.PendingAp
 			notifyText = "✅ <b>Approved</b> — session task created and waiting for agent execution."
 		}
 	}
-	h.updateNotificationMsg(ctx, "approval", pa.RequestID, pa.UserID, notifyText)
+	h.updateNotificationMsg(ctx, "approval", approvalNotifyTargetID(pa.RequestID, paTaskID(pa)), pa.UserID, notifyText)
 	h.decrementNotifierPolling(pa.UserID)
 
 	if pa.CallbackURL != nil && *pa.CallbackURL != "" {
@@ -304,8 +390,16 @@ func (h *ApprovalsHandler) markApproved(ctx context.Context, pa *store.PendingAp
 // The status update is a CAS from "pending" → "denied", so a concurrent
 // Approve against the same request_id can't co-resolve. If the row has
 // already been resolved (approved, denied, or executing), this is a no-op.
-func (h *ApprovalsHandler) DenyByRequestID(ctx context.Context, requestID, userID string) error {
-	pa, err := h.st.GetPendingApproval(ctx, requestID)
+func (h *ApprovalsHandler) DenyByRequestID(ctx context.Context, requestID, userID, callerTaskID string) error {
+	var (
+		pa  *store.PendingApproval
+		err error
+	)
+	if callerTaskID != "" {
+		pa, err = h.st.GetPendingApprovalByTask(ctx, requestID, userID, callerTaskID)
+	} else {
+		pa, err = h.st.GetPendingApproval(ctx, requestID, userID)
+	}
 	if err != nil {
 		return err
 	}
@@ -313,7 +407,8 @@ func (h *ApprovalsHandler) DenyByRequestID(ctx context.Context, requestID, userI
 		return errors.New("not your approval")
 	}
 
-	won, err := h.st.UpdatePendingApprovalStatusFrom(ctx, requestID, "pending", "denied")
+	taskID := paTaskID(pa)
+	won, err := h.st.UpdatePendingApprovalStatusFrom(ctx, requestID, userID, taskID, "pending", "denied")
 	if err != nil {
 		return err
 	}
@@ -330,11 +425,11 @@ func (h *ApprovalsHandler) DenyByRequestID(ctx context.Context, requestID, userI
 	if err := h.st.UpdateAuditOutcome(ctx, pa.AuditID, "denied", "", 0); err != nil {
 		h.logger.Error("failed to update audit outcome", "audit_id", pa.AuditID, "err", err)
 	}
-	if err := h.st.DeletePendingApproval(ctx, requestID); err != nil {
+	if err := h.st.DeletePendingApproval(ctx, requestID, userID, taskID); err != nil {
 		h.logger.Error("failed to delete pending approval", "request_id", requestID, "err", err)
 	}
 
-	h.updateNotificationMsg(ctx, "approval", requestID, pa.UserID, "❌ <b>Denied</b> — request rejected.")
+	h.updateNotificationMsg(ctx, "approval", approvalNotifyTargetID(requestID, taskID), pa.UserID, "❌ <b>Denied</b> — request rejected.")
 	h.decrementNotifierPolling(pa.UserID)
 	h.publishQueueAndAudit(userID, pa.AuditID)
 
@@ -363,13 +458,8 @@ func (h *ApprovalsHandler) Deny(w http.ResponseWriter, r *http.Request) {
 	}
 
 	requestID := r.PathValue("request_id")
-	pa, err := h.st.GetPendingApproval(r.Context(), requestID)
-	if err != nil {
-		if errors.Is(err, store.ErrNotFound) {
-			writeError(w, http.StatusNotFound, "NOT_FOUND", "pending approval not found")
-			return
-		}
-		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not get pending approval")
+	pa, ok := h.resolvePendingForRequest(w, r, user.ID)
+	if !ok {
 		return
 	}
 
@@ -378,7 +468,8 @@ func (h *ApprovalsHandler) Deny(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	won, err := h.st.UpdatePendingApprovalStatusFrom(r.Context(), requestID, "pending", "denied")
+	taskID := paTaskID(pa)
+	won, err := h.st.UpdatePendingApprovalStatusFrom(r.Context(), requestID, user.ID, taskID, "pending", "denied")
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not update approval")
 		return
@@ -397,11 +488,11 @@ func (h *ApprovalsHandler) Deny(w http.ResponseWriter, r *http.Request) {
 	if err := h.st.UpdateAuditOutcome(r.Context(), pa.AuditID, "denied", "", 0); err != nil {
 		h.logger.Error("failed to update audit outcome", "audit_id", pa.AuditID, "err", err)
 	}
-	if err := h.st.DeletePendingApproval(r.Context(), requestID); err != nil {
+	if err := h.st.DeletePendingApproval(r.Context(), requestID, user.ID, taskID); err != nil {
 		h.logger.Error("failed to delete pending approval", "request_id", requestID, "err", err)
 	}
 
-	h.updateNotificationMsg(r.Context(), "approval", requestID, pa.UserID, "❌ <b>Denied</b> — request rejected.")
+	h.updateNotificationMsg(r.Context(), "approval", approvalNotifyTargetID(requestID, taskID), pa.UserID, "❌ <b>Denied</b> — request rejected.")
 	h.decrementNotifierPolling(pa.UserID)
 	h.publishQueueAndAudit(user.ID, pa.AuditID)
 
@@ -448,7 +539,7 @@ func (h *ApprovalsHandler) executeApproval(ctx context.Context, pa *store.Pendin
 	if err := h.st.UpdateAuditOutcome(ctx, pa.AuditID, outcome, errMsg, dur); err != nil {
 		h.logger.Error("failed to update audit outcome", "audit_id", pa.AuditID, "err", err)
 	}
-	if err := h.st.DeletePendingApproval(ctx, pa.RequestID); err != nil {
+	if err := h.st.DeletePendingApproval(ctx, pa.RequestID, pa.UserID, paTaskID(pa)); err != nil {
 		h.logger.Error("failed to delete pending approval", "request_id", pa.RequestID, "err", err)
 	}
 
@@ -456,7 +547,7 @@ func (h *ApprovalsHandler) executeApproval(ctx context.Context, pa *store.Pendin
 	if errMsg != "" {
 		notifyText = "✅ <b>Approved</b> — execution failed: " + errMsg
 	}
-	h.updateNotificationMsg(ctx, "approval", pa.RequestID, pa.UserID, notifyText)
+	h.updateNotificationMsg(ctx, "approval", approvalNotifyTargetID(pa.RequestID, paTaskID(pa)), pa.UserID, notifyText)
 
 	if pa.CallbackURL != nil && *pa.CallbackURL != "" {
 		var cbResult *adapters.Result
@@ -512,11 +603,11 @@ func (h *ApprovalsHandler) RunExpiryCleanup(ctx context.Context) {
 func (h *ApprovalsHandler) processExpiredApproval(ctx context.Context, pa *store.PendingApproval, reason, telegramMsg string) {
 	h.resolveCanonicalApproval(ctx, pa, "deny", "expired")
 	_ = h.st.UpdateAuditOutcome(ctx, pa.AuditID, "timeout", "", 0)
-	h.updateNotificationMsg(ctx, "approval", pa.RequestID, pa.UserID, telegramMsg)
+	h.updateNotificationMsg(ctx, "approval", approvalNotifyTargetID(pa.RequestID, paTaskID(pa)), pa.UserID, telegramMsg)
 	// For the regular expired path the caller relies on us to delete the
 	// row; for the stranded path the CAS DELETE already happened, so the
 	// best-effort DELETE here is a no-op (zero rows affected).
-	_ = h.st.DeletePendingApproval(ctx, pa.RequestID)
+	_ = h.st.DeletePendingApproval(ctx, pa.RequestID, pa.UserID, paTaskID(pa))
 	if pa.CallbackURL != nil && *pa.CallbackURL != "" {
 		var blob pendingRequestBlob
 		_ = json.Unmarshal(pa.RequestBlob, &blob)
@@ -558,7 +649,7 @@ func (h *ApprovalsHandler) expireTimedOut(ctx context.Context) {
 		h.logger.Warn("expiry cleanup: stalled-executing list failed", "err", err)
 	} else {
 		for _, pa := range stalled {
-			won, err := h.st.ClaimStalledExecutingApprovalForRecovery(ctx, pa.RequestID, executingLeaseTTL)
+			won, err := h.st.ClaimStalledExecutingApprovalForRecovery(ctx, pa.RequestID, pa.UserID, paTaskID(pa), executingLeaseTTL)
 			if err != nil {
 				h.logger.Warn("expiry cleanup: stalled-executing claim failed", "request_id", pa.RequestID, "err", err)
 				continue
@@ -609,7 +700,7 @@ func (h *ApprovalsHandler) resolveCanonicalApproval(ctx context.Context, pa *sto
 	var rec *store.ApprovalRecord
 	if approvalID == nil {
 		var err error
-		rec, err = h.st.GetApprovalRecordByRequestID(ctx, pa.RequestID)
+		rec, err = h.st.GetApprovalRecordByRequestID(ctx, pa.RequestID, pa.UserID)
 		if err == nil {
 			approvalID = &rec.ID
 		}

--- a/internal/api/handlers/feedback.go
+++ b/internal/api/handlers/feedback.go
@@ -65,7 +65,21 @@ func (h *FeedbackHandler) ReportBug(w http.ResponseWriter, r *http.Request) {
 	var auditEntry *store.AuditEntry
 	var task *store.Task
 	if req.RequestID != "" {
-		if e, err := h.store.GetAuditEntryByRequestID(ctx, req.RequestID, agent.UserID); err == nil {
+		// When the agent supplied a task_id, scope the audit lookup to it —
+		// otherwise under symmetric dedup a sibling task's canonical for the
+		// same request_id could be attached to the bug report, misleading the
+		// reviewer. GetAuditEntryByRequestIDAndTask falls back to the
+		// pre-task canonical when no task-scoped row exists.
+		var (
+			e   *store.AuditEntry
+			err error
+		)
+		if req.TaskID != "" {
+			e, err = h.store.GetAuditEntryByRequestIDAndTask(ctx, req.RequestID, agent.UserID, req.TaskID)
+		} else {
+			e, err = h.store.GetAuditEntryByRequestID(ctx, req.RequestID, agent.UserID)
+		}
+		if err == nil {
 			auditEntry = e
 		}
 	}

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -252,25 +252,20 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 	if req.RequestID == "" {
 		req.RequestID = uuid.New().String()
 	} else {
-		// Dedup: if this request_id was already processed under the same task,
-		// return the existing outcome without re-processing. This prevents
-		// duplicate audit entries and re-execution of side-effect actions when
-		// the agent retries after a network timeout.
-		//
-		// The dedup is scoped to the same task_id so that reusing a request_id
-		// across different tasks/sessions is treated as a fresh request.
-		// Pre-task outcomes (e.g. "blocked" by restriction) have no task_id
-		// and are always dedup'd since they're stateless checks.
-		if existing, err := h.store.GetAuditEntryByRequestID(ctx, req.RequestID, agent.UserID); err == nil {
-			preTask := existing.TaskID == nil // blocked/error before task scope
-			sameTask := req.TaskID != "" && existing.TaskID != nil && *existing.TaskID == req.TaskID
-			if preTask || sameTask {
-				writeGatewayStatusResponse(w, existing, gatewayStatusResponseOptions{
-					Deduped: true,
-					Message: "Duplicate request_id reused; returning the existing result. Use a new request_id for a new request.",
-				})
-				return
-			}
+		// Dedup: if this (request_id, user, task) already has a canonical row,
+		// return its outcome without re-processing. FindDedupCandidate encodes
+		// the precedence directly — pre-task canonicals (task_id IS NULL) win
+		// over task-scoped canonicals for the same request_id, oldest-first
+		// within a tier — so a sibling task that landed its own canonical
+		// under symmetric scope doesn't shadow our retry's pre-task or
+		// same-task winner. Using the request_id-only getter here would
+		// silently return that sibling's "latest canonical" instead.
+		if existing, err := h.store.FindDedupCandidate(ctx, req.RequestID, agent.UserID, req.TaskID); err == nil {
+			writeGatewayStatusResponse(w, existing, gatewayStatusResponseOptions{
+				Deduped: true,
+				Message: "Duplicate request_id reused; returning the existing result. Use a new request_id for a new request.",
+			})
+			return
 		}
 	}
 	middleware.AddLogField(ctx, "request_id", req.RequestID)
@@ -498,13 +493,17 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 				h.logger.Warn("route to approval failed", "err", routeErr)
 			}
 			if r.URL.Query().Get("wait") == "true" && h.eventHub != nil {
-				pa := h.waitForApprovalDecision(r.Context(), req.RequestID, agent.UserID, longPollDeadline(r))
+				pa := h.waitForApprovalDecision(r.Context(), req.RequestID, agent.UserID, req.TaskID, longPollDeadline(r))
 				if pa != nil && pa.Status == "approved" && !time.Now().After(pa.ExpiresAt) {
 					h.executeAndRespond(w, r.Context(), pa, agent.ID)
 					return
 				}
 				if pa == nil {
-					if entry, err := h.store.GetAuditEntryByRequestID(r.Context(), req.RequestID, agent.UserID); err == nil && entry.Outcome != "pending" {
+					// Pending row was deleted (denied/expired). Scope the audit
+					// lookup to the same task to avoid picking up a sibling
+					// task's canonical for the same request_id under symmetric
+					// dedup.
+					if entry, err := h.store.GetAuditEntryByRequestIDAndTask(r.Context(), req.RequestID, agent.UserID, req.TaskID); err == nil && entry.Outcome != "pending" {
 						writeGatewayStatusResponse(w, entry)
 						return
 					}
@@ -1230,15 +1229,16 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 	}
 	// If wait=true, long-poll for approval then execute inline.
 	if r.URL.Query().Get("wait") == "true" && h.eventHub != nil {
-		pa := h.waitForApprovalDecision(r.Context(), req.RequestID, agent.UserID, longPollDeadline(r))
+		pa := h.waitForApprovalDecision(r.Context(), req.RequestID, agent.UserID, req.TaskID, longPollDeadline(r))
 		if pa != nil && pa.Status == "approved" && !time.Now().After(pa.ExpiresAt) {
 			h.executeAndRespond(w, r.Context(), pa, agent.ID)
 			return
 		}
-		// pa == nil means the row was deleted (denied/expired). Check the audit
-		// entry so we return the real outcome instead of a misleading "pending".
+		// pa == nil means the row was deleted (denied/expired). Look up the
+		// audit entry for the same task scope — request_id alone could pick up
+		// a sibling task's canonical under symmetric dedup.
 		if pa == nil {
-			if entry, err := h.store.GetAuditEntryByRequestID(r.Context(), req.RequestID, agent.UserID); err == nil && entry.Outcome != "pending" {
+			if entry, err := h.store.GetAuditEntryByRequestIDAndTask(r.Context(), req.RequestID, agent.UserID, req.TaskID); err == nil && entry.Outcome != "pending" {
 				writeGatewayStatusResponse(w, entry)
 				return
 			}
@@ -1275,7 +1275,12 @@ func (h *GatewayHandler) HandleGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	requestID := r.PathValue("request_id")
-	entry, err := h.store.GetAuditEntryByRequestID(r.Context(), requestID, agent.UserID)
+	// Optional ?task_id= scopes the lookup so an agent polling task A doesn't
+	// receive task B's newer canonical when both sides reused the same
+	// request_id under symmetric dedup. With no task_id the historical
+	// "latest canonical for this request_id" contract still applies.
+	taskID := r.URL.Query().Get("task_id")
+	entry, err := h.lookupAuditByRequestID(r.Context(), requestID, agent.UserID, taskID)
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "NOT_FOUND", "request not found")
@@ -1288,7 +1293,7 @@ func (h *GatewayHandler) HandleGet(w http.ResponseWriter, r *http.Request) {
 	// Long-poll: if wait=true and request is still pending, block until it
 	// transitions or the timeout elapses.
 	if r.URL.Query().Get("wait") == "true" && entry.Outcome == "pending" && h.eventHub != nil {
-		entry = h.waitForRequestResolution(r.Context(), requestID, agent.UserID, longPollDeadline(r))
+		entry = h.waitForRequestResolution(r.Context(), requestID, agent.UserID, taskID, longPollDeadline(r))
 		if r.Context().Err() != nil {
 			return
 		}
@@ -1297,13 +1302,28 @@ func (h *GatewayHandler) HandleGet(w http.ResponseWriter, r *http.Request) {
 	writeGatewayStatusResponse(w, entry)
 }
 
+// lookupAuditByRequestID returns the canonical audit entry for (request_id,
+// user_id), narrowing to the caller's task scope when taskID != "". The
+// task-scoped getter inverts FindDedupCandidate's precedence (exact-task
+// first, pre-task fallback) so a polling agent who knows its task_id always
+// gets the row that actually fired for that task — not a sibling task's
+// later canonical for the same request_id.
+func (h *GatewayHandler) lookupAuditByRequestID(ctx context.Context, requestID, userID, taskID string) (*store.AuditEntry, error) {
+	if taskID == "" {
+		return h.store.GetAuditEntryByRequestID(ctx, requestID, userID)
+	}
+	return h.store.GetAuditEntryByRequestIDAndTask(ctx, requestID, userID, taskID)
+}
+
 // waitForRequestResolution long-polls until the audit entry for a gateway
-// request leaves the "pending" state or the timeout expires.
-func (h *GatewayHandler) waitForRequestResolution(ctx context.Context, requestID, userID string, timeout time.Duration) *store.AuditEntry {
+// request leaves the "pending" state or the timeout expires. taskID is
+// forwarded to the lookup so a caller polling a specific task isn't woken
+// (or worse, returned) by a sibling task's canonical.
+func (h *GatewayHandler) waitForRequestResolution(ctx context.Context, requestID, userID, taskID string, timeout time.Duration) *store.AuditEntry {
 	return events.WaitFor(ctx, h.eventHub, userID, timeout,
 		[]string{"audit"},
 		func(c context.Context) (*store.AuditEntry, bool) {
-			e, err := h.store.GetAuditEntryByRequestID(c, requestID, userID)
+			e, err := h.lookupAuditByRequestID(c, requestID, userID, taskID)
 			if err != nil {
 				return &store.AuditEntry{RequestID: requestID, Outcome: "pending"}, false
 			}
@@ -1339,13 +1359,42 @@ func longPollDeadline(r *http.Request) time.Duration {
 	return time.Duration(parseLongPollTimeout(r))*time.Second + longPollGrace
 }
 
+// writeAmbiguousExecute emits the 409 AMBIGUOUS response shape for the
+// agent-facing /execute endpoint when (request_id, user_id) matches more than
+// one pending approval. Mirrors writeAmbiguousPending on the user-facing
+// approvals path so clients see one consistent disambiguation contract.
+func (h *GatewayHandler) writeAmbiguousExecute(w http.ResponseWriter, ctx context.Context, requestID, userID string) {
+	candidates, err := h.store.ListPendingApprovalsByRequestID(ctx, requestID, userID)
+	if err != nil {
+		writeError(w, http.StatusConflict, "AMBIGUOUS", "multiple pending approvals share this request_id; retry with ?task_id=<id>")
+		return
+	}
+	taskIDs := make([]string, 0, len(candidates))
+	for _, c := range candidates {
+		t := ""
+		if c.TaskID != nil {
+			t = *c.TaskID
+		}
+		taskIDs = append(taskIDs, t)
+	}
+	writeJSON(w, http.StatusConflict, map[string]any{
+		"error":              "multiple pending approvals share this request_id",
+		"code":               "AMBIGUOUS",
+		"hint":               "retry with ?task_id=<one of candidate_task_ids>",
+		"request_id":         requestID,
+		"candidate_task_ids": taskIDs,
+	})
+}
+
 // waitForApprovalDecision long-polls until the pending approval leaves the
-// "pending" state (approved/denied/deleted) or the timeout expires.
-func (h *GatewayHandler) waitForApprovalDecision(ctx context.Context, requestID, userID string, timeout time.Duration) *store.PendingApproval {
+// "pending" state (approved/denied/deleted) or the timeout expires. The
+// taskID scope is required so two pending approvals sharing a request_id
+// under symmetric dedup don't cross-signal one another.
+func (h *GatewayHandler) waitForApprovalDecision(ctx context.Context, requestID, userID, taskID string, timeout time.Duration) *store.PendingApproval {
 	return events.WaitFor(ctx, h.eventHub, userID, timeout,
 		[]string{"audit", "queue"},
 		func(c context.Context) (*store.PendingApproval, bool) {
-			pa, err := h.store.GetPendingApproval(c, requestID)
+			pa, err := h.store.GetPendingApprovalByTask(c, requestID, userID, taskID)
 			if err != nil {
 				return nil, true // row deleted (denied/expired)
 			}
@@ -1361,7 +1410,11 @@ func (h *GatewayHandler) waitForApprovalDecision(ctx context.Context, requestID,
 func (h *GatewayHandler) executeAndRespond(w http.ResponseWriter, ctx context.Context, pa *store.PendingApproval, agentID string) {
 	// Atomic claim: only one caller wins. Prevents double-execution of
 	// non-idempotent actions (emails, payments, etc.).
-	claimed, claimErr := h.store.ClaimPendingApprovalForExecution(ctx, pa.RequestID)
+	paTask := ""
+	if pa.TaskID != nil {
+		paTask = *pa.TaskID
+	}
+	claimed, claimErr := h.store.ClaimPendingApprovalForExecution(ctx, pa.RequestID, pa.UserID, paTask)
 	if claimErr != nil {
 		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not claim approval")
 		return
@@ -1407,7 +1460,7 @@ func (h *GatewayHandler) executeAndRespond(w http.ResponseWriter, ctx context.Co
 	}
 
 	_ = h.store.UpdateAuditOutcome(ctx, pa.AuditID, outcome, errMsg, dur)
-	_ = h.store.DeletePendingApproval(ctx, pa.RequestID)
+	_ = h.store.DeletePendingApproval(ctx, pa.RequestID, pa.UserID, paTask)
 	h.publishAuditAndQueue(pa.UserID, blob.TaskID)
 
 	resp := map[string]any{
@@ -1443,10 +1496,23 @@ func (h *GatewayHandler) HandleExecuteApproved(w http.ResponseWriter, r *http.Re
 	}
 
 	requestID := r.PathValue("request_id")
-	pa, err := h.store.GetPendingApproval(r.Context(), requestID)
+	// Optional ?task_id= disambiguates when the same request_id has more than
+	// one pending approval across tasks under symmetric dedup.
+	taskFromQuery := r.URL.Query().Get("task_id")
+	var pa *store.PendingApproval
+	var err error
+	if taskFromQuery != "" {
+		pa, err = h.store.GetPendingApprovalByTask(r.Context(), requestID, agent.UserID, taskFromQuery)
+	} else {
+		pa, err = h.store.GetPendingApproval(r.Context(), requestID, agent.UserID)
+	}
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "NOT_FOUND", "pending approval not found")
+			return
+		}
+		if errors.Is(err, store.ErrAmbiguous) {
+			h.writeAmbiguousExecute(w, r.Context(), requestID, agent.UserID)
 			return
 		}
 		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not get pending approval")
@@ -1471,12 +1537,19 @@ func (h *GatewayHandler) HandleExecuteApproved(w http.ResponseWriter, r *http.Re
 		return
 	}
 
+	paTask := ""
+	if pa.TaskID != nil {
+		paTask = *pa.TaskID
+	}
+
 	// If still pending and wait=true, long-poll until approval decision.
 	if pa.Status == "pending" && r.URL.Query().Get("wait") == "true" && h.eventHub != nil {
-		pa = h.waitForApprovalDecision(r.Context(), requestID, agent.UserID, longPollDeadline(r))
+		pa = h.waitForApprovalDecision(r.Context(), requestID, agent.UserID, paTask, longPollDeadline(r))
 		if pa == nil {
-			// Row deleted (denied/expired) — check the audit entry for the real outcome.
-			if entry, err := h.store.GetAuditEntryByRequestID(r.Context(), requestID, agent.UserID); err == nil && entry.Outcome != "pending" {
+			// Row deleted (denied/expired). Scope the audit lookup to paTask so
+			// a sibling task's canonical for the same request_id doesn't shadow
+			// the real outcome.
+			if entry, err := h.store.GetAuditEntryByRequestIDAndTask(r.Context(), requestID, agent.UserID, paTask); err == nil && entry.Outcome != "pending" {
 				writeGatewayStatusResponse(w, entry)
 				return
 			}
@@ -2054,6 +2127,7 @@ func (h *GatewayHandler) routeToApproval(
 		ID:               uuid.New().String(),
 		UserID:           userID,
 		RequestID:        blob.RequestID,
+		TaskID:           taskID,
 		AuditID:          auditID,
 		ApprovalRecordID: &approvalRecord.ID,
 		RequestBlob:      json.RawMessage(blobBytes),
@@ -2074,12 +2148,20 @@ func (h *GatewayHandler) routeToApproval(
 	}
 
 	expiresIn := fmt.Sprintf("%d minutes", int(time.Until(expiresAt).Minutes()))
-	approveURL := fmt.Sprintf("%s/dashboard?action=approve&request_id=%s", h.baseURL, blob.RequestID)
-	denyURL := fmt.Sprintf("%s/dashboard?action=deny&request_id=%s", h.baseURL, blob.RequestID)
+	// task_id is included on the deep links so the dashboard can address the
+	// correct sibling when two pending approvals share a request_id across
+	// tasks under symmetric dedup.
+	taskQS := ""
+	if blob.TaskID != "" {
+		taskQS = "&task_id=" + blob.TaskID
+	}
+	approveURL := fmt.Sprintf("%s/dashboard?action=approve&request_id=%s%s", h.baseURL, blob.RequestID, taskQS)
+	denyURL := fmt.Sprintf("%s/dashboard?action=deny&request_id=%s%s", h.baseURL, blob.RequestID, taskQS)
 
 	approvalReq := notify.ApprovalRequest{
 		PendingID:    pa.ID,
 		RequestID:    blob.RequestID,
+		TaskID:       blob.TaskID,
 		UserID:       userID,
 		AgentName:    blob.AgentName,
 		Service:      blob.Service,
@@ -2102,8 +2184,21 @@ func (h *GatewayHandler) routeToApproval(
 		return nil
 	}
 
-	_ = h.store.SaveNotificationMessage(ctx, "approval", blob.RequestID, "telegram", msgID)
+	_ = h.store.SaveNotificationMessage(ctx, "approval", approvalNotifyTargetID(blob.RequestID, blob.TaskID), "telegram", msgID)
 	return nil
+}
+
+// approvalNotifyTargetID composes the notification_messages target_id for a
+// pending approval. Two sibling pendings can share request_id under symmetric
+// dedup; without task_id in the key, the second SendApprovalRequest would
+// overwrite the first message row, and the resolve path would later update
+// the wrong Telegram message. Pre-task approvals (taskID == "") keep their
+// historical request_id-only key so existing rows remain addressable.
+func approvalNotifyTargetID(requestID, taskID string) string {
+	if taskID == "" {
+		return requestID
+	}
+	return requestID + "|" + taskID
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -1052,10 +1052,24 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			if verdict != nil {
 				e.Verification = intent.MarshalVerdict(verdict)
 			}
-			if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+			winner, logErr := h.logAuditCanonical(ctx, e)
+			if logErr != nil {
 				h.logger.Warn("audit log failed", "err", logErr)
 			}
 			h.publishAuditAndQueue(agent.UserID, req.TaskID)
+			if winner != nil {
+				// Same-scope race: the canonical landed in another goroutine.
+				// The adapter on this side already fired (see
+				// logAuditCanonical's auto-execute limitation), but we
+				// surface the winner's outcome to the agent and suppress
+				// chain-context extraction + callback on this loser so the
+				// agent doesn't see duplicate execution side effects.
+				writeGatewayStatusResponse(w, winner, gatewayStatusResponseOptions{
+					Deduped: true,
+					Message: "Duplicate request_id reused; returning the existing result. Use a new request_id for a new request.",
+				})
+				return
+			}
 
 			// Chain context extraction (async — cloud services only, guarded by verdict != nil)
 			chainSessionID := req.SessionID
@@ -1212,10 +1226,22 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 	e := baseEntry("approve", "pending", taskIDPtr)
 	e.DurationMS = int(time.Since(start).Milliseconds())
 	e.Verification = intent.MarshalVerdict(advisoryVerdict)
-	if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+	winner, logErr := h.logAuditCanonical(ctx, e)
+	if logErr != nil {
 		h.logger.Warn("audit log failed", "err", logErr)
 	}
 	h.publishAuditAndQueue(agent.UserID, req.TaskID)
+	if winner != nil {
+		// Same-scope race: another worker already enqueued the approval.
+		// Skip routeToApproval to avoid creating a duplicate pending row
+		// and surface the winner's outcome (which may itself still be
+		// "pending" — the agent should poll, not retry).
+		writeGatewayStatusResponse(w, winner, gatewayStatusResponseOptions{
+			Deduped: true,
+			Message: "Duplicate request_id reused; awaiting the existing approval. Use a new request_id for a new request.",
+		})
+		return
+	}
 	expiresAt := time.Now().Add(time.Duration(h.cfg.Approval.Timeout) * time.Second)
 	blob := buildRequestBlob(req, agent)
 	blob.Verification = advisoryVerdict
@@ -1357,6 +1383,48 @@ const longPollGrace = 10 * time.Second
 // request — the client-requested timeout plus longPollGrace.
 func longPollDeadline(r *http.Request) time.Duration {
 	return time.Duration(parseLongPollTimeout(r))*time.Second + longPollGrace
+}
+
+// logAuditCanonical writes a canonical audit row (DedupedOf == nil) and
+// recovers cleanly from a same-scope race. On a unique-violation against
+// idx_audit_canonical_dedup, it re-fetches the winning canonical via
+// FindDedupCandidate, demotes e in place to a dedup-attempt row pointing
+// at the winner, and re-LogAudits. Returns the winner (non-nil) iff race
+// recovery rewrote e; callers gating side effects or queue insertion on
+// canonical insertion should short-circuit on winner != nil with the
+// winner's outcome.
+//
+// Known limitation — auto-execute idempotency: callers that fire the
+// adapter BEFORE calling this helper can both miss the early
+// FindDedupCandidate check, both execute, and only collide here on the
+// audit insert. This helper recovers the audit shape (one canonical,
+// one dedup-attempt) but cannot un-fire a side effect the adapter
+// already executed. Closing the window requires an
+// insert-canonical-before-execute reservation pattern, intentionally
+// out of scope for the dedup-scope migration. The early
+// FindDedupCandidate at the request-handling entry still catches the
+// common case (sequential retries); the residual race is narrow (two
+// near-simultaneous identical requests). Even in that case, the
+// loser's response now reflects the winner's outcome and the loser's
+// callback is suppressed — the audit log is the only thing that no
+// longer "lies" about it.
+func (h *GatewayHandler) logAuditCanonical(ctx context.Context, e *store.AuditEntry) (*store.AuditEntry, error) {
+	err := h.store.LogAudit(ctx, e)
+	if err == nil || !errors.Is(err, store.ErrConflict) {
+		return nil, err
+	}
+	taskID := ""
+	if e.TaskID != nil {
+		taskID = *e.TaskID
+	}
+	winner, lookupErr := h.store.FindDedupCandidate(ctx, e.RequestID, e.UserID, taskID)
+	if lookupErr != nil {
+		return nil, fmt.Errorf("dedup candidate lookup after race: %w", lookupErr)
+	}
+	e.DedupedOf = &winner.ID
+	e.Decision = "dedup"
+	e.Outcome = winner.Outcome
+	return winner, h.store.LogAudit(ctx, e)
 }
 
 // writeAmbiguousExecute emits the 409 AMBIGUOUS response shape for the

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -260,8 +260,20 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 		// under symmetric scope doesn't shadow our retry's pre-task or
 		// same-task winner. Using the request_id-only getter here would
 		// silently return that sibling's "latest canonical" instead.
+		//
+		// If the canonical is an in-flight adapter reservation
+		// (decision=="execute", outcome=="pending"), wait for it to
+		// resolve so the deduped response reflects the actual outcome,
+		// not the transient "pending" reservation. Approval-pending and
+		// other long-lived states return immediately.
 		if existing, err := h.store.FindDedupCandidate(ctx, req.RequestID, agent.UserID, req.TaskID); err == nil {
-			writeGatewayStatusResponse(w, existing, gatewayStatusResponseOptions{
+			final := existing
+			if existing.Decision == "execute" && existing.Outcome == "pending" && h.eventHub != nil {
+				if resolved := h.waitForRequestResolution(ctx, req.RequestID, agent.UserID, req.TaskID, longPollDeadline(r)); resolved != nil {
+					final = resolved
+				}
+			}
+			writeGatewayStatusResponse(w, final, gatewayStatusResponseOptions{
 				Deduped: true,
 				Message: "Duplicate request_id reused; returning the existing result. Use a new request_id for a new request.",
 			})
@@ -479,10 +491,21 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			middleware.AddLogField(ctx, "outcome", "pending")
 			e := baseEntry("approve", "pending", nil)
 			e.DurationMS = int(time.Since(start).Milliseconds())
-			if logErr := h.store.LogAudit(ctx, e); logErr != nil {
+			winner, logErr := h.logAuditCanonical(ctx, e)
+			if logErr != nil {
 				h.logger.Warn("audit log failed", "err", logErr)
 			}
 			h.publishAuditAndQueue(agent.UserID, "")
+			if winner != nil {
+				// Same-scope race (pre-task scope: task_id IS NULL).
+				// Another worker already enqueued the approval; surface
+				// its row without creating a duplicate pending.
+				writeGatewayStatusResponse(w, winner, gatewayStatusResponseOptions{
+					Deduped: true,
+					Message: "Duplicate request_id reused; awaiting the existing approval. Use a new request_id for a new request.",
+				})
+				return
+			}
 			expiresAt := time.Now().Add(time.Duration(h.cfg.Approval.Timeout) * time.Second)
 			blob := buildRequestBlob(req, agent)
 			reason := "raw request needs review before execution"
@@ -858,6 +881,19 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 
+				// Reservation before the adapter call (see the cloud branch
+				// below for the full rationale). Local-executor side effects
+				// — file writes, subprocess spawns — are no more idempotent
+				// than a cloud adapter's, so the double-execute window has
+				// to close here too.
+				localReservation := baseEntry("execute", "pending", taskIDPtr)
+				if verdict != nil {
+					localReservation.Verification = intent.MarshalVerdict(verdict)
+				}
+				if !h.reserveExecAndWaitLoser(w, r, localReservation) {
+					return
+				}
+
 				result, execErr = h.localExec.Execute(ctx, agent.UserID, serviceType, req.Action, req.Params)
 			} else {
 				// ── Intent verification ──────────────────────────────────
@@ -984,6 +1020,20 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 					}
 				}
 
+				// Reservation: insert the canonical "execute"/"pending" row
+				// BEFORE running the adapter so the partial unique index
+				// on (user_id, request_id, COALESCE(task_id,'')) WHERE
+				// deduped_of IS NULL closes the double-execute window
+				// against concurrent identical requests. See
+				// reserveExecAndWaitLoser for the loser-wait semantics.
+				reservation := baseEntry("execute", "pending", taskIDPtr)
+				if verdict != nil {
+					reservation.Verification = intent.MarshalVerdict(verdict)
+				}
+				if !h.reserveExecAndWaitLoser(w, r, reservation) {
+					return
+				}
+
 				vKey := h.adapterReg.VaultKeyWithAliasForUser(serviceType, serviceAlias, agent.UserID)
 				result, execErr = executeAdapterRequest(ctx, h.vault, h.adapterReg, h.store,
 					agent.UserID, serviceType, req.Action, req.Params, vKey)
@@ -993,13 +1043,11 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 					adapter, adapterOK := h.adapterReg.GetForUser(ctx, serviceType, agent.UserID)
 					if adapterOK && adapter.ValidateCredential(nil) != nil {
 						dur := int(time.Since(start).Milliseconds())
-						e := baseEntry("block", "error", taskIDPtr)
-						e.DurationMS = dur
 						code, userErr, auditMsg := serviceNotActivatedResponse(ctx, h.vault, h.store, h.adapterReg, agent.UserID, serviceType, serviceAlias, req.Service, adapter)
-						e.ErrorMsg = &auditMsg
-						if logErr := h.store.LogAudit(ctx, e); logErr != nil {
-							h.logger.Warn("audit log failed", "err", logErr)
+						if updErr := h.store.UpdateAuditOutcome(ctx, auditID, "error", auditMsg, dur); updErr != nil {
+							h.logger.Warn("audit outcome update failed", "err", updErr)
 						}
+						outDecision, outOutcome = "execute", "error"
 						h.publishAuditAndQueue(agent.UserID, req.TaskID)
 						writeJSON(w, http.StatusBadRequest, map[string]any{
 							"status":     "error",
@@ -1019,12 +1067,10 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 
 			if execErr != nil {
 				errMsg := execErr.Error()
-				e := baseEntry("execute", "error", taskIDPtr)
-				e.DurationMS = dur
-				e.ErrorMsg = &errMsg
-				if logErr := h.store.LogAudit(ctx, e); logErr != nil {
-					h.logger.Warn("audit log failed", "err", logErr)
+				if updErr := h.store.UpdateAuditOutcome(ctx, auditID, "error", errMsg, dur); updErr != nil {
+					h.logger.Warn("audit outcome update failed", "err", updErr)
 				}
+				outDecision, outOutcome = "execute", "error"
 				h.publishAuditAndQueue(agent.UserID, req.TaskID)
 				if req.Context.CallbackURL != "" {
 					cbKey, _ := h.store.GetAgentCallbackSecret(ctx, agent.ID)
@@ -1044,32 +1090,14 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
-			// Success
+			// Success — update the reservation to "executed".
 			middleware.AddLogField(ctx, "decision", "execute")
 			middleware.AddLogField(ctx, "outcome", "executed")
-			e := baseEntry("execute", "executed", taskIDPtr)
-			e.DurationMS = dur
-			if verdict != nil {
-				e.Verification = intent.MarshalVerdict(verdict)
+			if updErr := h.store.UpdateAuditOutcome(ctx, auditID, "executed", "", dur); updErr != nil {
+				h.logger.Warn("audit outcome update failed", "err", updErr)
 			}
-			winner, logErr := h.logAuditCanonical(ctx, e)
-			if logErr != nil {
-				h.logger.Warn("audit log failed", "err", logErr)
-			}
+			outDecision, outOutcome = "execute", "executed"
 			h.publishAuditAndQueue(agent.UserID, req.TaskID)
-			if winner != nil {
-				// Same-scope race: the canonical landed in another goroutine.
-				// The adapter on this side already fired (see
-				// logAuditCanonical's auto-execute limitation), but we
-				// surface the winner's outcome to the agent and suppress
-				// chain-context extraction + callback on this loser so the
-				// agent doesn't see duplicate execution side effects.
-				writeGatewayStatusResponse(w, winner, gatewayStatusResponseOptions{
-					Deduped: true,
-					Message: "Duplicate request_id reused; returning the existing result. Use a new request_id for a new request.",
-				})
-				return
-			}
 
 			// Chain context extraction (async — cloud services only, guarded by verdict != nil)
 			chainSessionID := req.SessionID
@@ -1383,6 +1411,48 @@ const longPollGrace = 10 * time.Second
 // request — the client-requested timeout plus longPollGrace.
 func longPollDeadline(r *http.Request) time.Duration {
 	return time.Duration(parseLongPollTimeout(r))*time.Second + longPollGrace
+}
+
+// reserveExecAndWaitLoser inserts e as the canonical "execute"/"pending"
+// row that precedes the adapter call. Returns ok=true if the caller won
+// the canonical reservation and should proceed with the adapter; ok=false
+// if the caller lost the race and the deduped response has already been
+// written (caller must return).
+//
+// This is the only thing that prevents the auto-execute path from firing
+// non-idempotent adapter calls twice when two concurrent identical
+// requests both pass the early FindDedupCandidate gate at the top of
+// HandleRequest. Losers wait for the winner's canonical to leave
+// "pending" so the response reflects the actual outcome, not "pending".
+//
+// A reservation error (transient DB failure) returns ok=true with a warn
+// log — degrading to pre-PR best-effort behavior is better than failing
+// the request outright on a flaky write.
+func (h *GatewayHandler) reserveExecAndWaitLoser(w http.ResponseWriter, r *http.Request, e *store.AuditEntry) bool {
+	ctx := r.Context()
+	winner, reserveErr := h.logAuditCanonical(ctx, e)
+	if reserveErr != nil {
+		h.logger.Warn("audit reservation failed; proceeding without dedup protection", "err", reserveErr)
+	}
+	publishTaskID := ""
+	if e.TaskID != nil {
+		publishTaskID = *e.TaskID
+	}
+	h.publishAuditAndQueue(e.UserID, publishTaskID)
+	if winner == nil {
+		return true
+	}
+	final := winner
+	if winner.Outcome == "pending" && h.eventHub != nil {
+		if resolved := h.waitForRequestResolution(ctx, e.RequestID, e.UserID, publishTaskID, longPollDeadline(r)); resolved != nil {
+			final = resolved
+		}
+	}
+	writeGatewayStatusResponse(w, final, gatewayStatusResponseOptions{
+		Deduped: true,
+		Message: "Duplicate request_id reused; returning the existing result. Use a new request_id for a new request.",
+	})
+	return false
 }
 
 // logAuditCanonical writes a canonical audit row (DedupedOf == nil) and

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -1065,15 +1065,27 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 
 			dur := int(time.Since(start).Milliseconds())
 
+			// Finalize the reservation row with a fresh background context.
+			// If the HTTP client cancels mid-adapter, r.Context() is already
+			// Done and UpdateAuditOutcome(ctx) would fail with
+			// "context canceled" — leaving the canonical stuck in "pending"
+			// and shadowing every subsequent retry through the early dedup
+			// check. The adapter call already produced a definitive
+			// result/error; finalization must record it regardless of
+			// client liveness. Five seconds covers the slowest reasonable
+			// audit write on a busy DB.
+			finalizeCtx, finalizeCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer finalizeCancel()
+
 			if execErr != nil {
 				errMsg := execErr.Error()
-				if updErr := h.store.UpdateAuditOutcome(ctx, auditID, "error", errMsg, dur); updErr != nil {
+				if updErr := h.store.UpdateAuditOutcome(finalizeCtx, auditID, "error", errMsg, dur); updErr != nil {
 					h.logger.Warn("audit outcome update failed", "err", updErr)
 				}
 				outDecision, outOutcome = "execute", "error"
 				h.publishAuditAndQueue(agent.UserID, req.TaskID)
 				if req.Context.CallbackURL != "" {
-					cbKey, _ := h.store.GetAgentCallbackSecret(ctx, agent.ID)
+					cbKey, _ := h.store.GetAgentCallbackSecret(finalizeCtx, agent.ID)
 					h.dispatchCallback(req.Context.CallbackURL, &callback.Payload{
 						Type: "request", RequestID: req.RequestID, Status: "error", Error: errMsg, AuditID: auditID,
 					}, cbKey)
@@ -1093,7 +1105,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			// Success — update the reservation to "executed".
 			middleware.AddLogField(ctx, "decision", "execute")
 			middleware.AddLogField(ctx, "outcome", "executed")
-			if updErr := h.store.UpdateAuditOutcome(ctx, auditID, "executed", "", dur); updErr != nil {
+			if updErr := h.store.UpdateAuditOutcome(finalizeCtx, auditID, "executed", "", dur); updErr != nil {
 				h.logger.Warn("audit outcome update failed", "err", updErr)
 			}
 			outDecision, outOutcome = "execute", "executed"

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -1044,7 +1044,13 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 					if adapterOK && adapter.ValidateCredential(nil) != nil {
 						dur := int(time.Since(start).Milliseconds())
 						code, userErr, auditMsg := serviceNotActivatedResponse(ctx, h.vault, h.store, h.adapterReg, agent.UserID, serviceType, serviceAlias, req.Service, adapter)
-						if updErr := h.store.UpdateAuditOutcome(ctx, auditID, "error", auditMsg, dur); updErr != nil {
+						// Use a fresh background context: see the comment on
+						// finalizeCtx below — if the client cancelled while
+						// we were waiting on the vault, r.Context() is Done
+						// and we'd leave the reservation stuck in "pending".
+						vaultFinalizeCtx, vaultFinalizeCancel := context.WithTimeout(context.Background(), 5*time.Second)
+						defer vaultFinalizeCancel()
+						if updErr := h.store.UpdateAuditOutcome(vaultFinalizeCtx, auditID, "error", auditMsg, dur); updErr != nil {
 							h.logger.Warn("audit outcome update failed", "err", updErr)
 						}
 						outDecision, outOutcome = "execute", "error"

--- a/internal/api/handlers/local_service_test.go
+++ b/internal/api/handlers/local_service_test.go
@@ -116,6 +116,14 @@ func (s *localTestStore) GetAuditEntryByRequestID(_ context.Context, _, _ string
 	return nil, store.ErrNotFound
 }
 
+func (s *localTestStore) FindDedupCandidate(_ context.Context, _, _, _ string) (*store.AuditEntry, error) {
+	return nil, store.ErrNotFound
+}
+
+func (s *localTestStore) GetAuditEntryByRequestIDAndTask(_ context.Context, _, _, _ string) (*store.AuditEntry, error) {
+	return nil, store.ErrNotFound
+}
+
 func (s *localTestStore) ListChainFacts(_ context.Context, _, _ string, _ int) ([]*store.ChainFact, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/api/handlers/local_service_test.go
+++ b/internal/api/handlers/local_service_test.go
@@ -98,6 +98,26 @@ func (s *localTestStore) LogAudit(_ context.Context, entry *store.AuditEntry) er
 	return nil
 }
 
+// UpdateAuditOutcome stubs the reservation-pattern outcome update used by
+// HandleRequest's auto-execute path. Matches the audit row by id and mutates
+// Outcome/ErrorMsg/DurationMS in place so test assertions on
+// s.auditEntries observe the final state.
+func (s *localTestStore) UpdateAuditOutcome(_ context.Context, id, outcome, errMsg string, durationMS int) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, e := range s.auditEntries {
+		if e.ID == id {
+			e.Outcome = outcome
+			if errMsg != "" {
+				e.ErrorMsg = &errMsg
+			}
+			e.DurationMS = durationMS
+			return nil
+		}
+	}
+	return nil
+}
+
 func (s *localTestStore) LogGatewayRequest(_ context.Context, entry *store.GatewayRequestLog) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/api/handlers/overview.go
+++ b/internal/api/handlers/overview.go
@@ -59,6 +59,9 @@ func (h *OverviewHandler) Get(w http.ResponseWriter, r *http.Request) {
 			Params:    blob.Params,
 			Reason:    blob.Reason,
 		}
+		if pa.TaskID != nil {
+			qa.TaskID = *pa.TaskID
+		}
 		if blob.Verification != nil {
 			b, _ := json.Marshal(blob.Verification)
 			var m map[string]any

--- a/internal/api/handlers/queue.go
+++ b/internal/api/handlers/queue.go
@@ -20,7 +20,11 @@ func NewQueueHandler(st store.Store) *QueueHandler {
 }
 
 type queueApproval struct {
-	RequestID    string         `json:"request_id"`
+	RequestID string `json:"request_id"`
+	// TaskID disambiguates when two pending approvals share a request_id
+	// across tasks under symmetric dedup. Clients must round-trip this on
+	// approve/deny (?task_id=...) to avoid the 409 AMBIGUOUS path.
+	TaskID       string         `json:"task_id,omitempty"`
 	AuditID      string         `json:"audit_id"`
 	Service      string         `json:"service"`
 	Action       string         `json:"action"`
@@ -76,6 +80,9 @@ func (h *QueueHandler) List(w http.ResponseWriter, r *http.Request) {
 			Action:    blob.Action,
 			Params:    blob.Params,
 			Reason:    blob.Reason,
+		}
+		if pa.TaskID != nil {
+			qa.TaskID = *pa.TaskID
 		}
 		if blob.Verification != nil {
 			b, _ := json.Marshal(blob.Verification)

--- a/internal/api/handlers/services.go
+++ b/internal/api/handlers/services.go
@@ -149,7 +149,7 @@ func (h *ServicesHandler) checkPendingRequestOwnership(w http.ResponseWriter, r 
 	if pendingReqID == "" {
 		return true
 	}
-	pa, err := h.st.GetPendingApproval(r.Context(), pendingReqID)
+	pa, err := h.st.GetPendingApproval(r.Context(), pendingReqID, userID)
 	if err != nil || pa.UserID != userID {
 		h.logger.Warn("rejected oauth init with cross-user pending_request_id",
 			"caller_user_id", userID,
@@ -1337,7 +1337,7 @@ func (h *ServicesHandler) resolveIdentityAlias(
 
 // reactivatePendingRequest re-executes a pending request after service activation.
 func (h *ServicesHandler) reactivatePendingRequest(ctx context.Context, userID, requestID string) {
-	pa, err := h.st.GetPendingApproval(ctx, requestID)
+	pa, err := h.st.GetPendingApproval(ctx, requestID, userID)
 	if err != nil {
 		h.logger.Warn("reactivate: pending approval not found", "request_id", requestID, "err", err)
 		return
@@ -1373,7 +1373,11 @@ func (h *ServicesHandler) reactivatePendingRequest(ctx context.Context, userID, 
 	}
 
 	_ = h.st.UpdateAuditOutcome(ctx, pa.AuditID, outcome, errMsg, 0)
-	_ = h.st.DeletePendingApproval(ctx, requestID)
+	paTask := ""
+	if pa.TaskID != nil {
+		paTask = *pa.TaskID
+	}
+	_ = h.st.DeletePendingApproval(ctx, requestID, userID, paTask)
 
 	if pa.CallbackURL != nil && *pa.CallbackURL != "" {
 		var cbResult *adapters.Result

--- a/internal/api/handlers/services_pending_hijack_test.go
+++ b/internal/api/handlers/services_pending_hijack_test.go
@@ -73,7 +73,7 @@ func TestReactivatePendingRequest_RejectsCrossUserHijack(t *testing.T) {
 	// but victim's request_id. Must be a no-op.
 	h.reactivatePendingRequest(ctx, attacker.ID, "req-victim-1")
 
-	got, err := st.GetPendingApproval(ctx, "req-victim-1")
+	got, err := st.GetPendingApproval(ctx, "req-victim-1", victim.ID)
 	if err != nil {
 		t.Fatalf("victim's pending approval was deleted by cross-user reactivation: %v", err)
 	}

--- a/internal/api/request_approval_promotion_test.go
+++ b/internal/api/request_approval_promotion_test.go
@@ -56,7 +56,7 @@ func TestRequestApprovalAllowSessionPromotesToActiveTask(t *testing.T) {
 		t.Fatal("expected promoted task scope to auto-execute")
 	}
 
-	rec, err := env.Store.GetApprovalRecordByRequestID(context.Background(), reqID)
+	rec, err := env.Store.GetApprovalRecordByRequestID(context.Background(), reqID, sc.session.UserID)
 	if err != nil {
 		t.Fatalf("GetApprovalRecordByRequestID: %v", err)
 	}
@@ -108,7 +108,7 @@ func TestRequestApprovalAllowAlwaysPromotesToStandingTask(t *testing.T) {
 		t.Fatalf("expected no expiry for standing promoted task, got %v", promotedTask.ExpiresAt)
 	}
 
-	rec, err := env.Store.GetApprovalRecordByRequestID(context.Background(), reqID)
+	rec, err := env.Store.GetApprovalRecordByRequestID(context.Background(), reqID, sc.session.UserID)
 	if err != nil {
 		t.Fatalf("GetApprovalRecordByRequestID: %v", err)
 	}
@@ -139,7 +139,7 @@ func TestRequestApprovalDefaultRemainsAllowOnce(t *testing.T) {
 		t.Fatalf("expected no promoted task for allow_once, got %v", body["task_id"])
 	}
 
-	rec, err := env.Store.GetApprovalRecordByRequestID(context.Background(), reqID)
+	rec, err := env.Store.GetApprovalRecordByRequestID(context.Background(), reqID, sc.session.UserID)
 	if err != nil {
 		t.Fatalf("GetApprovalRecordByRequestID: %v", err)
 	}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1088,10 +1088,15 @@ func (s *Server) consumeNotifierDecisions(ctx context.Context, ch <-chan notify.
 			var err error
 			switch d.Type {
 			case "approval":
+				// d.TaskID disambiguates sibling pending approvals that share
+				// request_id under symmetric dedup. Telegram callback tokens
+				// carry it through; older clients leave it empty, in which
+				// case the handlers fall back to the request_id-only lookup
+				// and surface ErrAmbiguous if more than one row matches.
 				if d.Action == "approve" {
-					err = s.approvalsHandler.ApproveByRequestID(ctx, d.TargetID, d.UserID)
+					err = s.approvalsHandler.ApproveByRequestID(ctx, d.TargetID, d.UserID, d.TaskID)
 				} else {
-					err = s.approvalsHandler.DenyByRequestID(ctx, d.TargetID, d.UserID)
+					err = s.approvalsHandler.DenyByRequestID(ctx, d.TargetID, d.UserID, d.TaskID)
 				}
 			case "task":
 				if d.Action == "approve" {

--- a/internal/api/testutil_test.go
+++ b/internal/api/testutil_test.go
@@ -43,6 +43,14 @@ func newTestEnv(t *testing.T, extra ...adapters.Adapter) *testEnv {
 }
 
 func newTestEnvWithLLM(t *testing.T, llmCfg config.LLMConfig, extra ...adapters.Adapter) *testEnv {
+	return newTestEnvWithLLMAndVaultWrapper(t, llmCfg, nil, extra...)
+}
+
+func newTestEnvWithVaultWrapper(t *testing.T, wrapVault func(vault.Vault) vault.Vault, extra ...adapters.Adapter) *testEnv {
+	return newTestEnvWithLLMAndVaultWrapper(t, config.LLMConfig{}, wrapVault, extra...)
+}
+
+func newTestEnvWithLLMAndVaultWrapper(t *testing.T, llmCfg config.LLMConfig, wrapVault func(vault.Vault) vault.Vault, extra ...adapters.Adapter) *testEnv {
 	t.Helper()
 
 	ctx := context.Background()
@@ -55,9 +63,13 @@ func newTestEnvWithLLM(t *testing.T, llmCfg config.LLMConfig, extra ...adapters.
 	st := sqlitestore.NewStore(db)
 
 	// LocalVault with auto-generated key
-	v, err := intvault.NewLocalVault(t.TempDir()+"/vault.key", db, "sqlite")
+	localVault, err := intvault.NewLocalVault(t.TempDir()+"/vault.key", db, "sqlite")
 	if err != nil {
 		t.Fatalf("vault: %v", err)
+	}
+	var v vault.Vault = localVault
+	if wrapVault != nil {
+		v = wrapVault(v)
 	}
 
 	jwtSvc, err := auth.NewJWTService("test-secret-for-integration-tests")

--- a/internal/api/testutil_test.go
+++ b/internal/api/testutil_test.go
@@ -9,18 +9,19 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"golang.org/x/oauth2"
 
 	"github.com/clawvisor/clawvisor/internal/api"
 	"github.com/clawvisor/clawvisor/internal/auth"
-	sqlitestore "github.com/clawvisor/clawvisor/pkg/store/sqlite"
-	intvault "github.com/clawvisor/clawvisor/pkg/vault"
 	"github.com/clawvisor/clawvisor/pkg/adapters"
 	"github.com/clawvisor/clawvisor/pkg/config"
 	"github.com/clawvisor/clawvisor/pkg/store"
+	sqlitestore "github.com/clawvisor/clawvisor/pkg/store/sqlite"
 	"github.com/clawvisor/clawvisor/pkg/vault"
+	intvault "github.com/clawvisor/clawvisor/pkg/vault"
 )
 
 // ── Test environment ──────────────────────────────────────────────────────────
@@ -350,6 +351,8 @@ type mockAdapter struct {
 	actions   []string
 	result    *adapters.Result
 	execErr   error
+	calls     int64
+	onExecute func()
 }
 
 func newMockAdapter(serviceID string, actions ...string) *mockAdapter {
@@ -366,10 +369,23 @@ func (m *mockAdapter) withError(err error) *mockAdapter {
 	return m
 }
 
+func (m *mockAdapter) withExecuteHook(fn func()) *mockAdapter {
+	m.onExecute = fn
+	return m
+}
+
+func (m *mockAdapter) executeCount() int {
+	return int(atomic.LoadInt64(&m.calls))
+}
+
 func (m *mockAdapter) ServiceID() string          { return m.serviceID }
 func (m *mockAdapter) SupportedActions() []string { return m.actions }
 
 func (m *mockAdapter) Execute(_ context.Context, _ adapters.Request) (*adapters.Result, error) {
+	atomic.AddInt64(&m.calls, 1)
+	if m.onExecute != nil {
+		m.onExecute()
+	}
 	return m.result, m.execErr
 }
 

--- a/internal/events/longpoll.go
+++ b/internal/events/longpoll.go
@@ -35,13 +35,14 @@ func WaitFor[T any](
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()
 
-	// Periodic poll: catches transitions even if a publish lands between
-	// our Subscribe and the producer's Publish, or if the hub drops the
-	// event under contention (non-blocking Publish skips full buffers).
-	// Without this, a tightly-racing producer can resolve the state we
-	// care about and we'd wait until timeout for an event that's already
-	// gone.
-	poll := time.NewTicker(100 * time.Millisecond)
+	// Periodic poll: safety net for events the hub drops under buffer
+	// overflow (Publish skips full per-subscriber buffers). The
+	// initial-fetch above already covers publishes that landed between
+	// the caller's last check and our Subscribe call, so this only fires
+	// for the rare drop case. One second balances responsiveness against
+	// load (one fetch/sec per waiter) — under normal conditions
+	// nothing waits long enough for it to fire at all.
+	poll := time.NewTicker(1 * time.Second)
 	defer poll.Stop()
 
 	for {

--- a/internal/events/longpoll.go
+++ b/internal/events/longpoll.go
@@ -23,8 +23,26 @@ func WaitFor[T any](
 	ch, unsub := hub.Subscribe(userID)
 	defer unsub()
 
+	// Initial fetch after subscribe: if the state we're waiting on already
+	// resolved between the caller's last check and our Subscribe call, we'd
+	// otherwise block until timeout for an event that never arrives. The
+	// subscribe-then-check-then-wait order ensures any post-subscribe event
+	// still wakes us via ch even if the pre-subscribe one is missed.
+	if v, done := fetch(ctx); done {
+		return v
+	}
+
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()
+
+	// Periodic poll: catches transitions even if a publish lands between
+	// our Subscribe and the producer's Publish, or if the hub drops the
+	// event under contention (non-blocking Publish skips full buffers).
+	// Without this, a tightly-racing producer can resolve the state we
+	// care about and we'd wait until timeout for an event that's already
+	// gone.
+	poll := time.NewTicker(100 * time.Millisecond)
+	defer poll.Stop()
 
 	for {
 		select {
@@ -34,6 +52,10 @@ func WaitFor[T any](
 		case <-timer.C:
 			v, _ := fetch(context.Background())
 			return v
+		case <-poll.C:
+			if v, done := fetch(ctx); done {
+				return v
+			}
 		case evt, ok := <-ch:
 			if !ok {
 				v, _ := fetch(context.Background())

--- a/internal/notify/telegram/polling.go
+++ b/internal/notify/telegram/polling.go
@@ -348,6 +348,7 @@ func (n *Notifier) handleCallbackQuery(ctx context.Context, ps *pollingSession, 
 		Type:     entry.Type,
 		Action:   action,
 		TargetID: entry.TargetID,
+		TaskID:   entry.TaskID,
 		UserID:   entry.UserID,
 	}
 	select {

--- a/internal/notify/telegram/telegram.go
+++ b/internal/notify/telegram/telegram.go
@@ -337,7 +337,7 @@ func (n *Notifier) SendApprovalRequest(ctx context.Context, req notify.ApprovalR
 	text := formatApprovalMessage(req)
 
 	// Generate callback tokens for inline buttons.
-	approveID, denyID, tokenErr := n.cbTokens.Generate("approval", req.RequestID, req.UserID, chatID, 6*time.Minute)
+	approveID, denyID, tokenErr := n.cbTokens.Generate("approval", req.RequestID, req.UserID, req.TaskID, chatID, 6*time.Minute)
 	var keyboard any
 	if tokenErr == nil {
 		keyboard = inlineKeyboard([][]inlineButton{{
@@ -398,7 +398,7 @@ func (n *Notifier) SendTaskApprovalRequest(ctx context.Context, req notify.TaskA
 
 	text := formatTaskApprovalMessage(req)
 
-	approveID, denyID, tokenErr := n.cbTokens.Generate("task", req.TaskID, req.UserID, chatID, 6*time.Minute)
+	approveID, denyID, tokenErr := n.cbTokens.Generate("task", req.TaskID, req.UserID, "", chatID, 6*time.Minute)
 	var keyboard any
 	if tokenErr == nil {
 		keyboard = inlineKeyboard([][]inlineButton{{
@@ -432,7 +432,7 @@ func (n *Notifier) SendScopeExpansionRequest(ctx context.Context, req notify.Sco
 
 	text := formatScopeExpansionMessage(req)
 
-	approveID, denyID, tokenErr := n.cbTokens.Generate("scope_expansion", req.TaskID, req.UserID, chatID, 6*time.Minute)
+	approveID, denyID, tokenErr := n.cbTokens.Generate("scope_expansion", req.TaskID, req.UserID, "", chatID, 6*time.Minute)
 	var keyboard any
 	if tokenErr == nil {
 		keyboard = inlineKeyboard([][]inlineButton{{
@@ -474,7 +474,7 @@ func (n *Notifier) SendConnectionRequest(ctx context.Context, req notify.Connect
 
 	text := formatConnectionRequestMessage(req)
 
-	approveID, denyID, tokenErr := n.cbTokens.Generate("connection", req.ConnectionID, req.UserID, chatID, 6*time.Minute)
+	approveID, denyID, tokenErr := n.cbTokens.Generate("connection", req.ConnectionID, req.UserID, "", chatID, 6*time.Minute)
 	var keyboard any
 	if tokenErr == nil {
 		keyboard = inlineKeyboard([][]inlineButton{{

--- a/internal/notify/telegram/telegram_test.go
+++ b/internal/notify/telegram/telegram_test.go
@@ -149,9 +149,13 @@ func TestCallbackTokenStore_TaskIDRoundTrips(t *testing.T) {
 		t.Fatalf("Consume(denyB): TaskID=%q TargetID=%q, want task-B/req-X", gotB.TaskID, gotB.TargetID)
 	}
 
-	// Sibling token for the same target (denyA) must still be consumable —
-	// the share-state-across-pair behavior is keyed on TargetID, not TaskID,
-	// so siblings under different tasks are independent.
+	// Pair-state is shared per (approve, deny) entry: consuming approveA
+	// must invalidate denyA, and consuming denyB must invalidate approveB
+	// (so a user can't both approve and deny the same target). Cross-task
+	// siblings remain independent because they were minted from separate
+	// Generate calls — approveA / denyA carry task-A's entry, approveB /
+	// denyB carry task-B's, and consuming any one of the four does NOT
+	// touch the other task's pair.
 	if _, err := s.Consume(denyA); err != errTokenUsed {
 		t.Fatalf("Consume(denyA after approveA): want errTokenUsed, got %v", err)
 	}

--- a/internal/notify/telegram/telegram_test.go
+++ b/internal/notify/telegram/telegram_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	sqlitestore "github.com/clawvisor/clawvisor/pkg/store/sqlite"
 	"github.com/clawvisor/clawvisor/pkg/notify"
@@ -106,5 +107,55 @@ func notifyConnectionRequest(userID string) notify.ConnectionRequest {
 		IPAddress:    "127.0.0.1:4321",
 		ApproveURL:   "http://example.com/approve",
 		DenyURL:      "http://example.com/deny",
+	}
+}
+
+// TestCallbackTokenStore_TaskIDRoundTrips guards the symmetric-dedup
+// disambiguator for Telegram inline buttons: Generate must persist the
+// taskID alongside (type, target_id) and Consume must surface it on the
+// returned entry so the decision consumer can route to the correct sibling
+// pending approval. Without this, two pending approvals sharing a
+// request_id across tasks would emit indistinguishable CallbackDecisions
+// and the resolver would hit ErrAmbiguous.
+func TestCallbackTokenStore_TaskIDRoundTrips(t *testing.T) {
+	t.Parallel()
+	s := newCallbackTokenStore()
+
+	approveA, denyA, err := s.Generate("approval", "req-X", "user-1", "task-A", "chat-1", time.Minute)
+	if err != nil {
+		t.Fatalf("Generate(task-A): %v", err)
+	}
+	approveB, denyB, err := s.Generate("approval", "req-X", "user-1", "task-B", "chat-1", time.Minute)
+	if err != nil {
+		t.Fatalf("Generate(task-B): %v", err)
+	}
+	if approveA == approveB || denyA == denyB {
+		t.Fatalf("Generate must mint unique tokens per sibling, got dup")
+	}
+
+	gotA, err := s.Consume(approveA)
+	if err != nil {
+		t.Fatalf("Consume(approveA): %v", err)
+	}
+	if gotA.TaskID != "task-A" || gotA.TargetID != "req-X" {
+		t.Fatalf("Consume(approveA): TaskID=%q TargetID=%q, want task-A/req-X", gotA.TaskID, gotA.TargetID)
+	}
+
+	gotB, err := s.Consume(denyB)
+	if err != nil {
+		t.Fatalf("Consume(denyB): %v", err)
+	}
+	if gotB.TaskID != "task-B" || gotB.TargetID != "req-X" {
+		t.Fatalf("Consume(denyB): TaskID=%q TargetID=%q, want task-B/req-X", gotB.TaskID, gotB.TargetID)
+	}
+
+	// Sibling token for the same target (denyA) must still be consumable —
+	// the share-state-across-pair behavior is keyed on TargetID, not TaskID,
+	// so siblings under different tasks are independent.
+	if _, err := s.Consume(denyA); err != errTokenUsed {
+		t.Fatalf("Consume(denyA after approveA): want errTokenUsed, got %v", err)
+	}
+	if _, err := s.Consume(approveB); err != errTokenUsed {
+		t.Fatalf("Consume(approveB after denyB): want errTokenUsed, got %v", err)
 	}
 }

--- a/internal/notify/telegram/tokens.go
+++ b/internal/notify/telegram/tokens.go
@@ -16,8 +16,11 @@ var (
 
 // callbackEntry is one pair of approve/deny tokens for a single target.
 type callbackEntry struct {
-	Type      string // "approval", "task", "scope_expansion", "connection"
-	TargetID  string
+	Type     string // "approval", "task", "scope_expansion", "connection"
+	TargetID string
+	// TaskID is the symmetric-dedup disambiguator for Type=="approval".
+	// Empty for the pre-task scope and for non-approval entry types.
+	TaskID    string
 	UserID    string
 	ChatID    string
 	ExpiresAt time.Time
@@ -43,7 +46,7 @@ func newCallbackTokenStore() *callbackTokenStore {
 
 // Generate creates approve and deny tokens for a target.
 // Returns (approveShortID, denyShortID, error).
-func (s *callbackTokenStore) Generate(entryType, targetID, userID, chatID string, ttl time.Duration) (string, string, error) {
+func (s *callbackTokenStore) Generate(entryType, targetID, userID, taskID, chatID string, ttl time.Duration) (string, string, error) {
 	approveID, err := randomShortID()
 	if err != nil {
 		return "", "", err
@@ -56,6 +59,7 @@ func (s *callbackTokenStore) Generate(entryType, targetID, userID, chatID string
 	entry := &callbackEntry{
 		Type:      entryType,
 		TargetID:  targetID,
+		TaskID:    taskID,
 		UserID:    userID,
 		ChatID:    chatID,
 		ExpiresAt: time.Now().Add(ttl),

--- a/internal/notify/telegram/tokens_iface.go
+++ b/internal/notify/telegram/tokens_iface.go
@@ -4,8 +4,13 @@ import "time"
 
 // CallbackTokenStorer abstracts storage of Telegram inline callback tokens
 // so it can be backed by either in-memory state or Redis.
+//
+// taskID is the symmetric-dedup disambiguator for entryType=="approval".
+// It is stored alongside the entry and surfaced via Consume so the consumer
+// can route to the right pending row. Empty for all other entry types and
+// for pre-task approvals.
 type CallbackTokenStorer interface {
-	Generate(entryType, targetID, userID, chatID string, ttl time.Duration) (approveID, denyID string, err error)
+	Generate(entryType, targetID, userID, taskID, chatID string, ttl time.Duration) (approveID, denyID string, err error)
 	Consume(shortID string) (*callbackEntry, error)
 	Cleanup()
 }

--- a/internal/notify/telegram/tokens_redis.go
+++ b/internal/notify/telegram/tokens_redis.go
@@ -15,12 +15,13 @@ const redisCBTokenPrefix = "clawvisor:tgcb:"
 
 // callbackEntryJSON is the JSON form for Redis storage.
 type callbackEntryJSON struct {
-	Type       string `json:"type"`
-	TargetID   string `json:"target_id"`
-	UserID     string `json:"user_id"`
-	ChatID     string `json:"chat_id"`
-	ExpiresAt  int64  `json:"expires_at"`
-	SiblingID  string `json:"sibling_id"`
+	Type      string `json:"type"`
+	TargetID  string `json:"target_id"`
+	TaskID    string `json:"task_id,omitempty"`
+	UserID    string `json:"user_id"`
+	ChatID    string `json:"chat_id"`
+	ExpiresAt int64  `json:"expires_at"`
+	SiblingID string `json:"sibling_id"`
 }
 
 // redisCallbackTokenStore stores Telegram callback tokens in Redis for
@@ -34,7 +35,7 @@ func NewRedisCallbackTokenStore(rdb *redis.Client) CallbackTokenStorer {
 	return &redisCallbackTokenStore{rdb: rdb}
 }
 
-func (s *redisCallbackTokenStore) Generate(entryType, targetID, userID, chatID string, ttl time.Duration) (string, string, error) {
+func (s *redisCallbackTokenStore) Generate(entryType, targetID, userID, taskID, chatID string, ttl time.Duration) (string, string, error) {
 	approveID, err := redisRandomShortID()
 	if err != nil {
 		return "", "", err
@@ -49,6 +50,7 @@ func (s *redisCallbackTokenStore) Generate(entryType, targetID, userID, chatID s
 	approveData, err := json.Marshal(callbackEntryJSON{
 		Type:      entryType,
 		TargetID:  targetID,
+		TaskID:    taskID,
 		UserID:    userID,
 		ChatID:    chatID,
 		ExpiresAt: expiresAt,
@@ -60,6 +62,7 @@ func (s *redisCallbackTokenStore) Generate(entryType, targetID, userID, chatID s
 	denyData, err := json.Marshal(callbackEntryJSON{
 		Type:      entryType,
 		TargetID:  targetID,
+		TaskID:    taskID,
 		UserID:    userID,
 		ChatID:    chatID,
 		ExpiresAt: expiresAt,
@@ -112,6 +115,7 @@ func (s *redisCallbackTokenStore) Consume(shortID string) (*callbackEntry, error
 	return &callbackEntry{
 		Type:      j.Type,
 		TargetID:  j.TargetID,
+		TaskID:    j.TaskID,
 		UserID:    j.UserID,
 		ChatID:    j.ChatID,
 		ExpiresAt: time.UnixMilli(j.ExpiresAt),

--- a/pkg/notify/notify.go
+++ b/pkg/notify/notify.go
@@ -22,8 +22,13 @@ type Notifier interface {
 
 // ApprovalRequest carries the data needed to ask the user to approve or deny a gateway request.
 type ApprovalRequest struct {
-	PendingID    string
-	RequestID    string
+	PendingID string
+	RequestID string
+	// TaskID disambiguates sibling pending approvals that share a request_id
+	// under symmetric dedup. Empty for pre-task approvals. Notifiers MUST
+	// propagate this onto the CallbackDecision they emit so the resolver
+	// hits the right pending row.
+	TaskID       string
 	UserID       string
 	AgentName    string
 	Service      string
@@ -128,7 +133,11 @@ type CallbackDecision struct {
 	Type     string // "approval", "task", "scope_expansion", "connection"
 	Action   string // "approve" or "deny"
 	TargetID string
-	UserID   string
+	// TaskID disambiguates a Type=="approval" decision when two pending
+	// approvals share request_id under symmetric dedup. Empty for the
+	// pre-task scope and for non-"approval" decision types.
+	TaskID string
+	UserID string
 }
 
 // PollingDecrementer is implemented by notifiers that run callback polling

--- a/pkg/runtime/proxy/placeholder_runtime.go
+++ b/pkg/runtime/proxy/placeholder_runtime.go
@@ -316,7 +316,7 @@ func credentialReference(value string) string {
 
 func ensureRuntimeCredentialReview(ctx context.Context, st store.Store, session *store.RuntimeSession, host, headerName string, detection *headerCredentialDetection) (*store.ApprovalRecord, error) {
 	requestID := runtimeCredentialReviewRequestID(session.ID, host, headerName, detection)
-	rec, err := st.GetApprovalRecordByRequestID(ctx, requestID)
+	rec, err := st.GetApprovalRecordByRequestID(ctx, requestID, session.UserID)
 	if err == nil {
 		return rec, nil
 	}

--- a/pkg/runtime/proxy/policy_hook.go
+++ b/pkg/runtime/proxy/policy_hook.go
@@ -578,7 +578,7 @@ func loadOrCreatePendingRuntimeApproval(ctx context.Context, st store.Store, dra
 	if draft == nil || draft.RequestID == nil || strings.TrimSpace(*draft.RequestID) == "" {
 		return nil, store.ErrNotFound
 	}
-	rec, err := st.GetApprovalRecordByRequestID(ctx, *draft.RequestID)
+	rec, err := st.GetApprovalRecordByRequestID(ctx, *draft.RequestID, draft.UserID)
 	switch {
 	case err == nil && rec != nil && rec.Status == "pending":
 		return rec, nil

--- a/pkg/runtime/proxy/policy_hook_test.go
+++ b/pkg/runtime/proxy/policy_hook_test.go
@@ -781,6 +781,7 @@ func TestRuntimeProxyDeterministicMatchBeatsLeaseBias(t *testing.T) {
 
 type runtimeTestSession struct {
 	id     string
+	userID string
 	secret string
 }
 
@@ -799,7 +800,7 @@ func createRuntimeSession(t *testing.T, st store.Store, sessionID, userID, agent
 	if err := st.CreateRuntimeSession(context.Background(), sess); err != nil {
 		t.Fatalf("CreateRuntimeSession: %v", err)
 	}
-	return runtimeTestSession{id: sessionID, secret: secret}
+	return runtimeTestSession{id: sessionID, userID: userID, secret: secret}
 }
 
 func seedRuntimePrincipal(t *testing.T, st store.Store) (string, string) {

--- a/pkg/runtime/proxy/tooluse_runtime.go
+++ b/pkg/runtime/proxy/tooluse_runtime.go
@@ -683,18 +683,17 @@ func (s *Server) ensureHeldToolUseApproval(ctx context.Context, hooks ToolUseHoo
 
 func (s *Server) ensureHeldToolUseApprovalWithKind(ctx context.Context, hooks ToolUseHooks, session *store.RuntimeSession, reviewTask *store.Task, tu conversation.ToolUse, input map[string]any, approvalKind string, judgment runtimepolicy.RuntimeContextJudgment, reason string) (*store.ApprovalRecord, *review.HeldApproval, string) {
 	requestID := "runtime-tooluse:" + session.ID + ":" + tu.ID
-	// Under the symmetric (user, request_id, task_id) dedup scope a
-	// reviewTask scopes the lookup: we want THIS task's record, not a
-	// sibling task's. Without reviewTask we accept the pre-task scope.
-	// GetApprovalRecordByRequestID would return ErrAmbiguous (or the wrong
-	// row) once two task-scoped records share a request_id.
-	var rec *store.ApprovalRecord
-	var err error
+	// Always scope the lookup to a concrete task bucket so symmetric-dedup
+	// siblings can't return ErrAmbiguous. With reviewTask set we want THIS
+	// task's record; without it we want the pre-task scope (task_id IS NULL)
+	// — explicitly NOT a sibling task's row. GetApprovalRecordByRequestID
+	// (no task scope) would surface ErrAmbiguous once two task-scoped
+	// records share a request_id, blocking the legitimate pre-task path.
+	lookupTaskID := ""
 	if reviewTask != nil {
-		rec, err = hooks.Store.GetApprovalRecordByRequestIDAndTask(ctx, requestID, session.UserID, reviewTask.ID)
-	} else {
-		rec, err = hooks.Store.GetApprovalRecordByRequestID(ctx, requestID, session.UserID)
+		lookupTaskID = reviewTask.ID
 	}
+	rec, err := hooks.Store.GetApprovalRecordByRequestIDAndTask(ctx, requestID, session.UserID, lookupTaskID)
 	if err != nil && err != store.ErrNotFound {
 		return nil, nil, "Clawvisor could not create the runtime approval needed for this tool call."
 	}

--- a/pkg/runtime/proxy/tooluse_runtime.go
+++ b/pkg/runtime/proxy/tooluse_runtime.go
@@ -683,7 +683,18 @@ func (s *Server) ensureHeldToolUseApproval(ctx context.Context, hooks ToolUseHoo
 
 func (s *Server) ensureHeldToolUseApprovalWithKind(ctx context.Context, hooks ToolUseHooks, session *store.RuntimeSession, reviewTask *store.Task, tu conversation.ToolUse, input map[string]any, approvalKind string, judgment runtimepolicy.RuntimeContextJudgment, reason string) (*store.ApprovalRecord, *review.HeldApproval, string) {
 	requestID := "runtime-tooluse:" + session.ID + ":" + tu.ID
-	rec, err := hooks.Store.GetApprovalRecordByRequestID(ctx, requestID, session.UserID)
+	// Under the symmetric (user, request_id, task_id) dedup scope a
+	// reviewTask scopes the lookup: we want THIS task's record, not a
+	// sibling task's. Without reviewTask we accept the pre-task scope.
+	// GetApprovalRecordByRequestID would return ErrAmbiguous (or the wrong
+	// row) once two task-scoped records share a request_id.
+	var rec *store.ApprovalRecord
+	var err error
+	if reviewTask != nil {
+		rec, err = hooks.Store.GetApprovalRecordByRequestIDAndTask(ctx, requestID, session.UserID, reviewTask.ID)
+	} else {
+		rec, err = hooks.Store.GetApprovalRecordByRequestID(ctx, requestID, session.UserID)
+	}
 	if err != nil && err != store.ErrNotFound {
 		return nil, nil, "Clawvisor could not create the runtime approval needed for this tool call."
 	}

--- a/pkg/runtime/proxy/tooluse_runtime.go
+++ b/pkg/runtime/proxy/tooluse_runtime.go
@@ -683,7 +683,7 @@ func (s *Server) ensureHeldToolUseApproval(ctx context.Context, hooks ToolUseHoo
 
 func (s *Server) ensureHeldToolUseApprovalWithKind(ctx context.Context, hooks ToolUseHooks, session *store.RuntimeSession, reviewTask *store.Task, tu conversation.ToolUse, input map[string]any, approvalKind string, judgment runtimepolicy.RuntimeContextJudgment, reason string) (*store.ApprovalRecord, *review.HeldApproval, string) {
 	requestID := "runtime-tooluse:" + session.ID + ":" + tu.ID
-	rec, err := hooks.Store.GetApprovalRecordByRequestID(ctx, requestID)
+	rec, err := hooks.Store.GetApprovalRecordByRequestID(ctx, requestID, session.UserID)
 	if err != nil && err != store.ErrNotFound {
 		return nil, nil, "Clawvisor could not create the runtime approval needed for this tool call."
 	}

--- a/pkg/runtime/proxy/tooluse_runtime_test.go
+++ b/pkg/runtime/proxy/tooluse_runtime_test.go
@@ -12,12 +12,12 @@ import (
 	"time"
 
 	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
-	"github.com/clawvisor/clawvisor/pkg/runtime/leases"
 	runtimepolicy "github.com/clawvisor/clawvisor/internal/runtime/policy"
-	"github.com/clawvisor/clawvisor/pkg/runtime/review"
-	"github.com/clawvisor/clawvisor/pkg/store/sqlite"
 	"github.com/clawvisor/clawvisor/pkg/config"
+	"github.com/clawvisor/clawvisor/pkg/runtime/leases"
+	"github.com/clawvisor/clawvisor/pkg/runtime/review"
 	"github.com/clawvisor/clawvisor/pkg/store"
+	"github.com/clawvisor/clawvisor/pkg/store/sqlite"
 	"github.com/elazarl/goproxy"
 )
 
@@ -926,6 +926,82 @@ func TestStreamToolUseBlockRewritesBlockedOpenAIChatSSE(t *testing.T) {
 	}
 	if rec.ResolutionTransport != "release_held_tool_use" {
 		t.Fatalf("expected held approval transport, got %+v", rec)
+	}
+}
+
+func TestEnsureHeldToolUseApproval_PreTaskLookupIgnoresTaskScopedSiblings(t *testing.T) {
+	ctx := context.Background()
+	db, err := sqlite.New(ctx, t.TempDir()+"/tooluse-pre-task.db")
+	if err != nil {
+		t.Fatalf("sqlite.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	st := sqlite.NewStore(db)
+	userID, agentID := seedRuntimePrincipal(t, st)
+
+	session := createRuntimeSession(t, st, "runtime-pre-task-session", userID, agentID, false)
+	runtimeSession, err := st.GetRuntimeSession(ctx, session.id)
+	if err != nil {
+		t.Fatalf("GetRuntimeSession: %v", err)
+	}
+
+	requestID := "runtime-tooluse:" + session.id + ":call_shared"
+	sessionID := session.id
+	for _, taskID := range []string{"task-sibling-a", "task-sibling-b"} {
+		task := &store.Task{
+			ID:               taskID,
+			UserID:           userID,
+			AgentID:          agentID,
+			Purpose:          "Sibling " + taskID,
+			Status:           "active",
+			Lifetime:         "session",
+			SchemaVersion:    2,
+			ExpiresInSeconds: 3600,
+		}
+		if err := st.CreateTask(ctx, task); err != nil {
+			t.Fatalf("CreateTask(%s): %v", taskID, err)
+		}
+		taskIDCopy := taskID
+		if err := st.CreateApprovalRecord(ctx, &store.ApprovalRecord{
+			ID:                  "approval-" + taskID,
+			Kind:                "task_call_review",
+			UserID:              userID,
+			AgentID:             &agentID,
+			RequestID:           &requestID,
+			TaskID:              &taskIDCopy,
+			SessionID:           &sessionID,
+			Status:              "pending",
+			Surface:             "inline",
+			SummaryJSON:         json.RawMessage(`{}`),
+			PayloadJSON:         json.RawMessage(`{}`),
+			ResolutionTransport: "release_held_tool_use",
+		}); err != nil {
+			t.Fatalf("CreateApprovalRecord(%s): %v", taskID, err)
+		}
+	}
+
+	srv, err := NewServer(Config{DataDir: t.TempDir(), Addr: "127.0.0.1:0"}, nil)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	hooks := ToolUseHooks{
+		Store:       st,
+		Config:      config.Default(),
+		ReviewCache: review.NewApprovalCache(),
+		Leases:      leases.Service{Store: st},
+	}
+	rec, held, substitute := srv.ensureHeldToolUseApproval(ctx, hooks, runtimeSession, nil, conversationToolUse("call_shared", "Read"), map[string]any{"file_path": "/tmp/demo.txt"})
+	if rec == nil {
+		t.Fatalf("expected pre-task approval record despite task-scoped siblings, got nil with substitute %q", substitute)
+	}
+	if rec.TaskID != nil {
+		t.Fatalf("expected a pre-task approval record, got task_id=%q", *rec.TaskID)
+	}
+	if held == nil {
+		t.Fatal("expected held approval for pre-task record")
+	}
+	if !strings.Contains(substitute, "Clawvisor paused:") {
+		t.Fatalf("expected held approval prompt, got %q", substitute)
 	}
 }
 

--- a/pkg/runtime/proxy/tooluse_runtime_test.go
+++ b/pkg/runtime/proxy/tooluse_runtime_test.go
@@ -776,7 +776,7 @@ func TestStreamToolUseBlockRewritesBlockedAnthropicSSE(t *testing.T) {
 	if !strings.Contains(string(body), "Clawvisor paused:") {
 		t.Fatalf("expected blocked Anthropc SSE to contain approval prompt, got %s", string(body))
 	}
-	rec, err := st.GetApprovalRecordByRequestID(ctx, "runtime-tooluse:"+session.id+":toolu_1")
+	rec, err := st.GetApprovalRecordByRequestID(ctx, "runtime-tooluse:"+session.id+":toolu_1", session.userID)
 	if err != nil {
 		t.Fatalf("GetApprovalRecordByRequestID: %v", err)
 	}
@@ -848,7 +848,7 @@ func TestStreamToolUseBlockRewritesBlockedOpenAISSE(t *testing.T) {
 	if !strings.Contains(string(body), "Clawvisor paused:") {
 		t.Fatalf("expected blocked OpenAI SSE to contain approval prompt, got %s", string(body))
 	}
-	rec, err := st.GetApprovalRecordByRequestID(ctx, "runtime-tooluse:"+session.id+":call_1")
+	rec, err := st.GetApprovalRecordByRequestID(ctx, "runtime-tooluse:"+session.id+":call_1", session.userID)
 	if err != nil {
 		t.Fatalf("GetApprovalRecordByRequestID: %v", err)
 	}
@@ -920,7 +920,7 @@ func TestStreamToolUseBlockRewritesBlockedOpenAIChatSSE(t *testing.T) {
 	if !strings.Contains(string(body), "Clawvisor paused:") {
 		t.Fatalf("expected blocked OpenAI chat SSE to contain approval prompt, got %s", string(body))
 	}
-	rec, err := st.GetApprovalRecordByRequestID(ctx, "runtime-tooluse:"+session.id+":call_2")
+	rec, err := st.GetApprovalRecordByRequestID(ctx, "runtime-tooluse:"+session.id+":call_2", session.userID)
 	if err != nil {
 		t.Fatalf("GetApprovalRecordByRequestID: %v", err)
 	}

--- a/pkg/store/postgres/migrations/042_symmetric_dedup_scope.sql
+++ b/pkg/store/postgres/migrations/042_symmetric_dedup_scope.sql
@@ -47,3 +47,17 @@ DROP INDEX idx_approval_records_request_id;
 CREATE UNIQUE INDEX idx_approval_records_request_id
     ON approval_records(user_id, request_id, COALESCE(task_id, ''))
     WHERE request_id IS NOT NULL AND request_id != '';
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 4. notification_messages: backfill the composed target_id for in-flight
+--    approval rows so post-migration resolve handlers can still address the
+--    Telegram message. See the sqlite mirror for the full rationale.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+UPDATE notification_messages nm
+SET target_id = nm.target_id || '|' || pa.task_id
+FROM pending_approvals pa
+WHERE nm.target_type = 'approval'
+  AND nm.target_id = pa.request_id
+  AND pa.task_id IS NOT NULL
+  AND pa.task_id != '';

--- a/pkg/store/postgres/migrations/042_symmetric_dedup_scope.sql
+++ b/pkg/store/postgres/migrations/042_symmetric_dedup_scope.sql
@@ -1,0 +1,49 @@
+-- See pkg/store/sqlite/migrations/042_symmetric_dedup_scope.sql for the full
+-- rationale. Summary: align audit_log, pending_approvals, and approval_records
+-- on the same (user_id, request_id, COALESCE(task_id, '')) dedup key.
+--
+-- Postgres doesn't need the inline-UNIQUE rebuild dance, so all three changes
+-- are direct DDL: ALTER ... DROP CONSTRAINT, ALTER ... ADD COLUMN, ALTER ...
+-- ADD ... USING / CREATE UNIQUE INDEX. The pending_approvals.task_id backfill
+-- joins audit_log on audit_id.
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 1. audit_log: drop the (request_id, user_id) UNIQUE, add deduped_of, add the
+--    canonical-dedup partial unique index. Same as PR #361's migration 042.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+ALTER TABLE audit_log DROP CONSTRAINT IF EXISTS audit_log_request_id_user_id_key;
+ALTER TABLE audit_log ADD COLUMN deduped_of TEXT;
+
+CREATE UNIQUE INDEX idx_audit_canonical_dedup
+    ON audit_log(user_id, request_id, COALESCE(task_id, ''))
+    WHERE deduped_of IS NULL;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 2. pending_approvals: drop UNIQUE(request_id), add task_id, backfill from
+--    audit_log via audit_id, create the composite unique index.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+ALTER TABLE pending_approvals DROP CONSTRAINT IF EXISTS pending_approvals_request_id_key;
+ALTER TABLE pending_approvals ADD COLUMN task_id TEXT;
+
+UPDATE pending_approvals pa
+SET task_id = al.task_id
+FROM audit_log al
+WHERE al.id = pa.audit_id
+  AND pa.task_id IS NULL;
+
+CREATE UNIQUE INDEX idx_pending_approvals_dedup
+    ON pending_approvals(user_id, request_id, COALESCE(task_id, ''));
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 3. approval_records: replace the request_id-only partial unique index with
+--    the composite (user_id, request_id, COALESCE(task_id,'')) version.
+--    task_id column already exists (migration 030).
+-- ─────────────────────────────────────────────────────────────────────────────
+
+DROP INDEX idx_approval_records_request_id;
+
+CREATE UNIQUE INDEX idx_approval_records_request_id
+    ON approval_records(user_id, request_id, COALESCE(task_id, ''))
+    WHERE request_id IS NOT NULL AND request_id != '';

--- a/pkg/store/postgres/store.go
+++ b/pkg/store/postgres/store.go
@@ -689,8 +689,8 @@ func (s *Store) LogAudit(ctx context.Context, e *store.AuditEntry) error {
 			intent_verdict, used_active_task_context, used_lease_bias, used_conv_judge_resolution,
 			would_block, would_review, would_prompt_inline,
 			safety_flagged, safety_reason, reason, data_origin, context_src,
-			duration_ms, filters_applied, verification, error_msg
-		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32,$33,$34,$35,$36)
+			duration_ms, filters_applied, verification, error_msg, deduped_of
+		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32,$33,$34,$35,$36,$37)
 	`, e.ID, e.UserID, e.AgentID, e.RequestID, e.TaskID, e.SessionID, e.ApprovalID, e.LeaseID,
 		e.ToolUseID, e.MatchedTaskID, e.LeaseTaskID, e.Timestamp,
 		e.Service, e.Action, []byte(paramsSafe), e.Decision, e.Outcome,
@@ -699,7 +699,10 @@ func (s *Store) LogAudit(ctx context.Context, e *store.AuditEntry) error {
 		e.WouldBlock, e.WouldReview, e.WouldPromptInline,
 		e.SafetyFlagged, e.SafetyReason, e.Reason,
 		e.DataOrigin, e.ContextSrc, e.DurationMS, nilIfEmpty(e.FiltersApplied),
-		nilIfEmpty(e.Verification), e.ErrorMsg)
+		nilIfEmpty(e.Verification), e.ErrorMsg, e.DedupedOf)
+	if err != nil && isDuplicate(err) {
+		return store.ErrConflict
+	}
 	return err
 }
 
@@ -714,19 +717,24 @@ func (s *Store) UpdateAuditOutcome(ctx context.Context, id, outcome, errMsg stri
 	return err
 }
 
-func (s *Store) GetAuditEntry(ctx context.Context, id, userID string) (*store.AuditEntry, error) {
+// auditColumns is the canonical SELECT list for audit_log rows in the postgres
+// store. Kept in sync with scanAuditRow; deduped_of trails so symmetric-dedup
+// callers (FindDedupCandidate, GetAuditEntryByRequestID) can filter on the
+// canonical partial-unique index.
+const auditColumns = `
+	id, user_id, agent_id, request_id, task_id, session_id, approval_id, lease_id,
+	tool_use_id, matched_task_id, lease_task_id, timestamp, service, action,
+	params_safe, decision, outcome, policy_id, rule_id, resolution_confidence,
+	intent_verdict, used_active_task_context, used_lease_bias, used_conv_judge_resolution,
+	would_block, would_review, would_prompt_inline,
+	safety_flagged, safety_reason, reason, data_origin, context_src,
+	duration_ms, filters_applied, verification, error_msg, deduped_of
+`
+
+func scanAuditRow(scan func(...any) error) (*store.AuditEntry, error) {
 	e := &store.AuditEntry{}
 	var paramsSafe, filtersApplied, verification []byte
-	err := s.pool.QueryRow(ctx, `
-		SELECT id, user_id, agent_id, request_id, task_id, session_id, approval_id, lease_id,
-		       tool_use_id, matched_task_id, lease_task_id, timestamp, service, action,
-		       params_safe, decision, outcome, policy_id, rule_id, resolution_confidence,
-		       intent_verdict, used_active_task_context, used_lease_bias, used_conv_judge_resolution,
-		       would_block, would_review, would_prompt_inline,
-		       safety_flagged, safety_reason, reason, data_origin, context_src,
-		       duration_ms, filters_applied, verification, error_msg
-		FROM audit_log WHERE id = $1 AND user_id = $2
-	`, id, userID).Scan(
+	err := scan(
 		&e.ID, &e.UserID, &e.AgentID, &e.RequestID, &e.TaskID, &e.SessionID, &e.ApprovalID, &e.LeaseID,
 		&e.ToolUseID, &e.MatchedTaskID, &e.LeaseTaskID, &e.Timestamp,
 		&e.Service, &e.Action, &paramsSafe, &e.Decision, &e.Outcome,
@@ -734,10 +742,8 @@ func (s *Store) GetAuditEntry(ctx context.Context, id, userID string) (*store.Au
 		&e.UsedActiveTaskContext, &e.UsedLeaseBias, &e.UsedConvJudgeResolution,
 		&e.WouldBlock, &e.WouldReview, &e.WouldPromptInline,
 		&e.SafetyFlagged, &e.SafetyReason, &e.Reason,
-		&e.DataOrigin, &e.ContextSrc, &e.DurationMS, &filtersApplied, &verification, &e.ErrorMsg)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, store.ErrNotFound
-	}
+		&e.DataOrigin, &e.ContextSrc, &e.DurationMS, &filtersApplied, &verification, &e.ErrorMsg, &e.DedupedOf,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -751,41 +757,79 @@ func (s *Store) GetAuditEntry(ctx context.Context, id, userID string) (*store.Au
 	return e, nil
 }
 
-func (s *Store) GetAuditEntryByRequestID(ctx context.Context, requestID, userID string) (*store.AuditEntry, error) {
-	e := &store.AuditEntry{}
-	var paramsSafe, filtersApplied, verification []byte
-	err := s.pool.QueryRow(ctx, `
-		SELECT id, user_id, agent_id, request_id, task_id, session_id, approval_id, lease_id,
-		       tool_use_id, matched_task_id, lease_task_id, timestamp, service, action,
-		       params_safe, decision, outcome, policy_id, rule_id, resolution_confidence,
-		       intent_verdict, used_active_task_context, used_lease_bias, used_conv_judge_resolution,
-		       would_block, would_review, would_prompt_inline,
-		       safety_flagged, safety_reason, reason, data_origin, context_src,
-		       duration_ms, filters_applied, verification, error_msg
-		FROM audit_log WHERE request_id = $1 AND user_id = $2
-	`, requestID, userID).Scan(
-		&e.ID, &e.UserID, &e.AgentID, &e.RequestID, &e.TaskID, &e.SessionID, &e.ApprovalID, &e.LeaseID,
-		&e.ToolUseID, &e.MatchedTaskID, &e.LeaseTaskID, &e.Timestamp,
-		&e.Service, &e.Action, &paramsSafe, &e.Decision, &e.Outcome,
-		&e.PolicyID, &e.RuleID, &e.ResolutionConfidence, &e.IntentVerdict,
-		&e.UsedActiveTaskContext, &e.UsedLeaseBias, &e.UsedConvJudgeResolution,
-		&e.WouldBlock, &e.WouldReview, &e.WouldPromptInline,
-		&e.SafetyFlagged, &e.SafetyReason, &e.Reason,
-		&e.DataOrigin, &e.ContextSrc, &e.DurationMS, &filtersApplied, &verification, &e.ErrorMsg)
+func (s *Store) GetAuditEntry(ctx context.Context, id, userID string) (*store.AuditEntry, error) {
+	e, err := scanAuditRow(s.pool.QueryRow(ctx,
+		`SELECT `+auditColumns+` FROM audit_log WHERE id = $1 AND user_id = $2`,
+		id, userID,
+	).Scan)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, store.ErrNotFound
 	}
-	if err != nil {
-		return nil, err
+	return e, err
+}
+
+// GetAuditEntryByRequestID returns the latest canonical row for
+// (request_id, user_id) — polling endpoint contract. See sqlite for full
+// rationale.
+func (s *Store) GetAuditEntryByRequestID(ctx context.Context, requestID, userID string) (*store.AuditEntry, error) {
+	e, err := scanAuditRow(s.pool.QueryRow(ctx,
+		`SELECT `+auditColumns+` FROM audit_log
+		 WHERE request_id = $1 AND user_id = $2 AND deduped_of IS NULL
+		 ORDER BY timestamp DESC LIMIT 1`,
+		requestID, userID,
+	).Scan)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, store.ErrNotFound
 	}
-	e.ParamsSafe = json.RawMessage(paramsSafe)
-	if filtersApplied != nil {
-		e.FiltersApplied = json.RawMessage(filtersApplied)
+	return e, err
+}
+
+// GetAuditEntryByRequestIDAndTask returns the canonical row for an exact
+// (request_id, user_id, task_id) — inverting FindDedupCandidate's
+// precedence so the feedback handler can resolve the task's row first.
+func (s *Store) GetAuditEntryByRequestIDAndTask(ctx context.Context, requestID, userID, taskID string) (*store.AuditEntry, error) {
+	var taskFilter string
+	args := []any{requestID, userID}
+	if taskID == "" {
+		taskFilter = "task_id IS NULL"
+	} else {
+		taskFilter = "(task_id = $3 OR task_id IS NULL)"
+		args = append(args, taskID)
 	}
-	if verification != nil {
-		e.Verification = json.RawMessage(verification)
+	q := `SELECT ` + auditColumns + ` FROM audit_log
+		WHERE request_id = $1 AND user_id = $2 AND deduped_of IS NULL
+		  AND ` + taskFilter + `
+		ORDER BY CASE WHEN task_id IS NULL THEN 1 ELSE 0 END, timestamp DESC
+		LIMIT 1`
+	e, err := scanAuditRow(s.pool.QueryRow(ctx, q, args...).Scan)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, store.ErrNotFound
 	}
-	return e, nil
+	return e, err
+}
+
+// FindDedupCandidate returns the canonical audit row a new
+// (request_id, user_id, task_id) should dedup against. Pre-task canonicals
+// (task_id IS NULL) win over task-scoped ones; oldest within a tier.
+func (s *Store) FindDedupCandidate(ctx context.Context, requestID, userID, taskID string) (*store.AuditEntry, error) {
+	var taskFilter string
+	args := []any{requestID, userID}
+	if taskID == "" {
+		taskFilter = "task_id IS NULL"
+	} else {
+		taskFilter = "(task_id IS NULL OR task_id = $3)"
+		args = append(args, taskID)
+	}
+	q := `SELECT ` + auditColumns + ` FROM audit_log
+		WHERE request_id = $1 AND user_id = $2 AND deduped_of IS NULL
+		  AND ` + taskFilter + `
+		ORDER BY CASE WHEN task_id IS NULL THEN 0 ELSE 1 END, timestamp ASC
+		LIMIT 1`
+	e, err := scanAuditRow(s.pool.QueryRow(ctx, q, args...).Scan)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, store.ErrNotFound
+	}
+	return e, err
 }
 
 func (s *Store) ListAuditEntries(ctx context.Context, userID string, filter store.AuditFilter) ([]*store.AuditEntry, int, error) {
@@ -840,14 +884,7 @@ func (s *Store) ListAuditEntries(ctx context.Context, userID string, filter stor
 		return nil, 0, err
 	}
 
-	dataQuery := `SELECT id, user_id, agent_id, request_id, task_id, session_id, approval_id, lease_id,
-		tool_use_id, matched_task_id, lease_task_id, timestamp, service, action,
-		params_safe, decision, outcome, policy_id, rule_id, resolution_confidence,
-		intent_verdict, used_active_task_context, used_lease_bias, used_conv_judge_resolution,
-		would_block, would_review, would_prompt_inline,
-		safety_flagged, safety_reason, reason, data_origin, context_src,
-		duration_ms, filters_applied, verification, error_msg
-		FROM audit_log ` + where +
+	dataQuery := `SELECT ` + auditColumns + ` FROM audit_log ` + where +
 		fmt.Sprintf(" ORDER BY timestamp DESC LIMIT $%d OFFSET $%d", i, i+1)
 	args = append(args, limit, filter.Offset)
 
@@ -1290,6 +1327,24 @@ func scanTasks(rows pgx.Rows) ([]*store.Task, error) {
 
 // ── Pending Approvals ─────────────────────────────────────────────────────────
 
+// pendingApprovalColumns is the canonical SELECT list for pending_approvals
+// rows. task_id is part of the symmetric-dedup scope (post-migration 042).
+const pendingApprovalColumns = `
+	id, user_id, request_id, task_id, audit_id, approval_record_id, request_blob,
+	callback_url, status, expires_at, created_at
+`
+
+// taskScopeClauseAt returns "task_id IS NULL" when taskID == "", or
+// "task_id = $N" with N = nextPlaceholder when not. Callers append the same
+// taskID to their args slice. The placeholder index is explicit because
+// pgx does not support positional reuse like $? in sqlite.
+func taskScopeClauseAt(taskID string, nextPlaceholder int, args []any) (string, []any, int) {
+	if taskID == "" {
+		return "task_id IS NULL", args, nextPlaceholder
+	}
+	return fmt.Sprintf("task_id = $%d", nextPlaceholder), append(args, taskID), nextPlaceholder + 1
+}
+
 func (s *Store) SavePendingApproval(ctx context.Context, pa *store.PendingApproval) error {
 	if pa.ID == "" {
 		pa.ID = uuid.New().String()
@@ -1298,42 +1353,94 @@ func (s *Store) SavePendingApproval(ctx context.Context, pa *store.PendingApprov
 		pa.Status = "pending"
 	}
 	_, err := s.pool.Exec(ctx, `
-		INSERT INTO pending_approvals (id, user_id, request_id, audit_id, approval_record_id, request_blob, callback_url, status, expires_at)
-		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
-	`, pa.ID, pa.UserID, pa.RequestID, pa.AuditID, pa.ApprovalRecordID, []byte(pa.RequestBlob),
+		INSERT INTO pending_approvals (id, user_id, request_id, task_id, audit_id, approval_record_id, request_blob, callback_url, status, expires_at)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+	`, pa.ID, pa.UserID, pa.RequestID, pa.TaskID, pa.AuditID, pa.ApprovalRecordID, []byte(pa.RequestBlob),
 		pa.CallbackURL, pa.Status, pa.ExpiresAt)
+	if err != nil && isDuplicate(err) {
+		return store.ErrConflict
+	}
 	return err
 }
 
-func (s *Store) GetPendingApproval(ctx context.Context, requestID string) (*store.PendingApproval, error) {
+func scanPendingApprovalRow(scan func(...any) error) (*store.PendingApproval, error) {
 	pa := &store.PendingApproval{}
 	var requestBlob []byte
-	err := s.pool.QueryRow(ctx, `
-		SELECT id, user_id, request_id, audit_id, approval_record_id, request_blob, callback_url, status, expires_at, created_at
-		FROM pending_approvals WHERE request_id = $1
-	`, requestID).Scan(
-		&pa.ID, &pa.UserID, &pa.RequestID, &pa.AuditID, &pa.ApprovalRecordID, &requestBlob,
-		&pa.CallbackURL, &pa.Status, &pa.ExpiresAt, &pa.CreatedAt)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, store.ErrNotFound
-	}
-	if err != nil {
+	if err := scan(
+		&pa.ID, &pa.UserID, &pa.RequestID, &pa.TaskID, &pa.AuditID, &pa.ApprovalRecordID, &requestBlob,
+		&pa.CallbackURL, &pa.Status, &pa.ExpiresAt, &pa.CreatedAt,
+	); err != nil {
 		return nil, err
 	}
 	pa.RequestBlob = json.RawMessage(requestBlob)
 	return pa, nil
 }
 
-func (s *Store) DeletePendingApproval(ctx context.Context, requestID string) error {
+// GetPendingApproval returns the unique pending approval matching
+// (request_id, user_id). Returns ErrAmbiguous when more than one row matches
+// (cross-task reuse under symmetric scope).
+func (s *Store) GetPendingApproval(ctx context.Context, requestID, userID string) (*store.PendingApproval, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT `+pendingApprovalColumns+` FROM pending_approvals
+		 WHERE request_id = $1 AND user_id = $2
+		 LIMIT 2`,
+		requestID, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		return nil, store.ErrNotFound
+	}
+	pa, err := scanPendingApprovalRow(rows.Scan)
+	if err != nil {
+		return nil, err
+	}
+	if rows.Next() {
+		return nil, store.ErrAmbiguous
+	}
+	return pa, rows.Err()
+}
+
+func (s *Store) GetPendingApprovalByTask(ctx context.Context, requestID, userID, taskID string) (*store.PendingApproval, error) {
+	args := []any{requestID, userID}
+	scope, args, _ := taskScopeClauseAt(taskID, 3, args)
+	pa, err := scanPendingApprovalRow(s.pool.QueryRow(ctx,
+		`SELECT `+pendingApprovalColumns+` FROM pending_approvals
+		 WHERE request_id = $1 AND user_id = $2 AND `+scope, args...,
+	).Scan)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, store.ErrNotFound
+	}
+	return pa, err
+}
+
+func (s *Store) ListPendingApprovalsByRequestID(ctx context.Context, requestID, userID string) ([]*store.PendingApproval, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT `+pendingApprovalColumns+` FROM pending_approvals
+		 WHERE request_id = $1 AND user_id = $2
+		 ORDER BY created_at ASC`,
+		requestID, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanPendingApprovals(rows)
+}
+
+func (s *Store) DeletePendingApproval(ctx context.Context, requestID, userID, taskID string) error {
+	args := []any{requestID, userID}
+	scope, args, _ := taskScopeClauseAt(taskID, 3, args)
 	_, err := s.pool.Exec(ctx,
-		`DELETE FROM pending_approvals WHERE request_id = $1`, requestID)
+		`DELETE FROM pending_approvals WHERE request_id = $1 AND user_id = $2 AND `+scope, args...)
 	return err
 }
 
 func (s *Store) ListPendingApprovals(ctx context.Context, userID string) ([]*store.PendingApproval, error) {
-	rows, err := s.pool.Query(ctx, `
-		SELECT id, user_id, request_id, audit_id, approval_record_id, request_blob, callback_url, status, expires_at, created_at
-		FROM pending_approvals WHERE user_id = $1 AND status = 'pending' AND expires_at > NOW() ORDER BY created_at ASC`, userID)
+	rows, err := s.pool.Query(ctx,
+		`SELECT `+pendingApprovalColumns+` FROM pending_approvals
+		 WHERE user_id = $1 AND status = 'pending' AND expires_at > NOW()
+		 ORDER BY created_at ASC`, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -1342,9 +1449,9 @@ func (s *Store) ListPendingApprovals(ctx context.Context, userID string) ([]*sto
 }
 
 func (s *Store) ListExpiredPendingApprovals(ctx context.Context) ([]*store.PendingApproval, error) {
-	rows, err := s.pool.Query(ctx, `
-		SELECT id, user_id, request_id, audit_id, approval_record_id, request_blob, callback_url, status, expires_at, created_at
-		FROM pending_approvals WHERE status = 'pending' AND expires_at < NOW()`)
+	rows, err := s.pool.Query(ctx,
+		`SELECT `+pendingApprovalColumns+` FROM pending_approvals
+		 WHERE status = 'pending' AND expires_at < NOW()`)
 	if err != nil {
 		return nil, err
 	}
@@ -1468,26 +1575,9 @@ func containsStr(s, sub string) bool {
 func scanAuditEntries(rows pgx.Rows) ([]*store.AuditEntry, error) {
 	var entries []*store.AuditEntry
 	for rows.Next() {
-		e := &store.AuditEntry{}
-		var paramsSafe, filtersApplied, verification []byte
-		if err := rows.Scan(
-			&e.ID, &e.UserID, &e.AgentID, &e.RequestID, &e.TaskID, &e.SessionID, &e.ApprovalID, &e.LeaseID,
-			&e.ToolUseID, &e.MatchedTaskID, &e.LeaseTaskID, &e.Timestamp,
-			&e.Service, &e.Action, &paramsSafe, &e.Decision, &e.Outcome,
-			&e.PolicyID, &e.RuleID, &e.ResolutionConfidence, &e.IntentVerdict,
-			&e.UsedActiveTaskContext, &e.UsedLeaseBias, &e.UsedConvJudgeResolution,
-			&e.WouldBlock, &e.WouldReview, &e.WouldPromptInline,
-			&e.SafetyFlagged, &e.SafetyReason, &e.Reason,
-			&e.DataOrigin, &e.ContextSrc, &e.DurationMS, &filtersApplied, &verification, &e.ErrorMsg,
-		); err != nil {
+		e, err := scanAuditRow(rows.Scan)
+		if err != nil {
 			return nil, err
-		}
-		e.ParamsSafe = json.RawMessage(paramsSafe)
-		if filtersApplied != nil {
-			e.FiltersApplied = json.RawMessage(filtersApplied)
-		}
-		if verification != nil {
-			e.Verification = json.RawMessage(verification)
 		}
 		entries = append(entries, e)
 	}
@@ -1497,44 +1587,50 @@ func scanAuditEntries(rows pgx.Rows) ([]*store.AuditEntry, error) {
 func scanPendingApprovals(rows pgx.Rows) ([]*store.PendingApproval, error) {
 	var pas []*store.PendingApproval
 	for rows.Next() {
-		pa := &store.PendingApproval{}
-		var requestBlob []byte
-		if err := rows.Scan(
-			&pa.ID, &pa.UserID, &pa.RequestID, &pa.AuditID, &pa.ApprovalRecordID, &requestBlob,
-			&pa.CallbackURL, &pa.Status, &pa.ExpiresAt, &pa.CreatedAt,
-		); err != nil {
+		pa, err := scanPendingApprovalRow(rows.Scan)
+		if err != nil {
 			return nil, err
 		}
-		pa.RequestBlob = json.RawMessage(requestBlob)
 		pas = append(pas, pa)
 	}
 	return pas, rows.Err()
 }
 
-func (s *Store) UpdatePendingApprovalStatus(ctx context.Context, requestID, status string) error {
+func (s *Store) UpdatePendingApprovalStatus(ctx context.Context, requestID, userID, taskID, status string) error {
 	// Guard: only transition from 'pending'. This prevents regressions from
 	// 'approved'/'executing' back to earlier states, which would undermine
 	// the atomicity of ClaimPendingApprovalForExecution.
+	args := []any{status, requestID, userID}
+	scope, args, _ := taskScopeClauseAt(taskID, 4, args)
 	_, err := s.pool.Exec(ctx,
-		`UPDATE pending_approvals SET status = $1 WHERE request_id = $2 AND status = 'pending'`, status, requestID)
+		`UPDATE pending_approvals SET status = $1
+		 WHERE request_id = $2 AND user_id = $3 AND `+scope+` AND status = 'pending'`,
+		args...)
 	return err
 }
 
 // UpdatePendingApprovalStatusFrom is the CAS variant.
-func (s *Store) UpdatePendingApprovalStatusFrom(ctx context.Context, requestID, fromStatus, toStatus string) (bool, error) {
+func (s *Store) UpdatePendingApprovalStatusFrom(ctx context.Context, requestID, userID, taskID, fromStatus, toStatus string) (bool, error) {
+	args := []any{toStatus, requestID, userID}
+	scope, args, next := taskScopeClauseAt(taskID, 4, args)
+	args = append(args, fromStatus)
 	tag, err := s.pool.Exec(ctx,
-		`UPDATE pending_approvals SET status = $1 WHERE request_id = $2 AND status = $3`,
-		toStatus, requestID, fromStatus)
+		`UPDATE pending_approvals SET status = $1
+		 WHERE request_id = $2 AND user_id = $3 AND `+scope+fmt.Sprintf(` AND status = $%d`, next),
+		args...)
 	if err != nil {
 		return false, err
 	}
 	return tag.RowsAffected() > 0, nil
 }
 
-func (s *Store) ClaimPendingApprovalForExecution(ctx context.Context, requestID string) (bool, error) {
+func (s *Store) ClaimPendingApprovalForExecution(ctx context.Context, requestID, userID, taskID string) (bool, error) {
+	args := []any{requestID, userID}
+	scope, args, _ := taskScopeClauseAt(taskID, 3, args)
 	tag, err := s.pool.Exec(ctx,
 		`UPDATE pending_approvals SET status = 'executing', executing_since = NOW()
-		 WHERE request_id = $1 AND status = 'approved'`, requestID)
+		 WHERE request_id = $1 AND user_id = $2 AND `+scope+` AND status = 'approved'`,
+		args...)
 	if err != nil {
 		return false, err
 	}
@@ -1547,9 +1643,9 @@ func (s *Store) ClaimPendingApprovalForExecution(ctx context.Context, requestID 
 // Recovery to gate side-effects.
 func (s *Store) ListStalledExecutingApprovals(ctx context.Context, leaseTTL time.Duration) ([]*store.PendingApproval, error) {
 	cutoff := time.Now().UTC().Add(-leaseTTL)
-	rows, err := s.pool.Query(ctx, `
-		SELECT id, user_id, request_id, audit_id, approval_record_id, request_blob, callback_url, status, expires_at, created_at
-		FROM pending_approvals WHERE status = 'executing' AND executing_since IS NOT NULL AND executing_since < $1`, cutoff)
+	rows, err := s.pool.Query(ctx,
+		`SELECT `+pendingApprovalColumns+` FROM pending_approvals
+		 WHERE status = 'executing' AND executing_since IS NOT NULL AND executing_since < $1`, cutoff)
 	if err != nil {
 		return nil, err
 	}
@@ -1561,13 +1657,17 @@ func (s *Store) ListStalledExecutingApprovals(ctx context.Context, leaseTTL time
 // 'executing' row only if it is still in 'executing' status and still past
 // the lease cutoff. The DELETE's WHERE clause is the CAS — see sqlite
 // counterpart for the rationale.
-func (s *Store) ClaimStalledExecutingApprovalForRecovery(ctx context.Context, requestID string, leaseTTL time.Duration) (bool, error) {
+func (s *Store) ClaimStalledExecutingApprovalForRecovery(ctx context.Context, requestID, userID, taskID string, leaseTTL time.Duration) (bool, error) {
 	cutoff := time.Now().UTC().Add(-leaseTTL)
-	tag, err := s.pool.Exec(ctx, `
-		DELETE FROM pending_approvals
-		WHERE request_id = $1 AND status = 'executing'
-		  AND executing_since IS NOT NULL AND executing_since < $2`,
-		requestID, cutoff)
+	args := []any{requestID, userID}
+	scope, args, next := taskScopeClauseAt(taskID, 3, args)
+	args = append(args, cutoff)
+	tag, err := s.pool.Exec(ctx,
+		`DELETE FROM pending_approvals
+		 WHERE request_id = $1 AND user_id = $2 AND `+scope+`
+		   AND status = 'executing'
+		   AND executing_since IS NOT NULL AND executing_since < `+fmt.Sprintf("$%d", next),
+		args...)
 	if err != nil {
 		return false, err
 	}
@@ -1622,29 +1722,66 @@ func (s *Store) CreateApprovalRecordWithPending(ctx context.Context, rec *store.
 		return err
 	}
 	if _, err = tx.Exec(ctx, `
-		INSERT INTO pending_approvals (id, user_id, request_id, audit_id, approval_record_id, request_blob, callback_url, status, expires_at)
-		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
-	`, pa.ID, pa.UserID, pa.RequestID, pa.AuditID, pa.ApprovalRecordID, []byte(pa.RequestBlob),
+		INSERT INTO pending_approvals (id, user_id, request_id, task_id, audit_id, approval_record_id, request_blob, callback_url, status, expires_at)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+	`, pa.ID, pa.UserID, pa.RequestID, pa.TaskID, pa.AuditID, pa.ApprovalRecordID, []byte(pa.RequestBlob),
 		pa.CallbackURL, pa.Status, pa.ExpiresAt); err != nil {
+		if isDuplicate(err) {
+			err = store.ErrConflict
+		}
 		return err
 	}
 	return tx.Commit(ctx)
 }
 
+const approvalRecordColumns = `
+	id, kind, user_id, agent_id, request_id, task_id, session_id, status, surface,
+	summary_json, payload_json, resolution_transport, expires_at, resolved_at, resolution, created_at, updated_at
+`
+
 func (s *Store) GetApprovalRecord(ctx context.Context, id string) (*store.ApprovalRecord, error) {
-	return s.getApprovalRecord(ctx, `
-		SELECT id, kind, user_id, agent_id, request_id, task_id, session_id, status, surface,
-		       summary_json, payload_json, resolution_transport, expires_at, resolved_at, resolution, created_at, updated_at
-		FROM approval_records WHERE id = $1
-	`, id)
+	return s.getApprovalRecord(ctx,
+		`SELECT `+approvalRecordColumns+` FROM approval_records WHERE id = $1`, id)
 }
 
-func (s *Store) GetApprovalRecordByRequestID(ctx context.Context, requestID string) (*store.ApprovalRecord, error) {
-	return s.getApprovalRecord(ctx, `
-		SELECT id, kind, user_id, agent_id, request_id, task_id, session_id, status, surface,
-		       summary_json, payload_json, resolution_transport, expires_at, resolved_at, resolution, created_at, updated_at
-		FROM approval_records WHERE request_id = $1
-	`, requestID)
+// GetApprovalRecordByRequestID returns the unique approval record matching
+// (request_id, user_id). Returns ErrAmbiguous when more than one row matches.
+func (s *Store) GetApprovalRecordByRequestID(ctx context.Context, requestID, userID string) (*store.ApprovalRecord, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT `+approvalRecordColumns+` FROM approval_records
+		 WHERE request_id = $1 AND user_id = $2
+		 LIMIT 2`, requestID, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		return nil, store.ErrNotFound
+	}
+	rec, err := scanApprovalRecord(rows)
+	if err != nil {
+		return nil, err
+	}
+	if rows.Next() {
+		return nil, store.ErrAmbiguous
+	}
+	return rec, rows.Err()
+}
+
+func (s *Store) GetApprovalRecordByRequestIDAndTask(ctx context.Context, requestID, userID, taskID string) (*store.ApprovalRecord, error) {
+	args := []any{requestID, userID}
+	scope, args, _ := taskScopeClauseAt(taskID, 3, args)
+	rows, err := s.pool.Query(ctx,
+		`SELECT `+approvalRecordColumns+` FROM approval_records
+		 WHERE request_id = $1 AND user_id = $2 AND `+scope+` LIMIT 1`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		return nil, store.ErrNotFound
+	}
+	return scanApprovalRecord(rows)
 }
 
 func (s *Store) ListPendingApprovalRecords(ctx context.Context, userID string) ([]*store.ApprovalRecord, error) {

--- a/pkg/store/sqlite/migrations/042_symmetric_dedup_scope.sql
+++ b/pkg/store/sqlite/migrations/042_symmetric_dedup_scope.sql
@@ -1,0 +1,182 @@
+-- Symmetric dedup scoping: align audit_log, pending_approvals, and
+-- approval_records on the same (user_id, request_id, COALESCE(task_id, ''))
+-- key. Replaces the "audit-only" dedup scope from PR #361 with one that
+-- covers all three tables, so a cross-task reuse of a request_id either
+-- succeeds everywhere (different task = different scope = independent rows
+-- in every table) or hits a same-scope conflict everywhere (which the
+-- handler recovers via the existing dedup-attempt path).
+--
+-- New shape across the three tables:
+--   * audit_log: deduped_of NULL → canonical; deduped_of NOT NULL → retry
+--     attempt referencing the canonical. UNIQUE(user_id, request_id,
+--     COALESCE(task_id,'')) WHERE deduped_of IS NULL.
+--   * pending_approvals: new task_id column; UNIQUE(user_id, request_id,
+--     COALESCE(task_id,'')).
+--   * approval_records: existing task_id column; the partial unique on
+--     request_id is replaced with UNIQUE(user_id, request_id,
+--     COALESCE(task_id,'')) WHERE request_id IS NOT NULL AND request_id != ''.
+--
+-- Why one migration instead of three: the three tables form one logical
+-- dedup scope. Splitting the schema change across migrations would create
+-- transient states where audit_log permits cross-task canonicals but
+-- pending_approvals still UNIQUE-blocks them, which is exactly the wart
+-- this redesign exists to remove. Applying them together is the only
+-- coherent intermediate state.
+--
+-- SQLite rebuild dance: both audit_log and pending_approvals carry an
+-- inline UNIQUE constraint that SQLite cannot drop in place, so each
+-- table is recreated. audit_log is the heavyweight one (months of audit
+-- history); pending_approvals is small (only rows still awaiting a human
+-- decision) so its rebuild is effectively free.
+--
+-- Blocking time: the audit_log rewrite is the same shape as migration 028
+-- and PR #361's predecessor migration — fast on fresh installs, several
+-- seconds on installs with months of audit history. The pending_approvals
+-- rebuild is bounded by the number of in-flight approvals (typically 0–10).
+--
+-- Foreign-key safety on audit_log: chain_facts.audit_id references
+-- audit_log(id) ON DELETE CASCADE. PRAGMA defer_foreign_keys = ON only
+-- defers the *constraint check* to COMMIT — it does not suppress cascade
+-- actions. DROP TABLE audit_log fires an implicit DELETE FROM audit_log,
+-- which cascades to chain_facts and empties it. PRAGMA foreign_keys = OFF
+-- would suppress cascades but cannot be toggled inside a transaction (and
+-- the migration runner wraps each migration in one). Workaround: snapshot
+-- chain_facts to a TEMP TABLE before the rebuild and restore it afterwards.
+-- pending_approvals has no inbound FKs (verified at migration authoring
+-- time) so no companion backup is needed for it.
+
+PRAGMA defer_foreign_keys = ON;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 1. audit_log: add deduped_of, replace UNIQUE(request_id, user_id) with the
+--    partial canonical-dedup index. Same shape as PR #361's migration 042.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+CREATE TEMP TABLE chain_facts_backup AS SELECT * FROM chain_facts;
+
+CREATE TABLE audit_log_new (
+    id                          TEXT PRIMARY KEY,
+    user_id                     TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    agent_id                    TEXT REFERENCES agents(id) ON DELETE SET NULL,
+    request_id                  TEXT NOT NULL,
+    task_id                     TEXT,
+    session_id                  TEXT,
+    approval_id                 TEXT,
+    lease_id                    TEXT,
+    tool_use_id                 TEXT,
+    matched_task_id             TEXT,
+    lease_task_id               TEXT,
+    timestamp                   TEXT NOT NULL DEFAULT (datetime('now')),
+    service                     TEXT NOT NULL,
+    action                      TEXT NOT NULL,
+    params_safe                 TEXT NOT NULL DEFAULT '{}',
+    decision                    TEXT NOT NULL,
+    outcome                     TEXT NOT NULL,
+    policy_id                   TEXT,
+    rule_id                     TEXT,
+    resolution_confidence       TEXT,
+    intent_verdict              TEXT,
+    used_active_task_context    INTEGER NOT NULL DEFAULT 0,
+    used_lease_bias             INTEGER NOT NULL DEFAULT 0,
+    used_conv_judge_resolution  INTEGER NOT NULL DEFAULT 0,
+    would_block                 INTEGER NOT NULL DEFAULT 0,
+    would_review                INTEGER NOT NULL DEFAULT 0,
+    would_prompt_inline         INTEGER NOT NULL DEFAULT 0,
+    safety_flagged              INTEGER NOT NULL DEFAULT 0,
+    safety_reason               TEXT,
+    reason                      TEXT,
+    data_origin                 TEXT,
+    context_src                 TEXT,
+    duration_ms                 INTEGER NOT NULL DEFAULT 0,
+    filters_applied             TEXT,
+    verification                TEXT,
+    error_msg                   TEXT,
+    deduped_of                  TEXT
+);
+
+INSERT INTO audit_log_new SELECT
+    id, user_id, agent_id, request_id, task_id, session_id, approval_id, lease_id,
+    tool_use_id, matched_task_id, lease_task_id, timestamp, service, action,
+    params_safe, decision, outcome, policy_id, rule_id, resolution_confidence,
+    intent_verdict, used_active_task_context, used_lease_bias, used_conv_judge_resolution,
+    would_block, would_review, would_prompt_inline,
+    safety_flagged, safety_reason, reason, data_origin, context_src,
+    duration_ms, filters_applied, verification, error_msg,
+    NULL
+FROM audit_log;
+
+DROP TABLE audit_log;
+ALTER TABLE audit_log_new RENAME TO audit_log;
+
+INSERT INTO chain_facts SELECT * FROM chain_facts_backup;
+DROP TABLE chain_facts_backup;
+
+CREATE INDEX idx_audit_user_time ON audit_log(user_id, timestamp DESC);
+CREATE INDEX idx_audit_outcome   ON audit_log(user_id, outcome);
+CREATE INDEX idx_audit_service   ON audit_log(user_id, service);
+CREATE INDEX idx_audit_runtime_host_path
+    ON audit_log(
+        user_id,
+        service,
+        COALESCE(json_extract(params_safe, '$.host'), ''),
+        COALESCE(json_extract(params_safe, '$.path'), '')
+    );
+
+CREATE UNIQUE INDEX idx_audit_canonical_dedup
+    ON audit_log(user_id, request_id, COALESCE(task_id, ''))
+    WHERE deduped_of IS NULL;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 2. pending_approvals: add task_id, replace UNIQUE(request_id) with the
+--    composite UNIQUE(user_id, request_id, COALESCE(task_id,'')).
+--    Backfill task_id from audit_log via audit_id.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+CREATE TABLE pending_approvals_new (
+    id                  TEXT PRIMARY KEY,
+    user_id             TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    request_id          TEXT NOT NULL,
+    task_id             TEXT,
+    audit_id            TEXT NOT NULL,
+    request_blob        TEXT NOT NULL,
+    callback_url        TEXT,
+    telegram_msg_id     TEXT,
+    expires_at          TEXT NOT NULL,
+    created_at          TEXT NOT NULL DEFAULT (datetime('now')),
+    status              TEXT NOT NULL DEFAULT 'pending',
+    approval_record_id  TEXT,
+    executing_since     TEXT
+);
+
+INSERT INTO pending_approvals_new (
+    id, user_id, request_id, task_id, audit_id, request_blob,
+    callback_url, telegram_msg_id, expires_at, created_at,
+    status, approval_record_id, executing_since
+)
+SELECT
+    pa.id, pa.user_id, pa.request_id, al.task_id, pa.audit_id, pa.request_blob,
+    pa.callback_url, pa.telegram_msg_id, pa.expires_at, pa.created_at,
+    pa.status, pa.approval_record_id, pa.executing_since
+FROM pending_approvals pa
+LEFT JOIN audit_log al ON al.id = pa.audit_id;
+
+DROP TABLE pending_approvals;
+ALTER TABLE pending_approvals_new RENAME TO pending_approvals;
+
+CREATE INDEX idx_pending_approvals_user_status
+    ON pending_approvals(user_id, status);
+
+CREATE UNIQUE INDEX idx_pending_approvals_dedup
+    ON pending_approvals(user_id, request_id, COALESCE(task_id, ''));
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 3. approval_records: replace the request_id-only partial unique index with
+--    the composite (user_id, request_id, COALESCE(task_id,'')) version.
+--    task_id column already exists (migration 030).
+-- ─────────────────────────────────────────────────────────────────────────────
+
+DROP INDEX idx_approval_records_request_id;
+
+CREATE UNIQUE INDEX idx_approval_records_request_id
+    ON approval_records(user_id, request_id, COALESCE(task_id, ''))
+    WHERE request_id IS NOT NULL AND request_id != '';

--- a/pkg/store/sqlite/migrations/042_symmetric_dedup_scope.sql
+++ b/pkg/store/sqlite/migrations/042_symmetric_dedup_scope.sql
@@ -180,3 +180,29 @@ DROP INDEX idx_approval_records_request_id;
 CREATE UNIQUE INDEX idx_approval_records_request_id
     ON approval_records(user_id, request_id, COALESCE(task_id, ''))
     WHERE request_id IS NOT NULL AND request_id != '';
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 4. notification_messages: pre-migration approval rows were stored with
+--    target_id = request_id. Post-migration the handler addresses the row
+--    with target_id = request_id || '|' || task_id (see approvalNotifyTargetID
+--    in internal/api/handlers/gateway.go). Backfill so existing in-flight
+--    Telegram messages remain addressable.
+--
+--    The UPDATE only touches rows whose pending_approval now has a non-empty
+--    task_id (back-filled in step 2). Rows for pre-task approvals stay under
+--    their original request_id key, matching approvalNotifyTargetID's
+--    pre-task branch.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+UPDATE notification_messages
+SET target_id = target_id || '|' || (
+    SELECT pa.task_id FROM pending_approvals pa
+    WHERE pa.request_id = notification_messages.target_id
+      AND pa.task_id IS NOT NULL AND pa.task_id != ''
+    LIMIT 1
+)
+WHERE target_type = 'approval'
+  AND target_id IN (
+      SELECT pa2.request_id FROM pending_approvals pa2
+      WHERE pa2.task_id IS NOT NULL AND pa2.task_id != ''
+  );

--- a/pkg/store/sqlite/store.go
+++ b/pkg/store/sqlite/store.go
@@ -834,8 +834,8 @@ func (s *Store) LogAudit(ctx context.Context, e *store.AuditEntry) error {
 			intent_verdict, used_active_task_context, used_lease_bias, used_conv_judge_resolution,
 			would_block, would_review, would_prompt_inline,
 			safety_flagged, safety_reason, reason, data_origin, context_src,
-			duration_ms, filters_applied, verification, error_msg
-		) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+			duration_ms, filters_applied, verification, error_msg, deduped_of
+		) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
 	`, e.ID, e.UserID, e.AgentID, e.RequestID, e.TaskID, e.SessionID, e.ApprovalID, e.LeaseID,
 		e.ToolUseID, e.MatchedTaskID, e.LeaseTaskID, e.Timestamp.UTC().Format(time.RFC3339),
 		e.Service, e.Action, paramsSafe, e.Decision, e.Outcome,
@@ -843,7 +843,10 @@ func (s *Store) LogAudit(ctx context.Context, e *store.AuditEntry) error {
 		usedActiveTaskContext, usedLeaseBias, usedConvJudgeResolution,
 		wouldBlock, wouldReview, wouldPromptInline,
 		safetyFlagged, e.SafetyReason, e.Reason,
-		e.DataOrigin, e.ContextSrc, e.DurationMS, filtersApplied, verification, e.ErrorMsg)
+		e.DataOrigin, e.ContextSrc, e.DurationMS, filtersApplied, verification, e.ErrorMsg, e.DedupedOf)
+	if err != nil && isDuplicate(err) {
+		return store.ErrConflict
+	}
 	return err
 }
 
@@ -858,21 +861,27 @@ func (s *Store) UpdateAuditOutcome(ctx context.Context, id, outcome, errMsg stri
 	return err
 }
 
-func (s *Store) GetAuditEntry(ctx context.Context, id, userID string) (*store.AuditEntry, error) {
+// auditColumns is the canonical SELECT list for audit_log rows. Kept in
+// sync with scanAuditRow below; both deliberately include deduped_of as
+// the trailing column so the symmetric-dedup partial-unique index can
+// distinguish canonical rows (deduped_of IS NULL) from retry-attempt
+// rows.
+const auditColumns = `
+	id, user_id, agent_id, request_id, task_id, session_id, approval_id, lease_id,
+	tool_use_id, matched_task_id, lease_task_id, timestamp, service, action,
+	params_safe, decision, outcome, policy_id, rule_id, resolution_confidence,
+	intent_verdict, used_active_task_context, used_lease_bias, used_conv_judge_resolution,
+	would_block, would_review, would_prompt_inline,
+	safety_flagged, safety_reason, reason, data_origin, context_src,
+	duration_ms, filters_applied, verification, error_msg, deduped_of
+`
+
+func scanAuditRow(scan func(...any) error) (*store.AuditEntry, error) {
 	e := &store.AuditEntry{}
 	var timestamp, paramsSafe string
 	var safetyFlagged, usedActiveTaskContext, usedLeaseBias, usedConvJudgeResolution, wouldBlock, wouldReview, wouldPromptInline int
 	var filtersApplied, verification *string
-	err := s.db.QueryRowContext(ctx, `
-		SELECT id, user_id, agent_id, request_id, task_id, session_id, approval_id, lease_id,
-		       tool_use_id, matched_task_id, lease_task_id, timestamp, service, action,
-		       params_safe, decision, outcome, policy_id, rule_id, resolution_confidence,
-		       intent_verdict, used_active_task_context, used_lease_bias, used_conv_judge_resolution,
-		       would_block, would_review, would_prompt_inline,
-		       safety_flagged, safety_reason, reason, data_origin, context_src,
-		       duration_ms, filters_applied, verification, error_msg
-		FROM audit_log WHERE id = ? AND user_id = ?
-	`, id, userID).Scan(
+	err := scan(
 		&e.ID, &e.UserID, &e.AgentID, &e.RequestID, &e.TaskID, &e.SessionID, &e.ApprovalID, &e.LeaseID,
 		&e.ToolUseID, &e.MatchedTaskID, &e.LeaseTaskID, &timestamp,
 		&e.Service, &e.Action, &paramsSafe, &e.Decision, &e.Outcome,
@@ -880,10 +889,8 @@ func (s *Store) GetAuditEntry(ctx context.Context, id, userID string) (*store.Au
 		&usedActiveTaskContext, &usedLeaseBias, &usedConvJudgeResolution,
 		&wouldBlock, &wouldReview, &wouldPromptInline,
 		&safetyFlagged, &e.SafetyReason, &e.Reason,
-		&e.DataOrigin, &e.ContextSrc, &e.DurationMS, &filtersApplied, &verification, &e.ErrorMsg)
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil, store.ErrNotFound
-	}
+		&e.DataOrigin, &e.ContextSrc, &e.DurationMS, &filtersApplied, &verification, &e.ErrorMsg, &e.DedupedOf,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -905,51 +912,87 @@ func (s *Store) GetAuditEntry(ctx context.Context, id, userID string) (*store.Au
 	return e, nil
 }
 
-func (s *Store) GetAuditEntryByRequestID(ctx context.Context, requestID, userID string) (*store.AuditEntry, error) {
-	e := &store.AuditEntry{}
-	var timestamp, paramsSafe string
-	var safetyFlagged, usedActiveTaskContext, usedLeaseBias, usedConvJudgeResolution, wouldBlock, wouldReview, wouldPromptInline int
-	var filtersApplied, verification *string
-	err := s.db.QueryRowContext(ctx, `
-		SELECT id, user_id, agent_id, request_id, task_id, session_id, approval_id, lease_id,
-		       tool_use_id, matched_task_id, lease_task_id, timestamp, service, action,
-		       params_safe, decision, outcome, policy_id, rule_id, resolution_confidence,
-		       intent_verdict, used_active_task_context, used_lease_bias, used_conv_judge_resolution,
-		       would_block, would_review, would_prompt_inline,
-		       safety_flagged, safety_reason, reason, data_origin, context_src,
-		       duration_ms, filters_applied, verification, error_msg
-		FROM audit_log WHERE request_id = ? AND user_id = ?
-	`, requestID, userID).Scan(
-		&e.ID, &e.UserID, &e.AgentID, &e.RequestID, &e.TaskID, &e.SessionID, &e.ApprovalID, &e.LeaseID,
-		&e.ToolUseID, &e.MatchedTaskID, &e.LeaseTaskID, &timestamp,
-		&e.Service, &e.Action, &paramsSafe, &e.Decision, &e.Outcome,
-		&e.PolicyID, &e.RuleID, &e.ResolutionConfidence, &e.IntentVerdict,
-		&usedActiveTaskContext, &usedLeaseBias, &usedConvJudgeResolution,
-		&wouldBlock, &wouldReview, &wouldPromptInline,
-		&safetyFlagged, &e.SafetyReason, &e.Reason,
-		&e.DataOrigin, &e.ContextSrc, &e.DurationMS, &filtersApplied, &verification, &e.ErrorMsg)
+func (s *Store) GetAuditEntry(ctx context.Context, id, userID string) (*store.AuditEntry, error) {
+	e, err := scanAuditRow(s.db.QueryRowContext(ctx,
+		`SELECT `+auditColumns+` FROM audit_log WHERE id = ? AND user_id = ?`,
+		id, userID,
+	).Scan)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, store.ErrNotFound
 	}
-	if err != nil {
-		return nil, err
+	return e, err
+}
+
+// GetAuditEntryByRequestID returns the latest canonical row for
+// (request_id, user_id) — the polling endpoint's contract. Dedup-attempt
+// rows (deduped_of IS NOT NULL) are excluded; among canonicals, newer
+// wins because agents almost always poll right after submitting and want
+// the most recent canonical for that request_id.
+func (s *Store) GetAuditEntryByRequestID(ctx context.Context, requestID, userID string) (*store.AuditEntry, error) {
+	e, err := scanAuditRow(s.db.QueryRowContext(ctx,
+		`SELECT `+auditColumns+` FROM audit_log
+		 WHERE request_id = ? AND user_id = ? AND deduped_of IS NULL
+		 ORDER BY timestamp DESC LIMIT 1`,
+		requestID, userID,
+	).Scan)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, store.ErrNotFound
 	}
-	e.Timestamp = parseTime(timestamp)
-	e.SafetyFlagged = safetyFlagged != 0
-	e.UsedActiveTaskContext = usedActiveTaskContext != 0
-	e.UsedLeaseBias = usedLeaseBias != 0
-	e.UsedConvJudgeResolution = usedConvJudgeResolution != 0
-	e.WouldBlock = wouldBlock != 0
-	e.WouldReview = wouldReview != 0
-	e.WouldPromptInline = wouldPromptInline != 0
-	e.ParamsSafe = json.RawMessage(paramsSafe)
-	if filtersApplied != nil {
-		e.FiltersApplied = json.RawMessage(*filtersApplied)
+	return e, err
+}
+
+// GetAuditEntryByRequestIDAndTask returns the canonical row for an exact
+// (request_id, user_id, task_id) — inverting FindDedupCandidate's pre-task
+// precedence. taskID == "" matches the pre-task scope (task_id IS NULL).
+// Pre-task is the fallback when no task-scoped canonical exists so the
+// feedback handler can still resolve a request_id that was classified
+// pre-task even after a later task_id was attached.
+func (s *Store) GetAuditEntryByRequestIDAndTask(ctx context.Context, requestID, userID, taskID string) (*store.AuditEntry, error) {
+	var taskFilter string
+	args := []any{requestID, userID}
+	if taskID == "" {
+		taskFilter = "task_id IS NULL"
+	} else {
+		taskFilter = "(task_id = ? OR task_id IS NULL)"
+		args = append(args, taskID)
 	}
-	if verification != nil {
-		e.Verification = json.RawMessage(*verification)
+	q := `SELECT ` + auditColumns + ` FROM audit_log
+		WHERE request_id = ? AND user_id = ? AND deduped_of IS NULL
+		  AND ` + taskFilter + `
+		ORDER BY CASE WHEN task_id IS NULL THEN 1 ELSE 0 END, timestamp DESC
+		LIMIT 1`
+	e, err := scanAuditRow(s.db.QueryRowContext(ctx, q, args...).Scan)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, store.ErrNotFound
 	}
-	return e, nil
+	return e, err
+}
+
+// FindDedupCandidate returns the canonical audit row a new
+// (request_id, user_id, task_id) request should dedup against. Pre-task
+// canonicals (task_id IS NULL) always win over task-scoped canonicals for
+// the same request_id; within a tier the oldest row wins. taskID == ""
+// (runtime classification path before a task is bound) only matches
+// pre-task rows.
+func (s *Store) FindDedupCandidate(ctx context.Context, requestID, userID, taskID string) (*store.AuditEntry, error) {
+	var taskFilter string
+	args := []any{requestID, userID}
+	if taskID == "" {
+		taskFilter = "task_id IS NULL"
+	} else {
+		taskFilter = "(task_id IS NULL OR task_id = ?)"
+		args = append(args, taskID)
+	}
+	q := `SELECT ` + auditColumns + ` FROM audit_log
+		WHERE request_id = ? AND user_id = ? AND deduped_of IS NULL
+		  AND ` + taskFilter + `
+		ORDER BY CASE WHEN task_id IS NULL THEN 0 ELSE 1 END, timestamp ASC
+		LIMIT 1`
+	e, err := scanAuditRow(s.db.QueryRowContext(ctx, q, args...).Scan)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, store.ErrNotFound
+	}
+	return e, err
 }
 
 func (s *Store) ListAuditEntries(ctx context.Context, userID string, filter store.AuditFilter) ([]*store.AuditEntry, int, error) {
@@ -999,15 +1042,9 @@ func (s *Store) ListAuditEntries(ctx context.Context, userID string, filter stor
 	}
 
 	dataArgs := append(args, limit, filter.Offset)
-	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, user_id, agent_id, request_id, task_id, session_id, approval_id, lease_id,
-		       tool_use_id, matched_task_id, lease_task_id, timestamp, service, action,
-		       params_safe, decision, outcome, policy_id, rule_id, resolution_confidence,
-		       intent_verdict, used_active_task_context, used_lease_bias, used_conv_judge_resolution,
-		       would_block, would_review, would_prompt_inline,
-		       safety_flagged, safety_reason, reason, data_origin, context_src,
-		       duration_ms, filters_applied, verification, error_msg
-		FROM audit_log `+where+` ORDER BY timestamp DESC LIMIT ? OFFSET ?`, dataArgs...)
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT `+auditColumns+` FROM audit_log `+where+` ORDER BY timestamp DESC LIMIT ? OFFSET ?`,
+		dataArgs...)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -1015,36 +1052,9 @@ func (s *Store) ListAuditEntries(ctx context.Context, userID string, filter stor
 
 	var entries []*store.AuditEntry
 	for rows.Next() {
-		e := &store.AuditEntry{}
-		var timestamp, paramsSafe string
-		var safetyFlagged, usedActiveTaskContext, usedLeaseBias, usedConvJudgeResolution, wouldBlock, wouldReview, wouldPromptInline int
-		var filtersApplied, verification *string
-		if err := rows.Scan(
-			&e.ID, &e.UserID, &e.AgentID, &e.RequestID, &e.TaskID, &e.SessionID, &e.ApprovalID, &e.LeaseID,
-			&e.ToolUseID, &e.MatchedTaskID, &e.LeaseTaskID, &timestamp,
-			&e.Service, &e.Action, &paramsSafe, &e.Decision, &e.Outcome,
-			&e.PolicyID, &e.RuleID, &e.ResolutionConfidence, &e.IntentVerdict,
-			&usedActiveTaskContext, &usedLeaseBias, &usedConvJudgeResolution,
-			&wouldBlock, &wouldReview, &wouldPromptInline,
-			&safetyFlagged, &e.SafetyReason, &e.Reason,
-			&e.DataOrigin, &e.ContextSrc, &e.DurationMS, &filtersApplied, &verification, &e.ErrorMsg,
-		); err != nil {
+		e, err := scanAuditRow(rows.Scan)
+		if err != nil {
 			return nil, 0, err
-		}
-		e.Timestamp = parseTime(timestamp)
-		e.SafetyFlagged = safetyFlagged != 0
-		e.UsedActiveTaskContext = usedActiveTaskContext != 0
-		e.UsedLeaseBias = usedLeaseBias != 0
-		e.UsedConvJudgeResolution = usedConvJudgeResolution != 0
-		e.WouldBlock = wouldBlock != 0
-		e.WouldReview = wouldReview != 0
-		e.WouldPromptInline = wouldPromptInline != 0
-		e.ParamsSafe = json.RawMessage(paramsSafe)
-		if filtersApplied != nil {
-			e.FiltersApplied = json.RawMessage(*filtersApplied)
-		}
-		if verification != nil {
-			e.Verification = json.RawMessage(*verification)
 		}
 		entries = append(entries, e)
 	}
@@ -1579,6 +1589,24 @@ func (s *Store) ListExpiredTasks(ctx context.Context) ([]*store.Task, error) {
 
 // ── Pending Approvals ─────────────────────────────────────────────────────────
 
+// pendingApprovalColumns is the canonical SELECT list for pending_approvals
+// rows. task_id is included in the symmetric-dedup scope (post-migration 042).
+const pendingApprovalColumns = `
+	id, user_id, request_id, task_id, audit_id, approval_record_id, request_blob,
+	callback_url, status, expires_at, created_at
+`
+
+// taskScopeClause returns a WHERE fragment matching task_id = ? (or task_id IS
+// NULL when taskID == "") and appends the args. Used by every pending-approval
+// + approval-record mutation that needs to address a row in the symmetric
+// scope precisely.
+func taskScopeClause(taskID string, args []any) (string, []any) {
+	if taskID == "" {
+		return "task_id IS NULL", args
+	}
+	return "task_id = ?", append(args, taskID)
+}
+
 func (s *Store) SavePendingApproval(ctx context.Context, pa *store.PendingApproval) error {
 	if pa.ID == "" {
 		pa.ID = uuid.New().String()
@@ -1587,26 +1615,23 @@ func (s *Store) SavePendingApproval(ctx context.Context, pa *store.PendingApprov
 		pa.Status = "pending"
 	}
 	_, err := s.db.ExecContext(ctx, `
-		INSERT INTO pending_approvals (id, user_id, request_id, audit_id, approval_record_id, request_blob, callback_url, status, expires_at)
-		VALUES (?,?,?,?,?,?,?,?,?)
-	`, pa.ID, pa.UserID, pa.RequestID, pa.AuditID, pa.ApprovalRecordID, string(pa.RequestBlob),
+		INSERT INTO pending_approvals (id, user_id, request_id, task_id, audit_id, approval_record_id, request_blob, callback_url, status, expires_at)
+		VALUES (?,?,?,?,?,?,?,?,?,?)
+	`, pa.ID, pa.UserID, pa.RequestID, pa.TaskID, pa.AuditID, pa.ApprovalRecordID, string(pa.RequestBlob),
 		pa.CallbackURL, pa.Status, pa.ExpiresAt.UTC().Format(time.RFC3339))
+	if err != nil && isDuplicate(err) {
+		return store.ErrConflict
+	}
 	return err
 }
 
-func (s *Store) GetPendingApproval(ctx context.Context, requestID string) (*store.PendingApproval, error) {
+func scanPendingApprovalRow(scan func(...any) error) (*store.PendingApproval, error) {
 	pa := &store.PendingApproval{}
 	var requestBlob, expiresAt, createdAt string
-	err := s.db.QueryRowContext(ctx, `
-		SELECT id, user_id, request_id, audit_id, approval_record_id, request_blob, callback_url, status, expires_at, created_at
-		FROM pending_approvals WHERE request_id = ?
-	`, requestID).Scan(
-		&pa.ID, &pa.UserID, &pa.RequestID, &pa.AuditID, &pa.ApprovalRecordID, &requestBlob,
-		&pa.CallbackURL, &pa.Status, &expiresAt, &createdAt)
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil, store.ErrNotFound
-	}
-	if err != nil {
+	if err := scan(
+		&pa.ID, &pa.UserID, &pa.RequestID, &pa.TaskID, &pa.AuditID, &pa.ApprovalRecordID, &requestBlob,
+		&pa.CallbackURL, &pa.Status, &expiresAt, &createdAt,
+	); err != nil {
 		return nil, err
 	}
 	pa.RequestBlob = json.RawMessage(requestBlob)
@@ -1615,16 +1640,76 @@ func (s *Store) GetPendingApproval(ctx context.Context, requestID string) (*stor
 	return pa, nil
 }
 
-func (s *Store) DeletePendingApproval(ctx context.Context, requestID string) error {
+// GetPendingApproval returns the unique pending approval matching
+// (request_id, user_id). Returns ErrAmbiguous when more than one row matches
+// (cross-task reuse under symmetric scope); callers in that case must either
+// disambiguate via GetPendingApprovalByTask or surface 409 to the client via
+// ListPendingApprovalsByRequestID.
+func (s *Store) GetPendingApproval(ctx context.Context, requestID, userID string) (*store.PendingApproval, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT `+pendingApprovalColumns+` FROM pending_approvals
+		 WHERE request_id = ? AND user_id = ?
+		 LIMIT 2`,
+		requestID, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		return nil, store.ErrNotFound
+	}
+	pa, err := scanPendingApprovalRow(rows.Scan)
+	if err != nil {
+		return nil, err
+	}
+	if rows.Next() {
+		return nil, store.ErrAmbiguous
+	}
+	return pa, rows.Err()
+}
+
+// GetPendingApprovalByTask returns the row for an exact
+// (request_id, user_id, task_id). taskID == "" matches the pre-task scope.
+func (s *Store) GetPendingApprovalByTask(ctx context.Context, requestID, userID, taskID string) (*store.PendingApproval, error) {
+	args := []any{requestID, userID}
+	scope, args := taskScopeClause(taskID, args)
+	pa, err := scanPendingApprovalRow(s.db.QueryRowContext(ctx,
+		`SELECT `+pendingApprovalColumns+` FROM pending_approvals
+		 WHERE request_id = ? AND user_id = ? AND `+scope,
+		args...,
+	).Scan)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, store.ErrNotFound
+	}
+	return pa, err
+}
+
+func (s *Store) ListPendingApprovalsByRequestID(ctx context.Context, requestID, userID string) ([]*store.PendingApproval, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT `+pendingApprovalColumns+` FROM pending_approvals
+		 WHERE request_id = ? AND user_id = ?
+		 ORDER BY created_at ASC`,
+		requestID, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanSQLitePendingApprovals(rows)
+}
+
+func (s *Store) DeletePendingApproval(ctx context.Context, requestID, userID, taskID string) error {
+	args := []any{requestID, userID}
+	scope, args := taskScopeClause(taskID, args)
 	_, err := s.db.ExecContext(ctx,
-		`DELETE FROM pending_approvals WHERE request_id = ?`, requestID)
+		`DELETE FROM pending_approvals WHERE request_id = ? AND user_id = ? AND `+scope, args...)
 	return err
 }
 
 func (s *Store) ListPendingApprovals(ctx context.Context, userID string) ([]*store.PendingApproval, error) {
-	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, user_id, request_id, audit_id, approval_record_id, request_blob, callback_url, status, expires_at, created_at
-		FROM pending_approvals WHERE user_id = ? AND status = 'pending' AND expires_at > datetime('now') ORDER BY created_at ASC`, userID)
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT `+pendingApprovalColumns+` FROM pending_approvals
+		 WHERE user_id = ? AND status = 'pending' AND expires_at > datetime('now')
+		 ORDER BY created_at ASC`, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -1633,9 +1718,9 @@ func (s *Store) ListPendingApprovals(ctx context.Context, userID string) ([]*sto
 }
 
 func (s *Store) ListExpiredPendingApprovals(ctx context.Context) ([]*store.PendingApproval, error) {
-	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, user_id, request_id, audit_id, approval_record_id, request_blob, callback_url, status, expires_at, created_at
-		FROM pending_approvals WHERE status = 'pending' AND expires_at < datetime('now')`)
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT `+pendingApprovalColumns+` FROM pending_approvals
+		 WHERE status = 'pending' AND expires_at < datetime('now')`)
 	if err != nil {
 		return nil, err
 	}
@@ -1646,35 +1731,35 @@ func (s *Store) ListExpiredPendingApprovals(ctx context.Context) ([]*store.Pendi
 func scanSQLitePendingApprovals(rows *sql.Rows) ([]*store.PendingApproval, error) {
 	var pas []*store.PendingApproval
 	for rows.Next() {
-		pa := &store.PendingApproval{}
-		var requestBlob, expiresAt, createdAt string
-		if err := rows.Scan(
-			&pa.ID, &pa.UserID, &pa.RequestID, &pa.AuditID, &pa.ApprovalRecordID, &requestBlob,
-			&pa.CallbackURL, &pa.Status, &expiresAt, &createdAt,
-		); err != nil {
+		pa, err := scanPendingApprovalRow(rows.Scan)
+		if err != nil {
 			return nil, err
 		}
-		pa.RequestBlob = json.RawMessage(requestBlob)
-		pa.ExpiresAt = parseTime(expiresAt)
-		pa.CreatedAt = parseTime(createdAt)
 		pas = append(pas, pa)
 	}
 	return pas, rows.Err()
 }
 
-func (s *Store) UpdatePendingApprovalStatus(ctx context.Context, requestID, status string) error {
+func (s *Store) UpdatePendingApprovalStatus(ctx context.Context, requestID, userID, taskID, status string) error {
 	// Guard: only transition from 'pending'. This prevents regressions from
 	// 'approved'/'executing' back to earlier states, which would undermine
 	// the atomicity of ClaimPendingApprovalForExecution.
+	args := []any{status, requestID, userID}
+	scope, args := taskScopeClause(taskID, args)
 	_, err := s.db.ExecContext(ctx,
-		`UPDATE pending_approvals SET status = ? WHERE request_id = ? AND status = 'pending'`, status, requestID)
+		`UPDATE pending_approvals SET status = ?
+		 WHERE request_id = ? AND user_id = ? AND `+scope+` AND status = 'pending'`,
+		args...)
 	return err
 }
 
-func (s *Store) ClaimPendingApprovalForExecution(ctx context.Context, requestID string) (bool, error) {
+func (s *Store) ClaimPendingApprovalForExecution(ctx context.Context, requestID, userID, taskID string) (bool, error) {
+	args := []any{requestID, userID}
+	scope, args := taskScopeClause(taskID, args)
 	res, err := s.db.ExecContext(ctx,
 		`UPDATE pending_approvals SET status = 'executing', executing_since = CURRENT_TIMESTAMP
-		 WHERE request_id = ? AND status = 'approved'`, requestID)
+		 WHERE request_id = ? AND user_id = ? AND `+scope+` AND status = 'approved'`,
+		args...)
 	if err != nil {
 		return false, err
 	}
@@ -1689,10 +1774,14 @@ func (s *Store) ClaimPendingApprovalForExecution(ctx context.Context, requestID 
 // UpdatePendingApprovalStatus. The transition only happens when the row is
 // currently in fromStatus, so concurrent approve/deny pairs from UI vs
 // Telegram vs API can no longer both succeed.
-func (s *Store) UpdatePendingApprovalStatusFrom(ctx context.Context, requestID, fromStatus, toStatus string) (bool, error) {
+func (s *Store) UpdatePendingApprovalStatusFrom(ctx context.Context, requestID, userID, taskID, fromStatus, toStatus string) (bool, error) {
+	args := []any{toStatus, requestID, userID}
+	scope, args := taskScopeClause(taskID, args)
+	args = append(args, fromStatus)
 	res, err := s.db.ExecContext(ctx,
-		`UPDATE pending_approvals SET status = ? WHERE request_id = ? AND status = ?`,
-		toStatus, requestID, fromStatus)
+		`UPDATE pending_approvals SET status = ?
+		 WHERE request_id = ? AND user_id = ? AND `+scope+` AND status = ?`,
+		args...)
 	if err != nil {
 		return false, err
 	}
@@ -1717,10 +1806,9 @@ func (s *Store) ListStalledExecutingApprovals(ctx context.Context, leaseTTL time
 		leaseSeconds = 0
 	}
 	modifier := fmt.Sprintf("-%d seconds", leaseSeconds)
-	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, user_id, request_id, audit_id, approval_record_id, request_blob, callback_url, status, expires_at, created_at
-		FROM pending_approvals
-		WHERE status = 'executing' AND executing_since IS NOT NULL AND executing_since < datetime('now', ?)`, modifier)
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT `+pendingApprovalColumns+` FROM pending_approvals
+		 WHERE status = 'executing' AND executing_since IS NOT NULL AND executing_since < datetime('now', ?)`, modifier)
 	if err != nil {
 		return nil, err
 	}
@@ -1734,17 +1822,21 @@ func (s *Store) ListStalledExecutingApprovals(ctx context.Context, leaseTTL time
 // executor that finishes between list and claim has already DELETE'd the
 // row, so RowsAffected is 0 and the sweeper moves on without dispatching
 // a duplicate "timeout" callback.
-func (s *Store) ClaimStalledExecutingApprovalForRecovery(ctx context.Context, requestID string, leaseTTL time.Duration) (bool, error) {
+func (s *Store) ClaimStalledExecutingApprovalForRecovery(ctx context.Context, requestID, userID, taskID string, leaseTTL time.Duration) (bool, error) {
 	leaseSeconds := int64(leaseTTL.Seconds())
 	if leaseSeconds < 0 {
 		leaseSeconds = 0
 	}
 	modifier := fmt.Sprintf("-%d seconds", leaseSeconds)
-	res, err := s.db.ExecContext(ctx, `
-		DELETE FROM pending_approvals
-		WHERE request_id = ? AND status = 'executing'
-		  AND executing_since IS NOT NULL AND executing_since < datetime('now', ?)`,
-		requestID, modifier)
+	args := []any{requestID, userID}
+	scope, args := taskScopeClause(taskID, args)
+	args = append(args, modifier)
+	res, err := s.db.ExecContext(ctx,
+		`DELETE FROM pending_approvals
+		 WHERE request_id = ? AND user_id = ? AND `+scope+`
+		   AND status = 'executing'
+		   AND executing_since IS NOT NULL AND executing_since < datetime('now', ?)`,
+		args...)
 	if err != nil {
 		return false, err
 	}
@@ -1802,29 +1894,69 @@ func (s *Store) CreateApprovalRecordWithPending(ctx context.Context, rec *store.
 		return err
 	}
 	if _, err = tx.ExecContext(ctx, `
-		INSERT INTO pending_approvals (id, user_id, request_id, audit_id, approval_record_id, request_blob, callback_url, status, expires_at)
-		VALUES (?,?,?,?,?,?,?,?,?)
-	`, pa.ID, pa.UserID, pa.RequestID, pa.AuditID, pa.ApprovalRecordID, string(pa.RequestBlob),
+		INSERT INTO pending_approvals (id, user_id, request_id, task_id, audit_id, approval_record_id, request_blob, callback_url, status, expires_at)
+		VALUES (?,?,?,?,?,?,?,?,?,?)
+	`, pa.ID, pa.UserID, pa.RequestID, pa.TaskID, pa.AuditID, pa.ApprovalRecordID, string(pa.RequestBlob),
 		pa.CallbackURL, pa.Status, pa.ExpiresAt.UTC().Format(time.RFC3339)); err != nil {
+		if isDuplicate(err) {
+			err = store.ErrConflict
+		}
 		return err
 	}
 	return tx.Commit()
 }
 
+const approvalRecordColumns = `
+	id, kind, user_id, agent_id, request_id, task_id, session_id, status, surface,
+	summary_json, payload_json, resolution_transport, expires_at, resolved_at, resolution, created_at, updated_at
+`
+
 func (s *Store) GetApprovalRecord(ctx context.Context, id string) (*store.ApprovalRecord, error) {
-	return s.getApprovalRecord(ctx, `
-		SELECT id, kind, user_id, agent_id, request_id, task_id, session_id, status, surface,
-		       summary_json, payload_json, resolution_transport, expires_at, resolved_at, resolution, created_at, updated_at
-		FROM approval_records WHERE id = ?
-	`, id)
+	return s.getApprovalRecord(ctx,
+		`SELECT `+approvalRecordColumns+` FROM approval_records WHERE id = ?`, id)
 }
 
-func (s *Store) GetApprovalRecordByRequestID(ctx context.Context, requestID string) (*store.ApprovalRecord, error) {
-	return s.getApprovalRecord(ctx, `
-		SELECT id, kind, user_id, agent_id, request_id, task_id, session_id, status, surface,
-		       summary_json, payload_json, resolution_transport, expires_at, resolved_at, resolution, created_at, updated_at
-		FROM approval_records WHERE request_id = ?
-	`, requestID)
+// GetApprovalRecordByRequestID returns the unique approval record matching
+// (request_id, user_id). Returns ErrAmbiguous if more than one matches.
+func (s *Store) GetApprovalRecordByRequestID(ctx context.Context, requestID, userID string) (*store.ApprovalRecord, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT `+approvalRecordColumns+` FROM approval_records
+		 WHERE request_id = ? AND user_id = ?
+		 LIMIT 2`, requestID, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		return nil, store.ErrNotFound
+	}
+	rec, err := scanSQLiteApprovalRecord(rows)
+	if err != nil {
+		return nil, err
+	}
+	if rows.Next() {
+		return nil, store.ErrAmbiguous
+	}
+	return rec, rows.Err()
+}
+
+// GetApprovalRecordByRequestIDAndTask returns the approval record scoped to
+// (request_id, user_id, task_id). taskID == "" matches the pre-task scope
+// (task_id IS NULL).
+func (s *Store) GetApprovalRecordByRequestIDAndTask(ctx context.Context, requestID, userID, taskID string) (*store.ApprovalRecord, error) {
+	args := []any{requestID, userID}
+	scope, args := taskScopeClause(taskID, args)
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT `+approvalRecordColumns+` FROM approval_records
+		 WHERE request_id = ? AND user_id = ? AND `+scope+` LIMIT 1`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		return nil, store.ErrNotFound
+	}
+	return scanSQLiteApprovalRecord(rows)
 }
 
 func (s *Store) ListPendingApprovalRecords(ctx context.Context, userID string) ([]*store.ApprovalRecord, error) {

--- a/pkg/store/sqlite/store_runtime_test.go
+++ b/pkg/store/sqlite/store_runtime_test.go
@@ -103,7 +103,7 @@ func TestRuntimeUnificationRoundTrip(t *testing.T) {
 	if _, err := st.GetApprovalRecord(ctx, approval.ID); err != nil {
 		t.Fatalf("GetApprovalRecord: %v", err)
 	}
-	if _, err := st.GetApprovalRecordByRequestID(ctx, requestID); err != nil {
+	if _, err := st.GetApprovalRecordByRequestID(ctx, requestID, user.ID); err != nil {
 		t.Fatalf("GetApprovalRecordByRequestID: %v", err)
 	}
 	records, err := st.ListPendingApprovalRecords(ctx, user.ID)
@@ -129,7 +129,7 @@ func TestRuntimeUnificationRoundTrip(t *testing.T) {
 	if err := st.SavePendingApproval(ctx, pending); err != nil {
 		t.Fatalf("SavePendingApproval: %v", err)
 	}
-	gotPending, err := st.GetPendingApproval(ctx, requestID)
+	gotPending, err := st.GetPendingApproval(ctx, requestID, user.ID)
 	if err != nil {
 		t.Fatalf("GetPendingApproval: %v", err)
 	}
@@ -457,10 +457,10 @@ func TestPendingApproval_StalledExecutingRecovery(t *testing.T) {
 	}
 
 	// Promote pending → approved → executing (the legitimate hot path).
-	if err := st.UpdatePendingApprovalStatus(ctx, requestID, "approved"); err != nil {
+	if err := st.UpdatePendingApprovalStatus(ctx, requestID, user.ID, "", "approved"); err != nil {
 		t.Fatalf("UpdatePendingApprovalStatus(approved): %v", err)
 	}
-	claimed, err := st.ClaimPendingApprovalForExecution(ctx, requestID)
+	claimed, err := st.ClaimPendingApprovalForExecution(ctx, requestID, user.ID, "")
 	if err != nil {
 		t.Fatalf("ClaimPendingApprovalForExecution: %v", err)
 	}
@@ -490,7 +490,7 @@ func TestPendingApproval_StalledExecutingRecovery(t *testing.T) {
 	}
 
 	// Recovery: deleting the stale row frees the user to re-issue the request.
-	if err := st.DeletePendingApproval(ctx, requestID); err != nil {
+	if err := st.DeletePendingApproval(ctx, requestID, user.ID, ""); err != nil {
 		t.Fatalf("DeletePendingApproval: %v", err)
 	}
 	stalled, err = st.ListStalledExecutingApprovals(ctx, time.Second)
@@ -530,20 +530,20 @@ func TestPendingApproval_StatusCASBlocksConcurrentResolution(t *testing.T) {
 	}
 
 	// First transition wins.
-	won, err := st.UpdatePendingApprovalStatusFrom(ctx, "req-cas-1", "pending", "approved")
+	won, err := st.UpdatePendingApprovalStatusFrom(ctx, "req-cas-1", user.ID, "", "pending", "approved")
 	if err != nil || !won {
 		t.Fatalf("first CAS approve: won=%v err=%v", won, err)
 	}
 
 	// Concurrent attempt to deny the same row must lose, leaving status="approved".
-	won, err = st.UpdatePendingApprovalStatusFrom(ctx, "req-cas-1", "pending", "denied")
+	won, err = st.UpdatePendingApprovalStatusFrom(ctx, "req-cas-1", user.ID, "", "pending", "denied")
 	if err != nil {
 		t.Fatalf("second CAS: %v", err)
 	}
 	if won {
 		t.Fatal("expected second CAS to lose, got won=true")
 	}
-	got, err := st.GetPendingApproval(ctx, "req-cas-1")
+	got, err := st.GetPendingApproval(ctx, "req-cas-1", user.ID)
 	if err != nil {
 		t.Fatalf("GetPendingApproval: %v", err)
 	}
@@ -598,7 +598,7 @@ func TestPendingApproval_ConcurrentResolution_ExactlyOneWinner(t *testing.T) {
 		go func(t string) {
 			defer wg.Done()
 			<-start
-			won, err := st.UpdatePendingApprovalStatusFrom(ctx, "req-race-1", "pending", t)
+			won, err := st.UpdatePendingApprovalStatusFrom(ctx, "req-race-1", user.ID, "", "pending", t)
 			if err != nil {
 				errs.Add(1)
 				return
@@ -659,7 +659,7 @@ func TestClaimPendingApprovalForExecution_ConcurrentClaim_ExactlyOneWinner(t *te
 		go func() {
 			defer wg.Done()
 			<-start
-			won, err := st.ClaimPendingApprovalForExecution(ctx, "req-exec-1")
+			won, err := st.ClaimPendingApprovalForExecution(ctx, "req-exec-1", user.ID, "")
 			if err != nil {
 				errCount.Add(1)
 				firstErr.CompareAndSwap(nil, &err)
@@ -712,7 +712,7 @@ func TestClaimStalledExecutingApprovalForRecovery_ExactlyOneWinner(t *testing.T)
 	if err := st.SavePendingApproval(ctx, pa); err != nil {
 		t.Fatalf("SavePendingApproval: %v", err)
 	}
-	if won, err := st.ClaimPendingApprovalForExecution(ctx, "req-stalled-1"); err != nil || !won {
+	if won, err := st.ClaimPendingApprovalForExecution(ctx, "req-stalled-1", user.ID, ""); err != nil || !won {
 		t.Fatalf("seed claim: won=%v err=%v", won, err)
 	}
 	// SQLite CURRENT_TIMESTAMP and datetime('now') round to whole seconds,
@@ -734,7 +734,7 @@ func TestClaimStalledExecutingApprovalForRecovery_ExactlyOneWinner(t *testing.T)
 		go func() {
 			defer wg.Done()
 			<-start
-			won, err := st.ClaimStalledExecutingApprovalForRecovery(ctx, "req-stalled-1", time.Second)
+			won, err := st.ClaimStalledExecutingApprovalForRecovery(ctx, "req-stalled-1", user.ID, "", time.Second)
 			if err != nil {
 				errCount.Add(1)
 				firstErr.CompareAndSwap(nil, &err)

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -13,6 +13,13 @@ var ErrNotFound = errors.New("store: record not found")
 // ErrConflict is returned when a uniqueness constraint is violated.
 var ErrConflict = errors.New("store: record already exists")
 
+// ErrAmbiguous is returned by request-id-only lookups (GetPendingApproval,
+// GetApprovalRecordByRequestID) when more than one row matches under the
+// symmetric (user_id, request_id, COALESCE(task_id,'')) dedup scope.
+// Callers must disambiguate via the *ByTask variant, or surface 409 to the
+// client with the candidate task_ids enumerated via List*ByRequestID.
+var ErrAmbiguous = errors.New("store: multiple records match without task scope")
+
 // Store is the primary data access interface. All database operations go
 // through this interface; no direct queries are made outside the store package.
 type Store interface {
@@ -97,10 +104,40 @@ type Store interface {
 	LogGatewayRequest(ctx context.Context, entry *GatewayRequestLog) error
 
 	// Audit log
+	//
+	// LogAudit inserts an audit row. If entry.DedupedOf is nil the row is
+	// treated as canonical and subject to the (user_id, request_id,
+	// COALESCE(task_id,'')) WHERE deduped_of IS NULL partial unique index;
+	// a collision returns ErrConflict. The canonical-insertion sites in
+	// handlers/gateway.go gate side effects on a prior FindDedupCandidate
+	// check, so an ErrConflict here means two workers both passed that
+	// check and raced — the loser should look the winner up via
+	// FindDedupCandidate and surface its outcome instead of re-running.
+	// Rows with DedupedOf set are dedup-attempt rows and are outside the
+	// unique index.
 	LogAudit(ctx context.Context, entry *AuditEntry) error
 	UpdateAuditOutcome(ctx context.Context, id, outcome, errMsg string, durationMS int) error
 	GetAuditEntry(ctx context.Context, id, userID string) (*AuditEntry, error)
+	// GetAuditEntryByRequestID returns the latest canonical (deduped_of IS NULL)
+	// audit entry for (request_id, user_id). Used by the polling endpoint and
+	// other callers that don't have task context. Newer canonicals shadow older
+	// ones — agents almost always poll right after submitting, where "latest"
+	// is the entry they care about.
 	GetAuditEntryByRequestID(ctx context.Context, requestID, userID string) (*AuditEntry, error)
+	// GetAuditEntryByRequestIDAndTask returns the canonical audit entry for
+	// (request_id, user_id, task_id). Inverts FindDedupCandidate's precedence:
+	// an exact task_id match wins over a pre-task (task_id IS NULL) canonical,
+	// because callers (the feedback handler) want the row that actually fired
+	// in the agent's task. Pre-task is the fallback when no task-scoped row
+	// exists.
+	GetAuditEntryByRequestIDAndTask(ctx context.Context, requestID, userID, taskID string) (*AuditEntry, error)
+	// FindDedupCandidate returns the canonical audit entry that a new
+	// (request_id, user_id, task_id) request should dedup against, or
+	// ErrNotFound if no candidate exists. Pre-task canonicals (task_id IS NULL)
+	// always win over task-scoped canonicals for the same request_id; within a
+	// tier the oldest row wins. taskID == "" means the caller has no task
+	// context yet (runtime classification path) and only pre-task rows match.
+	FindDedupCandidate(ctx context.Context, requestID, userID, taskID string) (*AuditEntry, error)
 	ListAuditEntries(ctx context.Context, userID string, filter AuditFilter) ([]*AuditEntry, int, error)
 	AuditActivityBuckets(ctx context.Context, userID string, since time.Time, bucketMinutes int) ([]ActivityBucket, error)
 	CreateActivityMute(ctx context.Context, mute *ActivityMute) error
@@ -132,21 +169,45 @@ type Store interface {
 	RevokeTasksByAgent(ctx context.Context, agentID, userID string) (int, error)
 
 	// Pending approvals
+	//
+	// Under the symmetric dedup scope (user_id, request_id,
+	// COALESCE(task_id,'')), two pending approvals with the same request_id
+	// but different task_ids may coexist for one user. Lookups that take
+	// only request_id return ErrAmbiguous in that case; callers must
+	// disambiguate via the *ByTask variant or expose the ambiguity to the
+	// client via ListPendingApprovalsByRequestID.
 	SavePendingApproval(ctx context.Context, pa *PendingApproval) error
-	GetPendingApproval(ctx context.Context, requestID string) (*PendingApproval, error)
+	// GetPendingApproval returns the unique pending approval for
+	// (request_id, user_id). Returns ErrNotFound if no row matches and
+	// ErrAmbiguous if more than one matches.
+	GetPendingApproval(ctx context.Context, requestID, userID string) (*PendingApproval, error)
+	// GetPendingApprovalByTask returns the pending approval scoped to an
+	// exact (request_id, user_id, task_id). taskID == "" matches the
+	// pre-task scope (task_id IS NULL in SQL).
+	GetPendingApprovalByTask(ctx context.Context, requestID, userID, taskID string) (*PendingApproval, error)
+	// ListPendingApprovalsByRequestID returns every pending approval that
+	// matches (request_id, user_id). Used by the approval HTTP handlers to
+	// surface candidate task_ids in a 409 AMBIGUOUS response when a caller
+	// addresses a request_id-only endpoint and more than one row exists.
+	ListPendingApprovalsByRequestID(ctx context.Context, requestID, userID string) ([]*PendingApproval, error)
 	ListPendingApprovals(ctx context.Context, userID string) ([]*PendingApproval, error)
-	DeletePendingApproval(ctx context.Context, requestID string) error
+	// DeletePendingApproval removes the unique pending approval for
+	// (request_id, user_id, task_id). Pass taskID == "" for the pre-task
+	// scope. Callers must always supply task_id (typically read from a
+	// prior Get) so the delete cannot accidentally fan out across siblings.
+	DeletePendingApproval(ctx context.Context, requestID, userID, taskID string) error
 	ListExpiredPendingApprovals(ctx context.Context) ([]*PendingApproval, error)
-	UpdatePendingApprovalStatus(ctx context.Context, requestID, status string) error
+	UpdatePendingApprovalStatus(ctx context.Context, requestID, userID, taskID, status string) error
 	// UpdatePendingApprovalStatusFrom atomically transitions a pending
-	// approval from fromStatus to toStatus. Returns true if the caller won
-	// the race, false if the row was not in fromStatus. Use this for any
+	// approval from fromStatus to toStatus, scoped to a specific row by
+	// (request_id, user_id, task_id). Returns true if the caller won the
+	// race, false if the row was not in fromStatus. Use this for any
 	// approve/deny path that can be raced across UI/Telegram/API.
-	UpdatePendingApprovalStatusFrom(ctx context.Context, requestID, fromStatus, toStatus string) (bool, error)
+	UpdatePendingApprovalStatusFrom(ctx context.Context, requestID, userID, taskID, fromStatus, toStatus string) (bool, error)
 	// ClaimPendingApprovalForExecution atomically transitions a pending approval
 	// from "approved" to "executing". Returns true if the caller won the claim,
 	// false if another caller already claimed it (or the row is not "approved").
-	ClaimPendingApprovalForExecution(ctx context.Context, requestID string) (bool, error)
+	ClaimPendingApprovalForExecution(ctx context.Context, requestID, userID, taskID string) (bool, error)
 	// ListStalledExecutingApprovals returns rows stuck in "executing" beyond
 	// leaseTTL — the recovery hook for daemon crashes mid-execution.
 	ListStalledExecutingApprovals(ctx context.Context, leaseTTL time.Duration) ([]*PendingApproval, error)
@@ -156,7 +217,7 @@ type Store interface {
 	// callers must dispatch the timeout callback only on true. Returns
 	// false (no error) when the executor finished between list and claim
 	// or another sweep already won the race.
-	ClaimStalledExecutingApprovalForRecovery(ctx context.Context, requestID string, leaseTTL time.Duration) (bool, error)
+	ClaimStalledExecutingApprovalForRecovery(ctx context.Context, requestID, userID, taskID string, leaseTTL time.Duration) (bool, error)
 
 	// CreateApprovalRecordWithPending writes the canonical approval record
 	// and its corresponding pending approval row in a single transaction.
@@ -169,7 +230,15 @@ type Store interface {
 	// Canonical approval records
 	CreateApprovalRecord(ctx context.Context, rec *ApprovalRecord) error
 	GetApprovalRecord(ctx context.Context, id string) (*ApprovalRecord, error)
-	GetApprovalRecordByRequestID(ctx context.Context, requestID string) (*ApprovalRecord, error)
+	// GetApprovalRecordByRequestID returns the unique approval record for
+	// (request_id, user_id). Returns ErrNotFound if no row matches and
+	// ErrAmbiguous if more than one matches under the symmetric dedup
+	// scope.
+	GetApprovalRecordByRequestID(ctx context.Context, requestID, userID string) (*ApprovalRecord, error)
+	// GetApprovalRecordByRequestIDAndTask returns the approval record
+	// scoped to an exact (request_id, user_id, task_id). taskID == "" means
+	// pre-task (task_id IS NULL).
+	GetApprovalRecordByRequestIDAndTask(ctx context.Context, requestID, userID, taskID string) (*ApprovalRecord, error)
 	ListPendingApprovalRecords(ctx context.Context, userID string) ([]*ApprovalRecord, error)
 	ClearApprovalRecordRequestID(ctx context.Context, id string) error
 	ResolveApprovalRecord(ctx context.Context, id, resolution, status string, resolvedAt time.Time) error
@@ -436,6 +505,9 @@ type AuditEntry struct {
 	FiltersApplied          json.RawMessage `json:"filters_applied,omitempty"`
 	Verification            json.RawMessage `json:"verification,omitempty"`
 	ErrorMsg                *string         `json:"error_msg,omitempty"`
+	// DedupedOf is set on retry-attempt rows to the id of the canonical
+	// audit entry they shadow. Canonical rows have DedupedOf == nil.
+	DedupedOf *string `json:"deduped_of,omitempty"`
 }
 
 // ActivityMute suppresses noisy runtime egress rows from the activity feed.
@@ -518,6 +590,7 @@ type PendingApproval struct {
 	ID               string          `json:"id"`
 	UserID           string          `json:"user_id"`
 	RequestID        string          `json:"request_id"`
+	TaskID           *string         `json:"task_id,omitempty"`
 	AuditID          string          `json:"audit_id"`
 	ApprovalRecordID *string         `json:"approval_record_id,omitempty"`
 	RequestBlob      json.RawMessage `json:"request_blob"`

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -402,6 +402,10 @@ export interface PendingApproval {
   id: string
   user_id: string
   request_id: string
+  /** task_id disambiguates sibling pending approvals that share request_id
+   *  under symmetric dedup. Round-trip on approve/deny to avoid the 409
+   *  AMBIGUOUS path. */
+  task_id?: string
   audit_id: string
   request_blob: {
     service: string
@@ -788,6 +792,10 @@ export interface WelcomeData {
 
 export interface QueueApproval {
   request_id: string
+  /** task_id disambiguates sibling pending approvals that share request_id
+   *  under symmetric dedup. Round-trip on approve/deny to avoid the 409
+   *  AMBIGUOUS path. */
+  task_id?: string
   audit_id: string
   service: string
   action: string
@@ -1192,12 +1200,25 @@ export const api = {
   },
   approvals: {
     list: () => get<{ entries: PendingApproval[]; total: number }>('/api/approvals'),
-    approve: (requestId: string, resolution?: 'allow_once' | 'allow_session' | 'allow_always') =>
-      post<{ status: string; request_id: string; audit_id: string; resolution?: string; task_id?: string; task_status?: string; task_lifetime?: string; result?: unknown }>
-        (`/api/approvals/${requestId}/approve`, resolution ? { resolution } : {}),
-    deny: (requestId: string) =>
-      post<{ status: string; request_id: string; audit_id: string }>
-        (`/api/approvals/${requestId}/deny`, {}),
+    // taskId is the symmetric-dedup disambiguator. Pass it whenever the
+    // caller has it in scope; the server returns 409 AMBIGUOUS (with
+    // candidate_task_ids in the body) when it's omitted and more than one
+    // pending approval shares the request_id.
+    approve: (
+      requestId: string,
+      resolution?: 'allow_once' | 'allow_session' | 'allow_always',
+      taskId?: string,
+    ) => {
+      const path = `/api/approvals/${requestId}/approve${taskId ? `?task_id=${encodeURIComponent(taskId)}` : ''}`
+      return post<{ status: string; request_id: string; audit_id: string; resolution?: string; task_id?: string; task_status?: string; task_lifetime?: string; result?: unknown }>(
+        path,
+        resolution ? { resolution } : {},
+      )
+    },
+    deny: (requestId: string, taskId?: string) => {
+      const path = `/api/approvals/${requestId}/deny${taskId ? `?task_id=${encodeURIComponent(taskId)}` : ''}`
+      return post<{ status: string; request_id: string; audit_id: string }>(path, {})
+    },
   },
   runtime: {
     status: () => get<RuntimeStatus>('/api/runtime/status'),

--- a/web/src/pages/Overview.tsx
+++ b/web/src/pages/Overview.tsx
@@ -24,19 +24,23 @@ export default function Overview() {
   const liveSessionsUI = !!features?.agent_live_sessions
   const showRuntimeAttention = runtimeActivityUI || liveSessionsUI
 
-  // Deep link mutations for approval requests (moved from Queue)
+  // Deep link mutations for approval requests (moved from Queue). taskId is
+  // forwarded when the notification's deep link supplied it, so the resolve
+  // hits the specific sibling instead of the request_id-only AMBIGUOUS route.
+  type DeepLinkVars = { requestId: string; taskId?: string }
   const deepApproveRequest = useMutation({
-    mutationFn: (requestId: string) => api.approvals.approve(requestId),
-    onSuccess: (_data, requestId) => {
-      setDeepLinkResult(`Request ${requestId.slice(0, 8)}... approved.`)
+    mutationFn: ({ requestId, taskId }: DeepLinkVars) =>
+      api.approvals.approve(requestId, undefined, taskId),
+    onSuccess: (_data, vars) => {
+      setDeepLinkResult(`Request ${vars.requestId.slice(0, 8)}... approved.`)
       qc.invalidateQueries({ queryKey: ['overview'] })
     },
     onError: (err: Error) => setDeepLinkResult(`Approve failed: ${err.message}`),
   })
   const deepDenyRequest = useMutation({
-    mutationFn: (requestId: string) => api.approvals.deny(requestId),
-    onSuccess: (_data, requestId) => {
-      setDeepLinkResult(`Request ${requestId.slice(0, 8)}... denied.`)
+    mutationFn: ({ requestId, taskId }: DeepLinkVars) => api.approvals.deny(requestId, taskId),
+    onSuccess: (_data, vars) => {
+      setDeepLinkResult(`Request ${vars.requestId.slice(0, 8)}... denied.`)
       qc.invalidateQueries({ queryKey: ['overview'] })
     },
     onError: (err: Error) => setDeepLinkResult(`Deny failed: ${err.message}`),
@@ -46,12 +50,13 @@ export default function Overview() {
   useEffect(() => {
     const action = searchParams.get('action')
     const requestId = searchParams.get('request_id')
+    const taskId = searchParams.get('task_id') ?? undefined
     if (!action || !requestId) return
 
     setSearchParams({}, { replace: true })
 
-    if (action === 'approve') deepApproveRequest.mutate(requestId)
-    else if (action === 'deny') deepDenyRequest.mutate(requestId)
+    if (action === 'approve') deepApproveRequest.mutate({ requestId, taskId })
+    else if (action === 'deny') deepDenyRequest.mutate({ requestId, taskId })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
@@ -383,7 +388,7 @@ function ApprovalCard({ item }: { item: QueueItem }) {
   }
 
   const approveMut = useMutation({
-    mutationFn: () => api.approvals.approve(a.request_id, 'allow_once'),
+    mutationFn: () => api.approvals.approve(a.request_id, 'allow_once', a.task_id),
     onSuccess: (res) => {
       setResult(res.status === 'executed' ? 'Approved & executed' : `Outcome: ${res.status}`)
       invalidate()
@@ -391,7 +396,7 @@ function ApprovalCard({ item }: { item: QueueItem }) {
   })
 
   const denyMut = useMutation({
-    mutationFn: () => api.approvals.deny(a.request_id),
+    mutationFn: () => api.approvals.deny(a.request_id, a.task_id),
     onSuccess: () => {
       setResult('Denied')
       invalidate()


### PR DESCRIPTION
## Summary

Replaces the asymmetric audit-only dedup scope with one that covers
`audit_log`, `pending_approvals`, and `approval_records` uniformly on
`UNIQUE(user_id, request_id, COALESCE(task_id, ''))`, and closes the
double-execute window for concurrent identical requests by reserving
the canonical audit row before the adapter call (single-writer
guarantee from the partial unique index).

## What's in the PR

**Schema (migration 042, sqlite + postgres):** drops the inline UNIQUE
constraints on `audit_log` and `pending_approvals`, adds the composite
key, backfills `pending_approvals.task_id` from `audit_log` via
`audit_id`, rewrites `approval_records`' partial unique, and
backfills `notification_messages.target_id` for in-flight approval
rows so post-migration resolvers can still address the Telegram
message.

**Store interface:** `FindDedupCandidate`,
`GetAuditEntryByRequestIDAndTask`, `GetPendingApprovalByTask`,
`ListPendingApprovalsByRequestID`, `GetApprovalRecordByRequestIDAndTask`,
`ErrAmbiguous`. Mutating pending-approval methods take
`(userID, taskID)` explicitly.

**Gateway reservation pattern:** `reserveExecAndWaitLoser` inserts
the canonical `execute`/`pending` row before BOTH the local and
cloud adapter calls. Losers wait for the winner's canonical to
leave `"pending"` and surface its outcome. The early dedup check at
the top of `HandleRequest` also waits when the existing canonical
is an in-flight reservation. **Adapter executes exactly once across
N concurrent identical requests** (pinned by
`TestGateway_Dedup_ConcurrentSameScope_DoesNotDoubleExecuteAdapter`).

**Cancel resilience:** when the HTTP client cancels mid-adapter,
`r.Context()` is `Done` and would have left the reservation stuck
in `"pending"` forever — shadowing every subsequent retry through
the early dedup check. The success/error/missing-credential paths
all finalize the audit row through a fresh
`context.WithTimeout(Background, 5s)` so the canonical reaches a
terminal outcome regardless of client liveness.

**`task_id` end-to-end as an optional disambiguator:**
`?task_id=` everywhere a `request_id` identifies a row
(approve/deny/execute/status), with 409 `AMBIGUOUS` when omitted
on a collision. Notification deep-link URLs, Telegram callback
tokens (`CallbackDecision.TaskID`), and `ApproveByRequestID` /
`DenyByRequestID` all carry it. The feedback handler scopes its
audit lookup to the supplied `task_id`. Runtime tool-use approval
reuse always routes through `GetApprovalRecordByRequestIDAndTask`.

**Frontend:** `PendingApproval` / `QueueApproval` types include
`task_id`; `api.approvals.approve` / `.deny` accept an optional
`taskId` and append it as a query param; `Overview.tsx` forwards
it from each row and from the deep-link URL.

**`events.WaitFor` reliability:** does an initial fetch after
`Subscribe` (so a state transition between the caller's last check
and Subscribe doesn't block until timeout) and polls every 1s as a
fallback for the rare hub buffer-overflow drop. The loser-wait
path above was flaky under heavy parallel load without these.

## Behavior change

Two tasks that reuse the same `request_id` under approval-required
now get **independent** pending approvals (one queue entry per
task). Previously the second task's audit row was silently dedup'd
to the first task's pending. This matches the auto-execute case
where each task gets independent execution. The dashboard / Telegram
/ `/execute` all carry `task_id` end-to-end so resolving one
sibling does not affect the other.

## Test plan

- [x] `go build ./... && go vet ./...` clean
- [x] `go test ./...` clean — including new regression tests:
  - `TestGateway_Dedup_AfterCrossTaskReuse_RetryHitsOwnCanonical` — pre-LogAudit dedup picks the right canonical
  - `TestGateway_Dedup_SameRequestID_DifferentTask_ApprovalRequired_IndependentApprovals` — two pendings, both carry task_id
  - `TestGateway_Dedup_ConcurrentSameScope_RecoversCanonical` — 8 racers converge on one canonical audit_id
  - `TestGateway_Dedup_ConcurrentSameScope_DoesNotDoubleExecuteAdapter` — adapter executes exactly once across 8 racers
  - `TestGateway_Dedup_CanceledClientStillFinalizesExecuteReservation` — client cancel + adapter completes → outcome=executed
  - `TestGateway_Dedup_CanceledClientStillFinalizesMissingCredentialReservation` — client cancel + vault.ErrNotFound → outcome=error
  - `TestApprovals_Ambiguous_Returns409` — 409 shape + `?task_id=` disambiguation
  - `TestGateway_Status_TaskScoped` — status / long-poll respects ?task_id=
  - `TestGateway_NoTaskID_ConcurrentApprovalRaceReturnsCanonicalPending` — pre-task (task_id IS NULL) reservation race converges
  - `TestCallbackTokenStore_TaskIDRoundTrips` — Telegram callback token carries task_id end-to-end
  - `TestEnsureHeldToolUseApproval_PreTaskLookupIgnoresTaskScopedSiblings` — runtime tool-use lookup scopes correctly
- [x] `web` `tsc --noEmit` clean

## Migration notes

Migration 042 rewrites two tables on SQLite (`audit_log` +
`pending_approvals` — see the migration leading comment for the
chain_facts backup dance and expected blocking time). Postgres uses
direct `ALTER` + `CREATE UNIQUE INDEX`. The
`pending_approvals.task_id` backfill joins audit_log on audit_id;
rows pre-dating the migration get their task_id from the audit row
they back. `notification_messages.target_id` for type='approval' is
rewritten to the composed `request_id|task_id` key so existing
Telegram messages remain addressable post-migration.

## Known limitation

The reservation closes the double-execute window for concurrent
identical requests; it does not protect against process crashes
mid-adapter (the reservation row stays "pending" until the next
gateway request through the early dedup check waits on it). The
existing stalled-executing recovery sweeper covers the same shape
for approved+executing pending approvals; extending it to the
gateway reservation is out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)