### PR TITLE
feat(llmproxy): mint and inject Clawvisor conversation ID on Chat Completions turn 1

### DIFF
--- a/internal/api/handlers/llm_endpoint.go
+++ b/internal/api/handlers/llm_endpoint.go
@@ -576,6 +576,42 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 	// pre-strip body reflects what the harness actually shipped, which
 	// is the right input for the first-turn question.
 	bodyForFirstTurnDetect := body
+	// First-turn detection feeds two side-by-side decisions:
+	//
+	//  1. Conversation-ID mint. On harnesses without a native session
+	//     identifier (today: OpenAI Chat Completions), turn-1 of a
+	//     fresh conversation has no echoed marker yet, so
+	//     ConversationID() returned the user-message fingerprint.
+	//     Override it with a freshly minted "cv-conv-…" value and embed
+	//     that value in the response-side routing notice so the
+	//     harness round-trips it back to us in assistant history on
+	//     turn 2+. The state we key by conversation ID (pending-approval
+	//     holds, task-checkout focus) is created downstream under this
+	//     minted value, so the next-turn marker-echo resolves cleanly
+	//     to the same bucket.
+	//
+	//  2. Routing-notice prepend. Same firstTurn predicate selects
+	//     which response gets the human-visible Clawvisor notice.
+	firstTurn := !llmproxy.HasInboundAssistantTurn(provider, bodyForFirstTurnDetect)
+	mintedConversationID := ""
+	if firstTurn && provider == conversation.ProviderOpenAI && conversation.IsOpenAIChatCompletionsEndpoint(r) {
+		minted, mintErr := conversation.NewConversationID()
+		if mintErr != nil {
+			// Mint failure is rare (crypto/rand outage) and recoverable:
+			// fall through to the fingerprint that ConversationID()
+			// already produced. The cost is just a degraded scope key
+			// for this conversation, not a request failure.
+			h.Logger.WarnContext(r.Context(), "lite-proxy conversation id mint failed; falling through to fingerprint",
+				"request_id", requestID, "agent_id", agent.ID, "err", mintErr.Error())
+		} else {
+			mintedConversationID = minted
+			conversationID = minted
+			auditParams["conversation_id"] = minted
+			auditParams["conversation_id_minted"] = true
+		}
+	}
+	auditParams["first_turn"] = firstTurn
+	auditParams["conversation_id_source"] = liteProxyConversationIDSource(provider, r, conversationID, mintedConversationID)
 	if stripped, stripErr := llmproxy.StripSyntheticApprovalHistory(llmproxy.SyntheticApprovalHistoryStripRequest{
 		Provider: provider,
 		Body:     body,
@@ -984,8 +1020,12 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 		// accept the prepend and would be soft no-ops anyway. The
 		// per-tool-use auto-approve notice is handled separately on the
 		// continuation path and is additive with this one.
-		if resp.StatusCode == http.StatusOK && !llmproxy.HasInboundAssistantTurn(provider, bodyForFirstTurnDetect) {
-			notice := llmproxy.RenderAgentRoutingNotice(agent.Name)
+		if resp.StatusCode == http.StatusOK && firstTurn {
+			// mintedConversationID is non-empty only on Chat Completions
+			// turn 1 (where no native session ID exists). For Anthropic
+			// and OpenAI Responses the renderer drops the marker
+			// argument and emits the existing notice unchanged.
+			notice := llmproxy.RenderAgentRoutingNotice(agent.Name, mintedConversationID)
 			pre, changed, prependErr := llmproxy.PrependAssistantNotice(provider, processed.ContentType, processed.Body, notice)
 			switch {
 			case prependErr != nil:
@@ -2887,6 +2927,36 @@ func (h *LLMEndpointHandler) maybeHandleLiteApprovalRelease(w http.ResponseWrite
 
 func liteProxyDecisionPosture(agent *store.Agent) runtimedecision.EvaluationPosture {
 	return runtimedecision.PostureEnforce
+}
+
+// liteProxyConversationIDSource labels how the conversation ID currently
+// in use was derived, for the per-request audit row. Lets dashboards
+// answer "what fraction of Chat-Completions turn-2+ requests had the
+// minted marker round-trip?" without re-doing the lookup. Values are
+// stable strings safe to switch on in downstream queries.
+func liteProxyConversationIDSource(provider conversation.Provider, req *http.Request, conversationID, mintedConversationID string) string {
+	if conversationID == "" {
+		return "empty"
+	}
+	if mintedConversationID != "" && conversationID == mintedConversationID {
+		return "minted"
+	}
+	switch provider {
+	case conversation.ProviderAnthropic:
+		return "native_anthropic"
+	case conversation.ProviderOpenAI:
+		if req != nil && conversation.IsOpenAIChatCompletionsEndpoint(req) {
+			if strings.HasPrefix(conversationID, conversation.ConversationIDPrefix) {
+				return "echoed_marker"
+			}
+			if strings.HasPrefix(conversationID, "fp-") {
+				return "fingerprint"
+			}
+			return "unknown"
+		}
+		return "native_openai_responses"
+	}
+	return "unknown"
 }
 
 type liteProxyRequestSummary struct {

--- a/internal/api/handlers/llm_endpoint_conversation_id_marker_test.go
+++ b/internal/api/handlers/llm_endpoint_conversation_id_marker_test.go
@@ -1,0 +1,279 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/internal/api/middleware"
+	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy"
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/inspector"
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+// TestLLMEndpoint_ChatCompletions_FirstTurnMintsConversationIDMarker
+// exercises the end-to-end inject path: turn 1 of a Chat Completions
+// conversation mints a Clawvisor-owned conversation ID, embeds the
+// marker in the response routing notice, and records the mint in the
+// audit row.
+func TestLLMEndpoint_ChatCompletions_FirstTurnMintsConversationIDMarker(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"cmpl_1","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}]}`))
+	}))
+	defer upstream.Close()
+
+	h, st, rawToken, _ := newSeededHandler(t, upstream.URL)
+	h.Forwarder.Upstream.OpenAIBaseURL = upstream.URL
+	h.Inspector = inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{})
+	h.AuditEmitter = llmproxy.NewAuditEmitter(st, nil, nil)
+
+	mux := http.NewServeMux()
+	mw := middleware.RequireAgentLLM(st)
+	mux.Handle("POST /v1/chat/completions", mw(http.HandlerFunc(h.ChatCompletions)))
+
+	body := []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(string(body)))
+	req.Header.Set("Authorization", "Bearer "+rawToken)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (%s)", rec.Code, rec.Body.String())
+	}
+
+	// Routing notice + marker land in the assistant content of the
+	// first choice. PrependOpenAIChatAssistantText inserts the notice
+	// at the head of the existing content string.
+	respText := rec.Body.String()
+	if !strings.Contains(respText, "[Clawvisor] Routing this conversation through Clawvisor") {
+		t.Errorf("response missing routing notice: %s", respText)
+	}
+	if !strings.Contains(respText, conversation.ConversationIDMarker+conversation.ConversationIDPrefix) {
+		t.Errorf("response missing conversation ID marker: %s", respText)
+	}
+
+	// Pull the marker back out and verify the scanner round-trips it.
+	// Build a synthetic turn-2 body where the assistant turn is exactly
+	// the response we just got, and assert FindInjectedConversationID
+	// recovers the same value.
+	var parsed struct {
+		Choices []struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &parsed); err != nil {
+		t.Fatalf("parse response: %v", err)
+	}
+	if len(parsed.Choices) == 0 {
+		t.Fatalf("response has no choices")
+	}
+	assistantContent := parsed.Choices[0].Message.Content
+	turn2Body := []byte(`{"messages":[{"role":"user","content":"hi"},{"role":"assistant","content":` + mustJSONStr(t, assistantContent) + `},{"role":"user","content":"follow up"}]}`)
+	turn2Req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	recoveredID := conversation.FindInjectedConversationID(turn2Req, conversation.ProviderOpenAI, turn2Body)
+	if recoveredID == "" {
+		t.Fatalf("marker did not round-trip: assistant=%q", assistantContent)
+	}
+
+	// Audit row should record the mint + first_turn + source=minted.
+	user, _ := st.GetUserByEmail(context.Background(), "lite-proxy@example.com")
+	rows, _, err := st.ListAuditEntries(context.Background(), user.ID, store.AuditFilter{})
+	if err != nil {
+		t.Fatalf("ListAuditEntries: %v", err)
+	}
+	var serveRow *store.AuditEntry
+	for _, row := range rows {
+		if row.Action == "lite_proxy.chat.completions.create" {
+			serveRow = row
+			break
+		}
+	}
+	if serveRow == nil {
+		t.Fatalf("expected chat.completions.create audit row; got %d rows", len(rows))
+	}
+	var params map[string]any
+	if err := json.Unmarshal(serveRow.ParamsSafe, &params); err != nil {
+		t.Fatalf("parse params_safe: %v", err)
+	}
+	if params["first_turn"] != true {
+		t.Errorf("expected first_turn=true, params=%v", params)
+	}
+	if params["conversation_id_minted"] != true {
+		t.Errorf("expected conversation_id_minted=true, params=%v", params)
+	}
+	if params["conversation_id_source"] != "minted" {
+		t.Errorf("expected conversation_id_source=minted, got %v", params["conversation_id_source"])
+	}
+	if cid, _ := params["conversation_id"].(string); cid != recoveredID {
+		t.Errorf("expected audit conversation_id=%q to match recovered marker %q", cid, recoveredID)
+	}
+}
+
+// TestLLMEndpoint_ChatCompletions_Turn2EchoesMarkerNoRemint confirms a
+// continuation request that carries the marker in assistant history
+// re-uses the same conversation ID without minting a new one and
+// without re-prepending the routing notice.
+func TestLLMEndpoint_ChatCompletions_Turn2EchoesMarkerNoRemint(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"cmpl_2","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`))
+	}))
+	defer upstream.Close()
+
+	h, st, rawToken, _ := newSeededHandler(t, upstream.URL)
+	h.Forwarder.Upstream.OpenAIBaseURL = upstream.URL
+	h.Inspector = inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{})
+	h.AuditEmitter = llmproxy.NewAuditEmitter(st, nil, nil)
+
+	mux := http.NewServeMux()
+	mw := middleware.RequireAgentLLM(st)
+	mux.Handle("POST /v1/chat/completions", mw(http.HandlerFunc(h.ChatCompletions)))
+
+	const echoedID = "cv-conv-abcdefghijklmnopqrstuvwxyz"
+	body := []byte(`{"model":"gpt-4o","messages":[
+		{"role":"user","content":"hi"},
+		{"role":"assistant","content":"[Clawvisor] Routing this conversation through Clawvisor. [clawvisor:conversation=` + echoedID + `]"},
+		{"role":"user","content":"follow up"}
+	]}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(string(body)))
+	req.Header.Set("Authorization", "Bearer "+rawToken)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (%s)", rec.Code, rec.Body.String())
+	}
+	// Turn 2: no notice, no new marker — assistant content stays as
+	// the upstream's "ok" verbatim. (Note: marker MAY appear later in
+	// the body since fluentd-style mock JSON could contain literal
+	// strings; the test below checks the specific assistant content.)
+	respBody, _ := io.ReadAll(rec.Body)
+	var parsed struct {
+		Choices []struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		t.Fatalf("parse response: %v", err)
+	}
+	if len(parsed.Choices) == 0 || parsed.Choices[0].Message.Content != "ok" {
+		t.Fatalf("expected assistant content unchanged (\"ok\"), got %+v", parsed.Choices)
+	}
+
+	user, _ := st.GetUserByEmail(context.Background(), "lite-proxy@example.com")
+	rows, _, err := st.ListAuditEntries(context.Background(), user.ID, store.AuditFilter{})
+	if err != nil {
+		t.Fatalf("ListAuditEntries: %v", err)
+	}
+	var serveRow *store.AuditEntry
+	for _, row := range rows {
+		if row.Action == "lite_proxy.chat.completions.create" {
+			serveRow = row
+			break
+		}
+	}
+	if serveRow == nil {
+		t.Fatalf("expected chat.completions.create audit row; got %d rows", len(rows))
+	}
+	var params map[string]any
+	if err := json.Unmarshal(serveRow.ParamsSafe, &params); err != nil {
+		t.Fatalf("parse params_safe: %v", err)
+	}
+	if params["first_turn"] != false {
+		t.Errorf("expected first_turn=false, params=%v", params)
+	}
+	if _, minted := params["conversation_id_minted"]; minted {
+		t.Errorf("expected no conversation_id_minted key on turn 2, params=%v", params)
+	}
+	if params["conversation_id_source"] != "echoed_marker" {
+		t.Errorf("expected conversation_id_source=echoed_marker, got %v", params["conversation_id_source"])
+	}
+	if cid, _ := params["conversation_id"].(string); cid != echoedID {
+		t.Errorf("expected audit conversation_id=%q to equal echoed marker", cid)
+	}
+}
+
+// TestLLMEndpoint_Anthropic_NoConversationIDMarker confirms the marker
+// path is gated to OpenAI Chat Completions only. Anthropic uses the
+// native session_id, so the routing notice fires on turn 1 but
+// carries no marker.
+func TestLLMEndpoint_Anthropic_NoConversationIDMarker(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1","type":"message","role":"assistant","content":[{"type":"text","text":"hello"}],"model":"claude-sonnet-4","stop_reason":"end_turn"}`))
+	}))
+	defer upstream.Close()
+
+	h, st, rawToken, _ := newSeededHandler(t, upstream.URL)
+	h.Inspector = inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{})
+	h.AuditEmitter = llmproxy.NewAuditEmitter(st, nil, nil)
+
+	mux := http.NewServeMux()
+	mw := middleware.RequireAgentLLM(st)
+	mux.Handle("POST /v1/messages", mw(http.HandlerFunc(h.Messages)))
+
+	body := []byte(`{"model":"claude-sonnet-4","messages":[{"role":"user","content":"hi"}]}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(string(body)))
+	req.Header.Set("Authorization", "Bearer "+rawToken)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (%s)", rec.Code, rec.Body.String())
+	}
+	respText := rec.Body.String()
+	if !strings.Contains(respText, "[Clawvisor] Routing this conversation through Clawvisor") {
+		t.Errorf("Anthropic response missing routing notice: %s", respText)
+	}
+	if strings.Contains(respText, conversation.ConversationIDMarker) {
+		t.Errorf("Anthropic response unexpectedly carries conversation ID marker: %s", respText)
+	}
+
+	user, _ := st.GetUserByEmail(context.Background(), "lite-proxy@example.com")
+	rows, _, err := st.ListAuditEntries(context.Background(), user.ID, store.AuditFilter{})
+	if err != nil {
+		t.Fatalf("ListAuditEntries: %v", err)
+	}
+	for _, row := range rows {
+		if row.Action != "lite_proxy.messages.create" {
+			continue
+		}
+		var params map[string]any
+		_ = json.Unmarshal(row.ParamsSafe, &params)
+		if _, minted := params["conversation_id_minted"]; minted {
+			t.Errorf("Anthropic turn unexpectedly minted a conversation ID: params=%v", params)
+		}
+		// Anthropic body has no metadata.user_id → conversation_id_source
+		// is "empty" rather than "native_anthropic" for this minimal
+		// fixture. Both are legitimate — the assertion is just that
+		// it's NOT a Chat-Completions-only label.
+		src, _ := params["conversation_id_source"].(string)
+		if src == "minted" || src == "echoed_marker" || src == "fingerprint" {
+			t.Errorf("Anthropic row got Chat-Completions-only source label %q", src)
+		}
+		return
+	}
+	t.Fatalf("expected messages.create audit row")
+}
+
+func mustJSONStr(t *testing.T, s string) string {
+	t.Helper()
+	b, err := json.Marshal(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}

--- a/internal/runtime/conversation/conversation_id.go
+++ b/internal/runtime/conversation/conversation_id.go
@@ -30,12 +30,15 @@ import (
 //     per Codex session.
 //
 //   - OpenAI Chat Completions (/v1/chat/completions): no native session
-//     identifier exists on the wire. Fall back to a fingerprint of the FIRST
-//     user message text. The first user message is the most stable thing
-//     harnesses leave alone — system prompts can be rewritten on policy
-//     changes, and compaction replaces middle messages, but the first
-//     user-typed turn survives. Two conversations starting with literally
-//     identical text will collide; acceptable.
+//     identifier exists on the wire. First consult FindInjectedConversationID
+//     for a Clawvisor-minted marker echoed back in assistant history. Fall
+//     back to a fingerprint of the FIRST user message text when no marker
+//     has been minted yet (or the harness stripped it). The first user
+//     message is the most stable thing harnesses leave alone — system
+//     prompts can be rewritten on policy changes, and compaction replaces
+//     middle messages, but the first user-typed turn survives. Two
+//     conversations starting with literally identical text will collide
+//     under the fingerprint; the marker, when echoed, partitions cleanly.
 //
 // The request shape is inspected without disturbing it — body is read-only.
 func ConversationID(req *http.Request, provider Provider, body []byte) string {
@@ -47,6 +50,15 @@ func ConversationID(req *http.Request, provider Provider, body []byte) string {
 		return anthropicConversationID(body)
 	case ProviderOpenAI:
 		if req != nil && isOpenAIChatCompletionsEndpoint(req) {
+			// Echoed Clawvisor marker is conclusive when present — it
+			// was minted on turn 1 specifically because no native ID
+			// exists, and the harness has now round-tripped it.
+			if id := FindInjectedConversationID(req, ProviderOpenAI, body); id != "" {
+				return id
+			}
+			// Pre-mint or marker-stripped fallback. Will be removed in
+			// a follow-up once telemetry confirms the marker round-trips
+			// reliably across the active OpenClaw harness population.
 			return openAIChatFingerprint(body)
 		}
 		return openAIResponsesConversationID(body)

--- a/internal/runtime/conversation/conversation_id_marker.go
+++ b/internal/runtime/conversation/conversation_id_marker.go
@@ -1,0 +1,115 @@
+package conversation
+
+import (
+	"crypto/rand"
+	"encoding/base32"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+)
+
+// ConversationIDMarker is the prefix of the parseable footer the proxy
+// embeds in the first assistant turn on harnesses without a native
+// session identifier (today: OpenAI Chat Completions only). Format:
+// "[clawvisor:conversation=cv-conv-<id>]". Lives in this package so
+// both the request-body parser and the prompt renderer agree on the
+// literal.
+//
+// The marker is a distinct key ("conversation") from the approval
+// marker ("approval"), so a parser keyed on the marker name cannot
+// confuse them. The cv-conv-<id> prefix on the value is a human-
+// readability nicety, not a parser-level disambiguator.
+const ConversationIDMarker = "[clawvisor:conversation="
+
+// ConversationIDPrefix is the prefix every minted conversation ID
+// carries. Kept narrow so the scanner regex can reject any value that
+// doesn't structurally look like a Clawvisor-minted ID.
+const ConversationIDPrefix = "cv-conv-"
+
+// conversationIDMarkerRE matches the full bracket-enclosed marker
+// shape on Chat Completions assistant turns. The inner [a-z0-9]+ is a
+// tolerant superset of the actual mint alphabet (lowercase base32 =
+// a-z2-7) so a future mint-format tweak doesn't have to update this
+// regex in lockstep.
+var conversationIDMarkerRE = regexp.MustCompile(`\[clawvisor:conversation=(` + regexp.QuoteMeta(ConversationIDPrefix) + `[a-z0-9]+)\]`)
+
+// conversationIDRandRead is the entropy source for NewConversationID,
+// hooked at the package level so tests can inject a deterministic
+// reader. Matches the pattern used by liteApprovalRandRead in the
+// llmproxy package.
+var conversationIDRandRead = rand.Read
+
+// NewConversationID mints a fresh conversation identifier used by the
+// inject-and-echo flow on harnesses without a native session ID. The
+// returned value has the form "cv-conv-<26 chars lowercase base32>",
+// matching the entropy and encoding shape of approval IDs.
+//
+// The mint is a pure function — no I/O, no clock dependency — so the
+// handler can call it inline when it decides to mint on turn 1.
+func NewConversationID() (string, error) {
+	var b [16]byte
+	if _, err := conversationIDRandRead(b[:]); err != nil {
+		return "", fmt.Errorf("generate conversation id: %w", err)
+	}
+	encoded := strings.ToLower(base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(b[:]))
+	return ConversationIDPrefix + encoded, nil
+}
+
+// RenderConversationIDMarker returns the bracketed marker form that
+// callers embed verbatim in the rendered assistant text. Centralized
+// so the prepend renderer and the parser agree on the literal.
+func RenderConversationIDMarker(id string) string {
+	return ConversationIDMarker + id + "]"
+}
+
+// FindInjectedConversationID returns the conversation ID from the
+// rightmost [clawvisor:conversation=cv-conv-...] marker found in an
+// assistant-role message of the inbound request body. Scoped to:
+//
+//  1. ASSISTANT-ROLE turns only, walked structurally — a user typing
+//     the marker text into their own prompt MUST NOT hijack a
+//     conversation under an attacker-controlled ID.
+//  2. OpenAI Chat Completions inbound shape only, since that is the
+//     only provider+endpoint where the proxy injects the marker.
+//     Other providers / endpoints return "" without parsing.
+//
+// Returns "" when no marker is found, the body fails to parse, or the
+// provider/endpoint isn't a Chat Completions request. Most-recent-wins
+// when multiple assistant turns each carry a marker (compaction may
+// keep a marker from an earlier turn, but the freshest is the one
+// produced by the latest mint).
+func FindInjectedConversationID(req *http.Request, provider Provider, body []byte) string {
+	if len(body) == 0 || provider != ProviderOpenAI {
+		return ""
+	}
+	if req == nil || !isOpenAIChatCompletionsEndpoint(req) {
+		return ""
+	}
+	var probe struct {
+		Messages []openAIMessage `json:"messages"`
+	}
+	if err := json.Unmarshal(body, &probe); err != nil {
+		return ""
+	}
+	latest := ""
+	for _, msg := range probe.Messages {
+		if msg.Role != "assistant" {
+			continue
+		}
+		text := flattenOpenAIContent(msg.Content)
+		if text == "" {
+			continue
+		}
+		matches := conversationIDMarkerRE.FindAllStringSubmatch(text, -1)
+		if len(matches) == 0 {
+			continue
+		}
+		// Most-recent-wins within an assistant turn AND across turns:
+		// overwrite latest as we walk forward, so the final value is
+		// the last marker in the last assistant turn that carried one.
+		latest = strings.ToLower(matches[len(matches)-1][1])
+	}
+	return latest
+}

--- a/internal/runtime/conversation/conversation_id_marker_test.go
+++ b/internal/runtime/conversation/conversation_id_marker_test.go
@@ -1,0 +1,238 @@
+package conversation
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestNewConversationID_ShapeAndUniqueness(t *testing.T) {
+	seen := map[string]struct{}{}
+	for i := 0; i < 100; i++ {
+		id, err := NewConversationID()
+		if err != nil {
+			t.Fatalf("mint err: %v", err)
+		}
+		if !strings.HasPrefix(id, ConversationIDPrefix) {
+			t.Fatalf("missing %q prefix: %q", ConversationIDPrefix, id)
+		}
+		tail := strings.TrimPrefix(id, ConversationIDPrefix)
+		if len(tail) != 26 {
+			t.Fatalf("expected 26-char base32 tail, got %d (%q)", len(tail), id)
+		}
+		// Lowercase base32: a-z2-7. The scanner regex is a tolerant
+		// superset (a-z0-9), but the mint itself MUST stay inside the
+		// alphabet so a future regex tightening doesn't break echoes
+		// of historical IDs.
+		for _, r := range tail {
+			if !(r >= 'a' && r <= 'z') && !(r >= '2' && r <= '7') {
+				t.Fatalf("char %q outside base32 alphabet in %q", r, id)
+			}
+		}
+		if _, dup := seen[id]; dup {
+			t.Fatalf("collision after %d mints: %q", i+1, id)
+		}
+		seen[id] = struct{}{}
+	}
+}
+
+func TestNewConversationID_PropagatesEntropyError(t *testing.T) {
+	saved := conversationIDRandRead
+	t.Cleanup(func() { conversationIDRandRead = saved })
+	conversationIDRandRead = func(b []byte) (int, error) {
+		return 0, errors.New("boom")
+	}
+	if _, err := NewConversationID(); err == nil || !strings.Contains(err.Error(), "generate conversation id") {
+		t.Fatalf("expected wrapped entropy error, got %v", err)
+	}
+}
+
+func TestRenderConversationIDMarker_RoundTripsThroughRegex(t *testing.T) {
+	id, err := NewConversationID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rendered := RenderConversationIDMarker(id)
+	if !strings.HasPrefix(rendered, ConversationIDMarker) || !strings.HasSuffix(rendered, "]") {
+		t.Fatalf("rendered marker has unexpected shape: %q", rendered)
+	}
+	matches := conversationIDMarkerRE.FindStringSubmatch(rendered)
+	if matches == nil || matches[1] != id {
+		t.Fatalf("regex did not extract minted id: rendered=%q matches=%v", rendered, matches)
+	}
+}
+
+func chatCompletionsReq(t *testing.T) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest("POST", "https://api.openai.com/v1/chat/completions", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return req
+}
+
+func TestFindInjectedConversationID_SingleAssistantMarker(t *testing.T) {
+	req := chatCompletionsReq(t)
+	body := []byte(`{"messages":[
+		{"role":"user","content":"hi"},
+		{"role":"assistant","content":"[Clawvisor] Routing this conversation through Clawvisor. [clawvisor:conversation=cv-conv-abcdefghijklmnopqrstuvwxyz]"}
+	]}`)
+	got := FindInjectedConversationID(req, ProviderOpenAI, body)
+	if got != "cv-conv-abcdefghijklmnopqrstuvwxyz" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestFindInjectedConversationID_MostRecentWins(t *testing.T) {
+	// Two assistant turns carry markers. Most recent (last in order)
+	// wins — compaction may keep an earlier marker, but the freshest
+	// is the one produced by the live mint.
+	req := chatCompletionsReq(t)
+	body := []byte(`{"messages":[
+		{"role":"user","content":"hi"},
+		{"role":"assistant","content":"[clawvisor:conversation=cv-conv-aaaaaaaaaaaaaaaaaaaaaaaaaa]"},
+		{"role":"user","content":"again"},
+		{"role":"assistant","content":"[clawvisor:conversation=cv-conv-bbbbbbbbbbbbbbbbbbbbbbbbbb]"}
+	]}`)
+	got := FindInjectedConversationID(req, ProviderOpenAI, body)
+	if got != "cv-conv-bbbbbbbbbbbbbbbbbbbbbbbbbb" {
+		t.Fatalf("got %q, want the second marker", got)
+	}
+}
+
+func TestFindInjectedConversationID_IgnoresUserAuthoredMarker(t *testing.T) {
+	// Security-critical: a user typing the marker text into their own
+	// message MUST NOT hijack the conversation ID. Only assistant-role
+	// content is scanned.
+	req := chatCompletionsReq(t)
+	body := []byte(`{"messages":[
+		{"role":"system","content":"system [clawvisor:conversation=cv-conv-systemmmmmmmmmmmmmmmmmmmm]"},
+		{"role":"user","content":"hey [clawvisor:conversation=cv-conv-attackerrrrrrrrrrrrrrrrrrr]"},
+		{"role":"tool","content":"tool out [clawvisor:conversation=cv-conv-toolllllllllllllllllllllllll]"}
+	]}`)
+	got := FindInjectedConversationID(req, ProviderOpenAI, body)
+	if got != "" {
+		t.Fatalf("user/system/tool-authored marker leaked: got %q", got)
+	}
+}
+
+func TestFindInjectedConversationID_AssistantBlockContent(t *testing.T) {
+	// Assistant content carried as typed-block array (e.g. multimodal).
+	// flattenOpenAIContent already handles both shapes — verify the
+	// marker scanner picks it up the same way.
+	req := chatCompletionsReq(t)
+	body := []byte(`{"messages":[
+		{"role":"assistant","content":[
+			{"type":"text","text":"some prose"},
+			{"type":"text","text":"[clawvisor:conversation=cv-conv-blockcontentmarkerrrrrrrr]"}
+		]}
+	]}`)
+	got := FindInjectedConversationID(req, ProviderOpenAI, body)
+	if got != "cv-conv-blockcontentmarkerrrrrrrr" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestFindInjectedConversationID_MarkerInCodeFence(t *testing.T) {
+	// Models / harnesses sometimes wrap parts of an assistant message
+	// in code fences. The regex anchors on the literal bracket form,
+	// so surrounding fences / backticks are inert.
+	req := chatCompletionsReq(t)
+	body := []byte(`{"messages":[
+		{"role":"assistant","content":"see footer below:\n\n` + "```" + `\n[clawvisor:conversation=cv-conv-fencedmarkerrrrrrrrrrrrrr]\n` + "```" + `"}
+	]}`)
+	got := FindInjectedConversationID(req, ProviderOpenAI, body)
+	if got != "cv-conv-fencedmarkerrrrrrrrrrrrrr" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestFindInjectedConversationID_NoMarker(t *testing.T) {
+	req := chatCompletionsReq(t)
+	body := []byte(`{"messages":[
+		{"role":"user","content":"hi"},
+		{"role":"assistant","content":"hello, no marker here"}
+	]}`)
+	if got := FindInjectedConversationID(req, ProviderOpenAI, body); got != "" {
+		t.Fatalf("got %q, expected empty", got)
+	}
+}
+
+func TestFindInjectedConversationID_MalformedBody(t *testing.T) {
+	req := chatCompletionsReq(t)
+	if got := FindInjectedConversationID(req, ProviderOpenAI, []byte("{not json")); got != "" {
+		t.Fatalf("got %q on malformed body, expected empty", got)
+	}
+}
+
+func TestFindInjectedConversationID_RejectsNonChatCompletionsEndpoint(t *testing.T) {
+	// Responses endpoint must NOT consult the marker — it has a native
+	// session ID and we never inject markers there.
+	req, _ := http.NewRequest("POST", "https://api.openai.com/v1/responses", nil)
+	body := []byte(`{"messages":[
+		{"role":"assistant","content":"[clawvisor:conversation=cv-conv-shouldnotresolvvvvvvvvvvvv]"}
+	]}`)
+	if got := FindInjectedConversationID(req, ProviderOpenAI, body); got != "" {
+		t.Fatalf("Responses endpoint unexpectedly matched marker: %q", got)
+	}
+}
+
+func TestFindInjectedConversationID_RejectsNonOpenAIProvider(t *testing.T) {
+	req := chatCompletionsReq(t)
+	body := []byte(`{"messages":[
+		{"role":"assistant","content":"[clawvisor:conversation=cv-conv-anthropicccccccccccccccc]"}
+	]}`)
+	if got := FindInjectedConversationID(req, ProviderAnthropic, body); got != "" {
+		t.Fatalf("Anthropic provider unexpectedly matched marker: %q", got)
+	}
+}
+
+func TestFindInjectedConversationID_NilRequest(t *testing.T) {
+	body := []byte(`{"messages":[{"role":"assistant","content":"[clawvisor:conversation=cv-conv-niiiiiiiiiiiiiiiiiiiiiiiiil]"}]}`)
+	if got := FindInjectedConversationID(nil, ProviderOpenAI, body); got != "" {
+		t.Fatalf("nil request must not match: %q", got)
+	}
+}
+
+func TestFindInjectedConversationID_MalformedMarkerIgnored(t *testing.T) {
+	// Marker key matches but value doesn't have the cv-conv- prefix
+	// (e.g., an old approval ID accidentally embedded as a conversation
+	// value). Must NOT match the conversation scanner.
+	req := chatCompletionsReq(t)
+	body := []byte(`{"messages":[
+		{"role":"assistant","content":"[clawvisor:conversation=cv-not-the-conv-prefix-xx]"}
+	]}`)
+	if got := FindInjectedConversationID(req, ProviderOpenAI, body); got != "" {
+		t.Fatalf("non-cv-conv value unexpectedly matched: %q", got)
+	}
+}
+
+func TestConversationID_OpenAIChatPrefersMarkerOverFingerprint(t *testing.T) {
+	// Integration check on the public ConversationID() entry point:
+	// when an assistant turn carries a marker, it wins over the
+	// fingerprint fallback even if the first user message would have
+	// produced a stable fingerprint.
+	req := chatCompletionsReq(t)
+	body := []byte(`{"messages":[
+		{"role":"user","content":"identical opening line"},
+		{"role":"assistant","content":"[clawvisor:conversation=cv-conv-preferredmarkerrrrrrrrrrr]"},
+		{"role":"user","content":"continue"}
+	]}`)
+	got := ConversationID(req, ProviderOpenAI, body)
+	if got != "cv-conv-preferredmarkerrrrrrrrrrr" {
+		t.Fatalf("ConversationID = %q, want minted marker", got)
+	}
+}
+
+func TestConversationID_OpenAIChatFallsBackToFingerprintWhenNoMarker(t *testing.T) {
+	req := chatCompletionsReq(t)
+	body := []byte(`{"messages":[
+		{"role":"user","content":"opening line"},
+		{"role":"assistant","content":"no marker yet"}
+	]}`)
+	got := ConversationID(req, ProviderOpenAI, body)
+	if !strings.HasPrefix(got, "fp-") {
+		t.Fatalf("ConversationID = %q, want fp- fallback", got)
+	}
+}

--- a/internal/runtime/llmproxy/agent_notice.go
+++ b/internal/runtime/llmproxy/agent_notice.go
@@ -22,15 +22,28 @@ const agentNoticeMaxNameRunes = 80
 // through Clawvisor and which agent identity is in use. Empty / blank
 // agent names render a name-less fallback rather than an awkward empty
 // quote.
-func RenderAgentRoutingNotice(agentName string) string {
+//
+// mintedConversationID, when non-empty, is appended as a parseable
+// [clawvisor:conversation=cv-conv-…] footer so the harness round-trips
+// the ID back to us in assistant history on turn 2+. Only set on
+// harnesses without a native session identifier (today: OpenAI Chat
+// Completions); empty for Anthropic / OpenAI Responses where the
+// native session ID is the conclusive scope key.
+func RenderAgentRoutingNotice(agentName, mintedConversationID string) string {
 	cleaned := strings.TrimSpace(agentName)
 	cleaned = strings.ReplaceAll(cleaned, "\r", " ")
 	cleaned = strings.ReplaceAll(cleaned, "\n", " ")
 	cleaned = truncateRunes(cleaned, agentNoticeMaxNameRunes)
+	var notice string
 	if cleaned == "" {
-		return "[Clawvisor] Routing this conversation through Clawvisor."
+		notice = "[Clawvisor] Routing this conversation through Clawvisor."
+	} else {
+		notice = fmt.Sprintf("[Clawvisor] Routing this conversation through Clawvisor as agent %q.", cleaned)
 	}
-	return fmt.Sprintf("[Clawvisor] Routing this conversation through Clawvisor as agent %q.", cleaned)
+	if id := strings.TrimSpace(mintedConversationID); id != "" {
+		notice += " " + conversation.RenderConversationIDMarker(id)
+	}
+	return notice
 }
 
 // HasInboundAssistantTurn reports whether the inbound LLM request body

--- a/internal/runtime/llmproxy/agent_notice_test.go
+++ b/internal/runtime/llmproxy/agent_notice_test.go
@@ -1,6 +1,8 @@
 package llmproxy
 
 import (
+	"encoding/json"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -8,7 +10,7 @@ import (
 )
 
 func TestRenderAgentRoutingNotice_NamedAgent(t *testing.T) {
-	got := RenderAgentRoutingNotice("My Laptop")
+	got := RenderAgentRoutingNotice("My Laptop", "")
 	want := `[Clawvisor] Routing this conversation through Clawvisor as agent "My Laptop".`
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
@@ -16,7 +18,7 @@ func TestRenderAgentRoutingNotice_NamedAgent(t *testing.T) {
 }
 
 func TestRenderAgentRoutingNotice_EmptyName(t *testing.T) {
-	got := RenderAgentRoutingNotice("")
+	got := RenderAgentRoutingNotice("", "")
 	want := `[Clawvisor] Routing this conversation through Clawvisor.`
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
@@ -24,7 +26,7 @@ func TestRenderAgentRoutingNotice_EmptyName(t *testing.T) {
 }
 
 func TestRenderAgentRoutingNotice_WhitespaceName(t *testing.T) {
-	got := RenderAgentRoutingNotice("   \t  ")
+	got := RenderAgentRoutingNotice("   \t  ", "")
 	want := `[Clawvisor] Routing this conversation through Clawvisor.`
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
@@ -32,7 +34,7 @@ func TestRenderAgentRoutingNotice_WhitespaceName(t *testing.T) {
 }
 
 func TestRenderAgentRoutingNotice_StripsControlChars(t *testing.T) {
-	got := RenderAgentRoutingNotice("Line1\nLine2\rEnd")
+	got := RenderAgentRoutingNotice("Line1\nLine2\rEnd", "")
 	want := `[Clawvisor] Routing this conversation through Clawvisor as agent "Line1 Line2 End".`
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
@@ -41,7 +43,7 @@ func TestRenderAgentRoutingNotice_StripsControlChars(t *testing.T) {
 
 func TestRenderAgentRoutingNotice_TruncatesLongName(t *testing.T) {
 	long := strings.Repeat("z", agentNoticeMaxNameRunes+50)
-	got := RenderAgentRoutingNotice(long)
+	got := RenderAgentRoutingNotice(long, "")
 	if !strings.Contains(got, "…") {
 		t.Errorf("expected truncation ellipsis, got %q", got)
 	}
@@ -58,13 +60,74 @@ func TestRenderAgentRoutingNotice_TruncatesMultibyteRunes(t *testing.T) {
 	// mid-rune and produce U+FFFD on JSON marshal. Rune-aware truncation
 	// keeps the output well-formed.
 	long := strings.Repeat("日", agentNoticeMaxNameRunes+10)
-	got := RenderAgentRoutingNotice(long)
+	got := RenderAgentRoutingNotice(long, "")
 	if !strings.Contains(got, "…") {
 		t.Errorf("expected truncation ellipsis, got %q", got)
 	}
 	if strings.Count(got, "日") != agentNoticeMaxNameRunes {
 		t.Errorf("expected %d 日 runes, got %d", agentNoticeMaxNameRunes, strings.Count(got, "日"))
 	}
+}
+
+func TestRenderAgentRoutingNotice_AppendsConversationIDMarker(t *testing.T) {
+	id := "cv-conv-abcdefghijklmnopqrstuvwxyz"
+	got := RenderAgentRoutingNotice("My Laptop", id)
+	want := `[Clawvisor] Routing this conversation through Clawvisor as agent "My Laptop". [clawvisor:conversation=cv-conv-abcdefghijklmnopqrstuvwxyz]`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRenderAgentRoutingNotice_AppendsMarkerToNameLessFallback(t *testing.T) {
+	got := RenderAgentRoutingNotice("", "cv-conv-aaaaaaaaaaaaaaaaaaaaaaaaaa")
+	want := `[Clawvisor] Routing this conversation through Clawvisor. [clawvisor:conversation=cv-conv-aaaaaaaaaaaaaaaaaaaaaaaaaa]`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRenderAgentRoutingNotice_WhitespaceMintedIDOmitsMarker(t *testing.T) {
+	// Empty/whitespace mintedConversationID must not produce an empty
+	// "[clawvisor:conversation=]" footer.
+	got := RenderAgentRoutingNotice("agent", "   ")
+	want := `[Clawvisor] Routing this conversation through Clawvisor as agent "agent".`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRenderAgentRoutingNotice_MintedIDRoundTripsThroughScanner(t *testing.T) {
+	id, err := conversation.NewConversationID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	notice := RenderAgentRoutingNotice("agent", id)
+	// Build a Chat Completions inbound body where the assistant turn
+	// is exactly the rendered notice — simulating turn-2 echo.
+	body := []byte(`{"messages":[{"role":"assistant","content":` + mustJSONString(t, notice) + `}]}`)
+	req := chatCompletionsReq(t)
+	recovered := conversation.FindInjectedConversationID(req, conversation.ProviderOpenAI, body)
+	if recovered != id {
+		t.Fatalf("rendered notice did not round-trip through scanner: minted=%q recovered=%q notice=%q", id, recovered, notice)
+	}
+}
+
+func mustJSONString(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+func chatCompletionsReq(t *testing.T) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest("POST", "https://api.openai.com/v1/chat/completions", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return req
 }
 
 func TestHasInboundAssistantTurn_AnthropicNoAssistant(t *testing.T) {


### PR DESCRIPTION
## Summary

OpenAI Chat Completions has no native session identifier on the wire, so `ConversationID()` fell back to a sha256 fingerprint of the first user message. Templated kickoffs and scripted automations with identical opening lines silently collapsed into the same scoping bucket, sharing pending-approval and task-checkout state.

This PR adds the inject-and-echo flow that mints a Clawvisor-owned ID on turn 1 and recovers it from assistant history on turn 2+. Two commits:

1. **`conversation` package primitives + source-order change** — parser-only, inert in production until commit 2 lands. Lets the marker scanner be tested in isolation.
2. **Handler wiring** — mint on Chat Completions turn 1, fold marker into the routing notice, record audit fields.

## What this PR ships

### `internal/runtime/conversation`

- `ConversationIDMarker` / `ConversationIDPrefix` — literals shared by parser and renderer.
- `NewConversationID()` — mints `cv-conv-<26 chars lowercase base32>` via `crypto/rand`. Pure function; package-level rand hook for tests.
- `RenderConversationIDMarker()` — returns the bracketed marker form.
- `FindInjectedConversationID(req, provider, body)` — walks `messages[]` **structurally**, scans only `role:"assistant"` content for the most recent `[clawvisor:conversation=cv-conv-…]` marker. Scoped to OpenAI Chat Completions inbound shape only — Anthropic and Responses paths don't see the marker because they have native session IDs.
- `ConversationID()` reordered: Chat Completions consults the marker scanner first, falls back to the existing fingerprint when no marker has been echoed yet (or the harness stripped it).

### `internal/runtime/llmproxy`

- `RenderAgentRoutingNotice(agentName, mintedConversationID)` — extended signature. Empty `mintedConversationID` (Anthropic / Responses / mint failure) renders the existing notice unchanged. Non-empty appends ` [clawvisor:conversation=cv-conv-…]`.

### `internal/api/handlers/llm_endpoint.go`

- After the existing pre-strip body snapshot, compute `firstTurn := !HasInboundAssistantTurn(...)`.
- On Chat Completions turn 1, mint a fresh ID via `NewConversationID()` and override `conversationID` so all downstream state (pending-approval holds, task-checkout focus) keys under the value the harness round-trips back on turn 2. Mint failure falls through to the fingerprint — degraded scope key, not a request failure.
- Same `firstTurn` predicate now gates the response-side notice prepend (was an inline `HasInboundAssistantTurn` call). Marker is appended via the extended renderer.
- New audit params on every request:
  - `first_turn: bool`
  - `conversation_id_minted: true` (only when minted)
  - `conversation_id_source: "native_anthropic" | "native_openai_responses" | "minted" | "echoed_marker" | "fingerprint" | "empty" | "unknown"`

## Security note

`FindInjectedConversationID` walks `messages[]` structurally and only scans `role:"assistant"` content. A user typing the marker text into their own prompt cannot hijack the conversation under an attacker-controlled ID. Test: `TestFindInjectedConversationID_IgnoresUserAuthoredMarker`.

## Telemetry / rollout

The migration plan is behavioral, not flag-gated:

1. Land this PR. Marker injects + recovers; fingerprint stays as the empty-marker fallback.
2. Watch `conversation_id_source` distribution for Chat Completions in audit dashboards. The signal we care about is the **fraction of turn-2+ Chat Completions requests with `conversation_id_source = "fingerprint"`** — that's the rate at which harnesses are stripping our marker.
3. Once that rate is acceptably low across the active OpenClaw harness population, remove the fingerprint fallback in a follow-up PR.

## Test plan

- [x] `go test ./internal/runtime/conversation/` — 16 new unit tests (marker mint, scanner, integration with `ConversationID()`).
- [x] `go test ./internal/runtime/llmproxy/` — 4 new tests for the extended `RenderAgentRoutingNotice` signature; existing detector tests updated.
- [x] `go test ./internal/api/handlers/` — 3 new end-to-end tests:
  - Chat Completions turn 1 mints + prepends + audits `source=minted` + marker round-trips through the scanner.
  - Chat Completions turn 2 with echoed marker resolves to `source=echoed_marker`, no remint, no notice re-prepend.
  - Anthropic turn 1 prepends notice without a marker, no mint, source label is not a Chat-Completions-only value.
- [x] `go test ./...` passes.

## Out of scope

- Removing the fingerprint fallback (follow-up after telemetry confirms).
- Invisible marker encoding (HTML comment / zero-width). Visible parenthetical is the v1 — re-evaluate only if user feedback makes the visibility a problem in practice.
- Marker injection on Anthropic / Responses (they have native session IDs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)