### PR TITLE
feat(dashboard): explain blocked runtime approvals

### DIFF
--- a/web/src/components/RuntimeExplanationPanel.tsx
+++ b/web/src/components/RuntimeExplanationPanel.tsx
@@ -1,0 +1,151 @@
+import { useState } from 'react'
+import { parseExplanation } from '../lib/runtime-explanations'
+
+interface Props {
+  data: any // ApprovalRecord or RuntimeEvent
+  compact?: boolean
+  className?: string
+  defaultExpanded?: boolean
+}
+
+export function RuntimeExplanationPanel({ data, compact = false, className, defaultExpanded = false }: Props) {
+  const [expanded, setExpanded] = useState(defaultExpanded)
+  
+  if (!data) return null
+  
+  const explanation = parseExplanation(data)
+
+  const cx = (...classes: Array<string | false | null | undefined>) => classes.filter(Boolean).join(' ')
+
+  const ChevronIcon = ({ className }: { className?: string }) => (
+    <svg 
+      xmlns="http://www.w3.org/2000/svg" 
+      viewBox="0 0 20 20" 
+      fill="currentColor" 
+      className={cx("w-5 h-5 transition-transform duration-200", className)}
+    >
+      <path fillRule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z" clipRule="evenodd" />
+    </svg>
+  )
+
+  if (compact) {
+    return (
+      <div className={cx("bg-gray-800/50 rounded-md border border-gray-700/50 overflow-hidden text-sm", className)}>
+        <button 
+          onClick={() => setExpanded(!expanded)}
+          className="w-full flex items-center justify-between p-3 text-left hover:bg-gray-700/30 transition-colors"
+        >
+          <div className="flex items-center gap-2">
+            <span className="text-gray-400">Why was this blocked?</span>
+            <span className="text-gray-300 truncate max-w-xs md:max-w-md">{explanation.summary}</span>
+          </div>
+          <ChevronIcon className={expanded ? "rotate-180" : ""} />
+        </button>
+        
+        {expanded && (
+          <div className="p-4 border-t border-gray-700/50 space-y-3 bg-gray-800/80">
+            {explanation.nextStep && (
+              <div>
+                <span className="text-gray-400 block text-xs uppercase tracking-wider mb-1">What you can do</span>
+                <span className="text-gray-200">{explanation.nextStep}</span>
+              </div>
+            )}
+            {explanation.identifiers.length > 0 && (
+              <div className="pt-2">
+                 <span className="text-gray-500 block text-xs uppercase tracking-wider mb-1">Details</span>
+                 <div className="flex flex-wrap gap-3">
+                   {explanation.identifiers.map((id, i) => (
+                     <div key={i} className="text-xs">
+                       <span className="text-gray-500 mr-1">{id.label}:</span>
+                       <span className="text-gray-400 font-mono">{id.value}</span>
+                     </div>
+                   ))}
+                 </div>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div className={cx("bg-gray-800 rounded-lg border border-gray-700 overflow-hidden shadow-sm mt-4", className)}>
+      <button 
+        onClick={() => setExpanded(!expanded)}
+        className="w-full flex items-center justify-between p-4 text-left hover:bg-gray-700/50 transition-colors group"
+      >
+        <div className="flex items-center gap-3">
+          <div className="bg-amber-500/10 text-amber-500 p-1.5 rounded-md group-hover:bg-amber-500/20 transition-colors">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-5 h-5">
+              <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-5a.75.75 0 01.75.75v4.5a.75.75 0 01-1.5 0v-4.5A.75.75 0 0110 5zm0 10a1 1 0 100-2 1 1 0 000 2z" clipRule="evenodd" />
+            </svg>
+          </div>
+          <div>
+            <h4 className="text-sm font-medium text-gray-200">Why was this blocked?</h4>
+            {!expanded && <p className="text-xs text-gray-400 mt-0.5 truncate max-w-[200px] sm:max-w-md">{explanation.summary}</p>}
+          </div>
+        </div>
+        <ChevronIcon className={expanded ? "rotate-180 text-gray-400" : "text-gray-500 group-hover:text-gray-400"} />
+      </button>
+
+      {expanded && (
+        <div className="px-4 pb-4 animate-in slide-in-from-top-2 fade-in duration-200">
+          <div className="border-t border-gray-700 pt-4 space-y-4">
+            
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <span className="text-gray-400 block text-xs uppercase tracking-wider mb-1">Why</span>
+                <p className="text-gray-200 text-sm">{explanation.summary}</p>
+              </div>
+              
+              {explanation.nextStep && (
+                <div>
+                  <span className="text-gray-400 block text-xs uppercase tracking-wider mb-1">What you can do</span>
+                  <p className="text-gray-200 text-sm">{explanation.nextStep}</p>
+                </div>
+              )}
+            </div>
+
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 bg-gray-900/50 p-3 rounded-md border border-gray-800">
+               {explanation.toolName && (
+                  <div>
+                    <span className="text-gray-500 block text-xs uppercase tracking-wider mb-1">Tool</span>
+                    <span className="text-gray-300 text-sm font-mono truncate block" title={explanation.toolName}>{explanation.toolName}</span>
+                  </div>
+               )}
+               {explanation.target && (
+                  <div className="col-span-2 sm:col-span-1">
+                    <span className="text-gray-500 block text-xs uppercase tracking-wider mb-1">Target</span>
+                    <span className="text-gray-300 text-sm font-mono truncate block" title={explanation.target}>{explanation.target}</span>
+                  </div>
+               )}
+               {explanation.risk && (
+                  <div>
+                    <span className="text-gray-500 block text-xs uppercase tracking-wider mb-1">Risk</span>
+                    <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-800 text-gray-300 border border-gray-700">
+                      {explanation.risk}
+                    </span>
+                  </div>
+               )}
+            </div>
+            
+            {explanation.identifiers.length > 0 && (
+              <div className="pt-2 border-t border-gray-800/50">
+                 <div className="flex flex-wrap gap-x-6 gap-y-2">
+                   {explanation.identifiers.map((id, i) => (
+                     <div key={i} className="text-xs flex flex-col">
+                       <span className="text-gray-500 uppercase tracking-wider" style={{fontSize: '0.65rem'}}>{id.label}</span>
+                       <span className="text-gray-400 font-mono mt-0.5">{id.value}</span>
+                     </div>
+                   ))}
+                 </div>
+              </div>
+            )}
+            
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/TaskCard.tsx
+++ b/web/src/components/TaskCard.tsx
@@ -199,7 +199,6 @@ export default function TaskCard({
       status: task.status,
       decision: needsApproval || needsExpansion ? 'needs_approval' : task.status,
       reason: task.pending_reason
-        || task.risk_details?.explanation
         || (task.approval_source === 'inline_chat'
           ? 'The agent requested task scope before running a reviewed tool.'
           : 'This task needs approval before the agent can continue.'),
@@ -208,7 +207,7 @@ export default function TaskCard({
       agent_id: task.agent_id,
       risk_level: task.risk_level,
     }
-  }, [expectedTools, needsApproval, needsExpansion, task.agent_id, task.approval_source, task.id, task.pending_reason, task.risk_details?.explanation, task.risk_level, task.status])
+  }, [expectedTools, needsApproval, needsExpansion, task.agent_id, task.approval_source, task.id, task.pending_reason, task.risk_level, task.status])
 
   const [showPlannedCalls, setShowPlannedCalls] = useState(() => {
     if (totalPlanned === 0) return false

--- a/web/src/components/TaskCard.tsx
+++ b/web/src/components/TaskCard.tsx
@@ -7,6 +7,7 @@ import { isLocalHost } from '../lib/env'
 import CountdownTimer from './CountdownTimer'
 import VerificationIcon from './VerificationIcon'
 import ScopePill, { type ScopePillValue } from './ScopePill'
+import { RuntimeExplanationPanel } from './RuntimeExplanationPanel'
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -191,6 +192,23 @@ export default function TaskCard({
   }, [plannedCalls])
   const totalPlanned = plannedCalls.length
   const hasRuntimeEnvelope = expectedTools.length > 0 || expectedEgress.length > 0 || task.schema_version === 2 || !!task.expected_use || !!task.intent_verification_mode
+  const taskExplanationData = useMemo(() => {
+    const toolNames = expectedTools.map(tool => tool.tool_name).filter(Boolean)
+    return {
+      id: task.id,
+      status: task.status,
+      decision: needsApproval || needsExpansion ? 'needs_approval' : task.status,
+      reason: task.pending_reason
+        || task.risk_details?.explanation
+        || (task.approval_source === 'inline_chat'
+          ? 'The agent requested task scope before running a reviewed tool.'
+          : 'This task needs approval before the agent can continue.'),
+      tool_name: toolNames.length > 0 ? toolNames.join(', ') : undefined,
+      task_id: task.id,
+      agent_id: task.agent_id,
+      risk_level: task.risk_level,
+    }
+  }, [expectedTools, needsApproval, needsExpansion, task.agent_id, task.approval_source, task.id, task.pending_reason, task.risk_details?.explanation, task.risk_level, task.status])
 
   const [showPlannedCalls, setShowPlannedCalls] = useState(() => {
     if (totalPlanned === 0) return false
@@ -326,6 +344,9 @@ export default function TaskCard({
         <>
           {showRisk && <RiskPanel risk={riskDetails} level={riskLevel} />}
           {showRationale && <AutoApprovalPanel rationale={task.approval_rationale!} />}
+          <div className="px-4 pb-3">
+            <RuntimeExplanationPanel data={taskExplanationData} defaultExpanded />
+          </div>
           <div className="px-4 pb-3">
             {totalPlanned > 0 && (
               <div className="flex items-center justify-end pb-2">

--- a/web/src/lib/runtime-explanations.ts
+++ b/web/src/lib/runtime-explanations.ts
@@ -1,0 +1,211 @@
+import type { ApprovalRecord, RuntimeEvent } from '../api/client'
+
+export type RuntimeExplanation = {
+  title: string
+  summary: string
+  reason?: string
+  decision?: string
+  toolName?: string
+  agentName?: string
+  target?: string
+  scope?: string
+  risk?: string
+  identifiers: Array<{ label: string; value: string }>
+  nextStep?: string
+}
+
+type ExplanationSource = ApprovalRecord | RuntimeEvent | null | undefined
+
+const FALLBACK_SUMMARY = 'Clawvisor paused this request because it required review, but this event does not include a detailed policy reason.'
+const SECRET_KEY_RE = /(token|secret|password|credential|authorization|api[_-]?key|bearer|vault|nonce)/i
+
+export function parseExplanation(data: ExplanationSource): RuntimeExplanation {
+  const explanation: RuntimeExplanation = {
+    title: 'Needs Review',
+    summary: FALLBACK_SUMMARY,
+    identifiers: [],
+  }
+
+  if (!data) return explanation
+
+  const payload = isApprovalRecord(data) ? safeObject(data.payload_json) : {}
+  const summary = isApprovalRecord(data) ? safeObject(data.summary_json) : {}
+  const metadata = isRuntimeEvent(data) ? safeObject(data.metadata_json) : {}
+
+  const decision = firstString(
+    read(data, 'decision'),
+    read(data, 'status'),
+    read(data, 'outcome'),
+    read(payload, 'decision'),
+    read(payload, 'status'),
+    read(summary, 'decision'),
+    read(summary, 'status'),
+    read(metadata, 'decision'),
+    read(metadata, 'outcome'),
+  )
+  explanation.decision = decision
+  applyDecision(explanation, decision)
+
+  const reason = firstString(
+    read(data, 'reason'),
+    read(payload, 'reason'),
+    read(payload, 'policy_reason'),
+    read(payload, 'decision_reason'),
+    read(summary, 'reason'),
+    read(summary, 'policy_reason'),
+    read(summary, 'decision_reason'),
+    read(metadata, 'reason'),
+    read(metadata, 'policy_reason'),
+    read(metadata, 'decision_reason'),
+    read(metadata, 'original_reason'),
+  )
+  if (reason) {
+    explanation.reason = reason
+    explanation.summary = friendlyReason(reason)
+  }
+
+  explanation.toolName = firstString(
+    read(data, 'tool_name'),
+    read(payload, 'tool_name'),
+    read(summary, 'tool_name'),
+    read(metadata, 'tool_name'),
+    read(data, 'action_kind') === 'tool_use' ? read(data, 'event_type') : undefined,
+  )
+  explanation.agentName = firstString(read(data, 'agent_name'), read(data, 'agent_id'))
+
+  const target = buildTarget(safeObject(data), payload, metadata)
+  explanation.target = target ?? firstString(read(data, 'target'), read(payload, 'target'), read(summary, 'target'), read(metadata, 'target'))
+
+  const taskID = firstString(read(data, 'matched_task_id'), read(data, 'task_id'), read(payload, 'task_id'), read(summary, 'task_id'), read(metadata, 'task_id'))
+  if (taskID) explanation.scope = `Task ${shortID(taskID)}`
+  else if (reason && /no matching task|outside.*task|scope/i.test(reason)) explanation.scope = 'No matching approved task'
+
+  explanation.risk = firstString(read(data, 'risk_level'), read(payload, 'risk_level'), read(summary, 'risk_level'), read(metadata, 'risk_level'))
+
+  addIdentifier(explanation, 'Approval ID', firstString(read(data, 'approval_id'), isApprovalRecord(data) ? data.id : undefined))
+  addIdentifier(explanation, 'Task ID', taskID)
+  addIdentifier(explanation, 'Session ID', firstString(read(data, 'session_id'), read(payload, 'session_id'), read(metadata, 'session_id')))
+  addIdentifier(explanation, 'Request ID', isApprovalRecord(data) ? data.request_id : undefined)
+  addIdentifier(explanation, 'Tool Use ID', isRuntimeEvent(data) ? data.tool_use_id : firstString(read(payload, 'tool_use_id'), read(metadata, 'tool_use_id')))
+  addIdentifier(explanation, 'Policy Rule', safeDetailString(metadata, 'policy_rule') ?? safeDetailString(payload, 'policy_rule') ?? safeDetailString(summary, 'policy_rule'))
+
+  if (!explanation.nextStep) {
+    explanation.nextStep = defaultNextStep(explanation)
+  }
+
+  return explanation
+}
+
+function applyDecision(explanation: RuntimeExplanation, rawDecision?: string) {
+  const decision = rawDecision?.toLowerCase()
+  if (!decision) return
+
+  if (decision === 'block' || decision === 'blocked' || decision === 'deny' || decision === 'denied') {
+    explanation.title = 'Action Blocked'
+    explanation.summary = 'Clawvisor blocked this action before the agent could run it.'
+    explanation.nextStep = 'Adjust the task scope or policy only if this action is expected for the work.'
+    return
+  }
+  if (decision === 'restricted') {
+    explanation.title = 'Action Restricted'
+    explanation.summary = 'This action did not pass the configured runtime restrictions.'
+    explanation.nextStep = 'Review the restriction before changing policy. Restrictions are intended to be hard stops.'
+    return
+  }
+  if (decision === 'needs_approval' || decision === 'hold' || decision === 'held' || decision === 'pending' || decision === 'review' || decision === 'review_required') {
+    explanation.title = 'Approval Required'
+    explanation.summary = 'Clawvisor paused this action so a person can review it first.'
+    explanation.nextStep = 'Approve once, deny, or create a task that covers this tool if it should be repeatable.'
+  }
+}
+
+function friendlyReason(reason: string): string {
+  const normalized = reason.toLowerCase()
+  if (/no matching task|outside.*task|scope/.test(normalized)) {
+    return 'The agent tried to use a tool outside an approved task.'
+  }
+  if (/credential|secret|vault|placeholder|autovault/.test(normalized)) {
+    return 'The action touches credentials or vaulted secrets, so Clawvisor paused it for review.'
+  }
+  if (/private network|loopback|ssrf|self host|self-host/.test(normalized)) {
+    return 'The request targets a protected or private network boundary.'
+  }
+  if (/policy|rule|deny|blocked/.test(normalized)) {
+    return 'A runtime policy rule matched this action.'
+  }
+  if (/risk|high risk|critical/.test(normalized)) {
+    return 'This action was flagged as risky enough to require manual review.'
+  }
+  return reason
+}
+
+function defaultNextStep(explanation: RuntimeExplanation): string | undefined {
+  const title = explanation.title.toLowerCase()
+  if (title.includes('blocked') || title.includes('restricted')) {
+    return 'Only change policy if this action is expected and safe for the agent.'
+  }
+  if (title.includes('review') || title.includes('approval')) {
+    return 'Approve once, deny, or create a task that covers this tool if it should be repeatable.'
+  }
+  return undefined
+}
+
+function buildTarget(...sources: Record<string, unknown>[]): string | undefined {
+  const host = firstString(...sources.flatMap(source => [read(source, 'host'), read(source, 'target_host')]))
+  const path = firstString(...sources.flatMap(source => [read(source, 'path'), read(source, 'target_path')]))
+  const method = firstString(...sources.map(source => read(source, 'method')))
+  if (!host && !path && !method) return undefined
+  return truncateMiddle([method?.toUpperCase(), host && path ? `${host}${path}` : host || path].filter(Boolean).join(' '), 96)
+}
+
+function isApprovalRecord(value: ExplanationSource): value is ApprovalRecord {
+  return !!value && 'kind' in value && 'surface' in value
+}
+
+function isRuntimeEvent(value: ExplanationSource): value is RuntimeEvent {
+  return !!value && 'event_type' in value && 'timestamp' in value
+}
+
+function safeObject(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {}
+}
+
+function read(source: unknown, key: string): unknown {
+  if (!source || typeof source !== 'object') return undefined
+  return (source as Record<string, unknown>)[key]
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim() !== '') return value.trim()
+  }
+  return undefined
+}
+
+function safeDetailString(source: Record<string, unknown>, key: string): string | undefined {
+  if (SECRET_KEY_RE.test(key)) return undefined
+  const value = source[key]
+  if (typeof value !== 'string' || value.trim() === '') return undefined
+  if (looksSensitive(value)) return undefined
+  return value.trim()
+}
+
+function looksSensitive(value: string): boolean {
+  return /(bearer\s+|sk-[a-z0-9]|ghp_|github_pat_|xox[baprs]-|autovault_|cv-nonce|cvis_)/i.test(value)
+}
+
+function addIdentifier(explanation: RuntimeExplanation, label: string, value?: string) {
+  if (!value || looksSensitive(value)) return
+  explanation.identifiers.push({ label, value })
+}
+
+function shortID(value: string): string {
+  if (value.length <= 12) return value
+  return `${value.slice(0, 8)}...`
+}
+
+function truncateMiddle(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value
+  const keep = Math.floor((maxLength - 3) / 2)
+  return `${value.slice(0, keep)}...${value.slice(-keep)}`
+}

--- a/web/src/pages/Overview.tsx
+++ b/web/src/pages/Overview.tsx
@@ -10,6 +10,7 @@ import { isLocalHost } from '../lib/env'
 import CountdownTimer from '../components/CountdownTimer'
 import TaskCard from '../components/TaskCard'
 import VerificationIcon from '../components/VerificationIcon'
+import { RuntimeExplanationPanel } from '../components/RuntimeExplanationPanel'
 
 type AttentionItem =
   | { kind: 'queue'; createdAt: string; item: QueueItem }
@@ -625,6 +626,7 @@ function RuntimeApprovalCard({ approval }: { approval: ApprovalRecord }) {
       <div className="px-5 pt-5 pb-4">
         <span className="font-mono text-lg font-semibold text-text-primary break-all">{primary}</span>
         {reason && <p className="text-sm text-text-secondary mt-1.5">{reason}</p>}
+        <RuntimeExplanationPanel data={approval} defaultExpanded className="mt-3" />
         <div className="flex flex-wrap items-center gap-2 mt-2">
           <span className="inline-flex items-center gap-1.5 text-xs font-mono font-medium px-2 py-0.5 rounded bg-brand/15 text-brand">
             <span className="w-1.5 h-1.5 rounded-full bg-brand" />

--- a/web/src/pages/Runtime.tsx
+++ b/web/src/pages/Runtime.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { api, type Agent, type ApprovalRecord, type RuntimeEvent, type RuntimePolicyRule, type RuntimeStatus, type RuntimeSession, type StarterProfile } from '../api/client'
+import { RuntimeExplanationPanel } from '../components/RuntimeExplanationPanel'
 
 export type RuleDraft = Partial<RuntimePolicyRule> & { scope?: 'agent' | 'global' }
 
@@ -829,6 +830,7 @@ export function RuntimeApprovalsPanel({ approvals, onResolved }: { approvals: Ap
               {typeof payload.reason === 'string' && payload.reason.trim() !== '' && (
                 <div className="mt-1 text-xs text-text-tertiary">{payload.reason}</div>
               )}
+              <RuntimeExplanationPanel data={approval} compact defaultExpanded className="mt-3" />
               <div className="mt-3 flex flex-wrap gap-2">
                 <ApprovalButton label="Allow Once" onClick={() => resolveMut.mutate({ approvalId: approval.id, resolution: 'allow_once' })} busy={resolveMut.isPending} />
                 <ApprovalButton label="Allow Session" onClick={() => resolveMut.mutate({ approvalId: approval.id, resolution: 'allow_session' })} busy={resolveMut.isPending} />
@@ -964,6 +966,7 @@ export function RuntimeEventsPanel({
                     {agents.get(event.agent_id)?.name ?? event.agent_id} · {event.action_kind || 'runtime'} · {event.decision || 'observe'} / {event.outcome || 'n/a'}
                   </div>
                   {event.reason && <div className="mt-2 text-sm text-text-secondary">{event.reason}</div>}
+                  <RuntimeExplanationPanel data={event} compact className="mt-3" />
                 </div>
                 <div className="text-xs text-text-tertiary">{new Date(event.timestamp).toLocaleString()}</div>
               </div>


### PR DESCRIPTION
## Summary

Adds a small “Why was this blocked?” explanation panel to existing approval surfaces in the dashboard.

This helps users understand why Clawvisor paused or blocked a runtime/tool action without needing to inspect raw runtime metadata. The panel is intentionally built on top of existing approval/event data and does not change policy behavior, approval behavior, routes, or dashboard structure.

## What Changed

- Added a reusable `RuntimeExplanationPanel` component.
- Added runtime explanation parsing helpers for approval/event metadata.
- Rendered the explanation panel on:
  - pending task approval cards
  - dashboard runtime approval cards
  - runtime approvals panel
  - runtime events panel
- Kept the explanation safe and user-facing:
  - summarizes policy/task-scope/credential/private-network/risk reasons
  - avoids exposing likely secrets or sensitive token-like values
  - shows useful identifiers like approval/task/session IDs when available

## Why

When a tool call is paused or blocked, the dashboard previously showed technical runtime details but did not clearly explain the decision in plain language.

This makes approval prompts easier to trust and act on by answering:

- why Clawvisor paused the action
- what tool or target was involved
- what the user can do next

## Scope

This PR is limited to UI explanation on top of existing approval/runtime metadata.

It does not:

- change runtime policy enforcement
- change approval resolution behavior
- add new dashboard routes
- alter policy page structure
- introduce new package dependencies
- modify credential/vault handling

## Screenshots

<img width="1766" height="944" alt="Screenshot 2026-06-02 182240" src="https://github.com/user-attachments/assets/5d884b0a-9d88-4384-af95-91f7162cf06d" />

<img width="1919" height="912" alt="image" src="https://github.com/user-attachments/assets/f11a413a-cc71-4cca-9be8-88bfec50de73" />

## Testing

- Ran `cd web && npm run lint`
- Ran `docker compose -f deploy/docker-compose.local.yml build app`

Both passed.