### PR TITLE
chore(security): tighten proxy CA data dir to 0o700

### DIFF
--- a/pkg/runtime/proxy/ca.go
+++ b/pkg/runtime/proxy/ca.go
@@ -54,7 +54,10 @@ func GenerateCA(dataDir string) (*x509.Certificate, *ecdsa.PrivateKey, error) {
 		return nil, nil, fmt.Errorf("parse CA certificate: %w", err)
 	}
 
-	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+	// 0o700: dataDir holds the proxy CA's EC private key. The key file itself
+	// is 0o600, but tightening the parent dir prevents enumeration on shared
+	// hosts and matches conventional permissions for key-material directories.
+	if err := os.MkdirAll(dataDir, 0o700); err != nil {
 		return nil, nil, fmt.Errorf("create data dir: %w", err)
 	}
 


### PR DESCRIPTION
## Summary
The proxy CA data directory holds an EC private key. The key file is already \`0o600\`, but tightening the parent dir to \`0o700\` is defense-in-depth — it prevents enumeration on shared hosts and matches conventional permissions for key-material directories. Closes the one gosec G301 finding worth acting on; the rest of the G301 batch were false positives (public binaries, plist/systemd unit dirs, log dirs).

## Test plan
- [x] \`go build ./...\`
- [x] \`go test ./pkg/runtime/proxy/...\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)