### PR TITLE
Use gmail.modify for Gmail draft creation

### DIFF
--- a/internal/adapters/definitions/google_gmail.yaml
+++ b/internal/adapters/definitions/google_gmail.yaml
@@ -14,15 +14,9 @@ auth:
     scopes:
       - "https://www.googleapis.com/auth/gmail.readonly"
       - "https://www.googleapis.com/auth/gmail.send"
+      - "https://www.googleapis.com/auth/gmail.modify"
       - "https://www.googleapis.com/auth/userinfo.email"
       - "https://www.googleapis.com/auth/userinfo.profile"
-    conditional_scopes:
-      - scope: "https://www.googleapis.com/auth/gmail.compose"
-        env_gate: "GMAIL_DRAFTS_ENABLED"
-        default: true
-      - scope: "https://www.googleapis.com/auth/gmail.modify"
-        env_gate: "GMAIL_ARCHIVE_ENABLED"
-        default: true
     endpoint: google
     vault_key: google
     scope_merge: true
@@ -84,7 +78,7 @@ actions:
   create_draft:
     display_name: "Create draft"
     risk: { category: write, sensitivity: low, description: "Create an email draft (not sent)" }
-    scopes: ["https://www.googleapis.com/auth/gmail.compose"]
+    scopes: ["https://www.googleapis.com/auth/gmail.modify"]
     override: go
     params:
       to: { type: string }

--- a/internal/adapters/google/gmail/adapter.go
+++ b/internal/adapters/google/gmail/adapter.go
@@ -18,12 +18,14 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 
-	"github.com/clawvisor/clawvisor/pkg/adapters"
 	"github.com/clawvisor/clawvisor/internal/adapters/format"
 	"github.com/clawvisor/clawvisor/internal/adapters/google/credential"
+	"github.com/clawvisor/clawvisor/pkg/adapters"
 )
 
 const serviceID = "google.gmail"
+
+const gmailModifyScope = "https://www.googleapis.com/auth/gmail.modify"
 
 // gmailScopes is the full set of scopes Gmail can use. The YAML definition is
 // the source of truth for OAuth URL generation and action gating; this list
@@ -31,8 +33,7 @@ const serviceID = "google.gmail"
 var gmailScopes = []string{
 	"https://www.googleapis.com/auth/gmail.readonly",
 	"https://www.googleapis.com/auth/gmail.send",
-	"https://www.googleapis.com/auth/gmail.compose",
-	"https://www.googleapis.com/auth/gmail.modify",
+	gmailModifyScope,
 	"https://www.googleapis.com/auth/userinfo.email",
 	"https://www.googleapis.com/auth/userinfo.profile",
 }
@@ -106,12 +107,12 @@ func (a *GmailAdapter) Execute(ctx context.Context, req adapters.Request) (*adap
 	case "send_message":
 		return a.sendMessage(ctx, client, req.Params)
 	case "create_draft":
-		if err := a.requireComposeScope(req.Credential); err != nil {
+		if err := a.requireModifyScope(req.Credential, "create_draft", "draft permissions"); err != nil {
 			return nil, err
 		}
 		return a.createDraft(ctx, client, req.Params)
 	case "archive_message":
-		if err := a.requireModifyScope(req.Credential); err != nil {
+		if err := a.requireModifyScope(req.Credential, "archive_message", "label-modification permissions"); err != nil {
 			return nil, err
 		}
 		return a.archiveMessage(ctx, client, req.Params)
@@ -161,9 +162,11 @@ func (a *GmailAdapter) listMessages(ctx context.Context, client *http.Client, pa
 	}
 
 	var listResp struct {
-		Messages           []struct{ ID string `json:"id"` } `json:"messages"`
-		NextPageToken      string                             `json:"nextPageToken"`
-		ResultSizeEstimate int                                `json:"resultSizeEstimate"`
+		Messages []struct {
+			ID string `json:"id"`
+		} `json:"messages"`
+		NextPageToken      string `json:"nextPageToken"`
+		ResultSizeEstimate int    `json:"resultSizeEstimate"`
 	}
 	if err := gmailGET(ctx, client, u, &listResp); err != nil {
 		return nil, fmt.Errorf("gmail list_messages: %w", err)
@@ -508,30 +511,16 @@ func (a *GmailAdapter) sendMessage(ctx context.Context, client *http.Client, par
 	return &adapters.Result{Summary: summary, Data: result}, nil
 }
 
-// requireComposeScope checks whether the stored credential includes the
-// gmail.compose scope. Legacy tokens that only have gmail.send will fail
-// with a descriptive error prompting the user to reconnect.
-func (a *GmailAdapter) requireComposeScope(credBytes []byte) error {
-	cred, err := credential.Parse(credBytes)
-	if err != nil {
-		return fmt.Errorf("gmail create_draft: %w", err)
-	}
-	if !credential.HasAllScopes(cred.Scopes, []string{"https://www.googleapis.com/auth/gmail.compose"}) {
-		return fmt.Errorf("gmail create_draft: the gmail.compose scope is required — please reconnect your Google account to grant draft permissions")
-	}
-	return nil
-}
-
 // requireModifyScope checks whether the stored credential includes the
 // gmail.modify scope. Legacy tokens lacking it will fail with a descriptive
 // error prompting the user to reconnect.
-func (a *GmailAdapter) requireModifyScope(credBytes []byte) error {
+func (a *GmailAdapter) requireModifyScope(credBytes []byte, action, permissionDescription string) error {
 	cred, err := credential.Parse(credBytes)
 	if err != nil {
-		return fmt.Errorf("gmail archive_message: %w", err)
+		return fmt.Errorf("gmail %s: %w", action, err)
 	}
-	if !credential.HasAllScopes(cred.Scopes, []string{"https://www.googleapis.com/auth/gmail.modify"}) {
-		return fmt.Errorf("gmail archive_message: the gmail.modify scope is required — please reconnect your Google account to grant label-modification permissions")
+	if !credential.HasAllScopes(cred.Scopes, []string{gmailModifyScope}) {
+		return fmt.Errorf("gmail %s: the gmail.modify scope is required — please reconnect your Google account to grant %s", action, permissionDescription)
 	}
 	return nil
 }
@@ -1201,4 +1190,3 @@ func paramInt(params map[string]any, key string) (int, bool) {
 	}
 	return 0, false
 }
-

--- a/internal/adapters/google/gmail/adapter_test.go
+++ b/internal/adapters/google/gmail/adapter_test.go
@@ -8,15 +8,66 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"golang.org/x/oauth2"
+
+	"github.com/clawvisor/clawvisor/internal/adapters/google/credential"
 )
 
-func b64(s string) string { return base64.URLEncoding.EncodeToString([]byte(s)) }
+func b64(s string) string    { return base64.URLEncoding.EncodeToString([]byte(s)) }
 func rawB64(s string) string { return base64.RawURLEncoding.EncodeToString([]byte(s)) }
 
 type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
+}
+
+func testGoogleCredential(t *testing.T, scopes ...string) []byte {
+	t.Helper()
+	cred, err := credential.FromToken(&oauth2.Token{AccessToken: "access-token"}, scopes, true)
+	if err != nil {
+		t.Fatalf("credential.FromToken: %v", err)
+	}
+	return cred
+}
+
+func containsString(items []string, want string) bool {
+	for _, item := range items {
+		if item == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestRequiredScopesUseModifyForDrafts(t *testing.T) {
+	adapter := New(nil)
+	scopes := adapter.RequiredScopes()
+
+	if !containsString(scopes, gmailModifyScope) {
+		t.Fatalf("RequiredScopes() missing gmail.modify: %v", scopes)
+	}
+	if containsString(scopes, "https://www.googleapis.com/auth/gmail.compose") {
+		t.Fatalf("RequiredScopes() should not request gmail.compose: %v", scopes)
+	}
+}
+
+func TestRequireModifyScopeForDrafts(t *testing.T) {
+	adapter := New(nil)
+
+	if err := adapter.requireModifyScope(testGoogleCredential(t, gmailModifyScope), "create_draft", "draft permissions"); err != nil {
+		t.Fatalf("requireModifyScope with gmail.modify: %v", err)
+	}
+
+	err := adapter.requireModifyScope(testGoogleCredential(t, "https://www.googleapis.com/auth/gmail.compose"), "create_draft", "draft permissions")
+	if err == nil {
+		t.Fatal("expected error when gmail.modify is missing")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "gmail create_draft") || !strings.Contains(msg, "gmail.modify") || !strings.Contains(msg, "draft permissions") {
+		t.Fatalf("error = %q, want create_draft gmail.modify draft permission guidance", msg)
+	}
 }
 
 func TestExtractBodyFromParts_DirectPlainText(t *testing.T) {


### PR DESCRIPTION
## Summary
- request gmail.modify as a normal Gmail OAuth scope instead of env-gating it
- use gmail.modify for create_draft action scopes and runtime credential checks
- remove gmail.compose from Gmail adapter requested scopes

## Tests
- go test ./internal/adapters/google/gmail
- go test ./pkg/adapters/yamlloader ./pkg/adapters/yamlvalidate ./pkg/adapters/yamlruntime