### PR TITLE
fix(llmproxy): scope coalesced approval hold to conversation

### DIFF
--- a/internal/runtime/llmproxy/postprocess.go
+++ b/internal/runtime/llmproxy/postprocess.go
@@ -818,6 +818,7 @@ func Postprocess(req *http.Request, body []byte, contentType string, cfg Postpro
 		coalesced.UserID = cfg.AgentUserID
 		coalesced.AgentID = cfg.AgentID
 		coalesced.Provider = rewriter.Name()
+		coalesced.ConversationID = cfg.ConversationID
 		held, holdErr := originalPendingApprovals.Hold(req.Context(), coalesced)
 		if holdErr == nil {
 			// Coalesced hold committed. The buffered per-tool holds


### PR DESCRIPTION


## Summary

Fixes a cross-conversation approval spoofing regression introduced in #439 
No behaviour change for single-tool approval holds or for deployments where all agents use different tokens.

---

## Background

### Conversation scoping for pending approvals

Clawvisor supports multiple simultaneous conversations sharing a single agent token Conductor workspaces, sub-agents, multiple Claude Code sessions on the same install. To prevent these conversations from clobbering each other's pending approval holds, `PendingLiteApproval` carries a `ConversationID` field:
```go
// ConversationID partitions the hold to a single conversation when
// multiple conversations share a Clawvisor token... A bare "y" reply
// in conversation B can no longer release a hold from conversation A.
// Empty falls back to the pre-conversation-scoping key shape
// (user + agent + provider), preserving behavior for older clients.
ConversationID string
```

The field was introduced specifically so that typing `y` in one chat window cannot accidentally release a pending tool call in another.

### What #439 introduced

PR #439 added the coalesce path: when a model turn contains multiple `tool_use` blocks and at least one requires approval, all of them are bundled into a single `PendingLiteApproval` hold so the user sees one combined prompt and one `y/n` releases or denies the entire turn.

The hold is built here (`postprocess.go`):

```go
coalesced := coalesceFromCaptures(captures)
coalesced.UserID   = cfg.AgentUserID
coalesced.AgentID  = cfg.AgentID
coalesced.Provider = rewriter.Name()
// ← ConversationID never set; stays ""
held, holdErr := originalPendingApprovals.Hold(req.Context(), coalesced)
```

`coalesceFromCaptures()` does not touch `ConversationID` either. The field defaults to `""`, which - per the documented fallback - collapses the hold into the **global bucket** for `(userID, agentID, provider)`, making it visible to every conversation sharing that token.

The non-coalesced path (single-tool holds, unchanged since before #439) correctly sets the field:

```go
held, err := cfg.PendingApprovals.Hold(req.Context(), PendingLiteApproval{
    UserID:         cfg.AgentUserID,
    AgentID:        cfg.AgentID,
    Provider:       rewriter.Name(),
    ConversationID: cfg.ConversationID,   // present
    ToolUse:        tu,
    ...
})
```

---


### What can go wrong

```
Conversation A  ->  multi-tool turn   ->  coalesced hold stored with ConversationID=""
Conversation B  ->  user types "y"  ->  LIFO lookup finds conversation A's hold first  ->  conversation A's tools execute
```
### Scope of regression

- Only affects the **coalesce path** - turns with two or more `tool_use` blocks where at least one needs approval. Single-tool holds are unaffected.
- Requires multiple concurrent conversations on the same token. A single Claude Code session with one active conversation is not affected.

---

## Fix

```diff
  coalesced := coalesceFromCaptures(captures)
  coalesced.UserID   = cfg.AgentUserID
  coalesced.AgentID  = cfg.AgentID
  coalesced.Provider = rewriter.Name()
+ coalesced.ConversationID = cfg.ConversationID
  held, holdErr := originalPendingApprovals.Hold(req.Context(), coalesced)
```

Mirrors exactly what every other hold-creation site in the file already does.


---

## Files changed

| File | Change |
|------|--------|
| `internal/runtime/llmproxy/postprocess.go` | Add `coalesced.ConversationID = cfg.ConversationID` on the coalesce path |
