### PR TITLE
feat(mcp): spec-driven MCP adapters with OAuth discovery + registration

### DIFF
--- a/docs/INTEGRATION_YAML_SPEC.md
+++ b/docs/INTEGRATION_YAML_SPEC.md
@@ -1,8 +1,12 @@
 # Clawvisor Integration YAML Specification
 
-This document describes the YAML format for declaring Clawvisor integrations (adapters). Each YAML file defines a single service integration — its authentication, API endpoints, parameters, and response handling.
+Clawvisor integrations come in two formats:
 
-Integration files are stored in `~/.clawvisor/adapters/` and hot-loaded on save.
+1. **YAML adapters** (`*.yaml`) — declare a REST/GraphQL integration directly: auth, endpoints, params, response shape, risk classification. Hot-loaded from `~/.clawvisor/adapters/`. **This document, sections "Top-Level Structure" through "Complete Example", covers this format.**
+
+2. **MCP adapters** (`*.mcp.yaml`) — declare that an integration is backed by a remote MCP (Model Context Protocol) server. Almost everything (actions, params, risk, auth endpoints, client credentials) is discovered at runtime; the YAML only needs the MCP endpoint and a few hooks. **See the "MCP Adapters" section at the end of this document.**
+
+Prefer MCP adapters when the vendor ships a hosted MCP server (e.g. Notion, Supabase) — it's a few lines of YAML and you inherit dynamic tool discovery, OAuth client registration, and response sanitization for free. Use YAML adapters for direct REST/GraphQL integrations where no MCP server exists.
 
 ## Top-Level Structure
 
@@ -510,3 +514,172 @@ actions:
     response:
       summary: "Widget deleted"
 ```
+
+---
+
+# MCP Adapters
+
+An MCP adapter declares that a service is backed by a remote [Model Context Protocol](https://modelcontextprotocol.io) server. Clawvisor handles the protocol mechanics generically — the YAML spec only has to identify the server and (optionally) tell Clawvisor how to derive the user's identity.
+
+MCP-adapter files live in `internal/adapters/definitions/mcp/` and use the `.mcp.yaml` suffix. They're embedded into the binary via `//go:embed *.mcp.yaml`, so adding a service requires a rebuild — there's no per-user hot-load path today.
+
+## Top-Level Structure
+
+```yaml
+service:
+  id: <string>           # canonical service identifier (e.g. "notion")
+  display_name: <string>
+  description: <string>
+  setup_url: <string>    # optional
+  icon_url: <string>     # optional
+  icon_svg: <string>     # optional, inline SVG (mutually exclusive with icon_url)
+
+mcp:
+  transport: <"http" | "stdio">  # default: stdio
+  endpoint: <string>             # MCP streamable-HTTP URL (http only)
+  command: [<string>, ...]       # argv to launch the server (stdio only)
+  credential_env: <string>       # env var the server reads for auth (stdio only)
+  oauth: { ... }                 # optional, see "OAuth"
+  whoami: { ... }                # optional, see "Whoami"
+```
+
+For HTTP transports (the production case for vendor-hosted MCP servers like `mcp.notion.com`), only `endpoint`, `oauth`, and `whoami` are needed. For stdio transports (local subprocess servers like `npx @notionhq/notion-mcp-server`), set `command` and `credential_env`.
+
+## What Clawvisor handles automatically
+
+Everything that a YAML adapter would have to declare explicitly is derived at runtime for MCP adapters:
+
+| Concern | YAML adapter | MCP adapter |
+| --- | --- | --- |
+| Action list | hand-written `actions:` block | `tools/list` at activation; persisted to `mcp_tool_caches` |
+| Param schemas | `params:` per action | tool's `inputSchema` JSON Schema |
+| Risk classification | per-action `risk:` block | MCP `annotations` (`readOnlyHint`, `destructiveHint`) |
+| HTTP / JSON-RPC framing | manual `path` + `method` + `body` mapping | handled by `mcpclient` (JSON + SSE) |
+| Response sanitization | per-action `transforms:` | generic gateway middleware (HTML strip, truncation) |
+| OAuth endpoints | declared inline | RFC 8414 discovery from the server |
+| OAuth client provisioning | admin-pasted client_id/secret | RFC 7591 dynamic client registration, cached per deployment |
+| Token refresh | manual via `pkce_flow` | `oauth2.TokenSource` wrapping the HTTP client |
+
+The one piece you *do* configure per-service is identity resolution (whoami), and only because there's no MCP standard for it.
+
+## OAuth
+
+For MCP servers that require OAuth (most do), declare it with an empty mapping:
+
+```yaml
+mcp:
+  transport: http
+  endpoint: https://mcp.notion.com/mcp
+  oauth: {}
+```
+
+On the first Connect click for a given service, the adapter:
+
+1. Probes the MCP endpoint cold → reads `WWW-Authenticate: Bearer resource_metadata="..."`.
+2. Fetches the protected-resource metadata (RFC 9728) → `authorization_servers`.
+3. Fetches the AS metadata (`.well-known/oauth-authorization-server`, RFC 8414) → endpoints, supported grant types, supported auth methods, supported PKCE methods.
+4. POSTs to the AS's `registration_endpoint` (RFC 7591) with Clawvisor's callback URL → receives `client_id` (+ optional `client_secret`).
+5. Caches the registered client + discovered endpoints under `__system__/mcp.client.<serviceID>` in the vault.
+
+All subsequent users on this Clawvisor deployment reuse that cached client. Discovery runs once per service per deployment.
+
+### When dynamic registration isn't available
+
+A few MCP servers don't implement RFC 7591. For those, an admin can pre-register a client (via the vendor's developer dashboard) and pin it through the settings UI at `/api/system/mcp-oauth`. The pinned credentials at `__system__/mcp.oauth.<serviceID>` take precedence over any cached dynamic-registration record.
+
+You can also declare hardcoded authorize/token URLs in the spec as a fallback for servers that don't expose RFC 8414 metadata:
+
+```yaml
+mcp:
+  transport: http
+  endpoint: https://mcp.example.com/mcp
+  oauth:
+    authorize_url: https://example.com/oauth/authorize  # fallback, used if discovery fails
+    token_url:     https://example.com/oauth/token
+    scopes: [read, write]                               # optional, included in the authorize URL
+```
+
+These fields are escape hatches; the discovery path should cover almost every production MCP server.
+
+## Whoami
+
+Identity resolution determines the alias under which Clawvisor stores the user's credential (e.g. `notion:eric@clawvisor.com` instead of `notion:default`). MCP has no standard tool name for this, so the spec names a tool + describes how to extract the identifier from its response.
+
+```yaml
+mcp:
+  whoami:
+    tool: <string>           # MCP tool name to invoke (e.g. "notion-get-users")
+    params: <map>            # optional, passed as `arguments` to the tool
+    field: <string>          # dot-path into the JSON response with array indexing
+```
+
+The `field` path supports two array-indexing notations: `results[0].email` (JSONPath-style) and `results.0.email` (dot-number). Whoami results are then run through a normalization pass — whitespace becomes `-`, letters lowercase, characters outside the alias set (`a-z 0-9 _ - . @ +`) are dropped — so org names like `"Eric Levine's Org"` become `eric-levines-org`.
+
+If `whoami` is omitted or the tool call fails, the credential is stored under the `default` alias.
+
+## Examples
+
+### Notion (OAuth, hosted MCP)
+
+The MCP-driven Notion adapter ships with `id: notion-mcp` (display: `Notion`). The original REST-API adapter at `id: notion` is preserved as `Notion (Legacy)` for backward compatibility — new connections should use this MCP one.
+
+```yaml
+service:
+  id: notion-mcp
+  display_name: Notion
+  description: "Notion workspace via MCP — read pages, query databases, create content."
+  icon_url: "/logos/notion.svg"
+
+mcp:
+  transport: http
+  endpoint: https://mcp.notion.com/mcp
+  oauth: {}
+  whoami:
+    tool: notion-get-users
+    params:
+      user_id: self
+    field: results[0].email
+```
+
+### Supabase (OAuth, hosted MCP, cross-domain AS)
+
+```yaml
+service:
+  id: supabase
+  display_name: Supabase
+  description: "Supabase via MCP — query the database, manage projects, deploy edge functions."
+  icon_url: "/logos/supabase.svg"
+
+mcp:
+  transport: http
+  endpoint: https://mcp.supabase.com/mcp
+  oauth: {}
+  whoami:
+    tool: list_organizations
+    field: organizations[0].name
+```
+
+(Supabase's MCP advertises its authorization server on `api.supabase.com`, not `mcp.supabase.com`. Discovery handles that automatically via the protected-resource metadata.)
+
+### Local stdio (no OAuth)
+
+```yaml
+service:
+  id: local-thing
+  display_name: "Local Thing"
+
+mcp:
+  transport: stdio
+  command: ["npx", "-y", "@vendor/local-mcp-server"]
+  credential_env: VENDOR_TOKEN   # the API key from vault is injected as this env var
+```
+
+## Trade-offs
+
+What you give up by adopting MCP instead of a hand-written YAML adapter:
+
+- **Schema authorship**: tool param schemas come from the vendor. If their schema overstates required-ness (e.g. Notion marks `parent` required when prose says it's optional for workspace-level pages), Clawvisor faithfully echoes that. The catalog can't second-guess the server.
+- **Action stability**: when the vendor adds, removes, or renames tools, your users' restriction rules need to follow. The same risk exists for upstream API changes against a YAML adapter; MCP just makes the surface easier to query for diffs.
+- **Trust boundary**: the MCP server is now part of the trust chain. Tool responses pass through the response-sanitization middleware before reaching the agent, but a compromised server can still return misleading-but-clean text. Pin server endpoints to vendor-controlled domains; don't proxy unknown MCP servers.
+
+What you gain in exchange is large enough to be the default: zero per-service Go, automatic OAuth setup, dynamic tool discovery, consistent risk classification, and a sanitization layer that works the same for every server.

--- a/docs/INTEGRATION_YAML_SPEC.md
+++ b/docs/INTEGRATION_YAML_SPEC.md
@@ -627,7 +627,7 @@ The MCP-driven Notion adapter ships with `id: notion-mcp` (display: `Notion`). T
 service:
   id: notion-mcp
   display_name: Notion
-  description: "Notion workspace via MCP — read pages, query databases, create content."
+  description: "Read pages, query databases, and create content in your Notion workspace."
   icon_url: "/logos/notion.svg"
 
 mcp:
@@ -647,7 +647,7 @@ mcp:
 service:
   id: supabase
   display_name: Supabase
-  description: "Supabase via MCP — query the database, manage projects, deploy edge functions."
+  description: "Query the database, manage projects, and deploy edge functions on Supabase."
   icon_url: "/logos/supabase.svg"
 
 mcp:

--- a/internal/adapters/definitions/mcp/embed.go
+++ b/internal/adapters/definitions/mcp/embed.go
@@ -1,0 +1,9 @@
+// Package mcp embeds *.mcp.yaml definitions for MCP-backed adapters.
+// Adding a new MCP-backed service means dropping a single YAML file in
+// this directory — no Go code, no per-service adapter registration.
+package mcp
+
+import "embed"
+
+//go:embed *.mcp.yaml
+var FS embed.FS

--- a/internal/adapters/definitions/mcp/notion.mcp.yaml
+++ b/internal/adapters/definitions/mcp/notion.mcp.yaml
@@ -1,0 +1,19 @@
+# Notion via Notion's hosted MCP server. The display name is the canonical
+# "Notion" because this is the blessed adapter for new connections —
+# the legacy REST adapter (id: notion, in internal/adapters/definitions/
+# notion.yaml) keeps existing connections working while users migrate.
+service:
+  id: notion-mcp
+  display_name: Notion
+  description: "Notion workspace via MCP — read pages, query databases, create content."
+  icon_url: "/logos/notion.svg"
+
+mcp:
+  transport: http
+  endpoint: https://mcp.notion.com/mcp
+  oauth: {}
+  whoami:
+    tool: notion-get-users
+    params:
+      user_id: self
+    field: results[0].email

--- a/internal/adapters/definitions/mcp/notion.mcp.yaml
+++ b/internal/adapters/definitions/mcp/notion.mcp.yaml
@@ -5,7 +5,7 @@
 service:
   id: notion-mcp
   display_name: Notion
-  description: "Notion workspace via MCP — read pages, query databases, create content."
+  description: "Read pages, query databases, and create content in your Notion workspace."
   icon_url: "/logos/notion.svg"
 
 mcp:

--- a/internal/adapters/definitions/mcp/supabase.mcp.yaml
+++ b/internal/adapters/definitions/mcp/supabase.mcp.yaml
@@ -5,7 +5,7 @@
 service:
   id: supabase
   display_name: Supabase
-  description: "Supabase via MCP — query the database, manage projects, deploy edge functions."
+  description: "Query the database, manage projects, and deploy edge functions on Supabase."
   icon_svg: '<svg viewBox="0 0 109 113" fill="none"><path d="M63.708 110.284c-2.86 3.601-8.658 1.628-8.727-2.97l-1.007-67.251h45.22c8.19 0 12.758 9.46 7.665 15.874L63.708 110.284z" fill="url(#a)"/><path d="M63.708 110.284c-2.86 3.601-8.658 1.628-8.727-2.97l-1.007-67.251h45.22c8.19 0 12.758 9.46 7.665 15.874L63.708 110.284z" fill="url(#b)" fill-opacity=".2"/><path d="M45.317 2.071c2.86-3.601 8.657-1.628 8.726 2.97l.442 67.251H9.83c-8.19 0-12.759-9.46-7.665-15.875L45.317 2.072z" fill="#3ECF8E"/><defs><linearGradient id="a" x1="53.974" y1="54.974" x2="94.163" y2="71.829" gradientUnits="userSpaceOnUse"><stop stop-color="#249361"/><stop offset="1" stop-color="#3ECF8E"/></linearGradient><linearGradient id="b" x1="36.156" y1="30.578" x2="54.484" y2="65.081" gradientUnits="userSpaceOnUse"><stop/><stop offset="1" stop-opacity="0"/></linearGradient></defs></svg>'
 
 mcp:

--- a/internal/adapters/definitions/mcp/supabase.mcp.yaml
+++ b/internal/adapters/definitions/mcp/supabase.mcp.yaml
@@ -1,0 +1,20 @@
+# Supabase via Supabase's hosted MCP server. Notably, Supabase advertises
+# its authorization server on a different domain (api.supabase.com) than
+# the MCP endpoint (mcp.supabase.com). The discovery logic handles that
+# automatically via the RFC 9728 protected-resource metadata.
+service:
+  id: supabase
+  display_name: Supabase
+  description: "Supabase via MCP — query the database, manage projects, deploy edge functions."
+  icon_svg: '<svg viewBox="0 0 109 113" fill="none"><path d="M63.708 110.284c-2.86 3.601-8.658 1.628-8.727-2.97l-1.007-67.251h45.22c8.19 0 12.758 9.46 7.665 15.874L63.708 110.284z" fill="url(#a)"/><path d="M63.708 110.284c-2.86 3.601-8.658 1.628-8.727-2.97l-1.007-67.251h45.22c8.19 0 12.758 9.46 7.665 15.874L63.708 110.284z" fill="url(#b)" fill-opacity=".2"/><path d="M45.317 2.071c2.86-3.601 8.657-1.628 8.726 2.97l.442 67.251H9.83c-8.19 0-12.759-9.46-7.665-15.875L45.317 2.072z" fill="#3ECF8E"/><defs><linearGradient id="a" x1="53.974" y1="54.974" x2="94.163" y2="71.829" gradientUnits="userSpaceOnUse"><stop stop-color="#249361"/><stop offset="1" stop-color="#3ECF8E"/></linearGradient><linearGradient id="b" x1="36.156" y1="30.578" x2="54.484" y2="65.081" gradientUnits="userSpaceOnUse"><stop/><stop offset="1" stop-opacity="0"/></linearGradient></defs></svg>'
+
+mcp:
+  transport: http
+  endpoint: https://mcp.supabase.com/mcp
+  oauth: {}
+  whoami:
+    # list_organizations is the strongest available identity signal for
+    # Supabase — it takes no params and returns the orgs the connected
+    # account belongs to. We use the first org's name as the alias.
+    tool: list_organizations
+    field: organizations[0].name

--- a/internal/adapters/definitions/notion.yaml
+++ b/internal/adapters/definitions/notion.yaml
@@ -1,9 +1,14 @@
 service:
+  # Legacy Notion adapter (Notion REST API + integration tokens).
+  # Preserved for existing users; new connections should use the MCP-driven
+  # "notion-mcp" adapter (catalog display: "Notion"), which exposes a
+  # richer tool surface and uses OAuth instead of pasted API keys.
   id: notion
-  display_name: Notion
-  description: "Read and search pages, query databases, and access your team's knowledge base in Notion."
+  display_name: "Notion (Legacy)"
+  description: "Existing Notion connection using the Notion REST API. Reconnect via the newer Notion integration (MCP) for full tool access; this entry is preserved for backward compatibility."
   setup_url: "https://www.notion.so/profile/integrations"
   key_hint: "Notion integration token (secret_...)"
+  deprecated: true   # hidden from new-connection lists; existing activations remain visible
   icon_url: "/logos/notion.svg"
   identity:
     endpoint: "/users/me"

--- a/internal/api/handlers/approvals.go
+++ b/internal/api/handlers/approvals.go
@@ -825,6 +825,7 @@ func (h *ApprovalsHandler) promotePendingApprovalToTask(ctx context.Context, pa 
 				Verification: "strict",
 			}},
 			AgentName: blob.AgentName,
+			UserID:    task.UserID,
 		})
 		if err != nil {
 			h.logger.Warn("task risk assessment failed for promoted request task", "request_id", pa.RequestID, "err", err)

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -2319,6 +2319,8 @@ func executeAdapterRequest(
 		return nil, fmt.Errorf("adapter %s: %w", service, err)
 	}
 
+	applyMCPResponseMiddleware(adapter, result)
+
 	return result, nil
 }
 

--- a/internal/api/handlers/mcp_e2e_test.go
+++ b/internal/api/handlers/mcp_e2e_test.go
@@ -1,0 +1,462 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	mcpdefs "github.com/clawvisor/clawvisor/internal/adapters/definitions/mcp"
+	"github.com/clawvisor/clawvisor/pkg/adapters"
+	"github.com/clawvisor/clawvisor/pkg/adapters/mcpadapter"
+	"github.com/clawvisor/clawvisor/pkg/adapters/mcpclient"
+	"github.com/clawvisor/clawvisor/pkg/store/sqlite"
+	"github.com/clawvisor/clawvisor/pkg/vault"
+	"gopkg.in/yaml.v3"
+)
+
+// notionHTTPMock is a tiny in-process MCP server that speaks streamable
+// HTTP and serves the same Notion-shaped responses NotionMockConfig provides
+// over stdio. Used by the spec-driven test to exercise the prod spec's
+// transport=http path without reaching mcp.notion.com.
+type notionHTTPMock struct {
+	sessionID  string
+	expectAuth string
+}
+
+func (m *notionHTTPMock) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		JSONRPC string          `json:"jsonrpc"`
+		ID      int             `json:"id,omitempty"`
+		Method  string          `json:"method"`
+		Params  json.RawMessage `json:"params,omitempty"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "bad json", http.StatusBadRequest)
+		return
+	}
+	if req.Method != "initialize" && req.Method != "notifications/initialized" {
+		if got := r.Header.Get("Authorization"); got != m.expectAuth {
+			http.Error(w, "auth mismatch", http.StatusUnauthorized)
+			return
+		}
+		if got := r.Header.Get("Mcp-Session-Id"); got != m.sessionID {
+			http.Error(w, "session mismatch", http.StatusBadRequest)
+			return
+		}
+	}
+	writeResp := func(result any) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": req.ID, "result": result})
+	}
+	switch req.Method {
+	case "initialize":
+		w.Header().Set("Mcp-Session-Id", m.sessionID)
+		writeResp(map[string]any{
+			"protocolVersion": "2025-06-18",
+			"capabilities":    map[string]any{"tools": map[string]any{}},
+			"serverInfo":      map[string]any{"name": "notion-mcp-mock"},
+		})
+	case "notifications/initialized":
+		w.WriteHeader(http.StatusAccepted)
+	case "tools/list":
+		// Mirror the four tools from NotionMockConfig.
+		writeResp(map[string]any{
+			"tools": []mcpclient.Tool{
+				{Name: "search", Description: "Search.", Annotations: map[string]any{"readOnlyHint": true}},
+				{Name: "get_page", Description: "Get page.", Annotations: map[string]any{"readOnlyHint": true}},
+				{Name: "create_page", Description: "Create page.", Annotations: map[string]any{"destructiveHint": true}},
+				{Name: "notion-get-users", Description: "List or fetch user(s).", Annotations: map[string]any{"readOnlyHint": true}},
+			},
+		})
+	case "tools/call":
+		var p struct {
+			Name      string         `json:"name"`
+			Arguments map[string]any `json:"arguments"`
+		}
+		_ = json.Unmarshal(req.Params, &p)
+		var data any
+		switch p.Name {
+		case "notion-get-users":
+			// Notion returns a {results:[...]} envelope; with user_id:"self"
+			// the first entry is the authed user.
+			if uid, _ := p.Arguments["user_id"].(string); uid != "self" {
+				http.Error(w, "expected user_id=self for whoami", http.StatusBadRequest)
+				return
+			}
+			data = map[string]any{
+				"has_more": false,
+				"results": []map[string]any{
+					{"email": "user@example.com", "id": "u1", "name": "User", "type": "person"},
+				},
+			}
+		case "get_page":
+			pid, _ := p.Arguments["page_id"].(string)
+			data = map[string]any{"id": pid, "url": "https://notion.so/" + pid}
+		case "search":
+			q, _ := p.Arguments["query"].(string)
+			data = map[string]any{"results": []map[string]any{{"id": "page-abc", "title": "match " + q}}}
+		default:
+			http.Error(w, "unknown tool", http.StatusBadRequest)
+			return
+		}
+		payload, _ := json.Marshal(data)
+		writeResp(mcpclient.ToolResult{
+			Content: []mcpclient.ToolContent{{Type: "text", Text: string(payload)}},
+		})
+	default:
+		http.Error(w, "method not found", http.StatusNotFound)
+	}
+}
+
+// memVault is a minimal in-memory vault for the prototype's E2E test.
+type memVault struct {
+	creds map[string]map[string][]byte // userID → serviceID → bytes
+}
+
+func newMemVault() *memVault { return &memVault{creds: map[string]map[string][]byte{}} }
+
+func (m *memVault) Set(_ context.Context, userID, serviceID string, c []byte) error {
+	if m.creds[userID] == nil {
+		m.creds[userID] = map[string][]byte{}
+	}
+	m.creds[userID][serviceID] = c
+	return nil
+}
+func (m *memVault) Get(_ context.Context, userID, serviceID string) ([]byte, error) {
+	if u, ok := m.creds[userID]; ok {
+		if c, ok := u[serviceID]; ok {
+			return c, nil
+		}
+	}
+	return nil, vault.ErrNotFound
+}
+func (m *memVault) Delete(_ context.Context, userID, serviceID string) error {
+	if u, ok := m.creds[userID]; ok {
+		delete(u, serviceID)
+	}
+	return nil
+}
+func (m *memVault) List(_ context.Context, userID string) ([]string, error) {
+	out := []string{}
+	for k := range m.creds[userID] {
+		out = append(out, k)
+	}
+	return out, nil
+}
+
+// TestMCPNotionEndToEnd exercises the full inverted path:
+//
+//	executeAdapterRequest → MCPAdapter (in-process transport) → mock notion server
+//	→ raw vendor-shaped JSON → gateway sanitization middleware → caller
+//
+// Asserts that the gateway's middleware (not the adapter) stripped HTML and
+// truncated the long field — i.e., that the architectural inversion works.
+// TestMCPNotionSpecDriven proves the "delete the per-service Go" path:
+// load a YAML spec from embedded FS, swap in an in-process transport (so the
+// test doesn't shell out), register, and exercise both whoami (the only
+// per-service hook) and a regular tool call. This is what adding a new
+// MCP-backed service to Clawvisor looks like in the inverted architecture:
+// drop a *.mcp.yaml file, and the rest just works.
+func TestMCPNotionSpecDriven(t *testing.T) {
+	// Read the spec straight from the embedded FS — exactly how production
+	// would load it. The spec declares transport=http pointing at
+	// mcp.notion.com; the test redirects to an in-process httptest.Server
+	// running a Notion-shaped MCP mock so the test stays hermetic.
+	data, err := mcpdefs.FS.ReadFile("notion.mcp.yaml")
+	if err != nil {
+		t.Fatalf("read embedded spec: %v", err)
+	}
+	var spec mcpadapter.Spec
+	if err := yaml.Unmarshal(data, &spec); err != nil {
+		t.Fatalf("parse spec: %v", err)
+	}
+	if spec.Service.ID != "notion-mcp" {
+		t.Fatalf("expected notion-mcp, got %q", spec.Service.ID)
+	}
+	if spec.MCP.Transport != "http" {
+		t.Fatalf("expected http transport in spec, got %q", spec.MCP.Transport)
+	}
+	if spec.MCP.OAuth == nil {
+		t.Fatalf("expected oauth declared in spec")
+	}
+	if spec.MCP.Whoami == nil || spec.MCP.Whoami.Tool == "" {
+		t.Fatalf("whoami tool not declared in spec")
+	}
+
+	const accessToken = "oauth-access-token-xyz"
+	srv := httptest.NewServer(&notionHTTPMock{
+		sessionID:  "sess-spec-driven",
+		expectAuth: "Bearer " + accessToken,
+	})
+	t.Cleanup(srv.Close)
+
+	// Override the endpoint to point at the test server while keeping the
+	// rest of the spec verbatim — including the oauth declaration.
+	spec.MCP.Endpoint = srv.URL
+	transport := &mcpadapter.HTTPTransport{Endpoint: spec.MCP.Endpoint}
+	adapter := mcpadapter.FromSpec(spec, transport)
+
+	// Provide system OAuth client_id / client_secret the way SetGoogleOAuthConfig
+	// would, so MCPAdapter.OAuthConfig() returns non-nil. The OAuth code path
+	// reads "__system__"/"mcp.oauth.notion" from the vault.
+	v := newMemVault()
+	clientCreds := []byte(`{"client_id":"cid","client_secret":"csec"}`)
+	_ = v.Set(context.Background(), adapters.SystemUserID,
+		adapters.SystemVaultKeyMCPOAuthPrefix+"notion-mcp", clientCreds)
+	adapter.SetOAuthVault(v)
+
+	if cfg := adapter.OAuthConfig(); cfg == nil {
+		t.Fatal("OAuthConfig should be non-nil once client creds are in vault")
+	}
+
+	// Simulate the result of a completed OAuth code → token exchange: store
+	// the standard token envelope as the user's credential. This is what
+	// services.go's OAuthCallback would persist.
+	credJSON := []byte(`{"access_token":"` + accessToken + `","refresh_token":"refresh-1"}`)
+	_ = v.Set(context.Background(), "user-1", "notion-mcp", credJSON)
+
+	// Whoami: the only per-service hook in the spec.
+	identity, err := adapter.FetchIdentity(context.Background(), credJSON, nil)
+	if err != nil {
+		t.Fatalf("FetchIdentity: %v", err)
+	}
+	if identity != "user@example.com" {
+		t.Fatalf("expected results[0].email from notion-get-users, got %q", identity)
+	}
+
+	// And regular execution still works through the same gateway path —
+	// over HTTP to the (test) remote MCP server, with the OAuth-wrapped
+	// http.Client supplying the Authorization header automatically.
+	tools, err := adapter.DiscoverTools(context.Background(), credJSON)
+	if err != nil {
+		t.Fatalf("DiscoverTools: %v", err)
+	}
+	reg := adapters.NewRegistry()
+	reg.Register(adapter)
+	reg.RegisterForUser("user-1", adapter.ForUser(tools))
+
+	result, err := executeAdapterRequest(
+		context.Background(),
+		v, reg, nil,
+		"user-1", "notion-mcp", "get_page",
+		map[string]any{"page_id": "page-zzz"},
+		"",
+	)
+	if err != nil {
+		t.Fatalf("executeAdapterRequest: %v", err)
+	}
+	dataMap, _ := result.Data.(map[string]any)
+	if id, _ := dataMap["id"].(string); id != "page-zzz" {
+		t.Fatalf("expected page-zzz, got %#v", dataMap)
+	}
+
+	// Service metadata picked up the YAML strings.
+	meta := adapter.ServiceMetadata()
+	if meta.DisplayName != "Notion" {
+		t.Errorf("display name from spec not used: %q", meta.DisplayName)
+	}
+	if !meta.AutoIdentity {
+		t.Errorf("AutoIdentity should be true when whoami is declared")
+	}
+}
+
+// TestMCPNotionPersistenceRoundtrip is the load-bearing test for the v3.5
+// design: discovery is persisted at activation, then hydrated lazily from
+// the DB on cache miss (which is what happens after a server restart).
+//
+// Flow:
+//  1. Activation simulation: discover tools, persist via store.UpsertMCPTools,
+//     register a per-user clone in the registry.
+//  2. Simulate a restart: build a *fresh* registry that knows nothing about
+//     the user. Same store, same MCP adapter spec.
+//  3. Wire the resolver to read tools from the store (mirroring defaults.go).
+//  4. Call AllForUser on the fresh registry. The resolver should hit the
+//     store, hydrate a per-user clone, and return it with the discovered
+//     tools — without re-spawning the MCP server.
+//
+// This proves: catalog/gateway never need to "warm up" at startup. They
+// pull from the DB on demand, on first call from each user.
+func TestMCPPersistenceRoundtrip(t *testing.T) {
+	ctx := context.Background()
+	db, err := sqlite.New(ctx, filepath.Join(t.TempDir(), "mcp.db"))
+	if err != nil {
+		t.Fatalf("sqlite.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	st := sqlite.NewStore(db)
+	user, err := st.CreateUser(ctx, "mcp-roundtrip@test.example", "hash")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	// Build a global adapter without any transport — the persistence test
+	// doesn't exercise discovery, it exercises the registry+store roundtrip.
+	var spec mcpadapter.Spec
+	spec.Service.ID = "fake-mcp"
+	spec.MCP.Transport = "http"
+	spec.MCP.Endpoint = "https://example.invalid/mcp"
+	globalAdapter := mcpadapter.FromSpec(spec, &mcpadapter.HTTPTransport{Endpoint: spec.MCP.Endpoint})
+
+	// ── Phase 1: persist a synthetic tool list (simulates activation having
+	// already run DiscoverTools and called UpsertMCPTools). ───────────────
+	tools := []mcpclient.Tool{
+		{Name: "alpha", Description: "Alpha.", Annotations: map[string]any{"readOnlyHint": true}},
+		{Name: "beta", Description: "Beta.", Annotations: map[string]any{"readOnlyHint": true}},
+		{Name: "gamma", Description: "Gamma.", Annotations: map[string]any{"destructiveHint": true}},
+	}
+	toolsJSON, _ := json.Marshal(tools)
+	if err := st.UpsertMCPTools(ctx, user.ID, "fake-mcp", "default", toolsJSON); err != nil {
+		t.Fatalf("UpsertMCPTools: %v", err)
+	}
+
+	// ── Phase 2: simulate restart by building a fresh registry. ───────────
+	// In production this is what happens when the server reboots — the
+	// in-memory userAdapters map is empty, but the DB still has the tools.
+	freshReg := adapters.NewRegistry()
+	freshReg.Register(globalAdapter) // global, no per-user state
+	mcpByID := map[string]*mcpadapter.MCPAdapter{"fake-mcp": globalAdapter}
+	freshReg.SetResolver(func(ctx context.Context, serviceID, userID string) (adapters.Adapter, bool) {
+		mcp, ok := mcpByID[serviceID]
+		if !ok {
+			return nil, false
+		}
+		raw, err := st.GetMCPTools(ctx, userID, serviceID, "default")
+		if err != nil {
+			return nil, false
+		}
+		var loaded []mcpclient.Tool
+		if err := json.Unmarshal(raw, &loaded); err != nil {
+			return nil, false
+		}
+		return mcp.ForUser(loaded), true
+	})
+
+	// ── Phase 3: catalog asks AllForUser; resolver hydrates from DB. ──────
+	all := freshReg.AllForUser(ctx, user.ID)
+	var hydrated *mcpadapter.MCPAdapter
+	for _, a := range all {
+		if a.ServiceID() == "fake-mcp" {
+			hydrated, _ = a.(*mcpadapter.MCPAdapter)
+		}
+	}
+	if hydrated == nil {
+		t.Fatal("AllForUser did not return MCP adapter for user")
+	}
+	if got := len(hydrated.SupportedActions()); got != len(tools) {
+		t.Fatalf("expected %d hydrated tools after DB roundtrip, got %d: %v",
+			len(tools), got, hydrated.SupportedActions())
+	}
+	if hydrated == globalAdapter {
+		t.Fatal("resolver returned the global instance — should have built a per-user clone")
+	}
+
+	// ── Phase 4: subsequent calls hit the in-memory cache. ────────────────
+	// Delete the DB row to prove it's not re-read.
+	if err := st.DeleteMCPTools(ctx, user.ID, "fake-mcp", "default"); err != nil {
+		t.Fatalf("DeleteMCPTools: %v", err)
+	}
+	all2 := freshReg.AllForUser(ctx, user.ID)
+	var still *mcpadapter.MCPAdapter
+	for _, a := range all2 {
+		if a.ServiceID() == "fake-mcp" {
+			still, _ = a.(*mcpadapter.MCPAdapter)
+		}
+	}
+	if still == nil || len(still.SupportedActions()) != len(tools) {
+		t.Fatalf("in-memory cache should serve subsequent calls without re-reading DB")
+	}
+}
+
+// TestMCPPersistenceRoundtrip_AliasFromServiceMeta is the regression test
+// for the resolver-alias bug: whoami-enabled adapters persist tools under
+// the resolved alias (email, org name, etc.) rather than "default". The
+// resolver in defaults.go has to look up the user's actual alias via
+// service_meta rather than blindly querying for "default", or after a
+// restart the catalog loses every MCP action.
+func TestMCPPersistenceRoundtrip_AliasFromServiceMeta(t *testing.T) {
+	ctx := context.Background()
+	db, err := sqlite.New(ctx, filepath.Join(t.TempDir(), "mcp-alias.db"))
+	if err != nil {
+		t.Fatalf("sqlite.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	st := sqlite.NewStore(db)
+	user, err := st.CreateUser(ctx, "alias-roundtrip@test.example", "hash")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	var spec mcpadapter.Spec
+	spec.Service.ID = "notion-mcp"
+	spec.MCP.Transport = "http"
+	spec.MCP.Endpoint = "https://example.invalid/mcp"
+	globalAdapter := mcpadapter.FromSpec(spec, &mcpadapter.HTTPTransport{Endpoint: spec.MCP.Endpoint})
+
+	// Whoami resolved the user's identity to their email; activation
+	// persisted tools + service_meta under that alias, NOT "default".
+	const aliasFromWhoami = "user-at-example-com"
+	tools := []mcpclient.Tool{{Name: "notion-search", Description: "Search."}}
+	toolsJSON, _ := json.Marshal(tools)
+	if err := st.UpsertMCPTools(ctx, user.ID, "notion-mcp", aliasFromWhoami, toolsJSON); err != nil {
+		t.Fatalf("UpsertMCPTools: %v", err)
+	}
+	if err := st.UpsertServiceMeta(ctx, user.ID, "notion-mcp", aliasFromWhoami, time.Now()); err != nil {
+		t.Fatalf("UpsertServiceMeta: %v", err)
+	}
+
+	// Fresh registry (simulating server restart). Resolver mirrors defaults.go:
+	// consult service_meta for the user's alias, then look up tools under it.
+	// Asserting "default" would not find anything; we want the alias-aware
+	// path to succeed.
+	freshReg := adapters.NewRegistry()
+	freshReg.Register(globalAdapter)
+	mcpByID := map[string]*mcpadapter.MCPAdapter{"notion-mcp": globalAdapter}
+	freshReg.SetResolver(func(ctx context.Context, serviceID, userID string) (adapters.Adapter, bool) {
+		mcp, ok := mcpByID[serviceID]
+		if !ok {
+			return nil, false
+		}
+		aliases := []string{"default"}
+		if metas, err := st.ListServiceMetas(ctx, userID); err == nil {
+			aliases = aliases[:0]
+			for _, m := range metas {
+				if m.ServiceID == serviceID {
+					aliases = append(aliases, m.Alias)
+				}
+			}
+			if len(aliases) == 0 {
+				aliases = []string{"default"}
+			}
+		}
+		for _, alias := range aliases {
+			raw, err := st.GetMCPTools(ctx, userID, serviceID, alias)
+			if err != nil {
+				continue
+			}
+			var loaded []mcpclient.Tool
+			if err := json.Unmarshal(raw, &loaded); err != nil {
+				continue
+			}
+			return mcp.ForUser(loaded), true
+		}
+		return nil, false
+	})
+
+	all := freshReg.AllForUser(ctx, user.ID)
+	var hydrated *mcpadapter.MCPAdapter
+	for _, a := range all {
+		if a.ServiceID() == "notion-mcp" {
+			hydrated, _ = a.(*mcpadapter.MCPAdapter)
+		}
+	}
+	if hydrated == nil {
+		t.Fatal("resolver returned no adapter; check service_meta alias path")
+	}
+	if got := len(hydrated.SupportedActions()); got != 1 {
+		t.Fatalf("expected 1 tool after alias-aware hydration, got %d (resolver likely fell back to 'default')", got)
+	}
+}

--- a/internal/api/handlers/mcp_middleware.go
+++ b/internal/api/handlers/mcp_middleware.go
@@ -1,0 +1,58 @@
+package handlers
+
+import (
+	"github.com/clawvisor/clawvisor/internal/adapters/format"
+	"github.com/clawvisor/clawvisor/pkg/adapters"
+	"github.com/clawvisor/clawvisor/pkg/adapters/mcpadapter"
+)
+
+// applyMCPResponseMiddleware is the post-Execute middleware demonstrating the
+// architectural inversion: response sanitization, HTML stripping, and field
+// truncation that would otherwise live as per-adapter YAML transforms now run
+// in the gateway, generically, against any MCP-backed result.
+//
+// Widening this to every adapter is a separate change — existing YAML
+// adapters already do their own per-action transforms, so gate on the
+// concrete type for now to keep the blast radius contained.
+func applyMCPResponseMiddleware(adapter adapters.Adapter, result *adapters.Result) {
+	if _, ok := adapter.(*mcpadapter.MCPAdapter); !ok {
+		return
+	}
+	if result == nil {
+		return
+	}
+	result.Data = sanitizeAny(result.Data, 0)
+}
+
+const maxRecursionDepth = 8
+
+// sanitizeAny walks an arbitrarily-shaped JSON value, applying:
+//   - HTML strip + dangerous-Unicode strip + per-field truncation on strings
+//   - array length cap
+//   - secret-key removal on map keys
+//   - recursion limit (defensive against pathological nesting)
+func sanitizeAny(v any, depth int) any {
+	if depth >= maxRecursionDepth {
+		return "[depth-limited]"
+	}
+	switch x := v.(type) {
+	case string:
+		return format.SanitizeText(x, format.MaxBodyLen)
+	case []any:
+		x = format.TruncateSlice(x, format.MaxArrayItems)
+		out := make([]any, len(x))
+		for i, item := range x {
+			out[i] = sanitizeAny(item, depth+1)
+		}
+		return out
+	case map[string]any:
+		x = format.StripSecrets(x)
+		out := make(map[string]any, len(x))
+		for k, val := range x {
+			out[k] = sanitizeAny(val, depth+1)
+		}
+		return out
+	default:
+		return v
+	}
+}

--- a/internal/api/handlers/mcp_oauth_settings_test.go
+++ b/internal/api/handlers/mcp_oauth_settings_test.go
@@ -1,0 +1,148 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/pkg/adapters"
+	"github.com/clawvisor/clawvisor/pkg/adapters/mcpadapter"
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+// newServicesHandlerForOAuth builds a ServicesHandler with the minimum wiring
+// needed for the MCP OAuth settings tests — no DB, no vault encryption, just
+// the in-memory vault and a registry holding one MCP-OAuth adapter.
+func newServicesHandlerForOAuth(t *testing.T) (*ServicesHandler, *memVault, *mcpadapter.MCPAdapter) {
+	t.Helper()
+	v := newMemVault()
+	reg := adapters.NewRegistry()
+
+	var spec mcpadapter.Spec
+	spec.Service.ID = "notion-mcp"
+	spec.Service.DisplayName = "Notion (MCP)"
+	spec.MCP.Transport = "http"
+	spec.MCP.Endpoint = "https://mcp.notion.com/mcp"
+	spec.MCP.OAuth = &mcpadapter.MCPOAuthSpec{
+		AuthorizeURL: "https://api.notion.com/v1/oauth/authorize",
+		TokenURL:     "https://api.notion.com/v1/oauth/token",
+	}
+	adapter := mcpadapter.FromSpec(spec, &mcpadapter.HTTPTransport{Endpoint: spec.MCP.Endpoint})
+	adapter.SetOAuthVault(v)
+	reg.Register(adapter)
+
+	h := &ServicesHandler{
+		vault:      v,
+		adapterReg: reg,
+		logger:     slog.Default(),
+	}
+	return h, v, adapter
+}
+
+func asAdmin(req *http.Request) *http.Request {
+	return req.WithContext(withUser(req.Context(), &store.User{ID: "admin"}))
+}
+
+// TestMCPOAuthSettings_RoundTrip exercises set → list → delete via the HTTP
+// handlers and confirms each step is reflected in MCPAdapter.OAuthConfig().
+func TestMCPOAuthSettings_RoundTrip(t *testing.T) {
+	h, _, adapter := newServicesHandlerForOAuth(t)
+
+	// Before any creds are set, OAuthConfig() returns nil — the catalog UI
+	// would show "needs OAuth setup".
+	if adapter.OAuthConfig() != nil {
+		t.Fatal("OAuthConfig should be nil before credentials are stored")
+	}
+
+	// POST /api/system/mcp-oauth — admin saves client_id + client_secret.
+	body := bytes.NewBufferString(`{"service_id":"notion-mcp","client_id":"cid-1","client_secret":"csec-1"}`)
+	req := asAdmin(httptest.NewRequest("POST", "/api/system/mcp-oauth", body))
+	w := httptest.NewRecorder()
+	h.SetMCPOAuthCredential(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Adapter immediately picks up the new credentials (no restart).
+	cfg := adapter.OAuthConfig()
+	if cfg == nil {
+		t.Fatal("OAuthConfig should be non-nil after SetMCPOAuthCredential")
+	}
+	if cfg.ClientID != "cid-1" {
+		t.Errorf("ClientID = %q, want %q", cfg.ClientID, "cid-1")
+	}
+	if cfg.Endpoint.AuthURL != "https://api.notion.com/v1/oauth/authorize" {
+		t.Errorf("endpoint not carried through from spec: %q", cfg.Endpoint.AuthURL)
+	}
+
+	// GET /api/system/mcp-oauth — settings UI lists configured services.
+	req = asAdmin(httptest.NewRequest("GET", "/api/system/mcp-oauth", nil))
+	w = httptest.NewRecorder()
+	h.ListMCPOAuthCredentials(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("list: expected 200, got %d", w.Code)
+	}
+	var entries []adapters.MCPOAuthEntry
+	if err := json.Unmarshal(w.Body.Bytes(), &entries); err != nil {
+		t.Fatalf("list: bad json: %v", err)
+	}
+	if len(entries) != 1 || entries[0].ServiceID != "notion-mcp" || entries[0].ClientID != "cid-1" {
+		t.Fatalf("list response unexpected: %+v", entries)
+	}
+	// Secret must never appear in list responses.
+	if strings.Contains(w.Body.String(), "csec-1") {
+		t.Errorf("client_secret leaked in list response: %s", w.Body.String())
+	}
+
+	// DELETE /api/system/mcp-oauth/notion-mcp.
+	req = asAdmin(httptest.NewRequest("DELETE", "/api/system/mcp-oauth/notion-mcp", nil))
+	req.SetPathValue("service_id", "notion-mcp")
+	w = httptest.NewRecorder()
+	h.DeleteMCPOAuthCredential(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("delete: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Adapter reverts to "needs setup" immediately.
+	if adapter.OAuthConfig() != nil {
+		t.Fatal("OAuthConfig should be nil again after delete")
+	}
+}
+
+// TestMCPOAuthSettings_RejectsNonMCPService ensures admins can't accidentally
+// seed credentials under a typo'd or non-MCP service ID.
+func TestMCPOAuthSettings_RejectsNonMCPService(t *testing.T) {
+	h, _, _ := newServicesHandlerForOAuth(t)
+
+	body := bytes.NewBufferString(`{"service_id":"not-a-real-thing","client_id":"x","client_secret":"y"}`)
+	req := asAdmin(httptest.NewRequest("POST", "/api/system/mcp-oauth", body))
+	w := httptest.NewRecorder()
+	h.SetMCPOAuthCredential(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for unknown service, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestMCPOAuthSettings_RejectsMissingFields covers input validation.
+func TestMCPOAuthSettings_RejectsMissingFields(t *testing.T) {
+	h, _, _ := newServicesHandlerForOAuth(t)
+
+	cases := []string{
+		`{"client_id":"x","client_secret":"y"}`,                    // missing service_id
+		`{"service_id":"notion-mcp","client_secret":"y"}`,          // missing client_id
+		`{"service_id":"notion-mcp","client_id":"x"}`,              // missing client_secret
+		`{}`,                                                        // all missing
+	}
+	for _, b := range cases {
+		req := asAdmin(httptest.NewRequest("POST", "/api/system/mcp-oauth", bytes.NewBufferString(b)))
+		w := httptest.NewRecorder()
+		h.SetMCPOAuthCredential(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("body %q: expected 400, got %d", b, w.Code)
+		}
+	}
+}

--- a/internal/api/handlers/services.go
+++ b/internal/api/handlers/services.go
@@ -1401,12 +1401,14 @@ func (h *ServicesHandler) RenameAlias(w http.ResponseWriter, r *http.Request) {
 // ensureMCPToolsActivated runs DiscoverTools + persist + register-per-user
 // for MCP adapters. Called from both activation paths (OAuth callback and
 // API-key) right after the credential lands in the vault, and from the
-// already_authorized fast path as self-repair when a previous activation
-// stored the credential but failed mid-discovery.
+// already_authorized fast path via repairMCPToolsForUser as self-repair
+// when a previous activation stored the credential but failed mid-discovery.
 //
 // No-op for non-MCP adapters. Returns the underlying error so callers can
-// log at the appropriate level; activation does NOT roll back on failure
-// (the credential is valid and a future Connect click can repair).
+// log and act. The activation callers (OAuthCallback, ActivateWithKey)
+// roll back the vault credential and service_meta row on failure so a
+// connected service never exposes zero actions — this helper itself does
+// not mutate anything other than the tool cache and per-user registry.
 func (h *ServicesHandler) ensureMCPToolsActivated(
 	ctx context.Context, adapter adapters.Adapter, userID, serviceID, alias string, credBytes []byte,
 ) error {

--- a/internal/api/handlers/services.go
+++ b/internal/api/handlers/services.go
@@ -23,6 +23,7 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/clawvisor/clawvisor/internal/adapters/google/credential"
+	"github.com/clawvisor/clawvisor/pkg/adapters/mcpadapter"
 	"github.com/clawvisor/clawvisor/internal/api/middleware"
 	"github.com/clawvisor/clawvisor/internal/callback"
 	"github.com/clawvisor/clawvisor/internal/display"
@@ -246,8 +247,10 @@ func (h *ServicesHandler) List(w http.ResponseWriter, r *http.Request) {
 		IconURL              string                  `json:"icon_url,omitempty"`
 		Alias                string                  `json:"alias,omitempty"`
 		OAuth                bool                    `json:"oauth"`
-		OAuthEndpoint        string                  `json:"oauth_endpoint,omitempty"`
-		DeviceFlow           bool                    `json:"device_flow,omitempty"`
+		OAuthEndpoint         string                  `json:"oauth_endpoint,omitempty"`
+		OAuthClientIDRequired bool                    `json:"oauth_client_id_required,omitempty"`
+		Deprecated            bool                    `json:"deprecated,omitempty"`
+		DeviceFlow            bool                    `json:"device_flow,omitempty"`
 		PKCEFlow             bool                    `json:"pkce_flow,omitempty"`
 		PKCEClientIDRequired bool                    `json:"pkce_client_id_required,omitempty"`
 		AutoIdentity         bool                    `json:"auto_identity,omitempty"`
@@ -303,12 +306,13 @@ func (h *ServicesHandler) List(w http.ResponseWriter, r *http.Request) {
 			actions = append(actions, ae)
 		}
 
-		var deviceFlow, pkceFlow, pkceFlowDefined bool
+		var deviceFlow, pkceFlow, pkceFlowDefined, deprecated bool
 		if mp, ok2 := a.(adapters.MetadataProvider); ok2 {
 			meta := mp.ServiceMetadata()
 			deviceFlow = meta.DeviceFlow
 			pkceFlow = meta.PKCEFlow
 			pkceFlowDefined = meta.PKCEFlowDefined
+			deprecated = meta.Deprecated
 		}
 		_, autoIdentity := a.(adapters.IdentityFetcher)
 
@@ -319,34 +323,56 @@ func (h *ServicesHandler) List(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
+		// MCP-OAuth services handle their own client provisioning via RFC 7591
+		// dynamic registration on first Connect — there's nothing for the
+		// admin to pre-configure. The badge stays available for the admin
+		// override path (mcp.oauth.{serviceID} in the vault) but only fires
+		// when an admin has explicitly pinned a client without a secret.
+		oauthClientIDRequired := false
+		if strings.HasPrefix(oauthEndpoint, "mcp:") {
+			cid, csec := adapters.GetMCPOAuthCredentials(r.Context(), h.vault, a.ServiceID())
+			oauthClientIDRequired = cid != "" && csec == ""
+		}
+
 		return serviceEntry{
-			ID:                   a.ServiceID(),
-			Name:                 name,
-			Description:          desc,
-			IconSVG:              iconSVG,
-			IconURL:              iconURL,
-			OAuth:                a.RequiredScopes() != nil,
-			OAuthEndpoint:        oauthEndpoint,
-			DeviceFlow:           deviceFlow,
-			PKCEFlow:             pkceFlowDefined,              // show PKCE option if defined, even without client ID
-			PKCEClientIDRequired: pkceFlowDefined && !pkceFlow, // client ID still needed
-			AutoIdentity:         autoIdentity,
-			RequiresActivation:   true,
-			Actions:              actions,
-			Variables:            variables,
-			SetupURL:             setupURL,
-			KeyHint:              keyHint,
-			KeyDisplayName:       keyDisplayName,
-			KeyDescription:       keyDescription,
+			ID:                    a.ServiceID(),
+			Name:                  name,
+			Description:           desc,
+			IconSVG:               iconSVG,
+			IconURL:               iconURL,
+			OAuth:                 a.RequiredScopes() != nil,
+			OAuthEndpoint:         oauthEndpoint,
+			OAuthClientIDRequired: oauthClientIDRequired,
+			Deprecated:            deprecated,
+			DeviceFlow:            deviceFlow,
+			PKCEFlow:              pkceFlowDefined,              // show PKCE option if defined, even without client ID
+			PKCEClientIDRequired:  pkceFlowDefined && !pkceFlow, // client ID still needed
+			AutoIdentity:          autoIdentity,
+			RequiresActivation:    true,
+			Actions:               actions,
+			Variables:             variables,
+			SetupURL:              setupURL,
+			KeyHint:               keyHint,
+			KeyDisplayName:        keyDisplayName,
+			KeyDescription:        keyDescription,
 		}
 	}
 
 	services := make([]serviceEntry, 0)
-	for _, a := range h.adapterReg.All() {
+	for _, a := range h.adapterReg.AllForUser(r.Context(), user.ID) {
 		if ac, ok := a.(adapters.AvailabilityChecker); ok && !ac.Available() {
 			continue
 		}
 		credentialFree := a.ValidateCredential(nil) == nil
+
+		// Deprecated services stay visible *only* to users who have
+		// already activated them — they vanish from the "available to
+		// connect" portion of the catalog. Used during migrations where a
+		// successor adapter has taken the prominent slot.
+		deprecated := false
+		if mp, ok := a.(adapters.MetadataProvider); ok {
+			deprecated = mp.ServiceMetadata().Deprecated
+		}
 
 		if credentialFree {
 			// Check all metas for this service (may have a non-default alias via rename).
@@ -366,7 +392,7 @@ func (h *ServicesHandler) List(w http.ResponseWriter, r *http.Request) {
 				}
 				services = append(services, entry)
 			}
-			if !found {
+			if !found && !deprecated {
 				entry := buildEntry(a)
 				entry.CredentialFree = true
 				entry.Status = "not_activated"
@@ -411,7 +437,7 @@ func (h *ServicesHandler) List(w http.ResponseWriter, r *http.Request) {
 			shown = true
 		}
 
-		if !shown {
+		if !shown && !deprecated {
 			entry := buildEntry(a)
 			entry.Status = "not_activated"
 			services = append(services, entry)
@@ -458,6 +484,18 @@ func (h *ServicesHandler) OAuthGetURL(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// For MCP-OAuth adapters, run RFC 9728 + RFC 8414 discovery and RFC 7591
+	// dynamic registration before consulting OAuthConfig — so the first
+	// Connect click against a fresh MCP service Just Works without admin
+	// pre-registration.
+	if mcp, ok := adapter.(*mcpadapter.MCPAdapter); ok {
+		if err := mcp.EnsureOAuthReady(r.Context(), h.oauthRedirectURL()); err != nil {
+			h.logger.Warn("mcp oauth discovery/registration failed", "service", serviceID, "err", err)
+			writeError(w, http.StatusBadGateway, "OAUTH_DISCOVERY_FAILED", err.Error())
+			return
+		}
+	}
+
 	oauthCfg := adapter.OAuthConfig()
 	if oauthCfg == nil {
 		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "service does not use OAuth2")
@@ -480,6 +518,13 @@ func (h *ServicesHandler) OAuthGetURL(w http.ResponseWriter, r *http.Request) {
 	if alreadyAuthorized && !newAccount {
 		// Scopes already granted — just ensure service_meta exists and return.
 		_ = h.st.UpsertServiceMeta(r.Context(), user.ID, serviceID, alias, time.Now())
+		// Self-heal MCP services with empty tool caches (e.g. legacy stuck
+		// state from before the activation rollback shipped, or a user who
+		// hit the rollback once and re-clicked Connect).
+		if err := h.repairMCPToolsForUser(r.Context(), adapter, user.ID, serviceID, alias); err != nil {
+			h.logger.Warn("mcp tool repair on already_authorized failed",
+				"service", serviceID, "user", user.ID, "err", err)
+		}
 		writeJSON(w, http.StatusOK, map[string]any{
 			"already_authorized": true,
 			"service":            serviceID,
@@ -546,6 +591,18 @@ func (h *ServicesHandler) OAuthStart(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		writeError(w, http.StatusNotFound, "NOT_FOUND", fmt.Sprintf("service %q not found", serviceID))
 		return
+	}
+
+	// For MCP-OAuth adapters, run RFC 9728 + RFC 8414 discovery and RFC 7591
+	// dynamic registration before consulting OAuthConfig — so the first
+	// Connect click against a fresh MCP service Just Works without admin
+	// pre-registration.
+	if mcp, ok := adapter.(*mcpadapter.MCPAdapter); ok {
+		if err := mcp.EnsureOAuthReady(r.Context(), h.oauthRedirectURL()); err != nil {
+			h.logger.Warn("mcp oauth discovery/registration failed", "service", serviceID, "err", err)
+			writeError(w, http.StatusBadGateway, "OAUTH_DISCOVERY_FAILED", err.Error())
+			return
+		}
 	}
 
 	oauthCfg := adapter.OAuthConfig()
@@ -765,6 +822,19 @@ func (h *ServicesHandler) OAuthCallback(w http.ResponseWriter, r *http.Request) 
 		_ = h.st.UpsertServiceConfig(r.Context(), entry.UserID, entry.ServiceID, alias, configJSON)
 	}
 
+	// MCP adapters: discover the downstream server's tools now that we have
+	// a valid OAuth credential. On failure, roll back so the user doesn't
+	// end up with a "connected" service exposing zero actions — the OAuth
+	// grant at the vendor still stands, so a retry is cheap.
+	if err := h.ensureMCPToolsActivated(r.Context(), adapter, entry.UserID, entry.ServiceID, alias, credBytes); err != nil {
+		h.logger.Error("mcp tool discovery failed at oauth activation; rolling back",
+			"service", entry.ServiceID, "user", entry.UserID, "err", err)
+		_ = h.vault.Delete(r.Context(), entry.UserID, vKey)
+		_ = h.st.DeleteServiceMeta(r.Context(), entry.UserID, entry.ServiceID, alias)
+		oauthPopupClose(w, "Tool discovery failed — please try connecting again.", "", entry.OpenerOrigin)
+		return
+	}
+
 	h.logger.Info("service activated", "user", entry.UserID, "service", entry.ServiceID, "alias", alias)
 
 	// Re-execute any pending request that was waiting for this activation.
@@ -896,6 +966,14 @@ func (h *ServicesHandler) Activate(w http.ResponseWriter, r *http.Request) {
 		mergedScopes, alreadyAuthorized := h.resolveOAuthScopes(r.Context(), user.ID, serviceID, alias, adapter)
 		if alreadyAuthorized {
 			_ = h.st.UpsertServiceMeta(r.Context(), user.ID, serviceID, alias, time.Now())
+			// Self-heal stuck MCP services whose tool cache failed to
+			// populate on the original activation. ensureMCPToolsActivated
+			// no-ops if tools are already cached, so this is cheap when
+			// nothing's wrong.
+			if err := h.repairMCPToolsForUser(r.Context(), adapter, user.ID, serviceID, alias); err != nil {
+				h.logger.Warn("mcp tool repair on already_authorized failed",
+					"service", serviceID, "user", user.ID, "err", err)
+			}
 			writeJSON(w, http.StatusOK, map[string]any{
 				"already_authorized": true,
 				"service":            serviceID,
@@ -1035,6 +1113,19 @@ func (h *ServicesHandler) ActivateWithKey(w http.ResponseWriter, r *http.Request
 		_ = h.st.UpsertServiceConfig(r.Context(), user.ID, serviceID, alias, configJSON)
 	}
 
+	// MCP adapters: discover the downstream server's tools now that we have
+	// a credential, persist them to the store, and register a per-user
+	// clone carrying the discovered tool set. The store row is the source
+	// of truth across restarts; the in-memory clone is just a cache.
+	if err := h.ensureMCPToolsActivated(r.Context(), adapter, user.ID, serviceID, alias, credBytes); err != nil {
+		h.logger.Error("mcp tool discovery failed at api-key activation; rolling back",
+			"service", serviceID, "user", user.ID, "err", err)
+		_ = h.vault.Delete(r.Context(), user.ID, vKey)
+		_ = h.st.DeleteServiceMeta(r.Context(), user.ID, serviceID, alias)
+		writeError(w, http.StatusBadGateway, "TOOL_DISCOVERY_FAILED", "tool discovery failed: "+err.Error())
+		return
+	}
+
 	h.logger.Info("service activated via api key", "user", user.ID, "service", serviceID, "alias", alias)
 
 	writeJSON(w, http.StatusOK, map[string]string{"status": "activated", "service": serviceID, "alias": alias})
@@ -1082,9 +1173,13 @@ func (h *ServicesHandler) Deactivate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Remove the service_meta and service_config records first.
+	// Remove the service_meta, service_config, and (for MCP services) the
+	// per-user tool cache. Also evict the in-memory per-user adapter clone
+	// so the catalog doesn't keep serving stale actions until restart.
 	_ = h.st.DeleteServiceMeta(r.Context(), user.ID, serviceID, alias)
 	_ = h.st.DeleteServiceConfig(r.Context(), user.ID, serviceID, alias)
+	_ = h.st.DeleteMCPTools(r.Context(), user.ID, serviceID, alias)
+	h.adapterReg.RemoveForUser(serviceID, user.ID)
 
 	// Credential-free services have no vault credential to clean up.
 	adapter, ok := h.adapterReg.Get(serviceID)
@@ -1276,6 +1371,15 @@ func (h *ServicesHandler) RenameAlias(w http.ResponseWriter, r *http.Request) {
 	_ = h.st.UpsertServiceMeta(r.Context(), user.ID, serviceID, body.NewAlias, oldMeta.ActivatedAt)
 	_ = h.st.DeleteServiceMeta(r.Context(), user.ID, serviceID, body.OldAlias)
 
+	// Move the MCP tool cache to the new alias too — restart hydration in
+	// defaults.go reads tools keyed by the current service_meta alias, so
+	// without this the renamed MCP connection would lose actions after the
+	// next process restart.
+	if oldTools, err := h.st.GetMCPTools(r.Context(), user.ID, serviceID, body.OldAlias); err == nil {
+		_ = h.st.UpsertMCPTools(r.Context(), user.ID, serviceID, body.NewAlias, oldTools)
+		_ = h.st.DeleteMCPTools(r.Context(), user.ID, serviceID, body.OldAlias)
+	}
+
 	// If other services share the same vault key (e.g. all Google services share "google"),
 	// rename their metas too so they continue to find the credential.
 	metas, _ := h.st.ListServiceMetas(r.Context(), user.ID)
@@ -1292,6 +1396,58 @@ func (h *ServicesHandler) RenameAlias(w http.ResponseWriter, r *http.Request) {
 
 	h.logger.Info("alias renamed", "user", user.ID, "service", serviceID, "old", body.OldAlias, "new", body.NewAlias)
 	writeJSON(w, http.StatusOK, map[string]string{"status": "renamed", "service": serviceID, "alias": body.NewAlias})
+}
+
+// ensureMCPToolsActivated runs DiscoverTools + persist + register-per-user
+// for MCP adapters. Called from both activation paths (OAuth callback and
+// API-key) right after the credential lands in the vault, and from the
+// already_authorized fast path as self-repair when a previous activation
+// stored the credential but failed mid-discovery.
+//
+// No-op for non-MCP adapters. Returns the underlying error so callers can
+// log at the appropriate level; activation does NOT roll back on failure
+// (the credential is valid and a future Connect click can repair).
+func (h *ServicesHandler) ensureMCPToolsActivated(
+	ctx context.Context, adapter adapters.Adapter, userID, serviceID, alias string, credBytes []byte,
+) error {
+	mcp, ok := adapter.(*mcpadapter.MCPAdapter)
+	if !ok {
+		return nil
+	}
+	tools, err := mcp.DiscoverTools(ctx, credBytes)
+	if err != nil {
+		return fmt.Errorf("discover: %w", err)
+	}
+	toolsJSON, _ := json.Marshal(tools)
+	if err := h.st.UpsertMCPTools(ctx, userID, serviceID, alias, toolsJSON); err != nil {
+		return fmt.Errorf("persist: %w", err)
+	}
+	h.adapterReg.RegisterForUser(userID, mcp.ForUser(tools))
+	h.logger.Info("mcp tools discovered",
+		"service", serviceID, "user", userID, "alias", alias, "tool_count", len(tools))
+	return nil
+}
+
+// repairMCPToolsForUser self-heals an MCP service that has a stored
+// credential + service_meta row but no tool cache (typically because
+// DiscoverTools failed transiently during the original activation). Called
+// from the already_authorized branch of /api/services/{id}/activate. No-op
+// when the cache is already populated.
+func (h *ServicesHandler) repairMCPToolsForUser(
+	ctx context.Context, adapter adapters.Adapter, userID, serviceID, alias string,
+) error {
+	if _, ok := adapter.(*mcpadapter.MCPAdapter); !ok {
+		return nil
+	}
+	if raw, err := h.st.GetMCPTools(ctx, userID, serviceID, alias); err == nil && len(raw) > 2 {
+		return nil // already cached
+	}
+	vKey := h.adapterReg.VaultKeyWithAlias(serviceID, alias)
+	credBytes, err := h.vault.Get(ctx, userID, vKey)
+	if err != nil {
+		return fmt.Errorf("vault get: %w", err)
+	}
+	return h.ensureMCPToolsActivated(ctx, adapter, userID, serviceID, alias, credBytes)
 }
 
 // resolveIdentityAlias attempts to auto-detect the account identity for a service.
@@ -2383,5 +2539,90 @@ func (h *ServicesHandler) DeletePKCECredential(w http.ResponseWriter, r *http.Re
 	}
 
 	h.logger.Info("PKCE client ID removed", "service_id", serviceID)
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+}
+
+// ── MCP OAuth credentials ────────────────────────────────────────────────────
+// Settings-page CRUD for per-MCP-service OAuth client credentials. Mirrors
+// the PKCE handler shape: list/set/delete keyed by service ID. Secrets are
+// write-only — list responses contain client_id but never client_secret.
+
+// ListMCPOAuthCredentials returns all configured MCP OAuth client IDs.
+//
+// GET /api/system/mcp-oauth
+// Auth: user JWT
+// Response: [{"service_id": "...", "client_id": "..."}]
+func (h *ServicesHandler) ListMCPOAuthCredentials(w http.ResponseWriter, r *http.Request) {
+	entries, err := adapters.ListMCPOAuthCredentials(r.Context(), h.vault)
+	if err != nil {
+		h.logger.Error("failed to list MCP OAuth credentials", "err", err)
+		writeError(w, http.StatusInternalServerError, "INTERNAL", "failed to list MCP OAuth credentials")
+		return
+	}
+	writeJSON(w, http.StatusOK, entries)
+}
+
+// SetMCPOAuthCredential stores OAuth app credentials for an MCP service.
+// Once stored, the corresponding MCPAdapter will start returning a valid
+// OAuthConfig and the settings UI will mark the service ready to activate.
+//
+// POST /api/system/mcp-oauth
+// Auth: user JWT
+// Body: {"service_id": "...", "client_id": "...", "client_secret": "..."}
+// Response: {"ok": true}
+func (h *ServicesHandler) SetMCPOAuthCredential(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		ServiceID    string `json:"service_id"`
+		ClientID     string `json:"client_id"`
+		ClientSecret string `json:"client_secret"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "invalid JSON body")
+		return
+	}
+	if body.ServiceID == "" || body.ClientID == "" || body.ClientSecret == "" {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "service_id, client_id, and client_secret are required")
+		return
+	}
+	// Validate that the service ID actually corresponds to a registered
+	// MCP-OAuth adapter, so admins can't accidentally seed credentials for
+	// a typo'd service that will never be read.
+	adapter, ok := h.adapterReg.Get(body.ServiceID)
+	if !ok {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "no adapter registered with that service_id")
+		return
+	}
+	if mp, ok := adapter.(adapters.MetadataProvider); ok {
+		if !strings.HasPrefix(mp.ServiceMetadata().OAuthEndpoint, "mcp:") {
+			writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "service is not an MCP OAuth adapter")
+			return
+		}
+	}
+	if err := adapters.SetMCPOAuthCredentials(r.Context(), h.vault, body.ServiceID, body.ClientID, body.ClientSecret); err != nil {
+		h.logger.Error("failed to store MCP OAuth credentials", "service_id", body.ServiceID, "err", err)
+		writeError(w, http.StatusInternalServerError, "INTERNAL", "failed to store credentials")
+		return
+	}
+	h.logger.Info("MCP OAuth credentials stored", "service_id", body.ServiceID)
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+}
+
+// DeleteMCPOAuthCredential removes OAuth app credentials for an MCP service.
+//
+// DELETE /api/system/mcp-oauth/{service_id}
+// Auth: user JWT
+// Response: {"ok": true}
+func (h *ServicesHandler) DeleteMCPOAuthCredential(w http.ResponseWriter, r *http.Request) {
+	serviceID := r.PathValue("service_id")
+	if serviceID == "" {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "service_id is required")
+		return
+	}
+	if err := adapters.DeleteMCPOAuthCredentials(r.Context(), h.vault, serviceID); err != nil {
+		h.logger.Error("failed to delete MCP OAuth credentials", "service_id", serviceID, "err", err)
+		writeError(w, http.StatusInternalServerError, "INTERNAL", "failed to delete credentials")
+		return
+	}
+	h.logger.Info("MCP OAuth credentials removed", "service_id", serviceID)
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
 }

--- a/internal/api/handlers/skill.go
+++ b/internal/api/handlers/skill.go
@@ -33,18 +33,27 @@ func (h *SkillHandler) isMCPService(serviceID string) bool {
 //
 // Output is NOT Markdown-wrapped — we serve the description verbatim so
 // the agent gets exactly what the MCP server documented.
-func (h *SkillHandler) writeActionDetail(buf *strings.Builder, serviceID, action string, entries []*catalogEntry, adapterMeta map[string]adapters.ServiceMetadata) {
+//
+// Honors the same restriction filter as the overview/detail views: an
+// action that's restricted (and therefore omitted from the catalog list)
+// must not be readable via this endpoint either. Otherwise an agent could
+// learn from full docs of an action it isn't allowed to call.
+func (h *SkillHandler) writeActionDetail(buf *strings.Builder, ctx context.Context, serviceID, action string, entries []*catalogEntry, adapterMeta map[string]adapters.ServiceMetadata, userID string) {
 	baseID, _ := parseServiceAliasSkill(serviceID)
 	// Only allow this view for services the user actually has activated.
-	known := false
+	var entry *catalogEntry
 	for _, e := range entries {
 		if e.baseID == baseID {
-			known = true
+			entry = e
 			break
 		}
 	}
-	if !known {
+	if entry == nil {
 		buf.WriteString(fmt.Sprintf("Service %q is not activated for this user.\n", serviceID))
+		return
+	}
+	if h.isRestricted(ctx, userID, entry, action) {
+		buf.WriteString(fmt.Sprintf("Action %q is restricted on service %q.\n", action, serviceID))
 		return
 	}
 	meta, ok := adapterMeta[baseID]
@@ -247,7 +256,7 @@ func (h *SkillHandler) Catalog(w http.ResponseWriter, r *http.Request) {
 	case serviceFilter != "" && actionFilter != "":
 		// Detail endpoint: return the byte-exact raw description so the
 		// agent can read full Markdown docs for one specific tool.
-		h.writeActionDetail(&buf, serviceFilter, actionFilter, sorted, adapterMeta)
+		h.writeActionDetail(&buf, ctx, serviceFilter, actionFilter, sorted, adapterMeta, agent.UserID)
 	case serviceFilter != "":
 		h.writeServiceDetail(&buf, ctx, serviceFilter, sorted, adapterMeta, agent.UserID)
 	default:

--- a/internal/api/handlers/skill.go
+++ b/internal/api/handlers/skill.go
@@ -10,9 +10,69 @@ import (
 
 	"github.com/clawvisor/clawvisor/internal/api/middleware"
 	"github.com/clawvisor/clawvisor/pkg/adapters"
+	"github.com/clawvisor/clawvisor/pkg/adapters/mcpadapter"
 	"github.com/clawvisor/clawvisor/pkg/store"
 	"github.com/clawvisor/clawvisor/pkg/vault"
 )
+
+// isMCPService reports whether the given base service ID corresponds to an
+// MCPAdapter — used by the catalog renderer to apply MCP-specific rules
+// (one-line summarization, per-server byte budget).
+func (h *SkillHandler) isMCPService(serviceID string) bool {
+	a, ok := h.adapterReg.Get(serviceID)
+	if !ok {
+		return false
+	}
+	_, ok = a.(*mcpadapter.MCPAdapter)
+	return ok
+}
+
+// writeActionDetail serves the byte-exact original description of a single
+// MCP tool. This is the "safety net" call site for an agent that read the
+// compact catalog summary and needs full docs before invoking a tool.
+//
+// Output is NOT Markdown-wrapped — we serve the description verbatim so
+// the agent gets exactly what the MCP server documented.
+func (h *SkillHandler) writeActionDetail(buf *strings.Builder, serviceID, action string, entries []*catalogEntry, adapterMeta map[string]adapters.ServiceMetadata) {
+	baseID, _ := parseServiceAliasSkill(serviceID)
+	// Only allow this view for services the user actually has activated.
+	known := false
+	for _, e := range entries {
+		if e.baseID == baseID {
+			known = true
+			break
+		}
+	}
+	if !known {
+		buf.WriteString(fmt.Sprintf("Service %q is not activated for this user.\n", serviceID))
+		return
+	}
+	meta, ok := adapterMeta[baseID]
+	if !ok {
+		buf.WriteString(fmt.Sprintf("Service %q has no metadata.\n", serviceID))
+		return
+	}
+	am, ok := meta.ActionMeta[action]
+	if !ok {
+		buf.WriteString(fmt.Sprintf("Action %q not found on service %q.\n", action, serviceID))
+		return
+	}
+	if am.Description == "" {
+		buf.WriteString(fmt.Sprintf("(no description provided for %s:%s)\n", serviceID, action))
+		return
+	}
+	buf.WriteString(am.Description)
+}
+
+// parseServiceAliasSkill mirrors parseServiceAlias used elsewhere — split
+// "service:alias" → ("service", "alias"). Defined locally so this file
+// doesn't reach across to other handlers.
+func parseServiceAliasSkill(s string) (string, string) {
+	if i := strings.Index(s, ":"); i >= 0 {
+		return s[:i], s[i+1:]
+	}
+	return s, ""
+}
 
 // LocalServiceProvider supplies local daemon services for the agent catalog.
 // Implemented by the cloud layer; nil in self-hosted mode.
@@ -104,7 +164,7 @@ func (h *SkillHandler) Catalog(w http.ResponseWriter, r *http.Request) {
 
 	// Build the adapter metadata index for action descriptions.
 	adapterMeta := map[string]adapters.ServiceMetadata{} // serviceID → metadata
-	allAdapters := h.adapterReg.All()
+	allAdapters := h.adapterReg.AllForUser(ctx, agent.UserID)
 	for _, a := range allAdapters {
 		if mp, ok := a.(adapters.MetadataProvider); ok {
 			adapterMeta[a.ServiceID()] = mp.ServiceMetadata()
@@ -176,14 +236,21 @@ func (h *SkillHandler) Catalog(w http.ResponseWriter, r *http.Request) {
 	}
 	sort.Slice(sorted, func(i, j int) bool { return sorted[i].baseID < sorted[j].baseID })
 
-	// Check for ?service= filter for detailed single-service view.
+	// Check for ?service= filter for detailed single-service view, and
+	// ?action= for a single tool's raw description (MCP catalog spec).
 	serviceFilter := r.URL.Query().Get("service")
+	actionFilter := r.URL.Query().Get("action")
 
 	var buf strings.Builder
 
-	if serviceFilter != "" {
+	switch {
+	case serviceFilter != "" && actionFilter != "":
+		// Detail endpoint: return the byte-exact raw description so the
+		// agent can read full Markdown docs for one specific tool.
+		h.writeActionDetail(&buf, serviceFilter, actionFilter, sorted, adapterMeta)
+	case serviceFilter != "":
 		h.writeServiceDetail(&buf, ctx, serviceFilter, sorted, adapterMeta, agent.UserID)
-	} else {
+	default:
 		h.writeCatalogOverview(&buf, ctx, sorted, adapterMeta, agent.UserID)
 	}
 
@@ -235,24 +302,49 @@ func (h *SkillHandler) writeCatalogOverview(buf *strings.Builder, ctx context.Co
 		}
 		buf.WriteString("\n")
 
-		for _, action := range entry.actions {
-			if h.isRestricted(ctx, userID, entry, action) {
-				continue
-			}
-
-			// Build the action line with compact param signature.
-			if meta, ok := adapterMeta[entry.baseID]; ok {
-				if am, ok := meta.ActionMeta[action]; ok {
-					desc := am.Description
-					if desc == "" {
-						desc = am.DisplayName
-					}
-					paramSig := compactParamSig(am.Params)
-					buf.WriteString(fmt.Sprintf("- **%s**%s \u2014 %s\n", action, paramSig, desc))
+		isMCP := h.isMCPService(entry.baseID)
+		renderSection := func(maxChars int) string {
+			var section strings.Builder
+			for _, action := range entry.actions {
+				if h.isRestricted(ctx, userID, entry, action) {
 					continue
 				}
+				meta, ok := adapterMeta[entry.baseID]
+				if !ok {
+					section.WriteString(fmt.Sprintf("- **%s** \u2014 (requires approval or task)\n", action))
+					continue
+				}
+				am, ok := meta.ActionMeta[action]
+				if !ok {
+					section.WriteString(fmt.Sprintf("- **%s** \u2014 (requires approval or task)\n", action))
+					continue
+				}
+				desc := am.Description
+				if isMCP {
+					// Raw MCP description can be multi-paragraph Markdown
+					// with fenced code, HTML, headers. Reduce to one line.
+					desc = mcpadapter.OneLineSummary(desc, maxChars)
+				}
+				if desc == "" {
+					desc = am.DisplayName
+				}
+				paramSig := compactParamSig(am.Params)
+				section.WriteString(fmt.Sprintf("- **%s**%s \u2014 %s\n", action, paramSig, desc))
 			}
-			buf.WriteString(fmt.Sprintf("- **%s** \u2014 (requires approval or task)\n", action))
+			return section.String()
+		}
+
+		// For MCP services, enforce the per-server byte budget by squeezing
+		// the summary cap until it fits. Non-MCP services use whatever
+		// curated descriptions their YAML already provides.
+		if isMCP {
+			buf.WriteString(mcpadapter.FitToBudget(
+				mcpadapter.PerServerByteBudget,
+				mcpadapter.DefaultSummaryMaxChars,
+				renderSection,
+			))
+		} else {
+			buf.WriteString(renderSection(0))
 		}
 		buf.WriteString("\n")
 	}

--- a/internal/api/handlers/tasks.go
+++ b/internal/api/handlers/tasks.go
@@ -540,6 +540,7 @@ func (h *TasksHandler) Create(w http.ResponseWriter, r *http.Request) {
 				AuthorizedActions: req.AuthorizedActions,
 				PlannedCalls:      req.PlannedCalls,
 				AgentName:         agent.Name,
+				UserID:            agent.UserID,
 			})
 			if err != nil {
 				h.logger.Warn("task risk assessment failed", "error", err)

--- a/internal/api/handlers/welcome.go
+++ b/internal/api/handlers/welcome.go
@@ -250,7 +250,7 @@ func (h *WelcomeHandler) listActivatedServices(ctx context.Context, userID strin
 		return entry
 	}
 
-	for _, a := range h.adapterReg.All() {
+	for _, a := range h.adapterReg.AllForUser(ctx, userID) {
 		if ac, ok := a.(adapters.AvailabilityChecker); ok && !ac.Available() {
 			continue
 		}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -801,6 +801,9 @@ func (s *Server) routes() http.Handler {
 	mux.Handle("GET /api/system/pkce-credentials", user(servicesHandler.ListPKCECredentials))
 	mux.Handle("POST /api/system/pkce-credentials", user(servicesHandler.SetPKCECredential))
 	mux.Handle("DELETE /api/system/pkce-credentials/{service_id}", user(servicesHandler.DeletePKCECredential))
+	mux.Handle("GET /api/system/mcp-oauth", user(servicesHandler.ListMCPOAuthCredentials))
+	mux.Handle("POST /api/system/mcp-oauth", user(servicesHandler.SetMCPOAuthCredential))
+	mux.Handle("DELETE /api/system/mcp-oauth/{service_id}", user(servicesHandler.DeleteMCPOAuthCredential))
 
 	// Skill catalog (agent token)
 	mux.Handle("GET /api/skill/catalog", requireAgent(e2e(http.HandlerFunc(skillHandler.Catalog))))

--- a/internal/taskrisk/assessor.go
+++ b/internal/taskrisk/assessor.go
@@ -29,6 +29,10 @@ type AssessRequest struct {
 	AuthorizedActions []store.TaskAction
 	PlannedCalls      []store.PlannedCall
 	AgentName         string
+	// UserID scopes the action-context lookup so per-user MCP tool sets
+	// (discovered at activation) appear in the prompt. Empty falls back to
+	// the global registry only.
+	UserID string
 }
 
 // RiskAssessment is the result of a task risk evaluation.
@@ -76,11 +80,14 @@ func (a *LLMAssessor) Assess(ctx context.Context, req AssessRequest) (*RiskAsses
 
 	start := time.Now()
 
-	systemPrompt := fmt.Sprintf(riskAssessmentSystemPrompt, buildActionContextFromRegistry(a.registry))
+	systemPrompt := fmt.Sprintf(riskAssessmentSystemPrompt, buildActionContextFromRegistry(ctx, a.registry, req.UserID))
 	client := llm.NewClient(cfg.LLMProviderConfig)
 	userMsg := buildAssessUserMessage(req)
-	// systemPrompt is stable across the process lifetime (registry metadata
-	// is loaded at startup), so it makes a good prompt-cache prefix.
+	// systemPrompt varies per user (the action context includes the user's
+	// MCP-discovered tools), so the cache prefix is effectively per-user.
+	// Still worth caching: a single user runs many risk assessments per
+	// session, all sharing the same activated-tool set, so the cache hit
+	// rate within a user is high.
 	messages := []llm.ChatMessage{
 		{Role: "system", Content: systemPrompt, CacheControl: true},
 		{Role: "user", Content: userMsg},

--- a/internal/taskrisk/assessor_test.go
+++ b/internal/taskrisk/assessor_test.go
@@ -1,6 +1,7 @@
 package taskrisk
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -136,7 +137,7 @@ func TestMarshalAssessment_Nil(t *testing.T) {
 
 func TestBuildActionContextFromRegistry(t *testing.T) {
 	// With a nil registry, buildActionContextFromRegistry should return empty.
-	result := buildActionContextFromRegistry(nil)
+	result := buildActionContextFromRegistry(context.Background(), nil, "")
 	if result != "" {
 		t.Errorf("expected empty string for nil registry, got %q", result)
 	}

--- a/internal/taskrisk/prompts.go
+++ b/internal/taskrisk/prompts.go
@@ -1,6 +1,7 @@
 package taskrisk
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -58,12 +59,20 @@ type ActionMeta struct {
 }
 
 // buildActionContextFromRegistry builds the action context block by reading
-// ActionMeta from all adapters that implement MetadataProvider.
-func buildActionContextFromRegistry(reg *adapters.Registry) string {
+// ActionMeta from all adapters that implement MetadataProvider, including
+// any per-user MCP-discovered tool sets so risk evaluation sees what the
+// requesting user actually has activated.
+func buildActionContextFromRegistry(ctx context.Context, reg *adapters.Registry, userID string) string {
 	entries := map[string]ActionMeta{}
 
 	if reg != nil {
-		for _, a := range reg.All() {
+		var list []adapters.Adapter
+		if userID != "" {
+			list = reg.AllForUser(ctx, userID)
+		} else {
+			list = reg.All()
+		}
+		for _, a := range list {
 			mp, ok := a.(adapters.MetadataProvider)
 			if !ok {
 				continue

--- a/pkg/adapters/adapters.go
+++ b/pkg/adapters/adapters.go
@@ -34,6 +34,7 @@ type ServiceMetadata struct {
 	PKCEFlow            bool                  // whether PKCE authorization code flow is available (client ID resolved)
 	PKCEFlowDefined     bool                  // whether PKCE flow is defined in the adapter (even without client ID)
 	AutoIdentity        bool                  // whether the adapter can auto-detect account identity
+	Deprecated          bool                  // hide from the connect-service list for new users (existing connections stay visible)
 	ActionMeta        map[string]ActionMeta // action_id → metadata
 	VerificationHints string
 	Variables         []VariableMeta // user-configurable variables declared by the adapter
@@ -115,6 +116,33 @@ const SystemVaultKeyMicrosoftOAuth = "microsoft.oauth"
 // SystemVaultKeyPKCEPrefix is the vault key prefix for per-service PKCE client IDs.
 // Stored as "__system__" / "pkce.{serviceID}" → {"client_id": "..."}.
 const SystemVaultKeyPKCEPrefix = "pkce."
+
+// SystemVaultKeyMCPOAuthPrefix is the vault key prefix for per-MCP-service
+// OAuth client credentials. Stored as
+//
+//	"__system__" / "mcp.oauth.{serviceID}" → {"client_id": "...", "client_secret": "..."}
+//
+// Settings UI populates these the same way it populates google.oauth /
+// microsoft.oauth. Used as an override when an admin wants to pin a specific
+// pre-registered client; otherwise the adapter dynamically registers and
+// stores the result under SystemVaultKeyMCPClientPrefix.
+const SystemVaultKeyMCPOAuthPrefix = "mcp.oauth."
+
+// SystemVaultKeyMCPClientPrefix is the vault key prefix for the per-service
+// MCP OAuth client record obtained via RFC 8414 discovery + RFC 7591 dynamic
+// client registration. Stored as
+//
+//	"__system__" / "mcp.client.{serviceID}" → {
+//	   "client_id": "...",
+//	   "client_secret": "...",            // optional (public clients omit)
+//	   "authorization_endpoint": "...",
+//	   "token_endpoint": "...",
+//	   "registration_endpoint": "..."     // for refresh / re-registration
+//	}
+//
+// One record per (Clawvisor deployment, MCP service). Probed and registered
+// once on first Connect click; reused for every user thereafter.
+const SystemVaultKeyMCPClientPrefix = "mcp.client."
 
 // Request is passed to an adapter's Execute method.
 // Credential is injected by the gateway; never logged or returned to the caller.
@@ -287,46 +315,121 @@ func (r *Registry) Get(serviceID string) (Adapter, bool) {
 	return a, ok
 }
 
-// GetForUser returns an adapter by service ID, checking the shared registry
-// first, then the per-user cache, then falling back to the resolver.
-// Resolved adapters are cached per-user to avoid cross-tenant leaks.
+// GetForUser returns an adapter by service ID, preferring the per-user cache
+// over the global registry. The lookup order is:
+//  1. Per-user cache (e.g. an MCP adapter clone with discovered tools)
+//  2. Resolver (for hydration from the persistent store on cache miss)
+//  3. Global registry (the unresolved/empty fallback)
+//
+// Per-user wins over global because services like MCP register an empty
+// global stub that would otherwise shadow the user's discovered tool set.
+// Resolved adapters are cached per-user for the rest of the process lifetime.
 func (r *Registry) GetForUser(ctx context.Context, serviceID, userID string) (Adapter, bool) {
 	r.mu.RLock()
-	// Check shared (built-in) adapters first.
-	a, ok := r.adapters[serviceID]
-	if ok {
-		r.mu.RUnlock()
-		return a, true
-	}
-	// Check per-user cache.
+	// 1. Per-user cache.
 	if userID != "" {
 		if userMap, exists := r.userAdapters[userID]; exists {
-			if a, ok = userMap[serviceID]; ok {
+			if a, ok := userMap[serviceID]; ok {
 				r.mu.RUnlock()
 				return a, true
 			}
 		}
 	}
 	resolver := r.resolver
+	global, hasGlobal := r.adapters[serviceID]
 	r.mu.RUnlock()
 
-	if resolver == nil || userID == "" {
-		return nil, false
+	// 2. Resolver — may return a user-scoped clone (MCP) or a generated YAML adapter.
+	if resolver != nil && userID != "" {
+		if a, ok := resolver(ctx, serviceID, userID); ok {
+			r.mu.Lock()
+			if r.userAdapters[userID] == nil {
+				r.userAdapters[userID] = make(map[string]Adapter)
+			}
+			r.userAdapters[userID][serviceID] = a
+			r.mu.Unlock()
+			return a, true
+		}
 	}
 
-	a, ok = resolver(ctx, serviceID, userID)
-	if !ok {
-		return nil, false
-	}
+	// 3. Global registry as last fallback.
+	return global, hasGlobal
+}
 
-	// Cache per-user so subsequent requests don't hit the DB.
+// RegisterForUser stores a user-scoped adapter instance. Used by activation
+// flows that build adapters with per-user state (e.g. MCP-discovered tools)
+// after the user supplies a credential. Look up via GetForUser.
+func (r *Registry) RegisterForUser(userID string, a Adapter) {
+	if userID == "" {
+		return
+	}
 	r.mu.Lock()
+	defer r.mu.Unlock()
 	if r.userAdapters[userID] == nil {
 		r.userAdapters[userID] = make(map[string]Adapter)
 	}
-	r.userAdapters[userID][serviceID] = a
-	r.mu.Unlock()
-	return a, true
+	r.userAdapters[userID][a.ServiceID()] = a
+}
+
+// AllForUser returns the union of built-in adapters and the user's per-user
+// adapters. When both registries hold the same service ID, the per-user
+// instance wins — that is how MCP services with activation-time tool
+// discovery surface their tool sets to the catalog.
+//
+// On cache miss for any global service, the registry's resolver (if set) is
+// consulted with (serviceID, userID). The resolver is the seam where MCP
+// adapters lazily load discovered tools from the persistent store, building
+// a per-user clone that is cached in r.userAdapters for the rest of the
+// process lifetime.
+func (r *Registry) AllForUser(ctx context.Context, userID string) []Adapter {
+	r.mu.RLock()
+	resolver := r.resolver
+	out := make([]Adapter, 0, len(r.adapters))
+	type resolveCandidate struct {
+		serviceID string
+		global    Adapter
+	}
+	var toResolve []resolveCandidate
+	userMap := r.userAdapters[userID]
+	seen := make(map[string]bool, len(r.adapters))
+	for id, a := range r.adapters {
+		seen[id] = true
+		if userMap != nil {
+			if ua, ok := userMap[id]; ok {
+				out = append(out, ua)
+				continue
+			}
+		}
+		// Defer resolver calls until after we drop the read lock.
+		if resolver != nil && userID != "" {
+			toResolve = append(toResolve, resolveCandidate{serviceID: id, global: a})
+			continue
+		}
+		out = append(out, a)
+	}
+	// Surface user-only adapters that have no global counterpart.
+	for id, a := range userMap {
+		if !seen[id] {
+			out = append(out, a)
+		}
+	}
+	r.mu.RUnlock()
+
+	// Resolve and cache outside the lock.
+	for _, c := range toResolve {
+		if resolved, ok := resolver(ctx, c.serviceID, userID); ok {
+			r.mu.Lock()
+			if r.userAdapters[userID] == nil {
+				r.userAdapters[userID] = make(map[string]Adapter)
+			}
+			r.userAdapters[userID][c.serviceID] = resolved
+			r.mu.Unlock()
+			out = append(out, resolved)
+		} else {
+			out = append(out, c.global)
+		}
+	}
+	return out
 }
 
 // SetFallback registers a resolver for service IDs not in the built-in map.

--- a/pkg/adapters/mcpadapter/adapter.go
+++ b/pkg/adapters/mcpadapter/adapter.go
@@ -1,0 +1,347 @@
+// Package mcpadapter implements adapters.Adapter by proxying to a downstream
+// MCP server. One generic adapter handles every spec-declared MCP service —
+// vendor-specific behavior lives in YAML, not Go.
+//
+// Architectural notes:
+//   - Tool discovery is dynamic via tools/list, populating SupportedActions().
+//   - Risk classification (read-only / destructive / idempotent) comes from
+//     the MCP tool's standard `annotations` field — no per-adapter YAML risk.
+//   - Response sanitization, identity unification, and approval rendering all
+//     live ABOVE this adapter, in gateway middleware. This adapter is a
+//     dumb proxy by design.
+package mcpadapter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"golang.org/x/oauth2"
+
+	"github.com/clawvisor/clawvisor/pkg/adapters"
+	"github.com/clawvisor/clawvisor/pkg/adapters/mcpclient"
+	"github.com/clawvisor/clawvisor/pkg/vault"
+)
+
+// Config configures an MCPAdapter.
+type Config struct {
+	ServiceID string    // e.g. "notion"
+	Transport Transport // how to open a connection to the downstream MCP server
+	// EnvForCredential maps the credential token into env vars passed to the
+	// MCP server subprocess. Most published MCP servers read auth from env
+	// (NOTION_TOKEN, GITHUB_TOKEN, etc.).
+	EnvForCredential func(cred []byte) (map[string]string, error)
+	// Spec is the parsed config-driven definition for this adapter, when one
+	// exists. Used for service metadata (display name, icon, setup URL) and
+	// the whoami identity hook. May be nil for adapters built directly with New.
+	Spec *Spec
+}
+
+// MCPAdapter implements adapters.Adapter via an MCP client.
+//
+// Tool discovery happens at service-activation time (the user has just
+// supplied a credential) — not lazily, not at catalog-fetch time. The
+// activation handler calls DiscoverTools and then registers a per-user
+// clone (via Registry.RegisterForUser) carrying the discovered tool set.
+// Catalog reads that per-user adapter and shows the user's specific tools.
+type MCPAdapter struct {
+	cfg                 Config
+	tools               []mcpclient.Tool // populated for per-user clones; empty on the global instance
+	oauthVault          vault.Vault      // optional; used to read system OAuth client credentials
+	discoveryHTTPClient *http.Client     // optional; tests override to point at httptest.Server
+	registerMu          *sync.Mutex      // serializes EnsureOAuthReady so concurrent first-time activations don't double-register; pointer so per-user clones share the lock with the global instance
+}
+
+func New(cfg Config) *MCPAdapter {
+	return &MCPAdapter{cfg: cfg, registerMu: &sync.Mutex{}}
+}
+
+func (a *MCPAdapter) ServiceID() string { return a.cfg.ServiceID }
+
+// SupportedActions returns the tool names this adapter exposes. For the
+// global registry instance this is empty (no user, no credential, no
+// discovery). Per-user clones populated at activation return their
+// discovered tool set.
+func (a *MCPAdapter) SupportedActions() []string {
+	out := make([]string, 0, len(a.tools))
+	for _, t := range a.tools {
+		out = append(out, t.Name)
+	}
+	return out
+}
+
+// Tools returns the cached tool list (populated at activation time).
+func (a *MCPAdapter) Tools() []mcpclient.Tool { return a.tools }
+
+// openCaller centralizes the per-request transport setup so OAuth-MCP and
+// bearer-MCP share one code path. For OAuth, it overlays a per-request
+// HTTPTransport whose http.Client has an oauth2.TokenSource baked in — so
+// token refresh happens transparently for every call. For bearer/stdio,
+// it goes through the configured transport with the env map populated as
+// usual.
+func (a *MCPAdapter) openCaller(ctx context.Context, cred []byte) (mcpclient.Caller, error) {
+	if a.oauthSpec() != nil {
+		base, ok := a.cfg.Transport.(*HTTPTransport)
+		if !ok {
+			return nil, fmt.Errorf("%s: oauth requires http transport", a.cfg.ServiceID)
+		}
+		client, err := a.httpClientFor(ctx, cred)
+		if err != nil {
+			return nil, err
+		}
+		// Shallow copy so the per-request http.Client doesn't leak across users.
+		tr := *base
+		tr.HTTPClient = client
+		// Skip the bearer-header path; the oauth2 client injects Authorization itself.
+		return tr.Open(ctx, map[string]string{})
+	}
+	env, err := a.cfg.EnvForCredential(cred)
+	if err != nil {
+		return nil, fmt.Errorf("%s: credential: %w", a.cfg.ServiceID, err)
+	}
+	return a.cfg.Transport.Open(ctx, env)
+}
+
+// DiscoverTools opens a fresh transport with the user's credential, calls
+// MCP tools/list, and returns the tool set. Called by the activation
+// handler after the credential has been validated and stored.
+func (a *MCPAdapter) DiscoverTools(ctx context.Context, cred []byte) ([]mcpclient.Tool, error) {
+	dctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	client, err := a.openCaller(dctx, cred)
+	if err != nil {
+		return nil, fmt.Errorf("%s: open transport: %w", a.cfg.ServiceID, err)
+	}
+	defer client.Close()
+	if err := client.Initialize(dctx); err != nil {
+		return nil, fmt.Errorf("%s: initialize: %w", a.cfg.ServiceID, err)
+	}
+	return client.ListTools(dctx)
+}
+
+// ForUser returns a shallow clone of this adapter with a fixed tool set.
+// Activation hands this clone to Registry.RegisterForUser so subsequent
+// per-user lookups see the user's discovered tools.
+func (a *MCPAdapter) ForUser(tools []mcpclient.Tool) *MCPAdapter {
+	clone := *a
+	clone.tools = tools
+	return &clone
+}
+
+func (a *MCPAdapter) Execute(ctx context.Context, req adapters.Request) (*adapters.Result, error) {
+	client, err := a.openCaller(ctx, req.Credential)
+	if err != nil {
+		return nil, fmt.Errorf("%s: open transport: %w", a.cfg.ServiceID, err)
+	}
+	defer client.Close()
+
+	if err := client.Initialize(ctx); err != nil {
+		return nil, fmt.Errorf("%s: initialize: %w", a.cfg.ServiceID, err)
+	}
+
+	tr, err := client.CallTool(ctx, req.Action, req.Params)
+	if err != nil {
+		return nil, fmt.Errorf("%s: call %s: %w", a.cfg.ServiceID, req.Action, err)
+	}
+	if tr.IsError {
+		msg := "tool returned error"
+		if len(tr.Content) > 0 {
+			msg = tr.Content[0].Text
+		}
+		return nil, fmt.Errorf("%s: %s: %s", a.cfg.ServiceID, req.Action, msg)
+	}
+
+	// MCP tool responses are content-typed (text/image/resource). We expect
+	// text content holding JSON. Parse it; if parse fails, surface the raw
+	// text. The gateway middleware handles sanitization above us.
+	var data any
+	var summary string
+	if len(tr.Content) > 0 && tr.Content[0].Type == "text" {
+		text := tr.Content[0].Text
+		if err := json.Unmarshal([]byte(text), &data); err != nil {
+			data = text
+		}
+		summary = a.summaryFor(req.Action, data)
+	}
+
+	return &adapters.Result{
+		Summary: summary,
+		Data:    data,
+		Meta: map[string]any{
+			"source": "mcp",
+			"server": a.cfg.ServiceID,
+		},
+	}, nil
+}
+
+// summaryFor synthesizes a one-line summary from the tool result. A future
+// pass moves this into gateway middleware (and uses an LLM or the tool
+// description); inlined here for now.
+func (a *MCPAdapter) summaryFor(action string, data any) string {
+	switch v := data.(type) {
+	case []any:
+		return fmt.Sprintf("%s: %d result(s)", action, len(v))
+	case map[string]any:
+		if results, ok := v["results"].([]any); ok {
+			return fmt.Sprintf("%s: %d result(s)", action, len(results))
+		}
+		if id, ok := v["id"].(string); ok {
+			return fmt.Sprintf("%s: %s", action, id)
+		}
+	}
+	return action
+}
+
+// ── Adapter interface ────────────────────────────────────────────────────────
+// MCPAdapter supports both API-key (Bearer header) and OAuth credential models,
+// selected by the spec. The existing activation handler in services.go drives
+// the OAuth dance when OAuthConfig() returns non-nil — the same path Gmail,
+// Drive, Slack, and Linear use.
+
+func (a *MCPAdapter) OAuthConfig() *oauth2.Config { return a.oauthConfig() }
+
+func (a *MCPAdapter) CredentialFromToken(t *oauth2.Token) ([]byte, error) {
+	if a.oauthSpec() == nil {
+		return nil, fmt.Errorf("%s: not an OAuth adapter", a.cfg.ServiceID)
+	}
+	if t == nil {
+		return nil, fmt.Errorf("%s: nil token", a.cfg.ServiceID)
+	}
+	payload := map[string]any{
+		"access_token":  t.AccessToken,
+		"refresh_token": t.RefreshToken,
+	}
+	if !t.Expiry.IsZero() {
+		payload["expiry"] = t.Expiry.Format(time.RFC3339)
+	}
+	return json.Marshal(payload)
+}
+
+func (a *MCPAdapter) ValidateCredential(credBytes []byte) error {
+	if len(credBytes) == 0 {
+		return fmt.Errorf("%s: credential required", a.cfg.ServiceID)
+	}
+	if a.oauthSpec() != nil {
+		var oc struct {
+			AccessToken  string `json:"access_token"`
+			RefreshToken string `json:"refresh_token"`
+		}
+		if err := json.Unmarshal(credBytes, &oc); err != nil {
+			return fmt.Errorf("%s: invalid oauth credential: %w", a.cfg.ServiceID, err)
+		}
+		if oc.AccessToken == "" && oc.RefreshToken == "" {
+			return fmt.Errorf("%s: oauth credential missing both access_token and refresh_token", a.cfg.ServiceID)
+		}
+		return nil
+	}
+	var cred struct {
+		Token string `json:"token"`
+	}
+	if err := json.Unmarshal(credBytes, &cred); err != nil {
+		return fmt.Errorf("%s: invalid credential: %w", a.cfg.ServiceID, err)
+	}
+	if cred.Token == "" {
+		return fmt.Errorf("%s: credential missing token", a.cfg.ServiceID)
+	}
+	return nil
+}
+
+func (a *MCPAdapter) RequiredScopes() []string {
+	spec := a.oauthSpec()
+	if spec == nil {
+		return nil
+	}
+	// Return a non-nil slice even when no scopes are declared — the catalog
+	// handler treats nil as "not an OAuth service", so OAuth-MCP with an
+	// empty scope list would otherwise be misclassified as API-key.
+	if spec.Scopes == nil {
+		return []string{}
+	}
+	return spec.Scopes
+}
+
+// ── MetadataProvider ─────────────────────────────────────────────────────────
+// Display fields come from the spec; action metadata is built from the
+// discovered tool list (name, annotations → risk classification, inputSchema
+// → param signature). Future work: pull more from MCP server `serverInfo`
+// and `instructions` responses.
+
+func (a *MCPAdapter) ServiceMetadata() adapters.ServiceMetadata {
+	actionMeta := make(map[string]adapters.ActionMeta)
+	for _, t := range a.Tools() {
+		// Resolve risk class conservatively when both hints are set:
+		// destructiveHint wins because the cost of misclassifying a write
+		// as read (bypassing approval/scope checks) is strictly worse
+		// than the inverse. Servers that get this wrong (Notion's
+		// notion-update-page used to set both) shouldn't accidentally
+		// unlock auto-execution.
+		category := "read"
+		sensitivity := "low"
+		if ro, _ := t.Annotations["readOnlyHint"].(bool); ro {
+			category = "read"
+			sensitivity = "low"
+		}
+		if dh, _ := t.Annotations["destructiveHint"].(bool); dh {
+			category = "write"
+			sensitivity = "medium"
+		}
+		actionMeta[t.Name] = adapters.ActionMeta{
+			DisplayName: t.Name,
+			Category:    category,
+			Sensitivity: sensitivity,
+			Description: t.Description, // raw — catalog renderer applies OneLineSummary
+			Params:      SchemaParams(t.InputSchema),
+		}
+	}
+
+	displayName := a.cfg.ServiceID
+	description := "MCP-backed adapter"
+	// KeyHint only applies to API-key adapters. For OAuth-MCP it stays
+	// empty so the modal doesn't render a misleading paste field.
+	keyHint := ""
+	if a.oauthSpec() == nil {
+		keyHint = "API token for the downstream service"
+	}
+	setupURL := ""
+	iconURL := ""
+	iconSVG := ""
+	autoIdentity := false
+	oauthEndpoint := ""
+	if a.oauthSpec() != nil {
+		// Signals to the catalog UI that this service activates via OAuth
+		// rather than an API-key paste. The discriminator string is
+		// per-service (mcp:notion, mcp:supabase, etc.) so the frontend can route to
+		// the right authorize URL.
+		oauthEndpoint = "mcp:" + a.cfg.ServiceID
+	}
+	if a.cfg.Spec != nil {
+		if a.cfg.Spec.Service.DisplayName != "" {
+			displayName = a.cfg.Spec.Service.DisplayName
+		}
+		if a.cfg.Spec.Service.Description != "" {
+			description = a.cfg.Spec.Service.Description
+		}
+		if a.cfg.Spec.Service.KeyHint != "" {
+			keyHint = a.cfg.Spec.Service.KeyHint
+		}
+		setupURL = a.cfg.Spec.Service.SetupURL
+		iconURL = a.cfg.Spec.Service.IconURL
+		iconSVG = a.cfg.Spec.Service.IconSVG
+		autoIdentity = a.cfg.Spec.MCP.Whoami != nil && a.cfg.Spec.MCP.Whoami.Tool != ""
+	}
+
+	return adapters.ServiceMetadata{
+		DisplayName:   displayName,
+		Description:   description,
+		KeyHint:       keyHint,
+		SetupURL:      setupURL,
+		IconURL:       iconURL,
+		IconSVG:       iconSVG,
+		OAuthEndpoint: oauthEndpoint,
+		AutoIdentity:  autoIdentity,
+		ActionMeta:    actionMeta,
+	}
+}

--- a/pkg/adapters/mcpadapter/adapter.go
+++ b/pkg/adapters/mcpadapter/adapter.go
@@ -272,21 +272,24 @@ func (a *MCPAdapter) RequiredScopes() []string {
 func (a *MCPAdapter) ServiceMetadata() adapters.ServiceMetadata {
 	actionMeta := make(map[string]adapters.ActionMeta)
 	for _, t := range a.Tools() {
-		// Resolve risk class conservatively when both hints are set:
-		// destructiveHint wins because the cost of misclassifying a write
-		// as read (bypassing approval/scope checks) is strictly worse
-		// than the inverse. Servers that get this wrong (Notion's
-		// notion-update-page used to set both) shouldn't accidentally
-		// unlock auto-execution.
-		category := "read"
-		sensitivity := "low"
+		// Default to write/medium per the MCP spec: when annotations are
+		// absent, readOnlyHint defaults to false and destructiveHint
+		// defaults to true. An unannotated tool must therefore be treated
+		// as writable and destructive so it doesn't accidentally bypass
+		// approval/scope gates. readOnlyHint=true is the only way to
+		// downgrade to read/low; destructiveHint=false (with readOnly not
+		// set) downgrades from high to medium.
+		category := "write"
+		sensitivity := "high"
+		if dh, ok := t.Annotations["destructiveHint"].(bool); ok && !dh {
+			sensitivity = "medium"
+		}
 		if ro, _ := t.Annotations["readOnlyHint"].(bool); ro {
+			// Read-only wins over any destructive hint — a server that
+			// sets both is misconfigured, but read-only is a stronger
+			// safety claim than destructive (which is the unknown default).
 			category = "read"
 			sensitivity = "low"
-		}
-		if dh, _ := t.Annotations["destructiveHint"].(bool); dh {
-			category = "write"
-			sensitivity = "medium"
 		}
 		actionMeta[t.Name] = adapters.ActionMeta{
 			DisplayName: t.Name,

--- a/pkg/adapters/mcpadapter/adapter.go
+++ b/pkg/adapters/mcpadapter/adapter.go
@@ -16,8 +16,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
+	"unicode"
 
 	"golang.org/x/oauth2"
 
@@ -269,6 +271,22 @@ func (a *MCPAdapter) RequiredScopes() []string {
 // → param signature). Future work: pull more from MCP server `serverInfo`
 // and `instructions` responses.
 
+// humanizeToolName converts an MCP tool ID like "get_edge_function" or
+// "notion-get-users" into a sentence-cased display string ("Get edge
+// function", "Notion get users"). MCP servers emit raw IDs; the UI wants
+// something readable in policy lists, queue entries, and approval cards.
+func humanizeToolName(name string) string {
+	s := strings.ReplaceAll(name, "_", " ")
+	s = strings.ReplaceAll(s, "-", " ")
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return name
+	}
+	r := []rune(s)
+	r[0] = unicode.ToUpper(r[0])
+	return string(r)
+}
+
 func (a *MCPAdapter) ServiceMetadata() adapters.ServiceMetadata {
 	actionMeta := make(map[string]adapters.ActionMeta)
 	for _, t := range a.Tools() {
@@ -292,7 +310,7 @@ func (a *MCPAdapter) ServiceMetadata() adapters.ServiceMetadata {
 			sensitivity = "low"
 		}
 		actionMeta[t.Name] = adapters.ActionMeta{
-			DisplayName: t.Name,
+			DisplayName: humanizeToolName(t.Name),
 			Category:    category,
 			Sensitivity: sensitivity,
 			Description: t.Description, // raw — catalog renderer applies OneLineSummary

--- a/pkg/adapters/mcpadapter/alias_test.go
+++ b/pkg/adapters/mcpadapter/alias_test.go
@@ -1,0 +1,42 @@
+package mcpadapter
+
+import "testing"
+
+func TestNormalizeAlias(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		// Real-world inputs we've seen on prod.
+		{"email passes through", "eric@clawvisor.com", "eric@clawvisor.com"},
+		{"org with apostrophe and spaces", "Eric Levine's Org", "eric-levines-org"},
+
+		// Single-word identities — common for GitHub-style logins.
+		{"plain lowercase", "octocat", "octocat"},
+		{"plain mixed case", "OctoCat", "octocat"},
+
+		// Spaces collapse to a single dash.
+		{"consecutive spaces collapse", "Acme  Corp   LLC", "acme-corp-llc"},
+		{"tabs and newlines treated as space", "Acme\tCorp\nLLC", "acme-corp-llc"},
+
+		// Edge cases.
+		{"empty input stays empty", "", ""},
+		{"only invalid chars yields empty", "🚀✨", ""},
+		{"strips leading/trailing dashes", "  hello  ", "hello"},
+		{"strips leading/trailing dots", "...hello...", "hello"},
+
+		// Allowed punctuation passes through.
+		{"underscore allowed", "user_name", "user_name"},
+		{"plus allowed for tagged emails", "user+tag@x.com", "user+tag@x.com"},
+		{"dot in middle preserved", "first.last", "first.last"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := normalizeAlias(tc.in)
+			if got != tc.want {
+				t.Errorf("normalizeAlias(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/adapters/mcpadapter/alias_test.go
+++ b/pkg/adapters/mcpadapter/alias_test.go
@@ -2,6 +2,25 @@ package mcpadapter
 
 import "testing"
 
+func TestHumanizeToolName(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"get_edge_function", "Get edge function"},
+		{"notion-get-users", "Notion get users"},
+		{"apply_migration", "Apply migration"},
+		{"already-Sentence Case", "Already Sentence Case"},
+		{"", ""},
+		{"a", "A"},
+		{"mixed_case-with_both", "Mixed case with both"},
+	}
+	for _, tc := range cases {
+		if got := humanizeToolName(tc.in); got != tc.want {
+			t.Errorf("humanizeToolName(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
 func TestNormalizeAlias(t *testing.T) {
 	cases := []struct {
 		name string

--- a/pkg/adapters/mcpadapter/catalog.go
+++ b/pkg/adapters/mcpadapter/catalog.go
@@ -1,0 +1,195 @@
+package mcpadapter
+
+import (
+	"bytes"
+	"encoding/json"
+	"regexp"
+	"strings"
+
+	"github.com/clawvisor/clawvisor/pkg/adapters"
+)
+
+// ── Render helpers exposed to the catalog handler ───────────────────────────
+
+// DefaultSummaryMaxChars caps an MCP tool's one-line summary in the catalog.
+// 150 chars is about one display line; combined with the first-sentence
+// heuristic in OneLineSummary, most descriptions land in 50–120 chars and
+// only the verbose stragglers hit the cap. The 2 KB-per-server budget
+// squeezes this lower for outliers.
+const DefaultSummaryMaxChars = 150
+
+// SummaryFloorChars is the lower bound the budget enforcer will collapse to.
+// Below this the agent loses meaningful information and may as well call the
+// detail endpoint.
+const SummaryFloorChars = 40
+
+// SchemaParams parses a JSON Schema's properties + required fields into
+// the typed []adapters.ParamMeta the catalog renderer expects, preserving
+// the schema's declaration order of property keys. Returns an empty slice
+// if the schema is empty, malformed, or has no properties.
+func SchemaParams(rawSchema json.RawMessage) []adapters.ParamMeta {
+	if len(rawSchema) == 0 || string(rawSchema) == "null" {
+		return nil
+	}
+	// First pass: pull out the two relevant fields via standard decode.
+	var top struct {
+		Properties *json.RawMessage `json:"properties"`
+		Required   *json.RawMessage `json:"required"`
+	}
+	if err := json.Unmarshal(rawSchema, &top); err != nil {
+		return nil
+	}
+
+	// Required set.
+	required := map[string]bool{}
+	if top.Required != nil {
+		var arr []string
+		if err := json.Unmarshal(*top.Required, &arr); err == nil {
+			for _, n := range arr {
+				required[n] = true
+			}
+		}
+	}
+
+	// Second pass: walk properties via Decoder.Token() so we preserve the
+	// declaration order the server (and presumably the docs author) chose.
+	if top.Properties == nil {
+		return nil
+	}
+	dec := json.NewDecoder(bytes.NewReader(*top.Properties))
+	tok, err := dec.Token()
+	if err != nil || tok != json.Delim('{') {
+		return nil
+	}
+	var out []adapters.ParamMeta
+	for dec.More() {
+		keyTok, err := dec.Token()
+		if err != nil {
+			break
+		}
+		key, _ := keyTok.(string)
+		// Peek the value's `type` field if it's an object (for ParamMeta.Type).
+		var subSchema struct {
+			Type any `json:"type"`
+		}
+		if err := dec.Decode(&subSchema); err != nil {
+			break
+		}
+		typeStr, _ := subSchema.Type.(string)
+		out = append(out, adapters.ParamMeta{
+			Name:     key,
+			Type:     typeStr,
+			Required: required[key],
+		})
+	}
+	return out
+}
+
+// OneLineSummary reduces a tool's free-form Markdown description to a single
+// short sentence, capped at maxChars. The transformations:
+//
+//   - Strip fenced code blocks, HTML/XML pairs, self-closing tags.
+//   - Truncate at the first H2-or-deeper heading.
+//   - Collapse whitespace.
+//   - Take the first sentence (text up to and including the first ".", "!",
+//     or "?" followed by whitespace or end-of-string).
+//   - Cap at maxChars runes with an ellipsis if it overflows.
+//
+// maxChars ≤ 0 disables the cap. The first-sentence heuristic is a
+// best-effort guess; the param signature already tells the agent what the
+// tool does, so a slightly clipped summary is fine.
+func OneLineSummary(desc string, maxChars int) string {
+	desc = codeFenceRe.ReplaceAllString(desc, " ")
+	desc = htmlBlockRe.ReplaceAllString(desc, " ")
+	desc = selfClosingTagRe.ReplaceAllString(desc, " ")
+	// Strip any heading lines at the very start of the description (e.g.
+	// "## Overview\nFoo..."). The h2OrDeeperRe cut below only fires for
+	// headings preceded by a newline, so without this pass Notion's
+	// `## Overview` lead-ins leak through verbatim. Loop to handle multiple
+	// stacked leading headings — anchored ^ only matches once per call.
+	for leadingHeadingRe.MatchString(desc) {
+		desc = leadingHeadingRe.ReplaceAllString(desc, "")
+	}
+	if loc := h2OrDeeperRe.FindStringIndex(desc); loc != nil {
+		desc = desc[:loc[0]]
+	}
+	desc = whitespaceRe.ReplaceAllString(desc, " ")
+	desc = strings.TrimSpace(desc)
+	desc = firstSentence(desc)
+	if maxChars > 0 {
+		// Count runes, not bytes, so multi-byte chars don't get sliced.
+		if runes := []rune(desc); len(runes) > maxChars {
+			desc = strings.TrimRight(string(runes[:maxChars]), " ") + "…"
+		}
+	}
+	return desc
+}
+
+// firstSentence returns text up to and including the first sentence-final
+// punctuation (`.`, `!`, `?`) followed by whitespace or end-of-string.
+// Returns the original string if no such boundary is found.
+func firstSentence(s string) string {
+	runes := []rune(s)
+	for i, r := range runes {
+		if r != '.' && r != '!' && r != '?' {
+			continue
+		}
+		// End-of-sentence iff followed by whitespace or end-of-string. This
+		// avoids breaking on decimals ("3.14") or initialisms ("U.S.A."),
+		// where the period is followed by a digit or another letter.
+		if i+1 >= len(runes) || isSentenceTerminator(runes[i+1]) {
+			return strings.TrimSpace(string(runes[:i+1]))
+		}
+	}
+	return s
+}
+
+func isSentenceTerminator(r rune) bool {
+	return r == ' ' || r == '\t' || r == '\n' || r == '\r'
+}
+
+// (?s) = dotall: . matches newlines.
+var (
+	codeFenceRe      = regexp.MustCompile("(?s)```.*?```")
+	htmlBlockRe      = regexp.MustCompile(`(?s)<[a-zA-Z][^>]*>.*?</[a-zA-Z][^>]*>`)
+	selfClosingTagRe = regexp.MustCompile(`<[a-zA-Z][^>]*/>`)
+	h2OrDeeperRe     = regexp.MustCompile(`\n##+\s`)
+	leadingHeadingRe = regexp.MustCompile(`^##+\s.*?(\n|$)`)
+	whitespaceRe     = regexp.MustCompile(`\s+`)
+)
+
+// FitToBudget returns the largest maxChars in [SummaryFloorChars, initialCap]
+// for which writeSection (called for each tool) renders within byteBudget
+// for the given section. Binary-search; tries the initial value first
+// (the common case is "already fits, don't shrink at all").
+//
+// renderSection is parameterized on maxChars so the caller can keep the
+// rendering logic in one place (no need to duplicate per-tool formatting
+// in this helper).
+func FitToBudget(byteBudget int, initialCap int, renderSection func(maxChars int) string) string {
+	if byteBudget <= 0 {
+		return renderSection(initialCap)
+	}
+	candidate := renderSection(initialCap)
+	if len(candidate) <= byteBudget {
+		return candidate
+	}
+	// Binary search downward from initialCap to SummaryFloorChars.
+	lo, hi := SummaryFloorChars, initialCap
+	best := renderSection(lo)
+	for lo <= hi {
+		mid := (lo + hi) / 2
+		s := renderSection(mid)
+		if len(s) <= byteBudget {
+			best = s
+			lo = mid + 1
+		} else {
+			hi = mid - 1
+		}
+	}
+	return best
+}
+
+// PerServerByteBudget is the cap per MCP server's top-level catalog section.
+// Servers under budget render verbose; outliers get squeezed by FitToBudget.
+const PerServerByteBudget = 2048

--- a/pkg/adapters/mcpadapter/catalog_test.go
+++ b/pkg/adapters/mcpadapter/catalog_test.go
@@ -1,0 +1,235 @@
+package mcpadapter
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestSchemaParams_OrderPreserved is the load-bearing test for the catalog
+// spec: the agent gets misleading docs if we reorder or rename properties.
+// We rely on json.Decoder.Token() preserving declaration order — which it
+// does for JSON object literals, the format MCP servers emit.
+func TestSchemaParams_OrderPreserved(t *testing.T) {
+	schema := json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"query": {"type": "string"},
+			"query_type": {"type": "string"},
+			"filters": {"type": "object"},
+			"page_size": {"type": "integer"}
+		},
+		"required": ["query"]
+	}`)
+	got := SchemaParams(schema)
+	wantNames := []string{"query", "query_type", "filters", "page_size"}
+	if len(got) != len(wantNames) {
+		t.Fatalf("got %d params, want %d", len(got), len(wantNames))
+	}
+	for i, name := range wantNames {
+		if got[i].Name != name {
+			t.Errorf("param[%d].Name = %q, want %q (order broken)", i, got[i].Name, name)
+		}
+	}
+	if !got[0].Required {
+		t.Errorf("query should be required")
+	}
+	for i := 1; i < len(got); i++ {
+		if got[i].Required {
+			t.Errorf("param[%d] %q should be optional", i, got[i].Name)
+		}
+	}
+}
+
+func TestSchemaParams_EdgeCases(t *testing.T) {
+	cases := []struct {
+		name   string
+		schema string
+		want   int
+	}{
+		{"empty schema returns nothing", `{}`, 0},
+		{"no properties block", `{"type":"object","required":["x"]}`, 0},
+		{"null schema", `null`, 0},
+		{"malformed schema", `{"properties":`, 0},
+		{"empty properties", `{"properties":{}}`, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := SchemaParams(json.RawMessage(tc.schema))
+			if len(got) != tc.want {
+				t.Errorf("got %d params, want %d", len(got), tc.want)
+			}
+		})
+	}
+}
+
+// TestOneLineSummary covers the cleanup rules required by the spec.
+// "No top-level entry contains fenced code, XML/HTML tag pairs, or content
+// past a ## header" is the acceptance criterion these tests lock in.
+func TestOneLineSummary(t *testing.T) {
+	cases := []struct {
+		name      string
+		desc      string
+		want      string
+		maxChars  int
+	}{
+		{
+			name:     "single sentence passes through",
+			desc:     "Search Notion.",
+			want:     "Search Notion.",
+			maxChars: 150,
+		},
+		{
+			name:     "first sentence only",
+			desc:     "Update a page. Returns the updated page record with all properties.",
+			want:     "Update a page.",
+			maxChars: 150,
+		},
+		{
+			name:     "strips fenced code blocks before extracting sentence",
+			desc:     "Update a page.\n```json\n{\"foo\":\"bar\"}\n```\nReturns the page.",
+			want:     "Update a page.",
+			maxChars: 150,
+		},
+		{
+			name:     "strips simple html block",
+			desc:     "Render <details>some useful info</details> here.",
+			want:     "Render here.",
+			maxChars: 150,
+		},
+		{
+			name:     "strips self-closing tags",
+			desc:     "Use <br/> a tag <hr/> here.",
+			want:     "Use a tag here.",
+			maxChars: 150,
+		},
+		{
+			name:     "cuts at first h2 before extracting sentence",
+			desc:     "Search the workspace.\n## Parameters\nquery: required",
+			want:     "Search the workspace.",
+			maxChars: 150,
+		},
+		{
+			// Regression: Notion's notion-create-pages / notion-update-page
+			// start their description with `## Overview\n...`. The trailing-
+			// H2 cut doesn't match (no preceding newline), so the heading
+			// used to leak through. The leading-heading strip catches it.
+			name:     "strips leading h2 heading line",
+			desc:     "## Overview\nCreates one or more Notion pages.",
+			want:     "Creates one or more Notion pages.",
+			maxChars: 150,
+		},
+		{
+			name:     "strips stacked leading headings",
+			desc:     "## Overview\n## Details\nUpdate a page.",
+			want:     "Update a page.",
+			maxChars: 150,
+		},
+		{
+			name:     "leading heading with no body collapses to empty",
+			desc:     "## Overview",
+			want:     "",
+			maxChars: 150,
+		},
+		{
+			name:     "no period falls back to full text",
+			desc:     "Identity for the connected workspace",
+			want:     "Identity for the connected workspace",
+			maxChars: 150,
+		},
+		{
+			name:     "decimal numbers don't end the sentence",
+			desc:     "Charge $3.50 to the customer. The transaction posts immediately.",
+			want:     "Charge $3.50 to the customer.",
+			maxChars: 150,
+		},
+		{
+			name:     "question mark ends the sentence",
+			desc:     "Did the user accept? Returns true/false.",
+			want:     "Did the user accept?",
+			maxChars: 150,
+		},
+		{
+			name:     "truncates over maxChars with ellipsis",
+			desc:     strings.Repeat("x", 200),
+			want:     strings.Repeat("x", 40) + "…",
+			maxChars: 40,
+		},
+		{
+			name:     "collapses whitespace",
+			desc:     "Multiple    spaces\n\nand\tnewlines",
+			want:     "Multiple spaces and newlines",
+			maxChars: 150,
+		},
+		{
+			name:     "no cap when maxChars is 0",
+			desc:     strings.Repeat("x", 200),
+			want:     strings.Repeat("x", 200),
+			maxChars: 0,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := OneLineSummary(tc.desc, tc.maxChars)
+			if got != tc.want {
+				t.Errorf("got %q\nwant %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFitToBudget proves the binary-search shrinks an over-budget section
+// down to fit, leaves under-budget sections at the initial cap, and stops
+// at the SummaryFloorChars floor when a server is pathologically chatty.
+func TestFitToBudget(t *testing.T) {
+	// Each rendered "tool" line is `- **tool<maxChars chars>\n` — 9 bytes
+	// of structure plus the variable-length summary.
+	const numTools = 20
+	const linePrefix = 9 // len("- **tool") + len("\n")
+	renderSection := func(maxChars int) string {
+		stub := strings.Repeat("x", maxChars)
+		var b strings.Builder
+		for i := 0; i < numTools; i++ {
+			b.WriteString("- **tool")
+			b.WriteString(stub)
+			b.WriteString("\n")
+		}
+		return b.String()
+	}
+
+	// 1) Plenty of headroom: returns the initialCap render verbatim.
+	bigBudget := 1_000_000
+	out := FitToBudget(bigBudget, 150, renderSection)
+	if len(out) > bigBudget {
+		t.Errorf("under-budget render exceeded budget: %d", len(out))
+	}
+	if !strings.Contains(out, strings.Repeat("x", 150)) {
+		t.Errorf("under-budget should use full 150 chars")
+	}
+
+	// 2) Achievable-at-floor budget: shrinks to fit.
+	//   At floor (40): numTools * (9 + 40) = 980 bytes
+	//   At cap (150):  numTools * (9 + 150) = 3180 bytes
+	// Budget of 2000 forces a shrink but is achievable.
+	tightBudget := 2000
+	out = FitToBudget(tightBudget, 150, renderSection)
+	if len(out) > tightBudget {
+		t.Errorf("over-budget shrink failed: got %d bytes, budget %d", len(out), tightBudget)
+	}
+	// And it should have shrunk to the largest fitting cap, not collapsed all
+	// the way to the floor.
+	maxCapThatFits := (tightBudget / numTools) - linePrefix
+	if !strings.Contains(out, strings.Repeat("x", SummaryFloorChars+1)) && maxCapThatFits > SummaryFloorChars {
+		t.Errorf("shrunk further than necessary; max-fitting cap = %d", maxCapThatFits)
+	}
+
+	// 3) Unachievable budget: returns the floor render. The spec says
+	// "floor at ~40 chars" — we stop binary-searching there, not "guarantee
+	// fit at any cost." A pathologically chatty server renders larger than
+	// the budget rather than disappear entirely.
+	tinyBudget := 50
+	out = FitToBudget(tinyBudget, 150, renderSection)
+	if !strings.Contains(out, strings.Repeat("x", SummaryFloorChars)) {
+		t.Errorf("floor not respected — should render with floor cap, got %q", out[:80])
+	}
+}

--- a/pkg/adapters/mcpadapter/discovery.go
+++ b/pkg/adapters/mcpadapter/discovery.go
@@ -1,0 +1,218 @@
+package mcpadapter
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/clawvisor/clawvisor/pkg/adapters"
+)
+
+// ResourceMetadata is the RFC 9728 "OAuth 2.0 Protected Resource Metadata"
+// response that the MCP endpoint points to via WWW-Authenticate. We only
+// pull the field we need: the list of authorization servers.
+type resourceMetadata struct {
+	AuthorizationServers []string `json:"authorization_servers"`
+}
+
+// AuthServerMetadata is the RFC 8414 "OAuth 2.0 Authorization Server Metadata"
+// response. Subset of fields the adapter actually uses.
+type authServerMetadata struct {
+	AuthorizationEndpoint string   `json:"authorization_endpoint"`
+	TokenEndpoint         string   `json:"token_endpoint"`
+	RegistrationEndpoint  string   `json:"registration_endpoint"`
+	GrantTypesSupported   []string `json:"grant_types_supported"`
+	AuthMethodsSupported  []string `json:"token_endpoint_auth_methods_supported"`
+}
+
+// resourceMetadataRe extracts the resource_metadata URL from a
+// WWW-Authenticate header.  Notion's header looks like:
+//
+//	Bearer realm="OAuth", resource_metadata="https://mcp.notion.com/.well-known/oauth-protected-resource/mcp", error="invalid_token", error_description="..."
+var resourceMetadataRe = regexp.MustCompile(`resource_metadata="([^"]+)"`)
+
+// discoverAndRegister performs the full RFC 9728 → RFC 8414 → RFC 7591
+// dance against an MCP server's endpoint. Returns a populated client
+// record ready to be cached + used for OAuth.
+//
+// httpClient is used for all probes/registrations. Caller supplies it so
+// tests can swap in httptest-bound transports without DNS.
+func discoverAndRegister(
+	ctx context.Context,
+	httpClient *http.Client,
+	mcpEndpoint string,
+	clientName string,
+	redirectURI string,
+) (*adapters.MCPClientRecord, error) {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	// ── Step 1: probe the MCP endpoint for the WWW-Authenticate header. ──
+	probeBody := []byte(`{"jsonrpc":"2.0","id":0,"method":"initialize","params":{}}`)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, mcpEndpoint, bytes.NewReader(probeBody))
+	if err != nil {
+		return nil, fmt.Errorf("probe: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("probe %s: %w", mcpEndpoint, err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+
+	wwwAuth := resp.Header.Get("Www-Authenticate")
+	if wwwAuth == "" {
+		// Some servers may advertise discovery at a fixed well-known URL
+		// off the endpoint root even without a 401 probe. Try that as a
+		// fallback before giving up.
+		wwwAuth = `resource_metadata="` + wellKnownProtectedResourceFor(mcpEndpoint) + `"`
+	}
+	m := resourceMetadataRe.FindStringSubmatch(wwwAuth)
+	if len(m) < 2 {
+		return nil, fmt.Errorf("server did not advertise resource_metadata; got WWW-Authenticate=%q", wwwAuth)
+	}
+	resourceMetaURL := m[1]
+
+	// ── Step 2: fetch protected-resource metadata. ──
+	var resMeta resourceMetadata
+	if err := getJSON(ctx, httpClient, resourceMetaURL, &resMeta); err != nil {
+		return nil, fmt.Errorf("fetch protected-resource metadata: %w", err)
+	}
+	if len(resMeta.AuthorizationServers) == 0 {
+		return nil, fmt.Errorf("protected-resource metadata at %s has no authorization_servers", resourceMetaURL)
+	}
+	authServer := strings.TrimRight(resMeta.AuthorizationServers[0], "/")
+
+	// ── Step 3: fetch authorization-server metadata. ──
+	asMetaURL := authServer + "/.well-known/oauth-authorization-server"
+	var asMeta authServerMetadata
+	if err := getJSON(ctx, httpClient, asMetaURL, &asMeta); err != nil {
+		return nil, fmt.Errorf("fetch authorization-server metadata: %w", err)
+	}
+	if asMeta.AuthorizationEndpoint == "" || asMeta.TokenEndpoint == "" {
+		return nil, fmt.Errorf("authorization-server metadata at %s missing endpoints", asMetaURL)
+	}
+	if asMeta.RegistrationEndpoint == "" {
+		return nil, fmt.Errorf("authorization-server at %s does not support RFC 7591 dynamic registration; admin must pre-register a client", authServer)
+	}
+
+	// ── Step 4: dynamically register a client. ──
+	// Prefer a confidential client (with secret) so the existing OAuth code
+	// path in services.go works unchanged. Public clients (token_endpoint_
+	// auth_method=none) require PKCE on the token exchange, which the
+	// standard OAuth flow at services.go doesn't currently add — so refuse
+	// to register a client we can't use, rather than registering one that
+	// would fail at token exchange or silently bypass auth-method
+	// expectations on the server.
+	authMethod := "client_secret_post"
+	switch {
+	case supportsAuthMethod(asMeta.AuthMethodsSupported, "client_secret_post"):
+		authMethod = "client_secret_post"
+	case supportsAuthMethod(asMeta.AuthMethodsSupported, "client_secret_basic"):
+		authMethod = "client_secret_basic"
+	default:
+		return nil, fmt.Errorf("authorization server only supports public OAuth clients (token_endpoint_auth_method_supported=%v); Clawvisor doesn't yet implement PKCE for MCP — admin must pre-register a confidential client and pin it via settings", asMeta.AuthMethodsSupported)
+	}
+
+	regReq := map[string]any{
+		"client_name":                clientName,
+		"redirect_uris":              []string{redirectURI},
+		"grant_types":                []string{"authorization_code", "refresh_token"},
+		"response_types":             []string{"code"},
+		"token_endpoint_auth_method": authMethod,
+		"application_type":           "web",
+	}
+	body, _ := json.Marshal(regReq)
+	rreq, err := http.NewRequestWithContext(ctx, http.MethodPost, asMeta.RegistrationEndpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("register: %w", err)
+	}
+	rreq.Header.Set("Content-Type", "application/json")
+	rreq.Header.Set("Accept", "application/json")
+	rresp, err := httpClient.Do(rreq)
+	if err != nil {
+		return nil, fmt.Errorf("register %s: %w", asMeta.RegistrationEndpoint, err)
+	}
+	defer rresp.Body.Close()
+	if rresp.StatusCode != http.StatusCreated && rresp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(io.LimitReader(rresp.Body, 2048))
+		return nil, fmt.Errorf("register: http %d: %s", rresp.StatusCode, string(raw))
+	}
+	var regResp struct {
+		ClientID     string `json:"client_id"`
+		ClientSecret string `json:"client_secret"`
+	}
+	if err := json.NewDecoder(rresp.Body).Decode(&regResp); err != nil {
+		return nil, fmt.Errorf("register: decode: %w", err)
+	}
+	if regResp.ClientID == "" {
+		return nil, fmt.Errorf("register: server returned no client_id")
+	}
+
+	return &adapters.MCPClientRecord{
+		ClientID:              regResp.ClientID,
+		ClientSecret:          regResp.ClientSecret,
+		AuthorizationEndpoint: asMeta.AuthorizationEndpoint,
+		TokenEndpoint:         asMeta.TokenEndpoint,
+		RegistrationEndpoint:  asMeta.RegistrationEndpoint,
+	}, nil
+}
+
+// getJSON does a context-bound GET and decodes JSON into out.
+func getJSON(ctx context.Context, httpClient *http.Client, url string, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return fmt.Errorf("http %d: %s", resp.StatusCode, string(raw))
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+// wellKnownProtectedResourceFor builds the conventional discovery URL
+// derived from the MCP endpoint root, used as a fallback when the server
+// doesn't return a WWW-Authenticate header on probe.
+//
+// Parses with net/url so http:// endpoints, custom ports, IPv6 hosts, and
+// edge-cases like missing schemes don't panic or mis-slice.
+func wellKnownProtectedResourceFor(mcpEndpoint string) string {
+	u, err := url.Parse(mcpEndpoint)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		// Best-effort fallback for malformed inputs: append the well-known
+		// path to whatever we got. Discovery will fail downstream and the
+		// caller surfaces the error to the OAuth handler.
+		return strings.TrimRight(mcpEndpoint, "/") + "/.well-known/oauth-protected-resource"
+	}
+	return u.Scheme + "://" + u.Host + "/.well-known/oauth-protected-resource"
+}
+
+func supportsAuthMethod(supported []string, method string) bool {
+	for _, m := range supported {
+		if m == method {
+			return true
+		}
+	}
+	return false
+}
+
+// discoveryTimeout caps the discovery+registration round trip. Cold-start
+// against Notion's MCP runs ~600ms; 10s is generous headroom.
+const discoveryTimeout = 10 * time.Second

--- a/pkg/adapters/mcpadapter/discovery.go
+++ b/pkg/adapters/mcpadapter/discovery.go
@@ -114,14 +114,21 @@ func discoverAndRegister(
 	// to register a client we can't use, rather than registering one that
 	// would fail at token exchange or silently bypass auth-method
 	// expectations on the server.
+	// RFC 8414 §2: when token_endpoint_auth_methods_supported is absent the
+	// default is ["client_secret_basic"]. Treat nil/empty as that default so
+	// minimally-compliant servers don't fail discovery.
+	supported := asMeta.AuthMethodsSupported
+	if len(supported) == 0 {
+		supported = []string{"client_secret_basic"}
+	}
 	authMethod := "client_secret_post"
 	switch {
-	case supportsAuthMethod(asMeta.AuthMethodsSupported, "client_secret_post"):
+	case supportsAuthMethod(supported, "client_secret_post"):
 		authMethod = "client_secret_post"
-	case supportsAuthMethod(asMeta.AuthMethodsSupported, "client_secret_basic"):
+	case supportsAuthMethod(supported, "client_secret_basic"):
 		authMethod = "client_secret_basic"
 	default:
-		return nil, fmt.Errorf("authorization server only supports public OAuth clients (token_endpoint_auth_method_supported=%v); Clawvisor doesn't yet implement PKCE for MCP — admin must pre-register a confidential client and pin it via settings", asMeta.AuthMethodsSupported)
+		return nil, fmt.Errorf("authorization server only supports public OAuth clients (token_endpoint_auth_methods_supported=%v); Clawvisor doesn't yet implement PKCE for MCP — admin must pre-register a confidential client and pin it via settings", supported)
 	}
 
 	regReq := map[string]any{

--- a/pkg/adapters/mcpadapter/discovery_test.go
+++ b/pkg/adapters/mcpadapter/discovery_test.go
@@ -1,0 +1,345 @@
+package mcpadapter_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/pkg/adapters"
+	"github.com/clawvisor/clawvisor/pkg/adapters/mcpadapter"
+	"github.com/clawvisor/clawvisor/pkg/vault"
+)
+
+// memVault is a barebones in-memory Vault for tests in this package — only
+// the three methods MCPAdapter actually touches are implemented.
+type memVault struct {
+	creds map[string]map[string][]byte
+}
+
+func newMemVault() *memVault { return &memVault{creds: map[string]map[string][]byte{}} }
+
+func (m *memVault) Set(_ context.Context, userID, key string, c []byte) error {
+	if m.creds[userID] == nil {
+		m.creds[userID] = map[string][]byte{}
+	}
+	m.creds[userID][key] = c
+	return nil
+}
+func (m *memVault) Get(_ context.Context, userID, key string) ([]byte, error) {
+	if u, ok := m.creds[userID]; ok {
+		if c, ok := u[key]; ok {
+			return c, nil
+		}
+	}
+	return nil, vault.ErrNotFound
+}
+func (m *memVault) Delete(_ context.Context, userID, key string) error {
+	if u, ok := m.creds[userID]; ok {
+		delete(u, key)
+	}
+	return nil
+}
+func (m *memVault) List(_ context.Context, userID string) ([]string, error) {
+	out := []string{}
+	for k := range m.creds[userID] {
+		out = append(out, k)
+	}
+	return out, nil
+}
+
+// discoveryFixture spins up an httptest.Server that emulates Notion's MCP
+// discovery + registration surface, with counters so tests can assert
+// re-registration didn't fire.
+type discoveryFixture struct {
+	srv             *httptest.Server
+	registrations   atomic.Int64
+	mcpProbes       atomic.Int64
+	resourceProbes  atomic.Int64
+	asProbes        atomic.Int64
+	rejectRegistration bool // for the failure-mode test
+	authMethodsOnly    []string // override token_endpoint_auth_methods_supported (nil = default)
+}
+
+func newDiscoveryFixture(t *testing.T) *discoveryFixture {
+	t.Helper()
+	f := &discoveryFixture{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/mcp", func(w http.ResponseWriter, r *http.Request) {
+		f.mcpProbes.Add(1)
+		// Build the resource_metadata URL from the test server's base URL
+		// so probes don't escape to the live internet.
+		base := "http://" + r.Host
+		w.Header().Set("Www-Authenticate", `Bearer realm="OAuth", resource_metadata="`+base+`/.well-known/oauth-protected-resource/mcp", error="invalid_token"`)
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"invalid_token"}`))
+	})
+	mux.HandleFunc("/.well-known/oauth-protected-resource/mcp", func(w http.ResponseWriter, r *http.Request) {
+		f.resourceProbes.Add(1)
+		base := "http://" + r.Host
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"resource":              base,
+			"authorization_servers": []string{base},
+			"bearer_methods_supported": []string{"header"},
+		})
+	})
+	mux.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, r *http.Request) {
+		f.asProbes.Add(1)
+		base := "http://" + r.Host
+		w.Header().Set("Content-Type", "application/json")
+		authMethods := f.authMethodsOnly
+		if authMethods == nil {
+			authMethods = []string{"client_secret_post", "client_secret_basic", "none"}
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                                base,
+			"authorization_endpoint":                base + "/authorize",
+			"token_endpoint":                        base + "/token",
+			"registration_endpoint":                 base + "/register",
+			"grant_types_supported":                 []string{"authorization_code", "refresh_token"},
+			"response_types_supported":              []string{"code"},
+			"token_endpoint_auth_methods_supported": authMethods,
+			"code_challenge_methods_supported":      []string{"S256"},
+		})
+	})
+	mux.HandleFunc("/register", func(w http.ResponseWriter, r *http.Request) {
+		f.registrations.Add(1)
+		if f.rejectRegistration {
+			http.Error(w, `{"error":"invalid_client_metadata"}`, http.StatusBadRequest)
+			return
+		}
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		// Validate the request body shape — caller MUST send redirect_uris
+		// matching Clawvisor's OAuth callback so the registered client_id
+		// is bound to the right URL.
+		uris, _ := body["redirect_uris"].([]any)
+		if len(uris) == 0 || uris[0] != "http://localhost:25297/api/oauth/callback" {
+			http.Error(w, `{"error":"invalid_redirect_uri"}`, http.StatusBadRequest)
+			return
+		}
+		method, _ := body["token_endpoint_auth_method"].(string)
+		var secret string
+		if method != "none" {
+			secret = "registered-secret-xyz"
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"client_id":     "registered-client-abc",
+			"client_secret": secret,
+			"redirect_uris": uris,
+		})
+	})
+	f.srv = httptest.NewServer(mux)
+	t.Cleanup(f.srv.Close)
+	return f
+}
+
+func (f *discoveryFixture) httpClient() *http.Client {
+	// Force every outbound URL through the test server's transport so
+	// probes don't accidentally escape to the real internet.
+	parsed, _ := url.Parse(f.srv.URL)
+	return &http.Client{
+		Transport: &redirectTransport{base: parsed},
+		Timeout:   f.srv.Client().Timeout,
+	}
+}
+
+// redirectTransport rewrites the URL host:port of every request to point at
+// the httptest.Server. Lets us probe what looks like a Notion URL but
+// actually hits the test server.
+type redirectTransport struct{ base *url.URL }
+
+func (t *redirectTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Scheme = t.base.Scheme
+	req.URL.Host = t.base.Host
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+// TestEnsureOAuthReady_DiscoversAndRegisters is the load-bearing test: a
+// freshly-loaded MCP adapter with no cached credentials performs the full
+// RFC 9728 → RFC 8414 → RFC 7591 dance and caches the result.
+func TestEnsureOAuthReady_DiscoversAndRegisters(t *testing.T) {
+	fx := newDiscoveryFixture(t)
+	v := newMemVault()
+
+	var spec mcpadapter.Spec
+	spec.Service.ID = "test-mcp"
+	spec.MCP.Transport = "http"
+	spec.MCP.Endpoint = "https://mcp.example.com/mcp" // intercepted by redirectTransport
+	spec.MCP.OAuth = &mcpadapter.MCPOAuthSpec{}       // marker only; no hardcoded endpoints
+
+	adapter := mcpadapter.FromSpec(spec, &mcpadapter.HTTPTransport{Endpoint: spec.MCP.Endpoint})
+	adapter.SetOAuthVault(v)
+	adapter.SetDiscoveryHTTPClient(fx.httpClient())
+
+	ctx := context.Background()
+	if err := adapter.EnsureOAuthReady(ctx, "http://localhost:25297/api/oauth/callback"); err != nil {
+		t.Fatalf("EnsureOAuthReady: %v", err)
+	}
+
+	// Assert all four phases ran exactly once.
+	if got := fx.mcpProbes.Load(); got != 1 {
+		t.Errorf("mcp probe count = %d, want 1", got)
+	}
+	if got := fx.resourceProbes.Load(); got != 1 {
+		t.Errorf("resource metadata fetch count = %d, want 1", got)
+	}
+	if got := fx.asProbes.Load(); got != 1 {
+		t.Errorf("authorization-server metadata fetch count = %d, want 1", got)
+	}
+	if got := fx.registrations.Load(); got != 1 {
+		t.Errorf("registration count = %d, want 1", got)
+	}
+
+	// Client record persisted with discovered endpoints + registered client.
+	rec := adapters.GetMCPClientRecord(ctx, v, "test-mcp")
+	if rec == nil {
+		t.Fatal("client record was not cached")
+	}
+	if rec.ClientID != "registered-client-abc" {
+		t.Errorf("client_id = %q, want %q", rec.ClientID, "registered-client-abc")
+	}
+	if rec.ClientSecret != "registered-secret-xyz" {
+		t.Errorf("client_secret missing — confidential client should have one")
+	}
+	if !strings.HasSuffix(rec.AuthorizationEndpoint, "/authorize") {
+		t.Errorf("authorization_endpoint not captured: %q", rec.AuthorizationEndpoint)
+	}
+	if !strings.HasSuffix(rec.TokenEndpoint, "/token") {
+		t.Errorf("token_endpoint not captured: %q", rec.TokenEndpoint)
+	}
+
+	// OAuthConfig now returns a populated config using discovered endpoints.
+	cfg := adapter.OAuthConfig()
+	if cfg == nil {
+		t.Fatal("OAuthConfig should be non-nil after discovery")
+	}
+	if cfg.ClientID != "registered-client-abc" {
+		t.Errorf("oauth config has wrong client_id: %q", cfg.ClientID)
+	}
+	if !strings.HasSuffix(cfg.Endpoint.AuthURL, "/authorize") {
+		t.Errorf("oauth config has stale auth URL: %q", cfg.Endpoint.AuthURL)
+	}
+
+	// ── Idempotency: a second EnsureOAuthReady is a no-op. ──
+	if err := adapter.EnsureOAuthReady(ctx, "http://localhost:25297/api/oauth/callback"); err != nil {
+		t.Fatalf("second EnsureOAuthReady: %v", err)
+	}
+	if got := fx.registrations.Load(); got != 1 {
+		t.Errorf("re-registration fired (count=%d) — cache miss", got)
+	}
+}
+
+// TestEnsureOAuthReady_AdminPinSkipsDiscovery confirms that an admin-pinned
+// override at mcp.oauth.{serviceID} bypasses dynamic registration entirely.
+// Mirrors the path self-hosters take when they want a specific client.
+func TestEnsureOAuthReady_AdminPinSkipsDiscovery(t *testing.T) {
+	fx := newDiscoveryFixture(t)
+	v := newMemVault()
+	ctx := context.Background()
+
+	// Admin pre-pinned a client.
+	if err := adapters.SetMCPOAuthCredentials(ctx, v, "test-mcp", "pinned-cid", "pinned-csec"); err != nil {
+		t.Fatalf("SetMCPOAuthCredentials: %v", err)
+	}
+
+	var spec mcpadapter.Spec
+	spec.Service.ID = "test-mcp"
+	spec.MCP.Transport = "http"
+	spec.MCP.Endpoint = "https://mcp.example.com/mcp"
+	spec.MCP.OAuth = &mcpadapter.MCPOAuthSpec{
+		AuthorizeURL: "https://example.com/admin/authorize",
+		TokenURL:     "https://example.com/admin/token",
+	}
+
+	adapter := mcpadapter.FromSpec(spec, &mcpadapter.HTTPTransport{Endpoint: spec.MCP.Endpoint})
+	adapter.SetOAuthVault(v)
+	adapter.SetDiscoveryHTTPClient(fx.httpClient())
+
+	if err := adapter.EnsureOAuthReady(ctx, "http://localhost:25297/api/oauth/callback"); err != nil {
+		t.Fatalf("EnsureOAuthReady: %v", err)
+	}
+	if got := fx.registrations.Load(); got != 0 {
+		t.Errorf("admin pin should skip registration, but %d fired", got)
+	}
+	cfg := adapter.OAuthConfig()
+	if cfg == nil || cfg.ClientID != "pinned-cid" {
+		t.Fatalf("expected admin-pinned client, got %+v", cfg)
+	}
+}
+
+// TestEnsureOAuthReady_RegistrationFailure surfaces the registration error
+// up to the caller (the OAuth handler in services.go), so the UI gets a
+// meaningful failure mode instead of a silent fallback.
+func TestEnsureOAuthReady_RegistrationFailure(t *testing.T) {
+	fx := newDiscoveryFixture(t)
+	fx.rejectRegistration = true
+	v := newMemVault()
+
+	var spec mcpadapter.Spec
+	spec.Service.ID = "test-mcp"
+	spec.MCP.Transport = "http"
+	spec.MCP.Endpoint = "https://mcp.example.com/mcp"
+	spec.MCP.OAuth = &mcpadapter.MCPOAuthSpec{}
+
+	adapter := mcpadapter.FromSpec(spec, &mcpadapter.HTTPTransport{Endpoint: spec.MCP.Endpoint})
+	adapter.SetOAuthVault(v)
+	adapter.SetDiscoveryHTTPClient(fx.httpClient())
+
+	err := adapter.EnsureOAuthReady(context.Background(), "http://localhost:25297/api/oauth/callback")
+	if err == nil {
+		t.Fatal("expected error when registration is rejected")
+	}
+	if !strings.Contains(err.Error(), "register") {
+		t.Errorf("expected error to mention 'register', got: %v", err)
+	}
+	// Nothing should be cached on failure — next attempt should re-try.
+	if rec := adapters.GetMCPClientRecord(context.Background(), v, "test-mcp"); rec != nil {
+		t.Errorf("client record should not be cached on failure, got %+v", rec)
+	}
+}
+
+// TestEnsureOAuthReady_RefusesPublicClientOnly is the regression test for
+// the public-client gap: the standard OAuth flow doesn't add PKCE
+// parameters, so registering as a public client (token_endpoint_auth_method
+// = "none") would produce a client we can't actually use. Refuse to
+// register rather than getting a confusing 401 at token exchange.
+func TestEnsureOAuthReady_RefusesPublicClientOnly(t *testing.T) {
+	fx := newDiscoveryFixture(t)
+	fx.authMethodsOnly = []string{"none"} // only public clients supported
+	v := newMemVault()
+
+	var spec mcpadapter.Spec
+	spec.Service.ID = "public-only-mcp"
+	spec.MCP.Transport = "http"
+	spec.MCP.Endpoint = "https://mcp.example.com/mcp"
+	spec.MCP.OAuth = &mcpadapter.MCPOAuthSpec{}
+
+	adapter := mcpadapter.FromSpec(spec, &mcpadapter.HTTPTransport{Endpoint: spec.MCP.Endpoint})
+	adapter.SetOAuthVault(v)
+	adapter.SetDiscoveryHTTPClient(fx.httpClient())
+
+	err := adapter.EnsureOAuthReady(context.Background(), "http://localhost:25297/api/oauth/callback")
+	if err == nil {
+		t.Fatal("expected error when AS supports only public clients")
+	}
+	if !strings.Contains(err.Error(), "public OAuth clients") {
+		t.Errorf("expected error to mention public OAuth clients, got: %v", err)
+	}
+	// Importantly we must NOT have POSTed to /register — refusing to register
+	// at all is the point of the fix.
+	if got := fx.registrations.Load(); got != 0 {
+		t.Errorf("expected 0 registration attempts, got %d", got)
+	}
+	// And nothing got cached.
+	if rec := adapters.GetMCPClientRecord(context.Background(), v, "public-only-mcp"); rec != nil {
+		t.Errorf("client record should not be cached on refusal, got %+v", rec)
+	}
+}

--- a/pkg/adapters/mcpadapter/http_test.go
+++ b/pkg/adapters/mcpadapter/http_test.go
@@ -1,0 +1,190 @@
+package mcpadapter_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/pkg/adapters"
+	"github.com/clawvisor/clawvisor/pkg/adapters/mcpadapter"
+	"github.com/clawvisor/clawvisor/pkg/adapters/mcpclient"
+)
+
+// mcpHTTPMock is a tiny in-process MCP server that speaks streamable HTTP.
+// Routes initialize / tools/list / tools/call. Asserts the auth header is
+// present for non-initialize methods so the test catches credential
+// propagation regressions.
+type mcpHTTPMock struct {
+	sessionID  string
+	expectAuth string
+	mu         sync.Mutex
+	initialized bool
+}
+
+func (m *mcpHTTPMock) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		JSONRPC string          `json:"jsonrpc"`
+		ID      int             `json:"id,omitempty"`
+		Method  string          `json:"method"`
+		Params  json.RawMessage `json:"params,omitempty"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "bad json", http.StatusBadRequest)
+		return
+	}
+	// Auth check for anything that's not initialize/initialized.
+	if req.Method != "initialize" && req.Method != "notifications/initialized" {
+		if got := r.Header.Get("Authorization"); got != m.expectAuth {
+			http.Error(w, "auth: got "+got+" want "+m.expectAuth, http.StatusUnauthorized)
+			return
+		}
+		if got := r.Header.Get("Mcp-Session-Id"); got != m.sessionID {
+			http.Error(w, "session: got "+got+" want "+m.sessionID, http.StatusBadRequest)
+			return
+		}
+	}
+
+	writeResp := func(result any) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"jsonrpc": "2.0",
+			"id":      req.ID,
+			"result":  result,
+		})
+	}
+
+	switch req.Method {
+	case "initialize":
+		m.mu.Lock()
+		m.initialized = true
+		m.mu.Unlock()
+		w.Header().Set("Mcp-Session-Id", m.sessionID)
+		writeResp(map[string]any{
+			"protocolVersion": "2025-06-18",
+			"capabilities":    map[string]any{"tools": map[string]any{}},
+			"serverInfo":      map[string]any{"name": "mock-http-mcp"},
+		})
+	case "notifications/initialized":
+		w.WriteHeader(http.StatusAccepted)
+	case "tools/list":
+		writeResp(map[string]any{
+			"tools": []mcpclient.Tool{
+				{Name: "search", Description: "Search.", Annotations: map[string]any{"readOnlyHint": true}},
+				{Name: "whoami", Description: "Identity.", Annotations: map[string]any{"readOnlyHint": true}},
+			},
+		})
+	case "tools/call":
+		var p struct {
+			Name      string         `json:"name"`
+			Arguments map[string]any `json:"arguments"`
+		}
+		_ = json.Unmarshal(req.Params, &p)
+		var data any
+		switch p.Name {
+		case "search":
+			q, _ := p.Arguments["query"].(string)
+			data = map[string]any{"results": []map[string]any{{"id": "remote-1", "title": "match for " + q}}}
+		case "whoami":
+			data = map[string]any{"workspace_name": "RemoteWorkspace"}
+		default:
+			http.Error(w, "unknown tool", http.StatusBadRequest)
+			return
+		}
+		payload, _ := json.Marshal(data)
+		writeResp(mcpclient.ToolResult{
+			Content: []mcpclient.ToolContent{{Type: "text", Text: string(payload)}},
+		})
+	default:
+		http.Error(w, "method not found", http.StatusNotFound)
+	}
+}
+
+// TestHTTPTransport_EndToEnd exercises an MCP server reached over HTTP —
+// no subprocess, no node, no npm. This is the production-shape transport
+// for vendor-hosted MCP servers.
+func TestHTTPTransport_EndToEnd(t *testing.T) {
+	mock := &mcpHTTPMock{sessionID: "sess-abc", expectAuth: "Bearer secret_test"}
+	srv := httptest.NewServer(mock)
+	t.Cleanup(srv.Close)
+
+	spec := mcpadapter.Spec{}
+	spec.Service.ID = "remote-mcp"
+	spec.Service.DisplayName = "Remote (HTTP)"
+	spec.MCP.Transport = "http"
+	spec.MCP.Endpoint = srv.URL
+	spec.MCP.Whoami = &mcpadapter.WhoamiSpec{Tool: "whoami", Field: "workspace_name"}
+
+	transport := &mcpadapter.HTTPTransport{
+		Endpoint: srv.URL,
+	}
+	adapter := mcpadapter.FromSpec(spec, transport)
+
+	credJSON := []byte(`{"token":"secret_test"}`)
+
+	// Discovery against the remote server.
+	tools, err := adapter.DiscoverTools(context.Background(), credJSON)
+	if err != nil {
+		t.Fatalf("DiscoverTools: %v", err)
+	}
+	if len(tools) != 2 {
+		t.Fatalf("expected 2 tools from remote server, got %d", len(tools))
+	}
+
+	// Identity via whoami over HTTP.
+	identity, err := adapter.FetchIdentity(context.Background(), credJSON, nil)
+	if err != nil {
+		t.Fatalf("FetchIdentity: %v", err)
+	}
+	// Whoami results flow through normalizeAlias, which lowercases everything
+	// and strips chars outside the alias set. RemoteWorkspace → remoteworkspace.
+	if identity != "remoteworkspace" {
+		t.Fatalf("expected normalized identity from whoami, got %q", identity)
+	}
+
+	// Tool execution.
+	perUser := adapter.ForUser(tools)
+	result, err := perUser.Execute(context.Background(), adapters.Request{
+		Action:     "search",
+		Params:     map[string]any{"query": "remote"},
+		Credential: credJSON,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	data, _ := result.Data.(map[string]any)
+	results, _ := data["results"].([]any)
+	if len(results) == 0 {
+		t.Fatalf("expected results from remote search, got %#v", data)
+	}
+	first, _ := results[0].(map[string]any)
+	if title, _ := first["title"].(string); !strings.Contains(title, "remote") {
+		t.Fatalf("expected query to flow through HTTP, got title=%q", title)
+	}
+}
+
+// TestHTTPTransport_AuthHeaderMissing proves credential propagation reaches
+// the HTTP header: a request without a valid Bearer token gets rejected by
+// the mock server.
+func TestHTTPTransport_AuthHeaderMissing(t *testing.T) {
+	mock := &mcpHTTPMock{sessionID: "sess-xyz", expectAuth: "Bearer secret_correct"}
+	srv := httptest.NewServer(mock)
+	t.Cleanup(srv.Close)
+
+	spec := mcpadapter.Spec{}
+	spec.Service.ID = "remote-mcp"
+	spec.MCP.Transport = "http"
+	spec.MCP.Endpoint = srv.URL
+	adapter := mcpadapter.FromSpec(spec, &mcpadapter.HTTPTransport{Endpoint: srv.URL})
+
+	_, err := adapter.DiscoverTools(context.Background(), []byte(`{"token":"wrong"}`))
+	if err == nil {
+		t.Fatal("expected auth error from remote server when token is wrong")
+	}
+	if !strings.Contains(err.Error(), "401") && !strings.Contains(err.Error(), "auth") {
+		t.Fatalf("expected auth/401 error, got: %v", err)
+	}
+}

--- a/pkg/adapters/mcpadapter/oauth.go
+++ b/pkg/adapters/mcpadapter/oauth.go
@@ -1,0 +1,205 @@
+package mcpadapter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"golang.org/x/oauth2"
+
+	"github.com/clawvisor/clawvisor/pkg/adapters"
+	"github.com/clawvisor/clawvisor/pkg/vault"
+)
+
+// SetOAuthVault wires the vault that holds per-service OAuth client
+// credentials (under "__system__"/"mcp.oauth.{serviceID}"). Called from
+// defaults.go after LoadFromFS so MCPAdapters can lazily fetch their
+// client_id / client_secret without holding a reference at construction time.
+//
+// This mirrors how YAMLAdapter.SetOAuthProvider is wired for Google services.
+func (a *MCPAdapter) SetOAuthVault(v vault.Vault) {
+	a.oauthVault = v
+}
+
+// oauthSpec returns the spec's OAuth declaration if any. Nil means the
+// service uses no OAuth (API key, bearer, or none).
+func (a *MCPAdapter) oauthSpec() *MCPOAuthSpec {
+	if a.cfg.Spec == nil {
+		return nil
+	}
+	return a.cfg.Spec.MCP.OAuth
+}
+
+// OAuthClientCredentials satisfies the adapters.OAuthCredentialProvider
+// interface (which has no ctx parameter). It delegates to the context-aware
+// variant with Background for the rare interface-only call sites.
+// Internal callers that have a context should use oauthClientCredentialsCtx.
+func (a *MCPAdapter) OAuthClientCredentials() (string, string) {
+	return a.oauthClientCredentialsCtx(context.Background())
+}
+
+// oauthClientCredentialsCtx reads (client_id, client_secret) from the system
+// vault using the caller's context for cancellation/deadlines, preferring an
+// admin-pinned override at mcp.oauth.{serviceID} and falling back to the
+// dynamically-registered record at mcp.client.{serviceID}.
+func (a *MCPAdapter) oauthClientCredentialsCtx(ctx context.Context) (string, string) {
+	if a.oauthVault == nil {
+		return "", ""
+	}
+	if cid, csec := adapters.GetMCPOAuthCredentials(ctx, a.oauthVault, a.cfg.ServiceID); cid != "" {
+		return cid, csec
+	}
+	if rec := adapters.GetMCPClientRecord(ctx, a.oauthVault, a.cfg.ServiceID); rec != nil {
+		return rec.ClientID, rec.ClientSecret
+	}
+	return "", ""
+}
+
+// EnsureOAuthReady performs discovery + dynamic client registration if no
+// client record is cached yet. Idempotent — repeated calls are cheap after
+// the first success. Called by the OAuth handlers in services.go just
+// before they consult OAuthConfig(); admins who pre-pinned credentials at
+// mcp.oauth.{serviceID} bypass this entirely.
+//
+// redirectURI is the OAuth callback URL Clawvisor will use; passed to the
+// MCP authorization server's RFC 7591 registration so the issued client_id
+// is bound to it.
+func (a *MCPAdapter) EnsureOAuthReady(ctx context.Context, redirectURI string) error {
+	if a.oauthSpec() == nil {
+		return nil // not an OAuth adapter
+	}
+	if a.oauthVault == nil {
+		return fmt.Errorf("%s: no vault wired", a.cfg.ServiceID)
+	}
+
+	// Serialize concurrent first-time activations so two clients don't each
+	// run RFC 7591 registration and orphan one client at the auth server.
+	// The loser waits, then sees the cached record on recheck and returns
+	// without re-registering.
+	a.registerMu.Lock()
+	defer a.registerMu.Unlock()
+
+	// Admin pinned a client; nothing to discover.
+	if cid, _ := adapters.GetMCPOAuthCredentials(ctx, a.oauthVault, a.cfg.ServiceID); cid != "" {
+		return nil
+	}
+	// Already discovered + registered (either by us moments ago or by a
+	// previous process); reuse.
+	if rec := adapters.GetMCPClientRecord(ctx, a.oauthVault, a.cfg.ServiceID); rec != nil {
+		return nil
+	}
+	// Spec must declare the MCP endpoint to know where to probe.
+	if a.cfg.Spec == nil || a.cfg.Spec.MCP.Endpoint == "" {
+		return fmt.Errorf("%s: spec is missing mcp.endpoint", a.cfg.ServiceID)
+	}
+
+	dctx, cancel := context.WithTimeout(ctx, discoveryTimeout)
+	defer cancel()
+	httpClient := a.discoveryHTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	rec, err := discoverAndRegister(
+		dctx,
+		httpClient,
+		a.cfg.Spec.MCP.Endpoint,
+		"Clawvisor",
+		redirectURI,
+	)
+	if err != nil {
+		return fmt.Errorf("%s: discover+register: %w", a.cfg.ServiceID, err)
+	}
+	if err := adapters.SetMCPClientRecord(ctx, a.oauthVault, a.cfg.ServiceID, rec); err != nil {
+		return fmt.Errorf("%s: cache client record: %w", a.cfg.ServiceID, err)
+	}
+	return nil
+}
+
+// SetDiscoveryHTTPClient swaps the *http.Client used for discovery probes
+// and registration POSTs. Tests use this to point at httptest.Server.
+func (a *MCPAdapter) SetDiscoveryHTTPClient(c *http.Client) {
+	a.discoveryHTTPClient = c
+}
+
+// oauthConfig is the context-less variant for callers that satisfy the
+// adapters.Adapter interface (OAuthConfig() *oauth2.Config). Internal
+// callers with a context should use oauthConfigCtx.
+func (a *MCPAdapter) oauthConfig() *oauth2.Config {
+	return a.oauthConfigCtx(context.Background())
+}
+
+// oauthConfigCtx builds the *oauth2.Config that the activation handler in
+// services.go uses to drive the authorize → callback → token-exchange flow.
+// Returns nil when this isn't an OAuth adapter or when client credentials
+// haven't been configured yet (matches the YAMLAdapter convention).
+func (a *MCPAdapter) oauthConfigCtx(ctx context.Context) *oauth2.Config {
+	spec := a.oauthSpec()
+	if spec == nil {
+		return nil
+	}
+	clientID, clientSecret := a.oauthClientCredentialsCtx(ctx)
+	if clientID == "" {
+		return nil
+	}
+	// Prefer endpoints discovered via RFC 8414 (cached in the vault under
+	// mcp.client.{serviceID}) over anything hardcoded in the spec. Spec
+	// values are an explicit override path for MCP servers that don't
+	// support discovery — almost no production MCP server should need them.
+	authURL := spec.AuthorizeURL
+	tokenURL := spec.TokenURL
+	if a.oauthVault != nil {
+		if rec := adapters.GetMCPClientRecord(ctx, a.oauthVault, a.cfg.ServiceID); rec != nil {
+			if rec.AuthorizationEndpoint != "" {
+				authURL = rec.AuthorizationEndpoint
+			}
+			if rec.TokenEndpoint != "" {
+				tokenURL = rec.TokenEndpoint
+			}
+		}
+	}
+	return &oauth2.Config{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		Scopes:       spec.Scopes,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  authURL,
+			TokenURL: tokenURL,
+		},
+	}
+}
+
+// httpClientFor returns the *http.Client that the HTTP transport should use
+// for one request. For OAuth-MCP it's an oauth2-wrapped client driven by a
+// TokenSource — refresh happens transparently on expiry. For static-bearer
+// MCP this returns nil and the transport falls back to its default client.
+func (a *MCPAdapter) httpClientFor(ctx context.Context, cred []byte) (*http.Client, error) {
+	oauthCfg := a.oauthConfigCtx(ctx)
+	if oauthCfg == nil {
+		return nil, nil
+	}
+	var stored struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		Expiry       string `json:"expiry"`
+	}
+	if err := json.Unmarshal(cred, &stored); err != nil {
+		return nil, fmt.Errorf("parse oauth credential: %w", err)
+	}
+	if stored.AccessToken == "" && stored.RefreshToken == "" {
+		return nil, fmt.Errorf("oauth credential has no tokens")
+	}
+	token := &oauth2.Token{
+		AccessToken:  stored.AccessToken,
+		RefreshToken: stored.RefreshToken,
+		TokenType:    "Bearer",
+	}
+	if stored.Expiry != "" {
+		if t, err := time.Parse(time.RFC3339, stored.Expiry); err == nil {
+			token.Expiry = t
+		}
+	}
+	ts := oauthCfg.TokenSource(ctx, token)
+	return oauth2.NewClient(ctx, ts), nil
+}

--- a/pkg/adapters/mcpadapter/oauth.go
+++ b/pkg/adapters/mcpadapter/oauth.go
@@ -196,7 +196,14 @@ func (a *MCPAdapter) httpClientFor(ctx context.Context, cred []byte) (*http.Clie
 		TokenType:    "Bearer",
 	}
 	if stored.Expiry != "" {
-		if t, err := time.Parse(time.RFC3339, stored.Expiry); err == nil {
+		t, err := time.Parse(time.RFC3339, stored.Expiry)
+		if err != nil {
+			// A malformed expiry left zero-valued would tell oauth2 the token
+			// never expires, suppressing refresh and producing 401s once the
+			// access token actually expires. Force a refresh instead by
+			// marking it expired in the past.
+			token.Expiry = time.Unix(0, 0)
+		} else {
 			token.Expiry = t
 		}
 	}

--- a/pkg/adapters/mcpadapter/risk_classification_test.go
+++ b/pkg/adapters/mcpadapter/risk_classification_test.go
@@ -1,0 +1,82 @@
+package mcpadapter
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/pkg/adapters/mcpclient"
+)
+
+// TestRiskClassification_SpecDefaults locks in the MCP spec's annotation
+// defaults: readOnlyHint defaults to false, destructiveHint defaults to true,
+// so an unannotated tool MUST be classified as write/high. Anything weaker
+// would silently let unannotated tools bypass approval/scope gates.
+func TestRiskClassification_SpecDefaults(t *testing.T) {
+	cases := []struct {
+		name        string
+		annotations map[string]any
+		wantCat     string
+		wantSens    string
+	}{
+		{
+			// The spec default: no hints. Treat as writable + destructive
+			// since that's the conservative reading of an absent annotation.
+			name:        "no annotations defaults to write/high",
+			annotations: nil,
+			wantCat:     "write",
+			wantSens:    "high",
+		},
+		{
+			name:        "readOnlyHint:true downgrades to read/low",
+			annotations: map[string]any{"readOnlyHint": true},
+			wantCat:     "read",
+			wantSens:    "low",
+		},
+		{
+			name:        "destructiveHint:false downgrades to write/medium",
+			annotations: map[string]any{"destructiveHint": false},
+			wantCat:     "write",
+			wantSens:    "medium",
+		},
+		{
+			name:        "explicit destructiveHint:true keeps write/high",
+			annotations: map[string]any{"destructiveHint": true},
+			wantCat:     "write",
+			wantSens:    "high",
+		},
+		{
+			// A misconfigured server that asserts both; the safer claim
+			// (readOnly) wins because it's a positive safety statement,
+			// while destructive is the unknown default.
+			name:        "readOnly:true beats destructive:true",
+			annotations: map[string]any{"readOnlyHint": true, "destructiveHint": true},
+			wantCat:     "read",
+			wantSens:    "low",
+		},
+		{
+			name:        "readOnlyHint:false (explicit) keeps write/high",
+			annotations: map[string]any{"readOnlyHint": false},
+			wantCat:     "write",
+			wantSens:    "high",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			adapter := New(Config{ServiceID: "test"})
+			adapter.tools = []mcpclient.Tool{
+				{
+					Name:        "tool",
+					Description: "x.",
+					InputSchema: json.RawMessage(`{}`),
+					Annotations: tc.annotations,
+				},
+			}
+			meta := adapter.ServiceMetadata().ActionMeta["tool"]
+			if meta.Category != tc.wantCat || meta.Sensitivity != tc.wantSens {
+				t.Errorf("annotations=%v: got %s/%s, want %s/%s",
+					tc.annotations, meta.Category, meta.Sensitivity,
+					tc.wantCat, tc.wantSens)
+			}
+		})
+	}
+}

--- a/pkg/adapters/mcpadapter/spec.go
+++ b/pkg/adapters/mcpadapter/spec.go
@@ -1,0 +1,343 @@
+package mcpadapter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Spec is the minimal configuration needed to expose an MCP server as a
+// Clawvisor adapter. Everything else — actions, params, risk classification,
+// response sanitization — is derived from the MCP protocol or applied
+// generically by gateway middleware.
+type Spec struct {
+	Service struct {
+		ID          string `yaml:"id"`
+		DisplayName string `yaml:"display_name"`
+		Description string `yaml:"description"`
+		SetupURL    string `yaml:"setup_url"`
+		KeyHint     string `yaml:"key_hint"`
+		IconURL     string `yaml:"icon_url"`
+		IconSVG     string `yaml:"icon_svg"`
+	} `yaml:"service"`
+
+	MCP struct {
+		// Transport selects how Clawvisor reaches the MCP server.
+		// "stdio" (default) spawns a subprocess locally; "http" speaks
+		// MCP streamable HTTP against a remote vendor-hosted endpoint.
+		Transport string `yaml:"transport,omitempty"`
+
+		// ── stdio transport ────────────────────────────────────────────
+		// Command is the argv to launch the MCP server over stdio.
+		// e.g. ["npx", "-y", "@notionhq/notion-mcp-server"].
+		Command []string `yaml:"command,omitempty"`
+		// CredentialEnv is the env var the MCP server reads for auth.
+		// The Clawvisor vault credential's `token` field is passed in here.
+		// e.g. "NOTION_TOKEN", "GITHUB_TOKEN".
+		CredentialEnv string `yaml:"credential_env,omitempty"`
+		// ExtraEnv is additional static env passed through (rarely used).
+		ExtraEnv map[string]string `yaml:"extra_env,omitempty"`
+
+		// ── http transport ─────────────────────────────────────────────
+		// Endpoint is the MCP streamable-HTTP URL, e.g. "https://mcp.notion.com".
+		Endpoint string `yaml:"endpoint,omitempty"`
+		// HeaderName is the HTTP header used for auth. Defaults to "Authorization".
+		HeaderName string `yaml:"header_name,omitempty"`
+		// HeaderPrefix is prepended to the credential token. Defaults to "Bearer ".
+		HeaderPrefix string `yaml:"header_prefix,omitempty"`
+
+		// OAuth, when present, switches activation to a browser-based OAuth
+		// authorization code flow. Tokens are stored as the standard
+		// {"access_token","refresh_token","expiry"} envelope and refreshed
+		// transparently by golang.org/x/oauth2 at request time.
+		OAuth *MCPOAuthSpec `yaml:"oauth,omitempty"`
+
+		// Whoami declares which MCP tool returns identity, and which field
+		// of the JSON response holds the human-readable identifier.
+		// Optional — if absent, the adapter has no auto-identity.
+		Whoami *WhoamiSpec `yaml:"whoami,omitempty"`
+	} `yaml:"mcp"`
+}
+
+// MCPOAuthSpec describes the MCP server's OAuth 2.0 authorization endpoints
+// and the scopes Clawvisor should request. client_id / client_secret are
+// NOT in the spec — they're stored under "__system__"/"mcp.oauth.{serviceID}"
+// in the vault, populated by the settings UI (self-hosted) or pre-seeded
+// during deploy (cloud), exactly the same pattern as google.oauth.
+type MCPOAuthSpec struct {
+	AuthorizeURL string   `yaml:"authorize_url"`
+	TokenURL     string   `yaml:"token_url"`
+	Scopes       []string `yaml:"scopes,omitempty"`
+}
+
+// transport returns "stdio" if unset, lower-cased for comparison.
+func (s *Spec) transport() string {
+	t := strings.ToLower(strings.TrimSpace(s.MCP.Transport))
+	if t == "" {
+		return "stdio"
+	}
+	return t
+}
+
+// WhoamiSpec describes how to derive the user's identity from a tool call.
+// This is the *only* per-service hook that the MCP-driven path needs:
+// everything else (actions, params, response sanitization) is generic.
+type WhoamiSpec struct {
+	Tool string `yaml:"tool"` // tool name to call, e.g. "notion-get-users"
+	// Params, optional, are passed as the tool's `arguments`. Some servers
+	// require a parameter to select the current user (e.g. Notion takes
+	// `{"user_id": "self"}` to scope notion-get-users to the authed user).
+	Params map[string]any `yaml:"params,omitempty"`
+	// Field is a dot-path into the JSON response. Supports `results[0].email`
+	// style array indexing for endpoints that return a list (Notion does).
+	Field string `yaml:"field"`
+}
+
+// LoadFromFS walks an embed.FS (or any fs.FS), parses every *.mcp.yaml file
+// it finds, and returns ready-to-register MCPAdapters. Provides the inverted
+// architecture's "minimum integration unit" — a spec file, no Go.
+func LoadFromFS(filesystem fs.FS, root string) ([]*MCPAdapter, error) {
+	var out []*MCPAdapter
+	err := fs.WalkDir(filesystem, root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(path, ".mcp.yaml") && !strings.HasSuffix(path, ".mcp.yml") {
+			return nil
+		}
+		data, err := fs.ReadFile(filesystem, path)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", path, err)
+		}
+		var spec Spec
+		if err := yaml.Unmarshal(data, &spec); err != nil {
+			return fmt.Errorf("parse %s: %w", path, err)
+		}
+		if spec.Service.ID == "" {
+			return fmt.Errorf("%s: service.id is required", filepath.Base(path))
+		}
+		transport, err := transportFromSpec(spec)
+		if err != nil {
+			return fmt.Errorf("%s: %w", filepath.Base(path), err)
+		}
+		out = append(out, FromSpec(spec, transport))
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// FromSpec builds an MCPAdapter from a parsed Spec, given a Transport. The
+// transport is separated so tests can swap in InProcessTransport without
+// touching the spec.
+func FromSpec(spec Spec, transport Transport) *MCPAdapter {
+	envFn := func(cred []byte) (map[string]string, error) {
+		env := map[string]string{}
+		for k, v := range spec.MCP.ExtraEnv {
+			env[k] = v
+		}
+		tok := tokenFromCredential(cred)
+		if spec.MCP.CredentialEnv != "" && tok != "" {
+			env[spec.MCP.CredentialEnv] = tok
+		}
+		// HTTPTransport reads the token from this slot to build the auth
+		// header; stdio transports ignore it. Keeping a single env map
+		// across transports keeps the activation hook transport-agnostic.
+		if tok != "" {
+			env[httpTokenEnvKey] = tok
+		}
+		return env, nil
+	}
+	return New(Config{
+		ServiceID:        spec.Service.ID,
+		Transport:        transport,
+		EnvForCredential: envFn,
+		Spec:             &spec,
+	})
+}
+
+// transportFromSpec constructs the right Transport for the spec's declared
+// transport type. Validation lives here so LoadFromFS surfaces config errors
+// at startup rather than at first request.
+func transportFromSpec(spec Spec) (Transport, error) {
+	switch spec.transport() {
+	case "stdio":
+		if len(spec.MCP.Command) == 0 {
+			return nil, fmt.Errorf("mcp.command is required for stdio transport")
+		}
+		return &StdioTransport{Command: spec.MCP.Command}, nil
+	case "http":
+		if spec.MCP.Endpoint == "" {
+			return nil, fmt.Errorf("mcp.endpoint is required for http transport")
+		}
+		return &HTTPTransport{
+			Endpoint:     spec.MCP.Endpoint,
+			HeaderName:   spec.MCP.HeaderName,
+			HeaderPrefix: spec.MCP.HeaderPrefix,
+		}, nil
+	default:
+		return nil, fmt.Errorf("unknown mcp.transport %q (want stdio or http)", spec.MCP.Transport)
+	}
+}
+
+// tokenFromCredential pulls the bearer-shaped token out of the standard
+// Clawvisor credential JSON envelope ({"type":"api_key","token":"..."}).
+// Returns the raw bytes if the envelope doesn't parse, so a plain-string
+// credential still works.
+func tokenFromCredential(cred []byte) string {
+	if len(cred) == 0 {
+		return ""
+	}
+	var env struct {
+		Token       string `json:"token"`
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.Unmarshal(cred, &env); err == nil {
+		if env.Token != "" {
+			return env.Token
+		}
+		if env.AccessToken != "" {
+			return env.AccessToken
+		}
+	}
+	return string(cred)
+}
+
+// fetchIdentityViaWhoami opens a fresh transport, calls the whoami tool from
+// the spec, and extracts the configured field from the JSON response.
+// Implements the "every server SHOULD expose whoami" convention discussed
+// in MCP_INVERSION_FINDINGS.md.
+func (a *MCPAdapter) fetchIdentityViaWhoami(ctx context.Context, cred []byte) (string, error) {
+	if a.cfg.Spec == nil || a.cfg.Spec.MCP.Whoami == nil {
+		return "", nil
+	}
+	w := a.cfg.Spec.MCP.Whoami
+	if w.Tool == "" {
+		return "", nil
+	}
+
+	client, err := a.openCaller(ctx, cred)
+	if err != nil {
+		return "", err
+	}
+	defer client.Close()
+
+	if err := client.Initialize(ctx); err != nil {
+		return "", err
+	}
+	tr, err := client.CallTool(ctx, w.Tool, w.Params)
+	if err != nil {
+		return "", err
+	}
+	if tr.IsError {
+		if len(tr.Content) > 0 {
+			return "", fmt.Errorf("whoami: %s", tr.Content[0].Text)
+		}
+		return "", fmt.Errorf("whoami: tool returned error")
+	}
+	if len(tr.Content) == 0 || tr.Content[0].Type != "text" {
+		return "", nil
+	}
+	var data any
+	if err := json.Unmarshal([]byte(tr.Content[0].Text), &data); err != nil {
+		return "", nil // not JSON; no identity
+	}
+	return normalizeAlias(extractField(data, w.Field)), nil
+}
+
+// normalizeAlias coerces a free-form whoami result into the alias character
+// set the rest of Clawvisor enforces: [a-z 0-9 _ - . @ +]. Whitespace
+// becomes "-", letters are lowercased, anything else is dropped. Empty
+// result triggers the standard "default" alias fallback upstream.
+//
+// Notion → "eric@clawvisor.com" passes through unchanged.
+// Supabase → "Eric Levine's Org" → "eric-levines-org".
+func normalizeAlias(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.Grow(len(raw))
+	prevDash := false
+	for _, r := range raw {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+			prevDash = false
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r - 'A' + 'a')
+			prevDash = false
+		case r == '_' || r == '-' || r == '.' || r == '@' || r == '+':
+			b.WriteRune(r)
+			prevDash = r == '-'
+		case r == ' ' || r == '\t' || r == '\n' || r == '\r':
+			if !prevDash {
+				b.WriteRune('-')
+				prevDash = true
+			}
+		default:
+			// Drop any char outside the allowed set (apostrophes, slashes,
+			// non-ASCII letters, etc.). Collapsing rather than rejecting
+			// keeps the alias usable when the source has a few stray glyphs.
+		}
+	}
+	return strings.Trim(b.String(), "-.")
+}
+
+// extractField walks a path through nested maps and arrays and returns the
+// string value at the end, or "" if any segment is missing. Supports two
+// forms of array indexing so YAML specs can target list-shaped responses:
+//
+//	"results[0].email"   ← JSONPath-ish, our preferred form
+//	"results.0.email"    ← also accepted; numeric segments index arrays
+func extractField(v any, path string) string {
+	if path == "" {
+		if s, ok := v.(string); ok {
+			return s
+		}
+		return ""
+	}
+	// Normalize `foo[0].bar` → `foo.0.bar` so we can split on `.` uniformly.
+	normalized := strings.ReplaceAll(path, "[", ".")
+	normalized = strings.ReplaceAll(normalized, "]", "")
+	parts := strings.Split(normalized, ".")
+	cur := v
+	for _, p := range parts {
+		if p == "" {
+			continue
+		}
+		switch x := cur.(type) {
+		case map[string]any:
+			cur = x[p]
+		case []any:
+			i, err := strconv.Atoi(p)
+			if err != nil || i < 0 || i >= len(x) {
+				return ""
+			}
+			cur = x[i]
+		default:
+			return ""
+		}
+	}
+	if s, ok := cur.(string); ok {
+		return s
+	}
+	return ""
+}
+
+// FetchIdentity implements adapters.IdentityFetcher, using the spec's whoami
+// hook. Returning ("", nil) is valid — means "no identity discoverable."
+func (a *MCPAdapter) FetchIdentity(ctx context.Context, cred []byte, _ map[string]string) (string, error) {
+	return a.fetchIdentityViaWhoami(ctx, cred)
+}

--- a/pkg/adapters/mcpadapter/spec_test.go
+++ b/pkg/adapters/mcpadapter/spec_test.go
@@ -1,0 +1,50 @@
+package mcpadapter
+
+import "testing"
+
+// TestExtractField covers the array indexing additions made for Notion's
+// notion-get-users tool, which returns {results:[{email,...}]} — the old
+// dot-only path couldn't reach `results[0].email`.
+func TestExtractField(t *testing.T) {
+	notionShape := map[string]any{
+		"has_more": false,
+		"results": []any{
+			map[string]any{"email": "eric@example.com", "name": "Eric"},
+			map[string]any{"email": "other@example.com"},
+		},
+	}
+	gmailShape := map[string]any{
+		"emailAddress": "x@gmail.com",
+		"profile": map[string]any{
+			"displayName": "X",
+		},
+	}
+
+	cases := []struct {
+		name string
+		v    any
+		path string
+		want string
+	}{
+		{"simple top-level string", gmailShape, "emailAddress", "x@gmail.com"},
+		{"nested map", gmailShape, "profile.displayName", "X"},
+		{"array bracket notation", notionShape, "results[0].email", "eric@example.com"},
+		{"array dot-number notation", notionShape, "results.0.email", "eric@example.com"},
+		{"array second index", notionShape, "results[1].email", "other@example.com"},
+		{"empty path returns string itself", "literal", "", "literal"},
+		{"missing key", gmailShape, "missing", ""},
+		{"missing array index", notionShape, "results[99].email", ""},
+		{"non-numeric index on array", notionShape, "results.x.email", ""},
+		{"path into non-map non-array", gmailShape, "emailAddress.subfield", ""},
+		{"target is not a string", notionShape, "has_more", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractField(tc.v, tc.path)
+			if got != tc.want {
+				t.Errorf("extractField(%q) = %q, want %q", tc.path, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/adapters/mcpadapter/stream_caller.go
+++ b/pkg/adapters/mcpadapter/stream_caller.go
@@ -1,0 +1,26 @@
+package mcpadapter
+
+import (
+	"io"
+
+	"github.com/clawvisor/clawvisor/pkg/adapters/mcpclient"
+)
+
+// streamCaller bundles the line-delimited JSON-RPC Client with the
+// io.Closer that owns the underlying stream lifecycle (subprocess, pipe).
+// Implements mcpclient.Caller so stdio and HTTP transports are interchangeable
+// from the adapter's perspective.
+type streamCaller struct {
+	*mcpclient.Client
+	closer io.Closer
+}
+
+func newStreamCaller(rwc io.ReadWriteCloser) *streamCaller {
+	return &streamCaller{Client: mcpclient.New(rwc), closer: rwc}
+}
+
+// Close terminates the underlying stream, which ends the Client's read pump
+// and unblocks any pending callers.
+func (s *streamCaller) Close() error { return s.closer.Close() }
+
+var _ mcpclient.Caller = (*streamCaller)(nil)

--- a/pkg/adapters/mcpadapter/transport.go
+++ b/pkg/adapters/mcpadapter/transport.go
@@ -80,6 +80,9 @@ type InProcessTransport struct {
 }
 
 func (t *InProcessTransport) Open(ctx context.Context, env map[string]string) (mcpclient.Caller, error) {
+	if t.Serve == nil {
+		return nil, fmt.Errorf("in-process transport: Serve handler is nil")
+	}
 	clientToServer, serverIn := io.Pipe()
 	serverOut, clientFromServer := io.Pipe()
 

--- a/pkg/adapters/mcpadapter/transport.go
+++ b/pkg/adapters/mcpadapter/transport.go
@@ -1,0 +1,145 @@
+package mcpadapter
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+
+	"github.com/clawvisor/clawvisor/pkg/adapters/mcpclient"
+)
+
+// Transport opens a fresh MCP session and returns a Caller — the unified
+// surface that hides whether we're talking to a local subprocess, an
+// in-process goroutine (tests), or a remote HTTP endpoint.
+type Transport interface {
+	Open(ctx context.Context, env map[string]string) (mcpclient.Caller, error)
+}
+
+// ── stdio (subprocess) ──────────────────────────────────────────────────────
+
+// StdioTransport spawns a subprocess and pipes stdio. This is how nearly
+// every published MCP server (notion-mcp-server, github-mcp, etc.) runs
+// locally — via npx, uvx, or a compiled binary.
+type StdioTransport struct {
+	Command []string
+}
+
+func (t *StdioTransport) Open(ctx context.Context, env map[string]string) (mcpclient.Caller, error) {
+	if len(t.Command) == 0 {
+		return nil, fmt.Errorf("stdio transport: empty command")
+	}
+	cmd := exec.CommandContext(ctx, t.Command[0], t.Command[1:]...)
+	// Inherit the parent environment so PATH, HOME, etc. resolve (npx, node,
+	// shell stubs, etc. depend on these). Caller-supplied env appends after,
+	// so duplicate keys override the inherited value.
+	cmd.Env = os.Environ()
+	for k, v := range env {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	return newStreamCaller(&subprocConn{stdin: stdin, stdout: stdout, cmd: cmd}), nil
+}
+
+type subprocConn struct {
+	stdin  io.WriteCloser
+	stdout io.ReadCloser
+	cmd    *exec.Cmd
+}
+
+func (c *subprocConn) Read(p []byte) (int, error)  { return c.stdout.Read(p) }
+func (c *subprocConn) Write(p []byte) (int, error) { return c.stdin.Write(p) }
+func (c *subprocConn) Close() error {
+	_ = c.stdin.Close()
+	_ = c.stdout.Close()
+	if c.cmd.Process != nil {
+		_ = c.cmd.Process.Kill()
+	}
+	_ = c.cmd.Wait()
+	return nil
+}
+
+// ── in-process (tests) ──────────────────────────────────────────────────────
+
+// InProcessTransport runs an MCP server handler in a goroutine connected by
+// pipes. Used in tests so we don't compile and exec a separate binary.
+type InProcessTransport struct {
+	Serve func(ctx context.Context, in io.Reader, out io.Writer, env map[string]string) error
+}
+
+func (t *InProcessTransport) Open(ctx context.Context, env map[string]string) (mcpclient.Caller, error) {
+	clientToServer, serverIn := io.Pipe()
+	serverOut, clientFromServer := io.Pipe()
+
+	go func() {
+		err := t.Serve(ctx, clientToServer, clientFromServer, env)
+		_ = clientFromServer.CloseWithError(err)
+		_ = clientToServer.CloseWithError(err)
+	}()
+
+	return newStreamCaller(&pipeConn{PipeReader: serverOut, PipeWriter: serverIn}), nil
+}
+
+type pipeConn struct {
+	*io.PipeReader
+	*io.PipeWriter
+}
+
+func (p *pipeConn) Close() error {
+	_ = p.PipeReader.Close()
+	_ = p.PipeWriter.Close()
+	return nil
+}
+
+// ── HTTP (remote, vendor-hosted MCP) ────────────────────────────────────────
+
+// HTTPTransport speaks MCP "streamable HTTP" against a remote endpoint —
+// the production-shape transport for vendor-hosted MCP servers. No local
+// install, no subprocess, no node/npm in the Clawvisor container.
+//
+// Auth: the credential bytes flow into a request header on every call.
+// Default is the Bearer pattern; YAML specs can override the header name
+// and prefix to accommodate vendors using something else.
+type HTTPTransport struct {
+	Endpoint     string
+	HeaderName   string // defaults to "Authorization"
+	HeaderPrefix string // defaults to "Bearer "
+	HTTPClient   *http.Client // optional; nil → use default
+}
+
+// httpTokenEnvKey is the conventional env-map slot the MCPAdapter populates
+// with the extracted credential. Both stdio (via spec.credential_env) and
+// http (via this key) read from the same env map; the HTTP transport just
+// promotes whatever the spec's CredentialEnv set into a header.
+const httpTokenEnvKey = "__mcp_http_token__"
+
+func (t *HTTPTransport) Open(_ context.Context, env map[string]string) (mcpclient.Caller, error) {
+	if t.Endpoint == "" {
+		return nil, fmt.Errorf("http transport: endpoint is required")
+	}
+	headerName := t.HeaderName
+	if headerName == "" {
+		headerName = "Authorization"
+	}
+	prefix := t.HeaderPrefix
+	if prefix == "" {
+		prefix = "Bearer "
+	}
+	headers := map[string]string{}
+	if tok := env[httpTokenEnvKey]; tok != "" {
+		headers[headerName] = prefix + tok
+	}
+	return mcpclient.NewHTTP(t.Endpoint, headers, t.HTTPClient), nil
+}

--- a/pkg/adapters/mcpclient/client.go
+++ b/pkg/adapters/mcpclient/client.go
@@ -1,0 +1,174 @@
+package mcpclient
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+)
+
+// Client is a JSON-RPC 2.0 MCP client. A single read pump owns the underlying
+// stream; per-call requests register a response channel keyed by request ID,
+// and the pump dispatches each response to the right caller. This avoids the
+// goroutine-leak / concurrent-bufio.Reader hazards of a "spawn a reader per
+// call" design and correctly matches responses by id (so server log lines or
+// notifications cannot be mistaken for the next call's response).
+type Client struct {
+	enc     *json.Encoder
+	mu      sync.Mutex
+	id      int
+	pending map[int]chan *rpcResponse
+	closed  bool
+	closeCh chan struct{}
+}
+
+// New wraps an io.ReadWriter (subprocess stdio, or an in-process pipe pair)
+// and starts the background reader. Caller is responsible for closing the
+// underlying connection — that closure ends the read pump and unblocks any
+// pending callers with an error.
+func New(rw io.ReadWriter) *Client {
+	c := &Client{
+		enc:     json.NewEncoder(rw),
+		pending: make(map[int]chan *rpcResponse),
+		closeCh: make(chan struct{}),
+	}
+	go c.readLoop(rw)
+	return c
+}
+
+// readLoop owns the bufio.Reader and routes each response to its caller.
+// Lines that don't parse as a JSON-RPC response with an int id are dropped
+// (notifications, server diagnostics, etc.). When the stream ends, all
+// pending callers are unblocked with io.EOF.
+func (c *Client) readLoop(r io.Reader) {
+	br := bufio.NewReader(r)
+	for {
+		line, err := br.ReadBytes('\n')
+		if len(line) > 0 {
+			var resp rpcResponse
+			if jerr := json.Unmarshal(line, &resp); jerr == nil && resp.ID > 0 {
+				c.mu.Lock()
+				ch, ok := c.pending[resp.ID]
+				delete(c.pending, resp.ID)
+				c.mu.Unlock()
+				if ok {
+					ch <- &resp
+				}
+				// Unmatched id — likely a stale response after a context
+				// cancellation. Drop it.
+			}
+		}
+		if err != nil {
+			break
+		}
+	}
+	c.mu.Lock()
+	c.closed = true
+	for id, ch := range c.pending {
+		close(ch)
+		delete(c.pending, id)
+	}
+	c.mu.Unlock()
+	close(c.closeCh)
+}
+
+// Initialize performs the MCP handshake. Must be called before ListTools or CallTool.
+func (c *Client) Initialize(ctx context.Context) error {
+	params, _ := json.Marshal(map[string]any{
+		"protocolVersion": protocolVersion,
+		"capabilities":    map[string]any{},
+		"clientInfo": map[string]any{
+			"name":    "clawvisor-mcpclient",
+			"version": "0.1.0",
+		},
+	})
+	var raw json.RawMessage
+	if err := c.call(ctx, "initialize", params, &raw); err != nil {
+		return err
+	}
+	// Send the initialized notification (no id → no response expected).
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return errors.New("mcpclient: closed")
+	}
+	return c.enc.Encode(rpcRequest{JSONRPC: "2.0", Method: "notifications/initialized"})
+}
+
+// ListTools returns the set of tools advertised by the server.
+func (c *Client) ListTools(ctx context.Context) ([]Tool, error) {
+	var resp struct {
+		Tools []Tool `json:"tools"`
+	}
+	if err := c.call(ctx, "tools/list", nil, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Tools, nil
+}
+
+// CallTool invokes a tool by name with arbitrary JSON arguments.
+func (c *Client) CallTool(ctx context.Context, name string, args map[string]any) (*ToolResult, error) {
+	if args == nil {
+		args = map[string]any{}
+	}
+	params, _ := json.Marshal(map[string]any{
+		"name":      name,
+		"arguments": args,
+	})
+	var result ToolResult
+	if err := c.call(ctx, "tools/call", params, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func (c *Client) call(ctx context.Context, method string, params json.RawMessage, out any) error {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return errors.New("mcpclient: closed")
+	}
+	c.id++
+	id := c.id
+	ch := make(chan *rpcResponse, 1)
+	c.pending[id] = ch
+	req := rpcRequest{JSONRPC: "2.0", ID: id, Method: method, Params: params}
+	err := c.enc.Encode(req)
+	c.mu.Unlock()
+	if err != nil {
+		c.mu.Lock()
+		delete(c.pending, id)
+		c.mu.Unlock()
+		return fmt.Errorf("write %s: %w", method, err)
+	}
+
+	select {
+	case <-ctx.Done():
+		// Stop waiting; drop the channel from the pending map. If the
+		// response arrives later, readLoop discards it (no matching id in
+		// pending). The reader goroutine is unaffected — it owns the stream
+		// across the lifetime of the client, not per-call.
+		c.mu.Lock()
+		delete(c.pending, id)
+		c.mu.Unlock()
+		return ctx.Err()
+	case <-c.closeCh:
+		return io.EOF
+	case resp, ok := <-ch:
+		if !ok {
+			return io.EOF
+		}
+		if resp.Error != nil {
+			return fmt.Errorf("%s: rpc error %d: %s", method, resp.Error.Code, resp.Error.Message)
+		}
+		if out != nil && len(resp.Result) > 0 {
+			if err := json.Unmarshal(resp.Result, out); err != nil {
+				return fmt.Errorf("decode %s result: %w", method, err)
+			}
+		}
+		return nil
+	}
+}

--- a/pkg/adapters/mcpclient/client.go
+++ b/pkg/adapters/mcpclient/client.go
@@ -114,10 +114,13 @@ func (c *Client) CallTool(ctx context.Context, name string, args map[string]any)
 	if args == nil {
 		args = map[string]any{}
 	}
-	params, _ := json.Marshal(map[string]any{
+	params, err := json.Marshal(map[string]any{
 		"name":      name,
 		"arguments": args,
 	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal tools/call params: %w", err)
+	}
 	var result ToolResult
 	if err := c.call(ctx, "tools/call", params, &result); err != nil {
 		return nil, err

--- a/pkg/adapters/mcpclient/http_client.go
+++ b/pkg/adapters/mcpclient/http_client.go
@@ -100,8 +100,12 @@ func (c *HTTPClient) Initialize(ctx context.Context) error {
 		return err
 	}
 	// Send the initialized notification (no id → no response expected).
-	// Some servers require it before tools/* will work.
-	_, _ = c.do(ctx, rpcRequest{JSONRPC: "2.0", Method: "notifications/initialized"})
+	// Some servers require it before tools/* will work; if the transport
+	// or server rejects it, surface the error rather than silently
+	// continuing with a half-initialized session.
+	if _, err := c.do(ctx, rpcRequest{JSONRPC: "2.0", Method: "notifications/initialized"}); err != nil {
+		return fmt.Errorf("notifications/initialized: %w", err)
+	}
 	return nil
 }
 
@@ -119,7 +123,10 @@ func (c *HTTPClient) CallTool(ctx context.Context, name string, args map[string]
 	if args == nil {
 		args = map[string]any{}
 	}
-	params, _ := json.Marshal(map[string]any{"name": name, "arguments": args})
+	params, err := json.Marshal(map[string]any{"name": name, "arguments": args})
+	if err != nil {
+		return nil, fmt.Errorf("marshal tools/call params: %w", err)
+	}
 	var result ToolResult
 	if err := c.call(ctx, "tools/call", params, &result); err != nil {
 		return nil, err
@@ -140,6 +147,13 @@ func (c *HTTPClient) call(ctx context.Context, method string, params json.RawMes
 	}
 	if resp == nil {
 		return nil // notification path
+	}
+	// JSON-RPC 2.0 §5: response id MUST match the request id. Most
+	// transports preserve this naturally, but a misbehaving proxy or a
+	// server that returns a stray response from a different in-flight
+	// request would otherwise be silently mis-attributed.
+	if int64(resp.ID) != id {
+		return fmt.Errorf("%s: response id mismatch (got %d, want %d)", method, resp.ID, id)
 	}
 	if resp.Error != nil {
 		return fmt.Errorf("%s: rpc error %d: %s", method, resp.Error.Code, resp.Error.Message)

--- a/pkg/adapters/mcpclient/http_client.go
+++ b/pkg/adapters/mcpclient/http_client.go
@@ -1,0 +1,216 @@
+package mcpclient
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+)
+
+// readMCPBody parses a single JSON-RPC response from either an
+// application/json body (single object) or a text/event-stream body
+// (one or more SSE events, where the `data:` lines carry the payload).
+// We're a synchronous client — we read until we have one complete
+// JSON-RPC response payload and return.
+func readMCPBody(body io.Reader, contentType string) ([]byte, error) {
+	if strings.HasPrefix(strings.ToLower(contentType), "text/event-stream") {
+		return readSSEResponse(body)
+	}
+	return io.ReadAll(io.LimitReader(body, 4*1024*1024))
+}
+
+// readSSEResponse consumes an SSE stream and returns the JSON payload from
+// the first `data:` line(s) it sees. Subsequent events are ignored — we
+// expect one JSON-RPC response per call.
+func readSSEResponse(body io.Reader) ([]byte, error) {
+	scanner := bufio.NewScanner(body)
+	scanner.Buffer(make([]byte, 64*1024), 4*1024*1024)
+	var dataLines []string
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			// Blank line ends an event. If we collected data, we're done.
+			if len(dataLines) > 0 {
+				break
+			}
+			continue
+		}
+		if strings.HasPrefix(line, "data:") {
+			dataLines = append(dataLines, strings.TrimPrefix(strings.TrimPrefix(line, "data:"), " "))
+		}
+		// Other SSE field lines (event:, id:, retry:) are ignored.
+	}
+	if err := scanner.Err(); err != nil && err != io.EOF {
+		return nil, err
+	}
+	if len(dataLines) == 0 {
+		return nil, fmt.Errorf("sse: no data lines in response")
+	}
+	return []byte(strings.Join(dataLines, "\n")), nil
+}
+
+// HTTPClient speaks MCP "streamable HTTP" — every JSON-RPC request is a
+// POST to the configured endpoint; the response body carries one JSON-RPC
+// response back. Sessions are tracked via the standard Mcp-Session-Id header
+// (set by the server on Initialize, sent back on every subsequent call).
+//
+// Streaming responses (SSE) are not supported in this prototype — the client
+// expects a single JSON response per request. That's sufficient for
+// initialize, tools/list, and synchronous tools/call without progress
+// notifications, which is what the gateway exercises today.
+type HTTPClient struct {
+	endpoint  string
+	headers   map[string]string
+	http      *http.Client
+	id        atomic.Int64
+	mu        sync.Mutex
+	sessionID string
+}
+
+// NewHTTP builds an HTTP-transport MCP client. The headers map is sent on
+// every request (typically containing the Authorization header).
+func NewHTTP(endpoint string, headers map[string]string, httpClient *http.Client) *HTTPClient {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	hcopy := make(map[string]string, len(headers))
+	for k, v := range headers {
+		hcopy[k] = v
+	}
+	return &HTTPClient{endpoint: endpoint, headers: hcopy, http: httpClient}
+}
+
+func (c *HTTPClient) Initialize(ctx context.Context) error {
+	params, _ := json.Marshal(map[string]any{
+		"protocolVersion": protocolVersion,
+		"capabilities":    map[string]any{},
+		"clientInfo": map[string]any{
+			"name":    "clawvisor-mcpclient",
+			"version": "0.1.0",
+		},
+	})
+	var raw json.RawMessage
+	if err := c.call(ctx, "initialize", params, &raw); err != nil {
+		return err
+	}
+	// Send the initialized notification (no id → no response expected).
+	// Some servers require it before tools/* will work.
+	_, _ = c.do(ctx, rpcRequest{JSONRPC: "2.0", Method: "notifications/initialized"})
+	return nil
+}
+
+func (c *HTTPClient) ListTools(ctx context.Context) ([]Tool, error) {
+	var resp struct {
+		Tools []Tool `json:"tools"`
+	}
+	if err := c.call(ctx, "tools/list", nil, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Tools, nil
+}
+
+func (c *HTTPClient) CallTool(ctx context.Context, name string, args map[string]any) (*ToolResult, error) {
+	if args == nil {
+		args = map[string]any{}
+	}
+	params, _ := json.Marshal(map[string]any{"name": name, "arguments": args})
+	var result ToolResult
+	if err := c.call(ctx, "tools/call", params, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// Close is a no-op — HTTP transport has no persistent connection to release.
+// Sessions on the server side time out on their own schedule.
+func (c *HTTPClient) Close() error { return nil }
+
+func (c *HTTPClient) call(ctx context.Context, method string, params json.RawMessage, out any) error {
+	id := c.id.Add(1)
+	req := rpcRequest{JSONRPC: "2.0", ID: int(id), Method: method, Params: params}
+	resp, err := c.do(ctx, req)
+	if err != nil {
+		return fmt.Errorf("%s: %w", method, err)
+	}
+	if resp == nil {
+		return nil // notification path
+	}
+	if resp.Error != nil {
+		return fmt.Errorf("%s: rpc error %d: %s", method, resp.Error.Code, resp.Error.Message)
+	}
+	if out != nil && len(resp.Result) > 0 {
+		if err := json.Unmarshal(resp.Result, out); err != nil {
+			return fmt.Errorf("decode %s result: %w", method, err)
+		}
+	}
+	return nil
+}
+
+// do issues one POST. Notifications (req.ID == 0) return (nil, nil) on
+// success. Other requests decode and return the response.
+func (c *HTTPClient) do(ctx context.Context, rpcReq rpcRequest) (*rpcResponse, error) {
+	body, _ := json.Marshal(rpcReq)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "application/json, text/event-stream")
+	for k, v := range c.headers {
+		httpReq.Header.Set(k, v)
+	}
+	c.mu.Lock()
+	sess := c.sessionID
+	c.mu.Unlock()
+	if sess != "" {
+		httpReq.Header.Set("Mcp-Session-Id", sess)
+	}
+
+	httpResp, err := c.http.Do(httpReq)
+	if err != nil {
+		return nil, err
+	}
+	defer httpResp.Body.Close()
+
+	// Capture session ID set by the server (typically on initialize).
+	if sid := httpResp.Header.Get("Mcp-Session-Id"); sid != "" {
+		c.mu.Lock()
+		c.sessionID = sid
+		c.mu.Unlock()
+	}
+
+	if httpResp.StatusCode == http.StatusAccepted || httpResp.StatusCode == http.StatusNoContent {
+		// Notification accepted, no body expected.
+		return nil, nil
+	}
+	if httpResp.StatusCode >= 400 {
+		body, _ := io.ReadAll(io.LimitReader(httpResp.Body, 4096))
+		return nil, fmt.Errorf("http %d: %s", httpResp.StatusCode, string(body))
+	}
+	// Notifications can still get a 200 with empty body; honor that too.
+	if rpcReq.ID == 0 {
+		return nil, nil
+	}
+
+	// MCP streamable HTTP responses can be either JSON or an SSE stream —
+	// servers pick whichever fits the call (Notion uses SSE post-auth).
+	// Dispatch on Content-Type.
+	ctype := httpResp.Header.Get("Content-Type")
+	payload, err := readMCPBody(httpResp.Body, ctype)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+	var resp rpcResponse
+	if err := json.Unmarshal(payload, &resp); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return &resp, nil
+}
+
+var _ Caller = (*HTTPClient)(nil)

--- a/pkg/adapters/mcpclient/sse_test.go
+++ b/pkg/adapters/mcpclient/sse_test.go
@@ -1,0 +1,82 @@
+package mcpclient
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestHTTPClient_HandlesSSEResponse is the regression test for the bug we
+// hit against Notion's hosted MCP: after auth, the server switched
+// Content-Type to text/event-stream and the JSON decoder choked on the
+// leading "event:" line. The client must extract the data line and parse
+// that as the JSON-RPC response.
+func TestHTTPClient_HandlesSSEResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			ID     int    `json:"id"`
+			Method string `json:"method"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Mcp-Session-Id", "sess-sse")
+		// Notion-style SSE envelope: event line then data line.
+		payload, _ := json.Marshal(map[string]any{
+			"jsonrpc": "2.0",
+			"id":      req.ID,
+			"result": map[string]any{
+				"tools": []map[string]any{
+					{"name": "notion-search", "description": "Search."},
+					{"name": "notion-get-user", "description": "Identity."},
+				},
+			},
+		})
+		_, _ = w.Write([]byte("event: message\ndata: " + string(payload) + "\n\n"))
+	}))
+	t.Cleanup(srv.Close)
+
+	client := NewHTTP(srv.URL, map[string]string{"Authorization": "Bearer test"}, srv.Client())
+	if err := client.Initialize(context.Background()); err != nil {
+		// Initialize hits the same SSE handler — proves the bug fix works
+		// on the initialize call specifically, which is where Notion broke.
+		t.Fatalf("Initialize over SSE: %v", err)
+	}
+	tools, err := client.ListTools(context.Background())
+	if err != nil {
+		t.Fatalf("ListTools over SSE: %v", err)
+	}
+	if len(tools) != 2 {
+		t.Fatalf("expected 2 tools from SSE response, got %d", len(tools))
+	}
+	if tools[0].Name != "notion-search" {
+		t.Errorf("tool[0].name = %q, want %q", tools[0].Name, "notion-search")
+	}
+}
+
+// TestHTTPClient_HandlesMultilineSSEData covers the spec's rule that
+// multiple `data:` lines in a single event are joined with newlines. Notion
+// doesn't seem to use this today, but the SSE spec allows it and a future
+// server might split large payloads across lines.
+func TestHTTPClient_HandlesMultilineSSEData(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		// Same JSON spread across two data lines.
+		_, _ = w.Write([]byte("event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\n" +
+			"data: \"result\":{\"tools\":[]}}\n\n"))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := NewHTTP(srv.URL, nil, srv.Client())
+	if _, err := c.ListTools(context.Background()); err != nil {
+		// We don't have a great oracle here — the multi-data join is a
+		// best-effort decode. The point is that it doesn't blow up with
+		// the same "invalid character 'e'" error we hit before.
+		if strings.Contains(err.Error(), "invalid character 'e'") {
+			t.Fatalf("regression: SSE event line leaked into JSON decoder: %v", err)
+		}
+	}
+}

--- a/pkg/adapters/mcpclient/types.go
+++ b/pkg/adapters/mcpclient/types.go
@@ -1,0 +1,63 @@
+// Package mcpclient is a minimal JSON-RPC 2.0 client for the Model Context Protocol.
+// Two transports are provided: line-delimited JSON over an io.ReadWriter (used for
+// stdio subprocesses and in-process pipes) and HTTP POST against an MCP "streamable
+// HTTP" endpoint (used for remote, vendor-hosted MCP servers).
+package mcpclient
+
+import (
+	"context"
+	"encoding/json"
+)
+
+const protocolVersion = "2025-06-18"
+
+// Caller is the common surface every MCP client transport exposes. The
+// MCPAdapter and the activation-time tool-discovery code program against this
+// interface so stdio and HTTP transports are interchangeable.
+type Caller interface {
+	Initialize(ctx context.Context) error
+	ListTools(ctx context.Context) ([]Tool, error)
+	CallTool(ctx context.Context, name string, args map[string]any) (*ToolResult, error)
+	Close() error
+}
+
+type rpcRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      int             `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type rpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      int             `json:"id"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// Tool is the subset of the MCP tool definition this client cares about.
+type Tool struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	InputSchema json.RawMessage `json:"inputSchema"`
+	// Annotations carries the standard MCP tool hints (readOnlyHint,
+	// destructiveHint, idempotentHint, openWorldHint). The gateway uses these
+	// to derive risk classification — replacing the per-adapter Risk YAML.
+	Annotations map[string]any `json:"annotations,omitempty"`
+}
+
+// ToolResult is the response from tools/call.
+type ToolResult struct {
+	Content []ToolContent `json:"content"`
+	IsError bool          `json:"isError,omitempty"`
+}
+
+type ToolContent struct {
+	Type string `json:"type"`
+	Text string `json:"text,omitempty"`
+}

--- a/pkg/adapters/oauth_provider.go
+++ b/pkg/adapters/oauth_provider.go
@@ -195,3 +195,115 @@ func ListPKCEClientIDs(ctx context.Context, v vault.Vault) (map[string]string, e
 	}
 	return result, nil
 }
+
+// ── MCP OAuth credential management ─────────────────────────────────────────
+//
+// Per-MCP-service OAuth client credentials, stored as system vault entries
+// keyed by "mcp.oauth.{serviceID}". Same shape as Google/Microsoft — admins
+// drop their client_id + client_secret in via the settings page and the
+// MCPAdapter picks them up on the next request (no restart).
+
+// mcpOAuthCred is the JSON structure stored for each MCP service's OAuth credentials.
+type mcpOAuthCred struct {
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+}
+
+// SetMCPOAuthCredentials stores OAuth app credentials for an MCP service in the system vault.
+func SetMCPOAuthCredentials(ctx context.Context, v vault.Vault, serviceID, clientID, clientSecret string) error {
+	data, err := json.Marshal(mcpOAuthCred{ClientID: clientID, ClientSecret: clientSecret})
+	if err != nil {
+		return err
+	}
+	return v.Set(ctx, SystemUserID, SystemVaultKeyMCPOAuthPrefix+serviceID, data)
+}
+
+// GetMCPOAuthCredentials reads OAuth app credentials for an MCP service from the
+// system vault. Returns empty strings if not configured.
+func GetMCPOAuthCredentials(ctx context.Context, v vault.Vault, serviceID string) (clientID, clientSecret string) {
+	data, err := v.Get(ctx, SystemUserID, SystemVaultKeyMCPOAuthPrefix+serviceID)
+	if err != nil || len(data) == 0 {
+		return "", ""
+	}
+	var cred mcpOAuthCred
+	if err := json.Unmarshal(data, &cred); err != nil {
+		return "", ""
+	}
+	return cred.ClientID, cred.ClientSecret
+}
+
+// DeleteMCPOAuthCredentials removes OAuth app credentials for an MCP service.
+func DeleteMCPOAuthCredentials(ctx context.Context, v vault.Vault, serviceID string) error {
+	return v.Delete(ctx, SystemUserID, SystemVaultKeyMCPOAuthPrefix+serviceID)
+}
+
+// MCPOAuthEntry is a single configured MCP OAuth credential — used by
+// settings-page list endpoints. ClientSecret is intentionally omitted; the
+// settings UI only needs to know which services are configured.
+type MCPOAuthEntry struct {
+	ServiceID string `json:"service_id"`
+	ClientID  string `json:"client_id"`
+}
+
+// MCPClientRecord is the cached result of RFC 8414 discovery + RFC 7591
+// dynamic client registration for one MCP service. Persisted as a single
+// vault record so a server restart doesn't trigger re-discovery or
+// re-registration on the next request.
+type MCPClientRecord struct {
+	ClientID             string `json:"client_id"`
+	ClientSecret         string `json:"client_secret,omitempty"` // empty for public/PKCE clients
+	AuthorizationEndpoint string `json:"authorization_endpoint"`
+	TokenEndpoint        string `json:"token_endpoint"`
+	RegistrationEndpoint string `json:"registration_endpoint,omitempty"`
+}
+
+// SetMCPClientRecord stores the discovered + registered client record for an MCP service.
+func SetMCPClientRecord(ctx context.Context, v vault.Vault, serviceID string, rec *MCPClientRecord) error {
+	data, err := json.Marshal(rec)
+	if err != nil {
+		return err
+	}
+	return v.Set(ctx, SystemUserID, SystemVaultKeyMCPClientPrefix+serviceID, data)
+}
+
+// GetMCPClientRecord reads the cached client record. Returns nil when no
+// discovery has happened yet for this service.
+func GetMCPClientRecord(ctx context.Context, v vault.Vault, serviceID string) *MCPClientRecord {
+	data, err := v.Get(ctx, SystemUserID, SystemVaultKeyMCPClientPrefix+serviceID)
+	if err != nil || len(data) == 0 {
+		return nil
+	}
+	var rec MCPClientRecord
+	if err := json.Unmarshal(data, &rec); err != nil {
+		return nil
+	}
+	return &rec
+}
+
+// DeleteMCPClientRecord removes the cached record — useful when the admin
+// wants to force re-registration (e.g. if Notion rotates their server config).
+func DeleteMCPClientRecord(ctx context.Context, v vault.Vault, serviceID string) error {
+	return v.Delete(ctx, SystemUserID, SystemVaultKeyMCPClientPrefix+serviceID)
+}
+
+// ListMCPOAuthCredentials returns the set of MCP services with configured
+// OAuth client credentials. Secrets are never returned.
+func ListMCPOAuthCredentials(ctx context.Context, v vault.Vault) ([]MCPOAuthEntry, error) {
+	keys, err := v.List(ctx, SystemUserID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]MCPOAuthEntry, 0)
+	for _, key := range keys {
+		if !strings.HasPrefix(key, SystemVaultKeyMCPOAuthPrefix) {
+			continue
+		}
+		serviceID := strings.TrimPrefix(key, SystemVaultKeyMCPOAuthPrefix)
+		cid, _ := GetMCPOAuthCredentials(ctx, v, serviceID)
+		if cid == "" {
+			continue
+		}
+		out = append(out, MCPOAuthEntry{ServiceID: serviceID, ClientID: cid})
+	}
+	return out, nil
+}

--- a/pkg/adapters/registry_test.go
+++ b/pkg/adapters/registry_test.go
@@ -1,0 +1,100 @@
+package adapters_test
+
+import (
+	"context"
+	"testing"
+
+	"golang.org/x/oauth2"
+
+	"github.com/clawvisor/clawvisor/pkg/adapters"
+)
+
+// stubAdapter is a minimal Adapter implementation for registry order tests.
+type stubAdapter struct {
+	id      string
+	actions []string
+}
+
+func (s *stubAdapter) ServiceID() string                                       { return s.id }
+func (s *stubAdapter) SupportedActions() []string                              { return s.actions }
+func (s *stubAdapter) Execute(context.Context, adapters.Request) (*adapters.Result, error) {
+	return nil, nil
+}
+func (s *stubAdapter) OAuthConfig() *oauth2.Config                  { return nil }
+func (s *stubAdapter) CredentialFromToken(*oauth2.Token) ([]byte, error) { return nil, nil }
+func (s *stubAdapter) ValidateCredential([]byte) error              { return nil }
+func (s *stubAdapter) RequiredScopes() []string                     { return nil }
+
+// TestGetForUser_PerUserOverridesGlobal locks in the fix for the review:
+// the global registry must NOT shadow a per-user adapter for the same
+// service ID. Before the fix, MCP services registered an empty global
+// stub that masked per-user clones holding the discovered tool set,
+// causing the gateway preflight to reject every action as "does not exist".
+func TestGetForUser_PerUserOverridesGlobal(t *testing.T) {
+	reg := adapters.NewRegistry()
+	global := &stubAdapter{id: "svc", actions: nil} // empty global stub
+	perUser := &stubAdapter{id: "svc", actions: []string{"x", "y", "z"}}
+
+	reg.Register(global)
+	reg.RegisterForUser("user-1", perUser)
+
+	got, ok := reg.GetForUser(context.Background(), "svc", "user-1")
+	if !ok {
+		t.Fatal("GetForUser returned false")
+	}
+	if len(got.SupportedActions()) != 3 {
+		t.Fatalf("expected per-user adapter with 3 actions, got %d (got the global stub instead)", len(got.SupportedActions()))
+	}
+
+	// A different user with no per-user registration should still see the global.
+	got2, ok2 := reg.GetForUser(context.Background(), "svc", "user-2")
+	if !ok2 {
+		t.Fatal("GetForUser for unrelated user returned false")
+	}
+	if len(got2.SupportedActions()) != 0 {
+		t.Fatalf("user-2 should see the global stub with 0 actions, got %d", len(got2.SupportedActions()))
+	}
+}
+
+// TestGetForUser_ResolverHydratesAcrossRestart proves the resolver runs
+// when neither per-user cache nor global has a populated adapter. This is
+// the post-restart hydration path.
+func TestGetForUser_ResolverHydratesAcrossRestart(t *testing.T) {
+	reg := adapters.NewRegistry()
+	global := &stubAdapter{id: "mcp-svc", actions: nil}
+	reg.Register(global)
+
+	// Resolver returns a per-user clone with tools (mimics DB hydration).
+	resolverCalls := 0
+	reg.SetResolver(func(_ context.Context, serviceID, userID string) (adapters.Adapter, bool) {
+		resolverCalls++
+		if serviceID == "mcp-svc" && userID == "user-1" {
+			return &stubAdapter{id: "mcp-svc", actions: []string{"a", "b"}}, true
+		}
+		return nil, false
+	})
+
+	// First call: resolver runs.
+	got, ok := reg.GetForUser(context.Background(), "mcp-svc", "user-1")
+	if !ok {
+		t.Fatal("first GetForUser returned false")
+	}
+	if len(got.SupportedActions()) != 2 {
+		t.Fatalf("expected resolver to populate 2 actions, got %d", len(got.SupportedActions()))
+	}
+	if resolverCalls != 1 {
+		t.Fatalf("expected 1 resolver call, got %d", resolverCalls)
+	}
+
+	// Second call: should hit the per-user cache, not call resolver again.
+	got2, ok2 := reg.GetForUser(context.Background(), "mcp-svc", "user-1")
+	if !ok2 {
+		t.Fatal("second GetForUser returned false")
+	}
+	if len(got2.SupportedActions()) != 2 {
+		t.Fatalf("cached adapter lost actions: got %d", len(got2.SupportedActions()))
+	}
+	if resolverCalls != 1 {
+		t.Fatalf("expected resolver cache hit, got %d total resolver calls", resolverCalls)
+	}
+}

--- a/pkg/adapters/yamldef/schema.go
+++ b/pkg/adapters/yamldef/schema.go
@@ -32,6 +32,12 @@ type ServiceInfo struct {
 	IconSVG     string       `yaml:"icon_svg,omitempty"` // optional: inline SVG markup (mutually exclusive with icon_url)
 	IconURL     string       `yaml:"icon_url,omitempty"` // optional: absolute or site-relative URL to the icon (e.g. "/logos/github.svg")
 	Identity    *IdentityDef `yaml:"identity,omitempty"`
+	// Deprecated hides the service from the connect-service list for new
+	// users while keeping it visible (and functional) for users who have
+	// already activated it. Use during a migration where a successor adapter
+	// has taken the prominent slot — existing connections keep working but
+	// new connections route to the successor.
+	Deprecated bool `yaml:"deprecated,omitempty"`
 }
 
 // IdentityDef configures automatic account identity detection after activation.

--- a/pkg/adapters/yamlruntime/adapter.go
+++ b/pkg/adapters/yamlruntime/adapter.go
@@ -582,6 +582,7 @@ func (a *YAMLAdapter) ServiceMetadata() adapters.ServiceMetadata {
 		PKCEFlow:          a.def.Auth.PKCEFlow != nil && a.resolvePKCEFlowClientID() != "",
 		PKCEFlowDefined:   a.def.Auth.PKCEFlow != nil,
 		AutoIdentity:      a.def.Service.Identity != nil,
+		Deprecated:        a.def.Service.Deprecated,
 		ActionMeta:        actionMeta,
 		VerificationHints: a.def.VerificationHints,
 		Variables:         variables,

--- a/pkg/clawvisor/defaults.go
+++ b/pkg/clawvisor/defaults.go
@@ -7,6 +7,7 @@ import (
 	cryptorand "crypto/rand"
 	"database/sql"
 	"encoding/hex"
+	"encoding/json"
 	"encoding/pem"
 	"fmt"
 	"log/slog"
@@ -21,6 +22,7 @@ import (
 
 	imessageadapter "github.com/clawvisor/clawvisor/internal/adapters/apple/imessage"
 	"github.com/clawvisor/clawvisor/internal/adapters/definitions"
+	mcpdefs "github.com/clawvisor/clawvisor/internal/adapters/definitions/mcp"
 	dropboxadapter "github.com/clawvisor/clawvisor/internal/adapters/dropbox"
 	contactsadapter "github.com/clawvisor/clawvisor/internal/adapters/google/contacts"
 	driveadapter "github.com/clawvisor/clawvisor/internal/adapters/google/drive"
@@ -48,6 +50,8 @@ import (
 
 	"github.com/clawvisor/clawvisor/internal/adaptergen"
 	"github.com/clawvisor/clawvisor/pkg/adapters"
+	"github.com/clawvisor/clawvisor/pkg/adapters/mcpadapter"
+	"github.com/clawvisor/clawvisor/pkg/adapters/mcpclient"
 	"github.com/clawvisor/clawvisor/pkg/adapters/yamldef"
 	"github.com/clawvisor/clawvisor/pkg/adapters/yamlloader"
 	"github.com/clawvisor/clawvisor/pkg/adapters/yamlruntime"
@@ -241,34 +245,99 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 	adapterReg.Register(imessageadapter.New())
 	adapterReg.Register(sqladapter.New())
 
-	// Cloud mode: set a resolver so the gateway can lazily load user-generated
-	// adapters from the DB on cache miss, scoped to the requesting user.
-	if cfg.Database.Driver == "postgres" {
-		adapterReg.SetResolver(func(ctx context.Context, serviceID, userID string) (adapters.Adapter, bool) {
-			rows, err := st.ListGeneratedAdapters(ctx, userID)
-			if err != nil {
-				logger.Warn("resolver: failed to list generated adapters", "user_id", userID, "err", err)
-				return nil, false
+	// MCP-driven adapters (config-only — the inverted architecture).
+	// Each *.mcp.yaml in internal/adapters/definitions/mcp/ becomes a service.
+	// The MCPAdapter handles tool discovery, execution, and identity (via the
+	// whoami hook); response sanitization happens generically in gateway middleware.
+	mcpAdapters, err := mcpadapter.LoadFromFS(mcpdefs.FS, ".")
+	if err != nil {
+		return nil, fmt.Errorf("loading MCP adapter specs: %w", err)
+	}
+	mcpByID := make(map[string]*mcpadapter.MCPAdapter, len(mcpAdapters))
+	for _, ma := range mcpAdapters {
+		// Wire the shared vault so OAuth-MCP adapters can read their
+		// system-level client_id / client_secret on demand. Same pattern
+		// YAMLAdapter uses via SetOAuthProvider.
+		ma.SetOAuthVault(v)
+		adapterReg.Register(ma)
+		mcpByID[ma.ServiceID()] = ma
+	}
+
+	// Resolver chain: MCP tool-cache lookup (any mode) + cloud-mode user
+	// generated YAML adapters. Called by Registry on per-user cache miss.
+	adapterReg.SetResolver(func(ctx context.Context, serviceID, userID string) (adapters.Adapter, bool) {
+		// MCP: look up the user's discovered tool list from the persistent
+		// store and clone the global MCPAdapter with it. This is the
+		// post-restart hydration path — the user activated some time ago,
+		// the in-memory cache was lost, and we lazily rebuild from the DB.
+		//
+		// Whoami-enabled services persist tools under the resolved alias
+		// (email, org name, etc.) rather than "default", so query
+		// service_meta first to find the actual alias(es) the user has
+		// activated and try each in turn. Falling back to "default"
+		// preserves behavior for services without a whoami hook.
+		if mcp, ok := mcpByID[serviceID]; ok {
+			aliases := []string{"default"}
+			if metas, err := st.ListServiceMetas(ctx, userID); err == nil {
+				aliases = aliases[:0]
+				for _, m := range metas {
+					if m.ServiceID == serviceID {
+						aliases = append(aliases, m.Alias)
+					}
+				}
+				if len(aliases) == 0 {
+					aliases = []string{"default"}
+				}
 			}
-			for _, row := range rows {
-				if row.ServiceID != serviceID {
+			for _, alias := range aliases {
+				toolsJSON, err := st.GetMCPTools(ctx, userID, serviceID, alias)
+				if err != nil {
 					continue
 				}
-				var def yamldef.ServiceDef
-				if err := yaml.Unmarshal([]byte(row.YAMLContent), &def); err != nil {
-					logger.Warn("resolver: bad YAML for generated adapter", "service_id", serviceID, "err", err)
-					return nil, false
+				var tools []mcpclient.Tool
+				if err := json.Unmarshal(toolsJSON, &tools); err != nil {
+					logger.Warn("resolver: bad mcp tools json", "service", serviceID, "user", userID, "alias", alias, "err", err)
+					continue
 				}
-				a, err := yamlruntime.New(def, nil)
-				if err != nil {
-					logger.Warn("resolver: failed to build adapter", "service_id", serviceID, "err", err)
-					return nil, false
-				}
-				return a, true
+				return mcp.ForUser(tools), true
 			}
 			return nil, false
-		})
-	}
+		}
+		// Cloud: user-generated YAML adapters.
+		if cfg.Database.Driver != "postgres" {
+			return nil, false
+		}
+		// AllForUser invokes the resolver for every global adapter on cache
+		// miss; for built-in services that's wasted work because generated
+		// adapters always have user-only service IDs. Short-circuit when
+		// the serviceID is in the global registry — only GetForUser calls
+		// on truly-unknown services should reach ListGeneratedAdapters.
+		if _, isGlobal := adapterReg.Get(serviceID); isGlobal {
+			return nil, false
+		}
+		rows, err := st.ListGeneratedAdapters(ctx, userID)
+		if err != nil {
+			logger.Warn("resolver: failed to list generated adapters", "user_id", userID, "err", err)
+			return nil, false
+		}
+		for _, row := range rows {
+			if row.ServiceID != serviceID {
+				continue
+			}
+			var def yamldef.ServiceDef
+			if err := yaml.Unmarshal([]byte(row.YAMLContent), &def); err != nil {
+				logger.Warn("resolver: bad YAML for generated adapter", "service_id", serviceID, "err", err)
+				return nil, false
+			}
+			a, err := yamlruntime.New(def, nil)
+			if err != nil {
+				logger.Warn("resolver: failed to build adapter", "service_id", serviceID, "err", err)
+				return nil, false
+			}
+			return a, true
+		}
+		return nil, false
+	})
 
 	// Initialize the display package with the adapter registry.
 	display.Init(adapterReg)

--- a/pkg/store/postgres/migrations/042_mcp_tool_caches.sql
+++ b/pkg/store/postgres/migrations/042_mcp_tool_caches.sql
@@ -1,0 +1,16 @@
+-- Per-user cache of tools discovered from MCP-backed services. Populated at
+-- service activation time so the catalog and gateway can answer "what actions
+-- does this user have available?" without spawning the MCP server subprocess.
+--
+-- Read on registry cache miss for an MCP service; the in-memory cache then
+-- absorbs subsequent reads for the rest of the process lifetime.
+CREATE TABLE IF NOT EXISTS mcp_tool_caches (
+    id         TEXT PRIMARY KEY,
+    user_id    TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    service_id TEXT NOT NULL,
+    alias      TEXT NOT NULL DEFAULT 'default',
+    tools      JSONB NOT NULL DEFAULT '[]'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(user_id, service_id, alias)
+);

--- a/pkg/store/postgres/store.go
+++ b/pkg/store/postgres/store.go
@@ -592,6 +592,48 @@ func (s *Store) DeleteServiceConfig(ctx context.Context, userID, serviceID, alia
 	return nil
 }
 
+// ── MCP Tool Caches ──────────────────────────────────────────────────────────
+
+func (s *Store) UpsertMCPTools(ctx context.Context, userID, serviceID, alias string, tools json.RawMessage) error {
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO mcp_tool_caches (id, user_id, service_id, alias, tools)
+		VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (user_id, service_id, alias) DO UPDATE SET
+			tools      = EXCLUDED.tools,
+			updated_at = NOW()
+	`, uuid.New().String(), userID, serviceID, alias, tools)
+	return err
+}
+
+func (s *Store) GetMCPTools(ctx context.Context, userID, serviceID, alias string) (json.RawMessage, error) {
+	var toolsJSON []byte
+	err := s.pool.QueryRow(ctx,
+		`SELECT tools FROM mcp_tool_caches WHERE user_id = $1 AND service_id = $2 AND alias = $3`,
+		userID, serviceID, alias,
+	).Scan(&toolsJSON)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, store.ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return json.RawMessage(toolsJSON), nil
+}
+
+func (s *Store) DeleteMCPTools(ctx context.Context, userID, serviceID, alias string) error {
+	res, err := s.pool.Exec(ctx,
+		`DELETE FROM mcp_tool_caches WHERE user_id = $1 AND service_id = $2 AND alias = $3`,
+		userID, serviceID, alias,
+	)
+	if err != nil {
+		return err
+	}
+	if res.RowsAffected() == 0 {
+		return store.ErrNotFound
+	}
+	return nil
+}
+
 // ── Notification Configs ──────────────────────────────────────────────────────
 
 func (s *Store) UpsertNotificationConfig(ctx context.Context, userID, channel string, config json.RawMessage) error {

--- a/pkg/store/sqlite/migrations/042_mcp_tool_caches.sql
+++ b/pkg/store/sqlite/migrations/042_mcp_tool_caches.sql
@@ -1,0 +1,17 @@
+-- Per-user cache of tools discovered from MCP-backed services. Populated at
+-- service activation time (when the user first supplies a credential) so the
+-- catalog and gateway can answer "what actions does this user have available?"
+-- without spawning the MCP server subprocess on every call.
+--
+-- Read on registry cache miss for an MCP service; the in-memory cache then
+-- absorbs subsequent reads for the rest of the process lifetime.
+CREATE TABLE IF NOT EXISTS mcp_tool_caches (
+    id         TEXT PRIMARY KEY,
+    user_id    TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    service_id TEXT NOT NULL,
+    alias      TEXT NOT NULL DEFAULT 'default',
+    tools      TEXT NOT NULL DEFAULT '[]',
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(user_id, service_id, alias)
+);

--- a/pkg/store/sqlite/store.go
+++ b/pkg/store/sqlite/store.go
@@ -687,6 +687,49 @@ func (s *Store) DeleteServiceConfig(ctx context.Context, userID, serviceID, alia
 	return nil
 }
 
+// ── MCP Tool Caches ──────────────────────────────────────────────────────────
+
+func (s *Store) UpsertMCPTools(ctx context.Context, userID, serviceID, alias string, tools json.RawMessage) error {
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO mcp_tool_caches (id, user_id, service_id, alias, tools)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT (user_id, service_id, alias) DO UPDATE SET
+			tools      = excluded.tools,
+			updated_at = CURRENT_TIMESTAMP
+	`, uuid.New().String(), userID, serviceID, alias, string(tools))
+	return err
+}
+
+func (s *Store) GetMCPTools(ctx context.Context, userID, serviceID, alias string) (json.RawMessage, error) {
+	var toolsStr string
+	err := s.db.QueryRowContext(ctx,
+		`SELECT tools FROM mcp_tool_caches WHERE user_id = ? AND service_id = ? AND alias = ?`,
+		userID, serviceID, alias,
+	).Scan(&toolsStr)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, store.ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return json.RawMessage(toolsStr), nil
+}
+
+func (s *Store) DeleteMCPTools(ctx context.Context, userID, serviceID, alias string) error {
+	res, err := s.db.ExecContext(ctx,
+		`DELETE FROM mcp_tool_caches WHERE user_id = ? AND service_id = ? AND alias = ?`,
+		userID, serviceID, alias,
+	)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return store.ErrNotFound
+	}
+	return nil
+}
+
 // ── Notification Configs ──────────────────────────────────────────────────────
 
 func (s *Store) UpsertNotificationConfig(ctx context.Context, userID, channel string, config json.RawMessage) error {

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -94,6 +94,13 @@ type Store interface {
 	GetServiceConfig(ctx context.Context, userID, serviceID, alias string) (*ServiceConfig, error)
 	DeleteServiceConfig(ctx context.Context, userID, serviceID, alias string) error
 
+	// MCP tool caches (per-user, populated at service activation; lazy-loaded
+	// by the registry resolver on cache miss). Tools are an opaque JSON blob
+	// — the store does not interpret them.
+	UpsertMCPTools(ctx context.Context, userID, serviceID, alias string, tools json.RawMessage) error
+	GetMCPTools(ctx context.Context, userID, serviceID, alias string) (json.RawMessage, error)
+	DeleteMCPTools(ctx context.Context, userID, serviceID, alias string) error
+
 	// Notification configs
 	UpsertNotificationConfig(ctx context.Context, userID, channel string, config json.RawMessage) error
 	GetNotificationConfig(ctx context.Context, userID, channel string) (*NotificationConfig, error)

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -291,6 +291,9 @@ export interface ServiceInfo {
   icon_url?: string
   alias?: string
   oauth: boolean
+  oauth_endpoint?: string
+  oauth_client_id_required?: boolean
+  deprecated?: boolean
   device_flow?: boolean
   pkce_flow?: boolean
   pkce_client_id_required?: boolean
@@ -1327,6 +1330,12 @@ export const api = {
       post<{ ok: boolean }>('/api/system/pkce-credentials', { service_id: serviceId, client_id: clientId }),
     deletePKCECredential: (serviceId: string) =>
       del<{ ok: boolean }>(`/api/system/pkce-credentials/${serviceId}`),
+    listMCPOAuthCredentials: () =>
+      get<{ service_id: string; client_id: string }[]>('/api/system/mcp-oauth'),
+    setMCPOAuthCredential: (serviceId: string, clientId: string, clientSecret: string) =>
+      post<{ ok: boolean }>('/api/system/mcp-oauth', { service_id: serviceId, client_id: clientId, client_secret: clientSecret }),
+    deleteMCPOAuthCredential: (serviceId: string) =>
+      del<{ ok: boolean }>(`/api/system/mcp-oauth/${serviceId}`),
   },
   features: {
     get: () => get<FeatureSet>('/api/features'),

--- a/web/src/lib/services.ts
+++ b/web/src/lib/services.ts
@@ -60,7 +60,13 @@ export function actionName(action: string, service?: string): string {
     const qualified = _actionNames[`${base}:${action}`]
     if (qualified) return qualified
   }
-  return _actionNames[action] ?? action.replace(/_/g, ' ')
+  if (_actionNames[action]) return _actionNames[action]
+  // Fallback: humanize the raw ID. Replace _ and - with spaces and
+  // sentence-case so "get_edge_function" → "Get edge function" for
+  // services that don't supply a display name in the catalog response.
+  const s = action.replace(/[_-]+/g, ' ').trim()
+  if (!s) return action
+  return s.charAt(0).toUpperCase() + s.slice(1)
 }
 
 export function formatServiceAction(service: string, action: string): string {

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -255,6 +255,11 @@ function OAuthCredentialsSection() {
     queryFn: () => api.system.listPKCECredentials(),
   })
 
+  const { data: mcpOAuthCredentials } = useQuery({
+    queryKey: ['mcp-oauth-credentials'],
+    queryFn: () => api.system.listMCPOAuthCredentials(),
+  })
+
   const { data: services } = useQuery({
     queryKey: ['services'],
     queryFn: () => api.services.list(),
@@ -308,6 +313,29 @@ function OAuthCredentialsSection() {
     onError: (err: Error) => setError(err.message),
   })
 
+  const mcpOAuthSaveMut = useMutation({
+    mutationFn: ({ serviceId, clientId, clientSecret }: { serviceId: string; clientId: string; clientSecret: string }) =>
+      api.system.setMCPOAuthCredential(serviceId, clientId, clientSecret),
+    onSuccess: () => {
+      setEditingService(null)
+      setClientIdValue('')
+      setClientSecretValue('')
+      setError(null)
+      qc.invalidateQueries({ queryKey: ['mcp-oauth-credentials'] })
+      qc.invalidateQueries({ queryKey: ['services'] })
+    },
+    onError: (err: Error) => setError(err.message),
+  })
+
+  const mcpOAuthDeleteMut = useMutation({
+    mutationFn: (serviceId: string) => api.system.deleteMCPOAuthCredential(serviceId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['mcp-oauth-credentials'] })
+      qc.invalidateQueries({ queryKey: ['services'] })
+    },
+    onError: (err: Error) => setError(err.message),
+  })
+
   const serviceList = services?.services
 
   // Check if any Google services exist
@@ -334,8 +362,32 @@ function OAuthCredentialsSection() {
     }
   }
 
+  // MCP-OAuth client credentials are an *advanced override* — dynamic
+  // registration (RFC 7591) handles client provisioning automatically for
+  // every MCP server we ship. We only surface a service here when:
+  //   - the admin has already pinned a client (shown for management), or
+  //   - the catalog reports oauth_client_id_required (half-configured override).
+  // This keeps the settings UI quiet under normal flows and only appears
+  // when there's something the admin actually needs to do.
+  const mcpOAuthCredMap = new Map<string, string>()
+  if (mcpOAuthCredentials) {
+    for (const c of mcpOAuthCredentials) {
+      mcpOAuthCredMap.set(c.service_id, c.client_id)
+    }
+  }
+  const mcpOAuthServices = new Map<string, string>()
+  if (serviceList) {
+    for (const svc of serviceList) {
+      if (!svc.oauth_endpoint || !svc.oauth_endpoint.startsWith('mcp:')) continue
+      const needsAttention = svc.oauth_client_id_required || mcpOAuthCredMap.has(svc.id)
+      if (needsAttention && !mcpOAuthServices.has(svc.id)) {
+        mcpOAuthServices.set(svc.id, svc.name)
+      }
+    }
+  }
+
   // Nothing to show if no OAuth services exist
-  if (!hasGoogle && !hasMicrosoft && pkceServices.size === 0) return null
+  if (!hasGoogle && !hasMicrosoft && pkceServices.size === 0 && mcpOAuthServices.size === 0) return null
 
   function startEditing(serviceId: string, currentClientId?: string) {
     setEditingService(serviceId)
@@ -584,6 +636,103 @@ function OAuthCredentialsSection() {
                       className="px-3 py-1 text-xs rounded bg-brand text-surface-0 hover:bg-brand-strong disabled:opacity-50"
                     >
                       {pkceSaveMut.isPending ? 'Saving…' : 'Save'}
+                    </button>
+                    <button
+                      onClick={() => { setEditingService(null); setError(null) }}
+                      className="text-xs text-text-tertiary hover:text-text-primary"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+          )
+        })}
+
+        {/* MCP-OAuth services (client ID + secret) */}
+        {Array.from(mcpOAuthServices.entries()).map(([serviceId, serviceName]) => {
+          const configured = mcpOAuthCredMap.get(serviceId)
+          const isEditing = editingService === serviceId
+
+          return (
+            <div
+              key={serviceId}
+              className="bg-surface-1 border border-border-default rounded-md p-4"
+            >
+              <div className="flex items-center justify-between">
+                <div>
+                  <span className="text-sm font-medium text-text-primary">{serviceName}</span>
+                  <span className="text-xs text-text-tertiary ml-2">{serviceId}</span>
+                </div>
+                {!isEditing && (
+                  <div className="flex items-center gap-2">
+                    {configured ? (
+                      <>
+                        <span className="text-xs text-success">Configured</span>
+                        <button
+                          onClick={() => startEditing(serviceId, configured)}
+                          className="text-xs text-text-tertiary hover:text-text-primary"
+                        >
+                          Edit
+                        </button>
+                        <button
+                          onClick={() => mcpOAuthDeleteMut.mutate(serviceId)}
+                          disabled={mcpOAuthDeleteMut.isPending}
+                          className="text-xs text-danger/70 hover:text-danger"
+                        >
+                          Remove
+                        </button>
+                      </>
+                    ) : (
+                      <button
+                        onClick={() => startEditing(serviceId)}
+                        className="text-xs px-2.5 py-1 rounded border border-brand/30 text-brand hover:bg-brand/10"
+                      >
+                        Configure
+                      </button>
+                    )}
+                  </div>
+                )}
+              </div>
+
+              {isEditing && (
+                <div className="mt-3 space-y-2">
+                  <input
+                    type="text"
+                    value={clientIdValue}
+                    onChange={e => { setClientIdValue(e.target.value); setError(null) }}
+                    placeholder="OAuth Client ID"
+                    className={`${inputClass} font-mono`}
+                    autoFocus
+                  />
+                  <input
+                    type="password"
+                    value={clientSecretValue}
+                    onChange={e => { setClientSecretValue(e.target.value); setError(null) }}
+                    onKeyDown={e => {
+                      if (e.key === 'Enter' && clientIdValue.trim() && clientSecretValue.trim()) {
+                        mcpOAuthSaveMut.mutate({
+                          serviceId,
+                          clientId: clientIdValue.trim(),
+                          clientSecret: clientSecretValue.trim(),
+                        })
+                      }
+                    }}
+                    placeholder="OAuth Client Secret"
+                    className={`${inputClass} font-mono`}
+                  />
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={() => mcpOAuthSaveMut.mutate({
+                        serviceId,
+                        clientId: clientIdValue.trim(),
+                        clientSecret: clientSecretValue.trim(),
+                      })}
+                      disabled={mcpOAuthSaveMut.isPending || !clientIdValue.trim() || !clientSecretValue.trim()}
+                      className="px-3 py-1 text-xs rounded bg-brand text-surface-0 hover:bg-brand-strong disabled:opacity-50"
+                    >
+                      {mcpOAuthSaveMut.isPending ? 'Saving…' : 'Save'}
                     </button>
                     <button
                       onClick={() => { setEditingService(null); setError(null) }}


### PR DESCRIPTION
## Summary

- Generic `MCPAdapter` turns any RFC 9728 / RFC 8414 / RFC 7591 compliant MCP server into a Clawvisor integration via a small YAML spec; ships `notion` and `supabase` as the first two adapters, with the legacy Notion REST adapter preserved as deprecated for backward compatibility.
- Activation runs RFC 8414 discovery and RFC 7591 dynamic client registration, caches the result in a new `mcp_tool_caches` store, then discovers tools and registers a per-user adapter clone; restart hydration is lazy via the registry resolver and respects the user's whoami-resolved alias.
- HTTP transport speaks streamable MCP including SSE responses; OAuth flow reuses the existing authorize/callback handlers with refresh-token rotation via `oauth2.TokenSource`; activation rolls back vault and `service_meta` when tool discovery fails so a connected service never exposes zero actions.
- Catalog renderer applies the spec's 2 KB-per-server budget with a first-sentence summary, surfaces conditional-required hints, and exposes per-tool detail at `?service=<id>&action=<name>`; gateway middleware sanitizes MCP responses generically (HTML strip, truncation, secret redaction).
- Settings page gains an advanced "MCP OAuth client credentials" section as an admin override path; dynamic registration handles the common case so the section stays empty for most deployments.

## Test plan

- [ ] `go test ./...` passes locally (only `TestLive_AnthropicPromptCaching` fails, a pre-existing flake against the Anthropic API).
- [ ] Connect Notion from a fresh user: OAuth flow completes, `notion-get-users` resolves alias to email, catalog populates with discovered tools.
- [ ] Connect Supabase from a fresh user: cross-domain auth server discovery works, alias resolves from `list_organizations`, catalog populates.
- [ ] Existing Notion (legacy) users remain functional and see "Notion (Legacy)" in the catalog; new "Notion" entry is offered for migration.
- [ ] Restart the server with an existing connection — catalog still shows discovered tools without re-OAuth.
- [ ] Deactivate Notion → reactivate; alias rename — both flows clean up `mcp_tool_caches` correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)