### PR TITLE
fix(haikuproxy): revert base URL prefix to /v1

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -48,13 +48,12 @@ func PushURL() string {
 }
 
 // HaikuProxyURL returns the haiku proxy base URL for the current environment.
-// Includes /api/v1 so the LLM client's "/messages" append hits
-// /api/v1/messages.
+// Includes /v1 so the LLM client's "/messages" append hits /v1/messages.
 func HaikuProxyURL() string {
 	if IsStaging() {
-		return "https://hp.staging.clawvisor.com/api/v1"
+		return "https://hp.staging.clawvisor.com/v1"
 	}
-	return "https://hp.clawvisor.com/api/v1"
+	return "https://hp.clawvisor.com/v1"
 }
 
 // DashboardURL returns the externally reachable dashboard base URL for


### PR DESCRIPTION
## Summary
- PR #420 (lite-proxy routes under /api) collaterally edited `HaikuProxyURL()` to `/api/v1`, but the haiku proxy server (`hp.clawvisor.com`) still mounts routes at `/v1`.
- Result: every call from `pkg/haikuproxy` (register, usage) and the LLM client's `/messages` append was hitting `404 page not found`.
- This reverts only the haiku-proxy URL prefix; the lite-proxy `/api/v1/...` routes are untouched.

## Test plan
- [x] `go build ./...` and `go test ./pkg/version/... ./pkg/haikuproxy/...`
- [ ] After merge & release: verify `clawvisor-server` haiku-proxy quick-start registration succeeds and Claude Code haiku calls return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)