### PR TITLE
fix(llmproxy): persist script sessions and log resolver IO

### DIFF
--- a/internal/api/handlers/llm_endpoint.go
+++ b/internal/api/handlers/llm_endpoint.go
@@ -153,7 +153,8 @@ type LLMEndpointHandler struct {
 	// RawIOLogger, when non-nil, captures full raw HTTP bodies for
 	// inbound requests, upstream responses, and the bodies returned
 	// to the harness. Off by default; opted in via
-	// CLAWVISOR_PROXY_LITE_RAW_LOG or cfg.ProxyLite.RawLogPath.
+	// CLAWVISOR_PROXY_LITE_RAW_LOG_PATH or cfg.ProxyLite.RawLogPath
+	// (legacy CLAWVISOR_PROXY_LITE_RAW_LOG is still accepted).
 	// Bodies contain conversation content; the file is mode 0600 so
 	// only the daemon's user can read it, but operators should still
 	// avoid leaving this on outside of diagnostic sessions.

--- a/internal/api/handlers/proxy_resolver.go
+++ b/internal/api/handlers/proxy_resolver.go
@@ -44,6 +44,12 @@ type ProxyResolverHandler struct {
 	// per placeholder swapped. nil disables audit logging.
 	AuditEmitter *llmproxy.AuditEmitter
 
+	// RawIOLogger, when non-nil, captures resolver request bodies and
+	// response bodies for diagnostic JSONL logs. It must never be used
+	// to log post-swap upstream request headers because those carry real
+	// credentials.
+	RawIOLogger *llmproxy.RawIOLogger
+
 	// MaxRequestBytes caps the inbound body. Defaults to 34 MiB to mirror
 	// the LLM proxy endpoint (2 MiB above Anthropic's 32 MB Messages cap).
 	MaxRequestBytes int64
@@ -59,7 +65,6 @@ type ProxyResolverHandler struct {
 	// targets are reachable. Defaults to false; flip in self-host
 	// development environments.
 	AllowPrivateNetworks bool
-
 }
 
 // NewProxyResolverHandler builds the handler with sensible defaults. The
@@ -342,6 +347,21 @@ func (h *ProxyResolverHandler) Forward(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusRequestEntityTooLarge, "REQUEST_TOO_LARGE", err.Error())
 		return
 	}
+	if h.RawIOLogger != nil {
+		h.RawIOLogger.Emit(llmproxy.RawIOEvent{
+			Phase:       "resolver_received_request",
+			RequestID:   requestID,
+			UserID:      agent.UserID,
+			AgentID:     agent.ID,
+			Provider:    "resolver",
+			Method:      r.Method,
+			Path:        r.URL.RequestURI(),
+			ContentType: r.Header.Get("Content-Type"),
+			Headers:     llmproxy.SafeHeaderSnapshot(r.Header),
+			Body:        string(body),
+			BodyBytes:   len(body),
+		})
+	}
 
 	// Build outbound headers, swapping any header values that contain a
 	// shadow placeholder. The target host is the authoritative input to
@@ -532,6 +552,7 @@ func (h *ProxyResolverHandler) Forward(w http.ResponseWriter, r *http.Request) {
 
 	flusher, _ := w.(http.Flusher)
 	buf := make([]byte, 4096)
+	var rawHarnessBody bytes.Buffer
 	// respBytes is declared at the top of Forward so the deferred
 	// script-session post-processor can read its final value on
 	// every exit path (including early errors that never reach this
@@ -551,6 +572,9 @@ func (h *ProxyResolverHandler) Forward(w http.ResponseWriter, r *http.Request) {
 				if allowed > 0 {
 					if _, writeErr := w.Write(buf[:allowed]); writeErr != nil {
 						break
+					}
+					if h.RawIOLogger != nil {
+						rawHarnessBody.Write(buf[:allowed])
 					}
 					respBytes += allowed
 					if flusher != nil {
@@ -576,6 +600,9 @@ func (h *ProxyResolverHandler) Forward(w http.ResponseWriter, r *http.Request) {
 			if _, writeErr := w.Write(buf[:n]); writeErr != nil {
 				break
 			}
+			if h.RawIOLogger != nil {
+				rawHarnessBody.Write(buf[:n])
+			}
 			respBytes += int64(n)
 			if flusher != nil {
 				flusher.Flush()
@@ -587,6 +614,20 @@ func (h *ProxyResolverHandler) Forward(w http.ResponseWriter, r *http.Request) {
 		if readErr != nil {
 			break
 		}
+	}
+	if h.RawIOLogger != nil {
+		h.RawIOLogger.Emit(llmproxy.RawIOEvent{
+			Phase:       "resolver_harness_response",
+			RequestID:   requestID,
+			UserID:      agent.UserID,
+			AgentID:     agent.ID,
+			Provider:    "resolver",
+			Status:      resp.StatusCode,
+			ContentType: resp.Header.Get("Content-Type"),
+			Headers:     llmproxy.SafeHeaderSnapshot(w.Header()),
+			Body:        rawHarnessBody.String(),
+			BodyBytes:   int(respBytes),
+		})
 	}
 
 	// Script-session post-stream RecordBytes + use-row audit emission

--- a/internal/api/handlers/proxy_resolver_test.go
+++ b/internal/api/handlers/proxy_resolver_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
@@ -137,6 +138,8 @@ func TestResolver_HappyPath(t *testing.T) {
 	defer upstream.Close()
 
 	h, st, _, agent, nonces, placeholder := newSeededResolver(t)
+	var rawLog bytes.Buffer
+	h.RawIOLogger = llmproxy.NewRawIOLogger(&rawLog)
 
 	h.Client = upstream.Client()
 	h.Client.Transport = &redirectTargetTransport{base: upstream.URL}
@@ -149,7 +152,9 @@ func TestResolver_HappyPath(t *testing.T) {
 	// The redirectTargetTransport sends the actual dial to httptest's
 	// loopback URL, but the resolver believes (and validates against)
 	// api.github.com.
-	req := httptest.NewRequest(http.MethodGet, "/api/proxy/repos/x/y/issues", strings.NewReader(""))
+	req := httptest.NewRequest(http.MethodGet, "/api/proxy/repos/x/y/issues", strings.NewReader(`{"filter":"open"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Request-Id", "req-raw-resolver")
 	req.Header.Set("X-Clawvisor-Target-Host", "api.github.com")
 	req.Header.Set("X-Clawvisor-Caller", nonceForRequest(t, nonces, agent.ID, req))
 	// Harness sends the placeholder in the natural Authorization header.
@@ -169,7 +174,42 @@ func TestResolver_HappyPath(t *testing.T) {
 	if seenAuth != "Bearer real-gh-token" {
 		t.Fatalf("expected upstream Authorization=Bearer real-gh-token, got %q", seenAuth)
 	}
-	_ = seenBody
+	if string(seenBody) != `{"filter":"open"}` {
+		t.Fatalf("expected upstream body forwarded, got %q", string(seenBody))
+	}
+	rawLines := strings.Split(strings.TrimSpace(rawLog.String()), "\n")
+	if len(rawLines) != 2 {
+		t.Fatalf("expected 2 raw resolver log lines, got %d: %s", len(rawLines), rawLog.String())
+	}
+	var sawRequest, sawResponse bool
+	for _, line := range rawLines {
+		var ev map[string]any
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			t.Fatalf("raw log line is not JSON: %v\n%s", err, line)
+		}
+		switch ev["phase"] {
+		case "resolver_received_request":
+			sawRequest = true
+			if ev["body"] != `{"filter":"open"}` {
+				t.Fatalf("resolver request raw body = %v", ev["body"])
+			}
+			headers, _ := ev["headers"].(map[string]any)
+			if _, ok := headers["Authorization"]; ok {
+				t.Fatalf("resolver raw request logged Authorization header: %#v", headers)
+			}
+		case "resolver_harness_response":
+			sawResponse = true
+			if ev["body"] != `{"ok":true}` {
+				t.Fatalf("resolver response raw body = %v", ev["body"])
+			}
+		}
+	}
+	if !sawRequest || !sawResponse {
+		t.Fatalf("missing resolver raw phases: request=%v response=%v log=%s", sawRequest, sawResponse, rawLog.String())
+	}
+	if strings.Contains(rawLog.String(), "real-gh-token") {
+		t.Fatalf("raw resolver log should not contain swapped credential: %s", rawLog.String())
+	}
 }
 
 func TestResolver_RefreshesExpiredOAuthCredentialBeforeForwarding(t *testing.T) {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1252,6 +1252,9 @@ func (s *Server) registerLiteProxyRoutes(
 		llmHandler.Inspector = inspector.NewInspector(inspector.DefaultParser{}, validator)
 
 		tracePath := s.cfg.ProxyLite.TraceLogPath
+		if env := strings.TrimSpace(os.Getenv("CLAWVISOR_PROXY_LITE_TRACE_LOG_PATH")); env != "" {
+			tracePath = env
+		}
 		if env := strings.TrimSpace(os.Getenv("CLAWVISOR_PROXY_LITE_TRACE")); env != "" {
 			tracePath = env
 		}
@@ -1263,6 +1266,9 @@ func (s *Server) registerLiteProxyRoutes(
 		}
 
 		rawLogPath := s.cfg.ProxyLite.RawLogPath
+		if env := strings.TrimSpace(os.Getenv("CLAWVISOR_PROXY_LITE_RAW_LOG_PATH")); env != "" {
+			rawLogPath = env
+		}
 		if env := strings.TrimSpace(os.Getenv("CLAWVISOR_PROXY_LITE_RAW_LOG")); env != "" {
 			rawLogPath = env
 		}
@@ -1304,6 +1310,7 @@ func (s *Server) registerLiteProxyRoutes(
 		resolverHandler.SelfHostnames = s.cfg.ProxyLite.SelfHostnames
 		resolverHandler.AllowPrivateNetworks = s.cfg.ProxyLite.AllowPrivateNetworks
 		resolverHandler.AuditEmitter = auditEmitter
+		resolverHandler.RawIOLogger = llmHandler.RawIOLogger
 
 		callerNonces = s.callerNonces
 		if callerNonces == nil {

--- a/internal/runtime/llmproxy/rawlog.go
+++ b/internal/runtime/llmproxy/rawlog.go
@@ -31,14 +31,20 @@ import (
 //     (post-decompression, since we force `Accept-Encoding: identity`).
 //   - "harness_response"  — the body we send back to the harness after
 //     postprocess (tool_use rewrites, substitutions, intercepts).
+//   - "resolver_received_request" — the /api/proxy request body before
+//     credential placeholder swap. Headers are allowlisted so swapped
+//     upstream credentials are not recorded.
+//   - "resolver_harness_response" — the /api/proxy response body actually
+//     returned to the harness, after script-session byte caps/truncation.
 //
 // Together these cover everything that enters or leaves the LLM, plus
-// what the harness sees. Diagnosing model loops requires knowing both
-// what the proxy received and what the model actually receives —
+// what the harness sees on resolver calls. Diagnosing model loops requires
+// knowing both what the proxy received and what the model actually receives —
 // guessing at conversation state from summaries has limits.
 //
 // Disabled by default. Operators enable by setting
-// CLAWVISOR_PROXY_LITE_RAW_LOG to a file path. Production should keep
+// CLAWVISOR_PROXY_LITE_RAW_LOG_PATH (or legacy
+// CLAWVISOR_PROXY_LITE_RAW_LOG) to a file path. Production should keep
 // this off — bodies contain prompts, tool outputs, and credentials in
 // the model's conversation history. (Autovault placeholders are in
 // there. Live autovault placeholders are redacted before writing; real

--- a/internal/runtime/llmproxy/redis_stores_test.go
+++ b/internal/runtime/llmproxy/redis_stores_test.go
@@ -2,6 +2,7 @@ package llmproxy
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -20,6 +21,113 @@ func testRedisClient(t *testing.T) *redis.Client {
 	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
 	t.Cleanup(func() { _ = rdb.Close() })
 	return rdb
+}
+
+func TestRedisScriptSessionCacheCrossInstanceAuthorizeAndAccount(t *testing.T) {
+	rdb := testRedisClient(t)
+	minting := NewRedisScriptSessionCache(rdb)
+	resolver := NewRedisScriptSessionCache(rdb)
+	ctx := context.Background()
+
+	tok := mustMintSession(t, minting, sampleSession())
+	got, err := resolver.Authorize(ctx, tok, ScriptSessionRequest{
+		Host:        "gmail.googleapis.com:443",
+		Method:      "get",
+		Path:        "/gmail/v1/users/me/messages/abc?format=metadata",
+		Placeholder: "autovault_x",
+	})
+	if err != nil {
+		t.Fatalf("authorize: %v", err)
+	}
+	if got.UsedCount != 1 {
+		t.Fatalf("UsedCount after authorize = %d, want 1", got.UsedCount)
+	}
+	if got.TotalBytesUsed != got.MaxRequestBytes {
+		t.Fatalf("TotalBytesUsed after reservation = %d, want %d", got.TotalBytesUsed, got.MaxRequestBytes)
+	}
+
+	got, err = minting.RecordBytes(ctx, tok, 12)
+	if err != nil {
+		t.Fatalf("record bytes: %v", err)
+	}
+	if got.TotalBytesUsed != 12 {
+		t.Fatalf("TotalBytesUsed after true-up = %d, want 12", got.TotalBytesUsed)
+	}
+}
+
+func TestRedisScriptSessionCacheRecordBytesClearsStaleSnapshotAfterRetryMiss(t *testing.T) {
+	rdb := testRedisClient(t)
+	cache := NewRedisScriptSessionCache(rdb)
+	ctx := context.Background()
+
+	tok := mustMintSession(t, cache, sampleSession())
+	if _, err := cache.Authorize(ctx, tok, validRequest()); err != nil {
+		t.Fatalf("authorize: %v", err)
+	}
+	var raced bool
+	cache.beforeRecordBytesCommit = func(token string) {
+		if raced {
+			return
+		}
+		raced = true
+		if err := rdb.Del(ctx, redisScriptSessionKey(token)).Err(); err != nil {
+			t.Fatalf("delete during record race: %v", err)
+		}
+	}
+
+	got, err := cache.RecordBytes(ctx, tok, 12)
+	if err != nil {
+		t.Fatalf("record bytes: %v", err)
+	}
+	if !raced {
+		t.Fatal("test hook did not exercise retry path")
+	}
+	if got.ID != "" {
+		t.Fatalf("RecordBytes returned stale session after retry miss: %+v", got)
+	}
+}
+
+func TestRedisScriptSessionCacheReleaseAuthorizeUndoesUseAndReservation(t *testing.T) {
+	cache := NewRedisScriptSessionCache(testRedisClient(t))
+	ctx := context.Background()
+
+	tok := mustMintSession(t, cache, sampleSession())
+	if _, err := cache.Authorize(ctx, tok, validRequest()); err != nil {
+		t.Fatalf("authorize: %v", err)
+	}
+	if err := cache.ReleaseAuthorize(ctx, tok); err != nil {
+		t.Fatalf("release authorize: %v", err)
+	}
+	got, err := cache.Authorize(ctx, tok, validRequest())
+	if err != nil {
+		t.Fatalf("authorize after release: %v", err)
+	}
+	if got.UsedCount != 1 {
+		t.Fatalf("UsedCount after release+authorize = %d, want 1", got.UsedCount)
+	}
+	if got.TotalBytesUsed != got.MaxRequestBytes {
+		t.Fatalf("TotalBytesUsed after release+authorize = %d, want %d", got.TotalBytesUsed, got.MaxRequestBytes)
+	}
+}
+
+func TestRedisScriptSessionCacheScopeMismatchDoesNotConsumeUse(t *testing.T) {
+	cache := NewRedisScriptSessionCache(testRedisClient(t))
+	ctx := context.Background()
+
+	tok := mustMintSession(t, cache, sampleSession())
+	_, err := cache.Authorize(ctx, tok, ScriptSessionRequest{
+		Host: "evil.example", Method: "GET", Path: "/gmail/v1/users/me/messages", Placeholder: "autovault_x",
+	})
+	if !errors.Is(err, ErrScriptSessionScopeMismatch) {
+		t.Fatalf("authorize mismatch err = %v, want scope mismatch", err)
+	}
+	got, err := cache.Authorize(ctx, tok, validRequest())
+	if err != nil {
+		t.Fatalf("authorize after mismatch: %v", err)
+	}
+	if got.UsedCount != 1 {
+		t.Fatalf("UsedCount after mismatch+authorize = %d, want 1", got.UsedCount)
+	}
 }
 
 func TestRedisPendingApprovalCacheResolvesBareApprovalLIFO(t *testing.T) {

--- a/internal/runtime/llmproxy/script_session_redis.go
+++ b/internal/runtime/llmproxy/script_session_redis.go
@@ -1,0 +1,240 @@
+package llmproxy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const redisScriptSessionPrefix = "clawvisor:script_session:"
+
+// RedisScriptSessionCache stores script sessions in Redis so a session minted
+// by one proxy instance can be authorized and accounted by another. Mutating
+// operations use WATCH transactions so validation and counter updates remain
+// atomic under concurrent resolver requests.
+type RedisScriptSessionCache struct {
+	rdb                     *redis.Client
+	now                     func() time.Time
+	beforeRecordBytesCommit func(token string)
+}
+
+// NewRedisScriptSessionCache returns a Redis-backed script-session cache.
+func NewRedisScriptSessionCache(rdb *redis.Client) *RedisScriptSessionCache {
+	return &RedisScriptSessionCache{rdb: rdb, now: time.Now}
+}
+
+type redisScriptSessionPayload struct {
+	Session ScriptSession `json:"session"`
+}
+
+func redisScriptSessionKey(token string) string {
+	return redisScriptSessionPrefix + token
+}
+
+func (c *RedisScriptSessionCache) ttl(sess ScriptSession) time.Duration {
+	if sess.ExpiresAt.IsZero() {
+		return 0
+	}
+	return sess.ExpiresAt.Sub(c.now())
+}
+
+// Mint implements ScriptSessionCache.
+func (c *RedisScriptSessionCache) Mint(ctx context.Context, sess ScriptSession) (string, error) {
+	token, err := generateScriptSessionToken()
+	if err != nil {
+		return "", err
+	}
+	sess = normalizeScriptSession(sess)
+	raw, err := json.Marshal(redisScriptSessionPayload{Session: sess})
+	if err != nil {
+		return "", err
+	}
+	ttl := c.ttl(sess)
+	if !sess.ExpiresAt.IsZero() && ttl <= 0 {
+		ttl = time.Nanosecond
+	}
+	if err := c.rdb.Set(ctx, redisScriptSessionKey(token), raw, ttl).Err(); err != nil {
+		return "", err
+	}
+	return token, nil
+}
+
+// Authorize implements ScriptSessionCache.
+func (c *RedisScriptSessionCache) Authorize(ctx context.Context, token string, req ScriptSessionRequest) (ScriptSession, error) {
+	req = normalizeScriptSessionRequest(req)
+	key := redisScriptSessionKey(token)
+	var out ScriptSession
+	for {
+		err := c.rdb.Watch(ctx, func(tx *redis.Tx) error {
+			sess, err := c.getSessionForUpdate(ctx, tx, key)
+			if err != nil {
+				return err
+			}
+			if sess.TargetHost != req.Host {
+				return ErrScriptSessionScopeMismatch
+			}
+			if !sess.methodAllowed(req.Method) {
+				return ErrScriptSessionScopeMismatch
+			}
+			if !sess.pathAllowed(req.Path) {
+				return ErrScriptSessionScopeMismatch
+			}
+			if req.Placeholder == "" || req.Placeholder != sess.Placeholder {
+				return ErrScriptSessionScopeMismatch
+			}
+			if sess.MaxUses > 0 && sess.UsedCount >= sess.MaxUses {
+				return ErrScriptSessionExhausted
+			}
+			if sess.MaxTotalBytes > 0 && sess.TotalBytesUsed >= sess.MaxTotalBytes {
+				return ErrScriptSessionBytesExceeded
+			}
+			if sess.MaxRequestBytes > 0 && sess.MaxTotalBytes > 0 {
+				if sess.TotalBytesUsed+sess.MaxRequestBytes > sess.MaxTotalBytes {
+					return ErrScriptSessionBytesExceeded
+				}
+				sess.TotalBytesUsed += sess.MaxRequestBytes
+			}
+			sess.UsedCount++
+			out = sess
+			return c.setSessionTx(ctx, tx, key, sess)
+		}, key)
+		if errors.Is(err, redis.TxFailedErr) {
+			continue
+		}
+		return out, err
+	}
+}
+
+// RecordBytes implements ScriptSessionCache.
+func (c *RedisScriptSessionCache) RecordBytes(ctx context.Context, token string, bytes int64) (ScriptSession, error) {
+	key := redisScriptSessionKey(token)
+	var out ScriptSession
+	for {
+		var exceeded bool
+		err := c.rdb.Watch(ctx, func(tx *redis.Tx) error {
+			sess, err := c.getSessionForUpdate(ctx, tx, key)
+			if err != nil {
+				if errors.Is(err, ErrScriptSessionNotFound) || errors.Is(err, ErrScriptSessionExpired) {
+					out = ScriptSession{}
+					return nil
+				}
+				return err
+			}
+			switch {
+			case sess.MaxRequestBytes > 0 && sess.MaxTotalBytes > 0:
+				overReservation := sess.MaxRequestBytes - bytes
+				sess.TotalBytesUsed -= overReservation
+				if sess.TotalBytesUsed < 0 {
+					sess.TotalBytesUsed = 0
+				}
+			case bytes > 0:
+				sess.TotalBytesUsed += bytes
+			}
+			if sess.MaxTotalBytes > 0 && sess.TotalBytesUsed > sess.MaxTotalBytes {
+				exceeded = true
+			}
+			out = sess
+			if c.beforeRecordBytesCommit != nil {
+				c.beforeRecordBytesCommit(token)
+			}
+			if err := c.setSessionTx(ctx, tx, key, sess); err != nil {
+				return err
+			}
+			if exceeded {
+				return ErrScriptSessionBytesExceeded
+			}
+			return nil
+		}, key)
+		if errors.Is(err, redis.TxFailedErr) {
+			continue
+		}
+		return out, err
+	}
+}
+
+// ReleaseAuthorize implements ScriptSessionCache.
+func (c *RedisScriptSessionCache) ReleaseAuthorize(ctx context.Context, token string) error {
+	key := redisScriptSessionKey(token)
+	for {
+		err := c.rdb.Watch(ctx, func(tx *redis.Tx) error {
+			sess, err := c.getSessionForUpdate(ctx, tx, key)
+			if err != nil {
+				if errors.Is(err, ErrScriptSessionNotFound) || errors.Is(err, ErrScriptSessionExpired) {
+					return nil
+				}
+				return err
+			}
+			if sess.MaxRequestBytes > 0 && sess.MaxTotalBytes > 0 {
+				sess.TotalBytesUsed -= sess.MaxRequestBytes
+				if sess.TotalBytesUsed < 0 {
+					sess.TotalBytesUsed = 0
+				}
+			}
+			if sess.UsedCount > 0 {
+				sess.UsedCount--
+			}
+			return c.setSessionTx(ctx, tx, key, sess)
+		}, key)
+		if errors.Is(err, redis.TxFailedErr) {
+			continue
+		}
+		return err
+	}
+}
+
+// Revoke implements ScriptSessionCache.
+func (c *RedisScriptSessionCache) Revoke(ctx context.Context, token string) error {
+	return c.rdb.Del(ctx, redisScriptSessionKey(token)).Err()
+}
+
+func (c *RedisScriptSessionCache) getSessionForUpdate(ctx context.Context, tx *redis.Tx, key string) (ScriptSession, error) {
+	raw, err := tx.Get(ctx, key).Bytes()
+	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			return ScriptSession{}, ErrScriptSessionNotFound
+		}
+		return ScriptSession{}, err
+	}
+	var payload redisScriptSessionPayload
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		_, _ = tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+			pipe.Del(ctx, key)
+			return nil
+		})
+		return ScriptSession{}, ErrScriptSessionNotFound
+	}
+	sess := normalizeScriptSession(payload.Session)
+	if !sess.ExpiresAt.IsZero() && c.now().After(sess.ExpiresAt) {
+		_, _ = tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+			pipe.Del(ctx, key)
+			return nil
+		})
+		return ScriptSession{}, ErrScriptSessionExpired
+	}
+	return sess, nil
+}
+
+func (c *RedisScriptSessionCache) setSessionTx(ctx context.Context, tx *redis.Tx, key string, sess ScriptSession) error {
+	raw, err := json.Marshal(redisScriptSessionPayload{Session: sess})
+	if err != nil {
+		return err
+	}
+	ttl := c.ttl(sess)
+	if !sess.ExpiresAt.IsZero() && ttl <= 0 {
+		_, _ = tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+			pipe.Del(ctx, key)
+			return nil
+		})
+		return ErrScriptSessionExpired
+	}
+	_, err = tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+		pipe.Set(ctx, key, raw, ttl)
+		return nil
+	})
+	return err
+}
+
+var _ ScriptSessionCache = (*RedisScriptSessionCache)(nil)

--- a/pkg/clawvisor/defaults.go
+++ b/pkg/clawvisor/defaults.go
@@ -456,6 +456,7 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 	var dedupCache handlers.DedupCache
 	var verdictCache intent.VerdictCacher
 	var callerNonceCache llmproxy.CallerNonceCache
+	var scriptSessionCache llmproxy.ScriptSessionCache
 	var pendingSecretCache llmproxy.PendingSecretDecisionCache
 	var liteApprovalCache llmproxy.PendingApprovalCache
 	var liteOutcomeStore llmproxy.InlineApprovalOutcomeStore
@@ -498,6 +499,7 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 		// (well under a minute in practice) plus held-tool-use release
 		// windows that re-mint a fresh nonce.
 		callerNonceCache = llmproxy.NewRedisCallerNonceCache(client, 5*time.Minute)
+		scriptSessionCache = llmproxy.NewRedisScriptSessionCache(client)
 		pendingSecretCache = llmproxy.NewRedisPendingSecretDecisionCache(client, 10*time.Minute)
 		liteApprovalCache = llmproxy.NewRedisPendingApprovalCache(client, 10*time.Minute)
 		liteOutcomeStore = llmproxy.NewRedisInlineApprovalOutcomeStore(client, 24*time.Hour)
@@ -550,6 +552,7 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 		VerdictCache:       verdictCache,
 		ExtractionTracker:  extractionTracker,
 		CallerNonceCache:   callerNonceCache,
+		ScriptSessionCache: scriptSessionCache,
 		PendingSecretCache: pendingSecretCache,
 		LiteApprovalCache:  liteApprovalCache,
 		LiteOutcomeStore:   liteOutcomeStore,

--- a/pkg/clawvisor/options.go
+++ b/pkg/clawvisor/options.go
@@ -148,6 +148,7 @@ type ServerOptions struct {
 	VerdictCache       intent.VerdictCacher
 	ExtractionTracker  handlers.ExtractionTracker
 	CallerNonceCache   llmproxy.CallerNonceCache
+	ScriptSessionCache llmproxy.ScriptSessionCache
 	PendingSecretCache llmproxy.PendingSecretDecisionCache
 	LiteApprovalCache  llmproxy.PendingApprovalCache
 	LiteOutcomeStore   llmproxy.InlineApprovalOutcomeStore

--- a/pkg/clawvisor/run.go
+++ b/pkg/clawvisor/run.go
@@ -341,6 +341,9 @@ func RunWithContext(ctx context.Context, opts *ServerOptions) error {
 	if opts.CallerNonceCache != nil {
 		apiOpts = append(apiOpts, api.WithCallerNonceCache(opts.CallerNonceCache))
 	}
+	if opts.ScriptSessionCache != nil {
+		apiOpts = append(apiOpts, api.WithScriptSessionCache(opts.ScriptSessionCache))
+	}
 	if opts.PendingSecretCache != nil {
 		apiOpts = append(apiOpts, api.WithPendingSecretDecisionCache(opts.PendingSecretCache))
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -319,7 +319,8 @@ type ProxyLiteConfig struct {
 	// contain conversation content; the file is written with mode
 	// 0600 but operators should still keep this off outside of
 	// diagnostic sessions. The env var
-	// CLAWVISOR_PROXY_LITE_RAW_LOG overrides this when set.
+	// CLAWVISOR_PROXY_LITE_RAW_LOG_PATH overrides this when set.
+	// CLAWVISOR_PROXY_LITE_RAW_LOG remains accepted as a legacy alias.
 	RawLogPath string `yaml:"raw_log_path"`
 }
 


### PR DESCRIPTION
## Summary
- add raw JSON logging for /api/proxy resolver request/response bodies without logging post-swap upstream credential headers
- add Redis-backed ScriptSessionCache and wire it into Redis/default server setup so script sessions survive multi-instance routing
- align raw-log env override handling with CLAWVISOR_PROXY_LITE_RAW_LOG_PATH while retaining the legacy alias

## Verification
- go test ./internal/runtime/llmproxy/... ./internal/api/handlers ./internal/api ./pkg/clawvisor ./pkg/config
- git diff --check origin/main...HEAD

## Notes
- Local logs showed successful script-session resolver calls were already getting back to the agent; this follow-up addresses the logging observability gap and the process-local script-session cache footgun.