### PR TITLE
feat: Add builtin fact extraction patterns for Google Sheets spreadsheet IDs

### DIFF
--- a/internal/intent/extractor.go
+++ b/internal/intent/extractor.go
@@ -855,7 +855,7 @@ func builtinPatternsRaw(service, action string) []extractionPattern {
 		)
 	case "google.sheets":
 		return append(generic,
-			extractionPattern{FactType: "file_id", Regex:    `"spreadsheetId":\s*"([^"]+)"`},
+			extractionPattern{FactType: "file_id", Regex: `"spreadsheet_id":\s*"([^"]+)"`},
 		)
 	case "google.calendar":
 		// Google Calendar event IDs are lowercase base32 (5-1024 chars),

--- a/internal/intent/extractor.go
+++ b/internal/intent/extractor.go
@@ -853,6 +853,10 @@ func builtinPatternsRaw(service, action string) []extractionPattern {
 		return append(generic,
 			extractionPattern{FactType: "file_id", Regex: `"id":\s*"([^"]+)"`},
 		)
+	case "google.sheets":
+		return append(generic,
+			extractionPattern{FactType: "file_id", Regex:    `"spreadsheetId":\s*"([^"]+)"`},
+		)
 	case "google.calendar":
 		// Google Calendar event IDs are lowercase base32 (5-1024 chars),
 		// optionally prefixed with "_" for imported events, with an optional

--- a/internal/intent/extractor_test.go
+++ b/internal/intent/extractor_test.go
@@ -294,6 +294,7 @@ func TestBuiltinPatterns_NoEntityIDForKnownServices(t *testing.T) {
 	}{
 		{"google.gmail", `{"messages":[{"id":"19d5fe858c900042","threadId":"19d5fe858c900040"}]}`},
 		{"google.drive", `{"files":[{"id":"1BxR7a3mNpQ9vK2wL5sYcTfDgHjKlMnO"}]}`},
+		{"google.sheets", `{"spreadsheet_id":"1BxR7a3mNpQ9vK2wL5sYcTfDgHjKlMnO"}`},
 		{"google.calendar", `{"data":[{"id":"1pj4096shhq40g6hkl995jrqfo"}]}`},
 		{"slack", `{"channels":[{"id":"C0123456789"}]}`},
 		{"linear", `{"issues":[{"id":"3a7c8e1b-2d4f-49a0-91c5-b7e1f8d2c4a6","identifier":"ENG-123"}]}`},


### PR DESCRIPTION
## Summary

refrence #431 
Adds builtin extraction patterns for google.sheets so spreadsheetId values are automatically extracted into chain facts.

This follows the same approach already used for sibling Google services like:
- Gmail (message_id, thread_id)
- Drive (file_id)
- Calendar (event_id)
- Contacts (phone_number, email_address)

## Changes

- Added a google.sheets case inside builtinPatternsRaw()
- Extracts:
  - spreadsheetId → file_id

## Notes

This is a small non-blocking improvement based on mentor feedback for service-specific fact extractors in internal/intent/extractor.go.