### PR TITLE
feat(lite-proxy): add experimental secret detection toggle

### DIFF
--- a/internal/api/handlers/agents.go
+++ b/internal/api/handlers/agents.go
@@ -172,11 +172,12 @@ func (h *AgentsHandler) UpdateRuntimeSettings(w http.ResponseWriter, r *http.Req
 		return
 	}
 	var body struct {
-		RuntimeEnabled         bool   `json:"runtime_enabled"`
-		RuntimeMode            string `json:"runtime_mode"`
-		StarterProfile         string `json:"starter_profile"`
-		OutboundCredentialMode string `json:"outbound_credential_mode"`
-		InjectStoredBearer     bool   `json:"inject_stored_bearer"`
+		RuntimeEnabled                   bool   `json:"runtime_enabled"`
+		RuntimeMode                      string `json:"runtime_mode"`
+		StarterProfile                   string `json:"starter_profile"`
+		OutboundCredentialMode           string `json:"outbound_credential_mode"`
+		InjectStoredBearer               bool   `json:"inject_stored_bearer"`
+		LiteProxySecretDetectionDisabled *bool  `json:"lite_proxy_secret_detection_disabled"`
 	}
 	if !decodeJSON(w, r, &body) {
 		return
@@ -201,6 +202,9 @@ func (h *AgentsHandler) UpdateRuntimeSettings(w http.ResponseWriter, r *http.Req
 	settings.StarterProfile = body.StarterProfile
 	settings.OutboundCredentialMode = body.OutboundCredentialMode
 	settings.InjectStoredBearer = body.InjectStoredBearer
+	if body.LiteProxySecretDetectionDisabled != nil {
+		settings.LiteProxySecretDetectionDisabled = *body.LiteProxySecretDetectionDisabled
+	}
 	if err := h.st.UpsertAgentRuntimeSettings(r.Context(), settings); err != nil {
 		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not save agent runtime settings")
 		return
@@ -318,11 +322,12 @@ func defaultAgentRuntimeSettings(cfg *config.Config, agentID string) *store.Agen
 		runtimeMode = "enforce"
 	}
 	return &store.AgentRuntimeSettings{
-		AgentID:                agentID,
-		RuntimeEnabled:         true,
-		RuntimeMode:            runtimeMode,
-		StarterProfile:         "none",
-		OutboundCredentialMode: "inherit",
-		InjectStoredBearer:     cfg != nil && cfg.RuntimePolicy.InjectStoredBearer,
+		AgentID:                          agentID,
+		RuntimeEnabled:                   true,
+		RuntimeMode:                      runtimeMode,
+		StarterProfile:                   "none",
+		OutboundCredentialMode:           "inherit",
+		InjectStoredBearer:               cfg != nil && cfg.RuntimePolicy.InjectStoredBearer,
+		LiteProxySecretDetectionDisabled: true,
 	}
 }

--- a/internal/api/handlers/llm_endpoint.go
+++ b/internal/api/handlers/llm_endpoint.go
@@ -338,23 +338,28 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	decisionExtraSuppressed := map[string]struct{}{}
-	if decisionBody, decision, extraSuppressed, handled := h.maybeHandleLiteSecretDecision(w, r, agent, provider, requestID, body, auditParams, &auditStatus, &auditDecide, &auditOutcome, &auditReason); handled {
-		if len(decisionBody) == 0 {
-			return
+	liteProxySecretDetectionDisabled := agentLiteProxySecretDetectionDisabled(agent)
+	if liteProxySecretDetectionDisabled {
+		auditParams["lite_proxy_secret_detection_disabled"] = true
+	} else {
+		if decisionBody, decision, extraSuppressed, handled := h.maybeHandleLiteSecretDecision(w, r, agent, provider, requestID, body, auditParams, &auditStatus, &auditDecide, &auditOutcome, &auditReason); handled {
+			if len(decisionBody) == 0 {
+				return
+			}
+			body = decisionBody
+			if _, err := parser.ParseRequest(body); err != nil {
+				auditStatus = http.StatusBadRequest
+				auditDecide = "deny"
+				auditOutcome = "malformed_request"
+				auditReason = err.Error()
+				writeJSONError(w, http.StatusBadRequest, "MALFORMED_REQUEST", err.Error())
+				return
+			}
+			auditParams["secret_decision"] = string(decision)
+			decisionExtraSuppressed = extraSuppressed
 		}
-		body = decisionBody
-		if _, err := parser.ParseRequest(body); err != nil {
-			auditStatus = http.StatusBadRequest
-			auditDecide = "deny"
-			auditOutcome = "malformed_request"
-			auditReason = err.Error()
-			writeJSONError(w, http.StatusBadRequest, "MALFORMED_REQUEST", err.Error())
-			return
-		}
-		auditParams["secret_decision"] = string(decision)
-		decisionExtraSuppressed = extraSuppressed
 	}
-	if processed, held := h.preprocessLiteSecretBody(w, r, agent, provider, requestID, body, decisionExtraSuppressed, auditParams, &auditStatus, &auditDecide, &auditOutcome, &auditReason); held {
+	if processed, held := h.preprocessLiteSecretBody(w, r, agent, provider, requestID, body, decisionExtraSuppressed, liteProxySecretDetectionDisabled, auditParams, &auditStatus, &auditDecide, &auditOutcome, &auditReason); held {
 		return
 	} else {
 		body = processed
@@ -1317,7 +1322,7 @@ func (h *LLMEndpointHandler) forwardLitePassthrough(w http.ResponseWriter, r *ht
 	_, _ = io.Copy(w, resp.Body)
 }
 
-func (h *LLMEndpointHandler) preprocessLiteSecretBody(w http.ResponseWriter, r *http.Request, agent *store.Agent, provider conversation.Provider, requestID string, body []byte, extraSuppressed map[string]struct{}, auditParams map[string]any, auditStatus *int, auditDecide, auditOutcome, auditReason *string) ([]byte, bool) {
+func (h *LLMEndpointHandler) preprocessLiteSecretBody(w http.ResponseWriter, r *http.Request, agent *store.Agent, provider conversation.Provider, requestID string, body []byte, extraSuppressed map[string]struct{}, liteProxySecretDetectionDisabled bool, auditParams map[string]any, auditStatus *int, auditDecide, auditOutcome, auditReason *string) ([]byte, bool) {
 	if stripped, err := llmproxy.StripSecretDecisionHistory(llmproxy.SecretDecisionHistoryStripRequest{
 		Provider: provider,
 		Body:     body,
@@ -1339,6 +1344,14 @@ func (h *LLMEndpointHandler) preprocessLiteSecretBody(w http.ResponseWriter, r *
 		body = stripped.Body
 		auditParams["secret_decision_history_stripped"] = true
 	}
+	if liteProxySecretDetectionDisabled {
+		h.emitLiteSecretPipelineTrace(requestID, agent, "lite_proxy_secret_detection_skipped", map[string]any{
+			"provider": string(provider),
+			"body_sha": liteSecretBodySHA(body),
+			"reason":   "agent_setting",
+		})
+		return body, false
+	}
 	if rewritten, modified := h.applyRememberedSecretRewrites(r.Context(), agent, provider, requestID, body); modified {
 		body = rewritten
 		auditParams["secret_rewrites_applied"] = true
@@ -1347,6 +1360,10 @@ func (h *LLMEndpointHandler) preprocessLiteSecretBody(w http.ResponseWriter, r *
 		return body, true
 	}
 	return body, false
+}
+
+func agentLiteProxySecretDetectionDisabled(agent *store.Agent) bool {
+	return agent != nil && (agent.RuntimeSettings == nil || agent.RuntimeSettings.LiteProxySecretDetectionDisabled)
 }
 
 func (h *LLMEndpointHandler) maybeHandleLiteSecretDecision(w http.ResponseWriter, r *http.Request, agent *store.Agent, provider conversation.Provider, requestID string, body []byte, auditParams map[string]any, auditStatus *int, auditDecide, auditOutcome, auditReason *string) ([]byte, llmproxy.SecretDecisionAction, map[string]struct{}, bool) {

--- a/internal/api/handlers/llm_endpoint_test.go
+++ b/internal/api/handlers/llm_endpoint_test.go
@@ -132,6 +132,10 @@ func TestLiteProxyRequestDebugSummaryExtractsAvailableTools(t *testing.T) {
 }
 
 func newSeededHandler(t *testing.T, upstreamURL string) (*LLMEndpointHandler, store.Store, string, string) {
+	return newSeededHandlerWithLiteProxySecretDetection(t, upstreamURL, boolPtr(true))
+}
+
+func newSeededHandlerWithLiteProxySecretDetection(t *testing.T, upstreamURL string, enabled *bool) (*LLMEndpointHandler, store.Store, string, string) {
 	t.Helper()
 	ctx := context.Background()
 
@@ -153,6 +157,13 @@ func newSeededHandler(t *testing.T, upstreamURL string) (*LLMEndpointHandler, st
 	agent, err := st.CreateAgent(ctx, user.ID, "claude-code", auth.HashToken(rawAgentToken))
 	if err != nil {
 		t.Fatalf("CreateAgent: %v", err)
+	}
+	if enabled != nil {
+		settings := defaultAgentRuntimeSettings(nil, agent.ID)
+		settings.LiteProxySecretDetectionDisabled = !*enabled
+		if err := st.UpsertAgentRuntimeSettings(ctx, settings); err != nil {
+			t.Fatalf("UpsertAgentRuntimeSettings: %v", err)
+		}
 	}
 
 	v := &stubVault{}
@@ -467,6 +478,92 @@ func TestLLMEndpoint_InboundSecretDiscardRedactsBeforeForwarding(t *testing.T) {
 	}
 	if !strings.Contains(string(seenBody), "[redacted secret:github]") {
 		t.Fatalf("discard forwarded body missing redaction marker: %s", seenBody)
+	}
+}
+
+func TestLLMEndpoint_LiteProxySecretDetectionCanBeDisabledPerAgent(t *testing.T) {
+	upstreamHits := 0
+	var seenBody []byte
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits++
+		seenBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_123","type":"message"}`))
+	}))
+	defer upstream.Close()
+
+	h, st, rawToken, _ := newSeededHandler(t, upstream.URL)
+	user, err := st.GetUserByEmail(context.Background(), "lite-proxy@example.com")
+	if err != nil {
+		t.Fatalf("GetUserByEmail: %v", err)
+	}
+	agents, err := st.ListAgents(context.Background(), user.ID)
+	if err != nil || len(agents) == 0 {
+		t.Fatalf("ListAgents: agents=%d err=%v", len(agents), err)
+	}
+	settings := defaultAgentRuntimeSettings(nil, agents[0].ID)
+	settings.LiteProxySecretDetectionDisabled = true
+	if err := st.UpsertAgentRuntimeSettings(context.Background(), settings); err != nil {
+		t.Fatalf("UpsertAgentRuntimeSettings: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	mw := middleware.RequireAgentLLM(st)
+	mux.Handle("POST /v1/messages", mw(http.HandlerFunc(h.Messages)))
+
+	rawSecret := "ghp_1234567890abcdefABCDEF1234567890abcdef"
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{"model":"claude-sonnet-4","messages":[{"role":"user","content":"my github token is `+rawSecret+`"}]}`))
+	req.Header.Set("Authorization", "Bearer "+rawToken)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected upstream response, got %d (%s)", rec.Code, rec.Body.String())
+	}
+	if upstreamHits != 1 {
+		t.Fatalf("disabled detection should forward immediately, hits=%d", upstreamHits)
+	}
+	if !strings.Contains(string(seenBody), rawSecret) {
+		t.Fatalf("disabled detection should not redact raw secret: %s", seenBody)
+	}
+	if strings.Contains(rec.Body.String(), "Clawvisor detected a possible raw secret") {
+		t.Fatalf("disabled detection should not prompt: %s", rec.Body.String())
+	}
+}
+
+func TestLLMEndpoint_LiteProxySecretDetectionDisabledByDefault(t *testing.T) {
+	upstreamHits := 0
+	var seenBody []byte
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits++
+		seenBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_123","type":"message"}`))
+	}))
+	defer upstream.Close()
+
+	h, st, rawToken, _ := newSeededHandlerWithLiteProxySecretDetection(t, upstream.URL, nil)
+	mux := http.NewServeMux()
+	mw := middleware.RequireAgentLLM(st)
+	mux.Handle("POST /v1/messages", mw(http.HandlerFunc(h.Messages)))
+
+	rawSecret := "ghp_1234567890abcdefABCDEF1234567890abcdef"
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{"model":"claude-sonnet-4","messages":[{"role":"user","content":"my github token is `+rawSecret+`"}]}`))
+	req.Header.Set("Authorization", "Bearer "+rawToken)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected upstream response, got %d (%s)", rec.Code, rec.Body.String())
+	}
+	if upstreamHits != 1 {
+		t.Fatalf("default-disabled detection should forward immediately, hits=%d", upstreamHits)
+	}
+	if !strings.Contains(string(seenBody), rawSecret) {
+		t.Fatalf("default-disabled detection should not redact raw secret: %s", seenBody)
+	}
+	if strings.Contains(rec.Body.String(), "Clawvisor detected a possible raw secret") {
+		t.Fatalf("default-disabled detection should not prompt: %s", rec.Body.String())
 	}
 }
 

--- a/internal/tui/client/types.go
+++ b/internal/tui/client/types.go
@@ -53,14 +53,15 @@ type CreateRuntimeSessionResponse struct {
 }
 
 type AgentRuntimeSettings struct {
-	AgentID                string    `json:"agent_id"`
-	RuntimeEnabled         bool      `json:"runtime_enabled"`
-	RuntimeMode            string    `json:"runtime_mode"`
-	StarterProfile         string    `json:"starter_profile"`
-	OutboundCredentialMode string    `json:"outbound_credential_mode"`
-	InjectStoredBearer     bool      `json:"inject_stored_bearer"`
-	CreatedAt              time.Time `json:"created_at"`
-	UpdatedAt              time.Time `json:"updated_at"`
+	AgentID                          string    `json:"agent_id"`
+	RuntimeEnabled                   bool      `json:"runtime_enabled"`
+	RuntimeMode                      string    `json:"runtime_mode"`
+	StarterProfile                   string    `json:"starter_profile"`
+	OutboundCredentialMode           string    `json:"outbound_credential_mode"`
+	InjectStoredBearer               bool      `json:"inject_stored_bearer"`
+	LiteProxySecretDetectionDisabled bool      `json:"lite_proxy_secret_detection_disabled"`
+	CreatedAt                        time.Time `json:"created_at"`
+	UpdatedAt                        time.Time `json:"updated_at"`
 }
 
 type LLMCredentialSetResponse struct {

--- a/pkg/store/postgres/migrations/050_agent_lite_proxy_secret_detection_disabled.sql
+++ b/pkg/store/postgres/migrations/050_agent_lite_proxy_secret_detection_disabled.sql
@@ -1,0 +1,2 @@
+ALTER TABLE agent_runtime_settings
+ADD COLUMN IF NOT EXISTS lite_proxy_secret_detection_disabled BOOLEAN NOT NULL DEFAULT TRUE;

--- a/pkg/store/postgres/store.go
+++ b/pkg/store/postgres/store.go
@@ -274,7 +274,8 @@ func (s *Store) ListAgents(ctx context.Context, userID string) ([]*store.Agent, 
 		                   AND t.status IN ('active','pending_approval','pending_scope_expansion')), 0),
 		       (SELECT MAX(t.created_at) FROM tasks t WHERE t.agent_id = a.id),
 		       ars.agent_id, ars.runtime_enabled, ars.runtime_mode, ars.starter_profile,
-		       ars.outbound_credential_mode, ars.inject_stored_bearer, ars.created_at, ars.updated_at
+		       ars.outbound_credential_mode, ars.inject_stored_bearer, ars.lite_proxy_secret_detection_disabled,
+		       ars.created_at, ars.updated_at
 		FROM agents a
 		LEFT JOIN agent_runtime_settings ars ON ars.agent_id = a.id
 		WHERE a.user_id = $1 AND a.deleted_at IS NULL
@@ -291,13 +292,14 @@ func (s *Store) ListAgents(ctx context.Context, userID string) ([]*store.Agent, 
 func (s *Store) GetAgentRuntimeSettings(ctx context.Context, agentID string) (*store.AgentRuntimeSettings, error) {
 	row := s.pool.QueryRow(ctx, `
 		SELECT agent_id, runtime_enabled, runtime_mode, starter_profile,
-		       outbound_credential_mode, inject_stored_bearer, created_at, updated_at
+		       outbound_credential_mode, inject_stored_bearer, lite_proxy_secret_detection_disabled, created_at, updated_at
 		FROM agent_runtime_settings
 		WHERE agent_id = $1
 	`, agentID)
 	settings := &store.AgentRuntimeSettings{}
 	err := row.Scan(&settings.AgentID, &settings.RuntimeEnabled, &settings.RuntimeMode, &settings.StarterProfile,
-		&settings.OutboundCredentialMode, &settings.InjectStoredBearer, &settings.CreatedAt, &settings.UpdatedAt)
+		&settings.OutboundCredentialMode, &settings.InjectStoredBearer, &settings.LiteProxySecretDetectionDisabled,
+		&settings.CreatedAt, &settings.UpdatedAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, store.ErrNotFound
 	}
@@ -310,17 +312,18 @@ func (s *Store) UpsertAgentRuntimeSettings(ctx context.Context, settings *store.
 	}
 	_, err := s.pool.Exec(ctx, `
 		INSERT INTO agent_runtime_settings (
-			agent_id, runtime_enabled, runtime_mode, starter_profile, outbound_credential_mode, inject_stored_bearer
-		) VALUES ($1,$2,$3,$4,$5,$6)
+			agent_id, runtime_enabled, runtime_mode, starter_profile, outbound_credential_mode, inject_stored_bearer, lite_proxy_secret_detection_disabled
+		) VALUES ($1,$2,$3,$4,$5,$6,$7)
 		ON CONFLICT (agent_id) DO UPDATE SET
 			runtime_enabled = EXCLUDED.runtime_enabled,
 			runtime_mode = EXCLUDED.runtime_mode,
 			starter_profile = EXCLUDED.starter_profile,
 			outbound_credential_mode = EXCLUDED.outbound_credential_mode,
 			inject_stored_bearer = EXCLUDED.inject_stored_bearer,
+			lite_proxy_secret_detection_disabled = EXCLUDED.lite_proxy_secret_detection_disabled,
 			updated_at = NOW()
 	`, settings.AgentID, settings.RuntimeEnabled, settings.RuntimeMode, settings.StarterProfile,
-		settings.OutboundCredentialMode, settings.InjectStoredBearer)
+		settings.OutboundCredentialMode, settings.InjectStoredBearer, settings.LiteProxySecretDetectionDisabled)
 	return err
 }
 
@@ -3177,11 +3180,13 @@ func scanAgents(rows pgx.Rows) ([]*store.Agent, error) {
 		var settingsProfile *string
 		var settingsOutbound *string
 		var settingsInject *bool
+		var settingsLiteProxySecretDetectionDisabled *bool
 		var settingsCreatedAt *time.Time
 		var settingsUpdatedAt *time.Time
 		if err := rows.Scan(&a.ID, &a.UserID, &a.Name, &a.TokenHash, &a.CreatedAt, &orgID, &a.Description,
 			&a.ActiveTaskCount, &a.LastTaskAt, &settingsAgentID, &settingsEnabled, &settingsMode,
-			&settingsProfile, &settingsOutbound, &settingsInject, &settingsCreatedAt, &settingsUpdatedAt); err != nil {
+			&settingsProfile, &settingsOutbound, &settingsInject, &settingsLiteProxySecretDetectionDisabled,
+			&settingsCreatedAt, &settingsUpdatedAt); err != nil {
 			return nil, err
 		}
 		if orgID != nil {
@@ -3205,6 +3210,9 @@ func scanAgents(rows pgx.Rows) ([]*store.Agent, error) {
 			}
 			if settingsInject != nil {
 				a.RuntimeSettings.InjectStoredBearer = *settingsInject
+			}
+			if settingsLiteProxySecretDetectionDisabled != nil {
+				a.RuntimeSettings.LiteProxySecretDetectionDisabled = *settingsLiteProxySecretDetectionDisabled
 			}
 			if settingsCreatedAt != nil {
 				a.RuntimeSettings.CreatedAt = *settingsCreatedAt

--- a/pkg/store/sqlite/migrations/050_agent_lite_proxy_secret_detection_disabled.sql
+++ b/pkg/store/sqlite/migrations/050_agent_lite_proxy_secret_detection_disabled.sql
@@ -1,0 +1,2 @@
+ALTER TABLE agent_runtime_settings
+ADD COLUMN lite_proxy_secret_detection_disabled INTEGER NOT NULL DEFAULT 1;

--- a/pkg/store/sqlite/store.go
+++ b/pkg/store/sqlite/store.go
@@ -292,7 +292,8 @@ func (s *Store) ListAgents(ctx context.Context, userID string) ([]*store.Agent, 
 		                   AND t.status IN ('active','pending_approval','pending_scope_expansion')), 0),
 		       (SELECT MAX(t.created_at) FROM tasks t WHERE t.agent_id = a.id),
 		       ars.agent_id, ars.runtime_enabled, ars.runtime_mode, ars.starter_profile,
-		       ars.outbound_credential_mode, ars.inject_stored_bearer, ars.created_at, ars.updated_at
+		       ars.outbound_credential_mode, ars.inject_stored_bearer, ars.lite_proxy_secret_detection_disabled,
+		       ars.created_at, ars.updated_at
 		FROM agents a
 		LEFT JOIN agent_runtime_settings ars ON ars.agent_id = a.id
 		WHERE a.user_id = ? AND a.deleted_at IS NULL
@@ -316,11 +317,12 @@ func (s *Store) ListAgents(ctx context.Context, userID string) ([]*store.Agent, 
 		var settingsProfile *string
 		var settingsOutbound *string
 		var settingsInject *int
+		var settingsLiteProxySecretDetectionDisabled *int
 		var settingsCreatedAt *string
 		var settingsUpdatedAt *string
 		if err := rows.Scan(&a.ID, &a.UserID, &a.Name, &a.TokenHash, &createdAt, &orgID, &a.Description,
 			&a.ActiveTaskCount, &lastTaskAt, &settingsAgentID, &settingsEnabled, &settingsMode, &settingsProfile,
-			&settingsOutbound, &settingsInject, &settingsCreatedAt, &settingsUpdatedAt); err != nil {
+			&settingsOutbound, &settingsInject, &settingsLiteProxySecretDetectionDisabled, &settingsCreatedAt, &settingsUpdatedAt); err != nil {
 			return nil, err
 		}
 		a.CreatedAt = parseTime(createdAt)
@@ -331,7 +333,7 @@ func (s *Store) ListAgents(ctx context.Context, userID string) ([]*store.Agent, 
 			ts := parseTime(*lastTaskAt)
 			a.LastTaskAt = &ts
 		}
-		a.RuntimeSettings = scanSQLiteAgentRuntimeSettings(settingsAgentID, settingsEnabled, settingsMode, settingsProfile, settingsOutbound, settingsInject, settingsCreatedAt, settingsUpdatedAt)
+		a.RuntimeSettings = scanSQLiteAgentRuntimeSettings(settingsAgentID, settingsEnabled, settingsMode, settingsProfile, settingsOutbound, settingsInject, settingsLiteProxySecretDetectionDisabled, settingsCreatedAt, settingsUpdatedAt)
 		agents = append(agents, a)
 	}
 	return agents, rows.Err()
@@ -355,16 +357,17 @@ func (s *Store) UpdateAgentDescription(ctx context.Context, agentID, userID, des
 func (s *Store) GetAgentRuntimeSettings(ctx context.Context, agentID string) (*store.AgentRuntimeSettings, error) {
 	row := s.db.QueryRowContext(ctx, `
 		SELECT agent_id, runtime_enabled, runtime_mode, starter_profile,
-		       outbound_credential_mode, inject_stored_bearer, created_at, updated_at
+		       outbound_credential_mode, inject_stored_bearer, lite_proxy_secret_detection_disabled, created_at, updated_at
 		FROM agent_runtime_settings
 		WHERE agent_id = ?
 	`, agentID)
 	settings := &store.AgentRuntimeSettings{}
 	var runtimeEnabled int
 	var injectStoredBearer int
+	var liteProxySecretDetectionDisabled int
 	var createdAt, updatedAt string
 	err := row.Scan(&settings.AgentID, &runtimeEnabled, &settings.RuntimeMode, &settings.StarterProfile,
-		&settings.OutboundCredentialMode, &injectStoredBearer, &createdAt, &updatedAt)
+		&settings.OutboundCredentialMode, &injectStoredBearer, &liteProxySecretDetectionDisabled, &createdAt, &updatedAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, store.ErrNotFound
 	}
@@ -373,6 +376,7 @@ func (s *Store) GetAgentRuntimeSettings(ctx context.Context, agentID string) (*s
 	}
 	settings.RuntimeEnabled = runtimeEnabled != 0
 	settings.InjectStoredBearer = injectStoredBearer != 0
+	settings.LiteProxySecretDetectionDisabled = liteProxySecretDetectionDisabled != 0
 	settings.CreatedAt = parseTime(createdAt)
 	settings.UpdatedAt = parseTime(updatedAt)
 	return settings, nil
@@ -384,17 +388,18 @@ func (s *Store) UpsertAgentRuntimeSettings(ctx context.Context, settings *store.
 	}
 	_, err := s.db.ExecContext(ctx, `
 		INSERT INTO agent_runtime_settings (
-			agent_id, runtime_enabled, runtime_mode, starter_profile, outbound_credential_mode, inject_stored_bearer
-		) VALUES (?, ?, ?, ?, ?, ?)
+			agent_id, runtime_enabled, runtime_mode, starter_profile, outbound_credential_mode, inject_stored_bearer, lite_proxy_secret_detection_disabled
+		) VALUES (?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT (agent_id) DO UPDATE SET
 			runtime_enabled = excluded.runtime_enabled,
 			runtime_mode = excluded.runtime_mode,
 			starter_profile = excluded.starter_profile,
 			outbound_credential_mode = excluded.outbound_credential_mode,
 			inject_stored_bearer = excluded.inject_stored_bearer,
+			lite_proxy_secret_detection_disabled = excluded.lite_proxy_secret_detection_disabled,
 			updated_at = CURRENT_TIMESTAMP
 	`, settings.AgentID, boolToInt(settings.RuntimeEnabled), settings.RuntimeMode, settings.StarterProfile,
-		settings.OutboundCredentialMode, boolToInt(settings.InjectStoredBearer))
+		settings.OutboundCredentialMode, boolToInt(settings.InjectStoredBearer), boolToInt(settings.LiteProxySecretDetectionDisabled))
 	return err
 }
 
@@ -3576,7 +3581,7 @@ func rawJSONOrDefault(msg json.RawMessage, fallback string) string {
 	return string(msg)
 }
 
-func scanSQLiteAgentRuntimeSettings(agentID *string, runtimeEnabled *int, runtimeMode, starterProfile, outboundMode *string, injectStoredBearer *int, createdAt, updatedAt *string) *store.AgentRuntimeSettings {
+func scanSQLiteAgentRuntimeSettings(agentID *string, runtimeEnabled *int, runtimeMode, starterProfile, outboundMode *string, injectStoredBearer, liteProxySecretDetectionDisabled *int, createdAt, updatedAt *string) *store.AgentRuntimeSettings {
 	if agentID == nil {
 		return nil
 	}
@@ -3597,6 +3602,9 @@ func scanSQLiteAgentRuntimeSettings(agentID *string, runtimeEnabled *int, runtim
 	}
 	if injectStoredBearer != nil {
 		settings.InjectStoredBearer = *injectStoredBearer != 0
+	}
+	if liteProxySecretDetectionDisabled != nil {
+		settings.LiteProxySecretDetectionDisabled = *liteProxySecretDetectionDisabled != 0
 	}
 	if createdAt != nil {
 		settings.CreatedAt = parseTime(*createdAt)

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -414,14 +414,15 @@ type Agent struct {
 }
 
 type AgentRuntimeSettings struct {
-	AgentID                string    `json:"agent_id"`
-	RuntimeEnabled         bool      `json:"runtime_enabled"`
-	RuntimeMode            string    `json:"runtime_mode"`
-	StarterProfile         string    `json:"starter_profile"`
-	OutboundCredentialMode string    `json:"outbound_credential_mode"`
-	InjectStoredBearer     bool      `json:"inject_stored_bearer"`
-	CreatedAt              time.Time `json:"created_at"`
-	UpdatedAt              time.Time `json:"updated_at"`
+	AgentID                          string    `json:"agent_id"`
+	RuntimeEnabled                   bool      `json:"runtime_enabled"`
+	RuntimeMode                      string    `json:"runtime_mode"`
+	StarterProfile                   string    `json:"starter_profile"`
+	OutboundCredentialMode           string    `json:"outbound_credential_mode"`
+	InjectStoredBearer               bool      `json:"inject_stored_bearer"`
+	LiteProxySecretDetectionDisabled bool      `json:"lite_proxy_secret_detection_disabled"`
+	CreatedAt                        time.Time `json:"created_at"`
+	UpdatedAt                        time.Time `json:"updated_at"`
 }
 
 // ServiceMeta records that a user has activated a given service.

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -259,6 +259,7 @@ export interface AgentRuntimeSettings {
   starter_profile: string
   outbound_credential_mode: 'inherit' | 'observe' | 'strict'
   inject_stored_bearer: boolean
+  lite_proxy_secret_detection_disabled: boolean
   created_at?: string
   updated_at?: string
 }

--- a/web/src/pages/Agents.tsx
+++ b/web/src/pages/Agents.tsx
@@ -16,6 +16,7 @@ export default function Agents() {
   const qc = useQueryClient()
   const liveSessionsUI = !orgId && !!features?.agent_live_sessions
   const runtimePolicyUI = !orgId && !!features?.runtime_policy_ui
+  const proxyLiteUI = !orgId && !!features?.proxy_lite
   const [name, setName] = useState('')
   const [description, setDescription] = useState('')
   const [newToken, setNewToken] = useState<string | null>(null)
@@ -114,6 +115,7 @@ export default function Agents() {
         approvals={approvalsByAgent.get(selectedAgent.id) ?? []}
         liveSessionsUI={fullRuntimeSessionsUI}
         runtimePolicyUI={runtimePolicyUI}
+        proxyLiteUI={proxyLiteUI}
         onDeleted={() => {
           qc.invalidateQueries({ queryKey: ['agents'] })
           qc.invalidateQueries({ queryKey: ['tasks'] })
@@ -297,6 +299,7 @@ function AgentDetailView({
   approvals,
   liveSessionsUI,
   runtimePolicyUI,
+  proxyLiteUI,
   onDeleted,
 }: {
   agent: Agent
@@ -305,6 +308,7 @@ function AgentDetailView({
   approvals: ApprovalRecord[]
   liveSessionsUI: boolean
   runtimePolicyUI: boolean
+  proxyLiteUI: boolean
   onDeleted: () => void
 }) {
   const qc = useQueryClient()
@@ -317,7 +321,7 @@ function AgentDetailView({
   const { data: runtimeStatus } = useQuery({
     queryKey: ['runtime-status'],
     queryFn: () => api.runtime.status(),
-    enabled: runtimePolicyUI || liveSessionsUI,
+    enabled: runtimePolicyUI || liveSessionsUI || proxyLiteUI,
   })
   const { data: recentActivity } = useQuery({
     queryKey: ['audit', 'agent', agent.id],
@@ -351,7 +355,9 @@ function AgentDetailView({
     const rules = [...(allEgressRules?.entries ?? []), ...(allToolRules?.entries ?? [])]
     return rules.filter(rule => !rule.agent_id || rule.agent_id === agent.id)
   }, [agent.id, allEgressRules, allToolRules])
-  const proxyLiteActive = runtimePolicyUI && !!runtimeStatus?.proxy_lite_enabled
+  const proxyLiteActive = proxyLiteUI && !!runtimeStatus?.proxy_lite_enabled
+  const showRuntimeSettings = runtimePolicyUI && runtimeStatus?.enabled
+  const showAgentSettings = showRuntimeSettings || proxyLiteActive
 
   return (
     <div className="p-4 sm:p-8 space-y-8">
@@ -397,7 +403,7 @@ function AgentDetailView({
         </Link>
       </div>
 
-      {runtimePolicyUI && runtimeStatus?.enabled && <AgentRuntimePanel agentId={agent.id} defaultOpen />}
+      {showAgentSettings && <AgentRuntimePanel agentId={agent.id} defaultOpen showRuntimeControls={showRuntimeSettings} />}
 
       {proxyLiteActive && <AgentLiteProxyPanel agentId={agent.id} />}
       {proxyLiteActive && <AgentLLMCredentialsPanel agentId={agent.id} />}
@@ -548,7 +554,15 @@ function AgentMetric({ label, value }: { label: string; value: string }) {
   )
 }
 
-function AgentRuntimePanel({ agentId, defaultOpen = false }: { agentId: string; defaultOpen?: boolean }) {
+function AgentRuntimePanel({
+  agentId,
+  defaultOpen = false,
+  showRuntimeControls = true,
+}: {
+  agentId: string
+  defaultOpen?: boolean
+  showRuntimeControls?: boolean
+}) {
   const qc = useQueryClient()
   const [open, setOpen] = useState(defaultOpen)
   const { data: settings } = useQuery({
@@ -575,9 +589,11 @@ function AgentRuntimePanel({ agentId, defaultOpen = false }: { agentId: string; 
   })
 
   const current = draft ?? settings
+  const secretDetectionEnabled = current?.lite_proxy_secret_detection_disabled === false
+  const secretDetectionSummary = `secret detection ${secretDetectionEnabled ? 'on' : 'off'}`
 
   return (
-    <div className="mt-3 rounded border border-border-subtle bg-surface-0">
+    <div className="mt-3 overflow-hidden rounded border border-border-subtle bg-surface-0">
       <button
         onClick={() => {
           setOpen(v => !v)
@@ -586,73 +602,99 @@ function AgentRuntimePanel({ agentId, defaultOpen = false }: { agentId: string; 
         className="flex w-full items-center justify-between px-4 py-3 text-left"
       >
         <div>
-          <div className="text-sm font-medium text-text-primary">Runtime settings</div>
+          <div className="text-sm font-medium text-text-primary">{showRuntimeControls ? 'Runtime settings' : 'Agent settings'}</div>
           <div className="text-xs text-text-tertiary">
             {current
-              ? `${current.runtime_enabled ? 'enabled' : 'disabled'} · ${current.runtime_mode} · ${current.starter_profile || 'none'}`
-              : 'Configure observe vs enforce defaults, starter profile, and outbound credential posture.'}
+              ? showRuntimeControls
+                ? `${current.runtime_enabled ? 'enabled' : 'disabled'} · ${current.runtime_mode} · ${current.starter_profile || 'none'} · ${secretDetectionSummary}`
+                : `secret detection ${secretDetectionEnabled ? 'enabled' : 'disabled'}`
+              : showRuntimeControls
+                ? 'Configure observe vs enforce defaults, starter profile, and outbound credential posture.'
+                : 'Configure experimental agent controls.'}
           </div>
         </div>
         <span className="text-xs text-text-tertiary">{open ? 'Hide' : 'Edit'}</span>
       </button>
       {open && current && (
         <div className="border-t border-border-subtle px-4 py-4 space-y-3">
-          <div className="grid gap-3 md:grid-cols-2">
-            <label className="space-y-1">
-              <span className="text-xs text-text-tertiary">Runtime enabled</span>
-              <select
-                value={current.runtime_enabled ? 'true' : 'false'}
-                onChange={e => setDraft({ ...current, runtime_enabled: e.target.value === 'true' })}
-                className="w-full rounded border border-border-default bg-surface-1 px-3 py-2 text-sm text-text-primary"
-              >
-                <option value="true">Enabled</option>
-                <option value="false">Disabled</option>
-              </select>
-            </label>
-            <label className="space-y-1">
-              <span className="text-xs text-text-tertiary">Runtime mode</span>
-              <select
-                value={current.runtime_mode}
-                onChange={e => setDraft({ ...current, runtime_mode: e.target.value as AgentRuntimeSettings['runtime_mode'] })}
-                className="w-full rounded border border-border-default bg-surface-1 px-3 py-2 text-sm text-text-primary"
-              >
-                <option value="observe">Observe</option>
-                <option value="enforce">Enforce</option>
-              </select>
-            </label>
-            <label className="space-y-1">
-              <span className="text-xs text-text-tertiary">Starter profile</span>
-              <select
-                value={current.starter_profile}
-                onChange={e => setDraft({ ...current, starter_profile: e.target.value })}
-                className="w-full rounded border border-border-default bg-surface-1 px-3 py-2 text-sm text-text-primary"
-              >
-                <option value="none">None</option>
-                <option value="claude_code">Claude Code</option>
-                <option value="codex">Codex</option>
-              </select>
-            </label>
-            <label className="space-y-1">
-              <span className="text-xs text-text-tertiary">Outbound credential mode</span>
-              <select
-                value={current.outbound_credential_mode}
-                onChange={e => setDraft({ ...current, outbound_credential_mode: e.target.value as AgentRuntimeSettings['outbound_credential_mode'] })}
-                className="w-full rounded border border-border-default bg-surface-1 px-3 py-2 text-sm text-text-primary"
-              >
-                <option value="inherit">Inherit</option>
-                <option value="observe">Observe</option>
-                <option value="strict">Strict</option>
-              </select>
-            </label>
-          </div>
-          <label className="flex items-center gap-2 text-sm text-text-primary">
-            <input
-              type="checkbox"
-              checked={current.inject_stored_bearer}
-              onChange={e => setDraft({ ...current, inject_stored_bearer: e.target.checked })}
+          {showRuntimeControls && (
+            <>
+              <div className="grid gap-3 md:grid-cols-2">
+                <label className="space-y-1">
+                  <span className="text-xs text-text-tertiary">Runtime enabled</span>
+                  <select
+                    value={current.runtime_enabled ? 'true' : 'false'}
+                    onChange={e => setDraft({ ...current, runtime_enabled: e.target.value === 'true' })}
+                    className="w-full rounded border border-border-default bg-surface-1 px-3 py-2 text-sm text-text-primary"
+                  >
+                    <option value="true">Enabled</option>
+                    <option value="false">Disabled</option>
+                  </select>
+                </label>
+                <label className="space-y-1">
+                  <span className="text-xs text-text-tertiary">Runtime mode</span>
+                  <select
+                    value={current.runtime_mode}
+                    onChange={e => setDraft({ ...current, runtime_mode: e.target.value as AgentRuntimeSettings['runtime_mode'] })}
+                    className="w-full rounded border border-border-default bg-surface-1 px-3 py-2 text-sm text-text-primary"
+                  >
+                    <option value="observe">Observe</option>
+                    <option value="enforce">Enforce</option>
+                  </select>
+                </label>
+                <label className="space-y-1">
+                  <span className="text-xs text-text-tertiary">Starter profile</span>
+                  <select
+                    value={current.starter_profile}
+                    onChange={e => setDraft({ ...current, starter_profile: e.target.value })}
+                    className="w-full rounded border border-border-default bg-surface-1 px-3 py-2 text-sm text-text-primary"
+                  >
+                    <option value="none">None</option>
+                    <option value="claude_code">Claude Code</option>
+                    <option value="codex">Codex</option>
+                  </select>
+                </label>
+                <label className="space-y-1">
+                  <span className="text-xs text-text-tertiary">Outbound credential mode</span>
+                  <select
+                    value={current.outbound_credential_mode}
+                    onChange={e => setDraft({ ...current, outbound_credential_mode: e.target.value as AgentRuntimeSettings['outbound_credential_mode'] })}
+                    className="w-full rounded border border-border-default bg-surface-1 px-3 py-2 text-sm text-text-primary"
+                  >
+                    <option value="inherit">Inherit</option>
+                    <option value="observe">Observe</option>
+                    <option value="strict">Strict</option>
+                  </select>
+                </label>
+              </div>
+              <label className="flex items-center gap-2 text-sm text-text-primary">
+                <input
+                  type="checkbox"
+                  checked={current.inject_stored_bearer}
+                  onChange={e => setDraft({ ...current, inject_stored_bearer: e.target.checked })}
+                />
+                Inject stored bearer credentials
+              </label>
+            </>
+          )}
+          <div className="flex flex-wrap items-center justify-between gap-3 rounded border border-border-subtle bg-surface-1 px-4 py-3">
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-center gap-2">
+                <div className="text-sm font-medium text-text-primary">Detect raw secrets</div>
+                <span className="rounded border border-border-subtle px-2 py-0.5 text-[11px] uppercase tracking-wider text-text-tertiary">
+                  Experimental
+                </span>
+              </div>
+              <div className="mt-1 text-xs text-text-tertiary">
+                Scans agent LLM requests for raw secrets and pauses them so you can vault, discard, allow once, or mark them safe.
+              </div>
+            </div>
+            <SwitchControl
+              checked={secretDetectionEnabled}
+              onChange={checked => setDraft({ ...current, lite_proxy_secret_detection_disabled: !checked })}
+              label="Detect raw secrets"
             />
-            Inject stored bearer credentials
-          </label>
+          </div>
           <div className="flex justify-end">
             <button
               onClick={() => saveMut.mutate(current)}
@@ -665,6 +707,35 @@ function AgentRuntimePanel({ agentId, defaultOpen = false }: { agentId: string; 
         </div>
       )}
     </div>
+  )
+}
+
+function SwitchControl({
+  checked,
+  onChange,
+  label,
+}: {
+  checked: boolean
+  onChange: (checked: boolean) => void
+  label: string
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      onClick={() => onChange(!checked)}
+      className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/30 focus-visible:ring-offset-2 ${
+        checked ? 'bg-brand' : 'bg-border-strong'
+      }`}
+    >
+      <span
+        className={`pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform mt-0.5 ${
+          checked ? 'translate-x-[18px] ml-0' : 'translate-x-0.5'
+        }`}
+      />
+    </button>
   )
 }
 


### PR DESCRIPTION
Adds an opt-in experimental raw secret detection toggle for agent lite-proxy requests, defaulting detection off for new and unset runtime settings. Persists the setting through SQLite/Postgres, API/TUI client types, and the dashboard runtime settings panel. Skips lite-proxy secret decision handling, remembered rewrites, and hold/prompt scanning when disabled. Tests: go test ./internal/api/handlers ./pkg/store/sqlite ./pkg/store/postgres; cd web && npm run build.