### PR TITLE
fix(lite-proxy): move routes under api

### DIFF
--- a/docs/LITE_PROXY.md
+++ b/docs/LITE_PROXY.md
@@ -56,15 +56,20 @@ The proxy is gated by `proxy_lite.enabled`. When on, the daemon exposes:
 
 | Route | Purpose |
 |---|---|
-| `POST /v1/messages` | Anthropic Messages API (Claude Code, Anthropic SDK). |
-| `POST /v1/messages/count_tokens` | Anthropic token counter. |
-| `POST /v1/chat/completions` | OpenAI Chat Completions (Codex, OpenAI SDK). |
-| `POST /v1/responses` | OpenAI Responses API. |
-| `POST /proxy/v1/…` | The resolver — agents call here when their tool_use uses a vault placeholder. The daemon swaps it in and forwards to the real target host. |
-| `GET /control/skill` | Documents the control plane to the agent. |
-| `POST /control/tasks` | Task creation. Agents POST here to request scope before doing non-trivial work. |
-| `GET /control/tasks/{id}` | Status lookup. |
-| `POST /control/tasks/{id}/expand` | Add scope to an existing task. |
+| `POST /api/v1/messages` | Anthropic Messages API (Claude Code, Anthropic SDK). |
+| `POST /api/v1/messages/count_tokens` | Anthropic token counter. |
+| `POST /api/v1/chat/completions` | OpenAI Chat Completions (Codex, OpenAI SDK). |
+| `POST /api/v1/responses` | OpenAI Responses API. |
+| `POST /api/proxy/…` | The resolver — agents call here when their tool_use uses a vault placeholder. The daemon swaps it in and forwards to the real target host. |
+| `GET /api/control/skill` | Documents the control plane to the agent. |
+| `POST /api/control/tasks` | Task creation. Agents POST here to request scope before doing non-trivial work. |
+| `GET /api/control/tasks/{id}` | Status lookup. |
+| `POST /api/control/tasks/{id}/expand` | Add scope to an existing task. |
+
+Agents should be prompted to use the shorter synthetic URL
+`https://clawvisor.local/control/...`. Proxy-lite rewrites that model-facing
+path to the real daemon route under `/api/control/...`; harnesses and direct
+HTTP clients should use the real `/api/control` routes.
 
 ### Split hosted deployments
 
@@ -72,13 +77,13 @@ Hosted environments can run the dashboard/API and lite-proxy as separate
 services from the same binary by setting `server.route_set`:
 
 ```yaml
-# Main app: dashboard + user APIs, but no public /v1, /proxy/v1, or /control surface.
+# Main app: dashboard + user APIs, but no public /api/v1, /api/proxy, or /api/control surface.
 server:
   route_set: app
 proxy_lite:
   enabled: true
 
-# Dedicated proxy service: health + /v1, /proxy/v1, and /control only.
+# Dedicated proxy service: health + /api/v1, /api/proxy, and /api/control only.
 server:
   route_set: proxy_lite
 proxy_lite:
@@ -137,8 +142,8 @@ The wrappers inject the right environment variables for each harness:
 
 | Variable | Claude Code | Codex |
 |---|---|---|
-| Endpoint | `ANTHROPIC_BASE_URL=<daemon>` | `OPENAI_BASE_URL=<daemon>/v1` |
-| Auth | `ANTHROPIC_AUTH_TOKEN=<cvis_…>` | `OPENAI_API_KEY=<cvis_…>` |
+| Endpoint | `ANTHROPIC_BASE_URL=<daemon>/api` | `OPENAI_BASE_URL=<daemon>/api/v1` |
+| Auth | `ANTHROPIC_CUSTOM_HEADERS="X-Clawvisor-Agent-Token: <cvis_…>"` | `X-Clawvisor-Agent-Token: <cvis_…>` via Codex provider config |
 | Mask | `ANTHROPIC_API_KEY=` (empty) | Codex `-c model_provider=clawvisor` injected |
 
 If you need the raw exports for a custom invocation:
@@ -169,13 +174,13 @@ What happens at runtime:
 5. If all checks pass, the tool_use is **rewritten** before the harness sees it. The harness runs:
 
    ```bash
-   curl -sS https://daemon.example/proxy/v1/user \
+   curl -sS https://daemon.example/api/proxy/user \
      -H "Authorization: Bearer autovault_github_xyz123" \
      -H "X-Clawvisor-Target-Host: api.github.com" \
      -H "X-Clawvisor-Caller: Bearer cv-nonce-…"
    ```
 
-6. The resolver at `/proxy/v1/…` looks up the placeholder, fetches the real PAT from the vault, swaps the `Authorization` header value, and proxies the call to `api.github.com`. The harness gets the GitHub response.
+6. The resolver at `/api/proxy/…` looks up the placeholder, fetches the real PAT from the vault, swaps the `Authorization` header value, and proxies the call to `api.github.com`. The harness gets the GitHub response.
 
 The agent never sees the real PAT. The user pastes the placeholder once; Clawvisor handles substitution per call.
 
@@ -271,9 +276,9 @@ The dashboard approval surface lives in parallel. Async agents and multi-agent c
 
 Every inspected tool_use produces audit rows:
 
-- `lite_proxy.endpoint_call` — one per `/v1/*` request, with provider / model / streaming flag / available tools.
+- `lite_proxy.endpoint_call` — one per `/api/v1/*` request, with provider / model / streaming flag / available tools.
 - `lite_proxy.tool_use_inspected` — one per tool_use that the inspector saw. Records: tool name, decision (`allow` / `block` / `rewrite`), outcome, reason, host/method/path, placeholder (when applicable).
-- `lite_proxy.resolver_swap` — one per `/proxy/v1/…` resolver call, with the placeholder, bound service, target host/path.
+- `lite_proxy.resolver_swap` — one per `/api/proxy/…` resolver call, with the placeholder, bound service, target host/path.
 
 Credential patterns (`ghp_…`, `sk-ant-…`, `Bearer …`, etc.) are redacted before audit values are stored. Placeholders are kept verbatim — they're references, not secrets.
 

--- a/internal/api/handlers/control.go
+++ b/internal/api/handlers/control.go
@@ -17,9 +17,10 @@ func NewLLMControlHandler(baseURL string) *LLMControlHandler {
 func (h *LLMControlHandler) Capabilities(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{
 		"control_host": "https://clawvisor.local",
-		"direct_url":   strings.TrimRight(h.BaseURL, "/") + "/control/skill",
+		"direct_url":   strings.TrimRight(h.BaseURL, "/") + "/api/control/skill",
 		"base_path":    "/control",
-		"note":         "clawvisor.local is synthetic and is handled inside proxy-lite tool calls. Use direct_url when fetching documentation from a shell.",
+		"direct_path":  "/api/control",
+		"note":         "clawvisor.local/control is synthetic and is handled inside proxy-lite tool calls. Use direct_url when fetching documentation outside a proxy-lite tool call.",
 		"endpoints": []map[string]string{
 			{"method": "GET", "path": "/control/skill", "purpose": "Return schemas and examples for Clawvisor control-plane calls."},
 			{"method": "GET", "path": "/control/vault/items", "purpose": "List available vault item IDs that can be requested in a task."},
@@ -36,7 +37,7 @@ func (h *LLMControlHandler) Skill(w http.ResponseWriter, r *http.Request) {
 		"name":        "clawvisor-control",
 		"description": "Use this control plane to ask the user for permission before attempting tool work that may be blocked.",
 		"base_url":    "https://clawvisor.local",
-		"direct_docs": strings.TrimRight(h.BaseURL, "/") + "/control/skill",
+		"direct_docs": strings.TrimRight(h.BaseURL, "/") + "/api/control/skill",
 		"rules": []string{
 			"clawvisor.local is synthetic. Do not expect DNS lookup for the naked domain to work.",
 			"Use direct_docs for reading these schemas from a shell.",

--- a/internal/api/handlers/control_test.go
+++ b/internal/api/handlers/control_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestControlSkillCredentialExampleUsesCurrentVaultItemShape(t *testing.T) {
 	h := NewLLMControlHandler("http://localhost:25297")
-	req := httptest.NewRequest(http.MethodGet, "/control/skill", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/control/skill", nil)
 	res := httptest.NewRecorder()
 
 	h.Skill(res, req)
@@ -61,7 +61,7 @@ func TestControlSkillCredentialExampleUsesCurrentVaultItemShape(t *testing.T) {
 func TestControlFailureIncludesOriginalCommandContext(t *testing.T) {
 	h := NewLLMControlHandler("http://localhost:25297")
 	body := bytes.NewBufferString(`{"original_tool":"Bash","original_command":"curl -sS 'https://clawvisor.local/control/vault/items' | python3 -c 'print(1)'"}`)
-	req := httptest.NewRequest(http.MethodPost, "/control/failure?reason=malformed_control_command", body)
+	req := httptest.NewRequest(http.MethodPost, "/api/control/failure?reason=malformed_control_command", body)
 	res := httptest.NewRecorder()
 
 	h.Failure(res, req)

--- a/internal/api/handlers/inline_task_e2e_test.go
+++ b/internal/api/handlers/inline_task_e2e_test.go
@@ -17,18 +17,18 @@ import (
 // Full state-machine test for inline task approval. Walks the four
 // transitions described in the plan:
 //
-//   T1. Postprocess on a tool that needs approval pre-stages the
-//       PendingLiteApproval at Stage=tool (we skip this step in the
-//       fixture — it's covered by TestPostprocess_BashWithoutTaskScope*
-//       — and start from a primed StageTool hold).
-//   T2. User types "task" → RewriteTaskApprovalReply transitions the
-//       hold to Stage=awaiting_task_definition.
-//   T3. Model emits POST /control/tasks → postprocess intercept fires,
-//       holds a new Stage=awaiting_task_approval entry, substitutes
-//       the rendered approval prompt for the user.
-//   T4. User types "approve" → TryReleasePendingApproval cascades:
-//       creates the task pre-approved, drops the original tool hold,
-//       emits a synthetic assistant response carrying the task body.
+//	T1. Postprocess on a tool that needs approval pre-stages the
+//	    PendingLiteApproval at Stage=tool (we skip this step in the
+//	    fixture — it's covered by TestPostprocess_BashWithoutTaskScope*
+//	    — and start from a primed StageTool hold).
+//	T2. User types "task" → RewriteTaskApprovalReply transitions the
+//	    hold to Stage=awaiting_task_definition.
+//	T3. Model emits POST /api/control/tasks → postprocess intercept fires,
+//	    holds a new Stage=awaiting_task_approval entry, substitutes
+//	    the rendered approval prompt for the user.
+//	T4. User types "approve" → TryReleasePendingApproval cascades:
+//	    creates the task pre-approved, drops the original tool hold,
+//	    emits a synthetic assistant response carrying the task body.
 //
 // The test confirms that at the end:
 //   - There's a real store.Task with status=active + source=inline_chat.
@@ -86,7 +86,7 @@ func TestInlineTaskApprovalFullStateMachine(t *testing.T) {
 		t.Fatalf("T2: original hold should be dropped after task reply; got %+v", peekedT2)
 	}
 
-	// ── T3: model emits POST /control/tasks ──────────────────────────
+	// ── T3: model emits POST /api/control/tasks ──────────────────────────
 	// We can't easily run the full Postprocess here without seeding a
 	// store + inspector + boundary check. We exercise the intercept
 	// directly via the same exported helper Postprocess uses.
@@ -217,7 +217,6 @@ func TestInlineTaskApprovalFullStateMachine(t *testing.T) {
 		t.Error("rec.ResolvedAt should be set")
 	}
 }
-
 
 // extractField pulls a value out of the synthetic release response.
 // The task payload is now JSON-encoded inside a cat heredoc inside a
@@ -353,7 +352,7 @@ func TestInlineTaskRepeatTaskReplyOnInnerHoldDoesNothing(t *testing.T) {
 	// The rewrite WILL fire (the regex matches "task cv-...") but the
 	// hold's stage transitions to awaiting_task_definition. That's
 	// acceptable v1 behavior — if the user genuinely wants to redefine,
-	// the next POST /control/tasks will be intercepted again. The key
+	// the next POST /api/control/tasks will be intercepted again. The key
 	// invariant: no task was created, no double approval record.
 	_ = out
 	// Verify no Task or ApprovalRecord side-effects fired in the SAME

--- a/internal/api/handlers/llm_endpoint.go
+++ b/internal/api/handlers/llm_endpoint.go
@@ -30,9 +30,9 @@ import (
 // Anthropic-/OpenAI-shaped requests authenticated by the agent's existing
 // `cvis_…` token (carried in Authorization, x-api-key, or
 // X-Clawvisor-Agent-Token for upstream-auth passthrough), fetches or preserves
-// upstream auth, and proxies the response back. v1 is pure passthrough —
-// inspector and rewriter layer in via the response-body wrap path in
-// subsequent files.
+// upstream auth, and proxies the response back. The provider-compatible
+// /api/v1 routes are passthrough endpoints; inspector and rewriter layer in via
+// the response-body wrap path in subsequent files.
 type LLMEndpointHandler struct {
 	Store     store.Store
 	Vault     vault.Vault
@@ -45,7 +45,7 @@ type LLMEndpointHandler struct {
 	Inspector *inspector.Inspector
 
 	// ResolverBaseURL is the URL the rewriter redirects credentialed
-	// tool_uses through (e.g. https://clawvisor.example/proxy/v1). Empty
+	// tool_uses through (e.g. https://clawvisor.example/api/proxy). Empty
 	// disables rewriting even when Inspector is set.
 	ResolverBaseURL string
 
@@ -54,7 +54,7 @@ type LLMEndpointHandler struct {
 	// Empty disables control prompt injection and control rewrites.
 	ControlBaseURL string
 
-	// AuditEmitter writes one audit_log row per /v1/* request and per
+	// AuditEmitter writes one audit_log row per /api/v1/* request and per
 	// inspected tool_use. nil disables audit logging.
 	AuditEmitter *llmproxy.AuditEmitter
 
@@ -165,19 +165,19 @@ func NewLLMEndpointHandler(st store.Store, v vault.Vault, logger *slog.Logger) *
 	}
 }
 
-// Messages handles `POST /v1/messages` (Anthropic) and `POST
-// /v1/messages/count_tokens`. The route-selected parser dispatches to the
+// Messages handles `POST /api/v1/messages` (Anthropic) and `POST
+// /api/v1/messages/count_tokens`. The route-selected parser dispatches to the
 // Anthropic parser regardless of the inbound Host header.
 func (h *LLMEndpointHandler) Messages(w http.ResponseWriter, r *http.Request) {
 	h.serve(w, r)
 }
 
-// ChatCompletions handles `POST /v1/chat/completions` (OpenAI Chat API).
+// ChatCompletions handles `POST /api/v1/chat/completions` (OpenAI Chat API).
 func (h *LLMEndpointHandler) ChatCompletions(w http.ResponseWriter, r *http.Request) {
 	h.serve(w, r)
 }
 
-// Responses handles `POST /v1/responses` (OpenAI Responses API).
+// Responses handles `POST /api/v1/responses` (OpenAI Responses API).
 func (h *LLMEndpointHandler) Responses(w http.ResponseWriter, r *http.Request) {
 	h.serve(w, r)
 }
@@ -409,7 +409,7 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 	// resolves an awaiting_task_approval hold, create the task and
 	// rewrite the user message so the LLM gets clean context (rather
 	// than a synthesized cat-heredoc tool_use that confuses the model
-	// into re-POSTing /control/tasks).
+	// into re-POSTing /api/control/tasks).
 	inlineApprovalConsumed := false
 	if inlineRewrite, inlineErr := llmproxy.RewriteInlineTaskApprovalReply(r.Context(), llmproxy.InlineApprovalRewriteRequest{
 		HTTPRequest:     r,
@@ -453,7 +453,7 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 	// records what the user typed ("approve") not our one-shot
 	// rewrite ("approve [Clawvisor: ...]"), so on subsequent turns
 	// the context is lost and the model duplicates work
-	// (re-POSTs /control/tasks, re-emits tool_use). Walk conversation
+	// (re-POSTs /api/control/tasks, re-emits tool_use). Walk conversation
 	// history and re-inject the persistent context on every request.
 	if augBody, augmented, augErr := llmproxy.AugmentApprovedInlineTasksInHistory(body, provider, h.InlineApprovalOutcomes, agent.UserID, agent.ID); augErr != nil {
 		h.Logger.WarnContext(r.Context(), "lite-proxy inline task augmentation failed",
@@ -967,6 +967,7 @@ func (w *limitedCaptureWriter) Bytes() []byte {
 
 // actionForRoute maps a request path to an audit-log action label.
 func actionForRoute(path string) string {
+	path = strings.TrimPrefix(path, "/api")
 	switch path {
 	case "/v1/messages":
 		return "messages.create"

--- a/internal/api/handlers/llm_endpoint_test.go
+++ b/internal/api/handlers/llm_endpoint_test.go
@@ -210,10 +210,10 @@ func TestLLMEndpoint_PassthroughAnthropic(t *testing.T) {
 
 	mux := http.NewServeMux()
 	mw := middleware.RequireAgentLLM(st)
-	mux.Handle("POST /v1/messages", mw(http.HandlerFunc(h.Messages)))
+	mux.Handle("POST /api/v1/messages", mw(http.HandlerFunc(h.Messages)))
 
 	body := []byte(`{"model":"claude-sonnet-4","messages":[{"role":"user","content":"hi"}]}`)
-	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(string(body)))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/messages", strings.NewReader(string(body)))
 	req.Header.Set("Authorization", "Bearer "+rawToken)
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -303,7 +303,7 @@ func TestLLMEndpoint_InjectsControlNoticeWhenToolsAvailable(t *testing.T) {
 	}
 	// Negative: the daemon URL must not appear in the notice — it's a
 	// regression bug if it does.
-	if strings.Contains(string(seenBody), "http://localhost:25297/control/skill") {
+	if strings.Contains(string(seenBody), "http://localhost:25297/api/control/skill") {
 		t.Fatalf("control notice must not advertise the daemon URL: %s", seenBody)
 	}
 }
@@ -1391,7 +1391,7 @@ func TestLLMEndpoint_InspectorRewritesAutovaultToolUse(t *testing.T) {
 
 	h, st, rawToken, _ := newSeededHandler(t, upstream.URL)
 	h.Inspector = inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{})
-	h.ResolverBaseURL = "https://clawvisor.example/proxy/v1"
+	h.ResolverBaseURL = "https://clawvisor.example/api/proxy"
 
 	mux := http.NewServeMux()
 	mw := middleware.RequireAgentLLM(st)
@@ -1428,7 +1428,7 @@ func TestLLMEndpoint_InspectorRewritesAutovaultToolUse(t *testing.T) {
 		if err := json.Unmarshal(c.Input, &inputObj); err != nil {
 			t.Fatalf("rewritten input not parseable: %v", err)
 		}
-		if !strings.HasPrefix(inputObj.URL, "https://clawvisor.example/proxy/v1/repos/x/y/issues") {
+		if !strings.HasPrefix(inputObj.URL, "https://clawvisor.example/api/proxy/repos/x/y/issues") {
 			t.Fatalf("URL not rewritten to resolver: %q", inputObj.URL)
 		}
 		if inputObj.Headers["X-Clawvisor-Target-Host"] != "api.github.com" {
@@ -1468,7 +1468,7 @@ data: {"type":"message_stop"}
 
 	h, st, rawToken, _ := newSeededHandler(t, upstream.URL)
 	h.Inspector = inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{})
-	h.ResolverBaseURL = "https://clawvisor.example/proxy/v1"
+	h.ResolverBaseURL = "https://clawvisor.example/api/proxy"
 
 	mux := http.NewServeMux()
 	mw := middleware.RequireAgentLLM(st)
@@ -1484,7 +1484,7 @@ data: {"type":"message_stop"}
 		t.Fatalf("expected 200, got %d (%s)", rec.Code, rec.Body.String())
 	}
 	out := rec.Body.String()
-	if !strings.Contains(out, "https://clawvisor.example/proxy/v1/repos/x/y/issues") {
+	if !strings.Contains(out, "https://clawvisor.example/api/proxy/repos/x/y/issues") {
 		t.Fatalf("SSE response missing rewritten URL:\n%s", out)
 	}
 	if !strings.Contains(out, "X-Clawvisor-Target-Host") {
@@ -1513,7 +1513,7 @@ func TestLLMEndpoint_InlineApprovalReleasesHeldToolUse(t *testing.T) {
 
 	h, st, rawToken, _ := newSeededHandler(t, upstream.URL)
 	h.Inspector = inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{})
-	h.ResolverBaseURL = "https://clawvisor.example/proxy/v1"
+	h.ResolverBaseURL = "https://clawvisor.example/api/proxy"
 	h.AuditEmitter = llmproxy.NewAuditEmitter(st, slog.Default(), nil)
 	agent, err := st.GetAgentByToken(ctx, auth.HashToken(rawToken))
 	if err != nil {

--- a/internal/api/handlers/proxy_resolver.go
+++ b/internal/api/handlers/proxy_resolver.go
@@ -142,8 +142,8 @@ func (h *ProxyResolverHandler) safeDialContext(ctx context.Context, network, add
 	return nil, firstErr
 }
 
-// Forward handles ANY method on /proxy/v1/<path>. Path mapping: the request
-// path after `/proxy/v1/` becomes the upstream path verbatim.
+// Forward handles ANY method on /api/proxy/<path>. Path mapping: the request
+// path after `/api/proxy/` becomes the upstream path verbatim.
 func (h *ProxyResolverHandler) Forward(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
 	requestID := r.Header.Get("X-Request-Id")
@@ -207,9 +207,9 @@ func (h *ProxyResolverHandler) Forward(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Build the upstream URL. The path after `/proxy/v1/` is the upstream
+	// Build the upstream URL. The path after `/api/proxy/` is the upstream
 	// request path; query string is preserved.
-	upstreamPath := strings.TrimPrefix(r.URL.Path, "/proxy/v1")
+	upstreamPath := strings.TrimPrefix(r.URL.Path, "/api/proxy")
 	if upstreamPath == "" {
 		upstreamPath = "/"
 	}

--- a/internal/api/handlers/proxy_resolver_test.go
+++ b/internal/api/handlers/proxy_resolver_test.go
@@ -92,7 +92,7 @@ func nonceForRequest(t *testing.T, nonces llmproxy.CallerNonceCache, agentID str
 	return mintTestNonce(t, nonces, agentID,
 		req.Header.Get("X-Clawvisor-Target-Host"),
 		req.Method,
-		strings.TrimPrefix(req.URL.Path, "/proxy/v1"),
+		strings.TrimPrefix(req.URL.Path, "/api/proxy"),
 	)
 }
 
@@ -115,13 +115,13 @@ func TestResolver_HappyPath(t *testing.T) {
 
 	mux := http.NewServeMux()
 	mw := middleware.RequireAgentLLMNonce(st, nonces, slog.Default())
-	mux.Handle("/proxy/v1/", mw(http.HandlerFunc(h.Forward)))
+	mux.Handle("/api/proxy/", mw(http.HandlerFunc(h.Forward)))
 
 	// Target host: api.github.com (in the github bound-service allowlist).
 	// The redirectTargetTransport sends the actual dial to httptest's
 	// loopback URL, but the resolver believes (and validates against)
 	// api.github.com.
-	req := httptest.NewRequest(http.MethodGet, "/proxy/v1/repos/x/y/issues", strings.NewReader(""))
+	req := httptest.NewRequest(http.MethodGet, "/api/proxy/repos/x/y/issues", strings.NewReader(""))
 	req.Header.Set("X-Clawvisor-Target-Host", "api.github.com")
 	req.Header.Set("X-Clawvisor-Caller", nonceForRequest(t, nonces, agent.ID, req))
 	// Harness sends the placeholder in the natural Authorization header.
@@ -160,9 +160,9 @@ func TestResolver_AcceptsTargetHostWithExplicitPort(t *testing.T) {
 
 	mux := http.NewServeMux()
 	mw := middleware.RequireAgentLLMNonce(st, nonces, slog.Default())
-	mux.Handle("/proxy/v1/", mw(http.HandlerFunc(h.Forward)))
+	mux.Handle("/api/proxy/", mw(http.HandlerFunc(h.Forward)))
 
-	req := httptest.NewRequest(http.MethodGet, "/proxy/v1/repos/x/y/issues", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/proxy/repos/x/y/issues", nil)
 	req.Header.Set("X-Clawvisor-Target-Host", "api.github.com:8443")
 	req.Header.Set("X-Clawvisor-Caller", nonceForRequest(t, nonces, agent.ID, req))
 	req.Header.Set("Authorization", "Bearer "+placeholder)
@@ -179,9 +179,9 @@ func TestResolver_RejectsMissingTargetHost(t *testing.T) {
 
 	mux := http.NewServeMux()
 	mw := middleware.RequireAgentLLMNonce(st, nonces, slog.Default())
-	mux.Handle("/proxy/v1/", mw(http.HandlerFunc(h.Forward)))
+	mux.Handle("/api/proxy/", mw(http.HandlerFunc(h.Forward)))
 
-	req := httptest.NewRequest(http.MethodGet, "/proxy/v1/x", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/proxy/x", nil)
 	req.Header.Set("X-Clawvisor-Caller", nonceForRequest(t, nonces, agent.ID, req))
 	req.Header.Set("Authorization", "Bearer "+placeholder)
 	rec := httptest.NewRecorder()
@@ -209,9 +209,9 @@ func TestResolver_RejectsSelfTarget(t *testing.T) {
 
 	mux := http.NewServeMux()
 	mw := middleware.RequireAgentLLMNonce(st, nonces, slog.Default())
-	mux.Handle("/proxy/v1/", mw(http.HandlerFunc(h.Forward)))
+	mux.Handle("/api/proxy/", mw(http.HandlerFunc(h.Forward)))
 
-	req := httptest.NewRequest(http.MethodGet, "/proxy/v1/x", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/proxy/x", nil)
 	req.Header.Set("X-Clawvisor-Target-Host", "clawvisor.example")
 	req.Header.Set("X-Clawvisor-Caller", nonceForRequest(t, nonces, agent.ID, req))
 	req.Header.Set("Authorization", "Bearer "+placeholder)
@@ -250,9 +250,9 @@ func TestResolver_RejectsForeignPlaceholder(t *testing.T) {
 
 	mux := http.NewServeMux()
 	mw := middleware.RequireAgentLLMNonce(st, nonces, slog.Default())
-	mux.Handle("/proxy/v1/", mw(http.HandlerFunc(h.Forward)))
+	mux.Handle("/api/proxy/", mw(http.HandlerFunc(h.Forward)))
 
-	req := httptest.NewRequest(http.MethodGet, "/proxy/v1/x", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/proxy/x", nil)
 	req.Header.Set("X-Clawvisor-Target-Host", "api.github.com")
 	req.Header.Set("X-Clawvisor-Caller", nonceForRequest(t, nonces, agent.ID, req))
 	req.Header.Set("Authorization", "Bearer "+foreign)
@@ -294,9 +294,9 @@ func TestResolver_RejectsUnknownServicePlaceholderToArbitraryHost(t *testing.T) 
 
 	mux := http.NewServeMux()
 	mw := middleware.RequireAgentLLMNonce(st, nonces, slog.Default())
-	mux.Handle("/proxy/v1/", mw(http.HandlerFunc(h.Forward)))
+	mux.Handle("/api/proxy/", mw(http.HandlerFunc(h.Forward)))
 
-	req := httptest.NewRequest(http.MethodGet, "/proxy/v1/collect", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/proxy/collect", nil)
 	req.Header.Set("X-Clawvisor-Target-Host", "attacker.example")
 	req.Header.Set("X-Clawvisor-Caller", nonceForRequest(t, nonces, agent.ID, req))
 	req.Header.Set("Authorization", "Bearer "+placeholder)
@@ -316,9 +316,9 @@ func TestResolver_RejectsCallWithoutPlaceholder(t *testing.T) {
 
 	mux := http.NewServeMux()
 	mw := middleware.RequireAgentLLMNonce(st, nonces, slog.Default())
-	mux.Handle("/proxy/v1/", mw(http.HandlerFunc(h.Forward)))
+	mux.Handle("/api/proxy/", mw(http.HandlerFunc(h.Forward)))
 
-	req := httptest.NewRequest(http.MethodGet, "/proxy/v1/x", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/proxy/x", nil)
 	req.Header.Set("X-Clawvisor-Target-Host", "api.github.com")
 	req.Header.Set("X-Clawvisor-Caller", nonceForRequest(t, nonces, agent.ID, req))
 	// No header carries an autovault placeholder.
@@ -336,9 +336,9 @@ func TestResolver_RejectsHostOutsideBoundService(t *testing.T) {
 
 	mux := http.NewServeMux()
 	mw := middleware.RequireAgentLLMNonce(st, nonces, slog.Default())
-	mux.Handle("/proxy/v1/", mw(http.HandlerFunc(h.Forward)))
+	mux.Handle("/api/proxy/", mw(http.HandlerFunc(h.Forward)))
 
-	req := httptest.NewRequest(http.MethodGet, "/proxy/v1/api.test/path", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/proxy/api.test/path", nil)
 	req.Header.Set("X-Clawvisor-Target-Host", "slack.com")
 	req.Header.Set("X-Clawvisor-Caller", nonceForRequest(t, nonces, agent.ID, req))
 	req.Header.Set("Authorization", "Bearer "+placeholder)
@@ -405,9 +405,9 @@ func TestResolver_AllowsUnknownServiceHostBoundByCredentialGrant(t *testing.T) {
 
 	mux := http.NewServeMux()
 	mw := middleware.RequireAgentLLMNonce(st, nonces, slog.Default())
-	mux.Handle("/proxy/v1/", mw(http.HandlerFunc(h.Forward)))
+	mux.Handle("/api/proxy/", mw(http.HandlerFunc(h.Forward)))
 
-	req := httptest.NewRequest(http.MethodPost, "/proxy/v1/v1/calls", strings.NewReader(`{"to":"+15555550123"}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/proxy/v1/calls", strings.NewReader(`{"to":"+15555550123"}`))
 	req.Header.Set("X-Clawvisor-Target-Host", "api.agentphone.ai")
 	req.Header.Set("X-Clawvisor-Caller", nonceForRequest(t, nonces, agent.ID, req))
 	req.Header.Set("Authorization", "Bearer "+placeholder)
@@ -436,9 +436,9 @@ func TestResolver_StripsXClawvisorPrefixOnOutbound(t *testing.T) {
 
 	mux := http.NewServeMux()
 	mw := middleware.RequireAgentLLMNonce(st, nonces, slog.Default())
-	mux.Handle("/proxy/v1/", mw(http.HandlerFunc(h.Forward)))
+	mux.Handle("/api/proxy/", mw(http.HandlerFunc(h.Forward)))
 
-	req := httptest.NewRequest(http.MethodGet, "/proxy/v1/x", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/proxy/x", nil)
 	req.Header.Set("X-Clawvisor-Target-Host", "api.github.com")
 	req.Header.Set("X-Clawvisor-Caller", nonceForRequest(t, nonces, agent.ID, req))
 	req.Header.Set("X-Clawvisor-Custom", "secret")
@@ -480,9 +480,9 @@ func TestResolver_StripsForwardedHeadersOnOutbound(t *testing.T) {
 
 	mux := http.NewServeMux()
 	mw := middleware.RequireAgentLLMNonce(st, nonces, slog.Default())
-	mux.Handle("/proxy/v1/", mw(http.HandlerFunc(h.Forward)))
+	mux.Handle("/api/proxy/", mw(http.HandlerFunc(h.Forward)))
 
-	req := httptest.NewRequest(http.MethodGet, "/proxy/v1/x", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/proxy/x", nil)
 	req.Header.Set("X-Clawvisor-Target-Host", "api.github.com")
 	req.Header.Set("X-Clawvisor-Caller", nonceForRequest(t, nonces, agent.ID, req))
 	req.Header.Set("Authorization", "Bearer "+placeholder)
@@ -522,9 +522,9 @@ func TestResolver_StripsCallerAuthFromOutbound(t *testing.T) {
 
 	mux := http.NewServeMux()
 	mw := middleware.RequireAgentLLMNonce(st, nonces, slog.Default())
-	mux.Handle("/proxy/v1/", mw(http.HandlerFunc(h.Forward)))
+	mux.Handle("/api/proxy/", mw(http.HandlerFunc(h.Forward)))
 
-	req := httptest.NewRequest(http.MethodGet, "/proxy/v1/x", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/proxy/x", nil)
 	req.Header.Set("X-Clawvisor-Target-Host", "api.github.com")
 	req.Header.Set("X-Clawvisor-Caller", nonceForRequest(t, nonces, agent.ID, req))
 	// Placeholder rides on X-API-Key; Authorization carries a literal
@@ -554,10 +554,10 @@ func TestResolver_RejectsSelfTargetWithPort(t *testing.T) {
 
 	mux := http.NewServeMux()
 	mw := middleware.RequireAgentLLMNonce(st, nonces, slog.Default())
-	mux.Handle("/proxy/v1/", mw(http.HandlerFunc(h.Forward)))
+	mux.Handle("/api/proxy/", mw(http.HandlerFunc(h.Forward)))
 
 	for _, target := range []string{"clawvisor.example:443", "clawvisor.example:8080", "Clawvisor.Example:443"} {
-		req := httptest.NewRequest(http.MethodGet, "/proxy/v1/x", nil)
+		req := httptest.NewRequest(http.MethodGet, "/api/proxy/x", nil)
 		// Set Target-Host BEFORE minting the nonce so the nonce is bound
 		// to the target the resolver will see. Without this order, the
 		// middleware's nonce-target check fires first and the 403 below
@@ -593,9 +593,9 @@ func TestResolver_DoesNotFollowRedirects(t *testing.T) {
 
 	mux := http.NewServeMux()
 	mw := middleware.RequireAgentLLMNonce(st, nonces, slog.Default())
-	mux.Handle("/proxy/v1/", mw(http.HandlerFunc(h.Forward)))
+	mux.Handle("/api/proxy/", mw(http.HandlerFunc(h.Forward)))
 
-	req := httptest.NewRequest(http.MethodGet, "/proxy/v1/x", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/proxy/x", nil)
 	req.Header.Set("X-Clawvisor-Target-Host", "api.github.com")
 	req.Header.Set("X-Clawvisor-Caller", nonceForRequest(t, nonces, agent.ID, req))
 	req.Header.Set("Authorization", "Bearer "+placeholder)

--- a/internal/api/handlers/vault.go
+++ b/internal/api/handlers/vault.go
@@ -61,7 +61,7 @@ func (h *VaultHandler) ListForAgent(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "not authenticated")
 		return
 	}
-	if strings.HasPrefix(r.URL.Path, "/control/") {
+	if strings.HasPrefix(r.URL.Path, "/api/control/") {
 		h.writeControlList(w, r, agent.UserID)
 		return
 	}
@@ -74,7 +74,7 @@ func (h *VaultHandler) GetForAgent(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "not authenticated")
 		return
 	}
-	if strings.HasPrefix(r.URL.Path, "/control/") {
+	if strings.HasPrefix(r.URL.Path, "/api/control/") {
 		h.writeControlDetail(w, r, agent.UserID)
 		return
 	}

--- a/internal/api/handlers/vault_control_test.go
+++ b/internal/api/handlers/vault_control_test.go
@@ -39,7 +39,7 @@ func TestVaultControlItemsReturnsCompactAgentList(t *testing.T) {
 	}
 
 	h := NewVaultHandler(st, v, adapters.NewRegistry())
-	req := httptest.NewRequest(http.MethodGet, "/control/vault/items", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/control/vault/items", nil)
 	req = req.WithContext(store.WithAgent(req.Context(), agent))
 	rec := httptest.NewRecorder()
 
@@ -146,7 +146,7 @@ func TestVaultControlItemDetailReturnsCompactMetadata(t *testing.T) {
 	}
 
 	h := NewVaultHandler(st, v, adapters.NewRegistry())
-	req := httptest.NewRequest(http.MethodGet, "/control/vault/items/agentphone", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/control/vault/items/agentphone", nil)
 	req.SetPathValue("id", "agentphone")
 	req = req.WithContext(store.WithAgent(req.Context(), agent))
 	rec := httptest.NewRecorder()

--- a/internal/api/middleware/agent_llm.go
+++ b/internal/api/middleware/agent_llm.go
@@ -93,7 +93,7 @@ func RequireAgentLLM(st store.Store) func(http.Handler) http.Handler {
 }
 
 // RequireAgentLLMNonce authenticates the lite-proxy resolver
-// (/proxy/v1/...). The harness's resolver call carries the placeholder
+// (/api/proxy/...). The harness's resolver call carries the placeholder
 // being swapped in its natural credential header (Authorization /
 // x-api-key); caller-auth lives in `X-Clawvisor-Caller` and is a
 // short-lived single-use nonce minted by the proxy at rewrite time.
@@ -131,7 +131,7 @@ func RequireAgentLLMNonce(st store.Store, cache llmproxy.CallerNonceCache, logge
 			target := llmproxy.NonceTarget{
 				Host:   strings.TrimSpace(r.Header.Get("X-Clawvisor-Target-Host")),
 				Method: r.Method,
-				Path:   strings.TrimPrefix(r.URL.Path, "/proxy/v1"),
+				Path:   strings.TrimPrefix(r.URL.Path, "/api/proxy"),
 			}
 			agentID, err := cache.Consume(r.Context(), value, target)
 			if err != nil {

--- a/internal/api/middleware/agent_llm_test.go
+++ b/internal/api/middleware/agent_llm_test.go
@@ -170,7 +170,7 @@ func TestRequireAgentLLMNonce_RejectsExpiredNonceBoundAgent(t *testing.T) {
 		t.Fatal("handler should not run for an expired nonce-bound agent")
 	}))
 
-	req := httptest.NewRequest(http.MethodPost, "/proxy/v1/user", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/proxy/user", nil)
 	req.Header.Set("X-Clawvisor-Caller", "Bearer "+nonce)
 	req.Header.Set("X-Clawvisor-Target-Host", "api.github.com")
 	rec := httptest.NewRecorder()
@@ -208,7 +208,7 @@ func TestRequireAgentLLMNonce_AcceptsExplicitPortInTargetHostHeader(t *testing.T
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	req := httptest.NewRequest(http.MethodGet, "/proxy/v1/v1/whoami", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/proxy/v1/whoami", nil)
 	req.Header.Set("X-Clawvisor-Caller", "Bearer "+nonce)
 	// Rewriter emits host:port verbatim from parsed.Host.
 	req.Header.Set("X-Clawvisor-Target-Host", "api.example.com:8443")

--- a/internal/api/proxy_lite_routes_test.go
+++ b/internal/api/proxy_lite_routes_test.go
@@ -20,7 +20,9 @@ func TestProxyLiteRouteSetExposesOnlyProxySurface(t *testing.T) {
 	env := newRouteSetEnv(t, "proxy_lite")
 
 	assertStatus(t, env.ts.Client(), env.ts.URL+"/health", http.StatusOK)
-	assertStatus(t, env.ts.Client(), env.ts.URL+"/control", http.StatusOK)
+	assertStatus(t, env.ts.Client(), env.ts.URL+"/api/control", http.StatusOK)
+	assertStatus(t, env.ts.Client(), env.ts.URL+"/control", http.StatusNotFound)
+	assertStatus(t, env.ts.Client(), env.ts.URL+"/v1/messages", http.StatusNotFound)
 	assertStatus(t, env.ts.Client(), env.ts.URL+"/api/features", http.StatusNotFound)
 	assertStatus(t, env.ts.Client(), env.ts.URL+"/api/runtime/llm-credentials", http.StatusNotFound)
 }
@@ -29,12 +31,20 @@ func TestAppRouteSetHidesProxySurfaceButKeepsManagementRoutes(t *testing.T) {
 	env := newRouteSetEnv(t, "app")
 
 	assertStatus(t, env.ts.Client(), env.ts.URL+"/health", http.StatusOK)
-	assertStatus(t, env.ts.Client(), env.ts.URL+"/control", http.StatusNotFound)
-	assertStatus(t, env.ts.Client(), env.ts.URL+"/v1/messages", http.StatusNotFound)
+	assertStatus(t, env.ts.Client(), env.ts.URL+"/api/control", http.StatusNotFound)
+	assertStatus(t, env.ts.Client(), env.ts.URL+"/api/v1/messages", http.StatusNotFound)
 
 	// Route exists and rejects missing user auth. This is what lets the main
 	// app own credential management while a separate service owns proxy traffic.
 	assertStatus(t, env.ts.Client(), env.ts.URL+"/api/runtime/llm-credentials", http.StatusUnauthorized)
+}
+
+func TestFullRouteSetRejectsLegacyProxyPrefixes(t *testing.T) {
+	env := newRouteSetEnv(t, "")
+
+	assertStatus(t, env.ts.Client(), env.ts.URL+"/v1/responses", http.StatusNotFound)
+	assertStatus(t, env.ts.Client(), env.ts.URL+"/control", http.StatusNotFound)
+	assertStatus(t, env.ts.Client(), env.ts.URL+"/api/features", http.StatusOK)
 }
 
 type routeSetEnv struct {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -942,12 +942,10 @@ func (s *Server) routes() http.Handler {
 			routeSet != "app", true,
 		)
 	}
-	if routeSet == "app" {
-		mux.HandleFunc("/v1/", http.NotFound)
-		mux.HandleFunc("/proxy/v1/", http.NotFound)
-		mux.HandleFunc("/control", http.NotFound)
-		mux.HandleFunc("/control/", http.NotFound)
-	}
+	mux.HandleFunc("/v1/", http.NotFound)
+	mux.HandleFunc("/proxy/v1/", http.NotFound)
+	mux.HandleFunc("/control", http.NotFound)
+	mux.HandleFunc("/control/", http.NotFound)
 
 	// SSE event stream (user JWT or single-use ticket for EventSource)
 	requireUserOrTicket := middleware.RequireUserOrTicket(s.jwtSvc, s.store, s.ticketStore)
@@ -1215,7 +1213,7 @@ func (s *Server) registerLiteProxyRoutes(
 		if resolverBase == "" {
 			resolverBase = baseURL
 		}
-		llmHandler.ResolverBaseURL = strings.TrimRight(resolverBase, "/") + "/proxy/v1"
+		llmHandler.ResolverBaseURL = strings.TrimRight(resolverBase, "/") + "/api/proxy"
 		llmHandler.ControlBaseURL = strings.TrimRight(baseURL, "/")
 
 		auditEmitter := llmproxy.NewAuditEmitter(s.store, s.logger, nil)
@@ -1268,23 +1266,23 @@ func (s *Server) registerLiteProxyRoutes(
 			return middleware.RateLimit(gatewayRL, llmPreAuthKeyFn, gatewayLimit)(nonceMW(h))
 		}
 
-		mux.Handle("POST /v1/messages", requireAgentLLMRL(llmHandler.Messages))
-		mux.Handle("POST /v1/messages/count_tokens", requireAgentLLMRL(llmHandler.Messages))
-		mux.Handle("POST /v1/chat/completions", requireAgentLLMRL(llmHandler.ChatCompletions))
-		mux.Handle("POST /v1/responses", requireAgentLLMRL(llmHandler.Responses))
+		mux.Handle("POST /api/v1/messages", requireAgentLLMRL(llmHandler.Messages))
+		mux.Handle("POST /api/v1/messages/count_tokens", requireAgentLLMRL(llmHandler.Messages))
+		mux.Handle("POST /api/v1/chat/completions", requireAgentLLMRL(llmHandler.ChatCompletions))
+		mux.Handle("POST /api/v1/responses", requireAgentLLMRL(llmHandler.Responses))
 
-		mux.Handle("GET /control", http.HandlerFunc(controlHandler.Capabilities))
-		mux.Handle("GET /control/capabilities", http.HandlerFunc(controlHandler.Capabilities))
-		mux.Handle("GET /control/skill", http.HandlerFunc(controlHandler.Skill))
-		mux.Handle("POST /control/failure", requireAgentLLMCaller(e2e(http.HandlerFunc(controlHandler.Failure))))
-		mux.Handle("POST /control/tasks", requireAgentLLMCaller(e2e(http.HandlerFunc(tasksHandler.Create))))
-		mux.Handle("GET /control/tasks/{id}", requireAgentLLMCaller(e2e(http.HandlerFunc(tasksHandler.Get))))
-		mux.Handle("POST /control/tasks/{id}/expand", requireAgentLLMCaller(e2e(http.HandlerFunc(tasksHandler.Expand))))
-		mux.Handle("GET /control/vault/items", requireAgentLLMCaller(e2e(http.HandlerFunc(vaultHandler.ListForAgent))))
-		mux.Handle("GET /control/vault/items/{id}", requireAgentLLMCaller(e2e(http.HandlerFunc(vaultHandler.GetForAgent))))
-		mux.Handle("/control/", requireAgentLLMCaller(e2e(http.HandlerFunc(controlHandler.NotFound))))
+		mux.Handle("GET /api/control", http.HandlerFunc(controlHandler.Capabilities))
+		mux.Handle("GET /api/control/capabilities", http.HandlerFunc(controlHandler.Capabilities))
+		mux.Handle("GET /api/control/skill", http.HandlerFunc(controlHandler.Skill))
+		mux.Handle("POST /api/control/failure", requireAgentLLMCaller(e2e(http.HandlerFunc(controlHandler.Failure))))
+		mux.Handle("POST /api/control/tasks", requireAgentLLMCaller(e2e(http.HandlerFunc(tasksHandler.Create))))
+		mux.Handle("GET /api/control/tasks/{id}", requireAgentLLMCaller(e2e(http.HandlerFunc(tasksHandler.Get))))
+		mux.Handle("POST /api/control/tasks/{id}/expand", requireAgentLLMCaller(e2e(http.HandlerFunc(tasksHandler.Expand))))
+		mux.Handle("GET /api/control/vault/items", requireAgentLLMCaller(e2e(http.HandlerFunc(vaultHandler.ListForAgent))))
+		mux.Handle("GET /api/control/vault/items/{id}", requireAgentLLMCaller(e2e(http.HandlerFunc(vaultHandler.GetForAgent))))
+		mux.Handle("/api/control/", requireAgentLLMCaller(e2e(http.HandlerFunc(controlHandler.NotFound))))
 
-		mux.Handle("/proxy/v1/", requireAgentLLMCaller(http.HandlerFunc(resolverHandler.Forward)))
+		mux.Handle("/api/proxy/", requireAgentLLMCaller(http.HandlerFunc(resolverHandler.Forward)))
 	}
 
 	if includeCredentialRoutes {

--- a/internal/clawvisorcli/cmd_agent_lite.go
+++ b/internal/clawvisorcli/cmd_agent_lite.go
@@ -206,7 +206,7 @@ func buildLiteProxyEnv(provider, baseURL, agentToken string) ([]string, error) {
 	switch provider {
 	case liteProxyProviderClaude:
 		env = append(env,
-			"ANTHROPIC_BASE_URL="+baseURL,
+			"ANTHROPIC_BASE_URL="+liteProxyAPIBaseURL(baseURL),
 			"ANTHROPIC_CUSTOM_HEADERS="+liteProxyClaudeAgentTokenHeader+": "+agentToken,
 			"ANTHROPIC_AUTH_TOKEN=",
 			"ANTHROPIC_API_KEY=",
@@ -224,11 +224,21 @@ func normalizeLiteProxyServerURL(baseURL string) string {
 }
 
 func liteProxyOpenAIBaseURL(baseURL string) string {
+	return liteProxyAPIBaseURL(baseURL) + "/v1"
+}
+
+func liteProxyAPIBaseURL(baseURL string) string {
 	baseURL = normalizeLiteProxyServerURL(baseURL)
-	if strings.HasSuffix(baseURL, "/v1") {
+	if strings.HasSuffix(baseURL, "/api/v1") {
+		return strings.TrimSuffix(baseURL, "/v1")
+	}
+	if strings.HasSuffix(baseURL, "/api") {
 		return baseURL
 	}
-	return baseURL + "/v1"
+	if strings.HasSuffix(baseURL, "/v1") {
+		baseURL = strings.TrimSuffix(baseURL, "/v1")
+	}
+	return baseURL + "/api"
 }
 
 func runLiteProxyCommand(opts *liteProxyOptions, commandArgs []string) error {
@@ -258,7 +268,7 @@ func runLiteProxyCommand(opts *liteProxyOptions, commandArgs []string) error {
 // ensureLiteProxyEnabled preflight-checks that the daemon at baseURL
 // has `proxy_lite.enabled: true` in its config. Without this, the
 // harness would launch, dial the daemon, and get 404s on
-// `/v1/messages` — surfacing as a confusing "model unavailable"
+// `/api/v1/messages` — surfacing as a confusing "model unavailable"
 // error inside the harness's UI. The preflight is a single GET
 // against the unauthenticated `/api/features` endpoint with a tight
 // timeout; transient errors (connection refused, DNS lookup failure)
@@ -286,7 +296,7 @@ func ensureLiteProxyEnabled(baseURL string) error {
 	if resp.StatusCode != http.StatusOK {
 		// Older daemons may not expose /api/features. Don't refuse to
 		// run — fall through and let the harness see whatever the
-		// daemon actually responds with on /v1/*.
+		// daemon actually responds with on /api/v1/*.
 		return nil
 	}
 	var fs struct {

--- a/internal/clawvisorcli/cmd_agent_lite_test.go
+++ b/internal/clawvisorcli/cmd_agent_lite_test.go
@@ -28,7 +28,7 @@ func TestBuildLiteProxyEnvClaude(t *testing.T) {
 	if got := values["CLAWVISOR_PROXY_LITE_PROVIDER"]; got != "claude" {
 		t.Fatalf("CLAWVISOR_PROXY_LITE_PROVIDER = %q", got)
 	}
-	if got := values["ANTHROPIC_BASE_URL"]; got != "https://clawvisor.example" {
+	if got := values["ANTHROPIC_BASE_URL"]; got != "https://clawvisor.example/api" {
 		t.Fatalf("ANTHROPIC_BASE_URL = %q", got)
 	}
 	if got := values["ANTHROPIC_CUSTOM_HEADERS"]; got != "X-Clawvisor-Agent-Token: cvis_token" {
@@ -60,7 +60,7 @@ func TestBuildLiteProxyEnvCodex(t *testing.T) {
 	}
 	values := envMap(env)
 
-	if got := values["OPENAI_BASE_URL"]; got != "https://clawvisor.example/v1" {
+	if got := values["OPENAI_BASE_URL"]; got != "https://clawvisor.example/api/v1" {
 		t.Fatalf("OPENAI_BASE_URL = %q", got)
 	}
 	if _, ok := values["OPENAI_API_KEY"]; ok {
@@ -71,12 +71,22 @@ func TestBuildLiteProxyEnvCodex(t *testing.T) {
 	}
 }
 
-func TestBuildLiteProxyEnvCodexAvoidsDuplicateV1(t *testing.T) {
+func TestBuildLiteProxyEnvCodexAvoidsDuplicateAPI(t *testing.T) {
+	env, err := buildLiteProxyEnv("codex", "https://clawvisor.example/api/v1/", "cvis_token")
+	if err != nil {
+		t.Fatalf("buildLiteProxyEnv: %v", err)
+	}
+	if got := envMap(env)["OPENAI_BASE_URL"]; got != "https://clawvisor.example/api/v1" {
+		t.Fatalf("OPENAI_BASE_URL = %q", got)
+	}
+}
+
+func TestBuildLiteProxyEnvCodexRewritesLegacyV1Base(t *testing.T) {
 	env, err := buildLiteProxyEnv("codex", "https://clawvisor.example/v1/", "cvis_token")
 	if err != nil {
 		t.Fatalf("buildLiteProxyEnv: %v", err)
 	}
-	if got := envMap(env)["OPENAI_BASE_URL"]; got != "https://clawvisor.example/v1" {
+	if got := envMap(env)["OPENAI_BASE_URL"]; got != "https://clawvisor.example/api/v1" {
 		t.Fatalf("OPENAI_BASE_URL = %q", got)
 	}
 }
@@ -161,7 +171,7 @@ func TestPrepareLiteProxyCommandArgsInjectsCodexConfig(t *testing.T) {
 		"codex",
 		"-c", "model_provider=clawvisor",
 		"-c", `model_providers.clawvisor.name="clawvisor"`,
-		"-c", `model_providers.clawvisor.base_url="https://clawvisor.example/v1"`,
+		"-c", `model_providers.clawvisor.base_url="https://clawvisor.example/api/v1"`,
 		"-c", `model_providers.clawvisor.wire_api="responses"`,
 		"-c", `model_providers.clawvisor.requires_openai_auth=true`,
 		"-c", `model_providers.clawvisor.env_http_headers={"X-Clawvisor-Agent-Token"="CLAWVISOR_AGENT_TOKEN"}`,

--- a/internal/runtime/conversation/parser_route.go
+++ b/internal/runtime/conversation/parser_route.go
@@ -1,5 +1,7 @@
 package conversation
 
+import "strings"
+
 // ParserForProvider returns the registered parser for a given provider name.
 // The runtime proxy uses host-based Match(req); the lite-proxy LLM endpoint
 // dispatches by route (the request host is clawvisor.example, not the
@@ -19,12 +21,13 @@ func (r *Registry) ParserForProvider(p Provider) Parser {
 }
 
 // ParserForRoute returns the parser keyed off the lite-proxy route path. The
-// lite-proxy exposes /v1/messages (Anthropic) and /v1/chat/completions +
-// /v1/responses (OpenAI). When future providers ship their own routes, extend
-// here.
+// lite-proxy exposes /api/v1/messages (Anthropic) and /api/v1/chat/completions
+// + /api/v1/responses (OpenAI). When future providers ship their own routes,
+// extend here.
 //
 // Returns nil for unrecognized paths.
 func (r *Registry) ParserForRoute(path string) Parser {
+	path = strings.TrimPrefix(path, "/api")
 	switch {
 	case path == "/v1/messages" || path == "/v1/messages/count_tokens":
 		return r.ParserForProvider(ProviderAnthropic)

--- a/internal/runtime/conversation/parser_route_test.go
+++ b/internal/runtime/conversation/parser_route_test.go
@@ -8,10 +8,11 @@ func TestParserForRoute(t *testing.T) {
 		path string
 		want Provider
 	}{
+		{"/api/v1/messages", ProviderAnthropic},
+		{"/api/v1/messages/count_tokens", ProviderAnthropic},
+		{"/api/v1/chat/completions", ProviderOpenAI},
+		{"/api/v1/responses", ProviderOpenAI},
 		{"/v1/messages", ProviderAnthropic},
-		{"/v1/messages/count_tokens", ProviderAnthropic},
-		{"/v1/chat/completions", ProviderOpenAI},
-		{"/v1/responses", ProviderOpenAI},
 	}
 	for _, c := range cases {
 		got := r.ParserForRoute(c.path)

--- a/internal/runtime/conversation/response_test.go
+++ b/internal/runtime/conversation/response_test.go
@@ -107,7 +107,7 @@ data: {"type":"message_stop"}
 	result, err := (&AnthropicResponseRewriter{}).Rewrite(body, "text/event-stream", func(tu ToolUse) ToolUseVerdict {
 		return ToolUseVerdict{
 			Allowed:      true,
-			RewriteInput: json.RawMessage(`{"url":"https://example.test/control/skill","prompt":"What is here?"}`),
+			RewriteInput: json.RawMessage(`{"url":"https://example.test/api/control/skill","prompt":"What is here?"}`),
 		}
 	})
 	if err != nil {

--- a/internal/runtime/llmproxy/control.go
+++ b/internal/runtime/llmproxy/control.go
@@ -15,6 +15,8 @@ import (
 
 const (
 	ControlSyntheticHost  = "clawvisor.local"
+	ControlSyntheticPath  = "/control"
+	ControlAPIPath        = "/api/control"
 	ControlNoticeSentinel = "Clawvisor proxy-lite control plane."
 )
 
@@ -33,9 +35,9 @@ func controlNotice(controlBaseURL string, availableTools []string, toolRules []*
 	// bypass the rewrite path and end up reusing one-shot nonces from
 	// prior turns. controlBaseURL is intentionally ignored here.
 	_ = controlBaseURL
-	docsURL := "https://" + ControlSyntheticHost + "/control/skill"
-	vaultItemsURL := "https://" + ControlSyntheticHost + "/control/vault/items"
-	tasksURL := "https://" + ControlSyntheticHost + "/control/tasks"
+	docsURL := "https://" + ControlSyntheticHost + ControlSyntheticPath + "/skill"
+	vaultItemsURL := "https://" + ControlSyntheticHost + ControlSyntheticPath + "/vault/items"
+	tasksURL := "https://" + ControlSyntheticHost + ControlSyntheticPath + "/tasks"
 	tasksURLInline := tasksURL + "?surface=inline"
 	toolExamples := controlToolExamples(availableTools)
 	shellTool := controlShellTool(availableTools)
@@ -492,6 +494,9 @@ func RewriteControlToolUse(t conversation.ToolUse, controlBaseURL string, caller
 	if rewritten, ok, err := rewriteControlCommandToolUse(t, v, opts); ok {
 		return rewritten, v, true, err
 	}
+	if rewritten, ok, err := rewriteControlStructuredToolUse(t, opts); ok {
+		return rewritten, v, true, err
+	}
 	rewritten, err := inspector.Rewrite(inspector.ToolUse{
 		ID:    t.ID,
 		Name:  t.Name,
@@ -531,6 +536,50 @@ func rewriteControlCommandToolUse(t conversation.ToolUse, v inspector.Verdict, o
 	return out, true, err
 }
 
+func rewriteControlStructuredToolUse(t conversation.ToolUse, opts inspector.RewriteOpts) ([]byte, bool, error) {
+	resolver, err := url.Parse(opts.ResolverBaseURL)
+	if err != nil || resolver.Host == "" {
+		return nil, false, nil
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(t.Input, &raw); err != nil {
+		return nil, false, nil
+	}
+	urlVal, ok := raw["url"].(string)
+	if !ok || urlVal == "" {
+		return nil, false, nil
+	}
+	parsed, err := url.Parse(urlVal)
+	if err != nil || parsed.Host == "" || !strings.EqualFold(parsed.Hostname(), ControlSyntheticHost) {
+		return nil, false, nil
+	}
+	normalizedPath, ok := normalizeControlPath(parsed.Path)
+	if !ok {
+		return nil, false, nil
+	}
+	rewritten := *parsed
+	rewritten.Scheme = resolver.Scheme
+	rewritten.Host = resolver.Host
+	rewritten.Path = normalizedPath
+	if resolver.Path != "" {
+		rewritten.Path = strings.TrimRight(resolver.Path, "/") + normalizedPath
+	}
+	raw["url"] = rewritten.String()
+
+	headers, _ := raw["headers"].(map[string]any)
+	if headers == nil {
+		headers = map[string]any{}
+	}
+	headers[firstNonEmptyControl(opts.TargetHostHeader, "X-Clawvisor-Target-Host")] = parsed.Host
+	if opts.CallerToken != "" && opts.CallerHeader != "" {
+		headers[opts.CallerHeader] = "Bearer " + opts.CallerToken
+	}
+	raw["headers"] = headers
+
+	out, err := json.Marshal(raw)
+	return out, true, err
+}
+
 func RewriteControlFailureToolUse(t conversation.ToolUse, controlBaseURL string, callerToken string, reason string) ([]byte, bool, error) {
 	if strings.TrimSpace(controlBaseURL) == "" {
 		return nil, false, nil
@@ -548,7 +597,7 @@ func RewriteControlFailureToolUse(t conversation.ToolUse, controlBaseURL string,
 			return nil, false, nil
 		}
 	}
-	u, err := url.Parse(strings.TrimRight(controlBaseURL, "/") + "/control/failure")
+	u, err := url.Parse(strings.TrimRight(controlBaseURL, "/") + "/api/control/failure")
 	if err != nil {
 		return nil, false, err
 	}
@@ -609,7 +658,7 @@ func shellQuote(s string) string {
 }
 
 // controlToolUseMinYieldMs is the floor we clamp Codex's
-// exec_command yield_time_ms to when the call is a /control/* curl.
+// exec_command yield_time_ms to when the call is an /api/control/* curl.
 // The curl's max block is wait timeout (120s) plus network slop; 180s
 // gives a comfortable margin without forcing the agent to wait
 // substantially longer than necessary if the user replies quickly.
@@ -684,8 +733,11 @@ func rewriteControlCommandString(cmd string, v inspector.Verdict, opts inspector
 		rewritten := *parsed
 		rewritten.Scheme = resolver.Scheme
 		rewritten.Host = resolver.Host
+		if normalizedPath, ok := normalizeControlPath(parsed.Path); ok {
+			rewritten.Path = normalizedPath
+		}
 		if resolver.Path != "" {
-			rewritten.Path = strings.TrimRight(resolver.Path, "/") + parsed.Path
+			rewritten.Path = strings.TrimRight(resolver.Path, "/") + rewritten.Path
 		}
 		headers := " -H " + shellSingleQuote(firstNonEmptyControl(opts.TargetHostHeader, "X-Clawvisor-Target-Host")+": "+parsed.Host)
 		if opts.CallerToken != "" && opts.CallerHeader != "" {
@@ -822,18 +874,19 @@ func commandInputMentionsControlEndpoint(in json.RawMessage, controlBaseURL stri
 }
 
 func textMentionsControlEndpoint(text string, controlBaseURL string) bool {
-	if strings.Contains(text, "://"+ControlSyntheticHost+"/control") {
+	if strings.Contains(text, "://"+ControlSyntheticHost+ControlSyntheticPath) ||
+		strings.Contains(text, "://"+ControlSyntheticHost+ControlAPIPath) {
 		return true
 	}
 	base, err := url.Parse(strings.TrimSpace(controlBaseURL))
 	if err != nil || base.Host == "" {
 		return false
 	}
-	prefix := strings.TrimRight(controlBaseURL, "/") + "/control"
+	prefix := strings.TrimRight(controlBaseURL, "/") + ControlAPIPath
 	if strings.Contains(text, prefix) {
 		return true
 	}
-	if base.Scheme != "" && strings.Contains(text, base.Scheme+"://"+base.Host+"/control") {
+	if base.Scheme != "" && strings.Contains(text, base.Scheme+"://"+base.Host+ControlAPIPath) {
 		return true
 	}
 	return false
@@ -945,10 +998,25 @@ func parseControlURL(raw string, controlBaseURL string) (*url.URL, bool) {
 	if !isControlHost(u, controlBaseURL) {
 		return nil, false
 	}
-	if u.Path != "/control" && !strings.HasPrefix(u.Path, "/control/") {
+	normalized, ok := normalizeControlPath(u.Path)
+	if !ok {
 		return nil, false
 	}
+	u.Path = normalized
 	return u, true
+}
+
+func normalizeControlPath(path string) (string, bool) {
+	switch {
+	case path == ControlAPIPath || strings.HasPrefix(path, ControlAPIPath+"/"):
+		return path, true
+	case path == ControlSyntheticPath:
+		return ControlAPIPath, true
+	case strings.HasPrefix(path, ControlSyntheticPath+"/"):
+		return ControlAPIPath + strings.TrimPrefix(path, ControlSyntheticPath), true
+	default:
+		return "", false
+	}
 }
 
 func isControlHost(u *url.URL, controlBaseURL string) bool {
@@ -1230,7 +1298,7 @@ func parseSingleControlCurlStmt(cmd string, stmt *syntax.Stmt) ([]controlCurlArg
 // harness — so without a path allowlist a model could write or
 // overwrite arbitrary files (think `cat <<X >~/.bashrc`,
 // `>/etc/important.conf`, `>/Users/<u>/.ssh/authorized_keys`) while
-// the request looks like a normal /control/tasks call.
+// the request looks like a normal /api/control/tasks call.
 //
 // The allowed shape is `/tmp/<flat-name>.json`:
 //   - absolute, anchored at `/tmp/` — no $HOME expansion, no relative

--- a/internal/runtime/llmproxy/control_multistmt_test.go
+++ b/internal/runtime/llmproxy/control_multistmt_test.go
@@ -102,8 +102,8 @@ func TestControlPartsFromCommandInput_ResolvesDataAtPath(t *testing.T) {
 	if method != "POST" {
 		t.Errorf("method=%q, want POST", method)
 	}
-	if u == nil || !strings.HasSuffix(u.Path, "/control/tasks") {
-		t.Errorf("URL = %v, want .../control/tasks", u)
+	if u == nil || !strings.HasSuffix(u.Path, "/api/control/tasks") {
+		t.Errorf("URL = %v, want .../api/control/tasks", u)
 	}
 	if !strings.Contains(string(body), `"purpose":"Build a landing page"`) {
 		t.Errorf("body should have resolved @file → heredoc content; got %s", body)
@@ -130,7 +130,7 @@ func TestRewriteControlToolUse_RewritesMultiStmtCatHeredocPlusCurl(t *testing.T)
 	if !strings.Contains(out, "cat \\u003c\\u003c") {
 		t.Errorf("rewrite dropped the cat heredoc: %s", out)
 	}
-	if !strings.Contains(out, `https://control.example/control/tasks`) {
+	if !strings.Contains(out, `https://control.example/api/control/tasks`) {
 		t.Errorf("rewrite missing control URL: %s", out)
 	}
 	if !strings.Contains(out, `X-Clawvisor-Caller`) {

--- a/internal/runtime/llmproxy/forward.go
+++ b/internal/runtime/llmproxy/forward.go
@@ -48,6 +48,12 @@ func (s UpstreamSelector) URL(provider conversation.Provider, path string) (*url
 	return nil, fmt.Errorf("llmproxy: unknown provider %q", provider)
 }
 
+// ProviderPath maps Clawvisor's /api-hosted lite-proxy route back to the
+// provider-native path that should be sent upstream.
+func ProviderPath(_ conversation.Provider, path string) string {
+	return strings.TrimPrefix(path, "/api")
+}
+
 func joinURL(base, path string) (*url.URL, error) {
 	if base == "" {
 		return nil, errors.New("llmproxy: upstream base URL not configured")
@@ -138,7 +144,8 @@ func (f *Forwarder) Forward(ctx context.Context, userID, agentID string, provide
 		return nil, errors.New("llmproxy: inbound request is nil")
 	}
 
-	upstreamURL, err := f.Upstream.URL(provider, inbound.URL.Path)
+	upstreamPath := ProviderPath(provider, inbound.URL.Path)
+	upstreamURL, err := f.Upstream.URL(provider, upstreamPath)
 	if err != nil {
 		return nil, err
 	}
@@ -149,7 +156,7 @@ func (f *Forwarder) Forward(ctx context.Context, userID, agentID string, provide
 	// bearer's shape and claims; fall back to api.openai.com when in doubt.
 	if PassthroughUpstreamAuth(ctx) && provider == conversation.ProviderOpenAI {
 		if auth := passthroughBearerAuthorization(inbound); auth != "" {
-			if routed := openaiPassthroughRoute(auth, inbound.URL.Path); routed != nil {
+			if routed := openaiPassthroughRoute(auth, upstreamPath); routed != nil {
 				upstreamURL = routed
 			}
 		}

--- a/internal/runtime/llmproxy/forward_test.go
+++ b/internal/runtime/llmproxy/forward_test.go
@@ -81,7 +81,7 @@ func TestForward_AnthropicInjectsKey(t *testing.T) {
 		OpenAIBaseURL:    "",
 	}
 
-	inbound := httptest.NewRequest(http.MethodPost, "/v1/messages?beta=true", bytes.NewReader([]byte(`{"model":"claude"}`)))
+	inbound := httptest.NewRequest(http.MethodPost, "/api/v1/messages?beta=true", bytes.NewReader([]byte(`{"model":"claude"}`)))
 	inbound.Header.Set("Authorization", "Bearer cvis_xxx")
 	inbound.Header.Set("anthropic-beta", "beta1")
 
@@ -456,8 +456,8 @@ func TestOpenAIPassthroughRoute_CodexAccessTokenShape(t *testing.T) {
 
 func TestOpenAIPassthroughRoute_ChatGPTOAuth(t *testing.T) {
 	jwt := makeJWT(map[string]any{
-		"scp":                 "openid email profile",
-		"chatgpt_account_id":  "acct_xyz",
+		"scp":                "openid email profile",
+		"chatgpt_account_id": "acct_xyz",
 	})
 	got := openaiPassthroughRoute("Bearer "+jwt, "/v1/responses")
 	if got == nil {

--- a/internal/runtime/llmproxy/inbound_sanitize.go
+++ b/internal/runtime/llmproxy/inbound_sanitize.go
@@ -17,7 +17,7 @@ import (
 type SanitizeInboundRequest struct {
 	Provider        conversation.Provider
 	Body            []byte
-	ResolverBaseURL string // e.g. "http://localhost:25297/proxy/v1"
+	ResolverBaseURL string // e.g. "http://localhost:25297/api/proxy"
 	ControlBaseURL  string // e.g. "http://localhost:25297"
 }
 
@@ -31,8 +31,8 @@ type SanitizeInboundResult struct {
 
 const ClawvisorManagedMarker = "[clawvisor-managed]"
 
-// SanitizeInboundHistory walks an inbound /v1/messages or
-// /v1/chat/completions request body and reverts proxy-rewritten
+// SanitizeInboundHistory walks an inbound /api/v1/messages or
+// /api/v1/chat/completions request body and reverts proxy-rewritten
 // transport details inside assistant tool_use blocks back to the
 // synthetic form. Specifically, in every Bash-shaped tool_use we:
 //
@@ -41,14 +41,14 @@ const ClawvisorManagedMarker = "[clawvisor-managed]"
 //   - Convert `<daemon-resolver-base>/<path>` URLs back to
 //     `https://<target-host>/<path>` (target host extracted from the
 //     X-Clawvisor-Target-Host header before it was dropped).
-//   - Convert `<daemon-control-base>/control/…` URLs back to the
+//   - Convert `<daemon-control-base>/api/control/…` URLs back to the
 //     synthetic `https://clawvisor.local/control/…` form.
 //   - Replace any remaining literal `cv-nonce-…` substrings with a
 //     non-secret marker so the model can't pattern-match from them.
 //
 // Models pattern-match aggressively from their own conversation
 // history. Without this sanitization, after one rewrite turn the
-// model sees `curl … http://localhost:25297/proxy/v1/user
+// model sees `curl … http://localhost:25297/api/proxy/user
 // -H 'X-Clawvisor-Caller: Bearer cv-nonce-…' …` and starts emitting
 // that shape directly on subsequent turns — bypassing the rewrite
 // path and reusing stale nonces.
@@ -399,8 +399,8 @@ func sanitizeBashCommand(cmd string, req SanitizeInboundRequest) (string, bool) 
 	cmd = reCallerHeader.ReplaceAllString(cmd, "")
 
 	// Revert URLs. The resolver rewrite is `<resolver>/<path>` where
-	// resolver is something like `http://localhost:25297/proxy/v1`.
-	// The control rewrite is `<daemon>/control/<path>`.
+	// resolver is something like `http://localhost:25297/api/proxy`.
+	// The control rewrite is `<daemon>/api/control/<path>`.
 	resolverBase := strings.TrimRight(req.ResolverBaseURL, "/")
 	controlBase := strings.TrimRight(req.ControlBaseURL, "/")
 	if resolverBase != "" {
@@ -454,10 +454,10 @@ func revertResolverURLs(cmd, resolverBase, targetHost string) string {
 }
 
 func revertControlURLs(cmd, controlBase string) string {
-	// Replace `<controlBase>/control/…` and `<controlBase>/proxy/v1`
+	// Replace `<controlBase>/api/control/…` and `<controlBase>/api/proxy`
 	// has already been handled by revertResolverURLs. Here we only
 	// reach this when the rewriter targeted the control plane.
-	target := controlBase + "/control/"
+	target := controlBase + "/api/control/"
 	for {
 		idx := strings.Index(cmd, target)
 		if idx < 0 {

--- a/internal/runtime/llmproxy/inbound_sanitize_test.go
+++ b/internal/runtime/llmproxy/inbound_sanitize_test.go
@@ -19,7 +19,7 @@ func TestSanitizeInboundHistory_AnthropicRevertsRewrittenCurl(t *testing.T) {
 			{"role": "assistant", "content": [
 				{"type": "text", "text": "ok"},
 				{"type": "tool_use", "id": "toolu_1", "name": "Bash", "input": {
-					"command": "curl -sS -H 'Authorization: Bearer autovault_github_xxx' -H 'X-Clawvisor-Target-Host: api.github.com' -H 'X-Clawvisor-Caller: Bearer cv-nonce-abc123' http://localhost:25297/proxy/v1/user"
+					"command": "curl -sS -H 'Authorization: Bearer autovault_github_xxx' -H 'X-Clawvisor-Target-Host: api.github.com' -H 'X-Clawvisor-Caller: Bearer cv-nonce-abc123' http://localhost:25297/api/proxy/user"
 				}}
 			]}
 		]
@@ -27,7 +27,7 @@ func TestSanitizeInboundHistory_AnthropicRevertsRewrittenCurl(t *testing.T) {
 	res, err := SanitizeInboundHistory(SanitizeInboundRequest{
 		Provider:        conversation.ProviderAnthropic,
 		Body:            body,
-		ResolverBaseURL: "http://localhost:25297/proxy/v1",
+		ResolverBaseURL: "http://localhost:25297/api/proxy",
 		ControlBaseURL:  "http://localhost:25297",
 	})
 	if err != nil {
@@ -53,7 +53,7 @@ func TestSanitizeInboundHistory_AnthropicRevertsRewrittenCurl(t *testing.T) {
 		"X-Clawvisor-Caller",
 		"X-Clawvisor-Target-Host",
 		"http://localhost:25297",
-		"/proxy/v1/user",
+		"/api/proxy/user",
 	} {
 		if strings.Contains(out, banned) {
 			t.Errorf("post-rewrite leak: %q still present in sanitized body: %s", banned, out)
@@ -62,20 +62,20 @@ func TestSanitizeInboundHistory_AnthropicRevertsRewrittenCurl(t *testing.T) {
 }
 
 // Control-plane rewrites have a different shape: the rewriter targets
-// /control/... and uses clawvisor.local as the target host. The
+// /api/control/... and uses clawvisor.local as the target host. The
 // reversion goes to the synthetic clawvisor.local URL.
 func TestSanitizeInboundHistory_AnthropicRevertsControlCurl(t *testing.T) {
 	body := []byte(`{
 		"messages": [{"role": "assistant", "content": [
 			{"type": "tool_use", "id": "toolu_1", "name": "Bash", "input": {
-				"command": "curl -sS -X POST -H 'X-Clawvisor-Target-Host: clawvisor.local' -H 'X-Clawvisor-Caller: Bearer cv-nonce-xyz' http://localhost:25297/control/tasks --data '{}'"
+				"command": "curl -sS -X POST -H 'X-Clawvisor-Target-Host: clawvisor.local' -H 'X-Clawvisor-Caller: Bearer cv-nonce-xyz' http://localhost:25297/api/control/tasks --data '{}'"
 			}}
 		]}]
 	}`)
 	res, err := SanitizeInboundHistory(SanitizeInboundRequest{
 		Provider:        conversation.ProviderAnthropic,
 		Body:            body,
-		ResolverBaseURL: "http://localhost:25297/proxy/v1",
+		ResolverBaseURL: "http://localhost:25297/api/proxy",
 		ControlBaseURL:  "http://localhost:25297",
 	})
 	if err != nil {
@@ -100,7 +100,7 @@ func TestSanitizeInboundHistory_NoOpWhenNothingToStrip(t *testing.T) {
 	res, err := SanitizeInboundHistory(SanitizeInboundRequest{
 		Provider:        conversation.ProviderAnthropic,
 		Body:            body,
-		ResolverBaseURL: "http://localhost:25297/proxy/v1",
+		ResolverBaseURL: "http://localhost:25297/api/proxy",
 		ControlBaseURL:  "http://localhost:25297",
 	})
 	if err != nil {
@@ -126,7 +126,7 @@ func TestSanitizeInboundHistory_LeavesUserMessagesAlone(t *testing.T) {
 	res, _ := SanitizeInboundHistory(SanitizeInboundRequest{
 		Provider:        conversation.ProviderAnthropic,
 		Body:            body,
-		ResolverBaseURL: "http://localhost:25297/proxy/v1",
+		ResolverBaseURL: "http://localhost:25297/api/proxy",
 		ControlBaseURL:  "http://localhost:25297",
 	})
 	// The pre-filter sees "cv-nonce-" and engages, but the walk only
@@ -147,14 +147,14 @@ func TestSanitizeInboundHistory_OpenAIChatRevertsArguments(t *testing.T) {
 		"messages": [{"role":"assistant","tool_calls":[
 			{"id":"call_1","type":"function","function":{
 				"name":"Bash",
-				"arguments":"{\"command\":\"curl -sS -H 'Authorization: Bearer autovault_github_xxx' -H 'X-Clawvisor-Target-Host: api.github.com' -H 'X-Clawvisor-Caller: Bearer cv-nonce-abc' http://localhost:25297/proxy/v1/user\"}"
+				"arguments":"{\"command\":\"curl -sS -H 'Authorization: Bearer autovault_github_xxx' -H 'X-Clawvisor-Target-Host: api.github.com' -H 'X-Clawvisor-Caller: Bearer cv-nonce-abc' http://localhost:25297/api/proxy/user\"}"
 			}}
 		]}]
 	}`)
 	res, err := SanitizeInboundHistory(SanitizeInboundRequest{
 		Provider:        conversation.ProviderOpenAI,
 		Body:            body,
-		ResolverBaseURL: "http://localhost:25297/proxy/v1",
+		ResolverBaseURL: "http://localhost:25297/api/proxy",
 		ControlBaseURL:  "http://localhost:25297",
 	})
 	if err != nil {
@@ -181,14 +181,14 @@ func TestSanitizeInboundHistory_OpenAINonAssistantToolCallsUnchanged(t *testing.
 		"messages": [{"role":"tool","tool_call_id":"call_1","tool_calls":[
 			{"id":"call_1","type":"function","function":{
 				"name":"Bash",
-				"arguments":"{\"command\":\"curl -H 'X-Clawvisor-Caller: Bearer cv-nonce-stale' http://localhost:25297/proxy/v1/x\"}"
+				"arguments":"{\"command\":\"curl -H 'X-Clawvisor-Caller: Bearer cv-nonce-stale' http://localhost:25297/api/proxy/x\"}"
 			}}
 		]}]
 	}`)
 	res, err := SanitizeInboundHistory(SanitizeInboundRequest{
 		Provider:        conversation.ProviderOpenAI,
 		Body:            body,
-		ResolverBaseURL: "http://localhost:25297/proxy/v1",
+		ResolverBaseURL: "http://localhost:25297/api/proxy",
 		ControlBaseURL:  "http://localhost:25297",
 	})
 	if err != nil {
@@ -211,14 +211,14 @@ func TestSanitizeInboundHistory_IsIdempotent(t *testing.T) {
 	body := []byte(`{
 		"messages": [{"role":"assistant","content":[
 			{"type":"tool_use","id":"toolu_1","name":"Bash","input":{
-				"command":"curl -sS -H 'X-Clawvisor-Target-Host: api.github.com' -H 'X-Clawvisor-Caller: Bearer cv-nonce-1' http://localhost:25297/proxy/v1/user"
+				"command":"curl -sS -H 'X-Clawvisor-Target-Host: api.github.com' -H 'X-Clawvisor-Caller: Bearer cv-nonce-1' http://localhost:25297/api/proxy/user"
 			}}
 		]}]
 	}`)
 	req := SanitizeInboundRequest{
 		Provider:        conversation.ProviderAnthropic,
 		Body:            body,
-		ResolverBaseURL: "http://localhost:25297/proxy/v1",
+		ResolverBaseURL: "http://localhost:25297/api/proxy",
 		ControlBaseURL:  "http://localhost:25297",
 	}
 	first, _ := SanitizeInboundHistory(req)
@@ -237,7 +237,7 @@ func TestSanitizeInboundHistory_IsIdempotent(t *testing.T) {
 // description) must have it redacted to a placeholder marker.
 func TestSanitizeBashCommand_RedactsLooseNonces(t *testing.T) {
 	got, mut := sanitizeBashCommand("echo 'cv-nonce-leaked-into-comment'", SanitizeInboundRequest{
-		ResolverBaseURL: "http://localhost:25297/proxy/v1",
+		ResolverBaseURL: "http://localhost:25297/api/proxy",
 		ControlBaseURL:  "http://localhost:25297",
 	})
 	if !mut {

--- a/internal/runtime/llmproxy/inline_task_intercept.go
+++ b/internal/runtime/llmproxy/inline_task_intercept.go
@@ -19,7 +19,7 @@ import (
 const inlineTaskApprovalTTL = 10 * time.Minute
 
 // InlineSurfaceQueryParam is the query-string flag the model adds to
-// POST /control/tasks to opt in to the inline-approval flow when there
+// POST /api/control/tasks to opt in to the inline-approval flow when there
 // is no prior `task` reply (e.g. the agent knows the user is sitting
 // in the chat and prefers to approve there). Absent + no awaiting-
 // definition hold = the existing async dashboard path.
@@ -30,7 +30,7 @@ const InlineSurfaceQueryParam = "surface"
 const InlineSurfaceQueryValue = "inline"
 
 // maybeInterceptInlineTaskDefinition is the postprocess hook that
-// routes a model-emitted POST /control/tasks tool_use through the
+// routes a model-emitted POST /api/control/tasks tool_use through the
 // inline approval flow.
 //
 // The single opt-in signal is a `?surface=inline` query parameter on
@@ -46,7 +46,7 @@ const InlineSurfaceQueryValue = "inline"
 // prompt, and the user's next "yes" creates the task pre-approved.
 //
 // Returns (_, false) when the signal is absent, the body fails to
-// parse, or the path isn't POST /control/tasks — callers should
+// parse, or the path isn't POST /api/control/tasks — callers should
 // fall through to the regular control-rewrite path so headless task
 // creation still routes through the dashboard handler unchanged.
 func maybeInterceptInlineTaskDefinition(
@@ -61,11 +61,11 @@ func maybeInterceptInlineTaskDefinition(
 	if cfg.PendingApprovals == nil {
 		return conversation.ToolUseVerdict{}, false
 	}
-	// Only intercept POSTs to /control/tasks; the dashboard handler
+	// Only intercept POSTs to /api/control/tasks; the dashboard handler
 	// covers GETs (skill catalog) and other control paths. Exact
 	// path equality — HasSuffix would also match attacker-shaped paths
-	// like /foo/bar/control/tasks if the host check ever loosened.
-	if !strings.EqualFold(call.Method, "POST") || call.URL.Path != "/control/tasks" {
+	// like /foo/bar/api/control/tasks if the host check ever loosened.
+	if !strings.EqualFold(call.Method, "POST") || call.URL.Path != "/api/control/tasks" {
 		return conversation.ToolUseVerdict{}, false
 	}
 
@@ -97,7 +97,7 @@ func maybeInterceptInlineTaskDefinition(
 	// same request.
 	bodyBytes, ok := controlTaskBodyFromInput(tu.Input)
 	if !ok || len(bodyBytes) == 0 {
-		audit("fallthrough", "inline_task_body_missing", "POST /control/tasks had no body; deferring to dashboard rewrite")
+		audit("fallthrough", "inline_task_body_missing", "POST /api/control/tasks had no body; deferring to dashboard rewrite")
 		return conversation.ToolUseVerdict{}, false
 	}
 	parsed := &runtimetasks.TaskCreateRequest{}

--- a/internal/runtime/llmproxy/inline_task_intercept_test.go
+++ b/internal/runtime/llmproxy/inline_task_intercept_test.go
@@ -37,7 +37,7 @@ func anthropicBashControlTasksPost(body string) []byte {
 
 func TestPostprocess_AsyncControlTasksPostFallsThroughWhenNoHold(t *testing.T) {
 	// No awaiting_task_definition hold → the model is doing async task
-	// creation (or just calling /control/tasks directly), which should
+	// creation (or just calling /api/control/tasks directly), which should
 	// hit the dashboard-backed rewrite path unchanged.
 	cache := NewMemoryPendingApprovalCache(time.Minute)
 	st, userID, agentID := seedPostprocessStore(t, "autovault_github_xxx")
@@ -61,14 +61,14 @@ func TestPostprocess_AsyncControlTasksPostFallsThroughWhenNoHold(t *testing.T) {
 		t.Fatalf("expected control-tool rewrite to fire when no inline hold exists")
 	}
 	out := string(got.Body)
-	if !strings.Contains(out, "http://localhost:25297/control/tasks") {
+	if !strings.Contains(out, "http://localhost:25297/api/control/tasks") {
 		t.Fatalf("expected control URL rewrite; got %s", out)
 	}
 }
 
 // TestInlineTask_PostprocessIntoRelease drives both halves of the
 // state machine through real exported entry points: Postprocess
-// intercepts the model-emitted POST /control/tasks (via the
+// intercepts the model-emitted POST /api/control/tasks (via the
 // ?surface=inline query signal — the only production-reachable signal
 // today) and registers the inner hold; TryReleasePendingApproval
 // consumes the user's "approve" reply, drives the InlineTaskCreator,
@@ -80,7 +80,7 @@ func TestInlineTask_PostprocessIntoRelease(t *testing.T) {
 	st, userID, agentID := seedPostprocessStore(t, "autovault_github_xxx")
 
 	// Drive Postprocess on a model response that emits the bash-form
-	// POST /control/tasks WITH the surface=inline query — that's how a
+	// POST /api/control/tasks WITH the surface=inline query — that's how a
 	// compliant model signals an inline approval gesture in production.
 	body := anthropicBashControlTasksPostWithQuery(inlineTaskBody, "surface=inline")
 	req := httptest.NewRequest("POST", "/v1/messages", nil)
@@ -305,7 +305,7 @@ func TestPostprocess_InlineTaskInvalidCredentialFallsThroughToToolError(t *testi
 	if strings.Contains(out, "Clawvisor wants to create a task") {
 		t.Fatalf("invalid inline task should not render an approval prompt: %s", out)
 	}
-	if !strings.Contains(out, "http://localhost:25297/control/tasks") {
+	if !strings.Contains(out, "http://localhost:25297/api/control/tasks") {
 		t.Fatalf("invalid inline task should fall through to control rewrite so the tool receives the validation error: %s", out)
 	}
 
@@ -342,7 +342,7 @@ func TestPostprocess_InlineTaskBareNoSignalRoutesToDashboard(t *testing.T) {
 	if !got.Rewritten {
 		t.Fatalf("expected dashboard control-rewrite when no inline signal; got %s", got.Body)
 	}
-	if !strings.Contains(string(got.Body), "http://localhost:25297/control/tasks") {
+	if !strings.Contains(string(got.Body), "http://localhost:25297/api/control/tasks") {
 		t.Fatalf("expected control URL rewritten; got %s", got.Body)
 	}
 }

--- a/internal/runtime/llmproxy/inline_task_prompt.go
+++ b/internal/runtime/llmproxy/inline_task_prompt.go
@@ -9,7 +9,7 @@ import (
 
 // renderTaskApprovalPrompt builds the inline yes/no prompt the model
 // substitutes in place of the synthetic task_use_result for a model-emitted
-// POST /control/tasks when the user is mid-flight on an inline task gesture
+// POST /api/control/tasks when the user is mid-flight on an inline task gesture
 // (StageAwaitingTaskApproval).
 //
 // The output is plain text in the same shape as approvalPrompt — the harness

--- a/internal/runtime/llmproxy/inline_task_rewrite.go
+++ b/internal/runtime/llmproxy/inline_task_rewrite.go
@@ -71,7 +71,7 @@ type InlineApprovalRewriteResult struct {
 // user message and letting the request flow to the LLM, we:
 //
 //   - Avoid fabricating an assistant tool_use the LLM never authored
-//     (which previously confused the model into re-POSTing /control/tasks).
+//     (which previously confused the model into re-POSTing /api/control/tasks).
 //   - Avoid spoofing the harness into running shell commands the
 //     model didn't actually emit.
 //   - Give the LLM a clean conversation state with explicit context
@@ -210,7 +210,7 @@ func inlineApprovalOutcomeFromRewrite(requestID string, out InlineApprovalRewrit
 
 // InlineApprovalSubstitutedPromptMarker is the leading phrase of the
 // assistant text we substitute in place of a model-emitted POST
-// /control/tasks tool_use. The persistent-history rewriter looks for
+// /api/control/tasks tool_use. The persistent-history rewriter looks for
 // this marker to find user "approve" turns that need their context
 // re-injected on every subsequent request.
 const InlineApprovalSubstitutedPromptMarker = "Clawvisor wants to create a task to cover this work:"
@@ -236,7 +236,7 @@ const (
 // — the harness records what the user actually typed ("approve"), not
 // our transit-rewritten version. On subsequent turns the conversation
 // history shows bare "approve" and the model loses the task-creation
-// context, leading to duplicate /control/tasks POSTs and other
+// context, leading to duplicate /api/control/tasks POSTs and other
 // confusions.
 //
 // This function runs on every request as a no-op-or-augment pass. It

--- a/internal/runtime/llmproxy/inline_task_state_machine.md
+++ b/internal/runtime/llmproxy/inline_task_state_machine.md
@@ -14,7 +14,7 @@ user turn a blocked tool approval into an inline-approved task.
 
 `StageAwaitingTaskApproval`
 
-- The model emitted `POST /control/tasks?surface=inline`, and the proxy
+- The model emitted `POST /api/control/tasks?surface=inline`, and the proxy
   substituted a task approval prompt back into the conversation.
 - The user may reply `y`/`yes` or `n`/`no`.
 - Yes/no replies are normalized to `approve`/`deny` and handled by `RewriteInlineTaskApprovalReply`.
@@ -51,14 +51,14 @@ Effects:
 
 - Consumes the targeted tool hold.
 - Rewrites the user's `task` reply into a deterministic
-  `/control/tasks?surface=inline` task-creation prompt.
+  `/api/control/tasks?surface=inline` task-creation prompt.
 - Does not create a task.
 - Does not retain an orphan tool hold that could later be approved.
 
 `Postprocess` inline task intercept
 
 ```text
-model POST /control/tasks?surface=inline -> StageAwaitingTaskApproval
+model POST /api/control/tasks?surface=inline -> StageAwaitingTaskApproval
 ```
 
 Effects:

--- a/internal/runtime/llmproxy/inline_task_transitions.go
+++ b/internal/runtime/llmproxy/inline_task_transitions.go
@@ -12,7 +12,7 @@ func startInlineTaskDefinition(ctx context.Context, req TaskReplyRewriteRequest,
 	// harness now shows the task-creation prompt instead — there's
 	// no way back to approving the original tool. Leaving the hold
 	// in the cache was a latent safety issue: if the model didn't
-	// follow through with POST /control/tasks, the orphan hold could
+	// follow through with POST /api/control/tasks, the orphan hold could
 	// later be resolved as a regular tool approval by a bare approve.
 	//
 	// The inline-task intercept now relies on the query signal

--- a/internal/runtime/llmproxy/inspector/inspector_test.go
+++ b/internal/runtime/llmproxy/inspector/inspector_test.go
@@ -229,7 +229,7 @@ func TestRewrite_StructuredFetch(t *testing.T) {
 	if !ok || !v.IsAPICall {
 		t.Fatalf("setup: parser did not classify as IsAPICall")
 	}
-	out, err := Rewrite(in, v, DefaultRewriteOpts("https://proxy.clawvisor.example/proxy/v1"))
+	out, err := Rewrite(in, v, DefaultRewriteOpts("https://proxy.clawvisor.example/api/proxy"))
 	if err != nil {
 		t.Fatalf("Rewrite: %v", err)
 	}
@@ -238,7 +238,7 @@ func TestRewrite_StructuredFetch(t *testing.T) {
 		t.Fatalf("rewritten output not JSON: %v", err)
 	}
 	url, _ := got["url"].(string)
-	if !strings.HasPrefix(url, "https://proxy.clawvisor.example/proxy/v1/repos/x/y/issues") {
+	if !strings.HasPrefix(url, "https://proxy.clawvisor.example/api/proxy/repos/x/y/issues") {
 		t.Fatalf("rewritten url unexpected: %q", url)
 	}
 	if !strings.Contains(url, "state=open") {
@@ -259,7 +259,7 @@ func TestRewrite_BashAddsTargetHostHeader(t *testing.T) {
 	if !ok || !v.IsAPICall {
 		t.Fatalf("setup: parser did not classify as IsAPICall")
 	}
-	out, err := Rewrite(in, v, DefaultRewriteOpts("https://proxy.clawvisor.example/proxy/v1"))
+	out, err := Rewrite(in, v, DefaultRewriteOpts("https://proxy.clawvisor.example/api/proxy"))
 	if err != nil {
 		t.Fatalf("Rewrite: %v", err)
 	}
@@ -268,7 +268,7 @@ func TestRewrite_BashAddsTargetHostHeader(t *testing.T) {
 		t.Fatalf("rewritten output not JSON: %v", err)
 	}
 	cmd, _ := got["cmd"].(string)
-	if !strings.Contains(cmd, "https://proxy.clawvisor.example/proxy/v1/repos/x/y/issues") {
+	if !strings.Contains(cmd, "https://proxy.clawvisor.example/api/proxy/repos/x/y/issues") {
 		t.Fatalf("rewritten cmd missing resolver URL: %q", cmd)
 	}
 	if !strings.Contains(cmd, "X-Clawvisor-Target-Host: api.github.com") {
@@ -286,7 +286,7 @@ func TestRewrite_BashPostWithDataHeredocPreservesBody(t *testing.T) {
 	if !ok || !v.IsAPICall || v.Ambiguous {
 		t.Fatalf("setup: parser did not classify post body curl as IsAPICall: ok=%v %+v", ok, v)
 	}
-	out, err := Rewrite(in, v, DefaultRewriteOpts("https://proxy.clawvisor.example/proxy/v1"))
+	out, err := Rewrite(in, v, DefaultRewriteOpts("https://proxy.clawvisor.example/api/proxy"))
 	if err != nil {
 		t.Fatalf("Rewrite: %v", err)
 	}
@@ -295,7 +295,7 @@ func TestRewrite_BashPostWithDataHeredocPreservesBody(t *testing.T) {
 		t.Fatalf("rewritten output not JSON: %v", err)
 	}
 	rewritten, _ := got["command"].(string)
-	if !strings.Contains(rewritten, "https://proxy.clawvisor.example/proxy/v1/v1/calls") {
+	if !strings.Contains(rewritten, "https://proxy.clawvisor.example/api/proxy/v1/calls") {
 		t.Fatalf("rewritten cmd missing resolver URL: %q", rewritten)
 	}
 	if !strings.Contains(rewritten, "X-Clawvisor-Target-Host: api.agentphone.ai") {
@@ -321,7 +321,7 @@ func TestRewrite_BashCurlPipedToJqPreservesTail(t *testing.T) {
 	if !ok || !v.IsAPICall {
 		t.Fatalf("setup: parser did not classify piped curl as IsAPICall")
 	}
-	out, err := Rewrite(in, v, DefaultRewriteOpts("https://proxy.clawvisor.example/proxy/v1"))
+	out, err := Rewrite(in, v, DefaultRewriteOpts("https://proxy.clawvisor.example/api/proxy"))
 	if err != nil {
 		t.Fatalf("Rewrite: %v", err)
 	}
@@ -330,7 +330,7 @@ func TestRewrite_BashCurlPipedToJqPreservesTail(t *testing.T) {
 		t.Fatalf("rewritten output not JSON: %v", err)
 	}
 	cmd, _ := got["cmd"].(string)
-	if !strings.Contains(cmd, "https://proxy.clawvisor.example/proxy/v1/user") {
+	if !strings.Contains(cmd, "https://proxy.clawvisor.example/api/proxy/user") {
 		t.Fatalf("rewritten cmd missing resolver URL: %q", cmd)
 	}
 	if !strings.Contains(cmd, "| jq '.login'") {
@@ -350,7 +350,7 @@ func TestRewrite_BashCurlWithStderrRedirectPreservesTail(t *testing.T) {
 	if !ok || !v.IsAPICall {
 		t.Fatalf("setup: parser did not classify curl-with-redirect as IsAPICall")
 	}
-	out, err := Rewrite(in, v, DefaultRewriteOpts("https://proxy.clawvisor.example/proxy/v1"))
+	out, err := Rewrite(in, v, DefaultRewriteOpts("https://proxy.clawvisor.example/api/proxy"))
 	if err != nil {
 		t.Fatalf("Rewrite: %v", err)
 	}
@@ -360,7 +360,7 @@ func TestRewrite_BashCurlWithStderrRedirectPreservesTail(t *testing.T) {
 	if !strings.Contains(cmd, "2>/dev/null") {
 		t.Fatalf("redirect lost in rewrite: %q", cmd)
 	}
-	if !strings.Contains(cmd, "https://proxy.clawvisor.example/proxy/v1/user") {
+	if !strings.Contains(cmd, "https://proxy.clawvisor.example/api/proxy/user") {
 		t.Fatalf("rewritten cmd missing resolver URL: %q", cmd)
 	}
 }
@@ -371,7 +371,7 @@ func TestRewrite_BashPreservesExplicitPort(t *testing.T) {
 	if !ok || !v.IsAPICall {
 		t.Fatalf("setup: parser did not classify as IsAPICall")
 	}
-	out, err := Rewrite(in, v, DefaultRewriteOpts("https://proxy.clawvisor.example/proxy/v1"))
+	out, err := Rewrite(in, v, DefaultRewriteOpts("https://proxy.clawvisor.example/api/proxy"))
 	if err != nil {
 		t.Fatalf("Rewrite: %v", err)
 	}
@@ -398,7 +398,7 @@ func TestRewrite_StructuredPreservesExplicitPort(t *testing.T) {
 	if !ok || !v.IsAPICall {
 		t.Fatalf("setup: parser did not classify as IsAPICall")
 	}
-	out, err := Rewrite(in, v, DefaultRewriteOpts("https://proxy.clawvisor.example/proxy/v1"))
+	out, err := Rewrite(in, v, DefaultRewriteOpts("https://proxy.clawvisor.example/api/proxy"))
 	if err != nil {
 		t.Fatalf("Rewrite: %v", err)
 	}
@@ -487,7 +487,7 @@ func TestRewrite_InjectsCallerToken_Structured(t *testing.T) {
 	if !ok || !v.IsAPICall {
 		t.Fatalf("setup")
 	}
-	opts := DefaultRewriteOpts("https://proxy.example/proxy/v1")
+	opts := DefaultRewriteOpts("https://proxy.example/api/proxy")
 	opts.CallerToken = "cvis_abc123"
 
 	out, err := Rewrite(in, v, opts)
@@ -510,7 +510,7 @@ func TestRewrite_InjectsCallerToken_Bash(t *testing.T) {
 	if !ok || !v.IsAPICall {
 		t.Fatalf("setup")
 	}
-	opts := DefaultRewriteOpts("https://proxy.example/proxy/v1")
+	opts := DefaultRewriteOpts("https://proxy.example/api/proxy")
 	opts.CallerToken = "cvis_bash_token"
 
 	out, err := Rewrite(in, v, opts)
@@ -538,7 +538,7 @@ func TestRewrite_BashPreservesQuotedHeaderValue(t *testing.T) {
 	if !ok || !v.IsAPICall {
 		t.Fatalf("setup")
 	}
-	opts := DefaultRewriteOpts("https://proxy.example/proxy/v1")
+	opts := DefaultRewriteOpts("https://proxy.example/api/proxy")
 	opts.CallerToken = "cvis_call"
 
 	out, err := Rewrite(in, v, opts)

--- a/internal/runtime/llmproxy/pending_approval_cache.go
+++ b/internal/runtime/llmproxy/pending_approval_cache.go
@@ -21,7 +21,7 @@ import (
 //
 //	StageTool ──user types "task"──► StageAwaitingTaskDefinition
 //	                                 │
-//	                                 model emits POST /control/tasks
+//	                                 model emits POST /api/control/tasks
 //	                                 ▼
 //	                                 (new hold) StageAwaitingTaskApproval
 //	                                 │
@@ -35,7 +35,7 @@ const (
 	StageTool PendingApprovalStage = ""
 	// StageAwaitingTaskDefinition — user typed "task". The same hold's
 	// ToolUse field still points at the ORIGINAL tool. We're waiting for
-	// the model to emit a POST /control/tasks tool_use that defines the
+	// the model to emit a POST /api/control/tasks tool_use that defines the
 	// task that should cover this work.
 	StageAwaitingTaskDefinition PendingApprovalStage = "awaiting_task_definition"
 	// StageAwaitingTaskApproval — model has emitted the task definition.
@@ -69,7 +69,7 @@ type PendingLiteApproval struct {
 	// upstream bash/tool hold and release-or-deny it in cascade.
 	AwaitingTaskFor string
 
-	// TaskDefinition is the parsed body of the POST /control/tasks the
+	// TaskDefinition is the parsed body of the POST /api/control/tasks the
 	// model emitted at StageAwaitingTaskDefinition. Used both to render the
 	// inline approval prompt and to create the task once the user approves.
 	// nil at the other stages.

--- a/internal/runtime/llmproxy/postprocess.go
+++ b/internal/runtime/llmproxy/postprocess.go
@@ -226,10 +226,10 @@ func Postprocess(req *http.Request, body []byte, contentType string, cfg Postpro
 			// Inline task approval interception. When the user is
 			// mid-flight on a "task" gesture (the original tool hold has
 			// been transitioned to StageAwaitingTaskDefinition) and the
-			// model now emits POST /control/tasks, we route the task body
+			// model now emits POST /api/control/tasks, we route the task body
 			// through the inline approval path instead of letting it
 			// proxy through to the dashboard. The model never sees the
-			// real /control/tasks handler — its tool_use_result is
+			// real /api/control/tasks handler — its tool_use_result is
 			// replaced with a rendered yes/no prompt; the user's next
 			// "yes" creates the task pre-approved and the
 			// follow-up turn auto-releases the original tool call.
@@ -241,7 +241,7 @@ func Postprocess(req *http.Request, body []byte, contentType string, cfg Postpro
 			// Mint a nonce bound to the rewritten control URL's
 			// (host, method, path) — the rewritten curl carries it in
 			// X-Clawvisor-Caller; the daemon's nonce middleware on
-			// /control/* one-shot consumes it. Without this, the
+			// /api/control/* one-shot consumes it. Without this, the
 			// rewriter would have to embed the agent's raw cvis_ token
 			// (which the nonce middleware rejects) in the model's
 			// conversation context.
@@ -297,7 +297,7 @@ func Postprocess(req *http.Request, body []byte, contentType string, cfg Postpro
 				nonce, mintErr := cfg.CallerNonces.Mint(req.Context(), cfg.AgentID, NonceTarget{
 					Host:   ControlSyntheticHost,
 					Method: "POST",
-					Path:   "/control/failure",
+					Path:   "/api/control/failure",
 				})
 				if mintErr != nil {
 					audit("block", "caller_nonce_mint_failed", mintErr.Error())
@@ -318,7 +318,7 @@ func Postprocess(req *http.Request, body []byte, contentType string, cfg Postpro
 					trace(TraceEventControlRewrite,
 						"host", ControlSyntheticHost,
 						"method", "POST",
-						"path", "/control/failure",
+						"path", "/api/control/failure",
 						"failure_reason", reason,
 						"nonce_prefix", nonce[:min(len(nonce), 14)],
 						"rewrite_bytes", len(rewritten),

--- a/internal/runtime/llmproxy/postprocess_test.go
+++ b/internal/runtime/llmproxy/postprocess_test.go
@@ -79,7 +79,7 @@ func TestPostprocess_JSONNoTrigger(t *testing.T) {
 
 	got := Postprocess(req, body, "application/json", PostprocessConfig{
 		Inspector:    insp,
-		RewriteOpts:  inspector.DefaultRewriteOpts("https://proxy.example/proxy/v1"),
+		RewriteOpts:  inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
 		CallerNonces: NewMemoryCallerNonceCache(time.Minute),
 		Store:        st,
 		AgentUserID:  userID,
@@ -102,7 +102,7 @@ func TestPostprocess_AuditsNoTriggerToolUse(t *testing.T) {
 
 	got := Postprocess(req, body, "application/json", PostprocessConfig{
 		Inspector:    insp,
-		RewriteOpts:  inspector.DefaultRewriteOpts("https://proxy.example/proxy/v1"),
+		RewriteOpts:  inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
 		CallerNonces: NewMemoryCallerNonceCache(time.Minute),
 		Store:        st,
 		AgentUserID:  userID,
@@ -154,7 +154,7 @@ func TestPostprocess_SourceTriggerMissHonorsToolDenyRule(t *testing.T) {
 
 	got := Postprocess(req, body, "application/json", PostprocessConfig{
 		Inspector:    insp,
-		RewriteOpts:  inspector.DefaultRewriteOpts("https://proxy.example/proxy/v1"),
+		RewriteOpts:  inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
 		CallerNonces: NewMemoryCallerNonceCache(time.Minute),
 		Store:        st,
 		AgentUserID:  userID,
@@ -224,7 +224,7 @@ func TestPostprocess_ReadOnlyBashRequiresPolicyOrTaskScope(t *testing.T) {
 
 			got := Postprocess(req, body, "application/json", PostprocessConfig{
 				Inspector:        insp,
-				RewriteOpts:      inspector.DefaultRewriteOpts("https://proxy.example/proxy/v1"),
+				RewriteOpts:      inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
 				CallerNonces:     NewMemoryCallerNonceCache(time.Minute),
 				Store:            st,
 				AgentUserID:      userID,
@@ -258,7 +258,7 @@ func TestPostprocess_WriteStdinPollBypassesTaskScope(t *testing.T) {
 
 	got := Postprocess(req, body, "application/json", PostprocessConfig{
 		Inspector:        insp,
-		RewriteOpts:      inspector.DefaultRewriteOpts("https://proxy.example/proxy/v1"),
+		RewriteOpts:      inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
 		CallerNonces:     NewMemoryCallerNonceCache(time.Minute),
 		Store:            st,
 		AgentUserID:      userID,
@@ -294,7 +294,7 @@ func TestPostprocess_WriteStdinWithCharsStillRequiresApproval(t *testing.T) {
 
 	got := Postprocess(req, body, "application/json", PostprocessConfig{
 		Inspector:        insp,
-		RewriteOpts:      inspector.DefaultRewriteOpts("https://proxy.example/proxy/v1"),
+		RewriteOpts:      inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
 		CallerNonces:     NewMemoryCallerNonceCache(time.Minute),
 		Store:            st,
 		AgentUserID:      userID,
@@ -337,7 +337,7 @@ func TestPostprocess_MutatingBashStillRequiresApproval(t *testing.T) {
 
 			got := Postprocess(req, body, "application/json", PostprocessConfig{
 				Inspector:        insp,
-				RewriteOpts:      inspector.DefaultRewriteOpts("https://proxy.example/proxy/v1"),
+				RewriteOpts:      inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
 				CallerNonces:     NewMemoryCallerNonceCache(time.Minute),
 				Store:            st,
 				AgentUserID:      userID,
@@ -381,7 +381,7 @@ func TestPostprocess_ReadOnlyToolPolicyAllowlistBypassesTaskScope(t *testing.T) 
 
 			got := Postprocess(req, body, "application/json", PostprocessConfig{
 				Inspector:      insp,
-				RewriteOpts:    inspector.DefaultRewriteOpts("https://proxy.example/proxy/v1"),
+				RewriteOpts:    inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
 				CallerNonces:   NewMemoryCallerNonceCache(time.Minute),
 				Store:          st,
 				AgentUserID:    userID,
@@ -436,7 +436,7 @@ func TestPostprocess_BashWithoutTaskScopeStillRequiresApproval(t *testing.T) {
 
 	got := Postprocess(req, body, "application/json", PostprocessConfig{
 		Inspector:        insp,
-		RewriteOpts:      inspector.DefaultRewriteOpts("https://proxy.example/proxy/v1"),
+		RewriteOpts:      inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
 		CallerNonces:     NewMemoryCallerNonceCache(time.Minute),
 		Store:            st,
 		AgentUserID:      userID,
@@ -466,7 +466,7 @@ func TestPostprocess_SourceTriggerMissRequiresApprovalWhenScopeMissing(t *testin
 
 	got := Postprocess(req, body, "application/json", PostprocessConfig{
 		Inspector:        insp,
-		RewriteOpts:      inspector.DefaultRewriteOpts("https://proxy.example/proxy/v1"),
+		RewriteOpts:      inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
 		CallerNonces:     NewMemoryCallerNonceCache(time.Minute),
 		Store:            st,
 		AgentUserID:      userID,
@@ -522,7 +522,7 @@ func TestPostprocess_ToolTaskIntentRefusalRequiresApproval(t *testing.T) {
 
 	got := Postprocess(req, body, "application/json", PostprocessConfig{
 		Inspector:        insp,
-		RewriteOpts:      inspector.DefaultRewriteOpts("https://proxy.example/proxy/v1"),
+		RewriteOpts:      inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
 		CallerNonces:     NewMemoryCallerNonceCache(time.Minute),
 		Store:            st,
 		AgentUserID:      userID,
@@ -661,7 +661,7 @@ func TestPostprocess_RewritesSyntheticControlToolUseBeforeRules(t *testing.T) {
 		t.Fatalf("expected synthetic control URL rewrite")
 	}
 	out := string(got.Body)
-	if !strings.Contains(out, "http://localhost:25297/control/tasks") {
+	if !strings.Contains(out, "http://localhost:25297/api/control/tasks") {
 		t.Fatalf("control URL was not rewritten: %s", out)
 	}
 	if !strings.Contains(out, "X-Clawvisor-Target-Host") {
@@ -673,7 +673,7 @@ func TestPostprocess_RewritesSyntheticControlToolUseBeforeRules(t *testing.T) {
 }
 
 func TestPostprocess_RewritesConfiguredControlURLBeforeRules(t *testing.T) {
-	body := anthropicJSONWithToolUse(`{"cmd":"curl -i -X POST -H 'Content-Type: application/json' -H 'X-Clawvisor-Target-Host: clawvisor.local' -H 'X-Clawvisor-Caller: Bearer cvis_test' --data '{\"purpose\":\"Create a sample permission task from the shell for control-plane verification.\",\"intent_verification_mode\":\"strict\",\"expires_in_seconds\":600,\"expected_tools\":[{\"tool_name\":\"bash\",\"why\":\"Run curl against the proxied Clawvisor control endpoints.\"}]}' https://control.example.test/control/tasks"}`)
+	body := anthropicJSONWithToolUse(`{"cmd":"curl -i -X POST -H 'Content-Type: application/json' -H 'X-Clawvisor-Target-Host: clawvisor.local' -H 'X-Clawvisor-Caller: Bearer cvis_test' --data '{\"purpose\":\"Create a sample permission task from the shell for control-plane verification.\",\"intent_verification_mode\":\"strict\",\"expires_in_seconds\":600,\"expected_tools\":[{\"tool_name\":\"bash\",\"why\":\"Run curl against the proxied Clawvisor control endpoints.\"}]}' https://control.example.test/api/control/tasks"}`)
 	req := httptest.NewRequest("POST", "/v1/messages", nil)
 	insp := inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{})
 	st, userID, agentID := seedPostprocessStore(t, "autovault_github_xxx")
@@ -704,7 +704,7 @@ func TestPostprocess_RewritesConfiguredControlURLBeforeRules(t *testing.T) {
 		t.Fatalf("expected configured control URL rewrite")
 	}
 	out := string(got.Body)
-	if !strings.Contains(out, "https://control.example.test/control/tasks") {
+	if !strings.Contains(out, "https://control.example.test/api/control/tasks") {
 		t.Fatalf("control URL missing after rewrite: %s", out)
 	}
 	if !strings.Contains(out, "X-Clawvisor-Caller") {
@@ -716,7 +716,7 @@ func TestPostprocess_RewritesConfiguredControlURLBeforeRules(t *testing.T) {
 }
 
 func TestPostprocess_RewritesMultilineConfiguredControlURLBeforeRules(t *testing.T) {
-	body := anthropicJSONWithToolUse("{\"cmd\":\"curl -i -X POST \\\\\\n-H 'Content-Type: application/json' \\\\\\n--data '{\\\"purpose\\\":\\\"test\\\",\\\"expected_tools\\\":[{\\\"tool_name\\\":\\\"bash\\\",\\\"why\\\":\\\"test\\\"}]}' \\\\\\nhttps://control.example.test/control/tasks\"}")
+	body := anthropicJSONWithToolUse("{\"cmd\":\"curl -i -X POST \\\\\\n-H 'Content-Type: application/json' \\\\\\n--data '{\\\"purpose\\\":\\\"test\\\",\\\"expected_tools\\\":[{\\\"tool_name\\\":\\\"bash\\\",\\\"why\\\":\\\"test\\\"}]}' \\\\\\nhttps://control.example.test/api/control/tasks\"}")
 	req := httptest.NewRequest("POST", "/v1/messages", nil)
 	insp := inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{})
 	st, userID, agentID := seedPostprocessStore(t, "autovault_github_xxx")
@@ -791,7 +791,7 @@ func TestPostprocess_RewritesHeredocSyntheticControlURLBeforeRules(t *testing.T)
 	if strings.Contains(out, "bash blocked") {
 		t.Fatalf("heredoc synthetic control endpoint should bypass tool rules: %s", out)
 	}
-	if !strings.Contains(out, "'https://control.example.test/control/tasks?wait=true\\u0026timeout=120'") ||
+	if !strings.Contains(out, "'https://control.example.test/api/control/tasks?wait=true\\u0026timeout=120'") ||
 		!strings.Contains(out, "X-Clawvisor-Target-Host") ||
 		!strings.Contains(out, "X-Clawvisor-Caller") ||
 		!strings.Contains(out, `\u003c\u003c'JSON'`) {
@@ -827,7 +827,7 @@ func TestPostprocess_MalformedSyntheticControlCommandRewritesToToolFailure(t *te
 		t.Fatalf("expected malformed control command failure rewrite")
 	}
 	out := string(got.Body)
-	if !strings.Contains(out, "/control/failure") {
+	if !strings.Contains(out, "/api/control/failure") {
 		t.Fatalf("expected control failure endpoint rewrite, got: %s", out)
 	}
 	if !strings.Contains(out, "original_command") || !strings.Contains(out, "python3") {
@@ -863,7 +863,7 @@ func TestPostprocess_HoldsMultipleApprovalPromptsInOneResponse(t *testing.T) {
 
 	got := Postprocess(req, body, "application/json", PostprocessConfig{
 		Inspector:        insp,
-		RewriteOpts:      inspector.DefaultRewriteOpts("https://proxy.example/proxy/v1"),
+		RewriteOpts:      inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
 		CallerNonces:     NewMemoryCallerNonceCache(time.Minute),
 		Store:            st,
 		AgentUserID:      userID,
@@ -909,7 +909,7 @@ func TestPostprocess_ObservePostureDoesNotBlockToolDenyRule(t *testing.T) {
 
 	got := Postprocess(req, body, "application/json", PostprocessConfig{
 		Inspector:    insp,
-		RewriteOpts:  inspector.DefaultRewriteOpts("https://proxy.example/proxy/v1"),
+		RewriteOpts:  inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
 		CallerNonces: NewMemoryCallerNonceCache(time.Minute),
 		Store:        st,
 		AgentUserID:  userID,
@@ -933,7 +933,7 @@ func TestPostprocess_ObservePostureDoesNotBlockToolDenyRule(t *testing.T) {
 	if strings.Contains(string(got.Body), "web fetch blocked") {
 		t.Fatalf("observe mode should not block with rule reason: %s", got.Body)
 	}
-	if !strings.Contains(string(got.Body), "https://proxy.example/proxy/v1/repos/x/y/issues") {
+	if !strings.Contains(string(got.Body), "https://proxy.example/api/proxy/repos/x/y/issues") {
 		t.Fatalf("observe mode should allow rewrite through proxy: %s", got.Body)
 	}
 }
@@ -947,7 +947,7 @@ func TestPostprocess_JSONRewritesAutovaultURL(t *testing.T) {
 
 	got := Postprocess(req, body, "application/json", PostprocessConfig{
 		Inspector:    insp,
-		RewriteOpts:  inspector.DefaultRewriteOpts("https://proxy.example/proxy/v1"),
+		RewriteOpts:  inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
 		CallerNonces: NewMemoryCallerNonceCache(time.Minute),
 		Store:        st,
 		AgentUserID:  userID,
@@ -977,7 +977,7 @@ func TestPostprocess_JSONRewritesAutovaultURL(t *testing.T) {
 		if err := json.Unmarshal(c.Input, &inputObj); err != nil {
 			t.Fatalf("rewritten input not parseable: %v", err)
 		}
-		if !strings.HasPrefix(inputObj.URL, "https://proxy.example/proxy/v1/repos/x/y/issues") {
+		if !strings.HasPrefix(inputObj.URL, "https://proxy.example/api/proxy/repos/x/y/issues") {
 			t.Fatalf("URL not rewritten to resolver: %q", inputObj.URL)
 		}
 		if inputObj.Headers["X-Clawvisor-Target-Host"] != "api.github.com" {
@@ -1027,7 +1027,7 @@ data: {"type":"message_stop"}
 
 	got := Postprocess(req, body, "text/event-stream", PostprocessConfig{
 		Inspector:    insp,
-		RewriteOpts:  inspector.DefaultRewriteOpts("https://proxy.example/proxy/v1"),
+		RewriteOpts:  inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
 		CallerNonces: NewMemoryCallerNonceCache(time.Minute),
 		Store:        st,
 		AgentUserID:  userID,
@@ -1038,7 +1038,7 @@ data: {"type":"message_stop"}
 		t.Fatalf("expected SSE rewrite to fire on autovault placeholder")
 	}
 	out := string(got.Body)
-	if !strings.Contains(out, "https://proxy.example/proxy/v1/repos/x/y/issues") {
+	if !strings.Contains(out, "https://proxy.example/api/proxy/repos/x/y/issues") {
 		t.Fatalf("rewritten SSE missing resolver URL:\n%s", out)
 	}
 	if !strings.Contains(out, "X-Clawvisor-Target-Host") {
@@ -1069,7 +1069,7 @@ func TestPostprocess_OpenAIResponsesJSONRewrite(t *testing.T) {
 
 	got := Postprocess(req, body, "application/json", PostprocessConfig{
 		Inspector:    insp,
-		RewriteOpts:  inspector.DefaultRewriteOpts("https://proxy.example/proxy/v1"),
+		RewriteOpts:  inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
 		CallerNonces: NewMemoryCallerNonceCache(time.Minute),
 		Store:        st,
 		AgentUserID:  userID,
@@ -1079,7 +1079,7 @@ func TestPostprocess_OpenAIResponsesJSONRewrite(t *testing.T) {
 	if !got.Rewritten {
 		t.Fatalf("expected rewrite for OpenAI Responses JSON, got skipped=%q", got.SkippedReason)
 	}
-	if !strings.Contains(string(got.Body), "https://proxy.example/proxy/v1/repos/x/y/issues") {
+	if !strings.Contains(string(got.Body), "https://proxy.example/api/proxy/repos/x/y/issues") {
 		t.Fatalf("rewritten URL missing:\n%s", got.Body)
 	}
 	if !strings.Contains(string(got.Body), "X-Clawvisor-Target-Host") {
@@ -1114,7 +1114,7 @@ data: {"type":"response.completed","response":{"id":"resp_1","status":"completed
 
 	got := Postprocess(req, body, "text/event-stream", PostprocessConfig{
 		Inspector:    insp,
-		RewriteOpts:  inspector.DefaultRewriteOpts("https://proxy.example/proxy/v1"),
+		RewriteOpts:  inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
 		CallerNonces: NewMemoryCallerNonceCache(time.Minute),
 		Store:        st,
 		AgentUserID:  userID,
@@ -1125,7 +1125,7 @@ data: {"type":"response.completed","response":{"id":"resp_1","status":"completed
 		t.Fatalf("expected SSE rewrite for OpenAI Responses, got skipped=%q", got.SkippedReason)
 	}
 	out := string(got.Body)
-	if !strings.Contains(out, "https://proxy.example/proxy/v1/repos/x/y/issues") {
+	if !strings.Contains(out, "https://proxy.example/api/proxy/repos/x/y/issues") {
 		t.Fatalf("rewritten URL missing:\n%s", out)
 	}
 	if !strings.Contains(out, "response.output_item.done") || !strings.Contains(out, "response.completed") {
@@ -1156,7 +1156,7 @@ data: {"type":"response.completed","response":{"id":"resp_1","status":"completed
 
 	got := Postprocess(req, body, "text/event-stream", PostprocessConfig{
 		Inspector:    insp,
-		RewriteOpts:  inspector.DefaultRewriteOpts("https://proxy.example/proxy/v1"),
+		RewriteOpts:  inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
 		CallerNonces: NewMemoryCallerNonceCache(time.Minute),
 		Store:        st,
 		AgentUserID:  userID,
@@ -1223,7 +1223,7 @@ func TestPostprocess_OpenAIChatJSONRewrite(t *testing.T) {
 
 	got := Postprocess(req, body, "application/json", PostprocessConfig{
 		Inspector:    insp,
-		RewriteOpts:  inspector.DefaultRewriteOpts("https://proxy.example/proxy/v1"),
+		RewriteOpts:  inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
 		CallerNonces: NewMemoryCallerNonceCache(time.Minute),
 		Store:        st,
 		AgentUserID:  userID,
@@ -1233,7 +1233,7 @@ func TestPostprocess_OpenAIChatJSONRewrite(t *testing.T) {
 	if !got.Rewritten {
 		t.Fatalf("expected rewrite for OpenAI Chat JSON, got skipped=%q", got.SkippedReason)
 	}
-	if !strings.Contains(string(got.Body), "https://proxy.example/proxy/v1/repos/x/y/issues") {
+	if !strings.Contains(string(got.Body), "https://proxy.example/api/proxy/repos/x/y/issues") {
 		t.Fatalf("rewritten URL missing:\n%s", got.Body)
 	}
 }
@@ -1255,7 +1255,7 @@ data: [DONE]
 
 	got := Postprocess(req, body, "text/event-stream", PostprocessConfig{
 		Inspector:    insp,
-		RewriteOpts:  inspector.DefaultRewriteOpts("https://proxy.example/proxy/v1"),
+		RewriteOpts:  inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
 		CallerNonces: NewMemoryCallerNonceCache(time.Minute),
 		Store:        st,
 		AgentUserID:  userID,
@@ -1266,7 +1266,7 @@ data: [DONE]
 		t.Fatalf("expected SSE rewrite for OpenAI Chat, got skipped=%q", got.SkippedReason)
 	}
 	out := string(got.Body)
-	if !strings.Contains(out, "https://proxy.example/proxy/v1/repos/x/y/issues") {
+	if !strings.Contains(out, "https://proxy.example/api/proxy/repos/x/y/issues") {
 		t.Fatalf("rewritten URL missing:\n%s", out)
 	}
 	if !strings.Contains(out, `"finish_reason":"tool_calls"`) {
@@ -1289,7 +1289,7 @@ func TestPostprocess_AmbiguousFailsClosed(t *testing.T) {
 
 	got := Postprocess(req, body, "application/json", PostprocessConfig{
 		Inspector:    insp,
-		RewriteOpts:  inspector.DefaultRewriteOpts("https://proxy.example/proxy/v1"),
+		RewriteOpts:  inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
 		CallerNonces: NewMemoryCallerNonceCache(time.Minute),
 		Store:        st,
 		AgentUserID:  userID,

--- a/internal/runtime/llmproxy/release_test.go
+++ b/internal/runtime/llmproxy/release_test.go
@@ -338,7 +338,7 @@ func TestTryReleasePendingApproval_BlocksUnknownServiceHosts(t *testing.T) {
 		PendingApproval: cache,
 		Inspector:       inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{}),
 		Store:           st,
-		RewriteOpts:     inspector.DefaultRewriteOpts("https://proxy.example/proxy/v1"),
+		RewriteOpts:     inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
 		CallerNonces:    NewMemoryCallerNonceCache(time.Minute),
 		CandidateTasks: []*store.Task{{
 			ID:            "task-agentphone",
@@ -386,7 +386,7 @@ func TestTryReleasePendingApproval_BlockedReleaseShowsReason(t *testing.T) {
 		PendingApproval: cache,
 		Inspector:       inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{}),
 		Store:           st,
-		RewriteOpts:     inspector.DefaultRewriteOpts("https://proxy.example/proxy/v1"),
+		RewriteOpts:     inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
 		CallerNonces:    NewMemoryCallerNonceCache(time.Minute),
 	})
 	if !result.Handled || result.Decision != "deny" || result.Outcome != "approval_release_blocked" {

--- a/internal/runtime/llmproxy/secret_detection_test.go
+++ b/internal/runtime/llmproxy/secret_detection_test.go
@@ -504,7 +504,7 @@ func TestScanInboundSecrets_IgnoresClawvisorNonceInPriorToolArguments(t *testing
 		"model":"gpt-5.4",
 		"input":[
 			{"role":"user","content":[{"type":"input_text","text":"Check the recent emails in Resend using the vaulted credential placeholder."}]},
-			{"type":"function_call","name":"exec_command","arguments":"curl -sS -H 'X-Clawvisor-Target-Host: api.resend.com' -H 'X-Clawvisor-Caller: Bearer cv-nonce-pr7vwci4umcgs6rsj3lika4vve' http://localhost:25297/proxy/v1/emails -H 'Authorization: Bearer autovault_resend_1_example'","call_id":"call_abc123"},
+			{"type":"function_call","name":"exec_command","arguments":"curl -sS -H 'X-Clawvisor-Target-Host: api.resend.com' -H 'X-Clawvisor-Caller: Bearer cv-nonce-pr7vwci4umcgs6rsj3lika4vve' http://localhost:25297/api/proxy/emails -H 'Authorization: Bearer autovault_resend_1_example'","call_id":"call_abc123"},
 			{"type":"function_call_output","call_id":"call_abc123","output":"{\"statusCode\":400,\"message\":\"API key is invalid\",\"name\":\"validation_error\"}"},
 			{"role":"user","content":[{"type":"input_text","text":"continue"}]}
 		]

--- a/internal/runtime/llmproxy/taskscope_test.go
+++ b/internal/runtime/llmproxy/taskscope_test.go
@@ -161,7 +161,7 @@ func TestPostprocess_TaskScopeBlocksUnauthorizedAction(t *testing.T) {
 
 	got := Postprocess(req, body, "application/json", PostprocessConfig{
 		Inspector:   insp,
-		RewriteOpts: inspector.DefaultRewriteOpts("https://proxy.example/proxy/v1"),
+		RewriteOpts: inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
 		CallerNonces: NewMemoryCallerNonceCache(time.Minute),
 		Store:       st,
 		AgentUserID: userID,
@@ -175,7 +175,7 @@ func TestPostprocess_TaskScopeBlocksUnauthorizedAction(t *testing.T) {
 	// The body should contain a Clawvisor refusal in place of the
 	// rewritten tool_use input. We accept either an unrewritten body
 	// (rewriter fell back to refusal) or a body without the resolver URL.
-	if strings.Contains(string(got.Body), "https://proxy.example/proxy/v1") {
+	if strings.Contains(string(got.Body), "https://proxy.example/api/proxy") {
 		t.Fatalf("rewrite should NOT have happened — task scope denies github.create_issue:\n%s", got.Body)
 	}
 	if !strings.Contains(string(got.Body), "no active task scope") {
@@ -194,7 +194,7 @@ func TestPostprocess_TaskScopeAllowsAuthorizedAction(t *testing.T) {
 
 	got := Postprocess(req, body, "application/json", PostprocessConfig{
 		Inspector:   insp,
-		RewriteOpts: inspector.DefaultRewriteOpts("https://proxy.example/proxy/v1"),
+		RewriteOpts: inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
 		CallerNonces: NewMemoryCallerNonceCache(time.Minute),
 		Store:       st,
 		AgentUserID: userID,
@@ -208,7 +208,7 @@ func TestPostprocess_TaskScopeAllowsAuthorizedAction(t *testing.T) {
 	if !got.Rewritten {
 		t.Fatalf("expected rewrite when task scope allows")
 	}
-	if !strings.Contains(string(got.Body), "https://proxy.example/proxy/v1") {
+	if !strings.Contains(string(got.Body), "https://proxy.example/api/proxy") {
 		t.Errorf("rewritten body missing resolver URL:\n%s", got.Body)
 	}
 }
@@ -243,7 +243,7 @@ func TestPostprocess_IntentVerifierBlocksOnDeny(t *testing.T) {
 
 	got := Postprocess(req, body, "application/json", PostprocessConfig{
 		Inspector:   insp,
-		RewriteOpts: inspector.DefaultRewriteOpts("https://proxy.example/proxy/v1"),
+		RewriteOpts: inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
 		CallerNonces: NewMemoryCallerNonceCache(time.Minute),
 		Store:       st,
 		AgentUserID: userID,
@@ -285,7 +285,7 @@ func TestPostprocess_IntentVerifierLenientFlag(t *testing.T) {
 
 	_ = Postprocess(req, body, "application/json", PostprocessConfig{
 		Inspector:   insp,
-		RewriteOpts: inspector.DefaultRewriteOpts("https://proxy.example/proxy/v1"),
+		RewriteOpts: inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
 		CallerNonces: NewMemoryCallerNonceCache(time.Minute),
 		Store:       st,
 		AgentUserID: userID,
@@ -315,7 +315,7 @@ func TestPostprocess_IntentVerifierOffSkipsCall(t *testing.T) {
 
 	got := Postprocess(req, body, "application/json", PostprocessConfig{
 		Inspector:   insp,
-		RewriteOpts: inspector.DefaultRewriteOpts("https://proxy.example/proxy/v1"),
+		RewriteOpts: inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
 		CallerNonces: NewMemoryCallerNonceCache(time.Minute),
 		Store:       st,
 		AgentUserID: userID,
@@ -350,7 +350,7 @@ func TestPostprocess_TaskScopeFallthroughOnUnknownAction(t *testing.T) {
 	denyAll := stubTaskScope{decision: TaskScopeDecision{Reason: "should_not_be_called"}}
 	got := Postprocess(req, body, "application/json", PostprocessConfig{
 		Inspector:   insp,
-		RewriteOpts: inspector.DefaultRewriteOpts("https://proxy.example/proxy/v1"),
+		RewriteOpts: inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
 		CallerNonces: NewMemoryCallerNonceCache(time.Minute),
 		Store:       st,
 		AgentUserID: userID,
@@ -377,7 +377,7 @@ func TestPostprocess_SharedDecisionAllowSkipsLegacyTaskScope(t *testing.T) {
 	denyAll := stubTaskScope{decision: TaskScopeDecision{Reason: "legacy task scope should not run"}}
 	got := Postprocess(req, body, "application/json", PostprocessConfig{
 		Inspector:   insp,
-		RewriteOpts: inspector.DefaultRewriteOpts("https://proxy.example/proxy/v1"),
+		RewriteOpts: inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
 		CallerNonces: NewMemoryCallerNonceCache(time.Minute),
 		Store:       st,
 		AgentUserID: userID,

--- a/internal/runtime/tasks/envelope.go
+++ b/internal/runtime/tasks/envelope.go
@@ -40,7 +40,7 @@ type Envelope struct {
 	SchemaVersion          int
 }
 
-// TaskCreateRequest is the parsed body of `POST /control/tasks` (or
+// TaskCreateRequest is the parsed body of `POST /api/control/tasks` (or
 // equivalently `POST /api/tasks`). The full validating handler lives in
 // internal/api/handlers; this lighter shape is used by the lite-proxy's
 // inline task-approval flow to inspect a model-emitted task definition

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -48,12 +48,13 @@ func PushURL() string {
 }
 
 // HaikuProxyURL returns the haiku proxy base URL for the current environment.
-// Includes /v1 so the LLM client's "/messages" append hits /v1/messages.
+// Includes /api/v1 so the LLM client's "/messages" append hits
+// /api/v1/messages.
 func HaikuProxyURL() string {
 	if IsStaging() {
-		return "https://hp.staging.clawvisor.com/v1"
+		return "https://hp.staging.clawvisor.com/api/v1"
 	}
-	return "https://hp.clawvisor.com/v1"
+	return "https://hp.clawvisor.com/api/v1"
 }
 
 // CORSOrigins returns the allowed CORS origins for the current environment.

--- a/scripts/live-codex-secret-smoke.sh
+++ b/scripts/live-codex-secret-smoke.sh
@@ -18,7 +18,7 @@ OUT_DIR="${CLAWVISOR_SMOKE_OUT_DIR:-$ROOT/.context/live-codex-secret-smoke-$(dat
 WORK_DIR="${CLAWVISOR_SMOKE_WORKDIR:-$(mktemp -d "${TMPDIR:-/tmp}/clawvisor-codex-smoke.XXXXXX")}"
 CLAWVISOR_URL="${CLAWVISOR_URL:-http://127.0.0.1:25297}"
 CLAWVISOR_URL="${CLAWVISOR_URL%/}"
-OPENAI_BASE_URL="${CLAWVISOR_OPENAI_BASE_URL:-$CLAWVISOR_URL/v1}"
+OPENAI_BASE_URL="${CLAWVISOR_OPENAI_BASE_URL:-$CLAWVISOR_URL/api/v1}"
 AGENT_TOKEN="${CLAWVISOR_AGENT_TOKEN:-}"
 AGENT_ID="${CLAWVISOR_SMOKE_AGENT_ID:-}"
 MODEL_ARGS=()
@@ -63,7 +63,7 @@ PY
   registered_url="$(printf '%s\n' "$resolved" | sed -n '3p')"
   if [[ "${CLAWVISOR_URL:-}" == "http://127.0.0.1:25297" && -n "$registered_url" ]]; then
     CLAWVISOR_URL="${registered_url%/}"
-    OPENAI_BASE_URL="${CLAWVISOR_OPENAI_BASE_URL:-$CLAWVISOR_URL/v1}"
+    OPENAI_BASE_URL="${CLAWVISOR_OPENAI_BASE_URL:-$CLAWVISOR_URL/api/v1}"
   fi
 fi
 

--- a/web/src/pages/Agents.tsx
+++ b/web/src/pages/Agents.tsx
@@ -1583,20 +1583,20 @@ function ClaudeCodeGuide({ clawvisorURL, llmBaseURL, claim, userIdParam, newToke
   const connected = !!agents?.find(a => a.name === agentName)
 
   const jsonPath = `~/.clawvisor/agents/${agentName}.json`
-  const runCmd = `ANTHROPIC_BASE_URL=${llmBaseURL} \\
+  const runCmd = `ANTHROPIC_BASE_URL=${llmBaseURL}/api \\
 ANTHROPIC_CUSTOM_HEADERS="X-Clawvisor-Agent-Token: $(jq -r .token ${jsonPath})" \\
 ANTHROPIC_AUTH_TOKEN= ANTHROPIC_API_KEY= \\
 claude`
   const zshrcSnippet = `cat >> ~/.zshrc <<'EOF'
 claude-cv() {
-  ANTHROPIC_BASE_URL=${llmBaseURL} \\
+  ANTHROPIC_BASE_URL=${llmBaseURL}/api \\
   ANTHROPIC_CUSTOM_HEADERS="X-Clawvisor-Agent-Token: $(jq -r .token ${jsonPath})" \\
   ANTHROPIC_AUTH_TOKEN= ANTHROPIC_API_KEY= \\
   claude "$@"
 }
 EOF`
   const tokenValue = newToken ?? 'cvis_<your-token>'
-  const manualRunCmd = `ANTHROPIC_BASE_URL=${llmBaseURL} \\
+  const manualRunCmd = `ANTHROPIC_BASE_URL=${llmBaseURL}/api \\
 ANTHROPIC_CUSTOM_HEADERS='X-Clawvisor-Agent-Token: ${tokenValue}' \\
 ANTHROPIC_AUTH_TOKEN= ANTHROPIC_API_KEY= \\
 claude`
@@ -1773,7 +1773,7 @@ function CodexGuide({ clawvisorURL, llmBaseURL, claim, newToken, onCopy }: {
 
 [model_providers.clawvisor]
 name = "Clawvisor"
-base_url = "${llmBaseURL}/v1"
+base_url = "${llmBaseURL}/api/v1"
 wire_api = "responses"
 requires_openai_auth = true
 
@@ -2204,14 +2204,14 @@ function OpenClawGuide({ setupURL, clawvisorURL, llmBaseURL, claim, newToken, co
   const jsonPath = `~/.clawvisor/agents/${agentName}.json`
   const onboardCmd = `openclaw onboard --non-interactive \\
   --auth-choice custom-api-key \\
-  --custom-base-url "${llmBaseURL}/v1" \\
+  --custom-base-url "${llmBaseURL}/api/v1" \\
   --custom-model-id "claude-sonnet-4-6" \\
   --custom-api-key "$(jq -r .token ${jsonPath})" \\
   --custom-compatibility anthropic`
   const tokenValue = newToken ?? 'cvis_<your-token>'
   const manualOnboardCmd = `openclaw onboard --non-interactive \\
   --auth-choice custom-api-key \\
-  --custom-base-url "${llmBaseURL}/v1" \\
+  --custom-base-url "${llmBaseURL}/api/v1" \\
   --custom-model-id "claude-sonnet-4-6" \\
   --custom-api-key "${tokenValue}" \\
   --custom-compatibility anthropic`
@@ -2400,17 +2400,17 @@ function HermesGuide({ clawvisorURL, llmBaseURL, claim, newToken, onCopy }: {
   const keyReady = hasAnyUpstreamKey(creds)
 
   const jsonPath = `~/.clawvisor/agents/${agentName}.json`
-  const envCmd = `OPENAI_BASE_URL=${llmBaseURL}/v1 \\
+  const envCmd = `OPENAI_BASE_URL=${llmBaseURL}/api/v1 \\
 OPENAI_API_KEY=$(jq -r .token ${jsonPath}) \\
 hermes chat`
   const configCmd = `mkdir -p ~/.hermes && cat > ~/.hermes/config.yaml <<EOF
 model:
   provider: custom
-  base_url: "${llmBaseURL}/v1"
+  base_url: "${llmBaseURL}/api/v1"
   api_key: "$(jq -r .token ${jsonPath})"
 EOF`
   const tokenValue = newToken ?? 'cvis_<your-token>'
-  const manualEnvCmd = `OPENAI_BASE_URL=${llmBaseURL}/v1 \\
+  const manualEnvCmd = `OPENAI_BASE_URL=${llmBaseURL}/api/v1 \\
 OPENAI_API_KEY=${tokenValue} \\
 hermes chat`
 
@@ -2556,17 +2556,17 @@ function OtherAgentGuide({ setupURL, clawvisorURL, llmBaseURL, claim, newToken, 
   const anthropicSDK = `import anthropic, json, os
 data = json.load(open(os.path.expanduser("${jsonPath}")))
 client = anthropic.Anthropic(
-    base_url="${llmBaseURL}",
+    base_url="${llmBaseURL}/api",
     api_key=data["token"],
 )`
   const openaiSDK = `from openai import OpenAI
 import json, os
 data = json.load(open(os.path.expanduser("${jsonPath}")))
 client = OpenAI(
-    base_url="${llmBaseURL}/v1",
+    base_url="${llmBaseURL}/api/v1",
     api_key=data["token"],
 )`
-  const curlCmd = `curl -X POST "${llmBaseURL}/v1/messages" \\
+  const curlCmd = `curl -X POST "${llmBaseURL}/api/v1/messages" \\
   -H "Authorization: Bearer $(jq -r .token ${jsonPath})" \\
   -H "anthropic-version: 2023-06-01" \\
   -H "Content-Type: application/json" \\
@@ -2574,12 +2574,12 @@ client = OpenAI(
   const tokenValue = newToken ?? 'cvis_<your-token>'
   const manualAnthropicSDK = `import anthropic
 client = anthropic.Anthropic(
-    base_url="${llmBaseURL}",
+    base_url="${llmBaseURL}/api",
     api_key="${tokenValue}",
 )`
   const manualOpenaiSDK = `from openai import OpenAI
 client = OpenAI(
-    base_url="${llmBaseURL}/v1",
+    base_url="${llmBaseURL}/api/v1",
     api_key="${tokenValue}",
 )`
   const prompt = `Please install Clawvisor. It's a security gateway between you and external services like Gmail, Slack, and GitHub. You don't hold any API keys directly; instead, you make requests through Clawvisor and I approve which actions you can take. Every call is logged, and I can revoke access at any time.\n\nSetup is just registering an agent token and installing a skill that teaches you how to use it. I'll review each step before it happens.\n\nInstructions: ${setupURL}`
@@ -2872,7 +2872,7 @@ function ConnectionCard({ request: cr }: { request: ConnectionRequest }) {
 // ── Lite-proxy LLM credentials panel ─────────────────────────────────────────
 //
 // Stores the upstream API key (sk-ant-..., sk-...) the lite-proxy swaps in
-// when forwarding /v1/messages and /v1/chat/completions for this specific
+// when forwarding /api/v1/messages and /api/v1/chat/completions for this specific
 // agent. Falls back to the user-level credential when the agent-scoped one
 // isn't set, so configuring this is optional.
 function AgentLLMCredentialsPanel({ agentId }: { agentId: string }) {
@@ -3067,25 +3067,25 @@ function AgentLiteProxyPanel({ agentId: _agentId }: { agentId: string }) {
       })
   }
 
-  // Anthropic SDK + Claude CLI: env var is the ORIGIN; the SDK appends
-  // `/v1/messages` itself. OpenAI SDK + Codex: base URL includes `/v1`
+  // Anthropic SDK + Claude CLI: env var is the API family base; the SDK appends
+  // `/v1/messages` itself. OpenAI SDK + Codex: base URL includes `/api/v1`
   // because the client appends just the action path (`/chat/completions`).
-  const claudeCode = `ANTHROPIC_BASE_URL=${baseURL} ANTHROPIC_CUSTOM_HEADERS='X-Clawvisor-Agent-Token: cvis_<this-agent-token>' ANTHROPIC_AUTH_TOKEN= ANTHROPIC_API_KEY= claude`
+  const claudeCode = `ANTHROPIC_BASE_URL=${baseURL}/api ANTHROPIC_CUSTOM_HEADERS='X-Clawvisor-Agent-Token: cvis_<this-agent-token>' ANTHROPIC_AUTH_TOKEN= ANTHROPIC_API_KEY= claude`
   const codex = `CLAWVISOR_AGENT_TOKEN=cvis_<this-agent-token> codex exec \\
   -c model_provider=clawvisor \\
-  -c 'model_providers.clawvisor.base_url="${baseURL}/v1"' \\
+  -c 'model_providers.clawvisor.base_url="${baseURL}/api/v1"' \\
   -c 'model_providers.clawvisor.wire_api="responses"' \\
   -c 'model_providers.clawvisor.requires_openai_auth=true' \\
   -c 'model_providers.clawvisor.env_http_headers={"X-Clawvisor-Agent-Token"="CLAWVISOR_AGENT_TOKEN"}' \\
   -c 'model="gpt-4o-mini"'`
   const openaiSDK = `from openai import OpenAI
 client = OpenAI(
-    base_url="${baseURL}/v1",
+    base_url="${baseURL}/api/v1",
     api_key="cvis_<this-agent-token>",
 )`
   const anthropicSDK = `import anthropic
 client = anthropic.Anthropic(
-    base_url="${baseURL}",
+    base_url="${baseURL}/api",
     api_key="cvis_<this-agent-token>",
 )`
 
@@ -3108,9 +3108,9 @@ client = anthropic.Anthropic(
           <div>
             <div className="text-xs uppercase tracking-wider text-text-tertiary">Base URL</div>
             <div className="mt-1 flex items-center gap-2">
-              <code className="flex-1 px-3 py-1.5 text-sm font-mono rounded border border-border-default bg-surface-1 text-text-primary">{baseURL}/v1</code>
+              <code className="flex-1 px-3 py-1.5 text-sm font-mono rounded border border-border-default bg-surface-1 text-text-primary">{baseURL}/api/v1</code>
               <button
-                onClick={() => copy('base', `${baseURL}/v1`)}
+                onClick={() => copy('base', `${baseURL}/api/v1`)}
                 className="text-xs px-3 py-1 rounded border border-border-strong text-text-secondary hover:bg-surface-2"
               >
                 {copied === 'base' ? 'Copied!' : copied === 'base-failed' ? 'Copy failed' : 'Copy'}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -24,15 +24,9 @@ export default defineConfig({
     allowedHosts: allowAllHosts ? true : [],
     proxy: {
       '/api': backendURL,
-      '/control': backendURL,
       '/skill': backendURL,
       '/health': backendURL,
       '/ready': backendURL,
-      // Lite-proxy LLM endpoint (Anthropic + OpenAI compatible) and the
-      // resolver. Agents pointing ANTHROPIC_BASE_URL / OPENAI_BASE_URL
-      // at the dev server need these proxied through.
-      '/v1': backendURL,
-      '/proxy': backendURL,
       '/ws': {
         target: backendURL,
         ws: true,


### PR DESCRIPTION
## Summary
- Move lite-proxy LLM, resolver, and control-plane daemon routes under the `/api` family while rejecting legacy top-level prefixes.
- Keep prompt-facing control calls short via `https://clawvisor.local/control/...`, rewriting them to real `/api/control/...` routes before execution.
- Update CLI setup, Vite proxy config, dashboard snippets, docs, smoke script defaults, and route/rewrite tests for the new paths.

## Tests
- `go test ./...`
- `cd web && npm run lint && npm run build`
- `git diff --check`