### PR TITLE
fix(llmproxy): restore first-turn routing notice on streaming SSE

### DIFF
--- a/internal/api/handlers/llm_endpoint.go
+++ b/internal/api/handlers/llm_endpoint.go
@@ -858,6 +858,16 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 				Checkouts:                        h.TaskCheckouts,
 				DefaultTaskExpirySeconds:         h.DefaultTaskExpirySeconds,
 			}
+			// First-turn routing notice. Mirrors the buffered path's
+			// invocation below (search "first-turn routing notice").
+			// The streaming SSE injector inside PostprocessStream wraps
+			// the writer so the notice surfaces as the leading content
+			// block / output_item and downstream indices are shifted by
+			// +1. Skip on non-200 — error bodies aren't shaped to take
+			// the prepend and would be soft no-ops anyway.
+			if resp.StatusCode == http.StatusOK && firstTurn {
+				cfg.FirstTurnNotice = llmproxy.RenderAgentRoutingNotice(agent.Name, mintedConversationID)
+			}
 
 			w.Header().Del("Content-Length")
 			w.Header().Del("Content-Encoding")

--- a/internal/runtime/conversation/streaming_assistant_prepend.go
+++ b/internal/runtime/conversation/streaming_assistant_prepend.go
@@ -1,0 +1,434 @@
+package conversation
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// StreamShape identifies which streaming SSE wire format a notice
+// writer should target. The shape is fixed at construction so the
+// per-event injection logic can branch deterministically without
+// sniffing bytes.
+type StreamShape int
+
+const (
+	StreamShapeUnknown StreamShape = iota
+	StreamShapeAnthropicMessages
+	StreamShapeOpenAIChat
+	StreamShapeOpenAIResponses
+)
+
+// DetectStreamShape picks the streaming SSE shape from the inbound LLM
+// request. Returns StreamShapeUnknown when neither provider matches —
+// the streaming-notice writer treats that as "no-op pass-through" so a
+// stray shape never blocks a stream.
+func DetectStreamShape(req *http.Request, provider Provider) StreamShape {
+	switch provider {
+	case ProviderAnthropic:
+		return StreamShapeAnthropicMessages
+	case ProviderOpenAI:
+		if IsOpenAIChatCompletionsEndpoint(req) {
+			return StreamShapeOpenAIChat
+		}
+		return StreamShapeOpenAIResponses
+	}
+	return StreamShapeUnknown
+}
+
+// NewStreamingFirstTurnNoticeWriter wraps dest with an io.Writer that
+// transforms the SSE event stream written through it by injecting a
+// leading assistant-text notice at output index 0 and shifting all
+// subsequent indices by +1. The shape parameter selects the wire format:
+//
+//   - StreamShapeAnthropicMessages — after message_start passes through,
+//     emit content_block_start/delta/stop at index 0 with the notice
+//     text; shift `index` on every later content_block_* event by +1.
+//   - StreamShapeOpenAIResponses — after response.created passes through
+//     (or eagerly at the top if absent), emit the six-event notice
+//     envelope at output_index 0; shift `output_index` on every later
+//     event by +1; rewrite response.completed to prepend the notice item
+//     to response.output[] so reconcilers see the notice in the final
+//     state.
+//   - StreamShapeOpenAIChat — emit a synthetic chat.completion.chunk
+//     carrying role:"assistant" + content:<text> at the top of the
+//     stream, then pass everything else through unchanged.
+//
+// When text is blank or shape is StreamShapeUnknown, returns dest
+// unchanged (no-op).
+//
+// The wrapper line-buffers partial writes — callers don't need to
+// align Write boundaries with SSE event boundaries.
+func NewStreamingFirstTurnNoticeWriter(dest io.Writer, shape StreamShape, text string) io.Writer {
+	if strings.TrimSpace(text) == "" {
+		return dest
+	}
+	if shape == StreamShapeUnknown {
+		return dest
+	}
+	return &streamingPrependWriter{
+		dest:  dest,
+		shape: shape,
+		text:  text,
+	}
+}
+
+// streamingPrependWriter does the per-event line buffering shared by
+// the Anthropic and OpenAI-Responses paths. Each Write may carry
+// partial events; we accumulate lines until we hit a blank-line
+// terminator, then dispatch one complete event.
+type streamingPrependWriter struct {
+	dest  io.Writer
+	shape StreamShape
+	text  string
+
+	// lineBuf holds bytes that haven't yet completed a line (no \n
+	// yet). Once a \n arrives the accumulated line is processed.
+	lineBuf bytes.Buffer
+
+	// Event accumulator — SSE events are zero or more `event:` /
+	// `data:` lines followed by a blank line.
+	curEvent string
+	dataLns  []string
+
+	// State for index shifting + injection. noticeInjected goes true
+	// after we've emitted the leading notice events; from then on we
+	// shift downstream indices.
+	noticeInjected bool
+}
+
+func (s *streamingPrependWriter) Write(p []byte) (int, error) {
+	if _, err := s.lineBuf.Write(p); err != nil {
+		return 0, err
+	}
+	for s.processNextLine() {
+	}
+	return len(p), nil
+}
+
+// Close flushes any partial state the writer has buffered. SSE streams
+// SHOULD terminate every event with a blank line; this is the safety
+// net for upstreams that don't, and for unit tests that don't end on a
+// blank-line boundary. Safe to call multiple times.
+func (s *streamingPrependWriter) Close() error {
+	// Any line bytes without a trailing newline get treated as a final
+	// line so partial events at stream-end still flush.
+	if s.lineBuf.Len() > 0 {
+		trailing := s.lineBuf.String()
+		s.lineBuf.Reset()
+		trimmed := strings.TrimRight(trailing, "\r")
+		if strings.HasPrefix(trimmed, "event:") {
+			s.curEvent = strings.TrimSpace(strings.TrimPrefix(trimmed, "event:"))
+		} else if strings.HasPrefix(trimmed, "data:") {
+			s.dataLns = append(s.dataLns, strings.TrimSpace(strings.TrimPrefix(trimmed, "data:")))
+		} else if !strings.HasPrefix(trimmed, ":") && trimmed != "" {
+			fmt.Fprintln(s.dest, trailing)
+		}
+	}
+	if s.curEvent != "" || len(s.dataLns) > 0 {
+		s.flushEvent()
+	}
+	// Chat fallback — if the stream ended without a mergeable chunk
+	// AND without `data: [DONE]`, surface the notice via a synthetic
+	// trailing chunk so the user still sees it. Cheap to emit; loose
+	// accumulators happily concat it onto the prior assistant turn.
+	if s.shape == StreamShapeOpenAIChat && !s.noticeInjected {
+		s.emitSyntheticChatNotice()
+		s.noticeInjected = true
+	}
+	return nil
+}
+
+// processNextLine consumes one complete line (terminated by \n) from
+// the line buffer. Returns false when there's no complete line left
+// (caller stops looping). Returns true even on emit errors so the
+// caller drains the buffer — surfacing write errors mid-stream is a
+// non-recoverable case anyway (the client connection is gone).
+func (s *streamingPrependWriter) processNextLine() bool {
+	data := s.lineBuf.Bytes()
+	nl := bytes.IndexByte(data, '\n')
+	if nl < 0 {
+		return false
+	}
+	line := string(data[:nl])
+	s.lineBuf.Next(nl + 1)
+
+	trimmed := strings.TrimRight(line, "\r")
+
+	// Comment line — pass through verbatim (preserves SSE keepalives,
+	// vendor pings, etc. that the rewriter forwarded).
+	if strings.HasPrefix(trimmed, ":") {
+		fmt.Fprintln(s.dest, line)
+		return true
+	}
+
+	// Blank line — terminates the current event.
+	if trimmed == "" {
+		s.flushEvent()
+		return true
+	}
+
+	if strings.HasPrefix(trimmed, "event:") {
+		s.curEvent = strings.TrimSpace(strings.TrimPrefix(trimmed, "event:"))
+		return true
+	}
+	if strings.HasPrefix(trimmed, "data:") {
+		// OpenAI Chat Completions framing is one `data:` per event with
+		// blank-line separators that the upstream rewriter doesn't
+		// always preserve (the pass-through path in
+		// OpenAIResponseRewriter.streamRewriteChatCompletions emits
+		// `data: …\n` without the trailing `\n\n`). Treat each `data:`
+		// line as terminating the previous chat event so chunks don't
+		// silently merge into one giant accumulated event.
+		if s.shape == StreamShapeOpenAIChat && len(s.dataLns) > 0 {
+			s.flushEvent()
+		}
+		s.dataLns = append(s.dataLns, strings.TrimSpace(strings.TrimPrefix(trimmed, "data:")))
+		return true
+	}
+
+	// Unrecognized line shape — pass through unchanged so we don't
+	// silently drop content. SSE allows id: / retry: lines that we
+	// don't model.
+	fmt.Fprintln(s.dest, line)
+	return true
+}
+
+// flushEvent dispatches one complete accumulated event to the
+// provider-specific handler and resets the accumulator.
+func (s *streamingPrependWriter) flushEvent() {
+	if len(s.dataLns) == 0 && s.curEvent == "" {
+		return
+	}
+	event := s.curEvent
+	data := strings.Join(s.dataLns, "\n")
+	s.curEvent = ""
+	s.dataLns = s.dataLns[:0]
+
+	switch s.shape {
+	case StreamShapeAnthropicMessages:
+		s.flushAnthropic(event, data)
+	case StreamShapeOpenAIResponses:
+		s.flushOpenAIResponses(event, data)
+	case StreamShapeOpenAIChat:
+		s.flushOpenAIChat(event, data)
+	default:
+		// Unknown shape — pass through (defensive; constructor refuses
+		// StreamShapeUnknown, but keep this branch correct anyway).
+		s.passThrough(event, data)
+	}
+}
+
+// passThrough emits an event to the destination in canonical
+// `event:` / `data:` / blank-line form. Used by the per-shape handlers
+// for any event they don't transform.
+func (s *streamingPrependWriter) passThrough(event, data string) {
+	s.emitEvent(event, data)
+}
+
+func (s *streamingPrependWriter) emitEvent(event, data string) {
+	if event != "" {
+		fmt.Fprintf(s.dest, "event: %s\n", event)
+	}
+	fmt.Fprintf(s.dest, "data: %s\n\n", data)
+}
+
+func (s *streamingPrependWriter) emitJSON(event string, payload any) {
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return
+	}
+	s.emitEvent(event, string(raw))
+}
+
+// --- Anthropic ---------------------------------------------------------
+
+func (s *streamingPrependWriter) flushAnthropic(event, data string) {
+	switch event {
+	case "message_start":
+		s.passThrough(event, data)
+		if !s.noticeInjected {
+			s.emitJSON("content_block_start", map[string]any{
+				"type":  "content_block_start",
+				"index": 0,
+				"content_block": map[string]any{
+					"type": "text",
+					"text": "",
+				},
+			})
+			s.emitJSON("content_block_delta", map[string]any{
+				"type":  "content_block_delta",
+				"index": 0,
+				"delta": map[string]any{"type": "text_delta", "text": s.text},
+			})
+			s.emitJSON("content_block_stop", map[string]any{
+				"type":  "content_block_stop",
+				"index": 0,
+			})
+			s.noticeInjected = true
+		}
+	case "content_block_start", "content_block_delta", "content_block_stop":
+		if !s.noticeInjected {
+			s.passThrough(event, data)
+			return
+		}
+		shifted, ok := shiftAnthropicEventIndex(event, data, 1)
+		if !ok {
+			s.passThrough(event, data)
+			return
+		}
+		s.emitEvent(event, string(shifted))
+	default:
+		s.passThrough(event, data)
+	}
+}
+
+// --- OpenAI Responses --------------------------------------------------
+
+func (s *streamingPrependWriter) flushOpenAIResponses(event, data string) {
+	switch event {
+	case "response.created":
+		s.passThrough(event, data)
+		if !s.noticeInjected {
+			s.emitOpenAIResponsesNotice()
+			s.noticeInjected = true
+		}
+		return
+	case "response.completed":
+		// Late injection — emit the notice envelope first, then the
+		// rewritten completion. Mirrors the buffered helper's fallback
+		// when response.created was missing.
+		if !s.noticeInjected {
+			s.emitOpenAIResponsesNotice()
+			s.noticeInjected = true
+		}
+		rewritten, ok := injectNoticeIntoResponsesCompleted(data, s.text)
+		if ok {
+			s.emitEvent(event, string(rewritten))
+			return
+		}
+		s.passThrough(event, data)
+		return
+	}
+
+	if !s.noticeInjected {
+		// We received a non-response.created/completed event without
+		// having injected the notice. Emit eagerly so the harness sees
+		// the notice in the same stream.
+		s.emitOpenAIResponsesNotice()
+		s.noticeInjected = true
+	}
+
+	shifted, ok := shiftOpenAIResponsesEventIndex(data, 1)
+	if !ok {
+		s.passThrough(event, data)
+		return
+	}
+	s.emitEvent(event, string(shifted))
+}
+
+func (s *streamingPrependWriter) emitOpenAIResponsesNotice() {
+	const noticeItemID = "msg_clawvisor_notice"
+	s.emitJSON("response.output_item.added", map[string]any{
+		"type":         "response.output_item.added",
+		"output_index": 0,
+		"item": map[string]any{
+			"type":   "message",
+			"id":     noticeItemID,
+			"role":   "assistant",
+			"status": "in_progress",
+		},
+	})
+	s.emitJSON("response.content_part.added", map[string]any{
+		"type":          "response.content_part.added",
+		"item_id":       noticeItemID,
+		"output_index":  0,
+		"content_index": 0,
+		"part":          map[string]any{"type": "output_text", "text": ""},
+	})
+	s.emitJSON("response.output_text.delta", map[string]any{
+		"type":          "response.output_text.delta",
+		"item_id":       noticeItemID,
+		"output_index":  0,
+		"content_index": 0,
+		"delta":         s.text,
+	})
+	s.emitJSON("response.output_text.done", map[string]any{
+		"type":          "response.output_text.done",
+		"item_id":       noticeItemID,
+		"output_index":  0,
+		"content_index": 0,
+		"text":          s.text,
+	})
+	s.emitJSON("response.content_part.done", map[string]any{
+		"type":          "response.content_part.done",
+		"item_id":       noticeItemID,
+		"output_index":  0,
+		"content_index": 0,
+		"part":          map[string]any{"type": "output_text", "text": s.text},
+	})
+	s.emitJSON("response.output_item.done", map[string]any{
+		"type":         "response.output_item.done",
+		"output_index": 0,
+		"item": map[string]any{
+			"type":   "message",
+			"id":     noticeItemID,
+			"role":   "assistant",
+			"status": "completed",
+			"content": []map[string]any{
+				{"type": "output_text", "text": s.text},
+			},
+		},
+	})
+}
+
+// --- OpenAI Chat Completions ------------------------------------------
+
+func (s *streamingPrependWriter) flushOpenAIChat(event, data string) {
+	// `data: [DONE]` is the chat stream's terminal sentinel. If we
+	// haven't yet found a chunk to merge into, fall back to a
+	// synthetic leading chunk so the notice still surfaces. Mirrors
+	// synthLeadingNoticeChatSSE in the buffered helper.
+	if data == "[DONE]" {
+		if !s.noticeInjected {
+			s.emitSyntheticChatNotice()
+			s.noticeInjected = true
+		}
+		s.emitEvent(event, data)
+		return
+	}
+	if s.noticeInjected {
+		s.emitEvent(event, data)
+		return
+	}
+	// Merge into the first chunk that carries a choices[].delta. The
+	// buffered helper goes to lengths to avoid emitting a separate
+	// role-bearing chunk in front of the upstream's first chunk
+	// because strict accumulators interpret the second `role:"assistant"`
+	// as a new assistant turn. Streaming has the same constraint —
+	// merge instead of prefix.
+	if merged, ok := mergeOpenAIChatChunkWithNotice([]byte(data), s.text); ok {
+		s.emitEvent(event, string(merged))
+		s.noticeInjected = true
+		return
+	}
+	// This chunk wasn't mergeable (no choices/delta shape). Pass it
+	// through and try the next one.
+	s.emitEvent(event, data)
+}
+
+func (s *streamingPrependWriter) emitSyntheticChatNotice() {
+	block := chatCompletionSSEBlock(map[string]any{
+		"id":     "chatcmpl_clawvisor_notice",
+		"object": "chat.completion.chunk",
+		"choices": []map[string]any{{
+			"index":         0,
+			"delta":         map[string]any{"role": "assistant", "content": s.text},
+			"finish_reason": nil,
+		}},
+	})
+	_, _ = io.WriteString(s.dest, block)
+}

--- a/internal/runtime/conversation/streaming_assistant_prepend_test.go
+++ b/internal/runtime/conversation/streaming_assistant_prepend_test.go
@@ -1,0 +1,413 @@
+package conversation
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// writeInChunks emulates the rewriter writing partial event data
+// across multiple Write calls — the injector must line-buffer
+// correctly when events arrive split mid-line.
+func writeInChunks(t *testing.T, w io.Writer, body string, chunk int) {
+	t.Helper()
+	for i := 0; i < len(body); i += chunk {
+		end := i + chunk
+		if end > len(body) {
+			end = len(body)
+		}
+		if _, err := w.Write([]byte(body[i:end])); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+	}
+}
+
+func TestStreamingFirstTurnNoticeWriter_BlankTextIsNoOp(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewStreamingFirstTurnNoticeWriter(&buf, StreamShapeAnthropicMessages, "   ")
+	if w != &buf {
+		t.Fatalf("expected dest returned unchanged for blank text; got wrapper")
+	}
+}
+
+func TestStreamingFirstTurnNoticeWriter_UnknownShapeIsNoOp(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewStreamingFirstTurnNoticeWriter(&buf, StreamShapeUnknown, "hi")
+	if w != &buf {
+		t.Fatalf("expected dest returned unchanged for unknown shape; got wrapper")
+	}
+}
+
+func TestStreamingFirstTurnNoticeWriter_Anthropic(t *testing.T) {
+	upstream := strings.Join([]string{
+		`event: message_start`,
+		`data: {"type":"message_start","message":{"id":"msg_x","role":"assistant","model":"claude-sonnet-4"}}`,
+		``,
+		`event: content_block_start`,
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		``,
+		`event: content_block_delta`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hello"}}`,
+		``,
+		`event: content_block_stop`,
+		`data: {"type":"content_block_stop","index":0}`,
+		``,
+		`event: message_delta`,
+		`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}`,
+		``,
+		`event: message_stop`,
+		`data: {"type":"message_stop"}`,
+		``,
+	}, "\n")
+
+	var buf bytes.Buffer
+	w := NewStreamingFirstTurnNoticeWriter(&buf, StreamShapeAnthropicMessages, "[Clawvisor] notice")
+	writeInChunks(t, w, upstream, 17) // 17 to force splits across line boundaries
+	if c, ok := w.(io.Closer); ok {
+		_ = c.Close()
+	}
+
+	got := buf.String()
+
+	// Notice text appears once, before the upstream's "hello".
+	noticePos := strings.Index(got, "[Clawvisor] notice")
+	helloPos := strings.Index(got, "hello")
+	if noticePos == -1 {
+		t.Fatalf("notice text missing:\n%s", got)
+	}
+	if helloPos == -1 {
+		t.Fatalf("upstream text missing:\n%s", got)
+	}
+	if noticePos > helloPos {
+		t.Errorf("notice should precede upstream text:\n%s", got)
+	}
+	if strings.Count(got, "[Clawvisor] notice") != 1 {
+		t.Errorf("notice should appear exactly once:\n%s", got)
+	}
+
+	// Original upstream text block (at index 0) should be shifted to
+	// index 1. Walk the events and verify.
+	events, err := parseSSEEvents([]byte(got))
+	if err != nil {
+		t.Fatalf("parseSSEEvents: %v", err)
+	}
+
+	var sawNoticeStart, sawNoticeDelta, sawNoticeStop bool
+	var sawShiftedHello bool
+	for _, ev := range events {
+		var obj map[string]any
+		if err := json.Unmarshal([]byte(ev.Data), &obj); err != nil {
+			continue
+		}
+		switch ev.Event {
+		case "content_block_start":
+			cb, _ := obj["content_block"].(map[string]any)
+			idx := numAsInt(obj["index"])
+			if cb != nil && cb["type"] == "text" {
+				if idx == 0 && !sawNoticeStart {
+					sawNoticeStart = true
+				}
+			}
+		case "content_block_delta":
+			delta, _ := obj["delta"].(map[string]any)
+			idx := numAsInt(obj["index"])
+			if delta != nil && delta["text"] == "[Clawvisor] notice" && idx == 0 {
+				sawNoticeDelta = true
+			}
+			if delta != nil && delta["text"] == "hello" {
+				if idx != 1 {
+					t.Errorf("upstream hello delta should be at index 1; got %d", idx)
+				}
+				sawShiftedHello = true
+			}
+		case "content_block_stop":
+			idx := numAsInt(obj["index"])
+			if idx == 0 && !sawNoticeStop {
+				sawNoticeStop = true
+			}
+		}
+	}
+	if !sawNoticeStart || !sawNoticeDelta || !sawNoticeStop {
+		t.Errorf("notice events missing: start=%v delta=%v stop=%v",
+			sawNoticeStart, sawNoticeDelta, sawNoticeStop)
+	}
+	if !sawShiftedHello {
+		t.Errorf("upstream content_block_delta with text=hello not found in output")
+	}
+}
+
+func TestStreamingFirstTurnNoticeWriter_OpenAIChat_MergesIntoFirstChunk(t *testing.T) {
+	// First chunk carries role:"assistant" — the merge path must
+	// rewrite its delta.content to carry the notice + "hi" instead of
+	// emitting a separate role-bearing prefix chunk (which would
+	// register as a second assistant turn in strict accumulators).
+	upstream := `data: {"id":"chatcmpl_x","choices":[{"index":0,"delta":{"role":"assistant","content":"hi"}}]}` + "\n\n" +
+		`data: {"id":"chatcmpl_x","choices":[{"index":0,"delta":{"content":" there"}}]}` + "\n\n" +
+		`data: [DONE]` + "\n\n"
+
+	var buf bytes.Buffer
+	w := NewStreamingFirstTurnNoticeWriter(&buf, StreamShapeOpenAIChat, "[Clawvisor] notice")
+	writeInChunks(t, w, upstream, 13)
+	if c, ok := w.(io.Closer); ok {
+		_ = c.Close()
+	}
+
+	got := buf.String()
+
+	if !strings.Contains(got, "[DONE]") {
+		t.Fatalf("[DONE] sentinel missing:\n%s", got)
+	}
+	if strings.Count(got, "[Clawvisor] notice") != 1 {
+		t.Errorf("notice should appear exactly once:\n%s", got)
+	}
+	// The synthetic-prefix marker must NOT appear — that fallback only
+	// fires when no upstream chunk was mergeable.
+	if strings.Contains(got, "chatcmpl_clawvisor_notice") {
+		t.Errorf("synthetic prefix chunk should not be emitted when first chunk is mergeable:\n%s", got)
+	}
+	// Walk parsed chat chunks and check the first one carries
+	// role:"assistant" PLUS content that begins with the notice text.
+	events, err := parseSSEEvents([]byte(got))
+	if err != nil {
+		t.Fatalf("parseSSEEvents: %v", err)
+	}
+	if len(events) == 0 {
+		t.Fatalf("no events parsed:\n%s", got)
+	}
+	var first map[string]any
+	if err := json.Unmarshal([]byte(events[0].Data), &first); err != nil {
+		t.Fatalf("first chunk not JSON: %v\n%s", err, events[0].Data)
+	}
+	choices, _ := first["choices"].([]any)
+	if len(choices) == 0 {
+		t.Fatalf("first chunk missing choices: %v", first)
+	}
+	choice0, _ := choices[0].(map[string]any)
+	delta, _ := choice0["delta"].(map[string]any)
+	if delta["role"] != "assistant" {
+		t.Errorf("first chunk should preserve role:\"assistant\"; got delta=%v", delta)
+	}
+	content, _ := delta["content"].(string)
+	if !strings.HasPrefix(content, "[Clawvisor] notice") {
+		t.Errorf("first chunk content should be prefixed with notice; got %q", content)
+	}
+	if !strings.Contains(content, "hi") {
+		t.Errorf("first chunk content should still include original \"hi\"; got %q", content)
+	}
+	// Count role transitions across the stream — there must be
+	// exactly one. A second role:"assistant" in any subsequent chunk
+	// is the bug the merge path exists to prevent.
+	roleCount := 0
+	for _, ev := range events {
+		var obj map[string]any
+		if err := json.Unmarshal([]byte(ev.Data), &obj); err != nil {
+			continue
+		}
+		ch, _ := obj["choices"].([]any)
+		for _, c := range ch {
+			cm, _ := c.(map[string]any)
+			d, _ := cm["delta"].(map[string]any)
+			if _, ok := d["role"]; ok {
+				roleCount++
+			}
+		}
+	}
+	if roleCount != 1 {
+		t.Errorf("expected exactly one role transition in stream; got %d\n%s", roleCount, got)
+	}
+}
+
+func TestStreamingFirstTurnNoticeWriter_OpenAIChat_SyntheticFallbackOnDoneOnly(t *testing.T) {
+	// Stream carries only [DONE] — no mergeable chunk. The synthetic
+	// fallback should fire so the notice still surfaces.
+	upstream := `data: [DONE]` + "\n\n"
+
+	var buf bytes.Buffer
+	w := NewStreamingFirstTurnNoticeWriter(&buf, StreamShapeOpenAIChat, "[Clawvisor] notice")
+	writeInChunks(t, w, upstream, 5)
+	if c, ok := w.(io.Closer); ok {
+		_ = c.Close()
+	}
+
+	got := buf.String()
+	if !strings.Contains(got, "chatcmpl_clawvisor_notice") {
+		t.Errorf("expected synthetic notice chunk in [DONE]-only stream:\n%s", got)
+	}
+	if !strings.Contains(got, "[Clawvisor] notice") {
+		t.Errorf("notice text missing:\n%s", got)
+	}
+	if !strings.Contains(got, "[DONE]") {
+		t.Errorf("[DONE] sentinel must still be forwarded:\n%s", got)
+	}
+}
+
+func TestStreamingFirstTurnNoticeWriter_OpenAIResponses(t *testing.T) {
+	upstream := strings.Join([]string{
+		`event: response.created`,
+		`data: {"type":"response.created","response":{"id":"resp_x"}}`,
+		``,
+		`event: response.output_item.added`,
+		`data: {"type":"response.output_item.added","output_index":0,"item":{"type":"message","id":"msg_real","role":"assistant","status":"in_progress"}}`,
+		``,
+		`event: response.output_text.delta`,
+		`data: {"type":"response.output_text.delta","item_id":"msg_real","output_index":0,"content_index":0,"delta":"hello"}`,
+		``,
+		`event: response.output_item.done`,
+		`data: {"type":"response.output_item.done","output_index":0,"item":{"type":"message","id":"msg_real","role":"assistant","status":"completed","content":[{"type":"output_text","text":"hello"}]}}`,
+		``,
+		`event: response.completed`,
+		`data: {"type":"response.completed","response":{"id":"resp_x","output":[{"type":"message","id":"msg_real","role":"assistant","content":[{"type":"output_text","text":"hello"}]}],"output_text":"hello"}}`,
+		``,
+	}, "\n")
+
+	var buf bytes.Buffer
+	w := NewStreamingFirstTurnNoticeWriter(&buf, StreamShapeOpenAIResponses, "[Clawvisor] notice")
+	writeInChunks(t, w, upstream, 19)
+	if c, ok := w.(io.Closer); ok {
+		_ = c.Close()
+	}
+
+	got := buf.String()
+	noticePos := strings.Index(got, "[Clawvisor] notice")
+	helloPos := strings.Index(got, `"hello"`)
+	if noticePos == -1 {
+		t.Fatalf("notice text missing:\n%s", got)
+	}
+	if helloPos == -1 {
+		t.Fatalf("upstream content missing:\n%s", got)
+	}
+	if noticePos > helloPos {
+		t.Errorf("notice should precede upstream content:\n%s", got)
+	}
+
+	events, err := parseSSEEvents([]byte(got))
+	if err != nil {
+		t.Fatalf("parseSSEEvents: %v", err)
+	}
+
+	// Notice envelope is six events at output_index 0.
+	var noticeEnvelope []string
+	var shiftedHello bool
+	var completedHasNotice bool
+	for _, ev := range events {
+		var obj map[string]any
+		_ = json.Unmarshal([]byte(ev.Data), &obj)
+		switch ev.Event {
+		case "response.output_item.added", "response.content_part.added",
+			"response.output_text.delta", "response.output_text.done",
+			"response.content_part.done", "response.output_item.done":
+			idx := numAsInt(obj["output_index"])
+			itemID := ""
+			if v, ok := obj["item_id"].(string); ok {
+				itemID = v
+			}
+			if item, ok := obj["item"].(map[string]any); ok {
+				if id, ok := item["id"].(string); ok {
+					itemID = id
+				}
+			}
+			switch {
+			case itemID == "msg_clawvisor_notice":
+				if idx != 0 {
+					t.Errorf("notice event %q at unexpected index %d", ev.Event, idx)
+				}
+				noticeEnvelope = append(noticeEnvelope, ev.Event)
+			case itemID == "msg_real":
+				// Original upstream events should be shifted to index 1.
+				if idx != 1 {
+					t.Errorf("upstream event %q for msg_real should be at index 1; got %d", ev.Event, idx)
+				}
+				if delta, ok := obj["delta"].(string); ok && delta == "hello" {
+					shiftedHello = true
+				}
+			}
+		case "response.completed":
+			resp, _ := obj["response"].(map[string]any)
+			if resp == nil {
+				continue
+			}
+			output, _ := resp["output"].([]any)
+			if len(output) == 0 {
+				continue
+			}
+			first, _ := output[0].(map[string]any)
+			if first["id"] == "msg_clawvisor_notice" {
+				completedHasNotice = true
+			}
+		}
+	}
+	if len(noticeEnvelope) < 6 {
+		t.Errorf("expected six notice envelope events, got %d (%v)", len(noticeEnvelope), noticeEnvelope)
+	}
+	if !shiftedHello {
+		t.Errorf("upstream output_text.delta with text=hello not found shifted to index 1")
+	}
+	if !completedHasNotice {
+		t.Errorf("response.completed should have notice prepended to response.output[]\nGOT:\n%s", got)
+	}
+}
+
+func TestStreamingFirstTurnNoticeWriter_PassThroughComments(t *testing.T) {
+	// SSE allows `:` comments (vendor keepalives). The injector must
+	// pass them through verbatim, not eat them as data lines.
+	upstream := ": keepalive\n" +
+		"event: message_start\n" +
+		`data: {"type":"message_start","message":{"id":"msg_x","role":"assistant","model":"claude-sonnet-4"}}` + "\n\n" +
+		": another keepalive\n" +
+		"event: content_block_delta\n" +
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}` + "\n\n"
+
+	var buf bytes.Buffer
+	w := NewStreamingFirstTurnNoticeWriter(&buf, StreamShapeAnthropicMessages, "[Clawvisor] notice")
+	writeInChunks(t, w, upstream, 7)
+	if c, ok := w.(io.Closer); ok {
+		_ = c.Close()
+	}
+
+	got := buf.String()
+	if !strings.Contains(got, ": keepalive") {
+		t.Errorf("first keepalive comment lost:\n%s", got)
+	}
+	if !strings.Contains(got, ": another keepalive") {
+		t.Errorf("second keepalive comment lost:\n%s", got)
+	}
+}
+
+func TestDetectStreamShape(t *testing.T) {
+	cases := []struct {
+		name     string
+		path     string
+		provider Provider
+		want     StreamShape
+	}{
+		{"anthropic_messages", "/v1/messages", ProviderAnthropic, StreamShapeAnthropicMessages},
+		{"openai_chat", "/v1/chat/completions", ProviderOpenAI, StreamShapeOpenAIChat},
+		{"openai_responses", "/v1/responses", ProviderOpenAI, StreamShapeOpenAIResponses},
+		{"unknown_provider", "/v1/anything", Provider(""), StreamShapeUnknown},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("POST", tc.path, nil)
+			got := DetectStreamShape(req, tc.provider)
+			if got != tc.want {
+				t.Errorf("DetectStreamShape(%s, %s) = %d; want %d", tc.path, tc.provider, got, tc.want)
+			}
+		})
+	}
+}
+
+func numAsInt(v any) int {
+	switch n := v.(type) {
+	case float64:
+		return int(n)
+	case int:
+		return n
+	case json.Number:
+		i, _ := n.Int64()
+		return int(i)
+	}
+	return -1
+}

--- a/internal/runtime/llmproxy/postprocess.go
+++ b/internal/runtime/llmproxy/postprocess.go
@@ -1677,44 +1677,52 @@ func PostprocessStream(
 	contentType string,
 	cfg PostprocessConfig,
 ) (PostprocessResult, error) {
-	if cfg.Inspector == nil {
-		_, err := io.Copy(w, r)
-		return PostprocessResult{SkippedReason: "no inspector configured"}, err
-	}
-
 	registry := cfg.ResponseRegistry
 	if registry == nil {
 		registry = conversation.DefaultResponseRegistry()
 	}
 
 	streamingRewriter := matchByRouteStreaming(req, registry)
+
+	// First-turn routing notice. Wrap the destination so the per-event
+	// SSE state machine emits through an injector that prepends the
+	// notice block at index 0 and shifts the rest by +1. Mirrors the
+	// buffered path's PrependAssistantNotice call in the handler —
+	// kept here (not in the handler) so the rewriter itself doesn't
+	// need to grow a notice parameter, and so any future streaming
+	// caller picks up the behavior automatically.
+	//
+	// Wrap BEFORE the inspector / rewriter early returns so the notice
+	// still surfaces on the inspector-disabled pass-through path —
+	// matching the buffered Postprocess flow, which injects regardless
+	// of inspector state. Skip when there's no rewriter (we'd have no
+	// provider to derive the wire shape from) or when the shape is
+	// unrecognized (the constructor turns that into a no-op anyway, so
+	// this is belt-and-suspenders).
+	if cfg.FirstTurnNotice != "" && streamingRewriter != nil {
+		shape := conversation.DetectStreamShape(req, streamingRewriter.Name())
+		noticeW := conversation.NewStreamingFirstTurnNoticeWriter(w, shape, cfg.FirstTurnNotice)
+		// The injector buffers partial SSE events; ensure trailing
+		// state flushes when the stream completes. Closer-only
+		// wrappers (the real injector) flush; the no-op case
+		// (StreamShapeUnknown / blank text) returns dest unchanged
+		// and is not closeable.
+		if closer, ok := noticeW.(io.Closer); ok {
+			defer func() { _ = closer.Close() }()
+		}
+		w = noticeW
+	}
+
+	if cfg.Inspector == nil {
+		_, err := io.Copy(w, r)
+		return PostprocessResult{SkippedReason: "no inspector configured"}, err
+	}
 	if streamingRewriter == nil {
 		_, err := io.Copy(w, r)
 		return PostprocessResult{SkippedReason: "no streaming rewriter for route"}, err
 	}
 
 	provider := streamingRewriter.Name()
-
-	// First-turn routing notice. Wrap the destination so the per-event
-	// SSE state machine in the rewriter emits through an injector
-	// that prepends the notice block at index 0 and shifts the rest
-	// by +1. Mirrors the buffered path's PrependAssistantNotice call
-	// in the handler — kept here (not in the handler) so the rewriter
-	// itself doesn't need to grow a notice parameter, and so any
-	// future streaming caller picks up the behavior automatically.
-	if cfg.FirstTurnNotice != "" {
-		shape := conversation.DetectStreamShape(req, provider)
-		noticeW := conversation.NewStreamingFirstTurnNoticeWriter(w, shape, cfg.FirstTurnNotice)
-		// The injector buffers partial SSE events; ensure trailing
-		// state flushes when StreamRewrite returns. Closer-only
-		// callers (Close()-implementing wrappers) flush; the no-op
-		// case (StreamShapeUnknown / blank notice) returns dest
-		// unchanged and is not closeable.
-		if closer, ok := noticeW.(io.Closer); ok {
-			defer func() { _ = closer.Close() }()
-		}
-		w = noticeW
-	}
 
 	auditAgent := auditAgentForCfg(cfg)
 

--- a/internal/runtime/llmproxy/postprocess.go
+++ b/internal/runtime/llmproxy/postprocess.go
@@ -257,6 +257,15 @@ type PostprocessConfig struct {
 	// via cfg.ProxyLite.TraceLogPath. Calls on a nil *TraceLogger are
 	// no-ops, so production code doesn't branch.
 	Trace *TraceLogger
+
+	// FirstTurnNotice, when non-empty, is the assistant-text notice the
+	// streaming postprocess path prepends to the response so the user
+	// sees a one-liner ("[Clawvisor] Routing this conversation…")
+	// before the model's first content on a fresh conversation. Only
+	// consulted by PostprocessStream; the buffered Postprocess path
+	// keeps its existing inline prepend at the handler level. Empty
+	// disables injection.
+	FirstTurnNotice string
 }
 
 // PostprocessResult reports what happened during postprocess. The handler
@@ -1685,6 +1694,28 @@ func PostprocessStream(
 	}
 
 	provider := streamingRewriter.Name()
+
+	// First-turn routing notice. Wrap the destination so the per-event
+	// SSE state machine in the rewriter emits through an injector
+	// that prepends the notice block at index 0 and shifts the rest
+	// by +1. Mirrors the buffered path's PrependAssistantNotice call
+	// in the handler — kept here (not in the handler) so the rewriter
+	// itself doesn't need to grow a notice parameter, and so any
+	// future streaming caller picks up the behavior automatically.
+	if cfg.FirstTurnNotice != "" {
+		shape := conversation.DetectStreamShape(req, provider)
+		noticeW := conversation.NewStreamingFirstTurnNoticeWriter(w, shape, cfg.FirstTurnNotice)
+		// The injector buffers partial SSE events; ensure trailing
+		// state flushes when StreamRewrite returns. Closer-only
+		// callers (Close()-implementing wrappers) flush; the no-op
+		// case (StreamShapeUnknown / blank notice) returns dest
+		// unchanged and is not closeable.
+		if closer, ok := noticeW.(io.Closer); ok {
+			defer func() { _ = closer.Close() }()
+		}
+		w = noticeW
+	}
+
 	auditAgent := auditAgentForCfg(cfg)
 
 	originalPendingApprovals := cfg.PendingApprovals

--- a/internal/runtime/llmproxy/postprocess_test.go
+++ b/internal/runtime/llmproxy/postprocess_test.go
@@ -184,6 +184,68 @@ func TestPostprocessStream_NoStreamingRewriterPassesThrough(t *testing.T) {
 	}
 }
 
+// TestPostprocessStream_FirstTurnNoticeInjectsWithoutInspector covers
+// the inspector-disabled pass-through path. The buffered Postprocess
+// injects the routing notice independently of inspector state, so the
+// streaming path should match for symmetry.
+func TestPostprocessStream_FirstTurnNoticeInjectsWithoutInspector(t *testing.T) {
+	req := httptest.NewRequest("POST", "/v1/messages", nil)
+	input := "event: message_start\n" +
+		`data: {"type":"message_start","message":{"id":"msg_x","role":"assistant","model":"claude-sonnet-4"}}` + "\n\n" +
+		"event: content_block_start\n" +
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}` + "\n\n" +
+		"event: content_block_delta\n" +
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}` + "\n\n"
+	var output bytes.Buffer
+
+	result, err := PostprocessStream(context.Background(), req, strings.NewReader(input), &output, "text/event-stream", PostprocessConfig{
+		Inspector:       nil,
+		FirstTurnNotice: "[Clawvisor] routing notice",
+	})
+	if err != nil {
+		t.Fatalf("PostprocessStream: %v", err)
+	}
+	if result.SkippedReason != "no inspector configured" {
+		t.Fatalf("expected inspector-skipped result; got %q", result.SkippedReason)
+	}
+	got := output.String()
+	if !strings.Contains(got, "[Clawvisor] routing notice") {
+		t.Fatalf("notice should surface even without inspector:\n%s", got)
+	}
+	// Upstream "hi" delta should shift to index 1 since the injected
+	// notice occupies index 0.
+	if !strings.Contains(got, `"index":1`) {
+		t.Errorf("upstream content_block_delta should be shifted to index 1:\n%s", got)
+	}
+}
+
+// TestPostprocessStream_FirstTurnNoticeSkippedWithoutRewriter covers
+// the route-without-streaming-rewriter early return: we can't derive
+// a wire shape, so the injector is bypassed and the body passes
+// through unchanged.
+func TestPostprocessStream_FirstTurnNoticeSkippedWithoutRewriter(t *testing.T) {
+	req := httptest.NewRequest("POST", "/api/unknown", nil)
+	input := "data: hello\n\n"
+	var output bytes.Buffer
+
+	result, err := PostprocessStream(context.Background(), req, strings.NewReader(input), &output, "text/event-stream", PostprocessConfig{
+		Inspector:       inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{}),
+		FirstTurnNotice: "[Clawvisor] routing notice",
+	})
+	if err != nil {
+		t.Fatalf("PostprocessStream: %v", err)
+	}
+	if result.SkippedReason == "" {
+		t.Fatal("expected skipped reason")
+	}
+	if output.String() != input {
+		t.Fatalf("expected raw passthrough when no rewriter; got %q", output.String())
+	}
+	if strings.Contains(output.String(), "routing notice") {
+		t.Errorf("notice should not surface without a known wire shape:\n%s", output.String())
+	}
+}
+
 func TestPostprocess_JSONNoTrigger(t *testing.T) {
 	body := anthropicJSONWithToolUse(`{"url":"https://example.com/foo"}`)
 	req := httptest.NewRequest("POST", "/v1/messages", nil)


### PR DESCRIPTION
## Summary

The lite-proxy streaming branch added in #482 bypassed the first-turn `PrependAssistantNotice` that the buffered path applies, so the `[Clawvisor] Routing this conversation…` banner stopped surfacing on fresh conversations served via SSE.

Adds `conversation.NewStreamingFirstTurnNoticeWriter` — a per-event SSE injector that wraps the destination writer inside `PostprocessStream`. It prepends the notice as content_block 0 (Anthropic), output_item 0 with full six-event envelope + rewritten `response.completed` (OpenAI Responses), or merged into the first mergeable chunk's `delta.content` (OpenAI Chat), with a synthetic-chunk fallback when no upstream chunk is mergeable. Downstream indices are shifted by +1 in all cases. The buffered path is unchanged.

## Test plan

- [x] `go test ./internal/runtime/conversation ./internal/runtime/llmproxy ./internal/api/handlers`
- [x] Unit tests cover Anthropic / Chat / Responses notice injection, the chat merge-into-first-chunk path (asserts one role transition), `[DONE]`-only synthetic fallback, SSE comment passthrough, partial-write chunking, and shape detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)