### PR TITLE
feat(llmproxy): coalesce multi-tool turns into one approval

### DIFF
--- a/internal/runtime/conversation/anthropic_response.go
+++ b/internal/runtime/conversation/anthropic_response.go
@@ -562,6 +562,130 @@ func SynthAnthropicToolUseSSE(msgID, model, role, toolUseID, toolName string, to
 	return b.Bytes()
 }
 
+// SynthAnthropicToolUsesJSON builds an Anthropic JSON message-shaped
+// response carrying N tool_use content blocks. Used by the coalesced-
+// approval release path to surface every approved call in one assistant
+// turn. Byte-identical to SynthAnthropicToolUseJSON when len(calls)==1.
+func SynthAnthropicToolUsesJSON(msgID, model, role string, calls []SyntheticToolCall) []byte {
+	if msgID == "" {
+		msgID = "msg_clawvisor_approve"
+	}
+	if model == "" {
+		model = "unknown"
+	}
+	if role == "" {
+		role = "assistant"
+	}
+	content := make([]anthropicJSONContent, 0, len(calls))
+	for _, call := range calls {
+		input := call.Input
+		if input == nil {
+			input = map[string]any{}
+		}
+		inputJSON, err := json.Marshal(input)
+		if err != nil {
+			inputJSON = []byte("{}")
+		}
+		content = append(content, anthropicJSONContent{
+			Type:  "tool_use",
+			ID:    call.ID,
+			Name:  call.Name,
+			Input: inputJSON,
+		})
+	}
+	out := anthropicJSONResponse{
+		ID:         msgID,
+		Type:       "message",
+		Role:       role,
+		Model:      model,
+		Content:    content,
+		StopReason: "tool_use",
+	}
+	body, _ := json.Marshal(out)
+	return body
+}
+
+// SynthAnthropicToolUsesSSE is the SSE counterpart to
+// SynthAnthropicToolUsesJSON: one self-contained Anthropic streamed
+// message carrying N tool_use blocks at sequential indices.
+func SynthAnthropicToolUsesSSE(msgID, model, role string, calls []SyntheticToolCall) []byte {
+	if msgID == "" {
+		msgID = "msg_clawvisor_approve"
+	}
+	if model == "" {
+		model = "unknown"
+	}
+	if role == "" {
+		role = "assistant"
+	}
+	var b bytes.Buffer
+	emit := func(name string, data any) {
+		raw, _ := json.Marshal(data)
+		b.WriteString("event: ")
+		b.WriteString(name)
+		b.WriteString("\ndata: ")
+		b.Write(raw)
+		b.WriteString("\n\n")
+	}
+	emit("message_start", map[string]any{
+		"type": "message_start",
+		"message": map[string]any{
+			"id":            msgID,
+			"type":          "message",
+			"role":          role,
+			"model":         model,
+			"content":       []any{},
+			"stop_reason":   nil,
+			"stop_sequence": nil,
+			"usage":         map[string]int{"input_tokens": 0, "output_tokens": 0},
+		},
+	})
+	for i, call := range calls {
+		input := call.Input
+		if input == nil {
+			input = map[string]any{}
+		}
+		inputJSON, err := json.Marshal(input)
+		if err != nil {
+			inputJSON = []byte("{}")
+		}
+		emit("content_block_start", map[string]any{
+			"type":  "content_block_start",
+			"index": i,
+			"content_block": map[string]any{
+				"type":  "tool_use",
+				"id":    call.ID,
+				"name":  call.Name,
+				"input": map[string]any{},
+			},
+		})
+		emit("content_block_delta", map[string]any{
+			"type":  "content_block_delta",
+			"index": i,
+			"delta": map[string]any{
+				"type":         "input_json_delta",
+				"partial_json": string(inputJSON),
+			},
+		})
+		emit("content_block_stop", map[string]any{
+			"type":  "content_block_stop",
+			"index": i,
+		})
+	}
+	emit("message_delta", map[string]any{
+		"type": "message_delta",
+		"delta": map[string]any{
+			"stop_reason":   "tool_use",
+			"stop_sequence": nil,
+		},
+		"usage": map[string]int{"output_tokens": 0},
+	})
+	emit("message_stop", map[string]any{
+		"type": "message_stop",
+	})
+	return b.Bytes()
+}
+
 func SynthAnthropicToolUseJSON(msgID, model, role, toolUseID, toolName string, toolInput map[string]any) []byte {
 	if msgID == "" {
 		msgID = "msg_clawvisor_approve"

--- a/internal/runtime/conversation/approval_release.go
+++ b/internal/runtime/conversation/approval_release.go
@@ -43,14 +43,41 @@ func AnthropicApprovalReply(body []byte) (verb, id string) {
 	return "", ""
 }
 
+// SyntheticToolCall is one tool_use entry in a (possibly multi-block)
+// synthetic approval-release response. The release path emits one of
+// these per held tool_use when the user approves a coalesced hold.
+type SyntheticToolCall struct {
+	ID    string
+	Name  string
+	Input map[string]any
+}
+
 func SyntheticApprovalToolUseResponse(req *http.Request, provider Provider, requestBody []byte, allow bool, toolUseID, toolName string, toolInput map[string]any) (SyntheticApprovalResponse, bool) {
 	return SyntheticApprovalToolUseResponseWithDenyMessage(req, provider, requestBody, allow, toolUseID, toolName, toolInput, ApprovalDeniedMessage)
 }
 
 func SyntheticApprovalToolUseResponseWithDenyMessage(req *http.Request, provider Provider, requestBody []byte, allow bool, toolUseID, toolName string, toolInput map[string]any, denyMessage string) (SyntheticApprovalResponse, bool) {
+	calls := []SyntheticToolCall{{ID: toolUseID, Name: toolName, Input: toolInput}}
+	return SyntheticApprovalToolUsesResponseWithDenyMessage(req, provider, requestBody, allow, calls, denyMessage)
+}
+
+// SyntheticApprovalToolUsesResponseWithDenyMessage builds a synthetic
+// upstream response that carries N tool_use blocks on approve (or a
+// single text block on deny). When len(calls) == 1 the wire shape is
+// byte-identical to the single-call helper. When len(calls) > 1 the
+// shape is a multi-block assistant turn (Anthropic content[], OpenAI
+// Responses output[], OpenAI Chat tool_calls[]).
+//
+// Used by the coalesced-approval release path: one user yes/no covers
+// every held tool_use in the turn, so the synthetic response must
+// surface every approved call back to the harness for execution.
+func SyntheticApprovalToolUsesResponseWithDenyMessage(req *http.Request, provider Provider, requestBody []byte, allow bool, calls []SyntheticToolCall, denyMessage string) (SyntheticApprovalResponse, bool) {
 	denyMessage = strings.TrimSpace(denyMessage)
 	if denyMessage == "" {
 		denyMessage = ApprovalDeniedMessage
+	}
+	if allow && len(calls) == 0 {
+		return SyntheticApprovalResponse{}, false
 	}
 	contentType := "application/json"
 	var body []byte
@@ -60,9 +87,9 @@ func SyntheticApprovalToolUseResponseWithDenyMessage(req *http.Request, provider
 		if allow {
 			if stream {
 				contentType = "text/event-stream"
-				body = SynthAnthropicToolUseSSE("", "", "assistant", toolUseID, toolName, toolInput)
+				body = SynthAnthropicToolUsesSSE("", "", "assistant", calls)
 			} else {
-				body = SynthAnthropicToolUseJSON("", "", "assistant", toolUseID, toolName, toolInput)
+				body = SynthAnthropicToolUsesJSON("", "", "assistant", calls)
 			}
 		} else if stream {
 			contentType = "text/event-stream"
@@ -76,9 +103,9 @@ func SyntheticApprovalToolUseResponseWithDenyMessage(req *http.Request, provider
 			if allow {
 				if stream {
 					contentType = "text/event-stream"
-					body = SynthOpenAIChatToolCallSSE(toolUseID, toolName, toolInput)
+					body = SynthOpenAIChatToolCallsSSE(calls)
 				} else {
-					body = SynthOpenAIChatToolCallJSON(toolUseID, toolName, toolInput)
+					body = SynthOpenAIChatToolCallsJSON(calls)
 				}
 			} else if stream {
 				contentType = "text/event-stream"
@@ -89,9 +116,9 @@ func SyntheticApprovalToolUseResponseWithDenyMessage(req *http.Request, provider
 		} else if allow {
 			if stream {
 				contentType = "text/event-stream"
-				body = SynthOpenAIResponsesFunctionCallSSE(toolUseID, toolName, toolInput)
+				body = SynthOpenAIResponsesFunctionCallsSSE(calls)
 			} else {
-				body = SynthOpenAIResponsesFunctionCallJSON(toolUseID, toolName, toolInput)
+				body = SynthOpenAIResponsesFunctionCallsJSON(calls)
 			}
 		} else if stream {
 			contentType = "text/event-stream"

--- a/internal/runtime/conversation/openai_response.go
+++ b/internal/runtime/conversation/openai_response.go
@@ -915,6 +915,156 @@ func SynthOpenAIResponsesTextJSON(text string) []byte {
 	return body
 }
 
+// SynthOpenAIResponsesFunctionCallsJSON builds a Responses-API JSON
+// payload carrying N function_call items in `output`. Used by the
+// coalesced-approval release path.
+func SynthOpenAIResponsesFunctionCallsJSON(calls []SyntheticToolCall) []byte {
+	items := make([]openAIResponseOutputItem, 0, len(calls))
+	for _, call := range calls {
+		input := call.Input
+		if input == nil {
+			input = map[string]any{}
+		}
+		args, _ := json.Marshal(input)
+		items = append(items, openAIResponseOutputItem{
+			ID:        "fc_" + call.ID,
+			Type:      "function_call",
+			Status:    "completed",
+			CallID:    call.ID,
+			Name:      call.Name,
+			Arguments: string(args),
+		})
+	}
+	out := openAIResponsesJSON{
+		ID:     "resp_clawvisor_approve",
+		Object: "response",
+		Output: items,
+	}
+	body, _ := json.Marshal(out)
+	return body
+}
+
+// SynthOpenAIResponsesFunctionCallsSSE is the SSE counterpart to
+// SynthOpenAIResponsesFunctionCallsJSON: emits sequential output_item
+// added/delta/done sequences for each function_call.
+func SynthOpenAIResponsesFunctionCallsSSE(calls []SyntheticToolCall) []byte {
+	var b strings.Builder
+	b.WriteString(sseEventBlock("response.created", map[string]any{"type": "response.created", "response": map[string]any{"id": "resp_clawvisor_approve", "status": "in_progress"}}))
+	for i, call := range calls {
+		input := call.Input
+		if input == nil {
+			input = map[string]any{}
+		}
+		args, _ := json.Marshal(input)
+		b.WriteString(sseEventBlock("response.output_item.added", map[string]any{
+			"type":         "response.output_item.added",
+			"output_index": i,
+			"item":         map[string]any{"id": "fc_" + call.ID, "type": "function_call", "status": "in_progress", "call_id": call.ID, "name": call.Name},
+		}))
+		b.WriteString(sseEventBlock("response.function_call_arguments.delta", map[string]any{
+			"type":         "response.function_call_arguments.delta",
+			"item_id":      "fc_" + call.ID,
+			"output_index": i,
+			"delta":        string(args),
+		}))
+		b.WriteString(sseEventBlock("response.function_call_arguments.done", map[string]any{
+			"type":         "response.function_call_arguments.done",
+			"item_id":      "fc_" + call.ID,
+			"output_index": i,
+			"name":         call.Name,
+			"arguments":    string(args),
+		}))
+		b.WriteString(sseEventBlock("response.output_item.done", map[string]any{
+			"type":         "response.output_item.done",
+			"output_index": i,
+			"item":         map[string]any{"id": "fc_" + call.ID, "type": "function_call", "status": "completed", "call_id": call.ID, "name": call.Name, "arguments": string(args)},
+		}))
+	}
+	b.WriteString(sseEventBlock("response.completed", map[string]any{"type": "response.completed", "response": map[string]any{"id": "resp_clawvisor_approve", "status": "completed"}}))
+	return []byte(b.String())
+}
+
+// SynthOpenAIChatToolCallsJSON builds a chat.completion JSON payload
+// carrying N tool_calls on one assistant message. Used by the
+// coalesced-approval release path.
+func SynthOpenAIChatToolCallsJSON(calls []SyntheticToolCall) []byte {
+	toolCalls := make([]openAIChatToolCall, 0, len(calls))
+	for _, call := range calls {
+		input := call.Input
+		if input == nil {
+			input = map[string]any{}
+		}
+		args, _ := json.Marshal(input)
+		toolCalls = append(toolCalls, openAIChatToolCall{
+			ID:   call.ID,
+			Type: "function",
+			Function: openAIChatFunction{
+				Name:      call.Name,
+				Arguments: string(args),
+			},
+		})
+	}
+	out := openAIChatCompletionsResponse{
+		ID:     "chatcmpl_clawvisor_approve",
+		Object: "chat.completion",
+		Choices: []openAIChatChoice{{
+			Index: 0,
+			Message: openAIChatMessage{
+				Role:      "assistant",
+				ToolCalls: toolCalls,
+			},
+			FinishReason: "tool_calls",
+		}},
+	}
+	body, _ := json.Marshal(out)
+	return body
+}
+
+// SynthOpenAIChatToolCallsSSE is the SSE counterpart to
+// SynthOpenAIChatToolCallsJSON: emits one tool_calls delta carrying all
+// N entries (each with its own index in the array).
+func SynthOpenAIChatToolCallsSSE(calls []SyntheticToolCall) []byte {
+	var b strings.Builder
+	b.WriteString(chatCompletionSSEBlock(map[string]any{
+		"id":      "chatcmpl_clawvisor_approve",
+		"object":  "chat.completion.chunk",
+		"choices": []map[string]any{{"index": 0, "delta": map[string]any{"role": "assistant"}, "finish_reason": nil}},
+	}))
+	toolCalls := make([]map[string]any, 0, len(calls))
+	for i, call := range calls {
+		input := call.Input
+		if input == nil {
+			input = map[string]any{}
+		}
+		args, _ := json.Marshal(input)
+		toolCalls = append(toolCalls, map[string]any{
+			"index": i,
+			"id":    call.ID,
+			"type":  "function",
+			"function": map[string]any{
+				"name":      call.Name,
+				"arguments": string(args),
+			},
+		})
+	}
+	b.WriteString(chatCompletionSSEBlock(map[string]any{
+		"id":     "chatcmpl_clawvisor_approve",
+		"object": "chat.completion.chunk",
+		"choices": []map[string]any{{
+			"index":         0,
+			"delta":         map[string]any{"tool_calls": toolCalls},
+			"finish_reason": nil,
+		}},
+	}))
+	b.WriteString(chatCompletionSSEBlock(map[string]any{
+		"id":      "chatcmpl_clawvisor_approve",
+		"object":  "chat.completion.chunk",
+		"choices": []map[string]any{{"index": 0, "delta": map[string]any{}, "finish_reason": "tool_calls"}},
+	}))
+	b.WriteString("data: [DONE]\n\n")
+	return []byte(b.String())
+}
+
 func SynthOpenAIResponsesFunctionCallJSON(toolUseID, toolName string, toolInput map[string]any) []byte {
 	args, _ := json.Marshal(toolInput)
 	out := openAIResponsesJSON{

--- a/internal/runtime/llmproxy/audit.go
+++ b/internal/runtime/llmproxy/audit.go
@@ -154,21 +154,54 @@ func (e *AuditEmitter) LogApprovalRelease(ctx context.Context, agent *store.Agen
 	if e == nil || e.Store == nil || agent == nil || pending == nil {
 		return
 	}
+	// One audit row per release event, with every held tool's
+	// per-call detail under params.held_tools. The audit schema's
+	// canonical dedup index is UNIQUE(user_id, request_id, COALESCE(task_id, ''))
+	// which collapses N rows for the same request to one on insert;
+	// emitting N rows would only land the first and silently drop
+	// the rest, leaving the dashboard grouping that the comment
+	// promised broken. A single row carrying the held_tools array
+	// preserves the per-call detail without fighting the schema.
+	holds := pending.AllHolds()
+	coalesced := pending.IsCoalesced()
+	heldTools := make([]map[string]any, 0, len(holds))
+	for _, held := range holds {
+		heldTools = append(heldTools, map[string]any{
+			"tool_use_id":     held.ToolUse.ID,
+			"tool_name":       held.ToolUse.Name,
+			"held_kind":       string(held.Kind),
+			"target_host":     held.Inspector.Host,
+			"target_method":   held.Inspector.Method,
+			"target_path":     held.Inspector.Path,
+			"decision_source": string(held.Fingerprint.Source),
+		})
+	}
+	// The primary held use drives the top-level target_* fields for
+	// dashboards that key on (target_host, target_method, target_path)
+	// without parsing held_tools. Identical to the pre-coalesce shape
+	// when len(holds) == 1.
+	primary := holds[0]
+	if pending.IsCoalesced() && pending.PrimaryIndex < len(holds) {
+		primary = holds[pending.PrimaryIndex]
+	}
 	params := map[string]any{
 		"event":             "lite_proxy.approval_released",
 		"approval_id":       pending.ID,
 		"provider":          string(pending.Provider),
-		"target_host":       pending.Inspector.Host,
-		"target_method":     pending.Inspector.Method,
-		"target_path":       pending.Inspector.Path,
-		"decision_source":   string(pending.Fingerprint.Source),
+		"target_host":       primary.Inspector.Host,
+		"target_method":     primary.Inspector.Method,
+		"target_path":       primary.Inspector.Path,
+		"decision_source":   string(primary.Fingerprint.Source),
+		"coalesced":         coalesced,
+		"hold_size":         len(holds),
+		"held_tools":        heldTools,
 		"build_sha":         buildSHA(),
 		"validator_prompt":  e.ValidatorPromptSHA,
 		"parser_version":    parserVersion(),
 		"clawvisor_version": version.Version,
 	}
 	paramsJSON, _ := json.Marshal(params)
-	tu := pending.ToolUse.ID
+	tu := primary.ToolUse.ID
 	entry := &store.AuditEntry{
 		ID:         uuid.NewString(),
 		UserID:     agent.UserID,

--- a/internal/runtime/llmproxy/coalesce.go
+++ b/internal/runtime/llmproxy/coalesce.go
@@ -1,0 +1,309 @@
+package llmproxy
+
+import (
+	"context"
+
+	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/inspector"
+	runtimedecision "github.com/clawvisor/clawvisor/pkg/runtime/decision"
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+// evalCapture records one tool_use's outcome from the first eval pass.
+// Captured for every tool_use in a turn so the coalesce decision can
+// classify the whole turn before the response body is finalized.
+type evalCapture struct {
+	Use         conversation.ToolUse
+	Kind        HeldToolUseKind
+	HoldID      string
+	Stage       PendingApprovalStage
+	Inspector   inspector.Verdict
+	Fingerprint runtimedecision.DecisionFingerprint
+	Reason      string
+}
+
+// capturedHoldSink buffers PendingApprovalCache.Hold calls the first
+// eval pass makes. The wrapper does NOT touch the underlying cache
+// during pass 1 — it generates a stable ID, stores the Pending in the
+// buffer, and returns. After the coalesce decision the buffer is
+// either replayed into the underlying cache (legacy mode) or
+// discarded in favor of one coalesced hold (coalesce mode).
+//
+// Buffering avoids two distinct hazards that passthrough has:
+//   - Misleading audit ("allow"/"rewrite" rows for siblings whose
+//     calls were actually replaced by a coalesced approval prompt).
+//     The audit emitter is buffered with the same lifecycle so the
+//     coalesce branch can suppress those rows and replace them with
+//     "coalesced_approval_pending" rows that match what actually
+//     happened.
+//   - Spurious eviction in bounded caches. If the cache is near
+//     capacity, inserting N per-tool holds then the coalesced hold
+//     then dropping the per-tool holds can evict an unrelated older
+//     approval that nobody intended to displace. Buffering keeps the
+//     underlying cache untouched until the final shape is decided.
+type capturedHoldSink struct {
+	holds []capturedHold
+}
+
+type capturedHold struct {
+	// Pending carries the full PendingLiteApproval that the caller
+	// passed to Hold. ID/CreatedAt/ExpiresAt are populated by the
+	// wrapper so callers that consume the returned ID immediately
+	// (e.g. the inline-task intercept building its substitute text)
+	// get a stable value. Replay re-passes this struct unchanged to
+	// the underlying cache.
+	Pending PendingLiteApproval
+}
+
+// holdCapturingApprovalCache wraps a PendingApprovalCache so pass-1
+// Hold calls are buffered, not committed. Peek/Resolve/Drop fall
+// through to the inner cache so the eval pass can still observe
+// existing state (e.g. the inline-task two-step flow checking for an
+// older awaiting-definition hold).
+type holdCapturingApprovalCache struct {
+	inner PendingApprovalCache
+	sink  *capturedHoldSink
+}
+
+func newHoldCapturingApprovalCache(inner PendingApprovalCache, sink *capturedHoldSink) *holdCapturingApprovalCache {
+	return &holdCapturingApprovalCache{
+		inner: inner,
+		sink:  sink,
+	}
+}
+
+func (c *holdCapturingApprovalCache) Hold(_ context.Context, pending PendingLiteApproval) (HoldResult, error) {
+	if pending.ID == "" {
+		id, err := newLiteApprovalID()
+		if err != nil {
+			return HoldResult{}, err
+		}
+		pending.ID = id
+	}
+	// Deliberately do NOT fabricate CreatedAt or ExpiresAt here. The
+	// underlying cache's Hold sets them from its own configured TTL,
+	// and overwriting with a wrapper-local default would bypass that
+	// configuration — a memory cache instantiated with
+	// NewMemoryPendingApprovalCache(time.Minute) would end up
+	// granting 10-minute holds via the wrapper, etc. Callers that
+	// need a specific TTL (e.g. inline-task with its own 10m window)
+	// set ExpiresAt explicitly; we preserve that. Callers that don't
+	// set it get whatever the underlying cache decides at replay.
+	if c.sink != nil {
+		c.sink.holds = append(c.sink.holds, capturedHold{Pending: pending})
+	}
+	// Evicted is reported only at replay time, when the real cache
+	// actually inserts and may displace an older entry. Returning nil
+	// here matches reality (nothing has been inserted yet) and keeps
+	// the per-tool eviction audit row honest: if there's no eviction
+	// because there's no insert, there's no row.
+	return HoldResult{Pending: pending}, nil
+}
+
+func (c *holdCapturingApprovalCache) Peek(ctx context.Context, req ResolveRequest) (*PendingLiteApproval, error) {
+	return c.inner.Peek(ctx, req)
+}
+
+func (c *holdCapturingApprovalCache) Resolve(ctx context.Context, req ResolveRequest) (*PendingLiteApproval, error) {
+	return c.inner.Resolve(ctx, req)
+}
+
+func (c *holdCapturingApprovalCache) Drop(ctx context.Context, req ResolveRequest) error {
+	return c.inner.Drop(ctx, req)
+}
+
+// bufferedAudit is one deferred LogToolUseInspected call from pass 1.
+// Captured per audit() invocation; flushed (legacy) or discarded
+// (coalesce) after the coalesce decision.
+type bufferedAudit struct {
+	ToolUse  conversation.ToolUse
+	Verdict  inspector.Verdict
+	Decision string
+	Outcome  string
+	Reason   string
+}
+
+// capturedAuditSink buffers audit rows from pass 1. See capturedHoldSink
+// for the motivation: pass 1 may emit "allow"/"rewrite" rows for
+// siblings whose calls are then replaced by a coalesced approval, so
+// dashboards keyed on those rows would believe the calls executed.
+// Buffering lets the coalesce branch suppress them and emit corrected
+// rows instead.
+type capturedAuditSink struct {
+	entries []bufferedAudit
+}
+
+// store.Agent is referenced only by the helper signatures below.
+
+// replayBufferedHolds writes the buffered per-tool holds to the
+// underlying cache. Used on the legacy path (no coalescence) and on
+// the coalesced-Hold-failure fallback. Atomicity: if any single Hold
+// fails, every previously-written hold from this batch is dropped
+// and a non-nil error is returned so the caller (Postprocess) can
+// fail closed for the whole response — the alternative is shipping
+// an approval prompt that references a hold that doesn't exist,
+// which leaves the user typing "yes" into a void.
+//
+// Eviction is audited per-row since it didn't happen in pass 1 (the
+// wrapper deferred all writes).
+func replayBufferedHolds(ctx context.Context, cfg PostprocessConfig, inner PendingApprovalCache, sink *capturedHoldSink, agent *store.Agent, captures []evalCapture) error {
+	if inner == nil || sink == nil || len(sink.holds) == 0 {
+		return nil
+	}
+	// Track every successful commit so we can undo on the first
+	// failure. Drop is best-effort (TTL ages anything we miss out
+	// eventually); the important thing is that the response body we
+	// return reflects "no holds exist" rather than "some holds exist."
+	committed := make([]string, 0, len(sink.holds))
+	for i, h := range sink.holds {
+		res, err := inner.Hold(ctx, h.Pending)
+		if err != nil {
+			for _, id := range committed {
+				_ = inner.Drop(ctx, ResolveRequest{
+					UserID:     h.Pending.UserID,
+					AgentID:    h.Pending.AgentID,
+					Provider:   h.Pending.Provider,
+					ApprovalID: id,
+				})
+			}
+			if cfg.Audit != nil && agent != nil && i < len(captures) {
+				use := captures[i].Use
+				v := captures[i].Inspector
+				cfg.Audit.LogToolUseInspected(ctx, agent, cfg.RequestID, use, v, "block", "approval_hold_replay_failed", err.Error())
+			}
+			return err
+		}
+		committed = append(committed, res.Pending.ID)
+		if res.Evicted != nil && cfg.Audit != nil && agent != nil && i < len(captures) {
+			use := captures[i].Use
+			v := captures[i].Inspector
+			cfg.Audit.LogToolUseInspected(ctx, agent, cfg.RequestID, use, v, "block", "approval_evicted", "superseded pending approval "+res.Evicted.ID)
+		}
+	}
+	return nil
+}
+
+// flushBufferedAudit emits each buffered audit row to the configured
+// audit emitter. Used on the legacy path; coalesce mode replaces this
+// with emitCoalescedPendingAuditRows.
+func flushBufferedAudit(ctx context.Context, cfg PostprocessConfig, agent *store.Agent, sink *capturedAuditSink) {
+	if cfg.Audit == nil || agent == nil || sink == nil {
+		return
+	}
+	for _, e := range sink.entries {
+		cfg.Audit.LogToolUseInspected(ctx, agent, cfg.RequestID, e.ToolUse, e.Verdict, e.Decision, e.Outcome, e.Reason)
+	}
+}
+
+// emitCoalescedPendingAuditRows replaces the buffered audit with one
+// "coalesced_approval_pending" row per held tool_use. The original
+// classification (allow/rewrite/approval) is recorded in the reason
+// string so the trail still answers "what would have happened without
+// coalescence?" but the decision/outcome reflect what actually
+// happened: the call did not execute and is awaiting one combined
+// user approval.
+func emitCoalescedPendingAuditRows(ctx context.Context, cfg PostprocessConfig, agent *store.Agent, captures []evalCapture, approvalID string) {
+	if cfg.Audit == nil || agent == nil {
+		return
+	}
+	for _, c := range captures {
+		reason := "held under coalesced approval " + approvalID + " (originally classified as " + string(c.Kind) + ")"
+		cfg.Audit.LogToolUseInspected(ctx, agent, cfg.RequestID, c.Use, c.Inspector, "block", "coalesced_approval_pending", reason)
+	}
+}
+
+// classifyVerdict infers the held-use kind from a verdict. The
+// distinction Postprocess actually needs is approval-vs-not, but
+// allow/rewrite/deny are tracked so the coalesced prompt can label
+// each held use accurately ("auto-allowed alongside"/"rewritten
+// alongside"). The reason-string match on "approval required" is the
+// agreed contract between this classifier and the eval return paths
+// — those reasons are constructed in eval at known points and the
+// substring is stable.
+func classifyVerdict(v conversation.ToolUseVerdict) HeldToolUseKind {
+	if v.Allowed {
+		if len(v.RewriteInput) > 0 {
+			return HeldKindRewrite
+		}
+		return HeldKindAllow
+	}
+	// Approval prompts always include "approval required" in the
+	// Reason string (built in postprocess.go at the two NeedsApproval
+	// branches). Inline-task intercept uses "awaiting inline task
+	// approval" — classified by the Stage field on the captured hold,
+	// not by this function.
+	for _, marker := range []string{"approval required", "awaiting inline task approval"} {
+		if containsFold(v.Reason, marker) {
+			return HeldKindApproval
+		}
+	}
+	return HeldKindDeny
+}
+
+// shouldCoalesceTurn decides whether the post-pass should replace the
+// per-tool holds with a single coalesced hold for this turn.
+//
+// Coalesce iff:
+//   - at least one approval-needing tool_use is present, AND
+//   - more than one tool_use total (otherwise there is nothing to
+//     coalesce — the single hold IS the turn), AND
+//   - no inline-task hold is present (stage != StageTool); the inline-
+//     task flow is single-tool by design and its hold belongs to a
+//     different state machine.
+//
+// A hard-denied tool_use in the same turn falls back to legacy
+// behavior — coalescing around a hard deny would surface a confusing
+// "approve to run the not-blocked one" prompt while another sibling
+// is permanently blocked.
+func shouldCoalesceTurn(captures []evalCapture) bool {
+	if len(captures) <= 1 {
+		return false
+	}
+	approvals := 0
+	for _, c := range captures {
+		switch c.Kind {
+		case HeldKindApproval:
+			if c.Stage != "" && c.Stage != StageTool {
+				return false
+			}
+			approvals++
+		case HeldKindDeny:
+			return false
+		}
+	}
+	return approvals >= 1
+}
+
+func containsFold(s, substr string) bool {
+	if len(substr) == 0 {
+		return true
+	}
+	// ASCII case-insensitive substring search. The reason strings we
+	// match against are ASCII-only by construction, so a full Unicode
+	// fold isn't required. Avoiding strings.EqualFold + indexing keeps
+	// allocations to zero.
+	if len(s) < len(substr) {
+		return false
+	}
+	for i := 0; i+len(substr) <= len(s); i++ {
+		match := true
+		for j := 0; j < len(substr); j++ {
+			a := s[i+j]
+			b := substr[j]
+			if a >= 'A' && a <= 'Z' {
+				a += 'a' - 'A'
+			}
+			if b >= 'A' && b <= 'Z' {
+				b += 'a' - 'A'
+			}
+			if a != b {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/runtime/llmproxy/coalesce.go
+++ b/internal/runtime/llmproxy/coalesce.go
@@ -202,11 +202,30 @@ func flushBufferedAudit(ctx context.Context, cfg PostprocessConfig, agent *store
 // coalescence?" but the decision/outcome reflect what actually
 // happened: the call did not execute and is awaiting one combined
 // user approval.
+//
+// The audit schema's UNIQUE(user_id, request_id, COALESCE(task_id,''))
+// canonical dedup index collapses repeated emits for one request to a
+// single persisted row. Approval-triggering captures are emitted
+// FIRST so the row that wins dedup describes the call that drove the
+// hold — without ordering, an auto-allow sibling that happens to be
+// first in turn order would shadow the approval-needing call in the
+// persisted trail.
 func emitCoalescedPendingAuditRows(ctx context.Context, cfg PostprocessConfig, agent *store.Agent, captures []evalCapture, approvalID string) {
 	if cfg.Audit == nil || agent == nil {
 		return
 	}
+	ordered := make([]evalCapture, 0, len(captures))
 	for _, c := range captures {
+		if c.Kind == HeldKindApproval {
+			ordered = append(ordered, c)
+		}
+	}
+	for _, c := range captures {
+		if c.Kind != HeldKindApproval {
+			ordered = append(ordered, c)
+		}
+	}
+	for _, c := range ordered {
 		reason := "held under coalesced approval " + approvalID + " (originally classified as " + string(c.Kind) + ")"
 		cfg.Audit.LogToolUseInspected(ctx, agent, cfg.RequestID, c.Use, c.Inspector, "block", "coalesced_approval_pending", reason)
 	}

--- a/internal/runtime/llmproxy/coalesce_test.go
+++ b/internal/runtime/llmproxy/coalesce_test.go
@@ -580,6 +580,88 @@ func TestPostprocess_CoalesceAuditDoesNotEmitMisleadingAllow(t *testing.T) {
 	}
 }
 
+// Regression: the persisted coalesced-pending audit detail must not
+// lose the tool_use that actually triggered approval. The audit table
+// dedups canonical rows by (user, request, task), so writing one row
+// per held tool can leave only the first sibling (Bash) and drop the
+// WebFetch row that explains why the turn was held.
+func TestPostprocess_CoalescePendingAuditSurfacesApprovalTrigger(t *testing.T) {
+	requestID := "req-coalesced-pending-trigger"
+	body := []byte(`{
+		"id":"msg_1",
+		"type":"message",
+		"role":"assistant",
+		"model":"claude-haiku-4-5",
+		"content":[
+			{"type":"tool_use","id":"toolu_bash","name":"Bash","input":{"command":"ls -la"}},
+			{"type":"tool_use","id":"toolu_fetch","name":"WebFetch","input":{"url":"https://example.com/x"}}
+		],
+		"stop_reason":"tool_use"
+	}`)
+	req := httptest.NewRequest("POST", "/v1/messages", nil)
+	insp := inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{})
+	st, userID, agentID := seedPostprocessStore(t, "autovault_github_xxx")
+	cache := NewMemoryPendingApprovalCache(time.Minute)
+	emitter := NewAuditEmitter(st, nil, nil)
+
+	_ = Postprocess(req, body, "application/json", PostprocessConfig{
+		Inspector:        insp,
+		RewriteOpts:      inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
+		CallerNonces:     NewMemoryCallerNonceCache(time.Minute),
+		Store:            st,
+		AgentUserID:      userID,
+		AgentID:          agentID,
+		RequestID:        requestID,
+		PendingApprovals: cache,
+		ResponseRegistry: conversation.DefaultResponseRegistry(),
+		CandidateTasks:   []*store.Task{},
+		ToolRules: []*store.RuntimePolicyRule{
+			{ID: "review-webfetch", UserID: userID, AgentID: &agentID, Kind: "tool", Action: "review", ToolName: "WebFetch", Reason: "review web fetch", Enabled: true},
+		},
+		EgressRules: []*store.RuntimePolicyRule{},
+		Audit:       emitter,
+	})
+
+	rows, _, err := st.ListAuditEntries(context.Background(), userID, store.AuditFilter{})
+	if err != nil {
+		t.Fatalf("ListAuditEntries: %v", err)
+	}
+	foundPending := false
+	foundApprovalTrigger := false
+	var persisted []map[string]any
+	for _, r := range rows {
+		if r.RequestID != requestID || r.Outcome != "coalesced_approval_pending" {
+			continue
+		}
+		foundPending = true
+		var params map[string]any
+		if err := json.Unmarshal(r.ParamsSafe, &params); err != nil {
+			t.Fatalf("params unmarshal: %v", err)
+		}
+		persisted = append(persisted, params)
+		if params["tool_name"] == "WebFetch" || params["tool_use_id"] == "toolu_fetch" {
+			foundApprovalTrigger = true
+		}
+		if held, ok := params["held_tools"].([]any); ok {
+			for _, item := range held {
+				m, ok := item.(map[string]any)
+				if !ok {
+					continue
+				}
+				if m["tool_name"] == "WebFetch" || m["tool_use_id"] == "toolu_fetch" {
+					foundApprovalTrigger = true
+				}
+			}
+		}
+	}
+	if !foundPending {
+		t.Fatalf("expected a coalesced_approval_pending audit row for %s", requestID)
+	}
+	if !foundApprovalTrigger {
+		t.Fatalf("coalesced pending audit lost approval-triggering WebFetch/toolu_fetch; persisted params: %+v", persisted)
+	}
+}
+
 // Regression: legacy-path replay must fail closed when the underlying
 // cache rejects the Hold. The first-pass body references approval
 // prompts; if their per-tool holds can't be committed, the body
@@ -876,6 +958,56 @@ func TestAuditEmitter_LogApprovalRelease_CoalescedEmitsOneRowWithPerToolDetail(t
 		}
 		if m["tool_use_id"] == "" || m["held_kind"] == "" {
 			t.Fatalf("held_tools[%d] missing tool_use_id/held_kind: %+v", i, m)
+		}
+	}
+}
+
+// Regression: when the user types "task" against a coalesced hold,
+// the rewritten user turn (which the model sees on its next request)
+// must enumerate EVERY held tool's name in expected_tools — not
+// just the primary. Without this, the generated task scope covers
+// only one of the held calls and the sibling reviewed calls re-prompt
+// on retry, defeating the gesture.
+func TestStartInlineTaskDefinition_CoalescedHoldCoversEveryHeldTool(t *testing.T) {
+	ctx := context.Background()
+	cache := NewMemoryPendingApprovalCache(time.Minute)
+	held, err := cache.Hold(ctx, PendingLiteApproval{
+		ID:       "cv-coalescetaskxxxxxxxxxxxxxx",
+		UserID:   "user-1",
+		AgentID:  "agent-1",
+		Provider: conversation.ProviderAnthropic,
+		Stage:    StageTool,
+		ToolUse:  conversation.ToolUse{ID: "toolu_fetch", Name: "WebFetch", Input: json.RawMessage(`{"url":"https://example.com/x"}`)},
+		Additional: []HeldToolUse{{
+			ToolUse: conversation.ToolUse{ID: "toolu_bash", Name: "Bash", Input: json.RawMessage(`{"command":"ls"}`)},
+			Kind:    HeldKindAllow,
+		}},
+		PrimaryIndex: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := RewriteTaskApprovalReply(ctx, TaskReplyRewriteRequest{
+		HTTPRequest:     httptest.NewRequest("POST", "/v1/messages", nil),
+		Provider:        conversation.ProviderAnthropic,
+		Body:            []byte(`{"messages":[{"role":"user","content":"task ` + held.Pending.ID + `"}]}`),
+		Agent:           &store.Agent{ID: "agent-1", UserID: "user-1"},
+		PendingApproval: cache,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !out.Rewritten {
+		t.Fatalf("expected task-reply rewrite to fire on coalesced hold")
+	}
+	rewritten := string(out.Body)
+	// The prompt is embedded as a JSON string inside the Anthropic
+	// request body so double-quotes are escaped; match the escaped
+	// form to avoid coupling to the body's outer encoding.
+	for _, name := range []string{`\"tool_name\": \"WebFetch\"`, `\"tool_name\": \"Bash\"`} {
+		if !strings.Contains(rewritten, name) {
+			t.Fatalf("rewritten user turn must enumerate every held tool's name; missing %s\nbody: %s", name, rewritten)
 		}
 	}
 }

--- a/internal/runtime/llmproxy/coalesce_test.go
+++ b/internal/runtime/llmproxy/coalesce_test.go
@@ -1,0 +1,960 @@
+package llmproxy
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/inspector"
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+// Mixed-turn coalescence: bash that would auto-allow alongside a
+// WebFetch flagged for review. The whole turn is held under one
+// coalesced approval; the bash sibling is tagged HeldKindAllow on the
+// hold, and the rendered prompt mentions both calls.
+func TestPostprocess_CoalescesMixedAllowAndApproval(t *testing.T) {
+	body := []byte(`{
+		"id":"msg_1",
+		"type":"message",
+		"role":"assistant",
+		"model":"claude-haiku-4-5",
+		"content":[
+			{"type":"tool_use","id":"toolu_bash","name":"Bash","input":{"command":"ls -la"}},
+			{"type":"tool_use","id":"toolu_fetch","name":"WebFetch","input":{"url":"https://example.com/x"}}
+		],
+		"stop_reason":"tool_use"
+	}`)
+	req := httptest.NewRequest("POST", "/v1/messages", nil)
+	insp := inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{})
+	st, userID, agentID := seedPostprocessStore(t, "autovault_github_xxx")
+	cache := NewMemoryPendingApprovalCache(time.Minute)
+
+	got := Postprocess(req, body, "application/json", PostprocessConfig{
+		Inspector:        insp,
+		RewriteOpts:      inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
+		CallerNonces:     NewMemoryCallerNonceCache(time.Minute),
+		Store:            st,
+		AgentUserID:      userID,
+		AgentID:          agentID,
+		PendingApprovals: cache,
+		ResponseRegistry: conversation.DefaultResponseRegistry(),
+		CandidateTasks:   []*store.Task{},
+		ToolRules: []*store.RuntimePolicyRule{
+			{ID: "review-webfetch", UserID: userID, AgentID: &agentID, Kind: "tool", Action: "review", ToolName: "WebFetch", Reason: "review web fetch", Enabled: true},
+		},
+		EgressRules: []*store.RuntimePolicyRule{},
+	})
+	if !got.Rewritten {
+		t.Fatalf("expected coalesced approval rewrite, got: %s", got.Body)
+	}
+	out := string(got.Body)
+	if !strings.Contains(out, "Clawvisor paused this turn for approval (2 tool calls).") {
+		t.Fatalf("expected coalesced header, got: %s", out)
+	}
+	if !strings.Contains(out, "`Bash`") || !strings.Contains(out, "`WebFetch`") {
+		t.Fatalf("coalesced prompt should mention both tools, got: %s", out)
+	}
+	if !strings.Contains(out, "held alongside") {
+		t.Fatalf("expected the bash sibling to be labeled 'held alongside', got: %s", out)
+	}
+
+	holds := cache.snapshotHoldsForTest(userID, agentID, conversation.ProviderAnthropic)
+	if len(holds) != 1 {
+		t.Fatalf("expected exactly one coalesced hold, got %d", len(holds))
+	}
+	hold := holds[0]
+	all := hold.AllHolds()
+	if len(all) != 2 {
+		t.Fatalf("expected 2 held tool_uses, got %d", len(all))
+	}
+	// AllHolds() returns held tool_uses in the model's original turn
+	// order — Bash first (auto-allow), then WebFetch (approval
+	// trigger). The primary slot tracks the approval-needing
+	// WebFetch internally (Inspector/Fingerprint/Reason point at it),
+	// but the visible order matches the model's emit order so the
+	// released call sequence is deterministic for dependent calls.
+	if all[0].ToolUse.ID != "toolu_bash" || all[0].Kind != HeldKindAllow {
+		t.Fatalf("expected Bash first (turn order) as HeldKindAllow, got %+v", all[0])
+	}
+	if all[1].ToolUse.ID != "toolu_fetch" || all[1].Kind != HeldKindApproval {
+		t.Fatalf("expected WebFetch second (turn order) as HeldKindApproval, got %+v", all[1])
+	}
+	if hold.ToolUse.ID != "toolu_fetch" {
+		t.Fatalf("primary slot should be the approval-needing WebFetch, got %s", hold.ToolUse.ID)
+	}
+	if hold.PrimaryIndex != 1 {
+		t.Fatalf("PrimaryIndex = %d, want 1 (WebFetch was second in the turn)", hold.PrimaryIndex)
+	}
+}
+
+// A turn with a single tool_use needing approval is NOT coalesced —
+// coalescing one element into one element is a no-op, and the legacy
+// per-tool prompt (with the "task" verb) stays available.
+func TestPostprocess_SingleApprovalKeepsLegacyPromptShape(t *testing.T) {
+	body := []byte(`{
+		"id":"msg_1",
+		"type":"message",
+		"role":"assistant",
+		"model":"claude-haiku-4-5",
+		"content":[
+			{"type":"tool_use","id":"toolu_only","name":"WebFetch","input":{"url":"https://example.com/x"}}
+		],
+		"stop_reason":"tool_use"
+	}`)
+	req := httptest.NewRequest("POST", "/v1/messages", nil)
+	insp := inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{})
+	st, userID, agentID := seedPostprocessStore(t, "autovault_github_xxx")
+	cache := NewMemoryPendingApprovalCache(time.Minute)
+
+	got := Postprocess(req, body, "application/json", PostprocessConfig{
+		Inspector:        insp,
+		RewriteOpts:      inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
+		CallerNonces:     NewMemoryCallerNonceCache(time.Minute),
+		Store:            st,
+		AgentUserID:      userID,
+		AgentID:          agentID,
+		PendingApprovals: cache,
+		ResponseRegistry: conversation.DefaultResponseRegistry(),
+		CandidateTasks:   []*store.Task{},
+		ToolRules: []*store.RuntimePolicyRule{
+			{ID: "review-webfetch", UserID: userID, AgentID: &agentID, Kind: "tool", Action: "review", ToolName: "WebFetch", Reason: "review web fetch", Enabled: true},
+		},
+		EgressRules: []*store.RuntimePolicyRule{},
+	})
+	out := string(got.Body)
+	if !strings.Contains(out, "Clawvisor paused this tool call for approval.") {
+		t.Fatalf("single-tool turn should use legacy prompt, got: %s", out)
+	}
+	if !strings.Contains(out, "or `task` to instruct") {
+		t.Fatalf("single-tool prompt should retain the 'task' verb, got: %s", out)
+	}
+	holds := cache.snapshotHoldsForTest(userID, agentID, conversation.ProviderAnthropic)
+	if len(holds) != 1 || holds[0].IsCoalesced() {
+		t.Fatalf("single-tool turn should produce one non-coalesced hold; got %+v", holds)
+	}
+}
+
+func TestShouldCoalesceTurn(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []evalCapture
+		want bool
+	}{
+		{
+			name: "empty",
+			in:   nil,
+			want: false,
+		},
+		{
+			name: "single approval",
+			in:   []evalCapture{{Kind: HeldKindApproval}},
+			want: false,
+		},
+		{
+			name: "two approvals",
+			in:   []evalCapture{{Kind: HeldKindApproval}, {Kind: HeldKindApproval}},
+			want: true,
+		},
+		{
+			name: "approval + auto-allow sibling",
+			in:   []evalCapture{{Kind: HeldKindAllow}, {Kind: HeldKindApproval}},
+			want: true,
+		},
+		{
+			name: "all auto-allow — nothing to coalesce",
+			in:   []evalCapture{{Kind: HeldKindAllow}, {Kind: HeldKindAllow}},
+			want: false,
+		},
+		{
+			name: "hard deny in turn — fall back to legacy",
+			in:   []evalCapture{{Kind: HeldKindApproval}, {Kind: HeldKindDeny}},
+			want: false,
+		},
+		{
+			name: "inline-task stage skips coalesce",
+			in:   []evalCapture{{Kind: HeldKindApproval, Stage: StageAwaitingTaskApproval}, {Kind: HeldKindAllow}},
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldCoalesceTurn(tc.in); got != tc.want {
+				t.Fatalf("shouldCoalesceTurn(%s) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClassifyVerdict(t *testing.T) {
+	cases := []struct {
+		name string
+		v    conversation.ToolUseVerdict
+		want HeldToolUseKind
+	}{
+		{"allowed pass-through", conversation.ToolUseVerdict{Allowed: true}, HeldKindAllow},
+		{"allowed with rewrite", conversation.ToolUseVerdict{Allowed: true, RewriteInput: json.RawMessage(`{"x":1}`)}, HeldKindRewrite},
+		{"approval-required", conversation.ToolUseVerdict{Allowed: false, Reason: "Clawvisor: approval required — review"}, HeldKindApproval},
+		{"inline-task awaiting", conversation.ToolUseVerdict{Allowed: false, Reason: "Clawvisor: awaiting inline task approval"}, HeldKindApproval},
+		{"hard deny", conversation.ToolUseVerdict{Allowed: false, Reason: "Clawvisor: ambiguous credentialed call refused — bad shape"}, HeldKindDeny},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifyVerdict(tc.v); got != tc.want {
+				t.Fatalf("classifyVerdict(%s) = %q, want %q", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// Coalesced-hold release: a single user "yes" produces a synthetic
+// response carrying every approved tool_use. The harness then executes
+// them all from one user gesture.
+func TestTryReleasePendingApproval_CoalescedAllowEmitsAllCalls(t *testing.T) {
+	ctx := context.Background()
+	cache := NewMemoryPendingApprovalCache(time.Minute)
+
+	primary := conversation.ToolUse{ID: "toolu_a", Name: "Bash", Input: json.RawMessage(`{"command":"echo a"}`)}
+	sibling := conversation.ToolUse{ID: "toolu_b", Name: "Bash", Input: json.RawMessage(`{"command":"echo b"}`)}
+	held, err := cache.Hold(ctx, PendingLiteApproval{
+		ID:       "cv-coalescereleasexxxxxxxxxxx",
+		UserID:   "user-1",
+		AgentID:  "agent-1",
+		Provider: conversation.ProviderAnthropic,
+		Stage:    StageTool,
+		ToolUse:  primary,
+		Reason:   "test coalesced release",
+		Additional: []HeldToolUse{{
+			ToolUse: sibling,
+			Kind:    HeldKindAllow,
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := TryReleasePendingApproval(ctx, ReleaseRequest{
+		HTTPRequest:     httptest.NewRequest("POST", "/v1/messages", nil),
+		Provider:        conversation.ProviderAnthropic,
+		Body:            []byte(`{"messages":[{"role":"user","content":"approve ` + held.Pending.ID + `"}]}`),
+		Agent:           &store.Agent{ID: "agent-1", UserID: "user-1"},
+		PendingApproval: cache,
+		Inspector:       inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{}),
+	})
+	if !result.Handled || result.Decision != "allow" || result.Outcome != "approval_released" {
+		t.Fatalf("coalesced approve should release, got %+v", result)
+	}
+	bodyStr := string(result.Body)
+	if !strings.Contains(bodyStr, `"id":"toolu_a"`) || !strings.Contains(bodyStr, `"id":"toolu_b"`) {
+		t.Fatalf("coalesced release response must carry every approved tool_use; got: %s", bodyStr)
+	}
+	if !strings.Contains(bodyStr, `"name":"Bash"`) {
+		t.Fatalf("coalesced release response missing tool name; got: %s", bodyStr)
+	}
+}
+
+// Coalesced-hold release deny: a single "no" produces a single text
+// block; no tool_use blocks at all (no half-execution).
+func TestTryReleasePendingApproval_CoalescedDenyProducesTextOnly(t *testing.T) {
+	ctx := context.Background()
+	cache := NewMemoryPendingApprovalCache(time.Minute)
+
+	held, err := cache.Hold(ctx, PendingLiteApproval{
+		ID:       "cv-coalescedenyxxxxxxxxxxxxxx",
+		UserID:   "user-1",
+		AgentID:  "agent-1",
+		Provider: conversation.ProviderAnthropic,
+		Stage:    StageTool,
+		ToolUse:  conversation.ToolUse{ID: "toolu_a", Name: "Bash", Input: json.RawMessage(`{"command":"echo a"}`)},
+		Additional: []HeldToolUse{{
+			ToolUse: conversation.ToolUse{ID: "toolu_b", Name: "Bash", Input: json.RawMessage(`{"command":"echo b"}`)},
+			Kind:    HeldKindAllow,
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := TryReleasePendingApproval(ctx, ReleaseRequest{
+		HTTPRequest:     httptest.NewRequest("POST", "/v1/messages", nil),
+		Provider:        conversation.ProviderAnthropic,
+		Body:            []byte(`{"messages":[{"role":"user","content":"deny ` + held.Pending.ID + `"}]}`),
+		Agent:           &store.Agent{ID: "agent-1", UserID: "user-1"},
+		PendingApproval: cache,
+		Inspector:       inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{}),
+	})
+	if !result.Handled || result.Decision != "deny" || result.Outcome != "approval_denied" {
+		t.Fatalf("coalesced deny should be handled and denied, got %+v", result)
+	}
+	bodyStr := string(result.Body)
+	if strings.Contains(bodyStr, `"type":"tool_use"`) {
+		t.Fatalf("denied coalesced release should carry no tool_use blocks; got: %s", bodyStr)
+	}
+	if !strings.Contains(bodyStr, conversation.ApprovalDeniedMessage) {
+		t.Fatalf("denied response should carry the canonical deny message; got: %s", bodyStr)
+	}
+}
+
+// Regression: when the approval-needing tool_use is NOT the first in
+// the turn, coalescence must still surface every held call in the
+// original model-emitted order on release. Reordering breaks dependent
+// sequences (e.g. a Bash that produces output a following WebFetch
+// consumes). Setup: an auto-allow Bash followed by a review-flagged
+// WebFetch. The primary slot stores WebFetch (the approval trigger);
+// PrimaryIndex records its original position so AllHolds() emits
+// [Bash, WebFetch] and the multi-tool release synthesis preserves
+// that order.
+func TestPostprocess_CoalescedReleasePreservesTurnOrder(t *testing.T) {
+	ctx := context.Background()
+	body := []byte(`{
+		"id":"msg_1",
+		"type":"message",
+		"role":"assistant",
+		"model":"claude-haiku-4-5",
+		"content":[
+			{"type":"tool_use","id":"toolu_bash","name":"Bash","input":{"command":"ls -la"}},
+			{"type":"tool_use","id":"toolu_fetch","name":"WebFetch","input":{"url":"https://example.com/x"}}
+		],
+		"stop_reason":"tool_use"
+	}`)
+	req := httptest.NewRequest("POST", "/v1/messages", nil)
+	insp := inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{})
+	st, userID, agentID := seedPostprocessStore(t, "autovault_github_xxx")
+	cache := NewMemoryPendingApprovalCache(time.Minute)
+
+	_ = Postprocess(req, body, "application/json", PostprocessConfig{
+		Inspector:        insp,
+		RewriteOpts:      inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
+		CallerNonces:     NewMemoryCallerNonceCache(time.Minute),
+		Store:            st,
+		AgentUserID:      userID,
+		AgentID:          agentID,
+		PendingApprovals: cache,
+		ResponseRegistry: conversation.DefaultResponseRegistry(),
+		CandidateTasks:   []*store.Task{},
+		ToolRules: []*store.RuntimePolicyRule{
+			{ID: "review-webfetch", UserID: userID, AgentID: &agentID, Kind: "tool", Action: "review", ToolName: "WebFetch", Reason: "review web fetch", Enabled: true},
+		},
+		EgressRules: []*store.RuntimePolicyRule{},
+	})
+	holds := cache.snapshotHoldsForTest(userID, agentID, conversation.ProviderAnthropic)
+	if len(holds) != 1 {
+		t.Fatalf("want one coalesced hold, got %d", len(holds))
+	}
+	hold := holds[0]
+	all := hold.AllHolds()
+	if got := []string{all[0].ToolUse.ID, all[1].ToolUse.ID}; got[0] != "toolu_bash" || got[1] != "toolu_fetch" {
+		t.Fatalf("AllHolds order = %v, want [toolu_bash toolu_fetch] to match the model's turn order", got)
+	}
+	// The release synthesis pulls from AllHolds() too; confirm the
+	// wire-level call order matches as well.
+	result := TryReleasePendingApproval(ctx, ReleaseRequest{
+		HTTPRequest:     httptest.NewRequest("POST", "/v1/messages", nil),
+		Provider:        conversation.ProviderAnthropic,
+		Body:            []byte(`{"messages":[{"role":"user","content":"approve ` + hold.ID + `"}]}`),
+		Agent:           &store.Agent{ID: agentID, UserID: userID},
+		PendingApproval: cache,
+		Inspector:       insp,
+		Store:           st,
+		RewriteOpts:     inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
+		CallerNonces:    NewMemoryCallerNonceCache(time.Minute),
+	})
+	if !result.Handled || result.Decision != "allow" {
+		t.Fatalf("coalesced release should allow, got %+v", result)
+	}
+	bashAt := strings.Index(string(result.Body), `"id":"toolu_bash"`)
+	fetchAt := strings.Index(string(result.Body), `"id":"toolu_fetch"`)
+	if bashAt < 0 || fetchAt < 0 {
+		t.Fatalf("release body missing held tool_use IDs: %s", result.Body)
+	}
+	if bashAt > fetchAt {
+		t.Fatalf("release body reordered tool_uses: bash@%d fetch@%d (want bash first)", bashAt, fetchAt)
+	}
+}
+
+// Regression: when the coalesced Hold itself fails (Redis down, ID
+// gen panic), Postprocess must fall back to writing the per-tool
+// holds via legacy replay so the first-pass body's prompts resolve
+// to real cache entries. With pass-1 buffering the coalesced Hold is
+// the FIRST call against the underlying cache; failure triggers
+// legacy replay of the buffered per-tool holds.
+func TestPostprocess_CoalescedHoldFailureFallsBackToPerToolHolds(t *testing.T) {
+	body := []byte(`{
+		"id":"msg_1",
+		"type":"message",
+		"role":"assistant",
+		"model":"claude-haiku-4-5",
+		"content":[
+			{"type":"tool_use","id":"toolu_1","name":"WebFetch","input":{"url":"https://example.com/one"}},
+			{"type":"tool_use","id":"toolu_2","name":"WebFetch","input":{"url":"https://example.com/two"}}
+		],
+		"stop_reason":"tool_use"
+	}`)
+	req := httptest.NewRequest("POST", "/v1/messages", nil)
+	insp := inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{})
+	st, userID, agentID := seedPostprocessStore(t, "autovault_github_xxx")
+	inner := NewMemoryPendingApprovalCache(time.Minute)
+	// failFirst=1 → the coalesced Hold (first call) fails; subsequent
+	// replay calls succeed. With pass-1 buffering this is the right
+	// shape to exercise the fallback path.
+	cache := &flakyHoldCache{inner: inner, failFirst: 1}
+
+	_ = Postprocess(req, body, "application/json", PostprocessConfig{
+		Inspector:        insp,
+		RewriteOpts:      inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
+		CallerNonces:     NewMemoryCallerNonceCache(time.Minute),
+		Store:            st,
+		AgentUserID:      userID,
+		AgentID:          agentID,
+		PendingApprovals: cache,
+		ResponseRegistry: conversation.DefaultResponseRegistry(),
+		CandidateTasks:   []*store.Task{},
+		ToolRules: []*store.RuntimePolicyRule{
+			{ID: "review-webfetch", UserID: userID, AgentID: &agentID, Kind: "tool", Action: "review", ToolName: "WebFetch", Reason: "review web fetch", Enabled: true},
+		},
+		EgressRules: []*store.RuntimePolicyRule{},
+	})
+
+	// The coalesced Hold failed; legacy replay then wrote both
+	// per-tool holds. Final occupancy: 2.
+	got := inner.snapshotHoldsForTest(userID, agentID, conversation.ProviderAnthropic)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 per-tool holds after coalesced fallback; got %d: %+v", len(got), got)
+	}
+	if got[0].IsCoalesced() || got[1].IsCoalesced() {
+		t.Fatalf("fallback holds must be the per-tool singletons, not coalesced: %+v", got)
+	}
+}
+
+// Regression for #2: coalescing must not evict unrelated older
+// approvals when the underlying cache is near capacity. With pass-1
+// buffering the per-tool holds are never inserted into the cache, so
+// only the coalesced hold competes for an LRU slot — net occupancy
+// rises by exactly one regardless of how many tool_uses the turn
+// carries.
+func TestPostprocess_CoalesceDoesNotEvictUnrelatedApprovals(t *testing.T) {
+	ctx := context.Background()
+	// Cache max=10. Seed with 9 unrelated approvals so a single new
+	// coalesced hold lands at capacity without eviction; the
+	// pre-buffering passthrough design would have hit max via
+	// per-tool inserts and evicted one of the seeded entries.
+	cache := NewMemoryPendingApprovalCache(time.Minute)
+	st, userID, agentID := seedPostprocessStore(t, "autovault_github_xxx")
+	seedIDs := make([]string, 0, 9)
+	for i := 0; i < 9; i++ {
+		// 26-char suffix to satisfy approvalReplyRE if anyone
+		// resolves these by ID later (not used here, but defensive).
+		id := "cv-seedapprovalxxxxxxxxxxxx"[:len("cv-")] + padTo26(t, "seed"+stringFromInt(t, i))
+		res, err := cache.Hold(ctx, PendingLiteApproval{
+			ID:       id,
+			UserID:   userID,
+			AgentID:  agentID,
+			Provider: conversation.ProviderAnthropic,
+			Stage:    StageTool,
+			ToolUse:  conversation.ToolUse{ID: "seed_" + stringFromInt(t, i), Name: "Bash"},
+		})
+		if err != nil {
+			t.Fatalf("seed hold %d: %v", i, err)
+		}
+		seedIDs = append(seedIDs, res.Pending.ID)
+	}
+
+	body := []byte(`{
+		"id":"msg_1",
+		"type":"message",
+		"role":"assistant",
+		"model":"claude-haiku-4-5",
+		"content":[
+			{"type":"tool_use","id":"toolu_1","name":"WebFetch","input":{"url":"https://example.com/one"}},
+			{"type":"tool_use","id":"toolu_2","name":"WebFetch","input":{"url":"https://example.com/two"}}
+		],
+		"stop_reason":"tool_use"
+	}`)
+	req := httptest.NewRequest("POST", "/v1/messages", nil)
+	insp := inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{})
+
+	_ = Postprocess(req, body, "application/json", PostprocessConfig{
+		Inspector:        insp,
+		RewriteOpts:      inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
+		CallerNonces:     NewMemoryCallerNonceCache(time.Minute),
+		Store:            st,
+		AgentUserID:      userID,
+		AgentID:          agentID,
+		PendingApprovals: cache,
+		ResponseRegistry: conversation.DefaultResponseRegistry(),
+		CandidateTasks:   []*store.Task{},
+		ToolRules: []*store.RuntimePolicyRule{
+			{ID: "review-webfetch", UserID: userID, AgentID: &agentID, Kind: "tool", Action: "review", ToolName: "WebFetch", Reason: "review web fetch", Enabled: true},
+		},
+		EgressRules: []*store.RuntimePolicyRule{},
+	})
+
+	// All 9 seed approvals must still be present; only the one
+	// coalesced hold was added, putting total at 10 (== max).
+	final := cache.snapshotHoldsForTest(userID, agentID, conversation.ProviderAnthropic)
+	if len(final) != 10 {
+		t.Fatalf("expected 10 final holds (9 seed + 1 coalesced); got %d", len(final))
+	}
+	present := map[string]bool{}
+	for _, h := range final {
+		present[h.ID] = true
+	}
+	for _, id := range seedIDs {
+		if !present[id] {
+			t.Fatalf("unrelated seed approval %s was evicted by coalescence", id)
+		}
+	}
+}
+
+// Regression for #1: when coalescence kicks in, the audit trail must
+// describe each held tool_use as "coalesced_approval_pending" — not
+// as "allow" or "rewrite" that would falsely imply the call ran.
+func TestPostprocess_CoalesceAuditDoesNotEmitMisleadingAllow(t *testing.T) {
+	body := []byte(`{
+		"id":"msg_1",
+		"type":"message",
+		"role":"assistant",
+		"model":"claude-haiku-4-5",
+		"content":[
+			{"type":"tool_use","id":"toolu_bash","name":"Bash","input":{"command":"ls -la"}},
+			{"type":"tool_use","id":"toolu_fetch","name":"WebFetch","input":{"url":"https://example.com/x"}}
+		],
+		"stop_reason":"tool_use"
+	}`)
+	req := httptest.NewRequest("POST", "/v1/messages", nil)
+	insp := inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{})
+	st, userID, agentID := seedPostprocessStore(t, "autovault_github_xxx")
+	cache := NewMemoryPendingApprovalCache(time.Minute)
+	emitter := NewAuditEmitter(st, nil, nil)
+
+	_ = Postprocess(req, body, "application/json", PostprocessConfig{
+		Inspector:        insp,
+		RewriteOpts:      inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
+		CallerNonces:     NewMemoryCallerNonceCache(time.Minute),
+		Store:            st,
+		AgentUserID:      userID,
+		AgentID:          agentID,
+		PendingApprovals: cache,
+		ResponseRegistry: conversation.DefaultResponseRegistry(),
+		CandidateTasks:   []*store.Task{},
+		ToolRules: []*store.RuntimePolicyRule{
+			{ID: "review-webfetch", UserID: userID, AgentID: &agentID, Kind: "tool", Action: "review", ToolName: "WebFetch", Reason: "review web fetch", Enabled: true},
+		},
+		EgressRules: []*store.RuntimePolicyRule{},
+		Audit:       emitter,
+	})
+
+	// Pull every tool_use inspection row back; in coalesce mode the
+	// surviving row(s) must be "block / coalesced_approval_pending".
+	// The misuse this guards against is a sibling that would have
+	// auto-allowed leaving a stale "allow / pass_through" row in the
+	// audit trail even though its call never executed. Note that
+	// the audit schema has a unique (user_id, request_id, task_id)
+	// dedup index, so per-tool rows for the same request collapse on
+	// insert; what we assert is that the row that lands describes
+	// the coalesced state, never the buffered allow/rewrite that
+	// would have been wrong.
+	rows, _, err := st.ListAuditEntries(context.Background(), userID, store.AuditFilter{})
+	if err != nil {
+		t.Fatalf("ListAuditEntries: %v", err)
+	}
+	inspectionRows := 0
+	for _, r := range rows {
+		if !strings.HasPrefix(r.Action, "lite_proxy.tool_use.") {
+			continue
+		}
+		inspectionRows++
+		if r.Action != "lite_proxy.tool_use.block" {
+			t.Fatalf("audit action = %q; coalesce mode must report block (not allow/rewrite): %+v", r.Action, r)
+		}
+		if r.Outcome != "coalesced_approval_pending" {
+			t.Fatalf("audit outcome = %q; coalesce mode must report coalesced_approval_pending: %+v", r.Outcome, r)
+		}
+	}
+	if inspectionRows == 0 {
+		t.Fatalf("expected at least one tool_use inspection row, got none")
+	}
+}
+
+// Regression: legacy-path replay must fail closed when the underlying
+// cache rejects the Hold. The first-pass body references approval
+// prompts; if their per-tool holds can't be committed, the body
+// would invite the user to type "yes" at a prompt that resolves to
+// nothing. SkippedReason makes the handler emit 502 — the same
+// shape the pre-buffering eval used to take when Hold failed inline.
+func TestPostprocess_LegacyReplayFailureFailsClosed(t *testing.T) {
+	body := []byte(`{
+		"id":"msg_1",
+		"type":"message",
+		"role":"assistant",
+		"model":"claude-haiku-4-5",
+		"content":[
+			{"type":"tool_use","id":"toolu_only","name":"WebFetch","input":{"url":"https://example.com/x"}}
+		],
+		"stop_reason":"tool_use"
+	}`)
+	req := httptest.NewRequest("POST", "/v1/messages", nil)
+	insp := inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{})
+	st, userID, agentID := seedPostprocessStore(t, "autovault_github_xxx")
+	// failFirst=999 → every Hold call fails. Single tool_use → no
+	// coalescence; the legacy-replay path is the one exercised.
+	inner := NewMemoryPendingApprovalCache(time.Minute)
+	cache := &flakyHoldCache{inner: inner, failFirst: 999}
+
+	got := Postprocess(req, body, "application/json", PostprocessConfig{
+		Inspector:        insp,
+		RewriteOpts:      inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
+		CallerNonces:     NewMemoryCallerNonceCache(time.Minute),
+		Store:            st,
+		AgentUserID:      userID,
+		AgentID:          agentID,
+		PendingApprovals: cache,
+		ResponseRegistry: conversation.DefaultResponseRegistry(),
+		CandidateTasks:   []*store.Task{},
+		ToolRules: []*store.RuntimePolicyRule{
+			{ID: "review-webfetch", UserID: userID, AgentID: &agentID, Kind: "tool", Action: "review", ToolName: "WebFetch", Reason: "review web fetch", Enabled: true},
+		},
+		EgressRules: []*store.RuntimePolicyRule{},
+	})
+	if got.Body != nil {
+		t.Fatalf("replay failure must drop the body (handler emits 502); got %d bytes", len(got.Body))
+	}
+	if got.SkippedReason == "" || !strings.Contains(got.SkippedReason, "approval hold storage failed") {
+		t.Fatalf("replay failure should surface SkippedReason naming hold storage; got %q", got.SkippedReason)
+	}
+}
+
+// Regression: when a multi-hold replay fails partway through, the
+// committed holds must be dropped so the cache doesn't carry an
+// approval the response body never described. Tested directly
+// against replayBufferedHolds because constructing this scenario
+// through Postprocess proper would require a multi-hold turn that
+// also skips coalescence — a configuration the production rule
+// engine doesn't naturally produce.
+func TestReplayBufferedHolds_PartialFailureRollsBackCommitted(t *testing.T) {
+	ctx := context.Background()
+	inner := NewMemoryPendingApprovalCache(time.Minute)
+	// Three buffered holds; the second one's Hold call fails. The
+	// first should be committed then dropped on the failure path;
+	// the third should never be attempted.
+	cache := &flakyHoldFromCallN{inner: inner, failOnCall: 2}
+	sink := &capturedHoldSink{
+		holds: []capturedHold{
+			{Pending: PendingLiteApproval{UserID: "u", AgentID: "a", Provider: conversation.ProviderAnthropic, ToolUse: conversation.ToolUse{ID: "t1", Name: "Bash"}}},
+			{Pending: PendingLiteApproval{UserID: "u", AgentID: "a", Provider: conversation.ProviderAnthropic, ToolUse: conversation.ToolUse{ID: "t2", Name: "Bash"}}},
+			{Pending: PendingLiteApproval{UserID: "u", AgentID: "a", Provider: conversation.ProviderAnthropic, ToolUse: conversation.ToolUse{ID: "t3", Name: "Bash"}}},
+		},
+	}
+	captures := []evalCapture{{Use: sink.holds[0].Pending.ToolUse}, {Use: sink.holds[1].Pending.ToolUse}, {Use: sink.holds[2].Pending.ToolUse}}
+
+	err := replayBufferedHolds(ctx, PostprocessConfig{}, cache, sink, nil, captures)
+	if err == nil {
+		t.Fatalf("expected non-nil error from partial replay failure")
+	}
+	final := inner.snapshotHoldsForTest("u", "a", conversation.ProviderAnthropic)
+	if len(final) != 0 {
+		t.Fatalf("partial replay failure must roll back committed holds; got %d remaining: %+v", len(final), final)
+	}
+	if cache.calls != 2 {
+		t.Fatalf("expected replay to stop after the first failure (2 Hold attempts); got %d", cache.calls)
+	}
+}
+
+// flakyHoldFromCallN fails the N-th Hold call only and otherwise
+// passes through. Lets tests target a specific replay step.
+type flakyHoldFromCallN struct {
+	inner      PendingApprovalCache
+	failOnCall int
+	calls      int
+}
+
+func (c *flakyHoldFromCallN) Hold(ctx context.Context, p PendingLiteApproval) (HoldResult, error) {
+	c.calls++
+	if c.calls == c.failOnCall {
+		return HoldResult{}, errFlakyHold
+	}
+	return c.inner.Hold(ctx, p)
+}
+func (c *flakyHoldFromCallN) Peek(ctx context.Context, r ResolveRequest) (*PendingLiteApproval, error) {
+	return c.inner.Peek(ctx, r)
+}
+func (c *flakyHoldFromCallN) Resolve(ctx context.Context, r ResolveRequest) (*PendingLiteApproval, error) {
+	return c.inner.Resolve(ctx, r)
+}
+func (c *flakyHoldFromCallN) Drop(ctx context.Context, r ResolveRequest) error {
+	return c.inner.Drop(ctx, r)
+}
+
+// Regression: the buffering wrapper must NOT fabricate
+// CreatedAt/ExpiresAt. The real cache configured with a non-default
+// TTL must drive how long holds live; injecting a 10-minute default
+// in the wrapper would bypass that configuration.
+func TestPostprocess_BufferedHoldRespectsConfiguredCacheTTL(t *testing.T) {
+	body := []byte(`{
+		"id":"msg_1",
+		"type":"message",
+		"role":"assistant",
+		"model":"claude-haiku-4-5",
+		"content":[
+			{"type":"tool_use","id":"toolu_only","name":"WebFetch","input":{"url":"https://example.com/x"}}
+		],
+		"stop_reason":"tool_use"
+	}`)
+	req := httptest.NewRequest("POST", "/v1/messages", nil)
+	insp := inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{})
+	st, userID, agentID := seedPostprocessStore(t, "autovault_github_xxx")
+	// Configure the cache with a 30-second TTL. The wrapper used to
+	// default ExpiresAt = now + 10m; with that bug the persisted
+	// hold would expire 9.5 minutes later than the configured TTL.
+	cache := NewMemoryPendingApprovalCache(30 * time.Second)
+
+	_ = Postprocess(req, body, "application/json", PostprocessConfig{
+		Inspector:        insp,
+		RewriteOpts:      inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
+		CallerNonces:     NewMemoryCallerNonceCache(time.Minute),
+		Store:            st,
+		AgentUserID:      userID,
+		AgentID:          agentID,
+		PendingApprovals: cache,
+		ResponseRegistry: conversation.DefaultResponseRegistry(),
+		CandidateTasks:   []*store.Task{},
+		ToolRules: []*store.RuntimePolicyRule{
+			{ID: "review-webfetch", UserID: userID, AgentID: &agentID, Kind: "tool", Action: "review", ToolName: "WebFetch", Reason: "review web fetch", Enabled: true},
+		},
+		EgressRules: []*store.RuntimePolicyRule{},
+	})
+
+	holds := cache.snapshotHoldsForTest(userID, agentID, conversation.ProviderAnthropic)
+	if len(holds) != 1 {
+		t.Fatalf("expected one hold, got %d", len(holds))
+	}
+	lived := holds[0].ExpiresAt.Sub(holds[0].CreatedAt)
+	// Allow 1s slack for clock between buffering and replay.
+	if lived < 29*time.Second || lived > 31*time.Second {
+		t.Fatalf("hold lifetime = %s, want ~30s (the configured cache TTL); wrapper-default would have given 10m", lived)
+	}
+}
+
+// Regression: a coalesced sibling that was auto-allowed (no per-tool
+// Hold was created for it) must still carry its inspector verdict in
+// the Additional entry. Without this, the release audit's
+// target_host/method/path are empty for that sibling — it executes
+// after approval but the audit trail can't say where it went.
+func TestPostprocess_CoalescedSiblingCarriesInspectorMetadata(t *testing.T) {
+	body := []byte(`{
+		"id":"msg_1",
+		"type":"message",
+		"role":"assistant",
+		"model":"claude-haiku-4-5",
+		"content":[
+			{"type":"tool_use","id":"toolu_bash","name":"Bash","input":{"command":"ls -la"}},
+			{"type":"tool_use","id":"toolu_fetch","name":"WebFetch","input":{"url":"https://example.com/x"}}
+		],
+		"stop_reason":"tool_use"
+	}`)
+	req := httptest.NewRequest("POST", "/v1/messages", nil)
+	insp := inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{})
+	st, userID, agentID := seedPostprocessStore(t, "autovault_github_xxx")
+	cache := NewMemoryPendingApprovalCache(time.Minute)
+
+	_ = Postprocess(req, body, "application/json", PostprocessConfig{
+		Inspector:        insp,
+		RewriteOpts:      inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
+		CallerNonces:     NewMemoryCallerNonceCache(time.Minute),
+		Store:            st,
+		AgentUserID:      userID,
+		AgentID:          agentID,
+		PendingApprovals: cache,
+		ResponseRegistry: conversation.DefaultResponseRegistry(),
+		CandidateTasks:   []*store.Task{},
+		ToolRules: []*store.RuntimePolicyRule{
+			{ID: "review-webfetch", UserID: userID, AgentID: &agentID, Kind: "tool", Action: "review", ToolName: "WebFetch", Reason: "review web fetch", Enabled: true},
+		},
+		EgressRules: []*store.RuntimePolicyRule{},
+	})
+	holds := cache.snapshotHoldsForTest(userID, agentID, conversation.ProviderAnthropic)
+	if len(holds) != 1 {
+		t.Fatalf("want one coalesced hold, got %d", len(holds))
+	}
+	all := holds[0].AllHolds()
+	if len(all) != 2 {
+		t.Fatalf("expected 2 held tool_uses, got %d", len(all))
+	}
+	// Find the auto-allowed bash sibling.
+	var bash HeldToolUse
+	for _, h := range all {
+		if h.Kind == HeldKindAllow {
+			bash = h
+			break
+		}
+	}
+	if bash.ToolUse.ID != "toolu_bash" {
+		t.Fatalf("expected auto-allow sibling to be the bash call, got %+v", bash)
+	}
+	// The inspector verdict on the auto-allow sibling must be the
+	// real one from innerEval — not the zero value. SourceTriggerMiss
+	// is what the inspector reports for a bash with no credential
+	// placeholder. Reason should be non-empty for the same reason.
+	if bash.Inspector.Source == "" {
+		t.Fatalf("auto-allow sibling lost inspector verdict: %+v", bash.Inspector)
+	}
+}
+
+// Regression: LogApprovalRelease must emit ONE row per release event
+// (not N), with per-tool detail under params.held_tools. The audit
+// schema has UNIQUE(user_id, request_id, COALESCE(task_id, '')) so
+// N rows for one request would collapse on insert and the dashboard
+// grouping the comment promised would silently break.
+func TestAuditEmitter_LogApprovalRelease_CoalescedEmitsOneRowWithPerToolDetail(t *testing.T) {
+	ctx := context.Background()
+	st, agent := newAuditTestStore(t)
+	em := NewAuditEmitter(st, nil, nil)
+
+	pending := &PendingLiteApproval{
+		ID:       "cv-coalescedauditxxxxxxxxxx",
+		UserID:   agent.UserID,
+		AgentID:  agent.ID,
+		Provider: conversation.ProviderAnthropic,
+		ToolUse:  conversation.ToolUse{ID: "toolu_primary", Name: "WebFetch"},
+		Inspector: inspector.Verdict{
+			Host: "api.example.com", Method: "GET", Path: "/v1/x",
+			Source: inspector.SourceDeterministic,
+		},
+		Reason: "review web fetch",
+		Additional: []HeldToolUse{{
+			ToolUse:   conversation.ToolUse{ID: "toolu_sibling", Name: "Bash"},
+			Kind:      HeldKindAllow,
+			Inspector: inspector.Verdict{Source: inspector.SourceTriggerMiss},
+		}},
+		PrimaryIndex: 1, // primary sits second in turn order
+	}
+
+	em.LogApprovalRelease(ctx, agent, "req-coalesce", pending, "allow", "approval_released", "approved")
+
+	rows, _, err := st.ListAuditEntries(ctx, agent.UserID, store.AuditFilter{})
+	if err != nil {
+		t.Fatalf("ListAuditEntries: %v", err)
+	}
+	releaseRows := 0
+	var got *store.AuditEntry
+	for _, r := range rows {
+		if r.Action == "lite_proxy.approval.release" {
+			releaseRows++
+			got = r
+		}
+	}
+	if releaseRows != 1 {
+		t.Fatalf("expected exactly one release row (dedup index folds N to 1); got %d", releaseRows)
+	}
+	var params map[string]any
+	if err := json.Unmarshal(got.ParamsSafe, &params); err != nil {
+		t.Fatalf("params unmarshal: %v", err)
+	}
+	if got, want := params["coalesced"], true; got != want {
+		t.Fatalf("coalesced field = %v, want %v", got, want)
+	}
+	if got, want := params["hold_size"], float64(2); got != want {
+		t.Fatalf("hold_size = %v, want %v", got, want)
+	}
+	held, ok := params["held_tools"].([]any)
+	if !ok {
+		t.Fatalf("held_tools missing or wrong type: %T = %v", params["held_tools"], params["held_tools"])
+	}
+	if len(held) != 2 {
+		t.Fatalf("held_tools count = %d, want 2 (every held tool surfaced under one row)", len(held))
+	}
+	// Each entry must have tool_use_id and held_kind so dashboards
+	// can expand the per-call view from one row.
+	for i, e := range held {
+		m, ok := e.(map[string]any)
+		if !ok {
+			t.Fatalf("held_tools[%d] not an object: %T", i, e)
+		}
+		if m["tool_use_id"] == "" || m["held_kind"] == "" {
+			t.Fatalf("held_tools[%d] missing tool_use_id/held_kind: %+v", i, m)
+		}
+	}
+}
+
+// flakyHoldCache fails the first failFirst Hold calls then passes
+// through. Used to simulate a transient backend failure on the
+// coalesced Hold (first call under pass-1 buffering) while letting
+// the legacy-replay fallback succeed.
+type flakyHoldCache struct {
+	inner     PendingApprovalCache
+	failFirst int
+	calls     int
+}
+
+func (c *flakyHoldCache) Hold(ctx context.Context, p PendingLiteApproval) (HoldResult, error) {
+	c.calls++
+	if c.calls <= c.failFirst {
+		return HoldResult{}, errFlakyHold
+	}
+	return c.inner.Hold(ctx, p)
+}
+func (c *flakyHoldCache) Peek(ctx context.Context, r ResolveRequest) (*PendingLiteApproval, error) {
+	return c.inner.Peek(ctx, r)
+}
+func (c *flakyHoldCache) Resolve(ctx context.Context, r ResolveRequest) (*PendingLiteApproval, error) {
+	return c.inner.Resolve(ctx, r)
+}
+func (c *flakyHoldCache) Drop(ctx context.Context, r ResolveRequest) error {
+	return c.inner.Drop(ctx, r)
+}
+
+var errFlakyHold = errFlakyHoldType{}
+
+type errFlakyHoldType struct{}
+
+func (errFlakyHoldType) Error() string { return "flaky cache: hold refused" }
+
+func padTo26(t *testing.T, s string) string {
+	t.Helper()
+	for len(s) < 26 {
+		s += "x"
+	}
+	if len(s) > 26 {
+		s = s[:26]
+	}
+	return s
+}
+
+func stringFromInt(t *testing.T, n int) string {
+	t.Helper()
+	return string(rune('0' + n))
+}
+
+// SyntheticApprovalToolUsesResponseWithDenyMessage with a 1-element
+// slice must be byte-identical to the legacy single-call helper.
+// Guards downstream callers that haven't migrated.
+func TestSyntheticApprovalToolUses_SingletonMatchesLegacy(t *testing.T) {
+	req := httptest.NewRequest("POST", "/v1/messages", nil)
+	reqBody := []byte(`{"stream":false}`)
+	legacy, ok := conversation.SyntheticApprovalToolUseResponseWithDenyMessage(
+		req, conversation.ProviderAnthropic, reqBody, true,
+		"toolu_x", "Bash", map[string]any{"command": "echo ok"},
+		conversation.ApprovalDeniedMessage,
+	)
+	if !ok {
+		t.Fatal("legacy synth refused")
+	}
+	multi, ok := conversation.SyntheticApprovalToolUsesResponseWithDenyMessage(
+		req, conversation.ProviderAnthropic, reqBody, true,
+		[]conversation.SyntheticToolCall{{ID: "toolu_x", Name: "Bash", Input: map[string]any{"command": "echo ok"}}},
+		conversation.ApprovalDeniedMessage,
+	)
+	if !ok {
+		t.Fatal("multi synth refused")
+	}
+	if string(legacy.Body) != string(multi.Body) {
+		t.Fatalf("singleton multi-synth diverges from legacy:\nlegacy=%s\nmulti =%s", legacy.Body, multi.Body)
+	}
+	if legacy.ContentType != multi.ContentType {
+		t.Fatalf("singleton content-type mismatch: legacy=%q multi=%q", legacy.ContentType, multi.ContentType)
+	}
+}

--- a/internal/runtime/llmproxy/inline_task_transitions.go
+++ b/internal/runtime/llmproxy/inline_task_transitions.go
@@ -28,7 +28,13 @@ func startInlineTaskDefinition(ctx context.Context, req TaskReplyRewriteRequest,
 	if pending != nil {
 		pendingApprovalID = pending.ID
 	}
-	rewritten, ok, err := editor.ReplaceLatestUserText("task", pendingApprovalID, taskCreationPrompt(pending.ToolUse))
+	// For a coalesced hold, generate a task definition prompt that
+	// covers every held tool_use — not just the primary. Otherwise
+	// the user typing "task" on a multi-call review would scope only
+	// one call and the sibling reviewed calls re-prompt on retry,
+	// defeating the point of the gesture. Single-tool holds collapse
+	// to the legacy single-element prompt unchanged.
+	rewritten, ok, err := editor.ReplaceLatestUserText("task", pendingApprovalID, taskCreationPromptForHolds(pending.AllHolds()))
 	if err != nil || !ok {
 		return TaskReplyRewriteResult{Body: req.Body}, err
 	}

--- a/internal/runtime/llmproxy/pending_approval_cache.go
+++ b/internal/runtime/llmproxy/pending_approval_cache.go
@@ -74,6 +74,114 @@ type PendingLiteApproval struct {
 	// inline approval prompt and to create the task once the user approves.
 	// nil at the other stages.
 	TaskDefinition *runtimetasks.TaskCreateRequest
+
+	// Additional carries the other tool_uses that share this hold when
+	// multiple tool_uses in a single upstream response are coalesced into
+	// one approval. Empty for the standard single-tool hold path
+	// (preserves legacy behavior — the singular ToolUse + Inspector +
+	// Fingerprint + Reason describe the only held use). When non-empty,
+	// the singular fields describe the FIRST approval-needing use; the
+	// slice carries every other use in the turn (which may itself be
+	// approval-needing, auto-allow, or auto-rewrite — captured by Kind).
+	// One yes/no reply releases or denies the whole batch.
+	Additional []HeldToolUse
+
+	// PrimaryIndex is the position of the primary tool_use (the one
+	// mapped to the singular ToolUse/Inspector/Fingerprint/Reason
+	// fields) in the original turn order. Used by AllHolds() to
+	// reconstruct the full slice in turn order — release-time emission
+	// must match the order the model produced so that dependent tool
+	// call sequences (e.g. Bash then a WebFetch that consumes its
+	// output) execute in the right sequence. Zero (the JSON-omitted
+	// default) means "primary is the first held use," which is
+	// correct for legacy single-tool holds and for coalesced holds
+	// whose first held use happens to be the approval trigger.
+	PrimaryIndex int `json:",omitempty"`
+}
+
+// HeldToolUseKind tags how a tool_use was originally classified at hold
+// time. The release path re-evaluates each held use against current state,
+// but the original classification is the audit-trail truth and the cue
+// for whether the use needs re-rewriting at release.
+type HeldToolUseKind string
+
+const (
+	// HeldKindApproval is a tool_use that needed user approval. The hold
+	// exists because of these uses.
+	HeldKindApproval HeldToolUseKind = "approval"
+	// HeldKindAllow is a tool_use that would have auto-allowed (e.g.
+	// read-only bash, pass-through with no credential trigger) but is
+	// held alongside an approval-needing sibling because we hold the
+	// whole turn.
+	HeldKindAllow HeldToolUseKind = "allow"
+	// HeldKindRewrite is a tool_use that would have been credential-
+	// rewritten and auto-allowed, held alongside an approval-needing
+	// sibling. On release we re-run the rewriter to mint a fresh nonce
+	// (the one minted at hold time has long since expired).
+	HeldKindRewrite HeldToolUseKind = "rewrite"
+	// HeldKindDeny is a tool_use that policy would refuse outright.
+	// Not actually held (the coalesce decision treats this as a hard
+	// block — see Postprocess). The kind exists for classification
+	// completeness so downstream code can pattern-match without a
+	// default fallthrough.
+	HeldKindDeny HeldToolUseKind = "deny"
+)
+
+// HeldToolUse is one tool_use carried by a coalesced PendingLiteApproval.
+// Each entry remembers the original classification, the inspector
+// verdict, and the decision fingerprint so the release path can replay
+// the per-use decision in isolation.
+type HeldToolUse struct {
+	ToolUse     conversation.ToolUse
+	Kind        HeldToolUseKind
+	Inspector   inspector.Verdict
+	Fingerprint runtimedecision.DecisionFingerprint
+	Reason      string
+}
+
+// AllHolds returns every held tool_use in original turn order. For the
+// standard single-tool hold this is a one-element slice constructed
+// from the singular fields. For a coalesced hold the singular fields
+// describe one entry and Additional carries the others; PrimaryIndex
+// is the original position of the singular entry within the turn, so
+// the released call sequence matches what the model produced (e.g. a
+// preceding Bash whose stdout a later WebFetch consumes).
+func (p PendingLiteApproval) AllHolds() []HeldToolUse {
+	primary := HeldToolUse{
+		ToolUse:     p.ToolUse,
+		Kind:        HeldKindApproval,
+		Inspector:   p.Inspector,
+		Fingerprint: p.Fingerprint,
+		Reason:      p.Reason,
+	}
+	total := 1 + len(p.Additional)
+	idx := p.PrimaryIndex
+	if idx < 0 || idx >= total {
+		// Defensive: stale entries from before PrimaryIndex existed
+		// have idx==0, which is also the natural primary-first
+		// fallback. Out-of-range values get clamped to 0 to keep
+		// release order deterministic rather than panic on a slice
+		// bound.
+		idx = 0
+	}
+	out := make([]HeldToolUse, 0, total)
+	addIdx := 0
+	for i := 0; i < total; i++ {
+		if i == idx {
+			out = append(out, primary)
+			continue
+		}
+		out = append(out, p.Additional[addIdx])
+		addIdx++
+	}
+	return out
+}
+
+// IsCoalesced reports whether the hold covers more than one tool_use.
+// Single-tool holds (Additional empty) keep today's 3-option (yes/no/task)
+// prompt; coalesced holds are strictly binary.
+func (p PendingLiteApproval) IsCoalesced() bool {
+	return len(p.Additional) > 0
 }
 
 type ResolveRequest struct {
@@ -276,6 +384,23 @@ func (c *MemoryPendingApprovalCache) Drop(_ context.Context, req ResolveRequest)
 
 func (p PendingLiteApproval) key() pendingApprovalKey {
 	return pendingApprovalKey{userID: p.UserID, agentID: p.AgentID, provider: p.Provider}
+}
+
+// snapshotHoldsForTest returns the current holds for one
+// (user, agent, provider) tuple in insertion order. Test-only — used
+// by coalescence tests to assert how many holds were created and what
+// they contain without poking the private storage map.
+func (c *MemoryPendingApprovalCache) snapshotHoldsForTest(userID, agentID string, provider conversation.Provider) []PendingLiteApproval {
+	if c == nil {
+		return nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	key := pendingApprovalKey{userID: userID, agentID: agentID, provider: provider}
+	items := c.pending[key]
+	out := make([]PendingLiteApproval, len(items))
+	copy(out, items)
+	return out
 }
 
 func (c *MemoryPendingApprovalCache) pruneExpiredLocked(key pendingApprovalKey, now time.Time) []PendingLiteApproval {

--- a/internal/runtime/llmproxy/postprocess.go
+++ b/internal/runtime/llmproxy/postprocess.go
@@ -231,13 +231,50 @@ func Postprocess(req *http.Request, body []byte, contentType string, cfg Postpro
 
 	auditAgent := auditAgentForCfg(cfg)
 
-	eval := func(tu conversation.ToolUse) conversation.ToolUseVerdict {
+	// Coalescence capture state. Pass 1 runs with a buffering wrapper
+	// over both PendingApprovals and the audit emission so we can:
+	//   * detect when multiple tool_uses in one turn need approval
+	//   * detect the inline-task path (Stage != StageTool) to skip
+	//     coalescence for it
+	//   * decide a final shape (legacy: replay buffers; coalesce:
+	//     discard buffers and write one coalesced hold + per-tool
+	//     coalesced-pending audit rows)
+	// Buffering — rather than passthrough-and-then-cleanup — closes
+	// two hazards. (a) Misleading audit: in passthrough mode, pass 1
+	// would emit "allow"/"rewrite" rows for siblings whose calls then
+	// get replaced by a coalesced approval; dashboards would believe
+	// they executed. (b) Spurious eviction: bounded caches near
+	// capacity could displace an unrelated older approval while N
+	// per-tool holds are temporarily resident. Buffering keeps the
+	// underlying state untouched until the final shape is decided.
+	originalPendingApprovals := cfg.PendingApprovals
+	holdSink := &capturedHoldSink{}
+	if originalPendingApprovals != nil {
+		cfg.PendingApprovals = newHoldCapturingApprovalCache(originalPendingApprovals, holdSink)
+	}
+	auditSink := &capturedAuditSink{}
+	var captures []evalCapture
+
+	innerEval := func(tu conversation.ToolUse) conversation.ToolUseVerdict {
 		var v inspector.Verdict
 		audit := func(decision, outcome, reason string) {
-			if cfg.Audit == nil || auditAgent == nil {
-				return
-			}
-			cfg.Audit.LogToolUseInspected(req.Context(), auditAgent, cfg.RequestID, tu, v, decision, outcome, reason)
+			// Always buffer, even when no AuditEmitter is configured.
+			// The outer eval wrapper reads the last entry for this
+			// call to capture inspector metadata for coalesce
+			// siblings (auto-allow / auto-rewrite calls that don't
+			// create a hold). Without unconditional buffering, a
+			// caller with cfg.Audit=nil would lose target_host/method/path
+			// for those siblings in the coalesced hold's Additional
+			// entries. The flush helpers already check cfg.Audit and
+			// short-circuit, so this costs only a few struct copies
+			// per call in audit-disabled deployments.
+			auditSink.entries = append(auditSink.entries, bufferedAudit{
+				ToolUse:  tu,
+				Verdict:  v,
+				Decision: decision,
+				Outcome:  outcome,
+				Reason:   reason,
+			})
 		}
 		// trace emits one JSONL line per decision point when
 		// cfg.Trace is configured. The kv slice is event-specific.
@@ -688,6 +725,50 @@ func Postprocess(req *http.Request, body []byte, contentType string, cfg Postpro
 		}
 	}
 
+	// Outer eval wraps innerEval and records the kind + decision
+	// context for the coalesce post-pass. Two side channels feed the
+	// capture:
+	//   * holdSink.holds — populated by the (buffered) PendingApprovals.Hold
+	//     wrapper when innerEval creates a per-tool hold. Carries the
+	//     hold ID, stage, and the full inspector/fingerprint/reason
+	//     bundle the eval body assembled before calling Hold.
+	//   * auditSink.entries — populated by the (buffered) audit closure
+	//     on every audit() call inside innerEval. The last entry for
+	//     this call carries the inspector verdict and the final reason
+	//     even when no hold was created (auto-allow, auto-rewrite,
+	//     hard deny). Without this, coalesced sibling release audit
+	//     rows would have empty target_host/method/path because no
+	//     hold captured them.
+	// Fingerprint is captured only via the hold sink, because the
+	// release path's EquivalentFingerprint check only fires for
+	// HeldKindApproval entries — non-approval siblings either pass
+	// through, deny outright, or fail-closed with "re-prompt needed."
+	eval := func(tu conversation.ToolUse) conversation.ToolUseVerdict {
+		holdsBefore, auditsBefore := 0, 0
+		if holdSink != nil {
+			holdsBefore = len(holdSink.holds)
+		}
+		if auditSink != nil {
+			auditsBefore = len(auditSink.entries)
+		}
+		v := innerEval(tu)
+		c := evalCapture{Use: tu, Kind: classifyVerdict(v)}
+		if holdSink != nil && len(holdSink.holds) > holdsBefore {
+			h := holdSink.holds[len(holdSink.holds)-1]
+			c.HoldID = h.Pending.ID
+			c.Stage = h.Pending.Stage
+			c.Inspector = h.Pending.Inspector
+			c.Fingerprint = h.Pending.Fingerprint
+			c.Reason = h.Pending.Reason
+		} else if auditSink != nil && len(auditSink.entries) > auditsBefore {
+			last := auditSink.entries[len(auditSink.entries)-1]
+			c.Inspector = last.Verdict
+			c.Reason = last.Reason
+		}
+		captures = append(captures, c)
+		return v
+	}
+
 	result, err := rewriter.Rewrite(body, contentType, eval)
 	if err != nil {
 		// Fail closed: the rewriter failed mid-body so we don't know
@@ -702,12 +783,162 @@ func Postprocess(req *http.Request, body []byte, contentType string, cfg Postpro
 			SkippedReason: "rewriter error: " + err.Error(),
 		}
 	}
+
+	// Coalesce decision. When the turn carries multiple tool_uses and
+	// at least one needs approval (and the inline-task flow is not in
+	// play), replace the buffered per-tool holds with one coalesced
+	// hold covering the whole turn and rewrite the buffered audit so
+	// it reports the calls as "coalesced approval pending" rather
+	// than as if they had executed. A single user yes/no then
+	// releases (or denies) all sibling calls together.
+	if originalPendingApprovals != nil && shouldCoalesceTurn(captures) {
+		coalesced := coalesceFromCaptures(captures)
+		coalesced.UserID = cfg.AgentUserID
+		coalesced.AgentID = cfg.AgentID
+		coalesced.Provider = rewriter.Name()
+		held, holdErr := originalPendingApprovals.Hold(req.Context(), coalesced)
+		if holdErr == nil {
+			// Coalesced hold committed. The buffered per-tool holds
+			// were never inserted into the underlying cache, so
+			// there's nothing to drop here — that closes the
+			// bounded-cache eviction hazard. The buffered audit rows
+			// are deliberately discarded: they would have reported
+			// "allow"/"rewrite" for siblings whose calls are now
+			// being held under the coalesced approval, which is
+			// false in the audit trail. We emit one
+			// "coalesced_approval_pending" row per held tool_use
+			// instead so dashboards see what actually happened.
+			emitCoalescedPendingAuditRows(req.Context(), cfg, auditAgent, captures, held.Pending.ID)
+			// Re-run the rewriter with a coalesced eval. Every
+			// tool_use returns Allowed:false; the first carries the
+			// combined prompt as SubstituteWith, the rest carry
+			// empty SubstituteWith so the rewriter's join produces
+			// one prompt (not N copies).
+			coalescedPrompt := coalescedApprovalPrompt(held.Pending.AllHolds())
+			firstReplaced := false
+			coalescedEval := func(tu conversation.ToolUse) conversation.ToolUseVerdict {
+				out := conversation.ToolUseVerdict{
+					Allowed: false,
+					Reason:  "Clawvisor: approval required (coalesced turn) — " + held.Pending.Reason,
+				}
+				if !firstReplaced {
+					out.SubstituteWith = coalescedPrompt
+					firstReplaced = true
+				}
+				return out
+			}
+			coalescedResult, coalescedErr := rewriter.Rewrite(body, contentType, coalescedEval)
+			if coalescedErr == nil {
+				return PostprocessResult{
+					Body:        coalescedResult.Body,
+					ContentType: contentType,
+					Rewritten:   true,
+					Decisions:   coalescedResult.Decisions,
+				}
+			}
+			// Coalesced re-run failed but the coalesced hold exists.
+			// The first-pass body still references per-tool prompts
+			// that no longer correspond to cache state (the
+			// per-tool holds were never committed and the coalesced
+			// hold is the only one now). Fall through to flush the
+			// buffered audit (the rows describe what would have
+			// happened) and return the first-pass body. Degraded
+			// but recoverable: a user yes/no resolves the coalesced
+			// hold via LIFO and the release synth emits every
+			// approved call.
+			flushBufferedAudit(req.Context(), cfg, auditAgent, auditSink)
+			return PostprocessResult{
+				Body:        result.Body,
+				ContentType: contentType,
+				Rewritten:   result.Rewritten,
+				Decisions:   result.Decisions,
+			}
+		}
+		// Hold-failure path: the coalesced hold could not be
+		// committed. Fall through to legacy replay: write the
+		// buffered per-tool holds to the underlying cache and flush
+		// the buffered audit rows. The first-pass body already
+		// describes those per-tool prompts; once they exist in the
+		// cache the user's yes/no resolves them one by one (the
+		// pre-coalesce path).
+	}
+
+	// Legacy replay: no coalescence happened (either shouldCoalesceTurn
+	// said no, or the coalesced Hold failed). Commit the buffered
+	// per-tool holds to the underlying cache and emit the buffered
+	// audit rows as-is.
+	if replayErr := replayBufferedHolds(req.Context(), cfg, originalPendingApprovals, holdSink, auditAgent, captures); replayErr != nil {
+		// Fail closed: the first-pass body references approval
+		// prompts whose holds couldn't be committed to the cache.
+		// Returning the body would invite the user to type "yes" at
+		// a prompt that resolves to nothing. Drop the body and
+		// surface a non-empty SkippedReason so the handler emits
+		// 502 — matches the pre-buffering eval path that returned
+		// "Clawvisor: approval unavailable" inline when Hold failed.
+		// Buffered audits are still flushed: they describe what
+		// would have happened, and the SkippedReason adds the
+		// approval-hold-storage row separately.
+		flushBufferedAudit(req.Context(), cfg, auditAgent, auditSink)
+		return PostprocessResult{
+			Body:          nil,
+			ContentType:   contentType,
+			SkippedReason: "approval hold storage failed: " + replayErr.Error(),
+		}
+	}
+	flushBufferedAudit(req.Context(), cfg, auditAgent, auditSink)
+
 	return PostprocessResult{
 		Body:        result.Body,
 		ContentType: contentType,
 		Rewritten:   result.Rewritten,
 		Decisions:   result.Decisions,
 	}
+}
+
+// coalesceFromCaptures builds the single PendingLiteApproval covering
+// every tool_use in a turn. The first approval-needing capture becomes
+// the primary (its decision context is mapped to the singular
+// ToolUse/Inspector/Fingerprint/Reason fields the rest of the codebase
+// already understands). PrimaryIndex records where the primary sat in
+// the original turn, so AllHolds() — and the release path that emits
+// from it — keep the model's tool_use order intact. Reordering would
+// break dependent sequences like Bash producing stdout that a
+// following WebFetch consumes.
+func coalesceFromCaptures(captures []evalCapture) PendingLiteApproval {
+	primaryIdx := -1
+	for i, c := range captures {
+		if c.Kind == HeldKindApproval {
+			primaryIdx = i
+			break
+		}
+	}
+	if primaryIdx < 0 {
+		// shouldCoalesceTurn would have returned false; treat as
+		// defensive guard so callers don't have to re-check.
+		primaryIdx = 0
+	}
+	primary := captures[primaryIdx]
+	pending := PendingLiteApproval{
+		ToolUse:      primary.Use,
+		Inspector:    primary.Inspector,
+		Fingerprint:  primary.Fingerprint,
+		Reason:       primary.Reason,
+		PrimaryIndex: primaryIdx,
+	}
+	pending.Additional = make([]HeldToolUse, 0, len(captures)-1)
+	for i, c := range captures {
+		if i == primaryIdx {
+			continue
+		}
+		pending.Additional = append(pending.Additional, HeldToolUse{
+			ToolUse:     c.Use,
+			Kind:        c.Kind,
+			Inspector:   c.Inspector,
+			Fingerprint: c.Fingerprint,
+			Reason:      c.Reason,
+		})
+	}
+	return pending
 }
 
 // ambiguousRefusalGuidance produces the substitute message the model
@@ -766,6 +997,50 @@ func approvalPrompt(tu conversation.ToolUse, reason string) string {
 		b.WriteString(preview)
 	}
 	b.WriteString("\n\nReply `yes` or `y` to run this tool call, `no` or `n` to block it, or `task` to instruct the agent to include this in a task definition for approval.")
+	return b.String()
+}
+
+// coalescedApprovalPrompt renders the prompt for a hold that covers
+// multiple tool_uses in one turn. Binary approve/deny only — the inline-
+// task ("task" verb) flow is single-tool by design, so it's omitted to
+// avoid an ambiguous "task" gesture against a batch with mixed kinds.
+// The kinds slice parallels uses: each entry tags whether that use was
+// the trigger for approval or held alongside (auto-allow / auto-rewrite).
+func coalescedApprovalPrompt(uses []HeldToolUse) string {
+	var b strings.Builder
+	b.WriteString("Clawvisor paused this turn for approval (")
+	b.WriteString(strconv.Itoa(len(uses)))
+	b.WriteString(" tool calls).")
+	for i, held := range uses {
+		b.WriteString("\n\n")
+		b.WriteString(strconv.Itoa(i + 1))
+		b.WriteString(". ")
+		if name := strings.TrimSpace(held.ToolUse.Name); name != "" {
+			b.WriteString("`")
+			b.WriteString(name)
+			b.WriteString("`")
+		} else {
+			b.WriteString("(unnamed tool)")
+		}
+		switch held.Kind {
+		case HeldKindApproval:
+			if reason := strings.TrimSpace(held.Reason); reason != "" {
+				b.WriteString(" — approval required: ")
+				b.WriteString(reason)
+			} else {
+				b.WriteString(" — approval required")
+			}
+		case HeldKindAllow:
+			b.WriteString(" — held alongside (would auto-allow on its own)")
+		case HeldKindRewrite:
+			b.WriteString(" — held alongside (would auto-allow with credential rewrite on its own)")
+		}
+		if preview := conversation.MakeToolInputPreview(held.ToolUse.Input); preview != "" {
+			b.WriteString("\n   Input: ")
+			b.WriteString(preview)
+		}
+	}
+	b.WriteString("\n\nReply `yes` or `y` to approve all calls and run them in order, `no` or `n` to deny the whole turn.")
 	return b.String()
 }
 

--- a/internal/runtime/llmproxy/postprocess.go
+++ b/internal/runtime/llmproxy/postprocess.go
@@ -1001,9 +1001,14 @@ func approvalPrompt(tu conversation.ToolUse, reason string) string {
 }
 
 // coalescedApprovalPrompt renders the prompt for a hold that covers
-// multiple tool_uses in one turn. Binary approve/deny only — the inline-
-// task ("task" verb) flow is single-tool by design, so it's omitted to
-// avoid an ambiguous "task" gesture against a batch with mixed kinds.
+// multiple tool_uses in one turn. Offers approve/deny/task — the same
+// three verbs as the single-tool prompt. "task" against a coalesced
+// hold generates a task-definition prompt whose expected_tools
+// enumerates every distinct tool name in the batch (see
+// taskCreationPromptForHolds), so the user can promote the whole
+// batch into a durable scope in one gesture instead of approving
+// each call individually.
+//
 // The kinds slice parallels uses: each entry tags whether that use was
 // the trigger for approval or held alongside (auto-allow / auto-rewrite).
 func coalescedApprovalPrompt(uses []HeldToolUse) string {
@@ -1040,21 +1045,53 @@ func coalescedApprovalPrompt(uses []HeldToolUse) string {
 			b.WriteString(preview)
 		}
 	}
-	b.WriteString("\n\nReply `yes` or `y` to approve all calls and run them in order, `no` or `n` to deny the whole turn.")
+	b.WriteString("\n\nReply `yes` or `y` to approve all calls and run them in order, `no` or `n` to deny the whole turn, or `task` to scope this work under a Clawvisor task that covers every call above.")
 	return b.String()
 }
 
 func taskCreationPrompt(tu conversation.ToolUse) string {
-	toolName := strings.TrimSpace(tu.Name)
-	if toolName == "" {
+	return taskCreationPromptForHolds([]HeldToolUse{{ToolUse: tu, Kind: HeldKindApproval}})
+}
+
+// taskCreationPromptForHolds renders the task-creation prompt for one
+// or more held tool_uses. When len(holds) == 1 the output is
+// byte-identical to the legacy single-tool taskCreationPrompt — the
+// inline-task flow on a single hold is unchanged. When len(holds) > 1
+// (coalesced hold), `expected_tools` enumerates every distinct tool
+// name in the batch so the generated task scope covers every held
+// call. Without this, typing "task" on a coalesced approval prompt
+// would scope only the primary tool and leave sibling reviewed calls
+// to re-prompt on the next retry.
+func taskCreationPromptForHolds(holds []HeldToolUse) string {
+	if len(holds) == 0 {
+		return ""
+	}
+	// Deduplicate by tool name; keep insertion order so the rendered
+	// expected_tools mirrors the model's emit order (matters for
+	// dependent sequences readers will recognize). The why for a
+	// duplicated tool name comes from the FIRST tool_use of that
+	// name — taskToolWhy already produces a description broad enough
+	// to cover sibling calls (e.g. "Run shell commands needed for
+	// the task, including writes AND verification reads").
+	seen := map[string]bool{}
+	expected := make([]map[string]any, 0, len(holds))
+	for _, held := range holds {
+		name := strings.TrimSpace(held.ToolUse.Name)
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		expected = append(expected, map[string]any{
+			"tool_name": name,
+			"why":       taskToolWhy(held.ToolUse),
+		})
+	}
+	if len(expected) == 0 {
 		return ""
 	}
 	payload := map[string]any{
-		"purpose": "Describe the user-visible task you are trying to complete, including why this tool access is needed.",
-		"expected_tools": []map[string]any{{
-			"tool_name": toolName,
-			"why":       taskToolWhy(tu),
-		}},
+		"purpose":                  "Describe the user-visible task you are trying to complete, including why this tool access is needed.",
+		"expected_tools":           expected,
 		"intent_verification_mode": "strict",
 		"expires_in_seconds":       600,
 	}

--- a/internal/runtime/llmproxy/postprocess_test.go
+++ b/internal/runtime/llmproxy/postprocess_test.go
@@ -930,8 +930,8 @@ func TestPostprocess_CoalescesMultipleApprovalsIntoSingleHold(t *testing.T) {
 	if !strings.Contains(out, "https://example.com/one") || !strings.Contains(out, "https://example.com/two") {
 		t.Fatalf("coalesced prompt should describe every held call, got: %s", out)
 	}
-	if strings.Contains(out, "or `task` to instruct") {
-		t.Fatalf("coalesced prompt must be binary (no 'task' verb), got: %s", out)
+	if !strings.Contains(out, "`task` to scope this work under a Clawvisor task") {
+		t.Fatalf("coalesced prompt must offer the `task` verb so the user can promote a batch into a durable scope, got: %s", out)
 	}
 
 	// Only ONE hold is created for the whole turn; both held tool_uses

--- a/internal/runtime/llmproxy/postprocess_test.go
+++ b/internal/runtime/llmproxy/postprocess_test.go
@@ -890,7 +890,7 @@ func TestPostprocess_MalformedSyntheticControlCommandRewritesToToolFailure(t *te
 	}
 }
 
-func TestPostprocess_HoldsMultipleApprovalPromptsInOneResponse(t *testing.T) {
+func TestPostprocess_CoalescesMultipleApprovalsIntoSingleHold(t *testing.T) {
 	body := []byte(`{
 		"id":"msg_1",
 		"type":"message",
@@ -921,28 +921,41 @@ func TestPostprocess_HoldsMultipleApprovalPromptsInOneResponse(t *testing.T) {
 		EgressRules:      []*store.RuntimePolicyRule{},
 	})
 	if !got.Rewritten {
-		t.Fatalf("expected approval prompts for reviewed tool calls")
+		t.Fatalf("expected coalesced approval prompt for reviewed tool calls")
 	}
-	if !strings.Contains(string(got.Body), "Tool: `WebFetch`") ||
-		!strings.Contains(string(got.Body), "https://example.com/one") {
-		t.Fatalf("approval prompt should identify held tool and input: %s", got.Body)
+	out := string(got.Body)
+	if !strings.Contains(out, "Clawvisor paused this turn for approval (2 tool calls).") {
+		t.Fatalf("expected coalesced prompt header, got: %s", out)
 	}
-	// Bare no-ID resolve returns the most recent hold first (LIFO).
-	// The user is replying to the most recent prompt the harness
-	// rendered, not the oldest unresolved one.
-	first, err := cache.Resolve(req.Context(), ResolveRequest{UserID: userID, AgentID: agentID, Provider: conversation.ProviderAnthropic})
-	if err != nil {
-		t.Fatal(err)
+	if !strings.Contains(out, "https://example.com/one") || !strings.Contains(out, "https://example.com/two") {
+		t.Fatalf("coalesced prompt should describe every held call, got: %s", out)
 	}
-	if first == nil || first.ToolUse.ID != "toolu_2" {
-		t.Fatalf("first bare resolve = %+v, want toolu_2 (most recent)", first)
+	if strings.Contains(out, "or `task` to instruct") {
+		t.Fatalf("coalesced prompt must be binary (no 'task' verb), got: %s", out)
 	}
-	second, err := cache.Resolve(req.Context(), ResolveRequest{UserID: userID, AgentID: agentID, Provider: conversation.ProviderAnthropic})
-	if err != nil {
-		t.Fatal(err)
+
+	// Only ONE hold is created for the whole turn; both held tool_uses
+	// live under it (primary + Additional). A single user yes/no
+	// releases or denies all of them together.
+	holds := cache.snapshotHoldsForTest(userID, agentID, conversation.ProviderAnthropic)
+	if len(holds) != 1 {
+		t.Fatalf("expected exactly one coalesced hold, got %d: %+v", len(holds), holds)
 	}
-	if second == nil || second.ToolUse.ID != "toolu_1" {
-		t.Fatalf("second bare resolve = %+v, want toolu_1 (older after most-recent consumed)", second)
+	hold := holds[0]
+	if !hold.IsCoalesced() {
+		t.Fatalf("expected hold.IsCoalesced() true; got primary=%s additional=%d", hold.ToolUse.ID, len(hold.Additional))
+	}
+	all := hold.AllHolds()
+	if len(all) != 2 {
+		t.Fatalf("expected 2 held tool_uses in the coalesced hold, got %d", len(all))
+	}
+	if all[0].ToolUse.ID != "toolu_1" || all[1].ToolUse.ID != "toolu_2" {
+		t.Fatalf("held tool_uses out of order: %s, %s (want toolu_1, toolu_2)", all[0].ToolUse.ID, all[1].ToolUse.ID)
+	}
+	for _, h := range all {
+		if h.Kind != HeldKindApproval {
+			t.Fatalf("expected all coalesced uses to be HeldKindApproval, got %q for %s", h.Kind, h.ToolUse.ID)
+		}
 	}
 }
 

--- a/internal/runtime/llmproxy/release.go
+++ b/internal/runtime/llmproxy/release.go
@@ -173,30 +173,65 @@ func TryReleasePendingApproval(ctx context.Context, req ReleaseRequest) ReleaseR
 	}
 	if verb == "deny" {
 		req.logRelease(ctx, pending, "deny", "denied", "denied inline by user")
-		return syntheticReleaseResult(req, pending, false, nil, "deny", "approval_denied", "")
+		return syntheticReleaseResultMulti(req, pending, false, nil, "deny", "approval_denied", "")
 	}
 
-	rewrittenInput, releaseErr := rewriteApprovedToolUse(ctx, req, pending)
+	rewrittenCalls, releaseErr := rewriteApprovedToolUses(ctx, req, pending)
 	if releaseErr != nil {
 		req.logRelease(ctx, pending, "deny", "blocked", releaseErr.Error())
-		return syntheticReleaseResult(req, pending, false, nil, "deny", "approval_release_blocked", releaseErr.Error())
+		return syntheticReleaseResultMulti(req, pending, false, nil, "deny", "approval_release_blocked", releaseErr.Error())
 	}
 	req.logRelease(ctx, pending, "allow", "released", "approved inline by user")
-	return syntheticReleaseResult(req, pending, true, rewrittenInput, "allow", "approval_released", "")
+	return syntheticReleaseResultMulti(req, pending, true, rewrittenCalls, "allow", "approval_released", "")
 }
 
-func rewriteApprovedToolUse(ctx context.Context, req ReleaseRequest, pending *PendingLiteApproval) (map[string]any, error) {
-	if req.Inspector == nil || pending == nil {
+// rewriteApprovedToolUses re-evaluates every held tool_use in the
+// pending approval against current state and returns the synthesized
+// call list in turn order. Fail-closed for the whole batch: if any
+// single use refuses re-eval (decision changed, fingerprint diverged,
+// boundary failed, nonce mint failed), the entire release is denied so
+// we never half-execute a coalesced turn.
+//
+// For single-tool holds (no Additional entries) this collapses to the
+// pre-coalescence behavior — one input map for one tool_use — and the
+// returned slice has length 1.
+func rewriteApprovedToolUses(ctx context.Context, req ReleaseRequest, pending *PendingLiteApproval) ([]conversation.SyntheticToolCall, error) {
+	if pending == nil {
 		return nil, errors.New("no pending approval")
 	}
+	holds := pending.AllHolds()
+	out := make([]conversation.SyntheticToolCall, 0, len(holds))
+	for _, held := range holds {
+		input, err := rewriteApprovedHeldToolUse(ctx, req, held)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, conversation.SyntheticToolCall{
+			ID:    held.ToolUse.ID,
+			Name:  held.ToolUse.Name,
+			Input: input,
+		})
+	}
+	return out, nil
+}
+
+// rewriteApprovedHeldToolUse is the per-held-use re-evaluation that
+// rewriteApprovedToolUses calls in a loop. Replays the inspector,
+// decision, boundary, and (for credentialed paths) caller-nonce mint
+// against the current agent / catalog / posture state. Any divergence
+// from the originally captured fingerprint denies the release.
+func rewriteApprovedHeldToolUse(ctx context.Context, req ReleaseRequest, held HeldToolUse) (map[string]any, error) {
+	if req.Inspector == nil {
+		return nil, errors.New("no inspector configured for release")
+	}
 	verdict := req.Inspector.Inspect(ctx, inspector.ToolUse{
-		ID:    pending.ToolUse.ID,
-		Name:  pending.ToolUse.Name,
-		Input: pending.ToolUse.Input,
+		ID:    held.ToolUse.ID,
+		Name:  held.ToolUse.Name,
+		Input: held.ToolUse.Input,
 	})
 	if verdict.Source == inspector.SourceTriggerMiss {
 		decisionInput := runtimedecision.AuthorizationInput{
-			ToolUse:           pending.ToolUse,
+			ToolUse:           held.ToolUse,
 			UserID:            req.Agent.UserID,
 			AgentID:           req.Agent.ID,
 			Posture:           req.Posture,
@@ -214,11 +249,18 @@ func rewriteApprovedToolUse(ctx context.Context, req ReleaseRequest, pending *Pe
 		case runtimedecision.VerdictDeny:
 			return nil, errors.New(dec.Reason)
 		case runtimedecision.VerdictNeedsApproval:
-			if !runtimedecision.EquivalentFingerprint(pending.Fingerprint, runtimedecision.Fingerprint(dec, decisionInput)) {
+			if held.Kind != HeldKindApproval {
+				// A coalesced sibling that was previously auto-allow now
+				// requires approval. Fail-closed so the user isn't
+				// silently bypassing a new policy decision via an
+				// earlier yes that didn't promise this.
+				return nil, errors.New("coalesced sibling now requires approval; re-prompt needed")
+			}
+			if !runtimedecision.EquivalentFingerprint(held.Fingerprint, runtimedecision.Fingerprint(dec, decisionInput)) {
 				return nil, errors.New("held approval no longer matches current authorization decision")
 			}
 		}
-		return decodeToolUseInput(pending.ToolUse.Input), nil
+		return decodeToolUseInput(held.ToolUse.Input), nil
 	}
 	if verdict.Ambiguous || !verdict.IsAPICall {
 		return nil, errors.New("held tool use no longer resolves to a credentialed API call")
@@ -231,7 +273,7 @@ func rewriteApprovedToolUse(ctx context.Context, req ReleaseRequest, pending *Pe
 		resolved, _ = req.Catalog.Resolve(verdict.Host, verdict.Method, verdict.Path)
 	}
 	decisionInput := runtimedecision.AuthorizationInput{
-		ToolUse:        pending.ToolUse,
+		ToolUse:        held.ToolUse,
 		UserID:         req.Agent.UserID,
 		AgentID:        req.Agent.ID,
 		Posture:        req.Posture,
@@ -251,7 +293,10 @@ func rewriteApprovedToolUse(ctx context.Context, req ReleaseRequest, pending *Pe
 	case runtimedecision.VerdictDeny:
 		return nil, errors.New(dec.Reason)
 	case runtimedecision.VerdictNeedsApproval:
-		if !runtimedecision.EquivalentFingerprint(pending.Fingerprint, runtimedecision.Fingerprint(dec, decisionInput)) {
+		if held.Kind != HeldKindApproval {
+			return nil, errors.New("coalesced sibling now requires approval; re-prompt needed")
+		}
+		if !runtimedecision.EquivalentFingerprint(held.Fingerprint, runtimedecision.Fingerprint(dec, decisionInput)) {
 			return nil, errors.New("held approval no longer matches current authorization decision")
 		}
 	}
@@ -272,7 +317,7 @@ func rewriteApprovedToolUse(ctx context.Context, req ReleaseRequest, pending *Pe
 	}
 	opts := req.RewriteOpts
 	opts.CallerToken = nonce
-	raw, err := inspector.Rewrite(inspector.ToolUse{ID: pending.ToolUse.ID, Name: pending.ToolUse.Name, Input: pending.ToolUse.Input}, verdict, opts)
+	raw, err := inspector.Rewrite(inspector.ToolUse{ID: held.ToolUse.ID, Name: held.ToolUse.Name, Input: held.ToolUse.Input}, verdict, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -321,12 +366,19 @@ func boundaryCheckReleaseVerdict(ctx context.Context, req ReleaseRequest, v insp
 	return "", true
 }
 
-func syntheticReleaseResult(req ReleaseRequest, pending *PendingLiteApproval, allow bool, toolInput map[string]any, decision, outcome, reason string) ReleaseResult {
+// syntheticReleaseResultMulti synthesizes the release response for a
+// hold that may carry multiple tool_uses (the coalesced path). On
+// allow, the response carries every approved tool_use in turn order so
+// the harness executes them all from one user yes. On deny, the
+// response is a single text block — calls is ignored. A single-tool
+// hold (no Additional entries) collapses to a one-element synthesis
+// that is byte-identical to the pre-coalescence shape.
+func syntheticReleaseResultMulti(req ReleaseRequest, pending *PendingLiteApproval, allow bool, calls []conversation.SyntheticToolCall, decision, outcome, reason string) ReleaseResult {
 	denyMessage := conversation.ApprovalDeniedMessage
 	if !allow && outcome == "approval_release_blocked" && strings.TrimSpace(reason) != "" {
 		denyMessage = "Approval could not be released. " + strings.TrimSpace(reason)
 	}
-	synth, ok := conversation.SyntheticApprovalToolUseResponseWithDenyMessage(req.HTTPRequest, req.Provider, req.Body, allow, pending.ToolUse.ID, pending.ToolUse.Name, toolInput, denyMessage)
+	synth, ok := conversation.SyntheticApprovalToolUsesResponseWithDenyMessage(req.HTTPRequest, req.Provider, req.Body, allow, calls, denyMessage)
 	if !ok {
 		return ReleaseResult{Handled: true, HTTPStatus: http.StatusBadRequest, Decision: "deny", Outcome: "approval_release_unsupported", Reason: "unsupported approval release provider"}
 	}


### PR DESCRIPTION
## Summary

- When a model response carries multiple tool_uses and at least one needs approval, hold the whole turn under one coalesced approval. A single user yes/no releases or denies every held call together — preserving the model's original turn order so dependent sequences (Bash producing output a following WebFetch consumes) still execute in order on release.
- Mixed turns also coalesce: an auto-allow Bash alongside a review-flagged WebFetch are held together and run in one batch at release. Inline-task and hard-deny turns fall back to the legacy per-tool path unchanged.
- Audit emits one `lite_proxy.approval.release` row per release event with per-tool detail under `params.held_tools[]`, avoiding the `UNIQUE(user_id, request_id, COALESCE(task_id, ''))` canonical dedup index that would otherwise silently collapse N rows.

## How it works

Pass 1 runs the existing per-tool eval with buffered `PendingApprovals` and audit wrappers — no per-tool state is committed to the underlying cache or audit store until the coalesce decision is made. After pass 1:

- **Coalesce mode** (≥2 tool_uses, ≥1 needs approval, no inline-task hold, no hard deny): commit one coalesced hold and emit `coalesced_approval_pending` audit rows; re-run the rewriter with a coalesced eval producing one combined approval prompt.
- **Legacy mode** (everything else): replay the buffered per-tool holds atomically. Any single Hold failure rolls back the batch and surfaces `SkippedReason` so the handler emits 502 — matching the pre-change inline "approval unavailable" semantic.

Release synthesizes a multi-tool response (Anthropic JSON+SSE, OpenAI Chat+Responses) so the harness executes every approved call from one user gesture. `rewriteApprovedToolUses` re-evaluates each held tool_use against current state and fails closed for the whole batch if any single re-eval refuses (decision changed, fingerprint diverged, boundary failed, nonce mint failed) — no half-executed turns.

## Test plan

- [ ] CI `go build ./...` green
- [ ] CI `go vet ./...` green
- [ ] CI `go test ./...` green (passes locally; new coverage in `coalesce_test.go` for: coalesced hold creation, mixed turns, single-tool legacy preservation, turn order preservation through release, coalesced hold failure fallback, bounded cache eviction safety, legacy replay failure fail-closed, partial replay rollback, configured TTL preservation, sibling metadata preservation, audit dedup avoidance)
- [ ] Multi-tool turn UX: send a model response with 2+ tool_uses that hit a `review` rule; verify ONE prompt is rendered (not N) and `yes` releases every call in original order
- [ ] Mixed turn: review-flagged WebFetch + auto-allow Bash in one response; verify both held and both run on `yes`
- [ ] Inline-task path: existing `task` verb flow still works for single-tool reviews
- [ ] Audit: confirm `lite_proxy.approval.release` rows carry `held_tools` array for coalesced releases and that single-tool holds remain shape-compatible with dashboards

🤖 Generated with [Claude Code](https://claude.com/claude-code)