### PR TITLE
fix(tui): auto-detect local server from .local-session

### DIFF
--- a/cmd/clawvisor/cmd_tui.go
+++ b/cmd/clawvisor/cmd_tui.go
@@ -187,23 +187,24 @@ func resolveAuth() (serverURL, token string) {
 
 	// Config file as last resort.
 	if serverURL == "" || token == "" {
-		cfgPath, err := tuiconfig.DefaultPath()
-		if err != nil {
-			return
+		if cfgPath, err := tuiconfig.DefaultPath(); err == nil {
+			if cfg, err := tuiconfig.Load(cfgPath); err == nil {
+				if profile, err := cfg.Active(); err == nil {
+					if serverURL == "" {
+						serverURL = profile.ServerURL
+					}
+					if token == "" {
+						token = profile.Token
+					}
+				}
+			}
 		}
-		cfg, err := tuiconfig.Load(cfgPath)
-		if err != nil {
-			return
-		}
-		profile, err := cfg.Active()
-		if err != nil {
-			return
-		}
-		if serverURL == "" {
-			serverURL = profile.ServerURL
-		}
-		if token == "" {
-			token = profile.Token
+	}
+
+	// Fall back to .local-session
+	if serverURL == "" {
+		if sess, err := readLocalSession(); err == nil {
+			serverURL = sess.ServerURL
 		}
 	}
 


### PR DESCRIPTION

## Summary

`make tui` failed with "no server URL configured" on a fresh setup even when the local server was running. This PR wires the TUI to auto-detect the local server from `~/.clawvisor/.local-session` so it works out of the box.

## Root Cause

`resolveAuth()` checked flags → env vars → `tui.yaml` for the server URL. On a first run, none of these exist. The early `return` statements inside the `tui.yaml` loading block meant the function exited before reaching any fallback - even though `~/.clawvisor/.local-session` (written by the server on every startup) had exactly the URL needed.

## Fix

Two changes in `resolveAuth()`:

**1. Restructured config block to not return early on failure**

The original `return` statements on config load errors bypassed any fallback. Changed to nested `if err == nil` so failures skip the block and fall through instead of exiting the function.

**2. Added `.local-session` fallback**

```go
if serverURL == "" {
    if sess, err := readLocalSession(); err == nil {
        serverURL = sess.ServerURL
    }
}
```

If `serverURL` is still empty after flags/env/config, read it from `.local-session`. The server already writes this file on every startup - no new infrastructure needed.

## Behavior

- **Before:** `make tui` - "no server URL configured" unless `tui.yaml` already existed
- **After:** `make tui` - TUI launches automatically when local server is running

Existing users with `tui.yaml` configured are unaffected - the fallback only runs when `serverURL` is still empty.

## Note on cloud support

Wiring the TUI to a cloud Clawvisor instance is out of scope for this PR - that would need a separate auth flow. @ericlevine happy to follow up if there's a preferred approach.

## Testing

Ran `bash scripts/dev.sh` in one terminal, `make tui` in another - TUI launched and connected without any config.
<img width="1038" height="654" alt="image" src="https://github.com/user-attachments/assets/d8a3c919-3429-41cc-9774-8e1e076fcdd7" />


## Files Changed

| File | Change |
|------|--------|
| `cmd/clawvisor/cmd_tui.go` | Restructured config block, added `.local-session` fallback in `resolveAuth()` |
