### PR TITLE
fix(mcp): support numeric JSON timeout in tools exec proxy

### DIFF
--- a/internal/mcp/tools_exec.go
+++ b/internal/mcp/tools_exec.go
@@ -116,8 +116,14 @@ func buildInternalRequest(toolName string, arguments json.RawMessage) (internalR
 			return ""
 		}
 		var s string
-		json.Unmarshal(v, &s)
-		return s
+		if err := json.Unmarshal(v, &s); err == nil {
+			return s
+		}
+		var n json.Number
+		if err := json.Unmarshal(v, &n); err == nil {
+			return n.String()
+		}
+		return ""
 	}
 
 	switch toolName {

--- a/internal/mcp/tools_exec_test.go
+++ b/internal/mcp/tools_exec_test.go
@@ -88,6 +88,18 @@ func TestBuildInternalRequest_TimeoutParam(t *testing.T) {
 			wantContains: "timeout=120",
 		},
 		{
+			name:         "integer timeout value",
+			toolName:     "gateway_request",
+			extraArgs:    map[string]any{"wait": true, "timeout": 60},
+			wantContains: "timeout=60",
+		},
+		{
+			name:         "integer timeout get_task",
+			toolName:     "get_task",
+			extraArgs:    map[string]any{"task_id": "123", "wait": true, "timeout": 45},
+			wantContains: "timeout=45",
+		},
+		{
 			name:        "injection via ampersand in timeout",
 			toolName:    "gateway_request",
 			extraArgs:   map[string]any{"wait": true, "timeout": "120&admin=true"},


### PR DESCRIPTION
### Description
This PR resolves an issue where the `timeout` parameter passed by compliant MCP clients/agents was silently dropped by the tools execution proxy (`internal/mcp/tools_exec.go`).

### Root Cause
1. Standard MCP tools schemas (e.g. `create_task`, `gateway_request`, `get_task`, `expand_task`) define the `timeout` parameter as an `integer`.
2. The proxy logic extracted this using a local `getString` helper, which performed a standard `json.Unmarshal(v, &s)` into a `string` variable.
3. This unmarshal failed with `json: cannot unmarshal number into Go value of type string` when an integer was passed. The error was silently ignored, returning an empty string and preventing the timeout parameter from being appended to the internal wait query.
4. Existing tests missed this because they passed the timeout parameter as a string (`"120"`), which masked the type mismatch.

### Solution
1. Updated the `getString` argument extraction helper in `tools_exec.go` to fall back to `json.Number` unmarshaling if string unmarshaling fails. This seamlessly supports standard numeric integers/floats while maintaining backward compatibility for string-typed inputs.
2. Added new unit test cases to `tools_exec_test.go` verifying that real JSON integers (`60` and `45`) are successfully parsed and included in the resulting wait query string.
3. Ran `go test ./internal/mcp` and verified all tests pass.