### PR TITLE
feat(runtime): guard sensitive file reads

### DIFF
--- a/internal/api/handlers/runtime_controls_test.go
+++ b/internal/api/handlers/runtime_controls_test.go
@@ -450,6 +450,53 @@ func TestRuntimeHandlerToolControlsDiscoverAndUpsert(t *testing.T) {
 	if !foundReadOnlyDeny {
 		t.Fatalf("expected read-only shell deny setting, got %+v", rules)
 	}
+
+	disableGuardReq := httptest.NewRequest(http.MethodPut, "/api/runtime/tool-controls", bytes.NewReader([]byte(`{
+		"agent_id":"`+agent.ID+`",
+		"tool_name":"Bash",
+		"sensitive_file_guard_enabled":false
+	}`)))
+	disableGuardReq = disableGuardReq.WithContext(context.WithValue(disableGuardReq.Context(), middleware.UserContextKey, user))
+	disableGuardRes := httptest.NewRecorder()
+	h.UpsertToolControl(disableGuardRes, disableGuardReq)
+	if disableGuardRes.Code != http.StatusOK {
+		t.Fatalf("UpsertToolControl guard toggle status=%d body=%s", disableGuardRes.Code, disableGuardRes.Body.String())
+	}
+	rules, err = st.ListRuntimePolicyRules(ctx, user.ID, store.RuntimePolicyRuleFilter{AgentID: agent.ID, Kind: "tool"})
+	if err != nil {
+		t.Fatalf("ListRuntimePolicyRules after guard toggle: %v", err)
+	}
+	foundGuardAllow := false
+	for _, rule := range rules {
+		if rule.ToolName == "Bash" && rule.Source == toolnames.SensitiveFileGuardSettingSource && rule.Action == "allow" {
+			foundGuardAllow = true
+		}
+	}
+	if !foundGuardAllow {
+		t.Fatalf("expected sensitive-file-guard allow marker (=disabled), got %+v", rules)
+	}
+	if toolnames.SensitiveFileGuardEnabled("Bash", agent.ID, rules) {
+		t.Fatal("expected guard to be DISABLED after agent-scoped allow marker")
+	}
+
+	enableGuardReq := httptest.NewRequest(http.MethodPut, "/api/runtime/tool-controls", bytes.NewReader([]byte(`{
+		"agent_id":"`+agent.ID+`",
+		"tool_name":"Bash",
+		"sensitive_file_guard_enabled":true
+	}`)))
+	enableGuardReq = enableGuardReq.WithContext(context.WithValue(enableGuardReq.Context(), middleware.UserContextKey, user))
+	enableGuardRes := httptest.NewRecorder()
+	h.UpsertToolControl(enableGuardRes, enableGuardReq)
+	if enableGuardRes.Code != http.StatusOK {
+		t.Fatalf("UpsertToolControl re-enable guard status=%d body=%s", enableGuardRes.Code, enableGuardRes.Body.String())
+	}
+	rules, err = st.ListRuntimePolicyRules(ctx, user.ID, store.RuntimePolicyRuleFilter{AgentID: agent.ID, Kind: "tool"})
+	if err != nil {
+		t.Fatalf("ListRuntimePolicyRules after re-enable: %v", err)
+	}
+	if !toolnames.SensitiveFileGuardEnabled("Bash", agent.ID, rules) {
+		t.Fatal("expected guard ENABLED after re-enable toggle")
+	}
 }
 
 func TestRuntimeHandlerToolControlsPreferCurrentShellToolForReadOnlySetting(t *testing.T) {

--- a/internal/api/handlers/runtime_tool_controls.go
+++ b/internal/api/handlers/runtime_tool_controls.go
@@ -16,24 +16,30 @@ import (
 )
 
 type runtimeToolControlResponse struct {
-	AgentID                       string                     `json:"agent_id"`
-	ToolName                      string                     `json:"tool_name"`
-	Action                        string                     `json:"action"`
-	RuleID                        string                     `json:"rule_id,omitempty"`
-	Source                        string                     `json:"source"`
-	Scope                         string                     `json:"scope,omitempty"`
-	GlobalAction                  string                     `json:"global_action"`
-	GlobalRuleID                  string                     `json:"global_rule_id,omitempty"`
-	AgentAction                   string                     `json:"agent_action"`
-	AgentRuleID                   string                     `json:"agent_rule_id,omitempty"`
-	ReadOnlyCommandsAllowed       bool                       `json:"read_only_commands_allowed"`
-	GlobalReadOnlyCommandsAllowed *bool                      `json:"global_read_only_commands_allowed,omitempty"`
-	GlobalReadOnlyCommandsRuleID  string                     `json:"global_read_only_commands_rule_id,omitempty"`
-	AgentReadOnlyCommandsAllowed  *bool                      `json:"agent_read_only_commands_allowed,omitempty"`
-	AgentReadOnlyCommandsRuleID   string                     `json:"agent_read_only_commands_rule_id,omitempty"`
-	LastSeenAt                    *time.Time                 `json:"last_seen_at,omitempty"`
-	AdvancedRuleCount             int                        `json:"advanced_rule_count"`
-	AdvancedRules                 []*store.RuntimePolicyRule `json:"advanced_rules"`
+	AgentID                         string                     `json:"agent_id"`
+	ToolName                        string                     `json:"tool_name"`
+	Action                          string                     `json:"action"`
+	RuleID                          string                     `json:"rule_id,omitempty"`
+	Source                          string                     `json:"source"`
+	Scope                           string                     `json:"scope,omitempty"`
+	GlobalAction                    string                     `json:"global_action"`
+	GlobalRuleID                    string                     `json:"global_rule_id,omitempty"`
+	AgentAction                     string                     `json:"agent_action"`
+	AgentRuleID                     string                     `json:"agent_rule_id,omitempty"`
+	ReadOnlyCommandsAllowed         bool                       `json:"read_only_commands_allowed"`
+	GlobalReadOnlyCommandsAllowed   *bool                      `json:"global_read_only_commands_allowed,omitempty"`
+	GlobalReadOnlyCommandsRuleID    string                     `json:"global_read_only_commands_rule_id,omitempty"`
+	AgentReadOnlyCommandsAllowed    *bool                      `json:"agent_read_only_commands_allowed,omitempty"`
+	AgentReadOnlyCommandsRuleID     string                     `json:"agent_read_only_commands_rule_id,omitempty"`
+	SensitiveFileGuardApplies       bool                       `json:"sensitive_file_guard_applies"`
+	SensitiveFileGuardEnabled       bool                       `json:"sensitive_file_guard_enabled"`
+	GlobalSensitiveFileGuardEnabled *bool                      `json:"global_sensitive_file_guard_enabled,omitempty"`
+	GlobalSensitiveFileGuardRuleID  string                     `json:"global_sensitive_file_guard_rule_id,omitempty"`
+	AgentSensitiveFileGuardEnabled  *bool                      `json:"agent_sensitive_file_guard_enabled,omitempty"`
+	AgentSensitiveFileGuardRuleID   string                     `json:"agent_sensitive_file_guard_rule_id,omitempty"`
+	LastSeenAt                      *time.Time                 `json:"last_seen_at,omitempty"`
+	AdvancedRuleCount               int                        `json:"advanced_rule_count"`
+	AdvancedRules                   []*store.RuntimePolicyRule `json:"advanced_rules"`
 }
 
 func (h *RuntimeHandler) ListToolControls(w http.ResponseWriter, r *http.Request) {
@@ -62,15 +68,17 @@ func (h *RuntimeHandler) ListToolControls(w http.ResponseWriter, r *http.Request
 		ctrl := controls[name]
 		if ctrl == nil {
 			ctrl = &runtimeToolControlResponse{
-				AgentID:                 agentID,
-				ToolName:                name,
-				Action:                  "unset",
-				Source:                  "default",
-				Scope:                   "unset",
-				GlobalAction:            "unset",
-				AgentAction:             "unset",
-				ReadOnlyCommandsAllowed: toolnames.IsShellToolName(name),
-				LastSeenAt:              nil,
+				AgentID:                   agentID,
+				ToolName:                  name,
+				Action:                    "unset",
+				Source:                    "default",
+				Scope:                     "unset",
+				GlobalAction:              "unset",
+				AgentAction:               "unset",
+				ReadOnlyCommandsAllowed:   toolnames.IsShellToolName(name),
+				SensitiveFileGuardApplies: toolnames.IsSensitiveFileGuardableTool(name),
+				SensitiveFileGuardEnabled: toolnames.IsSensitiveFileGuardableTool(name),
+				LastSeenAt:                nil,
 			}
 			controls[name] = ctrl
 		}
@@ -181,6 +189,20 @@ func (h *RuntimeHandler) ListToolControls(w http.ResponseWriter, r *http.Request
 			}
 			continue
 		}
+		if toolnames.IsSensitiveFileGuardSettingRule(rule) {
+			// allow-action marker = guard disabled; anything else = enabled.
+			enabled := !strings.EqualFold(strings.TrimSpace(rule.Action), "allow")
+			for _, ctrl := range sensitiveFileGuardSettingControls(controls, ensure, rule.ToolName) {
+				if rule.AgentID != nil {
+					ctrl.AgentSensitiveFileGuardEnabled = &enabled
+					ctrl.AgentSensitiveFileGuardRuleID = rule.ID
+				} else {
+					ctrl.GlobalSensitiveFileGuardEnabled = &enabled
+					ctrl.GlobalSensitiveFileGuardRuleID = rule.ID
+				}
+			}
+			continue
+		}
 		controlToolName := displayToolName(rule.ToolName)
 		ctrl := ensure(controlToolName)
 		if ctrl == nil {
@@ -227,6 +249,8 @@ func (h *RuntimeHandler) ListToolControls(w http.ResponseWriter, r *http.Request
 	out := make([]*runtimeToolControlResponse, 0, len(controls))
 	for _, ctrl := range controls {
 		ctrl.ReadOnlyCommandsAllowed = effectiveReadOnlyShellCommandsAllowed(ctrl)
+		ctrl.SensitiveFileGuardApplies = toolnames.IsSensitiveFileGuardableTool(ctrl.ToolName)
+		ctrl.SensitiveFileGuardEnabled = effectiveSensitiveFileGuardEnabled(ctrl)
 		out = append(out, ctrl)
 	}
 	sort.Slice(out, func(i, j int) bool {
@@ -245,11 +269,12 @@ func (h *RuntimeHandler) UpsertToolControl(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	var body struct {
-		AgentID                 string `json:"agent_id"`
-		ToolName                string `json:"tool_name"`
-		Action                  string `json:"action"`
-		Scope                   string `json:"scope"`
-		ReadOnlyCommandsAllowed *bool  `json:"read_only_commands_allowed"`
+		AgentID                   string `json:"agent_id"`
+		ToolName                  string `json:"tool_name"`
+		Action                    string `json:"action"`
+		Scope                     string `json:"scope"`
+		ReadOnlyCommandsAllowed   *bool  `json:"read_only_commands_allowed"`
+		SensitiveFileGuardEnabled *bool  `json:"sensitive_file_guard_enabled"`
 	}
 	if !decodeJSON(w, r, &body) {
 		return
@@ -269,7 +294,7 @@ func (h *RuntimeHandler) UpsertToolControl(w http.ResponseWriter, r *http.Reques
 		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "tool_name is required")
 		return
 	}
-	if action == "" && body.ReadOnlyCommandsAllowed == nil {
+	if action == "" && body.ReadOnlyCommandsAllowed == nil && body.SensitiveFileGuardEnabled == nil {
 		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "action must be unset, allow, review, or deny")
 		return
 	}
@@ -290,7 +315,7 @@ func (h *RuntimeHandler) UpsertToolControl(w http.ResponseWriter, r *http.Reques
 			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not update read-only shell setting")
 			return
 		}
-		if action == "" {
+		if action == "" && body.SensitiveFileGuardEnabled == nil {
 			resp := runtimeToolControlResponse{
 				AgentID:                 agentID,
 				ToolName:                toolName,
@@ -305,6 +330,44 @@ func (h *RuntimeHandler) UpsertToolControl(w http.ResponseWriter, r *http.Reques
 				resp.GlobalReadOnlyCommandsAllowed = body.ReadOnlyCommandsAllowed
 			} else {
 				resp.AgentReadOnlyCommandsAllowed = body.ReadOnlyCommandsAllowed
+			}
+			writeJSON(w, http.StatusOK, resp)
+			return
+		}
+	}
+	if body.SensitiveFileGuardEnabled != nil {
+		if !toolnames.IsSensitiveFileGuardableTool(toolName) {
+			writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "sensitive-file-guard setting does not apply to this tool")
+			return
+		}
+		if err := h.upsertSensitiveFileGuardSetting(r.Context(), user.ID, agentID, toolName, scope, *body.SensitiveFileGuardEnabled); err != nil {
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not update sensitive-file-guard setting")
+			return
+		}
+		if action == "" {
+			resp := runtimeToolControlResponse{
+				AgentID:                   agentID,
+				ToolName:                  toolName,
+				Action:                    "unset",
+				Source:                    "default",
+				Scope:                     "unset",
+				GlobalAction:              "unset",
+				AgentAction:               "unset",
+				SensitiveFileGuardApplies: true,
+				SensitiveFileGuardEnabled: *body.SensitiveFileGuardEnabled,
+			}
+			if scope == "global" {
+				resp.GlobalSensitiveFileGuardEnabled = body.SensitiveFileGuardEnabled
+			} else {
+				resp.AgentSensitiveFileGuardEnabled = body.SensitiveFileGuardEnabled
+			}
+			if body.ReadOnlyCommandsAllowed != nil {
+				resp.ReadOnlyCommandsAllowed = *body.ReadOnlyCommandsAllowed
+				if scope == "global" {
+					resp.GlobalReadOnlyCommandsAllowed = body.ReadOnlyCommandsAllowed
+				} else {
+					resp.AgentReadOnlyCommandsAllowed = body.ReadOnlyCommandsAllowed
+				}
 			}
 			writeJSON(w, http.StatusOK, resp)
 			return
@@ -518,7 +581,7 @@ func isSimpleToolControlRule(rule *store.RuntimePolicyRule) bool {
 	if rule == nil || strings.TrimSpace(rule.InputRegex) != "" {
 		return false
 	}
-	if toolnames.IsReadOnlyShellSettingRule(rule) {
+	if toolnames.IsReadOnlyShellSettingRule(rule) || toolnames.IsSensitiveFileGuardSettingRule(rule) {
 		return false
 	}
 	return rawJSONEmptyObject(rule.InputShape)
@@ -536,6 +599,49 @@ func effectiveReadOnlyShellCommandsAllowed(ctrl *runtimeToolControlResponse) boo
 		allowed = *ctrl.AgentReadOnlyCommandsAllowed
 	}
 	return allowed
+}
+
+func effectiveSensitiveFileGuardEnabled(ctrl *runtimeToolControlResponse) bool {
+	if ctrl == nil || !toolnames.IsSensitiveFileGuardableTool(ctrl.ToolName) {
+		return false
+	}
+	enabled := true
+	if ctrl.GlobalSensitiveFileGuardEnabled != nil {
+		enabled = *ctrl.GlobalSensitiveFileGuardEnabled
+	}
+	if ctrl.AgentSensitiveFileGuardEnabled != nil {
+		enabled = *ctrl.AgentSensitiveFileGuardEnabled
+	}
+	return enabled
+}
+
+func sensitiveFileGuardSettingControls(controls map[string]*runtimeToolControlResponse, ensure func(string) *runtimeToolControlResponse, toolName string) []*runtimeToolControlResponse {
+	// Mirror readOnlyShellSettingControls: when the marker rule's
+	// ToolName is a shell-class tool, fan out to every discovered shell
+	// control. For non-shell guardable tools (Read/Glob/Grep/LS), the
+	// rule maps 1:1 to the matching control row.
+	if !toolnames.IsShellToolName(toolName) {
+		if ctrl := ensure(toolName); ctrl != nil {
+			return []*runtimeToolControlResponse{ctrl}
+		}
+		return nil
+	}
+	out := make([]*runtimeToolControlResponse, 0, 1)
+	for _, ctrl := range controls {
+		if ctrl != nil && toolnames.IsShellToolName(ctrl.ToolName) {
+			out = append(out, ctrl)
+		}
+	}
+	if len(out) > 0 {
+		sort.Slice(out, func(i, j int) bool {
+			return strings.ToLower(out[i].ToolName) < strings.ToLower(out[j].ToolName)
+		})
+		return out
+	}
+	if ctrl := ensure(toolName); ctrl != nil {
+		return []*runtimeToolControlResponse{ctrl}
+	}
+	return nil
 }
 
 func toolRuleNamesSameControl(ruleToolName, controlToolName string) bool {
@@ -590,6 +696,55 @@ func (h *RuntimeHandler) upsertReadOnlyShellSetting(ctx context.Context, userID,
 		InputShape: toolnames.ReadOnlyShellSettingInputShape(),
 		Reason:     reason,
 		Source:     toolnames.ReadOnlyShellSettingSource,
+		Enabled:    true,
+	})
+}
+
+func (h *RuntimeHandler) upsertSensitiveFileGuardSetting(ctx context.Context, userID, agentID, toolName, scope string, enabled bool) error {
+	ruleAgentID := &agentID
+	filterAgentID := agentID
+	if scope == "global" {
+		ruleAgentID = nil
+		filterAgentID = ""
+	}
+	rules, err := h.st.ListRuntimePolicyRules(ctx, userID, store.RuntimePolicyRuleFilter{
+		AgentID: filterAgentID,
+		Kind:    "tool",
+		Limit:   500,
+	})
+	if err != nil {
+		return err
+	}
+	for _, rule := range rules {
+		if rule == nil || !toolnames.IsSensitiveFileGuardSettingRule(rule) || !toolnames.ToolNamesSameClass(rule.ToolName, toolName) {
+			continue
+		}
+		if scope == "agent" && (rule.AgentID == nil || *rule.AgentID != agentID) {
+			continue
+		}
+		if scope == "global" && rule.AgentID != nil {
+			continue
+		}
+		if err := h.st.DeleteRuntimePolicyRule(ctx, rule.ID, userID); err != nil && err != store.ErrNotFound {
+			return err
+		}
+	}
+	action := "allow"
+	reason := "Allow reads of sensitive files (.env, SSH keys, …) without approval"
+	if enabled {
+		action = "deny"
+		reason = "Require task scope or approval for reads of sensitive files (.env, SSH keys, …)"
+	}
+	return h.st.CreateRuntimePolicyRule(ctx, &store.RuntimePolicyRule{
+		ID:         uuid.NewString(),
+		UserID:     userID,
+		AgentID:    ruleAgentID,
+		Kind:       "tool",
+		Action:     action,
+		ToolName:   toolName,
+		InputShape: toolnames.SensitiveFileGuardSettingInputShape(),
+		Reason:     reason,
+		Source:     toolnames.SensitiveFileGuardSettingSource,
 		Enabled:    true,
 	})
 }

--- a/internal/runtime/llmproxy/inspector/readonly_bash.go
+++ b/internal/runtime/llmproxy/inspector/readonly_bash.go
@@ -4,7 +4,59 @@ import (
 	"strings"
 
 	"mvdan.cc/sh/v3/syntax"
+
+	"github.com/clawvisor/clawvisor/pkg/runtime/sensitivepaths"
 )
+
+// CommandReferencesSensitivePath parses cmd and returns the first
+// literal word that resolves to a sensitive file path (SSH key, .env,
+// cloud credential, …), along with a short reason. Words that are
+// dynamic (command substitution, parameter expansion, …) or that
+// fail to parse are skipped — those paths are already blocked by
+// IsReadOnlyBashCommand's safety walk.
+//
+// The check is intentionally a defense-in-depth gate on top of
+// IsReadOnlyBashCommand: even a structurally safe `cat ~/.ssh/id_rsa`
+// must fall through to task-scope matching and intent verification
+// rather than ride the read-only shell auto-allow.
+func CommandReferencesSensitivePath(cmd string) (token, reason string, ok bool) {
+	cmd = strings.TrimSpace(cmd)
+	if cmd == "" {
+		return "", "", false
+	}
+	file, err := syntax.NewParser().Parse(strings.NewReader(cmd), "")
+	if err != nil {
+		return "", "", false
+	}
+	var (
+		hitToken  string
+		hitReason string
+	)
+	syntax.Walk(file, func(node syntax.Node) bool {
+		if hitReason != "" || node == nil {
+			return false
+		}
+		word, isWord := node.(*syntax.Word)
+		if !isWord {
+			return true
+		}
+		value, staticOK := staticWordValue(word)
+		if !staticOK {
+			return true
+		}
+		_, r, sensitive := sensitivepaths.FindSensitiveTokenInArgs([]string{value})
+		if sensitive {
+			hitToken = value
+			hitReason = r
+			return false
+		}
+		return true
+	})
+	if hitReason == "" {
+		return "", "", false
+	}
+	return hitToken, hitReason, true
+}
 
 // IsReadOnlyBashCommand reports whether cmd is composed entirely of
 // side-effect-free shell commands with no write redirects, substitutions, or

--- a/internal/runtime/llmproxy/inspector/readonly_bash.go
+++ b/internal/runtime/llmproxy/inspector/readonly_bash.go
@@ -1,6 +1,7 @@
 package inspector
 
 import (
+	"bytes"
 	"strings"
 
 	"mvdan.cc/sh/v3/syntax"
@@ -10,10 +11,9 @@ import (
 
 // CommandReferencesSensitivePath parses cmd and returns the first
 // literal word that resolves to a sensitive file path (SSH key, .env,
-// cloud credential, …), along with a short reason. Words that are
-// dynamic (command substitution, parameter expansion, …) or that
-// fail to parse are skipped — those paths are already blocked by
-// IsReadOnlyBashCommand's safety walk.
+// cloud credential, …), along with a short reason. For words containing
+// unresolved shell expansions, the rendered shell token is still checked
+// so common forms like $HOME/.ssh/id_rsa cannot ride a pass-through path.
 //
 // The check is intentionally a defense-in-depth gate on top of
 // IsReadOnlyBashCommand: even a structurally safe `cat ~/.ssh/id_rsa`
@@ -42,7 +42,10 @@ func CommandReferencesSensitivePath(cmd string) (token, reason string, ok bool) 
 		}
 		value, staticOK := staticWordValue(word)
 		if !staticOK {
-			return true
+			value = renderedWordValue(word)
+			if value == "" {
+				return true
+			}
 		}
 		_, r, sensitive := sensitivepaths.FindSensitiveTokenInArgs([]string{value})
 		if sensitive {
@@ -56,6 +59,17 @@ func CommandReferencesSensitivePath(cmd string) (token, reason string, ok bool) 
 		return "", "", false
 	}
 	return hitToken, hitReason, true
+}
+
+func renderedWordValue(word *syntax.Word) string {
+	if word == nil {
+		return ""
+	}
+	var buf bytes.Buffer
+	if err := syntax.NewPrinter().Print(&buf, word); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(buf.String())
 }
 
 // IsReadOnlyBashCommand reports whether cmd is composed entirely of

--- a/internal/runtime/llmproxy/inspector/readonly_bash_test.go
+++ b/internal/runtime/llmproxy/inspector/readonly_bash_test.go
@@ -2,6 +2,48 @@ package inspector
 
 import "testing"
 
+func TestCommandReferencesSensitivePathFlagsCommonSecrets(t *testing.T) {
+	cases := []struct {
+		name string
+		cmd  string
+	}{
+		{"cat home ssh key", "cat ~/.ssh/id_rsa"},
+		{"cat absolute ssh key", "cat /Users/eric/.ssh/id_ed25519"},
+		{"head .env", "head -n 5 .env"},
+		{"grep over aws dir", "grep -R access_key ~/.aws"},
+		{"cat pem", "cat certs/tls.pem"},
+		{"cat netrc", "cat ~/.netrc"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, reason, ok := CommandReferencesSensitivePath(tc.cmd)
+			if !ok {
+				t.Fatalf("expected %q to reference a sensitive path", tc.cmd)
+			}
+			if reason == "" {
+				t.Fatalf("expected non-empty reason for %q", tc.cmd)
+			}
+		})
+	}
+}
+
+func TestCommandReferencesSensitivePathIgnoresBenignCommands(t *testing.T) {
+	cases := []string{
+		"cat README.md",
+		"ls -la /tmp",
+		"grep TODO src/",
+		"find . -name '*.go'",
+		"cat .env.example", // committed template, not sensitive
+	}
+	for _, cmd := range cases {
+		t.Run(cmd, func(t *testing.T) {
+			if _, _, ok := CommandReferencesSensitivePath(cmd); ok {
+				t.Fatalf("expected %q to be benign", cmd)
+			}
+		})
+	}
+}
+
 func TestIsReadOnlyBashCommandAcceptsCommonReads(t *testing.T) {
 	cases := []string{
 		"pwd",

--- a/internal/runtime/llmproxy/inspector/readonly_bash_test.go
+++ b/internal/runtime/llmproxy/inspector/readonly_bash_test.go
@@ -9,7 +9,10 @@ func TestCommandReferencesSensitivePathFlagsCommonSecrets(t *testing.T) {
 	}{
 		{"cat home ssh key", "cat ~/.ssh/id_rsa"},
 		{"cat absolute ssh key", "cat /Users/eric/.ssh/id_ed25519"},
+		{"cat home expansion ssh key", "cat $HOME/.ssh/id_rsa"},
+		{"cat braced home expansion ssh key", "cat ${HOME}/.ssh/id_ed25519"},
 		{"head .env", "head -n 5 .env"},
+		{"rg option value env file", "rg --ignore-file=.env SECRET ."},
 		{"grep over aws dir", "grep -R access_key ~/.aws"},
 		{"cat pem", "cat certs/tls.pem"},
 		{"cat netrc", "cat ~/.netrc"},

--- a/internal/runtime/llmproxy/postprocess.go
+++ b/internal/runtime/llmproxy/postprocess.go
@@ -538,6 +538,17 @@ func Postprocess(req *http.Request, body []byte, contentType string, cfg Postpro
 				if toolnames.IsShellToolName(tu.Name) && readOnlyShellCommandsAllowed(tu.Name, cfg.AgentID, cfg.ToolRules) {
 					if cmd := shellCommandFromInput(tu.Input); cmd != "" {
 						readOnlyShellCommand, _ = inspector.IsReadOnlyBashCommand(cmd)
+						if readOnlyShellCommand && toolnames.SensitiveFileGuardEnabled(tu.Name, cfg.AgentID, cfg.ToolRules) {
+							// A read-only command that reads a sensitive
+							// path (SSH key, .env, cloud creds) must NOT
+							// ride the readonly_shell_pass_through bypass.
+							// Force fall-through to task-scope matching
+							// and intent verification.
+							if tok, reason, hit := inspector.CommandReferencesSensitivePath(cmd); hit {
+								readOnlyShellCommand = false
+								audit("block", "sensitive_path_in_read_only_shell", "command references sensitive path "+tok+" ("+reason+")")
+							}
+						}
 					}
 				}
 				decisionInput := runtimedecision.AuthorizationInput{

--- a/internal/runtime/llmproxy/postprocess.go
+++ b/internal/runtime/llmproxy/postprocess.go
@@ -533,24 +533,27 @@ func Postprocess(req *http.Request, body []byte, contentType string, cfg Postpro
 		// is no credential rewrite to perform, but shared authorization
 		// still sees ordinary tool_use calls such as Bash/Read.
 		if v.Source == inspector.SourceTriggerMiss {
-			if cfg.CandidateTasks != nil || cfg.ToolRules != nil || cfg.EgressRules != nil {
-				readOnlyShellCommand := false
-				if toolnames.IsShellToolName(tu.Name) && readOnlyShellCommandsAllowed(tu.Name, cfg.AgentID, cfg.ToolRules) {
-					if cmd := shellCommandFromInput(tu.Input); cmd != "" {
-						readOnlyShellCommand, _ = inspector.IsReadOnlyBashCommand(cmd)
-						if readOnlyShellCommand && toolnames.SensitiveFileGuardEnabled(tu.Name, cfg.AgentID, cfg.ToolRules) {
-							// A read-only command that reads a sensitive
-							// path (SSH key, .env, cloud creds) must NOT
-							// ride the readonly_shell_pass_through bypass.
-							// Force fall-through to task-scope matching
-							// and intent verification.
-							if tok, reason, hit := inspector.CommandReferencesSensitivePath(cmd); hit {
-								readOnlyShellCommand = false
-								audit("block", "sensitive_path_in_read_only_shell", "command references sensitive path "+tok+" ("+reason+")")
-							}
+			readOnlyShellCommand := false
+			sensitiveShellPath := false
+			if toolnames.IsShellToolName(tu.Name) && readOnlyShellCommandsAllowed(tu.Name, cfg.AgentID, cfg.ToolRules) {
+				if cmd := shellCommandFromInput(tu.Input); cmd != "" {
+					readOnlyShellCommand, _ = inspector.IsReadOnlyBashCommand(cmd)
+					if toolnames.SensitiveFileGuardEnabled(tu.Name, cfg.AgentID, cfg.ToolRules) {
+						// A shell command that references a sensitive path
+						// (SSH key, .env, cloud creds) must NOT ride the
+						// generic trigger-miss pass-through or the
+						// readonly_shell_pass_through bypass. Force
+						// fall-through to task-scope matching and intent
+						// verification.
+						if tok, reason, hit := inspector.CommandReferencesSensitivePath(cmd); hit {
+							sensitiveShellPath = true
+							readOnlyShellCommand = false
+							audit("block", "sensitive_path_in_read_only_shell", "command references sensitive path "+tok+" ("+reason+")")
 						}
 					}
 				}
+			}
+			if cfg.CandidateTasks != nil || cfg.ToolRules != nil || cfg.EgressRules != nil || sensitiveShellPath {
 				decisionInput := runtimedecision.AuthorizationInput{
 					ToolUse:                tu,
 					UserID:                 cfg.AgentUserID,

--- a/internal/runtime/llmproxy/postprocess_test.go
+++ b/internal/runtime/llmproxy/postprocess_test.go
@@ -253,6 +253,32 @@ func TestPostprocess_ReadOnlyBashBypassesTaskScopeByDefault(t *testing.T) {
 	}
 }
 
+func TestPostprocess_SensitiveShellPathRequiresApprovalWithoutPolicyConfig(t *testing.T) {
+	body := anthropicJSONWithNamedToolUse("Bash", `{"command":"cat $HOME/.ssh/id_rsa"}`)
+	req := httptest.NewRequest("POST", "/v1/messages", nil)
+	insp := inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{})
+	st, userID, agentID := seedPostprocessStore(t, "autovault_github_xxx")
+
+	got := Postprocess(req, body, "application/json", PostprocessConfig{
+		Inspector:        insp,
+		RewriteOpts:      inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
+		CallerNonces:     NewMemoryCallerNonceCache(time.Minute),
+		Store:            st,
+		AgentUserID:      userID,
+		AgentID:          agentID,
+		Audit:            NewAuditEmitter(st, nil, nil),
+		RequestID:        "req-bash-sensitive-default",
+		PendingApprovals: NewMemoryPendingApprovalCache(time.Minute),
+		Posture:          runtimedecision.PostureEnforce,
+	})
+	if !got.Rewritten {
+		t.Fatalf("sensitive shell path should require approval even without policy config")
+	}
+	if text := anthropicResponseText(t, got.Body); !strings.Contains(text, "no matching task scope") {
+		t.Fatalf("approval prompt missing scope reason: %s", text)
+	}
+}
+
 func TestPostprocess_ReadOnlyBashCanBeDisabledByPolicy(t *testing.T) {
 	body := anthropicJSONWithNamedToolUse("Bash", `{"command":"ls -la /tmp"}`)
 	req := httptest.NewRequest("POST", "/v1/messages", nil)

--- a/internal/runtime/policy/global_rules.go
+++ b/internal/runtime/policy/global_rules.go
@@ -61,7 +61,7 @@ func MatchRuntimePolicyTool(rules []*store.RuntimePolicyRule, agentID, toolName 
 		if rule == nil || rule.Kind != "tool" || !toolNamesMatch(rule.ToolName, toolName) {
 			return false, 0, nil
 		}
-		if toolnames.IsReadOnlyShellSettingRule(rule) {
+		if toolnames.IsReadOnlyShellSettingRule(rule) || toolnames.IsSensitiveFileGuardSettingRule(rule) {
 			return false, 0, nil
 		}
 		if rule.InputRegex != "" {

--- a/internal/runtime/policy/global_rules_test.go
+++ b/internal/runtime/policy/global_rules_test.go
@@ -78,3 +78,40 @@ func TestMatchRuntimePolicyToolIgnoresReadOnlyShellSettingMarker(t *testing.T) {
 		t.Fatalf("read-only shell marker must not act as a normal tool allow rule, got %+v", got)
 	}
 }
+
+func TestMatchRuntimePolicyToolIgnoresSensitiveFileGuardMarker(t *testing.T) {
+	agentID := "agent-1"
+	// Cover both the enabled (deny) and disabled (allow) marker actions:
+	// neither must surface as a normal authorization decision for any
+	// same-class tool call.
+	for _, action := range []string{"deny", "allow"} {
+		t.Run(action, func(t *testing.T) {
+			rules := []*store.RuntimePolicyRule{{
+				ID:         "sensitive-file-guard-marker",
+				AgentID:    &agentID,
+				Kind:       "tool",
+				Action:     action,
+				ToolName:   "Bash",
+				InputShape: toolnames.SensitiveFileGuardSettingInputShape(),
+				Source:     toolnames.SensitiveFileGuardSettingSource,
+				Enabled:    true,
+			}}
+			// A normal Bash call (no marker key) must not be matched.
+			got, err := MatchRuntimePolicyTool(rules, agentID, "Bash", map[string]any{"command": "ls"})
+			if err != nil {
+				t.Fatalf("MatchRuntimePolicyTool: %v", err)
+			}
+			if got != nil {
+				t.Fatalf("sensitive-file-guard marker must not authorize ordinary tool calls, got %+v", got)
+			}
+			// And a probe carrying the marker key itself must also be ignored.
+			got, err = MatchRuntimePolicyTool(rules, agentID, "Bash", map[string]any{toolnames.SensitiveFileGuardSettingShapeKey: true})
+			if err != nil {
+				t.Fatalf("MatchRuntimePolicyTool: %v", err)
+			}
+			if got != nil {
+				t.Fatalf("sensitive-file-guard marker must not act as a normal tool rule, got %+v", got)
+			}
+		})
+	}
+}

--- a/pkg/runtime/proxy/tool_defaults.go
+++ b/pkg/runtime/proxy/tool_defaults.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/clawvisor/clawvisor/pkg/runtime/sensitivepaths"
 	"github.com/clawvisor/clawvisor/pkg/runtime/toolnames"
 	"github.com/clawvisor/clawvisor/pkg/store"
 )
@@ -17,18 +18,18 @@ type sessionToolDefaults struct {
 	ToolAllowedRoots []string `json:"tool_allowed_roots"`
 }
 
-func allowSessionScopedToolDefault(session *store.RuntimeSession, toolName string, input map[string]any) (string, bool) {
+func allowSessionScopedToolDefault(session *store.RuntimeSession, toolName string, input map[string]any, sensitiveFileGuardEnabled bool) (string, bool) {
 	defaults := sessionToolDefaultsFromSession(session)
 	if !isCodingStarterProfile(defaults.StarterProfile) {
 		return "", false
 	}
 	switch normalizeToolName(toolName) {
 	case "read", "read_file", "mcp__filesystem__read_file":
-		return allowFileToolInRoots(defaults, toolName, input, "read")
+		return allowFileToolInRoots(defaults, toolName, input, "read", sensitiveFileGuardEnabled)
 	case "write", "edit", "notebookedit", "write_file", "edit_file", "mcp__filesystem__write_file", "mcp__filesystem__edit_file":
-		return allowFileToolInRoots(defaults, toolName, input, "write")
+		return allowFileToolInRoots(defaults, toolName, input, "write", sensitiveFileGuardEnabled)
 	case "glob", "grep", "ls":
-		return allowSearchToolInRoots(defaults, toolName, input)
+		return allowSearchToolInRoots(defaults, toolName, input, sensitiveFileGuardEnabled)
 	default:
 		return "", false
 	}
@@ -72,13 +73,22 @@ func normalizeToolName(name string) string {
 	return strings.ToLower(strings.TrimSpace(name))
 }
 
-func allowFileToolInRoots(defaults sessionToolDefaults, toolName string, input map[string]any, mode string) (string, bool) {
+func allowFileToolInRoots(defaults sessionToolDefaults, toolName string, input map[string]any, mode string, sensitiveFileGuardEnabled bool) (string, bool) {
 	paths := referencedToolPaths(defaults, input)
 	if len(paths) == 0 {
 		return "", false
 	}
 	for _, p := range paths {
 		if !pathWithinAnyRoot(p, defaults.ToolAllowedRoots) {
+			return "", false
+		}
+	}
+	// Even inside the workspace, sensitive files (SSH keys, .env,
+	// cloud credentials …) should not auto-allow on the
+	// workspace-root default. Fall through to task scope / intent
+	// verification so the user gets a chance to authorize.
+	if mode == "read" && sensitiveFileGuardEnabled {
+		if _, _, hit := findSensitiveTargetPath(paths); hit {
 			return "", false
 		}
 	}
@@ -89,7 +99,7 @@ func allowFileToolInRoots(defaults sessionToolDefaults, toolName string, input m
 	return fmt.Sprintf("coding default: %s %s inside the current workspace or /tmp", action, summarizePathList(paths)), true
 }
 
-func allowSearchToolInRoots(defaults sessionToolDefaults, toolName string, input map[string]any) (string, bool) {
+func allowSearchToolInRoots(defaults sessionToolDefaults, toolName string, input map[string]any, sensitiveFileGuardEnabled bool) (string, bool) {
 	paths := referencedToolPaths(defaults, input)
 	if len(paths) == 0 {
 		return "coding default: search inside the current workspace", true
@@ -99,7 +109,23 @@ func allowSearchToolInRoots(defaults sessionToolDefaults, toolName string, input
 			return "", false
 		}
 	}
+	// grep/glob over a sensitive directory leaks the same content as
+	// reading the file (`grep -r SECRET ~/.ssh`). Apply the same gate.
+	if sensitiveFileGuardEnabled {
+		if _, _, hit := findSensitiveTargetPath(paths); hit {
+			return "", false
+		}
+	}
 	return fmt.Sprintf("coding default: search %s inside the current workspace or /tmp", summarizePathList(paths)), true
+}
+
+func findSensitiveTargetPath(paths []string) (path, reason string, ok bool) {
+	for _, p := range paths {
+		if reason, ok := sensitivepaths.IsSensitivePath(p); ok {
+			return p, reason, true
+		}
+	}
+	return "", "", false
 }
 
 func referencedToolPaths(defaults sessionToolDefaults, input map[string]any) []string {

--- a/pkg/runtime/proxy/tool_defaults_test.go
+++ b/pkg/runtime/proxy/tool_defaults_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestAllowSessionScopedToolDefaultAllowsWorkspaceRead(t *testing.T) {
 	session := runtimeSessionWithToolRoots(t, "/repo/app", []string{"/repo/app", "/tmp"})
-	reason, ok := allowSessionScopedToolDefault(session, "Read", map[string]any{"file_path": "README.md"})
+	reason, ok := allowSessionScopedToolDefault(session, "Read", map[string]any{"file_path": "README.md"}, true)
 	if !ok {
 		t.Fatal("expected workspace read to be allowed")
 	}
@@ -20,29 +20,70 @@ func TestAllowSessionScopedToolDefaultAllowsWorkspaceRead(t *testing.T) {
 
 func TestAllowSessionScopedToolDefaultAllowsTmpWrite(t *testing.T) {
 	session := runtimeSessionWithToolRoots(t, "/repo/app", []string{"/repo/app", "/tmp"})
-	if _, ok := allowSessionScopedToolDefault(session, "Write", map[string]any{"file_path": "/tmp/demo.txt"}); !ok {
+	if _, ok := allowSessionScopedToolDefault(session, "Write", map[string]any{"file_path": "/tmp/demo.txt"}, true); !ok {
 		t.Fatal("expected /tmp write to be allowed")
 	}
 }
 
 func TestAllowSessionScopedToolDefaultBlocksOutsideRoots(t *testing.T) {
 	session := runtimeSessionWithToolRoots(t, "/repo/app", []string{"/repo/app", "/tmp"})
-	if _, ok := allowSessionScopedToolDefault(session, "Read", map[string]any{"file_path": "/etc/passwd"}); ok {
+	if _, ok := allowSessionScopedToolDefault(session, "Read", map[string]any{"file_path": "/etc/passwd"}, true); ok {
 		t.Fatal("expected outside-root read to require approval")
 	}
 }
 
 func TestAllowSessionScopedToolDefaultAllowsRelativeSearch(t *testing.T) {
 	session := runtimeSessionWithToolRoots(t, "/repo/app", []string{"/repo/app", "/tmp"})
-	if _, ok := allowSessionScopedToolDefault(session, "Glob", map[string]any{"pattern": "**/*.go"}); !ok {
+	if _, ok := allowSessionScopedToolDefault(session, "Glob", map[string]any{"pattern": "**/*.go"}, true); !ok {
 		t.Fatal("expected relative glob search to be allowed")
 	}
 }
 
 func TestAllowSessionScopedToolDefaultBlocksAbsoluteSearchOutsideRoots(t *testing.T) {
 	session := runtimeSessionWithToolRoots(t, "/repo/app", []string{"/repo/app", "/tmp"})
-	if _, ok := allowSessionScopedToolDefault(session, "Glob", map[string]any{"pattern": "/etc/**/*.conf"}); ok {
+	if _, ok := allowSessionScopedToolDefault(session, "Glob", map[string]any{"pattern": "/etc/**/*.conf"}, true); ok {
 		t.Fatal("expected absolute glob outside roots to require approval")
+	}
+}
+
+func TestAllowSessionScopedToolDefaultGatesSensitiveReadInsideWorkspace(t *testing.T) {
+	session := runtimeSessionWithToolRoots(t, "/repo/app", []string{"/repo/app", "/tmp"})
+	if _, ok := allowSessionScopedToolDefault(session, "Read", map[string]any{"file_path": ".env"}, true); ok {
+		t.Fatal("expected .env in workspace to fall through to task scope / approval")
+	}
+	if _, ok := allowSessionScopedToolDefault(session, "Read", map[string]any{"file_path": "secrets/service-account-prod.json"}, true); ok {
+		t.Fatal("expected service-account key to fall through")
+	}
+}
+
+func TestAllowSessionScopedToolDefaultStillAllowsEnvTemplateRead(t *testing.T) {
+	session := runtimeSessionWithToolRoots(t, "/repo/app", []string{"/repo/app", "/tmp"})
+	if _, ok := allowSessionScopedToolDefault(session, "Read", map[string]any{"file_path": ".env.example"}, true); !ok {
+		t.Fatal("expected .env.example template to remain auto-allowed")
+	}
+}
+
+func TestAllowSessionScopedToolDefaultAllowsWritingSensitivePath(t *testing.T) {
+	session := runtimeSessionWithToolRoots(t, "/repo/app", []string{"/repo/app", "/tmp"})
+	if _, ok := allowSessionScopedToolDefault(session, "Write", map[string]any{"file_path": ".env"}, true); !ok {
+		t.Fatal("write to .env should still be allowed (the gate is on reads, not writes)")
+	}
+}
+
+func TestAllowSessionScopedToolDefaultGatesSearchOverSensitiveDir(t *testing.T) {
+	session := runtimeSessionWithToolRoots(t, "/repo/app", []string{"/repo/app", "/tmp"})
+	if _, ok := allowSessionScopedToolDefault(session, "Grep", map[string]any{"path": ".ssh"}, true); ok {
+		t.Fatal("expected grep over a .ssh dir to fall through")
+	}
+}
+
+func TestAllowSessionScopedToolDefaultSkipsSensitiveCheckWhenGuardDisabled(t *testing.T) {
+	session := runtimeSessionWithToolRoots(t, "/repo/app", []string{"/repo/app", "/tmp"})
+	if _, ok := allowSessionScopedToolDefault(session, "Read", map[string]any{"file_path": ".env"}, false); !ok {
+		t.Fatal("expected .env read to auto-allow when guard is disabled")
+	}
+	if _, ok := allowSessionScopedToolDefault(session, "Grep", map[string]any{"path": ".ssh"}, false); !ok {
+		t.Fatal("expected grep over .ssh to auto-allow when guard is disabled")
 	}
 }
 

--- a/pkg/runtime/proxy/tooluse_runtime.go
+++ b/pkg/runtime/proxy/tooluse_runtime.go
@@ -20,6 +20,7 @@ import (
 	runtimedecision "github.com/clawvisor/clawvisor/pkg/runtime/decision"
 	"github.com/clawvisor/clawvisor/pkg/runtime/leases"
 	"github.com/clawvisor/clawvisor/pkg/runtime/review"
+	"github.com/clawvisor/clawvisor/pkg/runtime/toolnames"
 	"github.com/clawvisor/clawvisor/pkg/store"
 )
 
@@ -334,7 +335,8 @@ func (s *Server) handleToolUseBlockedResponse(resp *http.Response, ctx *goproxy.
 				}
 			}
 		}
-		if reason, ok := allowSessionScopedToolDefault(st.Session, tu.Name, input); ok {
+		sensitiveFileGuard := toolnames.SensitiveFileGuardEnabled(tu.Name, st.Session.AgentID, rules)
+		if reason, ok := allowSessionScopedToolDefault(st.Session, tu.Name, input, sensitiveFileGuard); ok {
 			decisionState[key] = toolDecisionState{}
 			return conversation.ToolUseVerdict{Allowed: true, Reason: reason}
 		}

--- a/pkg/runtime/sensitivepaths/sensitivepaths.go
+++ b/pkg/runtime/sensitivepaths/sensitivepaths.go
@@ -1,0 +1,212 @@
+// Package sensitivepaths classifies filesystem paths whose contents
+// are likely to be secrets (SSH keys, cloud credentials, .env files,
+// signing material, …). Callers use it to keep the LLM proxy's
+// permissive default tool-allow paths from silently exposing those
+// files: a positive match should fall through to task-scope matching
+// and human approval, not be auto-allowed.
+//
+// The classifier is intentionally conservative on the side of asking:
+// false positives only trigger an approval prompt, while false
+// negatives leak a secret.
+package sensitivepaths
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// IsSensitivePath reports whether path points at a file whose
+// contents are likely a secret. The matched returned string describes
+// which pattern hit, suitable for inclusion in a user-facing reason.
+func IsSensitivePath(path string) (matched string, ok bool) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", false
+	}
+	cleaned := filepath.Clean(path)
+	base := filepath.Base(cleaned)
+	if reason, ok := matchSensitiveBasename(base); ok {
+		return reason, true
+	}
+	parts := splitPathComponents(cleaned)
+	for i, segment := range parts {
+		if reason, ok := matchSensitiveDirComponent(segment); ok {
+			return reason, true
+		}
+		// Two-segment directory anchors like .config/gcloud or .config/gh.
+		if i+1 < len(parts) {
+			pair := segment + "/" + parts[i+1]
+			if reason, ok := sensitiveDirPairs[pair]; ok {
+				return reason, true
+			}
+		}
+	}
+	return "", false
+}
+
+func matchSensitiveBasename(base string) (string, bool) {
+	if base == "" {
+		return "", false
+	}
+	if envTemplateBasenames[base] {
+		// .env.example and friends are committed templates that name
+		// the keys without holding real secrets. Don't make the agent
+		// ask just to read them.
+		return "", false
+	}
+	if reason, ok := sensitiveBasenames[base]; ok {
+		return reason, true
+	}
+	for prefix, reason := range sensitiveBasenamePrefixes {
+		if strings.HasPrefix(base, prefix) {
+			return reason, true
+		}
+	}
+	lower := strings.ToLower(base)
+	for suffix, reason := range sensitiveBasenameSuffixes {
+		if strings.HasSuffix(lower, suffix) {
+			return reason, true
+		}
+	}
+	return "", false
+}
+
+var envTemplateBasenames = map[string]bool{
+	".env.example":  true,
+	".env.sample":   true,
+	".env.template": true,
+	".env.dist":     true,
+	".env.defaults": true,
+}
+
+func matchSensitiveDirComponent(segment string) (string, bool) {
+	if reason, ok := sensitiveDirComponents[segment]; ok {
+		return reason, true
+	}
+	return "", false
+}
+
+func splitPathComponents(path string) []string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil
+	}
+	// filepath.Clean on POSIX paths leaves "/" as separator; on Windows
+	// it normalizes to backslash. The proxy runs on Linux/macOS, but be
+	// defensive: split on both.
+	replaced := strings.ReplaceAll(path, "\\", "/")
+	parts := strings.Split(replaced, "/")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p == "" || p == "." {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+// Exact-basename matches. These are filenames whose entire purpose is
+// to hold credentials or secrets; reading them should never be silent.
+var sensitiveBasenames = map[string]string{
+	".env":                     ".env file",
+	".envrc":                   ".envrc file",
+	".netrc":                   ".netrc credentials",
+	".npmrc":                   ".npmrc (often contains auth tokens)",
+	".pypirc":                  ".pypirc (PyPI credentials)",
+	".boto":                    ".boto (AWS credentials)",
+	".pgpass":                  ".pgpass (Postgres password file)",
+	".my.cnf":                  ".my.cnf (MySQL credentials)",
+	"credentials":              "credentials file",
+	"credentials.json":         "credentials.json",
+	"service-account.json":     "service-account.json",
+	"id_rsa":                   "SSH private key (id_rsa)",
+	"id_dsa":                   "SSH private key (id_dsa)",
+	"id_ecdsa":                 "SSH private key (id_ecdsa)",
+	"id_ed25519":               "SSH private key (id_ed25519)",
+	"terraform.tfstate":        "terraform.tfstate (may contain secrets)",
+	"terraform.tfstate.backup": "terraform.tfstate.backup",
+}
+
+// Basename prefixes. e.g. .env.local, .env.production, service-account-foo.json.
+var sensitiveBasenamePrefixes = map[string]string{
+	".env.":            "dotenv variant",
+	"service-account-": "service-account key",
+}
+
+// Basename suffixes (case-insensitive). Crypto / key material file
+// extensions. We deliberately skip `.key` alone — too noisy (i18n
+// files, etc.) — and rely on directory + filename matches for SSH keys.
+var sensitiveBasenameSuffixes = map[string]string{
+	".pem":      "PEM-encoded key/cert",
+	".p12":      "PKCS#12 keystore",
+	".pfx":      "PKCS#12 keystore",
+	".jks":      "Java keystore",
+	".keystore": "Java keystore",
+	".asc":      "PGP/GPG armored key",
+}
+
+// Directory components: if a path's resolved components include any
+// of these, the file is treated as sensitive. Matches the directory
+// itself or anything under it.
+var sensitiveDirComponents = map[string]string{
+	".ssh":         "under ~/.ssh",
+	".aws":         "under ~/.aws",
+	".gnupg":       "under ~/.gnupg",
+	".kube":        "under ~/.kube",
+	".gcp":         "under ~/.gcp",
+	".docker":      "under ~/.docker (config.json holds registry auths)",
+	".terraform.d": "under ~/.terraform.d",
+}
+
+// Two-segment ancestor anchors. Useful for paths like ~/.config/gcloud/...
+// where ".config" by itself is not sensitive but ".config/gcloud" is.
+var sensitiveDirPairs = map[string]string{
+	".config/gcloud": "under ~/.config/gcloud",
+	".config/gh":     "under ~/.config/gh",
+	".config/glab":   "under ~/.config/glab",
+	".config/op":     "under ~/.config/op (1Password CLI)",
+}
+
+// FindSensitiveTokenInArgs scans an argv-like list (tokens already
+// split by a shell parser) and returns the first token that classifies
+// as a sensitive path. Returns "" / false if none match.
+//
+// Used by the read-only shell-command pass-through: even when the
+// command is structurally safe (no command substitution, allowlisted
+// binaries only), `cat ~/.ssh/id_rsa` still exposes secrets and should
+// fall through to task-scope matching and intent verification.
+func FindSensitiveTokenInArgs(args []string) (token, reason string, ok bool) {
+	for _, arg := range args {
+		candidate := normalizeShellPathArg(arg)
+		if candidate == "" {
+			continue
+		}
+		if reason, ok := IsSensitivePath(candidate); ok {
+			return arg, reason, true
+		}
+	}
+	return "", "", false
+}
+
+// normalizeShellPathArg expands a leading ~ (the most common form by
+// far) and trims surrounding quotes left over from incomplete shell
+// parsing. We deliberately do NOT expand $VAR — the inspector already
+// rejects command substitution, and unresolved env vars trip the
+// dynamic-command-name guard upstream.
+func normalizeShellPathArg(arg string) string {
+	arg = strings.TrimSpace(arg)
+	if arg == "" {
+		return ""
+	}
+	if (strings.HasPrefix(arg, "\"") && strings.HasSuffix(arg, "\"") && len(arg) >= 2) ||
+		(strings.HasPrefix(arg, "'") && strings.HasSuffix(arg, "'") && len(arg) >= 2) {
+		arg = arg[1 : len(arg)-1]
+	}
+	if strings.HasPrefix(arg, "~/") {
+		arg = arg[2:]
+	} else if arg == "~" {
+		arg = ""
+	}
+	return arg
+}

--- a/pkg/runtime/sensitivepaths/sensitivepaths.go
+++ b/pkg/runtime/sensitivepaths/sensitivepaths.go
@@ -190,10 +190,11 @@ func FindSensitiveTokenInArgs(args []string) (token, reason string, ok bool) {
 }
 
 // normalizeShellPathArg expands a leading ~ (the most common form by
-// far) and trims surrounding quotes left over from incomplete shell
-// parsing. We deliberately do NOT expand $VAR — the inspector already
-// rejects command substitution, and unresolved env vars trip the
-// dynamic-command-name guard upstream.
+// far), trims surrounding quotes left over from incomplete shell
+// parsing, and handles option values like --env-file=.env. We
+// deliberately do NOT expand $VAR — callers that care about shell
+// expansions should pass the rendered shell token through this same
+// classifier so literal sensitive components still match.
 func normalizeShellPathArg(arg string) string {
 	arg = strings.TrimSpace(arg)
 	if arg == "" {
@@ -202,6 +203,11 @@ func normalizeShellPathArg(arg string) string {
 	if (strings.HasPrefix(arg, "\"") && strings.HasSuffix(arg, "\"") && len(arg) >= 2) ||
 		(strings.HasPrefix(arg, "'") && strings.HasSuffix(arg, "'") && len(arg) >= 2) {
 		arg = arg[1 : len(arg)-1]
+	}
+	if strings.HasPrefix(arg, "-") {
+		if _, value, ok := strings.Cut(arg, "="); ok {
+			arg = strings.TrimSpace(value)
+		}
 	}
 	if strings.HasPrefix(arg, "~/") {
 		arg = arg[2:]

--- a/pkg/runtime/sensitivepaths/sensitivepaths_test.go
+++ b/pkg/runtime/sensitivepaths/sensitivepaths_test.go
@@ -1,0 +1,103 @@
+package sensitivepaths
+
+import "testing"
+
+func TestIsSensitivePathClassifiesKnownSecrets(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+	}{
+		{"dotenv at workspace root", "/repo/app/.env"},
+		{"dotenv variant", "/repo/app/.env.production"},
+		{"netrc in home", "/Users/eric/.netrc"},
+		{"npmrc anywhere", "/repo/app/.npmrc"},
+		{"ssh private key by name", "/Users/eric/.ssh/id_rsa"},
+		{"ssh ed25519 key by name", "/Users/eric/.ssh/id_ed25519"},
+		{"sibling of ssh key", "/Users/eric/.ssh/known_hosts"},
+		{"aws credentials directory", "/Users/eric/.aws/credentials"},
+		{"gcloud config", "/Users/eric/.config/gcloud/application_default_credentials.json"},
+		{"gh config", "/Users/eric/.config/gh/hosts.yml"},
+		{"docker config", "/Users/eric/.docker/config.json"},
+		{"PEM in repo", "/repo/app/certs/tls.pem"},
+		{"PKCS#12 keystore", "/repo/keys/store.p12"},
+		{"GPG ascii armored", "/Users/eric/keys/release-signing.asc"},
+		{"service-account-*.json", "/repo/secrets/service-account-prod.json"},
+		{"credentials.json basename", "/repo/app/credentials.json"},
+		{"terraform state", "/repo/infra/terraform.tfstate"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reason, ok := IsSensitivePath(tc.path)
+			if !ok {
+				t.Fatalf("expected %q to be classified sensitive", tc.path)
+			}
+			if reason == "" {
+				t.Fatalf("expected non-empty reason for %q", tc.path)
+			}
+		})
+	}
+}
+
+func TestIsSensitivePathLeavesOrdinaryFilesAlone(t *testing.T) {
+	cases := []string{
+		"/repo/app/README.md",
+		"/repo/app/main.go",
+		"/repo/app/locales/en.key", // bare .key extension — false positive avoided
+		"/repo/app/.gitignore",
+		"/repo/app/src/.eslintrc",
+		"/repo/app/.env.example",              // committed template
+		"/repo/app/.env.sample",               // committed template
+		"/repo/app/config/client.env.example", // not even a .env variant
+		"/repo/app/docs/.config/notes.md",     // .config alone isn't sensitive
+		"",
+	}
+	for _, path := range cases {
+		t.Run(path, func(t *testing.T) {
+			if reason, ok := IsSensitivePath(path); ok {
+				t.Fatalf("expected %q to be non-sensitive, got %q", path, reason)
+			}
+		})
+	}
+}
+
+func TestIsSensitivePathHandlesRelativeAndDirtyPaths(t *testing.T) {
+	cases := []string{
+		".env",
+		"./.env.local",
+		"sub/dir/../.ssh/id_rsa",
+		"  /repo/app/.env  ",
+	}
+	for _, path := range cases {
+		t.Run(path, func(t *testing.T) {
+			if _, ok := IsSensitivePath(path); !ok {
+				t.Fatalf("expected %q to be sensitive after cleaning", path)
+			}
+		})
+	}
+}
+
+func TestFindSensitiveTokenInArgsFindsSshKey(t *testing.T) {
+	tok, reason, ok := FindSensitiveTokenInArgs([]string{"cat", "~/.ssh/id_rsa"})
+	if !ok {
+		t.Fatal("expected ~/.ssh/id_rsa to be flagged")
+	}
+	if tok == "" || reason == "" {
+		t.Fatalf("expected non-empty token+reason, got token=%q reason=%q", tok, reason)
+	}
+}
+
+func TestFindSensitiveTokenInArgsIgnoresBenignTokens(t *testing.T) {
+	if _, _, ok := FindSensitiveTokenInArgs([]string{"ls", "-la", "/tmp"}); ok {
+		t.Fatal("expected benign args to be ignored")
+	}
+}
+
+func TestSensitivePathReasonMentionsCategory(t *testing.T) {
+	reason, ok := IsSensitivePath("/Users/eric/.ssh/id_rsa")
+	if !ok {
+		t.Fatal("expected ssh key to be sensitive")
+	}
+	if reason == "" {
+		t.Fatal("expected non-empty reason")
+	}
+}

--- a/pkg/runtime/sensitivepaths/sensitivepaths_test.go
+++ b/pkg/runtime/sensitivepaths/sensitivepaths_test.go
@@ -86,6 +86,16 @@ func TestFindSensitiveTokenInArgsFindsSshKey(t *testing.T) {
 	}
 }
 
+func TestFindSensitiveTokenInArgsFindsOptionValuePath(t *testing.T) {
+	tok, reason, ok := FindSensitiveTokenInArgs([]string{"rg", "--ignore-file=.env"})
+	if !ok {
+		t.Fatal("expected --ignore-file=.env to be flagged")
+	}
+	if tok != "--ignore-file=.env" || reason == "" {
+		t.Fatalf("expected original token and reason, got token=%q reason=%q", tok, reason)
+	}
+}
+
 func TestFindSensitiveTokenInArgsIgnoresBenignTokens(t *testing.T) {
 	if _, _, ok := FindSensitiveTokenInArgs([]string{"ls", "-la", "/tmp"}); ok {
 		t.Fatal("expected benign args to be ignored")

--- a/pkg/runtime/toolnames/toolnames.go
+++ b/pkg/runtime/toolnames/toolnames.go
@@ -8,9 +8,11 @@ import (
 )
 
 const (
-	ShellClass                   = "shell"
-	ReadOnlyShellSettingSource   = "readonly_shell_setting"
-	ReadOnlyShellSettingShapeKey = "clawvisor_readonly_shell_setting"
+	ShellClass                        = "shell"
+	ReadOnlyShellSettingSource        = "readonly_shell_setting"
+	ReadOnlyShellSettingShapeKey      = "clawvisor_readonly_shell_setting"
+	SensitiveFileGuardSettingSource   = "sensitive_file_guard_setting"
+	SensitiveFileGuardSettingShapeKey = "clawvisor_sensitive_file_guard_setting"
 )
 
 func IsShellToolName(name string) bool {
@@ -51,4 +53,74 @@ func IsReadOnlyShellSettingRule(rule *store.RuntimePolicyRule) bool {
 
 func ReadOnlyShellSettingInputShape() json.RawMessage {
 	return json.RawMessage(`{"` + ReadOnlyShellSettingShapeKey + `":true}`)
+}
+
+// IsSensitiveFileGuardSettingRule reports whether a rule is the
+// marker for the sensitive-file-guard toggle (see ListToolControls).
+func IsSensitiveFileGuardSettingRule(rule *store.RuntimePolicyRule) bool {
+	return rule != nil &&
+		rule.Kind == "tool" &&
+		strings.EqualFold(strings.TrimSpace(rule.Source), SensitiveFileGuardSettingSource)
+}
+
+// SensitiveFileGuardSettingInputShape is the shape used to fingerprint
+// the marker rule so it never matches normal authorization checks.
+func SensitiveFileGuardSettingInputShape() json.RawMessage {
+	return json.RawMessage(`{"` + SensitiveFileGuardSettingShapeKey + `":true}`)
+}
+
+// IsSensitiveFileGuardableTool reports whether the sensitive-file-guard
+// toggle is meaningful for this tool. The guard fires on file reads
+// (Read/Glob/Grep/LS variants) and on shell commands that touch
+// sensitive paths.
+func IsSensitiveFileGuardableTool(name string) bool {
+	if IsShellToolName(name) {
+		return true
+	}
+	switch ToolClass(name) {
+	case "read_file":
+		return true
+	}
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "glob", "grep", "ls", "mcp__filesystem__read_file":
+		return true
+	}
+	return false
+}
+
+// SensitiveFileGuardEnabled resolves whether the guard is on for a
+// given tool + agent, given the current rule set. Default ON when no
+// marker rule is present. Agent-scoped overrides win over global.
+//
+// Marker rule action convention:
+//
+//	allow  → guard DISABLED (file reads ride existing auto-allow paths)
+//	deny   → guard ENABLED  (sensitive paths fall through to approval)
+func SensitiveFileGuardEnabled(toolName, agentID string, rules []*store.RuntimePolicyRule) bool {
+	if !IsSensitiveFileGuardableTool(toolName) {
+		return false
+	}
+	global := true
+	var agentOverride *bool
+	for _, rule := range rules {
+		if rule == nil || !rule.Enabled || !IsSensitiveFileGuardSettingRule(rule) {
+			continue
+		}
+		if !ToolNamesSameClass(rule.ToolName, toolName) {
+			continue
+		}
+		enabled := !strings.EqualFold(strings.TrimSpace(rule.Action), "allow")
+		if rule.AgentID != nil {
+			if strings.TrimSpace(*rule.AgentID) == strings.TrimSpace(agentID) {
+				v := enabled
+				agentOverride = &v
+			}
+			continue
+		}
+		global = enabled
+	}
+	if agentOverride != nil {
+		return *agentOverride
+	}
+	return global
 }

--- a/pkg/runtime/toolnames/toolnames_test.go
+++ b/pkg/runtime/toolnames/toolnames_test.go
@@ -1,0 +1,87 @@
+package toolnames
+
+import (
+	"testing"
+
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+func TestIsSensitiveFileGuardableTool(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"Bash", true},
+		{"shell", true},
+		{"Read", true},
+		{"read_file", true},
+		{"Glob", true},
+		{"Grep", true},
+		{"LS", true},
+		{"WebFetch", false},
+		{"Write", false},
+		{"unknown_tool", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsSensitiveFileGuardableTool(tc.name); got != tc.want {
+				t.Fatalf("IsSensitiveFileGuardableTool(%q) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSensitiveFileGuardEnabledDefaultsOn(t *testing.T) {
+	if !SensitiveFileGuardEnabled("Read", "agent-1", nil) {
+		t.Fatal("expected guard to default ON when no marker rule")
+	}
+}
+
+func TestSensitiveFileGuardEnabledRespectsGlobalOff(t *testing.T) {
+	rules := []*store.RuntimePolicyRule{
+		guardMarkerRule(t, "Read", nil, "allow"),
+	}
+	if SensitiveFileGuardEnabled("Read", "agent-1", rules) {
+		t.Fatal("expected global allow marker to disable guard")
+	}
+}
+
+func TestSensitiveFileGuardEnabledAgentOverrideWinsOverGlobal(t *testing.T) {
+	agentID := "agent-1"
+	rules := []*store.RuntimePolicyRule{
+		guardMarkerRule(t, "Read", nil, "allow"),     // global: off
+		guardMarkerRule(t, "Read", &agentID, "deny"), // agent: on
+	}
+	if !SensitiveFileGuardEnabled("Read", agentID, rules) {
+		t.Fatal("expected agent-scoped deny to win over global allow")
+	}
+}
+
+func TestSensitiveFileGuardEnabledMatchesByClass(t *testing.T) {
+	// A rule keyed to "Bash" should apply to any shell-class tool.
+	rules := []*store.RuntimePolicyRule{
+		guardMarkerRule(t, "Bash", nil, "allow"),
+	}
+	if SensitiveFileGuardEnabled("shell", "agent-1", rules) {
+		t.Fatal("expected shell tool to inherit Bash marker disable")
+	}
+}
+
+func TestSensitiveFileGuardEnabledReturnsFalseForNonGuardableTool(t *testing.T) {
+	if SensitiveFileGuardEnabled("WebFetch", "agent-1", nil) {
+		t.Fatal("non-guardable tool should not be gated")
+	}
+}
+
+func guardMarkerRule(t *testing.T, toolName string, agentID *string, action string) *store.RuntimePolicyRule {
+	t.Helper()
+	return &store.RuntimePolicyRule{
+		Kind:       "tool",
+		Action:     action,
+		ToolName:   toolName,
+		AgentID:    agentID,
+		Source:     SensitiveFileGuardSettingSource,
+		InputShape: SensitiveFileGuardSettingInputShape(),
+		Enabled:    true,
+	}
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -760,6 +760,12 @@ export interface RuntimeToolControl {
   global_read_only_commands_rule_id?: string
   agent_read_only_commands_allowed?: boolean
   agent_read_only_commands_rule_id?: string
+  sensitive_file_guard_applies?: boolean
+  sensitive_file_guard_enabled?: boolean
+  global_sensitive_file_guard_enabled?: boolean
+  global_sensitive_file_guard_rule_id?: string
+  agent_sensitive_file_guard_enabled?: boolean
+  agent_sensitive_file_guard_rule_id?: string
   last_seen_at?: string
   advanced_rule_count: number
   advanced_rules?: RuntimePolicyRule[]
@@ -1326,7 +1332,7 @@ export const api = {
       }),
     listToolControls: (agentId: string) =>
       get<{ entries: RuntimeToolControl[]; total: number }>('/api/runtime/tool-controls', { agent_id: agentId }),
-    updateToolControl: (control: { agent_id: string; tool_name: string; action?: 'unset' | 'allow' | 'deny'; scope?: 'global' | 'agent'; read_only_commands_allowed?: boolean }) =>
+    updateToolControl: (control: { agent_id: string; tool_name: string; action?: 'unset' | 'allow' | 'deny'; scope?: 'global' | 'agent'; read_only_commands_allowed?: boolean; sensitive_file_guard_enabled?: boolean }) =>
       put<RuntimeToolControl>('/api/runtime/tool-controls', control),
     createRule: (rule: Partial<RuntimePolicyRule> & { scope?: 'agent' | 'global' }) =>
       post<RuntimePolicyRule>('/api/runtime/rules', rule),

--- a/web/src/pages/Restrictions.tsx
+++ b/web/src/pages/Restrictions.tsx
@@ -387,7 +387,7 @@ export default function Policy() {
     onSuccess: refreshRuntime,
   })
   const updateToolControlMut = useMutation({
-    mutationFn: (control: { agent_id: string; tool_name: string; action?: 'unset' | 'allow' | 'deny'; scope: 'global' | 'agent'; read_only_commands_allowed?: boolean }) => api.runtime.updateToolControl(control),
+    mutationFn: (control: { agent_id: string; tool_name: string; action?: 'unset' | 'allow' | 'deny'; scope: 'global' | 'agent'; read_only_commands_allowed?: boolean; sensitive_file_guard_enabled?: boolean }) => api.runtime.updateToolControl(control),
     onSuccess: refreshRuntime,
   })
 
@@ -493,6 +493,7 @@ export default function Policy() {
               busy={updateToolControlMut.isPending}
               onChange={(toolName, action, scope) => updateToolControlMut.mutate({ agent_id: agentFilter, tool_name: toolName, action, scope })}
               onReadOnlyCommandsChange={(toolName, allowed, scope) => updateToolControlMut.mutate({ agent_id: agentFilter, tool_name: toolName, read_only_commands_allowed: allowed, scope })}
+              onSensitiveFileGuardChange={(toolName, enabled, scope) => updateToolControlMut.mutate({ agent_id: agentFilter, tool_name: toolName, sensitive_file_guard_enabled: enabled, scope })}
               ruleBusy={createRuleMut.isPending || updateRuleMut.isPending}
               onSaveRule={async (draft) => {
                 if (draft.id) await updateRuleMut.mutateAsync(draft)
@@ -605,6 +606,7 @@ function ProxyLiteToolControlsPanel({
   busy,
   onChange,
   onReadOnlyCommandsChange,
+  onSensitiveFileGuardChange,
   ruleBusy,
   onSaveRule,
   onToggleAdvanced,
@@ -618,6 +620,7 @@ function ProxyLiteToolControlsPanel({
   busy: boolean
   onChange: (toolName: string, action: 'unset' | 'allow' | 'deny', scope: 'global' | 'agent') => void
   onReadOnlyCommandsChange: (toolName: string, allowed: boolean, scope: 'global' | 'agent') => void
+  onSensitiveFileGuardChange: (toolName: string, enabled: boolean, scope: 'global' | 'agent') => void
   ruleBusy: boolean
   onSaveRule: (draft: RuleDraft) => Promise<void>
   onToggleAdvanced: (rule: RuntimePolicyRule) => void
@@ -625,7 +628,7 @@ function ProxyLiteToolControlsPanel({
 }) {
   const needsAgent = agentId === 'all'
   const globalControls = controls.filter(control =>
-    isShellLikeToolName(control.tool_name) || !!control.global_rule_id || (control.advanced_rules ?? []).some(rule => !rule.agent_id),
+    isShellLikeToolName(control.tool_name) || control.sensitive_file_guard_applies || !!control.global_rule_id || (control.advanced_rules ?? []).some(rule => !rule.agent_id),
   )
   const agentSelector = (
     <div className="flex items-center gap-2">
@@ -696,6 +699,7 @@ function ProxyLiteToolControlsPanel({
             ruleBusy={ruleBusy}
             onChange={onChange}
             onReadOnlyCommandsChange={onReadOnlyCommandsChange}
+            onSensitiveFileGuardChange={onSensitiveFileGuardChange}
             onSaveRule={onSaveRule}
             onToggleAdvanced={onToggleAdvanced}
             onDeleteAdvanced={onDeleteAdvanced}
@@ -713,6 +717,7 @@ function ProxyLiteToolControlsPanel({
             ruleBusy={ruleBusy}
             onChange={onChange}
             onReadOnlyCommandsChange={onReadOnlyCommandsChange}
+            onSensitiveFileGuardChange={onSensitiveFileGuardChange}
             onSaveRule={onSaveRule}
             onToggleAdvanced={onToggleAdvanced}
             onDeleteAdvanced={onDeleteAdvanced}
@@ -736,6 +741,7 @@ function ToolControlListSection({
   ruleBusy,
   onChange,
   onReadOnlyCommandsChange,
+  onSensitiveFileGuardChange,
   onSaveRule,
   onToggleAdvanced,
   onDeleteAdvanced,
@@ -752,6 +758,7 @@ function ToolControlListSection({
   ruleBusy: boolean
   onChange: (toolName: string, action: 'unset' | 'allow' | 'deny', scope: 'global' | 'agent') => void
   onReadOnlyCommandsChange: (toolName: string, allowed: boolean, scope: 'global' | 'agent') => void
+  onSensitiveFileGuardChange: (toolName: string, enabled: boolean, scope: 'global' | 'agent') => void
   onSaveRule: (draft: RuleDraft) => Promise<void>
   onToggleAdvanced: (rule: RuntimePolicyRule) => void
   onDeleteAdvanced: (rule: RuntimePolicyRule) => void
@@ -783,6 +790,7 @@ function ToolControlListSection({
               ruleBusy={ruleBusy}
               onChange={onChange}
               onReadOnlyCommandsChange={onReadOnlyCommandsChange}
+              onSensitiveFileGuardChange={onSensitiveFileGuardChange}
               onSaveRule={onSaveRule}
               onToggleAdvanced={onToggleAdvanced}
               onDeleteAdvanced={onDeleteAdvanced}
@@ -804,6 +812,7 @@ function ToolControlRow({
   ruleBusy,
   onChange,
   onReadOnlyCommandsChange,
+  onSensitiveFileGuardChange,
   onSaveRule,
   onToggleAdvanced,
   onDeleteAdvanced,
@@ -817,17 +826,19 @@ function ToolControlRow({
   ruleBusy: boolean
   onChange: (toolName: string, action: 'unset' | 'allow' | 'deny', scope: 'global' | 'agent') => void
   onReadOnlyCommandsChange: (toolName: string, allowed: boolean, scope: 'global' | 'agent') => void
+  onSensitiveFileGuardChange: (toolName: string, enabled: boolean, scope: 'global' | 'agent') => void
   onSaveRule: (draft: RuleDraft) => Promise<void>
   onToggleAdvanced: (rule: RuntimePolicyRule) => void
   onDeleteAdvanced: (rule: RuntimePolicyRule) => void
 }) {
   const [inlineDraft, setInlineDraft] = useState<RuleDraft | null>(null)
   const shellLike = isShellLikeToolName(control.tool_name)
+  const guardApplies = !!control.sensitive_file_guard_applies
   const advancedRules = (control.advanced_rules ?? []).filter(rule =>
     sectionScope === 'global' ? !rule.agent_id : !!rule.agent_id,
   )
   const action = sectionScope === 'global' ? control.global_action : control.agent_action
-  const showSimpleControl = sectionScope === 'agent' || shellLike || !!control.global_rule_id || advancedRules.length > 0
+  const showSimpleControl = sectionScope === 'agent' || shellLike || guardApplies || !!control.global_rule_id || advancedRules.length > 0
   if (!showSimpleControl && advancedRules.length === 0) return null
   const scopeLabel = sectionScope === 'global'
     ? control.global_rule_id ? 'Global policy' : 'No global policy'
@@ -838,6 +849,12 @@ function ToolControlRow({
   const readOnlyCommandsExplicit = sectionScope === 'global'
     ? control.global_read_only_commands_allowed !== undefined
     : control.agent_read_only_commands_allowed !== undefined
+  const sensitiveGuardEnabled = sectionScope === 'global'
+    ? control.global_sensitive_file_guard_enabled ?? true
+    : control.agent_sensitive_file_guard_enabled ?? control.global_sensitive_file_guard_enabled ?? true
+  const sensitiveGuardExplicit = sectionScope === 'global'
+    ? control.global_sensitive_file_guard_enabled !== undefined
+    : control.agent_sensitive_file_guard_enabled !== undefined
   return (
     <div className="p-4">
       <div className="flex flex-wrap items-center justify-between gap-3">
@@ -886,6 +903,28 @@ function ToolControlRow({
           </div>
           <span className={`rounded px-2 py-0.5 text-xs ${readOnlyCommandsAllowed ? 'bg-success/15 text-success' : 'bg-warning/15 text-warning'}`}>
             {readOnlyCommandsAllowed ? 'allowed' : 'reviewed'}
+          </span>
+        </div>
+      )}
+
+      {guardApplies && showSimpleControl && (
+        <div className="mt-3 flex flex-wrap items-center justify-between gap-3 rounded border border-border-subtle bg-surface-1 px-3 py-2">
+          <div>
+            <label className="flex items-center gap-2 text-sm text-text-primary">
+              <input
+                type="checkbox"
+                checked={sensitiveGuardEnabled}
+                disabled={busy}
+                onChange={e => onSensitiveFileGuardChange(control.tool_name, e.target.checked, sectionScope)}
+              />
+              Require approval to read sensitive files
+            </label>
+            <div className="mt-1 text-xs text-text-tertiary">
+              {sensitiveGuardExplicit ? 'Explicit policy' : 'Default on'} · routes reads of .env, ~/.ssh, ~/.aws, *.pem and similar through task scope / approval.
+            </div>
+          </div>
+          <span className={`rounded px-2 py-0.5 text-xs ${sensitiveGuardEnabled ? 'bg-warning/15 text-warning' : 'bg-success/15 text-success'}`}>
+            {sensitiveGuardEnabled ? 'guarded' : 'allowed'}
           </span>
         </div>
       )}


### PR DESCRIPTION
Adds a sensitive-file guard for runtime tool defaults so reads of .env files, SSH keys, cloud credentials, key material, and similar paths fall through to task scope or approval instead of silent auto-allow. Adds marker-rule based API support and dashboard controls to enable or disable the guard globally or per agent, while keeping marker rules out of normal authorization matching. Extends read-only shell handling to stop pass-through for commands that reference sensitive paths and adds a shared sensitive path classifier. Tests cover guard resolution, API toggles, runtime defaults, policy marker exclusion, shell command detection, and sensitive path classification.