### PR TITLE
feat(notify): add approval notification escalation

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -131,3 +131,12 @@ rate_limit:
   review_run:                # per user — manual review triggers
     limit: 5
     window: 3600
+
+notifications:
+  escalation:
+    enabled: false
+    default_chain:
+      - channel: push
+        delay_seconds: 0
+      - channel: telegram
+        delay_seconds: 60

--- a/internal/api/handlers/approvals.go
+++ b/internal/api/handlers/approvals.go
@@ -35,6 +35,13 @@ type ApprovalsHandler struct {
 	logger     *slog.Logger
 	eventHub   events.EventHub
 	cbDispatch *CallbackDispatcher // bounded callback delivery; may be nil (falls back to inline panic-safe goroutines)
+	resolver   ApprovalNotificationResolver
+}
+
+// ApprovalNotificationResolver resolves an approval escalation and cleans up
+// every channel that received that approval notification.
+type ApprovalNotificationResolver interface {
+	Resolve(ctx context.Context, targetType, targetID, userID, text string)
 }
 
 func NewApprovalsHandler(st store.Store, v vault.Vault, adapterReg *adapters.Registry, notifier notify.Notifier, cfg config.Config, assessor taskrisk.Assessor, logger *slog.Logger, eventHub events.EventHub) *ApprovalsHandler {
@@ -55,6 +62,12 @@ func NewApprovalsHandler(st store.Store, v vault.Vault, adapterReg *adapters.Reg
 // inline goroutine — still panic-safe but with no concurrency cap.
 func (h *ApprovalsHandler) SetCallbackDispatcher(d *CallbackDispatcher) {
 	h.cbDispatch = d
+}
+
+// SetApprovalNotificationResolver enables multi-channel approval notification
+// cleanup. Nil preserves the legacy Telegram-only update path.
+func (h *ApprovalsHandler) SetApprovalNotificationResolver(resolver ApprovalNotificationResolver) {
+	h.resolver = resolver
 }
 
 // dispatchCallback enqueues a payload for delivery via the bounded
@@ -357,7 +370,7 @@ func (h *ApprovalsHandler) markApproved(ctx context.Context, pa *store.PendingAp
 			notifyText = "✅ <b>Approved</b> — session task created and waiting for agent execution."
 		}
 	}
-	h.updateNotificationMsg(ctx, "approval", approvalNotifyTargetID(pa.RequestID, paTaskID(pa)), pa.UserID, notifyText)
+	h.resolveApprovalNotificationMsg(ctx, approvalNotifyTargetID(pa.RequestID, paTaskID(pa)), pa.UserID, notifyText)
 	h.decrementNotifierPolling(pa.UserID)
 
 	if pa.CallbackURL != nil && *pa.CallbackURL != "" {
@@ -429,7 +442,7 @@ func (h *ApprovalsHandler) DenyByRequestID(ctx context.Context, requestID, userI
 		h.logger.Error("failed to delete pending approval", "request_id", requestID, "err", err)
 	}
 
-	h.updateNotificationMsg(ctx, "approval", approvalNotifyTargetID(requestID, taskID), pa.UserID, "❌ <b>Denied</b> — request rejected.")
+	h.resolveApprovalNotificationMsg(ctx, approvalNotifyTargetID(requestID, taskID), pa.UserID, "❌ <b>Denied</b> — request rejected.")
 	h.decrementNotifierPolling(pa.UserID)
 	h.publishQueueAndAudit(userID, pa.AuditID)
 
@@ -492,7 +505,7 @@ func (h *ApprovalsHandler) Deny(w http.ResponseWriter, r *http.Request) {
 		h.logger.Error("failed to delete pending approval", "request_id", requestID, "err", err)
 	}
 
-	h.updateNotificationMsg(r.Context(), "approval", approvalNotifyTargetID(requestID, taskID), pa.UserID, "❌ <b>Denied</b> — request rejected.")
+	h.resolveApprovalNotificationMsg(r.Context(), approvalNotifyTargetID(requestID, taskID), pa.UserID, "❌ <b>Denied</b> — request rejected.")
 	h.decrementNotifierPolling(pa.UserID)
 	h.publishQueueAndAudit(user.ID, pa.AuditID)
 
@@ -547,7 +560,7 @@ func (h *ApprovalsHandler) executeApproval(ctx context.Context, pa *store.Pendin
 	if errMsg != "" {
 		notifyText = "✅ <b>Approved</b> — execution failed: " + errMsg
 	}
-	h.updateNotificationMsg(ctx, "approval", approvalNotifyTargetID(pa.RequestID, paTaskID(pa)), pa.UserID, notifyText)
+	h.resolveApprovalNotificationMsg(ctx, approvalNotifyTargetID(pa.RequestID, paTaskID(pa)), pa.UserID, notifyText)
 
 	if pa.CallbackURL != nil && *pa.CallbackURL != "" {
 		var cbResult *adapters.Result
@@ -609,7 +622,7 @@ func (h *ApprovalsHandler) RunExpiryCleanup(ctx context.Context) {
 //     pending-only guard, paging on every recovery sweep.
 func (h *ApprovalsHandler) processExpiredApproval(ctx context.Context, pa *store.PendingApproval, reason, telegramMsg string) {
 	_ = h.st.UpdateAuditOutcome(ctx, pa.AuditID, "timeout", "", 0)
-	h.updateNotificationMsg(ctx, "approval", approvalNotifyTargetID(pa.RequestID, paTaskID(pa)), pa.UserID, telegramMsg)
+	h.resolveApprovalNotificationMsg(ctx, approvalNotifyTargetID(pa.RequestID, paTaskID(pa)), pa.UserID, telegramMsg)
 	// For the regular expired path the caller relies on us to delete the
 	// row; for the stranded path the CAS DELETE already happened, so the
 	// best-effort DELETE here is a no-op (zero rows affected).
@@ -879,6 +892,14 @@ func (h *ApprovalsHandler) decrementNotifierPolling(userID string) {
 	if pd, ok := h.notifier.(notify.PollingDecrementer); ok {
 		pd.DecrementPolling(userID)
 	}
+}
+
+func (h *ApprovalsHandler) resolveApprovalNotificationMsg(ctx context.Context, targetID, userID, text string) {
+	if h.resolver != nil {
+		h.resolver.Resolve(ctx, "approval", targetID, userID, text)
+		return
+	}
+	h.updateNotificationMsg(ctx, "approval", targetID, userID, text)
 }
 
 // updateNotificationMsg updates the Telegram message for a target

--- a/internal/api/handlers/devices.go
+++ b/internal/api/handlers/devices.go
@@ -307,6 +307,7 @@ func (h *DevicesHandler) Action(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		Action      string `json:"action"`       // "approve" or "deny"
 		TargetID    string `json:"target_id"`    // request/task/connection ID
+		TaskID      string `json:"task_id"`      // disambiguates sibling request approvals
 		RequestType string `json:"request_type"` // "approval", "task", "scope_expansion", "connection"
 	}
 	if !decodeJSON(w, r, &body) {
@@ -333,6 +334,7 @@ func (h *DevicesHandler) Action(w http.ResponseWriter, r *http.Request) {
 		Type:     body.RequestType,
 		Action:   body.Action,
 		TargetID: body.TargetID,
+		TaskID:   body.TaskID,
 		UserID:   device.UserID,
 	})
 

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -64,6 +64,12 @@ type LocalServiceExecutor interface {
 	Execute(ctx context.Context, userID, service, action string, params map[string]any) (*adapters.Result, error)
 }
 
+// ApprovalEscalator starts sequential notification escalation for request
+// approvals. Nil preserves legacy notifier fan-out behavior.
+type ApprovalEscalator interface {
+	StartApproval(ctx context.Context, approvalRecordID, targetType, targetID string, req notify.ApprovalRequest) error
+}
+
 // isLocalService returns true for services provided by local daemons.
 func isLocalService(serviceType string) bool {
 	return strings.HasPrefix(serviceType, "local.")
@@ -89,6 +95,7 @@ type GatewayHandler struct {
 	cbDispatch       *CallbackDispatcher  // bounded callback delivery; may be nil
 	gatewayRL        ratelimit.Limiter    // gateway-bucket limiter for per-sub-request charging in HandleBatch; may be nil
 	gatewayRLKey     func(*http.Request) string
+	escalator        ApprovalEscalator // request-approval notification escalation; may be nil
 }
 
 func NewGatewayHandler(
@@ -156,6 +163,11 @@ func (h *GatewayHandler) SetCallbackDispatcher(d *CallbackDispatcher) {
 func (h *GatewayHandler) SetGatewayRateLimiter(limiter ratelimit.Limiter, agentKey func(*http.Request) string) {
 	h.gatewayRL = limiter
 	h.gatewayRLKey = agentKey
+}
+
+// SetApprovalEscalator enables request-approval notification escalation.
+func (h *GatewayHandler) SetApprovalEscalator(escalator ApprovalEscalator) {
+	h.escalator = escalator
 }
 
 // dispatchCallback enqueues a payload for delivery via the bounded
@@ -2415,13 +2427,20 @@ func (h *GatewayHandler) routeToApproval(
 		approvalReq.VerifyReasonCoherence = verdict.ReasonCoherence
 		approvalReq.VerifyExplanation = verdict.Explanation
 	}
+	targetID := approvalNotifyTargetID(blob.RequestID, blob.TaskID)
+	if h.escalator != nil {
+		if err := h.escalator.StartApproval(ctx, approvalRecord.ID, "approval", targetID, approvalReq); err != nil {
+			h.logger.Warn("approval notification escalation failed", "err", err)
+		}
+		return nil
+	}
 	msgID, err := h.notifier.SendApprovalRequest(ctx, approvalReq)
 	if err != nil {
 		h.logger.Warn("telegram approval notification failed", "err", err)
 		return nil
 	}
 
-	_ = h.store.SaveNotificationMessage(ctx, "approval", approvalNotifyTargetID(blob.RequestID, blob.TaskID), "telegram", msgID)
+	_ = h.store.SaveNotificationMessage(ctx, "approval", targetID, "telegram", msgID)
 	return nil
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/clawvisor/clawvisor/internal/llm"
 	"github.com/clawvisor/clawvisor/internal/mcp"
 	mcpoauth "github.com/clawvisor/clawvisor/internal/mcp/oauth"
+	"github.com/clawvisor/clawvisor/internal/notify/escalation"
 	"github.com/clawvisor/clawvisor/internal/notify/push"
 	"github.com/clawvisor/clawvisor/internal/ratelimit"
 	"github.com/clawvisor/clawvisor/internal/relay"
@@ -78,6 +79,7 @@ type Server struct {
 	approvalsHandler   *handlers.ApprovalsHandler
 	tasksHandler       *handlers.TasksHandler
 	connectionsHandler *handlers.ConnectionsHandler
+	approvalEscalator  *escalation.Manager
 	devicesHandler     *handlers.DevicesHandler
 	llmVerifier        *intent.LLMVerifier          // verdict cache cleanup target; nil when verification disabled
 	cbDispatcher       *handlers.CallbackDispatcher // bounded callback delivery pool
@@ -521,11 +523,15 @@ func (s *Server) routes() http.Handler {
 		s.cbDispatcher.Start(16)
 	}
 
+	s.approvalEscalator = escalation.New(s.store, s.notifier, s.cfg.Notifications.Escalation, s.logger)
 	gatewayHandler := handlers.NewGatewayHandler(
 		s.store, s.vault, s.adapterReg,
 		s.notifier, verifier, extractor, *s.cfg, s.logger, baseURL, s.eventHub,
 	)
 	gatewayHandler.SetCallbackDispatcher(s.cbDispatcher)
+	if s.approvalEscalator != nil {
+		gatewayHandler.SetApprovalEscalator(s.approvalEscalator)
+	}
 	if s.llmCfg.Verification.Enabled {
 		gatewayHandler.SetGatewayRequestResolver(runtimepolicy.NewLLMGatewayRequestResolver(s.llmHealth, s.logger))
 	}
@@ -567,6 +573,9 @@ func (s *Server) routes() http.Handler {
 	s.taskRiskAssessor = assessor
 	approvalsHandler := handlers.NewApprovalsHandler(s.store, s.vault, s.adapterReg, s.notifier, *s.cfg, assessor, s.logger, s.eventHub)
 	approvalsHandler.SetCallbackDispatcher(s.cbDispatcher)
+	if s.approvalEscalator != nil {
+		approvalsHandler.SetApprovalNotificationResolver(s.approvalEscalator)
+	}
 	s.approvalsHandler = approvalsHandler
 
 	tasksHandler := handlers.NewTasksHandler(s.store, s.vault, s.adapterReg,
@@ -1413,6 +1422,9 @@ func (s *Server) Run(ctx context.Context) error {
 
 	// Start background expiry cleanup.
 	go s.approvalsHandler.RunExpiryCleanup(ctx)
+	if s.approvalEscalator != nil {
+		go s.approvalEscalator.Run(ctx)
+	}
 
 	// Start verdict-cache cleanup so the in-memory cache evicts expired
 	// entries on a schedule rather than only on-access.

--- a/internal/notify/escalation/worker.go
+++ b/internal/notify/escalation/worker.go
@@ -1,0 +1,266 @@
+package escalation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/clawvisor/clawvisor/pkg/config"
+	"github.com/clawvisor/clawvisor/pkg/notify"
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+const (
+	statusRetryDelay = 15 * time.Second
+	defaultPollEvery = 15 * time.Second
+	defaultDueLimit  = 50
+)
+
+// Store is the persistence surface the escalation worker needs.
+type Store interface {
+	CreateApprovalEscalation(ctx context.Context, e *store.ApprovalEscalation) error
+	ListDueApprovalEscalations(ctx context.Context, now time.Time, limit int) ([]*store.ApprovalEscalation, error)
+	ClaimApprovalEscalationStep(ctx context.Context, id string, currentStep int, now time.Time) (bool, error)
+	CompleteApprovalEscalationStep(ctx context.Context, id string, claimedStep, nextStep int, nextAt time.Time) (bool, error)
+	ReleaseApprovalEscalationStep(ctx context.Context, id string, claimedStep int, retryAt time.Time) error
+	ResolveApprovalEscalation(ctx context.Context, targetType, targetID string) error
+	TimeoutApprovalEscalation(ctx context.Context, id string, claimedStep int) error
+	SaveNotificationMessage(ctx context.Context, targetType, targetID, channel, messageID string) error
+	ListNotificationMessages(ctx context.Context, targetType, targetID string) ([]*store.NotificationMessage, error)
+}
+
+// Manager starts, advances, resolves, and cleans up request-approval
+// notification escalation sessions.
+type Manager struct {
+	store        Store
+	notifier     notify.Notifier
+	chain        []Step
+	pollInterval time.Duration
+	now          func() time.Time
+	logger       *slog.Logger
+}
+
+// Step describes one channel in the configured fallback chain.
+type Step struct {
+	Channel      string `json:"channel"`
+	DelaySeconds int    `json:"delay_seconds"`
+}
+
+// New creates an escalation manager from validated runtime config. It returns
+// nil when escalation is disabled or no notifier is configured.
+func New(st Store, notifier notify.Notifier, cfg config.NotificationEscalationConfig, logger *slog.Logger) *Manager {
+	if !cfg.Enabled || st == nil || notifier == nil {
+		return nil
+	}
+	chain := make([]Step, 0, len(cfg.DefaultChain))
+	for _, step := range cfg.DefaultChain {
+		chain = append(chain, Step{
+			Channel:      strings.ToLower(strings.TrimSpace(step.Channel)),
+			DelaySeconds: step.DelaySeconds,
+		})
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Manager{
+		store:        st,
+		notifier:     notifier,
+		chain:        chain,
+		pollInterval: defaultPollEvery,
+		now:          time.Now,
+		logger:       logger,
+	}
+}
+
+// StartApproval persists a new approval escalation and dispatches any step due
+// immediately, such as a first step configured with delay_seconds: 0.
+func (m *Manager) StartApproval(ctx context.Context, approvalRecordID, targetType, targetID string, req notify.ApprovalRequest) error {
+	if m == nil || len(m.chain) == 0 {
+		return nil
+	}
+	now := m.now().UTC()
+	reqJSON, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("marshal approval request: %w", err)
+	}
+	chainJSON, err := json.Marshal(m.chain)
+	if err != nil {
+		return fmt.Errorf("marshal escalation chain: %w", err)
+	}
+	firstAt := now.Add(time.Duration(m.chain[0].DelaySeconds) * time.Second)
+	if err := m.store.CreateApprovalEscalation(ctx, &store.ApprovalEscalation{
+		ApprovalRecordID: approvalRecordID,
+		UserID:           req.UserID,
+		TargetType:       targetType,
+		TargetID:         targetID,
+		ApprovalRequest:  reqJSON,
+		EscalationChain:  chainJSON,
+		CurrentStep:      0,
+		NextEscalateAt:   firstAt,
+		Status:           "active",
+	}); err != nil {
+		return fmt.Errorf("create approval escalation: %w", err)
+	}
+	if !firstAt.After(now) {
+		if err := m.ProcessDueOnce(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Run polls for due escalation steps until ctx is cancelled.
+func (m *Manager) Run(ctx context.Context) {
+	if m == nil {
+		return
+	}
+	ticker := time.NewTicker(m.pollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := m.ProcessDueOnce(ctx); err != nil {
+				m.logger.Warn("notification escalation poll failed", "err", err)
+			}
+		}
+	}
+}
+
+// ProcessDueOnce processes currently due escalation rows. It is exported for
+// focused tests and for immediate first-step dispatch.
+func (m *Manager) ProcessDueOnce(ctx context.Context) error {
+	if m == nil {
+		return nil
+	}
+	now := m.now().UTC()
+	due, err := m.store.ListDueApprovalEscalations(ctx, now, defaultDueLimit)
+	if err != nil {
+		return err
+	}
+	for _, esc := range due {
+		if err := m.process(ctx, esc, now); err != nil {
+			m.logger.Warn("notification escalation step failed", "id", esc.ID, "target_type", esc.TargetType, "target_id", esc.TargetID, "err", err)
+		}
+	}
+	return nil
+}
+
+// Resolve marks the escalation complete and best-effort updates every channel
+// that received a message for this approval.
+func (m *Manager) Resolve(ctx context.Context, targetType, targetID, userID, text string) {
+	if m == nil {
+		return
+	}
+	if err := m.store.ResolveApprovalEscalation(ctx, targetType, targetID); err != nil {
+		m.logger.Warn("notification escalation resolve failed", "target_type", targetType, "target_id", targetID, "err", err)
+	}
+	messages, err := m.store.ListNotificationMessages(ctx, targetType, targetID)
+	if err != nil {
+		m.logger.Warn("notification escalation list messages failed", "target_type", targetType, "target_id", targetID, "err", err)
+		return
+	}
+	for _, msg := range messages {
+		if msg.MessageID == "" {
+			continue
+		}
+		if err := m.updateChannelMessage(ctx, msg.Channel, userID, msg.MessageID, text); err != nil {
+			m.logger.Warn("notification escalation message cleanup failed", "channel", msg.Channel, "target_type", targetType, "target_id", targetID, "err", err)
+		}
+	}
+}
+
+func (m *Manager) process(ctx context.Context, esc *store.ApprovalEscalation, now time.Time) error {
+	chain, err := decodeChain(esc.EscalationChain)
+	if err != nil {
+		return err
+	}
+	claimed, err := m.store.ClaimApprovalEscalationStep(ctx, esc.ID, esc.CurrentStep, now)
+	if err != nil {
+		return err
+	}
+	if !claimed {
+		return nil
+	}
+	if esc.CurrentStep >= len(chain) {
+		return m.store.TimeoutApprovalEscalation(ctx, esc.ID, esc.CurrentStep)
+	}
+
+	var req notify.ApprovalRequest
+	if err := json.Unmarshal(esc.ApprovalRequest, &req); err != nil {
+		_ = m.store.ReleaseApprovalEscalationStep(ctx, esc.ID, esc.CurrentStep, now.Add(statusRetryDelay))
+		return fmt.Errorf("decode approval request: %w", err)
+	}
+
+	step := chain[esc.CurrentStep]
+	channel := strings.ToLower(strings.TrimSpace(step.Channel))
+	msgID, sendErr := m.sendToChannel(ctx, channel, req)
+	if sendErr != nil {
+		m.logger.Warn("notification escalation dispatch failed", "channel", channel, "target_type", esc.TargetType, "target_id", esc.TargetID, "err", sendErr)
+	} else if msgID != "" {
+		if err := m.store.SaveNotificationMessage(ctx, esc.TargetType, esc.TargetID, channel, msgID); err != nil {
+			m.logger.Warn("notification escalation message coordinate save failed", "channel", channel, "target_type", esc.TargetType, "target_id", esc.TargetID, "err", err)
+		}
+	}
+
+	nextStep := esc.CurrentStep + 1
+	if nextStep >= len(chain) {
+		return m.store.TimeoutApprovalEscalation(ctx, esc.ID, esc.CurrentStep)
+	}
+	nextAt := nextStepTime(esc.CreatedAt, now, chain[nextStep])
+	ok, err := m.store.CompleteApprovalEscalationStep(ctx, esc.ID, esc.CurrentStep, nextStep, nextAt)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	return sendErr
+}
+
+func (m *Manager) sendToChannel(ctx context.Context, channel string, req notify.ApprovalRequest) (string, error) {
+	if sender, ok := m.notifier.(notify.ChannelApprovalSender); ok {
+		return sender.SendApprovalRequestToChannel(ctx, channel, req)
+	}
+	if provider, ok := m.notifier.(notify.ChannelProvider); ok && strings.EqualFold(provider.NotificationChannel(), channel) {
+		return m.notifier.SendApprovalRequest(ctx, req)
+	}
+	return "", fmt.Errorf("notification channel unavailable: %s", channel)
+}
+
+func (m *Manager) updateChannelMessage(ctx context.Context, channel, userID, messageID, text string) error {
+	if updater, ok := m.notifier.(notify.ChannelMessageUpdater); ok {
+		return updater.UpdateMessageForChannel(ctx, channel, userID, messageID, text)
+	}
+	if provider, ok := m.notifier.(notify.ChannelProvider); ok && strings.EqualFold(provider.NotificationChannel(), channel) {
+		return m.notifier.UpdateMessage(ctx, userID, messageID, text)
+	}
+	return fmt.Errorf("notification channel unavailable: %s", channel)
+}
+
+func decodeChain(raw json.RawMessage) ([]Step, error) {
+	var chain []Step
+	if err := json.Unmarshal(raw, &chain); err != nil {
+		return nil, fmt.Errorf("decode escalation chain: %w", err)
+	}
+	if len(chain) == 0 {
+		return nil, fmt.Errorf("escalation chain is empty")
+	}
+	return chain, nil
+}
+
+func nextStepTime(createdAt, now time.Time, step Step) time.Time {
+	base := createdAt
+	if base.IsZero() {
+		base = now
+	}
+	nextAt := base.UTC().Add(time.Duration(step.DelaySeconds) * time.Second)
+	if nextAt.Before(now) {
+		return now
+	}
+	return nextAt
+}

--- a/internal/notify/escalation/worker_test.go
+++ b/internal/notify/escalation/worker_test.go
@@ -1,0 +1,351 @@
+package escalation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/clawvisor/clawvisor/pkg/notify"
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+type memoryEscalationStore struct {
+	mu          sync.Mutex
+	escalations map[string]*store.ApprovalEscalation
+	messages    []*store.NotificationMessage
+	nextID      int
+}
+
+func newMemoryEscalationStore() *memoryEscalationStore {
+	return &memoryEscalationStore{escalations: make(map[string]*store.ApprovalEscalation)}
+}
+
+func (s *memoryEscalationStore) CreateApprovalEscalation(ctx context.Context, e *store.ApprovalEscalation) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.nextID++
+	cp := cloneEscalation(e)
+	if cp.ID == "" {
+		cp.ID = fmt.Sprintf("esc-%d", s.nextID)
+	}
+	if cp.Status == "" {
+		cp.Status = "active"
+	}
+	if cp.CreatedAt.IsZero() {
+		cp.CreatedAt = cp.NextEscalateAt
+	}
+	cp.UpdatedAt = cp.CreatedAt
+	s.escalations[cp.ID] = cp
+	return nil
+}
+
+func (s *memoryEscalationStore) ListDueApprovalEscalations(ctx context.Context, now time.Time, limit int) ([]*store.ApprovalEscalation, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []*store.ApprovalEscalation
+	for _, esc := range s.escalations {
+		if esc.Status == "active" && !esc.NextEscalateAt.After(now) {
+			out = append(out, cloneEscalation(esc))
+		}
+	}
+	return out, nil
+}
+
+func (s *memoryEscalationStore) ClaimApprovalEscalationStep(ctx context.Context, id string, currentStep int, now time.Time) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	esc := s.escalations[id]
+	if esc == nil || esc.Status != "active" || esc.CurrentStep != currentStep || esc.NextEscalateAt.After(now) {
+		return false, nil
+	}
+	esc.Status = "dispatching"
+	return true, nil
+}
+
+func (s *memoryEscalationStore) CompleteApprovalEscalationStep(ctx context.Context, id string, claimedStep, nextStep int, nextAt time.Time) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	esc := s.escalations[id]
+	if esc == nil || esc.Status != "dispatching" || esc.CurrentStep != claimedStep {
+		return false, nil
+	}
+	esc.Status = "active"
+	esc.CurrentStep = nextStep
+	esc.NextEscalateAt = nextAt
+	return true, nil
+}
+
+func (s *memoryEscalationStore) ReleaseApprovalEscalationStep(ctx context.Context, id string, claimedStep int, retryAt time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if esc := s.escalations[id]; esc != nil && esc.Status == "dispatching" && esc.CurrentStep == claimedStep {
+		esc.Status = "active"
+		esc.NextEscalateAt = retryAt
+	}
+	return nil
+}
+
+func (s *memoryEscalationStore) ResolveApprovalEscalation(ctx context.Context, targetType, targetID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, esc := range s.escalations {
+		if esc.TargetType == targetType && esc.TargetID == targetID {
+			esc.Status = "resolved"
+		}
+	}
+	return nil
+}
+
+func (s *memoryEscalationStore) TimeoutApprovalEscalation(ctx context.Context, id string, claimedStep int) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if esc := s.escalations[id]; esc != nil && esc.Status == "dispatching" && esc.CurrentStep == claimedStep {
+		esc.Status = "timed_out"
+	}
+	return nil
+}
+
+func (s *memoryEscalationStore) SaveNotificationMessage(ctx context.Context, targetType, targetID, channel, messageID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.messages = append(s.messages, &store.NotificationMessage{
+		TargetType: targetType,
+		TargetID:   targetID,
+		Channel:    channel,
+		MessageID:  messageID,
+		CreatedAt:  time.Now().UTC(),
+	})
+	return nil
+}
+
+func (s *memoryEscalationStore) ListNotificationMessages(ctx context.Context, targetType, targetID string) ([]*store.NotificationMessage, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []*store.NotificationMessage
+	for _, msg := range s.messages {
+		if msg.TargetType == targetType && msg.TargetID == targetID {
+			cp := *msg
+			out = append(out, &cp)
+		}
+	}
+	return out, nil
+}
+
+func (s *memoryEscalationStore) onlyEscalation(t *testing.T) *store.ApprovalEscalation {
+	t.Helper()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.escalations) != 1 {
+		t.Fatalf("escalation count=%d, want 1", len(s.escalations))
+	}
+	for _, esc := range s.escalations {
+		return cloneEscalation(esc)
+	}
+	return nil
+}
+
+func (s *memoryEscalationStore) messageCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.messages)
+}
+
+func cloneEscalation(e *store.ApprovalEscalation) *store.ApprovalEscalation {
+	cp := *e
+	cp.ApprovalRequest = append([]byte(nil), e.ApprovalRequest...)
+	cp.EscalationChain = append([]byte(nil), e.EscalationChain...)
+	return &cp
+}
+
+type escalationNotifier struct {
+	mu      sync.Mutex
+	sent    []string
+	updates []string
+}
+
+func (n *escalationNotifier) SendApprovalRequestToChannel(ctx context.Context, channel string, req notify.ApprovalRequest) (string, error) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.sent = append(n.sent, channel)
+	return channel + "-msg", nil
+}
+
+func (n *escalationNotifier) UpdateMessageForChannel(ctx context.Context, channel, userID, messageID, text string) error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.updates = append(n.updates, channel+":"+messageID)
+	return nil
+}
+
+func (n *escalationNotifier) SendApprovalRequest(ctx context.Context, req notify.ApprovalRequest) (string, error) {
+	return n.SendApprovalRequestToChannel(ctx, "legacy", req)
+}
+
+func (n *escalationNotifier) SendActivationRequest(ctx context.Context, req notify.ActivationRequest) error {
+	return nil
+}
+
+func (n *escalationNotifier) SendTaskApprovalRequest(ctx context.Context, req notify.TaskApprovalRequest) (string, error) {
+	return "", nil
+}
+
+func (n *escalationNotifier) SendScopeExpansionRequest(ctx context.Context, req notify.ScopeExpansionRequest) (string, error) {
+	return "", nil
+}
+
+func (n *escalationNotifier) UpdateMessage(ctx context.Context, userID, messageID, text string) error {
+	return nil
+}
+
+func (n *escalationNotifier) SendTestMessage(ctx context.Context, userID string) error { return nil }
+
+func (n *escalationNotifier) SendConnectionRequest(ctx context.Context, req notify.ConnectionRequest) (string, error) {
+	return "", nil
+}
+
+func (n *escalationNotifier) SendAlert(ctx context.Context, userID, text string) error { return nil }
+
+func (n *escalationNotifier) sentChannels() []string {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return append([]string(nil), n.sent...)
+}
+
+func (n *escalationNotifier) updateMessages() []string {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return append([]string(nil), n.updates...)
+}
+
+func TestStartApprovalDispatchesImmediateFirstStepAndDelaysNext(t *testing.T) {
+	ctx := context.Background()
+	st := newMemoryEscalationStore()
+	notifier := &escalationNotifier{}
+	base := time.Date(2026, 5, 23, 10, 0, 0, 0, time.UTC)
+	m := &Manager{
+		store:    st,
+		notifier: notifier,
+		chain: []Step{
+			{Channel: "push", DelaySeconds: 0},
+			{Channel: "telegram", DelaySeconds: 60},
+		},
+		now:    func() time.Time { return base },
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	if err := m.StartApproval(ctx, "approval-1", "approval", "req-1", notify.ApprovalRequest{RequestID: "req-1", UserID: "user-1"}); err != nil {
+		t.Fatalf("StartApproval: %v", err)
+	}
+	if got := notifier.sentChannels(); len(got) != 1 || got[0] != "push" {
+		t.Fatalf("sent=%v, want [push]", got)
+	}
+	esc := st.onlyEscalation(t)
+	if esc.Status != "active" || esc.CurrentStep != 1 || !esc.NextEscalateAt.Equal(base.Add(time.Minute)) {
+		t.Fatalf("escalation status=%s step=%d next=%s", esc.Status, esc.CurrentStep, esc.NextEscalateAt)
+	}
+
+	m.now = func() time.Time { return base.Add(30 * time.Second) }
+	if err := m.ProcessDueOnce(ctx); err != nil {
+		t.Fatalf("ProcessDueOnce before due: %v", err)
+	}
+	if got := notifier.sentChannels(); len(got) != 1 {
+		t.Fatalf("sent before second due=%v, want one send", got)
+	}
+
+	m.now = func() time.Time { return base.Add(time.Minute) }
+	if err := m.ProcessDueOnce(ctx); err != nil {
+		t.Fatalf("ProcessDueOnce second due: %v", err)
+	}
+	if got := notifier.sentChannels(); len(got) != 2 || got[1] != "telegram" {
+		t.Fatalf("sent=%v, want [push telegram]", got)
+	}
+	if esc := st.onlyEscalation(t); esc.Status != "timed_out" {
+		t.Fatalf("status=%s, want timed_out", esc.Status)
+	}
+	if got := st.messageCount(); got != 2 {
+		t.Fatalf("message count=%d, want 2", got)
+	}
+}
+
+func TestResolvedEscalationSkipsLaterDispatchAndUpdatesMessages(t *testing.T) {
+	ctx := context.Background()
+	st := newMemoryEscalationStore()
+	notifier := &escalationNotifier{}
+	base := time.Date(2026, 5, 23, 10, 0, 0, 0, time.UTC)
+	m := &Manager{
+		store:    st,
+		notifier: notifier,
+		chain: []Step{
+			{Channel: "push", DelaySeconds: 0},
+			{Channel: "telegram", DelaySeconds: 60},
+		},
+		now:    func() time.Time { return base },
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	if err := m.StartApproval(ctx, "approval-1", "approval", "req-1", notify.ApprovalRequest{RequestID: "req-1", UserID: "user-1"}); err != nil {
+		t.Fatalf("StartApproval: %v", err)
+	}
+	m.Resolve(ctx, "approval", "req-1", "user-1", "resolved")
+	if got := notifier.updateMessages(); len(got) != 1 || got[0] != "push:push-msg" {
+		t.Fatalf("updates=%v, want [push:push-msg]", got)
+	}
+	m.now = func() time.Time { return base.Add(time.Minute) }
+	if err := m.ProcessDueOnce(ctx); err != nil {
+		t.Fatalf("ProcessDueOnce: %v", err)
+	}
+	if got := notifier.sentChannels(); len(got) != 1 {
+		t.Fatalf("sent after resolve=%v, want only first send", got)
+	}
+	if esc := st.onlyEscalation(t); esc.Status != "resolved" {
+		t.Fatalf("status=%s, want resolved", esc.Status)
+	}
+}
+
+func TestConcurrentDueProcessingClaimsStepOnce(t *testing.T) {
+	ctx := context.Background()
+	st := newMemoryEscalationStore()
+	notifier := &escalationNotifier{}
+	now := time.Date(2026, 5, 23, 10, 0, 0, 0, time.UTC)
+	req, _ := json.Marshal(notify.ApprovalRequest{RequestID: "req-1", UserID: "user-1"})
+	chain, _ := json.Marshal([]Step{{Channel: "push", DelaySeconds: 0}})
+	if err := st.CreateApprovalEscalation(ctx, &store.ApprovalEscalation{
+		ApprovalRecordID: "approval-1",
+		UserID:           "user-1",
+		TargetType:       "approval",
+		TargetID:         "req-1",
+		ApprovalRequest:  req,
+		EscalationChain:  chain,
+		CurrentStep:      0,
+		NextEscalateAt:   now,
+		Status:           "active",
+	}); err != nil {
+		t.Fatalf("CreateApprovalEscalation: %v", err)
+	}
+	m := &Manager{
+		store:    st,
+		notifier: notifier,
+		now:      func() time.Time { return now },
+		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := m.ProcessDueOnce(ctx); err != nil {
+				t.Errorf("ProcessDueOnce: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+	if got := notifier.sentChannels(); len(got) != 1 || got[0] != "push" {
+		t.Fatalf("sent=%v, want single push dispatch", got)
+	}
+}

--- a/internal/notify/push/notifier.go
+++ b/internal/notify/push/notifier.go
@@ -141,6 +141,8 @@ func (n *Notifier) DeregisterDevice(ctx context.Context, deviceToken string) err
 
 // ── notify.Notifier implementation ────────────────────────────────────────────
 
+func (n *Notifier) NotificationChannel() string { return "push" }
+
 func (n *Notifier) SendApprovalRequest(ctx context.Context, req notify.ApprovalRequest) (string, error) {
 	summary := req.Service + "/" + req.Action
 	body := fmt.Sprintf("%s wants to use %s.%s", req.AgentName, req.Service, req.Action)
@@ -149,7 +151,8 @@ func (n *Notifier) SendApprovalRequest(ctx context.Context, req notify.ApprovalR
 		Title:    "Approval Request",
 		Body:     body,
 		Data: map[string]string{
-			"target_id":      req.PendingID,
+			"target_id":      req.RequestID,
+			"task_id":        req.TaskID,
 			"type":           "approval",
 			"daemon_url":     n.daemonURL,
 			"action_summary": summary,
@@ -157,7 +160,8 @@ func (n *Notifier) SendApprovalRequest(ctx context.Context, req notify.ApprovalR
 		LiveActivity: &liveActivityPayload{
 			AttributesType: "ApprovalActivityAttributes",
 			Attributes: map[string]string{
-				"targetID":      req.PendingID,
+				"targetID":      req.RequestID,
+				"taskID":        req.TaskID,
 				"daemonURL":     n.daemonURL,
 				"requestType":   "approval",
 				"category":      "GATEWAY_APPROVAL",

--- a/internal/notify/push/notifier_test.go
+++ b/internal/notify/push/notifier_test.go
@@ -87,8 +87,8 @@ func TestSendApprovalRequest(t *testing.T) {
 	if !strings.Contains(received.Body, "TestAgent") {
 		t.Errorf("body should contain agent name, got %q", received.Body)
 	}
-	if received.Data["target_id"] != "pend-456" {
-		t.Errorf("expected target_id 'pend-456', got %v", received.Data["target_id"])
+	if received.Data["target_id"] != "req-123" {
+		t.Errorf("expected target_id 'req-123', got %v", received.Data["target_id"])
 	}
 	if received.Data["type"] != "approval" {
 		t.Errorf("expected type 'approval', got %v", received.Data["type"])

--- a/internal/notify/telegram/telegram.go
+++ b/internal/notify/telegram/telegram.go
@@ -328,6 +328,8 @@ func (n *Notifier) RunCleanup(ctx context.Context) {
 
 // ── notify.Notifier implementation ───────────────────────────────────────────
 
+func (n *Notifier) NotificationChannel() string { return "telegram" }
+
 func (n *Notifier) SendApprovalRequest(ctx context.Context, req notify.ApprovalRequest) (string, error) {
 	botToken, chatID, err := n.userConfig(ctx, req.UserID)
 	if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -39,6 +39,7 @@ type Config struct {
 	Telemetry     TelemetryConfig     `yaml:"telemetry"`
 	Daemon        DaemonConfig        `yaml:"daemon"`
 	Push          PushConfig          `yaml:"push"`
+	Notifications NotificationsConfig `yaml:"notifications"`
 	AutoUpdate    AutoUpdateConfig    `yaml:"auto_update"`
 	Redis         RedisConfig         `yaml:"redis"`
 
@@ -72,6 +73,24 @@ type DaemonConfig struct {
 type PushConfig struct {
 	Enabled bool   `yaml:"enabled"`
 	URL     string `yaml:"url"`
+}
+
+// NotificationsConfig holds cross-channel notification behavior.
+type NotificationsConfig struct {
+	Escalation NotificationEscalationConfig `yaml:"escalation"`
+}
+
+// NotificationEscalationConfig controls sequential approval notification
+// fallback. It is opt-in; when disabled the legacy notifier fan-out remains.
+type NotificationEscalationConfig struct {
+	Enabled      bool                         `yaml:"enabled"`
+	DefaultChain []NotificationEscalationStep `yaml:"default_chain"`
+}
+
+// NotificationEscalationStep is one channel in the approval fallback chain.
+type NotificationEscalationStep struct {
+	Channel      string `yaml:"channel"`
+	DelaySeconds int    `yaml:"delay_seconds"`
 }
 
 // AutoUpdateConfig holds settings for automatic binary updates.
@@ -951,6 +970,22 @@ func (c *Config) Validate() error {
 	}
 	if c.Approval.Timeout <= 0 {
 		return fmt.Errorf("approval.timeout must be positive (got %d)", c.Approval.Timeout)
+	}
+	if c.Notifications.Escalation.Enabled {
+		if len(c.Notifications.Escalation.DefaultChain) == 0 {
+			return fmt.Errorf("notifications.escalation.default_chain must not be empty when escalation is enabled")
+		}
+		for i, step := range c.Notifications.Escalation.DefaultChain {
+			channel := strings.ToLower(strings.TrimSpace(step.Channel))
+			switch channel {
+			case "push", "telegram":
+			default:
+				return fmt.Errorf("notifications.escalation.default_chain[%d].channel must be one of push, telegram (got %q)", i, step.Channel)
+			}
+			if step.DelaySeconds < 0 {
+				return fmt.Errorf("notifications.escalation.default_chain[%d].delay_seconds must be non-negative (got %d)", i, step.DelaySeconds)
+			}
+		}
 	}
 	if c.Task.DefaultExpirySeconds <= 0 {
 		return fmt.Errorf("task.default_expiry_seconds must be positive (got %d)", c.Task.DefaultExpirySeconds)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -106,6 +106,70 @@ func TestValidateRequiresBodyTraceDirWhenEnabled(t *testing.T) {
 	}
 }
 
+func TestValidateNotificationEscalationDefaultsDisabled(t *testing.T) {
+	cfg := Default()
+	if cfg.Notifications.Escalation.Enabled {
+		t.Fatal("expected notification escalation disabled by default")
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+}
+
+func TestValidateNotificationEscalationAcceptsPushTelegramChain(t *testing.T) {
+	cfg := Default()
+	cfg.Notifications.Escalation.Enabled = true
+	cfg.Notifications.Escalation.DefaultChain = []NotificationEscalationStep{
+		{Channel: "push", DelaySeconds: 0},
+		{Channel: "telegram", DelaySeconds: 60},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+}
+
+func TestValidateNotificationEscalationRejectsInvalidConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		mut  func(*Config)
+		want string
+	}{
+		{
+			name: "enabled empty chain",
+			mut: func(cfg *Config) {
+				cfg.Notifications.Escalation.Enabled = true
+			},
+			want: "default_chain",
+		},
+		{
+			name: "invalid channel",
+			mut: func(cfg *Config) {
+				cfg.Notifications.Escalation.Enabled = true
+				cfg.Notifications.Escalation.DefaultChain = []NotificationEscalationStep{{Channel: "sms"}}
+			},
+			want: "push, telegram",
+		},
+		{
+			name: "negative delay",
+			mut: func(cfg *Config) {
+				cfg.Notifications.Escalation.Enabled = true
+				cfg.Notifications.Escalation.DefaultChain = []NotificationEscalationStep{{Channel: "push", DelaySeconds: -1}}
+			},
+			want: "non-negative",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Default()
+			tt.mut(cfg)
+			err := cfg.Validate()
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("expected validation error containing %q, got %v", tt.want, err)
+			}
+		})
+	}
+}
+
 // TestInheritLLMDefaults_DoesNotInheritAnthropicEndpointIntoNonAnthropicSubBlock
 // covers two cases where the Anthropic-default endpoint must NOT propagate
 // into a sub-block that runs on a different provider:

--- a/pkg/notify/multi.go
+++ b/pkg/notify/multi.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"strings"
 	"sync"
 )
 
@@ -11,6 +12,7 @@ import (
 // Errors are logged but do not short-circuit delivery to remaining notifiers.
 type MultiNotifier struct {
 	notifiers  []Notifier
+	byChannel  map[string]Notifier
 	logger     *slog.Logger
 	decisionCh chan CallbackDecision
 
@@ -29,11 +31,18 @@ type MultiNotifier struct {
 func NewMultiNotifier(ctx context.Context, logger *slog.Logger, notifiers ...Notifier) *MultiNotifier {
 	m := &MultiNotifier{
 		notifiers:  notifiers,
+		byChannel:  make(map[string]Notifier),
 		logger:     logger,
 		decisionCh: make(chan CallbackDecision, 64),
 	}
 
 	for _, n := range notifiers {
+		if cp, ok := n.(ChannelProvider); ok {
+			channel := strings.ToLower(strings.TrimSpace(cp.NotificationChannel()))
+			if channel != "" {
+				m.byChannel[channel] = n
+			}
+		}
 		if p, ok := n.(TelegramPairer); ok && m.pairer == nil {
 			m.pairer = p
 		}
@@ -91,12 +100,14 @@ func NewMultiNotifier(ctx context.Context, logger *slog.Logger, notifiers ...Not
 
 // Compile-time interface checks.
 var (
-	_ Notifier           = (*MultiNotifier)(nil)
-	_ TelegramPairer     = (*MultiNotifier)(nil)
-	_ PollingDecrementer = (*MultiNotifier)(nil)
-	_ GroupObserver      = (*MultiNotifier)(nil)
-	_ GroupDetector      = (*MultiNotifier)(nil)
-	_ AgentGroupPairer        = (*MultiNotifier)(nil)
+	_ Notifier                 = (*MultiNotifier)(nil)
+	_ ChannelApprovalSender    = (*MultiNotifier)(nil)
+	_ ChannelMessageUpdater    = (*MultiNotifier)(nil)
+	_ TelegramPairer           = (*MultiNotifier)(nil)
+	_ PollingDecrementer       = (*MultiNotifier)(nil)
+	_ GroupObserver            = (*MultiNotifier)(nil)
+	_ GroupDetector            = (*MultiNotifier)(nil)
+	_ AgentGroupPairer         = (*MultiNotifier)(nil)
 	_ GroupMembershipValidator = (*MultiNotifier)(nil)
 )
 
@@ -115,6 +126,14 @@ func (m *MultiNotifier) SendApprovalRequest(ctx context.Context, req ApprovalReq
 		}
 	}
 	return messageID, errors.Join(errs...)
+}
+
+func (m *MultiNotifier) SendApprovalRequestToChannel(ctx context.Context, channel string, req ApprovalRequest) (string, error) {
+	n, ok := m.byChannel[strings.ToLower(strings.TrimSpace(channel))]
+	if !ok {
+		return "", errors.New("notification channel unavailable: " + channel)
+	}
+	return n.SendApprovalRequest(ctx, req)
 }
 
 func (m *MultiNotifier) SendActivationRequest(ctx context.Context, req ActivationRequest) error {
@@ -182,6 +201,14 @@ func (m *MultiNotifier) UpdateMessage(ctx context.Context, userID, messageID, te
 		}
 	}
 	return errors.Join(errs...)
+}
+
+func (m *MultiNotifier) UpdateMessageForChannel(ctx context.Context, channel, userID, messageID, text string) error {
+	n, ok := m.byChannel[strings.ToLower(strings.TrimSpace(channel))]
+	if !ok {
+		return errors.New("notification channel unavailable: " + channel)
+	}
+	return n.UpdateMessage(ctx, userID, messageID, text)
 }
 
 func (m *MultiNotifier) SendTestMessage(ctx context.Context, userID string) error {

--- a/pkg/notify/multi_test.go
+++ b/pkg/notify/multi_test.go
@@ -1,0 +1,109 @@
+package notify
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+)
+
+type recordingNotifier struct {
+	channel       string
+	approvalIDs   []string
+	updatedIDs    []string
+	activationHit int
+}
+
+func (n *recordingNotifier) NotificationChannel() string { return n.channel }
+
+func (n *recordingNotifier) SendApprovalRequest(ctx context.Context, req ApprovalRequest) (string, error) {
+	n.approvalIDs = append(n.approvalIDs, req.RequestID)
+	return n.channel + "-message", nil
+}
+
+func (n *recordingNotifier) SendActivationRequest(ctx context.Context, req ActivationRequest) error {
+	n.activationHit++
+	return nil
+}
+
+func (n *recordingNotifier) SendTaskApprovalRequest(ctx context.Context, req TaskApprovalRequest) (string, error) {
+	return "", nil
+}
+
+func (n *recordingNotifier) SendScopeExpansionRequest(ctx context.Context, req ScopeExpansionRequest) (string, error) {
+	return "", nil
+}
+
+func (n *recordingNotifier) UpdateMessage(ctx context.Context, userID, messageID, text string) error {
+	n.updatedIDs = append(n.updatedIDs, messageID)
+	return nil
+}
+
+func (n *recordingNotifier) SendTestMessage(ctx context.Context, userID string) error { return nil }
+
+func (n *recordingNotifier) SendConnectionRequest(ctx context.Context, req ConnectionRequest) (string, error) {
+	return "", nil
+}
+
+func (n *recordingNotifier) SendAlert(ctx context.Context, userID, text string) error { return nil }
+
+func TestMultiNotifierSendApprovalRequestToChannel(t *testing.T) {
+	ctx := context.Background()
+	push := &recordingNotifier{channel: "push"}
+	telegram := &recordingNotifier{channel: "telegram"}
+	m := NewMultiNotifier(ctx, slog.New(slog.NewTextHandler(io.Discard, nil)), push, telegram)
+
+	msgID, err := m.SendApprovalRequestToChannel(ctx, "telegram", ApprovalRequest{RequestID: "req-1"})
+	if err != nil {
+		t.Fatalf("SendApprovalRequestToChannel: %v", err)
+	}
+	if msgID != "telegram-message" {
+		t.Fatalf("messageID=%q, want telegram-message", msgID)
+	}
+	if len(push.approvalIDs) != 0 {
+		t.Fatalf("push approvals=%d, want 0", len(push.approvalIDs))
+	}
+	if len(telegram.approvalIDs) != 1 {
+		t.Fatalf("telegram approvals=%d, want 1", len(telegram.approvalIDs))
+	}
+}
+
+func TestMultiNotifierSendApprovalRequestStillFansOut(t *testing.T) {
+	ctx := context.Background()
+	push := &recordingNotifier{channel: "push"}
+	telegram := &recordingNotifier{channel: "telegram"}
+	m := NewMultiNotifier(ctx, slog.New(slog.NewTextHandler(io.Discard, nil)), push, telegram)
+
+	if _, err := m.SendApprovalRequest(ctx, ApprovalRequest{RequestID: "req-1"}); err != nil {
+		t.Fatalf("SendApprovalRequest: %v", err)
+	}
+	if len(push.approvalIDs) != 1 || len(telegram.approvalIDs) != 1 {
+		t.Fatalf("fanout approvals push=%d telegram=%d, want 1/1", len(push.approvalIDs), len(telegram.approvalIDs))
+	}
+}
+
+func TestMultiNotifierUnknownChannelReturnsControlledError(t *testing.T) {
+	ctx := context.Background()
+	m := NewMultiNotifier(ctx, slog.New(slog.NewTextHandler(io.Discard, nil)), &recordingNotifier{channel: "push"})
+
+	if _, err := m.SendApprovalRequestToChannel(ctx, "sms", ApprovalRequest{RequestID: "req-1"}); err == nil {
+		t.Fatal("expected unavailable channel error")
+	}
+}
+
+func TestMultiNotifierUpdateMessageForChannel(t *testing.T) {
+	ctx := context.Background()
+	push := &recordingNotifier{channel: "push"}
+	telegram := &recordingNotifier{channel: "telegram"}
+	m := NewMultiNotifier(ctx, slog.New(slog.NewTextHandler(io.Discard, nil)), push, telegram)
+
+	if err := m.UpdateMessageForChannel(ctx, "telegram", "user-1", "msg-1", "done"); err != nil {
+		t.Fatalf("UpdateMessageForChannel: %v", err)
+	}
+	if len(push.updatedIDs) != 0 {
+		t.Fatalf("push updates=%d, want 0", len(push.updatedIDs))
+	}
+	if len(telegram.updatedIDs) != 1 || telegram.updatedIDs[0] != "msg-1" {
+		t.Fatalf("telegram updates=%v, want [msg-1]", telegram.updatedIDs)
+	}
+}

--- a/pkg/notify/notify.go
+++ b/pkg/notify/notify.go
@@ -20,6 +20,23 @@ type Notifier interface {
 	SendAlert(ctx context.Context, userID, text string) error
 }
 
+// ChannelProvider identifies which configured notification channel a notifier
+// handles. Concrete notifiers that participate in escalation implement this.
+type ChannelProvider interface {
+	NotificationChannel() string
+}
+
+// ChannelApprovalSender can dispatch an approval prompt to one specific
+// notification channel without fanning out to every configured notifier.
+type ChannelApprovalSender interface {
+	SendApprovalRequestToChannel(ctx context.Context, channel string, req ApprovalRequest) (messageID string, err error)
+}
+
+// ChannelMessageUpdater can update or recall a message on one specific channel.
+type ChannelMessageUpdater interface {
+	UpdateMessageForChannel(ctx context.Context, channel, userID, messageID, text string) error
+}
+
 // ApprovalRequest carries the data needed to ask the user to approve or deny a gateway request.
 type ApprovalRequest struct {
 	PendingID string

--- a/pkg/store/postgres/migrations/051_approval_escalations.sql
+++ b/pkg/store/postgres/migrations/051_approval_escalations.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS approval_escalations (
+    id                 TEXT PRIMARY KEY,
+    approval_record_id TEXT NOT NULL REFERENCES approval_records(id) ON DELETE CASCADE,
+    user_id            TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    target_type        TEXT NOT NULL,
+    target_id          TEXT NOT NULL,
+    approval_request   JSONB NOT NULL,
+    escalation_chain   JSONB NOT NULL,
+    current_step       INTEGER NOT NULL DEFAULT 0,
+    next_escalate_at   TIMESTAMPTZ NOT NULL,
+    status             TEXT NOT NULL DEFAULT 'active',
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_approval_escalations_due
+    ON approval_escalations(status, next_escalate_at);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_approval_escalations_target
+    ON approval_escalations(target_type, target_id);

--- a/pkg/store/postgres/store.go
+++ b/pkg/store/postgres/store.go
@@ -1561,6 +1561,136 @@ func (s *Store) GetNotificationMessage(ctx context.Context, targetType, targetID
 
 // ── Chain Facts ───────────────────────────────────────────────────────────────
 
+func (s *Store) ListNotificationMessages(ctx context.Context, targetType, targetID string) ([]*store.NotificationMessage, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT target_type, target_id, channel, message_id, created_at
+		FROM notification_messages
+		WHERE target_type = $1 AND target_id = $2
+		ORDER BY created_at ASC
+	`, targetType, targetID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []*store.NotificationMessage
+	for rows.Next() {
+		m := &store.NotificationMessage{}
+		if err := rows.Scan(&m.TargetType, &m.TargetID, &m.Channel, &m.MessageID, &m.CreatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, m)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) CreateApprovalEscalation(ctx context.Context, e *store.ApprovalEscalation) error {
+	if e.ID == "" {
+		e.ID = uuid.New().String()
+	}
+	if e.Status == "" {
+		e.Status = "active"
+	}
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO approval_escalations (
+			id, approval_record_id, user_id, target_type, target_id, approval_request,
+			escalation_chain, current_step, next_escalate_at, status
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+		ON CONFLICT (target_type, target_id) DO UPDATE SET
+			approval_record_id = EXCLUDED.approval_record_id,
+			user_id = EXCLUDED.user_id,
+			approval_request = EXCLUDED.approval_request,
+			escalation_chain = EXCLUDED.escalation_chain,
+			current_step = EXCLUDED.current_step,
+			next_escalate_at = EXCLUDED.next_escalate_at,
+			status = EXCLUDED.status,
+			updated_at = NOW()
+	`, e.ID, e.ApprovalRecordID, e.UserID, e.TargetType, e.TargetID, e.ApprovalRequest,
+		e.EscalationChain, e.CurrentStep, e.NextEscalateAt.UTC(), e.Status)
+	return err
+}
+
+func (s *Store) ListDueApprovalEscalations(ctx context.Context, now time.Time, limit int) ([]*store.ApprovalEscalation, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	rows, err := s.pool.Query(ctx, `
+		SELECT id, approval_record_id, user_id, target_type, target_id, approval_request,
+		       escalation_chain, current_step, next_escalate_at, status, created_at, updated_at
+		FROM approval_escalations
+		WHERE status = 'active' AND next_escalate_at <= $1
+		ORDER BY next_escalate_at ASC
+		LIMIT $2
+	`, now.UTC(), limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []*store.ApprovalEscalation
+	for rows.Next() {
+		e := &store.ApprovalEscalation{}
+		var approvalRequest, chain []byte
+		if err := rows.Scan(&e.ID, &e.ApprovalRecordID, &e.UserID, &e.TargetType, &e.TargetID,
+			&approvalRequest, &chain, &e.CurrentStep, &e.NextEscalateAt, &e.Status, &e.CreatedAt, &e.UpdatedAt); err != nil {
+			return nil, err
+		}
+		e.ApprovalRequest = json.RawMessage(approvalRequest)
+		e.EscalationChain = json.RawMessage(chain)
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) ClaimApprovalEscalationStep(ctx context.Context, id string, currentStep int, now time.Time) (bool, error) {
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE approval_escalations
+		SET status = 'dispatching', updated_at = NOW()
+		WHERE id = $1 AND status = 'active' AND current_step = $2 AND next_escalate_at <= $3
+	`, id, currentStep, now.UTC())
+	if err != nil {
+		return false, err
+	}
+	return tag.RowsAffected() == 1, nil
+}
+
+func (s *Store) CompleteApprovalEscalationStep(ctx context.Context, id string, claimedStep, nextStep int, nextAt time.Time) (bool, error) {
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE approval_escalations
+		SET status = 'active', current_step = $1, next_escalate_at = $2, updated_at = NOW()
+		WHERE id = $3 AND status = 'dispatching' AND current_step = $4
+	`, nextStep, nextAt.UTC(), id, claimedStep)
+	if err != nil {
+		return false, err
+	}
+	return tag.RowsAffected() == 1, nil
+}
+
+func (s *Store) ReleaseApprovalEscalationStep(ctx context.Context, id string, claimedStep int, retryAt time.Time) error {
+	_, err := s.pool.Exec(ctx, `
+		UPDATE approval_escalations
+		SET status = 'active', next_escalate_at = $1, updated_at = NOW()
+		WHERE id = $2 AND status = 'dispatching' AND current_step = $3
+	`, retryAt.UTC(), id, claimedStep)
+	return err
+}
+
+func (s *Store) ResolveApprovalEscalation(ctx context.Context, targetType, targetID string) error {
+	_, err := s.pool.Exec(ctx, `
+		UPDATE approval_escalations
+		SET status = 'resolved', updated_at = NOW()
+		WHERE target_type = $1 AND target_id = $2 AND status IN ('active', 'dispatching', 'timed_out')
+	`, targetType, targetID)
+	return err
+}
+
+func (s *Store) TimeoutApprovalEscalation(ctx context.Context, id string, claimedStep int) error {
+	_, err := s.pool.Exec(ctx, `
+		UPDATE approval_escalations
+		SET status = 'timed_out', updated_at = NOW()
+		WHERE id = $1 AND status = 'dispatching' AND current_step = $2
+	`, id, claimedStep)
+	return err
+}
+
 func (s *Store) SaveChainFacts(ctx context.Context, facts []*store.ChainFact) error {
 	for _, f := range facts {
 		if f.ID == "" {

--- a/pkg/store/sqlite/approval_escalation_test.go
+++ b/pkg/store/sqlite/approval_escalation_test.go
@@ -1,0 +1,192 @@
+package sqlite
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+func TestApprovalEscalationLifecycle(t *testing.T) {
+	ctx := context.Background()
+	st, userID, approvalID := newEscalationTestStore(t, ctx)
+	now := time.Date(2026, 5, 23, 10, 0, 0, 0, time.UTC)
+	req := json.RawMessage(`{"request_id":"req-1","user_id":"user-1"}`)
+	chain := json.RawMessage(`[{"channel":"push","delay_seconds":0},{"channel":"telegram","delay_seconds":60}]`)
+
+	if err := st.CreateApprovalEscalation(ctx, &store.ApprovalEscalation{
+		ApprovalRecordID: approvalID,
+		UserID:           userID,
+		TargetType:       "approval",
+		TargetID:         "req-1",
+		ApprovalRequest:  req,
+		EscalationChain:  chain,
+		CurrentStep:      0,
+		NextEscalateAt:   now,
+		Status:           "active",
+	}); err != nil {
+		t.Fatalf("CreateApprovalEscalation: %v", err)
+	}
+
+	due, err := st.ListDueApprovalEscalations(ctx, now, 10)
+	if err != nil {
+		t.Fatalf("ListDueApprovalEscalations: %v", err)
+	}
+	if len(due) != 1 {
+		t.Fatalf("due count=%d, want 1", len(due))
+	}
+	claimed, err := st.ClaimApprovalEscalationStep(ctx, due[0].ID, 0, now)
+	if err != nil {
+		t.Fatalf("ClaimApprovalEscalationStep: %v", err)
+	}
+	if !claimed {
+		t.Fatal("expected claim to succeed")
+	}
+	if claimedAgain, err := st.ClaimApprovalEscalationStep(ctx, due[0].ID, 0, now); err != nil {
+		t.Fatalf("second ClaimApprovalEscalationStep: %v", err)
+	} else if claimedAgain {
+		t.Fatal("expected second claim to fail")
+	}
+
+	nextAt := now.Add(time.Minute)
+	completed, err := st.CompleteApprovalEscalationStep(ctx, due[0].ID, 0, 1, nextAt)
+	if err != nil {
+		t.Fatalf("CompleteApprovalEscalationStep: %v", err)
+	}
+	if !completed {
+		t.Fatal("expected complete to succeed")
+	}
+	notDue, err := st.ListDueApprovalEscalations(ctx, now.Add(30*time.Second), 10)
+	if err != nil {
+		t.Fatalf("ListDueApprovalEscalations not due: %v", err)
+	}
+	if len(notDue) != 0 {
+		t.Fatalf("not due count=%d, want 0", len(notDue))
+	}
+
+	due, err = st.ListDueApprovalEscalations(ctx, nextAt, 10)
+	if err != nil {
+		t.Fatalf("ListDueApprovalEscalations second: %v", err)
+	}
+	if len(due) != 1 || due[0].CurrentStep != 1 {
+		t.Fatalf("due second=%+v, want step 1", due)
+	}
+	if err := st.ResolveApprovalEscalation(ctx, "approval", "req-1"); err != nil {
+		t.Fatalf("ResolveApprovalEscalation: %v", err)
+	}
+	due, err = st.ListDueApprovalEscalations(ctx, nextAt, 10)
+	if err != nil {
+		t.Fatalf("ListDueApprovalEscalations after resolve: %v", err)
+	}
+	if len(due) != 0 {
+		t.Fatalf("resolved due count=%d, want 0", len(due))
+	}
+}
+
+func TestApprovalEscalationConcurrentClaimOnlyWinsOnce(t *testing.T) {
+	ctx := context.Background()
+	st, userID, approvalID := newEscalationTestStore(t, ctx)
+	now := time.Date(2026, 5, 23, 10, 0, 0, 0, time.UTC)
+	if err := st.CreateApprovalEscalation(ctx, &store.ApprovalEscalation{
+		ApprovalRecordID: approvalID,
+		UserID:           userID,
+		TargetType:       "approval",
+		TargetID:         "req-1",
+		ApprovalRequest:  json.RawMessage(`{"request_id":"req-1"}`),
+		EscalationChain:  json.RawMessage(`[{"channel":"push","delay_seconds":0}]`),
+		CurrentStep:      0,
+		NextEscalateAt:   now,
+		Status:           "active",
+	}); err != nil {
+		t.Fatalf("CreateApprovalEscalation: %v", err)
+	}
+	due, err := st.ListDueApprovalEscalations(ctx, now, 1)
+	if err != nil {
+		t.Fatalf("ListDueApprovalEscalations: %v", err)
+	}
+	if len(due) != 1 {
+		t.Fatalf("due count=%d, want 1", len(due))
+	}
+
+	var wg sync.WaitGroup
+	results := make(chan bool, 2)
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			claimed, err := st.ClaimApprovalEscalationStep(ctx, due[0].ID, 0, now)
+			if err != nil {
+				t.Errorf("ClaimApprovalEscalationStep: %v", err)
+				return
+			}
+			results <- claimed
+		}()
+	}
+	wg.Wait()
+	close(results)
+	var wins int
+	for claimed := range results {
+		if claimed {
+			wins++
+		}
+	}
+	if wins != 1 {
+		t.Fatalf("claim wins=%d, want 1", wins)
+	}
+}
+
+func TestApprovalEscalationNotificationMessagesListAllChannels(t *testing.T) {
+	ctx := context.Background()
+	st, _, _ := newEscalationTestStore(t, ctx)
+	if err := st.SaveNotificationMessage(ctx, "approval", "req-1", "push", "push-msg"); err != nil {
+		t.Fatalf("SaveNotificationMessage push: %v", err)
+	}
+	if err := st.SaveNotificationMessage(ctx, "approval", "req-1", "telegram", "telegram-msg"); err != nil {
+		t.Fatalf("SaveNotificationMessage telegram: %v", err)
+	}
+	messages, err := st.ListNotificationMessages(ctx, "approval", "req-1")
+	if err != nil {
+		t.Fatalf("ListNotificationMessages: %v", err)
+	}
+	if len(messages) != 2 {
+		t.Fatalf("message count=%d, want 2", len(messages))
+	}
+	got := map[string]string{}
+	for _, msg := range messages {
+		got[msg.Channel] = msg.MessageID
+	}
+	if got["push"] != "push-msg" || got["telegram"] != "telegram-msg" {
+		t.Fatalf("messages=%v, want push/telegram IDs", got)
+	}
+}
+
+func newEscalationTestStore(t *testing.T, ctx context.Context) (*Store, string, string) {
+	t.Helper()
+	db, err := New(ctx, filepath.Join(t.TempDir(), "clawvisor.db"))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	st := NewStore(db)
+	user, err := st.CreateUser(ctx, "escalation@example.com", "hash")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	approval := &store.ApprovalRecord{
+		Kind:                "request_once",
+		UserID:              user.ID,
+		Status:              "pending",
+		Surface:             "dashboard",
+		SummaryJSON:         json.RawMessage(`{"summary":"request"}`),
+		PayloadJSON:         json.RawMessage(`{"request_id":"req-1"}`),
+		ResolutionTransport: "execute_pending_request",
+	}
+	if err := st.CreateApprovalRecord(ctx, approval); err != nil {
+		t.Fatalf("CreateApprovalRecord: %v", err)
+	}
+	return st, user.ID, approval.ID
+}

--- a/pkg/store/sqlite/migrations/051_approval_escalations.sql
+++ b/pkg/store/sqlite/migrations/051_approval_escalations.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS approval_escalations (
+    id                 TEXT PRIMARY KEY,
+    approval_record_id TEXT NOT NULL,
+    user_id            TEXT NOT NULL,
+    target_type        TEXT NOT NULL,
+    target_id          TEXT NOT NULL,
+    approval_request   TEXT NOT NULL,
+    escalation_chain   TEXT NOT NULL,
+    current_step       INTEGER NOT NULL DEFAULT 0,
+    next_escalate_at   TEXT NOT NULL,
+    status             TEXT NOT NULL DEFAULT 'active',
+    created_at         TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at         TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (approval_record_id) REFERENCES approval_records(id) ON DELETE CASCADE,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_approval_escalations_due
+    ON approval_escalations(status, next_escalate_at);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_approval_escalations_target
+    ON approval_escalations(target_type, target_id);

--- a/pkg/store/sqlite/store.go
+++ b/pkg/store/sqlite/store.go
@@ -3159,6 +3159,147 @@ func (s *Store) GetNotificationMessage(ctx context.Context, targetType, targetID
 
 // ── OAuth ────────────────────────────────────────────────────────────────────
 
+func (s *Store) ListNotificationMessages(ctx context.Context, targetType, targetID string) ([]*store.NotificationMessage, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT target_type, target_id, channel, message_id, created_at
+		FROM notification_messages
+		WHERE target_type = ? AND target_id = ?
+		ORDER BY created_at ASC
+	`, targetType, targetID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []*store.NotificationMessage
+	for rows.Next() {
+		m := &store.NotificationMessage{}
+		var createdAt string
+		if err := rows.Scan(&m.TargetType, &m.TargetID, &m.Channel, &m.MessageID, &createdAt); err != nil {
+			return nil, err
+		}
+		m.CreatedAt = parseTime(createdAt)
+		out = append(out, m)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) CreateApprovalEscalation(ctx context.Context, e *store.ApprovalEscalation) error {
+	if e.ID == "" {
+		e.ID = uuid.New().String()
+	}
+	if e.Status == "" {
+		e.Status = "active"
+	}
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO approval_escalations (
+			id, approval_record_id, user_id, target_type, target_id, approval_request,
+			escalation_chain, current_step, next_escalate_at, status
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT (target_type, target_id) DO UPDATE SET
+			approval_record_id = excluded.approval_record_id,
+			user_id = excluded.user_id,
+			approval_request = excluded.approval_request,
+			escalation_chain = excluded.escalation_chain,
+			current_step = excluded.current_step,
+			next_escalate_at = excluded.next_escalate_at,
+			status = excluded.status,
+			updated_at = CURRENT_TIMESTAMP
+	`, e.ID, e.ApprovalRecordID, e.UserID, e.TargetType, e.TargetID, string(e.ApprovalRequest),
+		string(e.EscalationChain), e.CurrentStep, e.NextEscalateAt.UTC().Format(time.RFC3339), e.Status)
+	return err
+}
+
+func (s *Store) ListDueApprovalEscalations(ctx context.Context, now time.Time, limit int) ([]*store.ApprovalEscalation, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, approval_record_id, user_id, target_type, target_id, approval_request,
+		       escalation_chain, current_step, next_escalate_at, status, created_at, updated_at
+		FROM approval_escalations
+		WHERE status = 'active' AND next_escalate_at <= ?
+		ORDER BY next_escalate_at ASC
+		LIMIT ?
+	`, now.UTC().Format(time.RFC3339), limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanSQLiteApprovalEscalations(rows)
+}
+
+func (s *Store) ClaimApprovalEscalationStep(ctx context.Context, id string, currentStep int, now time.Time) (bool, error) {
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE approval_escalations
+		SET status = 'dispatching', updated_at = CURRENT_TIMESTAMP
+		WHERE id = ? AND status = 'active' AND current_step = ? AND next_escalate_at <= ?
+	`, id, currentStep, now.UTC().Format(time.RFC3339))
+	if err != nil {
+		return false, err
+	}
+	n, err := res.RowsAffected()
+	return n == 1, err
+}
+
+func (s *Store) CompleteApprovalEscalationStep(ctx context.Context, id string, claimedStep, nextStep int, nextAt time.Time) (bool, error) {
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE approval_escalations
+		SET status = 'active', current_step = ?, next_escalate_at = ?, updated_at = CURRENT_TIMESTAMP
+		WHERE id = ? AND status = 'dispatching' AND current_step = ?
+	`, nextStep, nextAt.UTC().Format(time.RFC3339), id, claimedStep)
+	if err != nil {
+		return false, err
+	}
+	n, err := res.RowsAffected()
+	return n == 1, err
+}
+
+func (s *Store) ReleaseApprovalEscalationStep(ctx context.Context, id string, claimedStep int, retryAt time.Time) error {
+	_, err := s.db.ExecContext(ctx, `
+		UPDATE approval_escalations
+		SET status = 'active', next_escalate_at = ?, updated_at = CURRENT_TIMESTAMP
+		WHERE id = ? AND status = 'dispatching' AND current_step = ?
+	`, retryAt.UTC().Format(time.RFC3339), id, claimedStep)
+	return err
+}
+
+func (s *Store) ResolveApprovalEscalation(ctx context.Context, targetType, targetID string) error {
+	_, err := s.db.ExecContext(ctx, `
+		UPDATE approval_escalations
+		SET status = 'resolved', updated_at = CURRENT_TIMESTAMP
+		WHERE target_type = ? AND target_id = ? AND status IN ('active', 'dispatching', 'timed_out')
+	`, targetType, targetID)
+	return err
+}
+
+func (s *Store) TimeoutApprovalEscalation(ctx context.Context, id string, claimedStep int) error {
+	_, err := s.db.ExecContext(ctx, `
+		UPDATE approval_escalations
+		SET status = 'timed_out', updated_at = CURRENT_TIMESTAMP
+		WHERE id = ? AND status = 'dispatching' AND current_step = ?
+	`, id, claimedStep)
+	return err
+}
+
+func scanSQLiteApprovalEscalations(rows *sql.Rows) ([]*store.ApprovalEscalation, error) {
+	var out []*store.ApprovalEscalation
+	for rows.Next() {
+		e := &store.ApprovalEscalation{}
+		var approvalRequest, chain, nextAt, createdAt, updatedAt string
+		if err := rows.Scan(&e.ID, &e.ApprovalRecordID, &e.UserID, &e.TargetType, &e.TargetID,
+			&approvalRequest, &chain, &e.CurrentStep, &nextAt, &e.Status, &createdAt, &updatedAt); err != nil {
+			return nil, err
+		}
+		e.ApprovalRequest = json.RawMessage(approvalRequest)
+		e.EscalationChain = json.RawMessage(chain)
+		e.NextEscalateAt = parseTime(nextAt)
+		e.CreatedAt = parseTime(createdAt)
+		e.UpdatedAt = parseTime(updatedAt)
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}
+
 func (s *Store) CreateOAuthClient(ctx context.Context, client *store.OAuthClient) error {
 	urisJSON, _ := json.Marshal(client.RedirectURIs)
 	_, err := s.db.ExecContext(ctx,

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -304,6 +304,16 @@ type Store interface {
 	// Notification messages (cross-channel message tracking)
 	SaveNotificationMessage(ctx context.Context, targetType, targetID, channel, messageID string) error
 	GetNotificationMessage(ctx context.Context, targetType, targetID, channel string) (string, error)
+	ListNotificationMessages(ctx context.Context, targetType, targetID string) ([]*NotificationMessage, error)
+
+	// Approval notification escalations
+	CreateApprovalEscalation(ctx context.Context, e *ApprovalEscalation) error
+	ListDueApprovalEscalations(ctx context.Context, now time.Time, limit int) ([]*ApprovalEscalation, error)
+	ClaimApprovalEscalationStep(ctx context.Context, id string, currentStep int, now time.Time) (bool, error)
+	CompleteApprovalEscalationStep(ctx context.Context, id string, claimedStep, nextStep int, nextAt time.Time) (bool, error)
+	ReleaseApprovalEscalationStep(ctx context.Context, id string, claimedStep int, retryAt time.Time) error
+	ResolveApprovalEscalation(ctx context.Context, targetType, targetID string) error
+	TimeoutApprovalEscalation(ctx context.Context, id string, claimedStep int) error
 
 	// Chain facts (intent verification context chaining)
 	SaveChainFacts(ctx context.Context, facts []*ChainFact) error
@@ -948,6 +958,33 @@ type GeneratedAdapter struct {
 	YAMLContent string    `json:"yaml_content"`
 	CreatedAt   time.Time `json:"created_at"`
 	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+// NotificationMessage stores a per-channel message coordinate for later
+// cleanup/update when an approval resolves on another channel.
+type NotificationMessage struct {
+	TargetType string    `json:"target_type"`
+	TargetID   string    `json:"target_id"`
+	Channel    string    `json:"channel"`
+	MessageID  string    `json:"message_id"`
+	CreatedAt  time.Time `json:"created_at"`
+}
+
+// ApprovalEscalation tracks one sequential notification fallback flow for a
+// pending approval.
+type ApprovalEscalation struct {
+	ID               string          `json:"id"`
+	ApprovalRecordID string          `json:"approval_record_id"`
+	UserID           string          `json:"user_id"`
+	TargetType       string          `json:"target_type"`
+	TargetID         string          `json:"target_id"`
+	ApprovalRequest  json.RawMessage `json:"approval_request"`
+	EscalationChain  json.RawMessage `json:"escalation_chain"`
+	CurrentStep      int             `json:"current_step"`
+	NextEscalateAt   time.Time       `json:"next_escalate_at"`
+	Status           string          `json:"status"`
+	CreatedAt        time.Time       `json:"created_at"`
+	UpdatedAt        time.Time       `json:"updated_at"`
 }
 
 // TelegramGroup represents a Telegram group configured for observation.


### PR DESCRIPTION
## Summary

Implements an opt-in notification escalation and fallback engine for request approvals.

When enabled, Clawvisor can send approval prompts through a configured sequence of notification channels instead of immediately fanning out to every notifier. The v1 implementation supports the concrete channels currently present in the repo: `push` and `telegram`.

Default behavior remains unchanged because escalation is disabled by default.

## What Changed

- Added config support for `notifications.escalation.enabled` and `notifications.escalation.default_chain`.
- Added validation for escalation config: disabled by default, enabled chains must not be empty, supported channels are `push` and `telegram`, and delays must be non-negative.
- Added channel-aware notification dispatch with `MultiNotifier.SendApprovalRequestToChannel` and `MultiNotifier.UpdateMessageForChannel`.
- Preserved legacy `SendApprovalRequest` fan-out behavior when escalation is disabled.
- Added channel identity for existing concrete notifiers: push reports `push`, telegram reports `telegram`.
- Added persistent escalation state with SQLite and Postgres migration `051_approval_escalations.sql`.
- Added store methods for creating, listing due, claiming, advancing, resolving, timing out escalation sessions, and listing notification messages.
- Added `internal/notify/escalation` worker to poll due sessions, atomically claim each step, dispatch the next configured channel, store per-channel message coordinates, and advance or timeout exhausted sessions.
- Wired request approval creation so `GatewayHandler.routeToApproval` starts escalation when enabled.
- Wired approval resolution, deny, execute, and expiry paths to resolve escalation state and best-effort update every sent channel.
- Fixed push approval target IDs so push request approval payloads use request ID as `target_id`.
- Added `task_id` preservation in device action callbacks for sibling approval disambiguation.
- Updated `config.example.yaml` with escalation disabled by default and an example `push -> telegram` chain.

## Scope

This PR intentionally scopes v1 escalation to request approvals only.

Not included in this PR:
- task approval escalation
- scope expansion escalation
- connection request escalation
- SMS or Slack escalation channels

Those can be added later once concrete notifier implementations exist.

## Behavior

With escalation disabled, existing notifier behavior remains unchanged.

With escalation enabled, the flow is:

1. A request approval is created.
2. The first configured channel sends when due.
3. If the approval remains unresolved, the worker advances to the next configured channel.
4. Approval, deny, execute, or expiry resolves the escalation.
5. Sent notification messages are updated or cleaned up best-effort.
6. Cleanup failures are logged but do not fail approval resolution.

Example chain:

`notifications.escalation.enabled = true`

`default_chain = push immediately, telegram after 60 seconds`

Expected result:

- Push sends immediately.
- Telegram sends after 60 seconds if the request is still unresolved.
- Any decision resolves the escalation and prevents later dispatch.

## Validation

Passed:

- `go test ./pkg/config ./pkg/notify ./internal/notify/... ./pkg/store/sqlite ./pkg/store/postgres`
- `go test ./internal/api/handlers`
- `go test ./internal/api`
- `go vet ./pkg/config ./pkg/notify ./internal/notify/... ./pkg/store/sqlite ./pkg/store/postgres ./internal/api/handlers ./internal/api`
- `git diff --cached --check`

Also attempted full repository validation on Windows:

- `go test ./...`

That still fails on pre-existing unrelated Windows compatibility issues, including:

- `undefined: syscall.Kill`
- `unknown field Setpgid in syscall.SysProcAttr`
- `undefined: syscall.Getpgid`
- file permission assertions expecting `0600` on Windows
- iMessage helper macOS `.app` path expectation

Those failures are unrelated to this feature and were intentionally kept out of this PR.

## Notes

This is opened as a draft because the broader notification roadmap may need eric's input before finalizing the public shape of escalation behavior.