### PR TITLE
fix: redact internal error from risk assessor and log Redis outcome

### DIFF
--- a/internal/runtime/llmproxy/inline_approval_outcome_redis.go
+++ b/internal/runtime/llmproxy/inline_approval_outcome_redis.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -43,7 +44,9 @@ func (s *RedisInlineApprovalOutcomeStore) Record(key InlineApprovalOutcomeKey, o
 	if err != nil {
 		return
 	}
-	_ = s.rdb.Set(context.Background(), redisInlineApprovalOutcomeKey(key), raw, s.ttl).Err()
+	if err := s.rdb.Set(context.Background(), redisInlineApprovalOutcomeKey(key), raw, s.ttl).Err(); err != nil {
+		slog.Warn("failed to persist inline approval outcome", "approval_id", key.ApprovalID, "error", err)
+	}
 }
 
 func (s *RedisInlineApprovalOutcomeStore) Lookup(key InlineApprovalOutcomeKey) (InlineApprovalOutcome, bool) {

--- a/internal/taskrisk/assessor.go
+++ b/internal/taskrisk/assessor.go
@@ -147,7 +147,7 @@ func (a *LLMAssessor) Assess(ctx context.Context, req AssessRequest) (*RiskAsses
 	a.logger.Warn("task risk assessment failed after retry", "error", lastErr)
 	return &RiskAssessment{
 		RiskLevel:   "unknown",
-		Explanation: "Risk assessment failed: " + lastErr.Error(),
+		Explanation: "Risk assessment temporarily unavailable.",
 		Model:       cfg.Model,
 		LatencyMS:   int(time.Since(start).Milliseconds()),
 	}, nil


### PR DESCRIPTION

## Context

Two error-handling gaps were introduced in recent merges:

- **`bd90ae4` - `feat!(proxy-lite): merge llm-proxy` (#417, May 19 2026)**
  This large merge brought in the entire `internal/runtime/llmproxy/` package.
  While most of the error handling is solid, `RedisInlineApprovalOutcomeStore.Record`
  was left with a silent `_ = s.rdb.Set(...)` - Redis write failures were swallowed
  with no visibility for operators.

- **`135b458` - `feat(taskrisk): run LLM risk assessor on v2 envelopes and inline tasks` (#427, May 21 2026)**
  The new `LLMAssessor` returned `lastErr.Error()` verbatim in the `Explanation`
  field of the returned `RiskAssessment`. Internal error details (timeouts,
  connection strings, provider error messages) could leak into stored task records
  or any downstream consumer of the struct.

---

## Changes

### 1. `internal/taskrisk/assessor.go`

**Problem:** On LLM call failure after retry, the assessor returned:

```go
return &RiskAssessment{
    RiskLevel:   "unknown",
    Explanation: "Risk assessment failed: " + lastErr.Error(),
    ...
}, nil
```

`lastErr.Error()` can contain internal details - LLM provider error messages,
connection strings, timeouts - that have no business being in a user-visible
or stored struct field. The error was already logged via `a.logger.Warn(...)` on
the line above, so operator visibility is fully preserved.

**Fix:** Replace the dynamic error string with a static generic message:

```go
return &RiskAssessment{
    RiskLevel:   "unknown",
    Explanation: "Risk assessment temporarily unavailable.",
    ...
}, nil
```

The calling code in `inline_task_intercept.go` already filters out `"unknown"`
risk levels and falls back to the deterministic envelope assessment, so this
change has no effect on the inline approval prompt shown to users.

---

### 2. `internal/runtime/llmproxy/inline_approval_outcome_redis.go`

**Problem:** The `Record` method silently dropped Redis write errors:

```go
_ = s.rdb.Set(context.Background(), redisInlineApprovalOutcomeKey(key), raw, s.ttl).Err()
```

`Record` is fire-and-forget by design (no return value) - the store is used for
cross-replica conversation-history augmentation, not for authoritative state.
However, silent failures make it impossible to distinguish "outcome not yet
recorded" from "Redis is down" when debugging missing augmentation in multi-replica
deployments.

**Fix:** Log the error at warn level without changing the method signature or
making the operation blocking:

```go
if err := s.rdb.Set(context.Background(), redisInlineApprovalOutcomeKey(key), raw, s.ttl).Err(); err != nil {
    slog.Warn("failed to persist inline approval outcome", "approval_id", key.ApprovalID, "error", err)
}
```

---

## What was NOT changed

During the audit, several other `_ =` patterns in `internal/runtime/llmproxy/` were
reviewed and determined to be **intentional**:

- `resolved, _ = req.Catalog.Resolve(...)` in `release.go` and `postprocess.go` - 
  `Resolve` returns `(ResolvedAction, bool)`, not an error. A catalog miss (unknown
  host) is expected and documented; the authorization decision safely falls through
  to approval-required when `Service` and `Action` are empty (see `decision.go:178`).

- `_ = json.Unmarshal(msg["role"], &role)` in `inbound_sanitize.go` and
  `secret_decision_history.go` - intentional lenient parsing. An unmarshal failure
  leaves `role` as `""`, which causes the block to be skipped. This is the correct
  safe default for a sanitization pass.

---

## Files changed

| File | Change |
|------|--------|
| `internal/taskrisk/assessor.go` | Redact `lastErr.Error()` from returned `Explanation` |
| `internal/runtime/llmproxy/inline_approval_outcome_redis.go` | Log Redis `Set` errors instead of swallowing |
