### PR TITLE
llmproxy: simplify inline approval flow and align tool scopes

### DIFF
--- a/internal/api/handlers/llm_endpoint.go
+++ b/internal/api/handlers/llm_endpoint.go
@@ -381,7 +381,7 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 	}
 	reqSummary := liteProxyRequestDebugSummary(provider, body)
 	if h.ControlBaseURL != "" && shouldInjectLiteControlNotice(r.URL.Path, reqSummary) {
-		injectedBody, injected, injectErr := llmproxy.InjectControlNotice(provider, body, h.ControlBaseURL)
+		injectedBody, injected, injectErr := llmproxy.InjectControlNotice(provider, body, h.ControlBaseURL, reqSummary.AvailableTools)
 		if injectErr != nil {
 			auditStatus = http.StatusBadRequest
 			auditDecide = "deny"

--- a/internal/api/handlers/llm_endpoint_test.go
+++ b/internal/api/handlers/llm_endpoint_test.go
@@ -221,9 +221,9 @@ func TestLLMEndpoint_InjectsControlNoticeWhenToolsAvailable(t *testing.T) {
 		"VAULT PLACEHOLDERS",
 		"autovault_",
 		"NOT raw credentials",
-		// Steer model to Bash+curl (Claude Code's WebFetch can't carry
+		// Steer model to the actual shell tool + curl (Claude Code's WebFetch can't carry
 		// the headers/body the control plane needs).
-		"Bash with curl",
+		"`Bash` with curl",
 		// Don't-leak-the-daemon-URL rule. The notice now phrases this as
 		// "NEVER call http://localhost:<port>" and "Always use the
 		// synthetic host" — match on the stable canonical-URL fragment.

--- a/internal/runtime/llmproxy/approval_body_editor.go
+++ b/internal/runtime/llmproxy/approval_body_editor.go
@@ -1,0 +1,77 @@
+package llmproxy
+
+import (
+	"net/http"
+
+	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+)
+
+type approvalBodyEditor interface {
+	LatestApprovalReply() (verb, approvalID string, ok bool)
+	ReplaceLatestUserText(expectedVerb, replacement string) ([]byte, bool, error)
+}
+
+func newApprovalBodyEditor(req *http.Request, provider conversation.Provider, body []byte) (approvalBodyEditor, bool) {
+	switch provider {
+	case conversation.ProviderAnthropic:
+		return anthropicApprovalBodyEditor{body: body}, true
+	case conversation.ProviderOpenAI:
+		if conversation.IsOpenAIChatCompletionsEndpoint(req) {
+			return openAIChatApprovalBodyEditor{body: body}, true
+		}
+		return openAIResponsesApprovalBodyEditor{body: body}, true
+	default:
+		return nil, false
+	}
+}
+
+func approvalReplyFromBody(req *http.Request, provider conversation.Provider, body []byte) (verb, approvalID string) {
+	editor, ok := newApprovalBodyEditor(req, provider, body)
+	if !ok {
+		return "", ""
+	}
+	verb, approvalID, ok = editor.LatestApprovalReply()
+	if !ok {
+		return "", ""
+	}
+	return verb, approvalID
+}
+
+type anthropicApprovalBodyEditor struct {
+	body []byte
+}
+
+func (e anthropicApprovalBodyEditor) LatestApprovalReply() (string, string, bool) {
+	verb, approvalID := conversation.AnthropicApprovalReply(e.body)
+	return verb, approvalID, verb != ""
+}
+
+func (e anthropicApprovalBodyEditor) ReplaceLatestUserText(expectedVerb, replacement string) ([]byte, bool, error) {
+	return replaceAnthropicApprovalReply(e.body, expectedVerb, replacement)
+}
+
+type openAIChatApprovalBodyEditor struct {
+	body []byte
+}
+
+func (e openAIChatApprovalBodyEditor) LatestApprovalReply() (string, string, bool) {
+	verb, approvalID := conversation.OpenAIApprovalReply(e.body)
+	return verb, approvalID, verb != ""
+}
+
+func (e openAIChatApprovalBodyEditor) ReplaceLatestUserText(expectedVerb, replacement string) ([]byte, bool, error) {
+	return replaceOpenAIChatApprovalReply(e.body, expectedVerb, replacement)
+}
+
+type openAIResponsesApprovalBodyEditor struct {
+	body []byte
+}
+
+func (e openAIResponsesApprovalBodyEditor) LatestApprovalReply() (string, string, bool) {
+	verb, approvalID := conversation.OpenAIApprovalReply(e.body)
+	return verb, approvalID, verb != ""
+}
+
+func (e openAIResponsesApprovalBodyEditor) ReplaceLatestUserText(expectedVerb, replacement string) ([]byte, bool, error) {
+	return replaceOpenAIResponsesApprovalReply(e.body, expectedVerb, replacement)
+}

--- a/internal/runtime/llmproxy/approval_body_editor.go
+++ b/internal/runtime/llmproxy/approval_body_editor.go
@@ -1,7 +1,9 @@
 package llmproxy
 
 import (
+	"encoding/json"
 	"net/http"
+	"strings"
 
 	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
 )
@@ -9,6 +11,7 @@ import (
 type approvalBodyEditor interface {
 	LatestApprovalReply() (verb, approvalID string, ok bool)
 	ReplaceLatestUserText(expectedVerb, replacement string) ([]byte, bool, error)
+	AugmentInlineApprovalHistory(outcomes InlineApprovalOutcomeStore, userID, agentID string) ([]byte, bool, error)
 }
 
 func newApprovalBodyEditor(req *http.Request, provider conversation.Provider, body []byte) (approvalBodyEditor, bool) {
@@ -25,18 +28,6 @@ func newApprovalBodyEditor(req *http.Request, provider conversation.Provider, bo
 	}
 }
 
-func approvalReplyFromBody(req *http.Request, provider conversation.Provider, body []byte) (verb, approvalID string) {
-	editor, ok := newApprovalBodyEditor(req, provider, body)
-	if !ok {
-		return "", ""
-	}
-	verb, approvalID, ok = editor.LatestApprovalReply()
-	if !ok {
-		return "", ""
-	}
-	return verb, approvalID
-}
-
 type anthropicApprovalBodyEditor struct {
 	body []byte
 }
@@ -48,6 +39,10 @@ func (e anthropicApprovalBodyEditor) LatestApprovalReply() (string, string, bool
 
 func (e anthropicApprovalBodyEditor) ReplaceLatestUserText(expectedVerb, replacement string) ([]byte, bool, error) {
 	return replaceAnthropicApprovalReply(e.body, expectedVerb, replacement)
+}
+
+func (e anthropicApprovalBodyEditor) AugmentInlineApprovalHistory(outcomes InlineApprovalOutcomeStore, userID, agentID string) ([]byte, bool, error) {
+	return augmentAnthropicApprovedInlineTasks(e.body, outcomes, userID, agentID)
 }
 
 type openAIChatApprovalBodyEditor struct {
@@ -63,15 +58,365 @@ func (e openAIChatApprovalBodyEditor) ReplaceLatestUserText(expectedVerb, replac
 	return replaceOpenAIChatApprovalReply(e.body, expectedVerb, replacement)
 }
 
+func (e openAIChatApprovalBodyEditor) AugmentInlineApprovalHistory(_ InlineApprovalOutcomeStore, _, _ string) ([]byte, bool, error) {
+	return e.body, false, nil
+}
+
 type openAIResponsesApprovalBodyEditor struct {
 	body []byte
 }
 
 func (e openAIResponsesApprovalBodyEditor) LatestApprovalReply() (string, string, bool) {
+	var req struct {
+		Input json.RawMessage `json:"input"`
+	}
+	if err := json.Unmarshal(e.body, &req); err == nil && len(req.Input) > 0 {
+		var input string
+		if err := json.Unmarshal(req.Input, &input); err == nil {
+			verb, approvalID := conversation.ParseApprovalReplyText(input)
+			return verb, approvalID, verb != ""
+		}
+	}
 	verb, approvalID := conversation.OpenAIApprovalReply(e.body)
 	return verb, approvalID, verb != ""
 }
 
 func (e openAIResponsesApprovalBodyEditor) ReplaceLatestUserText(expectedVerb, replacement string) ([]byte, bool, error) {
 	return replaceOpenAIResponsesApprovalReply(e.body, expectedVerb, replacement)
+}
+
+func (e openAIResponsesApprovalBodyEditor) AugmentInlineApprovalHistory(_ InlineApprovalOutcomeStore, _, _ string) ([]byte, bool, error) {
+	return e.body, false, nil
+}
+
+func replaceAnthropicApprovalReply(body []byte, expectedVerb, replacement string) ([]byte, bool, error) {
+	var req struct {
+		Messages []struct {
+			Role    string          `json:"role"`
+			Content json.RawMessage `json:"content"`
+		} `json:"messages"`
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, false, err
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, false, err
+	}
+	for i := len(req.Messages) - 1; i >= 0; i-- {
+		if req.Messages[i].Role != "user" {
+			continue
+		}
+		verb, _ := conversation.ParseApprovalReplyText(flattenAnthropicTaskReplyText(req.Messages[i].Content))
+		if verb != expectedVerb {
+			return body, false, nil
+		}
+		encoded, _ := json.Marshal(replacement)
+		req.Messages[i].Content = encoded
+		messages, err := json.Marshal(req.Messages)
+		if err != nil {
+			return nil, false, err
+		}
+		raw["messages"] = messages
+		out, err := json.Marshal(raw)
+		return out, err == nil, err
+	}
+	return body, false, nil
+}
+
+func replaceOpenAIChatApprovalReply(body []byte, expectedVerb, replacement string) ([]byte, bool, error) {
+	var req struct {
+		Messages []map[string]any `json:"messages"`
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, false, err
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, false, err
+	}
+	for i := len(req.Messages) - 1; i >= 0; i-- {
+		role, _ := req.Messages[i]["role"].(string)
+		if role != "user" {
+			continue
+		}
+		contentRaw, _ := json.Marshal(req.Messages[i]["content"])
+		verb, _ := conversation.ParseApprovalReplyText(flattenOpenAITaskReplyContent(contentRaw))
+		if verb != expectedVerb {
+			return body, false, nil
+		}
+		req.Messages[i]["content"] = replacement
+		messages, err := json.Marshal(req.Messages)
+		if err != nil {
+			return nil, false, err
+		}
+		raw["messages"] = messages
+		out, err := json.Marshal(raw)
+		return out, err == nil, err
+	}
+	return body, false, nil
+}
+
+func replaceOpenAIResponsesApprovalReply(body []byte, expectedVerb, replacement string) ([]byte, bool, error) {
+	var req struct {
+		Input json.RawMessage `json:"input"`
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, false, err
+	}
+	if err := json.Unmarshal(body, &req); err != nil || len(req.Input) == 0 {
+		return body, false, err
+	}
+	var inputString string
+	if err := json.Unmarshal(req.Input, &inputString); err == nil {
+		verb, _ := conversation.ParseApprovalReplyText(inputString)
+		if verb != expectedVerb {
+			return body, false, nil
+		}
+		encoded, _ := json.Marshal(replacement)
+		raw["input"] = encoded
+		out, err := json.Marshal(raw)
+		return out, err == nil, err
+	}
+	var items []map[string]any
+	if err := json.Unmarshal(req.Input, &items); err != nil {
+		return body, false, nil
+	}
+	for i := len(items) - 1; i >= 0; i-- {
+		typ, _ := items[i]["type"].(string)
+		role, _ := items[i]["role"].(string)
+		if typ != "message" || role != "user" {
+			continue
+		}
+		contentRaw, _ := json.Marshal(items[i]["content"])
+		verb, _ := conversation.ParseApprovalReplyText(flattenOpenAITaskReplyContent(contentRaw))
+		if verb != expectedVerb {
+			return body, false, nil
+		}
+		items[i]["content"] = []map[string]any{{"type": "input_text", "text": replacement}}
+		input, err := json.Marshal(items)
+		if err != nil {
+			return nil, false, err
+		}
+		raw["input"] = input
+		out, err := json.Marshal(raw)
+		return out, err == nil, err
+	}
+	return body, false, nil
+}
+
+func augmentAnthropicApprovedInlineTasks(body []byte, outcomes InlineApprovalOutcomeStore, userID, agentID string) ([]byte, bool, error) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return body, false, err
+	}
+	rawMessages, ok := raw["messages"]
+	if !ok {
+		return body, false, nil
+	}
+	var messages []map[string]json.RawMessage
+	if err := json.Unmarshal(rawMessages, &messages); err != nil {
+		return body, false, err
+	}
+
+	changed := false
+
+	for i := 1; i < len(messages); i++ {
+		var role string
+		if err := json.Unmarshal(messages[i]["role"], &role); err != nil || role != "user" {
+			continue
+		}
+		userText := flattenAnthropicTaskReplyText(messages[i]["content"])
+		verb, _ := conversation.ParseApprovalReplyText(userText)
+		if verb != "approve" {
+			continue
+		}
+		if strings.Contains(userText, InlineApprovalAugmentationMarker) {
+			continue
+		}
+
+		var priorRole string
+		if err := json.Unmarshal(messages[i-1]["role"], &priorRole); err != nil || priorRole != "assistant" {
+			continue
+		}
+		priorText := flattenAnthropicTaskReplyText(messages[i-1]["content"])
+		if !strings.Contains(priorText, InlineApprovalSubstitutedPromptMarker) {
+			continue
+		}
+
+		approvalID := extractApprovalIDFromPrompt(priorText)
+		note, ok := augmentationContextForOutcome(InlineApprovalOutcomeKey{
+			UserID:     userID,
+			AgentID:    agentID,
+			ApprovalID: approvalID,
+		}, outcomes)
+		if !ok {
+			continue
+		}
+
+		updated, ok := augmentUserContent(messages[i]["content"], verb, note)
+		if !ok {
+			continue
+		}
+		messages[i]["content"] = updated
+		changed = true
+	}
+
+	if !changed {
+		return body, false, nil
+	}
+	updatedMessages, err := json.Marshal(messages)
+	if err != nil {
+		return body, false, err
+	}
+	raw["messages"] = updatedMessages
+	out, err := json.Marshal(raw)
+	if err != nil {
+		return body, false, err
+	}
+	return out, true, nil
+}
+
+func augmentUserContent(content json.RawMessage, _ string, note string) (json.RawMessage, bool) {
+	if len(content) == 0 {
+		encoded, err := json.Marshal(note)
+		return encoded, err == nil
+	}
+	var s string
+	if err := json.Unmarshal(content, &s); err == nil {
+		encoded, marshalErr := json.Marshal(note)
+		return encoded, marshalErr == nil
+	}
+	var blocks []map[string]json.RawMessage
+	if err := json.Unmarshal(content, &blocks); err != nil {
+		return nil, false
+	}
+	spliceAt := -1
+	for i, blk := range blocks {
+		var t string
+		if err := json.Unmarshal(blk["type"], &t); err != nil {
+			continue
+		}
+		if t != "text" {
+			continue
+		}
+		var text string
+		if err := json.Unmarshal(blk["text"], &text); err != nil {
+			continue
+		}
+		if v, _ := conversation.ParseApprovalReplyText(text); v == "" {
+			continue
+		}
+		if spliceAt < 0 {
+			spliceAt = i
+		}
+		stripped := stripBareApprovalLines(text)
+		encoded, err := json.Marshal(stripped)
+		if err != nil {
+			return nil, false
+		}
+		blocks[i]["text"] = encoded
+	}
+	if spliceAt < 0 {
+		return nil, false
+	}
+	var spliceText string
+	_ = json.Unmarshal(blocks[spliceAt]["text"], &spliceText)
+	newSpliceText := note
+	if spliceText != "" {
+		newSpliceText = spliceText + "\n\n" + note
+	}
+	encoded, err := json.Marshal(newSpliceText)
+	if err != nil {
+		return nil, false
+	}
+	blocks[spliceAt]["text"] = encoded
+
+	kept := blocks[:0]
+	for _, blk := range blocks {
+		var t string
+		if err := json.Unmarshal(blk["type"], &t); err == nil && t == "text" {
+			var bt string
+			if err := json.Unmarshal(blk["text"], &bt); err == nil && bt == "" {
+				continue
+			}
+		}
+		kept = append(kept, blk)
+	}
+
+	out, err := json.Marshal(kept)
+	if err != nil {
+		return nil, false
+	}
+	return out, true
+}
+
+func stripBareApprovalLines(text string) string {
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	lines := strings.Split(text, "\n")
+	kept := make([]string, 0, len(lines))
+	for _, line := range lines {
+		probe := strings.TrimSpace(line)
+		if probe == "" {
+			kept = append(kept, line)
+			continue
+		}
+		if verb, _ := conversation.ParseApprovalReplyText(probe); verb != "" {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	return strings.TrimSpace(strings.Join(kept, "\n"))
+}
+
+func flattenAnthropicTaskReplyText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var simple string
+	if err := json.Unmarshal(raw, &simple); err == nil {
+		return simple
+	}
+	var blocks []struct {
+		Type string `json:"type"`
+		Text string `json:"text,omitempty"`
+	}
+	if err := json.Unmarshal(raw, &blocks); err != nil {
+		return ""
+	}
+	var parts []string
+	for _, b := range blocks {
+		if b.Type == "text" && b.Text != "" {
+			parts = append(parts, b.Text)
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+func flattenOpenAITaskReplyContent(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var simple string
+	if err := json.Unmarshal(raw, &simple); err == nil {
+		return simple
+	}
+	var blocks []struct {
+		Type string `json:"type"`
+		Text string `json:"text,omitempty"`
+	}
+	if err := json.Unmarshal(raw, &blocks); err != nil {
+		return ""
+	}
+	var parts []string
+	for _, b := range blocks {
+		switch b.Type {
+		case "text", "input_text":
+			if b.Text != "" {
+				parts = append(parts, b.Text)
+			}
+		}
+	}
+	return strings.Join(parts, "\n")
 }

--- a/internal/runtime/llmproxy/approval_body_editor_test.go
+++ b/internal/runtime/llmproxy/approval_body_editor_test.go
@@ -1,0 +1,108 @@
+package llmproxy
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+)
+
+func TestApprovalBodyEditorProviderShapes(t *testing.T) {
+	const replacement = "[replacement context]"
+
+	cases := []struct {
+		name       string
+		provider   conversation.Provider
+		path       string
+		body       string
+		wantReply  bool
+		wantVerb   string
+		wantID     string
+		want       string
+		wantAbsent string
+	}{
+		{
+			name:      "anthropic_string_content",
+			provider:  conversation.ProviderAnthropic,
+			path:      "/v1/messages",
+			body:      `{"messages":[{"role":"user","content":"approve"}]}`,
+			wantReply: true,
+			wantVerb:  "approve",
+			want:      `"content":"` + replacement + `"`,
+		},
+		{
+			name:     "anthropic_text_blocks",
+			provider: conversation.ProviderAnthropic,
+			path:     "/v1/messages",
+			body: `{"messages":[{"role":"user","content":[` +
+				`{"type":"text","text":"approve cv-abcdef123456"},` +
+				`{"type":"image","source":{"type":"base64","media_type":"image/png","data":"abc"}}]}]}`,
+			wantReply:  true,
+			wantVerb:   "approve",
+			wantID:     "cv-abcdef123456",
+			want:       `"content":"` + replacement + `"`,
+			wantAbsent: "cv-abcdef123456",
+		},
+		{
+			name:      "openai_chat_string_content",
+			provider:  conversation.ProviderOpenAI,
+			path:      "/v1/chat/completions",
+			body:      `{"messages":[{"role":"user","content":"approve"}]}`,
+			wantReply: true,
+			wantVerb:  "approve",
+			want:      `"content":"` + replacement + `"`,
+		},
+		{
+			name:     "openai_responses_string_input",
+			provider: conversation.ProviderOpenAI,
+			path:     "/v1/responses",
+			body:     `{"input":"approve"}`,
+			want:     `"input":"` + replacement + `"`,
+		},
+		{
+			name:     "openai_responses_message_blocks",
+			provider: conversation.ProviderOpenAI,
+			path:     "/v1/responses",
+			body: `{"input":[{"type":"message","role":"user","content":[` +
+				`{"type":"input_text","text":"approve cv-abcdef123456"}]}]}`,
+			wantReply:  true,
+			wantVerb:   "approve",
+			wantID:     "cv-abcdef123456",
+			want:       `"text":"` + replacement + `"`,
+			wantAbsent: "cv-abcdef123456",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("POST", tc.path, nil)
+			editor, ok := newApprovalBodyEditor(req, tc.provider, []byte(tc.body))
+			if !ok {
+				t.Fatal("expected provider body editor")
+			}
+			verb, approvalID, ok := editor.LatestApprovalReply()
+			if ok != tc.wantReply || verb != tc.wantVerb || approvalID != tc.wantID {
+				t.Fatalf("LatestApprovalReply=(%q,%q,%v), want (%q,%q,%v)", verb, approvalID, ok, tc.wantVerb, tc.wantID, tc.wantReply)
+			}
+			out, ok, err := replaceApprovalReplyForProvider(req, tc.provider, []byte(tc.body), "approve", replacement)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !ok {
+				t.Fatalf("expected body replacement to succeed")
+			}
+			if !json.Valid(out) {
+				t.Fatalf("replacement produced invalid JSON: %s", out)
+			}
+			got := string(out)
+			if !strings.Contains(got, tc.want) {
+				t.Fatalf("rewritten body missing %q: %s", tc.want, got)
+			}
+			if tc.wantAbsent != "" && strings.Contains(got, tc.wantAbsent) {
+				t.Fatalf("rewritten body should not retain %q: %s", tc.wantAbsent, got)
+			}
+		})
+	}
+}

--- a/internal/runtime/llmproxy/approval_body_editor_test.go
+++ b/internal/runtime/llmproxy/approval_body_editor_test.go
@@ -55,11 +55,13 @@ func TestApprovalBodyEditorProviderShapes(t *testing.T) {
 			want:      `"content":"` + replacement + `"`,
 		},
 		{
-			name:     "openai_responses_string_input",
-			provider: conversation.ProviderOpenAI,
-			path:     "/v1/responses",
-			body:     `{"input":"approve"}`,
-			want:     `"input":"` + replacement + `"`,
+			name:      "openai_responses_string_input",
+			provider:  conversation.ProviderOpenAI,
+			path:      "/v1/responses",
+			body:      `{"input":"approve"}`,
+			wantReply: true,
+			wantVerb:  "approve",
+			want:      `"input":"` + replacement + `"`,
 		},
 		{
 			name:     "openai_responses_message_blocks",
@@ -86,7 +88,7 @@ func TestApprovalBodyEditorProviderShapes(t *testing.T) {
 			if ok != tc.wantReply || verb != tc.wantVerb || approvalID != tc.wantID {
 				t.Fatalf("LatestApprovalReply=(%q,%q,%v), want (%q,%q,%v)", verb, approvalID, ok, tc.wantVerb, tc.wantID, tc.wantReply)
 			}
-			out, ok, err := replaceApprovalReplyForProvider(req, tc.provider, []byte(tc.body), "approve", replacement)
+			out, ok, err := editor.ReplaceLatestUserText("approve", replacement)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/runtime/llmproxy/approval_characterization_test.go
+++ b/internal/runtime/llmproxy/approval_characterization_test.go
@@ -2,7 +2,6 @@ package llmproxy
 
 import (
 	"context"
-	"encoding/json"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -133,103 +132,5 @@ func TestApprovalRoutingCharacterization_TaskReplyDropsOnlyNamedToolHold(t *test
 		ApprovalID: inlineHeld.Pending.ID,
 	}); p == nil {
 		t.Fatal("unrelated newer inline hold should remain")
-	}
-}
-
-func TestApprovalBodyReplacementProviderShapes(t *testing.T) {
-	const replacement = "[replacement context]"
-
-	cases := []struct {
-		name       string
-		provider   conversation.Provider
-		path       string
-		body       string
-		wantReply  bool
-		wantVerb   string
-		wantID     string
-		want       string
-		wantAbsent string
-	}{
-		{
-			name:      "anthropic_string_content",
-			provider:  conversation.ProviderAnthropic,
-			path:      "/v1/messages",
-			body:      `{"messages":[{"role":"user","content":"approve"}]}`,
-			wantReply: true,
-			wantVerb:  "approve",
-			want:      `"content":"` + replacement + `"`,
-		},
-		{
-			name:     "anthropic_text_blocks",
-			provider: conversation.ProviderAnthropic,
-			path:     "/v1/messages",
-			body: `{"messages":[{"role":"user","content":[` +
-				`{"type":"text","text":"approve cv-abcdef123456"},` +
-				`{"type":"image","source":{"type":"base64","media_type":"image/png","data":"abc"}}]}]}`,
-			wantReply:  true,
-			wantVerb:   "approve",
-			wantID:     "cv-abcdef123456",
-			want:       `"content":"` + replacement + `"`,
-			wantAbsent: "cv-abcdef123456",
-		},
-		{
-			name:      "openai_chat_string_content",
-			provider:  conversation.ProviderOpenAI,
-			path:      "/v1/chat/completions",
-			body:      `{"messages":[{"role":"user","content":"approve"}]}`,
-			wantReply: true,
-			wantVerb:  "approve",
-			want:      `"content":"` + replacement + `"`,
-		},
-		{
-			name:     "openai_responses_string_input",
-			provider: conversation.ProviderOpenAI,
-			path:     "/v1/responses",
-			body:     `{"input":"approve"}`,
-			want:     `"input":"` + replacement + `"`,
-		},
-		{
-			name:     "openai_responses_message_blocks",
-			provider: conversation.ProviderOpenAI,
-			path:     "/v1/responses",
-			body: `{"input":[{"type":"message","role":"user","content":[` +
-				`{"type":"input_text","text":"approve cv-abcdef123456"}]}]}`,
-			wantReply:  true,
-			wantVerb:   "approve",
-			wantID:     "cv-abcdef123456",
-			want:       `"text":"` + replacement + `"`,
-			wantAbsent: "cv-abcdef123456",
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			req := httptest.NewRequest("POST", tc.path, nil)
-			editor, ok := newApprovalBodyEditor(req, tc.provider, []byte(tc.body))
-			if !ok {
-				t.Fatal("expected provider body editor")
-			}
-			verb, approvalID, ok := editor.LatestApprovalReply()
-			if ok != tc.wantReply || verb != tc.wantVerb || approvalID != tc.wantID {
-				t.Fatalf("LatestApprovalReply=(%q,%q,%v), want (%q,%q,%v)", verb, approvalID, ok, tc.wantVerb, tc.wantID, tc.wantReply)
-			}
-			out, ok, err := replaceApprovalReplyForProvider(req, tc.provider, []byte(tc.body), "approve", replacement)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if !ok {
-				t.Fatalf("expected body replacement to succeed")
-			}
-			if !json.Valid(out) {
-				t.Fatalf("replacement produced invalid JSON: %s", out)
-			}
-			got := string(out)
-			if !strings.Contains(got, tc.want) {
-				t.Fatalf("rewritten body missing %q: %s", tc.want, got)
-			}
-			if tc.wantAbsent != "" && strings.Contains(got, tc.wantAbsent) {
-				t.Fatalf("rewritten body should not retain %q: %s", tc.wantAbsent, got)
-			}
-		})
 	}
 }

--- a/internal/runtime/llmproxy/approval_characterization_test.go
+++ b/internal/runtime/llmproxy/approval_characterization_test.go
@@ -1,0 +1,214 @@
+package llmproxy
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+	runtimetasks "github.com/clawvisor/clawvisor/internal/runtime/tasks"
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+func TestApprovalRoutingCharacterization_ExplicitInlineIDBeatsNewerToolHold(t *testing.T) {
+	ctx := context.Background()
+	cache := NewMemoryPendingApprovalCache(time.Minute)
+
+	inlineHeld, err := cache.Hold(ctx, PendingLiteApproval{
+		ID:       "cv-aaaaaaaaaaaaaaaaaaaaaaaaaa",
+		UserID:   "user-1",
+		AgentID:  "agent-1",
+		Provider: conversation.ProviderAnthropic,
+		Stage:    StageAwaitingTaskApproval,
+		ToolUse:  conversation.ToolUse{ID: "toolu_post", Name: "Bash"},
+		TaskDefinition: &runtimetasks.TaskCreateRequest{
+			Purpose: "Create a landing page",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	toolHeld, err := cache.Hold(ctx, PendingLiteApproval{
+		ID:       "cv-bbbbbbbbbbbbbbbbbbbbbbbbbb",
+		UserID:   "user-1",
+		AgentID:  "agent-1",
+		Provider: conversation.ProviderAnthropic,
+		Stage:    StageTool,
+		ToolUse:  conversation.ToolUse{ID: "toolu_newer", Name: "Bash"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	creator := &fakeInlineTaskCreator{
+		resp: &InlineApprovedTask{ID: "task-explicit-inline", ApprovalSource: "inline_chat"},
+	}
+	body := []byte(`{"messages":[{"role":"user","content":"approve ` + inlineHeld.Pending.ID + `"}]}`)
+	out, err := RewriteInlineTaskApprovalReply(ctx, InlineApprovalRewriteRequest{
+		HTTPRequest:     httptest.NewRequest("POST", "/v1/messages", nil),
+		Provider:        conversation.ProviderAnthropic,
+		Body:            body,
+		Agent:           &store.Agent{ID: "agent-1", UserID: "user-1"},
+		PendingApproval: cache,
+		Creator:         creator,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !out.Rewritten || out.Decision != "allow" || out.Outcome != "inline_task_approved" {
+		t.Fatalf("explicit inline approval should resolve named inline hold; got %+v", out)
+	}
+	if !creator.called {
+		t.Fatal("creator should be called for explicit inline approval")
+	}
+	if p, _ := cache.Peek(ctx, ResolveRequest{
+		UserID: "user-1", AgentID: "agent-1", Provider: conversation.ProviderAnthropic,
+		ApprovalID: inlineHeld.Pending.ID,
+	}); p != nil {
+		t.Fatalf("explicit inline hold should be consumed; got %+v", p)
+	}
+	if p, _ := cache.Peek(ctx, ResolveRequest{
+		UserID: "user-1", AgentID: "agent-1", Provider: conversation.ProviderAnthropic,
+		ApprovalID: toolHeld.Pending.ID,
+	}); p == nil {
+		t.Fatal("newer unrelated tool hold should remain")
+	}
+}
+
+func TestApprovalRoutingCharacterization_TaskReplyDropsOnlyNamedToolHold(t *testing.T) {
+	ctx := context.Background()
+	cache := NewMemoryPendingApprovalCache(time.Minute)
+
+	toolHeld, err := cache.Hold(ctx, PendingLiteApproval{
+		ID:       "cv-cccccccccccccccccccccccccc",
+		UserID:   "user-1",
+		AgentID:  "agent-1",
+		Provider: conversation.ProviderAnthropic,
+		Stage:    StageTool,
+		ToolUse:  conversation.ToolUse{ID: "toolu_named", Name: "Bash"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	inlineHeld, err := cache.Hold(ctx, PendingLiteApproval{
+		ID:       "cv-dddddddddddddddddddddddddd",
+		UserID:   "user-1",
+		AgentID:  "agent-1",
+		Provider: conversation.ProviderAnthropic,
+		Stage:    StageAwaitingTaskApproval,
+		ToolUse:  conversation.ToolUse{ID: "toolu_post", Name: "Bash"},
+		TaskDefinition: &runtimetasks.TaskCreateRequest{
+			Purpose: "Already proposed task",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body := []byte(`{"messages":[{"role":"user","content":"task ` + toolHeld.Pending.ID + `"}]}`)
+	out, err := RewriteTaskApprovalReply(ctx, TaskReplyRewriteRequest{
+		HTTPRequest:     httptest.NewRequest("POST", "/v1/messages", nil),
+		Provider:        conversation.ProviderAnthropic,
+		Body:            body,
+		Agent:           &store.Agent{ID: "agent-1", UserID: "user-1"},
+		PendingApproval: cache,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !out.Rewritten || !strings.Contains(string(out.Body), "surface=inline") {
+		t.Fatalf("task reply should rewrite to inline task-creation prompt; got %+v body=%s", out, out.Body)
+	}
+	if p, _ := cache.Peek(ctx, ResolveRequest{
+		UserID: "user-1", AgentID: "agent-1", Provider: conversation.ProviderAnthropic,
+		ApprovalID: toolHeld.Pending.ID,
+	}); p != nil {
+		t.Fatalf("named tool hold should be consumed by task reply; got %+v", p)
+	}
+	if p, _ := cache.Peek(ctx, ResolveRequest{
+		UserID: "user-1", AgentID: "agent-1", Provider: conversation.ProviderAnthropic,
+		ApprovalID: inlineHeld.Pending.ID,
+	}); p == nil {
+		t.Fatal("unrelated newer inline hold should remain")
+	}
+}
+
+func TestApprovalBodyReplacementProviderShapes(t *testing.T) {
+	const replacement = "[replacement context]"
+
+	cases := []struct {
+		name       string
+		provider   conversation.Provider
+		path       string
+		body       string
+		want       string
+		wantAbsent string
+	}{
+		{
+			name:     "anthropic_string_content",
+			provider: conversation.ProviderAnthropic,
+			path:     "/v1/messages",
+			body:     `{"messages":[{"role":"user","content":"approve"}]}`,
+			want:     `"content":"` + replacement + `"`,
+		},
+		{
+			name:     "anthropic_text_blocks",
+			provider: conversation.ProviderAnthropic,
+			path:     "/v1/messages",
+			body: `{"messages":[{"role":"user","content":[` +
+				`{"type":"text","text":"approve cv-abcdef123456"},` +
+				`{"type":"image","source":{"type":"base64","media_type":"image/png","data":"abc"}}]}]}`,
+			want:       `"content":"` + replacement + `"`,
+			wantAbsent: "cv-abcdef123456",
+		},
+		{
+			name:     "openai_chat_string_content",
+			provider: conversation.ProviderOpenAI,
+			path:     "/v1/chat/completions",
+			body:     `{"messages":[{"role":"user","content":"approve"}]}`,
+			want:     `"content":"` + replacement + `"`,
+		},
+		{
+			name:     "openai_responses_string_input",
+			provider: conversation.ProviderOpenAI,
+			path:     "/v1/responses",
+			body:     `{"input":"approve"}`,
+			want:     `"input":"` + replacement + `"`,
+		},
+		{
+			name:     "openai_responses_message_blocks",
+			provider: conversation.ProviderOpenAI,
+			path:     "/v1/responses",
+			body: `{"input":[{"type":"message","role":"user","content":[` +
+				`{"type":"input_text","text":"approve cv-abcdef123456"}]}]}`,
+			want:       `"text":"` + replacement + `"`,
+			wantAbsent: "cv-abcdef123456",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("POST", tc.path, nil)
+			out, ok, err := replaceApprovalReplyForProvider(req, tc.provider, []byte(tc.body), "approve", replacement)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !ok {
+				t.Fatalf("expected body replacement to succeed")
+			}
+			if !json.Valid(out) {
+				t.Fatalf("replacement produced invalid JSON: %s", out)
+			}
+			got := string(out)
+			if !strings.Contains(got, tc.want) {
+				t.Fatalf("rewritten body missing %q: %s", tc.want, got)
+			}
+			if tc.wantAbsent != "" && strings.Contains(got, tc.wantAbsent) {
+				t.Fatalf("rewritten body should not retain %q: %s", tc.wantAbsent, got)
+			}
+		})
+	}
+}

--- a/internal/runtime/llmproxy/approval_characterization_test.go
+++ b/internal/runtime/llmproxy/approval_characterization_test.go
@@ -144,15 +144,20 @@ func TestApprovalBodyReplacementProviderShapes(t *testing.T) {
 		provider   conversation.Provider
 		path       string
 		body       string
+		wantReply  bool
+		wantVerb   string
+		wantID     string
 		want       string
 		wantAbsent string
 	}{
 		{
-			name:     "anthropic_string_content",
-			provider: conversation.ProviderAnthropic,
-			path:     "/v1/messages",
-			body:     `{"messages":[{"role":"user","content":"approve"}]}`,
-			want:     `"content":"` + replacement + `"`,
+			name:      "anthropic_string_content",
+			provider:  conversation.ProviderAnthropic,
+			path:      "/v1/messages",
+			body:      `{"messages":[{"role":"user","content":"approve"}]}`,
+			wantReply: true,
+			wantVerb:  "approve",
+			want:      `"content":"` + replacement + `"`,
 		},
 		{
 			name:     "anthropic_text_blocks",
@@ -161,15 +166,20 @@ func TestApprovalBodyReplacementProviderShapes(t *testing.T) {
 			body: `{"messages":[{"role":"user","content":[` +
 				`{"type":"text","text":"approve cv-abcdef123456"},` +
 				`{"type":"image","source":{"type":"base64","media_type":"image/png","data":"abc"}}]}]}`,
+			wantReply:  true,
+			wantVerb:   "approve",
+			wantID:     "cv-abcdef123456",
 			want:       `"content":"` + replacement + `"`,
 			wantAbsent: "cv-abcdef123456",
 		},
 		{
-			name:     "openai_chat_string_content",
-			provider: conversation.ProviderOpenAI,
-			path:     "/v1/chat/completions",
-			body:     `{"messages":[{"role":"user","content":"approve"}]}`,
-			want:     `"content":"` + replacement + `"`,
+			name:      "openai_chat_string_content",
+			provider:  conversation.ProviderOpenAI,
+			path:      "/v1/chat/completions",
+			body:      `{"messages":[{"role":"user","content":"approve"}]}`,
+			wantReply: true,
+			wantVerb:  "approve",
+			want:      `"content":"` + replacement + `"`,
 		},
 		{
 			name:     "openai_responses_string_input",
@@ -184,6 +194,9 @@ func TestApprovalBodyReplacementProviderShapes(t *testing.T) {
 			path:     "/v1/responses",
 			body: `{"input":[{"type":"message","role":"user","content":[` +
 				`{"type":"input_text","text":"approve cv-abcdef123456"}]}]}`,
+			wantReply:  true,
+			wantVerb:   "approve",
+			wantID:     "cv-abcdef123456",
 			want:       `"text":"` + replacement + `"`,
 			wantAbsent: "cv-abcdef123456",
 		},
@@ -192,6 +205,14 @@ func TestApprovalBodyReplacementProviderShapes(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			req := httptest.NewRequest("POST", tc.path, nil)
+			editor, ok := newApprovalBodyEditor(req, tc.provider, []byte(tc.body))
+			if !ok {
+				t.Fatal("expected provider body editor")
+			}
+			verb, approvalID, ok := editor.LatestApprovalReply()
+			if ok != tc.wantReply || verb != tc.wantVerb || approvalID != tc.wantID {
+				t.Fatalf("LatestApprovalReply=(%q,%q,%v), want (%q,%q,%v)", verb, approvalID, ok, tc.wantVerb, tc.wantID, tc.wantReply)
+			}
 			out, ok, err := replaceApprovalReplyForProvider(req, tc.provider, []byte(tc.body), "approve", replacement)
 			if err != nil {
 				t.Fatal(err)

--- a/internal/runtime/llmproxy/approval_reply_resolver.go
+++ b/internal/runtime/llmproxy/approval_reply_resolver.go
@@ -1,0 +1,92 @@
+package llmproxy
+
+import (
+	"context"
+
+	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+)
+
+type approvalReplyActionKind string
+
+const (
+	approvalReplyActionNoop                      approvalReplyActionKind = "noop"
+	approvalReplyActionReleaseTool               approvalReplyActionKind = "release_tool"
+	approvalReplyActionStartInlineTaskDefinition approvalReplyActionKind = "start_inline_task_definition"
+	approvalReplyActionApproveInlineTask         approvalReplyActionKind = "approve_inline_task"
+	approvalReplyActionDenyInlineTask            approvalReplyActionKind = "deny_inline_task"
+)
+
+type approvalReplyAction struct {
+	Kind       approvalReplyActionKind
+	Verb       string
+	ApprovalID string
+	Hold       *PendingLiteApproval
+}
+
+type approvalReplyRoutingRequest struct {
+	UserID          string
+	AgentID         string
+	Provider        conversation.Provider
+	PendingApproval PendingApprovalCache
+	Verb            string
+	ApprovalID      string
+}
+
+// resolveApprovalReplyAction centralizes the shared routing rule for
+// conversational approval replies:
+//
+//   - explicit approval IDs target only that hold
+//   - bare replies target the newest visible hold across stages
+//   - approve/deny on an inline-task hold belongs to the inline rewriter
+//   - approve/deny on any other hold belongs to the regular release path
+//   - task starts the inline task-definition flow for the targeted hold
+//
+// This function only peeks and classifies; callers still own the
+// side effects for their action.
+func resolveApprovalReplyAction(ctx context.Context, req approvalReplyRoutingRequest) (approvalReplyAction, error) {
+	action := approvalReplyAction{
+		Kind:       approvalReplyActionNoop,
+		Verb:       req.Verb,
+		ApprovalID: req.ApprovalID,
+	}
+	if req.PendingApproval == nil || req.UserID == "" || req.AgentID == "" {
+		return action, nil
+	}
+	switch req.Verb {
+	case "approve", "deny", "task":
+	default:
+		return action, nil
+	}
+
+	hold, err := req.PendingApproval.Peek(ctx, ResolveRequest{
+		UserID:     req.UserID,
+		AgentID:    req.AgentID,
+		Provider:   req.Provider,
+		ApprovalID: req.ApprovalID,
+	})
+	if err != nil {
+		return action, err
+	}
+	if hold == nil {
+		return action, nil
+	}
+	action.Hold = hold
+
+	switch req.Verb {
+	case "task":
+		action.Kind = approvalReplyActionStartInlineTaskDefinition
+	case "approve":
+		if hold.Stage == StageAwaitingTaskApproval {
+			action.Kind = approvalReplyActionApproveInlineTask
+		} else {
+			action.Kind = approvalReplyActionReleaseTool
+		}
+	case "deny":
+		if hold.Stage == StageAwaitingTaskApproval {
+			action.Kind = approvalReplyActionDenyInlineTask
+		} else {
+			action.Kind = approvalReplyActionReleaseTool
+		}
+	}
+	return action, nil
+}

--- a/internal/runtime/llmproxy/approval_reply_resolver_test.go
+++ b/internal/runtime/llmproxy/approval_reply_resolver_test.go
@@ -1,0 +1,152 @@
+package llmproxy
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+)
+
+func TestResolveApprovalReplyActionCharacterizesRouting(t *testing.T) {
+	tests := []struct {
+		name       string
+		holds      []PendingLiteApproval
+		verb       string
+		approvalID string
+		wantKind   approvalReplyActionKind
+		wantID     string
+	}{
+		{
+			name: "bare_approve_targets_newest_tool_hold",
+			holds: []PendingLiteApproval{
+				resolverTestHold("cv-aaaaaaaaaaaaaaaaaaaaaaaaaa", StageAwaitingTaskApproval),
+				resolverTestHold("cv-bbbbbbbbbbbbbbbbbbbbbbbbbb", StageTool),
+			},
+			verb:     "approve",
+			wantKind: approvalReplyActionReleaseTool,
+			wantID:   "cv-bbbbbbbbbbbbbbbbbbbbbbbbbb",
+		},
+		{
+			name: "bare_approve_targets_newest_inline_hold",
+			holds: []PendingLiteApproval{
+				resolverTestHold("cv-cccccccccccccccccccccccccc", StageTool),
+				resolverTestHold("cv-dddddddddddddddddddddddddd", StageAwaitingTaskApproval),
+			},
+			verb:     "approve",
+			wantKind: approvalReplyActionApproveInlineTask,
+			wantID:   "cv-dddddddddddddddddddddddddd",
+		},
+		{
+			name: "bare_deny_targets_newest_inline_hold",
+			holds: []PendingLiteApproval{
+				resolverTestHold("cv-eeeeeeeeeeeeeeeeeeeeeeeeee", StageTool),
+				resolverTestHold("cv-ffffffffffffffffffffffffff", StageAwaitingTaskApproval),
+			},
+			verb:     "deny",
+			wantKind: approvalReplyActionDenyInlineTask,
+			wantID:   "cv-ffffffffffffffffffffffffff",
+		},
+		{
+			name: "explicit_id_targets_older_tool_hold",
+			holds: []PendingLiteApproval{
+				resolverTestHold("cv-gggggggggggggggggggggggggg", StageTool),
+				resolverTestHold("cv-hhhhhhhhhhhhhhhhhhhhhhhhhh", StageAwaitingTaskApproval),
+			},
+			verb:       "approve",
+			approvalID: "cv-gggggggggggggggggggggggggg",
+			wantKind:   approvalReplyActionReleaseTool,
+			wantID:     "cv-gggggggggggggggggggggggggg",
+		},
+		{
+			name: "explicit_id_targets_older_inline_hold",
+			holds: []PendingLiteApproval{
+				resolverTestHold("cv-iiiiiiiiiiiiiiiiiiiiiiiiii", StageAwaitingTaskApproval),
+				resolverTestHold("cv-jjjjjjjjjjjjjjjjjjjjjjjjjj", StageTool),
+			},
+			verb:       "approve",
+			approvalID: "cv-iiiiiiiiiiiiiiiiiiiiiiiiii",
+			wantKind:   approvalReplyActionApproveInlineTask,
+			wantID:     "cv-iiiiiiiiiiiiiiiiiiiiiiiiii",
+		},
+		{
+			name: "task_targets_newest_hold",
+			holds: []PendingLiteApproval{
+				resolverTestHold("cv-kkkkkkkkkkkkkkkkkkkkkkkkkk", StageTool),
+				resolverTestHold("cv-llllllllllllllllllllllllll", StageAwaitingTaskApproval),
+			},
+			verb:     "task",
+			wantKind: approvalReplyActionStartInlineTaskDefinition,
+			wantID:   "cv-llllllllllllllllllllllllll",
+		},
+		{
+			name: "missing_explicit_id_is_noop",
+			holds: []PendingLiteApproval{
+				resolverTestHold("cv-mmmmmmmmmmmmmmmmmmmmmmmmmm", StageTool),
+			},
+			verb:       "approve",
+			approvalID: "cv-nnnnnnnnnnnnnnnnnnnnnnnnnn",
+			wantKind:   approvalReplyActionNoop,
+		},
+		{
+			name: "unknown_verb_is_noop",
+			holds: []PendingLiteApproval{
+				resolverTestHold("cv-oooooooooooooooooooooooooo", StageTool),
+			},
+			verb:     "maybe",
+			wantKind: approvalReplyActionNoop,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cache := NewMemoryPendingApprovalCache(time.Minute)
+			ctx := context.Background()
+			for _, hold := range tc.holds {
+				if _, err := cache.Hold(ctx, hold); err != nil {
+					t.Fatal(err)
+				}
+			}
+			got, err := resolveApprovalReplyAction(ctx, approvalReplyRoutingRequest{
+				UserID:          "user-1",
+				AgentID:         "agent-1",
+				Provider:        conversation.ProviderAnthropic,
+				PendingApproval: cache,
+				Verb:            tc.verb,
+				ApprovalID:      tc.approvalID,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.Kind != tc.wantKind {
+				t.Fatalf("Kind=%q, want %q; action=%+v", got.Kind, tc.wantKind, got)
+			}
+			if tc.wantID == "" {
+				if got.Hold != nil {
+					t.Fatalf("Hold=%+v, want nil", got.Hold)
+				}
+				return
+			}
+			if got.Hold == nil || got.Hold.ID != tc.wantID {
+				t.Fatalf("Hold ID=%v, want %q", approvalActionHoldID(got), tc.wantID)
+			}
+		})
+	}
+}
+
+func resolverTestHold(id string, stage PendingApprovalStage) PendingLiteApproval {
+	return PendingLiteApproval{
+		ID:       id,
+		UserID:   "user-1",
+		AgentID:  "agent-1",
+		Provider: conversation.ProviderAnthropic,
+		Stage:    stage,
+	}
+}
+
+func approvalActionHoldID(action approvalReplyAction) string {
+	if action.Hold == nil {
+		return "<nil>"
+	}
+	return action.Hold.ID
+}

--- a/internal/runtime/llmproxy/control.go
+++ b/internal/runtime/llmproxy/control.go
@@ -15,7 +15,7 @@ const (
 	ControlSyntheticHost = "clawvisor.local"
 )
 
-func ControlNotice(controlBaseURL string) string {
+func ControlNotice(controlBaseURL string, availableTools []string) string {
 	// Always advertise the synthetic URL. Clawvisor rewrites it to the
 	// real daemon URL transparently and mints fresh auth on every call.
 	// Models that see (or guess) the daemon URL and call it directly
@@ -25,6 +25,11 @@ func ControlNotice(controlBaseURL string) string {
 	docsURL := "https://" + ControlSyntheticHost + "/control/skill"
 	tasksURLInline := "https://" + ControlSyntheticHost + "/control/tasks?wait=true&timeout=120&surface=inline"
 	tasksURLDashboard := "https://" + ControlSyntheticHost + "/control/tasks?wait=true&timeout=120"
+	toolExamples := controlToolExamples(availableTools)
+	shellTool := controlShellTool(availableTools)
+	if shellTool == "" {
+		shellTool = "bash"
+	}
 	return strings.Join([]string{
 		"Clawvisor proxy-lite control plane.",
 		"",
@@ -44,8 +49,8 @@ func ControlNotice(controlBaseURL string) string {
 		"",
 		"What goes in a good task:",
 		"  - `purpose`: a clear, user-visible sentence describing what you're about to do. Phrase it expansively enough to cover the obvious follow-up work — \"create and verify\" rather than just \"create\", \"refactor and test\" rather than just \"refactor\". Verification-by-reading is part of any sensible writing workflow; declare it.",
-		"  - `expected_tools_json`: list every tool family you expect to use (Bash, Read, Write, Edit, WebFetch, etc.). Be generous — list anything plausible. Missing scope is friction; over-declaring is fine. SCOPE PAIRS: writing implies reading (you will verify the file you just wrote), so when you list Write or Edit also list Read; running a shell that creates state usually means running a shell that inspects it, so a single Bash entry with a `why` that covers both is correct. Don't split write-then-verify into two tasks.",
-		"  - `why`: per-tool, one line explaining why that tool is needed for THIS task. For Bash/Write/Edit on a writing task, your `why` should explicitly include the verify/inspect/check workflow — e.g. \"Create the target files and run sanity checks (ls, wc, cat) against them.\" The intent verifier compares each individual command against the `why`; a `why` that only mentions writes will refuse the subsequent reads.",
+		"  - `expected_tools_json`: list the actual tool names you expect to use from this request's available tools (" + toolExamples + "). Be generous — list anything plausible. Missing scope is friction; over-declaring is fine. SCOPE PAIRS: writing implies reading (you will verify the file you just wrote), so when you list write/edit tools also list read tools when available; running a shell that creates state usually means running a shell that inspects it, so a single `" + shellTool + "` entry with a `why` that covers both is correct. Don't split write-then-verify into two tasks.",
+		"  - `why`: per-tool, one line explaining why that tool is needed for THIS task. For shell/write/edit tools on a writing task, your `why` should explicitly include the verify/inspect/check workflow — e.g. \"Create the target files and run sanity checks (ls, wc, cat) against them.\" The intent verifier compares each individual command against the `why`; a `why` that only mentions writes will refuse the subsequent reads.",
 		"",
 		"When NOT to create a task: single one-shot commands the user obviously wants (a single `ls`, a single `cat`), or follow-up clarifications inside an already-approved task's scope.",
 		"",
@@ -73,7 +78,7 @@ func ControlNotice(controlBaseURL string) string {
 		"Before creating the task, tell me I will need to approve it.",
 		"For schemas and examples, GET " + docsURL + ".",
 		"",
-		"Use Bash with curl for control-plane calls (not WebFetch/http_request — those tools",
+		"Use `" + shellTool + "` with curl for control-plane calls (not WebFetch/http_request — those tools",
 		"do not support the headers and JSON body that task creation requires).",
 		"",
 		"USE ONE CURL — emit a single curl invocation with the JSON body inline. Don't write the JSON to a temp file via cat/echo and then curl --data @file: the proxy can parse that shape but it adds variance for no benefit. The simplest, most reliable shape is `--data @-` with a heredoc.",
@@ -90,7 +95,7 @@ func ControlNotice(controlBaseURL string) string {
 		"    -H 'Content-Type: application/json' \\",
 		"    --data @- <<'JSON'",
 		"  {\"purpose\":\"<one-line user-visible goal>\",",
-		"   \"expected_tools_json\":[{\"tool_name\":\"bash\",\"why\":\"<concrete reason>\"}],",
+		"   \"expected_tools_json\":[{\"tool_name\":\"" + shellTool + "\",\"why\":\"<concrete reason>\"}],",
 		"   \"intent_verification_mode\":\"strict\",",
 		"   \"expires_in_seconds\":600}",
 		"  JSON",
@@ -101,14 +106,55 @@ func ControlNotice(controlBaseURL string) string {
 	}, "\n")
 }
 
+func controlToolExamples(availableTools []string) string {
+	tools := compactToolNames(availableTools)
+	if len(tools) == 0 {
+		return "Bash, Read, Write, Edit, WebFetch, etc."
+	}
+	const max = 8
+	if len(tools) > max {
+		tools = tools[:max]
+		return strings.Join(tools, ", ") + ", etc."
+	}
+	return strings.Join(tools, ", ")
+}
+
+func controlShellTool(availableTools []string) string {
+	for _, tool := range compactToolNames(availableTools) {
+		switch strings.ToLower(tool) {
+		case "bash", "shell", "exec", "exec_command":
+			return tool
+		}
+	}
+	return ""
+}
+
+func compactToolNames(availableTools []string) []string {
+	out := make([]string, 0, len(availableTools))
+	seen := make(map[string]struct{}, len(availableTools))
+	for _, tool := range availableTools {
+		tool = strings.TrimSpace(tool)
+		if tool == "" {
+			continue
+		}
+		key := strings.ToLower(tool)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, tool)
+	}
+	return out
+}
+
 // InjectControlNotice adds a compact control-plane hint to the request context.
 // The synthetic URL is rewritten from model-emitted tool calls before the tool
 // runner sees it, so the prompt stays stable across local and public daemon URLs.
-func InjectControlNotice(provider conversation.Provider, body []byte, controlBaseURL string) ([]byte, bool, error) {
+func InjectControlNotice(provider conversation.Provider, body []byte, controlBaseURL string, availableTools []string) ([]byte, bool, error) {
 	if strings.Contains(string(body), "https://"+ControlSyntheticHost+"/control") {
 		return body, false, nil
 	}
-	notice := ControlNotice(controlBaseURL)
+	notice := ControlNotice(controlBaseURL, availableTools)
 	switch provider {
 	case conversation.ProviderAnthropic:
 		return injectAnthropicControlNotice(body, notice)
@@ -863,6 +909,7 @@ func parseSingleControlCurlStmt(cmd string, stmt *syntax.Stmt) ([]controlCurlArg
 //   - the parser separately requires the path to be statically
 //     expandable, so `$HOME`/`$(…)`/`${…}` are already rejected
 //     upstream.
+//
 // Filename body allows alnum/underscore/hyphen segments separated by
 // single dots, ending with a literal `.json`. This rules out
 // `/tmp/foo..bar.json`, `/tmp/...json`, etc. — paths that aren't

--- a/internal/runtime/llmproxy/control_test.go
+++ b/internal/runtime/llmproxy/control_test.go
@@ -8,6 +8,23 @@ import (
 	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
 )
 
+func TestControlNoticeUsesAvailableShellToolNames(t *testing.T) {
+	notice := ControlNotice("http://localhost:25297", []string{"read", "edit", "write", "exec", "process"})
+
+	if !strings.Contains(notice, "Use `exec` with curl") {
+		t.Fatalf("notice should steer OpenClaw to its actual shell tool; got:\n%s", notice)
+	}
+	if !strings.Contains(notice, `"tool_name":"exec"`) {
+		t.Fatalf("notice example should declare exec in expected_tools_json; got:\n%s", notice)
+	}
+	if strings.Contains(notice, "Use Bash with curl") || strings.Contains(notice, `"tool_name":"bash"`) {
+		t.Fatalf("notice should not hardcode Bash when exec is available; got:\n%s", notice)
+	}
+	if !strings.Contains(notice, "available tools (read, edit, write, exec, process)") {
+		t.Fatalf("notice should show actual available tool examples; got:\n%s", notice)
+	}
+}
+
 // Regression: a curl invocation that mixes a synthetic control URL with
 // any other outbound URL must be refused. Otherwise the rewriter would
 // quietly rewrite only the control URL, and the model could run a

--- a/internal/runtime/llmproxy/inline_approval_outcome.go
+++ b/internal/runtime/llmproxy/inline_approval_outcome.go
@@ -5,21 +5,37 @@ import (
 	"time"
 )
 
-// InlineApprovalOutcome records what happened when the proxy attempted
-// to create the inline-approved task. The augmenter looks up an
-// outcome by approval ID parsed from the prior-assistant prompt and
-// injects the matching context onto subsequent turns — claiming
-// "task was created" only when the creation actually succeeded.
+// InlineApprovalOutcome is the canonical in-memory resolution record
+// for one inline task approval. The augmenter uses Succeeded/TaskID/
+// FailureReason to render later conversation history, while audit and
+// diagnostics can correlate the same approval ID to the decision,
+// outcome, request, and approval_records row that the rewrite path
+// produced. Keeping this as one record avoids maintaining a separate
+// "augmenter outcome" fact beside the audit fact.
 type InlineApprovalOutcome struct {
+	// Decision is the audit-level decision: "allow" on successful
+	// task creation, "deny" on denial or failure.
+	Decision string
+	// Outcome is the short audit/event tag, e.g. "inline_task_approved"
+	// or "inline_task_create_failed".
+	Outcome string
 	// Succeeded is true when the task was created and the approval
 	// record was persisted. False on any failure path (validation,
 	// missing creator, store error).
 	Succeeded bool
 	// TaskID is populated on success.
 	TaskID string
+	// ApprovalRecordID is populated on success when the canonical
+	// approval_records row was written.
+	ApprovalRecordID string
 	// FailureReason is populated on failure — short, suitable for
 	// embedding in an LLM-facing context note.
 	FailureReason string
+	// RequestID links this resolution back to the lite-proxy request
+	// that processed the user's approve/deny reply.
+	RequestID string
+	// ResolvedAt is when the proxy resolved the inline approval.
+	ResolvedAt time.Time
 }
 
 // InlineApprovalOutcomeKey scopes an outcome record. The approval ID

--- a/internal/runtime/llmproxy/inline_approval_outcome_test.go
+++ b/internal/runtime/llmproxy/inline_approval_outcome_test.go
@@ -15,10 +15,21 @@ import (
 func TestMemoryInlineApprovalOutcomeStore_RecordAndLookup(t *testing.T) {
 	s := NewMemoryInlineApprovalOutcomeStore(time.Minute)
 	key := InlineApprovalOutcomeKey{UserID: "user-1", AgentID: "agent-1", ApprovalID: "cv-1"}
-	s.Record(key, InlineApprovalOutcome{Succeeded: true, TaskID: "task-1"})
+	s.Record(key, InlineApprovalOutcome{
+		Decision:         "allow",
+		Outcome:          "inline_task_approved",
+		Succeeded:        true,
+		TaskID:           "task-1",
+		ApprovalRecordID: "approval-record-1",
+		RequestID:        "req-1",
+		ResolvedAt:       time.Now().UTC(),
+	})
 	out, ok := s.Lookup(key)
 	if !ok || !out.Succeeded || out.TaskID != "task-1" {
 		t.Fatalf("lookup = (%+v, %v)", out, ok)
+	}
+	if out.Decision != "allow" || out.Outcome != "inline_task_approved" || out.ApprovalRecordID != "approval-record-1" || out.RequestID != "req-1" || out.ResolvedAt.IsZero() {
+		t.Fatalf("lookup missing resolution metadata: %+v", out)
 	}
 	if _, ok := s.Lookup(InlineApprovalOutcomeKey{}); ok {
 		t.Fatal("empty key should miss")
@@ -92,6 +103,7 @@ func TestRewriteInlineTaskApprovalReply_RecordsSuccessOutcome(t *testing.T) {
 		Provider:        conversation.ProviderAnthropic,
 		Body:            []byte(`{"messages":[{"role":"user","content":"approve"}]}`),
 		Agent:           &store.Agent{ID: "agent-1", UserID: "user-1"},
+		RequestID:       "req-success",
 		PendingApproval: cache,
 		Creator:         stubInlineTaskCreator{taskID: "task-created"},
 		Outcomes:        outcomes,
@@ -108,6 +120,9 @@ func TestRewriteInlineTaskApprovalReply_RecordsSuccessOutcome(t *testing.T) {
 	}
 	if !recorded.Succeeded || recorded.TaskID != "task-created" {
 		t.Fatalf("recorded outcome = %+v", recorded)
+	}
+	if recorded.Decision != "allow" || recorded.Outcome != "inline_task_approved" || recorded.ApprovalRecordID != "ar-task-created" || recorded.RequestID != "req-success" || recorded.ResolvedAt.IsZero() {
+		t.Fatalf("recorded resolution metadata = %+v", recorded)
 	}
 }
 
@@ -135,6 +150,7 @@ func TestRewriteInlineTaskApprovalReply_RecordsFailureOutcome(t *testing.T) {
 		Provider:        conversation.ProviderAnthropic,
 		Body:            []byte(`{"messages":[{"role":"user","content":"approve"}]}`),
 		Agent:           &store.Agent{ID: "agent-1", UserID: "user-1"},
+		RequestID:       "req-failure",
 		PendingApproval: cache,
 		Creator:         stubInlineTaskCreator{err: "boom"},
 		Outcomes:        outcomes,
@@ -154,6 +170,9 @@ func TestRewriteInlineTaskApprovalReply_RecordsFailureOutcome(t *testing.T) {
 	}
 	if !strings.Contains(recorded.FailureReason, "boom") {
 		t.Fatalf("FailureReason should preserve the creator's error: %q", recorded.FailureReason)
+	}
+	if recorded.Decision != "deny" || recorded.Outcome != "inline_task_create_failed" || recorded.RequestID != "req-failure" || recorded.ResolvedAt.IsZero() {
+		t.Fatalf("recorded resolution metadata = %+v", recorded)
 	}
 }
 

--- a/internal/runtime/llmproxy/inline_task_rewrite.go
+++ b/internal/runtime/llmproxy/inline_task_rewrite.go
@@ -86,31 +86,24 @@ func RewriteInlineTaskApprovalReply(ctx context.Context, req InlineApprovalRewri
 		return InlineApprovalRewriteResult{Body: req.Body}, nil
 	}
 
-	// Peek the MOST RECENT hold (LIFO, no stage filter). The user's
-	// bare "approve" lands on whatever prompt the harness most
-	// recently rendered — if that's an inline-task prompt, we
-	// handle it here; if it's a regular tool prompt that just
-	// happened to land after an older inline gesture, the release
-	// path is the right place to consume it.
-	//
-	// Stage-filtering this Peek used to cause the inverse race:
-	// an OLDER inline hold could steal a bare "approve" intended
-	// for a NEWER tool prompt the user actually just saw.
-	inner, err := req.PendingApproval.Peek(ctx, ResolveRequest{
-		UserID:     req.Agent.UserID,
-		AgentID:    req.Agent.ID,
-		Provider:   req.Provider,
-		ApprovalID: approvalID,
+	action, err := resolveApprovalReplyAction(ctx, approvalReplyRoutingRequest{
+		UserID:          req.Agent.UserID,
+		AgentID:         req.Agent.ID,
+		Provider:        req.Provider,
+		PendingApproval: req.PendingApproval,
+		Verb:            verb,
+		ApprovalID:      approvalID,
 	})
 	if err != nil {
 		return InlineApprovalRewriteResult{Body: req.Body}, err
 	}
-	if inner == nil {
-		return InlineApprovalRewriteResult{Body: req.Body}, nil
-	}
-	if inner.Stage != StageAwaitingTaskApproval {
+	if action.Kind != approvalReplyActionApproveInlineTask && action.Kind != approvalReplyActionDenyInlineTask {
 		// Most recent hold isn't an inline-task hold (or the named
 		// approval isn't one). Defer to TryReleasePendingApproval.
+		return InlineApprovalRewriteResult{Body: req.Body}, nil
+	}
+	inner := action.Hold
+	if inner == nil {
 		return InlineApprovalRewriteResult{Body: req.Body}, nil
 	}
 

--- a/internal/runtime/llmproxy/inline_task_rewrite.go
+++ b/internal/runtime/llmproxy/inline_task_rewrite.go
@@ -81,7 +81,7 @@ func RewriteInlineTaskApprovalReply(ctx context.Context, req InlineApprovalRewri
 	if req.PendingApproval == nil || req.Agent == nil {
 		return InlineApprovalRewriteResult{Body: req.Body}, nil
 	}
-	verb, approvalID := conversation.ApprovalReplyForProvider(req.Provider, req.Body)
+	verb, approvalID := approvalReplyFromBody(req.HTTPRequest, req.Provider, req.Body)
 	if verb != "approve" && verb != "deny" {
 		return InlineApprovalRewriteResult{Body: req.Body}, nil
 	}

--- a/internal/runtime/llmproxy/inline_task_rewrite.go
+++ b/internal/runtime/llmproxy/inline_task_rewrite.go
@@ -135,14 +135,7 @@ func RewriteInlineTaskApprovalReply(ctx context.Context, req InlineApprovalRewri
 		return out, nil
 	}
 
-	// Consume the inner hold so TryReleasePendingApproval doesn't
-	// double-handle it.
-	resolved, err := req.PendingApproval.Resolve(ctx, ResolveRequest{
-		UserID:     req.Agent.UserID,
-		AgentID:    req.Agent.ID,
-		Provider:   req.Provider,
-		ApprovalID: inner.ID,
-	})
+	resolved, err := consumeApprovalActionHold(ctx, req.PendingApproval, req.Agent, req.Provider, action)
 	if err != nil {
 		return InlineApprovalRewriteResult{Body: req.Body}, err
 	}
@@ -153,63 +146,8 @@ func RewriteInlineTaskApprovalReply(ctx context.Context, req InlineApprovalRewri
 	// Drop the linked outer tool hold so it doesn't sit in the cache
 	// re-matching subsequent approval prompts. The model will re-emit
 	// the original tool naturally now that the task scope covers it.
-	if resolved.AwaitingTaskFor != "" {
-		_ = req.PendingApproval.Drop(ctx, ResolveRequest{
-			UserID:     req.Agent.UserID,
-			AgentID:    req.Agent.ID,
-			Provider:   req.Provider,
-			ApprovalID: resolved.AwaitingTaskFor,
-		})
-	}
-
-	var replacement string
-
-	if verb == "deny" {
-		replacement = renderInlineTaskDenyReply()
-		out.Decision = "deny"
-		out.Outcome = "inline_task_denied"
-		out.Reason = "user denied inline task"
-	} else {
-		// approve
-		switch {
-		case req.Creator == nil:
-			replacement = renderInlineTaskCreatorErrorReply("inline task creation is not available on this daemon")
-			out.Decision = "deny"
-			out.Outcome = "inline_task_creator_missing"
-			out.Reason = "no inline task creator configured"
-		case resolved.TaskDefinition == nil:
-			replacement = renderInlineTaskCreatorErrorReply("missing task definition on approval")
-			out.Decision = "deny"
-			out.Outcome = "inline_task_definition_missing"
-			out.Reason = "missing task definition on approval"
-		default:
-			originalToolUseID := resolved.AwaitingTaskFor
-			created, createErr := req.Creator.CreateInlineApprovedTask(ctx, req.Agent, resolved.TaskDefinition, originalToolUseID)
-			if createErr != nil {
-				replacement = renderInlineTaskCreatorErrorReply(createErr.Error())
-				out.Decision = "deny"
-				out.Outcome = "inline_task_create_failed"
-				out.Reason = "create failed: " + createErr.Error()
-			} else {
-				// Use the SAME text the persistent augmenter
-				// produces on subsequent turns. If turn 1 said
-				// "task 7827... purpose=..." and turn 2+ said
-				// "task was created and approved...", the model
-				// sees the same user message appear with DIFFERENT
-				// content across turns — measurable drift that
-				// invites the model to second-guess prior state.
-				// One canonical rendering, no drift.
-				replacement = inlineApprovedReplyAugmentation()
-				out.Decision = "allow"
-				out.Outcome = "inline_task_approved"
-				out.TaskID = created.ID
-				out.ApprovalRecordID = created.ApprovalRecordID
-				if req.Audit != nil {
-					req.Audit.LogInlineTaskApproved(ctx, req.Agent, req.RequestID, resolved, created)
-				}
-			}
-		}
-	}
+	dropLinkedToolHold(ctx, req.PendingApproval, req.Agent, req.Provider, resolved)
+	replacement, out := resolveInlineTaskApproval(ctx, req, resolved, verb)
 
 	// Record the outcome before returning. The augmenter on later
 	// turns reads this to decide whether to inject success or failure

--- a/internal/runtime/llmproxy/inline_task_rewrite.go
+++ b/internal/runtime/llmproxy/inline_task_rewrite.go
@@ -2,7 +2,6 @@ package llmproxy
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -82,8 +81,12 @@ func RewriteInlineTaskApprovalReply(ctx context.Context, req InlineApprovalRewri
 	if req.PendingApproval == nil || req.Agent == nil {
 		return InlineApprovalRewriteResult{Body: req.Body}, nil
 	}
-	verb, approvalID := approvalReplyFromBody(req.HTTPRequest, req.Provider, req.Body)
-	if verb != "approve" && verb != "deny" {
+	editor, ok := newApprovalBodyEditor(req.HTTPRequest, req.Provider, req.Body)
+	if !ok {
+		return InlineApprovalRewriteResult{Body: req.Body}, nil
+	}
+	verb, approvalID, ok := editor.LatestApprovalReply()
+	if !ok || (verb != "approve" && verb != "deny") {
 		return InlineApprovalRewriteResult{Body: req.Body}, nil
 	}
 
@@ -103,8 +106,7 @@ func RewriteInlineTaskApprovalReply(ctx context.Context, req InlineApprovalRewri
 		// approval isn't one). Defer to TryReleasePendingApproval.
 		return InlineApprovalRewriteResult{Body: req.Body}, nil
 	}
-	inner := action.Hold
-	if inner == nil {
+	if action.Hold == nil {
 		return InlineApprovalRewriteResult{Body: req.Body}, nil
 	}
 
@@ -117,7 +119,7 @@ func RewriteInlineTaskApprovalReply(ctx context.Context, req InlineApprovalRewri
 	// fail closed without disturbing the cache so a fixed retry can
 	// drive the flow.
 	out := InlineApprovalRewriteResult{Body: req.Body}
-	_, canRewrite, probeErr := replaceApprovalReplyForProvider(req.HTTPRequest, req.Provider, req.Body, verb, "")
+	_, canRewrite, probeErr := editor.ReplaceLatestUserText(verb, "")
 	if probeErr != nil {
 		return out, probeErr
 	}
@@ -161,7 +163,7 @@ func RewriteInlineTaskApprovalReply(ctx context.Context, req InlineApprovalRewri
 		}, inlineApprovalOutcomeFromRewrite(req.RequestID, out))
 	}
 
-	rewritten, ok, err := replaceApprovalReplyForProvider(req.HTTPRequest, req.Provider, req.Body, verb, replacement)
+	rewritten, ok, err := editor.ReplaceLatestUserText(verb, replacement)
 	if err != nil {
 		return out, err
 	}
@@ -235,260 +237,11 @@ const InlineApprovalAugmentationMarker = "[Clawvisor: inline task"
 // model-confusion vector since real authorization runs against the
 // task store, but consistent with the rest of the approval scoping.
 func AugmentApprovedInlineTasksInHistory(body []byte, provider conversation.Provider, outcomes InlineApprovalOutcomeStore, userID, agentID string) ([]byte, bool, error) {
-	switch provider {
-	case conversation.ProviderAnthropic:
-		return augmentAnthropicApprovedInlineTasks(body, outcomes, userID, agentID)
-	case conversation.ProviderOpenAI:
-		// OpenAI Chat / Responses can share the same persistence work
-		// once we have a reproducer there. For now we keep the
-		// rewrite Anthropic-only — Claude Code is the harness this
-		// matters for and it's the one we've observed losing the
-		// context.
-		return body, false, nil
-	default:
-		return body, false, nil
-	}
-}
-
-func augmentAnthropicApprovedInlineTasks(body []byte, outcomes InlineApprovalOutcomeStore, userID, agentID string) ([]byte, bool, error) {
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(body, &raw); err != nil {
-		return body, false, err
-	}
-	rawMessages, ok := raw["messages"]
+	editor, ok := newApprovalBodyEditor(nil, provider, body)
 	if !ok {
 		return body, false, nil
 	}
-	var messages []map[string]json.RawMessage
-	if err := json.Unmarshal(rawMessages, &messages); err != nil {
-		return body, false, err
-	}
-
-	changed := false
-
-	for i := 1; i < len(messages); i++ {
-		// Current must be user role.
-		var role string
-		if err := json.Unmarshal(messages[i]["role"], &role); err != nil || role != "user" {
-			continue
-		}
-		// Current content must parse to bare "approve" (the harness
-		// records exactly what the user typed — bare "approve" or
-		// "approve cv-xxx").
-		userText := flattenAnthropicTaskReplyText(messages[i]["content"])
-		verb, _ := conversation.ParseApprovalReplyText(userText)
-		if verb != "approve" {
-			continue
-		}
-		// Skip if we've already augmented this turn — the bracketed
-		// context contains a recognizable marker. Idempotency.
-		if strings.Contains(userText, InlineApprovalAugmentationMarker) {
-			continue
-		}
-
-		// Prior message must be assistant whose text starts with the
-		// substituted-prompt marker. That's how we know this approve
-		// was an inline task gesture (vs. a regular tool approval).
-		var priorRole string
-		if err := json.Unmarshal(messages[i-1]["role"], &priorRole); err != nil || priorRole != "assistant" {
-			continue
-		}
-		priorText := flattenAnthropicTaskReplyText(messages[i-1]["content"])
-		if !strings.Contains(priorText, InlineApprovalSubstitutedPromptMarker) {
-			continue
-		}
-
-		// Decide the augmentation text by looking up the per-approval
-		// outcome the rewrite path recorded on the original turn.
-		// Failed approvals must NOT be re-rendered as success on later
-		// turns — that would falsely tell the model the task is active.
-		approvalID := extractApprovalIDFromPrompt(priorText)
-		note, ok := augmentationContextForOutcome(InlineApprovalOutcomeKey{
-			UserID:     userID,
-			AgentID:    agentID,
-			ApprovalID: approvalID,
-		}, outcomes)
-		if !ok {
-			// Unknown outcome: prompt is from before the footer was
-			// added, or the outcome cache evicted/never recorded.
-			// Skip rather than guess.
-			continue
-		}
-
-		// Rewrite this user message's content. Verb is STRIPPED on
-		// both shapes — the bracketed note conveys what the user did
-		// and leaving "approve" on its own line would parse as a
-		// fresh approval to any downstream consumer (release path,
-		// future augmenter pass). See augmentUserContent for details.
-		//
-		//   - Bare string: replaced wholesale with note.
-		//   - Array of blocks: bare-verb lines stripped from every
-		//     text block; note spliced in at the first verb-bearing
-		//     block's position. Non-text blocks and prose pass
-		//     through unchanged.
-		updated, ok := augmentUserContent(messages[i]["content"], verb, note)
-		if !ok {
-			// Shape we don't know how to edit safely. Skip rather
-			// than risk losing image/tool_result blocks.
-			continue
-		}
-		messages[i]["content"] = updated
-		changed = true
-	}
-
-	if !changed {
-		return body, false, nil
-	}
-	updatedMessages, err := json.Marshal(messages)
-	if err != nil {
-		return body, false, err
-	}
-	raw["messages"] = updatedMessages
-	out, err := json.Marshal(raw)
-	if err != nil {
-		return body, false, err
-	}
-	return out, true, nil
-}
-
-// augmentUserContent rewrites a user message's content with the
-// approval augmentation while preserving non-text blocks (images,
-// tool_results) the harness may have included alongside.
-//
-// Both content shapes have the verb STRIPPED — neither string nor
-// array form leaves a bare "approve" line behind. A downstream
-// re-parse (release path, future augmenter pass, defensive scan) must
-// never find a fresh-looking approval gesture in already-augmented
-// content. The bracketed note conveys what happened ("created and
-// approved by the user inline" / "creation was NOT completed").
-//
-//   - Bare string: replaced wholesale with note.
-//   - Array of blocks: every text block whose text parses as a verb
-//     has its bare-verb lines STRIPPED; the note is spliced in at the
-//     first verb-bearing block's position. Non-text blocks and text
-//     blocks that don't carry the verb pass through unchanged.
-//
-// Returns (encoded, true) on success; (_, false) when the content
-// shape isn't one we can edit safely (e.g., an array with no
-// verb-bearing text block).
-func augmentUserContent(content json.RawMessage, verb, note string) (json.RawMessage, bool) {
-	_ = verb // historical signature; verb is no longer prepended
-
-	if len(content) == 0 {
-		encoded, err := json.Marshal(note)
-		return encoded, err == nil
-	}
-	// Bare string content.
-	var s string
-	if err := json.Unmarshal(content, &s); err == nil {
-		encoded, marshalErr := json.Marshal(note)
-		return encoded, marshalErr == nil
-	}
-	// Array-of-blocks content. Multi-block user messages can carry
-	// verb-bearing lines in more than one text block (e.g., an
-	// earlier "deny cv-stale" plus a later bare "approve"). Strip
-	// bare-verb lines from EVERY text block so none of them remains
-	// parseable as a fresh approval; splice the augmentation note in
-	// at the first verb-bearing block's position.
-	var blocks []map[string]json.RawMessage
-	if err := json.Unmarshal(content, &blocks); err != nil {
-		return nil, false
-	}
-	spliceAt := -1
-	for i, blk := range blocks {
-		var t string
-		if err := json.Unmarshal(blk["type"], &t); err != nil {
-			continue
-		}
-		if t != "text" {
-			continue
-		}
-		var text string
-		if err := json.Unmarshal(blk["text"], &text); err != nil {
-			continue
-		}
-		if v, _ := conversation.ParseApprovalReplyText(text); v == "" {
-			continue
-		}
-		if spliceAt < 0 {
-			spliceAt = i
-		}
-		stripped := stripBareApprovalLines(text)
-		encoded, err := json.Marshal(stripped)
-		if err != nil {
-			return nil, false
-		}
-		blocks[i]["text"] = encoded
-	}
-	if spliceAt < 0 {
-		return nil, false
-	}
-	// Splice the note into the first verb-bearing block. If that
-	// block is now empty (its content was only verb lines), the note
-	// becomes its content; otherwise the note is appended to whatever
-	// non-verb prose remained.
-	var spliceText string
-	_ = json.Unmarshal(blocks[spliceAt]["text"], &spliceText)
-	newSpliceText := note
-	if spliceText != "" {
-		newSpliceText = spliceText + "\n\n" + note
-	}
-	encoded, err := json.Marshal(newSpliceText)
-	if err != nil {
-		return nil, false
-	}
-	blocks[spliceAt]["text"] = encoded
-
-	// Drop any text block whose text became empty after stripping.
-	// Anthropic rejects requests containing empty text blocks
-	// (`messages: text content blocks must be non-empty`), and a
-	// multi-block user message with two verb-bearing blocks would
-	// otherwise leave the non-spliced one as {"type":"text","text":""}.
-	// The spliceAt block is not at risk — we just filled it with the
-	// note above.
-	kept := blocks[:0]
-	for _, blk := range blocks {
-		var t string
-		if err := json.Unmarshal(blk["type"], &t); err == nil && t == "text" {
-			var bt string
-			if err := json.Unmarshal(blk["text"], &bt); err == nil && bt == "" {
-				continue
-			}
-		}
-		kept = append(kept, blk)
-	}
-
-	out, err := json.Marshal(kept)
-	if err != nil {
-		return nil, false
-	}
-	return out, true
-}
-
-// stripBareApprovalLines removes lines that match the bare or
-// verb+cv-id approval shape — exactly the lines ParseApprovalReplyText
-// would have flagged. Used to ensure the augmented message doesn't
-// leave a parseable "approve" / "approve cv-xxx" line behind in the
-// content, which a downstream re-parse could interpret as a fresh
-// approval gesture.
-func stripBareApprovalLines(text string) string {
-	text = strings.ReplaceAll(text, "\r\n", "\n")
-	lines := strings.Split(text, "\n")
-	kept := make([]string, 0, len(lines))
-	for _, line := range lines {
-		probe := strings.TrimSpace(line)
-		if probe == "" {
-			kept = append(kept, line)
-			continue
-		}
-		// Use the same parser that decides whether a line is an
-		// approval — anything it would match, we drop.
-		if verb, _ := conversation.ParseApprovalReplyText(probe); verb != "" {
-			continue
-		}
-		kept = append(kept, line)
-	}
-	return strings.TrimSpace(strings.Join(kept, "\n"))
+	return editor.AugmentInlineApprovalHistory(outcomes, userID, agentID)
 }
 
 // augmentationContextForOutcome maps an outcome lookup to the bracketed

--- a/internal/runtime/llmproxy/inline_task_rewrite.go
+++ b/internal/runtime/llmproxy/inline_task_rewrite.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
 	"github.com/clawvisor/clawvisor/pkg/store"
@@ -219,11 +220,7 @@ func RewriteInlineTaskApprovalReply(ctx context.Context, req InlineApprovalRewri
 			UserID:     req.Agent.UserID,
 			AgentID:    req.Agent.ID,
 			ApprovalID: resolved.ID,
-		}, InlineApprovalOutcome{
-			Succeeded:     out.Decision == "allow",
-			TaskID:        out.TaskID,
-			FailureReason: out.Reason,
-		})
+		}, inlineApprovalOutcomeFromRewrite(req.RequestID, out))
 	}
 
 	rewritten, ok, err := replaceApprovalReplyForProvider(req.HTTPRequest, req.Provider, req.Body, verb, replacement)
@@ -239,6 +236,19 @@ func RewriteInlineTaskApprovalReply(ctx context.Context, req InlineApprovalRewri
 	out.Body = rewritten
 	out.Rewritten = true
 	return out, nil
+}
+
+func inlineApprovalOutcomeFromRewrite(requestID string, out InlineApprovalRewriteResult) InlineApprovalOutcome {
+	return InlineApprovalOutcome{
+		Decision:         out.Decision,
+		Outcome:          out.Outcome,
+		Succeeded:        out.Decision == "allow",
+		TaskID:           out.TaskID,
+		ApprovalRecordID: out.ApprovalRecordID,
+		FailureReason:    out.Reason,
+		RequestID:        requestID,
+		ResolvedAt:       time.Now().UTC(),
+	}
 }
 
 // InlineApprovalSubstitutedPromptMarker is the leading phrase of the

--- a/internal/runtime/llmproxy/inline_task_state_machine.md
+++ b/internal/runtime/llmproxy/inline_task_state_machine.md
@@ -114,15 +114,14 @@ Effects:
 
 ## Layer Ownership
 
-- `approval_body_editor.go`: provider request-body parsing and user text
-  replacement.
+- `approval_body_editor.go`: provider request-body parsing, user text
+  replacement, text flattening, and history augmentation shape edits.
 - `approval_reply_resolver.go`: pending-hold routing and action
   classification.
 - `inline_task_transitions.go`: named transition side effects.
-- `inline_task_rewrite.go`: inline approval preprocessing and history
-  augmentation.
+- `inline_task_rewrite.go`: inline approval preprocessing orchestration
+  and provider-independent augmentation context.
 - `task_reply.go`: `task` reply preprocessing.
 - `release.go`: regular tool approval release and fail-closed guard.
 - `inline_approval_outcome.go`: canonical in-memory resolution records
   used by history augmentation and diagnostics.
-

--- a/internal/runtime/llmproxy/inline_task_state_machine.md
+++ b/internal/runtime/llmproxy/inline_task_state_machine.md
@@ -1,0 +1,128 @@
+# Inline Task Approval State Machine
+
+This document describes the conversational approval flow that lets a
+user turn a blocked tool approval into an inline-approved task.
+
+## Stages
+
+`StageTool`
+
+- Standard pending tool approval.
+- The user may reply `approve`, `deny`, or `task`.
+- `approve`/`deny` are handled by `TryReleasePendingApproval`.
+- `task` is handled by `RewriteTaskApprovalReply`.
+
+`StageAwaitingTaskApproval`
+
+- The model emitted `POST /control/tasks?surface=inline`, and the proxy
+  substituted a task approval prompt back into the conversation.
+- The user may reply `approve` or `deny`.
+- `approve`/`deny` are handled by `RewriteInlineTaskApprovalReply`.
+- If this stage reaches `TryReleasePendingApproval`, release fails
+  closed with `inline_task_preprocess_missing` and leaves the hold in
+  cache for retry.
+
+## Routing
+
+`resolveApprovalReplyAction` owns approval reply routing.
+
+Rules:
+
+- Explicit approval IDs target only that hold.
+- Bare replies target the newest visible hold across all stages.
+- `approve`/`deny` on a `StageAwaitingTaskApproval` hold route to the
+  inline task approval transition.
+- `approve`/`deny` on any other hold route to regular tool release.
+- `task` routes to the inline task-definition transition for the
+  targeted hold.
+
+The routing function only peeks and classifies. Transition helpers own
+state mutation.
+
+## Transitions
+
+`RewriteTaskApprovalReply`
+
+```text
+StageTool + task -> startInlineTaskDefinition
+```
+
+Effects:
+
+- Consumes the targeted tool hold.
+- Rewrites the user's `task` reply into a deterministic
+  `/control/tasks?surface=inline` task-creation prompt.
+- Does not create a task.
+- Does not retain an orphan tool hold that could later be approved.
+
+`Postprocess` inline task intercept
+
+```text
+model POST /control/tasks?surface=inline -> StageAwaitingTaskApproval
+```
+
+Effects:
+
+- Parses the task definition.
+- Creates an inner pending hold at `StageAwaitingTaskApproval`.
+- Substitutes the inline task approval prompt into the model response.
+
+`RewriteInlineTaskApprovalReply`
+
+```text
+StageAwaitingTaskApproval + approve -> resolveInlineTaskApproval(success or failure)
+StageAwaitingTaskApproval + deny    -> resolveInlineTaskApproval(denied)
+```
+
+Effects:
+
+- Preflights request-body rewriting before mutating cache state.
+- Consumes the inner inline approval hold.
+- Drops the linked outer tool hold, if present.
+- On approve, attempts task creation through `InlineTaskCreator`.
+- Records one `InlineApprovalOutcome` resolution record.
+- Rewrites the user's reply into the canonical inline task context.
+
+`TryReleasePendingApproval`
+
+```text
+StageTool + approve -> release tool
+StageTool + deny    -> deny tool
+```
+
+Effects:
+
+- Resolves the same hold that routing peeked by explicit ID, closing the
+  peek/resolve race where a newer hold could otherwise be consumed.
+- Revalidates the held tool before release.
+- Emits the synthetic allow/deny provider response.
+
+## Invariants
+
+- Bare replies always target the newest visible hold.
+- Explicit IDs target only the matching hold.
+- Older inline holds cannot steal newer regular tool approvals.
+- Older tool holds cannot steal newer inline approvals.
+- `task` on a tool hold never releases that tool.
+- `approve` on an inline task hold never releases the original raw tool.
+- `approve` on a tool hold never creates an inline task.
+- Unsupported body rewrite shapes do not consume inline approval holds.
+- Failed inline task creation is never augmented as success in later
+  conversation history.
+- Already-augmented historical approval messages must not leave stale
+  bare approval text behind.
+
+## Layer Ownership
+
+- `approval_body_editor.go`: provider request-body parsing and user text
+  replacement.
+- `approval_reply_resolver.go`: pending-hold routing and action
+  classification.
+- `inline_task_transitions.go`: named transition side effects.
+- `inline_task_rewrite.go`: inline approval preprocessing and history
+  augmentation.
+- `task_reply.go`: `task` reply preprocessing.
+- `release.go`: regular tool approval release and fail-closed guard.
+- `inline_approval_outcome.go`: canonical in-memory resolution records
+  used by history augmentation and diagnostics.
+

--- a/internal/runtime/llmproxy/inline_task_transitions.go
+++ b/internal/runtime/llmproxy/inline_task_transitions.go
@@ -7,7 +7,7 @@ import (
 	"github.com/clawvisor/clawvisor/pkg/store"
 )
 
-func startInlineTaskDefinition(ctx context.Context, req TaskReplyRewriteRequest, action approvalReplyAction) (TaskReplyRewriteResult, error) {
+func startInlineTaskDefinition(ctx context.Context, req TaskReplyRewriteRequest, action approvalReplyAction, editor approvalBodyEditor) (TaskReplyRewriteResult, error) {
 	// Drop the original tool hold. The user typed "task" so the
 	// harness now shows the task-creation prompt instead — there's
 	// no way back to approving the original tool. Leaving the hold
@@ -24,7 +24,7 @@ func startInlineTaskDefinition(ctx context.Context, req TaskReplyRewriteRequest,
 	if err != nil || pending == nil {
 		return TaskReplyRewriteResult{Body: req.Body}, err
 	}
-	rewritten, ok, err := replaceTaskReplyForProvider(req.HTTPRequest, req.Provider, req.Body, taskCreationPrompt(pending.ToolUse))
+	rewritten, ok, err := editor.ReplaceLatestUserText("task", taskCreationPrompt(pending.ToolUse))
 	if err != nil || !ok {
 		return TaskReplyRewriteResult{Body: req.Body}, err
 	}

--- a/internal/runtime/llmproxy/inline_task_transitions.go
+++ b/internal/runtime/llmproxy/inline_task_transitions.go
@@ -1,0 +1,101 @@
+package llmproxy
+
+import (
+	"context"
+
+	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+func startInlineTaskDefinition(ctx context.Context, req TaskReplyRewriteRequest, action approvalReplyAction) (TaskReplyRewriteResult, error) {
+	// Drop the original tool hold. The user typed "task" so the
+	// harness now shows the task-creation prompt instead — there's
+	// no way back to approving the original tool. Leaving the hold
+	// in the cache was a latent safety issue: if the model didn't
+	// follow through with POST /control/tasks, the orphan hold could
+	// later be resolved as a regular tool approval by a bare approve.
+	//
+	// The inline-task intercept now relies on the query signal
+	// (surface=inline in the URL) rather than a retained
+	// awaiting_task_definition hold. taskCreationPrompt always renders
+	// surface=inline in the example URL, so compliant models still
+	// drive the inline path.
+	pending, err := consumeApprovalActionHold(ctx, req.PendingApproval, req.Agent, req.Provider, action)
+	if err != nil || pending == nil {
+		return TaskReplyRewriteResult{Body: req.Body}, err
+	}
+	rewritten, ok, err := replaceTaskReplyForProvider(req.HTTPRequest, req.Provider, req.Body, taskCreationPrompt(pending.ToolUse))
+	if err != nil || !ok {
+		return TaskReplyRewriteResult{Body: req.Body}, err
+	}
+	return TaskReplyRewriteResult{Body: rewritten, Rewritten: true}, nil
+}
+
+func consumeApprovalActionHold(ctx context.Context, cache PendingApprovalCache, agent *store.Agent, provider conversation.Provider, action approvalReplyAction) (*PendingLiteApproval, error) {
+	if cache == nil || agent == nil || action.Hold == nil {
+		return nil, nil
+	}
+	return cache.Resolve(ctx, ResolveRequest{
+		UserID:     agent.UserID,
+		AgentID:    agent.ID,
+		Provider:   provider,
+		ApprovalID: action.Hold.ID,
+	})
+}
+
+func dropLinkedToolHold(ctx context.Context, cache PendingApprovalCache, agent *store.Agent, provider conversation.Provider, resolved *PendingLiteApproval) {
+	if cache == nil || agent == nil || resolved == nil || resolved.AwaitingTaskFor == "" {
+		return
+	}
+	_ = cache.Drop(ctx, ResolveRequest{
+		UserID:     agent.UserID,
+		AgentID:    agent.ID,
+		Provider:   provider,
+		ApprovalID: resolved.AwaitingTaskFor,
+	})
+}
+
+func resolveInlineTaskApproval(ctx context.Context, req InlineApprovalRewriteRequest, resolved *PendingLiteApproval, verb string) (string, InlineApprovalRewriteResult) {
+	out := InlineApprovalRewriteResult{Body: req.Body}
+	if verb == "deny" {
+		out.Decision = "deny"
+		out.Outcome = "inline_task_denied"
+		out.Reason = "user denied inline task"
+		return renderInlineTaskDenyReply(), out
+	}
+
+	switch {
+	case req.Creator == nil:
+		out.Decision = "deny"
+		out.Outcome = "inline_task_creator_missing"
+		out.Reason = "no inline task creator configured"
+		return renderInlineTaskCreatorErrorReply("inline task creation is not available on this daemon"), out
+	case resolved == nil || resolved.TaskDefinition == nil:
+		out.Decision = "deny"
+		out.Outcome = "inline_task_definition_missing"
+		out.Reason = "missing task definition on approval"
+		return renderInlineTaskCreatorErrorReply("missing task definition on approval"), out
+	default:
+		originalToolUseID := resolved.AwaitingTaskFor
+		created, createErr := req.Creator.CreateInlineApprovedTask(ctx, req.Agent, resolved.TaskDefinition, originalToolUseID)
+		if createErr != nil {
+			out.Decision = "deny"
+			out.Outcome = "inline_task_create_failed"
+			out.Reason = "create failed: " + createErr.Error()
+			return renderInlineTaskCreatorErrorReply(createErr.Error()), out
+		}
+
+		out.Decision = "allow"
+		out.Outcome = "inline_task_approved"
+		out.TaskID = created.ID
+		out.ApprovalRecordID = created.ApprovalRecordID
+		if req.Audit != nil {
+			req.Audit.LogInlineTaskApproved(ctx, req.Agent, req.RequestID, resolved, created)
+		}
+		// Use the SAME text the persistent augmenter produces on
+		// subsequent turns. One canonical rendering avoids showing the
+		// model the same user approve turn with different content across
+		// calls.
+		return inlineApprovedReplyAugmentation(), out
+	}
+}

--- a/internal/runtime/llmproxy/inspector/parser.go
+++ b/internal/runtime/llmproxy/inspector/parser.go
@@ -105,6 +105,9 @@ var localOnlyTools = map[string]struct{}{
 	"TaskGet":    {},
 	"TaskOutput": {},
 	"TaskStop":   {},
+	// Harness-internal user clarification prompt. It does not reach
+	// outside the harness and should not require an approved task scope.
+	"AskUserQuestion": {},
 }
 
 func isLocalOnlyTool(name string) bool {

--- a/internal/runtime/llmproxy/inspector/parser_flags_test.go
+++ b/internal/runtime/llmproxy/inspector/parser_flags_test.go
@@ -138,6 +138,7 @@ func TestParser_LocalOnlyToolsPassThrough(t *testing.T) {
 		{"glob_with_placeholder_pattern", "Glob", `{"pattern":"autovault_github_xxx*.json"}`},
 		// Codex's read_file is treated the same as Claude Code's Read.
 		{"codex_read_file", "read_file", `{"path":"/tmp/autovault_github_xxx.json"}`},
+		{"ask_user_question", "AskUserQuestion", `{"question":"Use autovault_github_xxx for this task?","options":["yes","no"]}`},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/runtime/llmproxy/postprocess_test.go
+++ b/internal/runtime/llmproxy/postprocess_test.go
@@ -372,6 +372,7 @@ func TestPostprocess_LocalOnlyToolsBypassTaskScope(t *testing.T) {
 		{"task_get", "TaskGet", `{"taskId":"1"}`},
 		{"task_output", "TaskOutput", `{"taskId":"1"}`},
 		{"task_stop", "TaskStop", `{"taskId":"1"}`},
+		{"ask_user_question", "AskUserQuestion", `{"question":"Proceed with this approach?","options":["yes","no"]}`},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/runtime/llmproxy/release.go
+++ b/internal/runtime/llmproxy/release.go
@@ -34,13 +34,13 @@ type InlineTaskCreator interface {
 // model needs to see — it isn't a full store.Task because the LLM
 // doesn't care about every column.
 type InlineApprovedTask struct {
-	ID                string `json:"task_id"`
-	Status            string `json:"status"`
-	Purpose           string `json:"purpose,omitempty"`
-	Lifetime          string `json:"lifetime,omitempty"`
-	ApprovalSource    string `json:"approval_source,omitempty"`
-	ApprovalRecordID  string `json:"approval_record_id,omitempty"`
-	ExpiresAtRFC3339  string `json:"expires_at,omitempty"`
+	ID               string `json:"task_id"`
+	Status           string `json:"status"`
+	Purpose          string `json:"purpose,omitempty"`
+	Lifetime         string `json:"lifetime,omitempty"`
+	ApprovalSource   string `json:"approval_source,omitempty"`
+	ApprovalRecordID string `json:"approval_record_id,omitempty"`
+	ExpiresAtRFC3339 string `json:"expires_at,omitempty"`
 }
 
 type ReleaseRequest struct {
@@ -89,28 +89,18 @@ func TryReleasePendingApproval(ctx context.Context, req ReleaseRequest) ReleaseR
 	if verb == "task" {
 		return ReleaseResult{}
 	}
-	// Peek first to inspect the hold's stage. Resolving up-front would
-	// destroy an inline-task hold on the fail-closed guard below — the
-	// next user retry would find no hold and the inline flow would
-	// stay broken until TTL expiry. Resolve only after we know the
-	// stage is one this path should consume.
-	//
-	// Routing rule for bare replies (no ApprovalID): the user is
-	// answering the MOST RECENT prompt the harness rendered. We peek
-	// LIFO across all stages — if that newest hold is an inline-task
-	// hold, the preprocess didn't fire and we fail closed; if it's a
-	// regular tool hold, we proceed even when an OLDER inline hold is
-	// also pending (that older hold isn't what the user is replying
-	// to and stays in the cache for its own resolution path).
-	peeked, err := req.PendingApproval.Peek(ctx, ResolveRequest{
-		UserID:     req.Agent.UserID,
-		AgentID:    req.Agent.ID,
-		Provider:   req.Provider,
-		ApprovalID: approvalID,
+	action, err := resolveApprovalReplyAction(ctx, approvalReplyRoutingRequest{
+		UserID:          req.Agent.UserID,
+		AgentID:         req.Agent.ID,
+		Provider:        req.Provider,
+		PendingApproval: req.PendingApproval,
+		Verb:            verb,
+		ApprovalID:      approvalID,
 	})
 	if err != nil {
 		return ReleaseResult{Handled: true, HTTPStatus: http.StatusServiceUnavailable, Decision: "deny", Outcome: "approval_release_error", Reason: err.Error()}
 	}
+	peeked := action.Hold
 	if peeked == nil {
 		if approvalID != "" {
 			return ReleaseResult{Handled: true, HTTPStatus: http.StatusNotFound, Decision: "deny", Outcome: "approval_not_found", Reason: "no matching pending approval"}
@@ -124,7 +114,7 @@ func TryReleasePendingApproval(ctx context.Context, req ReleaseRequest) ReleaseR
 	// naming an inline-task hold directly. Older inline holds sitting
 	// behind a newer non-inline hold are NOT the user's target here
 	// and stay in the cache untouched.
-	if peeked.Stage == StageAwaitingTaskApproval {
+	if action.Kind == approvalReplyActionApproveInlineTask || action.Kind == approvalReplyActionDenyInlineTask {
 		req.logRelease(ctx, peeked, "deny", "blocked", "inline-task hold reached release path; preprocess not wired")
 		// 503 (Service Unavailable) reads more honestly than 500
 		// here: the inline-approval preprocess is missing, the

--- a/internal/runtime/llmproxy/release.go
+++ b/internal/runtime/llmproxy/release.go
@@ -82,7 +82,7 @@ type ReleaseResult struct {
 }
 
 func TryReleasePendingApproval(ctx context.Context, req ReleaseRequest) ReleaseResult {
-	verb, approvalID := conversation.ApprovalReplyForProvider(req.Provider, req.Body)
+	verb, approvalID := approvalReplyFromBody(req.HTTPRequest, req.Provider, req.Body)
 	if verb == "" || req.PendingApproval == nil || req.Agent == nil {
 		return ReleaseResult{}
 	}

--- a/internal/runtime/llmproxy/release.go
+++ b/internal/runtime/llmproxy/release.go
@@ -82,8 +82,12 @@ type ReleaseResult struct {
 }
 
 func TryReleasePendingApproval(ctx context.Context, req ReleaseRequest) ReleaseResult {
-	verb, approvalID := approvalReplyFromBody(req.HTTPRequest, req.Provider, req.Body)
-	if verb == "" || req.PendingApproval == nil || req.Agent == nil {
+	editor, ok := newApprovalBodyEditor(req.HTTPRequest, req.Provider, req.Body)
+	if !ok {
+		return ReleaseResult{}
+	}
+	verb, approvalID, ok := editor.LatestApprovalReply()
+	if !ok || verb == "" || req.PendingApproval == nil || req.Agent == nil {
 		return ReleaseResult{}
 	}
 	if verb == "task" {

--- a/internal/runtime/llmproxy/task_reply.go
+++ b/internal/runtime/llmproxy/task_reply.go
@@ -39,40 +39,7 @@ func RewriteTaskApprovalReply(ctx context.Context, req TaskReplyRewriteRequest) 
 	if err != nil || action.Kind != approvalReplyActionStartInlineTaskDefinition || action.Hold == nil {
 		return TaskReplyRewriteResult{Body: req.Body}, err
 	}
-	pending, err := req.PendingApproval.Resolve(ctx, ResolveRequest{
-		UserID:     req.Agent.UserID,
-		AgentID:    req.Agent.ID,
-		Provider:   req.Provider,
-		ApprovalID: action.Hold.ID,
-	})
-	if err != nil || pending == nil {
-		return TaskReplyRewriteResult{Body: req.Body}, err
-	}
-	// Drop the original tool hold. The user typed "task" so the
-	// harness now shows the task-creation prompt instead — there's
-	// no way back to approving the original tool. Leaving the hold
-	// in the cache (the previous behavior, which only transitioned
-	// the stage) was a latent safety issue: if the model didn't
-	// follow through with POST /control/tasks, the orphan hold
-	// could later be resolved as a regular tool approval by a bare
-	// `approve` reply on something else (LIFO ordering picks the
-	// newest, but the orphan can still surface when it's the only
-	// hold left), which would run the originally-blocked tool with
-	// no real human authorization.
-	//
-	// Note: this leaves the inline-task intercept relying entirely
-	// on the query signal (surface=inline in the URL) rather than
-	// the state signal (a prior awaiting_task_definition hold).
-	// taskCreationPrompt always renders surface=inline in the
-	// example URL, so this is robust for compliant models. A model
-	// that drops surface=inline falls through to the dashboard
-	// path, which is the same fallback as before any of this
-	// landed.
-	rewritten, ok, err := replaceTaskReplyForProvider(req.HTTPRequest, req.Provider, req.Body, taskCreationPrompt(pending.ToolUse))
-	if err != nil || !ok {
-		return TaskReplyRewriteResult{Body: req.Body}, err
-	}
-	return TaskReplyRewriteResult{Body: rewritten, Rewritten: true}, nil
+	return startInlineTaskDefinition(ctx, req, action)
 }
 
 func replaceTaskReplyForProvider(req *http.Request, provider conversation.Provider, body []byte, replacement string) ([]byte, bool, error) {

--- a/internal/runtime/llmproxy/task_reply.go
+++ b/internal/runtime/llmproxy/task_reply.go
@@ -24,7 +24,7 @@ type TaskReplyRewriteResult struct {
 }
 
 func RewriteTaskApprovalReply(ctx context.Context, req TaskReplyRewriteRequest) (TaskReplyRewriteResult, error) {
-	verb, approvalID := conversation.ApprovalReplyForProvider(req.Provider, req.Body)
+	verb, approvalID := approvalReplyFromBody(req.HTTPRequest, req.Provider, req.Body)
 	if verb != "task" || req.PendingApproval == nil || req.Agent == nil {
 		return TaskReplyRewriteResult{Body: req.Body}, nil
 	}
@@ -86,17 +86,11 @@ func replaceTaskReplyForProvider(req *http.Request, provider conversation.Provid
 // the LLM sees a clean conversation state instead of a synthesized
 // tool_use it never authored).
 func replaceApprovalReplyForProvider(req *http.Request, provider conversation.Provider, body []byte, expectedVerb, replacement string) ([]byte, bool, error) {
-	switch provider {
-	case conversation.ProviderAnthropic:
-		return replaceAnthropicApprovalReply(body, expectedVerb, replacement)
-	case conversation.ProviderOpenAI:
-		if conversation.IsOpenAIChatCompletionsEndpoint(req) {
-			return replaceOpenAIChatApprovalReply(body, expectedVerb, replacement)
-		}
-		return replaceOpenAIResponsesApprovalReply(body, expectedVerb, replacement)
-	default:
+	editor, ok := newApprovalBodyEditor(req, provider, body)
+	if !ok {
 		return body, false, nil
 	}
+	return editor.ReplaceLatestUserText(expectedVerb, replacement)
 }
 
 func replaceAnthropicApprovalReply(body []byte, expectedVerb, replacement string) ([]byte, bool, error) {

--- a/internal/runtime/llmproxy/task_reply.go
+++ b/internal/runtime/llmproxy/task_reply.go
@@ -28,11 +28,22 @@ func RewriteTaskApprovalReply(ctx context.Context, req TaskReplyRewriteRequest) 
 	if verb != "task" || req.PendingApproval == nil || req.Agent == nil {
 		return TaskReplyRewriteResult{Body: req.Body}, nil
 	}
+	action, err := resolveApprovalReplyAction(ctx, approvalReplyRoutingRequest{
+		UserID:          req.Agent.UserID,
+		AgentID:         req.Agent.ID,
+		Provider:        req.Provider,
+		PendingApproval: req.PendingApproval,
+		Verb:            verb,
+		ApprovalID:      approvalID,
+	})
+	if err != nil || action.Kind != approvalReplyActionStartInlineTaskDefinition || action.Hold == nil {
+		return TaskReplyRewriteResult{Body: req.Body}, err
+	}
 	pending, err := req.PendingApproval.Resolve(ctx, ResolveRequest{
 		UserID:     req.Agent.UserID,
 		AgentID:    req.Agent.ID,
 		Provider:   req.Provider,
-		ApprovalID: approvalID,
+		ApprovalID: action.Hold.ID,
 	})
 	if err != nil || pending == nil {
 		return TaskReplyRewriteResult{Body: req.Body}, err

--- a/internal/runtime/llmproxy/task_reply.go
+++ b/internal/runtime/llmproxy/task_reply.go
@@ -2,9 +2,7 @@ package llmproxy
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
-	"strings"
 
 	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
 	"github.com/clawvisor/clawvisor/pkg/store"
@@ -24,8 +22,12 @@ type TaskReplyRewriteResult struct {
 }
 
 func RewriteTaskApprovalReply(ctx context.Context, req TaskReplyRewriteRequest) (TaskReplyRewriteResult, error) {
-	verb, approvalID := approvalReplyFromBody(req.HTTPRequest, req.Provider, req.Body)
-	if verb != "task" || req.PendingApproval == nil || req.Agent == nil {
+	editor, ok := newApprovalBodyEditor(req.HTTPRequest, req.Provider, req.Body)
+	if !ok {
+		return TaskReplyRewriteResult{Body: req.Body}, nil
+	}
+	verb, approvalID, ok := editor.LatestApprovalReply()
+	if !ok || verb != "task" || req.PendingApproval == nil || req.Agent == nil {
 		return TaskReplyRewriteResult{Body: req.Body}, nil
 	}
 	action, err := resolveApprovalReplyAction(ctx, approvalReplyRoutingRequest{
@@ -39,202 +41,5 @@ func RewriteTaskApprovalReply(ctx context.Context, req TaskReplyRewriteRequest) 
 	if err != nil || action.Kind != approvalReplyActionStartInlineTaskDefinition || action.Hold == nil {
 		return TaskReplyRewriteResult{Body: req.Body}, err
 	}
-	return startInlineTaskDefinition(ctx, req, action)
-}
-
-func replaceTaskReplyForProvider(req *http.Request, provider conversation.Provider, body []byte, replacement string) ([]byte, bool, error) {
-	return replaceApprovalReplyForProvider(req, provider, body, "task", replacement)
-}
-
-// replaceApprovalReplyForProvider rewrites the most recent user
-// message's text content when its parsed verb matches expectedVerb.
-// Used for both "task" (rewriting to the task-creation prompt) and
-// "approve"/"deny" (rewriting to inline-task approval context, so
-// the LLM sees a clean conversation state instead of a synthesized
-// tool_use it never authored).
-func replaceApprovalReplyForProvider(req *http.Request, provider conversation.Provider, body []byte, expectedVerb, replacement string) ([]byte, bool, error) {
-	editor, ok := newApprovalBodyEditor(req, provider, body)
-	if !ok {
-		return body, false, nil
-	}
-	return editor.ReplaceLatestUserText(expectedVerb, replacement)
-}
-
-func replaceAnthropicApprovalReply(body []byte, expectedVerb, replacement string) ([]byte, bool, error) {
-	var req struct {
-		Messages []struct {
-			Role    string          `json:"role"`
-			Content json.RawMessage `json:"content"`
-		} `json:"messages"`
-	}
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(body, &raw); err != nil {
-		return nil, false, err
-	}
-	if err := json.Unmarshal(body, &req); err != nil {
-		return nil, false, err
-	}
-	for i := len(req.Messages) - 1; i >= 0; i-- {
-		if req.Messages[i].Role != "user" {
-			continue
-		}
-		verb, _ := conversation.ParseApprovalReplyText(flattenAnthropicTaskReplyText(req.Messages[i].Content))
-		if verb != expectedVerb {
-			return body, false, nil
-		}
-		encoded, _ := json.Marshal(replacement)
-		req.Messages[i].Content = encoded
-		messages, err := json.Marshal(req.Messages)
-		if err != nil {
-			return nil, false, err
-		}
-		raw["messages"] = messages
-		out, err := json.Marshal(raw)
-		return out, err == nil, err
-	}
-	return body, false, nil
-}
-
-func flattenAnthropicTaskReplyText(raw json.RawMessage) string {
-	if len(raw) == 0 {
-		return ""
-	}
-	var simple string
-	if err := json.Unmarshal(raw, &simple); err == nil {
-		return simple
-	}
-	var blocks []struct {
-		Type string `json:"type"`
-		Text string `json:"text,omitempty"`
-	}
-	if err := json.Unmarshal(raw, &blocks); err != nil {
-		return ""
-	}
-	// Concatenate every text-bearing block in order. Returning only
-	// the last block was a false-negative when the task reply was
-	// split across blocks or sat in an earlier block — the downstream
-	// parser finds the latest matching verb anywhere in the combined
-	// text.
-	var parts []string
-	for _, b := range blocks {
-		if b.Type == "text" && b.Text != "" {
-			parts = append(parts, b.Text)
-		}
-	}
-	return strings.Join(parts, "\n")
-}
-
-func replaceOpenAIChatApprovalReply(body []byte, expectedVerb, replacement string) ([]byte, bool, error) {
-	var req struct {
-		Messages []map[string]any `json:"messages"`
-	}
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(body, &raw); err != nil {
-		return nil, false, err
-	}
-	if err := json.Unmarshal(body, &req); err != nil {
-		return nil, false, err
-	}
-	for i := len(req.Messages) - 1; i >= 0; i-- {
-		role, _ := req.Messages[i]["role"].(string)
-		if role != "user" {
-			continue
-		}
-		contentRaw, _ := json.Marshal(req.Messages[i]["content"])
-		verb, _ := conversation.ParseApprovalReplyText(flattenOpenAITaskReplyContent(contentRaw))
-		if verb != expectedVerb {
-			return body, false, nil
-		}
-		req.Messages[i]["content"] = replacement
-		messages, err := json.Marshal(req.Messages)
-		if err != nil {
-			return nil, false, err
-		}
-		raw["messages"] = messages
-		out, err := json.Marshal(raw)
-		return out, err == nil, err
-	}
-	return body, false, nil
-}
-
-func replaceOpenAIResponsesApprovalReply(body []byte, expectedVerb, replacement string) ([]byte, bool, error) {
-	var req struct {
-		Input json.RawMessage `json:"input"`
-	}
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(body, &raw); err != nil {
-		return nil, false, err
-	}
-	if err := json.Unmarshal(body, &req); err != nil || len(req.Input) == 0 {
-		return body, false, err
-	}
-	var inputString string
-	if err := json.Unmarshal(req.Input, &inputString); err == nil {
-		verb, _ := conversation.ParseApprovalReplyText(inputString)
-		if verb != expectedVerb {
-			return body, false, nil
-		}
-		encoded, _ := json.Marshal(replacement)
-		raw["input"] = encoded
-		out, err := json.Marshal(raw)
-		return out, err == nil, err
-	}
-	var items []map[string]any
-	if err := json.Unmarshal(req.Input, &items); err != nil {
-		return body, false, nil
-	}
-	for i := len(items) - 1; i >= 0; i-- {
-		typ, _ := items[i]["type"].(string)
-		role, _ := items[i]["role"].(string)
-		if typ != "message" || role != "user" {
-			continue
-		}
-		contentRaw, _ := json.Marshal(items[i]["content"])
-		verb, _ := conversation.ParseApprovalReplyText(flattenOpenAITaskReplyContent(contentRaw))
-		if verb != expectedVerb {
-			return body, false, nil
-		}
-		items[i]["content"] = []map[string]any{{"type": "input_text", "text": replacement}}
-		input, err := json.Marshal(items)
-		if err != nil {
-			return nil, false, err
-		}
-		raw["input"] = input
-		out, err := json.Marshal(raw)
-		return out, err == nil, err
-	}
-	return body, false, nil
-}
-
-func flattenOpenAITaskReplyContent(raw json.RawMessage) string {
-	if len(raw) == 0 {
-		return ""
-	}
-	var simple string
-	if err := json.Unmarshal(raw, &simple); err == nil {
-		return simple
-	}
-	var blocks []struct {
-		Type string `json:"type"`
-		Text string `json:"text,omitempty"`
-	}
-	if err := json.Unmarshal(raw, &blocks); err != nil {
-		return ""
-	}
-	// Concatenate every text-bearing block in order. Returning only the
-	// last block was a false-negative when "approve cv-<id>" was split
-	// across blocks (e.g. ["please ", "approve cv-abc"]) or when the
-	// approve verb sat in an earlier block followed by trailing prose.
-	// The downstream parser regex finds the latest matching verb+id
-	// anywhere in the combined text.
-	var parts []string
-	for _, b := range blocks {
-		switch b.Type {
-		case "text", "input_text":
-			if b.Text != "" {
-				parts = append(parts, b.Text)
-			}
-		}
-	}
-	return strings.Join(parts, "\n")
+	return startInlineTaskDefinition(ctx, req, action, editor)
 }

--- a/internal/runtime/policy/task_match.go
+++ b/internal/runtime/policy/task_match.go
@@ -102,7 +102,7 @@ func toolNamesMatch(declared, actual string) bool {
 // class by accident.
 func toolClass(name string) string {
 	switch strings.ToLower(strings.TrimSpace(name)) {
-	case "bash", "shell", "exec_command":
+	case "bash", "shell", "exec", "exec_command":
 		return "shell"
 	case "read", "read_file":
 		return "read_file"

--- a/pkg/runtime/decision/decision_test.go
+++ b/pkg/runtime/decision/decision_test.go
@@ -346,6 +346,25 @@ func TestEvaluateAuthorization_ExpectedToolMatchAcceptsCrossHarnessAliases(t *te
 	}
 }
 
+// Regression: OpenClaw exposes its shell surface as `exec`, while the
+// task prompt asks models to declare shell scope as `Bash`. An inline
+// approved task with expected_tools_json[0].tool_name="Bash" must cover
+// a later OpenClaw `exec` call, otherwise the user sees a second
+// no-matching-task-scope approval immediately after approving the task.
+func TestEvaluateAuthorization_ExpectedToolMatchAcceptsOpenClawExecAlias(t *testing.T) {
+	got, err := EvaluateAuthorization(context.Background(), AuthorizationInput{
+		ToolUse:        toolUse("exec", map[string]any{"command": "openclaw cron --help 2>&1 | head -60"}),
+		AgentID:        "agent-1",
+		CandidateTasks: []*store.Task{taskWithExpectedTool("task-1", "agent-1", "Bash", "inspect openclaw cron help")},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Kind != VerdictAllow {
+		t.Fatalf("decision = %+v, want VerdictAllow (Bash should cover OpenClaw exec)", got)
+	}
+}
+
 // Regression: models populate expected_tools_json from documentation
 // and examples; they routinely use lowercase tool names (`bash`) even
 // when the harness reports `Bash`. The task-scope matcher must be
@@ -353,10 +372,10 @@ func TestEvaluateAuthorization_ExpectedToolMatchAcceptsCrossHarnessAliases(t *te
 // harness's capitalized actual tool name.
 func TestEvaluateAuthorization_ExpectedToolMatchIsCaseInsensitive(t *testing.T) {
 	got, err := EvaluateAuthorization(context.Background(), AuthorizationInput{
-		ToolUse:        toolUse("Bash", map[string]any{"command": "curl https://api.github.com/user"}),
-		AgentID:        "agent-1",
-		Service:        "github",
-		Action:         "get_user",
+		ToolUse: toolUse("Bash", map[string]any{"command": "curl https://api.github.com/user"}),
+		AgentID: "agent-1",
+		Service: "github",
+		Action:  "get_user",
 		// Task declared lowercase "bash" (what the model wrote).
 		CandidateTasks: []*store.Task{taskWithExpectedTool("task-1", "agent-1", "bash", "fetch user")},
 	})


### PR DESCRIPTION
## Summary
- centralize inline approval body editing and routing
- document the inline task state machine and add characterization coverage
- let harness-local AskUserQuestion bypass task scope
- map OpenClaw exec to shell task scope and tailor control notice examples to available tools

## Verification
- go test -count=1 ./...
- go test -count=1 ./internal/runtime/llmproxy/inspector
- go test -count=1 ./internal/runtime/llmproxy
- go test -count=1 ./internal/runtime/policy
- go test -count=1 ./pkg/runtime/decision
- go test -count=1 ./internal/api/handlers
- git diff --check