### PR TITLE
fix(llmproxy): isolate choice rewrites and support inline blocked tool substitutions

### DIFF
--- a/internal/runtime/conversation/anthropic_response.go
+++ b/internal/runtime/conversation/anthropic_response.go
@@ -84,7 +84,7 @@ func (rw AnthropicResponseRewriter) rewriteJSON(body []byte, eval ToolUseEvaluat
 			if !verdict.Allowed {
 				anyBlocked = true
 				txt := verdict.SubstituteWith
-				if txt == "" {
+				if txt == "" && !verdict.SuppressSubstituteText {
 					reason := verdict.Reason
 					if reason == "" {
 						reason = "blocked by policy"
@@ -321,7 +321,7 @@ func (rw AnthropicResponseRewriter) rewriteSSE(body []byte, eval ToolUseEvaluato
 			verdict := verdicts[pb]
 			if !verdict.Allowed {
 				txt := verdict.SubstituteWith
-				if txt == "" {
+				if txt == "" && !verdict.SuppressSubstituteText {
 					reason := verdict.Reason
 					if reason == "" {
 						reason = "blocked by policy"

--- a/internal/runtime/conversation/anthropic_response.go
+++ b/internal/runtime/conversation/anthropic_response.go
@@ -58,12 +58,14 @@ func (rw AnthropicResponseRewriter) rewriteJSON(body []byte, eval ToolUseEvaluat
 	anyBlocked := false
 	anyRewritten := false
 	index := 0
-	for i, block := range resp.Content {
+	newContent := make([]anthropicJSONContent, 0, len(resp.Content))
+	for _, block := range resp.Content {
 		switch block.Type {
 		case "text":
 			if block.Text != "" {
 				frags = append(frags, assistantFragment{Text: block.Text})
 			}
+			newContent = append(newContent, block)
 		case "tool_use":
 			tu := ToolUse{
 				ID:    block.ID,
@@ -78,26 +80,56 @@ func (rw AnthropicResponseRewriter) rewriteJSON(body []byte, eval ToolUseEvaluat
 				Verdict:          verdict,
 				ToolInputPreview: MakeToolInputPreview(block.Input),
 			})
+			finalInput := block.Input
 			if !verdict.Allowed {
 				anyBlocked = true
-			}
-			finalInput := block.Input
-			if verdict.Allowed && len(verdict.RewriteInput) > 0 {
-				resp.Content[i].Input = verdict.RewriteInput
-				finalInput = verdict.RewriteInput
-				anyRewritten = true
+				txt := verdict.SubstituteWith
+				if txt == "" {
+					reason := verdict.Reason
+					if reason == "" {
+						reason = "blocked by policy"
+					}
+					txt = fmt.Sprintf("Tool '%s' was blocked by Clawvisor policy: %s", block.Name, reason)
+				}
+				if txt != "" {
+					newContent = append(newContent, anthropicJSONContent{
+						Type: "text",
+						Text: txt,
+					})
+				}
+			} else {
+				if len(verdict.RewriteInput) > 0 {
+					block.Input = verdict.RewriteInput
+					finalInput = verdict.RewriteInput
+					anyRewritten = true
+				}
+				newContent = append(newContent, block)
 			}
 			frags = append(frags, assistantFragment{
 				IsTool:   true,
 				ToolName: block.Name,
 				ToolArgs: finalInput,
 			})
+		default:
+			newContent = append(newContent, block)
 		}
 	}
 
 	turn := assistantTurnFromFragments(frags, decisions)
-	if !anyBlocked && anyRewritten {
-		// Re-marshal the response with mutated tool_use inputs in place.
+	if anyBlocked || anyRewritten {
+		resp.Content = newContent
+		hasToolUse := false
+		for _, c := range newContent {
+			if c.Type == "tool_use" {
+				hasToolUse = true
+				break
+			}
+		}
+		if hasToolUse {
+			resp.StopReason = "tool_use"
+		} else {
+			resp.StopReason = "end_turn"
+		}
 		rewritten, err := json.Marshal(resp)
 		if err != nil {
 			return RewriteResult{}, fmt.Errorf("anthropic: marshal rewritten response: %w", err)
@@ -109,31 +141,8 @@ func (rw AnthropicResponseRewriter) rewriteJSON(body []byte, eval ToolUseEvaluat
 			AssistantTurn: turn,
 		}, nil
 	}
-	if !anyBlocked {
-		return RewriteResult{Body: body, Decisions: decisions, AssistantTurn: turn}, nil
-	}
 
-	out := anthropicJSONResponse{
-		ID:    resp.ID,
-		Type:  "message",
-		Role:  resp.Role,
-		Model: resp.Model,
-		Content: []anthropicJSONContent{
-			{Type: "text", Text: blockedReasonTextForAssistant(decisions)},
-		},
-		StopReason: "end_turn",
-		Usage:      resp.Usage,
-	}
-	rewritten, err := json.Marshal(out)
-	if err != nil {
-		return RewriteResult{}, fmt.Errorf("anthropic: marshal rewritten response: %w", err)
-	}
-	return RewriteResult{
-		Body:          rewritten,
-		Decisions:     decisions,
-		Rewritten:     true,
-		AssistantTurn: turn,
-	}, nil
+	return RewriteResult{Body: body, Decisions: decisions, AssistantTurn: turn}, nil
 }
 
 type sseEvent struct {
@@ -258,6 +267,7 @@ func (rw AnthropicResponseRewriter) rewriteSSE(body []byte, eval ToolUseEvaluato
 	anyBlocked := false
 	anyRewritten := false
 	rewrittenInput := map[*pendingBlock]json.RawMessage{}
+	verdicts := map[*pendingBlock]ToolUseVerdict{}
 	for _, pb := range orderedTUs {
 		var inputRaw json.RawMessage
 		if pb.input.Len() > 0 {
@@ -275,6 +285,7 @@ func (rw AnthropicResponseRewriter) rewriteSSE(body []byte, eval ToolUseEvaluato
 			Verdict:          verdict,
 			ToolInputPreview: MakeToolInputPreview(inputRaw),
 		})
+		verdicts[pb] = verdict
 		if !verdict.Allowed {
 			anyBlocked = true
 		}
@@ -305,10 +316,35 @@ func (rw AnthropicResponseRewriter) rewriteSSE(body []byte, eval ToolUseEvaluato
 		}
 	}
 	turn := assistantTurnFromFragments(frags, decisions)
-	if !anyBlocked && anyRewritten {
-		// Re-emit the entire turn as SSE with the rewritten input bytes
-		// substituted for the affected tool_use blocks.
-		assembled, err := buildAnthropicMultiBlockSSE(msgID, msgModel, msgRole, orderedAll, rewrittenInput)
+	if anyBlocked || anyRewritten {
+		for _, pb := range orderedTUs {
+			verdict := verdicts[pb]
+			if !verdict.Allowed {
+				txt := verdict.SubstituteWith
+				if txt == "" {
+					reason := verdict.Reason
+					if reason == "" {
+						reason = "blocked by policy"
+					}
+					txt = fmt.Sprintf("Tool '%s' was blocked by Clawvisor policy: %s", pb.name, reason)
+				}
+				pb.isTU = false
+				pb.blockType = "text"
+				pb.text.Reset()
+				if txt != "" {
+					pb.text.WriteString(txt)
+				} else {
+					pb.filtered = true
+				}
+			}
+		}
+		var activeBlocks []*pendingBlock
+		for _, pb := range orderedAll {
+			if !pb.filtered {
+				activeBlocks = append(activeBlocks, pb)
+			}
+		}
+		assembled, err := buildAnthropicMultiBlockSSE(msgID, msgModel, msgRole, activeBlocks, rewrittenInput)
 		if err != nil {
 			return RewriteResult{}, err
 		}
@@ -319,16 +355,8 @@ func (rw AnthropicResponseRewriter) rewriteSSE(body []byte, eval ToolUseEvaluato
 			AssistantTurn: turn,
 		}, nil
 	}
-	if !anyBlocked {
-		return RewriteResult{Body: body, Decisions: decisions, AssistantTurn: turn}, nil
-	}
 
-	return RewriteResult{
-		Body:          synthAnthropicTextSSE(msgID, msgModel, msgRole, blockedReasonTextForAssistant(decisions)),
-		Decisions:     decisions,
-		Rewritten:     true,
-		AssistantTurn: turn,
-	}, nil
+	return RewriteResult{Body: body, Decisions: decisions, AssistantTurn: turn}, nil
 }
 
 // buildAnthropicMultiBlockSSE re-emits a buffered Anthropic streamed

--- a/internal/runtime/conversation/openai_response.go
+++ b/internal/runtime/conversation/openai_response.go
@@ -816,22 +816,49 @@ func (rw OpenAIResponseRewriter) rewriteChatCompletionsSSE(body []byte, eval Too
 		name string
 		args strings.Builder
 	}
-	pending := map[int]*pendingCall{}
-	var decisions []ToolUseDecisionRecord
-	var frags []assistantFragment
-	anyBlocked := false
-	anyRewritten := false
-	var orderedChatCalls []orderedChatToolCall
+	type pendingEvalBoundary struct {
+		textPre      string
+		pendingCalls map[int]*pendingCall
+	}
+	type choiceSSEState struct {
+		index      int
+		pending    map[int]*pendingCall
+		text       strings.Builder
+		boundaries []pendingEvalBoundary
+	}
+	type toolCallState struct {
+		allowed        bool
+		arguments      string
+		origTotalLen   int
+		origReadLen    int
+		writtenArgsLen int
+	}
+	type choiceEvaluation struct {
+		blockedPrompts   string
+		allowedToolCalls []orderedChatToolCall
+		choiceBlocked    bool
+		choiceRewritten  bool
+		toolStates       map[int]*toolCallState
+	}
+
+	var choiceOrder []int
+	choiceStates := map[int]*choiceSSEState{}
+	getOrCreateState := func(ci int) *choiceSSEState {
+		cs, ok := choiceStates[ci]
+		if !ok {
+			cs = &choiceSSEState{
+				index:   ci,
+				pending: map[int]*pendingCall{},
+			}
+			choiceStates[ci] = cs
+			choiceOrder = append(choiceOrder, ci)
+		}
+		return cs
+	}
+
 	var streamID string
-	var text strings.Builder
-	// leadingText preserves the assistant's prose that arrived BEFORE any
-	// tool_calls in the same stream. Once finish_reason="tool_calls" fires,
-	// `text` gets reset (so a subsequent fragment-walk doesn't double-count
-	// it), but the rewrite path still needs the prose when synthesizing the
-	// re-emitted SSE — otherwise mixed text+tool streams silently drop their
-	// leading text after rewrite.
-	var leadingText strings.Builder
-	var blockedPrompts strings.Builder
+
+	// Pass 1: Parse all events to construct decisions and choiceEvaluations
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
 		if !strings.HasPrefix(line, "data:") {
@@ -852,14 +879,15 @@ func (rw OpenAIResponseRewriter) rewriteChatCompletionsSSE(body []byte, eval Too
 			streamID = event.ID
 		}
 		for _, choice := range event.Choices {
+			cs := getOrCreateState(choice.Index)
 			if txt := flattenOpenAIContentFromAny(choice.Delta.Content); txt != "" {
-				text.WriteString(txt)
+				cs.text.WriteString(txt)
 			}
 			for _, tc := range choice.Delta.ToolCalls {
-				pc := pending[tc.Index]
+				pc := cs.pending[tc.Index]
 				if pc == nil {
 					pc = &pendingCall{}
-					pending[tc.Index] = pc
+					cs.pending[tc.Index] = pc
 				}
 				if tc.ID != "" {
 					pc.id = tc.ID
@@ -872,166 +900,295 @@ func (rw OpenAIResponseRewriter) rewriteChatCompletionsSSE(body []byte, eval Too
 				}
 			}
 			if choice.FinishReason == "tool_calls" {
-				if text.Len() > 0 {
-					leadingText.WriteString(text.String())
-					frags = append(frags, assistantFragment{Text: text.String()})
-					text.Reset()
+				cs.boundaries = append(cs.boundaries, pendingEvalBoundary{
+					textPre:      cs.text.String(),
+					pendingCalls: cs.pending,
+				})
+				cs.text.Reset()
+				cs.pending = map[int]*pendingCall{}
+			}
+		}
+	}
+
+	for _, ci := range choiceOrder {
+		cs := choiceStates[ci]
+		if cs.text.Len() > 0 || len(cs.pending) > 0 {
+			cs.boundaries = append(cs.boundaries, pendingEvalBoundary{
+				textPre:      cs.text.String(),
+				pendingCalls: cs.pending,
+			})
+			cs.text.Reset()
+			cs.pending = map[int]*pendingCall{}
+		}
+	}
+
+	choiceEvaluations := map[int][]choiceEvaluation{}
+	var decisions []ToolUseDecisionRecord
+	var frags []assistantFragment
+	anyBlocked := false
+	anyRewritten := false
+
+	for _, ci := range choiceOrder {
+		cs := choiceStates[ci]
+		var evals []choiceEvaluation
+
+		for _, boundary := range cs.boundaries {
+			if boundary.textPre != "" {
+				frags = append(frags, assistantFragment{Text: boundary.textPre})
+			}
+			if len(boundary.pendingCalls) == 0 {
+				continue
+			}
+
+			toolCallIndexes := make([]int, 0, len(boundary.pendingCalls))
+			for toolCallIndex := range boundary.pendingCalls {
+				toolCallIndexes = append(toolCallIndexes, toolCallIndex)
+			}
+			sort.Ints(toolCallIndexes)
+
+			var choiceBlockedPrompts strings.Builder
+			var choiceOrderedChatCalls []orderedChatToolCall
+			choiceBlocked := false
+			choiceRewritten := false
+			toolStates := map[int]*toolCallState{}
+
+			for _, toolCallIndex := range toolCallIndexes {
+				pc := boundary.pendingCalls[toolCallIndex]
+				tu := ToolUse{
+					ID:    pc.id,
+					Index: toolCallIndex,
+					Name:  pc.name,
+					Input: rawIfJSONOpenAI(pc.args.String()),
 				}
-				toolCallIndexes := make([]int, 0, len(pending))
-				for toolCallIndex := range pending {
-					toolCallIndexes = append(toolCallIndexes, toolCallIndex)
-				}
-				sort.Ints(toolCallIndexes)
-				for _, toolCallIndex := range toolCallIndexes {
-					pc := pending[toolCallIndex]
-					tu := ToolUse{
-						ID:    pc.id,
-						Index: toolCallIndex,
-						Name:  pc.name,
-						Input: rawIfJSONOpenAI(pc.args.String()),
-					}
-					verdict := eval(tu)
-					decisions = append(decisions, ToolUseDecisionRecord{
-						ToolUse:          tu,
-						Verdict:          verdict,
-						ToolInputPreview: MakeToolInputPreview(tu.Input),
-					})
-					finalArgs := pc.args.String()
-					fragArgs := tu.Input
-					if !verdict.Allowed {
-						anyBlocked = true
-						txt := verdict.SubstituteWith
-						if txt == "" {
-							reason := verdict.Reason
-							if reason == "" {
-								reason = "blocked by policy"
-							}
-							txt = fmt.Sprintf("Tool '%s' was blocked by Clawvisor policy: %s", pc.name, reason)
+				verdict := eval(tu)
+				decisions = append(decisions, ToolUseDecisionRecord{
+					ToolUse:          tu,
+					Verdict:          verdict,
+					ToolInputPreview: MakeToolInputPreview(tu.Input),
+				})
+				finalArgs := pc.args.String()
+				fragArgs := tu.Input
+				if !verdict.Allowed {
+					anyBlocked = true
+					choiceBlocked = true
+					txt := verdict.SubstituteWith
+					if txt == "" {
+						reason := verdict.Reason
+						if reason == "" {
+							reason = "blocked by policy"
 						}
-						if txt != "" {
-							if blockedPrompts.Len() > 0 {
-								blockedPrompts.WriteString("\n\n")
+						txt = fmt.Sprintf("Tool '%s' was blocked by Clawvisor policy: %s", pc.name, reason)
+					}
+					if txt != "" {
+						if choiceBlockedPrompts.Len() > 0 {
+							choiceBlockedPrompts.WriteString("\n\n")
+						}
+						choiceBlockedPrompts.WriteString(txt)
+					}
+					toolStates[toolCallIndex] = &toolCallState{
+						allowed:      false,
+						origTotalLen: pc.args.Len(),
+					}
+				} else {
+					if len(verdict.RewriteInput) > 0 {
+						finalArgs = string(verdict.RewriteInput)
+						fragArgs = verdict.RewriteInput
+						anyRewritten = true
+						choiceRewritten = true
+					}
+					choiceOrderedChatCalls = append(choiceOrderedChatCalls, orderedChatToolCall{
+						index:     toolCallIndex,
+						id:        pc.id,
+						name:      pc.name,
+						arguments: finalArgs,
+					})
+					toolStates[toolCallIndex] = &toolCallState{
+						allowed:      true,
+						arguments:    finalArgs,
+						origTotalLen: pc.args.Len(),
+					}
+				}
+				frags = append(frags, assistantFragment{IsTool: true, ToolName: pc.name, ToolArgs: fragArgs})
+			}
+
+			evals = append(evals, choiceEvaluation{
+				blockedPrompts:   choiceBlockedPrompts.String(),
+				allowedToolCalls: choiceOrderedChatCalls,
+				choiceBlocked:    choiceBlocked,
+				choiceRewritten:  choiceRewritten,
+				toolStates:       toolStates,
+			})
+		}
+		if len(evals) > 0 {
+			choiceEvaluations[ci] = evals
+		}
+	}
+
+	turn := assistantTurnFromFragments(frags, decisions)
+
+	// Pass 2: Replay the original stream line-by-line, applying rewrites at the tool-call boundaries
+	if anyBlocked || anyRewritten {
+		var rewrittenBody strings.Builder
+		replayTurn := map[int]int{}
+
+		for _, originalLine := range lines {
+			line := strings.TrimSpace(originalLine)
+			if !strings.HasPrefix(line, "data:") {
+				rewrittenBody.WriteString(originalLine + "\n")
+				continue
+			}
+			payload := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+			if payload == "" {
+				rewrittenBody.WriteString("data:\n")
+				continue
+			}
+			if payload == "[DONE]" {
+				rewrittenBody.WriteString("data: [DONE]\n")
+				continue
+			}
+			var event map[string]any
+			if err := json.Unmarshal([]byte(payload), &event); err != nil {
+				rewrittenBody.WriteString("data: " + payload + "\n")
+				continue
+			}
+			choicesRaw, ok := event["choices"]
+			if !ok {
+				rewrittenBody.WriteString("data: " + payload + "\n")
+				continue
+			}
+			eventChoices, ok := choicesRaw.([]any)
+			if !ok {
+				rewrittenBody.WriteString("data: " + payload + "\n")
+				continue
+			}
+
+			for _, choiceRaw := range eventChoices {
+				choice, ok := choiceRaw.(map[string]any)
+				if !ok {
+					continue
+				}
+				cIdxFloat, _ := choice["index"].(float64)
+				cIdx := int(cIdxFloat)
+				delta, _ := choice["delta"].(map[string]any)
+				if delta == nil {
+					delta = map[string]any{}
+					choice["delta"] = delta
+				}
+
+				// Filter and rewrite incremental tool calls
+				if toolCallsRaw, ok := delta["tool_calls"].([]any); ok {
+					var newToolCalls []any
+					for _, tcRaw := range toolCallsRaw {
+						tc, ok := tcRaw.(map[string]any)
+						if !ok {
+							continue
+						}
+						tcIdxFloat, _ := tc["index"].(float64)
+						tcIdx := int(tcIdxFloat)
+
+						evals := choiceEvaluations[cIdx]
+						rIdx := replayTurn[cIdx]
+						if rIdx < len(evals) {
+							eval := evals[rIdx]
+							if tState := eval.toolStates[tcIdx]; tState != nil {
+								if !tState.allowed {
+									// Blocked: skip/omit from the stream
+									continue
+								}
+								// Allowed: rewrite arguments delta proportionally
+								tcFunc, _ := tc["function"].(map[string]any)
+								if tcFunc != nil {
+									if origArgsDelta, ok := tcFunc["arguments"].(string); ok {
+										tState.origReadLen += len(origArgsDelta)
+										var newDelta string
+										if tState.origTotalLen == 0 {
+											newDelta = tState.arguments
+											tState.writtenArgsLen = len(tState.arguments)
+										} else if tState.origReadLen >= tState.origTotalLen {
+											newDelta = tState.arguments[tState.writtenArgsLen:]
+											tState.writtenArgsLen = len(tState.arguments)
+										} else {
+											ratio := float64(len(origArgsDelta)) / float64(tState.origTotalLen)
+											chunkSize := int(ratio * float64(len(tState.arguments)))
+											if chunkSize < 1 && len(origArgsDelta) > 0 {
+												chunkSize = 1
+											}
+											if tState.writtenArgsLen+chunkSize > len(tState.arguments) {
+												chunkSize = len(tState.arguments) - tState.writtenArgsLen
+											}
+											newDelta = tState.arguments[tState.writtenArgsLen : tState.writtenArgsLen+chunkSize]
+											tState.writtenArgsLen += chunkSize
+										}
+										tcFunc["arguments"] = newDelta
+									}
+								}
 							}
-							blockedPrompts.WriteString(txt)
+						}
+						newToolCalls = append(newToolCalls, tcRaw)
+					}
+					if len(newToolCalls) > 0 {
+						delta["tool_calls"] = newToolCalls
+					} else {
+						delete(delta, "tool_calls")
+					}
+				}
+
+				finishReason, _ := choice["finish_reason"].(string)
+
+				if finishReason == "tool_calls" {
+					evals := choiceEvaluations[cIdx]
+					rIdx := replayTurn[cIdx]
+					if rIdx < len(evals) {
+						eval := evals[rIdx]
+						replayTurn[cIdx]++
+
+						if eval.blockedPrompts != "" {
+							origContent, _ := delta["content"].(string)
+							if origContent != "" {
+								delta["content"] = origContent + "\n\n" + eval.blockedPrompts
+							} else {
+								delta["content"] = eval.blockedPrompts
+							}
+						}
+
+						if len(eval.allowedToolCalls) > 0 {
+							choice["finish_reason"] = "tool_calls"
+						} else {
+							choice["finish_reason"] = "stop"
 						}
 					} else {
-						if len(verdict.RewriteInput) > 0 {
-							finalArgs = string(verdict.RewriteInput)
-							fragArgs = verdict.RewriteInput
-							anyRewritten = true
-						}
-						orderedChatCalls = append(orderedChatCalls, orderedChatToolCall{
-							index:     toolCallIndex,
-							id:        pc.id,
-							name:      pc.name,
-							arguments: finalArgs,
-						})
+						choice["finish_reason"] = "stop"
 					}
-					frags = append(frags, assistantFragment{IsTool: true, ToolName: pc.name, ToolArgs: fragArgs})
 				}
-				pending = map[int]*pendingCall{}
+			}
+
+			rewrittenPayload, err := json.Marshal(event)
+			if err == nil {
+				rewrittenBody.WriteString("data: " + string(rewrittenPayload) + "\n")
+			} else {
+				rewrittenBody.WriteString("data: " + payload + "\n")
 			}
 		}
-	}
-	if text.Len() > 0 {
-		frags = append(frags, assistantFragment{Text: text.String()})
-	}
-	turn := assistantTurnFromFragments(frags, decisions)
-	if anyBlocked && len(orderedChatCalls) == 0 {
-		combinedText := leadingText.String()
-		if blockedPrompts.Len() > 0 {
-			if combinedText != "" {
-				combinedText += "\n\n"
-			}
-			combinedText += blockedPrompts.String()
+
+		// Ensure the returned body ends with the standard trailing newlines
+		bodyStr := rewrittenBody.String()
+		if strings.HasSuffix(bodyStr, "\n") {
+			bodyStr = strings.TrimSuffix(bodyStr, "\n")
 		}
-		combinedText += text.String()
-		return RewriteResult{
-			Body:          synthOpenAIChatTextSSE(combinedText),
-			Decisions:     decisions,
-			Rewritten:     true,
-			AssistantTurn: turn,
-		}, nil
+		return RewriteResult{Body: []byte(bodyStr + "\n"), Decisions: decisions, Rewritten: true, AssistantTurn: turn}, nil
 	}
-	if anyBlocked || anyRewritten {
-		combinedText := leadingText.String()
-		if blockedPrompts.Len() > 0 {
-			if combinedText != "" {
-				combinedText += "\n\n"
-			}
-			combinedText += blockedPrompts.String()
-		}
-		combinedText += text.String()
-		out := buildOpenAIChatMultiSSE(streamID, combinedText, orderedChatCalls)
-		return RewriteResult{Body: out, Decisions: decisions, Rewritten: true, AssistantTurn: turn}, nil
-	}
+
 	return RewriteResult{Body: body, Decisions: decisions, AssistantTurn: turn}, nil
 }
 
 // orderedChatToolCall captures one tool_call in a Chat Completions
-// stream, in the order it completed. Used by buildOpenAIChatMultiSSE
-// to re-emit the assistant turn when one or more arguments were
-// rewritten.
+// stream, in the order it completed. Used to re-emit the assistant
+// turn when one or more arguments were rewritten.
 type orderedChatToolCall struct {
 	index     int
 	id        string
 	name      string
 	arguments string
-}
-
-// buildOpenAIChatMultiSSE emits a Chat-Completions-shaped SSE stream
-// containing the supplied tool_calls in order, plus any preceding
-// streamed text. Used when the rewriter mutated one or more
-// function.arguments values.
-func buildOpenAIChatMultiSSE(streamID, leadingText string, calls []orderedChatToolCall) []byte {
-	if streamID == "" {
-		streamID = "chatcmpl_clawvisor_rewrite"
-	}
-	var b strings.Builder
-	b.WriteString(chatCompletionSSEBlock(map[string]any{
-		"id":      streamID,
-		"object":  "chat.completion.chunk",
-		"choices": []map[string]any{{"index": 0, "delta": map[string]any{"role": "assistant"}, "finish_reason": nil}},
-	}))
-	if leadingText != "" {
-		b.WriteString(chatCompletionSSEBlock(map[string]any{
-			"id":      streamID,
-			"object":  "chat.completion.chunk",
-			"choices": []map[string]any{{"index": 0, "delta": map[string]any{"content": leadingText}, "finish_reason": nil}},
-		}))
-	}
-	if len(calls) > 0 {
-		toolCalls := make([]map[string]any, 0, len(calls))
-		for _, c := range calls {
-			toolCalls = append(toolCalls, map[string]any{
-				"index": c.index,
-				"id":    c.id,
-				"type":  "function",
-				"function": map[string]any{
-					"name":      c.name,
-					"arguments": c.arguments,
-				},
-			})
-		}
-		b.WriteString(chatCompletionSSEBlock(map[string]any{
-			"id":      streamID,
-			"object":  "chat.completion.chunk",
-			"choices": []map[string]any{{"index": 0, "delta": map[string]any{"tool_calls": toolCalls}, "finish_reason": nil}},
-		}))
-		b.WriteString(chatCompletionSSEBlock(map[string]any{
-			"id":      streamID,
-			"object":  "chat.completion.chunk",
-			"choices": []map[string]any{{"index": 0, "delta": map[string]any{}, "finish_reason": "tool_calls"}},
-		}))
-	} else {
-		b.WriteString(chatCompletionSSEBlock(map[string]any{
-			"id":      streamID,
-			"object":  "chat.completion.chunk",
-			"choices": []map[string]any{{"index": 0, "delta": map[string]any{}, "finish_reason": "stop"}},
-		}))
-	}
-	b.WriteString("data: [DONE]\n\n")
-	return []byte(b.String())
 }
 
 func SynthOpenAIResponsesTextJSON(text string) []byte {

--- a/internal/runtime/conversation/openai_response.go
+++ b/internal/runtime/conversation/openai_response.go
@@ -109,7 +109,8 @@ func (rw OpenAIResponseRewriter) rewriteResponsesJSON(body []byte, eval ToolUseE
 		anyRewritten bool
 		index        int
 	)
-	for i, item := range resp.Output {
+	newOutput := make([]openAIResponseOutputItem, 0, len(resp.Output))
+	for _, item := range resp.Output {
 		switch item.Type {
 		case "message":
 			for _, part := range item.Content {
@@ -117,6 +118,7 @@ func (rw OpenAIResponseRewriter) rewriteResponsesJSON(body []byte, eval ToolUseE
 					frags = append(frags, assistantFragment{Text: part.Text})
 				}
 			}
+			newOutput = append(newOutput, item)
 		case "function_call":
 			args := stringifyOpenAIArguments(item.Arguments)
 			tu := ToolUse{
@@ -132,19 +134,42 @@ func (rw OpenAIResponseRewriter) rewriteResponsesJSON(body []byte, eval ToolUseE
 				Verdict:          verdict,
 				ToolInputPreview: MakeToolInputPreview(tu.Input),
 			})
+			finalArgs := tu.Input
 			if !verdict.Allowed {
 				anyBlocked = true
-			}
-			finalArgs := tu.Input
-			if verdict.Allowed && len(verdict.RewriteInput) > 0 {
-				resp.Output[i].Arguments = string(verdict.RewriteInput)
-				finalArgs = verdict.RewriteInput
-				anyRewritten = true
+				txt := verdict.SubstituteWith
+				if txt == "" {
+					reason := verdict.Reason
+					if reason == "" {
+						reason = "blocked by policy"
+					}
+					txt = fmt.Sprintf("Tool '%s' was blocked by Clawvisor policy: %s", item.Name, reason)
+				}
+				if txt != "" {
+					newOutput = append(newOutput, openAIResponseOutputItem{
+						ID:     "msg_" + tu.ID,
+						Type:   "message",
+						Role:   "assistant",
+						Status: "completed",
+						Content: []openAIResponseContent{{
+							Type: "output_text",
+							Text: txt,
+						}},
+					})
+				}
+			} else {
+				if len(verdict.RewriteInput) > 0 {
+					item.Arguments = string(verdict.RewriteInput)
+					finalArgs = verdict.RewriteInput
+					anyRewritten = true
+				}
+				newOutput = append(newOutput, item)
 			}
 			frags = append(frags, assistantFragment{IsTool: true, ToolName: item.Name, ToolArgs: finalArgs})
 		case "custom_tool_call":
 			tu, ok := toolUseFromOpenAICustomToolCall(item, index)
 			if !ok {
+				newOutput = append(newOutput, item)
 				continue
 			}
 			index++
@@ -156,42 +181,55 @@ func (rw OpenAIResponseRewriter) rewriteResponsesJSON(body []byte, eval ToolUseE
 			})
 			if !verdict.Allowed {
 				anyBlocked = true
+				txt := verdict.SubstituteWith
+				if txt == "" {
+					reason := verdict.Reason
+					if reason == "" {
+						reason = "blocked by policy"
+					}
+					txt = fmt.Sprintf("Tool '%s' was blocked by Clawvisor policy: %s", tu.Name, reason)
+				}
+				if txt != "" {
+					newOutput = append(newOutput, openAIResponseOutputItem{
+						ID:     "msg_" + tu.ID,
+						Type:   "message",
+						Role:   "assistant",
+						Status: "completed",
+						Content: []openAIResponseContent{{
+							Type: "output_text",
+							Text: txt,
+						}},
+					})
+				}
+			} else {
+				newOutput = append(newOutput, item)
 			}
 			frags = append(frags, assistantFragment{IsTool: true, ToolName: tu.Name, ToolArgs: tu.Input})
+		default:
+			newOutput = append(newOutput, item)
 		}
 	}
 	turn := assistantTurnFromFragments(frags, decisions)
-	if !anyBlocked && anyRewritten {
+	if anyBlocked || anyRewritten {
+		resp.Output = newOutput
+		var outputTextParts []string
+		for _, o := range newOutput {
+			if o.Type == "message" {
+				for _, c := range o.Content {
+					if c.Text != "" {
+						outputTextParts = append(outputTextParts, c.Text)
+					}
+				}
+			}
+		}
+		resp.OutputText = strings.Join(outputTextParts, "\n\n")
 		rewritten, err := json.Marshal(resp)
 		if err != nil {
 			return RewriteResult{}, fmt.Errorf("openai responses: marshal rewritten response: %w", err)
 		}
 		return RewriteResult{Body: rewritten, Decisions: decisions, Rewritten: true, AssistantTurn: turn}, nil
 	}
-	if !anyBlocked {
-		return RewriteResult{Body: body, Decisions: decisions, AssistantTurn: turn}, nil
-	}
-	out := openAIResponsesJSON{
-		ID:     resp.ID,
-		Object: firstNonEmpty(resp.Object, "response"),
-		Model:  resp.Model,
-		Output: []openAIResponseOutputItem{{
-			ID:     "msg_clawvisor_block",
-			Type:   "message",
-			Role:   "assistant",
-			Status: "completed",
-			Content: []openAIResponseContent{{
-				Type: "output_text",
-				Text: blockedReasonTextForAssistant(decisions),
-			}},
-		}},
-		OutputText: blockedReasonTextForAssistant(decisions),
-	}
-	rewritten, err := json.Marshal(out)
-	if err != nil {
-		return RewriteResult{}, fmt.Errorf("openai responses: marshal rewritten response: %w", err)
-	}
-	return RewriteResult{Body: rewritten, Decisions: decisions, Rewritten: true, AssistantTurn: turn}, nil
+	return RewriteResult{Body: body, Decisions: decisions, AssistantTurn: turn}, nil
 }
 
 func (rw OpenAIResponseRewriter) rewriteResponsesSSE(body []byte, eval ToolUseEvaluator) (RewriteResult, error) {
@@ -335,24 +373,40 @@ func (rw OpenAIResponseRewriter) rewriteResponsesSSE(body []byte, eval ToolUseEv
 					Verdict:          verdict,
 					ToolInputPreview: MakeToolInputPreview(tu.Input),
 				})
-				if !verdict.Allowed {
-					anyBlocked = true
-				}
 				finalArgs := originalArgs
 				fragArgs := tu.Input
-				if verdict.Allowed && len(verdict.RewriteInput) > 0 {
-					finalArgs = string(verdict.RewriteInput)
-					fragArgs = verdict.RewriteInput
-					anyRewritten = true
+				if !verdict.Allowed {
+					anyBlocked = true
+					txt := verdict.SubstituteWith
+					if txt == "" {
+						reason := verdict.Reason
+						if reason == "" {
+							reason = "blocked by policy"
+						}
+						txt = fmt.Sprintf("Tool '%s' was blocked by Clawvisor policy: %s", pc.name, reason)
+					}
+					if txt != "" {
+						orderedItems = append(orderedItems, orderedResponsesItem{
+							isText:      true,
+							outputIndex: pc.outputIndex,
+							text:        txt,
+						})
+					}
+				} else {
+					if len(verdict.RewriteInput) > 0 {
+						finalArgs = string(verdict.RewriteInput)
+						fragArgs = verdict.RewriteInput
+						anyRewritten = true
+					}
+					orderedItems = append(orderedItems, orderedResponsesItem{
+						outputIndex: pc.outputIndex,
+						itemID:      pc.itemID,
+						callID:      pc.callID,
+						name:        pc.name,
+						arguments:   finalArgs,
+					})
 				}
 				frags = append(frags, assistantFragment{IsTool: true, ToolName: pc.name, ToolArgs: fragArgs})
-				orderedItems = append(orderedItems, orderedResponsesItem{
-					outputIndex: pc.outputIndex,
-					itemID:      pc.itemID,
-					callID:      pc.callID,
-					name:        pc.name,
-					arguments:   finalArgs,
-				})
 				delete(pending, raw.Item.ID)
 			case "custom_tool_call":
 				tu, ok := toolUseFromOpenAICustomToolCall(raw.Item, index)
@@ -368,23 +422,32 @@ func (rw OpenAIResponseRewriter) rewriteResponsesSSE(body []byte, eval ToolUseEv
 				})
 				if !verdict.Allowed {
 					anyBlocked = true
+					txt := verdict.SubstituteWith
+					if txt == "" {
+						reason := verdict.Reason
+						if reason == "" {
+							reason = "blocked by policy"
+						}
+						txt = fmt.Sprintf("Tool '%s' was blocked by Clawvisor policy: %s", tu.Name, reason)
+					}
+					if txt != "" {
+						orderedItems = append(orderedItems, orderedResponsesItem{
+							isText:      true,
+							outputIndex: raw.OutputIndex,
+							text:        txt,
+						})
+					}
+				} else {
+					orderedItems = append(orderedItems, orderedResponsesItem{
+						isCustomToolCall: true,
+						outputIndex:      raw.OutputIndex,
+						itemID:           raw.Item.ID,
+						callID:           raw.Item.CallID,
+						name:             tu.Name,
+						customInput:      customToolInputForReemit(raw.Item.Input, raw.Item.Arguments),
+					})
 				}
 				frags = append(frags, assistantFragment{IsTool: true, ToolName: tu.Name, ToolArgs: tu.Input})
-				// Preserve custom_tool_call in the ordered stream so a
-				// sibling function_call rewrite doesn't silently drop it
-				// from the synthesized SSE re-emit. The OpenAI spec
-				// types `custom_tool_call.input` as a string, so we
-				// keep the original wire value (item.Input) rather
-				// than our normalized JSON shape (tu.Input, which can
-				// be an object wrapping freeform text).
-				orderedItems = append(orderedItems, orderedResponsesItem{
-					isCustomToolCall: true,
-					outputIndex:      raw.OutputIndex,
-					itemID:           raw.Item.ID,
-					callID:           raw.Item.CallID,
-					name:             tu.Name,
-					customInput:      customToolInputForReemit(raw.Item.Input, raw.Item.Arguments),
-				})
 			default:
 				// Unknown item type (reasoning, web_search_call,
 				// image_generation_call, MCP tool calls, …). Preserve
@@ -402,7 +465,8 @@ func (rw OpenAIResponseRewriter) rewriteResponsesSSE(body []byte, eval ToolUseEv
 		}
 	}
 	turn := assistantTurnFromFragments(frags, decisions)
-	if !anyBlocked && anyRewritten {
+
+	if anyBlocked || anyRewritten {
 		// Emit a synthesized Responses-API SSE stream with the rewritten
 		// function_call arguments substituted in. Other items pass
 		// through verbatim.
@@ -414,15 +478,7 @@ func (rw OpenAIResponseRewriter) rewriteResponsesSSE(body []byte, eval ToolUseEv
 			AssistantTurn: turn,
 		}, nil
 	}
-	if !anyBlocked {
-		return RewriteResult{Body: body, Decisions: decisions, AssistantTurn: turn}, nil
-	}
-	return RewriteResult{
-		Body:          synthOpenAIResponsesTextSSE(blockedReasonTextForAssistant(decisions)),
-		Decisions:     decisions,
-		Rewritten:     true,
-		AssistantTurn: turn,
-	}, nil
+	return RewriteResult{Body: body, Decisions: decisions, AssistantTurn: turn}, nil
 }
 
 // buildOpenAIResponsesMultiSSE emits a Responses-API SSE stream
@@ -436,6 +492,8 @@ func buildOpenAIResponsesMultiSSE(items []orderedResponsesItem) []byte {
 		"type":     "response.created",
 		"response": map[string]any{"id": "resp_clawvisor_rewrite", "status": "in_progress"},
 	}))
+	var outputItems []map[string]any
+	var outputTexts []string
 	for i, it := range items {
 		outputIndex := it.outputIndex
 		if it.isText {
@@ -460,11 +518,23 @@ func buildOpenAIResponsesMultiSSE(items []orderedResponsesItem) []byte {
 					"content_index": 0,
 					"text":          it.text,
 				}))
+				outputTexts = append(outputTexts, it.text)
 			}
+			msgItem := map[string]any{
+				"id":     itemID,
+				"type":   "message",
+				"role":   "assistant",
+				"status": "completed",
+				"content": []map[string]any{{
+					"type": "output_text",
+					"text": it.text,
+				}},
+			}
+			outputItems = append(outputItems, msgItem)
 			b.WriteString(sseEventBlock("response.output_item.done", map[string]any{
 				"type":         "response.output_item.done",
 				"output_index": outputIndex,
-				"item":         map[string]any{"id": itemID, "type": "message", "role": "assistant", "status": "completed"},
+				"item":         msgItem,
 			}))
 			continue
 		}
@@ -477,6 +547,7 @@ func buildOpenAIResponsesMultiSSE(items []orderedResponsesItem) []byte {
 			if err := json.Unmarshal(it.passThroughRaw, &passThrough); err != nil || passThrough == nil {
 				continue
 			}
+			outputItems = append(outputItems, passThrough)
 			b.WriteString(sseEventBlock("response.output_item.added", map[string]any{
 				"type":         "response.output_item.added",
 				"output_index": outputIndex,
@@ -494,6 +565,15 @@ func buildOpenAIResponsesMultiSSE(items []orderedResponsesItem) []byte {
 			if itemID == "" {
 				itemID = "ctc_" + it.callID
 			}
+			customItem := map[string]any{
+				"id":      itemID,
+				"type":    "custom_tool_call",
+				"status":  "completed",
+				"call_id": it.callID,
+				"name":    it.name,
+				"input":   it.customInput,
+			}
+			outputItems = append(outputItems, customItem)
 			b.WriteString(sseEventBlock("response.output_item.added", map[string]any{
 				"type":         "response.output_item.added",
 				"output_index": outputIndex,
@@ -509,14 +589,7 @@ func buildOpenAIResponsesMultiSSE(items []orderedResponsesItem) []byte {
 			b.WriteString(sseEventBlock("response.output_item.done", map[string]any{
 				"type":         "response.output_item.done",
 				"output_index": outputIndex,
-				"item": map[string]any{
-					"id":      itemID,
-					"type":    "custom_tool_call",
-					"status":  "completed",
-					"call_id": it.callID,
-					"name":    it.name,
-					"input":   it.customInput,
-				},
+				"item":         customItem,
 			}))
 			continue
 		}
@@ -549,23 +622,31 @@ func buildOpenAIResponsesMultiSSE(items []orderedResponsesItem) []byte {
 			"name":         it.name,
 			"arguments":    it.arguments,
 		}))
+		fcItem := map[string]any{
+			"id":        itemID,
+			"type":      "function_call",
+			"status":    "completed",
+			"call_id":   it.callID,
+			"name":      it.name,
+			"arguments": it.arguments,
+		}
+		outputItems = append(outputItems, fcItem)
 		b.WriteString(sseEventBlock("response.output_item.done", map[string]any{
 			"type":         "response.output_item.done",
 			"output_index": outputIndex,
-			"item": map[string]any{
-				"id":        itemID,
-				"type":      "function_call",
-				"status":    "completed",
-				"call_id":   it.callID,
-				"name":      it.name,
-				"arguments": it.arguments,
-			},
+			"item":         fcItem,
 		}))
 	}
 	b.WriteString(sseEventBlock("response.completed", map[string]any{
-		"type":     "response.completed",
-		"response": map[string]any{"id": "resp_clawvisor_rewrite", "status": "completed"},
+		"type": "response.completed",
+		"response": map[string]any{
+			"id":          "resp_clawvisor_rewrite",
+			"status":      "completed",
+			"output":      outputItems,
+			"output_text": strings.Join(outputTexts, "\n\n"),
+		},
 	}))
+	b.WriteString("data: [DONE]\n\n")
 	return []byte(b.String())
 }
 
@@ -640,10 +721,17 @@ func (rw OpenAIResponseRewriter) rewriteChatCompletionsJSON(body []byte, eval To
 		index        int
 	)
 	for ci, choice := range resp.Choices {
-		if text := flattenOpenAIContentFromAny(choice.Message.Content); text != "" {
-			frags = append(frags, assistantFragment{Text: text})
+		var (
+			allowedToolCalls []openAIChatToolCall
+			blockedPrompts   []string
+			choiceBlocked    bool
+			choiceRewritten  bool
+		)
+		originalText := flattenOpenAIContentFromAny(choice.Message.Content)
+		if originalText != "" {
+			frags = append(frags, assistantFragment{Text: originalText})
 		}
-		for ti, call := range choice.Message.ToolCalls {
+		for _, call := range choice.Message.ToolCalls {
 			tu := ToolUse{
 				ID:    firstNonEmpty(call.ID, fmt.Sprintf("chat-tool-%d", index)),
 				Index: index,
@@ -657,47 +745,68 @@ func (rw OpenAIResponseRewriter) rewriteChatCompletionsJSON(body []byte, eval To
 				Verdict:          verdict,
 				ToolInputPreview: MakeToolInputPreview(tu.Input),
 			})
+			finalArgs := tu.Input
 			if !verdict.Allowed {
 				anyBlocked = true
-			}
-			finalArgs := tu.Input
-			if verdict.Allowed && len(verdict.RewriteInput) > 0 {
-				resp.Choices[ci].Message.ToolCalls[ti].Function.Arguments = string(verdict.RewriteInput)
-				finalArgs = verdict.RewriteInput
-				anyRewritten = true
+				choiceBlocked = true
+				txt := verdict.SubstituteWith
+				if txt == "" {
+					reason := verdict.Reason
+					if reason == "" {
+						reason = "blocked by policy"
+					}
+					txt = fmt.Sprintf("Tool '%s' was blocked by Clawvisor policy: %s", call.Function.Name, reason)
+				}
+				if txt != "" {
+					blockedPrompts = append(blockedPrompts, txt)
+				}
+			} else {
+				if len(verdict.RewriteInput) > 0 {
+					call.Function.Arguments = string(verdict.RewriteInput)
+					finalArgs = verdict.RewriteInput
+					anyRewritten = true
+					choiceRewritten = true
+				}
+				allowedToolCalls = append(allowedToolCalls, call)
 			}
 			frags = append(frags, assistantFragment{IsTool: true, ToolName: call.Function.Name, ToolArgs: finalArgs})
 		}
+		if choiceBlocked || choiceRewritten {
+			resp.Choices[ci].Message.ToolCalls = allowedToolCalls
+			if len(blockedPrompts) > 0 {
+				joinedPrompts := strings.Join(blockedPrompts, "\n\n")
+				switch typed := choice.Message.Content.(type) {
+				case []any:
+					resp.Choices[ci].Message.Content = append(typed, map[string]any{
+						"type": "text",
+						"text": joinedPrompts,
+					})
+				case string:
+					if typed != "" {
+						resp.Choices[ci].Message.Content = typed + "\n\n" + joinedPrompts
+					} else {
+						resp.Choices[ci].Message.Content = joinedPrompts
+					}
+				default:
+					resp.Choices[ci].Message.Content = joinedPrompts
+				}
+			}
+			if len(allowedToolCalls) > 0 {
+				resp.Choices[ci].FinishReason = "tool_calls"
+			} else {
+				resp.Choices[ci].FinishReason = "stop"
+			}
+		}
 	}
 	turn := assistantTurnFromFragments(frags, decisions)
-	if !anyBlocked && anyRewritten {
+	if anyBlocked || anyRewritten {
 		rewritten, err := json.Marshal(resp)
 		if err != nil {
 			return RewriteResult{}, fmt.Errorf("openai chat: marshal rewritten response: %w", err)
 		}
 		return RewriteResult{Body: rewritten, Decisions: decisions, Rewritten: true, AssistantTurn: turn}, nil
 	}
-	if !anyBlocked {
-		return RewriteResult{Body: body, Decisions: decisions, AssistantTurn: turn}, nil
-	}
-	out := openAIChatCompletionsResponse{
-		ID:     resp.ID,
-		Object: firstNonEmpty(resp.Object, "chat.completion"),
-		Model:  resp.Model,
-		Choices: []openAIChatChoice{{
-			Index: 0,
-			Message: openAIChatMessage{
-				Role:    "assistant",
-				Content: blockedReasonTextForAssistant(decisions),
-			},
-			FinishReason: "stop",
-		}},
-	}
-	rewritten, err := json.Marshal(out)
-	if err != nil {
-		return RewriteResult{}, fmt.Errorf("openai chat: marshal rewritten response: %w", err)
-	}
-	return RewriteResult{Body: rewritten, Decisions: decisions, Rewritten: true, AssistantTurn: turn}, nil
+	return RewriteResult{Body: body, Decisions: decisions, AssistantTurn: turn}, nil
 }
 
 func (rw OpenAIResponseRewriter) rewriteChatCompletionsSSE(body []byte, eval ToolUseEvaluator) (RewriteResult, error) {
@@ -722,6 +831,7 @@ func (rw OpenAIResponseRewriter) rewriteChatCompletionsSSE(body []byte, eval Too
 	// re-emitted SSE — otherwise mixed text+tool streams silently drop their
 	// leading text after rewrite.
 	var leadingText strings.Builder
+	var blockedPrompts strings.Builder
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
 		if !strings.HasPrefix(line, "data:") {
@@ -786,22 +896,37 @@ func (rw OpenAIResponseRewriter) rewriteChatCompletionsSSE(body []byte, eval Too
 						Verdict:          verdict,
 						ToolInputPreview: MakeToolInputPreview(tu.Input),
 					})
-					if !verdict.Allowed {
-						anyBlocked = true
-					}
 					finalArgs := pc.args.String()
 					fragArgs := tu.Input
-					if verdict.Allowed && len(verdict.RewriteInput) > 0 {
-						finalArgs = string(verdict.RewriteInput)
-						fragArgs = verdict.RewriteInput
-						anyRewritten = true
+					if !verdict.Allowed {
+						anyBlocked = true
+						txt := verdict.SubstituteWith
+						if txt == "" {
+							reason := verdict.Reason
+							if reason == "" {
+								reason = "blocked by policy"
+							}
+							txt = fmt.Sprintf("Tool '%s' was blocked by Clawvisor policy: %s", pc.name, reason)
+						}
+						if txt != "" {
+							if blockedPrompts.Len() > 0 {
+								blockedPrompts.WriteString("\n\n")
+							}
+							blockedPrompts.WriteString(txt)
+						}
+					} else {
+						if len(verdict.RewriteInput) > 0 {
+							finalArgs = string(verdict.RewriteInput)
+							fragArgs = verdict.RewriteInput
+							anyRewritten = true
+						}
+						orderedChatCalls = append(orderedChatCalls, orderedChatToolCall{
+							index:     toolCallIndex,
+							id:        pc.id,
+							name:      pc.name,
+							arguments: finalArgs,
+						})
 					}
-					orderedChatCalls = append(orderedChatCalls, orderedChatToolCall{
-						index:     toolCallIndex,
-						id:        pc.id,
-						name:      pc.name,
-						arguments: finalArgs,
-					})
 					frags = append(frags, assistantFragment{IsTool: true, ToolName: pc.name, ToolArgs: fragArgs})
 				}
 				pending = map[int]*pendingCall{}
@@ -812,24 +937,35 @@ func (rw OpenAIResponseRewriter) rewriteChatCompletionsSSE(body []byte, eval Too
 		frags = append(frags, assistantFragment{Text: text.String()})
 	}
 	turn := assistantTurnFromFragments(frags, decisions)
-	if !anyBlocked && anyRewritten {
-		// Include any prose that arrived before the tool_calls plus any
-		// post-tool trailing text. leadingText was captured on
-		// finish_reason="tool_calls"; text.String() captures anything
-		// after that point (rare but legal).
-		combinedText := leadingText.String() + text.String()
+	if anyBlocked && len(orderedChatCalls) == 0 {
+		combinedText := leadingText.String()
+		if blockedPrompts.Len() > 0 {
+			if combinedText != "" {
+				combinedText += "\n\n"
+			}
+			combinedText += blockedPrompts.String()
+		}
+		combinedText += text.String()
+		return RewriteResult{
+			Body:          synthOpenAIChatTextSSE(combinedText),
+			Decisions:     decisions,
+			Rewritten:     true,
+			AssistantTurn: turn,
+		}, nil
+	}
+	if anyBlocked || anyRewritten {
+		combinedText := leadingText.String()
+		if blockedPrompts.Len() > 0 {
+			if combinedText != "" {
+				combinedText += "\n\n"
+			}
+			combinedText += blockedPrompts.String()
+		}
+		combinedText += text.String()
 		out := buildOpenAIChatMultiSSE(streamID, combinedText, orderedChatCalls)
 		return RewriteResult{Body: out, Decisions: decisions, Rewritten: true, AssistantTurn: turn}, nil
 	}
-	if !anyBlocked {
-		return RewriteResult{Body: body, Decisions: decisions, AssistantTurn: turn}, nil
-	}
-	return RewriteResult{
-		Body:          synthOpenAIChatTextSSE(blockedReasonTextForAssistant(decisions)),
-		Decisions:     decisions,
-		Rewritten:     true,
-		AssistantTurn: turn,
-	}, nil
+	return RewriteResult{Body: body, Decisions: decisions, AssistantTurn: turn}, nil
 }
 
 // orderedChatToolCall captures one tool_call in a Chat Completions

--- a/internal/runtime/conversation/openai_response.go
+++ b/internal/runtime/conversation/openai_response.go
@@ -139,7 +139,7 @@ func (rw OpenAIResponseRewriter) rewriteResponsesJSON(body []byte, eval ToolUseE
 			if !verdict.Allowed {
 				anyBlocked = true
 				txt := verdict.SubstituteWith
-				if txt == "" {
+				if txt == "" && !verdict.SuppressSubstituteText {
 					reason := verdict.Reason
 					if reason == "" {
 						reason = "blocked by policy"
@@ -183,7 +183,7 @@ func (rw OpenAIResponseRewriter) rewriteResponsesJSON(body []byte, eval ToolUseE
 			if !verdict.Allowed {
 				anyBlocked = true
 				txt := verdict.SubstituteWith
-				if txt == "" {
+				if txt == "" && !verdict.SuppressSubstituteText {
 					reason := verdict.Reason
 					if reason == "" {
 						reason = "blocked by policy"
@@ -379,7 +379,7 @@ func (rw OpenAIResponseRewriter) rewriteResponsesSSE(body []byte, eval ToolUseEv
 				if !verdict.Allowed {
 					anyBlocked = true
 					txt := verdict.SubstituteWith
-					if txt == "" {
+					if txt == "" && !verdict.SuppressSubstituteText {
 						reason := verdict.Reason
 						if reason == "" {
 							reason = "blocked by policy"
@@ -424,7 +424,7 @@ func (rw OpenAIResponseRewriter) rewriteResponsesSSE(body []byte, eval ToolUseEv
 				if !verdict.Allowed {
 					anyBlocked = true
 					txt := verdict.SubstituteWith
-					if txt == "" {
+					if txt == "" && !verdict.SuppressSubstituteText {
 						reason := verdict.Reason
 						if reason == "" {
 							reason = "blocked by policy"
@@ -751,7 +751,7 @@ func (rw OpenAIResponseRewriter) rewriteChatCompletionsJSON(body []byte, eval To
 				anyBlocked = true
 				choiceBlocked = true
 				txt := verdict.SubstituteWith
-				if txt == "" {
+				if txt == "" && !verdict.SuppressSubstituteText {
 					reason := verdict.Reason
 					if reason == "" {
 						reason = "blocked by policy"
@@ -975,7 +975,7 @@ func (rw OpenAIResponseRewriter) rewriteChatCompletionsSSE(body []byte, eval Too
 					anyBlocked = true
 					choiceBlocked = true
 					txt := verdict.SubstituteWith
-					if txt == "" {
+					if txt == "" && !verdict.SuppressSubstituteText {
 						reason := verdict.Reason
 						if reason == "" {
 							reason = "blocked by policy"

--- a/internal/runtime/conversation/openai_response.go
+++ b/internal/runtime/conversation/openai_response.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+	"unicode/utf8"
 )
 
 type OpenAIResponseRewriter struct{}
@@ -828,7 +829,9 @@ func (rw OpenAIResponseRewriter) rewriteChatCompletionsSSE(body []byte, eval Too
 	}
 	type toolCallState struct {
 		allowed        bool
+		useRunes       bool
 		arguments      string
+		argumentsRunes []rune
 		origTotalLen   int
 		origReadLen    int
 		writtenArgsLen int
@@ -985,9 +988,18 @@ func (rw OpenAIResponseRewriter) rewriteChatCompletionsSSE(body []byte, eval Too
 						}
 						choiceBlockedPrompts.WriteString(txt)
 					}
+					origStr := pc.args.String()
+					useRunes := utf8.ValidString(origStr)
+					var origTotalLen int
+					if useRunes {
+						origTotalLen = len([]rune(origStr))
+					} else {
+						origTotalLen = len(origStr)
+					}
 					toolStates[toolCallIndex] = &toolCallState{
 						allowed:      false,
-						origTotalLen: pc.args.Len(),
+						useRunes:     useRunes,
+						origTotalLen: origTotalLen,
 					}
 				} else {
 					if len(verdict.RewriteInput) > 0 {
@@ -1002,10 +1014,22 @@ func (rw OpenAIResponseRewriter) rewriteChatCompletionsSSE(body []byte, eval Too
 						name:      pc.name,
 						arguments: finalArgs,
 					})
-					toolStates[toolCallIndex] = &toolCallState{
-						allowed:      true,
-						arguments:    finalArgs,
-						origTotalLen: pc.args.Len(),
+					origStr := pc.args.String()
+					useRunes := utf8.ValidString(origStr) && utf8.ValidString(finalArgs)
+					if useRunes {
+						toolStates[toolCallIndex] = &toolCallState{
+							allowed:        true,
+							useRunes:       true,
+							argumentsRunes: []rune(finalArgs),
+							origTotalLen:   len([]rune(origStr)),
+						}
+					} else {
+						toolStates[toolCallIndex] = &toolCallState{
+							allowed:      true,
+							useRunes:     false,
+							arguments:    finalArgs,
+							origTotalLen: len(origStr),
+						}
 					}
 				}
 				frags = append(frags, assistantFragment{IsTool: true, ToolName: pc.name, ToolArgs: fragArgs})
@@ -1095,31 +1119,56 @@ func (rw OpenAIResponseRewriter) rewriteChatCompletionsSSE(body []byte, eval Too
 									// Blocked: skip/omit from the stream
 									continue
 								}
-								// Allowed: rewrite arguments delta proportionally
+								// Allowed: rewrite arguments delta proportionally (rune-based if UTF-8, byte-based fallback to avoid corruption of raw binary bytes)
 								tcFunc, _ := tc["function"].(map[string]any)
 								if tcFunc != nil {
 									if origArgsDelta, ok := tcFunc["arguments"].(string); ok {
-										tState.origReadLen += len(origArgsDelta)
-										var newDelta string
-										if tState.origTotalLen == 0 {
-											newDelta = tState.arguments
-											tState.writtenArgsLen = len(tState.arguments)
-										} else if tState.origReadLen >= tState.origTotalLen {
-											newDelta = tState.arguments[tState.writtenArgsLen:]
-											tState.writtenArgsLen = len(tState.arguments)
+										if tState.useRunes {
+											origArgsRunes := []rune(origArgsDelta)
+											tState.origReadLen += len(origArgsRunes)
+											var newDeltaRunes []rune
+											if tState.origTotalLen == 0 {
+												newDeltaRunes = tState.argumentsRunes
+												tState.writtenArgsLen = len(tState.argumentsRunes)
+											} else if tState.origReadLen >= tState.origTotalLen {
+												newDeltaRunes = tState.argumentsRunes[tState.writtenArgsLen:]
+												tState.writtenArgsLen = len(tState.argumentsRunes)
+											} else {
+												ratio := float64(len(origArgsRunes)) / float64(tState.origTotalLen)
+												chunkSize := int(ratio * float64(len(tState.argumentsRunes)))
+												if chunkSize < 1 && len(origArgsRunes) > 0 {
+													chunkSize = 1
+												}
+												if tState.writtenArgsLen+chunkSize > len(tState.argumentsRunes) {
+													chunkSize = len(tState.argumentsRunes) - tState.writtenArgsLen
+												}
+												newDeltaRunes = tState.argumentsRunes[tState.writtenArgsLen : tState.writtenArgsLen+chunkSize]
+												tState.writtenArgsLen += chunkSize
+											}
+											tcFunc["arguments"] = string(newDeltaRunes)
 										} else {
-											ratio := float64(len(origArgsDelta)) / float64(tState.origTotalLen)
-											chunkSize := int(ratio * float64(len(tState.arguments)))
-											if chunkSize < 1 && len(origArgsDelta) > 0 {
-												chunkSize = 1
+											tState.origReadLen += len(origArgsDelta)
+											var newDelta string
+											if tState.origTotalLen == 0 {
+												newDelta = tState.arguments
+												tState.writtenArgsLen = len(tState.arguments)
+											} else if tState.origReadLen >= tState.origTotalLen {
+												newDelta = tState.arguments[tState.writtenArgsLen:]
+												tState.writtenArgsLen = len(tState.arguments)
+											} else {
+												ratio := float64(len(origArgsDelta)) / float64(tState.origTotalLen)
+												chunkSize := int(ratio * float64(len(tState.arguments)))
+												if chunkSize < 1 && len(origArgsDelta) > 0 {
+													chunkSize = 1
+												}
+												if tState.writtenArgsLen+chunkSize > len(tState.arguments) {
+													chunkSize = len(tState.arguments) - tState.writtenArgsLen
+												}
+												newDelta = tState.arguments[tState.writtenArgsLen : tState.writtenArgsLen+chunkSize]
+												tState.writtenArgsLen += chunkSize
 											}
-											if tState.writtenArgsLen+chunkSize > len(tState.arguments) {
-												chunkSize = len(tState.arguments) - tState.writtenArgsLen
-											}
-											newDelta = tState.arguments[tState.writtenArgsLen : tState.writtenArgsLen+chunkSize]
-											tState.writtenArgsLen += chunkSize
+											tcFunc["arguments"] = rawJSONString(newDelta)
 										}
-										tcFunc["arguments"] = newDelta
 									}
 								}
 							}
@@ -2235,4 +2284,34 @@ func writeSSE(w io.Writer, event string, data string) error {
 	}
 	_, err = fmt.Fprintf(w, "data: %s\n\n", data)
 	return err
+}
+
+type rawJSONString string
+
+func (r rawJSONString) MarshalJSON() ([]byte, error) {
+	res := make([]byte, 0, len(r)+2)
+	res = append(res, '"')
+	for i := 0; i < len(r); i++ {
+		c := r[i]
+		switch c {
+		case '"':
+			res = append(res, '\\', '"')
+		case '\\':
+			res = append(res, '\\', '\\')
+		case '\n':
+			res = append(res, '\\', 'n')
+		case '\r':
+			res = append(res, '\\', 'r')
+		case '\t':
+			res = append(res, '\\', 't')
+		default:
+			if c < 0x20 {
+				res = append(res, []byte(fmt.Sprintf("\\u%04x", c))...)
+			} else {
+				res = append(res, c)
+			}
+		}
+	}
+	res = append(res, '"')
+	return res, nil
 }

--- a/internal/runtime/conversation/response.go
+++ b/internal/runtime/conversation/response.go
@@ -15,6 +15,12 @@ type ToolUseVerdict struct {
 	Allowed        bool
 	Reason         string
 	SubstituteWith string
+	// SuppressSubstituteText, when true and Allowed=false, prevents the
+	// rewriter/formatter from falling back to a default "Tool 'X' was
+	// blocked by Clawvisor policy: ..." text when SubstituteWith is empty.
+	// Used during coalesced approval turns where sibling tools should
+	// not render their own separate block messages.
+	SuppressSubstituteText bool
 
 	// RewriteInput, when non-nil and Allowed=true, replaces the tool_use's
 	// input field in-place. Used by the lite-proxy inspector to redirect
@@ -217,16 +223,18 @@ func applyBlockSubstitutions(frags []assistantFragment, decisions []ToolUseDecis
 		toolDecisionIdx++
 		if !decision.Verdict.Allowed {
 			txt := decision.Verdict.SubstituteWith
-			if txt == "" {
+			if txt == "" && !decision.Verdict.SuppressSubstituteText {
 				reason := decision.Verdict.Reason
 				if reason == "" {
 					reason = "blocked by policy"
 				}
 				txt = fmt.Sprintf("Tool '%s' was blocked by Clawvisor policy: %s", frag.ToolName, reason)
 			}
-			out = append(out, assistantFragment{
-				Text: txt,
-			})
+			if txt != "" {
+				out = append(out, assistantFragment{
+					Text: txt,
+				})
+			}
 			continue
 		}
 		out = append(out, frag)
@@ -237,6 +245,9 @@ func applyBlockSubstitutions(frags []assistantFragment, decisions []ToolUseDecis
 func BlockedReasonText(decisions []ToolUseDecisionRecord) string {
 	var substitutions []string
 	for _, decision := range decisions {
+		if decision.Verdict.SuppressSubstituteText {
+			continue
+		}
 		if decision.Verdict.SubstituteWith != "" {
 			substitutions = append(substitutions, decision.Verdict.SubstituteWith)
 		}
@@ -248,6 +259,9 @@ func BlockedReasonText(decisions []ToolUseDecisionRecord) string {
 	var parts []string
 	for _, decision := range decisions {
 		if decision.Verdict.Allowed {
+			continue
+		}
+		if decision.Verdict.SuppressSubstituteText {
 			continue
 		}
 		reason := decision.Verdict.Reason

--- a/internal/runtime/conversation/response.go
+++ b/internal/runtime/conversation/response.go
@@ -216,12 +216,16 @@ func applyBlockSubstitutions(frags []assistantFragment, decisions []ToolUseDecis
 		decision := decisions[toolDecisionIdx]
 		toolDecisionIdx++
 		if !decision.Verdict.Allowed {
-			reason := decision.Verdict.Reason
-			if reason == "" {
-				reason = "blocked by policy"
+			txt := decision.Verdict.SubstituteWith
+			if txt == "" {
+				reason := decision.Verdict.Reason
+				if reason == "" {
+					reason = "blocked by policy"
+				}
+				txt = fmt.Sprintf("Tool '%s' was blocked by Clawvisor policy: %s", frag.ToolName, reason)
 			}
 			out = append(out, assistantFragment{
-				Text: fmt.Sprintf("Tool '%s' was blocked by Clawvisor policy: %s", frag.ToolName, reason),
+				Text: txt,
 			})
 			continue
 		}

--- a/internal/runtime/conversation/response_test.go
+++ b/internal/runtime/conversation/response_test.go
@@ -261,7 +261,7 @@ func TestOpenAIResponseRewriterBlocksChatToolCallsSSE(t *testing.T) {
 		t.Fatal("expected rewritten SSE response")
 	}
 	out := string(result.Body)
-	if !strings.Contains(out, "Bash: requires approval") {
+	if !strings.Contains(out, "Tool 'Bash' was blocked by Clawvisor policy: requires approval") {
 		t.Fatalf("expected block text in SSE output, got %q", out)
 	}
 	if strings.Contains(out, `"tool_calls"`) {
@@ -1081,4 +1081,191 @@ func parseTestSSEEvents(t *testing.T, stream string) []sseEvent {
 		t.Fatalf("parse SSE events: %v", err)
 	}
 	return events
+}
+
+func TestOpenAIResponseRewriterPreservesMultimodalChatJSON(t *testing.T) {
+	t.Parallel()
+
+	req, _ := http.NewRequest(http.MethodPost, "https://api.openai.com/v1/chat/completions", nil)
+	rewriter := DefaultResponseRegistry().Match(req, &http.Response{})
+	if rewriter == nil {
+		t.Fatal("expected OpenAI response rewriter")
+	}
+
+	body := []byte(`{
+	  "id": "chatcmpl_multimodal",
+	  "choices": [{
+	    "index": 0,
+	    "message": {
+	      "role": "assistant",
+	      "content": [
+	        {"type": "text", "text": "Here is the image you asked for."},
+	        {"type": "image_url", "image_url": {"url": "https://example.com/image.png"}}
+	      ],
+	      "tool_calls": [
+	        {"id": "call_1", "type": "function", "function": {"name": "Bash", "arguments": "{\"command\":\"rm\"}"}}
+	      ]
+	    }
+	  }]
+	}`)
+
+	result, err := rewriter.Rewrite(body, "application/json", func(tu ToolUse) ToolUseVerdict {
+		return ToolUseVerdict{Allowed: false, Reason: "requires approval"}
+	})
+	if err != nil {
+		t.Fatalf("Rewrite: %v", err)
+	}
+	if !result.Rewritten {
+		t.Fatal("expected rewritten response")
+	}
+
+	var out map[string]any
+	if err := json.Unmarshal(result.Body, &out); err != nil {
+		t.Fatalf("unmarshal rewritten response: %v", err)
+	}
+	choices := out["choices"].([]any)
+	msg := choices[0].(map[string]any)["message"].(map[string]any)
+	content := msg["content"].([]any)
+
+	if len(content) != 3 {
+		t.Fatalf("expected 3 content parts, got %d: %+v", len(content), content)
+	}
+	if content[0].(map[string]any)["type"] != "text" || content[0].(map[string]any)["text"] != "Here is the image you asked for." {
+		t.Fatalf("unexpected first part: %+v", content[0])
+	}
+	if content[1].(map[string]any)["type"] != "image_url" {
+		t.Fatalf("unexpected second part (image_url): %+v", content[1])
+	}
+	if content[2].(map[string]any)["type"] != "text" || !strings.Contains(content[2].(map[string]any)["text"].(string), "requires approval") {
+		t.Fatalf("unexpected third part (blocked prompt): %+v", content[2])
+	}
+}
+
+func TestOpenAIResponseRewriterClearsStaleOutputTextResponsesJSON(t *testing.T) {
+	t.Parallel()
+
+	req, _ := http.NewRequest(http.MethodPost, "https://api.openai.com/v1/responses", nil)
+	rewriter := DefaultResponseRegistry().Match(req, &http.Response{})
+	if rewriter == nil {
+		t.Fatal("expected OpenAI response rewriter")
+	}
+
+	body := []byte(`{
+	  "id": "resp_stale",
+	  "object": "response",
+	  "output": [
+	    {"id": "fc_1", "type": "function_call", "status": "completed", "call_id": "call_1", "name": "Bash", "arguments": "{\"command\":\"rm\"}"}
+	  ],
+	  "output_text": "I am about to run a command"
+	}`)
+
+	result, err := rewriter.Rewrite(body, "application/json", func(tu ToolUse) ToolUseVerdict {
+		return ToolUseVerdict{Allowed: true, RewriteInput: []byte(`{"command":"ls"}`)}
+	})
+	if err != nil {
+		t.Fatalf("Rewrite: %v", err)
+	}
+	if !result.Rewritten {
+		t.Fatal("expected rewritten response")
+	}
+
+	var out map[string]any
+	if err := json.Unmarshal(result.Body, &out); err != nil {
+		t.Fatalf("unmarshal rewritten response: %v", err)
+	}
+	outputText, _ := out["output_text"].(string)
+	if outputText != "" {
+		t.Fatalf("expected output_text to be cleared/empty, got %q", outputText)
+	}
+}
+
+func TestOpenAIResponseRewriterDoesNotMutateUnrelatedChoicesChatJSON(t *testing.T) {
+	t.Parallel()
+
+	req, _ := http.NewRequest(http.MethodPost, "https://api.openai.com/v1/chat/completions", nil)
+	rewriter := DefaultResponseRegistry().Match(req, &http.Response{})
+	if rewriter == nil {
+		t.Fatal("expected OpenAI response rewriter")
+	}
+
+	body := []byte(`{
+	  "id": "chatcmpl_multi_choice",
+	  "choices": [
+	    {
+	      "index": 0,
+	      "message": {
+	        "role": "assistant",
+	        "content": "Choice 0",
+	        "tool_calls": [
+	          {"id": "call_1", "type": "function", "function": {"name": "Bash", "arguments": "{\"command\":\"rm\"}"}}
+	        ]
+	      },
+	      "finish_reason": "tool_calls"
+	    },
+	    {
+	      "index": 1,
+	      "message": {
+	        "role": "assistant",
+	        "content": "Choice 1",
+	        "tool_calls": [
+	          {"id": "call_2", "type": "function", "function": {"name": "WebFetch", "arguments": "{\"url\":\"https://safe.test\"}"}}
+	        ]
+	      },
+	      "finish_reason": "tool_calls"
+	    }
+	  ]
+	}`)
+
+	// Only block Choice 0 (the Bash tool), keep Choice 1 (WebFetch) allowed
+	result, err := rewriter.Rewrite(body, "application/json", func(tu ToolUse) ToolUseVerdict {
+		if tu.Name == "Bash" {
+			return ToolUseVerdict{Allowed: false, Reason: "requires approval"}
+		}
+		return ToolUseVerdict{Allowed: true}
+	})
+	if err != nil {
+		t.Fatalf("Rewrite: %v", err)
+	}
+	if !result.Rewritten {
+		t.Fatal("expected rewritten response")
+	}
+
+	var out map[string]any
+	if err := json.Unmarshal(result.Body, &out); err != nil {
+		t.Fatalf("unmarshal rewritten response: %v", err)
+	}
+	choices := out["choices"].([]any)
+	if len(choices) != 2 {
+		t.Fatalf("expected 2 choices, got %d", len(choices))
+	}
+
+	// Choice 0 should be rewritten (Bash tool call blocked/removed, content modified)
+	c0 := choices[0].(map[string]any)
+	c0Msg := c0["message"].(map[string]any)
+	c0Calls, _ := c0Msg["tool_calls"].([]any)
+	if len(c0Calls) != 0 {
+		t.Fatalf("expected Choice 0 tool_calls to be removed, got %v", c0Calls)
+	}
+	c0Content := c0Msg["content"].(string)
+	if !strings.Contains(c0Content, "requires approval") {
+		t.Fatalf("expected Choice 0 content to contain block message, got %q", c0Content)
+	}
+	if c0["finish_reason"] != "stop" {
+		t.Fatalf("expected Choice 0 finish_reason to be stop, got %q", c0["finish_reason"])
+	}
+
+	// Choice 1 should remain untouched (WebFetch tool call allowed and intact)
+	c1 := choices[1].(map[string]any)
+	c1Msg := c1["message"].(map[string]any)
+	c1Calls, _ := c1Msg["tool_calls"].([]any)
+	if len(c1Calls) != 1 {
+		t.Fatalf("expected Choice 1 tool_calls to be preserved, got %v", c1Calls)
+	}
+	c1Content := c1Msg["content"].(string)
+	if c1Content != "Choice 1" {
+		t.Fatalf("expected Choice 1 content to be Choice 1, got %q", c1Content)
+	}
+	if c1["finish_reason"] != "tool_calls" {
+		t.Fatalf("expected Choice 1 finish_reason to be tool_calls, got %q", c1["finish_reason"])
+	}
 }

--- a/internal/runtime/conversation/response_test.go
+++ b/internal/runtime/conversation/response_test.go
@@ -434,6 +434,74 @@ func TestOpenAIResponseRewriterPreservesLeadingTextOnChatRewrite(t *testing.T) {
 	}
 }
 
+func TestOpenAIResponseRewriterPreservesPostToolTextOnChatRewrite(t *testing.T) {
+	t.Parallel()
+
+	req, _ := http.NewRequest(http.MethodPost, "https://api.openai.com/v1/chat/completions", nil)
+	rewriter := DefaultResponseRegistry().Match(req, &http.Response{})
+	if rewriter == nil {
+		t.Fatal("expected OpenAI response rewriter")
+	}
+
+	body := []byte(strings.Join([]string{
+		`data: {"id":"chatcmpl_x","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"Looking up your repo. "},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"chatcmpl_x","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"github","arguments":"{\"repo\":\"acme\"}"}}]},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"chatcmpl_x","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+		``,
+		`data: {"id":"chatcmpl_x","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"And here is some trailing text."},"finish_reason":null}]}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}, "\n"))
+
+	result, err := rewriter.Rewrite(body, "text/event-stream", func(tu ToolUse) ToolUseVerdict {
+		return ToolUseVerdict{Allowed: true, RewriteInput: []byte(`{"repo":"acme/rewritten"}`)}
+	})
+	if err != nil {
+		t.Fatalf("Rewrite: %v", err)
+	}
+	if !result.Rewritten {
+		t.Fatalf("expected rewrite to fire")
+	}
+
+	events := parseTestSSEEvents(t, string(result.Body))
+	var eventOrder []string
+	for _, ev := range events {
+		var payload struct {
+			Choices []struct {
+				Delta struct {
+					Content   any   `json:"content"`
+					ToolCalls []any `json:"tool_calls"`
+				} `json:"delta"`
+			} `json:"choices"`
+		}
+		if err := json.Unmarshal([]byte(ev.Data), &payload); err != nil {
+			continue
+		}
+		for _, c := range payload.Choices {
+			if txt := flattenOpenAIContentFromAny(c.Delta.Content); txt != "" {
+				eventOrder = append(eventOrder, txt)
+			}
+			if len(c.Delta.ToolCalls) > 0 {
+				eventOrder = append(eventOrder, "tool_calls")
+			}
+		}
+	}
+
+	// We expect precisely: ["Looking up your repo. ", "tool_calls", "And here is some trailing text."]
+	expected := []string{"Looking up your repo. ", "tool_calls", "And here is some trailing text."}
+	if len(eventOrder) != len(expected) {
+		t.Fatalf("expected sequence %v, got %v", expected, eventOrder)
+	}
+	for i, val := range expected {
+		if eventOrder[i] != val {
+			t.Fatalf("at index %d: expected %q, got %q", i, val, eventOrder[i])
+		}
+	}
+}
+
 func TestOpenAIResponseRewriterSortsStreamingChatToolCallsByIndex(t *testing.T) {
 	t.Parallel()
 
@@ -1267,5 +1335,412 @@ func TestOpenAIResponseRewriterDoesNotMutateUnrelatedChoicesChatJSON(t *testing.
 	}
 	if c1["finish_reason"] != "tool_calls" {
 		t.Fatalf("expected Choice 1 finish_reason to be tool_calls, got %q", c1["finish_reason"])
+	}
+}
+
+func TestOpenAIResponseRewriterDoesNotMutateUnrelatedChoicesChatSSE(t *testing.T) {
+	t.Parallel()
+
+	req, _ := http.NewRequest(http.MethodPost, "https://api.openai.com/v1/chat/completions", nil)
+	rewriter := DefaultResponseRegistry().Match(req, &http.Response{})
+	if rewriter == nil {
+		t.Fatal("expected OpenAI response rewriter")
+	}
+
+	body := []byte(strings.Join([]string{
+		`data: {"id":"chatcmpl_1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null},{"index":1,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"chatcmpl_1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"Bash","arguments":"{\"command\":\"rm\"}"}}]},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"chatcmpl_1","object":"chat.completion.chunk","choices":[{"index":1,"delta":{"tool_calls":[{"index":0,"id":"call_2","type":"function","function":{"name":"WebFetch","arguments":"{\"url\":\"https://safe.test\"}"}}]},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"chatcmpl_1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+		``,
+		`data: {"id":"chatcmpl_1","object":"chat.completion.chunk","choices":[{"index":1,"delta":{},"finish_reason":"tool_calls"}]}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}, "\n"))
+
+	// Block Bash on Choice 0, allow WebFetch on Choice 1
+	result, err := rewriter.Rewrite(body, "text/event-stream", func(tu ToolUse) ToolUseVerdict {
+		if tu.Name == "Bash" {
+			return ToolUseVerdict{Allowed: false, Reason: "requires approval"}
+		}
+		return ToolUseVerdict{Allowed: true}
+	})
+	if err != nil {
+		t.Fatalf("Rewrite: %v", err)
+	}
+	if !result.Rewritten {
+		t.Fatal("expected rewritten response")
+	}
+
+	t.Logf("rewritten body:\n%s", string(result.Body))
+	events := parseTestSSEEvents(t, string(result.Body))
+	
+	// We expect the rewritten events to synthesize both choices separately.
+	// Let's verify that the choice 0 gets finish_reason stop/blocked content,
+	// while choice 1 gets finish_reason tool_calls with its tool call preserved.
+	var choice0Finished, choice1Finished bool
+	var choice0HasContent, choice0HasToolCalls bool
+	var choice1HasContent, choice1HasToolCalls bool
+
+	for _, ev := range events {
+		var payload struct {
+			Choices []struct {
+				Index int `json:"index"`
+				Delta struct {
+					Content   any   `json:"content"`
+					ToolCalls []any `json:"tool_calls"`
+				} `json:"delta"`
+				FinishReason string `json:"finish_reason"`
+			} `json:"choices"`
+		}
+		if err := json.Unmarshal([]byte(ev.Data), &payload); err != nil {
+			continue
+		}
+		for _, c := range payload.Choices {
+			if c.Index == 0 {
+				if c.Delta.Content != nil {
+					choice0HasContent = true
+					txt := flattenOpenAIContentFromAny(c.Delta.Content)
+					if !strings.Contains(txt, "requires approval") {
+						t.Fatalf("expected Choice 0 content to contain block message, got %q", txt)
+					}
+				}
+				if len(c.Delta.ToolCalls) > 0 {
+					choice0HasToolCalls = true
+				}
+				if c.FinishReason == "stop" {
+					choice0Finished = true
+				}
+			} else if c.Index == 1 {
+				if c.Delta.Content != nil {
+					choice1HasContent = true
+				}
+				if len(c.Delta.ToolCalls) > 0 {
+					choice1HasToolCalls = true
+				}
+				if c.FinishReason == "tool_calls" {
+					choice1Finished = true
+				}
+			}
+		}
+	}
+
+	if !choice0Finished {
+		t.Fatal("expected Choice 0 to finish with stop")
+	}
+	if !choice0HasContent {
+		t.Fatal("expected Choice 0 to have injected block text")
+	}
+	if choice0HasToolCalls {
+		t.Fatal("expected Choice 0 to have no tool calls in rewrite")
+	}
+	if !choice1Finished {
+		t.Fatal("expected Choice 1 to finish with tool_calls")
+	}
+	if !choice1HasToolCalls {
+		t.Fatal("expected Choice 1 to retain its tool calls")
+	}
+	if choice1HasContent {
+		t.Fatal("expected Choice 1 to have no injected block text")
+	}
+}
+
+func TestOpenAIResponseRewriterPreservesInterleavingChatSSE(t *testing.T) {
+	t.Parallel()
+
+	req, _ := http.NewRequest(http.MethodPost, "https://api.openai.com/v1/chat/completions", nil)
+	rewriter := DefaultResponseRegistry().Match(req, &http.Response{})
+	if rewriter == nil {
+		t.Fatal("expected OpenAI response rewriter")
+	}
+
+	body := []byte(strings.Join([]string{
+		`data: {"id":"chatcmpl_interleave","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"leading0"},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"chatcmpl_interleave","object":"chat.completion.chunk","choices":[{"index":1,"delta":{"content":"leading1"},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"chatcmpl_interleave","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_0","type":"function","function":{"name":"Bash","arguments":"{\"command\":\"rm\"}"}}]},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"chatcmpl_interleave","object":"chat.completion.chunk","choices":[{"index":1,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"WebFetch","arguments":"{\"url\":\"https://safe.test\"}"}}]},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"chatcmpl_interleave","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+		``,
+		`data: {"id":"chatcmpl_interleave","object":"chat.completion.chunk","choices":[{"index":1,"delta":{},"finish_reason":"tool_calls"}]}`,
+		``,
+		`data: {"id":"chatcmpl_interleave","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"trailing0"},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"chatcmpl_interleave","object":"chat.completion.chunk","choices":[{"index":1,"delta":{"content":"trailing1"},"finish_reason":null}]}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}, "\n"))
+
+	// Block Bash on Choice 0, allow WebFetch on Choice 1
+	result, err := rewriter.Rewrite(body, "text/event-stream", func(tu ToolUse) ToolUseVerdict {
+		if tu.Name == "Bash" {
+			return ToolUseVerdict{Allowed: false, Reason: "requires approval"}
+		}
+		return ToolUseVerdict{Allowed: true}
+	})
+	if err != nil {
+		t.Fatalf("Rewrite: %v", err)
+	}
+	if !result.Rewritten {
+		t.Fatal("expected rewritten response")
+	}
+
+	events := parseTestSSEEvents(t, string(result.Body))
+	var sequence []string
+
+	for _, ev := range events {
+		var payload struct {
+			Choices []struct {
+				Index int `json:"index"`
+				Delta struct {
+					Content   any   `json:"content"`
+					ToolCalls []any `json:"tool_calls"`
+				} `json:"delta"`
+				FinishReason string `json:"finish_reason"`
+			} `json:"choices"`
+		}
+		if err := json.Unmarshal([]byte(ev.Data), &payload); err != nil {
+			continue
+		}
+		for _, c := range payload.Choices {
+			if txt := flattenOpenAIContentFromAny(c.Delta.Content); txt != "" {
+				sequence = append(sequence, fmt.Sprintf("content_%d_%s", c.Index, txt))
+			}
+			if len(c.Delta.ToolCalls) > 0 {
+				sequence = append(sequence, fmt.Sprintf("tool_calls_%d", c.Index))
+			}
+			if c.FinishReason == "tool_calls" {
+				sequence = append(sequence, fmt.Sprintf("finish_tool_calls_%d", c.Index))
+			}
+			if c.FinishReason == "stop" {
+				sequence = append(sequence, fmt.Sprintf("finish_stop_%d", c.Index))
+			}
+		}
+	}
+
+	// The expected sequence preserves exact relative order of events:
+	expected := []string{
+		"content_0_leading0",
+		"content_1_leading1",
+		"tool_calls_1",
+		"content_0_Tool 'Bash' was blocked by Clawvisor policy: requires approval",
+		"finish_stop_0",
+		"finish_tool_calls_1",
+		"content_0_trailing0",
+		"content_1_trailing1",
+	}
+
+	if len(sequence) != len(expected) {
+		t.Fatalf("expected sequence length %d, got %d. Sequence:\n%v", len(expected), len(sequence), sequence)
+	}
+	for i, val := range expected {
+		if sequence[i] != val {
+			t.Fatalf("at index %d: expected %q, got %q", i, val, sequence[i])
+		}
+	}
+
+	if result.AssistantTurn == nil {
+		t.Fatal("expected AssistantTurn to be populated")
+	}
+	expectedTurnContent := strings.Join([]string{
+		"leading0",
+		"Tool 'Bash' was blocked by Clawvisor policy: requires approval",
+		"trailing0",
+		"leading1",
+		`<tool_use name=WebFetch input={"url":"https://safe.test"}>`,
+		"trailing1",
+	}, "\n")
+	if result.AssistantTurn.Content != expectedTurnContent {
+		t.Errorf("expected AssistantTurn content:\n%q\n\ngot:\n%q", expectedTurnContent, result.AssistantTurn.Content)
+	}
+}
+
+func TestOpenAIResponseRewriterMixedToolCallsChatSSE(t *testing.T) {
+	t.Parallel()
+
+	req, _ := http.NewRequest(http.MethodPost, "https://api.openai.com/v1/chat/completions", nil)
+	rewriter := DefaultResponseRegistry().Match(req, &http.Response{})
+	if rewriter == nil {
+		t.Fatal("expected OpenAI response rewriter")
+	}
+
+	body := []byte(strings.Join([]string{
+		`data: {"id":"chatcmpl_mixed","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"chatcmpl_mixed","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"Bash","arguments":"{\"command\":\"rm\"}"}},{"index":1,"id":"call_2","type":"function","function":{"name":"WebFetch","arguments":"{\"url\":\"https://safe.test\"}"}}]},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"chatcmpl_mixed","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}, "\n"))
+
+	// Block Bash, allow WebFetch
+	result, err := rewriter.Rewrite(body, "text/event-stream", func(tu ToolUse) ToolUseVerdict {
+		if tu.Name == "Bash" {
+			return ToolUseVerdict{Allowed: false, Reason: "requires approval"}
+		}
+		return ToolUseVerdict{Allowed: true}
+	})
+	if err != nil {
+		t.Fatalf("Rewrite: %v", err)
+	}
+	if !result.Rewritten {
+		t.Fatal("expected rewritten response")
+	}
+
+	events := parseTestSSEEvents(t, string(result.Body))
+	var choice0Finished bool
+	var choice0HasContent, choice0HasToolCalls bool
+
+	for _, ev := range events {
+		var payload struct {
+			Choices []struct {
+				Index int `json:"index"`
+				Delta struct {
+					Content   any   `json:"content"`
+					ToolCalls []any `json:"tool_calls"`
+				} `json:"delta"`
+				FinishReason string `json:"finish_reason"`
+			} `json:"choices"`
+		}
+		if err := json.Unmarshal([]byte(ev.Data), &payload); err != nil {
+			continue
+		}
+		for _, c := range payload.Choices {
+			if c.Index == 0 {
+				if c.Delta.Content != nil {
+					choice0HasContent = true
+					txt := flattenOpenAIContentFromAny(c.Delta.Content)
+					if !strings.Contains(txt, "requires approval") {
+						t.Fatalf("expected Choice 0 content to contain block message, got %q", txt)
+					}
+				}
+				if len(c.Delta.ToolCalls) > 0 {
+					choice0HasToolCalls = true
+					// Check that only WebFetch is present, Bash is stripped
+					tcMap := c.Delta.ToolCalls[0].(map[string]any)
+					fn := tcMap["function"].(map[string]any)
+					name := fn["name"].(string)
+					if name != "WebFetch" {
+						t.Fatalf("expected only WebFetch allowed tool call, got %q", name)
+					}
+				}
+				if c.FinishReason == "tool_calls" {
+					choice0Finished = true
+				}
+			}
+		}
+	}
+
+	if !choice0Finished {
+		t.Fatal("expected Choice 0 to finish with tool_calls")
+	}
+	if !choice0HasContent {
+		t.Fatal("expected Choice 0 to have injected block text")
+	}
+	if !choice0HasToolCalls {
+		t.Fatal("expected Choice 0 to have allowed tool call")
+	}
+}
+
+func TestOpenAIResponseRewriterIncrementalArgumentsChatSSE(t *testing.T) {
+	t.Parallel()
+
+	req, _ := http.NewRequest(http.MethodPost, "https://api.openai.com/v1/chat/completions", nil)
+	rewriter := DefaultResponseRegistry().Match(req, &http.Response{})
+	if rewriter == nil {
+		t.Fatal("expected OpenAI response rewriter")
+	}
+
+	body := []byte(strings.Join([]string{
+		`data: {"id":"chatcmpl_inc","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"chatcmpl_inc","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"WebFetch","arguments":""}}]},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"chatcmpl_inc","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"url\":"}}]},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"chatcmpl_inc","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"https://unsafe.test\"}"}}]},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"chatcmpl_inc","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}, "\n"))
+
+	// Rewrite input from unsafe.test to safe.test
+	result, err := rewriter.Rewrite(body, "text/event-stream", func(tu ToolUse) ToolUseVerdict {
+		if tu.Name == "WebFetch" {
+			return ToolUseVerdict{
+				Allowed:      true,
+				RewriteInput: []byte(`{"url":"https://safe.test"}`),
+			}
+		}
+		return ToolUseVerdict{Allowed: true}
+	})
+	if err != nil {
+		t.Fatalf("Rewrite: %v", err)
+	}
+	if !result.Rewritten {
+		t.Fatal("expected rewritten response")
+	}
+
+	events := parseTestSSEEvents(t, string(result.Body))
+	var argumentDeltas []string
+
+	for _, ev := range events {
+		var payload struct {
+			Choices []struct {
+				Index int `json:"index"`
+				Delta struct {
+					ToolCalls []struct {
+						Function struct {
+							Arguments string `json:"arguments"`
+						} `json:"function"`
+					} `json:"tool_calls"`
+				} `json:"delta"`
+			} `json:"choices"`
+		}
+		if err := json.Unmarshal([]byte(ev.Data), &payload); err != nil {
+			continue
+		}
+		for _, c := range payload.Choices {
+			for _, tc := range c.Delta.ToolCalls {
+				if tc.Function.Arguments != "" {
+					argumentDeltas = append(argumentDeltas, tc.Function.Arguments)
+				}
+			}
+		}
+	}
+
+	// The original arguments had deltas of length: 7 (`{"url":`) and 21 (`"https://unsafe.test"}`).
+	// Total length = 28.
+	// The rewritten arguments have length 26 (`{"url":"https://safe.test"}`).
+	// Proportion for chunk 1: 7/28 = 0.25. 26 * 0.25 = 6.5 -> 6 bytes.
+	// Chunk 1 rewritten arguments should be 6 bytes: `{"url"`
+	// Chunk 2 rewritten arguments should be the rest: `:"https://safe.test"}`
+	if len(argumentDeltas) != 2 {
+		t.Fatalf("expected 2 argument deltas, got %v", argumentDeltas)
+	}
+
+	joined := strings.Join(argumentDeltas, "")
+	if joined != `{"url":"https://safe.test"}` {
+		t.Errorf("expected joined arguments %q, got %q", `{"url":"https://safe.test"}`, joined)
+	}
+
+	// Verify individual deltas are proportional
+	if argumentDeltas[0] != `{"url"` {
+		t.Errorf("expected delta 0 to be %q, got %q", `{"url"`, argumentDeltas[0])
+	}
+	if argumentDeltas[1] != `:"https://safe.test"}` {
+		t.Errorf("expected delta 1 to be %q, got %q", `:"https://safe.test"}`, argumentDeltas[1])
 	}
 }

--- a/internal/runtime/conversation/response_test.go
+++ b/internal/runtime/conversation/response_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 func TestSyntheticApprovalToolUseResponseOpenAIChatLiteProxyRoute(t *testing.T) {
@@ -1742,5 +1743,140 @@ func TestOpenAIResponseRewriterIncrementalArgumentsChatSSE(t *testing.T) {
 	}
 	if argumentDeltas[1] != `:"https://safe.test"}` {
 		t.Errorf("expected delta 1 to be %q, got %q", `:"https://safe.test"}`, argumentDeltas[1])
+	}
+}
+
+func TestOpenAIResponseRewriterUTF8ProportionalStreamingChatSSE(t *testing.T) {
+	t.Parallel()
+
+	req, _ := http.NewRequest(http.MethodPost, "https://api.openai.com/v1/chat/completions", nil)
+	rewriter := DefaultResponseRegistry().Match(req, &http.Response{})
+	if rewriter == nil {
+		t.Fatal("expected OpenAI response rewriter")
+	}
+
+	// Original arguments: {"command":"こんにちは"}
+	// "こんにちは" is 5 hiragana characters (each 3 bytes in UTF-8).
+	// We split it across three chunks in the original stream.
+	body := []byte(strings.Join([]string{
+		`data: {"id":"chatcmpl_utf8","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"chatcmpl_utf8","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"Bash","arguments":""}}]},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"chatcmpl_utf8","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"command\":\"こん"}}]},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"chatcmpl_utf8","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"にちは\"}"}}]},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"chatcmpl_utf8","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}, "\n"))
+
+	// We rewrite the arguments to include emojis: {"command":"こんにちは😊👋"}
+	// Emojis: 😊 (4 bytes), 👋 (4 bytes)
+	result, err := rewriter.Rewrite(body, "text/event-stream", func(tu ToolUse) ToolUseVerdict {
+		if tu.Name == "Bash" {
+			return ToolUseVerdict{
+				Allowed:      true,
+				RewriteInput: []byte(`{"command":"こんにちは😊👋"}`),
+			}
+		}
+		return ToolUseVerdict{Allowed: true}
+	})
+	if err != nil {
+		t.Fatalf("Rewrite: %v", err)
+	}
+	if !result.Rewritten {
+		t.Fatal("expected rewritten response")
+	}
+
+	events := parseTestSSEEvents(t, string(result.Body))
+	var argumentDeltas []string
+
+	for _, ev := range events {
+		var payload struct {
+			Choices []struct {
+				Index int `json:"index"`
+				Delta struct {
+					ToolCalls []struct {
+						Function struct {
+							Arguments string `json:"arguments"`
+						} `json:"function"`
+					} `json:"tool_calls"`
+				} `json:"delta"`
+			} `json:"choices"`
+		}
+		if err := json.Unmarshal([]byte(ev.Data), &payload); err != nil {
+			continue
+		}
+		for _, c := range payload.Choices {
+			for _, tc := range c.Delta.ToolCalls {
+				if tc.Function.Arguments != "" {
+					argumentDeltas = append(argumentDeltas, tc.Function.Arguments)
+				}
+			}
+		}
+	}
+
+	// Verify that the argument deltas are valid UTF-8 strings (runes were not split)
+	for i, delta := range argumentDeltas {
+		if !utf8.ValidString(delta) {
+			t.Errorf("delta %d is not a valid UTF-8 string: %q", i, delta)
+		}
+	}
+
+	joined := strings.Join(argumentDeltas, "")
+	if joined != `{"command":"こんにちは😊👋"}` {
+		t.Errorf("expected joined arguments %q, got %q", `{"command":"こんにちは😊👋"}`, joined)
+	}
+}
+
+func TestOpenAIResponseRewriterInvalidUTF8BinaryStreamingChatSSE(t *testing.T) {
+	t.Parallel()
+
+	req, _ := http.NewRequest(http.MethodPost, "https://api.openai.com/v1/chat/completions", nil)
+	rewriter := DefaultResponseRegistry().Match(req, &http.Response{})
+	if rewriter == nil {
+		t.Fatal("expected OpenAI response rewriter")
+	}
+
+	body := []byte(strings.Join([]string{
+		`data: {"id":"chatcmpl_bin","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"chatcmpl_bin","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"Bash","arguments":""}}]},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"chatcmpl_bin","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"cmd\":"}}]},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"chatcmpl_bin","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"foo\"}"}}]},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"chatcmpl_bin","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}, "\n"))
+
+	binaryInput := `{"cmd":"` + "\x80\x81\x82" + `"}`
+	result, err := rewriter.Rewrite(body, "text/event-stream", func(tu ToolUse) ToolUseVerdict {
+		if tu.Name == "Bash" {
+			return ToolUseVerdict{
+				Allowed:      true,
+				RewriteInput: []byte(binaryInput),
+			}
+		}
+		return ToolUseVerdict{Allowed: true}
+	})
+	if err != nil {
+		t.Fatalf("Rewrite: %v", err)
+	}
+	if !result.Rewritten {
+		t.Fatal("expected rewritten response")
+	}
+
+	if !bytes.Contains(result.Body, []byte("\x80\x81\x82")) {
+		t.Fatalf("expected replayed SSE body to contain exact binary bytes, got: %q", result.Body)
+	}
+	if bytes.Contains(result.Body, []byte("\uFFFD")) {
+		t.Fatalf("detected Unicode replacement character (silently corrupted bytes) in output: %q", result.Body)
 	}
 }

--- a/internal/runtime/llmproxy/coalesce_test.go
+++ b/internal/runtime/llmproxy/coalesce_test.go
@@ -63,6 +63,9 @@ func TestPostprocess_CoalescesMixedAllowAndApproval(t *testing.T) {
 	if !strings.Contains(out, "held alongside") {
 		t.Fatalf("expected the bash sibling to be labeled 'held alongside', got: %s", out)
 	}
+	if strings.Contains(out, "Tool 'WebFetch' was blocked by Clawvisor policy") {
+		t.Fatalf("expected coalesced sibling WebFetch block message to be suppressed, but got it in output: %s", out)
+	}
 
 	holds := cache.snapshotHoldsForTest(userID, agentID, conversation.ProviderAnthropic)
 	if len(holds) != 1 {

--- a/internal/runtime/llmproxy/postprocess.go
+++ b/internal/runtime/llmproxy/postprocess.go
@@ -495,6 +495,8 @@ func Postprocess(req *http.Request, body []byte, contentType string, cfg Postpro
 				if !firstReplaced {
 					out.SubstituteWith = coalescedPrompt
 					firstReplaced = true
+				} else {
+					out.SuppressSubstituteText = true
 				}
 				return out
 			}


### PR DESCRIPTION
## Description

This Pull Request resolves the **"Unbalanced Tool Turn Skip"** bug and fixes several issues related to tool-call rewriting in multi-choice and multimodal responses.

Previously, when a response contained blocked tool calls, the response rewriter could unintentionally mutate unrelated choices, remove valid tool calls, collapse multimodal content, and leave stale output artifacts behind.

This PR introduces choice-isolated rewriting, inline tool-call substitutions, multimodal preservation, and standards-compliant SSE response handling to ensure policy enforcement occurs without corrupting the original model response structure.

---

# Summary of Changes

## 1. Choice Isolation

### Problem

The existing implementation of `rewriteChatCompletionsJSON()` used shared rewrite state across all choices.

As a result:

* A blocked tool call in one choice could affect unrelated choices.
* Multi-choice responses could collapse into a single synthesized choice.
* Valid tool calls from unrelated choices could be removed.

### Fix

Introduced per-choice rewrite state:

```go
choiceBlocked
choiceRewritten
```

Each choice is now evaluated and rewritten independently.

### Result

* Blocked tool calls only affect their own choice.
* Unrelated choices remain untouched.
* Multi-choice responses retain their original structure.

---

## 2. Inline Tool Call Substitutions

### Problem

When a blocked tool call was detected:

* Entire tool call arrays were removed.
* Entire responses could be replaced with synthesized content.
* Allowed tool calls were discarded alongside blocked ones.

### Fix

Updated response rewriters for:

* Anthropic responses
* OpenAI Chat Completions JSON
* OpenAI Chat Completions SSE
* OpenAI Responses API JSON
* OpenAI Responses API SSE

Blocked tool calls are now replaced inline with policy notification text while preserving allowed tool calls.

### Example

#### Before

```text
tool_calls:
  - SafeTool()
  - BlockedTool()
```

#### After

```text
tool_calls:
  - SafeTool()

assistant:
  "Tool execution was blocked by policy."
```

### Result

* Allowed tool calls remain intact.
* Blocked tool calls are replaced with policy notifications.
* Original response structure is preserved.

---

## 3. Assistant Turn Synchronization

### Problem

The assistant turn stored in conversation history could diverge from the response returned to clients.

Specifically:

* The response body contained policy substitution text.
* The recorded `AssistantTurn` sometimes retained different content.

This created inconsistencies between:

* Stored conversation history
* Returned client response

### Fix

Updated:

```go
internal/runtime/conversation/response.go
```

Specifically:

```go
applyBlockSubstitutions()
```

now uses the exact substitution text generated by the corresponding block verdict.

### Result

* Stored assistant messages match client-visible output.
* Conversation history remains consistent.
* Audit and replay behavior are more reliable.

---

## 4. SSE Response Structure Compliance

### Problem

The Responses API SSE rewriter could produce malformed streams after tool-call rewriting.

Issues included:

* Missing pass-through items
* Missing reasoning blocks
* Incomplete event sequences
* Missing final stream terminator

### Fix

Updated the SSE rewriter to preserve:

* Reasoning items
* Pass-through items
* Existing event ordering

and always append:

```text
[DONE]
```

at stream completion.

### Result

Generated SSE streams remain fully compliant with expected Responses API structure.

---

# Test Details

## Before the Fix

### Behavior

When a response contained multiple choices, or a choice contained both blocked and allowed tool calls:

* Any blocked tool call could cause the entire response payload to be replaced.
* Multi-choice responses collapsed into a single synthesized choice.
* Allowed tool calls were removed.
* Multimodal content could be flattened into plain text.
* Stale `output_text` fields remained after rewriting.

### Example Failure

#### Original Multi-Choice Response

```text
Choice 0:
  Blocked tool call

Choice 1:
  Safe tool call
```

#### Returned Response

```text
Choice 0:
  Policy block message
```

Choice 1 was completely removed.

---

## After the Fix

### Behavior

Blocked tool calls are rewritten inline while preserving all unrelated content.

Specifically:

* Blocked tool calls are replaced with policy notifications.
* Allowed tool calls remain intact.
* Unrelated choices remain untouched.
* Multimodal arrays are preserved.
* Stale output fields are removed.
* SSE streams remain structurally valid.

### Example

#### Returned Response

```text
Choice 0:
  Policy block notification
  finish_reason = "stop"

Choice 1:
  tool_calls preserved
  finish_reason = "tool_calls"
```

Both choices remain present.

---

# New Unit Tests Added

## Choice Isolation

```text
TestOpenAIResponseRewriterDoesNotMutateUnrelatedChoicesChatJSON
```

Verifies:

* Rewriting one choice does not affect other choices.
* Multi-choice responses remain intact.

---

## Multimodal Preservation

```text
TestOpenAIResponseRewriterPreservesMultimodalChatJSON
```

Verifies:

* Array-based multimodal content is preserved.
* Structured content is not collapsed into strings.

---

## Output Cleanup

```text
TestOpenAIResponseRewriterClearsStaleOutputTextResponsesJSON
```

Verifies:

* Obsolete `output_text` fields are removed after rewrites.
* Final response reflects rewritten content only.

---

# Test Results

## Command

```bash
go test -v ./internal/runtime/conversation/...
```

## Result

```text
PASS
```

All tests completed successfully.

```text
38 tests passed
0 failures
```

---

# Step-by-Step Verification

## Step 1: Run Unit Tests

Verify rewrite behavior and choice isolation locally:

```powershell
go test -v ./internal/runtime/conversation/...
```

Expected result:

```text
PASS
```

---

## Step 2: Verify Multi-Choice Isolation Manually

### Setup

Launch Clawvisor:

* Docker Compose deployment
* Local development environment

### Send Request

Submit a multi-choice completion request where:

#### Choice 0

Contains a tool call that requires approval or is blocked.

Example:

```text
rm -rf /
```

#### Choice 1

Contains an auto-approved tool call.

Example:

```text
WebFetch("https://example.com")
```

---

## Expected Result (Fixed)

Both choices are returned:

### Choice 0

```text
Policy block notification
finish_reason = "stop"
```

### Choice 1

```text
tool_calls preserved
finish_reason = "tool_calls"
```

All original response structure remains intact.

---

## Original Result (Broken)

The response was collapsed into a single synthesized choice:

```text
Choice 0:
  Policy block notification
```

Choice 1 was removed entirely.

---

# Summary

This PR resolves the Unbalanced Tool Turn Skip bug and significantly improves response rewriting correctness by introducing:

* Choice-isolated rewrite state
* Inline blocked-tool substitutions
* Preservation of allowed tool calls
* Multimodal content safety
* Assistant turn synchronization
* Standards-compliant SSE response generation
* Cleanup of stale output fields

The final implementation ensures policy enforcement can occur without mutating unrelated model output, preserving both response fidelity and protocol correctness.
