### PR TITLE
fix(llmproxy): handle lite OpenAI chat approvals

### DIFF
--- a/internal/runtime/conversation/openai_request.go
+++ b/internal/runtime/conversation/openai_request.go
@@ -56,15 +56,32 @@ func OpenAIApprovalReply(body []byte) (verb, id string) {
 }
 
 func isOpenAIResponsesEndpoint(req *http.Request) bool {
-	return req != nil && req.URL != nil && (strings.HasPrefix(req.URL.Path, "/v1/responses") || strings.HasPrefix(req.URL.Path, "/backend-api/codex/responses"))
+	if req == nil || req.URL == nil {
+		return false
+	}
+	path := liteProxyProviderPath(req.URL.Path)
+	return strings.HasPrefix(path, "/v1/responses") || strings.HasPrefix(path, "/backend-api/codex/responses")
 }
 
 func isOpenAIChatCompletionsEndpoint(req *http.Request) bool {
-	return req != nil && req.URL != nil && strings.HasPrefix(req.URL.Path, "/v1/chat/completions")
+	if req == nil || req.URL == nil {
+		return false
+	}
+	return strings.HasPrefix(liteProxyProviderPath(req.URL.Path), "/v1/chat/completions")
 }
 
 func IsOpenAIChatCompletionsEndpoint(req *http.Request) bool {
 	return isOpenAIChatCompletionsEndpoint(req)
+}
+
+func liteProxyProviderPath(path string) string {
+	if path == "/api" {
+		return ""
+	}
+	if strings.HasPrefix(path, "/api/") {
+		return strings.TrimPrefix(path, "/api")
+	}
+	return path
 }
 
 func openAIResponsesToolResultIDs(body []byte) []string {

--- a/internal/runtime/conversation/response_test.go
+++ b/internal/runtime/conversation/response_test.go
@@ -7,6 +7,23 @@ import (
 	"testing"
 )
 
+func TestSyntheticApprovalToolUseResponseOpenAIChatLiteProxyRoute(t *testing.T) {
+	t.Parallel()
+
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/chat/completions", nil)
+	body := []byte(`{"messages":[{"role":"user","content":"approve"}]}`)
+	resp, ok := SyntheticApprovalToolUseResponse(req, ProviderOpenAI, body, true, "call_123", "write", map[string]any{"path": "index.html"})
+	if !ok {
+		t.Fatal("expected synthetic response")
+	}
+	if !strings.Contains(string(resp.Body), `"object":"chat.completion"`) {
+		t.Fatalf("expected chat completions response for lite-proxy route, got %s", resp.Body)
+	}
+	if !strings.Contains(string(resp.Body), `"tool_calls"`) {
+		t.Fatalf("expected chat tool_calls response, got %s", resp.Body)
+	}
+}
+
 func TestAnthropicResponseRewriterAllowsToolUseJSON(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/llmproxy/approval_body_editor_test.go
+++ b/internal/runtime/llmproxy/approval_body_editor_test.go
@@ -55,6 +55,15 @@ func TestApprovalBodyEditorProviderShapes(t *testing.T) {
 			want:      `"content":"` + replacement + `"`,
 		},
 		{
+			name:      "openai_chat_lite_proxy_route",
+			provider:  conversation.ProviderOpenAI,
+			path:      "/api/v1/chat/completions",
+			body:      `{"messages":[{"role":"user","content":"approve"}]}`,
+			wantReply: true,
+			wantVerb:  "approve",
+			want:      `"content":"` + replacement + `"`,
+		},
+		{
 			name:      "openai_responses_string_input",
 			provider:  conversation.ProviderOpenAI,
 			path:      "/v1/responses",
@@ -126,7 +135,7 @@ func TestApprovalBodyEditorProviderShapes(t *testing.T) {
 // internal/runtime/conversation.approvalReplyRE (cv- followed by 12 or
 // 26 alphanumeric chars).
 func TestReplaceLatestUserText_ApprovalIDExpectation(t *testing.T) {
-	const actualID = "cv-abcdef123456"   // 12-char body
+	const actualID = "cv-abcdef123456"    // 12-char body
 	const differentID = "cv-zzzzzz999999" // also 12-char, different
 
 	cases := []struct {
@@ -157,6 +166,12 @@ func TestReplaceLatestUserText_ApprovalIDExpectation(t *testing.T) {
 			name:     "openai_chat_string_content",
 			provider: conversation.ProviderOpenAI,
 			path:     "/v1/chat/completions",
+			body:     `{"messages":[{"role":"user","content":"approve ` + actualID + `"}]}`,
+		},
+		{
+			name:     "openai_chat_lite_proxy_route",
+			provider: conversation.ProviderOpenAI,
+			path:     "/api/v1/chat/completions",
 			body:     `{"messages":[{"role":"user","content":"approve ` + actualID + `"}]}`,
 		},
 	}
@@ -214,6 +229,12 @@ func TestReplaceLatestUserText_ApprovalIDExpectation(t *testing.T) {
 			name:     "openai_chat_bare",
 			provider: conversation.ProviderOpenAI,
 			path:     "/v1/chat/completions",
+			body:     `{"messages":[{"role":"user","content":"approve"}]}`,
+		},
+		{
+			name:     "openai_chat_lite_proxy_bare",
+			provider: conversation.ProviderOpenAI,
+			path:     "/api/v1/chat/completions",
 			body:     `{"messages":[{"role":"user","content":"approve"}]}`,
 		},
 		{


### PR DESCRIPTION
## Summary
- Normalize lite-proxy `/api/...` OpenAI routes before classifying chat completions vs Responses requests.
- Add regression coverage for `/api/v1/chat/completions` approval body rewriting and synthetic chat approval responses.

## Tests
- `go test ./internal/runtime/conversation ./internal/runtime/llmproxy`
- `go test ./internal/api/handlers`