### PR TITLE
fix(security): address code scanning findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   go:
     name: Go

--- a/.github/workflows/e2e-install.yml
+++ b/.github/workflows/e2e-install.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   e2e-install:
     name: E2E Install (Docker)

--- a/e2e/smoke/testserver_test.go
+++ b/e2e/smoke/testserver_test.go
@@ -336,6 +336,7 @@ func newCIEnv(t *testing.T) *ciTestEnv {
 	cmd.Env = []string{
 		"HOME=" + tmpDir,
 		"CONFIG_FILE=" + configPath,
+		"CLAWVISOR_YAMLRUNTIME_ALLOW_PRIVATE_NETWORKS=1",
 		"PATH=" + os.Getenv("PATH"),
 		"TMPDIR=" + os.Getenv("TMPDIR"),
 	}

--- a/extensions/clawvisor-webhook/index.ts
+++ b/extensions/clawvisor-webhook/index.ts
@@ -9,6 +9,9 @@ const DEFAULT_PATH = "/clawvisor/callback";
 const MAX_BODY_BYTES = 1024 * 512;
 const DEFAULT_GATEWAY_WS_URL = "ws://127.0.0.1:18789";
 const DEFAULT_SESSION_KEY = "agent:main:main";
+const DEFAULT_TICK_INTERVAL_MS = 15000;
+const MIN_TICK_INTERVAL_MS = 1000;
+const MAX_TICK_INTERVAL_MS = 300000;
 
 // ── Types ──────────────────────────────────────────────────────────────
 
@@ -77,6 +80,11 @@ function publicKeyToBase64Url(publicKeyPem: string): string {
     ? spki.subarray(ED25519_SPKI_PREFIX.length)
     : spki;
   return base64UrlEncode(raw);
+}
+
+function clampTickIntervalMs(value: unknown): number {
+  const n = typeof value === "number" && Number.isFinite(value) ? value : DEFAULT_TICK_INTERVAL_MS;
+  return Math.min(Math.max(Math.trunc(n), MIN_TICK_INTERVAL_MS), MAX_TICK_INTERVAL_MS);
 }
 
 // ── Device identity (persisted) ────────────────────────────────────────
@@ -230,7 +238,7 @@ class GatewayClient {
   private connecting = false;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private tickTimer: ReturnType<typeof setInterval> | null = null;
-  private tickIntervalMs = 15000;
+  private tickIntervalMs = DEFAULT_TICK_INTERVAL_MS;
 
   constructor(device: DeviceIdentity, gatewayToken: string, gatewayWsUrl: string, log: OpenClawPluginApi["log"]) {
     this.device = device;
@@ -283,7 +291,7 @@ class GatewayClient {
           if (frame.ok && frame.payload?.type === "hello-ok") {
             this.connected = true;
             this.connecting = false;
-            this.tickIntervalMs = frame.payload.policy?.tickIntervalMs ?? 15000;
+            this.tickIntervalMs = clampTickIntervalMs(frame.payload.policy?.tickIntervalMs);
             this.startTicking();
             this.log?.info("clawvisor-webhook: Gateway handshake complete");
             resolve();
@@ -388,6 +396,7 @@ class GatewayClient {
       if (this.ws?.readyState === WebSocket.OPEN) {
         this.ws.send(JSON.stringify({ type: "req", id: randomUUID(), method: "tick", params: {} }));
       }
+    // codeql[js/resource-exhaustion] tickIntervalMs is clamped to a bounded policy range before timers start.
     }, this.tickIntervalMs);
   }
 

--- a/internal/adapters/apple/imessage/adapter.go
+++ b/internal/adapters/apple/imessage/adapter.go
@@ -391,6 +391,7 @@ func extractTarGz(r io.Reader, destDir string) error {
 
 	tr := tar.NewReader(gz)
 	for {
+		// codeql[go/zipslip] The extracted path is converted to an absolute path and checked to remain under destDir before writes.
 		hdr, err := tr.Next()
 		if err == io.EOF {
 			return nil

--- a/internal/adapters/sql/adapter.go
+++ b/internal/adapters/sql/adapter.go
@@ -24,10 +24,10 @@ import (
 )
 
 const (
-	serviceID     = "sql"
-	maxRows       = 500
-	maxColWidth   = 1000
-	queryTimeout  = 30 * time.Second
+	serviceID    = "sql"
+	maxRows      = 500
+	maxColWidth  = 1000
+	queryTimeout = 30 * time.Second
 )
 
 // credential is the JSON structure stored in the vault.
@@ -48,8 +48,8 @@ func (a *Adapter) SupportedActions() []string {
 	return []string{"query", "execute", "list_tables", "describe_table"}
 }
 
-func (a *Adapter) OAuthConfig() *oauth2.Config                        { return nil }
-func (a *Adapter) RequiredScopes() []string                           { return nil }
+func (a *Adapter) OAuthConfig() *oauth2.Config { return nil }
+func (a *Adapter) RequiredScopes() []string    { return nil }
 func (a *Adapter) CredentialFromToken(_ *oauth2.Token) ([]byte, error) {
 	return nil, fmt.Errorf("sql: no token exchange — uses connection string")
 }
@@ -229,6 +229,7 @@ func (a *Adapter) query(ctx context.Context, cred *credential, params map[string
 	}
 	defer tx.Rollback()
 
+	// codeql[go/sql-injection] Raw SQL execution is the SQL adapter's explicit product capability, gated by credentials and approvals.
 	rows, err := tx.QueryContext(ctx, sqlStr, args...)
 	if err != nil {
 		return nil, fmt.Errorf("sql: query: %w", err)
@@ -265,6 +266,7 @@ func (a *Adapter) execute(ctx context.Context, cred *credential, params map[stri
 	ctx, cancel := context.WithTimeout(ctx, queryTimeout)
 	defer cancel()
 
+	// codeql[go/sql-injection] Raw SQL execution is the SQL adapter's explicit product capability, gated by credentials and approvals.
 	result, err := db.ExecContext(ctx, sqlStr, args...)
 	if err != nil {
 		return nil, fmt.Errorf("sql: execute: %w", err)
@@ -371,6 +373,7 @@ func (a *Adapter) describeTable(ctx context.Context, cred *credential, params ma
 		query = fmt.Sprintf("PRAGMA table_info(%s)", table)
 	}
 
+	// codeql[go/sql-injection] Query text is fixed per driver; user table input is parameterized or validated as a simple SQLite identifier.
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("sql: describe_table: %w", err)
@@ -563,9 +566,8 @@ func init() {
 
 // Ensure interface compliance at compile time.
 var (
-	_ adapters.Adapter                = (*Adapter)(nil)
-	_ adapters.MetadataProvider       = (*Adapter)(nil)
-	_ adapters.VerificationHinter     = (*Adapter)(nil)
+	_ adapters.Adapter                 = (*Adapter)(nil)
+	_ adapters.MetadataProvider        = (*Adapter)(nil)
+	_ adapters.VerificationHinter      = (*Adapter)(nil)
 	_ adapters.APIKeyCredentialBuilder = (*Adapter)(nil)
 )
-

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -1,6 +1,8 @@
 package api_test
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -153,6 +155,74 @@ func TestAuth_Logout_InvalidatesRefreshToken(t *testing.T) {
 		"refresh_token": s.RefreshToken,
 	})
 	mustStatus(t, resp, http.StatusUnauthorized)
+}
+
+func TestAuth_LogoutWithCookieDoesNotRequireAccessToken(t *testing.T) {
+	env := newTestEnv(t)
+	s := newSession(t, env)
+
+	req, err := http.NewRequest(http.MethodPost, env.url("/api/auth/logout"), bytes.NewReader([]byte(`{}`)))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: "clawvisor_refresh_token", Value: s.RefreshToken})
+	resp, err := env.client.Do(req)
+	if err != nil {
+		t.Fatalf("logout: %v", err)
+	}
+	mustStatus(t, resp, http.StatusNoContent)
+
+	var cleared bool
+	for _, c := range resp.Cookies() {
+		if c.Name == "clawvisor_refresh_token" && c.MaxAge < 0 {
+			cleared = true
+			break
+		}
+	}
+	if !cleared {
+		t.Fatalf("logout did not clear refresh cookie: %v", resp.Cookies())
+	}
+
+	resp = env.do("POST", "/api/auth/refresh", "", map[string]any{
+		"refresh_token": s.RefreshToken,
+	})
+	mustStatus(t, resp, http.StatusUnauthorized)
+}
+
+func TestAuth_BrowserResponseOmitsRefreshTokenJSON(t *testing.T) {
+	env := newTestEnv(t)
+	email := fmt.Sprintf("browser-%s@test.example", randSuffix())
+	body, _ := json.Marshal(map[string]any{
+		"email": email, "password": "secret123",
+	})
+	req, err := http.NewRequest(http.MethodPost, env.url("/api/auth/register"), bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Sec-Fetch-Site", "same-origin")
+	resp, err := env.client.Do(req)
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	decoded := mustStatus(t, resp, http.StatusCreated)
+	if _, ok := decoded["refresh_token"]; ok {
+		t.Fatalf("browser response exposed refresh_token: %v", decoded)
+	}
+	if str(t, decoded, "access_token") == "" {
+		t.Fatal("browser response missing access_token")
+	}
+	var setRefreshCookie bool
+	for _, c := range resp.Cookies() {
+		if c.Name == "clawvisor_refresh_token" && c.Value != "" && c.HttpOnly {
+			setRefreshCookie = true
+			break
+		}
+	}
+	if !setRefreshCookie {
+		t.Fatalf("browser response did not set HttpOnly refresh cookie: %v", resp.Cookies())
+	}
 }
 
 func TestAuth_InvalidToken_Rejected(t *testing.T) {

--- a/internal/api/handlers/adaptergen.go
+++ b/internal/api/handlers/adaptergen.go
@@ -45,10 +45,10 @@ func (h *AdapterGenHandler) generatorForRequest(r *http.Request) *adaptergen.Gen
 
 // createAdapterRequest is the request body for POST /api/adapters/generate.
 type createAdapterRequest struct {
-	SourceType    string            `json:"source_type"`                // "mcp", "openapi", "docs"
-	Source        string            `json:"source,omitempty"`           // raw content (mutually exclusive with source_url)
-	SourceURL     string            `json:"source_url,omitempty"`      // URL to fetch content from
-	SourceHeaders map[string]string `json:"source_headers,omitempty"`  // headers to send when fetching source_url (e.g. Authorization)
+	SourceType    string            `json:"source_type"`              // "mcp", "openapi", "docs"
+	Source        string            `json:"source,omitempty"`         // raw content (mutually exclusive with source_url)
+	SourceURL     string            `json:"source_url,omitempty"`     // URL to fetch content from
+	SourceHeaders map[string]string `json:"source_headers,omitempty"` // headers to send when fetching source_url (e.g. Authorization)
 	ServiceID     string            `json:"service_id,omitempty"`
 	AuthType      string            `json:"auth_type,omitempty"`
 }
@@ -69,7 +69,7 @@ const maxFetchBytes = 2 * 1024 * 1024 // 2 MB limit for fetched specs
 // dev/test — can opt in via ssrfSafeOAuthClient without re-listing every range.
 var ssrfRanges = func() []*net.IPNet {
 	cidrs := []string{
-		"0.0.0.0/8",     // "this" network (includes 0.0.0.0)
+		"0.0.0.0/8", // "this" network (includes 0.0.0.0)
 		"10.0.0.0/8",
 		"172.16.0.0/12",
 		"192.168.0.0/16",
@@ -163,6 +163,7 @@ func fetchSourceURL(ctx context.Context, rawURL string, headers map[string]strin
 	for k, v := range headers {
 		req.Header.Set(k, v)
 	}
+	// codeql[go/request-forgery] ssrfSafeClient resolves at dial time and blocks internal/private IP ranges.
 	resp, err := ssrfSafeClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("fetching source_url: %w", err)

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -32,8 +33,10 @@ func NewAuthHandler(jwtSvc pkgauth.TokenService, st store.Store, cfg config.Auth
 type authResponse struct {
 	User         *store.User `json:"user"`
 	AccessToken  string      `json:"access_token"`
-	RefreshToken string      `json:"refresh_token"`
+	RefreshToken string      `json:"refresh_token,omitempty"`
 }
+
+const refreshTokenCookieName = "clawvisor_refresh_token"
 
 // Register creates a new user account.
 //
@@ -95,7 +98,7 @@ func (h *AuthHandler) Register(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp, err := h.issueTokens(r, user)
+	resp, err := h.issueTokens(w, r, user)
 	if err != nil {
 		_ = h.st.DeleteUser(r.Context(), user.ID)
 		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not issue tokens")
@@ -130,7 +133,7 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp, err := h.issueTokens(r, user)
+	resp, err := h.issueTokens(w, r, user)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not issue tokens")
 		return
@@ -146,12 +149,23 @@ func (h *AuthHandler) Refresh(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		RefreshToken string `json:"refresh_token"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.RefreshToken == "" {
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil && err != io.EOF {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "refresh_token is required")
+		return
+	}
+	refreshToken := body.RefreshToken
+	if refreshToken == "" {
+		cookie, err := r.Cookie(refreshTokenCookieName)
+		if err == nil {
+			refreshToken = cookie.Value
+		}
+	}
+	if refreshToken == "" {
 		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "refresh_token is required")
 		return
 	}
 
-	tokenHash := auth.HashToken(body.RefreshToken)
+	tokenHash := auth.HashToken(refreshToken)
 	// Atomic delete-and-return so a stolen refresh token replayed
 	// concurrently produces at most one new token pair: the second caller
 	// gets ErrNotFound because the first deleted the row first.
@@ -171,7 +185,7 @@ func (h *AuthHandler) Refresh(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp, err := h.issueTokens(r, user)
+	resp, err := h.issueTokens(w, r, user)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not issue tokens")
 		return
@@ -182,14 +196,10 @@ func (h *AuthHandler) Refresh(w http.ResponseWriter, r *http.Request) {
 // Logout invalidates the current session's refresh token.
 //
 // POST /api/auth/logout
-// Auth: Bearer <access_token>
+// Auth: optional Bearer <access_token>
 // Body: {"refresh_token": "..."}  (optional; clears the specific session)
 func (h *AuthHandler) Logout(w http.ResponseWriter, r *http.Request) {
 	user := middleware.UserFromContext(r.Context())
-	if user == nil {
-		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "not authenticated")
-		return
-	}
 
 	var body struct {
 		RefreshToken string `json:"refresh_token"`
@@ -198,10 +208,13 @@ func (h *AuthHandler) Logout(w http.ResponseWriter, r *http.Request) {
 
 	if body.RefreshToken != "" {
 		_ = h.st.DeleteSession(r.Context(), auth.HashToken(body.RefreshToken))
-	} else {
+	} else if cookie, err := r.Cookie(refreshTokenCookieName); err == nil && cookie.Value != "" {
+		_ = h.st.DeleteSession(r.Context(), auth.HashToken(cookie.Value))
+	} else if user != nil {
 		// No specific token provided — clear all sessions for the user.
 		_ = h.st.DeleteUserSessions(r.Context(), user.ID)
 	}
+	h.clearRefreshCookie(w, r)
 
 	w.WriteHeader(http.StatusNoContent)
 }
@@ -345,7 +358,7 @@ func (h *AuthHandler) ExchangeMagic(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp, err := h.issueTokens(r, user)
+	resp, err := h.issueTokens(w, r, user)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not issue tokens")
 		return
@@ -400,7 +413,7 @@ func (h *AuthHandler) GenerateMagicLocal(w http.ResponseWriter, r *http.Request)
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-func (h *AuthHandler) issueTokens(r *http.Request, user *store.User) (*authResponse, error) {
+func (h *AuthHandler) issueTokens(w http.ResponseWriter, r *http.Request, user *store.User) (*authResponse, error) {
 	accessTTL, err := h.cfg.AccessTokenDuration()
 	if err != nil {
 		return nil, err
@@ -424,11 +437,51 @@ func (h *AuthHandler) issueTokens(r *http.Request, user *store.User) (*authRespo
 	if _, err := h.st.CreateSession(r.Context(), user.ID, auth.HashToken(rawRefresh), expiresAt); err != nil {
 		return nil, err
 	}
+	h.setRefreshCookie(w, r, rawRefresh, expiresAt)
 
-	return &authResponse{
+	resp := &authResponse{
 		User:         user,
 		AccessToken:  accessToken,
 		RefreshToken: rawRefresh,
-	}, nil
+	}
+	if isBrowserRequest(r) {
+		resp.RefreshToken = ""
+	}
+	return resp, nil
 }
 
+func (h *AuthHandler) setRefreshCookie(w http.ResponseWriter, r *http.Request, token string, expiresAt time.Time) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     refreshTokenCookieName,
+		Value:    token,
+		Path:     "/api/auth",
+		Expires:  expiresAt,
+		MaxAge:   int(time.Until(expiresAt).Seconds()),
+		HttpOnly: true,
+		Secure:   h.secureRefreshCookie(r),
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+func (h *AuthHandler) clearRefreshCookie(w http.ResponseWriter, r *http.Request) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     refreshTokenCookieName,
+		Value:    "",
+		Path:     "/api/auth",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   h.secureRefreshCookie(r),
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+func (h *AuthHandler) secureRefreshCookie(r *http.Request) bool {
+	return r.TLS != nil || !h.isLocal
+}
+
+func isBrowserRequest(r *http.Request) bool {
+	return r.Header.Get("Sec-Fetch-Site") != "" ||
+		r.Header.Get("Sec-Fetch-Mode") != "" ||
+		r.Header.Get("Origin") != "" ||
+		r.Header.Get("Referer") != ""
+}

--- a/internal/api/handlers/llm_endpoint.go
+++ b/internal/api/handlers/llm_endpoint.go
@@ -2096,7 +2096,8 @@ func liteSecretBodySHA(body []byte) string {
 	if len(body) == 0 {
 		return ""
 	}
-	sum := sha256.Sum256(body) // lgtm[go/weak-cryptographic-algorithm]
+	// codeql[go/weak-cryptographic-algorithm] Request body hash is a non-secret cache key, not a security boundary.
+	sum := sha256.Sum256(body)
 	return fmt.Sprintf("%x", sum[:])[:16]
 }
 

--- a/internal/api/handlers/proxy_resolver.go
+++ b/internal/api/handlers/proxy_resolver.go
@@ -296,7 +296,8 @@ func (h *ProxyResolverHandler) Forward(w http.ResponseWriter, r *http.Request) {
 	// vhost-routing metadata from reaching upstream. CodeQL's
 	// reachability analysis correctly traces user input to Client.Do
 	// but cannot see those defenses.
-	resp, err := h.Client.Do(upstreamReq) // lgtm[go/request-forgery]
+	// codeql[go/request-forgery] Proxy resolver upstream requests are constrained by the handler's configured upstream URL policy.
+	resp, err := h.Client.Do(upstreamReq)
 	if err != nil {
 		h.Logger.WarnContext(r.Context(), "lite-proxy resolver: upstream call failed",
 			"agent_id", agent.ID, "host", targetHost, "err", err.Error())

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -572,6 +572,7 @@ func (s *Server) routes() http.Handler {
 
 	// Middleware
 	requireUser := middleware.RequireUser(s.jwtSvc, s.store)
+	optionalUser := middleware.OptionalUser(s.jwtSvc, s.store)
 	requireAgent := middleware.RequireAgent(s.store)
 	logMiddleware := middleware.Logging(s.logger)
 	recoverMiddleware := middleware.Recover(s.logger)
@@ -642,6 +643,9 @@ func (s *Server) routes() http.Handler {
 	authRateLimited := func(h http.HandlerFunc) http.Handler {
 		return middleware.RateLimit(authRL, ipKeyFn, rlCfg.Auth.Limit)(h)
 	}
+	optionalUserAuthRateLimited := func(h http.HandlerFunc) http.Handler {
+		return middleware.RateLimit(authRL, ipKeyFn, rlCfg.Auth.Limit)(optionalUser(h))
+	}
 
 	// Health (no auth)
 	mux.HandleFunc("GET /health", healthHandler.Health)
@@ -679,7 +683,7 @@ func (s *Server) routes() http.Handler {
 
 	// Auth — core routes (always registered)
 	mux.Handle("POST /api/auth/refresh", authRateLimited(authHandler.Refresh))
-	mux.Handle("POST /api/auth/logout", user(authHandler.Logout))
+	mux.Handle("POST /api/auth/logout", optionalUserAuthRateLimited(authHandler.Logout))
 	mux.Handle("GET /api/me", user(authHandler.Me))
 
 	// Magic link auth — /local is always registered so the CLI gets a
@@ -1113,6 +1117,7 @@ func (s *Server) routes() http.Handler {
 				return
 			}
 			path := s.cfg.Server.FrontendDir + r.URL.Path
+			// codeql[go/path-injection] This only chooses SPA fallback; actual static serving is delegated to http.FileServer rooted at FrontendDir.
 			if _, err := os.Stat(path); os.IsNotExist(err) || r.URL.Path == "/" {
 				// index.html must not be cached — it references content-hashed
 				// JS/CSS chunks, so a stale copy serves outdated code.

--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -20,6 +20,7 @@ func GenerateAgentToken() (string, error) {
 // HashToken returns the SHA-256 hex digest of any token string.
 // Used for both agent tokens and refresh tokens.
 func HashToken(token string) string {
+	// codeql[go/weak-sensitive-data-hashing] Tokens are high-entropy random values; SHA-256 is used only for internal lookup/deduplication, not password storage.
 	h := sha256.Sum256([]byte(token))
 	return hex.EncodeToString(h[:])
 }

--- a/internal/callback/callback.go
+++ b/internal/callback/callback.go
@@ -182,6 +182,7 @@ func DeliverResult(ctx context.Context, callbackURL string, payload *Payload, si
 		req.Header.Set("X-Clawvisor-Signature", "sha256="+hex.EncodeToString(mac.Sum(nil)))
 	}
 
+	// codeql[go/request-forgery] httpClient uses ssrfSafeDialContext, which resolves and blocks private/internal targets at connect time.
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		idKey, idVal := payloadIDAttr(payload)

--- a/internal/e2e/harness/testadapter.go
+++ b/internal/e2e/harness/testadapter.go
@@ -85,6 +85,7 @@ func (a *TestEchoAdapter) Execute(ctx context.Context, req adapters.Request) (*a
 		if err != nil {
 			return nil, fmt.Errorf("fetch_url: build request: %w", err)
 		}
+		// codeql[go/request-forgery] E2E-only harness action for tests; not registered as a production adapter.
 		resp, err := client.Do(httpReq)
 		if err != nil {
 			return nil, fmt.Errorf("fetch_url: do: %w", err)

--- a/internal/local/remoteinstall/manager.go
+++ b/internal/local/remoteinstall/manager.go
@@ -498,6 +498,7 @@ func extractTarGz(src, dest string) ([]string, error) {
 	tr := tar.NewReader(gzr)
 	topLevel := map[string]bool{}
 	for {
+		// codeql[go/zipslip] Each tar path is cleaned and rejected if absolute or parent-relative before any filesystem operation.
 		hdr, err := tr.Next()
 		if err == io.EOF {
 			break

--- a/internal/runtime/conversation/parser.go
+++ b/internal/runtime/conversation/parser.go
@@ -59,6 +59,7 @@ func (AnthropicParser) ParseRequest(body []byte) ([]Turn, error) {
 	if err := json.Unmarshal(body, &r); err != nil {
 		return nil, err
 	}
+	// codeql[go/allocation-size-overflow] len(r.Messages) comes from an already-materialized slice; overflow would require an impossible in-memory request.
 	out := make([]Turn, 0, len(r.Messages)+1)
 	if sys := flattenAnthropicContent(r.System, 0); sys != "" {
 		out = append(out, Turn{Role: RoleSystem, Content: sys})
@@ -207,6 +208,7 @@ func (OpenAIParser) ParseRequest(body []byte) ([]Turn, error) {
 	if err := json.Unmarshal(body, &req); err != nil {
 		return nil, err
 	}
+	// codeql[go/allocation-size-overflow] len(req.Messages) comes from an already-materialized slice; overflow would require an impossible in-memory request.
 	out := make([]Turn, 0, len(req.Messages)+1)
 	if req.Instructions != "" {
 		out = append(out, Turn{Role: RoleSystem, Content: req.Instructions})
@@ -229,9 +231,9 @@ func (OpenAIParser) ParseRequest(body []byte) ([]Turn, error) {
 }
 
 type openAIRequest struct {
-	Messages     []openAIMessage  `json:"messages"`
-	Input        json.RawMessage  `json:"input,omitempty"`
-	Instructions string           `json:"instructions,omitempty"`
+	Messages     []openAIMessage `json:"messages"`
+	Input        json.RawMessage `json:"input,omitempty"`
+	Instructions string          `json:"instructions,omitempty"`
 }
 
 type openAIMessage struct {

--- a/internal/runtime/llmproxy/control.go
+++ b/internal/runtime/llmproxy/control.go
@@ -603,6 +603,7 @@ func shellQuote(s string) string {
 		return "''"
 	}
 	if !strings.Contains(s, "'") {
+		// codeql[go/unsafe-quoting] This branch only handles strings without single quotes; the branch below escapes embedded quotes.
 		return "'" + s + "'"
 	}
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"

--- a/internal/runtime/llmproxy/rawlog.go
+++ b/internal/runtime/llmproxy/rawlog.go
@@ -170,6 +170,7 @@ func (l *RawIOLogger) addPromptPrefixFieldsLocked(payload map[string]any, ev Raw
 	if !ok || len(prefix) == 0 {
 		return
 	}
+	// codeql[go/weak-sensitive-data-hashing] Prompt-prefix digest is internal deduplication metadata, not password storage.
 	sum := sha256.Sum256(prefix)
 	digest := hex.EncodeToString(sum[:])
 	payload["prompt_prefix_sha256"] = digest
@@ -241,7 +242,8 @@ func appendRawPart(parts [][]byte, label string, raw json.RawMessage) [][]byte {
 	// here would require a `raw` payload near 2^63 bytes — physically
 	// impossible given those caps. The sum stays well within `int`
 	// range on every supported GOARCH.
-	part := make([]byte, 0, len(label)+1+len(raw)) // lgtm[go/allocation-size-overflow]
+	// codeql[go/allocation-size-overflow] label and raw are already-materialized byte slices.
+	part := make([]byte, 0, len(label)+1+len(raw))
 	part = append(part, label...)
 	part = append(part, ':')
 	part = append(part, raw...)

--- a/internal/runtime/llmproxy/secret_detection.go
+++ b/internal/runtime/llmproxy/secret_detection.go
@@ -608,6 +608,7 @@ func redactFoundSecret(raw, service, source string, entropy float64, suppressed 
 }
 
 func SecretFingerprint(raw string) string {
+	// codeql[go/weak-sensitive-data-hashing] Internal secret deduplication fingerprint; not used for password storage or authentication.
 	sum := sha256.Sum256([]byte(raw))
 	return hex.EncodeToString(sum[:])
 }

--- a/internal/runtime/timing/trace_sink.go
+++ b/internal/runtime/timing/trace_sink.go
@@ -119,6 +119,7 @@ func (s *FileSink) WriteBody(baseDir string, ts time.Time, requestID, kind strin
 	}
 	filename := requestID + "." + kind + ".body"
 	path := filepath.Join(dayDir, filename)
+	// codeql[go/path-injection] requestID is generated as a UUID and kind is a fixed internal body-capture label.
 	if err := os.WriteFile(path, body, 0o600); err != nil {
 		return nil, fmt.Errorf("write body capture: %w", err)
 	}

--- a/pkg/adapters/yamlruntime/adapter.go
+++ b/pkg/adapters/yamlruntime/adapter.go
@@ -184,6 +184,7 @@ func (a *YAMLAdapter) FetchIdentity(ctx context.Context, credBytes []byte, confi
 	if err != nil {
 		return "", fmt.Errorf("%s: identity request: %w", a.def.Service.ID, err)
 	}
+	// codeql[go/request-forgery] YAML runtime clients use yamlRuntimeHTTPClient, whose transport blocks private/internal IP ranges at dial time.
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("%s: identity request: %w", a.def.Service.ID, err)
@@ -479,6 +480,8 @@ func (a *YAMLAdapter) buildOAuthClient(ctx context.Context, credBytes []byte, oa
 			token.Expiry = t
 		}
 	}
+	oauthClient := yamlRuntimeHTTPClient(nil)
+	ctx = context.WithValue(ctx, oauth2.HTTPClient, oauthClient)
 	ts := oauthCfg.TokenSource(ctx, token)
 	return oauth2.NewClient(ctx, ts), nil
 }

--- a/pkg/adapters/yamlruntime/auth.go
+++ b/pkg/adapters/yamlruntime/auth.go
@@ -45,15 +45,13 @@ func buildHTTPClient(authDef yamldef.AuthDef, credBytes []byte, config map[strin
 		if err != nil {
 			return nil, err
 		}
-		return &http.Client{
-			Transport: &headerTransport{
-				header:       authDef.Header,
-				headerPrefix: authDef.HeaderPrefix,
-				token:        token,
-				extraHeaders: authDef.ExtraHeaders,
-				base:         http.DefaultTransport,
-			},
-		}, nil
+		return yamlRuntimeHTTPClientWithTransport(&headerTransport{
+			header:       authDef.Header,
+			headerPrefix: authDef.HeaderPrefix,
+			token:        token,
+			extraHeaders: authDef.ExtraHeaders,
+			base:         yamlRuntimeSSRFTransport(http.DefaultTransport),
+		}), nil
 
 	case "basic":
 		token, err := extractToken(credBytes)
@@ -74,14 +72,12 @@ func buildHTTPClient(authDef yamldef.AuthDef, credBytes []byte, config map[strin
 			}
 			user, pass = parts[0], parts[1]
 		}
-		return &http.Client{
-			Transport: &basicAuthTransport{
-				user:         user,
-				pass:         pass,
-				extraHeaders: authDef.ExtraHeaders,
-				base:         http.DefaultTransport,
-			},
-		}, nil
+		return yamlRuntimeHTTPClientWithTransport(&basicAuthTransport{
+			user:         user,
+			pass:         pass,
+			extraHeaders: authDef.ExtraHeaders,
+			base:         yamlRuntimeSSRFTransport(http.DefaultTransport),
+		}), nil
 
 	case "oauth2":
 		// OAuth credentials are stored as JSON with access_token, refresh_token, etc.
@@ -95,23 +91,19 @@ func buildHTTPClient(authDef yamldef.AuthDef, credBytes []byte, config map[strin
 		if oauthCred.AccessToken == "" {
 			return nil, fmt.Errorf("oauth2 credential missing access_token")
 		}
-		return &http.Client{
-			Transport: &headerTransport{
-				header:       "Authorization",
-				headerPrefix: "Bearer ",
-				token:        oauthCred.AccessToken,
-				extraHeaders: authDef.ExtraHeaders,
-				base:         http.DefaultTransport,
-			},
-		}, nil
+		return yamlRuntimeHTTPClientWithTransport(&headerTransport{
+			header:       "Authorization",
+			headerPrefix: "Bearer ",
+			token:        oauthCred.AccessToken,
+			extraHeaders: authDef.ExtraHeaders,
+			base:         yamlRuntimeSSRFTransport(http.DefaultTransport),
+		}), nil
 
 	case "none":
-		return &http.Client{
-			Transport: &headerTransport{
-				extraHeaders: authDef.ExtraHeaders,
-				base:         http.DefaultTransport,
-			},
-		}, nil
+		return yamlRuntimeHTTPClientWithTransport(&headerTransport{
+			extraHeaders: authDef.ExtraHeaders,
+			base:         yamlRuntimeSSRFTransport(http.DefaultTransport),
+		}), nil
 
 	default:
 		return nil, fmt.Errorf("unsupported auth type %q", authDef.Type)

--- a/pkg/adapters/yamlruntime/ssrf.go
+++ b/pkg/adapters/yamlruntime/ssrf.go
@@ -1,0 +1,117 @@
+package yamlruntime
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"time"
+)
+
+var allowPrivateNetworkTargetsForTests bool
+
+var yamlRuntimeSSRFRanges = func() []*net.IPNet {
+	cidrs := []string{
+		"0.0.0.0/8",
+		"10.0.0.0/8",
+		"127.0.0.0/8",
+		"169.254.0.0/16",
+		"172.16.0.0/12",
+		"192.168.0.0/16",
+		"::1/128",
+		"fc00::/7",
+		"fe80::/10",
+	}
+	nets := make([]*net.IPNet, 0, len(cidrs))
+	for _, cidr := range cidrs {
+		_, n, _ := net.ParseCIDR(cidr)
+		nets = append(nets, n)
+	}
+	return nets
+}()
+
+func yamlRuntimeHTTPClient(base http.RoundTripper) *http.Client {
+	return &http.Client{
+		Timeout:   30 * time.Second,
+		Transport: yamlRuntimeSSRFTransport(base),
+	}
+}
+
+func yamlRuntimeHTTPClientWithTransport(transport http.RoundTripper) *http.Client {
+	return &http.Client{
+		Timeout:   30 * time.Second,
+		Transport: transport,
+	}
+}
+
+func yamlRuntimeSSRFTransport(base http.RoundTripper) http.RoundTripper {
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	transport, ok := base.(*http.Transport)
+	if !ok {
+		return &ssrfCheckingRoundTripper{base: base}
+	}
+	clone := transport.Clone()
+	clone.Proxy = nil
+	clone.DialContext = yamlRuntimeSSRFSafeDialContext
+	return &ssrfCheckingRoundTripper{base: clone}
+}
+
+func yamlRuntimeSSRFSafeDialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, fmt.Errorf("yamlruntime: invalid address %q: %w", address, err)
+	}
+
+	ips, err := net.DefaultResolver.LookupHost(ctx, host)
+	if err != nil {
+		return nil, fmt.Errorf("yamlruntime: cannot resolve host %q: %w", host, err)
+	}
+	for _, ipStr := range ips {
+		ip := net.ParseIP(ipStr)
+		if ip == nil {
+			continue
+		}
+		if yamlRuntimeIsSSRFTarget(ip) {
+			return nil, fmt.Errorf("yamlruntime: host %q resolves to blocked IP %s", host, ipStr)
+		}
+		return (&net.Dialer{Timeout: 5 * time.Second}).DialContext(ctx, network, net.JoinHostPort(ipStr, port))
+	}
+	return nil, fmt.Errorf("yamlruntime: no safe IPs found for host %q", host)
+}
+
+func yamlRuntimeIsSSRFTarget(ip net.IP) bool {
+	if allowPrivateNetworkTargetsForTests || os.Getenv("CLAWVISOR_YAMLRUNTIME_ALLOW_PRIVATE_NETWORKS") == "1" {
+		return false
+	}
+	for _, n := range yamlRuntimeSSRFRanges {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+type ssrfCheckingRoundTripper struct {
+	base http.RoundTripper
+}
+
+func (t *ssrfCheckingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	host := req.URL.Hostname()
+	if host == "" {
+		return nil, fmt.Errorf("yamlruntime: request URL must include a host")
+	}
+	ips, err := net.DefaultResolver.LookupHost(req.Context(), host)
+	if err != nil {
+		return nil, fmt.Errorf("yamlruntime: cannot resolve host %q: %w", host, err)
+	}
+	for _, ipStr := range ips {
+		ip := net.ParseIP(ipStr)
+		if ip != nil && yamlRuntimeIsSSRFTarget(ip) {
+			return nil, fmt.Errorf("yamlruntime: host %q resolves to blocked IP %s", host, ipStr)
+		}
+	}
+	return t.base.RoundTrip(req)
+}

--- a/pkg/adapters/yamlruntime/ssrf_test.go
+++ b/pkg/adapters/yamlruntime/ssrf_test.go
@@ -1,0 +1,40 @@
+package yamlruntime
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func init() {
+	allowPrivateNetworkTargetsForTests = true
+}
+
+func TestYAMLRuntimeSSRFBlocksPrivateTargetBeforeProxy(t *testing.T) {
+	oldAllow := allowPrivateNetworkTargetsForTests
+	allowPrivateNetworkTargetsForTests = false
+	t.Cleanup(func() { allowPrivateNetworkTargetsForTests = oldAllow })
+
+	var proxyHit bool
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		proxyHit = true
+		w.WriteHeader(http.StatusTeapot)
+	}))
+	defer proxy.Close()
+	t.Setenv("HTTP_PROXY", proxy.URL)
+	t.Setenv("HTTPS_PROXY", proxy.URL)
+	t.Setenv("NO_PROXY", "")
+
+	client := yamlRuntimeHTTPClient(nil)
+	_, err := client.Get("http://169.254.169.254/latest/meta-data")
+	if err == nil {
+		t.Fatal("expected private target to be blocked")
+	}
+	if !strings.Contains(err.Error(), "blocked IP") {
+		t.Fatalf("expected blocked IP error, got %v", err)
+	}
+	if proxyHit {
+		t.Fatal("request reached environment proxy before SSRF validation")
+	}
+}

--- a/pkg/runtime/proxy/auth.go
+++ b/pkg/runtime/proxy/auth.go
@@ -27,6 +27,7 @@ var ErrProxyAuthorizationRejected = errors.New("proxy authorization rejected")
 var ErrProxyAuthorizationUnavailable = errors.New("proxy authorization unavailable")
 
 func HashProxyBearerSecret(secret string) string {
+	// codeql[go/weak-sensitive-data-hashing] Runtime bearer secrets are high-entropy random values; SHA-256 is only an internal lookup key.
 	sum := sha256.Sum256([]byte(secret))
 	return hex.EncodeToString(sum[:])
 }

--- a/pkg/runtime/proxy/inbound_secret_runtime.go
+++ b/pkg/runtime/proxy/inbound_secret_runtime.go
@@ -837,6 +837,7 @@ func (s *runtimeSecretScanner) lookupOrAdjudicate(ctx context.Context, fieldName
 }
 
 func secretValueCacheKey(agentID, raw string) string {
+	// codeql[go/weak-sensitive-data-hashing] Internal secret deduplication key; not used for password storage or authentication.
 	sum := sha256.Sum256([]byte(raw))
 	return agentID + ":" + hex.EncodeToString(sum[:])
 }

--- a/pkg/runtime/proxy/placeholder_runtime.go
+++ b/pkg/runtime/proxy/placeholder_runtime.go
@@ -344,6 +344,7 @@ func injectStoredBearer(req *http.Request, v vault.Vault, userID string) (bool, 
 }
 
 func credentialReference(value string) string {
+	// codeql[go/weak-sensitive-data-hashing] Internal credential deduplication reference; not used for password storage or authentication.
 	sum := sha256.Sum256([]byte(value))
 	return "sha256:" + hex.EncodeToString(sum[:])
 }

--- a/pkg/runtime/proxy/tooluse_runtime.go
+++ b/pkg/runtime/proxy/tooluse_runtime.go
@@ -956,6 +956,7 @@ func runtimeToolMetadata(toolName string, toolInput map[string]any) map[string]a
 }
 
 func withRuleMetadata(metadata map[string]any, extras ...map[string]any) map[string]any {
+	// codeql[go/allocation-size-overflow] metadata is an already-materialized map with a small bounded set of runtime audit keys.
 	out := make(map[string]any, len(metadata)+4)
 	for k, v := range metadata {
 		out[k] = v

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1,5 +1,5 @@
 // Typed API client. All requests go through these helpers.
-// Access token is stored in memory (React state); refresh token in localStorage.
+// Access token is stored in memory (React state); refresh token is an HttpOnly cookie.
 // On 401, the caller should trigger a token refresh.
 
 import { populateFromServices } from '../lib/services'
@@ -166,7 +166,7 @@ export interface User {
 export interface AuthResponse {
   user: User
   access_token: string
-  refresh_token: string
+  refresh_token?: string
 }
 
 export interface GoogleAuthResult {
@@ -1097,8 +1097,8 @@ export const api = {
       post<{ status: 'waitlisted' }>('/api/auth/waitlist', { email }),
     login: (email: string, password: string) =>
       post<LoginResult>('/api/auth/login', { email, password }),
-    refresh: (refreshToken: string) =>
-      post<AuthResponse>('/api/auth/refresh', { refresh_token: refreshToken }),
+    refresh: () =>
+      post<AuthResponse>('/api/auth/refresh', {}),
     magic: (token: string) =>
       post<AuthResponse>('/api/auth/magic', { token }),
     verifyEmail: (token: string) =>
@@ -1107,8 +1107,8 @@ export const api = {
       post<{ status: string }>('/api/auth/resend-verification', { email }),
     devSkipOnboarding: (email: string) =>
       post<AuthResponse>('/api/auth/dev/skip-onboarding', { email }),
-    logout: (refreshToken?: string) =>
-      post<void>('/api/auth/logout', { refresh_token: refreshToken }),
+    logout: () =>
+      post<void>('/api/auth/logout', {}),
     me: () => get<User>('/api/me'),
     updateMe: (currentPassword: string, newPassword: string) =>
       put<User>('/api/me', { current_password: currentPassword, new_password: newPassword }),

--- a/web/src/hooks/useAuth.tsx
+++ b/web/src/hooks/useAuth.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useCallback, createContext, useContext, useRef, type ReactNode } from 'react'
 import { APIError, api, setAccessToken, setRefreshCallback, setCurrentOrgId, type User, type FeatureSet, type LoginResult, type RegisterResult, type Org } from '../api/client'
 
-const REFRESH_TOKEN_KEY = 'clawvisor_refresh_token'
 const CURRENT_ORG_KEY = 'clawvisor_current_org'
 const INITIAL_REFRESH_RETRY_MS = 1_000
 const MAX_INITIAL_REFRESH_RETRY_MS = 5_000
@@ -33,7 +32,7 @@ interface AuthContextValue {
   register: (email: string, password: string) => Promise<RegisterResult>
   logout: () => Promise<void>
   /** Set session tokens directly (used by pages that handle multi-step auth flows) */
-  setSession: (accessToken: string, refreshToken: string, user: User) => void
+  setSession: (accessToken: string, refreshToken: string | undefined, user: User) => void
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null)
@@ -92,7 +91,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     if (didInit.current) return
     didInit.current = true
 
-    // Fetch auth mode and refresh token in parallel. Features are fetched
+    localStorage.removeItem('clawvisor_refresh_token')
+
+    // Fetch auth mode and refresh cookie in parallel. Features are fetched
     // separately by the user-dependent effect below so we can return a
     // per-user FeatureSet (e.g. plan-based gating) once the user is known.
     const configPromise = api.config.public()
@@ -100,23 +101,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       .catch((e) => console.warn('useAuth: failed to fetch config', e)) // default stays null → treated like password mode
 
     async function restoreSession() {
-      let refreshToken = localStorage.getItem(REFRESH_TOKEN_KEY)
-      if (!refreshToken) return
-
       let retryDelay = INITIAL_REFRESH_RETRY_MS
       for (let attempt = 1; attempt <= MAX_INITIAL_REFRESH_ATTEMPTS; attempt++) {
         try {
-          const resp = await api.auth.refresh(refreshToken)
+          const resp = await api.auth.refresh()
           setAccessToken(resp.access_token)
-          safeSetItem(REFRESH_TOKEN_KEY, resp.refresh_token)
           setUser(resp.user)
           // Check onboarding status now that we have a valid token.
           checkOnboarding()
           return
         } catch (e) {
           if (isRefreshTokenRejected(e)) {
-            console.warn('useAuth: token refresh rejected', e)
-            localStorage.removeItem(REFRESH_TOKEN_KEY)
             setAccessToken(null)
             return
           }
@@ -130,12 +125,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           console.warn('useAuth: token refresh temporarily failed; retrying', e)
           await delay(retryDelay)
           retryDelay = Math.min(retryDelay * 2, MAX_INITIAL_REFRESH_RETRY_MS)
-
-          refreshToken = localStorage.getItem(REFRESH_TOKEN_KEY)
-          if (!refreshToken) {
-            setAccessToken(null)
-            return
-          }
         }
       }
     }
@@ -162,12 +151,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // data endpoints (expired access token) without logging the user out.
   useEffect(() => {
     setRefreshCallback(async () => {
-      const storedRefresh = localStorage.getItem(REFRESH_TOKEN_KEY)
-      if (!storedRefresh) throw new Error('no refresh token stored')
       try {
-        const resp = await api.auth.refresh(storedRefresh)
+        const resp = await api.auth.refresh()
         setAccessToken(resp.access_token)
-        safeSetItem(REFRESH_TOKEN_KEY, resp.refresh_token)
         setUser(resp.user)
         return resp.access_token
       } catch (e) {
@@ -175,7 +161,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           // The server definitively rejected this refresh token. Clear auth so
           // RequireAuth redirects to /login.
           setAccessToken(null)
-          localStorage.removeItem(REFRESH_TOKEN_KEY)
           setUser(null)
         }
         throw e
@@ -184,9 +169,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return () => setRefreshCallback(null)
   }, [])
 
-  const setSession = useCallback((at: string, rt: string, u: User) => {
+  const setSession = useCallback((at: string, _rt: string | undefined, u: User) => {
     setAccessToken(at)
-    safeSetItem(REFRESH_TOKEN_KEY, rt)
     setUser(u)
     checkOnboarding()
   }, [checkOnboarding])
@@ -194,9 +178,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const login = useCallback(async (email: string, password: string): Promise<LoginResult> => {
     const resp = await api.auth.login(email, password)
     // Only set session if we got full tokens back (not TOTP/setup redirect)
-    if (resp.access_token && resp.refresh_token && resp.user) {
+    if (resp.access_token && resp.user) {
       setAccessToken(resp.access_token)
-      safeSetItem(REFRESH_TOKEN_KEY, resp.refresh_token)
       setUser(resp.user)
       checkOnboarding()
     }
@@ -208,10 +191,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, [])
 
   const logout = useCallback(async () => {
-    const refreshToken = localStorage.getItem(REFRESH_TOKEN_KEY) ?? undefined
-    await api.auth.logout(refreshToken).catch((e) => console.warn('useAuth: logout request failed', e))
+    await api.auth.logout().catch((e) => console.warn('useAuth: logout request failed', e))
     setAccessToken(null)
-    localStorage.removeItem(REFRESH_TOKEN_KEY)
     localStorage.removeItem(CURRENT_ORG_KEY)
     setCurrentOrgId(null)
     setCurrentOrgState(null)

--- a/web/src/pages/MagicLink.tsx
+++ b/web/src/pages/MagicLink.tsx
@@ -3,8 +3,6 @@ import { Navigate, useSearchParams } from 'react-router-dom'
 import { useAuth } from '../hooks/useAuth'
 import { api, setAccessToken } from '../api/client'
 
-const REFRESH_TOKEN_KEY = 'clawvisor_refresh_token'
-
 export default function MagicLink() {
   const { isAuthenticated, isLoading } = useAuth()
   const [searchParams] = useSearchParams()
@@ -20,7 +18,6 @@ export default function MagicLink() {
     api.auth.magic(magicToken)
       .then((resp) => {
         setAccessToken(resp.access_token)
-        localStorage.setItem(REFRESH_TOKEN_KEY, resp.refresh_token)
         window.location.href = '/dashboard'
       })
       .catch((e) => {

--- a/web/src/pages/SetupAuth.tsx
+++ b/web/src/pages/SetupAuth.tsx
@@ -4,8 +4,6 @@ import { api, setAccessToken, type AuthResponse } from '../api/client'
 import { useAuth } from '../hooks/useAuth'
 import { isWebAuthnAvailable, startRegistration } from '../lib/webauthn'
 
-const REFRESH_TOKEN_KEY = 'clawvisor_refresh_token'
-
 type Step = 'choose' | 'passkey' | 'password' | 'totp'
 
 export default function SetupAuth() {
@@ -53,7 +51,6 @@ export default function SetupAuth() {
       // Setup password returns session tokens so we can call TOTP setup
       const pwResp = await api.auth.setupPassword(password, setupToken) as AuthResponse
       setAccessToken(pwResp.access_token)
-      localStorage.setItem(REFRESH_TOKEN_KEY, pwResp.refresh_token)
       // Now set up TOTP (uses the session token we just stored)
       const totp = await api.auth.totp.setup()
       setTotpQR(totp.qr_data_url)


### PR DESCRIPTION
## Summary
- move browser refresh sessions to HttpOnly cookies and omit refresh tokens from browser-shaped auth JSON responses
- harden YAML runtime HTTP requests against SSRF, including environment proxy bypasses
- add reviewed CodeQL suppressions for product/security design decisions and false positives
- add minimal workflow permissions and clamp webhook polling intervals

## Tests
- go test ./...
- cd web && npm run build
- node --experimental-strip-types --check extensions/clawvisor-webhook/index.ts