### PR TITLE
fix(llmproxy): decline tool_use rewrite under extended thinking

### DIFF
--- a/internal/runtime/conversation/anthropic_response.go
+++ b/internal/runtime/conversation/anthropic_response.go
@@ -53,6 +53,25 @@ func (rw AnthropicResponseRewriter) rewriteJSON(body []byte, eval ToolUseEvaluat
 		return RewriteResult{Body: body}, nil
 	}
 
+	// Extended-thinking sentinel: when the assistant message has a
+	// thinking or redacted_thinking block, the model's signature
+	// covers every sibling block including tool_use.input. Rewriting
+	// the input in place would invalidate the signature, and the
+	// agent's NEXT request — which echoes this assistant message
+	// back to Anthropic with the rewritten input — would 400 with
+	// "thinking blocks in the latest assistant message cannot be
+	// modified." Detect the case here and convert any
+	// rewrite-bearing verdict into a structured block result so the
+	// downstream block-rendering path emits a Clawvisor refusal in
+	// place of the broken rewrite.
+	hasThinking := false
+	for _, block := range resp.Content {
+		if block.Type == "thinking" || block.Type == "redacted_thinking" {
+			hasThinking = true
+			break
+		}
+	}
+
 	var decisions []ToolUseDecisionRecord
 	var frags []assistantFragment
 	anyBlocked := false
@@ -73,6 +92,9 @@ func (rw AnthropicResponseRewriter) rewriteJSON(body []byte, eval ToolUseEvaluat
 			}
 			index++
 			verdict := eval(tu)
+			if hasThinking && verdict.Allowed && len(verdict.RewriteInput) > 0 {
+				verdict = ThinkingRewriteRefusal(verdict)
+			}
 			decisions = append(decisions, ToolUseDecisionRecord{
 				ToolUse:          tu,
 				Verdict:          verdict,
@@ -254,6 +276,17 @@ func (rw AnthropicResponseRewriter) rewriteSSE(body []byte, eval ToolUseEvaluato
 		}
 	}
 
+	// Extended-thinking sentinel — mirror the rewriteJSON guard. See
+	// the comment there for why an in-place rewrite under thinking
+	// breaks the agent's next request.
+	hasThinking := false
+	for _, pb := range orderedAll {
+		if pb.blockType == "thinking" || pb.blockType == "redacted_thinking" {
+			hasThinking = true
+			break
+		}
+	}
+
 	var decisions []ToolUseDecisionRecord
 	anyBlocked := false
 	anyRewritten := false
@@ -270,6 +303,9 @@ func (rw AnthropicResponseRewriter) rewriteSSE(body []byte, eval ToolUseEvaluato
 			Input: inputRaw,
 		}
 		verdict := eval(tu)
+		if hasThinking && verdict.Allowed && len(verdict.RewriteInput) > 0 {
+			verdict = ThinkingRewriteRefusal(verdict)
+		}
 		decisions = append(decisions, ToolUseDecisionRecord{
 			ToolUse:          tu,
 			Verdict:          verdict,
@@ -1092,6 +1128,7 @@ func (rw AnthropicResponseRewriter) StreamRewrite(ctx context.Context, r io.Read
 	nextContentIndex := 0
 	nextOutboundIndex := 0
 	firstBufferedToolIndex := -1
+	hasThinking := false
 
 	writeSSE := func(event string, data string) error {
 		var err error
@@ -1155,6 +1192,12 @@ func (rw AnthropicResponseRewriter) StreamRewrite(ctx context.Context, r io.Read
 				return writeSSE(event, data)
 			}
 			inboundIndex := cbs.Index
+			if cbs.ContentBlock.Type == "thinking" || cbs.ContentBlock.Type == "redacted_thinking" {
+				// Note presence even for blocks we don't filter — the
+				// post-stream rewrite loop needs to know to decline
+				// any in-place tool_use input rewrite on this turn.
+				hasThinking = true
+			}
 			if cbs.ContentBlock.Type == "thinking" && isNonClaudeModel(msgModel) {
 				blocks[inboundIndex] = &pendingBlock{
 					index:     -1,
@@ -1391,6 +1434,7 @@ func (rw AnthropicResponseRewriter) StreamRewrite(ctx context.Context, r io.Read
 		Role:                      msgRole,
 		StreamFormat:              "anthropic_messages",
 		NextAnthropicContentIndex: firstNonToolIndex(nextContentIndex, firstBufferedToolIndex, len(orderedTUs) > 0),
+		HasThinking:               hasThinking,
 	}, nil
 }
 

--- a/internal/runtime/conversation/response.go
+++ b/internal/runtime/conversation/response.go
@@ -67,6 +67,44 @@ type ToolUseDecisionRecord struct {
 	ToolInputPreview string
 }
 
+// ThinkingRewriteRefusal converts a verdict that wanted to rewrite a
+// tool_use input into a blocked verdict, used by Anthropic response
+// rewriters (both buffered and streaming) when the assistant message
+// contains a thinking or redacted_thinking block.
+//
+// Anthropic's signature on a thinking block covers every sibling
+// block in the assistant message, including each tool_use.input.
+// Modifying an input in place invalidates the signature; the agent
+// CLI then echoes the modified content back on the next turn and
+// Anthropic returns:
+//
+//	400 invalid_request_error: `thinking` or `redacted_thinking` blocks
+//	in the latest assistant message cannot be modified.
+//
+// The refusal carries the SAME message in Reason and
+// ContinueWithToolResult so the recovery surfaces both as a
+// refusal-text and as a synthetic tool_result on the continuation
+// path — same shape the rewriter failure path already uses for the
+// no-rewriter-for-shape case.
+//
+// Exported so the lite-proxy's streaming postprocess loop (which
+// applies rewrites AFTER StreamRewrite returns) can call it with the
+// same shape as the buffered rewriters.
+func ThinkingRewriteRefusal(orig ToolUseVerdict) ToolUseVerdict {
+	const reason = "Clawvisor: credentialed rewrite declined — extended thinking is active on this assistant turn. " +
+		"Rewriting the tool_use input in place would invalidate the model's thinking-block signature, " +
+		"and Anthropic would 400 the next request with `thinking blocks in the latest assistant message cannot be modified`. " +
+		"To proceed: retry without extended thinking, or restructure so the credentialed call doesn't need an in-place rewrite (e.g. have the agent construct the proxy URL itself rather than calling the upstream host directly)."
+	return ToolUseVerdict{
+		Allowed:                false,
+		Reason:                 reason,
+		ContinueWithToolResult: reason,
+		// Carry through any CreatedTaskID so audit linkage stays
+		// intact even though the rewrite was declined.
+		CreatedTaskID: orig.CreatedTaskID,
+	}
+}
+
 const toolInputPreviewLimit = 512
 
 func MakeToolInputPreview(in json.RawMessage) string {
@@ -94,6 +132,18 @@ type StreamingRewriteResult struct {
 	StreamFormat              string
 	NextAnthropicContentIndex int
 	NextOpenAIOutputIndex     int
+
+	// HasThinking is true when the streamed assistant turn included a
+	// thinking or redacted_thinking content block. The post-stream
+	// rewrite loop in lite-proxy MUST NOT apply any tool_use input
+	// rewrite when this is set — the model's signature covers every
+	// sibling block, including tool_use inputs, so an in-place rewrite
+	// invalidates it and the agent's NEXT request 400s with
+	// "thinking blocks in the latest assistant message cannot be
+	// modified." Callers should convert any RewriteInput-bearing
+	// verdict into a ThinkingRewriteRefusal-style block result when
+	// this is true.
+	HasThinking bool
 }
 
 type ResponseRewriter interface {

--- a/internal/runtime/conversation/response_test.go
+++ b/internal/runtime/conversation/response_test.go
@@ -121,6 +121,125 @@ func TestAnthropicResponseRewriterBlocksToolUseJSON(t *testing.T) {
 	}
 }
 
+// TestAnthropicResponseRewriterDeclinesRewriteUnderThinkingJSON exercises
+// the extended-thinking guard: when the assistant message contains a
+// thinking (or redacted_thinking) block, any rewrite-bearing verdict is
+// converted to a blocked refusal verdict. Without this guard the proxy
+// would mutate tool_use.input in place, the agent CLI would echo the
+// rewritten content back to Anthropic on its next turn, and Anthropic
+// would 400 with "thinking blocks in the latest assistant message
+// cannot be modified."
+func TestAnthropicResponseRewriterDeclinesRewriteUnderThinkingJSON(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{
+	  "id":"msg_t1",
+	  "type":"message",
+	  "role":"assistant",
+	  "model":"claude-test",
+	  "content":[
+	    {"type":"thinking","thinking":"i should curl gmail","signature":"sig_abc"},
+	    {"type":"tool_use","id":"toolu_t1","name":"Bash","input":{"command":"curl https://gmail.googleapis.com/gmail/v1/users/me/messages -H 'Authorization: Bearer autovault_x'"}}
+	  ],
+	  "stop_reason":"tool_use"
+	}`)
+
+	result, err := (&AnthropicResponseRewriter{}).Rewrite(body, "application/json", func(ToolUse) ToolUseVerdict {
+		return ToolUseVerdict{
+			Allowed:      true,
+			RewriteInput: json.RawMessage(`{"command":"curl http://localhost/api/proxy/gmail/v1/users/me/messages -H 'X-Clawvisor-Caller: cv-nonce-xxx'"}`),
+		}
+	})
+	if err != nil {
+		t.Fatalf("Rewrite: %v", err)
+	}
+	if !result.Rewritten {
+		t.Fatal("expected refusal to mark the response rewritten")
+	}
+	if len(result.Decisions) != 1 {
+		t.Fatalf("expected one decision, got %d", len(result.Decisions))
+	}
+	d := result.Decisions[0]
+	if d.Verdict.Allowed {
+		t.Fatal("verdict must be Allowed=false when thinking is present")
+	}
+	if len(d.Verdict.RewriteInput) != 0 {
+		t.Fatalf("verdict must not carry RewriteInput when thinking is present; got %s", d.Verdict.RewriteInput)
+	}
+	if d.Verdict.Reason == "" || d.Verdict.ContinueWithToolResult == "" {
+		t.Fatalf("verdict must populate Reason and ContinueWithToolResult; got %+v", d.Verdict)
+	}
+	for _, want := range []string{"extended thinking", "thinking-block signature", "credentialed rewrite declined"} {
+		if !strings.Contains(d.Verdict.Reason, want) {
+			t.Fatalf("recovery reason missing %q:\n%s", want, d.Verdict.Reason)
+		}
+	}
+}
+
+// TestAnthropicResponseRewriterDeclinesRewriteUnderRedactedThinkingJSON
+// covers the redacted variant Anthropic emits for sensitive thinking
+// content. Same guard, different block type.
+func TestAnthropicResponseRewriterDeclinesRewriteUnderRedactedThinkingJSON(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{
+	  "id":"msg_t2",
+	  "type":"message",
+	  "role":"assistant",
+	  "model":"claude-test",
+	  "content":[
+	    {"type":"redacted_thinking","data":"opaque_blob"},
+	    {"type":"tool_use","id":"toolu_t2","name":"Bash","input":{"command":"curl https://gmail.googleapis.com -H 'Authorization: Bearer autovault_x'"}}
+	  ],
+	  "stop_reason":"tool_use"
+	}`)
+
+	result, err := (&AnthropicResponseRewriter{}).Rewrite(body, "application/json", func(ToolUse) ToolUseVerdict {
+		return ToolUseVerdict{
+			Allowed:      true,
+			RewriteInput: json.RawMessage(`{"command":"rewritten"}`),
+		}
+	})
+	if err != nil {
+		t.Fatalf("Rewrite: %v", err)
+	}
+	if !result.Rewritten || len(result.Decisions) != 1 {
+		t.Fatalf("expected one declined decision, got %+v", result.Decisions)
+	}
+	if result.Decisions[0].Verdict.Allowed {
+		t.Fatal("verdict must be Allowed=false under redacted_thinking")
+	}
+}
+
+// TestAnthropicResponseRewriterAllowsRewriteWithoutThinkingJSON guards
+// against the guard over-triggering: a response with no thinking block
+// must still admit the original rewrite verdict unmodified.
+func TestAnthropicResponseRewriterAllowsRewriteWithoutThinkingJSON(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{
+	  "id":"msg_norew",
+	  "type":"message",
+	  "role":"assistant",
+	  "model":"claude-test",
+	  "content":[
+	    {"type":"tool_use","id":"toolu_norew","name":"Bash","input":{"command":"curl https://gmail.googleapis.com -H 'Authorization: Bearer autovault_x'"}}
+	  ],
+	  "stop_reason":"tool_use"
+	}`)
+
+	rewrite := json.RawMessage(`{"command":"rewritten"}`)
+	result, err := (&AnthropicResponseRewriter{}).Rewrite(body, "application/json", func(ToolUse) ToolUseVerdict {
+		return ToolUseVerdict{Allowed: true, RewriteInput: rewrite}
+	})
+	if err != nil {
+		t.Fatalf("Rewrite: %v", err)
+	}
+	if !result.Rewritten || len(result.Decisions) != 1 || !result.Decisions[0].Verdict.Allowed {
+		t.Fatalf("expected the rewrite to go through unchanged when no thinking blocks present; got %+v", result.Decisions)
+	}
+}
+
 func TestAnthropicResponseRewriterOmitsEmptyTextBlocksWhenRewritingSSE(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/llmproxy/postprocess.go
+++ b/internal/runtime/llmproxy/postprocess.go
@@ -1809,6 +1809,19 @@ func PostprocessStream(
 
 	for _, tu := range streamResult.ToolUses {
 		v := eval(tu)
+		// Mirror the buffered-rewriter guard: when the streamed
+		// assistant turn includes a thinking or redacted_thinking
+		// block, the model's signature covers every sibling block.
+		// Applying an in-place tool_use input rewrite would
+		// invalidate it, and the agent's NEXT request would 400 with
+		// "thinking blocks in the latest assistant message cannot
+		// be modified." Convert any rewrite-bearing verdict to a
+		// blocked refusal verdict whose Reason + ContinueWithToolResult
+		// explain the cause; the downstream block-rendering path
+		// surfaces the refusal in place of the (broken) rewrite.
+		if streamResult.HasThinking && v.Allowed && len(v.RewriteInput) > 0 {
+			v = conversation.ThinkingRewriteRefusal(v)
+		}
 		decisions = append(decisions, conversation.ToolUseDecisionRecord{
 			ToolUse:          tu,
 			Verdict:          v,


### PR DESCRIPTION
## Summary

- When an Anthropic assistant message contains a \`thinking\` or \`redacted_thinking\` block, the model's signature covers every sibling block including each \`tool_use.input\`. The proxy's in-place rewrite of \`tool_use.input\` (to redirect credentialed curls at the resolver) silently invalidates the signature. The agent CLI echoes the rewritten content back to Anthropic on the next turn and Anthropic returns \`400 \\\`thinking\\\` or \\\`redacted_thinking\\\` blocks in the latest assistant message cannot be modified\`.
- Detect thinking/redacted-thinking presence at three points in the rewrite pipeline (\`rewriteJSON\`, \`rewriteSSE\`, and the streaming postprocess loop that applies rewrites after \`StreamRewrite\` returns) and convert any \`RewriteInput\`-bearing verdict into a structured refusal verdict. The downstream block-rendering path surfaces a Clawvisor refusal in place of the broken rewrite, so the conversation continues instead of hard-failing with an opaque 400.
- Three regression tests in \`response_test.go\` cover thinking, redacted-thinking, and the no-thinking baseline (to guard against the guard over-triggering).

## Who's affected

Any Anthropic-based agent with extended thinking enabled doing credentialed tool calls through the resolver — most prominently Claude Code on Sonnet 4.6+, which enables thinking on most reasoning-heavy task types. OpenAI/Codex paths aren't affected (no thinking-signature equivalent).

## Net behavior change

A turn that previously hard-failed with an opaque Anthropic 400 now fails closed with a Clawvisor-authored refusal on the same turn. The agent sees a tool_result explaining why the call was declined and the conversation continues.

## Test plan

- [x] \`go test ./internal/runtime/conversation/ ./internal/runtime/llmproxy/ ./internal/api/handlers/\` — all green.
- [x] New unit tests assert the JSON rewriter declines under \`thinking\` and \`redacted_thinking\`, and still admits rewrites on turns without either.
- [x] Manual e2e against Claude (Sonnet 4.6) with a credentialed Gmail-style request previously reproduced the upstream 400; with this fix the proxy now emits a Clawvisor refusal on the same turn instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)