### PR TITLE
fix(llmproxy): stop re-firing approval release on stale OpenAI history

### DIFF
--- a/internal/runtime/conversation/approval_release_test.go
+++ b/internal/runtime/conversation/approval_release_test.go
@@ -103,3 +103,82 @@ func TestOpenAIApprovalReplyResponsesInputBareReplyUsesMarker(t *testing.T) {
 		t.Fatalf("verb=%q id=%q, want approve cv-dddddddddddd", verb, id)
 	}
 }
+
+func TestOpenAIApprovalReplyResponsesInputStaleAfterFunctionCallOutput(t *testing.T) {
+	// Regression: after the user's "y" is consumed and the released tool
+	// has run, the function_call_output item appears later in the input
+	// array than the "y". Subsequent inference requests still carry the
+	// "y" in history but it must NOT re-fire the release path, or the
+	// proxy will deny every follow-up with "approval no longer valid".
+	body := []byte(`{
+		"input": [
+			{"type": "message", "role": "user", "content": [{"type": "input_text", "text": "create some files"}]},
+			{"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": "paused [clawvisor:approval=cv-eeeeeeeeeeee]"}]},
+			{"type": "message", "role": "user", "content": [{"type": "input_text", "text": "y"}]},
+			{"type": "function_call", "name": "exec_command", "call_id": "call_1", "arguments": "{}"},
+			{"type": "function_call_output", "call_id": "call_1", "output": "ok"}
+		]
+	}`)
+	verb, id := OpenAIApprovalReply(body)
+	if verb != "" || id != "" {
+		t.Fatalf("verb=%q id=%q, want empty (release already happened)", verb, id)
+	}
+}
+
+func TestOpenAIApprovalReplyResponsesInputStaleAfterPendingFunctionCall(t *testing.T) {
+	// Defense: even if only a function_call (no output yet) has appeared
+	// after the "y", the model has already moved past the approval turn
+	// — the held call was released and the harness is about to execute
+	// it. Treat the "y" as stale rather than re-firing the release path.
+	body := []byte(`{
+		"input": [
+			{"type": "message", "role": "user", "content": [{"type": "input_text", "text": "create some files"}]},
+			{"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": "paused [clawvisor:approval=cv-ffffffffffff]"}]},
+			{"type": "message", "role": "user", "content": [{"type": "input_text", "text": "y"}]},
+			{"type": "function_call", "name": "exec_command", "call_id": "call_2", "arguments": "{}"}
+		]
+	}`)
+	verb, id := OpenAIApprovalReply(body)
+	if verb != "" || id != "" {
+		t.Fatalf("verb=%q id=%q, want empty (release already happened)", verb, id)
+	}
+}
+
+func TestOpenAIApprovalReplyResponsesInputStaleAfterCustomToolCall(t *testing.T) {
+	// custom_tool_call is a first-class input item type that Responses
+	// round-trips (see sanitizeResponsesItemForInput). A released custom
+	// tool call sitting after the user's "y" is the same staleness
+	// signal as function_call — the approval was already processed.
+	body := []byte(`{
+		"input": [
+			{"type": "message", "role": "user", "content": [{"type": "input_text", "text": "apply the patch"}]},
+			{"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": "paused [clawvisor:approval=cv-hhhhhhhhhhhh]"}]},
+			{"type": "message", "role": "user", "content": [{"type": "input_text", "text": "y"}]},
+			{"type": "custom_tool_call", "name": "apply_patch", "call_id": "ctc_1", "input": "*** Begin Patch\n*** End Patch\n"}
+		]
+	}`)
+	verb, id := OpenAIApprovalReply(body)
+	if verb != "" || id != "" {
+		t.Fatalf("verb=%q id=%q, want empty (release already happened)", verb, id)
+	}
+}
+
+func TestOpenAIApprovalReplyResponsesInputHeldCallBeforeReplyStillFires(t *testing.T) {
+	// Inverse of the stale case: when the held function_call sits BEFORE
+	// the "y" (the model emitted it on the prior turn, it was held, then
+	// the user replied), the release path must still fire. Only function
+	// calls appearing AFTER the user reply indicate the conversation
+	// moved past the approval.
+	body := []byte(`{
+		"input": [
+			{"type": "message", "role": "user", "content": [{"type": "input_text", "text": "create some files"}]},
+			{"type": "function_call", "name": "exec_command", "call_id": "call_3", "arguments": "{}"},
+			{"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": "paused [clawvisor:approval=cv-gggggggggggg]"}]},
+			{"type": "message", "role": "user", "content": [{"type": "input_text", "text": "y"}]}
+		]
+	}`)
+	verb, id := OpenAIApprovalReply(body)
+	if verb != "approve" || id != "cv-gggggggggggg" {
+		t.Fatalf("verb=%q id=%q, want approve cv-gggggggggggg", verb, id)
+	}
+}

--- a/internal/runtime/conversation/openai_request.go
+++ b/internal/runtime/conversation/openai_request.go
@@ -64,10 +64,37 @@ func OpenAIApprovalReply(body []byte) (verb, id string) {
 	if len(probe.Input) > 0 {
 		var items []openAIInputItem
 		if err := json.Unmarshal(probe.Input, &items); err == nil {
+			// Find the latest message,role=user. If a tool-call or
+			// tool-output item appears more recently than that user
+			// message, the conversation has already moved past the
+			// approval turn (the held call was approved, executed, and
+			// the model has spoken since) — the "y" is stale history,
+			// not a fresh release. Bail so we pass through to upstream
+			// instead of denying with "approval no longer valid".
+			//
+			// This mirrors Anthropic's natural shape: tool_result there
+			// is a role=user message whose flattened text is empty, so
+			// the existing latest-user-text scan silently goes quiet
+			// once a tool runs. The Responses API splits message and
+			// function_call_output into separate item types, so we have
+			// to skip past them explicitly to get the same behavior.
+			//
+			// custom_tool_call is included because Responses round-trips
+			// it as an input-acceptable item type (see
+			// sanitizeResponsesItemForInput); a released custom tool
+			// call sitting after the stale "y" would otherwise re-fire
+			// this scan the same way function_call did.
 			itemUserIdx := -1
 			for i := len(items) - 1; i >= 0; i-- {
-				if items[i].Type == "message" && items[i].Role == "user" {
-					itemUserIdx = i
+				switch items[i].Type {
+				case "function_call", "function_call_output", "custom_tool_call":
+					return "", ""
+				case "message":
+					if items[i].Role == "user" {
+						itemUserIdx = i
+					}
+				}
+				if itemUserIdx >= 0 {
 					break
 				}
 			}

--- a/internal/runtime/conversation/response_test.go
+++ b/internal/runtime/conversation/response_test.go
@@ -283,10 +283,15 @@ func TestOpenAIResponseRewriterBlocksResponsesFunctionCallSSE(t *testing.T) {
 func TestOpenAIToolResultIDsAndApprovalReply(t *testing.T) {
 	t.Parallel()
 
+	// function_call_output must precede the user approval reply: tool
+	// outputs only appear after a prior release, so a real conversation
+	// can't have one sitting AFTER the message that's now requesting a
+	// release. OpenAIApprovalReply treats a function_call_output after
+	// the latest user message as a signal the approval already happened.
 	responsesBody := []byte(`{
 	  "input":[
-	    {"type":"message","role":"user","content":[{"type":"input_text","text":"approve cv-abcdefghijklmnopqrstuvwxyz"}]},
-	    {"type":"function_call_output","call_id":"call_123","output":"ok"}
+	    {"type":"function_call_output","call_id":"call_123","output":"ok"},
+	    {"type":"message","role":"user","content":[{"type":"input_text","text":"approve cv-abcdefghijklmnopqrstuvwxyz"}]}
 	  ]
 	}`)
 	responsesReq, _ := http.NewRequest(http.MethodPost, "https://api.openai.com/v1/responses", nil)


### PR DESCRIPTION
## Summary
- OpenAI Responses approval-reply detector treated every conversation that still contained a `y` user message as a fresh release attempt, so once an inline approval was consumed every follow-up inference request was denied with "this approval is no longer valid" (observed with Codex against `cv-4bdssy3ahetadolo3thhm64yze`).
- Fix: in `OpenAIApprovalReply`'s Responses items scan, treat a `function_call`, `function_call_output`, or `custom_tool_call` appearing after the latest `message,role=user` as a signal the conversation has moved past the approval turn — mirrors Anthropic's natural shape, where `tool_result` is a `role=user` message whose flattened text is empty.
- Added regression tests for the function_call_output, pending function_call, and custom_tool_call staleness cases plus a "held-before-reply still fires" guard; reordered one existing test body whose item order wasn't reachable in a real conversation.

## Test plan
- [x] `go test ./internal/runtime/conversation ./internal/runtime/llmproxy ./pkg/runtime/proxy`
- [ ] Reproduce the original Codex scenario (inline task approval + follow-up tool call) and confirm no spurious "approval no longer valid" denial

🤖 Generated with [Claude Code](https://claude.com/claude-code)