### PR TITLE
fix(approvals): skip canonical resolve on stranded-executor recovery

### DIFF
--- a/internal/api/handlers/approvals.go
+++ b/internal/api/handlers/approvals.go
@@ -501,16 +501,22 @@ func (h *ApprovalsHandler) RunExpiryCleanup(ctx context.Context) {
 	}
 }
 
-// processExpiredApproval performs the canonical-resolution + audit-update +
-// notification + callback work for a pending_approvals row that has either
-// timed out (caller already deleted the row) or been recovered from a
-// stalled 'executing' state (CAS DELETE already happened). reason is
-// included in the structured log so the operator can distinguish
-// "user never replied" from "executor crashed mid-execution"; it is NOT
-// passed as the canonical status (which must be "expired" — see
-// validateApprovalRecordTransition).
+// processExpiredApproval performs the audit-update + notification + callback
+// work for a pending_approvals row that has either timed out (caller already
+// deleted the row) or been recovered from a stalled 'executing' state (CAS
+// DELETE already happened). reason is included in the structured log so the
+// operator can distinguish "user never replied" from "executor crashed
+// mid-execution".
+//
+// The canonical ApprovalRecord is NOT touched here. The two callers each
+// know the right thing to do with it:
+//   - regular-expired path: canonical record is still 'pending'; the caller
+//     flips it to deny/expired inline before invoking us.
+//   - stranded-executing path: the user already approved, so the canonical
+//     record is already in 'approved'. Flipping it would both lie about the
+//     user's decision and fail validateApprovalRecordTransition's
+//     pending-only guard, paging on every recovery sweep.
 func (h *ApprovalsHandler) processExpiredApproval(ctx context.Context, pa *store.PendingApproval, reason, telegramMsg string) {
-	h.resolveCanonicalApproval(ctx, pa, "deny", "expired")
 	_ = h.st.UpdateAuditOutcome(ctx, pa.AuditID, "timeout", "", 0)
 	h.updateNotificationMsg(ctx, "approval", pa.RequestID, pa.UserID, telegramMsg)
 	// For the regular expired path the caller relies on us to delete the
@@ -545,6 +551,11 @@ func (h *ApprovalsHandler) expireTimedOut(ctx context.Context) {
 		return
 	}
 	for _, pa := range expired {
+		// Regular-expired path: the user never replied, so the canonical
+		// approval record is still 'pending' and must be moved to a terminal
+		// state. The stranded path below skips this because the canonical
+		// record is already 'approved' there.
+		h.resolveCanonicalApproval(ctx, pa, "deny", "expired")
 		h.processExpiredApproval(ctx, pa, "expired", "⏰ <b>Timed out</b> — approval window expired.")
 	}
 	// Stranded 'executing' rows: claim each via a CAS DELETE before

--- a/internal/api/handlers/approvals_test.go
+++ b/internal/api/handlers/approvals_test.go
@@ -1,0 +1,100 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/clawvisor/clawvisor/internal/taskrisk"
+	"github.com/clawvisor/clawvisor/pkg/config"
+	"github.com/clawvisor/clawvisor/pkg/store"
+	"github.com/clawvisor/clawvisor/pkg/store/sqlite"
+)
+
+// TestExpireTimedOut_StrandedExecutorPreservesApprovedCanonical guards against
+// the "illegal canonical approval transition" page. The stranded-executing
+// recovery sweep used to pipe its pending-approval row through the same helper
+// as the never-replied path, which unconditionally tried to flip the canonical
+// record to deny/expired. For a stranded request the canonical record is
+// already in "approved" (the user said yes; only execution lapsed), so the
+// transition validator rejected it and logged an Error-level line that fired
+// the alert. The user's recorded decision must stand, and the recovery sweep
+// must not produce that error.
+func TestExpireTimedOut_StrandedExecutorPreservesApprovedCanonical(t *testing.T) {
+	ctx := context.Background()
+	db, err := sqlite.New(ctx, filepath.Join(t.TempDir(), "stranded-canonical.db"))
+	if err != nil {
+		t.Fatalf("sqlite.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	st := sqlite.NewStore(db)
+
+	user, err := st.CreateUser(ctx, "stranded-canonical@test.example", "hash")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	agent, err := st.CreateAgent(ctx, user.ID, "agent", "token-hash")
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	requestID := "req-stranded-1"
+	rec := &store.ApprovalRecord{
+		ID:        "rec-stranded-1",
+		Kind:      "request_once",
+		UserID:    user.ID,
+		AgentID:   &agent.ID,
+		RequestID: &requestID,
+		Status:    "pending",
+		Surface:   "dashboard",
+	}
+	if err := st.CreateApprovalRecord(ctx, rec); err != nil {
+		t.Fatalf("CreateApprovalRecord: %v", err)
+	}
+
+	// Simulate the user clicking Approve: canonical record becomes "approved".
+	if err := st.ResolveApprovalRecord(ctx, rec.ID, "allow_once", "approved", time.Now().UTC()); err != nil {
+		t.Fatalf("ResolveApprovalRecord: %v", err)
+	}
+
+	// Pending approval row in the state the stranded sweep finds it: the user
+	// already approved, the executor claimed it, then crashed past the lease.
+	// processExpiredApproval expects the CAS DELETE has already happened, so
+	// we don't insert a pending_approvals row — we only construct the struct
+	// the sweeper would hand us.
+	recID := rec.ID
+	pa := &store.PendingApproval{
+		UserID:           user.ID,
+		RequestID:        requestID,
+		AuditID:          "audit-stranded-1",
+		ApprovalRecordID: &recID,
+		RequestBlob:      []byte(`{}`),
+		Status:           "executing",
+		ExpiresAt:        time.Now().UTC().Add(30 * time.Minute),
+	}
+
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	h := NewApprovalsHandler(st, nil, nil, nil, config.Config{}, taskrisk.NoopAssessor{}, logger, nil)
+
+	h.processExpiredApproval(ctx, pa, "stranded", "⏰ <b>Recovered</b> — execution lease expired.")
+
+	if strings.Contains(logBuf.String(), "illegal canonical approval transition") {
+		t.Fatalf("stranded recovery sweep must not log illegal-transition error\nlogs:\n%s", logBuf.String())
+	}
+
+	got, err := st.GetApprovalRecord(ctx, rec.ID)
+	if err != nil {
+		t.Fatalf("GetApprovalRecord: %v", err)
+	}
+	if got.Status != "approved" {
+		t.Fatalf("canonical record status after stranded recovery = %q, want %q (user's approval must stand)", got.Status, "approved")
+	}
+	if got.Resolution != "allow_once" {
+		t.Fatalf("canonical record resolution after stranded recovery = %q, want %q", got.Resolution, "allow_once")
+	}
+}


### PR DESCRIPTION
The expiry-cleanup recovery sweep for stalled 'executing' approvals shared a helper with the never-replied path, which unconditionally flipped the canonical ApprovalRecord to deny/expired. For stranded rows the canonical record is already 'approved' (the user said yes; only execution lapsed), so `validateApprovalRecordTransition`'s pending-only guard rejected the transition and logged an Error-level "illegal canonical approval transition" line that paged on every sweep. This moves the canonical resolve into the regular-expired loop only and adds a regression test that asserts the stranded path neither logs that error nor disturbs the user's recorded approval.