### PR TITLE
test(llmproxy): add provider protocol replay coverage

### DIFF
--- a/internal/api/handlers/llm_endpoint_test.go
+++ b/internal/api/handlers/llm_endpoint_test.go
@@ -297,6 +297,7 @@ func TestLLMEndpoint_InjectsControlNoticeWhenToolsAvailable(t *testing.T) {
 		// the model must not fabricate its own `autovault_*` strings.
 		"VAULT PLACEHOLDERS",
 		"autovault_",
+		"Do not invent or fabricate `autovault_...` placeholders",
 		// Escape-stable substring of the "no fabricated autovault" rule.
 		// (The full sentence contains `<` which gets JSON-escaped on the
 		// wire; matching on the leading clause keeps the assertion

--- a/internal/api/handlers/provider_protocol_replay_test.go
+++ b/internal/api/handlers/provider_protocol_replay_test.go
@@ -1,0 +1,91 @@
+package handlers
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+)
+
+func TestProviderProtocolReplay_AnthropicContinuationSpliceFixture(t *testing.T) {
+	spliced, err := spliceStreamingContinuationBody(conversation.ProviderAnthropic, conversation.StreamingRewriteResult{
+		StreamFormat:              "anthropic_messages",
+		NextAnthropicContentIndex: 2,
+	}, "text/event-stream", readHandlerProviderReplayFixture(t, "anthropic/continuation_stream.sse"))
+	if err != nil {
+		t.Fatalf("spliceStreamingContinuationBody: %v", err)
+	}
+	out := string(spliced)
+	if strings.Contains(out, "event: message_start") {
+		t.Fatalf("spliced Anthropic continuation must not duplicate message_start:\n%s", out)
+	}
+	if got := strings.Count(out, "event: message_stop"); got != 1 {
+		t.Fatalf("message_stop count=%d, want 1:\n%s", got, out)
+	}
+	if !strings.Contains(out, `"index":2`) {
+		t.Fatalf("spliced Anthropic continuation did not offset content index to 2:\n%s", out)
+	}
+}
+
+func TestProviderProtocolReplay_OpenAIResponsesContinuationSpliceFixture(t *testing.T) {
+	spliced, err := spliceStreamingContinuationBody(conversation.ProviderOpenAI, conversation.StreamingRewriteResult{
+		StreamID:              "resp_original",
+		StreamFormat:          "openai_responses",
+		NextOpenAIOutputIndex: 1,
+	}, "text/event-stream", readHandlerProviderReplayFixture(t, "openai_responses/continuation_stream.sse"))
+	if err != nil {
+		t.Fatalf("spliceStreamingContinuationBody: %v", err)
+	}
+	out := string(spliced)
+	if strings.Contains(out, "event: response.created") {
+		t.Fatalf("spliced Responses continuation must not duplicate response.created:\n%s", out)
+	}
+	if got := strings.Count(out, "event: response.completed"); got != 1 {
+		t.Fatalf("response.completed count=%d, want 1:\n%s", got, out)
+	}
+	if !strings.Contains(out, `"output_index":1`) {
+		t.Fatalf("spliced Responses continuation did not offset output_index to 1:\n%s", out)
+	}
+	completed := handlerReplayEventData(t, out, "response.completed")
+	var payload struct {
+		Response struct {
+			ID string `json:"id"`
+		} `json:"response"`
+	}
+	if err := json.Unmarshal([]byte(completed), &payload); err != nil {
+		t.Fatalf("response.completed payload malformed: %v\n%s", err, completed)
+	}
+	if payload.Response.ID != "resp_original" {
+		t.Fatalf("response.completed id=%q, want resp_original:\n%s", payload.Response.ID, out)
+	}
+}
+
+func readHandlerProviderReplayFixture(t *testing.T, rel string) []byte {
+	t.Helper()
+	path := filepath.Join("..", "..", "runtime", "llmproxy", "testdata", "provider_replay", filepath.FromSlash(rel))
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", rel, err)
+	}
+	return body
+}
+
+func handlerReplayEventData(t *testing.T, stream, event string) string {
+	t.Helper()
+	for _, block := range strings.Split(strings.ReplaceAll(stream, "\r\n", "\n"), "\n\n") {
+		if !strings.Contains(block, "event: "+event) {
+			continue
+		}
+		for _, line := range strings.Split(block, "\n") {
+			line = strings.TrimSpace(line)
+			if strings.HasPrefix(line, "data:") {
+				return strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+			}
+		}
+	}
+	t.Fatalf("event %q not found in stream:\n%s", event, stream)
+	return ""
+}

--- a/internal/runtime/conversation/openai_response.go
+++ b/internal/runtime/conversation/openai_response.go
@@ -984,6 +984,7 @@ func SynthOpenAIResponsesFunctionCallsSSE(calls []SyntheticToolCall) []byte {
 		}))
 	}
 	b.WriteString(sseEventBlock("response.completed", map[string]any{"type": "response.completed", "response": map[string]any{"id": "resp_clawvisor_approve", "status": "completed"}}))
+	b.WriteString("data: [DONE]\n\n")
 	return []byte(b.String())
 }
 
@@ -1236,6 +1237,7 @@ func synthOpenAIResponsesFunctionCallSSE(toolUseID, toolName string, toolInput m
 		"item":         map[string]any{"id": "fc_" + toolUseID, "type": "function_call", "status": "completed", "call_id": toolUseID, "name": toolName, "arguments": string(args)},
 	}))
 	b.WriteString(sseEventBlock("response.completed", map[string]any{"type": "response.completed", "response": map[string]any{"id": "resp_clawvisor_approve", "status": "completed"}}))
+	b.WriteString("data: [DONE]\n\n")
 	return []byte(b.String())
 }
 
@@ -1507,7 +1509,7 @@ func (rw OpenAIResponseRewriter) streamRewriteChatCompletions(ctx context.Contex
 		}
 		if trimmed == "data: [DONE]" {
 			if len(pending) == 0 {
-				_, _ = fmt.Fprintln(w, line)
+				_, _ = fmt.Fprintf(w, "%s\n\n", line)
 			}
 			continue
 		}
@@ -1521,7 +1523,7 @@ func (rw OpenAIResponseRewriter) streamRewriteChatCompletions(ctx context.Contex
 			Choices []openAIChatChoice `json:"choices"`
 		}
 		if err := json.Unmarshal([]byte(payload), &event); err != nil {
-			_, _ = fmt.Fprintln(w, line)
+			_, _ = fmt.Fprintf(w, "%s\n\n", line)
 			continue
 		}
 		if event.ID != "" && streamID == "" {
@@ -1595,7 +1597,7 @@ func (rw OpenAIResponseRewriter) streamRewriteChatCompletions(ctx context.Contex
 			continue
 		}
 
-		_, _ = fmt.Fprintln(w, line)
+		_, _ = fmt.Fprintf(w, "%s\n\n", line)
 	}
 
 	if err := scanner.Err(); err != nil {
@@ -1658,7 +1660,8 @@ func (rw OpenAIResponseRewriter) streamRewriteResponses(ctx context.Context, r i
 	var lastEvent string
 	var dataLns []string
 	withheldTool := false
-	streamID := "resp_clawvisor_rewrite"
+	var streamID string
+	responseCreated := false
 
 	flushEvent := func() error {
 		if len(dataLns) == 0 {
@@ -1671,17 +1674,23 @@ func (rw OpenAIResponseRewriter) streamRewriteResponses(ctx context.Context, r i
 		dataLns = dataLns[:0]
 
 		if data == "[DONE]" {
+			if !withheldTool {
+				_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+			}
 			return nil
 		}
 
 		switch event {
 		case "response.created":
+			responseCreated = true
 			var raw struct {
 				Response struct {
 					ID string `json:"id"`
 				} `json:"response"`
 			}
-			if err := json.Unmarshal([]byte(data), &raw); err == nil && raw.Response.ID != "" {
+			if err := json.Unmarshal([]byte(data), &raw); err != nil {
+				return writeSSE(w, event, data)
+			} else if raw.Response.ID != "" {
 				streamID = raw.Response.ID
 			}
 			return writeSSE(w, event, data)
@@ -1924,11 +1933,12 @@ func (rw OpenAIResponseRewriter) streamRewriteResponses(ctx context.Context, r i
 	}
 
 	return StreamingRewriteResult{
-		ToolUses:              tus,
-		AssistantTurn:         turn,
-		StreamID:              streamID,
-		StreamFormat:          "openai_responses",
-		NextOpenAIOutputIndex: nextOutputIndex,
+		ToolUses:                 tus,
+		AssistantTurn:            turn,
+		StreamID:                 streamID,
+		StreamFormat:             "openai_responses",
+		NextOpenAIOutputIndex:    nextOutputIndex,
+		HasOpenAIResponseCreated: responseCreated,
 	}, nil
 }
 

--- a/internal/runtime/conversation/response.go
+++ b/internal/runtime/conversation/response.go
@@ -94,6 +94,7 @@ type StreamingRewriteResult struct {
 	StreamFormat              string
 	NextAnthropicContentIndex int
 	NextOpenAIOutputIndex     int
+	HasOpenAIResponseCreated  bool
 }
 
 type ResponseRewriter interface {

--- a/internal/runtime/llmproxy/control.go
+++ b/internal/runtime/llmproxy/control.go
@@ -98,6 +98,7 @@ func controlNotice(controlBaseURL string, availableTools []string, toolRules []*
 		"  - Pure local work (file edits, shell inspection, etc.) does NOT need `required_credentials`. Omit the field entirely; it is not a per-task formality.",
 		"  - If task creation is rejected with `vault item \"<id>\" is not available`, do NOT tell the user the credential is missing. List GET " + vaultItemsURL + " to discover the correct (possibly account-aliased) handle, then retry the task. Only report the credential as missing if the list itself has no plausible match.",
 		"  - Do not ask the user to paste raw secrets into chat.",
+		"  - Do not invent or fabricate `autovault_...` placeholders. Only use placeholders already present in the conversation or returned by Clawvisor.",
 		"",
 		"VAULT PLACEHOLDERS — use minted `autovault_*` values verbatim in Authorization headers or curl arguments; Clawvisor substitutes the real secret at proxy time. NEVER write your own `autovault_<service>` string in `required_credentials` (use the account-scoped vault item id there) or in a downstream call. Raw tokens such as `ghp_...` or `sk-...` are sensitive; ask the user to vault them first.",
 		"",

--- a/internal/runtime/llmproxy/postprocess.go
+++ b/internal/runtime/llmproxy/postprocess.go
@@ -1,6 +1,7 @@
 package llmproxy
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -1884,7 +1885,11 @@ func writeProviderBlockedPrompt(w io.Writer, provider conversation.Provider, res
 
 	case conversation.ProviderOpenAI:
 		if result.StreamFormat == "openai_responses" {
-			_, err := w.Write(conversation.SynthOpenAIResponsesTextSSE(text))
+			body, err := openAIResponsesSyntheticForExistingStream(conversation.SynthOpenAIResponsesTextSSE(text), result.StreamID, result.HasOpenAIResponseCreated)
+			if err != nil {
+				return err
+			}
+			_, err = w.Write(body)
 			return err
 		}
 		chunk := map[string]any{
@@ -1928,7 +1933,11 @@ func writeProviderToolUses(w io.Writer, provider conversation.Provider, result c
 		return writeAnthropicToolUsesSSE(w, tus, rewrittenInput)
 	case conversation.ProviderOpenAI:
 		if result.StreamFormat == "openai_responses" {
-			_, err := w.Write(conversation.SynthOpenAIResponsesFunctionCallsSSE(syntheticCallsFromToolUses(tus, rewrittenInput)))
+			body, err := openAIResponsesSyntheticForExistingStream(conversation.SynthOpenAIResponsesFunctionCallsSSE(syntheticCallsFromToolUses(tus, rewrittenInput)), result.StreamID, result.HasOpenAIResponseCreated)
+			if err != nil {
+				return err
+			}
+			_, err = w.Write(body)
 			return err
 		}
 		return writeOpenAIChatToolUsesSSE(w, result.StreamID, tus, rewrittenInput)
@@ -2078,6 +2087,55 @@ func syntheticCallsFromToolUses(tus []conversation.ToolUse, rewrittenInput map[s
 		})
 	}
 	return calls
+}
+
+func openAIResponsesSyntheticForExistingStream(body []byte, streamID string, alreadyCreated bool) ([]byte, error) {
+	if !alreadyCreated {
+		return body, nil
+	}
+	events := strings.Split(strings.ReplaceAll(string(body), "\r\n", "\n"), "\n\n")
+	var out bytes.Buffer
+	for _, eventBlock := range events {
+		eventBlock = strings.TrimSpace(eventBlock)
+		if eventBlock == "" {
+			continue
+		}
+		var event string
+		var dataLines []string
+		for _, line := range strings.Split(eventBlock, "\n") {
+			line = strings.TrimSpace(line)
+			switch {
+			case strings.HasPrefix(line, "event:"):
+				event = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+			case strings.HasPrefix(line, "data:"):
+				dataLines = append(dataLines, strings.TrimSpace(strings.TrimPrefix(line, "data:")))
+			}
+		}
+		if len(dataLines) == 0 {
+			continue
+		}
+		data := strings.Join(dataLines, "\n")
+		if data == "[DONE]" {
+			out.WriteString("data: [DONE]\n\n")
+			continue
+		}
+		if event == "response.created" {
+			continue
+		}
+		var payload map[string]any
+		if err := json.Unmarshal([]byte(data), &payload); err != nil {
+			return nil, err
+		}
+		if event == "response.completed" {
+			if response, ok := payload["response"].(map[string]any); ok {
+				response["id"] = streamID
+			}
+		}
+		if err := writeSSE(&out, event, payload); err != nil {
+			return nil, err
+		}
+	}
+	return out.Bytes(), nil
 }
 
 func writeSSE(w io.Writer, event string, data any) error {

--- a/internal/runtime/llmproxy/provider_protocol_replay_test.go
+++ b/internal/runtime/llmproxy/provider_protocol_replay_test.go
@@ -1,0 +1,412 @@
+package llmproxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/inspector"
+)
+
+const providerReplayPlaceholder = "autovault_github_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+func TestProviderProtocolReplay_TextOnlyStreams(t *testing.T) {
+	tests := []struct {
+		name     string
+		route    string
+		provider string
+		fixture  string
+		wantText string
+	}{
+		{"anthropic", "/v1/messages", "anthropic", "anthropic/text_only_stream.sse", "Hello from Anthropic"},
+		{"openai chat", "/v1/chat/completions", "openai_chat", "openai_chat/text_only_stream.sse", "Hello from chat"},
+		{"openai responses", "/v1/responses", "openai_responses", "openai_responses/text_only_stream.sse", "Hello from responses"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, out, err := runProviderReplayStream(t, tt.route, tt.fixture, replayPostprocessConfig(t, false))
+			if err != nil {
+				t.Fatalf("PostprocessStream: %v", err)
+			}
+			if result.Rewritten {
+				t.Fatalf("text-only stream should not rewrite: %+v", result)
+			}
+			if len(result.Decisions) != 0 {
+				t.Fatalf("text-only stream produced decisions: %+v", result.Decisions)
+			}
+			if !strings.Contains(out, tt.wantText) {
+				t.Fatalf("text-only stream lost text %q:\n%s", tt.wantText, out)
+			}
+			assertProviderReplayProtocol(t, tt.provider, out)
+		})
+	}
+}
+
+func TestProviderProtocolReplay_ToolRewriteStreams(t *testing.T) {
+	tests := []struct {
+		name     string
+		route    string
+		provider string
+		fixture  string
+	}{
+		{"anthropic", "/v1/messages", "anthropic", "anthropic/tool_rewrite_stream.sse"},
+		{"openai chat", "/v1/chat/completions", "openai_chat", "openai_chat/tool_rewrite_stream.sse"},
+		{"openai responses", "/v1/responses", "openai_responses", "openai_responses/function_call_rewrite_stream.sse"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, out, err := runProviderReplayStream(t, tt.route, tt.fixture, replayPostprocessConfig(t, true))
+			if err != nil {
+				t.Fatalf("PostprocessStream: %v", err)
+			}
+			if !result.Rewritten {
+				t.Fatalf("expected tool stream rewrite, got %+v\n%s", result, out)
+			}
+			if len(result.Decisions) != 1 {
+				t.Fatalf("expected one inspected tool call, got %+v", result.Decisions)
+			}
+			if !strings.Contains(out, "https://proxy.example/api/proxy/repos/x/y/issues") {
+				t.Fatalf("rewritten stream missing proxy URL:\n%s", out)
+			}
+			assertProviderReplayProtocol(t, tt.provider, out)
+		})
+	}
+}
+
+func TestProviderProtocolReplay_BlockedToolStreams(t *testing.T) {
+	tests := []struct {
+		name     string
+		route    string
+		provider string
+		fixture  string
+	}{
+		{"anthropic", "/v1/messages", "anthropic", "anthropic/blocked_tool_stream.sse"},
+		{"openai chat", "/v1/chat/completions", "openai_chat", "openai_chat/blocked_tool_stream.sse"},
+		{"openai responses custom tool", "/v1/responses", "openai_responses", "openai_responses/custom_tool_call_blocked_stream.sse"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, out, err := runProviderReplayStream(t, tt.route, tt.fixture, replayPostprocessConfig(t, false))
+			if err != nil {
+				t.Fatalf("PostprocessStream: %v", err)
+			}
+			if !result.Rewritten {
+				t.Fatalf("expected blocked tool stream rewrite, got %+v\n%s", result, out)
+			}
+			if len(result.Decisions) != 1 {
+				t.Fatalf("expected one blocked tool decision, got %+v", result.Decisions)
+			}
+			if !strings.Contains(out, "Tool use was blocked by the Clawvisor proxy") {
+				t.Fatalf("blocked stream missing provider-shaped refusal:\n%s", out)
+			}
+			if strings.Contains(out, providerReplayPlaceholder) {
+				t.Fatalf("blocked stream leaked placeholder:\n%s", out)
+			}
+			if strings.Contains(out, `"custom_tool_call"`) {
+				t.Fatalf("blocked Responses custom tool leaked original item:\n%s", out)
+			}
+			assertProviderReplayProtocol(t, tt.provider, out)
+		})
+	}
+}
+
+func TestProviderProtocolReplay_MalformedStreamsPassThroughWithoutAbort(t *testing.T) {
+	tests := []struct {
+		name    string
+		route   string
+		fixture string
+	}{
+		{"anthropic", "/v1/messages", "anthropic/malformed_partial_stream.sse"},
+		{"openai chat", "/v1/chat/completions", "openai_chat/malformed_partial_stream.sse"},
+		{"openai responses", "/v1/responses", "openai_responses/malformed_partial_stream.sse"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, out, err := runProviderReplayStream(t, tt.route, tt.fixture, replayPostprocessConfig(t, true))
+			if err != nil {
+				t.Fatalf("malformed stream should pass through without aborting: %v", err)
+			}
+			if result.Rewritten {
+				t.Fatalf("malformed stream should not be rewritten: %+v", result)
+			}
+			if out == "" {
+				t.Fatal("malformed stream should still deliver passthrough bytes")
+			}
+		})
+	}
+}
+
+func TestProviderProtocolReplay_OpenAIResponsesSyntheticKeepsCreatedWhenOriginalMissing(t *testing.T) {
+	body, err := openAIResponsesSyntheticForExistingStream([]byte(strings.Join([]string{
+		`event: response.created`,
+		`data: {"type":"response.created","response":{"id":"resp_synthetic","status":"in_progress"}}`,
+		``,
+		`event: response.completed`,
+		`data: {"type":"response.completed","response":{"id":"resp_synthetic","status":"completed"}}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}, "\n")), "resp_original", false)
+	if err != nil {
+		t.Fatalf("openAIResponsesSyntheticForExistingStream: %v", err)
+	}
+	out := string(body)
+	if !strings.Contains(out, "event: response.created") {
+		t.Fatalf("synthetic stream without prior response.created must keep creation event:\n%s", out)
+	}
+	if !strings.Contains(out, "resp_synthetic") {
+		t.Fatalf("synthetic stream without prior response.created should remain unchanged:\n%s", out)
+	}
+}
+
+func runProviderReplayStream(t *testing.T, route, fixture string, cfg PostprocessConfig) (PostprocessResult, string, error) {
+	t.Helper()
+	req := httptest.NewRequest("POST", route, nil)
+	var output bytes.Buffer
+	result, err := PostprocessStream(context.Background(), req, bytes.NewReader(readProviderReplayFixture(t, fixture)), &output, "text/event-stream", cfg)
+	return result, output.String(), err
+}
+
+func replayPostprocessConfig(t *testing.T, allowRewrite bool) PostprocessConfig {
+	t.Helper()
+	st, userID, agentID := seedPostprocessStore(t, providerReplayPlaceholder)
+	cfg := PostprocessConfig{
+		Inspector:   inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{}),
+		Store:       st,
+		AgentUserID: userID,
+		AgentID:     agentID,
+	}
+	if allowRewrite {
+		cfg.RewriteOpts = inspector.DefaultRewriteOpts("https://proxy.example/api/proxy")
+		cfg.CallerNonces = NewMemoryCallerNonceCache(time.Minute)
+	}
+	return cfg
+}
+
+func readProviderReplayFixture(t *testing.T, rel string) []byte {
+	t.Helper()
+	path := filepath.Join("testdata", "provider_replay", filepath.FromSlash(rel))
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", rel, err)
+	}
+	return body
+}
+
+type replaySSEEvent struct {
+	Event string
+	Data  string
+}
+
+func parseProviderReplaySSE(t *testing.T, stream string) []replaySSEEvent {
+	t.Helper()
+	blocks := strings.Split(strings.ReplaceAll(stream, "\r\n", "\n"), "\n\n")
+	events := make([]replaySSEEvent, 0, len(blocks))
+	for _, block := range blocks {
+		block = strings.TrimSuffix(block, "\n")
+		if strings.TrimSpace(block) == "" {
+			continue
+		}
+		var ev replaySSEEvent
+		var dataLines []string
+		for _, line := range strings.Split(block, "\n") {
+			line = strings.TrimSuffix(line, "\r")
+			switch {
+			case strings.HasPrefix(line, "event:"):
+				ev.Event = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+			case strings.HasPrefix(line, "data:"):
+				data := strings.TrimPrefix(line, "data:")
+				if strings.HasPrefix(data, " ") {
+					data = data[1:]
+				}
+				dataLines = append(dataLines, data)
+			}
+		}
+		if len(dataLines) == 0 {
+			continue
+		}
+		ev.Data = strings.Join(dataLines, "\n")
+		events = append(events, ev)
+	}
+	return events
+}
+
+func assertProviderReplayProtocol(t *testing.T, provider, stream string) {
+	t.Helper()
+	switch provider {
+	case "anthropic":
+		assertAnthropicReplayProtocol(t, stream)
+	case "openai_chat":
+		assertOpenAIChatReplayProtocol(t, stream)
+	case "openai_responses":
+		assertOpenAIResponsesReplayProtocol(t, stream)
+	default:
+		t.Fatalf("unknown provider %q", provider)
+	}
+}
+
+func assertAnthropicReplayProtocol(t *testing.T, stream string) {
+	t.Helper()
+	events := parseProviderReplaySSE(t, stream)
+	messageStart, messageStop := 0, 0
+	started := map[int]bool{}
+	stopped := map[int]bool{}
+	for _, ev := range events {
+		switch ev.Event {
+		case "message_start":
+			messageStart++
+		case "message_stop":
+			messageStop++
+		case "content_block_start", "content_block_delta", "content_block_stop":
+			idx := replayEventIndex(t, ev)
+			if idx < 0 {
+				t.Fatalf("negative Anthropic content index in %s: %s", ev.Event, ev.Data)
+			}
+			switch ev.Event {
+			case "content_block_start":
+				if started[idx] {
+					t.Fatalf("duplicate Anthropic content_block_start index %d:\n%s", idx, stream)
+				}
+				started[idx] = true
+			case "content_block_delta":
+				if !started[idx] {
+					t.Fatalf("Anthropic delta before start for index %d:\n%s", idx, stream)
+				}
+			case "content_block_stop":
+				if !started[idx] {
+					t.Fatalf("Anthropic stop before start for index %d:\n%s", idx, stream)
+				}
+				stopped[idx] = true
+			}
+		}
+	}
+	if messageStart != 1 {
+		t.Fatalf("Anthropic stream has %d message_start events, want 1:\n%s", messageStart, stream)
+	}
+	if messageStop != 1 {
+		t.Fatalf("Anthropic stream has %d message_stop events, want 1:\n%s", messageStop, stream)
+	}
+	for idx := range started {
+		if !stopped[idx] {
+			t.Fatalf("Anthropic content block index %d was not stopped:\n%s", idx, stream)
+		}
+	}
+}
+
+func assertOpenAIChatReplayProtocol(t *testing.T, stream string) {
+	t.Helper()
+	events := parseProviderReplaySSE(t, stream)
+	done, terminal := 0, false
+	for _, ev := range events {
+		if ev.Data == "[DONE]" {
+			done++
+			continue
+		}
+		var payload struct {
+			Choices []struct {
+				FinishReason *string `json:"finish_reason"`
+				Delta        struct {
+					ToolCalls []struct {
+						Index int `json:"index"`
+					} `json:"tool_calls"`
+				} `json:"delta"`
+			} `json:"choices"`
+		}
+		if err := json.Unmarshal([]byte(ev.Data), &payload); err != nil {
+			t.Fatalf("malformed OpenAI Chat SSE data: %v\n%s", err, ev.Data)
+		}
+		for _, choice := range payload.Choices {
+			if choice.FinishReason != nil && (*choice.FinishReason == "stop" || *choice.FinishReason == "tool_calls") {
+				terminal = true
+			}
+			for _, tc := range choice.Delta.ToolCalls {
+				if tc.Index < 0 {
+					t.Fatalf("negative OpenAI Chat tool index: %s", ev.Data)
+				}
+			}
+		}
+	}
+	if done != 1 {
+		t.Fatalf("OpenAI Chat stream has %d [DONE] sentinels, want 1:\n%s", done, stream)
+	}
+	if !terminal {
+		t.Fatalf("OpenAI Chat stream missing terminal stop/tool_calls chunk:\n%s", stream)
+	}
+}
+
+func assertOpenAIResponsesReplayProtocol(t *testing.T, stream string) {
+	t.Helper()
+	events := parseProviderReplaySSE(t, stream)
+	created, completed, done := 0, 0, 0
+	for _, ev := range events {
+		if ev.Data == "[DONE]" {
+			done++
+			continue
+		}
+		if ev.Event == "response.created" {
+			created++
+		}
+		if ev.Event == "response.completed" {
+			completed++
+		}
+		var payload map[string]any
+		if err := json.Unmarshal([]byte(ev.Data), &payload); err != nil {
+			t.Fatalf("malformed OpenAI Responses SSE data in %s: %v\n%s", ev.Event, err, ev.Data)
+		}
+		if idx, ok, valid := replayNumericIndex(payload["output_index"]); ok {
+			if !valid {
+				t.Fatalf("fractional OpenAI Responses output_index in %s: %s", ev.Event, ev.Data)
+			}
+			if idx < 0 {
+				t.Fatalf("negative OpenAI Responses output_index in %s: %s", ev.Event, ev.Data)
+			}
+		}
+	}
+	if created > 1 {
+		t.Fatalf("OpenAI Responses stream has %d response.created events:\n%s", created, stream)
+	}
+	if completed != 1 {
+		t.Fatalf("OpenAI Responses stream has %d response.completed events, want 1:\n%s", completed, stream)
+	}
+	if done != 1 {
+		t.Fatalf("OpenAI Responses stream has %d [DONE] sentinels, want 1:\n%s", done, stream)
+	}
+}
+
+func replayEventIndex(t *testing.T, ev replaySSEEvent) int {
+	t.Helper()
+	var payload struct {
+		Index *int `json:"index"`
+	}
+	if err := json.Unmarshal([]byte(ev.Data), &payload); err != nil {
+		t.Fatalf("malformed SSE event data in %s: %v\n%s", ev.Event, err, ev.Data)
+	}
+	if payload.Index == nil {
+		t.Fatalf("SSE event %s missing index: %s", ev.Event, ev.Data)
+	}
+	return *payload.Index
+}
+
+func replayNumericIndex(v any) (int, bool, bool) {
+	switch n := v.(type) {
+	case float64:
+		if n != float64(int(n)) {
+			return 0, true, false
+		}
+		return int(n), true, true
+	case int:
+		return n, true, true
+	default:
+		return 0, false, true
+	}
+}

--- a/internal/runtime/llmproxy/testdata/provider_replay/anthropic/blocked_tool_stream.sse
+++ b/internal/runtime/llmproxy/testdata/provider_replay/anthropic/blocked_tool_stream.sse
@@ -1,0 +1,17 @@
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_block","type":"message","role":"assistant","model":"claude-sonnet-4","content":[]}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_block","name":"WebFetch","input":{}}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"url\":\"https://api.github.com/repos/x/y/issues\",\"method\":\"POST\",\"headers\":{\"X-Fixture-Token\":\"autovault_github_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"}}"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":10}}
+
+event: message_stop
+data: {"type":"message_stop"}

--- a/internal/runtime/llmproxy/testdata/provider_replay/anthropic/continuation_stream.sse
+++ b/internal/runtime/llmproxy/testdata/provider_replay/anthropic/continuation_stream.sse
@@ -1,0 +1,18 @@
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_cont","type":"message","role":"assistant","model":"claude-sonnet-4","content":[]}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Continuation text"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":5}}
+
+event: message_stop
+data: {"type":"message_stop"}
+

--- a/internal/runtime/llmproxy/testdata/provider_replay/anthropic/malformed_partial_stream.sse
+++ b/internal/runtime/llmproxy/testdata/provider_replay/anthropic/malformed_partial_stream.sse
@@ -1,0 +1,5 @@
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_bad","type":"message","role":"assistant","model":"claude-sonnet-4","content":[]}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_bad","name":"WebFetch","input":{"url":"https://api.github.com/repos/x/y/issues","headers":{"X-Fixture-Token":"autovault_github_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}}

--- a/internal/runtime/llmproxy/testdata/provider_replay/anthropic/text_only_stream.sse
+++ b/internal/runtime/llmproxy/testdata/provider_replay/anthropic/text_only_stream.sse
@@ -1,0 +1,18 @@
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_text","type":"message","role":"assistant","model":"claude-sonnet-4","content":[]}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello from Anthropic"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":4}}
+
+event: message_stop
+data: {"type":"message_stop"}
+

--- a/internal/runtime/llmproxy/testdata/provider_replay/anthropic/tool_rewrite_stream.sse
+++ b/internal/runtime/llmproxy/testdata/provider_replay/anthropic/tool_rewrite_stream.sse
@@ -1,0 +1,26 @@
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_tool","type":"message","role":"assistant","model":"claude-sonnet-4","content":[]}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"I will call the API."}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: content_block_start
+data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_rewrite","name":"WebFetch","input":{}}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"url\":\"https://api.github.com/repos/x/y/issues\",\"method\":\"POST\",\"headers\":{\"X-Fixture-Token\":\"autovault_github_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"}}"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":1}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":12}}
+
+event: message_stop
+data: {"type":"message_stop"}

--- a/internal/runtime/llmproxy/testdata/provider_replay/openai_chat/blocked_tool_stream.sse
+++ b/internal/runtime/llmproxy/testdata/provider_replay/openai_chat/blocked_tool_stream.sse
@@ -1,0 +1,7 @@
+data: {"id":"chatcmpl_block","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}
+
+data: {"id":"chatcmpl_block","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_block","type":"function","function":{"name":"WebFetch","arguments":"{\"url\":\"https://api.github.com/repos/x/y/issues\",\"method\":\"POST\",\"headers\":{\"X-Fixture-Token\":\"autovault_github_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"}}"}}]},"finish_reason":null}]}
+
+data: {"id":"chatcmpl_block","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}
+
+data: [DONE]

--- a/internal/runtime/llmproxy/testdata/provider_replay/openai_chat/malformed_partial_stream.sse
+++ b/internal/runtime/llmproxy/testdata/provider_replay/openai_chat/malformed_partial_stream.sse
@@ -1,0 +1,1 @@
+data: {"id":"chatcmpl_bad","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_bad","type":"function","function":{"name":"WebFetch","arguments":"{\"url\":\"https://api.github.com/repos/x/y/issues\",\"headers\":{\"X-Fixture-Token\":\"autovault_github_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"}}"}}]},"finish_reason":null}

--- a/internal/runtime/llmproxy/testdata/provider_replay/openai_chat/text_only_stream.sse
+++ b/internal/runtime/llmproxy/testdata/provider_replay/openai_chat/text_only_stream.sse
@@ -1,0 +1,6 @@
+data: {"id":"chatcmpl_text","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello from chat"},"finish_reason":null}]}
+
+data: {"id":"chatcmpl_text","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
+
+data: [DONE]
+

--- a/internal/runtime/llmproxy/testdata/provider_replay/openai_chat/tool_rewrite_stream.sse
+++ b/internal/runtime/llmproxy/testdata/provider_replay/openai_chat/tool_rewrite_stream.sse
@@ -1,0 +1,9 @@
+data: {"id":"chatcmpl_tool","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}
+
+data: {"id":"chatcmpl_tool","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_rewrite","type":"function","function":{"name":"WebFetch","arguments":""}}]},"finish_reason":null}]}
+
+data: {"id":"chatcmpl_tool","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"url\":\"https://api.github.com/repos/x/y/issues\",\"method\":\"POST\",\"headers\":{\"X-Fixture-Token\":\"autovault_github_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"}}"}}]},"finish_reason":null}]}
+
+data: {"id":"chatcmpl_tool","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}
+
+data: [DONE]

--- a/internal/runtime/llmproxy/testdata/provider_replay/openai_responses/continuation_stream.sse
+++ b/internal/runtime/llmproxy/testdata/provider_replay/openai_responses/continuation_stream.sse
@@ -1,0 +1,16 @@
+event: response.created
+data: {"type":"response.created","response":{"id":"resp_continuation","status":"in_progress"}}
+
+event: response.output_item.added
+data: {"type":"response.output_item.added","output_index":0,"item":{"id":"msg_continuation","type":"message","status":"in_progress"}}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","item_id":"msg_continuation","output_index":0,"content_index":0,"delta":"Continuation text"}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","output_index":0,"item":{"id":"msg_continuation","type":"message","status":"completed","content":[{"type":"output_text","text":"Continuation text"}]}}
+
+event: response.completed
+data: {"type":"response.completed","response":{"id":"resp_continuation","status":"completed","output_text":"Continuation text"}}
+
+data: [DONE]

--- a/internal/runtime/llmproxy/testdata/provider_replay/openai_responses/custom_tool_call_blocked_stream.sse
+++ b/internal/runtime/llmproxy/testdata/provider_replay/openai_responses/custom_tool_call_blocked_stream.sse
@@ -1,0 +1,13 @@
+event: response.created
+data: {"type":"response.created","response":{"id":"resp_custom","status":"in_progress"}}
+
+event: response.output_item.added
+data: {"type":"response.output_item.added","output_index":0,"item":{"id":"ctc_1","type":"custom_tool_call","status":"in_progress","call_id":"call_custom","name":"WebFetch"}}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","output_index":0,"item":{"id":"ctc_1","type":"custom_tool_call","status":"completed","call_id":"call_custom","name":"WebFetch","input":"{\"url\":\"https://api.github.com/repos/x/y/issues\",\"method\":\"POST\",\"headers\":{\"X-Fixture-Token\":\"autovault_github_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"}}"}}
+
+event: response.completed
+data: {"type":"response.completed","response":{"id":"resp_custom","status":"completed"}}
+
+data: [DONE]

--- a/internal/runtime/llmproxy/testdata/provider_replay/openai_responses/function_call_rewrite_stream.sse
+++ b/internal/runtime/llmproxy/testdata/provider_replay/openai_responses/function_call_rewrite_stream.sse
@@ -1,0 +1,19 @@
+event: response.created
+data: {"type":"response.created","response":{"id":"resp_tool","status":"in_progress"}}
+
+event: response.output_item.added
+data: {"type":"response.output_item.added","output_index":0,"item":{"id":"fc_1","type":"function_call","status":"in_progress","call_id":"call_rewrite","name":"WebFetch"}}
+
+event: response.function_call_arguments.delta
+data: {"type":"response.function_call_arguments.delta","item_id":"fc_1","output_index":0,"delta":"{\"url\":\"https://api.github.com/repos/x/y/issues\",\"method\":\"POST\",\"headers\":{\"X-Fixture-Token\":\"autovault_github_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"}}"}
+
+event: response.function_call_arguments.done
+data: {"type":"response.function_call_arguments.done","item_id":"fc_1","output_index":0,"name":"WebFetch","arguments":"{\"url\":\"https://api.github.com/repos/x/y/issues\",\"method\":\"POST\",\"headers\":{\"X-Fixture-Token\":\"autovault_github_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"}}"}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","output_index":0,"item":{"id":"fc_1","type":"function_call","status":"completed","call_id":"call_rewrite","name":"WebFetch","arguments":"{\"url\":\"https://api.github.com/repos/x/y/issues\",\"method\":\"POST\",\"headers\":{\"X-Fixture-Token\":\"autovault_github_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"}}"}}
+
+event: response.completed
+data: {"type":"response.completed","response":{"id":"resp_tool","status":"completed"}}
+
+data: [DONE]

--- a/internal/runtime/llmproxy/testdata/provider_replay/openai_responses/malformed_partial_stream.sse
+++ b/internal/runtime/llmproxy/testdata/provider_replay/openai_responses/malformed_partial_stream.sse
@@ -1,0 +1,5 @@
+event: response.created
+data: {"type":"response.created","response":{"id":"resp_bad","status":"in_progress"}}
+
+event: response.output_item.added
+data: {"type":"response.output_item.added","output_index":0,"item":{"id":"ctc_bad","type":"custom_tool_call","status":"in_progress","call_id":"call_bad","name":"WebFetch","input":"{\"url\":\"https://api.github.com/repos/x/y/issues\",\"headers\":{\"X-Fixture-Token\":\"autovault_github_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"}}"}

--- a/internal/runtime/llmproxy/testdata/provider_replay/openai_responses/text_only_stream.sse
+++ b/internal/runtime/llmproxy/testdata/provider_replay/openai_responses/text_only_stream.sse
@@ -1,0 +1,19 @@
+event: response.created
+data: {"type":"response.created","response":{"id":"resp_text","status":"in_progress"}}
+
+event: response.output_item.added
+data: {"type":"response.output_item.added","output_index":0,"item":{"id":"msg_text","type":"message","status":"in_progress"}}
+
+event: response.content_part.added
+data: {"type":"response.content_part.added","item_id":"msg_text","output_index":0,"content_index":0,"part":{"type":"output_text","text":""}}
+
+event: response.output_text.delta
+data: {"type":"response.output_text.delta","item_id":"msg_text","output_index":0,"content_index":0,"delta":"Hello from responses"}
+
+event: response.output_item.done
+data: {"type":"response.output_item.done","output_index":0,"item":{"id":"msg_text","type":"message","status":"completed","content":[{"type":"output_text","text":"Hello from responses"}]}}
+
+event: response.completed
+data: {"type":"response.completed","response":{"id":"resp_text","status":"completed","output_text":"Hello from responses"}}
+
+data: [DONE]


### PR DESCRIPTION
## Description

This follows up on the selective SSE streaming work from #482 by adding provider protocol replay coverage for lite-proxy SSE rewriting.

The SSE feature now has real provider-shaped replay fixtures for Anthropic, OpenAI Chat Completions, and OpenAI Responses. These tests pin the exact stream lifecycle behavior that the proxy must preserve while it inspects, blocks, rewrites, or continues tool-bearing streams.

This is intentionally scoped to replay coverage plus the small protocol hardening needed for those replay assertions.

## Why

The selective SSE PR made Clawvisor stream model text before completion while still buffering and inspecting tool calls. That behavior is security-sensitive because each provider has a different SSE contract:

- Anthropic uses indexed content blocks and `message_delta` / `message_stop`.
- OpenAI Chat uses delta chunks and `[DONE]`.
- OpenAI Responses uses response lifecycle events such as `response.created`, output item events, content-part events, and `response.completed`.

The replay tests make sure future changes do not accidentally:
- leak blocked tool calls before inspection,
- emit malformed or duplicate completion events,
- break provider lifecycle ordering,
- corrupt content/tool indexes,
- mis-handle continuation splicing,
- abort streams unnecessarily on malformed partial chunks.

## Changes

Adds provider replay tests for:

- Anthropic text-only streams.
- Anthropic blocked tool streams.
- Anthropic continuation streams.
- Anthropic malformed partial streams.
- Anthropic tool rewrite streams.
- OpenAI Chat text-only streams.
- OpenAI Chat blocked tool streams.
- OpenAI Chat malformed partial streams.
- OpenAI Chat tool rewrite streams.
- OpenAI Responses text-only streams.
- OpenAI Responses continuation streams.
- OpenAI Responses custom tool-call blocked streams.
- OpenAI Responses function-call rewrite streams.
- OpenAI Responses malformed partial streams.

Also adds handler-level provider replay coverage under:

- `internal/api/handlers/provider_protocol_replay_test.go`
- `internal/runtime/llmproxy/provider_protocol_replay_test.go`
- `internal/runtime/llmproxy/testdata/provider_replay/...`

## Hardening Included

This PR also keeps a few replay-driven hardening changes:

- Tracks stream format metadata so rewritten OpenAI Responses streams are emitted as Responses-shaped SSE, not Chat Completions-shaped chunks.
- Preserves OpenAI Responses creation lifecycle when required by the original stream.
- Tightens provider replay assertions around required lifecycle events and stream completion.
- Adds an explicit control-notice assertion that agents must not fabricate `autovault_...` placeholders.
- Uses fixture-safe placeholder headers instead of bearer-token-looking replay data.

## Relationship To SSE PR

This is a test/hardening follow-up to the selective SSE streaming PR:

- SSE implementation PR: #482
- This PR: provider protocol replay coverage for that SSE behavior

The implementation already landed in upstream main. This branch is based on current upstream `main` and adds one focused follow-up commit.

## Test Coverage

Command run:
```text
git diff --check
Result: PASS

Command run:

go test ./internal/api/handlers -run "Test.*Stream|Test.*Streaming|TestLLMEndpoint|TestTryContinuation|TestProviderProtocolReplay|TestLLMEndpoint_InjectsControlNoticeWhenToolsAvailable" -count=1
Result: PASS

Command run:

go test ./internal/runtime/conversation/... -count=1
Result: PASS

Command run:

go test ./internal/runtime/llmproxy/... -run "Test.*Replay|Test.*Provider|Test.*Stream|Test.*Streaming|TestContinuation|TestControlNotice" -count=1
Result: PASS