### PR TITLE
feat(taskrisk): run LLM risk assessor on v2 envelopes and inline tasks

### DIFF
--- a/internal/api/handlers/llm_endpoint.go
+++ b/internal/api/handlers/llm_endpoint.go
@@ -20,6 +20,7 @@ import (
 	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/inspector"
+	"github.com/clawvisor/clawvisor/internal/taskrisk"
 	runtimedecision "github.com/clawvisor/clawvisor/pkg/runtime/decision"
 	"github.com/clawvisor/clawvisor/pkg/store"
 	"github.com/clawvisor/clawvisor/pkg/vault"
@@ -120,6 +121,11 @@ type LLMEndpointHandler struct {
 	// inspector decision point for diagnostic purposes. Off by
 	// default; opted in via cfg.ProxyLite.TraceLogPath.
 	TraceLogger *llmproxy.TraceLogger
+
+	// TaskRiskAssessor evaluates the runtime envelope of an inline task
+	// gesture at approval time. Optional — when nil, the inline approval
+	// prompt falls back to the deterministic envelope-shape policy only.
+	TaskRiskAssessor taskrisk.Assessor
 
 	// RawIOLogger, when non-nil, captures full raw HTTP bodies for
 	// inbound requests, upstream responses, and the bodies returned
@@ -815,8 +821,10 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 			// Per-tool-use nonce minting overrides RewriteOpts.CallerToken
 			// inside the credentialed rewrite path so the agent's raw
 			// bearer token never enters the model's conversation context.
-			CallerNonces: h.CallerNonces,
-			Trace:        h.TraceLogger,
+			CallerNonces:     h.CallerNonces,
+			Trace:            h.TraceLogger,
+			TaskRiskAssessor: h.taskRiskBridge(),
+			AgentName:        agent.Name,
 		})
 		h.Logger.DebugContext(r.Context(), "lite-proxy postprocess complete",
 			"request_id", requestID,
@@ -2606,4 +2614,45 @@ func clawvisorAgentTokenHeader(r *http.Request) string {
 		return strings.TrimSpace(v[len(prefix):])
 	}
 	return v
+}
+
+// taskRiskBridge adapts the handler's taskrisk.Assessor (which speaks the
+// shared AssessRequest shape used by the dashboard task-create path) to
+// the narrow llmproxy.TaskRiskAssessor interface the postprocess pipeline
+// consumes. Returns nil when the handler has no assessor configured so
+// the intercept's nil-check correctly falls back to the deterministic
+// envelope policy.
+func (h *LLMEndpointHandler) taskRiskBridge() llmproxy.TaskRiskAssessor {
+	if h == nil || h.TaskRiskAssessor == nil {
+		return nil
+	}
+	return &liteProxyTaskRiskBridge{assessor: h.TaskRiskAssessor}
+}
+
+type liteProxyTaskRiskBridge struct {
+	assessor taskrisk.Assessor
+}
+
+func (b *liteProxyTaskRiskBridge) AssessEnvelope(ctx context.Context, req llmproxy.TaskRiskAssessRequest) *llmproxy.TaskRiskAssessment {
+	if b == nil || b.assessor == nil {
+		return nil
+	}
+	out, err := b.assessor.Assess(ctx, taskrisk.AssessRequest{
+		Purpose:                req.Purpose,
+		AgentName:              req.AgentName,
+		UserID:                 req.UserID,
+		ExpectedTools:          req.ExpectedTools,
+		ExpectedEgress:         req.ExpectedEgress,
+		RequiredCredentials:    req.RequiredCredentials,
+		IntentVerificationMode: req.IntentVerificationMode,
+		ExpectedUse:            req.ExpectedUse,
+	})
+	if err != nil || out == nil {
+		return nil
+	}
+	return &llmproxy.TaskRiskAssessment{
+		RiskLevel:   out.RiskLevel,
+		Explanation: out.Explanation,
+		Factors:     out.Factors,
+	}
 }

--- a/internal/api/handlers/tasks.go
+++ b/internal/api/handlers/tasks.go
@@ -565,20 +565,33 @@ func (h *TasksHandler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Run risk assessment (non-blocking — errors are logged, not propagated).
+	// Both schema versions route through the LLM assessor: v1 carries
+	// AuthorizedActions/PlannedCalls, v2 carries the runtime envelope.
+	// The deterministic envelope-shape policy serves as a floor for v2
+	// tasks so structural amplifiers (wildcard hosts, regex matchers,
+	// intent verification off) are never under-graded by the LLM.
 	if h.assessor != nil {
 		var assessment *taskrisk.RiskAssessment
-		if len(req.AuthorizedActions) > 0 {
-			legacyAssessment, err := h.assessor.Assess(ctx, taskrisk.AssessRequest{
+		if len(req.AuthorizedActions) > 0 || hasV2Fields {
+			llmReq := taskrisk.AssessRequest{
 				Purpose:           req.Purpose,
 				AuthorizedActions: req.AuthorizedActions,
 				PlannedCalls:      req.PlannedCalls,
 				AgentName:         agent.Name,
 				UserID:            agent.UserID,
-			})
+			}
+			if hasV2Fields {
+				llmReq.ExpectedTools = env.ExpectedTools
+				llmReq.ExpectedEgress = env.ExpectedEgress
+				llmReq.RequiredCredentials = env.RequiredCredentials
+				llmReq.IntentVerificationMode = env.IntentVerificationMode
+				llmReq.ExpectedUse = env.ExpectedUse
+			}
+			llmAssessment, err := h.assessor.Assess(ctx, llmReq)
 			if err != nil {
 				h.logger.Warn("task risk assessment failed", "error", err)
 			}
-			assessment = legacyAssessment
+			assessment = llmAssessment
 		}
 		if hasV2Fields {
 			envelopeAssessment := runtimepolicy.AssessTaskEnvelope(req.Purpose, env)

--- a/internal/api/handlers/tasks_inline.go
+++ b/internal/api/handlers/tasks_inline.go
@@ -153,14 +153,33 @@ func (h *TasksHandler) CreateInlineApprovedTask(ctx context.Context, agent *stor
 		task.ApprovalRationale = rationale
 	}
 
-	// Best-effort risk assessment for parity with the dashboard path; a
-	// failure here is non-fatal (the dashboard path also swallows it).
+	// Run the LLM-backed risk assessor and merge with the deterministic
+	// envelope-shape policy for parity with the dashboard path. Failures
+	// in either are non-fatal — a task should still be created with at
+	// least the structural assessment when the LLM call errors out.
+	envelopeAssessment := runtimepolicy.AssessTaskEnvelope(req.Purpose, env)
+	finalAssessment := envelopeAssessment
 	if h.assessor != nil {
-		envelopeAssessment := runtimepolicy.AssessTaskEnvelope(req.Purpose, env)
-		if envelopeAssessment != nil {
-			task.RiskLevel = envelopeAssessment.RiskLevel
-			task.RiskDetails = taskrisk.MarshalAssessment(envelopeAssessment)
+		llmAssessment, err := h.assessor.Assess(ctx, taskrisk.AssessRequest{
+			Purpose:                req.Purpose,
+			AgentName:              agent.Name,
+			UserID:                 agent.UserID,
+			ExpectedTools:          env.ExpectedTools,
+			ExpectedEgress:         env.ExpectedEgress,
+			RequiredCredentials:    env.RequiredCredentials,
+			IntentVerificationMode: env.IntentVerificationMode,
+			ExpectedUse:            env.ExpectedUse,
+		})
+		if err != nil {
+			h.logger.Warn("inline task risk assessment failed", "error", err)
 		}
+		if llmAssessment != nil && !strings.EqualFold(llmAssessment.RiskLevel, "unknown") {
+			finalAssessment = mergeRiskAssessments(llmAssessment, envelopeAssessment)
+		}
+	}
+	if finalAssessment != nil {
+		task.RiskLevel = finalAssessment.RiskLevel
+		task.RiskDetails = taskrisk.MarshalAssessment(finalAssessment)
 	}
 
 	if err := h.st.CreateTask(ctx, task); err != nil {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -112,6 +112,12 @@ type Server struct {
 	taskCheckouts      llmproxy.TaskCheckoutStore
 
 	adapterGenFactory handlers.GeneratorFactory // per-request Generator factory; set via option
+
+	// taskRiskAssessor scores task envelopes at creation time. Shared
+	// between the dashboard task-create path (via TasksHandler) and the
+	// lite-proxy inline-approval intercept so both surfaces see the
+	// same LLM-judged risk read.
+	taskRiskAssessor taskrisk.Assessor
 }
 
 // Dependencies is passed to ExtraRoutes so extension handlers can access shared services.
@@ -551,11 +557,14 @@ func (s *Server) routes() http.Handler {
 	if s.localServiceProvider != nil {
 		skillHandler.SetLocalServiceProvider(s.localServiceProvider)
 	}
-	// Construct task risk assessor (noop if disabled).
+	// Construct task risk assessor (noop if disabled). Stashed on the
+	// server so registerLiteProxyRoutes can plumb the same instance into
+	// the lite-proxy's inline-approval intercept.
 	var assessor taskrisk.Assessor = taskrisk.NoopAssessor{}
 	if s.llmCfg.TaskRisk.Enabled {
 		assessor = taskrisk.NewLLMAssessor(s.llmHealth, s.adapterReg, s.logger)
 	}
+	s.taskRiskAssessor = assessor
 	approvalsHandler := handlers.NewApprovalsHandler(s.store, s.vault, s.adapterReg, s.notifier, *s.cfg, assessor, s.logger, s.eventHub)
 	approvalsHandler.SetCallbackDispatcher(s.cbDispatcher)
 	s.approvalsHandler = approvalsHandler
@@ -1271,6 +1280,7 @@ func (s *Server) registerLiteProxyRoutes(
 			s.logger.Warn("lite-proxy: TaskCheckoutStore not configured — task focus is process-local; use Redis for multi-instance proxy deployments")
 		}
 		llmHandler.InlineTaskCreator = tasksHandler
+		llmHandler.TaskRiskAssessor = s.taskRiskAssessor
 
 		controlHandler := handlers.NewLLMControlHandler(baseURL)
 		controlHandler.Store = s.store

--- a/internal/runtime/llmproxy/inline_task_intercept.go
+++ b/internal/runtime/llmproxy/inline_task_intercept.go
@@ -9,6 +9,7 @@ import (
 	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
 	runtimepolicy "github.com/clawvisor/clawvisor/internal/runtime/policy"
 	runtimetasks "github.com/clawvisor/clawvisor/internal/runtime/tasks"
+	"github.com/clawvisor/clawvisor/internal/taskrisk"
 )
 
 // inlineTaskApprovalTTL is how long the user has to type yes/no
@@ -151,12 +152,96 @@ func maybeInterceptInlineTaskDefinition(
 		"purpose", parsed.Purpose,
 		"signal", "query",
 	)
-	assessment := runtimepolicy.AssessTaskEnvelope(parsed.Purpose, env)
+	assessment := assessInlineTaskRisk(req, cfg, parsed, env, trace)
 	return conversation.ToolUseVerdict{
 		Allowed:        false,
 		Reason:         "Clawvisor: awaiting inline task approval",
 		SubstituteWith: renderTaskApprovalPromptWithRisk(parsed, innerHold.Pending.ID, assessment),
 	}, true
+}
+
+// assessInlineTaskRisk runs the LLM-backed risk assessor (when configured) and
+// merges its verdict with the deterministic envelope-shape policy. The
+// envelope policy is the floor — it catches structural risk (wildcard hosts,
+// regex matchers, intent-verification off) that the LLM may underweight or
+// miss. The LLM verdict supplies the user-facing explanation and any extra
+// factors when its level is at least as high as the floor.
+//
+// Returns the deterministic envelope assessment alone when the assessor is
+// nil, returns nil-from-LLM (e.g. spend cap exhausted), or returns an
+// "unknown"/error result. This keeps the inline approval prompt rendering
+// even if the LLM call fails — the user still sees the deterministic risk
+// read, just without the LLM's explanation.
+func assessInlineTaskRisk(
+	req *http.Request,
+	cfg PostprocessConfig,
+	parsed *runtimetasks.TaskCreateRequest,
+	env runtimetasks.Envelope,
+	trace func(event string, kv ...any),
+) *taskrisk.RiskAssessment {
+	envelopeAssessment := runtimepolicy.AssessTaskEnvelope(parsed.Purpose, env)
+	if cfg.TaskRiskAssessor == nil {
+		return envelopeAssessment
+	}
+
+	llmVerdict := cfg.TaskRiskAssessor.AssessEnvelope(req.Context(), TaskRiskAssessRequest{
+		Purpose:                parsed.Purpose,
+		AgentName:              cfg.AgentName,
+		UserID:                 cfg.AgentUserID,
+		ExpectedTools:          env.ExpectedTools,
+		ExpectedEgress:         env.ExpectedEgress,
+		RequiredCredentials:    env.RequiredCredentials,
+		IntentVerificationMode: env.IntentVerificationMode,
+		ExpectedUse:            env.ExpectedUse,
+	})
+	if llmVerdict == nil || strings.EqualFold(strings.TrimSpace(llmVerdict.RiskLevel), "unknown") {
+		trace("inline_task.risk_llm_unavailable")
+		return envelopeAssessment
+	}
+
+	llmAssessment := &taskrisk.RiskAssessment{
+		RiskLevel:   llmVerdict.RiskLevel,
+		Explanation: llmVerdict.Explanation,
+		Factors:     llmVerdict.Factors,
+	}
+	return mergeInlineRisk(llmAssessment, envelopeAssessment)
+}
+
+// mergeInlineRisk picks the higher of the two risk levels and prefers the
+// LLM explanation when it set the ceiling; the envelope policy supplies the
+// explanation only when it raised the level above the LLM's read. Factors
+// from both are concatenated.
+func mergeInlineRisk(llm, envelope *taskrisk.RiskAssessment) *taskrisk.RiskAssessment {
+	if llm == nil {
+		return envelope
+	}
+	if envelope == nil {
+		return llm
+	}
+	out := *llm
+	if riskRank(envelope.RiskLevel) > riskRank(llm.RiskLevel) {
+		out.RiskLevel = envelope.RiskLevel
+		if envelope.Explanation != "" {
+			out.Explanation = envelope.Explanation
+		}
+	}
+	out.Factors = append(append([]string{}, llm.Factors...), envelope.Factors...)
+	out.Conflicts = append(append([]taskrisk.ConflictDetail{}, llm.Conflicts...), envelope.Conflicts...)
+	return &out
+}
+
+func riskRank(level string) int {
+	switch strings.ToLower(strings.TrimSpace(level)) {
+	case "low":
+		return 0
+	case "medium":
+		return 1
+	case "high":
+		return 2
+	case "critical":
+		return 3
+	}
+	return -1
 }
 
 func inlineTaskValidationReason(issues []runtimepolicy.ValidationIssue) string {

--- a/internal/runtime/llmproxy/inline_task_intercept_test.go
+++ b/internal/runtime/llmproxy/inline_task_intercept_test.go
@@ -396,6 +396,104 @@ func TestReleaseInlineTaskApproval_QueryOnlyHoldNoOuterCascade(t *testing.T) {
 	}
 }
 
+// stubInlineRiskAssessor is a recorder for the LLM-backed task risk path.
+type stubInlineRiskAssessor struct {
+	got    TaskRiskAssessRequest
+	called bool
+	out    *TaskRiskAssessment
+}
+
+func (s *stubInlineRiskAssessor) AssessEnvelope(_ context.Context, req TaskRiskAssessRequest) *TaskRiskAssessment {
+	s.called = true
+	s.got = req
+	return s.out
+}
+
+func TestPostprocess_InlineTaskSubstitutesLLMRiskExplanation(t *testing.T) {
+	cache := NewMemoryPendingApprovalCache(time.Minute)
+	st, userID, agentID := seedPostprocessStore(t, "autovault_github_xxx")
+
+	assessor := &stubInlineRiskAssessor{out: &TaskRiskAssessment{
+		RiskLevel:   "medium",
+		Explanation: "Writing to /tmp may collide with other processes' files.",
+	}}
+
+	body := anthropicBashControlTasksPostWithQuery(inlineTaskBody, "surface=inline")
+	req := httptest.NewRequest("POST", "/v1/messages", nil)
+	insp := inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{})
+
+	got := Postprocess(req, body, "application/json", PostprocessConfig{
+		Inspector:        insp,
+		RewriteOpts:      inspector.DefaultRewriteOpts("http://localhost:25297"),
+		CallerNonces:     NewMemoryCallerNonceCache(time.Minute),
+		Store:            st,
+		AgentUserID:      userID,
+		AgentID:          agentID,
+		ControlBaseURL:   "http://localhost:25297",
+		PendingApprovals: cache,
+		TaskRiskAssessor: assessor,
+		AgentName:        "test-agent",
+	})
+
+	if !assessor.called {
+		t.Fatalf("expected LLM risk assessor to be called during inline task intercept")
+	}
+	if assessor.got.AgentName != "test-agent" {
+		t.Fatalf("assessor request missing agent name: %+v", assessor.got)
+	}
+	if assessor.got.Purpose == "" {
+		t.Fatalf("assessor request missing purpose: %+v", assessor.got)
+	}
+	if len(assessor.got.ExpectedTools) == 0 {
+		t.Fatalf("assessor request missing expected tools: %+v", assessor.got)
+	}
+	out := string(got.Body)
+	if !strings.Contains(out, "Writing to /tmp may collide") {
+		t.Fatalf("approval prompt should carry LLM explanation; got %s", out)
+	}
+	if !strings.Contains(out, "medium") {
+		t.Fatalf("approval prompt should reflect LLM risk level; got %s", out)
+	}
+}
+
+// TestPostprocess_InlineTaskFallsBackWhenLLMUnknown confirms the merge
+// path: an "unknown" LLM verdict (spend-cap exhausted, parse failure, etc.)
+// drops back to the deterministic envelope policy so the prompt still
+// renders a risk read.
+func TestPostprocess_InlineTaskFallsBackWhenLLMUnknown(t *testing.T) {
+	cache := NewMemoryPendingApprovalCache(time.Minute)
+	st, userID, agentID := seedPostprocessStore(t, "autovault_github_xxx")
+
+	assessor := &stubInlineRiskAssessor{out: &TaskRiskAssessment{
+		RiskLevel:   "unknown",
+		Explanation: "Risk assessment failed: spend cap exhausted",
+	}}
+
+	body := anthropicBashControlTasksPostWithQuery(inlineTaskBody, "surface=inline")
+	req := httptest.NewRequest("POST", "/v1/messages", nil)
+	insp := inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{})
+
+	got := Postprocess(req, body, "application/json", PostprocessConfig{
+		Inspector:        insp,
+		RewriteOpts:      inspector.DefaultRewriteOpts("http://localhost:25297"),
+		CallerNonces:     NewMemoryCallerNonceCache(time.Minute),
+		Store:            st,
+		AgentUserID:      userID,
+		AgentID:          agentID,
+		ControlBaseURL:   "http://localhost:25297",
+		PendingApprovals: cache,
+		TaskRiskAssessor: assessor,
+	})
+
+	if !assessor.called {
+		t.Fatalf("expected assessor to be called even when it returns unknown")
+	}
+	out := string(got.Body)
+	if !strings.Contains(out, "constrained runtime envelope") {
+		t.Fatalf("expected deterministic-policy fallback explanation; got %s", out)
+	}
+}
+
 func TestPostprocess_InlineTaskMalformedBodyFallsThrough(t *testing.T) {
 	ctx := context.Background()
 	cache := NewMemoryPendingApprovalCache(time.Minute)

--- a/internal/runtime/llmproxy/postprocess.go
+++ b/internal/runtime/llmproxy/postprocess.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/inspector"
+	runtimetasks "github.com/clawvisor/clawvisor/internal/runtime/tasks"
 	runtimedecision "github.com/clawvisor/clawvisor/pkg/runtime/decision"
 	"github.com/clawvisor/clawvisor/pkg/runtime/toolnames"
 	"github.com/clawvisor/clawvisor/pkg/store"
@@ -22,6 +23,39 @@ import (
 // dependency into this package.
 type IntentVerifier interface {
 	Verify(ctx context.Context, req IntentVerifyRequest) (*IntentVerdict, error)
+}
+
+// TaskRiskAssessor scores a candidate task envelope at creation time so
+// the inline-approval prompt can surface a real, LLM-judged risk read
+// instead of the deterministic fallback. Narrow interface so this
+// package doesn't pull in the taskrisk LLM client dependency.
+type TaskRiskAssessor interface {
+	AssessEnvelope(ctx context.Context, req TaskRiskAssessRequest) *TaskRiskAssessment
+}
+
+// TaskRiskAssessRequest is the per-task input to TaskRiskAssessor. It
+// mirrors taskrisk.AssessRequest's v2-envelope shape; the handler
+// adapter is responsible for translating between the two so this
+// package can stay independent of the taskrisk package.
+type TaskRiskAssessRequest struct {
+	Purpose                string
+	AgentName              string
+	UserID                 string
+	ExpectedTools          []runtimetasks.ExpectedTool
+	ExpectedEgress         []runtimetasks.ExpectedEgress
+	RequiredCredentials    []runtimetasks.RequiredCredential
+	IntentVerificationMode string
+	ExpectedUse            string
+}
+
+// TaskRiskAssessment mirrors taskrisk.RiskAssessment but lives in this
+// package to keep the dependency narrow. The renderer only consumes
+// RiskLevel + Explanation; the rest is passed through for parity with
+// the dashboard surface.
+type TaskRiskAssessment struct {
+	RiskLevel   string
+	Explanation string
+	Factors     []string
 }
 
 // IntentVerifyRequest is the per-tool-use input to the verifier. Mirrors
@@ -121,6 +155,17 @@ type PostprocessConfig struct {
 	PreferredTaskID string
 
 	PendingApprovals PendingApprovalCache
+
+	// TaskRiskAssessor scores a task envelope via LLM at inline-approval
+	// time so the approval prompt carries an evaluated risk read.
+	// Optional: when nil, the intercept falls back to the deterministic
+	// envelope-shape policy alone.
+	TaskRiskAssessor TaskRiskAssessor
+
+	// AgentName is the agent's display name, surfaced to the assessor so
+	// its prompt context matches the dashboard task-creation surface.
+	// Optional.
+	AgentName string
 
 	// ControlBaseURL is the daemon URL used for synthetic Clawvisor control
 	// endpoint rewrites. Empty disables the control-plane rewrite path.

--- a/internal/taskrisk/assessor.go
+++ b/internal/taskrisk/assessor.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/clawvisor/clawvisor/internal/llm"
+	runtimetasks "github.com/clawvisor/clawvisor/internal/runtime/tasks"
 	"github.com/clawvisor/clawvisor/pkg/adapters"
 	"github.com/clawvisor/clawvisor/pkg/store"
 )
@@ -24,6 +25,13 @@ type Assessor interface {
 }
 
 // AssessRequest contains the data needed for task risk assessment.
+//
+// A request carries one of two scope shapes — the legacy v1 fields
+// (AuthorizedActions, PlannedCalls) or the v2 runtime envelope
+// (ExpectedTools, ExpectedEgress, RequiredCredentials, IntentVerificationMode,
+// ExpectedUse). The prompt renderer handles either shape so the same
+// LLMAssessor covers dashboard, control-plane, and lite-proxy task
+// creation paths.
 type AssessRequest struct {
 	Purpose           string
 	AuthorizedActions []store.TaskAction
@@ -33,6 +41,19 @@ type AssessRequest struct {
 	// (discovered at activation) appear in the prompt. Empty falls back to
 	// the global registry only.
 	UserID string
+
+	// V2 runtime envelope. Proxy-lite tasks (and any v2-schema dashboard
+	// task) declare scope here instead of AuthorizedActions/PlannedCalls.
+	ExpectedTools          []runtimetasks.ExpectedTool
+	ExpectedEgress         []runtimetasks.ExpectedEgress
+	RequiredCredentials    []runtimetasks.RequiredCredential
+	IntentVerificationMode string
+	ExpectedUse            string
+}
+
+// HasEnvelope reports whether the request carries v2 envelope fields.
+func (r AssessRequest) HasEnvelope() bool {
+	return len(r.ExpectedTools) > 0 || len(r.ExpectedEgress) > 0 || len(r.RequiredCredentials) > 0
 }
 
 // RiskAssessment is the result of a task risk evaluation.

--- a/internal/taskrisk/prompts.go
+++ b/internal/taskrisk/prompts.go
@@ -11,19 +11,21 @@ import (
 )
 
 const riskAssessmentSystemPrompt = `You are a security risk assessor for an AI agent authorization system.
-You will be given a task declaration from an AI agent: a purpose statement, a list of authorized actions (with optional expected_use reasons), and the agent's name. Your job is to evaluate the risk profile of this task scope.
+You will be given a task declaration from an AI agent: a purpose statement, and EITHER a list of authorized actions (v1 schema, legacy adapter-based tasks) OR a runtime envelope (v2 schema, used by the lite-proxy and modern v2 dashboard tasks) declaring expected_tools, expected_egress, and required_credentials. Your job is to evaluate the risk profile of this task scope.
 
 Evaluate these dimensions:
 
-1. **Scope breadth.** How many destructive/sensitive actions are authorized? Wildcards ("*") amplify risk because they grant access to ALL actions on that service, including destructive ones. Auto-execute on write/delete actions is higher risk than requiring per-request approval.
+1. **Scope breadth.** How many destructive/sensitive actions or tools are authorized? Wildcards ("*") amplify risk because they grant access to ALL operations on that service or host, including destructive ones. Auto-execute on write/delete actions is higher risk than requiring per-request approval. For envelopes, mutating HTTP methods (POST/PUT/PATCH/DELETE) on egress targets are higher risk than read-only GET access; wildcard hosts ("*", "*.example.com") and regex-based input/path matching are amplifiers because they widen what the matcher accepts at runtime.
 
-2. **Purpose-scope alignment.** Does the stated purpose justify the requested scope? A task claiming "check my calendar" but requesting gmail:send_email is suspicious. Unrelated services in the same task are a signal.
+2. **Purpose-scope alignment.** Does the stated purpose justify the requested scope? A task claiming "check my calendar" but requesting gmail:send_email is suspicious. Unrelated services in the same task are a signal. The same logic applies to envelope tools and egress hosts: a "summarize logs" task asking for write tools or POST egress to an unrelated host is a misalignment.
 
-3. **Internal coherence.** Are the expected_use reasons for each action consistent with the purpose and with each other? A task with purpose "summarize my inbox" but expected_use "send automated replies" on gmail:send_email has an internal conflict. Actions that don't logically relate to each other in the same task are a signal.
+3. **Internal coherence.** Are the per-item reasons (expected_use on actions; why on tools, egress, credentials) consistent with the purpose and with each other? A task with purpose "summarize my inbox" but a why field that says "send automated replies" has an internal conflict. Items that don't logically relate to each other in the same task are a signal.
 
 4. **Planned calls.** The agent may declare specific API calls it intends to make. These calls will skip per-request intent verification if they match at runtime, so evaluate them carefully. Parameters may be exact values or "$chain" (meaning the actual value will come from a prior call's results via context chaining). Evaluate whether each call is consistent with the stated purpose, whether exact parameters are reasonable, and whether "$chain" references make sense given the call sequence. Planned calls that contradict the purpose or authorized scope are a conflict.
 
-5. **Verification mode.** Each authorized action has a verification setting that controls how strictly the gateway checks runtime requests against the task's purpose and scope. "strict" is the safe default. "lenient" relaxes the check so routine variation isn't blocked — acceptable on read/search actions, but a meaningful risk amplifier on writes/deletes because a compromised or confused agent is more likely to slip a harmful call through. "off" disables runtime verification for that scope entirely, so nothing but the declared scope itself protects the user from misuse — this is high-risk on writes/deletes and warrants a conflict even when the rest of the task looks coherent. Auto-execute + write/delete + ("lenient" or "off") is the most dangerous combination; call it out explicitly.
+5. **Verification mode.** Each task (v2 envelope) or authorized action (v1) has a verification setting that controls how strictly the gateway checks runtime requests against the task's purpose and scope. "strict" is the safe default. "lenient" relaxes the check so routine variation isn't blocked — acceptable on read/search operations, but a meaningful risk amplifier on writes/deletes because a compromised or confused agent is more likely to slip a harmful call through. "off" disables runtime verification entirely, so nothing but the declared scope itself protects the user from misuse — this is high-risk on writes/deletes and warrants a conflict even when the rest of the task looks coherent. Auto-execute + write/delete + ("lenient" or "off") is the most dangerous combination; call it out explicitly.
+
+6. **Credential access (v2).** Required credentials hand the agent a vault item for the lifetime of the task. Each requested credential should have a coherent why tied to the purpose; broad credential requests with vague justifications are a signal.
 
 Use this action context to understand what each action does:
 
@@ -104,27 +106,47 @@ func buildActionContextFromRegistry(ctx context.Context, reg *adapters.Registry,
 }
 
 // buildAssessUserMessage constructs the user message for task risk assessment.
+// The renderer emits the v1 action block when AuthorizedActions/PlannedCalls
+// are present and the v2 envelope block when ExpectedTools/Egress/Credentials
+// are present; a task may legitimately carry both (mixed-schema) or just one.
 func buildAssessUserMessage(req AssessRequest) string {
 	var b strings.Builder
 
-	fmt.Fprintf(&b, "Agent: %s\n", req.AgentName)
-	fmt.Fprintf(&b, "Purpose: %s\n\n", req.Purpose)
-	fmt.Fprintf(&b, "Authorized actions (%d):\n", len(req.AuthorizedActions))
+	agentName := req.AgentName
+	if agentName == "" {
+		agentName = "(unspecified)"
+	}
+	fmt.Fprintf(&b, "Agent: %s\n", agentName)
+	fmt.Fprintf(&b, "Purpose: %s\n", req.Purpose)
+	if req.HasEnvelope() {
+		mode := strings.TrimSpace(req.IntentVerificationMode)
+		if mode == "" {
+			mode = "strict"
+		}
+		fmt.Fprintf(&b, "Intent verification mode: %s\n", mode)
+		if eu := strings.TrimSpace(req.ExpectedUse); eu != "" {
+			fmt.Fprintf(&b, "Expected use: %q\n", eu)
+		}
+	}
+	b.WriteString("\n")
 
-	for i, a := range req.AuthorizedActions {
-		autoExec := "false"
-		if a.AutoExecute {
-			autoExec = "true"
+	if len(req.AuthorizedActions) > 0 || (!req.HasEnvelope() && len(req.PlannedCalls) == 0) {
+		fmt.Fprintf(&b, "Authorized actions (%d):\n", len(req.AuthorizedActions))
+		for i, a := range req.AuthorizedActions {
+			autoExec := "false"
+			if a.AutoExecute {
+				autoExec = "true"
+			}
+			verification := a.Verification
+			if verification == "" {
+				verification = "strict"
+			}
+			fmt.Fprintf(&b, "  %d. %s:%s (auto_execute=%s, verification=%s)", i+1, a.Service, a.Action, autoExec, verification)
+			if a.ExpectedUse != "" {
+				fmt.Fprintf(&b, " — expected_use: %q", a.ExpectedUse)
+			}
+			b.WriteString("\n")
 		}
-		verification := a.Verification
-		if verification == "" {
-			verification = "strict"
-		}
-		fmt.Fprintf(&b, "  %d. %s:%s (auto_execute=%s, verification=%s)", i+1, a.Service, a.Action, autoExec, verification)
-		if a.ExpectedUse != "" {
-			fmt.Fprintf(&b, " — expected_use: %q", a.ExpectedUse)
-		}
-		b.WriteString("\n")
 	}
 
 	if len(req.PlannedCalls) > 0 {
@@ -138,6 +160,65 @@ func buildAssessUserMessage(req AssessRequest) string {
 				b.WriteString(" — params: none (will NOT skip verification)")
 			}
 			b.WriteString("\n")
+		}
+	}
+
+	if req.HasEnvelope() {
+		if len(req.ExpectedTools) > 0 {
+			fmt.Fprintf(&b, "\nExpected tools (%d):\n", len(req.ExpectedTools))
+			for i, t := range req.ExpectedTools {
+				fmt.Fprintf(&b, "  %d. %s", i+1, t.ToolName)
+				if t.InputRegex != "" {
+					fmt.Fprintf(&b, " (input_regex=%q — amplifies risk: regex widens matcher)", t.InputRegex)
+				}
+				if len(t.InputShape) > 0 {
+					shapeJSON, _ := json.Marshal(t.InputShape)
+					fmt.Fprintf(&b, " (input_shape=%s)", shapeJSON)
+				}
+				if why := strings.TrimSpace(t.Why); why != "" {
+					fmt.Fprintf(&b, " — why: %q", why)
+				}
+				b.WriteString("\n")
+			}
+		}
+
+		if len(req.ExpectedEgress) > 0 {
+			fmt.Fprintf(&b, "\nExpected egress (%d):\n", len(req.ExpectedEgress))
+			for i, eg := range req.ExpectedEgress {
+				method := strings.ToUpper(strings.TrimSpace(eg.Method))
+				if method == "" {
+					method = "ANY"
+				}
+				fmt.Fprintf(&b, "  %d. %s %s", i+1, method, eg.Host)
+				if eg.Path != "" {
+					fmt.Fprintf(&b, " path=%q", eg.Path)
+				}
+				if eg.PathRegex != "" {
+					fmt.Fprintf(&b, " path_regex=%q (amplifies risk: regex widens matcher)", eg.PathRegex)
+				}
+				if eg.CredentialAlias != "" {
+					fmt.Fprintf(&b, " credential_alias=%q", eg.CredentialAlias)
+				}
+				if why := strings.TrimSpace(eg.Why); why != "" {
+					fmt.Fprintf(&b, " — why: %q", why)
+				}
+				b.WriteString("\n")
+			}
+		}
+
+		if len(req.RequiredCredentials) > 0 {
+			fmt.Fprintf(&b, "\nRequired credentials (%d):\n", len(req.RequiredCredentials))
+			for i, c := range req.RequiredCredentials {
+				display := c.VaultItemID
+				if display == "" {
+					display = c.VaultItemHandle
+				}
+				fmt.Fprintf(&b, "  %d. %s", i+1, display)
+				if why := strings.TrimSpace(c.Why); why != "" {
+					fmt.Fprintf(&b, " — why: %q", why)
+				}
+				b.WriteString("\n")
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
Proxy-lite inline-approval prompts and v2 dashboard task creation previously only ran the deterministic envelope-shape policy, so every well-formed task surfaced the same canned "constrained runtime envelope" explanation.

This extends `taskrisk.AssessRequest` with the v2 envelope shape, teaches the assessor prompt about `expected_tools`/`expected_egress`/`required_credentials`, and wires the LLM assessor into the lite-proxy intercept (via a narrow `TaskRiskAssessor` interface on `PostprocessConfig`) and the inline/dashboard task-create handlers. The deterministic envelope policy now acts as a structural floor — merged in so wildcard hosts, regex matchers, and disabled intent verification can never be under-graded — and is also the clean fallback when the LLM returns `unknown` or errors.

## Test plan
- [x] `go build ./...` and `go vet ./...` clean
- [x] `go test ./internal/taskrisk/... ./internal/runtime/... ./internal/api/... ./internal/e2e/...` green
- [x] New tests cover the LLM-explanation-in-prompt path and the `unknown`-verdict fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)