### PR TITLE
feat(pricing): add claude-opus-4-8 row

### DIFF
--- a/internal/runtime/llmproxy/pricing/pricing.go
+++ b/internal/runtime/llmproxy/pricing/pricing.go
@@ -71,6 +71,7 @@ var table = map[string]ModelPricing{
 	// Anthropic — current generation (Claude 4.x). CacheWrite1hPerM
 	// is 2x InputPerM (Anthropic's 1-hour cache premium); 5-minute
 	// writes are at 1.25x.
+	"claude-opus-4-8":             {InputPerM: 15.00, OutputPerM: 75.00, CacheWritePerM: 18.75, CacheWrite1hPerM: 30.00, CacheReadPerM: 1.50, PricedAt: time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC)},
 	"claude-opus-4-7":             {InputPerM: 15.00, OutputPerM: 75.00, CacheWritePerM: 18.75, CacheWrite1hPerM: 30.00, CacheReadPerM: 1.50, PricedAt: lastBulkPricedAt},
 	"claude-opus-4-6":             {InputPerM: 15.00, OutputPerM: 75.00, CacheWritePerM: 18.75, CacheWrite1hPerM: 30.00, CacheReadPerM: 1.50, PricedAt: lastBulkPricedAt},
 	"claude-opus-4-5":             {InputPerM: 15.00, OutputPerM: 75.00, CacheWritePerM: 18.75, CacheWrite1hPerM: 30.00, CacheReadPerM: 1.50, PricedAt: lastBulkPricedAt},


### PR DESCRIPTION
## Summary
Adds a `claude-opus-4-8` entry to the lite-proxy pricing table at the same rates as the rest of the Claude 4.x Opus generation ($15/$75 input/output, $18.75 5m-cache-write, $30 1h-cache-write, $1.50 cache-read). Uses an inline `PricedAt` per the file's convention for single-row additions between bulk reconciliations.

## Test plan
- [x] \`go test ./internal/runtime/llmproxy/pricing/...\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)