### PR TITLE
chore(security): address Oneleet SARIF findings

### DIFF
--- a/internal/adapters/apple/imessage/adapter.go
+++ b/internal/adapters/apple/imessage/adapter.go
@@ -368,6 +368,11 @@ func (a *IMessageAdapter) downloadHelper(installDir string) (string, error) {
 	return filepath.Join(destApp, helperRelBinary), nil
 }
 
+// maxArchiveFileSize caps any single file extracted from the helper bundle to
+// guard against decompression bombs. The signed helper is a small macOS app
+// (well under 100 MiB total), so 256 MiB per entry leaves plenty of headroom.
+const maxArchiveFileSize = 256 << 20
+
 // extractTarGz extracts a gzipped tar archive into destDir.
 func extractTarGz(r io.Reader, destDir string) error {
 	gz, err := gzip.NewReader(r)
@@ -416,9 +421,14 @@ func extractTarGz(r io.Reader, destDir string) error {
 			if err != nil {
 				return err
 			}
-			if _, err := io.Copy(f, tr); err != nil {
+			n, err := io.CopyN(f, tr, maxArchiveFileSize+1)
+			if err != nil && err != io.EOF {
 				f.Close()
 				return err
+			}
+			if n > maxArchiveFileSize {
+				f.Close()
+				return fmt.Errorf("imessage: tar entry %q exceeds max file size %d", hdr.Name, maxArchiveFileSize)
 			}
 			f.Close()
 		}

--- a/internal/daemon/oauth_listener.go
+++ b/internal/daemon/oauth_listener.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/http"
 	"sync"
+	"time"
 )
 
 // startOAuthListener starts a one-shot HTTP server on a random localhost port.
@@ -32,7 +33,7 @@ func startOAuthListener() (port int, done chan struct{}, cleanup func()) {
 	}
 
 	port = ln.Addr().(*net.TCPAddr).Port
-	srv := &http.Server{Handler: mux}
+	srv := &http.Server{Handler: mux, ReadHeaderTimeout: 10 * time.Second}
 
 	go func() { _ = srv.Serve(ln) }()
 

--- a/internal/local/remoteinstall/manager.go
+++ b/internal/local/remoteinstall/manager.go
@@ -477,6 +477,11 @@ func validateServicePayload(payloadPath, serviceID string, defaultTimeout time.D
 	return nil
 }
 
+// maxArchiveFileSize caps any single file extracted from a service bundle to
+// guard against decompression bombs. Bundles are signed release artifacts, so
+// 1 GiB per entry leaves room for chunky payloads while still bounding RAM/disk.
+const maxArchiveFileSize = 1 << 30
+
 func extractTarGz(src, dest string) ([]string, error) {
 	f, err := os.Open(src)
 	if err != nil {
@@ -523,9 +528,14 @@ func extractTarGz(src, dest string) ([]string, error) {
 			if err != nil {
 				return nil, err
 			}
-			if _, err := io.Copy(out, tr); err != nil {
+			n, err := io.CopyN(out, tr, maxArchiveFileSize+1)
+			if err != nil && err != io.EOF {
 				out.Close()
 				return nil, err
+			}
+			if n > maxArchiveFileSize {
+				out.Close()
+				return nil, fmt.Errorf("archive entry %q exceeds max file size %d", hdr.Name, maxArchiveFileSize)
 			}
 			if err := out.Close(); err != nil {
 				return nil, err

--- a/internal/tui/screens/services.go
+++ b/internal/tui/screens/services.go
@@ -1242,7 +1242,7 @@ func startOAuthListener() (port int, done chan struct{}, cleanup func()) {
 	}
 
 	port = ln.Addr().(*net.TCPAddr).Port
-	srv := &http.Server{Handler: mux}
+	srv := &http.Server{Handler: mux, ReadHeaderTimeout: 10 * time.Second}
 
 	go func() { _ = srv.Serve(ln) }()
 

--- a/web/.npmrc
+++ b/web/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true


### PR DESCRIPTION
## Summary
Address actionable findings from the Oneleet SARIF scan. The remaining ~145 findings were triaged as false positives (test fixtures, internal config paths, parameterized SQL, intentional InsecureSkipVerify in the e2e harness, etc.) and are best suppressed in Oneleet rather than the code.

- **web/.npmrc**: \`ignore-scripts=true\` blocks npm lifecycle scripts on install (Oneleet npm.no-ignore-scripts).
- **daemon/tui OAuth listeners**: set \`ReadHeaderTimeout: 10s\` on the localhost \`http.Server\` constructions (gosec G112).
- **imessage helper + service-bundle extractors**: switch \`io.Copy\` to bounded \`io.CopyN\` and error if a tar entry exceeds the cap (256 MiB helper, 1 GiB service bundle) to guard against decompression bombs (gosec G110).

## Test plan
- [x] \`go build ./...\`
- [x] \`go test ./internal/daemon/... ./internal/tui/... ./internal/adapters/apple/imessage/... ./internal/local/remoteinstall/...\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)