### PR TITLE
Connect-an-Agent wizard + fix Codex passthrough

### DIFF
--- a/internal/api/connections_test.go
+++ b/internal/api/connections_test.go
@@ -489,6 +489,89 @@ func TestConnectionRequest_ClaimInvalid(t *testing.T) {
 	}
 }
 
+// Regression: a recoverable validation failure (e.g., duplicate name 409)
+// must NOT burn the single-use claim code. Otherwise the dashboard would
+// render a stale, unusable claim for ~4 minutes before the next refetch,
+// and the user's corrected retry would fail with INVALID_CLAIM.
+func TestConnectionRequest_ClaimSurvivesNameCollision(t *testing.T) {
+	env, session := setupConnectionEnv(t)
+
+	// First, create an existing agent named "Foo" by going through the
+	// approve flow so the name shows up in the agents list.
+	resp := env.do("POST", "/api/agents/connect", "", map[string]any{"name": "Foo"})
+	body := mustStatus(t, resp, http.StatusCreated)
+	connID := str(t, body, "connection_id")
+	resp = session.do("POST", "/api/agents/connect/"+connID+"/approve", nil)
+	mustStatus(t, resp, http.StatusOK)
+
+	// Mint a fresh claim.
+	resp = session.do("POST", "/api/agents/connect/claim", nil)
+	code := str(t, mustStatus(t, resp, http.StatusCreated), "code")
+
+	// Attempt to bootstrap "Foo" again — collides with the existing agent.
+	resp = env.do("POST", "/api/agents/connect?claim="+code+"&name=Foo", "", nil)
+	body = mustStatus(t, resp, http.StatusConflict)
+	if got := str(t, body, "code"); got != "AGENT_NAME_EXISTS" {
+		t.Errorf("expected code=AGENT_NAME_EXISTS, got %q", got)
+	}
+
+	// Retry with a different name using the SAME claim — must succeed,
+	// proving the claim wasn't consumed by the 409.
+	resp = env.do("POST", "/api/agents/connect?claim="+code+"&name=Bar", "", nil)
+	mustStatus(t, resp, http.StatusCreated)
+
+	// Now a third use of the same claim must fail — the successful Bar
+	// request consumed it.
+	resp = env.do("POST", "/api/agents/connect?claim="+code+"&name=Baz", "", nil)
+	body = mustStatus(t, resp, http.StatusUnauthorized)
+	if got := str(t, body, "code"); got != "INVALID_CLAIM" {
+		t.Errorf("expected code=INVALID_CLAIM on third use, got %q", got)
+	}
+}
+
+// Regression: the duplicate-name guard at request creation isn't enough
+// because an agent with the same name can be created between request
+// creation and approval (concurrent approve of a different pending,
+// add-agent form, etc.). ApproveByID must re-check.
+func TestConnectionRequest_ApproveRejectsRacingDuplicateName(t *testing.T) {
+	env, session := setupConnectionEnv(t)
+
+	// Create a connection request named "Race" — its name guard sees no
+	// existing agent.
+	resp := env.do("POST", "/api/agents/connect", "", map[string]any{"name": "Race"})
+	body := mustStatus(t, resp, http.StatusCreated)
+	pendingID := str(t, body, "connection_id")
+
+	// Sneak an agent named "Race" into the store directly, simulating a
+	// concurrent approve or add-agent form submission that landed first.
+	if _, err := env.Store.CreateAgent(context.Background(), session.UserID, "Race", "decoy-token-hash"); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	// Approving the pending request must now reject — the name is taken.
+	resp = session.do("POST", "/api/agents/connect/"+pendingID+"/approve", nil)
+	body = mustStatus(t, resp, http.StatusConflict)
+	if got := str(t, body, "code"); got != "AGENT_NAME_EXISTS" {
+		t.Errorf("expected code=AGENT_NAME_EXISTS on race, got %q", got)
+	}
+
+	// Confirm exactly one agent named "Race" exists (the decoy, not a
+	// second one created by the approve handler).
+	agents, err := env.Store.ListAgents(context.Background(), session.UserID)
+	if err != nil {
+		t.Fatalf("ListAgents: %v", err)
+	}
+	var raceCount int
+	for _, a := range agents {
+		if a.Name == "Race" {
+			raceCount++
+		}
+	}
+	if raceCount != 1 {
+		t.Errorf("expected exactly one 'Race' agent, got %d", raceCount)
+	}
+}
+
 func TestConnectionRequest_WaitDeniedReturns403(t *testing.T) {
 	env, session := setupConnectionEnv(t)
 	resp := session.do("POST", "/api/agents/connect/claim", nil)

--- a/internal/api/connections_test.go
+++ b/internal/api/connections_test.go
@@ -489,6 +489,102 @@ func TestConnectionRequest_ClaimInvalid(t *testing.T) {
 	}
 }
 
+func TestConnectionRequest_WaitDeniedReturns403(t *testing.T) {
+	env, session := setupConnectionEnv(t)
+	resp := session.do("POST", "/api/agents/connect/claim", nil)
+	claim := str(t, mustStatus(t, resp, http.StatusCreated), "code")
+
+	type result struct {
+		status int
+		body   map[string]any
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		r := env.do("POST", "/api/agents/connect?claim="+claim+"&name=DenyMe&wait=true&timeout=10", "", nil)
+		defer r.Body.Close()
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		resultCh <- result{status: r.StatusCode, body: body}
+	}()
+
+	// Wait until the pending request shows up server-side, then deny it.
+	var connID string
+	for i := 0; i < 50; i++ {
+		pending, err := env.Store.ListPendingConnectionRequests(context.Background(), session.UserID)
+		if err == nil && len(pending) > 0 {
+			connID = pending[0].ID
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if connID == "" {
+		t.Fatal("pending request never appeared")
+	}
+	denyResp := session.do("POST", "/api/agents/connect/"+connID+"/deny", nil)
+	mustStatus(t, denyResp, http.StatusOK)
+
+	select {
+	case got := <-resultCh:
+		if got.status != http.StatusForbidden {
+			t.Errorf("expected 403 Forbidden on denied wait=true response, got %d (body=%v)", got.status, got.body)
+		}
+		if s, _ := got.body["status"].(string); s != "denied" {
+			t.Errorf("expected response status=denied, got %q", s)
+		}
+		if _, hasToken := got.body["token"]; hasToken {
+			t.Error("denied response must not include a token")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("wait=true POST never returned after deny")
+	}
+}
+
+func TestConnectionRequest_WaitApprovedReturns201WithToken(t *testing.T) {
+	env, session := setupConnectionEnv(t)
+	resp := session.do("POST", "/api/agents/connect/claim", nil)
+	claim := str(t, mustStatus(t, resp, http.StatusCreated), "code")
+
+	type result struct {
+		status int
+		body   map[string]any
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		r := env.do("POST", "/api/agents/connect?claim="+claim+"&name=ApproveMeWait&wait=true&timeout=10", "", nil)
+		defer r.Body.Close()
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		resultCh <- result{status: r.StatusCode, body: body}
+	}()
+
+	var connID string
+	for i := 0; i < 50; i++ {
+		pending, err := env.Store.ListPendingConnectionRequests(context.Background(), session.UserID)
+		if err == nil && len(pending) > 0 {
+			connID = pending[0].ID
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if connID == "" {
+		t.Fatal("pending request never appeared")
+	}
+	approveResp := session.do("POST", "/api/agents/connect/"+connID+"/approve", nil)
+	mustStatus(t, approveResp, http.StatusOK)
+
+	select {
+	case got := <-resultCh:
+		if got.status != http.StatusCreated {
+			t.Errorf("expected 201 Created on approved wait=true response, got %d (body=%v)", got.status, got.body)
+		}
+		if tok, _ := got.body["token"].(string); tok == "" {
+			t.Error("approved response must include a non-empty token")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("wait=true POST never returned after approve")
+	}
+}
+
 func TestConnectionRequest_NameFromQuery(t *testing.T) {
 	env, session := setupConnectionEnv(t)
 

--- a/internal/api/connections_test.go
+++ b/internal/api/connections_test.go
@@ -3,6 +3,7 @@ package api_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -152,10 +153,11 @@ func TestConnectionRequest_Deny(t *testing.T) {
 func TestConnectionRequest_MaxPending(t *testing.T) {
 	env, _ := setupConnectionEnv(t)
 
-	// Create 10 pending requests (the max).
+	// Create 10 pending requests (the max). Names must differ because
+	// duplicate-name pending requests are rejected up front.
 	for i := 0; i < 10; i++ {
 		resp := env.do("POST", "/api/agents/connect", "", map[string]any{
-			"name": "Agent",
+			"name": fmt.Sprintf("Agent-%d", i),
 		})
 		mustStatus(t, resp, http.StatusCreated)
 	}
@@ -165,6 +167,94 @@ func TestConnectionRequest_MaxPending(t *testing.T) {
 		"name": "OneMore",
 	})
 	mustStatus(t, resp, http.StatusTooManyRequests)
+}
+
+func TestConnectionRequest_DuplicateAgentName(t *testing.T) {
+	env, session := setupConnectionEnv(t)
+
+	// Create a request and approve it so an agent named "Bootstrap" exists.
+	resp := env.do("POST", "/api/agents/connect", "", map[string]any{
+		"name": "Bootstrap",
+	})
+	body := mustStatus(t, resp, http.StatusCreated)
+	connID := str(t, body, "connection_id")
+	resp = session.do("POST", "/api/agents/connect/"+connID+"/approve", nil)
+	mustStatus(t, resp, http.StatusOK)
+
+	owner, err := env.Store.GetUserByEmail(context.Background(), "admin@local")
+	if err != nil {
+		t.Fatalf("GetUserByEmail: %v", err)
+	}
+	agentsBefore, err := env.Store.ListAgents(context.Background(), owner.ID)
+	if err != nil {
+		t.Fatalf("ListAgents: %v", err)
+	}
+	pendingBefore, err := env.Store.ListPendingConnectionRequests(context.Background(), owner.ID)
+	if err != nil {
+		t.Fatalf("ListPendingConnectionRequests: %v", err)
+	}
+
+	// A new request with the same name must be rejected without side effects.
+	resp = env.do("POST", "/api/agents/connect", "", map[string]any{
+		"name": "Bootstrap",
+	})
+	body = mustStatus(t, resp, http.StatusConflict)
+	if got := str(t, body, "code"); got != "AGENT_NAME_EXISTS" {
+		t.Errorf("expected code=AGENT_NAME_EXISTS, got %q", got)
+	}
+
+	agentsAfter, err := env.Store.ListAgents(context.Background(), owner.ID)
+	if err != nil {
+		t.Fatalf("ListAgents after: %v", err)
+	}
+	if len(agentsAfter) != len(agentsBefore) {
+		t.Errorf("collision created an agent: before=%d after=%d", len(agentsBefore), len(agentsAfter))
+	}
+	pendingAfter, err := env.Store.ListPendingConnectionRequests(context.Background(), owner.ID)
+	if err != nil {
+		t.Fatalf("ListPendingConnectionRequests after: %v", err)
+	}
+	if len(pendingAfter) != len(pendingBefore) {
+		t.Errorf("collision created a pending request: before=%d after=%d", len(pendingBefore), len(pendingAfter))
+	}
+}
+
+func TestConnectionRequest_DuplicatePendingName(t *testing.T) {
+	env, _ := setupConnectionEnv(t)
+
+	// First request creates a pending entry.
+	resp := env.do("POST", "/api/agents/connect", "", map[string]any{
+		"name": "InFlight",
+	})
+	mustStatus(t, resp, http.StatusCreated)
+
+	owner, err := env.Store.GetUserByEmail(context.Background(), "admin@local")
+	if err != nil {
+		t.Fatalf("GetUserByEmail: %v", err)
+	}
+	pendingBefore, err := env.Store.ListPendingConnectionRequests(context.Background(), owner.ID)
+	if err != nil {
+		t.Fatalf("ListPendingConnectionRequests: %v", err)
+	}
+
+	// Second request with the same name while the first is still pending
+	// must be rejected; we don't want two concurrent bootstrap curls racing
+	// for the same on-disk JSON path.
+	resp = env.do("POST", "/api/agents/connect", "", map[string]any{
+		"name": "InFlight",
+	})
+	body := mustStatus(t, resp, http.StatusConflict)
+	if got := str(t, body, "code"); got != "AGENT_NAME_EXISTS" {
+		t.Errorf("expected code=AGENT_NAME_EXISTS, got %q", got)
+	}
+
+	pendingAfter, err := env.Store.ListPendingConnectionRequests(context.Background(), owner.ID)
+	if err != nil {
+		t.Fatalf("ListPendingConnectionRequests after: %v", err)
+	}
+	if len(pendingAfter) != len(pendingBefore) {
+		t.Errorf("collision created a second pending request: before=%d after=%d", len(pendingBefore), len(pendingAfter))
+	}
 }
 
 func TestConnectionRequest_Expired(t *testing.T) {
@@ -307,5 +397,118 @@ func TestConnectionRequest_CountPending(t *testing.T) {
 	}
 	if count != 1 {
 		t.Errorf("expected 1 pending, got %d", count)
+	}
+}
+
+func TestConnectionRequest_ClaimMint(t *testing.T) {
+	_, session := setupConnectionEnv(t)
+
+	resp := session.do("POST", "/api/agents/connect/claim", nil)
+	body := mustStatus(t, resp, http.StatusCreated)
+
+	code := str(t, body, "code")
+	if len(code) != 10 {
+		t.Errorf("expected 10-char claim code, got %q (len %d)", code, len(code))
+	}
+	if str(t, body, "expires_at") == "" {
+		t.Error("expected non-empty expires_at")
+	}
+}
+
+func TestConnectionRequest_ClaimResolvesUser(t *testing.T) {
+	env, session := setupConnectionEnv(t)
+
+	// Mint a claim.
+	resp := session.do("POST", "/api/agents/connect/claim", nil)
+	body := mustStatus(t, resp, http.StatusCreated)
+	code := str(t, body, "code")
+
+	// Use the claim — note the body has no user_id.
+	resp = env.do("POST", "/api/agents/connect?claim="+code, "", map[string]any{
+		"name": "ClaimAgent",
+	})
+	body = mustStatus(t, resp, http.StatusCreated)
+
+	if str(t, body, "status") != "pending" {
+		t.Errorf("expected status=pending, got %s", str(t, body, "status"))
+	}
+
+	// The request must be attributed to the minting user.
+	pending, err := env.Store.ListPendingConnectionRequests(context.Background(), session.UserID)
+	if err != nil {
+		t.Fatalf("ListPendingConnectionRequests: %v", err)
+	}
+	if len(pending) != 1 || pending[0].Name != "ClaimAgent" {
+		t.Errorf("expected one pending request named ClaimAgent for the minting user, got %+v", pending)
+	}
+}
+
+func TestConnectionRequest_ClaimSingleUse(t *testing.T) {
+	env, session := setupConnectionEnv(t)
+
+	resp := session.do("POST", "/api/agents/connect/claim", nil)
+	body := mustStatus(t, resp, http.StatusCreated)
+	code := str(t, body, "code")
+
+	// First use succeeds.
+	resp = env.do("POST", "/api/agents/connect?claim="+code, "", map[string]any{
+		"name": "FirstUse",
+	})
+	mustStatus(t, resp, http.StatusCreated)
+
+	// Second use of the same claim must be rejected.
+	resp = env.do("POST", "/api/agents/connect?claim="+code, "", map[string]any{
+		"name": "SecondUse",
+	})
+	body = mustStatus(t, resp, http.StatusUnauthorized)
+	if got := str(t, body, "code"); got != "INVALID_CLAIM" {
+		t.Errorf("expected code=INVALID_CLAIM, got %q", got)
+	}
+
+	// The second attempt should not have created any pending request.
+	pending, err := env.Store.ListPendingConnectionRequests(context.Background(), session.UserID)
+	if err != nil {
+		t.Fatalf("ListPendingConnectionRequests: %v", err)
+	}
+	for _, p := range pending {
+		if p.Name == "SecondUse" {
+			t.Error("re-using a consumed claim must not create a pending request")
+		}
+	}
+}
+
+func TestConnectionRequest_ClaimInvalid(t *testing.T) {
+	env, _ := setupConnectionEnv(t)
+
+	resp := env.do("POST", "/api/agents/connect?claim=clm_does_not_exist", "", map[string]any{
+		"name": "Bogus",
+	})
+	body := mustStatus(t, resp, http.StatusUnauthorized)
+	if got := str(t, body, "code"); got != "INVALID_CLAIM" {
+		t.Errorf("expected code=INVALID_CLAIM, got %q", got)
+	}
+}
+
+func TestConnectionRequest_NameFromQuery(t *testing.T) {
+	env, session := setupConnectionEnv(t)
+
+	resp := session.do("POST", "/api/agents/connect/claim", nil)
+	body := mustStatus(t, resp, http.StatusCreated)
+	code := str(t, body, "code")
+
+	// Both name and claim ride on the URL; body is empty (no -d, no
+	// Content-Type required). This is the canonical bootstrap shape.
+	resp = env.do("POST", "/api/agents/connect?claim="+code+"&name=QueryAgent", "", nil)
+	body = mustStatus(t, resp, http.StatusCreated)
+	if str(t, body, "status") != "pending" {
+		t.Errorf("expected status=pending, got %s", str(t, body, "status"))
+	}
+
+	pending, err := env.Store.ListPendingConnectionRequests(context.Background(), session.UserID)
+	if err != nil {
+		t.Fatalf("ListPendingConnectionRequests: %v", err)
+	}
+	if len(pending) != 1 || pending[0].Name != "QueryAgent" {
+		t.Errorf("expected one pending request named QueryAgent, got %+v", pending)
 	}
 }

--- a/internal/api/connections_test.go
+++ b/internal/api/connections_test.go
@@ -572,6 +572,42 @@ func TestConnectionRequest_ApproveRejectsRacingDuplicateName(t *testing.T) {
 	}
 }
 
+// Regression: when wait=true's long-poll deadline fires with the request
+// still pending, the server must expire the request before returning, so a
+// late approve can't create an agent whose token never reaches a caller
+// (which would otherwise hold the name and block a clean re-bootstrap).
+func TestConnectionRequest_WaitTimeoutExpiresPending(t *testing.T) {
+	env, session := setupConnectionEnv(t)
+	resp := session.do("POST", "/api/agents/connect/claim", nil)
+	claim := str(t, mustStatus(t, resp, http.StatusCreated), "code")
+
+	// Long-poll with a very short deadline. timeout=1 → ~1s wait window.
+	resp = env.do("POST", "/api/agents/connect?claim="+claim+"&name=TimeoutMe&wait=true&timeout=1", "", nil)
+	body := mustStatus(t, resp, http.StatusGone)
+	if got := str(t, body, "status"); got != "expired" {
+		t.Errorf("expected status=expired in response, got %q", got)
+	}
+
+	// The pending request must be gone — a late approve attempt must fail
+	// because the request is no longer pending.
+	pending, err := env.Store.ListPendingConnectionRequests(context.Background(), session.UserID)
+	if err != nil {
+		t.Fatalf("ListPendingConnectionRequests: %v", err)
+	}
+	for _, p := range pending {
+		if p.Name == "TimeoutMe" {
+			t.Errorf("expected the timed-out request to no longer be pending, found: %+v", p)
+		}
+	}
+
+	// And re-bootstrap with the same name must succeed cleanly (no
+	// AGENT_NAME_EXISTS) — the agent was never created.
+	resp = session.do("POST", "/api/agents/connect/claim", nil)
+	claim2 := str(t, mustStatus(t, resp, http.StatusCreated), "code")
+	resp = env.do("POST", "/api/agents/connect?claim="+claim2+"&name=TimeoutMe", "", nil)
+	mustStatus(t, resp, http.StatusCreated)
+}
+
 func TestConnectionRequest_WaitDeniedReturns403(t *testing.T) {
 	env, session := setupConnectionEnv(t)
 	resp := session.do("POST", "/api/agents/connect/claim", nil)

--- a/internal/api/handlers/claim_cache.go
+++ b/internal/api/handlers/claim_cache.go
@@ -1,0 +1,67 @@
+package handlers
+
+import (
+	"sync"
+	"time"
+)
+
+// ClaimCodeCache stores short-lived single-use claim codes that authorize
+// a bootstrap curl to be attributed to a specific user without exposing the
+// user's ID in the URL. Codes are minted by an authenticated session and
+// consumed (atomically) by the unauthenticated POST /api/agents/connect
+// endpoint when the curl runs.
+type ClaimCodeCache interface {
+	// Store records a claim code for the user with the given TTL.
+	Store(code, userID string, ttl time.Duration)
+	// Consume atomically validates+removes the claim code. Returns the
+	// user ID if the code is valid and unused; the second value is false
+	// for unknown, expired, or already-consumed codes.
+	Consume(code string) (userID string, ok bool)
+}
+
+type claimCodeEntry struct {
+	userID    string
+	expiresAt time.Time
+}
+
+type memoryClaimCodeCache struct {
+	mu      sync.Mutex
+	entries map[string]claimCodeEntry
+}
+
+func newMemoryClaimCodeCache() *memoryClaimCodeCache {
+	return &memoryClaimCodeCache{entries: make(map[string]claimCodeEntry)}
+}
+
+func (c *memoryClaimCodeCache) Store(code, userID string, ttl time.Duration) {
+	c.mu.Lock()
+	c.entries[code] = claimCodeEntry{userID: userID, expiresAt: time.Now().Add(ttl)}
+	c.mu.Unlock()
+	go c.cleanup()
+}
+
+func (c *memoryClaimCodeCache) Consume(code string) (string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.entries[code]
+	if !ok {
+		return "", false
+	}
+	// Always remove on lookup — single-use, even if expired.
+	delete(c.entries, code)
+	if time.Now().After(entry.expiresAt) {
+		return "", false
+	}
+	return entry.userID, true
+}
+
+func (c *memoryClaimCodeCache) cleanup() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	now := time.Now()
+	for code, entry := range c.entries {
+		if now.After(entry.expiresAt) {
+			delete(c.entries, code)
+		}
+	}
+}

--- a/internal/api/handlers/claim_cache.go
+++ b/internal/api/handlers/claim_cache.go
@@ -13,6 +13,12 @@ import (
 type ClaimCodeCache interface {
 	// Store records a claim code for the user with the given TTL.
 	Store(code, userID string, ttl time.Duration)
+	// Peek returns the user ID for a claim without consuming it. Lets
+	// callers validate the request before burning the single-use code, so
+	// recoverable failures (duplicate-name 409, max-pending 429) don't
+	// strand the dashboard with a stale claim it can't refresh for
+	// minutes.
+	Peek(code string) (userID string, ok bool)
 	// Consume atomically validates+removes the claim code. Returns the
 	// user ID if the code is valid and unused; the second value is false
 	// for unknown, expired, or already-consumed codes.
@@ -38,6 +44,20 @@ func (c *memoryClaimCodeCache) Store(code, userID string, ttl time.Duration) {
 	c.entries[code] = claimCodeEntry{userID: userID, expiresAt: time.Now().Add(ttl)}
 	c.mu.Unlock()
 	go c.cleanup()
+}
+
+func (c *memoryClaimCodeCache) Peek(code string) (string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.entries[code]
+	if !ok {
+		return "", false
+	}
+	if time.Now().After(entry.expiresAt) {
+		delete(c.entries, code)
+		return "", false
+	}
+	return entry.userID, true
 }
 
 func (c *memoryClaimCodeCache) Consume(code string) (string, bool) {

--- a/internal/api/handlers/claim_cache_redis.go
+++ b/internal/api/handlers/claim_cache_redis.go
@@ -30,6 +30,20 @@ func (c *RedisClaimCodeCache) Store(code, userID string, ttl time.Duration) {
 	_ = c.rdb.Set(ctx, redisClaimCachePrefix+code, userID, ttl).Err()
 }
 
+// Peek reads the user ID without deleting the entry. Lets the connections
+// handler validate the request shape before burning the claim — failures
+// that the user can recover from (duplicate name, max pending) shouldn't
+// burn their single-use code.
+func (c *RedisClaimCodeCache) Peek(code string) (string, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	val, err := c.rdb.Get(ctx, redisClaimCachePrefix+code).Result()
+	if errors.Is(err, redis.Nil) || err != nil {
+		return "", false
+	}
+	return val, true
+}
+
 // Consume reads and deletes the entry in one round-trip via GETDEL, so two
 // concurrent consumes of the same code can't both succeed. Returns ("",
 // false) for unknown, expired (Redis already evicted), or already-consumed

--- a/internal/api/handlers/claim_cache_redis.go
+++ b/internal/api/handlers/claim_cache_redis.go
@@ -1,0 +1,45 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const redisClaimCachePrefix = "clawvisor:claimcode:"
+
+// RedisClaimCodeCache stores short-lived single-use claim codes in Redis so
+// the bootstrap-curl POST can land on any instance and still consume a code
+// minted on another. Single-use is enforced atomically via GETDEL.
+type RedisClaimCodeCache struct {
+	rdb *redis.Client
+}
+
+// NewRedisClaimCodeCache creates a Redis-backed claim code cache. TTL is
+// passed per-Store call so the in-memory and Redis variants have the same
+// shape; the caller (the connections handler) decides the TTL.
+func NewRedisClaimCodeCache(rdb *redis.Client) *RedisClaimCodeCache {
+	return &RedisClaimCodeCache{rdb: rdb}
+}
+
+func (c *RedisClaimCodeCache) Store(code, userID string, ttl time.Duration) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = c.rdb.Set(ctx, redisClaimCachePrefix+code, userID, ttl).Err()
+}
+
+// Consume reads and deletes the entry in one round-trip via GETDEL, so two
+// concurrent consumes of the same code can't both succeed. Returns ("",
+// false) for unknown, expired (Redis already evicted), or already-consumed
+// codes.
+func (c *RedisClaimCodeCache) Consume(code string) (string, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	val, err := c.rdb.GetDel(ctx, redisClaimCachePrefix+code).Result()
+	if errors.Is(err, redis.Nil) || err != nil {
+		return "", false
+	}
+	return val, true
+}

--- a/internal/api/handlers/connections.go
+++ b/internal/api/handlers/connections.go
@@ -232,6 +232,10 @@ func (h *ConnectionsHandler) RequestConnect(w http.ResponseWriter, r *http.Reque
 	}
 
 	// If wait=true, long-poll until the connection request is resolved.
+	// The status code distinguishes outcomes so a `curl -sf` bootstrap
+	// exits non-zero on anything other than approval — that way
+	// --remove-on-error cleans up the tokenless response body and the
+	// caller never ends up with garbage on disk.
 	if r.URL.Query().Get("wait") == "true" && h.eventHub != nil {
 		resolved := h.waitForConnectionResolution(r.Context(), req.ID, owner.ID, longPollDeadline(r))
 		if r.Context().Err() != nil {
@@ -242,12 +246,23 @@ func (h *ConnectionsHandler) RequestConnect(w http.ResponseWriter, r *http.Reque
 			"status":        resolved.Status,
 			"expires_at":    resolved.ExpiresAt,
 		}
-		if resolved.Status == "approved" {
+		status := http.StatusCreated
+		switch resolved.Status {
+		case "approved":
 			if raw, ok := h.tokenCache.Load(req.ID); ok {
 				resp["token"] = raw
 			}
+		case "denied":
+			status = http.StatusForbidden
+		case "expired":
+			status = http.StatusGone
+		default:
+			// "pending" reaching the wait deadline is the long-poll
+			// equivalent of a timeout — caller should retry the curl
+			// or check the dashboard directly.
+			status = http.StatusRequestTimeout
 		}
-		writeJSON(w, http.StatusCreated, resp)
+		writeJSON(w, status, resp)
 		return
 	}
 

--- a/internal/api/handlers/connections.go
+++ b/internal/api/handlers/connections.go
@@ -291,8 +291,17 @@ func (h *ConnectionsHandler) RequestConnect(w http.ResponseWriter, r *http.Reque
 		default:
 			// "pending" reaching the wait deadline is the long-poll
 			// equivalent of a timeout — caller should retry the curl
-			// or check the dashboard directly.
-			status = http.StatusRequestTimeout
+			// or check the dashboard directly. Expire the request
+			// server-side BEFORE returning the 408, so a late approve
+			// can't create an agent whose token nobody is around to
+			// receive. The agent would otherwise hold the name and
+			// block a clean retry with AGENT_NAME_EXISTS.
+			if expireErr := h.expireByID(r.Context(), req.ID, owner.ID); expireErr == nil {
+				resp["status"] = "expired"
+				status = http.StatusGone
+			} else {
+				status = http.StatusRequestTimeout
+			}
 		}
 		writeJSON(w, status, resp)
 		return

--- a/internal/api/handlers/connections.go
+++ b/internal/api/handlers/connections.go
@@ -23,6 +23,7 @@ var (
 	errAlreadyResolved = errors.New("connection request already resolved")
 	errExpired         = errors.New("connection request expired")
 	errForbidden       = errors.New("connection request does not belong to this user")
+	errAgentNameTaken  = errors.New("agent name is already in use")
 )
 
 const (
@@ -118,14 +119,23 @@ func (h *ConnectionsHandler) RequestConnect(w http.ResponseWriter, r *http.Reque
 
 	// Resolve the target user. A `?claim=<code>` query param (minted by an
 	// authenticated dashboard session) takes precedence and avoids leaking
-	// user_id into the bootstrap curl URL. Single-use: the claim is
-	// consumed up front, so any failure below requires the dashboard to
-	// re-mint. Fallback paths: user_id in the body (legacy callers,
-	// skill-based setup flow) or admin@local in single-tenant mode.
-	var owner *store.User
-	var err error
+	// user_id into the bootstrap curl URL.
+	//
+	// Claim handling is two-phase: Peek first to identify the user so we
+	// can run the cheap validation that follows (name collisions, max
+	// pending), then Consume only when we're about to create the request.
+	// Burning the single-use code on a 4xx the caller could fix would
+	// leave the dashboard renderering a stale claim for up to four minutes
+	// before the next mint refetch — too long for a corrected retry.
+	// Fallback paths: user_id in the body (legacy callers, skill-based
+	// setup flow) or admin@local in single-tenant mode.
+	var (
+		owner          *store.User
+		err            error
+		pendingClaim   string // non-empty when we owe a Consume after validation
+	)
 	if claim := r.URL.Query().Get("claim"); claim != "" {
-		userID, ok := h.claimCache.Consume(claim)
+		userID, ok := h.claimCache.Peek(claim)
 		if !ok {
 			writeError(w, http.StatusUnauthorized, "INVALID_CLAIM", "claim code is invalid, expired, or already consumed")
 			return
@@ -135,6 +145,7 @@ func (h *ConnectionsHandler) RequestConnect(w http.ResponseWriter, r *http.Reque
 			writeError(w, http.StatusNotFound, "USER_NOT_FOUND", "user not found")
 			return
 		}
+		pendingClaim = claim
 	} else if body.UserID != "" {
 		owner, err = h.st.GetUserByID(r.Context(), body.UserID)
 		if err != nil {
@@ -196,6 +207,16 @@ func (h *ConnectionsHandler) RequestConnect(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	// All validations passed — now atomically consume the claim. A
+	// concurrent caller racing on the same code loses here (Consume
+	// returns !ok), preserving single-use semantics.
+	if pendingClaim != "" {
+		if _, ok := h.claimCache.Consume(pendingClaim); !ok {
+			writeError(w, http.StatusUnauthorized, "INVALID_CLAIM", "claim code is invalid, expired, or already consumed")
+			return
+		}
+	}
+
 	req := &store.ConnectionRequest{
 		UserID:      owner.ID,
 		Name:        body.Name,
@@ -249,9 +270,20 @@ func (h *ConnectionsHandler) RequestConnect(w http.ResponseWriter, r *http.Reque
 		status := http.StatusCreated
 		switch resolved.Status {
 		case "approved":
-			if raw, ok := h.tokenCache.Load(req.ID); ok {
-				resp["token"] = raw
+			raw, ok := h.tokenCache.Load(req.ID)
+			if !ok {
+				// The approve handler wrote the token to the cache; if
+				// it's gone by the time we read it, we'd otherwise return
+				// 201 with no token field — and the bootstrap curl would
+				// happily write the tokenless body to disk. Surface as a
+				// 500 so --remove-on-error cleans up.
+				h.logger.WarnContext(r.Context(), "lite-proxy: approved request missing token in cache",
+					"connection_id", req.ID)
+				writeError(w, http.StatusInternalServerError, "TOKEN_UNAVAILABLE",
+					"connection was approved but the token cache no longer has it; ask the user to re-approve")
+				return
 			}
+			resp["token"] = raw
 		case "denied":
 			status = http.StatusForbidden
 		case "expired":
@@ -465,6 +497,9 @@ func (h *ConnectionsHandler) Approve(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusConflict, "ALREADY_RESOLVED", "connection request is not pending")
 		case errExpired:
 			writeError(w, http.StatusGone, "EXPIRED", "connection request has expired")
+		case errAgentNameTaken:
+			writeError(w, http.StatusConflict, "AGENT_NAME_EXISTS",
+				"an agent with this name already exists; deny this request and bootstrap with a different name")
 		default:
 			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not approve connection request")
 		}
@@ -493,6 +528,22 @@ func (h *ConnectionsHandler) ApproveByID(ctx context.Context, id, userID string)
 	if time.Now().After(cr.ExpiresAt) {
 		_ = h.expireByID(ctx, id, userID)
 		return "", errExpired
+	}
+
+	// Re-check name uniqueness at approve time. The request-creation guard
+	// runs much earlier; between then and now a second agent with the same
+	// name could have been created (concurrent approve of another pending
+	// request, an Add Agent form submission, etc.). Without this re-check
+	// the duplicate guarantee leaks. The store has no unique index on
+	// (user_id, name) so we enforce it in code.
+	existing, listErr := h.st.ListAgents(ctx, userID)
+	if listErr != nil {
+		return "", fmt.Errorf("list agents: %w", listErr)
+	}
+	for _, a := range existing {
+		if a.Name == cr.Name {
+			return "", errAgentNameTaken
+		}
 	}
 
 	rawToken, err := auth.GenerateAgentToken()

--- a/internal/api/handlers/connections.go
+++ b/internal/api/handlers/connections.go
@@ -2,6 +2,8 @@ package handlers
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -26,6 +28,7 @@ var (
 const (
 	connectionRequestExpiry   = 5 * time.Minute
 	connectionTokenWindow     = 5 * time.Minute
+	claimCodeTTL              = 5 * time.Minute
 	maxPendingRequests        = 10
 	pollTimeout               = 30 * time.Second
 	maxConcurrentPollsPerUser = 10
@@ -43,6 +46,11 @@ type ConnectionsHandler struct {
 	// Token cache for approved agent tokens. Backed by either in-memory
 	// or Redis, depending on server configuration.
 	tokenCache TokenCache
+
+	// Claim code cache for the bootstrap-curl flow. In-memory only —
+	// codes are 5-minute single-use and don't survive process restart,
+	// which is fine for transient bootstrap credentials.
+	claimCache ClaimCodeCache
 
 	// Per-user concurrent poll tracking.
 	userPollsMu sync.Mutex
@@ -68,6 +76,7 @@ func NewConnectionsHandler(st store.Store, notifier notify.Notifier,
 		baseURL:     baseURL,
 		multiTenant: multiTenant,
 		tokenCache:  newMemoryTokenCache(connectionTokenWindow),
+		claimCache:  newMemoryClaimCodeCache(),
 		userPolls:   make(map[string]int),
 		ipPolls:     make(map[string]int),
 	}
@@ -76,6 +85,11 @@ func NewConnectionsHandler(st store.Store, notifier notify.Notifier,
 // SetTokenCache overrides the default in-memory token cache.
 func (h *ConnectionsHandler) SetTokenCache(tc TokenCache) {
 	h.tokenCache = tc
+}
+
+// SetClaimCodeCache overrides the default in-memory claim code cache.
+func (h *ConnectionsHandler) SetClaimCodeCache(cc ClaimCodeCache) {
+	h.claimCache = cc
 }
 
 // RequestConnect handles POST /api/agents/connect (unauthenticated).
@@ -87,32 +101,86 @@ func (h *ConnectionsHandler) RequestConnect(w http.ResponseWriter, r *http.Reque
 		CallbackURL string `json:"callback_url"`
 		UserID      string `json:"user_id"`
 	}
-	if !decodeJSON(w, r, &body) {
+	// decodeJSON tolerates an empty body so callers can send everything as
+	// query params and skip the Content-Type / -d flags entirely.
+	if !decodeJSONAllowEmpty(w, r, &body) {
 		return
+	}
+	// Name may also arrive as a query param to keep the bootstrap curl
+	// body-less. Body wins if both are set (legacy callers).
+	if body.Name == "" {
+		body.Name = r.URL.Query().Get("name")
 	}
 	if body.Name == "" {
 		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "name is required")
 		return
 	}
 
-	// Resolve the target user. In multi-tenant mode, user_id is required so
-	// the connection request is routed to the correct user. In single-tenant
-	// mode, fall back to admin@local for backward compatibility.
+	// Resolve the target user. A `?claim=<code>` query param (minted by an
+	// authenticated dashboard session) takes precedence and avoids leaking
+	// user_id into the bootstrap curl URL. Single-use: the claim is
+	// consumed up front, so any failure below requires the dashboard to
+	// re-mint. Fallback paths: user_id in the body (legacy callers,
+	// skill-based setup flow) or admin@local in single-tenant mode.
 	var owner *store.User
 	var err error
-	if body.UserID != "" {
+	if claim := r.URL.Query().Get("claim"); claim != "" {
+		userID, ok := h.claimCache.Consume(claim)
+		if !ok {
+			writeError(w, http.StatusUnauthorized, "INVALID_CLAIM", "claim code is invalid, expired, or already consumed")
+			return
+		}
+		owner, err = h.st.GetUserByID(r.Context(), userID)
+		if err != nil {
+			writeError(w, http.StatusNotFound, "USER_NOT_FOUND", "user not found")
+			return
+		}
+	} else if body.UserID != "" {
 		owner, err = h.st.GetUserByID(r.Context(), body.UserID)
 		if err != nil {
 			writeError(w, http.StatusNotFound, "USER_NOT_FOUND", "user not found")
 			return
 		}
 	} else if h.multiTenant {
-		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "user_id is required")
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "user_id or claim is required")
 		return
 	} else {
 		owner, err = h.st.GetUserByEmail(r.Context(), "admin@local")
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not resolve daemon owner")
+			return
+		}
+	}
+
+	// Reject duplicate agent names up front so the bootstrap curl never
+	// silently clobbers an existing agent. The check runs before any DB
+	// write or notification — a name collision must leave the existing
+	// agent (and the on-disk JSON for that name on the caller's machine)
+	// untouched. We also reject if a *pending* request already exists for
+	// the same name; otherwise two concurrent bootstrap curls could both
+	// resolve into agents and only the first would be addressable by its
+	// chosen name.
+	existingAgents, err := h.st.ListAgents(r.Context(), owner.ID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not list agents")
+		return
+	}
+	for _, a := range existingAgents {
+		if a.Name == body.Name {
+			writeError(w, http.StatusConflict, "AGENT_NAME_EXISTS",
+				fmt.Sprintf("agent %q already exists; pick a different name or delete it first", body.Name))
+			return
+		}
+	}
+	pendingRequests, err := h.st.ListPendingConnectionRequests(r.Context(), owner.ID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not list pending requests")
+		return
+	}
+	for _, p := range pendingRequests {
+		if p.Name == body.Name {
+			writeError(w, http.StatusConflict, "AGENT_NAME_EXISTS",
+				fmt.Sprintf("a pending request named %q is already waiting; approve or deny it before creating another with the same name", body.Name))
 			return
 		}
 	}
@@ -188,6 +256,34 @@ func (h *ConnectionsHandler) RequestConnect(w http.ResponseWriter, r *http.Reque
 		"status":        req.Status,
 		"poll_url":      "/api/agents/connect/" + req.ID + "/status",
 		"expires_at":    req.ExpiresAt,
+	})
+}
+
+// MintClaim handles POST /api/agents/connect/claim (user JWT). It mints a
+// short-lived single-use claim code that the dashboard embeds in the
+// bootstrap curl URL as `?claim=…`. The unauthenticated RequestConnect
+// endpoint consumes the claim to attribute the request to the minting
+// user without that user's ID ever appearing in the URL.
+//
+// The code is 10 URL-safe base64 characters (60 bits of entropy from
+// 8 random bytes, truncated). 5-minute single-use codes don't need
+// long-term unguessability and a tight URL is easier on the eyes.
+func (h *ConnectionsHandler) MintClaim(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "not authenticated")
+		return
+	}
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not generate claim code")
+		return
+	}
+	code := base64.RawURLEncoding.EncodeToString(b)[:10]
+	h.claimCache.Store(code, user.ID, claimCodeTTL)
+	writeJSON(w, http.StatusCreated, map[string]any{
+		"code":       code,
+		"expires_at": time.Now().Add(claimCodeTTL),
 	})
 }
 

--- a/internal/api/handlers/health.go
+++ b/internal/api/handlers/health.go
@@ -122,6 +122,21 @@ func decodeJSON(w http.ResponseWriter, r *http.Request, v any) bool {
 	return true
 }
 
+// decodeJSONAllowEmpty is decodeJSON but treats an empty body as a no-op so
+// callers can supply all fields via query string. Non-empty malformed JSON
+// still errors normally.
+func decodeJSONAllowEmpty(w http.ResponseWriter, r *http.Request, v any) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodySize)
+	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
+		if errors.Is(err, io.EOF) {
+			return true
+		}
+		writeDetailedError(w, http.StatusBadRequest, diagnoseJSONError(err))
+		return false
+	}
+	return true
+}
+
 // diagnoseJSONError inspects a JSON decode error and returns an actionable error detail.
 func diagnoseJSONError(err error) apiErrorDetail {
 	d := apiErrorDetail{

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -98,6 +98,7 @@ type Server struct {
 	// Multi-instance stores (set via options; nil = use defaults).
 	replayCache        middleware.ReplayCache
 	tokenCache         handlers.TokenCache
+	claimCodeCache     handlers.ClaimCodeCache
 	devicePairingStore handlers.DevicePairingStore
 	oauthStateStore    handlers.OAuthStateStore
 	pairingCodeStore   handlers.PairingCodeStore
@@ -284,6 +285,13 @@ func WithReplayCache(rc middleware.ReplayCache) ServerOption {
 // WithTokenCache overrides the default in-memory connection token cache.
 func WithTokenCache(tc handlers.TokenCache) ServerOption {
 	return func(s *Server) { s.tokenCache = tc }
+}
+
+// WithClaimCodeCache overrides the default in-memory claim code cache.
+// Multi-instance deployments must supply a shared (e.g. Redis-backed) cache
+// so a code minted on one instance can be consumed on another.
+func WithClaimCodeCache(cc handlers.ClaimCodeCache) ServerOption {
+	return func(s *Server) { s.claimCodeCache = cc }
 }
 
 // WithDevicePairingStore overrides the default in-memory device pairing store.
@@ -698,6 +706,9 @@ func (s *Server) routes() http.Handler {
 	connectionsHandler := handlers.NewConnectionsHandler(s.store, s.notifier, s.eventHub, s.logger, baseURL, s.features.MultiTenant)
 	if s.tokenCache != nil {
 		connectionsHandler.SetTokenCache(s.tokenCache)
+	}
+	if s.claimCodeCache != nil {
+		connectionsHandler.SetClaimCodeCache(s.claimCodeCache)
 	}
 	s.connectionsHandler = connectionsHandler
 	connectionsRL := newKeyedLimiterFromBucket(config.RateLimitBucket{Limit: 10, Window: 60})

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -706,6 +706,7 @@ func (s *Server) routes() http.Handler {
 	mux.Handle("GET /api/agents/connect/{id}/status", e2e(http.HandlerFunc(connectionsHandler.PollStatus)))
 
 	// Connection request management (user JWT)
+	mux.Handle("POST /api/agents/connect/claim", user(connectionsHandler.MintClaim))
 	mux.Handle("GET /api/agents/connections", user(connectionsHandler.List))
 	mux.Handle("POST /api/agents/connect/{id}/approve", user(connectionsHandler.Approve))
 	mux.Handle("POST /api/agents/connect/{id}/deny", user(connectionsHandler.Deny))

--- a/internal/runtime/conversation/openai_codex_response_test.go
+++ b/internal/runtime/conversation/openai_codex_response_test.go
@@ -1,0 +1,76 @@
+package conversation
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// Regression: a captured live SSE response from chatgpt.com/backend-api/codex
+// must hit the rewriter eval for every function_call output item it carries.
+// If the eval never fires, clawvisor.local URLs in the tool_use args won't
+// get rewritten and the harness ends up curling a non-existent host.
+func TestCodexSSEResponse_RewriterCallsEvalForFunctionCalls(t *testing.T) {
+	body, err := os.ReadFile("/tmp/codex_curl_response.txt")
+	if err != nil {
+		t.Skipf("captured codex response not present at /tmp/codex_response.txt: %v", err)
+	}
+	if !strings.Contains(string(body), "function_call") {
+		t.Fatalf("captured body has no function_call — wrong fixture")
+	}
+	if !strings.Contains(string(body), "clawvisor.local") {
+		t.Fatalf("captured body has no clawvisor.local — wrong fixture")
+	}
+	var seen []ToolUse
+	eval := func(tu ToolUse) ToolUseVerdict {
+		seen = append(seen, tu)
+		return ToolUseVerdict{Allowed: true}
+	}
+	rw := OpenAIResponseRewriter{}
+	result, err := rw.Rewrite(body, "text/event-stream", eval)
+	if err != nil {
+		t.Fatalf("Rewrite returned error: %v", err)
+	}
+	t.Logf("eval invocations: %d", len(seen))
+	for i, tu := range seen {
+		t.Logf("  #%d name=%s input=%s", i, tu.Name, truncate(string(tu.Input), 200))
+	}
+	t.Logf("result.Body bytes: %d (input was %d)", len(result.Body), len(body))
+	if len(seen) == 0 {
+		t.Fatalf("expected the rewriter to call eval at least once for the function_call output items in the captured response; got 0")
+	}
+}
+
+// Regression: in production we observed Postprocess running with an empty
+// Content-Type header (rawlog `content_type=` empty), and tool_use_entry
+// trace events never fired. That suggests the rewriter dispatched to the
+// JSON path on an SSE body, which decodes to nothing — no eval calls. This
+// test asserts that scenario.
+func TestCodexSSEResponse_RewriterEmptyContentType(t *testing.T) {
+	body, err := os.ReadFile("/tmp/codex_curl_response.txt")
+	if err != nil {
+		t.Skipf("captured codex response not present at /tmp/codex_curl_response.txt: %v", err)
+	}
+	var seen []ToolUse
+	eval := func(tu ToolUse) ToolUseVerdict {
+		seen = append(seen, tu)
+		return ToolUseVerdict{Allowed: true}
+	}
+	rw := OpenAIResponseRewriter{}
+	// Pass empty Content-Type — matches what we saw in production.
+	_, err = rw.Rewrite(body, "", eval)
+	if err != nil {
+		t.Fatalf("Rewrite returned error: %v", err)
+	}
+	t.Logf("eval invocations with empty CT: %d", len(seen))
+	if len(seen) == 0 {
+		t.Fatalf("rewriter dispatch on empty content-type missed the SSE body's function_calls")
+	}
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/internal/runtime/conversation/openai_response.go
+++ b/internal/runtime/conversation/openai_response.go
@@ -24,7 +24,7 @@ func (rw OpenAIResponseRewriter) Rewrite(body []byte, contentType string, eval T
 	case isOpenAIResponsesBody(body):
 		return rw.rewriteResponses(body, contentType, eval)
 	default:
-		if isSSE(contentType) {
+		if isSSE(contentType) || looksLikeSSE(body) {
 			if bytes.Contains(body, []byte("response.output_item.added")) || bytes.Contains(body, []byte("response.function_call_arguments")) {
 				return rw.rewriteResponses(body, contentType, eval)
 			}
@@ -34,18 +34,39 @@ func (rw OpenAIResponseRewriter) Rewrite(body []byte, contentType string, eval T
 	}
 }
 
+// rewriteResponses picks the SSE vs JSON path. Content-Type is the primary
+// signal but isn't always present (some upstreams elide it for streamed
+// responses, and proxy hops may strip it); fall back to body sniffing.
 func (rw OpenAIResponseRewriter) rewriteResponses(body []byte, contentType string, eval ToolUseEvaluator) (RewriteResult, error) {
-	if isSSE(contentType) {
+	if isSSE(contentType) || looksLikeSSE(body) {
 		return rw.rewriteResponsesSSE(body, eval)
 	}
 	return rw.rewriteResponsesJSON(body, eval)
 }
 
 func (rw OpenAIResponseRewriter) rewriteChatCompletions(body []byte, contentType string, eval ToolUseEvaluator) (RewriteResult, error) {
-	if isSSE(contentType) {
+	if isSSE(contentType) || looksLikeSSE(body) {
 		return rw.rewriteChatCompletionsSSE(body, eval)
 	}
 	return rw.rewriteChatCompletionsJSON(body, eval)
+}
+
+// looksLikeSSE sniffs the body for an SSE framing pattern. Used as a
+// fallback when the Content-Type header is missing — happens with some
+// upstream transports and shows up here as empty contentType, which would
+// otherwise route an SSE body through the JSON path (json.Unmarshal fails,
+// no tool_uses get extracted, no rewrites fire).
+func looksLikeSSE(body []byte) bool {
+	if len(body) == 0 {
+		return false
+	}
+	head := body
+	if len(head) > 4096 {
+		head = head[:4096]
+	}
+	return bytes.HasPrefix(bytes.TrimLeft(head, "\r\n "), []byte("event:")) ||
+		bytes.HasPrefix(bytes.TrimLeft(head, "\r\n "), []byte("data:")) ||
+		bytes.Contains(head, []byte("\nevent: response."))
 }
 
 type openAIResponsesJSON struct {

--- a/internal/runtime/llmproxy/forward.go
+++ b/internal/runtime/llmproxy/forward.go
@@ -9,6 +9,8 @@ package llmproxy
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -140,6 +142,18 @@ func (f *Forwarder) Forward(ctx context.Context, userID, agentID string, provide
 	if err != nil {
 		return nil, err
 	}
+	// In passthrough mode, OpenAI splits its Codex surface across two
+	// upstreams: ChatGPT-OAuth bearers must hit chatgpt.com/backend-api/codex/*
+	// while API keys (and OAuth bearers explicitly scoped with
+	// api.responses.write) hit api.openai.com/v1/*. Route based on the
+	// bearer's shape and claims; fall back to api.openai.com when in doubt.
+	if PassthroughUpstreamAuth(ctx) && provider == conversation.ProviderOpenAI {
+		if auth := passthroughBearerAuthorization(inbound); auth != "" {
+			if routed := openaiPassthroughRoute(auth, inbound.URL.Path); routed != nil {
+				upstreamURL = routed
+			}
+		}
+	}
 	upstreamURL.RawQuery = inbound.URL.RawQuery
 
 	req, err := http.NewRequestWithContext(ctx, inbound.Method, upstreamURL.String(), bytes.NewReader(body))
@@ -247,6 +261,96 @@ func passthroughBearerAuthorization(inbound *http.Request) string {
 		return ""
 	}
 	return prefix + token
+}
+
+// openaiPassthroughRoute decides which OpenAI upstream a passthrough request
+// should hit. ChatGPT-OAuth JWT bearers — JWTs whose scope claims don't
+// include api.responses.write — must be routed to
+// chatgpt.com/backend-api/codex/*; everything else (sk-* / sk-proj-* API
+// keys, JWTs with api.responses.write, unrecognized tokens) falls back to
+// api.openai.com/v1/*. Returns nil to mean "use default routing."
+//
+// The Authorization header argument is the full "Bearer <token>" string.
+// The path argument is the inbound request path (typically /v1/responses).
+func openaiPassthroughRoute(authorization, inboundPath string) *url.URL {
+	const prefix = "Bearer "
+	token := strings.TrimSpace(strings.TrimPrefix(authorization, prefix))
+	if token == "" {
+		return nil
+	}
+	// API keys: sk-* and sk-proj-* go to the API endpoint.
+	if strings.HasPrefix(token, "sk-") {
+		return nil
+	}
+	parts := strings.SplitN(token, ".", 3)
+	if len(parts) != 3 {
+		return nil
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		// Some JWT emitters use padded base64; tolerate that.
+		payload, err = base64.URLEncoding.DecodeString(parts[1])
+		if err != nil {
+			return nil
+		}
+	}
+	// Codex's access_token has scp as a JSON array; other OAuth providers
+	// emit space-separated strings. Decode both into json.RawMessage and
+	// normalize.
+	var claims struct {
+		Scp   json.RawMessage `json:"scp"`
+		Scope json.RawMessage `json:"scope"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return nil
+	}
+	if scopesIncludes(claims.Scp, "api.responses.write") || scopesIncludes(claims.Scope, "api.responses.write") {
+		return nil
+	}
+	// ChatGPT-OAuth JWT without api.responses.write: route to chatgpt.com.
+	// Path mapping: /v1/<rest> → /backend-api/codex/<rest>.
+	suffix := strings.TrimPrefix(inboundPath, "/v1")
+	if !strings.HasPrefix(suffix, "/") {
+		suffix = "/" + suffix
+	}
+	return &url.URL{
+		Scheme: "https",
+		Host:   "chatgpt.com",
+		Path:   "/backend-api/codex" + suffix,
+	}
+}
+
+// scopesIncludes checks for a target scope in either of the two shapes OAuth
+// providers emit: a space-separated string (RFC 6749 oauth2 standard) or a
+// JSON array of strings (what Codex's access_token uses).
+func scopesIncludes(raw json.RawMessage, want string) bool {
+	if len(raw) == 0 || want == "" {
+		return false
+	}
+	if raw[0] == '"' {
+		var s string
+		if err := json.Unmarshal(raw, &s); err != nil {
+			return false
+		}
+		for _, t := range strings.Fields(s) {
+			if t == want {
+				return true
+			}
+		}
+		return false
+	}
+	if raw[0] == '[' {
+		var list []string
+		if err := json.Unmarshal(raw, &list); err != nil {
+			return false
+		}
+		for _, t := range list {
+			if t == want {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func injectPassthroughOpenAIAuth(req *http.Request, authorization string) {

--- a/internal/runtime/llmproxy/forward_test.go
+++ b/internal/runtime/llmproxy/forward_test.go
@@ -3,6 +3,8 @@ package llmproxy
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -384,5 +386,99 @@ func TestCopyForwardableHeaders_StripsConnectionScoped(t *testing.T) {
 	}
 	if dst.Get("Authorization") != "" {
 		t.Errorf("Authorization (static skip) should still be stripped, got %q", dst.Get("Authorization"))
+	}
+}
+
+// makeJWT builds a syntactically-valid JWT with the given claims for routing
+// tests. Signature is not verified — the routing helper inspects claims only.
+func makeJWT(claims map[string]any) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+	payload, _ := json.Marshal(claims)
+	body := base64.RawURLEncoding.EncodeToString(payload)
+	sig := base64.RawURLEncoding.EncodeToString([]byte("sig"))
+	return header + "." + body + "." + sig
+}
+
+func TestOpenAIPassthroughRoute_APIKeyFallsBackToDefault(t *testing.T) {
+	if got := openaiPassthroughRoute("Bearer sk-abc123", "/v1/responses"); got != nil {
+		t.Errorf("sk-* API key must use default api.openai.com routing, got %s", got)
+	}
+	if got := openaiPassthroughRoute("Bearer sk-proj-abc123", "/v1/responses"); got != nil {
+		t.Errorf("sk-proj-* API key must use default routing, got %s", got)
+	}
+}
+
+func TestOpenAIPassthroughRoute_OAuthWithResponseScope(t *testing.T) {
+	// Space-separated string form (RFC 6749).
+	jwt := makeJWT(map[string]any{"scp": "api.responses.write other.scope"})
+	if got := openaiPassthroughRoute("Bearer "+jwt, "/v1/responses"); got != nil {
+		t.Errorf("OAuth bearer with api.responses.write scp (string) must use default routing, got %s", got)
+	}
+	// Array form (Codex's actual token format).
+	jwtArr := makeJWT(map[string]any{"scp": []string{"openid", "api.responses.write", "email"}})
+	if got := openaiPassthroughRoute("Bearer "+jwtArr, "/v1/responses"); got != nil {
+		t.Errorf("OAuth bearer with api.responses.write scp (array) must use default routing, got %s", got)
+	}
+	jwtScope := makeJWT(map[string]any{"scope": "api.responses.write"})
+	if got := openaiPassthroughRoute("Bearer "+jwtScope, "/v1/responses"); got != nil {
+		t.Errorf("OAuth bearer with api.responses.write scope must use default routing, got %s", got)
+	}
+}
+
+// Regression: Codex's access_token has scp as a JSON array. Earlier the
+// helper assumed scp was a space-separated string, so unmarshal failed and
+// we fell through to default routing (api.openai.com), which rejected the
+// bearer for missing api scopes.
+func TestOpenAIPassthroughRoute_CodexAccessTokenShape(t *testing.T) {
+	jwt := makeJWT(map[string]any{
+		"iss": "https://auth.openai.com",
+		"scp": []string{"openid", "profile", "email", "offline_access", "api.connectors.read", "api.connectors.invoke"},
+	})
+	got := openaiPassthroughRoute("Bearer "+jwt, "/v1/responses")
+	if got == nil {
+		t.Fatal("Codex-shaped access_token (scp as array without api.responses.write) must route to chatgpt.com")
+	}
+	if got.Host != "chatgpt.com" || got.Path != "/backend-api/codex/responses" {
+		t.Errorf("expected https://chatgpt.com/backend-api/codex/responses, got %s://%s%s", got.Scheme, got.Host, got.Path)
+	}
+}
+
+func TestOpenAIPassthroughRoute_ChatGPTOAuth(t *testing.T) {
+	jwt := makeJWT(map[string]any{
+		"scp":                 "openid email profile",
+		"chatgpt_account_id":  "acct_xyz",
+	})
+	got := openaiPassthroughRoute("Bearer "+jwt, "/v1/responses")
+	if got == nil {
+		t.Fatal("ChatGPT-OAuth bearer (no api.responses.write) must route to chatgpt.com")
+	}
+	if got.Host != "chatgpt.com" {
+		t.Errorf("expected chatgpt.com host, got %s", got.Host)
+	}
+	if got.Path != "/backend-api/codex/responses" {
+		t.Errorf("expected /backend-api/codex/responses, got %s", got.Path)
+	}
+	if got.Scheme != "https" {
+		t.Errorf("expected https scheme, got %s", got.Scheme)
+	}
+}
+
+func TestOpenAIPassthroughRoute_MalformedTokenFallsBack(t *testing.T) {
+	if got := openaiPassthroughRoute("Bearer not.a.jwt.too.many.dots", "/v1/responses"); got != nil {
+		t.Errorf("malformed token must fall back to default routing, got %s", got)
+	}
+	if got := openaiPassthroughRoute("Bearer notjwt", "/v1/responses"); got != nil {
+		t.Errorf("non-JWT non-API-key must fall back, got %s", got)
+	}
+	if got := openaiPassthroughRoute("", "/v1/responses"); got != nil {
+		t.Errorf("empty bearer must return nil, got %s", got)
+	}
+}
+
+func TestOpenAIPassthroughRoute_NonV1PathPreserved(t *testing.T) {
+	jwt := makeJWT(map[string]any{"scp": "openid"})
+	got := openaiPassthroughRoute("Bearer "+jwt, "/v1/chat/completions")
+	if got == nil || got.Path != "/backend-api/codex/chat/completions" {
+		t.Errorf("expected /backend-api/codex/chat/completions, got %v", got)
 	}
 }

--- a/pkg/clawvisor/defaults.go
+++ b/pkg/clawvisor/defaults.go
@@ -408,6 +408,7 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 	var ticketStore auth.TicketStorer
 	var replayCache middleware.ReplayCache
 	var tokenCache handlers.TokenCache
+	var claimCodeCache handlers.ClaimCodeCache
 	var devicePairingStore handlers.DevicePairingStore
 	var oauthStateStore handlers.OAuthStateStore
 	var pairingCodeStore handlers.PairingCodeStore
@@ -431,6 +432,7 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 		ticketStore = auth.NewRedisTicketStore(client)
 		replayCache = middleware.NewRedisReplayCache(client)
 		tokenCache = handlers.NewRedisTokenCache(client, 5*time.Minute)
+		claimCodeCache = handlers.NewRedisClaimCodeCache(client)
 		devicePairingStore = handlers.NewRedisDevicePairingStore(client)
 		oauthStateStore = handlers.NewRedisOAuthStateStore(client)
 		pairingCodeStore = handlers.NewRedisPairingCodeStore(client, 5*time.Minute, 3)
@@ -493,6 +495,7 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 		TicketStore:        ticketStore,
 		ReplayCache:        replayCache,
 		TokenCache:         tokenCache,
+		ClaimCodeCache:     claimCodeCache,
 		DevicePairingStore: devicePairingStore,
 		OAuthStateStore:    oauthStateStore,
 		PairingCodeStore:   pairingCodeStore,

--- a/pkg/clawvisor/options.go
+++ b/pkg/clawvisor/options.go
@@ -140,6 +140,7 @@ type ServerOptions struct {
 	TicketStore        intauth.TicketStorer
 	ReplayCache        middleware.ReplayCache
 	TokenCache         handlers.TokenCache
+	ClaimCodeCache     handlers.ClaimCodeCache
 	DevicePairingStore handlers.DevicePairingStore
 	OAuthStateStore    handlers.OAuthStateStore
 	PairingCodeStore   handlers.PairingCodeStore

--- a/pkg/clawvisor/run.go
+++ b/pkg/clawvisor/run.go
@@ -306,6 +306,9 @@ func RunWithContext(ctx context.Context, opts *ServerOptions) error {
 	if opts.TokenCache != nil {
 		apiOpts = append(apiOpts, api.WithTokenCache(opts.TokenCache))
 	}
+	if opts.ClaimCodeCache != nil {
+		apiOpts = append(apiOpts, api.WithClaimCodeCache(opts.ClaimCodeCache))
+	}
 	if opts.DevicePairingStore != nil {
 		apiOpts = append(apiOpts, api.WithDevicePairingStore(opts.DevicePairingStore))
 	}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1188,6 +1188,8 @@ export const api = {
       post<{ status: string; agent_id: string }>(`/api/agents/connect/${id}/approve`, {}),
     deny: (id: string) =>
       post<{ status: string }>(`/api/agents/connect/${id}/deny`, {}),
+    mintClaim: () =>
+      post<{ code: string; expires_at: string }>('/api/agents/connect/claim', {}),
   },
   services: {
     list: async () => {

--- a/web/src/pages/Agents.tsx
+++ b/web/src/pages/Agents.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { Fragment, useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { api, type Agent, type ApprovalRecord, type AgentRuntimeSettings, type AuditEntry, type RuntimePolicyRule, type RuntimeSession } from '../api/client'
@@ -133,7 +133,7 @@ export default function Agents() {
       </p>
 
       {/* Connect an Agent guide (personal context only) */}
-      {!orgId && <ConnectAgentGuide />}
+      {!orgId && <ConnectAgentGuide newToken={newToken} />}
 
       {/* Pending connection requests (personal context only) */}
       {!orgId && pending.length > 0 && (
@@ -670,15 +670,15 @@ function AgentRuntimePanel({ agentId, defaultOpen = false }: { agentId: string; 
 
 // ── Connect an Agent guide ───────────────────────────────────────────────────
 
-type AgentTab = 'openclaw' | 'claude-code' | 'claude-desktop' | 'other'
+type AgentTab = 'openclaw' | 'hermes' | 'claude-code' | 'codex' | 'claude-desktop' | 'other'
 
-const AGENT_TABS: AgentTab[] = ['openclaw', 'claude-code', 'claude-desktop', 'other']
+const AGENT_TABS: AgentTab[] = ['openclaw', 'hermes', 'claude-code', 'codex', 'claude-desktop', 'other']
 
-function ConnectAgentGuide() {
+function ConnectAgentGuide({ newToken }: { newToken: string | null }) {
   const [searchParams, setSearchParams] = useSearchParams()
   const initialTab = (AGENT_TABS.includes(searchParams.get('agent') as AgentTab)
     ? (searchParams.get('agent') as AgentTab)
-    : 'openclaw')
+    : 'claude-code')
   const [tab, setTabState] = useState<AgentTab>(initialTab)
   const setTab = (next: AgentTab) => {
     setTabState(next)
@@ -686,12 +686,28 @@ function ConnectAgentGuide() {
     params.set('agent', next)
     setSearchParams(params, { replace: true })
   }
+  // `?mode=skill` opens each tab with its skill-based escape hatch expanded
+  // by default — useful for support / docs deep links. Otherwise tabs lead
+  // with the proxy-lite (passthrough or vaulted) setup.
+  const showSkillDefault = searchParams.get('mode') === 'skill'
   const [copied, setCopied] = useState(false)
   const { user } = useAuth()
 
   const { data: pairInfo } = useQuery({
     queryKey: ['pairInfo'],
     queryFn: () => api.devices.pairInfo(),
+  })
+
+  // Mint a single-use claim code so the bootstrap curl never has to embed
+  // the user's ID. BootstrapApproveStep invalidates this query after the
+  // claim is consumed (via the inline Approve mutation) so re-bootstrapping
+  // in the same session always has a fresh code. Codes expire server-side
+  // at claimCodeTTL (5 min); refetch every 4 min to keep the visible curl warm.
+  const { data: claim } = useQuery({
+    queryKey: ['connection-claim'],
+    queryFn: () => api.connections.mintClaim(),
+    refetchInterval: 4 * 60 * 1000,
+    staleTime: 4 * 60 * 1000,
   })
 
   const isLocal = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1'
@@ -719,8 +735,10 @@ function ConnectAgentGuide() {
   }
 
   const tabs: { id: AgentTab; label: string }[] = [
-    { id: 'openclaw', label: 'OpenClaw / Hermes' },
+    { id: 'openclaw', label: 'OpenClaw' },
+    { id: 'hermes', label: 'Hermes' },
     { id: 'claude-code', label: 'Claude Code' },
+    { id: 'codex', label: 'Codex' },
     { id: 'claude-desktop', label: 'Claude Desktop' },
     { id: 'other', label: 'Other Agents' },
   ]
@@ -752,10 +770,12 @@ function ConnectAgentGuide() {
       </div>
 
       <div className="p-5">
-        {tab === 'openclaw' && <OpenClawGuide setupURL={setupURL} copied={copied} onCopy={copyText} />}
-        {tab === 'claude-code' && <ClaudeCodeGuide clawvisorURL={clawvisorURL} userIdParam={userIdParam} onCopy={copyText} />}
-        {tab === 'claude-desktop' && <ClaudeDesktopGuide isLocal={isLocal} onCopy={copyText} />}
-        {tab === 'other' && <OtherAgentGuide setupURL={setupURL} clawvisorURL={clawvisorURL} copied={copied} onCopy={copyText} />}
+        {tab === 'openclaw' && <OpenClawGuide setupURL={setupURL} clawvisorURL={clawvisorURL} claim={claim?.code} newToken={newToken} copied={copied} onCopy={copyText} showSkillDefault={showSkillDefault} />}
+        {tab === 'hermes' && <HermesGuide clawvisorURL={clawvisorURL} claim={claim?.code} newToken={newToken} onCopy={copyText} />}
+        {tab === 'claude-code' && <ClaudeCodeGuide clawvisorURL={clawvisorURL} claim={claim?.code} userIdParam={userIdParam} newToken={newToken} onCopy={copyText} showSkillDefault={showSkillDefault} />}
+        {tab === 'codex' && <CodexGuide clawvisorURL={clawvisorURL} claim={claim?.code} newToken={newToken} onCopy={copyText} />}
+        {tab === 'claude-desktop' && <ClaudeDesktopGuide clawvisorURL={clawvisorURL} claim={claim?.code} newToken={newToken} isLocal={isLocal} onCopy={copyText} showSkillDefault={showSkillDefault} />}
+        {tab === 'other' && <OtherAgentGuide setupURL={setupURL} clawvisorURL={clawvisorURL} claim={claim?.code} newToken={newToken} copied={copied} onCopy={copyText} showSkillDefault={showSkillDefault} />}
       </div>
     </section>
   )
@@ -799,278 +819,938 @@ function CodeBlock({ children, onCopy }: { children: string; onCopy?: () => void
   )
 }
 
-function ClaudeCodeGuide({ clawvisorURL, userIdParam, onCopy }: {
-  clawvisorURL: string
-  userIdParam: string
-  onCopy: (text: string) => void
-}) {
-  const installCmd = `curl -sf "${clawvisorURL}/skill/clawvisor-setup.md${userIdParam}" \\\n  --create-dirs -o ~/.claude/commands/clawvisor-setup.md`
-
-  return (
-    <div className="space-y-5">
-      <p className="text-sm text-text-secondary">
-        Install a slash command, then run it in Claude Code. It handles agent registration,
-        skill installation, environment setup, and a smoke test — all interactively.
-      </p>
-
-      <div className="flex items-start gap-3">
-        <StepNumber n={1} />
-        <div className="space-y-1.5 min-w-0 flex-1">
-          <p className="text-sm font-medium text-text-primary">Install the setup command</p>
-          <p className="text-xs text-text-tertiary">
-            Run this in your terminal to install the{' '}
-            <code className="font-mono text-text-secondary">/clawvisor-setup</code> slash command:
-          </p>
-          <CodeBlock onCopy={() => onCopy(installCmd)}>{installCmd}</CodeBlock>
-        </div>
-      </div>
-
-      <div className="flex items-start gap-3">
-        <StepNumber n={2} />
-        <div className="space-y-1.5 min-w-0 flex-1">
-          <p className="text-sm font-medium text-text-primary">Run /clawvisor-setup in Claude Code</p>
-          <p className="text-xs text-text-tertiary">
-            Open Claude Code and type{' '}
-            <code className="font-mono text-text-secondary">/clawvisor-setup</code>.
-            Claude will walk you through the setup — registering as an agent, configuring
-            environment variables, and verifying the connection.
-          </p>
-        </div>
-      </div>
-
-      <div className="flex items-start gap-3">
-        <StepNumber n={3} />
-        <div className="space-y-1.5 min-w-0 flex-1">
-          <p className="text-sm font-medium text-text-primary">Approve the connection</p>
-          <p className="text-xs text-text-tertiary">
-            During setup, Claude Code sends a connection request. Approve it in the{' '}
-            <strong>Pending Connections</strong> section above. Once approved, Claude Code
-            finishes setup automatically and runs a smoke test.
-          </p>
-        </div>
-      </div>
-    </div>
-  )
+// Restrict agent names to characters that round-trip cleanly through a
+// filesystem path, a shell single-quoted JSON body, and a URL. Spaces
+// become dashes; other characters drop. Matches the daemon's collision
+// check by exact-string equality, so what the user types is what the
+// daemon stores.
+function sanitizeAgentName(input: string): string {
+  return input
+    .replace(/\s+/g, '-')
+    .replace(/[^a-zA-Z0-9_.-]/g, '')
+    .slice(0, 64)
 }
 
-function ClaudeDesktopGuide({ isLocal, onCopy }: { isLocal: boolean; onCopy: (text: string) => void }) {
-  const marketplaceSlug = 'clawvisor/cowork-plugins'
-  const pluginLabel = isLocal ? 'Clawvisor Local' : 'Clawvisor'
-
-  return (
-    <div className="space-y-5">
-      <p className="text-sm text-text-secondary">
-        {isLocal
-          ? 'Connect Claude Cowork to your local Clawvisor instance via the Cowork plugin.'
-          : 'Connect Claude Cowork to your Clawvisor cloud account via the Cowork plugin.'}
-      </p>
-
-      <div className="flex items-start gap-3">
-        <StepNumber n={1} />
-        <div className="space-y-1.5 min-w-0 flex-1">
-          <p className="text-sm font-medium text-text-primary">Open the plugin manager</p>
-          <p className="text-xs text-text-tertiary">
-            In Claude Desktop, navigate to <strong>Claude Cowork</strong>, click{' '}
-            <strong>Customize</strong> in the sidebar, then press the <strong>+</strong> next to{' '}
-            <strong>Personal plugins</strong>.
-          </p>
-        </div>
-      </div>
-
-      <div className="flex items-start gap-3">
-        <StepNumber n={2} />
-        <div className="space-y-1.5 min-w-0 flex-1">
-          <p className="text-sm font-medium text-text-primary">Add the marketplace</p>
-          <p className="text-xs text-text-tertiary">
-            Under <strong>Create plugin</strong>, select <strong>Add marketplace</strong> and paste:
-          </p>
-          <CodeBlock onCopy={() => onCopy(marketplaceSlug)}>{marketplaceSlug}</CodeBlock>
-        </div>
-      </div>
-
-      <div className="flex items-start gap-3">
-        <StepNumber n={3} />
-        <div className="space-y-1.5 min-w-0 flex-1">
-          <p className="text-sm font-medium text-text-primary">Install the {pluginLabel} plugin</p>
-          <p className="text-xs text-text-tertiary">
-            Open the <strong>Personal</strong> tab, switch to the <strong>cowork-plugins</strong> tab,
-            then select <strong>{pluginLabel}</strong> to install.
-          </p>
-        </div>
-      </div>
-
-      {!isLocal && (
-        <div className="flex items-start gap-3">
-          <StepNumber n={4} />
-          <div className="space-y-1.5 min-w-0 flex-1">
-            <p className="text-sm font-medium text-text-primary">Connect the Clawvisor connector</p>
-            <p className="text-xs text-text-tertiary">
-              Under the <strong>Clawvisor</strong> plugin, select <strong>Connectors</strong>, click the{' '}
-              <strong>clawvisor</strong> connector, and connect. Authorize Claude Cowork in your browser
-              when prompted.
-            </p>
-          </div>
-        </div>
-      )}
-
-      <div className="flex items-start gap-3">
-        <StepNumber n={isLocal ? 4 : 5} />
-        <div className="space-y-1.5 min-w-0 flex-1">
-          <p className="text-sm font-medium text-text-primary">Start using it</p>
-          <p className="text-xs text-text-tertiary">
-            Create a new Claude Cowork session and ask your agent to use a connected account via
-            Clawvisor — e.g. "check my Gmail" or "list my GitHub issues." Claude will create a task,
-            ask you to approve, and execute through Clawvisor.{' '}
-            {isLocal &&
-              <>Open the dashboard with <code className="font-mono text-text-secondary">clawvisor tui</code> or visit <code className="font-mono text-text-secondary">http://localhost:25297</code> to manage services, approvals, and restrictions.</>
-            }
-          </p>
-        </div>
-      </div>
-    </div>
-  )
+// Resolve a collision-free version of base by trying base, base-0,
+// base-1, … against the agents list. Returns base itself when no
+// existing agent matches.
+function nextAvailableName(base: string, agents: Agent[] | undefined): string {
+  if (!agents) return base
+  const taken = new Set(agents.map(a => a.name))
+  if (!taken.has(base)) return base
+  for (let i = 0; i < 1000; i++) {
+    const candidate = `${base}-${i}`
+    if (!taken.has(candidate)) return candidate
+  }
+  // Fallback for the absurd case of 1000 agents with the same base. The
+  // dashboard would have other problems by this point.
+  return `${base}-${Date.now()}`
 }
 
-function OpenClawGuide({ setupURL, copied, onCopy }: {
-  setupURL: string
-  copied: boolean
-  onCopy: (text: string) => void
-}) {
-  const prompt = `Please install Clawvisor. It's a security gateway between you and external services like Gmail, Slack, and GitHub. You don't hold any API keys directly; instead, you make requests through Clawvisor and I approve which actions you can take. Every call is logged, and I can revoke access at any time.\n\nSetup is just registering an agent token and installing a skill that teaches you how to use it. I'll review each step before it happens.\n\nInstructions: ${setupURL}`
+// useSequencedAgentName initializes agentName to a collision-free variant
+// of base. It only runs once per mount — subsequent user typing controls
+// the value, even if the user types a name that already exists.
+function useSequencedAgentName(base: string, agents: Agent[] | undefined): [string, (n: string) => void] {
+  const [name, setName] = useState(base)
+  const sequenced = useRef(false)
+  useEffect(() => {
+    if (sequenced.current || !agents) return
+    sequenced.current = true
+    const next = nextAvailableName(base, agents)
+    if (next !== base) setName(next)
+  }, [agents, base])
+  return [name, setName]
+}
 
+function buildBootstrapCommand(clawvisorURL: string, claim: string | undefined, agentName: string): string {
+  // Name and claim ride on the URL so the curl is body-less — no -H, no -d.
+  // The claim code (minted by an authenticated dashboard session) attributes
+  // this curl to the user without leaking user_id into the URL. mkdir + chmod
+  // bracket the curl so the file lands with tight perms; -sf makes curl exit
+  // non-zero without overwriting the file on a 4xx (duplicate-name 409,
+  // expired-claim 401, etc.) so retries don't clobber a previously-good file.
+  const claimParam = claim ? `&claim=${claim}` : ''
+  return `mkdir -p ~/.clawvisor/agents && curl -sf -X POST \\
+  "${clawvisorURL}/api/agents/connect?wait=true&name=${agentName}${claimParam}" \\
+  -o ~/.clawvisor/agents/${agentName}.json \\
+  && chmod 600 ~/.clawvisor/agents/${agentName}.json`
+}
+
+// ── Wizard primitives ────────────────────────────────────────────────────────
+//
+// Each per-harness guide renders a small wizard with 2-3 steps. The shared
+// scaffolding (StepBar, WizardNav) keeps the per-guide implementations short
+// and consistent. Steps are tracked by integer index; completion of an earlier
+// step is observable (agent exists, key vaulted) so the bar reflects real
+// progress rather than just clicks.
+
+type WizardStepDef = { id: string; title: string; done: boolean }
+
+function StepBar({ steps, activeIndex }: { steps: WizardStepDef[]; activeIndex: number }) {
   return (
-    <div className="space-y-5">
-      <p className="text-sm text-text-secondary">
-        Connect your agent to Clawvisor. Paste the setup prompt below into your agent — it will self-register and wait for your approval.
-      </p>
-
-      <div className="space-y-4">
-        <div className="flex items-start gap-3">
-          <StepNumber n={1} />
-          <div className="space-y-1.5 min-w-0 flex-1">
-            <p className="text-sm font-medium text-text-primary">Paste this into your agent</p>
-            <div className="relative group bg-surface-0 border border-brand/20 rounded overflow-hidden">
-              <pre className="px-3 py-2.5 sm:pr-16 text-xs font-mono text-text-primary overflow-x-auto whitespace-pre-wrap break-words">
-                {prompt}
-              </pre>
-              <button
-                onClick={() => onCopy(prompt)}
-                className="hidden sm:block absolute top-2 right-2 text-xs px-2 py-1 rounded border border-border-subtle text-text-tertiary hover:text-text-primary hover:bg-surface-1"
-              >
-                {copied ? 'Copied' : 'Copy'}
-              </button>
-              <div className="sm:hidden border-t border-brand/20 px-3 py-1.5 flex justify-end">
-                <button
-                  onClick={() => onCopy(prompt)}
-                  className="text-xs px-2.5 py-1 rounded border border-border-subtle text-text-tertiary hover:text-text-primary hover:bg-surface-1"
-                >
-                  {copied ? 'Copied' : 'Copy'}
-                </button>
+    <ol className="inline-flex items-center gap-2 text-xs">
+      {steps.map((s, i) => {
+        const isActive = i === activeIndex
+        const isDone = s.done
+        const circleClass = isDone
+          ? 'bg-brand text-surface-0 border-brand'
+          : isActive
+            ? 'bg-surface-0 text-brand border-brand ring-2 ring-brand/30'
+            : 'bg-surface-0 text-text-tertiary border-border-default'
+        const labelClass = isActive ? 'text-text-primary font-medium' : 'text-text-tertiary'
+        return (
+          <Fragment key={s.id}>
+            {i > 0 && (
+              <div className={`h-px w-6 ${steps[i - 1].done ? 'bg-brand' : 'bg-border-default'}`} />
+            )}
+            <li className="flex items-center gap-2 whitespace-nowrap">
+              <div className={`w-5 h-5 rounded-full flex items-center justify-center text-[10px] font-bold border transition-colors ${circleClass}`}>
+                {i + 1}
               </div>
-            </div>
-            <p className="text-xs text-text-tertiary">
-              Your agent will follow the setup instructions — registering itself
-              and installing the Clawvisor skill.
-            </p>
-          </div>
-        </div>
+              <span className={labelClass}>{s.title}</span>
+            </li>
+          </Fragment>
+        )
+      })}
+    </ol>
+  )
+}
 
-        <div className="flex items-start gap-3">
-          <StepNumber n={2} />
-          <div className="space-y-1.5 min-w-0 flex-1">
-            <p className="text-sm font-medium text-text-primary">Approve the connection</p>
-            <p className="text-xs text-text-tertiary">
-              A connection request will appear in the <strong>Pending Connections</strong> section above.
-              Click <strong>Approve</strong> to grant the agent a token. It receives the token automatically
-              and is ready to go.
-            </p>
-          </div>
-        </div>
+function WizardNav({
+  canBack, canNext, onBack, onNext, onSkip,
+  nextLabel = 'Next', skipLabel = 'Skip', nextDisabledHint,
+}: {
+  canBack: boolean
+  canNext: boolean
+  onBack: () => void
+  onNext: () => void
+  onSkip?: () => void
+  nextLabel?: string
+  skipLabel?: string
+  nextDisabledHint?: string
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3 pt-4 mt-4 border-t border-border-subtle">
+      <div>
+        {canBack && (
+          <button
+            onClick={onBack}
+            className="text-sm text-text-secondary hover:text-text-primary"
+          >
+            ← Back
+          </button>
+        )}
       </div>
+      <div className="flex items-center gap-4">
+        {!canNext && nextDisabledHint && (
+          <span className="text-xs text-text-tertiary">{nextDisabledHint}</span>
+        )}
+        {onSkip && (
+          <button
+            onClick={onSkip}
+            className="text-sm text-text-secondary hover:text-text-primary"
+          >
+            {skipLabel}
+          </button>
+        )}
+        <button
+          onClick={onNext}
+          disabled={!canNext}
+          className="bg-brand text-surface-0 font-medium rounded px-4 py-1.5 text-sm hover:bg-brand-strong disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {nextLabel}
+        </button>
+      </div>
+    </div>
+  )
+}
 
-      {/* Telegram tip */}
-      <div className="bg-surface-0 border border-border-subtle rounded-md px-4 py-3">
-        <p className="text-sm text-text-secondary">
-          <strong>Using Telegram?</strong> If you talk to your agent via Telegram, you can set up a
-          group chat with Clawvisor to get inline approval notifications and auto-approvals.{' '}
-          <a href="/dashboard/settings" className="text-brand hover:underline">Set it up in Settings &rarr; Telegram</a>.
+// BootstrapApproveStep handles step 1 for every harness: name input, the
+// bootstrap curl, and (when the curl runs) inline Approve / Deny buttons for
+// the pending connection request — so the user never has to scroll up to the
+// Pending Connections card. Completion is detected via the existing
+// ['agents'] query: the step becomes done when an agent matching the chosen
+// name exists.
+function BootstrapApproveStep({
+  clawvisorURL, claim, agentName, setAgentName, onCopy, onAdvance,
+}: {
+  clawvisorURL: string
+  claim: string | undefined
+  agentName: string
+  setAgentName: (n: string) => void
+  onCopy: (text: string) => void
+  onAdvance: (agentId: string) => void
+}) {
+  const qc = useQueryClient()
+  const { data: connections } = useQuery({
+    queryKey: ['connections'],
+    queryFn: () => api.connections.list(),
+    refetchInterval: 3000,
+  })
+  const { data: agents } = useQuery({
+    queryKey: ['agents', 'personal'],
+    queryFn: () => api.agents.list(),
+    refetchInterval: 3000,
+  })
+
+  const myAgent = useMemo(
+    () => agents?.find(a => a.name === agentName),
+    [agents, agentName],
+  )
+  const myPending = useMemo(
+    () => connections?.find(c => c.name === agentName && c.status === 'pending'),
+    [connections, agentName],
+  )
+
+  const [actionError, setActionError] = useState<string | null>(null)
+  const approveMut = useMutation({
+    mutationFn: (id: string) => api.connections.approve(id),
+    onSuccess: (data) => {
+      qc.invalidateQueries({ queryKey: ['connections'] })
+      qc.invalidateQueries({ queryKey: ['agents', 'personal'] })
+      qc.invalidateQueries({ queryKey: ['agents'] })
+      qc.invalidateQueries({ queryKey: ['welcome'] })
+      qc.invalidateQueries({ queryKey: ['overview'] })
+      // Claim is consumed once the curl POSTs; re-mint so a follow-up
+      // bootstrap in this session always has a fresh code.
+      qc.invalidateQueries({ queryKey: ['connection-claim'] })
+      if (data.agent_id) onAdvance(data.agent_id)
+    },
+    onError: (err: Error) => setActionError(err.message),
+  })
+  const denyMut = useMutation({
+    mutationFn: (id: string) => api.connections.deny(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['connections'] })
+      qc.invalidateQueries({ queryKey: ['overview'] })
+    },
+    onError: (err: Error) => setActionError(err.message),
+  })
+
+  const bootstrapCmd = buildBootstrapCommand(clawvisorURL, claim, agentName)
+  const filePath = `~/.clawvisor/agents/${agentName}.json`
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <label className="text-xs uppercase tracking-wider text-text-tertiary">Name this agent</label>
+        <input
+          type="text"
+          value={agentName}
+          onChange={e => setAgentName(sanitizeAgentName(e.target.value))}
+          disabled={!!myPending}
+          className="mt-1 block w-full max-w-xs text-sm font-mono rounded border border-border-default bg-surface-0 text-text-primary px-3 py-1.5 focus:outline-none focus:ring-1 focus:ring-brand/30 focus:border-brand disabled:opacity-60"
+        />
+        <p className="text-xs text-text-tertiary mt-1">
+          Determines both the agent's name in Clawvisor and the on-disk file:{' '}
+          <code className="font-mono text-text-secondary">{filePath}</code>
+          {myAgent && !myPending && (
+            <span className="ml-1 text-warning">— an agent with this name already exists; pick a different name to bootstrap a fresh one, or reuse it below.</span>
+          )}
         </p>
       </div>
+
+      <div className="space-y-1.5">
+        <p className="text-sm font-medium text-text-primary">Run this in your terminal</p>
+        <CodeBlock onCopy={() => onCopy(bootstrapCmd)}>{bootstrapCmd}</CodeBlock>
+      </div>
+
+      {myPending ? (
+        <div className="rounded border border-brand/30 bg-brand/5 px-4 py-3 space-y-2">
+          <div>
+            <p className="text-sm font-medium text-text-primary">Connection request received.</p>
+            <p className="text-xs text-text-secondary mt-1">
+              From <code className="font-mono">{myPending.ip_address}</code> ·{' '}
+              requested {formatDistanceToNow(new Date(myPending.created_at), { addSuffix: true })}.
+              Approve to release the curl with a fresh token.
+            </p>
+          </div>
+          {actionError && <p className="text-xs text-danger">{actionError}</p>}
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => { setActionError(null); approveMut.mutate(myPending.id) }}
+              disabled={approveMut.isPending || denyMut.isPending}
+              className="bg-brand text-surface-0 font-medium rounded px-4 py-1.5 text-sm hover:bg-brand-strong disabled:opacity-50"
+            >
+              {approveMut.isPending ? 'Approving…' : 'Approve'}
+            </button>
+            <button
+              onClick={() => { setActionError(null); denyMut.mutate(myPending.id) }}
+              disabled={approveMut.isPending || denyMut.isPending}
+              className="rounded px-4 py-1.5 text-sm font-medium bg-danger/10 text-danger border border-danger/20 hover:bg-danger/20 disabled:opacity-50"
+            >
+              Deny
+            </button>
+          </div>
+        </div>
+      ) : myAgent ? (
+        <div className="rounded border border-border-default bg-surface-0 px-4 py-3 space-y-2">
+          <p className="text-sm text-text-secondary">
+            Reuse the existing agent (token still on disk if you previously bootstrapped this name), or rename to bootstrap a fresh one.
+          </p>
+          <button
+            onClick={() => onAdvance(myAgent.id)}
+            className="bg-brand text-surface-0 font-medium rounded px-4 py-1.5 text-sm hover:bg-brand-strong"
+          >
+            Use existing “{myAgent.name}”
+          </button>
+        </div>
+      ) : (
+        <p className="text-xs text-text-tertiary">
+          Waiting for you to run the curl above. Once it lands, an Approve button shows up right here.
+        </p>
+      )}
     </div>
   )
 }
 
-function OtherAgentGuide({ setupURL, clawvisorURL, copied, onCopy }: {
-  setupURL: string
+// VaultKeyStep collects the upstream Anthropic / OpenAI key that the proxy
+// swaps in when forwarding requests for swap-mode harnesses. Completion
+// requires at least one provider to have a key stored (user-level OR
+// agent-scoped). The user can also skip if they've vaulted the key
+// elsewhere (or via the agent detail page) — but the step warns them.
+function VaultKeyStep({ agentId }: { agentId: string }) {
+  const qc = useQueryClient()
+  const [editingProvider, setEditingProvider] = useState<string | null>(null)
+  const [apiKey, setApiKey] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  const { data: creds } = useQuery({
+    queryKey: ['llm-credentials', agentId],
+    queryFn: () => api.llmCredentials.list(agentId),
+  })
+
+  const setMut = useMutation({
+    mutationFn: (params: { provider: string; key: string }) =>
+      api.llmCredentials.set(params.provider, params.key, agentId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['llm-credentials', agentId] })
+      setEditingProvider(null)
+      setApiKey('')
+      setError(null)
+    },
+    onError: (err: Error) => setError(err.message),
+  })
+
+  return (
+    <div className="space-y-3">
+      <p className="text-sm text-text-secondary">
+        Clawvisor swaps your <code className="font-mono">cvis_…</code> token for an upstream
+        Anthropic or OpenAI key on each call. Vault at least one key — either now (agent-scoped)
+        or globally on the <a href="/dashboard/credentials" className="text-brand hover:underline">Credentials</a> page.
+      </p>
+
+      {error && <p className="text-xs text-danger">{error}</p>}
+
+      {creds?.credentials.map(c => (
+        <div key={c.provider} className="rounded border border-border-default bg-surface-1 p-3 space-y-2">
+          <div className="flex items-center justify-between">
+            <div>
+              <div className="text-sm font-medium text-text-primary capitalize">{c.provider}</div>
+              <div className="text-xs text-text-tertiary mt-0.5">
+                {c.agent_stored ? (
+                  <span className="text-success">Agent-scoped key set</span>
+                ) : c.stored ? (
+                  <span className="text-success">Using user-level key</span>
+                ) : (
+                  <span className="text-warning">No key configured</span>
+                )}
+              </div>
+            </div>
+            <button
+              onClick={() => { setEditingProvider(c.provider); setApiKey(''); setError(null) }}
+              className="text-xs px-3 py-1 rounded border border-brand/30 text-brand hover:bg-brand/10"
+            >
+              {c.agent_stored ? 'Replace' : c.stored ? 'Override for this agent' : 'Set key'}
+            </button>
+          </div>
+          {editingProvider === c.provider && (
+            <div className="space-y-2 pt-2 border-t border-border-subtle">
+              <input
+                type="password"
+                value={apiKey}
+                onChange={e => { setApiKey(e.target.value); setError(null) }}
+                placeholder={c.provider === 'anthropic' ? 'sk-ant-...' : 'sk-...'}
+                className="block w-full text-sm rounded border border-border-default bg-surface-0 text-text-primary px-3 py-1.5 focus:outline-none focus:ring-1 focus:ring-brand/30 focus:border-brand placeholder:text-text-tertiary"
+              />
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={() => { if (!apiKey) { setError('API key is required'); return } setMut.mutate({ provider: c.provider, key: apiKey }) }}
+                  disabled={setMut.isPending || !apiKey}
+                  className="px-3 py-1 text-xs rounded bg-brand text-surface-0 hover:bg-brand-strong disabled:opacity-50"
+                >
+                  {setMut.isPending ? 'Saving…' : 'Save'}
+                </button>
+                <button
+                  onClick={() => { setEditingProvider(null); setApiKey(''); setError(null) }}
+                  className="text-xs text-text-tertiary hover:text-text-primary"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// Whether the upstream-key step is satisfied: at least one provider has a key
+// available, whether scoped to this agent or inherited from the user.
+function hasAnyUpstreamKey(creds: { credentials: { stored: boolean; agent_stored?: boolean }[] } | undefined): boolean {
+  if (!creds) return false
+  return creds.credentials.some(c => c.stored || c.agent_stored)
+}
+
+function ClaudeCodeGuide({ clawvisorURL, claim, userIdParam, newToken, onCopy, showSkillDefault }: {
   clawvisorURL: string
-  copied: boolean
+  claim: string | undefined
+  userIdParam: string
+  newToken: string | null
   onCopy: (text: string) => void
+  showSkillDefault: boolean
 }) {
-  const prompt = `Please install Clawvisor. It's a security gateway between you and external services like Gmail, Slack, and GitHub. You don't hold any API keys directly; instead, you make requests through Clawvisor and I approve which actions you can take. Every call is logged, and I can revoke access at any time.\n\nSetup is just registering an agent token and installing a skill that teaches you how to use it. I'll review each step before it happens.\n\nInstructions: ${setupURL}`
+  const [step, setStep] = useState(0)
+  const { data: agents } = useQuery({
+    queryKey: ['agents', 'personal'],
+    queryFn: () => api.agents.list(),
+    refetchInterval: 3000,
+  })
+  const [agentName, setAgentName] = useSequencedAgentName('claude-code', agents)
+  const connected = !!agents?.find(a => a.name === agentName)
+
+  const jsonPath = `~/.clawvisor/agents/${agentName}.json`
+  const runCmd = `ANTHROPIC_BASE_URL=${clawvisorURL} \\
+ANTHROPIC_CUSTOM_HEADERS="X-Clawvisor-Agent-Token: $(jq -r .token ${jsonPath})" \\
+ANTHROPIC_AUTH_TOKEN= ANTHROPIC_API_KEY= \\
+claude`
+  const zshrcSnippet = `cat >> ~/.zshrc <<'EOF'
+claude-cv() {
+  ANTHROPIC_BASE_URL=${clawvisorURL} \\
+  ANTHROPIC_CUSTOM_HEADERS="X-Clawvisor-Agent-Token: $(jq -r .token ${jsonPath})" \\
+  ANTHROPIC_AUTH_TOKEN= ANTHROPIC_API_KEY= \\
+  claude "$@"
+}
+EOF`
+  const tokenValue = newToken ?? 'cvis_<your-token>'
+  const manualRunCmd = `ANTHROPIC_BASE_URL=${clawvisorURL} \\
+ANTHROPIC_CUSTOM_HEADERS='X-Clawvisor-Agent-Token: ${tokenValue}' \\
+ANTHROPIC_AUTH_TOKEN= ANTHROPIC_API_KEY= \\
+claude`
+  const installCmd = `curl -sf "${clawvisorURL}/skill/clawvisor-setup.md${userIdParam}" \\\n  --create-dirs -o ~/.claude/commands/clawvisor-setup.md`
+
+  const wizardSteps: WizardStepDef[] = [
+    { id: 'bootstrap', title: 'Bootstrap agent', done: connected },
+    { id: 'use', title: 'Run Claude Code', done: step > 1 },
+  ]
 
   return (
     <div className="space-y-5">
       <p className="text-sm text-text-secondary">
-        Any agent that can make HTTP requests can connect to Clawvisor. The fastest way is to paste the setup
-        prompt below directly into your agent's chat — it will self-register and wait for your approval.
+        Claude Code runs in <strong>passthrough mode</strong>: your existing Anthropic login
+        (subscription or API key) authenticates upstream, and Clawvisor only identifies the
+        agent. Two steps — bootstrap, then run.
       </p>
 
-      <div className="space-y-4">
-        <div className="flex items-start gap-3">
-          <StepNumber n={1} />
-          <div className="space-y-1.5 min-w-0 flex-1">
-            <p className="text-sm font-medium text-text-primary">Paste this into your agent</p>
-            <div className="relative group bg-surface-0 border border-brand/20 rounded overflow-hidden">
-              <pre className="px-3 py-2.5 sm:pr-16 text-xs font-mono text-text-primary overflow-x-auto whitespace-pre-wrap break-words">
-                {prompt}
-              </pre>
-              <button
-                onClick={() => onCopy(prompt)}
-                className="hidden sm:block absolute top-2 right-2 text-xs px-2 py-1 rounded border border-border-subtle text-text-tertiary hover:text-text-primary hover:bg-surface-1"
-              >
-                {copied ? 'Copied' : 'Copy'}
-              </button>
-              <div className="sm:hidden border-t border-brand/20 px-3 py-1.5 flex justify-end">
-                <button
-                  onClick={() => onCopy(prompt)}
-                  className="text-xs px-2.5 py-1 rounded border border-border-subtle text-text-tertiary hover:text-text-primary hover:bg-surface-1"
-                >
-                  {copied ? 'Copied' : 'Copy'}
-                </button>
-              </div>
-            </div>
-            <p className="text-xs text-text-tertiary">
-              The agent will follow the setup instructions at that URL — it registers itself,
-              sets up E2E encryption, and installs the Clawvisor skill.
-            </p>
-          </div>
-        </div>
+      <div className="rounded-md border border-border-default bg-surface-1 px-4 py-5 space-y-4">
+        <StepBar steps={wizardSteps} activeIndex={step} />
 
-        <div className="flex items-start gap-3">
-          <StepNumber n={2} />
-          <div className="space-y-1.5 min-w-0 flex-1">
-            <p className="text-sm font-medium text-text-primary">Approve the connection</p>
-            <p className="text-xs text-text-tertiary">
-              A connection request will appear in the <strong>Pending Connections</strong> section above.
-              Click <strong>Approve</strong> to grant the agent a token. It receives the token automatically
-              and is ready to go.
-            </p>
+      {step === 0 && (
+        <BootstrapApproveStep
+          clawvisorURL={clawvisorURL}
+          claim={claim}
+          agentName={agentName}
+          setAgentName={setAgentName}
+          onCopy={onCopy}
+          onAdvance={() => setStep(1)}
+        />
+      )}
+
+      {step === 1 && (
+        <>
+          <div className="space-y-3">
+            <div className="space-y-1.5">
+              <p className="text-sm font-medium text-text-primary">Run Claude Code through Clawvisor</p>
+              <CodeBlock onCopy={() => onCopy(runCmd)}>{runCmd}</CodeBlock>
+              <p className="text-xs text-text-tertiary">
+                Needs <code className="font-mono text-text-secondary">jq</code> (<code className="font-mono text-text-secondary">brew install jq</code> on macOS).
+              </p>
+            </div>
+
+            <details className="group">
+              <summary className="text-sm font-medium text-text-secondary cursor-pointer hover:text-text-primary select-none">
+                Optional: persist as a shell function (naked <code className="font-mono">claude-cv</code> works)
+              </summary>
+              <div className="mt-3 space-y-1.5">
+                <CodeBlock onCopy={() => onCopy(zshrcSnippet)}>{zshrcSnippet}</CodeBlock>
+                <p className="text-xs text-text-tertiary">
+                  After running, open a new shell or <code className="font-mono text-text-secondary">source ~/.zshrc</code>.
+                  The function re-reads the JSON on every call.
+                </p>
+              </div>
+            </details>
           </div>
+          <WizardNav
+            canBack
+            canNext
+            onBack={() => setStep(0)}
+            onNext={() => setStep(2)}
+            nextLabel="Done"
+          />
+        </>
+      )}
+
+      {step >= 2 && (
+        <div className="rounded border border-success/30 bg-success/10 px-4 py-3">
+          <p className="text-sm font-medium text-success">All set.</p>
+          <p className="text-xs text-text-secondary mt-1">
+            Re-run the curl any time you need to rotate the token (pick the same name).
+          </p>
+          <button
+            onClick={() => setStep(1)}
+            className="mt-2 text-xs text-brand hover:underline"
+          >
+            Show the run command again
+          </button>
         </div>
+      )}
       </div>
 
-      {/* Manual path */}
       <details className="group">
         <summary className="text-sm font-medium text-text-secondary cursor-pointer hover:text-text-primary select-none">
-          Manual setup (token + environment variables)
+          Manual setup (env vars without an on-disk file)
         </summary>
-        <div className="mt-4 space-y-4 pl-0">
+        <div className="mt-3 space-y-1.5">
+          <p className="text-xs text-text-tertiary">
+            If you don't want a JSON file on disk, create an agent in <strong>Your Agents</strong>{' '}
+            below and inline the token directly:
+          </p>
+          <CodeBlock onCopy={() => onCopy(manualRunCmd)}>{manualRunCmd}</CodeBlock>
+          {!newToken && (
+            <p className="text-xs text-text-tertiary">
+              The placeholder fills in automatically after you create an agent.
+            </p>
+          )}
+        </div>
+      </details>
+
+      <details className="group" open={showSkillDefault}>
+        <summary className="text-sm font-medium text-text-secondary cursor-pointer hover:text-text-primary select-none">
+          Skill-based setup (use Clawvisor's native skill protocol instead)
+        </summary>
+        <div className="mt-4 space-y-4">
+          <p className="text-sm text-text-secondary">
+            Install a slash command, then run it in Claude Code. It handles agent registration,
+            skill installation, environment setup, and a smoke test — all interactively.
+          </p>
+
           <div className="flex items-start gap-3">
             <StepNumber n={1} />
             <div className="space-y-1.5 min-w-0 flex-1">
-              <p className="text-sm font-medium text-text-primary">Create an agent token</p>
+              <p className="text-sm font-medium text-text-primary">Install the setup command</p>
               <p className="text-xs text-text-tertiary">
-                Use the <strong>Create Agent</strong> form above. Copy the token — it's shown only once.
+                Run this in your terminal to install the{' '}
+                <code className="font-mono text-text-secondary">/clawvisor-setup</code> slash command:
+              </p>
+              <CodeBlock onCopy={() => onCopy(installCmd)}>{installCmd}</CodeBlock>
+            </div>
+          </div>
+
+          <div className="flex items-start gap-3">
+            <StepNumber n={2} />
+            <div className="space-y-1.5 min-w-0 flex-1">
+              <p className="text-sm font-medium text-text-primary">Run /clawvisor-setup in Claude Code</p>
+              <p className="text-xs text-text-tertiary">
+                Open Claude Code and type{' '}
+                <code className="font-mono text-text-secondary">/clawvisor-setup</code>.
+                Claude will walk you through the setup — registering as an agent, configuring
+                environment variables, and verifying the connection.
+              </p>
+            </div>
+          </div>
+
+          <div className="flex items-start gap-3">
+            <StepNumber n={3} />
+            <div className="space-y-1.5 min-w-0 flex-1">
+              <p className="text-sm font-medium text-text-primary">Approve the connection</p>
+              <p className="text-xs text-text-tertiary">
+                During setup, Claude Code sends a connection request. Approve it in the{' '}
+                <strong>Pending Connections</strong> section above. Once approved, Claude Code
+                finishes setup automatically and runs a smoke test.
+              </p>
+            </div>
+          </div>
+        </div>
+      </details>
+    </div>
+  )
+}
+
+function CodexGuide({ clawvisorURL, claim, newToken, onCopy }: {
+  clawvisorURL: string
+  claim: string | undefined
+  newToken: string | null
+  onCopy: (text: string) => void
+}) {
+  const [step, setStep] = useState(0)
+  const { data: agents } = useQuery({
+    queryKey: ['agents', 'personal'],
+    queryFn: () => api.agents.list(),
+    refetchInterval: 3000,
+  })
+  const [agentName, setAgentName] = useSequencedAgentName('codex', agents)
+  const connected = !!agents?.find(a => a.name === agentName)
+
+  const jsonPath = `~/.clawvisor/agents/${agentName}.json`
+  // Idempotent: skip the append when [model_providers.clawvisor] is already
+  // in the file. Re-running the snippet otherwise creates a duplicate-table
+  // entry that Codex rejects on startup.
+  const configWrite = `mkdir -p ~/.codex && grep -q '^\\[model_providers\\.clawvisor\\]' ~/.codex/config.toml 2>/dev/null || cat >> ~/.codex/config.toml <<'EOF'
+
+[model_providers.clawvisor]
+name = "Clawvisor"
+base_url = "${clawvisorURL}/v1"
+wire_api = "responses"
+requires_openai_auth = true
+
+[model_providers.clawvisor.env_http_headers]
+X-Clawvisor-Agent-Token = "CLAWVISOR_AGENT_TOKEN"
+EOF`
+  const runCmd = `CLAWVISOR_AGENT_TOKEN=$(jq -r .token ${jsonPath}) \\
+codex -c model_provider=clawvisor`
+  const zshrcSnippet = `cat >> ~/.zshrc <<'EOF'
+codex-cv() {
+  CLAWVISOR_AGENT_TOKEN=$(jq -r .token ${jsonPath}) \\
+  codex -c model_provider=clawvisor "$@"
+}
+EOF`
+  const tokenValue = newToken ?? 'cvis_<your-token>'
+  const manualRunCmd = `CLAWVISOR_AGENT_TOKEN=${tokenValue} \\
+codex -c model_provider=clawvisor`
+
+  const wizardSteps: WizardStepDef[] = [
+    { id: 'bootstrap', title: 'Bootstrap agent', done: connected },
+    { id: 'configure', title: 'Configure & run', done: step > 1 },
+  ]
+
+  return (
+    <div className="space-y-5">
+      <p className="text-sm text-text-secondary">
+        Codex runs in <strong>passthrough mode</strong>: your ChatGPT login (via{' '}
+        <code className="font-mono text-text-secondary">codex login</code>) authenticates
+        upstream, Clawvisor only identifies the agent. Two steps — bootstrap, then configure.
+      </p>
+
+      <div className="rounded-md border border-border-default bg-surface-1 px-4 py-5 space-y-4">
+        <StepBar steps={wizardSteps} activeIndex={step} />
+
+      {step === 0 && (
+        <BootstrapApproveStep
+          clawvisorURL={clawvisorURL}
+          claim={claim}
+          agentName={agentName}
+          setAgentName={setAgentName}
+          onCopy={onCopy}
+          onAdvance={() => setStep(1)}
+        />
+      )}
+
+      {step === 1 && (
+        <>
+          <div className="space-y-4">
+            <div className="space-y-1.5">
+              <p className="text-sm font-medium text-text-primary">Add the provider block (one time)</p>
+              <CodeBlock onCopy={() => onCopy(configWrite)}>{configWrite}</CodeBlock>
+              <p className="text-xs text-text-tertiary">
+                Appends a <code className="font-mono text-text-secondary">[model_providers.clawvisor]</code>{' '}
+                block to <code className="font-mono text-text-secondary">~/.codex/config.toml</code>.{' '}
+                <code className="font-mono text-text-secondary">requires_openai_auth=true</code> tells Codex
+                to authenticate the call to Clawvisor with your existing ChatGPT login.
+              </p>
+            </div>
+
+            <div className="space-y-1.5">
+              <p className="text-sm font-medium text-text-primary">Run Codex through Clawvisor</p>
+              <CodeBlock onCopy={() => onCopy(runCmd)}>{runCmd}</CodeBlock>
+              <p className="text-xs text-text-tertiary">
+                Needs <code className="font-mono text-text-secondary">jq</code> (<code className="font-mono text-text-secondary">brew install jq</code> on macOS).
+                Make sure you've run <code className="font-mono text-text-secondary">codex login</code> at
+                least once first.
+              </p>
+            </div>
+
+            <details className="group">
+              <summary className="text-sm font-medium text-text-secondary cursor-pointer hover:text-text-primary select-none">
+                Optional: persist as a shell function (naked <code className="font-mono">codex-cv</code> works)
+              </summary>
+              <div className="mt-3 space-y-1.5">
+                <CodeBlock onCopy={() => onCopy(zshrcSnippet)}>{zshrcSnippet}</CodeBlock>
+                <p className="text-xs text-text-tertiary">
+                  After running, open a new shell or <code className="font-mono text-text-secondary">source ~/.zshrc</code>.
+                </p>
+              </div>
+            </details>
+          </div>
+          <WizardNav
+            canBack
+            canNext
+            onBack={() => setStep(0)}
+            onNext={() => setStep(2)}
+            nextLabel="Done"
+          />
+        </>
+      )}
+
+      {step >= 2 && (
+        <div className="rounded border border-success/30 bg-success/10 px-4 py-3">
+          <p className="text-sm font-medium text-success">All set.</p>
+          <p className="text-xs text-text-secondary mt-1">
+            Re-run the bootstrap curl any time you need to rotate the token (pick the same name).
+          </p>
+          <button
+            onClick={() => setStep(1)}
+            className="mt-2 text-xs text-brand hover:underline"
+          >
+            Show the configure & run commands again
+          </button>
+        </div>
+      )}
+      </div>
+
+      <details className="group">
+        <summary className="text-sm font-medium text-text-secondary cursor-pointer hover:text-text-primary select-none">
+          Manual setup (env var without an on-disk file)
+        </summary>
+        <div className="mt-3 space-y-1.5">
+          <p className="text-xs text-text-tertiary">
+            If you don't want a JSON file on disk, create an agent in <strong>Your Agents</strong>{' '}
+            below and inline the token directly:
+          </p>
+          <CodeBlock onCopy={() => onCopy(manualRunCmd)}>{manualRunCmd}</CodeBlock>
+          {!newToken && (
+            <p className="text-xs text-text-tertiary">
+              The placeholder fills in automatically after you create an agent.
+            </p>
+          )}
+        </div>
+      </details>
+    </div>
+  )
+}
+
+function ClaudeDesktopGuide({ clawvisorURL, claim, newToken, isLocal, onCopy, showSkillDefault }: {
+  clawvisorURL: string
+  claim: string | undefined
+  newToken: string | null
+  isLocal: boolean
+  onCopy: (text: string) => void
+  showSkillDefault: boolean
+}) {
+  const [step, setStep] = useState(0)
+  const { data: agents } = useQuery({
+    queryKey: ['agents', 'personal'],
+    queryFn: () => api.agents.list(),
+    refetchInterval: 3000,
+  })
+  const [agentName, setAgentName] = useSequencedAgentName('claude-desktop', agents)
+  const myAgent = agents?.find(a => a.name === agentName)
+  const connected = !!myAgent
+  const { data: creds } = useQuery({
+    queryKey: ['llm-credentials', myAgent?.id ?? ''],
+    queryFn: () => api.llmCredentials.list(myAgent!.id),
+    enabled: !!myAgent,
+  })
+  const keyReady = hasAnyUpstreamKey(creds)
+
+  const jsonPath = `~/.clawvisor/agents/${agentName}.json`
+  const printTokenCmd = `cat ${jsonPath} | jq -r .token`
+  const tokenValue = newToken ?? 'cvis_<your-token>'
+  const marketplaceSlug = 'clawvisor/cowork-plugins'
+  const pluginLabel = isLocal ? 'Clawvisor Local' : 'Clawvisor'
+
+  const wizardSteps: WizardStepDef[] = [
+    { id: 'bootstrap', title: 'Bootstrap agent', done: connected },
+    { id: 'key', title: 'Vault upstream key', done: keyReady },
+    { id: 'configure', title: 'Configure Desktop', done: step > 2 },
+  ]
+
+  return (
+    <div className="space-y-5">
+      <p className="text-sm text-text-secondary">
+        Claude Desktop runs in <strong>swap mode</strong>: the GUI presents the Clawvisor token
+        as its API key, and Clawvisor swaps in your vaulted upstream Anthropic key on each call.
+        Three steps — bootstrap, vault, configure.
+      </p>
+
+      <div className="rounded-md border border-border-default bg-surface-1 px-4 py-5 space-y-4">
+        <StepBar steps={wizardSteps} activeIndex={step} />
+
+      {step === 0 && (
+        <BootstrapApproveStep
+          clawvisorURL={clawvisorURL}
+          claim={claim}
+          agentName={agentName}
+          setAgentName={setAgentName}
+          onCopy={onCopy}
+          onAdvance={() => setStep(1)}
+        />
+      )}
+
+      {step === 1 && myAgent && (
+        <>
+          <VaultKeyStep agentId={myAgent.id} />
+          <WizardNav
+            canBack
+            canNext={keyReady}
+            onBack={() => setStep(0)}
+            onNext={() => setStep(2)}
+            onSkip={() => setStep(2)}
+            skipLabel="Skip — I'll vault one elsewhere"
+            nextDisabledHint={keyReady ? undefined : 'Vault at least one provider key to continue'}
+          />
+        </>
+      )}
+
+      {step === 2 && (
+        <>
+          <div className="space-y-4">
+            <div className="flex items-start gap-3">
+              <StepNumber n={1} />
+              <div className="space-y-1.5 min-w-0 flex-1">
+                <p className="text-sm font-medium text-text-primary">Enable Developer Mode</p>
+                <p className="text-xs text-text-tertiary">
+                  In Claude Desktop, open <strong>Help → Troubleshooting</strong> and turn on{' '}
+                  <strong>Enable Developer Mode</strong>.
+                </p>
+              </div>
+            </div>
+
+            <div className="flex items-start gap-3">
+              <StepNumber n={2} />
+              <div className="space-y-1.5 min-w-0 flex-1">
+                <p className="text-sm font-medium text-text-primary">Open the inference config panel</p>
+                <p className="text-xs text-text-tertiary">
+                  From the new <strong>Developer</strong> menu, select{' '}
+                  <strong>Configure Third-Party Inference…</strong> and set{' '}
+                  <strong>Backend Type</strong> to <strong>Gateway (Anthropic-compatible)</strong>.
+                </p>
+              </div>
+            </div>
+
+            <div className="flex items-start gap-3">
+              <StepNumber n={3} />
+              <div className="space-y-1.5 min-w-0 flex-1">
+                <p className="text-sm font-medium text-text-primary">Fill in the gateway fields</p>
+                <div className="space-y-2">
+                  <div>
+                    <div className="text-xs uppercase tracking-wider text-text-tertiary">Gateway base URL</div>
+                    <div className="mt-1 flex items-center gap-2">
+                      <code className="flex-1 px-3 py-1.5 text-sm font-mono rounded border border-border-default bg-surface-0 text-text-primary break-all">{clawvisorURL}</code>
+                      <button
+                        onClick={() => onCopy(clawvisorURL)}
+                        className="text-xs px-3 py-1 rounded border border-border-strong text-text-secondary hover:bg-surface-2"
+                      >
+                        Copy
+                      </button>
+                    </div>
+                  </div>
+                  <div>
+                    <div className="text-xs uppercase tracking-wider text-text-tertiary">Gateway API key</div>
+                    <p className="text-xs text-text-tertiary mt-1">
+                      Print the token from the JSON file, then paste it into the field:
+                    </p>
+                    <div className="mt-1">
+                      <CodeBlock onCopy={() => onCopy(printTokenCmd)}>{printTokenCmd}</CodeBlock>
+                    </div>
+                  </div>
+                  <div>
+                    <div className="text-xs uppercase tracking-wider text-text-tertiary">Gateway auth scheme</div>
+                    <code className="mt-1 inline-block px-3 py-1.5 text-sm font-mono rounded border border-border-default bg-surface-0 text-text-primary">bearer</code>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div className="flex items-start gap-3">
+              <StepNumber n={4} />
+              <div className="space-y-1.5 min-w-0 flex-1">
+                <p className="text-sm font-medium text-text-primary">Apply & restart</p>
+                <p className="text-xs text-text-tertiary">
+                  Click <strong>Apply locally</strong>, then fully quit and reopen Claude Desktop.
+                  Inference now routes through Clawvisor.
+                </p>
+              </div>
+            </div>
+          </div>
+          <WizardNav
+            canBack
+            canNext
+            onBack={() => setStep(1)}
+            onNext={() => setStep(3)}
+            nextLabel="Done"
+          />
+        </>
+      )}
+
+      {step >= 3 && (
+        <div className="rounded border border-success/30 bg-success/10 px-4 py-3">
+          <p className="text-sm font-medium text-success">All set.</p>
+          <button
+            onClick={() => setStep(2)}
+            className="mt-2 text-xs text-brand hover:underline"
+          >
+            Show the configure steps again
+          </button>
+        </div>
+      )}
+      </div>
+
+      <details className="group">
+        <summary className="text-sm font-medium text-text-secondary cursor-pointer hover:text-text-primary select-none">
+          Manual setup (use a token created via the dashboard)
+        </summary>
+        <div className="mt-3 space-y-2">
+          <p className="text-xs text-text-tertiary">
+            Skip the bootstrap and create an agent in <strong>Your Agents</strong> below. Paste
+            its token directly into the Gateway API key field:
+          </p>
+          <div className="flex items-center gap-2">
+            <code className="flex-1 px-3 py-1.5 text-sm font-mono rounded border border-border-default bg-surface-0 text-text-primary break-all">{tokenValue}</code>
+            <button
+              onClick={() => onCopy(tokenValue)}
+              className="text-xs px-3 py-1 rounded border border-border-strong text-text-secondary hover:bg-surface-2"
+            >
+              Copy
+            </button>
+          </div>
+          {!newToken && (
+            <p className="text-xs text-text-tertiary">
+              The placeholder fills in automatically after you create an agent.
+            </p>
+          )}
+        </div>
+      </details>
+
+      <details className="group" open={showSkillDefault}>
+        <summary className="text-sm font-medium text-text-secondary cursor-pointer hover:text-text-primary select-none">
+          Skill-based setup (use the Clawvisor Cowork plugin instead)
+        </summary>
+        <div className="mt-4 space-y-4">
+          <p className="text-sm text-text-secondary">
+            {isLocal
+              ? 'Connect Claude Cowork to your local Clawvisor instance via the Cowork plugin.'
+              : 'Connect Claude Cowork to your Clawvisor cloud account via the Cowork plugin.'}
+          </p>
+
+          <div className="flex items-start gap-3">
+            <StepNumber n={1} />
+            <div className="space-y-1.5 min-w-0 flex-1">
+              <p className="text-sm font-medium text-text-primary">Open the plugin manager</p>
+              <p className="text-xs text-text-tertiary">
+                In Claude Desktop, navigate to <strong>Claude Cowork</strong>, click{' '}
+                <strong>Customize</strong> in the sidebar, then press the <strong>+</strong> next to{' '}
+                <strong>Personal plugins</strong>.
               </p>
             </div>
           </div>
@@ -1078,26 +1758,661 @@ function OtherAgentGuide({ setupURL, clawvisorURL, copied, onCopy }: {
           <div className="flex items-start gap-3">
             <StepNumber n={2} />
             <div className="space-y-1.5 min-w-0 flex-1">
-              <p className="text-sm font-medium text-text-primary">Configure environment variables</p>
+              <p className="text-sm font-medium text-text-primary">Add the marketplace</p>
               <p className="text-xs text-text-tertiary">
-                Set these in your agent's environment (<code className="font-mono text-text-secondary">.env</code>, shell profile, container config, etc.):
+                Under <strong>Create plugin</strong>, select <strong>Add marketplace</strong> and paste:
               </p>
-              <CodeBlock>{`CLAWVISOR_URL=${clawvisorURL}\nCLAWVISOR_AGENT_TOKEN=<your token>`}</CodeBlock>
+              <CodeBlock onCopy={() => onCopy(marketplaceSlug)}>{marketplaceSlug}</CodeBlock>
             </div>
           </div>
 
           <div className="flex items-start gap-3">
             <StepNumber n={3} />
             <div className="space-y-1.5 min-w-0 flex-1">
-              <p className="text-sm font-medium text-text-primary">Verify</p>
-              <CodeBlock>{`curl -sf -H "Authorization: Bearer $CLAWVISOR_AGENT_TOKEN" \\\n  "$CLAWVISOR_URL/api/skill/catalog" | head -20`}</CodeBlock>
+              <p className="text-sm font-medium text-text-primary">Install the {pluginLabel} plugin</p>
               <p className="text-xs text-text-tertiary">
-                Should return a JSON catalog of available services. See{' '}
-                <code className="font-mono text-text-secondary">{clawvisorURL}/skill/SKILL.md</code>{' '}
-                for the full protocol reference.
+                Open the <strong>Personal</strong> tab, switch to the <strong>cowork-plugins</strong> tab,
+                then select <strong>{pluginLabel}</strong> to install.
               </p>
             </div>
           </div>
+
+          {!isLocal && (
+            <div className="flex items-start gap-3">
+              <StepNumber n={4} />
+              <div className="space-y-1.5 min-w-0 flex-1">
+                <p className="text-sm font-medium text-text-primary">Connect the Clawvisor connector</p>
+                <p className="text-xs text-text-tertiary">
+                  Under the <strong>Clawvisor</strong> plugin, select <strong>Connectors</strong>, click the{' '}
+                  <strong>clawvisor</strong> connector, and connect. Authorize Claude Cowork in your browser
+                  when prompted.
+                </p>
+              </div>
+            </div>
+          )}
+
+          <div className="flex items-start gap-3">
+            <StepNumber n={isLocal ? 4 : 5} />
+            <div className="space-y-1.5 min-w-0 flex-1">
+              <p className="text-sm font-medium text-text-primary">Start using it</p>
+              <p className="text-xs text-text-tertiary">
+                Create a new Claude Cowork session and ask your agent to use a connected account via
+                Clawvisor — e.g. "check my Gmail" or "list my GitHub issues." Claude will create a task,
+                ask you to approve, and execute through Clawvisor.{' '}
+                {isLocal &&
+                  <>Open the dashboard with <code className="font-mono text-text-secondary">clawvisor tui</code> or visit <code className="font-mono text-text-secondary">http://localhost:25297</code> to manage services, approvals, and restrictions.</>
+                }
+              </p>
+            </div>
+          </div>
+        </div>
+      </details>
+    </div>
+  )
+}
+
+function OpenClawGuide({ setupURL, clawvisorURL, claim, newToken, copied, onCopy, showSkillDefault }: {
+  setupURL: string
+  clawvisorURL: string
+  claim: string | undefined
+  newToken: string | null
+  copied: boolean
+  onCopy: (text: string) => void
+  showSkillDefault: boolean
+}) {
+  const [step, setStep] = useState(0)
+  const { data: agents } = useQuery({
+    queryKey: ['agents', 'personal'],
+    queryFn: () => api.agents.list(),
+    refetchInterval: 3000,
+  })
+  const [agentName, setAgentName] = useSequencedAgentName('openclaw', agents)
+  const myAgent = agents?.find(a => a.name === agentName)
+  const connected = !!myAgent
+  const { data: creds } = useQuery({
+    queryKey: ['llm-credentials', myAgent?.id ?? ''],
+    queryFn: () => api.llmCredentials.list(myAgent!.id),
+    enabled: !!myAgent,
+  })
+  const keyReady = hasAnyUpstreamKey(creds)
+
+  const jsonPath = `~/.clawvisor/agents/${agentName}.json`
+  const onboardCmd = `openclaw onboard --non-interactive \\
+  --auth-choice custom-api-key \\
+  --custom-base-url "${clawvisorURL}/v1" \\
+  --custom-model-id "claude-sonnet-4-6" \\
+  --custom-api-key "$(jq -r .token ${jsonPath})" \\
+  --custom-compatibility anthropic`
+  const tokenValue = newToken ?? 'cvis_<your-token>'
+  const manualOnboardCmd = `openclaw onboard --non-interactive \\
+  --auth-choice custom-api-key \\
+  --custom-base-url "${clawvisorURL}/v1" \\
+  --custom-model-id "claude-sonnet-4-6" \\
+  --custom-api-key "${tokenValue}" \\
+  --custom-compatibility anthropic`
+  const prompt = `Please install Clawvisor. It's a security gateway between you and external services like Gmail, Slack, and GitHub. You don't hold any API keys directly; instead, you make requests through Clawvisor and I approve which actions you can take. Every call is logged, and I can revoke access at any time.\n\nSetup is just registering an agent token and installing a skill that teaches you how to use it. I'll review each step before it happens.\n\nInstructions: ${setupURL}`
+
+  const wizardSteps: WizardStepDef[] = [
+    { id: 'bootstrap', title: 'Bootstrap agent', done: connected },
+    { id: 'key', title: 'Vault upstream key', done: keyReady },
+    { id: 'onboard', title: 'Onboard OpenClaw', done: step > 2 },
+  ]
+
+  return (
+    <div className="space-y-5">
+      <p className="text-sm text-text-secondary">
+        OpenClaw runs in <strong>swap mode</strong>: Clawvisor swaps your{' '}
+        <code className="font-mono text-text-secondary">cvis_…</code> token for a vaulted
+        upstream Anthropic key on each call. Three steps — bootstrap, vault, onboard.
+      </p>
+
+      <div className="rounded-md border border-border-default bg-surface-1 px-4 py-5 space-y-4">
+        <StepBar steps={wizardSteps} activeIndex={step} />
+
+      {step === 0 && (
+        <BootstrapApproveStep
+          clawvisorURL={clawvisorURL}
+          claim={claim}
+          agentName={agentName}
+          setAgentName={setAgentName}
+          onCopy={onCopy}
+          onAdvance={() => setStep(1)}
+        />
+      )}
+
+      {step === 1 && myAgent && (
+        <>
+          <VaultKeyStep agentId={myAgent.id} />
+          <WizardNav
+            canBack
+            canNext={keyReady}
+            onBack={() => setStep(0)}
+            onNext={() => setStep(2)}
+            onSkip={() => setStep(2)}
+            skipLabel="Skip — I'll vault one elsewhere"
+            nextDisabledHint={keyReady ? undefined : 'Vault at least one provider key to continue'}
+          />
+        </>
+      )}
+
+      {step === 2 && (
+        <>
+          <div className="space-y-1.5">
+            <p className="text-sm font-medium text-text-primary">Onboard OpenClaw</p>
+            <CodeBlock onCopy={() => onCopy(onboardCmd)}>{onboardCmd}</CodeBlock>
+            <p className="text-xs text-text-tertiary">
+              After this finishes, OpenClaw remembers the config — naked{' '}
+              <code className="font-mono text-text-secondary">openclaw</code> goes through Clawvisor.
+              Needs <code className="font-mono text-text-secondary">jq</code>.
+            </p>
+          </div>
+          <WizardNav
+            canBack
+            canNext
+            onBack={() => setStep(1)}
+            onNext={() => setStep(3)}
+            nextLabel="Done"
+          />
+        </>
+      )}
+
+      {step >= 3 && (
+        <div className="rounded border border-success/30 bg-success/10 px-4 py-3">
+          <p className="text-sm font-medium text-success">All set.</p>
+          <button
+            onClick={() => setStep(2)}
+            className="mt-2 text-xs text-brand hover:underline"
+          >
+            Show the onboard command again
+          </button>
+        </div>
+      )}
+      </div>
+
+      <details className="group">
+        <summary className="text-sm font-medium text-text-secondary cursor-pointer hover:text-text-primary select-none">
+          Manual setup (paste a token created via the dashboard)
+        </summary>
+        <div className="mt-3 space-y-1.5">
+          <p className="text-xs text-text-tertiary">
+            If you don't want a JSON file on disk, create an agent in <strong>Your Agents</strong>{' '}
+            below and inline the token directly:
+          </p>
+          <CodeBlock onCopy={() => onCopy(manualOnboardCmd)}>{manualOnboardCmd}</CodeBlock>
+          {!newToken && (
+            <p className="text-xs text-text-tertiary">
+              The placeholder fills in automatically after you create an agent.
+            </p>
+          )}
+        </div>
+      </details>
+
+      <details className="group" open={showSkillDefault}>
+        <summary className="text-sm font-medium text-text-secondary cursor-pointer hover:text-text-primary select-none">
+          Skill-based setup (let your agent self-register via the Clawvisor skill)
+        </summary>
+        <div className="mt-4 space-y-4">
+          <p className="text-sm text-text-secondary">
+            Paste the setup prompt below into your agent — it will self-register and wait for your approval.
+          </p>
+
+          <div className="flex items-start gap-3">
+            <StepNumber n={1} />
+            <div className="space-y-1.5 min-w-0 flex-1">
+              <p className="text-sm font-medium text-text-primary">Paste this into your agent</p>
+              <div className="relative group bg-surface-0 border border-brand/20 rounded overflow-hidden">
+                <pre className="px-3 py-2.5 sm:pr-16 text-xs font-mono text-text-primary overflow-x-auto whitespace-pre-wrap break-words">
+                  {prompt}
+                </pre>
+                <button
+                  onClick={() => onCopy(prompt)}
+                  className="hidden sm:block absolute top-2 right-2 text-xs px-2 py-1 rounded border border-border-subtle text-text-tertiary hover:text-text-primary hover:bg-surface-1"
+                >
+                  {copied ? 'Copied' : 'Copy'}
+                </button>
+                <div className="sm:hidden border-t border-brand/20 px-3 py-1.5 flex justify-end">
+                  <button
+                    onClick={() => onCopy(prompt)}
+                    className="text-xs px-2.5 py-1 rounded border border-border-subtle text-text-tertiary hover:text-text-primary hover:bg-surface-1"
+                  >
+                    {copied ? 'Copied' : 'Copy'}
+                  </button>
+                </div>
+              </div>
+              <p className="text-xs text-text-tertiary">
+                Your agent will follow the setup instructions — registering itself
+                and installing the Clawvisor skill.
+              </p>
+            </div>
+          </div>
+
+          <div className="flex items-start gap-3">
+            <StepNumber n={2} />
+            <div className="space-y-1.5 min-w-0 flex-1">
+              <p className="text-sm font-medium text-text-primary">Approve the connection</p>
+              <p className="text-xs text-text-tertiary">
+                A connection request will appear in the <strong>Pending Connections</strong> section above.
+                Click <strong>Approve</strong> to grant the agent a token. It receives the token automatically
+                and is ready to go.
+              </p>
+            </div>
+          </div>
+
+          <div className="bg-surface-0 border border-border-subtle rounded-md px-4 py-3">
+            <p className="text-sm text-text-secondary">
+              <strong>Using Telegram?</strong> If you talk to your agent via Telegram, you can set up a
+              group chat with Clawvisor to get inline approval notifications and auto-approvals.{' '}
+              <a href="/dashboard/settings" className="text-brand hover:underline">Set it up in Settings &rarr; Telegram</a>.
+            </p>
+          </div>
+        </div>
+      </details>
+    </div>
+  )
+}
+
+function HermesGuide({ clawvisorURL, claim, newToken, onCopy }: {
+  clawvisorURL: string
+  claim: string | undefined
+  newToken: string | null
+  onCopy: (text: string) => void
+}) {
+  const [step, setStep] = useState(0)
+  const { data: agents } = useQuery({
+    queryKey: ['agents', 'personal'],
+    queryFn: () => api.agents.list(),
+    refetchInterval: 3000,
+  })
+  const [agentName, setAgentName] = useSequencedAgentName('hermes', agents)
+  const myAgent = agents?.find(a => a.name === agentName)
+  const connected = !!myAgent
+  const { data: creds } = useQuery({
+    queryKey: ['llm-credentials', myAgent?.id ?? ''],
+    queryFn: () => api.llmCredentials.list(myAgent!.id),
+    enabled: !!myAgent,
+  })
+  const keyReady = hasAnyUpstreamKey(creds)
+
+  const jsonPath = `~/.clawvisor/agents/${agentName}.json`
+  const envCmd = `OPENAI_BASE_URL=${clawvisorURL}/v1 \\
+OPENAI_API_KEY=$(jq -r .token ${jsonPath}) \\
+hermes chat`
+  const configCmd = `mkdir -p ~/.hermes && cat > ~/.hermes/config.yaml <<EOF
+model:
+  provider: custom
+  base_url: "${clawvisorURL}/v1"
+  api_key: "$(jq -r .token ${jsonPath})"
+EOF`
+  const tokenValue = newToken ?? 'cvis_<your-token>'
+  const manualEnvCmd = `OPENAI_BASE_URL=${clawvisorURL}/v1 \\
+OPENAI_API_KEY=${tokenValue} \\
+hermes chat`
+
+  const wizardSteps: WizardStepDef[] = [
+    { id: 'bootstrap', title: 'Bootstrap agent', done: connected },
+    { id: 'key', title: 'Vault upstream key', done: keyReady },
+    { id: 'use', title: 'Run Hermes', done: step > 2 },
+  ]
+
+  return (
+    <div className="space-y-5">
+      <p className="text-sm text-text-secondary">
+        Hermes runs in <strong>swap mode</strong>: Hermes presents the Clawvisor token via{' '}
+        <code className="font-mono text-text-secondary">OPENAI_API_KEY</code>, and Clawvisor
+        swaps in your vaulted upstream key on each call. Three steps — bootstrap, vault, run.
+      </p>
+
+      <div className="rounded-md border border-border-default bg-surface-1 px-4 py-5 space-y-4">
+        <StepBar steps={wizardSteps} activeIndex={step} />
+
+      {step === 0 && (
+        <BootstrapApproveStep
+          clawvisorURL={clawvisorURL}
+          claim={claim}
+          agentName={agentName}
+          setAgentName={setAgentName}
+          onCopy={onCopy}
+          onAdvance={() => setStep(1)}
+        />
+      )}
+
+      {step === 1 && myAgent && (
+        <>
+          <VaultKeyStep agentId={myAgent.id} />
+          <WizardNav
+            canBack
+            canNext={keyReady}
+            onBack={() => setStep(0)}
+            onNext={() => setStep(2)}
+            onSkip={() => setStep(2)}
+            skipLabel="Skip — I'll vault one elsewhere"
+            nextDisabledHint={keyReady ? undefined : 'Vault at least one provider key to continue'}
+          />
+        </>
+      )}
+
+      {step === 2 && (
+        <>
+          <div className="space-y-3">
+            <div className="space-y-1.5">
+              <p className="text-sm font-medium text-text-primary">Run Hermes via env vars</p>
+              <CodeBlock onCopy={() => onCopy(envCmd)}>{envCmd}</CodeBlock>
+              <p className="text-xs text-text-tertiary">
+                Re-reads the token on every invocation. Needs{' '}
+                <code className="font-mono text-text-secondary">jq</code>.
+              </p>
+            </div>
+
+            <details className="group">
+              <summary className="text-sm font-medium text-text-secondary cursor-pointer hover:text-text-primary select-none">
+                Optional: persist as <code className="font-mono">~/.hermes/config.yaml</code>
+              </summary>
+              <div className="mt-3 space-y-1.5">
+                <CodeBlock onCopy={() => onCopy(configCmd)}>{configCmd}</CodeBlock>
+                <p className="text-xs text-text-tertiary">
+                  Bakes the current token into the file. If you re-bootstrap the same agent name,
+                  re-run this snippet to pick up the new token.
+                </p>
+              </div>
+            </details>
+          </div>
+          <WizardNav
+            canBack
+            canNext
+            onBack={() => setStep(1)}
+            onNext={() => setStep(3)}
+            nextLabel="Done"
+          />
+        </>
+      )}
+
+      {step >= 3 && (
+        <div className="rounded border border-success/30 bg-success/10 px-4 py-3">
+          <p className="text-sm font-medium text-success">All set.</p>
+          <button
+            onClick={() => setStep(2)}
+            className="mt-2 text-xs text-brand hover:underline"
+          >
+            Show the run command again
+          </button>
+        </div>
+      )}
+      </div>
+
+      <details className="group">
+        <summary className="text-sm font-medium text-text-secondary cursor-pointer hover:text-text-primary select-none">
+          Manual setup (inline a token created via the dashboard)
+        </summary>
+        <div className="mt-3 space-y-1.5">
+          <p className="text-xs text-text-tertiary">
+            If you don't want a JSON file on disk, create an agent in <strong>Your Agents</strong>{' '}
+            below and inline the token directly:
+          </p>
+          <CodeBlock onCopy={() => onCopy(manualEnvCmd)}>{manualEnvCmd}</CodeBlock>
+          {!newToken && (
+            <p className="text-xs text-text-tertiary">
+              The placeholder fills in automatically after you create an agent.
+            </p>
+          )}
+        </div>
+      </details>
+    </div>
+  )
+}
+
+function OtherAgentGuide({ setupURL, clawvisorURL, claim, newToken, copied, onCopy, showSkillDefault }: {
+  setupURL: string
+  clawvisorURL: string
+  claim: string | undefined
+  newToken: string | null
+  copied: boolean
+  onCopy: (text: string) => void
+  showSkillDefault: boolean
+}) {
+  const [step, setStep] = useState(0)
+  const { data: agents } = useQuery({
+    queryKey: ['agents', 'personal'],
+    queryFn: () => api.agents.list(),
+    refetchInterval: 3000,
+  })
+  const [agentName, setAgentName] = useSequencedAgentName('my-agent', agents)
+  const myAgent = agents?.find(a => a.name === agentName)
+  const connected = !!myAgent
+  const { data: creds } = useQuery({
+    queryKey: ['llm-credentials', myAgent?.id ?? ''],
+    queryFn: () => api.llmCredentials.list(myAgent!.id),
+    enabled: !!myAgent,
+  })
+  const keyReady = hasAnyUpstreamKey(creds)
+
+  const jsonPath = `~/.clawvisor/agents/${agentName}.json`
+  const anthropicSDK = `import anthropic, json, os
+data = json.load(open(os.path.expanduser("${jsonPath}")))
+client = anthropic.Anthropic(
+    base_url="${clawvisorURL}",
+    api_key=data["token"],
+)`
+  const openaiSDK = `from openai import OpenAI
+import json, os
+data = json.load(open(os.path.expanduser("${jsonPath}")))
+client = OpenAI(
+    base_url="${clawvisorURL}/v1",
+    api_key=data["token"],
+)`
+  const curlCmd = `curl -X POST "${clawvisorURL}/v1/messages" \\
+  -H "Authorization: Bearer $(jq -r .token ${jsonPath})" \\
+  -H "anthropic-version: 2023-06-01" \\
+  -H "Content-Type: application/json" \\
+  -d '{"model":"claude-sonnet-4-6","max_tokens":256,"messages":[{"role":"user","content":"hi"}]}'`
+  const tokenValue = newToken ?? 'cvis_<your-token>'
+  const manualAnthropicSDK = `import anthropic
+client = anthropic.Anthropic(
+    base_url="${clawvisorURL}",
+    api_key="${tokenValue}",
+)`
+  const manualOpenaiSDK = `from openai import OpenAI
+client = OpenAI(
+    base_url="${clawvisorURL}/v1",
+    api_key="${tokenValue}",
+)`
+  const prompt = `Please install Clawvisor. It's a security gateway between you and external services like Gmail, Slack, and GitHub. You don't hold any API keys directly; instead, you make requests through Clawvisor and I approve which actions you can take. Every call is logged, and I can revoke access at any time.\n\nSetup is just registering an agent token and installing a skill that teaches you how to use it. I'll review each step before it happens.\n\nInstructions: ${setupURL}`
+
+  const wizardSteps: WizardStepDef[] = [
+    { id: 'bootstrap', title: 'Bootstrap agent', done: connected },
+    { id: 'key', title: 'Vault upstream key', done: keyReady },
+    { id: 'use', title: 'Use it', done: step > 2 },
+  ]
+
+  return (
+    <div className="space-y-5">
+      <p className="text-sm text-text-secondary">
+        Any Anthropic- or OpenAI-compatible client works in <strong>swap mode</strong>:
+        Clawvisor swaps your <code className="font-mono text-text-secondary">cvis_…</code> token
+        for a vaulted upstream key on each call. Three steps — bootstrap, vault, use.
+      </p>
+
+      <div className="rounded-md border border-border-default bg-surface-1 px-4 py-5 space-y-4">
+        <StepBar steps={wizardSteps} activeIndex={step} />
+
+      {step === 0 && (
+        <BootstrapApproveStep
+          clawvisorURL={clawvisorURL}
+          claim={claim}
+          agentName={agentName}
+          setAgentName={setAgentName}
+          onCopy={onCopy}
+          onAdvance={() => setStep(1)}
+        />
+      )}
+
+      {step === 1 && myAgent && (
+        <>
+          <VaultKeyStep agentId={myAgent.id} />
+          <WizardNav
+            canBack
+            canNext={keyReady}
+            onBack={() => setStep(0)}
+            onNext={() => setStep(2)}
+            onSkip={() => setStep(2)}
+            skipLabel="Skip — I'll vault one elsewhere"
+            nextDisabledHint={keyReady ? undefined : 'Vault at least one provider key to continue'}
+          />
+        </>
+      )}
+
+      {step === 2 && (
+        <>
+          <div className="space-y-3">
+            <div className="space-y-1.5">
+              <p className="text-sm font-medium text-text-primary">Anthropic SDK (Python)</p>
+              <CodeBlock onCopy={() => onCopy(anthropicSDK)}>{anthropicSDK}</CodeBlock>
+            </div>
+
+            <div className="space-y-1.5">
+              <p className="text-sm font-medium text-text-primary">OpenAI SDK (Python)</p>
+              <CodeBlock onCopy={() => onCopy(openaiSDK)}>{openaiSDK}</CodeBlock>
+            </div>
+
+            <div className="space-y-1.5">
+              <p className="text-sm font-medium text-text-primary">curl / direct HTTP</p>
+              <CodeBlock onCopy={() => onCopy(curlCmd)}>{curlCmd}</CodeBlock>
+              <p className="text-xs text-text-tertiary">
+                Needs <code className="font-mono text-text-secondary">jq</code> (<code className="font-mono text-text-secondary">brew install jq</code> on macOS).
+              </p>
+            </div>
+          </div>
+          <WizardNav
+            canBack
+            canNext
+            onBack={() => setStep(1)}
+            onNext={() => setStep(3)}
+            nextLabel="Done"
+          />
+        </>
+      )}
+
+      {step >= 3 && (
+        <div className="rounded border border-success/30 bg-success/10 px-4 py-3">
+          <p className="text-sm font-medium text-success">All set.</p>
+          <button
+            onClick={() => setStep(2)}
+            className="mt-2 text-xs text-brand hover:underline"
+          >
+            Show the SDK snippets again
+          </button>
+        </div>
+      )}
+      </div>
+
+      <details className="group">
+        <summary className="text-sm font-medium text-text-secondary cursor-pointer hover:text-text-primary select-none">
+          Manual setup (inline a token created via the dashboard)
+        </summary>
+        <div className="mt-3 space-y-3">
+          <p className="text-xs text-text-tertiary">
+            If you don't want a JSON file on disk, create an agent in <strong>Your Agents</strong>{' '}
+            below and inline the token directly. The placeholder fills in automatically after creation.
+          </p>
+          <CodeBlock onCopy={() => onCopy(manualAnthropicSDK)}>{manualAnthropicSDK}</CodeBlock>
+          <CodeBlock onCopy={() => onCopy(manualOpenaiSDK)}>{manualOpenaiSDK}</CodeBlock>
+        </div>
+      </details>
+
+      <details className="group" open={showSkillDefault}>
+        <summary className="text-sm font-medium text-text-secondary cursor-pointer hover:text-text-primary select-none">
+          Skill-based setup (use Clawvisor's native skill protocol instead)
+        </summary>
+        <div className="mt-4 space-y-5">
+          <p className="text-sm text-text-secondary">
+            Any agent that can make HTTP requests can speak Clawvisor's skill protocol directly.
+            The fastest way is to paste the setup prompt below into your agent's chat — it will
+            self-register and wait for your approval.
+          </p>
+
+          <div className="space-y-4">
+            <div className="flex items-start gap-3">
+              <StepNumber n={1} />
+              <div className="space-y-1.5 min-w-0 flex-1">
+                <p className="text-sm font-medium text-text-primary">Paste this into your agent</p>
+                <div className="relative group bg-surface-0 border border-brand/20 rounded overflow-hidden">
+                  <pre className="px-3 py-2.5 sm:pr-16 text-xs font-mono text-text-primary overflow-x-auto whitespace-pre-wrap break-words">
+                    {prompt}
+                  </pre>
+                  <button
+                    onClick={() => onCopy(prompt)}
+                    className="hidden sm:block absolute top-2 right-2 text-xs px-2 py-1 rounded border border-border-subtle text-text-tertiary hover:text-text-primary hover:bg-surface-1"
+                  >
+                    {copied ? 'Copied' : 'Copy'}
+                  </button>
+                  <div className="sm:hidden border-t border-brand/20 px-3 py-1.5 flex justify-end">
+                    <button
+                      onClick={() => onCopy(prompt)}
+                      className="text-xs px-2.5 py-1 rounded border border-border-subtle text-text-tertiary hover:text-text-primary hover:bg-surface-1"
+                    >
+                      {copied ? 'Copied' : 'Copy'}
+                    </button>
+                  </div>
+                </div>
+                <p className="text-xs text-text-tertiary">
+                  The agent will follow the setup instructions at that URL — it registers itself,
+                  sets up E2E encryption, and installs the Clawvisor skill.
+                </p>
+              </div>
+            </div>
+
+            <div className="flex items-start gap-3">
+              <StepNumber n={2} />
+              <div className="space-y-1.5 min-w-0 flex-1">
+                <p className="text-sm font-medium text-text-primary">Approve the connection</p>
+                <p className="text-xs text-text-tertiary">
+                  A connection request will appear in the <strong>Pending Connections</strong> section above.
+                  Click <strong>Approve</strong> to grant the agent a token. It receives the token automatically
+                  and is ready to go.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <details className="group">
+            <summary className="text-sm font-medium text-text-secondary cursor-pointer hover:text-text-primary select-none">
+              Manual setup (token + environment variables)
+            </summary>
+            <div className="mt-4 space-y-4 pl-0">
+              <div className="flex items-start gap-3">
+                <StepNumber n={1} />
+                <div className="space-y-1.5 min-w-0 flex-1">
+                  <p className="text-sm font-medium text-text-primary">Create an agent token</p>
+                  <p className="text-xs text-text-tertiary">
+                    Use the <strong>Create Agent</strong> form above. Copy the token — it's shown only once.
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex items-start gap-3">
+                <StepNumber n={2} />
+                <div className="space-y-1.5 min-w-0 flex-1">
+                  <p className="text-sm font-medium text-text-primary">Configure environment variables</p>
+                  <p className="text-xs text-text-tertiary">
+                    Set these in your agent's environment (<code className="font-mono text-text-secondary">.env</code>, shell profile, container config, etc.):
+                  </p>
+                  <CodeBlock>{`CLAWVISOR_URL=${clawvisorURL}\nCLAWVISOR_AGENT_TOKEN=<your token>`}</CodeBlock>
+                </div>
+              </div>
+
+              <div className="flex items-start gap-3">
+                <StepNumber n={3} />
+                <div className="space-y-1.5 min-w-0 flex-1">
+                  <p className="text-sm font-medium text-text-primary">Verify</p>
+                  <CodeBlock>{`curl -sf -H "Authorization: Bearer $CLAWVISOR_AGENT_TOKEN" \\\n  "$CLAWVISOR_URL/api/skill/catalog" | head -20`}</CodeBlock>
+                  <p className="text-xs text-text-tertiary">
+                    Should return a JSON catalog of available services. See{' '}
+                    <code className="font-mono text-text-secondary">{clawvisorURL}/skill/SKILL.md</code>{' '}
+                    for the full protocol reference.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </details>
         </div>
       </details>
     </div>

--- a/web/src/pages/Agents.tsx
+++ b/web/src/pages/Agents.tsx
@@ -867,10 +867,12 @@ function buildBootstrapCommand(clawvisorURL: string, claim: string | undefined, 
   // The claim code (minted by an authenticated dashboard session) attributes
   // this curl to the user without leaking user_id into the URL. mkdir + chmod
   // bracket the curl so the file lands with tight perms; -sf makes curl exit
-  // non-zero without overwriting the file on a 4xx (duplicate-name 409,
-  // expired-claim 401, etc.) so retries don't clobber a previously-good file.
+  // non-zero on a 4xx (duplicate-name 409, expired-claim 401, etc.) and
+  // --remove-on-error guarantees the partial/error body never lands on disk.
+  // Without --remove-on-error, a failed retry would silently overwrite the
+  // previous good JSON with the error response.
   const claimParam = claim ? `&claim=${claim}` : ''
-  return `mkdir -p ~/.clawvisor/agents && curl -sf -X POST \\
+  return `mkdir -p ~/.clawvisor/agents && curl -sf --remove-on-error -X POST \\
   "${clawvisorURL}/api/agents/connect?wait=true&name=${agentName}${claimParam}" \\
   -o ~/.clawvisor/agents/${agentName}.json \\
   && chmod 600 ~/.clawvisor/agents/${agentName}.json`

--- a/web/src/pages/Agents.tsx
+++ b/web/src/pages/Agents.tsx
@@ -1025,6 +1025,10 @@ function BootstrapApproveStep({
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['connections'] })
       qc.invalidateQueries({ queryKey: ['overview'] })
+      // The claim was burned by the bootstrap curl that produced this
+      // request; pasting the same command again would 401. Mint a fresh
+      // one so the visible curl is immediately retry-able.
+      qc.invalidateQueries({ queryKey: ['connection-claim'] })
     },
     onError: (err: Error) => setActionError(err.message),
   })

--- a/web/src/pages/Agents.tsx
+++ b/web/src/pages/Agents.tsx
@@ -1004,6 +1004,21 @@ function BootstrapApproveStep({
     [connections, agentName],
   )
 
+  // Any time a previously-tracked pending request disappears (approved,
+  // denied via the inline buttons, or server-expired after a wait-timeout)
+  // the claim that produced it has been burned. Mint a fresh one so the
+  // visible curl in the UI is immediately retry-able. The mutation
+  // onSuccess handlers also invalidate, but this effect is the only thing
+  // that catches the server-expired case where the dashboard wasn't the
+  // driver of the resolution.
+  const hadPendingRef = useRef(false)
+  useEffect(() => {
+    if (hadPendingRef.current && !myPending) {
+      qc.invalidateQueries({ queryKey: ['connection-claim'] })
+    }
+    hadPendingRef.current = !!myPending
+  }, [myPending, qc])
+
   const [actionError, setActionError] = useState<string | null>(null)
   const approveMut = useMutation({
     mutationFn: (id: string) => api.connections.approve(id),


### PR DESCRIPTION
## Summary

- **Connect-an-Agent UI rebuilt as a per-harness wizard.** Each tab (OpenClaw, Hermes, Claude Code, Codex, Claude Desktop, Other) now drives through bootstrap → (optional) vault upstream key → use it, with state-detected progress and inline Approve/Deny so the user never has to scroll to the Pending Connections card. Auto-sequenced agent names (`codex` → `codex-0` → `codex-1`) on collisions; idempotent Codex config snippet.
- **Bootstrap curl flow + claim codes.** `POST /api/agents/connect` now accepts a single-use `?claim=` minted by an authenticated session (`POST /api/agents/connect/claim`), so the dashboard's bootstrap curl no longer leaks the user's ID. Name comes in via the query string too — body is empty. Duplicate-name collisions reject with 409 before any DB write.
- **Codex passthrough fix (the big one).** ChatGPT-OAuth bearers now route to `chatgpt.com/backend-api/codex/responses` instead of `api.openai.com/v1/responses`; a JWT-scope decode of the inbound bearer picks the upstream. The OpenAI rewriter also sniffs SSE framing in the body when Content-Type is missing — without that, Codex's `clawvisor.local/control/*` URLs were silently passed through unrewritten and the harness curled a non-existent host. Includes a regression test against a captured live Codex response.

## Test plan

- [ ] `go test ./internal/api/... ./internal/runtime/llmproxy/... ./internal/runtime/conversation/...`
- [ ] `tsc --noEmit` (frontend)
- [ ] Dashboard: bootstrap a fresh agent via each tab; verify auto-sequencing, inline approve, snippet token inlining.
- [ ] Codex: paste the dashboard's idempotent `~/.codex/config.toml` snippet twice — no duplicate block, no Codex startup error.
- [ ] End-to-end: `clawvisor agent codex --agent <name> -- exec --skip-git-repo-check --dangerously-bypass-approvals-and-sandbox 'write hello to /tmp/foo'` succeeds and the proxy's `lite-proxy-trace.jsonl` shows `control_rewrite` events for the task-creation tool_use.
- [ ] Claim code: re-running the bootstrap curl with the same claim returns 401 INVALID_CLAIM; dashboard auto-mints a fresh one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)