### PR TITLE
fix(server): use PublicURL for magic link when set

### DIFF
--- a/internal/server/run.go
+++ b/internal/server/run.go
@@ -78,6 +78,9 @@ func SetupLocalAuth(opts *clawvisor.ServerOptions, logger *slog.Logger) (*LocalA
 		displayHost = "localhost"
 	}
 	serverURL := fmt.Sprintf("http://%s:%d", displayHost, cfg.Server.Port)
+	if cfg.Server.PublicURL != "" {
+		serverURL = cfg.Server.PublicURL
+	}
 
 	token, err := ms.Generate(localUser.ID)
 	if err != nil {


### PR DESCRIPTION

## Summary

When running `scripts/dev.sh`, the magic link printed in the terminal showed the backend port (a random free port like `54957`) instead of the Vite frontend port (`25297`). Opening the printed link would hit the backend directly instead of going through Vite, causing "link expired or already used" errors.

## Root Cause

`dev.sh` sets `PUBLIC_URL=http://localhost:25297` when starting the backend, which gets loaded into `cfg.Server.PublicURL`. But `SetupLocalAuth` in `internal/server/run.go` always built `serverURL` from `cfg.Server.Port` (the backend port), ignoring `PublicURL` entirely.

## Fix

```go
// before
serverURL := fmt.Sprintf("http://%s:%d", displayHost, cfg.Server.Port)

// after
serverURL := fmt.Sprintf("http://%s:%d", displayHost, cfg.Server.Port)
if cfg.Server.PublicURL != "" {
    serverURL = cfg.Server.PublicURL
}
```

When `PUBLIC_URL` is set (as `dev.sh` does), use it for the magic link and TUI session URL. Falls back to the old behavior when `PUBLIC_URL` is not set.

## Testing

Ran `bash scripts/dev.sh` before and after - magic link now correctly shows `http://localhost:25297/magic-link?token=...` instead of the random backend port.
##Before
<img width="944" height="629" alt="image" src="https://github.com/user-attachments/assets/635f3e0d-de43-4458-8492-304c171ceead" />

## After
<img width="1323" height="653" alt="image" src="https://github.com/user-attachments/assets/f56898f4-63b4-4b39-a6a6-441375d97e90" />

## Files Changed

| File | Change |
|------|--------|
| `internal/server/run.go` | Use `cfg.Server.PublicURL` for magic link when set |
