### PR TITLE
refactor(ui): standardize user-facing terminology from 'Services' to 'Accounts'

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ The web UI provides:
 
 - **Overview** — pending approvals queue, activity charts, and notification setup
 - **Tasks** — view active/standing tasks, approve/deny/revoke task scopes, filterable by status
-- **Services** — activate services via OAuth (Google) or API key (GitHub, Slack, Notion, etc.), re-authenticate, manage aliases
+- **Accounts** — activate integrations/accounts via OAuth (Google) or API key (GitHub, Slack, Notion, etc.), re-authenticate, manage aliases
 - **Restrictions** — toggle hard blocks on service/action pairs
 - **Agents** — create agent tokens, manage connection requests
 - **Gateway log** — searchable audit trail of every gateway request with outcomes and verification results

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -428,7 +428,7 @@ The frontend is a React 18 SPA built with Vite, TypeScript, Tailwind CSS, and sh
 
 - **Overview**: Pending approval count, quick actions
 - **Tasks**: Active/standing/pending tasks with approval controls, scope expansion management
-- **Services**: Activation status for all adapters, OAuth popup flow for Google, token input for API key services, deactivation
+- **Accounts**: Activation status for all adapters, OAuth popup flow for Google, token input for API key services, deactivation
 - **Restrictions**: Create and manage hard blocks on service/action pairs
 - **Agents**: Create agent tokens (shown once), delete agents
 - **Audit Log**: Searchable, filterable history of every gateway request

--- a/docs/GOOGLE_OAUTH_SETUP.md
+++ b/docs/GOOGLE_OAUTH_SETUP.md
@@ -81,7 +81,7 @@ export GOOGLE_CLIENT_SECRET="your-client-secret"
 ## 6. Connect your account
 
 1. Start Clawvisor: `CONFIG_FILE="$HOME/.clawvisor/config.yaml" make run`
-2. Open the dashboard and go to **Services**
+2. Open the dashboard and go to **Accounts**
 3. Click **Connect** next to Google
 4. You'll be redirected to Google's consent screen — authorize with your account
 5. You may see a "This app isn't verified" warning — click **Advanced** then

--- a/docs/INTEGRATE_CLAUDE_CODE.md
+++ b/docs/INTEGRATE_CLAUDE_CODE.md
@@ -123,7 +123,7 @@ curl -sf -H "Authorization: Bearer $CLAWVISOR_AGENT_TOKEN" \
   "$CLAWVISOR_URL/api/skill/catalog" | head -20
 ```
 
-This should return a JSON catalog of available services. If it returns a 401,
+This should return a JSON catalog of available tools. If it returns a 401,
 the token is invalid. If it fails to connect, `CLAWVISOR_URL` is wrong or the
 server isn't running.
 
@@ -154,7 +154,7 @@ Explain how it works:
   to check status, then call `POST /api/gateway/request/{request_id}/execute`.
 
 Remind the user to:
-- Connect services in the Clawvisor dashboard under the **Services** tab
+- Connect accounts in the Clawvisor dashboard under the **Accounts** tab
   before asking Claude to use them
 - Approve tasks in the dashboard (or via Telegram) when Claude requests them
 - Optionally set restrictions in the dashboard to hard-block specific actions

--- a/docs/INTEGRATE_CLAUDE_CODE.md
+++ b/docs/INTEGRATE_CLAUDE_CODE.md
@@ -123,7 +123,7 @@ curl -sf -H "Authorization: Bearer $CLAWVISOR_AGENT_TOKEN" \
   "$CLAWVISOR_URL/api/skill/catalog" | head -20
 ```
 
-This should return a JSON catalog of available tools. If it returns a 401,
+This should return a JSON catalog of available services. If it returns a 401,
 the token is invalid. If it fails to connect, `CLAWVISOR_URL` is wrong or the
 server isn't running.
 

--- a/docs/INTEGRATE_CLAUDE_COWORK.md
+++ b/docs/INTEGRATE_CLAUDE_COWORK.md
@@ -111,7 +111,7 @@ issues." Claude should create a task, prompt for approval, and execute
 through Clawvisor.
 
 You can also call the `fetch_catalog` MCP tool directly to confirm the
-connection is working. It should return the list of available tools. If
+connection is working. It should return the list of available services. If
 it returns an auth error, repeat Step 5. If it fails to connect, the
 connector points at the wrong instance or Clawvisor isn't running — ask the
 user to check.

--- a/docs/INTEGRATE_CLAUDE_COWORK.md
+++ b/docs/INTEGRATE_CLAUDE_COWORK.md
@@ -90,14 +90,14 @@ If the OAuth flow does not complete:
 
 ---
 
-## Step 6: Connect services
+## Step 6: Connect accounts
 
-Before Claude can use a service, it must be activated in Clawvisor. Direct
+Before Claude can use an integration, it must be connected in Clawvisor. Direct
 the user to:
 
 1. Open the Clawvisor dashboard
-2. Go to the **Services** tab
-3. Connect the services they want Claude to access (Gmail, GitHub, Slack, etc.)
+2. Go to the **Accounts** tab
+3. Connect the accounts they want Claude to access (Gmail, GitHub, Slack, etc.)
 
 Each service has its own OAuth flow or API key configuration.
 
@@ -111,7 +111,7 @@ issues." Claude should create a task, prompt for approval, and execute
 through Clawvisor.
 
 You can also call the `fetch_catalog` MCP tool directly to confirm the
-connection is working. It should return the list of available services. If
+connection is working. It should return the list of available tools. If
 it returns an auth error, repeat Step 5. If it fails to connect, the
 connector points at the wrong instance or Clawvisor isn't running — ask the
 user to check.
@@ -140,7 +140,7 @@ Explain how it works:
 - All actions are logged in the audit trail. Credentials never leave Clawvisor.
 
 Remind the user to:
-- Connect services in the Clawvisor dashboard under the **Services** tab
+- Connect accounts in the Clawvisor dashboard under the **Accounts** tab
   before asking Claude to use them
 - Approve tasks in the dashboard (or via Telegram) when Claude requests them
 - Optionally set restrictions in the dashboard to hard-block specific actions

--- a/docs/INTEGRATE_OPENCLAW.md
+++ b/docs/INTEGRATE_OPENCLAW.md
@@ -241,9 +241,9 @@ Webhook:    clawvisor-webhook plugin enabled
 
 Remind the user to:
 - If Google services were configured, connect their Google account under
-  the Services tab (one OAuth connection covers Gmail, Calendar, Drive, and
+  the Accounts tab (one OAuth connection covers Gmail, Calendar, Drive, and
   Contacts)
 - For non-OAuth services (GitHub, Slack, Notion, etc.), activate them
-  under the Services tab using API keys
+  under the Accounts tab using API keys
 - Restart OpenClaw if it was already running so it picks up the new
   `.env` values and webhook plugin

--- a/docs/LITE_PROXY.md
+++ b/docs/LITE_PROXY.md
@@ -188,7 +188,7 @@ The agent never sees the real PAT. The user pastes the placeholder once; Clawvis
 
 Two paths:
 
-- **Dashboard.** Open the Services page → connect the service (vaults the real credential). Then the "Shadow Tokens" panel → pick an agent + service → "Mint token". Copy the `autovault_…` string.
+- **Dashboard.** Open the Accounts page → connect the account (vaults the real credential). Then the "Shadow Tokens" panel → pick an agent + integration/account → "Mint token". Copy the `autovault_…` string.
 - **API.** `POST /api/runtime/placeholders/mint` with `{"agent_id": "...", "service": "github"}`. Returns the placeholder.
 
 The `secret_vault` feature flag controls the Shadow Tokens UI visibility. Lite-proxy alone is enough to surface it; you don't need to also enable the runtime proxy:

--- a/docs/SETUP_CLOUD.md
+++ b/docs/SETUP_CLOUD.md
@@ -335,7 +335,7 @@ To connect:  ssh -L 25297:localhost:25297 user@<server-ip>
 ```
 
 Remind the user to:
-- Connect services under the **Services** tab:
+- Connect accounts under the **Accounts** tab:
   - Google (Gmail, Calendar, Drive, Contacts) — one OAuth connection covers
     all four
   - GitHub, Slack, Notion, Linear, Stripe, Twilio — activate with API

--- a/docs/SETUP_DOCKER.md
+++ b/docs/SETUP_DOCKER.md
@@ -182,7 +182,7 @@ To stop:  docker compose -f deploy/docker-compose.yml down
 
 Remind the user to:
 - Open the magic link to access the dashboard
-- Connect services under the **Services** tab:
+- Connect accounts under the **Accounts** tab:
   - Google (Gmail, Calendar, Drive, Contacts) — one OAuth connection covers
     all four. Requires Google OAuth credentials from Step 3.
   - GitHub, Slack, Notion, Linear, Stripe, Twilio — activate with API

--- a/docs/SETUP_LOCAL.md
+++ b/docs/SETUP_LOCAL.md
@@ -212,7 +212,7 @@ To stop:    Ctrl+C in the server terminal
 
 Remind the user to:
 - Open the magic link to access the dashboard
-- Connect services under the **Services** tab:
+- Connect accounts under the **Accounts** tab:
   - Google (Gmail, Calendar, Drive, Contacts) — one OAuth connection covers
     all four. Requires Google OAuth credentials set via env vars — see
     [GOOGLE_OAUTH_SETUP.md](GOOGLE_OAUTH_SETUP.md).

--- a/skills/clawvisor-generate-integration.md
+++ b/skills/clawvisor-generate-integration.md
@@ -65,4 +65,4 @@ Tell the user:
 1. The file path where it was saved
 2. How many actions were generated
 3. What auth setup is needed (e.g. "Set ACME_CLIENT_ID env var" or "Paste your API key when connecting")
-4. That they can connect the service on the Clawvisor dashboard Services page
+4. That they can connect the integration on the Clawvisor dashboard Accounts page

--- a/skills/clawvisor/README.md
+++ b/skills/clawvisor/README.md
@@ -30,7 +30,7 @@ Or deploy to Cloud Run — see `deploy/` in the repository.
 **2. Set up your account**
 
 Open http://localhost:25297, register, then:
-- **Services** → connect Google (covers Gmail, Calendar, Drive, Contacts) and/or GitHub
+- **Accounts** → connect Google (covers Gmail, Calendar, Drive, Contacts) and/or GitHub
 - **Agents** → create an agent, copy the token
 - **Policies** → optionally add policies to control what the agent can do
 

--- a/web/src/components/OnboardingBanner.tsx
+++ b/web/src/components/OnboardingBanner.tsx
@@ -30,7 +30,7 @@ export default function OnboardingBanner() {
   if (hasService && hasAgent) return null
 
   const missing: string[] = []
-  if (!hasService) missing.push('a service')
+  if (!hasService) missing.push('an account')
   if (!hasAgent) missing.push('an agent')
   const missingText = missing.join(' and ')
 

--- a/web/src/pages/AdapterGen.tsx
+++ b/web/src/pages/AdapterGen.tsx
@@ -250,7 +250,7 @@ function DocsTab() {
       <p className="text-xs text-text-tertiary">
         Claude will research the API docs, generate the integration YAML with risk classification, and save it to{' '}
         <code className="px-1 py-0.5 rounded bg-surface-2 font-mono">~/.clawvisor/adapters/</code>.
-        The integration will appear on the Services page immediately.
+        The integration will appear on the Accounts page immediately.
       </p>
     </div>
   )
@@ -366,7 +366,7 @@ export default function AdapterGen() {
             <div className="flex gap-4">
               <div className="flex-1">
                 <label className="block text-xs font-medium text-text-secondary mb-1">
-                  Service ID <span className="text-text-tertiary">(optional)</span>
+                  Adapter ID <span className="text-text-tertiary">(optional)</span>
                 </label>
                 <input
                   type="text"

--- a/web/src/pages/Agents.tsx
+++ b/web/src/pages/Agents.tsx
@@ -1232,7 +1232,7 @@ function LegacyOtherAgentGuide({ setupURL, clawvisorURL, copied, onCopy }: {
               <p className="text-sm font-medium text-text-primary">Verify</p>
               <CodeBlock>{`curl -sf -H "Authorization: Bearer $CLAWVISOR_AGENT_TOKEN" \\\n  "$CLAWVISOR_URL/api/skill/catalog" | head -20`}</CodeBlock>
               <p className="text-xs text-text-tertiary">
-                Should return a JSON catalog of available tools. See{' '}
+                Should return a JSON catalog of available services. See{' '}
                 <code className="font-mono text-text-secondary">{clawvisorURL}/skill/SKILL.md</code>{' '}
                 for the full protocol reference.
               </p>
@@ -2870,7 +2870,7 @@ client = OpenAI(
                   <p className="text-sm font-medium text-text-primary">Verify</p>
                   <CodeBlock>{`curl -sf -H "Authorization: Bearer $CLAWVISOR_AGENT_TOKEN" \\\n  "$CLAWVISOR_URL/api/skill/catalog" | head -20`}</CodeBlock>
                   <p className="text-xs text-text-tertiary">
-                    Should return a JSON catalog of available tools. See{' '}
+                    Should return a JSON catalog of available services. See{' '}
                     <code className="font-mono text-text-secondary">{clawvisorURL}/skill/SKILL.md</code>{' '}
                     for the full protocol reference.
                   </p>

--- a/web/src/pages/Agents.tsx
+++ b/web/src/pages/Agents.tsx
@@ -130,7 +130,7 @@ export default function Agents() {
     <div className="p-4 sm:p-8 space-y-8">
       <h1 className="text-2xl font-bold text-text-primary">Agents</h1>
       <p className="text-sm text-text-tertiary">
-        An agent is any AI system (Claude, a custom bot, etc.) that you want to give controlled access to your services.
+        An agent is any AI system (Claude, a custom bot, etc.) that you want to give controlled access to your accounts.
         Each agent gets a unique token — paste it into your agent's configuration to connect it to Clawvisor.
       </p>
 
@@ -466,11 +466,11 @@ function AgentPolicyPanel({
     <section className="rounded border border-border-subtle bg-surface-1 p-5 space-y-4">
       <div>
         <h2 className="text-lg font-semibold text-text-primary">Applied Policy</h2>
-        <p className="text-sm text-text-tertiary mt-1">Current starter profile, service presets, and effective runtime restrictions for this agent.</p>
+        <p className="text-sm text-text-tertiary mt-1">Current starter profile, account presets, and effective runtime restrictions for this agent.</p>
       </div>
       <div className="grid gap-3 md:grid-cols-3">
         <AgentMetric label="Starter profile" value={starterProfile === 'none' ? 'None' : starterProfile} />
-        <AgentMetric label="Service presets" value={String(inferredPresets.size)} />
+        <AgentMetric label="Account presets" value={String(inferredPresets.size)} />
         <AgentMetric label="Effective runtime rules" value={String(rules.length)} />
       </div>
       <div className="grid gap-4 md:grid-cols-2">
@@ -478,7 +478,7 @@ function AgentPolicyPanel({
           <div className="text-sm font-medium text-text-primary">Presets</div>
           <div className="mt-2 space-y-2 text-sm text-text-secondary">
             <div>Harness profile: <span className="text-text-primary">{starterProfile === 'none' ? 'None' : starterProfile}</span></div>
-            <div>Service presets: <span className="text-text-primary">{inferredPresets.size === 0 ? 'None detected' : Array.from(inferredPresets).join(', ')}</span></div>
+            <div>Account presets: <span className="text-text-primary">{inferredPresets.size === 0 ? 'None detected' : Array.from(inferredPresets).join(', ')}</span></div>
           </div>
         </div>
         <div className="rounded border border-border-subtle bg-surface-0 p-4">
@@ -1076,7 +1076,7 @@ function LegacyClaudeDesktopGuide({ isLocal, onCopy }: { isLocal: boolean; onCop
             Clawvisor — e.g. "check my Gmail" or "list my GitHub issues." Claude will create a task,
             ask you to approve, and execute through Clawvisor.{' '}
             {isLocal &&
-              <>Open the dashboard with <code className="font-mono text-text-secondary">clawvisor tui</code> or visit <code className="font-mono text-text-secondary">http://localhost:25297</code> to manage services, approvals, and restrictions.</>
+              <>Open the dashboard with <code className="font-mono text-text-secondary">clawvisor tui</code> or visit <code className="font-mono text-text-secondary">http://localhost:25297</code> to manage accounts, approvals, and restrictions.</>
             }
           </p>
         </div>
@@ -1232,7 +1232,7 @@ function LegacyOtherAgentGuide({ setupURL, clawvisorURL, copied, onCopy }: {
               <p className="text-sm font-medium text-text-primary">Verify</p>
               <CodeBlock>{`curl -sf -H "Authorization: Bearer $CLAWVISOR_AGENT_TOKEN" \\\n  "$CLAWVISOR_URL/api/skill/catalog" | head -20`}</CodeBlock>
               <p className="text-xs text-text-tertiary">
-                Should return a JSON catalog of available services. See{' '}
+                Should return a JSON catalog of available tools. See{' '}
                 <code className="font-mono text-text-secondary">{clawvisorURL}/skill/SKILL.md</code>{' '}
                 for the full protocol reference.
               </p>
@@ -2262,7 +2262,7 @@ function ClaudeDesktopGuide({ clawvisorURL, llmBaseURL, claim, newToken, isLocal
                 Clawvisor — e.g. "check my Gmail" or "list my GitHub issues." Claude will create a task,
                 ask you to approve, and execute through Clawvisor.{' '}
                 {isLocal &&
-                  <>Open the dashboard with <code className="font-mono text-text-secondary">clawvisor tui</code> or visit <code className="font-mono text-text-secondary">http://localhost:25297</code> to manage services, approvals, and restrictions.</>
+                  <>Open the dashboard with <code className="font-mono text-text-secondary">clawvisor tui</code> or visit <code className="font-mono text-text-secondary">http://localhost:25297</code> to manage accounts, approvals, and restrictions.</>
                 }
               </p>
             </div>
@@ -2870,7 +2870,7 @@ client = OpenAI(
                   <p className="text-sm font-medium text-text-primary">Verify</p>
                   <CodeBlock>{`curl -sf -H "Authorization: Bearer $CLAWVISOR_AGENT_TOKEN" \\\n  "$CLAWVISOR_URL/api/skill/catalog" | head -20`}</CodeBlock>
                   <p className="text-xs text-text-tertiary">
-                    Should return a JSON catalog of available services. See{' '}
+                    Should return a JSON catalog of available tools. See{' '}
                     <code className="font-mono text-text-secondary">{clawvisorURL}/skill/SKILL.md</code>{' '}
                     for the full protocol reference.
                   </p>

--- a/web/src/pages/Audit.tsx
+++ b/web/src/pages/Audit.tsx
@@ -16,7 +16,7 @@ function escapeCsvField(value: string): string {
 }
 
 function entriesToCsv(entries: AuditEntry[]): string {
-  const headers = ['Timestamp', 'Service', 'Action', 'Decision', 'Outcome', 'Duration (ms)', 'Reason', 'Data Origin', 'Error', 'Policy', 'Safety Flagged', 'Safety Reason', 'Request ID']
+  const headers = ['Timestamp', 'Account', 'Action', 'Decision', 'Outcome', 'Duration (ms)', 'Reason', 'Data Origin', 'Error', 'Policy', 'Safety Flagged', 'Safety Reason', 'Request ID']
   const rows = entries.map(e => [
     e.timestamp,
     serviceName(e.service),
@@ -51,7 +51,7 @@ const ACTIVITY_TYPES = [
   { value: 'runtime_egress', label: 'Runtime egress' },
   { value: 'runtime_tool_use', label: 'Runtime tool use' },
   { value: 'runtime', label: 'Other runtime activity' },
-  { value: 'service', label: 'Service activity' },
+  { value: 'service', label: 'Account activity' },
 ] as const
 
 const OUTCOME_STYLE: Record<string, string> = {
@@ -373,7 +373,7 @@ function CreateRuleModal({
 
         {!isRuntimeRule && (
           <div className="rounded border border-border-subtle bg-surface-0 p-3 text-sm text-text-secondary">
-            This activity currently creates a service restriction entry. Runtime allow / review / deny actions are only available for runtime egress and tool-use rows.
+            This activity currently creates an account restriction entry. Runtime allow / review / deny actions are only available for runtime egress and tool-use rows.
           </div>
         )}
 
@@ -915,7 +915,7 @@ export default function Activity() {
         <input
           value={serviceFilter}
           onChange={e => { setServiceFilter(e.target.value); setOffset(0) }}
-          placeholder="Filter by service…"
+          placeholder="Filter by account…"
           className="text-sm rounded border border-border-default bg-surface-0 text-text-primary px-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-brand/30 focus:border-brand placeholder:text-text-tertiary"
         />
       </div>

--- a/web/src/pages/GetStarted.tsx
+++ b/web/src/pages/GetStarted.tsx
@@ -51,7 +51,7 @@ function LoadingState() {
           <h2 className="text-xl font-semibold text-text-primary">Checking your setup&hellip;</h2>
         </div>
         <div className="grid gap-3 sm:grid-cols-2">
-          <SkeletonCard label="Services" />
+          <SkeletonCard label="Accounts" />
           <SkeletonCard label="Agents" />
         </div>
       </section>
@@ -123,7 +123,7 @@ function Hero({
         <p className="text-sm text-text-tertiary">Loading your setup&hellip;</p>
       ) : ready ? (
         <p className="text-sm text-text-tertiary">
-          {services.length} service{services.length === 1 ? '' : 's'} connected · {agents.length}{' '}
+          {services.length} account{services.length === 1 ? '' : 's'} connected · {agents.length}{' '}
           agent{agents.length === 1 ? '' : 's'} registered
         </p>
       ) : null}
@@ -153,7 +153,7 @@ function SetupSteps({
       </p>
 
       <div className="space-y-3">
-        <SetupStepCard num={1} done={hasService} title="Connect a service" loading={isLoading}>
+        <SetupStepCard num={1} done={hasService} title="Connect an account" loading={isLoading}>
           <p className="text-sm text-text-secondary mb-3">
             Link an API like Gmail, GitHub, Slack, or Linear so your agents have something to act
             on. Credentials stay in Clawvisor's vault — agents never see them.
@@ -171,7 +171,7 @@ function SetupSteps({
                 to="/dashboard/accounts"
                 className="inline-flex items-center gap-1 text-sm font-medium text-brand hover:text-brand-strong px-3 py-1.5 rounded-md border border-brand/40 bg-brand-muted transition-colors"
               >
-                Browse all services
+                Browse all integrations
                 <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
                   <path d="M9 5l7 7-7 7" />
                 </svg>
@@ -326,7 +326,7 @@ function YourSetupSection({ services, agents }: { services: WelcomeService[]; ag
       <div className="grid gap-4 md:grid-cols-2">
         <div className="rounded-lg border border-border-subtle bg-surface-1 p-4">
           <div className="flex items-baseline justify-between mb-3">
-            <h3 className="font-medium text-text-primary">Services</h3>
+            <h3 className="font-medium text-text-primary">Accounts</h3>
             <Link to="/dashboard/accounts" className="text-xs text-brand hover:text-brand-strong font-medium">
               Manage →
             </Link>

--- a/web/src/pages/OAuthAuthorize.tsx
+++ b/web/src/pages/OAuthAuthorize.tsx
@@ -105,7 +105,7 @@ export default function OAuthAuthorize() {
         <div className="bg-surface-2 border border-border-strong rounded-md p-4 mb-6">
           <p className="text-sm text-text-secondary mb-2">This will allow the application to:</p>
           <ul className="text-sm text-text-secondary space-y-1">
-            <li>View your service catalog</li>
+            <li>View your account catalog</li>
             <li>Create and manage tasks</li>
             <li>Make gateway requests (subject to your approval settings)</li>
           </ul>

--- a/web/src/pages/OrgAdapters.tsx
+++ b/web/src/pages/OrgAdapters.tsx
@@ -23,7 +23,7 @@ export default function OrgAdapters() {
       </h2>
       <p className="text-sm text-text-secondary">
         Register custom HTTP API adapters for your organization's internal APIs.
-        Service IDs must start with <code className="font-mono text-xs bg-surface-0 px-1 rounded">custom.</code>
+        Adapter IDs must start with <code className="font-mono text-xs bg-surface-0 px-1 rounded">custom.</code>
       </p>
 
       <div className="space-y-2">

--- a/web/src/pages/Restrictions.tsx
+++ b/web/src/pages/Restrictions.tsx
@@ -430,8 +430,8 @@ export default function Policy() {
             {proxyLiteOnly
               ? 'Configure harness tool access and connected account restrictions.'
               : runtimePolicyUI || servicePresetsUI
-                ? 'Configure presets, runtime rules, defaults, and legacy service restrictions from one control surface.'
-              : 'Configure service restrictions for your connected adapters and integrations.'}
+                ? 'Configure presets, runtime rules, defaults, and legacy account restrictions from one control surface.'
+                : 'Configure account restrictions for your connected adapters and integrations.'}
           </p>
         </div>
       </div>
@@ -1121,13 +1121,13 @@ function AccountControlsPanel({
 
       {!isLoading && allServices.length === 0 && (
         <div className="text-sm text-text-tertiary py-8 text-center">
-          No services registered. Add adapters in the server configuration to manage policy.
+          No integrations registered. Add adapters in the server configuration to manage policy.
         </div>
       )}
 
       {!isLoading && allServices.length > 0 && activated.length === 0 && (
         <div className="text-sm text-text-tertiary py-8 text-center">
-          Activate a service first to manage account controls.{' '}
+          Connect an account first to manage controls.{' '}
           <Link to="/dashboard/accounts" className="text-brand hover:underline">Go to Accounts</Link>
         </div>
       )}
@@ -1149,7 +1149,7 @@ function AccountControlsPanel({
             onClick={onToggleShowAll}
             className="text-sm text-text-tertiary hover:text-text-primary"
           >
-            {showAll ? 'Hide unactivated services' : `Show all services (${unactivated.length} not activated)`}
+            {showAll ? 'Hide unactivated integrations' : `Show all integrations (${unactivated.length} not activated)`}
           </button>
           {showAll && (
             <div className="space-y-4 opacity-50">
@@ -1585,7 +1585,7 @@ function PolicyRulesPanel({
   onDeleteRule: (rule: RuntimePolicyRule) => void
 }) {
   const tabs: Array<{ id: 'service' | 'egress' | 'tool'; label: string; count: number }> = [
-    { id: 'service', label: 'Service', count: serviceRuleCount },
+    { id: 'service', label: 'Account', count: serviceRuleCount },
     ...(runtimePolicyUI
       ? [
           { id: 'egress' as const, label: 'Egress', count: egressRuleCount },
@@ -1601,8 +1601,8 @@ function PolicyRulesPanel({
           <h2 className="text-lg font-semibold text-text-primary">Rules</h2>
           <p className="text-sm text-text-tertiary mt-1">
             {runtimePolicyUI
-              ? 'Switch between service, egress, and tool policy without bouncing across separate sections.'
-              : 'Manage service-level policy for connected adapters and integrations.'}
+              ? 'Switch between account, egress, and tool policy without bouncing across separate sections.'
+              : 'Manage account-level policy for connected adapters and integrations.'}
           </p>
         </div>
         <div className="inline-flex rounded-lg border border-border-default bg-surface-0 p-1">
@@ -1718,7 +1718,7 @@ function ServicePresetsPanel({
     <section className="rounded-md border border-border-default bg-surface-1 p-5 space-y-4">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div>
-          <h2 className="text-lg font-semibold text-text-primary">Service Presets</h2>
+          <h2 className="text-lg font-semibold text-text-primary">Account Presets</h2>
           <p className="text-sm text-text-tertiary mt-1">
             Apply narrow allowlists for common integrations without hand-authoring every runtime rule.
           </p>

--- a/web/src/pages/Services.tsx
+++ b/web/src/pages/Services.tsx
@@ -288,7 +288,7 @@ function LegacyVaultInventorySection({
       <div className="space-y-2">
         {activeServices.length === 0 && (
           <div className="rounded border border-dashed border-border-default bg-surface-0 px-4 py-6 text-sm text-text-tertiary">
-            No connected services yet.
+            No connected accounts yet.
           </div>
         )}
         {activeServices.map(service => (
@@ -355,7 +355,7 @@ function ShadowTokensSection({
   return (
     <AccountSection
       title="Shadow Tokens"
-      description="Mint revocable shadow tokens for a specific agent and connected service. Agents can use these placeholders in config or prompts without ever seeing the real credential."
+      description="Mint revocable shadow tokens for a specific agent and connected account. Agents can use these placeholders in config or prompts without ever seeing the real credential."
     >
       <div className="grid gap-3 md:grid-cols-[1fr_1fr_auto]">
         <select
@@ -373,7 +373,7 @@ function ShadowTokensSection({
           onChange={e => setServiceId(e.target.value)}
           className="rounded border border-border-default bg-surface-0 px-3 py-2 text-sm text-text-primary"
         >
-          <option value="">Choose connected service</option>
+          <option value="">Choose connected account</option>
           {tokenServices.map(service => {
             const value = service.alias ? `${service.id}:${service.alias}` : service.id
             return (
@@ -445,12 +445,12 @@ function CredentialActivitySection({ entries }: { entries: AuditEntry[] }) {
   return (
     <AccountSection
       title="Credential Activity"
-      description="Recent account and credential-related activity touching your connected services."
+      description="Recent account and credential-related activity touching your connected accounts."
     >
       <div className="space-y-2">
         {entries.length === 0 && (
           <div className="rounded border border-dashed border-border-default bg-surface-0 px-4 py-6 text-sm text-text-tertiary">
-            No recent service activity.
+            No recent account activity.
           </div>
         )}
         {entries.map(entry => (
@@ -598,13 +598,13 @@ function VaultServiceActions({ svc }: { svc: ServiceInfo }) {
       const { affected_task_count } = await api.services.deactivatePreflight(svc.id, alias)
       const name = serviceName(svc.id, svc.alias)
       const taskWarning = affected_task_count > 0
-        ? `\n\nThis will revoke ${affected_task_count} active task${affected_task_count === 1 ? '' : 's'} that use${affected_task_count === 1 ? 's' : ''} this service.`
+        ? `\n\nThis will revoke ${affected_task_count} active task${affected_task_count === 1 ? '' : 's'} that use${affected_task_count === 1 ? 's' : ''} this account.`
         : ''
       if (!confirm(`Disconnect ${name}? Your agents will lose access.${taskWarning}`)) return
       await api.services.deactivate(svc.id, alias)
       refreshAccountData()
     } catch (e: any) {
-      setError(e.message ?? 'Failed to disconnect service')
+      setError(e.message ?? 'Failed to disconnect account')
     }
   }
 
@@ -966,13 +966,13 @@ function ActiveServiceRow({ svc }: { svc: ServiceInfo }) {
       const { affected_task_count } = await api.services.deactivatePreflight(svc.id, alias)
       const name = serviceName(svc.id, svc.alias)
       const taskWarning = affected_task_count > 0
-        ? `\n\nThis will revoke ${affected_task_count} active task${affected_task_count === 1 ? '' : 's'} that use${affected_task_count === 1 ? 's' : ''} this service.`
+        ? `\n\nThis will revoke ${affected_task_count} active task${affected_task_count === 1 ? '' : 's'} that use${affected_task_count === 1 ? 's' : ''} this account.`
         : ''
       if (!confirm(`Deactivate ${name}? Your agents will lose access.${taskWarning}`)) return
       await api.services.deactivate(svc.id, alias)
       qc.invalidateQueries({ queryKey: ['services'] })
     } catch (e: any) {
-      setError(e.message ?? 'Failed to deactivate service')
+      setError(e.message ?? 'Failed to deactivate account')
     }
   }
 
@@ -1337,7 +1337,7 @@ function AddServiceModal({
       qc.invalidateQueries({ queryKey: ['services'] })
       onSuccess(serviceId)
     } catch (e: any) {
-      setError(e.message ?? 'Failed to activate service')
+      setError(e.message ?? 'Failed to activate account')
     }
   }
 
@@ -1497,7 +1497,7 @@ function AddServiceModal({
       {/* Modal */}
       <div className="relative bg-surface-1 border border-border-default rounded-lg w-full max-w-2xl mx-4 max-h-[80vh] flex flex-col shadow-xl">
         <div className="flex items-center justify-between px-6 py-4 border-b border-border-default">
-          <h2 className="text-lg font-semibold text-text-primary">Connect a service</h2>
+          <h2 className="text-lg font-semibold text-text-primary">Connect an account</h2>
           <button
             onClick={onClose}
             className="text-text-tertiary hover:text-text-primary text-xl leading-none"
@@ -1511,7 +1511,7 @@ function AddServiceModal({
             type="text"
             value={search}
             onChange={e => setSearch(e.target.value)}
-            placeholder="Search services..."
+            placeholder="Search accounts..."
             className="w-full text-sm px-3 py-2 border border-border-default bg-surface-0 text-text-primary rounded-lg focus:outline-none focus:ring-1 focus:ring-brand/30 focus:border-brand placeholder:text-text-tertiary"
             autoFocus
           />
@@ -1757,7 +1757,7 @@ function AddServiceModal({
           </div>
 
           {serviceTypes.length === 0 && (
-            <p className="text-sm text-text-tertiary py-4">No services available.</p>
+            <p className="text-sm text-text-tertiary py-4">No accounts available.</p>
           )}
         </div>
       </div>
@@ -1781,7 +1781,7 @@ function OrgServicesView({ orgId, orgName }: { orgId: string; orgName: string })
       <div>
         <h1 className="text-2xl font-bold text-text-primary">{orgName} Accounts</h1>
         <p className="text-sm text-text-tertiary mt-1">
-          Org-wide shared credentials and per-user service activation.
+          Org-wide shared credentials and per-user account activation.
         </p>
       </div>
 
@@ -1804,7 +1804,7 @@ function OrgServicesView({ orgId, orgName }: { orgId: string; orgName: string })
         ))}
         {services.length === 0 && (
           <div className="text-sm text-text-tertiary py-8 text-center">
-            No services configured for this organization.
+            No accounts configured for this organization.
           </div>
         )}
       </div>
@@ -2092,7 +2092,7 @@ export default function Services() {
             onClick={() => setShowModal(true)}
             className="px-4 py-2 rounded-md bg-brand text-surface-0 text-sm font-medium hover:bg-brand-strong shadow-sm"
           >
-            Connect service
+            Connect account
           </button>
         </div>
       </div>
@@ -2118,7 +2118,7 @@ export default function Services() {
           <div>
             <p className="text-sm font-medium text-text-primary">Google OAuth not configured</p>
             <p className="text-xs text-text-secondary mt-0.5">
-              Google services (Gmail, Calendar, Drive, Contacts) require OAuth credentials.{' '}
+              Google accounts (Gmail, Calendar, Drive, Contacts) require OAuth credentials.{' '}
               <a href="/dashboard/settings" className="text-brand hover:underline">Go to Settings</a>{' '}
               to configure your Google Client ID and Client Secret.
             </p>
@@ -2132,7 +2132,7 @@ export default function Services() {
           <div>
             <p className="text-sm font-medium text-text-primary">Microsoft OAuth not configured</p>
             <p className="text-xs text-text-secondary mt-0.5">
-              Microsoft services (Outlook, OneDrive, Teams) require OAuth credentials.{' '}
+              Microsoft accounts (Outlook, OneDrive, Teams) require OAuth credentials.{' '}
               <a href="/dashboard/settings" className="text-brand hover:underline">Go to Settings</a>{' '}
               to configure your Microsoft Client ID and Client Secret.
             </p>
@@ -2141,7 +2141,7 @@ export default function Services() {
       )}
 
       {isLoading && <div className="text-sm text-text-tertiary">Loading…</div>}
-      {error && <div className="text-sm text-danger">Failed to load services.</div>}
+      {error && <div className="text-sm text-danger">Failed to load accounts.</div>}
 
       {!orgId && !isLoading && !error && (
         <>
@@ -2182,7 +2182,7 @@ export default function Services() {
             </svg>
           </div>
           <div className="text-center">
-            <p className="text-sm font-medium text-text-primary">Connect your first service</p>
+            <p className="text-sm font-medium text-text-primary">Connect your first account</p>
             <p className="text-xs text-text-tertiary mt-0.5">Slack, GitHub, Gmail, and more</p>
           </div>
         </button>

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -403,7 +403,7 @@ function OAuthCredentialsSection() {
       <div>
         <h2 className="text-lg font-semibold text-text-primary">OAuth Credentials</h2>
         <p className="text-sm text-text-tertiary mt-0.5">
-          Configure OAuth app credentials for services that require browser-based authorization.
+          Configure OAuth app credentials for accounts that require browser-based authorization.
         </p>
       </div>
 
@@ -1745,7 +1745,7 @@ function DaemonCard({ daemon, onDelete, deleting, enabledServiceIds }: {
       {daemon.connected && services.length > 0 && (
         <div className="mt-4 pt-4 border-t border-border-default">
           <div className="flex items-center justify-between mb-3">
-            <p className="text-xs font-medium text-text-secondary uppercase tracking-wide">Services</p>
+            <p className="text-xs font-medium text-text-secondary uppercase tracking-wide">Accounts</p>
             <button
               onClick={() => navigate('/dashboard/accounts')}
               className="text-xs text-brand hover:underline"


### PR DESCRIPTION
**Background**
During user onboarding, the term "Services" was causing confusion since it overloaded several concepts (external API connections vs. local OS daemon background services). To make the dashboard more intuitive for new users, this PR standardizes the concept of connecting external APIs to use the term **"Accounts"** (or **"Integrations"** / **"Adapters"** in developer-facing contexts).

**Changes Included**
- **Dashboard UI (`web/src/`)**: Renamed all user-facing labels, buttons, metrics, empty states, error toasts, and table headers from "Services" to "Accounts" (e.g., in `Services.tsx`, `Audit.tsx`, `Agents.tsx`, `Restrictions.tsx`).
- **Adapter Generation (`AdapterGen.tsx`, `OrgAdapters.tsx`)**: Rebranded technical setup text to use "Adapter ID" instead of "Service ID" for custom YAML integrations.
- **Documentation & Setup Guides (`docs/`, `skills/`)**: Updated markdown files, setup prompts, and setup URLs to reflect the new "Accounts" taxonomy.

**What was intentionally left unchanged (Zero Breaking Changes)**
To ensure complete backwards compatibility with the Go backend engine and existing API schemas, the following were explicitly excluded from this rename:
1. **Internal Logic:** React `queryKey`s, API routes (`/api/services`), variable names, and JSON schema properties (`service_id`) remain unchanged.
2. **Local Daemon:** Any references to macOS/Linux background processes (e.g., "Local Services") were preserved, as they accurately describe native OS daemons rather than external API integrations.

**Testing**
- Confirmed the web dashboard compiles without type errors.
- Verified that all underlying API requests still correctly submit `service` variables to the backend endpoints.
