### PR TITLE
chore(logging): migrate request-scoped log calls to *Context variants

### DIFF
--- a/internal/api/handlers/adaptergen.go
+++ b/internal/api/handlers/adaptergen.go
@@ -223,7 +223,7 @@ func (h *AdapterGenHandler) Create(w http.ResponseWriter, r *http.Request) {
 
 	result, err := h.generatorForRequest(r).Generate(r.Context(), src)
 	if err != nil {
-		h.logger.Warn("adapter generation failed", "err", err)
+		h.logger.WarnContext(r.Context(), "adapter generation failed", "err", err)
 		writeJSONResponse(w, http.StatusUnprocessableEntity, map[string]string{"error": err.Error()})
 		return
 	}
@@ -269,7 +269,7 @@ func (h *AdapterGenHandler) Update(w http.ResponseWriter, r *http.Request) {
 
 	result, err := h.generatorForRequest(r).Update(r.Context(), serviceID, src)
 	if err != nil {
-		h.logger.Warn("adapter update failed", "service_id", serviceID, "err", err)
+		h.logger.WarnContext(r.Context(), "adapter update failed", "service_id", serviceID, "err", err)
 		writeJSONResponse(w, http.StatusUnprocessableEntity, map[string]string{"error": err.Error()})
 		return
 	}
@@ -286,7 +286,7 @@ func (h *AdapterGenHandler) Remove(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.generatorForRequest(r).Remove(r.Context(), serviceID); err != nil {
-		h.logger.Warn("adapter removal failed", "service_id", serviceID, "err", err)
+		h.logger.WarnContext(r.Context(), "adapter removal failed", "service_id", serviceID, "err", err)
 		writeJSONResponse(w, http.StatusUnprocessableEntity, map[string]string{"error": err.Error()})
 		return
 	}
@@ -310,7 +310,7 @@ func (h *AdapterGenHandler) Install(w http.ResponseWriter, r *http.Request) {
 
 	result, err := h.generatorForRequest(r).Install(r.Context(), req.YAML)
 	if err != nil {
-		h.logger.Warn("adapter install failed", "err", err)
+		h.logger.WarnContext(r.Context(), "adapter install failed", "err", err)
 		writeJSONResponse(w, http.StatusUnprocessableEntity, map[string]string{"error": err.Error()})
 		return
 	}

--- a/internal/api/handlers/agents.go
+++ b/internal/api/handlers/agents.go
@@ -288,7 +288,7 @@ func (h *AgentsHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	// Revoke all active/pending tasks for this agent before deleting.
 	revokedCount, err := h.st.RevokeTasksByAgent(ctx, id, user.ID)
 	if err != nil {
-		h.logger.Warn("failed to revoke tasks for agent", "err", err, "agent_id", id)
+		h.logger.WarnContext(ctx, "failed to revoke tasks for agent", "err", err, "agent_id", id)
 	}
 
 	if err := h.st.DeleteAgent(ctx, id, user.ID); err != nil {

--- a/internal/api/handlers/approvals.go
+++ b/internal/api/handlers/approvals.go
@@ -219,7 +219,7 @@ func (h *ApprovalsHandler) Approve(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusConflict, "ALREADY_RESOLVED", "this approval is no longer pending — refresh to see the current state")
 			return
 		}
-		h.logger.Error("failed to approve pending request", "request_id", requestID, "resolution", resolution, "err", err)
+		h.logger.ErrorContext(r.Context(), "failed to approve pending request", "request_id", requestID, "resolution", resolution, "err", err)
 		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not approve pending request")
 		return
 	}
@@ -288,7 +288,7 @@ func (h *ApprovalsHandler) ApproveByRequestID(ctx context.Context, requestID, us
 func (h *ApprovalsHandler) revertOrTerminate(ctx context.Context, pa *store.PendingApproval, reason string) {
 	won, err := h.st.UpdatePendingApprovalStatusFrom(ctx, pa.RequestID, pa.UserID, paTaskID(pa), "approved", pa.Status)
 	if err != nil {
-		h.logger.Error("failed to revert approval status",
+		h.logger.ErrorContext(ctx, "failed to revert approval status",
 			"request_id", pa.RequestID, "reason", reason, "err", err)
 		return
 	}
@@ -300,7 +300,7 @@ func (h *ApprovalsHandler) revertOrTerminate(ctx context.Context, pa *store.Pend
 	// approval to a terminal "denied" state so it doesn't stay pending in
 	// the dashboard. The pending_approvals row itself will be cleaned up
 	// by the lease-recovery sweeper.
-	h.logger.Warn("approval revert lost CAS; forcing canonical resolution",
+	h.logger.WarnContext(ctx, "approval revert lost CAS; forcing canonical resolution",
 		"request_id", pa.RequestID, "reason", reason)
 	h.resolveCanonicalApproval(ctx, pa, "deny", "denied")
 }
@@ -325,7 +325,7 @@ var errApprovalAlreadyResolved = errors.New("approval is no longer pending")
 func (h *ApprovalsHandler) markApproved(ctx context.Context, pa *store.PendingApproval, resolution string) (*store.Task, error) {
 	won, err := h.st.UpdatePendingApprovalStatusFrom(ctx, pa.RequestID, pa.UserID, paTaskID(pa), "pending", "approved")
 	if err != nil {
-		h.logger.Error("failed to update approval status", "request_id", pa.RequestID, "err", err)
+		h.logger.ErrorContext(ctx, "failed to update approval status", "request_id", pa.RequestID, "err", err)
 		return nil, err
 	}
 	if !won {
@@ -346,7 +346,7 @@ func (h *ApprovalsHandler) markApproved(ctx context.Context, pa *store.PendingAp
 	}
 	h.resolveCanonicalApproval(ctx, pa, resolution, "approved")
 	if err := h.st.UpdateAuditOutcome(ctx, pa.AuditID, "approved", "", 0); err != nil {
-		h.logger.Error("failed to update audit outcome", "audit_id", pa.AuditID, "err", err)
+		h.logger.ErrorContext(ctx, "failed to update audit outcome", "audit_id", pa.AuditID, "err", err)
 	}
 
 	notifyText := "✅ <b>Approved</b> — waiting for agent to execute."
@@ -423,10 +423,10 @@ func (h *ApprovalsHandler) DenyByRequestID(ctx context.Context, requestID, userI
 
 	h.resolveCanonicalApproval(ctx, pa, "deny", "denied")
 	if err := h.st.UpdateAuditOutcome(ctx, pa.AuditID, "denied", "", 0); err != nil {
-		h.logger.Error("failed to update audit outcome", "audit_id", pa.AuditID, "err", err)
+		h.logger.ErrorContext(ctx, "failed to update audit outcome", "audit_id", pa.AuditID, "err", err)
 	}
 	if err := h.st.DeletePendingApproval(ctx, requestID, userID, taskID); err != nil {
-		h.logger.Error("failed to delete pending approval", "request_id", requestID, "err", err)
+		h.logger.ErrorContext(ctx, "failed to delete pending approval", "request_id", requestID, "err", err)
 	}
 
 	h.updateNotificationMsg(ctx, "approval", approvalNotifyTargetID(requestID, taskID), pa.UserID, "❌ <b>Denied</b> — request rejected.")
@@ -486,10 +486,10 @@ func (h *ApprovalsHandler) Deny(w http.ResponseWriter, r *http.Request) {
 
 	h.resolveCanonicalApproval(r.Context(), pa, "deny", "denied")
 	if err := h.st.UpdateAuditOutcome(r.Context(), pa.AuditID, "denied", "", 0); err != nil {
-		h.logger.Error("failed to update audit outcome", "audit_id", pa.AuditID, "err", err)
+		h.logger.ErrorContext(r.Context(), "failed to update audit outcome", "audit_id", pa.AuditID, "err", err)
 	}
 	if err := h.st.DeletePendingApproval(r.Context(), requestID, user.ID, taskID); err != nil {
-		h.logger.Error("failed to delete pending approval", "request_id", requestID, "err", err)
+		h.logger.ErrorContext(r.Context(), "failed to delete pending approval", "request_id", requestID, "err", err)
 	}
 
 	h.updateNotificationMsg(r.Context(), "approval", approvalNotifyTargetID(requestID, taskID), pa.UserID, "❌ <b>Denied</b> — request rejected.")
@@ -537,10 +537,10 @@ func (h *ApprovalsHandler) executeApproval(ctx context.Context, pa *store.Pendin
 	}
 
 	if err := h.st.UpdateAuditOutcome(ctx, pa.AuditID, outcome, errMsg, dur); err != nil {
-		h.logger.Error("failed to update audit outcome", "audit_id", pa.AuditID, "err", err)
+		h.logger.ErrorContext(ctx, "failed to update audit outcome", "audit_id", pa.AuditID, "err", err)
 	}
 	if err := h.st.DeletePendingApproval(ctx, pa.RequestID, pa.UserID, paTaskID(pa)); err != nil {
-		h.logger.Error("failed to delete pending approval", "request_id", pa.RequestID, "err", err)
+		h.logger.ErrorContext(ctx, "failed to delete pending approval", "request_id", pa.RequestID, "err", err)
 	}
 
 	notifyText := "✅ <b>Approved</b> — request executed."
@@ -632,13 +632,13 @@ func (h *ApprovalsHandler) processExpiredApproval(ctx context.Context, pa *store
 	}
 	h.decrementNotifierPolling(pa.UserID)
 	h.publishQueueAndAudit(pa.UserID, pa.AuditID)
-	h.logger.Info("pending approval expired", "request_id", pa.RequestID, "reason", reason)
+	h.logger.InfoContext(ctx, "pending approval expired", "request_id", pa.RequestID, "reason", reason)
 }
 
 func (h *ApprovalsHandler) expireTimedOut(ctx context.Context) {
 	expired, err := h.st.ListExpiredPendingApprovals(ctx)
 	if err != nil {
-		h.logger.Warn("expiry cleanup: list failed", "err", err)
+		h.logger.WarnContext(ctx, "expiry cleanup: list failed", "err", err)
 		return
 	}
 	for _, pa := range expired {
@@ -657,21 +657,21 @@ func (h *ApprovalsHandler) expireTimedOut(ctx context.Context) {
 	// resolver wins.
 	stalled, err := h.st.ListStalledExecutingApprovals(ctx, executingLeaseTTL)
 	if err != nil {
-		h.logger.Warn("expiry cleanup: stalled-executing list failed", "err", err)
+		h.logger.WarnContext(ctx, "expiry cleanup: stalled-executing list failed", "err", err)
 	} else {
 		for _, pa := range stalled {
 			won, err := h.st.ClaimStalledExecutingApprovalForRecovery(ctx, pa.RequestID, pa.UserID, paTaskID(pa), executingLeaseTTL)
 			if err != nil {
-				h.logger.Warn("expiry cleanup: stalled-executing claim failed", "request_id", pa.RequestID, "err", err)
+				h.logger.WarnContext(ctx, "expiry cleanup: stalled-executing claim failed", "request_id", pa.RequestID, "err", err)
 				continue
 			}
 			if !won {
 				// The executor finished between list and claim — it has
 				// already delivered an "executed" callback. Do nothing.
-				h.logger.Debug("stalled approval finished before recovery sweep", "request_id", pa.RequestID)
+				h.logger.DebugContext(ctx, "stalled approval finished before recovery sweep", "request_id", pa.RequestID)
 				continue
 			}
-			h.logger.Warn("recovered stalled executing approval", "request_id", pa.RequestID, "user_id", pa.UserID)
+			h.logger.WarnContext(ctx, "recovered stalled executing approval", "request_id", pa.RequestID, "user_id", pa.UserID)
 			h.processExpiredApproval(ctx, pa, "stranded", "⏰ <b>Recovered</b> — execution lease expired.")
 		}
 	}
@@ -679,7 +679,7 @@ func (h *ApprovalsHandler) expireTimedOut(ctx context.Context) {
 	// Expire timed-out tasks.
 	expiredTasks, err := h.st.ListExpiredTasks(ctx)
 	if err != nil {
-		h.logger.Warn("task expiry cleanup: list failed", "err", err)
+		h.logger.WarnContext(ctx, "task expiry cleanup: list failed", "err", err)
 		return
 	}
 	for _, task := range expiredTasks {
@@ -699,7 +699,7 @@ func (h *ApprovalsHandler) expireTimedOut(ctx context.Context) {
 		}
 		h.decrementNotifierPolling(task.UserID)
 		h.publishTasksAndQueue(task.UserID)
-		h.logger.Info("task expired", "task_id", task.ID)
+		h.logger.InfoContext(ctx, "task expired", "task_id", task.ID)
 	}
 }
 
@@ -723,18 +723,18 @@ func (h *ApprovalsHandler) resolveCanonicalApproval(ctx context.Context, pa *sto
 		loaded, err := h.st.GetApprovalRecord(ctx, *approvalID)
 		if err != nil {
 			if !errors.Is(err, store.ErrNotFound) {
-				h.logger.Error("failed to load canonical approval before resolve", "approval_id", *approvalID, "request_id", pa.RequestID, "err", err)
+				h.logger.ErrorContext(ctx, "failed to load canonical approval before resolve", "approval_id", *approvalID, "request_id", pa.RequestID, "err", err)
 			}
 			return
 		}
 		rec = loaded
 	}
 	if err := validateApprovalRecordTransition(rec, resolution, status); err != nil {
-		h.logger.Error("illegal canonical approval transition", "approval_id", rec.ID, "request_id", pa.RequestID, "kind", rec.Kind, "from_status", rec.Status, "resolution", resolution, "status", status, "err", err)
+		h.logger.ErrorContext(ctx, "illegal canonical approval transition", "approval_id", rec.ID, "request_id", pa.RequestID, "kind", rec.Kind, "from_status", rec.Status, "resolution", resolution, "status", status, "err", err)
 		return
 	}
 	if err := h.st.ResolveApprovalRecord(ctx, *approvalID, resolution, status, time.Now().UTC()); err != nil && !errors.Is(err, store.ErrNotFound) {
-		h.logger.Error("failed to resolve canonical approval", "approval_id", *approvalID, "request_id", pa.RequestID, "err", err)
+		h.logger.ErrorContext(ctx, "failed to resolve canonical approval", "approval_id", *approvalID, "request_id", pa.RequestID, "err", err)
 	}
 }
 
@@ -828,7 +828,7 @@ func (h *ApprovalsHandler) promotePendingApprovalToTask(ctx context.Context, pa 
 			UserID:    task.UserID,
 		})
 		if err != nil {
-			h.logger.Warn("task risk assessment failed for promoted request task", "request_id", pa.RequestID, "err", err)
+			h.logger.WarnContext(ctx, "task risk assessment failed for promoted request task", "request_id", pa.RequestID, "err", err)
 		} else if assessment != nil {
 			task.RiskLevel = assessment.RiskLevel
 			task.RiskDetails = taskrisk.MarshalAssessment(assessment)
@@ -892,6 +892,6 @@ func (h *ApprovalsHandler) updateNotificationMsg(ctx context.Context, targetType
 		return
 	}
 	if err := h.notifier.UpdateMessage(ctx, userID, msgID, text); err != nil {
-		h.logger.Warn("telegram message update failed", "err", err, "target_type", targetType, "target_id", targetID)
+		h.logger.WarnContext(ctx, "telegram message update failed", "err", err, "target_type", targetType, "target_id", targetID)
 	}
 }

--- a/internal/api/handlers/async.go
+++ b/internal/api/handlers/async.go
@@ -146,7 +146,7 @@ func (d *CallbackDispatcher) deliverOne(job callbackJob) {
 	cbCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	if err := callback.DeliverResult(cbCtx, job.url, job.payload, job.signingKey); err != nil && d.logger != nil {
-		d.logger.Warn("callback delivery failed",
+		d.logger.WarnContext(cbCtx, "callback delivery failed",
 			"url", job.url,
 			"request_id", job.payload.RequestID,
 			"task_id", job.payload.TaskID,

--- a/internal/api/handlers/connections.go
+++ b/internal/api/handlers/connections.go
@@ -246,7 +246,7 @@ func (h *ConnectionsHandler) RequestConnect(w http.ResponseWriter, r *http.Reque
 			ApproveURL:   approveURL,
 			DenyURL:      denyURL,
 		}); err != nil {
-			h.logger.Warn("failed to send connection request notification", "err", err)
+			h.logger.WarnContext(r.Context(), "failed to send connection request notification", "err", err)
 		} else if msgID != "" {
 			_ = h.st.SaveNotificationMessage(r.Context(), "connection", req.ID, "telegram", msgID)
 		}
@@ -720,7 +720,7 @@ func (h *ConnectionsHandler) updateNotificationMsg(ctx context.Context, targetID
 		return
 	}
 	if err := h.notifier.UpdateMessage(ctx, userID, msgID, text); err != nil {
-		h.logger.Warn("telegram message update failed", "err", err, "target_type", "connection", "target_id", targetID)
+		h.logger.WarnContext(ctx, "telegram message update failed", "err", err, "target_type", "connection", "target_id", targetID)
 	}
 }
 

--- a/internal/api/handlers/devices.go
+++ b/internal/api/handlers/devices.go
@@ -225,7 +225,7 @@ func (h *DevicesHandler) CompletePairing(w http.ResponseWriter, r *http.Request)
 	// Register with push service if available.
 	if h.pushN != nil {
 		if err := h.pushN.RegisterDevice(r.Context(), body.DeviceToken, bundleID); err != nil {
-			h.logger.Warn("failed to register device with push service", "err", err)
+			h.logger.WarnContext(r.Context(), "failed to register device with push service", "err", err)
 		}
 	}
 
@@ -283,7 +283,7 @@ func (h *DevicesHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	// Deregister from push service before deleting.
 	if h.pushN != nil {
 		if err := h.pushN.DeregisterDevice(r.Context(), device.DeviceToken); err != nil {
-			h.logger.Warn("failed to deregister device from push service", "err", err)
+			h.logger.WarnContext(r.Context(), "failed to deregister device from push service", "err", err)
 		}
 	}
 
@@ -371,7 +371,7 @@ func (h *DevicesHandler) UpdatePushToStartToken(w http.ResponseWriter, r *http.R
 
 	// Register the token with the push service so the daemon is authorized to send live activities to it.
 	if err := h.pushN.RegisterPushToStartToken(r.Context(), body.PushToStartToken); err != nil {
-		h.logger.Warn("failed to register push-to-start token with push service", "err", err)
+		h.logger.WarnContext(r.Context(), "failed to register push-to-start token with push service", "err", err)
 	}
 
 	_ = h.st.UpdatePairedDeviceLastSeen(r.Context(), device.ID)
@@ -416,7 +416,7 @@ func (h *DevicesHandler) MintToken(w http.ResponseWriter, r *http.Request) {
 	// Look up the user to get their email for the JWT claims.
 	user, err := h.st.GetUserByID(r.Context(), device.UserID)
 	if err != nil {
-		h.logger.Error("mint device token: user lookup failed", "device_id", device.ID, "user_id", device.UserID, "error", err)
+		h.logger.ErrorContext(r.Context(), "mint device token: user lookup failed", "device_id", device.ID, "user_id", device.UserID, "error", err)
 		writeError(w, http.StatusInternalServerError, "TOKEN_ERROR", "failed to resolve user")
 		return
 	}
@@ -424,7 +424,7 @@ func (h *DevicesHandler) MintToken(w http.ResponseWriter, r *http.Request) {
 	const tokenTTL = 5 * time.Minute
 	token, err := h.jwtSvc.GenerateAccessToken(user.ID, user.Email, tokenTTL)
 	if err != nil {
-		h.logger.Error("mint device token failed", "device_id", device.ID, "error", err)
+		h.logger.ErrorContext(r.Context(), "mint device token failed", "device_id", device.ID, "error", err)
 		writeError(w, http.StatusInternalServerError, "TOKEN_ERROR", "failed to generate token")
 		return
 	}

--- a/internal/api/handlers/feedback.go
+++ b/internal/api/handlers/feedback.go
@@ -97,7 +97,7 @@ func (h *FeedbackHandler) ReportBug(w http.ResponseWriter, r *http.Request) {
 		AgentName:   agent.Name,
 	})
 	if err != nil {
-		h.logger.Error("feedback review failed", "err", err)
+		h.logger.ErrorContext(ctx, "feedback review failed", "err", err)
 		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to review report")
 		return
 	}
@@ -118,12 +118,12 @@ func (h *FeedbackHandler) ReportBug(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.store.CreateFeedbackReport(ctx, report); err != nil {
-		h.logger.Error("failed to save feedback report", "err", err)
+		h.logger.ErrorContext(ctx, "failed to save feedback report", "err", err)
 		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to save report")
 		return
 	}
 
-	h.logger.Info("agent feedback report submitted",
+	h.logger.InfoContext(ctx, "agent feedback report submitted",
 		"report_id", report.ID,
 		"agent_id", agent.ID,
 		"category", reviewResult.Category,
@@ -183,12 +183,12 @@ func (h *FeedbackHandler) SubmitNPS(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.store.SaveNPSResponse(ctx, nps); err != nil {
-		h.logger.Error("failed to save NPS response", "err", err)
+		h.logger.ErrorContext(ctx, "failed to save NPS response", "err", err)
 		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to save response")
 		return
 	}
 
-	h.logger.Info("agent NPS response submitted",
+	h.logger.InfoContext(ctx, "agent NPS response submitted",
 		"agent_id", agent.ID,
 		"score", req.Score,
 	)

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -237,7 +237,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 
 	if req.Context.CallbackURL != "" {
 		if err := callback.ValidateCallbackURL(req.Context.CallbackURL); err != nil {
-			h.logger.Warn("callback URL blocked by SSRF policy",
+			h.logger.WarnContext(ctx, "callback URL blocked by SSRF policy",
 				"callback_url", req.Context.CallbackURL,
 				"err", err,
 				"agent_id", agent.ID,
@@ -311,7 +311,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			Outcome:    outOutcome,
 			DurationMS: int(time.Since(start).Milliseconds()),
 		}); logErr != nil {
-			h.logger.Warn("backup request log failed", "err", logErr)
+			h.logger.WarnContext(ctx, "backup request log failed", "err", logErr)
 		}
 	}()
 
@@ -345,7 +345,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			e := baseEntry("block", "blocked", nil)
 			e.DurationMS = int(time.Since(start).Milliseconds())
 			if logErr := h.store.LogAudit(ctx, e); logErr != nil {
-				h.logger.Warn("audit log failed", "err", logErr)
+				h.logger.WarnContext(ctx, "audit log failed", "err", logErr)
 			}
 			h.publishAuditAndQueue(agent.UserID, "")
 			resp := map[string]any{
@@ -380,7 +380,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 		}
 		e.DurationMS = int(time.Since(start).Milliseconds())
 		if logErr := h.store.LogAudit(ctx, e); logErr != nil {
-			h.logger.Warn("audit log failed", "err", logErr)
+			h.logger.WarnContext(ctx, "audit log failed", "err", logErr)
 		}
 		h.publishAuditAndQueue(agent.UserID, "")
 		reason := ""
@@ -425,7 +425,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			errMsg := "missing required field: task_id"
 			e.ErrorMsg = &errMsg
 			if logErr := h.store.LogAudit(ctx, e); logErr != nil {
-				h.logger.Warn("audit log failed", "err", logErr)
+				h.logger.WarnContext(ctx, "audit log failed", "err", logErr)
 			}
 			writeDetailedError(w, http.StatusBadRequest, apiErrorDetail{
 				Error:         errMsg,
@@ -458,7 +458,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 				Params:         req.Params,
 			})
 			if resolveErr != nil {
-				h.logger.Warn("gateway request resolver failed", "err", resolveErr, "service", serviceType, "action", req.Action, "request_id", req.RequestID)
+				h.logger.WarnContext(ctx, "gateway request resolver failed", "err", resolveErr, "service", serviceType, "action", req.Action, "request_id", req.RequestID)
 			} else {
 				classification = resolved
 			}
@@ -472,7 +472,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			errMsg := "request matches multiple active tasks; specify task_id explicitly"
 			e.ErrorMsg = &errMsg
 			if logErr := h.store.LogAudit(ctx, e); logErr != nil {
-				h.logger.Warn("audit log failed", "err", logErr)
+				h.logger.WarnContext(ctx, "audit log failed", "err", logErr)
 			}
 			h.publishAuditAndQueue(agent.UserID, "")
 			resp := map[string]any{
@@ -494,7 +494,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			e.DurationMS = int(time.Since(start).Milliseconds())
 			winner, logErr := h.logAuditCanonical(ctx, e)
 			if logErr != nil {
-				h.logger.Warn("audit log failed", "err", logErr)
+				h.logger.WarnContext(ctx, "audit log failed", "err", logErr)
 			}
 			h.publishAuditAndQueue(agent.UserID, "")
 			if winner != nil {
@@ -514,7 +514,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 				reason = "request is outside every active task and may need a new task"
 			}
 			if routeErr := h.routeToApproval(ctx, agent.UserID, blob, auditID, req.Context.CallbackURL, expiresAt, reason, nil); routeErr != nil {
-				h.logger.Warn("route to approval failed", "err", routeErr)
+				h.logger.WarnContext(ctx, "route to approval failed", "err", routeErr)
 			}
 			if r.URL.Query().Get("wait") == "true" && h.eventHub != nil {
 				pa := h.waitForApprovalDecision(r.Context(), req.RequestID, agent.UserID, req.TaskID, longPollDeadline(r))
@@ -549,7 +549,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			errMsg := "missing required field: task_id"
 			e.ErrorMsg = &errMsg
 			if logErr := h.store.LogAudit(ctx, e); logErr != nil {
-				h.logger.Warn("audit log failed", "err", logErr)
+				h.logger.WarnContext(ctx, "audit log failed", "err", logErr)
 			}
 			writeDetailedError(w, http.StatusBadRequest, apiErrorDetail{
 				Error:         errMsg,
@@ -582,7 +582,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			errMsg := fmt.Sprintf("task %q not found", req.TaskID)
 			e.ErrorMsg = &errMsg
 			if logErr := h.store.LogAudit(ctx, e); logErr != nil {
-				h.logger.Warn("audit log failed", "err", logErr)
+				h.logger.WarnContext(ctx, "audit log failed", "err", logErr)
 			}
 			writeDetailedError(w, http.StatusBadRequest, apiErrorDetail{
 				Error: errMsg,
@@ -598,7 +598,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			errMsg := "task does not belong to this agent's user"
 			e.ErrorMsg = &errMsg
 			if logErr := h.store.LogAudit(ctx, e); logErr != nil {
-				h.logger.Warn("audit log failed", "err", logErr)
+				h.logger.WarnContext(ctx, "audit log failed", "err", logErr)
 			}
 			writeDetailedError(w, http.StatusForbidden, apiErrorDetail{
 				Error: errMsg,
@@ -619,7 +619,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			errMsg := "task belongs to a different agent"
 			e.ErrorMsg = &errMsg
 			if logErr := h.store.LogAudit(ctx, e); logErr != nil {
-				h.logger.Warn("audit log failed", "err", logErr)
+				h.logger.WarnContext(ctx, "audit log failed", "err", logErr)
 			}
 			writeDetailedError(w, http.StatusForbidden, apiErrorDetail{
 				Error: errMsg,
@@ -633,7 +633,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			e := baseEntry("reject", "task_expired", taskIDPtr)
 			e.DurationMS = int(time.Since(start).Milliseconds())
 			if logErr := h.store.LogAudit(ctx, e); logErr != nil {
-				h.logger.Warn("audit log failed", "err", logErr)
+				h.logger.WarnContext(ctx, "audit log failed", "err", logErr)
 			}
 			resp := map[string]any{
 				"status":  "task_expired",
@@ -664,7 +664,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			e.DurationMS = int(time.Since(start).Milliseconds())
 			e.ErrorMsg = &errMsg
 			if logErr := h.store.LogAudit(ctx, e); logErr != nil {
-				h.logger.Warn("audit log failed", "err", logErr)
+				h.logger.WarnContext(ctx, "audit log failed", "err", logErr)
 			}
 			writeDetailedError(w, http.StatusConflict, apiErrorDetail{
 				Error: errMsg,
@@ -681,7 +681,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			errMsg := "session_id is required for standing task requests"
 			e.ErrorMsg = &errMsg
 			if logErr := h.store.LogAudit(ctx, e); logErr != nil {
-				h.logger.Warn("audit log failed", "err", logErr)
+				h.logger.WarnContext(ctx, "audit log failed", "err", logErr)
 			}
 			writeDetailedError(w, http.StatusBadRequest, apiErrorDetail{
 				Error: errMsg,
@@ -714,7 +714,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 				e.DurationMS = int(time.Since(start).Milliseconds())
 				e.ErrorMsg = &msg
 				if logErr := h.store.LogAudit(ctx, e); logErr != nil {
-					h.logger.Warn("audit log failed", "err", logErr)
+					h.logger.WarnContext(ctx, "audit log failed", "err", logErr)
 				}
 				h.publishAuditAndQueue(agent.UserID, req.TaskID)
 				writeDetailedError(w, http.StatusBadRequest, apiErrorDetail{
@@ -734,7 +734,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 				e.DurationMS = int(time.Since(start).Milliseconds())
 				e.ErrorMsg = &msg
 				if logErr := h.store.LogAudit(ctx, e); logErr != nil {
-					h.logger.Warn("audit log failed", "err", logErr)
+					h.logger.WarnContext(ctx, "audit log failed", "err", logErr)
 				}
 				h.publishAuditAndQueue(agent.UserID, req.TaskID)
 				writeDetailedError(w, http.StatusBadRequest, apiErrorDetail{
@@ -761,7 +761,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			e.DurationMS = int(time.Since(start).Milliseconds())
 			e.ErrorMsg = &msg
 			if logErr := h.store.LogAudit(ctx, e); logErr != nil {
-				h.logger.Warn("audit log failed", "err", logErr)
+				h.logger.WarnContext(ctx, "audit log failed", "err", logErr)
 			}
 			h.publishAuditAndQueue(agent.UserID, req.TaskID)
 			resp := map[string]any{
@@ -796,7 +796,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 					errMsg := "local services are not available in this deployment"
 					e.ErrorMsg = &errMsg
 					if logErr := h.store.LogAudit(ctx, e); logErr != nil {
-						h.logger.Warn("audit log failed", "err", logErr)
+						h.logger.WarnContext(ctx, "audit log failed", "err", logErr)
 					}
 					h.publishAuditAndQueue(agent.UserID, req.TaskID)
 					writeJSON(w, http.StatusOK, map[string]any{
@@ -815,7 +815,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 				matchedPlannedCall := matchPlannedCall(task.PlannedCalls, req.Service, req.Action, req.Params, chainFacts)
 				vMode := verificationModeFor(match.MatchedAction)
 				if matchedPlannedCall != nil && plannedCallBypassEligible(task.RiskLevel) {
-					h.logger.Info("request matches planned call — skipping intent verification",
+					h.logger.InfoContext(ctx, "request matches planned call — skipping intent verification",
 						"task_id", req.TaskID,
 						"service", req.Service,
 						"action", req.Action,
@@ -838,7 +838,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 					}
 				} else {
 					if matchedPlannedCall != nil {
-						h.logger.Info("planned call match present but risk assessment did not run; running verifier anyway",
+						h.logger.InfoContext(ctx, "planned call match present but risk assessment did not run; running verifier anyway",
 							"task_id", req.TaskID, "risk_level", task.RiskLevel)
 					}
 					verdict = h.runVerification(ctx, task, match.MatchedAction, req, serviceType, agent.UserID, chainFacts, vMode == "lenient")
@@ -852,7 +852,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 					e.DurationMS = dur
 					e.Verification = intent.MarshalVerdict(verdict)
 					if logErr := h.store.LogAudit(ctx, e); logErr != nil {
-						h.logger.Warn("audit log failed", "err", logErr)
+						h.logger.WarnContext(ctx, "audit log failed", "err", logErr)
 					}
 					h.publishAuditAndQueue(agent.UserID, req.TaskID)
 					if verdict.ReasonCoherence == "incoherent" && h.notifier != nil {
@@ -863,7 +863,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 								"<b>Verdict:</b> %s",
 							task.Purpose, req.Reason, verdict.Explanation)
 						if alertErr := h.notifier.SendAlert(ctx, agent.UserID, alertText); alertErr != nil {
-							h.logger.Warn("intent alert failed", "err", alertErr)
+							h.logger.WarnContext(ctx, "intent alert failed", "err", alertErr)
 						}
 					}
 					resp := map[string]any{
@@ -908,7 +908,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 
 				vMode := verificationModeFor(match.MatchedAction)
 				if matchedPlannedCall != nil && plannedCallBypassEligible(task.RiskLevel) {
-					h.logger.Info("request matches planned call — skipping intent verification",
+					h.logger.InfoContext(ctx, "request matches planned call — skipping intent verification",
 						"task_id", req.TaskID,
 						"service", req.Service,
 						"action", req.Action,
@@ -931,7 +931,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 					}
 				} else {
 					if matchedPlannedCall != nil {
-						h.logger.Info("planned call match present but risk assessment did not run; running verifier anyway",
+						h.logger.InfoContext(ctx, "planned call match present but risk assessment did not run; running verifier anyway",
 							"task_id", req.TaskID, "risk_level", task.RiskLevel)
 					}
 					verdict = h.runVerification(ctx, task, match.MatchedAction, req, serviceType, agent.UserID, chainFacts, vMode == "lenient")
@@ -948,7 +948,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 					e.DurationMS = dur
 					e.Verification = intent.MarshalVerdict(verdict)
 					if logErr := h.store.LogAudit(ctx, e); logErr != nil {
-						h.logger.Warn("audit log failed", "err", logErr)
+						h.logger.WarnContext(ctx, "audit log failed", "err", logErr)
 					}
 					h.publishAuditAndQueue(agent.UserID, req.TaskID)
 					// Alert on incoherent reason
@@ -960,7 +960,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 								"<b>Verdict:</b> %s",
 							task.Purpose, req.Reason, verdict.Explanation)
 						if alertErr := h.notifier.SendAlert(ctx, agent.UserID, alertText); alertErr != nil {
-							h.logger.Warn("intent alert failed", "err", alertErr)
+							h.logger.WarnContext(ctx, "intent alert failed", "err", alertErr)
 						}
 					}
 					resp := map[string]any{
@@ -989,7 +989,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 						code, userErr, auditMsg := serviceNotActivatedResponse(ctx, h.vault, h.store, h.adapterReg, agent.UserID, serviceType, serviceAlias, req.Service, taskAdapter)
 						e.ErrorMsg = &auditMsg
 						if logErr := h.store.LogAudit(ctx, e); logErr != nil {
-							h.logger.Warn("audit log failed", "err", logErr)
+							h.logger.WarnContext(ctx, "audit log failed", "err", logErr)
 						}
 						h.publishAuditAndQueue(agent.UserID, req.TaskID)
 						writeJSON(w, http.StatusBadRequest, map[string]any{
@@ -1013,7 +1013,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 						e.DurationMS = int(time.Since(start).Milliseconds())
 						e.ErrorMsg = &errMsg
 						if logErr := h.store.LogAudit(ctx, e); logErr != nil {
-							h.logger.Warn("audit log failed", "err", logErr)
+							h.logger.WarnContext(ctx, "audit log failed", "err", logErr)
 						}
 						h.publishAuditAndQueue(agent.UserID, req.TaskID)
 						writeDetailedError(w, http.StatusBadRequest, *paramErr)
@@ -1052,7 +1052,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 						vaultFinalizeCtx, vaultFinalizeCancel := context.WithTimeout(context.Background(), 5*time.Second)
 						defer vaultFinalizeCancel()
 						if updErr := h.store.UpdateAuditOutcome(vaultFinalizeCtx, auditID, "error", auditMsg, dur); updErr != nil {
-							h.logger.Warn("audit outcome update failed", "err", updErr)
+							h.logger.WarnContext(ctx, "audit outcome update failed", "err", updErr)
 						}
 						outDecision, outOutcome = "execute", "error"
 						h.publishAuditAndQueue(agent.UserID, req.TaskID)
@@ -1087,7 +1087,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			if execErr != nil {
 				errMsg := execErr.Error()
 				if updErr := h.store.UpdateAuditOutcome(finalizeCtx, auditID, "error", errMsg, dur); updErr != nil {
-					h.logger.Warn("audit outcome update failed", "err", updErr)
+					h.logger.WarnContext(ctx, "audit outcome update failed", "err", updErr)
 				}
 				outDecision, outOutcome = "execute", "error"
 				h.publishAuditAndQueue(agent.UserID, req.TaskID)
@@ -1113,7 +1113,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			middleware.AddLogField(ctx, "decision", "execute")
 			middleware.AddLogField(ctx, "outcome", "executed")
 			if updErr := h.store.UpdateAuditOutcome(finalizeCtx, auditID, "executed", "", dur); updErr != nil {
-				h.logger.Warn("audit outcome update failed", "err", updErr)
+				h.logger.WarnContext(ctx, "audit outcome update failed", "err", updErr)
 			}
 			outDecision, outOutcome = "execute", "executed"
 			h.publishAuditAndQueue(agent.UserID, req.TaskID)
@@ -1167,7 +1167,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 			errMsg := fmt.Sprintf("unknown service %q", serviceType)
 			e.ErrorMsg = &errMsg
 			if logErr := h.store.LogAudit(ctx, e); logErr != nil {
-				h.logger.Warn("audit log failed", "err", logErr)
+				h.logger.WarnContext(ctx, "audit log failed", "err", logErr)
 			}
 			h.publishAuditAndQueue(agent.UserID, "")
 			writeJSON(w, http.StatusBadRequest, map[string]any{
@@ -1199,7 +1199,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 				code, userErr, auditMsg := serviceNotActivatedResponse(ctx, h.vault, h.store, h.adapterReg, agent.UserID, serviceType, serviceAlias, req.Service, approveAdapter)
 				e.ErrorMsg = &auditMsg
 				if logErr := h.store.LogAudit(ctx, e); logErr != nil {
-					h.logger.Warn("audit log failed", "err", logErr)
+					h.logger.WarnContext(ctx, "audit log failed", "err", logErr)
 				}
 				h.publishAuditAndQueue(agent.UserID, "")
 				writeJSON(w, http.StatusBadRequest, map[string]any{
@@ -1223,7 +1223,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 	e.Verification = intent.MarshalVerdict(advisoryVerdict)
 	winner, logErr := h.logAuditCanonical(ctx, e)
 	if logErr != nil {
-		h.logger.Warn("audit log failed", "err", logErr)
+		h.logger.WarnContext(ctx, "audit log failed", "err", logErr)
 	}
 	h.publishAuditAndQueue(agent.UserID, req.TaskID)
 	if winner != nil {
@@ -1246,7 +1246,7 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 	}
 	if routeErr := h.routeToApproval(ctx, agent.UserID, blob, auditID,
 		req.Context.CallbackURL, expiresAt, reason, advisoryVerdict); routeErr != nil {
-		h.logger.Warn("route to approval failed", "err", routeErr)
+		h.logger.WarnContext(ctx, "route to approval failed", "err", routeErr)
 	}
 	// If wait=true, long-poll for approval then execute inline.
 	if r.URL.Query().Get("wait") == "true" && h.eventHub != nil {
@@ -1399,7 +1399,7 @@ func (h *GatewayHandler) reserveExecAndWaitLoser(w http.ResponseWriter, r *http.
 	ctx := r.Context()
 	winner, reserveErr := h.logAuditCanonical(ctx, e)
 	if reserveErr != nil {
-		h.logger.Warn("audit reservation failed; proceeding without dedup protection", "err", reserveErr)
+		h.logger.WarnContext(ctx, "audit reservation failed; proceeding without dedup protection", "err", reserveErr)
 	}
 	publishTaskID := ""
 	if e.TaskID != nil {
@@ -1729,7 +1729,7 @@ func (h *GatewayHandler) maybeInjectNPS(ctx context.Context, resp map[string]any
 	}
 	lastNPS, err := h.store.GetAgentLastNPSTime(ctx, agentID)
 	if err != nil {
-		h.logger.Warn("nps cooldown check failed, skipping cooldown", "err", err, "agent_id", agentID)
+		h.logger.WarnContext(ctx, "nps cooldown check failed, skipping cooldown", "err", err, "agent_id", agentID)
 		// Fall through — don't suppress NPS just because the cooldown check failed.
 	}
 	if lastNPS != nil && time.Since(*lastNPS) < 7*24*time.Hour {
@@ -2189,7 +2189,7 @@ func chainContextFallback(
 			}
 		}
 		if allFound {
-			logger.Info("chain context fallback: values landed after waiting for in-flight extraction",
+			logger.InfoContext(ctx, "chain context fallback: values landed after waiting for in-flight extraction",
 				"task_id", taskID,
 				"session_id", chainSessionID,
 				"missing_values", verdict.MissingChainValues,
@@ -2198,7 +2198,7 @@ func chainContextFallback(
 	}
 
 	if allFound {
-		logger.Info("chain context fallback: all missing values found in extended context",
+		logger.InfoContext(ctx, "chain context fallback: all missing values found in extended context",
 			"task_id", taskID,
 			"missing_values", verdict.MissingChainValues,
 		)
@@ -2212,7 +2212,7 @@ func chainContextFallback(
 	// Log at warn so lossy-extraction cases are still visible even though
 	// they now reject rather than auto-allow.
 	if len(loadedFacts) > 0 {
-		logger.Warn("chain context fallback: missing value not in loaded facts or DB, rejecting",
+		logger.WarnContext(ctx, "chain context fallback: missing value not in loaded facts or DB, rejecting",
 			"task_id", taskID,
 			"missing_values", verdict.MissingChainValues,
 			"loaded_facts", len(loadedFacts),
@@ -2244,7 +2244,7 @@ func checkMissingValues(
 		}
 		found, err := st.ChainFactValueExists(ctx, taskID, chainSessionID, value)
 		if err != nil {
-			logger.Warn("chain fact fallback DB query failed", "err", err, "task_id", taskID)
+			logger.WarnContext(ctx, "chain fact fallback DB query failed", "err", err, "task_id", taskID)
 			return false, err
 		}
 		if !found {
@@ -2417,7 +2417,7 @@ func (h *GatewayHandler) routeToApproval(
 	}
 	msgID, err := h.notifier.SendApprovalRequest(ctx, approvalReq)
 	if err != nil {
-		h.logger.Warn("telegram approval notification failed", "err", err)
+		h.logger.WarnContext(ctx, "telegram approval notification failed", "err", err)
 		return nil
 	}
 

--- a/internal/api/handlers/gateway_batch.go
+++ b/internal/api/handlers/gateway_batch.go
@@ -113,7 +113,7 @@ func (h *GatewayHandler) HandleBatch(w http.ResponseWriter, r *http.Request) {
 			// unrecovered panic here would crash the whole process.
 			defer func() {
 				if rec := recover(); rec != nil {
-					h.logger.Error("batch sub-request panicked",
+					h.logger.ErrorContext(r.Context(), "batch sub-request panicked",
 						"panic", rec,
 						"request_id", sub.RequestID,
 						"service", sub.Service,

--- a/internal/api/handlers/guard.go
+++ b/internal/api/handlers/guard.go
@@ -238,7 +238,7 @@ func (h *GuardHandler) logGuardAudit(
 	}
 
 	if err := h.store.LogAudit(ctx, entry); err != nil {
-		h.logger.Warn("guard audit log failed", "err", err)
+		h.logger.WarnContext(ctx, "guard audit log failed", "err", err)
 	}
 
 	if taskID != nil {

--- a/internal/api/handlers/services.go
+++ b/internal/api/handlers/services.go
@@ -152,7 +152,7 @@ func (h *ServicesHandler) checkPendingRequestOwnership(w http.ResponseWriter, r 
 	}
 	pa, err := h.st.GetPendingApproval(r.Context(), pendingReqID, userID)
 	if err != nil || pa.UserID != userID {
-		h.logger.Warn("rejected oauth init with cross-user pending_request_id",
+		h.logger.WarnContext(r.Context(), "rejected oauth init with cross-user pending_request_id",
 			"caller_user_id", userID,
 			"pending_request_id", pendingReqID,
 			"err", err,
@@ -490,7 +490,7 @@ func (h *ServicesHandler) OAuthGetURL(w http.ResponseWriter, r *http.Request) {
 	// pre-registration.
 	if mcp, ok := adapter.(*mcpadapter.MCPAdapter); ok {
 		if err := mcp.EnsureOAuthReady(r.Context(), h.oauthRedirectURL()); err != nil {
-			h.logger.Warn("mcp oauth discovery/registration failed", "service", serviceID, "err", err)
+			h.logger.WarnContext(r.Context(), "mcp oauth discovery/registration failed", "service", serviceID, "err", err)
 			writeError(w, http.StatusBadGateway, "OAUTH_DISCOVERY_FAILED", err.Error())
 			return
 		}
@@ -522,7 +522,7 @@ func (h *ServicesHandler) OAuthGetURL(w http.ResponseWriter, r *http.Request) {
 		// state from before the activation rollback shipped, or a user who
 		// hit the rollback once and re-clicked Connect).
 		if err := h.repairMCPToolsForUser(r.Context(), adapter, user.ID, serviceID, alias); err != nil {
-			h.logger.Warn("mcp tool repair on already_authorized failed",
+			h.logger.WarnContext(r.Context(), "mcp tool repair on already_authorized failed",
 				"service", serviceID, "user", user.ID, "err", err)
 		}
 		writeJSON(w, http.StatusOK, map[string]any{
@@ -599,7 +599,7 @@ func (h *ServicesHandler) OAuthStart(w http.ResponseWriter, r *http.Request) {
 	// pre-registration.
 	if mcp, ok := adapter.(*mcpadapter.MCPAdapter); ok {
 		if err := mcp.EnsureOAuthReady(r.Context(), h.oauthRedirectURL()); err != nil {
-			h.logger.Warn("mcp oauth discovery/registration failed", "service", serviceID, "err", err)
+			h.logger.WarnContext(r.Context(), "mcp oauth discovery/registration failed", "service", serviceID, "err", err)
 			writeError(w, http.StatusBadGateway, "OAUTH_DISCOVERY_FAILED", err.Error())
 			return
 		}
@@ -705,7 +705,7 @@ func (h *ServicesHandler) OAuthCallback(w http.ResponseWriter, r *http.Request) 
 			"grant_type":    {"authorization_code"},
 		}
 		if err := validateTokenEndpoint(oauthCfg.Endpoint.TokenURL); err != nil {
-			h.logger.Warn("oauth token exchange: invalid token_url", "service", entry.ServiceID, "err", err)
+			h.logger.WarnContext(r.Context(), "oauth token exchange: invalid token_url", "service", entry.ServiceID, "err", err)
 			oauthPopupClose(w, "Provider token endpoint is not allowed.", "", entry.OpenerOrigin)
 			return
 		}
@@ -719,7 +719,7 @@ func (h *ServicesHandler) OAuthCallback(w http.ResponseWriter, r *http.Request) 
 
 		resp, err := ssrfSafeOAuthClient.Do(tokenReq)
 		if err != nil {
-			h.logger.Warn("oauth token exchange failed", "service", entry.ServiceID, "err", err)
+			h.logger.WarnContext(r.Context(), "oauth token exchange failed", "service", entry.ServiceID, "err", err)
 			oauthPopupClose(w, "Token exchange with provider failed.", "", entry.OpenerOrigin)
 			return
 		}
@@ -735,7 +735,7 @@ func (h *ServicesHandler) OAuthCallback(w http.ResponseWriter, r *http.Request) 
 			if desc == "" {
 				desc = errVal
 			}
-			h.logger.Warn("oauth token exchange: provider error", "service", entry.ServiceID, "error", errVal, "desc", desc)
+			h.logger.WarnContext(r.Context(), "oauth token exchange: provider error", "service", entry.ServiceID, "error", errVal, "desc", desc)
 			oauthPopupClose(w, "Authorization failed: "+desc, "", entry.OpenerOrigin)
 			return
 		}
@@ -748,25 +748,25 @@ func (h *ServicesHandler) OAuthCallback(w http.ResponseWriter, r *http.Request) 
 		credBytes, err = credentialFromTokenPathResponse(rawResp, entry.TokenPath, scopes, existingRefreshToken, time.Now())
 		if err != nil {
 			if errors.Is(err, errEmptyAccessToken) {
-				h.logger.Warn("oauth token exchange: empty access token", "service", entry.ServiceID, "token_path", entry.TokenPath)
+				h.logger.WarnContext(r.Context(), "oauth token exchange: empty access token", "service", entry.ServiceID, "token_path", entry.TokenPath)
 				oauthPopupClose(w, "Provider returned empty access token.", "", entry.OpenerOrigin)
 				return
 			}
-			h.logger.Warn("credential from token_path response failed", "service", entry.ServiceID, "err", err)
+			h.logger.WarnContext(r.Context(), "credential from token_path response failed", "service", entry.ServiceID, "err", err)
 			oauthPopupClose(w, "Failed to process credential.", "", entry.OpenerOrigin)
 			return
 		}
 	} else {
 		// Standard OAuth2 token exchange — route through the SSRF-safe client.
 		if err := validateTokenEndpoint(oauthCfg.Endpoint.TokenURL); err != nil {
-			h.logger.Warn("oauth token exchange: invalid token_url", "service", entry.ServiceID, "err", err)
+			h.logger.WarnContext(r.Context(), "oauth token exchange: invalid token_url", "service", entry.ServiceID, "err", err)
 			oauthPopupClose(w, "Provider token endpoint is not allowed.", "", entry.OpenerOrigin)
 			return
 		}
 		exchangeCtx := context.WithValue(r.Context(), oauth2.HTTPClient, ssrfSafeOAuthClient)
 		token, err := oauthCfg.Exchange(exchangeCtx, code)
 		if err != nil {
-			h.logger.Warn("oauth token exchange failed", "service", entry.ServiceID, "err", err)
+			h.logger.WarnContext(r.Context(), "oauth token exchange failed", "service", entry.ServiceID, "err", err)
 			oauthPopupClose(w, "Token exchange with provider failed.", "", entry.OpenerOrigin)
 			return
 		}
@@ -798,7 +798,7 @@ func (h *ServicesHandler) OAuthCallback(w http.ResponseWriter, r *http.Request) 
 
 		credBytes, err = credential.FromToken(token, scopes, scopesGranted)
 		if err != nil {
-			h.logger.Warn("credential from token failed", "service", entry.ServiceID, "err", err)
+			h.logger.WarnContext(r.Context(), "credential from token failed", "service", entry.ServiceID, "err", err)
 			oauthPopupClose(w, "Failed to process credential.", "", entry.OpenerOrigin)
 			return
 		}
@@ -809,7 +809,7 @@ func (h *ServicesHandler) OAuthCallback(w http.ResponseWriter, r *http.Request) 
 
 	vKey := h.adapterReg.VaultKeyWithAliasForUser(entry.ServiceID, alias, entry.UserID)
 	if err := h.vault.Set(r.Context(), entry.UserID, vKey, credBytes); err != nil {
-		h.logger.Warn("vault set failed", "service", entry.ServiceID, "err", err)
+		h.logger.WarnContext(r.Context(), "vault set failed", "service", entry.ServiceID, "err", err)
 		oauthPopupClose(w, "Failed to store credential in vault.", "", entry.OpenerOrigin)
 		return
 	}
@@ -827,7 +827,7 @@ func (h *ServicesHandler) OAuthCallback(w http.ResponseWriter, r *http.Request) 
 	// end up with a "connected" service exposing zero actions — the OAuth
 	// grant at the vendor still stands, so a retry is cheap.
 	if err := h.ensureMCPToolsActivated(r.Context(), adapter, entry.UserID, entry.ServiceID, alias, credBytes); err != nil {
-		h.logger.Error("mcp tool discovery failed at oauth activation; rolling back",
+		h.logger.ErrorContext(r.Context(), "mcp tool discovery failed at oauth activation; rolling back",
 			"service", entry.ServiceID, "user", entry.UserID, "err", err)
 		_ = h.vault.Delete(r.Context(), entry.UserID, vKey)
 		_ = h.st.DeleteServiceMeta(r.Context(), entry.UserID, entry.ServiceID, alias)
@@ -835,7 +835,7 @@ func (h *ServicesHandler) OAuthCallback(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	h.logger.Info("service activated", "user", entry.UserID, "service", entry.ServiceID, "alias", alias)
+	h.logger.InfoContext(r.Context(), "service activated", "user", entry.UserID, "service", entry.ServiceID, "alias", alias)
 
 	// Re-execute any pending request that was waiting for this activation.
 	if entry.PendingReqID != "" {
@@ -977,7 +977,7 @@ func (h *ServicesHandler) Activate(w http.ResponseWriter, r *http.Request) {
 			// no-ops if tools are already cached, so this is cheap when
 			// nothing's wrong.
 			if err := h.repairMCPToolsForUser(r.Context(), adapter, user.ID, serviceID, alias); err != nil {
-				h.logger.Warn("mcp tool repair on already_authorized failed",
+				h.logger.WarnContext(r.Context(), "mcp tool repair on already_authorized failed",
 					"service", serviceID, "user", user.ID, "err", err)
 			}
 			writeJSON(w, http.StatusOK, map[string]any{
@@ -1019,7 +1019,7 @@ func (h *ServicesHandler) Activate(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		_ = h.st.UpsertServiceMeta(r.Context(), user.ID, serviceID, "default", time.Now())
-		h.logger.Info("credential-free service activated", "user", user.ID, "service", serviceID)
+		h.logger.InfoContext(r.Context(), "credential-free service activated", "user", user.ID, "service", serviceID)
 		writeJSON(w, http.StatusOK, map[string]string{"status": "activated", "service": serviceID})
 		return
 	}
@@ -1107,7 +1107,7 @@ func (h *ServicesHandler) ActivateWithKey(w http.ResponseWriter, r *http.Request
 
 	vKey := h.adapterReg.VaultKeyWithAliasForUser(serviceID, alias, user.ID)
 	if err := h.vault.Set(r.Context(), user.ID, vKey, credBytes); err != nil {
-		h.logger.Warn("vault set failed (api key)", "service", serviceID, "err", err)
+		h.logger.WarnContext(r.Context(), "vault set failed (api key)", "service", serviceID, "err", err)
 		writeError(w, http.StatusInternalServerError, "VAULT_ERROR", "failed to store credential")
 		return
 	}
@@ -1124,7 +1124,7 @@ func (h *ServicesHandler) ActivateWithKey(w http.ResponseWriter, r *http.Request
 	// clone carrying the discovered tool set. The store row is the source
 	// of truth across restarts; the in-memory clone is just a cache.
 	if err := h.ensureMCPToolsActivated(r.Context(), adapter, user.ID, serviceID, alias, credBytes); err != nil {
-		h.logger.Error("mcp tool discovery failed at api-key activation; rolling back",
+		h.logger.ErrorContext(r.Context(), "mcp tool discovery failed at api-key activation; rolling back",
 			"service", serviceID, "user", user.ID, "err", err)
 		_ = h.vault.Delete(r.Context(), user.ID, vKey)
 		_ = h.st.DeleteServiceMeta(r.Context(), user.ID, serviceID, alias)
@@ -1132,7 +1132,7 @@ func (h *ServicesHandler) ActivateWithKey(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	h.logger.Info("service activated via api key", "user", user.ID, "service", serviceID, "alias", alias)
+	h.logger.InfoContext(r.Context(), "service activated via api key", "user", user.ID, "service", serviceID, "alias", alias)
 
 	writeJSON(w, http.StatusOK, map[string]string{"status": "activated", "service": serviceID, "alias": alias})
 }
@@ -1191,7 +1191,7 @@ func (h *ServicesHandler) Deactivate(w http.ResponseWriter, r *http.Request) {
 	adapter, ok := h.adapterReg.GetForUser(r.Context(), serviceID, user.ID)
 	if ok && adapter.ValidateCredential(nil) == nil {
 		h.revokeTasksForService(r.Context(), user.ID, serviceID, alias)
-		h.logger.Info("credential-free service deactivated", "user", user.ID, "service", serviceID)
+		h.logger.InfoContext(r.Context(), "credential-free service deactivated", "user", user.ID, "service", serviceID)
 		writeJSON(w, http.StatusOK, map[string]string{"status": "deactivated", "service": serviceID})
 		return
 	}
@@ -1222,7 +1222,7 @@ func (h *ServicesHandler) Deactivate(w http.ResponseWriter, r *http.Request) {
 
 	h.revokeTasksForService(r.Context(), user.ID, serviceID, alias)
 
-	h.logger.Info("service deactivated", "user", user.ID, "service", serviceID, "alias", alias)
+	h.logger.InfoContext(r.Context(), "service deactivated", "user", user.ID, "service", serviceID, "alias", alias)
 
 	writeJSON(w, http.StatusOK, map[string]string{"status": "deactivated", "service": serviceID})
 }
@@ -1242,7 +1242,7 @@ func serviceMatchStrings(serviceID, alias string) (base, withAlias string) {
 func (h *ServicesHandler) countTasksForService(ctx context.Context, userID, serviceID, alias string) int {
 	tasks, _, err := h.st.ListTasks(ctx, userID, store.TaskFilter{ActiveOnly: true})
 	if err != nil {
-		h.logger.Warn("failed to list tasks for service count", "err", err, "user", userID)
+		h.logger.WarnContext(ctx, "failed to list tasks for service count", "err", err, "user", userID)
 		return 0
 	}
 	base, withAlias := serviceMatchStrings(serviceID, alias)
@@ -1260,7 +1260,7 @@ func (h *ServicesHandler) countTasksForService(ctx context.Context, userID, serv
 func (h *ServicesHandler) revokeTasksForService(ctx context.Context, userID, serviceID, alias string) {
 	tasks, _, err := h.st.ListTasks(ctx, userID, store.TaskFilter{ActiveOnly: true})
 	if err != nil {
-		h.logger.Warn("failed to list tasks for service cleanup", "err", err, "user", userID)
+		h.logger.WarnContext(ctx, "failed to list tasks for service cleanup", "err", err, "user", userID)
 		return
 	}
 
@@ -1269,11 +1269,11 @@ func (h *ServicesHandler) revokeTasksForService(ctx context.Context, userID, ser
 	for _, t := range tasks {
 		if taskReferencesService(t, base, withAlias) {
 			if err := h.st.RevokeTask(ctx, t.ID, userID); err != nil {
-				h.logger.Warn("failed to revoke task for deactivated service", "err", err, "task_id", t.ID)
+				h.logger.WarnContext(ctx, "failed to revoke task for deactivated service", "err", err, "task_id", t.ID)
 				continue
 			}
 			_ = h.st.DeleteChainFactsByTask(ctx, t.ID)
-			h.logger.Info("revoked task due to service deactivation", "task_id", t.ID, "service", serviceID, "alias", alias)
+			h.logger.InfoContext(ctx, "revoked task due to service deactivation", "task_id", t.ID, "service", serviceID, "alias", alias)
 		}
 	}
 
@@ -1396,11 +1396,11 @@ func (h *ServicesHandler) RenameAlias(w http.ResponseWriter, r *http.Request) {
 		if h.adapterReg.VaultKeyWithAliasForUser(m.ServiceID, m.Alias, user.ID) == oldVKey {
 			_ = h.st.UpsertServiceMeta(r.Context(), user.ID, m.ServiceID, body.NewAlias, m.ActivatedAt)
 			_ = h.st.DeleteServiceMeta(r.Context(), user.ID, m.ServiceID, m.Alias)
-			h.logger.Info("alias renamed (shared key)", "user", user.ID, "service", m.ServiceID, "old", m.Alias, "new", body.NewAlias)
+			h.logger.InfoContext(r.Context(), "alias renamed (shared key)", "user", user.ID, "service", m.ServiceID, "old", m.Alias, "new", body.NewAlias)
 		}
 	}
 
-	h.logger.Info("alias renamed", "user", user.ID, "service", serviceID, "old", body.OldAlias, "new", body.NewAlias)
+	h.logger.InfoContext(r.Context(), "alias renamed", "user", user.ID, "service", serviceID, "old", body.OldAlias, "new", body.NewAlias)
 	writeJSON(w, http.StatusOK, map[string]string{"status": "renamed", "service": serviceID, "alias": body.NewAlias})
 }
 
@@ -1431,7 +1431,7 @@ func (h *ServicesHandler) ensureMCPToolsActivated(
 		return fmt.Errorf("persist: %w", err)
 	}
 	h.adapterReg.RegisterForUser(userID, mcp.ForUser(tools))
-	h.logger.Info("mcp tools discovered",
+	h.logger.InfoContext(ctx, "mcp tools discovered",
 		"service", serviceID, "user", userID, "alias", alias, "tool_count", len(tools))
 	return nil
 }
@@ -1482,19 +1482,19 @@ func (h *ServicesHandler) resolveIdentityAlias(
 	identity, err := fetcher.FetchIdentity(ctx, credBytes, config)
 	if err != nil || identity == "" {
 		if err != nil {
-			h.logger.Warn("identity fetch failed, using default alias",
+			h.logger.WarnContext(ctx, "identity fetch failed, using default alias",
 				"service", serviceID, "err", err)
 		}
 		return currentAlias
 	}
 
 	if !validAlias(identity) {
-		h.logger.Warn("fetched identity contains invalid characters, using default alias",
+		h.logger.WarnContext(ctx, "fetched identity contains invalid characters, using default alias",
 			"service", serviceID, "identity", identity)
 		return currentAlias
 	}
 
-	h.logger.Info("auto-detected service identity",
+	h.logger.InfoContext(ctx, "auto-detected service identity",
 		"service", serviceID, "identity", identity)
 	return identity
 }
@@ -1503,14 +1503,14 @@ func (h *ServicesHandler) resolveIdentityAlias(
 func (h *ServicesHandler) reactivatePendingRequest(ctx context.Context, userID, requestID string) {
 	pa, err := h.st.GetPendingApproval(ctx, requestID, userID)
 	if err != nil {
-		h.logger.Warn("reactivate: pending approval not found", "request_id", requestID, "err", err)
+		h.logger.WarnContext(ctx, "reactivate: pending approval not found", "request_id", requestID, "err", err)
 		return
 	}
 	// Defense in depth: even though OAuth init verifies ownership before
 	// stashing the request_id, refuse to act on a pending approval that does
 	// not belong to the user whose OAuth flow we just completed.
 	if pa.UserID != userID {
-		h.logger.Warn("reactivate: refusing cross-user pending approval",
+		h.logger.WarnContext(ctx, "reactivate: refusing cross-user pending approval",
 			"request_id", requestID,
 			"oauth_user_id", userID,
 			"pending_user_id", pa.UserID,
@@ -1520,7 +1520,7 @@ func (h *ServicesHandler) reactivatePendingRequest(ctx context.Context, userID, 
 
 	var blob pendingRequestBlob
 	if err := json.Unmarshal(pa.RequestBlob, &blob); err != nil {
-		h.logger.Warn("reactivate: invalid request blob", "request_id", requestID, "err", err)
+		h.logger.WarnContext(ctx, "reactivate: invalid request blob", "request_id", requestID, "err", err)
 		return
 	}
 
@@ -1558,7 +1558,7 @@ func (h *ServicesHandler) reactivatePendingRequest(ctx context.Context, userID, 
 		}, cbKey)
 	}
 
-	h.logger.Info("pending request re-executed after activation",
+	h.logger.InfoContext(ctx, "pending request re-executed after activation",
 		"request_id", requestID, "outcome", outcome)
 }
 
@@ -1793,7 +1793,7 @@ func (h *ServicesHandler) DeviceFlowStart(w http.ResponseWriter, r *http.Request
 		"scope":     {strings.Join(dfCfg.Scopes, " ")},
 	}
 	if err := validateTokenEndpoint(dfCfg.DeviceCodeURL); err != nil {
-		h.logger.Warn("device flow: invalid device_code_url", "service", serviceID, "err", err)
+		h.logger.WarnContext(r.Context(), "device flow: invalid device_code_url", "service", serviceID, "err", err)
 		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "device_code_url is not allowed")
 		return
 	}
@@ -1807,7 +1807,7 @@ func (h *ServicesHandler) DeviceFlowStart(w http.ResponseWriter, r *http.Request
 
 	resp, err := ssrfSafeOAuthClient.Do(req)
 	if err != nil {
-		h.logger.Warn("device flow: request to provider failed", "err", err)
+		h.logger.WarnContext(r.Context(), "device flow: request to provider failed", "err", err)
 		writeError(w, http.StatusBadGateway, "PROVIDER_ERROR", "failed to contact provider")
 		return
 	}
@@ -1827,7 +1827,7 @@ func (h *ServicesHandler) DeviceFlowStart(w http.ResponseWriter, r *http.Request
 		return
 	}
 	if dfResp.Error != "" {
-		h.logger.Warn("device flow: provider error", "error", dfResp.Error, "desc", dfResp.ErrorDesc)
+		h.logger.WarnContext(r.Context(), "device flow: provider error", "error", dfResp.Error, "desc", dfResp.ErrorDesc)
 		writeError(w, http.StatusBadGateway, "PROVIDER_ERROR", dfResp.ErrorDesc)
 		return
 	}
@@ -1911,7 +1911,7 @@ func (h *ServicesHandler) DeviceFlowPoll(w http.ResponseWriter, r *http.Request)
 		"grant_type":  {entry.GrantType},
 	}
 	if err := validateTokenEndpoint(entry.TokenURL); err != nil {
-		h.logger.Warn("device flow poll: invalid token_url", "service", entry.ServiceID, "err", err)
+		h.logger.WarnContext(r.Context(), "device flow poll: invalid token_url", "service", entry.ServiceID, "err", err)
 		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "token_url is not allowed")
 		return
 	}
@@ -1925,7 +1925,7 @@ func (h *ServicesHandler) DeviceFlowPoll(w http.ResponseWriter, r *http.Request)
 
 	resp, err := ssrfSafeOAuthClient.Do(req)
 	if err != nil {
-		h.logger.Warn("device flow poll: request failed", "err", err)
+		h.logger.WarnContext(r.Context(), "device flow poll: request failed", "err", err)
 		writeError(w, http.StatusBadGateway, "PROVIDER_ERROR", "failed to contact provider")
 		return
 	}
@@ -1970,7 +1970,7 @@ func (h *ServicesHandler) DeviceFlowPoll(w http.ResponseWriter, r *http.Request)
 
 	// Success: validate and store the token as an api_key credential.
 	if tokenResp.AccessToken == "" {
-		h.logger.Warn("device flow: provider returned empty access token", "service", entry.ServiceID)
+		h.logger.WarnContext(r.Context(), "device flow: provider returned empty access token", "service", entry.ServiceID)
 		h.oauthStore.DeleteDeviceFlow(body.FlowID)
 		writeError(w, http.StatusBadGateway, "PROVIDER_ERROR", "provider returned empty access token")
 		return
@@ -1989,7 +1989,7 @@ func (h *ServicesHandler) DeviceFlowPoll(w http.ResponseWriter, r *http.Request)
 
 	vKey := h.adapterReg.VaultKeyWithAliasForUser(entry.ServiceID, alias, entry.UserID)
 	if err := h.vault.Set(r.Context(), entry.UserID, vKey, credBytes); err != nil {
-		h.logger.Warn("device flow: vault set failed", "err", err)
+		h.logger.WarnContext(r.Context(), "device flow: vault set failed", "err", err)
 		writeError(w, http.StatusInternalServerError, "VAULT_ERROR", "failed to store credential")
 		return
 	}
@@ -2000,7 +2000,7 @@ func (h *ServicesHandler) DeviceFlowPoll(w http.ResponseWriter, r *http.Request)
 	}
 	h.oauthStore.DeleteDeviceFlow(body.FlowID)
 
-	h.logger.Info("service activated via device flow", "user", entry.UserID, "service", entry.ServiceID, "alias", alias)
+	h.logger.InfoContext(r.Context(), "service activated via device flow", "user", entry.UserID, "service", entry.ServiceID, "alias", alias)
 	writeJSON(w, http.StatusOK, map[string]any{"status": "complete", "alias": alias})
 }
 
@@ -2071,7 +2071,7 @@ func (h *ServicesHandler) PKCEFlowStart(w http.ResponseWriter, r *http.Request) 
 	// If a client_id was provided in the request, save it to the vault for future use.
 	if body.ClientID != "" {
 		if err := adapters.SetPKCEClientID(r.Context(), h.vault, serviceID, body.ClientID); err != nil {
-			h.logger.Error("failed to store PKCE client ID", "service_id", serviceID, "err", err)
+			h.logger.ErrorContext(r.Context(), "failed to store PKCE client ID", "service_id", serviceID, "err", err)
 		}
 	}
 
@@ -2221,7 +2221,7 @@ func (h *ServicesHandler) PKCEFlowCallback(w http.ResponseWriter, r *http.Reques
 		"grant_type":    {"authorization_code"},
 	}
 	if err := validateTokenEndpoint(entry.TokenURL); err != nil {
-		h.logger.Warn("pkce flow: invalid token_url", "service", entry.ServiceID, "err", err)
+		h.logger.WarnContext(r.Context(), "pkce flow: invalid token_url", "service", entry.ServiceID, "err", err)
 		oauthPopupClose(w, "Provider token endpoint is not allowed.", "", entry.OpenerOrigin)
 		return
 	}
@@ -2235,7 +2235,7 @@ func (h *ServicesHandler) PKCEFlowCallback(w http.ResponseWriter, r *http.Reques
 
 	resp, err := ssrfSafeOAuthClient.Do(tokenReq)
 	if err != nil {
-		h.logger.Warn("pkce flow: token exchange failed", "err", err)
+		h.logger.WarnContext(r.Context(), "pkce flow: token exchange failed", "err", err)
 		oauthPopupClose(w, "Failed to contact token endpoint.", "", entry.OpenerOrigin)
 		return
 	}
@@ -2253,7 +2253,7 @@ func (h *ServicesHandler) PKCEFlowCallback(w http.ResponseWriter, r *http.Reques
 		if desc == "" {
 			desc = errVal
 		}
-		h.logger.Warn("pkce flow: provider returned error", "error", errVal, "desc", desc)
+		h.logger.WarnContext(r.Context(), "pkce flow: provider returned error", "error", errVal, "desc", desc)
 		oauthPopupClose(w, "Authorization failed: "+desc, "", entry.OpenerOrigin)
 		return
 	}
@@ -2267,11 +2267,11 @@ func (h *ServicesHandler) PKCEFlowCallback(w http.ResponseWriter, r *http.Reques
 	)
 	if err != nil {
 		if errors.Is(err, errEmptyAccessToken) {
-			h.logger.Warn("pkce flow: empty access token in response", "service", entry.ServiceID, "token_path", entry.TokenPath)
+			h.logger.WarnContext(r.Context(), "pkce flow: empty access token in response", "service", entry.ServiceID, "token_path", entry.TokenPath)
 			oauthPopupClose(w, "Provider returned empty access token.", "", entry.OpenerOrigin)
 			return
 		}
-		h.logger.Warn("pkce flow: failed to process token response", "service", entry.ServiceID, "err", err)
+		h.logger.WarnContext(r.Context(), "pkce flow: failed to process token response", "service", entry.ServiceID, "err", err)
 		oauthPopupClose(w, "Failed to process credential.", "", entry.OpenerOrigin)
 		return
 	}
@@ -2281,7 +2281,7 @@ func (h *ServicesHandler) PKCEFlowCallback(w http.ResponseWriter, r *http.Reques
 
 	vKey := h.adapterReg.VaultKeyWithAliasForUser(entry.ServiceID, alias, entry.UserID)
 	if err := h.vault.Set(r.Context(), entry.UserID, vKey, credBytes); err != nil {
-		h.logger.Warn("pkce flow: vault set failed", "err", err)
+		h.logger.WarnContext(r.Context(), "pkce flow: vault set failed", "err", err)
 		oauthPopupClose(w, "Failed to store credential.", "", entry.OpenerOrigin)
 		return
 	}
@@ -2291,7 +2291,7 @@ func (h *ServicesHandler) PKCEFlowCallback(w http.ResponseWriter, r *http.Reques
 		_ = h.st.UpsertServiceConfig(r.Context(), entry.UserID, entry.ServiceID, alias, configJSON)
 	}
 
-	h.logger.Info("service activated via PKCE flow", "user", entry.UserID, "service", entry.ServiceID, "alias", alias)
+	h.logger.InfoContext(r.Context(), "service activated via PKCE flow", "user", entry.UserID, "service", entry.ServiceID, "alias", alias)
 	oauthPopupClose(w, "", entry.CLICallback, entry.OpenerOrigin)
 }
 
@@ -2425,12 +2425,12 @@ func (h *ServicesHandler) SetGoogleOAuthConfig(w http.ResponseWriter, r *http.Re
 	}
 
 	if err := adapters.SetGoogleOAuthCredentials(r.Context(), h.vault, body.ClientID, body.ClientSecret); err != nil {
-		h.logger.Error("failed to store Google OAuth credentials", "err", err)
+		h.logger.ErrorContext(r.Context(), "failed to store Google OAuth credentials", "err", err)
 		writeError(w, http.StatusInternalServerError, "INTERNAL", "failed to store credentials")
 		return
 	}
 
-	h.logger.Info("Google OAuth credentials stored in system vault")
+	h.logger.InfoContext(r.Context(), "Google OAuth credentials stored in system vault")
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
 }
 
@@ -2467,12 +2467,12 @@ func (h *ServicesHandler) SetMicrosoftOAuthConfig(w http.ResponseWriter, r *http
 	}
 
 	if err := adapters.SetMicrosoftOAuthCredentials(r.Context(), h.vault, body.ClientID, body.ClientSecret); err != nil {
-		h.logger.Error("failed to store Microsoft OAuth credentials", "err", err)
+		h.logger.ErrorContext(r.Context(), "failed to store Microsoft OAuth credentials", "err", err)
 		writeError(w, http.StatusInternalServerError, "INTERNAL", "failed to store credentials")
 		return
 	}
 
-	h.logger.Info("Microsoft OAuth credentials stored in system vault")
+	h.logger.InfoContext(r.Context(), "Microsoft OAuth credentials stored in system vault")
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
 }
 
@@ -2519,12 +2519,12 @@ func (h *ServicesHandler) SetPKCECredential(w http.ResponseWriter, r *http.Reque
 	}
 
 	if err := adapters.SetPKCEClientID(r.Context(), h.vault, body.ServiceID, body.ClientID); err != nil {
-		h.logger.Error("failed to store PKCE client ID", "service_id", body.ServiceID, "err", err)
+		h.logger.ErrorContext(r.Context(), "failed to store PKCE client ID", "service_id", body.ServiceID, "err", err)
 		writeError(w, http.StatusInternalServerError, "INTERNAL", "failed to store credential")
 		return
 	}
 
-	h.logger.Info("PKCE client ID stored", "service_id", body.ServiceID)
+	h.logger.InfoContext(r.Context(), "PKCE client ID stored", "service_id", body.ServiceID)
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
 }
 
@@ -2541,12 +2541,12 @@ func (h *ServicesHandler) DeletePKCECredential(w http.ResponseWriter, r *http.Re
 	}
 
 	if err := adapters.DeletePKCEClientID(r.Context(), h.vault, serviceID); err != nil {
-		h.logger.Error("failed to delete PKCE client ID", "service_id", serviceID, "err", err)
+		h.logger.ErrorContext(r.Context(), "failed to delete PKCE client ID", "service_id", serviceID, "err", err)
 		writeError(w, http.StatusInternalServerError, "INTERNAL", "failed to delete credential")
 		return
 	}
 
-	h.logger.Info("PKCE client ID removed", "service_id", serviceID)
+	h.logger.InfoContext(r.Context(), "PKCE client ID removed", "service_id", serviceID)
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
 }
 
@@ -2563,7 +2563,7 @@ func (h *ServicesHandler) DeletePKCECredential(w http.ResponseWriter, r *http.Re
 func (h *ServicesHandler) ListMCPOAuthCredentials(w http.ResponseWriter, r *http.Request) {
 	entries, err := adapters.ListMCPOAuthCredentials(r.Context(), h.vault)
 	if err != nil {
-		h.logger.Error("failed to list MCP OAuth credentials", "err", err)
+		h.logger.ErrorContext(r.Context(), "failed to list MCP OAuth credentials", "err", err)
 		writeError(w, http.StatusInternalServerError, "INTERNAL", "failed to list MCP OAuth credentials")
 		return
 	}
@@ -2607,11 +2607,11 @@ func (h *ServicesHandler) SetMCPOAuthCredential(w http.ResponseWriter, r *http.R
 		}
 	}
 	if err := adapters.SetMCPOAuthCredentials(r.Context(), h.vault, body.ServiceID, body.ClientID, body.ClientSecret); err != nil {
-		h.logger.Error("failed to store MCP OAuth credentials", "service_id", body.ServiceID, "err", err)
+		h.logger.ErrorContext(r.Context(), "failed to store MCP OAuth credentials", "service_id", body.ServiceID, "err", err)
 		writeError(w, http.StatusInternalServerError, "INTERNAL", "failed to store credentials")
 		return
 	}
-	h.logger.Info("MCP OAuth credentials stored", "service_id", body.ServiceID)
+	h.logger.InfoContext(r.Context(), "MCP OAuth credentials stored", "service_id", body.ServiceID)
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
 }
 
@@ -2627,10 +2627,10 @@ func (h *ServicesHandler) DeleteMCPOAuthCredential(w http.ResponseWriter, r *htt
 		return
 	}
 	if err := adapters.DeleteMCPOAuthCredentials(r.Context(), h.vault, serviceID); err != nil {
-		h.logger.Error("failed to delete MCP OAuth credentials", "service_id", serviceID, "err", err)
+		h.logger.ErrorContext(r.Context(), "failed to delete MCP OAuth credentials", "service_id", serviceID, "err", err)
 		writeError(w, http.StatusInternalServerError, "INTERNAL", "failed to delete credentials")
 		return
 	}
-	h.logger.Info("MCP OAuth credentials removed", "service_id", serviceID)
+	h.logger.InfoContext(r.Context(), "MCP OAuth credentials removed", "service_id", serviceID)
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
 }

--- a/internal/api/handlers/skill.go
+++ b/internal/api/handlers/skill.go
@@ -362,7 +362,7 @@ func (h *SkillHandler) writeCatalogOverview(buf *strings.Builder, ctx context.Co
 	if h.localSvcProvider != nil {
 		localServices, err := h.localSvcProvider.ActiveLocalServices(ctx, userID)
 		if err != nil {
-			h.logger.Warn("failed to fetch local services for catalog", "err", err)
+			h.logger.WarnContext(ctx, "failed to fetch local services for catalog", "err", err)
 		} else if len(localServices) > 0 {
 			buf.WriteString("---\n\n")
 			buf.WriteString("# Local Services\n\n")

--- a/internal/api/handlers/tasks.go
+++ b/internal/api/handlers/tasks.go
@@ -221,7 +221,7 @@ func (h *TasksHandler) Create(w http.ResponseWriter, r *http.Request) {
 			})
 			return
 		}
-		h.logger.Warn("deprecated: task created with planned_calls but no authorized_actions; deriving scope from planned_calls",
+		h.logger.WarnContext(ctx, "deprecated: task created with planned_calls but no authorized_actions; deriving scope from planned_calls",
 			"agent_id", agent.ID,
 			"derived_scope_count", len(req.AuthorizedActions),
 		)
@@ -589,7 +589,7 @@ func (h *TasksHandler) Create(w http.ResponseWriter, r *http.Request) {
 			}
 			llmAssessment, err := h.assessor.Assess(ctx, llmReq)
 			if err != nil {
-				h.logger.Warn("task risk assessment failed", "error", err)
+				h.logger.WarnContext(ctx, "task risk assessment failed", "error", err)
 			}
 			assessment = llmAssessment
 		}
@@ -661,7 +661,7 @@ func (h *TasksHandler) Create(w http.ResponseWriter, r *http.Request) {
 					AgentName:           agent.Name,
 				})
 				if err != nil {
-					h.logger.Warn("group chat approval check failed", "err", err, "user_id", agent.UserID)
+					h.logger.WarnContext(ctx, "group chat approval check failed", "err", err, "user_id", agent.UserID)
 				} else if result != nil && result.Approved {
 					preApproved = true
 					task.Status = "active"
@@ -677,7 +677,7 @@ func (h *TasksHandler) Create(w http.ResponseWriter, r *http.Request) {
 						"latency_ms":  result.LatencyMS,
 					})
 					task.ApprovalRationale = rationale
-					h.logger.Info("task auto-approved via group chat LLM check",
+					h.logger.InfoContext(ctx, "task auto-approved via group chat LLM check",
 						"task_id", task.ID, "confidence", result.Confidence,
 						"explanation", result.Explanation, "model", result.Model,
 						"latency_ms", result.LatencyMS)
@@ -687,13 +687,13 @@ func (h *TasksHandler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.st.CreateTask(ctx, task); err != nil {
-		h.logger.Warn("create task failed", "err", err)
+		h.logger.WarnContext(ctx, "create task failed", "err", err)
 		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not create task")
 		return
 	}
 	if !preApproved {
 		if err := h.createCanonicalTaskApproval(ctx, task, "task_create"); err != nil {
-			h.logger.Error("failed to create canonical task approval", "task_id", task.ID, "err", err)
+			h.logger.ErrorContext(ctx, "failed to create canonical task approval", "task_id", task.ID, "err", err)
 		}
 	}
 
@@ -757,7 +757,7 @@ func (h *TasksHandler) Create(w http.ResponseWriter, r *http.Request) {
 			DenyURL:      denyURL,
 			ExpiresIn:    expiresInStr,
 		}); err != nil {
-			h.logger.Warn("failed to send task approval notification", "task_id", task.ID, "err", err)
+			h.logger.WarnContext(ctx, "failed to send task approval notification", "task_id", task.ID, "err", err)
 		} else if msgID != "" {
 			_ = h.st.SaveNotificationMessage(ctx, "task", task.ID, "telegram", msgID)
 		}
@@ -1051,7 +1051,7 @@ func (h *TasksHandler) List(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	h.logger.Info("listing tasks", "active_only", filter.ActiveOnly, "status", filter.Status, "limit", filter.Limit, "offset", filter.Offset)
+	h.logger.InfoContext(ctx, "listing tasks", "active_only", filter.ActiveOnly, "status", filter.Status, "limit", filter.Limit, "offset", filter.Offset)
 
 	tasks, total, err := h.st.ListTasks(ctx, user.ID, filter)
 	if err != nil {
@@ -1733,7 +1733,7 @@ func (h *TasksHandler) Deny(w http.ResponseWriter, r *http.Request) {
 	}
 	h.resolveCanonicalTaskApproval(ctx, task, canonicalTaskApprovalKind(task), "deny", "denied")
 	if err := h.st.DeleteChainFactsByTask(ctx, taskID); err != nil {
-		h.logger.Warn("chain facts cleanup failed", "err", err, "task_id", taskID)
+		h.logger.WarnContext(ctx, "chain facts cleanup failed", "err", err, "task_id", taskID)
 	}
 
 	h.publishTasksAndQueue(user.ID)
@@ -1792,7 +1792,7 @@ func (h *TasksHandler) Complete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := h.st.DeleteChainFactsByTask(ctx, taskID); err != nil {
-		h.logger.Warn("chain facts cleanup failed", "err", err, "task_id", taskID)
+		h.logger.WarnContext(ctx, "chain facts cleanup failed", "err", err, "task_id", taskID)
 	}
 
 	h.publishTasksAndQueue(agent.UserID)
@@ -1991,7 +1991,7 @@ func (h *TasksHandler) Expand(w http.ResponseWriter, r *http.Request) {
 	task.PendingReason = req.Reason
 	task.Status = "pending_scope_expansion"
 	if err := h.createCanonicalTaskApproval(ctx, task, "task_expand"); err != nil {
-		h.logger.Error("failed to create canonical scope expansion approval", "task_id", taskID, "err", err)
+		h.logger.ErrorContext(ctx, "failed to create canonical scope expansion approval", "task_id", taskID, "err", err)
 	}
 
 	// Send notification.
@@ -2009,7 +2009,7 @@ func (h *TasksHandler) Expand(w http.ResponseWriter, r *http.Request) {
 			ApproveURL: approveURL,
 			DenyURL:    denyURL,
 		}); err != nil {
-			h.logger.Warn("failed to send scope expansion notification", "task_id", taskID, "err", err)
+			h.logger.WarnContext(ctx, "failed to send scope expansion notification", "task_id", taskID, "err", err)
 		} else if msgID != "" {
 			_ = h.st.SaveNotificationMessage(ctx, "task", taskID, "telegram", msgID)
 		}
@@ -2429,16 +2429,16 @@ func (h *TasksHandler) resolveCanonicalTaskApproval(ctx context.Context, task *s
 	rec, err := h.findPendingTaskApprovalRecord(ctx, task.UserID, task.ID, kind)
 	if err != nil {
 		if !errors.Is(err, store.ErrNotFound) {
-			h.logger.Error("failed to load canonical task approval", "task_id", task.ID, "kind", kind, "err", err)
+			h.logger.ErrorContext(ctx, "failed to load canonical task approval", "task_id", task.ID, "kind", kind, "err", err)
 		}
 		return
 	}
 	if err := validateApprovalRecordTransition(rec, resolution, status); err != nil {
-		h.logger.Error("illegal canonical task approval transition", "task_id", task.ID, "approval_id", rec.ID, "kind", rec.Kind, "from_status", rec.Status, "resolution", resolution, "status", status, "err", err)
+		h.logger.ErrorContext(ctx, "illegal canonical task approval transition", "task_id", task.ID, "approval_id", rec.ID, "kind", rec.Kind, "from_status", rec.Status, "resolution", resolution, "status", status, "err", err)
 		return
 	}
 	if err := h.st.ResolveApprovalRecord(ctx, rec.ID, resolution, status, time.Now().UTC()); err != nil {
-		h.logger.Error("failed to resolve canonical task approval", "task_id", task.ID, "approval_id", rec.ID, "err", err)
+		h.logger.ErrorContext(ctx, "failed to resolve canonical task approval", "task_id", task.ID, "approval_id", rec.ID, "err", err)
 	}
 }
 
@@ -2473,7 +2473,7 @@ func (h *TasksHandler) updateNotificationMsg(ctx context.Context, targetType, ta
 		return
 	}
 	if err := h.notifier.UpdateMessage(ctx, userID, msgID, text); err != nil {
-		h.logger.Warn("telegram message update failed", "err", err, "target_type", targetType, "target_id", targetID)
+		h.logger.WarnContext(ctx, "telegram message update failed", "err", err, "target_type", targetType, "target_id", targetID)
 	}
 }
 
@@ -2510,7 +2510,7 @@ func (h *TasksHandler) Revoke(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := h.st.DeleteChainFactsByTask(ctx, taskID); err != nil {
-		h.logger.Warn("chain facts cleanup failed", "err", err, "task_id", taskID)
+		h.logger.WarnContext(ctx, "chain facts cleanup failed", "err", err, "task_id", taskID)
 	}
 
 	h.publishTasksAndQueue(user.ID)

--- a/internal/api/handlers/tasks_inline.go
+++ b/internal/api/handlers/tasks_inline.go
@@ -225,7 +225,7 @@ func (h *TasksHandler) createInlineApprovedTask(ctx context.Context, agent *stor
 			ExpectedUse:            env.ExpectedUse,
 		})
 		if err != nil {
-			h.logger.Warn("inline task risk assessment failed", "error", err)
+			h.logger.WarnContext(ctx, "inline task risk assessment failed", "error", err)
 		}
 		if llmAssessment != nil && !strings.EqualFold(llmAssessment.RiskLevel, "unknown") {
 			finalAssessment = mergeRiskAssessments(llmAssessment, envelopeAssessment)
@@ -248,7 +248,7 @@ func (h *TasksHandler) createInlineApprovedTask(ctx context.Context, agent *stor
 		var err error
 		credentialPlaceholders, err = h.mintTaskCredentialPlaceholders(ctx, task, requiredCredentials, credentialExpiresAt)
 		if err != nil {
-			h.logger.Error("failed to mint inline task credential placeholders; denying task to avoid orphaned active credential task",
+			h.logger.ErrorContext(ctx, "failed to mint inline task credential placeholders; denying task to avoid orphaned active credential task",
 				"task_id", task.ID, "err", err)
 			// Rollback must outlive the inbound request — a client
 			// disconnect that cancels ctx between the mint failure and
@@ -257,7 +257,7 @@ func (h *TasksHandler) createInlineApprovedTask(ctx context.Context, agent *stor
 			// values (logging, tracing).
 			rollbackCtx := context.WithoutCancel(ctx)
 			if rollbackErr := h.st.UpdateTaskStatus(rollbackCtx, task.ID, "denied"); rollbackErr != nil {
-				h.logger.Error("CRITICAL: credential placeholder mint failed AND rollback failed; task is now orphaned active",
+				h.logger.ErrorContext(ctx, "CRITICAL: credential placeholder mint failed AND rollback failed; task is now orphaned active",
 					"task_id", task.ID, "mint_err", err, "rollback_err", rollbackErr)
 			}
 			return nil, fmt.Errorf("mint credential placeholders: %w", err)
@@ -279,14 +279,14 @@ func (h *TasksHandler) createInlineApprovedTask(ctx context.Context, agent *stor
 		// authorize anything, then fail the inline-create — the caller
 		// will rewrite the user message as a deny with the approval
 		// error surfaced to the LLM.
-		h.logger.Error("failed to create inline approval record; denying task to preserve audit invariant",
+		h.logger.ErrorContext(ctx, "failed to create inline approval record; denying task to preserve audit invariant",
 			"task_id", task.ID, "err", err)
 		rollbackCtx := context.WithoutCancel(ctx)
 		if rollbackErr := h.st.UpdateTaskStatus(rollbackCtx, task.ID, "denied"); rollbackErr != nil {
 			// Best-effort: log loudly. The original error is what we
 			// surface; an orphaned active task here is far worse than
 			// any other failure mode, so flag it.
-			h.logger.Error("CRITICAL: approval record failed AND rollback failed; task is now orphaned active",
+			h.logger.ErrorContext(ctx, "CRITICAL: approval record failed AND rollback failed; task is now orphaned active",
 				"task_id", task.ID, "approval_err", err, "rollback_err", rollbackErr)
 		}
 		return nil, fmt.Errorf("create inline approval record: %w", err)

--- a/internal/api/handlers/welcome.go
+++ b/internal/api/handlers/welcome.go
@@ -115,14 +115,14 @@ func (h *WelcomeHandler) Suggestions(w http.ResponseWriter, r *http.Request) {
 
 	services, err := h.listActivatedServices(ctx, user.ID)
 	if err != nil {
-		h.logger.Warn("welcome: failed to list services", "err", err)
+		h.logger.WarnContext(ctx, "welcome: failed to list services", "err", err)
 		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not list services")
 		return
 	}
 
 	agents, err := h.st.ListAgents(ctx, user.ID)
 	if err != nil {
-		h.logger.Warn("welcome: failed to list agents", "err", err)
+		h.logger.WarnContext(ctx, "welcome: failed to list agents", "err", err)
 		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not list agents")
 		return
 	}
@@ -165,7 +165,7 @@ func (h *WelcomeHandler) Suggestions(w http.ResponseWriter, r *http.Request) {
 			h.llmHealth.SetSpendCapExhausted()
 			resp.LLMStatus = "exhausted"
 		} else {
-			h.logger.Warn("welcome: suggestion generation failed", "err", err)
+			h.logger.WarnContext(ctx, "welcome: suggestion generation failed", "err", err)
 			resp.LLMStatus = "error"
 		}
 		writeJSON(w, http.StatusOK, resp)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1406,7 +1406,7 @@ func (s *Server) consumeNotifierDecisions(ctx context.Context, ch <-chan notify.
 				}
 			}
 			if err != nil {
-				s.logger.Warn("notifier decision failed",
+				s.logger.WarnContext(ctx, "notifier decision failed",
 					"type", d.Type, "action", d.Action,
 					"target_id", d.TargetID, "err", err)
 			}

--- a/internal/callback/callback.go
+++ b/internal/callback/callback.go
@@ -186,7 +186,7 @@ func DeliverResult(ctx context.Context, callbackURL string, payload *Payload, si
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		idKey, idVal := payloadIDAttr(payload)
-		slog.Warn("callback: delivery failed",
+		slog.WarnContext(ctx, "callback: delivery failed",
 			"url", callbackURL,
 			"type", payload.Type,
 			idKey, idVal,
@@ -199,7 +199,7 @@ func DeliverResult(ctx context.Context, callbackURL string, payload *Payload, si
 	if resp.StatusCode >= 300 {
 		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		idKey, idVal := payloadIDAttr(payload)
-		slog.Warn("callback: non-success response",
+		slog.WarnContext(ctx, "callback: non-success response",
 			"url", callbackURL,
 			"type", payload.Type,
 			idKey, idVal,

--- a/internal/events/redis_hub.go
+++ b/internal/events/redis_hub.go
@@ -111,7 +111,7 @@ func (h *RedisHub) forwardFromRedis(ctx context.Context, userID string) {
 			}
 			var e Event
 			if err := json.Unmarshal([]byte(msg.Payload), &e); err != nil {
-				h.logger.Warn("redis hub: unmarshal event", "err", err)
+				h.logger.WarnContext(ctx, "redis hub: unmarshal event", "err", err)
 				continue
 			}
 			h.local.Publish(userID, e)

--- a/internal/intent/extractor.go
+++ b/internal/intent/extractor.go
@@ -535,7 +535,7 @@ func (e *LLMExtractor) ExtractLLM(ctx context.Context, req ExtractRequest, exist
 		if errors.Is(err, llm.ErrSpendCapExhausted) {
 			e.health.SetSpendCapExhausted()
 		}
-		e.logger.Warn("chain context extraction LLM call failed", "err", err, "task_id", req.TaskID)
+		e.logger.WarnContext(ctx, "chain context extraction LLM call failed", "err", err, "task_id", req.TaskID)
 		return nil, nil
 	}
 	llm.LogUsage(e.logger, "chain_context_extraction", cfg.Model, usage)
@@ -546,7 +546,7 @@ func (e *LLMExtractor) ExtractLLM(ctx context.Context, req ExtractRequest, exist
 	// brace-matching to avoid those failure modes.
 	extracted := extractFirstJSONValue(raw)
 	if extracted == "" {
-		e.logger.Warn("chain context extraction: no JSON value found in response", "task_id", req.TaskID)
+		e.logger.WarnContext(ctx, "chain context extraction: no JSON value found in response", "task_id", req.TaskID)
 		return nil, nil
 	}
 	directFacts, patterns := parseExtractionResponse(extracted, e.logger, req.TaskID)
@@ -561,7 +561,7 @@ func (e *LLMExtractor) ExtractLLM(ctx context.Context, req ExtractRequest, exist
 
 	facts, dropped := mergeExtractionResults(directFacts, patterns, seen, req, e.logger)
 
-	e.logger.Debug("chain context LLM extraction complete",
+	e.logger.DebugContext(ctx, "chain context LLM extraction complete",
 		"task_id", req.TaskID,
 		"direct_facts", len(directFacts)-dropped,
 		"dropped", dropped,

--- a/internal/intent/verifier.go
+++ b/internal/intent/verifier.go
@@ -157,7 +157,7 @@ func (v *LLMVerifier) StartGeminiCache(ctx context.Context, cfg llm.GeminiCacheM
 	for _, vr := range variants {
 		mgr, nameFn, invalidator, err := llm.StartCachedSystemPrompt(ctx, cfg, vr.prompt)
 		if err != nil {
-			logger.Warn("verifier gemini cache start failed for variant; running uncached for this variant",
+			logger.WarnContext(ctx, "verifier gemini cache start failed for variant; running uncached for this variant",
 				"variant", vr.variant.String(), "err", err)
 			if firstErr == nil {
 				firstErr = fmt.Errorf("verifier gemini cache (%s): %w", vr.variant.String(), err)
@@ -297,7 +297,7 @@ func (v *LLMVerifier) Verify(ctx context.Context, req VerifyRequest) (*Verificat
 		return verdict, nil
 	}
 
-	v.logger.Warn("intent verification failed after retry",
+	v.logger.WarnContext(ctx, "intent verification failed after retry",
 		"error", lastErr,
 		"service", req.Service,
 		"action", req.Action,

--- a/internal/llm/gemini_cache.go
+++ b/internal/llm/gemini_cache.go
@@ -114,7 +114,7 @@ func (m *GeminiCacheManager) Start(ctx context.Context) error {
 		return fmt.Errorf("create initial cache: %w", err)
 	}
 	m.cacheName.Store(name)
-	m.logger.Info("gemini cache created",
+	m.logger.InfoContext(ctx, "gemini cache created",
 		"name", name, "model", m.cfg.Model, "ttl", m.cfg.TTL)
 	go m.refreshLoop()
 	return nil
@@ -190,12 +190,12 @@ func (m *GeminiCacheManager) InvalidateIfMatches(failed string) {
 		defer cancel()
 		newName, err := m.create(ctx)
 		if err != nil {
-			m.logger.Warn("gemini cache async refresh after invalidation failed",
+			m.logger.WarnContext(ctx, "gemini cache async refresh after invalidation failed",
 				"err", err)
 			return
 		}
 		m.cacheName.Store(newName)
-		m.logger.Info("gemini cache repopulated after invalidation",
+		m.logger.InfoContext(ctx, "gemini cache repopulated after invalidation",
 			"name", newName)
 	}()
 }
@@ -218,7 +218,7 @@ func (m *GeminiCacheManager) Stop(ctx context.Context) {
 		if name, _ := m.cacheName.Load().(string); name != "" {
 			m.cacheName.Store("")
 			if err := m.delete(ctx, name); err != nil {
-				m.logger.Warn("gemini cache delete on shutdown failed (will auto-expire)",
+				m.logger.WarnContext(ctx, "gemini cache delete on shutdown failed (will auto-expire)",
 					"err", err, "name", name)
 			}
 		}
@@ -252,13 +252,13 @@ func (m *GeminiCacheManager) refreshLoop() {
 			newName, err := m.create(ctx)
 			cancel()
 			if err != nil {
-				m.logger.Warn("gemini cache refresh failed; keeping old cache until it expires",
+				m.logger.WarnContext(ctx, "gemini cache refresh failed; keeping old cache until it expires",
 					"err", err)
 				continue
 			}
 			old, _ := m.cacheName.Load().(string)
 			m.cacheName.Store(newName)
-			m.logger.Info("gemini cache refreshed",
+			m.logger.InfoContext(ctx, "gemini cache refreshed",
 				"new_name", newName, "old_name", old)
 			// Best-effort delete the old cache. Don't block the loop on it.
 			if old != "" {
@@ -266,7 +266,7 @@ func (m *GeminiCacheManager) refreshLoop() {
 					ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 					defer cancel()
 					if err := m.delete(ctx, name); err != nil {
-						m.logger.Debug("delete of old cache failed (will auto-expire)",
+						m.logger.DebugContext(ctx, "delete of old cache failed (will auto-expire)",
 							"err", err, "name", name)
 					}
 				}(old)

--- a/internal/local/daemon/daemon.go
+++ b/internal/local/daemon/daemon.go
@@ -115,7 +115,7 @@ func (d *Daemon) RunContext(ctx context.Context) error {
 	paired := d.state.IsPaired()
 	d.mu.RUnlock()
 
-	d.logger.Info("starting", "version", version.Version, "daemon_id", daemonID)
+	d.logger.InfoContext(ctx, "starting", "version", version.Version, "daemon_id", daemonID)
 
 	// Initialize server manager.
 	d.serverMgr = executor.NewServerManager(d.baseDir)
@@ -168,7 +168,7 @@ func (d *Daemon) RunContext(ctx context.Context) error {
 
 	<-ctx.Done()
 
-	d.logger.Info("shutting down")
+	d.logger.InfoContext(ctx, "shutting down")
 
 	if scanTicker != nil {
 		scanTicker.Stop()
@@ -419,7 +419,7 @@ func (d *Daemon) handleRequest(ctx context.Context, id string, req *tunnel.Reque
 
 	if tc != nil {
 		if err := tc.SendResponse(id, payload); err != nil {
-			d.logger.Warn("failed to send response", "request_id", id, "err", err)
+			d.logger.WarnContext(ctx, "failed to send response", "request_id", id, "err", err)
 		}
 	}
 }

--- a/internal/local/tunnel/client.go
+++ b/internal/local/tunnel/client.go
@@ -218,7 +218,7 @@ func (c *Client) readLoop(connCtx context.Context, conn *websocket.Conn) error {
 
 		var frame Frame
 		if err := json.Unmarshal(data, &frame); err != nil {
-			c.logger.Warn("tunnel: invalid frame", "err", err)
+			c.logger.WarnContext(connCtx, "tunnel: invalid frame", "err", err)
 			continue
 		}
 
@@ -226,7 +226,7 @@ func (c *Client) readLoop(connCtx context.Context, conn *websocket.Conn) error {
 		case FrameRequest:
 			var req RequestPayload
 			if err := json.Unmarshal(frame.Payload, &req); err != nil {
-				c.logger.Warn("tunnel: invalid request payload", "err", err)
+				c.logger.WarnContext(connCtx, "tunnel: invalid request payload", "err", err)
 				continue
 			}
 			if c.onRequest != nil {
@@ -238,7 +238,7 @@ func (c *Client) readLoop(connCtx context.Context, conn *websocket.Conn) error {
 			// reset on each successful Read call.
 
 		default:
-			c.logger.Debug("tunnel: unknown frame type", "type", frame.Type)
+			c.logger.DebugContext(connCtx, "tunnel: unknown frame type", "type", frame.Type)
 		}
 	}
 }
@@ -253,7 +253,7 @@ func (c *Client) pingLoop(connCtx context.Context, connCancel context.CancelFunc
 			return
 		case <-ticker.C:
 			if err := c.writeFrame(FramePing, generateFrameID(), map[string]string{}); err != nil {
-				c.logger.Warn("tunnel: ping write failed, closing connection", "err", err)
+				c.logger.WarnContext(connCtx, "tunnel: ping write failed, closing connection", "err", err)
 				connCancel()
 				return
 			}

--- a/internal/mcp/oauth/provider.go
+++ b/internal/mcp/oauth/provider.go
@@ -84,7 +84,7 @@ func (p *Provider) Register(w http.ResponseWriter, r *http.Request) {
 		RedirectURIs: req.RedirectURIs,
 	}
 	if err := p.st.CreateOAuthClient(r.Context(), client); err != nil {
-		p.logger.Error("failed to create oauth client", "err", err)
+		p.logger.ErrorContext(r.Context(), "failed to create oauth client", "err", err)
 		writeOAuthError(w, http.StatusInternalServerError, "server_error", "failed to register client")
 		return
 	}
@@ -163,7 +163,7 @@ func (p *Provider) AuthorizeApprove(w http.ResponseWriter, r *http.Request) {
 		ExpiresAt:     time.Now().Add(5 * time.Minute),
 	}
 	if err := p.st.SaveAuthorizationCode(r.Context(), authCode); err != nil {
-		p.logger.Error("failed to save authorization code", "err", err)
+		p.logger.ErrorContext(r.Context(), "failed to save authorization code", "err", err)
 		writeOAuthError(w, http.StatusInternalServerError, "server_error", "failed to save authorization code")
 		return
 	}
@@ -307,7 +307,7 @@ func (p *Provider) Token(w http.ResponseWriter, r *http.Request) {
 	_, err = p.st.CreateAgentWithExpiry(r.Context(), authCode.UserID, agentName,
 		auth.HashToken(rawToken), time.Now().UTC().Add(mcpTokenTTL))
 	if err != nil {
-		p.logger.Error("failed to create agent for oauth token", "err", err)
+		p.logger.ErrorContext(r.Context(), "failed to create agent for oauth token", "err", err)
 		writeOAuthError(w, http.StatusInternalServerError, "server_error", "failed to create agent")
 		return
 	}
@@ -348,7 +348,7 @@ func (p *Provider) handleRelayPairing(w http.ResponseWriter, r *http.Request) {
 	// Look up the local user — in daemon mode this is always admin@local.
 	user, err := p.st.GetUserByEmail(r.Context(), "admin@local")
 	if err != nil {
-		p.logger.Error("relay_pairing: could not find local user", "err", err)
+		p.logger.ErrorContext(r.Context(), "relay_pairing: could not find local user", "err", err)
 		writeOAuthError(w, http.StatusInternalServerError, "server_error", "could not resolve local user")
 		return
 	}
@@ -356,7 +356,7 @@ func (p *Provider) handleRelayPairing(w http.ResponseWriter, r *http.Request) {
 	// Generate a long-lived agent token (same as authorization_code grant).
 	token, err := auth.GenerateAgentToken()
 	if err != nil {
-		p.logger.Error("relay_pairing: failed to generate agent token", "err", err)
+		p.logger.ErrorContext(r.Context(), "relay_pairing: failed to generate agent token", "err", err)
 		writeOAuthError(w, http.StatusInternalServerError, "server_error", "failed to generate token")
 		return
 	}
@@ -368,7 +368,7 @@ func (p *Provider) handleRelayPairing(w http.ResponseWriter, r *http.Request) {
 	const relayTokenTTL = 30 * 24 * time.Hour
 	if _, err := p.st.CreateAgentWithExpiry(r.Context(), user.ID, agentName, tokenHash,
 		time.Now().UTC().Add(relayTokenTTL)); err != nil {
-		p.logger.Error("relay_pairing: failed to create agent", "err", err)
+		p.logger.ErrorContext(r.Context(), "relay_pairing: failed to create agent", "err", err)
 		writeOAuthError(w, http.StatusInternalServerError, "server_error", "failed to create agent")
 		return
 	}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -41,7 +41,7 @@ func (s *Server) HandleJSONRPC(w http.ResponseWriter, r *http.Request, req *Requ
 		// Notification — validate session but no response either way.
 		sessionID := r.Header.Get("Mcp-Session-Id")
 		if !s.sessions.Valid(r.Context(), sessionID) {
-			s.logger.Warn("notifications/initialized with invalid session", "session_id", sessionID)
+			s.logger.WarnContext(r.Context(), "notifications/initialized with invalid session", "session_id", sessionID)
 		}
 		return nil
 	case "ping", "tools/list", "tools/call", "prompts/list", "prompts/get":

--- a/internal/mcp/session.go
+++ b/internal/mcp/session.go
@@ -45,7 +45,7 @@ func (s *SessionStore) Create(ctx context.Context) (string, error) {
 func (s *SessionStore) Valid(ctx context.Context, id string) bool {
 	ok, err := s.store.MCPSessionValid(ctx, id)
 	if err != nil {
-		s.logger.Warn("mcp session lookup failed", "session_id", id, "err", err)
+		s.logger.WarnContext(ctx, "mcp session lookup failed", "session_id", id, "err", err)
 		return false
 	}
 	return ok

--- a/internal/mcp/tools_exec.go
+++ b/internal/mcp/tools_exec.go
@@ -61,7 +61,7 @@ func executeTool(
 	respBody := rec.Body.String()
 	statusCode := rec.Code
 
-	logger.Debug("mcp tool executed",
+	logger.DebugContext(originalReq.Context(), "mcp tool executed",
 		"tool", toolName,
 		"status", statusCode,
 		"response_len", len(respBody),

--- a/internal/notify/decision_redis.go
+++ b/internal/notify/decision_redis.go
@@ -54,7 +54,7 @@ func (b *RedisDecisionBus) Subscribe(ctx context.Context) <-chan notify.Callback
 				if err == redis.Nil {
 					continue // timeout, loop again
 				}
-				b.logger.Warn("redis decision bus: brpop", "err", err)
+				b.logger.WarnContext(ctx, "redis decision bus: brpop", "err", err)
 				time.Sleep(100 * time.Millisecond)
 				continue
 			}
@@ -64,7 +64,7 @@ func (b *RedisDecisionBus) Subscribe(ctx context.Context) <-chan notify.Callback
 			}
 			var d notify.CallbackDecision
 			if err := json.Unmarshal([]byte(result[1]), &d); err != nil {
-				b.logger.Warn("redis decision bus: unmarshal", "err", err)
+				b.logger.WarnContext(ctx, "redis decision bus: unmarshal", "err", err)
 				continue
 			}
 			select {

--- a/internal/notify/push/notifier.go
+++ b/internal/notify/push/notifier.go
@@ -382,9 +382,9 @@ func (n *Notifier) sendToDevices(ctx context.Context, userID string, p pushPaylo
 				AlertBody:         p.LiveActivity.AlertBody,
 			}
 			laBody, _ := json.Marshal(laReq)
-			n.logger.Info("push: sending live activity", "token_count", len(ptsTokens))
+			n.logger.InfoContext(ctx, "push: sending live activity", "token_count", len(ptsTokens))
 			if err := n.signedPost(ctx, "/api/push/live-activity", laBody); err != nil {
-				n.logger.Warn("push: live activity failed", "err", err)
+				n.logger.WarnContext(ctx, "push: live activity failed", "err", err)
 			}
 			return "push:" + n.daemonID, nil
 		}
@@ -403,7 +403,7 @@ func (n *Notifier) sendToDevices(ctx context.Context, userID string, p pushPaylo
 		return "", err
 	}
 
-	n.logger.Info("push: sending notification", "category", p.Category, "title", p.Title, "data", p.Data, "device_count", len(tokens))
+	n.logger.InfoContext(ctx, "push: sending notification", "category", p.Category, "title", p.Title, "data", p.Data, "device_count", len(tokens))
 
 	if err := n.signedPost(ctx, "/api/push", body); err != nil {
 		return "", err

--- a/internal/notify/telegram/polling.go
+++ b/internal/notify/telegram/polling.go
@@ -131,7 +131,7 @@ func (n *Notifier) DecrementPolling(userID string) {
 func (n *Notifier) BootstrapGroupObservation(ctx context.Context) {
 	groups, err := n.store.ListAllTelegramGroups(ctx)
 	if err != nil {
-		slog.Default().Warn("bootstrap group observation: list telegram_groups failed", "err", err)
+		slog.Default().WarnContext(ctx, "bootstrap group observation: list telegram_groups failed", "err", err)
 		return
 	}
 
@@ -157,7 +157,7 @@ func (n *Notifier) BootstrapGroupObservation(ctx context.Context) {
 			continue
 		}
 		n.EnsureGroupObservation(g.UserID, bi.botToken, bi.chatID, g.GroupChatID)
-		slog.Default().Info("group observation bootstrapped", "user_id", g.UserID, "group_chat_id", g.GroupChatID)
+		slog.Default().InfoContext(ctx, "group observation bootstrapped", "user_id", g.UserID, "group_chat_id", g.GroupChatID)
 	}
 }
 
@@ -173,14 +173,14 @@ func (n *Notifier) pollForCallbacks(ctx context.Context, ps *pollingSession) {
 	// Acquire distributed lock before polling. Only one instance should
 	// call getUpdates per bot token.
 	if !n.pollingLock.Acquire(ctx, ps.userID) {
-		logger.Debug("callback polling: lock not acquired, another instance is polling", "user_id", ps.userID)
+		logger.DebugContext(ctx, "callback polling: lock not acquired, another instance is polling", "user_id", ps.userID)
 		return
 	}
 
 	// Drain old updates to get current offset.
 	updates, err := n.getUpdates(ctx, ps.botToken, 0, 0)
 	if err != nil {
-		logger.Warn("callback polling: drain failed", "user_id", ps.userID, "err", err)
+		logger.WarnContext(ctx, "callback polling: drain failed", "user_id", ps.userID, "err", err)
 		return
 	}
 	var offset int
@@ -254,7 +254,7 @@ func (n *Notifier) handleChatMemberUpdate(ctx context.Context, ps *pollingSessio
 		DetectedAt: time.Now(),
 	})
 
-	slog.Default().Info("telegram bot added to group",
+	slog.Default().InfoContext(ctx, "telegram bot added to group",
 		"user_id", ps.userID, "chat_id", chatID, "title", cm.Chat.Title)
 
 	// Send a DM to the user's private chat.
@@ -385,7 +385,7 @@ func (n *Notifier) handleCallbackQuery(ctx context.Context, ps *pollingSession, 
 	// Decrement pending count.
 	n.DecrementPolling(ps.userID)
 
-	logger.Info("telegram callback processed",
+	logger.InfoContext(ctx, "telegram callback processed",
 		"user_id", entry.UserID, "type", entry.Type,
 		"target_id", entry.TargetID, "action", action)
 }

--- a/internal/relay/client.go
+++ b/internal/relay/client.go
@@ -134,7 +134,7 @@ func (c *Client) register(ctx context.Context) error {
 
 	c.daemonID = result.DaemonID
 	c.registered = true
-	c.logger.Info("relay: registered with relay", "daemon_id", result.DaemonID)
+	c.logger.InfoContext(ctx, "relay: registered with relay", "daemon_id", result.DaemonID)
 	return nil
 }
 
@@ -146,7 +146,7 @@ func (c *Client) Run(ctx context.Context) error {
 	// daemon_id if the key is already known.
 	if !c.registered {
 		if err := c.register(ctx); err != nil {
-			c.logger.Warn("relay: initial registration failed, will retry on auth failure", "err", err)
+			c.logger.WarnContext(ctx, "relay: initial registration failed, will retry on auth failure", "err", err)
 		}
 	}
 
@@ -164,10 +164,10 @@ func (c *Client) Run(ctx context.Context) error {
 		if err != nil && isAuthError(err) {
 			consecutiveAuthFailures++
 			if regErr := c.register(ctx); regErr != nil {
-				c.logger.Warn("relay: re-registration failed", "err", regErr)
+				c.logger.WarnContext(ctx, "relay: re-registration failed", "err", regErr)
 			}
 			if consecutiveAuthFailures >= maxConsecutiveAuthFailures {
-				c.logger.Error("relay auth failing repeatedly — check daemon key/config",
+				c.logger.ErrorContext(ctx, "relay auth failing repeatedly — check daemon key/config",
 					"err", err, "consecutive_failures", consecutiveAuthFailures)
 			}
 		} else {
@@ -181,7 +181,7 @@ func (c *Client) Run(ctx context.Context) error {
 			delay = c.baseDelay
 		}
 
-		c.logger.Warn("relay connection lost, reconnecting",
+		c.logger.WarnContext(ctx, "relay connection lost, reconnecting",
 			"err", err, "delay", delay)
 
 		// Apply ±25% jitter.
@@ -274,7 +274,7 @@ func (c *Client) connectAndServe(ctx context.Context) (connectedAt time.Time, er
 		conn.Close(websocket.StatusNormalClosure, "")
 	}()
 
-	c.logger.Info("relay connected", "daemon_id", c.daemonID)
+	c.logger.InfoContext(connCtx, "relay connected", "daemon_id", c.daemonID)
 
 	// Send periodic pings to keep the connection alive. The relay may not
 	// send traffic during idle periods, so without client-side pings the
@@ -288,7 +288,7 @@ func (c *Client) connectAndServe(ctx context.Context) (connectedAt time.Time, er
 				return
 			case <-ticker.C:
 				if err := c.sendFrame(FramePing, "", nil); err != nil {
-					c.logger.Warn("relay: ping write failed, closing connection", "err", err)
+					c.logger.WarnContext(connCtx, "relay: ping write failed, closing connection", "err", err)
 					connCancel() // tear down read loop
 					return
 				}
@@ -307,7 +307,7 @@ func (c *Client) connectAndServe(ctx context.Context) (connectedAt time.Time, er
 
 		var frame Frame
 		if err := json.Unmarshal(data, &frame); err != nil {
-			c.logger.Warn("relay: invalid frame", "err", err)
+			c.logger.WarnContext(connCtx, "relay: invalid frame", "err", err)
 			continue
 		}
 
@@ -315,14 +315,14 @@ func (c *Client) connectAndServe(ctx context.Context) (connectedAt time.Time, er
 		case FrameHTTPRequest:
 			var payload HTTPRequestPayload
 			if err := json.Unmarshal(frame.Payload, &payload); err != nil {
-				c.logger.Warn("relay: invalid request payload", "err", err)
+				c.logger.WarnContext(connCtx, "relay: invalid request payload", "err", err)
 				continue
 			}
 			// Acquire semaphore slot (bounded concurrency).
 			select {
 			case sem <- struct{}{}:
 			default:
-				c.logger.Warn("relay: too many concurrent requests, dropping", "id", frame.ID)
+				c.logger.WarnContext(connCtx, "relay: too many concurrent requests, dropping", "id", frame.ID)
 				go c.sendResponse(frame.ID, HTTPResponsePayload{
 					Status:  http.StatusServiceUnavailable,
 					Headers: map[string][]string{"Content-Type": {"text/plain"}},
@@ -341,7 +341,7 @@ func (c *Client) connectAndServe(ctx context.Context) (connectedAt time.Time, er
 			c.sendFrame(FramePong, frame.ID, nil)
 
 		default:
-			c.logger.Debug("relay: ignoring frame", "type", frame.Type)
+			c.logger.DebugContext(connCtx, "relay: ignoring frame", "type", frame.Type)
 		}
 	}
 }

--- a/internal/relay/tunnel.go
+++ b/internal/relay/tunnel.go
@@ -32,7 +32,7 @@ func (c *Client) handleRequest(ctx context.Context, id string, payload HTTPReque
 	tunnelCtx := context.WithValue(ctx, viaRelayKey, true)
 	req, err := http.NewRequestWithContext(tunnelCtx, payload.Method, payload.Path, bytes.NewReader(body))
 	if err != nil {
-		c.logger.Warn("relay: failed to build request", "id", id, "err", err)
+		c.logger.WarnContext(ctx, "relay: failed to build request", "id", id, "err", err)
 		c.sendResponse(id, HTTPResponsePayload{
 			Status:  http.StatusBadGateway,
 			Headers: map[string][]string{"Content-Type": {"text/plain"}},
@@ -55,7 +55,7 @@ func (c *Client) handleRequest(ctx context.Context, id string, payload HTTPReque
 		if ip := net.ParseIP(payload.ClientIP); ip != nil {
 			req.RemoteAddr = net.JoinHostPort(ip.String(), "0")
 		} else {
-			c.logger.Warn("relay: rejecting non-IP client_ip from envelope",
+			c.logger.WarnContext(ctx, "relay: rejecting non-IP client_ip from envelope",
 				"id", id, "client_ip", payload.ClientIP)
 		}
 	}

--- a/internal/server/run.go
+++ b/internal/server/run.go
@@ -65,7 +65,7 @@ func SetupLocalAuth(opts *clawvisor.ServerOptions, logger *slog.Logger) (*LocalA
 		if _, err := opts.Store.CreateUser(bgCtx, localEmail, hash); err != nil {
 			return nil, fmt.Errorf("creating local user: %w", err)
 		}
-		logger.Debug("created local user", "email", localEmail)
+		logger.DebugContext(bgCtx, "created local user", "email", localEmail)
 	}
 
 	localUser, err := opts.Store.GetUserByEmail(bgCtx, localEmail)
@@ -91,7 +91,7 @@ func SetupLocalAuth(opts *clawvisor.ServerOptions, logger *slog.Logger) (*LocalA
 	// TUI auto-login token (written to .local-session).
 	tuiToken, err := ms.Generate(localUser.ID)
 	if err != nil {
-		logger.Warn("could not generate TUI magic token", "err", err)
+		logger.WarnContext(bgCtx, "could not generate TUI magic token", "err", err)
 	} else {
 		writeLocalSession(serverURL, tuiToken, logger)
 	}

--- a/internal/taskrisk/assessor.go
+++ b/internal/taskrisk/assessor.go
@@ -202,7 +202,7 @@ func (a *LLMAssessor) Assess(ctx context.Context, req AssessRequest) (*RiskAsses
 		return assessment, nil
 	}
 
-	a.logger.Warn("task risk assessment failed after retry", "error", lastErr)
+	a.logger.WarnContext(ctx, "task risk assessment failed after retry", "error", lastErr)
 	return &RiskAssessment{
 		RiskLevel:   "unknown",
 		Explanation: "Risk assessment temporarily unavailable.",

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -107,7 +107,7 @@ func Start(ctx context.Context, cfg *config.Config, st store.Store, logger *slog
 func fillUsage(ctx context.Context, st store.Store, e *event, logger *slog.Logger) {
 	counts, err := st.TelemetryCounts(ctx)
 	if err != nil {
-		logger.Debug("telemetry: count query error", "err", err)
+		logger.DebugContext(ctx, "telemetry: count query error", "err", err)
 		return
 	}
 	e.Agents = bucket(counts.Agents)
@@ -130,7 +130,7 @@ func fillUsage(ctx context.Context, st store.Store, e *event, logger *slog.Logge
 func send(ctx context.Context, endpoint string, e *event, logger *slog.Logger) {
 	body, err := json.Marshal(e)
 	if err != nil {
-		logger.Debug("telemetry: marshal error", "err", err)
+		logger.DebugContext(ctx, "telemetry: marshal error", "err", err)
 		return
 	}
 
@@ -139,16 +139,16 @@ func send(ctx context.Context, endpoint string, e *event, logger *slog.Logger) {
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
 	if err != nil {
-		logger.Debug("telemetry: request error", "err", err)
+		logger.DebugContext(ctx, "telemetry: request error", "err", err)
 		return
 	}
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		logger.Debug("telemetry: send error", "err", err)
+		logger.DebugContext(ctx, "telemetry: send error", "err", err)
 		return
 	}
 	resp.Body.Close()
-	logger.Info("telemetry: sent", "event", e.Event, "endpoint", endpoint, "status", resp.StatusCode)
+	logger.InfoContext(ctx, "telemetry: sent", "event", e.Event, "endpoint", endpoint, "status", resp.StatusCode)
 }

--- a/pkg/clawvisor/defaults.go
+++ b/pkg/clawvisor/defaults.go
@@ -325,7 +325,7 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 				}
 				var tools []mcpclient.Tool
 				if err := json.Unmarshal(toolsJSON, &tools); err != nil {
-					logger.Warn("resolver: bad mcp tools json", "service", serviceID, "user", userID, "alias", alias, "err", err)
+					logger.WarnContext(ctx, "resolver: bad mcp tools json", "service", serviceID, "user", userID, "alias", alias, "err", err)
 					continue
 				}
 				return mcp.ForUser(tools), true
@@ -346,7 +346,7 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 		}
 		rows, err := st.ListGeneratedAdapters(ctx, userID)
 		if err != nil {
-			logger.Warn("resolver: failed to list generated adapters", "user_id", userID, "err", err)
+			logger.WarnContext(ctx, "resolver: failed to list generated adapters", "user_id", userID, "err", err)
 			return nil, false
 		}
 		for _, row := range rows {
@@ -362,13 +362,13 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 		adapterReg.SetUserAdapterLister(func(ctx context.Context, userID string) ([]adapters.Adapter, bool) {
 			rows, err := st.ListGeneratedAdapters(ctx, userID)
 			if err != nil {
-				logger.Warn("resolver: failed to list generated adapters", "user_id", userID, "err", err)
+				logger.WarnContext(ctx, "resolver: failed to list generated adapters", "user_id", userID, "err", err)
 				return nil, false
 			}
 			out := make([]adapters.Adapter, 0, len(rows))
 			for _, row := range rows {
 				if _, isGlobal := adapterReg.Get(row.ServiceID); isGlobal {
-					logger.Warn("resolver: skipping generated adapter that collides with a built-in adapter",
+					logger.WarnContext(ctx, "resolver: skipping generated adapter that collides with a built-in adapter",
 						"user_id", userID, "service_id", row.ServiceID)
 					continue
 				}

--- a/pkg/clawvisor/run.go
+++ b/pkg/clawvisor/run.go
@@ -75,14 +75,14 @@ func RunWithContext(ctx context.Context, opts *ServerOptions) error {
 			if traceDir == "" {
 				traceDir = filepath.Join(dataDir, "timing-traces")
 			}
-			opts.Logger.Info("runtime proxy timing traces enabled", "dir", traceDir)
+			opts.Logger.InfoContext(ctx, "runtime proxy timing traces enabled", "dir", traceDir)
 		}
 		if opts.Config.RuntimeProxy.BodyTraceEnabled && opts.Logger != nil {
 			traceDir := bodyTraceDir
 			if traceDir == "" {
 				traceDir = filepath.Join(dataDir, "body-traces")
 			}
-			opts.Logger.Info("runtime proxy body traces enabled", "dir", traceDir)
+			opts.Logger.InfoContext(ctx, "runtime proxy body traces enabled", "dir", traceDir)
 		}
 		runtimeSrv.InstallSessionGuard(&runtimeproxy.Authenticator{Store: opts.Store, Config: opts.Config, Logger: opts.Logger})
 		runtimeSrv.InstallObserveNoticeRequestScrubber()
@@ -105,7 +105,7 @@ func RunWithContext(ctx context.Context, opts *ServerOptions) error {
 			// In-memory approval cache is correct only for single-instance deploys.
 			// On a multi-replica setup, an approval held on one replica is invisible
 			// to others and the proxy will block forever on the second instance.
-			opts.Logger.Warn("runtime proxy: RedisClient not configured — held-approval cache is process-local; running multiple replicas will desync approvals")
+			opts.Logger.WarnContext(ctx, "runtime proxy: RedisClient not configured — held-approval cache is process-local; running multiple replicas will desync approvals")
 		}
 		contextJudge := runtimepolicy.NewLLMRuntimeContextJudge(llm.NewHealth(opts.Config.LLM), opts.Logger)
 		runtimeSrv.InstallToolUseInterceptors(runtimeproxy.ToolUseHooks{
@@ -373,13 +373,13 @@ func RunWithContext(ctx context.Context, opts *ServerOptions) error {
 		if err := runtimeSrv.Start(); err != nil {
 			return err
 		}
-		opts.Logger.Info("runtime proxy running", "addr", runtimeSrv.Addr())
+		opts.Logger.InfoContext(ctx, "runtime proxy running", "addr", runtimeSrv.Addr())
 		go func() {
 			<-ctx.Done()
 			shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 			if err := runtimeSrv.Shutdown(shutdownCtx); err != nil && opts.Logger != nil {
-				opts.Logger.Warn("runtime proxy shutdown failed", "error", err)
+				opts.Logger.WarnContext(shutdownCtx, "runtime proxy shutdown failed", "error", err)
 			}
 		}()
 	}
@@ -390,7 +390,7 @@ func RunWithContext(ctx context.Context, opts *ServerOptions) error {
 		opts.RelayClient.SetHandler(srv.Handler())
 		go func() {
 			if err := opts.RelayClient.Run(ctx); err != nil && ctx.Err() == nil {
-				opts.Logger.Error("relay client stopped", "error", err)
+				opts.Logger.ErrorContext(ctx, "relay client stopped", "error", err)
 			}
 		}()
 	}

--- a/pkg/notify/multi.go
+++ b/pkg/notify/multi.go
@@ -108,7 +108,7 @@ func (m *MultiNotifier) SendApprovalRequest(ctx context.Context, req ApprovalReq
 	for _, n := range m.notifiers {
 		id, err := n.SendApprovalRequest(ctx, req)
 		if err != nil {
-			m.logger.Warn("notifier: SendApprovalRequest failed", "err", err)
+			m.logger.WarnContext(ctx,"notifier: SendApprovalRequest failed", "err", err)
 			errs = append(errs, err)
 		} else if messageID == "" && id != "" {
 			messageID = id
@@ -121,7 +121,7 @@ func (m *MultiNotifier) SendActivationRequest(ctx context.Context, req Activatio
 	var errs []error
 	for _, n := range m.notifiers {
 		if err := n.SendActivationRequest(ctx, req); err != nil {
-			m.logger.Warn("notifier: SendActivationRequest failed", "err", err)
+			m.logger.WarnContext(ctx,"notifier: SendActivationRequest failed", "err", err)
 			errs = append(errs, err)
 		}
 	}
@@ -134,7 +134,7 @@ func (m *MultiNotifier) SendTaskApprovalRequest(ctx context.Context, req TaskApp
 	for _, n := range m.notifiers {
 		id, err := n.SendTaskApprovalRequest(ctx, req)
 		if err != nil {
-			m.logger.Warn("notifier: SendTaskApprovalRequest failed", "err", err)
+			m.logger.WarnContext(ctx,"notifier: SendTaskApprovalRequest failed", "err", err)
 			errs = append(errs, err)
 		} else if messageID == "" && id != "" {
 			messageID = id
@@ -149,7 +149,7 @@ func (m *MultiNotifier) SendScopeExpansionRequest(ctx context.Context, req Scope
 	for _, n := range m.notifiers {
 		id, err := n.SendScopeExpansionRequest(ctx, req)
 		if err != nil {
-			m.logger.Warn("notifier: SendScopeExpansionRequest failed", "err", err)
+			m.logger.WarnContext(ctx,"notifier: SendScopeExpansionRequest failed", "err", err)
 			errs = append(errs, err)
 		} else if messageID == "" && id != "" {
 			messageID = id
@@ -164,7 +164,7 @@ func (m *MultiNotifier) SendConnectionRequest(ctx context.Context, req Connectio
 	for _, n := range m.notifiers {
 		id, err := n.SendConnectionRequest(ctx, req)
 		if err != nil {
-			m.logger.Warn("notifier: SendConnectionRequest failed", "err", err)
+			m.logger.WarnContext(ctx,"notifier: SendConnectionRequest failed", "err", err)
 			errs = append(errs, err)
 		} else if messageID == "" && id != "" {
 			messageID = id
@@ -177,7 +177,7 @@ func (m *MultiNotifier) UpdateMessage(ctx context.Context, userID, messageID, te
 	var errs []error
 	for _, n := range m.notifiers {
 		if err := n.UpdateMessage(ctx, userID, messageID, text); err != nil {
-			m.logger.Warn("notifier: UpdateMessage failed", "err", err)
+			m.logger.WarnContext(ctx,"notifier: UpdateMessage failed", "err", err)
 			errs = append(errs, err)
 		}
 	}
@@ -188,7 +188,7 @@ func (m *MultiNotifier) SendTestMessage(ctx context.Context, userID string) erro
 	var errs []error
 	for _, n := range m.notifiers {
 		if err := n.SendTestMessage(ctx, userID); err != nil {
-			m.logger.Warn("notifier: SendTestMessage failed", "err", err)
+			m.logger.WarnContext(ctx,"notifier: SendTestMessage failed", "err", err)
 			errs = append(errs, err)
 		}
 	}
@@ -199,7 +199,7 @@ func (m *MultiNotifier) SendAlert(ctx context.Context, userID, text string) erro
 	var errs []error
 	for _, n := range m.notifiers {
 		if err := n.SendAlert(ctx, userID, text); err != nil {
-			m.logger.Warn("notifier: SendAlert failed", "err", err)
+			m.logger.WarnContext(ctx,"notifier: SendAlert failed", "err", err)
 			errs = append(errs, err)
 		}
 	}

--- a/pkg/runtime/proxy/auth.go
+++ b/pkg/runtime/proxy/auth.go
@@ -231,7 +231,7 @@ func (a *Authenticator) maybeExtendSessionExpiry(ctx context.Context, session *s
 	}
 	if err := a.Store.UpdateRuntimeSessionExpiry(ctx, session.ID, newExpiry); err != nil {
 		if a.Logger != nil {
-			a.Logger.Warn("failed to extend runtime session expiry", "session_id", session.ID, "err", err)
+			a.Logger.WarnContext(ctx, "failed to extend runtime session expiry", "session_id", session.ID, "err", err)
 		}
 		return
 	}

--- a/pkg/runtime/proxy/inbound_secret_runtime.go
+++ b/pkg/runtime/proxy/inbound_secret_runtime.go
@@ -627,7 +627,7 @@ func (s *runtimeSecretScanner) runAdjudicationGroup(ctx context.Context, client 
 	if err != nil {
 		s.recordAdjudicationDebug(debugRec)
 		if s.hooks.Logger != nil {
-			s.hooks.Logger.Warn("runtime secret adjudicator failed", "err", err, "host", s.host, "field", rep.fieldName)
+			s.hooks.Logger.WarnContext(ctx, "runtime secret adjudicator failed", "err", err, "host", s.host, "field", rep.fieldName)
 		}
 		return
 	}
@@ -636,7 +636,7 @@ func (s *runtimeSecretScanner) runAdjudicationGroup(ctx context.Context, client 
 		debugRec.ParseErr = perr
 		s.recordAdjudicationDebug(debugRec)
 		if s.hooks.Logger != nil {
-			s.hooks.Logger.Warn("runtime secret adjudicator parse failed",
+			s.hooks.Logger.WarnContext(ctx, "runtime secret adjudicator parse failed",
 				"err", perr, "host", s.host, "field", rep.fieldName, "raw_len", len(raw))
 		}
 		return
@@ -811,7 +811,7 @@ func (s *runtimeSecretScanner) lookupOrAdjudicate(ctx context.Context, fieldName
 	if err != nil {
 		s.recordAdjudicationDebug(debugRec)
 		if s.hooks.Logger != nil {
-			s.hooks.Logger.Warn("runtime secret adjudicator failed", "err", err, "host", s.host, "field", fieldName)
+			s.hooks.Logger.WarnContext(ctx, "runtime secret adjudicator failed", "err", err, "host", s.host, "field", fieldName)
 		}
 		return adjudicationVerdict{}, false
 	}
@@ -820,7 +820,7 @@ func (s *runtimeSecretScanner) lookupOrAdjudicate(ctx context.Context, fieldName
 		debugRec.ParseErr = perr
 		s.recordAdjudicationDebug(debugRec)
 		if s.hooks.Logger != nil {
-			s.hooks.Logger.Warn("runtime secret adjudicator parse failed",
+			s.hooks.Logger.WarnContext(ctx, "runtime secret adjudicator parse failed",
 				"err", perr, "host", s.host, "field", fieldName, "raw_len", len(raw))
 		}
 		return adjudicationVerdict{}, false

--- a/pkg/runtime/proxy/policy_hook.go
+++ b/pkg/runtime/proxy/policy_hook.go
@@ -316,7 +316,7 @@ func (s *Server) InstallEgressPolicy(hooks PolicyHooks) {
 			})
 			s.recordTimingSpan(req, "egress.context_judge", judgeStartedAt)
 			if judgeErr != nil && hooks.Logger != nil {
-				hooks.Logger.Warn("runtime context judge failed", "err", judgeErr, "session_id", st.Session.ID, "host", host, "method", req.Method, "path", req.URL.Path)
+				hooks.Logger.WarnContext(req.Context(), "runtime context judge failed", "err", judgeErr, "session_id", st.Session.ID, "host", host, "method", req.Method, "path", req.URL.Path)
 			}
 			switch judgment.Kind {
 			case runtimepolicy.ClassificationBelongsToExistingTask:

--- a/pkg/runtime/proxy/timing_hooks.go
+++ b/pkg/runtime/proxy/timing_hooks.go
@@ -117,7 +117,11 @@ func (s *Server) logTimingTrace(ctx *goproxy.ProxyCtx, st *RequestState, resp *h
 			entry.Attrs = attrs
 		}
 		if err := s.traceSink.Write(entry); err != nil && s.logger != nil {
-			s.logger.Warn("runtime timing trace write failed", "err", err)
+			if ctx != nil && ctx.Req != nil {
+				s.logger.WarnContext(ctx.Req.Context(), "runtime timing trace write failed", "err", err)
+			} else {
+				s.logger.Warn("runtime timing trace write failed", "err", err)
+			}
 		}
 	})
 }

--- a/pkg/version/autoupdate.go
+++ b/pkg/version/autoupdate.go
@@ -16,11 +16,11 @@ import (
 // The goroutine exits when ctx is cancelled. It is a no-op for dev builds.
 func StartAutoUpdater(ctx context.Context, interval time.Duration, logger *slog.Logger) {
 	if v := GetCurrent(); v == "dev" || v == "" {
-		logger.Debug("auto-update: skipping for dev build")
+		logger.DebugContext(ctx, "auto-update: skipping for dev build")
 		return
 	}
 
-	logger.Info("auto-update: enabled", "check_interval", interval)
+	logger.InfoContext(ctx, "auto-update: enabled", "check_interval", interval)
 
 	go func() {
 		// Stagger the first check so it doesn't fire immediately on startup.


### PR DESCRIPTION
## Summary
Companion to #456 (cloudlogging.Handler). The handler stamps `logging.googleapis.com/trace` on a record only when callers use the `*Context` slog variants (`InfoContext`, `WarnContext`, etc.) — plain `logger.Info(...)` calls hit the handler with `context.Background()`, find no trace ID, and write out un-grouped. Without this migration, only the per-request summary line coalesces in the Logs Explorer.

This change converts every `logger.Info/Warn/Error/Debug` (and `slog.*`) call site in production packages where a `context.Context` is reachable in scope:
- Function/method parameters typed `context.Context`
- HTTP handler `r.Context()`
- In-scope `ctx` variables

Calls in goroutines/helpers that don't have access to a ctx are intentionally left untouched (no trace to stamp anyway).

## Scope
- All `internal/api/handlers/`, `internal/api/middleware/`, `internal/auth/`, `internal/callback/`, `internal/relay/`, `internal/runtime/`, `internal/notify/`, `internal/mcp/`, `internal/llm/`, `internal/intent/`, `internal/taskrisk/`, `internal/local/`, `internal/server/`, `internal/telemetry/`, `internal/events/`
- `pkg/clawvisor/`, `pkg/runtime/proxy/`, `pkg/notify/`, `pkg/version/`

## Out of scope (skipped)
- `_test.go` files
- `cmd/` (startup, no request context)
- `internal/tui/` (local TUI, not deployed)
- Helpers that take no `context.Context` (rule: no ctx in scope → no migration)

## Result
43 files, 274/270 line churn. Mechanical change — same call shapes, same args, just `Info → InfoContext(ctx, …)`.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/api/... ./pkg/cloudlogging/...` passes
- [ ] After parent-side bump + deploy, query a request log and verify child entries (not just the request-summary) now show up beneath the parent request log in the Cloud Logs Explorer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)