### PR TITLE
Expose proxy-lite public URL for agent setup

### DIFF
--- a/internal/api/handlers/config.go
+++ b/internal/api/handlers/config.go
@@ -1,0 +1,27 @@
+package handlers
+
+import (
+	"net/http"
+	"strings"
+)
+
+// ConfigHandler serves unauthenticated public configuration used by the web UI.
+type ConfigHandler struct {
+	authMode           string
+	proxyLitePublicURL string
+}
+
+func NewConfigHandler(authMode string, proxyLitePublicURL string) *ConfigHandler {
+	return &ConfigHandler{
+		authMode:           authMode,
+		proxyLitePublicURL: strings.TrimRight(strings.TrimSpace(proxyLitePublicURL), "/"),
+	}
+}
+
+// Public returns public configuration (no auth required).
+func (h *ConfigHandler) Public(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]any{
+		"auth_mode":             h.authMode,
+		"proxy_lite_public_url": h.proxyLitePublicURL,
+	})
+}

--- a/internal/api/handlers/config_test.go
+++ b/internal/api/handlers/config_test.go
@@ -1,0 +1,33 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestConfigPublicIncludesProxyLitePublicURL(t *testing.T) {
+	handler := NewConfigHandler("password", "https://llm.example.com/")
+	req := httptest.NewRequest(http.MethodGet, "/api/config/public", nil)
+	rec := httptest.NewRecorder()
+
+	handler.Public(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d, want %d", rec.Code, http.StatusOK)
+	}
+	var body struct {
+		AuthMode           string `json:"auth_mode"`
+		ProxyLitePublicURL string `json:"proxy_lite_public_url"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if body.AuthMode != "password" {
+		t.Fatalf("AuthMode=%q", body.AuthMode)
+	}
+	if body.ProxyLitePublicURL != "https://llm.example.com" {
+		t.Fatalf("ProxyLitePublicURL=%q", body.ProxyLitePublicURL)
+	}
+}

--- a/internal/api/handlers/health.go
+++ b/internal/api/handlers/health.go
@@ -14,13 +14,12 @@ import (
 
 // HealthHandler handles /health and /ready.
 type HealthHandler struct {
-	st       store.Store
-	v        vault.Vault
-	authMode string // "magic_link" or "password"
+	st store.Store
+	v  vault.Vault
 }
 
-func NewHealthHandler(st store.Store, v vault.Vault, authMode string) *HealthHandler {
-	return &HealthHandler{st: st, v: v, authMode: authMode}
+func NewHealthHandler(st store.Store, v vault.Vault) *HealthHandler {
+	return &HealthHandler{st: st, v: v}
 }
 
 // Health always returns 200 — used by load balancers.
@@ -55,13 +54,6 @@ func (h *HealthHandler) Ready(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, code, resp)
-}
-
-// ConfigPublic returns public configuration (no auth required).
-func (h *HealthHandler) ConfigPublic(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, http.StatusOK, map[string]any{
-		"auth_mode": h.authMode,
-	})
 }
 
 // Version returns the current and latest available version (no auth required).

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -451,7 +451,8 @@ func (s *Server) routes() http.Handler {
 	} else if s.features.PasswordAuth {
 		authMode = "password"
 	}
-	healthHandler := handlers.NewHealthHandler(s.store, s.vault, authMode)
+	healthHandler := handlers.NewHealthHandler(s.store, s.vault)
+	configHandler := handlers.NewConfigHandler(authMode, s.cfg.ProxyLite.PublicURL)
 	restrictionsHandler := handlers.NewRestrictionsHandler(s.store)
 	agentsHandler := handlers.NewAgentsHandler(s.store, s.eventHub, s.logger, s.cfg)
 	auditHandler := handlers.NewAuditHandler(s.store)
@@ -645,7 +646,7 @@ func (s *Server) routes() http.Handler {
 	// Health (no auth)
 	mux.HandleFunc("GET /health", healthHandler.Health)
 	mux.HandleFunc("GET /ready", healthHandler.Ready)
-	mux.HandleFunc("GET /api/config/public", healthHandler.ConfigPublic)
+	mux.HandleFunc("GET /api/config/public", configHandler.Public)
 	mux.HandleFunc("GET /api/version", healthHandler.Version)
 	mux.HandleFunc("GET /api/skill/version", healthHandler.SkillVersion)
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -284,6 +284,10 @@ type RuntimePolicyConfig struct {
 type ProxyLiteConfig struct {
 	Enabled bool `yaml:"enabled"`
 
+	// PublicURL is the externally reachable lite-proxy endpoint shown to
+	// agent harnesses by the dashboard in split cloud deployments.
+	PublicURL string `yaml:"public_url"`
+
 	// AnthropicBaseURL overrides the upstream Anthropic host. Empty =
 	// use https://api.anthropic.com.
 	AnthropicBaseURL string `yaml:"anthropic_base_url"`
@@ -787,6 +791,9 @@ func Load(path string) (*Config, error) {
 	}
 	if v := os.Getenv("CLAWVISOR_PROXY_LITE_ENABLED"); v != "" {
 		cfg.ProxyLite.Enabled = v == "true" || v == "1"
+	}
+	if v := os.Getenv("CLAWVISOR_PROXY_LITE_PUBLIC_URL"); v != "" {
+		cfg.ProxyLite.PublicURL = strings.TrimRight(strings.TrimSpace(v), "/")
 	}
 	if v := os.Getenv("CLAWVISOR_PROXY_LITE_ANTHROPIC_BASE_URL"); v != "" {
 		cfg.ProxyLite.AnthropicBaseURL = strings.TrimSpace(v)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -32,6 +32,7 @@ func TestLoadAppliesRuntimeProxyTimingTraceEnv(t *testing.T) {
 func TestLoadAppliesProxyLiteCloudEnv(t *testing.T) {
 	t.Setenv("CLAWVISOR_ROUTE_SET", "proxy_lite")
 	t.Setenv("CLAWVISOR_PROXY_LITE_ENABLED", "true")
+	t.Setenv("CLAWVISOR_PROXY_LITE_PUBLIC_URL", "https://llm.example.com/")
 	t.Setenv("CLAWVISOR_PROXY_LITE_ANTHROPIC_BASE_URL", "https://anthropic.internal")
 	t.Setenv("CLAWVISOR_PROXY_LITE_OPENAI_BASE_URL", "https://openai.internal")
 	t.Setenv("CLAWVISOR_PROXY_LITE_SELF_HOSTNAMES", "app.example.com, llm.example.com")
@@ -48,6 +49,9 @@ func TestLoadAppliesProxyLiteCloudEnv(t *testing.T) {
 	}
 	if !cfg.ProxyLite.Enabled {
 		t.Fatal("expected proxy lite enabled")
+	}
+	if cfg.ProxyLite.PublicURL != "https://llm.example.com" {
+		t.Fatalf("PublicURL=%q", cfg.ProxyLite.PublicURL)
 	}
 	if cfg.ProxyLite.AnthropicBaseURL != "https://anthropic.internal" {
 		t.Fatalf("AnthropicBaseURL=%q", cfg.ProxyLite.AnthropicBaseURL)

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1381,7 +1381,7 @@ export const api = {
       put<TelegramGroup>(`/api/notifications/telegram/groups/active/${groupChatId}/auto-approval`, { enabled, ...(notify !== undefined && { notify }) }),
   },
   config: {
-    public: () => get<{ auth_mode: 'magic_link' | 'password' | 'passkey' }>('/api/config/public'),
+    public: () => get<{ auth_mode: 'magic_link' | 'password' | 'passkey'; proxy_lite_public_url?: string }>('/api/config/public'),
   },
   version: {
     get: () => get<VersionInfo>('/api/version'),

--- a/web/src/pages/Agents.tsx
+++ b/web/src/pages/Agents.tsx
@@ -705,6 +705,10 @@ function ConnectAgentGuide({ newToken }: { newToken: string | null }) {
     queryKey: ['pairInfo'],
     queryFn: () => api.devices.pairInfo(),
   })
+  const { data: publicConfig } = useQuery({
+    queryKey: ['public-config'],
+    queryFn: () => api.config.public(),
+  })
 
   // Mint a single-use claim code so the bootstrap curl never has to embed
   // the user's ID. BootstrapApproveStep invalidates this query after the
@@ -730,6 +734,9 @@ function ConnectAgentGuide({ newToken }: { newToken: string | null }) {
     : hasRelay
       ? `https://${pairInfo!.relay_host}/d/${pairInfo!.daemon_id}`
       : window.location.origin
+  const proxyLiteURL = !isLocal && proxyLiteUI
+    ? normalizePublicURL(publicConfig?.proxy_lite_public_url) ?? clawvisorURL
+    : clawvisorURL
 
   const userIdParam = user?.id ? `?user_id=${encodeURIComponent(user.id)}` : ''
 
@@ -790,12 +797,12 @@ function ConnectAgentGuide({ newToken }: { newToken: string | null }) {
       <div className="p-5">
         {proxyLiteUI ? (
           <>
-            {tab === 'openclaw' && <OpenClawGuide setupURL={setupURL} clawvisorURL={clawvisorURL} claim={claim?.code} newToken={newToken} copied={copied} onCopy={copyText} showSkillDefault={showSkillDefault} />}
-            {tab === 'hermes' && <HermesGuide clawvisorURL={clawvisorURL} claim={claim?.code} newToken={newToken} onCopy={copyText} />}
-            {tab === 'claude-code' && <ClaudeCodeGuide clawvisorURL={clawvisorURL} claim={claim?.code} userIdParam={userIdParam} newToken={newToken} onCopy={copyText} showSkillDefault={showSkillDefault} />}
-            {tab === 'codex' && <CodexGuide clawvisorURL={clawvisorURL} claim={claim?.code} newToken={newToken} onCopy={copyText} />}
-            {tab === 'claude-desktop' && <ClaudeDesktopGuide clawvisorURL={clawvisorURL} claim={claim?.code} newToken={newToken} isLocal={isLocal} onCopy={copyText} showSkillDefault={showSkillDefault} />}
-            {tab === 'other' && <OtherAgentGuide setupURL={setupURL} clawvisorURL={clawvisorURL} claim={claim?.code} newToken={newToken} copied={copied} onCopy={copyText} showSkillDefault={showSkillDefault} />}
+            {tab === 'openclaw' && <OpenClawGuide setupURL={setupURL} clawvisorURL={clawvisorURL} llmBaseURL={proxyLiteURL} claim={claim?.code} newToken={newToken} copied={copied} onCopy={copyText} showSkillDefault={showSkillDefault} />}
+            {tab === 'hermes' && <HermesGuide clawvisorURL={clawvisorURL} llmBaseURL={proxyLiteURL} claim={claim?.code} newToken={newToken} onCopy={copyText} />}
+            {tab === 'claude-code' && <ClaudeCodeGuide clawvisorURL={clawvisorURL} llmBaseURL={proxyLiteURL} claim={claim?.code} userIdParam={userIdParam} newToken={newToken} onCopy={copyText} showSkillDefault={showSkillDefault} />}
+            {tab === 'codex' && <CodexGuide clawvisorURL={clawvisorURL} llmBaseURL={proxyLiteURL} claim={claim?.code} newToken={newToken} onCopy={copyText} />}
+            {tab === 'claude-desktop' && <ClaudeDesktopGuide clawvisorURL={clawvisorURL} llmBaseURL={proxyLiteURL} claim={claim?.code} newToken={newToken} isLocal={isLocal} onCopy={copyText} showSkillDefault={showSkillDefault} />}
+            {tab === 'other' && <OtherAgentGuide setupURL={setupURL} clawvisorURL={clawvisorURL} llmBaseURL={proxyLiteURL} claim={claim?.code} newToken={newToken} copied={copied} onCopy={copyText} showSkillDefault={showSkillDefault} />}
           </>
         ) : (
           <>
@@ -1190,6 +1197,11 @@ function useSequencedAgentName(base: string, agents: Agent[] | undefined): [stri
   return [name, setAndMarkTouched]
 }
 
+function normalizePublicURL(url: string | null | undefined): string | null {
+  const trimmed = url?.trim().replace(/\/+$/, '')
+  return trimmed || null
+}
+
 function buildBootstrapCommand(clawvisorURL: string, claim: string | undefined, agentName: string): string {
   // Name and claim ride on the URL so the curl is body-less — no -H, no -d.
   // The claim code (minted by an authenticated dashboard session) attributes
@@ -1552,8 +1564,9 @@ function hasAnyUpstreamKey(creds: { credentials: { stored: boolean; agent_stored
   return creds.credentials.some(c => c.stored || c.agent_stored)
 }
 
-function ClaudeCodeGuide({ clawvisorURL, claim, userIdParam, newToken, onCopy, showSkillDefault }: {
+function ClaudeCodeGuide({ clawvisorURL, llmBaseURL, claim, userIdParam, newToken, onCopy, showSkillDefault }: {
   clawvisorURL: string
+  llmBaseURL: string
   claim: string | undefined
   userIdParam: string
   newToken: string | null
@@ -1570,20 +1583,20 @@ function ClaudeCodeGuide({ clawvisorURL, claim, userIdParam, newToken, onCopy, s
   const connected = !!agents?.find(a => a.name === agentName)
 
   const jsonPath = `~/.clawvisor/agents/${agentName}.json`
-  const runCmd = `ANTHROPIC_BASE_URL=${clawvisorURL} \\
+  const runCmd = `ANTHROPIC_BASE_URL=${llmBaseURL} \\
 ANTHROPIC_CUSTOM_HEADERS="X-Clawvisor-Agent-Token: $(jq -r .token ${jsonPath})" \\
 ANTHROPIC_AUTH_TOKEN= ANTHROPIC_API_KEY= \\
 claude`
   const zshrcSnippet = `cat >> ~/.zshrc <<'EOF'
 claude-cv() {
-  ANTHROPIC_BASE_URL=${clawvisorURL} \\
+  ANTHROPIC_BASE_URL=${llmBaseURL} \\
   ANTHROPIC_CUSTOM_HEADERS="X-Clawvisor-Agent-Token: $(jq -r .token ${jsonPath})" \\
   ANTHROPIC_AUTH_TOKEN= ANTHROPIC_API_KEY= \\
   claude "$@"
 }
 EOF`
   const tokenValue = newToken ?? 'cvis_<your-token>'
-  const manualRunCmd = `ANTHROPIC_BASE_URL=${clawvisorURL} \\
+  const manualRunCmd = `ANTHROPIC_BASE_URL=${llmBaseURL} \\
 ANTHROPIC_CUSTOM_HEADERS='X-Clawvisor-Agent-Token: ${tokenValue}' \\
 ANTHROPIC_AUTH_TOKEN= ANTHROPIC_API_KEY= \\
 claude`
@@ -1736,8 +1749,9 @@ claude`
   )
 }
 
-function CodexGuide({ clawvisorURL, claim, newToken, onCopy }: {
+function CodexGuide({ clawvisorURL, llmBaseURL, claim, newToken, onCopy }: {
   clawvisorURL: string
+  llmBaseURL: string
   claim: string | undefined
   newToken: string | null
   onCopy: (text: string) => void
@@ -1759,7 +1773,7 @@ function CodexGuide({ clawvisorURL, claim, newToken, onCopy }: {
 
 [model_providers.clawvisor]
 name = "Clawvisor"
-base_url = "${clawvisorURL}/v1"
+base_url = "${llmBaseURL}/v1"
 wire_api = "responses"
 requires_openai_auth = true
 
@@ -1888,8 +1902,9 @@ codex -c model_provider=clawvisor`
   )
 }
 
-function ClaudeDesktopGuide({ clawvisorURL, claim, newToken, isLocal, onCopy, showSkillDefault }: {
+function ClaudeDesktopGuide({ clawvisorURL, llmBaseURL, claim, newToken, isLocal, onCopy, showSkillDefault }: {
   clawvisorURL: string
+  llmBaseURL: string
   claim: string | undefined
   newToken: string | null
   isLocal: boolean
@@ -1995,9 +2010,9 @@ function ClaudeDesktopGuide({ clawvisorURL, claim, newToken, isLocal, onCopy, sh
                   <div>
                     <div className="text-xs uppercase tracking-wider text-text-tertiary">Gateway base URL</div>
                     <div className="mt-1 flex items-center gap-2">
-                      <code className="flex-1 px-3 py-1.5 text-sm font-mono rounded border border-border-default bg-surface-0 text-text-primary break-all">{clawvisorURL}</code>
+                      <code className="flex-1 px-3 py-1.5 text-sm font-mono rounded border border-border-default bg-surface-0 text-text-primary break-all">{llmBaseURL}</code>
                       <button
-                        onClick={() => onCopy(clawvisorURL)}
+                        onClick={() => onCopy(llmBaseURL)}
                         className="text-xs px-3 py-1 rounded border border-border-strong text-text-secondary hover:bg-surface-2"
                       >
                         Copy
@@ -2160,9 +2175,10 @@ function ClaudeDesktopGuide({ clawvisorURL, claim, newToken, isLocal, onCopy, sh
   )
 }
 
-function OpenClawGuide({ setupURL, clawvisorURL, claim, newToken, copied, onCopy, showSkillDefault }: {
+function OpenClawGuide({ setupURL, clawvisorURL, llmBaseURL, claim, newToken, copied, onCopy, showSkillDefault }: {
   setupURL: string
   clawvisorURL: string
+  llmBaseURL: string
   claim: string | undefined
   newToken: string | null
   copied: boolean
@@ -2188,14 +2204,14 @@ function OpenClawGuide({ setupURL, clawvisorURL, claim, newToken, copied, onCopy
   const jsonPath = `~/.clawvisor/agents/${agentName}.json`
   const onboardCmd = `openclaw onboard --non-interactive \\
   --auth-choice custom-api-key \\
-  --custom-base-url "${clawvisorURL}/v1" \\
+  --custom-base-url "${llmBaseURL}/v1" \\
   --custom-model-id "claude-sonnet-4-6" \\
   --custom-api-key "$(jq -r .token ${jsonPath})" \\
   --custom-compatibility anthropic`
   const tokenValue = newToken ?? 'cvis_<your-token>'
   const manualOnboardCmd = `openclaw onboard --non-interactive \\
   --auth-choice custom-api-key \\
-  --custom-base-url "${clawvisorURL}/v1" \\
+  --custom-base-url "${llmBaseURL}/v1" \\
   --custom-model-id "claude-sonnet-4-6" \\
   --custom-api-key "${tokenValue}" \\
   --custom-compatibility anthropic`
@@ -2360,8 +2376,9 @@ function OpenClawGuide({ setupURL, clawvisorURL, claim, newToken, copied, onCopy
   )
 }
 
-function HermesGuide({ clawvisorURL, claim, newToken, onCopy }: {
+function HermesGuide({ clawvisorURL, llmBaseURL, claim, newToken, onCopy }: {
   clawvisorURL: string
+  llmBaseURL: string
   claim: string | undefined
   newToken: string | null
   onCopy: (text: string) => void
@@ -2383,17 +2400,17 @@ function HermesGuide({ clawvisorURL, claim, newToken, onCopy }: {
   const keyReady = hasAnyUpstreamKey(creds)
 
   const jsonPath = `~/.clawvisor/agents/${agentName}.json`
-  const envCmd = `OPENAI_BASE_URL=${clawvisorURL}/v1 \\
+  const envCmd = `OPENAI_BASE_URL=${llmBaseURL}/v1 \\
 OPENAI_API_KEY=$(jq -r .token ${jsonPath}) \\
 hermes chat`
   const configCmd = `mkdir -p ~/.hermes && cat > ~/.hermes/config.yaml <<EOF
 model:
   provider: custom
-  base_url: "${clawvisorURL}/v1"
+  base_url: "${llmBaseURL}/v1"
   api_key: "$(jq -r .token ${jsonPath})"
 EOF`
   const tokenValue = newToken ?? 'cvis_<your-token>'
-  const manualEnvCmd = `OPENAI_BASE_URL=${clawvisorURL}/v1 \\
+  const manualEnvCmd = `OPENAI_BASE_URL=${llmBaseURL}/v1 \\
 OPENAI_API_KEY=${tokenValue} \\
 hermes chat`
 
@@ -2509,9 +2526,10 @@ hermes chat`
   )
 }
 
-function OtherAgentGuide({ setupURL, clawvisorURL, claim, newToken, copied, onCopy, showSkillDefault }: {
+function OtherAgentGuide({ setupURL, clawvisorURL, llmBaseURL, claim, newToken, copied, onCopy, showSkillDefault }: {
   setupURL: string
   clawvisorURL: string
+  llmBaseURL: string
   claim: string | undefined
   newToken: string | null
   copied: boolean
@@ -2538,17 +2556,17 @@ function OtherAgentGuide({ setupURL, clawvisorURL, claim, newToken, copied, onCo
   const anthropicSDK = `import anthropic, json, os
 data = json.load(open(os.path.expanduser("${jsonPath}")))
 client = anthropic.Anthropic(
-    base_url="${clawvisorURL}",
+    base_url="${llmBaseURL}",
     api_key=data["token"],
 )`
   const openaiSDK = `from openai import OpenAI
 import json, os
 data = json.load(open(os.path.expanduser("${jsonPath}")))
 client = OpenAI(
-    base_url="${clawvisorURL}/v1",
+    base_url="${llmBaseURL}/v1",
     api_key=data["token"],
 )`
-  const curlCmd = `curl -X POST "${clawvisorURL}/v1/messages" \\
+  const curlCmd = `curl -X POST "${llmBaseURL}/v1/messages" \\
   -H "Authorization: Bearer $(jq -r .token ${jsonPath})" \\
   -H "anthropic-version: 2023-06-01" \\
   -H "Content-Type: application/json" \\
@@ -2556,12 +2574,12 @@ client = OpenAI(
   const tokenValue = newToken ?? 'cvis_<your-token>'
   const manualAnthropicSDK = `import anthropic
 client = anthropic.Anthropic(
-    base_url="${clawvisorURL}",
+    base_url="${llmBaseURL}",
     api_key="${tokenValue}",
 )`
   const manualOpenaiSDK = `from openai import OpenAI
 client = OpenAI(
-    base_url="${clawvisorURL}/v1",
+    base_url="${llmBaseURL}/v1",
     api_key="${tokenValue}",
 )`
   const prompt = `Please install Clawvisor. It's a security gateway between you and external services like Gmail, Slack, and GitHub. You don't hold any API keys directly; instead, you make requests through Clawvisor and I approve which actions you can take. Every call is logged, and I can revoke access at any time.\n\nSetup is just registering an agent token and installing a skill that teaches you how to use it. I'll review each step before it happens.\n\nInstructions: ${setupURL}`
@@ -3008,14 +3026,22 @@ function AgentLiteProxyPanel({ agentId: _agentId }: { agentId: string }) {
     queryKey: ['pairInfo'],
     queryFn: () => api.devices.pairInfo(),
   })
+  const { data: publicConfig } = useQuery({
+    queryKey: ['public-config'],
+    queryFn: () => api.config.public(),
+  })
   // window.location.origin points at the relay when the dashboard is
   // accessed via the cloud, not the per-daemon mount the agent harness
-  // must talk to. Prefer the daemon-scoped relay path when we have one
-  // and the dashboard isn't local; otherwise fall back to the origin.
+  // must talk to. Prefer the configured cloud lite-proxy URL, then the
+  // daemon-scoped relay path when we have one and the dashboard isn't
+  // local; otherwise fall back to the origin.
   const isLocal = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1'
   const hasRelay = !!(pairInfo?.daemon_id && pairInfo?.relay_host)
-  const baseURL = !isLocal && hasRelay
-    ? `https://${pairInfo!.relay_host}/d/${pairInfo!.daemon_id}`
+  const configuredProxyLiteURL = normalizePublicURL(publicConfig?.proxy_lite_public_url)
+  const baseURL = !isLocal && configuredProxyLiteURL
+    ? configuredProxyLiteURL
+    : !isLocal && hasRelay
+      ? `https://${pairInfo!.relay_host}/d/${pairInfo!.daemon_id}`
     : window.location.origin
   const [copied, setCopied] = useState<string | null>(null)
 


### PR DESCRIPTION
## Summary
- add CLAWVISOR_PROXY_LITE_PUBLIC_URL / proxy_lite.public_url config and expose it through /api/config/public
- keep bootstrap/setup URLs pointed at the main app while using the proxy-lite public URL for LLM base URL snippets
- update agent detail lite-proxy examples to prefer the configured proxy-lite endpoint

## Verification
- go test ./pkg/config ./internal/api/handlers ./internal/api
- npm run lint