### PR TITLE
Trace proxy-lite secret adjudication

### DIFF
--- a/internal/api/handlers/llm_endpoint.go
+++ b/internal/api/handlers/llm_endpoint.go
@@ -1639,6 +1639,7 @@ func (h *LLMEndpointHandler) applyRememberedSecretRewrites(ctx context.Context, 
 	}
 	h.emitLiteSecretPipelineTrace(requestID, agent, "rewrite_scan_done", map[string]any{
 		"provider":        string(provider),
+		"adjudications":   liteSecretAdjudicationTraceSummaries(scan.Adjudications),
 		"active_rules":    len(rewrites),
 		"findings":        liteSecretFindingTraceSummaries(scan.Findings),
 		"findings_count":  len(scan.Findings),
@@ -1799,14 +1800,16 @@ func (h *LLMEndpointHandler) maybeHoldInboundSecret(w http.ResponseWriter, r *ht
 	}
 	if !found {
 		h.emitLiteSecretPipelineTrace(requestID, agent, "hold_scan_no_findings", map[string]any{
-			"provider": string(provider),
-			"body_sha": liteSecretBodySHA(body),
+			"provider":      string(provider),
+			"adjudications": liteSecretAdjudicationTraceSummaries(scan.Adjudications),
+			"body_sha":      liteSecretBodySHA(body),
 		})
 		return false
 	}
 	scan.Findings = h.annotateExistingVaultSecrets(r.Context(), agent.UserID, scan.Findings)
 	h.emitLiteSecretPipelineTrace(requestID, agent, "hold_scan_findings", map[string]any{
 		"provider":          string(provider),
+		"adjudications":     liteSecretAdjudicationTraceSummaries(scan.Adjudications),
 		"findings_count":    len(scan.Findings),
 		"findings":          liteSecretFindingTraceSummaries(scan.Findings),
 		"body_sha_before":   liteSecretBodySHA(body),
@@ -1841,6 +1844,7 @@ func (h *LLMEndpointHandler) maybeHoldInboundSecret(w http.ResponseWriter, r *ht
 	}
 	h.emitLiteSecretPipelineTrace(requestID, agent, "hold_created", map[string]any{
 		"provider":          string(provider),
+		"adjudications":     liteSecretAdjudicationTraceSummaries(scan.Adjudications),
 		"decision_id":       held.ID,
 		"findings_count":    len(scan.Findings),
 		"findings":          liteSecretFindingTraceSummaries(scan.Findings),
@@ -2022,6 +2026,43 @@ func liteSecretFindingTraceSummaries(findings []llmproxy.InboundSecretFinding) [
 	return out
 }
 
+func liteSecretAdjudicationTraceSummaries(adjudications []llmproxy.InboundSecretAdjudication) []map[string]any {
+	out := make([]map[string]any, 0, len(adjudications))
+	for _, adjudication := range adjudications {
+		summary := map[string]any{
+			"fingerprint_prefix": liteSecretFingerprintPrefix(adjudication.Fingerprint),
+			"outcome":            adjudication.Outcome,
+		}
+		if adjudication.FieldName != "" {
+			summary["field_name"] = adjudication.FieldName
+		}
+		if adjudication.Charset != "" {
+			summary["charset"] = adjudication.Charset
+		}
+		if adjudication.Entropy > 0 {
+			summary["entropy"] = adjudication.Entropy
+		}
+		if adjudication.DurationMS > 0 {
+			summary["duration_ms"] = adjudication.DurationMS
+		}
+		if adjudication.Outcome == "verdict" {
+			summary["credential"] = adjudication.Credential
+			summary["confidence"] = adjudication.Confidence
+			if adjudication.Service != "" {
+				summary["service"] = adjudication.Service
+			}
+		}
+		if adjudication.ErrorKind != "" {
+			summary["error_kind"] = adjudication.ErrorKind
+		}
+		if adjudication.ErrorMessage != "" {
+			summary["error_message"] = truncateLiteSecretTraceString(adjudication.ErrorMessage, 500)
+		}
+		out = append(out, summary)
+	}
+	return out
+}
+
 func liteSecretFindingTraceSummary(finding llmproxy.InboundSecretFinding) map[string]any {
 	out := map[string]any{
 		"fingerprint_prefix": liteSecretFingerprintPrefix(finding.Fingerprint),
@@ -2036,6 +2077,16 @@ func liteSecretFindingTraceSummary(finding llmproxy.InboundSecretFinding) map[st
 		out["entropy"] = finding.Entropy
 	}
 	return out
+}
+
+func truncateLiteSecretTraceString(value string, max int) string {
+	if max <= 0 || len(value) <= max {
+		return value
+	}
+	if max <= 3 {
+		return value[:max]
+	}
+	return value[:max-3] + "..."
 }
 
 func liteSecretFindingFingerprintPrefixes(findings []llmproxy.InboundSecretFinding) []string {

--- a/internal/runtime/llmproxy/secret_detection.go
+++ b/internal/runtime/llmproxy/secret_detection.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base32"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"math"
 	"regexp"
 	"sort"
@@ -29,8 +30,23 @@ type InboundSecretFinding struct {
 }
 
 type InboundSecretScanResult struct {
-	Findings     []InboundSecretFinding `json:"findings"`
-	RedactedBody []byte                 `json:"-"`
+	Findings      []InboundSecretFinding      `json:"findings"`
+	Adjudications []InboundSecretAdjudication `json:"adjudications,omitempty"`
+	RedactedBody  []byte                      `json:"-"`
+}
+
+type InboundSecretAdjudication struct {
+	Fingerprint  string  `json:"fingerprint"`
+	FieldName    string  `json:"field_name,omitempty"`
+	Charset      string  `json:"charset,omitempty"`
+	Entropy      float64 `json:"entropy,omitempty"`
+	Outcome      string  `json:"outcome"`
+	Credential   bool    `json:"credential,omitempty"`
+	Service      string  `json:"service,omitempty"`
+	Confidence   float64 `json:"confidence,omitempty"`
+	ErrorKind    string  `json:"error_kind,omitempty"`
+	ErrorMessage string  `json:"error_message,omitempty"`
+	DurationMS   int64   `json:"duration_ms,omitempty"`
 }
 
 type InboundSecretScanOptions struct {
@@ -248,9 +264,10 @@ func ScanInboundSecretsWithOptions(ctx context.Context, opts InboundSecretScanOp
 		return InboundSecretScanResult{}, false, err
 	}
 	findings := map[string]InboundSecretFinding{}
-	rewritten, changed := scanInboundSecretValue(ctx, payload, "", true, false, false, opts, findings)
+	var adjudications []InboundSecretAdjudication
+	rewritten, changed := scanInboundSecretValue(ctx, payload, "", true, false, false, opts, findings, &adjudications)
 	if len(findings) == 0 {
-		return InboundSecretScanResult{}, false, nil
+		return InboundSecretScanResult{Adjudications: adjudications}, false, nil
 	}
 	encoded := body
 	if changed {
@@ -265,13 +282,13 @@ func ScanInboundSecretsWithOptions(ctx context.Context, opts InboundSecretScanOp
 		list = append(list, finding)
 	}
 	sort.Slice(list, func(i, j int) bool { return list[i].Fingerprint < list[j].Fingerprint })
-	return InboundSecretScanResult{Findings: list, RedactedBody: encoded}, true, nil
+	return InboundSecretScanResult{Findings: list, Adjudications: adjudications, RedactedBody: encoded}, true, nil
 }
 
-func scanInboundSecretValue(ctx context.Context, value any, fieldName string, topLevel bool, skipHeuristic bool, inToolResult bool, opts InboundSecretScanOptions, findings map[string]InboundSecretFinding) (any, bool) {
+func scanInboundSecretValue(ctx context.Context, value any, fieldName string, topLevel bool, skipHeuristic bool, inToolResult bool, opts InboundSecretScanOptions, findings map[string]InboundSecretFinding, adjudications *[]InboundSecretAdjudication) (any, bool) {
 	switch typed := value.(type) {
 	case string:
-		return scanInboundSecretString(ctx, typed, fieldName, skipHeuristic, inToolResult, opts, findings)
+		return scanInboundSecretString(ctx, typed, fieldName, skipHeuristic, inToolResult, opts, findings, adjudications)
 	case map[string]any:
 		if strings.EqualFold(stringFromMap(typed, "type"), "thinking") {
 			return value, false
@@ -280,7 +297,7 @@ func scanInboundSecretValue(ctx context.Context, value any, fieldName string, to
 		changed := false
 		for key, item := range typed {
 			childSkipHeuristic := skipHeuristic || (topLevel && runtimeautovault.NoiseSubtreeKey(key))
-			next, nextChanged := scanInboundSecretValue(ctx, item, key, false, childSkipHeuristic, childInToolResult, opts, findings)
+			next, nextChanged := scanInboundSecretValue(ctx, item, key, false, childSkipHeuristic, childInToolResult, opts, findings, adjudications)
 			if nextChanged {
 				typed[key] = next
 				changed = true
@@ -290,7 +307,7 @@ func scanInboundSecretValue(ctx context.Context, value any, fieldName string, to
 	case []any:
 		changed := false
 		for i, item := range typed {
-			next, nextChanged := scanInboundSecretValue(ctx, item, fieldName, false, skipHeuristic, inToolResult, opts, findings)
+			next, nextChanged := scanInboundSecretValue(ctx, item, fieldName, false, skipHeuristic, inToolResult, opts, findings, adjudications)
 			if nextChanged {
 				typed[i] = next
 				changed = true
@@ -310,7 +327,7 @@ func isToolResultSecretScanSubtree(value map[string]any) bool {
 	return strings.EqualFold(stringFromMap(value, "role"), "tool")
 }
 
-func scanInboundSecretString(ctx context.Context, value, fieldName string, skipHeuristic bool, inToolResult bool, opts InboundSecretScanOptions, findings map[string]InboundSecretFinding) (string, bool) {
+func scanInboundSecretString(ctx context.Context, value, fieldName string, skipHeuristic bool, inToolResult bool, opts InboundSecretScanOptions, findings map[string]InboundSecretFinding, adjudications *[]InboundSecretAdjudication) (string, bool) {
 	if strings.TrimSpace(value) == "" || runtimeautovault.ProtectedStringField(fieldName) {
 		return value, false
 	}
@@ -360,8 +377,10 @@ func scanInboundSecretString(ctx context.Context, value, fieldName string, skipH
 		case runtimeautovault.HighContextSecretField(fieldName), !inToolResult && runtimeautovault.SecretContextHint(value, candidate.Value):
 			value = strings.ReplaceAll(value, candidate.Value, redactFoundSecret(candidate.Value, runtimeautovault.GuessService(fieldName, value), "heuristic_swap", candidate.Entropy, opts.Suppressed, findings))
 		default:
-			verdict, ok, adjudicatorErr := adjudicateInboundSecret(ctx, opts, fieldName, value, candidate)
+			result, ok, adjudicatorErr := adjudicateInboundSecret(ctx, opts, fieldName, value, candidate)
+			recordInboundSecretAdjudication(adjudications, fieldName, candidate, result, ok, adjudicatorErr)
 			if ok {
+				verdict := result.Verdict
 				if !verdict.Credential || verdict.Confidence < 0.6 {
 					continue
 				}
@@ -372,7 +391,7 @@ func scanInboundSecretString(ctx context.Context, value, fieldName string, skipH
 				value = strings.ReplaceAll(value, candidate.Value, redactFoundSecret(candidate.Value, service, "heuristic_adjudicated", candidate.Entropy, opts.Suppressed, findings))
 				continue
 			}
-			if !adjudicatorErr {
+			if adjudicatorErr == nil {
 				continue
 			}
 			value = strings.ReplaceAll(value, candidate.Value, redactFoundSecret(candidate.Value, runtimeautovault.GuessService(fieldName, value), "heuristic_observe", candidate.Entropy, opts.Suppressed, findings))
@@ -479,9 +498,9 @@ func stripSecretRedactionMarkers(value string) string {
 	return secretRedactionMarkerRE.ReplaceAllString(value, "")
 }
 
-func adjudicateInboundSecret(ctx context.Context, opts InboundSecretScanOptions, fieldName, content string, candidate runtimeautovault.Candidate) (runtimeautovault.SecretAdjudicationVerdict, bool, bool) {
+func adjudicateInboundSecret(ctx context.Context, opts InboundSecretScanOptions, fieldName, content string, candidate runtimeautovault.Candidate) (runtimeautovault.SecretAdjudicationResult, bool, error) {
 	if opts.Adjudicator == nil {
-		return runtimeautovault.SecretAdjudicationVerdict{}, false, false
+		return runtimeautovault.SecretAdjudicationResult{}, false, nil
 	}
 	host := opts.Host
 	if host == "" {
@@ -494,9 +513,67 @@ func adjudicateInboundSecret(ctx context.Context, opts InboundSecretScanOptions,
 		Candidate: candidate,
 	})
 	if err != nil {
-		return runtimeautovault.SecretAdjudicationVerdict{}, false, true
+		return result, false, err
 	}
-	return result.Verdict, true, false
+	return result, true, nil
+}
+
+func recordInboundSecretAdjudication(adjudications *[]InboundSecretAdjudication, fieldName string, candidate runtimeautovault.Candidate, result runtimeautovault.SecretAdjudicationResult, ok bool, err error) {
+	if adjudications == nil {
+		return
+	}
+	trace := InboundSecretAdjudication{
+		Fingerprint: SecretFingerprint(candidate.Value),
+		FieldName:   fieldName,
+		Charset:     candidate.Charset,
+		Entropy:     candidate.Entropy,
+	}
+	if result.Duration > 0 {
+		trace.DurationMS = result.Duration.Milliseconds()
+	}
+	switch {
+	case ok:
+		trace.Outcome = "verdict"
+		trace.Credential = result.Verdict.Credential
+		trace.Service = runtimeautovault.NormalizeSecretService(result.Verdict.Service)
+		trace.Confidence = result.Verdict.Confidence
+	case err != nil:
+		trace.Outcome = "error"
+		trace.ErrorKind = inboundSecretAdjudicationErrorKind(err)
+		trace.ErrorMessage = err.Error()
+	default:
+		trace.Outcome = "not_configured"
+	}
+	*adjudications = append(*adjudications, trace)
+}
+
+func inboundSecretAdjudicationErrorKind(err error) string {
+	if err == nil {
+		return ""
+	}
+	switch {
+	case errors.Is(err, runtimeautovault.ErrSecretAdjudicatorDisabled):
+		return "disabled"
+	case errors.Is(err, context.DeadlineExceeded):
+		return "timeout"
+	case errors.Is(err, context.Canceled):
+		return "canceled"
+	}
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "timeout") || strings.Contains(msg, "deadline exceeded"):
+		return "timeout"
+	case strings.Contains(msg, "gemini auth") || strings.Contains(msg, "oauth2") || strings.Contains(msg, "credentials"):
+		return "auth"
+	case strings.Contains(msg, "status "):
+		return "upstream_status"
+	case strings.Contains(msg, "no json object") || strings.Contains(msg, "invalid character") || strings.Contains(msg, "unmarshal"):
+		return "parse"
+	case strings.Contains(msg, "decode gemini response") || strings.Contains(msg, "no candidates") || strings.Contains(msg, "no text part"):
+		return "response_decode"
+	default:
+		return "error"
+	}
 }
 
 func redactFoundSecret(raw, service, source string, entropy float64, suppressed map[string]struct{}, findings map[string]InboundSecretFinding) string {

--- a/internal/runtime/llmproxy/secret_detection_test.go
+++ b/internal/runtime/llmproxy/secret_detection_test.go
@@ -349,6 +349,12 @@ func TestScanInboundSecrets_AdjudicatorControlsAmbiguousCandidates(t *testing.T)
 			if found != tc.want {
 				t.Fatalf("found=%v, want %v, findings=%+v", found, tc.want, scan.Findings)
 			}
+			if len(scan.Adjudications) != 1 || scan.Adjudications[0].Outcome != "verdict" {
+				t.Fatalf("expected adjudicator verdict trace, got %+v", scan.Adjudications)
+			}
+			if scan.Adjudications[0].Credential != tc.verdict.Credential || scan.Adjudications[0].Confidence != tc.verdict.Confidence {
+				t.Fatalf("unexpected adjudicator trace: %+v", scan.Adjudications[0])
+			}
 			if found {
 				if len(scan.Findings) != 1 || scan.Findings[0].Source != "heuristic_adjudicated" || scan.Findings[0].Service != "custom_service" {
 					t.Fatalf("unexpected adjudicated finding: %+v", scan.Findings)
@@ -400,6 +406,35 @@ func TestScanInboundSecrets_AdjudicatorErrorFallsBackToHeuristic(t *testing.T) {
 	}
 	if scan.Findings[0].Source != "heuristic_observe" {
 		t.Fatalf("unexpected fallback finding: %+v", scan.Findings[0])
+	}
+	if len(scan.Adjudications) != 1 {
+		t.Fatalf("expected adjudicator error trace, got %+v", scan.Adjudications)
+	}
+	trace := scan.Adjudications[0]
+	if trace.Outcome != "error" || trace.ErrorKind != "error" || trace.ErrorMessage != "verification unavailable" {
+		t.Fatalf("unexpected adjudicator error trace: %+v", trace)
+	}
+	if trace.Fingerprint != scan.Findings[0].Fingerprint || trace.FieldName != "text" {
+		t.Fatalf("adjudicator trace should identify the same candidate without exposing it: trace=%+v finding=%+v", trace, scan.Findings[0])
+	}
+}
+
+func TestInboundSecretAdjudicationErrorKind(t *testing.T) {
+	cases := []struct {
+		err  error
+		want string
+	}{
+		{err: runtimeautovault.ErrSecretAdjudicatorDisabled, want: "disabled"},
+		{err: context.DeadlineExceeded, want: "timeout"},
+		{err: errors.New("llm: gemini auth: missing credentials"), want: "auth"},
+		{err: errors.New("llm: gemini model status 429: rate limited"), want: "upstream_status"},
+		{err: errors.New("no JSON object found in adjudicator response"), want: "parse"},
+		{err: errors.New("llm: no candidates in gemini response"), want: "response_decode"},
+	}
+	for _, tc := range cases {
+		if got := inboundSecretAdjudicationErrorKind(tc.err); got != tc.want {
+			t.Fatalf("inboundSecretAdjudicationErrorKind(%v) = %q, want %q", tc.err, got, tc.want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- record redacted adjudicator attempts in inbound secret scan results
- emit adjudication summaries in proxy-lite secret_pipeline trace events, including verdicts, durations, and classified errors
- add tests for verdict traces, error fallback traces, and error kind classification

## Verification
- go test ./internal/runtime/llmproxy -run 'TestScanInboundSecrets_Adjudicator|TestScanInboundSecrets_NoAdjudicator|TestInboundSecretAdjudicationErrorKind'\n- go test ./internal/api/handlers -run 'TestLLMEndpoint_.*Secret|Test.*Secret'\n- go test ./...\n- git diff --check