### PR TITLE
feat(lite-proxy): add task checkout focus

### DIFF
--- a/internal/api/handlers/control.go
+++ b/internal/api/handlers/control.go
@@ -2,12 +2,22 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
+	"time"
+
+	"github.com/clawvisor/clawvisor/internal/api/middleware"
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy"
+	"github.com/clawvisor/clawvisor/pkg/store"
+	"github.com/google/uuid"
 )
 
 type LLMControlHandler struct {
-	BaseURL string
+	BaseURL       string
+	Store         store.Store
+	TaskCheckouts llmproxy.TaskCheckoutStore
+	Audit         *llmproxy.AuditEmitter
 }
 
 func NewLLMControlHandler(baseURL string) *LLMControlHandler {
@@ -25,7 +35,9 @@ func (h *LLMControlHandler) Capabilities(w http.ResponseWriter, r *http.Request)
 			{"method": "GET", "path": "/control/skill", "purpose": "Return schemas and examples for Clawvisor control-plane calls."},
 			{"method": "GET", "path": "/control/vault/items", "purpose": "List available vault item IDs that can be requested in a task."},
 			{"method": "GET", "path": "/control/vault/items/{id}", "purpose": "Return compact, non-secret metadata for one vault item ID."},
+			{"method": "GET", "path": "/control/tasks", "purpose": "List this agent's active tasks and current focus."},
 			{"method": "POST", "path": "/control/tasks", "purpose": "Create a task approval request for future tool use."},
+			{"method": "POST", "path": "/control/task/checkout", "purpose": "Set the current task focus for disambiguating later tool use."},
 			{"method": "GET", "path": "/control/tasks/{id}", "purpose": "Fetch task status."},
 			{"method": "POST", "path": "/control/tasks/{id}/expand", "purpose": "Request additional scope for an existing task."},
 		},
@@ -45,11 +57,17 @@ func (h *LLMControlHandler) Skill(w http.ResponseWriter, r *http.Request) {
 			"Clawvisor handles the synthetic URL before the shell command runs.",
 			"Before creating a task, tell me that you are requesting a Clawvisor task and that I will need to approve it.",
 			"Creating or expanding a task requests permission. It does not grant permission until I approve it.",
+			"When multiple active tasks exist, use /control/task/checkout to select the task you are actively working on. Checkout is only a routing preference; it does not grant new permission.",
 			"If you already have an autovault_... placeholder, do not call /control/vault/items just to identify it. Create the task for the intended API call, omit required_credentials, and use the placeholder directly after approval.",
 			"Use /control/vault/items only when you need Clawvisor to mint a new placeholder from an available vault item. The response is just IDs; do not pipe or shell-filter it. If you need non-secret metadata for one item, fetch /control/vault/items/{id}.",
 			"Prefer expected_tools for harness tools such as bash, exec_command, WebFetch, Read, Write, or Edit.",
 			"When a task needs a new credential placeholder, include required_credentials with a concrete vault_item_id or vault_item_handle plus a specific why. Do not ask the user to paste raw secrets into chat.",
 			"Task lifetime defaults to session. Use lifetime=session with expires_in_seconds for temporary permission; use lifetime=standing only when the user explicitly wants persistent permission, and never combine standing with expires_in_seconds.",
+		},
+		"list_tasks": map[string]any{
+			"method":  "GET",
+			"path":    "/control/tasks",
+			"purpose": "List active tasks for this agent, including the currently checked-out task focus.",
 		},
 		"create_task": map[string]any{
 			"method": "POST",
@@ -79,6 +97,13 @@ func (h *LLMControlHandler) Skill(w http.ResponseWriter, r *http.Request) {
 				"reason":       "Explain why the existing task scope is insufficient.",
 			},
 		},
+		"checkout_task": map[string]any{
+			"method": "POST",
+			"path":   "/control/task/checkout",
+			"body": map[string]any{
+				"task_id": "The active task id to prefer for later tool calls.",
+			},
+		},
 	})
 }
 
@@ -104,6 +129,191 @@ func (h *LLMControlHandler) Failure(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+type controlTaskSummary struct {
+	ID                string              `json:"id"`
+	Purpose           string              `json:"purpose"`
+	Status            string              `json:"status"`
+	Lifetime          string              `json:"lifetime,omitempty"`
+	ExpiresAt         *time.Time          `json:"expires_at,omitempty"`
+	AuthorizedActions []store.TaskAction  `json:"authorized_actions,omitempty"`
+	PlannedCalls      []store.PlannedCall `json:"planned_calls,omitempty"`
+	ExpectedTools     json.RawMessage     `json:"expected_tools,omitempty"`
+	ExpectedEgress    json.RawMessage     `json:"expected_egress,omitempty"`
+	CheckedOut        bool                `json:"checked_out"`
+}
+
+func (h *LLMControlHandler) ListTasks(w http.ResponseWriter, r *http.Request) {
+	agent := middleware.AgentFromContext(r.Context())
+	if agent == nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]any{
+			"error":   "unauthorized",
+			"message": "missing agent context",
+		})
+		return
+	}
+	if h.Store == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{
+			"error":   "task_list_unavailable",
+			"message": "task store is not configured",
+		})
+		return
+	}
+
+	tasks, _, err := h.Store.ListTasks(r.Context(), agent.UserID, store.TaskFilter{Status: "active"})
+	if err != nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{
+			"error":   "task_list_failed",
+			"message": "could not list active tasks",
+		})
+		return
+	}
+
+	checkoutID := ""
+	checkoutUnavailable := false
+	key := llmproxy.TaskCheckoutKey{UserID: agent.UserID, AgentID: agent.ID}
+	if h.TaskCheckouts != nil {
+		if checkout, ok, err := h.TaskCheckouts.Get(r.Context(), key); err != nil {
+			checkoutUnavailable = true
+		} else if ok {
+			checkoutID = strings.TrimSpace(checkout.TaskID)
+		}
+	}
+
+	now := time.Now()
+	summaries := make([]controlTaskSummary, 0, len(tasks))
+	checkoutStillActive := checkoutID == ""
+	for _, task := range tasks {
+		if task == nil || task.AgentID != agent.ID || task.Status != "active" {
+			continue
+		}
+		if task.ExpiresAt != nil && task.ExpiresAt.Before(now) {
+			_ = h.Store.UpdateTaskStatus(r.Context(), task.ID, "expired")
+			continue
+		}
+		checkedOut := task.ID == checkoutID
+		if checkedOut {
+			checkoutStillActive = true
+		}
+		summaries = append(summaries, controlTaskSummary{
+			ID:                task.ID,
+			Purpose:           task.Purpose,
+			Status:            task.Status,
+			Lifetime:          task.Lifetime,
+			ExpiresAt:         task.ExpiresAt,
+			AuthorizedActions: task.AuthorizedActions,
+			PlannedCalls:      task.PlannedCalls,
+			ExpectedTools:     task.ExpectedTools,
+			ExpectedEgress:    task.ExpectedEgress,
+			CheckedOut:        checkedOut,
+		})
+	}
+	if !checkoutStillActive && h.TaskCheckouts != nil {
+		_ = h.TaskCheckouts.Clear(r.Context(), key)
+		checkoutID = ""
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"active_task_id":       checkoutID,
+		"checkout_unavailable": checkoutUnavailable,
+		"total":                len(summaries),
+		"tasks":                summaries,
+		"next_step":            "To switch active tasks, POST /control/task/checkout with the target task_id. Checkout is only a routing preference; it does not grant new permission.",
+	})
+}
+
+func (h *LLMControlHandler) CheckoutTask(w http.ResponseWriter, r *http.Request) {
+	agent := middleware.AgentFromContext(r.Context())
+	if agent == nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]any{
+			"error":   "unauthorized",
+			"message": "missing agent context",
+		})
+		return
+	}
+	if h.Store == nil || h.TaskCheckouts == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{
+			"error":   "task_checkout_unavailable",
+			"message": "task checkout store is not configured",
+		})
+		return
+	}
+	var body struct {
+		TaskID string `json:"task_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{
+			"error":   "invalid_json",
+			"message": err.Error(),
+		})
+		return
+	}
+	taskID := strings.TrimSpace(body.TaskID)
+	if taskID == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]any{
+			"error":   "task_id_required",
+			"message": "task_id is required",
+		})
+		return
+	}
+	task, err := h.Store.GetTask(r.Context(), taskID)
+	if err != nil {
+		status := http.StatusServiceUnavailable
+		code := "task_lookup_failed"
+		if errors.Is(err, store.ErrNotFound) {
+			status = http.StatusNotFound
+			code = "task_not_found"
+		}
+		writeJSON(w, status, map[string]any{
+			"error":   code,
+			"message": "could not find an active task with that id for this agent",
+		})
+		return
+	}
+	if task.UserID != agent.UserID || task.AgentID != agent.ID || task.Status != "active" {
+		writeJSON(w, http.StatusForbidden, map[string]any{
+			"error":   "task_not_active_for_agent",
+			"message": "task_id must name an active task owned by this agent",
+		})
+		return
+	}
+	ttl := 24 * time.Hour
+	if task.ExpiresAt != nil {
+		untilExpiry := time.Until(*task.ExpiresAt)
+		if untilExpiry <= 0 {
+			writeJSON(w, http.StatusForbidden, map[string]any{
+				"error":   "task_expired",
+				"message": "task is expired and cannot be checked out",
+			})
+			return
+		}
+		ttl = untilExpiry
+	}
+	if err := h.TaskCheckouts.Set(r.Context(), llmproxy.TaskCheckoutKey{
+		UserID:  agent.UserID,
+		AgentID: agent.ID,
+	}, task.ID, ttl); err != nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{
+			"error":   "task_checkout_failed",
+			"message": err.Error(),
+		})
+		return
+	}
+	if h.Audit != nil {
+		h.Audit.LogEndpointCall(r.Context(), agent, uuid.NewString(), "clawvisor.control", "task.checkout", http.StatusOK, "allow", "checked_out", "", 0, map[string]any{
+			"task_id": task.ID,
+			"purpose": task.Purpose,
+		})
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"status":     "checked_out",
+		"task_id":    task.ID,
+		"purpose":    task.Purpose,
+		"expires_at": task.ExpiresAt,
+		"message":    "Task is checked out as the current focus. Clawvisor will prefer it only when it is a valid match for later tool calls.",
+		"next_step":  "Continue with the requested work using normal tool calls. Do not add task_id or extra fields to tool inputs.",
+	})
+}
+
 func (h *LLMControlHandler) NotFound(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusNotFound, map[string]any{
 		"error":   "control_endpoint_not_found",
@@ -113,7 +323,9 @@ func (h *LLMControlHandler) NotFound(w http.ResponseWriter, r *http.Request) {
 			"GET /control/skill",
 			"GET /control/vault/items",
 			"GET /control/vault/items/{id}",
+			"GET /control/tasks",
 			"POST /control/tasks",
+			"POST /control/task/checkout",
 			"GET /control/tasks/{id}",
 			"POST /control/tasks/{id}/expand",
 		},

--- a/internal/api/handlers/control_test.go
+++ b/internal/api/handlers/control_test.go
@@ -2,11 +2,18 @@ package handlers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy"
+	"github.com/clawvisor/clawvisor/pkg/store"
+	"github.com/clawvisor/clawvisor/pkg/store/sqlite"
 )
 
 func TestControlSkillCredentialExampleUsesCurrentVaultItemShape(t *testing.T) {
@@ -87,5 +94,109 @@ func TestControlFailureIncludesOriginalCommandContext(t *testing.T) {
 	}
 	if !strings.Contains(payload.NextStep, "/control/vault/items") {
 		t.Fatalf("expected retry guidance, got %+v", payload)
+	}
+}
+
+func TestControlListTasksReturnsAgentActiveTasksAndCheckout(t *testing.T) {
+	ctx := context.Background()
+	db, err := sqlite.New(ctx, filepath.Join(t.TempDir(), "control-tasks.db"))
+	if err != nil {
+		t.Fatalf("sqlite.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	st := sqlite.NewStore(db)
+
+	user, err := st.CreateUser(ctx, "control-list@test.example", "hash")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	agent, err := st.CreateAgent(ctx, user.ID, "agent", "token-hash")
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+	otherAgent, err := st.CreateAgent(ctx, user.ID, "other-agent", "other-token-hash")
+	if err != nil {
+		t.Fatalf("CreateAgent(other): %v", err)
+	}
+
+	expiresAt := time.Now().UTC().Add(time.Hour).Truncate(time.Second)
+	for _, task := range []*store.Task{
+		{
+			ID:            "task-active",
+			UserID:        user.ID,
+			AgentID:       agent.ID,
+			Purpose:       "Send the requested status email",
+			Status:        "active",
+			Lifetime:      "session",
+			ExpiresAt:     &expiresAt,
+			ExpectedTools: json.RawMessage(`[{"tool_name":"Bash","why":"Use curl"}]`),
+		},
+		{
+			ID:       "task-other-agent",
+			UserID:   user.ID,
+			AgentID:  otherAgent.ID,
+			Purpose:  "Other agent task",
+			Status:   "active",
+			Lifetime: "session",
+		},
+		{
+			ID:       "task-pending",
+			UserID:   user.ID,
+			AgentID:  agent.ID,
+			Purpose:  "Pending task",
+			Status:   "pending_approval",
+			Lifetime: "session",
+		},
+	} {
+		if err := st.CreateTask(ctx, task); err != nil {
+			t.Fatalf("CreateTask(%s): %v", task.ID, err)
+		}
+	}
+
+	checkouts := llmproxy.NewMemoryTaskCheckoutStore(time.Hour)
+	if err := checkouts.Set(ctx, llmproxy.TaskCheckoutKey{UserID: user.ID, AgentID: agent.ID}, "task-active", time.Hour); err != nil {
+		t.Fatalf("checkout.Set: %v", err)
+	}
+	h := &LLMControlHandler{
+		BaseURL:       "http://localhost:25297",
+		Store:         st,
+		TaskCheckouts: checkouts,
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/control/tasks", nil)
+	req = req.WithContext(store.WithAgent(req.Context(), agent))
+	res := httptest.NewRecorder()
+
+	h.ListTasks(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("ListTasks status=%d body=%s", res.Code, res.Body.String())
+	}
+	var payload struct {
+		ActiveTaskID string `json:"active_task_id"`
+		Total        int    `json:"total"`
+		Tasks        []struct {
+			ID         string          `json:"id"`
+			Purpose    string          `json:"purpose"`
+			Status     string          `json:"status"`
+			CheckedOut bool            `json:"checked_out"`
+			Tools      json.RawMessage `json:"expected_tools"`
+		} `json:"tasks"`
+		NextStep string `json:"next_step"`
+	}
+	if err := json.Unmarshal(res.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if payload.ActiveTaskID != "task-active" || payload.Total != 1 || len(payload.Tasks) != 1 {
+		t.Fatalf("unexpected task list payload: %+v", payload)
+	}
+	got := payload.Tasks[0]
+	if got.ID != "task-active" || got.Purpose == "" || got.Status != "active" || !got.CheckedOut {
+		t.Fatalf("unexpected task summary: %+v", got)
+	}
+	if !strings.Contains(string(got.Tools), "Bash") {
+		t.Fatalf("expected scope hints in task summary: %+v", got)
+	}
+	if !strings.Contains(payload.NextStep, "/control/task/checkout") {
+		t.Fatalf("expected checkout guidance, got %q", payload.NextStep)
 	}
 }

--- a/internal/api/handlers/inline_task_e2e_test.go
+++ b/internal/api/handlers/inline_task_e2e_test.go
@@ -160,13 +160,10 @@ func TestInlineTaskApprovalFullStateMachine(t *testing.T) {
 	}
 
 	// Rewritten user message carries the canonical inline-approval
-	// augmentation context. We intentionally do NOT include the
-	// per-task id/purpose in the rewrite — that would cause it to
-	// drift from the augmenter's rendering on subsequent turns (the
-	// augmenter scans history without DB access). The result
-	// struct still surfaces the task id for audit purposes.
+	// augmentation context, including the checked-out task id when
+	// checkout storage succeeds.
 	rewrittenBody := string(t4Result.Body)
-	if !strings.Contains(rewrittenBody, "task was created and approved by the user inline") {
+	if !strings.Contains(rewrittenBody, "task was created and approved by the user") {
 		t.Errorf("rewritten body missing canonical augmentation context; got %s", rewrittenBody)
 	}
 	if !strings.Contains(strings.ToLower(rewrittenBody), "do not post /control/tasks") {

--- a/internal/api/handlers/llm_endpoint.go
+++ b/internal/api/handlers/llm_endpoint.go
@@ -104,6 +104,10 @@ type LLMEndpointHandler struct {
 	// than the prior unconditional "task approved" claim).
 	InlineApprovalOutcomes llmproxy.InlineApprovalOutcomeStore
 
+	// TaskCheckouts stores the current task focus for an agent. The decision
+	// layer treats this as a preference among already-valid task candidates.
+	TaskCheckouts llmproxy.TaskCheckoutStore
+
 	// CallerNonces mints short-lived per-rewrite nonces that stand in
 	// for the agent's bearer token in the rewritten tool_use. The
 	// resolver-side middleware shares the same cache instance and
@@ -156,6 +160,7 @@ func NewLLMEndpointHandler(st store.Store, v vault.Vault, logger *slog.Logger) *
 		PendingApprovals:       llmproxy.NewMemoryPendingApprovalCache(10 * time.Minute),
 		PendingSecrets:         llmproxy.NewMemoryPendingSecretDecisionCache(10 * time.Minute),
 		InlineApprovalOutcomes: llmproxy.NewMemoryInlineApprovalOutcomeStore(24 * time.Hour),
+		TaskCheckouts:          llmproxy.NewMemoryTaskCheckoutStore(24 * time.Hour),
 		// Default in-process nonce cache; production wires the Redis-
 		// backed cache via WithCallerNonceCache. Cache instance is
 		// shared with the resolver-side middleware in production.
@@ -426,6 +431,7 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 		Audit:           h.AuditEmitter,
 		RequestID:       requestID,
 		Outcomes:        h.InlineApprovalOutcomes,
+		Checkouts:       h.TaskCheckouts,
 	}); inlineErr != nil {
 		auditStatus = http.StatusBadRequest
 		auditDecide = "deny"
@@ -448,6 +454,9 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 		auditParams["inline_task_outcome"] = inlineRewrite.Outcome
 		if inlineRewrite.TaskID != "" {
 			auditParams["inline_task_id"] = inlineRewrite.TaskID
+		}
+		if inlineRewrite.CheckedOut {
+			auditParams["inline_task_checked_out"] = true
 		}
 		if inlineRewrite.Reason != "" {
 			auditParams["inline_task_reason"] = inlineRewrite.Reason
@@ -768,6 +777,13 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 				"authorization inputs unavailable; please retry")
 			return
 		}
+		preferredTaskID, preferredTaskErr := h.checkedOutTaskID(r.Context(), agent, candidateTasks)
+		if preferredTaskErr != nil {
+			h.Logger.WarnContext(r.Context(), "lite-proxy task checkout lookup failed; continuing without preferred task",
+				"request_id", requestID, "agent_id", agent.ID, "err", preferredTaskErr.Error())
+			auditParams["task_checkout_unavailable"] = true
+			preferredTaskID = ""
+		}
 		h.Logger.DebugContext(r.Context(), "lite-proxy decision inputs loaded",
 			"request_id", requestID,
 			"agent_id", agent.ID,
@@ -776,6 +792,7 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 			"candidate_tasks", len(candidateTasks),
 			"tool_rules", len(toolRules),
 			"egress_rules", len(egressRules),
+			"preferred_task_id", preferredTaskID,
 		)
 		processed := llmproxy.Postprocess(r, full, upstreamCT, llmproxy.PostprocessConfig{
 			Inspector:        h.Inspector,
@@ -792,6 +809,7 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 			CandidateTasks:   candidateTasks,
 			ToolRules:        toolRules,
 			EgressRules:      egressRules,
+			PreferredTaskID:  preferredTaskID,
 			PendingApprovals: h.PendingApprovals,
 			ControlBaseURL:   h.ControlBaseURL,
 			// Per-tool-use nonce minting overrides RewriteOpts.CallerToken
@@ -1058,6 +1076,28 @@ func (h *LLMEndpointHandler) loadLiteProxyDecisionInputs(ctx context.Context, ag
 		egressRules = []*store.RuntimePolicyRule{}
 	}
 	return candidateTasks, toolRules, egressRules, nil
+}
+
+func (h *LLMEndpointHandler) checkedOutTaskID(ctx context.Context, agent *store.Agent, candidateTasks []*store.Task) (string, error) {
+	if h == nil || h.TaskCheckouts == nil || agent == nil {
+		return "", nil
+	}
+	checkout, ok, err := h.TaskCheckouts.Get(ctx, llmproxy.TaskCheckoutKey{
+		UserID:  agent.UserID,
+		AgentID: agent.ID,
+	})
+	if err != nil || !ok || strings.TrimSpace(checkout.TaskID) == "" {
+		return "", err
+	}
+	for _, task := range candidateTasks {
+		if task != nil && task.ID == checkout.TaskID && task.Status == "active" && task.AgentID == agent.ID {
+			return checkout.TaskID, nil
+		}
+	}
+	if err := h.TaskCheckouts.Clear(ctx, llmproxy.TaskCheckoutKey{UserID: agent.UserID, AgentID: agent.ID}); err != nil {
+		return "", err
+	}
+	return "", nil
 }
 
 func (h *LLMEndpointHandler) ensureDefaultToolRules(ctx context.Context, agent *store.Agent, availableTools []string) {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -109,6 +109,7 @@ type Server struct {
 	pendingSecrets     llmproxy.PendingSecretDecisionCache
 	liteApprovals      llmproxy.PendingApprovalCache
 	liteOutcomes       llmproxy.InlineApprovalOutcomeStore
+	taskCheckouts      llmproxy.TaskCheckoutStore
 
 	adapterGenFactory handlers.GeneratorFactory // per-request Generator factory; set via option
 }
@@ -355,6 +356,13 @@ func WithLiteApprovalCache(c llmproxy.PendingApprovalCache) ServerOption {
 // deployments so later turns can see approvals resolved by another instance.
 func WithLiteApprovalOutcomeStore(c llmproxy.InlineApprovalOutcomeStore) ServerOption {
 	return func(s *Server) { s.liteOutcomes = c }
+}
+
+// WithTaskCheckoutStore overrides the default in-memory proxy-lite task focus
+// store. Use a shared implementation in multi-instance deployments so checkout
+// state follows the agent across replicas.
+func WithTaskCheckoutStore(c llmproxy.TaskCheckoutStore) ServerOption {
+	return func(s *Server) { s.taskCheckouts = c }
 }
 
 // New creates a Server and registers all routes.
@@ -1257,9 +1265,17 @@ func (s *Server) registerLiteProxyRoutes(
 		} else if s.logger != nil && strings.EqualFold(strings.TrimSpace(s.cfg.Server.RouteSet), "proxy_lite") {
 			s.logger.Warn("lite-proxy: LiteApprovalOutcomeStore not configured — inline approval outcomes are process-local; use Redis for multi-instance proxy deployments")
 		}
+		if s.taskCheckouts != nil {
+			llmHandler.TaskCheckouts = s.taskCheckouts
+		} else if s.logger != nil && strings.EqualFold(strings.TrimSpace(s.cfg.Server.RouteSet), "proxy_lite") {
+			s.logger.Warn("lite-proxy: TaskCheckoutStore not configured — task focus is process-local; use Redis for multi-instance proxy deployments")
+		}
 		llmHandler.InlineTaskCreator = tasksHandler
 
 		controlHandler := handlers.NewLLMControlHandler(baseURL)
+		controlHandler.Store = s.store
+		controlHandler.TaskCheckouts = llmHandler.TaskCheckouts
+		controlHandler.Audit = auditEmitter
 		requireAgentLLM := middleware.RequireAgentLLM(s.store)
 		requireAgentLLMRL := func(h http.HandlerFunc) http.Handler {
 			agentLimited := middleware.RateLimit(gatewayRL, llmAgentKeyFn, gatewayLimit)(http.HandlerFunc(h))
@@ -1280,7 +1296,9 @@ func (s *Server) registerLiteProxyRoutes(
 		mux.Handle("GET /api/control/capabilities", http.HandlerFunc(controlHandler.Capabilities))
 		mux.Handle("GET /api/control/skill", http.HandlerFunc(controlHandler.Skill))
 		mux.Handle("POST /api/control/failure", requireAgentLLMCaller(e2e(http.HandlerFunc(controlHandler.Failure))))
+		mux.Handle("GET /api/control/tasks", requireAgentLLMCaller(e2e(http.HandlerFunc(controlHandler.ListTasks))))
 		mux.Handle("POST /api/control/tasks", requireAgentLLMCaller(e2e(http.HandlerFunc(tasksHandler.Create))))
+		mux.Handle("POST /api/control/task/checkout", requireAgentLLMCaller(e2e(http.HandlerFunc(controlHandler.CheckoutTask))))
 		mux.Handle("GET /api/control/tasks/{id}", requireAgentLLMCaller(e2e(http.HandlerFunc(tasksHandler.Get))))
 		mux.Handle("POST /api/control/tasks/{id}/expand", requireAgentLLMCaller(e2e(http.HandlerFunc(tasksHandler.Expand))))
 		mux.Handle("GET /api/control/vault/items", requireAgentLLMCaller(e2e(http.HandlerFunc(vaultHandler.ListForAgent))))

--- a/internal/runtime/llmproxy/approval_body_editor.go
+++ b/internal/runtime/llmproxy/approval_body_editor.go
@@ -270,7 +270,7 @@ func augmentAnthropicApprovedInlineTasks(body []byte, outcomes InlineApprovalOut
 		if verb != "approve" {
 			continue
 		}
-		if strings.Contains(userText, InlineApprovalAugmentationMarker) {
+		if containsInlineApprovalAugmentationMarker(userText) {
 			continue
 		}
 

--- a/internal/runtime/llmproxy/control.go
+++ b/internal/runtime/llmproxy/control.go
@@ -40,6 +40,7 @@ func controlNotice(controlBaseURL string, availableTools []string, toolRules []*
 	vaultItemsURL := "https://" + ControlSyntheticHost + ControlSyntheticPath + "/vault/items"
 	tasksURL := "https://" + ControlSyntheticHost + ControlSyntheticPath + "/tasks"
 	tasksURLInline := tasksURL + "?surface=inline"
+	taskCheckoutURL := "https://" + ControlSyntheticHost + ControlSyntheticPath + "/task/checkout"
 	toolExamples := controlToolExamples(availableTools)
 	shellTool := controlShellTool(availableTools)
 	shellToolExample := shellTool
@@ -61,6 +62,7 @@ func controlNotice(controlBaseURL string, availableTools []string, toolRules []*
 		"Task endpoint:",
 		"  - Interactive user present: POST " + tasksURLInline,
 		"  - Headless/background run: POST " + tasksURL,
+		"  - To switch focus among active tasks: POST " + taskCheckoutURL + " with {\"task_id\":\"<active task id>\"}. Checkout is only a preference among valid matches; it does not grant permission.",
 		"",
 		"Required task shape:",
 		"  {\"purpose\":\"<user-visible goal>\",",
@@ -817,12 +819,12 @@ func ParseControlToolUse(t conversation.ToolUse) (ControlCall, bool) {
 }
 
 func ParseControlToolUseWithBase(t conversation.ToolUse, controlBaseURL string) (ControlCall, bool) {
-	u, method, _, ok := controlCallParts(t, controlBaseURL)
+	u, method, body, ok := controlCallParts(t, controlBaseURL)
 	if !ok {
 		return ControlCall{}, false
 	}
 	if method == "" {
-		method = controlMethodForPath(u.Path)
+		method = controlMethodForCall(u.Path, body)
 	}
 	method = strings.ToUpper(strings.TrimSpace(method))
 	if method == "" {
@@ -1094,7 +1096,7 @@ func defaultPort(scheme string) string {
 }
 
 func controlVerdict(u *url.URL) inspector.Verdict {
-	return controlVerdictWithMethod(u, controlMethodForPath(u.Path))
+	return controlVerdictWithMethod(u, controlMethodForCall(u.Path, nil))
 }
 
 func controlVerdictWithMethod(u *url.URL, method string) inspector.Verdict {
@@ -1109,7 +1111,11 @@ func controlVerdictWithMethod(u *url.URL, method string) inspector.Verdict {
 }
 
 func controlMethodForPath(path string) string {
-	if strings.HasSuffix(path, "/tasks") {
+	return controlMethodForCall(path, nil)
+}
+
+func controlMethodForCall(path string, body []byte) string {
+	if strings.HasSuffix(path, "/tasks") && len(body) > 0 {
 		return "POST"
 	}
 	return "GET"

--- a/internal/runtime/llmproxy/control_multistmt_test.go
+++ b/internal/runtime/llmproxy/control_multistmt_test.go
@@ -69,6 +69,44 @@ func TestControlPartsFromCommandInput_ResolvesDataAtDashFromHeredoc(t *testing.T
 	}
 }
 
+func TestParseControlToolUse_BodylessTasksCurlIsGET(t *testing.T) {
+	tu := conversation.ToolUse{
+		ID:    "tu_1",
+		Name:  "Bash",
+		Input: json.RawMessage(`{"command":"curl -sS https://clawvisor.local/control/tasks"}`),
+	}
+
+	call, ok := ParseControlToolUse(tu)
+	if !ok {
+		t.Fatal("expected control call to parse")
+	}
+	if call.Method != "GET" {
+		t.Fatalf("method=%q, want GET for bodyless task list curl", call.Method)
+	}
+	if call.Verdict.Method != "GET" {
+		t.Fatalf("verdict method=%q, want GET", call.Verdict.Method)
+	}
+}
+
+func TestParseControlToolUse_TasksCurlWithBodyIsPOST(t *testing.T) {
+	tu := conversation.ToolUse{
+		ID:    "tu_1",
+		Name:  "Bash",
+		Input: json.RawMessage(`{"command":"curl -sS https://clawvisor.local/control/tasks --data '{\"purpose\":\"x\"}'"}`),
+	}
+
+	call, ok := ParseControlToolUse(tu)
+	if !ok {
+		t.Fatal("expected control call to parse")
+	}
+	if call.Method != "POST" {
+		t.Fatalf("method=%q, want POST for task creation curl with body", call.Method)
+	}
+	if call.Verdict.Method != "POST" {
+		t.Fatalf("verdict method=%q, want POST", call.Verdict.Method)
+	}
+}
+
 func TestParseControlCmd_MultiStmtCatHeredocPlusCurl(t *testing.T) {
 	args, dataFiles, ok := parseControlCmd(multiStmtCatCurlCmd)
 	if !ok {

--- a/internal/runtime/llmproxy/inline_approval_outcome.go
+++ b/internal/runtime/llmproxy/inline_approval_outcome.go
@@ -31,6 +31,9 @@ type InlineApprovalOutcome struct {
 	// ApprovalRecordID is populated on success when the canonical
 	// approval_records row was written.
 	ApprovalRecordID string
+	// CheckedOut is true when this inline-approved task was also stored
+	// as the agent's current task focus.
+	CheckedOut bool
 	// FailureReason is populated on failure — short, suitable for
 	// embedding in an LLM-facing context note.
 	FailureReason string

--- a/internal/runtime/llmproxy/inline_task_augment_test.go
+++ b/internal/runtime/llmproxy/inline_task_augment_test.go
@@ -434,7 +434,7 @@ func TestInlineFailedReplyAugmentationContextSanitizesReason(t *testing.T) {
 // Both now reduce to the bracketed context with no verb prefix.
 func TestAugment_OneShotAndPersistentProduceIdenticalText(t *testing.T) {
 	oneShot := inlineApprovedReplyAugmentation()
-	persistent := inlineApprovedReplyAugmentationContext(nil)
+	persistent := inlineApprovedReplyAugmentationContext("", false, nil)
 	if oneShot != persistent {
 		t.Fatalf("one-shot and persistent renderings differ — drift bug.\n  one-shot:\n%s\n  persistent:\n%s", oneShot, persistent)
 	}

--- a/internal/runtime/llmproxy/inline_task_intercept_test.go
+++ b/internal/runtime/llmproxy/inline_task_intercept_test.go
@@ -146,7 +146,7 @@ func TestInlineTask_PostprocessIntoRelease(t *testing.T) {
 	if !creator.called {
 		t.Fatal("Creator should have been invoked")
 	}
-	if !strings.Contains(string(rewrite.Body), "task was created and approved by the user inline") {
+	if !strings.Contains(string(rewrite.Body), "task was created and approved by the user") {
 		t.Fatalf("rewritten body missing canonical augmentation context: %s", rewrite.Body)
 	}
 	if rewrite.TaskID != "task-uuid-final" {

--- a/internal/runtime/llmproxy/inline_task_release_test.go
+++ b/internal/runtime/llmproxy/inline_task_release_test.go
@@ -83,6 +83,7 @@ func seedInlineTaskHolds(t *testing.T, cache *MemoryPendingApprovalCache) (outer
 
 func TestRewriteInlineTaskApproval_ApproveCreatesTaskAndRewritesBody(t *testing.T) {
 	cache := NewMemoryPendingApprovalCache(time.Minute)
+	checkouts := NewMemoryTaskCheckoutStore(time.Hour)
 	outerID, innerID := seedInlineTaskHolds(t, cache)
 
 	creator := &fakeInlineTaskCreator{
@@ -110,6 +111,7 @@ func TestRewriteInlineTaskApproval_ApproveCreatesTaskAndRewritesBody(t *testing.
 		Agent:           &store.Agent{ID: "agent-1", UserID: "user-1"},
 		PendingApproval: cache,
 		Creator:         creator,
+		Checkouts:       checkouts,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -126,17 +128,21 @@ func TestRewriteInlineTaskApproval_ApproveCreatesTaskAndRewritesBody(t *testing.
 	if len(out.Credentials) != 1 || out.Credentials[0].Placeholder != "autovault_agentphone_real123" {
 		t.Fatalf("expected minted credential placeholder in rewrite result, got %+v", out.Credentials)
 	}
+	if !out.CheckedOut {
+		t.Fatal("expected inline-approved task to be checked out")
+	}
+	checkout, ok, err := checkouts.Get(context.Background(), TaskCheckoutKey{UserID: "user-1", AgentID: "agent-1"})
+	if err != nil || !ok || checkout.TaskID != "task-uuid-123" {
+		t.Fatalf("checkout = %+v ok=%v err=%v, want task-uuid-123", checkout, ok, err)
+	}
 	if !creator.called {
 		t.Fatal("expected creator to be called")
 	}
 	if creator.gotOrigID != outerID {
 		t.Errorf("creator gotOrigID=%q, want %q", creator.gotOrigID, outerID)
 	}
-	// Body carries the canonical augmentation context. The per-task
-	// task_id is intentionally NOT in the rewrite — see the no-drift
-	// invariant in TestAugment_OneShotAndPersistentProduceIdenticalText.
 	rewrittenBody := string(out.Body)
-	if !strings.Contains(rewrittenBody, "task was created and approved by the user inline") {
+	if !strings.Contains(rewrittenBody, "task was created and approved by the user") {
 		t.Errorf("rewritten body missing canonical augmentation context: %s", rewrittenBody)
 	}
 	if !strings.Contains(strings.ToLower(rewrittenBody), "do not post /control/tasks") {
@@ -144,6 +150,10 @@ func TestRewriteInlineTaskApproval_ApproveCreatesTaskAndRewritesBody(t *testing.
 	}
 	if !strings.Contains(rewrittenBody, "agentphone=autovault_agentphone_real123") {
 		t.Errorf("rewritten body missing exact credential placeholder: %s", rewrittenBody)
+	}
+	if !strings.Contains(rewrittenBody, "Task task-uuid-123 is now the active task") ||
+		!strings.Contains(rewrittenBody, "https://clawvisor.local/control/tasks") {
+		t.Errorf("rewritten body missing active task guidance: %s", rewrittenBody)
 	}
 	// Both holds gone.
 	for _, id := range []string{outerID, innerID} {

--- a/internal/runtime/llmproxy/inline_task_rewrite.go
+++ b/internal/runtime/llmproxy/inline_task_rewrite.go
@@ -34,6 +34,9 @@ type InlineApprovalRewriteRequest struct {
 	// turns can re-inject the correct context (success vs. failure)
 	// instead of blindly claiming the task was created.
 	Outcomes InlineApprovalOutcomeStore
+	// Checkouts stores the created task as the agent's current focus on
+	// successful inline approval. Checkout is a routing preference only.
+	Checkouts TaskCheckoutStore
 }
 
 // InlineApprovalRewriteResult reports what happened. When Rewritten
@@ -60,6 +63,8 @@ type InlineApprovalRewriteResult struct {
 	// ApprovalRecordID is the canonical approval_records row id
 	// created at the same time as the task. Useful for audit traces.
 	ApprovalRecordID string
+	// CheckedOut reports whether the task was stored as current focus.
+	CheckedOut bool
 }
 
 // RewriteInlineTaskApprovalReply consumes an awaiting_task_approval
@@ -202,6 +207,7 @@ func inlineApprovalOutcomeFromRewrite(requestID string, out InlineApprovalRewrit
 		TaskID:           out.TaskID,
 		Credentials:      out.Credentials,
 		ApprovalRecordID: out.ApprovalRecordID,
+		CheckedOut:       out.CheckedOut,
 		FailureReason:    out.Reason,
 		RequestID:        requestID,
 		ResolvedAt:       time.Now().UTC(),
@@ -219,12 +225,21 @@ const InlineApprovalSubstitutedPromptMarker = "Clawvisor wants to create a task 
 // user message so subsequent passes can detect that a turn was
 // already augmented and skip it. Avoids double-augmentation across
 // retries / multi-step preprocess pipelines.
-const InlineApprovalAugmentationMarker = "[Clawvisor: inline task"
+const InlineApprovalAugmentationMarker = "[Clawvisor: task"
+
+// LegacyInlineApprovalAugmentationMarker keeps older synthetic history
+// recognizable after the user-visible wording was shortened.
+const LegacyInlineApprovalAugmentationMarker = "[Clawvisor: inline task"
 
 const (
 	InlineTaskDenyMarker         = "[Clawvisor: the user denied the task-creation request."
-	InlineTaskCreatorErrorMarker = "[Clawvisor: inline task creation failed"
+	InlineTaskCreatorErrorMarker = "[Clawvisor: task creation failed"
 )
+
+func containsInlineApprovalAugmentationMarker(text string) bool {
+	return strings.Contains(text, InlineApprovalAugmentationMarker) ||
+		strings.Contains(text, LegacyInlineApprovalAugmentationMarker)
+}
 
 // AugmentApprovedInlineTasksInHistory walks the conversation history
 // and re-injects the "[Clawvisor: ... task approved inline ...]"
@@ -280,7 +295,7 @@ func augmentationContextForOutcome(key InlineApprovalOutcomeKey, store InlineApp
 		return "", false
 	}
 	if outcome.Succeeded {
-		return inlineApprovedReplyAugmentationContext(outcome.Credentials), true
+		return inlineApprovedReplyAugmentationContext(outcome.TaskID, outcome.CheckedOut, outcome.Credentials), true
 	}
 	return inlineFailedReplyAugmentationContext(outcome.FailureReason), true
 }
@@ -337,18 +352,28 @@ func sanitizeFailureReasonForBracketEnvelope(reason string) string {
 // "approve" message wholesale with this bracketed context. Leaving
 // "approve" on its own line would still parse as a fresh bare
 // approval to a downstream re-parse; the bracketed text fully
-// conveys what happened ("created and approved by the user inline")
+// conveys what happened ("created and approved by the user")
 // without that sharp edge.
 func inlineApprovedReplyAugmentation() string {
-	return inlineApprovedReplyAugmentationContext(nil)
+	return inlineApprovedReplyAugmentationContext("", false, nil)
 }
 
 // inlineApprovedReplyAugmentationContext is the bracketed body shared
 // between the one-shot rewrite and the persistent augmenter.
-func inlineApprovedReplyAugmentationContext(credentials []InlineTaskCredentialPlaceholder) string {
+func inlineApprovedReplyAugmentationContext(taskID string, checkedOut bool, credentials []InlineTaskCredentialPlaceholder) string {
 	var b strings.Builder
 	b.WriteString(InlineApprovalAugmentationMarker)
-	b.WriteString(" was created and approved by the user inline. Approval source: inline_chat. The task covers the originally requested work; proceed by emitting your next tool_use(s). Do NOT POST /control/tasks again for the same work — that would create a duplicate task. If your earlier tool_use already completed successfully (you can see a successful tool_result above), do NOT re-emit it; move on to the next step.")
+	b.WriteString(" was created and approved by the user. The task covers the originally requested work; proceed by emitting your next tool_use(s). Do NOT POST /control/tasks again for the same work. If an earlier tool_use already completed successfully, do NOT re-emit it; move on to the next step using the results above.")
+	if strings.TrimSpace(taskID) != "" {
+		b.WriteString(" Task ID: ")
+		b.WriteString(strings.TrimSpace(taskID))
+		b.WriteString(".")
+	}
+	if checkedOut && strings.TrimSpace(taskID) != "" {
+		b.WriteString(" Task ")
+		b.WriteString(strings.TrimSpace(taskID))
+		b.WriteString(" is now the active task. To switch active tasks, fetch https://clawvisor.local/control/tasks, then POST https://clawvisor.local/control/task/checkout with the target task_id.")
+	}
 	if len(credentials) > 0 {
 		b.WriteString(" Credential placeholders granted for this task:")
 		for _, cred := range credentials {

--- a/internal/runtime/llmproxy/inline_task_transitions.go
+++ b/internal/runtime/llmproxy/inline_task_transitions.go
@@ -94,6 +94,14 @@ func resolveInlineTaskApproval(ctx context.Context, req InlineApprovalRewriteReq
 		out.TaskID = created.ID
 		out.ApprovalRecordID = created.ApprovalRecordID
 		out.Credentials = created.Credentials
+		if req.Checkouts != nil && req.Agent != nil && created.ID != "" {
+			if err := req.Checkouts.Set(ctx, TaskCheckoutKey{
+				UserID:  req.Agent.UserID,
+				AgentID: req.Agent.ID,
+			}, created.ID, 0); err == nil {
+				out.CheckedOut = true
+			}
+		}
 		if req.Audit != nil {
 			req.Audit.LogInlineTaskApproved(ctx, req.Agent, req.RequestID, resolved, created)
 		}
@@ -101,6 +109,6 @@ func resolveInlineTaskApproval(ctx context.Context, req InlineApprovalRewriteReq
 		// subsequent turns. One canonical rendering avoids showing the
 		// model the same user approve turn with different content across
 		// calls.
-		return inlineApprovedReplyAugmentationContext(created.Credentials), out
+		return inlineApprovedReplyAugmentationContext(created.ID, out.CheckedOut, created.Credentials), out
 	}
 }

--- a/internal/runtime/llmproxy/postprocess.go
+++ b/internal/runtime/llmproxy/postprocess.go
@@ -114,10 +114,11 @@ type PostprocessConfig struct {
 	// Postprocess authorizes through pkg/runtime/decision after inspector
 	// boundary validation. When all are nil, it falls back to the legacy
 	// Catalog/TaskScope flow for compatibility with older tests/configs.
-	Posture        runtimedecision.EvaluationPosture
-	CandidateTasks []*store.Task
-	ToolRules      []*store.RuntimePolicyRule
-	EgressRules    []*store.RuntimePolicyRule
+	Posture         runtimedecision.EvaluationPosture
+	CandidateTasks  []*store.Task
+	ToolRules       []*store.RuntimePolicyRule
+	EgressRules     []*store.RuntimePolicyRule
+	PreferredTaskID string
 
 	PendingApprovals PendingApprovalCache
 
@@ -374,6 +375,7 @@ func Postprocess(req *http.Request, body []byte, contentType string, cfg Postpro
 					CandidateTasks:         cfg.CandidateTasks,
 					ToolRules:              cfg.ToolRules,
 					EgressRules:            cfg.EgressRules,
+					PreferredTaskID:        cfg.PreferredTaskID,
 					IntentVerifier:         decisionIntentVerifier{inner: cfg.IntentVerifier},
 					SkipIntentVerification: readOnlyShellCommand,
 				}
@@ -480,17 +482,18 @@ func Postprocess(req *http.Request, body []byte, contentType string, cfg Postpro
 				resolved, _ = cfg.Catalog.Resolve(v.Host, v.Method, v.Path)
 			}
 			decisionInput := runtimedecision.AuthorizationInput{
-				ToolUse:        tu,
-				UserID:         cfg.AgentUserID,
-				AgentID:        cfg.AgentID,
-				Posture:        cfg.Posture,
-				Target:         runtimedecision.TargetRequest{Host: v.Host, Method: v.Method, Path: v.Path},
-				Service:        resolved.ServiceID,
-				Action:         resolved.ActionID,
-				CandidateTasks: cfg.CandidateTasks,
-				ToolRules:      cfg.ToolRules,
-				EgressRules:    cfg.EgressRules,
-				IntentVerifier: decisionIntentVerifier{inner: cfg.IntentVerifier},
+				ToolUse:         tu,
+				UserID:          cfg.AgentUserID,
+				AgentID:         cfg.AgentID,
+				Posture:         cfg.Posture,
+				Target:          runtimedecision.TargetRequest{Host: v.Host, Method: v.Method, Path: v.Path},
+				Service:         resolved.ServiceID,
+				Action:          resolved.ActionID,
+				CandidateTasks:  cfg.CandidateTasks,
+				ToolRules:       cfg.ToolRules,
+				EgressRules:     cfg.EgressRules,
+				PreferredTaskID: cfg.PreferredTaskID,
+				IntentVerifier:  decisionIntentVerifier{inner: cfg.IntentVerifier},
 			}
 			dec, err := runtimedecision.EvaluateAuthorization(req.Context(), decisionInput)
 			if err != nil {

--- a/internal/runtime/llmproxy/secret_detection.go
+++ b/internal/runtime/llmproxy/secret_detection.go
@@ -474,6 +474,7 @@ func stripClawvisorGeneratedMarkers(value string) string {
 		InlineApprovalIDMarker,
 		InlineApprovalSubstitutedPromptMarker,
 		InlineApprovalAugmentationMarker,
+		LegacyInlineApprovalAugmentationMarker,
 		InlineTaskDenyMarker,
 		InlineTaskCreatorErrorMarker,
 		SecretDecisionIDMarker,

--- a/internal/runtime/llmproxy/synthetic_history_strip.go
+++ b/internal/runtime/llmproxy/synthetic_history_strip.go
@@ -99,7 +99,7 @@ func isSyntheticApprovalPromptText(text string) bool {
 }
 
 func isBareSyntheticApprovalReply(text string) bool {
-	if strings.Contains(text, InlineApprovalAugmentationMarker) ||
+	if containsInlineApprovalAugmentationMarker(text) ||
 		strings.Contains(text, InlineTaskDenyMarker) ||
 		strings.Contains(text, InlineTaskCreatorErrorMarker) {
 		return false

--- a/internal/runtime/llmproxy/task_checkout.go
+++ b/internal/runtime/llmproxy/task_checkout.go
@@ -1,0 +1,100 @@
+package llmproxy
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// TaskCheckoutKey scopes the agent's current task focus. This is deliberately
+// an authorization hint only: decision logic must still verify the checked-out
+// task is a valid candidate for the concrete tool/API call.
+type TaskCheckoutKey struct {
+	UserID  string
+	AgentID string
+}
+
+// TaskCheckout records the task an agent is currently focused on.
+type TaskCheckout struct {
+	TaskID    string
+	UpdatedAt time.Time
+	ExpiresAt time.Time
+}
+
+// TaskCheckoutStore persists per-agent task focus for lite-proxy sessions.
+type TaskCheckoutStore interface {
+	Set(ctx context.Context, key TaskCheckoutKey, taskID string, ttl time.Duration) error
+	Get(ctx context.Context, key TaskCheckoutKey) (TaskCheckout, bool, error)
+	Clear(ctx context.Context, key TaskCheckoutKey) error
+}
+
+type MemoryTaskCheckoutStore struct {
+	defaultTTL time.Duration
+
+	mu      sync.Mutex
+	entries map[TaskCheckoutKey]TaskCheckout
+}
+
+func NewMemoryTaskCheckoutStore(defaultTTL time.Duration) *MemoryTaskCheckoutStore {
+	if defaultTTL <= 0 {
+		defaultTTL = 24 * time.Hour
+	}
+	return &MemoryTaskCheckoutStore{
+		defaultTTL: defaultTTL,
+		entries:    map[TaskCheckoutKey]TaskCheckout{},
+	}
+}
+
+func (s *MemoryTaskCheckoutStore) Set(_ context.Context, key TaskCheckoutKey, taskID string, ttl time.Duration) error {
+	if key.UserID == "" || key.AgentID == "" || taskID == "" {
+		return nil
+	}
+	if ttl <= 0 {
+		ttl = s.defaultTTL
+	}
+	now := time.Now().UTC()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.gcLocked(now)
+	s.entries[key] = TaskCheckout{
+		TaskID:    taskID,
+		UpdatedAt: now,
+		ExpiresAt: now.Add(ttl),
+	}
+	return nil
+}
+
+func (s *MemoryTaskCheckoutStore) Get(_ context.Context, key TaskCheckoutKey) (TaskCheckout, bool, error) {
+	if key.UserID == "" || key.AgentID == "" {
+		return TaskCheckout{}, false, nil
+	}
+	now := time.Now().UTC()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entry, ok := s.entries[key]
+	if !ok {
+		return TaskCheckout{}, false, nil
+	}
+	if !entry.ExpiresAt.IsZero() && now.After(entry.ExpiresAt) {
+		delete(s.entries, key)
+		return TaskCheckout{}, false, nil
+	}
+	return entry, true, nil
+}
+
+func (s *MemoryTaskCheckoutStore) Clear(_ context.Context, key TaskCheckoutKey) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.entries, key)
+	return nil
+}
+
+func (s *MemoryTaskCheckoutStore) gcLocked(now time.Time) {
+	for key, entry := range s.entries {
+		if !entry.ExpiresAt.IsZero() && now.After(entry.ExpiresAt) {
+			delete(s.entries, key)
+		}
+	}
+}
+
+var _ TaskCheckoutStore = (*MemoryTaskCheckoutStore)(nil)

--- a/internal/runtime/llmproxy/task_checkout_redis.go
+++ b/internal/runtime/llmproxy/task_checkout_redis.go
@@ -1,0 +1,83 @@
+package llmproxy
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const redisTaskCheckoutPrefix = "clawvisor:lite_task_checkout:"
+
+type RedisTaskCheckoutStore struct {
+	rdb        *redis.Client
+	defaultTTL time.Duration
+	now        func() time.Time
+}
+
+func NewRedisTaskCheckoutStore(rdb *redis.Client, defaultTTL time.Duration) *RedisTaskCheckoutStore {
+	if defaultTTL <= 0 {
+		defaultTTL = 24 * time.Hour
+	}
+	return &RedisTaskCheckoutStore{rdb: rdb, defaultTTL: defaultTTL, now: time.Now}
+}
+
+func (s *RedisTaskCheckoutStore) Set(ctx context.Context, key TaskCheckoutKey, taskID string, ttl time.Duration) error {
+	if s == nil || s.rdb == nil || key.UserID == "" || key.AgentID == "" || taskID == "" {
+		return nil
+	}
+	if ttl <= 0 {
+		ttl = s.defaultTTL
+	}
+	now := s.now().UTC()
+	checkout := TaskCheckout{
+		TaskID:    taskID,
+		UpdatedAt: now,
+		ExpiresAt: now.Add(ttl),
+	}
+	raw, err := json.Marshal(checkout)
+	if err != nil {
+		return err
+	}
+	return s.rdb.Set(ctx, redisTaskCheckoutKey(key), raw, ttl).Err()
+}
+
+func (s *RedisTaskCheckoutStore) Get(ctx context.Context, key TaskCheckoutKey) (TaskCheckout, bool, error) {
+	if s == nil || s.rdb == nil || key.UserID == "" || key.AgentID == "" {
+		return TaskCheckout{}, false, nil
+	}
+	raw, err := s.rdb.Get(ctx, redisTaskCheckoutKey(key)).Bytes()
+	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			return TaskCheckout{}, false, nil
+		}
+		return TaskCheckout{}, false, err
+	}
+	var checkout TaskCheckout
+	if err := json.Unmarshal(raw, &checkout); err != nil {
+		return TaskCheckout{}, false, err
+	}
+	if !checkout.ExpiresAt.IsZero() && s.now().UTC().After(checkout.ExpiresAt) {
+		_ = s.rdb.Del(ctx, redisTaskCheckoutKey(key)).Err()
+		return TaskCheckout{}, false, nil
+	}
+	return checkout, true, nil
+}
+
+func (s *RedisTaskCheckoutStore) Clear(ctx context.Context, key TaskCheckoutKey) error {
+	if s == nil || s.rdb == nil || key.UserID == "" || key.AgentID == "" {
+		return nil
+	}
+	return s.rdb.Del(ctx, redisTaskCheckoutKey(key)).Err()
+}
+
+func redisTaskCheckoutKey(key TaskCheckoutKey) string {
+	sum := sha256.Sum256([]byte(key.UserID + "\x00" + key.AgentID))
+	return redisTaskCheckoutPrefix + hex.EncodeToString(sum[:])
+}
+
+var _ TaskCheckoutStore = (*RedisTaskCheckoutStore)(nil)

--- a/internal/runtime/policy/request_classify.go
+++ b/internal/runtime/policy/request_classify.go
@@ -33,6 +33,10 @@ type GatewayRequestResolver interface {
 }
 
 func ClassifyGatewayRequest(tasks []*store.Task, agentID, serviceType, alias, action string) GatewayRequestClassification {
+	return ClassifyGatewayRequestPreferred(tasks, agentID, serviceType, alias, action, "")
+}
+
+func ClassifyGatewayRequestPreferred(tasks []*store.Task, agentID, serviceType, alias, action, preferredTaskID string) GatewayRequestClassification {
 	candidates := make([]*store.Task, 0, len(tasks))
 	for _, task := range tasks {
 		if task == nil || task.AgentID != agentID || task.Status != "active" {
@@ -63,6 +67,14 @@ func ClassifyGatewayRequest(tasks []*store.Task, agentID, serviceType, alias, ac
 			MatchedTask: inScope[0],
 		}
 	default:
+		for _, task := range inScope {
+			if preferredTaskID != "" && task.ID == preferredTaskID {
+				return GatewayRequestClassification{
+					Kind:        ClassificationBelongsToExistingTask,
+					MatchedTask: task,
+				}
+			}
+		}
 		return GatewayRequestClassification{
 			Kind:           ClassificationAmbiguous,
 			CandidateTasks: inScope,

--- a/internal/runtime/policy/task_match.go
+++ b/internal/runtime/policy/task_match.go
@@ -32,50 +32,88 @@ type EgressMatch struct {
 }
 
 func MatchToolCall(tasks []*store.Task, toolName string, input map[string]any) (*ToolMatch, error) {
+	return MatchToolCallPreferred(tasks, toolName, input, "")
+}
+
+func MatchToolCallPreferred(tasks []*store.Task, toolName string, input map[string]any, preferredTaskID string) (*ToolMatch, error) {
+	if preferredTaskID != "" {
+		match, err := matchToolCallInTask(tasks, toolName, input, preferredTaskID)
+		if err != nil || match != nil {
+			return match, err
+		}
+	}
 	var best *ToolMatch
 	bestScore := -1
 	for _, task := range tasks {
-		env, err := runtimetasks.EnvelopeFromTask(task)
+		match, score, err := bestToolMatchInTask(task, toolName, input)
 		if err != nil {
 			return nil, err
 		}
-		for _, item := range env.ExpectedTools {
-			// Tool-name match. Two layers:
-			//
-			// 1. Case-insensitive equality — handles the model
-			//    pattern-matching from documentation and emitting the
-			//    lowercase form (`bash` instead of `Bash`).
-			// 2. Tool-class equivalence — handles cross-harness aliases
-			//    (Claude Code says `Bash`, Codex says `exec_command`;
-			//    Claude Code says `Read`, Codex says `read_file`).
-			//
-			// A task created in a Claude Code session that declares
-			// `Bash` should cover the same work in a Codex session
-			// that uses `exec_command`. The model doesn't always know
-			// which harness it's in; the task does what it semantically
-			// said, not what the literal string matched.
-			if !toolNamesMatch(item.ToolName, toolName) {
-				continue
-			}
-			if item.InputRegex != "" {
-				if ok, err := matchRegexMap(item.InputRegex, input); err != nil || !ok {
-					if err != nil {
-						return nil, err
-					}
-					continue
-				}
-			}
-			if !matchShape(item.InputShape, input) {
-				continue
-			}
-			score := toolMatchSpecificity(item)
-			if score > bestScore {
-				bestScore = score
-				best = &ToolMatch{TaskID: task.ID, Item: item}
-			}
+		if match != nil && score > bestScore {
+			bestScore = score
+			best = match
 		}
 	}
 	return best, nil
+}
+
+func matchToolCallInTask(tasks []*store.Task, toolName string, input map[string]any, taskID string) (*ToolMatch, error) {
+	for _, task := range tasks {
+		if task == nil || task.ID != taskID {
+			continue
+		}
+		match, _, err := bestToolMatchInTask(task, toolName, input)
+		return match, err
+	}
+	return nil, nil
+}
+
+func bestToolMatchInTask(task *store.Task, toolName string, input map[string]any) (*ToolMatch, int, error) {
+	if task == nil {
+		return nil, -1, nil
+	}
+	env, err := runtimetasks.EnvelopeFromTask(task)
+	if err != nil {
+		return nil, -1, err
+	}
+	var best *ToolMatch
+	bestScore := -1
+	for _, item := range env.ExpectedTools {
+		// Tool-name match. Two layers:
+		//
+		// 1. Case-insensitive equality — handles the model
+		//    pattern-matching from documentation and emitting the
+		//    lowercase form (`bash` instead of `Bash`).
+		// 2. Tool-class equivalence — handles cross-harness aliases
+		//    (Claude Code says `Bash`, Codex says `exec_command`;
+		//    Claude Code says `Read`, Codex says `read_file`).
+		//
+		// A task created in a Claude Code session that declares
+		// `Bash` should cover the same work in a Codex session
+		// that uses `exec_command`. The model doesn't always know
+		// which harness it's in; the task does what it semantically
+		// said, not what the literal string matched.
+		if !toolNamesMatch(item.ToolName, toolName) {
+			continue
+		}
+		if item.InputRegex != "" {
+			if ok, err := matchRegexMap(item.InputRegex, input); err != nil || !ok {
+				if err != nil {
+					return nil, -1, err
+				}
+				continue
+			}
+		}
+		if !matchShape(item.InputShape, input) {
+			continue
+		}
+		score := toolMatchSpecificity(item)
+		if score > bestScore {
+			bestScore = score
+			best = &ToolMatch{TaskID: task.ID, Item: item}
+		}
+	}
+	return best, bestScore, nil
 }
 
 // toolNamesMatch decides whether a tool-call's actual name matches a
@@ -101,48 +139,86 @@ func toolClass(name string) string {
 }
 
 func MatchEgressRequest(tasks []*store.Task, req EgressRequest) (*EgressMatch, error) {
+	return MatchEgressRequestPreferred(tasks, req, "")
+}
+
+func MatchEgressRequestPreferred(tasks []*store.Task, req EgressRequest, preferredTaskID string) (*EgressMatch, error) {
 	host := strings.ToLower(req.Host)
 	method := strings.ToUpper(req.Method)
+	if preferredTaskID != "" {
+		match, err := matchEgressRequestInTask(tasks, req, host, method, preferredTaskID)
+		if err != nil || match != nil {
+			return match, err
+		}
+	}
 	var best *EgressMatch
 	bestScore := -1
 	for _, task := range tasks {
-		env, err := runtimetasks.EnvelopeFromTask(task)
+		match, score, err := bestEgressMatchInTask(task, req, host, method)
 		if err != nil {
 			return nil, err
 		}
-		for _, item := range env.ExpectedEgress {
-			if strings.ToLower(item.Host) != host {
-				continue
-			}
-			if item.Method != "" && strings.ToUpper(item.Method) != method {
-				continue
-			}
-			if item.Path != "" && item.Path != req.Path {
-				continue
-			}
-			if item.PathRegex != "" {
-				ok, err := regexp.MatchString(item.PathRegex, req.Path)
-				if err != nil {
-					return nil, err
-				}
-				if !ok {
-					continue
-				}
-			}
-			if !matchShape(item.QueryShape, req.Query) || !matchShape(item.BodyShape, req.Body) {
-				continue
-			}
-			if !matchHeaders(item.Headers, req.Headers) {
-				continue
-			}
-			score := egressMatchSpecificity(item)
-			if score > bestScore {
-				bestScore = score
-				best = &EgressMatch{TaskID: task.ID, Item: item}
-			}
+		if match != nil && score > bestScore {
+			bestScore = score
+			best = match
 		}
 	}
 	return best, nil
+}
+
+func matchEgressRequestInTask(tasks []*store.Task, req EgressRequest, host, method, taskID string) (*EgressMatch, error) {
+	for _, task := range tasks {
+		if task == nil || task.ID != taskID {
+			continue
+		}
+		match, _, err := bestEgressMatchInTask(task, req, host, method)
+		return match, err
+	}
+	return nil, nil
+}
+
+func bestEgressMatchInTask(task *store.Task, req EgressRequest, host, method string) (*EgressMatch, int, error) {
+	if task == nil {
+		return nil, -1, nil
+	}
+	env, err := runtimetasks.EnvelopeFromTask(task)
+	if err != nil {
+		return nil, -1, err
+	}
+	var best *EgressMatch
+	bestScore := -1
+	for _, item := range env.ExpectedEgress {
+		if strings.ToLower(item.Host) != host {
+			continue
+		}
+		if item.Method != "" && strings.ToUpper(item.Method) != method {
+			continue
+		}
+		if item.Path != "" && item.Path != req.Path {
+			continue
+		}
+		if item.PathRegex != "" {
+			ok, err := regexp.MatchString(item.PathRegex, req.Path)
+			if err != nil {
+				return nil, -1, err
+			}
+			if !ok {
+				continue
+			}
+		}
+		if !matchShape(item.QueryShape, req.Query) || !matchShape(item.BodyShape, req.Body) {
+			continue
+		}
+		if !matchHeaders(item.Headers, req.Headers) {
+			continue
+		}
+		score := egressMatchSpecificity(item)
+		if score > bestScore {
+			bestScore = score
+			best = &EgressMatch{TaskID: task.ID, Item: item}
+		}
+	}
+	return best, bestScore, nil
 }
 
 func matchHeaders(shape map[string]any, headers map[string]string) bool {

--- a/pkg/clawvisor/defaults.go
+++ b/pkg/clawvisor/defaults.go
@@ -427,6 +427,7 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 	var pendingSecretCache llmproxy.PendingSecretDecisionCache
 	var liteApprovalCache llmproxy.PendingApprovalCache
 	var liteOutcomeStore llmproxy.InlineApprovalOutcomeStore
+	var taskCheckoutStore llmproxy.TaskCheckoutStore
 	var extractionTracker handlers.ExtractionTracker
 	var rdb *redis.Client
 	if cfg.Redis.URL != "" {
@@ -468,6 +469,7 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 		pendingSecretCache = llmproxy.NewRedisPendingSecretDecisionCache(client, 10*time.Minute)
 		liteApprovalCache = llmproxy.NewRedisPendingApprovalCache(client, 10*time.Minute)
 		liteOutcomeStore = llmproxy.NewRedisInlineApprovalOutcomeStore(client, 24*time.Hour)
+		taskCheckoutStore = llmproxy.NewRedisTaskCheckoutStore(client, 24*time.Hour)
 
 		// Safety TTL exceeds the 30s extraction timeout + 10s save timeout
 		// so a crashed instance doesn't orphan entries.
@@ -519,6 +521,7 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 		PendingSecretCache: pendingSecretCache,
 		LiteApprovalCache:  liteApprovalCache,
 		LiteOutcomeStore:   liteOutcomeStore,
+		TaskCheckoutStore:  taskCheckoutStore,
 		RedisClient:        rdb,
 	}
 

--- a/pkg/clawvisor/options.go
+++ b/pkg/clawvisor/options.go
@@ -151,6 +151,7 @@ type ServerOptions struct {
 	PendingSecretCache llmproxy.PendingSecretDecisionCache
 	LiteApprovalCache  llmproxy.PendingApprovalCache
 	LiteOutcomeStore   llmproxy.InlineApprovalOutcomeStore
+	TaskCheckoutStore  llmproxy.TaskCheckoutStore
 	RedisClient        *redis.Client
 }
 

--- a/pkg/clawvisor/run.go
+++ b/pkg/clawvisor/run.go
@@ -346,6 +346,9 @@ func RunWithContext(ctx context.Context, opts *ServerOptions) error {
 	if opts.LiteOutcomeStore != nil {
 		apiOpts = append(apiOpts, api.WithLiteApprovalOutcomeStore(opts.LiteOutcomeStore))
 	}
+	if opts.TaskCheckoutStore != nil {
+		apiOpts = append(apiOpts, api.WithTaskCheckoutStore(opts.TaskCheckoutStore))
+	}
 	if opts.LocalServiceProvider != nil {
 		apiOpts = append(apiOpts, api.WithLocalServiceProvider(&localSvcAdapter{opts.LocalServiceProvider}))
 	}

--- a/pkg/runtime/decision/decision.go
+++ b/pkg/runtime/decision/decision.go
@@ -109,6 +109,10 @@ type AuthorizationInput struct {
 	CandidateTasks []*store.Task
 	ToolRules      []*store.RuntimePolicyRule
 	EgressRules    []*store.RuntimePolicyRule
+	// PreferredTaskID is the lite-proxy checked-out task focus. It only
+	// disambiguates among tasks that already match the request; it never grants
+	// scope to a task that would not otherwise cover the call.
+	PreferredTaskID string
 
 	IntentVerifier IntentVerifier
 
@@ -185,7 +189,7 @@ func EvaluateAuthorization(ctx context.Context, in AuthorizationInput) (Authoriz
 		// match — the lite-proxy's taskCreationPrompt tells the model
 		// to declare scope by tool_name, so a task created via that
 		// path will only have expected_tools populated.
-		if match, err := runtimepolicy.MatchToolCall(in.CandidateTasks, in.ToolUse.Name, toolInput); err != nil {
+		if match, err := runtimepolicy.MatchToolCallPreferred(in.CandidateTasks, in.ToolUse.Name, toolInput, in.PreferredTaskID); err != nil {
 			return AuthorizationDecision{}, err
 		} else if match != nil {
 			task := taskByID(in.CandidateTasks, match.TaskID)
@@ -215,14 +219,14 @@ func EvaluateAuthorization(ctx context.Context, in AuthorizationInput) (Authoriz
 	}
 
 	if in.Target.Host != "" {
-		match, err := runtimepolicy.MatchEgressRequest(in.CandidateTasks, runtimepolicy.EgressRequest{
+		match, err := runtimepolicy.MatchEgressRequestPreferred(in.CandidateTasks, runtimepolicy.EgressRequest{
 			Host:    in.Target.Host,
 			Method:  in.Target.Method,
 			Path:    in.Target.Path,
 			Query:   in.Target.Query,
 			Body:    in.Target.Body,
 			Headers: in.Target.Headers,
-		})
+		}, in.PreferredTaskID)
 		if err != nil {
 			return AuthorizationDecision{}, err
 		}
@@ -236,7 +240,7 @@ func EvaluateAuthorization(ctx context.Context, in AuthorizationInput) (Authoriz
 		}
 	}
 
-	match, err := runtimepolicy.MatchToolCall(in.CandidateTasks, in.ToolUse.Name, toolInput)
+	match, err := runtimepolicy.MatchToolCallPreferred(in.CandidateTasks, in.ToolUse.Name, toolInput, in.PreferredTaskID)
 	if err != nil {
 		return AuthorizationDecision{}, err
 	}
@@ -389,7 +393,7 @@ func reviewDecisionWithRule(posture EvaluationPosture, rule *store.RuntimePolicy
 }
 
 func evaluateServiceActionScope(ctx context.Context, in AuthorizationInput, posture EvaluationPosture, toolInput map[string]any) (AuthorizationDecision, error) {
-	classification := runtimepolicy.ClassifyGatewayRequest(in.CandidateTasks, in.AgentID, in.Service, "", in.Action)
+	classification := runtimepolicy.ClassifyGatewayRequestPreferred(in.CandidateTasks, in.AgentID, in.Service, "", in.Action, in.PreferredTaskID)
 	switch classification.Kind {
 	case runtimepolicy.ClassificationBelongsToExistingTask:
 		task := classification.MatchedTask

--- a/pkg/runtime/decision/decision_test.go
+++ b/pkg/runtime/decision/decision_test.go
@@ -288,6 +288,65 @@ func TestEvaluateAuthorization_ToolTaskRunsIntentVerifier(t *testing.T) {
 	}
 }
 
+func TestEvaluateAuthorization_PreferredTaskDisambiguatesToolScope(t *testing.T) {
+	verifier := &stubIntentVerifier{verdict: &IntentVerdict{Allow: true, Explanation: "fits checked-out task"}}
+	got, err := EvaluateAuthorization(context.Background(), AuthorizationInput{
+		ToolUse:         toolUse("exec_command", map[string]any{"cmd": "cat README.md"}),
+		AgentID:         "agent-1",
+		CandidateTasks:  []*store.Task{taskWithExpectedTool("task-1", "agent-1", "exec_command", "read repo files"), taskWithExpectedTool("task-2", "agent-1", "exec_command", "read repo files")},
+		PreferredTaskID: "task-2",
+		IntentVerifier:  verifier,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Kind != VerdictAllow || got.Source != SourceTaskScope || got.Task == nil || got.Task.ID != "task-2" {
+		t.Fatalf("decision = %+v, want preferred task-scope allow for task-2", got)
+	}
+	if verifier.last.TaskID != "task-2" {
+		t.Fatalf("intent verifier TaskID = %q, want task-2", verifier.last.TaskID)
+	}
+}
+
+func TestEvaluateAuthorization_PreferredTaskDisambiguatesServiceAction(t *testing.T) {
+	verifier := &stubIntentVerifier{verdict: &IntentVerdict{Allow: true, Explanation: "fits checked-out task"}}
+	got, err := EvaluateAuthorization(context.Background(), AuthorizationInput{
+		ToolUse:         toolUse("WebFetch", map[string]any{"url": "https://api.github.com/repos/acme/app/issues"}),
+		AgentID:         "agent-1",
+		Service:         "github",
+		Action:          "create_issue",
+		CandidateTasks:  []*store.Task{taskWithAction("task-1", "agent-1", "github", "create_issue", "strict"), taskWithAction("task-2", "agent-1", "github", "create_issue", "strict")},
+		PreferredTaskID: "task-2",
+		IntentVerifier:  verifier,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Kind != VerdictAllow || got.Source != SourceTaskScope || got.Task == nil || got.Task.ID != "task-2" {
+		t.Fatalf("decision = %+v, want preferred task-scope allow for task-2", got)
+	}
+	if verifier.last.TaskID != "task-2" {
+		t.Fatalf("intent verifier TaskID = %q, want task-2", verifier.last.TaskID)
+	}
+}
+
+func TestEvaluateAuthorization_IgnoresPreferredTaskOutsideCandidateSet(t *testing.T) {
+	got, err := EvaluateAuthorization(context.Background(), AuthorizationInput{
+		ToolUse:         toolUse("WebFetch", map[string]any{"url": "https://api.github.com/repos/acme/app/issues"}),
+		AgentID:         "agent-1",
+		Service:         "github",
+		Action:          "create_issue",
+		CandidateTasks:  []*store.Task{taskWithAction("task-1", "agent-1", "github", "create_issue", "strict"), taskWithAction("task-2", "agent-1", "github", "create_issue", "strict")},
+		PreferredTaskID: "task-other",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Kind != VerdictNeedsApproval || got.Source != SourceTaskScopeAmbiguous {
+		t.Fatalf("decision = %+v, want ambiguity when preferred task is not a valid candidate", got)
+	}
+}
+
 func TestEvaluateAuthorization_CanSkipIntentForLocallyClassifiedLowRiskTool(t *testing.T) {
 	verifier := &stubIntentVerifier{verdict: &IntentVerdict{Allow: false, Explanation: "would block if called"}}
 	got, err := EvaluateAuthorization(context.Background(), AuthorizationInput{


### PR DESCRIPTION
## Summary
- add proxy-lite task checkout stores plus /control/task/checkout and GET /control/tasks so agents can inspect and switch active task focus
- automatically check out inline-approved tasks and surface a shorter synthetic approval context with task ID, active-task guidance, and credential placeholders
- use checked-out tasks only to disambiguate among valid matching task candidates for tool, service/action, and egress scope

## Tests
- go test ./...