### PR TITLE
fix(mcp): url-encode timeout param and add injection tests

### DIFF
--- a/internal/mcp/tools_exec.go
+++ b/internal/mcp/tools_exec.go
@@ -218,7 +218,7 @@ func buildWaitQuery(args map[string]json.RawMessage, getString func(string) stri
 	}
 	q := "?wait=true"
 	if t := getString("timeout"); t != "" {
-		q += "&timeout=" + t
+		q += "&timeout=" + url.QueryEscape(t)
 	}
 	return q
 }

--- a/internal/mcp/tools_exec_test.go
+++ b/internal/mcp/tools_exec_test.go
@@ -1,0 +1,134 @@
+package mcp
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func args(t *testing.T, kv map[string]any) json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(kv)
+	if err != nil {
+		t.Fatalf("marshal args: %v", err)
+	}
+	return b
+}
+
+func TestBuildInternalRequest_FetchCatalog_ServiceParam(t *testing.T) {
+	tests := []struct {
+		name        string
+		service     any
+		wantPath    string
+		wantNoParam string // must NOT appear as a separate query param
+	}{
+		{
+			name:     "normal service value",
+			service:  "google.gmail",
+			wantPath: "/api/skill/catalog?service=google.gmail",
+		},
+		{
+			name:        "injection via ampersand",
+			service:     "google.gmail&admin=true",
+			wantPath:    "/api/skill/catalog?service=google.gmail%26admin%3Dtrue",
+			wantNoParam: "&admin=true",
+		},
+		{
+			name:        "injection via equals",
+			service:     "google.gmail=foo",
+			wantPath:    "/api/skill/catalog?service=google.gmail%3Dfoo",
+			wantNoParam: "&foo",
+		},
+		{
+			name:     "spaces encoded",
+			service:  "google gmail",
+			wantPath: "/api/skill/catalog?service=google+gmail",
+		},
+		{
+			name:     "empty service omits query string",
+			service:  "",
+			wantPath: "/api/skill/catalog",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var a json.RawMessage
+			if tt.service == "" {
+				a = args(t, map[string]any{})
+			} else {
+				a = args(t, map[string]any{"service": tt.service})
+			}
+			route, _, err := buildInternalRequest("fetch_catalog", a)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if route.path != tt.wantPath {
+				t.Errorf("path = %q, want %q", route.path, tt.wantPath)
+			}
+			if tt.wantNoParam != "" && strings.Contains(route.path, tt.wantNoParam) {
+				t.Errorf("path %q contains injected param %q", route.path, tt.wantNoParam)
+			}
+		})
+	}
+}
+
+func TestBuildInternalRequest_TimeoutParam(t *testing.T) {
+	tests := []struct {
+		name        string
+		toolName    string
+		extraArgs   map[string]any
+		wantContains string
+		wantMissing  string
+	}{
+		{
+			name:         "normal timeout value",
+			toolName:     "gateway_request",
+			extraArgs:    map[string]any{"wait": true, "timeout": "120"},
+			wantContains: "timeout=120",
+		},
+		{
+			name:        "injection via ampersand in timeout",
+			toolName:    "gateway_request",
+			extraArgs:   map[string]any{"wait": true, "timeout": "120&admin=true"},
+			wantContains: "timeout=120%26admin%3Dtrue",
+			wantMissing:  "&admin=true",
+		},
+		{
+			name:        "injection via equals in timeout",
+			toolName:    "gateway_request",
+			extraArgs:   map[string]any{"wait": true, "timeout": "120=foo"},
+			wantContains: "timeout=120%3Dfoo",
+			wantMissing:  "=foo&",
+		},
+		{
+			name:         "no timeout omits timeout param",
+			toolName:     "gateway_request",
+			extraArgs:    map[string]any{"wait": true},
+			wantContains: "?wait=true",
+			wantMissing:  "timeout",
+		},
+		{
+			name:        "wait=false ignores timeout entirely",
+			toolName:    "gateway_request",
+			extraArgs:   map[string]any{"wait": false, "timeout": "120&admin=true"},
+			wantMissing: "wait",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := args(t, tt.extraArgs)
+			route, _, err := buildInternalRequest(tt.toolName, a)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantContains != "" && !strings.Contains(route.path, tt.wantContains) {
+				t.Errorf("path %q does not contain %q", route.path, tt.wantContains)
+			}
+			if tt.wantMissing != "" && strings.Contains(route.path, tt.wantMissing) {
+				t.Errorf("path %q should not contain %q", route.path, tt.wantMissing)
+			}
+		})
+	}
+}


### PR DESCRIPTION

## Summary

Follow-up to #[prev-pr-number] which fixed the `service` param in `fetch_catalog`. As flagged by @[maintainer] in review, `buildWaitQuery` had the same injection class via the `timeout` parameter. This PR fixes that and adds tests covering both params.

## The Bug

In `buildWaitQuery`, the agent-supplied `timeout` value was concatenated raw into the query string:

```go
// before
q += "&timeout=" + t
```

The tool schema declares `timeout` as an integer, but `getString` reads it as a string. An agent could send `"timeout": "120&admin=true"` as a JSON string and the URL becomes:

```
?wait=true&timeout=120&admin=true
```

The server sees `admin=true` as a real separate parameter. Same injection class as the `service` fix, just via a different parameter. Affects `create_task`, `get_task`, `expand_task`, `gateway_request`, `gateway_batch`, and `execute_request` - all tools that call `buildWaitQuery`.

## Fix

```go
// after
q += "&timeout=" + url.QueryEscape(t)
```

`&` becomes `%26`, `=` becomes `%3D`. The injected content stays inside the `timeout` value and never reaches the server as a separate param.

## Tests

Added `internal/mcp/tools_exec_test.go` covering both `service` and `timeout` params:

**service param cases:**
- normal value passes through unchanged
- `&` injection encoded correctly
- `=` injection encoded correctly
- spaces encoded correctly
- empty value omits the query string entirely

**timeout param cases:**
- normal value passes through unchanged
- `&` injection encoded correctly
- `=` injection encoded correctly
- no timeout omits the param entirely
- `wait=false` ignores timeout altogether
<img width="1179" height="669" alt="image" src="https://github.com/user-attachments/assets/f966dd39-ac2c-46e4-9436-d29bb39f88d4" />

## Files Changed

| File | Change |
|------|--------|
| `internal/mcp/tools_exec.go` | Add `net/url` import, encode `timeout` param |
| `internal/mcp/tools_exec_test.go` | New file - injection tests for `service` and `timeout` |
