### PR TITLE
Fix Gemini secret adjudicator configuration

### DIFF
--- a/internal/runtime/autovault/adjudicator.go
+++ b/internal/runtime/autovault/adjudicator.go
@@ -85,7 +85,13 @@ func (a *LLMSecretAdjudicator) AdjudicateSecret(ctx context.Context, req SecretA
 }
 
 func SecretAdjudicatorConfigured(cfg config.VerificationConfig) bool {
-	return cfg.Enabled && cfg.Endpoint != "" && cfg.Model != ""
+	if !cfg.Enabled || cfg.Model == "" {
+		return false
+	}
+	if cfg.Endpoint != "" {
+		return true
+	}
+	return cfg.Provider == "gemini" && cfg.Project != ""
 }
 
 func SecretAdjudicationTimeout(cfg config.VerificationConfig) time.Duration {

--- a/internal/runtime/autovault/adjudicator_test.go
+++ b/internal/runtime/autovault/adjudicator_test.go
@@ -3,6 +3,8 @@ package autovault
 import (
 	"strings"
 	"testing"
+
+	"github.com/clawvisor/clawvisor/pkg/config"
 )
 
 func TestBuildSecretAdjudicatorPromptRedactsPeerCandidates(t *testing.T) {
@@ -21,5 +23,80 @@ func TestBuildSecretAdjudicatorPromptRedactsPeerCandidates(t *testing.T) {
 	}
 	if strings.Contains(prompt, peer) {
 		t.Fatalf("peer candidate should also be redacted before adjudication:\n%s", prompt)
+	}
+}
+
+func TestSecretAdjudicatorConfigured(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  config.VerificationConfig
+		want bool
+	}{
+		{
+			name: "disabled",
+			cfg: config.VerificationConfig{
+				LLMProviderConfig: config.LLMProviderConfig{
+					Provider: "openai",
+					Endpoint: "https://api.openai.com/v1",
+					Model:    "gpt-test",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "endpoint provider",
+			cfg: config.VerificationConfig{
+				LLMProviderConfig: config.LLMProviderConfig{
+					Enabled:  true,
+					Provider: "openai",
+					Endpoint: "https://api.openai.com/v1",
+					Model:    "gpt-test",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "gemini project region endpoint built by client",
+			cfg: config.VerificationConfig{
+				LLMProviderConfig: config.LLMProviderConfig{
+					Enabled:  true,
+					Provider: "gemini",
+					Project:  "clawvisor-staging",
+					Region:   "global",
+					Model:    "gemini-3.1-flash-lite-preview",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "gemini requires project when endpoint omitted",
+			cfg: config.VerificationConfig{
+				LLMProviderConfig: config.LLMProviderConfig{
+					Enabled:  true,
+					Provider: "gemini",
+					Model:    "gemini-3.1-flash-lite-preview",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "non gemini requires endpoint",
+			cfg: config.VerificationConfig{
+				LLMProviderConfig: config.LLMProviderConfig{
+					Enabled:  true,
+					Provider: "openai",
+					Model:    "gpt-test",
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SecretAdjudicatorConfigured(tt.cfg); got != tt.want {
+				t.Fatalf("SecretAdjudicatorConfigured() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- Treat Gemini verification configs with project/model and no explicit endpoint as configured for secret adjudication
- Preserve endpoint-required behavior for non-Gemini providers
- Add focused coverage for configured/disabled adjudicator config shapes

## Tests
- go test ./internal/runtime/autovault ./internal/runtime/llmproxy ./internal/api/handlers