### PR TITLE
test(llmproxy): add pipeline safety and rollback validation tests

### DIFF
--- a/internal/runtime/llmproxy/pipeline/finalizer_test.go
+++ b/internal/runtime/llmproxy/pipeline/finalizer_test.go
@@ -447,7 +447,7 @@ func TestFinalizerCoalescedEvictionAuditUsesApprovalPrimary(t *testing.T) {
 	}
 }
 
-func TestFinalizerReplayPartialFailureRollback(t *testing.T) {
+func TestFinalizerReplayFailureRollsBackPendingTaskForFailedCapture(t *testing.T) {
 	submitErr := errors.New("third submit failed")
 	deps := &finalizerTestDeps{
 		submit:     pipeline.HoldSubmitResult{ApprovalID: "cv-committed"},
@@ -484,4 +484,3 @@ func TestFinalizerReplayPartialFailureRollback(t *testing.T) {
 		t.Fatalf("rolledBack = %+v, want toolu_fail", deps.rolledBack)
 	}
 }
-

--- a/internal/runtime/llmproxy/pipeline/finalizer_test.go
+++ b/internal/runtime/llmproxy/pipeline/finalizer_test.go
@@ -446,3 +446,42 @@ func TestFinalizerCoalescedEvictionAuditUsesApprovalPrimary(t *testing.T) {
 		t.Fatalf("coalesced eviction audit primary = %v, want approval capture", deps.coalescedEvictedAuditToolUseID)
 	}
 }
+
+func TestFinalizerReplayPartialFailureRollback(t *testing.T) {
+	submitErr := errors.New("third submit failed")
+	deps := &finalizerTestDeps{
+		submit:     pipeline.HoldSubmitResult{ApprovalID: "cv-committed"},
+		submitErrs: []error{nil, nil, submitErr},
+	}
+	f := pipeline.NewFinalizer(deps)
+	for _, id := range []string{"toolu_ok1", "toolu_ok2", "toolu_fail"} {
+		f.AddCapture(pipeline.HoldCapture{
+			ToolUseID: id,
+			Kind:      eval.HeldKindHintApproval,
+			Stage:     "inline_task",
+			Payload:   "pending-" + id,
+		})
+	}
+
+	_, err := f.Finalize(context.Background())
+	if !errors.Is(err, submitErr) {
+		t.Fatalf("Finalize error = %v, want %v", err, submitErr)
+	}
+
+	// Should drop the first two committed holds
+	if len(deps.dropped) != 2 {
+		t.Fatalf("dropped count = %d, want 2", len(deps.dropped))
+	}
+	if deps.dropped[0].ToolUseID != "toolu_ok1" || deps.dropped[1].ToolUseID != "toolu_ok2" {
+		t.Fatalf("dropped = %+v, want toolu_ok1 and toolu_ok2", deps.dropped)
+	}
+
+	// Should rollback pending tasks for the remaining (failed) captures (index 2 onwards)
+	if len(deps.rolledBack) != 1 {
+		t.Fatalf("rolledBack count = %d, want 1", len(deps.rolledBack))
+	}
+	if deps.rolledBack[0].ToolUseID != "toolu_fail" {
+		t.Fatalf("rolledBack = %+v, want toolu_fail", deps.rolledBack)
+	}
+}
+

--- a/internal/runtime/llmproxy/pipeline/finalizer_test.go
+++ b/internal/runtime/llmproxy/pipeline/finalizer_test.go
@@ -3,6 +3,7 @@ package pipeline_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
@@ -22,6 +23,7 @@ type finalizerTestDeps struct {
 	coalescedEvictedAuditToolUseID []string
 	omitCoalescedPerToolAudit      bool
 	rolledBack                     []pipeline.HoldCapture
+	sequence                       []string
 }
 
 func (d *finalizerTestDeps) SubmitHold(context.Context, any) (pipeline.HoldSubmitResult, error) {
@@ -34,6 +36,7 @@ func (d *finalizerTestDeps) SubmitHold(context.Context, any) (pipeline.HoldSubmi
 
 func (d *finalizerTestDeps) DropHold(_ context.Context, c pipeline.HoldCapture) error {
 	d.dropped = append(d.dropped, c)
+	d.sequence = append(d.sequence, "drop-"+c.ToolUseID)
 	d.dropCalls++
 	if len(d.dropErrs) >= d.dropCalls && d.dropErrs[d.dropCalls-1] != nil {
 		return d.dropErrs[d.dropCalls-1]
@@ -80,6 +83,7 @@ func (d *finalizerTestDeps) CleanupEvictedHold(context.Context, any) {}
 
 func (d *finalizerTestDeps) RollbackPendingTask(_ context.Context, c pipeline.HoldCapture) {
 	d.rolledBack = append(d.rolledBack, c)
+	d.sequence = append(d.sequence, "rollback-"+c.ToolUseID)
 }
 
 func (d *finalizerTestDeps) WriteAudit(_ context.Context, ev conversation.AuditEvent) {
@@ -447,14 +451,14 @@ func TestFinalizerCoalescedEvictionAuditUsesApprovalPrimary(t *testing.T) {
 	}
 }
 
-func TestFinalizerReplayFailureRollsBackPendingTaskForFailedCapture(t *testing.T) {
+func TestFinalizerReplayFailureRollsBackPendingTasksForFailedAndRemainingCaptures(t *testing.T) {
 	submitErr := errors.New("third submit failed")
 	deps := &finalizerTestDeps{
 		submit:     pipeline.HoldSubmitResult{ApprovalID: "cv-committed"},
 		submitErrs: []error{nil, nil, submitErr},
 	}
 	f := pipeline.NewFinalizer(deps)
-	for _, id := range []string{"toolu_ok1", "toolu_ok2", "toolu_fail"} {
+	for _, id := range []string{"toolu_ok1", "toolu_ok2", "toolu_fail", "toolu_after"} {
 		f.AddCapture(pipeline.HoldCapture{
 			ToolUseID: id,
 			Kind:      eval.HeldKindHintApproval,
@@ -477,10 +481,22 @@ func TestFinalizerReplayFailureRollsBackPendingTaskForFailedCapture(t *testing.T
 	}
 
 	// Should rollback pending tasks for the remaining (failed) captures (index 2 onwards)
-	if len(deps.rolledBack) != 1 {
-		t.Fatalf("rolledBack count = %d, want 1", len(deps.rolledBack))
+	if len(deps.rolledBack) != 2 {
+		t.Fatalf("rolledBack count = %d, want 2", len(deps.rolledBack))
 	}
-	if deps.rolledBack[0].ToolUseID != "toolu_fail" {
-		t.Fatalf("rolledBack = %+v, want toolu_fail", deps.rolledBack)
+	if deps.rolledBack[0].ToolUseID != "toolu_fail" || deps.rolledBack[1].ToolUseID != "toolu_after" {
+		t.Fatalf("rolledBack = %+v, want toolu_fail and toolu_after", deps.rolledBack)
+	}
+
+	// Verify contract: DropHold calls must fire before RollbackPendingTask calls
+	seenRollback := false
+	for _, step := range deps.sequence {
+		if strings.HasPrefix(step, "rollback-") {
+			seenRollback = true
+		} else if strings.HasPrefix(step, "drop-") {
+			if seenRollback {
+				t.Fatalf("DropHold called after RollbackPendingTask in sequence: %v", deps.sequence)
+			}
+		}
 	}
 }

--- a/internal/runtime/llmproxy/postproc/coalesce_test.go
+++ b/internal/runtime/llmproxy/postproc/coalesce_test.go
@@ -1533,6 +1533,9 @@ func TestPostprocess_DropsCoalescedHoldOnPromptRewriteFailure(t *testing.T) {
 	if !strings.Contains(got.SkippedReason, "simulated prompt rewrite failure") {
 		t.Fatalf("expected simulated error in SkippedReason, got: %s", got.SkippedReason)
 	}
+	if got.Body != nil {
+		t.Fatalf("failClosed must drop body; got %d bytes", len(got.Body))
+	}
 
 	// The coalesced hold should have been committed during finalize but dropped/rolled back when rewrite failed.
 	holds := cache.SnapshotHoldsForTest(userID, agentID, conversation.ProviderAnthropic)
@@ -1541,9 +1544,11 @@ func TestPostprocess_DropsCoalescedHoldOnPromptRewriteFailure(t *testing.T) {
 	}
 }
 
+// flakyRewriter intercepts rewrite passes. It identifies the coalesced rewrite
+// pass by inspecting the evaluation verdicts and triggers a failure during
+// that pass, simulating a rewrite failure after storage has already committed.
 type flakyRewriter struct {
-	inner        conversation.ResponseRewriter
-	rewriteCount int
+	inner conversation.ResponseRewriter
 }
 
 func (f *flakyRewriter) Name() conversation.Provider {
@@ -1555,10 +1560,20 @@ func (f *flakyRewriter) MatchesResponse(req *http.Request, resp *http.Response) 
 }
 
 func (f *flakyRewriter) Rewrite(body []byte, contentType string, eval conversation.ToolUseEvaluator) (conversation.RewriteResult, error) {
-	f.rewriteCount++
-	if f.rewriteCount == 3 {
+	isCoalescedPass := false
+	wrappedEval := func(tu conversation.ToolUse) conversation.ToolUseVerdict {
+		verdict := eval(tu)
+		if strings.Contains(verdict.Reason, "coalesced turn") {
+			isCoalescedPass = true
+		}
+		return verdict
+	}
+	res, err := f.inner.Rewrite(body, contentType, wrappedEval)
+	if err != nil {
+		return res, err
+	}
+	if isCoalescedPass {
 		return conversation.RewriteResult{}, errors.New("simulated prompt rewrite failure")
 	}
-	return f.inner.Rewrite(body, contentType, eval)
+	return res, nil
 }
-

--- a/internal/runtime/llmproxy/postproc/coalesce_test.go
+++ b/internal/runtime/llmproxy/postproc/coalesce_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"strings"
@@ -1476,3 +1477,88 @@ func TestSyntheticApprovalToolUses_SingletonMatchesLegacy(t *testing.T) {
 		t.Fatalf("singleton multi-synth diverges semantically from legacy:\nlegacy=%s\nmulti =%s", legacy.Body, multi.Body)
 	}
 }
+
+func TestPostprocess_DropsCoalescedHoldOnPromptRewriteFailure(t *testing.T) {
+	body := []byte(`{
+		"id":"msg_1",
+		"type":"message",
+		"role":"assistant",
+		"model":"claude-haiku-4-5",
+		"content":[
+			{"type":"tool_use","id":"toolu_bash","name":"Bash","input":{"command":"ls -la"}},
+			{"type":"tool_use","id":"toolu_fetch","name":"WebFetch","input":{"url":"https://example.com/x"}}
+		],
+		"stop_reason":"tool_use"
+	}`)
+	req := httptest.NewRequest("POST", "/v1/messages", nil)
+	insp := inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{})
+	st, userID, agentID := seedPostprocessStore(t, "autovault_github_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
+	cache := llmproxy.NewMemoryPendingApprovalCache(time.Minute)
+
+	// Create our custom flaky rewriter
+	anthropicRewriter := conversation.DefaultResponseRegistry().ForProvider(conversation.ProviderAnthropic)
+	flaky := &flakyRewriter{inner: anthropicRewriter}
+	registry := conversation.NewResponseRegistry(flaky)
+
+	got := Postprocess(req, body, "application/json", llmproxy.PostprocessConfig{
+		ToolUseEvaluatorFactory: pipelineFactory,
+		AgentContext: llmproxy.AgentContext{
+			AgentUserID: userID,
+			AgentID:     agentID,
+		},
+		AuthorizationContext: llmproxy.AuthorizationContext{
+			CandidateTasks: []*store.Task{},
+			ToolRules: []*store.RuntimePolicyRule{
+				{ID: "review-webfetch", UserID: userID, AgentID: &agentID, Kind: "tool", Action: "review", ToolName: "WebFetch", Reason: "review web fetch", Enabled: true},
+			},
+			EgressRules: []*store.RuntimePolicyRule{},
+		},
+		ApprovalContext: llmproxy.ApprovalContext{
+			PendingApprovals: cache,
+		},
+		RewriteContext: llmproxy.RewriteContext{
+			Inspector:    insp,
+			RewriteOpts:  inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
+			CallerNonces: llmproxy.NewMemoryCallerNonceCache(time.Minute),
+			Store:        st,
+		},
+		RoutingContext: llmproxy.RoutingContext{
+			ResponseRegistry: registry,
+		},
+	})
+
+	if got.SkippedReason == "" {
+		t.Fatal("expected coalesced prompt rewrite failure to fail closed")
+	}
+	if !strings.Contains(got.SkippedReason, "simulated prompt rewrite failure") {
+		t.Fatalf("expected simulated error in SkippedReason, got: %s", got.SkippedReason)
+	}
+
+	// The coalesced hold should have been committed during finalize but dropped/rolled back when rewrite failed.
+	holds := cache.SnapshotHoldsForTest(userID, agentID, conversation.ProviderAnthropic)
+	if len(holds) != 0 {
+		t.Fatalf("coalesced hold should be dropped after prompt rewrite failure, got %+v", holds)
+	}
+}
+
+type flakyRewriter struct {
+	inner        conversation.ResponseRewriter
+	rewriteCount int
+}
+
+func (f *flakyRewriter) Name() conversation.Provider {
+	return f.inner.Name()
+}
+
+func (f *flakyRewriter) MatchesResponse(req *http.Request, resp *http.Response) bool {
+	return f.inner.MatchesResponse(req, resp)
+}
+
+func (f *flakyRewriter) Rewrite(body []byte, contentType string, eval conversation.ToolUseEvaluator) (conversation.RewriteResult, error) {
+	f.rewriteCount++
+	if f.rewriteCount == 3 {
+		return conversation.RewriteResult{}, errors.New("simulated prompt rewrite failure")
+	}
+	return f.inner.Rewrite(body, contentType, eval)
+}
+

--- a/internal/runtime/llmproxy/postproc/coalesce_test.go
+++ b/internal/runtime/llmproxy/postproc/coalesce_test.go
@@ -1478,6 +1478,8 @@ func TestSyntheticApprovalToolUses_SingletonMatchesLegacy(t *testing.T) {
 	}
 }
 
+var errSimulatedPromptRewrite = errors.New("simulated prompt rewrite failure")
+
 func TestPostprocess_DropsCoalescedHoldOnPromptRewriteFailure(t *testing.T) {
 	body := []byte(`{
 		"id":"msg_1",
@@ -1530,7 +1532,7 @@ func TestPostprocess_DropsCoalescedHoldOnPromptRewriteFailure(t *testing.T) {
 	if got.SkippedReason == "" {
 		t.Fatal("expected coalesced prompt rewrite failure to fail closed")
 	}
-	if !strings.Contains(got.SkippedReason, "simulated prompt rewrite failure") {
+	if !strings.Contains(got.SkippedReason, errSimulatedPromptRewrite.Error()) {
 		t.Fatalf("expected simulated error in SkippedReason, got: %s", got.SkippedReason)
 	}
 	if got.Body != nil {
@@ -1573,7 +1575,7 @@ func (f *flakyRewriter) Rewrite(body []byte, contentType string, eval conversati
 		return res, err
 	}
 	if isCoalescedPass {
-		return conversation.RewriteResult{}, errors.New("simulated prompt rewrite failure")
+		return conversation.RewriteResult{}, errSimulatedPromptRewrite
 	}
 	return res, nil
 }


### PR DESCRIPTION
## Description

This PR introduces critical safety and rollback validation tests for the LLM proxy pipeline refactored in #526 (and related stream refactoring in #527).

Specifically, it implements the following verification paths:

1. **Replay Failure Rolls Back Pending Task for Failed Capture (`TestFinalizerReplayFailureRollsBackPendingTaskForFailedCapture`)**:
   Ensures that when replaying legacy per-tool holds, any partial failures during execution (e.g. durable storage error on a middle tool) correctly trigger rollback and cleanup of any previously committed holds in that batch, and that the failed hold itself has its pending tasks rolled back.
2. **Coalesced Hold Rewrite Failure (`TestPostprocess_DropsCoalescedHoldOnPromptRewriteFailure`)**:
   Ensures that if the final rewriter pass (rendering/splicing the coalesced prompt back into the response body) fails, the already-committed coalesced hold is safely evicted/dropped from the pending approval cache, `got.Body` is fully dropped (`nil`), and the transaction fails closed. The failure trigger is content-based (matching the verdict reason) to avoid brittle coupling to rewrite pass counts.

## Related PRs

- Builds directly on top of the pipeline changes introduced in refactor(llmproxy): split proxy pipeline and policies **#526** (and the subsequent streaming adjustments in fix(llmproxy): persist script sessions and log resolver IO **#527**).

## Verification Results

Successfully compiled and validated on Windows:
- `go test -v ./internal/runtime/llmproxy/pipeline/...` (Pass)
- `go test -v ./internal/runtime/llmproxy/postproc/...` (Pass)