### PR TITLE
feat(llmproxy): per-task LLM cost tracking + dashboard

### DIFF
--- a/internal/api/handlers/control.go
+++ b/internal/api/handlers/control.go
@@ -302,7 +302,7 @@ func (h *LLMControlHandler) CheckoutTask(w http.ResponseWriter, r *http.Request)
 		h.Audit.LogEndpointCall(r.Context(), agent, uuid.NewString(), "clawvisor.control", "task.checkout", http.StatusOK, "allow", "checked_out", "", 0, map[string]any{
 			"task_id": task.ID,
 			"purpose": task.Purpose,
-		})
+		}, llmproxy.EndpointCallExtras{TaskID: task.ID})
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
 		"status":     "checked_out",

--- a/internal/api/handlers/llm_endpoint.go
+++ b/internal/api/handlers/llm_endpoint.go
@@ -1051,23 +1051,23 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 				if contCT != "" && contCT != upstreamCT {
 					w.Header().Set("Content-Type", contCT)
 				}
-				// Reattribute the cost row to the task that the
-				// continuation was made for. The auto-approve gate
-				// in the first postprocess pass minted a new task
+				// Reattribute the cost row ONLY when no prior task
+				// attribution exists. The auto-approve gate in the
+				// first postprocess pass minted a new task
 				// (Verdict.CreatedTaskID) and the continuation does
-				// THAT task's work, so the cost belongs there — not
-				// on the pre-continuation checkout (which was
-				// resolved before the task existed and is often
-				// empty for the conversation's very first turn).
-				// Use the first decision that carried both
-				// ContinueWithToolResult (so it actually triggered a
-				// continuation) and a CreatedTaskID; multiple in one
-				// turn is rare, and any one is a strict improvement
-				// over NULL.
-				for _, dec := range processed.Decisions {
-					if dec.Verdict.ContinueWithToolResult != "" && dec.Verdict.CreatedTaskID != "" {
-						auditTaskID = dec.Verdict.CreatedTaskID
-						break
+				// THAT task's work, so when the conversation had no
+				// checkout yet (first turn) the cost belongs there
+				// rather than on NULL. But when the user already had
+				// a task checked out for this conversation,
+				// preferredTaskID populated auditTaskID earlier — a
+				// real, specific attribution we should preserve
+				// rather than overwrite with the just-minted task.
+				if auditTaskID == "" {
+					for _, dec := range processed.Decisions {
+						if dec.Verdict.ContinueWithToolResult != "" && dec.Verdict.CreatedTaskID != "" {
+							auditTaskID = dec.Verdict.CreatedTaskID
+							break
+						}
 					}
 				}
 				// Roll the continuation's tokens into the per-request
@@ -1648,14 +1648,14 @@ func (w *limitedCaptureWriter) Bytes() []byte {
 // are all collapsed by pricing.Normalize). Used to gate the
 // continuation token-merge so a continuation that resolves to a
 // different upstream model can't get billed at the first call's rate.
-// An empty model on either side is treated as "match unknown" — the
-// merge proceeds because the prior code path used to assume models
-// always match, and an empty model is almost always the first call
-// (extractor populated it from requestModel) and the continuation
-// (extractor saw the same body).
+// Returns false when either side is empty — without a known model we
+// can't prove a match, and silently merging unattributable tokens
+// risks mispricing if a future caller starts populating only one
+// side (the existing extractor path leaves Model empty only on
+// pathological responses that fail to surface a model at all).
 func pricingModelMatch(a, b string) bool {
 	if a == "" || b == "" {
-		return true
+		return false
 	}
 	return pricing.Normalize(a) == pricing.Normalize(b)
 }

--- a/internal/api/handlers/llm_endpoint.go
+++ b/internal/api/handlers/llm_endpoint.go
@@ -232,6 +232,11 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 		auditOutcome string
 		auditReason  string
 		auditParams  map[string]any
+		// Cost-extraction state populated once the upstream response
+		// has been buffered. The deferred audit emission below reads
+		// these to write a paired llm_request_cost row.
+		auditUsage   *llmproxy.ExtractUsageResult
+		auditTaskID  string
 	)
 	defer func() {
 		// One-liner summary at handler exit — visible in slog even
@@ -266,7 +271,8 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 		// stalls invisible until we added the raw I/O log).
 		h.AuditEmitter.LogEndpointCall(context.Background(), auditAgent, requestID, provName,
 			auditAction, auditStatus, auditDecide, auditOutcome, auditReason,
-			time.Since(start), auditParams)
+			time.Since(start), auditParams,
+			llmproxy.EndpointCallExtras{TaskID: auditTaskID, Usage: auditUsage})
 	}()
 
 	agent := middleware.AgentFromContext(r.Context())
@@ -779,6 +785,27 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 		auditParams["upstream_body_bytes"] = bytesRead
 		auditParams["upstream_read_ms"] = readElapsed.Milliseconds()
 		auditParams["upstream_ttfb_body_ms"] = readTTFB.Milliseconds()
+		// Extract token usage on success (skip 4xx/5xx — they have no
+		// token-bearing body). The deferred audit emit at the top of
+		// serve() reads auditUsage / auditTaskID and writes one
+		// llm_request_cost row when usage is found. Cost is best-
+		// effort observability and never blocks the response. The
+		// task-id link is filled in below, once preferredTaskID has
+		// been resolved.
+		if readErr == nil && resp.StatusCode < 400 {
+			if usage := llmproxy.ExtractUsage(provider, upstreamCT, full, reqSummary.Model); usage.Found {
+				u := usage
+				auditUsage = &u
+				auditParams["usage_input_tokens"] = usage.Usage.InputTokens
+				auditParams["usage_output_tokens"] = usage.Usage.OutputTokens
+				if usage.Usage.CacheReadTokens > 0 {
+					auditParams["usage_cache_read_tokens"] = usage.Usage.CacheReadTokens
+				}
+				if usage.Usage.CacheWriteTokens > 0 {
+					auditParams["usage_cache_write_tokens"] = usage.Usage.CacheWriteTokens
+				}
+			}
+		}
 		if readErr != nil {
 			clientCancelled := r.Context().Err() != nil
 			h.Logger.WarnContext(context.Background(), "lite-proxy upstream read error",
@@ -879,6 +906,9 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 			auditParams["task_checkout_unavailable"] = true
 			preferredTaskID = ""
 		}
+		if preferredTaskID != "" {
+			auditTaskID = preferredTaskID
+		}
 		h.Logger.DebugContext(r.Context(), "lite-proxy decision inputs loaded",
 			"request_id", requestID,
 			"agent_id", agent.ID,
@@ -958,7 +988,7 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 		// original `processed` (which still carries SubstituteWith as a
 		// terminal assistant text), so the harness never sees an empty body.
 		{
-			contFinal, contStatus, contCT, contErr := h.tryContinuation(r, agent, provider, requestID, body, full, upstreamCT, resp.StatusCode, processed, llmproxy.PostprocessConfig{
+			contFinal, contStatus, contCT, contUsage, contErr := h.tryContinuation(r, agent, provider, requestID, body, full, upstreamCT, resp.StatusCode, processed, llmproxy.PostprocessConfig{
 				Inspector:                        h.Inspector,
 				RewriteOpts:                      opts,
 				Store:                            h.Store,
@@ -1019,6 +1049,23 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 				}
 				if contCT != "" && contCT != upstreamCT {
 					w.Header().Set("Content-Type", contCT)
+				}
+				// Roll the continuation's tokens into the per-request
+				// cost. Both calls used the same model (the
+				// continuation builder preserves it), so summing the
+				// token buckets is correct; pricing.Compute will
+				// price the combined sum against one model row.
+				if contUsage != nil {
+					if auditUsage == nil {
+						auditUsage = contUsage
+					} else {
+						auditUsage.Usage.InputTokens += contUsage.Usage.InputTokens
+						auditUsage.Usage.OutputTokens += contUsage.Usage.OutputTokens
+						auditUsage.Usage.CacheReadTokens += contUsage.Usage.CacheReadTokens
+						auditUsage.Usage.CacheWriteTokens += contUsage.Usage.CacheWriteTokens
+						auditUsage.Usage.CacheWrite1hTokens += contUsage.Usage.CacheWrite1hTokens
+					}
+					auditParams["continuation_usage_recorded"] = true
 				}
 			}
 		}
@@ -1281,13 +1328,13 @@ func (h *LLMEndpointHandler) tryContinuation(
 	upstreamStatus int,
 	processed llmproxy.PostprocessResult,
 	cfg llmproxy.PostprocessConfig,
-) (*llmproxy.PostprocessResult, int, string, error) {
+) (*llmproxy.PostprocessResult, int, string, *llmproxy.ExtractUsageResult, error) {
 	if upstreamStatus >= 400 {
 		// Don't try to continue on top of an upstream error response —
 		// the model never actually emitted a clean tool_use turn, and
 		// the body shape may not match what extractAnthropicAssistantContent
 		// expects.
-		return nil, 0, "", nil
+		return nil, 0, "", nil, nil
 	}
 	var toolResults []llmproxy.ContinuationToolResult
 	for _, dec := range processed.Decisions {
@@ -1300,7 +1347,7 @@ func (h *LLMEndpointHandler) tryContinuation(
 		})
 	}
 	if len(toolResults) == 0 {
-		return nil, 0, "", nil
+		return nil, 0, "", nil, nil
 	}
 	// Tool_use / tool_result must be 1:1 for the upstream — Anthropic
 	// and OpenAI Chat both 400 on an unbalanced continuation body. If
@@ -1349,11 +1396,11 @@ func (h *LLMEndpointHandler) tryContinuation(
 		if h.AuditEmitter != nil {
 			h.AuditEmitter.LogContinuationSkippedSiblingTools(r.Context(), agent, requestID, autoApprovedTaskID, autoApprovedTUID, droppedNames)
 		}
-		return nil, 0, "", nil
+		return nil, 0, "", nil, nil
 	}
 	contBody, err := llmproxy.BuildContinuationBody(provider, upstreamCT, inboundBody, upstreamBody, toolResults)
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("build continuation body: %w", err)
+		return nil, 0, "", nil, fmt.Errorf("build continuation body: %w", err)
 	}
 	h.Logger.DebugContext(r.Context(), "lite-proxy continuation forwarding",
 		"request_id", requestID,
@@ -1364,19 +1411,32 @@ func (h *LLMEndpointHandler) tryContinuation(
 	)
 	resp, err := h.Forwarder.Forward(r.Context(), agent.UserID, agent.ID, provider, r, contBody)
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("forward continuation: %w", err)
+		return nil, 0, "", nil, fmt.Errorf("forward continuation: %w", err)
 	}
 	defer resp.Body.Close()
 	full, readErr := readResponseLimited(resp.Body, h.MaxResponseBytes)
 	if readErr != nil {
-		return nil, 0, "", fmt.Errorf("read continuation upstream: %w", readErr)
+		return nil, 0, "", nil, fmt.Errorf("read continuation upstream: %w", readErr)
 	}
 	if resp.StatusCode >= 400 {
-		return nil, 0, "", fmt.Errorf("continuation upstream returned %d", resp.StatusCode)
+		return nil, 0, "", nil, fmt.Errorf("continuation upstream returned %d", resp.StatusCode)
 	}
 	contCT := resp.Header.Get("Content-Type")
 	if contCT == "" {
 		contCT = upstreamCT
+	}
+	// Extract usage on the continuation body so its tokens land in
+	// the per-task cost rollup. Without this, any auto-approved
+	// task that proceeds via continuation would under-report by
+	// exactly the tokens the post-approval call burned — typically
+	// the call that actually does the work. The continuation reuses
+	// the inbound request's model (BuildContinuationBody preserves
+	// it) so the upstream body will name the same model — no
+	// requestModel fallback needed.
+	var contUsage *llmproxy.ExtractUsageResult
+	if u := llmproxy.ExtractUsage(provider, contCT, full, ""); u.Found {
+		uc := u
+		contUsage = &uc
 	}
 	// Refresh decision inputs before the continuation postprocess. The
 	// original cfg.CandidateTasks was loaded at the top of serve(),
@@ -1502,7 +1562,7 @@ func (h *LLMEndpointHandler) tryContinuation(
 		}
 	}
 
-	return &newProcessed, resp.StatusCode, contCT, nil
+	return &newProcessed, resp.StatusCode, contCT, contUsage, nil
 }
 
 // readResponseLimited mirrors readLimited for upstream responses. Default

--- a/internal/api/handlers/llm_endpoint.go
+++ b/internal/api/handlers/llm_endpoint.go
@@ -20,6 +20,7 @@ import (
 	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/inspector"
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/pricing"
 	"github.com/clawvisor/clawvisor/internal/taskrisk"
 	runtimedecision "github.com/clawvisor/clawvisor/pkg/runtime/decision"
 	"github.com/clawvisor/clawvisor/pkg/store"
@@ -1050,22 +1051,56 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 				if contCT != "" && contCT != upstreamCT {
 					w.Header().Set("Content-Type", contCT)
 				}
+				// Reattribute the cost row to the task that the
+				// continuation was made for. The auto-approve gate
+				// in the first postprocess pass minted a new task
+				// (Verdict.CreatedTaskID) and the continuation does
+				// THAT task's work, so the cost belongs there — not
+				// on the pre-continuation checkout (which was
+				// resolved before the task existed and is often
+				// empty for the conversation's very first turn).
+				// Use the first decision that carried both
+				// ContinueWithToolResult (so it actually triggered a
+				// continuation) and a CreatedTaskID; multiple in one
+				// turn is rare, and any one is a strict improvement
+				// over NULL.
+				for _, dec := range processed.Decisions {
+					if dec.Verdict.ContinueWithToolResult != "" && dec.Verdict.CreatedTaskID != "" {
+						auditTaskID = dec.Verdict.CreatedTaskID
+						break
+					}
+				}
 				// Roll the continuation's tokens into the per-request
-				// cost. Both calls used the same model (the
-				// continuation builder preserves it), so summing the
-				// token buckets is correct; pricing.Compute will
-				// price the combined sum against one model row.
+				// cost. We expect both calls to report the same
+				// model (BuildContinuationBody preserves the inbound
+				// `model` field), so summing token buckets is safe
+				// and pricing.Compute will price the combined sum
+				// against one model row. Defend against a future
+				// regression where the upstream resolves to a
+				// different model on the continuation: drop the
+				// continuation's usage rather than silently bill it
+				// at the first call's rate.
 				if contUsage != nil {
-					if auditUsage == nil {
+					switch {
+					case auditUsage == nil:
 						auditUsage = contUsage
-					} else {
+						auditParams["continuation_usage_recorded"] = true
+					case pricingModelMatch(auditUsage.Model, contUsage.Model):
 						auditUsage.Usage.InputTokens += contUsage.Usage.InputTokens
 						auditUsage.Usage.OutputTokens += contUsage.Usage.OutputTokens
 						auditUsage.Usage.CacheReadTokens += contUsage.Usage.CacheReadTokens
 						auditUsage.Usage.CacheWriteTokens += contUsage.Usage.CacheWriteTokens
 						auditUsage.Usage.CacheWrite1hTokens += contUsage.Usage.CacheWrite1hTokens
+						auditParams["continuation_usage_recorded"] = true
+					default:
+						h.Logger.WarnContext(r.Context(), "lite-proxy continuation usage dropped: model mismatch with original call",
+							"request_id", requestID,
+							"agent_id", agent.ID,
+							"original_model", auditUsage.Model,
+							"continuation_model", contUsage.Model,
+						)
+						auditParams["continuation_usage_dropped_model_mismatch"] = true
 					}
-					auditParams["continuation_usage_recorded"] = true
 				}
 			}
 		}
@@ -1606,6 +1641,23 @@ func (w *limitedCaptureWriter) Bytes() []byte {
 		return nil
 	}
 	return w.buf.Bytes()
+}
+
+// pricingModelMatch reports whether two model identifiers resolve to
+// the same pricing-table row (case, vendor prefix, date suffix, etc.
+// are all collapsed by pricing.Normalize). Used to gate the
+// continuation token-merge so a continuation that resolves to a
+// different upstream model can't get billed at the first call's rate.
+// An empty model on either side is treated as "match unknown" — the
+// merge proceeds because the prior code path used to assume models
+// always match, and an empty model is almost always the first call
+// (extractor populated it from requestModel) and the continuation
+// (extractor saw the same body).
+func pricingModelMatch(a, b string) bool {
+	if a == "" || b == "" {
+		return true
+	}
+	return pricing.Normalize(a) == pricing.Normalize(b)
 }
 
 // actionForRoute maps a request path to an audit-log action label.

--- a/internal/api/handlers/llm_endpoint_continuation_test.go
+++ b/internal/api/handlers/llm_endpoint_continuation_test.go
@@ -106,7 +106,7 @@ func TestTryContinuation_PostsSecondCallWithToolResult(t *testing.T) {
 	agent := firstSeededAgent(t, h.Store)
 	req = req.WithContext(store.WithAgent(req.Context(), agent))
 
-	final, status, ct, err := h.tryContinuation(
+	final, status, ct, _, err := h.tryContinuation(
 		req,
 		agent,
 		conversation.ProviderAnthropic,
@@ -263,7 +263,7 @@ func TestTryContinuation_RefreshesCandidateTasksFromStore(t *testing.T) {
 	// where the original load happened before any inline auto-approve
 	// minted a new task — the refresh inside tryContinuation must
 	// re-read the store to find the seeded github task.
-	final, _, _, err := h.tryContinuation(
+	final, _, _, _, err := h.tryContinuation(
 		req, agent, conversation.ProviderAnthropic, "req-refresh",
 		inboundBody, firstUpstreamBody, "application/json", http.StatusOK,
 		processed,
@@ -351,7 +351,7 @@ func TestTryContinuation_PrependsUserFacingNotice(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/messages", strings.NewReader(string(inboundBody)))
 	req = req.WithContext(store.WithAgent(req.Context(), agent))
 
-	final, _, _, err := h.tryContinuation(
+	final, _, _, _, err := h.tryContinuation(
 		req, agent, conversation.ProviderAnthropic, "req-notice",
 		inboundBody, firstUpstreamBody, "application/json", http.StatusOK,
 		processed,
@@ -402,7 +402,7 @@ func TestTryContinuation_NoContinueDecisionIsNoOp(t *testing.T) {
 			Verdict: conversation.ToolUseVerdict{Allowed: true},
 		}},
 	}
-	final, status, ct, err := h.tryContinuation(
+	final, status, ct, _, err := h.tryContinuation(
 		req, agent, conversation.ProviderAnthropic, "req-x",
 		[]byte(`{"messages":[]}`), []byte(`{"content":[]}`), "application/json", http.StatusOK,
 		processed, llmproxy.PostprocessConfig{Inspector: h.Inspector},
@@ -471,7 +471,7 @@ func TestServe_ContinuationClearsStaleContentLengthHeader(t *testing.T) {
 		}},
 	}
 
-	final, _, _, err := h.tryContinuation(
+	final, _, _, _, err := h.tryContinuation(
 		req, agent, conversation.ProviderAnthropic, "req-headers",
 		[]byte(`{"messages":[{"role":"user","content":"x"}]}`),
 		[]byte(`{"content":[{"type":"tool_use","id":"toolu_a","name":"Bash","input":{}}]}`),
@@ -536,7 +536,7 @@ func TestTryContinuation_UpstreamErrorFallsBack(t *testing.T) {
 	}
 	inbound := []byte(`{"messages":[{"role":"user","content":"hi"}]}`)
 	first := []byte(`{"content":[{"type":"tool_use","id":"toolu_x","name":"Bash","input":{}}]}`)
-	final, _, _, err := h.tryContinuation(
+	final, _, _, _, err := h.tryContinuation(
 		req, agent, conversation.ProviderAnthropic, "req-y",
 		inbound, first, "application/json", http.StatusOK,
 		processed, llmproxy.PostprocessConfig{Inspector: h.Inspector},

--- a/internal/api/handlers/tasks.go
+++ b/internal/api/handlers/tasks.go
@@ -874,6 +874,50 @@ func (h *TasksHandler) Get(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, task)
 }
 
+// Cost returns the LLM token usage and computed cost (in micro-USD)
+// for one task, rolled up across all upstream calls made under that
+// task. Authenticated by user (not agent) — the dashboard surfaces
+// per-task spend; agents don't need this view.
+//
+// GET /api/tasks/{id}/cost
+// Auth: user session
+func (h *TasksHandler) Cost(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	user := middleware.UserFromContext(ctx)
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "not authenticated")
+		return
+	}
+	taskID := r.PathValue("id")
+	if taskID == "" {
+		writeError(w, http.StatusBadRequest, "BAD_REQUEST", "missing task id")
+		return
+	}
+	// Confirm the task belongs to this user before exposing its cost.
+	// GetTaskCost itself filters by user_id, but a missing task should
+	// still 404 rather than silently returning a zeroed summary.
+	task, err := h.st.GetTask(ctx, taskID)
+	if err != nil {
+		if err == store.ErrNotFound {
+			writeError(w, http.StatusNotFound, "NOT_FOUND", "task not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not get task")
+		return
+	}
+	if task.UserID != user.ID {
+		writeError(w, http.StatusForbidden, "FORBIDDEN", "not your task")
+		return
+	}
+	summary, err := h.st.GetTaskCost(ctx, user.ID, taskID)
+	if err != nil {
+		h.logger.WarnContext(ctx, "GetTaskCost failed", "task_id", taskID, "err", err.Error())
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not load task cost")
+		return
+	}
+	writeJSON(w, http.StatusOK, summary)
+}
+
 // Start resolves a task into the active state and, when provided a runtime
 // session id, binds that runtime session to the task for subsequent proxy
 // attribution and biasing.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -954,6 +954,7 @@ func (s *Server) routes() http.Handler {
 
 	// Tasks (user JWT)
 	mux.Handle("GET /api/tasks", user(tasksHandler.List))
+	mux.Handle("GET /api/tasks/{id}/cost", user(tasksHandler.Cost))
 	mux.Handle("POST /api/tasks/{id}/approve", user(tasksHandler.Approve))
 	mux.Handle("PATCH /api/tasks/{id}/scope", user(tasksHandler.UpdateScope))
 	mux.Handle("POST /api/tasks/{id}/deny", user(tasksHandler.Deny))

--- a/internal/runtime/llmproxy/audit.go
+++ b/internal/runtime/llmproxy/audit.go
@@ -3,6 +3,7 @@ package llmproxy
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"regexp"
 	"strings"
@@ -119,31 +120,60 @@ func (e *AuditEmitter) LogEndpointCall(ctx context.Context, agent *store.Agent, 
 		DurationMS: int(duration.Milliseconds()),
 	}
 	if err := e.Store.LogAudit(ctx, entry); err != nil {
-		// Surface the token counts to slog on the failure path so a
-		// dropped row leaves a trace that can be reconciled later —
-		// without this, an audit-log outage silently loses the
-		// per-request usage data entirely.
-		var tokenAttrs []any
-		tokenAttrs = append(tokenAttrs, "agent_id", agent.ID, "action", action, "err", err.Error())
-		if extras.Usage != nil && extras.Usage.Found {
-			tokenAttrs = append(tokenAttrs,
-				"usage_model", extras.Usage.Model,
-				"usage_input_tokens", extras.Usage.Usage.InputTokens,
-				"usage_output_tokens", extras.Usage.Usage.OutputTokens,
-				"usage_cache_read_tokens", extras.Usage.Usage.CacheReadTokens,
-				"usage_cache_write_tokens", extras.Usage.Usage.CacheWriteTokens,
-				"usage_cache_write_1h_tokens", extras.Usage.Usage.CacheWrite1hTokens,
-			)
+		// ErrConflict means the canonical audit row for this
+		// (user_id, request_id, task_id) already exists — this is
+		// the dedup path the schema is designed to enforce, not a
+		// store failure. Fall through and still record cost so the
+		// retried request's billable usage isn't permanently lost.
+		//
+		// BUT: llm_request_cost.audit_id has a FK into audit_log(id)
+		// ON DELETE CASCADE, so using the locally generated entry.ID
+		// (which never landed) would violate the FK. Resolve the
+		// surviving canonical row via FindDedupCandidate — the audit
+		// task_id used for dedup is COALESCE(task_id, ''), and
+		// endpoint_call rows deliberately leave audit_log.task_id
+		// NULL (see EndpointCallExtras.TaskID), so we look up with
+		// taskID="" to match the canonical pre-task row.
+		if errors.Is(err, store.ErrConflict) {
+			canonical, lookupErr := e.Store.FindDedupCandidate(ctx, requestID, agent.UserID, "")
+			if lookupErr != nil || canonical == nil {
+				// Defensive: ErrConflict means the row exists, so
+				// the lookup should succeed. If it doesn't, skip the
+				// cost row rather than risk an FK violation — the
+				// tokens are still observable via the warn below.
+				e.Logger.WarnContext(ctx, "lite-proxy: audit deduped but canonical lookup failed; skipping cost record",
+					"agent_id", agent.ID, "request_id", requestID, "action", action, "err", errString(lookupErr))
+				return
+			}
+			entry.ID = canonical.ID
+			entry.Timestamp = canonical.Timestamp
+			e.Logger.DebugContext(ctx, "lite-proxy: audit log deduped; recording cost against canonical row",
+				"agent_id", agent.ID, "request_id", requestID, "action", action, "canonical_audit_id", canonical.ID)
+		} else {
+			// Surface the token counts to slog on the failure path so
+			// a dropped row leaves a trace that can be reconciled
+			// later — without this, an audit-log outage silently
+			// loses the per-request usage data entirely.
+			var tokenAttrs []any
+			tokenAttrs = append(tokenAttrs, "agent_id", agent.ID, "action", action, "err", err.Error())
+			if extras.Usage != nil && extras.Usage.Found {
+				tokenAttrs = append(tokenAttrs,
+					"usage_model", extras.Usage.Model,
+					"usage_input_tokens", extras.Usage.Usage.InputTokens,
+					"usage_output_tokens", extras.Usage.Usage.OutputTokens,
+					"usage_cache_read_tokens", extras.Usage.Usage.CacheReadTokens,
+					"usage_cache_write_tokens", extras.Usage.Usage.CacheWriteTokens,
+					"usage_cache_write_1h_tokens", extras.Usage.Usage.CacheWrite1hTokens,
+				)
+			}
+			e.Logger.WarnContext(ctx, "lite-proxy: audit log failed", tokenAttrs...)
+			// Skip cost recording on real store errors. The cost
+			// row carries no FK to audit_log so technically we could
+			// land it anyway, but a store error on audit suggests
+			// the cost insert would likely fail too — and the
+			// tokens above are in slog for reconciliation.
+			return
 		}
-		e.Logger.WarnContext(ctx, "lite-proxy: audit log failed", tokenAttrs...)
-		// Skip cost recording when the audit row didn't land. The
-		// schema does not enforce a foreign key between
-		// llm_request_cost.audit_id and audit_log.id (intentionally —
-		// we don't want a cost-record outage to gate the audit row),
-		// so write-order is what guarantees the cost row never refers
-		// to a non-existent audit. Tokens just logged above survive
-		// the drop.
-		return
 	}
 	if extras.Usage != nil && extras.Usage.Found {
 		// Store the normalized model id so GROUP BY in GetTaskCost
@@ -568,6 +598,16 @@ func nilIfEmpty(s string) *string {
 		return nil
 	}
 	return &s
+}
+
+// errString safely renders an error for slog without panicking on nil.
+// Used on defensive branches where the error may or may not be set
+// (e.g. a nil-return-with-nil-error contract from a store lookup).
+func errString(err error) string {
+	if err == nil {
+		return "<nil>"
+	}
+	return err.Error()
 }
 
 // buildSHA returns the clawvisor build identifier. Stamped at link time

--- a/internal/runtime/llmproxy/audit.go
+++ b/internal/runtime/llmproxy/audit.go
@@ -226,8 +226,20 @@ func (e *AuditEmitter) LogEndpointCall(ctx context.Context, agent *store.Agent, 
 				CostMicros:       costMicros,
 			}
 			if err := e.Store.RecordLLMRequestCost(ctx, row); err != nil {
-				e.Logger.WarnContext(ctx, "lite-proxy: cost record failed",
-					"agent_id", agent.ID, "audit_id", entry.ID, "err", err.Error())
+				// ErrConflict on the cost insert is the expected,
+				// harmless path during dedup retries: the audit
+				// row got resolved to the canonical id above, but
+				// the cost row keyed on that same id is already
+				// present from the original call. Demote to Debug
+				// so routine retries don't fire alerts; surface
+				// real store errors at Warn.
+				if errors.Is(err, store.ErrConflict) {
+					e.Logger.DebugContext(ctx, "lite-proxy: cost record deduped (canonical cost row already exists)",
+						"agent_id", agent.ID, "audit_id", entry.ID)
+				} else {
+					e.Logger.WarnContext(ctx, "lite-proxy: cost record failed",
+						"agent_id", agent.ID, "audit_id", entry.ID, "err", err.Error())
+				}
 			}
 		}
 	}

--- a/internal/runtime/llmproxy/audit.go
+++ b/internal/runtime/llmproxy/audit.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/inspector"
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/pricing"
 	"github.com/clawvisor/clawvisor/pkg/store"
 	"github.com/clawvisor/clawvisor/pkg/version"
 	"github.com/google/uuid"
@@ -48,11 +49,37 @@ func NewAuditEmitter(st store.Store, logger *slog.Logger, v interface{ PromptSHA
 	return e
 }
 
+// EndpointCallExtras carries optional, request-call-specific signals
+// that LogEndpointCall threads into the audit row and (when present)
+// the llm_request_cost row. Keeping these out of the positional args
+// avoids breaking the many callers that don't supply them.
+type EndpointCallExtras struct {
+	// TaskID, when non-empty, populates llm_request_cost.task_id so
+	// per-task spend rolls up. It deliberately does NOT propagate to
+	// audit_log.task_id: that column is part of the canonical dedup
+	// key UNIQUE(user_id, request_id, COALESCE(task_id, '')) and the
+	// same request_id already has task-scoped audit rows landing
+	// from LogToolUseInspected / LogInlineTaskApproved at
+	// (uid, rid, T). Adding the endpoint_call row at the same key
+	// would silently dedup it out — and the cost row with it.
+	// Leaving audit_log.task_id NULL keeps the legacy dedup behavior
+	// and the cost table carries the task linkage independently.
+	TaskID string
+	// Usage, when Found, drives one llm_request_cost row computed
+	// against the pricing table. Skipped when nil or not Found.
+	Usage *ExtractUsageResult
+}
+
 // LogEndpointCall records one /v1/* request hitting the lite-proxy LLM
 // endpoint. Service is the provider name; Action is the route shape
 // ("messages.create", "responses.create", "chat.completions.create").
 // outcome is "success" / "error_<status>" / "upstream_key_missing" etc.
-func (e *AuditEmitter) LogEndpointCall(ctx context.Context, agent *store.Agent, requestID, provider, action string, statusCode int, decision, outcome, reason string, duration time.Duration, paramsExtra map[string]any) {
+//
+// When extras.Usage is non-nil and reports Found, the call also writes
+// one llm_request_cost row tying the audit entry to its token + price
+// breakdown. Cost-record failures are logged but never block the
+// audit insert — billing is best-effort observability, not a gate.
+func (e *AuditEmitter) LogEndpointCall(ctx context.Context, agent *store.Agent, requestID, provider, action string, statusCode int, decision, outcome, reason string, duration time.Duration, paramsExtra map[string]any, extras EndpointCallExtras) {
 	if e == nil || e.Store == nil || agent == nil {
 		return
 	}
@@ -69,6 +96,14 @@ func (e *AuditEmitter) LogEndpointCall(ctx context.Context, agent *store.Agent, 
 	}
 	paramsJSON, _ := json.Marshal(params)
 
+	var taskIDPtr *string
+	if extras.TaskID != "" {
+		t := extras.TaskID
+		taskIDPtr = &t
+	}
+	// audit_log.task_id is deliberately left NULL on endpoint_call
+	// rows — see EndpointCallExtras.TaskID for the dedup rationale.
+	// The task linkage is recorded on the cost row below.
 	entry := &store.AuditEntry{
 		ID:         uuid.NewString(),
 		UserID:     agent.UserID,
@@ -84,8 +119,87 @@ func (e *AuditEmitter) LogEndpointCall(ctx context.Context, agent *store.Agent, 
 		DurationMS: int(duration.Milliseconds()),
 	}
 	if err := e.Store.LogAudit(ctx, entry); err != nil {
-		e.Logger.WarnContext(ctx, "lite-proxy: audit log failed",
-			"agent_id", agent.ID, "action", action, "err", err.Error())
+		// Surface the token counts to slog on the failure path so a
+		// dropped row leaves a trace that can be reconciled later —
+		// without this, an audit-log outage silently loses the
+		// per-request usage data entirely.
+		var tokenAttrs []any
+		tokenAttrs = append(tokenAttrs, "agent_id", agent.ID, "action", action, "err", err.Error())
+		if extras.Usage != nil && extras.Usage.Found {
+			tokenAttrs = append(tokenAttrs,
+				"usage_model", extras.Usage.Model,
+				"usage_input_tokens", extras.Usage.Usage.InputTokens,
+				"usage_output_tokens", extras.Usage.Usage.OutputTokens,
+				"usage_cache_read_tokens", extras.Usage.Usage.CacheReadTokens,
+				"usage_cache_write_tokens", extras.Usage.Usage.CacheWriteTokens,
+				"usage_cache_write_1h_tokens", extras.Usage.Usage.CacheWrite1hTokens,
+			)
+		}
+		e.Logger.WarnContext(ctx, "lite-proxy: audit log failed", tokenAttrs...)
+		// Skip cost recording when the audit row didn't land. The
+		// schema does not enforce a foreign key between
+		// llm_request_cost.audit_id and audit_log.id (intentionally —
+		// we don't want a cost-record outage to gate the audit row),
+		// so write-order is what guarantees the cost row never refers
+		// to a non-existent audit. Tokens just logged above survive
+		// the drop.
+		return
+	}
+	if extras.Usage != nil && extras.Usage.Found {
+		// Store the normalized model id so GROUP BY in GetTaskCost
+		// doesn't fragment a task's spend across spelling variants
+		// (e.g. `claude-opus-4-7` and `anthropic/claude-opus-4-7` and
+		// `claude-opus-4-7-20260120` are the same priced model).
+		normModel := pricing.Normalize(extras.Usage.Model)
+		if normModel == "" {
+			// Both the upstream body and the inbound request omitted
+			// a model id. The cost row would be unattributable (it
+			// can't be priced, can't roll up under any model in the
+			// UI). Skip the insert and warn — the token counts are
+			// still in slog above for forensics.
+			e.Logger.WarnContext(ctx, "lite-proxy: skipping cost record — no model on request or response",
+				"agent_id", agent.ID, "audit_id", entry.ID)
+		} else {
+			cost := pricing.Compute(normModel, extras.Usage.Usage)
+			var costMicros *int64
+			if cost.Known {
+				c := cost.CostMicros
+				costMicros = &c
+			} else {
+				// Surface unknown-model rows so the pricing table can
+				// be updated. Recorded with cost_micros=NULL so
+				// aggregates can flag them rather than under-billing
+				// silently.
+				e.Logger.WarnContext(ctx, "lite-proxy: cost not priced — model missing from pricing table",
+					"agent_id", agent.ID, "model", normModel)
+			}
+			// Storage flattens the per-TTL cache-write breakdown into
+			// one column; cost has already been computed against the
+			// split buckets by pricing.Compute above. Re-deriving cost
+			// from the stored row would assume 5m rates and slightly
+			// under-bill 1h cache writes — acceptable for re-derivation
+			// today, callable out in a future schema bump if needed.
+			cacheWriteTotal := extras.Usage.Usage.CacheWriteTokens + extras.Usage.Usage.CacheWrite1hTokens
+			row := &store.LLMRequestCost{
+				AuditID:          entry.ID,
+				UserID:           agent.UserID,
+				AgentID:          &agent.ID,
+				TaskID:           taskIDPtr,
+				RequestID:        requestID,
+				Timestamp:        entry.Timestamp,
+				Provider:         provider,
+				Model:            normModel,
+				InputTokens:      extras.Usage.Usage.InputTokens,
+				OutputTokens:     extras.Usage.Usage.OutputTokens,
+				CacheReadTokens:  extras.Usage.Usage.CacheReadTokens,
+				CacheWriteTokens: cacheWriteTotal,
+				CostMicros:       costMicros,
+			}
+			if err := e.Store.RecordLLMRequestCost(ctx, row); err != nil {
+				e.Logger.WarnContext(ctx, "lite-proxy: cost record failed",
+					"agent_id", agent.ID, "audit_id", entry.ID, "err", err.Error())
+			}
+		}
 	}
 }
 

--- a/internal/runtime/llmproxy/audit_test.go
+++ b/internal/runtime/llmproxy/audit_test.go
@@ -38,7 +38,7 @@ func TestAuditEmitter_LogEndpointCall(t *testing.T) {
 	em := NewAuditEmitter(st, nil, nil)
 
 	em.LogEndpointCall(context.Background(), agent, "req-1", "anthropic", "lite_proxy.messages.create",
-		200, "allow", "success", "", 12*time.Millisecond, map[string]any{"input_tokens": 18, "output_tokens": 8})
+		200, "allow", "success", "", 12*time.Millisecond, map[string]any{"input_tokens": 18, "output_tokens": 8}, EndpointCallExtras{})
 
 	rows, _, err := st.ListAuditEntries(context.Background(), agent.UserID, store.AuditFilter{})
 	if err != nil {
@@ -209,7 +209,7 @@ func TestAuditEmitter_PopulatesValidatorPromptSHA(t *testing.T) {
 	em := NewAuditEmitter(st, nil, promptSHAStub{sha: "abc123"})
 
 	em.LogEndpointCall(context.Background(), agent, "req-1", "anthropic", "lite_proxy.messages.create",
-		200, "allow", "success", "", 0, nil)
+		200, "allow", "success", "", 0, nil, EndpointCallExtras{})
 
 	rows, _, _ := st.ListAuditEntries(context.Background(), agent.UserID, store.AuditFilter{})
 	if len(rows) != 1 {

--- a/internal/runtime/llmproxy/audit_test.go
+++ b/internal/runtime/llmproxy/audit_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/inspector"
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/pricing"
 	"github.com/clawvisor/clawvisor/pkg/store"
 	"github.com/clawvisor/clawvisor/pkg/store/sqlite"
 )
@@ -78,6 +79,96 @@ func TestAuditEmitter_LogEndpointCall(t *testing.T) {
 	}
 	if _, ok := params["parser_version"]; !ok {
 		t.Errorf("expected forensic parser_version")
+	}
+}
+
+// TestAuditEmitter_LogEndpointCall_DedupCostUsesCanonicalAuditID
+// pins the FK-safety contract on the dedup path: when LogAudit
+// returns ErrConflict (the canonical row already exists for this
+// request_id), the cost row must be written against the surviving
+// canonical audit row's id — not the locally generated id that
+// never landed. With FK llm_request_cost.audit_id REFERENCES
+// audit_log(id), using the local id would fail the insert.
+func TestAuditEmitter_LogEndpointCall_DedupCostUsesCanonicalAuditID(t *testing.T) {
+	st, agent := newAuditTestStore(t)
+	em := NewAuditEmitter(st, nil, nil)
+	ctx := context.Background()
+
+	usage := &ExtractUsageResult{
+		Found: true,
+		Model: "claude-opus-4-7",
+		Usage: pricing.Usage{InputTokens: 100, OutputTokens: 50},
+	}
+
+	// First call lands the canonical audit row + cost row.
+	em.LogEndpointCall(ctx, agent, "req-dedup", "anthropic", "lite_proxy.messages.create",
+		200, "allow", "success", "", 0, nil, EndpointCallExtras{Usage: usage})
+
+	rows, _, err := st.ListAuditEntries(ctx, agent.UserID, store.AuditFilter{})
+	if err != nil {
+		t.Fatalf("ListAuditEntries: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 audit row after first call, got %d", len(rows))
+	}
+	canonicalAuditID := rows[0].ID
+
+	costSummary, err := st.GetTaskCost(ctx, agent.UserID, "")
+	if err != nil {
+		t.Fatalf("GetTaskCost: %v", err)
+	}
+	_ = costSummary // task_id is NULL on these rows; just confirm no error
+
+	// Second call with same request_id triggers ErrConflict on LogAudit.
+	// The cost record must succeed (FK-safe) by pointing at the
+	// canonical row's id, not the new entry's local id.
+	em.LogEndpointCall(ctx, agent, "req-dedup", "anthropic", "lite_proxy.messages.create",
+		200, "allow", "success", "", 0, nil, EndpointCallExtras{Usage: usage})
+
+	// Still exactly one audit row (dedup worked).
+	rows, _, err = st.ListAuditEntries(ctx, agent.UserID, store.AuditFilter{})
+	if err != nil {
+		t.Fatalf("ListAuditEntries after retry: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 audit row after retry (dedup), got %d", len(rows))
+	}
+	if rows[0].ID != canonicalAuditID {
+		t.Fatalf("canonical audit id changed unexpectedly: %s -> %s", canonicalAuditID, rows[0].ID)
+	}
+
+	// The cost row from the FIRST call must still be there (PK conflict
+	// on audit_id meant the retry insert was a no-op rather than a row
+	// pointing at a non-existent audit_id). If the dedup path had used
+	// a fresh entry.ID, the FK would have rejected it; if there were
+	// no FK, we'd now have two cost rows for one canonical audit row.
+	sqliteStore, ok := st.(*sqlite.Store)
+	if !ok {
+		t.Fatalf("expected *sqlite.Store, got %T", st)
+	}
+	db := sqliteStore.DB()
+	var costRowCount int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM llm_request_cost WHERE audit_id = ?`, canonicalAuditID,
+	).Scan(&costRowCount); err != nil {
+		t.Fatalf("count cost rows: %v", err)
+	}
+	if costRowCount != 1 {
+		t.Fatalf("expected exactly 1 cost row tied to canonical audit_id %s, got %d",
+			canonicalAuditID, costRowCount)
+	}
+
+	// And no orphan cost rows pointing at audit ids that don't exist.
+	var orphans int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM llm_request_cost c
+		 LEFT JOIN audit_log a ON a.id = c.audit_id
+		 WHERE a.id IS NULL`,
+	).Scan(&orphans); err != nil {
+		t.Fatalf("count orphan cost rows: %v", err)
+	}
+	if orphans != 0 {
+		t.Fatalf("found %d orphan cost rows pointing at non-existent audit_log rows", orphans)
 	}
 }
 

--- a/internal/runtime/llmproxy/pricing/pricing.go
+++ b/internal/runtime/llmproxy/pricing/pricing.go
@@ -60,40 +60,44 @@ type Cost struct {
 	CostMicros int64
 }
 
-// asOf2026q2 stamps every entry below. Bump when you edit a price.
-var asOf2026q2 = time.Date(2026, 5, 27, 0, 0, 0, 0, time.UTC)
+// lastBulkPricedAt is the timestamp the entire table was last
+// reconciled against upstream pricing in one pass. Single-row updates
+// between bulk reconciliations should inline a distinct time.Date(...)
+// literal on the row instead — using this shared stamp on a row that
+// was edited later makes the PricedAt claim a lie for that row.
+var lastBulkPricedAt = time.Date(2026, 5, 27, 0, 0, 0, 0, time.UTC)
 
 var table = map[string]ModelPricing{
 	// Anthropic — current generation (Claude 4.x). CacheWrite1hPerM
 	// is 2x InputPerM (Anthropic's 1-hour cache premium); 5-minute
 	// writes are at 1.25x.
-	"claude-opus-4-7":             {InputPerM: 15.00, OutputPerM: 75.00, CacheWritePerM: 18.75, CacheWrite1hPerM: 30.00, CacheReadPerM: 1.50, PricedAt: asOf2026q2},
-	"claude-opus-4-6":             {InputPerM: 15.00, OutputPerM: 75.00, CacheWritePerM: 18.75, CacheWrite1hPerM: 30.00, CacheReadPerM: 1.50, PricedAt: asOf2026q2},
-	"claude-opus-4-5":             {InputPerM: 15.00, OutputPerM: 75.00, CacheWritePerM: 18.75, CacheWrite1hPerM: 30.00, CacheReadPerM: 1.50, PricedAt: asOf2026q2},
-	"claude-sonnet-4-7":           {InputPerM: 3.00, OutputPerM: 15.00, CacheWritePerM: 3.75, CacheWrite1hPerM: 6.00, CacheReadPerM: 0.30, PricedAt: asOf2026q2},
-	"claude-sonnet-4-6":           {InputPerM: 3.00, OutputPerM: 15.00, CacheWritePerM: 3.75, CacheWrite1hPerM: 6.00, CacheReadPerM: 0.30, PricedAt: asOf2026q2},
-	"claude-sonnet-4-5":           {InputPerM: 3.00, OutputPerM: 15.00, CacheWritePerM: 3.75, CacheWrite1hPerM: 6.00, CacheReadPerM: 0.30, PricedAt: asOf2026q2},
-	"claude-haiku-4-5":            {InputPerM: 1.00, OutputPerM: 5.00, CacheWritePerM: 1.25, CacheWrite1hPerM: 2.00, CacheReadPerM: 0.10, PricedAt: asOf2026q2},
+	"claude-opus-4-7":             {InputPerM: 15.00, OutputPerM: 75.00, CacheWritePerM: 18.75, CacheWrite1hPerM: 30.00, CacheReadPerM: 1.50, PricedAt: lastBulkPricedAt},
+	"claude-opus-4-6":             {InputPerM: 15.00, OutputPerM: 75.00, CacheWritePerM: 18.75, CacheWrite1hPerM: 30.00, CacheReadPerM: 1.50, PricedAt: lastBulkPricedAt},
+	"claude-opus-4-5":             {InputPerM: 15.00, OutputPerM: 75.00, CacheWritePerM: 18.75, CacheWrite1hPerM: 30.00, CacheReadPerM: 1.50, PricedAt: lastBulkPricedAt},
+	"claude-sonnet-4-7":           {InputPerM: 3.00, OutputPerM: 15.00, CacheWritePerM: 3.75, CacheWrite1hPerM: 6.00, CacheReadPerM: 0.30, PricedAt: lastBulkPricedAt},
+	"claude-sonnet-4-6":           {InputPerM: 3.00, OutputPerM: 15.00, CacheWritePerM: 3.75, CacheWrite1hPerM: 6.00, CacheReadPerM: 0.30, PricedAt: lastBulkPricedAt},
+	"claude-sonnet-4-5":           {InputPerM: 3.00, OutputPerM: 15.00, CacheWritePerM: 3.75, CacheWrite1hPerM: 6.00, CacheReadPerM: 0.30, PricedAt: lastBulkPricedAt},
+	"claude-haiku-4-5":            {InputPerM: 1.00, OutputPerM: 5.00, CacheWritePerM: 1.25, CacheWrite1hPerM: 2.00, CacheReadPerM: 0.10, PricedAt: lastBulkPricedAt},
 	// Keys are the normalized form: vendor prefix, `-latest` suffix,
 	// and `-YYYYMMDD` date suffix stripped (see Normalize). So the
 	// concrete `claude-3-7-sonnet-20250219` and the alias
 	// `claude-3-7-sonnet-latest` both resolve to this row.
-	"claude-3-7-sonnet":           {InputPerM: 3.00, OutputPerM: 15.00, CacheWritePerM: 3.75, CacheWrite1hPerM: 6.00, CacheReadPerM: 0.30, PricedAt: asOf2026q2},
-	"claude-3-5-haiku":            {InputPerM: 0.80, OutputPerM: 4.00, CacheWritePerM: 1.00, CacheWrite1hPerM: 1.60, CacheReadPerM: 0.08, PricedAt: asOf2026q2},
+	"claude-3-7-sonnet":           {InputPerM: 3.00, OutputPerM: 15.00, CacheWritePerM: 3.75, CacheWrite1hPerM: 6.00, CacheReadPerM: 0.30, PricedAt: lastBulkPricedAt},
+	"claude-3-5-haiku":            {InputPerM: 0.80, OutputPerM: 4.00, CacheWritePerM: 1.00, CacheWrite1hPerM: 1.60, CacheReadPerM: 0.08, PricedAt: lastBulkPricedAt},
 
 	// OpenAI. CacheWritePerM is omitted because OpenAI caches
 	// automatically with no per-write premium; their prompt-caching
 	// only discounts the cached-read portion. Cache-write fields
 	// stay zero for OpenAI rows.
-	"gpt-5.5":         {InputPerM: 5.00, OutputPerM: 30.00, CacheReadPerM: 0.50, PricedAt: asOf2026q2},
-	"gpt-5.5-pro":     {InputPerM: 30.00, OutputPerM: 180.00, CacheReadPerM: 3.00, PricedAt: asOf2026q2},
-	"gpt-5.2-codex":   {InputPerM: 1.75, OutputPerM: 14.00, CacheReadPerM: 0.175, PricedAt: asOf2026q2},
-	"gpt-4o":          {InputPerM: 2.50, OutputPerM: 10.00, CacheReadPerM: 1.25, PricedAt: asOf2026q2},
-	"gpt-4o-mini":     {InputPerM: 0.15, OutputPerM: 0.60, CacheReadPerM: 0.075, PricedAt: asOf2026q2},
-	"gpt-4-turbo":     {InputPerM: 10.00, OutputPerM: 30.00, PricedAt: asOf2026q2},
-	"o1":              {InputPerM: 15.00, OutputPerM: 60.00, CacheReadPerM: 7.50, PricedAt: asOf2026q2},
-	"o1-mini":         {InputPerM: 3.00, OutputPerM: 12.00, CacheReadPerM: 1.50, PricedAt: asOf2026q2},
-	"o3-mini":         {InputPerM: 1.10, OutputPerM: 4.40, CacheReadPerM: 0.55, PricedAt: asOf2026q2},
+	"gpt-5.5":         {InputPerM: 5.00, OutputPerM: 30.00, CacheReadPerM: 0.50, PricedAt: lastBulkPricedAt},
+	"gpt-5.5-pro":     {InputPerM: 30.00, OutputPerM: 180.00, CacheReadPerM: 3.00, PricedAt: lastBulkPricedAt},
+	"gpt-5.2-codex":   {InputPerM: 1.75, OutputPerM: 14.00, CacheReadPerM: 0.175, PricedAt: lastBulkPricedAt},
+	"gpt-4o":          {InputPerM: 2.50, OutputPerM: 10.00, CacheReadPerM: 1.25, PricedAt: lastBulkPricedAt},
+	"gpt-4o-mini":     {InputPerM: 0.15, OutputPerM: 0.60, CacheReadPerM: 0.075, PricedAt: lastBulkPricedAt},
+	"gpt-4-turbo":     {InputPerM: 10.00, OutputPerM: 30.00, PricedAt: lastBulkPricedAt},
+	"o1":              {InputPerM: 15.00, OutputPerM: 60.00, CacheReadPerM: 7.50, PricedAt: lastBulkPricedAt},
+	"o1-mini":         {InputPerM: 3.00, OutputPerM: 12.00, CacheReadPerM: 1.50, PricedAt: lastBulkPricedAt},
+	"o3-mini":         {InputPerM: 1.10, OutputPerM: 4.40, CacheReadPerM: 0.55, PricedAt: lastBulkPricedAt},
 }
 
 // Compute returns the dollar cost of one request, in micro-USD.

--- a/internal/runtime/llmproxy/pricing/pricing.go
+++ b/internal/runtime/llmproxy/pricing/pricing.go
@@ -1,0 +1,180 @@
+// Package pricing turns raw LLM token counts into a cost in micro-USD.
+//
+// Money is stored as int64 micro-USD (1e-6 USD) everywhere downstream
+// of this package. That avoids float drift in SUM() aggregates and
+// matches how Stripe / GCP / most billing systems represent cents-fractions.
+//
+// The table is hand-maintained; bump pricedAt on each entry when you
+// touch it so a future "is this stale?" check is grep-able. Unknown
+// models return Cost{Known: false} — callers should still log token
+// counts and skip the cost field rather than fail the request.
+package pricing
+
+import (
+	"regexp"
+	"strings"
+	"time"
+)
+
+// ModelPricing is the per-1M-token list price (USD) for one model.
+// CacheWritePerM is the price for a 5-minute prompt-cache write
+// (typically 1.25x InputPerM). CacheWrite1hPerM is the longer-TTL
+// variant Anthropic introduced for repeated-system-prompt workloads,
+// typically ~2x InputPerM; falls back to CacheWritePerM when zero so
+// older table entries keep working. CacheReadPerM is the discounted
+// re-read price, typically 0.1x InputPerM.
+type ModelPricing struct {
+	InputPerM        float64
+	OutputPerM       float64
+	CacheWritePerM   float64
+	CacheWrite1hPerM float64
+	CacheReadPerM    float64
+	PricedAt         time.Time
+}
+
+// Usage is the per-request token breakdown extracted from the upstream
+// response. Field names match the Anthropic wire shape; OpenAI's
+// equivalents (prompt_tokens, completion_tokens, cached_tokens) are
+// normalised into the same struct at the call site.
+//
+// CacheWriteTokens is the 5-minute-TTL bucket; CacheWrite1hTokens is
+// the 1-hour-TTL bucket. Anthropic reports them separately under
+// `usage.cache_creation.{ephemeral_5m_input_tokens,
+// ephemeral_1h_input_tokens}`. Older clients that only emit the
+// top-level `cache_creation_input_tokens` land entirely in
+// CacheWriteTokens (5m bucket) — that matches the historical default
+// TTL.
+type Usage struct {
+	InputTokens        int
+	OutputTokens       int
+	CacheWriteTokens   int
+	CacheWrite1hTokens int
+	CacheReadTokens    int
+}
+
+// Cost is the computed result. CostMicros is the only field downstream
+// storage cares about; the rest are surfaced for debugging.
+type Cost struct {
+	Known      bool
+	Model      string
+	CostMicros int64
+}
+
+// asOf2026q2 stamps every entry below. Bump when you edit a price.
+var asOf2026q2 = time.Date(2026, 5, 27, 0, 0, 0, 0, time.UTC)
+
+var table = map[string]ModelPricing{
+	// Anthropic — current generation (Claude 4.x). CacheWrite1hPerM
+	// is 2x InputPerM (Anthropic's 1-hour cache premium); 5-minute
+	// writes are at 1.25x.
+	"claude-opus-4-7":             {InputPerM: 15.00, OutputPerM: 75.00, CacheWritePerM: 18.75, CacheWrite1hPerM: 30.00, CacheReadPerM: 1.50, PricedAt: asOf2026q2},
+	"claude-opus-4-6":             {InputPerM: 15.00, OutputPerM: 75.00, CacheWritePerM: 18.75, CacheWrite1hPerM: 30.00, CacheReadPerM: 1.50, PricedAt: asOf2026q2},
+	"claude-opus-4-5":             {InputPerM: 15.00, OutputPerM: 75.00, CacheWritePerM: 18.75, CacheWrite1hPerM: 30.00, CacheReadPerM: 1.50, PricedAt: asOf2026q2},
+	"claude-sonnet-4-7":           {InputPerM: 3.00, OutputPerM: 15.00, CacheWritePerM: 3.75, CacheWrite1hPerM: 6.00, CacheReadPerM: 0.30, PricedAt: asOf2026q2},
+	"claude-sonnet-4-6":           {InputPerM: 3.00, OutputPerM: 15.00, CacheWritePerM: 3.75, CacheWrite1hPerM: 6.00, CacheReadPerM: 0.30, PricedAt: asOf2026q2},
+	"claude-sonnet-4-5":           {InputPerM: 3.00, OutputPerM: 15.00, CacheWritePerM: 3.75, CacheWrite1hPerM: 6.00, CacheReadPerM: 0.30, PricedAt: asOf2026q2},
+	"claude-haiku-4-5":            {InputPerM: 1.00, OutputPerM: 5.00, CacheWritePerM: 1.25, CacheWrite1hPerM: 2.00, CacheReadPerM: 0.10, PricedAt: asOf2026q2},
+	// Keys are the normalized form: vendor prefix, `-latest` suffix,
+	// and `-YYYYMMDD` date suffix stripped (see Normalize). So the
+	// concrete `claude-3-7-sonnet-20250219` and the alias
+	// `claude-3-7-sonnet-latest` both resolve to this row.
+	"claude-3-7-sonnet":           {InputPerM: 3.00, OutputPerM: 15.00, CacheWritePerM: 3.75, CacheWrite1hPerM: 6.00, CacheReadPerM: 0.30, PricedAt: asOf2026q2},
+	"claude-3-5-haiku":            {InputPerM: 0.80, OutputPerM: 4.00, CacheWritePerM: 1.00, CacheWrite1hPerM: 1.60, CacheReadPerM: 0.08, PricedAt: asOf2026q2},
+
+	// OpenAI. CacheWritePerM is omitted because OpenAI caches
+	// automatically with no per-write premium; their prompt-caching
+	// only discounts the cached-read portion. Cache-write fields
+	// stay zero for OpenAI rows.
+	"gpt-5.5":         {InputPerM: 5.00, OutputPerM: 30.00, CacheReadPerM: 0.50, PricedAt: asOf2026q2},
+	"gpt-5.5-pro":     {InputPerM: 30.00, OutputPerM: 180.00, CacheReadPerM: 3.00, PricedAt: asOf2026q2},
+	"gpt-5.2-codex":   {InputPerM: 1.75, OutputPerM: 14.00, CacheReadPerM: 0.175, PricedAt: asOf2026q2},
+	"gpt-4o":          {InputPerM: 2.50, OutputPerM: 10.00, CacheReadPerM: 1.25, PricedAt: asOf2026q2},
+	"gpt-4o-mini":     {InputPerM: 0.15, OutputPerM: 0.60, CacheReadPerM: 0.075, PricedAt: asOf2026q2},
+	"gpt-4-turbo":     {InputPerM: 10.00, OutputPerM: 30.00, PricedAt: asOf2026q2},
+	"o1":              {InputPerM: 15.00, OutputPerM: 60.00, CacheReadPerM: 7.50, PricedAt: asOf2026q2},
+	"o1-mini":         {InputPerM: 3.00, OutputPerM: 12.00, CacheReadPerM: 1.50, PricedAt: asOf2026q2},
+	"o3-mini":         {InputPerM: 1.10, OutputPerM: 4.40, CacheReadPerM: 0.55, PricedAt: asOf2026q2},
+}
+
+// Compute returns the dollar cost of one request, in micro-USD.
+// model is matched against the table after a Normalize pass. Unknown
+// models return Cost{Known: false, CostMicros: 0}.
+func Compute(model string, u Usage) Cost {
+	key := Normalize(model)
+	p, ok := table[key]
+	if !ok {
+		return Cost{Known: false, Model: model}
+	}
+	// (tokens / 1_000_000) * pricePerM USD * 1_000_000 micros/USD
+	// = tokens * pricePerM micros — the 1M factors cancel, so we
+	// don't lose precision on small token counts.
+	cacheWrite1hRate := p.CacheWrite1hPerM
+	if cacheWrite1hRate == 0 {
+		// Table entry doesn't distinguish TTLs (older row, or a
+		// provider with only one cache write tier). Fall back to the
+		// 5m rate so we under-bill less catastrophically than zero.
+		cacheWrite1hRate = p.CacheWritePerM
+	}
+	total := float64(u.InputTokens)*p.InputPerM +
+		float64(u.OutputTokens)*p.OutputPerM +
+		float64(u.CacheWriteTokens)*p.CacheWritePerM +
+		float64(u.CacheWrite1hTokens)*cacheWrite1hRate +
+		float64(u.CacheReadTokens)*p.CacheReadPerM
+	return Cost{
+		Known:      true,
+		Model:      key,
+		CostMicros: int64(total + 0.5),
+	}
+}
+
+// dateSuffix matches an `-YYYYMMDD` trailing component on a model
+// id. Anthropic's stable wire IDs include the release date
+// (`claude-3-7-sonnet-20250219`); OpenAI does the same for some
+// snapshots (`gpt-4o-2024-08-06`, which after the dash-only pass
+// reads as `gpt-4o-20240806`). Strip it so dated and aliased ids
+// collapse to the same table key.
+var dateSuffix = regexp.MustCompile(`-\d{8}$`)
+
+// Normalize collapses the many shapes a model identifier can arrive
+// in down to one table key. Strips, in order: vendor prefixes
+// (`anthropic/`, `openai/`); the `[1m]` / `:1m` / `-1m` context-
+// window markers (hosted 1M-context Anthropic variants price the
+// same as the 200k base today); `-latest` and `-YYYYMMDD` so
+// aliased and concrete-dated ids resolve to the same row. Also
+// folds OpenAI's `YYYY-MM-DD` snapshot suffix to the same shape.
+//
+// Exported so callers can normalize the model name they persist on
+// llm_request_cost rows — GROUP BY would otherwise fragment a
+// task's spend across spelling variants.
+func Normalize(model string) string {
+	m := strings.ToLower(strings.TrimSpace(model))
+	// Strip vendor prefixes. Slash-form (`anthropic/...`) is the
+	// common one for first-party SDKs and most gateways. Dot-form
+	// (`anthropic.claude-opus-4-7`) shows up on Bedrock-style
+	// routing, which the lite-proxy doesn't target today but might
+	// see indirectly via an upstream that does.
+	for _, p := range []string{"anthropic/", "openai/", "anthropic.", "openai."} {
+		m = strings.TrimPrefix(m, p)
+	}
+	m = strings.TrimSuffix(m, "[1m]")
+	m = strings.TrimSuffix(m, ":1m")
+	m = strings.TrimSuffix(m, "-1m")
+	m = strings.TrimSuffix(m, "-latest")
+	// Fold OpenAI's YYYY-MM-DD snapshot ids (e.g. `gpt-4o-2024-08-06`)
+	// into the same shape Anthropic uses so one strip handles both.
+	if i := len(m) - 11; i > 0 && m[i] == '-' &&
+		isDigits(m[i+1:i+5]) && m[i+5] == '-' && isDigits(m[i+6:i+8]) && m[i+8] == '-' && isDigits(m[i+9:]) {
+		m = m[:i] + "-" + m[i+1:i+5] + m[i+6:i+8] + m[i+9:]
+	}
+	m = dateSuffix.ReplaceAllString(m, "")
+	return m
+}
+
+func isDigits(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return len(s) > 0
+}

--- a/internal/runtime/llmproxy/pricing/pricing_test.go
+++ b/internal/runtime/llmproxy/pricing/pricing_test.go
@@ -1,0 +1,86 @@
+package pricing
+
+import "testing"
+
+func TestCompute_KnownModel(t *testing.T) {
+	// Sonnet 4.7: 1000 input + 500 output should be
+	// 1000*3 + 500*15 = 10,500 micros (0.0105 USD).
+	got := Compute("claude-sonnet-4-7", Usage{InputTokens: 1000, OutputTokens: 500})
+	if !got.Known {
+		t.Fatalf("expected known model")
+	}
+	if got.CostMicros != 10500 {
+		t.Fatalf("CostMicros = %d, want 10500", got.CostMicros)
+	}
+}
+
+func TestCompute_WithCacheTokens(t *testing.T) {
+	// Sonnet 4.7 cache_read at 0.30/M: 10_000 read tokens = 3_000 micros.
+	got := Compute("claude-sonnet-4-7", Usage{CacheReadTokens: 10000})
+	if got.CostMicros != 3000 {
+		t.Fatalf("CostMicros = %d, want 3000", got.CostMicros)
+	}
+}
+
+func TestCompute_UnknownModel(t *testing.T) {
+	got := Compute("not-a-real-model", Usage{InputTokens: 1000})
+	if got.Known {
+		t.Fatalf("unknown model should report Known=false")
+	}
+	if got.CostMicros != 0 {
+		t.Fatalf("unknown model CostMicros = %d, want 0", got.CostMicros)
+	}
+}
+
+func TestCompute_NormalizesVendorPrefixAndSuffix(t *testing.T) {
+	cases := []string{
+		"claude-opus-4-7",
+		"anthropic/claude-opus-4-7",
+		"Claude-Opus-4-7",
+		"claude-opus-4-7[1m]",
+		"claude-opus-4-7-1m",
+		"claude-opus-4-7-20260120", // dated snapshot
+	}
+	want := Compute("claude-opus-4-7", Usage{InputTokens: 1_000_000}).CostMicros
+	for _, c := range cases {
+		got := Compute(c, Usage{InputTokens: 1_000_000})
+		if !got.Known {
+			t.Fatalf("model %q: expected known", c)
+		}
+		if got.CostMicros != want {
+			t.Fatalf("model %q: CostMicros = %d, want %d", c, got.CostMicros, want)
+		}
+	}
+}
+
+func TestNormalize_DatedAndAliasedCollapse(t *testing.T) {
+	cases := map[string]string{
+		// Anthropic dated variants → table key.
+		"claude-3-7-sonnet-20250219": "claude-3-7-sonnet",
+		"claude-3-7-sonnet-latest":   "claude-3-7-sonnet",
+		"claude-3-5-haiku-20241022":  "claude-3-5-haiku",
+		// OpenAI YYYY-MM-DD snapshot folds to the same shape.
+		"gpt-4o-2024-08-06": "gpt-4o",
+		"gpt-4o-mini-2024-07-18": "gpt-4o-mini",
+		// Vendor prefix + casing.
+		"Anthropic/Claude-Opus-4-7": "claude-opus-4-7",
+	}
+	for in, want := range cases {
+		if got := Normalize(in); got != want {
+			t.Errorf("Normalize(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestCompute_DatedAnthropicMatches(t *testing.T) {
+	// The actual upstream wire model — exactly the shape Anthropic
+	// returns. Pre-fix this would have landed as Known=false.
+	got := Compute("claude-3-7-sonnet-20250219", Usage{InputTokens: 1000, OutputTokens: 500})
+	if !got.Known {
+		t.Fatalf("expected dated sonnet to price as known")
+	}
+	// 1000*3 + 500*15 = 10,500 micros
+	if got.CostMicros != 10500 {
+		t.Errorf("CostMicros = %d, want 10500", got.CostMicros)
+	}
+}

--- a/internal/runtime/llmproxy/usage.go
+++ b/internal/runtime/llmproxy/usage.go
@@ -83,7 +83,14 @@ func bodyLooksLikeSSE(body []byte) bool {
 		i++
 	}
 	rest := body[i:]
-	return bytes.HasPrefix(rest, []byte("event:")) || bytes.HasPrefix(rest, []byte("data:"))
+	// Per the SSE spec a line starting with `:` is a comment, often
+	// used by intermediaries as a keep-alive heartbeat (e.g. `: ping`)
+	// before any real event arrives. A stream that opens with a
+	// comment line is still SSE; treating it as JSON would silently
+	// skip cost recording for the call.
+	return bytes.HasPrefix(rest, []byte("event:")) ||
+		bytes.HasPrefix(rest, []byte("data:")) ||
+		bytes.HasPrefix(rest, []byte(":"))
 }
 
 type anthropicCacheCreation struct {

--- a/internal/runtime/llmproxy/usage.go
+++ b/internal/runtime/llmproxy/usage.go
@@ -1,0 +1,368 @@
+package llmproxy
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"strings"
+
+	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/pricing"
+)
+
+// ExtractUsageResult is what one upstream response told us about its
+// token usage. Model echoes the upstream's `model` field, which may
+// differ from the request-supplied model (Anthropic resolves aliases
+// like `claude-opus-4-7-latest` to a concrete version on the way back).
+// Found is false when no usage payload was present — caller should
+// not record a cost row in that case.
+type ExtractUsageResult struct {
+	Found bool
+	Model string
+	Usage pricing.Usage
+}
+
+// ExtractUsage pulls the token-usage payload out of an upstream LLM
+// response body. Handles both JSON and SSE shapes for Anthropic and
+// OpenAI.
+//
+//   - Anthropic JSON:  body is a single `{"usage":{...}}` envelope.
+//   - Anthropic SSE:   input tokens land in the `message_start` event,
+//                      output tokens in the final `message_delta`.
+//   - OpenAI JSON:     body has `usage:{prompt_tokens, completion_tokens,
+//                      prompt_tokens_details.cached_tokens}`.
+//   - OpenAI SSE:      usage appears in the final chunk only when the
+//                      caller set `stream_options.include_usage=true`.
+//                      Returns Found=false otherwise (no fabrication).
+//
+// requestModel falls back when the upstream body omits the model field
+// (rare; happens on some error envelopes). Pass the model the caller
+// asked for — it's still the right billing key.
+func ExtractUsage(provider conversation.Provider, contentType string, body []byte, requestModel string) ExtractUsageResult {
+	if len(body) == 0 {
+		return ExtractUsageResult{}
+	}
+	// Detect SSE from the body itself, not just the Content-Type
+	// header. Some upstream proxy paths drop or mangle the header by
+	// the time it reaches us — we'd then fall through to the JSON
+	// parser, fail to unmarshal an SSE stream, and silently return
+	// Found=false. The body shape is unambiguous: SSE always opens
+	// with an `event:` or `data:` line, while JSON opens with `{`.
+	// Content-Type is consulted only as a tiebreaker for atypical
+	// bodies.
+	isSSE := strings.Contains(strings.ToLower(contentType), "text/event-stream") || bodyLooksLikeSSE(body)
+	switch provider {
+	case conversation.ProviderAnthropic:
+		if isSSE {
+			return extractAnthropicSSE(body, requestModel)
+		}
+		return extractAnthropicJSON(body, requestModel)
+	case conversation.ProviderOpenAI:
+		if isSSE {
+			return extractOpenAISSE(body, requestModel)
+		}
+		return extractOpenAIJSON(body, requestModel)
+	}
+	return ExtractUsageResult{}
+}
+
+// bodyLooksLikeSSE returns true when the first non-whitespace byte
+// of the body starts an `event:` or `data:` SSE field. Skips a UTF-8
+// BOM if present (real SSE streams sometimes have one) before the
+// prefix check.
+func bodyLooksLikeSSE(body []byte) bool {
+	if len(body) == 0 {
+		return false
+	}
+	// Skip BOM + leading whitespace.
+	i := 0
+	if len(body) >= 3 && body[0] == 0xEF && body[1] == 0xBB && body[2] == 0xBF {
+		i = 3
+	}
+	for i < len(body) && (body[i] == ' ' || body[i] == '\t' || body[i] == '\r' || body[i] == '\n') {
+		i++
+	}
+	rest := body[i:]
+	return bytes.HasPrefix(rest, []byte("event:")) || bytes.HasPrefix(rest, []byte("data:"))
+}
+
+type anthropicCacheCreation struct {
+	Ephemeral5mInputTokens int `json:"ephemeral_5m_input_tokens"`
+	Ephemeral1hInputTokens int `json:"ephemeral_1h_input_tokens"`
+}
+
+type anthropicUsage struct {
+	InputTokens              int                    `json:"input_tokens"`
+	OutputTokens             int                    `json:"output_tokens"`
+	CacheCreationInputTokens int                    `json:"cache_creation_input_tokens"`
+	CacheCreation            anthropicCacheCreation `json:"cache_creation"`
+	CacheReadInputTokens     int                    `json:"cache_read_input_tokens"`
+}
+
+func (u anthropicUsage) toPricing() pricing.Usage {
+	// Prefer the per-TTL breakdown when the upstream surfaced it
+	// (newer Anthropic versions emit cache_creation.{ephemeral_5m,
+	// ephemeral_1h}_input_tokens). Fall back to the legacy
+	// cache_creation_input_tokens scalar by treating it as 5-minute
+	// cache writes — matches Anthropic's historical default TTL.
+	write5m := u.CacheCreation.Ephemeral5mInputTokens
+	write1h := u.CacheCreation.Ephemeral1hInputTokens
+	if write5m == 0 && write1h == 0 {
+		write5m = u.CacheCreationInputTokens
+	}
+	return pricing.Usage{
+		InputTokens:        u.InputTokens,
+		OutputTokens:       u.OutputTokens,
+		CacheReadTokens:    u.CacheReadInputTokens,
+		CacheWriteTokens:   write5m,
+		CacheWrite1hTokens: write1h,
+	}
+}
+
+type anthropicJSONEnvelope struct {
+	Model string         `json:"model"`
+	Usage anthropicUsage `json:"usage"`
+}
+
+func extractAnthropicJSON(body []byte, requestModel string) ExtractUsageResult {
+	var env anthropicJSONEnvelope
+	if err := json.Unmarshal(body, &env); err != nil {
+		return ExtractUsageResult{}
+	}
+	// A response that uses only the newer per-TTL fields (5m/1h
+	// buckets nested under cache_creation) has the legacy scalar
+	// at zero — include those in the zero-check or the row would
+	// be silently dropped from cost recording.
+	u := env.Usage
+	if u.InputTokens == 0 && u.OutputTokens == 0 &&
+		u.CacheReadInputTokens == 0 && u.CacheCreationInputTokens == 0 &&
+		u.CacheCreation.Ephemeral5mInputTokens == 0 && u.CacheCreation.Ephemeral1hInputTokens == 0 {
+		return ExtractUsageResult{}
+	}
+	model := env.Model
+	if model == "" {
+		model = requestModel
+	}
+	return ExtractUsageResult{Found: true, Model: model, Usage: env.Usage.toPricing()}
+}
+
+func extractAnthropicSSE(body []byte, requestModel string) ExtractUsageResult {
+	// The stream's authoritative usage is assembled from two events:
+	//   * message_start.message.usage carries input + cache tokens
+	//     (and a placeholder output_tokens that the model overwrites).
+	//   * the final message_delta.usage carries the real output_tokens.
+	// We don't validate event ordering; just take the last non-zero
+	// of each field as we walk the stream. That tolerates partial
+	// streams (cancelled mid-flight) by reporting whatever did land.
+	var merged anthropicUsage
+	var model string
+	scanner := bufio.NewScanner(bytes.NewReader(body))
+	// Cap the per-line buffer at the body length itself. The body is
+	// already bounded by h.MaxResponseBytes upstream, so this neither
+	// uses more memory than the read already did nor lets a giant
+	// single chunk silently truncate (which would have made usage
+	// extraction return Found=false for the request).
+	scanner.Buffer(make([]byte, 0, 64*1024), len(body)+1)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if !bytes.HasPrefix(line, []byte("data:")) {
+			continue
+		}
+		payload := bytes.TrimSpace(line[len("data:"):])
+		if len(payload) == 0 || bytes.Equal(payload, []byte("[DONE]")) {
+			continue
+		}
+		var ev struct {
+			Type    string `json:"type"`
+			Message struct {
+				Model string         `json:"model"`
+				Usage anthropicUsage `json:"usage"`
+			} `json:"message"`
+			Usage anthropicUsage `json:"usage"`
+		}
+		if err := json.Unmarshal(payload, &ev); err != nil {
+			continue
+		}
+		switch ev.Type {
+		case "message_start":
+			if ev.Message.Model != "" {
+				model = ev.Message.Model
+			}
+			if ev.Message.Usage.InputTokens > 0 {
+				merged.InputTokens = ev.Message.Usage.InputTokens
+			}
+			if ev.Message.Usage.CacheCreationInputTokens > 0 {
+				merged.CacheCreationInputTokens = ev.Message.Usage.CacheCreationInputTokens
+			}
+			if ev.Message.Usage.CacheCreation.Ephemeral5mInputTokens > 0 {
+				merged.CacheCreation.Ephemeral5mInputTokens = ev.Message.Usage.CacheCreation.Ephemeral5mInputTokens
+			}
+			if ev.Message.Usage.CacheCreation.Ephemeral1hInputTokens > 0 {
+				merged.CacheCreation.Ephemeral1hInputTokens = ev.Message.Usage.CacheCreation.Ephemeral1hInputTokens
+			}
+			if ev.Message.Usage.CacheReadInputTokens > 0 {
+				merged.CacheReadInputTokens = ev.Message.Usage.CacheReadInputTokens
+			}
+		case "message_delta":
+			if ev.Usage.OutputTokens > 0 {
+				merged.OutputTokens = ev.Usage.OutputTokens
+			}
+		}
+	}
+	// Found if anything we'd bill for landed. A cancelled stream
+	// that delivered only message_start (prompt counted, no output
+	// yet) is intentionally recorded — the user paid for the prompt
+	// regardless of completion, and the cost row keeps OutputTokens
+	// at zero rather than fabricating one.
+	if merged.InputTokens == 0 && merged.OutputTokens == 0 &&
+		merged.CacheReadInputTokens == 0 && merged.CacheCreationInputTokens == 0 &&
+		merged.CacheCreation.Ephemeral5mInputTokens == 0 && merged.CacheCreation.Ephemeral1hInputTokens == 0 {
+		return ExtractUsageResult{}
+	}
+	if model == "" {
+		model = requestModel
+	}
+	return ExtractUsageResult{Found: true, Model: model, Usage: merged.toPricing()}
+}
+
+// openaiUsage accepts both shapes the OpenAI APIs return:
+//   - Chat Completions / legacy: prompt_tokens, completion_tokens,
+//     prompt_tokens_details.cached_tokens
+//   - Responses API (/v1/responses): input_tokens, output_tokens,
+//     input_tokens_details.cached_tokens
+//
+// Only one shape is populated per response; toPricing() picks
+// whichever has non-zero token counts. Without this, Responses-API
+// calls extract as zero and the cost row never lands.
+type openaiUsage struct {
+	// Chat Completions shape.
+	PromptTokens        int `json:"prompt_tokens"`
+	CompletionTokens    int `json:"completion_tokens"`
+	PromptTokensDetails struct {
+		CachedTokens int `json:"cached_tokens"`
+	} `json:"prompt_tokens_details"`
+	// Responses-API shape.
+	InputTokens        int `json:"input_tokens"`
+	OutputTokens       int `json:"output_tokens"`
+	InputTokensDetails struct {
+		CachedTokens int `json:"cached_tokens"`
+	} `json:"input_tokens_details"`
+}
+
+// hasTokens reports whether either shape populated anything billable.
+// Used to distinguish "this response had no usage block" from "this
+// response priced as a no-op."
+func (u openaiUsage) hasTokens() bool {
+	return u.PromptTokens > 0 || u.CompletionTokens > 0 ||
+		u.InputTokens > 0 || u.OutputTokens > 0
+}
+
+func (u openaiUsage) toPricing() pricing.Usage {
+	// Pick the shape that has data. Chat Completions returns
+	// prompt_tokens / completion_tokens; Responses returns
+	// input_tokens / output_tokens with the cached count nested
+	// under input_tokens_details. Both shapes report the total
+	// prompt as the headline number with the cached portion as a
+	// sub-field, so the uncached-input split is identical.
+	prompt := u.PromptTokens
+	completion := u.CompletionTokens
+	cached := u.PromptTokensDetails.CachedTokens
+	if prompt == 0 && completion == 0 {
+		prompt = u.InputTokens
+		completion = u.OutputTokens
+		cached = u.InputTokensDetails.CachedTokens
+	}
+	// The pricing table charges cache_read at a discount and the
+	// remainder at the full input rate, so subtract cached out of
+	// the input bucket to avoid double-billing the cached chunk.
+	uncached := prompt - cached
+	if uncached < 0 {
+		uncached = 0
+	}
+	return pricing.Usage{
+		InputTokens:     uncached,
+		OutputTokens:    completion,
+		CacheReadTokens: cached,
+	}
+}
+
+type openaiJSONEnvelope struct {
+	Model string      `json:"model"`
+	Usage openaiUsage `json:"usage"`
+}
+
+func extractOpenAIJSON(body []byte, requestModel string) ExtractUsageResult {
+	var env openaiJSONEnvelope
+	if err := json.Unmarshal(body, &env); err != nil {
+		return ExtractUsageResult{}
+	}
+	if !env.Usage.hasTokens() {
+		return ExtractUsageResult{}
+	}
+	model := env.Model
+	if model == "" {
+		model = requestModel
+	}
+	return ExtractUsageResult{Found: true, Model: model, Usage: env.Usage.toPricing()}
+}
+
+func extractOpenAISSE(body []byte, requestModel string) ExtractUsageResult {
+	// OpenAI SSE only emits usage when the caller set
+	// `stream_options.include_usage=true` — when present it lands in
+	// a final chunk with `usage:{...}` and an empty choices array.
+	// Walk to the last chunk that carries a non-zero usage field.
+	var last openaiUsage
+	var model string
+	found := false
+	scanner := bufio.NewScanner(bytes.NewReader(body))
+	// Cap the per-line buffer at the body length itself. The body is
+	// already bounded by h.MaxResponseBytes upstream, so this neither
+	// uses more memory than the read already did nor lets a giant
+	// single chunk silently truncate (which would have made usage
+	// extraction return Found=false for the request).
+	scanner.Buffer(make([]byte, 0, 64*1024), len(body)+1)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if !bytes.HasPrefix(line, []byte("data:")) {
+			continue
+		}
+		payload := bytes.TrimSpace(line[len("data:"):])
+		if len(payload) == 0 || bytes.Equal(payload, []byte("[DONE]")) {
+			continue
+		}
+		// Chat Completions SSE puts usage at the top level of each
+		// chunk; Responses SSE nests it under `response`. Try both
+		// shapes per event — whichever populated wins.
+		var ev struct {
+			Model    string       `json:"model"`
+			Usage    *openaiUsage `json:"usage"`
+			Response *struct {
+				Model string       `json:"model"`
+				Usage *openaiUsage `json:"usage"`
+			} `json:"response"`
+		}
+		if err := json.Unmarshal(payload, &ev); err != nil {
+			continue
+		}
+		if ev.Model != "" {
+			model = ev.Model
+		} else if ev.Response != nil && ev.Response.Model != "" {
+			model = ev.Response.Model
+		}
+		usage := ev.Usage
+		if usage == nil && ev.Response != nil {
+			usage = ev.Response.Usage
+		}
+		if usage != nil && usage.hasTokens() {
+			last = *usage
+			found = true
+		}
+	}
+	if !found {
+		return ExtractUsageResult{}
+	}
+	if model == "" {
+		model = requestModel
+	}
+	return ExtractUsageResult{Found: true, Model: model, Usage: last.toPricing()}
+}

--- a/internal/runtime/llmproxy/usage_test.go
+++ b/internal/runtime/llmproxy/usage_test.go
@@ -1,0 +1,209 @@
+package llmproxy
+
+import (
+	"testing"
+
+	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+)
+
+func TestExtractUsage_AnthropicJSON(t *testing.T) {
+	body := []byte(`{
+		"id":"msg_1","type":"message","role":"assistant",
+		"model":"claude-sonnet-4-7",
+		"content":[{"type":"text","text":"hi"}],
+		"usage":{"input_tokens":100,"output_tokens":50,"cache_read_input_tokens":20,"cache_creation_input_tokens":10}
+	}`)
+	got := ExtractUsage(conversation.ProviderAnthropic, "application/json", body, "")
+	if !got.Found {
+		t.Fatal("expected Found=true")
+	}
+	if got.Model != "claude-sonnet-4-7" {
+		t.Errorf("Model = %q, want claude-sonnet-4-7", got.Model)
+	}
+	if got.Usage.InputTokens != 100 || got.Usage.OutputTokens != 50 {
+		t.Errorf("input/output = %d/%d, want 100/50", got.Usage.InputTokens, got.Usage.OutputTokens)
+	}
+	if got.Usage.CacheReadTokens != 20 || got.Usage.CacheWriteTokens != 10 {
+		t.Errorf("cache read/write = %d/%d, want 20/10", got.Usage.CacheReadTokens, got.Usage.CacheWriteTokens)
+	}
+}
+
+func TestExtractUsage_AnthropicJSON_PerTTLCacheCreation(t *testing.T) {
+	body := []byte(`{
+		"id":"msg_2","type":"message","role":"assistant",
+		"model":"claude-opus-4-7",
+		"content":[{"type":"text","text":"hi"}],
+		"usage":{
+			"input_tokens":100,"output_tokens":50,
+			"cache_read_input_tokens":20,
+			"cache_creation_input_tokens":30,
+			"cache_creation":{"ephemeral_5m_input_tokens":20,"ephemeral_1h_input_tokens":10}
+		}
+	}`)
+	got := ExtractUsage(conversation.ProviderAnthropic, "application/json", body, "")
+	if !got.Found {
+		t.Fatal("expected Found=true")
+	}
+	// When the per-TTL breakdown is present it takes precedence
+	// over the legacy scalar.
+	if got.Usage.CacheWriteTokens != 20 {
+		t.Errorf("CacheWriteTokens (5m) = %d, want 20", got.Usage.CacheWriteTokens)
+	}
+	if got.Usage.CacheWrite1hTokens != 10 {
+		t.Errorf("CacheWrite1hTokens = %d, want 10", got.Usage.CacheWrite1hTokens)
+	}
+}
+
+func TestExtractUsage_AnthropicJSON_LegacyCacheCreationFallback(t *testing.T) {
+	// Older responses only carry the scalar — falls into the 5m bucket.
+	body := []byte(`{"model":"claude-opus-4-7","usage":{"input_tokens":1,"output_tokens":1,"cache_creation_input_tokens":42}}`)
+	got := ExtractUsage(conversation.ProviderAnthropic, "application/json", body, "")
+	if got.Usage.CacheWriteTokens != 42 || got.Usage.CacheWrite1hTokens != 0 {
+		t.Errorf("legacy fallback wrong: 5m=%d 1h=%d", got.Usage.CacheWriteTokens, got.Usage.CacheWrite1hTokens)
+	}
+}
+
+func TestExtractUsage_AnthropicSSE(t *testing.T) {
+	body := []byte("" +
+		"event: message_start\n" +
+		`data: {"type":"message_start","message":{"id":"m1","model":"claude-opus-4-7","usage":{"input_tokens":200,"cache_read_input_tokens":50,"cache_creation_input_tokens":25,"output_tokens":1}}}` + "\n\n" +
+		"event: content_block_start\n" +
+		`data: {"type":"content_block_start","index":0}` + "\n\n" +
+		"event: message_delta\n" +
+		`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":150}}` + "\n\n" +
+		"event: message_stop\n" +
+		`data: {"type":"message_stop"}` + "\n\n",
+	)
+	got := ExtractUsage(conversation.ProviderAnthropic, "text/event-stream", body, "claude-opus-4-7")
+	if !got.Found {
+		t.Fatal("expected Found=true")
+	}
+	if got.Model != "claude-opus-4-7" {
+		t.Errorf("Model = %q, want claude-opus-4-7", got.Model)
+	}
+	if got.Usage.InputTokens != 200 || got.Usage.OutputTokens != 150 {
+		t.Errorf("input/output = %d/%d, want 200/150", got.Usage.InputTokens, got.Usage.OutputTokens)
+	}
+	if got.Usage.CacheReadTokens != 50 || got.Usage.CacheWriteTokens != 25 {
+		t.Errorf("cache read/write = %d/%d, want 50/25", got.Usage.CacheReadTokens, got.Usage.CacheWriteTokens)
+	}
+}
+
+func TestExtractUsage_OpenAIJSON(t *testing.T) {
+	body := []byte(`{
+		"id":"chatcmpl-1","model":"gpt-4o",
+		"choices":[{"message":{"role":"assistant","content":"hi"}}],
+		"usage":{"prompt_tokens":300,"completion_tokens":80,"prompt_tokens_details":{"cached_tokens":120}}
+	}`)
+	got := ExtractUsage(conversation.ProviderOpenAI, "application/json", body, "")
+	if !got.Found {
+		t.Fatal("expected Found=true")
+	}
+	// prompt_tokens includes cached; we split: 300 - 120 = 180 uncached input.
+	if got.Usage.InputTokens != 180 {
+		t.Errorf("InputTokens = %d, want 180 (300 - 120 cached)", got.Usage.InputTokens)
+	}
+	if got.Usage.CacheReadTokens != 120 {
+		t.Errorf("CacheReadTokens = %d, want 120", got.Usage.CacheReadTokens)
+	}
+	if got.Usage.OutputTokens != 80 {
+		t.Errorf("OutputTokens = %d, want 80", got.Usage.OutputTokens)
+	}
+}
+
+func TestExtractUsage_DetectsSSEFromBodyWhenContentTypeMissing(t *testing.T) {
+	// Regression: Codex traffic was arriving with the Content-Type
+	// header empty by the time our extractor saw it, so the SSE
+	// branch never fired and Found stayed false despite usage being
+	// present in the body. We now detect SSE from the body shape.
+	body := []byte("" +
+		`event: response.completed` + "\n" +
+		`data: {"type":"response.completed","response":{"id":"r1","model":"gpt-5.5","usage":{"input_tokens":300,"output_tokens":40}}}` + "\n\n",
+	)
+	got := ExtractUsage(conversation.ProviderOpenAI, "", body, "gpt-5.5")
+	if !got.Found {
+		t.Fatal("empty content-type with SSE body should still extract")
+	}
+	if got.Usage.OutputTokens != 40 || got.Usage.InputTokens != 300 {
+		t.Errorf("in=%d out=%d, want 300/40", got.Usage.InputTokens, got.Usage.OutputTokens)
+	}
+	// Negative case: a JSON body must still go through the JSON
+	// branch — bodyLooksLikeSSE only flips true for actual SSE
+	// preludes, not for a `{` opener.
+	jsonBody := []byte(`{"model":"gpt-5.5","usage":{"input_tokens":50,"output_tokens":10}}`)
+	got = ExtractUsage(conversation.ProviderOpenAI, "", jsonBody, "")
+	if !got.Found {
+		t.Fatal("empty content-type with JSON body should still extract via JSON path")
+	}
+}
+
+func TestExtractUsage_OpenAIResponsesJSON(t *testing.T) {
+	// Responses API uses input_tokens / output_tokens, not the Chat
+	// Completions fields. Before the fix this returned Found=false.
+	body := []byte(`{
+		"id":"resp_1","model":"gpt-4o",
+		"output":[{"type":"message","content":[{"type":"output_text","text":"hi"}]}],
+		"usage":{"input_tokens":300,"output_tokens":80,"input_tokens_details":{"cached_tokens":120}}
+	}`)
+	got := ExtractUsage(conversation.ProviderOpenAI, "application/json", body, "")
+	if !got.Found {
+		t.Fatal("expected Found=true for Responses-API shape")
+	}
+	if got.Usage.InputTokens != 180 {
+		t.Errorf("InputTokens = %d, want 180 (300 - 120 cached)", got.Usage.InputTokens)
+	}
+	if got.Usage.OutputTokens != 80 {
+		t.Errorf("OutputTokens = %d, want 80", got.Usage.OutputTokens)
+	}
+	if got.Usage.CacheReadTokens != 120 {
+		t.Errorf("CacheReadTokens = %d, want 120", got.Usage.CacheReadTokens)
+	}
+}
+
+func TestExtractUsage_OpenAIResponsesSSE(t *testing.T) {
+	body := []byte("" +
+		`data: {"type":"response.in_progress","response":{"id":"r1","model":"gpt-4o"}}` + "\n\n" +
+		`data: {"type":"response.completed","response":{"id":"r1","model":"gpt-4o","usage":{"input_tokens":50,"output_tokens":10}}}` + "\n\n",
+	)
+	got := ExtractUsage(conversation.ProviderOpenAI, "text/event-stream", body, "gpt-4o")
+	if !got.Found {
+		t.Fatal("expected Found=true for Responses-API SSE")
+	}
+	if got.Usage.InputTokens != 50 || got.Usage.OutputTokens != 10 {
+		t.Errorf("got input/output %d/%d, want 50/10", got.Usage.InputTokens, got.Usage.OutputTokens)
+	}
+}
+
+func TestExtractUsage_OpenAISSE_NoUsage(t *testing.T) {
+	// OpenAI SSE without include_usage=true never emits usage.
+	body := []byte("" +
+		`data: {"id":"c1","model":"gpt-4o","choices":[{"delta":{"content":"hi"}}]}` + "\n\n" +
+		`data: [DONE]` + "\n\n",
+	)
+	got := ExtractUsage(conversation.ProviderOpenAI, "text/event-stream", body, "gpt-4o")
+	if got.Found {
+		t.Errorf("expected Found=false when no usage in stream")
+	}
+}
+
+func TestExtractUsage_OpenAISSE_WithUsage(t *testing.T) {
+	body := []byte("" +
+		`data: {"id":"c1","model":"gpt-4o","choices":[{"delta":{"content":"hi"}}]}` + "\n\n" +
+		`data: {"id":"c1","model":"gpt-4o","choices":[],"usage":{"prompt_tokens":50,"completion_tokens":10}}` + "\n\n" +
+		`data: [DONE]` + "\n\n",
+	)
+	got := ExtractUsage(conversation.ProviderOpenAI, "text/event-stream", body, "gpt-4o")
+	if !got.Found {
+		t.Fatal("expected Found=true")
+	}
+	if got.Usage.InputTokens != 50 || got.Usage.OutputTokens != 10 {
+		t.Errorf("got input/output %d/%d, want 50/10", got.Usage.InputTokens, got.Usage.OutputTokens)
+	}
+}
+
+func TestExtractUsage_EmptyBody(t *testing.T) {
+	got := ExtractUsage(conversation.ProviderAnthropic, "application/json", nil, "claude-opus-4-7")
+	if got.Found {
+		t.Errorf("empty body should report Found=false")
+	}
+}

--- a/internal/runtime/llmproxy/usage_test.go
+++ b/internal/runtime/llmproxy/usage_test.go
@@ -111,6 +111,27 @@ func TestExtractUsage_OpenAIJSON(t *testing.T) {
 	}
 }
 
+func TestExtractUsage_DetectsSSEFromCommentLine(t *testing.T) {
+	// SSE intermediaries (CDN proxies, etc.) often send `:` comment
+	// lines as a keep-alive heartbeat before the first event. The
+	// body sniff has to recognize that as SSE — otherwise a stream
+	// that opens with `: ping\n\n` would fall through to the JSON
+	// parser and silently drop the usage row when Content-Type was
+	// also absent.
+	body := []byte("" +
+		`: keep-alive heartbeat` + "\n\n" +
+		`event: response.completed` + "\n" +
+		`data: {"type":"response.completed","response":{"id":"r1","model":"gpt-5.5","usage":{"input_tokens":42,"output_tokens":7}}}` + "\n\n",
+	)
+	got := ExtractUsage(conversation.ProviderOpenAI, "", body, "gpt-5.5")
+	if !got.Found {
+		t.Fatal("body opening with `:` comment must still be detected as SSE")
+	}
+	if got.Usage.InputTokens != 42 || got.Usage.OutputTokens != 7 {
+		t.Errorf("got in/out %d/%d, want 42/7", got.Usage.InputTokens, got.Usage.OutputTokens)
+	}
+}
+
 func TestExtractUsage_DetectsSSEFromBodyWhenContentTypeMissing(t *testing.T) {
 	// Regression: Codex traffic was arriving with the Content-Type
 	// header empty by the time our extractor saw it, so the SSE

--- a/pkg/store/postgres/migrations/052_llm_request_cost.sql
+++ b/pkg/store/postgres/migrations/052_llm_request_cost.sql
@@ -1,0 +1,31 @@
+-- Per-LLM-request cost and token usage. One row per upstream LLM
+-- call. See the SQLite copy of this migration for the rationale
+-- (separate table to avoid mostly-NULL columns on audit_log;
+-- task_id denormalised for fast SUM rollups; cost_micros nullable
+-- for unknown-model rows so aggregates surface them).
+CREATE TABLE IF NOT EXISTS llm_request_cost (
+  audit_id            TEXT PRIMARY KEY,
+  user_id             TEXT NOT NULL,
+  agent_id            TEXT,
+  task_id             TEXT,
+  request_id          TEXT NOT NULL,
+  timestamp           TIMESTAMPTZ NOT NULL,
+  provider            TEXT NOT NULL,
+  model               TEXT NOT NULL,
+  input_tokens        INTEGER NOT NULL DEFAULT 0,
+  output_tokens       INTEGER NOT NULL DEFAULT 0,
+  cache_read_tokens   INTEGER NOT NULL DEFAULT 0,
+  cache_write_tokens  INTEGER NOT NULL DEFAULT 0,
+  cost_micros         BIGINT
+);
+
+-- Primary read path: GetTaskCost filters on (user_id, task_id).
+-- A user_id-leading composite lets the planner do an index-only
+-- seek without a heap filter on user_id, which matters once a
+-- single task accumulates many cost rows.
+CREATE INDEX IF NOT EXISTS idx_llm_cost_user_task
+  ON llm_request_cost(user_id, task_id)
+  WHERE task_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_llm_cost_user_time
+  ON llm_request_cost(user_id, timestamp);

--- a/pkg/store/postgres/migrations/052_llm_request_cost.sql
+++ b/pkg/store/postgres/migrations/052_llm_request_cost.sql
@@ -3,8 +3,14 @@
 -- (separate table to avoid mostly-NULL columns on audit_log;
 -- task_id denormalised for fast SUM rollups; cost_micros nullable
 -- for unknown-model rows so aggregates surface them).
+--
+-- audit_id FKs into audit_log(id) ON DELETE CASCADE so cost rows
+-- can't become orphaned. The dedup-conflict path in LogEndpointCall
+-- resolves the surviving canonical audit row's id via
+-- FindDedupCandidate before inserting the cost row, so the FK
+-- doesn't fire on the legitimate retry case.
 CREATE TABLE IF NOT EXISTS llm_request_cost (
-  audit_id            TEXT PRIMARY KEY,
+  audit_id            TEXT PRIMARY KEY REFERENCES audit_log(id) ON DELETE CASCADE,
   user_id             TEXT NOT NULL,
   agent_id            TEXT,
   task_id             TEXT,

--- a/pkg/store/postgres/migrations/052_llm_request_cost.sql
+++ b/pkg/store/postgres/migrations/052_llm_request_cost.sql
@@ -9,6 +9,13 @@
 -- resolves the surviving canonical audit row's id via
 -- FindDedupCandidate before inserting the cost row, so the FK
 -- doesn't fire on the legitimate retry case.
+--
+-- Note: user_id / agent_id / task_id are NOT FKs into their parent
+-- tables. Cleanup on parent-row deletion is indirect via the
+-- audit_log CASCADE chain (audit retention sweep removes audit rows;
+-- this CASCADE takes the cost rows with them). Task soft-delete
+-- (status='revoked') deliberately preserves the cost history so
+-- the dashboard's per-task spend view keeps working post-revocation.
 CREATE TABLE IF NOT EXISTS llm_request_cost (
   audit_id            TEXT PRIMARY KEY REFERENCES audit_log(id) ON DELETE CASCADE,
   user_id             TEXT NOT NULL,

--- a/pkg/store/postgres/store.go
+++ b/pkg/store/postgres/store.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/google/uuid"
@@ -769,6 +770,82 @@ func (s *Store) LogAudit(ctx context.Context, e *store.AuditEntry) error {
 		return store.ErrConflict
 	}
 	return err
+}
+
+// RecordLLMRequestCost inserts one llm_request_cost row. See the
+// sqlite copy for the contract.
+func (s *Store) RecordLLMRequestCost(ctx context.Context, c *store.LLMRequestCost) error {
+	if c == nil || c.AuditID == "" {
+		return errors.New("RecordLLMRequestCost: audit_id required")
+	}
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO llm_request_cost (
+			audit_id, user_id, agent_id, task_id, request_id, timestamp,
+			provider, model, input_tokens, output_tokens, cache_read_tokens,
+			cache_write_tokens, cost_micros
+		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)
+	`, c.AuditID, c.UserID, c.AgentID, c.TaskID, c.RequestID, c.Timestamp,
+		c.Provider, c.Model, c.InputTokens, c.OutputTokens,
+		c.CacheReadTokens, c.CacheWriteTokens, c.CostMicros)
+	if err != nil && isDuplicate(err) {
+		return store.ErrConflict
+	}
+	return err
+}
+
+// GetTaskCost rolls up llm_request_cost rows for one task. See the
+// sqlite copy for the contract.
+func (s *Store) GetTaskCost(ctx context.Context, userID, taskID string) (*store.TaskCostSummary, error) {
+	out := &store.TaskCostSummary{TaskID: taskID, ByModel: []store.TaskCostByModelEntry{}}
+	// Postgres' SUM(bigint) widens to NUMERIC; pgx can't scan that
+	// into int64. Cast each SUM back to bigint so the column type
+	// matches the destination. Token columns are INTEGER → SUM is
+	// BIGINT natively, so a cast there is harmless but explicit.
+	rows, err := s.pool.Query(ctx, `
+		SELECT model,
+		       COUNT(*) AS n,
+		       COALESCE(SUM(input_tokens), 0)::bigint,
+		       COALESCE(SUM(output_tokens), 0)::bigint,
+		       COALESCE(SUM(cache_read_tokens), 0)::bigint,
+		       COALESCE(SUM(cache_write_tokens), 0)::bigint,
+		       COALESCE(SUM(cost_micros), 0)::bigint,
+		       SUM(CASE WHEN cost_micros IS NULL THEN 1 ELSE 0 END)::bigint AS unknown_rows
+		FROM llm_request_cost
+		WHERE user_id = $1 AND task_id = $2
+		GROUP BY model
+		ORDER BY model`, userID, taskID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	unknownModels := map[string]struct{}{}
+	for rows.Next() {
+		var e store.TaskCostByModelEntry
+		var unknownRows int64
+		if err := rows.Scan(&e.Model, &e.RequestCount, &e.InputTokens, &e.OutputTokens,
+			&e.CacheReadTokens, &e.CacheWriteTokens, &e.CostMicros, &unknownRows); err != nil {
+			return nil, err
+		}
+		e.Known = unknownRows == 0
+		if !e.Known {
+			unknownModels[e.Model] = struct{}{}
+		}
+		out.ByModel = append(out.ByModel, e)
+		out.RequestCount += e.RequestCount
+		out.InputTokens += e.InputTokens
+		out.OutputTokens += e.OutputTokens
+		out.CacheReadTokens += e.CacheReadTokens
+		out.CacheWriteTokens += e.CacheWriteTokens
+		out.CostMicros += e.CostMicros
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	for m := range unknownModels {
+		out.UnknownModels = append(out.UnknownModels, m)
+	}
+	sort.Strings(out.UnknownModels)
+	return out, nil
 }
 
 func (s *Store) UpdateAuditOutcome(ctx context.Context, id, outcome, errMsg string, durationMS int) error {

--- a/pkg/store/postgres/store.go
+++ b/pkg/store/postgres/store.go
@@ -805,6 +805,13 @@ func (s *Store) GetTaskCost(ctx context.Context, userID, taskID string) (*store.
 	// into int64. Cast each SUM back to bigint so the column type
 	// matches the destination. Token columns are INTEGER → SUM is
 	// BIGINT natively, so a cast there is harmless but explicit.
+	//
+	// `AND task_id IS NOT NULL` is redundant for a non-empty taskID
+	// at runtime but makes the partial index idx_llm_cost_user_task
+	// (WHERE task_id IS NOT NULL) reliably eligible at plan time —
+	// without it, Postgres has to prove the predicate from the
+	// equality, which it does for literals but not always for bound
+	// parameters.
 	rows, err := s.pool.Query(ctx, `
 		SELECT model,
 		       COUNT(*) AS n,
@@ -815,7 +822,7 @@ func (s *Store) GetTaskCost(ctx context.Context, userID, taskID string) (*store.
 		       COALESCE(SUM(cost_micros), 0)::bigint,
 		       SUM(CASE WHEN cost_micros IS NULL THEN 1 ELSE 0 END)::bigint AS unknown_rows
 		FROM llm_request_cost
-		WHERE user_id = $1 AND task_id = $2
+		WHERE user_id = $1 AND task_id = $2 AND task_id IS NOT NULL
 		GROUP BY model
 		ORDER BY model`, userID, taskID)
 	if err != nil {

--- a/pkg/store/postgres/store.go
+++ b/pkg/store/postgres/store.go
@@ -796,7 +796,11 @@ func (s *Store) RecordLLMRequestCost(ctx context.Context, c *store.LLMRequestCos
 // GetTaskCost rolls up llm_request_cost rows for one task. See the
 // sqlite copy for the contract.
 func (s *Store) GetTaskCost(ctx context.Context, userID, taskID string) (*store.TaskCostSummary, error) {
-	out := &store.TaskCostSummary{TaskID: taskID, ByModel: []store.TaskCostByModelEntry{}}
+	out := &store.TaskCostSummary{
+		TaskID:        taskID,
+		ByModel:       []store.TaskCostByModelEntry{},
+		UnknownModels: []string{},
+	}
 	// Postgres' SUM(bigint) widens to NUMERIC; pgx can't scan that
 	// into int64. Cast each SUM back to bigint so the column type
 	// matches the destination. Token columns are INTEGER → SUM is

--- a/pkg/store/sqlite/migrations/052_llm_request_cost.sql
+++ b/pkg/store/sqlite/migrations/052_llm_request_cost.sql
@@ -20,6 +20,15 @@
 -- canonical audit row's id before insert specifically to honor this).
 -- The SQLite store enables this with PRAGMA foreign_keys = ON in
 -- sqlite.New (migration 001 also sets it for new DBs).
+--
+-- Note: user_id / agent_id / task_id are NOT FKs into their parent
+-- tables. Cleanup of orphan cost rows when a task or agent is hard-
+-- deleted relies on the audit_log CASCADE chain — any audit row
+-- tied to the deleted parent will be removed by the audit_log
+-- retention sweep, and CASCADE on audit_id takes the cost row with
+-- it. Don't add direct FKs here without considering the read path:
+-- task soft-deletion (status='revoked') intentionally keeps the
+-- spend history visible on the dashboard.
 CREATE TABLE IF NOT EXISTS llm_request_cost (
   audit_id            TEXT PRIMARY KEY REFERENCES audit_log(id) ON DELETE CASCADE,
   user_id             TEXT NOT NULL,

--- a/pkg/store/sqlite/migrations/052_llm_request_cost.sql
+++ b/pkg/store/sqlite/migrations/052_llm_request_cost.sql
@@ -12,8 +12,16 @@
 -- aggregates can surface "unknown-model spend" rather than silently
 -- under-bill. Tokens are recorded regardless so cost is re-derivable
 -- if a pricing-table bug slips through.
+--
+-- audit_id FKs into audit_log(id) ON DELETE CASCADE so cost rows can't
+-- become orphaned (e.g. when an audit row is GC'd later, or when a
+-- code path tries to insert a cost row whose audit_id never landed —
+-- the dedup-conflict path in LogEndpointCall resolves the surviving
+-- canonical audit row's id before insert specifically to honor this).
+-- The SQLite store enables this with PRAGMA foreign_keys = ON in
+-- sqlite.New (migration 001 also sets it for new DBs).
 CREATE TABLE IF NOT EXISTS llm_request_cost (
-  audit_id            TEXT PRIMARY KEY,
+  audit_id            TEXT PRIMARY KEY REFERENCES audit_log(id) ON DELETE CASCADE,
   user_id             TEXT NOT NULL,
   agent_id            TEXT,
   task_id             TEXT,

--- a/pkg/store/sqlite/migrations/052_llm_request_cost.sql
+++ b/pkg/store/sqlite/migrations/052_llm_request_cost.sql
@@ -1,0 +1,41 @@
+-- Per-LLM-request cost and token usage. One row per upstream LLM
+-- call. Lives in its own table (not on audit_log) because the vast
+-- majority of audit rows are tool_use / approval / resolver swaps
+-- with no usage to record — widening audit_log would be mostly NULLs.
+--
+-- TaskID is denormalised onto the row (rather than joining via
+-- audit_id → audit_log.task_id) so the primary read pattern —
+-- SUM(cost_micros) WHERE task_id = ? — is a single-table index seek.
+--
+-- cost_micros is int64 micro-USD (1e-6 USD per unit) to avoid float
+-- drift on SUM(); NULL when the model isn't in the pricing table so
+-- aggregates can surface "unknown-model spend" rather than silently
+-- under-bill. Tokens are recorded regardless so cost is re-derivable
+-- if a pricing-table bug slips through.
+CREATE TABLE IF NOT EXISTS llm_request_cost (
+  audit_id            TEXT PRIMARY KEY,
+  user_id             TEXT NOT NULL,
+  agent_id            TEXT,
+  task_id             TEXT,
+  request_id          TEXT NOT NULL,
+  timestamp           DATETIME NOT NULL,
+  provider            TEXT NOT NULL,
+  model               TEXT NOT NULL,
+  input_tokens        INTEGER NOT NULL DEFAULT 0,
+  output_tokens       INTEGER NOT NULL DEFAULT 0,
+  cache_read_tokens   INTEGER NOT NULL DEFAULT 0,
+  cache_write_tokens  INTEGER NOT NULL DEFAULT 0,
+  cost_micros         INTEGER
+);
+
+-- Primary aggregation path: per-task cost rollups. The composite
+-- (user_id, task_id) matches GetTaskCost's WHERE clause exactly so
+-- the planner can do an index-only seek without filtering on
+-- user_id in the heap.
+CREATE INDEX IF NOT EXISTS idx_llm_cost_user_task
+  ON llm_request_cost(user_id, task_id)
+  WHERE task_id IS NOT NULL;
+
+-- Secondary aggregation path: per-user time-range billing.
+CREATE INDEX IF NOT EXISTS idx_llm_cost_user_time
+  ON llm_request_cost(user_id, timestamp);

--- a/pkg/store/sqlite/store.go
+++ b/pkg/store/sqlite/store.go
@@ -958,6 +958,10 @@ func (s *Store) GetTaskCost(ctx context.Context, userID, taskID string) (*store.
 		ByModel:       []store.TaskCostByModelEntry{},
 		UnknownModels: []string{},
 	}
+	// `AND task_id IS NOT NULL` is redundant for a non-empty taskID
+	// but lets SQLite's planner reliably pick the partial index
+	// idx_llm_cost_user_task (WHERE task_id IS NOT NULL) without
+	// having to prove non-nullity from the equality predicate.
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT model,
 		       COUNT(*) AS n,
@@ -968,7 +972,7 @@ func (s *Store) GetTaskCost(ctx context.Context, userID, taskID string) (*store.
 		       COALESCE(SUM(cost_micros), 0),
 		       SUM(CASE WHEN cost_micros IS NULL THEN 1 ELSE 0 END) AS unknown_rows
 		FROM llm_request_cost
-		WHERE user_id = ? AND task_id = ?
+		WHERE user_id = ? AND task_id = ? AND task_id IS NOT NULL
 		GROUP BY model
 		ORDER BY model`, userID, taskID)
 	if err != nil {

--- a/pkg/store/sqlite/store.go
+++ b/pkg/store/sqlite/store.go
@@ -953,7 +953,11 @@ func (s *Store) RecordLLMRequestCost(ctx context.Context, c *store.LLMRequestCos
 // empty TaskCostSummary (not ErrNotFound) when the task has no cost
 // rows yet — the caller can still render "no LLM spend recorded".
 func (s *Store) GetTaskCost(ctx context.Context, userID, taskID string) (*store.TaskCostSummary, error) {
-	out := &store.TaskCostSummary{TaskID: taskID, ByModel: []store.TaskCostByModelEntry{}}
+	out := &store.TaskCostSummary{
+		TaskID:        taskID,
+		ByModel:       []store.TaskCostByModelEntry{},
+		UnknownModels: []string{},
+	}
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT model,
 		       COUNT(*) AS n,

--- a/pkg/store/sqlite/store.go
+++ b/pkg/store/sqlite/store.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -922,6 +923,86 @@ func (s *Store) LogAudit(ctx context.Context, e *store.AuditEntry) error {
 		return store.ErrConflict
 	}
 	return err
+}
+
+// RecordLLMRequestCost inserts one llm_request_cost row. AuditID is
+// the FK back to the audit_log row that captured this request; the
+// primary-key conflict path is harmless on retries because the audit
+// row is also written exactly-once per request.
+func (s *Store) RecordLLMRequestCost(ctx context.Context, c *store.LLMRequestCost) error {
+	if c == nil || c.AuditID == "" {
+		return errors.New("RecordLLMRequestCost: audit_id required")
+	}
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO llm_request_cost (
+			audit_id, user_id, agent_id, task_id, request_id, timestamp,
+			provider, model, input_tokens, output_tokens, cache_read_tokens,
+			cache_write_tokens, cost_micros
+		) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)
+	`, c.AuditID, c.UserID, c.AgentID, c.TaskID, c.RequestID,
+		c.Timestamp.UTC().Format(time.RFC3339Nano),
+		c.Provider, c.Model, c.InputTokens, c.OutputTokens,
+		c.CacheReadTokens, c.CacheWriteTokens, c.CostMicros)
+	if err != nil && isDuplicate(err) {
+		return store.ErrConflict
+	}
+	return err
+}
+
+// GetTaskCost rolls up llm_request_cost rows for one task. Returns an
+// empty TaskCostSummary (not ErrNotFound) when the task has no cost
+// rows yet — the caller can still render "no LLM spend recorded".
+func (s *Store) GetTaskCost(ctx context.Context, userID, taskID string) (*store.TaskCostSummary, error) {
+	out := &store.TaskCostSummary{TaskID: taskID, ByModel: []store.TaskCostByModelEntry{}}
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT model,
+		       COUNT(*) AS n,
+		       COALESCE(SUM(input_tokens), 0),
+		       COALESCE(SUM(output_tokens), 0),
+		       COALESCE(SUM(cache_read_tokens), 0),
+		       COALESCE(SUM(cache_write_tokens), 0),
+		       COALESCE(SUM(cost_micros), 0),
+		       SUM(CASE WHEN cost_micros IS NULL THEN 1 ELSE 0 END) AS unknown_rows
+		FROM llm_request_cost
+		WHERE user_id = ? AND task_id = ?
+		GROUP BY model
+		ORDER BY model`, userID, taskID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	unknownModels := map[string]struct{}{}
+	for rows.Next() {
+		var e store.TaskCostByModelEntry
+		var unknownRows int64
+		if err := rows.Scan(&e.Model, &e.RequestCount, &e.InputTokens, &e.OutputTokens,
+			&e.CacheReadTokens, &e.CacheWriteTokens, &e.CostMicros, &unknownRows); err != nil {
+			return nil, err
+		}
+		// A model is "known" when every row for it priced successfully.
+		// Mixed (some priced, some not) — common when the pricing table
+		// is updated mid-task — surfaces in UnknownModels so the UI can
+		// flag that the total is a lower bound.
+		e.Known = unknownRows == 0
+		if !e.Known {
+			unknownModels[e.Model] = struct{}{}
+		}
+		out.ByModel = append(out.ByModel, e)
+		out.RequestCount += e.RequestCount
+		out.InputTokens += e.InputTokens
+		out.OutputTokens += e.OutputTokens
+		out.CacheReadTokens += e.CacheReadTokens
+		out.CacheWriteTokens += e.CacheWriteTokens
+		out.CostMicros += e.CostMicros
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	for m := range unknownModels {
+		out.UnknownModels = append(out.UnknownModels, m)
+	}
+	sort.Strings(out.UnknownModels)
+	return out, nil
 }
 
 func (s *Store) UpdateAuditOutcome(ctx context.Context, id, outcome, errMsg string, durationMS int) error {

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -150,6 +150,13 @@ type Store interface {
 	FindDedupCandidate(ctx context.Context, requestID, userID, taskID string) (*AuditEntry, error)
 	ListAuditEntries(ctx context.Context, userID string, filter AuditFilter) ([]*AuditEntry, int, error)
 	AuditActivityBuckets(ctx context.Context, userID string, since time.Time, bucketMinutes int) ([]ActivityBucket, error)
+
+	// LLM request cost tracking. RecordLLMRequestCost stores one row per
+	// upstream LLM call so per-task / per-user spend can be aggregated
+	// without scanning audit_log. GetTaskCost rolls up by model for one
+	// task.
+	RecordLLMRequestCost(ctx context.Context, cost *LLMRequestCost) error
+	GetTaskCost(ctx context.Context, userID, taskID string) (*TaskCostSummary, error)
 	CreateActivityMute(ctx context.Context, mute *ActivityMute) error
 	ListActivityMutes(ctx context.Context, userID string) ([]*ActivityMute, error)
 	DeleteActivityMute(ctx context.Context, id, userID string) error
@@ -642,6 +649,65 @@ type AuditEntry struct {
 	// DedupedOf is set on retry-attempt rows to the id of the canonical
 	// audit entry they shadow. Canonical rows have DedupedOf == nil.
 	DedupedOf *string `json:"deduped_of,omitempty"`
+}
+
+// LLMRequestCost is one row per upstream LLM call recording the model,
+// token breakdown, and computed cost. Lives in its own table (not on
+// audit_log) so the majority of audit rows — tool_use, approvals,
+// resolver swaps — don't carry mostly-NULL usage columns. AuditID is
+// the FK back to the audit_log row that captured the request.
+//
+// CostMicros is int64 micro-USD (1e-6 USD per unit). Nil when the
+// model isn't in the pricing table — token counts are still recorded
+// so aggregates can surface "unknown-model spend" and cost is
+// re-derivable when the table updates.
+//
+// Caller contract: UserID must equal the owning agent's UserID (the
+// per-user cost rollup query in GetTaskCost filters by this column,
+// so a mismatch would silently miscount). Today the only producer is
+// the lite-proxy audit emitter, which derives UserID from
+// agent.UserID; any future caller should preserve that invariant.
+type LLMRequestCost struct {
+	AuditID          string    `json:"audit_id"`
+	UserID           string    `json:"user_id"`
+	AgentID          *string   `json:"agent_id,omitempty"`
+	TaskID           *string   `json:"task_id,omitempty"`
+	RequestID        string    `json:"request_id"`
+	Timestamp        time.Time `json:"timestamp"`
+	Provider         string    `json:"provider"`
+	Model            string    `json:"model"`
+	InputTokens      int       `json:"input_tokens"`
+	OutputTokens     int       `json:"output_tokens"`
+	CacheReadTokens  int       `json:"cache_read_tokens"`
+	CacheWriteTokens int       `json:"cache_write_tokens"`
+	CostMicros       *int64    `json:"cost_micros,omitempty"`
+}
+
+// TaskCostSummary is the rollup of all LLMRequestCost rows for a
+// single task. ByModel breaks the totals down per model so the UI
+// can show "X spent on Opus, Y on Sonnet" without re-querying.
+type TaskCostSummary struct {
+	TaskID           string                  `json:"task_id"`
+	RequestCount     int                     `json:"request_count"`
+	InputTokens      int64                   `json:"input_tokens"`
+	OutputTokens     int64                   `json:"output_tokens"`
+	CacheReadTokens  int64                   `json:"cache_read_tokens"`
+	CacheWriteTokens int64                   `json:"cache_write_tokens"`
+	CostMicros       int64                   `json:"cost_micros"`
+	UnknownModels    []string                `json:"unknown_models,omitempty"`
+	ByModel          []TaskCostByModelEntry  `json:"by_model"`
+}
+
+// TaskCostByModelEntry is one model's contribution to a task's cost.
+type TaskCostByModelEntry struct {
+	Model            string `json:"model"`
+	RequestCount     int    `json:"request_count"`
+	InputTokens      int64  `json:"input_tokens"`
+	OutputTokens     int64  `json:"output_tokens"`
+	CacheReadTokens  int64  `json:"cache_read_tokens"`
+	CacheWriteTokens int64  `json:"cache_write_tokens"`
+	CostMicros       int64  `json:"cost_micros"`
+	Known            bool   `json:"known"`
 }
 
 // ActivityMute suppresses noisy runtime egress rows from the activity feed.

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -694,8 +694,11 @@ type TaskCostSummary struct {
 	CacheReadTokens  int64                   `json:"cache_read_tokens"`
 	CacheWriteTokens int64                   `json:"cache_write_tokens"`
 	CostMicros       int64                   `json:"cost_micros"`
-	UnknownModels    []string                `json:"unknown_models,omitempty"`
-	ByModel          []TaskCostByModelEntry  `json:"by_model"`
+	// UnknownModels and ByModel both serialize as `[]` when empty so
+	// consumers (TS client) get a consistent shape across all
+	// summaries and don't have to branch on undefined-vs-empty-array.
+	UnknownModels []string               `json:"unknown_models"`
+	ByModel       []TaskCostByModelEntry `json:"by_model"`
 }
 
 // TaskCostByModelEntry is one model's contribution to a task's cost.

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1628,7 +1628,31 @@ export const api = {
       post<{ task_id: string; status: string }>(`/api/tasks/${id}/expand/deny`, {}),
     revoke: (id: string) =>
       post<{ task_id: string; status: string }>(`/api/tasks/${id}/revoke`, {}),
+    cost: (id: string) => get<TaskCostSummary>(`/api/tasks/${id}/cost`),
   },
+}
+
+export interface TaskCostByModelEntry {
+  model: string
+  request_count: number
+  input_tokens: number
+  output_tokens: number
+  cache_read_tokens: number
+  cache_write_tokens: number
+  cost_micros: number
+  known: boolean
+}
+
+export interface TaskCostSummary {
+  task_id: string
+  request_count: number
+  input_tokens: number
+  output_tokens: number
+  cache_read_tokens: number
+  cache_write_tokens: number
+  cost_micros: number
+  unknown_models?: string[]
+  by_model: TaskCostByModelEntry[]
 }
 
 export { get, post, put, patch, del }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1651,7 +1651,7 @@ export interface TaskCostSummary {
   cache_read_tokens: number
   cache_write_tokens: number
   cost_micros: number
-  unknown_models?: string[]
+  unknown_models: string[]
   by_model: TaskCostByModelEntry[]
 }
 

--- a/web/src/components/TaskCard.tsx
+++ b/web/src/components/TaskCard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { api, type Task, type TaskAction, type AuditEntry, type RiskAssessment, type ApprovalRationale, type ScopeOverride, type PlannedCall, type ExpectedTool, type ExpectedEgress } from '../api/client'
+import { api, type Task, type TaskAction, type AuditEntry, type RiskAssessment, type ApprovalRationale, type ScopeOverride, type PlannedCall, type ExpectedTool, type ExpectedEgress, type TaskCostSummary } from '../api/client'
 import { format } from 'date-fns'
 import { serviceName, actionName } from '../lib/services'
 import { isLocalHost } from '../lib/env'
@@ -69,7 +69,7 @@ export default function TaskCard({
   const qc = useQueryClient()
   const [result, setResult] = useState<string | null>(null)
   const [expanded, setExpanded] = useState(false)
-  const [activeTab, setActiveTab] = useState<'activity' | 'scopes'>(
+  const [activeTab, setActiveTab] = useState<'activity' | 'scopes' | 'cost'>(
     task.request_count === 0 ? 'scopes' : 'activity'
   )
   const [scopesOpenInExpansion, setScopesOpenInExpansion] = useState(false)
@@ -121,6 +121,11 @@ export default function TaskCard({
   const isStanding = task.lifetime === 'standing'
   const isActionable = needsApproval || needsExpansion
   const activityVisible = !isActionable && expanded && activeTab === 'activity'
+  // Fetch cost as soon as the card is expanded (not gated on tab click)
+  // so we can decide whether to render the Cost tab at all — non-llm-proxy
+  // tasks return request_count=0 and the tab stays hidden. The query is
+  // cheap when there are no rows.
+  const costPrefetchEnabled = !isActionable && expanded
 
   const { data: auditData, isLoading: auditLoading } = useQuery({
     queryKey: ['audit', { task_id: task.id }],
@@ -129,6 +134,17 @@ export default function TaskCard({
     refetchInterval: (query) =>
       activityVisible && task.request_count !== (query.state.data?.entries?.length ?? 0) ? 1_000 : false,
   })
+
+  const { data: costData, isLoading: costLoading } = useQuery({
+    queryKey: ['task-cost', task.id],
+    queryFn: () => api.tasks.cost(task.id),
+    enabled: costPrefetchEnabled,
+    // Poll while the card is expanded on an active task so a
+    // newly-appearing cost row makes the tab show up without a manual
+    // refresh. Drops to no-poll once the task is no longer active.
+    refetchInterval: costPrefetchEnabled && isActive ? 5_000 : false,
+  })
+  const hasCostData = (costData?.request_count ?? 0) > 0
 
   const effectiveValue = (a: TaskAction): ScopePillValue => {
     const key = `${a.service}|${a.action}`
@@ -446,6 +462,23 @@ export default function TaskCard({
             >
               Scopes
             </button>
+            {/* Cost tab appears only when the prefetch (kicked off on
+                expand) has confirmed at least one llm_request_cost row
+                for this task. Tasks not driven through the lite-proxy
+                — regular API tasks, control-plane-only flows — return
+                request_count=0 and never surface the tab. */}
+            {hasCostData && (
+              <button
+                onClick={() => setActiveTab('cost')}
+                className={`px-3 py-2.5 text-[12.5px] border-b-2 -mb-px transition-colors ${
+                  activeTab === 'cost'
+                    ? 'text-text-primary border-brand'
+                    : 'text-text-tertiary border-transparent hover:text-text-secondary'
+                }`}
+              >
+                Cost
+              </button>
+            )}
           </div>
 
           {activeTab === 'activity' && (
@@ -498,6 +531,10 @@ export default function TaskCard({
                 )}
               </div>
             </div>
+          )}
+
+          {activeTab === 'cost' && (
+            <CostPanel data={costData} loading={costLoading} />
           )}
 
           {!result && isActive && (
@@ -1038,6 +1075,98 @@ function ActivityRow({ entry }: { entry: AuditEntry }) {
           <ParamsTable params={entry.params_safe} />
         </div>
       )}
+    </div>
+  )
+}
+
+// ── Cost panel ────────────────────────────────────────────────────────────────
+
+function formatMicros(micros: number): string {
+  // Sub-cent precision matters at low token counts (a single short
+  // request can be ~$0.0001). Switch format at $1 so the column
+  // doesn't render as "0.0001" forever. Zero collapses to "$0.00"
+  // so a task whose models are all unpriced doesn't read as a long
+  // string of zeros.
+  if (micros === 0) return '$0.00'
+  const dollars = micros / 1_000_000
+  if (dollars >= 1) return `$${dollars.toFixed(2)}`
+  if (dollars >= 0.01) return `$${dollars.toFixed(4)}`
+  return `$${dollars.toFixed(6)}`
+}
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`
+  return String(n)
+}
+
+function CostPanel({ data, loading }: { data: TaskCostSummary | undefined; loading: boolean }) {
+  if (loading) {
+    return <div className="px-4 py-3 text-xs text-text-tertiary">Loading…</div>
+  }
+  if (!data || data.request_count === 0) {
+    return (
+      <div className="px-4 py-3 text-xs text-text-tertiary">
+        No LLM requests recorded for this task yet.
+      </div>
+    )
+  }
+  const hasUnknown = (data.unknown_models?.length ?? 0) > 0
+  return (
+    <div className="px-4 py-3 space-y-3">
+      <div className="grid grid-cols-3 gap-3">
+        <Stat label="Total cost" value={formatMicros(data.cost_micros)} mono />
+        <Stat label="Requests" value={String(data.request_count)} mono />
+        <Stat label="Tokens"
+          value={`${formatTokens(data.input_tokens + data.output_tokens + data.cache_read_tokens + data.cache_write_tokens)}`}
+          mono />
+      </div>
+      {hasUnknown && (
+        <div className="text-[11px] text-warning">
+          Cost is a lower bound — pricing not configured for: {data.unknown_models!.join(', ')}
+        </div>
+      )}
+      {data.by_model.length > 0 && (
+        <div className="border border-border-subtle rounded overflow-hidden">
+          <table className="w-full text-xs">
+            <thead className="bg-surface-2">
+              <tr className="text-text-tertiary">
+                <th className="text-left px-3 py-1.5 font-medium">Model</th>
+                <th className="text-right px-3 py-1.5 font-medium">Reqs</th>
+                <th className="text-right px-3 py-1.5 font-medium">Input</th>
+                <th className="text-right px-3 py-1.5 font-medium">Output</th>
+                <th className="text-right px-3 py-1.5 font-medium">Cache R/W</th>
+                <th className="text-right px-3 py-1.5 font-medium">Cost</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border-subtle">
+              {data.by_model.map(m => (
+                <tr key={m.model}>
+                  <td className="px-3 py-1.5 font-mono text-text-primary">{m.model}</td>
+                  <td className="px-3 py-1.5 text-right font-mono text-text-secondary">{m.request_count}</td>
+                  <td className="px-3 py-1.5 text-right font-mono text-text-secondary">{formatTokens(m.input_tokens)}</td>
+                  <td className="px-3 py-1.5 text-right font-mono text-text-secondary">{formatTokens(m.output_tokens)}</td>
+                  <td className="px-3 py-1.5 text-right font-mono text-text-secondary">
+                    {formatTokens(m.cache_read_tokens)} / {formatTokens(m.cache_write_tokens)}
+                  </td>
+                  <td className="px-3 py-1.5 text-right font-mono text-text-primary">
+                    {m.known ? formatMicros(m.cost_micros) : <span className="text-warning">—</span>}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function Stat({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <div className="bg-surface-2 rounded px-3 py-2">
+      <div className="text-[10px] uppercase tracking-wider text-text-tertiary">{label}</div>
+      <div className={`text-sm text-text-primary mt-0.5 ${mono ? 'font-mono' : ''}`}>{value}</div>
     </div>
   )
 }

--- a/web/src/components/TaskCard.tsx
+++ b/web/src/components/TaskCard.tsx
@@ -120,20 +120,11 @@ export default function TaskCard({
   const isActive = task.status === 'active'
   const isStanding = task.lifetime === 'standing'
   const isActionable = needsApproval || needsExpansion
-  const activityVisible = !isActionable && expanded && activeTab === 'activity'
   // Fetch cost as soon as the card is expanded (not gated on tab click)
   // so we can decide whether to render the Cost tab at all — non-llm-proxy
   // tasks return request_count=0 and the tab stays hidden. The query is
   // cheap when there are no rows.
   const costPrefetchEnabled = !isActionable && expanded
-
-  const { data: auditData, isLoading: auditLoading } = useQuery({
-    queryKey: ['audit', { task_id: task.id }],
-    queryFn: () => api.audit.list({ task_id: task.id, limit: 50 }),
-    enabled: activityVisible,
-    refetchInterval: (query) =>
-      activityVisible && task.request_count !== (query.state.data?.entries?.length ?? 0) ? 1_000 : false,
-  })
 
   const { data: costData, isLoading: costLoading } = useQuery({
     queryKey: ['task-cost', task.id],
@@ -145,6 +136,25 @@ export default function TaskCard({
     refetchInterval: costPrefetchEnabled && isActive ? 5_000 : false,
   })
   const hasCostData = (costData?.request_count ?? 0) > 0
+  // If the user picked Cost and the data later disappears (refetch
+  // returns 0 rows, error, etc.), the tab button vanishes but
+  // activeTab is still 'cost' — that strands them on an empty panel
+  // with no obvious way back. Fall through to the default tab in
+  // that case. Local-only; activeTab itself stays as-is so if data
+  // reappears the original selection takes effect again.
+  const effectiveTab: typeof activeTab =
+    activeTab === 'cost' && !hasCostData
+      ? (task.request_count === 0 ? 'scopes' : 'activity')
+      : activeTab
+  const activityVisible = !isActionable && expanded && effectiveTab === 'activity'
+
+  const { data: auditData, isLoading: auditLoading } = useQuery({
+    queryKey: ['audit', { task_id: task.id }],
+    queryFn: () => api.audit.list({ task_id: task.id, limit: 50 }),
+    enabled: activityVisible,
+    refetchInterval: (query) =>
+      activityVisible && task.request_count !== (query.state.data?.entries?.length ?? 0) ? 1_000 : false,
+  })
 
   const effectiveValue = (a: TaskAction): ScopePillValue => {
     const key = `${a.service}|${a.action}`
@@ -445,7 +455,7 @@ export default function TaskCard({
             <button
               onClick={() => setActiveTab('activity')}
               className={`px-3 py-2.5 text-[12.5px] border-b-2 -mb-px transition-colors ${
-                activeTab === 'activity'
+                effectiveTab === 'activity'
                   ? 'text-text-primary border-brand'
                   : 'text-text-tertiary border-transparent hover:text-text-secondary'
               }`}
@@ -455,7 +465,7 @@ export default function TaskCard({
             <button
               onClick={() => setActiveTab('scopes')}
               className={`px-3 py-2.5 text-[12.5px] border-b-2 -mb-px transition-colors ${
-                activeTab === 'scopes'
+                effectiveTab === 'scopes'
                   ? 'text-text-primary border-brand'
                   : 'text-text-tertiary border-transparent hover:text-text-secondary'
               }`}
@@ -471,7 +481,7 @@ export default function TaskCard({
               <button
                 onClick={() => setActiveTab('cost')}
                 className={`px-3 py-2.5 text-[12.5px] border-b-2 -mb-px transition-colors ${
-                  activeTab === 'cost'
+                  effectiveTab === 'cost'
                     ? 'text-text-primary border-brand'
                     : 'text-text-tertiary border-transparent hover:text-text-secondary'
                 }`}
@@ -481,7 +491,7 @@ export default function TaskCard({
             )}
           </div>
 
-          {activeTab === 'activity' && (
+          {effectiveTab === 'activity' && (
             <div className="divide-y divide-border-subtle text-sm">
               {auditLoading && <div className="px-4 py-2 text-xs text-text-tertiary">Loading...</div>}
               {!auditLoading && auditEntries.length === 0 && (
@@ -491,7 +501,7 @@ export default function TaskCard({
             </div>
           )}
 
-          {activeTab === 'scopes' && (
+          {effectiveTab === 'scopes' && (
             <div className="pt-3">
               {showRisk && <RiskPanel risk={riskDetails} level={riskLevel} />}
               {showRationale && <AutoApprovalPanel rationale={task.approval_rationale!} />}
@@ -533,7 +543,7 @@ export default function TaskCard({
             </div>
           )}
 
-          {activeTab === 'cost' && (
+          {effectiveTab === 'cost' && (
             <CostPanel data={costData} loading={costLoading} />
           )}
 
@@ -1111,7 +1121,7 @@ function CostPanel({ data, loading }: { data: TaskCostSummary | undefined; loadi
       </div>
     )
   }
-  const hasUnknown = (data.unknown_models?.length ?? 0) > 0
+  const hasUnknown = data.unknown_models.length > 0
   return (
     <div className="px-4 py-3 space-y-3">
       <div className="grid grid-cols-3 gap-3">
@@ -1123,7 +1133,7 @@ function CostPanel({ data, loading }: { data: TaskCostSummary | undefined; loadi
       </div>
       {hasUnknown && (
         <div className="text-[11px] text-warning">
-          Cost is a lower bound — pricing not configured for: {data.unknown_models!.join(', ')}
+          Cost is a lower bound — pricing not configured for: {data.unknown_models.join(', ')}
         </div>
       )}
       {data.by_model.length > 0 && (


### PR DESCRIPTION
## Summary

- New `llm_request_cost` table (sqlite + postgres) records token usage and computed cost in micro-USD for every upstream LLM call, FK'd to `audit_log` and keyed by `(user_id, task_id)` for fast per-task rollups.
- `pricing` package covers current Anthropic + OpenAI models, including Anthropic's per-TTL cache-write split (5m vs 1h) and OpenAI's cached-input discount; `Normalize` collapses dated/aliased/vendor-prefixed model IDs to one table key so `GROUP BY` doesn't fragment a task's spend.
- Usage extractor handles Anthropic JSON/SSE and both OpenAI shapes — Chat Completions and the Responses API; falls back to body-shape sniffing when `Content-Type` is absent (chatgpt.com's `backend-api/codex` endpoint used by Codex with ChatGPT OAuth doesn't emit `text/event-stream`).
- `GET /api/tasks/{id}/cost` returns per-model breakdowns; the TaskCard's expanded view shows a **Cost** tab whenever a prefetch query confirms at least one cost row exists for the task.

## Test plan

- [ ] Run a Claude Code task; verify `llm_request_cost` rows land with non-NULL `cost_micros` and Cost tab appears with per-model breakdown.
- [ ] Run a Codex (ChatGPT OAuth) task; verify Codex `gpt-5.5` rows land via the `chatgpt.com/backend-api/codex/responses` upstream, body-sniff handles the empty Content-Type.
- [ ] Run a non-LLM-proxy task (e.g. plain API control-plane call); verify Cost tab stays hidden.
- [ ] Confirm `GET /api/tasks/{id}/cost` returns the expected `request_count`, `cost_micros`, and `by_model` breakdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)