### PR TITLE
fix(intent): clean builtin email extraction and add chain_extraction opt-in

### DIFF
--- a/internal/api/handlers/chain_extraction_mode_test.go
+++ b/internal/api/handlers/chain_extraction_mode_test.go
@@ -1,0 +1,29 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+func TestResolveChainExtractionMode(t *testing.T) {
+	cases := []struct {
+		name string
+		task *store.Task
+		want string
+	}{
+		{"nil task falls through to default", nil, chainExtractionFull},
+		{"unset task field falls through to default", &store.Task{}, chainExtractionFull},
+		{"explicit full", &store.Task{ChainExtractionMode: "full"}, chainExtractionFull},
+		{"explicit builtins_only", &store.Task{ChainExtractionMode: "builtins_only"}, chainExtractionBuiltinsOnly},
+		{"unrecognized value falls through to default", &store.Task{ChainExtractionMode: "garbage"}, chainExtractionFull},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveChainExtractionMode(tc.task)
+			if got != tc.want {
+				t.Errorf("resolveChainExtractionMode(%+v) = %q, want %q", tc.task, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -1160,7 +1160,11 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 					}
 
 					// Phase 2: LLM (slower, seconds). Returns only NEW facts
-					// beyond what builtins captured.
+					// beyond what builtins captured. Skipped when the task
+					// opted into builtins_only mode.
+					if resolveChainExtractionMode(task) == chainExtractionBuiltinsOnly {
+						return
+					}
 					extractCtx, extractCancel := context.WithTimeout(context.Background(), 30*time.Second)
 					defer extractCancel()
 					llmFacts, err := h.extractor.ExtractLLM(extractCtx, extractReq, builtinFacts)
@@ -2048,6 +2052,28 @@ const (
 	extractionPollInterval = 250 * time.Millisecond
 	extractionPollMaxWait  = 1500 * time.Millisecond
 )
+
+// Chain extraction modes. The empty string means "use the system default".
+// The system default is currently `chainExtractionFull` (today's behavior);
+// flipping the default is a one-line change in resolveChainExtractionMode.
+const (
+	chainExtractionFull         = "full"
+	chainExtractionBuiltinsOnly = "builtins_only"
+)
+
+// resolveChainExtractionMode returns the effective chain-extraction mode for
+// a task. An unset (empty) task-level value defers to the system default. The
+// system default is intentionally `chainExtractionFull` for now — Phase 3's
+// eval-suite gate has to pass before we flip the default to builtins_only.
+func resolveChainExtractionMode(task *store.Task) string {
+	if task != nil {
+		switch task.ChainExtractionMode {
+		case chainExtractionFull, chainExtractionBuiltinsOnly:
+			return task.ChainExtractionMode
+		}
+	}
+	return chainExtractionFull
+}
 
 // chainContextFallback handles chain context violations by checking whether
 // the missing values actually exist in the chain facts. Three outcomes:

--- a/internal/api/handlers/tasks.go
+++ b/internal/api/handlers/tasks.go
@@ -133,6 +133,7 @@ type createTaskRequest struct {
 	ExpectedTools          []runtimetasks.ExpectedTool   `json:"expected_tools_json,omitempty"`
 	ExpectedEgress         []runtimetasks.ExpectedEgress `json:"expected_egress_json,omitempty"`
 	IntentVerificationMode string                        `json:"intent_verification_mode,omitempty"`
+	ChainExtractionMode    string                        `json:"chain_extraction_mode,omitempty"` // "" | "full" | "builtins_only"
 	ExpectedUse            string                        `json:"expected_use,omitempty"`
 	SchemaVersion          int                           `json:"schema_version,omitempty"`
 	ExpiresInSeconds       int                           `json:"expires_in_seconds"`
@@ -442,6 +443,17 @@ func (h *TasksHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// chain_extraction_mode is a small enum; reject unknown values before the
+	// dedup lookup so an invalid value can't surface a cached 201 response,
+	// and so the mode participates correctly in the dedup key below.
+	switch req.ChainExtractionMode {
+	case "", "full", "builtins_only":
+	default:
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST",
+			`chain_extraction_mode must be "", "full", or "builtins_only"`)
+		return
+	}
+
 	// Content-based dedup: if an identical task creation request was recently made
 	// by the same agent, return the existing task instead of creating a duplicate.
 	//
@@ -449,6 +461,8 @@ func (h *TasksHandler) Create(w http.ResponseWriter, r *http.Request) {
 	// intent_verification_mode, expected_use, schema_version) only participate in
 	// the hash when any are non-empty. v1-only requests therefore produce the
 	// same fingerprint they did pre-#310, preserving the existing dedup window.
+	// chain_extraction_mode is treated the same way: only enters the key when
+	// set, so default tasks keep their existing fingerprint.
 	dedupParts := []any{"task", agent.ID, req.Purpose, req.AuthorizedActions}
 	if len(req.PlannedCalls) > 0 ||
 		len(req.ExpectedTools) > 0 ||
@@ -466,6 +480,9 @@ func (h *TasksHandler) Create(w http.ResponseWriter, r *http.Request) {
 		)
 	}
 	dedupParts = append(dedupParts, lifetime)
+	if req.ChainExtractionMode != "" {
+		dedupParts = append(dedupParts, "chain_extraction_mode", req.ChainExtractionMode)
+	}
 	taskDedupKey := buildDedupKey(dedupParts...)
 	if cached, ok := h.contentDedup.Get(taskDedupKey); ok {
 		resp := cached.(map[string]any)
@@ -489,6 +506,7 @@ func (h *TasksHandler) Create(w http.ResponseWriter, r *http.Request) {
 		AuthorizedActions:      req.AuthorizedActions,
 		PlannedCalls:           req.PlannedCalls,
 		IntentVerificationMode: env.IntentVerificationMode,
+		ChainExtractionMode:    req.ChainExtractionMode,
 		ExpectedUse:            req.ExpectedUse,
 		SchemaVersion:          schemaVersion,
 		ExpiresInSeconds:       expiresIn,

--- a/internal/intent/extractor.go
+++ b/internal/intent/extractor.go
@@ -830,13 +830,15 @@ func builtinPatterns(service, action string) []extractionPattern {
 // builtinPatternsRaw returns the per-service patterns without setting a
 // Source — the public builtinPatterns wrapper handles that uniformly.
 func builtinPatternsRaw(service, action string) []extractionPattern {
-	// Generic patterns that apply to most JSON API responses. Includes a
-	// permissive entity_id catch for any "id" field with an 8+ char value;
-	// service-specific patterns below typically also extract these values
-	// under more precise fact_types, and dedupe handles the overlap.
+	// Generic patterns that apply to most JSON API responses. The
+	// email_address pattern strips a "Display Name <…>" prefix (both literal
+	// `<`/`>` and JSON-escaped `<`/`>` forms) so the captured value
+	// is just the address. Known services add more precise fact_types below;
+	// the catch-all entity_id pattern fires only on the default branch so
+	// known services don't emit duplicate (entity_id, message_id) rows for
+	// the same value.
 	generic := []extractionPattern{
-		{FactType: "email_address", Regex: `"(?:email|emailAddress|from|to|sender|recipient)":\s*"([^"]+@[^"]+)"`},
-		{FactType: "entity_id", Regex: `"id":\s*"([^"]{8,})"`},
+		{FactType: "email_address", Regex: `"(?:email|emailAddress|from|to|sender|recipient|cc|bcc|replyTo|reply_to)":\s*"(?:[^"]*?(?:<|\\u003c)\s*)?([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})\s*(?:>|\\u003e)?\s*"`},
 	}
 
 	svc := strings.SplitN(service, ":", 2)[0] // strip instance suffix
@@ -846,23 +848,19 @@ func builtinPatternsRaw(service, action string) []extractionPattern {
 		return append(generic,
 			extractionPattern{FactType: "message_id", Regex: `"id":\s*"([a-f0-9]{16})"`},
 			extractionPattern{FactType: "thread_id", Regex: `"threadId":\s*"([a-f0-9]{16})"`},
-			extractionPattern{FactType: "email_address", Regex: `"email":\s*"([^"]+@[^"]+)"`},
 		)
 	case "google.drive":
 		return append(generic,
 			extractionPattern{FactType: "file_id", Regex: `"id":\s*"([^"]+)"`},
-			extractionPattern{FactType: "email_address", Regex: `"emailAddress":\s*"([^"]+@[^"]+)"`},
 		)
 	case "google.calendar":
 		// Google Calendar event IDs are lowercase base32 (5-1024 chars),
 		// optionally prefixed with "_" for imported events, with an optional
 		// "_<UTC_datetime>Z" suffix for recurring instances. Tight to avoid
 		// labeling calendar IDs (e.g. "primary", "x@group.calendar.google.com")
-		// as event_ids; those still get captured by the generic entity_id
-		// fallback in the shared block above.
+		// as event_ids. Calendar IDs themselves are not extracted as facts.
 		return append(generic,
 			extractionPattern{FactType: "event_id", Regex: `"id":\s*"(_?[a-z0-9]+(?:_[0-9]{8}T[0-9]{6}Z)?)"`},
-			extractionPattern{FactType: "email_address", Regex: `"email":\s*"([^"]+@[^"]+)"`},
 		)
 	case "google.contacts":
 		return append(generic,
@@ -895,10 +893,13 @@ func builtinPatternsRaw(service, action string) []extractionPattern {
 			extractionPattern{FactType: "phone_number", Regex: `"(?:handle|sender|recipient)":\s*"(\+?[\d]{10,})"`},
 		)
 	default:
-		// Unknown service: rely entirely on the generic block, which already
-		// emits an entity_id pattern with an 8+ char minimum and the email
-		// pattern. No service-specific additions.
-		return generic
+		// Unknown service: also emit a catch-all entity_id pattern for any
+		// "id" field with an 8+ char value. Known services above declare
+		// their own ID fact_types, so this fires only on the default branch
+		// to avoid duplicate (entity_id, <service>_id) rows for the same value.
+		return append(generic,
+			extractionPattern{FactType: "entity_id", Regex: `"id":\s*"([^"]{8,})"`},
+		)
 	}
 }
 

--- a/internal/intent/extractor_test.go
+++ b/internal/intent/extractor_test.go
@@ -166,6 +166,63 @@ func TestBuiltinPatterns_Gmail(t *testing.T) {
 	}
 }
 
+func TestBuiltinPatterns_EmailDisplayName(t *testing.T) {
+	patterns := builtinPatterns("google.gmail", "list_messages")
+
+	cases := []struct {
+		name   string
+		result string
+		want   []string
+		reject []string
+	}{
+		{
+			name:   "literal angle brackets",
+			result: `{"from":"Tom Wilson <tom.wilson@example.com>","to":"Alice Park <alice.park@example.org>","cc":"Ben Liu <ben.liu@example.net>"}`,
+			want:   []string{"tom.wilson@example.com", "alice.park@example.org", "ben.liu@example.net"},
+			reject: []string{"Tom Wilson <tom.wilson@example.com>", "<tom.wilson@example.com>"},
+		},
+		{
+			name:   "unicode-escaped angle brackets",
+			result: `{"from":"Tom Wilson \u003ctom.wilson@example.com\u003e","to":"Alice Park \u003calice.park@example.org\u003e"}`,
+			want:   []string{"tom.wilson@example.com", "alice.park@example.org"},
+			reject: []string{`Tom Wilson \u003ctom.wilson@example.com\u003e`, `\u003ctom.wilson@example.com\u003e`, `tom.wilson@example.com\u003e`},
+		},
+		{
+			name:   "bare email (no display name)",
+			result: `{"from":"dana.chen@example.com","sender":"morgan.kim@example.org"}`,
+			want:   []string{"dana.chen@example.com", "morgan.kim@example.org"},
+		},
+		{
+			name:   "malformed local-only address is excluded",
+			result: `{"from":"kira@","to":"noor@"}`,
+			want:   nil,
+			reject: []string{"kira@", "noor@"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			matches := runExtractionPatterns(patterns, tc.result, slog.Default(), "test")
+			values := make(map[string]bool)
+			for _, m := range matches {
+				if m.factType == "email_address" {
+					values[m.factValue] = true
+				}
+			}
+			for _, w := range tc.want {
+				if !values[w] {
+					t.Errorf("expected email_address %q in matches; got %v", w, values)
+				}
+			}
+			for _, r := range tc.reject {
+				if values[r] {
+					t.Errorf("did not expect email_address %q in matches", r)
+				}
+			}
+		})
+	}
+}
+
 func TestBuiltinPatterns_Drive(t *testing.T) {
 	patterns := builtinPatterns("google.drive", "list_files")
 	result := `{"files":[{"id":"file_001_abc","owners":[{"emailAddress":"bob@co.com"}]}]}`
@@ -210,8 +267,8 @@ func TestBuiltinPatterns_Calendar(t *testing.T) {
 }
 
 func TestBuiltinPatterns_GenericEntityIDFallback(t *testing.T) {
-	// Unknown service: the cross-service generic block should still emit an
-	// entity_id pattern that catches any "id" field with an 8+ char value.
+	// Unknown service: the default arm should still emit an entity_id pattern
+	// that catches any "id" field with an 8+ char value.
 	patterns := builtinPatterns("some.new.saas", "list_things")
 	result := `{"things":[{"id":"thing_abc12345"},{"id":"42"}]}`
 	matches := runExtractionPatterns(patterns, result, slog.Default(), "test")
@@ -224,6 +281,34 @@ func TestBuiltinPatterns_GenericEntityIDFallback(t *testing.T) {
 	}
 	if found["entity_id|42"] {
 		t.Error("entity_id 42 should NOT be captured (under 8-char minimum)")
+	}
+}
+
+func TestBuiltinPatterns_NoEntityIDForKnownServices(t *testing.T) {
+	// Services with their own ID fact_types should not emit a redundant
+	// entity_id row for the same value. The 8+ char generic catch is only
+	// for unknown services.
+	cases := []struct {
+		service string
+		result  string
+	}{
+		{"google.gmail", `{"messages":[{"id":"19d5fe858c900042","threadId":"19d5fe858c900040"}]}`},
+		{"google.drive", `{"files":[{"id":"1BxR7a3mNpQ9vK2wL5sYcTfDgHjKlMnO"}]}`},
+		{"google.calendar", `{"data":[{"id":"1pj4096shhq40g6hkl995jrqfo"}]}`},
+		{"slack", `{"channels":[{"id":"C0123456789"}]}`},
+		{"linear", `{"issues":[{"id":"3a7c8e1b-2d4f-49a0-91c5-b7e1f8d2c4a6","identifier":"ENG-123"}]}`},
+		{"stripe", `{"charges":[{"id":"ch_3OdN8h2eZvKYlo2C0H8Vp9wY"}]}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.service, func(t *testing.T) {
+			patterns := builtinPatterns(tc.service, "list_x")
+			matches := runExtractionPatterns(patterns, tc.result, slog.Default(), "test")
+			for _, m := range matches {
+				if m.factType == "entity_id" {
+					t.Errorf("did not expect entity_id match for %s, got %q", tc.service, m.factValue)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/intent/testdata/extract_eval_cases.json
+++ b/internal/intent/testdata/extract_eval_cases.json
@@ -1101,5 +1101,58 @@
         "Re: integration plan"
       ]
     }
+  },
+  {
+    "name": "format_display_name_literal_angle_brackets",
+    "category": "format_compliance",
+    "request": {
+      "task_purpose": "Read message thread",
+      "service": "google.gmail",
+      "action": "list_messages",
+      "result": "{\"data\":[{\"id\":\"18de3f7a2b4c6d90\",\"from\":\"Tom Wilson <tom.wilson@example.com>\",\"to\":\"Alice Park <alice.park@example.org>\",\"cc\":\"Ben Liu <ben.liu@example.net>\"}]}"
+    },
+    "expected": {
+      "min_facts": 3,
+      "must_include_types": [
+        "email_address"
+      ],
+      "must_include_values": [
+        "tom.wilson@example.com",
+        "alice.park@example.org",
+        "ben.liu@example.net"
+      ],
+      "must_exclude_values": [
+        "Tom Wilson <tom.wilson@example.com>",
+        "<tom.wilson@example.com>",
+        "Alice Park <alice.park@example.org>",
+        "Ben Liu <ben.liu@example.net>"
+      ]
+    }
+  },
+  {
+    "name": "format_display_name_unicode_escaped_angle_brackets",
+    "category": "format_compliance",
+    "request": {
+      "task_purpose": "Read message thread",
+      "service": "google.gmail",
+      "action": "list_messages",
+      "result": "{\"data\":[{\"id\":\"18de3f7a2b4c6d90\",\"from\":\"Tom Wilson \\u003ctom.wilson@example.com\\u003e\",\"to\":\"Alice Park \\u003calice.park@example.org\\u003e\"}]}"
+    },
+    "expected": {
+      "min_facts": 2,
+      "must_include_types": [
+        "email_address"
+      ],
+      "must_include_values": [
+        "tom.wilson@example.com",
+        "alice.park@example.org"
+      ],
+      "must_exclude_values": [
+        "Tom Wilson \\u003ctom.wilson@example.com\\u003e",
+        "\\u003ctom.wilson@example.com\\u003e",
+        "tom.wilson@example.com\\u003e",
+        "Tom Wilson <tom.wilson@example.com>"
+      ]
+    }
   }
 ]

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -97,6 +97,7 @@ func toolDefs() []Tool {
 						"description": "Optional pre-registered calls. Calls matching a planned call skip per-request intent verification. Each must be covered by authorized_actions and must include params."
 					},
 					"intent_verification_mode": {"type": "string", "enum": ["strict", "lenient", "off"], "description": "Runtime intent verification strictness for v2 envelopes. Defaults to strict."},
+					"chain_extraction_mode": {"type": "string", "enum": ["full", "builtins_only"], "description": "Async chain-context extraction mode for this task. \"full\" runs the LLM Phase-2 extraction pass; \"builtins_only\" skips it and relies only on the synchronous builtin regex patterns. Omit to defer to the system default."},
 					"expected_use": {"type": "string", "description": "Top-level intended use summary for runtime-backed tasks"},
 					"schema_version": {"type": "integer", "enum": [1, 2], "description": "Task schema version. Use 2 when sending expected_tools_json, expected_egress_json, intent_verification_mode, or expected_use."},
 					"expires_in_seconds": {"type": "integer", "description": "Session task expiry in seconds (default 1800)"},

--- a/pkg/store/postgres/migrations/043_tasks_chain_extraction_mode.sql
+++ b/pkg/store/postgres/migrations/043_tasks_chain_extraction_mode.sql
@@ -1,0 +1,9 @@
+-- Per-task override for chain-context extraction mode. NULL or "" means the
+-- system default applies (today: full Phase-2 LLM extraction). "builtins_only"
+-- skips the async LLM extraction pass — only the synchronous builtin regex
+-- patterns run. "full" forces today's behavior even after the system default
+-- is flipped to builtins_only.
+--
+-- Enforced in the gateway's extraction dispatch; see resolveChainExtractionMode
+-- in internal/api/handlers/gateway.go.
+ALTER TABLE tasks ADD COLUMN chain_extraction_mode TEXT;

--- a/pkg/store/postgres/store.go
+++ b/pkg/store/postgres/store.go
@@ -1007,14 +1007,15 @@ func (s *Store) CreateTask(ctx context.Context, task *store.Task) error {
 		INSERT INTO tasks (id, user_id, agent_id, purpose, status, authorized_actions, planned_calls, callback_url,
 			expires_in_seconds, approved_at, expires_at, pending_action, pending_reason, lifetime,
 			risk_level, risk_details, approval_source, approval_rationale, expected_tools_json,
-			expected_egress_json, intent_verification_mode, expected_use, schema_version)
-		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23)
+			expected_egress_json, intent_verification_mode, expected_use, schema_version, chain_extraction_mode)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24)
 	`, task.ID, task.UserID, task.AgentID, task.Purpose, task.Status,
 		actionsJSON, plannedCallsJSON, task.CallbackURL, task.ExpiresInSeconds,
 		task.ApprovedAt, task.ExpiresAt,
 		nilIfEmpty(pendingActionJSON), task.PendingReason, task.Lifetime,
 		task.RiskLevel, string(riskDetails), task.ApprovalSource, approvalRationale,
-		expectedToolsJSON, expectedEgressJSON, task.IntentVerificationMode, task.ExpectedUse, task.SchemaVersion)
+		expectedToolsJSON, expectedEgressJSON, task.IntentVerificationMode, task.ExpectedUse, task.SchemaVersion,
+		task.ChainExtractionMode)
 	return err
 }
 
@@ -1022,18 +1023,20 @@ func (s *Store) GetTask(ctx context.Context, id string) (*store.Task, error) {
 	t := &store.Task{}
 	var actionsJSON, plannedCallsJSON, pendingActionJSON, expectedToolsJSON, expectedEgressJSON []byte
 	var riskDetailsStr, approvalRationaleStr string
+	var chainExtractionMode *string
 	err := s.pool.QueryRow(ctx, `
 		SELECT id, user_id, agent_id, purpose, status, authorized_actions, planned_calls, callback_url,
 		       created_at, approved_at, expires_at, expires_in_seconds, request_count,
 		       pending_action, pending_reason, lifetime, risk_level, risk_details,
 		       approval_source, approval_rationale, expected_tools_json, expected_egress_json,
-		       intent_verification_mode, expected_use, schema_version
+		       intent_verification_mode, expected_use, schema_version, chain_extraction_mode
 		FROM tasks WHERE id = $1
 	`, id).Scan(&t.ID, &t.UserID, &t.AgentID, &t.Purpose, &t.Status, &actionsJSON,
 		&plannedCallsJSON, &t.CallbackURL, &t.CreatedAt, &t.ApprovedAt, &t.ExpiresAt, &t.ExpiresInSeconds,
 		&t.RequestCount, &pendingActionJSON, &t.PendingReason, &t.Lifetime,
 		&t.RiskLevel, &riskDetailsStr, &t.ApprovalSource, &approvalRationaleStr,
-		&expectedToolsJSON, &expectedEgressJSON, &t.IntentVerificationMode, &t.ExpectedUse, &t.SchemaVersion)
+		&expectedToolsJSON, &expectedEgressJSON, &t.IntentVerificationMode, &t.ExpectedUse, &t.SchemaVersion,
+		&chainExtractionMode)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, store.ErrNotFound
 	}
@@ -1067,6 +1070,9 @@ func (s *Store) GetTask(ctx context.Context, id string) (*store.Task, error) {
 	if expectedEgressJSON != nil {
 		t.ExpectedEgress = json.RawMessage(expectedEgressJSON)
 	}
+	if chainExtractionMode != nil {
+		t.ChainExtractionMode = *chainExtractionMode
+	}
 	return t, nil
 }
 
@@ -1097,7 +1103,7 @@ func (s *Store) ListTasks(ctx context.Context, userID string, filter store.TaskF
 		       created_at, approved_at, expires_at, expires_in_seconds, request_count,
 		       pending_action, pending_reason, lifetime, risk_level, risk_details,
 		       approval_source, approval_rationale, expected_tools_json, expected_egress_json,
-		       intent_verification_mode, expected_use, schema_version
+		       intent_verification_mode, expected_use, schema_version, chain_extraction_mode
 		FROM tasks ` + where + ` ORDER BY created_at DESC`
 
 	if filter.Limit > 0 {
@@ -1267,7 +1273,7 @@ func (s *Store) ListExpiredTasks(ctx context.Context) ([]*store.Task, error) {
 		       created_at, approved_at, expires_at, expires_in_seconds, request_count,
 		       pending_action, pending_reason, lifetime, risk_level, risk_details,
 		       approval_source, approval_rationale, expected_tools_json, expected_egress_json,
-		       intent_verification_mode, expected_use, schema_version
+		       intent_verification_mode, expected_use, schema_version, chain_extraction_mode
 		FROM tasks WHERE status = 'active' AND lifetime = 'session' AND expires_at < NOW()
 	`)
 	if err != nil {
@@ -1283,12 +1289,17 @@ func scanTasks(rows pgx.Rows) ([]*store.Task, error) {
 		t := &store.Task{}
 		var actionsJSON, plannedCallsJSON, pendingActionJSON, expectedToolsJSON, expectedEgressJSON []byte
 		var riskDetailsStr, approvalRationaleStr string
+		var chainExtractionMode *string
 		if err := rows.Scan(&t.ID, &t.UserID, &t.AgentID, &t.Purpose, &t.Status, &actionsJSON,
 			&plannedCallsJSON, &t.CallbackURL, &t.CreatedAt, &t.ApprovedAt, &t.ExpiresAt, &t.ExpiresInSeconds,
 			&t.RequestCount, &pendingActionJSON, &t.PendingReason, &t.Lifetime,
 			&t.RiskLevel, &riskDetailsStr, &t.ApprovalSource, &approvalRationaleStr,
-			&expectedToolsJSON, &expectedEgressJSON, &t.IntentVerificationMode, &t.ExpectedUse, &t.SchemaVersion); err != nil {
+			&expectedToolsJSON, &expectedEgressJSON, &t.IntentVerificationMode, &t.ExpectedUse, &t.SchemaVersion,
+			&chainExtractionMode); err != nil {
 			return nil, err
+		}
+		if chainExtractionMode != nil {
+			t.ChainExtractionMode = *chainExtractionMode
 		}
 		// authorized_actions IS the task scope — fail loudly rather than load
 		// a task with no authorized actions (which would silently fall through

--- a/pkg/store/sqlite/migrations/043_tasks_chain_extraction_mode.sql
+++ b/pkg/store/sqlite/migrations/043_tasks_chain_extraction_mode.sql
@@ -1,0 +1,9 @@
+-- Per-task override for chain-context extraction mode. NULL or "" means the
+-- system default applies (today: full Phase-2 LLM extraction). "builtins_only"
+-- skips the async LLM extraction pass — only the synchronous builtin regex
+-- patterns run. "full" forces today's behavior even after the system default
+-- is flipped to builtins_only.
+--
+-- Enforced in the gateway's extraction dispatch; see resolveChainExtractionMode
+-- in internal/api/handlers/gateway.go.
+ALTER TABLE tasks ADD COLUMN chain_extraction_mode TEXT;

--- a/pkg/store/sqlite/store.go
+++ b/pkg/store/sqlite/store.go
@@ -1190,13 +1190,14 @@ func (s *Store) CreateTask(ctx context.Context, task *store.Task) error {
 		INSERT INTO tasks (id, user_id, agent_id, purpose, status, authorized_actions, planned_calls, callback_url,
 			expires_in_seconds, approved_at, expires_at, pending_action, pending_reason, lifetime,
 			risk_level, risk_details, approval_source, approval_rationale, expected_tools_json,
-			expected_egress_json, intent_verification_mode, expected_use, schema_version)
-		VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+			expected_egress_json, intent_verification_mode, expected_use, schema_version, chain_extraction_mode)
+		VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
 	`, task.ID, task.UserID, task.AgentID, task.Purpose, task.Status,
 		string(actionsJSON), string(plannedCallsJSON), task.CallbackURL, task.ExpiresInSeconds,
 		approvedAt, expiresAt, pendingActionJSON, task.PendingReason, task.Lifetime,
 		task.RiskLevel, riskDetails, task.ApprovalSource, approvalRationale, expectedToolsJSON,
-		expectedEgressJSON, task.IntentVerificationMode, task.ExpectedUse, task.SchemaVersion)
+		expectedEgressJSON, task.IntentVerificationMode, task.ExpectedUse, task.SchemaVersion,
+		task.ChainExtractionMode)
 	return err
 }
 
@@ -1205,18 +1206,20 @@ func (s *Store) GetTask(ctx context.Context, id string) (*store.Task, error) {
 	var actionsStr, plannedCallsStr, createdAt string
 	var approvedAt, expiresAt, pendingActionStr *string
 	var riskDetailsStr, approvalRationaleStr, expectedToolsStr, expectedEgressStr string
+	var chainExtractionMode *string
 	err := s.db.QueryRowContext(ctx, `
 		SELECT id, user_id, agent_id, purpose, status, authorized_actions, planned_calls, callback_url,
 		       created_at, approved_at, expires_at, expires_in_seconds, request_count,
 		       pending_action, pending_reason, lifetime, risk_level, risk_details,
 		       approval_source, approval_rationale, expected_tools_json, expected_egress_json,
-		       intent_verification_mode, expected_use, schema_version
+		       intent_verification_mode, expected_use, schema_version, chain_extraction_mode
 		FROM tasks WHERE id = ?
 	`, id).Scan(&t.ID, &t.UserID, &t.AgentID, &t.Purpose, &t.Status, &actionsStr,
 		&plannedCallsStr, &t.CallbackURL, &createdAt, &approvedAt, &expiresAt, &t.ExpiresInSeconds,
 		&t.RequestCount, &pendingActionStr, &t.PendingReason, &t.Lifetime,
 		&t.RiskLevel, &riskDetailsStr, &t.ApprovalSource, &approvalRationaleStr,
-		&expectedToolsStr, &expectedEgressStr, &t.IntentVerificationMode, &t.ExpectedUse, &t.SchemaVersion)
+		&expectedToolsStr, &expectedEgressStr, &t.IntentVerificationMode, &t.ExpectedUse, &t.SchemaVersion,
+		&chainExtractionMode)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, store.ErrNotFound
 	}
@@ -1259,6 +1262,9 @@ func (s *Store) GetTask(ctx context.Context, id string) (*store.Task, error) {
 	if expectedEgressStr != "" {
 		t.ExpectedEgress = json.RawMessage(expectedEgressStr)
 	}
+	if chainExtractionMode != nil {
+		t.ChainExtractionMode = *chainExtractionMode
+	}
 	return t, nil
 }
 
@@ -1286,7 +1292,7 @@ func (s *Store) ListTasks(ctx context.Context, userID string, filter store.TaskF
 		       created_at, approved_at, expires_at, expires_in_seconds, request_count,
 		       pending_action, pending_reason, lifetime, risk_level, risk_details,
 		       approval_source, approval_rationale, expected_tools_json, expected_egress_json,
-		       intent_verification_mode, expected_use, schema_version
+		       intent_verification_mode, expected_use, schema_version, chain_extraction_mode
 		FROM tasks ` + where + ` ORDER BY created_at DESC`
 
 	if filter.Limit > 0 {
@@ -1306,12 +1312,17 @@ func (s *Store) ListTasks(ctx context.Context, userID string, filter store.TaskF
 		var actionsStr, plannedCallsStr, createdAt string
 		var approvedAt, expiresAt, pendingActionStr *string
 		var riskDetailsStr, approvalRationaleStr, expectedToolsStr, expectedEgressStr string
+		var chainExtractionMode *string
 		if err := rows.Scan(&t.ID, &t.UserID, &t.AgentID, &t.Purpose, &t.Status, &actionsStr,
 			&plannedCallsStr, &t.CallbackURL, &createdAt, &approvedAt, &expiresAt, &t.ExpiresInSeconds,
 			&t.RequestCount, &pendingActionStr, &t.PendingReason, &t.Lifetime,
 			&t.RiskLevel, &riskDetailsStr, &t.ApprovalSource, &approvalRationaleStr,
-			&expectedToolsStr, &expectedEgressStr, &t.IntentVerificationMode, &t.ExpectedUse, &t.SchemaVersion); err != nil {
+			&expectedToolsStr, &expectedEgressStr, &t.IntentVerificationMode, &t.ExpectedUse, &t.SchemaVersion,
+			&chainExtractionMode); err != nil {
 			return nil, 0, err
+		}
+		if chainExtractionMode != nil {
+			t.ChainExtractionMode = *chainExtractionMode
 		}
 		t.CreatedAt = parseTime(createdAt)
 		if approvedAt != nil {
@@ -1524,7 +1535,7 @@ func (s *Store) ListExpiredTasks(ctx context.Context) ([]*store.Task, error) {
 		       created_at, approved_at, expires_at, expires_in_seconds, request_count,
 		       pending_action, pending_reason, lifetime, risk_level, risk_details,
 		       approval_source, approval_rationale, expected_tools_json, expected_egress_json,
-		       intent_verification_mode, expected_use, schema_version
+		       intent_verification_mode, expected_use, schema_version, chain_extraction_mode
 		FROM tasks WHERE status = 'active' AND lifetime = 'session' AND expires_at < datetime('now')
 	`)
 	if err != nil {
@@ -1539,12 +1550,17 @@ func (s *Store) ListExpiredTasks(ctx context.Context) ([]*store.Task, error) {
 		var plannedCallsStr *string
 		var approvedAt, expiresAt, pendingActionStr *string
 		var riskDetailsStr, approvalRationaleStr, expectedToolsStr, expectedEgressStr string
+		var chainExtractionMode *string
 		if err := rows.Scan(&t.ID, &t.UserID, &t.AgentID, &t.Purpose, &t.Status, &actionsStr,
 			&plannedCallsStr, &t.CallbackURL, &createdAt, &approvedAt, &expiresAt, &t.ExpiresInSeconds,
 			&t.RequestCount, &pendingActionStr, &t.PendingReason, &t.Lifetime,
 			&t.RiskLevel, &riskDetailsStr, &t.ApprovalSource, &approvalRationaleStr,
-			&expectedToolsStr, &expectedEgressStr, &t.IntentVerificationMode, &t.ExpectedUse, &t.SchemaVersion); err != nil {
+			&expectedToolsStr, &expectedEgressStr, &t.IntentVerificationMode, &t.ExpectedUse, &t.SchemaVersion,
+			&chainExtractionMode); err != nil {
 			return nil, err
+		}
+		if chainExtractionMode != nil {
+			t.ChainExtractionMode = *chainExtractionMode
 		}
 		t.CreatedAt = parseTime(createdAt)
 		if approvedAt != nil {

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -15,7 +15,7 @@ var ErrConflict = errors.New("store: record already exists")
 
 // ErrAmbiguous is returned by request-id-only lookups (GetPendingApproval,
 // GetApprovalRecordByRequestID) when more than one row matches under the
-// symmetric (user_id, request_id, COALESCE(task_id,'')) dedup scope.
+// symmetric (user_id, request_id, COALESCE(task_id,”)) dedup scope.
 // Callers must disambiguate via the *ByTask variant, or surface 409 to the
 // client with the candidate task_ids enumerated via List*ByRequestID.
 var ErrAmbiguous = errors.New("store: multiple records match without task scope")
@@ -379,12 +379,12 @@ type Session struct {
 
 // Agent is an AI agent that authenticates via a long-lived bearer token.
 type Agent struct {
-	ID          string `json:"id"`
-	UserID      string `json:"user_id"`
-	Name        string `json:"name"`
-	Description string `json:"description,omitempty"`
-	TokenHash   string `json:"-"`
-	OrgID       string `json:"org_id,omitempty"` // set by cloud when agent belongs to an org
+	ID          string    `json:"id"`
+	UserID      string    `json:"user_id"`
+	Name        string    `json:"name"`
+	Description string    `json:"description,omitempty"`
+	TokenHash   string    `json:"-"`
+	OrgID       string    `json:"org_id,omitempty"` // set by cloud when agent belongs to an org
 	CreatedAt   time.Time `json:"created_at"`
 	// TokenExpiresAt bounds the lifetime of a leaked bearer token. nil
 	// means no expiry — preserved for legacy POST /api/agents tokens that
@@ -566,14 +566,19 @@ type Task struct {
 	ExpectedTools          json.RawMessage `json:"expected_tools_json,omitempty"`
 	ExpectedEgress         json.RawMessage `json:"expected_egress_json,omitempty"`
 	IntentVerificationMode string          `json:"intent_verification_mode,omitempty"`
-	ExpectedUse            string          `json:"expected_use,omitempty"`
-	SchemaVersion          int             `json:"schema_version,omitempty"`
-	CallbackURL            *string         `json:"callback_url,omitempty"`
-	CreatedAt              time.Time       `json:"created_at"`
-	ApprovedAt             *time.Time      `json:"approved_at,omitempty"`
-	ExpiresAt              *time.Time      `json:"expires_at,omitempty"`
-	ExpiresInSeconds       int             `json:"expires_in_seconds,omitempty"`
-	RequestCount           int             `json:"request_count"`
+	// ChainExtractionMode overrides the system default for async chain-context
+	// extraction. "" (unset) defers to the system default; "full" runs the
+	// LLM Phase-2 pass; "builtins_only" skips it (synchronous builtin regex
+	// only). Resolved in internal/api/handlers/gateway.go.
+	ChainExtractionMode string     `json:"chain_extraction_mode,omitempty"`
+	ExpectedUse         string     `json:"expected_use,omitempty"`
+	SchemaVersion       int        `json:"schema_version,omitempty"`
+	CallbackURL         *string    `json:"callback_url,omitempty"`
+	CreatedAt           time.Time  `json:"created_at"`
+	ApprovedAt          *time.Time `json:"approved_at,omitempty"`
+	ExpiresAt           *time.Time `json:"expires_at,omitempty"`
+	ExpiresInSeconds    int        `json:"expires_in_seconds,omitempty"`
+	RequestCount        int        `json:"request_count"`
 	// PendingAction holds the action awaiting scope expansion approval.
 	PendingAction *TaskAction `json:"pending_action,omitempty"`
 	PendingReason string      `json:"pending_reason,omitempty"`


### PR DESCRIPTION
## Summary

- **Builtin email regex now handles JSON-escaped display-name form.** A production audit found 40% of builtin `email_address` facts were broken values like `Tom Wilson <tom.wilson@example.com>` because Gmail's response body JSON-escapes the angle brackets and Go's `regexp` runs on raw bytes. The new pattern strips both `<…>` and `<…>` prefixes and ships a tighter local/domain char class so it can't over-consume the escaped suffix.
- **Generic `entity_id` catch-all moved into the `default:` arm** of `builtinPatternsRaw`, so services with their own ID fact_type (message_id, file_id, event_id, …) no longer emit redundant `(entity_id, <service_id>)` rows for the same value.
- **`tasks.chain_extraction_mode` column** (migration 043, postgres + sqlite) plus a `resolveChainExtractionMode` gate in the gateway extraction dispatch. A task opting into `builtins_only` skips the async Phase-2 LLM extraction; the system default stays `full` until the verifier eval gate passes.

## Test plan

- [ ] `go test ./...` (run; only pre-existing unrelated live-API flake fails)
- [ ] Eval cases for both literal and `<`-escaped display-name forms pass
- [ ] Per-service test confirms no `entity_id` rows for gmail / drive / calendar / slack / linear / stripe
- [ ] `resolveChainExtractionMode` table-test covers nil, unset, full, builtins_only, and unknown values
- [ ] Post-deploy: `broken_ratio` query for builtin `email_address` (`created_at > deploy_time`) drops from ~40% to <1% within an hour

🤖 Generated with [Claude Code](https://claude.com/claude-code)