### PR TITLE
fix(conversation): accept yes/y/no/n as approval aliases

### DIFF
--- a/internal/runtime/conversation/approval_reply.go
+++ b/internal/runtime/conversation/approval_reply.go
@@ -6,7 +6,7 @@ import (
 )
 
 var approvalReplyRE = regexp.MustCompile(`(?i)\b(approve|deny)\s+(cv-[a-z0-9]{12})\b`)
-var bareApprovalRE = regexp.MustCompile(`(?i)^\s*(approve|deny)\s*$`)
+var bareApprovalRE = regexp.MustCompile(`(?i)^\s*(approve|yes|deny|no|ok|cancel)\s*$`)
 
 // ParseApprovalReplyText extracts the most recent approval reply from a block
 // of user-visible text. It scans non-empty lines from bottom to top and
@@ -24,7 +24,14 @@ func ParseApprovalReplyText(text string) (verb, id string) {
 			return strings.ToLower(match[1]), strings.ToLower(match[2])
 		}
 		if match := bareApprovalRE.FindStringSubmatch(line); match != nil {
-			return strings.ToLower(match[1]), ""
+			v:=strings.ToLower(match[1])
+			switch v{
+			case "yes","ok":
+				v="approve"
+			case "no","cancel":
+				v="deny"
+			}
+			return v, ""
 		}
 	}
 	return "", ""

--- a/internal/runtime/conversation/approval_reply.go
+++ b/internal/runtime/conversation/approval_reply.go
@@ -6,7 +6,7 @@ import (
 )
 
 var approvalReplyRE = regexp.MustCompile(`(?i)\b(approve|deny)\s+(cv-[a-z0-9]{12})\b`)
-var bareApprovalRE = regexp.MustCompile(`(?i)^\s*(approve|yes|deny|no|ok|cancel)\s*$`)
+var bareApprovalRE = regexp.MustCompile(`(?i)^\s*(approve|yes|y|deny|no|n)\s*$`)
 
 // ParseApprovalReplyText extracts the most recent approval reply from a block
 // of user-visible text. It scans non-empty lines from bottom to top and
@@ -26,9 +26,9 @@ func ParseApprovalReplyText(text string) (verb, id string) {
 		if match := bareApprovalRE.FindStringSubmatch(line); match != nil {
 			v := strings.ToLower(match[1])
 			switch v {
-			case "yes", "ok":
+			case "yes", "y":
 				v = "approve"
-			case "no", "cancel":
+			case "no", "n":
 				v = "deny"
 			}
 			return v, ""

--- a/internal/runtime/conversation/approval_reply.go
+++ b/internal/runtime/conversation/approval_reply.go
@@ -24,12 +24,12 @@ func ParseApprovalReplyText(text string) (verb, id string) {
 			return strings.ToLower(match[1]), strings.ToLower(match[2])
 		}
 		if match := bareApprovalRE.FindStringSubmatch(line); match != nil {
-			v:=strings.ToLower(match[1])
-			switch v{
-			case "yes","ok":
-				v="approve"
-			case "no","cancel":
-				v="deny"
+			v := strings.ToLower(match[1])
+			switch v {
+			case "yes", "ok":
+				v = "approve"
+			case "no", "cancel":
+				v = "deny"
 			}
 			return v, ""
 		}

--- a/internal/runtime/conversation/approval_reply_test.go
+++ b/internal/runtime/conversation/approval_reply_test.go
@@ -8,12 +8,14 @@ func TestParseApprovalReplyText(t *testing.T) {
 		wantVerb string
 		wantID   string
 	}{
+		{"yes", "approve", ""},
+		{"y", "approve", ""},
+		{"no", "deny", ""},
+		{"n", "deny", ""},
 		{"approve", "approve", ""},
 		{"deny", "deny", ""},
-		{"yes", "approve", ""},
-		{"no", "deny", ""},
-		{"ok", "approve", ""},
-		{"cancel", "deny", ""},
+		{"ok", "", ""},
+		{"cancel", "", ""},
 		{"approve cv-abc123def456", "approve", "cv-abc123def456"},
 		{"deny cv-abc123def456", "deny", "cv-abc123def456"},
 		{"", "", ""},

--- a/internal/runtime/conversation/approval_reply_test.go
+++ b/internal/runtime/conversation/approval_reply_test.go
@@ -2,27 +2,27 @@ package conversation
 
 import "testing"
 
-func TestParseApprovalReplyText(t *testing.T){
-	tests:= []struct{
-		input string
+func TestParseApprovalReplyText(t *testing.T) {
+	tests := []struct {
+		input    string
 		wantVerb string
-		wantID string
+		wantID   string
 	}{
-		{"approve","approve",""},
-		{"deny","deny",""},
-		{"yes","approve",""},
-		{"no","deny",""},
-		{"ok","approve",""},
-		{"cancel","deny",""},
-		{"approve cv-abc123def456", "approve", "cv-abc123def456"},                                                              
-        {"deny cv-abc123def456", "deny", "cv-abc123def456"},                                                                    
-        {"", "", ""},
-		{"I'll approve it later", "", ""},   //should NOT trigger                                                              
-		{"looks good to me!", "", ""},       //should NOT trigger       
+		{"approve", "approve", ""},
+		{"deny", "deny", ""},
+		{"yes", "approve", ""},
+		{"no", "deny", ""},
+		{"ok", "approve", ""},
+		{"cancel", "deny", ""},
+		{"approve cv-abc123def456", "approve", "cv-abc123def456"},
+		{"deny cv-abc123def456", "deny", "cv-abc123def456"},
+		{"", "", ""},
+		{"I'll approve it later", "", ""}, //should NOT trigger
+		{"looks good to me!", "", ""},     //should NOT trigger
 	}
-	for _, tt:= range tests{
-		verb, id:= ParseApprovalReplyText(tt.input)
-		if verb!= tt.wantVerb || id!= tt.wantID{
+	for _, tt := range tests {
+		verb, id := ParseApprovalReplyText(tt.input)
+		if verb != tt.wantVerb || id != tt.wantID {
 			t.Errorf("ParseApprovalReplyText(%q)=%q,%q, want %q,%q", tt.input, verb, id, tt.wantVerb, tt.wantID)
 		}
 	}

--- a/internal/runtime/conversation/approval_reply_test.go
+++ b/internal/runtime/conversation/approval_reply_test.go
@@ -1,0 +1,29 @@
+package conversation
+
+import "testing"
+
+func TestParseApprovalReplyText(t *testing.T){
+	tests:= []struct{
+		input string
+		wantVerb string
+		wantID string
+	}{
+		{"approve","approve",""},
+		{"deny","deny",""},
+		{"yes","approve",""},
+		{"no","deny",""},
+		{"ok","approve",""},
+		{"cancel","deny",""},
+		{"approve cv-abc123def456", "approve", "cv-abc123def456"},                                                              
+        {"deny cv-abc123def456", "deny", "cv-abc123def456"},                                                                    
+        {"", "", ""},
+		{"I'll approve it later", "", ""},   //should NOT trigger                                                              
+		{"looks good to me!", "", ""},       //should NOT trigger       
+	}
+	for _, tt:= range tests{
+		verb, id:= ParseApprovalReplyText(tt.input)
+		if verb!= tt.wantVerb || id!= tt.wantID{
+			t.Errorf("ParseApprovalReplyText(%q)=%q,%q, want %q,%q", tt.input, verb, id, tt.wantVerb, tt.wantID)
+		}
+	}
+}


### PR DESCRIPTION

## Problem

The inline task approval flow only accepted the exact words `approve` and `deny`.
Users who naturally typed `yes`, `y`, `no`, or `n` were silently ignored
the hold wasn't resolved and the LLM would just continue the conversation without
creating the task. This was especially confusing because there's no error feedback.

## Change

**`internal/runtime/conversation/approval_reply.go`**

Extended `bareApprovalRE` to also match `yes`, `y`, `no`, and `n`.
Added normalization in `ParseApprovalReplyText` so aliases map back to the
canonical verbs before returning - no changes needed in any downstream caller.

```
yes, y   → approve
no, n → deny
```

The ID-prefixed regex (`approve cv-xxx` / `deny cv-xxx`) is unchanged - aliases
don't make sense with an explicit approval ID.

## Test file added

`internal/runtime/conversation/approval_reply_test.go` - covers:
- canonical `approve` / `deny`
- all new aliases
- ID-prefixed form
- negative cases (sentences containing the word, empty input)

