### PR TITLE
feat(llmproxy): clarify inline task approval prompt

### DIFF
--- a/internal/api/handlers/llm_endpoint.go
+++ b/internal/api/handlers/llm_endpoint.go
@@ -138,6 +138,15 @@ type LLMEndpointHandler struct {
 	// prompt falls back to the deterministic envelope-shape policy only.
 	TaskRiskAssessor taskrisk.Assessor
 
+	// DefaultTaskExpirySeconds mirrors the daemon's resolved
+	// cfg.Task.DefaultExpirySeconds. Surfaced into the inline task
+	// approval prompt so the displayed Duration matches the operator's
+	// configured default when the agent omits expires_in_seconds.
+	// Optional — 0 lets the renderer fall back to its 30-minute
+	// constant, which is fine for tests and unconfigured deploys but
+	// would drift from the resolved scope in production.
+	DefaultTaskExpirySeconds int
+
 	// RawIOLogger, when non-nil, captures full raw HTTP bodies for
 	// inbound requests, upstream responses, and the bodies returned
 	// to the harness. Off by default; opted in via
@@ -922,6 +931,7 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 			ConversationAutoApproveThreshold: autoApproveThreshold,
 			InlineTaskCreator:                h.InlineTaskCreator,
 			Checkouts:                        h.TaskCheckouts,
+			DefaultTaskExpirySeconds:         h.DefaultTaskExpirySeconds,
 		})
 		h.Logger.DebugContext(r.Context(), "lite-proxy postprocess complete",
 			"request_id", requestID,
@@ -975,6 +985,7 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 				ConversationAutoApproveThreshold: autoApproveThreshold,
 				InlineTaskCreator:                h.InlineTaskCreator,
 				Checkouts:                        h.TaskCheckouts,
+				DefaultTaskExpirySeconds:         h.DefaultTaskExpirySeconds,
 			})
 			switch {
 			case contErr != nil:

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1303,6 +1303,7 @@ func (s *Server) registerLiteProxyRoutes(
 		}
 		llmHandler.InlineTaskCreator = tasksHandler
 		llmHandler.TaskRiskAssessor = s.taskRiskAssessor
+		llmHandler.DefaultTaskExpirySeconds = s.cfg.Task.DefaultExpirySeconds
 
 		controlHandler := handlers.NewLLMControlHandler(baseURL)
 		controlHandler.Store = s.store

--- a/internal/runtime/llmproxy/inline_task_intercept.go
+++ b/internal/runtime/llmproxy/inline_task_intercept.go
@@ -137,6 +137,19 @@ func maybeInterceptInlineTaskDefinition(
 		return conversation.ToolUseVerdict{}, false
 	}
 
+	// Lifetime/expires conflict: standing tasks reject expires_in_seconds
+	// at creation time (see tasks_inline.go's createInlineApprovedTask).
+	// Catch the same conflict here before rendering — otherwise the user
+	// would see a "Lifetime: always" prompt, approve, and then watch the
+	// release path fail with a confusing error. Fall through to the
+	// dashboard rewrite so the model gets the same JSON error it would
+	// receive from a direct POST, keeping behavior consistent across
+	// surfaces.
+	if strings.EqualFold(strings.TrimSpace(parsed.Lifetime), "standing") && parsed.ExpiresInSeconds > 0 {
+		audit("fallthrough", "inline_task_invalid_envelope", "expires_in_seconds cannot be set on a standing task; deferring to dashboard rewrite")
+		return conversation.ToolUseVerdict{}, false
+	}
+
 	// Risk assessment runs BEFORE the hold so the auto-approval gate
 	// can decide whether to skip the human prompt entirely. The
 	// assessment is also used to render the prompt on the fall-through
@@ -313,7 +326,7 @@ func maybeInterceptInlineTaskDefinition(
 	return conversation.ToolUseVerdict{
 		Allowed:        false,
 		Reason:         "Clawvisor: awaiting inline task approval",
-		SubstituteWith: renderTaskApprovalPromptWithRisk(parsed, innerHold.Pending.ID, assessment),
+		SubstituteWith: renderTaskApprovalPromptWithRisk(parsed, innerHold.Pending.ID, assessment, cfg.DefaultTaskExpirySeconds),
 	}, true
 }
 

--- a/internal/runtime/llmproxy/inline_task_intercept_test.go
+++ b/internal/runtime/llmproxy/inline_task_intercept_test.go
@@ -332,6 +332,48 @@ func TestPostprocess_InlineTaskInvalidCredentialFallsThroughToToolError(t *testi
 	}
 }
 
+func TestPostprocess_InlineTaskStandingWithExpiresFallsThrough(t *testing.T) {
+	// lifetime=standing + expires_in_seconds>0 is rejected at task
+	// creation time (tasks_inline.go); the intercept catches the same
+	// conflict before rendering so the user never sees an approval
+	// prompt that would resolve to a failed create.
+	cache := NewMemoryPendingApprovalCache(time.Minute)
+	st, userID, agentID := seedPostprocessStore(t, "autovault_github_xxx")
+
+	taskBody := `{"purpose":"Standing task with expiry","lifetime":"standing","expires_in_seconds":600,"expected_tools":[{"tool_name":"Bash","why":"x"}]}`
+	body := anthropicBashControlTasksPostWithQuery(taskBody, "surface=inline")
+	req := httptest.NewRequest("POST", "/v1/messages", nil)
+	insp := inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{})
+
+	got := Postprocess(req, body, "application/json", PostprocessConfig{
+		Inspector:        insp,
+		RewriteOpts:      inspector.DefaultRewriteOpts("http://localhost:25297"),
+		CallerNonces:     NewMemoryCallerNonceCache(time.Minute),
+		Store:            st,
+		AgentUserID:      userID,
+		AgentID:          agentID,
+		ControlBaseURL:   "http://localhost:25297",
+		PendingApprovals: cache,
+	})
+
+	out := string(got.Body)
+	if strings.Contains(out, "Clawvisor wants to create a task") {
+		t.Fatalf("standing+expires_in_seconds should not render an approval prompt: %s", out)
+	}
+	if !strings.Contains(out, "http://localhost:25297/api/control/tasks") {
+		t.Fatalf("standing+expires_in_seconds should fall through to control rewrite: %s", out)
+	}
+
+	cache.mu.Lock()
+	holds := len(cache.pending[pendingApprovalKey{
+		userID: userID, agentID: agentID, provider: conversation.ProviderAnthropic,
+	}])
+	cache.mu.Unlock()
+	if holds != 0 {
+		t.Fatalf("standing+expires_in_seconds should not create an approval hold, got %d", holds)
+	}
+}
+
 func TestPostprocess_InlineTaskBareNoSignalRoutesToDashboard(t *testing.T) {
 	// No prior `task` reply AND no surface=inline → fall through to
 	// the regular control-rewrite path (dashboard task creation).

--- a/internal/runtime/llmproxy/inline_task_prompt.go
+++ b/internal/runtime/llmproxy/inline_task_prompt.go
@@ -60,7 +60,7 @@ func renderTaskApprovalPromptWithRisk(req *runtimetasks.TaskCreateRequest, appro
 	var b strings.Builder
 	b.WriteString("Clawvisor wants to create a task to cover this work:\n\n")
 	b.WriteString("Purpose\n  ")
-	b.WriteString(wrapForPrompt(purpose, 80, "  "))
+	b.WriteString(wrapForPrompt(purpose, 80, "    "))
 
 	if len(req.ExpectedTools) > 0 {
 		b.WriteString("\n\nTools requested")
@@ -73,7 +73,7 @@ func renderTaskApprovalPromptWithRisk(req *runtimetasks.TaskCreateRequest, appro
 			b.WriteString(name)
 			if why := strings.TrimSpace(tool.Why); why != "" {
 				b.WriteString(" — ")
-				b.WriteString(wrapForPrompt(why, 80, "    "))
+				b.WriteString(wrapForPrompt(why, 80, "      "))
 			}
 		}
 	}
@@ -89,7 +89,7 @@ func renderTaskApprovalPromptWithRisk(req *runtimetasks.TaskCreateRequest, appro
 			b.WriteString(host)
 			if why := strings.TrimSpace(eg.Why); why != "" {
 				b.WriteString(" — ")
-				b.WriteString(wrapForPrompt(why, 80, "    "))
+				b.WriteString(wrapForPrompt(why, 80, "      "))
 			}
 		}
 	}
@@ -108,7 +108,7 @@ func renderTaskApprovalPromptWithRisk(req *runtimetasks.TaskCreateRequest, appro
 			b.WriteString(name)
 			if why := strings.TrimSpace(cred.Why); why != "" {
 				b.WriteString(" — ")
-				b.WriteString(wrapForPrompt(why, 80, "    "))
+				b.WriteString(wrapForPrompt(why, 80, "      "))
 			}
 		}
 	}
@@ -124,7 +124,7 @@ func renderTaskApprovalPromptWithRisk(req *runtimetasks.TaskCreateRequest, appro
 		b.WriteString(level)
 		if explanation := strings.TrimSpace(risk.Explanation); explanation != "" {
 			b.WriteString(" — ")
-			b.WriteString(wrapForPrompt(explanation, 80, "    "))
+			b.WriteString(wrapForPrompt(explanation, 80, "      "))
 		}
 	}
 

--- a/internal/runtime/llmproxy/inline_task_prompt.go
+++ b/internal/runtime/llmproxy/inline_task_prompt.go
@@ -36,10 +36,18 @@ import (
 // a failed one when both leave only a bare "approve" in conversation
 // history.
 func renderTaskApprovalPrompt(req *runtimetasks.TaskCreateRequest, approvalID string) string {
-	return renderTaskApprovalPromptWithRisk(req, approvalID, nil)
+	return renderTaskApprovalPromptWithRisk(req, approvalID, nil, 0)
 }
 
-func renderTaskApprovalPromptWithRisk(req *runtimetasks.TaskCreateRequest, approvalID string, risk *taskrisk.RiskAssessment) string {
+// renderTaskApprovalPromptWithRisk renders the inline approval prompt.
+//
+// defaultExpirySeconds is the daemon's resolved task.default_expiry_seconds,
+// used to fill the displayed Duration when the agent omits
+// expires_in_seconds. Pass 0 (or a negative) to fall back to
+// defaultSessionTaskDurationSeconds — that fallback exists so callers that
+// don't have access to live config (tests, the renderTaskApprovalPrompt
+// convenience wrapper) still produce an honest-looking prompt.
+func renderTaskApprovalPromptWithRisk(req *runtimetasks.TaskCreateRequest, approvalID string, risk *taskrisk.RiskAssessment, defaultExpirySeconds int) string {
 	suffix := approvalIDFooter(approvalID)
 	if req == nil {
 		return "Clawvisor wants to create a task.\n\nReply `yes` or `y` to authorize, `no` or `n` to cancel." + suffix
@@ -121,7 +129,7 @@ func renderTaskApprovalPromptWithRisk(req *runtimetasks.TaskCreateRequest, appro
 	}
 
 	mode := strings.TrimSpace(req.IntentVerificationMode)
-	durationLabel, durationValue := durationLine(req.Lifetime, req.ExpiresInSeconds)
+	durationLabel, durationValue := durationLine(req.Lifetime, req.ExpiresInSeconds, defaultExpirySeconds)
 
 	if (mode != "" && mode != "strict") || durationValue != "" {
 		b.WriteString("\n\n")
@@ -175,14 +183,15 @@ func extractApprovalIDFromPrompt(text string) string {
 	return strings.TrimSpace(rest[:end])
 }
 
-// defaultSessionTaskDurationSeconds mirrors pkg/config.TaskConfig's
-// default_expiry_seconds (1800 = 30 min). Duplicated here rather than
-// threaded through PostprocessConfig because the renderer is a UI
-// concern and only needs an honest display fallback — the actual
-// task-scope expiry binding happens in tasks_inline.go using the live
-// config value. If an operator overrides the config default, the
-// prompt may show "30 min" while the resolved scope uses a different
-// number; that drift is acceptable for a status line.
+// defaultSessionTaskDurationSeconds is the renderer's last-resort
+// fallback when both the agent's expires_in_seconds and the daemon's
+// resolved default are unset/non-positive — matches the historical
+// pkg/config.TaskConfig default (1800 = 30 min). Production wires the
+// live config value through PostprocessConfig.DefaultTaskExpirySeconds
+// so this constant is only hit by tests and unconfigured deploys; in
+// configured deploys an operator override flows through to the
+// displayed Duration and the prompt no longer drifts from the resolved
+// scope.
 const defaultSessionTaskDurationSeconds = 1800
 
 // durationLine returns the (label, value) pair describing how long the
@@ -190,18 +199,22 @@ const defaultSessionTaskDurationSeconds = 1800
 // different labels because they answer different user questions:
 //
 //   - session (the common case): "Duration: 30 min" — how long the
-//     scope is usable. Empty expires_in_seconds falls back to the daemon
-//     default so the user always sees a concrete number.
+//     scope is usable. Empty expires_in_seconds falls back to the
+//     caller-provided default (daemon config), and then to
+//     defaultSessionTaskDurationSeconds if that's also unset.
 //   - standing: "Lifetime: always" — standing tasks reject
 //     expires_in_seconds (see tasks_inline.go), so there is no duration
 //     to show; the label conveys "no time cap" instead.
 //
 // Returns ("", "") only for unknown lifetime strings, so callers can
 // omit the line entirely rather than printing something misleading.
-func durationLine(lifetime string, expiresInSeconds int) (label, value string) {
+func durationLine(lifetime string, expiresInSeconds, defaultExpirySeconds int) (label, value string) {
 	switch strings.TrimSpace(lifetime) {
 	case "", "session":
 		secs := expiresInSeconds
+		if secs <= 0 {
+			secs = defaultExpirySeconds
+		}
 		if secs <= 0 {
 			secs = defaultSessionTaskDurationSeconds
 		}

--- a/internal/runtime/llmproxy/inline_task_prompt.go
+++ b/internal/runtime/llmproxy/inline_task_prompt.go
@@ -20,10 +20,10 @@ import (
 //   - purpose (wrapped at 80 cols)
 //   - expected_tools[].tool_name + .why (bullet list)
 //   - required_credentials[].vault_item_id / vault_item_handle + .why (bullet list)
-//   - assessed risk level + explanation when available
-//   - intent_verification_mode (default "strict")
-//   - lifetime humanized ("until session ends" / "always")
-//   - expires_in_seconds humanized ("10 min" / "1 hour")
+//   - assessed risk level + explanation when available (with 🟢/🟡/🟠/🔴 prefix)
+//   - intent_verification_mode (only when non-strict — strict is default and noise)
+//   - duration: "Duration: 30 min" for session tasks (using daemon default
+//     when unset) or "Lifetime: always" for standing tasks
 //
 // Malformed or empty input falls back to a one-line summary instead of
 // raw JSON — never leak unparsed input back at the user.
@@ -106,9 +106,14 @@ func renderTaskApprovalPromptWithRisk(req *runtimetasks.TaskCreateRequest, appro
 	}
 
 	if risk != nil && strings.TrimSpace(risk.RiskLevel) != "" {
+		level := strings.TrimSpace(risk.RiskLevel)
 		b.WriteString("\n\nRisk")
 		b.WriteString("\n  ")
-		b.WriteString(strings.TrimSpace(risk.RiskLevel))
+		if emoji := riskEmoji(level); emoji != "" {
+			b.WriteString(emoji)
+			b.WriteString(" ")
+		}
+		b.WriteString(level)
 		if explanation := strings.TrimSpace(risk.Explanation); explanation != "" {
 			b.WriteString(" — ")
 			b.WriteString(wrapForPrompt(explanation, 80, "    "))
@@ -116,25 +121,27 @@ func renderTaskApprovalPromptWithRisk(req *runtimetasks.TaskCreateRequest, appro
 	}
 
 	mode := strings.TrimSpace(req.IntentVerificationMode)
-	if mode == "" {
-		mode = "strict"
-	}
-	lifetime := humanizeLifetime(req.Lifetime)
-	expires := humanizeExpiresIn(req.ExpiresInSeconds)
+	durationLabel, durationValue := durationLine(req.Lifetime, req.ExpiresInSeconds)
 
-	b.WriteString("\n\nVerification: ")
-	b.WriteString(mode)
-	if lifetime != "" {
-		b.WriteString("   Lifetime: ")
-		b.WriteString(lifetime)
-	}
-	if expires != "" {
-		b.WriteString("   Expires: ")
-		b.WriteString(expires)
+	if (mode != "" && mode != "strict") || durationValue != "" {
+		b.WriteString("\n\n")
+		needsSep := false
+		if mode != "" && mode != "strict" {
+			b.WriteString("Verification: ")
+			b.WriteString(mode)
+			needsSep = true
+		}
+		if durationValue != "" {
+			if needsSep {
+				b.WriteString("   ")
+			}
+			b.WriteString(durationLabel)
+			b.WriteString(": ")
+			b.WriteString(durationValue)
+		}
 	}
 
-	b.WriteString("\n\nApproving will create this task and run the original tool call.\n")
-	b.WriteString("Reply `yes` or `y` to authorize, `no` or `n` to cancel.")
+	b.WriteString("\n\nReply `yes` or `y` to authorize, `no` or `n` to cancel.")
 	b.WriteString(suffix)
 	return b.String()
 }
@@ -168,17 +175,63 @@ func extractApprovalIDFromPrompt(text string) string {
 	return strings.TrimSpace(rest[:end])
 }
 
-// humanizeLifetime maps the task lifetime to a short user-facing phrase.
-// Defaults to "until session ends" for empty/"session"; "always" for
-// "standing". Unknown values pass through as-is.
-func humanizeLifetime(lifetime string) string {
+// defaultSessionTaskDurationSeconds mirrors pkg/config.TaskConfig's
+// default_expiry_seconds (1800 = 30 min). Duplicated here rather than
+// threaded through PostprocessConfig because the renderer is a UI
+// concern and only needs an honest display fallback — the actual
+// task-scope expiry binding happens in tasks_inline.go using the live
+// config value. If an operator overrides the config default, the
+// prompt may show "30 min" while the resolved scope uses a different
+// number; that drift is acceptable for a status line.
+const defaultSessionTaskDurationSeconds = 1800
+
+// durationLine returns the (label, value) pair describing how long the
+// task will be active once approved. The two lifetime modes render with
+// different labels because they answer different user questions:
+//
+//   - session (the common case): "Duration: 30 min" — how long the
+//     scope is usable. Empty expires_in_seconds falls back to the daemon
+//     default so the user always sees a concrete number.
+//   - standing: "Lifetime: always" — standing tasks reject
+//     expires_in_seconds (see tasks_inline.go), so there is no duration
+//     to show; the label conveys "no time cap" instead.
+//
+// Returns ("", "") only for unknown lifetime strings, so callers can
+// omit the line entirely rather than printing something misleading.
+func durationLine(lifetime string, expiresInSeconds int) (label, value string) {
 	switch strings.TrimSpace(lifetime) {
 	case "", "session":
-		return "until session ends"
+		secs := expiresInSeconds
+		if secs <= 0 {
+			secs = defaultSessionTaskDurationSeconds
+		}
+		return "Duration", humanizeExpiresIn(secs)
 	case "standing":
-		return "always"
+		return "Lifetime", "always"
 	default:
-		return lifetime
+		return "", ""
+	}
+}
+
+// riskEmoji maps the LLM-assessed risk level to a traffic-light emoji
+// prefix. "unknown" gets a neutral marker so the user can distinguish a
+// parse-failed assessment from an unscored task. Unknown levels return
+// "" so the level renders without a prefix rather than with a
+// misleading one.
+func riskEmoji(level string) string {
+	switch strings.ToLower(strings.TrimSpace(level)) {
+	case "low":
+		return "🟢"
+	case "medium":
+		return "🟡"
+	case "high":
+		return "🟠"
+	case "critical":
+		return "🔴"
+	case "unknown":
+		return "⚪"
+	default:
+		return ""
 	}
 }
 

--- a/internal/runtime/llmproxy/inline_task_prompt_test.go
+++ b/internal/runtime/llmproxy/inline_task_prompt_test.go
@@ -170,7 +170,7 @@ func TestRenderTaskApprovalPromptRendersRisk(t *testing.T) {
 	}, "", &taskrisk.RiskAssessment{
 		RiskLevel:   "medium",
 		Explanation: "This task requests credential access.",
-	})
+	}, 0)
 	if !strings.Contains(prompt, "Risk") {
 		t.Errorf("expected risk section, got %q", prompt)
 	}
@@ -203,26 +203,30 @@ func TestHumanizeExpiresIn(t *testing.T) {
 
 func TestDurationLine(t *testing.T) {
 	cases := []struct {
-		name      string
-		lifetime  string
-		seconds   int
-		wantLabel string
-		wantValue string
+		name           string
+		lifetime       string
+		seconds        int
+		defaultSeconds int
+		wantLabel      string
+		wantValue      string
 	}{
-		{"session explicit", "session", 600, "Duration", "10 min"},
-		{"session default (empty)", "session", 0, "Duration", "30 min"},
-		{"empty lifetime treated as session", "", 0, "Duration", "30 min"},
-		{"empty lifetime explicit duration", "", 3600, "Duration", "1 hour"},
-		{"standing ignores seconds", "standing", 0, "Lifetime", "always"},
-		{"standing ignores nonzero seconds", "standing", 600, "Lifetime", "always"},
-		{"unknown lifetime omits line", "weird", 0, "", ""},
+		{"session explicit overrides default", "session", 600, 1800, "Duration", "10 min"},
+		{"session default from config", "session", 0, 3600, "Duration", "1 hour"},
+		{"session falls back to const when no default", "session", 0, 0, "Duration", "30 min"},
+		{"empty lifetime + zero default uses const", "", 0, 0, "Duration", "30 min"},
+		{"empty lifetime + config default", "", 0, 7200, "Duration", "2 hours"},
+		{"empty lifetime + explicit duration", "", 3600, 0, "Duration", "1 hour"},
+		{"standing ignores seconds and default", "standing", 0, 3600, "Lifetime", "always"},
+		{"standing ignores nonzero seconds", "standing", 600, 1800, "Lifetime", "always"},
+		{"unknown lifetime omits line", "weird", 0, 0, "", ""},
+		{"negative default treated as unset", "session", 0, -1, "Duration", "30 min"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			gotLabel, gotValue := durationLine(c.lifetime, c.seconds)
+			gotLabel, gotValue := durationLine(c.lifetime, c.seconds, c.defaultSeconds)
 			if gotLabel != c.wantLabel || gotValue != c.wantValue {
-				t.Errorf("durationLine(%q, %d) = (%q, %q), want (%q, %q)",
-					c.lifetime, c.seconds, gotLabel, gotValue, c.wantLabel, c.wantValue)
+				t.Errorf("durationLine(%q, %d, %d) = (%q, %q), want (%q, %q)",
+					c.lifetime, c.seconds, c.defaultSeconds, gotLabel, gotValue, c.wantLabel, c.wantValue)
 			}
 		})
 	}

--- a/internal/runtime/llmproxy/inline_task_prompt_test.go
+++ b/internal/runtime/llmproxy/inline_task_prompt_test.go
@@ -31,14 +31,14 @@ func TestRenderTaskApprovalPromptWellFormed(t *testing.T) {
 	if !strings.Contains(prompt, "Create directory") {
 		t.Errorf("missing why text: %q", prompt)
 	}
-	if !strings.Contains(prompt, "Verification: strict") {
-		t.Errorf("missing verification line: %q", prompt)
+	if strings.Contains(prompt, "Verification:") {
+		t.Errorf("strict verification should be hidden as the default: %q", prompt)
 	}
-	if !strings.Contains(prompt, "until session ends") {
-		t.Errorf("missing humanized lifetime: %q", prompt)
+	if strings.Contains(prompt, "Lifetime:") {
+		t.Errorf("session lifetime should not surface a Lifetime line: %q", prompt)
 	}
-	if !strings.Contains(prompt, "10 min") {
-		t.Errorf("missing humanized expiry: %q", prompt)
+	if !strings.Contains(prompt, "Duration: 10 min") {
+		t.Errorf("missing combined Duration line: %q", prompt)
 	}
 	if !strings.Contains(prompt, "`yes` or `y`") || !strings.Contains(prompt, "`no` or `n`") {
 		t.Errorf("missing yes/no instructions: %q", prompt)
@@ -58,23 +58,35 @@ func TestRenderTaskApprovalPromptStandingLifetime(t *testing.T) {
 	}
 }
 
-func TestRenderTaskApprovalPromptDefaultsVerification(t *testing.T) {
+func TestRenderTaskApprovalPromptHidesStrictVerification(t *testing.T) {
 	prompt := renderTaskApprovalPrompt(&runtimetasks.TaskCreateRequest{
 		Purpose: "Send a single test email",
 	}, "")
-	if !strings.Contains(prompt, "Verification: strict") {
-		t.Errorf("expected default strict verification, got %q", prompt)
+	if strings.Contains(prompt, "Verification:") {
+		t.Errorf("strict (default) verification should be omitted, got %q", prompt)
 	}
 }
 
-func TestRenderTaskApprovalPromptOmitsExpiryWhenUnset(t *testing.T) {
+func TestRenderTaskApprovalPromptShowsNonStrictVerification(t *testing.T) {
 	prompt := renderTaskApprovalPrompt(&runtimetasks.TaskCreateRequest{
 		Purpose:                "x",
-		ExpiresInSeconds:       0,
 		IntentVerificationMode: "lenient",
 	}, "")
+	if !strings.Contains(prompt, "Verification: lenient") {
+		t.Errorf("expected lenient verification surfaced, got %q", prompt)
+	}
+}
+
+func TestRenderTaskApprovalPromptDefaultsDurationWhenExpiryUnset(t *testing.T) {
+	prompt := renderTaskApprovalPrompt(&runtimetasks.TaskCreateRequest{
+		Purpose:          "x",
+		ExpiresInSeconds: 0,
+	}, "")
+	if !strings.Contains(prompt, "Duration: 30 min") {
+		t.Errorf("expected default 30 min duration when seconds<=0, got %q", prompt)
+	}
 	if strings.Contains(prompt, "Expires:") {
-		t.Errorf("expected no Expires line when seconds<=0, got %q", prompt)
+		t.Errorf("legacy Expires label leaked, got %q", prompt)
 	}
 }
 
@@ -162,8 +174,8 @@ func TestRenderTaskApprovalPromptRendersRisk(t *testing.T) {
 	if !strings.Contains(prompt, "Risk") {
 		t.Errorf("expected risk section, got %q", prompt)
 	}
-	if !strings.Contains(prompt, "medium") {
-		t.Errorf("expected risk level in prompt, got %q", prompt)
+	if !strings.Contains(prompt, "🟡 medium") {
+		t.Errorf("expected risk level with traffic-light emoji prefix, got %q", prompt)
 	}
 	if !strings.Contains(prompt, "This task requests credential access.") {
 		t.Errorf("expected risk explanation in prompt, got %q", prompt)
@@ -189,17 +201,48 @@ func TestHumanizeExpiresIn(t *testing.T) {
 	}
 }
 
-func TestHumanizeLifetime(t *testing.T) {
+func TestDurationLine(t *testing.T) {
+	cases := []struct {
+		name      string
+		lifetime  string
+		seconds   int
+		wantLabel string
+		wantValue string
+	}{
+		{"session explicit", "session", 600, "Duration", "10 min"},
+		{"session default (empty)", "session", 0, "Duration", "30 min"},
+		{"empty lifetime treated as session", "", 0, "Duration", "30 min"},
+		{"empty lifetime explicit duration", "", 3600, "Duration", "1 hour"},
+		{"standing ignores seconds", "standing", 0, "Lifetime", "always"},
+		{"standing ignores nonzero seconds", "standing", 600, "Lifetime", "always"},
+		{"unknown lifetime omits line", "weird", 0, "", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			gotLabel, gotValue := durationLine(c.lifetime, c.seconds)
+			if gotLabel != c.wantLabel || gotValue != c.wantValue {
+				t.Errorf("durationLine(%q, %d) = (%q, %q), want (%q, %q)",
+					c.lifetime, c.seconds, gotLabel, gotValue, c.wantLabel, c.wantValue)
+			}
+		})
+	}
+}
+
+func TestRiskEmoji(t *testing.T) {
 	cases := map[string]string{
-		"":         "until session ends",
-		"session":  "until session ends",
-		"standing": "always",
-		"weird":    "weird",
+		"low":      "🟢",
+		"medium":   "🟡",
+		"high":     "🟠",
+		"critical": "🔴",
+		"unknown":  "⚪",
+		"":         "",
+		"weird":    "",
+		"LOW":      "🟢",
 	}
 	for input, want := range cases {
-		got := humanizeLifetime(input)
+		got := riskEmoji(input)
 		if got != want {
-			t.Errorf("humanizeLifetime(%q) = %q, want %q", input, got, want)
+			t.Errorf("riskEmoji(%q) = %q, want %q", input, got, want)
 		}
 	}
 }

--- a/internal/runtime/llmproxy/postprocess.go
+++ b/internal/runtime/llmproxy/postprocess.go
@@ -242,6 +242,15 @@ type PostprocessConfig struct {
 	// endpoint rewrites. Empty disables the control-plane rewrite path.
 	ControlBaseURL string
 
+	// DefaultTaskExpirySeconds is the daemon's resolved
+	// task.default_expiry_seconds, surfaced into the inline task
+	// approval prompt so the displayed Duration tracks the operator's
+	// configured default when the agent omits expires_in_seconds.
+	// Optional: when 0 or unset, the renderer falls back to its
+	// historical 30-minute constant — the actual scope-binding
+	// fallback used by tasks_inline.go is unaffected either way.
+	DefaultTaskExpirySeconds int
+
 	// Trace, when non-nil, receives one JSON-line event per inspector
 	// decision point for this request. Disabled by default; enabled
 	// via cfg.ProxyLite.TraceLogPath. Calls on a nil *TraceLogger are


### PR DESCRIPTION
## Summary
- Collapse the `Verification: strict   Lifetime: until session ends   Expires: 10 min` line into a single `Duration: 30 min` (or `Lifetime: always` for standing tasks). Verification is now shown only when non-strict.
- Default the Duration display to 30 min when the agent omits `expires_in_seconds`, matching the daemon default in \`pkg/config/config.go\`.
- Prefix the risk level with a 🟢 / 🟡 / 🟠 / 🔴 / ⚪ traffic light so the assessment is scannable at a glance.
- Drop the redundant "Approving will create this task and run the original tool call." line above the yes/no instruction.

## Test plan
- [x] \`go test ./internal/runtime/llmproxy/...\`
- [ ] Eyeball an inline approval prompt in a real session

🤖 Generated with [Claude Code](https://claude.com/claude-code)