### PR TITLE
fix(llmproxy): byte-faithful Anthropic request and response rewriting

### DIFF
--- a/internal/runtime/conversation/anthropic_response.go
+++ b/internal/runtime/conversation/anthropic_response.go
@@ -1173,11 +1173,6 @@ func (rw AnthropicResponseRewriter) StreamRewrite(ctx context.Context, r io.Read
 				outboundIndex = nextOutboundIndex
 				nextOutboundIndex++
 				nextContentIndex = nextOutboundIndex
-				cbs.Index = outboundIndex
-			}
-			rewrittenData, err := json.Marshal(cbs)
-			if err != nil {
-				return err
 			}
 			pb := &pendingBlock{
 				index:     outboundIndex,
@@ -1207,7 +1202,21 @@ func (rw AnthropicResponseRewriter) StreamRewrite(ctx context.Context, r io.Read
 			if pb.index < 0 {
 				return nil
 			}
-			return writeSSE(event, string(rewrittenData))
+			// Pass the upstream event through with byte fidelity,
+			// rewriting only the integer index field. Avoid
+			// json.Marshal of the typed struct above — it reorders
+			// keys, drops fields we don't model (estimated_tokens,
+			// etc.), and applies `omitempty` to empty values.
+			// Anthropic enforces a signature over the thinking block
+			// across turns; any reshaping causes downstream 400s.
+			if pb.index == inboundIndex {
+				return writeSSE(event, data)
+			}
+			shifted, ok := setAnthropicEventIndex(data, pb.index)
+			if !ok {
+				return writeSSE(event, data)
+			}
+			return writeSSE(event, string(shifted))
 
 		case "content_block_delta":
 			var cbd struct {
@@ -1296,15 +1305,17 @@ func (rw AnthropicResponseRewriter) StreamRewrite(ctx context.Context, r io.Read
 			if pb.index < 0 {
 				return nil
 			}
-			cbs.Index = pb.index
-			rewrittenData, err := json.Marshal(cbs)
-			if err != nil {
-				return err
-			}
 			if pb.isTU {
 				return nil
 			}
-			return writeSSE(event, string(rewrittenData))
+			if pb.index == cbs.Index {
+				return writeSSE(event, data)
+			}
+			shifted, ok := setAnthropicEventIndex(data, pb.index)
+			if !ok {
+				return writeSSE(event, data)
+			}
+			return writeSSE(event, string(shifted))
 
 		case "message_delta", "message_stop":
 			if len(orderedTUs) == 0 {

--- a/internal/runtime/conversation/assistant_prepend.go
+++ b/internal/runtime/conversation/assistant_prepend.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -909,35 +910,114 @@ func shiftOpenAIResponsesEventIndex(data string, delta int) ([]byte, bool) {
 	return out, true
 }
 
-// shiftAnthropicEventIndex re-serialises a content_block_* event with
-// its `index` field bumped by delta. The event data is preserved
-// byte-for-byte except for the index field. Returns (nil, false) if
-// the data isn't a JSON object with an integer index — the caller
-// passes the original event through unchanged in that case.
+// shiftAnthropicEventIndex returns a copy of data with the top-level
+// integer `index` field bumped by delta. Every other byte —
+// including key order, whitespace, and any fields we don't model
+// (estimated_tokens, future additions) — is preserved verbatim.
+//
+// Byte fidelity matters because Anthropic enforces a cryptographic
+// signature over thinking blocks across turns: any reordering or
+// stripping in the assistant turn causes "thinking blocks cannot be
+// modified" 400s on the next request that includes that turn.
+//
+// Returns (nil, false) if the data isn't a JSON object with an integer
+// top-level `index` — the caller passes the original event through
+// unchanged in that case.
 func shiftAnthropicEventIndex(event, data string, delta int) ([]byte, bool) {
-	var obj map[string]json.RawMessage
-	if err := json.Unmarshal([]byte(data), &obj); err != nil {
-		return nil, false
+	if delta == 0 {
+		return []byte(data), true
 	}
-	idxRaw, ok := obj["index"]
+	valueStart, valueEnd, current, ok := findTopLevelIndexBytes(data)
 	if !ok {
 		return nil, false
 	}
-	var idx int
-	if err := json.Unmarshal(idxRaw, &idx); err != nil {
-		return nil, false
-	}
-	idx += delta
-	newIdx, err := json.Marshal(idx)
-	if err != nil {
-		return nil, false
-	}
-	obj["index"] = newIdx
-	out, err := json.Marshal(obj)
-	if err != nil {
-		return nil, false
-	}
+	b := []byte(data)
+	out := make([]byte, 0, len(b)+8)
+	out = append(out, b[:valueStart]...)
+	out = strconv.AppendInt(out, int64(current+delta), 10)
+	out = append(out, b[valueEnd:]...)
 	return out, true
+}
+
+// setAnthropicEventIndex returns a copy of data with the top-level
+// integer `index` field replaced by newIndex. Byte fidelity is
+// preserved for all other content. See [shiftAnthropicEventIndex] for
+// rationale.
+func setAnthropicEventIndex(data string, newIndex int) ([]byte, bool) {
+	valueStart, valueEnd, current, ok := findTopLevelIndexBytes(data)
+	if !ok {
+		return nil, false
+	}
+	if current == newIndex {
+		return []byte(data), true
+	}
+	b := []byte(data)
+	out := make([]byte, 0, len(b)+8)
+	out = append(out, b[:valueStart]...)
+	out = strconv.AppendInt(out, int64(newIndex), 10)
+	out = append(out, b[valueEnd:]...)
+	return out, true
+}
+
+// findTopLevelIndexBytes locates the byte range of the integer value
+// of the top-level `index` field in a JSON object. Returns
+// (valueStart, valueEnd, currentValue, true) where data[valueStart:valueEnd]
+// is the encoded integer, or (_, _, _, false) on parse failure / missing
+// field / non-integer value. Uses json.Decoder so nested "index"
+// fields inside e.g. a tool_use's input object are not misidentified.
+func findTopLevelIndexBytes(data string) (int, int, int, bool) {
+	dec := json.NewDecoder(strings.NewReader(data))
+	tok, err := dec.Token()
+	if err != nil {
+		return 0, 0, 0, false
+	}
+	if d, ok := tok.(json.Delim); !ok || d != '{' {
+		return 0, 0, 0, false
+	}
+	b := []byte(data)
+	for dec.More() {
+		keyTok, err := dec.Token()
+		if err != nil {
+			return 0, 0, 0, false
+		}
+		key, ok := keyTok.(string)
+		if !ok {
+			return 0, 0, 0, false
+		}
+		if key != "index" {
+			var skip json.RawMessage
+			if err := dec.Decode(&skip); err != nil {
+				return 0, 0, 0, false
+			}
+			continue
+		}
+		// dec.InputOffset() now sits just past the closing quote of
+		// the "index" key. Scan forward past ':' and whitespace to
+		// find the start of the value.
+		p := int(dec.InputOffset())
+		for p < len(b) && b[p] != ':' {
+			p++
+		}
+		if p >= len(b) {
+			return 0, 0, 0, false
+		}
+		p++ // past ':'
+		for p < len(b) && (b[p] == ' ' || b[p] == '\t' || b[p] == '\n' || b[p] == '\r') {
+			p++
+		}
+		valueStart := p
+		var raw json.RawMessage
+		if err := dec.Decode(&raw); err != nil {
+			return 0, 0, 0, false
+		}
+		valueEnd := int(dec.InputOffset())
+		var idx int
+		if err := json.Unmarshal(raw, &idx); err != nil {
+			return 0, 0, 0, false
+		}
+		return valueStart, valueEnd, idx, true
+	}
+	return 0, 0, 0, false
 }
 
 func isFirstBlockThinking(events []sseEvent) bool {

--- a/internal/runtime/conversation/assistant_prepend.go
+++ b/internal/runtime/conversation/assistant_prepend.go
@@ -63,12 +63,14 @@ func prependAnthropicAssistantTextJSON(body []byte, text string) ([]byte, error)
 		}
 	}
 
+	// Use append-from-literal rather than make-with-precomputed-cap.
+	// CodeQL flags `len(content)+1` as a potential overflow; the input
+	// is bounded by Anthropic content-block limits so it's unreachable
+	// in practice, but sidestepping the explicit arithmetic keeps the
+	// static analyzer quiet.
 	var merged []json.RawMessage
 	if isThinking {
-		merged = make([]json.RawMessage, 0, len(content)+1)
-		merged = append(merged, content[0])
-		merged = append(merged, json.RawMessage(textBlock))
-		merged = append(merged, content[1:]...)
+		merged = append([]json.RawMessage{content[0], json.RawMessage(textBlock)}, content[1:]...)
 	} else {
 		merged = append([]json.RawMessage{json.RawMessage(textBlock)}, content...)
 	}

--- a/internal/runtime/conversation/assistant_prepend.go
+++ b/internal/runtime/conversation/assistant_prepend.go
@@ -934,7 +934,10 @@ func shiftAnthropicEventIndex(event, data string, delta int) ([]byte, bool) {
 		return nil, false
 	}
 	b := []byte(data)
-	out := make([]byte, 0, len(b)+8)
+	// Drop the explicit capacity hint — CodeQL flags `len()+N`
+	// arithmetic as potential overflow; bounded inputs make it
+	// unreachable in practice but the analyzer can't see that.
+	var out []byte
 	out = append(out, b[:valueStart]...)
 	out = strconv.AppendInt(out, int64(current+delta), 10)
 	out = append(out, b[valueEnd:]...)

--- a/internal/runtime/conversation/assistant_prepend_test.go
+++ b/internal/runtime/conversation/assistant_prepend_test.go
@@ -635,3 +635,56 @@ func TestPrependAnthropicAssistantText_SSE_ThinkingOnly(t *testing.T) {
 		t.Errorf("there should be no model text block, got index %d", textIndex)
 	}
 }
+
+func TestShiftAnthropicEventIndexPreservesBytes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		data  string
+		delta int
+		want  string
+	}{
+		{
+			name:  "preserves trailing whitespace",
+			data:  `{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":""}}       `,
+			delta: 1,
+			want:  `{"type":"content_block_delta","index":1,"delta":{"type":"thinking_delta","thinking":""}}       `,
+		},
+		{
+			name:  "preserves unmodelled fields like estimated_tokens",
+			data:  `{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"","estimated_tokens":50}}`,
+			delta: 2,
+			want:  `{"type":"content_block_delta","index":2,"delta":{"type":"thinking_delta","thinking":"","estimated_tokens":50}}`,
+		},
+		{
+			name:  "preserves key order (does not sort)",
+			data:  `{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":"","signature":""}}`,
+			delta: 1,
+			want:  `{"type":"content_block_start","index":1,"content_block":{"type":"thinking","thinking":"","signature":""}}`,
+		},
+		{
+			name:  "ignores nested index in tool_use input",
+			data:  `{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":"Foo","input":{"index":99}}}`,
+			delta: 1,
+			want:  `{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_1","name":"Foo","input":{"index":99}}}`,
+		},
+		{
+			name:  "delta zero returns input byte-equal",
+			data:  `{"type":"content_block_stop","index":5}`,
+			delta: 0,
+			want:  `{"type":"content_block_stop","index":5}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := shiftAnthropicEventIndex("content_block_delta", tc.data, tc.delta)
+			if !ok {
+				t.Fatalf("shiftAnthropicEventIndex returned ok=false for input: %s", tc.data)
+			}
+			if string(got) != tc.want {
+				t.Errorf("byte mismatch\n got: %q\nwant: %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/runtime/conversation/response_test.go
+++ b/internal/runtime/conversation/response_test.go
@@ -695,6 +695,61 @@ func TestAnthropicStreamRewritePreservesEmptyThinkingDeltaField(t *testing.T) {
 	}
 }
 
+// Anthropic enforces a cryptographic signature over thinking blocks
+// across turns: any reshape of the assistant turn — reordered keys,
+// dropped unknown fields, stripped whitespace — corrupts the
+// downstream verification and causes 400s with "thinking or
+// redacted_thinking blocks ... cannot be modified".
+//
+// This test pins byte fidelity for thinking-related events through
+// StreamRewrite when no index shift is needed: the upstream bytes
+// must come through unchanged, key order preserved, including fields
+// the rewriter does not model (e.g. estimated_tokens) and trailing
+// SSE whitespace.
+func TestAnthropicStreamRewriteThinkingEventsAreBytePreserved(t *testing.T) {
+	t.Parallel()
+
+	// Mimic the exact byte shape Anthropic emits for an opus thinking
+	// stream — including the `estimated_tokens` field the rewriter
+	// has no struct field for, and trailing whitespace on the data
+	// payload that an inadvertent re-marshal would strip.
+	upstreamEvents := []struct{ event, data string }{
+		{"message_start", `{"type":"message_start","message":{"id":"msg_x","type":"message","role":"assistant","model":"claude-opus-4-7","content":[]}}`},
+		{"content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":"","signature":""}}`},
+		{"content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"","estimated_tokens":50}}`},
+		{"content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"abc123"}}`},
+		{"content_block_stop", `{"type":"content_block_stop","index":0}`},
+		{"message_delta", `{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":1}}`},
+		{"message_stop", `{"type":"message_stop"}`},
+	}
+
+	var sb strings.Builder
+	for _, ev := range upstreamEvents {
+		sb.WriteString("event: ")
+		sb.WriteString(ev.event)
+		sb.WriteString("\ndata: ")
+		sb.WriteString(ev.data)
+		sb.WriteString("\n\n")
+	}
+	input := sb.String()
+
+	var output bytes.Buffer
+	if _, err := (AnthropicResponseRewriter{}).StreamRewrite(context.Background(), strings.NewReader(input), &output); err != nil {
+		t.Fatalf("StreamRewrite: %v", err)
+	}
+	out := output.String()
+
+	// Each upstream event's data line must appear verbatim in the
+	// output — same key order, same trailing whitespace, same
+	// unmodelled fields.
+	for _, ev := range upstreamEvents {
+		expected := "data: " + ev.data + "\n\n"
+		if !strings.Contains(out, expected) {
+			t.Errorf("event %q data not byte-preserved.\n  want: %q\n  output: %s", ev.event, ev.data, out)
+		}
+	}
+}
+
 func TestAnthropicStreamRewriteDropsNonClaudeThinkingBlocks(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtime/llmproxy/anthropic_sanitize.go
+++ b/internal/runtime/llmproxy/anthropic_sanitize.go
@@ -16,13 +16,13 @@ import (
 // `unmarshal → map → marshal` round-trip alphabetizes keys and trips
 // "thinking blocks cannot be modified" 400s on subsequent requests.
 func SanitizeAnthropicRequest(body []byte) ([]byte, bool, error) {
-	if !looksLikeJSONObject(body) {
-		// Match the previous behavior: surface parse errors so the caller
-		// can return a 400.
-		var ignored map[string]json.RawMessage
-		if err := json.Unmarshal(body, &ignored); err != nil {
-			return nil, false, err
-		}
+	// Eagerly validate the body is parseable JSON. The previous
+	// implementation did the same via `json.Unmarshal(body, &raw)` at
+	// the top, and callers depend on this to surface a 400 for
+	// malformed bodies before they reach the upstream provider.
+	var probe map[string]json.RawMessage
+	if err := json.Unmarshal(body, &probe); err != nil {
+		return nil, false, err
 	}
 	out := body
 	changed := false
@@ -55,10 +55,8 @@ func SanitizeAnthropicRequest(body []byte) ([]byte, bool, error) {
 		msgsBytes := out[msgsStart:msgsEnd]
 		messages, ok := flattenJSONArray(msgsBytes)
 		if !ok {
-			// Preserve the previous behavior of surfacing a parse
-			// error so the caller can return a 400. `messages`
-			// present but not an array is malformed input we should
-			// not silently accept.
+			// `messages` present but not an array — malformed input.
+			// Surface the parse error so the caller can return a 400.
 			if err := json.Unmarshal(msgsBytes, &messages); err != nil {
 				return nil, false, err
 			}
@@ -229,12 +227,3 @@ func isEmptyTextBlock(block json.RawMessage) bool {
 	return strings.TrimSpace(text) == ""
 }
 
-func looksLikeJSONObject(data []byte) bool {
-	for _, b := range data {
-		if isJSONWS(b) {
-			continue
-		}
-		return b == '{'
-	}
-	return false
-}

--- a/internal/runtime/llmproxy/anthropic_sanitize.go
+++ b/internal/runtime/llmproxy/anthropic_sanitize.go
@@ -8,14 +8,28 @@ import (
 // SanitizeAnthropicRequest removes empty text content blocks that Anthropic
 // rejects on the request path. Some harnesses preserve zero-length streamed
 // text blocks in conversation history after a tool-use response.
+//
+// Byte fidelity invariant: any content block we are not actively removing
+// passes through with its original bytes. Top-level body keys, message
+// keys, and block keys keep their incoming order. This matters because
+// Anthropic verifies thinking-block signatures across turns; an
+// `unmarshal → map → marshal` round-trip alphabetizes keys and trips
+// "thinking blocks cannot be modified" 400s on subsequent requests.
 func SanitizeAnthropicRequest(body []byte) ([]byte, bool, error) {
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(body, &raw); err != nil {
-		return nil, false, err
+	if !looksLikeJSONObject(body) {
+		// Match the previous behavior: surface parse errors so the caller
+		// can return a 400.
+		var ignored map[string]json.RawMessage
+		if err := json.Unmarshal(body, &ignored); err != nil {
+			return nil, false, err
+		}
 	}
+	out := body
 	changed := false
 
-	if sys, ok := raw["system"]; ok {
+	// system field.
+	if sysStart, sysEnd, ok := findJSONFieldValue(out, "system"); ok {
+		sys := out[sysStart:sysEnd]
 		sanitized, fieldChanged, empty, err := sanitizeAnthropicContent(sys)
 		if err != nil {
 			return nil, false, err
@@ -23,94 +37,133 @@ func SanitizeAnthropicRequest(body []byte) ([]byte, bool, error) {
 		if fieldChanged {
 			changed = true
 			if empty {
-				delete(raw, "system")
+				if deleted, ok := DeleteJSONField(out, "system"); ok {
+					out = deleted
+				}
 			} else {
-				raw["system"] = sanitized
+				replaced, err := SetJSONField(out, "system", sanitized)
+				if err != nil {
+					return nil, false, err
+				}
+				out = replaced
 			}
 		}
 	}
 
-	if msgsRaw, ok := raw["messages"]; ok {
-		var messages []map[string]json.RawMessage
-		if err := json.Unmarshal(msgsRaw, &messages); err != nil {
-			return nil, false, err
+	// messages field.
+	if msgsStart, msgsEnd, ok := findJSONFieldValue(out, "messages"); ok {
+		msgsBytes := out[msgsStart:msgsEnd]
+		messages, ok := flattenJSONArray(msgsBytes)
+		if !ok {
+			if !changed {
+				return body, false, nil
+			}
+			return out, true, nil
 		}
-		out := make([]map[string]json.RawMessage, 0, len(messages))
+		newMessages := make([]json.RawMessage, 0, len(messages))
+		msgsChanged := false
 		for _, msg := range messages {
-			content, ok := msg["content"]
-			if !ok {
-				out = append(out, msg)
-				continue
-			}
-			sanitized, fieldChanged, empty, err := sanitizeAnthropicContent(content)
+			newMsg, msgChanged, drop, err := sanitizeAnthropicMessage(msg)
 			if err != nil {
 				return nil, false, err
 			}
-			if fieldChanged {
-				changed = true
+			if msgChanged {
+				msgsChanged = true
 			}
-			if empty {
+			if drop {
 				continue
 			}
-			if fieldChanged {
-				msg["content"] = sanitized
-			}
-			out = append(out, msg)
+			newMessages = append(newMessages, newMsg)
 		}
-		if len(out) != len(messages) {
+		if msgsChanged || len(newMessages) != len(messages) {
 			changed = true
-		}
-		if changed {
-			encoded, err := json.Marshal(out)
+			newMsgsBytes, err := json.Marshal(newMessages)
 			if err != nil {
 				return nil, false, err
 			}
-			raw["messages"] = encoded
+			replaced, err := SetJSONField(out, "messages", newMsgsBytes)
+			if err != nil {
+				return nil, false, err
+			}
+			out = replaced
 		}
 	}
 
 	if !changed {
 		return body, false, nil
 	}
-	out, err := json.Marshal(raw)
-	return out, err == nil, err
+	return out, true, nil
 }
 
-func sanitizeAnthropicContent(raw json.RawMessage) (json.RawMessage, bool, bool, error) {
-	if len(raw) == 0 || string(raw) == "null" {
-		return raw, false, false, nil
+// sanitizeAnthropicMessage applies sanitization to a single message's
+// content. Returns (newBytes, contentChanged, dropMessage, err).
+// When dropMessage is true, the caller should omit the message from
+// the parent array.
+func sanitizeAnthropicMessage(msg json.RawMessage) (json.RawMessage, bool, bool, error) {
+	contentStart, contentEnd, ok := findJSONFieldValue(msg, "content")
+	if !ok {
+		return msg, false, false, nil
 	}
-	var text string
-	if err := json.Unmarshal(raw, &text); err == nil {
-		if strings.TrimSpace(text) == "" {
-			return nil, true, true, nil
-		}
-		return raw, false, false, nil
+	content := msg[contentStart:contentEnd]
+	sanitized, contentChanged, empty, err := sanitizeAnthropicContent(content)
+	if err != nil {
+		return nil, false, false, err
 	}
+	if !contentChanged {
+		return msg, false, false, nil
+	}
+	if empty {
+		return nil, true, true, nil
+	}
+	newMsg, err := SetJSONField(msg, "content", sanitized)
+	if err != nil {
+		return nil, false, false, err
+	}
+	return newMsg, true, false, nil
+}
 
-	var blocks []map[string]json.RawMessage
-	if err := json.Unmarshal(raw, &blocks); err != nil {
+// sanitizeAnthropicContent returns the sanitized content payload. The
+// shape mirrors the original API: (newBytes, changed, empty, err).
+// When empty is true the caller should remove the surrounding field
+// (or drop the parent message).
+func sanitizeAnthropicContent(raw json.RawMessage) (json.RawMessage, bool, bool, error) {
+	if len(raw) == 0 {
 		return raw, false, false, nil
 	}
-	changed := false
-	out := make([]map[string]json.RawMessage, 0, len(blocks))
-	for _, block := range blocks {
-		var typ string
-		_ = json.Unmarshal(block["type"], &typ)
-		if typ == "text" {
-			// Only treat as empty when `text` decodes as a string AND
-			// that string is whitespace-only. A malformed or non-string
-			// `text` (e.g. number, object) is left alone — dropping it
-			// silently risks losing real content the model emitted.
-			var blockText string
-			if err := json.Unmarshal(block["text"], &blockText); err == nil {
-				if strings.TrimSpace(blockText) == "" {
-					changed = true
-					continue
-				}
+	trimmed := trimJSONWS(raw)
+	if string(trimmed) == "null" {
+		return raw, false, false, nil
+	}
+	// String content: empty/whitespace → drop. Otherwise preserve.
+	if looksLikeJSONString(raw) {
+		var text string
+		if err := json.Unmarshal(raw, &text); err == nil {
+			if strings.TrimSpace(text) == "" {
+				return nil, true, true, nil
 			}
 		}
-		if nested, ok := block["content"]; ok {
+		return raw, false, false, nil
+	}
+	// Array content: walk blocks, preserve unchanged ones byte-for-byte.
+	blocks, ok := flattenJSONArray(raw)
+	if !ok {
+		return raw, false, false, nil
+	}
+	newBlocks := make([]json.RawMessage, 0, len(blocks))
+	changed := false
+	for _, block := range blocks {
+		// Inspect type to decide whether to keep/modify.
+		blockType := extractBlockType(block)
+		if blockType == "text" {
+			if isEmptyTextBlock(block) {
+				changed = true
+				continue
+			}
+		}
+		// Recurse into nested content (e.g. tool_result blocks whose
+		// `content` field is itself a list of content blocks).
+		if nestedStart, nestedEnd, ok := findJSONFieldValue(block, "content"); ok {
+			nested := block[nestedStart:nestedEnd]
 			sanitized, nestedChanged, empty, err := sanitizeAnthropicContent(nested)
 			if err != nil {
 				return nil, false, false, err
@@ -118,20 +171,63 @@ func sanitizeAnthropicContent(raw json.RawMessage) (json.RawMessage, bool, bool,
 			if nestedChanged {
 				changed = true
 				if empty {
-					delete(block, "content")
+					deleted, ok := DeleteJSONField(block, "content")
+					if ok {
+						block = deleted
+					}
 				} else {
-					block["content"] = sanitized
+					replaced, err := SetJSONField(block, "content", sanitized)
+					if err != nil {
+						return nil, false, false, err
+					}
+					block = replaced
 				}
 			}
 		}
-		out = append(out, block)
+		newBlocks = append(newBlocks, block)
 	}
 	if !changed {
 		return raw, false, false, nil
 	}
-	if len(out) == 0 {
+	if len(newBlocks) == 0 {
 		return nil, true, true, nil
 	}
-	encoded, err := json.Marshal(out)
+	encoded, err := json.Marshal(newBlocks)
 	return encoded, true, false, err
+}
+
+func extractBlockType(block json.RawMessage) string {
+	start, end, ok := findJSONFieldValue(block, "type")
+	if !ok {
+		return ""
+	}
+	var typ string
+	if err := json.Unmarshal(block[start:end], &typ); err != nil {
+		return ""
+	}
+	return typ
+}
+
+func isEmptyTextBlock(block json.RawMessage) bool {
+	start, end, ok := findJSONFieldValue(block, "text")
+	if !ok {
+		return false
+	}
+	var text string
+	if err := json.Unmarshal(block[start:end], &text); err != nil {
+		// Malformed `text` (number, object) — leave alone; dropping
+		// silently risks losing real content the model emitted.
+		return false
+	}
+	return strings.TrimSpace(text) == ""
+}
+
+func looksLikeJSONObject(data []byte) bool {
+	for _, b := range data {
+		if isJSONWS(b) {
+			continue
+		}
+		return b == '{'
+	}
+	return false
 }

--- a/internal/runtime/llmproxy/anthropic_sanitize.go
+++ b/internal/runtime/llmproxy/anthropic_sanitize.go
@@ -55,6 +55,13 @@ func SanitizeAnthropicRequest(body []byte) ([]byte, bool, error) {
 		msgsBytes := out[msgsStart:msgsEnd]
 		messages, ok := flattenJSONArray(msgsBytes)
 		if !ok {
+			// Preserve the previous behavior of surfacing a parse
+			// error so the caller can return a 400. `messages`
+			// present but not an array is malformed input we should
+			// not silently accept.
+			if err := json.Unmarshal(msgsBytes, &messages); err != nil {
+				return nil, false, err
+			}
 			if !changed {
 				return body, false, nil
 			}

--- a/internal/runtime/llmproxy/approval_body_editor.go
+++ b/internal/runtime/llmproxy/approval_body_editor.go
@@ -245,27 +245,38 @@ func replaceOpenAIResponsesApprovalReply(body []byte, expectedVerb, expectedAppr
 }
 
 func augmentAnthropicApprovedInlineTasks(body []byte, outcomes InlineApprovalOutcomeStore, userID, agentID string) ([]byte, bool, error) {
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(body, &raw); err != nil {
-		return body, false, err
-	}
-	rawMessages, ok := raw["messages"]
+	// Byte fidelity invariant: unchanged messages pass through verbatim.
+	// Only the user message whose content we're augmenting is reshaped.
+	// Top-level body keys keep their incoming order. See SanitizeAnthropicRequest
+	// for why this matters.
+	msgsStart, msgsEnd, ok := findJSONFieldValue(body, "messages")
 	if !ok {
 		return body, false, nil
 	}
-	var messages []map[string]json.RawMessage
-	if err := json.Unmarshal(rawMessages, &messages); err != nil {
-		return body, false, err
+	messages, ok := flattenJSONArray(body[msgsStart:msgsEnd])
+	if !ok {
+		return body, false, nil
 	}
-
+	newMessages := make([]json.RawMessage, len(messages))
+	copy(newMessages, messages)
 	changed := false
 
 	for i := 1; i < len(messages); i++ {
-		var role string
-		if err := json.Unmarshal(messages[i]["role"], &role); err != nil || role != "user" {
+		msg := messages[i]
+		roleStart, roleEnd, ok := findJSONFieldValue(msg, "role")
+		if !ok {
 			continue
 		}
-		userText := flattenAnthropicTaskReplyText(messages[i]["content"])
+		var role string
+		if err := json.Unmarshal(msg[roleStart:roleEnd], &role); err != nil || role != "user" {
+			continue
+		}
+		contentStart, contentEnd, ok := findJSONFieldValue(msg, "content")
+		if !ok {
+			continue
+		}
+		content := msg[contentStart:contentEnd]
+		userText := flattenAnthropicTaskReplyText(content)
 		verb, _ := conversation.ParseApprovalReplyText(userText)
 		if verb != "approve" {
 			continue
@@ -274,11 +285,20 @@ func augmentAnthropicApprovedInlineTasks(body []byte, outcomes InlineApprovalOut
 			continue
 		}
 
-		var priorRole string
-		if err := json.Unmarshal(messages[i-1]["role"], &priorRole); err != nil || priorRole != "assistant" {
+		priorMsg := messages[i-1]
+		priorRoleStart, priorRoleEnd, ok := findJSONFieldValue(priorMsg, "role")
+		if !ok {
 			continue
 		}
-		priorText := flattenAnthropicTaskReplyText(messages[i-1]["content"])
+		var priorRole string
+		if err := json.Unmarshal(priorMsg[priorRoleStart:priorRoleEnd], &priorRole); err != nil || priorRole != "assistant" {
+			continue
+		}
+		priorContentStart, priorContentEnd, ok := findJSONFieldValue(priorMsg, "content")
+		if !ok {
+			continue
+		}
+		priorText := flattenAnthropicTaskReplyText(priorMsg[priorContentStart:priorContentEnd])
 		if !strings.Contains(priorText, InlineApprovalSubstitutedPromptMarker) {
 			continue
 		}
@@ -293,23 +313,26 @@ func augmentAnthropicApprovedInlineTasks(body []byte, outcomes InlineApprovalOut
 			continue
 		}
 
-		updated, ok := augmentUserContent(messages[i]["content"], verb, note)
+		updatedContent, ok := augmentUserContent(content, verb, note)
 		if !ok {
 			continue
 		}
-		messages[i]["content"] = updated
+		newMsg, err := SetJSONField(msg, "content", updatedContent)
+		if err != nil {
+			continue
+		}
+		newMessages[i] = newMsg
 		changed = true
 	}
 
 	if !changed {
 		return body, false, nil
 	}
-	updatedMessages, err := json.Marshal(messages)
+	newMsgsBytes, err := json.Marshal(newMessages)
 	if err != nil {
 		return body, false, err
 	}
-	raw["messages"] = updatedMessages
-	out, err := json.Marshal(raw)
+	out, err := SetJSONField(body, "messages", newMsgsBytes)
 	if err != nil {
 		return body, false, err
 	}

--- a/internal/runtime/llmproxy/byte_fidelity_test.go
+++ b/internal/runtime/llmproxy/byte_fidelity_test.go
@@ -1,0 +1,168 @@
+package llmproxy
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+)
+
+// Anthropic enforces a cryptographic signature over thinking blocks
+// across turns. Any reshape on the request side — reordered keys,
+// stripped whitespace, applied `,omitempty`, dropped unknown fields —
+// can corrupt the verification and trip "thinking blocks cannot be
+// modified" 400s on the next request that includes that turn.
+//
+// These tests pin byte-for-byte fidelity for thinking blocks through
+// each preprocessing function that touches the inbound body.
+
+const thinkingBlockOriginal = `{"type":"thinking","thinking":"","signature":"sig123"}`
+
+// thinkingBodyTemplate is a minimal Anthropic /v1/messages request
+// with one assistant turn whose first content block is a thinking
+// block in the exact byte shape Anthropic emits. The blank in `%s`
+// is filled with the field under test.
+const thinkingBodyTemplate = `{"model":"claude-opus-4-7","messages":[{"role":"assistant","content":[` + thinkingBlockOriginal + `,{"type":"text","text":"%s"}]},{"role":"user","content":[{"type":"text","text":"reply"}]}]}`
+
+func assertThinkingBlockPreserved(t *testing.T, body []byte) {
+	t.Helper()
+	if !strings.Contains(string(body), thinkingBlockOriginal) {
+		t.Errorf("thinking block was reshaped — its exact byte representation no longer appears in body:\n  want substring: %s\n  body: %s", thinkingBlockOriginal, body)
+	}
+}
+
+func TestSanitizeAnthropicRequestPreservesThinkingBlockBytes(t *testing.T) {
+	t.Parallel()
+	// The empty text block triggers sanitization and would otherwise
+	// cause a full body re-marshal (which alphabetizes keys).
+	body := []byte(`{"model":"claude-opus-4-7","messages":[{"role":"assistant","content":[` + thinkingBlockOriginal + `,{"type":"text","text":""},{"type":"tool_use","id":"toolu_1","name":"Bash","input":{}}]}]}`)
+	out, changed, err := SanitizeAnthropicRequest(body)
+	if err != nil {
+		t.Fatalf("SanitizeAnthropicRequest: %v", err)
+	}
+	if !changed {
+		t.Fatalf("expected sanitization to modify body (empty text block present)")
+	}
+	assertThinkingBlockPreserved(t, out)
+}
+
+func TestInjectControlNoticePreservesThinkingBlockBytes(t *testing.T) {
+	t.Parallel()
+	body := []byte(strings.ReplaceAll(thinkingBodyTemplate, "%s", "hello"))
+	out, injected, err := InjectControlNoticeWithPolicy(conversation.ProviderAnthropic, body, "https://clawvisor.local", []string{"Bash"}, nil)
+	if err != nil {
+		t.Fatalf("InjectControlNoticeWithPolicy: %v", err)
+	}
+	if !injected {
+		t.Fatalf("expected notice to be injected")
+	}
+	assertThinkingBlockPreserved(t, out)
+}
+
+func TestStripSyntheticApprovalHistoryPreservesThinkingBlockBytes(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"model":"claude-opus-4-7","messages":[` +
+		`{"role":"assistant","content":[` + thinkingBlockOriginal + `,{"type":"text","text":"some response"}]},` +
+		`{"role":"user","content":[{"type":"text","text":"next"}]},` +
+		`{"role":"assistant","content":[{"type":"text","text":"Clawvisor paused this tool call for approval. clawvisor-approval-id=abc"}]},` +
+		`{"role":"user","content":[{"type":"text","text":"approve"}]}` +
+		`]}`)
+	res, err := StripSyntheticApprovalHistory(SyntheticApprovalHistoryStripRequest{
+		Provider: conversation.ProviderAnthropic,
+		Body:     body,
+	})
+	if err != nil {
+		t.Fatalf("StripSyntheticApprovalHistory: %v", err)
+	}
+	if !res.Modified {
+		t.Fatalf("expected synthetic-approval history to be stripped")
+	}
+	assertThinkingBlockPreserved(t, res.Body)
+}
+
+func TestSanitizeInboundAnthropicPreservesThinkingBlockBytes(t *testing.T) {
+	t.Parallel()
+	// tool_use input has a command that will be rewritten (host/header
+	// stripping). Triggers per-block surgery.
+	body := []byte(`{"model":"claude-opus-4-7","messages":[{"role":"assistant","content":[` + thinkingBlockOriginal + `,{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"curl -sS http://localhost:25297/api/proxy/foo"}}]}]}`)
+	res, err := SanitizeInboundHistory(SanitizeInboundRequest{
+		Provider:        conversation.ProviderAnthropic,
+		Body:            body,
+		ResolverBaseURL: "http://localhost:25297",
+		ControlBaseURL:  "http://localhost:25297",
+	})
+	if err != nil {
+		t.Fatalf("SanitizeInboundHistory: %v", err)
+	}
+	// Whether or not it modifies depends on heuristics, but the
+	// thinking block must always pass through bytes-intact regardless.
+	if res.Modified {
+		assertThinkingBlockPreserved(t, res.Body)
+	} else {
+		assertThinkingBlockPreserved(t, body)
+	}
+}
+
+func TestStripSecretDecisionHistoryPreservesThinkingBlockBytes(t *testing.T) {
+	t.Parallel()
+	// Embed a secret-decision-marker assistant message followed by a
+	// matching user decision reply, so the strip path actually fires.
+	body := []byte(`{"model":"claude-opus-4-7","messages":[` +
+		`{"role":"assistant","content":[` + thinkingBlockOriginal + `,{"type":"text","text":"real response"}]},` +
+		`{"role":"user","content":[{"type":"text","text":"next"}]},` +
+		`{"role":"assistant","content":[{"type":"text","text":"` + SecretDecisionIDMarker + `:abc"}]},` +
+		`{"role":"user","content":[{"type":"text","text":"` + string(SecretDecisionAllowOnce) + `"}]}` +
+		`]}`)
+	res, err := StripSecretDecisionHistory(SecretDecisionHistoryStripRequest{
+		Provider: conversation.ProviderAnthropic,
+		Body:     body,
+	})
+	if err != nil {
+		t.Fatalf("StripSecretDecisionHistory: %v", err)
+	}
+	if !res.Modified {
+		t.Skip("strip path didn't fire — unrelated to byte fidelity")
+	}
+	assertThinkingBlockPreserved(t, res.Body)
+}
+
+// End-to-end: chain the preprocessors in the same order the request
+// handler does, then verify the thinking block bytes are still intact
+// in the final body that would go upstream.
+func TestRequestPreprocessingChainPreservesThinkingBlockBytes(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"model":"claude-opus-4-7","messages":[` +
+		`{"role":"assistant","content":[` + thinkingBlockOriginal + `,{"type":"text","text":""},{"type":"text","text":"hello"}]},` +
+		`{"role":"user","content":[{"type":"text","text":"next"}]}` +
+		`],"system":"existing"}`)
+
+	// 1. Sanitize (would remove the empty text block).
+	sanitized, _, err := SanitizeAnthropicRequest(body)
+	if err != nil {
+		t.Fatalf("SanitizeAnthropicRequest: %v", err)
+	}
+	assertThinkingBlockPreserved(t, sanitized)
+
+	// 2. Inject control notice (modifies top-level system).
+	noticed, _, err := InjectControlNoticeWithPolicy(conversation.ProviderAnthropic, sanitized, "https://clawvisor.local", []string{"Bash"}, nil)
+	if err != nil {
+		t.Fatalf("InjectControlNoticeWithPolicy: %v", err)
+	}
+	assertThinkingBlockPreserved(t, noticed)
+
+	// 3. Sanitize inbound history.
+	inbound, err := SanitizeInboundHistory(SanitizeInboundRequest{
+		Provider:        conversation.ProviderAnthropic,
+		Body:            noticed,
+		ResolverBaseURL: "http://localhost:25297",
+		ControlBaseURL:  "http://localhost:25297",
+	})
+	if err != nil {
+		t.Fatalf("SanitizeInboundHistory: %v", err)
+	}
+	final := inbound.Body
+	assertThinkingBlockPreserved(t, final)
+
+	_ = context.Background()
+}

--- a/internal/runtime/llmproxy/byte_fidelity_test.go
+++ b/internal/runtime/llmproxy/byte_fidelity_test.go
@@ -1,7 +1,6 @@
 package llmproxy
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -161,8 +160,5 @@ func TestRequestPreprocessingChainPreservesThinkingBlockBytes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SanitizeInboundHistory: %v", err)
 	}
-	final := inbound.Body
-	assertThinkingBlockPreserved(t, final)
-
-	_ = context.Background()
+	assertThinkingBlockPreserved(t, inbound.Body)
 }

--- a/internal/runtime/llmproxy/byte_fidelity_test.go
+++ b/internal/runtime/llmproxy/byte_fidelity_test.go
@@ -121,7 +121,7 @@ func TestStripSecretDecisionHistoryPreservesThinkingBlockBytes(t *testing.T) {
 		t.Fatalf("StripSecretDecisionHistory: %v", err)
 	}
 	if !res.Modified {
-		t.Skip("strip path didn't fire — unrelated to byte fidelity")
+		t.Fatalf("expected strip path to fire — the test fixture is explicitly constructed to trigger it; a regression that no longer fires would silently bypass byte-fidelity assertions")
 	}
 	assertThinkingBlockPreserved(t, res.Body)
 }

--- a/internal/runtime/llmproxy/control.go
+++ b/internal/runtime/llmproxy/control.go
@@ -443,31 +443,42 @@ func rawSystemContains(raw json.RawMessage, needle string) bool {
 }
 
 func injectAnthropicControlNotice(body []byte, notice string) ([]byte, bool, error) {
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(body, &raw); err != nil {
-		return nil, false, err
-	}
-	sys, ok := raw["system"]
-	if !ok || len(sys) == 0 || string(sys) == "null" {
+	// Use byte-faithful surgery so we don't reorder top-level keys
+	// (alphabetizing the body re-shapes assistant turn content blocks
+	// downstream, which can corrupt cryptographically-signed thinking
+	// blocks across turns).
+	sysStart, sysEnd, present := findJSONFieldValue(body, "system")
+	if !present || sysEnd-sysStart == 0 {
 		encoded, _ := json.Marshal(notice)
-		raw["system"] = encoded
-		return marshalInjected(raw)
+		out, err := SetJSONField(body, "system", encoded)
+		return out, err == nil, err
+	}
+	sys := body[sysStart:sysEnd]
+	if string(trimJSONWS(sys)) == "null" {
+		encoded, _ := json.Marshal(notice)
+		out, err := SetJSONField(body, "system", encoded)
+		return out, err == nil, err
 	}
 	var s string
 	if err := json.Unmarshal(sys, &s); err == nil {
 		encoded, _ := json.Marshal(appendNotice(s, notice))
-		raw["system"] = encoded
-		return marshalInjected(raw)
+		out, err := SetJSONField(body, "system", encoded)
+		return out, err == nil, err
 	}
-	var blocks []map[string]any
-	if err := json.Unmarshal(sys, &blocks); err == nil {
-		blocks = append(blocks, map[string]any{"type": "text", "text": notice})
-		encoded, err := json.Marshal(blocks)
+	// System is a content-blocks array. Append a text block to it.
+	// Preserve existing blocks' bytes via []json.RawMessage round-trip.
+	if elems, ok := flattenJSONArray(sys); ok {
+		newBlock, err := json.Marshal(map[string]any{"type": "text", "text": notice})
 		if err != nil {
 			return nil, false, err
 		}
-		raw["system"] = encoded
-		return marshalInjected(raw)
+		elems = append(elems, json.RawMessage(newBlock))
+		encoded, err := json.Marshal(elems)
+		if err != nil {
+			return nil, false, err
+		}
+		out, err := SetJSONField(body, "system", encoded)
+		return out, err == nil, err
 	}
 	return body, false, nil
 }

--- a/internal/runtime/llmproxy/control.go
+++ b/internal/runtime/llmproxy/control.go
@@ -448,7 +448,7 @@ func injectAnthropicControlNotice(body []byte, notice string) ([]byte, bool, err
 	// downstream, which can corrupt cryptographically-signed thinking
 	// blocks across turns).
 	sysStart, sysEnd, present := findJSONFieldValue(body, "system")
-	if !present || sysEnd-sysStart == 0 {
+	if !present {
 		encoded, _ := json.Marshal(notice)
 		out, err := SetJSONField(body, "system", encoded)
 		return out, err == nil, err

--- a/internal/runtime/llmproxy/inbound_sanitize.go
+++ b/internal/runtime/llmproxy/inbound_sanitize.go
@@ -81,74 +81,103 @@ func inboundLooksRewritten(body []byte) bool {
 
 // sanitizeAnthropicInbound walks messages[].content[] looking for
 // tool_use blocks and rewrites the inner cmd / command field.
+//
+// Byte fidelity invariant: unchanged messages and unchanged content
+// blocks pass through with their original bytes intact. Top-level
+// body keys, message keys, and block keys keep their incoming order.
+// Critical because Anthropic verifies thinking-block signatures across
+// turns; any reshape on the request path can corrupt them.
 func sanitizeAnthropicInbound(req SanitizeInboundRequest) (SanitizeInboundResult, error) {
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(req.Body, &raw); err != nil {
-		return SanitizeInboundResult{Body: req.Body}, nil
-	}
-	msgsRaw, ok := raw["messages"]
+	body := req.Body
+	msgsStart, msgsEnd, ok := findJSONFieldValue(body, "messages")
 	if !ok {
-		return SanitizeInboundResult{Body: req.Body}, nil
+		return SanitizeInboundResult{Body: body}, nil
 	}
-	var messages []map[string]json.RawMessage
-	if err := json.Unmarshal(msgsRaw, &messages); err != nil {
-		return SanitizeInboundResult{Body: req.Body}, nil
+	messages, ok := flattenJSONArray(body[msgsStart:msgsEnd])
+	if !ok {
+		return SanitizeInboundResult{Body: body}, nil
 	}
-	modified := false
-	for _, msg := range messages {
-		roleRaw := msg["role"]
-		var role string
-		_ = json.Unmarshal(roleRaw, &role)
-		if role != "assistant" {
-			continue
-		}
-		contentRaw, ok := msg["content"]
-		if !ok {
-			continue
-		}
-		var blocks []map[string]json.RawMessage
-		if err := json.Unmarshal(contentRaw, &blocks); err != nil {
-			continue
-		}
-		blockChanged := false
-		for _, block := range blocks {
-			typeRaw := block["type"]
-			var typ string
-			_ = json.Unmarshal(typeRaw, &typ)
-			if typ != "tool_use" {
-				continue
-			}
-			inputRaw, ok := block["input"]
-			if !ok {
-				continue
-			}
-			sanitized, changed := sanitizeToolUseInput(inputRaw, req)
-			if changed {
-				block["input"] = sanitized
-				blockChanged = true
-			}
-		}
-		if blockChanged {
-			encoded, err := json.Marshal(blocks)
-			if err == nil {
-				msg["content"] = encoded
-				modified = true
-			}
+	anyChanged := false
+	newMessages := make([]json.RawMessage, len(messages))
+	for i, msg := range messages {
+		newMsg, changed := sanitizeAnthropicInboundMessage(msg, req)
+		newMessages[i] = newMsg
+		if changed {
+			anyChanged = true
 		}
 	}
-	if !modified {
-		return SanitizeInboundResult{Body: req.Body}, nil
+	if !anyChanged {
+		return SanitizeInboundResult{Body: body}, nil
 	}
-	encodedMsgs, err := json.Marshal(messages)
+	newMsgsBytes, err := json.Marshal(newMessages)
 	if err != nil {
-		return SanitizeInboundResult{Body: req.Body}, nil
+		return SanitizeInboundResult{Body: body}, nil
 	}
-	raw["messages"] = encodedMsgs
-	out, err := json.Marshal(raw)
+	out, err := SetJSONField(body, "messages", newMsgsBytes)
 	if err != nil {
-		return SanitizeInboundResult{Body: req.Body}, nil
+		return SanitizeInboundResult{Body: body}, nil
 	}
 	return SanitizeInboundResult{Body: out, Modified: true}, nil
+}
+
+// sanitizeAnthropicInboundMessage rewrites a single message's
+// assistant tool_use input commands while preserving byte fidelity
+// for everything else (other blocks, the message envelope).
+func sanitizeAnthropicInboundMessage(msg json.RawMessage, req SanitizeInboundRequest) (json.RawMessage, bool) {
+	roleStart, roleEnd, ok := findJSONFieldValue(msg, "role")
+	if !ok {
+		return msg, false
+	}
+	var role string
+	if err := json.Unmarshal(msg[roleStart:roleEnd], &role); err != nil || role != "assistant" {
+		return msg, false
+	}
+	contentStart, contentEnd, ok := findJSONFieldValue(msg, "content")
+	if !ok {
+		return msg, false
+	}
+	content := msg[contentStart:contentEnd]
+	blocks, ok := flattenJSONArray(content)
+	if !ok {
+		return msg, false
+	}
+	anyChanged := false
+	newBlocks := make([]json.RawMessage, len(blocks))
+	for i, block := range blocks {
+		if extractBlockType(block) != "tool_use" {
+			newBlocks[i] = block
+			continue
+		}
+		inputStart, inputEnd, ok := findJSONFieldValue(block, "input")
+		if !ok {
+			newBlocks[i] = block
+			continue
+		}
+		sanitized, changed := sanitizeToolUseInput(block[inputStart:inputEnd], req)
+		if !changed {
+			newBlocks[i] = block
+			continue
+		}
+		newBlock, err := SetJSONField(block, "input", sanitized)
+		if err != nil {
+			newBlocks[i] = block
+			continue
+		}
+		newBlocks[i] = newBlock
+		anyChanged = true
+	}
+	if !anyChanged {
+		return msg, false
+	}
+	newContentBytes, err := json.Marshal(newBlocks)
+	if err != nil {
+		return msg, false
+	}
+	newMsg, err := SetJSONField(msg, "content", newContentBytes)
+	if err != nil {
+		return msg, false
+	}
+	return newMsg, true
 }
 
 // sanitizeOpenAIInbound walks messages[].tool_calls[].function.arguments

--- a/internal/runtime/llmproxy/json_surgery.go
+++ b/internal/runtime/llmproxy/json_surgery.go
@@ -1,0 +1,262 @@
+package llmproxy
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// Byte-faithful surgical edits on JSON byte slices.
+//
+// The Anthropic streaming protocol enforces a cryptographic signature
+// over thinking blocks across turns. Any reshape — reordered keys,
+// stripped whitespace, applied `,omitempty`, dropped unknown fields —
+// risks "thinking blocks cannot be modified" 400s on subsequent
+// requests. The conventional `json.Unmarshal` →
+// `map[string]json.RawMessage` → `json.Marshal` round-trip alphabetizes
+// keys and drops unknown fields, so it cannot be used on bodies that
+// carry assistant turns we need to pass back upstream verbatim.
+//
+// These helpers operate on the raw byte representation. They use
+// `encoding/json.Decoder` to navigate JSON structure (so nested keys
+// don't collide with top-level ones), then splice replacements into
+// the original byte slice without re-emitting surrounding context.
+
+// findJSONFieldValue locates the byte range of the value associated
+// with the given top-level key in a JSON object. Returns
+// (valueStart, valueEnd, true) such that data[valueStart:valueEnd] is
+// the raw JSON value, or (_, _, false) if data isn't a JSON object or
+// the key isn't present.
+func findJSONFieldValue(data []byte, key string) (int, int, bool) {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	tok, err := dec.Token()
+	if err != nil {
+		return 0, 0, false
+	}
+	if d, ok := tok.(json.Delim); !ok || d != '{' {
+		return 0, 0, false
+	}
+	for dec.More() {
+		keyTok, err := dec.Token()
+		if err != nil {
+			return 0, 0, false
+		}
+		k, ok := keyTok.(string)
+		if !ok {
+			return 0, 0, false
+		}
+		if k != key {
+			var skip json.RawMessage
+			if err := dec.Decode(&skip); err != nil {
+				return 0, 0, false
+			}
+			continue
+		}
+		// dec.InputOffset() sits just past the closing quote of the
+		// matched key. Scan forward past ':' and whitespace to find
+		// where the value begins.
+		p := int(dec.InputOffset())
+		for p < len(data) && data[p] != ':' {
+			p++
+		}
+		if p >= len(data) {
+			return 0, 0, false
+		}
+		p++ // past ':'
+		for p < len(data) && isJSONWS(data[p]) {
+			p++
+		}
+		valueStart := p
+		var skip json.RawMessage
+		if err := dec.Decode(&skip); err != nil {
+			return 0, 0, false
+		}
+		return valueStart, int(dec.InputOffset()), true
+	}
+	return 0, 0, false
+}
+
+// SetJSONField returns data with the value at the given top-level key
+// replaced by newValue. If the key doesn't exist, it's appended just
+// before the closing `}`. All unmodified bytes — including key order,
+// whitespace, and any fields we don't model — are preserved verbatim.
+//
+// newValue must be valid JSON (object, array, string, number, bool,
+// or null). Callers typically construct it via json.Marshal of a
+// single value, never via json.Marshal of an envelope.
+func SetJSONField(data []byte, key string, newValue []byte) ([]byte, error) {
+	if start, end, ok := findJSONFieldValue(data, key); ok {
+		out := make([]byte, 0, len(data)+len(newValue)-(end-start))
+		out = append(out, data[:start]...)
+		out = append(out, newValue...)
+		out = append(out, data[end:]...)
+		return out, nil
+	}
+	return appendJSONField(data, key, newValue)
+}
+
+// DeleteJSONField returns data with the named top-level field
+// removed. If the key isn't present, data is returned unchanged.
+func DeleteJSONField(data []byte, key string) ([]byte, bool) {
+	valueStart, valueEnd, ok := findJSONFieldValue(data, key)
+	if !ok {
+		return data, false
+	}
+	// Walk backward from valueStart past the colon and the key string
+	// to find the start of `"<key>"`.
+	keyStart := valueStart
+	for keyStart > 0 && data[keyStart-1] != '"' {
+		keyStart--
+	}
+	if keyStart <= 0 {
+		return data, false
+	}
+	// Now keyStart points one past a closing quote of the key. Walk
+	// past `:` and whitespace backward.
+	p := keyStart - 1 // closing quote
+	// Walk back across the key string itself.
+	for p > 0 && data[p-1] != '"' {
+		p--
+	}
+	if p == 0 {
+		return data, false
+	}
+	keyOpenQuote := p - 1 // position of opening quote of key
+	// Now decide what to remove on either side. We want to remove
+	// either a leading comma (if this isn't the first field) or a
+	// trailing comma (if it is). Skip whitespace.
+	removeStart := keyOpenQuote
+	removeEnd := valueEnd
+	// Skip whitespace before the key opening quote.
+	for removeStart > 0 && isJSONWS(data[removeStart-1]) {
+		removeStart--
+	}
+	// Skip whitespace after the value.
+	for removeEnd < len(data) && isJSONWS(data[removeEnd]) {
+		removeEnd++
+	}
+	// Now: if data[removeStart-1] == ',' → drop leading comma.
+	// Else if data[removeEnd] == ',' → drop trailing comma.
+	// Else this was the only field (don't drop anything else).
+	if removeStart > 0 && data[removeStart-1] == ',' {
+		removeStart--
+	} else if removeEnd < len(data) && data[removeEnd] == ',' {
+		removeEnd++
+	}
+	out := make([]byte, 0, len(data)-(removeEnd-removeStart))
+	out = append(out, data[:removeStart]...)
+	out = append(out, data[removeEnd:]...)
+	return out, true
+}
+
+// appendJSONField inserts `"key":<newValue>` just before the closing
+// brace of a JSON object, adding a leading comma if there are existing
+// fields. Returns an error only on malformed input.
+func appendJSONField(data []byte, key string, newValue []byte) ([]byte, error) {
+	// Find the closing `}` of the top-level object. We need to walk
+	// through the JSON to find the matching brace at depth 0.
+	dec := json.NewDecoder(bytes.NewReader(data))
+	tok, err := dec.Token()
+	if err != nil {
+		return nil, err
+	}
+	if d, ok := tok.(json.Delim); !ok || d != '{' {
+		return nil, jsonNotObjectErr
+	}
+	hasExistingFields := dec.More()
+	// Drain to the closing brace.
+	for dec.More() {
+		// Read and discard key.
+		if _, err := dec.Token(); err != nil {
+			return nil, err
+		}
+		var skip json.RawMessage
+		if err := dec.Decode(&skip); err != nil {
+			return nil, err
+		}
+	}
+	// Read the closing brace token to advance offset.
+	if _, err := dec.Token(); err != nil {
+		return nil, err
+	}
+	closeBracePos := int(dec.InputOffset()) - 1
+	// Walk back across whitespace.
+	for closeBracePos > 0 && isJSONWS(data[closeBracePos-1]) {
+		closeBracePos--
+	}
+	encodedKey, err := json.Marshal(key)
+	if err != nil {
+		return nil, err
+	}
+	insert := make([]byte, 0, len(encodedKey)+1+len(newValue)+1)
+	if hasExistingFields {
+		insert = append(insert, ',')
+	}
+	insert = append(insert, encodedKey...)
+	insert = append(insert, ':')
+	insert = append(insert, newValue...)
+	out := make([]byte, 0, len(data)+len(insert))
+	out = append(out, data[:closeBracePos]...)
+	out = append(out, insert...)
+	out = append(out, data[closeBracePos:]...)
+	return out, nil
+}
+
+func isJSONWS(b byte) bool {
+	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
+}
+
+var jsonNotObjectErr = &jsonSurgeryError{msg: "JSON value is not an object"}
+
+type jsonSurgeryError struct {
+	msg string
+}
+
+func (e *jsonSurgeryError) Error() string { return e.msg }
+
+// jsonObjectIsArray reports whether the leading non-whitespace
+// character of data is `[`.
+func jsonObjectIsArray(data []byte) bool {
+	for _, b := range data {
+		if isJSONWS(b) {
+			continue
+		}
+		return b == '['
+	}
+	return false
+}
+
+// flattenJSONArray returns the top-level elements of a JSON array as
+// raw byte slices, preserving each element's bytes verbatim. The
+// returned slices alias into data. Returns nil, false if data isn't a
+// JSON array.
+func flattenJSONArray(data []byte) ([]json.RawMessage, bool) {
+	if !jsonObjectIsArray(data) {
+		return nil, false
+	}
+	var elems []json.RawMessage
+	if err := json.Unmarshal(data, &elems); err != nil {
+		return nil, false
+	}
+	return elems, true
+}
+
+// looksLikeJSONString reports whether data is a JSON-encoded string
+// (leading quote, after whitespace). Useful for distinguishing
+// string-content from array-content.
+func looksLikeJSONString(data []byte) bool {
+	for _, b := range data {
+		if isJSONWS(b) {
+			continue
+		}
+		return b == '"'
+	}
+	return false
+}
+
+// trimJSONWS returns data with leading/trailing JSON whitespace
+// removed.
+func trimJSONWS(data []byte) []byte {
+	return bytes.TrimFunc(data, func(r rune) bool {
+		return r == ' ' || r == '\t' || r == '\n' || r == '\r'
+	})
+}

--- a/internal/runtime/llmproxy/json_surgery.go
+++ b/internal/runtime/llmproxy/json_surgery.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"slices"
 )
 
 // Byte-faithful surgical edits on JSON byte slices.
@@ -120,11 +121,7 @@ func findJSONFieldSpan(data []byte, key string) (int, int, int, bool) {
 // single value, never via json.Marshal of an envelope.
 func SetJSONField(data []byte, key string, newValue []byte) ([]byte, error) {
 	if start, end, ok := findJSONFieldValue(data, key); ok {
-		out := make([]byte, 0, len(data)+len(newValue)-(end-start))
-		out = append(out, data[:start]...)
-		out = append(out, newValue...)
-		out = append(out, data[end:]...)
-		return out, nil
+		return slices.Concat(data[:start], newValue, data[end:]), nil
 	}
 	return appendJSONField(data, key, newValue)
 }
@@ -151,10 +148,7 @@ func DeleteJSONField(data []byte, key string) ([]byte, bool) {
 	} else if removeEnd < len(data) && data[removeEnd] == ',' {
 		removeEnd++
 	}
-	out := make([]byte, 0, len(data)-(removeEnd-removeStart))
-	out = append(out, data[:removeStart]...)
-	out = append(out, data[removeEnd:]...)
-	return out, true
+	return slices.Concat(data[:removeStart], data[removeEnd:]), true
 }
 
 // appendJSONField inserts `"key":<newValue>` just before the closing
@@ -196,18 +190,14 @@ func appendJSONField(data []byte, key string, newValue []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	insert := make([]byte, 0, len(encodedKey)+1+len(newValue)+1)
+	var insert []byte
 	if hasExistingFields {
 		insert = append(insert, ',')
 	}
 	insert = append(insert, encodedKey...)
 	insert = append(insert, ':')
 	insert = append(insert, newValue...)
-	out := make([]byte, 0, len(data)+len(insert))
-	out = append(out, data[:closeBracePos]...)
-	out = append(out, insert...)
-	out = append(out, data[closeBracePos:]...)
-	return out, nil
+	return slices.Concat(data[:closeBracePos], insert, data[closeBracePos:]), nil
 }
 
 func isJSONWS(b byte) bool {

--- a/internal/runtime/llmproxy/json_surgery.go
+++ b/internal/runtime/llmproxy/json_surgery.go
@@ -3,6 +3,7 @@ package llmproxy
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 )
 
 // Byte-faithful surgical edits on JSON byte slices.
@@ -27,39 +28,73 @@ import (
 // the raw JSON value, or (_, _, false) if data isn't a JSON object or
 // the key isn't present.
 func findJSONFieldValue(data []byte, key string) (int, int, bool) {
+	_, valueStart, valueEnd, ok := findJSONFieldSpan(data, key)
+	return valueStart, valueEnd, ok
+}
+
+// findJSONFieldSpan locates byte ranges for both the key string and
+// the value of a top-level field. Returns (keyOpenQuote, valueStart,
+// valueEnd, true) on success where data[keyOpenQuote] == '"' is the
+// opening quote of the JSON-encoded key. Used by DeleteJSONField so
+// it can locate the start of the key without a backward scan
+// (which is brittle when the key contains escaped quotes).
+func findJSONFieldSpan(data []byte, key string) (int, int, int, bool) {
 	dec := json.NewDecoder(bytes.NewReader(data))
 	tok, err := dec.Token()
 	if err != nil {
-		return 0, 0, false
+		return 0, 0, 0, false
 	}
 	if d, ok := tok.(json.Delim); !ok || d != '{' {
-		return 0, 0, false
+		return 0, 0, 0, false
 	}
 	for dec.More() {
 		keyTok, err := dec.Token()
 		if err != nil {
-			return 0, 0, false
+			return 0, 0, 0, false
 		}
 		k, ok := keyTok.(string)
 		if !ok {
-			return 0, 0, false
+			return 0, 0, 0, false
 		}
+		keyEnd := int(dec.InputOffset()) // just past closing quote of key
 		if k != key {
 			var skip json.RawMessage
 			if err := dec.Decode(&skip); err != nil {
-				return 0, 0, false
+				return 0, 0, 0, false
 			}
 			continue
 		}
-		// dec.InputOffset() sits just past the closing quote of the
-		// matched key. Scan forward past ':' and whitespace to find
-		// where the value begins.
-		p := int(dec.InputOffset())
+		// Walk backward from the closing quote to find the matching
+		// opening quote, accounting for escaped quotes. `\"` inside
+		// the key string must not terminate the backward scan.
+		closeQuote := keyEnd - 1 // position of `"` that closes the key
+		openQuote := closeQuote - 1
+		for openQuote >= 0 {
+			if data[openQuote] != '"' {
+				openQuote--
+				continue
+			}
+			// Count consecutive backslashes immediately before this
+			// quote; an odd count means it's escaped.
+			bs := 0
+			for q := openQuote - 1; q >= 0 && data[q] == '\\'; q-- {
+				bs++
+			}
+			if bs%2 == 0 {
+				break
+			}
+			openQuote--
+		}
+		if openQuote < 0 {
+			return 0, 0, 0, false
+		}
+		// Scan forward past ':' and whitespace to find value start.
+		p := keyEnd
 		for p < len(data) && data[p] != ':' {
 			p++
 		}
 		if p >= len(data) {
-			return 0, 0, false
+			return 0, 0, 0, false
 		}
 		p++ // past ':'
 		for p < len(data) && isJSONWS(data[p]) {
@@ -68,11 +103,11 @@ func findJSONFieldValue(data []byte, key string) (int, int, bool) {
 		valueStart := p
 		var skip json.RawMessage
 		if err := dec.Decode(&skip); err != nil {
-			return 0, 0, false
+			return 0, 0, 0, false
 		}
-		return valueStart, int(dec.InputOffset()), true
+		return openQuote, valueStart, int(dec.InputOffset()), true
 	}
-	return 0, 0, false
+	return 0, 0, 0, false
 }
 
 // SetJSONField returns data with the value at the given top-level key
@@ -97,46 +132,20 @@ func SetJSONField(data []byte, key string, newValue []byte) ([]byte, error) {
 // DeleteJSONField returns data with the named top-level field
 // removed. If the key isn't present, data is returned unchanged.
 func DeleteJSONField(data []byte, key string) ([]byte, bool) {
-	valueStart, valueEnd, ok := findJSONFieldValue(data, key)
+	keyOpenQuote, _, valueEnd, ok := findJSONFieldSpan(data, key)
 	if !ok {
 		return data, false
 	}
-	// Walk backward from valueStart past the colon and the key string
-	// to find the start of `"<key>"`.
-	keyStart := valueStart
-	for keyStart > 0 && data[keyStart-1] != '"' {
-		keyStart--
-	}
-	if keyStart <= 0 {
-		return data, false
-	}
-	// Now keyStart points one past a closing quote of the key. Walk
-	// past `:` and whitespace backward.
-	p := keyStart - 1 // closing quote
-	// Walk back across the key string itself.
-	for p > 0 && data[p-1] != '"' {
-		p--
-	}
-	if p == 0 {
-		return data, false
-	}
-	keyOpenQuote := p - 1 // position of opening quote of key
-	// Now decide what to remove on either side. We want to remove
-	// either a leading comma (if this isn't the first field) or a
-	// trailing comma (if it is). Skip whitespace.
 	removeStart := keyOpenQuote
 	removeEnd := valueEnd
-	// Skip whitespace before the key opening quote.
+	// Eat surrounding whitespace, then decide whether to consume a
+	// leading or trailing comma so the resulting object stays valid.
 	for removeStart > 0 && isJSONWS(data[removeStart-1]) {
 		removeStart--
 	}
-	// Skip whitespace after the value.
 	for removeEnd < len(data) && isJSONWS(data[removeEnd]) {
 		removeEnd++
 	}
-	// Now: if data[removeStart-1] == ',' → drop leading comma.
-	// Else if data[removeEnd] == ',' → drop trailing comma.
-	// Else this was the only field (don't drop anything else).
 	if removeStart > 0 && data[removeStart-1] == ',' {
 		removeStart--
 	} else if removeEnd < len(data) && data[removeEnd] == ',' {
@@ -205,13 +214,7 @@ func isJSONWS(b byte) bool {
 	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
 }
 
-var jsonNotObjectErr = &jsonSurgeryError{msg: "JSON value is not an object"}
-
-type jsonSurgeryError struct {
-	msg string
-}
-
-func (e *jsonSurgeryError) Error() string { return e.msg }
+var jsonNotObjectErr = errors.New("JSON value is not an object")
 
 // jsonObjectIsArray reports whether the leading non-whitespace
 // character of data is `[`.

--- a/internal/runtime/llmproxy/json_surgery_test.go
+++ b/internal/runtime/llmproxy/json_surgery_test.go
@@ -1,0 +1,160 @@
+package llmproxy
+
+import (
+	"testing"
+)
+
+func TestSetJSONFieldReplaceExisting(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   string
+		key  string
+		val  string
+		want string
+	}{
+		{
+			name: "preserves preceding key order",
+			in:   `{"model":"claude","messages":[],"system":"old"}`,
+			key:  "system",
+			val:  `"new"`,
+			want: `{"model":"claude","messages":[],"system":"new"}`,
+		},
+		{
+			name: "preserves following key order",
+			in:   `{"system":"old","model":"claude"}`,
+			key:  "system",
+			val:  `"new"`,
+			want: `{"system":"new","model":"claude"}`,
+		},
+		{
+			name: "replaces array value",
+			in:   `{"a":[1,2,3],"b":"x"}`,
+			key:  "a",
+			val:  `[4,5]`,
+			want: `{"a":[4,5],"b":"x"}`,
+		},
+		{
+			name: "preserves whitespace around colon",
+			in:   `{"a"  :  1 , "b":2}`,
+			key:  "a",
+			val:  `42`,
+			want: `{"a"  :  42 , "b":2}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := SetJSONField([]byte(tc.in), tc.key, []byte(tc.val))
+			if err != nil {
+				t.Fatalf("SetJSONField err: %v", err)
+			}
+			if string(got) != tc.want {
+				t.Errorf("byte mismatch\n got: %q\nwant: %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSetJSONFieldAppendsMissingKey(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   string
+		key  string
+		val  string
+		want string
+	}{
+		{
+			name: "appends to non-empty object",
+			in:   `{"model":"claude"}`,
+			key:  "system",
+			val:  `"hello"`,
+			want: `{"model":"claude","system":"hello"}`,
+		},
+		{
+			name: "appends to empty object",
+			in:   `{}`,
+			key:  "system",
+			val:  `"hello"`,
+			want: `{"system":"hello"}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := SetJSONField([]byte(tc.in), tc.key, []byte(tc.val))
+			if err != nil {
+				t.Fatalf("SetJSONField err: %v", err)
+			}
+			if string(got) != tc.want {
+				t.Errorf("byte mismatch\n got: %q\nwant: %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSetJSONFieldIgnoresNestedKey(t *testing.T) {
+	t.Parallel()
+	// `system` exists nested in `metadata` but not at the top level —
+	// should append at top level, not modify the nested value.
+	in := `{"model":"claude","metadata":{"system":"nested"}}`
+	want := `{"model":"claude","metadata":{"system":"nested"},"system":"new"}`
+	got, err := SetJSONField([]byte(in), "system", []byte(`"new"`))
+	if err != nil {
+		t.Fatalf("SetJSONField err: %v", err)
+	}
+	if string(got) != want {
+		t.Errorf("byte mismatch\n got: %q\nwant: %q", got, want)
+	}
+}
+
+func TestFindJSONFieldValueByteRange(t *testing.T) {
+	t.Parallel()
+	in := []byte(`{"a":1,"b":[2,3],"c":"x"}`)
+	start, end, ok := findJSONFieldValue(in, "b")
+	if !ok {
+		t.Fatalf("expected to find b")
+	}
+	if string(in[start:end]) != `[2,3]` {
+		t.Errorf("got %q want [2,3]", string(in[start:end]))
+	}
+}
+
+func TestDeleteJSONField(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   string
+		key  string
+		want string
+	}{
+		{
+			name: "removes leading comma when deleting non-first",
+			in:   `{"a":1,"b":2,"c":3}`,
+			key:  "b",
+			want: `{"a":1,"c":3}`,
+		},
+		{
+			name: "removes trailing comma when deleting first",
+			in:   `{"a":1,"b":2}`,
+			key:  "a",
+			want: `{"b":2}`,
+		},
+		{
+			name: "removes only field",
+			in:   `{"a":1}`,
+			key:  "a",
+			want: `{}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := DeleteJSONField([]byte(tc.in), tc.key)
+			if !ok {
+				t.Fatalf("expected key to be found")
+			}
+			if string(got) != tc.want {
+				t.Errorf("byte mismatch\n got: %q\nwant: %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/runtime/llmproxy/json_surgery_test.go
+++ b/internal/runtime/llmproxy/json_surgery_test.go
@@ -119,6 +119,21 @@ func TestFindJSONFieldValueByteRange(t *testing.T) {
 	}
 }
 
+func TestDeleteJSONFieldKeyWithEscapedQuote(t *testing.T) {
+	t.Parallel()
+	// Key `a"b` is JSON-encoded as `"a\"b"`. A naive backward walk for
+	// the first `"` would stop at the escaped inner quote and pick
+	// the wrong boundary.
+	in := `{"a\"b":1,"c":2}`
+	got, ok := DeleteJSONField([]byte(in), `a"b`)
+	if !ok {
+		t.Fatalf("expected key to be found")
+	}
+	if string(got) != `{"c":2}` {
+		t.Errorf("got %q want %q", got, `{"c":2}`)
+	}
+}
+
 func TestDeleteJSONField(t *testing.T) {
 	t.Parallel()
 	cases := []struct {

--- a/internal/runtime/llmproxy/secret_decision_history.go
+++ b/internal/runtime/llmproxy/secret_decision_history.go
@@ -32,18 +32,20 @@ func StripSecretDecisionHistory(req SecretDecisionHistoryStripRequest) (SecretDe
 }
 
 func stripAnthropicSecretDecisionHistory(body []byte) (SecretDecisionHistoryStripResult, error) {
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(body, &raw); err != nil {
+	// Byte fidelity: this strips entire messages by index but never
+	// modifies a surviving message's content, so we can preserve each
+	// survivor's bytes verbatim via []json.RawMessage.
+	msgsStart, msgsEnd, ok := findJSONFieldValue(body, "messages")
+	if !ok {
 		return SecretDecisionHistoryStripResult{Body: body}, nil
 	}
-	var messages []map[string]json.RawMessage
-	if err := json.Unmarshal(raw["messages"], &messages); err != nil {
+	messages, ok := flattenJSONArray(body[msgsStart:msgsEnd])
+	if !ok {
 		return SecretDecisionHistoryStripResult{Body: body}, nil
 	}
-	out, modified := stripSecretDecisionMessages(messages, func(msg map[string]json.RawMessage) (string, string) {
-		var role string
-		_ = json.Unmarshal(msg["role"], &role)
-		return role, flattenAnthropicTaskReplyText(msg["content"])
+	out, modified := stripSecretDecisionMessagesRaw(messages, func(msg json.RawMessage) (string, string) {
+		role := extractMessageRole(msg)
+		return role, flattenAnthropicTaskReplyText(extractMessageContent(msg))
 	})
 	if !modified {
 		return SecretDecisionHistoryStripResult{Body: body}, nil
@@ -52,12 +54,11 @@ func stripAnthropicSecretDecisionHistory(body []byte) (SecretDecisionHistoryStri
 	if err != nil {
 		return SecretDecisionHistoryStripResult{Body: body}, err
 	}
-	raw["messages"] = encoded
-	body, err = json.Marshal(raw)
+	newBody, err := SetJSONField(body, "messages", encoded)
 	if err != nil {
 		return SecretDecisionHistoryStripResult{Body: body}, err
 	}
-	return SecretDecisionHistoryStripResult{Body: body, Modified: true}, nil
+	return SecretDecisionHistoryStripResult{Body: newBody, Modified: true}, nil
 }
 
 func stripOpenAISecretDecisionHistory(body []byte) (SecretDecisionHistoryStripResult, error) {
@@ -116,6 +117,38 @@ func stripOpenAISecretDecisionHistory(body []byte) (SecretDecisionHistoryStripRe
 
 func stripSecretDecisionMessages(messages []map[string]json.RawMessage, text func(map[string]json.RawMessage) (string, string)) ([]map[string]json.RawMessage, bool) {
 	out := make([]map[string]json.RawMessage, 0, len(messages))
+	modified := false
+	skipDecisionIndex := -1
+	for i := 0; i < len(messages); i++ {
+		if i == skipDecisionIndex {
+			modified = true
+			continue
+		}
+		role, content := text(messages[i])
+		if role == "assistant" && strings.Contains(content, SecretDecisionIDMarker) {
+			modified = true
+			for j := i + 1; j < len(messages); j++ {
+				nextRole, nextContent := text(messages[j])
+				if nextRole != "user" {
+					continue
+				}
+				if ParseSecretDecisionReply(nextContent).Action != SecretDecisionNone {
+					skipDecisionIndex = j
+				}
+				break
+			}
+			continue
+		}
+		out = append(out, messages[i])
+	}
+	return out, modified
+}
+
+// stripSecretDecisionMessagesRaw is the byte-faithful analogue of
+// stripSecretDecisionMessages: messages are passed as raw bytes so
+// surviving entries pass through verbatim.
+func stripSecretDecisionMessagesRaw(messages []json.RawMessage, text func(json.RawMessage) (string, string)) ([]json.RawMessage, bool) {
+	out := make([]json.RawMessage, 0, len(messages))
 	modified := false
 	skipDecisionIndex := -1
 	for i := 0; i < len(messages); i++ {

--- a/internal/runtime/llmproxy/secret_decision_history.go
+++ b/internal/runtime/llmproxy/secret_decision_history.go
@@ -43,7 +43,7 @@ func stripAnthropicSecretDecisionHistory(body []byte) (SecretDecisionHistoryStri
 	if !ok {
 		return SecretDecisionHistoryStripResult{Body: body}, nil
 	}
-	out, modified := stripSecretDecisionMessagesRaw(messages, func(msg json.RawMessage) (string, string) {
+	out, modified := stripSecretDecisionMessages(messages, func(msg json.RawMessage) (string, string) {
 		role := extractMessageRole(msg)
 		return role, flattenAnthropicTaskReplyText(extractMessageContent(msg))
 	})
@@ -115,40 +115,8 @@ func stripOpenAISecretDecisionHistory(body []byte) (SecretDecisionHistoryStripRe
 	return SecretDecisionHistoryStripResult{Body: out, Modified: true}, nil
 }
 
-func stripSecretDecisionMessages(messages []map[string]json.RawMessage, text func(map[string]json.RawMessage) (string, string)) ([]map[string]json.RawMessage, bool) {
-	out := make([]map[string]json.RawMessage, 0, len(messages))
-	modified := false
-	skipDecisionIndex := -1
-	for i := 0; i < len(messages); i++ {
-		if i == skipDecisionIndex {
-			modified = true
-			continue
-		}
-		role, content := text(messages[i])
-		if role == "assistant" && strings.Contains(content, SecretDecisionIDMarker) {
-			modified = true
-			for j := i + 1; j < len(messages); j++ {
-				nextRole, nextContent := text(messages[j])
-				if nextRole != "user" {
-					continue
-				}
-				if ParseSecretDecisionReply(nextContent).Action != SecretDecisionNone {
-					skipDecisionIndex = j
-				}
-				break
-			}
-			continue
-		}
-		out = append(out, messages[i])
-	}
-	return out, modified
-}
-
-// stripSecretDecisionMessagesRaw is the byte-faithful analogue of
-// stripSecretDecisionMessages: messages are passed as raw bytes so
-// surviving entries pass through verbatim.
-func stripSecretDecisionMessagesRaw(messages []json.RawMessage, text func(json.RawMessage) (string, string)) ([]json.RawMessage, bool) {
-	out := make([]json.RawMessage, 0, len(messages))
+func stripSecretDecisionMessages[T any](messages []T, text func(T) (string, string)) ([]T, bool) {
+	out := make([]T, 0, len(messages))
 	modified := false
 	skipDecisionIndex := -1
 	for i := 0; i < len(messages); i++ {

--- a/internal/runtime/llmproxy/synthetic_history_strip.go
+++ b/internal/runtime/llmproxy/synthetic_history_strip.go
@@ -182,9 +182,9 @@ func mergeAnthropicContent(c1, c2 json.RawMessage) (json.RawMessage, error) {
 		if err := json.Unmarshal(c2, &blocks2); err != nil {
 			return nil, err
 		}
-		out := make([]json.RawMessage, 0, len(blocks2)+1)
-		out = append(out, anthropicTextBlockRaw(s1))
-		out = append(out, blocks2...)
+		// Use append-from-literal to sidestep CodeQL's
+		// allocation-size-overflow warning on `len(blocks2)+1`.
+		out := append([]json.RawMessage{anthropicTextBlockRaw(s1)}, blocks2...)
 		return json.Marshal(out)
 	}
 

--- a/internal/runtime/llmproxy/synthetic_history_strip.go
+++ b/internal/runtime/llmproxy/synthetic_history_strip.go
@@ -48,24 +48,24 @@ func stripAnthropicSyntheticApprovalHistory(body []byte) (SyntheticApprovalHisto
 	if !strings.Contains(string(body), "Clawvisor") {
 		return SyntheticApprovalHistoryStripResult{Body: body}, nil
 	}
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(body, &raw); err != nil {
-		return SyntheticApprovalHistoryStripResult{Body: body}, nil
-	}
-	rawMessages, ok := raw["messages"]
+	// Byte fidelity invariant: surviving messages pass through verbatim.
+	// Top-level body keys keep their order. Only messages we merge get
+	// re-marshalled — and those are user messages, never assistants
+	// carrying thinking blocks, so signature verification is unaffected.
+	msgsStart, msgsEnd, ok := findJSONFieldValue(body, "messages")
 	if !ok {
 		return SyntheticApprovalHistoryStripResult{Body: body}, nil
 	}
-	var messages []map[string]json.RawMessage
-	if err := json.Unmarshal(rawMessages, &messages); err != nil {
+	messages, ok := flattenJSONArray(body[msgsStart:msgsEnd])
+	if !ok {
 		return SyntheticApprovalHistoryStripResult{Body: body}, nil
 	}
-	out := make([]map[string]json.RawMessage, 0, len(messages))
+	survivors := make([]json.RawMessage, 0, len(messages))
 	modified := false
 	skipNextBareApprovalReply := false
 	for _, msg := range messages {
-		role := rawMessageString(msg["role"])
-		contentText := flattenAnthropicTaskReplyText(msg["content"])
+		role := extractMessageRole(msg)
+		contentText := flattenAnthropicTaskReplyText(extractMessageContent(msg))
 		if skipNextBareApprovalReply {
 			skipNextBareApprovalReply = false
 			if role == "user" && isBareSyntheticApprovalReply(contentText) {
@@ -78,45 +78,68 @@ func stripAnthropicSyntheticApprovalHistory(body []byte) (SyntheticApprovalHisto
 			skipNextBareApprovalReply = true
 			continue
 		}
-		out = append(out, msg)
+		survivors = append(survivors, msg)
 	}
-	if !modified || len(out) == 0 {
+	if !modified || len(survivors) == 0 {
 		return SyntheticApprovalHistoryStripResult{Body: body}, nil
 	}
 
-	// Merge consecutive messages with the same role (especially user messages
-	// that become adjacent after stripping an assistant approval prompt).
-	var mergedOut []map[string]json.RawMessage
-	for _, msg := range out {
-		if len(mergedOut) == 0 {
-			mergedOut = append(mergedOut, msg)
+	// Merge consecutive user messages that became adjacent after the strip.
+	var merged []json.RawMessage
+	for _, msg := range survivors {
+		if len(merged) == 0 {
+			merged = append(merged, msg)
 			continue
 		}
-		prev := mergedOut[len(mergedOut)-1]
-		prevRole := rawMessageString(prev["role"])
-		currRole := rawMessageString(msg["role"])
-		if prevRole == currRole && currRole == "user" && canMergeAnthropicContent(prev["content"], msg["content"]) {
-			mergedContent, err := mergeAnthropicContent(prev["content"], msg["content"])
-			if err != nil {
-				return SyntheticApprovalHistoryStripResult{Body: body}, err
+		prev := merged[len(merged)-1]
+		prevRole := extractMessageRole(prev)
+		currRole := extractMessageRole(msg)
+		if prevRole == currRole && currRole == "user" {
+			prevContent := extractMessageContent(prev)
+			currContent := extractMessageContent(msg)
+			if canMergeAnthropicContent(prevContent, currContent) {
+				mergedContent, err := mergeAnthropicContent(prevContent, currContent)
+				if err != nil {
+					return SyntheticApprovalHistoryStripResult{Body: body}, err
+				}
+				newPrev, err := SetJSONField(prev, "content", mergedContent)
+				if err != nil {
+					return SyntheticApprovalHistoryStripResult{Body: body}, err
+				}
+				merged[len(merged)-1] = newPrev
+				continue
 			}
-			prev["content"] = mergedContent
-		} else {
-			mergedOut = append(mergedOut, msg)
 		}
+		merged = append(merged, msg)
 	}
-	out = mergedOut
 
-	encoded, err := json.Marshal(out)
+	newMsgsBytes, err := json.Marshal(merged)
 	if err != nil {
 		return SyntheticApprovalHistoryStripResult{Body: body}, err
 	}
-	raw["messages"] = json.RawMessage(encoded)
-	next, err := json.Marshal(raw)
+	next, err := SetJSONField(body, "messages", newMsgsBytes)
 	if err != nil {
 		return SyntheticApprovalHistoryStripResult{Body: body}, err
 	}
 	return SyntheticApprovalHistoryStripResult{Body: next, Modified: true}, nil
+}
+
+func extractMessageRole(msg json.RawMessage) string {
+	start, end, ok := findJSONFieldValue(msg, "role")
+	if !ok {
+		return ""
+	}
+	var s string
+	_ = json.Unmarshal(msg[start:end], &s)
+	return s
+}
+
+func extractMessageContent(msg json.RawMessage) json.RawMessage {
+	start, end, ok := findJSONFieldValue(msg, "content")
+	if !ok {
+		return nil
+	}
+	return msg[start:end]
 }
 
 func canMergeAnthropicContent(c1, c2 json.RawMessage) bool {


### PR DESCRIPTION
## Summary

PR #510 fixed one symptom (empty `thinking` fields dropped by `,omitempty`) but the underlying problem is broader. The Anthropic streaming rewriter — and the inbound request preprocessing pipeline — both round-trip the body through `json.Unmarshal → map[string]json.RawMessage → json.Marshal`. That cycle alphabetizes keys, applies `,omitempty` to empty values, and drops unknown fields.

Concretely, what we observed even after #510:

```
# What the harness sent us (proxy_received_request):
{\"type\":\"thinking\",\"thinking\":\"\",\"signature\":\"...\"}

# What we forwarded to Anthropic (inbound_request):
{\"signature\":\"...\",\"thinking\":\"\",\"type\":\"thinking\"}
```

Same fields, same values, alphabetical key order. Anthropic happens to accept this today, but Clawvisor's invariant should be: **request and response bodies pass through byte-for-byte except where we are intentionally mutating them.** Anything else is a latent bug for a byte-sensitive Anthropic policy or for downstream consumers of captured raw logs.

## Two commits, two scopes

### Commit 1 — response side (`internal/runtime/conversation/`)

- Rewrite `shiftAnthropicEventIndex` to do a byte-level edit using `json.Decoder` to find the top-level `index` integer's byte range. Surgically replace just those bytes. All other content — key order, whitespace, unmodelled fields like `estimated_tokens` — passes through.
- Add sibling `setAnthropicEventIndex` for absolute-replacement callers.
- Replace `json.Marshal(cbs)` at `content_block_start` and `content_block_stop` in `StreamRewrite` with pass-through-when-index-matches / surgical-edit-when-shifted, mirroring what #510 did for `content_block_delta`.

### Commit 2 — request side (`internal/runtime/llmproxy/`)

- New `json_surgery.go` with byte-level helpers: `findJSONFieldValue`, `SetJSONField`, `DeleteJSONField`, `flattenJSONArray`.
- Refactor every inbound-preprocessing function that mutates Anthropic bodies:
  - `SanitizeAnthropicRequest` (removes empty text blocks)
  - `injectAnthropicControlNotice` (adds `[Clawvisor]` system notice)
  - `sanitizeAnthropicInbound` (rewrites tool_use input commands)
  - `augmentAnthropicApprovedInlineTasks` (augments inline-approval user replies)
  - `stripAnthropicSyntheticApprovalHistory` (filters synthetic approval messages)
  - `stripAnthropicSecretDecisionHistory` (filters secret-decision messages)
- Pattern: parse just enough to identify the byte range to mutate, splice in the new value, leave everything else untouched. For arrays we use `[]json.RawMessage` (re-marshalling preserves each element's bytes); for objects we use the surgery helpers (re-marshalling would alphabetize keys).

## Tests

- Unit tests for `shiftAnthropicEventIndex` (trailing whitespace, unmodelled fields, key order, nested `\"index\"` in tool_use input, delta-zero pass-through).
- Unit tests for `SetJSONField` / `DeleteJSONField` / `findJSONFieldValue`.
- End-to-end test that pins byte fidelity for thinking events through `StreamRewrite`.
- `byte_fidelity_test.go` — pins the invariant: a thinking block with exact bytes `{\"type\":\"thinking\",\"thinking\":\"\",\"signature\":\"sig123\"}` must appear verbatim in the output of every preprocessing function and in the full chained pipeline.
- All existing tests in `internal/runtime/conversation/...` and `internal/runtime/llmproxy/...` pass.

## Out of scope

- `buildAnthropicMultiBlockSSE` (rebuilds the response from accumulated pendingBlock state when tool_use buffering is active) still emits via `map[string]any`. Not on the streaming hot path that triggered the bugs we've been chasing — leaving for a follow-up.
- A few read-only inspectors in `human_turns.go`, `agent_notice.go` still use `map[string]json.RawMessage`. They don't mutate bodies, so they're safe.

## Caveat

This stops new corruption. It does not retroactively repair existing on-disk conversation history that already contains alphabetized or `\"undefined\"` thinking blocks — those sessions will keep producing reshaped history until restarted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)