### PR TITLE
feat(installer)!: enable lite-proxy by default in generated config

### DIFF
--- a/internal/daemon/setup.go
+++ b/internal/daemon/setup.go
@@ -631,6 +631,9 @@ func writeDaemonConfig(cfg *daemonConfig, dataDir, jwtSecret, path string) error
 	fmt.Fprintf(&b, "  chain_context:\n")
 	fmt.Fprintf(&b, "    enabled: %t\n", cfg.chainContextEnabled)
 
+	fmt.Fprintf(&b, "\nproxy_lite:\n")
+	fmt.Fprintf(&b, "  enabled: true\n")
+
 	fmt.Fprintf(&b, "\ntelemetry:\n")
 	fmt.Fprintf(&b, "  enabled: %t\n", cfg.telemetryEnabled)
 


### PR DESCRIPTION
## Summary
- The setup wizard (`clawvisor-server install`, which `scripts/install.sh` invokes) now writes `proxy_lite.enabled: true` into the generated `~/.clawvisor/config.yaml`, so local users get the lite-proxy LLM endpoint without an extra config step.
- The schema default in `pkg/config/config.go` stays `false`, so manual configs, tests, and Cloud Run deployments are unaffected.
- Users can still flip it off post-install via `config.yaml` or `CLAWVISOR_PROXY_LITE_ENABLED=false`.

## Test plan
- [ ] Run `clawvisor-server install` in a clean data dir and confirm the generated `config.yaml` contains `proxy_lite.enabled: true`
- [ ] Confirm the lite-proxy routes accept requests without further config

🤖 Generated with [Claude Code](https://claude.com/claude-code)