### PR TITLE
feat(llmproxy): inject Clawvisor routing notice on first assistant turn

### DIFF
--- a/internal/api/handlers/llm_endpoint.go
+++ b/internal/api/handlers/llm_endpoint.go
@@ -565,6 +565,17 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	// Snapshot the pre-strip body for the first-turn routing-notice
+	// detector below. StripSyntheticApprovalHistory removes assistant
+	// approval-prompt turns and their bare "approve" replies so the
+	// upstream model doesn't see synthesized scaffolding it could
+	// hallucinate; from the user's POV those turns still happened.
+	// Detecting on the post-strip body would misclassify
+	// "first user prompt → tool_use → approval → continuation" as a
+	// fresh turn-1 request and re-prepend the routing notice. The
+	// pre-strip body reflects what the harness actually shipped, which
+	// is the right input for the first-turn question.
+	bodyForFirstTurnDetect := body
 	if stripped, stripErr := llmproxy.StripSyntheticApprovalHistory(llmproxy.SyntheticApprovalHistoryStripRequest{
 		Provider: provider,
 		Body:     body,
@@ -973,7 +984,7 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 		// accept the prepend and would be soft no-ops anyway. The
 		// per-tool-use auto-approve notice is handled separately on the
 		// continuation path and is additive with this one.
-		if resp.StatusCode == http.StatusOK && !llmproxy.HasInboundAssistantTurn(provider, body) {
+		if resp.StatusCode == http.StatusOK && !llmproxy.HasInboundAssistantTurn(provider, bodyForFirstTurnDetect) {
 			notice := llmproxy.RenderAgentRoutingNotice(agent.Name)
 			pre, changed, prependErr := llmproxy.PrependAssistantNotice(provider, processed.ContentType, processed.Body, notice)
 			switch {

--- a/internal/api/handlers/llm_endpoint.go
+++ b/internal/api/handlers/llm_endpoint.go
@@ -965,6 +965,29 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 				"response postprocess failed; see clawvisor audit log")
 			return
 		}
+		// First-turn routing notice. When the inbound transcript carries
+		// no prior assistant turn, this is the user's opening prompt of
+		// a fresh conversation — prepend a one-liner so they see that
+		// Clawvisor is intermediating and which agent identity is in
+		// use. Only fires on 200; non-success bodies aren't shaped to
+		// accept the prepend and would be soft no-ops anyway. The
+		// per-tool-use auto-approve notice is handled separately on the
+		// continuation path and is additive with this one.
+		if resp.StatusCode == http.StatusOK && !llmproxy.HasInboundAssistantTurn(provider, body) {
+			notice := llmproxy.RenderAgentRoutingNotice(agent.Name)
+			pre, changed, prependErr := llmproxy.PrependAssistantNotice(provider, processed.ContentType, processed.Body, notice)
+			switch {
+			case prependErr != nil:
+				h.Logger.WarnContext(r.Context(), "lite-proxy first-turn notice prepend failed; returning unannotated body",
+					"request_id", requestID, "agent_id", agent.ID, "err", prependErr.Error())
+			case changed:
+				processed.Body = pre
+				// Mark Rewritten so the Content-Length / Content-Encoding
+				// cleanup below runs — the prepended body's length no
+				// longer matches the upstream header.
+				processed.Rewritten = true
+			}
+		}
 		if processed.Rewritten {
 			// Drop Content-Length entirely — the rewritten body's length
 			// differs from upstream's. Setting it to "" leaves an empty

--- a/internal/runtime/llmproxy/agent_notice.go
+++ b/internal/runtime/llmproxy/agent_notice.go
@@ -1,0 +1,145 @@
+package llmproxy
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+)
+
+// agentNoticeMaxNameRunes caps the agent display name embedded in the
+// first-turn notice. The agent name is operator-controlled (not
+// model-authored), but a runaway name from a misconfigured deployment
+// would still dominate the assistant turn without this. Matches the
+// defensive cap on [autoApproveUserNotice].
+const agentNoticeMaxNameRunes = 80
+
+// RenderAgentRoutingNotice returns the human-facing one-liner the
+// handler prepends to the first assistant turn of a conversation so the
+// user can see at a glance that the conversation is being routed
+// through Clawvisor and which agent identity is in use. Empty / blank
+// agent names render a name-less fallback rather than an awkward empty
+// quote.
+func RenderAgentRoutingNotice(agentName string) string {
+	cleaned := strings.TrimSpace(agentName)
+	cleaned = strings.ReplaceAll(cleaned, "\r", " ")
+	cleaned = strings.ReplaceAll(cleaned, "\n", " ")
+	cleaned = truncateRunes(cleaned, agentNoticeMaxNameRunes)
+	if cleaned == "" {
+		return "[Clawvisor] Routing this conversation through Clawvisor."
+	}
+	return fmt.Sprintf("[Clawvisor] Routing this conversation through Clawvisor as agent %q.", cleaned)
+}
+
+// HasInboundAssistantTurn reports whether the inbound LLM request body
+// already contains at least one assistant turn. The first-message
+// notice fires only when this returns false — i.e. the very first
+// upstream call of a fresh conversation. On a malformed body or an
+// unrecognized provider shape, returns true (fail-safe: skip the
+// notice rather than risk prepending it on every turn of a
+// long-running conversation we couldn't parse).
+func HasInboundAssistantTurn(provider conversation.Provider, body []byte) bool {
+	if len(body) == 0 {
+		return true
+	}
+	switch provider {
+	case conversation.ProviderAnthropic:
+		return anthropicInboundHasAssistant(body)
+	case conversation.ProviderOpenAI:
+		return openAIInboundHasAssistant(body)
+	default:
+		return true
+	}
+}
+
+func anthropicInboundHasAssistant(body []byte) bool {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return true
+	}
+	msgsRaw, ok := raw["messages"]
+	if !ok {
+		return true
+	}
+	var messages []struct {
+		Role string `json:"role"`
+	}
+	if err := json.Unmarshal(msgsRaw, &messages); err != nil {
+		return true
+	}
+	for _, m := range messages {
+		if m.Role == "assistant" {
+			return true
+		}
+	}
+	return false
+}
+
+func openAIInboundHasAssistant(body []byte) bool {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return true
+	}
+	// Chat Completions shape: messages[].role
+	if msgsRaw, ok := raw["messages"]; ok {
+		var messages []struct {
+			Role string `json:"role"`
+		}
+		if err := json.Unmarshal(msgsRaw, &messages); err != nil {
+			return true
+		}
+		for _, m := range messages {
+			if m.Role == "assistant" {
+				return true
+			}
+		}
+		return false
+	}
+	// Responses API shape: `input` is either a plain string (single
+	// user turn, no prior assistant) or an array of typed items where
+	// assistant turns appear as role:"assistant" message items.
+	if inputRaw, ok := raw["input"]; ok {
+		var asString string
+		if err := json.Unmarshal(inputRaw, &asString); err == nil {
+			return false
+		}
+		var items []struct {
+			Type string `json:"type"`
+			Role string `json:"role"`
+		}
+		if err := json.Unmarshal(inputRaw, &items); err != nil {
+			return true
+		}
+		for _, it := range items {
+			if it.Type != "" && it.Type != "message" {
+				continue
+			}
+			if it.Role == "assistant" {
+				return true
+			}
+		}
+		return false
+	}
+	// No messages and no input — fail safe.
+	return true
+}
+
+func truncateRunes(s string, max int) string {
+	if max <= 0 {
+		return ""
+	}
+	count := 0
+	cut := len(s)
+	for i := range s {
+		if count == max {
+			cut = i
+			break
+		}
+		count++
+	}
+	if cut == len(s) {
+		return s
+	}
+	return s[:cut] + "…"
+}

--- a/internal/runtime/llmproxy/agent_notice.go
+++ b/internal/runtime/llmproxy/agent_notice.go
@@ -97,16 +97,23 @@ func openAIInboundHasAssistant(body []byte) bool {
 		}
 		return false
 	}
-	// Responses API stateful conversation mode: the harness uses
-	// `previous_response_id` (or the newer `conversation` field) to
-	// chain turns server-side, leaving the request body to carry only
-	// the new user turn. Either field is conclusive evidence that
-	// prior assistant state exists, even if `input` contains only
-	// user-shaped items. Check before walking `input`.
+	// Responses API stateful chaining: `previous_response_id`
+	// back-references a prior response, which is always assistant
+	// output. Conclusive evidence of prior history regardless of what
+	// `input` carries — check before walking `input`.
+	//
+	// We deliberately do NOT treat the top-level `conversation` field
+	// the same way. A conversation is a container that can be brand-
+	// new and empty on a fresh client kickoff, so its presence alone
+	// is not evidence that any assistant turn has occurred yet.
+	// Clients that chain turns within a conversation typically also
+	// set `previous_response_id` (the conversation field carries
+	// state; the response_id chain carries the back-reference), so
+	// the conclusive signal is still available. A client that chains
+	// via `conversation` ALONE and ships only a new user turn each
+	// time will get the notice re-prepended on every turn — degenerate
+	// but acceptable for a UX-polish surface.
 	if prev, ok := raw["previous_response_id"]; ok && hasNonEmptyJSONStringOrObject(prev) {
-		return true
-	}
-	if conv, ok := raw["conversation"]; ok && hasNonEmptyJSONStringOrObject(conv) {
 		return true
 	}
 	// Responses API shape: `input` is either a plain string (single

--- a/internal/runtime/llmproxy/agent_notice.go
+++ b/internal/runtime/llmproxy/agent_notice.go
@@ -97,8 +97,17 @@ func openAIInboundHasAssistant(body []byte) bool {
 		return false
 	}
 	// Responses API shape: `input` is either a plain string (single
-	// user turn, no prior assistant) or an array of typed items where
-	// assistant turns appear as role:"assistant" message items.
+	// user turn, no prior assistant) or an array of typed items. The
+	// "no prior assistant" set is small and well-known: `message` items
+	// with role in {user, system, developer}. Everything else carries
+	// assistant-side state — assistant-role messages, `function_call`,
+	// `custom_tool_call`, `reasoning`, built-in tool calls
+	// (`web_search_call`, `file_search_call`, …), and even
+	// `function_call_output` (which only exists in response to a prior
+	// assistant function_call). Enumerate the user-side shape and treat
+	// everything else as assistant history; otherwise a turn-2+ request
+	// whose assistant turn was a tool call (no text message) would be
+	// misread as the first turn and re-prepended on every continuation.
 	if inputRaw, ok := raw["input"]; ok {
 		var asString string
 		if err := json.Unmarshal(inputRaw, &asString); err == nil {
@@ -112,10 +121,18 @@ func openAIInboundHasAssistant(body []byte) bool {
 			return true
 		}
 		for _, it := range items {
-			if it.Type != "" && it.Type != "message" {
-				continue
+			// Default item type is "message" when omitted.
+			typ := it.Type
+			if typ == "" {
+				typ = "message"
 			}
-			if it.Role == "assistant" {
+			if typ != "message" {
+				return true
+			}
+			switch it.Role {
+			case "user", "system", "developer":
+				continue
+			default:
 				return true
 			}
 		}

--- a/internal/runtime/llmproxy/agent_notice.go
+++ b/internal/runtime/llmproxy/agent_notice.go
@@ -1,6 +1,7 @@
 package llmproxy
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -96,6 +97,18 @@ func openAIInboundHasAssistant(body []byte) bool {
 		}
 		return false
 	}
+	// Responses API stateful conversation mode: the harness uses
+	// `previous_response_id` (or the newer `conversation` field) to
+	// chain turns server-side, leaving the request body to carry only
+	// the new user turn. Either field is conclusive evidence that
+	// prior assistant state exists, even if `input` contains only
+	// user-shaped items. Check before walking `input`.
+	if prev, ok := raw["previous_response_id"]; ok && hasNonEmptyJSONStringOrObject(prev) {
+		return true
+	}
+	if conv, ok := raw["conversation"]; ok && hasNonEmptyJSONStringOrObject(conv) {
+		return true
+	}
 	// Responses API shape: `input` is either a plain string (single
 	// user turn, no prior assistant) or an array of typed items. The
 	// "no prior assistant" set is small and well-known: `message` items
@@ -140,6 +153,38 @@ func openAIInboundHasAssistant(body []byte) bool {
 	}
 	// No messages and no input — fail safe.
 	return true
+}
+
+// hasNonEmptyJSONStringOrObject reports whether the raw JSON value is a
+// non-empty string, a non-null object, or any other concrete (non-null,
+// non-empty-string) value. Used to detect whether an optional pointer-
+// like field on the Responses request (`previous_response_id`,
+// `conversation`) is actually set vs. literally `null` / `""` / absent.
+func hasNonEmptyJSONStringOrObject(raw json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return false
+	}
+	if bytes.Equal(trimmed, []byte("null")) {
+		return false
+	}
+	if bytes.Equal(trimmed, []byte(`""`)) {
+		return false
+	}
+	// Try as string first — the common case for previous_response_id
+	// ("resp_abc123") and the string form of conversation
+	// ("conv_xyz789").
+	var s string
+	if err := json.Unmarshal(trimmed, &s); err == nil {
+		return strings.TrimSpace(s) != ""
+	}
+	// Object form (e.g. {"id":"conv_xyz789"}) — anything that parses
+	// as a non-null object counts.
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(trimmed, &obj); err == nil {
+		return len(obj) > 0
+	}
+	return false
 }
 
 func truncateRunes(s string, max int) string {

--- a/internal/runtime/llmproxy/agent_notice_test.go
+++ b/internal/runtime/llmproxy/agent_notice_test.go
@@ -1,0 +1,192 @@
+package llmproxy
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+)
+
+func TestRenderAgentRoutingNotice_NamedAgent(t *testing.T) {
+	got := RenderAgentRoutingNotice("My Laptop")
+	want := `[Clawvisor] Routing this conversation through Clawvisor as agent "My Laptop".`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRenderAgentRoutingNotice_EmptyName(t *testing.T) {
+	got := RenderAgentRoutingNotice("")
+	want := `[Clawvisor] Routing this conversation through Clawvisor.`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRenderAgentRoutingNotice_WhitespaceName(t *testing.T) {
+	got := RenderAgentRoutingNotice("   \t  ")
+	want := `[Clawvisor] Routing this conversation through Clawvisor.`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRenderAgentRoutingNotice_StripsControlChars(t *testing.T) {
+	got := RenderAgentRoutingNotice("Line1\nLine2\rEnd")
+	want := `[Clawvisor] Routing this conversation through Clawvisor as agent "Line1 Line2 End".`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRenderAgentRoutingNotice_TruncatesLongName(t *testing.T) {
+	long := strings.Repeat("z", agentNoticeMaxNameRunes+50)
+	got := RenderAgentRoutingNotice(long)
+	if !strings.Contains(got, "…") {
+		t.Errorf("expected truncation ellipsis, got %q", got)
+	}
+	// 'z' appears nowhere in the surrounding template, so counting
+	// occurrences in the rendered notice gives the truncated name's
+	// rune length directly.
+	if strings.Count(got, "z") != agentNoticeMaxNameRunes {
+		t.Errorf("expected %d z's, got %d (notice=%q)", agentNoticeMaxNameRunes, strings.Count(got, "z"), got)
+	}
+}
+
+func TestRenderAgentRoutingNotice_TruncatesMultibyteRunes(t *testing.T) {
+	// Multibyte runes: '日' is 3 bytes. A naive byte-slice would split
+	// mid-rune and produce U+FFFD on JSON marshal. Rune-aware truncation
+	// keeps the output well-formed.
+	long := strings.Repeat("日", agentNoticeMaxNameRunes+10)
+	got := RenderAgentRoutingNotice(long)
+	if !strings.Contains(got, "…") {
+		t.Errorf("expected truncation ellipsis, got %q", got)
+	}
+	if strings.Count(got, "日") != agentNoticeMaxNameRunes {
+		t.Errorf("expected %d 日 runes, got %d", agentNoticeMaxNameRunes, strings.Count(got, "日"))
+	}
+}
+
+func TestHasInboundAssistantTurn_AnthropicNoAssistant(t *testing.T) {
+	body := mustMarshal(t, map[string]any{
+		"messages": []map[string]any{
+			{"role": "user", "content": "hi"},
+		},
+	})
+	if HasInboundAssistantTurn(conversation.ProviderAnthropic, body) {
+		t.Error("expected false for user-only inbound")
+	}
+}
+
+func TestHasInboundAssistantTurn_AnthropicWithAssistant(t *testing.T) {
+	body := mustMarshal(t, map[string]any{
+		"messages": []map[string]any{
+			{"role": "user", "content": "hi"},
+			{"role": "assistant", "content": "hello"},
+			{"role": "user", "content": "follow-up"},
+		},
+	})
+	if !HasInboundAssistantTurn(conversation.ProviderAnthropic, body) {
+		t.Error("expected true when inbound has prior assistant turn")
+	}
+}
+
+func TestHasInboundAssistantTurn_AnthropicEmptyMessages(t *testing.T) {
+	body := mustMarshal(t, map[string]any{
+		"messages": []map[string]any{},
+	})
+	if HasInboundAssistantTurn(conversation.ProviderAnthropic, body) {
+		t.Error("expected false for empty messages[]")
+	}
+}
+
+func TestHasInboundAssistantTurn_AnthropicNoMessagesField(t *testing.T) {
+	body := mustMarshal(t, map[string]any{"model": "claude"})
+	if !HasInboundAssistantTurn(conversation.ProviderAnthropic, body) {
+		t.Error("expected true (fail-safe) when messages[] absent")
+	}
+}
+
+func TestHasInboundAssistantTurn_MalformedJSON(t *testing.T) {
+	if !HasInboundAssistantTurn(conversation.ProviderAnthropic, []byte("{not json")) {
+		t.Error("expected true (fail-safe) on malformed body")
+	}
+}
+
+func TestHasInboundAssistantTurn_EmptyBody(t *testing.T) {
+	if !HasInboundAssistantTurn(conversation.ProviderAnthropic, nil) {
+		t.Error("expected true (fail-safe) on empty body")
+	}
+}
+
+func TestHasInboundAssistantTurn_UnknownProvider(t *testing.T) {
+	body := mustMarshal(t, map[string]any{
+		"messages": []map[string]any{{"role": "user", "content": "hi"}},
+	})
+	if !HasInboundAssistantTurn(conversation.Provider("unknown"), body) {
+		t.Error("expected true (fail-safe) for unknown provider")
+	}
+}
+
+func TestHasInboundAssistantTurn_OpenAIChatNoAssistant(t *testing.T) {
+	body := mustMarshal(t, map[string]any{
+		"messages": []map[string]any{
+			{"role": "system", "content": "you are a helper"},
+			{"role": "user", "content": "hi"},
+		},
+	})
+	if HasInboundAssistantTurn(conversation.ProviderOpenAI, body) {
+		t.Error("expected false for system+user OpenAI Chat inbound")
+	}
+}
+
+func TestHasInboundAssistantTurn_OpenAIChatWithAssistant(t *testing.T) {
+	body := mustMarshal(t, map[string]any{
+		"messages": []map[string]any{
+			{"role": "user", "content": "hi"},
+			{"role": "assistant", "content": "hello"},
+		},
+	})
+	if !HasInboundAssistantTurn(conversation.ProviderOpenAI, body) {
+		t.Error("expected true when OpenAI Chat inbound has assistant turn")
+	}
+}
+
+func TestHasInboundAssistantTurn_OpenAIResponsesStringInput(t *testing.T) {
+	body := mustMarshal(t, map[string]any{
+		"input": "run echo hello",
+	})
+	if HasInboundAssistantTurn(conversation.ProviderOpenAI, body) {
+		t.Error("expected false for OpenAI Responses string input (no prior history)")
+	}
+}
+
+func TestHasInboundAssistantTurn_OpenAIResponsesArrayNoAssistant(t *testing.T) {
+	body := mustMarshal(t, map[string]any{
+		"input": []map[string]any{
+			{"type": "message", "role": "user", "content": "hi"},
+		},
+	})
+	if HasInboundAssistantTurn(conversation.ProviderOpenAI, body) {
+		t.Error("expected false for OpenAI Responses user-only array input")
+	}
+}
+
+func TestHasInboundAssistantTurn_OpenAIResponsesArrayWithAssistant(t *testing.T) {
+	body := mustMarshal(t, map[string]any{
+		"input": []map[string]any{
+			{"type": "message", "role": "user", "content": "hi"},
+			{"type": "message", "role": "assistant", "content": "hello"},
+		},
+	})
+	if !HasInboundAssistantTurn(conversation.ProviderOpenAI, body) {
+		t.Error("expected true when OpenAI Responses array has assistant turn")
+	}
+}
+
+func TestHasInboundAssistantTurn_OpenAINoMessagesOrInput(t *testing.T) {
+	body := mustMarshal(t, map[string]any{"model": "gpt-4"})
+	if !HasInboundAssistantTurn(conversation.ProviderOpenAI, body) {
+		t.Error("expected true (fail-safe) when neither messages nor input present")
+	}
+}

--- a/internal/runtime/llmproxy/agent_notice_test.go
+++ b/internal/runtime/llmproxy/agent_notice_test.go
@@ -315,9 +315,13 @@ func TestHasInboundAssistantTurn_OpenAIResponsesEmptyPreviousResponseID(t *testi
 	}
 }
 
-func TestHasInboundAssistantTurn_OpenAIResponsesConversationField(t *testing.T) {
-	// Newer Responses conversation-state field. Accept both the
-	// string-id form and the object form.
+func TestHasInboundAssistantTurn_OpenAIResponsesConversationAloneNotConclusive(t *testing.T) {
+	// `conversation` is a container, not a back-reference: a fresh
+	// client kickoff can ship a brand-new (empty) conversation alongside
+	// the user's first turn. Without other evidence of prior assistant
+	// activity, this must be classified as a first turn so the routing
+	// notice fires. Compare to previous_response_id, which IS a
+	// conclusive back-reference and short-circuits to "has history."
 	for _, tc := range []struct {
 		name string
 		conv any
@@ -328,12 +332,44 @@ func TestHasInboundAssistantTurn_OpenAIResponsesConversationField(t *testing.T) 
 		t.Run(tc.name, func(t *testing.T) {
 			body := mustMarshal(t, map[string]any{
 				"conversation": tc.conv,
-				"input":        "follow up",
+				"input":        "first turn in this conversation",
 			})
-			if !HasInboundAssistantTurn(conversation.ProviderOpenAI, body) {
-				t.Errorf("expected true when conversation field is %v", tc.conv)
+			if HasInboundAssistantTurn(conversation.ProviderOpenAI, body) {
+				t.Errorf("expected false (first turn) for conversation-only kickoff, conv=%v", tc.conv)
 			}
 		})
+	}
+}
+
+func TestHasInboundAssistantTurn_OpenAIResponsesConversationWithPreviousResponseID(t *testing.T) {
+	// Mixed-field follow-up: conversation container + previous_response_id
+	// back-reference. The back-reference is conclusive — there IS a
+	// prior response.
+	body := mustMarshal(t, map[string]any{
+		"conversation":         "conv_xyz789",
+		"previous_response_id": "resp_abc123",
+		"input":                "follow up",
+	})
+	if !HasInboundAssistantTurn(conversation.ProviderOpenAI, body) {
+		t.Error("expected true when previous_response_id is set alongside conversation")
+	}
+}
+
+func TestHasInboundAssistantTurn_OpenAIResponsesConversationWithAssistantInput(t *testing.T) {
+	// A conversation chain that echoes prior assistant items in
+	// `input` is still caught by the items walk — `conversation`
+	// being non-conclusive doesn't disable the rest of the detector.
+	body := mustMarshal(t, map[string]any{
+		"conversation": "conv_xyz789",
+		"input": []map[string]any{
+			{"type": "message", "role": "user", "content": "first"},
+			{"type": "function_call", "name": "Bash", "arguments": `{"command":"ls"}`, "call_id": "c1"},
+			{"type": "function_call_output", "call_id": "c1", "output": "a"},
+			{"type": "message", "role": "user", "content": "follow up"},
+		},
+	})
+	if !HasInboundAssistantTurn(conversation.ProviderOpenAI, body) {
+		t.Error("expected true when conversation chain echoes prior assistant items in input")
 	}
 }
 

--- a/internal/runtime/llmproxy/agent_notice_test.go
+++ b/internal/runtime/llmproxy/agent_notice_test.go
@@ -379,3 +379,52 @@ func TestHasInboundAssistantTurn_OpenAINoMessagesOrInput(t *testing.T) {
 		t.Error("expected true (fail-safe) when neither messages nor input present")
 	}
 }
+
+// TestHasInboundAssistantTurn_PostSyntheticApprovalStripIsAmbiguous documents
+// the bug class the handler avoids by snapshotting the body BEFORE
+// StripSyntheticApprovalHistory runs.
+//
+// Scenario: a fresh conversation's very first user prompt triggered a
+// tool_use that Postprocess substituted with an approval prompt
+// containing ToolApprovalSubstitutedPromptMarker. The user replied
+// "approve". On the continuation request, the inbound body has
+// [user, assistant(prompt+routing-notice), user("approve")]. The
+// strip removes the assistant prompt AND the bare reply, leaving just
+// [user]. The detector cannot tell this stripped body apart from a
+// genuine fresh turn-1 request and (correctly per its own contract)
+// returns false.
+//
+// The handler must therefore pass the pre-strip body to the detector
+// (or otherwise consult the synthetic_approval_history_stripped audit
+// signal). This test pins that invariant: if you change the strip to
+// preserve a turn-marker stub, update both this test and the handler
+// snapshot logic together.
+func TestHasInboundAssistantTurn_PostSyntheticApprovalStripIsAmbiguous(t *testing.T) {
+	preStrip := anthropicTextBody(
+		map[string]string{"role": "user", "content": "delete /tmp/x"},
+		map[string]string{"role": "assistant", "content": "[Clawvisor] Routing this conversation through Clawvisor as agent \"laptop\".\n\n" + ToolApprovalSubstitutedPromptMarker + " Reply yes or y to approve."},
+		map[string]string{"role": "user", "content": "y"},
+	)
+	// Sanity: the un-stripped body has the assistant turn the user saw.
+	if !HasInboundAssistantTurn(conversation.ProviderAnthropic, preStrip) {
+		t.Fatal("pre-strip body should detect as having an assistant turn")
+	}
+	stripped, err := StripSyntheticApprovalHistory(SyntheticApprovalHistoryStripRequest{
+		Provider: conversation.ProviderAnthropic,
+		Body:     preStrip,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !stripped.Modified {
+		t.Fatal("expected the synthetic approval prompt to be stripped")
+	}
+	// Post-strip the assistant turn is gone — detection now reports
+	// "no assistant" even though the user observed one in turn 1.
+	// The handler MUST use the pre-strip body for the first-turn
+	// decision; this assertion locks the failure mode in place so a
+	// future refactor that loses the snapshot trips this test.
+	if HasInboundAssistantTurn(conversation.ProviderAnthropic, stripped.Body) {
+		t.Fatal("post-strip body unexpectedly still has an assistant turn; the snapshot may no longer be necessary — re-evaluate the handler wiring")
+	}
+}

--- a/internal/runtime/llmproxy/agent_notice_test.go
+++ b/internal/runtime/llmproxy/agent_notice_test.go
@@ -184,6 +184,89 @@ func TestHasInboundAssistantTurn_OpenAIResponsesArrayWithAssistant(t *testing.T)
 	}
 }
 
+func TestHasInboundAssistantTurn_OpenAIResponsesFunctionCallHistory(t *testing.T) {
+	// Turn-2+ Responses continuation: the assistant's prior turn was a
+	// tool call (function_call) followed by the tool's output
+	// (function_call_output). No assistant-role message exists. Must
+	// still be treated as "has assistant history" so the routing notice
+	// doesn't re-prepend on every continuation.
+	body := mustMarshal(t, map[string]any{
+		"input": []map[string]any{
+			{"type": "message", "role": "user", "content": "list files"},
+			{"type": "function_call", "name": "Bash", "arguments": `{"command":"ls"}`, "call_id": "call_1"},
+			{"type": "function_call_output", "call_id": "call_1", "output": "a\nb"},
+		},
+	})
+	if !HasInboundAssistantTurn(conversation.ProviderOpenAI, body) {
+		t.Error("expected true when Responses input carries function_call history")
+	}
+}
+
+func TestHasInboundAssistantTurn_OpenAIResponsesReasoningHistory(t *testing.T) {
+	body := mustMarshal(t, map[string]any{
+		"input": []map[string]any{
+			{"type": "message", "role": "user", "content": "think then answer"},
+			{"type": "reasoning", "summary": []any{}, "encrypted_content": "..."},
+		},
+	})
+	if !HasInboundAssistantTurn(conversation.ProviderOpenAI, body) {
+		t.Error("expected true when Responses input carries reasoning history")
+	}
+}
+
+func TestHasInboundAssistantTurn_OpenAIResponsesBuiltinToolCallHistory(t *testing.T) {
+	body := mustMarshal(t, map[string]any{
+		"input": []map[string]any{
+			{"type": "message", "role": "user", "content": "search the web"},
+			{"type": "web_search_call", "id": "ws_1"},
+		},
+	})
+	if !HasInboundAssistantTurn(conversation.ProviderOpenAI, body) {
+		t.Error("expected true when Responses input carries a built-in tool_call item")
+	}
+}
+
+func TestHasInboundAssistantTurn_OpenAIResponsesCustomToolCallHistory(t *testing.T) {
+	body := mustMarshal(t, map[string]any{
+		"input": []map[string]any{
+			{"type": "message", "role": "user", "content": "use my tool"},
+			{"type": "custom_tool_call", "name": "do_thing", "call_id": "ct_1"},
+		},
+	})
+	if !HasInboundAssistantTurn(conversation.ProviderOpenAI, body) {
+		t.Error("expected true when Responses input carries a custom_tool_call item")
+	}
+}
+
+func TestHasInboundAssistantTurn_OpenAIResponsesSystemAndUserOnly(t *testing.T) {
+	// First turn variants: developer/system priming + user message,
+	// no prior assistant activity of any kind. Must still detect as
+	// first turn.
+	body := mustMarshal(t, map[string]any{
+		"input": []map[string]any{
+			{"type": "message", "role": "system", "content": "you are a helper"},
+			{"type": "message", "role": "developer", "content": "behave deterministically"},
+			{"type": "message", "role": "user", "content": "hi"},
+		},
+	})
+	if HasInboundAssistantTurn(conversation.ProviderOpenAI, body) {
+		t.Error("expected false for system/developer/user-only Responses input")
+	}
+}
+
+func TestHasInboundAssistantTurn_OpenAIResponsesItemWithoutTypeIsMessage(t *testing.T) {
+	// Items default to type:"message" when omitted. A user-role item
+	// without an explicit type must still be classified correctly.
+	body := mustMarshal(t, map[string]any{
+		"input": []map[string]any{
+			{"role": "user", "content": "hi"},
+		},
+	})
+	if HasInboundAssistantTurn(conversation.ProviderOpenAI, body) {
+		t.Error("expected false when message item omits type field (defaults to message)")
+	}
+}
+
 func TestHasInboundAssistantTurn_OpenAINoMessagesOrInput(t *testing.T) {
 	body := mustMarshal(t, map[string]any{"model": "gpt-4"})
 	if !HasInboundAssistantTurn(conversation.ProviderOpenAI, body) {

--- a/internal/runtime/llmproxy/agent_notice_test.go
+++ b/internal/runtime/llmproxy/agent_notice_test.go
@@ -267,6 +267,76 @@ func TestHasInboundAssistantTurn_OpenAIResponsesItemWithoutTypeIsMessage(t *test
 	}
 }
 
+func TestHasInboundAssistantTurn_OpenAIResponsesPreviousResponseIDStringInput(t *testing.T) {
+	// Stateful Responses follow-up: the harness chains turns via
+	// previous_response_id and ships only the new user turn as a plain
+	// string input. Server-side state holds the assistant history, so
+	// this must NOT be treated as a first turn.
+	body := mustMarshal(t, map[string]any{
+		"previous_response_id": "resp_abc123",
+		"input":                "follow up question",
+	})
+	if !HasInboundAssistantTurn(conversation.ProviderOpenAI, body) {
+		t.Error("expected true when previous_response_id is set (stateful follow-up)")
+	}
+}
+
+func TestHasInboundAssistantTurn_OpenAIResponsesPreviousResponseIDUserItems(t *testing.T) {
+	body := mustMarshal(t, map[string]any{
+		"previous_response_id": "resp_abc123",
+		"input": []map[string]any{
+			{"type": "message", "role": "user", "content": "another follow up"},
+		},
+	})
+	if !HasInboundAssistantTurn(conversation.ProviderOpenAI, body) {
+		t.Error("expected true when previous_response_id is set with user-only input items")
+	}
+}
+
+func TestHasInboundAssistantTurn_OpenAIResponsesEmptyPreviousResponseID(t *testing.T) {
+	// Empty/null previous_response_id must NOT trigger the follow-up
+	// classification — it's the absent-field signal.
+	for _, tc := range []struct {
+		name string
+		val  any
+	}{
+		{"empty string", ""},
+		{"null", nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			body := mustMarshal(t, map[string]any{
+				"previous_response_id": tc.val,
+				"input":                "first turn",
+			})
+			if HasInboundAssistantTurn(conversation.ProviderOpenAI, body) {
+				t.Errorf("expected false when previous_response_id is %v", tc.val)
+			}
+		})
+	}
+}
+
+func TestHasInboundAssistantTurn_OpenAIResponsesConversationField(t *testing.T) {
+	// Newer Responses conversation-state field. Accept both the
+	// string-id form and the object form.
+	for _, tc := range []struct {
+		name string
+		conv any
+	}{
+		{"string form", "conv_xyz789"},
+		{"object form", map[string]any{"id": "conv_xyz789"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			body := mustMarshal(t, map[string]any{
+				"conversation": tc.conv,
+				"input":        "follow up",
+			})
+			if !HasInboundAssistantTurn(conversation.ProviderOpenAI, body) {
+				t.Errorf("expected true when conversation field is %v", tc.conv)
+			}
+		})
+	}
+}
+
 func TestHasInboundAssistantTurn_OpenAINoMessagesOrInput(t *testing.T) {
 	body := mustMarshal(t, map[string]any{"model": "gpt-4"})
 	if !HasInboundAssistantTurn(conversation.ProviderOpenAI, body) {


### PR DESCRIPTION
## Summary

- Prepends `[Clawvisor] Routing this conversation through Clawvisor as agent "<name>".` to the first assistant response of a conversation so users can tell their chat is being intermediated and which agent identity is in use.
- First-turn detection is shape-based — no prior `assistant` role in the inbound transcript — across Anthropic `messages[]`, OpenAI Chat `messages[]`, and OpenAI Responses `input` (both string and array forms). Parse errors / unknown providers fail safe: skip the notice rather than risk re-prepending on every turn.
- Reuses the existing `PrependAssistantNotice` machinery; additively stacks with the per-tool-use auto-approve notice on the continuation path.

## Implementation notes

- New `internal/runtime/llmproxy/agent_notice.go`: `RenderAgentRoutingNotice(agentName)` (control-char strip, 80-rune cap, rune-safe truncation, name-less fallback) + `HasInboundAssistantTurn(provider, body)`.
- Wired into `llm_endpoint.go` `serve()` after the postprocess fail-closed check and before the `Rewritten` header cleanup. On success the body is replaced and `processed.Rewritten = true` so Content-Length / Content-Encoding get dropped to match the mutated body length. Prepend errors log a warn and pass the body through unannotated — the notice is UX polish, not correctness.
- Resumed transcripts (Claude Code reload, etc.) carry prior assistant turns so the notice does not re-prepend.

## Test plan

- [x] `go test ./internal/runtime/llmproxy/ ./internal/api/handlers/` passes.
- [x] `go test ./...` passes.
- [x] 18 new unit tests in `agent_notice_test.go` cover blank/whitespace/long/multibyte agent names and first-turn detection across Anthropic, OpenAI Chat, OpenAI Responses (string and array `input`), plus malformed/empty/unknown-provider fail-safe paths.
- [ ] Smoke-test against a live Claude Code session: confirm the notice appears on the first turn only and not on subsequent turns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)