### PR TITLE
fix(llmproxy): extend inline task approval hold lifetime

### DIFF
--- a/internal/api/handlers/tasks_inline.go
+++ b/internal/api/handlers/tasks_inline.go
@@ -114,7 +114,13 @@ func (h *TasksHandler) createInlineApprovedTask(ctx context.Context, agent *stor
 	}
 	requiredCredentials := req.RequiredCredentials
 
-	now := time.Now().UTC()
+	// createInlineApprovedTask is only invoked from the release path
+	// (resolveInlineTaskApproval, after the user's "approve" gesture)
+	// or from the auto-approve gate (which constitutes approval — no
+	// user gesture, but creation is the approval). In both cases
+	// "now" is approval time, not hold time. Name it accordingly so
+	// the scope-lifetime computation below is unambiguous.
+	approvedAt := time.Now().UTC()
 	task := &store.Task{
 		ID:                     uuid.New().String(),
 		UserID:                 agent.UserID,
@@ -127,10 +133,21 @@ func (h *TasksHandler) createInlineApprovedTask(ctx context.Context, agent *stor
 		SchemaVersion:          env.SchemaVersion,
 		ExpiresInSeconds:       expiresIn,
 		ApprovalSource:         "inline_chat",
-		ApprovedAt:             &now,
+		ApprovedAt:             &approvedAt,
 	}
 	if lifetime != "standing" {
-		expiresAt := now.Add(time.Duration(expiresIn) * time.Second)
+		// Task scope lifetime once approved. expires_in_seconds is
+		// "usable scope after the user approves," not "time to
+		// decide" — the awaiting_task_approval hold (see
+		// inlineTaskApprovalHoldTTL) owns the decide window. So
+		// regardless of how long the approval took to land, the
+		// caller gets a full expiresIn of usable scope starting
+		// now. The most common runtime case is expiresIn falling
+		// back to task.default_expiry_seconds (config default
+		// 1800 → 30 minutes of post-approval scope); callers
+		// passing an explicit expires_in_seconds get exactly what
+		// they asked for.
+		expiresAt := approvedAt.Add(time.Duration(expiresIn) * time.Second)
 		task.ExpiresAt = &expiresAt
 	}
 	if len(req.ExpectedTools) > 0 {
@@ -253,7 +270,7 @@ func (h *TasksHandler) createInlineApprovedTask(ctx context.Context, agent *stor
 	// (allow_session for session, allow_always for standing) to match
 	// what taskApprovalResolution returns for the dashboard path.
 	resolution := taskApprovalResolution(task)
-	rec, err := h.createCanonicalInlineApprovalRecord(ctx, task, resolution, now)
+	rec, err := h.createCanonicalInlineApprovalRecord(ctx, task, resolution, approvedAt)
 	if err != nil {
 		// Audit invariant: every active inline_chat task must have a
 		// matching approval_records row. Without that row, we'd leave

--- a/internal/runtime/llmproxy/inline_task_intercept.go
+++ b/internal/runtime/llmproxy/inline_task_intercept.go
@@ -14,12 +14,18 @@ import (
 	"github.com/clawvisor/clawvisor/pkg/store"
 )
 
-// inlineTaskApprovalTTL is how long the user has to type yes/no
-// after the model has emitted the task definition. Bounded so the second
-// gesture sits within the same approval cache window as the first; if
-// the user walks away mid-flight both holds expire together and the
-// model's next turn naturally re-prompts.
-const inlineTaskApprovalTTL = 10 * time.Minute
+// inlineTaskApprovalHoldTTL bounds how long an awaiting_task_approval
+// hold may sit in the cache before it's pruned. It is the decide
+// window only in the sense of "we won't keep this hold around
+// forever" — it does NOT cap the user's usable scope. The task's
+// scope lifetime is expires_in_seconds, applied at approval time
+// (see tasks_inline.go), so a generous decide window is safe:
+// regardless of how long the user takes to approve, they get a full
+// expires_in_seconds of usable scope starting from their "yes".
+//
+// 24h is chosen to comfortably cover an overnight decide gap while
+// still bounding stale-approval accumulation in the cache.
+const inlineTaskApprovalHoldTTL = 24 * time.Hour
 
 // InlineSurfaceQueryParam is the query-string flag the model adds to
 // POST /api/control/tasks to opt in to the inline-approval flow when there
@@ -290,7 +296,7 @@ func maybeInterceptInlineTaskDefinition(
 		Stage:          StageAwaitingTaskApproval,
 		TaskDefinition: parsed,
 		CreatedAt:      now,
-		ExpiresAt:      now.Add(inlineTaskApprovalTTL),
+		ExpiresAt:      now.Add(inlineTaskApprovalHoldTTL),
 	})
 	if holdErr != nil {
 		audit("block", "inline_task_hold_failed", holdErr.Error())

--- a/internal/runtime/llmproxy/pending_approval_cache.go
+++ b/internal/runtime/llmproxy/pending_approval_cache.go
@@ -342,31 +342,22 @@ func (c *MemoryPendingApprovalCache) findLocked(req ResolveRequest) (*PendingLit
 		}
 		return nil, -1, items
 	}
-	// Stage-filtered scan: callers that know which kind of hold they
-	// want (e.g. the inline-task release path) pass req.Stage so a
-	// stale tool-stage hold doesn't shadow the inline-task hold they
-	// care about. Scan from the END so the MOST RECENT matching hold
-	// wins — same LIFO rule the no-stage branch below uses. The two
-	// must agree: a user reply lands on the freshest prompt of its
-	// kind, never the oldest.
-	if req.Stage != "" {
-		for i := len(items) - 1; i >= 0; i-- {
-			if items[i].Stage == req.Stage {
-				pending := items[i]
-				return &pending, i, items
-			}
-		}
-		return nil, -1, items
-	}
-	// No ID, no stage filter — pick the MOST RECENT hold (items[-1]).
-	// The user is replying to the most recent approval prompt the
-	// harness rendered; resolving the oldest hold (FIFO) is
-	// counterintuitive and was a source of "I approved but nothing
-	// happened" bugs when one prompt sat unresolved while another
-	// arrived. Explicit-ID lookups (above) and Stage-filtered lookups
-	// are unaffected — they're scoped by construction.
+	// Bare reply (no explicit ApprovalID): only the absolute most
+	// recent hold qualifies. The user typing "approve" / "deny" /
+	// "task" is responding to the harness's LAST rendered prompt —
+	// not to anything older. If the newest hold's stage doesn't
+	// match a Stage filter the caller passed, the bare reply
+	// doesn't apply and we return no match rather than walking
+	// past the newest to find an older same-stage hold. Walking
+	// would let a stale older same-stage hold steal the user's
+	// response away from a newer different-stage prompt the user
+	// actually saw last — the opposite of "direct response to the
+	// last message."
 	idx := len(items) - 1
 	pending := items[idx]
+	if req.Stage != "" && pending.Stage != req.Stage {
+		return nil, -1, items
+	}
 	return &pending, idx, items
 }
 

--- a/internal/runtime/llmproxy/pending_approval_cache_redis.go
+++ b/internal/runtime/llmproxy/pending_approval_cache_redis.go
@@ -75,11 +75,28 @@ func (c *RedisPendingApprovalCache) Hold(ctx context.Context, pending PendingLit
 			evicted = &decoded
 		}
 	}
-	pipe := c.rdb.TxPipeline()
-	pipe.LPush(ctx, key, raw)
-	pipe.LTrim(ctx, key, 0, int64(max-1))
-	pipe.Expire(ctx, key, c.ttl)
-	if _, err := pipe.Exec(ctx); err != nil {
+	// Key TTL must be at least as long as the longest per-hold
+	// ExpiresAt currently sitting in the key — otherwise Redis evicts
+	// the entire list (and every hold in it) before its holds expire.
+	// c.ttl is the floor for holds that don't set their own ExpiresAt
+	// (most tool-stage holds); per-hold ExpiresAt may extend beyond
+	// that floor (inline-task approval holds use a 24h ExpiresAt to
+	// give the user an overnight decide window).
+	//
+	// The push+trim+ttl is one Lua script so the conditional-EXPIRE
+	// observes the same key state as the LPush — and so a sibling
+	// 10-min hold pushed onto a key that already has a 24h hold can't
+	// drop the key TTL below 24h.
+	keyTTL := c.ttl
+	if !pending.ExpiresAt.IsZero() {
+		if d := pending.ExpiresAt.Sub(now); d > keyTTL {
+			keyTTL = d
+		}
+	}
+	if _, err := redisPendingApprovalHoldScript.Run(
+		ctx, c.rdb, []string{key},
+		raw, max, keyTTL.Milliseconds(),
+	).Result(); err != nil && !errors.Is(err, redis.Nil) {
 		return HoldResult{}, err
 	}
 	return HoldResult{Pending: pending, Evicted: evicted}, nil
@@ -170,8 +187,14 @@ func (c *RedisPendingApprovalCache) find(ctx context.Context, req ResolveRequest
 			}
 			return &pending, raw, c.dropExpired(ctx, key, firstExpired)
 		}
+		// Bare reply: only the newest valid hold qualifies. If the
+		// caller passed a Stage filter and the newest's stage
+		// doesn't match, bail rather than walking back to find an
+		// older same-stage hold — the user's "approve" / "deny" /
+		// "task" pertains to the LAST prompt the harness rendered,
+		// not to a stale earlier one of the right shape.
 		if req.Stage != "" && pending.Stage != req.Stage {
-			continue
+			break
 		}
 		fallback = &pending
 		fallbackRaw = raw
@@ -210,6 +233,26 @@ func redisPendingApprovalRemovalMarker(now time.Time) string {
 	return "__clawvisor_removed_pending_approval__:" + now.UTC().Format(time.RFC3339Nano)
 }
 
+// redisPendingApprovalHoldScript performs LPush + LTrim + conditional
+// PEXPIRE atomically. The PEXPIRE only fires when it would EXTEND the
+// current TTL — never shorten it. Treats "no TTL" (-1) and "missing"
+// (-2) as zero so a freshly LPush'd key always gets an initial TTL.
+// (ExpireGT alone won't do this: it treats a no-TTL key as infinite
+// and thus refuses to set the first TTL.)
+var redisPendingApprovalHoldScript = redis.NewScript(`
+local key = KEYS[1]
+local raw = ARGV[1]
+local max_len = tonumber(ARGV[2])
+local target_ms = tonumber(ARGV[3])
+redis.call('LPUSH', key, raw)
+redis.call('LTRIM', key, 0, max_len - 1)
+local current_ms = redis.call('PTTL', key)
+if current_ms == -1 or current_ms == -2 or current_ms < target_ms then
+  redis.call('PEXPIRE', key, target_ms)
+end
+return 1
+`)
+
 var redisResolvePendingApprovalScript = redis.NewScript(`
 local key = KEYS[1]
 local approval_id = ARGV[1]
@@ -237,7 +280,16 @@ for i = 0, len - 1 do
 				redis.call('LREM', key, 1, marker)
 				return raw
 			end
-		elseif stage == '' or pending_stage == stage then
+		else
+			-- Bare reply: only the newest valid hold (the first
+			-- one we reach after skipping invalid JSON) qualifies.
+			-- If a Stage filter is set and this hold's stage
+			-- doesn't match, return nil rather than walking past
+			-- to find an older same-stage hold. Expired-by-
+			-- ExpiresAt is handled by the Go caller's retry loop.
+			if stage ~= '' and pending_stage ~= stage then
+				return nil
+			end
 			redis.call('LSET', key, i, marker)
 			redis.call('LREM', key, 1, marker)
 			return raw

--- a/internal/runtime/llmproxy/pending_approval_cache_test.go
+++ b/internal/runtime/llmproxy/pending_approval_cache_test.go
@@ -315,12 +315,14 @@ func TestPendingLiteApprovalCarriesNewFields(t *testing.T) {
 	}
 }
 
-// Two StageAwaitingTaskApproval holds alive at once must resolve LIFO
-// when a stage-filtered lookup runs without an ApprovalID. The user
-// is replying to the MOST RECENT inline prompt the harness rendered;
-// resolving the older one would silently land on stale state — the
-// same failure pattern the no-stage LIFO fix addressed, just in the
-// stage-filtered code path.
+// Two StageAwaitingTaskApproval holds alive at once must resolve to
+// the most recent one when a stage-filtered lookup runs without an
+// ApprovalID — the user's bare reply pertains to the harness's last
+// rendered prompt, so the newer of two same-stage prompts wins.
+// (Companion test below pins the stricter rule that drives this:
+// bare with a stage filter returns NOTHING when the newest hold's
+// stage doesn't match. Same-stage just happens to be a sub-case
+// where the newest also matches.)
 func TestMemoryPendingApprovalCache_StageFilteredLookupIsLIFO(t *testing.T) {
 	cache := NewMemoryPendingApprovalCache(time.Minute)
 	ctx := context.Background()
@@ -352,6 +354,61 @@ func TestMemoryPendingApprovalCache_StageFilteredLookupIsLIFO(t *testing.T) {
 		t.Fatalf("stage-filtered no-ID Peek returned %+v, want most recent %q", peeked, newer.Pending.ID)
 	}
 	_ = older
+}
+
+// Bare reply with a Stage filter must NOT walk past a newer
+// different-stage hold to find an older same-stage one. The user's
+// "approve" (no ID) is a direct response to the harness's last
+// rendered prompt — if that prompt was a tool-stage hold, an older
+// awaiting-task-approval hold can't claim the response. The user
+// must use the explicit ID form to target the older hold.
+func TestMemoryPendingApprovalCache_BareReplyDoesNotWalkPastNewest(t *testing.T) {
+	cache := NewMemoryPendingApprovalCache(time.Minute)
+	ctx := context.Background()
+
+	// Older inline-task hold sits in the cache first.
+	if _, err := cache.Hold(ctx, PendingLiteApproval{
+		ID: "cv-older-inline", UserID: "user-1", AgentID: "agent-1",
+		Provider: conversation.ProviderAnthropic, Stage: StageAwaitingTaskApproval,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// Newer tool-stage hold arrives — that's what the harness most
+	// recently prompted the user about.
+	if _, err := cache.Hold(ctx, PendingLiteApproval{
+		ID: "cv-newer-tool", UserID: "user-1", AgentID: "agent-1",
+		Provider: conversation.ProviderAnthropic, Stage: StageTool,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Bare peek with StageAwaitingTaskApproval filter: newest is
+	// StageTool → no match. Must NOT silently return the older
+	// inline hold.
+	got, err := cache.Peek(ctx, ResolveRequest{
+		UserID: "user-1", AgentID: "agent-1",
+		Provider: conversation.ProviderAnthropic,
+		Stage:    StageAwaitingTaskApproval,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Fatalf("bare stage-filtered peek returned %+v, want nil (newest hold's stage doesn't match filter)", got)
+	}
+
+	// Sanity: explicit-ID lookup still reaches the older inline hold.
+	got, err = cache.Peek(ctx, ResolveRequest{
+		UserID: "user-1", AgentID: "agent-1",
+		Provider:   conversation.ProviderAnthropic,
+		ApprovalID: "cv-older-inline",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil || got.ID != "cv-older-inline" {
+		t.Fatalf("explicit-ID peek = %+v, want cv-older-inline", got)
+	}
 }
 
 // TestMemoryPendingApprovalCacheScopesByConversationID guards the

--- a/internal/runtime/llmproxy/redis_stores_test.go
+++ b/internal/runtime/llmproxy/redis_stores_test.go
@@ -111,6 +111,73 @@ func TestRedisPendingApprovalCacheStageResolveLeavesOtherHolds(t *testing.T) {
 	}
 }
 
+// Bare reply with a Stage filter must NOT walk past a newer
+// different-stage hold to find an older same-stage one. Redis
+// counterpart to the memory cache's
+// TestMemoryPendingApprovalCache_BareReplyDoesNotWalkPastNewest —
+// the Lua-script bare branch and the Go find()'s bare branch must
+// agree: newest doesn't match → no match.
+func TestRedisPendingApprovalCache_BareReplyDoesNotWalkPastNewest(t *testing.T) {
+	cache := NewRedisPendingApprovalCache(testRedisClient(t), time.Minute)
+	ctx := context.Background()
+
+	if _, err := cache.Hold(ctx, PendingLiteApproval{
+		ID: "cv-older-inline", UserID: "user-1", AgentID: "agent-1",
+		Provider: conversation.ProviderAnthropic, Stage: StageAwaitingTaskApproval,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := cache.Hold(ctx, PendingLiteApproval{
+		ID: "cv-newer-tool", UserID: "user-1", AgentID: "agent-1",
+		Provider: conversation.ProviderAnthropic, Stage: StageTool,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Peek (Go find() branch).
+	got, err := cache.Peek(ctx, ResolveRequest{
+		UserID: "user-1", AgentID: "agent-1",
+		Provider: conversation.ProviderAnthropic,
+		Stage:    StageAwaitingTaskApproval,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Fatalf("bare stage-filtered Peek returned %+v, want nil", got)
+	}
+
+	// Resolve (Lua-script branch) — separate path, same rule.
+	got, err = cache.Resolve(ctx, ResolveRequest{
+		UserID: "user-1", AgentID: "agent-1",
+		Provider: conversation.ProviderAnthropic,
+		Stage:    StageAwaitingTaskApproval,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Fatalf("bare stage-filtered Resolve returned %+v, want nil", got)
+	}
+
+	// Both holds must still be in the cache — a no-match bare reply
+	// must not consume anything.
+	if got, _ := cache.Peek(ctx, ResolveRequest{
+		UserID: "user-1", AgentID: "agent-1",
+		Provider:   conversation.ProviderAnthropic,
+		ApprovalID: "cv-older-inline",
+	}); got == nil {
+		t.Fatal("older inline hold should still be in cache")
+	}
+	if got, _ := cache.Peek(ctx, ResolveRequest{
+		UserID: "user-1", AgentID: "agent-1",
+		Provider:   conversation.ProviderAnthropic,
+		ApprovalID: "cv-newer-tool",
+	}); got == nil {
+		t.Fatal("newer tool hold should still be in cache")
+	}
+}
+
 // TestRedisPendingApprovalCacheScopesByConversationID asserts the
 // redis-backed cache also partitions holds per conversation. Without
 // this, two Claude Code sessions sharing a token would collide on the
@@ -160,6 +227,57 @@ func TestRedisPendingApprovalCacheScopesByConversationID(t *testing.T) {
 	}
 	if resolvedB == nil || resolvedB.ID != "cv-B" {
 		t.Fatalf("conv-B resolved %+v, want cv-B", resolvedB)
+	}
+}
+
+// Hold's key TTL must honor per-hold ExpiresAt; otherwise the Redis
+// key (and every hold inside it) is evicted at c.ttl from the last
+// LPush, regardless of the longer ExpiresAt written into the JSON.
+func TestRedisPendingApprovalCacheHoldKeyTTLHonorsPerHoldExpiresAt(t *testing.T) {
+	rdb := testRedisClient(t)
+	cache := NewRedisPendingApprovalCache(rdb, 10*time.Minute)
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+	if _, err := cache.Hold(ctx, PendingLiteApproval{
+		ID:        "cv-long",
+		UserID:    "user-1",
+		AgentID:   "agent-1",
+		Provider:  conversation.ProviderAnthropic,
+		ExpiresAt: now.Add(24 * time.Hour),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	key := redisPendingApprovalKey("user-1", "agent-1", conversation.ProviderAnthropic, "")
+	ttl, err := rdb.PTTL(ctx, key).Result()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Floor: must exceed the cache's default c.ttl (10 min). We expect
+	// roughly 24h; allow generous slack for clock-tick variance.
+	if ttl < 23*time.Hour {
+		t.Fatalf("key PTTL = %v, want ≥ 23h (per-hold ExpiresAt was 24h)", ttl)
+	}
+
+	// A subsequent short-TTL hold pushed onto the same key must NOT
+	// shrink the existing 24h key TTL — otherwise the still-pending
+	// 24h hold would be evicted along with the key.
+	if _, err := cache.Hold(ctx, PendingLiteApproval{
+		ID:        "cv-short",
+		UserID:    "user-1",
+		AgentID:   "agent-1",
+		Provider:  conversation.ProviderAnthropic,
+		ExpiresAt: now.Add(2 * time.Minute),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	ttl, err = rdb.PTTL(ctx, key).Result()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ttl < 23*time.Hour {
+		t.Fatalf("after short-TTL Hold, key PTTL = %v, want ≥ 23h (sibling 24h hold must not be evicted)", ttl)
 	}
 }
 


### PR DESCRIPTION
Extends inline task approval holds to 24 hours while keeping task scope expiry anchored to approval time.

Updates pending approval cache routing so bare replies only target the newest hold, and teaches Redis to preserve key TTLs for longer per-hold expirations.

Adds memory and Redis cache tests for bare reply routing and Redis TTL behavior.

Tests: go test ./internal/runtime/llmproxy ./internal/api/handlers