### PR TITLE
feat(llmproxy): log upstream 4xx/5xx response bodies

### DIFF
--- a/internal/api/handlers/llm_endpoint.go
+++ b/internal/api/handlers/llm_endpoint.go
@@ -995,6 +995,16 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 
 			streamResp.Commit()
 
+			if resp.StatusCode >= 400 {
+				h.Logger.WarnContext(r.Context(), "lite-proxy streaming upstream error body",
+					"request_id", requestID,
+					"agent_id", agent.ID,
+					"provider", string(provider),
+					"status", resp.StatusCode,
+					"body_preview", truncateForLog(capturedUpstream.String(), 2048),
+				)
+			}
+
 			if resp.StatusCode < 400 {
 				if usage := llmproxy.ExtractUsage(provider, firstUpstreamCT, capturedUpstream.Bytes(), reqSummary.Model); usage.Found {
 					u := usage
@@ -1114,7 +1124,7 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if resp.StatusCode >= 400 {
-			h.Logger.DebugContext(r.Context(), "lite-proxy upstream error body",
+			h.Logger.WarnContext(r.Context(), "lite-proxy upstream error body",
 				"request_id", requestID,
 				"agent_id", agent.ID,
 				"provider", string(provider),
@@ -2687,7 +2697,13 @@ func (h *LLMEndpointHandler) forwardLitePassthrough(w http.ResponseWriter, r *ht
 			w.Header().Add(name, v)
 		}
 	}
-	if h.RawIOLogger != nil {
+	// Capture the response body whenever the upstream returned an error
+	// status so we can surface its content in slog (forensic visibility
+	// without needing RawIOLogger turned on). On 2xx, only capture if
+	// RawIOLogger is configured to avoid buffering large streamed bodies
+	// for no reason.
+	captureForError := resp.StatusCode >= 400
+	if h.RawIOLogger != nil || captureForError {
 		capture := newLimitedCaptureWriter(h.MaxResponseBytes)
 		w.WriteHeader(resp.StatusCode)
 		_, copyErr := io.Copy(io.MultiWriter(w, capture), resp.Body)
@@ -2696,23 +2712,34 @@ func (h *LLMEndpointHandler) forwardLitePassthrough(w http.ResponseWriter, r *ht
 			*auditReason = copyErr.Error()
 		}
 		full := capture.Bytes()
-		bodyStr, bodyEnc := llmproxy.EncodeBody(full)
-		h.RawIOLogger.Emit(llmproxy.RawIOEvent{
-			Phase:        "harness_response",
-			RequestID:    requestID,
-			UserID:       agent.UserID,
-			AgentID:      agent.ID,
-			Provider:     string(provider),
-			Method:       r.Method,
-			Path:         r.URL.RequestURI(),
-			Status:       resp.StatusCode,
-			ContentType:  resp.Header.Get("Content-Type"),
-			Headers:      llmproxy.SafeHeaderSnapshot(w.Header()),
-			Body:         bodyStr,
-			BodyEncoding: bodyEnc,
-			BodyBytes:    len(full),
-			Marker:       "break_glass_passthrough",
-		})
+		if captureForError {
+			h.Logger.WarnContext(r.Context(), "lite-proxy passthrough upstream error body",
+				"request_id", requestID,
+				"agent_id", agent.ID,
+				"provider", string(provider),
+				"status", resp.StatusCode,
+				"body_preview", truncateForLog(string(full), 2048),
+			)
+		}
+		if h.RawIOLogger != nil {
+			bodyStr, bodyEnc := llmproxy.EncodeBody(full)
+			h.RawIOLogger.Emit(llmproxy.RawIOEvent{
+				Phase:        "harness_response",
+				RequestID:    requestID,
+				UserID:       agent.UserID,
+				AgentID:      agent.ID,
+				Provider:     string(provider),
+				Method:       r.Method,
+				Path:         r.URL.RequestURI(),
+				Status:       resp.StatusCode,
+				ContentType:  resp.Header.Get("Content-Type"),
+				Headers:      llmproxy.SafeHeaderSnapshot(w.Header()),
+				Body:         bodyStr,
+				BodyEncoding: bodyEnc,
+				BodyBytes:    len(full),
+				Marker:       "break_glass_passthrough",
+			})
+		}
 		return
 	}
 	w.WriteHeader(resp.StatusCode)


### PR DESCRIPTION
## Summary
- Surface upstream Anthropic/OpenAI error response bodies in slog at WARN level so the actual error message is visible in gcloud without needing RawIOLogger turned on. Today the proxy logs only the status code + byte count.
- Three call sites covered: buffered LLM endpoint (`DebugContext` → `WarnContext`), streaming SSE endpoint (new block reading the existing `capturedUpstream` buffer), and raw lite-proxy passthrough (extends body capture to fire on `resp.StatusCode >= 400` even when RawIOLogger is off).
- Body preview capped at 2048 chars. No success-path overhead — 2xx still streams as before unless RawIOLogger is configured.

## Motivation
Today a 4xx from Anthropic looks like this in gcloud:

```
"lite-proxy upstream headers received" status=400 anthropic_request_id=req_011…
"lite_proxy.upstream_progress.body_first_byte" chunk_bytes=192
"lite_proxy.upstream_progress.body_eof" bytes_total=192
"lite-proxy request completed" http_status=400 outcome=client_error
```

The 192-byte error body — the actual reason Anthropic returned 400 — is captured and immediately discarded. Debugging requires either replaying the request locally with the proxy's exact preprocessing or running raw curl tests against Anthropic. With this change, the body content shows up directly.

## Tradeoff acknowledged
Anthropic's error `message` field can quote offending request values into the body (e.g., `"text: invalid value: \"<some user content>\""`). Those snippets land in Cloud Logging via this log line. Accepted tradeoff — error-path debug speed matters more than perfect content isolation for non-200 responses.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/api/handlers/`
- [ ] Verify in staging: trigger a 4xx (e.g., send malformed Anthropic request through the proxy) and confirm the new `body_preview` field shows up in Cloud Logging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)