### PR TITLE
feat(resolver): refresh expired OAuth tokens before forwarding

### DIFF
--- a/internal/api/handlers/proxy_resolver.go
+++ b/internal/api/handlers/proxy_resolver.go
@@ -577,12 +577,26 @@ func (h *ProxyResolverHandler) oauthAccessTokenForRuntimeCredential(ctx context.
 	if oauthCfg == nil {
 		return "", false, nil
 	}
+	// Past this point the adapter has declared itself OAuth via
+	// OAuthConfig(), so the stored credential MUST be OAuth-shaped.
+	// A parse failure here (e.g. malformed `expiry`) is not a signal
+	// to fall back to ExtractCredentialValue — that path would pull
+	// the stale access_token verbatim and ship it upstream, silently
+	// disabling refresh. Fail closed with a distinct error code.
 	var stored oauthCredentialForResolver
 	if err := json.Unmarshal(raw, &stored); err != nil {
-		return "", false, nil
+		return "", true, &resolverAPIError{
+			status: http.StatusUnauthorized,
+			code:   "OAUTH_CREDENTIAL_INVALID",
+			msg:    "stored OAuth credential could not be parsed",
+		}
 	}
 	if stored.AccessToken == "" && stored.RefreshToken == "" {
-		return "", false, nil
+		return "", true, &resolverAPIError{
+			status: http.StatusUnauthorized,
+			code:   "OAUTH_CREDENTIAL_INVALID",
+			msg:    "stored OAuth credential has no access or refresh token",
+		}
 	}
 	token, err := oauthCfg.TokenSource(ctx, &oauth2.Token{
 		AccessToken:  stored.AccessToken,

--- a/internal/api/handlers/proxy_resolver.go
+++ b/internal/api/handlers/proxy_resolver.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -17,8 +18,10 @@ import (
 	"github.com/clawvisor/clawvisor/internal/runtime/autovault"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/inspector"
+	"github.com/clawvisor/clawvisor/pkg/adapters"
 	"github.com/clawvisor/clawvisor/pkg/store"
 	"github.com/clawvisor/clawvisor/pkg/vault"
+	"golang.org/x/oauth2"
 )
 
 // ProxyResolverHandler is the lite-proxy reverse-proxy. The agent harness
@@ -30,10 +33,11 @@ import (
 // v1 scope: header-credential placeholders only. Body / query / cookie
 // placeholder mutation is Phase 4.
 type ProxyResolverHandler struct {
-	Store  store.Store
-	Vault  vault.Vault
-	Client *http.Client
-	Logger *slog.Logger
+	Store      store.Store
+	Vault      vault.Vault
+	AdapterReg *adapters.Registry
+	Client     *http.Client
+	Logger     *slog.Logger
 
 	// AuditEmitter writes one audit_log row per resolver request +
 	// per placeholder swapped. nil disables audit logging.
@@ -463,9 +467,9 @@ func (h *ProxyResolverHandler) swapHeaderPlaceholders(r *http.Request, agent *st
 			}
 			return "", err
 		}
-		extracted, err := autovault.ExtractCredentialValue(raw)
+		extracted, err := h.extractRuntimeCredentialValue(r.Context(), ph, raw)
 		if err != nil {
-			return "", fmt.Errorf("extract credential: %w", err)
+			return "", err
 		}
 		go func(id string) {
 			// Fire-and-forget: detach cancellation but cap so a stuck DB
@@ -535,6 +539,72 @@ func (h *ProxyResolverHandler) swapHeaderPlaceholders(r *http.Request, agent *st
 		out[canonical] = swapped
 	}
 	return out, allReplaced, nil
+}
+
+type oauthCredentialForResolver struct {
+	AccessToken  string    `json:"access_token"`
+	RefreshToken string    `json:"refresh_token"`
+	Expiry       time.Time `json:"expiry"`
+}
+
+func (h *ProxyResolverHandler) extractRuntimeCredentialValue(ctx context.Context, ph *store.RuntimePlaceholder, raw []byte) (string, error) {
+	if token, ok, err := h.oauthAccessTokenForRuntimeCredential(ctx, ph, raw); ok || err != nil {
+		if err != nil {
+			return "", err
+		}
+		return token, nil
+	}
+	extracted, err := autovault.ExtractCredentialValue(raw)
+	if err != nil {
+		return "", fmt.Errorf("extract credential: %w", err)
+	}
+	return extracted, nil
+}
+
+func (h *ProxyResolverHandler) oauthAccessTokenForRuntimeCredential(ctx context.Context, ph *store.RuntimePlaceholder, raw []byte) (string, bool, error) {
+	if h.AdapterReg == nil || ph == nil {
+		return "", false, nil
+	}
+	serviceID, _ := splitServiceScopedVaultItemID(ph.ServiceID)
+	if serviceID == "" {
+		return "", false, nil
+	}
+	adapter, ok := h.AdapterReg.GetForUser(ctx, serviceID, ph.UserID)
+	if !ok {
+		return "", false, nil
+	}
+	oauthCfg := adapter.OAuthConfig()
+	if oauthCfg == nil {
+		return "", false, nil
+	}
+	var stored oauthCredentialForResolver
+	if err := json.Unmarshal(raw, &stored); err != nil {
+		return "", false, nil
+	}
+	if stored.AccessToken == "" && stored.RefreshToken == "" {
+		return "", false, nil
+	}
+	token, err := oauthCfg.TokenSource(ctx, &oauth2.Token{
+		AccessToken:  stored.AccessToken,
+		RefreshToken: stored.RefreshToken,
+		Expiry:       stored.Expiry,
+		TokenType:    "Bearer",
+	}).Token()
+	if err != nil {
+		return "", true, &resolverAPIError{
+			status: http.StatusUnauthorized,
+			code:   "OAUTH_REFRESH_FAILED",
+			msg:    "could not refresh OAuth credential",
+		}
+	}
+	if token.AccessToken == "" {
+		return "", true, &resolverAPIError{
+			status: http.StatusUnauthorized,
+			code:   "OAUTH_REFRESH_FAILED",
+			msg:    "OAuth credential did not return an access token",
+		}
+	}
+	return token.AccessToken, true, nil
 }
 
 // resolverHopByHopHeaders is the canonical set of hop-by-hop headers

--- a/internal/api/handlers/proxy_resolver_test.go
+++ b/internal/api/handlers/proxy_resolver_test.go
@@ -269,6 +269,98 @@ func TestResolver_RefreshesExpiredOAuthCredentialBeforeForwarding(t *testing.T) 
 	}
 }
 
+// Malformed `expiry` in a stored OAuth credential must fail closed with
+// OAUTH_CREDENTIAL_INVALID rather than silently falling back to the
+// legacy ExtractCredentialValue path, which would lift the stale
+// access_token verbatim and ship it upstream (disabling refresh).
+func TestResolver_MalformedOAuthExpiryFailsClosed(t *testing.T) {
+	var refreshRequests int
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		refreshRequests++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"fresh-access-token","token_type":"Bearer","expires_in":3600}`))
+	}))
+	defer tokenSrv.Close()
+
+	var upstreamCalls int
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamCalls++
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer upstream.Close()
+
+	h, st, user, agent, nonces, _ := newSeededResolver(t)
+	reg := adapters.NewRegistry()
+	reg.Register(resolverOAuthTestAdapter{serviceID: "google.gmail", tokenURL: tokenSrv.URL})
+	h.AdapterReg = reg
+	h.Client = upstream.Client()
+	h.Client.Transport = &redirectTargetTransport{base: upstream.URL}
+
+	// Hand-rolled JSON so `expiry` is an unparseable string — encoding/json
+	// would otherwise emit a valid RFC3339 timestamp for a time.Time field.
+	credential := []byte(`{"type":"oauth2","access_token":"expired-access-token","refresh_token":"refresh-token","expiry":"not-a-date"}`)
+	const vaultKey = "google:eric@example.com"
+	if err := h.Vault.Set(context.Background(), user.ID, vaultKey, credential); err != nil {
+		t.Fatalf("vault.Set: %v", err)
+	}
+	expiresAt := time.Now().UTC().Add(time.Hour)
+	const grantID = "grant-google"
+	if err := st.CreateCredentialAuthorization(context.Background(), &store.CredentialAuthorization{
+		ID:            grantID,
+		UserID:        user.ID,
+		AgentID:       agent.ID,
+		Scope:         "session",
+		CredentialRef: vaultKey,
+		Service:       "google.gmail:eric@example.com",
+		Host:          "gmail.googleapis.com",
+		HeaderName:    "authorization",
+		Scheme:        "bearer",
+		Status:        "active",
+		ExpiresAt:     &expiresAt,
+	}); err != nil {
+		t.Fatalf("CreateCredentialAuthorization: %v", err)
+	}
+	placeholder, err := autovault.GeneratePlaceholder(autovault.PlaceholderPrefix("google.gmail:eric@example.com"))
+	if err != nil {
+		t.Fatalf("GeneratePlaceholder: %v", err)
+	}
+	if err := st.CreateRuntimePlaceholder(context.Background(), &store.RuntimePlaceholder{
+		Placeholder:       placeholder,
+		UserID:            user.ID,
+		AgentID:           agent.ID,
+		ServiceID:         "google.gmail:eric@example.com",
+		VaultItemID:       "google.gmail:eric@example.com",
+		CredentialGrantID: grantID,
+		ExpiresAt:         &expiresAt,
+	}); err != nil {
+		t.Fatalf("CreateRuntimePlaceholder: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	mw := middleware.RequireAgentLLMNonce(st, nonces, slog.Default())
+	mux.Handle("/api/proxy/", mw(http.HandlerFunc(h.Forward)))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/proxy/gmail/v1/users/me/messages", nil)
+	req.Header.Set("X-Clawvisor-Target-Host", "gmail.googleapis.com")
+	req.Header.Set("X-Clawvisor-Caller", nonceForRequest(t, nonces, agent.ID, req))
+	req.Header.Set("Authorization", "Bearer "+placeholder)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d (%s)", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "OAUTH_CREDENTIAL_INVALID") {
+		t.Fatalf("expected OAUTH_CREDENTIAL_INVALID in body, got %q", rec.Body.String())
+	}
+	if refreshRequests != 0 {
+		t.Fatalf("expected no refresh attempt on unparseable credential, got %d", refreshRequests)
+	}
+	if upstreamCalls != 0 {
+		t.Fatalf("stale access_token must not be forwarded upstream, got %d calls", upstreamCalls)
+	}
+}
+
 // An explicit port on X-Clawvisor-Target-Host must pass the bound-service
 // allowlist check (allowlist entries are hostnames) without losing the
 // port for the actual upstream dial. Before the fix, the boundary check

--- a/internal/api/handlers/proxy_resolver_test.go
+++ b/internal/api/handlers/proxy_resolver_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"log/slog"
 	"net"
@@ -16,8 +17,10 @@ import (
 	"github.com/clawvisor/clawvisor/internal/auth"
 	"github.com/clawvisor/clawvisor/internal/runtime/autovault"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy"
+	"github.com/clawvisor/clawvisor/pkg/adapters"
 	"github.com/clawvisor/clawvisor/pkg/store"
 	"github.com/clawvisor/clawvisor/pkg/store/sqlite"
+	"golang.org/x/oauth2"
 )
 
 func newSeededResolver(t *testing.T) (*ProxyResolverHandler, store.Store, *store.User, *store.Agent, llmproxy.CallerNonceCache, string) {
@@ -96,6 +99,31 @@ func nonceForRequest(t *testing.T, nonces llmproxy.CallerNonceCache, agentID str
 	)
 }
 
+type resolverOAuthTestAdapter struct {
+	serviceID string
+	tokenURL  string
+}
+
+func (a resolverOAuthTestAdapter) ServiceID() string { return a.serviceID }
+func (a resolverOAuthTestAdapter) SupportedActions() []string {
+	return []string{"list_messages"}
+}
+func (a resolverOAuthTestAdapter) Execute(context.Context, adapters.Request) (*adapters.Result, error) {
+	return nil, nil
+}
+func (a resolverOAuthTestAdapter) OAuthConfig() *oauth2.Config {
+	return &oauth2.Config{
+		ClientID:     "client-id",
+		ClientSecret: "client-secret",
+		Endpoint: oauth2.Endpoint{
+			TokenURL: a.tokenURL,
+		},
+	}
+}
+func (a resolverOAuthTestAdapter) CredentialFromToken(*oauth2.Token) ([]byte, error) { return nil, nil }
+func (a resolverOAuthTestAdapter) ValidateCredential([]byte) error                   { return nil }
+func (a resolverOAuthTestAdapter) RequiredScopes() []string                          { return nil }
+
 func TestResolver_HappyPath(t *testing.T) {
 	var seenHost, seenPath, seenAuth string
 	var seenBody []byte
@@ -142,6 +170,103 @@ func TestResolver_HappyPath(t *testing.T) {
 		t.Fatalf("expected upstream Authorization=Bearer real-gh-token, got %q", seenAuth)
 	}
 	_ = seenBody
+}
+
+func TestResolver_RefreshesExpiredOAuthCredentialBeforeForwarding(t *testing.T) {
+	var refreshRequests int
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		refreshRequests++
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		if r.Form.Get("grant_type") != "refresh_token" || r.Form.Get("refresh_token") != "refresh-token" {
+			t.Fatalf("unexpected refresh request form: %v", r.Form)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"fresh-access-token","token_type":"Bearer","expires_in":3600}`))
+	}))
+	defer tokenSrv.Close()
+
+	var seenAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenAuth = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer upstream.Close()
+
+	h, st, user, agent, nonces, _ := newSeededResolver(t)
+	reg := adapters.NewRegistry()
+	reg.Register(resolverOAuthTestAdapter{serviceID: "google.gmail", tokenURL: tokenSrv.URL})
+	h.AdapterReg = reg
+	h.Client = upstream.Client()
+	h.Client.Transport = &redirectTargetTransport{base: upstream.URL}
+
+	credential, err := json.Marshal(map[string]any{
+		"type":          "oauth2",
+		"access_token":  "expired-access-token",
+		"refresh_token": "refresh-token",
+		"expiry":        time.Now().UTC().Add(-time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("Marshal credential: %v", err)
+	}
+	const vaultKey = "google:eric@example.com"
+	if err := h.Vault.Set(context.Background(), user.ID, vaultKey, credential); err != nil {
+		t.Fatalf("vault.Set: %v", err)
+	}
+	expiresAt := time.Now().UTC().Add(time.Hour)
+	const grantID = "grant-google"
+	if err := st.CreateCredentialAuthorization(context.Background(), &store.CredentialAuthorization{
+		ID:            grantID,
+		UserID:        user.ID,
+		AgentID:       agent.ID,
+		Scope:         "session",
+		CredentialRef: vaultKey,
+		Service:       "google.gmail:eric@example.com",
+		Host:          "gmail.googleapis.com",
+		HeaderName:    "authorization",
+		Scheme:        "bearer",
+		Status:        "active",
+		ExpiresAt:     &expiresAt,
+	}); err != nil {
+		t.Fatalf("CreateCredentialAuthorization: %v", err)
+	}
+	placeholder, err := autovault.GeneratePlaceholder(autovault.PlaceholderPrefix("google.gmail:eric@example.com"))
+	if err != nil {
+		t.Fatalf("GeneratePlaceholder: %v", err)
+	}
+	if err := st.CreateRuntimePlaceholder(context.Background(), &store.RuntimePlaceholder{
+		Placeholder:       placeholder,
+		UserID:            user.ID,
+		AgentID:           agent.ID,
+		ServiceID:         "google.gmail:eric@example.com",
+		VaultItemID:       "google.gmail:eric@example.com",
+		CredentialGrantID: grantID,
+		ExpiresAt:         &expiresAt,
+	}); err != nil {
+		t.Fatalf("CreateRuntimePlaceholder: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	mw := middleware.RequireAgentLLMNonce(st, nonces, slog.Default())
+	mux.Handle("/api/proxy/", mw(http.HandlerFunc(h.Forward)))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/proxy/gmail/v1/users/me/messages", nil)
+	req.Header.Set("X-Clawvisor-Target-Host", "gmail.googleapis.com")
+	req.Header.Set("X-Clawvisor-Caller", nonceForRequest(t, nonces, agent.ID, req))
+	req.Header.Set("Authorization", "Bearer "+placeholder)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (%s)", rec.Code, rec.Body.String())
+	}
+	if refreshRequests != 1 {
+		t.Fatalf("expected one refresh request, got %d", refreshRequests)
+	}
+	if seenAuth != "Bearer fresh-access-token" {
+		t.Fatalf("expected refreshed access token upstream, got %q", seenAuth)
+	}
 }
 
 // An explicit port on X-Clawvisor-Target-Host must pass the bound-service

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1286,6 +1286,7 @@ func (s *Server) registerLiteProxyRoutes(
 		)
 
 		resolverHandler := handlers.NewProxyResolverHandler(s.store, s.vault, s.logger)
+		resolverHandler.AdapterReg = s.adapterReg
 		resolverHandler.SelfHostnames = s.cfg.ProxyLite.SelfHostnames
 		resolverHandler.AllowPrivateNetworks = s.cfg.ProxyLite.AllowPrivateNetworks
 		resolverHandler.AuditEmitter = auditEmitter


### PR DESCRIPTION
## Summary
- When a runtime placeholder's stored credential is an OAuth2 bundle (access_token + refresh_token + expiry) and the service has a registered adapter with an `OAuthConfig`, the resolver now refreshes the token via `oauth2.TokenSource` before forwarding the request upstream. Stored credential is left as-is; refresh happens per-request inside the swap path.
- Refresh failures surface as `401 OAUTH_REFRESH_FAILED` so they're distinguishable from a missing placeholder or vault miss.
- New test wires a fake OAuth token server + upstream and verifies an expired access token triggers exactly one refresh and that the upstream receives the fresh token.

## Test plan
- [x] `go test ./internal/api/handlers/...`
- [ ] Manual: trigger a Gmail call with an expired access token and confirm upstream sees the refreshed bearer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)