### PR TITLE
Use yes/no for lite proxy approvals

### DIFF
--- a/docs/LITE_PROXY.md
+++ b/docs/LITE_PROXY.md
@@ -221,7 +221,7 @@ Tool: Bash
 Reason: no matching task scope
 Input: mkdir -p /tmp/landing
 
-Reply (y)es to run this tool call, (n)o to block it,
+Reply yes or y to run this tool call, no or n to block it,
 or task to instruct the agent to include this in a task definition for approval.
 ```
 

--- a/internal/api/handlers/llm_endpoint_test.go
+++ b/internal/api/handlers/llm_endpoint_test.go
@@ -398,7 +398,7 @@ func TestLLMEndpoint_BreakGlassPassthroughSkipsControlAndInspection(t *testing.T
 		t.Fatalf("passthrough should not inject control notice or sanitize request:\n%s", seenBody)
 	}
 	out := rec.Body.String()
-	if strings.Contains(out, "Reply `(y)es`") {
+	if strings.Contains(out, "Reply `yes` or `y`") {
 		t.Fatalf("passthrough should not inspect/block tool use: %s", out)
 	}
 	if !strings.Contains(out, "mkdir /tmp/needs-task") {
@@ -1534,7 +1534,7 @@ func TestLLMEndpoint_InlineApprovalReleasesHeldToolUse(t *testing.T) {
 	if firstRec.Code != http.StatusOK {
 		t.Fatalf("first response status = %d (%s)", firstRec.Code, firstRec.Body.String())
 	}
-	if !strings.Contains(firstRec.Body.String(), "Reply `(y)es`") {
+	if !strings.Contains(firstRec.Body.String(), "Reply `yes` or `y`") {
 		t.Fatalf("first response missing approval prompt: %s", firstRec.Body.String())
 	}
 	if upstreamHits != 1 {
@@ -1648,7 +1648,7 @@ func TestLLMEndpoint_RequiresApprovalForOpenAIToolUseWithoutScope(t *testing.T) 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d (%s)", rec.Code, rec.Body.String())
 	}
-	if !strings.Contains(rec.Body.String(), "Reply `(y)es`") {
+	if !strings.Contains(rec.Body.String(), "Reply `yes` or `y`") {
 		t.Fatalf("expected approval prompt, got %s", rec.Body.String())
 	}
 

--- a/internal/runtime/llmproxy/inline_task_augment_test.go
+++ b/internal/runtime/llmproxy/inline_task_augment_test.go
@@ -26,7 +26,7 @@ func anthropicTextBody(messages ...map[string]string) []byte {
 // promptWithFooter builds an inline-prompt assistant message with the
 // approval-id footer the augmenter parses to look up the outcome.
 func promptWithFooter(approvalID, purposeLine string) string {
-	body := "Clawvisor wants to create a task to cover this work:\n\nPurpose\n  " + purposeLine + "\n\nReply (y)es to authorize, (n)o to cancel."
+	body := "Clawvisor wants to create a task to cover this work:\n\nPurpose\n  " + purposeLine + "\n\nReply yes or y to authorize, no or n to cancel."
 	return body + "\n\n" + InlineApprovalIDMarker + approvalID + "]"
 }
 
@@ -89,7 +89,7 @@ func TestAugment_IdempotentOnSecondPass(t *testing.T) {
 func TestAugment_NoopOnRegularToolApprove(t *testing.T) {
 	body := anthropicTextBody(
 		map[string]string{"role": "user", "content": "Do something"},
-		map[string]string{"role": "assistant", "content": "Clawvisor paused this tool call for approval.\n\nTool: Bash\nInput: ls\n\nReply (y)es to run, (n)o to block, or task to ..."},
+		map[string]string{"role": "assistant", "content": "Clawvisor paused this tool call for approval.\n\nTool: Bash\nInput: ls\n\nReply yes or y to run, no or n to block, or task to ..."},
 		map[string]string{"role": "user", "content": "approve"},
 	)
 	_, ok, err := AugmentApprovedInlineTasksInHistory(body, conversation.ProviderAnthropic, NewMemoryInlineApprovalOutcomeStore(time.Minute), "user-1", "agent-1")

--- a/internal/runtime/llmproxy/inline_task_prompt.go
+++ b/internal/runtime/llmproxy/inline_task_prompt.go
@@ -42,11 +42,11 @@ func renderTaskApprovalPrompt(req *runtimetasks.TaskCreateRequest, approvalID st
 func renderTaskApprovalPromptWithRisk(req *runtimetasks.TaskCreateRequest, approvalID string, risk *taskrisk.RiskAssessment) string {
 	suffix := approvalIDFooter(approvalID)
 	if req == nil {
-		return "Clawvisor wants to create a task.\n\nReply `(y)es` to authorize, `(n)o` to cancel." + suffix
+		return "Clawvisor wants to create a task.\n\nReply `yes` or `y` to authorize, `no` or `n` to cancel." + suffix
 	}
 	purpose := strings.TrimSpace(req.Purpose)
 	if purpose == "" {
-		return "Clawvisor wants to create a task: unnamed.\n\nReply `(y)es` to authorize, `(n)o` to cancel." + suffix
+		return "Clawvisor wants to create a task: unnamed.\n\nReply `yes` or `y` to authorize, `no` or `n` to cancel." + suffix
 	}
 
 	var b strings.Builder
@@ -134,7 +134,7 @@ func renderTaskApprovalPromptWithRisk(req *runtimetasks.TaskCreateRequest, appro
 	}
 
 	b.WriteString("\n\nApproving will create this task and run the original tool call.\n")
-	b.WriteString("Reply `(y)es` to authorize, `(n)o` to cancel.")
+	b.WriteString("Reply `yes` or `y` to authorize, `no` or `n` to cancel.")
 	b.WriteString(suffix)
 	return b.String()
 }

--- a/internal/runtime/llmproxy/inline_task_prompt_test.go
+++ b/internal/runtime/llmproxy/inline_task_prompt_test.go
@@ -40,7 +40,7 @@ func TestRenderTaskApprovalPromptWellFormed(t *testing.T) {
 	if !strings.Contains(prompt, "10 min") {
 		t.Errorf("missing humanized expiry: %q", prompt)
 	}
-	if !strings.Contains(prompt, "(y)es") || !strings.Contains(prompt, "(n)o") {
+	if !strings.Contains(prompt, "`yes` or `y`") || !strings.Contains(prompt, "`no` or `n`") {
 		t.Errorf("missing yes/no instructions: %q", prompt)
 	}
 	if strings.Contains(prompt, "{") {
@@ -85,7 +85,7 @@ func TestRenderTaskApprovalPromptFallbackForEmptyPurpose(t *testing.T) {
 	if !strings.Contains(prompt, "unnamed") {
 		t.Errorf("expected 'unnamed' fallback, got %q", prompt)
 	}
-	if !strings.Contains(prompt, "(y)es") {
+	if !strings.Contains(prompt, "`yes`") {
 		t.Errorf("expected yes instructions in fallback, got %q", prompt)
 	}
 }

--- a/internal/runtime/llmproxy/postprocess.go
+++ b/internal/runtime/llmproxy/postprocess.go
@@ -704,7 +704,7 @@ func approvalPrompt(tu conversation.ToolUse, reason string) string {
 		b.WriteString("\nInput: ")
 		b.WriteString(preview)
 	}
-	b.WriteString("\n\nReply `(y)es` to run this tool call, `(n)o` to block it, or `task` to instruct the agent to include this in a task definition for approval.")
+	b.WriteString("\n\nReply `yes` or `y` to run this tool call, `no` or `n` to block it, or `task` to instruct the agent to include this in a task definition for approval.")
 	return b.String()
 }
 

--- a/internal/runtime/llmproxy/postprocess_test.go
+++ b/internal/runtime/llmproxy/postprocess_test.go
@@ -484,7 +484,7 @@ func TestPostprocess_SourceTriggerMissRequiresApprovalWhenScopeMissing(t *testin
 		t.Fatalf("missing task/rule scope should rewrite to an approval prompt")
 	}
 	text := anthropicResponseText(t, got.Body)
-	if !strings.Contains(text, "Reply `(y)es`") ||
+	if !strings.Contains(text, "Reply `yes` or `y`") ||
 		!strings.Contains(text, "`task`") ||
 		!strings.Contains(text, "no matching task scope") {
 		t.Fatalf("approval prompt missing expected text: %s", got.Body)
@@ -539,7 +539,7 @@ func TestPostprocess_ToolTaskIntentRefusalRequiresApproval(t *testing.T) {
 		t.Fatalf("intent refusal should rewrite to an approval prompt")
 	}
 	text := anthropicResponseText(t, got.Body)
-	if !strings.Contains(text, "Reply `(y)es`") ||
+	if !strings.Contains(text, "Reply `yes` or `y`") ||
 		!strings.Contains(text, "/tmp/goodbye.py") ||
 		!strings.Contains(text, "do not match the task purpose") {
 		t.Fatalf("intent refusal prompt missing expected text: %s", got.Body)
@@ -576,7 +576,7 @@ func TestApprovalPromptMentionsTaskReply(t *testing.T) {
 	}, "no matching task scope")
 
 	for _, want := range []string{
-		"Reply `(y)es`",
+		"Reply `yes` or `y`",
 		"`task`",
 		"task definition for approval",
 	} {


### PR DESCRIPTION
## Summary
- change lite-proxy approval prompts from approve/deny to yes/y and no/n
- normalize yes/no shorthand to the existing approve/deny internal decisions
- require approval commands with IDs to occupy the exact line to avoid prose false positives
- update lite-proxy docs and tests

## Tests
- go test ./internal/runtime/conversation ./internal/runtime/llmproxy ./internal/api/handlers