### PR TITLE
Use yes/no for lite proxy approvals

### DIFF
--- a/docs/LITE_PROXY.md
+++ b/docs/LITE_PROXY.md
@@ -7,7 +7,7 @@ The lite-proxy is an LLM termination + tool-mediation surface that runs inside t
 
 - Swaps the agent token for the real upstream API key from the vault before forwarding to Anthropic / OpenAI.
 - Inspects every tool_use in the response, rewrites credentialed calls through Clawvisor's resolver, and gates them on task scope.
-- Holds tool_uses that need user approval, returning a synthesized prompt the user replies to inline (`approve` / `deny` / `task`).
+- Holds tool_uses that need user approval, returning a synthesized prompt the user replies to inline (`y`/`yes` / `n`/`no` / `task`).
 - Substitutes vaulted credentials into the outbound HTTP call at proxy time so the agent never holds the real secret.
 
 It is an alternative to the [runtime proxy](RUNTIME_PROXY.md) (CONNECT/TLS-MITM). They solve overlapping problems with different tradeoffs:
@@ -221,14 +221,14 @@ Tool: Bash
 Reason: no matching task scope
 Input: mkdir -p /tmp/landing
 
-Reply approve to run this tool call, deny to block it,
+Reply (y)es to run this tool call, (n)o to block it,
 or task to instruct the agent to include this in a task definition for approval.
 ```
 
 Three replies:
 
-- `approve` — release the held tool_use. Daemon rewrites and re-emits it; harness runs it; model gets the result.
-- `deny` — refuse it. Model sees a synthetic refusal tool_result and stops.
+- `y` / `yes` — release the held tool_use. Daemon rewrites and re-emits it; harness runs it; model gets the result.
+- `n` / `no` — refuse it. Model sees a synthetic refusal tool_result and stops.
 - `task` — daemon tells the model to POST a task definition that covers this work. Once the task is approved, the original tool_use re-emits within the new scope.
 
 The dashboard approval surface lives in parallel. Async agents and multi-agent control panels still use it. Single-user interactive sessions can stay entirely in chat.

--- a/internal/api/handlers/llm_endpoint_test.go
+++ b/internal/api/handlers/llm_endpoint_test.go
@@ -398,7 +398,7 @@ func TestLLMEndpoint_BreakGlassPassthroughSkipsControlAndInspection(t *testing.T
 		t.Fatalf("passthrough should not inject control notice or sanitize request:\n%s", seenBody)
 	}
 	out := rec.Body.String()
-	if strings.Contains(out, "Reply `approve`") {
+	if strings.Contains(out, "Reply `(y)es`") {
 		t.Fatalf("passthrough should not inspect/block tool use: %s", out)
 	}
 	if !strings.Contains(out, "mkdir /tmp/needs-task") {
@@ -1534,7 +1534,7 @@ func TestLLMEndpoint_InlineApprovalReleasesHeldToolUse(t *testing.T) {
 	if firstRec.Code != http.StatusOK {
 		t.Fatalf("first response status = %d (%s)", firstRec.Code, firstRec.Body.String())
 	}
-	if !strings.Contains(firstRec.Body.String(), "Reply `approve`") {
+	if !strings.Contains(firstRec.Body.String(), "Reply `(y)es`") {
 		t.Fatalf("first response missing approval prompt: %s", firstRec.Body.String())
 	}
 	if upstreamHits != 1 {
@@ -1648,7 +1648,7 @@ func TestLLMEndpoint_RequiresApprovalForOpenAIToolUseWithoutScope(t *testing.T) 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d (%s)", rec.Code, rec.Body.String())
 	}
-	if !strings.Contains(rec.Body.String(), "Reply `approve`") {
+	if !strings.Contains(rec.Body.String(), "Reply `(y)es`") {
 		t.Fatalf("expected approval prompt, got %s", rec.Body.String())
 	}
 

--- a/internal/runtime/conversation/approval_reply.go
+++ b/internal/runtime/conversation/approval_reply.go
@@ -5,13 +5,15 @@ import (
 	"strings"
 )
 
-var approvalReplyRE = regexp.MustCompile(`(?i)\b(approve|deny|task)\s+(cv-(?:[a-z0-9]{12}|[a-z0-9]{26}))\b`)
-var bareApprovalRE = regexp.MustCompile(`(?i)^\s*(approve|deny|task)\s*$`)
+var approvalReplyRE = regexp.MustCompile(`(?i)^\s*(approve|deny|yes|y|no|n|task)\s+(cv-(?:[a-z0-9]{12}|[a-z0-9]{26}))\s*$`)
+var bareApprovalRE = regexp.MustCompile(`(?i)^\s*(approve|deny|yes|y|no|n|task)\s*$`)
 
 // ParseApprovalReplyText extracts the most recent approval reply from a block
-// of user-visible text. It scans non-empty lines from bottom to top and
-// returns the first explicit approval marker it finds, allowing clients to
-// wrap an approval with metadata or follow-up commentary.
+// of user-visible text. User-facing yes/no replies are normalized to the
+// canonical approve/deny verbs used by the release pipeline. It scans non-empty
+// lines from bottom to top and returns the first explicit approval marker it
+// finds, allowing clients to wrap an approval with metadata or follow-up
+// commentary.
 func ParseApprovalReplyText(text string) (verb, id string) {
 	text = strings.ReplaceAll(text, "\r\n", "\n")
 	lines := strings.Split(text, "\n")
@@ -21,11 +23,22 @@ func ParseApprovalReplyText(text string) (verb, id string) {
 			continue
 		}
 		if match := approvalReplyRE.FindStringSubmatch(line); match != nil {
-			return strings.ToLower(match[1]), strings.ToLower(match[2])
+			return normalizeApprovalReplyVerb(match[1]), strings.ToLower(match[2])
 		}
 		if match := bareApprovalRE.FindStringSubmatch(line); match != nil {
-			return strings.ToLower(match[1]), ""
+			return normalizeApprovalReplyVerb(match[1]), ""
 		}
 	}
 	return "", ""
+}
+
+func normalizeApprovalReplyVerb(verb string) string {
+	switch strings.ToLower(verb) {
+	case "y", "yes":
+		return "approve"
+	case "n", "no":
+		return "deny"
+	default:
+		return strings.ToLower(verb)
+	}
 }

--- a/internal/runtime/llmproxy/approval_body_editor_test.go
+++ b/internal/runtime/llmproxy/approval_body_editor_test.go
@@ -27,7 +27,7 @@ func TestApprovalBodyEditorProviderShapes(t *testing.T) {
 			name:      "anthropic_string_content",
 			provider:  conversation.ProviderAnthropic,
 			path:      "/v1/messages",
-			body:      `{"messages":[{"role":"user","content":"approve"}]}`,
+			body:      `{"messages":[{"role":"user","content":"yes"}]}`,
 			wantReply: true,
 			wantVerb:  "approve",
 			want:      `"content":"` + replacement + `"`,

--- a/internal/runtime/llmproxy/approval_reply_resolver.go
+++ b/internal/runtime/llmproxy/approval_reply_resolver.go
@@ -37,6 +37,7 @@ type approvalReplyRoutingRequest struct {
 //
 //   - explicit approval IDs target only that hold
 //   - bare replies target the newest visible hold across stages
+//   - yes/no replies normalize to approve/deny
 //   - approve/deny on an inline-task hold belongs to the inline rewriter
 //   - approve/deny on any other hold belongs to the regular release path
 //   - task starts the inline task-definition flow for the targeted hold

--- a/internal/runtime/llmproxy/inline_approval_outcome.go
+++ b/internal/runtime/llmproxy/inline_approval_outcome.go
@@ -35,7 +35,7 @@ type InlineApprovalOutcome struct {
 	// embedding in an LLM-facing context note.
 	FailureReason string
 	// RequestID links this resolution back to the lite-proxy request
-	// that processed the user's approve/deny reply.
+	// that processed the user's yes/no reply.
 	RequestID string
 	// ResolvedAt is when the proxy resolved the inline approval.
 	ResolvedAt time.Time

--- a/internal/runtime/llmproxy/inline_task_augment_test.go
+++ b/internal/runtime/llmproxy/inline_task_augment_test.go
@@ -26,18 +26,18 @@ func anthropicTextBody(messages ...map[string]string) []byte {
 // promptWithFooter builds an inline-prompt assistant message with the
 // approval-id footer the augmenter parses to look up the outcome.
 func promptWithFooter(approvalID, purposeLine string) string {
-	body := "Clawvisor wants to create a task to cover this work:\n\nPurpose\n  " + purposeLine + "\n\nReply approve to authorize, deny to cancel."
+	body := "Clawvisor wants to create a task to cover this work:\n\nPurpose\n  " + purposeLine + "\n\nReply (y)es to authorize, (n)o to cancel."
 	return body + "\n\n" + InlineApprovalIDMarker + approvalID + "]"
 }
 
-func TestAugment_InjectsContextOnBareApproveAfterSubstitutedPrompt(t *testing.T) {
+func TestAugment_InjectsContextOnBareYesAfterSubstitutedPrompt(t *testing.T) {
 	outcomes := NewMemoryInlineApprovalOutcomeStore(time.Minute)
 	outcomes.Record(InlineApprovalOutcomeKey{UserID: "user-1", AgentID: "agent-1", ApprovalID: "cv-approve-1"}, InlineApprovalOutcome{Succeeded: true, TaskID: "task-abc"})
 
 	body := anthropicTextBody(
 		map[string]string{"role": "user", "content": "Can you create a series of fake LLM conversations in /tmp/x?"},
 		map[string]string{"role": "assistant", "content": promptWithFooter("cv-approve-1", "Create /tmp/x ...")},
-		map[string]string{"role": "user", "content": "approve"},
+		map[string]string{"role": "user", "content": "yes"},
 		map[string]string{"role": "assistant", "content": "Running mkdir..."},
 		map[string]string{"role": "user", "content": "mkdir output"},
 	)
@@ -46,7 +46,7 @@ func TestAugment_InjectsContextOnBareApproveAfterSubstitutedPrompt(t *testing.T)
 		t.Fatal(err)
 	}
 	if !rewritten {
-		t.Fatal("expected augmentation to fire on bare approve after substituted prompt")
+		t.Fatal("expected augmentation to fire on bare yes after substituted prompt")
 	}
 	s := string(out)
 	if !strings.Contains(s, InlineApprovalAugmentationMarker) {
@@ -89,7 +89,7 @@ func TestAugment_IdempotentOnSecondPass(t *testing.T) {
 func TestAugment_NoopOnRegularToolApprove(t *testing.T) {
 	body := anthropicTextBody(
 		map[string]string{"role": "user", "content": "Do something"},
-		map[string]string{"role": "assistant", "content": "Clawvisor paused this tool call for approval.\n\nTool: Bash\nInput: ls\n\nReply approve to run, deny to block, or task to ..."},
+		map[string]string{"role": "assistant", "content": "Clawvisor paused this tool call for approval.\n\nTool: Bash\nInput: ls\n\nReply (y)es to run, (n)o to block, or task to ..."},
 		map[string]string{"role": "user", "content": "approve"},
 	)
 	_, ok, err := AugmentApprovedInlineTasksInHistory(body, conversation.ProviderAnthropic, NewMemoryInlineApprovalOutcomeStore(time.Minute), "user-1", "agent-1")

--- a/internal/runtime/llmproxy/inline_task_intercept.go
+++ b/internal/runtime/llmproxy/inline_task_intercept.go
@@ -11,7 +11,7 @@ import (
 	runtimetasks "github.com/clawvisor/clawvisor/internal/runtime/tasks"
 )
 
-// inlineTaskApprovalTTL is how long the user has to type approve/deny
+// inlineTaskApprovalTTL is how long the user has to type yes/no
 // after the model has emitted the task definition. Bounded so the second
 // gesture sits within the same approval cache window as the first; if
 // the user walks away mid-flight both holds expire together and the
@@ -42,8 +42,8 @@ const InlineSurfaceQueryValue = "inline"
 // in production traffic for the intercept to observe.)
 //
 // When the query signal fires, the model never actually POSTs the
-// task — the tool_use_result is replaced with a rendered approve/deny
-// prompt, and the user's next "approve" creates the task pre-approved.
+// task — the tool_use_result is replaced with a rendered yes/no
+// prompt, and the user's next "yes" creates the task pre-approved.
 //
 // Returns (_, false) when the signal is absent, the body fails to
 // parse, or the path isn't POST /control/tasks — callers should
@@ -145,7 +145,7 @@ func maybeInterceptInlineTaskDefinition(
 		return conversation.ToolUseVerdict{}, false
 	}
 
-	audit("block", "inline_task_pending_approval", "awaiting user approve/deny on inline task definition (query)")
+	audit("block", "inline_task_pending_approval", "awaiting user yes/no on inline task definition (query)")
 	trace("inline_task.held",
 		"approval_id", innerHold.Pending.ID,
 		"purpose", parsed.Purpose,

--- a/internal/runtime/llmproxy/inline_task_intercept_test.go
+++ b/internal/runtime/llmproxy/inline_task_intercept_test.go
@@ -117,7 +117,7 @@ func TestInlineTask_PostprocessIntoRelease(t *testing.T) {
 		t.Fatal("postprocess did not register an inner hold")
 	}
 
-	// User types approve.
+	// User types yes.
 	creator := &capturingInlineCreator{
 		resp: &InlineApprovedTask{
 			ID:               "task-uuid-final",
@@ -128,7 +128,7 @@ func TestInlineTask_PostprocessIntoRelease(t *testing.T) {
 			ApprovalRecordID: "appr-final",
 		},
 	}
-	approveBody := []byte(`{"messages":[{"role":"user","content":"approve ` + innerID + `"}]}`)
+	approveBody := []byte(`{"messages":[{"role":"user","content":"yes ` + innerID + `"}]}`)
 	rewrite, err := RewriteInlineTaskApprovalReply(ctx, InlineApprovalRewriteRequest{
 		HTTPRequest:     httptest.NewRequest("POST", "/v1/messages", nil),
 		Provider:        conversation.ProviderAnthropic,
@@ -359,7 +359,7 @@ func TestReleaseInlineTaskApproval_QueryOnlyHoldNoOuterCascade(t *testing.T) {
 	creator := &capturingInlineCreator{
 		resp: &InlineApprovedTask{ID: "task-q", Status: "active", ApprovalSource: "inline_chat", Lifetime: "session", ApprovalRecordID: "appr-q"},
 	}
-	approveBody := []byte(`{"messages":[{"role":"user","content":"approve ` + inner.Pending.ID + `"}]}`)
+	approveBody := []byte(`{"messages":[{"role":"user","content":"yes ` + inner.Pending.ID + `"}]}`)
 	rewrite, err := RewriteInlineTaskApprovalReply(ctx, InlineApprovalRewriteRequest{
 		HTTPRequest:     httptest.NewRequest("POST", "/v1/messages", nil),
 		Provider:        conversation.ProviderAnthropic,

--- a/internal/runtime/llmproxy/inline_task_prompt.go
+++ b/internal/runtime/llmproxy/inline_task_prompt.go
@@ -7,7 +7,7 @@ import (
 	"github.com/clawvisor/clawvisor/internal/taskrisk"
 )
 
-// renderTaskApprovalPrompt builds the inline approve/deny prompt the model
+// renderTaskApprovalPrompt builds the inline yes/no prompt the model
 // substitutes in place of the synthetic task_use_result for a model-emitted
 // POST /control/tasks when the user is mid-flight on an inline task gesture
 // (StageAwaitingTaskApproval).
@@ -42,11 +42,11 @@ func renderTaskApprovalPrompt(req *runtimetasks.TaskCreateRequest, approvalID st
 func renderTaskApprovalPromptWithRisk(req *runtimetasks.TaskCreateRequest, approvalID string, risk *taskrisk.RiskAssessment) string {
 	suffix := approvalIDFooter(approvalID)
 	if req == nil {
-		return "Clawvisor wants to create a task.\n\nReply `approve` to authorize, `deny` to cancel." + suffix
+		return "Clawvisor wants to create a task.\n\nReply `(y)es` to authorize, `(n)o` to cancel." + suffix
 	}
 	purpose := strings.TrimSpace(req.Purpose)
 	if purpose == "" {
-		return "Clawvisor wants to create a task: unnamed.\n\nReply `approve` to authorize, `deny` to cancel." + suffix
+		return "Clawvisor wants to create a task: unnamed.\n\nReply `(y)es` to authorize, `(n)o` to cancel." + suffix
 	}
 
 	var b strings.Builder
@@ -134,7 +134,7 @@ func renderTaskApprovalPromptWithRisk(req *runtimetasks.TaskCreateRequest, appro
 	}
 
 	b.WriteString("\n\nApproving will create this task and run the original tool call.\n")
-	b.WriteString("Reply `approve` to authorize, `deny` to cancel.")
+	b.WriteString("Reply `(y)es` to authorize, `(n)o` to cancel.")
 	b.WriteString(suffix)
 	return b.String()
 }

--- a/internal/runtime/llmproxy/inline_task_prompt_test.go
+++ b/internal/runtime/llmproxy/inline_task_prompt_test.go
@@ -40,8 +40,8 @@ func TestRenderTaskApprovalPromptWellFormed(t *testing.T) {
 	if !strings.Contains(prompt, "10 min") {
 		t.Errorf("missing humanized expiry: %q", prompt)
 	}
-	if !strings.Contains(prompt, "approve") || !strings.Contains(prompt, "deny") {
-		t.Errorf("missing approve/deny instructions: %q", prompt)
+	if !strings.Contains(prompt, "(y)es") || !strings.Contains(prompt, "(n)o") {
+		t.Errorf("missing yes/no instructions: %q", prompt)
 	}
 	if strings.Contains(prompt, "{") {
 		t.Errorf("raw JSON leaked into prompt: %q", prompt)
@@ -85,8 +85,8 @@ func TestRenderTaskApprovalPromptFallbackForEmptyPurpose(t *testing.T) {
 	if !strings.Contains(prompt, "unnamed") {
 		t.Errorf("expected 'unnamed' fallback, got %q", prompt)
 	}
-	if !strings.Contains(prompt, "approve") {
-		t.Errorf("expected approve instructions in fallback, got %q", prompt)
+	if !strings.Contains(prompt, "(y)es") {
+		t.Errorf("expected yes instructions in fallback, got %q", prompt)
 	}
 }
 

--- a/internal/runtime/llmproxy/inline_task_rewrite.go
+++ b/internal/runtime/llmproxy/inline_task_rewrite.go
@@ -63,7 +63,7 @@ type InlineApprovalRewriteResult struct {
 }
 
 // RewriteInlineTaskApprovalReply consumes an awaiting_task_approval
-// hold when the user's most recent message is "approve" or "deny",
+// hold when the user's most recent message is yes/no,
 // creates the task (on approve), drops the linked outer tool hold,
 // and rewrites the user message to include task-creation context.
 //

--- a/internal/runtime/llmproxy/inline_task_state_machine.md
+++ b/internal/runtime/llmproxy/inline_task_state_machine.md
@@ -8,16 +8,16 @@ user turn a blocked tool approval into an inline-approved task.
 `StageTool`
 
 - Standard pending tool approval.
-- The user may reply `approve`, `deny`, or `task`.
-- `approve`/`deny` are handled by `TryReleasePendingApproval`.
+- The user may reply `y`/`yes`, `n`/`no`, or `task`.
+- Yes/no replies are normalized to `approve`/`deny` and handled by `TryReleasePendingApproval`.
 - `task` is handled by `RewriteTaskApprovalReply`.
 
 `StageAwaitingTaskApproval`
 
 - The model emitted `POST /control/tasks?surface=inline`, and the proxy
   substituted a task approval prompt back into the conversation.
-- The user may reply `approve` or `deny`.
-- `approve`/`deny` are handled by `RewriteInlineTaskApprovalReply`.
+- The user may reply `y`/`yes` or `n`/`no`.
+- Yes/no replies are normalized to `approve`/`deny` and handled by `RewriteInlineTaskApprovalReply`.
 - If this stage reaches `TryReleasePendingApproval`, release fails
   closed with `inline_task_preprocess_missing` and leaves the hold in
   cache for retry.
@@ -30,9 +30,9 @@ Rules:
 
 - Explicit approval IDs target only that hold.
 - Bare replies target the newest visible hold across all stages.
-- `approve`/`deny` on a `StageAwaitingTaskApproval` hold route to the
+- Normalized `approve`/`deny` on a `StageAwaitingTaskApproval` hold route to the
   inline task approval transition.
-- `approve`/`deny` on any other hold route to regular tool release.
+- Normalized `approve`/`deny` on any other hold route to regular tool release.
 - `task` routes to the inline task-definition transition for the
   targeted hold.
 
@@ -70,8 +70,8 @@ Effects:
 `RewriteInlineTaskApprovalReply`
 
 ```text
-StageAwaitingTaskApproval + approve -> resolveInlineTaskApproval(success or failure)
-StageAwaitingTaskApproval + deny    -> resolveInlineTaskApproval(denied)
+StageAwaitingTaskApproval + yes -> resolveInlineTaskApproval(success or failure)
+StageAwaitingTaskApproval + no  -> resolveInlineTaskApproval(denied)
 ```
 
 Effects:
@@ -86,8 +86,8 @@ Effects:
 `TryReleasePendingApproval`
 
 ```text
-StageTool + approve -> release tool
-StageTool + deny    -> deny tool
+StageTool + yes -> release tool
+StageTool + no  -> deny tool
 ```
 
 Effects:

--- a/internal/runtime/llmproxy/pending_approval_cache.go
+++ b/internal/runtime/llmproxy/pending_approval_cache.go
@@ -31,7 +31,7 @@ import (
 type PendingApprovalStage string
 
 const (
-	// StageTool — the original tool_use hold awaiting approve/deny/task.
+	// StageTool — the original tool_use hold awaiting yes/no/task.
 	StageTool PendingApprovalStage = ""
 	// StageAwaitingTaskDefinition — user typed "task". The same hold's
 	// ToolUse field still points at the ORIGINAL tool. We're waiting for
@@ -41,7 +41,7 @@ const (
 	// StageAwaitingTaskApproval — model has emitted the task definition.
 	// The hold's ToolUse is the task-creation POST itself; AwaitingTaskFor
 	// links back to the original tool hold. We're waiting for the user
-	// to approve/deny.
+	// to yes/no.
 	StageAwaitingTaskApproval PendingApprovalStage = "awaiting_task_approval"
 )
 

--- a/internal/runtime/llmproxy/postprocess.go
+++ b/internal/runtime/llmproxy/postprocess.go
@@ -230,8 +230,8 @@ func Postprocess(req *http.Request, body []byte, contentType string, cfg Postpro
 			// through the inline approval path instead of letting it
 			// proxy through to the dashboard. The model never sees the
 			// real /control/tasks handler — its tool_use_result is
-			// replaced with a rendered approve/deny prompt; the user's
-			// next "approve" creates the task pre-approved and the
+			// replaced with a rendered yes/no prompt; the user's next
+			// "yes" creates the task pre-approved and the
 			// follow-up turn auto-releases the original tool call.
 			if inlineVerdict, inlineHandled := maybeInterceptInlineTaskDefinition(
 				req, cfg, audit, trace, rewriter.Name(), tu, call,
@@ -704,7 +704,7 @@ func approvalPrompt(tu conversation.ToolUse, reason string) string {
 		b.WriteString("\nInput: ")
 		b.WriteString(preview)
 	}
-	b.WriteString("\n\nReply `approve` to run this tool call, `deny` to block it, or `task` to instruct the agent to include this in a task definition for approval.")
+	b.WriteString("\n\nReply `(y)es` to run this tool call, `(n)o` to block it, or `task` to instruct the agent to include this in a task definition for approval.")
 	return b.String()
 }
 
@@ -728,7 +728,7 @@ func taskCreationPrompt(tu conversation.ToolUse) string {
 	}
 	// The user just typed "task" at the inline prompt — they are
 	// definitionally at the chat surface. Pass ?surface=inline so the
-	// proxy holds the approve/deny gesture inline rather than routing
+	// proxy holds the yes/no gesture inline rather than routing
 	// to the dashboard's notification queue.
 	//
 	// Use the single-curl `--data @- <<JSON` shape. The proxy DOES

--- a/internal/runtime/llmproxy/postprocess_test.go
+++ b/internal/runtime/llmproxy/postprocess_test.go
@@ -484,7 +484,7 @@ func TestPostprocess_SourceTriggerMissRequiresApprovalWhenScopeMissing(t *testin
 		t.Fatalf("missing task/rule scope should rewrite to an approval prompt")
 	}
 	text := anthropicResponseText(t, got.Body)
-	if !strings.Contains(text, "Reply `approve`") ||
+	if !strings.Contains(text, "Reply `(y)es`") ||
 		!strings.Contains(text, "`task`") ||
 		!strings.Contains(text, "no matching task scope") {
 		t.Fatalf("approval prompt missing expected text: %s", got.Body)
@@ -539,7 +539,7 @@ func TestPostprocess_ToolTaskIntentRefusalRequiresApproval(t *testing.T) {
 		t.Fatalf("intent refusal should rewrite to an approval prompt")
 	}
 	text := anthropicResponseText(t, got.Body)
-	if !strings.Contains(text, "Reply `approve`") ||
+	if !strings.Contains(text, "Reply `(y)es`") ||
 		!strings.Contains(text, "/tmp/goodbye.py") ||
 		!strings.Contains(text, "do not match the task purpose") {
 		t.Fatalf("intent refusal prompt missing expected text: %s", got.Body)
@@ -576,7 +576,7 @@ func TestApprovalPromptMentionsTaskReply(t *testing.T) {
 	}, "no matching task scope")
 
 	for _, want := range []string{
-		"Reply `approve`",
+		"Reply `(y)es`",
 		"`task`",
 		"task definition for approval",
 	} {

--- a/internal/runtime/llmproxy/release_test.go
+++ b/internal/runtime/llmproxy/release_test.go
@@ -59,6 +59,26 @@ func TestTryReleasePendingApprovalParsesLongExplicitID(t *testing.T) {
 	if verb != "deny" || id != "cv-abcdef123456" {
 		t.Fatalf("short approval ID compatibility broke: verb=%q id=%q", verb, id)
 	}
+	verb, id = conversation.ParseApprovalReplyText("yes cv-abcdefghijklmnopqrstuvwxyz")
+	if verb != "approve" || id != "cv-abcdefghijklmnopqrstuvwxyz" {
+		t.Fatalf("yes approval ID did not normalize: verb=%q id=%q", verb, id)
+	}
+	verb, id = conversation.ParseApprovalReplyText("Y")
+	if verb != "approve" || id != "" {
+		t.Fatalf("uppercase bare yes shorthand did not normalize: verb=%q id=%q", verb, id)
+	}
+	verb, id = conversation.ParseApprovalReplyText("No cv-abcdef123456")
+	if verb != "deny" || id != "cv-abcdef123456" {
+		t.Fatalf("capitalized explicit no did not normalize: verb=%q id=%q", verb, id)
+	}
+	verb, id = conversation.ParseApprovalReplyText("n")
+	if verb != "deny" || id != "" {
+		t.Fatalf("bare no shorthand did not normalize: verb=%q id=%q", verb, id)
+	}
+	verb, id = conversation.ParseApprovalReplyText("I see no cv-abcdef123456 in the message")
+	if verb != "" || id != "" {
+		t.Fatalf("prose containing no + approval ID must not parse: verb=%q id=%q", verb, id)
+	}
 	verb, id = conversation.ParseApprovalReplyText("task")
 	if verb != "task" || id != "" {
 		t.Fatalf("bare task did not parse: verb=%q id=%q", verb, id)


### PR DESCRIPTION
Updates lite-proxy approval prompts to ask users for y/yes or n/no while preserving task as the task-definition reply. Normalizes yes/no approval replies to the existing approve/deny verbs used by release and inline task routing, with parser coverage for shorthand, explicit IDs, and prose false positives. Refreshes related handler, llmproxy, and docs expectations. Tests: go test -count=1 ./internal/runtime/conversation ./internal/runtime/llmproxy ./internal/api/handlers