### PR TITLE
test(lite-proxy): gate scenario matrix behind CLAWVISOR_LITE_PROXY_E2E=1

### DIFF
--- a/internal/e2e/lite/lite_test.go
+++ b/internal/e2e/lite/lite_test.go
@@ -3,6 +3,7 @@ package lite
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -10,6 +11,12 @@ import (
 
 	"github.com/clawvisor/clawvisor/internal/e2e/lite/drivers"
 )
+
+// EnvRunLiteProxyE2E gates the (expensive, LLM-driven) lite-proxy
+// scenario matrix. The matrix calls real upstream Anthropic/OpenAI
+// APIs and can take minutes to run, so it stays off in `go test ./...`
+// unless the caller explicitly opts in.
+const EnvRunLiteProxyE2E = "CLAWVISOR_LITE_PROXY_E2E"
 
 // scenarioDirs is the explicit list of scenarios under library/ that
 // the runner exercises. Kept explicit (vs. globbing) so a half-written
@@ -53,6 +60,9 @@ func allDrivers() []drivers.Driver {
 // against every available driver as a sub-test, so a single test
 // invocation produces a (scenario × driver) matrix.
 func TestLiteProxyScenarios(t *testing.T) {
+	if os.Getenv(EnvRunLiteProxyE2E) != "1" {
+		t.Skipf("set %s=1 to run lite-proxy scenarios", EnvRunLiteProxyE2E)
+	}
 	anthropicKey := ResolveAnthropicKey()
 	openaiKey := ResolveOpenAIKey()
 	if anthropicKey == "" && openaiKey == "" {


### PR DESCRIPTION
## Summary
- `TestLiteProxyScenarios` now skips unless `CLAWVISOR_LITE_PROXY_E2E=1` is set, keeping the LLM-driven matrix out of `go test ./...` by default.
- The cheap `TestLoadAllLibraryScenarios` loader test stays ungated since it doesn't hit any upstream APIs.

## Test plan
- [x] `go test -v -run TestLiteProxyScenarios ./internal/e2e/lite/` → SKIP with the env-var hint
- [ ] `CLAWVISOR_LITE_PROXY_E2E=1` (with upstream keys) still runs the matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)