### PR TITLE
fix(llmproxy): preserve thinking block bytes in secret-rewrite path

### DIFF
--- a/internal/api/handlers/llm_endpoint.go
+++ b/internal/api/handlers/llm_endpoint.go
@@ -19,6 +19,7 @@ import (
 	runtimeautovault "github.com/clawvisor/clawvisor/internal/runtime/autovault"
 	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy"
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/bodytransform"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/scriptjudge"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/inspector"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/jsonsurgery"
@@ -3850,93 +3851,28 @@ func rewriteJSONArray(data []byte, replacements map[string]string, keys []string
 }
 
 func rewriteJSONObject(data []byte, replacements map[string]string, keys []string) ([]byte, bool, error) {
-	if isSignedThinkingBlock(data) {
+	if bodytransform.IsThinkingBlock(data) {
 		return data, false, nil
 	}
-	fields, ok := parseJSONObjectFields(data)
+	fields, ok := jsonsurgery.FlattenObject(data)
 	if !ok {
 		return data, false, nil
 	}
 	anyChanged := false
 	for i := range fields {
-		newVal, changed, err := rewriteJSONValue(fields[i].value, replacements, keys)
+		newVal, changed, err := rewriteJSONValue(fields[i].Value, replacements, keys)
 		if err != nil {
 			return nil, false, err
 		}
 		if changed {
-			fields[i].value = newVal
+			fields[i].Value = newVal
 			anyChanged = true
 		}
 	}
 	if !anyChanged {
 		return data, false, nil
 	}
-	return marshalJSONObjectFields(fields), true, nil
-}
-
-func isSignedThinkingBlock(data []byte) bool {
-	typeStart, typeEnd, ok := jsonsurgery.FindFieldValue(data, "type")
-	if !ok {
-		return false
-	}
-	var typ string
-	if err := json.Unmarshal(data[typeStart:typeEnd], &typ); err != nil {
-		return false
-	}
-	return typ == "thinking" || typ == "redacted_thinking"
-}
-
-type jsonObjectField struct {
-	key   string
-	value json.RawMessage
-}
-
-// parseJSONObjectFields iterates a JSON object's key/value pairs in
-// source order. Values come back as RawMessages over the original bytes
-// (including any internal whitespace), so unchanged values can be
-// reassembled verbatim.
-func parseJSONObjectFields(data []byte) ([]jsonObjectField, bool) {
-	dec := json.NewDecoder(bytes.NewReader(data))
-	tok, err := dec.Token()
-	if err != nil {
-		return nil, false
-	}
-	if d, isDelim := tok.(json.Delim); !isDelim || d != '{' {
-		return nil, false
-	}
-	var fields []jsonObjectField
-	for dec.More() {
-		keyTok, err := dec.Token()
-		if err != nil {
-			return nil, false
-		}
-		key, ok := keyTok.(string)
-		if !ok {
-			return nil, false
-		}
-		var val json.RawMessage
-		if err := dec.Decode(&val); err != nil {
-			return nil, false
-		}
-		fields = append(fields, jsonObjectField{key: key, value: val})
-	}
-	return fields, true
-}
-
-func marshalJSONObjectFields(fields []jsonObjectField) []byte {
-	var buf bytes.Buffer
-	buf.WriteByte('{')
-	for i, f := range fields {
-		if i > 0 {
-			buf.WriteByte(',')
-		}
-		keyEnc, _ := json.Marshal(f.key)
-		buf.Write(keyEnc)
-		buf.WriteByte(':')
-		buf.Write(f.value)
-	}
-	buf.WriteByte('}')
-	return buf.Bytes()
+	return jsonsurgery.MarshalObjectFields(fields), true, nil
 }
 
 func (h *LLMEndpointHandler) loadActiveSecretRewrites(ctx context.Context, agent *store.Agent) (map[string]liteSecretVaultRewrite, error) {

--- a/internal/api/handlers/llm_endpoint.go
+++ b/internal/api/handlers/llm_endpoint.go
@@ -21,6 +21,7 @@ import (
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/scriptjudge"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/inspector"
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/jsonsurgery"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/policies"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/postproc"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/pricing"
@@ -3745,26 +3746,27 @@ func (h *LLMEndpointHandler) applyRememberedSecretRewrites(ctx context.Context, 
 	return out, modified, nil
 }
 
+// rewriteJSONStrings applies the replacements map to every string value
+// in body and returns the rewritten body. Unchanged subtrees pass through
+// with their original bytes intact. Changed subtrees are re-emitted with
+// original key order preserved.
+//
+// Byte fidelity matters here: Anthropic verifies thinking and
+// redacted_thinking block signatures across turns, and any byte change to
+// those blocks — including reordering sibling keys, normalizing
+// whitespace, or rewriting text inside the `thinking` field — invalidates
+// the signature and the next request gets rejected with
+// "thinking … blocks in the latest assistant message cannot be modified".
+// Signed blocks are therefore passed through verbatim (the secret-scan
+// path at secret_detection.go:277 applies the same skip during detection;
+// the rewrite path historically did not, which is what scrambled keys in
+// staging when a vaulted value appeared anywhere in the request body).
 func rewriteJSONStrings(body []byte, replacements map[string]string) ([]byte, bool, error) {
 	if len(body) == 0 || len(replacements) == 0 {
 		return body, false, nil
 	}
-	var parsed any
-	if err := json.Unmarshal(body, &parsed); err != nil {
-		return nil, false, err
-	}
 	keys := sortedReplacementKeys(replacements)
-	rewritten, modified := rewriteJSONValueStrings(parsed, replacements, keys)
-	if !modified {
-		return body, false, nil
-	}
-	// Re-marshaling intentionally canonicalizes object key order and
-	// whitespace. The upstream LLM APIs only care about semantic JSON.
-	out, err := json.Marshal(rewritten)
-	if err != nil {
-		return nil, false, err
-	}
-	return out, true, nil
+	return rewriteJSONValue(body, replacements, keys)
 }
 
 func sortedReplacementKeys(replacements map[string]string) []string {
@@ -3784,37 +3786,157 @@ func sortedReplacementKeys(replacements map[string]string) []string {
 	return keys
 }
 
-func rewriteJSONValueStrings(value any, replacements map[string]string, keys []string) (any, bool) {
-	switch typed := value.(type) {
-	case string:
-		out := typed
-		for _, secret := range keys {
-			out = strings.ReplaceAll(out, secret, replacements[secret])
-		}
-		return out, out != typed
-	case []any:
-		modified := false
-		for i, item := range typed {
-			rewritten, changed := rewriteJSONValueStrings(item, replacements, keys)
-			if changed {
-				typed[i] = rewritten
-				modified = true
-			}
-		}
-		return typed, modified
-	case map[string]any:
-		modified := false
-		for key, item := range typed {
-			rewritten, changed := rewriteJSONValueStrings(item, replacements, keys)
-			if changed {
-				typed[key] = rewritten
-				modified = true
-			}
-		}
-		return typed, modified
-	default:
-		return value, false
+func rewriteJSONValue(data []byte, replacements map[string]string, keys []string) ([]byte, bool, error) {
+	trimmed := jsonsurgery.TrimWS(data)
+	if len(trimmed) == 0 {
+		return data, false, nil
 	}
+	switch trimmed[0] {
+	case '"':
+		return rewriteJSONStringLeaf(data, replacements, keys)
+	case '[':
+		return rewriteJSONArray(data, replacements, keys)
+	case '{':
+		return rewriteJSONObject(data, replacements, keys)
+	default:
+		return data, false, nil
+	}
+}
+
+func rewriteJSONStringLeaf(data []byte, replacements map[string]string, keys []string) ([]byte, bool, error) {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, false, err
+	}
+	out := s
+	for _, key := range keys {
+		out = strings.ReplaceAll(out, key, replacements[key])
+	}
+	if out == s {
+		return data, false, nil
+	}
+	enc, err := json.Marshal(out)
+	if err != nil {
+		return nil, false, err
+	}
+	return enc, true, nil
+}
+
+func rewriteJSONArray(data []byte, replacements map[string]string, keys []string) ([]byte, bool, error) {
+	elements, ok := jsonsurgery.FlattenArray(data)
+	if !ok {
+		return data, false, nil
+	}
+	out := make([]json.RawMessage, len(elements))
+	anyChanged := false
+	for i, elem := range elements {
+		newElem, changed, err := rewriteJSONValue(elem, replacements, keys)
+		if err != nil {
+			return nil, false, err
+		}
+		out[i] = newElem
+		if changed {
+			anyChanged = true
+		}
+	}
+	if !anyChanged {
+		return data, false, nil
+	}
+	enc, err := json.Marshal(out)
+	if err != nil {
+		return nil, false, err
+	}
+	return enc, true, nil
+}
+
+func rewriteJSONObject(data []byte, replacements map[string]string, keys []string) ([]byte, bool, error) {
+	if isSignedThinkingBlock(data) {
+		return data, false, nil
+	}
+	fields, ok := parseJSONObjectFields(data)
+	if !ok {
+		return data, false, nil
+	}
+	anyChanged := false
+	for i := range fields {
+		newVal, changed, err := rewriteJSONValue(fields[i].value, replacements, keys)
+		if err != nil {
+			return nil, false, err
+		}
+		if changed {
+			fields[i].value = newVal
+			anyChanged = true
+		}
+	}
+	if !anyChanged {
+		return data, false, nil
+	}
+	return marshalJSONObjectFields(fields), true, nil
+}
+
+func isSignedThinkingBlock(data []byte) bool {
+	typeStart, typeEnd, ok := jsonsurgery.FindFieldValue(data, "type")
+	if !ok {
+		return false
+	}
+	var typ string
+	if err := json.Unmarshal(data[typeStart:typeEnd], &typ); err != nil {
+		return false
+	}
+	return typ == "thinking" || typ == "redacted_thinking"
+}
+
+type jsonObjectField struct {
+	key   string
+	value json.RawMessage
+}
+
+// parseJSONObjectFields iterates a JSON object's key/value pairs in
+// source order. Values come back as RawMessages over the original bytes
+// (including any internal whitespace), so unchanged values can be
+// reassembled verbatim.
+func parseJSONObjectFields(data []byte) ([]jsonObjectField, bool) {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	tok, err := dec.Token()
+	if err != nil {
+		return nil, false
+	}
+	if d, isDelim := tok.(json.Delim); !isDelim || d != '{' {
+		return nil, false
+	}
+	var fields []jsonObjectField
+	for dec.More() {
+		keyTok, err := dec.Token()
+		if err != nil {
+			return nil, false
+		}
+		key, ok := keyTok.(string)
+		if !ok {
+			return nil, false
+		}
+		var val json.RawMessage
+		if err := dec.Decode(&val); err != nil {
+			return nil, false
+		}
+		fields = append(fields, jsonObjectField{key: key, value: val})
+	}
+	return fields, true
+}
+
+func marshalJSONObjectFields(fields []jsonObjectField) []byte {
+	var buf bytes.Buffer
+	buf.WriteByte('{')
+	for i, f := range fields {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		keyEnc, _ := json.Marshal(f.key)
+		buf.Write(keyEnc)
+		buf.WriteByte(':')
+		buf.Write(f.value)
+	}
+	buf.WriteByte('}')
+	return buf.Bytes()
 }
 
 func (h *LLMEndpointHandler) loadActiveSecretRewrites(ctx context.Context, agent *store.Agent) (map[string]liteSecretVaultRewrite, error) {

--- a/internal/api/handlers/llm_endpoint_test.go
+++ b/internal/api/handlers/llm_endpoint_test.go
@@ -903,6 +903,101 @@ func TestRewriteJSONStringsDoesNotRewriteKeys(t *testing.T) {
 	}
 }
 
+// TestRewriteJSONStringsPreservesThinkingBlockBytes reproduces the
+// staging failure where Anthropic rejected requests with "thinking or
+// redacted_thinking blocks in the latest assistant message cannot be
+// modified" after a secret_rewrite rule triggered. Re-marshaling a
+// map[string]any alphabetizes object keys, which corrupts the byte
+// sequence Anthropic uses to verify the thinking-block signature.
+func TestRewriteJSONStringsPreservesThinkingBlockBytes(t *testing.T) {
+	thinkingBlock := `{"type":"thinking","thinking":"reasoning step","signature":"sig-abc123"}`
+	body := []byte(`{"model":"claude-opus-4-7","messages":[` +
+		`{"role":"assistant","content":[` +
+		thinkingBlock + `,` +
+		`{"type":"text","text":"see token tok_REDACT_ME for details"}` +
+		`]}` +
+		`]}`)
+	rewritten, modified, err := rewriteJSONStrings(body, map[string]string{
+		"tok_REDACT_ME": "{{vault.token}}",
+	})
+	if err != nil {
+		t.Fatalf("rewriteJSONStrings: %v", err)
+	}
+	if !modified {
+		t.Fatal("expected text-block replacement to register as modified")
+	}
+	if !bytes.Contains(rewritten, []byte(thinkingBlock)) {
+		t.Fatalf("thinking block bytes were modified by rewriteJSONStrings.\n"+
+			"want substring: %s\ngot: %s", thinkingBlock, rewritten)
+	}
+}
+
+// TestRewriteJSONStringsDoesNotRewriteInsideThinking confirms that
+// secret values appearing inside a thinking block's text are NOT
+// substituted. Substitution there would change the thinking-block bytes
+// the same way key reordering does, breaking signature verification.
+// The proxy can't safely redact the thinking content the model already
+// emitted; it must pass it back verbatim.
+func TestRewriteJSONStringsDoesNotRewriteInsideThinking(t *testing.T) {
+	thinkingBlock := `{"type":"thinking","thinking":"I considered tok_REDACT_ME carefully","signature":"sig-xyz"}`
+	body := []byte(`{"messages":[{"role":"assistant","content":[` + thinkingBlock + `]}]}`)
+	rewritten, modified, err := rewriteJSONStrings(body, map[string]string{
+		"tok_REDACT_ME": "{{vault.token}}",
+	})
+	if err != nil {
+		t.Fatalf("rewriteJSONStrings: %v", err)
+	}
+	if modified {
+		t.Fatalf("must not modify body when the only match is inside a thinking block: %s", rewritten)
+	}
+	if !bytes.Contains(rewritten, []byte(thinkingBlock)) {
+		t.Fatalf("thinking block bytes changed: %s", rewritten)
+	}
+}
+
+// TestRewriteJSONStringsPreservesRedactedThinkingBytes covers the
+// redacted_thinking variant (Anthropic returns these when thinking
+// content is filtered; same byte-fidelity contract as thinking blocks).
+func TestRewriteJSONStringsPreservesRedactedThinkingBytes(t *testing.T) {
+	redacted := `{"type":"redacted_thinking","data":"opaque-tok_REDACT_ME-payload"}`
+	body := []byte(`{"messages":[{"role":"assistant","content":[` + redacted +
+		`,{"type":"text","text":"surface tok_REDACT_ME mention"}]}]}`)
+	rewritten, modified, err := rewriteJSONStrings(body, map[string]string{
+		"tok_REDACT_ME": "{{vault.token}}",
+	})
+	if err != nil {
+		t.Fatalf("rewriteJSONStrings: %v", err)
+	}
+	if !modified {
+		t.Fatal("expected text-block replacement to register as modified")
+	}
+	if !bytes.Contains(rewritten, []byte(redacted)) {
+		t.Fatalf("redacted_thinking block bytes changed: %s", rewritten)
+	}
+}
+
+// TestRewriteJSONStringsPreservesKeyOrderInRewrittenObjects locks in
+// the byte-faithful invariant that even when an object is rewritten
+// (because a string value inside it changed), its sibling keys keep
+// their original source order. Re-marshaling via map[string]any
+// alphabetizes; the byte-faithful walker must not.
+func TestRewriteJSONStringsPreservesKeyOrderInRewrittenObjects(t *testing.T) {
+	body := []byte(`{"zeta":"see tok_REDACT_ME here","alpha":1,"mu":true}`)
+	rewritten, modified, err := rewriteJSONStrings(body, map[string]string{
+		"tok_REDACT_ME": "{{vault.token}}",
+	})
+	if err != nil {
+		t.Fatalf("rewriteJSONStrings: %v", err)
+	}
+	if !modified {
+		t.Fatal("expected modification")
+	}
+	want := `{"zeta":"see {{vault.token}} here","alpha":1,"mu":true}`
+	if string(rewritten) != want {
+		t.Fatalf("key order changed.\nwant: %s\ngot:  %s", want, rewritten)
+	}
+}
+
 func TestLLMEndpoint_InboundSecretAllowOnceAppliesRememberedRewrite(t *testing.T) {
 	var seenBody []byte
 	upstreamHits := 0

--- a/internal/runtime/jsonpatch/jsonpatch.go
+++ b/internal/runtime/jsonpatch/jsonpatch.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"io"
 	"slices"
 )
 
@@ -88,6 +89,12 @@ type ObjectField struct {
 // (including internal whitespace), letting callers do surgical edits
 // without canonicalizing key order — important for Anthropic thinking
 // blocks where any byte change invalidates the signature.
+//
+// Returns ok=false for any input that is not exactly one well-formed
+// JSON object: truncated input (`{"a":1`), trailing garbage
+// (`{"a":1}xyz`), concatenated objects (`{"a":1}{"b":2}`), and so on.
+// This mirrors the strictness of FlattenArray (which uses json.Unmarshal)
+// so rewrite paths never operate on partial payloads.
 func FlattenObject(data []byte) ([]ObjectField, bool) {
 	dec := json.NewDecoder(bytes.NewReader(data))
 	tok, err := dec.Token()
@@ -112,6 +119,21 @@ func FlattenObject(data []byte) ([]ObjectField, bool) {
 			return nil, false
 		}
 		fields = append(fields, ObjectField{Key: key, Value: val})
+	}
+	// dec.More() returning false on a truncated object (no closing
+	// brace) doesn't itself signal error — the decoder just stops. We
+	// must explicitly consume the closing '}' and then confirm the
+	// stream is exhausted, so a missing '}' or trailing tokens both
+	// fail the parse instead of silently stripping bytes.
+	closeTok, err := dec.Token()
+	if err != nil {
+		return nil, false
+	}
+	if d, ok := closeTok.(json.Delim); !ok || d != '}' {
+		return nil, false
+	}
+	if _, err := dec.Token(); err != io.EOF {
+		return nil, false
 	}
 	return fields, true
 }

--- a/internal/runtime/jsonpatch/jsonpatch.go
+++ b/internal/runtime/jsonpatch/jsonpatch.go
@@ -74,6 +74,68 @@ func FlattenArray(data []byte) ([]json.RawMessage, bool) {
 	return elems, true
 }
 
+// ObjectField is a single key/value pair in a JSON object. When
+// produced by FlattenObject, Value is a RawMessage over the original
+// input bytes so unchanged fields can be reassembled verbatim by
+// MarshalObjectFields.
+type ObjectField struct {
+	Key   string
+	Value json.RawMessage
+}
+
+// FlattenObject iterates a JSON object's key/value pairs in source
+// order. Values come back as RawMessages over the input bytes
+// (including internal whitespace), letting callers do surgical edits
+// without canonicalizing key order — important for Anthropic thinking
+// blocks where any byte change invalidates the signature.
+func FlattenObject(data []byte) ([]ObjectField, bool) {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	tok, err := dec.Token()
+	if err != nil {
+		return nil, false
+	}
+	if d, ok := tok.(json.Delim); !ok || d != '{' {
+		return nil, false
+	}
+	var fields []ObjectField
+	for dec.More() {
+		keyTok, err := dec.Token()
+		if err != nil {
+			return nil, false
+		}
+		key, ok := keyTok.(string)
+		if !ok {
+			return nil, false
+		}
+		var val json.RawMessage
+		if err := dec.Decode(&val); err != nil {
+			return nil, false
+		}
+		fields = append(fields, ObjectField{Key: key, Value: val})
+	}
+	return fields, true
+}
+
+// MarshalObjectFields emits a compact JSON object preserving the given
+// field order. Values are written verbatim. The dual of FlattenObject:
+// FlattenObject → mutate values → MarshalObjectFields round-trips an
+// object without reordering its keys.
+func MarshalObjectFields(fields []ObjectField) []byte {
+	var buf bytes.Buffer
+	buf.WriteByte('{')
+	for i, f := range fields {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		keyEnc, _ := json.Marshal(f.Key)
+		buf.Write(keyEnc)
+		buf.WriteByte(':')
+		buf.Write(f.Value)
+	}
+	buf.WriteByte('}')
+	return buf.Bytes()
+}
+
 // LooksLikeString reports whether data begins with a JSON string after
 // leading JSON whitespace.
 func LooksLikeString(data []byte) bool {

--- a/internal/runtime/jsonpatch/jsonpatch_test.go
+++ b/internal/runtime/jsonpatch/jsonpatch_test.go
@@ -77,3 +77,51 @@ func TestSetTopLevelField_ReplacesObjectValue(t *testing.T) {
 		t.Errorf("got %q, want %q", string(out), want)
 	}
 }
+
+func TestFlattenObject_PreservesKeyOrderAndValueBytes(t *testing.T) {
+	in := []byte(`{"zeta":"first","alpha":1,"mu":{"nested":true}}`)
+	fields, ok := jsonpatch.FlattenObject(in)
+	if !ok {
+		t.Fatal("FlattenObject returned ok=false on valid object")
+	}
+	if len(fields) != 3 {
+		t.Fatalf("expected 3 fields, got %d", len(fields))
+	}
+	if fields[0].Key != "zeta" || fields[1].Key != "alpha" || fields[2].Key != "mu" {
+		t.Fatalf("key order not preserved: %v", []string{fields[0].Key, fields[1].Key, fields[2].Key})
+	}
+	if string(fields[0].Value) != `"first"` || string(fields[1].Value) != `1` || string(fields[2].Value) != `{"nested":true}` {
+		t.Fatalf("value bytes not preserved: %v", fields)
+	}
+}
+
+func TestFlattenObject_RejectsNonObject(t *testing.T) {
+	if _, ok := jsonpatch.FlattenObject([]byte(`[1,2,3]`)); ok {
+		t.Error("expected ok=false for array input")
+	}
+	if _, ok := jsonpatch.FlattenObject([]byte(`"string"`)); ok {
+		t.Error("expected ok=false for string input")
+	}
+	if _, ok := jsonpatch.FlattenObject([]byte(`not json`)); ok {
+		t.Error("expected ok=false for garbage input")
+	}
+}
+
+func TestMarshalObjectFields_RoundTripPreservesKeyOrder(t *testing.T) {
+	in := []byte(`{"zeta":"first","alpha":1,"mu":true}`)
+	fields, ok := jsonpatch.FlattenObject(in)
+	if !ok {
+		t.Fatal("FlattenObject returned ok=false")
+	}
+	out := jsonpatch.MarshalObjectFields(fields)
+	if string(out) != string(in) {
+		t.Fatalf("round trip changed bytes.\nin:  %s\nout: %s", in, out)
+	}
+}
+
+func TestMarshalObjectFields_EmitsEmptyObject(t *testing.T) {
+	out := jsonpatch.MarshalObjectFields(nil)
+	if string(out) != `{}` {
+		t.Errorf("expected `{}`, got %q", out)
+	}
+}

--- a/internal/runtime/jsonpatch/jsonpatch_test.go
+++ b/internal/runtime/jsonpatch/jsonpatch_test.go
@@ -107,6 +107,61 @@ func TestFlattenObject_RejectsNonObject(t *testing.T) {
 	}
 }
 
+// TestFlattenObject_RejectsMalformedAndTrailingGarbage locks in the
+// strictness contract: any input that isn't exactly one well-formed
+// JSON object must fail. The looser variant silently stripped trailing
+// bytes or accepted truncated objects, which let rewrite paths operate
+// on partial payloads.
+func TestFlattenObject_RejectsMalformedAndTrailingGarbage(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"trailing_garbage", `{"a":1}garbage`},
+		{"trailing_garbage_multifield", `{"a":1,"b":2}xyz`},
+		{"concatenated_objects", `{"a":1}{"b":2}`},
+		{"truncated_no_close", `{"a":1`},
+		{"truncated_after_comma", `{"a":1,`},
+		{"truncated_after_key", `{"a"`},
+		{"only_open_brace", `{`},
+		{"trailing_value", `{"a":1}null`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, ok := jsonpatch.FlattenObject([]byte(tc.input)); ok {
+				t.Errorf("FlattenObject(%q) returned ok=true; expected rejection", tc.input)
+			}
+		})
+	}
+}
+
+func TestFlattenObject_AcceptsTrailingWhitespace(t *testing.T) {
+	cases := []string{
+		`{"a":1}`,
+		`{"a":1}   `,
+		`{"a":1}` + "\n",
+		`  {"a":1}  `,
+		`{}`,
+	}
+	for _, c := range cases {
+		fields, ok := jsonpatch.FlattenObject([]byte(c))
+		if !ok {
+			t.Errorf("FlattenObject(%q) returned ok=false; expected success", c)
+			continue
+		}
+		// Empty object should produce zero fields; everything else has the "a":1 pair.
+		if c == `{}` {
+			if len(fields) != 0 {
+				t.Errorf("FlattenObject(%q): expected 0 fields, got %d", c, len(fields))
+			}
+			continue
+		}
+		if len(fields) != 1 || fields[0].Key != "a" || string(fields[0].Value) != `1` {
+			t.Errorf("FlattenObject(%q): unexpected fields %v", c, fields)
+		}
+	}
+}
+
 func TestMarshalObjectFields_RoundTripPreservesKeyOrder(t *testing.T) {
 	in := []byte(`{"zeta":"first","alpha":1,"mu":true}`)
 	fields, ok := jsonpatch.FlattenObject(in)

--- a/internal/runtime/llmproxy/bodytransform/anthropic_sanitize.go
+++ b/internal/runtime/llmproxy/bodytransform/anthropic_sanitize.go
@@ -203,6 +203,22 @@ func sanitizeAnthropicContent(raw json.RawMessage) (json.RawMessage, bool, bool,
 	return encoded, true, false, err
 }
 
+// IsThinkingBlock reports whether block is an Anthropic `thinking` or
+// `redacted_thinking` content block. Both block types carry a signature
+// Anthropic verifies across turns; callers that walk assistant content
+// must preserve their bytes verbatim — even reordering sibling keys is
+// enough to invalidate the signature and produce
+// "thinking ... blocks in the latest assistant message cannot be modified"
+// on the next request.
+func IsThinkingBlock(block json.RawMessage) bool {
+	switch extractBlockType(block) {
+	case "thinking", "redacted_thinking":
+		return true
+	default:
+		return false
+	}
+}
+
 func extractBlockType(block json.RawMessage) string {
 	start, end, ok := jsonsurgery.FindFieldValue(block, "type")
 	if !ok {

--- a/internal/runtime/llmproxy/bodytransform/anthropic_sanitize_test.go
+++ b/internal/runtime/llmproxy/bodytransform/anthropic_sanitize_test.go
@@ -63,6 +63,29 @@ func TestSanitizeAnthropicRequestNoop(t *testing.T) {
 	}
 }
 
+func TestIsThinkingBlock(t *testing.T) {
+	cases := []struct {
+		name  string
+		block string
+		want  bool
+	}{
+		{"thinking", `{"type":"thinking","thinking":"...","signature":"sig"}`, true},
+		{"redacted_thinking", `{"type":"redacted_thinking","data":"opaque"}`, true},
+		{"text", `{"type":"text","text":"hello"}`, false},
+		{"tool_use", `{"type":"tool_use","id":"t1","name":"n","input":{}}`, false},
+		{"missing_type", `{"thinking":"x"}`, false},
+		{"non_object", `"thinking"`, false},
+		{"reordered_thinking", `{"signature":"sig","thinking":"...","type":"thinking"}`, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsThinkingBlock(json.RawMessage(tc.block)); got != tc.want {
+				t.Errorf("IsThinkingBlock(%s) = %v, want %v", tc.block, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestSanitizeAnthropicRequestMalformedErrorDoesNotEchoBodySecrets(t *testing.T) {
 	secrets := []string{
 		"sk-ant-api03-secret-value",

--- a/internal/runtime/llmproxy/jsonsurgery/json_surgery.go
+++ b/internal/runtime/llmproxy/jsonsurgery/json_surgery.go
@@ -29,6 +29,20 @@ func FlattenArray(data []byte) ([]json.RawMessage, bool) {
 	return jsonpatch.FlattenArray(data)
 }
 
+// ObjectField is re-exported from jsonpatch — a single key/value pair
+// for use with FlattenObject / MarshalObjectFields.
+type ObjectField = jsonpatch.ObjectField
+
+// FlattenObject iterates a JSON object's key/value pairs in source order.
+func FlattenObject(data []byte) ([]ObjectField, bool) {
+	return jsonpatch.FlattenObject(data)
+}
+
+// MarshalObjectFields emits a JSON object preserving the given field order.
+func MarshalObjectFields(fields []ObjectField) []byte {
+	return jsonpatch.MarshalObjectFields(fields)
+}
+
 // LooksLikeString reports whether data is a JSON-encoded string after
 // leading JSON whitespace.
 func LooksLikeString(data []byte) bool {


### PR DESCRIPTION
## Summary
- `rewriteJSONStrings` round-tripped the whole request body through `json.Unmarshal → map[string]any → json.Marshal`, which alphabetizes object keys. Anthropic verifies `thinking` / `redacted_thinking` block signatures across turns by byte, so the moment any active `secret_rewrite` rule matched a value anywhere in the body (a vaulted token re-appearing in a Gmail tool_result, etc.), every thinking block in history got scrambled and Anthropic returned `400 messages.X.content.Y: thinking … blocks in the latest assistant message cannot be modified`.
- Replaced the round-trip with a byte-faithful walker built on `jsonsurgery`: unchanged subtrees pass through verbatim, changed objects preserve source key order, and `thinking` / `redacted_thinking` blocks are skipped entirely — mirroring the same `type=="thinking"` skip the secret-scan path at `secret_detection.go:277` already had.
- The secondary suspects flagged during the investigation (`extractAnthropicAssistantContentSSE` in `conversation/anthropic_response.go` and `replaceAnthropicApprovalReply` in `llmproxy/approval_body_editor.go`) hit different trigger paths and are left for follow-up.

## Test plan
- [x] `TestRewriteJSONStringsPreservesThinkingBlockBytes` reproduces the staging 400 by asserting the thinking block's original byte sequence survives a text-block replacement (fails on old code, passes now).
- [x] `TestRewriteJSONStringsDoesNotRewriteInsideThinking` — a secret inside the `thinking` field is left alone (rewriting it would also break the signature).
- [x] `TestRewriteJSONStringsPreservesRedactedThinkingBytes` — same contract for `redacted_thinking`.
- [x] `TestRewriteJSONStringsPreservesKeyOrderInRewrittenObjects` — even when an object is rewritten, sibling keys keep their input order.
- [x] All 3 pre-existing `rewriteJSONStrings` tests still pass (escaped values, longest-first replacement, no-key-rewrite).
- [x] Full `internal/api/handlers` package suite green; `go build ./...` and `go vet ./internal/api/handlers/` clean.
- [ ] Watch staging for recurrence of the `thinking … blocks … cannot be modified` 400 after rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)