### PR TITLE
Make proxy-lite the default agent CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,21 +460,21 @@ When paired with a mobile device, the daemon connects to `relay.clawvisor.com` v
 
 Clawvisor exposes an MCP (Model Context Protocol) server at `/mcp` with OAuth 2.1 for integration with Claude Desktop and other MCP clients. Tools available via MCP: `fetch_catalog`, `create_task`, `get_task`, `complete_task`, `expand_task`, `gateway_request`. See [docs/INTEGRATE_CLAUDE_COWORK.md](docs/INTEGRATE_CLAUDE_COWORK.md) for setup.
 
-## Runtime Proxy (preview)
+## Proxy-Lite Runtime (preview)
 
-The runtime proxy is a TLS-terminating egress proxy that runs inside the Clawvisor daemon. While the gateway describes what an agent intends to do, the runtime proxy sees what it actually sends on the wire — so Clawvisor can observe model API calls, intercept tool-use, hold inline approvals, and attribute every request to a runtime session.
+Proxy-lite runs inside the Clawvisor daemon and presents Anthropic/OpenAI-compatible LLM endpoints to command-line agents. It can observe model API calls, intercept tool-use, hold inline approvals, and attribute requests to a registered agent without requiring a CONNECT/TLS MITM proxy.
 
 > [!WARNING]
-> **The runtime proxy is in active development.** Behavior, flags, and the API surface may change in any release while it remains pre-1.0. Treat it as preview-quality and pin to a specific Clawvisor version in production.
+> **Proxy-lite is in active development.** Behavior, flags, and the API surface may change in any release while it remains pre-1.0. Treat it as preview-quality and pin to a specific Clawvisor version in production.
 
-It ships off by default. To enable, set `runtime_proxy.enabled: true` in `config.yaml` (or `CLAWVISOR_RUNTIME_PROXY_ENABLED=true`), restart the daemon, and run an agent through it:
+Register an agent, store its upstream Anthropic or OpenAI key, and run a command through proxy-lite:
 
 ```bash
 clawvisor agent register my-agent
 clawvisor agent run --agent my-agent -- claude
 ```
 
-For configuration, Dockerized agents, container isolation, starter profiles, and observe-vs-enforce mode, see [docs/RUNTIME_PROXY.md](docs/RUNTIME_PROXY.md).
+For provider-specific wrappers and raw environment exports, see [docs/LITE_PROXY.md](docs/LITE_PROXY.md).
 
 ## Architecture
 

--- a/cmd/clawvisor/cmd_agent_docker.go
+++ b/cmd/clawvisor/cmd_agent_docker.go
@@ -778,7 +778,7 @@ func init() {
 	agentDockerComposeCmd.Flags().StringArrayVar(&dockerComposePublishPorts, "publish-port", nil,
 		"Port to publish on the holder (compose `ports:` syntax, e.g. \"18789:18789\" or \"0.0.0.0:18790:18790/tcp\"). Repeatable. Required when the user service in the base compose file declares `ports:`, since `network_mode: service:…` forbids it. Only meaningful with --isolation=container.")
 
-	agentCmd.AddCommand(agentDockerEnvCmd)
-	agentCmd.AddCommand(agentDockerRunCmd)
-	agentCmd.AddCommand(agentDockerComposeCmd)
+	// Docker wiring depends on the full CONNECT/TLS runtime proxy, which is no
+	// longer exposed on the public CLI. Keep the implementation available for
+	// internal tests and future migration, but do not register the commands.
 }

--- a/cmd/clawvisor/cmd_agent_lite.go
+++ b/cmd/clawvisor/cmd_agent_lite.go
@@ -59,6 +59,25 @@ var agentLiteRunCmd = &cobra.Command{
 	SilenceUsage: true,
 }
 
+var agentRunCmd = &cobra.Command{
+	Use:   "run -- <command> [args...]",
+	Short: "Run an agent harness through proxy-lite",
+	Long:  "Infer the harness from the command name, inject proxy-lite LLM endpoint environment variables, and run Claude Code or Codex. Use --provider when the command name is a wrapper script.",
+	Args:  cobra.ArbitraryArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		provider, commandArgs, err := liteProxyRunPlan(args, liteRunProvider)
+		if err != nil {
+			return err
+		}
+		opts, err := liteProxyOptionsFromFlags(provider)
+		if err != nil {
+			return err
+		}
+		return runLiteProxyCommand(opts, commandArgs)
+	},
+	SilenceUsage: true,
+}
+
 func newLiteProxyHarnessCmd(provider string) *cobra.Command {
 	return &cobra.Command{
 		Use:   provider + " -- [args...]",
@@ -255,12 +274,14 @@ func addLiteProxyFlags(cmd *cobra.Command) {
 func init() {
 	agentClaudeCmd := newLiteProxyHarnessCmd(liteProxyProviderClaude)
 	agentCodexCmd := newLiteProxyHarnessCmd(liteProxyProviderCodex)
-	for _, subcmd := range []*cobra.Command{agentLiteEnvCmd, agentLiteRunCmd, agentClaudeCmd, agentCodexCmd} {
+	for _, subcmd := range []*cobra.Command{agentLiteEnvCmd, agentLiteRunCmd, agentRunCmd, agentClaudeCmd, agentCodexCmd} {
 		addLiteProxyFlags(subcmd)
 	}
 	agentLiteRunCmd.Flags().StringVar(&liteRunProvider, "provider", "", "Proxy-lite provider when it cannot be inferred from the command name (claude or codex)")
+	agentRunCmd.Flags().StringVar(&liteRunProvider, "provider", "", "Proxy-lite provider when it cannot be inferred from the command name (claude or codex)")
 	agentCmd.AddCommand(agentLiteEnvCmd)
 	agentCmd.AddCommand(agentLiteRunCmd)
+	agentCmd.AddCommand(agentRunCmd)
 	agentCmd.AddCommand(agentClaudeCmd)
 	agentCmd.AddCommand(agentCodexCmd)
 }

--- a/cmd/clawvisor/cmd_agent_lite_test.go
+++ b/cmd/clawvisor/cmd_agent_lite_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 func TestBuildLiteProxyEnvClaude(t *testing.T) {
@@ -169,4 +171,36 @@ func TestPrepareLiteProxyCommandArgsLeavesNonCodexWrapperAlone(t *testing.T) {
 	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
 		t.Fatalf("command args = %#v, want %#v", got, want)
 	}
+}
+
+func TestAgentCommandTreeDefaultsToLiteAndHidesFullProxyCommands(t *testing.T) {
+	agent := childCommand(rootCmd, "agent")
+	if agent == nil {
+		t.Fatal("agent command not registered")
+	}
+	run := childCommand(agent, "run")
+	if run == nil {
+		t.Fatal("agent run command not registered")
+	}
+	if !strings.Contains(run.Short, "proxy-lite") {
+		t.Fatalf("agent run short = %q, want proxy-lite command", run.Short)
+	}
+
+	for _, name := range []string{"runtime-env", "docker-env", "docker-run", "docker-compose"} {
+		if childCommand(agent, name) != nil {
+			t.Fatalf("agent %s should not be registered on the public CLI", name)
+		}
+	}
+	if childCommand(rootCmd, "proxy") != nil {
+		t.Fatal("root proxy command should not be registered on the public CLI")
+	}
+}
+
+func childCommand(parent *cobra.Command, name string) *cobra.Command {
+	for _, cmd := range parent.Commands() {
+		if cmd.Name() == name {
+			return cmd
+		}
+	}
+	return nil
 }

--- a/cmd/clawvisor/cmd_agent_registry.go
+++ b/cmd/clawvisor/cmd_agent_registry.go
@@ -4,13 +4,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/charmbracelet/huh"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 
 	"github.com/clawvisor/clawvisor/internal/daemon"
 	"github.com/clawvisor/clawvisor/internal/tui/client"
@@ -41,6 +44,9 @@ type resolvedAgentCredentials struct {
 }
 
 var agentRegisterJSON bool
+var agentRegisterProvider string
+var agentRegisterAPIKey string
+var agentRegisterSkipLLMKey bool
 
 var agentRegisterCmd = &cobra.Command{
 	Use:   "register <name>",
@@ -95,6 +101,11 @@ var agentRegisterCmd = &cobra.Command{
 			return fmt.Errorf("rotated token for agent %q but could not save local registry: %w\nrecovery:\n  server_url=%s\n  agent_token=%s", name, err, cl.BaseURL(), agent.Token)
 		}
 
+		llmSetup, err := maybeConfigureRegisteredAgentLLM(cmd, cl, entry)
+		if err != nil {
+			return err
+		}
+
 		if agentRegisterJSON {
 			enc := json.NewEncoder(os.Stdout)
 			enc.SetIndent("", "  ")
@@ -103,6 +114,7 @@ var agentRegisterCmd = &cobra.Command{
 
 		fmt.Printf("Registered agent %q for future `--agent` use.\n", name)
 		fmt.Printf("Stored token for %s at %s\n", cl.BaseURL(), path)
+		printAgentRegisterNextSteps(os.Stdout, entry, llmSetup)
 		return nil
 	},
 	SilenceUsage: true,
@@ -172,6 +184,174 @@ func saveAgentRegistry(path string, registry *agentRegistry) error {
 	return nil
 }
 
+type agentRegisterLLMSetup struct {
+	Provider string
+	Stored   bool
+	Skipped  bool
+}
+
+func maybeConfigureRegisteredAgentLLM(cmd *cobra.Command, cl *client.Client, entry registeredAgent) (*agentRegisterLLMSetup, error) {
+	if agentRegisterSkipLLMKey {
+		return &agentRegisterLLMSetup{Skipped: true}, nil
+	}
+
+	provider, err := normalizeAgentRegisterLLMProvider(agentRegisterProvider)
+	if err != nil {
+		return nil, err
+	}
+	apiKey := strings.TrimSpace(agentRegisterAPIKey)
+	interactive := !agentRegisterJSON && cmd != nil && cmd.InOrStdin() != nil && term.IsTerminal(int(os.Stdin.Fd())) && term.IsTerminal(int(os.Stdout.Fd()))
+
+	if provider == "" && apiKey != "" {
+		return nil, fmt.Errorf("--api-key requires --provider")
+	}
+
+	if provider == "" {
+		if !interactive {
+			return &agentRegisterLLMSetup{Skipped: true}, nil
+		}
+		provider = "anthropic"
+		if err := huh.NewForm(
+			huh.NewGroup(
+				huh.NewSelect[string]().
+					Title("Which upstream LLM provider should proxy-lite use for this agent?").
+					Options(
+						huh.NewOption("Anthropic (Claude Code)", "anthropic"),
+						huh.NewOption("OpenAI (Codex)", "openai"),
+						huh.NewOption("Skip for now", "skip"),
+					).
+					Value(&provider),
+			),
+		).Run(); err != nil {
+			return nil, err
+		}
+		if provider == "skip" {
+			return &agentRegisterLLMSetup{Skipped: true}, nil
+		}
+	}
+
+	if apiKey == "" {
+		if !interactive {
+			return nil, fmt.Errorf("--provider requires --api-key when stdin/stdout are not interactive")
+		}
+		if err := huh.NewForm(
+			huh.NewGroup(
+				huh.NewInput().
+					Title(agentRegisterAPIKeyPromptTitle(provider)).
+					EchoMode(huh.EchoModePassword).
+					Value(&apiKey),
+			),
+		).Run(); err != nil {
+			return nil, err
+		}
+		apiKey = strings.TrimSpace(apiKey)
+		if apiKey == "" {
+			return nil, fmt.Errorf("API key is required")
+		}
+	}
+
+	if _, err := cl.SetLLMCredential(provider, apiKey, entry.AgentID); err != nil {
+		return nil, fmt.Errorf("storing %s upstream API key for agent %q: %w", provider, entry.Alias, err)
+	}
+	return &agentRegisterLLMSetup{Provider: provider, Stored: true}, nil
+}
+
+func normalizeAgentRegisterLLMProvider(provider string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "":
+		return "", nil
+	case "anthropic", "claude", "claude-code":
+		return "anthropic", nil
+	case "openai", "codex":
+		return "openai", nil
+	default:
+		return "", fmt.Errorf("unsupported provider %q: expected anthropic or openai", provider)
+	}
+}
+
+func agentRegisterAPIKeyPromptTitle(provider string) string {
+	switch provider {
+	case "anthropic":
+		return "Anthropic API key"
+	case "openai":
+		return "OpenAI API key"
+	default:
+		return "Upstream API key"
+	}
+}
+
+func agentRegisterHarnessForProvider(provider string) string {
+	switch provider {
+	case "anthropic":
+		return liteProxyProviderClaude
+	case "openai":
+		return liteProxyProviderCodex
+	default:
+		return ""
+	}
+}
+
+func printAgentRegisterNextSteps(out io.Writer, entry registeredAgent, setup *agentRegisterLLMSetup) {
+	if out == nil {
+		return
+	}
+	alias := entry.Alias
+	if alias == "" {
+		alias = entry.AgentName
+	}
+	if alias == "" {
+		return
+	}
+	fmt.Fprintln(out)
+	if setup != nil && setup.Stored {
+		fmt.Fprintf(out, "Stored %s upstream API key for this agent.\n", setup.Provider)
+	}
+	aliasArg := shellQuoteIfNeeded(alias)
+	if harness := ""; setup != nil {
+		harness = agentRegisterHarnessForProvider(setup.Provider)
+		if harness != "" {
+			fmt.Fprintln(out, "Connect through proxy-lite:")
+			fmt.Fprintf(out, "  clawvisor agent %s --agent %s -- %s\n", harness, aliasArg, sampleLiteProxyPrompt(harness))
+			fmt.Fprintf(out, "  clawvisor agent lite-env %s --agent %s\n", harness, aliasArg)
+			return
+		}
+	}
+	fmt.Fprintln(out, "Connect through proxy-lite after storing an upstream key:")
+	fmt.Fprintf(out, "  clawvisor agent register %s --provider anthropic --api-key \"$ANTHROPIC_API_KEY\"\n", aliasArg)
+	fmt.Fprintf(out, "  clawvisor agent register %s --provider openai --api-key \"$OPENAI_API_KEY\"\n", aliasArg)
+	fmt.Fprintf(out, "  clawvisor agent claude --agent %s -- --print \"what is 2+2\"\n", aliasArg)
+	fmt.Fprintf(out, "  clawvisor agent codex --agent %s -- exec \"say hi\"\n", aliasArg)
+	fmt.Fprintf(out, "  clawvisor agent lite-env claude --agent %s\n", aliasArg)
+}
+
+func shellQuoteIfNeeded(value string) string {
+	if value == "" {
+		return shellQuote(value)
+	}
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '.', r == '_', r == '-', r == '/', r == ':':
+		default:
+			return shellQuote(value)
+		}
+	}
+	return value
+}
+
+func sampleLiteProxyPrompt(harness string) string {
+	switch harness {
+	case liteProxyProviderClaude:
+		return "--print \"what is 2+2\""
+	case liteProxyProviderCodex:
+		return "exec \"say hi\""
+	default:
+		return "\"say hi\""
+	}
+}
+
 func resolveAgentCredentials(agentName, agentToken, baseURL string) (*resolvedAgentCredentials, error) {
 	name := strings.TrimSpace(agentName)
 	token := strings.TrimSpace(agentToken)
@@ -235,5 +415,8 @@ func resolveAgentCredentials(agentName, agentToken, baseURL string) (*resolvedAg
 
 func init() {
 	agentRegisterCmd.Flags().BoolVar(&agentRegisterJSON, "json", false, "Output the registered agent record in JSON format")
+	agentRegisterCmd.Flags().StringVar(&agentRegisterProvider, "provider", "", "Upstream LLM provider to store for proxy-lite (anthropic or openai)")
+	agentRegisterCmd.Flags().StringVar(&agentRegisterAPIKey, "api-key", "", "Upstream provider API key to store for this agent (prefer the interactive prompt when possible)")
+	agentRegisterCmd.Flags().BoolVar(&agentRegisterSkipLLMKey, "skip-llm-key", false, "Do not prompt for or store an upstream provider API key")
 	agentCmd.AddCommand(agentRegisterCmd)
 }

--- a/cmd/clawvisor/cmd_agent_registry_test.go
+++ b/cmd/clawvisor/cmd_agent_registry_test.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"bytes"
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -230,5 +232,69 @@ func TestAgentRegistryPathUsesHome(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Dir(path)); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("expected registry dir to be created lazily, stat err=%v", err)
+	}
+}
+
+func TestNormalizeAgentRegisterLLMProvider(t *testing.T) {
+	tests := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"", "", false},
+		{"anthropic", "anthropic", false},
+		{"Claude", "anthropic", false},
+		{"claude-code", "anthropic", false},
+		{"openai", "openai", false},
+		{"Codex", "openai", false},
+		{"gemini", "", true},
+	}
+	for _, tt := range tests {
+		got, err := normalizeAgentRegisterLLMProvider(tt.in)
+		if tt.wantErr {
+			if err == nil {
+				t.Fatalf("normalizeAgentRegisterLLMProvider(%q): expected error", tt.in)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("normalizeAgentRegisterLLMProvider(%q): %v", tt.in, err)
+		}
+		if got != tt.want {
+			t.Fatalf("normalizeAgentRegisterLLMProvider(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestPrintAgentRegisterNextStepsForStoredProvider(t *testing.T) {
+	var out bytes.Buffer
+	printAgentRegisterNextSteps(&out, registeredAgent{Alias: "dev"}, &agentRegisterLLMSetup{
+		Provider: "openai",
+		Stored:   true,
+	})
+	got := out.String()
+	for _, want := range []string{
+		"Stored openai upstream API key for this agent.",
+		"clawvisor agent codex --agent dev -- exec \"say hi\"",
+		"clawvisor agent lite-env codex --agent dev",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("next steps missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestPrintAgentRegisterNextStepsWhenCredentialSkipped(t *testing.T) {
+	var out bytes.Buffer
+	printAgentRegisterNextSteps(&out, registeredAgent{Alias: "dev"}, &agentRegisterLLMSetup{Skipped: true})
+	got := out.String()
+	for _, want := range []string{
+		"Connect through proxy-lite after storing an upstream key:",
+		"clawvisor agent claude --agent dev -- --print \"what is 2+2\"",
+		"clawvisor agent codex --agent dev -- exec \"say hi\"",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("next steps missing %q:\n%s", want, got)
+		}
 	}
 }

--- a/cmd/clawvisor/cmd_agent_runtime.go
+++ b/cmd/clawvisor/cmd_agent_runtime.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"time"
 
-	runtimeproxy "github.com/clawvisor/clawvisor/pkg/runtime/proxy"
 	"github.com/clawvisor/clawvisor/internal/tui/client"
+	runtimeproxy "github.com/clawvisor/clawvisor/pkg/runtime/proxy"
 	"github.com/spf13/cobra"
 )
 
@@ -385,6 +385,7 @@ func init() {
 		subcmd.Flags().StringVar(&runtimeProfileOverride, "runtime-profile", "", "Explicit starter profile hint for this launch (e.g. claude_code or codex)")
 		subcmd.MarkFlagsMutuallyExclusive("agent", "agent-token")
 	}
-	agentCmd.AddCommand(agentRuntimeEnvCmd)
-	agentCmd.AddCommand(agentRuntimeRunCmd)
+	// The full CONNECT/TLS runtime proxy is intentionally not exposed on the
+	// public CLI. Proxy-lite is the default command-line path (`agent run`,
+	// `agent claude`, `agent codex`) and does not require MITM proxy setup.
 }

--- a/cmd/clawvisor/cmd_proxy_expose.go
+++ b/cmd/clawvisor/cmd_proxy_expose.go
@@ -327,5 +327,6 @@ func init() {
 
 	proxyExposeCmd.AddCommand(proxyExposeStopCmd)
 	proxyCmd.AddCommand(proxyExposeCmd)
-	rootCmd.AddCommand(proxyCmd)
+	// Full runtime-proxy exposure is intentionally not registered on the
+	// public CLI while proxy-lite is the default command-line integration.
 }

--- a/docs/LITE_PROXY.md
+++ b/docs/LITE_PROXY.md
@@ -78,16 +78,25 @@ The simplest connection is via the bundled wrappers:
 
 ```bash
 # One-time: register the agent. Pick a memorable alias.
-clawvisor agent register --name dev
+clawvisor agent register dev
+```
 
+In an interactive terminal, registration also asks whether this agent should
+forward to Anthropic or OpenAI, then stores that upstream API key in the
+agent-scoped vault entry used by proxy-lite. For automation, pass
+`--provider anthropic --api-key "$ANTHROPIC_API_KEY"` or
+`--provider openai --api-key "$OPENAI_API_KEY"`; use `--skip-llm-key` to only
+register the agent token.
+
+```bash
 # Run Claude Code through the lite-proxy:
 clawvisor agent claude --agent dev -- --print "what is 2+2"
 
 # Run Codex through the lite-proxy:
 clawvisor agent codex --agent dev -- exec "say hi"
 
-# Auto-detect harness from the command:
-clawvisor agent lite-run --agent dev -- claude --print "ping"
+# Auto-detect harness from the command. This is the default `agent run` path.
+clawvisor agent run --agent dev -- claude --print "ping"
 ```
 
 The wrappers inject the right environment variables for each harness:

--- a/docs/RUNTIME_PROXY.md
+++ b/docs/RUNTIME_PROXY.md
@@ -3,6 +3,13 @@
 > [!WARNING]
 > The runtime proxy is in active development. Behavior, flags, and API surface may change in any release while it remains pre-1.0. Treat it as preview-quality and pin to a specific Clawvisor version in production.
 
+> [!NOTE]
+> The public command-line launcher now defaults to proxy-lite. Use
+> `clawvisor agent run --agent <name> -- claude` or the provider-specific
+> `clawvisor agent claude` / `clawvisor agent codex` wrappers from
+> [LITE_PROXY.md](LITE_PROXY.md). The full CONNECT/TLS runtime-proxy launcher
+> commands are not registered on the public CLI.
+
 The runtime proxy is a TLS-terminating egress proxy that runs inside the Clawvisor daemon. When enabled, an agent's outbound HTTPS traffic is routed through it so Clawvisor can observe model API calls, intercept tool-use, hold inline approvals, capture or substitute credentials, and attribute every request to a runtime session.
 
 It is complementary to the gateway: gateway requests describe what the agent intends to do; the runtime proxy sees what it actually sends on the wire.
@@ -37,7 +44,7 @@ Restart the daemon to pick up the change:
 clawvisor restart
 ```
 
-On first start, the proxy generates a CA at `~/.clawvisor/runtime-proxy/ca.pem`. Agent traffic must trust this CA — the launcher commands below mount it for you.
+On first start, the proxy generates a CA at `~/.clawvisor/runtime-proxy/ca.pem`.
 
 ### Multi-replica deployments
 
@@ -48,136 +55,39 @@ redis:
   url: redis://...
 ```
 
-## Run an agent through the proxy
+## Historical full-proxy launcher
 
-The simplest flow uses a registered agent:
+The full runtime-proxy launcher used to expose `agent run` and `runtime-env`.
+Those command names are no longer available for the full proxy on the public
+CLI; `agent run` now means proxy-lite.
 
 ```bash
-# 1. Register an agent. This creates the agent on the daemon and stores its
-#    token at ~/.clawvisor/agents.json so launchers can reference it by name.
 clawvisor agent register my-agent
-
-# 2. Run a command under a runtime session. Mints a session, injects proxy
-#    env vars (HTTP_PROXY, HTTPS_PROXY, CLAWVISOR_RUNTIME_*, CA trust paths),
-#    and execs the command.
 clawvisor agent run --agent my-agent -- claude
 ```
 
-The session runs until the wrapped process exits or the configured TTL elapses (default 1 hour). Pass `--ttl-seconds` to override.
+See [LITE_PROXY.md](LITE_PROXY.md) for the supported command-line flow.
 
-If you'd rather inject the env into your current shell — useful for debugging or for launchers that don't tolerate a wrapping process — use `runtime-env`:
+## Public CLI status
+
+The full CONNECT/TLS proxy still exists in the daemon and lower-level runtime
+code, but its command-line launchers are not part of the public CLI. This means
+the following historical commands are intentionally unavailable:
 
 ```bash
-eval "$(clawvisor agent runtime-env --agent my-agent)"
-claude  # now routes through the proxy
+clawvisor agent runtime-env
+clawvisor agent docker-env
+clawvisor agent docker-run
+clawvisor agent docker-compose
+clawvisor proxy expose
 ```
 
-## Run a Dockerized agent
-
-Container launchers use a long-lived agent token instead of a runtime session secret so containers can restart without re-minting credentials.
-
-### One-shot `docker run`
+For command-line agents, use proxy-lite instead:
 
 ```bash
-clawvisor agent docker-run --agent my-agent -- \
-  docker run --rm -it my-agent-image agent serve
-```
-
-This injects the env vars and mounts the proxy CA into the container at `/clawvisor/ca.pem`.
-
-### `docker compose`
-
-Generate a Compose override for a named service:
-
-```bash
-clawvisor agent docker-compose --agent my-agent --service my-svc > clawvisor.override.yml
-docker compose -f docker-compose.yml -f clawvisor.override.yml up
-```
-
-The override is templated by default — it references `${CLAWVISOR_AGENT_TOKEN}` rather than baking the token in. Export the token before running compose:
-
-```bash
-export CLAWVISOR_AGENT_TOKEN=<token from `clawvisor agent register`>
-```
-
-### Print env for other launchers
-
-To inspect or pipe the env into a different launcher:
-
-```bash
-clawvisor agent docker-env --agent my-agent --format env       # KEY=VALUE
-clawvisor agent docker-env --agent my-agent --format export    # export KEY="VALUE"
-clawvisor agent docker-env --agent my-agent --format docker-args  # -e KEY=VALUE -e ...
-```
-
-## Container isolation (advanced)
-
-The default container flow trusts that the agent honors `HTTPS_PROXY`. For workloads that bypass env-var proxies (e.g. clients that pin DNS and call `connect()` directly), Clawvisor offers a kernel-enforced isolation mode that runs the user container in a netns sidecar with an iptables policy that rejects everything except the proxy and API endpoints.
-
-This requires a separately-running `clawvisor proxy expose` instance the container's docker network can reach. `expose` publishes the local proxy and daemon API onto a network-routable bind address with a source-IP allowlist.
-
-```bash
-# On the host running the daemon (or a host that can reach it):
-clawvisor proxy expose --detach \
-  --bind 0.0.0.0 \
-  --proxy-port 25291 \
-  --api-port 18791
-# Stop later with:
-clawvisor proxy expose stop
-```
-
-By default the allowlist accepts loopback + RFC-1918. Use `--allow-cidr` to narrow or extend it (repeatable).
-
-Then generate the isolated Compose override:
-
-```bash
-clawvisor agent docker-compose --agent my-agent --service my-svc \
-  --isolation=container \
-  --expose-url http://10.0.0.5:25291 \
-  --expose-api-url http://10.0.0.5:18791 \
-  > clawvisor.override.yml
-```
-
-The override emits a privileged netns-holder sidecar plus rewires the user service to share its netns via `network_mode: service:…`. Direct `connect()` to anything other than the two expose listeners returns `ECONNREFUSED` at the kernel.
-
-If the user service in the base compose file declares `ports:`, those need to move to the holder. Use `--publish-port` (repeatable, Compose port syntax):
-
-```bash
-clawvisor agent docker-compose ... \
-  --isolation=container \
-  --publish-port 18789:18789 \
-  --publish-port 0.0.0.0:18790:18790/tcp \
-  --expose-url ... --expose-api-url ...
-```
-
-The user service automatically clears its inherited `ports:` list with `ports: !reset []`.
-
-The same isolation mode is available for `docker run`:
-
-```bash
-clawvisor agent docker-run --agent my-agent --isolation=container -- \
-  docker run --rm my-agent-image agent serve
-```
-
-## Starter profiles
-
-The first time you launch a recognized agent (e.g. `claude`, `codex`), the launcher prompts to apply a starter set of allow rules for that agent's known control-plane traffic — model API calls, telemetry endpoints, OAuth refresh, and so on. This keeps the proxy from holding routine traffic for review while you build out your real policy.
-
-Available profiles ship with Clawvisor:
-
-| Profile ID | Display Name | Triggers on argv | Covers |
-|---|---|---|---|
-| `claude_code` | Claude Code | `claude` | `api.anthropic.com`, `platform.claude.com`, `mcp-proxy.anthropic.com`, plugin distribution, telemetry |
-| `codex` | Codex | `codex` | `api.openai.com /v1/responses`, `/v1/chat/completions`, `chatgpt.com /backend-api/codex/responses` |
-
-Press `Y` to apply, or `n`/`a` to skip. Both `n` and `a` persist a skip decision keyed by command + profile (not by agent), so future launches of that command won't prompt again for that profile. You can manage these decisions later from the dashboard.
-
-The prompt also won't fire if the agent's runtime settings already record this profile as its starter profile, if the launcher isn't attached to a TTY, or if the launched argv isn't a recognized command key (currently `claude` or `codex`).
-
-To apply a profile non-interactively:
-
-```bash
-clawvisor agent run --agent my-agent --runtime-profile claude_code -- claude
+clawvisor agent register my-agent
+clawvisor agent run --agent my-agent -- claude --print "ping"
+clawvisor agent codex --agent my-agent -- exec "say hi"
 ```
 
 ## Observe vs enforce
@@ -193,23 +103,13 @@ runtime_policy:
 
 (Or `CLAWVISOR_RUNTIME_POLICY_OBSERVATION_DEFAULT=true`.) This only affects the initial runtime settings created for new agents; existing agents keep whatever they have.
 
-The launcher prints a notice on every observe-mode run so it's not silently lost.
-
-To override per-launch:
-
-```bash
-clawvisor agent run --agent my-agent --observe -- claude        # force observe
-clawvisor agent run --agent my-agent --observe=false -- claude  # force enforce
-```
-
 The persistent default for a specific agent is its `runtime_mode` field (`observe` or `enforce`) on the agent's runtime settings record, configurable from the dashboard or via `PUT /api/agents/{id}/runtime-settings`.
 
 ## Where things live
 
 | Path | Contents |
 |---|---|
-| `~/.clawvisor/runtime-proxy/ca.pem` | Runtime proxy CA. Mounted at `/clawvisor/ca.pem` inside containers by the launchers. |
-| `~/.clawvisor/runtime-proxy/expose.pid` | Pidfile written by `clawvisor proxy expose --detach`. |
+| `~/.clawvisor/runtime-proxy/ca.pem` | Runtime proxy CA generated when the full proxy is enabled. |
 | `~/.clawvisor/agents.json` | Local agent registry populated by `clawvisor agent register`. |
 | `runtime_proxy.timing_trace_dir` | Per-request latency traces when `runtime_proxy.timing_trace_enabled=true`. |
 | `runtime_proxy.body_trace_dir` | Request/response body captures when `runtime_proxy.body_trace_enabled=true`. Disable in production. |

--- a/internal/tui/client/client.go
+++ b/internal/tui/client/client.go
@@ -130,6 +130,20 @@ func (c *Client) UpdateAgentRuntimeSettings(agentID string, settings AgentRuntim
 	return &resp, nil
 }
 
+func (c *Client) SetLLMCredential(provider, apiKey, agentID string) (*LLMCredentialSetResponse, error) {
+	path := "/api/runtime/llm-credentials/" + url.PathEscape(provider)
+	if strings.TrimSpace(agentID) != "" {
+		params := url.Values{}
+		params.Set("agent_id", agentID)
+		path += "?" + params.Encode()
+	}
+	var resp LLMCredentialSetResponse
+	if err := c.doJSONWithRetry("PUT", c.baseURL+path, map[string]string{"api_key": apiKey}, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
 func (c *Client) GetRuntimePresetDecision(commandKey, profile string) (*RuntimePresetDecision, error) {
 	params := url.Values{}
 	params.Set("command_key", commandKey)

--- a/internal/tui/client/types.go
+++ b/internal/tui/client/types.go
@@ -63,6 +63,13 @@ type AgentRuntimeSettings struct {
 	UpdatedAt              time.Time `json:"updated_at"`
 }
 
+type LLMCredentialSetResponse struct {
+	Provider  string `json:"provider"`
+	ServiceID string `json:"service_id"`
+	Status    string `json:"status"`
+	AgentID   string `json:"agent_id,omitempty"`
+}
+
 type RuntimePolicyRule struct {
 	ID            string         `json:"id"`
 	UserID        string         `json:"user_id"`


### PR DESCRIPTION
## Summary
- Make `clawvisor agent run` route through proxy-lite by default and hide the public full runtime-proxy CLI commands.
- Add interactive `agent register` setup for Anthropic/OpenAI upstream keys, with non-interactive flags for automation.
- Update lite/runtime docs and add CLI command-tree and registration helper tests.

## Tests
- `go test ./cmd/clawvisor ./internal/tui/client`