### PR TITLE
feat: add Google Sheets adapter with OAuth integration 

### DIFF
--- a/internal/adapters/definitions/google_sheets.yaml
+++ b/internal/adapters/definitions/google_sheets.yaml
@@ -13,7 +13,6 @@ auth:
   oauth:
     scopes:
       - "https://www.googleapis.com/auth/spreadsheets"
-      - "https://www.googleapis.com/auth/drive.readonly"
       - "https://www.googleapis.com/auth/userinfo.email"
     endpoint: google
     vault_key: google

--- a/internal/adapters/definitions/google_sheets.yaml
+++ b/internal/adapters/definitions/google_sheets.yaml
@@ -1,0 +1,90 @@
+service:
+  id: google.sheets
+  display_name: Google Sheets
+  description: "Read and write Google Sheets spreadsheets."
+  setup_url: "https://github.com/clawvisor/clawvisor/blob/main/docs/GOOGLE_OAUTH_SETUP.md"
+  icon_url: "/logos/google-sheets.svg"
+  identity:
+    endpoint: "https://www.googleapis.com/oauth2/v2/userinfo"
+    field: email
+
+auth:
+  type: oauth2
+  oauth:
+    scopes:
+      - "https://www.googleapis.com/auth/spreadsheets"
+      - "https://www.googleapis.com/auth/drive.readonly"
+      - "https://www.googleapis.com/auth/userinfo.email"
+    endpoint: google
+    vault_key: google
+    scope_merge: true
+
+api:
+  # Required by the YAML schema even when actions are overridden in Go.
+  base_url: "https://sheets.googleapis.com/v4"
+
+# The Sheets adapter is implemented in Go for now; this YAML exists so the
+# service appears in the catalog with action risk metadata.
+# Each action is wired via defaults.go using goOverrides.
+actions:
+  list_spreadsheets:
+    display_name: "List spreadsheets"
+    risk: { category: read, sensitivity: low, description: "List spreadsheets in Google Drive" }
+    scopes: ["https://www.googleapis.com/auth/drive.readonly"]
+    override: go
+    params:
+      query: { type: string }
+      max_results: { type: int, default: 10, max: 50 }
+
+  get_spreadsheet:
+    display_name: "Get spreadsheet"
+    risk: { category: read, sensitivity: low, description: "Read spreadsheet metadata (sheets, titles)" }
+    scopes: ["https://www.googleapis.com/auth/spreadsheets"]
+    override: go
+    params:
+      spreadsheet_id: { type: string, required: true }
+
+  read_range:
+    display_name: "Read range"
+    risk: { category: read, sensitivity: low, description: "Read values from a range" }
+    scopes: ["https://www.googleapis.com/auth/spreadsheets"]
+    override: go
+    params:
+      spreadsheet_id: { type: string, required: true }
+      range: { type: string, required: true, description: "A1 notation, e.g. Sheet1!A1:D10" }
+      major_dimension:
+        type: string
+        default: "ROWS"
+        description: "ROWS or COLUMNS"
+      max_rows: { type: int, default: 200, max: 200 }
+
+  append_rows:
+    display_name: "Append rows"
+    risk: { category: write, sensitivity: medium, description: "Append rows to a sheet" }
+    scopes: ["https://www.googleapis.com/auth/spreadsheets"]
+    override: go
+    params:
+      spreadsheet_id: { type: string, required: true }
+      range: { type: string, required: true }
+      rows: { type: array, required: true, description: "2D array of rows" }
+      value_input_option: { type: string, default: "USER_ENTERED" }
+
+  update_cells:
+    display_name: "Update cells"
+    risk: { category: write, sensitivity: medium, description: "Update values in a sheet range" }
+    scopes: ["https://www.googleapis.com/auth/spreadsheets"]
+    override: go
+    params:
+      spreadsheet_id: { type: string, required: true }
+      range: { type: string, required: true }
+      values: { type: array, required: true, description: "2D array of values" }
+      value_input_option: { type: string, default: "USER_ENTERED" }
+
+  create_spreadsheet:
+    display_name: "Create spreadsheet"
+    risk: { category: write, sensitivity: medium, description: "Create a new spreadsheet" }
+    scopes: ["https://www.googleapis.com/auth/spreadsheets"]
+    override: go
+    params:
+      title: { type: string, required: true }
+      sheets: { type: array, description: "Optional array of sheet titles" }

--- a/internal/adapters/google/sheets/actions.go
+++ b/internal/adapters/google/sheets/actions.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 
 	"github.com/clawvisor/clawvisor/internal/adapters/format"
@@ -18,6 +19,12 @@ const (
 	sheetsAPIBase = "https://sheets.googleapis.com/v4"
 	driveAPIBase  = "https://www.googleapis.com/drive/v3"
 )
+
+// driveQueryAllowlist permits only characters that appear in ordinary file
+// names: letters, digits, whitespace, hyphens, dots, underscores, commas,
+// parentheses, ampersands, @, !, #, +.  Drive query operators (quotes,
+// backslashes, =, <, >, and/or keywords, etc.) are intentionally excluded.
+var driveQueryAllowlist = regexp.MustCompile(`^[a-zA-Z0-9\s\-._,()&@!#+]+$`)
 
 type spreadsheetListItem struct {
 	ID           string `json:"id"`
@@ -41,10 +48,10 @@ func (a *SheetsAdapter) listSpreadsheets(ctx context.Context, client *http.Clien
 	// Default query: spreadsheets only, not trashed.
 	driveQ := "mimeType='application/vnd.google-apps.spreadsheet' and trashed=false"
 	if strings.TrimSpace(query) != "" {
-		// Basic substring search in name. Keep it simple; Google's q language is powerful
-		// but we don't want to accept arbitrary query strings without review.
-		safe := strings.ReplaceAll(query, "'", "\\'")
-		driveQ += fmt.Sprintf(" and name contains '%s'", safe)
+		if !driveQueryAllowlist.MatchString(query) {
+			return nil, fmt.Errorf("sheets list_spreadsheets: query contains disallowed characters; use only letters, digits, spaces, and common punctuation (- . , ( ) & @ ! # +)")
+		}
+		driveQ += fmt.Sprintf(" and name contains '%s'", query)
 	}
 	q.Set("q", driveQ)
 

--- a/internal/adapters/google/sheets/actions.go
+++ b/internal/adapters/google/sheets/actions.go
@@ -81,10 +81,10 @@ func (a *SheetsAdapter) listSpreadsheets(ctx context.Context, client *http.Clien
 }
 
 type spreadsheetMeta struct {
-	SpreadsheetID string `json:"spreadsheet_id"`
-	Title         string `json:"title"`
-	Locale        string `json:"locale,omitempty"`
-	Timezone      string `json:"timezone,omitempty"`
+	SpreadsheetID string      `json:"spreadsheet_id"`
+	Title         string      `json:"title"`
+	Locale        string      `json:"locale,omitempty"`
+	Timezone      string      `json:"timezone,omitempty"`
 	Sheets        []sheetMeta `json:"sheets"`
 }
 
@@ -167,10 +167,10 @@ func (a *SheetsAdapter) readRange(ctx context.Context, client *http.Client, para
 		q.Encode())
 
 	var resp struct {
-		SpreadsheetID   string          `json:"spreadsheetId"`
-		Range           string          `json:"range"`
-		MajorDimension  string          `json:"majorDimension"`
-		Values          [][]interface{} `json:"values"`
+		SpreadsheetID  string          `json:"spreadsheetId"`
+		Range          string          `json:"range"`
+		MajorDimension string          `json:"majorDimension"`
+		Values         [][]interface{} `json:"values"`
 	}
 	if err := apiGET(ctx, client, u, &resp); err != nil {
 		return nil, fmt.Errorf("sheets read_range: %w", err)
@@ -325,8 +325,8 @@ func (a *SheetsAdapter) updateCells(ctx context.Context, client *http.Client, pa
 }
 
 type createResult struct {
-	SpreadsheetID string `json:"spreadsheet_id"`
-	Title         string `json:"title"`
+	SpreadsheetID  string `json:"spreadsheet_id"`
+	Title          string `json:"title"`
 	SpreadsheetURL string `json:"spreadsheet_url,omitempty"`
 }
 
@@ -391,7 +391,7 @@ func (a *SheetsAdapter) createSpreadsheet(ctx context.Context, client *http.Clie
 	return &adapters.Result{Summary: format.Summary("Created spreadsheet: %s", out.Title), Data: out}, nil
 }
 
-// HTTP helpers 
+// HTTP helpers
 
 func apiGET(ctx context.Context, client *http.Client, url string, out any) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)

--- a/internal/adapters/google/sheets/actions.go
+++ b/internal/adapters/google/sheets/actions.go
@@ -1,0 +1,457 @@
+package sheets
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/clawvisor/clawvisor/internal/adapters/format"
+	"github.com/clawvisor/clawvisor/pkg/adapters"
+)
+
+const (
+	sheetsAPIBase = "https://sheets.googleapis.com/v4"
+	driveAPIBase  = "https://www.googleapis.com/drive/v3"
+)
+
+type spreadsheetListItem struct {
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	ModifiedTime string `json:"modified_time"`
+	WebViewLink  string `json:"web_view_link,omitempty"`
+}
+
+func (a *SheetsAdapter) listSpreadsheets(ctx context.Context, client *http.Client, params map[string]any) (*adapters.Result, error) {
+	// Implemented via Drive API because Sheets API has no "list".
+	query, _ := params["query"].(string)
+	maxResults := 10
+	if v, ok := paramInt(params, "max_results"); ok && v > 0 && v <= 50 {
+		maxResults = v
+	}
+
+	q := url.Values{}
+	q.Set("pageSize", fmt.Sprintf("%d", maxResults))
+	q.Set("fields", "files(id,name,modifiedTime,webViewLink)")
+
+	// Default query: spreadsheets only, not trashed.
+	driveQ := "mimeType='application/vnd.google-apps.spreadsheet' and trashed=false"
+	if strings.TrimSpace(query) != "" {
+		// Basic substring search in name. Keep it simple; Google's q language is powerful
+		// but we don't want to accept arbitrary query strings without review.
+		safe := strings.ReplaceAll(query, "'", "\\'")
+		driveQ += fmt.Sprintf(" and name contains '%s'", safe)
+	}
+	q.Set("q", driveQ)
+
+	apiURL := driveAPIBase + "/files?" + q.Encode()
+	var resp struct {
+		Files []struct {
+			ID           string `json:"id"`
+			Name         string `json:"name"`
+			ModifiedTime string `json:"modifiedTime"`
+			WebViewLink  string `json:"webViewLink"`
+		} `json:"files"`
+	}
+	if err := apiGET(ctx, client, apiURL, &resp); err != nil {
+		return nil, fmt.Errorf("sheets list_spreadsheets: %w", err)
+	}
+
+	items := make([]spreadsheetListItem, 0, len(resp.Files))
+	for _, f := range resp.Files {
+		items = append(items, spreadsheetListItem{
+			ID:           f.ID,
+			Name:         format.SanitizeText(f.Name, format.MaxFieldLen),
+			ModifiedTime: f.ModifiedTime,
+			WebViewLink:  f.WebViewLink,
+		})
+	}
+	return &adapters.Result{Summary: format.Summary("%d spreadsheet(s)", len(items)), Data: items}, nil
+}
+
+type spreadsheetMeta struct {
+	SpreadsheetID string `json:"spreadsheet_id"`
+	Title         string `json:"title"`
+	Locale        string `json:"locale,omitempty"`
+	Timezone      string `json:"timezone,omitempty"`
+	Sheets        []sheetMeta `json:"sheets"`
+}
+
+type sheetMeta struct {
+	SheetID int    `json:"sheet_id"`
+	Title   string `json:"title"`
+}
+
+func (a *SheetsAdapter) getSpreadsheet(ctx context.Context, client *http.Client, params map[string]any) (*adapters.Result, error) {
+	ssid, err := requireSpreadsheetID(params)
+	if err != nil {
+		return nil, fmt.Errorf("sheets get_spreadsheet: %w", err)
+	}
+
+	u := fmt.Sprintf("%s/spreadsheets/%s?fields=spreadsheetId,properties(title,locale,timeZone),sheets(properties(sheetId,title))",
+		sheetsAPIBase, url.PathEscape(ssid))
+	var resp struct {
+		SpreadsheetID string `json:"spreadsheetId"`
+		Properties    struct {
+			Title    string `json:"title"`
+			Locale   string `json:"locale"`
+			TimeZone string `json:"timeZone"`
+		} `json:"properties"`
+		Sheets []struct {
+			Properties struct {
+				SheetID int    `json:"sheetId"`
+				Title   string `json:"title"`
+			} `json:"properties"`
+		} `json:"sheets"`
+	}
+	if err := apiGET(ctx, client, u, &resp); err != nil {
+		return nil, fmt.Errorf("sheets get_spreadsheet: %w", err)
+	}
+
+	out := spreadsheetMeta{
+		SpreadsheetID: resp.SpreadsheetID,
+		Title:         format.SanitizeText(resp.Properties.Title, format.MaxFieldLen),
+		Locale:        resp.Properties.Locale,
+		Timezone:      resp.Properties.TimeZone,
+		Sheets:        make([]sheetMeta, 0, len(resp.Sheets)),
+	}
+	for _, s := range resp.Sheets {
+		out.Sheets = append(out.Sheets, sheetMeta{SheetID: s.Properties.SheetID, Title: format.SanitizeText(s.Properties.Title, format.MaxFieldLen)})
+	}
+
+	return &adapters.Result{Summary: format.Summary("Spreadsheet: %s", out.Title), Data: out}, nil
+}
+
+type rangeValues struct {
+	SpreadsheetID string          `json:"spreadsheet_id"`
+	Range         string          `json:"range"`
+	MajorDim      string          `json:"major_dimension"`
+	Values        [][]interface{} `json:"values"`
+}
+
+func (a *SheetsAdapter) readRange(ctx context.Context, client *http.Client, params map[string]any) (*adapters.Result, error) {
+	ssid, err := requireSpreadsheetID(params)
+	if err != nil {
+		return nil, fmt.Errorf("sheets read_range: %w", err)
+	}
+	rng, err := requireA1Range(params)
+	if err != nil {
+		return nil, fmt.Errorf("sheets read_range: %w", err)
+	}
+	majorDim := "ROWS"
+	if v, _ := params["major_dimension"].(string); v != "" {
+		majorDim = strings.ToUpper(v)
+	}
+	if majorDim != "ROWS" && majorDim != "COLUMNS" {
+		return nil, fmt.Errorf("major_dimension must be ROWS or COLUMNS")
+	}
+
+	q := url.Values{}
+	q.Set("majorDimension", majorDim)
+
+	u := fmt.Sprintf("%s/spreadsheets/%s/values/%s?%s",
+		sheetsAPIBase,
+		url.PathEscape(ssid),
+		url.PathEscape(rng),
+		q.Encode())
+
+	var resp struct {
+		SpreadsheetID   string          `json:"spreadsheetId"`
+		Range           string          `json:"range"`
+		MajorDimension  string          `json:"majorDimension"`
+		Values          [][]interface{} `json:"values"`
+	}
+	if err := apiGET(ctx, client, u, &resp); err != nil {
+		return nil, fmt.Errorf("sheets read_range: %w", err)
+	}
+
+	values := resp.Values
+	if maxRows, ok := paramInt(params, "max_rows"); ok && maxRows > 0 {
+		if maxRows > 200 {
+			maxRows = 200
+		}
+		if len(values) > maxRows {
+			values = values[:maxRows]
+		}
+	}
+
+	out := rangeValues{SpreadsheetID: resp.SpreadsheetID, Range: resp.Range, MajorDim: resp.MajorDimension, Values: values}
+
+	rows := len(out.Values)
+	summary := format.Summary("Read %d row(s) from %s", rows, format.SanitizeText(resp.Range, format.MaxFieldLen))
+	return &adapters.Result{Summary: summary, Data: out}, nil
+}
+
+type appendResult struct {
+	SpreadsheetID string `json:"spreadsheet_id"`
+	TableRange    string `json:"table_range"`
+	UpdatedRange  string `json:"updated_range"`
+	UpdatedRows   int    `json:"updated_rows"`
+}
+
+func (a *SheetsAdapter) appendRows(ctx context.Context, client *http.Client, params map[string]any) (*adapters.Result, error) {
+	ssid, err := requireSpreadsheetID(params)
+	if err != nil {
+		return nil, fmt.Errorf("sheets append_rows: %w", err)
+	}
+	rng, err := requireA1Range(params)
+	if err != nil {
+		return nil, fmt.Errorf("sheets append_rows: %w", err)
+	}
+	rows, err := require2DValues(params, "rows")
+	if err != nil {
+		return nil, fmt.Errorf("sheets append_rows: %w", err)
+	}
+	if len(rows) == 0 {
+		return nil, fmt.Errorf("rows must not be empty")
+	}
+	if len(rows) > 200 {
+		return nil, fmt.Errorf("too many rows (max 200)")
+	}
+
+	valueInput := "USER_ENTERED"
+	if v, _ := params["value_input_option"].(string); v != "" {
+		valueInput = strings.ToUpper(v)
+	}
+	if valueInput != "USER_ENTERED" && valueInput != "RAW" {
+		return nil, fmt.Errorf("value_input_option must be USER_ENTERED or RAW")
+	}
+
+	q := url.Values{}
+	q.Set("valueInputOption", valueInput)
+	q.Set("insertDataOption", "INSERT_ROWS")
+
+	payload := map[string]any{
+		"majorDimension": "ROWS",
+		"values":         rows,
+	}
+
+	u := fmt.Sprintf("%s/spreadsheets/%s/values/%s:append?%s",
+		sheetsAPIBase,
+		url.PathEscape(ssid),
+		url.PathEscape(rng),
+		q.Encode())
+
+	var resp struct {
+		SpreadsheetID string `json:"spreadsheetId"`
+		TableRange    string `json:"tableRange"`
+		Updates       struct {
+			UpdatedRange string `json:"updatedRange"`
+			UpdatedRows  int    `json:"updatedRows"`
+		} `json:"updates"`
+	}
+	if err := apiPOST(ctx, client, u, payload, &resp); err != nil {
+		return nil, fmt.Errorf("sheets append_rows: %w", err)
+	}
+
+	out := appendResult{SpreadsheetID: resp.SpreadsheetID, TableRange: resp.TableRange, UpdatedRange: resp.Updates.UpdatedRange, UpdatedRows: resp.Updates.UpdatedRows}
+	return &adapters.Result{Summary: format.Summary("Appended %d row(s) to %s", len(rows), rangeSheetLabel(rng)), Data: out}, nil
+}
+
+type updateResult struct {
+	SpreadsheetID string `json:"spreadsheet_id"`
+	UpdatedRange  string `json:"updated_range"`
+	UpdatedRows   int    `json:"updated_rows"`
+	UpdatedCols   int    `json:"updated_columns"`
+	UpdatedCells  int    `json:"updated_cells"`
+}
+
+func (a *SheetsAdapter) updateCells(ctx context.Context, client *http.Client, params map[string]any) (*adapters.Result, error) {
+	ssid, err := requireSpreadsheetID(params)
+	if err != nil {
+		return nil, fmt.Errorf("sheets update_cells: %w", err)
+	}
+	rng, err := requireA1Range(params)
+	if err != nil {
+		return nil, fmt.Errorf("sheets update_cells: %w", err)
+	}
+	values, err := require2DValues(params, "values")
+	if err != nil {
+		return nil, fmt.Errorf("sheets update_cells: %w", err)
+	}
+	if len(values) == 0 {
+		return nil, fmt.Errorf("values must not be empty")
+	}
+	if len(values) > 200 {
+		return nil, fmt.Errorf("too many rows (max 200)")
+	}
+
+	valueInput := "USER_ENTERED"
+	if v, _ := params["value_input_option"].(string); v != "" {
+		valueInput = strings.ToUpper(v)
+	}
+	if valueInput != "USER_ENTERED" && valueInput != "RAW" {
+		return nil, fmt.Errorf("value_input_option must be USER_ENTERED or RAW")
+	}
+
+	q := url.Values{}
+	q.Set("valueInputOption", valueInput)
+
+	payload := map[string]any{
+		"majorDimension": "ROWS",
+		"values":         values,
+	}
+
+	u := fmt.Sprintf("%s/spreadsheets/%s/values/%s?%s",
+		sheetsAPIBase,
+		url.PathEscape(ssid),
+		url.PathEscape(rng),
+		q.Encode())
+
+	var resp struct {
+		SpreadsheetID  string `json:"spreadsheetId"`
+		UpdatedRange   string `json:"updatedRange"`
+		UpdatedRows    int    `json:"updatedRows"`
+		UpdatedColumns int    `json:"updatedColumns"`
+		UpdatedCells   int    `json:"updatedCells"`
+	}
+	if err := apiPUT(ctx, client, u, payload, &resp); err != nil {
+		return nil, fmt.Errorf("sheets update_cells: %w", err)
+	}
+
+	out := updateResult{SpreadsheetID: resp.SpreadsheetID, UpdatedRange: resp.UpdatedRange, UpdatedRows: resp.UpdatedRows, UpdatedCols: resp.UpdatedColumns, UpdatedCells: resp.UpdatedCells}
+	return &adapters.Result{Summary: format.Summary("Updated %s", format.SanitizeText(resp.UpdatedRange, format.MaxFieldLen)), Data: out}, nil
+}
+
+type createResult struct {
+	SpreadsheetID string `json:"spreadsheet_id"`
+	Title         string `json:"title"`
+	SpreadsheetURL string `json:"spreadsheet_url,omitempty"`
+}
+
+func (a *SheetsAdapter) createSpreadsheet(ctx context.Context, client *http.Client, params map[string]any) (*adapters.Result, error) {
+	title, _ := params["title"].(string)
+	title = strings.TrimSpace(title)
+	if title == "" {
+		return nil, fmt.Errorf("title is required")
+	}
+	if len(title) > 200 {
+		return nil, fmt.Errorf("title too long")
+	}
+
+	// Optional: sheets: ["Sheet1", "Sheet2"]
+	var sheetTitles []string
+	if raw, ok := params["sheets"]; ok {
+		arr, ok := raw.([]any)
+		if !ok {
+			return nil, fmt.Errorf("sheets must be an array of strings")
+		}
+		for _, v := range arr {
+			s, ok := v.(string)
+			if !ok {
+				return nil, fmt.Errorf("sheets must be an array of strings")
+			}
+			s = strings.TrimSpace(s)
+			if s == "" {
+				continue
+			}
+			if len(s) > 100 {
+				return nil, fmt.Errorf("sheet name too long")
+			}
+			sheetTitles = append(sheetTitles, s)
+		}
+		if len(sheetTitles) > 20 {
+			return nil, fmt.Errorf("too many sheets (max 20)")
+		}
+	}
+
+	payload := map[string]any{"properties": map[string]any{"title": title}}
+	if len(sheetTitles) > 0 {
+		sheets := make([]map[string]any, 0, len(sheetTitles))
+		for _, s := range sheetTitles {
+			sheets = append(sheets, map[string]any{"properties": map[string]any{"title": s}})
+		}
+		payload["sheets"] = sheets
+	}
+
+	u := sheetsAPIBase + "/spreadsheets"
+	var resp struct {
+		SpreadsheetID  string `json:"spreadsheetId"`
+		SpreadsheetURL string `json:"spreadsheetUrl"`
+		Properties     struct {
+			Title string `json:"title"`
+		} `json:"properties"`
+	}
+	if err := apiPOST(ctx, client, u, payload, &resp); err != nil {
+		return nil, fmt.Errorf("sheets create_spreadsheet: %w", err)
+	}
+
+	out := createResult{SpreadsheetID: resp.SpreadsheetID, Title: format.SanitizeText(resp.Properties.Title, format.MaxFieldLen), SpreadsheetURL: resp.SpreadsheetURL}
+	return &adapters.Result{Summary: format.Summary("Created spreadsheet: %s", out.Title), Data: out}, nil
+}
+
+// HTTP helpers 
+
+func apiGET(ctx context.Context, client *http.Client, url string, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 8192))
+		return fmt.Errorf("status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	if out == nil {
+		return nil
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+func apiPOST(ctx context.Context, client *http.Client, url string, payload any, out any) error {
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(b))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 8192))
+		return fmt.Errorf("status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	if out == nil {
+		return nil
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+func apiPUT(ctx context.Context, client *http.Client, url string, payload any, out any) error {
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewReader(b))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 8192))
+		return fmt.Errorf("status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	if out == nil {
+		return nil
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}

--- a/internal/adapters/google/sheets/actions_test.go
+++ b/internal/adapters/google/sheets/actions_test.go
@@ -1,0 +1,378 @@
+package sheets
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// newTestClient returns an *http.Client whose transport rewrites every request
+// URL so that it hits srv instead of the real API endpoints.
+func newTestClient(srv *httptest.Server) *http.Client {
+	return &http.Client{
+		Transport: rewriteTransport{base: srv.URL, inner: http.DefaultTransport},
+	}
+}
+
+// rewriteTransport replaces the scheme+host of every outgoing request with the
+// test server's base URL, leaving the path and query intact.
+type rewriteTransport struct {
+	base  string // e.g. "http://127.0.0.1:PORT"
+	inner http.RoundTripper
+}
+
+func (r rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	clone := req.Clone(req.Context())
+	clone.URL.Scheme = "http"
+	clone.URL.Host = strings.TrimPrefix(r.base, "http://")
+	return r.inner.RoundTrip(clone)
+}
+
+// jsonHandler returns an HTTP handler that always responds 200 with v as JSON.
+func jsonHandler(t *testing.T, v any) http.HandlerFunc {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("jsonHandler: marshal: %v", err)
+	}
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(b)
+	}
+}
+
+// adapter returns a zero-config SheetsAdapter (OAuth not needed for these tests
+// because we bypass Execute and call the action methods directly).
+func adapter() *SheetsAdapter { return New(staticOAuthProvider{}) }
+
+// ---------------------------------------------------------------------------
+// listSpreadsheets
+// ---------------------------------------------------------------------------
+
+func TestListSpreadsheets_HappyPath(t *testing.T) {
+	resp := map[string]any{
+		"files": []any{
+			map[string]any{
+				"id":           "sheet-id-1",
+				"name":         "My Budget",
+				"modifiedTime": "2024-01-01T00:00:00Z",
+				"webViewLink":  "https://docs.google.com/spreadsheets/d/sheet-id-1",
+			},
+		},
+	}
+	srv := httptest.NewServer(jsonHandler(t, resp))
+	defer srv.Close()
+
+	result, err := adapter().listSpreadsheets(t.Context(), newTestClient(srv), map[string]any{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	items, ok := result.Data.([]spreadsheetListItem)
+	if !ok {
+		t.Fatalf("unexpected data type: %T", result.Data)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	if items[0].ID != "sheet-id-1" {
+		t.Errorf("unexpected ID: %q", items[0].ID)
+	}
+	if items[0].Name != "My Budget" {
+		t.Errorf("unexpected name: %q", items[0].Name)
+	}
+}
+
+func TestListSpreadsheets_WithQuery(t *testing.T) {
+	srv := httptest.NewServer(jsonHandler(t, map[string]any{"files": []any{}}))
+	defer srv.Close()
+
+	// Valid query — should pass the allowlist.
+	_, err := adapter().listSpreadsheets(t.Context(), newTestClient(srv), map[string]any{
+		"query": "Budget 2024",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error for valid query: %v", err)
+	}
+}
+
+func TestListSpreadsheets_QueryAllowlistRejects(t *testing.T) {
+	srv := httptest.NewServer(jsonHandler(t, map[string]any{"files": []any{}}))
+	defer srv.Close()
+
+	badQueries := []string{
+		"name' or '1'='1",       // quote injection
+		"foo and trashed=false", // Drive operator
+		"bar\\baz",              // backslash
+		"x<y",                   // comparison operator
+	}
+	for _, q := range badQueries {
+		_, err := adapter().listSpreadsheets(t.Context(), newTestClient(srv), map[string]any{
+			"query": q,
+		})
+		if err == nil {
+			t.Errorf("expected error for query %q, got nil", q)
+		}
+	}
+}
+
+func TestListSpreadsheets_MaxResults(t *testing.T) {
+	var gotPageSize string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPageSize = r.URL.Query().Get("pageSize")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"files":[]}`))
+	}))
+	defer srv.Close()
+
+	_, err := adapter().listSpreadsheets(t.Context(), newTestClient(srv), map[string]any{
+		"max_results": 25,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotPageSize != "25" {
+		t.Errorf("expected pageSize=25, got %q", gotPageSize)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// getSpreadsheet
+// ---------------------------------------------------------------------------
+
+func TestGetSpreadsheet_HappyPath(t *testing.T) {
+	resp := map[string]any{
+		"spreadsheetId": "sheet-id-1",
+		"properties": map[string]any{
+			"title":    "My Budget",
+			"locale":   "en_US",
+			"timeZone": "America/New_York",
+		},
+		"sheets": []any{
+			map[string]any{"properties": map[string]any{"sheetId": 0, "title": "Sheet1"}},
+		},
+	}
+	srv := httptest.NewServer(jsonHandler(t, resp))
+	defer srv.Close()
+
+	result, err := adapter().getSpreadsheet(t.Context(), newTestClient(srv), map[string]any{
+		"spreadsheet_id": "sheet-id-1",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	meta, ok := result.Data.(spreadsheetMeta)
+	if !ok {
+		t.Fatalf("unexpected data type: %T", result.Data)
+	}
+	if meta.Title != "My Budget" {
+		t.Errorf("unexpected title: %q", meta.Title)
+	}
+	if len(meta.Sheets) != 1 || meta.Sheets[0].Title != "Sheet1" {
+		t.Errorf("unexpected sheets: %+v", meta.Sheets)
+	}
+}
+
+func TestGetSpreadsheet_MissingID(t *testing.T) {
+	srv := httptest.NewServer(http.NotFoundHandler())
+	defer srv.Close()
+
+	_, err := adapter().getSpreadsheet(t.Context(), newTestClient(srv), map[string]any{})
+	if err == nil {
+		t.Fatalf("expected error for missing spreadsheet_id")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// readRange
+// ---------------------------------------------------------------------------
+
+func TestReadRange_HappyPath(t *testing.T) {
+	resp := map[string]any{
+		"spreadsheetId":  "sheet-id-1",
+		"range":          "Sheet1!A1:B2",
+		"majorDimension": "ROWS",
+		"values": []any{
+			[]any{"Name", "Score"},
+			[]any{"Alice", "99"},
+		},
+	}
+	srv := httptest.NewServer(jsonHandler(t, resp))
+	defer srv.Close()
+
+	result, err := adapter().readRange(t.Context(), newTestClient(srv), map[string]any{
+		"spreadsheet_id": "sheet-id-1",
+		"range":          "Sheet1!A1:B2",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	rv, ok := result.Data.(rangeValues)
+	if !ok {
+		t.Fatalf("unexpected data type: %T", result.Data)
+	}
+	if len(rv.Values) != 2 {
+		t.Errorf("expected 2 rows, got %d", len(rv.Values))
+	}
+}
+
+func TestReadRange_MaxRowsClamped(t *testing.T) {
+	rows := make([]any, 10)
+	for i := range rows {
+		rows[i] = []any{"cell"}
+	}
+	resp := map[string]any{
+		"spreadsheetId":  "sheet-id-1",
+		"range":          "Sheet1!A1:A10",
+		"majorDimension": "ROWS",
+		"values":         rows,
+	}
+	srv := httptest.NewServer(jsonHandler(t, resp))
+	defer srv.Close()
+
+	result, err := adapter().readRange(t.Context(), newTestClient(srv), map[string]any{
+		"spreadsheet_id": "sheet-id-1",
+		"range":          "Sheet1!A1:A10",
+		"max_rows":       5,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	rv := result.Data.(rangeValues)
+	if len(rv.Values) != 5 {
+		t.Errorf("expected 5 rows after clamping, got %d", len(rv.Values))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// appendRows
+// ---------------------------------------------------------------------------
+
+func TestAppendRows_HappyPath(t *testing.T) {
+	resp := map[string]any{
+		"spreadsheetId": "sheet-id-1",
+		"tableRange":    "Sheet1!A1:B1",
+		"updates": map[string]any{
+			"updatedRange": "Sheet1!A2:B2",
+			"updatedRows":  1,
+		},
+	}
+	srv := httptest.NewServer(jsonHandler(t, resp))
+	defer srv.Close()
+
+	result, err := adapter().appendRows(t.Context(), newTestClient(srv), map[string]any{
+		"spreadsheet_id": "sheet-id-1",
+		"range":          "Sheet1!A1:B1",
+		"rows":           []any{[]any{"Alice", "99"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ar, ok := result.Data.(appendResult)
+	if !ok {
+		t.Fatalf("unexpected data type: %T", result.Data)
+	}
+	if ar.UpdatedRows != 1 {
+		t.Errorf("expected 1 updated row, got %d", ar.UpdatedRows)
+	}
+}
+
+func TestAppendRows_EmptyRowsRejected(t *testing.T) {
+	srv := httptest.NewServer(http.NotFoundHandler())
+	defer srv.Close()
+
+	_, err := adapter().appendRows(t.Context(), newTestClient(srv), map[string]any{
+		"spreadsheet_id": "sheet-id-1",
+		"range":          "Sheet1!A1",
+		"rows":           []any{},
+	})
+	if err == nil {
+		t.Fatalf("expected error for empty rows")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// updateCells
+// ---------------------------------------------------------------------------
+
+func TestUpdateCells_HappyPath(t *testing.T) {
+	resp := map[string]any{
+		"spreadsheetId":  "sheet-id-1",
+		"updatedRange":   "Sheet1!A1:B1",
+		"updatedRows":    1,
+		"updatedColumns": 2,
+		"updatedCells":   2,
+	}
+	srv := httptest.NewServer(jsonHandler(t, resp))
+	defer srv.Close()
+
+	result, err := adapter().updateCells(t.Context(), newTestClient(srv), map[string]any{
+		"spreadsheet_id": "sheet-id-1",
+		"range":          "Sheet1!A1:B1",
+		"values":         []any{[]any{"Alice", "100"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ur, ok := result.Data.(updateResult)
+	if !ok {
+		t.Fatalf("unexpected data type: %T", result.Data)
+	}
+	if ur.UpdatedCells != 2 {
+		t.Errorf("expected 2 updated cells, got %d", ur.UpdatedCells)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// createSpreadsheet
+// ---------------------------------------------------------------------------
+
+func TestCreateSpreadsheet_HappyPath(t *testing.T) {
+	resp := map[string]any{
+		"spreadsheetId":  "new-sheet-id",
+		"spreadsheetUrl": "https://docs.google.com/spreadsheets/d/new-sheet-id",
+		"properties":     map[string]any{"title": "Q1 Report"},
+	}
+	srv := httptest.NewServer(jsonHandler(t, resp))
+	defer srv.Close()
+
+	result, err := adapter().createSpreadsheet(t.Context(), newTestClient(srv), map[string]any{
+		"title": "Q1 Report",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cr, ok := result.Data.(createResult)
+	if !ok {
+		t.Fatalf("unexpected data type: %T", result.Data)
+	}
+	if cr.SpreadsheetID != "new-sheet-id" {
+		t.Errorf("unexpected spreadsheet_id: %q", cr.SpreadsheetID)
+	}
+	if cr.Title != "Q1 Report" {
+		t.Errorf("unexpected title: %q", cr.Title)
+	}
+}
+
+func TestCreateSpreadsheet_MissingTitle(t *testing.T) {
+	srv := httptest.NewServer(http.NotFoundHandler())
+	defer srv.Close()
+
+	_, err := adapter().createSpreadsheet(t.Context(), newTestClient(srv), map[string]any{})
+	if err == nil {
+		t.Fatalf("expected error for missing title")
+	}
+}
+
+func TestCreateSpreadsheet_TitleTooLong(t *testing.T) {
+	srv := httptest.NewServer(http.NotFoundHandler())
+	defer srv.Close()
+
+	_, err := adapter().createSpreadsheet(t.Context(), newTestClient(srv), map[string]any{
+		"title": strings.Repeat("x", 201),
+	})
+	if err == nil {
+		t.Fatalf("expected error for title > 200 chars")
+	}
+}

--- a/internal/adapters/google/sheets/adapter.go
+++ b/internal/adapters/google/sheets/adapter.go
@@ -1,0 +1,110 @@
+// Package sheets implements the Clawvisor adapter for Google Sheets.
+package sheets
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+
+	"github.com/clawvisor/clawvisor/internal/adapters/google/credential"
+	"github.com/clawvisor/clawvisor/pkg/adapters"
+)
+
+const serviceID = "google.sheets"
+
+// SheetsAdapter implements adapters.Adapter for Google Sheets.
+type SheetsAdapter struct {
+	oauthProvider adapters.OAuthCredentialProvider
+}
+
+func New(provider adapters.OAuthCredentialProvider) *SheetsAdapter {
+	return &SheetsAdapter{oauthProvider: provider}
+}
+
+func (a *SheetsAdapter) ServiceID() string { return serviceID }
+
+func (a *SheetsAdapter) SupportedActions() []string {
+	return []string{
+		"list_spreadsheets",
+		"get_spreadsheet",
+		"read_range",
+		"append_rows",
+		"update_cells",
+		"create_spreadsheet",
+	}
+}
+
+func (a *SheetsAdapter) RequiredScopes() []string { return sheetsScopes }
+
+func (a *SheetsAdapter) OAuthConfig() *oauth2.Config {
+	if a.oauthProvider == nil {
+		return nil
+	}
+	clientID, clientSecret := a.oauthProvider.OAuthClientCredentials()
+	if clientID == "" {
+		return nil
+	}
+	return &oauth2.Config{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		Scopes:       sheetsScopes,
+		Endpoint:     google.Endpoint,
+	}
+}
+
+func (a *SheetsAdapter) CredentialFromToken(token *oauth2.Token) ([]byte, error) {
+	return credential.FromToken(token, sheetsScopes, false)
+}
+
+func (a *SheetsAdapter) ValidateCredential(credBytes []byte) error {
+	return credential.Validate(credBytes)
+}
+
+// FetchIdentity returns the Google account email for auto-alias detection.
+func (a *SheetsAdapter) FetchIdentity(ctx context.Context, credBytes []byte, _ map[string]string) (string, error) {
+	client, err := a.httpClient(ctx, credBytes)
+	if err != nil {
+		return "", err
+	}
+	return credential.FetchGoogleEmail(ctx, client)
+}
+
+func (a *SheetsAdapter) Execute(ctx context.Context, req adapters.Request) (*adapters.Result, error) {
+	client, err := a.httpClient(ctx, req.Credential)
+	if err != nil {
+		return nil, err
+	}
+
+	switch req.Action {
+	case "list_spreadsheets":
+		return a.listSpreadsheets(ctx, client, req.Params)
+	case "get_spreadsheet":
+		return a.getSpreadsheet(ctx, client, req.Params)
+	case "read_range":
+		return a.readRange(ctx, client, req.Params)
+	case "append_rows":
+		return a.appendRows(ctx, client, req.Params)
+	case "update_cells":
+		return a.updateCells(ctx, client, req.Params)
+	case "create_spreadsheet":
+		return a.createSpreadsheet(ctx, client, req.Params)
+	default:
+		return nil, fmt.Errorf("sheets: unsupported action %q", req.Action)
+	}
+}
+
+func (a *SheetsAdapter) httpClient(ctx context.Context, credBytes []byte) (*http.Client, error) {
+	cred, err := credential.Parse(credBytes)
+	if err != nil {
+		return nil, fmt.Errorf("sheets: %w", err)
+	}
+	cfg := a.OAuthConfig()
+	if cfg == nil {
+		return nil, fmt.Errorf("sheets: OAuth client credentials not configured")
+	}
+	ts := cfg.TokenSource(ctx, cred.ToOAuth2Token())
+	return oauth2.NewClient(ctx, ts), nil
+}

--- a/internal/adapters/google/sheets/adapter_test.go
+++ b/internal/adapters/google/sheets/adapter_test.go
@@ -1,0 +1,48 @@
+package sheets
+
+import (
+	"context"
+	"testing"
+
+	"golang.org/x/oauth2"
+
+	"github.com/clawvisor/clawvisor/internal/adapters/google/credential"
+	"github.com/clawvisor/clawvisor/pkg/adapters"
+)
+
+func testGoogleCredential(t *testing.T, scopes ...string) []byte {
+	t.Helper()
+	cred, err := credential.FromToken(&oauth2.Token{AccessToken: "access-token"}, scopes, true)
+	if err != nil {
+		t.Fatalf("credential.FromToken: %v", err)
+	}
+	return cred
+}
+
+type staticOAuthProvider struct{}
+
+func (staticOAuthProvider) OAuthClientCredentials() (string, string) {
+	return "client-id", "client-secret"
+}
+
+func TestSupportedActions(t *testing.T) {
+	a := New(staticOAuthProvider{})
+	if len(a.SupportedActions()) != 6 {
+		t.Fatalf("expected 6 actions, got %d", len(a.SupportedActions()))
+	}
+}
+
+func TestValidateCredential(t *testing.T) {
+	a := New(staticOAuthProvider{})
+	if err := a.ValidateCredential(testGoogleCredential(t, scopeSheets)); err != nil {
+		t.Fatalf("ValidateCredential: %v", err)
+	}
+}
+
+func TestExecuteUnsupportedAction(t *testing.T) {
+	a := New(staticOAuthProvider{})
+	_, err := a.Execute(context.Background(), adapters.Request{Action: "nope", Credential: testGoogleCredential(t, scopeSheets)})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}

--- a/internal/adapters/google/sheets/format.go
+++ b/internal/adapters/google/sheets/format.go
@@ -1,0 +1,11 @@
+package sheets
+
+import "strings"
+
+func rangeSheetLabel(a1 string) string {
+	// "Sheet1!A1:D10" -> "Sheet1"
+	if i := strings.Index(a1, "!"); i > 0 {
+		return a1[:i]
+	}
+	return a1
+}

--- a/internal/adapters/google/sheets/format_test.go
+++ b/internal/adapters/google/sheets/format_test.go
@@ -1,0 +1,12 @@
+package sheets
+
+import "testing"
+
+func TestRangeSheetLabel(t *testing.T) {
+	if got := rangeSheetLabel("Sheet1!A1:D10"); got != "Sheet1" {
+		t.Fatalf("got %q", got)
+	}
+	if got := rangeSheetLabel("NoBang"); got != "NoBang" {
+		t.Fatalf("got %q", got)
+	}
+}

--- a/internal/adapters/google/sheets/metadata.go
+++ b/internal/adapters/google/sheets/metadata.go
@@ -1,0 +1,86 @@
+package sheets
+
+import "github.com/clawvisor/clawvisor/pkg/adapters"
+
+// ServiceMetadata provides display + risk metadata for the Google Sheets adapter.
+func (a *SheetsAdapter) ServiceMetadata() adapters.ServiceMetadata {
+	maxResults := 50
+	maxRows := 200
+
+	return adapters.ServiceMetadata{
+		DisplayName:   "Google Sheets",
+		Description:   "Read and write Google Sheets spreadsheets",
+		IconURL:       "/logos/google-sheets.svg",
+		VaultKey:      "google",
+		OAuthEndpoint: "google",
+		AutoIdentity:  true,
+		ActionMeta: map[string]adapters.ActionMeta{
+			"list_spreadsheets": {
+				DisplayName: "List spreadsheets",
+				Category:    "read",
+				Sensitivity: "low",
+				Description: "List the user's spreadsheets (via Google Drive)",
+				Params: []adapters.ParamMeta{
+					{Name: "query", Type: "string"},
+					{Name: "max_results", Type: "int", Default: 10, Max: &maxResults},
+				},
+			},
+			"get_spreadsheet": {
+				DisplayName: "Get spreadsheet",
+				Category:    "read",
+				Sensitivity: "low",
+				Description: "Fetch spreadsheet metadata (sheets, named ranges)",
+				Params: []adapters.ParamMeta{
+					{Name: "spreadsheet_id", Type: "string", Required: true},
+				},
+			},
+			"read_range": {
+				DisplayName: "Read range",
+				Category:    "read",
+				Sensitivity: "low",
+				Description: "Read values from a range such as Sheet1!A1:D10",
+				Params: []adapters.ParamMeta{
+					{Name: "spreadsheet_id", Type: "string", Required: true},
+					{Name: "range", Type: "string", Required: true},
+					{Name: "major_dimension", Type: "string", Default: "ROWS"},
+					{Name: "max_rows", Type: "int", Default: 200, Max: &maxRows},
+				},
+			},
+			"append_rows": {
+				DisplayName: "Append rows",
+				Category:    "write",
+				Sensitivity: "medium",
+				Description: "Append rows to a sheet range (adds rows after the last row)",
+				Params: []adapters.ParamMeta{
+					{Name: "spreadsheet_id", Type: "string", Required: true},
+					{Name: "range", Type: "string", Required: true},
+					{Name: "rows", Type: "array", Required: true},
+					{Name: "value_input_option", Type: "string", Default: "USER_ENTERED"},
+				},
+			},
+			"update_cells": {
+				DisplayName: "Update cells",
+				Category:    "write",
+				Sensitivity: "medium",
+				Description: "Write values to a range (overwrites existing cells)",
+				Params: []adapters.ParamMeta{
+					{Name: "spreadsheet_id", Type: "string", Required: true},
+					{Name: "range", Type: "string", Required: true},
+					{Name: "values", Type: "array", Required: true},
+					{Name: "value_input_option", Type: "string", Default: "USER_ENTERED"},
+				},
+			},
+			"create_spreadsheet": {
+				DisplayName: "Create spreadsheet",
+				Category:    "write",
+				Sensitivity: "medium",
+				Description: "Create a new spreadsheet",
+				Params: []adapters.ParamMeta{
+					{Name: "title", Type: "string", Required: true},
+					{Name: "sheets", Type: "array"},
+				},
+			},
+		},
+		VerificationHints: "Google Sheets actions that write data (append_rows, update_cells, create_spreadsheet) should be verified carefully: confirm the spreadsheet_id and range refer to the intended document and that row values do not contain secrets or unintended PII.",
+	}
+}

--- a/internal/adapters/google/sheets/scopes.go
+++ b/internal/adapters/google/sheets/scopes.go
@@ -1,0 +1,16 @@
+package sheets
+
+const (
+	// Full read/write access to Sheets spreadsheets.
+	scopeSheets = "https://www.googleapis.com/auth/spreadsheets"
+	// Scope used for listing spreadsheets via Drive (files.list).
+	scopeDriveReadonly = "https://www.googleapis.com/auth/drive.readonly"
+	// Default identity detection.
+	scopeUserInfoEmail = "https://www.googleapis.com/auth/userinfo.email"
+)
+
+var sheetsScopes = []string{
+	scopeSheets,
+	scopeDriveReadonly,
+	scopeUserInfoEmail,
+}

--- a/internal/adapters/google/sheets/validate.go
+++ b/internal/adapters/google/sheets/validate.go
@@ -1,0 +1,86 @@
+package sheets
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var (
+	spreadsheetIDRe = regexp.MustCompile(`^[a-zA-Z0-9-_]{10,200}$`)
+	// Permissive A1 notation check. We don't try to fully parse it, but we do
+	// prevent obvious garbage and path traversal-like strings.
+	a1RangeRe = regexp.MustCompile(`^[^\s]{1,200}$`)
+)
+
+func paramInt(params map[string]any, key string) (int, bool) {
+	v, ok := params[key]
+	if !ok {
+		return 0, false
+	}
+	switch n := v.(type) {
+	case int:
+		return n, true
+	case int64:
+		return int(n), true
+	case float64:
+		return int(n), true
+	default:
+		return 0, false
+	}
+}
+
+func requireSpreadsheetID(params map[string]any) (string, error) {
+	ssid, _ := params["spreadsheet_id"].(string)
+	ssid = strings.TrimSpace(ssid)
+	if ssid == "" {
+		return "", fmt.Errorf("spreadsheet_id is required")
+	}
+	if !spreadsheetIDRe.MatchString(ssid) {
+		return "", fmt.Errorf("spreadsheet_id looks invalid")
+	}
+	return ssid, nil
+}
+
+func requireA1Range(params map[string]any) (string, error) {
+	rng, _ := params["range"].(string)
+	rng = strings.TrimSpace(rng)
+	if rng == "" {
+		return "", fmt.Errorf("range is required")
+	}
+	if strings.Contains(rng, "..") || strings.ContainsAny(rng, "\n\r\t") {
+		return "", fmt.Errorf("range looks invalid")
+	}
+	if !a1RangeRe.MatchString(rng) {
+		return "", fmt.Errorf("range looks invalid")
+	}
+	// Encourage explicit sheet names for safety.
+	if !strings.Contains(rng, "!") {
+		return "", fmt.Errorf("range must be in A1 notation with a sheet name, e.g. Sheet1!A1:D10")
+	}
+	return rng, nil
+}
+
+func require2DValues(params map[string]any, key string) ([][]any, error) {
+	raw, ok := params[key]
+	if !ok {
+		return nil, fmt.Errorf("%s is required", key)
+	}
+	arr, ok := raw.([]any)
+	if !ok {
+		return nil, fmt.Errorf("%s must be an array of rows", key)
+	}
+	out := make([][]any, 0, len(arr))
+	for _, row := range arr {
+		rowArr, ok := row.([]any)
+		if !ok {
+			return nil, fmt.Errorf("%s must be an array of rows (each row is an array)", key)
+		}
+		// Clamp row width to avoid accidental huge payloads.
+		if len(rowArr) > 200 {
+			return nil, fmt.Errorf("row has too many columns (max 200)")
+		}
+		out = append(out, rowArr)
+	}
+	return out, nil
+}

--- a/internal/adapters/google/sheets/validate_test.go
+++ b/internal/adapters/google/sheets/validate_test.go
@@ -1,0 +1,68 @@
+package sheets
+
+import "testing"
+
+func TestRequireSpreadsheetID(t *testing.T) {
+	_, err := requireSpreadsheetID(map[string]any{})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+
+	_, err = requireSpreadsheetID(map[string]any{"spreadsheet_id": "!!!"})
+	if err == nil {
+		t.Fatalf("expected invalid id error")
+	}
+
+	got, err := requireSpreadsheetID(map[string]any{"spreadsheet_id": "1AbcdefGhij-klmNOPQr"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "1AbcdefGhij-klmNOPQr" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestRequireA1Range(t *testing.T) {
+	_, err := requireA1Range(map[string]any{})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	_, err = requireA1Range(map[string]any{"range": "A1:B2"})
+	if err == nil {
+		t.Fatalf("expected missing sheet name error")
+	}
+	_, err = requireA1Range(map[string]any{"range": "Sheet1!A1\nB2"})
+	if err == nil {
+		t.Fatalf("expected invalid range error")
+	}
+	got, err := requireA1Range(map[string]any{"range": "Sheet1!A1:D10"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "Sheet1!A1:D10" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestRequire2DValues(t *testing.T) {
+	_, err := require2DValues(map[string]any{}, "rows")
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	_, err = require2DValues(map[string]any{"rows": "nope"}, "rows")
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	_, err = require2DValues(map[string]any{"rows": []any{"nope"}}, "rows")
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+
+	rows, err := require2DValues(map[string]any{"rows": []any{[]any{"a", 1, true}}}, "rows")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rows) != 1 || len(rows[0]) != 3 {
+		t.Fatalf("unexpected rows: %#v", rows)
+	}
+}

--- a/internal/runtime/llmproxy/inspector/boundservices.go
+++ b/internal/runtime/llmproxy/inspector/boundservices.go
@@ -42,6 +42,12 @@ func BoundServiceHosts(serviceID string) []string {
 			"www.googleapis.com",
 			"oauth2.googleapis.com",
 		}
+	case "gsheets", "google.sheets", "gsheet", "google.sheet":
+		return []string{
+			"sheets.googleapis.com",
+			"www.googleapis.com",
+			"oauth2.googleapis.com",
+		}
 	case "google.contacts":
 		return []string{
 			"people.googleapis.com",
@@ -54,6 +60,7 @@ func BoundServiceHosts(serviceID string) []string {
 			"gmail.googleapis.com",
 			"calendar.googleapis.com",
 			"drive.googleapis.com",
+			"sheets.googleapis.com",
 			"oauth2.googleapis.com",
 		}
 	case "stripe":

--- a/internal/runtime/llmproxy/inspector/boundservices_test.go
+++ b/internal/runtime/llmproxy/inspector/boundservices_test.go
@@ -70,17 +70,30 @@ func TestBoundServiceHosts_HandlesLLMScopedKeys(t *testing.T) {
 func TestBoundServiceHosts_SplitsGoogleServiceContexts(t *testing.T) {
 	gmail := BoundServiceHosts("google.gmail")
 	calendar := BoundServiceHosts("google.calendar")
+	sheets := BoundServiceHosts("google.sheets")
 	if !containsHost(gmail, "gmail.googleapis.com") {
 		t.Fatalf("gmail hosts should include gmail API, got %v", gmail)
 	}
 	if containsHost(gmail, "calendar.googleapis.com") {
 		t.Fatalf("gmail hosts should not include calendar API, got %v", gmail)
 	}
+	if containsHost(gmail, "sheets.googleapis.com") {
+		t.Fatalf("gmail hosts should not include sheets API, got %v", gmail)
+	}
 	if !containsHost(calendar, "calendar.googleapis.com") {
 		t.Fatalf("calendar hosts should include calendar API, got %v", calendar)
 	}
 	if containsHost(calendar, "gmail.googleapis.com") {
 		t.Fatalf("calendar hosts should not include gmail API, got %v", calendar)
+	}
+	if containsHost(calendar, "sheets.googleapis.com") {
+		t.Fatalf("calendar hosts should not include sheets API, got %v", calendar)
+	}
+	if !containsHost(sheets, "sheets.googleapis.com") {
+		t.Fatalf("sheets hosts should include sheets API, got %v", sheets)
+	}
+	if containsHost(sheets, "gmail.googleapis.com") {
+		t.Fatalf("sheets hosts should not include gmail API, got %v", sheets)
 	}
 }
 

--- a/pkg/adapters/yamlloader/loader_test.go
+++ b/pkg/adapters/yamlloader/loader_test.go
@@ -29,6 +29,7 @@ func TestLoadEmbeddedDefinitions(t *testing.T) {
 		"google.calendar":  false,
 		"google.drive":     false,
 		"google.contacts":  false,
+		"google.sheets":    false,
 		"dropbox":          false,
 		"granola":          false,
 		"perplexity":       false,

--- a/pkg/clawvisor/defaults.go
+++ b/pkg/clawvisor/defaults.go
@@ -27,6 +27,7 @@ import (
 	contactsadapter "github.com/clawvisor/clawvisor/internal/adapters/google/contacts"
 	driveadapter "github.com/clawvisor/clawvisor/internal/adapters/google/drive"
 	gmailadapter "github.com/clawvisor/clawvisor/internal/adapters/google/gmail"
+	sheetsadapter "github.com/clawvisor/clawvisor/internal/adapters/google/sheets"
 	onedriveadapter "github.com/clawvisor/clawvisor/internal/adapters/microsoft/onedrive"
 	outlookadapter "github.com/clawvisor/clawvisor/internal/adapters/microsoft/outlook"
 	perplexityadapter "github.com/clawvisor/clawvisor/internal/adapters/perplexity"
@@ -178,6 +179,11 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 	}
 	contacts := contactsadapter.New(oauthProvider)
 	goOverrides["google.contacts:list_contacts"] = contacts.Execute
+
+	sheets := sheetsadapter.New(oauthProvider)
+	for _, action := range []string{"list_spreadsheets", "get_spreadsheet", "read_range", "append_rows", "update_cells", "create_spreadsheet"} {
+		goOverrides["google.sheets:"+action] = sheets.Execute
+	}
 
 	dbx := dropboxadapter.New()
 	for _, action := range []string{"list_folder", "download_file", "upload_file"} {

--- a/web/public/logos/google-sheets.svg
+++ b/web/public/logos/google-sheets.svg
@@ -1,0 +1,16 @@
+<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
+  <!-- Background -->
+  <rect width="48" height="48" rx="2" fill="#34A853"/>
+  
+  <!-- Grid lines (representing spreadsheet cells) -->
+  <line x1="8" y1="16" x2="40" y2="16" stroke="white" stroke-width="1.5"/>
+  <line x1="8" y1="24" x2="40" y2="24" stroke="white" stroke-width="1.5"/>
+  <line x1="8" y1="32" x2="40" y2="32" stroke="white" stroke-width="1.5"/>
+  
+  <line x1="16" y1="8" x2="16" y2="40" stroke="white" stroke-width="1.5"/>
+  <line x1="24" y1="8" x2="24" y2="40" stroke="white" stroke-width="1.5"/>
+  <line x1="32" y1="8" x2="32" y2="40" stroke="white" stroke-width="1.5"/>
+  
+  <!-- Border -->
+  <rect x="8" y="8" width="32" height="32" rx="1" fill="none" stroke="white" stroke-width="1.5"/>
+</svg>


### PR DESCRIPTION
fixes #430 
Adds a new `google.sheets` adapter with Google OAuth integration and MVP spreadsheet actions.

### Features

- Added `google.sheets` adapter
- Reused existing Google OAuth + vault credential flow
- Added service catalog entry via `google_sheets.yaml`
- Wired Go overrides in `defaults.go`
- Added validation, metadata, and semantic response formatting

### Supported Actions

- `list_spreadsheets`
- `get_spreadsheet`
- `read_range`
- `append_rows`
- `update_cells`
- `create_spreadsheet`

### Notes

- Shares the existing Google OAuth connection model using:
  - `vault_key: google`
  - `scope_merge: true`

### PREVIEW

https://drive.google.com/drive/u/0/folders/1oWeN3vWqZSxoaaEK4mAErPi3osRlm2aE

