### PR TITLE
feat(cloudlogging): coalesce log lines under request entries in GCP Logs Explorer

### DIFF
--- a/internal/api/middleware/logging.go
+++ b/internal/api/middleware/logging.go
@@ -6,6 +6,8 @@ import (
 	"log/slog"
 	"net/http"
 	"time"
+
+	"github.com/clawvisor/clawvisor/pkg/cloudlogging"
 )
 
 type responseWriter struct {
@@ -39,10 +41,18 @@ func Logging(logger *slog.Logger) func(http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			start := time.Now()
 
-			traceID := generateTraceID()
+			// Prefer an upstream trace from X-Cloud-Trace-Context or W3C
+			// traceparent so log entries coalesce under the GCP request
+			// log in the Cloud Logs Explorer. Fall back to a locally
+			// generated ID so X-Trace-Id is always set.
+			traceID, spanID := cloudlogging.ExtractTrace(r)
+			if traceID == "" {
+				traceID = generateTraceID()
+			}
 			w.Header().Set("X-Trace-Id", traceID)
 
-			ctx, lf := WithLogFields(r.Context())
+			ctx := cloudlogging.WithTrace(r.Context(), traceID, spanID)
+			ctx, lf := WithLogFields(ctx)
 			r = r.WithContext(ctx)
 
 			rw := &responseWriter{ResponseWriter: w, status: http.StatusOK}

--- a/pkg/cloudlogging/cloudlogging.go
+++ b/pkg/cloudlogging/cloudlogging.go
@@ -1,0 +1,125 @@
+// Package cloudlogging adapts a slog handler for Google Cloud Logging, so
+// log entries that share a trace ID coalesce under the parent request entry
+// in the Logs Explorer.
+//
+// The Logs Explorer groups child entries beneath the request log when they
+// carry a matching logging.googleapis.com/trace field. This package supplies
+// an slog.Handler wrapper that injects that field (and spanId, when known)
+// from values placed on the context by the HTTP middleware.
+package cloudlogging
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+)
+
+// Field names recognised by Google Cloud Logging.
+const (
+	traceField  = "logging.googleapis.com/trace"
+	spanIDField = "logging.googleapis.com/spanId"
+)
+
+type ctxKey struct{}
+
+type traceCtx struct {
+	traceID string
+	spanID  string
+}
+
+// WithTrace returns a context carrying the given trace and span IDs. An empty
+// traceID returns ctx unchanged.
+func WithTrace(ctx context.Context, traceID, spanID string) context.Context {
+	if traceID == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, ctxKey{}, traceCtx{traceID: traceID, spanID: spanID})
+}
+
+// TraceFromContext returns the trace and span IDs stored on ctx, if any.
+func TraceFromContext(ctx context.Context) (traceID, spanID string, ok bool) {
+	if ctx == nil {
+		return "", "", false
+	}
+	tc, ok := ctx.Value(ctxKey{}).(traceCtx)
+	if !ok {
+		return "", "", false
+	}
+	return tc.traceID, tc.spanID, true
+}
+
+// ExtractTrace parses the trace ID and span ID from an incoming request.
+// It prefers the Google Cloud-specific X-Cloud-Trace-Context header and falls
+// back to the W3C traceparent header. Returns empty strings if neither is
+// present or parseable.
+func ExtractTrace(r *http.Request) (traceID, spanID string) {
+	if v := r.Header.Get("X-Cloud-Trace-Context"); v != "" {
+		// Format: TRACE_ID/SPAN_ID;o=OPTIONS
+		rest := v
+		if i := strings.Index(rest, ";"); i >= 0 {
+			rest = rest[:i]
+		}
+		if i := strings.Index(rest, "/"); i >= 0 {
+			return rest[:i], rest[i+1:]
+		}
+		return rest, ""
+	}
+	if v := r.Header.Get("traceparent"); v != "" {
+		// Format: VERSION-TRACE_ID-PARENT_ID-FLAGS
+		parts := strings.Split(v, "-")
+		if len(parts) >= 3 {
+			return parts[1], parts[2]
+		}
+	}
+	return "", ""
+}
+
+// Handler wraps another slog.Handler and adds trace fields recognised by
+// Google Cloud Logging when a trace is present on the record's context.
+type Handler struct {
+	inner     slog.Handler
+	projectID string
+}
+
+// NewHandler returns a Handler that augments inner with GCP trace fields.
+// projectID is the Google Cloud project ID (the trace field must be a fully
+// qualified name like "projects/PROJECT_ID/traces/TRACE_ID"). If projectID
+// is empty, the handler still emits the bare trace ID so entries correlate
+// in other viewers, but they will not group in the Cloud Logs Explorer.
+func NewHandler(inner slog.Handler, projectID string) *Handler {
+	return &Handler{inner: inner, projectID: projectID}
+}
+
+// Enabled reports whether the inner handler accepts records at the given level.
+func (h *Handler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.inner.Enabled(ctx, level)
+}
+
+// Handle injects trace fields from ctx and forwards to the inner handler.
+func (h *Handler) Handle(ctx context.Context, r slog.Record) error {
+	traceID, spanID, ok := TraceFromContext(ctx)
+	if !ok || traceID == "" {
+		return h.inner.Handle(ctx, r)
+	}
+	traceValue := traceID
+	if h.projectID != "" {
+		traceValue = fmt.Sprintf("projects/%s/traces/%s", h.projectID, traceID)
+	}
+	r.AddAttrs(slog.String(traceField, traceValue))
+	if spanID != "" {
+		r.AddAttrs(slog.String(spanIDField, spanID))
+	}
+	return h.inner.Handle(ctx, r)
+}
+
+// WithAttrs returns a new Handler whose inner handler has the given attributes.
+func (h *Handler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &Handler{inner: h.inner.WithAttrs(attrs), projectID: h.projectID}
+}
+
+// WithGroup returns a new Handler whose inner handler is in the given group.
+func (h *Handler) WithGroup(name string) slog.Handler {
+	return &Handler{inner: h.inner.WithGroup(name), projectID: h.projectID}
+}

--- a/pkg/cloudlogging/cloudlogging.go
+++ b/pkg/cloudlogging/cloudlogging.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
 )
 
@@ -52,28 +53,42 @@ func TraceFromContext(ctx context.Context) (traceID, spanID string, ok bool) {
 
 // ExtractTrace parses the trace ID and span ID from an incoming request.
 // It prefers the Google Cloud-specific X-Cloud-Trace-Context header and falls
-// back to the W3C traceparent header. Returns empty strings if neither is
-// present or parseable.
+// back to the W3C traceparent header. The returned spanID is always 16-char
+// hex (the form logging.googleapis.com/spanId expects); X-Cloud-Trace-Context
+// carries it in decimal, so it is converted here. Returns empty strings if
+// neither header is present or parseable.
 func ExtractTrace(r *http.Request) (traceID, spanID string) {
 	if v := r.Header.Get("X-Cloud-Trace-Context"); v != "" {
-		// Format: TRACE_ID/SPAN_ID;o=OPTIONS
+		// Format: TRACE_ID/SPAN_ID;o=OPTIONS — SPAN_ID is a decimal uint64.
 		rest := v
 		if i := strings.Index(rest, ";"); i >= 0 {
 			rest = rest[:i]
 		}
 		if i := strings.Index(rest, "/"); i >= 0 {
-			return rest[:i], rest[i+1:]
+			return rest[:i], decimalSpanIDToHex(rest[i+1:])
 		}
 		return rest, ""
 	}
 	if v := r.Header.Get("traceparent"); v != "" {
-		// Format: VERSION-TRACE_ID-PARENT_ID-FLAGS
+		// Format: VERSION-TRACE_ID-PARENT_ID-FLAGS — PARENT_ID is already
+		// 16-char hex, matching logging.googleapis.com/spanId.
 		parts := strings.Split(v, "-")
 		if len(parts) >= 3 {
 			return parts[1], parts[2]
 		}
 	}
 	return "", ""
+}
+
+// decimalSpanIDToHex converts an X-Cloud-Trace-Context decimal span ID into
+// the 16-char zero-padded hex form that logging.googleapis.com/spanId
+// expects. Returns "" if s is not a valid unsigned 64-bit decimal.
+func decimalSpanIDToHex(s string) string {
+	n, err := strconv.ParseUint(s, 10, 64)
+	if err != nil {
+		return ""
+	}
+	return fmt.Sprintf("%016x", n)
 }
 
 // Handler wraps another slog.Handler and adds trace fields recognised by

--- a/pkg/cloudlogging/cloudlogging_test.go
+++ b/pkg/cloudlogging/cloudlogging_test.go
@@ -11,11 +11,33 @@ import (
 
 func TestExtractTrace_CloudHeader(t *testing.T) {
 	req := httptest.NewRequest("GET", "/", nil)
+	// X-Cloud-Trace-Context span IDs are decimal; we must convert to the
+	// 16-char hex form logging.googleapis.com/spanId expects.
 	req.Header.Set("X-Cloud-Trace-Context", "abc123/456;o=1")
 
 	traceID, spanID := ExtractTrace(req)
-	if traceID != "abc123" || spanID != "456" {
+	if traceID != "abc123" || spanID != "00000000000001c8" {
 		t.Fatalf("got %q/%q", traceID, spanID)
+	}
+}
+
+func TestExtractTrace_CloudHeaderMaxSpanID(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("X-Cloud-Trace-Context", "abc/18446744073709551615")
+
+	_, spanID := ExtractTrace(req)
+	if spanID != "ffffffffffffffff" {
+		t.Fatalf("expected ffffffffffffffff, got %q", spanID)
+	}
+}
+
+func TestExtractTrace_CloudHeaderBadSpanID(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("X-Cloud-Trace-Context", "abc/notanumber")
+
+	traceID, spanID := ExtractTrace(req)
+	if traceID != "abc" || spanID != "" {
+		t.Fatalf("expected abc/'', got %q/%q", traceID, spanID)
 	}
 }
 
@@ -53,7 +75,7 @@ func TestHandler_InjectsTraceAndSpan(t *testing.T) {
 	h := NewHandler(inner, "my-project")
 	logger := slog.New(h)
 
-	ctx := WithTrace(context.Background(), "abc123", "456")
+	ctx := WithTrace(context.Background(), "abc123", "00000000000001c8")
 	logger.InfoContext(ctx, "hello")
 
 	var got map[string]any
@@ -63,7 +85,7 @@ func TestHandler_InjectsTraceAndSpan(t *testing.T) {
 	if got["logging.googleapis.com/trace"] != "projects/my-project/traces/abc123" {
 		t.Fatalf("trace field: %v", got["logging.googleapis.com/trace"])
 	}
-	if got["logging.googleapis.com/spanId"] != "456" {
+	if got["logging.googleapis.com/spanId"] != "00000000000001c8" {
 		t.Fatalf("span field: %v", got["logging.googleapis.com/spanId"])
 	}
 }

--- a/pkg/cloudlogging/cloudlogging_test.go
+++ b/pkg/cloudlogging/cloudlogging_test.go
@@ -1,0 +1,122 @@
+package cloudlogging
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestExtractTrace_CloudHeader(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("X-Cloud-Trace-Context", "abc123/456;o=1")
+
+	traceID, spanID := ExtractTrace(req)
+	if traceID != "abc123" || spanID != "456" {
+		t.Fatalf("got %q/%q", traceID, spanID)
+	}
+}
+
+func TestExtractTrace_CloudHeaderNoSpan(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("X-Cloud-Trace-Context", "abc123")
+
+	traceID, spanID := ExtractTrace(req)
+	if traceID != "abc123" || spanID != "" {
+		t.Fatalf("got %q/%q", traceID, spanID)
+	}
+}
+
+func TestExtractTrace_W3CTraceparent(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
+
+	traceID, spanID := ExtractTrace(req)
+	if traceID != "0af7651916cd43dd8448eb211c80319c" || spanID != "b7ad6b7169203331" {
+		t.Fatalf("got %q/%q", traceID, spanID)
+	}
+}
+
+func TestExtractTrace_None(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	traceID, spanID := ExtractTrace(req)
+	if traceID != "" || spanID != "" {
+		t.Fatalf("expected empty, got %q/%q", traceID, spanID)
+	}
+}
+
+func TestHandler_InjectsTraceAndSpan(t *testing.T) {
+	var buf bytes.Buffer
+	inner := slog.NewJSONHandler(&buf, nil)
+	h := NewHandler(inner, "my-project")
+	logger := slog.New(h)
+
+	ctx := WithTrace(context.Background(), "abc123", "456")
+	logger.InfoContext(ctx, "hello")
+
+	var got map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got["logging.googleapis.com/trace"] != "projects/my-project/traces/abc123" {
+		t.Fatalf("trace field: %v", got["logging.googleapis.com/trace"])
+	}
+	if got["logging.googleapis.com/spanId"] != "456" {
+		t.Fatalf("span field: %v", got["logging.googleapis.com/spanId"])
+	}
+}
+
+func TestHandler_NoTraceInContext(t *testing.T) {
+	var buf bytes.Buffer
+	h := NewHandler(slog.NewJSONHandler(&buf, nil), "my-project")
+	logger := slog.New(h)
+
+	logger.Info("hello")
+
+	var got map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := got["logging.googleapis.com/trace"]; ok {
+		t.Fatalf("did not expect trace field, got: %v", got)
+	}
+}
+
+func TestHandler_NoProjectIDEmitsBareTraceID(t *testing.T) {
+	var buf bytes.Buffer
+	h := NewHandler(slog.NewJSONHandler(&buf, nil), "")
+	logger := slog.New(h)
+
+	ctx := WithTrace(context.Background(), "abc123", "")
+	logger.InfoContext(ctx, "hello")
+
+	var got map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got["logging.googleapis.com/trace"] != "abc123" {
+		t.Fatalf("trace field: %v", got["logging.googleapis.com/trace"])
+	}
+}
+
+func TestHandler_WithAttrsAndGroup(t *testing.T) {
+	var buf bytes.Buffer
+	h := NewHandler(slog.NewJSONHandler(&buf, nil), "p")
+	logger := slog.New(h).With("svc", "test")
+
+	ctx := WithTrace(context.Background(), "t1", "s1")
+	logger.InfoContext(ctx, "hello", "k", "v")
+
+	var got map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got["svc"] != "test" || got["k"] != "v" {
+		t.Fatalf("missing attrs: %v", got)
+	}
+	if got["logging.googleapis.com/trace"] != "projects/p/traces/t1" {
+		t.Fatalf("trace field: %v", got["logging.googleapis.com/trace"])
+	}
+}


### PR DESCRIPTION
## Summary
- Add `pkg/cloudlogging`: an `slog.Handler` wrapper that stamps `logging.googleapis.com/trace` and `spanId` on records from a context value. Cloud Logs Explorer uses that field to group child entries beneath the request log.
- Export `ExtractTrace` (parses `X-Cloud-Trace-Context` and W3C `traceparent`), `WithTrace`, and `TraceFromContext` so HTTP middleware can seed the trace once per request.
- Update `middleware.Logging` to prefer an upstream trace ID (falling back to the locally generated one) and seed it onto the request context so downstream `*Context` log calls inherit it. `X-Trace-Id` continues to be set on every response.

## Behavior
- When the wrapping handler is applied (the cloud parent repo does this when `GOOGLE_CLOUD_PROJECT` is set), `logger.InfoContext(ctx, …)` calls in the request scope emit `logging.googleapis.com/trace=projects/<PROJECT>/traces/<TRACE_ID>` and coalesce under the Cloud Run request entry in the Logs Explorer.
- Plain `logger.Info(...)` calls without ctx are unchanged — they remain ungrouped. Nothing existing breaks.

## Test plan
- [x] `go test ./pkg/cloudlogging/...` covers both header formats, no-trace passthrough, empty-project bare-ID emission, and `WithAttrs`/`With` chains.
- [x] `go vet ./...` clean.
- [ ] After merge + cloud-side wiring, confirm in the GCP Logs Explorer that request logs from Cloud Run have a disclosure triangle grouping the application log lines beneath.

🤖 Generated with [Claude Code](https://claude.com/claude-code)