### PR TITLE
llmproxy: support split cloud deployment

### DIFF
--- a/docs/LITE_PROXY.md
+++ b/docs/LITE_PROXY.md
@@ -66,6 +66,38 @@ The proxy is gated by `proxy_lite.enabled`. When on, the daemon exposes:
 | `GET /control/tasks/{id}` | Status lookup. |
 | `POST /control/tasks/{id}/expand` | Add scope to an existing task. |
 
+### Split hosted deployments
+
+Hosted environments can run the dashboard/API and lite-proxy as separate
+services from the same binary by setting `server.route_set`:
+
+```yaml
+# Main app: dashboard + user APIs, but no public /v1, /proxy/v1, or /control surface.
+server:
+  route_set: app
+proxy_lite:
+  enabled: true
+
+# Dedicated proxy service: health + /v1, /proxy/v1, and /control only.
+server:
+  route_set: proxy_lite
+proxy_lite:
+  enabled: true
+```
+
+Equivalent environment variables:
+
+```bash
+CLAWVISOR_ROUTE_SET=proxy_lite
+CLAWVISOR_PROXY_LITE_ENABLED=true
+CLAWVISOR_PROXY_LITE_SELF_HOSTNAMES=app.example.com,llm-proxy.example.com
+CLAWVISOR_PROXY_LITE_ALLOW_PRIVATE_NETWORKS=false
+```
+
+For multi-instance proxy deployments, configure `REDIS_URL`. Redis backs both
+resolver caller nonces and inline approval holds, so an `approve` / `deny`
+reply can release a tool call held by another instance.
+
 Restart the daemon after editing config:
 
 ```bash

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	cloud.google.com/go/secretmanager v1.16.0
+	github.com/alicebob/miniredis/v2 v2.38.0
 	github.com/atotto/clipboard v0.1.4
 	github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7
 	github.com/charmbracelet/bubbletea v1.3.6
@@ -81,6 +82,7 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ filippo.io/edwards25519 v1.1.1 h1:YpjwWWlNmGIDyXOn8zLzqiD+9TyIlPhGFG96P39uBpw=
 filippo.io/edwards25519 v1.1.1/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
+github.com/alicebob/miniredis/v2 v2.38.0 h1:nZAzCR+Lj+Vxk4ZXzm2NuKq2O33RXj1XxJ2e2uP9jiw=
+github.com/alicebob/miniredis/v2 v2.38.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
@@ -192,6 +194,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/internal/api/proxy_lite_routes_test.go
+++ b/internal/api/proxy_lite_routes_test.go
@@ -1,0 +1,96 @@
+package api_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/internal/api"
+	"github.com/clawvisor/clawvisor/internal/auth"
+	"github.com/clawvisor/clawvisor/pkg/adapters"
+	"github.com/clawvisor/clawvisor/pkg/config"
+	"github.com/clawvisor/clawvisor/pkg/store"
+	sqlitestore "github.com/clawvisor/clawvisor/pkg/store/sqlite"
+	"github.com/clawvisor/clawvisor/pkg/vault"
+	intvault "github.com/clawvisor/clawvisor/pkg/vault"
+)
+
+func TestProxyLiteRouteSetExposesOnlyProxySurface(t *testing.T) {
+	env := newRouteSetEnv(t, "proxy_lite")
+
+	assertStatus(t, env.ts.Client(), env.ts.URL+"/health", http.StatusOK)
+	assertStatus(t, env.ts.Client(), env.ts.URL+"/control", http.StatusOK)
+	assertStatus(t, env.ts.Client(), env.ts.URL+"/api/features", http.StatusNotFound)
+	assertStatus(t, env.ts.Client(), env.ts.URL+"/api/runtime/llm-credentials", http.StatusNotFound)
+}
+
+func TestAppRouteSetHidesProxySurfaceButKeepsManagementRoutes(t *testing.T) {
+	env := newRouteSetEnv(t, "app")
+
+	assertStatus(t, env.ts.Client(), env.ts.URL+"/health", http.StatusOK)
+	assertStatus(t, env.ts.Client(), env.ts.URL+"/control", http.StatusNotFound)
+	assertStatus(t, env.ts.Client(), env.ts.URL+"/v1/messages", http.StatusNotFound)
+
+	// Route exists and rejects missing user auth. This is what lets the main
+	// app own credential management while a separate service owns proxy traffic.
+	assertStatus(t, env.ts.Client(), env.ts.URL+"/api/runtime/llm-credentials", http.StatusUnauthorized)
+}
+
+type routeSetEnv struct {
+	ts    *httptest.Server
+	Store store.Store
+	Vault vault.Vault
+}
+
+func newRouteSetEnv(t *testing.T, routeSet string) *routeSetEnv {
+	t.Helper()
+
+	ctx := context.Background()
+	db, err := sqlitestore.New(ctx, t.TempDir()+"/test.db")
+	if err != nil {
+		t.Fatalf("sqlite: %v", err)
+	}
+	st := sqlitestore.NewStore(db)
+	v, err := intvault.NewLocalVault(t.TempDir()+"/vault.key", db, "sqlite")
+	if err != nil {
+		t.Fatalf("vault: %v", err)
+	}
+	jwtSvc, err := auth.NewJWTService("test-secret-for-integration-tests")
+	if err != nil {
+		t.Fatalf("jwt: %v", err)
+	}
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{Host: "127.0.0.1", Port: 0, RouteSet: routeSet},
+		Auth: config.AuthConfig{
+			JWTSecret:       "test-secret-for-integration-tests",
+			AccessTokenTTL:  "15m",
+			RefreshTokenTTL: "720h",
+		},
+		Approval:  config.ApprovalConfig{Timeout: 300, OnTimeout: "fail"},
+		Task:      config.TaskConfig{DefaultExpirySeconds: 3600},
+		ProxyLite: config.ProxyLiteConfig{Enabled: true},
+	}
+
+	srv, err := api.New(cfg, st, v, jwtSvc, adapters.NewRegistry(), nil, config.LLMConfig{}, nil)
+	if err != nil {
+		t.Fatalf("api.New: %v", err)
+	}
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+	t.Cleanup(func() { _ = st.Close() })
+	return &routeSetEnv{ts: ts, Store: st, Vault: v}
+}
+
+func assertStatus(t *testing.T, c *http.Client, url string, want int) {
+	t.Helper()
+	resp, err := c.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != want {
+		t.Fatalf("GET %s status=%d, want %d", url, resp.StatusCode, want)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -107,6 +107,8 @@ type Server struct {
 	extractionTracker  handlers.ExtractionTracker
 	callerNonces       llmproxy.CallerNonceCache
 	pendingSecrets     llmproxy.PendingSecretDecisionCache
+	liteApprovals      llmproxy.PendingApprovalCache
+	liteOutcomes       llmproxy.InlineApprovalOutcomeStore
 
 	adapterGenFactory handlers.GeneratorFactory // per-request Generator factory; set via option
 }
@@ -339,6 +341,20 @@ func WithCallerNonceCache(c llmproxy.CallerNonceCache) ServerOption {
 // deployments so a held secret decision can be consumed atomically anywhere.
 func WithPendingSecretDecisionCache(c llmproxy.PendingSecretDecisionCache) ServerOption {
 	return func(s *Server) { s.pendingSecrets = c }
+}
+
+// WithLiteApprovalCache overrides the default in-memory lite-proxy inline
+// approval cache. Use a shared implementation in multi-instance deployments so
+// an approve/deny reply can release a tool call held by another instance.
+func WithLiteApprovalCache(c llmproxy.PendingApprovalCache) ServerOption {
+	return func(s *Server) { s.liteApprovals = c }
+}
+
+// WithLiteApprovalOutcomeStore overrides the default in-memory lite-proxy
+// inline approval outcome store. Use a shared implementation in multi-instance
+// deployments so later turns can see approvals resolved by another instance.
+func WithLiteApprovalOutcomeStore(c llmproxy.InlineApprovalOutcomeStore) ServerOption {
+	return func(s *Server) { s.liteOutcomes = c }
 }
 
 // New creates a Server and registers all routes.
@@ -602,6 +618,13 @@ func (s *Server) routes() http.Handler {
 	gatewayHandler.SetGatewayRateLimiter(gatewayRL, agentKeyFn)
 
 	user := func(h http.HandlerFunc) http.Handler { return requireUser(h) }
+	// E2E encryption middleware — wraps agent-facing routes so relay traffic is encrypted.
+	// Local requests pass through unencrypted; relay requests without E2E get 403.
+	e2e := func(h http.Handler) http.Handler { return h }
+	if s.x25519Key != nil {
+		e2eMw := middleware.E2E(s.x25519Key)
+		e2e = func(h http.Handler) http.Handler { return e2eMw(h) }
+	}
 	userOAuthRL := func(h http.HandlerFunc) http.Handler {
 		return requireUser(middleware.RateLimit(oauthRL, userKeyFn, rlCfg.OAuth.Limit)(h))
 	}
@@ -625,6 +648,20 @@ func (s *Server) routes() http.Handler {
 	mux.HandleFunc("GET /api/config/public", healthHandler.ConfigPublic)
 	mux.HandleFunc("GET /api/version", healthHandler.Version)
 	mux.HandleFunc("GET /api/skill/version", healthHandler.SkillVersion)
+
+	routeSet := strings.ToLower(strings.TrimSpace(s.cfg.Server.RouteSet))
+	if routeSet == "proxy_lite" {
+		s.registerLiteProxyRoutes(
+			mux, baseURL, verifier, tasksHandler, vaultHandler, e2e, user,
+			gatewayRL, llmAgentKeyFn, llmPreAuthKeyFn, rlCfg.Gateway.Limit,
+			true, false,
+		)
+		handler := securityMiddleware(logMiddleware(recoverMiddleware(mux)))
+		if s.wrapRoutes != nil {
+			handler = s.wrapRoutes(handler)
+		}
+		return handler
+	}
 
 	// LLM status and runtime config update
 	configPath := os.Getenv("CONFIG_FILE")
@@ -701,14 +738,6 @@ func (s *Server) routes() http.Handler {
 	mux.Handle("POST /api/notifications/telegram/groups/active/{group_chat_id}/pair", user(notificationsHandler.CreateGroupPairing))
 	mux.Handle("GET /api/notifications/telegram/groups/active/{group_chat_id}/agents", user(notificationsHandler.ListPairedAgents))
 	mux.Handle("POST /api/notifications/telegram/groups/pair/{session_id}", requireAgent(http.HandlerFunc(notificationsHandler.PairAgentToGroup)))
-
-	// E2E encryption middleware — wraps agent-facing routes so relay traffic is encrypted.
-	// Local requests pass through unencrypted; relay requests without E2E get 403.
-	e2e := func(h http.Handler) http.Handler { return h }
-	if s.x25519Key != nil {
-		e2eMw := middleware.E2E(s.x25519Key)
-		e2e = func(h http.Handler) http.Handler { return e2eMw(h) }
-	}
 
 	// Connection requests (unauthenticated — agents requesting access)
 	connectionsHandler := handlers.NewConnectionsHandler(s.store, s.notifier, s.eventHub, s.logger, baseURL, s.features.MultiTenant)
@@ -905,188 +934,18 @@ func (s *Server) routes() http.Handler {
 	mux.Handle("POST /api/audit/mutes", user(auditHandler.CreateMute))
 	mux.Handle("DELETE /api/audit/mutes/{id}", user(auditHandler.DeleteMute))
 
-	// Lite-proxy LLM endpoint (opt-in via config). Agents set
-	// ANTHROPIC_BASE_URL / OPENAI_BASE_URL at this server and present
-	// their existing cvis_… token via Authorization: Bearer, x-api-key,
-	// or X-Clawvisor-Agent-Token. The dedicated Clawvisor header lets
-	// Claude Code keep Authorization for subscription/OAuth passthrough.
 	if s.cfg.ProxyLite.Enabled {
-		llmHandler := handlers.NewLLMEndpointHandler(s.store, s.vault, s.logger)
-		if v := s.cfg.ProxyLite.AnthropicBaseURL; v != "" {
-			llmHandler.Forwarder.Upstream.AnthropicBaseURL = v
-		}
-		if v := s.cfg.ProxyLite.OpenAIBaseURL; v != "" {
-			llmHandler.Forwarder.Upstream.OpenAIBaseURL = v
-		}
-
-		// Wire the inspector into the response leg so credentialed
-		// tool_uses get rewritten through the resolver. The validator
-		// reuses the daemon's own LLM provider config (Gemini /
-		// Anthropic / OpenAI / Vertex — whatever cfg.LLM.Verification
-		// points at). When verification is disabled or missing
-		// credentials, falls back to AmbiguousValidator so unparseable
-		// shapes refuse closed rather than passing through.
-		var validator inspector.Validator = inspector.AmbiguousValidator{}
-		if s.cfg.LLM.Verification.Enabled {
-			validator = inspector.NewLLMClientValidator(s.llmHealth.VerificationConfig, s.logger)
-			llmHandler.SecretAdjudicator = runtimeautovault.NewLLMSecretAdjudicator(s.llmHealth.VerificationConfig, s.logger)
-		}
-		llmHandler.Inspector = inspector.NewInspector(inspector.DefaultParser{}, validator)
-		// Optional decision-trace log. Strictly observational; off
-		// unless cfg.ProxyLite.TraceLogPath or CLAWVISOR_PROXY_LITE_TRACE
-		// is set. Failure to open the file logs at WARN and the daemon
-		// continues without tracing.
-		tracePath := s.cfg.ProxyLite.TraceLogPath
-		if env := strings.TrimSpace(os.Getenv("CLAWVISOR_PROXY_LITE_TRACE")); env != "" {
-			tracePath = env
-		}
-		if traceLogger, err := llmproxy.OpenTraceLogger(tracePath); err != nil {
-			s.logger.Warn("lite-proxy: failed to open trace log", "path", tracePath, "err", err.Error())
-		} else if traceLogger != nil {
-			llmHandler.TraceLogger = traceLogger
-			s.logger.Info("lite-proxy: decision trace enabled", "path", tracePath)
-		}
-		// Optional raw I/O log — captures full request/response bodies
-		// for every LLM call. Off by default. Opt in via
-		// CLAWVISOR_PROXY_LITE_RAW_LOG or cfg.ProxyLite.RawLogPath.
-		// Bodies contain conversation content; keep this on only
-		// during diagnostic sessions.
-		rawLogPath := s.cfg.ProxyLite.RawLogPath
-		if env := strings.TrimSpace(os.Getenv("CLAWVISOR_PROXY_LITE_RAW_LOG")); env != "" {
-			rawLogPath = env
-		}
-		if rawLogger, err := llmproxy.OpenRawIOLogger(rawLogPath); err != nil {
-			s.logger.Warn("lite-proxy: failed to open raw-io log", "path", rawLogPath, "err", err.Error())
-		} else if rawLogger != nil {
-			llmHandler.RawIOLogger = rawLogger
-			s.logger.Info("lite-proxy: raw I/O log enabled", "path", rawLogPath)
-		}
-		// Prefer the configured public URL so the rewritten resolver URL the
-		// agent dials is reachable across networks; fall back to the local
-		// baseURL so single-host self-installs still rewrite (without this
-		// fallback, inspector.Rewrite fails closed on "missing ResolverBaseURL").
-		resolverBase := s.cfg.Server.PublicURL
-		if resolverBase == "" {
-			resolverBase = baseURL
-		}
-		llmHandler.ResolverBaseURL = strings.TrimRight(resolverBase, "/") + "/proxy/v1"
-		llmHandler.ControlBaseURL = strings.TrimRight(baseURL, "/")
-
-		// Audit emission for /v1/* endpoint calls + per-tool-use
-		// inspection rows + resolver swaps. All write into audit_log
-		// so the existing dashboard surfaces them automatically.
-		auditEmitter := llmproxy.NewAuditEmitter(s.store, s.logger, nil)
-		llmHandler.AuditEmitter = auditEmitter
-
-		// Task-scope authorization: reverse-resolve (host, method, path)
-		// to (service, action) via the YAML adapter catalog, then check
-		// against the agent's active tasks before letting a tool_use
-		// rewrite proceed. The catalog is lazy so newly-registered or
-		// hot-reloaded adapters get picked up on first use.
-		llmHandler.Catalog = llmproxy.NewLazyServiceCatalog(llmproxy.DefsFromRegistry(s.adapterReg))
-		llmHandler.TaskScope = llmproxy.NewStoreTaskScopeChecker(s.store)
-
-		// Intent verification reuses the gateway's existing verifier so
-		// prompts + caching + provider config stay consistent across
-		// runtime-proxy, MCP gateway, and lite-proxy. NoopVerifier
-		// returns nil verdicts → postprocess treats it as off-mode.
-		// Wrap in a circuit breaker so a sustained verifier outage
-		// fails closed rather than silently allowing every tool_use
-		// through with no scope check.
-		llmHandler.IntentVerifier = llmproxy.NewCircuitBreakerVerifier(
-			llmproxy.NewIntentVerifierAdapter(verifier),
-			llmproxy.DefaultCircuitBreakerConfig(),
+		s.registerLiteProxyRoutes(
+			mux, baseURL, verifier, tasksHandler, vaultHandler, e2e, user,
+			gatewayRL, llmAgentKeyFn, llmPreAuthKeyFn, rlCfg.Gateway.Limit,
+			routeSet != "app", true,
 		)
-
-		resolverHandler := handlers.NewProxyResolverHandler(s.store, s.vault, s.logger)
-		resolverHandler.SelfHostnames = s.cfg.ProxyLite.SelfHostnames
-		resolverHandler.AllowPrivateNetworks = s.cfg.ProxyLite.AllowPrivateNetworks
-		resolverHandler.AuditEmitter = auditEmitter
-
-		// Caller-auth nonce cache: minted by the postprocess layer when
-		// rewriting credentialed tool_uses, consumed by the resolver
-		// middleware below. Configured via WithCallerNonceCache (Redis
-		// in multi-instance mode); falls back to in-process memory cache
-		// for single-daemon installs. The nonce stands in for the agent's
-		// bearer token so the token never appears in the model's
-		// conversation context.
-		callerNonces := s.callerNonces
-		if callerNonces == nil {
-			callerNonces = llmproxy.NewMemoryCallerNonceCache(5 * time.Minute)
-		}
-		llmHandler.CallerNonces = callerNonces
-		if s.pendingSecrets != nil {
-			llmHandler.PendingSecrets = s.pendingSecrets
-		}
-
-		// Inline task approval: when an agent's "approve" reply on a
-		// task-definition prompt lands, the release path calls
-		// tasksHandler.CreateInlineApprovedTask to atomically create
-		// the task pre-approved with surface=inline_chat. The handler
-		// also gets the same validation, risk assessment, and audit
-		// record creation the dashboard path uses.
-		llmHandler.InlineTaskCreator = tasksHandler
-
-		llmCredHandler := handlers.NewLLMCredentialsHandler(s.store, s.vault, s.logger)
-		controlHandler := handlers.NewLLMControlHandler(baseURL)
-
-		// LLM endpoint accepts the agent token via SDK auth headers or
-		// X-Clawvisor-Agent-Token for Claude Code subscription passthrough.
-		requireAgentLLM := middleware.RequireAgentLLM(s.store)
-		requireAgentLLMRL := func(h http.HandlerFunc) http.Handler {
-			agentLimited := middleware.RateLimit(gatewayRL, llmAgentKeyFn, rlCfg.Gateway.Limit)(http.HandlerFunc(h))
-			authenticated := requireAgentLLM(agentLimited)
-			return middleware.RateLimit(gatewayRL, llmPreAuthKeyFn, rlCfg.Gateway.Limit)(authenticated)
-		}
-
-		// Resolver expects a short-lived single-use nonce in
-		// X-Clawvisor-Caller — never the raw agent token. The nonce is
-		// bound to (agent, host, method, path), so a leaked nonce only
-		// authorizes the specific call the proxy already approved.
-		//
-		// Rate-limit by source IP first, then enforce the nonce.
-		// Without IP-level rate limiting a leaked nonce could be
-		// brute-force-replayed against many (host, method, path)
-		// tuples within its TTL window — each attempt that misses the
-		// target still costs a cache round-trip even though
-		// one-shot-consume invalidates the nonce on the first match.
-		// The IP key is correct here because the resolver authenticates
-		// *inside* this middleware.
-		nonceMW := middleware.RequireAgentLLMNonce(s.store, callerNonces, s.logger)
-		requireAgentLLMCaller := func(h http.Handler) http.Handler {
-			return middleware.RateLimit(gatewayRL, llmPreAuthKeyFn, rlCfg.Gateway.Limit)(nonceMW(h))
-		}
-
-		mux.Handle("POST /v1/messages", requireAgentLLMRL(llmHandler.Messages))
-		mux.Handle("POST /v1/messages/count_tokens", requireAgentLLMRL(llmHandler.Messages))
-		mux.Handle("POST /v1/chat/completions", requireAgentLLMRL(llmHandler.ChatCompletions))
-		mux.Handle("POST /v1/responses", requireAgentLLMRL(llmHandler.Responses))
-
-		// Synthetic Clawvisor control plane. Model-emitted calls to
-		// https://clawvisor.local/control/... are rewritten here with
-		// X-Clawvisor-Caller auth so agents can request task scope before
-		// that scope exists.
-		mux.Handle("GET /control", http.HandlerFunc(controlHandler.Capabilities))
-		mux.Handle("GET /control/capabilities", http.HandlerFunc(controlHandler.Capabilities))
-		mux.Handle("GET /control/skill", http.HandlerFunc(controlHandler.Skill))
-		mux.Handle("POST /control/failure", requireAgentLLMCaller(e2e(http.HandlerFunc(controlHandler.Failure))))
-		mux.Handle("POST /control/tasks", requireAgentLLMCaller(e2e(http.HandlerFunc(tasksHandler.Create))))
-		mux.Handle("GET /control/tasks/{id}", requireAgentLLMCaller(e2e(http.HandlerFunc(tasksHandler.Get))))
-		mux.Handle("POST /control/tasks/{id}/expand", requireAgentLLMCaller(e2e(http.HandlerFunc(tasksHandler.Expand))))
-		mux.Handle("GET /control/vault/items", requireAgentLLMCaller(e2e(http.HandlerFunc(vaultHandler.ListForAgent))))
-		mux.Handle("GET /control/vault/items/{id}", requireAgentLLMCaller(e2e(http.HandlerFunc(vaultHandler.GetForAgent))))
-		mux.Handle("/control/", requireAgentLLMCaller(e2e(http.HandlerFunc(controlHandler.NotFound))))
-
-		// Resolver — agent harness's outbound HTTPS calls land here so
-		// we can swap autovault placeholders in headers for real vault
-		// credentials before forwarding to the real upstream service.
-		mux.Handle("/proxy/v1/", requireAgentLLMCaller(http.HandlerFunc(resolverHandler.Forward)))
-
-		// Upstream credential management (user JWT) — store the real
-		// sk-ant-… or sk-… in vault under (user_id, "anthropic"|"openai").
-		mux.Handle("PUT /api/runtime/llm-credentials/{provider}", user(llmCredHandler.Set))
-		mux.Handle("DELETE /api/runtime/llm-credentials/{provider}", user(llmCredHandler.Delete))
-		mux.Handle("GET /api/runtime/llm-credentials", user(llmCredHandler.List))
+	}
+	if routeSet == "app" {
+		mux.HandleFunc("/v1/", http.NotFound)
+		mux.HandleFunc("/proxy/v1/", http.NotFound)
+		mux.HandleFunc("/control", http.NotFound)
+		mux.HandleFunc("/control/", http.NotFound)
 	}
 
 	// SSE event stream (user JWT or single-use ticket for EventSource)
@@ -1297,6 +1156,144 @@ func (s *Server) routes() http.Handler {
 	return handler
 }
 
+func (s *Server) registerLiteProxyRoutes(
+	mux *http.ServeMux,
+	baseURL string,
+	verifier intent.Verifier,
+	tasksHandler *handlers.TasksHandler,
+	vaultHandler *handlers.VaultHandler,
+	e2e func(http.Handler) http.Handler,
+	user func(http.HandlerFunc) http.Handler,
+	gatewayRL ratelimit.Limiter,
+	llmAgentKeyFn func(*http.Request) string,
+	llmPreAuthKeyFn func(*http.Request) string,
+	gatewayLimit int,
+	includeProxySurface bool,
+	includeCredentialRoutes bool,
+) {
+	var callerNonces llmproxy.CallerNonceCache
+	if includeProxySurface {
+		llmHandler := handlers.NewLLMEndpointHandler(s.store, s.vault, s.logger)
+		if v := s.cfg.ProxyLite.AnthropicBaseURL; v != "" {
+			llmHandler.Forwarder.Upstream.AnthropicBaseURL = v
+		}
+		if v := s.cfg.ProxyLite.OpenAIBaseURL; v != "" {
+			llmHandler.Forwarder.Upstream.OpenAIBaseURL = v
+		}
+
+		var validator inspector.Validator = inspector.AmbiguousValidator{}
+		if s.cfg.LLM.Verification.Enabled {
+			validator = inspector.NewLLMClientValidator(s.llmHealth.VerificationConfig, s.logger)
+			llmHandler.SecretAdjudicator = runtimeautovault.NewLLMSecretAdjudicator(s.llmHealth.VerificationConfig, s.logger)
+		}
+		llmHandler.Inspector = inspector.NewInspector(inspector.DefaultParser{}, validator)
+
+		tracePath := s.cfg.ProxyLite.TraceLogPath
+		if env := strings.TrimSpace(os.Getenv("CLAWVISOR_PROXY_LITE_TRACE")); env != "" {
+			tracePath = env
+		}
+		if traceLogger, err := llmproxy.OpenTraceLogger(tracePath); err != nil {
+			s.logger.Warn("lite-proxy: failed to open trace log", "path", tracePath, "err", err.Error())
+		} else if traceLogger != nil {
+			llmHandler.TraceLogger = traceLogger
+			s.logger.Info("lite-proxy: decision trace enabled", "path", tracePath)
+		}
+
+		rawLogPath := s.cfg.ProxyLite.RawLogPath
+		if env := strings.TrimSpace(os.Getenv("CLAWVISOR_PROXY_LITE_RAW_LOG")); env != "" {
+			rawLogPath = env
+		}
+		if rawLogger, err := llmproxy.OpenRawIOLogger(rawLogPath); err != nil {
+			s.logger.Warn("lite-proxy: failed to open raw-io log", "path", rawLogPath, "err", err.Error())
+		} else if rawLogger != nil {
+			llmHandler.RawIOLogger = rawLogger
+			s.logger.Info("lite-proxy: raw I/O log enabled", "path", rawLogPath)
+		}
+
+		resolverBase := s.cfg.Server.PublicURL
+		if resolverBase == "" {
+			resolverBase = baseURL
+		}
+		llmHandler.ResolverBaseURL = strings.TrimRight(resolverBase, "/") + "/proxy/v1"
+		llmHandler.ControlBaseURL = strings.TrimRight(baseURL, "/")
+
+		auditEmitter := llmproxy.NewAuditEmitter(s.store, s.logger, nil)
+		llmHandler.AuditEmitter = auditEmitter
+		llmHandler.Catalog = llmproxy.NewLazyServiceCatalog(llmproxy.DefsFromRegistry(s.adapterReg))
+		llmHandler.TaskScope = llmproxy.NewStoreTaskScopeChecker(s.store)
+		llmHandler.IntentVerifier = llmproxy.NewCircuitBreakerVerifier(
+			llmproxy.NewIntentVerifierAdapter(verifier),
+			llmproxy.DefaultCircuitBreakerConfig(),
+		)
+
+		resolverHandler := handlers.NewProxyResolverHandler(s.store, s.vault, s.logger)
+		resolverHandler.SelfHostnames = s.cfg.ProxyLite.SelfHostnames
+		resolverHandler.AllowPrivateNetworks = s.cfg.ProxyLite.AllowPrivateNetworks
+		resolverHandler.AuditEmitter = auditEmitter
+
+		callerNonces = s.callerNonces
+		if callerNonces == nil {
+			callerNonces = llmproxy.NewMemoryCallerNonceCache(5 * time.Minute)
+			if s.logger != nil && strings.EqualFold(strings.TrimSpace(s.cfg.Server.RouteSet), "proxy_lite") {
+				s.logger.Warn("lite-proxy: CallerNonceCache not configured — resolver nonces are process-local; use Redis for multi-instance proxy deployments")
+			}
+		}
+		llmHandler.CallerNonces = callerNonces
+		if s.pendingSecrets != nil {
+			llmHandler.PendingSecrets = s.pendingSecrets
+		}
+
+		if s.liteApprovals != nil {
+			llmHandler.PendingApprovals = s.liteApprovals
+		} else if s.logger != nil && strings.EqualFold(strings.TrimSpace(s.cfg.Server.RouteSet), "proxy_lite") {
+			s.logger.Warn("lite-proxy: LiteApprovalCache not configured — inline approvals are process-local; use Redis for multi-instance proxy deployments")
+		}
+		if s.liteOutcomes != nil {
+			llmHandler.InlineApprovalOutcomes = s.liteOutcomes
+		} else if s.logger != nil && strings.EqualFold(strings.TrimSpace(s.cfg.Server.RouteSet), "proxy_lite") {
+			s.logger.Warn("lite-proxy: LiteApprovalOutcomeStore not configured — inline approval outcomes are process-local; use Redis for multi-instance proxy deployments")
+		}
+		llmHandler.InlineTaskCreator = tasksHandler
+
+		controlHandler := handlers.NewLLMControlHandler(baseURL)
+		requireAgentLLM := middleware.RequireAgentLLM(s.store)
+		requireAgentLLMRL := func(h http.HandlerFunc) http.Handler {
+			agentLimited := middleware.RateLimit(gatewayRL, llmAgentKeyFn, gatewayLimit)(http.HandlerFunc(h))
+			authenticated := requireAgentLLM(agentLimited)
+			return middleware.RateLimit(gatewayRL, llmPreAuthKeyFn, gatewayLimit)(authenticated)
+		}
+		nonceMW := middleware.RequireAgentLLMNonce(s.store, callerNonces, s.logger)
+		requireAgentLLMCaller := func(h http.Handler) http.Handler {
+			return middleware.RateLimit(gatewayRL, llmPreAuthKeyFn, gatewayLimit)(nonceMW(h))
+		}
+
+		mux.Handle("POST /v1/messages", requireAgentLLMRL(llmHandler.Messages))
+		mux.Handle("POST /v1/messages/count_tokens", requireAgentLLMRL(llmHandler.Messages))
+		mux.Handle("POST /v1/chat/completions", requireAgentLLMRL(llmHandler.ChatCompletions))
+		mux.Handle("POST /v1/responses", requireAgentLLMRL(llmHandler.Responses))
+
+		mux.Handle("GET /control", http.HandlerFunc(controlHandler.Capabilities))
+		mux.Handle("GET /control/capabilities", http.HandlerFunc(controlHandler.Capabilities))
+		mux.Handle("GET /control/skill", http.HandlerFunc(controlHandler.Skill))
+		mux.Handle("POST /control/failure", requireAgentLLMCaller(e2e(http.HandlerFunc(controlHandler.Failure))))
+		mux.Handle("POST /control/tasks", requireAgentLLMCaller(e2e(http.HandlerFunc(tasksHandler.Create))))
+		mux.Handle("GET /control/tasks/{id}", requireAgentLLMCaller(e2e(http.HandlerFunc(tasksHandler.Get))))
+		mux.Handle("POST /control/tasks/{id}/expand", requireAgentLLMCaller(e2e(http.HandlerFunc(tasksHandler.Expand))))
+		mux.Handle("GET /control/vault/items", requireAgentLLMCaller(e2e(http.HandlerFunc(vaultHandler.ListForAgent))))
+		mux.Handle("GET /control/vault/items/{id}", requireAgentLLMCaller(e2e(http.HandlerFunc(vaultHandler.GetForAgent))))
+		mux.Handle("/control/", requireAgentLLMCaller(e2e(http.HandlerFunc(controlHandler.NotFound))))
+
+		mux.Handle("/proxy/v1/", requireAgentLLMCaller(http.HandlerFunc(resolverHandler.Forward)))
+	}
+
+	if includeCredentialRoutes {
+		llmCredHandler := handlers.NewLLMCredentialsHandler(s.store, s.vault, s.logger)
+		mux.Handle("PUT /api/runtime/llm-credentials/{provider}", user(llmCredHandler.Set))
+		mux.Handle("DELETE /api/runtime/llm-credentials/{provider}", user(llmCredHandler.Delete))
+		mux.Handle("GET /api/runtime/llm-credentials", user(llmCredHandler.List))
+	}
+}
+
 // handleFeatures returns the active feature set as JSON.
 func (s *Server) handleFeatures(w http.ResponseWriter, r *http.Request) {
 	fs := s.features
@@ -1356,7 +1353,9 @@ func (s *Server) consumeNotifierDecisions(ctx context.Context, ch <-chan notify.
 					err = s.tasksHandler.ExpandDenyByTaskID(ctx, d.TargetID, d.UserID)
 				}
 			case "connection":
-				if d.Action == "approve" {
+				if s.connectionsHandler == nil {
+					err = fmt.Errorf("connection decisions are unavailable in route_set=%q", s.cfg.Server.RouteSet)
+				} else if d.Action == "approve" {
 					_, err = s.connectionsHandler.ApproveByID(ctx, d.TargetID, d.UserID)
 				} else {
 					err = s.connectionsHandler.DenyByID(ctx, d.TargetID, d.UserID)

--- a/internal/runtime/llmproxy/inline_approval_outcome.go
+++ b/internal/runtime/llmproxy/inline_approval_outcome.go
@@ -67,9 +67,9 @@ type InlineApprovalOutcomeStore interface {
 }
 
 // MemoryInlineApprovalOutcomeStore is an in-process outcome store with
-// TTL eviction. Outcomes only matter for in-flight conversations, so a
-// process-local store is sufficient — daemon restart resets state,
-// after which there are no live inline approvals to worry about.
+// TTL eviction. It is appropriate for single-process installs. Multi-instance
+// proxy deployments should use RedisInlineApprovalOutcomeStore so later turns
+// can re-inject approval context even when they land on a different replica.
 type MemoryInlineApprovalOutcomeStore struct {
 	ttl time.Duration
 

--- a/internal/runtime/llmproxy/inline_approval_outcome_redis.go
+++ b/internal/runtime/llmproxy/inline_approval_outcome_redis.go
@@ -1,0 +1,72 @@
+package llmproxy
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const redisInlineApprovalOutcomePrefix = "clawvisor:lite_inline_approval_outcome:"
+
+// RedisInlineApprovalOutcomeStore stores inline task approval outcomes in
+// Redis so conversation-history augmentation works across proxy replicas.
+type RedisInlineApprovalOutcomeStore struct {
+	rdb *redis.Client
+	ttl time.Duration
+	now func() time.Time
+}
+
+func NewRedisInlineApprovalOutcomeStore(rdb *redis.Client, ttl time.Duration) *RedisInlineApprovalOutcomeStore {
+	if ttl <= 0 {
+		ttl = 24 * time.Hour
+	}
+	return &RedisInlineApprovalOutcomeStore{
+		rdb: rdb,
+		ttl: ttl,
+		now: time.Now,
+	}
+}
+
+func (s *RedisInlineApprovalOutcomeStore) Record(key InlineApprovalOutcomeKey, outcome InlineApprovalOutcome) {
+	if s == nil || s.rdb == nil || key.ApprovalID == "" {
+		return
+	}
+	if outcome.ResolvedAt.IsZero() {
+		outcome.ResolvedAt = s.now().UTC()
+	}
+	raw, err := json.Marshal(outcome)
+	if err != nil {
+		return
+	}
+	_ = s.rdb.Set(context.Background(), redisInlineApprovalOutcomeKey(key), raw, s.ttl).Err()
+}
+
+func (s *RedisInlineApprovalOutcomeStore) Lookup(key InlineApprovalOutcomeKey) (InlineApprovalOutcome, bool) {
+	if s == nil || s.rdb == nil || key.ApprovalID == "" {
+		return InlineApprovalOutcome{}, false
+	}
+	raw, err := s.rdb.Get(context.Background(), redisInlineApprovalOutcomeKey(key)).Bytes()
+	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			return InlineApprovalOutcome{}, false
+		}
+		return InlineApprovalOutcome{}, false
+	}
+	var outcome InlineApprovalOutcome
+	if err := json.Unmarshal(raw, &outcome); err != nil {
+		return InlineApprovalOutcome{}, false
+	}
+	return outcome, true
+}
+
+func redisInlineApprovalOutcomeKey(key InlineApprovalOutcomeKey) string {
+	sum := sha256.Sum256([]byte(key.UserID + "\x00" + key.AgentID + "\x00" + key.ApprovalID))
+	return redisInlineApprovalOutcomePrefix + hex.EncodeToString(sum[:])
+}
+
+var _ InlineApprovalOutcomeStore = (*RedisInlineApprovalOutcomeStore)(nil)

--- a/internal/runtime/llmproxy/pending_approval_cache_redis.go
+++ b/internal/runtime/llmproxy/pending_approval_cache_redis.go
@@ -1,0 +1,241 @@
+package llmproxy
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+	"github.com/redis/go-redis/v9"
+)
+
+const redisPendingApprovalPrefix = "clawvisor:lite_pending_approval:"
+
+// RedisPendingApprovalCache stores lite-proxy inline approval holds in Redis
+// so a dedicated or multi-replica proxy deployment can release a hold created
+// by another instance. The list is newest-first and bounded to match the
+// in-memory cache's LIFO behavior.
+type RedisPendingApprovalCache struct {
+	rdb *redis.Client
+	ttl time.Duration
+	max int
+	now func() time.Time
+}
+
+// NewRedisPendingApprovalCache returns a Redis-backed pending approval cache.
+// ttl <= 0 is replaced with 10 minutes.
+func NewRedisPendingApprovalCache(rdb *redis.Client, ttl time.Duration) *RedisPendingApprovalCache {
+	if ttl <= 0 {
+		ttl = 10 * time.Minute
+	}
+	return &RedisPendingApprovalCache{
+		rdb: rdb,
+		ttl: ttl,
+		max: 10,
+		now: time.Now,
+	}
+}
+
+// Hold implements PendingApprovalCache.
+func (c *RedisPendingApprovalCache) Hold(ctx context.Context, pending PendingLiteApproval) (HoldResult, error) {
+	if c == nil || c.rdb == nil {
+		return HoldResult{Pending: pending}, nil
+	}
+	now := c.now().UTC()
+	if pending.ID == "" {
+		id, err := newLiteApprovalID()
+		if err != nil {
+			return HoldResult{}, err
+		}
+		pending.ID = id
+	}
+	if pending.CreatedAt.IsZero() {
+		pending.CreatedAt = now
+	}
+	if pending.ExpiresAt.IsZero() {
+		pending.ExpiresAt = now.Add(c.ttl)
+	}
+	raw, err := json.Marshal(pending)
+	if err != nil {
+		return HoldResult{}, err
+	}
+	key := redisPendingApprovalKey(pending.UserID, pending.AgentID, pending.Provider)
+	max := c.max
+	if max <= 0 {
+		max = 10
+	}
+	var evicted *PendingLiteApproval
+	if rawEvicted, err := c.rdb.LIndex(ctx, key, int64(max-1)).Bytes(); err == nil {
+		var decoded PendingLiteApproval
+		if json.Unmarshal(rawEvicted, &decoded) == nil {
+			evicted = &decoded
+		}
+	}
+	pipe := c.rdb.TxPipeline()
+	pipe.LPush(ctx, key, raw)
+	pipe.LTrim(ctx, key, 0, int64(max-1))
+	pipe.Expire(ctx, key, c.ttl)
+	if _, err := pipe.Exec(ctx); err != nil {
+		return HoldResult{}, err
+	}
+	return HoldResult{Pending: pending, Evicted: evicted}, nil
+}
+
+// Peek implements PendingApprovalCache.
+func (c *RedisPendingApprovalCache) Peek(ctx context.Context, req ResolveRequest) (*PendingLiteApproval, error) {
+	if c == nil || c.rdb == nil {
+		return nil, nil
+	}
+	found, _, err := c.find(ctx, req)
+	return found, err
+}
+
+// Resolve implements PendingApprovalCache.
+func (c *RedisPendingApprovalCache) Resolve(ctx context.Context, req ResolveRequest) (*PendingLiteApproval, error) {
+	if c == nil || c.rdb == nil {
+		return nil, nil
+	}
+	key := redisPendingApprovalKey(req.UserID, req.AgentID, req.Provider)
+	for {
+		result, err := redisResolvePendingApprovalScript.Run(ctx, c.rdb, []string{key},
+			req.ApprovalID, string(req.Stage), redisPendingApprovalRemovalMarker(c.now()),
+		).Result()
+		if err != nil {
+			if errors.Is(err, redis.Nil) {
+				return nil, nil
+			}
+			return nil, err
+		}
+		raw, ok := result.(string)
+		if !ok {
+			return nil, fmt.Errorf("redis pending approval script returned %T", result)
+		}
+		var found PendingLiteApproval
+		if err := json.Unmarshal([]byte(raw), &found); err != nil {
+			continue
+		}
+		if !found.ExpiresAt.IsZero() && !found.ExpiresAt.After(c.now().UTC()) {
+			continue
+		}
+		return &found, nil
+	}
+}
+
+// Drop implements PendingApprovalCache.
+func (c *RedisPendingApprovalCache) Drop(ctx context.Context, req ResolveRequest) error {
+	if c == nil || c.rdb == nil {
+		return nil
+	}
+	key := redisPendingApprovalKey(req.UserID, req.AgentID, req.Provider)
+	if req.ApprovalID == "" {
+		return c.rdb.Del(ctx, key).Err()
+	}
+	_, raw, err := c.find(ctx, req)
+	if err != nil || raw == "" {
+		return err
+	}
+	return c.rdb.LRem(ctx, key, 1, raw).Err()
+}
+
+func (c *RedisPendingApprovalCache) find(ctx context.Context, req ResolveRequest) (*PendingLiteApproval, string, error) {
+	key := redisPendingApprovalKey(req.UserID, req.AgentID, req.Provider)
+	rawItems, err := c.rdb.LRange(ctx, key, 0, -1).Result()
+	if err != nil {
+		return nil, "", err
+	}
+	now := c.now().UTC()
+	var firstExpired []string
+	var fallback *PendingLiteApproval
+	var fallbackRaw string
+	for _, raw := range rawItems {
+		var pending PendingLiteApproval
+		if err := json.Unmarshal([]byte(raw), &pending); err != nil {
+			firstExpired = append(firstExpired, raw)
+			continue
+		}
+		if !pending.ExpiresAt.IsZero() && !pending.ExpiresAt.After(now) {
+			firstExpired = append(firstExpired, raw)
+			continue
+		}
+		if req.ApprovalID != "" {
+			if pending.ID != req.ApprovalID {
+				continue
+			}
+			if req.Stage != "" && pending.Stage != req.Stage {
+				break
+			}
+			return &pending, raw, c.dropExpired(ctx, key, firstExpired)
+		}
+		if req.Stage != "" && pending.Stage != req.Stage {
+			continue
+		}
+		fallback = &pending
+		fallbackRaw = raw
+		break
+	}
+	return fallback, fallbackRaw, c.dropExpired(ctx, key, firstExpired)
+}
+
+func (c *RedisPendingApprovalCache) dropExpired(ctx context.Context, key string, raws []string) error {
+	if len(raws) == 0 {
+		return nil
+	}
+	pipe := c.rdb.TxPipeline()
+	for _, raw := range raws {
+		pipe.LRem(ctx, key, 0, raw)
+	}
+	_, err := pipe.Exec(ctx)
+	return err
+}
+
+func redisPendingApprovalKey(userID, agentID string, provider conversation.Provider) string {
+	sum := sha256.Sum256([]byte(userID + "\x00" + agentID + "\x00" + string(provider)))
+	return redisPendingApprovalPrefix + hex.EncodeToString(sum[:])
+}
+
+func redisPendingApprovalRemovalMarker(now time.Time) string {
+	return "__clawvisor_removed_pending_approval__:" + now.UTC().Format(time.RFC3339Nano)
+}
+
+var redisResolvePendingApprovalScript = redis.NewScript(`
+local key = KEYS[1]
+local approval_id = ARGV[1]
+local stage = ARGV[2]
+local marker = ARGV[3]
+local len = redis.call('LLEN', key)
+for i = 0, len - 1 do
+	local raw = redis.call('LINDEX', key, i)
+	if not raw then
+		return nil
+	end
+	local ok, pending = pcall(cjson.decode, raw)
+	if not ok then
+		redis.call('LSET', key, i, marker)
+		redis.call('LREM', key, 1, marker)
+	else
+		local id = pending['ID'] or ''
+		local pending_stage = pending['Stage'] or ''
+		if approval_id ~= '' then
+			if id == approval_id then
+				if stage ~= '' and pending_stage ~= stage then
+					return nil
+				end
+				redis.call('LSET', key, i, marker)
+				redis.call('LREM', key, 1, marker)
+				return raw
+			end
+		elseif stage == '' or pending_stage == stage then
+			redis.call('LSET', key, i, marker)
+			redis.call('LREM', key, 1, marker)
+			return raw
+		end
+	end
+end
+return nil
+`)
+
+var _ PendingApprovalCache = (*RedisPendingApprovalCache)(nil)

--- a/internal/runtime/llmproxy/redis_stores_test.go
+++ b/internal/runtime/llmproxy/redis_stores_test.go
@@ -1,0 +1,139 @@
+package llmproxy
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+	"github.com/redis/go-redis/v9"
+)
+
+func testRedisClient(t *testing.T) *redis.Client {
+	t.Helper()
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(mr.Close)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+	return rdb
+}
+
+func TestRedisPendingApprovalCacheResolvesBareApprovalLIFO(t *testing.T) {
+	cache := NewRedisPendingApprovalCache(testRedisClient(t), time.Minute)
+	ctx := context.Background()
+
+	for _, id := range []string{"cv-first", "cv-second"} {
+		if _, err := cache.Hold(ctx, PendingLiteApproval{
+			ID:       id,
+			UserID:   "user-1",
+			AgentID:  "agent-1",
+			Provider: conversation.ProviderAnthropic,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	resolved, err := cache.Resolve(ctx, ResolveRequest{
+		UserID:   "user-1",
+		AgentID:  "agent-1",
+		Provider: conversation.ProviderAnthropic,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved == nil || resolved.ID != "cv-second" {
+		t.Fatalf("first resolve = %+v, want cv-second", resolved)
+	}
+
+	resolved, err = cache.Resolve(ctx, ResolveRequest{
+		UserID:   "user-1",
+		AgentID:  "agent-1",
+		Provider: conversation.ProviderAnthropic,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved == nil || resolved.ID != "cv-first" {
+		t.Fatalf("second resolve = %+v, want cv-first", resolved)
+	}
+}
+
+func TestRedisPendingApprovalCacheStageResolveLeavesOtherHolds(t *testing.T) {
+	cache := NewRedisPendingApprovalCache(testRedisClient(t), time.Minute)
+	ctx := context.Background()
+
+	if _, err := cache.Hold(ctx, PendingLiteApproval{
+		ID:       "cv-tool",
+		UserID:   "user-1",
+		AgentID:  "agent-1",
+		Provider: conversation.ProviderAnthropic,
+		Stage:    StageTool,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := cache.Hold(ctx, PendingLiteApproval{
+		ID:       "cv-task",
+		UserID:   "user-1",
+		AgentID:  "agent-1",
+		Provider: conversation.ProviderAnthropic,
+		Stage:    StageAwaitingTaskApproval,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	resolved, err := cache.Resolve(ctx, ResolveRequest{
+		UserID:   "user-1",
+		AgentID:  "agent-1",
+		Provider: conversation.ProviderAnthropic,
+		Stage:    StageAwaitingTaskApproval,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved == nil || resolved.ID != "cv-task" {
+		t.Fatalf("stage resolve = %+v, want cv-task", resolved)
+	}
+
+	resolved, err = cache.Resolve(ctx, ResolveRequest{
+		UserID:   "user-1",
+		AgentID:  "agent-1",
+		Provider: conversation.ProviderAnthropic,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved == nil || resolved.ID != "cv-tool" {
+		t.Fatalf("remaining resolve = %+v, want cv-tool", resolved)
+	}
+}
+
+func TestRedisInlineApprovalOutcomeStoreRecordAndLookup(t *testing.T) {
+	store := NewRedisInlineApprovalOutcomeStore(testRedisClient(t), time.Minute)
+	key := InlineApprovalOutcomeKey{UserID: "user-1", AgentID: "agent-1", ApprovalID: "cv-1"}
+
+	store.Record(key, InlineApprovalOutcome{
+		Decision:  "allow",
+		Outcome:   "inline_task_approved",
+		Succeeded: true,
+		TaskID:    "task-1",
+		Credentials: []InlineTaskCredentialPlaceholder{
+			{VaultItemID: "api_key", Placeholder: "cv_secret_1"},
+		},
+		RequestID: "req-1",
+	})
+
+	out, ok := store.Lookup(key)
+	if !ok || !out.Succeeded || out.TaskID != "task-1" || out.RequestID != "req-1" {
+		t.Fatalf("lookup = (%+v, %v)", out, ok)
+	}
+	if len(out.Credentials) != 1 || out.Credentials[0].Placeholder != "cv_secret_1" {
+		t.Fatalf("credentials not preserved: %+v", out.Credentials)
+	}
+	if _, ok := store.Lookup(InlineApprovalOutcomeKey{UserID: "user-1", AgentID: "agent-2", ApprovalID: "cv-1"}); ok {
+		t.Fatal("lookup should be scoped by agent")
+	}
+}

--- a/pkg/clawvisor/defaults.go
+++ b/pkg/clawvisor/defaults.go
@@ -425,6 +425,8 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 	var verdictCache intent.VerdictCacher
 	var callerNonceCache llmproxy.CallerNonceCache
 	var pendingSecretCache llmproxy.PendingSecretDecisionCache
+	var liteApprovalCache llmproxy.PendingApprovalCache
+	var liteOutcomeStore llmproxy.InlineApprovalOutcomeStore
 	var extractionTracker handlers.ExtractionTracker
 	var rdb *redis.Client
 	if cfg.Redis.URL != "" {
@@ -464,6 +466,8 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 		// windows that re-mint a fresh nonce.
 		callerNonceCache = llmproxy.NewRedisCallerNonceCache(client, 5*time.Minute)
 		pendingSecretCache = llmproxy.NewRedisPendingSecretDecisionCache(client, 10*time.Minute)
+		liteApprovalCache = llmproxy.NewRedisPendingApprovalCache(client, 10*time.Minute)
+		liteOutcomeStore = llmproxy.NewRedisInlineApprovalOutcomeStore(client, 24*time.Hour)
 
 		// Safety TTL exceeds the 30s extraction timeout + 10s save timeout
 		// so a crashed instance doesn't orphan entries.
@@ -513,6 +517,8 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 		ExtractionTracker:  extractionTracker,
 		CallerNonceCache:   callerNonceCache,
 		PendingSecretCache: pendingSecretCache,
+		LiteApprovalCache:  liteApprovalCache,
+		LiteOutcomeStore:   liteOutcomeStore,
 		RedisClient:        rdb,
 	}
 

--- a/pkg/clawvisor/options.go
+++ b/pkg/clawvisor/options.go
@@ -149,6 +149,8 @@ type ServerOptions struct {
 	ExtractionTracker  handlers.ExtractionTracker
 	CallerNonceCache   llmproxy.CallerNonceCache
 	PendingSecretCache llmproxy.PendingSecretDecisionCache
+	LiteApprovalCache  llmproxy.PendingApprovalCache
+	LiteOutcomeStore   llmproxy.InlineApprovalOutcomeStore
 	RedisClient        *redis.Client
 }
 

--- a/pkg/clawvisor/run.go
+++ b/pkg/clawvisor/run.go
@@ -340,6 +340,12 @@ func RunWithContext(ctx context.Context, opts *ServerOptions) error {
 	if opts.PendingSecretCache != nil {
 		apiOpts = append(apiOpts, api.WithPendingSecretDecisionCache(opts.PendingSecretCache))
 	}
+	if opts.LiteApprovalCache != nil {
+		apiOpts = append(apiOpts, api.WithLiteApprovalCache(opts.LiteApprovalCache))
+	}
+	if opts.LiteOutcomeStore != nil {
+		apiOpts = append(apiOpts, api.WithLiteApprovalOutcomeStore(opts.LiteOutcomeStore))
+	}
 	if opts.LocalServiceProvider != nil {
 		apiOpts = append(apiOpts, api.WithLocalServiceProvider(&localSvcAdapter{opts.LocalServiceProvider}))
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -119,6 +119,7 @@ type ServerConfig struct {
 	AuthMode    string `yaml:"auth_mode"`  // "magic_link", "password", or "" (auto-detect from IsLocal)
 	LogFormat   string `yaml:"log_format"` // "json", "text", or "" (auto: json in prod, text in dev)
 	LogLevel    string `yaml:"log_level"`  // "debug", "info", "warn", "error" (default: "info")
+	RouteSet    string `yaml:"route_set"`  // "full" (default), "app", or "proxy_lite" for split deployments
 	// TrustedProxies is the list of CIDR ranges whose r.RemoteAddr is treated
 	// as a reverse proxy. When a request arrives from one of these networks,
 	// the right-most non-trusted entry of X-Forwarded-For is used as the
@@ -537,6 +538,9 @@ func Load(path string) (*Config, error) {
 	if v := os.Getenv("LOG_LEVEL"); v != "" {
 		cfg.Server.LogLevel = v
 	}
+	if v := os.Getenv("CLAWVISOR_ROUTE_SET"); v != "" {
+		cfg.Server.RouteSet = strings.ToLower(strings.TrimSpace(v))
+	}
 
 	// Shared LLM overrides (inherited by all subsections)
 	if v := os.Getenv("CLAWVISOR_LLM_PROVIDER"); v != "" {
@@ -781,6 +785,27 @@ func Load(path string) (*Config, error) {
 	if v := os.Getenv("CLAWVISOR_RUNTIME_POLICY_INJECT_STORED_BEARER"); v != "" {
 		cfg.RuntimePolicy.InjectStoredBearer = v == "true" || v == "1"
 	}
+	if v := os.Getenv("CLAWVISOR_PROXY_LITE_ENABLED"); v != "" {
+		cfg.ProxyLite.Enabled = v == "true" || v == "1"
+	}
+	if v := os.Getenv("CLAWVISOR_PROXY_LITE_ANTHROPIC_BASE_URL"); v != "" {
+		cfg.ProxyLite.AnthropicBaseURL = strings.TrimSpace(v)
+	}
+	if v := os.Getenv("CLAWVISOR_PROXY_LITE_OPENAI_BASE_URL"); v != "" {
+		cfg.ProxyLite.OpenAIBaseURL = strings.TrimSpace(v)
+	}
+	if v := os.Getenv("CLAWVISOR_PROXY_LITE_SELF_HOSTNAMES"); v != "" {
+		cfg.ProxyLite.SelfHostnames = splitCSV(v)
+	}
+	if v := os.Getenv("CLAWVISOR_PROXY_LITE_ALLOW_PRIVATE_NETWORKS"); v != "" {
+		cfg.ProxyLite.AllowPrivateNetworks = v == "true" || v == "1"
+	}
+	if v := os.Getenv("CLAWVISOR_PROXY_LITE_TRACE_LOG_PATH"); v != "" {
+		cfg.ProxyLite.TraceLogPath = strings.TrimSpace(v)
+	}
+	if v := os.Getenv("CLAWVISOR_PROXY_LITE_RAW_LOG_PATH"); v != "" {
+		cfg.ProxyLite.RawLogPath = strings.TrimSpace(v)
+	}
 
 	if v := os.Getenv("CLAWVISOR_RELAY_URL"); v != "" {
 		cfg.Relay.URL = v
@@ -857,6 +882,16 @@ func ensureGeminiCache(p **GeminiCacheConfig) *GeminiCacheConfig {
 	return *p
 }
 
+func splitCSV(v string) []string {
+	var out []string
+	for _, part := range strings.Split(v, ",") {
+		if part = strings.TrimSpace(part); part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}
+
 // inheritLLMDefaults fills empty fields in sub with the shared LLM-level defaults.
 func inheritLLMDefaults(sub *LLMProviderConfig, shared *LLMConfig) {
 	if sub.Provider == "" {
@@ -930,6 +965,14 @@ func (c *Config) Validate() error {
 	}
 	if c.RuntimePolicy.OneOffTTLSeconds <= 0 {
 		return fmt.Errorf("runtime_policy.one_off_ttl_seconds must be positive (got %d)", c.RuntimePolicy.OneOffTTLSeconds)
+	}
+	switch strings.ToLower(strings.TrimSpace(c.Server.RouteSet)) {
+	case "", "full", "app", "proxy_lite":
+	default:
+		return fmt.Errorf("server.route_set must be one of full, app, proxy_lite (got %q)", c.Server.RouteSet)
+	}
+	if strings.EqualFold(strings.TrimSpace(c.Server.RouteSet), "proxy_lite") && !c.ProxyLite.Enabled {
+		return fmt.Errorf("server.route_set=proxy_lite requires proxy_lite.enabled=true")
 	}
 	switch strings.ToLower(strings.TrimSpace(c.RuntimePolicy.AutovaultMode)) {
 	case "", "observe", "auto", "strict":

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -29,6 +29,57 @@ func TestLoadAppliesRuntimeProxyTimingTraceEnv(t *testing.T) {
 	}
 }
 
+func TestLoadAppliesProxyLiteCloudEnv(t *testing.T) {
+	t.Setenv("CLAWVISOR_ROUTE_SET", "proxy_lite")
+	t.Setenv("CLAWVISOR_PROXY_LITE_ENABLED", "true")
+	t.Setenv("CLAWVISOR_PROXY_LITE_ANTHROPIC_BASE_URL", "https://anthropic.internal")
+	t.Setenv("CLAWVISOR_PROXY_LITE_OPENAI_BASE_URL", "https://openai.internal")
+	t.Setenv("CLAWVISOR_PROXY_LITE_SELF_HOSTNAMES", "app.example.com, llm.example.com")
+	t.Setenv("CLAWVISOR_PROXY_LITE_ALLOW_PRIVATE_NETWORKS", "false")
+	t.Setenv("CLAWVISOR_PROXY_LITE_TRACE_LOG_PATH", "/tmp/lite-trace.jsonl")
+	t.Setenv("CLAWVISOR_PROXY_LITE_RAW_LOG_PATH", "/tmp/lite-raw.jsonl")
+
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Server.RouteSet != "proxy_lite" {
+		t.Fatalf("RouteSet=%q, want proxy_lite", cfg.Server.RouteSet)
+	}
+	if !cfg.ProxyLite.Enabled {
+		t.Fatal("expected proxy lite enabled")
+	}
+	if cfg.ProxyLite.AnthropicBaseURL != "https://anthropic.internal" {
+		t.Fatalf("AnthropicBaseURL=%q", cfg.ProxyLite.AnthropicBaseURL)
+	}
+	if cfg.ProxyLite.OpenAIBaseURL != "https://openai.internal" {
+		t.Fatalf("OpenAIBaseURL=%q", cfg.ProxyLite.OpenAIBaseURL)
+	}
+	if got := strings.Join(cfg.ProxyLite.SelfHostnames, ","); got != "app.example.com,llm.example.com" {
+		t.Fatalf("SelfHostnames=%q", got)
+	}
+	if cfg.ProxyLite.AllowPrivateNetworks {
+		t.Fatal("expected private networks disabled")
+	}
+	if cfg.ProxyLite.TraceLogPath != "/tmp/lite-trace.jsonl" {
+		t.Fatalf("TraceLogPath=%q", cfg.ProxyLite.TraceLogPath)
+	}
+	if cfg.ProxyLite.RawLogPath != "/tmp/lite-raw.jsonl" {
+		t.Fatalf("RawLogPath=%q", cfg.ProxyLite.RawLogPath)
+	}
+}
+
+func TestValidateProxyLiteRouteSetRequiresProxyLite(t *testing.T) {
+	cfg := Default()
+	cfg.Server.RouteSet = "proxy_lite"
+	cfg.ProxyLite.Enabled = false
+
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "proxy_lite.enabled") {
+		t.Fatalf("expected proxy_lite.enabled validation error, got %v", err)
+	}
+}
+
 func TestValidateRequiresTimingTraceDirWhenEnabled(t *testing.T) {
 	cfg := Default()
 	cfg.RuntimeProxy.TimingTraceEnabled = true


### PR DESCRIPTION
## Summary
- add route-set support so hosted deployments can run the main app and lite-proxy as separate services
- add Cloud Run-friendly env overrides for proxy-lite configuration
- add Redis-backed inline approval holds for multi-instance lite-proxy deployments
- document split deployment setup in docs/LITE_PROXY.md

## Verification
- go test ./pkg/config ./internal/runtime/llmproxy ./internal/api ./pkg/clawvisor
- from cloud wrapper: go test ./...
- from cloud wrapper: CGO_ENABLED=0 GOOS=linux go build -o /tmp/clawvisor-cloud-test ./cmd/cloud
- from cloud wrapper: CGO_ENABLED=0 GOOS=linux go build -o /tmp/clawvisor-admin-test ./cmd/admin

## Notes
- main app can run with CLAWVISOR_ROUTE_SET=app and CLAWVISOR_PROXY_LITE_ENABLED=true to keep credential-management/runtime UI routes while hiding /v1, /proxy/v1, and /control
- dedicated proxy service can run with CLAWVISOR_ROUTE_SET=proxy_lite and CLAWVISOR_PROXY_LITE_ENABLED=true to expose only health plus lite-proxy/control routes