### PR TITLE
test(llmproxy): adversarial cross-conversation approval spoofing coverage

### DIFF
--- a/internal/runtime/llmproxy/cross_conversation_test.go
+++ b/internal/runtime/llmproxy/cross_conversation_test.go
@@ -1,0 +1,197 @@
+package llmproxy
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+)
+
+// Holds for distinct conversation IDs must land in separate cache buckets.
+// A Peek scoped to conv-b must not see conv-a's hold, and vice versa.
+// Explicit-ID resolution from the wrong conversation must return nil even
+// when the caller supplies the exact approval ID.
+func TestPendingApprovalCache_ConversationIDIsolatesHolds(t *testing.T) {
+	ctx := context.Background()
+	cache := NewMemoryPendingApprovalCache(time.Minute)
+	const (
+		userID  = "u-isolation"
+		agentID = "a-isolation"
+	)
+
+	resA, err := cache.Hold(ctx, PendingLiteApproval{
+		UserID:         userID,
+		AgentID:        agentID,
+		Provider:       conversation.ProviderAnthropic,
+		ConversationID: "conv-a",
+		ToolUse:        conversation.ToolUse{ID: "toolu_a", Name: "Bash"},
+	})
+	if err != nil {
+		t.Fatalf("Hold conv-a: %v", err)
+	}
+
+	resB, err := cache.Hold(ctx, PendingLiteApproval{
+		UserID:         userID,
+		AgentID:        agentID,
+		Provider:       conversation.ProviderAnthropic,
+		ConversationID: "conv-b",
+		ToolUse:        conversation.ToolUse{ID: "toolu_b", Name: "WebFetch"},
+	})
+	if err != nil {
+		t.Fatalf("Hold conv-b: %v", err)
+	}
+
+	peekA, err := cache.Peek(ctx, ResolveRequest{
+		UserID:         userID,
+		AgentID:        agentID,
+		Provider:       conversation.ProviderAnthropic,
+		ConversationID: "conv-a",
+	})
+	if err != nil {
+		t.Fatalf("Peek conv-a: %v", err)
+	}
+	if peekA == nil || peekA.ToolUse.ID != "toolu_a" {
+		t.Fatalf("Peek conv-a: got %v, want toolu_a", peekA)
+	}
+
+	peekB, err := cache.Peek(ctx, ResolveRequest{
+		UserID:         userID,
+		AgentID:        agentID,
+		Provider:       conversation.ProviderAnthropic,
+		ConversationID: "conv-b",
+	})
+	if err != nil {
+		t.Fatalf("Peek conv-b: %v", err)
+	}
+	if peekB == nil || peekB.ToolUse.ID != "toolu_b" {
+		t.Fatalf("Peek conv-b: got %v, want toolu_b", peekB)
+	}
+
+	// Explicit-ID resolve from conv-b targeting conv-a's approval must return nil.
+	crossAB, err := cache.Resolve(ctx, ResolveRequest{
+		UserID:         userID,
+		AgentID:        agentID,
+		Provider:       conversation.ProviderAnthropic,
+		ConversationID: "conv-b",
+		ApprovalID:     resA.Pending.ID,
+	})
+	if err != nil {
+		t.Fatalf("cross-resolve b→a: %v", err)
+	}
+	if crossAB != nil {
+		t.Fatalf("cross-resolve b→a: expected nil, got hold for tool %s", crossAB.ToolUse.ID)
+	}
+
+	// Explicit-ID resolve from conv-a targeting conv-b's approval must return nil.
+	crossBA, err := cache.Resolve(ctx, ResolveRequest{
+		UserID:         userID,
+		AgentID:        agentID,
+		Provider:       conversation.ProviderAnthropic,
+		ConversationID: "conv-a",
+		ApprovalID:     resB.Pending.ID,
+	})
+	if err != nil {
+		t.Fatalf("cross-resolve a→b: %v", err)
+	}
+	if crossBA != nil {
+		t.Fatalf("cross-resolve a→b: expected nil, got hold for tool %s", crossBA.ToolUse.ID)
+	}
+
+	// Both holds must still be intact after the failed cross-resolves.
+	stillA, _ := cache.Peek(ctx, ResolveRequest{UserID: userID, AgentID: agentID, Provider: conversation.ProviderAnthropic, ConversationID: "conv-a"})
+	stillB, _ := cache.Peek(ctx, ResolveRequest{UserID: userID, AgentID: agentID, Provider: conversation.ProviderAnthropic, ConversationID: "conv-b"})
+	if stillA == nil {
+		t.Fatal("conv-a hold was consumed by a cross-resolve from conv-b")
+	}
+	if stillB == nil {
+		t.Fatal("conv-b hold was consumed by a cross-resolve from conv-a")
+	}
+}
+
+// A bare reply (no ApprovalID) from conv-b must not release a hold that
+// belongs to conv-a. The user typing "y" always responds to the most-recent
+// hold in their own conversation bucket; conv-b has no holds here, so the
+// bare resolve must return nil and leave conv-a's hold untouched.
+func TestPendingApprovalCache_BareReplyCannotCrossConversations(t *testing.T) {
+	ctx := context.Background()
+	cache := NewMemoryPendingApprovalCache(time.Minute)
+	const (
+		userID  = "u-barereply"
+		agentID = "a-barereply"
+	)
+
+	if _, err := cache.Hold(ctx, PendingLiteApproval{
+		UserID:         userID,
+		AgentID:        agentID,
+		Provider:       conversation.ProviderAnthropic,
+		ConversationID: "conv-a",
+		ToolUse:        conversation.ToolUse{ID: "toolu_victim", Name: "Bash"},
+	}); err != nil {
+		t.Fatalf("Hold conv-a: %v", err)
+	}
+
+	// Bare "y" from conv-b — no ApprovalID, wrong ConversationID.
+	resolved, err := cache.Resolve(ctx, ResolveRequest{
+		UserID:         userID,
+		AgentID:        agentID,
+		Provider:       conversation.ProviderAnthropic,
+		ConversationID: "conv-b",
+		// ApprovalID intentionally empty (simulates a bare chat reply)
+	})
+	if err != nil {
+		t.Fatalf("bare Resolve from conv-b: %v", err)
+	}
+	if resolved != nil {
+		t.Fatalf("bare reply from conv-b resolved conv-a's hold (tool=%s); must not cross conversation boundaries",
+			resolved.ToolUse.ID)
+	}
+
+	// Conv-a's hold must still be intact.
+	still, err := cache.Peek(ctx, ResolveRequest{
+		UserID:         userID,
+		AgentID:        agentID,
+		Provider:       conversation.ProviderAnthropic,
+		ConversationID: "conv-a",
+	})
+	if err != nil {
+		t.Fatalf("Peek conv-a after failed cross-resolve: %v", err)
+	}
+	if still == nil || still.ToolUse.ID != "toolu_victim" {
+		t.Fatalf("conv-a hold was incorrectly consumed by bare reply from conv-b (got %v)", still)
+	}
+}
+
+// Empty ConversationID falls back to the pre-scoping shared bucket so older
+// clients that don't surface a conversation identifier on the wire keep working.
+func TestPendingApprovalCache_EmptyConversationIDIsSharedBucket(t *testing.T) {
+	ctx := context.Background()
+	cache := NewMemoryPendingApprovalCache(time.Minute)
+	const (
+		userID  = "u-legacy"
+		agentID = "a-legacy"
+	)
+
+	if _, err := cache.Hold(ctx, PendingLiteApproval{
+		UserID:   userID,
+		AgentID:  agentID,
+		Provider: conversation.ProviderAnthropic,
+		// ConversationID intentionally empty (legacy client)
+		ToolUse: conversation.ToolUse{ID: "toolu_legacy", Name: "Bash"},
+	}); err != nil {
+		t.Fatalf("Hold (legacy): %v", err)
+	}
+
+	resolved, err := cache.Resolve(ctx, ResolveRequest{
+		UserID:   userID,
+		AgentID:  agentID,
+		Provider: conversation.ProviderAnthropic,
+		// ConversationID intentionally empty (bare reply from legacy client)
+	})
+	if err != nil {
+		t.Fatalf("Resolve (legacy): %v", err)
+	}
+	if resolved == nil || resolved.ToolUse.ID != "toolu_legacy" {
+		t.Fatalf("legacy bare reply must resolve the shared-bucket hold, got %v", resolved)
+	}
+}

--- a/internal/runtime/llmproxy/postproc/cross_conversation_test.go
+++ b/internal/runtime/llmproxy/postproc/cross_conversation_test.go
@@ -1,0 +1,254 @@
+package postproc
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy"
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/inspector"
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+// Postprocess must copy cfg.AuditContext.ConversationID onto the coalesced
+// hold so it lands in the correct per-conversation bucket. This is the
+// regression introduced by #439 (coalesceFromCaptures does not touch
+// ConversationID) and fixed by #441.
+//
+// The test verifies:
+//   - the hold is retrievable via the correct ConversationID
+//   - the hold is NOT visible from a different conversation's bucket
+//   - the legacy (empty-ID) bucket is empty — the hold didn't fall through
+func TestPostprocess_CoalescedHoldInheritsConversationID(t *testing.T) {
+	const convID = "conv-test-abc"
+	body := []byte(`{
+		"id":"msg_1",
+		"type":"message",
+		"role":"assistant",
+		"model":"claude-haiku-4-5",
+		"content":[
+			{"type":"tool_use","id":"toolu_bash","name":"Bash","input":{"command":"ls"}},
+			{"type":"tool_use","id":"toolu_fetch","name":"WebFetch","input":{"url":"https://example.com/x"}}
+		],
+		"stop_reason":"tool_use"
+	}`)
+	req := httptest.NewRequest("POST", "/v1/messages", nil)
+	insp := inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{})
+	st, userID, agentID := seedPostprocessStore(t, "autovault_github_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
+	cache := llmproxy.NewMemoryPendingApprovalCache(time.Minute)
+
+	result := Postprocess(req, body, "application/json", llmproxy.PostprocessConfig{
+		ToolUseEvaluatorFactory: pipelineFactory,
+		AgentContext: llmproxy.AgentContext{
+			AgentUserID: userID,
+			AgentID:     agentID,
+		},
+		AuditContext: llmproxy.AuditContext{
+			ConversationID: convID,
+		},
+		AuthorizationContext: llmproxy.AuthorizationContext{
+			CandidateTasks: []*store.Task{},
+			ToolRules: []*store.RuntimePolicyRule{
+				{ID: "review-webfetch", UserID: userID, AgentID: &agentID, Kind: "tool", Action: "review", ToolName: "WebFetch", Reason: "review web fetch", Enabled: true},
+			},
+			EgressRules: []*store.RuntimePolicyRule{},
+		},
+		ApprovalContext: llmproxy.ApprovalContext{
+			PendingApprovals: cache,
+		},
+		RewriteContext: llmproxy.RewriteContext{
+			Inspector:    insp,
+			RewriteOpts:  inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
+			CallerNonces: llmproxy.NewMemoryCallerNonceCache(time.Minute),
+			Store:        st,
+		},
+		RoutingContext: llmproxy.RoutingContext{
+			ResponseRegistry: conversation.DefaultResponseRegistry(),
+		},
+	})
+	if !result.Rewritten {
+		t.Fatalf("expected coalesced rewrite, got skipped: %s", result.SkippedReason)
+	}
+
+	ctx := context.Background()
+
+	// Hold must be retrievable from the correct conversation bucket.
+	hold, err := cache.Peek(ctx, llmproxy.ResolveRequest{
+		UserID:         userID,
+		AgentID:        agentID,
+		Provider:       conversation.ProviderAnthropic,
+		ConversationID: convID,
+	})
+	if err != nil {
+		t.Fatalf("Peek with ConversationID=%q: %v", convID, err)
+	}
+	if hold == nil {
+		t.Fatalf("coalesced hold not found under ConversationID %q — "+
+			"AuditContext.ConversationID was not propagated to coalesced.ConversationID (regression from #439)", convID)
+	}
+	if hold.ConversationID != convID {
+		t.Fatalf("hold.ConversationID = %q, want %q", hold.ConversationID, convID)
+	}
+
+	// Hold must NOT be visible from an unrelated conversation.
+	wrong, err := cache.Peek(ctx, llmproxy.ResolveRequest{
+		UserID:         userID,
+		AgentID:        agentID,
+		Provider:       conversation.ProviderAnthropic,
+		ConversationID: "conv-other",
+	})
+	if err != nil {
+		t.Fatalf("Peek wrong conversation: %v", err)
+	}
+	if wrong != nil {
+		t.Fatalf("coalesced hold leaked into unrelated conversation bucket (tool=%s)", wrong.ToolUse.ID)
+	}
+
+	// Hold must NOT have fallen into the legacy (empty-ConversationID) shared bucket.
+	legacy := cache.SnapshotHoldsForTest(userID, agentID, conversation.ProviderAnthropic)
+	if len(legacy) != 0 {
+		t.Fatalf("coalesced hold unexpectedly landed in legacy empty-ConversationID bucket (%d holds)", len(legacy))
+	}
+}
+
+// Adversarial end-to-end: conversation A produces a coalesced hold for two
+// WebFetch calls. A bare "y" from conversation B (which has no pending holds)
+// must return nil, and an explicit resolve of A's hold ID from B must also
+// return nil. Conv-A's hold must survive both spoofing attempts and be
+// resolvable only by conversation A itself.
+func TestPostprocess_ConcurrentConversationsCannotSpoof(t *testing.T) {
+	twoWebFetchBody := func(id1, id2, url1, url2 string) []byte {
+		return []byte(`{
+			"id":"msg_x",
+			"type":"message",
+			"role":"assistant",
+			"model":"claude-haiku-4-5",
+			"content":[
+				{"type":"tool_use","id":"` + id1 + `","name":"WebFetch","input":{"url":"` + url1 + `"}},
+				{"type":"tool_use","id":"` + id2 + `","name":"WebFetch","input":{"url":"` + url2 + `"}}
+			],
+			"stop_reason":"tool_use"
+		}`)
+	}
+
+	insp := inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{})
+	st, userID, agentID := seedPostprocessStore(t, "autovault_github_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
+	cache := llmproxy.NewMemoryPendingApprovalCache(time.Minute)
+	rules := []*store.RuntimePolicyRule{
+		{ID: "review-webfetch", UserID: userID, AgentID: &agentID, Kind: "tool", Action: "review", ToolName: "WebFetch", Reason: "review web fetch", Enabled: true},
+	}
+
+	cfgFor := func(convID string) llmproxy.PostprocessConfig {
+		return llmproxy.PostprocessConfig{
+			ToolUseEvaluatorFactory: pipelineFactory,
+			AgentContext: llmproxy.AgentContext{
+				AgentUserID: userID,
+				AgentID:     agentID,
+			},
+			AuditContext: llmproxy.AuditContext{
+				ConversationID: convID,
+			},
+			AuthorizationContext: llmproxy.AuthorizationContext{
+				CandidateTasks: []*store.Task{},
+				ToolRules:      rules,
+				EgressRules:    []*store.RuntimePolicyRule{},
+			},
+			ApprovalContext: llmproxy.ApprovalContext{
+				PendingApprovals: cache,
+			},
+			RewriteContext: llmproxy.RewriteContext{
+				Inspector:    insp,
+				RewriteOpts:  inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
+				CallerNonces: llmproxy.NewMemoryCallerNonceCache(time.Minute),
+				Store:        st,
+			},
+			RoutingContext: llmproxy.RoutingContext{
+				ResponseRegistry: conversation.DefaultResponseRegistry(),
+			},
+		}
+	}
+
+	// Conversation A produces a coalesced hold.
+	reqA := httptest.NewRequest("POST", "/v1/messages", nil)
+	resultA := Postprocess(reqA,
+		twoWebFetchBody("toolu_a1", "toolu_a2", "https://example.com/a1", "https://example.com/a2"),
+		"application/json", cfgFor("conv-a"))
+	if !resultA.Rewritten {
+		t.Fatalf("conv-a: expected coalesced rewrite, got skipped: %s", resultA.SkippedReason)
+	}
+
+	ctx := context.Background()
+
+	holdA, err := cache.Peek(ctx, llmproxy.ResolveRequest{
+		UserID:         userID,
+		AgentID:        agentID,
+		Provider:       conversation.ProviderAnthropic,
+		ConversationID: "conv-a",
+	})
+	if err != nil || holdA == nil {
+		t.Fatalf("conv-a hold not found after Postprocess: err=%v hold=%v", err, holdA)
+	}
+
+	// Spoofing attempt 1: bare "y" from conv-b (conv-b has no pending holds).
+	// Must return nil; must not consume conv-a's hold.
+	bareSpoof, err := cache.Resolve(ctx, llmproxy.ResolveRequest{
+		UserID:         userID,
+		AgentID:        agentID,
+		Provider:       conversation.ProviderAnthropic,
+		ConversationID: "conv-b",
+		// ApprovalID empty — simulates a bare "y" in the conv-b chat window
+	})
+	if err != nil {
+		t.Fatalf("bare spoof attempt: %v", err)
+	}
+	if bareSpoof != nil {
+		t.Fatalf("bare reply from conv-b resolved a hold (tool=%s, id=%s); expected nil",
+			bareSpoof.ToolUse.ID, bareSpoof.ID)
+	}
+
+	// Spoofing attempt 2: explicit ID targeting conv-a's hold, issued from conv-b.
+	explicitSpoof, err := cache.Resolve(ctx, llmproxy.ResolveRequest{
+		UserID:         userID,
+		AgentID:        agentID,
+		Provider:       conversation.ProviderAnthropic,
+		ConversationID: "conv-b",
+		ApprovalID:     holdA.ID,
+	})
+	if err != nil {
+		t.Fatalf("explicit-ID spoof attempt: %v", err)
+	}
+	if explicitSpoof != nil {
+		t.Fatalf("explicit ApprovalID from conv-b resolved conv-a's hold (tool=%s, id=%s); must not cross conversation boundaries",
+			explicitSpoof.ToolUse.ID, explicitSpoof.ID)
+	}
+
+	// Conv-a's hold must be intact after both spoofing attempts.
+	stillA, err := cache.Peek(ctx, llmproxy.ResolveRequest{
+		UserID:         userID,
+		AgentID:        agentID,
+		Provider:       conversation.ProviderAnthropic,
+		ConversationID: "conv-a",
+	})
+	if err != nil {
+		t.Fatalf("Peek conv-a after spoof attempts: %v", err)
+	}
+	if stillA == nil {
+		t.Fatal("conv-a hold was consumed by a spoofed resolution from conv-b")
+	}
+
+	// Conv-a can resolve its own hold.
+	selfResolved, err := cache.Resolve(ctx, llmproxy.ResolveRequest{
+		UserID:         userID,
+		AgentID:        agentID,
+		Provider:       conversation.ProviderAnthropic,
+		ConversationID: "conv-a",
+	})
+	if err != nil {
+		t.Fatalf("conv-a self-resolve: %v", err)
+	}
+	if selfResolved == nil {
+		t.Fatal("conv-a could not resolve its own hold")
+	}
+}


### PR DESCRIPTION
Summary                                                                                                                                        
                                                                                                                                                 
  - Adds dedicated regression tests for the ConversationID scoping fix landed in #441 (regression from #439's coalesce path)                     
  - Covers both the cache layer (bucket isolation, bare-reply isolation, legacy compat) and the Postprocess layer (coalesced hold inherits cfg.ConversationID, end-to-end spoofing scenarios)                                                                                             
  - Without the one-line fix in #441, TestPostprocess_CoalescedHoldInheritsConversationID and TestPostprocess_ConcurrentConversationsCannotSpoof both fail                                                                                                                                      
                                                                                                                                               
  Tests added (cross_conversation_test.go)                                                                                                       
                                                                                                                                               
  - TestPendingApprovalCache_ConversationIDIsolatesHolds - holds for conv-a and conv-b land in separate buckets; explicit-ID resolve from the wrong conversation returns nil in both directions
  - TestPendingApprovalCache_BareReplyCannotCrossConversations - bare "y" from a conversation with no pending holds cannot consume another conversation's hold                                                                                                                          
  - TestPendingApprovalCache_EmptyConversationIDIsSharedBucket - empty ConversationID still resolves via the shared legacy bucket (backward compat)                                                                                                                                        
  - TestPostprocess_CoalescedHoldInheritsConversationID - Postprocess stores the coalesced hold under the correct conversation key, not in the empty-ID legacy bucket                                                                                                                         
  - TestPostprocess_ConcurrentConversationsCannotSpoof- bare and explicit-ID spoofing attempts from conv-b both return nil; conv-a's hold survives both and self-resolves normally  