### PR TITLE
fix(adaptergen): isolate generated adapters per user

### DIFF
--- a/internal/adaptergen/generator.go
+++ b/internal/adaptergen/generator.go
@@ -27,32 +27,32 @@ type Generator struct {
 	genClient  *llm.Client // high max_tokens for YAML generation
 	riskClient *llm.Client // lower max_tokens for risk classification JSON
 	registry   *adapters.Registry
-	store       AdapterStore
-	userID      string // scopes cache operations; empty for local single-user mode
-	logger      *slog.Logger
+	store      AdapterStore
+	userID     string // scopes cache operations; empty for local single-user mode
+	logger     *slog.Logger
 }
 
 // GenerateResult contains the output of a generation attempt.
 type GenerateResult struct {
-	ServiceID   string         `json:"service_id"`
-	DisplayName string         `json:"display_name"`
-	Description string         `json:"description,omitempty"`
-	BaseURL     string         `json:"base_url"`
-	AuthType    string         `json:"auth_type"`
-	YAML        string         `json:"yaml"`
+	ServiceID   string          `json:"service_id"`
+	DisplayName string          `json:"display_name"`
+	Description string          `json:"description,omitempty"`
+	BaseURL     string          `json:"base_url"`
+	AuthType    string          `json:"auth_type"`
+	YAML        string          `json:"yaml"`
 	Actions     []ActionPreview `json:"actions"`
-	Warnings    []string       `json:"warnings,omitempty"`
-	Installed   bool           `json:"installed"`
+	Warnings    []string        `json:"warnings,omitempty"`
+	Installed   bool            `json:"installed"`
 }
 
 // ActionPreview is a user-friendly summary of a generated action.
 type ActionPreview struct {
-	Name        string        `json:"name"`
-	DisplayName string        `json:"display_name"`
-	Method      string        `json:"method,omitempty"`
-	Path        string        `json:"path,omitempty"`
-	Category    string        `json:"category"`
-	Sensitivity string        `json:"sensitivity"`
+	Name        string         `json:"name"`
+	DisplayName string         `json:"display_name"`
+	Method      string         `json:"method,omitempty"`
+	Path        string         `json:"path,omitempty"`
+	Category    string         `json:"category"`
+	Sensitivity string         `json:"sensitivity"`
 	Params      []ParamPreview `json:"params,omitempty"`
 }
 
@@ -158,7 +158,7 @@ func (g *Generator) Install(ctx context.Context, yamlContent string) (*GenerateR
 // Update regenerates an existing adapter from new source material.
 // The old adapter is replaced in-place.
 func (g *Generator) Update(ctx context.Context, serviceID string, src Source) (*GenerateResult, error) {
-	if _, ok := g.registry.Get(serviceID); !ok {
+	if _, ok := g.registry.GetForUser(ctx, serviceID, g.userID); !ok {
 		return nil, fmt.Errorf("adapter %q not found in registry", serviceID)
 	}
 
@@ -243,6 +243,12 @@ func (g *Generator) classifyRisk(ctx context.Context, rawYAML string) (string, e
 
 // install persists the YAML via the adapter store and hot-loads the adapter into the registry.
 func (g *Generator) install(ctx context.Context, def yamldef.ServiceDef, yamlContent string) error {
+	if g.userID != "" {
+		if _, ok := g.registry.Get(def.Service.ID); ok {
+			return fmt.Errorf("service ID %q collides with a built-in adapter", def.Service.ID)
+		}
+	}
+
 	if err := g.store.Save(ctx, def.Service.ID, yamlContent); err != nil {
 		return fmt.Errorf("saving adapter: %w", err)
 	}
@@ -252,7 +258,11 @@ func (g *Generator) install(ctx context.Context, def yamldef.ServiceDef, yamlCon
 	if err != nil {
 		return fmt.Errorf("building adapter from definition: %w", err)
 	}
-	g.registry.Replace(adapter)
+	if g.userID != "" {
+		g.registry.ReplaceForUser(def.Service.ID, g.userID, adapter)
+	} else {
+		g.registry.Replace(adapter)
+	}
 
 	return nil
 }

--- a/internal/adaptergen/generator_test.go
+++ b/internal/adaptergen/generator_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 
+	"golang.org/x/oauth2"
+
 	"github.com/clawvisor/clawvisor/pkg/adapters"
 	"github.com/clawvisor/clawvisor/pkg/adapters/yamlvalidate"
 	"github.com/clawvisor/clawvisor/pkg/config"
@@ -121,10 +123,58 @@ actions:
 // riskJSON is the risk classification response the mock LLM returns.
 const riskJSON = `{"list_items":{"category":"read","sensitivity":"low"},"create_item":{"category":"write","sensitivity":"medium"}}`
 
+const installableYAML = `service:
+  id: testapi
+  display_name: Test API
+  description: A test API service
+auth:
+  type: api_key
+  header: Authorization
+  header_prefix: "Bearer "
+api:
+  base_url: https://api.test.com
+  type: rest
+actions:
+  list_items:
+    display_name: List items
+    risk:
+      category: read
+      sensitivity: low
+      description: List all items
+    method: GET
+    path: /items
+    params:
+      limit:
+        type: int
+        location: query
+    response:
+      fields:
+        - { name: id }
+        - { name: name }
+      summary: "{{len .Data}} items"
+`
+
 func newTestStore(t *testing.T) *FilesystemStore {
 	t.Helper()
 	return NewFilesystemStore(filepath.Join(t.TempDir(), "adapters"))
 }
+
+type installTestAdapter struct {
+	id      string
+	actions []string
+}
+
+func (a *installTestAdapter) ServiceID() string { return a.id }
+func (a *installTestAdapter) SupportedActions() []string {
+	return a.actions
+}
+func (a *installTestAdapter) Execute(context.Context, adapters.Request) (*adapters.Result, error) {
+	return nil, nil
+}
+func (a *installTestAdapter) OAuthConfig() *oauth2.Config                       { return nil }
+func (a *installTestAdapter) CredentialFromToken(*oauth2.Token) ([]byte, error) { return nil, nil }
+func (a *installTestAdapter) ValidateCredential([]byte) error                   { return nil }
+func (a *installTestAdapter) RequiredScopes() []string                          { return nil }
 
 func TestGenerate_EndToEnd(t *testing.T) {
 	callCount := 0
@@ -190,6 +240,118 @@ func TestGenerate_EndToEnd(t *testing.T) {
 	yamlPath := filepath.Join(store.dir, "testapi.yaml")
 	if _, err := os.Stat(yamlPath); os.IsNotExist(err) {
 		t.Error("adapter YAML file not written to disk")
+	}
+}
+
+func TestInstall_UserScopedDoesNotTouchSharedRegistry(t *testing.T) {
+	store := newTestStore(t)
+	registry := adapters.NewRegistry()
+	gen := New(config.AdapterGenConfig{}, registry, store, "alice", nil)
+
+	installed, err := gen.Install(context.Background(), installableYAML)
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if !installed.Installed {
+		t.Fatal("expected installed result")
+	}
+
+	if _, ok := registry.Get("testapi"); ok {
+		t.Fatal("user-scoped install registered adapter in shared registry")
+	}
+
+	aliceAdapter, ok := registry.GetForUser(context.Background(), "testapi", "alice")
+	if !ok {
+		t.Fatal("alice cannot resolve her generated adapter")
+	}
+	if len(aliceAdapter.SupportedActions()) != 1 {
+		t.Fatalf("alice adapter actions: got %d, want 1", len(aliceAdapter.SupportedActions()))
+	}
+
+	if _, ok := registry.GetForUser(context.Background(), "testapi", "bob"); ok {
+		t.Fatal("bob can resolve alice's generated adapter")
+	}
+}
+
+func TestInstall_UserScopedRejectsBuiltInCollision(t *testing.T) {
+	store := newTestStore(t)
+	registry := adapters.NewRegistry()
+	registry.Register(&installTestAdapter{id: "testapi", actions: []string{"builtin"}})
+	gen := New(config.AdapterGenConfig{}, registry, store, "alice", nil)
+
+	_, err := gen.Install(context.Background(), installableYAML)
+	if err == nil {
+		t.Fatal("expected collision error")
+	}
+	if !strings.Contains(err.Error(), "collides with a built-in adapter") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	yamlPath := filepath.Join(store.dir, "testapi.yaml")
+	if _, statErr := os.Stat(yamlPath); !os.IsNotExist(statErr) {
+		t.Fatalf("colliding adapter was saved to disk; stat err=%v", statErr)
+	}
+
+	got, ok := registry.Get("testapi")
+	if !ok {
+		t.Fatal("built-in adapter disappeared")
+	}
+	actions := got.SupportedActions()
+	if len(actions) != 1 || actions[0] != "builtin" {
+		t.Fatalf("built-in adapter was replaced: actions=%v", actions)
+	}
+}
+
+func TestUpdate_UserScopedGeneratedAdapter(t *testing.T) {
+	callCount := 0
+	_, cfg := newMockLLMServer(t, func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		if callCount == 1 {
+			w.Write(oaResponse(generatedYAML))
+		} else {
+			w.Write(oaResponse(riskJSON))
+		}
+	})
+
+	store := newTestStore(t)
+	registry := adapters.NewRegistry()
+	gen := New(cfg, registry, store, "alice", nil)
+	if _, err := gen.Install(context.Background(), installableYAML); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	result, err := gen.Update(context.Background(), "testapi", Source{
+		Type:    SourceMCP,
+		Content: sampleSlackMCPTools,
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if result.ServiceID != "testapi" {
+		t.Fatalf("updated service ID: got %q, want testapi", result.ServiceID)
+	}
+	if result.Installed {
+		t.Fatal("Update should return a preview, not install automatically")
+	}
+}
+
+func TestRemove_UserScopedGeneratedAdapter(t *testing.T) {
+	store := newTestStore(t)
+	registry := adapters.NewRegistry()
+	gen := New(config.AdapterGenConfig{}, registry, store, "alice", nil)
+	if _, err := gen.Install(context.Background(), installableYAML); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	if err := gen.Remove(context.Background(), "testapi"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if _, ok := registry.GetForUser(context.Background(), "testapi", "alice"); ok {
+		t.Fatal("alice can still resolve removed generated adapter")
+	}
+	if _, ok := registry.Get("testapi"); ok {
+		t.Fatal("removed user adapter affected shared registry")
 	}
 }
 

--- a/internal/api/handlers/approvals.go
+++ b/internal/api/handlers/approvals.go
@@ -522,7 +522,7 @@ func (h *ApprovalsHandler) executeApproval(ctx context.Context, pa *store.Pendin
 	}
 
 	serviceType, alias := parseServiceAlias(blob.Service)
-	vKey := h.adapterReg.VaultKeyWithAlias(serviceType, alias)
+	vKey := h.adapterReg.VaultKeyWithAliasForUser(serviceType, alias, pa.UserID)
 
 	start := time.Now()
 	result, execErr := executeAdapterRequest(ctx, h.vault, h.adapterReg, h.st,

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -2452,7 +2452,7 @@ func parseServiceAlias(service string) (serviceType, alias string) {
 // hasAnyAlias reports whether any vault entry exists for the given service type
 // (under any alias). It uses vault.List and checks for matching key prefixes.
 func hasAnyAlias(ctx context.Context, v vault.Vault, reg *adapters.Registry, userID, serviceType string) bool {
-	base := reg.VaultKey(serviceType)
+	base := reg.VaultKeyForUser(serviceType, userID)
 	keys, err := v.List(ctx, userID)
 	if err != nil {
 		return false
@@ -2488,7 +2488,7 @@ func listServiceAliases(
 		}
 		return aliases
 	}
-	base := reg.VaultKey(serviceType)
+	base := reg.VaultKeyForUser(serviceType, userID)
 	keys, err := v.List(ctx, userID)
 	if err != nil {
 		return nil

--- a/internal/api/handlers/generated_adapter_catalog_test.go
+++ b/internal/api/handlers/generated_adapter_catalog_test.go
@@ -1,0 +1,118 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+
+	"github.com/clawvisor/clawvisor/internal/api/middleware"
+	"github.com/clawvisor/clawvisor/pkg/adapters"
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+type generatedCatalogAdapter struct {
+	id string
+}
+
+func (a *generatedCatalogAdapter) ServiceID() string          { return a.id }
+func (a *generatedCatalogAdapter) SupportedActions() []string { return []string{"list_items"} }
+func (a *generatedCatalogAdapter) Execute(context.Context, adapters.Request) (*adapters.Result, error) {
+	return nil, nil
+}
+func (a *generatedCatalogAdapter) OAuthConfig() *oauth2.Config                       { return nil }
+func (a *generatedCatalogAdapter) CredentialFromToken(*oauth2.Token) ([]byte, error) { return nil, nil }
+func (a *generatedCatalogAdapter) ValidateCredential(cred []byte) error {
+	if len(cred) == 0 {
+		return errors.New("credential required")
+	}
+	return nil
+}
+func (a *generatedCatalogAdapter) RequiredScopes() []string { return nil }
+func (a *generatedCatalogAdapter) ServiceMetadata() adapters.ServiceMetadata {
+	return adapters.ServiceMetadata{
+		DisplayName: "Generated API",
+		Description: "A user generated API adapter",
+		ActionMeta: map[string]adapters.ActionMeta{
+			"list_items": {
+				DisplayName: "List items",
+				Category:    "read",
+				Sensitivity: "low",
+			},
+		},
+	}
+}
+
+type catalogVault struct {
+	keys map[string][]string
+}
+
+func (v catalogVault) Set(context.Context, string, string, []byte) error         { return nil }
+func (v catalogVault) SetIfAbsent(context.Context, string, string, []byte) error { return nil }
+func (v catalogVault) Get(context.Context, string, string) ([]byte, error)       { return nil, nil }
+func (v catalogVault) Delete(context.Context, string, string) error              { return nil }
+func (v catalogVault) List(_ context.Context, userID string) ([]string, error) {
+	return v.keys[userID], nil
+}
+
+func TestServicesListIncludesUserGeneratedAdapter(t *testing.T) {
+	registry := adapters.NewRegistry()
+	registry.SetUserAdapterLister(func(_ context.Context, userID string) ([]adapters.Adapter, bool) {
+		if userID != "alice" {
+			return nil, true
+		}
+		return []adapters.Adapter{&generatedCatalogAdapter{id: "generated.api"}}, true
+	})
+
+	st := newLocalTestStore()
+	st.serviceMetas = []*store.ServiceMeta{{
+		UserID:      "alice",
+		ServiceID:   "generated.api",
+		Alias:       "default",
+		ActivatedAt: time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC),
+	}}
+	h := NewServicesHandler(st, catalogVault{keys: map[string][]string{
+		"alice": {"generated.api"},
+	}}, registry, slog.Default(), "http://localhost:9090", nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/services", nil)
+	req = req.WithContext(context.WithValue(req.Context(), middleware.UserContextKey, &store.User{ID: "alice"}))
+	w := httptest.NewRecorder()
+
+	h.List(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Services []struct {
+			ID      string `json:"id"`
+			Name    string `json:"name"`
+			Status  string `json:"status"`
+			Actions []struct {
+				ID          string `json:"id"`
+				DisplayName string `json:"display_name"`
+				Category    string `json:"category"`
+			} `json:"actions"`
+		} `json:"services"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if len(resp.Services) != 1 {
+		t.Fatalf("expected one generated service, got %#v", resp.Services)
+	}
+	svc := resp.Services[0]
+	if svc.ID != "generated.api" || svc.Name != "Generated API" || svc.Status != "activated" {
+		t.Fatalf("unexpected service entry: %#v", svc)
+	}
+	if len(svc.Actions) != 1 || svc.Actions[0].ID != "list_items" || svc.Actions[0].Category != "read" {
+		t.Fatalf("unexpected action metadata: %#v", svc.Actions)
+	}
+}

--- a/internal/api/handlers/services.go
+++ b/internal/api/handlers/services.go
@@ -23,12 +23,12 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/clawvisor/clawvisor/internal/adapters/google/credential"
-	"github.com/clawvisor/clawvisor/pkg/adapters/mcpadapter"
 	"github.com/clawvisor/clawvisor/internal/api/middleware"
 	"github.com/clawvisor/clawvisor/internal/callback"
 	"github.com/clawvisor/clawvisor/internal/display"
 	"github.com/clawvisor/clawvisor/internal/events"
 	"github.com/clawvisor/clawvisor/pkg/adapters"
+	"github.com/clawvisor/clawvisor/pkg/adapters/mcpadapter"
 	"github.com/clawvisor/clawvisor/pkg/adapters/yamldef"
 	"github.com/clawvisor/clawvisor/pkg/store"
 	"github.com/clawvisor/clawvisor/pkg/vault"
@@ -240,30 +240,30 @@ func (h *ServicesHandler) List(w http.ResponseWriter, r *http.Request) {
 	}
 
 	type serviceEntry struct {
-		ID                   string                  `json:"id"`
-		Name                 string                  `json:"name"`
-		Description          string                  `json:"description"`
-		IconSVG              string                  `json:"icon_svg,omitempty"`
-		IconURL              string                  `json:"icon_url,omitempty"`
-		Alias                string                  `json:"alias,omitempty"`
-		OAuth                bool                    `json:"oauth"`
+		ID                    string                  `json:"id"`
+		Name                  string                  `json:"name"`
+		Description           string                  `json:"description"`
+		IconSVG               string                  `json:"icon_svg,omitempty"`
+		IconURL               string                  `json:"icon_url,omitempty"`
+		Alias                 string                  `json:"alias,omitempty"`
+		OAuth                 bool                    `json:"oauth"`
 		OAuthEndpoint         string                  `json:"oauth_endpoint,omitempty"`
 		OAuthClientIDRequired bool                    `json:"oauth_client_id_required,omitempty"`
 		Deprecated            bool                    `json:"deprecated,omitempty"`
 		DeviceFlow            bool                    `json:"device_flow,omitempty"`
-		PKCEFlow             bool                    `json:"pkce_flow,omitempty"`
-		PKCEClientIDRequired bool                    `json:"pkce_client_id_required,omitempty"`
-		AutoIdentity         bool                    `json:"auto_identity,omitempty"`
-		RequiresActivation   bool                    `json:"requires_activation"`
-		CredentialFree       bool                    `json:"credential_free"`
-		Actions              []actionEntry           `json:"actions"`
-		Variables            []adapters.VariableMeta `json:"variables,omitempty"`
-		Status               string                  `json:"status"`
-		ActivatedAt          *time.Time              `json:"activated_at,omitempty"`
-		SetupURL             string                  `json:"setup_url,omitempty"`
-		KeyHint              string                  `json:"key_hint,omitempty"`
-		KeyDisplayName       string                  `json:"key_display_name,omitempty"`
-		KeyDescription       string                  `json:"key_description,omitempty"`
+		PKCEFlow              bool                    `json:"pkce_flow,omitempty"`
+		PKCEClientIDRequired  bool                    `json:"pkce_client_id_required,omitempty"`
+		AutoIdentity          bool                    `json:"auto_identity,omitempty"`
+		RequiresActivation    bool                    `json:"requires_activation"`
+		CredentialFree        bool                    `json:"credential_free"`
+		Actions               []actionEntry           `json:"actions"`
+		Variables             []adapters.VariableMeta `json:"variables,omitempty"`
+		Status                string                  `json:"status"`
+		ActivatedAt           *time.Time              `json:"activated_at,omitempty"`
+		SetupURL              string                  `json:"setup_url,omitempty"`
+		KeyHint               string                  `json:"key_hint,omitempty"`
+		KeyDisplayName        string                  `json:"key_display_name,omitempty"`
+		KeyDescription        string                  `json:"key_description,omitempty"`
 	}
 
 	// buildEntry creates a serviceEntry from an adapter, using MetadataProvider when available.
@@ -406,7 +406,7 @@ func (h *ServicesHandler) List(w http.ResponseWriter, r *http.Request) {
 			if m.ServiceID != a.ServiceID() {
 				continue
 			}
-			vKey := h.adapterReg.VaultKeyWithAlias(a.ServiceID(), m.Alias)
+			vKey := h.adapterReg.VaultKeyWithAliasForUser(a.ServiceID(), m.Alias, user.ID)
 			if !keySet[vKey] {
 				continue
 			}
@@ -423,7 +423,7 @@ func (h *ServicesHandler) List(w http.ResponseWriter, r *http.Request) {
 			services = append(services, entry)
 		}
 
-		baseKey := h.adapterReg.VaultKey(a.ServiceID())
+		baseKey := h.adapterReg.VaultKeyForUser(a.ServiceID(), user.ID)
 		usesSharedKey := baseKey != a.ServiceID()
 		if !shown && !usesSharedKey && keySet[baseKey] {
 			var activatedAt *time.Time
@@ -478,7 +478,7 @@ func (h *ServicesHandler) OAuthGetURL(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	adapter, ok := h.adapterReg.Get(serviceID)
+	adapter, ok := h.adapterReg.GetForUser(r.Context(), serviceID, user.ID)
 	if !ok {
 		writeError(w, http.StatusNotFound, "NOT_FOUND", fmt.Sprintf("service %q not found", serviceID))
 		return
@@ -587,7 +587,7 @@ func (h *ServicesHandler) OAuthStart(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	adapter, ok := h.adapterReg.Get(serviceID)
+	adapter, ok := h.adapterReg.GetForUser(r.Context(), serviceID, user.ID)
 	if !ok {
 		writeError(w, http.StatusNotFound, "NOT_FOUND", fmt.Sprintf("service %q not found", serviceID))
 		return
@@ -675,7 +675,7 @@ func (h *ServicesHandler) OAuthCallback(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	adapter, ok := h.adapterReg.Get(entry.ServiceID)
+	adapter, ok := h.adapterReg.GetForUser(r.Context(), entry.ServiceID, entry.UserID)
 	if !ok {
 		oauthPopupClose(w, "Service not found.", "", entry.OpenerOrigin)
 		return
@@ -805,9 +805,9 @@ func (h *ServicesHandler) OAuthCallback(w http.ResponseWriter, r *http.Request) 
 	}
 
 	// Auto-detect identity (e.g. email) before storing so the vault key is correct.
-	alias = h.resolveIdentityAlias(r.Context(), entry.ServiceID, alias, credBytes, entry.Config)
+	alias = h.resolveIdentityAlias(r.Context(), entry.UserID, entry.ServiceID, alias, credBytes, entry.Config)
 
-	vKey := h.adapterReg.VaultKeyWithAlias(entry.ServiceID, alias)
+	vKey := h.adapterReg.VaultKeyWithAliasForUser(entry.ServiceID, alias, entry.UserID)
 	if err := h.vault.Set(r.Context(), entry.UserID, vKey, credBytes); err != nil {
 		h.logger.Warn("vault set failed", "service", entry.ServiceID, "err", err)
 		oauthPopupClose(w, "Failed to store credential in vault.", "", entry.OpenerOrigin)
@@ -942,7 +942,7 @@ func (h *ServicesHandler) Activate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	adapter, ok := h.adapterReg.Get(serviceID)
+	adapter, ok := h.adapterReg.GetForUser(r.Context(), serviceID, user.ID)
 	if !ok {
 		writeError(w, http.StatusNotFound, "NOT_FOUND", fmt.Sprintf("service %q not found", serviceID))
 		return
@@ -1046,7 +1046,7 @@ func (h *ServicesHandler) ActivateWithKey(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	adapter, ok := h.adapterReg.Get(serviceID)
+	adapter, ok := h.adapterReg.GetForUser(r.Context(), serviceID, user.ID)
 	if !ok {
 		writeError(w, http.StatusNotFound, "NOT_FOUND", fmt.Sprintf("service %q not found", serviceID))
 		return
@@ -1103,9 +1103,9 @@ func (h *ServicesHandler) ActivateWithKey(w http.ResponseWriter, r *http.Request
 	}
 
 	// Auto-detect identity (e.g. GitHub username) before storing.
-	alias = h.resolveIdentityAlias(r.Context(), serviceID, alias, credBytes, body.Config)
+	alias = h.resolveIdentityAlias(r.Context(), user.ID, serviceID, alias, credBytes, body.Config)
 
-	vKey := h.adapterReg.VaultKeyWithAlias(serviceID, alias)
+	vKey := h.adapterReg.VaultKeyWithAliasForUser(serviceID, alias, user.ID)
 	if err := h.vault.Set(r.Context(), user.ID, vKey, credBytes); err != nil {
 		h.logger.Warn("vault set failed (api key)", "service", serviceID, "err", err)
 		writeError(w, http.StatusInternalServerError, "VAULT_ERROR", "failed to store credential")
@@ -1188,7 +1188,7 @@ func (h *ServicesHandler) Deactivate(w http.ResponseWriter, r *http.Request) {
 	h.adapterReg.RemoveForUser(serviceID, user.ID)
 
 	// Credential-free services have no vault credential to clean up.
-	adapter, ok := h.adapterReg.Get(serviceID)
+	adapter, ok := h.adapterReg.GetForUser(r.Context(), serviceID, user.ID)
 	if ok && adapter.ValidateCredential(nil) == nil {
 		h.revokeTasksForService(r.Context(), user.ID, serviceID, alias)
 		h.logger.Info("credential-free service deactivated", "user", user.ID, "service", serviceID)
@@ -1201,18 +1201,18 @@ func (h *ServicesHandler) Deactivate(w http.ResponseWriter, r *http.Request) {
 	// deactivated service's scopes from the stored credential instead of
 	// deleting it. This ensures resolveOAuthScopes will re-request consent
 	// if the service is re-activated later.
-	vKey := h.adapterReg.VaultKeyWithAlias(serviceID, alias)
+	vKey := h.adapterReg.VaultKeyWithAliasForUser(serviceID, alias, user.ID)
 	metas, _ := h.st.ListServiceMetas(r.Context(), user.ID)
 	otherUsesKey := false
 	for _, m := range metas {
-		if h.adapterReg.VaultKeyWithAlias(m.ServiceID, m.Alias) == vKey {
+		if h.adapterReg.VaultKeyWithAliasForUser(m.ServiceID, m.Alias, user.ID) == vKey {
 			otherUsesKey = true
 			break
 		}
 	}
 	if otherUsesKey {
 		// Strip the deactivated service's scopes from the shared credential.
-		adapter, ok := h.adapterReg.Get(serviceID)
+		adapter, ok := h.adapterReg.GetForUser(r.Context(), serviceID, user.ID)
 		if ok {
 			h.removeAdapterScopes(r.Context(), user.ID, vKey, adapter)
 		}
@@ -1360,8 +1360,8 @@ func (h *ServicesHandler) RenameAlias(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Move the vault credential (if the service has one).
-	oldVKey := h.adapterReg.VaultKeyWithAlias(serviceID, body.OldAlias)
-	newVKey := h.adapterReg.VaultKeyWithAlias(serviceID, body.NewAlias)
+	oldVKey := h.adapterReg.VaultKeyWithAliasForUser(serviceID, body.OldAlias, user.ID)
+	newVKey := h.adapterReg.VaultKeyWithAliasForUser(serviceID, body.NewAlias, user.ID)
 	if oldVKey != newVKey {
 		credBytes, err := h.vault.Get(r.Context(), user.ID, oldVKey)
 		if err == nil && len(credBytes) > 0 {
@@ -1393,7 +1393,7 @@ func (h *ServicesHandler) RenameAlias(w http.ResponseWriter, r *http.Request) {
 		if m.ServiceID == serviceID {
 			continue // already handled
 		}
-		if h.adapterReg.VaultKeyWithAlias(m.ServiceID, m.Alias) == oldVKey {
+		if h.adapterReg.VaultKeyWithAliasForUser(m.ServiceID, m.Alias, user.ID) == oldVKey {
 			_ = h.st.UpsertServiceMeta(r.Context(), user.ID, m.ServiceID, body.NewAlias, m.ActivatedAt)
 			_ = h.st.DeleteServiceMeta(r.Context(), user.ID, m.ServiceID, m.Alias)
 			h.logger.Info("alias renamed (shared key)", "user", user.ID, "service", m.ServiceID, "old", m.Alias, "new", body.NewAlias)
@@ -1450,7 +1450,7 @@ func (h *ServicesHandler) repairMCPToolsForUser(
 	if raw, err := h.st.GetMCPTools(ctx, userID, serviceID, alias); err == nil && len(raw) > 2 {
 		return nil // already cached
 	}
-	vKey := h.adapterReg.VaultKeyWithAlias(serviceID, alias)
+	vKey := h.adapterReg.VaultKeyWithAliasForUser(serviceID, alias, userID)
 	credBytes, err := h.vault.Get(ctx, userID, vKey)
 	if err != nil {
 		return fmt.Errorf("vault get: %w", err)
@@ -1463,13 +1463,13 @@ func (h *ServicesHandler) repairMCPToolsForUser(
 // it fetches the identity and returns it as the new alias. On failure or if the
 // adapter doesn't support identity fetching, it returns the original alias unchanged.
 func (h *ServicesHandler) resolveIdentityAlias(
-	ctx context.Context, serviceID, currentAlias string, credBytes []byte, config map[string]string,
+	ctx context.Context, userID, serviceID, currentAlias string, credBytes []byte, config map[string]string,
 ) string {
 	if currentAlias != "default" {
 		return currentAlias // user explicitly chose an alias
 	}
 
-	adapter, ok := h.adapterReg.Get(serviceID)
+	adapter, ok := h.adapterReg.GetForUser(ctx, serviceID, userID)
 	if !ok {
 		return currentAlias
 	}
@@ -1525,7 +1525,7 @@ func (h *ServicesHandler) reactivatePendingRequest(ctx context.Context, userID, 
 	}
 
 	serviceType, alias := parseServiceAlias(blob.Service)
-	vKey := h.adapterReg.VaultKeyWithAlias(serviceType, alias)
+	vKey := h.adapterReg.VaultKeyWithAliasForUser(serviceType, alias, userID)
 	result, execErr := executeAdapterRequest(ctx, h.vault, h.adapterReg, h.st,
 		userID, blob.Service, blob.Action, blob.Params, vKey)
 
@@ -1577,7 +1577,7 @@ func (h *ServicesHandler) resolveOAuthScopes(
 	}
 
 	// Check for existing credential in the vault.
-	vKey := h.adapterReg.VaultKeyWithAlias(serviceID, alias)
+	vKey := h.adapterReg.VaultKeyWithAliasForUser(serviceID, alias, userID)
 	existingBytes, err := h.vault.Get(ctx, userID, vKey)
 	if err != nil || len(existingBytes) == 0 {
 		// No existing credential — just use this adapter's scopes.
@@ -1665,7 +1665,7 @@ func oauthAuthURL(cfg *oauth2.Config, stateToken string, selectAccount bool, sco
 // loadExistingRefreshToken retrieves the refresh token from an existing vault
 // credential, if any. Google may not re-issue a refresh token on re-consent.
 func (h *ServicesHandler) loadExistingRefreshToken(ctx context.Context, userID, serviceID, alias string) string {
-	vKey := h.adapterReg.VaultKeyWithAlias(serviceID, alias)
+	vKey := h.adapterReg.VaultKeyWithAliasForUser(serviceID, alias, userID)
 	existingBytes, err := h.vault.Get(ctx, userID, vKey)
 	if err != nil || len(existingBytes) == 0 {
 		return ""
@@ -1748,7 +1748,7 @@ func (h *ServicesHandler) DeviceFlowStart(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	adapter, ok := h.adapterReg.Get(serviceID)
+	adapter, ok := h.adapterReg.GetForUser(r.Context(), serviceID, user.ID)
 	if !ok {
 		writeError(w, http.StatusNotFound, "NOT_FOUND", fmt.Sprintf("service %q not found", serviceID))
 		return
@@ -1985,9 +1985,9 @@ func (h *ServicesHandler) DeviceFlowPoll(w http.ResponseWriter, r *http.Request)
 	}
 
 	// Auto-detect identity before storing.
-	alias := h.resolveIdentityAlias(r.Context(), entry.ServiceID, entry.Alias, credBytes, entry.Config)
+	alias := h.resolveIdentityAlias(r.Context(), entry.UserID, entry.ServiceID, entry.Alias, credBytes, entry.Config)
 
-	vKey := h.adapterReg.VaultKeyWithAlias(entry.ServiceID, alias)
+	vKey := h.adapterReg.VaultKeyWithAliasForUser(entry.ServiceID, alias, entry.UserID)
 	if err := h.vault.Set(r.Context(), entry.UserID, vKey, credBytes); err != nil {
 		h.logger.Warn("device flow: vault set failed", "err", err)
 		writeError(w, http.StatusInternalServerError, "VAULT_ERROR", "failed to store credential")
@@ -2040,7 +2040,7 @@ func (h *ServicesHandler) PKCEFlowStart(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	adapter, ok := h.adapterReg.Get(serviceID)
+	adapter, ok := h.adapterReg.GetForUser(r.Context(), serviceID, user.ID)
 	if !ok {
 		writeError(w, http.StatusNotFound, "NOT_FOUND", fmt.Sprintf("service %q not found", serviceID))
 		return
@@ -2202,7 +2202,7 @@ func (h *ServicesHandler) PKCEFlowCallback(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	adapter, ok := h.adapterReg.Get(entry.ServiceID)
+	adapter, ok := h.adapterReg.GetForUser(r.Context(), entry.ServiceID, entry.UserID)
 	if !ok {
 		oauthPopupClose(w, "Service not found.", "", entry.OpenerOrigin)
 		return
@@ -2277,9 +2277,9 @@ func (h *ServicesHandler) PKCEFlowCallback(w http.ResponseWriter, r *http.Reques
 	}
 
 	// Auto-detect identity before storing.
-	alias = h.resolveIdentityAlias(r.Context(), entry.ServiceID, alias, credBytes, entry.Config)
+	alias = h.resolveIdentityAlias(r.Context(), entry.UserID, entry.ServiceID, alias, credBytes, entry.Config)
 
-	vKey := h.adapterReg.VaultKeyWithAlias(entry.ServiceID, alias)
+	vKey := h.adapterReg.VaultKeyWithAliasForUser(entry.ServiceID, alias, entry.UserID)
 	if err := h.vault.Set(r.Context(), entry.UserID, vKey, credBytes); err != nil {
 		h.logger.Warn("pkce flow: vault set failed", "err", err)
 		oauthPopupClose(w, "Failed to store credential.", "", entry.OpenerOrigin)

--- a/internal/api/handlers/skill.go
+++ b/internal/api/handlers/skill.go
@@ -206,7 +206,7 @@ func (h *SkillHandler) Catalog(w http.ResponseWriter, r *http.Request) {
 			if m.ServiceID != baseID {
 				continue
 			}
-			vKey := h.adapterReg.VaultKeyWithAlias(baseID, m.Alias)
+			vKey := h.adapterReg.VaultKeyWithAliasForUser(baseID, m.Alias, agent.UserID)
 			if !keySet[vKey] {
 				continue
 			}
@@ -226,7 +226,7 @@ func (h *SkillHandler) Catalog(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if !shown {
-			baseKey := h.adapterReg.VaultKey(baseID)
+			baseKey := h.adapterReg.VaultKeyForUser(baseID, agent.UserID)
 			usesSharedKey := baseKey != baseID
 			if !usesSharedKey && keySet[baseKey] {
 				entries[baseID] = &catalogEntry{

--- a/internal/api/handlers/tasks.go
+++ b/internal/api/handlers/tasks.go
@@ -2566,7 +2566,7 @@ func (h *TasksHandler) serviceActivated(ctx context.Context, userID, serviceType
 		_, err := h.st.GetServiceMeta(ctx, userID, serviceType, alias)
 		return err == nil
 	}
-	vKey := h.adapterReg.VaultKeyWithAlias(serviceType, alias)
+	vKey := h.adapterReg.VaultKeyWithAliasForUser(serviceType, alias, userID)
 	_, err := h.vault.Get(ctx, userID, vKey)
 	return err == nil
 }
@@ -2595,7 +2595,7 @@ func (h *TasksHandler) missingCredentialScopes(ctx context.Context, userID, serv
 	if len(required) == 0 {
 		return nil
 	}
-	vKey := h.adapterReg.VaultKeyWithAlias(serviceType, alias)
+	vKey := h.adapterReg.VaultKeyWithAliasForUser(serviceType, alias, userID)
 	credBytes, err := h.vault.Get(ctx, userID, vKey)
 	if err != nil || len(credBytes) == 0 {
 		return nil

--- a/internal/api/handlers/welcome.go
+++ b/internal/api/handlers/welcome.go
@@ -275,7 +275,7 @@ func (h *WelcomeHandler) listActivatedServices(ctx context.Context, userID strin
 			if m.ServiceID != a.ServiceID() {
 				continue
 			}
-			vKey := h.adapterReg.VaultKeyWithAlias(a.ServiceID(), m.Alias)
+			vKey := h.adapterReg.VaultKeyWithAliasForUser(a.ServiceID(), m.Alias, userID)
 			if !keySet[vKey] {
 				continue
 			}
@@ -287,7 +287,7 @@ func (h *WelcomeHandler) listActivatedServices(ctx context.Context, userID strin
 			out = append(out, buildEntry(a, m.Alias))
 		}
 
-		baseKey := h.adapterReg.VaultKey(a.ServiceID())
+		baseKey := h.adapterReg.VaultKeyForUser(a.ServiceID(), userID)
 		usesSharedKey := baseKey != a.ServiceID()
 		if !usesSharedKey && keySet[baseKey] {
 			key := a.ServiceID() + ":default"

--- a/pkg/adapters/adapters.go
+++ b/pkg/adapters/adapters.go
@@ -23,18 +23,18 @@ type ServiceMetadata struct {
 	DisplayName       string
 	Description       string
 	SetupURL          string
-	KeyHint           string // placeholder text for the credential input
-	KeyDisplayName    string // label rendered above the credential input (e.g. "Connection string")
-	KeyDescription    string // helper text shown under the label; supports newlines
+	KeyHint           string                // placeholder text for the credential input
+	KeyDisplayName    string                // label rendered above the credential input (e.g. "Connection string")
+	KeyDescription    string                // helper text shown under the label; supports newlines
 	IconSVG           string                // inline SVG markup for the service icon (mutually exclusive with IconURL)
 	IconURL           string                // absolute or site-relative URL to the service icon (e.g. "/logos/github.svg")
 	VaultKey          string                // shared vault key (e.g. "google" for all google.* services); empty = use service ID
 	OAuthEndpoint     string                // well-known OAuth endpoint name (e.g. "google"); empty = not OAuth or no known endpoint
-	DeviceFlow          bool                  // whether device flow activation is available
-	PKCEFlow            bool                  // whether PKCE authorization code flow is available (client ID resolved)
-	PKCEFlowDefined     bool                  // whether PKCE flow is defined in the adapter (even without client ID)
-	AutoIdentity        bool                  // whether the adapter can auto-detect account identity
-	Deprecated          bool                  // hide from the connect-service list for new users (existing connections stay visible)
+	DeviceFlow        bool                  // whether device flow activation is available
+	PKCEFlow          bool                  // whether PKCE authorization code flow is available (client ID resolved)
+	PKCEFlowDefined   bool                  // whether PKCE flow is defined in the adapter (even without client ID)
+	AutoIdentity      bool                  // whether the adapter can auto-detect account identity
+	Deprecated        bool                  // hide from the connect-service list for new users (existing connections stay visible)
 	ActionMeta        map[string]ActionMeta // action_id → metadata
 	VerificationHints string
 	Variables         []VariableMeta // user-configurable variables declared by the adapter
@@ -63,9 +63,9 @@ type ParamMeta struct {
 	Name     string // parameter name as passed in the request
 	Type     string // "string", "int", "bool", "object", "array"
 	Required bool
-	Default  any    // default value, nil if none
-	Min      *int   // minimum value (for int params)
-	Max      *int   // maximum value (for int params)
+	Default  any  // default value, nil if none
+	Min      *int // minimum value (for int params)
+	Max      *int // maximum value (for int params)
 }
 
 // ActionInfo is returned by the service catalog with per-action metadata.
@@ -251,7 +251,7 @@ type Adapter interface {
 // ParamInfo describes a single action parameter for validation and error reporting.
 type ParamInfo struct {
 	Name     string `json:"name"`
-	Type     string `json:"type"`               // "string", "int", "bool", "object", "array"
+	Type     string `json:"type"` // "string", "int", "bool", "object", "array"
 	Required bool   `json:"required"`
 }
 
@@ -276,13 +276,18 @@ type ServiceInfo struct {
 // Used in cloud mode to lazily resolve user-generated adapters from the database.
 type AdapterResolver func(ctx context.Context, serviceID, userID string) (Adapter, bool)
 
+// UserAdapterLister loads all adapters owned by a specific user.
+// Used by catalog/listing paths where the service ID is not known up front.
+type UserAdapterLister func(ctx context.Context, userID string) ([]Adapter, bool)
+
 // Registry holds all registered adapters, keyed by service ID.
 // It is safe for concurrent use.
 type Registry struct {
 	mu           sync.RWMutex
-	adapters     map[string]Adapter                // built-in (shared) adapters
-	userAdapters map[string]map[string]Adapter     // userID → serviceID → adapter (per-user generated)
-	resolver     AdapterResolver                   // optional; called on cache miss by GetForUser
+	adapters     map[string]Adapter                                          // built-in (shared) adapters
+	userAdapters map[string]map[string]Adapter                               // userID → serviceID → adapter (per-user generated)
+	resolver     AdapterResolver                                             // optional; called on cache miss by GetForUser
+	userLister   UserAdapterLister                                           // optional; loads user-only adapters for catalog views
 	fallback     func(ctx context.Context, serviceID string) (Adapter, bool) // cloud-injected resolver for custom adapters
 }
 
@@ -299,6 +304,15 @@ func (r *Registry) SetResolver(fn AdapterResolver) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.resolver = fn
+}
+
+// SetUserAdapterLister sets an optional resolver for user-only adapters when
+// the caller needs the user's whole adapter set and does not already know each
+// service ID. This is the catalog/listing counterpart to GetForUser's resolver.
+func (r *Registry) SetUserAdapterLister(fn UserAdapterLister) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.userLister = fn
 }
 
 func (r *Registry) Register(a Adapter) {
@@ -356,19 +370,29 @@ func (r *Registry) GetForUser(ctx context.Context, serviceID, userID string) (Ad
 	return global, hasGlobal
 }
 
-// RegisterForUser stores a user-scoped adapter instance. Used by activation
-// flows that build adapters with per-user state (e.g. MCP-discovered tools)
-// after the user supplies a credential. Look up via GetForUser.
-func (r *Registry) RegisterForUser(userID string, a Adapter) {
+// ReplaceForUser stores or replaces a user-scoped adapter instance without
+// touching the shared registry. Used for generated adapters and for activation
+// flows that build adapters with per-user state (e.g. MCP-discovered tools).
+func (r *Registry) ReplaceForUser(serviceID, userID string, a Adapter) {
 	if userID == "" {
 		return
+	}
+	if serviceID == "" {
+		serviceID = a.ServiceID()
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.userAdapters[userID] == nil {
 		r.userAdapters[userID] = make(map[string]Adapter)
 	}
-	r.userAdapters[userID][a.ServiceID()] = a
+	r.userAdapters[userID][serviceID] = a
+}
+
+// RegisterForUser stores a user-scoped adapter instance. Used by activation
+// flows that build adapters with per-user state (e.g. MCP-discovered tools)
+// after the user supplies a credential. Look up via GetForUser.
+func (r *Registry) RegisterForUser(userID string, a Adapter) {
+	r.ReplaceForUser(a.ServiceID(), userID, a)
 }
 
 // AllForUser returns the union of built-in adapters and the user's per-user
@@ -384,6 +408,7 @@ func (r *Registry) RegisterForUser(userID string, a Adapter) {
 func (r *Registry) AllForUser(ctx context.Context, userID string) []Adapter {
 	r.mu.RLock()
 	resolver := r.resolver
+	userLister := r.userLister
 	out := make([]Adapter, 0, len(r.adapters))
 	type resolveCandidate struct {
 		serviceID string
@@ -427,6 +452,41 @@ func (r *Registry) AllForUser(ctx context.Context, userID string) []Adapter {
 			out = append(out, resolved)
 		} else {
 			out = append(out, c.global)
+		}
+	}
+	if userLister != nil && userID != "" {
+		if userAdapters, ok := userLister(ctx, userID); ok {
+			r.mu.Lock()
+			if r.userAdapters[userID] == nil {
+				r.userAdapters[userID] = make(map[string]Adapter)
+			}
+			for _, a := range userAdapters {
+				serviceID := a.ServiceID()
+				if _, global := r.adapters[serviceID]; global {
+					continue
+				}
+				r.userAdapters[userID][serviceID] = a
+			}
+			r.mu.Unlock()
+
+			present := make(map[string]bool, len(out))
+			for _, a := range out {
+				present[a.ServiceID()] = true
+			}
+			for _, a := range userAdapters {
+				serviceID := a.ServiceID()
+				if present[serviceID] {
+					continue
+				}
+				r.mu.RLock()
+				_, global := r.adapters[serviceID]
+				r.mu.RUnlock()
+				if global {
+					continue
+				}
+				out = append(out, a)
+				present[serviceID] = true
+			}
 		}
 	}
 	return out

--- a/pkg/adapters/registry_test.go
+++ b/pkg/adapters/registry_test.go
@@ -15,15 +15,15 @@ type stubAdapter struct {
 	actions []string
 }
 
-func (s *stubAdapter) ServiceID() string                                       { return s.id }
-func (s *stubAdapter) SupportedActions() []string                              { return s.actions }
+func (s *stubAdapter) ServiceID() string          { return s.id }
+func (s *stubAdapter) SupportedActions() []string { return s.actions }
 func (s *stubAdapter) Execute(context.Context, adapters.Request) (*adapters.Result, error) {
 	return nil, nil
 }
-func (s *stubAdapter) OAuthConfig() *oauth2.Config                  { return nil }
+func (s *stubAdapter) OAuthConfig() *oauth2.Config                       { return nil }
 func (s *stubAdapter) CredentialFromToken(*oauth2.Token) ([]byte, error) { return nil, nil }
-func (s *stubAdapter) ValidateCredential([]byte) error              { return nil }
-func (s *stubAdapter) RequiredScopes() []string                     { return nil }
+func (s *stubAdapter) ValidateCredential([]byte) error                   { return nil }
+func (s *stubAdapter) RequiredScopes() []string                          { return nil }
 
 // TestGetForUser_PerUserOverridesGlobal locks in the fix for the review:
 // the global registry must NOT shadow a per-user adapter for the same
@@ -97,4 +97,79 @@ func TestGetForUser_ResolverHydratesAcrossRestart(t *testing.T) {
 	if resolverCalls != 1 {
 		t.Fatalf("expected resolver cache hit, got %d total resolver calls", resolverCalls)
 	}
+}
+
+func TestAllForUser_ListerHydratesUserOnlyAdapters(t *testing.T) {
+	reg := adapters.NewRegistry()
+	reg.Register(&stubAdapter{id: "builtin", actions: []string{"read"}})
+
+	listerCalls := 0
+	reg.SetUserAdapterLister(func(_ context.Context, userID string) ([]adapters.Adapter, bool) {
+		listerCalls++
+		if userID == "alice" {
+			return []adapters.Adapter{
+				&stubAdapter{id: "generated", actions: []string{"custom_action"}},
+			}, true
+		}
+		return nil, true
+	})
+
+	all := reg.AllForUser(context.Background(), "alice")
+	seen := map[string]adapters.Adapter{}
+	for _, a := range all {
+		seen[a.ServiceID()] = a
+	}
+	if _, ok := seen["builtin"]; !ok {
+		t.Fatal("AllForUser omitted shared built-in adapter")
+	}
+	generated, ok := seen["generated"]
+	if !ok {
+		t.Fatal("AllForUser omitted user-only generated adapter")
+	}
+	if len(generated.SupportedActions()) != 1 {
+		t.Fatalf("generated adapter lost actions: got %d", len(generated.SupportedActions()))
+	}
+
+	got, ok := reg.GetForUser(context.Background(), "generated", "alice")
+	if !ok {
+		t.Fatal("listed generated adapter was not cached for GetForUser")
+	}
+	if got.ServiceID() != "generated" {
+		t.Fatalf("cached wrong adapter: got %q", got.ServiceID())
+	}
+
+	bobAll := reg.AllForUser(context.Background(), "bob")
+	for _, a := range bobAll {
+		if a.ServiceID() == "generated" {
+			t.Fatal("bob saw alice's generated adapter")
+		}
+	}
+	if listerCalls != 2 {
+		t.Fatalf("expected lister to be called for alice and bob, got %d", listerCalls)
+	}
+}
+
+func TestAllForUser_ListerCannotOverrideGlobalAdapter(t *testing.T) {
+	reg := adapters.NewRegistry()
+	reg.Register(&stubAdapter{id: "builtin", actions: []string{"shared"}})
+	reg.SetUserAdapterLister(func(_ context.Context, userID string) ([]adapters.Adapter, bool) {
+		if userID == "alice" {
+			return []adapters.Adapter{
+				&stubAdapter{id: "builtin", actions: []string{"generated"}},
+			}, true
+		}
+		return nil, true
+	})
+
+	all := reg.AllForUser(context.Background(), "alice")
+	for _, a := range all {
+		if a.ServiceID() == "builtin" {
+			actions := a.SupportedActions()
+			if len(actions) != 1 || actions[0] != "shared" {
+				t.Fatalf("user lister overrode global adapter: actions=%v", actions)
+			}
+			return
+		}
+	}
+	t.Fatal("AllForUser omitted built-in adapter")
 }

--- a/pkg/clawvisor/defaults.go
+++ b/pkg/clawvisor/defaults.go
@@ -272,6 +272,20 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 		mcpByID[ma.ServiceID()] = ma
 	}
 
+	buildGeneratedAdapter := func(serviceID, yamlContent string) (adapters.Adapter, bool) {
+		var def yamldef.ServiceDef
+		if err := yaml.Unmarshal([]byte(yamlContent), &def); err != nil {
+			logger.Warn("resolver: bad YAML for generated adapter", "service_id", serviceID, "err", err)
+			return nil, false
+		}
+		a, err := yamlruntime.New(def, nil)
+		if err != nil {
+			logger.Warn("resolver: failed to build adapter", "service_id", serviceID, "err", err)
+			return nil, false
+		}
+		return a, true
+	}
+
 	// Resolver chain: MCP tool-cache lookup (any mode) + cloud-mode user
 	// generated YAML adapters. Called by Registry on per-user cache miss.
 	adapterReg.SetResolver(func(ctx context.Context, serviceID, userID string) (adapters.Adapter, bool) {
@@ -333,20 +347,32 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 			if row.ServiceID != serviceID {
 				continue
 			}
-			var def yamldef.ServiceDef
-			if err := yaml.Unmarshal([]byte(row.YAMLContent), &def); err != nil {
-				logger.Warn("resolver: bad YAML for generated adapter", "service_id", serviceID, "err", err)
-				return nil, false
-			}
-			a, err := yamlruntime.New(def, nil)
-			if err != nil {
-				logger.Warn("resolver: failed to build adapter", "service_id", serviceID, "err", err)
-				return nil, false
-			}
-			return a, true
+			return buildGeneratedAdapter(serviceID, row.YAMLContent)
 		}
 		return nil, false
 	})
+
+	if cfg.Database.Driver == "postgres" {
+		adapterReg.SetUserAdapterLister(func(ctx context.Context, userID string) ([]adapters.Adapter, bool) {
+			rows, err := st.ListGeneratedAdapters(ctx, userID)
+			if err != nil {
+				logger.Warn("resolver: failed to list generated adapters", "user_id", userID, "err", err)
+				return nil, false
+			}
+			out := make([]adapters.Adapter, 0, len(rows))
+			for _, row := range rows {
+				if _, isGlobal := adapterReg.Get(row.ServiceID); isGlobal {
+					logger.Warn("resolver: skipping generated adapter that collides with a built-in adapter",
+						"user_id", userID, "service_id", row.ServiceID)
+					continue
+				}
+				if a, ok := buildGeneratedAdapter(row.ServiceID, row.YAMLContent); ok {
+					out = append(out, a)
+				}
+			}
+			return out, true
+		})
+	}
 
 	// Initialize the display package with the adapter registry.
 	display.Init(adapterReg)


### PR DESCRIPTION
## Summary

Closes #301

This fixes user-generated adapter isolation end to end.

Previously, installing a generated adapter could hot-load it into the shared adapter registry. In a multi-user/cloud deployment, that means a custom adapter generated by one user could become process-wide state and be visible/resolvable outside that user’s scope.

This PR makes generated adapters user-scoped through install, update, remove, catalog listing, activation, vault lookup, and execution paths.

## What Changed

- User-scoped adapter installs now hot-load into the per-user registry cache instead of the shared registry.
- User-scoped installs reject service IDs that collide with built-in/shared adapters.
- `Update` and `Remove` now resolve generated adapters through `GetForUser`, so cloud/user-scoped adapters can be managed after install.
- Added a user adapter listing hook to the registry so catalog/listing paths can discover user-only generated adapters when the service ID is not already known.
- Wired the cloud resolver to list DB-backed generated adapters for the current user and cache them per user.
- Updated service, welcome, skill catalog, task, approval, and gateway paths to use user-aware adapter/vault-key lookup where generated adapters may be involved.

## Why This Fully Addresses The Issue

The incomplete fix only handled part of the install path. This PR covers the missing surfaces called out in review:

- A generated adapter is not registered globally.
- Another user cannot resolve that adapter through `GetForUser`.
- Built-in adapter IDs cannot be overwritten by generated adapters.
- User-generated adapters still appear in `/api/services` and catalog-style listing paths after restart via `AllForUser`.
- Activation and execution-related paths use user-aware registry/vault-key resolution, so a listed user-generated adapter can actually be used by its owner.

## Regression Coverage

Added tests for:

- User-scoped generated adapter install does not touch the shared registry.
- The owning user can resolve the generated adapter.
- A different user cannot resolve it.
- Built-in/shared adapter ID collisions are rejected before save/hot-load.
- User-scoped generated adapter update works.
- User-scoped generated adapter removal evicts only the user-scoped adapter.
- `AllForUser` hydrates user-only adapters for catalog/listing paths.
- `AllForUser` does not allow a listed user adapter to override a global adapter.
- `/api/services` includes a user-generated adapter for the owning user.

## Validation

Targeted validation passed:

```text
go test ./pkg/adapters
go test ./internal/adaptergen
go test ./internal/api/handlers
go test ./pkg/clawvisor
go vet ./pkg/adapters ./internal/adaptergen ./internal/api/handlers ./pkg/clawvisor
git diff --check
```

Focused regression runs passed:

```text
go test ./pkg/adapters -run "Test(GetForUser|AllForUser)" -count=1 -v
go test ./internal/adaptergen -run "Test(Install_UserScoped|Update_UserScoped|Remove_UserScoped|Generate_EndToEnd)" -count=1 -v
go test ./internal/api/handlers -run "TestServicesListIncludesUserGeneratedAdapter" -count=1 -v
```

Relevant passing package output:

```text
ok      github.com/clawvisor/clawvisor/internal/adaptergen      (cached)
ok      github.com/clawvisor/clawvisor/internal/api/handlers    (cached)
ok      github.com/clawvisor/clawvisor/pkg/adapters             (cached)
ok      github.com/clawvisor/clawvisor/pkg/clawvisor            (cached)
```

Full suite was attempted on Windows:

```text
go test ./...
```

It is blocked by existing Windows/platform-specific failures unrelated to this PR, including Unix-only process APIs:

```text
internal/runtime/isolation/prune.go:153:17: undefined: syscall.Kill
internal/local/executor/exec.go:70:41: unknown field Setpgid in struct literal of type syscall.SysProcAttr
internal/local/executor/exec.go:229:23: undefined: syscall.Getpgid
internal/local/executor/exec.go:233:14: undefined: syscall.Kill
internal/local/executor/server.go:236:41: unknown field Setpgid in struct literal of type syscall.SysProcAttr
```

There are also unrelated Windows file permission expectation failures:

```text
vault key permissions = 666, want 0600
raw log mode=0666, want 0600
adjudication debug dir ... must be owner-only (0700)
```

The packages touched by this PR pass their targeted tests and vet checks locally.