### PR TITLE
fix(intent): always run builtin chain extraction so created IDs reach chain_facts

### DIFF
--- a/internal/api/handlers/chain_extraction_wiring_test.go
+++ b/internal/api/handlers/chain_extraction_wiring_test.go
@@ -1,0 +1,450 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/clawvisor/clawvisor/internal/intent"
+	"github.com/clawvisor/clawvisor/pkg/adapters"
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+// recordingExtractor records calls to ExtractBuiltins and ExtractLLM so tests
+// can assert which extraction phases ran. Each phase returns a pre-configured
+// fact stamped with the request's TaskID/SessionID so the store assertions
+// reflect what would actually land in chain_facts.
+type recordingExtractor struct {
+	mu              sync.Mutex
+	builtinCalls    int
+	llmCalls        int
+	builtinFactType string
+	builtinValue    string
+	llmFactType     string
+	llmValue        string
+	// done is closed when ExtractBuiltins is called for the first time so
+	// tests can synchronize on the async goroutine without sleeping.
+	done chan struct{}
+}
+
+func newRecordingExtractor() *recordingExtractor {
+	return &recordingExtractor{
+		builtinFactType: "event_id",
+		builtinValue:    "evt_4o1mhcvmiq8mlhqg61bn6fpphs",
+		llmFactType:     "title",
+		llmValue:        "Q3 planning",
+		done:            make(chan struct{}, 1),
+	}
+}
+
+func (r *recordingExtractor) ExtractBuiltins(req intent.ExtractRequest) []*store.ChainFact {
+	r.mu.Lock()
+	r.builtinCalls++
+	r.mu.Unlock()
+	select {
+	case r.done <- struct{}{}:
+	default:
+	}
+	return []*store.ChainFact{{
+		TaskID:    req.TaskID,
+		SessionID: req.SessionID,
+		AuditID:   req.AuditID,
+		Service:   req.Service,
+		Action:    req.Action,
+		FactType:  r.builtinFactType,
+		FactValue: r.builtinValue,
+		Source:    "builtin",
+	}}
+}
+
+func (r *recordingExtractor) ExtractLLM(_ context.Context, req intent.ExtractRequest, _ []*store.ChainFact) ([]*store.ChainFact, error) {
+	r.mu.Lock()
+	r.llmCalls++
+	r.mu.Unlock()
+	return []*store.ChainFact{{
+		TaskID:    req.TaskID,
+		SessionID: req.SessionID,
+		AuditID:   req.AuditID,
+		Service:   req.Service,
+		Action:    req.Action,
+		FactType:  r.llmFactType,
+		FactValue: r.llmValue,
+		Source:    "llm_direct",
+	}}, nil
+}
+
+func (r *recordingExtractor) Extract(_ context.Context, _ intent.ExtractRequest) ([]*store.ChainFact, error) {
+	return nil, nil
+}
+
+func (r *recordingExtractor) builtinCallCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.builtinCalls
+}
+
+func (r *recordingExtractor) llmCallCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.llmCalls
+}
+
+// waitForExtraction polls until ExtractBuiltins has been called at least once
+// or the deadline elapses. Extraction runs in a goroutine after the response
+// is written, so tests must give it a brief window.
+func (r *recordingExtractor) waitForExtraction(t *testing.T) {
+	t.Helper()
+	select {
+	case <-r.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for ExtractBuiltins to be called")
+	}
+	// Give the goroutine a brief moment to also call ExtractLLM + save.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		r.mu.Lock()
+		llm := r.llmCalls
+		r.mu.Unlock()
+		if llm > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	// Allow saves to flush even when no LLM call happened.
+	time.Sleep(50 * time.Millisecond)
+}
+
+func newGatewayHandlerWithRecordingExtractor(
+	st *localTestStore,
+	provider *mockLocalProvider,
+	executor *mockLocalExecutor,
+	verifier *mockVerifier,
+	extractor intent.Extractor,
+) *GatewayHandler {
+	h := newTestGatewayHandler(st, provider, executor, verifier)
+	h.extractor = extractor
+	return h
+}
+
+// TestChainExtraction_Gateway_CreateAction_RunsBuiltinPhase reproduces the
+// reported bug: when the verifier returns extract_context=false (the prompt
+// instructs this for "create" actions), the gateway currently gates the
+// entire two-phase extraction block on that flag, so the newly-created
+// entity's ID never lands in chain_facts. The fix must always run the cheap
+// Phase 1 builtin pass; only Phase 2 (LLM) should be gated.
+func TestChainExtraction_Gateway_CreateAction_RunsBuiltinPhase(t *testing.T) {
+	st := newLocalTestStore()
+	st.tasks["task-1"] = &store.Task{
+		ID: "task-1", UserID: "user-1", AgentID: "agent-1", Status: "active",
+		AuthorizedActions: []store.TaskAction{
+			{Service: "local.files", Action: "write_file", AutoExecute: true},
+		},
+	}
+
+	provider := &mockLocalProvider{services: testServices()}
+	executor := &mockLocalExecutor{result: &adapters.Result{
+		Summary: "created",
+		Data:    map[string]any{"id": "evt_4o1mhcvmiq8mlhqg61bn6fpphs"},
+	}}
+	// Verifier mirrors what the LLM emits for a "create" verdict per
+	// prompts.go:67 — allow, but extract_context: false.
+	verifier := &mockVerifier{
+		verdict: &intent.VerificationVerdict{
+			Allow: true, ParamScope: "ok", ReasonCoherence: "ok", ExtractContext: false,
+		},
+	}
+	extractor := newRecordingExtractor()
+
+	h := newGatewayHandlerWithRecordingExtractor(st, provider, executor, verifier, extractor)
+
+	w := makeGatewayRequest(t, h, map[string]any{
+		"service": "local.files",
+		"action":  "write_file",
+		"reason":  "create the agenda file the user asked for",
+		"task_id": "task-1",
+		"params":  map[string]any{"path": "/tmp/agenda.txt", "content": "..."},
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	extractor.waitForExtraction(t)
+
+	if extractor.builtinCallCount() != 1 {
+		t.Errorf("ExtractBuiltins called %d times, want 1 (builtins must run even when extract_context=false; otherwise new IDs from creates never reach chain_facts)", extractor.builtinCallCount())
+	}
+	if extractor.llmCallCount() != 0 {
+		t.Errorf("ExtractLLM called %d times, want 0 (LLM phase stays gated on extract_context)", extractor.llmCallCount())
+	}
+
+	// And the builtin fact must actually be persisted so the next request can
+	// look it up via ListChainFacts.
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	if len(st.chainFacts) != 1 {
+		t.Fatalf("chain_facts saved = %d, want 1", len(st.chainFacts))
+	}
+	if st.chainFacts[0].FactValue != "evt_4o1mhcvmiq8mlhqg61bn6fpphs" {
+		t.Errorf("saved fact value = %q, want %q", st.chainFacts[0].FactValue, "evt_4o1mhcvmiq8mlhqg61bn6fpphs")
+	}
+	if st.chainFacts[0].Source != "builtin" {
+		t.Errorf("saved fact source = %q, want %q", st.chainFacts[0].Source, "builtin")
+	}
+}
+
+// TestChainExtraction_Gateway_ReadAction_RunsBothPhases is the sanity check
+// for the unbroken path: when the verifier sets extract_context=true (the
+// list/get/search case), both builtin and LLM extraction run.
+func TestChainExtraction_Gateway_ReadAction_RunsBothPhases(t *testing.T) {
+	st := newLocalTestStore()
+	st.tasks["task-1"] = &store.Task{
+		ID: "task-1", UserID: "user-1", AgentID: "agent-1", Status: "active",
+		AuthorizedActions: []store.TaskAction{
+			{Service: "local.files", Action: "read_file", AutoExecute: true},
+		},
+	}
+
+	provider := &mockLocalProvider{services: testServices()}
+	executor := &mockLocalExecutor{result: &adapters.Result{Summary: "ok"}}
+	verifier := &mockVerifier{
+		verdict: &intent.VerificationVerdict{
+			Allow: true, ParamScope: "ok", ReasonCoherence: "ok", ExtractContext: true,
+		},
+	}
+	extractor := newRecordingExtractor()
+
+	h := newGatewayHandlerWithRecordingExtractor(st, provider, executor, verifier, extractor)
+
+	w := makeGatewayRequest(t, h, map[string]any{
+		"service": "local.files",
+		"action":  "read_file",
+		"reason":  "read the meeting notes",
+		"task_id": "task-1",
+		"params":  map[string]any{"path": "/tmp/notes.txt"},
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	extractor.waitForExtraction(t)
+
+	if extractor.builtinCallCount() != 1 {
+		t.Errorf("ExtractBuiltins called %d times, want 1", extractor.builtinCallCount())
+	}
+	if extractor.llmCallCount() != 1 {
+		t.Errorf("ExtractLLM called %d times, want 1", extractor.llmCallCount())
+	}
+}
+
+// TestChainExtraction_Gateway_BuiltinsOnlyMode_SkipsLLM exercises the
+// existing task-level opt-out: when chain_extraction_mode=builtins_only the
+// LLM phase is skipped regardless of verdict.ExtractContext. This is the
+// invariant that complements the create-action fix — builtins always run,
+// LLM gating is the union of (verdict.ExtractContext) AND (mode != builtins_only).
+func TestChainExtraction_Gateway_BuiltinsOnlyMode_SkipsLLM(t *testing.T) {
+	st := newLocalTestStore()
+	st.tasks["task-1"] = &store.Task{
+		ID: "task-1", UserID: "user-1", AgentID: "agent-1", Status: "active",
+		ChainExtractionMode: "builtins_only",
+		AuthorizedActions: []store.TaskAction{
+			{Service: "local.files", Action: "read_file", AutoExecute: true},
+		},
+	}
+
+	provider := &mockLocalProvider{services: testServices()}
+	executor := &mockLocalExecutor{result: &adapters.Result{Summary: "ok"}}
+	verifier := &mockVerifier{
+		verdict: &intent.VerificationVerdict{
+			Allow: true, ParamScope: "ok", ReasonCoherence: "ok", ExtractContext: true,
+		},
+	}
+	extractor := newRecordingExtractor()
+
+	h := newGatewayHandlerWithRecordingExtractor(st, provider, executor, verifier, extractor)
+
+	w := makeGatewayRequest(t, h, map[string]any{
+		"service": "local.files",
+		"action":  "read_file",
+		"reason":  "read the meeting notes",
+		"task_id": "task-1",
+		"params":  map[string]any{"path": "/tmp/notes.txt"},
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	extractor.waitForExtraction(t)
+
+	if extractor.builtinCallCount() != 1 {
+		t.Errorf("ExtractBuiltins called %d times, want 1", extractor.builtinCallCount())
+	}
+	if extractor.llmCallCount() != 0 {
+		t.Errorf("ExtractLLM called %d times, want 0 (builtins_only)", extractor.llmCallCount())
+	}
+}
+
+// ── Approval execution path ─────────────────────────────────────────────────
+
+// approvalTestStore extends localTestStore with the pending-approval methods
+// executeAndRespond exercises. Kept narrowly scoped so other tests using
+// localTestStore aren't affected.
+type approvalTestStore struct {
+	*localTestStore
+
+	paMu     sync.Mutex
+	pa       *store.PendingApproval
+	claimed  bool
+	deleted  bool
+}
+
+func newApprovalTestStore() *approvalTestStore {
+	return &approvalTestStore{localTestStore: newLocalTestStore()}
+}
+
+func (s *approvalTestStore) GetPendingApproval(_ context.Context, requestID, userID string) (*store.PendingApproval, error) {
+	s.paMu.Lock()
+	defer s.paMu.Unlock()
+	if s.pa == nil || s.pa.RequestID != requestID || s.pa.UserID != userID {
+		return nil, store.ErrNotFound
+	}
+	return s.pa, nil
+}
+
+func (s *approvalTestStore) GetPendingApprovalByTask(ctx context.Context, requestID, userID, _ string) (*store.PendingApproval, error) {
+	return s.GetPendingApproval(ctx, requestID, userID)
+}
+
+func (s *approvalTestStore) ClaimPendingApprovalForExecution(_ context.Context, requestID, userID, _ string) (bool, error) {
+	s.paMu.Lock()
+	defer s.paMu.Unlock()
+	if s.pa == nil || s.pa.RequestID != requestID || s.pa.UserID != userID {
+		return false, nil
+	}
+	if s.claimed {
+		return false, nil
+	}
+	s.claimed = true
+	return true, nil
+}
+
+func (s *approvalTestStore) DeletePendingApproval(_ context.Context, requestID, userID, _ string) error {
+	s.paMu.Lock()
+	defer s.paMu.Unlock()
+	if s.pa != nil && s.pa.RequestID == requestID && s.pa.UserID == userID {
+		s.deleted = true
+	}
+	return nil
+}
+
+func makeExecuteApprovedRequest(t *testing.T, h *GatewayHandler, requestID string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("POST", "/api/gateway/request/"+requestID+"/execute", nil)
+	req.SetPathValue("request_id", requestID)
+	req = req.WithContext(withAgent(req.Context(), testAgent))
+	w := httptest.NewRecorder()
+	h.HandleExecuteApproved(w, req)
+	return w
+}
+
+// TestChainExtraction_ExecuteApproved_RunsBuiltinPhase covers the second
+// half of the reported bug: when a "create" request goes through per-request
+// approval (the typical path when auto_execute=false), executeAndRespond
+// currently does no chain extraction at all — the new entity's ID never
+// reaches chain_facts, so any downstream "update_*" reference is treated as
+// a chain-context violation.
+func TestChainExtraction_ExecuteApproved_RunsBuiltinPhase(t *testing.T) {
+	st := newApprovalTestStore()
+	st.tasks["task-1"] = &store.Task{
+		ID: "task-1", UserID: "user-1", AgentID: "agent-1", Status: "active",
+		AuthorizedActions: []store.TaskAction{
+			{Service: "local.files", Action: "write_file"}, // auto_execute=false implied
+		},
+	}
+
+	blob := pendingRequestBlob{
+		Service:   "local.files",
+		Action:    "write_file",
+		Params:    map[string]any{"path": "/tmp/agenda.txt", "content": "..."},
+		UserID:    "user-1",
+		AgentID:   "agent-1",
+		AgentName: "test-agent",
+		RequestID: "req-create-1",
+		TaskID:    "task-1",
+		Reason:    "create the agenda file",
+		// Advisory verdict stored at approval time for a "create" action:
+		// allow but extract_context=false (per prompts.go:67).
+		Verification: &intent.VerificationVerdict{
+			Allow: true, ParamScope: "ok", ReasonCoherence: "ok", ExtractContext: false,
+		},
+	}
+	blobBytes, _ := json.Marshal(blob)
+	taskID := "task-1"
+	st.pa = &store.PendingApproval{
+		UserID:      "user-1",
+		RequestID:   "req-create-1",
+		AuditID:     "audit-1",
+		TaskID:      &taskID,
+		RequestBlob: blobBytes,
+		Status:      "approved",
+		ExpiresAt:   time.Now().Add(10 * time.Minute),
+	}
+
+	executor := &mockLocalExecutor{result: &adapters.Result{
+		Summary: "created",
+		Data:    map[string]any{"id": "evt_4o1mhcvmiq8mlhqg61bn6fpphs"},
+	}}
+	provider := &mockLocalProvider{services: testServices()}
+
+	// Wrap approvalTestStore in something with localTestStore methods exposed —
+	// newTestGatewayHandler takes *localTestStore. The embedded pointer means
+	// the gateway will use approvalTestStore's overrides when called via
+	// store.Store, but the test helper's signature wants *localTestStore.
+	verifier := &mockVerifier{verdict: &intent.VerificationVerdict{Allow: true}}
+	extractor := newRecordingExtractor()
+	h := newGatewayHandlerWithApprovalStore(st, provider, executor, verifier, extractor)
+
+	w := makeExecuteApprovedRequest(t, h, "req-create-1")
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	extractor.waitForExtraction(t)
+
+	if extractor.builtinCallCount() != 1 {
+		t.Errorf("ExtractBuiltins called %d times, want 1 (post-approval create must populate chain_facts so downstream update_* requests resolve)", extractor.builtinCallCount())
+	}
+	if extractor.llmCallCount() != 0 {
+		t.Errorf("ExtractLLM called %d times, want 0 (advisory verdict extract_context=false)", extractor.llmCallCount())
+	}
+
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	if len(st.chainFacts) != 1 {
+		t.Fatalf("chain_facts saved = %d, want 1", len(st.chainFacts))
+	}
+}
+
+// newGatewayHandlerWithApprovalStore wires an approvalTestStore (which extends
+// localTestStore with PendingApproval methods) into a GatewayHandler.
+func newGatewayHandlerWithApprovalStore(
+	st *approvalTestStore,
+	provider *mockLocalProvider,
+	executor *mockLocalExecutor,
+	verifier *mockVerifier,
+	extractor intent.Extractor,
+) *GatewayHandler {
+	h := newTestGatewayHandler(st.localTestStore, provider, executor, verifier)
+	// Re-point the store to the wrapper so PendingApproval methods route
+	// through approvalTestStore's overrides rather than panicking on the
+	// embedded nil store.Store interface.
+	h.store = st
+	h.extractor = extractor
+	return h
+}

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -41,6 +41,7 @@ type pendingRequestBlob struct {
 	AgentName    string                      `json:"agent_name"`
 	RequestID    string                      `json:"request_id"`
 	TaskID       string                      `json:"task_id"`
+	SessionID    string                      `json:"session_id,omitempty"`
 	Reason       string                      `json:"reason"`
 	CallbackURL  string                      `json:"callback_url"`
 	Verification *intent.VerificationVerdict `json:"verification,omitempty"`
@@ -1117,70 +1118,14 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			outDecision, outOutcome = "execute", "executed"
 			h.publishAuditAndQueue(agent.UserID, req.TaskID)
 
-			// Chain context extraction (async — cloud services only, guarded by verdict != nil)
-			chainSessionID := req.SessionID
-			if chainSessionID == "" && task.Lifetime != "standing" {
-				chainSessionID = req.TaskID
-			}
-			if chainSessionID != "" && verdict != nil && verdict.ExtractContext {
-				resultJSON, _ := json.Marshal(result)
-				// Mark synchronously (before returning to the agent) so a
-				// follow-up request sees the pending flag even if it arrives
-				// before the goroutine is scheduled.
-				markCtx, markCancel := context.WithTimeout(context.Background(), 2*time.Second)
-				h.extractTrack.MarkPending(markCtx, req.TaskID, chainSessionID, auditID)
-				markCancel()
-				safeGo(h.logger, "chain context extraction", func() {
-					defer func() {
-						doneCtx, doneCancel := context.WithTimeout(context.Background(), 2*time.Second)
-						h.extractTrack.MarkDone(doneCtx, req.TaskID, chainSessionID, auditID)
-						doneCancel()
-					}()
-					extractReq := intent.ExtractRequest{
-						TaskPurpose:       task.Purpose,
-						AuthorizedActions: task.AuthorizedActions,
-						Service:           req.Service,
-						Action:            req.Action,
-						Result:            string(resultJSON),
-						TaskID:            req.TaskID,
-						SessionID:         chainSessionID,
-						AuditID:           auditID,
-					}
-
-					// Phase 1: builtin regex (fast, ~ms). Save immediately so
-					// downstream verifications targeting these IDs pass without
-					// waiting on the LLM round trip.
-					builtinFacts := h.extractor.ExtractBuiltins(extractReq)
-					if len(builtinFacts) > 0 {
-						saveCtx, saveCancel := context.WithTimeout(context.Background(), 10*time.Second)
-						if err := h.store.SaveChainFacts(saveCtx, builtinFacts); err != nil {
-							h.logger.Warn("chain facts (builtin) save failed", "err", err, "task_id", req.TaskID)
-						}
-						saveCancel()
-					}
-
-					// Phase 2: LLM (slower, seconds). Returns only NEW facts
-					// beyond what builtins captured. Skipped when the task
-					// opted into builtins_only mode.
-					if resolveChainExtractionMode(task) == chainExtractionBuiltinsOnly {
-						return
-					}
-					extractCtx, extractCancel := context.WithTimeout(context.Background(), 30*time.Second)
-					defer extractCancel()
-					llmFacts, err := h.extractor.ExtractLLM(extractCtx, extractReq, builtinFacts)
-					if err != nil {
-						h.logger.Warn("chain context LLM extraction failed", "err", err, "task_id", req.TaskID)
-						return
-					}
-					if len(llmFacts) > 0 {
-						saveCtx, saveCancel := context.WithTimeout(context.Background(), 10*time.Second)
-						if err := h.store.SaveChainFacts(saveCtx, llmFacts); err != nil {
-							h.logger.Warn("chain facts (llm) save failed", "err", err, "task_id", req.TaskID)
-						}
-						saveCancel()
-					}
-				})
-			}
+			// Chain context extraction (async). The builtin pass always runs:
+			// it is the only thing that catches a create's new entity ID in
+			// time for the next request. The LLM pass is gated on the
+			// verifier's extract_context flag (false for creates/sends per
+			// the prompt) to keep cost bounded.
+			runLLM := verdict != nil && verdict.ExtractContext
+			h.startChainExtraction(task, req.Service, req.Action, result,
+				req.TaskID, req.SessionID, auditID, runLLM)
 
 			if req.Context.CallbackURL != "" {
 				cbKey, _ := h.store.GetAgentCallbackSecret(ctx, agent.ID)
@@ -1623,6 +1568,21 @@ func (h *GatewayHandler) executeAndRespond(w http.ResponseWriter, ctx context.Co
 	_ = h.store.DeletePendingApproval(ctx, pa.RequestID, pa.UserID, paTask)
 	h.publishAuditAndQueue(pa.UserID, blob.TaskID)
 
+	// On successful execution, seed chain_facts with anything the new result
+	// carries (e.g. the IDs of a newly-created calendar event or page). The
+	// auto-execute path does this inline; without the call here, a "create"
+	// approved through the per-request flow would never reach the extractor
+	// and the next "update_*" request would fail chain verification.
+	if execErr == nil && blob.TaskID != "" {
+		var task *store.Task
+		if t, err := h.store.GetTask(ctx, blob.TaskID); err == nil {
+			task = t
+		}
+		runLLM := blob.Verification != nil && blob.Verification.ExtractContext
+		h.startChainExtraction(task, blob.Service, blob.Action, result,
+			blob.TaskID, blob.SessionID, pa.AuditID, runLLM)
+	}
+
 	resp := map[string]any{
 		"status":     outcome,
 		"request_id": pa.RequestID,
@@ -1852,6 +1812,99 @@ func (h *GatewayHandler) publishAuditAndQueue(userID, taskID string) {
 	}
 	h.eventHub.Publish(userID, events.Event{Type: "audit", ID: taskID})
 	h.eventHub.Publish(userID, events.Event{Type: "queue"})
+}
+
+// startChainExtraction launches the async chain-context extraction goroutine
+// for a completed request. Phase 1 (builtin regex) always runs so the next
+// request from the agent can see freshly minted IDs — especially for "create"
+// actions where the response body IS the new entity reference. Phase 2 (LLM)
+// is gated on runLLM (typically the verifier's extract_context verdict) and
+// further suppressed when the task opts into chain_extraction_mode=builtins_only.
+//
+// Safe to call with task == nil; nil and the standing-task case both leave
+// chainSessionID empty, which is the no-op signal.
+func (h *GatewayHandler) startChainExtraction(
+	task *store.Task,
+	service, action string,
+	result *adapters.Result,
+	taskID, sessionID, auditID string,
+	runLLM bool,
+) {
+	chainSessionID := sessionID
+	if chainSessionID == "" && task != nil && task.Lifetime != "standing" {
+		chainSessionID = taskID
+	}
+	if chainSessionID == "" {
+		return
+	}
+
+	resultJSON, _ := json.Marshal(result)
+
+	// Mark pending synchronously (before this function returns to the
+	// HTTP handler) so a follow-up request arriving before the goroutine
+	// is scheduled still sees the pending flag and waits in the fallback.
+	markCtx, markCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	h.extractTrack.MarkPending(markCtx, taskID, chainSessionID, auditID)
+	markCancel()
+
+	taskPurpose := ""
+	var authorizedActions []store.TaskAction
+	if task != nil {
+		taskPurpose = task.Purpose
+		authorizedActions = task.AuthorizedActions
+	}
+	builtinsOnly := resolveChainExtractionMode(task) == chainExtractionBuiltinsOnly
+
+	safeGo(h.logger, "chain context extraction", func() {
+		defer func() {
+			doneCtx, doneCancel := context.WithTimeout(context.Background(), 2*time.Second)
+			h.extractTrack.MarkDone(doneCtx, taskID, chainSessionID, auditID)
+			doneCancel()
+		}()
+		extractReq := intent.ExtractRequest{
+			TaskPurpose:       taskPurpose,
+			AuthorizedActions: authorizedActions,
+			Service:           service,
+			Action:            action,
+			Result:            string(resultJSON),
+			TaskID:            taskID,
+			SessionID:         chainSessionID,
+			AuditID:           auditID,
+		}
+
+		// Phase 1: builtin regex (fast, ~ms). Save immediately so
+		// downstream verifications targeting these IDs pass without
+		// waiting on the LLM round trip.
+		builtinFacts := h.extractor.ExtractBuiltins(extractReq)
+		if len(builtinFacts) > 0 {
+			saveCtx, saveCancel := context.WithTimeout(context.Background(), 10*time.Second)
+			if err := h.store.SaveChainFacts(saveCtx, builtinFacts); err != nil {
+				h.logger.Warn("chain facts (builtin) save failed", "err", err, "task_id", taskID)
+			}
+			saveCancel()
+		}
+
+		// Phase 2: LLM (slower, seconds). Skip when the caller didn't
+		// request it (e.g. verdict.extract_context=false for terminal
+		// actions) or when the task opted into builtins_only.
+		if !runLLM || builtinsOnly {
+			return
+		}
+		extractCtx, extractCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer extractCancel()
+		llmFacts, err := h.extractor.ExtractLLM(extractCtx, extractReq, builtinFacts)
+		if err != nil {
+			h.logger.Warn("chain context LLM extraction failed", "err", err, "task_id", taskID)
+			return
+		}
+		if len(llmFacts) > 0 {
+			saveCtx, saveCancel := context.WithTimeout(context.Background(), 10*time.Second)
+			if err := h.store.SaveChainFacts(saveCtx, llmFacts); err != nil {
+				h.logger.Warn("chain facts (llm) save failed", "err", err, "task_id", taskID)
+			}
+			saveCancel()
+		}
+	})
 }
 
 // runVerification runs intent verification for a request and returns the verdict.
@@ -2499,6 +2552,7 @@ func buildRequestBlob(req gateway.Request, agent *store.Agent) *pendingRequestBl
 		AgentName:   agent.Name,
 		RequestID:   req.RequestID,
 		TaskID:      req.TaskID,
+		SessionID:   req.SessionID,
 		Reason:      req.Reason,
 		CallbackURL: req.Context.CallbackURL,
 	}

--- a/internal/api/handlers/local_service_test.go
+++ b/internal/api/handlers/local_service_test.go
@@ -150,7 +150,10 @@ func (s *localTestStore) ListChainFacts(_ context.Context, _, _ string, _ int) (
 	return s.chainFacts, nil
 }
 
-func (s *localTestStore) SaveChainFacts(_ context.Context, _ []*store.ChainFact) error {
+func (s *localTestStore) SaveChainFacts(_ context.Context, facts []*store.ChainFact) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.chainFacts = append(s.chainFacts, facts...)
 	return nil
 }
 

--- a/internal/intent/prompts.go
+++ b/internal/intent/prompts.go
@@ -61,10 +61,10 @@ SLOT ASSIGNMENT — when classifying a violation, decide which slot it belongs i
 3. Chain context verification: If chain context is provided (a table of facts extracted from prior actions in this task), and the current request targets a specific entity (email address, file ID, phone number, etc.), check whether that entity appeared in the chain context. If the agent targets an entity NOT present in the chain context, that is a param_scope "violation" — unless the task purpose or expected use explicitly names that target. Task purpose and expected use always take precedence over chain context. When flagging a chain context violation, set "missing_chain_values" to an array of the exact entity values (IDs, emails, phone numbers, etc.) that you could not find in the chain context. There may be one or more missing values. This allows a programmatic fallback check against extended context that may not fit in the table above.
 
 4. Extract context: Set "extract_context" to true ONLY when ALL of these conditions are met:
-   - The action reads or retrieves data (not a terminal write/send/delete)
-   - The task scope includes downstream actions that would reference entities from the result (e.g., a list action followed by a get or send action)
+   - The action either reads data OR returns a reference to a newly-affected entity that downstream steps will need (e.g., create_event returning the new event_id, create_page returning the new page_id, update_event returning the updated event_id)
+   - The task scope includes downstream actions that would reference those entities (e.g., a list followed by a get, or a create followed by an update)
    - The task involves multiple steps
-   Default to false. Omit or set false for terminal actions (send, delete, update, create).
+   Default to false. Set false for terminal actions whose result the agent will not reference again (send-and-forget messages, deletes).
 
 Respond ONLY with a JSON object on a single line, no markdown, no explanation:
   {"allow": true, "param_scope": "ok", "reason_coherence": "ok", "extract_context": false, "explanation": "one sentence"}


### PR DESCRIPTION
## Summary

When an agent **created** something (calendar event, Notion page, Drive file, etc.) and then tried to act on it downstream (e.g. `update_event`), the new entity's ID was missing from chain context — so the follow-up request got flagged as a chain-context violation.

Two paths conspired to skip extraction for creates:

1. **Auto-execute path** gated the whole two-phase extraction block on `verdict.ExtractContext`. The verifier prompt (`prompts.go:63-67`) explicitly instructed the LLM to set `extract_context: false` for terminal actions, listing `send, delete, update, create` — so the cheap Phase 1 builtin regex pass never ran on the one action whose ID downstream steps actually need.
2. **`executeAndRespond`** (the real per-request-approval execute handler — `approvals.go:executeApproval` is dead code) ran no chain extraction at all, regardless of action type. So when a create went through human approval, extraction was skipped entirely.

## Fix

- Extracted the extraction goroutine into `(*GatewayHandler).startChainExtraction`. Phase 1 builtin always runs; Phase 2 LLM is gated on `runLLM` (the verifier's `extract_context`) **and** `chain_extraction_mode != builtins_only`.
- `executeAndRespond` now calls the helper after a successful run, looking up the task and reading the advisory verdict from the stored blob to decide LLM gating.
- Added `SessionID` to `pendingRequestBlob` + `buildRequestBlob` so standing-task sessions survive the approval round-trip.
- Reworded `prompts.go` so the LLM no longer defaults creates/updates to `extract_context: false`. The gateway change is load-bearing; the prompt edit is belt-and-suspenders.

## Test plan

- [x] `TestChainExtraction_Gateway_CreateAction_RunsBuiltinPhase` — was failing pre-fix (2s timeout waiting for `ExtractBuiltins`), passes now.
- [x] `TestChainExtraction_ExecuteApproved_RunsBuiltinPhase` — was failing pre-fix, passes now.
- [x] `TestChainExtraction_Gateway_ReadAction_RunsBothPhases` — sanity for the unbroken path, still green.
- [x] `TestChainExtraction_Gateway_BuiltinsOnlyMode_SkipsLLM` — guards the existing task-level opt-out, still green.
- [x] `go test ./internal/api/handlers/... ./internal/intent/...` all green.
- [x] One repo-wide failure (`TestLive_AnthropicPromptCaching`) reproduces on `main` and is unrelated — it asserts a cold cache that the live Anthropic prompt cache had already warmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)