### PR TITLE
fix(runtime): allow read-only agent tools

### DIFF
--- a/internal/api/handlers/runtime_controls_test.go
+++ b/internal/api/handlers/runtime_controls_test.go
@@ -437,7 +437,24 @@ func TestDefaultToolRulesSeedAndRespectUnset(t *testing.T) {
 	}
 
 	h := NewLLMEndpointHandler(st, nil, nil)
-	h.ensureDefaultToolRules(ctx, agent, []string{"Read", "read_file", "Bash", "Write"})
+	h.ensureDefaultToolRules(ctx, agent, []string{
+		"Read",
+		"read_file",
+		"Bash",
+		"Write",
+		"sessions_list",
+		"sessions_history",
+		"session_status",
+		"sessions_yield",
+		"memory_search",
+		"memory_get",
+		"exec",
+		"process",
+		"web_fetch",
+		"sessions_send",
+		"sessions_spawn",
+		"subagents",
+	})
 	enabled := true
 	rules, err := st.ListRuntimePolicyRules(ctx, user.ID, store.RuntimePolicyRuleFilter{AgentID: agent.ID, Kind: "tool", Enabled: &enabled})
 	if err != nil {
@@ -450,10 +467,15 @@ func TestDefaultToolRulesSeedAndRespectUnset(t *testing.T) {
 			t.Fatalf("default tool rule should be agent-scoped, got %+v", rule)
 		}
 	}
-	if !allowed["Read"] || !allowed["read_file"] {
+	if !allowed["Read"] || !allowed["read_file"] ||
+		!allowed["sessions_list"] || !allowed["sessions_history"] ||
+		!allowed["session_status"] || !allowed["sessions_yield"] ||
+		!allowed["memory_search"] || !allowed["memory_get"] {
 		t.Fatalf("expected discovered default tools to be seeded as always allow, got %+v", rules)
 	}
-	if allowed["Bash"] || allowed["Write"] {
+	if allowed["Bash"] || allowed["Write"] || allowed["exec"] || allowed["process"] ||
+		allowed["web_fetch"] || allowed["sessions_send"] || allowed["sessions_spawn"] ||
+		allowed["subagents"] {
 		t.Fatalf("non-default tools should not be seeded as always allow, got %+v", rules)
 	}
 

--- a/internal/api/handlers/runtime_controls_test.go
+++ b/internal/api/handlers/runtime_controls_test.go
@@ -454,6 +454,22 @@ func TestDefaultToolRulesSeedAndRespectUnset(t *testing.T) {
 		"sessions_send",
 		"sessions_spawn",
 		"subagents",
+		"search_files",
+		"session_search",
+		"skills_list",
+		"skill_view",
+		"clarify",
+		"browser_snapshot",
+		"browser_console",
+		"browser_get_images",
+		"terminal",
+		"write_file",
+		"patch",
+		"browser_navigate",
+		"browser_click",
+		"browser_type",
+		"browser_vision",
+		"delegate_task",
 	})
 	enabled := true
 	rules, err := st.ListRuntimePolicyRules(ctx, user.ID, store.RuntimePolicyRuleFilter{AgentID: agent.ID, Kind: "tool", Enabled: &enabled})
@@ -470,12 +486,18 @@ func TestDefaultToolRulesSeedAndRespectUnset(t *testing.T) {
 	if !allowed["Read"] || !allowed["read_file"] ||
 		!allowed["sessions_list"] || !allowed["sessions_history"] ||
 		!allowed["session_status"] || !allowed["sessions_yield"] ||
-		!allowed["memory_search"] || !allowed["memory_get"] {
+		!allowed["memory_search"] || !allowed["memory_get"] ||
+		!allowed["search_files"] || !allowed["session_search"] ||
+		!allowed["skills_list"] || !allowed["skill_view"] ||
+		!allowed["clarify"] || !allowed["browser_snapshot"] ||
+		!allowed["browser_console"] || !allowed["browser_get_images"] {
 		t.Fatalf("expected discovered default tools to be seeded as always allow, got %+v", rules)
 	}
 	if allowed["Bash"] || allowed["Write"] || allowed["exec"] || allowed["process"] ||
 		allowed["web_fetch"] || allowed["sessions_send"] || allowed["sessions_spawn"] ||
-		allowed["subagents"] {
+		allowed["subagents"] || allowed["terminal"] || allowed["write_file"] ||
+		allowed["patch"] || allowed["browser_navigate"] || allowed["browser_click"] ||
+		allowed["browser_type"] || allowed["browser_vision"] || allowed["delegate_task"] {
 		t.Fatalf("non-default tools should not be seeded as always allow, got %+v", rules)
 	}
 

--- a/internal/runtime/llmproxy/inspector/parser.go
+++ b/internal/runtime/llmproxy/inspector/parser.go
@@ -86,6 +86,12 @@ var localOnlyTools = map[string]struct{}{
 	"Monitor":    {},
 	// Pure local reads — Codex.
 	"read_file": {},
+	// Pure local reads — OpenClaw.
+	"memory_get":       {},
+	"memory_search":    {},
+	"session_status":   {},
+	"sessions_history": {},
+	"sessions_list":    {},
 	// Harness-internal lifecycle / planning state. Mutating, but the
 	// state is not user-observable.
 	"TodoWrite":        {},
@@ -113,6 +119,9 @@ var localOnlyTools = map[string]struct{}{
 	"TaskGet":    {},
 	"TaskOutput": {},
 	"TaskStop":   {},
+	// OpenClaw's local turn-control tool. It does not reach outside
+	// the harness.
+	"sessions_yield": {},
 	// Harness-internal user clarification prompt. It does not reach
 	// outside the harness and should not require an approved task scope.
 	"AskUserQuestion": {},
@@ -155,6 +164,12 @@ var defaultAllowedTools = map[string]struct{}{
 	"TaskCreate":                  {},
 	"TaskStop":                    {},
 	"TaskUpdate":                  {},
+	"memory_get":                  {},
+	"memory_search":               {},
+	"session_status":              {},
+	"sessions_history":            {},
+	"sessions_list":               {},
+	"sessions_yield":              {},
 	"read_file":                   {},
 	"list_mcp_resources":          {},
 	"list_mcp_resource_templates": {},

--- a/internal/runtime/llmproxy/inspector/parser.go
+++ b/internal/runtime/llmproxy/inspector/parser.go
@@ -95,6 +95,7 @@ var localOnlyTools = map[string]struct{}{
 	"skill_view":         {},
 	"skills_list":        {},
 	// Pure local reads — OpenClaw.
+	"read":             {},
 	"memory_get":       {},
 	"memory_search":    {},
 	"session_status":   {},

--- a/internal/runtime/llmproxy/inspector/parser.go
+++ b/internal/runtime/llmproxy/inspector/parser.go
@@ -52,8 +52,8 @@ func (DefaultParser) Parse(t ToolUse) (Verdict, bool) {
 // Authorization is handled separately by runtime tool policies.
 //
 //  1. Pure local reads. Read / Glob / Grep / BashOutput / ToolSearch
-//     and their Codex equivalent (read_file). These don't change
-//     state or transmit credentials.
+//     and their Codex / Hermes equivalents (read_file, search_files).
+//     These don't change state or transmit credentials.
 //
 //  2. Harness-internal lifecycle / planning state. Skill / Agent /
 //     EnterPlanMode / ExitPlanMode / EnterWorktree / ExitWorktree /
@@ -86,6 +86,14 @@ var localOnlyTools = map[string]struct{}{
 	"Monitor":    {},
 	// Pure local reads — Codex.
 	"read_file": {},
+	// Pure local reads — Hermes.
+	"browser_console":    {},
+	"browser_get_images": {},
+	"browser_snapshot":   {},
+	"search_files":       {},
+	"session_search":     {},
+	"skill_view":         {},
+	"skills_list":        {},
 	// Pure local reads — OpenClaw.
 	"memory_get":       {},
 	"memory_search":    {},
@@ -122,6 +130,9 @@ var localOnlyTools = map[string]struct{}{
 	// OpenClaw's local turn-control tool. It does not reach outside
 	// the harness.
 	"sessions_yield": {},
+	// Hermes' user-clarification tool. It does not reach outside the
+	// harness or downstream APIs.
+	"clarify": {},
 	// Harness-internal user clarification prompt. It does not reach
 	// outside the harness and should not require an approved task scope.
 	"AskUserQuestion": {},
@@ -164,12 +175,20 @@ var defaultAllowedTools = map[string]struct{}{
 	"TaskCreate":                  {},
 	"TaskStop":                    {},
 	"TaskUpdate":                  {},
+	"browser_console":             {},
+	"browser_get_images":          {},
+	"browser_snapshot":            {},
+	"clarify":                     {},
 	"memory_get":                  {},
 	"memory_search":               {},
+	"search_files":                {},
 	"session_status":              {},
+	"session_search":              {},
 	"sessions_history":            {},
 	"sessions_list":               {},
 	"sessions_yield":              {},
+	"skill_view":                  {},
+	"skills_list":                 {},
 	"read_file":                   {},
 	"list_mcp_resources":          {},
 	"list_mcp_resource_templates": {},

--- a/internal/runtime/llmproxy/inspector/parser_flags_test.go
+++ b/internal/runtime/llmproxy/inspector/parser_flags_test.go
@@ -257,6 +257,53 @@ func TestOpenClawReadOnlyToolsAreLocalOnlyDefaults(t *testing.T) {
 	}
 }
 
+func TestHermesReadOnlyToolsAreLocalOnlyDefaults(t *testing.T) {
+	for _, name := range []string{
+		"browser_console",
+		"browser_get_images",
+		"browser_snapshot",
+		"clarify",
+		"read_file",
+		"search_files",
+		"session_search",
+		"skill_view",
+		"skills_list",
+	} {
+		if !IsLocalOnlyTool(name) {
+			t.Fatalf("%s should be treated as local-only", name)
+		}
+		if !IsDefaultAllowedTool(name) {
+			t.Fatalf("%s should be seeded as a default allowed tool", name)
+		}
+	}
+	for _, name := range []string{
+		"browser_back",
+		"browser_click",
+		"browser_navigate",
+		"browser_press",
+		"browser_scroll",
+		"browser_type",
+		"browser_vision",
+		"cronjob",
+		"delegate_task",
+		"execute_code",
+		"image_generate",
+		"memory",
+		"patch",
+		"process",
+		"send_message",
+		"skill_manage",
+		"terminal",
+		"text_to_speech",
+		"vision_analyze",
+		"write_file",
+	} {
+		if IsDefaultAllowedTool(name) {
+			t.Fatalf("%s should not be seeded as a default allowed tool", name)
+		}
+	}
+}
+
 // Regression: a placeholder substring inside a local-only tool's args
 // (Skill, Read, Edit, etc.) must pass through without engaging the
 // LLM validator. Otherwise smoke-test installs without an LLM-backed

--- a/internal/runtime/llmproxy/inspector/parser_flags_test.go
+++ b/internal/runtime/llmproxy/inspector/parser_flags_test.go
@@ -321,6 +321,8 @@ func TestParser_LocalOnlyToolsPassThrough(t *testing.T) {
 		{"glob_with_placeholder_pattern", "Glob", `{"pattern":"autovault_github_xxx*.json"}`},
 		// Codex's read_file is treated the same as Claude Code's Read.
 		{"codex_read_file", "read_file", `{"path":"/tmp/autovault_github_xxx.json"}`},
+		// OpenClaw's read tool is lowercase but should be treated as a local file read.
+		{"openclaw_read", "read", `{"path":"/tmp/autovault_github_xxx.json"}`},
 		{"ask_user_question", "AskUserQuestion", `{"question":"Use autovault_github_xxx for this task?","options":["yes","no"]}`},
 	}
 	for _, tc := range cases {

--- a/internal/runtime/llmproxy/inspector/parser_flags_test.go
+++ b/internal/runtime/llmproxy/inspector/parser_flags_test.go
@@ -224,6 +224,39 @@ func TestParseBashCurl_AcceptsLineContinuationBeforeHeader(t *testing.T) {
 	}
 }
 
+func TestOpenClawReadOnlyToolsAreLocalOnlyDefaults(t *testing.T) {
+	for _, name := range []string{
+		"memory_get",
+		"memory_search",
+		"session_status",
+		"sessions_history",
+		"sessions_list",
+		"sessions_yield",
+	} {
+		if !IsLocalOnlyTool(name) {
+			t.Fatalf("%s should be treated as local-only", name)
+		}
+		if !IsDefaultAllowedTool(name) {
+			t.Fatalf("%s should be seeded as a default allowed tool", name)
+		}
+	}
+	for _, name := range []string{
+		"edit",
+		"exec",
+		"image",
+		"process",
+		"sessions_send",
+		"sessions_spawn",
+		"subagents",
+		"web_fetch",
+		"write",
+	} {
+		if IsDefaultAllowedTool(name) {
+			t.Fatalf("%s should not be seeded as a default allowed tool", name)
+		}
+	}
+}
+
 // Regression: a placeholder substring inside a local-only tool's args
 // (Skill, Read, Edit, etc.) must pass through without engaging the
 // LLM validator. Otherwise smoke-test installs without an LLM-backed

--- a/internal/runtime/policy/starter_profiles.go
+++ b/internal/runtime/policy/starter_profiles.go
@@ -88,12 +88,16 @@ func StarterProfiles() []StarterProfile {
 		{
 			ID:          "openclaw",
 			DisplayName: "OpenClaw",
-			Description: "Recommended allow rules for OpenClaw's read-only inspection tools.",
+			Description: "Recommended allow rules for OpenClaw's read-only inspection and local session tools.",
 			CommandKeys: []string{"openclaw"},
 			Rules: []StarterProfileRuleDraft{
-				{Kind: "tool", Action: "allow", ToolName: "Read", Reason: "Read local files for single-step inspection"},
-				{Kind: "tool", Action: "allow", ToolName: "List", Reason: "List local files without changing state"},
-				{Kind: "tool", Action: "allow", ToolName: "Search", Reason: "Search local files without changing state"},
+				{Kind: "tool", Action: "allow", ToolName: "read", Reason: "Read local files for single-step inspection"},
+				{Kind: "tool", Action: "allow", ToolName: "sessions_list", Reason: "List visible sessions without changing external systems"},
+				{Kind: "tool", Action: "allow", ToolName: "sessions_history", Reason: "Read sanitized visible session history"},
+				{Kind: "tool", Action: "allow", ToolName: "session_status", Reason: "Inspect local session status"},
+				{Kind: "tool", Action: "allow", ToolName: "sessions_yield", Reason: "Yield the current turn without external side effects"},
+				{Kind: "tool", Action: "allow", ToolName: "memory_search", Reason: "Search local OpenClaw memory"},
+				{Kind: "tool", Action: "allow", ToolName: "memory_get", Reason: "Read exact excerpts from local OpenClaw memory"},
 			},
 		},
 		{

--- a/internal/runtime/policy/starter_profiles.go
+++ b/internal/runtime/policy/starter_profiles.go
@@ -103,12 +103,18 @@ func StarterProfiles() []StarterProfile {
 		{
 			ID:          "hermes",
 			DisplayName: "Hermes",
-			Description: "Recommended allow rules for Hermes read-only inspection tools.",
+			Description: "Recommended allow rules for Hermes read-only inspection and local clarification tools.",
 			CommandKeys: []string{"hermes"},
 			Rules: []StarterProfileRuleDraft{
-				{Kind: "tool", Action: "allow", ToolName: "Read", Reason: "Read local files for single-step inspection"},
-				{Kind: "tool", Action: "allow", ToolName: "Glob", Reason: "Find files by pattern without changing state"},
-				{Kind: "tool", Action: "allow", ToolName: "Grep", Reason: "Search local files without changing state"},
+				{Kind: "tool", Action: "allow", ToolName: "read_file", Reason: "Read local files for single-step inspection"},
+				{Kind: "tool", Action: "allow", ToolName: "search_files", Reason: "Search local files without changing state"},
+				{Kind: "tool", Action: "allow", ToolName: "session_search", Reason: "Search local session history"},
+				{Kind: "tool", Action: "allow", ToolName: "skills_list", Reason: "List available local skills"},
+				{Kind: "tool", Action: "allow", ToolName: "skill_view", Reason: "Read local skill content"},
+				{Kind: "tool", Action: "allow", ToolName: "clarify", Reason: "Ask the user for clarification without external side effects"},
+				{Kind: "tool", Action: "allow", ToolName: "browser_snapshot", Reason: "Inspect the current browser page accessibility tree"},
+				{Kind: "tool", Action: "allow", ToolName: "browser_console", Reason: "Inspect current browser console output"},
+				{Kind: "tool", Action: "allow", ToolName: "browser_get_images", Reason: "Inspect current browser image metadata"},
 			},
 		},
 	}

--- a/internal/runtime/policy/starter_profiles_test.go
+++ b/internal/runtime/policy/starter_profiles_test.go
@@ -123,3 +123,57 @@ func TestOpenClawStarterProfileMatchesDiscoveredReadOnlyTools(t *testing.T) {
 		}
 	}
 }
+
+func TestHermesStarterProfileMatchesDiscoveredReadOnlyTools(t *testing.T) {
+	profile, ok := StarterProfileByID("hermes")
+	if !ok {
+		t.Fatalf("StarterProfileByID(hermes) = false, want true")
+	}
+	allowedTools := map[string]bool{}
+	for _, rule := range profile.Rules {
+		if rule.Kind == "tool" && rule.Action == "allow" {
+			allowedTools[rule.ToolName] = true
+		}
+	}
+	for _, name := range []string{
+		"browser_console",
+		"browser_get_images",
+		"browser_snapshot",
+		"clarify",
+		"read_file",
+		"search_files",
+		"session_search",
+		"skill_view",
+		"skills_list",
+	} {
+		if !allowedTools[name] {
+			t.Fatalf("hermes starter profile missing %s", name)
+		}
+	}
+	for _, name := range []string{
+		"browser_back",
+		"browser_click",
+		"browser_navigate",
+		"browser_press",
+		"browser_scroll",
+		"browser_type",
+		"browser_vision",
+		"cronjob",
+		"delegate_task",
+		"execute_code",
+		"image_generate",
+		"memory",
+		"patch",
+		"process",
+		"send_message",
+		"skill_manage",
+		"terminal",
+		"text_to_speech",
+		"vision_analyze",
+		"write_file",
+	} {
+		if allowedTools[name] {
+			t.Fatalf("hermes starter profile should not blanket-allow %s", name)
+		}
+	}
+}

--- a/internal/runtime/policy/starter_profiles_test.go
+++ b/internal/runtime/policy/starter_profiles_test.go
@@ -82,3 +82,44 @@ func TestStarterProfilesCoverInitialHarnessSetWithReadOnlyToolRules(t *testing.T
 		}
 	}
 }
+
+func TestOpenClawStarterProfileMatchesDiscoveredReadOnlyTools(t *testing.T) {
+	profile, ok := StarterProfileByID("openclaw")
+	if !ok {
+		t.Fatalf("StarterProfileByID(openclaw) = false, want true")
+	}
+	allowedTools := map[string]bool{}
+	for _, rule := range profile.Rules {
+		if rule.Kind == "tool" && rule.Action == "allow" {
+			allowedTools[rule.ToolName] = true
+		}
+	}
+	for _, name := range []string{
+		"read",
+		"memory_get",
+		"memory_search",
+		"session_status",
+		"sessions_history",
+		"sessions_list",
+		"sessions_yield",
+	} {
+		if !allowedTools[name] {
+			t.Fatalf("openclaw starter profile missing %s", name)
+		}
+	}
+	for _, name := range []string{
+		"edit",
+		"exec",
+		"image",
+		"process",
+		"sessions_send",
+		"sessions_spawn",
+		"subagents",
+		"web_fetch",
+		"write",
+	} {
+		if allowedTools[name] {
+			t.Fatalf("openclaw starter profile should not blanket-allow %s", name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Seed default allow rules for discovered OpenClaw read-only memory, session history/status, and yield tools.
- Seed default allow rules for discovered Hermes file/search reads, skill/session recall, clarification, and read-only browser inspection tools.
- Align the OpenClaw and Hermes starter profiles with their observed tool names while keeping mutating, shell, network, messaging, generation, scheduling, and delegation tools out of the default allowlist.

## Tests
- go test ./internal/runtime/policy -run 'TestStarterProfilesCoverInitialHarnessSetWithReadOnlyToolRules|TestOpenClawStarterProfileMatchesDiscoveredReadOnlyTools|TestHermesStarterProfileMatchesDiscoveredReadOnlyTools'\n- go test ./internal/runtime/llmproxy/inspector -run 'TestHermesReadOnlyToolsAreLocalOnlyDefaults|TestOpenClawReadOnlyToolsAreLocalOnlyDefaults'\n- go test ./internal/api/handlers -run 'TestDefaultToolRulesSeedAndRespectUnset|TestRuntimeHandlerToolControlsDiscoverAndUpsert|TestDefaultToolRulesMigratesStaleGlobalSystemDefaultsToAgent'