### PR TITLE
feat(llmproxy): implement smart token budgeting and rate-limit queueing

### DIFF
--- a/internal/api/handlers/agents.go
+++ b/internal/api/handlers/agents.go
@@ -2,6 +2,8 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
+	"io"
 	"log/slog"
 	"net/http"
 
@@ -171,6 +173,14 @@ func (h *AgentsHandler) UpdateRuntimeSettings(w http.ResponseWriter, r *http.Req
 		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not load agent runtime settings")
 		return
 	}
+	bodyReader := http.MaxBytesReader(w, r.Body, maxRequestBodySize)
+	defer bodyReader.Close()
+	bodyBytes, err := io.ReadAll(bodyReader)
+	if err != nil {
+		writeDetailedError(w, http.StatusBadRequest, diagnoseJSONError(err))
+		return
+	}
+
 	var body struct {
 		RuntimeEnabled                   bool    `json:"runtime_enabled"`
 		RuntimeMode                      string  `json:"runtime_mode"`
@@ -182,23 +192,46 @@ func (h *AgentsHandler) UpdateRuntimeSettings(w http.ResponseWriter, r *http.Req
 		MaxCostMicros                    *int64  `json:"max_cost_micros"`
 		MaxTokens                        *int64  `json:"max_tokens"`
 	}
-	if !decodeJSON(w, r, &body) {
+	if err := json.Unmarshal(bodyBytes, &body); err != nil {
+		writeDetailedError(w, http.StatusBadRequest, diagnoseJSONError(err))
 		return
 	}
-	switch body.RuntimeMode {
-	case "observe", "enforce":
-	default:
-		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "runtime_mode must be observe or enforce")
+
+	var rawMap map[string]json.RawMessage
+	if err := json.Unmarshal(bodyBytes, &rawMap); err != nil {
+		writeDetailedError(w, http.StatusBadRequest, diagnoseJSONError(err))
 		return
 	}
-	switch body.OutboundCredentialMode {
-	case "inherit", "observe", "strict":
-	default:
-		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "outbound_credential_mode must be inherit, observe, or strict")
-		return
+	if _, ok := rawMap["runtime_enabled"]; ok {
+		settings.RuntimeEnabled = body.RuntimeEnabled
 	}
-	if body.StarterProfile == "" {
-		body.StarterProfile = "none"
+	if _, ok := rawMap["runtime_mode"]; ok {
+		switch body.RuntimeMode {
+		case "observe", "enforce":
+			settings.RuntimeMode = body.RuntimeMode
+		default:
+			writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "runtime_mode must be observe or enforce")
+			return
+		}
+	}
+	if _, ok := rawMap["starter_profile"]; ok {
+		if body.StarterProfile == "" {
+			settings.StarterProfile = "none"
+		} else {
+			settings.StarterProfile = body.StarterProfile
+		}
+	}
+	if _, ok := rawMap["outbound_credential_mode"]; ok {
+		switch body.OutboundCredentialMode {
+		case "inherit", "observe", "strict":
+			settings.OutboundCredentialMode = body.OutboundCredentialMode
+		default:
+			writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "outbound_credential_mode must be inherit, observe, or strict")
+			return
+		}
+	}
+	if _, ok := rawMap["inject_stored_bearer"]; ok {
+		settings.InjectStoredBearer = body.InjectStoredBearer
 	}
 	// Conversation auto-approve threshold is optional in the request
 	// body so the existing runtime-settings clients (which don't know
@@ -214,16 +247,15 @@ func (h *AgentsHandler) UpdateRuntimeSettings(w http.ResponseWriter, r *http.Req
 		}
 		settings.ConversationAutoApproveThreshold = normalized
 	}
-	settings.RuntimeEnabled = body.RuntimeEnabled
-	settings.RuntimeMode = body.RuntimeMode
-	settings.StarterProfile = body.StarterProfile
-	settings.OutboundCredentialMode = body.OutboundCredentialMode
-	settings.InjectStoredBearer = body.InjectStoredBearer
 	if body.LiteProxySecretDetectionDisabled != nil {
 		settings.LiteProxySecretDetectionDisabled = *body.LiteProxySecretDetectionDisabled
 	}
-	settings.MaxCostMicros = body.MaxCostMicros
-	settings.MaxTokens = body.MaxTokens
+	if _, ok := rawMap["max_cost_micros"]; ok {
+		settings.MaxCostMicros = body.MaxCostMicros
+	}
+	if _, ok := rawMap["max_tokens"]; ok {
+		settings.MaxTokens = body.MaxTokens
+	}
 	if err := h.st.UpsertAgentRuntimeSettings(r.Context(), settings); err != nil {
 		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not save agent runtime settings")
 		return

--- a/internal/api/handlers/agents.go
+++ b/internal/api/handlers/agents.go
@@ -179,6 +179,8 @@ func (h *AgentsHandler) UpdateRuntimeSettings(w http.ResponseWriter, r *http.Req
 		InjectStoredBearer               bool    `json:"inject_stored_bearer"`
 		LiteProxySecretDetectionDisabled *bool   `json:"lite_proxy_secret_detection_disabled"`
 		ConversationAutoApproveThreshold *string `json:"conversation_auto_approve_threshold"`
+		MaxCostMicros                    *int64  `json:"max_cost_micros"`
+		MaxTokens                        *int64  `json:"max_tokens"`
 	}
 	if !decodeJSON(w, r, &body) {
 		return
@@ -220,6 +222,8 @@ func (h *AgentsHandler) UpdateRuntimeSettings(w http.ResponseWriter, r *http.Req
 	if body.LiteProxySecretDetectionDisabled != nil {
 		settings.LiteProxySecretDetectionDisabled = *body.LiteProxySecretDetectionDisabled
 	}
+	settings.MaxCostMicros = body.MaxCostMicros
+	settings.MaxTokens = body.MaxTokens
 	if err := h.st.UpsertAgentRuntimeSettings(r.Context(), settings); err != nil {
 		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not save agent runtime settings")
 		return

--- a/internal/api/handlers/llm_endpoint.go
+++ b/internal/api/handlers/llm_endpoint.go
@@ -731,7 +731,13 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 
 	budgetCheck, err := llmproxy.EvaluateBudget(r.Context(), h.Store, h.PendingApprovals, h.BudgetOverrides, agent, activeTaskID, provider, conversationID)
 	if err != nil {
-		h.Logger.WarnContext(r.Context(), "budget check failed", "err", err)
+		h.Logger.WarnContext(r.Context(), "budget check failed; continuing under fail-open posture",
+			"err", err,
+			"agent_id", agent.ID,
+			"task_id", activeTaskID,
+			"provider", string(provider),
+			"conversation_id", conversationID,
+		)
 	} else if budgetCheck.Blocked {
 		auditStatus = http.StatusOK
 		auditDecide = "deny"

--- a/internal/api/handlers/llm_endpoint.go
+++ b/internal/api/handlers/llm_endpoint.go
@@ -749,7 +749,7 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 
 	// Rate limit throttle
 	if h.RateLimits != nil {
-		if delay := h.RateLimits.ThrottleDelay(agent.ID, reqSummary.Model); delay > 0 {
+		if delay := h.RateLimits.ThrottleDelay(agent.ID, string(provider), reqSummary.Model); delay > 0 {
 			h.Logger.InfoContext(r.Context(), "rate limit throttling active, sleeping thread", "delay_ms", delay.Milliseconds())
 			select {
 			case <-r.Context().Done():
@@ -796,7 +796,7 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 	}
 	defer resp.Body.Close()
 	if h.RateLimits != nil {
-		h.RateLimits.Update(agent.ID, reqSummary.Model, resp.Header)
+		h.RateLimits.Update(agent.ID, string(provider), reqSummary.Model, resp.Header)
 	}
 	upstreamHeadersMs := time.Since(forwardStart).Milliseconds()
 	auditStatus = resp.StatusCode

--- a/internal/api/handlers/llm_endpoint.go
+++ b/internal/api/handlers/llm_endpoint.go
@@ -170,6 +170,11 @@ type LLMEndpointHandler struct {
 
 	defaultToolRulesMu   sync.Mutex
 	defaultToolRulesSeen map[string]map[string]struct{}
+
+	// BudgetOverrides tracks transient user overrides for budget warnings.
+	BudgetOverrides      *llmproxy.BudgetOverrideCache
+	// RateLimits tracks upstream request/token rate limits.
+	RateLimits           *llmproxy.RateLimitTracker
 }
 
 const defaultToolRulesSeenMaxAgents = 10000
@@ -197,6 +202,8 @@ func NewLLMEndpointHandler(st store.Store, v vault.Vault, logger *slog.Logger) *
 		CallerNonces:         llmproxy.NewMemoryCallerNonceCache(5 * time.Minute),
 		MaxRequestBytes:      34 << 20,
 		defaultToolRulesSeen: map[string]map[string]struct{}{},
+		BudgetOverrides:      llmproxy.NewBudgetOverrideCache(),
+		RateLimits:           llmproxy.NewRateLimitTracker(),
 	}
 }
 
@@ -520,6 +527,22 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	budgetApprovalConsumed := false
+	if budgetRewrite, budgetErr := llmproxy.RewriteBudgetApprovalReply(r.Context(), llmproxy.TaskReplyRewriteRequest{
+		HTTPRequest:     r,
+		Provider:        provider,
+		Body:            body,
+		Agent:           agent,
+		ConversationID:  conversationID,
+		PendingApproval: h.PendingApprovals,
+	}, h.BudgetOverrides); budgetErr != nil {
+		h.Logger.WarnContext(r.Context(), "budget approval reply handle failed", "err", budgetErr)
+	} else if budgetRewrite.Rewritten {
+		body = budgetRewrite.Body
+		budgetApprovalConsumed = true
+		auditParams["budget_approval_rewritten"] = true
+	}
+
 	// Persistent inline-approval context augmentation. The harness
 	// records what the user typed ("approve") not our one-shot
 	// rewrite ("approve [Clawvisor: ...]"), so on subsequent turns
@@ -595,7 +618,7 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 	// tool-stage approval emitted alongside the inline-task POST in
 	// the same turn). A single user "approve" must only resolve one
 	// hold.
-	if !inlineApprovalConsumed {
+	if !budgetApprovalConsumed && !inlineApprovalConsumed {
 		if handled := h.maybeHandleLiteApprovalRelease(w, r, agent, provider, requestID, conversationID, body, &auditStatus, &auditDecide, &auditOutcome, &auditReason); handled {
 			return
 		}
@@ -700,6 +723,36 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 			BodyBytes:    len(body),
 		})
 	}
+
+	// Load active checkout taskID and check budget
+	candidateTasks, _, _, _ := h.loadLiteProxyDecisionInputs(r.Context(), agent)
+	activeTaskID, _ := h.checkedOutTaskID(r.Context(), agent, conversationID, candidateTasks)
+	auditTaskID = activeTaskID
+
+	budgetCheck, err := llmproxy.EvaluateBudget(r.Context(), h.Store, h.PendingApprovals, h.BudgetOverrides, agent, activeTaskID, provider, conversationID)
+	if err != nil {
+		h.Logger.WarnContext(r.Context(), "budget check failed", "err", err)
+	} else if budgetCheck.Blocked {
+		auditStatus = http.StatusOK
+		auditDecide = "deny"
+		auditOutcome = "budget_limit_hit"
+		auditReason = budgetCheck.Message
+		h.writeLiteProxyError(w, r, agent, provider, body, requestID, http.StatusOK, "BUDGET_LIMIT_HIT", budgetCheck.Message)
+		return
+	}
+
+	// Rate limit throttle
+	if h.RateLimits != nil {
+		if delay := h.RateLimits.ThrottleDelay(agent.ID, reqSummary.Model); delay > 0 {
+			h.Logger.InfoContext(r.Context(), "rate limit throttling active, sleeping thread", "delay_ms", delay.Milliseconds())
+			select {
+			case <-r.Context().Done():
+				return
+			case <-time.After(delay):
+			}
+		}
+	}
+
 	forwardStart := time.Now()
 	resp, err := h.Forwarder.Forward(r.Context(), agent.UserID, agent.ID, provider, r, body)
 	if err != nil {
@@ -736,6 +789,9 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer resp.Body.Close()
+	if h.RateLimits != nil {
+		h.RateLimits.Update(agent.ID, reqSummary.Model, resp.Header)
+	}
 	upstreamHeadersMs := time.Since(forwardStart).Milliseconds()
 	auditStatus = resp.StatusCode
 	auditOutcome = outcomeFromStatus(resp.StatusCode)

--- a/internal/api/handlers/llm_endpoint_test.go
+++ b/internal/api/handlers/llm_endpoint_test.go
@@ -2287,6 +2287,9 @@ func TestLLMEndpoint_BudgetLimits(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected status 200, got %d (%s)", rec.Code, rec.Body.String())
 	}
+	if upstreamHits != 0 {
+		t.Fatalf("expected upstream NOT to be hit on soft-block budget warning, got hits=%d", upstreamHits)
+	}
 	bodyStr := rec.Body.String()
 	if !strings.Contains(bodyStr, "Clawvisor: Task budget is at 90%") {
 		t.Fatalf("expected budget warning in response, got %s", bodyStr)

--- a/internal/api/handlers/llm_endpoint_test.go
+++ b/internal/api/handlers/llm_endpoint_test.go
@@ -2211,3 +2211,120 @@ data: {"type":"message_stop"}
 		t.Fatal("timed out waiting for streamed text before upstream completion")
 	}
 }
+
+func TestLLMEndpoint_BudgetLimits(t *testing.T) {
+	ctx := context.Background()
+	upstreamHits := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		upstreamHits++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_123","type":"message","role":"assistant","content":[{"type":"text","text":"ok"}]}`))
+	}))
+	defer upstream.Close()
+
+	h, st, rawToken, _ := newSeededHandler(t, upstream.URL)
+	agent, err := st.GetAgentByToken(ctx, auth.HashToken(rawToken))
+	if err != nil {
+		t.Fatalf("GetAgentByToken: %v", err)
+	}
+
+	// Upsert agent runtime settings with a low budget limit
+	settings, err := st.GetAgentRuntimeSettings(ctx, agent.ID)
+	if err != nil && err != store.ErrNotFound {
+		t.Fatalf("GetAgentRuntimeSettings: %v", err)
+	}
+	if settings == nil {
+		settings = defaultAgentRuntimeSettings(nil, agent.ID)
+	}
+	limitCost := int64(100) // $0.0001
+	settings.MaxCostMicros = &limitCost
+	if err := st.UpsertAgentRuntimeSettings(ctx, settings); err != nil {
+		t.Fatalf("UpsertAgentRuntimeSettings: %v", err)
+	}
+
+	// 1. Record cost of 95 micros (95% budget limit)
+	audit := &store.AuditEntry{
+		ID:         "audit-b1",
+		UserID:     agent.UserID,
+		AgentID:    &agent.ID,
+		RequestID:  "req-b1",
+		Timestamp:  time.Now(),
+		Service:    "anthropic",
+		Action:     "lite_proxy.messages.create",
+		Decision:   "allow",
+		Outcome:    "success",
+		ParamsSafe: []byte("{}"),
+	}
+	if err := st.LogAudit(ctx, audit); err != nil {
+		t.Fatalf("LogAudit: %v", err)
+	}
+	costMicros := int64(95)
+	cost := &store.LLMRequestCost{
+		AuditID:     "audit-b1",
+		UserID:      agent.UserID,
+		AgentID:     &agent.ID,
+		RequestID:   "req-b1",
+		Timestamp:   time.Now(),
+		Provider:    "anthropic",
+		Model:       "claude-haiku-4-5",
+		InputTokens: 10,
+		CostMicros:  &costMicros,
+	}
+	if err := st.RecordLLMRequestCost(ctx, cost); err != nil {
+		t.Fatalf("RecordLLMRequestCost: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	mw := middleware.RequireAgentLLM(st)
+	mux.Handle("POST /v1/messages", mw(http.HandlerFunc(h.Messages)))
+
+	// 2. Make LLM request, should hit 90% soft-block budget warning
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{"model":"claude-haiku-4-5","messages":[{"role":"user","content":"hello"}]}`))
+	req.Header.Set("Authorization", "Bearer "+rawToken)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d (%s)", rec.Code, rec.Body.String())
+	}
+	bodyStr := rec.Body.String()
+	if !strings.Contains(bodyStr, "Clawvisor: Task budget is at 90%") {
+		t.Fatalf("expected budget warning in response, got %s", bodyStr)
+	}
+
+	// Extract Hold ID from warning message
+	idx := strings.Index(bodyStr, "cv-")
+	if idx == -1 {
+		t.Fatalf("no cv- prefix found in body: %s", bodyStr)
+	}
+	holdID := bodyStr[idx : idx+29]
+
+	// Verify hold is registered in memory cache
+	peeked, err := h.PendingApprovals.Peek(ctx, llmproxy.ResolveRequest{
+		UserID:   agent.UserID,
+		AgentID:  agent.ID,
+		Provider: conversation.ProviderAnthropic,
+		Stage:    llmproxy.StageBudgetWarning,
+	})
+	if err != nil || peeked == nil || peeked.ID != holdID {
+		t.Fatalf("expected hold %s in cache, got peeked=%v", holdID, peeked)
+	}
+
+	// 3. User replies "approve" to resolve hold
+	approveReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{"model":"claude-haiku-4-5","messages":[{"role":"user","content":"approve `+holdID+`"}]}`))
+	approveReq.Header.Set("Authorization", "Bearer "+rawToken)
+	approveRec := httptest.NewRecorder()
+	mux.ServeHTTP(approveRec, approveReq)
+
+	if approveRec.Code != http.StatusOK {
+		t.Fatalf("approve response status = %d (%s)", approveRec.Code, approveRec.Body.String())
+	}
+	// It should pass through to upstream mock and return "ok"
+	if !strings.Contains(approveRec.Body.String(), "ok") {
+		t.Fatalf("expected ok response from mock upstream, got %s", approveRec.Body.String())
+	}
+	if upstreamHits != 1 {
+		t.Fatalf("expected upstream to be hit 1 time, got %d", upstreamHits)
+	}
+}
+

--- a/internal/api/handlers/tasks.go
+++ b/internal/api/handlers/tasks.go
@@ -510,6 +510,12 @@ func (h *TasksHandler) Create(w http.ResponseWriter, r *http.Request) {
 	if req.ChainExtractionMode != "" {
 		dedupParts = append(dedupParts, "chain_extraction_mode", req.ChainExtractionMode)
 	}
+	if req.MaxCostMicros != nil {
+		dedupParts = append(dedupParts, "max_cost_micros", *req.MaxCostMicros)
+	}
+	if req.MaxTokens != nil {
+		dedupParts = append(dedupParts, "max_tokens", *req.MaxTokens)
+	}
 	taskDedupKey := buildDedupKey(dedupParts...)
 	if cached, ok := h.contentDedup.Get(taskDedupKey); ok {
 		resp := cached.(map[string]any)

--- a/internal/api/handlers/tasks.go
+++ b/internal/api/handlers/tasks.go
@@ -142,6 +142,8 @@ type createTaskRequest struct {
 	ExpiresInSeconds       int                               `json:"expires_in_seconds"`
 	CallbackURL            string                            `json:"callback_url"`
 	Lifetime               string                            `json:"lifetime"` // "session" (default), "sliding", or "standing"
+	MaxCostMicros          *int64                            `json:"max_cost_micros,omitempty"`
+	MaxTokens              *int64                            `json:"max_tokens,omitempty"`
 }
 
 // Create declares a new task scope.
@@ -535,6 +537,8 @@ func (h *TasksHandler) Create(w http.ResponseWriter, r *http.Request) {
 		ExpectedUse:            req.ExpectedUse,
 		SchemaVersion:          schemaVersion,
 		ExpiresInSeconds:       expiresIn,
+		MaxCostMicros:          req.MaxCostMicros,
+		MaxTokens:              req.MaxTokens,
 	}
 	if req.CallbackURL != "" {
 		task.CallbackURL = &req.CallbackURL

--- a/internal/runtime/llmproxy/budget_rules.go
+++ b/internal/runtime/llmproxy/budget_rules.go
@@ -246,7 +246,9 @@ func EvaluateBudget(ctx context.Context, db store.Store, approvals PendingApprov
 			ExpiresAt:      time.Now().Add(10 * time.Minute),
 			PendingTaskID:  taskID,
 		}
-		_, _ = approvals.Hold(ctx, hold)
+		if _, err := approvals.Hold(ctx, hold); err != nil {
+			return EvaluateBudgetResult{}, err
+		}
 
 		return EvaluateBudgetResult{
 			Blocked:    true,

--- a/internal/runtime/llmproxy/budget_rules.go
+++ b/internal/runtime/llmproxy/budget_rules.go
@@ -1,0 +1,306 @@
+package llmproxy
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/pricing"
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+const StageBudgetWarning PendingApprovalStage = "budget_warning"
+
+type BudgetOverrideCache struct {
+	mu        sync.Mutex
+	overrides map[string]time.Time
+}
+
+func NewBudgetOverrideCache() *BudgetOverrideCache {
+	return &BudgetOverrideCache{
+		overrides: make(map[string]time.Time),
+	}
+}
+
+func (c *BudgetOverrideCache) Add(id string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.overrides[id] = time.Now().Add(10 * time.Minute)
+}
+
+func (c *BudgetOverrideCache) Has(id string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	t, ok := c.overrides[id]
+	if !ok {
+		return false
+	}
+	if time.Now().After(t) {
+		delete(c.overrides, id)
+		return false
+	}
+	return true
+}
+
+type RateLimitState struct {
+	RequestsLimit     int64
+	RequestsRemaining int64
+	RequestsResetSecs float64
+	TokensLimit       int64
+	TokensRemaining   int64
+	TokensResetSecs   float64
+	LastUpdated       time.Time
+}
+
+type RateLimitTracker struct {
+	mu     sync.Mutex
+	states map[string]RateLimitState
+}
+
+func NewRateLimitTracker() *RateLimitTracker {
+	return &RateLimitTracker{
+		states: make(map[string]RateLimitState),
+	}
+}
+
+func (t *RateLimitTracker) Update(agentID, model string, header http.Header) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	reqLimit, _ := strconv.ParseInt(header.Get("anthropic-ratelimit-requests-limit"), 10, 64)
+	reqRem, _ := strconv.ParseInt(header.Get("anthropic-ratelimit-requests-remaining"), 10, 64)
+	reqReset, _ := strconv.ParseFloat(header.Get("anthropic-ratelimit-requests-reset"), 64)
+
+	tokLimit, _ := strconv.ParseInt(header.Get("anthropic-ratelimit-tokens-limit"), 10, 64)
+	tokRem, _ := strconv.ParseInt(header.Get("anthropic-ratelimit-tokens-remaining"), 10, 64)
+	tokReset, _ := strconv.ParseFloat(header.Get("anthropic-ratelimit-tokens-reset"), 64)
+
+	if reqLimit == 0 {
+		reqLimit, _ = strconv.ParseInt(header.Get("x-ratelimit-limit-requests"), 10, 64)
+		reqRem, _ = strconv.ParseInt(header.Get("x-ratelimit-remaining-requests"), 10, 64)
+		reqReset, _ = strconv.ParseFloat(strings.TrimSuffix(header.Get("x-ratelimit-reset-requests"), "s"), 64)
+	}
+	if tokLimit == 0 {
+		tokLimit, _ = strconv.ParseInt(header.Get("x-ratelimit-limit-tokens"), 10, 64)
+		tokRem, _ = strconv.ParseInt(header.Get("x-ratelimit-remaining-tokens"), 10, 64)
+		tokReset, _ = strconv.ParseFloat(strings.TrimSuffix(header.Get("x-ratelimit-reset-tokens"), "s"), 64)
+	}
+
+	if reqLimit > 0 || tokLimit > 0 {
+		key := agentID + ":" + pricing.Normalize(model)
+		t.states[key] = RateLimitState{
+			RequestsLimit:     reqLimit,
+			RequestsRemaining: reqRem,
+			RequestsResetSecs: reqReset,
+			TokensLimit:       tokLimit,
+			TokensRemaining:   tokRem,
+			TokensResetSecs:   tokReset,
+			LastUpdated:       time.Now(),
+		}
+	}
+}
+
+func (t *RateLimitTracker) ThrottleDelay(agentID, model string) time.Duration {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	key := agentID + ":" + pricing.Normalize(model)
+	state, ok := t.states[key]
+	if !ok || time.Since(state.LastUpdated) > 10*time.Minute {
+		return 0
+	}
+
+	var delay time.Duration
+	if state.TokensLimit > 0 && state.TokensRemaining < state.TokensLimit/10 && state.TokensResetSecs > 0 {
+		d := time.Duration(float64(time.Second) * state.TokensResetSecs * (1.0 - float64(state.TokensRemaining)/float64(state.TokensLimit)))
+		if d > 5*time.Second {
+			d = 5 * time.Second
+		}
+		if d > delay {
+			delay = d
+		}
+	}
+	if state.RequestsLimit > 0 && state.RequestsRemaining < state.RequestsLimit/10 && state.RequestsResetSecs > 0 {
+		d := time.Duration(float64(time.Second) * state.RequestsResetSecs * (1.0 - float64(state.RequestsRemaining)/float64(state.RequestsLimit)))
+		if d > 5*time.Second {
+			d = 5 * time.Second
+		}
+		if d > delay {
+			delay = d
+		}
+	}
+	return delay
+}
+
+type EvaluateBudgetResult struct {
+	Blocked    bool
+	Refused    bool
+	Warning    bool
+	Message    string
+	ApprovalID string
+}
+
+func EvaluateBudget(ctx context.Context, db store.Store, approvals PendingApprovalCache, overrides *BudgetOverrideCache, agent *store.Agent, taskID string, provider conversation.Provider, conversationID string) (EvaluateBudgetResult, error) {
+	var limitCost, limitTokens *int64
+	var currentCost, currentTokens int64
+
+	if taskID != "" {
+		task, err := db.GetTask(ctx, taskID)
+		if err == nil && task != nil {
+			limitCost = task.MaxCostMicros
+			limitTokens = task.MaxTokens
+			summary, err := db.GetTaskCost(ctx, agent.UserID, taskID)
+			if err == nil && summary != nil {
+				currentCost = summary.CostMicros
+				currentTokens = summary.InputTokens + summary.OutputTokens
+			}
+		}
+	}
+
+	if limitCost == nil && limitTokens == nil {
+		settings, err := db.GetAgentRuntimeSettings(ctx, agent.ID)
+		if err == nil && settings != nil {
+			limitCost = settings.MaxCostMicros
+			limitTokens = settings.MaxTokens
+			summary, err := db.GetAgentCost(ctx, agent.UserID, agent.ID)
+			if err == nil && summary != nil {
+				currentCost = summary.CostMicros
+				currentTokens = summary.InputTokens + summary.OutputTokens
+			}
+		}
+	}
+
+	if limitCost == nil && limitTokens == nil {
+		return EvaluateBudgetResult{}, nil
+	}
+
+	overrideID := fmt.Sprintf("task:%s", taskID)
+	if taskID == "" {
+		overrideID = fmt.Sprintf("agent:%s", agent.ID)
+	}
+
+	if overrides.Has(overrideID) {
+		return EvaluateBudgetResult{}, nil
+	}
+
+	holdSearchKey := ResolveRequest{
+		UserID:         agent.UserID,
+		AgentID:        agent.ID,
+		Provider:       provider,
+		ConversationID: conversationID,
+		Stage:          StageBudgetWarning,
+	}
+
+	if (limitCost != nil && currentCost >= *limitCost) || (limitTokens != nil && currentTokens >= *limitTokens) {
+		var reason string
+		if limitCost != nil && currentCost >= *limitCost {
+			reason = fmt.Sprintf("Cost budget exceeded: spent $%0.4f of limit $%0.4f", float64(currentCost)/1e6, float64(*limitCost)/1e6)
+		} else {
+			reason = fmt.Sprintf("Token budget exceeded: consumed %d of limit %d tokens", currentTokens, *limitTokens)
+		}
+		return EvaluateBudgetResult{
+			Blocked: true,
+			Refused: true,
+			Message: fmt.Sprintf("Clawvisor: %s. Run `/allow budget` to raise it.", reason),
+		}, nil
+	}
+
+	isCostWarning := limitCost != nil && currentCost >= (*limitCost)*9/10
+	isTokenWarning := limitTokens != nil && currentTokens >= (*limitTokens)*9/10
+
+	if isCostWarning || isTokenWarning {
+		var warningDetail string
+		if isCostWarning {
+			warningDetail = fmt.Sprintf("cost spent $%0.4f of limit $%0.4f", float64(currentCost)/1e6, float64(*limitCost)/1e6)
+		} else {
+			warningDetail = fmt.Sprintf("tokens consumed %d of limit %d", currentTokens, *limitTokens)
+		}
+
+		if peeked, err := approvals.Peek(ctx, holdSearchKey); err == nil && peeked != nil {
+			return EvaluateBudgetResult{
+				Blocked:    true,
+				Warning:    true,
+				ApprovalID: peeked.ID,
+				Message:    fmt.Sprintf("Clawvisor: Task budget is at 90%% (%s). Reply y or approve to continue. (Hold ID: %s)", warningDetail, peeked.ID),
+			}, nil
+		}
+
+		approvalID, err := newLiteApprovalID()
+		if err != nil {
+			return EvaluateBudgetResult{}, err
+		}
+		hold := PendingLiteApproval{
+			ID:             approvalID,
+			UserID:         agent.UserID,
+			AgentID:        agent.ID,
+			Provider:       provider,
+			ConversationID: conversationID,
+			Reason:         fmt.Sprintf("Budget warning: %s", warningDetail),
+			Stage:          StageBudgetWarning,
+			CreatedAt:      time.Now(),
+			ExpiresAt:      time.Now().Add(10 * time.Minute),
+			PendingTaskID:  taskID,
+		}
+		_, _ = approvals.Hold(ctx, hold)
+
+		return EvaluateBudgetResult{
+			Blocked:    true,
+			Warning:    true,
+			ApprovalID: approvalID,
+			Message:    fmt.Sprintf("Clawvisor: Task budget is at 90%% (%s). Reply y or approve to continue. (Hold ID: %s)", warningDetail, approvalID),
+		}, nil
+	}
+
+	return EvaluateBudgetResult{}, nil
+}
+
+func RewriteBudgetApprovalReply(ctx context.Context, req TaskReplyRewriteRequest, overrides *BudgetOverrideCache) (TaskReplyRewriteResult, error) {
+	editor, ok := newApprovalBodyEditor(req.HTTPRequest, req.Provider, req.Body)
+	if !ok {
+		return TaskReplyRewriteResult{Body: req.Body}, nil
+	}
+	verb, approvalID, ok := editor.LatestApprovalReply()
+	if !ok || req.PendingApproval == nil || req.Agent == nil {
+		return TaskReplyRewriteResult{Body: req.Body}, nil
+	}
+	if verb != "approve" {
+		return TaskReplyRewriteResult{Body: req.Body}, nil
+	}
+
+	hold, err := req.PendingApproval.Peek(ctx, ResolveRequest{
+		UserID:         req.Agent.UserID,
+		AgentID:        req.Agent.ID,
+		Provider:       req.Provider,
+		ConversationID: req.ConversationID,
+		ApprovalID:     approvalID,
+		Stage:          StageBudgetWarning,
+	})
+	if err != nil || hold == nil {
+		return TaskReplyRewriteResult{Body: req.Body}, err
+	}
+
+	_, err = req.PendingApproval.Resolve(ctx, ResolveRequest{
+		UserID:         req.Agent.UserID,
+		AgentID:        req.Agent.ID,
+		Provider:       req.Provider,
+		ConversationID: req.ConversationID,
+		ApprovalID:     hold.ID,
+		Stage:          StageBudgetWarning,
+	})
+	if err != nil {
+		return TaskReplyRewriteResult{Body: req.Body}, err
+	}
+
+	overrideID := fmt.Sprintf("agent:%s", req.Agent.ID)
+	overrides.Add(overrideID)
+	if hold.PendingTaskID != "" {
+		overrides.Add(fmt.Sprintf("task:%s", hold.PendingTaskID))
+	}
+
+	return TaskReplyRewriteResult{Body: req.Body, Rewritten: true}, nil
+}

--- a/internal/runtime/llmproxy/budget_rules.go
+++ b/internal/runtime/llmproxy/budget_rules.go
@@ -68,7 +68,7 @@ func NewRateLimitTracker() *RateLimitTracker {
 	}
 }
 
-func (t *RateLimitTracker) Update(agentID, model string, header http.Header) {
+func (t *RateLimitTracker) Update(agentID, provider, model string, header http.Header) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
@@ -92,7 +92,7 @@ func (t *RateLimitTracker) Update(agentID, model string, header http.Header) {
 	}
 
 	if reqLimit > 0 || tokLimit > 0 {
-		key := agentID + ":" + pricing.Normalize(model)
+		key := agentID + ":" + provider + ":" + pricing.Normalize(model)
 		t.states[key] = RateLimitState{
 			RequestsLimit:     reqLimit,
 			RequestsRemaining: reqRem,
@@ -105,11 +105,11 @@ func (t *RateLimitTracker) Update(agentID, model string, header http.Header) {
 	}
 }
 
-func (t *RateLimitTracker) ThrottleDelay(agentID, model string) time.Duration {
+func (t *RateLimitTracker) ThrottleDelay(agentID, provider, model string) time.Duration {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	key := agentID + ":" + pricing.Normalize(model)
+	key := agentID + ":" + provider + ":" + pricing.Normalize(model)
 	state, ok := t.states[key]
 	if !ok || time.Since(state.LastUpdated) > 10*time.Minute {
 		return 0
@@ -148,27 +148,43 @@ type EvaluateBudgetResult struct {
 func EvaluateBudget(ctx context.Context, db store.Store, approvals PendingApprovalCache, overrides *BudgetOverrideCache, agent *store.Agent, taskID string, provider conversation.Provider, conversationID string) (EvaluateBudgetResult, error) {
 	var limitCost, limitTokens *int64
 	var currentCost, currentTokens int64
+	enforcingTaskBudget := false
 
 	if taskID != "" {
 		task, err := db.GetTask(ctx, taskID)
+		if err != nil && err != store.ErrNotFound {
+			return EvaluateBudgetResult{}, err
+		}
 		if err == nil && task != nil {
 			limitCost = task.MaxCostMicros
 			limitTokens = task.MaxTokens
-			summary, err := db.GetTaskCost(ctx, agent.UserID, taskID)
-			if err == nil && summary != nil {
-				currentCost = summary.CostMicros
-				currentTokens = summary.InputTokens + summary.OutputTokens
+			if limitCost != nil || limitTokens != nil {
+				enforcingTaskBudget = true
+				summary, err := db.GetTaskCost(ctx, agent.UserID, taskID)
+				if err != nil {
+					return EvaluateBudgetResult{}, err
+				}
+				if summary != nil {
+					currentCost = summary.CostMicros
+					currentTokens = summary.InputTokens + summary.OutputTokens
+				}
 			}
 		}
 	}
 
-	if limitCost == nil && limitTokens == nil {
+	if !enforcingTaskBudget {
 		settings, err := db.GetAgentRuntimeSettings(ctx, agent.ID)
+		if err != nil && err != store.ErrNotFound {
+			return EvaluateBudgetResult{}, err
+		}
 		if err == nil && settings != nil {
 			limitCost = settings.MaxCostMicros
 			limitTokens = settings.MaxTokens
 			summary, err := db.GetAgentCost(ctx, agent.UserID, agent.ID)
-			if err == nil && summary != nil {
+			if err != nil {
+				return EvaluateBudgetResult{}, err
+			}
+			if summary != nil {
 				currentCost = summary.CostMicros
 				currentTokens = summary.InputTokens + summary.OutputTokens
 			}
@@ -179,8 +195,10 @@ func EvaluateBudget(ctx context.Context, db store.Store, approvals PendingApprov
 		return EvaluateBudgetResult{}, nil
 	}
 
-	overrideID := fmt.Sprintf("task:%s", taskID)
-	if taskID == "" {
+	var overrideID string
+	if enforcingTaskBudget {
+		overrideID = fmt.Sprintf("task:%s", taskID)
+	} else {
 		overrideID = fmt.Sprintf("agent:%s", agent.ID)
 	}
 

--- a/internal/runtime/llmproxy/budget_rules_test.go
+++ b/internal/runtime/llmproxy/budget_rules_test.go
@@ -206,6 +206,28 @@ func TestEvaluateBudget_CachedOverride(t *testing.T) {
 	if res.Blocked || res.Warning {
 		t.Fatalf("expected override to allow request, got: %+v", res)
 	}
+
+	// 5. Test agent-level override unblocks task-scoped request falling back to agent budget
+	expiresAt := time.Now().Add(1 * time.Hour)
+	task := &store.Task{
+		ID:        "task-123",
+		UserID:    agent.UserID,
+		AgentID:   agent.ID,
+		Status:    "active",
+		CreatedAt: time.Now(),
+		ExpiresAt: &expiresAt,
+	}
+	if err := st.CreateTask(ctx, task); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+
+	res, err = EvaluateBudget(ctx, st, approvals, overrides, agent, "task-123", conversation.ProviderAnthropic, "conv-1")
+	if err != nil {
+		t.Fatalf("EvaluateBudget with task fallback: %v", err)
+	}
+	if res.Blocked || res.Warning {
+		t.Fatalf("expected agent override to unblock task fallback request, got: %+v", res)
+	}
 }
 
 func TestRewriteBudgetApprovalReply_ResolvesHold(t *testing.T) {
@@ -303,20 +325,78 @@ func TestRateLimitTracker_ThrottleDelay(t *testing.T) {
 	header.Set("anthropic-ratelimit-tokens-remaining", "900")
 	header.Set("anthropic-ratelimit-tokens-reset", "60")
 
-	tracker.Update("agent-1", "claude-3-5-sonnet", header)
-	delay := tracker.ThrottleDelay("agent-1", "claude-3-5-sonnet")
+	tracker.Update("agent-1", "anthropic", "claude-3-5-sonnet", header)
+	delay := tracker.ThrottleDelay("agent-1", "anthropic", "claude-3-5-sonnet")
 	if delay != 0 {
 		t.Fatalf("expected no delay under normal rate limits, got %v", delay)
 	}
 
 	// Update with critical requests remaining (under 10%)
 	header.Set("anthropic-ratelimit-requests-remaining", "5")
-	tracker.Update("agent-1", "claude-3-5-sonnet", header)
-	delay = tracker.ThrottleDelay("agent-1", "claude-3-5-sonnet")
+	tracker.Update("agent-1", "anthropic", "claude-3-5-sonnet", header)
+	delay = tracker.ThrottleDelay("agent-1", "anthropic", "claude-3-5-sonnet")
 	if delay == 0 {
 		t.Fatalf("expected throttling delay, got 0")
 	}
 	if delay > 5*time.Second {
 		t.Errorf("expected delay capped at 5s, got %v", delay)
+	}
+}
+
+func TestEvaluateBudget_TaskRules(t *testing.T) {
+	st, agent := newBudgetTestStore(t)
+	ctx := context.Background()
+
+	approvals := NewMemoryPendingApprovalCache(10 * time.Minute)
+	overrides := NewBudgetOverrideCache()
+
+	// 1. Create a task with a budget
+	expiresAt := time.Now().Add(1 * time.Hour)
+	limitCost := int64(1000) // $0.001
+	limitTokens := int64(100)
+	task := &store.Task{
+		ID:            "task-budget",
+		UserID:        agent.UserID,
+		AgentID:       agent.ID,
+		Status:        "active",
+		CreatedAt:     time.Now(),
+		ExpiresAt:     &expiresAt,
+		MaxCostMicros: &limitCost,
+		MaxTokens:     &limitTokens,
+	}
+	if err := st.CreateTask(ctx, task); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+
+	// 2. Under budget check (Spend is 0)
+	res, err := EvaluateBudget(ctx, st, approvals, overrides, agent, "task-budget", conversation.ProviderAnthropic, "conv-1")
+	if err != nil {
+		t.Fatalf("EvaluateBudget: %v", err)
+	}
+	if res.Blocked || res.Refused || res.Warning {
+		t.Fatalf("expected clean result, got: %+v", res)
+	}
+
+	// 3. Spend is 90% (900 micros) -> Warning triggers!
+	recordMockCost(ctx, t, st, agent, "task-budget", 900, 90, "audit-task-warning", "req-task-warning")
+	res, err = EvaluateBudget(ctx, st, approvals, overrides, agent, "task-budget", conversation.ProviderAnthropic, "conv-1")
+	if err != nil {
+		t.Fatalf("EvaluateBudget: %v", err)
+	}
+	if !res.Blocked || !res.Warning || res.Refused {
+		t.Fatalf("expected warning block, got: %+v", res)
+	}
+	if !strings.Contains(res.Message, "budget is at 90%") {
+		t.Errorf("expected budget message, got: %q", res.Message)
+	}
+
+	// 4. Spent 1500 micros -> Hard refusal!
+	recordMockCost(ctx, t, st, agent, "task-budget", 600, 60, "audit-task-exceeded", "req-task-exceeded")
+	res, err = EvaluateBudget(ctx, st, approvals, overrides, agent, "task-budget", conversation.ProviderAnthropic, "conv-1")
+	if err != nil {
+		t.Fatalf("EvaluateBudget: %v", err)
+	}
+	if !res.Blocked || !res.Refused || res.Warning {
+		t.Fatalf("expected hard refusal, got: %+v", res)
 	}
 }

--- a/internal/runtime/llmproxy/budget_rules_test.go
+++ b/internal/runtime/llmproxy/budget_rules_test.go
@@ -1,0 +1,322 @@
+package llmproxy
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+	"github.com/clawvisor/clawvisor/pkg/store"
+	"github.com/clawvisor/clawvisor/pkg/store/sqlite"
+)
+
+func newBudgetTestStore(t *testing.T) (store.Store, *store.Agent) {
+	t.Helper()
+	ctx := context.Background()
+	db, err := sqlite.New(ctx, filepath.Join(t.TempDir(), "budget.db"))
+	if err != nil {
+		t.Fatalf("sqlite.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	st := sqlite.NewStore(db)
+	user, err := st.CreateUser(ctx, "budget@example.com", "x")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	agent, err := st.CreateAgent(ctx, user.ID, "budget-agent", "agent-token-hash")
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+	return st, agent
+}
+
+func recordMockCost(ctx context.Context, t *testing.T, st store.Store, agent *store.Agent, taskID string, costMicrosVal int64, tokensVal int, auditID string, requestID string) {
+	t.Helper()
+	audit := &store.AuditEntry{
+		ID:         auditID,
+		UserID:     agent.UserID,
+		AgentID:    &agent.ID,
+		RequestID:  requestID,
+		Timestamp:  time.Now(),
+		Service:    "anthropic",
+		Action:     "lite_proxy.messages.create",
+		Decision:   "allow",
+		Outcome:    "success",
+		ParamsSafe: []byte("{}"),
+	}
+	if err := st.LogAudit(ctx, audit); err != nil {
+		t.Fatalf("LogAudit: %v", err)
+	}
+
+	var taskIDPtr *string
+	if taskID != "" {
+		taskIDPtr = &taskID
+	}
+	cost := &store.LLMRequestCost{
+		AuditID:      auditID,
+		UserID:       agent.UserID,
+		AgentID:      &agent.ID,
+		TaskID:       taskIDPtr,
+		RequestID:    requestID,
+		Timestamp:    time.Now(),
+		Provider:     "anthropic",
+		Model:        "claude-opus-4-7",
+		InputTokens:  tokensVal / 2,
+		OutputTokens: tokensVal / 2,
+		CostMicros:   &costMicrosVal,
+	}
+	if err := st.RecordLLMRequestCost(ctx, cost); err != nil {
+		t.Fatalf("RecordLLMRequestCost: %v", err)
+	}
+}
+
+func TestEvaluateBudget_Rules(t *testing.T) {
+	st, agent := newBudgetTestStore(t)
+	ctx := context.Background()
+
+	approvals := NewMemoryPendingApprovalCache(10 * time.Minute)
+	overrides := NewBudgetOverrideCache()
+
+	// 1. No budget set
+	res, err := EvaluateBudget(ctx, st, approvals, overrides, agent, "", conversation.ProviderAnthropic, "conv-1")
+	if err != nil {
+		t.Fatalf("EvaluateBudget: %v", err)
+	}
+	if res.Blocked || res.Refused || res.Warning {
+		t.Fatalf("expected clean result, got: %+v", res)
+	}
+
+	// Setup agent settings with a budget
+	settings := &store.AgentRuntimeSettings{
+		AgentID:                           agent.ID,
+		RuntimeEnabled:                    true,
+		RuntimeMode:                       "enforce",
+		StarterProfile:                    "none",
+		OutboundCredentialMode:            "inherit",
+		ConversationAutoApproveThreshold: "none",
+	}
+	limitCost := int64(1000) // $0.001
+	limitTokens := int64(100)
+	settings.MaxCostMicros = &limitCost
+	settings.MaxTokens = &limitTokens
+	if err := st.UpsertAgentRuntimeSettings(ctx, settings); err != nil {
+		t.Fatalf("UpsertAgentRuntimeSettings: %v", err)
+	}
+
+	// 2. Budget is set, but current spend is 0 (Under Budget)
+	res, err = EvaluateBudget(ctx, st, approvals, overrides, agent, "", conversation.ProviderAnthropic, "conv-1")
+	if err != nil {
+		t.Fatalf("EvaluateBudget: %v", err)
+	}
+	if res.Blocked || res.Refused || res.Warning {
+		t.Fatalf("expected clean result, got: %+v", res)
+	}
+
+	// Record cost of $0.0005 (500 micros) and 50 tokens (50% budget) -> Still under warning threshold
+	recordMockCost(ctx, t, st, agent, "", 500, 50, "audit-under", "req-under")
+
+	res, err = EvaluateBudget(ctx, st, approvals, overrides, agent, "", conversation.ProviderAnthropic, "conv-1")
+	if err != nil {
+		t.Fatalf("EvaluateBudget: %v", err)
+	}
+	if res.Blocked || res.Refused || res.Warning {
+		t.Fatalf("expected clean result, got: %+v", res)
+	}
+
+	// Record another cost of $0.0004 (400 micros) -> total 900 micros (90% budget) -> Warning triggers!
+	recordMockCost(ctx, t, st, agent, "", 400, 40, "audit-warning", "req-warning")
+
+	res, err = EvaluateBudget(ctx, st, approvals, overrides, agent, "", conversation.ProviderAnthropic, "conv-1")
+	if err != nil {
+		t.Fatalf("EvaluateBudget: %v", err)
+	}
+	if !res.Blocked || !res.Warning || res.Refused {
+		t.Fatalf("expected warning block, got: %+v", res)
+	}
+	if !strings.Contains(res.Message, "budget is at 90%") {
+		t.Errorf("expected budget message, got: %q", res.Message)
+	}
+	if res.ApprovalID == "" {
+		t.Errorf("expected generated ApprovalID")
+	}
+
+	// 3. Repeated check should return the same warning with the same ApprovalID without creating a new one
+	res2, err := EvaluateBudget(ctx, st, approvals, overrides, agent, "", conversation.ProviderAnthropic, "conv-1")
+	if err != nil {
+		t.Fatalf("EvaluateBudget repeat: %v", err)
+	}
+	if res2.ApprovalID != res.ApprovalID {
+		t.Errorf("expected same ApprovalID, got: %q vs %q", res2.ApprovalID, res.ApprovalID)
+	}
+
+	// 4. Exceeded budget (Cost micros > 1000) -> Hard refuse!
+	// Wait, we bypass warning hold checks if cost is fully exceeded
+	recordMockCost(ctx, t, st, agent, "", 150, 15, "audit-exceeded", "req-exceeded")
+	res, err = EvaluateBudget(ctx, st, approvals, overrides, agent, "", conversation.ProviderAnthropic, "conv-1")
+	if err != nil {
+		t.Fatalf("EvaluateBudget exceeded: %v", err)
+	}
+	if !res.Blocked || !res.Refused || res.Warning {
+		t.Fatalf("expected hard refusal, got: %+v", res)
+	}
+}
+
+func TestEvaluateBudget_CachedOverride(t *testing.T) {
+	st, agent := newBudgetTestStore(t)
+	ctx := context.Background()
+
+	approvals := NewMemoryPendingApprovalCache(10 * time.Minute)
+	overrides := NewBudgetOverrideCache()
+
+	settings := &store.AgentRuntimeSettings{
+		AgentID:                           agent.ID,
+		RuntimeEnabled:                    true,
+		RuntimeMode:                       "enforce",
+		StarterProfile:                    "none",
+		OutboundCredentialMode:            "inherit",
+		ConversationAutoApproveThreshold: "none",
+	}
+	limitCost := int64(100)
+	settings.MaxCostMicros = &limitCost
+	if err := st.UpsertAgentRuntimeSettings(ctx, settings); err != nil {
+		t.Fatalf("UpsertAgentRuntimeSettings: %v", err)
+	}
+
+	// Add cost of 95 micros (95% budget)
+	recordMockCost(ctx, t, st, agent, "", 95, 10, "audit-ov", "req-ov")
+
+	// Verify it triggers warning
+	res, _ := EvaluateBudget(ctx, st, approvals, overrides, agent, "", conversation.ProviderAnthropic, "conv-1")
+	if !res.Blocked || !res.Warning {
+		t.Fatalf("expected warning block, got: %+v", res)
+	}
+
+	// Now add override to overrides cache
+	overrides.Add("agent:" + agent.ID)
+
+	// Verify budget check bypasses warning
+	res, err := EvaluateBudget(ctx, st, approvals, overrides, agent, "", conversation.ProviderAnthropic, "conv-1")
+	if err != nil {
+		t.Fatalf("EvaluateBudget: %v", err)
+	}
+	if res.Blocked || res.Warning {
+		t.Fatalf("expected override to allow request, got: %+v", res)
+	}
+}
+
+func TestRewriteBudgetApprovalReply_ResolvesHold(t *testing.T) {
+	st, agent := newBudgetTestStore(t)
+	ctx := context.Background()
+
+	approvals := NewMemoryPendingApprovalCache(10 * time.Minute)
+	overrides := NewBudgetOverrideCache()
+
+	settings := &store.AgentRuntimeSettings{
+		AgentID:                           agent.ID,
+		RuntimeEnabled:                    true,
+		RuntimeMode:                       "enforce",
+		StarterProfile:                    "none",
+		OutboundCredentialMode:            "inherit",
+		ConversationAutoApproveThreshold: "none",
+	}
+	limitCost := int64(100)
+	settings.MaxCostMicros = &limitCost
+	if err := st.UpsertAgentRuntimeSettings(ctx, settings); err != nil {
+		t.Fatalf("UpsertAgentRuntimeSettings: %v", err)
+	}
+
+	recordMockCost(ctx, t, st, agent, "", 95, 10, "audit-rw", "req-rw")
+
+	// Trigger warning to create hold
+	res, _ := EvaluateBudget(ctx, st, approvals, overrides, agent, "", conversation.ProviderAnthropic, "conv-1")
+	holdID := res.ApprovalID
+
+	// Verify hold is in the cache
+	peeked, _ := approvals.Peek(ctx, ResolveRequest{
+		UserID:         agent.UserID,
+		AgentID:        agent.ID,
+		Provider:       conversation.ProviderAnthropic,
+		ConversationID: "conv-1",
+		Stage:          StageBudgetWarning,
+	})
+	if peeked == nil || peeked.ID != holdID {
+		t.Fatalf("expected hold %s in cache", holdID)
+	}
+
+	// Mock a user reply "approve" (which usually matches standard approve reply format)
+	// Let's create an HTTP request containing the approval reply
+	httpReq := httptest.NewRequest("POST", "/api/v1/messages", strings.NewReader(`{
+		"messages": [
+			{"role": "user", "content": "approve `+holdID+`"}
+		]
+	}`))
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	rewriteReq := TaskReplyRewriteRequest{
+		HTTPRequest:     httpReq,
+		Provider:        conversation.ProviderAnthropic,
+		Body:            []byte(`{"messages": [{"role": "user", "content": "approve ` + holdID + `"}]}`),
+		Agent:           agent,
+		ConversationID:  "conv-1",
+		PendingApproval: approvals,
+	}
+
+	rewriteRes, err := RewriteBudgetApprovalReply(ctx, rewriteReq, overrides)
+	if err != nil {
+		t.Fatalf("RewriteBudgetApprovalReply: %v", err)
+	}
+	if !rewriteRes.Rewritten {
+		t.Fatalf("expected Rewritten=true")
+	}
+
+	// Verify override has been added
+	if !overrides.Has("agent:" + agent.ID) {
+		t.Errorf("expected override to be added")
+	}
+
+	// Verify hold was popped from cache
+	peekedAfter, _ := approvals.Peek(ctx, ResolveRequest{
+		UserID:         agent.UserID,
+		AgentID:        agent.ID,
+		Provider:       conversation.ProviderAnthropic,
+		ConversationID: "conv-1",
+		Stage:          StageBudgetWarning,
+	})
+	if peekedAfter != nil {
+		t.Fatalf("expected hold to be deleted after resolve")
+	}
+}
+
+func TestRateLimitTracker_ThrottleDelay(t *testing.T) {
+	tracker := NewRateLimitTracker()
+
+	// Update with safe limits
+	header := http.Header{}
+	header.Set("anthropic-ratelimit-requests-limit", "100")
+	header.Set("anthropic-ratelimit-requests-remaining", "90")
+	header.Set("anthropic-ratelimit-requests-reset", "60")
+	header.Set("anthropic-ratelimit-tokens-limit", "1000")
+	header.Set("anthropic-ratelimit-tokens-remaining", "900")
+	header.Set("anthropic-ratelimit-tokens-reset", "60")
+
+	tracker.Update("agent-1", "claude-3-5-sonnet", header)
+	delay := tracker.ThrottleDelay("agent-1", "claude-3-5-sonnet")
+	if delay != 0 {
+		t.Fatalf("expected no delay under normal rate limits, got %v", delay)
+	}
+
+	// Update with critical requests remaining (under 10%)
+	header.Set("anthropic-ratelimit-requests-remaining", "5")
+	tracker.Update("agent-1", "claude-3-5-sonnet", header)
+	delay = tracker.ThrottleDelay("agent-1", "claude-3-5-sonnet")
+	if delay == 0 {
+		t.Fatalf("expected throttling delay, got 0")
+	}
+	if delay > 5*time.Second {
+		t.Errorf("expected delay capped at 5s, got %v", delay)
+	}
+}

--- a/internal/runtime/llmproxy/synthetic_history_strip.go
+++ b/internal/runtime/llmproxy/synthetic_history_strip.go
@@ -18,6 +18,7 @@ type SyntheticApprovalHistoryStripResult struct {
 }
 
 const ToolApprovalSubstitutedPromptMarker = "Clawvisor paused this tool call for approval."
+const BudgetApprovalSubstitutedPromptMarker = "Clawvisor: Task budget is at"
 
 // StripSyntheticApprovalHistory removes Clawvisor-generated approval UI from
 // conversation history before it is sent back to the upstream model. The live
@@ -195,7 +196,8 @@ func rawMessageString(raw json.RawMessage) string {
 
 func isSyntheticApprovalPromptText(text string) bool {
 	return strings.Contains(text, InlineApprovalSubstitutedPromptMarker) ||
-		strings.Contains(text, ToolApprovalSubstitutedPromptMarker)
+		strings.Contains(text, ToolApprovalSubstitutedPromptMarker) ||
+		strings.Contains(text, BudgetApprovalSubstitutedPromptMarker)
 }
 
 func isBareSyntheticApprovalReply(text string) bool {

--- a/internal/runtime/llmproxy/synthetic_history_strip_test.go
+++ b/internal/runtime/llmproxy/synthetic_history_strip_test.go
@@ -213,3 +213,27 @@ func TestStripSyntheticApprovalHistory_DoesNotTouchUserMention(t *testing.T) {
 		t.Fatalf("user-authored diagnostic text should be preserved: %s", out.Body)
 	}
 }
+
+func TestStripSyntheticApprovalHistory_DropsBudgetPromptAndBareReply(t *testing.T) {
+	body := anthropicTextBody(
+		map[string]string{"role": "user", "content": "Run tasks"},
+		map[string]string{"role": "assistant", "content": BudgetApprovalSubstitutedPromptMarker + " 90% (cost spent $0.0009 of limit $0.0010). Reply y or approve to continue. (Hold ID: cv-123)"},
+		map[string]string{"role": "user", "content": "y"},
+	)
+
+	out, err := StripSyntheticApprovalHistory(SyntheticApprovalHistoryStripRequest{
+		Provider: conversation.ProviderAnthropic,
+		Body:     body,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !out.Modified {
+		t.Fatal("expected synthetic budget prompt history to be stripped")
+	}
+	text := string(out.Body)
+	if strings.Contains(text, BudgetApprovalSubstitutedPromptMarker) || strings.Contains(text, `"y"`) {
+		t.Fatalf("synthetic budget approval history leaked upstream: %s", text)
+	}
+}
+

--- a/pkg/store/postgres/migrations/055_budget.sql
+++ b/pkg/store/postgres/migrations/055_budget.sql
@@ -1,5 +1,5 @@
-ALTER TABLE tasks ADD COLUMN IF NOT EXISTS max_cost_micros BIGINT;
-ALTER TABLE tasks ADD COLUMN IF NOT EXISTS max_tokens BIGINT;
+ALTER TABLE tasks ADD COLUMN IF NOT EXISTS max_cost_micros BIGINT CHECK (max_cost_micros >= 0);
+ALTER TABLE tasks ADD COLUMN IF NOT EXISTS max_tokens BIGINT CHECK (max_tokens >= 0);
 
-ALTER TABLE agent_runtime_settings ADD COLUMN IF NOT EXISTS max_cost_micros BIGINT;
-ALTER TABLE agent_runtime_settings ADD COLUMN IF NOT EXISTS max_tokens BIGINT;
+ALTER TABLE agent_runtime_settings ADD COLUMN IF NOT EXISTS max_cost_micros BIGINT CHECK (max_cost_micros >= 0);
+ALTER TABLE agent_runtime_settings ADD COLUMN IF NOT EXISTS max_tokens BIGINT CHECK (max_tokens >= 0);

--- a/pkg/store/postgres/migrations/055_budget.sql
+++ b/pkg/store/postgres/migrations/055_budget.sql
@@ -1,0 +1,5 @@
+ALTER TABLE tasks ADD COLUMN IF NOT EXISTS max_cost_micros BIGINT;
+ALTER TABLE tasks ADD COLUMN IF NOT EXISTS max_tokens BIGINT;
+
+ALTER TABLE agent_runtime_settings ADD COLUMN IF NOT EXISTS max_cost_micros BIGINT;
+ALTER TABLE agent_runtime_settings ADD COLUMN IF NOT EXISTS max_tokens BIGINT;

--- a/pkg/store/postgres/store.go
+++ b/pkg/store/postgres/store.go
@@ -283,7 +283,7 @@ func (s *Store) ListAgents(ctx context.Context, userID string) ([]*store.Agent, 
 		       ars.agent_id, ars.runtime_enabled, ars.runtime_mode, ars.starter_profile,
 		       ars.outbound_credential_mode, ars.inject_stored_bearer, ars.lite_proxy_secret_detection_disabled,
 		       ars.conversation_auto_approve_threshold,
-		       ars.created_at, ars.updated_at
+		       ars.created_at, ars.updated_at, ars.max_cost_micros, ars.max_tokens
 		FROM agents a
 		LEFT JOIN agent_runtime_settings ars ON ars.agent_id = a.id
 		WHERE a.user_id = $1 AND a.deleted_at IS NULL
@@ -301,7 +301,7 @@ func (s *Store) GetAgentRuntimeSettings(ctx context.Context, agentID string) (*s
 	row := s.pool.QueryRow(ctx, `
 		SELECT agent_id, runtime_enabled, runtime_mode, starter_profile,
 		       outbound_credential_mode, inject_stored_bearer, lite_proxy_secret_detection_disabled,
-		       conversation_auto_approve_threshold, created_at, updated_at
+		       conversation_auto_approve_threshold, created_at, updated_at, max_cost_micros, max_tokens
 		FROM agent_runtime_settings
 		WHERE agent_id = $1
 	`, agentID)
@@ -309,7 +309,7 @@ func (s *Store) GetAgentRuntimeSettings(ctx context.Context, agentID string) (*s
 	err := row.Scan(&settings.AgentID, &settings.RuntimeEnabled, &settings.RuntimeMode, &settings.StarterProfile,
 		&settings.OutboundCredentialMode, &settings.InjectStoredBearer, &settings.LiteProxySecretDetectionDisabled,
 		&settings.ConversationAutoApproveThreshold,
-		&settings.CreatedAt, &settings.UpdatedAt)
+		&settings.CreatedAt, &settings.UpdatedAt, &settings.MaxCostMicros, &settings.MaxTokens)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, store.ErrNotFound
 	}
@@ -327,8 +327,8 @@ func (s *Store) UpsertAgentRuntimeSettings(ctx context.Context, settings *store.
 	_, err := s.pool.Exec(ctx, `
 		INSERT INTO agent_runtime_settings (
 			agent_id, runtime_enabled, runtime_mode, starter_profile, outbound_credential_mode, inject_stored_bearer, lite_proxy_secret_detection_disabled,
-			conversation_auto_approve_threshold
-		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+			conversation_auto_approve_threshold, max_cost_micros, max_tokens
+		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
 		ON CONFLICT (agent_id) DO UPDATE SET
 			runtime_enabled = EXCLUDED.runtime_enabled,
 			runtime_mode = EXCLUDED.runtime_mode,
@@ -337,10 +337,12 @@ func (s *Store) UpsertAgentRuntimeSettings(ctx context.Context, settings *store.
 			inject_stored_bearer = EXCLUDED.inject_stored_bearer,
 			lite_proxy_secret_detection_disabled = EXCLUDED.lite_proxy_secret_detection_disabled,
 			conversation_auto_approve_threshold = EXCLUDED.conversation_auto_approve_threshold,
+			max_cost_micros = EXCLUDED.max_cost_micros,
+			max_tokens = EXCLUDED.max_tokens,
 			updated_at = NOW()
 	`, settings.AgentID, settings.RuntimeEnabled, settings.RuntimeMode, settings.StarterProfile,
 		settings.OutboundCredentialMode, settings.InjectStoredBearer, settings.LiteProxySecretDetectionDisabled,
-		settings.ConversationAutoApproveThreshold)
+		settings.ConversationAutoApproveThreshold, settings.MaxCostMicros, settings.MaxTokens)
 	return err
 }
 
@@ -889,6 +891,59 @@ func (s *Store) GetTaskCost(ctx context.Context, userID, taskID string) (*store.
 	return out, nil
 }
 
+func (s *Store) GetAgentCost(ctx context.Context, userID, agentID string) (*store.AgentCostSummary, error) {
+	out := &store.AgentCostSummary{
+		AgentID:       agentID,
+		ByModel:       []store.TaskCostByModelEntry{},
+		UnknownModels: []string{},
+	}
+	rows, err := s.pool.Query(ctx, `
+		SELECT model,
+		       COUNT(*)::integer AS n,
+		       COALESCE(SUM(input_tokens), 0)::bigint,
+		       COALESCE(SUM(output_tokens), 0)::bigint,
+		       COALESCE(SUM(cache_read_tokens), 0)::bigint,
+		       COALESCE(SUM(cache_write_tokens), 0)::bigint,
+		       COALESCE(SUM(cost_micros), 0)::bigint,
+		       SUM(CASE WHEN cost_micros IS NULL THEN 1 ELSE 0 END)::bigint AS unknown_rows
+		FROM llm_request_cost
+		WHERE user_id = $1 AND agent_id = $2 AND agent_id IS NOT NULL
+		GROUP BY model
+		ORDER BY model`, userID, agentID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	unknownModels := map[string]struct{}{}
+	for rows.Next() {
+		var e store.TaskCostByModelEntry
+		var unknownRows int64
+		if err := rows.Scan(&e.Model, &e.RequestCount, &e.InputTokens, &e.OutputTokens,
+			&e.CacheReadTokens, &e.CacheWriteTokens, &e.CostMicros, &unknownRows); err != nil {
+			return nil, err
+		}
+		e.Known = unknownRows == 0
+		if !e.Known {
+			unknownModels[e.Model] = struct{}{}
+		}
+		out.ByModel = append(out.ByModel, e)
+		out.RequestCount += e.RequestCount
+		out.InputTokens += e.InputTokens
+		out.OutputTokens += e.OutputTokens
+		out.CacheReadTokens += e.CacheReadTokens
+		out.CacheWriteTokens += e.CacheWriteTokens
+		out.CostMicros += e.CostMicros
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	for m := range unknownModels {
+		out.UnknownModels = append(out.UnknownModels, m)
+	}
+	sort.Strings(out.UnknownModels)
+	return out, nil
+}
+
 func (s *Store) UpdateAuditOutcome(ctx context.Context, id, outcome, errMsg string, durationMS int) error {
 	var errMsgPtr *string
 	if errMsg != "" {
@@ -1198,15 +1253,16 @@ func (s *Store) CreateTask(ctx context.Context, task *store.Task) error {
 		INSERT INTO tasks (id, user_id, agent_id, purpose, status, authorized_actions, planned_calls, callback_url,
 			expires_in_seconds, approved_at, expires_at, pending_action, pending_reason, lifetime,
 			risk_level, risk_details, approval_source, approval_rationale, expected_tools_json,
-			expected_egress_json, required_credentials_json, intent_verification_mode, expected_use, schema_version, chain_extraction_mode)
-		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25)
+			expected_egress_json, required_credentials_json, intent_verification_mode, expected_use, schema_version, chain_extraction_mode,
+			max_cost_micros, max_tokens)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27)
 	`, task.ID, task.UserID, task.AgentID, task.Purpose, task.Status,
 		actionsJSON, plannedCallsJSON, task.CallbackURL, task.ExpiresInSeconds,
 		task.ApprovedAt, task.ExpiresAt,
 		nilIfEmpty(pendingActionJSON), task.PendingReason, task.Lifetime,
 		task.RiskLevel, string(riskDetails), task.ApprovalSource, approvalRationale,
 		expectedToolsJSON, expectedEgressJSON, requiredCredentialsJSON, task.IntentVerificationMode, task.ExpectedUse, task.SchemaVersion,
-		task.ChainExtractionMode)
+		task.ChainExtractionMode, task.MaxCostMicros, task.MaxTokens)
 	return err
 }
 
@@ -1220,14 +1276,15 @@ func (s *Store) GetTask(ctx context.Context, id string) (*store.Task, error) {
 		       created_at, approved_at, expires_at, expires_in_seconds, request_count,
 		       pending_action, pending_reason, lifetime, risk_level, risk_details,
 		       approval_source, approval_rationale, expected_tools_json, expected_egress_json,
-		       required_credentials_json, intent_verification_mode, expected_use, schema_version, chain_extraction_mode
+		       required_credentials_json, intent_verification_mode, expected_use, schema_version, chain_extraction_mode,
+		       max_cost_micros, max_tokens
 		FROM tasks WHERE id = $1
 	`, id).Scan(&t.ID, &t.UserID, &t.AgentID, &t.Purpose, &t.Status, &actionsJSON,
 		&plannedCallsJSON, &t.CallbackURL, &t.CreatedAt, &t.ApprovedAt, &t.ExpiresAt, &t.ExpiresInSeconds,
 		&t.RequestCount, &pendingActionJSON, &t.PendingReason, &t.Lifetime,
 		&t.RiskLevel, &riskDetailsStr, &t.ApprovalSource, &approvalRationaleStr,
 		&expectedToolsJSON, &expectedEgressJSON, &requiredCredentialsJSON, &t.IntentVerificationMode, &t.ExpectedUse, &t.SchemaVersion,
-		&chainExtractionMode)
+		&chainExtractionMode, &t.MaxCostMicros, &t.MaxTokens)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, store.ErrNotFound
 	}
@@ -1297,7 +1354,8 @@ func (s *Store) ListTasks(ctx context.Context, userID string, filter store.TaskF
 		       created_at, approved_at, expires_at, expires_in_seconds, request_count,
 		       pending_action, pending_reason, lifetime, risk_level, risk_details,
 		       approval_source, approval_rationale, expected_tools_json, expected_egress_json,
-		       required_credentials_json, intent_verification_mode, expected_use, schema_version, chain_extraction_mode
+		       required_credentials_json, intent_verification_mode, expected_use, schema_version, chain_extraction_mode,
+		       max_cost_micros, max_tokens
 		FROM tasks ` + where + ` ORDER BY created_at DESC`
 
 	if filter.Limit > 0 {
@@ -1479,7 +1537,8 @@ func (s *Store) ListExpiredTasks(ctx context.Context) ([]*store.Task, error) {
 		       created_at, approved_at, expires_at, expires_in_seconds, request_count,
 		       pending_action, pending_reason, lifetime, risk_level, risk_details,
 		       approval_source, approval_rationale, expected_tools_json, expected_egress_json,
-		       required_credentials_json, intent_verification_mode, expected_use, schema_version, chain_extraction_mode
+		       required_credentials_json, intent_verification_mode, expected_use, schema_version, chain_extraction_mode,
+		       max_cost_micros, max_tokens
 		FROM tasks WHERE status = 'active' AND lifetime = 'session' AND expires_at < NOW()
 	`)
 	if err != nil {
@@ -1498,7 +1557,8 @@ func (s *Store) ListExpiredInlineChatPendingTasks(ctx context.Context, cutoff ti
 		       created_at, approved_at, expires_at, expires_in_seconds, request_count,
 		       pending_action, pending_reason, lifetime, risk_level, risk_details,
 		       approval_source, approval_rationale, expected_tools_json, expected_egress_json,
-		       required_credentials_json, intent_verification_mode, expected_use, schema_version, chain_extraction_mode
+		       required_credentials_json, intent_verification_mode, expected_use, schema_version, chain_extraction_mode,
+		       max_cost_micros, max_tokens
 		FROM tasks
 		WHERE status = 'pending_approval'
 		  AND approval_source = 'inline_chat'
@@ -1523,7 +1583,7 @@ func scanTasks(rows pgx.Rows) ([]*store.Task, error) {
 			&t.RequestCount, &pendingActionJSON, &t.PendingReason, &t.Lifetime,
 			&t.RiskLevel, &riskDetailsStr, &t.ApprovalSource, &approvalRationaleStr,
 			&expectedToolsJSON, &expectedEgressJSON, &requiredCredentialsJSON, &t.IntentVerificationMode, &t.ExpectedUse, &t.SchemaVersion,
-			&chainExtractionMode); err != nil {
+			&chainExtractionMode, &t.MaxCostMicros, &t.MaxTokens); err != nil {
 			return nil, err
 		}
 		if chainExtractionMode != nil {
@@ -3396,12 +3456,15 @@ func scanAgents(rows pgx.Rows) ([]*store.Agent, error) {
 		var settingsConversationAutoApprove *string
 		var settingsCreatedAt *time.Time
 		var settingsUpdatedAt *time.Time
+		var settingsMaxCostMicros *int64
+		var settingsMaxTokens *int64
 		if err := rows.Scan(&a.ID, &a.UserID, &a.Name, &a.TokenHash, &a.CreatedAt, &orgID, &a.Description,
 			&installContext,
 			&a.ActiveTaskCount, &a.LastTaskAt, &settingsAgentID, &settingsEnabled, &settingsMode,
 			&settingsProfile, &settingsOutbound, &settingsInject, &settingsLiteProxySecretDetectionDisabled,
 			&settingsConversationAutoApprove,
-			&settingsCreatedAt, &settingsUpdatedAt); err != nil {
+			&settingsCreatedAt, &settingsUpdatedAt,
+			&settingsMaxCostMicros, &settingsMaxTokens); err != nil {
 			return nil, err
 		}
 		if orgID != nil {
@@ -3443,6 +3506,8 @@ func scanAgents(rows pgx.Rows) ([]*store.Agent, error) {
 			if settingsUpdatedAt != nil {
 				a.RuntimeSettings.UpdatedAt = *settingsUpdatedAt
 			}
+			a.RuntimeSettings.MaxCostMicros = settingsMaxCostMicros
+			a.RuntimeSettings.MaxTokens = settingsMaxTokens
 		}
 		agents = append(agents, a)
 	}

--- a/pkg/store/postgres/store.go
+++ b/pkg/store/postgres/store.go
@@ -825,14 +825,55 @@ func (s *Store) RecordLLMRequestCost(ctx context.Context, c *store.LLMRequestCos
 	return err
 }
 
-// GetTaskCost rolls up llm_request_cost rows for one task. See the
-// sqlite copy for the contract.
-func (s *Store) GetTaskCost(ctx context.Context, userID, taskID string) (*store.TaskCostSummary, error) {
-	out := &store.TaskCostSummary{
-		TaskID:        taskID,
+type costAccumulator struct {
+	RequestCount     int
+	InputTokens      int64
+	OutputTokens     int64
+	CacheReadTokens  int64
+	CacheWriteTokens int64
+	CostMicros       int64
+	UnknownModels    []string
+	ByModel          []store.TaskCostByModelEntry
+}
+
+func scanAndAccumulateCost(rows pgx.Rows) (*costAccumulator, error) {
+	acc := &costAccumulator{
 		ByModel:       []store.TaskCostByModelEntry{},
 		UnknownModels: []string{},
 	}
+	unknownModels := map[string]struct{}{}
+	for rows.Next() {
+		var e store.TaskCostByModelEntry
+		var unknownRows int64
+		if err := rows.Scan(&e.Model, &e.RequestCount, &e.InputTokens, &e.OutputTokens,
+			&e.CacheReadTokens, &e.CacheWriteTokens, &e.CostMicros, &unknownRows); err != nil {
+			return nil, err
+		}
+		e.Known = unknownRows == 0
+		if !e.Known {
+			unknownModels[e.Model] = struct{}{}
+		}
+		acc.ByModel = append(acc.ByModel, e)
+		acc.RequestCount += e.RequestCount
+		acc.InputTokens += e.InputTokens
+		acc.OutputTokens += e.OutputTokens
+		acc.CacheReadTokens += e.CacheReadTokens
+		acc.CacheWriteTokens += e.CacheWriteTokens
+		acc.CostMicros += e.CostMicros
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	for m := range unknownModels {
+		acc.UnknownModels = append(acc.UnknownModels, m)
+	}
+	sort.Strings(acc.UnknownModels)
+	return acc, nil
+}
+
+// GetTaskCost rolls up llm_request_cost rows for one task. See the
+// sqlite copy for the contract.
+func (s *Store) GetTaskCost(ctx context.Context, userID, taskID string) (*store.TaskCostSummary, error) {
 	// Postgres' SUM(bigint) widens to NUMERIC; pgx can't scan that
 	// into int64. Cast each SUM back to bigint so the column type
 	// matches the destination. Token columns are INTEGER → SUM is
@@ -861,42 +902,26 @@ func (s *Store) GetTaskCost(ctx context.Context, userID, taskID string) (*store.
 		return nil, err
 	}
 	defer rows.Close()
-	unknownModels := map[string]struct{}{}
-	for rows.Next() {
-		var e store.TaskCostByModelEntry
-		var unknownRows int64
-		if err := rows.Scan(&e.Model, &e.RequestCount, &e.InputTokens, &e.OutputTokens,
-			&e.CacheReadTokens, &e.CacheWriteTokens, &e.CostMicros, &unknownRows); err != nil {
-			return nil, err
-		}
-		e.Known = unknownRows == 0
-		if !e.Known {
-			unknownModels[e.Model] = struct{}{}
-		}
-		out.ByModel = append(out.ByModel, e)
-		out.RequestCount += e.RequestCount
-		out.InputTokens += e.InputTokens
-		out.OutputTokens += e.OutputTokens
-		out.CacheReadTokens += e.CacheReadTokens
-		out.CacheWriteTokens += e.CacheWriteTokens
-		out.CostMicros += e.CostMicros
-	}
-	if err := rows.Err(); err != nil {
+
+	acc, err := scanAndAccumulateCost(rows)
+	if err != nil {
 		return nil, err
 	}
-	for m := range unknownModels {
-		out.UnknownModels = append(out.UnknownModels, m)
-	}
-	sort.Strings(out.UnknownModels)
-	return out, nil
+
+	return &store.TaskCostSummary{
+		TaskID:           taskID,
+		RequestCount:     acc.RequestCount,
+		InputTokens:      acc.InputTokens,
+		OutputTokens:     acc.OutputTokens,
+		CacheReadTokens:  acc.CacheReadTokens,
+		CacheWriteTokens: acc.CacheWriteTokens,
+		CostMicros:       acc.CostMicros,
+		UnknownModels:    acc.UnknownModels,
+		ByModel:          acc.ByModel,
+	}, nil
 }
 
 func (s *Store) GetAgentCost(ctx context.Context, userID, agentID string) (*store.AgentCostSummary, error) {
-	out := &store.AgentCostSummary{
-		AgentID:       agentID,
-		ByModel:       []store.TaskCostByModelEntry{},
-		UnknownModels: []string{},
-	}
 	rows, err := s.pool.Query(ctx, `
 		SELECT model,
 		       COUNT(*)::integer AS n,
@@ -914,34 +939,23 @@ func (s *Store) GetAgentCost(ctx context.Context, userID, agentID string) (*stor
 		return nil, err
 	}
 	defer rows.Close()
-	unknownModels := map[string]struct{}{}
-	for rows.Next() {
-		var e store.TaskCostByModelEntry
-		var unknownRows int64
-		if err := rows.Scan(&e.Model, &e.RequestCount, &e.InputTokens, &e.OutputTokens,
-			&e.CacheReadTokens, &e.CacheWriteTokens, &e.CostMicros, &unknownRows); err != nil {
-			return nil, err
-		}
-		e.Known = unknownRows == 0
-		if !e.Known {
-			unknownModels[e.Model] = struct{}{}
-		}
-		out.ByModel = append(out.ByModel, e)
-		out.RequestCount += e.RequestCount
-		out.InputTokens += e.InputTokens
-		out.OutputTokens += e.OutputTokens
-		out.CacheReadTokens += e.CacheReadTokens
-		out.CacheWriteTokens += e.CacheWriteTokens
-		out.CostMicros += e.CostMicros
-	}
-	if err := rows.Err(); err != nil {
+
+	acc, err := scanAndAccumulateCost(rows)
+	if err != nil {
 		return nil, err
 	}
-	for m := range unknownModels {
-		out.UnknownModels = append(out.UnknownModels, m)
-	}
-	sort.Strings(out.UnknownModels)
-	return out, nil
+
+	return &store.AgentCostSummary{
+		AgentID:          agentID,
+		RequestCount:     acc.RequestCount,
+		InputTokens:      acc.InputTokens,
+		OutputTokens:     acc.OutputTokens,
+		CacheReadTokens:  acc.CacheReadTokens,
+		CacheWriteTokens: acc.CacheWriteTokens,
+		CostMicros:       acc.CostMicros,
+		UnknownModels:    acc.UnknownModels,
+		ByModel:          acc.ByModel,
+	}, nil
 }
 
 func (s *Store) UpdateAuditOutcome(ctx context.Context, id, outcome, errMsg string, durationMS int) error {

--- a/pkg/store/sqlite/migrations/055_budget.sql
+++ b/pkg/store/sqlite/migrations/055_budget.sql
@@ -1,5 +1,7 @@
-ALTER TABLE tasks ADD COLUMN max_cost_micros INTEGER;
-ALTER TABLE tasks ADD COLUMN max_tokens INTEGER;
+-- SQLite ALTER TABLE doesn't support IF NOT EXISTS on columns, but the migration
+-- runner is idempotent by version number and tolerates "duplicate column name" errors.
+ALTER TABLE tasks ADD COLUMN max_cost_micros INTEGER CHECK (max_cost_micros >= 0);
+ALTER TABLE tasks ADD COLUMN max_tokens INTEGER CHECK (max_tokens >= 0);
 
-ALTER TABLE agent_runtime_settings ADD COLUMN max_cost_micros INTEGER;
-ALTER TABLE agent_runtime_settings ADD COLUMN max_tokens INTEGER;
+ALTER TABLE agent_runtime_settings ADD COLUMN max_cost_micros INTEGER CHECK (max_cost_micros >= 0);
+ALTER TABLE agent_runtime_settings ADD COLUMN max_tokens INTEGER CHECK (max_tokens >= 0);

--- a/pkg/store/sqlite/migrations/055_budget.sql
+++ b/pkg/store/sqlite/migrations/055_budget.sql
@@ -1,0 +1,5 @@
+ALTER TABLE tasks ADD COLUMN max_cost_micros INTEGER;
+ALTER TABLE tasks ADD COLUMN max_tokens INTEGER;
+
+ALTER TABLE agent_runtime_settings ADD COLUMN max_cost_micros INTEGER;
+ALTER TABLE agent_runtime_settings ADD COLUMN max_tokens INTEGER;

--- a/pkg/store/sqlite/store.go
+++ b/pkg/store/sqlite/store.go
@@ -301,7 +301,7 @@ func (s *Store) ListAgents(ctx context.Context, userID string) ([]*store.Agent, 
 		       ars.agent_id, ars.runtime_enabled, ars.runtime_mode, ars.starter_profile,
 		       ars.outbound_credential_mode, ars.inject_stored_bearer, ars.lite_proxy_secret_detection_disabled,
 		       ars.conversation_auto_approve_threshold,
-		       ars.created_at, ars.updated_at
+		       ars.created_at, ars.updated_at, ars.max_cost_micros, ars.max_tokens
 		FROM agents a
 		LEFT JOIN agent_runtime_settings ars ON ars.agent_id = a.id
 		WHERE a.user_id = ? AND a.deleted_at IS NULL
@@ -330,10 +330,13 @@ func (s *Store) ListAgents(ctx context.Context, userID string) ([]*store.Agent, 
 		var settingsConversationAutoApprove *string
 		var settingsCreatedAt *string
 		var settingsUpdatedAt *string
+		var settingsMaxCostMicros *int64
+		var settingsMaxTokens *int64
 		if err := rows.Scan(&a.ID, &a.UserID, &a.Name, &a.TokenHash, &createdAt, &orgID, &a.Description, &installContext,
 			&a.ActiveTaskCount, &lastTaskAt, &settingsAgentID, &settingsEnabled, &settingsMode, &settingsProfile,
 			&settingsOutbound, &settingsInject, &settingsLiteProxySecretDetectionDisabled,
-			&settingsConversationAutoApprove, &settingsCreatedAt, &settingsUpdatedAt); err != nil {
+			&settingsConversationAutoApprove, &settingsCreatedAt, &settingsUpdatedAt,
+			&settingsMaxCostMicros, &settingsMaxTokens); err != nil {
 			return nil, err
 		}
 		a.CreatedAt = parseTime(createdAt)
@@ -349,7 +352,7 @@ func (s *Store) ListAgents(ctx context.Context, userID string) ([]*store.Agent, 
 			ts := parseTime(*lastTaskAt)
 			a.LastTaskAt = &ts
 		}
-		a.RuntimeSettings = scanSQLiteAgentRuntimeSettings(settingsAgentID, settingsEnabled, settingsMode, settingsProfile, settingsOutbound, settingsInject, settingsLiteProxySecretDetectionDisabled, settingsConversationAutoApprove, settingsCreatedAt, settingsUpdatedAt)
+		a.RuntimeSettings = scanSQLiteAgentRuntimeSettings(settingsAgentID, settingsEnabled, settingsMode, settingsProfile, settingsOutbound, settingsInject, settingsLiteProxySecretDetectionDisabled, settingsConversationAutoApprove, settingsCreatedAt, settingsUpdatedAt, settingsMaxCostMicros, settingsMaxTokens)
 		agents = append(agents, a)
 	}
 	return agents, rows.Err()
@@ -374,7 +377,7 @@ func (s *Store) GetAgentRuntimeSettings(ctx context.Context, agentID string) (*s
 	row := s.db.QueryRowContext(ctx, `
 		SELECT agent_id, runtime_enabled, runtime_mode, starter_profile,
 		       outbound_credential_mode, inject_stored_bearer, lite_proxy_secret_detection_disabled,
-		       conversation_auto_approve_threshold, created_at, updated_at
+		       conversation_auto_approve_threshold, created_at, updated_at, max_cost_micros, max_tokens
 		FROM agent_runtime_settings
 		WHERE agent_id = ?
 	`, agentID)
@@ -385,7 +388,7 @@ func (s *Store) GetAgentRuntimeSettings(ctx context.Context, agentID string) (*s
 	var createdAt, updatedAt string
 	err := row.Scan(&settings.AgentID, &runtimeEnabled, &settings.RuntimeMode, &settings.StarterProfile,
 		&settings.OutboundCredentialMode, &injectStoredBearer, &liteProxySecretDetectionDisabled,
-		&settings.ConversationAutoApproveThreshold, &createdAt, &updatedAt)
+		&settings.ConversationAutoApproveThreshold, &createdAt, &updatedAt, &settings.MaxCostMicros, &settings.MaxTokens)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, store.ErrNotFound
 	}
@@ -412,8 +415,8 @@ func (s *Store) UpsertAgentRuntimeSettings(ctx context.Context, settings *store.
 	_, err := s.db.ExecContext(ctx, `
 		INSERT INTO agent_runtime_settings (
 			agent_id, runtime_enabled, runtime_mode, starter_profile, outbound_credential_mode, inject_stored_bearer, lite_proxy_secret_detection_disabled,
-			conversation_auto_approve_threshold
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+			conversation_auto_approve_threshold, max_cost_micros, max_tokens
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT (agent_id) DO UPDATE SET
 			runtime_enabled = excluded.runtime_enabled,
 			runtime_mode = excluded.runtime_mode,
@@ -422,10 +425,12 @@ func (s *Store) UpsertAgentRuntimeSettings(ctx context.Context, settings *store.
 			inject_stored_bearer = excluded.inject_stored_bearer,
 			lite_proxy_secret_detection_disabled = excluded.lite_proxy_secret_detection_disabled,
 			conversation_auto_approve_threshold = excluded.conversation_auto_approve_threshold,
+			max_cost_micros = excluded.max_cost_micros,
+			max_tokens = excluded.max_tokens,
 			updated_at = CURRENT_TIMESTAMP
 	`, settings.AgentID, boolToInt(settings.RuntimeEnabled), settings.RuntimeMode, settings.StarterProfile,
 		settings.OutboundCredentialMode, boolToInt(settings.InjectStoredBearer), boolToInt(settings.LiteProxySecretDetectionDisabled),
-		settings.ConversationAutoApproveThreshold)
+		settings.ConversationAutoApproveThreshold, settings.MaxCostMicros, settings.MaxTokens)
 	return err
 }
 
@@ -1053,6 +1058,59 @@ func (s *Store) GetTaskCost(ctx context.Context, userID, taskID string) (*store.
 	return out, nil
 }
 
+func (s *Store) GetAgentCost(ctx context.Context, userID, agentID string) (*store.AgentCostSummary, error) {
+	out := &store.AgentCostSummary{
+		AgentID:       agentID,
+		ByModel:       []store.TaskCostByModelEntry{},
+		UnknownModels: []string{},
+	}
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT model,
+		       COUNT(*) AS n,
+		       COALESCE(SUM(input_tokens), 0),
+		       COALESCE(SUM(output_tokens), 0),
+		       COALESCE(SUM(cache_read_tokens), 0),
+		       COALESCE(SUM(cache_write_tokens), 0),
+		       COALESCE(SUM(cost_micros), 0),
+		       SUM(CASE WHEN cost_micros IS NULL THEN 1 ELSE 0 END) AS unknown_rows
+		FROM llm_request_cost
+		WHERE user_id = ? AND agent_id = ? AND agent_id IS NOT NULL
+		GROUP BY model
+		ORDER BY model`, userID, agentID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	unknownModels := map[string]struct{}{}
+	for rows.Next() {
+		var e store.TaskCostByModelEntry
+		var unknownRows int64
+		if err := rows.Scan(&e.Model, &e.RequestCount, &e.InputTokens, &e.OutputTokens,
+			&e.CacheReadTokens, &e.CacheWriteTokens, &e.CostMicros, &unknownRows); err != nil {
+			return nil, err
+		}
+		e.Known = unknownRows == 0
+		if !e.Known {
+			unknownModels[e.Model] = struct{}{}
+		}
+		out.ByModel = append(out.ByModel, e)
+		out.RequestCount += e.RequestCount
+		out.InputTokens += e.InputTokens
+		out.OutputTokens += e.OutputTokens
+		out.CacheReadTokens += e.CacheReadTokens
+		out.CacheWriteTokens += e.CacheWriteTokens
+		out.CostMicros += e.CostMicros
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	for m := range unknownModels {
+		out.UnknownModels = append(out.UnknownModels, m)
+	}
+	sort.Strings(out.UnknownModels)
+	return out, nil
+}
+
 func (s *Store) UpdateAuditOutcome(ctx context.Context, id, outcome, errMsg string, durationMS int) error {
 	var errMsgPtr *string
 	if errMsg != "" {
@@ -1391,14 +1449,15 @@ func (s *Store) CreateTask(ctx context.Context, task *store.Task) error {
 		INSERT INTO tasks (id, user_id, agent_id, purpose, status, authorized_actions, planned_calls, callback_url,
 			expires_in_seconds, approved_at, expires_at, pending_action, pending_reason, lifetime,
 			risk_level, risk_details, approval_source, approval_rationale, expected_tools_json,
-			expected_egress_json, required_credentials_json, intent_verification_mode, expected_use, schema_version, chain_extraction_mode)
-		VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+			expected_egress_json, required_credentials_json, intent_verification_mode, expected_use, schema_version, chain_extraction_mode,
+			max_cost_micros, max_tokens)
+		VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
 	`, task.ID, task.UserID, task.AgentID, task.Purpose, task.Status,
 		string(actionsJSON), string(plannedCallsJSON), task.CallbackURL, task.ExpiresInSeconds,
 		approvedAt, expiresAt, pendingActionJSON, task.PendingReason, task.Lifetime,
 		task.RiskLevel, riskDetails, task.ApprovalSource, approvalRationale, expectedToolsJSON,
 		expectedEgressJSON, requiredCredentialsJSON, task.IntentVerificationMode, task.ExpectedUse, task.SchemaVersion,
-		task.ChainExtractionMode)
+		task.ChainExtractionMode, task.MaxCostMicros, task.MaxTokens)
 	return err
 }
 
@@ -1413,14 +1472,15 @@ func (s *Store) GetTask(ctx context.Context, id string) (*store.Task, error) {
 		       created_at, approved_at, expires_at, expires_in_seconds, request_count,
 		       pending_action, pending_reason, lifetime, risk_level, risk_details,
 		       approval_source, approval_rationale, expected_tools_json, expected_egress_json,
-		       required_credentials_json, intent_verification_mode, expected_use, schema_version, chain_extraction_mode
+		       required_credentials_json, intent_verification_mode, expected_use, schema_version, chain_extraction_mode,
+		       max_cost_micros, max_tokens
 		FROM tasks WHERE id = ?
 	`, id).Scan(&t.ID, &t.UserID, &t.AgentID, &t.Purpose, &t.Status, &actionsStr,
 		&plannedCallsStr, &t.CallbackURL, &createdAt, &approvedAt, &expiresAt, &t.ExpiresInSeconds,
 		&t.RequestCount, &pendingActionStr, &t.PendingReason, &t.Lifetime,
 		&t.RiskLevel, &riskDetailsStr, &t.ApprovalSource, &approvalRationaleStr,
 		&expectedToolsStr, &expectedEgressStr, &requiredCredentialsStr, &t.IntentVerificationMode, &t.ExpectedUse, &t.SchemaVersion,
-		&chainExtractionMode)
+		&chainExtractionMode, &t.MaxCostMicros, &t.MaxTokens)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, store.ErrNotFound
 	}
@@ -1496,7 +1556,8 @@ func (s *Store) ListTasks(ctx context.Context, userID string, filter store.TaskF
 		       created_at, approved_at, expires_at, expires_in_seconds, request_count,
 		       pending_action, pending_reason, lifetime, risk_level, risk_details,
 		       approval_source, approval_rationale, expected_tools_json, expected_egress_json,
-		       required_credentials_json, intent_verification_mode, expected_use, schema_version, chain_extraction_mode
+		       required_credentials_json, intent_verification_mode, expected_use, schema_version, chain_extraction_mode,
+		       max_cost_micros, max_tokens
 		FROM tasks ` + where + ` ORDER BY created_at DESC`
 
 	if filter.Limit > 0 {
@@ -1522,7 +1583,7 @@ func (s *Store) ListTasks(ctx context.Context, userID string, filter store.TaskF
 			&t.RequestCount, &pendingActionStr, &t.PendingReason, &t.Lifetime,
 			&t.RiskLevel, &riskDetailsStr, &t.ApprovalSource, &approvalRationaleStr,
 			&expectedToolsStr, &expectedEgressStr, &requiredCredentialsStr, &t.IntentVerificationMode, &t.ExpectedUse, &t.SchemaVersion,
-			&chainExtractionMode); err != nil {
+			&chainExtractionMode, &t.MaxCostMicros, &t.MaxTokens); err != nil {
 			return nil, 0, err
 		}
 		if chainExtractionMode != nil {
@@ -3860,7 +3921,7 @@ func rawJSONOrDefault(msg json.RawMessage, fallback string) string {
 	return string(msg)
 }
 
-func scanSQLiteAgentRuntimeSettings(agentID *string, runtimeEnabled *int, runtimeMode, starterProfile, outboundMode *string, injectStoredBearer, liteProxySecretDetectionDisabled *int, conversationAutoApprove *string, createdAt, updatedAt *string) *store.AgentRuntimeSettings {
+func scanSQLiteAgentRuntimeSettings(agentID *string, runtimeEnabled *int, runtimeMode, starterProfile, outboundMode *string, injectStoredBearer, liteProxySecretDetectionDisabled *int, conversationAutoApprove *string, createdAt, updatedAt *string, maxCostMicros *int64, maxTokens *int64) *store.AgentRuntimeSettings {
 	if agentID == nil {
 		return nil
 	}
@@ -3894,6 +3955,8 @@ func scanSQLiteAgentRuntimeSettings(agentID *string, runtimeEnabled *int, runtim
 	if updatedAt != nil {
 		settings.UpdatedAt = parseTime(*updatedAt)
 	}
+	settings.MaxCostMicros = maxCostMicros
+	settings.MaxTokens = maxTokens
 	return settings
 }
 

--- a/pkg/store/sqlite/store.go
+++ b/pkg/store/sqlite/store.go
@@ -994,15 +994,56 @@ func (s *Store) RecordLLMRequestCost(ctx context.Context, c *store.LLMRequestCos
 	return err
 }
 
+type costAccumulator struct {
+	RequestCount     int
+	InputTokens      int64
+	OutputTokens     int64
+	CacheReadTokens  int64
+	CacheWriteTokens int64
+	CostMicros       int64
+	UnknownModels    []string
+	ByModel          []store.TaskCostByModelEntry
+}
+
+func scanAndAccumulateCost(rows *sql.Rows) (*costAccumulator, error) {
+	acc := &costAccumulator{
+		ByModel:       []store.TaskCostByModelEntry{},
+		UnknownModels: []string{},
+	}
+	unknownModels := map[string]struct{}{}
+	for rows.Next() {
+		var e store.TaskCostByModelEntry
+		var unknownRows int64
+		if err := rows.Scan(&e.Model, &e.RequestCount, &e.InputTokens, &e.OutputTokens,
+			&e.CacheReadTokens, &e.CacheWriteTokens, &e.CostMicros, &unknownRows); err != nil {
+			return nil, err
+		}
+		e.Known = unknownRows == 0
+		if !e.Known {
+			unknownModels[e.Model] = struct{}{}
+		}
+		acc.ByModel = append(acc.ByModel, e)
+		acc.RequestCount += e.RequestCount
+		acc.InputTokens += e.InputTokens
+		acc.OutputTokens += e.OutputTokens
+		acc.CacheReadTokens += e.CacheReadTokens
+		acc.CacheWriteTokens += e.CacheWriteTokens
+		acc.CostMicros += e.CostMicros
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	for m := range unknownModels {
+		acc.UnknownModels = append(acc.UnknownModels, m)
+	}
+	sort.Strings(acc.UnknownModels)
+	return acc, nil
+}
+
 // GetTaskCost rolls up llm_request_cost rows for one task. Returns an
 // empty TaskCostSummary (not ErrNotFound) when the task has no cost
 // rows yet — the caller can still render "no LLM spend recorded".
 func (s *Store) GetTaskCost(ctx context.Context, userID, taskID string) (*store.TaskCostSummary, error) {
-	out := &store.TaskCostSummary{
-		TaskID:        taskID,
-		ByModel:       []store.TaskCostByModelEntry{},
-		UnknownModels: []string{},
-	}
 	// `AND task_id IS NOT NULL` is redundant for a non-empty taskID
 	// but lets SQLite's planner reliably pick the partial index
 	// idx_llm_cost_user_task (WHERE task_id IS NOT NULL) without
@@ -1024,46 +1065,26 @@ func (s *Store) GetTaskCost(ctx context.Context, userID, taskID string) (*store.
 		return nil, err
 	}
 	defer rows.Close()
-	unknownModels := map[string]struct{}{}
-	for rows.Next() {
-		var e store.TaskCostByModelEntry
-		var unknownRows int64
-		if err := rows.Scan(&e.Model, &e.RequestCount, &e.InputTokens, &e.OutputTokens,
-			&e.CacheReadTokens, &e.CacheWriteTokens, &e.CostMicros, &unknownRows); err != nil {
-			return nil, err
-		}
-		// A model is "known" when every row for it priced successfully.
-		// Mixed (some priced, some not) — common when the pricing table
-		// is updated mid-task — surfaces in UnknownModels so the UI can
-		// flag that the total is a lower bound.
-		e.Known = unknownRows == 0
-		if !e.Known {
-			unknownModels[e.Model] = struct{}{}
-		}
-		out.ByModel = append(out.ByModel, e)
-		out.RequestCount += e.RequestCount
-		out.InputTokens += e.InputTokens
-		out.OutputTokens += e.OutputTokens
-		out.CacheReadTokens += e.CacheReadTokens
-		out.CacheWriteTokens += e.CacheWriteTokens
-		out.CostMicros += e.CostMicros
-	}
-	if err := rows.Err(); err != nil {
+
+	acc, err := scanAndAccumulateCost(rows)
+	if err != nil {
 		return nil, err
 	}
-	for m := range unknownModels {
-		out.UnknownModels = append(out.UnknownModels, m)
-	}
-	sort.Strings(out.UnknownModels)
-	return out, nil
+
+	return &store.TaskCostSummary{
+		TaskID:           taskID,
+		RequestCount:     acc.RequestCount,
+		InputTokens:      acc.InputTokens,
+		OutputTokens:     acc.OutputTokens,
+		CacheReadTokens:  acc.CacheReadTokens,
+		CacheWriteTokens: acc.CacheWriteTokens,
+		CostMicros:       acc.CostMicros,
+		UnknownModels:    acc.UnknownModels,
+		ByModel:          acc.ByModel,
+	}, nil
 }
 
 func (s *Store) GetAgentCost(ctx context.Context, userID, agentID string) (*store.AgentCostSummary, error) {
-	out := &store.AgentCostSummary{
-		AgentID:       agentID,
-		ByModel:       []store.TaskCostByModelEntry{},
-		UnknownModels: []string{},
-	}
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT model,
 		       COUNT(*) AS n,
@@ -1081,34 +1102,23 @@ func (s *Store) GetAgentCost(ctx context.Context, userID, agentID string) (*stor
 		return nil, err
 	}
 	defer rows.Close()
-	unknownModels := map[string]struct{}{}
-	for rows.Next() {
-		var e store.TaskCostByModelEntry
-		var unknownRows int64
-		if err := rows.Scan(&e.Model, &e.RequestCount, &e.InputTokens, &e.OutputTokens,
-			&e.CacheReadTokens, &e.CacheWriteTokens, &e.CostMicros, &unknownRows); err != nil {
-			return nil, err
-		}
-		e.Known = unknownRows == 0
-		if !e.Known {
-			unknownModels[e.Model] = struct{}{}
-		}
-		out.ByModel = append(out.ByModel, e)
-		out.RequestCount += e.RequestCount
-		out.InputTokens += e.InputTokens
-		out.OutputTokens += e.OutputTokens
-		out.CacheReadTokens += e.CacheReadTokens
-		out.CacheWriteTokens += e.CacheWriteTokens
-		out.CostMicros += e.CostMicros
-	}
-	if err := rows.Err(); err != nil {
+
+	acc, err := scanAndAccumulateCost(rows)
+	if err != nil {
 		return nil, err
 	}
-	for m := range unknownModels {
-		out.UnknownModels = append(out.UnknownModels, m)
-	}
-	sort.Strings(out.UnknownModels)
-	return out, nil
+
+	return &store.AgentCostSummary{
+		AgentID:          agentID,
+		RequestCount:     acc.RequestCount,
+		InputTokens:      acc.InputTokens,
+		OutputTokens:     acc.OutputTokens,
+		CacheReadTokens:  acc.CacheReadTokens,
+		CacheWriteTokens: acc.CacheWriteTokens,
+		CostMicros:       acc.CostMicros,
+		UnknownModels:    acc.UnknownModels,
+		ByModel:          acc.ByModel,
+	}, nil
 }
 
 func (s *Store) UpdateAuditOutcome(ctx context.Context, id, outcome, errMsg string, durationMS int) error {

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -161,6 +161,7 @@ type Store interface {
 	// task.
 	RecordLLMRequestCost(ctx context.Context, cost *LLMRequestCost) error
 	GetTaskCost(ctx context.Context, userID, taskID string) (*TaskCostSummary, error)
+	GetAgentCost(ctx context.Context, userID, agentID string) (*AgentCostSummary, error)
 	CreateActivityMute(ctx context.Context, mute *ActivityMute) error
 	ListActivityMutes(ctx context.Context, userID string) ([]*ActivityMute, error)
 	DeleteActivityMute(ctx context.Context, id, userID string) error
@@ -569,6 +570,8 @@ type AgentRuntimeSettings struct {
 	ConversationAutoApproveThreshold string    `json:"conversation_auto_approve_threshold"`
 	CreatedAt                        time.Time `json:"created_at"`
 	UpdatedAt                        time.Time `json:"updated_at"`
+	MaxCostMicros                    *int64    `json:"max_cost_micros,omitempty"`
+	MaxTokens                        *int64    `json:"max_tokens,omitempty"`
 }
 
 // ServiceMeta records that a user has activated a given service.
@@ -724,6 +727,20 @@ type TaskCostSummary struct {
 	ByModel       []TaskCostByModelEntry `json:"by_model"`
 }
 
+// AgentCostSummary is the rollup of all LLMRequestCost rows for a
+// single agent.
+type AgentCostSummary struct {
+	AgentID          string                  `json:"agent_id"`
+	RequestCount     int                     `json:"request_count"`
+	InputTokens      int64                   `json:"input_tokens"`
+	OutputTokens     int64                   `json:"output_tokens"`
+	CacheReadTokens  int64                   `json:"cache_read_tokens"`
+	CacheWriteTokens int64                   `json:"cache_write_tokens"`
+	CostMicros       int64                   `json:"cost_micros"`
+	UnknownModels    []string                `json:"unknown_models"`
+	ByModel          []TaskCostByModelEntry `json:"by_model"`
+}
+
 // TaskCostByModelEntry is one model's contribution to a task's cost.
 type TaskCostByModelEntry struct {
 	Model            string `json:"model"`
@@ -820,6 +837,8 @@ type Task struct {
 	// INLINE_CHAT_BOUND) plus the chat-bound expiry sweep.
 	ApprovalSource    string          `json:"approval_source,omitempty"`
 	ApprovalRationale json.RawMessage `json:"approval_rationale,omitempty"`
+	MaxCostMicros     *int64          `json:"max_cost_micros,omitempty"`
+	MaxTokens         *int64          `json:"max_tokens,omitempty"`
 }
 
 // PendingApproval is a gateway request awaiting human approval.

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -330,6 +330,8 @@ export interface AgentRuntimeSettings {
   // turns authorize the task and the risk is at-or-below this level.
   // Backend rejects values above "medium" at the API layer.
   conversation_auto_approve_threshold?: ConversationAutoApproveThreshold
+  max_cost_micros?: number
+  max_tokens?: number
   created_at?: string
   updated_at?: string
 }
@@ -652,6 +654,8 @@ export interface Task {
   risk_details?: RiskAssessment
   approval_source?: string
   approval_rationale?: ApprovalRationale
+  max_cost_micros?: number
+  max_tokens?: number
 }
 
 export interface ApprovalRationale {

--- a/web/src/components/TaskCard.tsx
+++ b/web/src/components/TaskCard.tsx
@@ -124,7 +124,7 @@ export default function TaskCard({
   // so we can decide whether to render the Cost tab at all — non-llm-proxy
   // tasks return request_count=0 and the tab stays hidden. The query is
   // cheap when there are no rows.
-  const costPrefetchEnabled = !isActionable && expanded
+  const costPrefetchEnabled = !isActionable && (expanded || typeof task.max_cost_micros === 'number' || typeof task.max_tokens === 'number')
 
   const { data: costData, isLoading: costLoading } = useQuery({
     queryKey: ['task-cost', task.id],
@@ -291,6 +291,25 @@ export default function TaskCard({
                 <RequestCounter count={task.request_count} active={isActive} />
               </>
             )}
+            {costData && (typeof task.max_cost_micros === 'number' || typeof task.max_tokens === 'number') && (
+              <>
+                <span>&middot;</span>
+                <span className="text-text-secondary font-medium">
+                  Budget:{' '}
+                  {typeof task.max_cost_micros === 'number' && (
+                    <span>
+                      {formatMicros(costData.cost_micros)} of {formatMicros(task.max_cost_micros)}
+                    </span>
+                  )}
+                  {typeof task.max_cost_micros === 'number' && typeof task.max_tokens === 'number' && ' · '}
+                  {typeof task.max_tokens === 'number' && (
+                    <span>
+                      {formatTokens(costData.input_tokens + costData.output_tokens + costData.cache_read_tokens + costData.cache_write_tokens)} of {formatTokens(task.max_tokens)} tokens
+                    </span>
+                  )}
+                </span>
+              </>
+            )}
           </div>
         </div>
       )}
@@ -310,6 +329,17 @@ export default function TaskCard({
               {isStanding ? 'ongoing' : 'session'}
               {!isStanding && task.expires_in_seconds > 0 && ` · ${Math.round(task.expires_in_seconds / 60)}m`}
             </span>
+            {(typeof task.max_cost_micros === 'number' || typeof task.max_tokens === 'number') && (
+              <>
+                <span className="text-xs text-text-tertiary">&middot;</span>
+                <span className="text-xs font-mono text-text-secondary font-medium">
+                  Budget:{' '}
+                  {typeof task.max_cost_micros === 'number' && formatMicros(task.max_cost_micros)}
+                  {typeof task.max_cost_micros === 'number' && typeof task.max_tokens === 'number' && ' / '}
+                  {typeof task.max_tokens === 'number' && `${formatTokens(task.max_tokens)} tokens`}
+                </span>
+              </>
+            )}
           </div>
         </div>
       )}
@@ -566,7 +596,7 @@ export default function TaskCard({
           )}
 
           {effectiveTab === 'cost' && (
-            <CostPanel data={costData} loading={costLoading} />
+            <CostPanel data={costData} loading={costLoading} task={task} />
           )}
 
           {!result && isActive && (
@@ -1132,7 +1162,7 @@ function formatTokens(n: number): string {
   return String(n)
 }
 
-function CostPanel({ data, loading }: { data: TaskCostSummary | undefined; loading: boolean }) {
+function CostPanel({ data, loading, task }: { data: TaskCostSummary | undefined; loading: boolean; task: Task }) {
   if (loading) {
     return <div className="px-4 py-3 text-xs text-text-tertiary">Loading…</div>
   }
@@ -1144,8 +1174,51 @@ function CostPanel({ data, loading }: { data: TaskCostSummary | undefined; loadi
     )
   }
   const hasUnknown = data.unknown_models.length > 0
+  const totalUsedTokens = data.input_tokens + data.output_tokens + data.cache_read_tokens + data.cache_write_tokens
+
   return (
-    <div className="px-4 py-3 space-y-3">
+    <div className="px-4 py-3 space-y-4">
+      {typeof task.max_cost_micros === 'number' && (
+        <div className="space-y-1 rounded border border-border-subtle bg-surface-0 px-3 py-2">
+          <div className="flex justify-between text-xs text-text-secondary">
+            <span className="font-medium text-text-primary">Cost Budget Usage</span>
+            <span>{formatMicros(data.cost_micros)} / {formatMicros(task.max_cost_micros)} ({Math.round((data.cost_micros / task.max_cost_micros) * 100)}%)</span>
+          </div>
+          <div className="h-1.5 w-full bg-surface-2 rounded-full overflow-hidden">
+            <div
+              className={`h-full rounded-full transition-all duration-500 ${
+                data.cost_micros >= task.max_cost_micros
+                  ? 'bg-danger'
+                  : data.cost_micros >= task.max_cost_micros * 0.9
+                  ? 'bg-warning'
+                  : 'bg-brand'
+              }`}
+              style={{ width: `${Math.min(100, (data.cost_micros / task.max_cost_micros) * 100)}%` }}
+            />
+          </div>
+        </div>
+      )}
+
+      {typeof task.max_tokens === 'number' && (
+        <div className="space-y-1 rounded border border-border-subtle bg-surface-0 px-3 py-2">
+          <div className="flex justify-between text-xs text-text-secondary">
+            <span className="font-medium text-text-primary">Token Budget Usage</span>
+            <span>{formatTokens(totalUsedTokens)} / {formatTokens(task.max_tokens)} ({Math.round((totalUsedTokens / task.max_tokens) * 100)}%)</span>
+          </div>
+          <div className="h-1.5 w-full bg-surface-2 rounded-full overflow-hidden">
+            <div
+              className={`h-full rounded-full transition-all duration-500 ${
+                totalUsedTokens >= task.max_tokens
+                  ? 'bg-danger'
+                  : totalUsedTokens >= task.max_tokens * 0.9
+                  ? 'bg-warning'
+                  : 'bg-brand'
+              }`}
+              style={{ width: `${Math.min(100, (totalUsedTokens / task.max_tokens) * 100)}%` }}
+            />
+          </div>
+        </div>
+      )}
       <div className="grid grid-cols-3 gap-3">
         <Stat label="Total cost" value={formatMicros(data.cost_micros)} mono />
         <Stat label="Requests" value={String(data.request_count)} mono />

--- a/web/src/pages/Agents.tsx
+++ b/web/src/pages/Agents.tsx
@@ -808,6 +808,60 @@ function AgentRuntimePanel({
               </select>
             </label>
           </div>
+          <div className="rounded border border-border-subtle bg-surface-1 px-4 py-3 space-y-2">
+            <div className="flex flex-wrap items-center gap-2">
+              <div className="text-sm font-medium text-text-primary">Token budgeting</div>
+            </div>
+            <p className="text-xs text-text-tertiary">
+              Limit this agent's lifetime spending or token usage. Leave blank for unlimited.
+            </p>
+            <div className="grid gap-3 md:grid-cols-2">
+              <label className="block space-y-1">
+                <span className="text-xs text-text-tertiary">Max Cost (USD)</span>
+                <input
+                  type="number"
+                  step="0.0001"
+                  min="0"
+                  placeholder="Unlimited"
+                  value={
+                    current.max_cost_micros !== undefined && current.max_cost_micros !== null
+                      ? current.max_cost_micros / 1000000
+                      : ''
+                  }
+                  onChange={e => {
+                    const val = e.target.value === '' ? undefined : Math.round(parseFloat(e.target.value) * 1000000)
+                    setDraft({
+                      ...current,
+                      max_cost_micros: val,
+                    })
+                  }}
+                  className="w-full rounded border border-border-default bg-surface-0 px-3 py-2 text-sm text-text-primary placeholder:text-text-disabled"
+                />
+              </label>
+              <label className="block space-y-1">
+                <span className="text-xs text-text-tertiary">Max Tokens</span>
+                <input
+                  type="number"
+                  step="1000"
+                  min="0"
+                  placeholder="Unlimited"
+                  value={
+                    current.max_tokens !== undefined && current.max_tokens !== null
+                      ? current.max_tokens
+                      : ''
+                  }
+                  onChange={e => {
+                    const val = e.target.value === '' ? undefined : parseInt(e.target.value, 10)
+                    setDraft({
+                      ...current,
+                      max_tokens: val,
+                    })
+                  }}
+                  className="w-full rounded border border-border-default bg-surface-0 px-3 py-2 text-sm text-text-primary placeholder:text-text-disabled"
+                />
+              </label>
+            </div>
+          </div>
           <div className="flex justify-end">
             <button
               onClick={() => saveMut.mutate(current)}


### PR DESCRIPTION
## Description

This PR implements **Smart Token Budgeting** and **Rate-Limit Throttling/Queueing** within Clawvisor's LLM proxy flow. These layers protect developers from runaway agent loops (such as Claude Code) by enforcing maximum cost (USD) and token budget limits at both the Task and Agent levels. Additionally, it applies auto-throttling by tracking upstream rate-limit headers.

---

## Key Features

### 1. Store & Database Extensions
- Added migrations for SQLite and Postgres introducing `max_cost_micros` and `max_tokens` columns to the `tasks` and `agent_runtime_settings` tables.
- Implemented DB store mappings and a new cost aggregation query (`GetAgentCost`) to compute cumulative agent/task spends on demand.

### 2. Pre-Request Interceptor & Throttling
- **Soft-Block Warn**: Intercepts requests when accumulated costs/tokens hit 90% of the limit. It returns a synthetic HTTP 200 assistant message containing a `StageBudgetWarning` hold and prompts the user in-band. Replying `y` or `approve` registers a 10-minute override cache token.
- **Hard-Block Refusal**: Fully rejects incoming LLM queries with an HTTP 200 assistant refusal turn if task or agent budget limits are exceeded, preventing upstream dispatch.
- **Auto-Throttling**: A thread-safe `RateLimitTracker` parses reset/remaining headers from Anthropic/OpenAI responses. If remaining limits fall below 10%, proxy threads are temporarily delayed (capped at 5s).

### 3. History Stripping
- Updated the history compiler to strip Clawvisor's budget warning notices and the user's `y`/`approve` release replies from message chains. This prevents upstream LLMs from seeing internal gateway scaffolding.

### 4. React Dashboard UI
- **Agents Page**: Added budget configuration inputs for Max Cost (USD) and Max Tokens inside the `AgentRuntimePanel`.
- **Tasks Page & TaskCard**: Enabled prefetching for budgeted tasks and updated the card UI to render spent vs limit metrics. Added visual progress bars inside the task's Cost panel that transition color (green -> amber -> red) based on threshold status.

---

## Verifications & Tests

- **Backend Unit & Integration Tests**: 
  - Verified SQLite/Postgres aggregations (`go test ./pkg/store/...` - PASS).
  - Verified handler and proxy routing integration flows (`go test ./internal/api/handlers/...` - PASS).
- **Frontend Verification**: 
  - TypeScript compilation and ESLint checks (`npm run lint` - PASS).
  - Production build bundle generation (`npm run build` - Vite built successfully).
- **Manual E2E Verification**:
  - Confirmed 100% hard-blocking at the proxy boundary, dashboard limit adjustment to resume, and 90% soft-blocking release via in-band console response (`y`).
  
## Screenshots

<img width="1919" height="925" alt="Screenshot 2026-06-03 174438" src="https://github.com/user-attachments/assets/57dbbc9f-48df-40a2-9573-0b2a37cd1f70" />
