### PR TITLE
fix(llmproxy): raise inbound body cap to 34 MiB

### DIFF
--- a/internal/api/handlers/llm_endpoint.go
+++ b/internal/api/handlers/llm_endpoint.go
@@ -136,7 +136,10 @@ type LLMEndpointHandler struct {
 	// avoid leaving this on outside of diagnostic sessions.
 	RawIOLogger *llmproxy.RawIOLogger
 
-	// MaxRequestBytes caps the inbound request body. Defaults to 4 MiB.
+	// MaxRequestBytes caps the inbound request body. Defaults to 34 MiB —
+	// 2 MiB of headroom above Anthropic's 32 MB Messages API cap (OpenAI's
+	// is ~25 MB), so the proxy never rejects a request the upstream would
+	// have accepted.
 	MaxRequestBytes int64
 
 	// MaxResponseBytes caps the upstream response body when buffering for
@@ -171,7 +174,7 @@ func NewLLMEndpointHandler(st store.Store, v vault.Vault, logger *slog.Logger) *
 		// backed cache via WithCallerNonceCache. Cache instance is
 		// shared with the resolver-side middleware in production.
 		CallerNonces:         llmproxy.NewMemoryCallerNonceCache(5 * time.Minute),
-		MaxRequestBytes:      4 << 20,
+		MaxRequestBytes:      34 << 20,
 		defaultToolRulesSeen: map[string]map[string]struct{}{},
 	}
 }

--- a/internal/api/handlers/proxy_resolver.go
+++ b/internal/api/handlers/proxy_resolver.go
@@ -39,7 +39,8 @@ type ProxyResolverHandler struct {
 	// per placeholder swapped. nil disables audit logging.
 	AuditEmitter *llmproxy.AuditEmitter
 
-	// MaxRequestBytes caps the inbound body. Defaults to 8 MiB.
+	// MaxRequestBytes caps the inbound body. Defaults to 34 MiB to mirror
+	// the LLM proxy endpoint (2 MiB above Anthropic's 32 MB Messages cap).
 	MaxRequestBytes int64
 
 	// SelfHostnames is the set of hosts this Clawvisor deployment serves
@@ -69,7 +70,7 @@ func NewProxyResolverHandler(st store.Store, v vault.Vault, logger *slog.Logger)
 		Store:           st,
 		Vault:           v,
 		Logger:          logger,
-		MaxRequestBytes: 8 << 20,
+		MaxRequestBytes: 34 << 20,
 	}
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.ResponseHeaderTimeout = 30 * time.Second


### PR DESCRIPTION
## Summary
- The v1 LLM proxy capped inbound request bodies at 4 MiB and the resolver at 8 MiB, both well below upstream limits (Anthropic Messages API: 32 MB, OpenAI: ~25 MB), so the proxy was rejecting requests that the providers would have accepted and breaking conversations with large contexts.
- Bumps both caps to 34 MiB (2 MiB of headroom above Anthropic's 32 MB) so oversized requests now fail at the upstream's native 413 rather than ours.

## Test plan
- [ ] Verify a previously-failing large agent conversation now passes through the proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)