### PR TITLE
fix(llmproxy): preserve index 0 for thinking blocks in Anthropic SSE stream

### DIFF
--- a/internal/runtime/conversation/assistant_prepend.go
+++ b/internal/runtime/conversation/assistant_prepend.go
@@ -48,13 +48,29 @@ func prependAnthropicAssistantTextJSON(body []byte, text string) ([]byte, error)
 	if err != nil {
 		return nil, fmt.Errorf("prepend anthropic text: marshal text block: %w", err)
 	}
-	// Use append-from-literal rather than make with a pre-computed
-	// cap. CodeQL flags `len(content)+1` as a potential overflow in
-	// the allocation size; the input is bounded by upstream
-	// MaxResponseBytes so the overflow is unreachable in practice,
-	// but sidestepping the explicit arithmetic keeps the static
-	// analyzer quiet without buying us anything in exchange.
-	merged := append([]json.RawMessage{json.RawMessage(textBlock)}, content...)
+	// Inspect the first content block. If it is a thinking block or redacted_thinking
+	// block, we insert the notice block at index 1 instead of index 0.
+	isThinking := false
+	if len(content) > 0 {
+		var firstBlock struct {
+			Type string `json:"type"`
+		}
+		if err := json.Unmarshal(content[0], &firstBlock); err == nil {
+			if firstBlock.Type == "thinking" || firstBlock.Type == "redacted_thinking" {
+				isThinking = true
+			}
+		}
+	}
+
+	var merged []json.RawMessage
+	if isThinking {
+		merged = make([]json.RawMessage, 0, len(content)+1)
+		merged = append(merged, content[0])
+		merged = append(merged, json.RawMessage(textBlock))
+		merged = append(merged, content[1:]...)
+	} else {
+		merged = append([]json.RawMessage{json.RawMessage(textBlock)}, content...)
+	}
 	mergedRaw, err := json.Marshal(merged)
 	if err != nil {
 		return nil, fmt.Errorf("prepend anthropic text: marshal content: %w", err)
@@ -96,7 +112,38 @@ func prependAnthropicAssistantTextSSE(body []byte, text string) ([]byte, error) 
 		return nil
 	}
 
-	textBlockInserted := false
+	delayNotice := isFirstBlockThinking(events)
+	noticeInserted := false
+	maxIndexSeen := 0
+
+	emitNotice := func(idx int) error {
+		if err := emit("content_block_start", map[string]any{
+			"type":  "content_block_start",
+			"index": idx,
+			"content_block": map[string]any{
+				"type": "text",
+				"text": "",
+			},
+		}); err != nil {
+			return err
+		}
+		if err := emit("content_block_delta", map[string]any{
+			"type":  "content_block_delta",
+			"index": idx,
+			"delta": map[string]any{"type": "text_delta", "text": text},
+		}); err != nil {
+			return err
+		}
+		if err := emit("content_block_stop", map[string]any{
+			"type":  "content_block_stop",
+			"index": idx,
+		}); err != nil {
+			return err
+		}
+		noticeInserted = true
+		return nil
+	}
+
 	for _, ev := range events {
 		switch ev.Event {
 		case "message_start":
@@ -106,58 +153,127 @@ func prependAnthropicAssistantTextSSE(body []byte, text string) ([]byte, error) 
 			out.WriteString("\ndata: ")
 			out.WriteString(ev.Data)
 			out.WriteString("\n\n")
-			// Inject our text block immediately after message_start so
-			// the harness renders the notice before any tool_use the
-			// upstream emitted.
-			if err := emit("content_block_start", map[string]any{
-				"type":  "content_block_start",
-				"index": 0,
-				"content_block": map[string]any{
-					"type": "text",
-					"text": "",
-				},
-			}); err != nil {
-				return body, nil
+
+			if !delayNotice {
+				if err := emitNotice(0); err != nil {
+					return body, nil
+				}
 			}
-			if err := emit("content_block_delta", map[string]any{
-				"type":  "content_block_delta",
-				"index": 0,
-				"delta": map[string]any{"type": "text_delta", "text": text},
-			}); err != nil {
-				return body, nil
+		case "content_block_start":
+			var cbs struct {
+				Index int `json:"index"`
 			}
-			if err := emit("content_block_stop", map[string]any{
-				"type":  "content_block_stop",
-				"index": 0,
-			}); err != nil {
-				return body, nil
+			_ = json.Unmarshal([]byte(ev.Data), &cbs)
+			if cbs.Index > maxIndexSeen {
+				maxIndexSeen = cbs.Index
 			}
-			textBlockInserted = true
-		case "content_block_start", "content_block_delta", "content_block_stop":
-			if !textBlockInserted {
-				// No message_start observed yet (malformed stream). Pass
-				// through unchanged; we'd rather render a broken
-				// notice than corrupt the original event order.
+
+			if delayNotice {
+				if !noticeInserted {
+					if cbs.Index == 0 {
+						// Pass through the thinking block verbatim.
+						out.WriteString("event: ")
+						out.WriteString(ev.Event)
+						out.WriteString("\ndata: ")
+						out.WriteString(ev.Data)
+						out.WriteString("\n\n")
+					} else {
+						// Inject notice block at index 1
+						if err := emitNotice(1); err != nil {
+							return body, nil
+						}
+						// Shift this block to index 2
+						shifted, ok := shiftAnthropicEventIndex(ev.Event, ev.Data, 1)
+						if !ok {
+							return body, nil
+						}
+						out.WriteString("event: ")
+						out.WriteString(ev.Event)
+						out.WriteString("\ndata: ")
+						out.Write(shifted)
+						out.WriteString("\n\n")
+					}
+				} else {
+					shifted, ok := shiftAnthropicEventIndex(ev.Event, ev.Data, 1)
+					if !ok {
+						return body, nil
+					}
+					out.WriteString("event: ")
+					out.WriteString(ev.Event)
+					out.WriteString("\ndata: ")
+					out.Write(shifted)
+					out.WriteString("\n\n")
+				}
+			} else {
+				if !noticeInserted {
+					// No message_start observed yet. Pass through unchanged.
+					out.WriteString("event: ")
+					out.WriteString(ev.Event)
+					out.WriteString("\ndata: ")
+					out.WriteString(ev.Data)
+					out.WriteString("\n\n")
+					continue
+				}
+				shifted, ok := shiftAnthropicEventIndex(ev.Event, ev.Data, 1)
+				if !ok {
+					return body, nil
+				}
 				out.WriteString("event: ")
 				out.WriteString(ev.Event)
 				out.WriteString("\ndata: ")
-				out.WriteString(ev.Data)
+				out.Write(shifted)
 				out.WriteString("\n\n")
-				continue
 			}
-			shifted, ok := shiftAnthropicEventIndex(ev.Event, ev.Data, 1)
-			if !ok {
+		case "content_block_delta", "content_block_stop":
+			if delayNotice {
+				if !noticeInserted {
+					// Must be index 0 (thinking block). Pass through verbatim.
+					out.WriteString("event: ")
+					out.WriteString(ev.Event)
+					out.WriteString("\ndata: ")
+					out.WriteString(ev.Data)
+					out.WriteString("\n\n")
+				} else {
+					shifted, ok := shiftAnthropicEventIndex(ev.Event, ev.Data, 1)
+					if !ok {
+						return body, nil
+					}
+					out.WriteString("event: ")
+					out.WriteString(ev.Event)
+					out.WriteString("\ndata: ")
+					out.Write(shifted)
+					out.WriteString("\n\n")
+				}
+			} else {
+				if !noticeInserted {
+					out.WriteString("event: ")
+					out.WriteString(ev.Event)
+					out.WriteString("\ndata: ")
+					out.WriteString(ev.Data)
+					out.WriteString("\n\n")
+					continue
+				}
+				shifted, ok := shiftAnthropicEventIndex(ev.Event, ev.Data, 1)
+				if !ok {
+					return body, nil
+				}
 				out.WriteString("event: ")
 				out.WriteString(ev.Event)
 				out.WriteString("\ndata: ")
-				out.WriteString(ev.Data)
+				out.Write(shifted)
 				out.WriteString("\n\n")
-				continue
+			}
+		case "message_delta", "message_stop":
+			if delayNotice && !noticeInserted {
+				// Inject notice block at index 1 before message delta/stop
+				if err := emitNotice(1); err != nil {
+					return body, nil
+				}
 			}
 			out.WriteString("event: ")
 			out.WriteString(ev.Event)
 			out.WriteString("\ndata: ")
-			out.Write(shifted)
+			out.WriteString(ev.Data)
 			out.WriteString("\n\n")
 		default:
 			out.WriteString("event: ")
@@ -165,6 +281,12 @@ func prependAnthropicAssistantTextSSE(body []byte, text string) ([]byte, error) 
 			out.WriteString("\ndata: ")
 			out.WriteString(ev.Data)
 			out.WriteString("\n\n")
+		}
+	}
+
+	if delayNotice && !noticeInserted {
+		if err := emitNotice(maxIndexSeen + 1); err != nil {
+			return body, nil
 		}
 	}
 	return out.Bytes(), nil
@@ -816,4 +938,21 @@ func shiftAnthropicEventIndex(event, data string, delta int) ([]byte, bool) {
 		return nil, false
 	}
 	return out, true
+}
+
+func isFirstBlockThinking(events []sseEvent) bool {
+	for _, ev := range events {
+		if ev.Event == "content_block_start" {
+			var cbs struct {
+				ContentBlock struct {
+					Type string `json:"type"`
+				} `json:"content_block"`
+			}
+			if err := json.Unmarshal([]byte(ev.Data), &cbs); err == nil {
+				return cbs.ContentBlock.Type == "thinking" || cbs.ContentBlock.Type == "redacted_thinking"
+			}
+			break
+		}
+	}
+	return false
 }

--- a/internal/runtime/conversation/assistant_prepend_test.go
+++ b/internal/runtime/conversation/assistant_prepend_test.go
@@ -441,3 +441,197 @@ func TestPrependAnthropicAssistantText_SSE_NoMessageStartFallsThrough(t *testing
 		t.Errorf("notice should not be inserted into malformed stream (no message_start)")
 	}
 }
+
+func TestPrependAnthropicAssistantText_JSON_WithThinking(t *testing.T) {
+	body := []byte(`{
+		"id": "msg_abc",
+		"type": "message",
+		"role": "assistant",
+		"model": "claude-sonnet-4",
+		"content": [
+			{"type": "thinking", "thinking": "reasoning here"},
+			{"type": "text", "text": "hello"}
+		],
+		"stop_reason": "end_turn"
+	}`)
+
+	out, err := PrependAnthropicAssistantText("application/json", body, "[Clawvisor] approved")
+	if err != nil {
+		t.Fatalf("PrependAnthropicAssistantText: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(out, &parsed); err != nil {
+		t.Fatalf("output not JSON: %v\n%s", err, out)
+	}
+
+	content, ok := parsed["content"].([]any)
+	if !ok || len(content) != 3 {
+		t.Fatalf("expected 3 content blocks; got %d: %v", len(content), content)
+	}
+
+	// First block must remain thinking
+	thinking := content[0].(map[string]any)
+	if thinking["type"] != "thinking" || thinking["thinking"] != "reasoning here" {
+		t.Errorf("thinking block should remain at index 0, got %v", thinking)
+	}
+
+	// Second block must be notice
+	notice := content[1].(map[string]any)
+	if notice["type"] != "text" || notice["text"] != "[Clawvisor] approved" {
+		t.Errorf("notice block should be at index 1, got %v", notice)
+	}
+
+	// Third block must be original text
+	text := content[2].(map[string]any)
+	if text["type"] != "text" || text["text"] != "hello" {
+		t.Errorf("original text block should be shifted to index 2, got %v", text)
+	}
+}
+
+func TestPrependAnthropicAssistantText_SSE_WithThinking(t *testing.T) {
+	sse := strings.Join([]string{
+		`event: message_start`,
+		`data: {"type":"message_start","message":{"id":"msg_x","role":"assistant","model":"claude-sonnet-4","content":[]}}`,
+		``,
+		`event: content_block_start`,
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking"}}`,
+		``,
+		`event: content_block_delta`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"thinking text"}}`,
+		``,
+		`event: content_block_stop`,
+		`data: {"type":"content_block_stop","index":0}`,
+		``,
+		`event: content_block_start`,
+		`data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}`,
+		``,
+		`event: content_block_delta`,
+		`data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"hello"}}`,
+		``,
+		`event: content_block_stop`,
+		`data: {"type":"content_block_stop","index":1}`,
+		``,
+		`event: message_delta`,
+		`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}`,
+		``,
+		`event: message_stop`,
+		`data: {"type":"message_stop"}`,
+		``,
+	}, "\n")
+
+	out, err := PrependAnthropicAssistantText("text/event-stream", []byte(sse), "[Clawvisor] approved")
+	if err != nil {
+		t.Fatalf("PrependAnthropicAssistantText: %v", err)
+	}
+
+	events, err := parseSSEEvents(out)
+	if err != nil {
+		t.Fatalf("parseSSEEvents: %v", err)
+	}
+
+	var noticeIndex, thinkingIndex, textIndex int
+	noticeIndex, thinkingIndex, textIndex = -1, -1, -1
+
+	for _, ev := range events {
+		var obj map[string]any
+		if err := json.Unmarshal([]byte(ev.Data), &obj); err != nil {
+			continue
+		}
+		if ev.Event == "content_block_start" {
+			cb, _ := obj["content_block"].(map[string]any)
+			idx := numAsInt(obj["index"])
+			if cb != nil {
+				switch cb["type"] {
+				case "text":
+					if noticeIndex == -1 {
+						noticeIndex = idx
+					} else {
+						textIndex = idx
+					}
+				case "thinking":
+					thinkingIndex = idx
+				}
+			}
+		}
+	}
+
+	if thinkingIndex != 0 {
+		t.Errorf("thinking block should remain at index 0, got %d", thinkingIndex)
+	}
+	if noticeIndex != 1 {
+		t.Errorf("notice block should be injected at index 1, got %d", noticeIndex)
+	}
+	if textIndex != 2 {
+		t.Errorf("model text block should be shifted to index 2, got %d", textIndex)
+	}
+}
+
+func TestPrependAnthropicAssistantText_SSE_ThinkingOnly(t *testing.T) {
+	sse := strings.Join([]string{
+		`event: message_start`,
+		`data: {"type":"message_start","message":{"id":"msg_x","role":"assistant","model":"claude-sonnet-4","content":[]}}`,
+		``,
+		`event: content_block_start`,
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking"}}`,
+		``,
+		`event: content_block_delta`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"thinking text"}}`,
+		``,
+		`event: content_block_stop`,
+		`data: {"type":"content_block_stop","index":0}`,
+		``,
+		`event: message_delta`,
+		`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}`,
+		``,
+		`event: message_stop`,
+		`data: {"type":"message_stop"}`,
+		``,
+	}, "\n")
+
+	out, err := PrependAnthropicAssistantText("text/event-stream", []byte(sse), "[Clawvisor] approved")
+	if err != nil {
+		t.Fatalf("PrependAnthropicAssistantText: %v", err)
+	}
+
+	events, err := parseSSEEvents(out)
+	if err != nil {
+		t.Fatalf("parseSSEEvents: %v", err)
+	}
+
+	var noticeIndex, thinkingIndex, textIndex int
+	noticeIndex, thinkingIndex, textIndex = -1, -1, -1
+
+	for _, ev := range events {
+		var obj map[string]any
+		if err := json.Unmarshal([]byte(ev.Data), &obj); err != nil {
+			continue
+		}
+		if ev.Event == "content_block_start" {
+			cb, _ := obj["content_block"].(map[string]any)
+			idx := numAsInt(obj["index"])
+			if cb != nil {
+				switch cb["type"] {
+				case "text":
+					if noticeIndex == -1 {
+						noticeIndex = idx
+					} else {
+						textIndex = idx
+					}
+				case "thinking":
+					thinkingIndex = idx
+				}
+			}
+		}
+	}
+
+	if thinkingIndex != 0 {
+		t.Errorf("thinking block should remain at index 0, got %d", thinkingIndex)
+	}
+	if noticeIndex != 1 {
+		t.Errorf("notice block should be injected at index 1, got %d", noticeIndex)
+	}
+	if textIndex != -1 {
+		t.Errorf("there should be no model text block, got index %d", textIndex)
+	}
+}

--- a/internal/runtime/conversation/streaming_assistant_prepend.go
+++ b/internal/runtime/conversation/streaming_assistant_prepend.go
@@ -98,6 +98,10 @@ type streamingPrependWriter struct {
 	// after we've emitted the leading notice events; from then on we
 	// shift downstream indices.
 	noticeInjected bool
+
+	// State for Anthropic thinking fallback
+	hasSeenAnyBlock bool
+	maxIndexSeen    int
 }
 
 func (s *streamingPrependWriter) Write(p []byte) (int, error) {
@@ -138,6 +142,10 @@ func (s *streamingPrependWriter) Close() error {
 	if s.shape == StreamShapeOpenAIChat && !s.noticeInjected {
 		s.emitSyntheticChatNotice()
 		s.noticeInjected = true
+	}
+	// Anthropic fallback — if the stream ended without notice being injected (e.g. thinking-only stream)
+	if s.shape == StreamShapeAnthropicMessages && !s.noticeInjected {
+		s.injectAnthropicFallbackNotice()
 	}
 	return nil
 }
@@ -246,6 +254,31 @@ func (s *streamingPrependWriter) emitJSON(event string, payload any) {
 
 // --- Anthropic ---------------------------------------------------------
 
+func (s *streamingPrependWriter) injectAnthropicFallbackNotice() {
+	idx := 0
+	if s.hasSeenAnyBlock {
+		idx = s.maxIndexSeen + 1
+	}
+	s.emitJSON("content_block_start", map[string]any{
+		"type":  "content_block_start",
+		"index": idx,
+		"content_block": map[string]any{
+			"type": "text",
+			"text": "",
+		},
+	})
+	s.emitJSON("content_block_delta", map[string]any{
+		"type":  "content_block_delta",
+		"index": idx,
+		"delta": map[string]any{"type": "text_delta", "text": s.text},
+	})
+	s.emitJSON("content_block_stop", map[string]any{
+		"type":  "content_block_stop",
+		"index": idx,
+	})
+	s.noticeInjected = true
+}
+
 func (s *streamingPrependWriter) flushAnthropic(event, data string) {
 	switch event {
 	case "message_start":
@@ -260,10 +293,16 @@ func (s *streamingPrependWriter) flushAnthropic(event, data string) {
 				} `json:"content_block"`
 			}
 			err := json.Unmarshal([]byte(data), &cbs)
-			if err == nil && cbs.ContentBlock.Type == "thinking" {
-				// Keep thinking block at index 0, do not inject notice yet.
-				s.passThrough(event, data)
-				return
+			if err == nil {
+				s.hasSeenAnyBlock = true
+				if cbs.Index > s.maxIndexSeen {
+					s.maxIndexSeen = cbs.Index
+				}
+				if cbs.ContentBlock.Type == "thinking" || cbs.ContentBlock.Type == "redacted_thinking" {
+					// Keep thinking block at index 0, do not inject notice yet.
+					s.passThrough(event, data)
+					return
+				}
 			}
 
 			// We need to inject the notice block at the current index.
@@ -320,6 +359,12 @@ func (s *streamingPrependWriter) flushAnthropic(event, data string) {
 			return
 		}
 		s.emitEvent(event, string(shifted))
+
+	case "message_delta", "message_stop":
+		if !s.noticeInjected {
+			s.injectAnthropicFallbackNotice()
+		}
+		s.passThrough(event, data)
 
 	default:
 		s.passThrough(event, data)

--- a/internal/runtime/conversation/streaming_assistant_prepend.go
+++ b/internal/runtime/conversation/streaming_assistant_prepend.go
@@ -250,10 +250,31 @@ func (s *streamingPrependWriter) flushAnthropic(event, data string) {
 	switch event {
 	case "message_start":
 		s.passThrough(event, data)
+
+	case "content_block_start":
 		if !s.noticeInjected {
+			var cbs struct {
+				Index        int `json:"index"`
+				ContentBlock struct {
+					Type string `json:"type"`
+				} `json:"content_block"`
+			}
+			err := json.Unmarshal([]byte(data), &cbs)
+			if err == nil && cbs.ContentBlock.Type == "thinking" {
+				// Keep thinking block at index 0, do not inject notice yet.
+				s.passThrough(event, data)
+				return
+			}
+
+			// We need to inject the notice block at the current index.
+			idx := 0
+			if err == nil {
+				idx = cbs.Index
+			}
+
 			s.emitJSON("content_block_start", map[string]any{
 				"type":  "content_block_start",
-				"index": 0,
+				"index": idx,
 				"content_block": map[string]any{
 					"type": "text",
 					"text": "",
@@ -261,16 +282,34 @@ func (s *streamingPrependWriter) flushAnthropic(event, data string) {
 			})
 			s.emitJSON("content_block_delta", map[string]any{
 				"type":  "content_block_delta",
-				"index": 0,
+				"index": idx,
 				"delta": map[string]any{"type": "text_delta", "text": s.text},
 			})
 			s.emitJSON("content_block_stop", map[string]any{
 				"type":  "content_block_stop",
-				"index": 0,
+				"index": idx,
 			})
 			s.noticeInjected = true
+
+			// Shift the current block by 1 and emit.
+			shifted, ok := shiftAnthropicEventIndex(event, data, 1)
+			if !ok {
+				s.passThrough(event, data)
+				return
+			}
+			s.emitEvent(event, string(shifted))
+			return
 		}
-	case "content_block_start", "content_block_delta", "content_block_stop":
+
+		// Notice is already injected. Shift the current block by 1.
+		shifted, ok := shiftAnthropicEventIndex(event, data, 1)
+		if !ok {
+			s.passThrough(event, data)
+			return
+		}
+		s.emitEvent(event, string(shifted))
+
+	case "content_block_delta", "content_block_stop":
 		if !s.noticeInjected {
 			s.passThrough(event, data)
 			return
@@ -281,6 +320,7 @@ func (s *streamingPrependWriter) flushAnthropic(event, data string) {
 			return
 		}
 		s.emitEvent(event, string(shifted))
+
 	default:
 		s.passThrough(event, data)
 	}

--- a/internal/runtime/conversation/streaming_assistant_prepend_test.go
+++ b/internal/runtime/conversation/streaming_assistant_prepend_test.go
@@ -413,80 +413,176 @@ func numAsInt(v any) int {
 }
 
 func TestStreamingFirstTurnNoticeWriter_Anthropic_ThinkingBlockIndexCollision(t *testing.T) {
-	upstream := strings.Join([]string{
-		`event: message_start`,
-		`data: {"type":"message_start","message":{"id":"msg_x","role":"assistant","model":"claude-sonnet-4"}}`,
-		``,
-		`event: content_block_start`,
-		`data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}`,
-		``,
-		`event: content_block_delta`,
-		`data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"thinking text"}}`,
-		``,
-		`event: content_block_stop`,
-		`data: {"type":"content_block_stop","index":0}`,
-		``,
-		`event: content_block_start`,
-		`data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}`,
-		``,
-		`event: content_block_delta`,
-		`data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"hello"}}`,
-		``,
-		`event: content_block_stop`,
-		`data: {"type":"content_block_stop","index":1}`,
-		``,
-		`event: message_delta`,
-		`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}`,
-		``,
-		`event: message_stop`,
-		`data: {"type":"message_stop"}`,
-		``,
-	}, "\n")
+	runTest := func(t *testing.T, blockType string) {
+		upstream := strings.Join([]string{
+			`event: message_start`,
+			`data: {"type":"message_start","message":{"id":"msg_x","role":"assistant","model":"claude-sonnet-4"}}`,
+			``,
+			`event: content_block_start`,
+			`data: {"type":"content_block_start","index":0,"content_block":{"type":"` + blockType + `"}}`,
+			``,
+			`event: content_block_delta`,
+			`data: {"type":"content_block_delta","index":0,"delta":{"type":"` + blockType + `_delta"}}`,
+			``,
+			`event: content_block_stop`,
+			`data: {"type":"content_block_stop","index":0}`,
+			``,
+			`event: content_block_start`,
+			`data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}`,
+			``,
+			`event: content_block_delta`,
+			`data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"hello"}}`,
+			``,
+			`event: content_block_stop`,
+			`data: {"type":"content_block_stop","index":1}`,
+			``,
+			`event: message_delta`,
+			`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}`,
+			``,
+			`event: message_stop`,
+			`data: {"type":"message_stop"}`,
+			``,
+		}, "\n")
 
-	var buf bytes.Buffer
-	w := NewStreamingFirstTurnNoticeWriter(&buf, StreamShapeAnthropicMessages, "[Clawvisor] notice")
-	writeInChunks(t, w, upstream, 17)
-	if c, ok := w.(io.Closer); ok {
-		_ = c.Close()
-	}
-
-	got := buf.String()
-	events, err := parseSSEEvents([]byte(got))
-	if err != nil {
-		t.Fatalf("parseSSEEvents: %v", err)
-	}
-
-	var noticeIndex, thinkingIndex, textIndex int
-	noticeIndex, thinkingIndex, textIndex = -1, -1, -1
-
-	for _, ev := range events {
-		var obj map[string]any
-		if err := json.Unmarshal([]byte(ev.Data), &obj); err != nil {
-			continue
+		var buf bytes.Buffer
+		w := NewStreamingFirstTurnNoticeWriter(&buf, StreamShapeAnthropicMessages, "[Clawvisor] notice")
+		writeInChunks(t, w, upstream, 17)
+		if c, ok := w.(io.Closer); ok {
+			_ = c.Close()
 		}
-		if ev.Event == "content_block_start" {
-			cb, _ := obj["content_block"].(map[string]any)
-			idx := numAsInt(obj["index"])
-			if cb != nil {
-				switch cb["type"] {
-				case "text":
-					if noticeIndex == -1 {
-						noticeIndex = idx
-					} else {
-						textIndex = idx
+
+		got := buf.String()
+		events, err := parseSSEEvents([]byte(got))
+		if err != nil {
+			t.Fatalf("parseSSEEvents: %v", err)
+		}
+
+		var noticeIndex, thinkingIndex, textIndex int
+		noticeIndex, thinkingIndex, textIndex = -1, -1, -1
+
+		for _, ev := range events {
+			var obj map[string]any
+			if err := json.Unmarshal([]byte(ev.Data), &obj); err != nil {
+				continue
+			}
+			if ev.Event == "content_block_start" {
+				cb, _ := obj["content_block"].(map[string]any)
+				idx := numAsInt(obj["index"])
+				if cb != nil {
+					switch cb["type"] {
+					case "text":
+						if noticeIndex == -1 {
+							noticeIndex = idx
+						} else {
+							textIndex = idx
+						}
+					case "thinking", "redacted_thinking":
+						thinkingIndex = idx
 					}
-				case "thinking":
-					thinkingIndex = idx
 				}
 			}
 		}
+
+		t.Logf("Indices for %s: notice=%d, thinking=%d, text=%d", blockType, noticeIndex, thinkingIndex, textIndex)
+
+		if thinkingIndex != 0 {
+			t.Errorf("thinking block should remain at index 0, got %d", thinkingIndex)
+		}
+		if noticeIndex != 1 {
+			t.Errorf("notice block should be injected at index 1, got %d", noticeIndex)
+		}
+		if textIndex != 2 {
+			t.Errorf("model text block should be shifted to index 2, got %d", textIndex)
+		}
 	}
 
-	t.Logf("Indices: notice=%d, thinking=%d, text=%d", noticeIndex, thinkingIndex, textIndex)
-	
-	// We expect the bug to shift thinking to index 1 and text to index 2, instead of keeping thinking at 0
-	if thinkingIndex != 0 {
-		t.Errorf("EXPECTED BUG: thinking block got shifted to index %d instead of remaining at 0", thinkingIndex)
-	}
+	t.Run("thinking", func(t *testing.T) {
+		runTest(t, "thinking")
+	})
+	t.Run("redacted_thinking", func(t *testing.T) {
+		runTest(t, "redacted_thinking")
+	})
 }
 
+func TestStreamingFirstTurnNoticeWriter_Anthropic_ThinkingOnlyFallback(t *testing.T) {
+	runTest := func(t *testing.T, blockType string) {
+		upstream := strings.Join([]string{
+			`event: message_start`,
+			`data: {"type":"message_start","message":{"id":"msg_x","role":"assistant","model":"claude-sonnet-4"}}`,
+			``,
+			`event: content_block_start`,
+			`data: {"type":"content_block_start","index":0,"content_block":{"type":"` + blockType + `"}}`,
+			``,
+			`event: content_block_delta`,
+			`data: {"type":"content_block_delta","index":0,"delta":{"type":"` + blockType + `_delta"}}`,
+			``,
+			`event: content_block_stop`,
+			`data: {"type":"content_block_stop","index":0}`,
+			``,
+			`event: message_delta`,
+			`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}`,
+			``,
+			`event: message_stop`,
+			`data: {"type":"message_stop"}`,
+			``,
+		}, "\n")
+
+		var buf bytes.Buffer
+		w := NewStreamingFirstTurnNoticeWriter(&buf, StreamShapeAnthropicMessages, "[Clawvisor] notice")
+		writeInChunks(t, w, upstream, 17)
+		if c, ok := w.(io.Closer); ok {
+			_ = c.Close()
+		}
+
+		got := buf.String()
+		events, err := parseSSEEvents([]byte(got))
+		if err != nil {
+			t.Fatalf("parseSSEEvents: %v", err)
+		}
+
+		var noticeIndex, thinkingIndex, textIndex int
+		noticeIndex, thinkingIndex, textIndex = -1, -1, -1
+
+		for _, ev := range events {
+			var obj map[string]any
+			if err := json.Unmarshal([]byte(ev.Data), &obj); err != nil {
+				continue
+			}
+			if ev.Event == "content_block_start" {
+				cb, _ := obj["content_block"].(map[string]any)
+				idx := numAsInt(obj["index"])
+				if cb != nil {
+					switch cb["type"] {
+					case "text":
+						if noticeIndex == -1 {
+							noticeIndex = idx
+						} else {
+							textIndex = idx
+						}
+					case "thinking", "redacted_thinking":
+						thinkingIndex = idx
+					}
+				}
+			}
+		}
+
+		t.Logf("Indices for thinking-only %s: notice=%d, thinking=%d, text=%d", blockType, noticeIndex, thinkingIndex, textIndex)
+
+		if thinkingIndex != 0 {
+			t.Errorf("thinking block should remain at index 0, got %d", thinkingIndex)
+		}
+		if noticeIndex != 1 {
+			t.Errorf("notice block should be injected at index 1, got %d", noticeIndex)
+		}
+		if textIndex != -1 {
+			t.Errorf("there should be no model text block, got index %d", textIndex)
+		}
+	}
+
+	t.Run("thinking", func(t *testing.T) {
+		runTest(t, "thinking")
+	})
+	t.Run("redacted_thinking", func(t *testing.T) {
+		runTest(t, "redacted_thinking")
+	})
+}

--- a/internal/runtime/conversation/streaming_assistant_prepend_test.go
+++ b/internal/runtime/conversation/streaming_assistant_prepend_test.go
@@ -411,3 +411,82 @@ func numAsInt(v any) int {
 	}
 	return -1
 }
+
+func TestStreamingFirstTurnNoticeWriter_Anthropic_ThinkingBlockIndexCollision(t *testing.T) {
+	upstream := strings.Join([]string{
+		`event: message_start`,
+		`data: {"type":"message_start","message":{"id":"msg_x","role":"assistant","model":"claude-sonnet-4"}}`,
+		``,
+		`event: content_block_start`,
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}`,
+		``,
+		`event: content_block_delta`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"thinking text"}}`,
+		``,
+		`event: content_block_stop`,
+		`data: {"type":"content_block_stop","index":0}`,
+		``,
+		`event: content_block_start`,
+		`data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}`,
+		``,
+		`event: content_block_delta`,
+		`data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"hello"}}`,
+		``,
+		`event: content_block_stop`,
+		`data: {"type":"content_block_stop","index":1}`,
+		``,
+		`event: message_delta`,
+		`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}`,
+		``,
+		`event: message_stop`,
+		`data: {"type":"message_stop"}`,
+		``,
+	}, "\n")
+
+	var buf bytes.Buffer
+	w := NewStreamingFirstTurnNoticeWriter(&buf, StreamShapeAnthropicMessages, "[Clawvisor] notice")
+	writeInChunks(t, w, upstream, 17)
+	if c, ok := w.(io.Closer); ok {
+		_ = c.Close()
+	}
+
+	got := buf.String()
+	events, err := parseSSEEvents([]byte(got))
+	if err != nil {
+		t.Fatalf("parseSSEEvents: %v", err)
+	}
+
+	var noticeIndex, thinkingIndex, textIndex int
+	noticeIndex, thinkingIndex, textIndex = -1, -1, -1
+
+	for _, ev := range events {
+		var obj map[string]any
+		if err := json.Unmarshal([]byte(ev.Data), &obj); err != nil {
+			continue
+		}
+		if ev.Event == "content_block_start" {
+			cb, _ := obj["content_block"].(map[string]any)
+			idx := numAsInt(obj["index"])
+			if cb != nil {
+				switch cb["type"] {
+				case "text":
+					if noticeIndex == -1 {
+						noticeIndex = idx
+					} else {
+						textIndex = idx
+					}
+				case "thinking":
+					thinkingIndex = idx
+				}
+			}
+		}
+	}
+
+	t.Logf("Indices: notice=%d, thinking=%d, text=%d", noticeIndex, thinkingIndex, textIndex)
+	
+	// We expect the bug to shift thinking to index 1 and text to index 2, instead of keeping thinking at 0
+	if thinkingIndex != 0 {
+		t.Errorf("EXPECTED BUG: thinking block got shifted to index %d instead of remaining at 0", thinkingIndex)
+	}
+}
+


### PR DESCRIPTION
### Description
Addresses the issue where Claude Code's "Percolating..." thinking display disappears prematurely when streaming responses through Clawvisor.

### Root Cause
Clawvisor prepended the first-turn notice block at Index 0 and pushed the model's actual streaming output to Index 1. Because Claude Code's parser expects any reasoning/thinking block to be at Index 0, shifting the thinking block to Index 1 caused the terminal harness to assume thinking was skipped or completed, instantly hiding the spinner.

### Solution
- Modified the Anthropic SSE stream rewriter in `streaming_assistant_prepend.go` to delay notice injection when a `thinking` block is detected first.
- The `thinking` block remains at Index 0, allowing client harnesses to render the reasoning spinner correctly.
- The notice is injected as a separate text block at Index 1 immediately before the model's output text block starts.

### Verification & Tests
- Added `TestStreamingFirstTurnNoticeWriter_Anthropic_ThinkingBlockIndexCollision` to verify that the notice is deferred to Index 1 and thinking remains at Index 0.
- Ran the full `internal/runtime/conversation/...` test suite to ensure no regressions with standard streams.

### Video Proof

https://github.com/user-attachments/assets/83b93d16-2abe-4165-91e7-8815be14286e

