### PR TITLE
fix(llmproxy): context-aware bypass for file-manipulation placeholder false positives

### DIFF
--- a/internal/runtime/conversation/openai_response.go
+++ b/internal/runtime/conversation/openai_response.go
@@ -1925,7 +1925,7 @@ func (rw OpenAIResponseRewriter) streamRewriteChatCompletions(ctx context.Contex
 				reemitPayload := map[string]any{
 					"id":      event.ID,
 					"object":  "chat.completion.chunk",
-					"model":   event.Model,
+					"model":   msgModel,
 					"choices": contentOnlyChoices,
 				}
 				raw, err := json.Marshal(reemitPayload)

--- a/internal/runtime/llmproxy/inspector/inspector.go
+++ b/internal/runtime/llmproxy/inspector/inspector.go
@@ -132,6 +132,9 @@ func (i *Inspector) Inspect(ctx context.Context, t ToolUse) Verdict {
 	if i != nil && i.Parser != nil {
 		if v, ok := i.Parser.Parse(t); ok {
 			v.Source = SourceDeterministic
+			if len(v.Placeholders) == 0 {
+				v.Placeholders = extractPlaceholdersFromInput(t.Input)
+			}
 			return v
 		}
 	}

--- a/internal/runtime/llmproxy/inspector/inspector_test.go
+++ b/internal/runtime/llmproxy/inspector/inspector_test.go
@@ -756,3 +756,24 @@ func TestAllPlaceholdersAreStubs(t *testing.T) {
 		})
 	}
 }
+
+func TestDefaultParser_FileManipulationToolsAllowed(t *testing.T) {
+	p := DefaultParser{}
+	tests := []string{"Write", "Edit", "replace_file_content", "apply_patch"}
+	for _, name := range tests {
+		tu := ToolUse{
+			Name:  name,
+			Input: json.RawMessage(`{"file_path": "test.txt", "content": "autovault_stripe_mock_token_for_unit_tests"}`),
+		}
+		v, ok := p.Parse(tu)
+		if !ok {
+			t.Errorf("expected parser to handle tool %s", name)
+		}
+		if v.IsAPICall {
+			t.Errorf("expected IsAPICall false for %s, got true", name)
+		}
+		if v.Ambiguous {
+			t.Errorf("expected Ambiguous false for %s, got true", name)
+		}
+	}
+}

--- a/internal/runtime/llmproxy/inspector/inspector_test.go
+++ b/internal/runtime/llmproxy/inspector/inspector_test.go
@@ -777,3 +777,25 @@ func TestDefaultParser_FileManipulationToolsAllowed(t *testing.T) {
 		}
 	}
 }
+
+func TestDefaultParser_FileManipulationWithURLAllowed(t *testing.T) {
+	p := DefaultParser{}
+	// Write tool call where the input has a "url" key.
+	// If parseStructuredFetch ran first, it would see "url" and try to treat it as a Structured Fetch API call.
+	// Because it runs after isFileManipulationTool, it should be parsed as a file manipulation tool instead.
+	tu := ToolUse{
+		Name:  "Write",
+		Input: json.RawMessage(`{"file_path": "test.txt", "url": "https://api.github.com/repos/x/y", "content": "autovault_stripe_mock_token_for_unit_tests"}`),
+	}
+	v, ok := p.Parse(tu)
+	if !ok {
+		t.Fatalf("expected parser to handle Write tool")
+	}
+	if v.IsAPICall {
+		t.Errorf("expected IsAPICall false, got true")
+	}
+	if v.Ambiguous {
+		t.Errorf("expected Ambiguous false, got true")
+	}
+}
+

--- a/internal/runtime/llmproxy/inspector/parser.go
+++ b/internal/runtime/llmproxy/inspector/parser.go
@@ -26,6 +26,12 @@ type DefaultParser struct{}
 
 // Parse implements Parser.
 func (DefaultParser) Parse(t ToolUse) (Verdict, bool) {
+	if v, ok := parseStructuredFetch(t); ok {
+		return v, true
+	}
+	if v, ok := parseBashCurl(t); ok {
+		return v, true
+	}
 	// Known-local tools never make outbound HTTP calls; if a placeholder
 	// substring appears in their args (a user pasting the placeholder
 	// into a chat that gets routed through Skill, an Edit that records
@@ -45,17 +51,15 @@ func (DefaultParser) Parse(t ToolUse) (Verdict, bool) {
 			Reason:    "non-API file manipulation tool (" + t.Name + ")",
 		}, true
 	}
-	if v, ok := parseStructuredFetch(t); ok {
-		return v, true
-	}
-	if v, ok := parseBashCurl(t); ok {
-		return v, true
-	}
 	return Verdict{}, false
 }
 
 func isFileManipulationTool(name string) bool {
-	switch strings.ToLower(strings.TrimSpace(name)) {
+	nameLower := strings.ToLower(strings.TrimSpace(name))
+	if strings.Contains(nameLower, "__") && !strings.HasPrefix(nameLower, "mcp__filesystem__") {
+		return false
+	}
+	switch nameLower {
 	case "write", "edit", "notebookedit", "write_file", "edit_file",
 		"mcp__filesystem__write_file", "mcp__filesystem__edit_file",
 		"replace_file_content", "multi_replace_file_content", "write_to_file",
@@ -233,6 +237,10 @@ var defaultAllowedTools = map[string]struct{}{
 }
 
 func isLocalOnlyTool(name string) bool {
+	nameLower := strings.ToLower(strings.TrimSpace(name))
+	if strings.Contains(nameLower, "__") && !strings.HasPrefix(nameLower, "mcp__filesystem__") {
+		return false
+	}
 	return IsLocalOnlyTool(name)
 }
 

--- a/internal/runtime/llmproxy/inspector/parser.go
+++ b/internal/runtime/llmproxy/inspector/parser.go
@@ -26,12 +26,6 @@ type DefaultParser struct{}
 
 // Parse implements Parser.
 func (DefaultParser) Parse(t ToolUse) (Verdict, bool) {
-	if v, ok := parseStructuredFetch(t); ok {
-		return v, true
-	}
-	if v, ok := parseBashCurl(t); ok {
-		return v, true
-	}
 	// Known-local tools never make outbound HTTP calls; if a placeholder
 	// substring appears in their args (a user pasting the placeholder
 	// into a chat that gets routed through Skill, an Edit that records
@@ -50,6 +44,12 @@ func (DefaultParser) Parse(t ToolUse) (Verdict, bool) {
 			Ambiguous: false,
 			Reason:    "non-API file manipulation tool (" + t.Name + ")",
 		}, true
+	}
+	if v, ok := parseStructuredFetch(t); ok {
+		return v, true
+	}
+	if v, ok := parseBashCurl(t); ok {
+		return v, true
 	}
 	return Verdict{}, false
 }

--- a/internal/runtime/llmproxy/inspector/parser.go
+++ b/internal/runtime/llmproxy/inspector/parser.go
@@ -38,6 +38,13 @@ func (DefaultParser) Parse(t ToolUse) (Verdict, bool) {
 			Reason:    "local-only tool (" + t.Name + "); placeholder not transmitted",
 		}, true
 	}
+	if isFileManipulationTool(t.Name) {
+		return Verdict{
+			IsAPICall: false,
+			Ambiguous: false,
+			Reason:    "non-API file manipulation tool (" + t.Name + ")",
+		}, true
+	}
 	if v, ok := parseStructuredFetch(t); ok {
 		return v, true
 	}
@@ -45,6 +52,18 @@ func (DefaultParser) Parse(t ToolUse) (Verdict, bool) {
 		return v, true
 	}
 	return Verdict{}, false
+}
+
+func isFileManipulationTool(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "write", "edit", "notebookedit", "write_file", "edit_file",
+		"mcp__filesystem__write_file", "mcp__filesystem__edit_file",
+		"replace_file_content", "multi_replace_file_content", "write_to_file",
+		"apply_patch", "replace", "strreplace", "str_replace":
+		return true
+	default:
+		return false
+	}
 }
 
 // localOnlyTools enumerates tool names whose payloads should not be

--- a/internal/runtime/llmproxy/postprocess.go
+++ b/internal/runtime/llmproxy/postprocess.go
@@ -872,7 +872,7 @@ func newToolUseEvaluator(req *http.Request, cfg PostprocessConfig, provider conv
 		// Inspector says trigger missed (no autovault placeholder). There
 		// is no credential rewrite to perform, but shared authorization
 		// still sees ordinary tool_use calls such as Bash/Read.
-		if v.Source == inspector.SourceTriggerMiss {
+		if v.Source == inspector.SourceTriggerMiss || (!v.IsAPICall && !v.Ambiguous) {
 			readOnlyShellCommand := false
 			sensitiveShellPath := false
 			if toolnames.IsShellToolName(tu.Name) && readOnlyShellCommandsAllowed(tu.Name, cfg.AgentID, cfg.ToolRules) {
@@ -986,25 +986,36 @@ func newToolUseEvaluator(req *http.Request, cfg PostprocessConfig, provider conv
 				}
 			}
 			// Record ordinary tool uses even when no credential trigger was
-			// present so lite-proxy activity shows the agent's tool calls.
-			audit("allow", "pass_through", "no credential trigger")
+			// present or it was a confident non-API call so activity shows it.
+			reason := "no credential trigger"
+			if v.Source != inspector.SourceTriggerMiss {
+				reason = "confident non-API call: " + v.Reason
+			}
+			audit("allow", "pass_through", reason)
 			return conversation.ToolUseVerdict{Allowed: true}
 		}
 		if !v.IsAPICall {
-			if v.Ambiguous {
-				audit("block", "ambiguous", v.Reason)
-				reason := "Clawvisor: ambiguous credentialed call refused — " + v.Reason
-				return conversation.ToolUseVerdict{
-					Allowed:                false,
-					Reason:                 reason,
-					ContinueWithToolResult: reason,
-				}
+			// Since !v.Ambiguous is handled in the authorization block above,
+			// if we reach here, it must be ambiguous.
+			audit("block", "ambiguous", v.Reason)
+			reason := "Clawvisor: ambiguous credentialed call refused — " + v.Reason
+			return conversation.ToolUseVerdict{
+				Allowed:                false,
+				Reason:                 reason,
+				ContinueWithToolResult: reason,
 			}
-			audit("allow", "pass_through", "confident non-API call: "+v.Reason)
-			return conversation.ToolUseVerdict{Allowed: true}
 		}
 		if v.Ambiguous {
 			audit("block", "ambiguous", v.Reason)
+			// ContinueWithToolResult preserves the agent's actual
+			// tool_use in conversation history and feeds the rejection
+			// back as a synthetic tool_result — the canonical Anthropic
+			// shape for "your tool call failed, here's why." The model's
+			// own emitted input is right above the synthetic user turn,
+			// so it can see exactly what shape got rejected. The
+			// SubstituteWith fallback is what gets rendered if the
+			// handler can't perform the continuation call (older
+			// provider, recursion bound reached, upstream outage).
 			reason := "Clawvisor: ambiguous credentialed call refused — " + v.Reason
 			return conversation.ToolUseVerdict{
 				Allowed:                false,

--- a/internal/runtime/llmproxy/postprocess.go
+++ b/internal/runtime/llmproxy/postprocess.go
@@ -990,17 +990,21 @@ func newToolUseEvaluator(req *http.Request, cfg PostprocessConfig, provider conv
 			audit("allow", "pass_through", "no credential trigger")
 			return conversation.ToolUseVerdict{Allowed: true}
 		}
-		if v.Ambiguous || !v.IsAPICall {
+		if !v.IsAPICall {
+			if v.Ambiguous {
+				audit("block", "ambiguous", v.Reason)
+				reason := "Clawvisor: ambiguous credentialed call refused — " + v.Reason
+				return conversation.ToolUseVerdict{
+					Allowed:                false,
+					Reason:                 reason,
+					ContinueWithToolResult: reason,
+				}
+			}
+			audit("allow", "pass_through", "confident non-API call: "+v.Reason)
+			return conversation.ToolUseVerdict{Allowed: true}
+		}
+		if v.Ambiguous {
 			audit("block", "ambiguous", v.Reason)
-			// ContinueWithToolResult preserves the agent's actual
-			// tool_use in conversation history and feeds the rejection
-			// back as a synthetic tool_result — the canonical Anthropic
-			// shape for "your tool call failed, here's why." The model's
-			// own emitted input is right above the synthetic user turn,
-			// so it can see exactly what shape got rejected. The
-			// SubstituteWith fallback is what gets rendered if the
-			// handler can't perform the continuation call (older
-			// provider, recursion bound reached, upstream outage).
 			reason := "Clawvisor: ambiguous credentialed call refused — " + v.Reason
 			return conversation.ToolUseVerdict{
 				Allowed:                false,

--- a/internal/runtime/llmproxy/postprocess.go
+++ b/internal/runtime/llmproxy/postprocess.go
@@ -872,7 +872,7 @@ func newToolUseEvaluator(req *http.Request, cfg PostprocessConfig, provider conv
 		// Inspector says trigger missed (no autovault placeholder). There
 		// is no credential rewrite to perform, but shared authorization
 		// still sees ordinary tool_use calls such as Bash/Read.
-		if v.Source == inspector.SourceTriggerMiss || (!v.IsAPICall && !v.Ambiguous && v.Source == inspector.SourceDeterministic) {
+		if v.Source == inspector.SourceTriggerMiss || (!v.IsAPICall && !v.Ambiguous) {
 			readOnlyShellCommand := false
 			sensitiveShellPath := false
 			if toolnames.IsShellToolName(tu.Name) && readOnlyShellCommandsAllowed(tu.Name, cfg.AgentID, cfg.ToolRules) {

--- a/internal/runtime/llmproxy/postprocess.go
+++ b/internal/runtime/llmproxy/postprocess.go
@@ -872,7 +872,7 @@ func newToolUseEvaluator(req *http.Request, cfg PostprocessConfig, provider conv
 		// Inspector says trigger missed (no autovault placeholder). There
 		// is no credential rewrite to perform, but shared authorization
 		// still sees ordinary tool_use calls such as Bash/Read.
-		if v.Source == inspector.SourceTriggerMiss || (!v.IsAPICall && !v.Ambiguous) {
+		if v.Source == inspector.SourceTriggerMiss || (!v.IsAPICall && !v.Ambiguous && v.Source == inspector.SourceDeterministic) {
 			readOnlyShellCommand := false
 			sensitiveShellPath := false
 			if toolnames.IsShellToolName(tu.Name) && readOnlyShellCommandsAllowed(tu.Name, cfg.AgentID, cfg.ToolRules) {

--- a/internal/runtime/llmproxy/postprocess.go
+++ b/internal/runtime/llmproxy/postprocess.go
@@ -995,10 +995,17 @@ func newToolUseEvaluator(req *http.Request, cfg PostprocessConfig, provider conv
 			return conversation.ToolUseVerdict{Allowed: true}
 		}
 		if !v.IsAPICall {
-			// Since !v.Ambiguous is handled in the authorization block above,
-			// if we reach here, it must be ambiguous.
-			audit("block", "ambiguous", v.Reason)
-			reason := "Clawvisor: ambiguous credentialed call refused — " + v.Reason
+			if v.Ambiguous {
+				audit("block", "ambiguous", v.Reason)
+				reason := "Clawvisor: ambiguous credentialed call refused — " + v.Reason
+				return conversation.ToolUseVerdict{
+					Allowed:                false,
+					Reason:                 reason,
+					ContinueWithToolResult: reason,
+				}
+			}
+			audit("block", "non_api_credentialed", v.Reason)
+			reason := "Clawvisor: non-API tool calls carrying credentials are not permitted — " + v.Reason
 			return conversation.ToolUseVerdict{
 				Allowed:                false,
 				Reason:                 reason,

--- a/internal/runtime/llmproxy/postprocess_test.go
+++ b/internal/runtime/llmproxy/postprocess_test.go
@@ -1999,3 +1999,33 @@ func (r *postprocessErroringReader) Read(p []byte) (n int, err error) {
 	return n, nil
 }
 
+func TestPostprocess_AllowsConfidentNonAPICalls(t *testing.T) {
+	t.Parallel()
+	body := anthropicJSONWithNamedToolUse("Write", `{"file_path":"test.txt","content":"autovault_stripe_mock_token_for_unit_tests"}`)
+	req := httptest.NewRequest("POST", "/v1/messages", nil)
+	insp := inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{})
+	st, userID, agentID := seedPostprocessStore(t, "autovault_stripe_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
+
+	got := Postprocess(req, body, "application/json", PostprocessConfig{
+		Inspector:    insp,
+		RewriteOpts:  inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
+		CallerNonces: NewMemoryCallerNonceCache(time.Minute),
+		Store:        st,
+		AgentUserID:  userID,
+		AgentID:      agentID,
+	})
+
+	if len(got.Decisions) != 1 {
+		t.Fatalf("expected 1 decision, got %d", len(got.Decisions))
+	}
+	if !got.Decisions[0].Verdict.Allowed {
+		t.Fatalf("confident non-API tool call (Write with long mock placeholder) should be allowed, got decision: %+v", got.Decisions[0])
+	}
+	if got.Rewritten {
+		t.Fatalf("confident non-API tool call should not be rewritten")
+	}
+	if string(got.Body) != string(body) {
+		t.Fatalf("body should be unchanged when non-API passes through")
+	}
+}
+

--- a/internal/runtime/llmproxy/postprocess_test.go
+++ b/internal/runtime/llmproxy/postprocess_test.go
@@ -2029,3 +2029,40 @@ func TestPostprocess_AllowsConfidentNonAPICalls(t *testing.T) {
 	}
 }
 
+func TestPostprocess_EnforcesRulesOnConfidentNonAPICalls(t *testing.T) {
+	t.Parallel()
+	body := anthropicJSONWithNamedToolUse("Write", `{"file_path":"test.txt","content":"autovault_stripe_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}`)
+	req := httptest.NewRequest("POST", "/v1/messages", nil)
+	insp := inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{})
+	st, userID, agentID := seedPostprocessStore(t, "autovault_stripe_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
+
+	got := Postprocess(req, body, "application/json", PostprocessConfig{
+		Inspector:    insp,
+		RewriteOpts:  inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
+		CallerNonces: NewMemoryCallerNonceCache(time.Minute),
+		Store:        st,
+		AgentUserID:  userID,
+		AgentID:      agentID,
+		ToolRules: []*store.RuntimePolicyRule{{
+			ID:       "deny-write",
+			UserID:   userID,
+			AgentID:  &agentID,
+			Kind:     "tool",
+			Action:   "deny",
+			ToolName: "Write",
+			Reason:   "file writes blocked",
+			Enabled:  true,
+		}},
+	})
+
+	if len(got.Decisions) != 1 {
+		t.Fatalf("expected 1 decision, got %d", len(got.Decisions))
+	}
+	if got.Decisions[0].Verdict.Allowed {
+		t.Fatalf("confident non-API tool call (Write) should be blocked by ToolRules")
+	}
+	if !strings.Contains(string(got.Body), "file writes blocked") {
+		t.Fatalf("expected error block message with rule reason, got body: %s", got.Body)
+	}
+}
+

--- a/internal/runtime/llmproxy/postprocess_test.go
+++ b/internal/runtime/llmproxy/postprocess_test.go
@@ -2066,18 +2066,19 @@ func TestPostprocess_EnforcesRulesOnConfidentNonAPICalls(t *testing.T) {
 	}
 }
 
-func TestPostprocess_AllowsConfidentNonAPICallsFromValidator(t *testing.T) {
+func TestPostprocess_BlocksValidatorOriginNonAPICalls(t *testing.T) {
 	t.Parallel()
 	// Use a custom tool name so DefaultParser doesn't recognize it.
 	body := anthropicJSONWithNamedToolUse("CustomTool", `{"arg":"autovault_stripe_mock_token_for_unit_tests"}`)
 	req := httptest.NewRequest("POST", "/v1/messages", nil)
 
-	// The validator returns IsAPICall=false, Ambiguous=false
+	// The validator returns IsAPICall=false, Ambiguous=false.
+	// Since the source is validator, this is not trusted to bypass mediation (fail-closed security rule).
 	insp := inspector.NewInspector(inspector.DefaultParser{}, postprocessFakeValidator{
 		verdict: inspector.Verdict{
 			IsAPICall: false,
 			Ambiguous: false,
-			Reason:    "confident non-API verdict from LLM",
+			Reason:    "non-API verdict from LLM",
 		},
 	})
 	st, userID, agentID := seedPostprocessStore(t, "autovault_stripe_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
@@ -2094,15 +2095,13 @@ func TestPostprocess_AllowsConfidentNonAPICallsFromValidator(t *testing.T) {
 	if len(got.Decisions) != 1 {
 		t.Fatalf("expected 1 decision, got %d", len(got.Decisions))
 	}
-	if !got.Decisions[0].Verdict.Allowed {
-		t.Fatalf("confident validator non-API tool call should be allowed, got decision: %+v", got.Decisions[0])
+	if got.Decisions[0].Verdict.Allowed {
+		t.Fatalf("validator non-API tool call should be blocked, got decision: %+v", got.Decisions[0])
 	}
-	if got.Rewritten {
-		t.Fatalf("confident validator non-API tool call should not be rewritten")
-	}
-	if string(got.Body) != string(body) {
-		t.Fatalf("body should be unchanged when non-API passes through")
+	if !strings.Contains(string(got.Body), "ambiguous credentialed call refused") {
+		t.Fatalf("expected ambiguous block error message, got body: %s", got.Body)
 	}
 }
+
 
 

--- a/internal/runtime/llmproxy/postprocess_test.go
+++ b/internal/runtime/llmproxy/postprocess_test.go
@@ -2066,3 +2066,43 @@ func TestPostprocess_EnforcesRulesOnConfidentNonAPICalls(t *testing.T) {
 	}
 }
 
+func TestPostprocess_AllowsConfidentNonAPICallsFromValidator(t *testing.T) {
+	t.Parallel()
+	// Use a custom tool name so DefaultParser doesn't recognize it.
+	body := anthropicJSONWithNamedToolUse("CustomTool", `{"arg":"autovault_stripe_mock_token_for_unit_tests"}`)
+	req := httptest.NewRequest("POST", "/v1/messages", nil)
+
+	// The validator returns IsAPICall=false, Ambiguous=false
+	insp := inspector.NewInspector(inspector.DefaultParser{}, postprocessFakeValidator{
+		verdict: inspector.Verdict{
+			IsAPICall: false,
+			Ambiguous: false,
+			Reason:    "confident non-API verdict from LLM",
+		},
+	})
+	st, userID, agentID := seedPostprocessStore(t, "autovault_stripe_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
+
+	got := Postprocess(req, body, "application/json", PostprocessConfig{
+		Inspector:    insp,
+		RewriteOpts:  inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
+		CallerNonces: NewMemoryCallerNonceCache(time.Minute),
+		Store:        st,
+		AgentUserID:  userID,
+		AgentID:      agentID,
+	})
+
+	if len(got.Decisions) != 1 {
+		t.Fatalf("expected 1 decision, got %d", len(got.Decisions))
+	}
+	if !got.Decisions[0].Verdict.Allowed {
+		t.Fatalf("confident validator non-API tool call should be allowed, got decision: %+v", got.Decisions[0])
+	}
+	if got.Rewritten {
+		t.Fatalf("confident validator non-API tool call should not be rewritten")
+	}
+	if string(got.Body) != string(body) {
+		t.Fatalf("body should be unchanged when non-API passes through")
+	}
+}
+
+

--- a/internal/runtime/llmproxy/postprocess_test.go
+++ b/internal/runtime/llmproxy/postprocess_test.go
@@ -2068,8 +2068,9 @@ func TestPostprocess_EnforcesRulesOnConfidentNonAPICalls(t *testing.T) {
 
 func TestPostprocess_BlocksValidatorOriginNonAPICalls(t *testing.T) {
 	t.Parallel()
-	// Use a custom tool name so DefaultParser doesn't recognize it.
-	body := anthropicJSONWithNamedToolUse("CustomTool", `{"arg":"autovault_stripe_mock_token_for_unit_tests"}`)
+	// Use a custom tool name so DefaultParser doesn't recognize it, and a realistic
+	// placeholder token to ensure it isn't classified as a stub (trigger-miss).
+	body := anthropicJSONWithNamedToolUse("CustomTool", `{"arg":"autovault_stripe_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}`)
 	req := httptest.NewRequest("POST", "/v1/messages", nil)
 
 	// The validator returns IsAPICall=false, Ambiguous=false.
@@ -2098,10 +2099,11 @@ func TestPostprocess_BlocksValidatorOriginNonAPICalls(t *testing.T) {
 	if got.Decisions[0].Verdict.Allowed {
 		t.Fatalf("validator non-API tool call should be blocked, got decision: %+v", got.Decisions[0])
 	}
-	if !strings.Contains(string(got.Body), "ambiguous credentialed call refused") {
-		t.Fatalf("expected ambiguous block error message, got body: %s", got.Body)
+	if !strings.Contains(string(got.Body), "non-API tool calls carrying credentials are not permitted") {
+		t.Fatalf("expected non-API block error message, got body: %s", got.Body)
 	}
 }
+
 
 
 

--- a/internal/runtime/llmproxy/progress_reader_test.go
+++ b/internal/runtime/llmproxy/progress_reader_test.go
@@ -34,8 +34,11 @@ func TestProgressReader_StatsCountReadBytes(t *testing.T) {
 	if bytesTotal != 10 {
 		t.Errorf("bytes_total=%d, want 10", bytesTotal)
 	}
-	if ttfb == 0 || ttfb > elapsed {
-		t.Errorf("ttfb=%v elapsed=%v — ttfb should be set and <= elapsed", ttfb, elapsed)
+	if ttfb > elapsed {
+		t.Errorf("ttfb=%v elapsed=%v — ttfb should be <= elapsed", ttfb, elapsed)
+	}
+	if pr.firstByte.IsZero() {
+		t.Error("firstByte timestamp was not recorded")
 	}
 }
 

--- a/internal/runtime/llmproxy/rawlog_test.go
+++ b/internal/runtime/llmproxy/rawlog_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -44,6 +45,9 @@ func TestRawIOLogger_EmitsJSONLineWithBody(t *testing.T) {
 }
 
 func TestOpenRawIOLoggerTightensExistingFilePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping Unix permission checks on Windows")
+	}
 	path := filepath.Join(t.TempDir(), "raw.jsonl")
 	if err := os.WriteFile(path, nil, 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>Fix File-Manipulation Credential Inspection False Positives and Strengthen Inspector Security Boundaries</h1><h2>Problem</h2><p>Agents were unable to edit or create files containing long <code inline="">autovault_*</code> placeholder tokens.</p><p>When an agent attempted to write:</p><ul><li><p>Unit tests</p></li><li><p>Markdown documentation</p></li><li><p>Configuration templates</p></li><li><p>Mock credential fixtures</p></li></ul><p>the credential inspector incorrectly triggered the credential mediation path.</p><p>Because file-editing tools such as:</p><ul><li><p><code inline="">Write</code></p></li><li><p><code inline="">Edit</code></p></li><li><p><code inline="">apply_patch</code></p></li><li><p><code inline="">replace_file_content</code></p></li></ul><p>are local filesystem operations rather than outbound API calls, they should never have been subjected to credential-boundary mediation.</p><p>However, the inspector failed to classify them as local operations and instead delegated evaluation to the LLM validator.</p><p>In environments without a configured validator, the default verdict became:</p><pre><code class="language-go">Ambiguous: true
</code></pre><p>which resulted in:</p><pre><code class="language-text">Clawvisor: ambiguous credentialed call refused
</code></pre><p>As a result, agents were blocked from editing their own test files and local project assets.</p><hr><h1>Root Cause Analysis</h1><h2>1. Missing File-Manipulation Classification</h2><h3>File</h3><pre><code class="language-text">internal/runtime/llmproxy/inspector/parser.go
</code></pre><h3>Problem</h3><p><code inline="">DefaultParser</code> had no dedicated handling for file-manipulation tools.</p><p>These tool calls fell through to:</p><ul><li><p><code inline="">parseStructuredFetch()</code></p></li><li><p><code inline="">parseBashCurl()</code></p></li></ul><p>which returned:</p><pre><code class="language-go">(Verdict{}, false)
</code></pre><p>causing the request to be evaluated by the LLM validator.</p><h3>Before</h3><pre><code class="language-go">func (DefaultParser) Parse(t ToolUse) (Verdict, bool) {
    if v, ok := parseStructuredFetch(t); ok {
        return v, true
    }

    if v, ok := parseBashCurl(t); ok {
        return v, true
    }

    if isLocalOnlyTool(t.Name) {
        ...
    }

    // No file-manipulation path
    return Verdict{}, false
}
</code></pre><h3>Impact</h3><p>File writes containing placeholder-like tokens were incorrectly treated as potential API calls.</p><hr><h2>2. Incorrect Parser Evaluation Order</h2><h3>File</h3><pre><code class="language-text">internal/runtime/llmproxy/inspector/parser.go
</code></pre><h3>Problem</h3><p>Network-shaped parsers ran before local tool detection.</p><p>This created a security issue where a file-write tool containing a JSON field such as:</p><pre><code class="language-json">{
  "url": "https://example.com"
}
</code></pre><p>could be classified as a structured outbound request.</p><h3>Impact</h3><p>A local filesystem operation could be incorrectly treated as an API call simply because its payload contained a URL-shaped field.</p><hr><h2>3. Non-API Bypass Trusted Validator Verdicts</h2><h3>File</h3><pre><code class="language-text">internal/runtime/llmproxy/postprocess.go
</code></pre><h3>Problem</h3><p>The bypass condition allowed any confident non-API verdict to skip boundary mediation:</p><pre><code class="language-go">if v.Source == inspector.SourceTriggerMiss ||
   (!v.IsAPICall &amp;&amp; !v.Ambiguous) {
    ...
}
</code></pre><p>This trusted:</p><ul><li><p>Static parser verdicts</p></li><li><p>LLM validator verdicts</p></li></ul><p>equally.</p><h3>Security Risk</h3><p>A validator could incorrectly classify an outbound API call as:</p><pre><code class="language-go">{
    IsAPICall: false,
    Ambiguous: false
}
</code></pre><p>allowing it to bypass:</p><ul><li><p>Credential mediation</p></li><li><p>Credential rewriting</p></li><li><p>Task-scope authorization</p></li></ul><p>This represented a fail-open path.</p><hr><h2>4. Incorrect Non-API Fallback Handling</h2><h3>File</h3><pre><code class="language-text">internal/runtime/llmproxy/postprocess.go
</code></pre><h3>Problem</h3><p>The fallback block assumed every non-API verdict reaching it was ambiguous.</p><pre><code class="language-go">if !v.IsAPICall {
    // Must be ambiguous
}
</code></pre><p>After introducing deterministic-source restrictions, a validator-origin verdict could reach this path while being:</p><pre><code class="language-go">{
    IsAPICall: false,
    Ambiguous: false
}
</code></pre><h3>Impact</h3><ul><li><p>Incorrect audit events</p></li><li><p>Misleading refusal reasons</p></li><li><p>Wrong enforcement path</p></li></ul><hr><h2>5. External MCP Namespace Spoofing</h2><h3>File</h3><pre><code class="language-text">internal/runtime/llmproxy/inspector/parser.go
</code></pre><h3>Problem</h3><p>Tool classification relied only on short tool names.</p><p>An external MCP server could expose:</p><pre><code class="language-text">mcp__evilserver__write_file
</code></pre><p>which matched local write allowlists.</p><h3>Security Risk</h3><p>A remote tool could impersonate a trusted local filesystem tool and bypass network-aware inspection.</p><hr><h1>Fixes</h1><h2>Parser Improvements</h2><h3>File</h3><pre><code class="language-text">internal/runtime/llmproxy/inspector/parser.go
</code></pre><h3>Before</h3><pre><code class="language-go">func (DefaultParser) Parse(t ToolUse) (Verdict, bool) {
    if v, ok := parseStructuredFetch(t); ok {
        return v, true
    }

    if v, ok := parseBashCurl(t); ok {
        return v, true
    }

    if isLocalOnlyTool(t.Name) {
        ...
    }

    return Verdict{}, false
}
</code></pre><h3>After</h3><pre><code class="language-go">func (DefaultParser) Parse(t ToolUse) (Verdict, bool) {
    // Local-only and file-manipulation tools evaluated first.

    if isLocalOnlyTool(t.Name) {
        ...
    }

    if isFileManipulationTool(t.Name) {
        return Verdict{
            IsAPICall: false,
            Ambiguous: false,
            ...
        }, true
    }

    if v, ok := parseStructuredFetch(t); ok {
        return v, true
    }

    if v, ok := parseBashCurl(t); ok {
        return v, true
    }

    return Verdict{}, false
}
</code></pre><h3>Benefits</h3><ul><li><p>File tools are classified before network-shape parsers.</p></li><li><p>Local semantics cannot be overridden by payload shape.</p></li><li><p>File writes no longer fall through to validator inspection.</p></li></ul><hr><h2>File-Manipulation Tool Detection</h2><h3>New Logic</h3><pre><code class="language-go">func isFileManipulationTool(name string) bool {
    nameLower := strings.ToLower(strings.TrimSpace(name))

    if strings.Contains(nameLower, "__") &amp;&amp;
        !strings.HasPrefix(nameLower, "mcp__filesystem__") {
        return false
    }

    switch nameLower {
    case "write",
         "edit",
         "notebookedit",
         "write_file",
         "edit_file",
         "mcp__filesystem__write_file",
         "mcp__filesystem__edit_file",
         "replace_file_content",
         "multi_replace_file_content",
         "write_to_file",
         "apply_patch",
         "replace",
         "strreplace",
         "str_replace":
        return true
    }

    return false
}
</code></pre><h3>Benefits</h3><ul><li><p>Explicit file-manipulation classification.</p></li><li><p>Trusted filesystem MCP support.</p></li><li><p>External MCP namespace spoofing blocked.</p></li></ul><hr><h2>Namespace Protection for Local Tools</h2><h3>Updated Logic</h3><pre><code class="language-go">func isLocalOnlyTool(name string) bool {
    nameLower := strings.ToLower(strings.TrimSpace(name))

    if strings.Contains(nameLower, "__") &amp;&amp;
        !strings.HasPrefix(nameLower, "mcp__filesystem__") {
        return false
    }

    return IsLocalOnlyTool(name)
}
</code></pre><h3>Benefits</h3><ul><li><p>Prevents namespace spoofing.</p></li><li><p>Restricts trusted filesystem tool handling.</p></li></ul><hr><h2>Deterministic-Only Non-API Bypass</h2><h3>File</h3><pre><code class="language-text">internal/runtime/llmproxy/postprocess.go
</code></pre><h3>Before</h3><pre><code class="language-go">if v.Source == inspector.SourceTriggerMiss ||
   (!v.IsAPICall &amp;&amp; !v.Ambiguous) {
    ...
}
</code></pre><h3>After</h3><pre><code class="language-go">if v.Source == inspector.SourceTriggerMiss ||
   (!v.IsAPICall &amp;&amp;
    !v.Ambiguous &amp;&amp;
    v.Source == inspector.SourceDeterministic) {
    ...
}
</code></pre><h3>Benefits</h3><p>Only parser-generated verdicts can bypass credential mediation.</p><p>Validator-generated verdicts are no longer trusted to fail open.</p><hr><h2>Correct Non-API Enforcement Paths</h2><h3>Updated Logic</h3><pre><code class="language-go">if !v.IsAPICall {
    if v.Ambiguous {
        audit("block", "ambiguous", v.Reason)

        reason :=
            "Clawvisor: ambiguous credentialed call refused — " +
            v.Reason

        return ...
    }

    audit("block", "non_api_credentialed", v.Reason)

    reason :=
        "Clawvisor: non-API tool calls carrying credentials " +
        "are not permitted — " + v.Reason

    return ...
}
</code></pre><h3>Benefits</h3><ul><li><p>Accurate audit logging.</p></li><li><p>Correct refusal messages.</p></li><li><p>Distinguishes ambiguity from policy violations.</p></li></ul><hr><h1>Tests Added and Updated</h1>
Test | File | Purpose
-- | -- | --
TestDefaultParser_FileManipulationToolsAllowed | inspector_test.go | Verifies file tools return IsAPICall:false and Ambiguous:false even with long mock placeholders
TestDefaultParser_FileManipulationWithURLAllowed | inspector_test.go | Verifies URL-bearing file writes are not claimed by parseStructuredFetch()
TestPostprocess_AllowsConfidentNonAPICalls | postprocess_test.go | Verifies parser-classified file tools pass without rewriting
TestPostprocess_EnforcesRulesOnConfidentNonAPICalls | postprocess_test.go | Verifies deny rules still block file-manipulation tools
TestPostprocess_BlocksValidatorOriginNonAPICalls | postprocess_test.go | Verifies validator-origin non-API verdicts are blocked

<hr><h1>Summary</h1><p>This PR fixes false-positive credential mediation for local file-manipulation tools while closing multiple security and correctness issues in the credential inspection pipeline.</p><p>Key improvements include:</p><ul><li><p>Deterministic file-manipulation classification</p></li><li><p>Correct parser priority ordering</p></li><li><p>MCP namespace spoofing protection</p></li><li><p>Deterministic-only mediation bypasses</p></li><li><p>Accurate audit and enforcement paths</p></li><li><p>Improved placeholder handling</p></li><li><p>Expanded unit and integration test coverage</p></li></ul><p>The result is that agents can safely edit local files containing placeholder credentials while maintaining strict enforcement for actual outbound credential-bearing operations.</p></body></html><!--EndFragment-->
</body>
</html>