### PR TITLE
fix(web): clarify inline-chat deep-link approval failures

### DIFF
--- a/web/src/pages/Overview.tsx
+++ b/web/src/pages/Overview.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useCallback, useMemo, type ReactNode } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Link, useSearchParams } from 'react-router-dom'
-import { api, type Task, type QueueItem, type Agent, type ActivityBucket, type VerificationVerdict, type ConnectionRequest, type ApprovalRecord, type RuntimeStatus } from '../api/client'
+import { api, APIError, type Task, type QueueItem, type Agent, type ActivityBucket, type VerificationVerdict, type ConnectionRequest, type ApprovalRecord, type RuntimeStatus } from '../api/client'
 import { filterLiveRuntimeApprovals, isActiveRuntimeSession } from './Runtime'
 import { useAuth } from '../hooks/useAuth'
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts'
@@ -34,7 +34,13 @@ export default function Overview() {
       setDeepLinkResult(`Request ${vars.requestId.slice(0, 8)}... approved.`)
       qc.invalidateQueries({ queryKey: ['overview'] })
     },
-    onError: (err: Error) => setDeepLinkResult(`Approve failed: ${err.message}`),
+    onError: (err: Error) => {
+      if (err instanceof APIError && err.code === 'INLINE_CHAT_BOUND') {
+        setDeepLinkResult('Reply approve/deny in the agent chat')
+      } else {
+        setDeepLinkResult(`Approve failed: ${err.message}`)
+      }
+    },
   })
   const deepDenyRequest = useMutation({
     mutationFn: ({ requestId, taskId }: DeepLinkVars) => api.approvals.deny(requestId, taskId),
@@ -42,7 +48,13 @@ export default function Overview() {
       setDeepLinkResult(`Request ${vars.requestId.slice(0, 8)}... denied.`)
       qc.invalidateQueries({ queryKey: ['overview'] })
     },
-    onError: (err: Error) => setDeepLinkResult(`Deny failed: ${err.message}`),
+    onError: (err: Error) => {
+      if (err instanceof APIError && err.code === 'INLINE_CHAT_BOUND') {
+        setDeepLinkResult('Reply approve/deny in the agent chat')
+      } else {
+        setDeepLinkResult(`Deny failed: ${err.message}`)
+      }
+    },
   })
 
   // Handle deep link actions for approvals

--- a/web/src/pages/Tasks.tsx
+++ b/web/src/pages/Tasks.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useSearchParams, Link } from 'react-router-dom'
-import { api, type Agent } from '../api/client'
+import { api, APIError, type Agent } from '../api/client'
 import { useAuth } from '../hooks/useAuth'
 import TaskCard from '../components/TaskCard'
 
@@ -29,12 +29,24 @@ export default function Tasks() {
   const deepApprove = useMutation({
     mutationFn: (taskId: string) => api.tasks.approve(taskId),
     onSuccess: () => { setDeepLinkResult('Task approved.'); qc.invalidateQueries({ queryKey: ['tasks'] }) },
-    onError: (err: Error) => setDeepLinkResult(`Approve failed: ${err.message}`),
+    onError: (err: Error) => {
+      if (err instanceof APIError && err.code === 'INLINE_CHAT_BOUND') {
+        setDeepLinkResult('Reply approve/deny in the agent chat')
+      } else {
+        setDeepLinkResult(`Approve failed: ${err.message}`)
+      }
+    },
   })
   const deepDeny = useMutation({
     mutationFn: (taskId: string) => api.tasks.deny(taskId),
     onSuccess: () => { setDeepLinkResult('Task denied.'); qc.invalidateQueries({ queryKey: ['tasks'] }) },
-    onError: (err: Error) => setDeepLinkResult(`Deny failed: ${err.message}`),
+    onError: (err: Error) => {
+      if (err instanceof APIError && err.code === 'INLINE_CHAT_BOUND') {
+        setDeepLinkResult('Reply approve/deny in the agent chat')
+      } else {
+        setDeepLinkResult(`Deny failed: ${err.message}`)
+      }
+    },
   })
   const deepExpandApprove = useMutation({
     mutationFn: (taskId: string) => api.tasks.expandApprove(taskId),


### PR DESCRIPTION
## Summary

Inline-chat pending tasks are intentionally chat-bound: the dashboard approve endpoint returns `409 INLINE_CHAT_BOUND` and the user must reply in the agent chat instead.

Deep-link approval flows were still rendering the raw error message, so users could see the cryptic banner:

`Approve failed: Conflict`

This PR teaches the dashboard deep-link handlers to inspect `APIError.code` and render the actionable message:

`Reply approve/deny in the agent chat`

## Why

PR #472 made inline-chat pending tasks visible in the dashboard while keeping approval resolution anchored to the running chat session. The backend already returns a typed `INLINE_CHAT_BOUND` error for dashboard approval attempts, but the deep-link UI did not special-case that code.

## Changes

- `Overview` deep-link approve/deny mutations now map `INLINE_CHAT_BOUND` to the chat guidance message.
- `Tasks` deep-link approve/deny mutations now do the same.
- Other API errors keep the existing fallback text.

## Test plan

- [x] `go test ./internal/api/handlers -run TestApprove_HTTPRefusesInlineChatPending -count=1`
- [x] `cd web && npm run lint`
- [x] `cd web && npx tsc -b && npx vite build`
- [x] `git diff --check`
- [x] Manual: local mock backend returned `409 {"code":"INLINE_CHAT_BOUND"}` for `POST /api/tasks/fake-inline-chat-task/approve`; `/dashboard/tasks?action=approve&task_id=fake-inline-chat-task` rendered `Reply approve/deny in the agent chat` instead of `Approve failed: Conflict`.

## Notes

`npm run build` reaches a successful TypeScript/Vite build on Windows, then fails at the final `touch dist/.gitkeep dist/placeholder.html` step because `touch` is unavailable in the default Windows npm shell. I validated the equivalent build steps with `npx tsc -b` and `npx vite build`.

## Verification Screenshot

<img width="1919" height="954" alt="Screenshot 2026-05-29 173747" src="https://github.com/user-attachments/assets/88e9beb4-abf3-40fa-8448-80b2c478065c" />
