### PR TITLE
feat(drive): export specific sheet tabs

### DIFF
--- a/internal/adapters/definitions/google_drive.yaml
+++ b/internal/adapters/definitions/google_drive.yaml
@@ -99,6 +99,9 @@ actions:
         type: string
         required: true
         description: "Target MIME type (e.g. application/pdf, text/plain, text/csv, application/vnd.openxmlformats-officedocument.wordprocessingml.document)"
+      sheet_name:
+        type: string
+        description: "Google Sheets only: name of the tab to export when mime_type is text/csv or text/tab-separated-values. Without this, only the first tab is returned."
 
   search_files:
     display_name: "Search files"

--- a/internal/adapters/google/drive/adapter.go
+++ b/internal/adapters/google/drive/adapter.go
@@ -369,15 +369,15 @@ func (a *DriveAdapter) exportFile(ctx context.Context, client *http.Client, para
 		res.Meta = map[string]any{
 			"hint": "Google Sheets CSV export returns only the first tab. Pass sheet_name (e.g. \"Routing Map\") to export a specific tab.",
 		}
+		if titles, err := a.listSheetTitles(ctx, client, meta.ID); err == nil && len(titles) > 0 {
+			res.Meta["available_tabs"] = titles
+			res.Meta["hint"] = fmt.Sprintf("Google Sheets CSV export returns only the first tab. Pass sheet_name with one of: %s.", strings.Join(titles, ", "))
+		}
 	}
 	return res, nil
 }
 
-// exportSheetTab reads a single sheet (tab) from a Google Sheets file via the
-// Sheets API and serializes the values as CSV or TSV. The drive.readonly scope
-// is sufficient to call spreadsheets.values.get.
-func (a *DriveAdapter) exportSheetTab(ctx context.Context, client *http.Client, fileID, fileName, sheetName, targetMime string) (*adapters.Result, error) {
-	// Validate that the named tab exists; surface available titles otherwise.
+func (a *DriveAdapter) listSheetTitles(ctx context.Context, client *http.Client, fileID string) ([]string, error) {
 	ssURL := fmt.Sprintf("https://sheets.googleapis.com/v4/spreadsheets/%s?fields=sheets(properties(title))",
 		url.PathEscape(fileID))
 	var ssResp struct {
@@ -388,20 +388,32 @@ func (a *DriveAdapter) exportSheetTab(ctx context.Context, client *http.Client, 
 		} `json:"sheets"`
 	}
 	if err := apiGET(ctx, client, ssURL, &ssResp); err != nil {
+		return nil, err
+	}
+	titles := make([]string, 0, len(ssResp.Sheets))
+	for _, s := range ssResp.Sheets {
+		titles = append(titles, s.Properties.Title)
+	}
+	return titles, nil
+}
+
+// exportSheetTab reads a single sheet (tab) from a Google Sheets file via the
+// Sheets API and serializes the values as CSV or TSV. The drive.readonly scope
+// is sufficient to call spreadsheets.values.get.
+func (a *DriveAdapter) exportSheetTab(ctx context.Context, client *http.Client, fileID, fileName, sheetName, targetMime string) (*adapters.Result, error) {
+	// Validate that the named tab exists; surface available titles otherwise.
+	titles, err := a.listSheetTitles(ctx, client, fileID)
+	if err != nil {
 		return nil, fmt.Errorf("drive export_file: resolving sheet metadata: %w", err)
 	}
 	found := false
-	for _, s := range ssResp.Sheets {
-		if s.Properties.Title == sheetName {
+	for _, title := range titles {
+		if title == sheetName {
 			found = true
 			break
 		}
 	}
 	if !found {
-		titles := make([]string, 0, len(ssResp.Sheets))
-		for _, s := range ssResp.Sheets {
-			titles = append(titles, s.Properties.Title)
-		}
 		return nil, fmt.Errorf("drive export_file: sheet_name %q not found; available tabs: %s", sheetName, strings.Join(titles, ", "))
 	}
 

--- a/internal/adapters/google/drive/adapter.go
+++ b/internal/adapters/google/drive/adapter.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"encoding/csv"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -15,10 +16,12 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 
-	"github.com/clawvisor/clawvisor/pkg/adapters"
 	"github.com/clawvisor/clawvisor/internal/adapters/format"
 	"github.com/clawvisor/clawvisor/internal/adapters/google/credential"
+	"github.com/clawvisor/clawvisor/pkg/adapters"
 )
+
+const sheetsMimeType = "application/vnd.google-apps.spreadsheet"
 
 const serviceID = "google.drive"
 
@@ -171,11 +174,11 @@ func (a *DriveAdapter) listFiles(ctx context.Context, client *http.Client, param
 
 // textMimeTypes are the MIME types for which content preview is returned.
 var textMimeTypes = map[string]bool{
-	"text/plain":        true,
-	"text/markdown":     true,
-	"application/json":  true,
-	"text/csv":          true,
-	"text/html":         true,
+	"text/plain":       true,
+	"text/markdown":    true,
+	"application/json": true,
+	"text/csv":         true,
+	"text/html":        true,
 }
 
 func (a *DriveAdapter) getFile(ctx context.Context, client *http.Client, params map[string]any) (*adapters.Result, error) {
@@ -200,11 +203,11 @@ func (a *DriveAdapter) getFile(ctx context.Context, client *http.Client, params 
 	}
 
 	result := map[string]any{
-		"id":           meta.ID,
-		"name":         format.SanitizeText(meta.Name, format.MaxFieldLen),
-		"mime_type":    meta.MimeType,
-		"modified_at":  meta.ModifiedTime,
-		"size":         meta.Size,
+		"id":            meta.ID,
+		"name":          format.SanitizeText(meta.Name, format.MaxFieldLen),
+		"mime_type":     meta.MimeType,
+		"modified_at":   meta.ModifiedTime,
+		"size":          meta.Size,
 		"web_view_link": meta.WebViewLink,
 	}
 
@@ -291,9 +294,16 @@ func (a *DriveAdapter) downloadFile(ctx context.Context, client *http.Client, pa
 
 // exportFile exports a Google Workspace file (Docs, Sheets, Slides) to the
 // requested MIME type using the Drive files.export endpoint.
+//
+// For Google Sheets exported as CSV/TSV, the Drive export endpoint only emits
+// the first tab. When sheet_name is supplied (and the source is a Google
+// Sheet), exportFile instead calls the Sheets API to read just that tab's
+// values and serializes them as CSV/TSV.
 func (a *DriveAdapter) exportFile(ctx context.Context, client *http.Client, params map[string]any) (*adapters.Result, error) {
 	fileID, _ := params["file_id"].(string)
 	targetMime, _ := params["mime_type"].(string)
+	sheetName, _ := params["sheet_name"].(string)
+	sheetName = strings.TrimSpace(sheetName)
 	if fileID == "" {
 		return nil, fmt.Errorf("drive export_file: file_id is required")
 	}
@@ -311,6 +321,20 @@ func (a *DriveAdapter) exportFile(ctx context.Context, client *http.Client, para
 	}
 	if err := apiGET(ctx, client, metaURL, &meta); err != nil {
 		return nil, fmt.Errorf("drive export_file: %w", err)
+	}
+
+	isSheet := meta.MimeType == sheetsMimeType
+	wantsTabular := targetMime == "text/csv" || targetMime == "text/tab-separated-values"
+
+	if sheetName != "" && !isSheet {
+		return nil, fmt.Errorf("drive export_file: sheet_name is only supported when the source is a Google Sheet (got %s)", meta.MimeType)
+	}
+	if sheetName != "" && !wantsTabular {
+		return nil, fmt.Errorf("drive export_file: sheet_name requires mime_type=text/csv or text/tab-separated-values")
+	}
+
+	if isSheet && wantsTabular && sheetName != "" {
+		return a.exportSheetTab(ctx, client, meta.ID, meta.Name, sheetName, targetMime)
 	}
 
 	exportURL := fmt.Sprintf("https://www.googleapis.com/drive/v3/files/%s/export?mimeType=%s",
@@ -331,14 +355,102 @@ func (a *DriveAdapter) exportFile(ctx context.Context, client *http.Client, para
 	}
 
 	result := map[string]any{
-		"id":              meta.ID,
-		"name":            format.SanitizeText(meta.Name, format.MaxFieldLen),
+		"id":               meta.ID,
+		"name":             format.SanitizeText(meta.Name, format.MaxFieldLen),
 		"source_mime_type": meta.MimeType,
 		"export_mime_type": targetMime,
-		"content":         format.SanitizeText(string(body), format.MaxBodyLen),
+		"content":          format.SanitizeText(string(body), format.MaxBodyLen),
+	}
+	res := &adapters.Result{
+		Summary: format.Summary("Exported %s as %s", meta.Name, targetMime),
+		Data:    result,
+	}
+	if isSheet && wantsTabular {
+		res.Meta = map[string]any{
+			"hint": "Google Sheets CSV export returns only the first tab. Pass sheet_name (e.g. \"Routing Map\") to export a specific tab.",
+		}
+	}
+	return res, nil
+}
+
+// exportSheetTab reads a single sheet (tab) from a Google Sheets file via the
+// Sheets API and serializes the values as CSV or TSV. The drive.readonly scope
+// is sufficient to call spreadsheets.values.get.
+func (a *DriveAdapter) exportSheetTab(ctx context.Context, client *http.Client, fileID, fileName, sheetName, targetMime string) (*adapters.Result, error) {
+	// Validate that the named tab exists; surface available titles otherwise.
+	ssURL := fmt.Sprintf("https://sheets.googleapis.com/v4/spreadsheets/%s?fields=sheets(properties(title))",
+		url.PathEscape(fileID))
+	var ssResp struct {
+		Sheets []struct {
+			Properties struct {
+				Title string `json:"title"`
+			} `json:"properties"`
+		} `json:"sheets"`
+	}
+	if err := apiGET(ctx, client, ssURL, &ssResp); err != nil {
+		return nil, fmt.Errorf("drive export_file: resolving sheet metadata: %w", err)
+	}
+	found := false
+	for _, s := range ssResp.Sheets {
+		if s.Properties.Title == sheetName {
+			found = true
+			break
+		}
+	}
+	if !found {
+		titles := make([]string, 0, len(ssResp.Sheets))
+		for _, s := range ssResp.Sheets {
+			titles = append(titles, s.Properties.Title)
+		}
+		return nil, fmt.Errorf("drive export_file: sheet_name %q not found; available tabs: %s", sheetName, strings.Join(titles, ", "))
+	}
+
+	// Read all values for the named sheet. The A1 range must single-quote the
+	// sheet title — otherwise titles with spaces or punctuation are rejected,
+	// and a bare title that happens to match a defined named range resolves to
+	// the named range instead of the tab. Embedded single quotes double.
+	a1Range := "'" + strings.ReplaceAll(sheetName, "'", "''") + "'"
+	valuesURL := fmt.Sprintf("https://sheets.googleapis.com/v4/spreadsheets/%s/values/%s",
+		url.PathEscape(fileID), url.PathEscape(a1Range))
+	var valuesResp struct {
+		Range  string          `json:"range"`
+		Values [][]interface{} `json:"values"`
+	}
+	if err := apiGET(ctx, client, valuesURL, &valuesResp); err != nil {
+		return nil, fmt.Errorf("drive export_file: reading sheet values: %w", err)
+	}
+
+	delim := ','
+	if targetMime == "text/tab-separated-values" {
+		delim = '\t'
+	}
+	var buf bytes.Buffer
+	w := csv.NewWriter(&buf)
+	w.Comma = delim
+	for _, row := range valuesResp.Values {
+		record := make([]string, len(row))
+		for i, cell := range row {
+			record[i] = fmt.Sprintf("%v", cell)
+		}
+		if err := w.Write(record); err != nil {
+			return nil, fmt.Errorf("drive export_file: serializing row: %w", err)
+		}
+	}
+	w.Flush()
+	if err := w.Error(); err != nil {
+		return nil, fmt.Errorf("drive export_file: serializing CSV: %w", err)
+	}
+
+	result := map[string]any{
+		"id":               fileID,
+		"name":             format.SanitizeText(fileName, format.MaxFieldLen),
+		"source_mime_type": sheetsMimeType,
+		"export_mime_type": targetMime,
+		"sheet_name":       sheetName,
+		"content":          format.SanitizeText(buf.String(), format.MaxBodyLen),
 	}
 	return &adapters.Result{
-		Summary: format.Summary("Exported %s as %s", meta.Name, targetMime),
+		Summary: format.Summary("Exported %s [%s] as %s (%d row(s))", fileName, sheetName, targetMime, len(valuesResp.Values)),
 		Data:    result,
 	}, nil
 }
@@ -497,4 +609,3 @@ func paramInt(params map[string]any, key string) (int, bool) {
 	}
 	return 0, false
 }
-

--- a/internal/adapters/google/drive/adapter.go
+++ b/internal/adapters/google/drive/adapter.go
@@ -211,6 +211,12 @@ func (a *DriveAdapter) getFile(ctx context.Context, client *http.Client, params 
 		"web_view_link": meta.WebViewLink,
 	}
 
+	if meta.MimeType == sheetsMimeType {
+		if titles, err := a.listSheetTitles(ctx, client, meta.ID); err == nil && len(titles) > 0 {
+			result["available_tabs"] = titles
+		}
+	}
+
 	// Fetch content preview for text types only.
 	if textMimeTypes[meta.MimeType] {
 		contentURL := fmt.Sprintf("https://www.googleapis.com/drive/v3/files/%s?alt=media",
@@ -370,6 +376,7 @@ func (a *DriveAdapter) exportFile(ctx context.Context, client *http.Client, para
 			"hint": "Google Sheets CSV export returns only the first tab. Pass sheet_name (e.g. \"Routing Map\") to export a specific tab.",
 		}
 		if titles, err := a.listSheetTitles(ctx, client, meta.ID); err == nil && len(titles) > 0 {
+			result["available_tabs"] = titles
 			res.Meta["available_tabs"] = titles
 			res.Meta["hint"] = fmt.Sprintf("Google Sheets CSV export returns only the first tab. Pass sheet_name with one of: %s.", strings.Join(titles, ", "))
 		}

--- a/internal/adapters/google/drive/adapter_test.go
+++ b/internal/adapters/google/drive/adapter_test.go
@@ -137,6 +137,42 @@ func TestExportFile_RejectsSheetNameOnNonSheet(t *testing.T) {
 	}
 }
 
+func TestGetFile_SheetIncludesAvailableTabs(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/drive/v3/files/sheet-1":
+			writeJSON(w, map[string]any{"id": "sheet-1", "name": "Routing", "mimeType": sheetsMimeType})
+		case "/v4/spreadsheets/sheet-1":
+			writeJSON(w, map[string]any{
+				"sheets": []any{
+					map[string]any{"properties": map[string]any{"title": "README"}},
+					map[string]any{"properties": map[string]any{"title": "Routing Map"}},
+				},
+			})
+		default:
+			t.Errorf("unexpected request path: %s", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	a := New(staticOAuthProvider{})
+	res, err := a.getFile(t.Context(), newTestClient(srv), map[string]any{
+		"file_id": "sheet-1",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data := res.Data.(map[string]any)
+	tabs, ok := data["available_tabs"].([]string)
+	if !ok {
+		t.Fatalf("available_tabs = %T, want []string", data["available_tabs"])
+	}
+	if len(tabs) != 2 || tabs[0] != "README" || tabs[1] != "Routing Map" {
+		t.Errorf("available_tabs = %v, want [README Routing Map]", tabs)
+	}
+}
+
 func TestExportFile_SheetWithoutSheetNameEmitsHint(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -179,6 +215,14 @@ func TestExportFile_SheetWithoutSheetNameEmitsHint(t *testing.T) {
 	}
 	if len(tabs) != 2 || tabs[0] != "README" || tabs[1] != "Routing Map" {
 		t.Errorf("available_tabs = %v, want [README Routing Map]", tabs)
+	}
+	data := res.Data.(map[string]any)
+	dataTabs, ok := data["available_tabs"].([]string)
+	if !ok {
+		t.Fatalf("data.available_tabs = %T, want []string", data["available_tabs"])
+	}
+	if len(dataTabs) != 2 || dataTabs[0] != "README" || dataTabs[1] != "Routing Map" {
+		t.Errorf("data.available_tabs = %v, want [README Routing Map]", dataTabs)
 	}
 }
 

--- a/internal/adapters/google/drive/adapter_test.go
+++ b/internal/adapters/google/drive/adapter_test.go
@@ -1,0 +1,202 @@
+package drive
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type staticOAuthProvider struct{}
+
+func (staticOAuthProvider) OAuthClientCredentials() (string, string) { return "id", "secret" }
+
+func newTestClient(srv *httptest.Server) *http.Client {
+	return &http.Client{Transport: rewriteTransport{base: srv.URL}}
+}
+
+type rewriteTransport struct{ base string }
+
+func (r rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	clone := req.Clone(req.Context())
+	clone.URL.Scheme = "http"
+	clone.URL.Host = strings.TrimPrefix(r.base, "http://")
+	return http.DefaultTransport.RoundTrip(clone)
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func TestExportFile_SheetTabByName(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/drive/v3/files/sheet-1":
+			writeJSON(w, map[string]any{"id": "sheet-1", "name": "Routing", "mimeType": sheetsMimeType})
+		case "/v4/spreadsheets/sheet-1":
+			writeJSON(w, map[string]any{
+				"sheets": []any{
+					map[string]any{"properties": map[string]any{"title": "README"}},
+					map[string]any{"properties": map[string]any{"title": "Routing Map"}},
+				},
+			})
+		case "/v4/spreadsheets/sheet-1/values/'Routing Map'":
+			writeJSON(w, map[string]any{
+				"range":  "Routing Map!A1:B2",
+				"values": [][]any{{"GP", "Sector"}, {"Alice", "Fintech"}},
+			})
+		default:
+			t.Errorf("unexpected request path: %s", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	a := New(staticOAuthProvider{})
+	res, err := a.exportFile(t.Context(), newTestClient(srv), map[string]any{
+		"file_id":    "sheet-1",
+		"mime_type":  "text/csv",
+		"sheet_name": "Routing Map",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data, ok := res.Data.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map data, got %T", res.Data)
+	}
+	if data["sheet_name"] != "Routing Map" {
+		t.Errorf("sheet_name = %v, want Routing Map", data["sheet_name"])
+	}
+	content, _ := data["content"].(string)
+	if !strings.Contains(content, "GP,Sector") || !strings.Contains(content, "Alice,Fintech") {
+		t.Errorf("content missing expected rows:\n%s", content)
+	}
+}
+
+// TestExportFile_SheetTabQuotesEmbeddedApostrophe verifies that a tab title
+// containing a single quote (e.g. "Q1'25") is escaped per A1 notation rules.
+func TestExportFile_SheetTabQuotesEmbeddedApostrophe(t *testing.T) {
+	var valuesHit string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/drive/v3/files/sheet-1":
+			writeJSON(w, map[string]any{"id": "sheet-1", "name": "Routing", "mimeType": sheetsMimeType})
+		case r.URL.Path == "/v4/spreadsheets/sheet-1":
+			writeJSON(w, map[string]any{
+				"sheets": []any{
+					map[string]any{"properties": map[string]any{"title": "Q1'25"}},
+				},
+			})
+		case strings.HasPrefix(r.URL.Path, "/v4/spreadsheets/sheet-1/values/"):
+			valuesHit = r.URL.Path
+			writeJSON(w, map[string]any{"values": [][]any{{"x"}}})
+		default:
+			t.Errorf("unexpected request path: %s", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	a := New(staticOAuthProvider{})
+	_, err := a.exportFile(t.Context(), newTestClient(srv), map[string]any{
+		"file_id":    "sheet-1",
+		"mime_type":  "text/csv",
+		"sheet_name": "Q1'25",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Expect range 'Q1''25' (single quote in title doubled), URL-encoded.
+	if !strings.HasSuffix(valuesHit, "/'Q1''25'") {
+		t.Errorf("values path = %q, want suffix /'Q1''25'", valuesHit)
+	}
+}
+
+func TestExportFile_RejectsSheetNameOnNonSheet(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/drive/v3/files/doc-1" {
+			writeJSON(w, map[string]any{"id": "doc-1", "name": "Memo", "mimeType": "application/vnd.google-apps.document"})
+			return
+		}
+		t.Errorf("unexpected request path: %s", r.URL.Path)
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	a := New(staticOAuthProvider{})
+	_, err := a.exportFile(t.Context(), newTestClient(srv), map[string]any{
+		"file_id":    "doc-1",
+		"mime_type":  "text/csv",
+		"sheet_name": "Sheet1",
+	})
+	if err == nil || !strings.Contains(err.Error(), "only supported when the source is a Google Sheet") {
+		t.Errorf("expected source-type error, got %v", err)
+	}
+}
+
+func TestExportFile_SheetWithoutSheetNameEmitsHint(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/drive/v3/files/sheet-1":
+			writeJSON(w, map[string]any{"id": "sheet-1", "name": "Routing", "mimeType": sheetsMimeType})
+		case "/drive/v3/files/sheet-1/export":
+			_, _ = w.Write([]byte("col1,col2\n"))
+		default:
+			t.Errorf("unexpected request path: %s", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	a := New(staticOAuthProvider{})
+	res, err := a.exportFile(t.Context(), newTestClient(srv), map[string]any{
+		"file_id":   "sheet-1",
+		"mime_type": "text/csv",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Meta == nil || res.Meta["hint"] == nil {
+		t.Fatal("expected meta.hint pointing at sheet_name")
+	}
+	hint, _ := res.Meta["hint"].(string)
+	if !strings.Contains(hint, "sheet_name") || !strings.Contains(hint, "first tab") {
+		t.Errorf("hint missing expected guidance: %q", hint)
+	}
+}
+
+func TestExportFile_UnknownSheetName(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/drive/v3/files/sheet-1":
+			writeJSON(w, map[string]any{"id": "sheet-1", "name": "Routing", "mimeType": sheetsMimeType})
+		case "/v4/spreadsheets/sheet-1":
+			writeJSON(w, map[string]any{
+				"sheets": []any{
+					map[string]any{"properties": map[string]any{"title": "README"}},
+					map[string]any{"properties": map[string]any{"title": "Routing Map"}},
+				},
+			})
+		default:
+			t.Errorf("unexpected request path: %s", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	a := New(staticOAuthProvider{})
+	_, err := a.exportFile(t.Context(), newTestClient(srv), map[string]any{
+		"file_id":    "sheet-1",
+		"mime_type":  "text/csv",
+		"sheet_name": "Nope",
+	})
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected not-found error listing available tabs, got %v", err)
+	}
+	if err != nil && !strings.Contains(err.Error(), "Routing Map") {
+		t.Errorf("expected error to list available tabs (got %v)", err)
+	}
+}

--- a/internal/adapters/google/drive/adapter_test.go
+++ b/internal/adapters/google/drive/adapter_test.go
@@ -144,6 +144,13 @@ func TestExportFile_SheetWithoutSheetNameEmitsHint(t *testing.T) {
 			writeJSON(w, map[string]any{"id": "sheet-1", "name": "Routing", "mimeType": sheetsMimeType})
 		case "/drive/v3/files/sheet-1/export":
 			_, _ = w.Write([]byte("col1,col2\n"))
+		case "/v4/spreadsheets/sheet-1":
+			writeJSON(w, map[string]any{
+				"sheets": []any{
+					map[string]any{"properties": map[string]any{"title": "README"}},
+					map[string]any{"properties": map[string]any{"title": "Routing Map"}},
+				},
+			})
 		default:
 			t.Errorf("unexpected request path: %s", r.URL.Path)
 			http.NotFound(w, r)
@@ -165,6 +172,13 @@ func TestExportFile_SheetWithoutSheetNameEmitsHint(t *testing.T) {
 	hint, _ := res.Meta["hint"].(string)
 	if !strings.Contains(hint, "sheet_name") || !strings.Contains(hint, "first tab") {
 		t.Errorf("hint missing expected guidance: %q", hint)
+	}
+	tabs, ok := res.Meta["available_tabs"].([]string)
+	if !ok {
+		t.Fatalf("available_tabs = %T, want []string", res.Meta["available_tabs"])
+	}
+	if len(tabs) != 2 || tabs[0] != "README" || tabs[1] != "Routing Map" {
+		t.Errorf("available_tabs = %v, want [README Routing Map]", tabs)
 	}
 }
 


### PR DESCRIPTION
Adds a sheet_name parameter to google.drive export_file so agents can export a specific Google Sheets tab as CSV or TSV. The Drive adapter validates the source file and tab name, reads tab values through the Sheets API, serializes them with CSV/TSV escaping, and keeps the existing first-tab export path. Google Sheets get_file responses and first-tab CSV/TSV export data now include available_tabs when Sheets metadata is available, so agents can choose the exact tab instead of guessing names. Adds focused Drive adapter tests for tab discovery, named tabs, quoted tab names, invalid source types, hints with available tabs, and unknown tabs. Tested with go test ./... .