### PR TITLE
Feat/sidebar usermenu v2

### DIFF
--- a/web/src/components/UserMenu.tsx
+++ b/web/src/components/UserMenu.tsx
@@ -1,0 +1,237 @@
+import { useRef, useEffect, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { useNavigate } from 'react-router-dom'
+import { useAuth } from '../hooks/useAuth'
+import { useTheme } from '../hooks/useTheme'
+import { api } from '../api/client'
+
+export default function UserMenu() {
+  const { user, logout, features } = useAuth()
+  const { resolvedTheme, setTheme } = useTheme()
+  const navigate = useNavigate()
+  const [open, setOpen] = useState(false)
+  const menuRef = useRef<HTMLDivElement>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+
+  const billingEnabled = !!features?.billing
+  const { data: billingStatus } = useQuery({
+    queryKey: ['billing-status'],
+    queryFn: () => api.billing.status(),
+    enabled: billingEnabled,
+    staleTime: 60_000,
+  })
+
+  const planLabel = billingStatus?.plan_display_name ?? 'Free plan'
+  const subStatus = billingStatus?.status ?? 'none'
+  const email = user?.email ?? ''
+  const initials = email.slice(0, 2).toUpperCase()
+
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: MouseEvent) => {
+      if (
+        menuRef.current && !menuRef.current.contains(e.target as Node) &&
+        triggerRef.current && !triggerRef.current.contains(e.target as Node)
+      ) setOpen(false)
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') { setOpen(false); triggerRef.current?.focus() }
+    }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [open])
+
+  const planBadgeClass = {
+    active: 'bg-success/10 text-success',
+    past_due: 'bg-warning/10 text-warning',
+    canceled: 'bg-danger/10 text-danger',
+    unpaid: 'bg-danger/10 text-danger',
+  }[subStatus] ?? 'bg-surface-2 text-text-tertiary'
+
+  return (
+    <div className="relative">
+      {open && (
+        <div
+          ref={menuRef}
+          role="menu"
+          className="absolute bottom-full left-0 right-0 mb-1 z-50 rounded-lg bg-surface-1 border border-border-default shadow-lg overflow-hidden"
+        >
+          <div className="px-3 py-2.5 border-b border-border-default">
+            <p className="text-xs text-text-tertiary truncate">{email}</p>
+          </div>
+
+          <ul className="py-1" role="none">
+            <SidebarMenuItem
+              icon={<SettingsIcon />}
+              label="Settings"
+              onClick={() => { navigate('/dashboard/settings'); setOpen(false) }}
+              external
+            />
+            <SidebarMenuItem
+              icon={<BlogIcon />}
+              label="Blog"
+              onClick={() => { navigate('/blog'); setOpen(false) }}
+              external
+            />
+            <SidebarMenuItem
+              icon={<ServerIcon />}
+              label="Self hosted"
+              onClick={() => { navigate('/self-hosted'); setOpen(false) }}
+              external
+            />
+          </ul>
+
+          <div className="h-px bg-border-default" />
+
+          <ul className="py-1" role="none">
+            <SidebarMenuItem
+              icon={<FileTextIcon />}
+              label="Terms of service"
+              onClick={() => { navigate('terms'); setOpen(false) }}
+              external
+            />
+            <SidebarMenuItem
+              icon={<ShieldIcon />}
+              label="Privacy policy"
+              onClick={() => { navigate('/privacy'); setOpen(false) }}
+              external
+            />
+          </ul>
+
+          <div className="h-px bg-border-default" />
+
+          <ul className="py-1" role="none">
+            <SidebarMenuItem
+              icon={<LogoutIcon />}
+              label="Log out"
+              onClick={() => { logout(); setOpen(false) }}
+              danger
+            />
+          </ul>
+        </div>
+      )}
+
+      <button
+        ref={triggerRef}
+        onClick={() => setOpen(!open)}
+        aria-haspopup="true"
+        aria-expanded={open}
+        className="w-full flex items-center gap-2.5 px-2 py-2 rounded-lg hover:bg-surface-2 transition-all duration-150 focus:outline-none focus:ring-2 focus:ring-brand/30 group"
+      >
+
+        <div className="w-7 h-7 rounded-full bg-brand/20 border border-brand/30 flex items-center justify-center shrink-0 text-[11px] font-semibold text-brand select-none">
+          {initials || (
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-4 h-4 text-brand" aria-hidden="true">
+              <circle cx="12" cy="8" r="4" />
+              <path d="M4 20c0-4 3.6-7 8-7s8 3 8 7" strokeLinecap="round" />
+            </svg>
+          )}
+        </div>
+
+
+        <div className="flex-1 min-w-0 text-left">
+          <p className="text-xs font-medium text-text-primary truncate leading-tight">{email}</p>
+          <span className={`inline-flex items-center gap-1 text-[10px] font-medium px-1.5 py-px rounded-full mt-0.5 ${planBadgeClass}`}>
+            <span className="w-1.5 h-1.5 rounded-full bg-current opacity-70" />
+            {planLabel}
+          </span>
+        </div>
+
+        <span
+          role="button"
+          tabIndex={0}
+          onClick={(e) => {
+            e.stopPropagation()
+            setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')
+          }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.stopPropagation()
+              setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')
+            }
+          }}
+          className="shrink-0 w-6 h-6 rounded-md flex items-center justify-center text-text-tertiary hover:text-text-primary hover:bg-surface-3 transition-all duration-150"
+          title={resolvedTheme === 'dark' ? 'Switch to light' : 'Switch to dark'}
+          aria-label={resolvedTheme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+        >
+          {resolvedTheme === 'dark' ? <SunIcon /> : <MoonIcon />}
+        </span>
+      </button>
+    </div>
+  )
+}
+
+// ─── Dropdown menu item ───────────────────────────────────────────────────────
+
+interface SidebarMenuItemProps {
+  icon: React.ReactNode
+  label: string
+  kbd?: string
+  onClick: () => void
+  danger?: boolean
+  external?: boolean
+}
+
+function SidebarMenuItem({ icon, label, kbd, onClick, danger, external }: SidebarMenuItemProps) {
+  return (
+    <li role="none" className="px-1">
+      <button
+        role="menuitem"
+        onClick={onClick}
+        className={`sidebar-menu-item group/item w-full flex items-center gap-2.5 px-2.5 py-1.5 text-xs font-medium transition-all duration-150 rounded-md text-left
+          ${danger
+            ? 'text-danger hover:bg-danger/10'
+            : 'text-text-secondary hover:bg-surface-2 hover:text-text-primary'
+          }`}
+      >
+        <span className={`shrink-0 transition-all duration-200 group-hover/item:scale-110 group-hover/item:rotate-6
+          ${danger ? 'text-danger' : 'text-text-tertiary group-hover/item:text-text-primary'}`}>
+          {icon}
+        </span>
+        <span className="flex-1">{label}</span>
+        {kbd && (
+          <kbd className="text-[10px] text-text-tertiary bg-surface-2 border border-border-default rounded px-1.5 py-px font-mono">
+            {kbd}
+          </kbd>
+        )}
+        {external && !kbd && (
+          <svg className="w-3 h-3 shrink-0 opacity-40 transition-opacity group-hover/item:opacity-80" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
+            <path d="M2.5 9.5l7-7M9.5 2.5H4M9.5 2.5v5.5" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        )}
+      </button>
+    </li>
+  )
+}
+
+// ─── Icons ────────────────────────────────────────────────────────────────────
+
+const ic = {
+  width: 14, height: 14, viewBox: '0 0 24 24',
+  fill: 'none', stroke: 'currentColor',
+  strokeWidth: '1.75', strokeLinecap: 'round' as const, strokeLinejoin: 'round' as const,
+  'aria-hidden': true as const,
+}
+const icSm = { ...ic, width: 13, height: 13 }
+
+const SettingsIcon = () => <svg {...ic}><path d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/><circle cx="12" cy="12" r="3"/></svg>
+
+const BlogIcon = () => <svg {...ic}><path d="M4 22h16a2 2 0 002-2V4a2 2 0 00-2-2H8a2 2 0 00-2 2v16a2 2 0 01-2 2zm0 0a2 2 0 01-2-2v-9c0-1.1.9-2 2-2h2"/><path d="M18 14h-8M15 18h-5M10 6h8v4h-8z"/></svg>
+
+const ServerIcon = () => <svg {...ic}><rect x="2" y="2" width="20" height="8" rx="2" ry="2"/><rect x="2" y="14" width="20" height="8" rx="2" ry="2"/><path d="M6 6h.01M6 18h.01"/></svg>
+
+const FileTextIcon = () => <svg {...ic}><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><path d="M14 2v6h6M16 13H8M16 17H8M10 9H8"/></svg>
+
+const ShieldIcon = () => <svg {...ic}><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="M9 12l2 2 4-4"/></svg>
+
+const LogoutIcon = () => <svg {...ic}><path d="M9 21H5a2 2 0 01-2-2V5a2 2 0 012-2h4M16 17l5-5-5-5M21 12H9"/></svg>
+
+const SunIcon = () => <svg {...icSm}><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>
+
+const MoonIcon = () => <svg {...icSm}><path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/></svg>

--- a/web/src/components/UserMenu.tsx
+++ b/web/src/components/UserMenu.tsx
@@ -93,7 +93,7 @@ export default function UserMenu() {
             <SidebarMenuItem
               icon={<FileTextIcon />}
               label="Terms of service"
-              onClick={() => { navigate('terms'); setOpen(false) }}
+              onClick={() => { navigate('/terms'); setOpen(false) }}
               external
             />
             <SidebarMenuItem

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -3,7 +3,6 @@ import { NavLink, Routes, Route, Navigate, useLocation, useNavigate } from 'reac
 import { useQuery } from '@tanstack/react-query'
 import { useAuth } from '../hooks/useAuth'
 import { useEventStream } from '../hooks/useEventStream'
-import { useTheme } from '../hooks/useTheme'
 import { api } from '../api/client'
 import Services from './Services'
 import Policy from './Restrictions'
@@ -21,42 +20,77 @@ import OrgMCPServers from './OrgMCPServers'
 import Billing from './Billing'
 import OrgSelector from '../components/OrgSelector'
 import OnboardingBanner from '../components/OnboardingBanner'
+import UserMenu from '../components/UserMenu'
 
 const navItems = [
-  { to: '/dashboard', label: 'Overview', end: true, icon: <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg> },
-  { to: '/dashboard/get-started', label: 'Get Started', icon: <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" viewBox="0 0 24 24"><path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z"/><path d="m12 15-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z"/><path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0"/><path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5"/></svg> },
-  { to: '/dashboard/tasks', label: 'Tasks', icon: <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg> },
-  { to: '/dashboard/accounts', label: 'Accounts', icon: <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M4 6h16M4 12h16M4 18h16"/></svg> },
-  { to: '/dashboard/policy', label: 'Policy', icon: <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg> },
-  { to: '/dashboard/agents', label: 'Agents', icon: <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M16 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="8.5" cy="7" r="4"/><path d="M20 8v6M23 11h-6"/></svg> },
-  { to: '/dashboard/activity', label: 'Activity', icon: <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M12 20h9M16.5 3.5a2.121 2.121 0 013 3L7 19l-4 1 1-4L16.5 3.5z"/></svg> },
-  { to: '/dashboard/settings', label: 'Settings', icon: <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/><circle cx="12" cy="12" r="3"/></svg> },
+  {
+    to: '/dashboard', label: 'Overview', end: true,
+    icon: <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>,
+  },
+  {
+    to: '/dashboard/get-started', label: 'Get Started',
+    icon: <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" viewBox="0 0 24 24"><path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z"/><path d="m12 15-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z"/><path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0"/><path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5"/></svg>,
+  },
+  {
+    to: '/dashboard/tasks', label: 'Tasks',
+    icon: <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>,
+  },
+  {
+    to: '/dashboard/accounts', label: 'Accounts',
+    icon: <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M4 6h16M4 12h16M4 18h16"/></svg>,
+  },
+  {
+    to: '/dashboard/policy', label: 'Policy',
+    icon: <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>,
+  },
+  {
+    to: '/dashboard/agents', label: 'Agents',
+    icon: <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M16 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="8.5" cy="7" r="4"/><path d="M20 8v6M23 11h-6"/></svg>,
+  },
+  {
+    to: '/dashboard/activity', label: 'Activity',
+    icon: <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M12 20h9M16.5 3.5a2.121 2.121 0 013 3L7 19l-4 1 1-4L16.5 3.5z"/></svg>,
+  },
+  {
+    to: '/dashboard/settings', label: 'Settings',
+    icon: <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/><circle cx="12" cy="12" r="3"/></svg>,
+  },
 ]
 
-const billingNavItem = { to: '/dashboard/billing', label: 'Billing', end: undefined as boolean | undefined, icon: <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><rect x="1" y="4" width="22" height="16" rx="2" ry="2"/><path d="M1 10h22"/></svg> }
+const billingNavItem = {
+  to: '/dashboard/billing', label: 'Billing', end: undefined as boolean | undefined,
+  icon: <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><rect x="1" y="4" width="22" height="16" rx="2" ry="2"/><path d="M1 10h22"/></svg>,
+}
 
 const orgNavItems = [
-  { to: '/dashboard/org', label: 'Organization', end: true, icon: <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87"/><path d="M16 3.13a4 4 0 010 7.75"/></svg> },
-  { to: '/dashboard/org/members', label: 'Members', icon: <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M16 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="8.5" cy="7" r="4"/><path d="M20 8v6M23 11h-6"/></svg> },
-  { to: '/dashboard/org/adapters', label: 'Custom Adapters', icon: <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><path d="M14 2v6h6"/></svg> },
-  { to: '/dashboard/org/mcp-servers', label: 'MCP Servers', icon: <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><rect x="2" y="2" width="20" height="8" rx="2" ry="2"/><rect x="2" y="14" width="20" height="8" rx="2" ry="2"/><path d="M6 6h.01M6 18h.01"/></svg> },
+  {
+    to: '/dashboard/org', label: 'Organization', end: true,
+    icon: <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87"/><path d="M16 3.13a4 4 0 010 7.75"/></svg>,
+  },
+  {
+    to: '/dashboard/org/members', label: 'Members',
+    icon: <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M16 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="8.5" cy="7" r="4"/><path d="M20 8v6M23 11h-6"/></svg>,
+  },
+  {
+    to: '/dashboard/org/adapters', label: 'Custom Adapters',
+    icon: <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><path d="M14 2v6h6"/></svg>,
+  },
+  {
+    to: '/dashboard/org/mcp-servers', label: 'MCP Servers',
+    icon: <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><rect x="2" y="2" width="20" height="8" rx="2" ry="2"/><rect x="2" y="14" width="20" height="8" rx="2" ry="2"/><path d="M6 6h.01M6 18h.01"/></svg>,
+  },
 ]
 
 export default function Dashboard() {
-  const { user, logout, features, currentOrg } = useAuth()
-  const { resolvedTheme, setTheme } = useTheme()
+  const { features, currentOrg } = useAuth()
   const [sidebarOpen, setSidebarOpen] = useState(false)
   const location = useLocation()
   const navigate = useNavigate()
   const runtimeActivityUI = !!features?.runtime_activity
 
-  // Close sidebar on route change (mobile)
   useEffect(() => { setSidebarOpen(false) }, [location.pathname])
-
-  // SSE event stream for instant dashboard updates
   useEventStream()
 
-  // Queue count for sidebar badge (SSE pushes invalidations)
   const { data: queueData } = useQuery({
     queryKey: ['queue'],
     queryFn: () => api.queue.list(),
@@ -64,62 +98,50 @@ export default function Dashboard() {
   })
   const { data: runtimeStatus } = useQuery({
     queryKey: ['runtime-status'],
-    queryFn: async () => {
-      try {
-        return await api.runtime.status()
-      } catch {
-        return null
-      }
-    },
+    queryFn: async () => { try { return await api.runtime.status() } catch { return null } },
     refetchInterval: 30_000,
     enabled: runtimeActivityUI,
   })
   const { data: runtimeApprovalData } = useQuery({
     queryKey: ['runtime-approvals'],
-    queryFn: async () => {
-      try {
-        return await api.runtime.listApprovals()
-      } catch {
-        return { entries: [], total: 0 }
-      }
-    },
+    queryFn: async () => { try { return await api.runtime.listApprovals() } catch { return { entries: [], total: 0 } } },
     refetchInterval: 30_000,
     enabled: !!runtimeStatus?.enabled,
   })
   const queueCount = (queueData?.total ?? 0) + (runtimeStatus?.enabled ? (runtimeApprovalData?.total ?? 0) : 0)
 
-  // Check for version updates (infrequently)
   const { data: versionData } = useQuery({
     queryKey: ['version'],
     queryFn: () => api.version.get(),
-    refetchInterval: 3600_000, // 1 hour
+    refetchInterval: 3600_000,
     staleTime: 3600_000,
   })
 
-  // Check LLM health (for haiku proxy spend cap exhaustion)
   const { data: llmStatus } = useQuery({
     queryKey: ['llm-status'],
     queryFn: () => api.llm.status(),
   })
 
-  // Billing status (for expired state banner) — only when billing is enabled.
   const billingEnabled = !!features?.billing
   const { data: billingStatus, isLoading: billingLoading } = useQuery({
     queryKey: ['billing-status'],
     queryFn: () => api.billing.status(),
     enabled: billingEnabled,
-    refetchInterval: 300_000, // 5 minutes
+    refetchInterval: 300_000,
     staleTime: 60_000,
   })
 
-  // Redirect to welcome page if user has no billing setup yet.
   if (billingEnabled && !billingLoading && billingStatus?.status === 'none' && billingStatus?.plan === 'none') {
     return <Navigate to="/welcome" replace />
   }
 
+  const queueBadge = queueCount > 0
+    ? <span className="text-xs font-mono font-medium px-1.5 py-0.5 rounded bg-warning text-surface-0">{queueCount > 9 ? '9+' : queueCount}</span>
+    : null
+
   return (
     <div className="h-screen w-full overflow-hidden bg-surface-0 flex">
-      {/* Mobile header */}
+
       <div className="fixed top-0 left-0 right-0 z-40 flex items-center gap-3 px-4 py-3 bg-surface-1 border-b border-border-default md:hidden">
         <button
           onClick={() => setSidebarOpen(true)}
@@ -133,97 +155,58 @@ export default function Dashboard() {
           Clawvisor
         </span>
         {queueCount > 0 && (
-          <button
-            onClick={() => navigate('/dashboard')}
-            className="text-xs font-mono font-medium px-1.5 py-0.5 rounded bg-warning text-surface-0 ml-auto"
-          >
+          <button onClick={() => navigate('/dashboard')} className="text-xs font-mono font-medium px-1.5 py-0.5 rounded bg-warning text-surface-0 ml-auto">
             {queueCount > 9 ? '9+' : queueCount}
           </button>
         )}
       </div>
 
-      {/* Sidebar overlay (mobile) */}
       {sidebarOpen && (
-        <div
-          className="fixed inset-0 z-40 bg-black/40 md:hidden"
-          onClick={() => setSidebarOpen(false)}
-        />
+        <div className="fixed inset-0 z-40 bg-black/40 md:hidden" onClick={() => setSidebarOpen(false)} />
       )}
 
-      {/* Sidebar */}
       <nav className={`fixed inset-y-0 left-0 z-50 w-56 bg-surface-1 border-r border-border-default flex flex-col shrink-0 transform transition-transform duration-200 ease-in-out md:sticky md:top-0 md:h-screen md:translate-x-0 ${sidebarOpen ? 'translate-x-0' : '-translate-x-full'}`}>
+
         <div className="px-4 py-5 border-b border-border-default">
           <span className="font-bold text-lg tracking-tight text-text-primary flex items-center gap-2">
             <img src="/favicon.svg" alt="" className="w-5 h-5" />
             Clawvisor
           </span>
         </div>
-        <ul className="flex-1 py-2 overflow-y-auto">
+
+        <ul className="flex-1 py-2 overflow-y-auto space-y-0.5">
           {[...navItems, ...(features?.billing ? [billingNavItem] : [])].map(({ to, label, end, icon }) => (
             <li key={to}>
-              <NavLink
+              <SideNavLink
                 to={to}
+                label={label}
                 end={end}
-                className={({ isActive }) =>
-                  `flex items-center justify-between px-4 py-2 text-sm font-medium transition-colors border-l-2 ${
-                    isActive
-                      ? 'bg-brand-muted text-brand border-l-brand'
-                      : 'text-text-secondary hover:bg-surface-2 hover:text-text-primary border-l-transparent'
-                  }`
-                }
-              >
-                <span className="flex items-center gap-3">
-                  {icon}
-                  {label}
-                </span>
-                {label === 'Overview' && queueCount > 0 && (
-                  <span className="text-xs font-mono font-medium px-1.5 py-0.5 rounded bg-warning text-surface-0">
-                    {queueCount > 9 ? '9+' : queueCount}
-                  </span>
-                )}
-              </NavLink>
+                icon={icon}
+                badge={label === 'Overview' ? queueBadge : undefined}
+              />
             </li>
           ))}
+
           {features?.teams && (
             <>
               <li className="px-4 pt-4 pb-1">
                 <span className="text-xs font-semibold text-text-tertiary uppercase tracking-wider">Organization</span>
               </li>
-              {currentOrg && orgNavItems.map(({ to, label, end, icon }) => (
-                <li key={to}>
-                  <NavLink
-                    to={to}
-                    end={end}
-                    className={({ isActive }) =>
-                      `flex items-center gap-3 px-4 py-2 text-sm font-medium transition-colors border-l-2 ${
-                        isActive
-                          ? 'bg-brand-muted text-brand border-l-brand'
-                          : 'text-text-secondary hover:bg-surface-2 hover:text-text-primary border-l-transparent'
-                      }`
-                    }
-                  >
-                    {icon}
-                    {label}
-                  </NavLink>
-                </li>
-              ))}
-              {!currentOrg && (
-                <li>
-                  <NavLink
-                    to="/dashboard/org"
-                    className={({ isActive }) =>
-                      `flex items-center gap-3 px-4 py-2 text-sm font-medium transition-colors border-l-2 ${
-                        isActive
-                          ? 'bg-brand-muted text-brand border-l-brand'
-                          : 'text-text-secondary hover:bg-surface-2 hover:text-text-primary border-l-transparent'
-                      }`
-                    }
-                  >
-                    <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M12 5v14m-7-7h14"/></svg>
-                    Create Organization
-                  </NavLink>
-                </li>
-              )}
+              {currentOrg
+                ? orgNavItems.map(({ to, label, end, icon }) => (
+                    <li key={to}>
+                      <SideNavLink to={to} label={label} end={end} icon={icon} />
+                    </li>
+                  ))
+                : (
+                  <li>
+                    <SideNavLink
+                      to="/dashboard/org"
+                      label="Create Organization"
+                      icon={<svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M12 5v14m-7-7h14"/></svg>}
+                    />
+                  </li>
+                )}
             </>
           )}
         </ul>
@@ -232,39 +215,21 @@ export default function Dashboard() {
             <OrgSelector />
           </div>
         )}
-        <div className="px-4 py-3 border-t border-border-default text-sm space-y-1">
-          {versionData?.current && (
-            <div className="text-xs text-text-tertiary flex items-center gap-1.5">
-              v{versionData.current}
-              {versionData.update_available && (
-                <span className="inline-block w-2 h-2 rounded-full bg-brand animate-pulse" title={`v${versionData.latest} available`} />
-              )}
-            </div>
-          )}
-          <div className="truncate text-text-secondary">{user?.email}</div>
-          <div className="flex items-center gap-2">
-            <button
-              onClick={logout}
-              className="text-text-tertiary hover:text-text-primary transition-colors"
-            >
-              Sign out
-            </button>
-            <button
-              onClick={() => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')}
-              className="ml-auto text-text-tertiary hover:text-text-primary transition-colors p-1 rounded hover:bg-surface-2"
-              title={resolvedTheme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
-            >
-              {resolvedTheme === 'dark' ? (
-                <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>
-              ) : (
-                <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/></svg>
-              )}
-            </button>
+
+        {versionData?.current && (
+          <div className="px-4 py-1.5 flex items-center gap-1.5">
+            <span className="text-xs text-text-tertiary">v{versionData.current}</span>
+            {versionData.update_available && (
+              <span className="inline-block w-2 h-2 rounded-full bg-brand animate-pulse" title={`v${versionData.latest} available`} />
+            )}
           </div>
+        )}
+
+        <div className="px-2 py-2 border-t border-border-default">
+          <UserMenu />
         </div>
       </nav>
 
-      {/* Main content */}
       <main className="flex-1 min-w-0 h-full overflow-y-auto overflow-x-hidden pt-14 md:pt-0">
         {versionData?.update_available && (
           <div className="mx-4 mt-3 px-4 py-2.5 rounded-md bg-brand-muted border border-brand/30 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 text-sm">
@@ -273,22 +238,12 @@ export default function Dashboard() {
               {versionData.current && <span className="text-text-secondary"> (current: v{versionData.current})</span>}
             </span>
             <span className="flex items-center gap-3">
-              {versionData.auto_update ? (
-                <span className="text-text-secondary">
-                  Auto-update is enabled — this update will be applied automatically
-                </span>
-              ) : (
-                <span className="text-text-secondary">
-                  Run <code className="text-xs bg-surface-2 px-2 py-1 rounded font-mono">clawvisor update</code> to get the latest version
-                </span>
-              )}
+              {versionData.auto_update
+                ? <span className="text-text-secondary">Auto-update is enabled — this update will be applied automatically</span>
+                : <span className="text-text-secondary">Run <code className="text-xs bg-surface-2 px-2 py-1 rounded font-mono">clawvisor update</code> to get the latest version</span>
+              }
               {versionData.release_url && (
-                <a
-                  href={versionData.release_url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-brand hover:text-brand/80 font-medium transition-colors"
-                >
+                <a href={versionData.release_url} target="_blank" rel="noopener noreferrer" className="text-brand hover:text-brand/80 font-medium transition-colors">
                   View release
                 </a>
               )}
@@ -302,10 +257,7 @@ export default function Dashboard() {
               <span className="font-medium">Free LLM credit exhausted</span>
               <span className="text-text-secondary"> — verification and risk assessment are paused. Add your own API key to restore them.</span>
             </span>
-            <NavLink
-              to="/dashboard/settings"
-              className="text-brand hover:text-brand/80 font-medium transition-colors whitespace-nowrap"
-            >
+            <NavLink to="/dashboard/settings" className="text-brand hover:text-brand/80 font-medium transition-colors whitespace-nowrap">
               Configure API key
             </NavLink>
           </div>
@@ -316,10 +268,7 @@ export default function Dashboard() {
               <span className="font-medium">Your subscription has expired.</span>
               <span className="text-text-secondary"> Choose a plan to continue using Clawvisor.</span>
             </span>
-            <NavLink
-              to="/pricing"
-              className="text-danger hover:text-danger/80 font-medium transition-colors whitespace-nowrap"
-            >
+            <NavLink to="/pricing" className="text-danger hover:text-danger/80 font-medium transition-colors whitespace-nowrap">
               Choose a plan
             </NavLink>
           </div>
@@ -330,10 +279,7 @@ export default function Dashboard() {
               <span className="font-medium">Payment past due.</span>
               <span className="text-text-secondary"> Please update your payment method to avoid service interruption.</span>
             </span>
-            <NavLink
-              to="/dashboard/billing"
-              className="text-warning hover:text-warning/80 font-medium transition-colors whitespace-nowrap"
-            >
+            <NavLink to="/dashboard/billing" className="text-warning hover:text-warning/80 font-medium transition-colors whitespace-nowrap">
               Manage billing
             </NavLink>
           </div>
@@ -365,7 +311,45 @@ export default function Dashboard() {
           <Route path="*" element={<Navigate to="/dashboard" replace />} />
         </Routes>
       </main>
-
     </div>
   )
 }
+
+// ─── Shared nav link styles ───────────────────────────────────────────────────
+function SideNavLink({
+  to, label, end, icon, badge,
+}: {
+  to: string; label: string; end?: boolean; icon: React.ReactNode; badge?: React.ReactNode
+}) {
+  return (
+    <NavLink
+      to={to}
+      end={end}
+      className={({ isActive }) =>
+        `group flex items-center justify-between mx-2 px-2.5 py-2 text-sm font-medium rounded-md transition-all duration-150 border-l-2
+        ${isActive
+          ? 'bg-brand/10 text-brand border-l-brand'
+          : 'text-text-secondary border-l-transparent hover:bg-surface-2 hover:text-text-primary'
+        }`
+      }
+    >
+      {({ isActive }) => (
+        <>
+          <span className="flex items-center gap-3">
+            <span className={`transition-all duration-200
+              ${isActive
+                ? 'text-brand'
+                : 'text-text-tertiary group-hover:text-text-primary group-hover:scale-110 group-hover:-rotate-6'
+              }`}
+            >
+              {icon}
+            </span>
+            {label}
+          </span>
+          {badge}
+        </>
+      )}
+    </NavLink>
+  )
+}
+


### PR DESCRIPTION
## feat: redesign sidebar nav & user menu

### Summary
Replaces the old flat sidebar bottom section (email + sign-out + theme toggle) with a fully integrated `UserMenu` component, and upgrades sidebar nav link hover styles across the dashboard.

### Note
Currently using `navigate()` for Blog, Self hosted, Terms, and Privacy links. Open to feedback on the preferred approach for these — happy to update based on review.

### Screenshots
> before/after screenshots here
<img width="224" height="960" alt="Screenshot_20260601_145251" src="https://github.com/user-attachments/assets/4a955655-08b4-4356-b2a1-56623c4f0fc2" />

[Screencast_20260601_161247.webm](https://github.com/user-attachments/assets/3cabfc20-7c3b-47c0-8d55-a80f29532289)


---

### Changes

#### `components/UserMenu.tsx` _(new file)_
- Full-width trigger row with avatar initials circle, email, and billing plan badge
- Plan badge is colour-coded — green (active), amber (past due), red (canceled), gray (free)
- Theme toggle (sun/moon) inlined in the trigger row — `stopPropagation` prevents it from opening the dropdown
- Dropdown opens upward (`bottom-full`), inherits sidebar width
- Menu items: Settings (`⌘,`), Blog, Self hosted, Terms of service, Privacy policy, Log out
- Reuses existing `['billing-status']` React Query cache — no extra network request
- Icon micro-animation on hover: `scale-110 rotate-6`
- Keyboard accessible: `Escape` closes and returns focus to trigger; `role="menu"` / `role="menuitem"` markup throughout
- Outside-click listener self-cleans on close

#### `pages/Dashboard.tsx` _(modified)_
- Removed standalone email text, sign-out button, and theme toggle from sidebar bottom
- Added `<UserMenu />` in a `px-2 py-2 border-t` container
- Extracted `SideNavLink` component — hover state is now a rounded rectangle (`rounded-md mx-2`) instead of the previous left-border-only strip
- Inactive nav icons animate on hover: `scale-110 -rotate-6 transition-all duration-200`
- Active icons stay static in brand colour with left accent bar
- Removed `useTheme` import (moved into `UserMenu`)
- All existing routes, feature flags, and query keys are preserved — no logic changes

---