### PR TITLE
fix(llmproxy): accept echo with any dashed argument

### DIFF
--- a/internal/runtime/llmproxy/inspector/readonly_bash.go
+++ b/internal/runtime/llmproxy/inspector/readonly_bash.go
@@ -190,6 +190,10 @@ func commandFlagsReadOnly(name string, args []*syntax.Word) bool {
 		return false
 	}
 	switch name {
+	case "echo":
+		// echo treats only -e/-n/-E (and combinations) as flags; everything
+		// else is printed literally. Any static argument is safe.
+		return true
 	case "date":
 		return dateArgsReadOnly(values)
 	case "find":
@@ -265,7 +269,6 @@ var readOnlyCommandOptions = map[string]optionSpec{
 	"tr":       {shortNoArg: "cdst", longNoArg: flagSet("complement", "delete", "squeeze-repeats", "truncate-set1", "help", "version"), operands: operandsAny},
 	"paste":    {shortNoArg: "sz", shortArg: "d", longNoArg: flagSet("serial", "zero-terminated", "help", "version"), longArg: flagSet("delimiters"), operands: operandsAny},
 	"col":      {shortNoArg: "bfhpx", operands: operandsAny},
-	"echo":     {shortNoArg: "enE", longNoArg: flagSet("help", "version"), operands: operandsAny},
 }
 
 func flagSet(names ...string) map[string]bool {

--- a/internal/runtime/llmproxy/inspector/readonly_bash_test.go
+++ b/internal/runtime/llmproxy/inspector/readonly_bash_test.go
@@ -31,6 +31,13 @@ func TestIsReadOnlyBashCommandAcceptsCommonReads(t *testing.T) {
 		"tail -40 README.md",
 		"ls /tmp | head -40",
 		"ls /tmp | tail -5",
+		"echo ---",
+		"echo -x",
+		"echo -- foo",
+		"echo --foo",
+		"echo --bar=baz",
+		"echo -en hi",
+		"echo -e hi",
 	}
 	for _, cmd := range cases {
 		t.Run(cmd, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- `echo`'s option spec in the read-only bash allowlist only accepted `-e`/`-n`/`-E` shorts and `--help`/`--version` longs, so `echo ---`, `echo -x`, `echo --foo`, `echo --bar=baz`, etc. were rejected as mutating flags and dropped out of the read-only path.
- Real bash `echo` only treats `-e`/`-n`/`-E` (and combinations) as flags and prints anything else literally, so any static argument is safe. Replaced the option spec with a `case "echo": return true` in `commandFlagsReadOnly`.
- Redirects, command/process substitution, and dynamic args are still caught upstream in the walk; only static literal arg validation is short-circuited.

## Test plan
- [x] `go test ./internal/runtime/llmproxy/...`
- [x] New positive cases added in `readonly_bash_test.go` covering `echo ---`, `echo -x`, `echo -- foo`, `echo --foo`, `echo --bar=baz`, `echo -en hi`, `echo -e hi`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)