### PR TITLE
Harden LLM proxy security boundaries

### DIFF
--- a/cmd/clawvisor/cmd_agent_registry.go
+++ b/cmd/clawvisor/cmd_agent_registry.go
@@ -98,7 +98,7 @@ var agentRegisterCmd = &cobra.Command{
 		}
 		registry.Agents[name] = entry
 		if err := saveAgentRegistry(path, registry); err != nil {
-			return fmt.Errorf("rotated token for agent %q but could not save local registry: %w\nrecovery:\n  server_url=%s\n  agent_token=%s", name, err, cl.BaseURL(), agent.Token)
+			return fmt.Errorf("rotated token for agent %q but could not save local registry at %s: %w", name, path, err)
 		}
 
 		llmSetup, err := maybeConfigureRegisteredAgentLLM(cmd, cl, entry)

--- a/internal/api/handlers/proxy_resolver.go
+++ b/internal/api/handlers/proxy_resolver.go
@@ -201,7 +201,9 @@ func (h *ProxyResolverHandler) Forward(w http.ResponseWriter, r *http.Request) {
 		auditDecide = "deny"
 		auditOutcome = "ssrf_blocked"
 		auditReason = err.Error()
-		writeJSONError(w, http.StatusForbidden, "SSRF_BLOCKED", err.Error())
+		h.Logger.WarnContext(r.Context(), "lite-proxy resolver: blocked target host",
+			"host", targetHost, "err", err.Error())
+		writeJSONError(w, http.StatusForbidden, "SSRF_BLOCKED", "target host is not allowed")
 		return
 	}
 
@@ -406,22 +408,27 @@ func (h *ProxyResolverHandler) swapHeaderPlaceholders(r *http.Request, agent *st
 			}
 		}
 		// Bound-service host check.
-		hosts := inspector.BoundServiceHosts(ph.ServiceID)
-		if len(hosts) > 0 {
-			// Strip port for allowlist comparison; preserve the original
-			// host:port for the upstream dial. Allowlist entries are
-			// hostnames (e.g. "api.github.com"), so targetHost like
-			// "api.github.com:443" must compare as "api.github.com".
-			hostOnly := targetHost
-			if h, _, err := net.SplitHostPort(targetHost); err == nil {
-				hostOnly = h
+		hosts, boundReason := llmproxy.RuntimePlaceholderBoundHosts(r.Context(), h.Store, ph)
+		if len(hosts) == 0 {
+			return "", &resolverAPIError{
+				status: http.StatusForbidden,
+				code:   "TARGET_HOST_NOT_BOUND",
+				msg:    "target host not in placeholder's bound-service allowlist: " + boundReason,
 			}
-			if ok, reason := inspector.BoundaryCheck(inspector.Verdict{IsAPICall: true, Host: hostOnly}, hosts); !ok {
-				return "", &resolverAPIError{
-					status: http.StatusForbidden,
-					code:   "TARGET_HOST_NOT_BOUND",
-					msg:    "target host not in placeholder's bound-service allowlist: " + reason,
-				}
+		}
+		// Strip port for allowlist comparison; preserve the original
+		// host:port for the upstream dial. Allowlist entries are
+		// hostnames (e.g. "api.github.com"), so targetHost like
+		// "api.github.com:443" must compare as "api.github.com".
+		hostOnly := targetHost
+		if h, _, err := net.SplitHostPort(targetHost); err == nil {
+			hostOnly = h
+		}
+		if ok, reason := inspector.BoundaryCheck(inspector.Verdict{IsAPICall: true, Host: hostOnly}, hosts); !ok {
+			return "", &resolverAPIError{
+				status: http.StatusForbidden,
+				code:   "TARGET_HOST_NOT_BOUND",
+				msg:    "target host not in placeholder's bound-service allowlist: " + reason,
 			}
 		}
 		vaultLookupKey := ph.ServiceID
@@ -605,6 +612,7 @@ func (h *ProxyResolverHandler) checkSSRF(ctx context.Context, host string) error
 }
 
 func isPrivateIP(ip net.IP) bool {
-	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() ||
+	cgnat := &net.IPNet{IP: net.IPv4(100, 64, 0, 0), Mask: net.CIDRMask(10, 32)}
+	return ip.IsLoopback() || ip.IsPrivate() || cgnat.Contains(ip) || ip.IsLinkLocalUnicast() ||
 		ip.IsLinkLocalMulticast() || ip.IsUnspecified() || ip.IsInterfaceLocalMulticast()
 }

--- a/internal/api/handlers/proxy_resolver_test.go
+++ b/internal/api/handlers/proxy_resolver_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -190,6 +191,18 @@ func TestResolver_RejectsMissingTargetHost(t *testing.T) {
 	}
 }
 
+func TestProxyResolverTreatsCGNATAsPrivate(t *testing.T) {
+	if !isPrivateIP(net.ParseIP("100.64.0.1")) {
+		t.Fatal("expected RFC6598 CGNAT address to be treated as private")
+	}
+	if !isPrivateIP(net.ParseIP("100.127.255.254")) {
+		t.Fatal("expected upper RFC6598 CGNAT address to be treated as private")
+	}
+	if isPrivateIP(net.ParseIP("100.128.0.1")) {
+		t.Fatal("address outside RFC6598 CGNAT range should not be treated as private")
+	}
+}
+
 func TestResolver_RejectsSelfTarget(t *testing.T) {
 	h, st, _, agent, nonces, placeholder := newSeededResolver(t)
 	h.SelfHostnames = []string{"clawvisor.example"}
@@ -250,6 +263,54 @@ func TestResolver_RejectsForeignPlaceholder(t *testing.T) {
 	}
 }
 
+func TestResolver_RejectsUnknownServicePlaceholderToArbitraryHost(t *testing.T) {
+	var seenAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenAuth = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer upstream.Close()
+
+	h, st, user, agent, nonces, _ := newSeededResolver(t)
+	const serviceID = "custom_api_key"
+	if err := h.Vault.Set(context.Background(), user.ID, serviceID, []byte("custom-secret")); err != nil {
+		t.Fatalf("vault.Set: %v", err)
+	}
+	placeholder, err := autovault.GeneratePlaceholder(autovault.PlaceholderPrefix(serviceID))
+	if err != nil {
+		t.Fatalf("GeneratePlaceholder: %v", err)
+	}
+	if err := st.CreateRuntimePlaceholder(context.Background(), &store.RuntimePlaceholder{
+		Placeholder: placeholder,
+		UserID:      user.ID,
+		AgentID:     agent.ID,
+		ServiceID:   serviceID,
+		VaultItemID: serviceID,
+	}); err != nil {
+		t.Fatalf("CreateRuntimePlaceholder: %v", err)
+	}
+	h.Client = upstream.Client()
+	h.Client.Transport = &redirectTargetTransport{base: upstream.URL}
+
+	mux := http.NewServeMux()
+	mw := middleware.RequireAgentLLMNonce(st, nonces, slog.Default())
+	mux.Handle("/proxy/v1/", mw(http.HandlerFunc(h.Forward)))
+
+	req := httptest.NewRequest(http.MethodGet, "/proxy/v1/collect", nil)
+	req.Header.Set("X-Clawvisor-Target-Host", "attacker.example")
+	req.Header.Set("X-Clawvisor-Caller", nonceForRequest(t, nonces, agent.ID, req))
+	req.Header.Set("Authorization", "Bearer "+placeholder)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected unknown-service placeholder to fail closed, got %d (%s)", rec.Code, rec.Body.String())
+	}
+	if seenAuth != "" {
+		t.Fatalf("unknown-service placeholder should not be swapped to arbitrary host, saw auth %q", seenAuth)
+	}
+}
+
 func TestResolver_RejectsCallWithoutPlaceholder(t *testing.T) {
 	h, st, _, agent, nonces, _ := newSeededResolver(t)
 
@@ -292,7 +353,7 @@ func TestResolver_RejectsHostOutsideBoundService(t *testing.T) {
 	}
 }
 
-func TestResolver_AllowsUnknownServiceHostAfterPlaceholderAndTaskValidation(t *testing.T) {
+func TestResolver_AllowsUnknownServiceHostBoundByCredentialGrant(t *testing.T) {
 	var seenAuth string
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		seenAuth = r.Header.Get("Authorization")
@@ -310,12 +371,31 @@ func TestResolver_AllowsUnknownServiceHostAfterPlaceholderAndTaskValidation(t *t
 	if err != nil {
 		t.Fatalf("GeneratePlaceholder: %v", err)
 	}
+	expiresAt := time.Now().UTC().Add(time.Hour)
+	const grantID = "grant-agentphone"
+	if err := st.CreateCredentialAuthorization(context.Background(), &store.CredentialAuthorization{
+		ID:            grantID,
+		UserID:        user.ID,
+		AgentID:       agent.ID,
+		Scope:         "session",
+		CredentialRef: "agentphone",
+		Service:       "agentphone",
+		Host:          "api.agentphone.ai",
+		HeaderName:    "authorization",
+		Scheme:        "bearer",
+		Status:        "active",
+		ExpiresAt:     &expiresAt,
+	}); err != nil {
+		t.Fatalf("CreateCredentialAuthorization: %v", err)
+	}
 	if err := st.CreateRuntimePlaceholder(context.Background(), &store.RuntimePlaceholder{
-		Placeholder: placeholder,
-		UserID:      user.ID,
-		AgentID:     agent.ID,
-		ServiceID:   "agentphone",
-		VaultItemID: "agentphone",
+		Placeholder:       placeholder,
+		UserID:            user.ID,
+		AgentID:           agent.ID,
+		ServiceID:         "agentphone",
+		VaultItemID:       "agentphone",
+		CredentialGrantID: grantID,
+		ExpiresAt:         &expiresAt,
 	}); err != nil {
 		t.Fatalf("CreateRuntimePlaceholder: %v", err)
 	}

--- a/internal/api/handlers/runtime.go
+++ b/internal/api/handlers/runtime.go
@@ -237,10 +237,6 @@ func (h *RuntimeHandler) CreateUserPlaceholder(w http.ResponseWriter, r *http.Re
 		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "ttl_seconds must be positive")
 		return
 	}
-	if ttl <= 0 {
-		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "ttl_seconds must be positive")
-		return
-	}
 	var agentID string
 	if req.AgentID != "" {
 		agents, err := h.st.ListAgents(r.Context(), user.ID)

--- a/internal/api/middleware/agent_llm.go
+++ b/internal/api/middleware/agent_llm.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/clawvisor/clawvisor/internal/auth"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy"
@@ -73,6 +74,10 @@ func RequireAgentLLM(st store.Store) func(http.Handler) http.Handler {
 					return
 				}
 				writeAuthError(w, http.StatusUnauthorized, "UNAUTHORIZED", "invalid agent token")
+				return
+			}
+			if agent.TokenExpiresAt != nil && time.Now().After(*agent.TokenExpiresAt) {
+				writeAuthError(w, http.StatusUnauthorized, "TOKEN_EXPIRED", "agent token has expired")
 				return
 			}
 			ctx := store.WithAgent(r.Context(), agent)
@@ -158,6 +163,10 @@ func RequireAgentLLMNonce(st store.Store, cache llmproxy.CallerNonceCache, logge
 				}
 				writeAuthError(w, http.StatusServiceUnavailable, "SERVICE_UNAVAILABLE",
 					"temporary service error, please retry")
+				return
+			}
+			if agent.TokenExpiresAt != nil && time.Now().After(*agent.TokenExpiresAt) {
+				writeAuthError(w, http.StatusUnauthorized, "TOKEN_EXPIRED", "agent token has expired")
 				return
 			}
 			ctx := store.WithAgent(r.Context(), agent)

--- a/internal/api/middleware/agent_llm_test.go
+++ b/internal/api/middleware/agent_llm_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/clawvisor/clawvisor/internal/auth"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy"
@@ -34,6 +35,31 @@ func newSeededAgent(t *testing.T) (store.Store, *store.Agent, string) {
 	agent, err := st.CreateAgent(ctx, user.ID, "test", auth.HashToken(raw))
 	if err != nil {
 		t.Fatalf("CreateAgent: %v", err)
+	}
+	return st, agent, raw
+}
+
+func newExpiredSeededAgent(t *testing.T) (store.Store, *store.Agent, string) {
+	t.Helper()
+	ctx := context.Background()
+	db, err := sqlite.New(ctx, filepath.Join(t.TempDir(), "agent.db"))
+	if err != nil {
+		t.Fatalf("sqlite.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	st := sqlite.NewStore(db)
+
+	user, err := st.CreateUser(ctx, "expired-agent-llm@example.com", "x")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	raw, err := auth.GenerateAgentToken()
+	if err != nil {
+		t.Fatalf("GenerateAgentToken: %v", err)
+	}
+	agent, err := st.CreateAgentWithExpiry(ctx, user.ID, "expired", auth.HashToken(raw), time.Now().Add(-time.Minute))
+	if err != nil {
+		t.Fatalf("CreateAgentWithExpiry: %v", err)
 	}
 	return st, agent, raw
 }
@@ -108,6 +134,50 @@ func TestRequireAgentLLM_AcceptsClawvisorAgentTokenHeaderForPassthrough(t *testi
 	}
 	if !passthrough {
 		t.Fatalf("expected passthrough upstream auth context")
+	}
+}
+
+func TestRequireAgentLLM_RejectsExpiredAgentToken(t *testing.T) {
+	st, _, raw := newExpiredSeededAgent(t)
+
+	handler := RequireAgentLLM(st)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("handler should not run for an expired agent token")
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	req.Header.Set("Authorization", "Bearer "+raw)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for expired agent token, got %d (%s)", rec.Code, rec.Body.String())
+	}
+}
+
+func TestRequireAgentLLMNonce_RejectsExpiredNonceBoundAgent(t *testing.T) {
+	st, agent, _ := newExpiredSeededAgent(t)
+	nonces := llmproxy.NewMemoryCallerNonceCache(5 * time.Minute)
+	nonce, err := nonces.Mint(context.Background(), agent.ID, llmproxy.NonceTarget{
+		Host:   "api.github.com",
+		Method: http.MethodPost,
+		Path:   "/user",
+	})
+	if err != nil {
+		t.Fatalf("Mint: %v", err)
+	}
+
+	handler := RequireAgentLLMNonce(st, nonces, nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("handler should not run for an expired nonce-bound agent")
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/proxy/v1/user", nil)
+	req.Header.Set("X-Clawvisor-Caller", "Bearer "+nonce)
+	req.Header.Set("X-Clawvisor-Target-Host", "api.github.com")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for expired nonce-bound agent, got %d (%s)", rec.Code, rec.Body.String())
 	}
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -607,6 +607,13 @@ func (s *Server) routes() http.Handler {
 	userPolicyRL := func(h http.HandlerFunc) http.Handler {
 		return requireUser(middleware.RateLimit(policyRL, userKeyFn, rlCfg.PolicyAPI.Limit)(h))
 	}
+	llmPreAuthKeyFn := func(r *http.Request) string { return "llm-ip:" + ipKeyFn(r) }
+	llmAgentKeyFn := func(r *http.Request) string {
+		if a := middleware.AgentFromContext(r.Context()); a != nil {
+			return "llm-agent:" + a.ID
+		}
+		return ""
+	}
 	authRateLimited := func(h http.HandlerFunc) http.Handler {
 		return middleware.RateLimit(authRL, ipKeyFn, rlCfg.Auth.Limit)(h)
 	}
@@ -1021,6 +1028,11 @@ func (s *Server) routes() http.Handler {
 		// LLM endpoint accepts the agent token via SDK auth headers or
 		// X-Clawvisor-Agent-Token for Claude Code subscription passthrough.
 		requireAgentLLM := middleware.RequireAgentLLM(s.store)
+		requireAgentLLMRL := func(h http.HandlerFunc) http.Handler {
+			agentLimited := middleware.RateLimit(gatewayRL, llmAgentKeyFn, rlCfg.Gateway.Limit)(http.HandlerFunc(h))
+			authenticated := requireAgentLLM(agentLimited)
+			return middleware.RateLimit(gatewayRL, llmPreAuthKeyFn, rlCfg.Gateway.Limit)(authenticated)
+		}
 
 		// Resolver expects a short-lived single-use nonce in
 		// X-Clawvisor-Caller — never the raw agent token. The nonce is
@@ -1028,10 +1040,10 @@ func (s *Server) routes() http.Handler {
 		// authorizes the specific call the proxy already approved.
 		requireAgentLLMCaller := middleware.RequireAgentLLMNonce(s.store, callerNonces, s.logger)
 
-		mux.Handle("POST /v1/messages", requireAgentLLM(http.HandlerFunc(llmHandler.Messages)))
-		mux.Handle("POST /v1/messages/count_tokens", requireAgentLLM(http.HandlerFunc(llmHandler.Messages)))
-		mux.Handle("POST /v1/chat/completions", requireAgentLLM(http.HandlerFunc(llmHandler.ChatCompletions)))
-		mux.Handle("POST /v1/responses", requireAgentLLM(http.HandlerFunc(llmHandler.Responses)))
+		mux.Handle("POST /v1/messages", requireAgentLLMRL(llmHandler.Messages))
+		mux.Handle("POST /v1/messages/count_tokens", requireAgentLLMRL(llmHandler.Messages))
+		mux.Handle("POST /v1/chat/completions", requireAgentLLMRL(llmHandler.ChatCompletions))
+		mux.Handle("POST /v1/responses", requireAgentLLMRL(llmHandler.Responses))
 
 		// Synthetic Clawvisor control plane. Model-emitted calls to
 		// https://clawvisor.local/control/... are rewritten here with

--- a/internal/runtime/autovault/swap.go
+++ b/internal/runtime/autovault/swap.go
@@ -83,7 +83,7 @@ func ExtractCredentialValue(credential []byte) (string, error) {
 	}
 	for _, key := range []string{"access_token", "token", "api_key", "password"} {
 		if raw, ok := decoded[key].(string); ok && strings.TrimSpace(raw) != "" {
-			return raw, nil
+			return strings.TrimSpace(raw), nil
 		}
 	}
 	return "", fmt.Errorf("credential has no swappable token field")

--- a/internal/runtime/conversation/anthropic_response.go
+++ b/internal/runtime/conversation/anthropic_response.go
@@ -292,7 +292,10 @@ func (rw AnthropicResponseRewriter) rewriteSSE(body []byte, eval ToolUseEvaluato
 	if !anyBlocked && anyRewritten {
 		// Re-emit the entire turn as SSE with the rewritten input bytes
 		// substituted for the affected tool_use blocks.
-		assembled := buildAnthropicMultiBlockSSE(msgID, msgModel, msgRole, orderedAll, rewrittenInput)
+		assembled, err := buildAnthropicMultiBlockSSE(msgID, msgModel, msgRole, orderedAll, rewrittenInput)
+		if err != nil {
+			return RewriteResult{}, err
+		}
 		return RewriteResult{
 			Body:          assembled,
 			Decisions:     decisions,
@@ -321,7 +324,7 @@ func (rw AnthropicResponseRewriter) rewriteSSE(body []byte, eval ToolUseEvaluato
 // message_delta + message_stop. Block indices are 0..N-1 contiguous;
 // the upstream's original indices are not preserved (which is fine —
 // stop_reason and overall structure are what the harness cares about).
-func buildAnthropicMultiBlockSSE(msgID, model, role string, blocks []*pendingBlock, rewrittenInput map[*pendingBlock]json.RawMessage) []byte {
+func buildAnthropicMultiBlockSSE(msgID, model, role string, blocks []*pendingBlock, rewrittenInput map[*pendingBlock]json.RawMessage) ([]byte, error) {
 	if msgID == "" {
 		msgID = "msg_clawvisor_rewrite"
 	}
@@ -333,16 +336,20 @@ func buildAnthropicMultiBlockSSE(msgID, model, role string, blocks []*pendingBlo
 	}
 
 	var b bytes.Buffer
-	emit := func(name string, data any) {
-		raw, _ := json.Marshal(data)
+	emit := func(name string, data any) error {
+		raw, err := json.Marshal(data)
+		if err != nil {
+			return err
+		}
 		b.WriteString("event: ")
 		b.WriteString(name)
 		b.WriteString("\ndata: ")
 		b.Write(raw)
 		b.WriteString("\n\n")
+		return nil
 	}
 
-	emit("message_start", map[string]any{
+	if err := emit("message_start", map[string]any{
 		"type": "message_start",
 		"message": map[string]any{
 			"id":            msgID,
@@ -354,14 +361,16 @@ func buildAnthropicMultiBlockSSE(msgID, model, role string, blocks []*pendingBlo
 			"stop_sequence": nil,
 			"usage":         map[string]int{"input_tokens": 0, "output_tokens": 0},
 		},
-	})
+	}); err != nil {
+		return nil, err
+	}
 
 	stopReason := "end_turn"
 	outIndex := 0
 	for _, pb := range blocks {
 		if pb.isTU {
 			stopReason = "tool_use"
-			emit("content_block_start", map[string]any{
+			if err := emit("content_block_start", map[string]any{
 				"type":  "content_block_start",
 				"index": outIndex,
 				"content_block": map[string]any{
@@ -370,23 +379,29 @@ func buildAnthropicMultiBlockSSE(msgID, model, role string, blocks []*pendingBlo
 					"name":  pb.name,
 					"input": map[string]any{},
 				},
-			})
+			}); err != nil {
+				return nil, err
+			}
 			input := pb.input.Bytes()
 			if rw, ok := rewrittenInput[pb]; ok {
 				input = rw
 			}
-			emit("content_block_delta", map[string]any{
+			if err := emit("content_block_delta", map[string]any{
 				"type":  "content_block_delta",
 				"index": outIndex,
 				"delta": map[string]any{
 					"type":         "input_json_delta",
 					"partial_json": string(input),
 				},
-			})
-			emit("content_block_stop", map[string]any{
+			}); err != nil {
+				return nil, err
+			}
+			if err := emit("content_block_stop", map[string]any{
 				"type":  "content_block_stop",
 				"index": outIndex,
-			})
+			}); err != nil {
+				return nil, err
+			}
 			outIndex++
 			continue
 		}
@@ -394,43 +409,53 @@ func buildAnthropicMultiBlockSSE(msgID, model, role string, blocks []*pendingBlo
 			continue
 		}
 		// Text block.
-		emit("content_block_start", map[string]any{
+		if err := emit("content_block_start", map[string]any{
 			"type":  "content_block_start",
 			"index": outIndex,
 			"content_block": map[string]any{
 				"type": "text",
 				"text": "",
 			},
-		})
+		}); err != nil {
+			return nil, err
+		}
 		if pb.text.Len() > 0 {
-			emit("content_block_delta", map[string]any{
+			if err := emit("content_block_delta", map[string]any{
 				"type":  "content_block_delta",
 				"index": outIndex,
 				"delta": map[string]any{
 					"type": "text_delta",
 					"text": pb.text.String(),
 				},
-			})
+			}); err != nil {
+				return nil, err
+			}
 		}
-		emit("content_block_stop", map[string]any{
+		if err := emit("content_block_stop", map[string]any{
 			"type":  "content_block_stop",
 			"index": outIndex,
-		})
+		}); err != nil {
+			return nil, err
+		}
 		outIndex++
 	}
 
-	emit("message_delta", map[string]any{
+	if err := emit("message_delta", map[string]any{
 		"type": "message_delta",
 		"delta": map[string]any{
 			"stop_reason":   stopReason,
 			"stop_sequence": nil,
 		},
 		"usage": map[string]int{"output_tokens": 0},
-	})
-	emit("message_stop", map[string]any{
+	}); err != nil {
+		return nil, err
+	}
+	if err := emit("message_stop", map[string]any{
 		"type": "message_stop",
-	})
-	return b.Bytes()
+	}); err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 func SynthAnthropicTextSSE(msgID, model, role, text string) []byte {

--- a/internal/runtime/conversation/openai_response.go
+++ b/internal/runtime/conversation/openai_response.go
@@ -434,32 +434,33 @@ func buildOpenAIResponsesMultiSSE(items []orderedResponsesItem) []byte {
 		"response": map[string]any{"id": "resp_clawvisor_rewrite", "status": "in_progress"},
 	}))
 	for i, it := range items {
+		outputIndex := it.outputIndex
 		if it.isText {
 			itemID := fmt.Sprintf("msg_clawvisor_%d", i)
 			b.WriteString(sseEventBlock("response.output_item.added", map[string]any{
 				"type":         "response.output_item.added",
-				"output_index": i,
+				"output_index": outputIndex,
 				"item":         map[string]any{"id": itemID, "type": "message", "role": "assistant", "status": "in_progress"},
 			}))
 			if it.text != "" {
 				b.WriteString(sseEventBlock("response.output_text.delta", map[string]any{
 					"type":          "response.output_text.delta",
 					"item_id":       itemID,
-					"output_index":  i,
+					"output_index":  outputIndex,
 					"content_index": 0,
 					"delta":         it.text,
 				}))
 				b.WriteString(sseEventBlock("response.output_text.done", map[string]any{
 					"type":          "response.output_text.done",
 					"item_id":       itemID,
-					"output_index":  i,
+					"output_index":  outputIndex,
 					"content_index": 0,
 					"text":          it.text,
 				}))
 			}
 			b.WriteString(sseEventBlock("response.output_item.done", map[string]any{
 				"type":         "response.output_item.done",
-				"output_index": i,
+				"output_index": outputIndex,
 				"item":         map[string]any{"id": itemID, "type": "message", "role": "assistant", "status": "completed"},
 			}))
 			continue
@@ -475,12 +476,12 @@ func buildOpenAIResponsesMultiSSE(items []orderedResponsesItem) []byte {
 			}
 			b.WriteString(sseEventBlock("response.output_item.added", map[string]any{
 				"type":         "response.output_item.added",
-				"output_index": i,
+				"output_index": outputIndex,
 				"item":         passThrough,
 			}))
 			b.WriteString(sseEventBlock("response.output_item.done", map[string]any{
 				"type":         "response.output_item.done",
-				"output_index": i,
+				"output_index": outputIndex,
 				"item":         passThrough,
 			}))
 			continue
@@ -492,7 +493,7 @@ func buildOpenAIResponsesMultiSSE(items []orderedResponsesItem) []byte {
 			}
 			b.WriteString(sseEventBlock("response.output_item.added", map[string]any{
 				"type":         "response.output_item.added",
-				"output_index": i,
+				"output_index": outputIndex,
 				"item": map[string]any{
 					"id":      itemID,
 					"type":    "custom_tool_call",
@@ -504,7 +505,7 @@ func buildOpenAIResponsesMultiSSE(items []orderedResponsesItem) []byte {
 			}))
 			b.WriteString(sseEventBlock("response.output_item.done", map[string]any{
 				"type":         "response.output_item.done",
-				"output_index": i,
+				"output_index": outputIndex,
 				"item": map[string]any{
 					"id":      itemID,
 					"type":    "custom_tool_call",
@@ -523,7 +524,7 @@ func buildOpenAIResponsesMultiSSE(items []orderedResponsesItem) []byte {
 		}
 		b.WriteString(sseEventBlock("response.output_item.added", map[string]any{
 			"type":         "response.output_item.added",
-			"output_index": i,
+			"output_index": outputIndex,
 			"item": map[string]any{
 				"id":      itemID,
 				"type":    "function_call",
@@ -535,19 +536,19 @@ func buildOpenAIResponsesMultiSSE(items []orderedResponsesItem) []byte {
 		b.WriteString(sseEventBlock("response.function_call_arguments.delta", map[string]any{
 			"type":         "response.function_call_arguments.delta",
 			"item_id":      itemID,
-			"output_index": i,
+			"output_index": outputIndex,
 			"delta":        it.arguments,
 		}))
 		b.WriteString(sseEventBlock("response.function_call_arguments.done", map[string]any{
 			"type":         "response.function_call_arguments.done",
 			"item_id":      itemID,
-			"output_index": i,
+			"output_index": outputIndex,
 			"name":         it.name,
 			"arguments":    it.arguments,
 		}))
 		b.WriteString(sseEventBlock("response.output_item.done", map[string]any{
 			"type":         "response.output_item.done",
-			"output_index": i,
+			"output_index": outputIndex,
 			"item": map[string]any{
 				"id":        itemID,
 				"type":      "function_call",

--- a/internal/runtime/conversation/openai_response_custom_input_test.go
+++ b/internal/runtime/conversation/openai_response_custom_input_test.go
@@ -34,6 +34,29 @@ func TestCustomToolCallReemit_PreservesStringInput(t *testing.T) {
 	}
 }
 
+func TestResponsesMultiSSEPreservesOriginalOutputIndex(t *testing.T) {
+	sse := string(buildOpenAIResponsesMultiSSE([]orderedResponsesItem{
+		{
+			isText:      true,
+			outputIndex: 2,
+			text:        "hello",
+		},
+		{
+			outputIndex: 5,
+			itemID:      "fc_1",
+			callID:      "call_1",
+			name:        "shell",
+			arguments:   `{"cmd":"pwd"}`,
+		},
+	}))
+	if strings.Contains(sse, `"output_index":0`) || strings.Contains(sse, `"output_index":1`) {
+		t.Fatalf("synthesized SSE should preserve original output_index values, got:\n%s", sse)
+	}
+	if !strings.Contains(sse, `"output_index":2`) || !strings.Contains(sse, `"output_index":5`) {
+		t.Fatalf("synthesized SSE missing original output_index values, got:\n%s", sse)
+	}
+}
+
 func TestCustomToolInputForReemit_NilCollapsesToNull(t *testing.T) {
 	got := customToolInputForReemit(nil, nil)
 	if got != nil {

--- a/internal/runtime/llmproxy/inspector/boundservices.go
+++ b/internal/runtime/llmproxy/inspector/boundservices.go
@@ -66,6 +66,8 @@ func BoundServiceHosts(serviceID string) []string {
 		return []string{"api.linear.app"}
 	case "perplexity":
 		return []string{"api.perplexity.ai"}
+	case "resend":
+		return []string{"api.resend.com"}
 	case "openai":
 		return []string{"api.openai.com"}
 	case "anthropic":

--- a/internal/runtime/llmproxy/placeholder_bound_hosts.go
+++ b/internal/runtime/llmproxy/placeholder_bound_hosts.go
@@ -1,0 +1,54 @@
+package llmproxy
+
+import (
+	"context"
+	"net"
+	"net/url"
+	"strings"
+
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/inspector"
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+// RuntimePlaceholderBoundHosts returns the authoritative host allowlist for a
+// runtime placeholder. Known services use the built-in service boundary; custom
+// services may only fall back to the original credential authorization host.
+func RuntimePlaceholderBoundHosts(ctx context.Context, st store.Store, ph *store.RuntimePlaceholder) ([]string, string) {
+	if ph == nil {
+		return nil, "placeholder missing"
+	}
+	hosts := inspector.BoundServiceHosts(ph.ServiceID)
+	if len(hosts) > 0 {
+		return hosts, ""
+	}
+	serviceID := strings.TrimSpace(ph.ServiceID)
+	if ph.CredentialGrantID == "" {
+		return nil, "no bound-service hosts for service " + serviceID
+	}
+	if st == nil {
+		return nil, "no store configured for credential grant host lookup"
+	}
+	auth, err := st.GetCredentialAuthorization(ctx, ph.CredentialGrantID)
+	if err != nil {
+		return nil, "credential grant host lookup failed"
+	}
+	host := normalizeCredentialAuthorizationHost(auth.Host)
+	if host == "" {
+		return nil, "no bound-service hosts for service " + serviceID
+	}
+	return []string{host}, ""
+}
+
+func normalizeCredentialAuthorizationHost(host string) string {
+	host = strings.ToLower(strings.TrimSpace(host))
+	if host == "" {
+		return ""
+	}
+	if parsed, err := url.Parse(host); err == nil && parsed.Host != "" {
+		host = parsed.Host
+	}
+	if hostOnly, _, err := net.SplitHostPort(host); err == nil {
+		host = hostOnly
+	}
+	return strings.TrimSuffix(host, ".")
+}

--- a/internal/runtime/llmproxy/postprocess.go
+++ b/internal/runtime/llmproxy/postprocess.go
@@ -907,10 +907,7 @@ func redactPlaceholderForReason(ph string) string {
 }
 
 // boundaryCheckVerdict validates the inspector's claimed host against
-// the bound-service allowlist of every placeholder it found. Unknown
-// services do not fail the boundary check; they fall through to the
-// task/intent authorization layer, which is the only source of truth for
-// services we have not hardcoded.
+// the bound-service allowlist of every placeholder it found.
 func boundaryCheckVerdict(req *http.Request, cfg PostprocessConfig, v inspector.Verdict) (string, bool) {
 	if cfg.Store == nil {
 		return "no store configured for boundary check", false
@@ -932,9 +929,9 @@ func boundaryCheckVerdict(req *http.Request, cfg PostprocessConfig, v inspector.
 		if reason, ok := ValidateRuntimePlaceholderAccess(req.Context(), cfg.Store, rec, cfg.AgentUserID, cfg.AgentID, time.Now().UTC()); !ok {
 			return reason + " (placeholder=" + redactPlaceholderForReason(ph) + ")", false
 		}
-		hosts := inspector.BoundServiceHosts(rec.ServiceID)
+		hosts, boundReason := RuntimePlaceholderBoundHosts(req.Context(), cfg.Store, rec)
 		if len(hosts) == 0 {
-			return "no hardcoded bound-service hosts for service " + rec.ServiceID + "; deferring to task/intent verification", true
+			return boundReason, false
 		}
 		if ok, reason := inspector.BoundaryCheck(v, hosts); !ok {
 			return reason, false

--- a/internal/runtime/llmproxy/postprocess_test.go
+++ b/internal/runtime/llmproxy/postprocess_test.go
@@ -179,7 +179,7 @@ func TestPostprocess_SourceTriggerMissHonorsToolDenyRule(t *testing.T) {
 	}
 }
 
-func TestBoundaryCheckVerdictUnknownServiceDefersToIntentVerification(t *testing.T) {
+func TestBoundaryCheckVerdictUnknownServiceFailsClosed(t *testing.T) {
 	placeholder := "autovault_agentphone_xxx"
 	st, userID, agentID := seedPostprocessStoreWithService(t, placeholder, "agentphone")
 	req := httptest.NewRequest("POST", "/v1/messages", nil)
@@ -194,11 +194,11 @@ func TestBoundaryCheckVerdictUnknownServiceDefersToIntentVerification(t *testing
 		Placeholders: []string{placeholder},
 	})
 
-	if !ok {
-		t.Fatalf("expected unknown service to defer to task/intent verification, got reason %q", reason)
+	if ok {
+		t.Fatalf("expected unknown service to fail closed, got reason %q", reason)
 	}
-	if !strings.Contains(reason, "deferring to task/intent verification") {
-		t.Fatalf("expected deferral reason, got %q", reason)
+	if !strings.Contains(reason, "no bound-service hosts") {
+		t.Fatalf("expected missing bound-host reason, got %q", reason)
 	}
 }
 

--- a/internal/runtime/llmproxy/release.go
+++ b/internal/runtime/llmproxy/release.go
@@ -310,9 +310,9 @@ func boundaryCheckReleaseVerdict(ctx context.Context, req ReleaseRequest, v insp
 		if reason, ok := ValidateRuntimePlaceholderAccess(ctx, req.Store, rec, req.Agent.UserID, req.Agent.ID, time.Now().UTC()); !ok {
 			return reason, false
 		}
-		hosts := inspector.BoundServiceHosts(rec.ServiceID)
+		hosts, boundReason := RuntimePlaceholderBoundHosts(ctx, req.Store, rec)
 		if len(hosts) == 0 {
-			return "no hardcoded bound-service hosts for service " + rec.ServiceID + "; deferring to task/intent verification", true
+			return boundReason, false
 		}
 		if ok, reason := inspector.BoundaryCheck(v, hosts); !ok {
 			return reason, false

--- a/internal/runtime/llmproxy/release_test.go
+++ b/internal/runtime/llmproxy/release_test.go
@@ -309,7 +309,7 @@ func TestTryReleasePendingApproval_ResolveIsPinnedToPeekedID(t *testing.T) {
 	}
 }
 
-func TestTryReleasePendingApproval_ReleaseDefersUnknownServiceHostsToIntent(t *testing.T) {
+func TestTryReleasePendingApproval_BlocksUnknownServiceHosts(t *testing.T) {
 	ctx := context.Background()
 	cache := NewMemoryPendingApprovalCache(time.Minute)
 	placeholder := "autovault_agentphone_test"
@@ -349,11 +349,11 @@ func TestTryReleasePendingApproval_ReleaseDefersUnknownServiceHostsToIntent(t *t
 		}},
 		IntentVerifier: &stubIntentVerifier{verdict: &IntentVerdict{Allow: true, Explanation: "fits task"}},
 	})
-	if !result.Handled || result.Decision != "allow" || result.Outcome != "approval_released" {
-		t.Fatalf("unknown service host should defer to task/intent on release, got %+v", result)
+	if !result.Handled || result.Decision != "deny" || result.Outcome != "approval_release_blocked" {
+		t.Fatalf("unknown service host should fail closed on release, got %+v", result)
 	}
-	if strings.Contains(string(result.Body), "Approval denied") {
-		t.Fatalf("release body should contain approved tool call, got:\n%s", result.Body)
+	if !strings.Contains(string(result.Body), "no bound-service hosts") {
+		t.Fatalf("blocked release body should explain missing bound hosts, got:\n%s", result.Body)
 	}
 }
 

--- a/internal/runtime/policy/global_rules.go
+++ b/internal/runtime/policy/global_rules.go
@@ -57,7 +57,7 @@ func MatchRuntimePolicyEgress(rules []*store.RuntimePolicyRule, agentID string, 
 
 func MatchRuntimePolicyTool(rules []*store.RuntimePolicyRule, agentID, toolName string, input map[string]any) (*store.RuntimePolicyRule, error) {
 	return bestMatchingRuntimePolicyRule(rules, agentID, func(rule *store.RuntimePolicyRule) (bool, int, error) {
-		if rule == nil || rule.Kind != "tool" || rule.ToolName != toolName {
+		if rule == nil || rule.Kind != "tool" || !toolNamesMatch(rule.ToolName, toolName) {
 			return false, 0, nil
 		}
 		if rule.InputRegex != "" {

--- a/pkg/runtime/decision/decision_test.go
+++ b/pkg/runtime/decision/decision_test.go
@@ -116,6 +116,30 @@ func TestEvaluateAuthorization_HardDenyOverridesTaskScope(t *testing.T) {
 	}
 }
 
+func TestEvaluateAuthorization_HardDenyMatchesCrossHarnessToolAlias(t *testing.T) {
+	agentID := "agent-1"
+	toolDeny := rule("tool-deny", "tool", "deny", &agentID)
+	toolDeny.ToolName = "Bash"
+	verifier := &stubIntentVerifier{verdict: &IntentVerdict{Allow: true, Explanation: "fits task"}}
+
+	got, err := EvaluateAuthorization(context.Background(), AuthorizationInput{
+		ToolUse:        toolUse("exec_command", map[string]any{"cmd": "cat README.md"}),
+		AgentID:        agentID,
+		CandidateTasks: []*store.Task{taskWithExpectedTool("task-1", agentID, "exec_command", "read repo files")},
+		ToolRules:      []*store.RuntimePolicyRule{toolDeny},
+		IntentVerifier: verifier,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Kind != VerdictDeny || got.Source != SourceRuleDeny || got.Rule != toolDeny {
+		t.Fatalf("decision = %+v, want Bash hard-deny to block exec_command alias", got)
+	}
+	if verifier.called {
+		t.Fatal("intent verifier should not run after hard deny")
+	}
+}
+
 func TestEvaluateAuthorization_ObserveDoesNotSoftenIntentRefusal(t *testing.T) {
 	verifier := &stubIntentVerifier{verdict: &IntentVerdict{Allow: false, Explanation: "wrong repo"}}
 	got, err := EvaluateAuthorization(context.Background(), AuthorizationInput{

--- a/pkg/runtime/proxy/inbound_secret_runtime.go
+++ b/pkg/runtime/proxy/inbound_secret_runtime.go
@@ -16,10 +16,12 @@ import (
 	"time"
 
 	"github.com/elazarl/goproxy"
+	"github.com/google/uuid"
 
 	"github.com/clawvisor/clawvisor/internal/llm"
 	runtimeautovault "github.com/clawvisor/clawvisor/internal/runtime/autovault"
 	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy"
 	runtimetiming "github.com/clawvisor/clawvisor/internal/runtime/timing"
 	"github.com/clawvisor/clawvisor/pkg/config"
 	"github.com/clawvisor/clawvisor/pkg/store"
@@ -299,10 +301,6 @@ func (s *runtimeSecretScanner) rewriteString(ctx context.Context, value string, 
 	replaced := false
 	s.stringsSeen++
 
-	if skipHeuristic {
-		return value, false
-	}
-
 	knownPrefixStartedAt := time.Now()
 	for _, spec := range runtimeautovault.KnownPrefixSpecs() {
 		if !strings.Contains(value, spec.Prefix) {
@@ -326,6 +324,10 @@ func (s *runtimeSecretScanner) rewriteString(ctx context.Context, value string, 
 		})
 	}
 	s.addMetric("inbound_secret.scan.known_prefix", time.Since(knownPrefixStartedAt))
+
+	if skipHeuristic {
+		return value, replaced && value != original
+	}
 
 	protocolNoiseStartedAt := time.Now()
 	if runtimeLooksLikeProtocolNoise(fieldName, value) {
@@ -353,7 +355,7 @@ func (s *runtimeSecretScanner) rewriteString(ctx context.Context, value string, 
 		if runtimeautovault.LooksLikeShadow(candidate.Value) {
 			continue
 		}
-		if placeholder, ok := s.lookupReusablePlaceholder(candidate.Value); ok {
+		if placeholder, ok := s.lookupReusablePlaceholder(ctx, candidate.Value); ok {
 			value = strings.ReplaceAll(value, candidate.Value, placeholder)
 			replaced = true
 			s.replacements++
@@ -401,7 +403,7 @@ func (s *runtimeSecretScanner) rewriteString(ctx context.Context, value string, 
 		if runtimeautovault.LooksLikeShadow(passwordValue) {
 			continue
 		}
-		placeholder, ok := s.lookupReusablePlaceholder(passwordValue)
+		placeholder, ok := s.lookupReusablePlaceholder(ctx, passwordValue)
 		if !ok {
 			var err error
 			placeholder, err = s.placeholderForValue(ctx, guessService(fieldName, value), passwordValue)
@@ -458,15 +460,15 @@ func stripRuntimeHarnessMetadataTags(value string) string {
 }
 
 func (s *runtimeSecretScanner) placeholderForValue(ctx context.Context, service, raw string) (string, error) {
-	placeholder, err := captureRuntimeSecret(ctx, s.server, s.hooks.Store, s.hooks.Vault, s.session, service, raw)
+	placeholder, err := captureRuntimeSecret(ctx, s.server, s.hooks.Store, s.hooks.Vault, s.session, s.host, service, raw)
 	if err == nil {
 		s.serviceLabels[normalizeSecretService(service)] = struct{}{}
 	}
 	return placeholder, err
 }
 
-func (s *runtimeSecretScanner) lookupReusablePlaceholder(raw string) (string, bool) {
-	return lookupRuntimeSecretPlaceholder(s.server, s.session, raw)
+func (s *runtimeSecretScanner) lookupReusablePlaceholder(ctx context.Context, raw string) (string, bool) {
+	return lookupRuntimeSecretPlaceholder(ctx, s.server, s.hooks.Store, s.session, raw)
 }
 
 func (s *runtimeSecretScanner) recordAdjudicationDebug(rec adjudicationDebugRecord) {
@@ -678,7 +680,7 @@ func (s *runtimeSecretScanner) collectAdjudicationTasks(value any, fieldName str
 			if runtimeautovault.LooksLikeShadow(candidate.Value) {
 				continue
 			}
-			if _, ok := s.lookupReusablePlaceholder(candidate.Value); ok {
+			if _, ok := s.lookupReusablePlaceholder(context.Background(), candidate.Value); ok {
 				continue
 			}
 			if highContextSecretField(fieldName) || secretContextHint(typed, candidate.Value) {
@@ -839,14 +841,15 @@ func secretValueCacheKey(agentID, raw string) string {
 	return agentID + ":" + hex.EncodeToString(sum[:])
 }
 
-func captureRuntimeSecret(ctx context.Context, srv *Server, st store.Store, v vault.Vault, session *store.RuntimeSession, service, raw string) (string, error) {
-	if placeholder, ok := lookupRuntimeSecretPlaceholder(srv, session, raw); ok {
+func captureRuntimeSecret(ctx context.Context, srv *Server, st store.Store, v vault.Vault, session *store.RuntimeSession, host, service, raw string) (string, error) {
+	if placeholder, ok := lookupRuntimeSecretPlaceholder(ctx, srv, st, session, raw); ok {
 		return placeholder, nil
 	}
 	cacheKey := secretValueCacheKey(session.AgentID, raw)
 	if entry, ok := srv.sharedCapturedSecretGet(cacheKey); ok {
-		srv.secretValueCache.Store(cacheKey, entry)
-		return entry.Placeholder, nil
+		if placeholder, ok := validateCapturedSecretCacheEntry(ctx, srv, st, session, cacheKey, entry); ok {
+			return placeholder, nil
+		}
 	}
 	release := func() {}
 	if ok, unlock := srv.acquireCapturedSecretLock(cacheKey); ok {
@@ -856,8 +859,9 @@ func captureRuntimeSecret(ctx context.Context, srv *Server, st store.Store, v va
 		deadline := time.Now().UTC().Add(2 * time.Second)
 		for time.Now().UTC().Before(deadline) {
 			if entry, ok := srv.sharedCapturedSecretGet(cacheKey); ok {
-				srv.secretValueCache.Store(cacheKey, entry)
-				return entry.Placeholder, nil
+				if placeholder, ok := validateCapturedSecretCacheEntry(ctx, srv, st, session, cacheKey, entry); ok {
+					return placeholder, nil
+				}
 			}
 			time.Sleep(50 * time.Millisecond)
 		}
@@ -874,11 +878,34 @@ func captureRuntimeSecret(ctx context.Context, srv *Server, st store.Store, v va
 	if err := v.Set(ctx, session.UserID, serviceID, []byte(raw)); err != nil {
 		return "", err
 	}
+	grantID := uuid.NewString()
+	expiresAt := session.ExpiresAt
+	metadata, _ := json.Marshal(map[string]any{"source": "runtime_secret_capture"})
+	if err := st.CreateCredentialAuthorization(ctx, &store.CredentialAuthorization{
+		ID:            grantID,
+		UserID:        session.UserID,
+		AgentID:       session.AgentID,
+		SessionID:     &session.ID,
+		Scope:         "session",
+		CredentialRef: serviceID,
+		Service:       serviceID,
+		Host:          host,
+		HeaderName:    "authorization",
+		Scheme:        "bearer",
+		Status:        "active",
+		MetadataJSON:  metadata,
+		ExpiresAt:     &expiresAt,
+	}); err != nil {
+		return "", err
+	}
 	if err := st.CreateRuntimePlaceholder(ctx, &store.RuntimePlaceholder{
-		Placeholder: placeholder,
-		UserID:      session.UserID,
-		AgentID:     session.AgentID,
-		ServiceID:   serviceID,
+		Placeholder:       placeholder,
+		UserID:            session.UserID,
+		AgentID:           session.AgentID,
+		ServiceID:         serviceID,
+		VaultItemID:       serviceID,
+		CredentialGrantID: grantID,
+		ExpiresAt:         &expiresAt,
 	}); err != nil {
 		return "", err
 	}
@@ -891,7 +918,7 @@ func captureRuntimeSecret(ctx context.Context, srv *Server, st store.Store, v va
 	return placeholder, nil
 }
 
-func lookupRuntimeSecretPlaceholder(srv *Server, session *store.RuntimeSession, raw string) (string, bool) {
+func lookupRuntimeSecretPlaceholder(ctx context.Context, srv *Server, st store.Store, session *store.RuntimeSession, raw string) (string, bool) {
 	if srv == nil || session == nil {
 		return "", false
 	}
@@ -899,13 +926,41 @@ func lookupRuntimeSecretPlaceholder(srv *Server, session *store.RuntimeSession, 
 	value, ok := srv.secretValueCache.Load(cacheKey)
 	if !ok {
 		if entry, ok := srv.sharedCapturedSecretGet(cacheKey); ok {
-			srv.secretValueCache.Store(cacheKey, entry)
-			return entry.Placeholder, true
+			return validateCapturedSecretCacheEntry(ctx, srv, st, session, cacheKey, entry)
 		}
 		return "", false
 	}
 	entry, _ := value.(capturedSecretEntry)
-	return entry.Placeholder, entry.Placeholder != ""
+	return validateCapturedSecretCacheEntry(ctx, srv, st, session, cacheKey, entry)
+}
+
+func validateCapturedSecretCacheEntry(ctx context.Context, srv *Server, st store.Store, session *store.RuntimeSession, cacheKey string, entry capturedSecretEntry) (string, bool) {
+	if entry.Placeholder == "" || st == nil || session == nil {
+		return "", false
+	}
+	rec, err := st.GetRuntimePlaceholder(ctx, entry.Placeholder)
+	if err != nil {
+		if srv != nil {
+			srv.secretValueCache.Delete(cacheKey)
+		}
+		return "", false
+	}
+	if entry.ServiceID != "" && rec.ServiceID != entry.ServiceID {
+		if srv != nil {
+			srv.secretValueCache.Delete(cacheKey)
+		}
+		return "", false
+	}
+	if _, ok := llmproxy.ValidateRuntimePlaceholderAccess(ctx, st, rec, session.UserID, session.AgentID, time.Now().UTC()); !ok {
+		if srv != nil {
+			srv.secretValueCache.Delete(cacheKey)
+		}
+		return "", false
+	}
+	if srv != nil {
+		srv.secretValueCache.Store(cacheKey, entry)
+	}
+	return entry.Placeholder, true
 }
 
 var knownProtocolNoisePrefixes = []string{

--- a/pkg/runtime/proxy/inbound_secret_runtime_test.go
+++ b/pkg/runtime/proxy/inbound_secret_runtime_test.go
@@ -10,9 +10,12 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy"
 	runtimetiming "github.com/clawvisor/clawvisor/internal/runtime/timing"
 	"github.com/clawvisor/clawvisor/pkg/config"
+	"github.com/clawvisor/clawvisor/pkg/store"
 	"github.com/clawvisor/clawvisor/pkg/store/sqlite"
 	intvault "github.com/clawvisor/clawvisor/pkg/vault"
 )
@@ -82,6 +85,66 @@ func TestRuntimeSecretCaptureKnownPrefixAndReusePlaceholder(t *testing.T) {
 	}
 }
 
+func TestRuntimeSecretCaptureIgnoresExpiredCachedPlaceholder(t *testing.T) {
+	ctx := context.Background()
+	db, err := sqlite.New(ctx, filepath.Join(t.TempDir(), "runtime-secret-expired-cache.db"))
+	if err != nil {
+		t.Fatalf("sqlite.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	st := sqlite.NewStore(db)
+	v, err := intvault.NewLocalVault(filepath.Join(t.TempDir(), "vault.key"), db, "sqlite")
+	if err != nil {
+		t.Fatalf("NewLocalVault: %v", err)
+	}
+	userID, agentID := seedRuntimePrincipal(t, st)
+	srv, err := NewServer(Config{DataDir: t.TempDir(), Addr: "127.0.0.1:0"}, nil)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	raw := "re_expiredCacheSecret123456789"
+	expiredSession := &store.RuntimeSession{
+		ID:                    "expired-capture-session",
+		UserID:                userID,
+		AgentID:               agentID,
+		Mode:                  "proxy",
+		ProxyBearerSecretHash: HashProxyBearerSecret("expired-secret"),
+		ExpiresAt:             time.Now().UTC().Add(-time.Minute),
+	}
+	if err := st.CreateRuntimeSession(ctx, expiredSession); err != nil {
+		t.Fatalf("CreateRuntimeSession(expired): %v", err)
+	}
+	first, err := captureRuntimeSecret(ctx, srv, st, v, expiredSession, "api.resend.com", "resend", raw)
+	if err != nil {
+		t.Fatalf("captureRuntimeSecret(expired): %v", err)
+	}
+	freshSession := &store.RuntimeSession{
+		ID:                    "fresh-capture-session",
+		UserID:                userID,
+		AgentID:               agentID,
+		Mode:                  "proxy",
+		ProxyBearerSecretHash: HashProxyBearerSecret("fresh-secret"),
+		ExpiresAt:             time.Now().UTC().Add(time.Hour),
+	}
+	if err := st.CreateRuntimeSession(ctx, freshSession); err != nil {
+		t.Fatalf("CreateRuntimeSession(fresh): %v", err)
+	}
+	second, err := captureRuntimeSecret(ctx, srv, st, v, freshSession, "api.resend.com", "resend", raw)
+	if err != nil {
+		t.Fatalf("captureRuntimeSecret(fresh): %v", err)
+	}
+	if first == second {
+		t.Fatalf("expected expired cached placeholder to be ignored, reused %q", first)
+	}
+	rec, err := st.GetRuntimePlaceholder(ctx, second)
+	if err != nil {
+		t.Fatalf("GetRuntimePlaceholder(fresh): %v", err)
+	}
+	if _, ok := llmproxy.ValidateRuntimePlaceholderAccess(ctx, st, rec, userID, agentID, time.Now().UTC()); !ok {
+		t.Fatalf("fresh placeholder should validate: %+v", rec)
+	}
+}
+
 func TestRuntimeSecretCaptureDoesNotRewriteToolSchemaNames(t *testing.T) {
 	ctx := context.Background()
 	db, err := sqlite.New(ctx, filepath.Join(t.TempDir(), "runtime-secret-schema.db"))
@@ -118,6 +181,44 @@ func TestRuntimeSecretCaptureDoesNotRewriteToolSchemaNames(t *testing.T) {
 	}
 	if string(rewritten) != string(body) {
 		t.Fatalf("tool schema should not be rewritten:\n%s", string(rewritten))
+	}
+}
+
+func TestRuntimeSecretCaptureKnownPrefixInsideNoiseSubtree(t *testing.T) {
+	ctx := context.Background()
+	db, err := sqlite.New(ctx, filepath.Join(t.TempDir(), "runtime-secret-noise-prefix.db"))
+	if err != nil {
+		t.Fatalf("sqlite.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	st := sqlite.NewStore(db)
+	v, err := intvault.NewLocalVault(filepath.Join(t.TempDir(), "vault.key"), db, "sqlite")
+	if err != nil {
+		t.Fatalf("NewLocalVault: %v", err)
+	}
+	userID, agentID := seedRuntimePrincipal(t, st)
+	session := createRuntimeSession(t, st, "noise-prefix-session", userID, agentID, false)
+	runtimeSession, err := st.GetRuntimeSession(ctx, session.id)
+	if err != nil {
+		t.Fatalf("GetRuntimeSession: %v", err)
+	}
+	srv, err := NewServer(Config{DataDir: t.TempDir(), Addr: "127.0.0.1:0"}, nil)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	cfg := config.Default()
+	cfg.LLM.Verification.Enabled = false
+	body := []byte(`{"tools":[{"name":"send","description":"Use ghp_toolSecret123456789 if requested."}],"messages":[{"role":"user","content":[{"type":"text","text":"hello"}]}]}`)
+
+	rewritten, summary, observed, err := srv.scanAndReplaceRuntimeSecrets(ctx, InboundSecretHooks{Store: st, Vault: v, Config: cfg}, runtimeSession, "api.openai.com", body)
+	if err != nil {
+		t.Fatalf("scanAndReplaceRuntimeSecrets: %v", err)
+	}
+	if observed != 0 || summary == nil || summary.ReplacementCount != 1 {
+		t.Fatalf("expected deterministic known-prefix rewrite in noise subtree, summary=%+v observed=%d", summary, observed)
+	}
+	if strings.Contains(string(rewritten), "ghp_toolSecret123456789") || !strings.Contains(string(rewritten), "autovault_github_") {
+		t.Fatalf("expected tools subtree secret to be replaced, got %s", string(rewritten))
 	}
 }
 
@@ -529,7 +630,7 @@ func TestRuntimeSecretCaptureDoesNotRewriteThinkingBlocksOrSignatures(t *testing
 	}
 }
 
-func TestRuntimeSecretCapturePlaceholdersResolveThroughOutboundSwap(t *testing.T) {
+func TestRuntimeSecretCapturePlaceholderRejectsUnboundOutboundHost(t *testing.T) {
 	ctx := context.Background()
 	db, err := sqlite.New(ctx, filepath.Join(t.TempDir(), "runtime-secret-e2e.db"))
 	if err != nil {
@@ -564,7 +665,9 @@ func TestRuntimeSecretCapturePlaceholdersResolveThroughOutboundSwap(t *testing.T
 		t.Fatalf("expected placeholder in rewritten body: %s", string(rewritten))
 	}
 
+	var seenAuth string
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenAuth = r.Header.Get("Authorization")
 		if got := r.Header.Get("Authorization"); got != "Bearer re_bridgeSecret123456789" {
 			t.Fatalf("expected outbound placeholder swap, got %q", got)
 		}
@@ -589,8 +692,11 @@ func TestRuntimeSecretCapturePlaceholdersResolveThroughOutboundSwap(t *testing.T
 	}
 	out, _ := io.ReadAll(resp.Body)
 	resp.Body.Close()
-	if resp.StatusCode != http.StatusOK || string(out) != "ok" {
-		t.Fatalf("expected upstream success, got %d %q", resp.StatusCode, string(out))
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected unbound captured placeholder rejection, got %d %q", resp.StatusCode, string(out))
+	}
+	if seenAuth != "" {
+		t.Fatalf("captured placeholder should not be forwarded to unbound host, saw auth %q", seenAuth)
 	}
 }
 

--- a/pkg/runtime/proxy/placeholder_runtime.go
+++ b/pkg/runtime/proxy/placeholder_runtime.go
@@ -78,7 +78,7 @@ func (s *Server) InstallPlaceholderSwap(hooks PlaceholderHooks) {
 					if _, ok := llmproxy.ValidateRuntimePlaceholderAccess(req.Context(), hooks.Store, meta, st.Session.UserID, st.Session.AgentID, now); !ok {
 						return "", store.ErrNotFound
 					}
-					if err := validateRuntimePlaceholderBoundHost(req, meta.ServiceID); err != nil {
+					if err := validateRuntimePlaceholderBoundHost(req, hooks.Store, meta); err != nil {
 						return "", err
 					}
 					vaultLookupKey := meta.ServiceID
@@ -197,10 +197,10 @@ func (s *Server) InstallPlaceholderSwap(hooks PlaceholderHooks) {
 	})
 }
 
-func validateRuntimePlaceholderBoundHost(req *http.Request, serviceID string) error {
-	hosts := inspector.BoundServiceHosts(serviceID)
+func validateRuntimePlaceholderBoundHost(req *http.Request, st store.Store, ph *store.RuntimePlaceholder) error {
+	hosts, reason := llmproxy.RuntimePlaceholderBoundHosts(req.Context(), st, ph)
 	if len(hosts) == 0 {
-		return nil
+		return fmt.Errorf("target host outside placeholder bound-service: %s", reason)
 	}
 	if ok, reason := inspector.BoundaryCheck(inspector.Verdict{IsAPICall: true, Host: requestHost(req)}, hosts); !ok {
 		return fmt.Errorf("target host outside placeholder bound-service: %s", reason)

--- a/pkg/runtime/proxy/placeholder_runtime_test.go
+++ b/pkg/runtime/proxy/placeholder_runtime_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -42,14 +43,6 @@ func TestRuntimeProxySwapsScopedPlaceholders(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GeneratePlaceholder: %v", err)
 	}
-	if err := st.CreateRuntimePlaceholder(ctx, &store.RuntimePlaceholder{
-		Placeholder: placeholder,
-		UserID:      userID,
-		AgentID:     agentID,
-		ServiceID:   "mock.placeholder",
-	}); err != nil {
-		t.Fatalf("CreateRuntimePlaceholder: %v", err)
-	}
 
 	cfg := config.Default()
 	cfg.RuntimeProxy.Enabled = true
@@ -61,6 +54,31 @@ func TestRuntimeProxySwapsScopedPlaceholders(t *testing.T) {
 		_, _ = w.Write([]byte(`ok`))
 	}))
 	defer upstream.Close()
+	upstreamHost := mustURL(t, upstream.URL).Hostname()
+	if err := st.CreateCredentialAuthorization(ctx, &store.CredentialAuthorization{
+		ID:            "grant-mock-placeholder",
+		UserID:        userID,
+		AgentID:       agentID,
+		Scope:         "session",
+		CredentialRef: "mock.placeholder",
+		Service:       "mock.placeholder",
+		Host:          upstreamHost,
+		HeaderName:    "authorization",
+		Scheme:        "bearer",
+		Status:        "active",
+	}); err != nil {
+		t.Fatalf("CreateCredentialAuthorization: %v", err)
+	}
+	if err := st.CreateRuntimePlaceholder(ctx, &store.RuntimePlaceholder{
+		Placeholder:       placeholder,
+		UserID:            userID,
+		AgentID:           agentID,
+		ServiceID:         "mock.placeholder",
+		VaultItemID:       "mock.placeholder",
+		CredentialGrantID: "grant-mock-placeholder",
+	}); err != nil {
+		t.Fatalf("CreateRuntimePlaceholder: %v", err)
+	}
 
 	ownerSession := createRuntimeSession(t, st, "session-owner", userID, agentID, false)
 	otherSession := createRuntimeSession(t, st, "session-other", userID, otherAgent.ID, false)
@@ -112,6 +130,15 @@ func TestRuntimeProxySwapsScopedPlaceholders(t *testing.T) {
 	if resp.StatusCode != http.StatusForbidden {
 		t.Fatalf("expected cross-agent placeholder rejection, got %d", resp.StatusCode)
 	}
+}
+
+func mustURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("url.Parse(%q): %v", raw, err)
+	}
+	return u
 }
 
 func TestRuntimeProxyRejectsPlaceholderOutsideBoundServiceHost(t *testing.T) {
@@ -284,7 +311,7 @@ func TestRuntimeProxyObservesKnownOutboundCredentialWithoutCapturing(t *testing.
 	if resp.StatusCode != http.StatusOK || seenAuth != "Bearer "+rawToken {
 		t.Fatalf("expected raw header to pass through unchanged, status=%d auth=%q", resp.StatusCode, seenAuth)
 	}
-	if _, ok := lookupRuntimeSecretPlaceholder(srv, &store.RuntimeSession{AgentID: agentID}, rawToken); ok {
+	if _, ok := lookupRuntimeSecretPlaceholder(ctx, srv, st, &store.RuntimeSession{UserID: userID, AgentID: agentID}, rawToken); ok {
 		t.Fatal("expected outbound raw credential observation to avoid silent capture")
 	}
 	events, err := st.ListRuntimeEvents(ctx, userID, store.RuntimeEventFilter{SessionID: session.id, Limit: 10})
@@ -350,7 +377,7 @@ func TestRuntimeProxyObservesUnknownOutboundCredentialInObserveMode(t *testing.T
 		t.Fatalf("proxy request: %v", err)
 	}
 	resp.Body.Close()
-	if _, ok := lookupRuntimeSecretPlaceholder(srv, &store.RuntimeSession{AgentID: agentID}, rawToken); ok {
+	if _, ok := lookupRuntimeSecretPlaceholder(ctx, srv, st, &store.RuntimeSession{UserID: userID, AgentID: agentID}, rawToken); ok {
 		t.Fatal("observe mode should not capture unknown outbound credentials")
 	}
 	events, err := st.ListRuntimeEvents(ctx, userID, store.RuntimeEventFilter{SessionID: session.id, Limit: 10})

--- a/pkg/store/postgres/store.go
+++ b/pkg/store/postgres/store.go
@@ -412,15 +412,19 @@ func (s *Store) GetAgent(ctx context.Context, id string) (*store.Agent, error) {
 func (s *Store) getAgentByID(ctx context.Context, id string) (*store.Agent, error) {
 	a := &store.Agent{}
 	var orgID *string
+	var tokenExpiresAt *time.Time
 	err := s.pool.QueryRow(ctx,
-		`SELECT id, user_id, name, description, token_hash, created_at, org_id FROM agents WHERE id = $1 AND deleted_at IS NULL`,
+		`SELECT id, user_id, name, description, token_hash, created_at, org_id, token_expires_at FROM agents WHERE id = $1 AND deleted_at IS NULL`,
 		id,
-	).Scan(&a.ID, &a.UserID, &a.Name, &a.Description, &a.TokenHash, &a.CreatedAt, &orgID)
+	).Scan(&a.ID, &a.UserID, &a.Name, &a.Description, &a.TokenHash, &a.CreatedAt, &orgID, &tokenExpiresAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, store.ErrNotFound
 	}
 	if orgID != nil {
 		a.OrgID = *orgID
+	}
+	if tokenExpiresAt != nil {
+		a.TokenExpiresAt = tokenExpiresAt
 	}
 	if settings, settingsErr := s.GetAgentRuntimeSettings(ctx, a.ID); settingsErr == nil {
 		a.RuntimeSettings = settings

--- a/pkg/store/sqlite/store.go
+++ b/pkg/store/sqlite/store.go
@@ -485,10 +485,11 @@ func (s *Store) getAgentByID(ctx context.Context, id string) (*store.Agent, erro
 	a := &store.Agent{}
 	var createdAt string
 	var orgID *string
+	var tokenExpiresAt *string
 	err := s.db.QueryRowContext(ctx,
-		`SELECT id, user_id, name, description, token_hash, created_at, org_id FROM agents WHERE id = ? AND deleted_at IS NULL`,
+		`SELECT id, user_id, name, description, token_hash, created_at, org_id, token_expires_at FROM agents WHERE id = ? AND deleted_at IS NULL`,
 		id,
-	).Scan(&a.ID, &a.UserID, &a.Name, &a.Description, &a.TokenHash, &createdAt, &orgID)
+	).Scan(&a.ID, &a.UserID, &a.Name, &a.Description, &a.TokenHash, &createdAt, &orgID, &tokenExpiresAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, store.ErrNotFound
 	}
@@ -498,6 +499,11 @@ func (s *Store) getAgentByID(ctx context.Context, id string) (*store.Agent, erro
 	a.CreatedAt = parseTime(createdAt)
 	if orgID != nil {
 		a.OrgID = *orgID
+	}
+	if tokenExpiresAt != nil && *tokenExpiresAt != "" {
+		if t := parseTime(*tokenExpiresAt); !t.IsZero() {
+			a.TokenExpiresAt = &t
+		}
 	}
 	if settings, settingsErr := s.GetAgentRuntimeSettings(ctx, a.ID); settingsErr == nil {
 		a.RuntimeSettings = settings

--- a/web/src/pages/Agents.tsx
+++ b/web/src/pages/Agents.tsx
@@ -707,7 +707,7 @@ function ConnectAgentGuide({ newToken }: { newToken: string | null }) {
     queryKey: ['connection-claim'],
     queryFn: () => api.connections.mintClaim(),
     refetchInterval: 4 * 60 * 1000,
-    staleTime: 4 * 60 * 1000,
+    staleTime: 0,
   })
 
   const isLocal = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1'


### PR DESCRIPTION
## Summary
- reject expired finite-lifetime agent tokens on LLM proxy and nonce-bound resolver paths
- fail closed for unbound custom runtime placeholders, while preserving known-service and credential-grant host binding
- align runtime tool rules with cross-harness tool aliases
- harden adjacent review findings: deterministic known-prefix scanning, LLM route rate limiting, SSRF error redaction, token-safe registry errors, SSE output indexes, CGNAT blocking, and credential trimming

## Tests
- go test ./internal/api/middleware ./internal/api/handlers ./internal/api ./internal/runtime/llmproxy ./internal/runtime/llmproxy/inspector ./internal/runtime/conversation ./pkg/runtime/proxy ./pkg/runtime/decision ./pkg/store/sqlite ./pkg/store/postgres ./cmd/clawvisor -count=1
- go test ./internal/runtime/autovault ./internal/api/handlers ./pkg/runtime/proxy -count=1
- git diff --check

## Notes
- npm run lint in web could not run in this workspace because tsc is not installed in web/node_modules.