### PR TITLE
fix(llmproxy): preserve empty `thinking` field on thinking_delta re-emit

### DIFF
--- a/internal/runtime/conversation/anthropic_response.go
+++ b/internal/runtime/conversation/anthropic_response.go
@@ -1251,11 +1251,6 @@ func (rw AnthropicResponseRewriter) StreamRewrite(ctx context.Context, r io.Read
 				}
 				return nil
 			}
-			cbd.Index = pb.index
-			rewrittenData, err := json.Marshal(cbd)
-			if err != nil {
-				return err
-			}
 			switch cbd.Delta.Type {
 			case "text_delta":
 				pb.text.WriteString(cbd.Delta.Text)
@@ -1264,7 +1259,21 @@ func (rw AnthropicResponseRewriter) StreamRewrite(ctx context.Context, r io.Read
 			case "signature_delta":
 				pb.signature += cbd.Delta.Signature
 			}
-			return writeSSE(event, string(rewrittenData))
+			// Pass the original delta data through byte-for-byte, only
+			// rewriting the index field. Re-marshalling via the typed
+			// struct above would drop empty payload fields due to
+			// `omitempty` — e.g. a `thinking_delta` with `"thinking":""`
+			// becomes `{"type":"thinking_delta"}`, which the harness then
+			// reads as `delta.thinking === undefined` and concatenates as
+			// the literal string "undefined" into stored history.
+			if pb.index == cbd.Index {
+				return writeSSE(event, data)
+			}
+			shifted, ok := shiftAnthropicEventIndex(event, data, pb.index-cbd.Index)
+			if !ok {
+				return writeSSE(event, data)
+			}
+			return writeSSE(event, string(shifted))
 
 		case "content_block_stop":
 			var cbs struct {

--- a/internal/runtime/conversation/response_test.go
+++ b/internal/runtime/conversation/response_test.go
@@ -638,6 +638,63 @@ func TestAnthropicStreamRewritePreservesThinkingBlocks(t *testing.T) {
 	}
 }
 
+// Regression: a thinking_delta event with an empty `thinking` field must
+// be passed through with the field intact. Previously the rewriter
+// round-tripped the delta through a typed struct where `Thinking` had
+// `,omitempty`, so an empty value was dropped on re-marshal. Claude
+// Code's harness reads `delta.thinking` unconditionally on
+// thinking_delta events; a missing field reads as `undefined`, which
+// JS coerces to the literal string "undefined" and concatenates into
+// the stored thinking text — corrupting the assistant turn and
+// triggering Anthropic's "thinking blocks cannot be modified" 400 on
+// the next request that includes the turn.
+func TestAnthropicStreamRewritePreservesEmptyThinkingDeltaField(t *testing.T) {
+	t.Parallel()
+
+	input := strings.Join([]string{
+		`event: message_start`,
+		`data: {"type":"message_start","message":{"id":"msg_x","type":"message","role":"assistant","model":"claude-3-5-sonnet","content":[]}}`,
+		``,
+		`event: content_block_start`,
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":"","signature":""}}`,
+		``,
+		`event: content_block_delta`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":""}}`,
+		``,
+		`event: content_block_delta`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig123"}}`,
+		``,
+		`event: content_block_stop`,
+		`data: {"type":"content_block_stop","index":0}`,
+		``,
+		`event: content_block_start`,
+		`data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}`,
+		``,
+		`event: content_block_delta`,
+		`data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"hi"}}`,
+		``,
+		`event: content_block_stop`,
+		`data: {"type":"content_block_stop","index":1}`,
+		``,
+		`event: message_delta`,
+		`data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":1}}`,
+		``,
+		`event: message_stop`,
+		`data: {"type":"message_stop"}`,
+		``,
+	}, "\n")
+
+	var output bytes.Buffer
+	if _, err := (AnthropicResponseRewriter{}).StreamRewrite(context.Background(), strings.NewReader(input), &output); err != nil {
+		t.Fatalf("StreamRewrite: %v", err)
+	}
+	out := output.String()
+
+	if !strings.Contains(out, `"type":"thinking_delta","thinking":""`) {
+		t.Fatalf("thinking_delta should retain explicit empty `thinking` field, got:\n%s", out)
+	}
+}
+
 func TestAnthropicStreamRewriteDropsNonClaudeThinkingBlocks(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

A `thinking_delta` event with an empty `thinking` field was losing the field on re-emit, which the Claude Code harness reads as `undefined` and concatenates as the literal string `"undefined"` into the stored thinking text. Anthropic then rejects the corrupted assistant turn on the next request with `messages.N.content.M: \`thinking\` or \`redacted_thinking\` blocks in the latest assistant message cannot be modified.`

## Root cause

`AnthropicResponseRewriter.StreamRewrite` in `internal/runtime/conversation/anthropic_response.go` unmarshalled each `content_block_delta` into a typed struct:

```go
Delta struct {
    Type     string `json:"type"`
    Thinking string `json:"thinking,omitempty"`
    ...
}
```

then re-marshalled it via `json.Marshal(cbd)` to emit downstream. When Anthropic sent `{"delta":{"type":"thinking_delta","thinking":""}}` (common for low-effort / signature-only thinking blocks), the `,omitempty` tag dropped the empty `thinking` field, producing `{"delta":{"type":"thinking_delta"}}`. The harness then did roughly `block.thinking += delta.thinking`, with `delta.thinking === undefined`, and stored `thinking: "undefined"` for the turn. Anthropic's signature validation flagged the modified text on the next request.

## Fix

Pass the original delta data through byte-for-byte instead of round-tripping it through the lossy struct. The index field is mutated when filtering shifts block positions, using the existing `shiftAnthropicEventIndex` helper. The `pendingBlock` accumulator still reads from the parsed struct — the change is only on the emit side.

## Relation to #507

#507 fixed the related but distinct bug where the leading first-turn notice shifted thinking off index 0, which the harness misclassified entirely (resulting in much longer `"undefined"` soup from every shifted delta). With #507 landed, thinking blocks stay at index 0 and the harness reads them correctly — exposing this second, narrower remarshal corruption. Diagnosed by checking the raw log: a fresh post-#507 session still produced `"thinking": "undefined"` in stored history, traced via the `harness_response` SSE bytes to a `thinking_delta` event missing its `thinking` field.

## Test plan

- [x] New regression test `TestAnthropicStreamRewritePreservesEmptyThinkingDeltaField` exercises an empty-thinking thinking_delta and asserts the field is present in the output
- [x] Existing `TestAnthropicStreamRewritePreservesThinkingBlocks` still passes (non-empty thinking deltas)
- [x] Full `internal/runtime/conversation/...` test suite passes
- [ ] Verify in raw logs after deploy that fresh sessions no longer produce `"thinking": "undefined"` in stored assistant turns

## Caveat

This stops new corruption. It does not retroactively repair existing on-disk conversation history that already contains `"thinking": "undefined"` blocks — those sessions will keep hitting the Anthropic 400 until restarted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)