### PR TITLE
Stop /api/features from being cached as the anonymous response

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1373,6 +1373,10 @@ func (s *Server) handleFeatures(w http.ResponseWriter, r *http.Request) {
 		fs = s.featuresHook(r.Context(), middleware.UserFromContext(r.Context()), fs)
 	}
 	w.Header().Set("Content-Type", "application/json")
+	// The response varies per-user (via featuresHook). Without no-store, a
+	// browser may cache the anonymous response and serve it back after the
+	// user logs in, since Authorization is not part of the default cache key.
+	w.Header().Set("Cache-Control", "no-store")
 	json.NewEncoder(w).Encode(fs)
 }
 


### PR DESCRIPTION
## Summary
- `/api/features` returns a per-user FeatureSet (via `FeaturesHook`), but the handler set no `Cache-Control` header. Browsers cached the anonymous fetch on first page load and re-served it for the post-login request, because `Authorization` is not part of the default HTTP cache key.
- Result: newly-enabled feature flags only took effect after a hard reload. Discovered while rolling out default-enabled proxy-lite for new users in [clawvisor/cloud#158](https://github.com/clawvisor/cloud/pull/158).

## Test plan
- [ ] Sign up a new account, confirm the post-signup UI reflects the per-user feature set without needing a reload.
- [ ] `curl -i /api/features` shows `Cache-Control: no-store` in response headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)