### PR TITLE
fix(llmproxy): thread matched task_id into tool_use audit rows

### DIFF
--- a/internal/runtime/llmproxy/audit.go
+++ b/internal/runtime/llmproxy/audit.go
@@ -92,7 +92,16 @@ func (e *AuditEmitter) LogEndpointCall(ctx context.Context, agent *store.Agent, 
 // LogToolUseInspected records one tool_use seen by the lite-proxy. Each row
 // carries the tool name, a bounded input summary, verdict source, decision,
 // target host (when known), and placeholder substrings (no real credential).
-func (e *AuditEmitter) LogToolUseInspected(ctx context.Context, agent *store.Agent, requestID string, tu conversation.ToolUse, verdict inspector.Verdict, decision, outcome, reason string) {
+//
+// taskID names the active task this tool_use matched (via task-scope
+// authorization), when one was matched. The dashboard task viewer
+// filters audit rows on AuditEntry.task_id, so threading the matched
+// task here is what makes lite-proxy tool_use rows visible in the
+// per-task activity feed. Empty taskID means "no task matched" — the
+// row still lands in the global audit feed but won't appear in any
+// task's activity tab, which matches reality (the call wasn't bound
+// to a task).
+func (e *AuditEmitter) LogToolUseInspected(ctx context.Context, agent *store.Agent, requestID string, tu conversation.ToolUse, verdict inspector.Verdict, decision, outcome, reason, taskID string) {
 	if e == nil || e.Store == nil || agent == nil {
 		return
 	}
@@ -136,6 +145,7 @@ func (e *AuditEmitter) LogToolUseInspected(ctx context.Context, agent *store.Age
 		AgentID:    &agent.ID,
 		RequestID:  requestID,
 		ToolUseID:  &toolUseID,
+		TaskID:     nilIfEmpty(taskID),
 		Timestamp:  time.Now().UTC(),
 		Service:    service,
 		Action:     "lite_proxy.tool_use." + decision,

--- a/internal/runtime/llmproxy/audit_test.go
+++ b/internal/runtime/llmproxy/audit_test.go
@@ -101,7 +101,7 @@ func TestAuditEmitter_LogToolUseInspected(t *testing.T) {
 		ID:    "toolu_1",
 		Name:  "WebFetch",
 		Input: json.RawMessage(`{"url":"https://api.github.com/repos/x/y/issues","headers":{"Authorization":"Bearer secret"}}`),
-	}, verdict, "rewrite", "success", verdict.Reason)
+	}, verdict, "rewrite", "success", verdict.Reason, "")
 
 	rows, _, _ := st.ListAuditEntries(context.Background(), agent.UserID, store.AuditFilter{})
 	if len(rows) != 1 {
@@ -116,6 +116,9 @@ func TestAuditEmitter_LogToolUseInspected(t *testing.T) {
 	}
 	if row.ToolUseID == nil || *row.ToolUseID != "toolu_1" {
 		t.Errorf("tool_use_id missing or wrong: %v", row.ToolUseID)
+	}
+	if row.TaskID != nil {
+		t.Errorf("task_id should be nil when caller passes empty string, got %v", row.TaskID)
 	}
 	var params map[string]any
 	_ = json.Unmarshal(row.ParamsSafe, &params)
@@ -135,6 +138,31 @@ func TestAuditEmitter_LogToolUseInspected(t *testing.T) {
 	headers, _ := toolInput["headers"].(map[string]any)
 	if _, ok := headers["Authorization"]; ok {
 		t.Errorf("tool_input should not persist Authorization header: %+v", headers)
+	}
+}
+
+// TestAuditEmitter_LogToolUseInspected_TaskID confirms that passing a
+// non-empty taskID populates AuditEntry.TaskID — the field the
+// dashboard's per-task activity feed filters on (GET /api/audit?task_id=).
+// Without this linkage, lite-proxy tool_use rows never appear in any
+// task's activity tab.
+func TestAuditEmitter_LogToolUseInspected_TaskID(t *testing.T) {
+	st, agent := newAuditTestStore(t)
+	em := NewAuditEmitter(st, nil, nil)
+
+	em.LogToolUseInspected(context.Background(), agent, "req-task", conversation.ToolUse{
+		ID:    "toolu_2",
+		Name:  "WebFetch",
+		Input: json.RawMessage(`{"url":"https://api.github.com/repos/x/y"}`),
+	}, inspector.Verdict{IsAPICall: true, Host: "api.github.com", Method: "GET", Path: "/repos/x/y", Source: inspector.SourceDeterministic},
+		"allow", "matched_task", "scope covered", "task-abc")
+
+	rows, _, _ := st.ListAuditEntries(context.Background(), agent.UserID, store.AuditFilter{TaskID: "task-abc"})
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row filtered by task_id, got %d", len(rows))
+	}
+	if rows[0].TaskID == nil || *rows[0].TaskID != "task-abc" {
+		t.Errorf("task_id not persisted: %v", rows[0].TaskID)
 	}
 }
 

--- a/internal/runtime/llmproxy/coalesce.go
+++ b/internal/runtime/llmproxy/coalesce.go
@@ -20,6 +20,14 @@ type evalCapture struct {
 	Inspector   inspector.Verdict
 	Fingerprint runtimedecision.DecisionFingerprint
 	Reason      string
+	// TaskID names the active task this tool_use matched (via task
+	// scope or authorization decision), when one was matched. Empty
+	// for paths that ran before/without a task match (trigger miss
+	// pass-through, control-tool inline-task creation, hard denials
+	// preceding any decision). Forwarded to the coalesced audit rows
+	// so dashboards filtering on task_id surface coalesced-pending
+	// rows alongside their owning task.
+	TaskID string
 }
 
 // capturedHoldSink buffers PendingApprovalCache.Hold calls the first
@@ -121,6 +129,7 @@ type bufferedAudit struct {
 	Decision string
 	Outcome  string
 	Reason   string
+	TaskID   string
 }
 
 // capturedAuditSink buffers audit rows from pass 1. See capturedHoldSink
@@ -169,7 +178,7 @@ func replayBufferedHolds(ctx context.Context, cfg PostprocessConfig, inner Pendi
 			if cfg.Audit != nil && agent != nil && i < len(captures) {
 				use := captures[i].Use
 				v := captures[i].Inspector
-				cfg.Audit.LogToolUseInspected(ctx, agent, cfg.RequestID, use, v, "block", "approval_hold_replay_failed", err.Error())
+				cfg.Audit.LogToolUseInspected(ctx, agent, cfg.RequestID, use, v, "block", "approval_hold_replay_failed", err.Error(), captures[i].TaskID)
 			}
 			return err
 		}
@@ -177,7 +186,7 @@ func replayBufferedHolds(ctx context.Context, cfg PostprocessConfig, inner Pendi
 		if res.Evicted != nil && cfg.Audit != nil && agent != nil && i < len(captures) {
 			use := captures[i].Use
 			v := captures[i].Inspector
-			cfg.Audit.LogToolUseInspected(ctx, agent, cfg.RequestID, use, v, "block", "approval_evicted", "superseded pending approval "+res.Evicted.ID)
+			cfg.Audit.LogToolUseInspected(ctx, agent, cfg.RequestID, use, v, "block", "approval_evicted", "superseded pending approval "+res.Evicted.ID, captures[i].TaskID)
 		}
 	}
 	return nil
@@ -191,7 +200,7 @@ func flushBufferedAudit(ctx context.Context, cfg PostprocessConfig, agent *store
 		return
 	}
 	for _, e := range sink.entries {
-		cfg.Audit.LogToolUseInspected(ctx, agent, cfg.RequestID, e.ToolUse, e.Verdict, e.Decision, e.Outcome, e.Reason)
+		cfg.Audit.LogToolUseInspected(ctx, agent, cfg.RequestID, e.ToolUse, e.Verdict, e.Decision, e.Outcome, e.Reason, e.TaskID)
 	}
 }
 
@@ -227,7 +236,7 @@ func emitCoalescedPendingAuditRows(ctx context.Context, cfg PostprocessConfig, a
 	}
 	for _, c := range ordered {
 		reason := "held under coalesced approval " + approvalID + " (originally classified as " + string(c.Kind) + ")"
-		cfg.Audit.LogToolUseInspected(ctx, agent, cfg.RequestID, c.Use, c.Inspector, "block", "coalesced_approval_pending", reason)
+		cfg.Audit.LogToolUseInspected(ctx, agent, cfg.RequestID, c.Use, c.Inspector, "block", "coalesced_approval_pending", reason, c.TaskID)
 	}
 }
 

--- a/internal/runtime/llmproxy/postprocess.go
+++ b/internal/runtime/llmproxy/postprocess.go
@@ -328,6 +328,16 @@ func Postprocess(req *http.Request, body []byte, contentType string, cfg Postpro
 
 	innerEval := func(tu conversation.ToolUse) conversation.ToolUseVerdict {
 		var v inspector.Verdict
+		// matchedTaskID is set by branches that resolve a task scope
+		// (EvaluateAuthorization with a matched task, or
+		// TaskScope.Check returning Allowed). audit() reads it into
+		// the buffered row's TaskID so flushed audit rows carry the
+		// matched task — that's what the dashboard's per-task activity
+		// feed filters on (AuditEntry.task_id). Branches that never
+		// matched a task (trigger-miss pass-through, hard denials
+		// before any decision, control-tool inline-task creation where
+		// the task is being created here) leave it empty.
+		var matchedTaskID string
 		audit := func(decision, outcome, reason string) {
 			// Always buffer, even when no AuditEmitter is configured.
 			// The outer eval wrapper reads the last entry for this
@@ -345,6 +355,7 @@ func Postprocess(req *http.Request, body []byte, contentType string, cfg Postpro
 				Decision: decision,
 				Outcome:  outcome,
 				Reason:   reason,
+				TaskID:   matchedTaskID,
 			})
 		}
 		// trace emits one JSONL line per decision point when
@@ -537,6 +548,7 @@ func Postprocess(req *http.Request, body []byte, contentType string, cfg Postpro
 					audit("block", "decision_error", err.Error())
 					return conversation.ToolUseVerdict{Allowed: false, Reason: "Clawvisor: authorization failed — " + err.Error()}
 				}
+				matchedTaskID = taskIDFromDecision(dec)
 				trace(TraceEventDecision,
 					"path", "trigger_miss",
 					"kind", string(dec.Kind),
@@ -664,6 +676,7 @@ func Postprocess(req *http.Request, body []byte, contentType string, cfg Postpro
 					Reason:  "Clawvisor: authorization failed — " + err.Error(),
 				}
 			}
+			matchedTaskID = taskIDFromDecision(dec)
 			trace(TraceEventDecision,
 				"path", "credentialed",
 				"kind", string(dec.Kind),
@@ -735,6 +748,7 @@ func Postprocess(req *http.Request, body []byte, contentType string, cfg Postpro
 						Reason:  "Clawvisor: no active task scope covers " + resolved.ServiceID + "." + resolved.ActionID + " — " + dec.Reason,
 					}
 				}
+				matchedTaskID = dec.TaskID
 				// Intent verification: when the matched TaskAction's
 				// Verification mode opts in (strict | lenient | empty)
 				// and an IntentVerifier is configured, the LLM compares
@@ -849,6 +863,16 @@ func Postprocess(req *http.Request, body []byte, contentType string, cfg Postpro
 			last := auditSink.entries[len(auditSink.entries)-1]
 			c.Inspector = last.Verdict
 			c.Reason = last.Reason
+		}
+		// TaskID is sourced from the audit sink (not the hold sink)
+		// because the hold sink doesn't carry it — the matched task
+		// is recorded by the audit closure right after EvaluateAuthorization
+		// or TaskScope.Check resolves it. Both the held and the
+		// non-held branches above leave any matched task on the most
+		// recent audit entry, so reading it here picks it up
+		// regardless of whether a hold was created.
+		if auditSink != nil && len(auditSink.entries) > auditsBefore {
+			c.TaskID = auditSink.entries[len(auditSink.entries)-1].TaskID
 		}
 		captures = append(captures, c)
 		return v


### PR DESCRIPTION
## Summary

The dashboard task viewer's activity tab queries `GET /api/audit?task_id=<id>`, which filters on `AuditEntry.task_id`. `LogToolUseInspected` never set that field, so lite-proxy tool_use rows never appeared in any task's activity feed.

This plumbs the matched task ID from the authorization decision (or `TaskScope.Check`) through the buffered-audit pipeline so flushed and coalesced rows carry it. `LogToolUseInspected` gains a `taskID` parameter; `bufferedAudit` and `evalCapture` carry it; the `audit` closure in postprocess reads a new `matchedTaskID` variable set after each successful decision.

## Test plan

- [x] go build ./...
- [x] go test ./... (all packages pass)
- [x] New unit test `TestAuditEmitter_LogToolUseInspected_TaskID` confirms the row is retrievable via `AuditFilter{TaskID: …}`
- [ ] Manual: trigger a credentialed tool_use against an active task and confirm the row shows in the task viewer's activity tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)