### PR TITLE
revert(llmproxy): restore 10m TTL for inline approvals

### DIFF
--- a/internal/api/handlers/llm_endpoint.go
+++ b/internal/api/handlers/llm_endpoint.go
@@ -166,7 +166,7 @@ func NewLLMEndpointHandler(st store.Store, v vault.Vault, logger *slog.Logger) *
 		Forwarder:              llmproxy.NewForwarder(v),
 		Parsers:                conversation.DefaultRegistry(),
 		Logger:                 logger,
-		PendingApprovals:       llmproxy.NewMemoryPendingApprovalCache(1 * time.Minute), // TEMP: shortened for branch testing of expired-approval flow
+		PendingApprovals:       llmproxy.NewMemoryPendingApprovalCache(10 * time.Minute),
 		PendingSecrets:         llmproxy.NewMemoryPendingSecretDecisionCache(10 * time.Minute),
 		InlineApprovalOutcomes: llmproxy.NewMemoryInlineApprovalOutcomeStore(24 * time.Hour),
 		TaskCheckouts:          llmproxy.NewMemoryTaskCheckoutStore(24 * time.Hour),

--- a/internal/runtime/llmproxy/inline_task_intercept.go
+++ b/internal/runtime/llmproxy/inline_task_intercept.go
@@ -19,7 +19,7 @@ import (
 // gesture sits within the same approval cache window as the first; if
 // the user walks away mid-flight both holds expire together and the
 // model's next turn naturally re-prompts.
-const inlineTaskApprovalTTL = 1 * time.Minute // TEMP: shortened for branch testing of expired-approval flow
+const inlineTaskApprovalTTL = 10 * time.Minute
 
 // InlineSurfaceQueryParam is the query-string flag the model adds to
 // POST /api/control/tasks to opt in to the inline-approval flow when there


### PR DESCRIPTION
## Summary

PR #451 was reviewed with two TEMP commits still in the branch — they shortened the inline-approval cache TTL from 10 minutes to 1 minute so the new harness-shaped expired-approval message could be exercised quickly. This PR restores the 10-minute window on `main` so users have a reasonable time to act on approval prompts before they expire into the (now-friendly) "this approval is no longer valid" message.

Touches the same two constants the TEMP commits touched:
- `internal/api/handlers/llm_endpoint.go:169` — `NewMemoryPendingApprovalCache(10 * time.Minute)`
- `internal/runtime/llmproxy/inline_task_intercept.go:22` — `inlineTaskApprovalTTL = 10 * time.Minute`

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./internal/api/handlers/ ./internal/runtime/llmproxy/` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)