### PR TITLE
fix(llmproxy): reuse inline risk assessment on manual approval

### DIFF
--- a/internal/api/handlers/inline_task_e2e_test.go
+++ b/internal/api/handlers/inline_task_e2e_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy"
 	runtimetasks "github.com/clawvisor/clawvisor/internal/runtime/tasks"
+	"github.com/clawvisor/clawvisor/internal/taskrisk"
 	"github.com/clawvisor/clawvisor/pkg/store"
 )
 
@@ -212,6 +213,95 @@ func TestInlineTaskApprovalFullStateMachine(t *testing.T) {
 	}
 	if rec.ResolvedAt == nil {
 		t.Error("rec.ResolvedAt should be set")
+	}
+}
+
+// Manual-approve release path threads the hold's PrecomputedRisk into
+// CreateInlineApprovedTaskWithAssessment, so the persisted
+// task.RiskDetails matches what the user saw in the inline prompt
+// instead of a second assessor call that lacks RecentUserTurns and
+// produces a different, more cautious explanation.
+func TestInlineTaskApproval_PrecomputedRiskThreadsThrough(t *testing.T) {
+	ctx := context.Background()
+	h, st, _, agent := newInlineTasksHandlerForTest(t)
+	// Wire an assessor that would return a DIFFERENT verdict than the
+	// precomputed one. If the release path falls back to the legacy
+	// CreateInlineApprovedTask (which re-runs the assessor), the
+	// recorded calls AND the persisted RiskLevel will both reflect
+	// this — failing the test.
+	rec := &recordingAssessor{
+		respond: func() *taskrisk.RiskAssessment {
+			return &taskrisk.RiskAssessment{RiskLevel: "high", Explanation: "fresh-assessor-call"}
+		},
+	}
+	h.assessor = rec
+
+	cache := llmproxy.NewMemoryPendingApprovalCache(time.Minute)
+
+	const originalHoldID = "cv-origtoolxxxxxxxxxxxxxxxxxx"
+	if _, err := cache.Hold(ctx, llmproxy.PendingLiteApproval{
+		ID:       originalHoldID,
+		UserID:   agent.UserID,
+		AgentID:  agent.ID,
+		Provider: conversation.ProviderAnthropic,
+		ToolUse:  conversation.ToolUse{ID: "toolu_orig", Name: "Bash"},
+		Stage:    llmproxy.StageAwaitingTaskDefinition,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	innerHold, err := cache.Hold(ctx, llmproxy.PendingLiteApproval{
+		UserID:          agent.UserID,
+		AgentID:         agent.ID,
+		Provider:        conversation.ProviderAnthropic,
+		ToolUse:         conversation.ToolUse{ID: "toolu_post", Name: "Bash"},
+		Stage:           llmproxy.StageAwaitingTaskApproval,
+		AwaitingTaskFor: originalHoldID,
+		TaskDefinition: &runtimetasks.TaskCreateRequest{
+			Purpose:                "files in /tmp",
+			IntentVerificationMode: "strict",
+			ExpiresInSeconds:       600,
+			ExpectedTools:          []runtimetasks.ExpectedTool{{ToolName: "Bash", Why: "create"}},
+		},
+		PrecomputedRisk: &taskrisk.RiskAssessment{
+			RiskLevel:   "low",
+			Explanation: "precomputed-at-hold-time",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body := []byte(`{"messages":[{"role":"user","content":"approve ` + innerHold.Pending.ID + `"}]}`)
+	result, err := llmproxy.RewriteInlineTaskApprovalReply(ctx, llmproxy.InlineApprovalRewriteRequest{
+		HTTPRequest:     httptest.NewRequest("POST", "/v1/messages", nil),
+		Provider:        conversation.ProviderAnthropic,
+		Body:            body,
+		Agent:           agent,
+		PendingApproval: cache,
+		Creator:         h,
+	})
+	if err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	if result.Decision != "allow" {
+		t.Fatalf("decision=%q want allow (outcome=%s)", result.Decision, result.Outcome)
+	}
+
+	if rec.calls != 0 {
+		t.Errorf("assessor should NOT be called on the release path when the hold carries PrecomputedRisk; got calls=%d", rec.calls)
+	}
+
+	tasks := listTasksForAgent(t, st, agent)
+	if len(tasks) != 1 {
+		t.Fatalf("want 1 task; got %d", len(tasks))
+	}
+	task := tasks[0]
+	if task.RiskLevel != "low" {
+		t.Errorf("task.RiskLevel=%q want low (the precomputed level); release path likely fell back to a fresh assessor call", task.RiskLevel)
+	}
+	if !strings.Contains(string(task.RiskDetails), "precomputed-at-hold-time") {
+		t.Errorf("task.RiskDetails should carry the precomputed explanation; got %s", string(task.RiskDetails))
 	}
 }
 

--- a/internal/runtime/llmproxy/inline_task_intercept.go
+++ b/internal/runtime/llmproxy/inline_task_intercept.go
@@ -287,16 +287,17 @@ func maybeInterceptInlineTaskDefinition(
 
 	now := time.Now().UTC()
 	innerHold, holdErr := cfg.PendingApprovals.Hold(req.Context(), PendingLiteApproval{
-		UserID:         cfg.AgentUserID,
-		AgentID:        cfg.AgentID,
-		Provider:       provider,
-		ConversationID: cfg.ConversationID,
-		ToolUse:        tu,
-		Reason:         "inline task creation awaiting user approval",
-		Stage:          StageAwaitingTaskApproval,
-		TaskDefinition: parsed,
-		CreatedAt:      now,
-		ExpiresAt:      now.Add(inlineTaskApprovalHoldTTL),
+		UserID:          cfg.AgentUserID,
+		AgentID:         cfg.AgentID,
+		Provider:        provider,
+		ConversationID:  cfg.ConversationID,
+		ToolUse:         tu,
+		Reason:          "inline task creation awaiting user approval",
+		Stage:           StageAwaitingTaskApproval,
+		TaskDefinition:  parsed,
+		PrecomputedRisk: assessment,
+		CreatedAt:       now,
+		ExpiresAt:       now.Add(inlineTaskApprovalHoldTTL),
 	})
 	if holdErr != nil {
 		audit("block", "inline_task_hold_failed", holdErr.Error())

--- a/internal/runtime/llmproxy/inline_task_transitions.go
+++ b/internal/runtime/llmproxy/inline_task_transitions.go
@@ -92,7 +92,21 @@ func resolveInlineTaskApproval(ctx context.Context, req InlineApprovalRewriteReq
 		return renderInlineTaskCreatorErrorReply("missing task definition on approval"), out
 	default:
 		originalToolUseID := resolved.AwaitingTaskFor
-		created, createErr := req.Creator.CreateInlineApprovedTask(ctx, req.Agent, resolved.TaskDefinition, originalToolUseID)
+		// Fast-path the precomputed assessment when the creator honors
+		// it. The intercept ran the assessor with RecentUserTurns in
+		// scope; reusing that verdict here keeps the persisted
+		// task.RiskDetails (and the dashboard) in sync with the inline
+		// approval prompt the user actually approved. Falling back to
+		// CreateInlineApprovedTask triggers a second assessor call
+		// without conversation context, which produces a different,
+		// more cautious explanation than the one shown inline.
+		var created *InlineApprovedTask
+		var createErr error
+		if withAssessment, ok := req.Creator.(InlineTaskCreatorWithAssessment); ok {
+			created, createErr = withAssessment.CreateInlineApprovedTaskWithAssessment(ctx, req.Agent, resolved.TaskDefinition, originalToolUseID, resolved.PrecomputedRisk)
+		} else {
+			created, createErr = req.Creator.CreateInlineApprovedTask(ctx, req.Agent, resolved.TaskDefinition, originalToolUseID)
+		}
 		if createErr != nil {
 			out.Decision = "deny"
 			out.Outcome = "inline_task_create_failed"

--- a/internal/runtime/llmproxy/pending_approval_cache.go
+++ b/internal/runtime/llmproxy/pending_approval_cache.go
@@ -12,6 +12,7 @@ import (
 	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/inspector"
 	runtimetasks "github.com/clawvisor/clawvisor/internal/runtime/tasks"
+	"github.com/clawvisor/clawvisor/internal/taskrisk"
 	runtimedecision "github.com/clawvisor/clawvisor/pkg/runtime/decision"
 )
 
@@ -82,6 +83,17 @@ type PendingLiteApproval struct {
 	// inline approval prompt and to create the task once the user approves.
 	// nil at the other stages.
 	TaskDefinition *runtimetasks.TaskCreateRequest
+
+	// PrecomputedRisk is the merged LLM+envelope risk assessment computed
+	// at hold time (with RecentUserTurns in scope). The release path
+	// passes this to CreateInlineApprovedTaskWithAssessment so the
+	// persisted task.RiskDetails matches what the user saw in the inline
+	// approval prompt — without it the handler runs a fresh assessor call
+	// that lacks conversation context and produces a different, more
+	// cautious explanation that disagrees with the inline read.
+	// nil at stages other than StageAwaitingTaskApproval, and may be nil
+	// at that stage if the assessor wasn't configured or returned unknown.
+	PrecomputedRisk *taskrisk.RiskAssessment
 
 	// Additional carries the other tool_uses that share this hold when
 	// multiple tool_uses in a single upstream response are coalesced into


### PR DESCRIPTION
## Summary

The manual inline-task approval release path called `CreateInlineApprovedTask`, which re-ran the LLM risk assessor without `RecentUserTurns` and produced an explanation that disagreed with the verdict the user already approved in the inline prompt — the dashboard would show a more cautious, context-free risk write-up than the one shown inline.

This threads the assessment computed at hold time through `PendingLiteApproval.PrecomputedRisk` and calls `CreateInlineApprovedTaskWithAssessment` on release, matching the auto-approve gate's existing fast path. Result: one less LLM round-trip per approval, and the persisted `task.RiskDetails` matches what the user actually approved.

## Test plan

- [x] `go test ./internal/api/handlers/ ./internal/runtime/llmproxy/...`
- [x] New `TestInlineTaskApproval_PrecomputedRiskThreadsThrough` asserts the assessor is not re-called and the persisted level/explanation come from the precomputed assessment

🤖 Generated with [Claude Code](https://claude.com/claude-code)