### PR TITLE
fix(llmproxy): default allow Codex internal tools

### DIFF
--- a/internal/api/handlers/runtime_controls_test.go
+++ b/internal/api/handlers/runtime_controls_test.go
@@ -440,6 +440,16 @@ func TestDefaultToolRulesSeedAndRespectUnset(t *testing.T) {
 	h.ensureDefaultToolRules(ctx, agent, []string{
 		"Read",
 		"read_file",
+		"view_image",
+		"update_plan",
+		"request_user_input",
+		"tool_suggest",
+		"wait_agent",
+		"close_agent",
+		"resume_agent",
+		"list_mcp_resources",
+		"list_mcp_resource_templates",
+		"read_mcp_resource",
 		"Bash",
 		"Write",
 		"sessions_list",
@@ -470,6 +480,11 @@ func TestDefaultToolRulesSeedAndRespectUnset(t *testing.T) {
 		"browser_type",
 		"browser_vision",
 		"delegate_task",
+		"exec_command",
+		"write_stdin",
+		"apply_patch",
+		"spawn_agent",
+		"send_input",
 	})
 	enabled := true
 	rules, err := st.ListRuntimePolicyRules(ctx, user.ID, store.RuntimePolicyRuleFilter{AgentID: agent.ID, Kind: "tool", Enabled: &enabled})
@@ -483,7 +498,12 @@ func TestDefaultToolRulesSeedAndRespectUnset(t *testing.T) {
 			t.Fatalf("default tool rule should be agent-scoped, got %+v", rule)
 		}
 	}
-	if !allowed["Read"] || !allowed["read_file"] ||
+	if !allowed["Read"] || !allowed["read_file"] || !allowed["view_image"] ||
+		!allowed["update_plan"] || !allowed["request_user_input"] ||
+		!allowed["tool_suggest"] || !allowed["wait_agent"] ||
+		!allowed["close_agent"] || !allowed["resume_agent"] ||
+		!allowed["list_mcp_resources"] || !allowed["list_mcp_resource_templates"] ||
+		!allowed["read_mcp_resource"] ||
 		!allowed["sessions_list"] || !allowed["sessions_history"] ||
 		!allowed["session_status"] || !allowed["sessions_yield"] ||
 		!allowed["memory_search"] || !allowed["memory_get"] ||
@@ -497,7 +517,9 @@ func TestDefaultToolRulesSeedAndRespectUnset(t *testing.T) {
 		allowed["web_fetch"] || allowed["sessions_send"] || allowed["sessions_spawn"] ||
 		allowed["subagents"] || allowed["terminal"] || allowed["write_file"] ||
 		allowed["patch"] || allowed["browser_navigate"] || allowed["browser_click"] ||
-		allowed["browser_type"] || allowed["browser_vision"] || allowed["delegate_task"] {
+		allowed["browser_type"] || allowed["browser_vision"] || allowed["delegate_task"] ||
+		allowed["exec_command"] || allowed["write_stdin"] || allowed["apply_patch"] ||
+		allowed["spawn_agent"] || allowed["send_input"] {
 		t.Fatalf("non-default tools should not be seeded as always allow, got %+v", rules)
 	}
 

--- a/internal/runtime/llmproxy/inspector/parser.go
+++ b/internal/runtime/llmproxy/inspector/parser.go
@@ -52,7 +52,8 @@ func (DefaultParser) Parse(t ToolUse) (Verdict, bool) {
 // Authorization is handled separately by runtime tool policies.
 //
 //  1. Pure local reads. Read / Glob / Grep / BashOutput / ToolSearch
-//     and their Codex / Hermes equivalents (read_file, search_files).
+//     and their Codex / Hermes equivalents (read_file, view_image,
+//     search_files).
 //     These don't change state or transmit credentials.
 //
 //  2. Harness-internal lifecycle / planning state. Skill / Agent /
@@ -85,7 +86,8 @@ var localOnlyTools = map[string]struct{}{
 	"LSP":        {},
 	"Monitor":    {},
 	// Pure local reads — Codex.
-	"read_file": {},
+	"read_file":  {},
+	"view_image": {},
 	// Pure local reads — Hermes.
 	"browser_console":    {},
 	"browser_get_images": {},
@@ -137,6 +139,14 @@ var localOnlyTools = map[string]struct{}{
 	// Harness-internal user clarification prompt. It does not reach
 	// outside the harness and should not require an approved task scope.
 	"AskUserQuestion": {},
+	// Codex internal state / user-interaction tools. These don't make
+	// downstream API calls or mutate the user's workspace.
+	"update_plan":        {},
+	"request_user_input": {},
+	"tool_suggest":       {},
+	"wait_agent":         {},
+	"close_agent":        {},
+	"resume_agent":       {},
 }
 
 var defaultAllowedTools = map[string]struct{}{
@@ -191,9 +201,16 @@ var defaultAllowedTools = map[string]struct{}{
 	"skill_view":                  {},
 	"skills_list":                 {},
 	"read_file":                   {},
+	"view_image":                  {},
 	"list_mcp_resources":          {},
 	"list_mcp_resource_templates": {},
 	"read_mcp_resource":           {},
+	"update_plan":                 {},
+	"request_user_input":          {},
+	"tool_suggest":                {},
+	"wait_agent":                  {},
+	"close_agent":                 {},
+	"resume_agent":                {},
 }
 
 func isLocalOnlyTool(name string) bool {

--- a/internal/runtime/llmproxy/inspector/parser_flags_test.go
+++ b/internal/runtime/llmproxy/inspector/parser_flags_test.go
@@ -304,6 +304,46 @@ func TestHermesReadOnlyToolsAreLocalOnlyDefaults(t *testing.T) {
 	}
 }
 
+func TestCodexInternalToolsAreLocalOnlyDefaults(t *testing.T) {
+	for _, name := range []string{
+		"read_file",
+		"view_image",
+		"update_plan",
+		"request_user_input",
+		"tool_suggest",
+		"wait_agent",
+		"close_agent",
+		"resume_agent",
+	} {
+		if !IsLocalOnlyTool(name) {
+			t.Fatalf("%s should be treated as local-only", name)
+		}
+		if !IsDefaultAllowedTool(name) {
+			t.Fatalf("%s should be seeded as a default allowed tool", name)
+		}
+	}
+	for _, name := range []string{
+		"list_mcp_resources",
+		"list_mcp_resource_templates",
+		"read_mcp_resource",
+	} {
+		if !IsDefaultAllowedTool(name) {
+			t.Fatalf("%s should be seeded as a default allowed tool", name)
+		}
+	}
+	for _, name := range []string{
+		"exec_command",
+		"write_stdin",
+		"apply_patch",
+		"spawn_agent",
+		"send_input",
+	} {
+		if IsDefaultAllowedTool(name) {
+			t.Fatalf("%s should not be seeded as a default allowed tool", name)
+		}
+	}
+}
+
 // Regression: a placeholder substring inside a local-only tool's args
 // (Skill, Read, Edit, etc.) must pass through without engaging the
 // LLM validator. Otherwise smoke-test installs without an LLM-backed


### PR DESCRIPTION
## Summary
- Default-allow Codex internal/read-only tools such as view_image, update_plan, request_user_input, and MCP resource reads in llmproxy policy seeding.
- Keep workspace-mutating Codex tools such as exec_command, apply_patch, and spawn_agent out of the default allowlist.
- Add regression coverage for the tool classifier and runtime tool-control seeding.

## Tests
- go test ./internal/runtime/llmproxy/inspector ./internal/api/handlers