### PR TITLE
fix(llmproxy): treat tool_search and reasoning items as approval-reply staleness signals

### DIFF
--- a/internal/runtime/conversation/approval_release_test.go
+++ b/internal/runtime/conversation/approval_release_test.go
@@ -163,6 +163,52 @@ func TestOpenAIApprovalReplyResponsesInputStaleAfterCustomToolCall(t *testing.T)
 	}
 }
 
+func TestOpenAIApprovalReplyResponsesInputStaleAfterToolSearch(t *testing.T) {
+	// Regression: Codex's built-in tool-discovery emits tool_search_call
+	// and tool_search_output items, which Codex round-trips on
+	// continuation requests. A tool_search round-trip sitting after the
+	// user's "y" — together with the assistant commentary and reasoning
+	// items the model emitted post-approval — means the conversation has
+	// moved past the approval turn. Before the fix the proxy missed
+	// these item types and re-fired the release path on every
+	// follow-up, denying with "approval no longer valid" once the hold
+	// had already been consumed.
+	body := []byte(`{
+		"input": [
+			{"type": "message", "role": "user", "content": [{"type": "input_text", "text": "search happenstance"}]},
+			{"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": "paused [clawvisor:approval=cv-iiiiiiiiiiii]"}]},
+			{"type": "message", "role": "user", "content": [{"type": "input_text", "text": "y"}]},
+			{"type": "reasoning", "summary": []},
+			{"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": "I'll look for the available tools first."}]},
+			{"type": "tool_search_call", "call_id": "call_ts_1", "status": "completed", "arguments": {"query": "happenstance"}},
+			{"type": "tool_search_output", "call_id": "call_ts_1", "status": "completed", "tools": []}
+		]
+	}`)
+	verb, id := OpenAIApprovalReply(body)
+	if verb != "" || id != "" {
+		t.Fatalf("verb=%q id=%q, want empty (conversation moved past approval turn)", verb, id)
+	}
+}
+
+func TestOpenAIApprovalReplyResponsesInputStaleAfterAssistantMessage(t *testing.T) {
+	// Even without any tool activity, an assistant message appearing
+	// after the user's "y" means the model has already responded —
+	// the release happened on a prior request and the bare "y" lingering
+	// in history is stale.
+	body := []byte(`{
+		"input": [
+			{"type": "message", "role": "user", "content": [{"type": "input_text", "text": "do the thing"}]},
+			{"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": "paused [clawvisor:approval=cv-jjjjjjjjjjjj]"}]},
+			{"type": "message", "role": "user", "content": [{"type": "input_text", "text": "y"}]},
+			{"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": "OK, working on it."}]}
+		]
+	}`)
+	verb, id := OpenAIApprovalReply(body)
+	if verb != "" || id != "" {
+		t.Fatalf("verb=%q id=%q, want empty (assistant already spoke past approval)", verb, id)
+	}
+}
+
 func TestOpenAIApprovalReplyResponsesInputHeldCallBeforeReplyStillFires(t *testing.T) {
 	// Inverse of the stale case: when the held function_call sits BEFORE
 	// the "y" (the model emitted it on the prior turn, it was held, then

--- a/internal/runtime/conversation/openai_request.go
+++ b/internal/runtime/conversation/openai_request.go
@@ -64,48 +64,48 @@ func OpenAIApprovalReply(body []byte) (verb, id string) {
 	if len(probe.Input) > 0 {
 		var items []openAIInputItem
 		if err := json.Unmarshal(probe.Input, &items); err == nil {
-			// Find the latest message,role=user. If a tool-call or
-			// tool-output item appears more recently than that user
-			// message, the conversation has already moved past the
-			// approval turn (the held call was approved, executed, and
-			// the model has spoken since) — the "y" is stale history,
-			// not a fresh release. Bail so we pass through to upstream
-			// instead of denying with "approval no longer valid".
+			// The user's approval reply must sit at the tail of the
+			// input array. If any item appears after it
+			// (function_call, function_call_output, custom_tool_call,
+			// reasoning, Codex's tool_search round-trip
+			// tool_search_call/tool_search_output, any of the
+			// Responses built-in tool calls, or a later assistant
+			// message), the conversation has moved past the
+			// approval turn — the held call was approved, executed,
+			// and the model has already spoken since. The "y" is
+			// stale history, not a fresh release; bail so we pass
+			// through to upstream instead of denying with "approval
+			// no longer valid".
 			//
-			// This mirrors Anthropic's natural shape: tool_result there
-			// is a role=user message whose flattened text is empty, so
-			// the existing latest-user-text scan silently goes quiet
-			// once a tool runs. The Responses API splits message and
-			// function_call_output into separate item types, so we have
-			// to skip past them explicitly to get the same behavior.
+			// Inverting the test (latest item must be a user
+			// message) rather than enumerating every
+			// staleness-signal item type avoids silently re-firing
+			// the release path when OpenAI introduces a new
+			// Responses item type — the previous enumeration missed
+			// tool_search_call/tool_search_output (Codex's built-in
+			// tool-discovery items) and reasoning items, both of
+			// which Codex round-trips on continuation requests.
 			//
-			// custom_tool_call is included because Responses round-trips
-			// it as an input-acceptable item type (see
-			// sanitizeResponsesItemForInput); a released custom tool
-			// call sitting after the stale "y" would otherwise re-fire
-			// this scan the same way function_call did.
-			itemUserIdx := -1
-			for i := len(items) - 1; i >= 0; i-- {
-				switch items[i].Type {
-				case "function_call", "function_call_output", "custom_tool_call":
-					return "", ""
-				case "message":
-					if items[i].Role == "user" {
-						itemUserIdx = i
-					}
-				}
-				if itemUserIdx >= 0 {
-					break
-				}
-			}
-			if itemUserIdx < 0 {
+			// This mirrors Anthropic's natural shape: tool_result
+			// there is a role=user message whose flattened text is
+			// empty, so the existing latest-user-text scan silently
+			// goes quiet once a tool runs. The Responses API splits
+			// message and tool items into separate item types, so
+			// we have to make the "moved past the reply" check
+			// explicit.
+			n := len(items)
+			if n == 0 {
 				return "", ""
 			}
-			verb, id = ParseApprovalReplyText(flattenOpenAIContent(items[itemUserIdx].Content))
+			last := items[n-1]
+			if last.Type != "message" || last.Role != "user" {
+				return "", ""
+			}
+			verb, id = ParseApprovalReplyText(flattenOpenAIContent(last.Content))
 			if verb == "" || id != "" {
 				return verb, id
 			}
-			for i := itemUserIdx - 1; i >= 0; i-- {
+			for i := n - 2; i >= 0; i-- {
 				if items[i].Type != "message" || items[i].Role != "assistant" {
 					continue
 				}


### PR DESCRIPTION
## Summary
- The Responses-input scan in `OpenAIApprovalReply` only bailed on `function_call` / `function_call_output` / `custom_tool_call` items appearing after the user's bare \`y\`. Codex's `tool_search_call` / `tool_search_output` round-trip and `reasoning` items slipped through, so once the inline-task hold was consumed on turn N, every follow-up still carried \`y\` in history and the proxy re-fired the release path — denying with \`synth_error_APPROVAL_RELEASE_ERROR\` (\"this approval is no longer valid\") on turn N+1.
- Invert the test instead of enumerating item types: the last input item must be a user message; anything else means the conversation has moved past the approval turn. Robust to future Responses item types OpenAI adds.
- Adds regression tests for the tool_search round-trip case (reproduces the exact item sequence from the captured raw log) and the bare assistant-message case.

## Test plan
- [x] `go test ./internal/runtime/conversation/` — all existing approval-reply tests still pass, two new ones added.
- [x] `go test ./internal/runtime/llmproxy/ ./internal/api/handlers/` — no regressions in dependent packages.