### PR TITLE
Support Claude Code and Codex passthrough auth

### DIFF
--- a/cmd/clawvisor/cmd_agent_lite.go
+++ b/cmd/clawvisor/cmd_agent_lite.go
@@ -11,8 +11,9 @@ import (
 )
 
 const (
-	liteProxyProviderClaude = "claude"
-	liteProxyProviderCodex  = "codex"
+	liteProxyProviderClaude         = "claude"
+	liteProxyProviderCodex          = "codex"
+	liteProxyClaudeAgentTokenHeader = "X-Clawvisor-Agent-Token"
 )
 
 var liteRunProvider string
@@ -202,7 +203,8 @@ func buildLiteProxyEnv(provider, baseURL, agentToken string) ([]string, error) {
 	case liteProxyProviderClaude:
 		env = append(env,
 			"ANTHROPIC_BASE_URL="+baseURL,
-			"ANTHROPIC_AUTH_TOKEN="+agentToken,
+			"ANTHROPIC_CUSTOM_HEADERS="+liteProxyClaudeAgentTokenHeader+": "+agentToken,
+			"ANTHROPIC_AUTH_TOKEN=",
 			"ANTHROPIC_API_KEY=",
 		)
 	case liteProxyProviderCodex:

--- a/cmd/clawvisor/cmd_agent_lite.go
+++ b/cmd/clawvisor/cmd_agent_lite.go
@@ -210,7 +210,6 @@ func buildLiteProxyEnv(provider, baseURL, agentToken string) ([]string, error) {
 	case liteProxyProviderCodex:
 		env = append(env,
 			"OPENAI_BASE_URL="+liteProxyOpenAIBaseURL(baseURL),
-			"OPENAI_API_KEY="+agentToken,
 		)
 	}
 	return env, nil
@@ -261,7 +260,9 @@ func prepareLiteProxyCommandArgs(opts *liteProxyOptions, commandArgs []string) [
 		"-c", "model_provider=clawvisor",
 		"-c", `model_providers.clawvisor.name="clawvisor"`,
 		"-c", fmt.Sprintf(`model_providers.clawvisor.base_url=%q`, liteProxyOpenAIBaseURL(opts.BaseURL)),
-		"-c", `model_providers.clawvisor.env_key="CLAWVISOR_AGENT_TOKEN"`,
+		"-c", `model_providers.clawvisor.wire_api="responses"`,
+		"-c", `model_providers.clawvisor.requires_openai_auth=true`,
+		"-c", `model_providers.clawvisor.env_http_headers={"X-Clawvisor-Agent-Token"="CLAWVISOR_AGENT_TOKEN"}`,
 	}
 	return append(injected, commandArgs[1:]...)
 }

--- a/cmd/clawvisor/cmd_agent_lite_test.go
+++ b/cmd/clawvisor/cmd_agent_lite_test.go
@@ -61,8 +61,8 @@ func TestBuildLiteProxyEnvCodex(t *testing.T) {
 	if got := values["OPENAI_BASE_URL"]; got != "https://clawvisor.example/v1" {
 		t.Fatalf("OPENAI_BASE_URL = %q", got)
 	}
-	if got := values["OPENAI_API_KEY"]; got != "cvis_token" {
-		t.Fatalf("OPENAI_API_KEY = %q", got)
+	if _, ok := values["OPENAI_API_KEY"]; ok {
+		t.Fatalf("OPENAI_API_KEY should be omitted for codex OpenAI-auth passthrough")
 	}
 	if got, ok := values["ANTHROPIC_BASE_URL"]; ok {
 		t.Fatalf("ANTHROPIC_BASE_URL should be omitted for codex, got %q (present in env)", got)
@@ -160,7 +160,9 @@ func TestPrepareLiteProxyCommandArgsInjectsCodexConfig(t *testing.T) {
 		"-c", "model_provider=clawvisor",
 		"-c", `model_providers.clawvisor.name="clawvisor"`,
 		"-c", `model_providers.clawvisor.base_url="https://clawvisor.example/v1"`,
-		"-c", `model_providers.clawvisor.env_key="CLAWVISOR_AGENT_TOKEN"`,
+		"-c", `model_providers.clawvisor.wire_api="responses"`,
+		"-c", `model_providers.clawvisor.requires_openai_auth=true`,
+		"-c", `model_providers.clawvisor.env_http_headers={"X-Clawvisor-Agent-Token"="CLAWVISOR_AGENT_TOKEN"}`,
 		"exec",
 		"hello",
 	}

--- a/cmd/clawvisor/cmd_agent_lite_test.go
+++ b/cmd/clawvisor/cmd_agent_lite_test.go
@@ -29,7 +29,12 @@ func TestBuildLiteProxyEnvClaude(t *testing.T) {
 	if got := values["ANTHROPIC_BASE_URL"]; got != "https://clawvisor.example" {
 		t.Fatalf("ANTHROPIC_BASE_URL = %q", got)
 	}
-	if got := values["ANTHROPIC_AUTH_TOKEN"]; got != "cvis_token" {
+	if got := values["ANTHROPIC_CUSTOM_HEADERS"]; got != "X-Clawvisor-Agent-Token: cvis_token" {
+		t.Fatalf("ANTHROPIC_CUSTOM_HEADERS = %q", got)
+	}
+	if got, ok := values["ANTHROPIC_AUTH_TOKEN"]; !ok {
+		t.Fatalf("ANTHROPIC_AUTH_TOKEN not present in env; expected explicit empty value to preserve subscription OAuth fallback")
+	} else if got != "" {
 		t.Fatalf("ANTHROPIC_AUTH_TOKEN = %q", got)
 	}
 	// Two-step check: the key must be present in the env (so it explicitly

--- a/internal/api/handlers/llm_endpoint.go
+++ b/internal/api/handlers/llm_endpoint.go
@@ -28,9 +28,9 @@ import (
 
 // LLMEndpointHandler is the lite-proxy LLM termination point. It accepts
 // Anthropic-/OpenAI-shaped requests authenticated by the agent's existing
-// `cvis_…` token (carried in either Authorization or x-api-key), fetches
-// the real upstream API key from the vault under (user_id, "anthropic" |
-// "openai"), and proxies the response back. v1 is pure passthrough —
+// `cvis_…` token (carried in Authorization, x-api-key, or
+// X-Clawvisor-Agent-Token for Claude Code subscription passthrough), fetches
+// or preserves upstream auth, and proxies the response back. v1 is pure passthrough —
 // inspector and rewriter layer in via the response-body wrap path in
 // subsequent files.
 type LLMEndpointHandler struct {
@@ -509,17 +509,27 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 	)
 
 	// Skip the regular release path when the inline rewrite already
-	// consumed its hold. The rewritten user message still starts with
-	// the literal "approve" verb (the rewrite preserves it so the LLM
-	// can see the user's actual reply); without this guard the release
-	// path would re-parse that verb, LIFO-Peek the cache, and resolve
-	// some UNRELATED hold (e.g., a parallel tool-stage approval the
-	// model emitted alongside the inline-task POST in the same turn).
-	// A single user "approve" would then approve two distinct holds.
+	// consumed its hold. Without this guard, a future change that
+	// leaves any parseable approval text in the rewritten body could
+	// let the release path resolve an unrelated hold (e.g., a parallel
+	// tool-stage approval emitted alongside the inline-task POST in
+	// the same turn). A single user "approve" must only resolve one
+	// hold.
 	if !inlineApprovalConsumed {
 		if handled := h.maybeHandleLiteApprovalRelease(w, r, agent, provider, requestID, body, &auditStatus, &auditDecide, &auditOutcome, &auditReason); handled {
 			return
 		}
+	}
+	if stripped, stripErr := llmproxy.StripSyntheticApprovalHistory(llmproxy.SyntheticApprovalHistoryStripRequest{
+		Provider: provider,
+		Body:     body,
+	}); stripErr != nil {
+		h.Logger.WarnContext(r.Context(), "lite-proxy synthetic approval history strip failed",
+			"request_id", requestID, "agent_id", agent.ID, "err", stripErr.Error())
+	} else if stripped.Modified {
+		body = stripped.Body
+		auditParams["synthetic_approval_history_stripped"] = true
+		reqSummary = liteProxyRequestDebugSummary(provider, body)
 	}
 
 	upstreamURL := ""
@@ -2311,7 +2321,16 @@ func agentLogID(a *store.Agent) string {
 func liteProxyAuthMode(r *http.Request) string {
 	hasBearer := strings.TrimSpace(r.Header.Get("Authorization")) != ""
 	hasAPIKey := strings.TrimSpace(r.Header.Get("x-api-key")) != ""
+	hasClawvisorAgentToken := strings.TrimSpace(r.Header.Get(middleware.AgentTokenHeader)) != ""
 	switch {
+	case hasClawvisorAgentToken && hasBearer && hasAPIKey:
+		return "clawvisor-agent-token+authorization+x-api-key"
+	case hasClawvisorAgentToken && hasBearer:
+		return "clawvisor-agent-token+authorization"
+	case hasClawvisorAgentToken && hasAPIKey:
+		return "clawvisor-agent-token+x-api-key"
+	case hasClawvisorAgentToken:
+		return "clawvisor-agent-token"
 	case hasBearer && hasAPIKey:
 		return "authorization+x-api-key"
 	case hasBearer:
@@ -2362,10 +2381,13 @@ func clearMirroredUpstreamHeaders(h http.Header) {
 }
 
 // inboundAgentToken extracts the cvis_… token from the inbound request's
-// Authorization or x-api-key header (the SDK's natural caller-auth slot
-// at the LLM endpoint). Used as a fallback to source the caller token
-// for the rewriter when no dedicated middleware ran.
+// Clawvisor agent header, Authorization, or x-api-key header. Used as a
+// fallback to source the caller token for the rewriter when no dedicated
+// middleware ran.
 func inboundAgentToken(r *http.Request) string {
+	if h := clawvisorAgentTokenHeader(r); strings.HasPrefix(h, "cvis_") {
+		return h
+	}
 	if h := r.Header.Get("Authorization"); strings.HasPrefix(h, "Bearer ") {
 		token := strings.TrimSpace(h[len("Bearer "):])
 		if strings.HasPrefix(token, "cvis_") {
@@ -2376,4 +2398,16 @@ func inboundAgentToken(r *http.Request) string {
 		return h
 	}
 	return ""
+}
+
+func clawvisorAgentTokenHeader(r *http.Request) string {
+	v := strings.TrimSpace(r.Header.Get(middleware.AgentTokenHeader))
+	if v == "" {
+		return ""
+	}
+	const prefix = "Bearer "
+	if strings.HasPrefix(v, prefix) {
+		return strings.TrimSpace(v[len(prefix):])
+	}
+	return v
 }

--- a/internal/api/handlers/llm_endpoint.go
+++ b/internal/api/handlers/llm_endpoint.go
@@ -29,8 +29,8 @@ import (
 // LLMEndpointHandler is the lite-proxy LLM termination point. It accepts
 // Anthropic-/OpenAI-shaped requests authenticated by the agent's existing
 // `cvis_…` token (carried in Authorization, x-api-key, or
-// X-Clawvisor-Agent-Token for Claude Code subscription passthrough), fetches
-// or preserves upstream auth, and proxies the response back. v1 is pure passthrough —
+// X-Clawvisor-Agent-Token for upstream-auth passthrough), fetches or preserves
+// upstream auth, and proxies the response back. v1 is pure passthrough —
 // inspector and rewriter layer in via the response-body wrap path in
 // subsequent files.
 type LLMEndpointHandler struct {

--- a/internal/api/middleware/agent_llm.go
+++ b/internal/api/middleware/agent_llm.go
@@ -17,6 +17,8 @@ import (
 //
 //   - `Authorization: Bearer <token>` — OpenAI SDK convention.
 //   - `x-api-key: <token>` — Anthropic SDK convention.
+//   - `X-Clawvisor-Agent-Token: <token>` — Claude Code passthrough auth,
+//     where Authorization must remain the user's Claude subscription OAuth token.
 //
 // Suitable for the LLM endpoint where the agent token rides on the SDK's
 // natural auth header. For the resolver path, use RequireAgentLLMNonce
@@ -29,12 +31,12 @@ import (
 // `cvis_…` doesn't authenticate against api.anthropic.com or
 // api.openai.com; it only works against this proxy.
 //
-// On success, attaches the resolved agent to the request context. Both
-// header candidates are tried — a client sending Authorization and
-// x-api-key with different values still authenticates when EITHER is a
-// valid agent token. This matters for mixed-header clients that might
-// inherit a bogus Authorization value (e.g., a stale OAuth token from
-// the environment) while the actual agent token rides on x-api-key.
+// On success, attaches the resolved agent to the request context. Header
+// candidates are tried in priority order — a client sending Authorization,
+// x-api-key, and/or X-Clawvisor-Agent-Token with different values still
+// authenticates when any one is a valid agent token. This matters for mixed-
+// header clients that keep upstream OAuth in Authorization while the actual
+// agent token rides in a Clawvisor-only header.
 func RequireAgentLLM(st store.Store) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -46,17 +48,19 @@ func RequireAgentLLM(st store.Store) func(http.Handler) http.Handler {
 			var (
 				agent     *store.Agent
 				validTok  string
+				source    string
 				transient bool
 			)
-			for _, tok := range candidates {
-				if !strings.HasPrefix(tok, "cvis_") {
+			for _, candidate := range candidates {
+				if !strings.HasPrefix(candidate.Token, "cvis_") {
 					continue
 				}
-				hash := auth.HashToken(tok)
+				hash := auth.HashToken(candidate.Token)
 				a, err := st.GetAgentByToken(r.Context(), hash)
 				if err == nil {
 					agent = a
-					validTok = tok
+					validTok = candidate.Token
+					source = candidate.Source
 					break
 				}
 				if !errors.Is(err, store.ErrNotFound) {
@@ -73,6 +77,9 @@ func RequireAgentLLM(st store.Store) func(http.Handler) http.Handler {
 			}
 			ctx := store.WithAgent(r.Context(), agent)
 			ctx = withCallerToken(ctx, validTok)
+			if source == agentLLMTokenSourceClawvisorHeader {
+				ctx = llmproxy.WithPassthroughUpstreamAuth(ctx)
+			}
 			AddLogField(ctx, "agent_id", agent.ID)
 			AddLogField(ctx, "user_id", agent.UserID)
 			next.ServeHTTP(w, r.WithContext(ctx))
@@ -164,21 +171,55 @@ func RequireAgentLLMNonce(st store.Store, cache llmproxy.CallerNonceCache, logge
 // agentLLMTokenCandidates returns every header value that could be the
 // agent token, in priority order. Callers iterate and accept the first
 // one that authenticates. Returning a slice (rather than a single
-// "best" value) means a client sending both headers with different
+// "best" value) means a client sending multiple headers with different
 // values still authenticates if at least one is valid.
-func agentLLMTokenCandidates(r *http.Request) []string {
-	var out []string
+const (
+	AgentTokenHeader                   = "X-Clawvisor-Agent-Token"
+	agentLLMTokenSourceAuthorization   = "authorization"
+	agentLLMTokenSourceXAPIKey         = "x-api-key"
+	agentLLMTokenSourceClawvisorHeader = "x-clawvisor-agent-token"
+)
+
+type agentLLMTokenCandidate struct {
+	Token  string
+	Source string
+}
+
+func agentLLMTokenCandidates(r *http.Request) []agentLLMTokenCandidate {
+	var out []agentLLMTokenCandidate
+	if t := clawvisorAgentTokenHeader(r); t != "" {
+		out = append(out, agentLLMTokenCandidate{Token: t, Source: agentLLMTokenSourceClawvisorHeader})
+	}
 	if t := bearerToken(r); t != "" {
-		out = append(out, t)
+		out = appendAgentLLMTokenCandidate(out, t, agentLLMTokenSourceAuthorization)
 	}
 	if t := strings.TrimSpace(r.Header.Get("x-api-key")); t != "" {
-		// De-dupe: if Authorization happened to carry the same value,
-		// don't re-attempt.
-		if len(out) == 0 || out[0] != t {
-			out = append(out, t)
-		}
+		out = appendAgentLLMTokenCandidate(out, t, agentLLMTokenSourceXAPIKey)
 	}
 	return out
+}
+
+func appendAgentLLMTokenCandidate(out []agentLLMTokenCandidate, token, source string) []agentLLMTokenCandidate {
+	for _, existing := range out {
+		if existing.Token == token {
+			return out
+		}
+	}
+	return append(out, agentLLMTokenCandidate{Token: token, Source: source})
+}
+
+// clawvisorAgentTokenHeader extracts out-of-band agent auth for Claude Code
+// passthrough mode. Accepts either bare `cvis_...` or `Bearer cvis_...`.
+func clawvisorAgentTokenHeader(r *http.Request) string {
+	v := strings.TrimSpace(r.Header.Get(AgentTokenHeader))
+	if v == "" {
+		return ""
+	}
+	const prefix = "Bearer "
+	if strings.HasPrefix(v, prefix) {
+		return strings.TrimSpace(v[len(prefix):])
+	}
+	return v
 }
 
 // callerHeaderBearer extracts the agent token from `X-Clawvisor-Caller`.

--- a/internal/api/middleware/agent_llm.go
+++ b/internal/api/middleware/agent_llm.go
@@ -17,8 +17,8 @@ import (
 //
 //   - `Authorization: Bearer <token>` — OpenAI SDK convention.
 //   - `x-api-key: <token>` — Anthropic SDK convention.
-//   - `X-Clawvisor-Agent-Token: <token>` — Claude Code passthrough auth,
-//     where Authorization must remain the user's Claude subscription OAuth token.
+//   - `X-Clawvisor-Agent-Token: <token>` — passthrough auth for clients where
+//     Authorization must remain the user's upstream subscription/OAuth token.
 //
 // Suitable for the LLM endpoint where the agent token rides on the SDK's
 // natural auth header. For the resolver path, use RequireAgentLLMNonce
@@ -208,7 +208,7 @@ func appendAgentLLMTokenCandidate(out []agentLLMTokenCandidate, token, source st
 	return append(out, agentLLMTokenCandidate{Token: token, Source: source})
 }
 
-// clawvisorAgentTokenHeader extracts out-of-band agent auth for Claude Code
+// clawvisorAgentTokenHeader extracts out-of-band agent auth for upstream
 // passthrough mode. Accepts either bare `cvis_...` or `Bearer cvis_...`.
 func clawvisorAgentTokenHeader(r *http.Request) string {
 	v := strings.TrimSpace(r.Header.Get(AgentTokenHeader))

--- a/internal/api/middleware/agent_llm_test.go
+++ b/internal/api/middleware/agent_llm_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/clawvisor/clawvisor/internal/auth"
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy"
 	"github.com/clawvisor/clawvisor/pkg/store"
 	"github.com/clawvisor/clawvisor/pkg/store/sqlite"
 )
@@ -79,6 +80,34 @@ func TestRequireAgentLLM_AcceptsXAPIKey(t *testing.T) {
 	}
 	if seenAgent == nil || seenAgent.ID != agent.ID {
 		t.Fatalf("expected agent in context")
+	}
+}
+
+func TestRequireAgentLLM_AcceptsClawvisorAgentTokenHeaderForPassthrough(t *testing.T) {
+	st, agent, raw := newSeededAgent(t)
+
+	var seenAgent *store.Agent
+	var passthrough bool
+	handler := RequireAgentLLM(st)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenAgent = AgentFromContext(r.Context())
+		passthrough = llmproxy.PassthroughUpstreamAuth(r.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	req.Header.Set(AgentTokenHeader, raw)
+	req.Header.Set("Authorization", "Bearer claude-oauth-token")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 with %s auth, got %d (%s)", AgentTokenHeader, rec.Code, rec.Body.String())
+	}
+	if seenAgent == nil || seenAgent.ID != agent.ID {
+		t.Fatalf("expected agent in context")
+	}
+	if !passthrough {
+		t.Fatalf("expected passthrough upstream auth context")
 	}
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -878,8 +878,9 @@ func (s *Server) routes() http.Handler {
 
 	// Lite-proxy LLM endpoint (opt-in via config). Agents set
 	// ANTHROPIC_BASE_URL / OPENAI_BASE_URL at this server and present
-	// their existing cvis_… token via Authorization: Bearer (OpenAI
-	// SDK convention) or x-api-key (Anthropic SDK convention).
+	// their existing cvis_… token via Authorization: Bearer, x-api-key,
+	// or X-Clawvisor-Agent-Token. The dedicated Clawvisor header lets
+	// Claude Code keep Authorization for subscription/OAuth passthrough.
 	if s.cfg.ProxyLite.Enabled {
 		llmHandler := handlers.NewLLMEndpointHandler(s.store, s.vault, s.logger)
 		if v := s.cfg.ProxyLite.AnthropicBaseURL; v != "" {
@@ -1000,8 +1001,8 @@ func (s *Server) routes() http.Handler {
 		llmCredHandler := handlers.NewLLMCredentialsHandler(s.store, s.vault, s.logger)
 		controlHandler := handlers.NewLLMControlHandler(baseURL)
 
-		// LLM endpoint accepts the agent token via Authorization or
-		// x-api-key (SDK conventions).
+		// LLM endpoint accepts the agent token via SDK auth headers or
+		// X-Clawvisor-Agent-Token for Claude Code subscription passthrough.
 		requireAgentLLM := middleware.RequireAgentLLM(s.store)
 
 		// Resolver expects a short-lived single-use nonce in

--- a/internal/runtime/llmproxy/auth_context.go
+++ b/internal/runtime/llmproxy/auth_context.go
@@ -7,14 +7,14 @@ type upstreamAuthModeContextKey struct{}
 const upstreamAuthModePassthrough = "passthrough"
 
 // WithPassthroughUpstreamAuth marks a lite-proxy request as authenticated to
-// Clawvisor out-of-band, allowing the Anthropic upstream Authorization header
-// to remain the user's Claude Code OAuth/subscription credential.
+// Clawvisor out-of-band, allowing the upstream Authorization header to remain
+// the user's provider OAuth/subscription credential.
 func WithPassthroughUpstreamAuth(ctx context.Context) context.Context {
 	return context.WithValue(ctx, upstreamAuthModeContextKey{}, upstreamAuthModePassthrough)
 }
 
 // PassthroughUpstreamAuth reports whether the request should preserve a
-// non-Clawvisor Anthropic Authorization header instead of injecting a vault key.
+// non-Clawvisor upstream Authorization header instead of injecting a vault key.
 func PassthroughUpstreamAuth(ctx context.Context) bool {
 	v, _ := ctx.Value(upstreamAuthModeContextKey{}).(string)
 	return v == upstreamAuthModePassthrough

--- a/internal/runtime/llmproxy/auth_context.go
+++ b/internal/runtime/llmproxy/auth_context.go
@@ -1,0 +1,21 @@
+package llmproxy
+
+import "context"
+
+type upstreamAuthModeContextKey struct{}
+
+const upstreamAuthModePassthrough = "passthrough"
+
+// WithPassthroughUpstreamAuth marks a lite-proxy request as authenticated to
+// Clawvisor out-of-band, allowing the Anthropic upstream Authorization header
+// to remain the user's Claude Code OAuth/subscription credential.
+func WithPassthroughUpstreamAuth(ctx context.Context) context.Context {
+	return context.WithValue(ctx, upstreamAuthModeContextKey{}, upstreamAuthModePassthrough)
+}
+
+// PassthroughUpstreamAuth reports whether the request should preserve a
+// non-Clawvisor Anthropic Authorization header instead of injecting a vault key.
+func PassthroughUpstreamAuth(ctx context.Context) bool {
+	v, _ := ctx.Value(upstreamAuthModeContextKey{}).(string)
+	return v == upstreamAuthModePassthrough
+}

--- a/internal/runtime/llmproxy/forward.go
+++ b/internal/runtime/llmproxy/forward.go
@@ -142,13 +142,6 @@ func (f *Forwarder) Forward(ctx context.Context, userID, agentID string, provide
 	}
 	upstreamURL.RawQuery = inbound.URL.RawQuery
 
-	keyBytes, serviceID, err := f.lookupVaultKey(ctx, userID, agentID, provider)
-	if err != nil {
-		return nil, err
-	}
-	defer zeroBytes(keyBytes)
-	_ = serviceID // serviceID is recorded by the handler for audit; future hook
-
 	req, err := http.NewRequestWithContext(ctx, inbound.Method, upstreamURL.String(), bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("llmproxy: build upstream request: %w", err)
@@ -161,6 +154,20 @@ func (f *Forwarder) Forward(ctx context.Context, userID, agentID string, provide
 	// rewrites by making the body unparseable. Cost: marginally larger
 	// SSE payload from upstream.
 	req.Header.Set("Accept-Encoding", "identity")
+
+	if provider == conversation.ProviderAnthropic && PassthroughUpstreamAuth(ctx) {
+		if auth := passthroughAnthropicAuthorization(inbound); auth != "" {
+			injectPassthroughAnthropicAuth(req, auth)
+			return f.Client.Do(req)
+		}
+	}
+
+	keyBytes, serviceID, err := f.lookupVaultKey(ctx, userID, agentID, provider)
+	if err != nil {
+		return nil, err
+	}
+	defer zeroBytes(keyBytes)
+	_ = serviceID // serviceID is recorded by the handler for audit; future hook
 
 	if err := injectUpstreamAuth(req, provider, keyBytes); err != nil {
 		return nil, err
@@ -218,6 +225,30 @@ func injectUpstreamAuth(req *http.Request, provider conversation.Provider, key [
 		return fmt.Errorf("llmproxy: unknown provider %q", provider)
 	}
 	return nil
+}
+
+func passthroughAnthropicAuthorization(inbound *http.Request) string {
+	if inbound == nil {
+		return ""
+	}
+	auth := strings.TrimSpace(inbound.Header.Get("Authorization"))
+	const prefix = "Bearer "
+	if !strings.HasPrefix(auth, prefix) {
+		return ""
+	}
+	token := strings.TrimSpace(auth[len(prefix):])
+	if token == "" || strings.HasPrefix(token, "cvis_") {
+		return ""
+	}
+	return prefix + token
+}
+
+func injectPassthroughAnthropicAuth(req *http.Request, authorization string) {
+	req.Header.Set("Authorization", authorization)
+	req.Header.Del("x-api-key")
+	if req.Header.Get("anthropic-version") == "" {
+		req.Header.Set("anthropic-version", "2023-06-01")
+	}
 }
 
 // forwardSkipHeaders are stripped from the inbound request when copying

--- a/internal/runtime/llmproxy/forward.go
+++ b/internal/runtime/llmproxy/forward.go
@@ -1,8 +1,9 @@
 // Package llmproxy implements the lite-proxy LLM endpoint pipeline: it
 // terminates Anthropic/OpenAI-compatible requests authenticated by the
-// agent's existing token, swaps in the real upstream API key from the
-// vault, and streams the response back. Tool-use inspection and resolver
-// are layered on top of this in sibling files.
+// agent's existing token, swaps in the real upstream API key from the vault
+// or preserves upstream OAuth in passthrough mode, and streams the response
+// back. Tool-use inspection and resolver are layered on top of this in sibling
+// files.
 package llmproxy
 
 import (
@@ -112,11 +113,10 @@ func NewForwarder(v vault.Vault) *Forwarder {
 	}
 }
 
-// Forward fetches the upstream API key for (userID, agentID, provider),
-// builds an upstream request mirroring the inbound one, injects the
-// upstream auth header per-provider, and dispatches via Client. The
-// returned *http.Response is the raw upstream response; the caller
-// streams its body to the harness.
+// Forward builds an upstream request mirroring the inbound one, injects the
+// upstream auth header per-provider or preserves upstream OAuth in passthrough
+// mode, and dispatches via Client. The returned *http.Response is the raw
+// upstream response; the caller streams its body to the harness.
 //
 // Vault key resolution order:
 //  1. agent-scoped: vault.Get(userID, "agent:<agentID>:<provider>")
@@ -155,10 +155,16 @@ func (f *Forwarder) Forward(ctx context.Context, userID, agentID string, provide
 	// SSE payload from upstream.
 	req.Header.Set("Accept-Encoding", "identity")
 
-	if provider == conversation.ProviderAnthropic && PassthroughUpstreamAuth(ctx) {
-		if auth := passthroughAnthropicAuthorization(inbound); auth != "" {
-			injectPassthroughAnthropicAuth(req, auth)
-			return f.Client.Do(req)
+	if PassthroughUpstreamAuth(ctx) {
+		if auth := passthroughBearerAuthorization(inbound); auth != "" {
+			if provider == conversation.ProviderOpenAI {
+				injectPassthroughOpenAIAuth(req, auth)
+				return f.Client.Do(req)
+			}
+			if provider == conversation.ProviderAnthropic {
+				injectPassthroughAnthropicAuth(req, auth)
+				return f.Client.Do(req)
+			}
 		}
 	}
 
@@ -227,7 +233,7 @@ func injectUpstreamAuth(req *http.Request, provider conversation.Provider, key [
 	return nil
 }
 
-func passthroughAnthropicAuthorization(inbound *http.Request) string {
+func passthroughBearerAuthorization(inbound *http.Request) string {
 	if inbound == nil {
 		return ""
 	}
@@ -243,6 +249,11 @@ func passthroughAnthropicAuthorization(inbound *http.Request) string {
 	return prefix + token
 }
 
+func injectPassthroughOpenAIAuth(req *http.Request, authorization string) {
+	req.Header.Set("Authorization", authorization)
+	req.Header.Del("x-api-key")
+}
+
 func injectPassthroughAnthropicAuth(req *http.Request, authorization string) {
 	req.Header.Set("Authorization", authorization)
 	req.Header.Del("x-api-key")
@@ -253,8 +264,8 @@ func injectPassthroughAnthropicAuth(req *http.Request, authorization string) {
 
 // forwardSkipHeaders are stripped from the inbound request when copying
 // to the upstream. Most are hop-by-hop or specific to the lite-proxy edge
-// (the agent's own bearer/x-api-key carries cvis_… and would 401 upstream;
-// the upstream gets its own per-provider header set in injectUpstreamAuth).
+// (the agent's own bearer/x-api-key may carry cvis_… and would 401 upstream;
+// upstream auth is restored explicitly after this copy step).
 //
 // All `X-Clawvisor-*` headers are also stripped via prefix match in
 // copyForwardableHeaders — they're for the proxy's edge, not the upstream.

--- a/internal/runtime/llmproxy/forward_test.go
+++ b/internal/runtime/llmproxy/forward_test.go
@@ -160,6 +160,41 @@ func TestForward_OpenAIInjectsKey(t *testing.T) {
 	}
 }
 
+func TestForward_OpenAIPassthroughAuthPreservesOAuthAuthorization(t *testing.T) {
+	v := &stubVault{}
+
+	var seenAuth, seenAccountID string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenAuth = r.Header.Get("Authorization")
+		seenAccountID = r.Header.Get("ChatGPT-Account-Id")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer upstream.Close()
+
+	f := NewForwarder(v)
+	f.Upstream = UpstreamSelector{OpenAIBaseURL: upstream.URL}
+
+	inbound := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader("{}"))
+	inbound.Header.Set("Authorization", "Bearer codex-oauth-token")
+	inbound.Header.Set("ChatGPT-Account-Id", "acct_123")
+	inbound.Header.Set("X-Clawvisor-Agent-Token", "cvis_agent_token")
+
+	ctx := WithPassthroughUpstreamAuth(context.Background())
+	resp, err := f.Forward(ctx, "user1", "", conversation.ProviderOpenAI, inbound, []byte("{}"))
+	if err != nil {
+		t.Fatalf("Forward: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if seenAuth != "Bearer codex-oauth-token" {
+		t.Fatalf("expected upstream OAuth Authorization to pass through, got %q", seenAuth)
+	}
+	if seenAccountID != "acct_123" {
+		t.Fatalf("expected ChatGPT-Account-Id to pass through when present, got %q", seenAccountID)
+	}
+}
+
 func TestForward_VaultMissing(t *testing.T) {
 	v := &stubVault{}
 	f := NewForwarder(v)

--- a/internal/runtime/llmproxy/forward_test.go
+++ b/internal/runtime/llmproxy/forward_test.go
@@ -95,6 +95,44 @@ func TestForward_AnthropicInjectsKey(t *testing.T) {
 	}
 }
 
+func TestForward_AnthropicPassthroughAuthPreservesOAuthAuthorization(t *testing.T) {
+	v := &stubVault{}
+
+	var seenAuth, seenAPIKey, seenVersion string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenAuth = r.Header.Get("Authorization")
+		seenAPIKey = r.Header.Get("x-api-key")
+		seenVersion = r.Header.Get("anthropic-version")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1"}`))
+	}))
+	defer upstream.Close()
+
+	f := NewForwarder(v)
+	f.Upstream = UpstreamSelector{AnthropicBaseURL: upstream.URL}
+
+	inbound := httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader([]byte(`{"model":"claude"}`)))
+	inbound.Header.Set("Authorization", "Bearer claude-oauth-token")
+	inbound.Header.Set("x-api-key", "cvis_agent_token")
+
+	ctx := WithPassthroughUpstreamAuth(context.Background())
+	resp, err := f.Forward(ctx, "user1", "", conversation.ProviderAnthropic, inbound, []byte(`{"model":"claude"}`))
+	if err != nil {
+		t.Fatalf("Forward: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if seenAuth != "Bearer claude-oauth-token" {
+		t.Fatalf("expected upstream OAuth Authorization to pass through, got %q", seenAuth)
+	}
+	if seenAPIKey != "" {
+		t.Fatalf("expected upstream x-api-key stripped in passthrough mode, got %q", seenAPIKey)
+	}
+	if seenVersion == "" {
+		t.Errorf("expected default anthropic-version header")
+	}
+}
+
 func TestForward_OpenAIInjectsKey(t *testing.T) {
 	v := &stubVault{}
 	v.Set(context.Background(), "user1", "openai", []byte("sk-real-openai-key"))

--- a/internal/runtime/llmproxy/inline_task_intercept.go
+++ b/internal/runtime/llmproxy/inline_task_intercept.go
@@ -145,7 +145,7 @@ func maybeInterceptInlineTaskDefinition(
 		return conversation.ToolUseVerdict{}, false
 	}
 
-	audit("block", "inline_task_pending_approval", "awaiting user yes/no on inline task definition (query)")
+	audit("approve", "pending", "inline_task_pending_approval: awaiting user yes/no on inline task definition (query)")
 	trace("inline_task.held",
 		"approval_id", innerHold.Pending.ID,
 		"purpose", parsed.Purpose,

--- a/internal/runtime/llmproxy/inline_task_intercept_test.go
+++ b/internal/runtime/llmproxy/inline_task_intercept_test.go
@@ -207,6 +207,8 @@ func TestPostprocess_InlineTaskInterceptedWithSurfaceInlineQueryParam(t *testing
 		AgentID:          agentID,
 		ControlBaseURL:   "http://localhost:25297",
 		PendingApprovals: cache,
+		Audit:            NewAuditEmitter(st, nil, nil),
+		RequestID:        "req-inline-task-pending",
 	})
 
 	out := string(got.Body)
@@ -215,6 +217,20 @@ func TestPostprocess_InlineTaskInterceptedWithSurfaceInlineQueryParam(t *testing
 	}
 	if strings.Contains(out, "X-Clawvisor-Caller") {
 		t.Fatalf("surface=inline should NOT rewrite the curl through to the daemon; got %s", out)
+	}
+	rows, _, err := st.ListAuditEntries(req.Context(), userID, store.AuditFilter{})
+	if err != nil {
+		t.Fatalf("ListAuditEntries: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 audit row, got %d", len(rows))
+	}
+	row := rows[0]
+	if row.Action != "lite_proxy.tool_use.approve" || row.Decision != "approve" || row.Outcome != "pending" {
+		t.Fatalf("expected pending approval audit row, got action=%q decision=%q outcome=%q", row.Action, row.Decision, row.Outcome)
+	}
+	if row.ToolUseID == nil || *row.ToolUseID != "toolu_1" {
+		t.Fatalf("tool_use_id=%v, want toolu_1", row.ToolUseID)
 	}
 
 	// One inner hold should now exist, with AwaitingTaskFor="" (no

--- a/internal/runtime/llmproxy/synthetic_history_strip.go
+++ b/internal/runtime/llmproxy/synthetic_history_strip.go
@@ -1,0 +1,109 @@
+package llmproxy
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+)
+
+type SyntheticApprovalHistoryStripRequest struct {
+	Provider conversation.Provider
+	Body     []byte
+}
+
+type SyntheticApprovalHistoryStripResult struct {
+	Body     []byte
+	Modified bool
+}
+
+const ToolApprovalSubstitutedPromptMarker = "Clawvisor paused this tool call for approval."
+
+// StripSyntheticApprovalHistory removes Clawvisor-generated approval UI from
+// conversation history before it is sent back to the upstream model. The live
+// pending-approval cache is the source of truth; historical assistant text that
+// looks like an approval prompt is untrusted model context and can be copied or
+// hallucinated by the model on later turns.
+func StripSyntheticApprovalHistory(req SyntheticApprovalHistoryStripRequest) (SyntheticApprovalHistoryStripResult, error) {
+	if len(req.Body) == 0 {
+		return SyntheticApprovalHistoryStripResult{Body: req.Body}, nil
+	}
+	switch req.Provider {
+	case conversation.ProviderAnthropic:
+		return stripAnthropicSyntheticApprovalHistory(req.Body)
+	default:
+		return SyntheticApprovalHistoryStripResult{Body: req.Body}, nil
+	}
+}
+
+func stripAnthropicSyntheticApprovalHistory(body []byte) (SyntheticApprovalHistoryStripResult, error) {
+	if !strings.Contains(string(body), "Clawvisor") {
+		return SyntheticApprovalHistoryStripResult{Body: body}, nil
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return SyntheticApprovalHistoryStripResult{Body: body}, nil
+	}
+	rawMessages, ok := raw["messages"]
+	if !ok {
+		return SyntheticApprovalHistoryStripResult{Body: body}, nil
+	}
+	var messages []map[string]json.RawMessage
+	if err := json.Unmarshal(rawMessages, &messages); err != nil {
+		return SyntheticApprovalHistoryStripResult{Body: body}, nil
+	}
+	out := make([]map[string]json.RawMessage, 0, len(messages))
+	modified := false
+	skipNextBareApprovalReply := false
+	for _, msg := range messages {
+		role := rawMessageString(msg["role"])
+		contentText := flattenAnthropicTaskReplyText(msg["content"])
+		if skipNextBareApprovalReply {
+			skipNextBareApprovalReply = false
+			if role == "user" && isBareSyntheticApprovalReply(contentText) {
+				modified = true
+				continue
+			}
+		}
+		if role == "assistant" && isSyntheticApprovalPromptText(contentText) {
+			modified = true
+			skipNextBareApprovalReply = true
+			continue
+		}
+		out = append(out, msg)
+	}
+	if !modified || len(out) == 0 {
+		return SyntheticApprovalHistoryStripResult{Body: body}, nil
+	}
+	encoded, err := json.Marshal(out)
+	if err != nil {
+		return SyntheticApprovalHistoryStripResult{Body: body}, err
+	}
+	raw["messages"] = encoded
+	next, err := json.Marshal(raw)
+	if err != nil {
+		return SyntheticApprovalHistoryStripResult{Body: body}, err
+	}
+	return SyntheticApprovalHistoryStripResult{Body: next, Modified: true}, nil
+}
+
+func rawMessageString(raw json.RawMessage) string {
+	var s string
+	_ = json.Unmarshal(raw, &s)
+	return s
+}
+
+func isSyntheticApprovalPromptText(text string) bool {
+	return strings.Contains(text, InlineApprovalSubstitutedPromptMarker) ||
+		strings.Contains(text, ToolApprovalSubstitutedPromptMarker)
+}
+
+func isBareSyntheticApprovalReply(text string) bool {
+	if strings.Contains(text, InlineApprovalAugmentationMarker) ||
+		strings.Contains(text, InlineTaskDenyMarker) ||
+		strings.Contains(text, InlineTaskCreatorErrorMarker) {
+		return false
+	}
+	verb, _ := conversation.ParseApprovalReplyText(text)
+	return verb != ""
+}

--- a/internal/runtime/llmproxy/synthetic_history_strip_test.go
+++ b/internal/runtime/llmproxy/synthetic_history_strip_test.go
@@ -1,0 +1,114 @@
+package llmproxy
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+)
+
+func TestStripSyntheticApprovalHistory_DropsInlinePromptAndBareReply(t *testing.T) {
+	body := anthropicTextBody(
+		map[string]string{"role": "user", "content": "Can you delete it?"},
+		map[string]string{"role": "assistant", "content": promptWithFooter("cv-approve-1", "Delete /tmp/hello.py")},
+		map[string]string{"role": "user", "content": "y"},
+	)
+
+	out, err := StripSyntheticApprovalHistory(SyntheticApprovalHistoryStripRequest{
+		Provider: conversation.ProviderAnthropic,
+		Body:     body,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !out.Modified {
+		t.Fatal("expected synthetic inline prompt history to be stripped")
+	}
+	text := string(out.Body)
+	if strings.Contains(text, InlineApprovalSubstitutedPromptMarker) || strings.Contains(text, "cv-approve-1") {
+		t.Fatalf("approval prompt leaked upstream: %s", text)
+	}
+	var decoded struct {
+		Messages []struct {
+			Role    string          `json:"role"`
+			Content json.RawMessage `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(out.Body, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if len(decoded.Messages) != 1 {
+		t.Fatalf("expected only the real user request to remain; got %+v", decoded.Messages)
+	}
+	if got := flattenAnthropicTaskReplyText(decoded.Messages[0].Content); got != "Can you delete it?" {
+		t.Fatalf("unexpected remaining message: %q", got)
+	}
+}
+
+func TestStripSyntheticApprovalHistory_KeepsInlineOutcomeContext(t *testing.T) {
+	note := inlineApprovedReplyAugmentation()
+	body := anthropicTextBody(
+		map[string]string{"role": "user", "content": "Create /tmp/hello.py"},
+		map[string]string{"role": "assistant", "content": promptWithFooter("cv-approve-1", "Create /tmp/hello.py")},
+		map[string]string{"role": "user", "content": note},
+	)
+
+	out, err := StripSyntheticApprovalHistory(SyntheticApprovalHistoryStripRequest{
+		Provider: conversation.ProviderAnthropic,
+		Body:     body,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !out.Modified {
+		t.Fatal("expected synthetic prompt to be stripped")
+	}
+	text := string(out.Body)
+	if strings.Contains(text, InlineApprovalSubstitutedPromptMarker) {
+		t.Fatalf("approval prompt leaked upstream: %s", text)
+	}
+	if !strings.Contains(text, InlineApprovalAugmentationMarker) {
+		t.Fatalf("inline outcome context should remain: %s", text)
+	}
+}
+
+func TestStripSyntheticApprovalHistory_DropsToolPromptAndBareReply(t *testing.T) {
+	body := anthropicTextBody(
+		map[string]string{"role": "user", "content": "Run ls"},
+		map[string]string{"role": "assistant", "content": ToolApprovalSubstitutedPromptMarker + "\n\nTool: `Bash`\nInput: ls\n\nReply `(y)es` to run this tool call."},
+		map[string]string{"role": "user", "content": "no"},
+	)
+
+	out, err := StripSyntheticApprovalHistory(SyntheticApprovalHistoryStripRequest{
+		Provider: conversation.ProviderAnthropic,
+		Body:     body,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !out.Modified {
+		t.Fatal("expected synthetic tool prompt history to be stripped")
+	}
+	text := string(out.Body)
+	if strings.Contains(text, ToolApprovalSubstitutedPromptMarker) || strings.Contains(text, `"no"`) {
+		t.Fatalf("synthetic tool approval history leaked upstream: %s", text)
+	}
+}
+
+func TestStripSyntheticApprovalHistory_DoesNotTouchUserMention(t *testing.T) {
+	body := anthropicTextBody(
+		map[string]string{"role": "user", "content": "Why did it say " + InlineApprovalSubstitutedPromptMarker + "?"},
+	)
+
+	out, err := StripSyntheticApprovalHistory(SyntheticApprovalHistoryStripRequest{
+		Provider: conversation.ProviderAnthropic,
+		Body:     body,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Modified {
+		t.Fatalf("user-authored diagnostic text should be preserved: %s", out.Body)
+	}
+}

--- a/web/src/pages/Agents.tsx
+++ b/web/src/pages/Agents.tsx
@@ -1380,7 +1380,7 @@ function AgentLiteProxyPanel({ agentId: _agentId }: { agentId: string }) {
   // Anthropic SDK + Claude CLI: env var is the ORIGIN; the SDK appends
   // `/v1/messages` itself. OpenAI SDK + Codex: base URL includes `/v1`
   // because the client appends just the action path (`/chat/completions`).
-  const claudeCode = `ANTHROPIC_BASE_URL=${baseURL} ANTHROPIC_API_KEY=cvis_<this-agent-token> claude`
+  const claudeCode = `ANTHROPIC_BASE_URL=${baseURL} ANTHROPIC_CUSTOM_HEADERS='X-Clawvisor-Agent-Token: cvis_<this-agent-token>' ANTHROPIC_AUTH_TOKEN= ANTHROPIC_API_KEY= claude`
   const codex = `codex exec \\
   -c model_provider=clawvisor \\
   -c 'model_providers.clawvisor.base_url="${baseURL}/v1"' \\

--- a/web/src/pages/Agents.tsx
+++ b/web/src/pages/Agents.tsx
@@ -1381,10 +1381,12 @@ function AgentLiteProxyPanel({ agentId: _agentId }: { agentId: string }) {
   // `/v1/messages` itself. OpenAI SDK + Codex: base URL includes `/v1`
   // because the client appends just the action path (`/chat/completions`).
   const claudeCode = `ANTHROPIC_BASE_URL=${baseURL} ANTHROPIC_CUSTOM_HEADERS='X-Clawvisor-Agent-Token: cvis_<this-agent-token>' ANTHROPIC_AUTH_TOKEN= ANTHROPIC_API_KEY= claude`
-  const codex = `codex exec \\
+  const codex = `CLAWVISOR_AGENT_TOKEN=cvis_<this-agent-token> codex exec \\
   -c model_provider=clawvisor \\
   -c 'model_providers.clawvisor.base_url="${baseURL}/v1"' \\
-  -c 'model_providers.clawvisor.env_key="CLAWVISOR_AGENT_TOKEN"' \\
+  -c 'model_providers.clawvisor.wire_api="responses"' \\
+  -c 'model_providers.clawvisor.requires_openai_auth=true' \\
+  -c 'model_providers.clawvisor.env_http_headers={"X-Clawvisor-Agent-Token"="CLAWVISOR_AGENT_TOKEN"}' \\
   -c 'model="gpt-4o-mini"'`
   const openaiSDK = `from openai import OpenAI
 client = OpenAI(
@@ -1406,7 +1408,7 @@ client = anthropic.Anthropic(
         <div>
           <div className="text-sm font-medium text-text-primary">Lite-proxy connection</div>
           <div className="text-xs text-text-tertiary">
-            Point an agent harness at this daemon's LLM endpoint. We'll swap your <code className="font-mono text-[11px]">cvis_…</code> token for the real upstream key on each call.
+            Point an agent harness at this daemon's LLM endpoint. Clawvisor authenticates the agent and either preserves upstream auth or swaps in a vaulted provider key.
           </div>
         </div>
         <span className="text-xs text-text-tertiary">{open ? 'Hide' : 'Show'}</span>


### PR DESCRIPTION
## Summary
- allow Claude Code proxy-lite sessions to authenticate Clawvisor with `X-Clawvisor-Agent-Token` while preserving the user's upstream Claude subscription auth
- switch Codex proxy-lite launches to `requires_openai_auth=true` with `X-Clawvisor-Agent-Token` in `env_http_headers`, avoiding `OPENAI_API_KEY=cvis_...` for Codex
- preserve OpenAI/Codex upstream OAuth `Authorization` in passthrough mode, including forwarding `ChatGPT-Account-Id` when present
- update Claude/Codex setup snippets and strip synthetic Clawvisor approval prompts from Anthropic history so models cannot replay stale approval UI

## Tests
- `go test ./internal/api/middleware ./internal/runtime/llmproxy ./cmd/clawvisor ./internal/api/handlers`
- `npm run lint`
- `git diff --check`
- Codex CLI config parse smoke: `codex ... debug models` with `requires_openai_auth=true` and `env_http_headers` overrides