### PR TITLE
feat(llmproxy): batch intent verification across parallel tool_uses

### DIFF
--- a/internal/runtime/llmproxy/pipelineeval/factory.go
+++ b/internal/runtime/llmproxy/pipelineeval/factory.go
@@ -47,7 +47,7 @@ var Factory llmproxy.ToolUseEvaluatorFactory = func(
 	toolUses []conversation.ToolUse,
 	emit func(conversation.AuditEvent),
 ) conversation.ToolUseEvaluator {
-	credentialedTaskScope := buildCredentialedTaskScope(
+	credentialedBundle := buildCredentialedTaskScope(
 		cfg.AgentContext,
 		cfg.AuditContext,
 		cfg.AuthorizationContext,
@@ -57,13 +57,15 @@ var Factory llmproxy.ToolUseEvaluatorFactory = func(
 		emit,
 	)
 
+	authBundle := buildAuthorizationResolver(cfg.AgentContext, cfg.AuditContext, cfg.AuthorizationContext, cfg.ApprovalContext, cfg.RewriteContext, provider)
+
 	chain := policies.ComposeToolUseEvaluatorChain(policies.ToolUseChainConfig{
 		Control:       buildControlResolver(req, cfg.AgentContext, cfg.AuditContext, cfg.ApprovalContext, cfg.RewriteContext, cfg.RoutingContext, provider, emit),
 		ScriptSession: buildScriptSessionResolver(cfg.RewriteContext, cfg.ScriptSessionContext),
 		Inspector:     cfg.Inspector,
 		Boundary:      buildBoundaryResolver(cfg.AgentContext, cfg.Store),
-		Authorization: buildAuthorizationResolver(cfg.AgentContext, cfg.AuditContext, cfg.AuthorizationContext, cfg.ApprovalContext, cfg.RewriteContext, provider),
-		TaskScope:     credentialedTaskScope,
+		Authorization: authBundle.Resolve,
+		TaskScope:     credentialedBundle.Resolve,
 		Rewrite:       buildRewriteResolver(cfg.AgentContext, cfg.RewriteContext),
 	})
 
@@ -79,6 +81,33 @@ var Factory llmproxy.ToolUseEvaluatorFactory = func(
 		}
 	}
 	ctx := req.Context()
+	// Prime the authorization decision caches by batch-evaluating all
+	// sibling tool_uses' decision-engine inputs in parallel before the
+	// orchestrator's serial loop starts. This collapses N intent-verifier
+	// round-trips per turn (one per parallel tool_use) into a single
+	// wall-clock round-trip per path — the trigger-miss
+	// (AuthorizationPolicy) and credentialed (TaskScopeEvaluator) paths
+	// each maintain their own cache and run their batch independently.
+	// Per-tool-use side effects (audit emission, PendingApprovals.Hold,
+	// SlideTaskExpiry) still run serially inside the orchestrator's
+	// existing loop so approval-hold ordering and audit ordering are
+	// preserved.
+	//
+	// The two prefetches run sequentially, not concurrently. Both walk
+	// rewrite.Inspector over the full sibling set, and Inspector +
+	// Validator implementations don't document a concurrent-Inspect
+	// contract — wrapping an unsynchronized backend would race. The
+	// verifier calls INSIDE each batch still fan out via the decision
+	// engine's EvaluateAuthorizationBatch (which already requires
+	// IntentVerifier to be concurrency-safe), so the per-path wins are
+	// preserved. The only cost is the rare turn that mixes both paths,
+	// which pays two batch latencies instead of one.
+	if authBundle.Prefetch != nil {
+		authBundle.Prefetch(ctx, toolUses)
+	}
+	if credentialedBundle.Prefetch != nil {
+		credentialedBundle.Prefetch(ctx, toolUses)
+	}
 	res := &multiToolUseResponse{provider: provider, toolUses: toolUses}
 	evalFn, result, err := pipeline.RunToolUseEvaluators(ctx, res, toolUses, chain)
 	if err != nil {
@@ -413,6 +442,39 @@ func buildBoundaryResolver(agent llmproxy.AgentContext, st store.Store) policies
 	}
 }
 
+// credentialedTaskScopeBundle pairs the TaskScopeResolver
+// TaskScopeEvaluator consumes with an optional Prefetch hook the
+// Factory invokes once per response to batch the credentialed-path
+// decision-engine calls for every sibling tool_use in parallel.
+//
+// Prefetch is best-effort and only covers the modern decision-engine
+// path (auth.CandidateTasks / ToolRules / EgressRules set). The
+// legacy TaskScope.Check + runIntentVerify fallback stays serial: it
+// is a deprecated path that few callers exercise, and the side
+// effects there are interleaved with the verifier call in a way that
+// does not factor as cleanly.
+type credentialedTaskScopeBundle struct {
+	Resolve  policies.TaskScopeResolver
+	Prefetch func(ctx context.Context, toolUses []conversation.ToolUse)
+}
+
+// credentialedPlan captures everything the credentialed-path resolver
+// needs to apply side effects after a decision has been computed: the
+// inspector verdict + catalog resolution that drove the input, plus
+// the decision-engine input itself (required for Fingerprint on hold).
+type credentialedPlan struct {
+	Verdict       inspector.Verdict
+	Resolved      llmproxy.ResolvedAction
+	DecisionInput runtimedecision.AuthorizationInput
+}
+
+// credentialedOutcome is what Prefetch stashes in the per-response
+// cache: the planning context plus the batched decision outcome.
+type credentialedOutcome struct {
+	Plan    credentialedPlan
+	Outcome runtimedecision.AuthorizationOutcome
+}
+
 // buildCredentialedTaskScope builds the credentialed-path authorization
 // closure that TaskScopeEvaluator consumes via its TaskScopeResolver.
 // The closure runs the runtimedecision.EvaluateAuthorization flow on
@@ -422,8 +484,12 @@ func buildBoundaryResolver(agent llmproxy.AgentContext, st store.Store) policies
 // TaskScopeDecision when the call is authorized so TaskScopeEvaluator
 // Skips and downstream stages (IntentVerify, CredentialRewrite) run.
 //
-// This adapter is where the policy layer reaches the credentialed-path
-// authorization helper behavior without importing llmproxy directly.
+// Prefetch (returned alongside Resolve) batches the modern-path
+// EvaluateAuthorization calls across all sibling tool_uses so a turn
+// with N parallel credentialed tool_uses pays one verifier round-trip
+// of wall time, not N. Side effects (audit / Hold / SlideTaskExpiry)
+// still fire serially inside Resolve so hold-eviction ordering and
+// audit ordering are unchanged.
 func buildCredentialedTaskScope(
 	agent llmproxy.AgentContext,
 	auditCtx llmproxy.AuditContext,
@@ -432,12 +498,130 @@ func buildCredentialedTaskScope(
 	rewrite llmproxy.RewriteContext,
 	provider conversation.Provider,
 	emit func(conversation.AuditEvent),
-) policies.TaskScopeResolver {
+) credentialedTaskScopeBundle {
 	if rewrite.Inspector == nil {
-		return nil
+		return credentialedTaskScopeBundle{}
 	}
 	approvalCleanupCfg := llmproxy.PostprocessConfig{ApprovalContext: approval}
-	return func(ctx context.Context, tu conversation.ToolUse) policies.TaskScopeDecision {
+
+	// planModernPath builds the per-tool-use credentialedPlan for the
+	// modern decision-engine path. Returns (plan, true) when the tool_use
+	// is credentialed AND the modern path is configured. Returns
+	// (_, false) when the legacy fallback should handle it (or the
+	// tool_use is not credentialed at all).
+	planModernPath := func(ctx context.Context, tu conversation.ToolUse) (credentialedPlan, bool) {
+		v := rewrite.Inspector.Inspect(ctx, inspector.ToolUse{
+			ID:    tu.ID,
+			Name:  tu.Name,
+			Input: tu.Input,
+		})
+		if !v.IsAPICall || v.Ambiguous {
+			return credentialedPlan{}, false
+		}
+		if auth.CandidateTasks == nil && auth.ToolRules == nil && auth.EgressRules == nil {
+			return credentialedPlan{Verdict: v}, false
+		}
+		resolved := llmproxy.ResolvedAction{}
+		if auth.Catalog != nil {
+			resolved, _ = auth.Catalog.Resolve(v.Host, v.Method, v.Path)
+		}
+		return credentialedPlan{
+			Verdict:  v,
+			Resolved: resolved,
+			DecisionInput: runtimedecision.AuthorizationInput{
+				ToolUse:         tu,
+				UserID:          agent.AgentUserID,
+				AgentID:         agent.AgentID,
+				Posture:         auth.Posture,
+				Target:          runtimedecision.TargetRequest{Host: v.Host, Method: v.Method, Path: v.Path},
+				Service:         resolved.ServiceID,
+				Action:          resolved.ActionID,
+				CandidateTasks:  auth.CandidateTasks,
+				ToolRules:       auth.ToolRules,
+				EgressRules:     auth.EgressRules,
+				PreferredTaskID: auth.PreferredTaskID,
+				IntentVerifier:  intentverify.DecisionVerifierFor(auth.IntentVerifier),
+			},
+		}, true
+	}
+
+	// Per-response decision cache. Written by Prefetch after its
+	// goroutines join; read by Resolve serially from the orchestrator
+	// loop. No concurrent access.
+	cache := make(map[string]credentialedOutcome)
+
+	// applyModernDecision turns a (plan, decision, err) into the
+	// TaskScopeDecision the policy consumes, firing audit / Hold /
+	// SlideTaskExpiry side effects serially in tool_use order.
+	applyModernDecision := func(
+		ctx context.Context,
+		tu conversation.ToolUse,
+		plan credentialedPlan,
+		dec runtimedecision.AuthorizationDecision,
+		err error,
+		audit func(decision, outcome, reason, taskID string),
+	) policies.TaskScopeDecision {
+		if err != nil {
+			audit("block", "decision_error", err.Error(), "")
+			return policies.TaskScopeDecision{Kind: policies.TaskScopeDecisionDeny, Reason: policies.ModelSafeInternalReason("authorization")}
+		}
+		matchedTaskID := ""
+		if dec.Task != nil {
+			matchedTaskID = dec.Task.ID
+		}
+		switch dec.Kind {
+		case runtimedecision.VerdictAllow:
+			if dec.Task != nil && rewrite.Store != nil {
+				_, _, _ = tasklifetime.SlideTaskExpiry(ctx, rewrite.Store, dec.Task, time.Now().UTC())
+			}
+			return policies.TaskScopeDecision{}
+		case runtimedecision.VerdictDeny:
+			audit("block", string(dec.Source), dec.Reason, matchedTaskID)
+			return policies.TaskScopeDecision{
+				Kind:   policies.TaskScopeDecisionDeny,
+				Reason: "Clawvisor: " + dec.Reason,
+				TaskID: matchedTaskID,
+			}
+		case runtimedecision.VerdictNeedsApproval:
+			var approvalID string
+			if approval.PendingApprovals != nil {
+				held, herr := approval.PendingApprovals.Hold(ctx, llmproxy.PendingLiteApproval{
+					UserID:         agent.AgentUserID,
+					AgentID:        agent.AgentID,
+					Provider:       provider,
+					ConversationID: auditCtx.ConversationID,
+					ToolUse:        tu,
+					Inspector:      plan.Verdict,
+					Fingerprint:    runtimedecision.Fingerprint(dec, plan.DecisionInput),
+					Reason:         dec.Reason,
+				})
+				if herr != nil {
+					audit("block", "approval_hold_error", herr.Error(), "")
+					return policies.TaskScopeDecision{Kind: policies.TaskScopeDecisionDeny, Reason: policies.ModelSafeUnavailableReason("approval")}
+				}
+				if held.Evicted != nil {
+					audit("block", "approval_evicted", "superseded pending approval "+held.Evicted.ID, "")
+					llmproxy.CleanupEvictedInlineTask(ctx, approvalCleanupCfg, held.Evicted)
+				}
+				approvalID = held.Pending.ID
+			}
+			audit("block", string(dec.Source), dec.Reason, matchedTaskID)
+			return policies.TaskScopeDecision{
+				Kind:           policies.TaskScopeDecisionHold,
+				Allowed:        false,
+				Reason:         "Clawvisor: approval required — " + dec.Reason,
+				SubstituteText: approvaltext.ApprovalPrompt(tu, dec.Reason, approvalID),
+				TaskID:         matchedTaskID,
+			}
+		}
+		return policies.TaskScopeDecision{}
+	}
+
+	resolve := func(ctx context.Context, tu conversation.ToolUse) policies.TaskScopeDecision {
+		// Inspect once: needed for the not-credentialed early return,
+		// the audit emitter's snapshot, and the legacy fallback branch.
+		// Cheap and deterministic — duplicating the call against the
+		// prefetch path is acceptable.
 		v := rewrite.Inspector.Inspect(ctx, inspector.ToolUse{
 			ID:    tu.ID,
 			Name:  tu.Name,
@@ -460,77 +644,18 @@ func buildCredentialedTaskScope(
 			})
 		}
 		if auth.CandidateTasks != nil || auth.ToolRules != nil || auth.EgressRules != nil {
-			resolved := llmproxy.ResolvedAction{}
-			if auth.Catalog != nil {
-				resolved, _ = auth.Catalog.Resolve(v.Host, v.Method, v.Path)
+			if cached, ok := cache[tu.ID]; ok {
+				return applyModernDecision(ctx, tu, cached.Plan, cached.Outcome.Decision, cached.Outcome.Err, audit)
 			}
-			decisionInput := runtimedecision.AuthorizationInput{
-				ToolUse:         tu,
-				UserID:          agent.AgentUserID,
-				AgentID:         agent.AgentID,
-				Posture:         auth.Posture,
-				Target:          runtimedecision.TargetRequest{Host: v.Host, Method: v.Method, Path: v.Path},
-				Service:         resolved.ServiceID,
-				Action:          resolved.ActionID,
-				CandidateTasks:  auth.CandidateTasks,
-				ToolRules:       auth.ToolRules,
-				EgressRules:     auth.EgressRules,
-				PreferredTaskID: auth.PreferredTaskID,
-				IntentVerifier:  intentverify.DecisionVerifierFor(auth.IntentVerifier),
-			}
-			dec, err := runtimedecision.EvaluateAuthorization(ctx, decisionInput)
-			if err != nil {
-				audit("block", "decision_error", err.Error(), "")
-				return policies.TaskScopeDecision{Kind: policies.TaskScopeDecisionDeny, Reason: policies.ModelSafeInternalReason("authorization")}
-			}
-			matchedTaskID := ""
-			if dec.Task != nil {
-				matchedTaskID = dec.Task.ID
-			}
-			switch dec.Kind {
-			case runtimedecision.VerdictAllow:
-				if dec.Task != nil && rewrite.Store != nil {
-					_, _, _ = tasklifetime.SlideTaskExpiry(ctx, rewrite.Store, dec.Task, time.Now().UTC())
-				}
-				return policies.TaskScopeDecision{}
-			case runtimedecision.VerdictDeny:
-				audit("block", string(dec.Source), dec.Reason, matchedTaskID)
-				return policies.TaskScopeDecision{
-					Kind:   policies.TaskScopeDecisionDeny,
-					Reason: "Clawvisor: " + dec.Reason,
-					TaskID: matchedTaskID,
-				}
-			case runtimedecision.VerdictNeedsApproval:
-				var approvalID string
-				if approval.PendingApprovals != nil {
-					held, herr := approval.PendingApprovals.Hold(ctx, llmproxy.PendingLiteApproval{
-						UserID:         agent.AgentUserID,
-						AgentID:        agent.AgentID,
-						Provider:       provider,
-						ConversationID: auditCtx.ConversationID,
-						ToolUse:        tu,
-						Inspector:      v,
-						Fingerprint:    runtimedecision.Fingerprint(dec, decisionInput),
-						Reason:         dec.Reason,
-					})
-					if herr != nil {
-						audit("block", "approval_hold_error", herr.Error(), "")
-						return policies.TaskScopeDecision{Kind: policies.TaskScopeDecisionDeny, Reason: policies.ModelSafeUnavailableReason("approval")}
-					}
-					if held.Evicted != nil {
-						audit("block", "approval_evicted", "superseded pending approval "+held.Evicted.ID, "")
-						llmproxy.CleanupEvictedInlineTask(ctx, approvalCleanupCfg, held.Evicted)
-					}
-					approvalID = held.Pending.ID
-				}
-				audit("block", string(dec.Source), dec.Reason, matchedTaskID)
-				return policies.TaskScopeDecision{
-					Kind:           policies.TaskScopeDecisionHold,
-					Allowed:        false,
-					Reason:         "Clawvisor: approval required — " + dec.Reason,
-					SubstituteText: approvaltext.ApprovalPrompt(tu, dec.Reason, approvalID),
-					TaskID:         matchedTaskID,
-				}
+			// Cache miss (Prefetch not invoked, or this tool_use was
+			// excluded from the batch). Fall back to inline evaluation.
+			plan, planned := planModernPath(ctx, tu)
+			if !planned {
+				// planModernPath agreed it's credentialed but the modern
+				// path isn't configured — fall through to legacy below.
+			} else {
+				dec, err := runtimedecision.EvaluateAuthorization(ctx, plan.DecisionInput)
+				return applyModernDecision(ctx, tu, plan, dec, err, audit)
 			}
 		}
 		// Legacy TaskScope.Check + intent verify fallback.
@@ -567,12 +692,64 @@ func buildCredentialedTaskScope(
 		}
 		return policies.TaskScopeDecision{}
 	}
+
+	prefetch := func(ctx context.Context, toolUses []conversation.ToolUse) {
+		// Modern-path inputs only. Tool_uses that don't reach
+		// EvaluateAuthorization (not credentialed, or legacy fallback)
+		// are skipped — Resolve handles them inline.
+		type pending struct {
+			tuID string
+			plan credentialedPlan
+		}
+		pendings := make([]pending, 0, len(toolUses))
+		for _, tu := range toolUses {
+			plan, planned := planModernPath(ctx, tu)
+			if !planned {
+				continue
+			}
+			pendings = append(pendings, pending{tuID: tu.ID, plan: plan})
+		}
+		if len(pendings) == 0 {
+			return
+		}
+		batchInputs := make([]runtimedecision.AuthorizationInput, len(pendings))
+		for i, p := range pendings {
+			batchInputs[i] = p.plan.DecisionInput
+		}
+		outcomes := runtimedecision.EvaluateAuthorizationBatch(ctx, batchInputs)
+		for i, out := range outcomes {
+			cache[pendings[i].tuID] = credentialedOutcome{
+				Plan:    pendings[i].plan,
+				Outcome: out,
+			}
+		}
+	}
+
+	return credentialedTaskScopeBundle{Resolve: resolve, Prefetch: prefetch}
+}
+
+// authorizationResolverBundle pairs the AuthorizationResolver
+// AuthorizationPolicy consumes with an optional Prefetch hook the
+// Factory invokes once per response to batch the decision-engine
+// calls for every sibling tool_use in parallel.
+//
+// Prefetch is best-effort: when the cache is primed, Resolve returns
+// AuthorizationInputs with Precomputed set, and AuthorizationPolicy
+// skips its inline EvaluateAuthorization call. When Prefetch was not
+// invoked (or a tool_use was excluded from the batch), Resolve
+// returns AuthorizationInputs without Precomputed and the policy
+// falls back to the inline call. Either way, the side-effect dispatch
+// (SlideTask / HoldHandler) still runs serially inside Evaluate so
+// approval-hold ordering and audit emission stay identical.
+type authorizationResolverBundle struct {
+	Resolve  policies.AuthorizationResolver
+	Prefetch func(ctx context.Context, toolUses []conversation.ToolUse)
 }
 
 // buildAuthorizationResolver wires AuthorizationPolicy to
 // PostprocessConfig's decision-engine inputs + PendingApprovals cache.
-// Returns nil when the policy has no role (no inspector, no policy
-// config, and no sensitive-path hook).
+// Returns an empty bundle when the policy has no role (no inspector
+// configured).
 func buildAuthorizationResolver(
 	agent llmproxy.AgentContext,
 	audit llmproxy.AuditContext,
@@ -580,9 +757,9 @@ func buildAuthorizationResolver(
 	approval llmproxy.ApprovalContext,
 	rewrite llmproxy.RewriteContext,
 	provider conversation.Provider,
-) policies.AuthorizationResolver {
+) authorizationResolverBundle {
 	if rewrite.Inspector == nil {
-		return nil
+		return authorizationResolverBundle{}
 	}
 	intentVerifier := intentverify.DecisionVerifierFor(auth.IntentVerifier)
 	holdHandler := &authorizationHoldHandler{
@@ -597,7 +774,12 @@ func buildAuthorizationResolver(
 		}
 		_, _, _ = tasklifetime.SlideTaskExpiry(ctx, rewrite.Store, task, time.Now().UTC())
 	}
-	return func(ctx context.Context, tu conversation.ToolUse, v inspector.Verdict) *policies.AuthorizationInputs {
+
+	// planFor builds the per-tool-use AuthorizationInputs the policy
+	// consumes. Shared by Resolve (per-tool-use) and Prefetch
+	// (response-scoped batch). Pure: no decision-engine call, no side
+	// effects.
+	planFor := func(tu conversation.ToolUse) *policies.AuthorizationInputs {
 		hasPolicyConfig := auth.CandidateTasks != nil || auth.ToolRules != nil || auth.EgressRules != nil
 		readOnlyShell, sensitivePath := detectShellSpecials(tu, agent, auth)
 		shellPoll := shellpolicy.IsShellPollTool(tu.Name, tu.Input)
@@ -621,6 +803,71 @@ func buildAuthorizationResolver(
 			SlideTask:            slideTask,
 		}
 	}
+
+	// Per-response decision cache. Written by Prefetch (after its
+	// goroutines join), read by Resolve from the orchestrator's
+	// serial Evaluate loop. No concurrent access — Prefetch returns
+	// before the orchestrator starts iterating.
+	cache := make(map[string]runtimedecision.AuthorizationOutcome)
+
+	resolve := func(_ context.Context, tu conversation.ToolUse, _ inspector.Verdict) *policies.AuthorizationInputs {
+		inputs := planFor(tu)
+		if out, ok := cache[tu.ID]; ok {
+			if out.Err != nil {
+				inputs.PrecomputedErr = out.Err
+			} else {
+				dec := out.Decision
+				inputs.Precomputed = &dec
+			}
+		}
+		return inputs
+	}
+
+	prefetch := func(ctx context.Context, toolUses []conversation.ToolUse) {
+		// Gather the inputs EvaluateAuthorization would actually
+		// consume for each sibling: only tool_uses the inspector
+		// classifies as trigger-miss AND that have policy config or
+		// sensitive-path. Tool_uses outside that set short-circuit in
+		// AuthorizationPolicy.Evaluate without a decision-engine call,
+		// so batching them would be wasted work.
+		type pending struct {
+			tuID  string
+			input runtimedecision.AuthorizationInput
+		}
+		pendings := make([]pending, 0, len(toolUses))
+		for _, tu := range toolUses {
+			v := rewrite.Inspector.Inspect(ctx, inspector.ToolUse{
+				ID:    tu.ID,
+				Name:  tu.Name,
+				Input: tu.Input,
+			})
+			if v.Source != inspector.SourceTriggerMiss {
+				continue
+			}
+			inputs := planFor(tu)
+			if !inputs.HasPolicyConfig && !inputs.ShellSensitivePath {
+				continue
+			}
+			// Mirror AuthorizationPolicy.Evaluate's SkipIntentVerification
+			// assignment so the cached decision matches the inline call.
+			in := inputs.Input
+			in.SkipIntentVerification = inputs.ReadOnlyShellCommand
+			pendings = append(pendings, pending{tuID: tu.ID, input: in})
+		}
+		if len(pendings) == 0 {
+			return
+		}
+		batchInputs := make([]runtimedecision.AuthorizationInput, len(pendings))
+		for i, p := range pendings {
+			batchInputs[i] = p.input
+		}
+		outcomes := runtimedecision.EvaluateAuthorizationBatch(ctx, batchInputs)
+		for i, out := range outcomes {
+			cache[pendings[i].tuID] = out
+		}
+	}
+
+	return authorizationResolverBundle{Resolve: resolve, Prefetch: prefetch}
 }
 
 // detectShellSpecials derives read-only-shell and sensitive-path flags

--- a/internal/runtime/llmproxy/policies/authorization_policy.go
+++ b/internal/runtime/llmproxy/policies/authorization_policy.go
@@ -57,6 +57,20 @@ type AuthorizationInputs struct {
 	// matched task so the task's sliding lifetime bumps. The handler
 	// closes over the store and time.Now.
 	SlideTask func(ctx context.Context, task *store.Task)
+	// Precomputed, when non-nil, supplies the decision a caller already
+	// resolved (typically via a batched pre-pass over the response's
+	// sibling tool_uses, e.g. runtimedecision.EvaluateAuthorizationBatch).
+	// Evaluate uses it in place of an inline EvaluateAuthorization call —
+	// the side-effect dispatch (SlideTask / HoldHandler) still runs
+	// serially in the orchestrator's per-tool-use loop, so ordering is
+	// preserved.
+	//
+	// PrecomputedErr, when non-nil, surfaces a decision-engine error
+	// the pre-pass collected. It takes priority over Precomputed and
+	// yields the same Deny + "decision_error" fact path the inline
+	// call would have taken.
+	Precomputed    *runtimedecision.AuthorizationDecision
+	PrecomputedErr error
 }
 
 // AuthorizationHoldHandler is the typed interface PostprocessConfig
@@ -125,7 +139,18 @@ func (p *AuthorizationPolicy) Evaluate(ctx context.Context, _ pipeline.ReadOnlyR
 	}
 	input := in.Input
 	input.SkipIntentVerification = in.ReadOnlyShellCommand
-	dec, err := runtimedecision.EvaluateAuthorization(ctx, input)
+	var (
+		dec runtimedecision.AuthorizationDecision
+		err error
+	)
+	switch {
+	case in.PrecomputedErr != nil:
+		err = in.PrecomputedErr
+	case in.Precomputed != nil:
+		dec = *in.Precomputed
+	default:
+		dec, err = runtimedecision.EvaluateAuthorization(ctx, input)
+	}
 	if err != nil {
 		return pipeline.ToolUseVerdict{
 			Outcome: pipeline.OutcomeDeny,

--- a/internal/runtime/llmproxy/postproc/parallel_intent_verify_test.go
+++ b/internal/runtime/llmproxy/postproc/parallel_intent_verify_test.go
@@ -1,0 +1,278 @@
+package postproc
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy"
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/inspector"
+	runtimedecision "github.com/clawvisor/clawvisor/pkg/runtime/decision"
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+// blockingIntentVerifier blocks each Verify call until release is closed.
+// Tracks peak in-flight calls so the test can prove the proxy fans out
+// verifier calls in parallel rather than serializing them.
+type blockingIntentVerifier struct {
+	release    chan struct{}
+	inFlight   int32
+	peak       int32
+	totalCalls int32
+}
+
+func (b *blockingIntentVerifier) Verify(ctx context.Context, _ llmproxy.IntentVerifyRequest) (*llmproxy.IntentVerdict, error) {
+	atomic.AddInt32(&b.totalCalls, 1)
+	cur := atomic.AddInt32(&b.inFlight, 1)
+	for {
+		peak := atomic.LoadInt32(&b.peak)
+		if cur <= peak || atomic.CompareAndSwapInt32(&b.peak, peak, cur) {
+			break
+		}
+	}
+	defer atomic.AddInt32(&b.inFlight, -1)
+	select {
+	case <-b.release:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	return &llmproxy.IntentVerdict{Allow: true}, nil
+}
+
+// anthropicJSONWithParallelToolUses builds a response with N parallel
+// Write tool_uses, each writing to a distinct path. The trigger-miss
+// path (CandidateTasks → expected_tools matching) routes every one of
+// them through runtimedecision.EvaluateAuthorization with intent
+// verification on.
+func anthropicJSONWithParallelToolUses(n int) []byte {
+	type block struct {
+		Type  string          `json:"type"`
+		ID    string          `json:"id,omitempty"`
+		Name  string          `json:"name,omitempty"`
+		Input json.RawMessage `json:"input,omitempty"`
+		Text  string          `json:"text,omitempty"`
+	}
+	blocks := []block{{Type: "text", Text: "sure"}}
+	for i := 0; i < n; i++ {
+		path := "/tmp/hello_" + jsonIndex(i) + ".py"
+		input, _ := json.Marshal(map[string]string{
+			"file_path": path,
+			"content":   "print('hi')\n",
+		})
+		blocks = append(blocks, block{
+			Type:  "tool_use",
+			ID:    "toolu_" + jsonIndex(i),
+			Name:  "Write",
+			Input: input,
+		})
+	}
+	body, _ := json.Marshal(map[string]any{
+		"id":          "msg_1",
+		"type":        "message",
+		"role":        "assistant",
+		"model":       "claude-haiku-4-5",
+		"content":     blocks,
+		"stop_reason": "tool_use",
+	})
+	return body
+}
+
+func jsonIndex(i int) string {
+	// Two-digit zero-padded so tool_use IDs sort lexically. Enough room
+	// for the tool-use counts the test exercises.
+	return string(rune('0'+i/10)) + string(rune('0'+i%10))
+}
+
+// TestPostprocess_ParallelToolUsesBatchIntentVerify proves that when a
+// turn contains multiple parallel tool_uses that all route through
+// EvaluateAuthorization, the intent verifier fan-out happens in
+// parallel rather than serially. Without the batch pre-pass, the
+// verifier sees one in-flight call at a time; with the pre-pass, all
+// of them are in flight together.
+func TestPostprocess_ParallelToolUsesBatchIntentVerify(t *testing.T) {
+	const parallel = 4
+	body := anthropicJSONWithParallelToolUses(parallel)
+	req := httptest.NewRequest("POST", "/v1/messages", nil)
+	insp := inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{})
+	st, userID, agentID := seedPostprocessStore(t, "autovault_github_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
+
+	task := &store.Task{
+		ID:                     "task-parallel",
+		AgentID:                agentID,
+		Purpose:                "Create hello.py variants",
+		Status:                 "active",
+		IntentVerificationMode: "strict",
+		ExpectedUse:            "create hello.py files for testing",
+		ExpectedTools:          json.RawMessage(`[{"tool_name":"Write","why":"create hello.py files"}]`),
+	}
+
+	verifier := &blockingIntentVerifier{release: make(chan struct{})}
+
+	done := make(chan struct{})
+	go func() {
+		_ = Postprocess(req, body, "application/json", llmproxy.PostprocessConfig{
+			ToolUseEvaluatorFactory: pipelineFactory,
+			AgentContext: llmproxy.AgentContext{
+				AgentUserID: userID,
+				AgentID:     agentID,
+			},
+			AuthorizationContext: llmproxy.AuthorizationContext{
+				CandidateTasks: []*store.Task{task},
+				ToolRules:      []*store.RuntimePolicyRule{},
+				EgressRules:    []*store.RuntimePolicyRule{},
+				IntentVerifier: verifier,
+				Posture:        runtimedecision.PostureEnforce,
+			},
+			ApprovalContext: llmproxy.ApprovalContext{
+				PendingApprovals: llmproxy.NewMemoryPendingApprovalCache(time.Minute),
+			},
+			RewriteContext: llmproxy.RewriteContext{
+				Inspector:    insp,
+				RewriteOpts:  inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
+				CallerNonces: llmproxy.NewMemoryCallerNonceCache(time.Minute),
+				Store:        st,
+			},
+		})
+		close(done)
+	}()
+
+	// Wait until all parallel verifier calls are parked simultaneously.
+	// If batching regressed and the proxy serialized verifier calls, peak
+	// would stay at 1 and this loop would time out.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if atomic.LoadInt32(&verifier.peak) >= parallel {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	peak := atomic.LoadInt32(&verifier.peak)
+	close(verifier.release)
+	<-done
+
+	if peak < parallel {
+		t.Fatalf("peak in-flight verifier calls = %d, want >= %d (verifier fan-out is serial?)", peak, parallel)
+	}
+	if got := atomic.LoadInt32(&verifier.totalCalls); got != parallel {
+		t.Fatalf("verifier total calls = %d, want exactly %d (one per tool_use)", got, parallel)
+	}
+}
+
+// anthropicJSONWithParallelCredentialedToolUses builds a response with
+// N parallel WebFetch-style tool_uses, each carrying the autovault_github
+// placeholder so the inspector classifies them as credentialed API calls.
+// Each call targets a slightly different /repos/owner/repo-{i}/issues
+// path so they're distinct tool_uses but all match the same (service,
+// action) resolution.
+func anthropicJSONWithParallelCredentialedToolUses(n int, placeholder string) []byte {
+	type block struct {
+		Type  string          `json:"type"`
+		ID    string          `json:"id,omitempty"`
+		Name  string          `json:"name,omitempty"`
+		Input json.RawMessage `json:"input,omitempty"`
+		Text  string          `json:"text,omitempty"`
+	}
+	blocks := []block{{Type: "text", Text: "sure"}}
+	for i := 0; i < n; i++ {
+		input, _ := json.Marshal(map[string]any{
+			"url":     "https://api.github.com/repos/x/y-" + jsonIndex(i) + "/issues",
+			"method":  "POST",
+			"headers": map[string]string{"Authorization": "Bearer " + placeholder},
+		})
+		blocks = append(blocks, block{
+			Type:  "tool_use",
+			ID:    "toolu_" + jsonIndex(i),
+			Name:  "WebFetch",
+			Input: input,
+		})
+	}
+	body, _ := json.Marshal(map[string]any{
+		"id":          "msg_1",
+		"type":        "message",
+		"role":        "assistant",
+		"model":       "claude-haiku-4-5",
+		"content":     blocks,
+		"stop_reason": "tool_use",
+	})
+	return body
+}
+
+// TestPostprocess_ParallelCredentialedToolUsesBatchIntentVerify is the
+// credentialed-path counterpart to ParallelToolUsesBatchIntentVerify.
+// It proves the TaskScopeEvaluator (credentialed) path also batches
+// intent-verifier calls when a turn carries multiple parallel API
+// tool_uses that all route through runtimedecision.EvaluateAuthorization.
+func TestPostprocess_ParallelCredentialedToolUsesBatchIntentVerify(t *testing.T) {
+	const parallel = 4
+	placeholder := "autovault_github_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+	body := anthropicJSONWithParallelCredentialedToolUses(parallel, placeholder)
+	req := httptest.NewRequest("POST", "/v1/messages", nil)
+	insp := inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{})
+	st, userID, agentID := seedPostprocessStore(t, placeholder)
+
+	// Modern-path task: AuthorizedActions covers (github, create_issue)
+	// with strict verification so the verifier fires for every sibling.
+	task := &store.Task{
+		ID:      "task-credentialed-parallel",
+		AgentID: agentID,
+		Purpose: "create issues for bug-triage",
+		Status:  "active",
+		AuthorizedActions: []store.TaskAction{
+			{Service: "github", Action: "create_issue", Verification: "strict", ExpectedUse: "create bug-triage issues"},
+		},
+	}
+
+	verifier := &blockingIntentVerifier{release: make(chan struct{})}
+
+	done := make(chan struct{})
+	go func() {
+		_ = Postprocess(req, body, "application/json", llmproxy.PostprocessConfig{
+			ToolUseEvaluatorFactory: pipelineFactory,
+			AgentContext: llmproxy.AgentContext{
+				AgentUserID: userID,
+				AgentID:     agentID,
+			},
+			AuthorizationContext: llmproxy.AuthorizationContext{
+				Catalog: stubCatalog{resolve: func(host, method, path string) (llmproxy.ResolvedAction, bool) {
+					return llmproxy.ResolvedAction{ServiceID: "github", ActionID: "create_issue"}, true
+				}},
+				CandidateTasks: []*store.Task{task},
+				ToolRules:      []*store.RuntimePolicyRule{},
+				EgressRules:    []*store.RuntimePolicyRule{},
+				IntentVerifier: verifier,
+				Posture:        runtimedecision.PostureEnforce,
+			},
+			ApprovalContext: llmproxy.ApprovalContext{
+				PendingApprovals: llmproxy.NewMemoryPendingApprovalCache(time.Minute),
+			},
+			RewriteContext: llmproxy.RewriteContext{
+				Inspector:    insp,
+				RewriteOpts:  inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
+				CallerNonces: llmproxy.NewMemoryCallerNonceCache(time.Minute),
+				Store:        st,
+			},
+		})
+		close(done)
+	}()
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if atomic.LoadInt32(&verifier.peak) >= parallel {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	peak := atomic.LoadInt32(&verifier.peak)
+	close(verifier.release)
+	<-done
+
+	if peak < parallel {
+		t.Fatalf("credentialed peak in-flight verifier calls = %d, want >= %d (verifier fan-out is serial?)", peak, parallel)
+	}
+	if got := atomic.LoadInt32(&verifier.totalCalls); got != parallel {
+		t.Fatalf("credentialed verifier total calls = %d, want exactly %d (one per tool_use)", got, parallel)
+	}
+}

--- a/pkg/runtime/decision/batch.go
+++ b/pkg/runtime/decision/batch.go
@@ -1,0 +1,52 @@
+package decision
+
+import (
+	"context"
+	"sync"
+)
+
+// AuthorizationOutcome pairs an EvaluateAuthorization result with its
+// error. EvaluateAuthorizationBatch returns one outcome per input, in
+// the same order.
+type AuthorizationOutcome struct {
+	Decision AuthorizationDecision
+	Err      error
+}
+
+// EvaluateAuthorizationBatch runs EvaluateAuthorization for each input
+// concurrently. Each input's IntentVerifier round-trip — the expensive
+// LLM call — overlaps with its siblings'; the rest of the evaluation
+// (rule eval, task classification) is pure-function and safe to run
+// concurrently on independent inputs.
+//
+// Errors are per-input — a failure on one input does not affect any
+// other. The returned slice is index-aligned with inputs. Callers that
+// need to react to errors should inspect each outcome.Err.
+//
+// Singleton batches degenerate to a direct EvaluateAuthorization call
+// (no goroutine cost). An empty input slice returns an empty slice.
+//
+// The batch does not impose a concurrency cap. Verifier implementations
+// that need rate limiting should enforce it themselves; that constraint
+// is the verifier's, not the decision engine's.
+func EvaluateAuthorizationBatch(ctx context.Context, inputs []AuthorizationInput) []AuthorizationOutcome {
+	outcomes := make([]AuthorizationOutcome, len(inputs))
+	if len(inputs) == 0 {
+		return outcomes
+	}
+	if len(inputs) == 1 {
+		outcomes[0].Decision, outcomes[0].Err = EvaluateAuthorization(ctx, inputs[0])
+		return outcomes
+	}
+	var wg sync.WaitGroup
+	wg.Add(len(inputs))
+	for i := range inputs {
+		i := i
+		go func() {
+			defer wg.Done()
+			outcomes[i].Decision, outcomes[i].Err = EvaluateAuthorization(ctx, inputs[i])
+		}()
+	}
+	wg.Wait()
+	return outcomes
+}

--- a/pkg/runtime/decision/batch_test.go
+++ b/pkg/runtime/decision/batch_test.go
@@ -1,0 +1,183 @@
+package decision
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+// blockingIntentVerifier holds Verify until release is closed so the
+// test can observe concurrent goroutines parked inside the verifier
+// (proof that fan-out is real and not serial).
+type blockingIntentVerifier struct {
+	release   chan struct{}
+	concurrent int32
+	peak       int32
+	verdict    *IntentVerdict
+}
+
+func (b *blockingIntentVerifier) Verify(ctx context.Context, _ IntentVerifyRequest) (*IntentVerdict, error) {
+	cur := atomic.AddInt32(&b.concurrent, 1)
+	for {
+		peak := atomic.LoadInt32(&b.peak)
+		if cur <= peak || atomic.CompareAndSwapInt32(&b.peak, peak, cur) {
+			break
+		}
+	}
+	defer atomic.AddInt32(&b.concurrent, -1)
+	select {
+	case <-b.release:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	return b.verdict, nil
+}
+
+func TestEvaluateAuthorizationBatch_ParallelizesVerifierCalls(t *testing.T) {
+	agentID := "agent-1"
+	verifier := &blockingIntentVerifier{
+		release: make(chan struct{}),
+		verdict: &IntentVerdict{Allow: true, Explanation: "fits task"},
+	}
+	task := taskWithExpectedTool("task-1", agentID, "exec_command", "read repo files")
+
+	mkInput := func(id string) AuthorizationInput {
+		return AuthorizationInput{
+			ToolUse:        conversation.ToolUse{ID: id, Name: "exec_command", Input: []byte(`{"cmd":"cat README.md"}`)},
+			AgentID:        agentID,
+			CandidateTasks: []*store.Task{task},
+			IntentVerifier: verifier,
+		}
+	}
+
+	inputs := []AuthorizationInput{mkInput("toolu_1"), mkInput("toolu_2"), mkInput("toolu_3")}
+
+	done := make(chan []AuthorizationOutcome, 1)
+	go func() {
+		done <- EvaluateAuthorizationBatch(context.Background(), inputs)
+	}()
+
+	// Wait until all three verifier calls are parked concurrently. If
+	// fan-out regressed to serial, peak would never exceed 1 and this
+	// loop would time out.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if atomic.LoadInt32(&verifier.peak) == 3 {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	if got := atomic.LoadInt32(&verifier.peak); got != 3 {
+		close(verifier.release)
+		<-done
+		t.Fatalf("peak concurrent verifier calls = %d, want 3", got)
+	}
+
+	close(verifier.release)
+	outcomes := <-done
+
+	if len(outcomes) != 3 {
+		t.Fatalf("outcomes len = %d, want 3", len(outcomes))
+	}
+	for i, o := range outcomes {
+		if o.Err != nil {
+			t.Fatalf("outcome[%d] err = %v, want nil", i, o.Err)
+		}
+		if o.Decision.Kind != VerdictAllow || o.Decision.Source != SourceTaskScope {
+			t.Fatalf("outcome[%d] decision = %+v, want task-scope allow", i, o.Decision)
+		}
+	}
+}
+
+func TestEvaluateAuthorizationBatch_EmptyInputs(t *testing.T) {
+	outcomes := EvaluateAuthorizationBatch(context.Background(), nil)
+	if len(outcomes) != 0 {
+		t.Fatalf("outcomes len = %d, want 0", len(outcomes))
+	}
+}
+
+func TestEvaluateAuthorizationBatch_SingletonDoesNotSpawnGoroutine(t *testing.T) {
+	// Smoke test the singleton fast-path: identical result shape to the
+	// batched path. Concurrency itself isn't observable; we just check
+	// the verdict matches a direct EvaluateAuthorization.
+	agentID := "agent-1"
+	toolAllow := rule("tool-allow", "tool", "allow", &agentID)
+	toolAllow.ToolName = "Bash"
+	input := AuthorizationInput{
+		ToolUse:   toolUse("Bash", nil),
+		AgentID:   agentID,
+		ToolRules: []*store.RuntimePolicyRule{toolAllow},
+	}
+
+	outcomes := EvaluateAuthorizationBatch(context.Background(), []AuthorizationInput{input})
+	if len(outcomes) != 1 {
+		t.Fatalf("outcomes len = %d, want 1", len(outcomes))
+	}
+	if outcomes[0].Err != nil {
+		t.Fatalf("outcome err = %v, want nil", outcomes[0].Err)
+	}
+	if outcomes[0].Decision.Kind != VerdictAllow || outcomes[0].Decision.Source != SourceRuleAllow {
+		t.Fatalf("decision = %+v, want rule allow", outcomes[0].Decision)
+	}
+}
+
+// erroringIntentVerifier returns an error for a specific tool_use ID
+// so the test can verify that errors are isolated to their input.
+type erroringIntentVerifier struct {
+	failTaskID string
+	err        error
+	verdict    *IntentVerdict
+}
+
+func (e *erroringIntentVerifier) Verify(_ context.Context, req IntentVerifyRequest) (*IntentVerdict, error) {
+	if req.TaskID == e.failTaskID {
+		return nil, e.err
+	}
+	return e.verdict, nil
+}
+
+func TestEvaluateAuthorizationBatch_PerInputErrorIsolation(t *testing.T) {
+	agentID := "agent-1"
+	taskA := taskWithExpectedTool("task-A", agentID, "exec_command", "read repo files")
+	taskB := taskWithExpectedTool("task-B", agentID, "exec_command", "read repo files")
+	wantErr := errors.New("verifier exploded")
+	verifier := &erroringIntentVerifier{
+		failTaskID: "task-A",
+		err:        wantErr,
+		verdict:    &IntentVerdict{Allow: true, Explanation: "ok"},
+	}
+
+	inputs := []AuthorizationInput{
+		{
+			ToolUse:        conversation.ToolUse{ID: "toolu_A", Name: "exec_command", Input: []byte(`{"cmd":"cat README.md"}`)},
+			AgentID:        agentID,
+			CandidateTasks: []*store.Task{taskA},
+			IntentVerifier: verifier,
+		},
+		{
+			ToolUse:        conversation.ToolUse{ID: "toolu_B", Name: "exec_command", Input: []byte(`{"cmd":"cat README.md"}`)},
+			AgentID:        agentID,
+			CandidateTasks: []*store.Task{taskB},
+			IntentVerifier: verifier,
+		},
+	}
+
+	outcomes := EvaluateAuthorizationBatch(context.Background(), inputs)
+	if len(outcomes) != 2 {
+		t.Fatalf("outcomes len = %d, want 2", len(outcomes))
+	}
+	if !errors.Is(outcomes[0].Err, wantErr) {
+		t.Fatalf("outcomes[0].Err = %v, want %v", outcomes[0].Err, wantErr)
+	}
+	if outcomes[1].Err != nil {
+		t.Fatalf("outcomes[1].Err = %v, want nil (sibling shouldn't be poisoned)", outcomes[1].Err)
+	}
+	if outcomes[1].Decision.Kind != VerdictAllow {
+		t.Fatalf("outcomes[1].Decision = %+v, want allow", outcomes[1].Decision)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `EvaluateAuthorizationBatch` to the decision engine: fans out per-input `EvaluateAuthorization` calls so the intent verifier's LLM round-trips overlap instead of running serially. A turn with N parallel tool_uses now pays one verifier wall-clock latency per path, not N.
- Both authorization paths in the lite-proxy consume it via a per-response prefetch on their resolver bundle. Trigger-miss (`AuthorizationPolicy`) reads cached decisions through a new additive `Precomputed` field on `AuthorizationInputs`; credentialed (`TaskScopeEvaluator`) reads them through a parallel cache inside `buildCredentialedTaskScope`. Side effects (`PendingApprovals.Hold`, audit emission, `SlideTaskExpiry`) still run serially in the orchestrator's existing per-tool-use loop so approval-hold eviction ordering and audit ordering are unchanged.
- The two prefetches run sequentially to avoid concurrent access to the unsynchronized `Inspector` — only verifier calls (already a documented concurrency-safe contract) fan out.

## Test plan
- [x] New decision-engine tests cover parallel fan-out (blocking verifier reaching peak=N), empty input, and per-input error isolation
- [x] New `postproc` end-to-end tests cover both authorization paths: 4 parallel tool_uses with a blocking verifier, assert peak in-flight = 4 and total calls = 4
- [x] Regression sanity check: temporarily neutering each cache write makes the corresponding parallelism test fail with "peak = 1, want 4"
- [x] Full `-race` sweep across `internal/runtime/llmproxy/...`, `internal/api/...`, `pkg/runtime/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)