### PR TITLE
Refetch /api/features after onboarding completes

### DIFF
--- a/web/src/hooks/useAuth.tsx
+++ b/web/src/hooks/useAuth.tsx
@@ -134,18 +134,20 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     Promise.all([configPromise, authPromise]).finally(() => setIsLoading(false))
   }, [checkOnboarding])
 
-  // Fetch features on mount and whenever the authenticated user changes, so
-  // the server can return per-user feature gates (e.g. plan-based gating).
-  // The cancel flag drops stale responses if `user` changes again before the
-  // in-flight request resolves — without it a slow anonymous request could
-  // clobber a fast per-user response on login.
+  // Fetch features on mount and whenever the authenticated user or onboarding
+  // state changes, so the server can return per-user feature gates (e.g.
+  // plan-based gating). The onboardingComplete dep matters because
+  // /api/features returns 403 ONBOARDING_REQUIRED until onboarding finishes;
+  // without it the post-login fetch fails and features stay stale until the
+  // user reloads. The cancel flag drops stale responses if deps change again
+  // before the in-flight request resolves.
   useEffect(() => {
     let cancelled = false
     api.features.get()
       .then((f) => { if (!cancelled) setFeatures(f) })
       .catch((e) => console.warn('useAuth: failed to fetch features', e))
     return () => { cancelled = true }
-  }, [user])
+  }, [user, onboardingComplete])
 
   // Register a refresh callback so the API client can silently handle 401s on
   // data endpoints (expired access token) without logging the user out.


### PR DESCRIPTION
## Summary
- `/api/features` returns 403 `ONBOARDING_REQUIRED` until a new user finishes onboarding, so the post-login fetch in `useAuth` fails and `features` stays at its anonymous/null value. After onboarding completes nothing retriggers the fetch, so the dashboard renders against stale features until the user reloads.
- Fix: add `onboardingComplete` to the features-fetch effect's dep array, so `refreshOnboarding` (called from `SecuritySetup.handleComplete`) also retriggers the features fetch when the value transitions to `true`.
- Discovered while rolling out default-enabled proxy-lite for new users in [clawvisor/cloud#158](https://github.com/clawvisor/cloud/pull/158); follow-up to #494.

## Test plan
- [ ] Sign up a new account, complete onboarding, confirm the dashboard reflects the per-user feature set (e.g. proxy-lite onboarding banner) without needing a reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)