### PR TITLE
fix(autovault): allowlist placeholder prefix chars to match inspector

### DIFF
--- a/internal/runtime/autovault/placeholder.go
+++ b/internal/runtime/autovault/placeholder.go
@@ -6,10 +6,30 @@ import (
 	"strings"
 )
 
-var placeholderPrefixReplacer = strings.NewReplacer(".", "_", ":", "_", "-", "_", "/", "_")
+// sanitizePlaceholderPrefix folds the lowercased service id to the
+// [a-z0-9_] allowlist — everything outside becomes `_`. This must stay
+// a strict subset of the inspector's placeholder character class
+// (inspector/inspector.go shadowPlaceholderExtractRE,
+// parser/parser.go autovaultPlaceholderRE) so any placeholder we
+// generate round-trips through detection. A denylist of known
+// separators ("." ":" "-" "/") had let chars like "@" survive into
+// stored placeholders that the inspector then truncated mid-string.
+func sanitizePlaceholderPrefix(s string) string {
+	b := make([]byte, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'a' && c <= 'z', c >= '0' && c <= '9', c == '_':
+			b[i] = c
+		default:
+			b[i] = '_'
+		}
+	}
+	return string(b)
+}
 
 func PlaceholderPrefix(service string) string {
-	safe := placeholderPrefixReplacer.Replace(strings.ToLower(strings.TrimSpace(service)))
+	safe := sanitizePlaceholderPrefix(strings.ToLower(strings.TrimSpace(service)))
 	if safe == "" {
 		safe = "unknown"
 	}


### PR DESCRIPTION
## Summary
- Vault item ids containing characters like `@` (e.g. `google.gmail:eric@clawvisor.com`) produced placeholders the inspector regex then truncated mid-string, causing post-approval release to fail with `outcome=approval_release_blocked reason="placeholder lookup failed"`.
- Replaced the denylist (`.` `:` `-` `/` → `_`) with an `[a-z0-9_]` allowlist that mirrors the inspector's character class, so any generated placeholder round-trips through detection. Comment pins the dependency on the inspector regexes.

## Test plan
- [x] `go test ./internal/runtime/autovault/... ./internal/runtime/llmproxy/... ./internal/api/handlers/...`
- [ ] Existing vault rows with `@` in the placeholder need to be re-added (or migrated) to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)