### PR TITLE
feat(llmproxy): scaffold Vertex/Azure/Bedrock upstream flavors

### DIFF
--- a/internal/runtime/llmproxy/forward.go
+++ b/internal/runtime/llmproxy/forward.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/upstreamflavor"
 	"github.com/clawvisor/clawvisor/pkg/vault"
 )
 
@@ -30,12 +31,21 @@ var DefaultUpstream = UpstreamSelector{
 }
 
 // UpstreamSelector resolves a (provider, path) pair to a concrete upstream
-// URL. Configurable to point staging deployments at non-prod hosts and to
-// support BYO Bedrock/Vertex/Azure endpoints in future phases.
+// URL. Configurable to point staging deployments at non-prod hosts.
+//
+// When AnthropicFlavor is non-nil, Anthropic-shaped requests are
+// rewritten by the flavor adapter (Vertex AI / Azure AI Foundry / AWS
+// Bedrock) instead of being forwarded to AnthropicBaseURL. OpenAI and
+// Google traffic is unaffected.
 type UpstreamSelector struct {
 	AnthropicBaseURL string
 	OpenAIBaseURL    string
 	GoogleBaseURL    string
+
+	// AnthropicFlavor, when non-nil, replaces native-Anthropic
+	// forwarding with a deployment-specific adapter. See the
+	// upstreamflavor package for available implementations.
+	AnthropicFlavor upstreamflavor.Flavor
 }
 
 // URL returns the upstream URL the lite-proxy should forward to for a given
@@ -150,6 +160,13 @@ func (f *Forwarder) Forward(ctx context.Context, userID, agentID string, provide
 		return nil, errors.New("llmproxy: inbound request is nil")
 	}
 
+	// Flavor dispatch: when a non-native Anthropic deployment is
+	// configured, the flavor adapter owns URL/body/auth and the rest
+	// of the native path is bypassed.
+	if provider == conversation.ProviderAnthropic && f.Upstream.AnthropicFlavor != nil {
+		return f.forwardFlavor(ctx, userID, agentID, f.Upstream.AnthropicFlavor, inbound, body)
+	}
+
 	upstreamPath := ProviderPath(provider, inbound.URL.Path)
 	upstreamURL, err := f.Upstream.URL(provider, upstreamPath)
 	if err != nil {
@@ -213,6 +230,88 @@ func (f *Forwarder) Forward(ctx context.Context, userID, agentID string, provide
 	return f.Client.Do(req)
 }
 
+// forwardFlavor handles Anthropic-shaped requests addressed to a
+// non-native deployment (Vertex AI, Azure AI Foundry, AWS Bedrock).
+// The flavor adapter rewrites URL, body, and auth; everything else
+// (header copy, identity encoding, header sanitization) mirrors the
+// native path so streaming + postprocess behavior is unchanged.
+func (f *Forwarder) forwardFlavor(ctx context.Context, userID, agentID string, flavor upstreamflavor.Flavor, inbound *http.Request, body []byte) (*http.Response, error) {
+	upstreamPath := ProviderPath(conversation.ProviderAnthropic, inbound.URL.Path)
+
+	model, err := upstreamflavor.ExtractModel(body)
+	if err != nil {
+		return nil, fmt.Errorf("llmproxy: flavor %s: %w", flavor.Name(), err)
+	}
+
+	upstreamURL, err := flavor.BuildURL(upstreamPath, model)
+	if err != nil {
+		return nil, fmt.Errorf("llmproxy: flavor %s build URL: %w", flavor.Name(), err)
+	}
+	// Preserve any inbound query string the client may have sent
+	// (e.g. ?beta=true). The flavor's own query (api-version for
+	// Azure) takes precedence when keys collide.
+	if inbound.URL.RawQuery != "" {
+		upstreamURL = mergeQuery(upstreamURL, inbound.URL.RawQuery)
+	}
+
+	newBody, err := flavor.TransformBody(body)
+	if err != nil {
+		return nil, fmt.Errorf("llmproxy: flavor %s transform body: %w", flavor.Name(), err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, inbound.Method, upstreamURL.String(), bytes.NewReader(newBody))
+	if err != nil {
+		return nil, fmt.Errorf("llmproxy: flavor %s build upstream request: %w", flavor.Name(), err)
+	}
+	copyForwardableHeaders(req.Header, inbound.Header)
+	req.Header.Set("Host", upstreamURL.Host)
+	req.Host = upstreamURL.Host
+	req.Header.Set("Accept-Encoding", "identity")
+
+	if PassthroughUpstreamAuth(ctx) {
+		if auth := passthroughBearerAuthorization(inbound); auth != "" {
+			req.Header.Set("Authorization", auth)
+			if err := flavor.InjectAuth(req, nil); err != nil {
+				return nil, fmt.Errorf("llmproxy: flavor %s passthrough auth: %w", flavor.Name(), err)
+			}
+			return f.Client.Do(req)
+		}
+	}
+
+	serviceID := flavor.VaultServiceID()
+	if serviceID == "" {
+		return nil, fmt.Errorf("llmproxy: flavor %s is passthrough-only but inbound request has no passthrough Authorization", flavor.Name())
+	}
+	keyBytes, _, err := f.lookupVaultKeyForService(ctx, userID, agentID, serviceID)
+	if err != nil {
+		return nil, err
+	}
+	defer zeroBytes(keyBytes)
+
+	if err := flavor.InjectAuth(req, keyBytes); err != nil {
+		return nil, fmt.Errorf("llmproxy: flavor %s auth: %w", flavor.Name(), err)
+	}
+	return f.Client.Do(req)
+}
+
+// mergeQuery merges an inbound RawQuery into u, with u's existing keys
+// taking precedence on collision.
+func mergeQuery(u *url.URL, inboundRaw string) *url.URL {
+	inbound, err := url.ParseQuery(inboundRaw)
+	if err != nil {
+		return u
+	}
+	existing := u.Query()
+	for k, vs := range inbound {
+		if _, exists := existing[k]; exists {
+			continue
+		}
+		existing[k] = vs
+	}
+	u.RawQuery = existing.Encode()
+	return u
+}
+
 // lookupVaultKey resolves the upstream API key with agent-scoped-first
 // fallback to user-scoped. Returns (key bytes, the serviceID actually
 // used, error). The serviceID is useful for audit so the row records
@@ -242,6 +341,34 @@ func (f *Forwarder) lookupVaultKey(ctx context.Context, userID, agentID string, 
 		return nil, userServiceID, fmt.Errorf("llmproxy: vault get: %w", err)
 	}
 	return key, userServiceID, nil
+}
+
+// lookupVaultKeyForService is the flavor-driven analogue of lookupVaultKey:
+// the caller supplies the bare service ID (e.g. "vertex", "azure",
+// "bedrock") instead of a Provider enum. Same agent-scoped → user-scoped
+// fallback semantics.
+func (f *Forwarder) lookupVaultKeyForService(ctx context.Context, userID, agentID, serviceID string) ([]byte, string, error) {
+	if serviceID == "" {
+		return nil, "", errors.New("llmproxy: empty serviceID")
+	}
+	if agentID != "" {
+		scoped := "agent:" + agentID + ":" + serviceID
+		key, err := f.Vault.Get(ctx, userID, scoped)
+		if err == nil {
+			return key, scoped, nil
+		}
+		if !errors.Is(err, vault.ErrNotFound) {
+			return nil, "", fmt.Errorf("llmproxy: vault get agent-scoped: %w", err)
+		}
+	}
+	key, err := f.Vault.Get(ctx, userID, serviceID)
+	if err != nil {
+		if errors.Is(err, vault.ErrNotFound) {
+			return nil, serviceID, fmt.Errorf("llmproxy: upstream credential not found in vault for service %q: %w", serviceID, vault.ErrNotFound)
+		}
+		return nil, serviceID, fmt.Errorf("llmproxy: vault get: %w", err)
+	}
+	return key, serviceID, nil
 }
 
 // injectUpstreamAuth writes the upstream-specific auth header using the raw

--- a/internal/runtime/llmproxy/forward_flavor_test.go
+++ b/internal/runtime/llmproxy/forward_flavor_test.go
@@ -1,0 +1,217 @@
+package llmproxy
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/upstreamflavor"
+)
+
+// simpleFlavor implements upstreamflavor.Flavor via closures so each
+// test can configure the three hooks independently.
+type simpleFlavor struct {
+	name           string
+	vaultServiceID string
+	buildURL       func(path, model string) (*url.URL, error)
+	transformBody  func([]byte) ([]byte, error)
+	injectAuth     func(*http.Request, []byte) error
+
+	// recorded
+	gotModel string
+}
+
+var _ upstreamflavor.Flavor = (*simpleFlavor)(nil)
+
+func (s *simpleFlavor) Name() string { return s.name }
+func (s *simpleFlavor) BuildURL(path, model string) (*url.URL, error) {
+	s.gotModel = model
+	return s.buildURL(path, model)
+}
+func (s *simpleFlavor) TransformBody(b []byte) ([]byte, error) { return s.transformBody(b) }
+func (s *simpleFlavor) InjectAuth(req *http.Request, c []byte) error {
+	return s.injectAuth(req, c)
+}
+func (s *simpleFlavor) VaultServiceID() string { return s.vaultServiceID }
+
+func TestForward_FlavorDispatch(t *testing.T) {
+	t.Parallel()
+
+	var seenAuth, seenAPIKey, seenPath, seenAnthropicVersion string
+	var seenBody []byte
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenAuth = r.Header.Get("Authorization")
+		seenAPIKey = r.Header.Get("api-key")
+		seenAnthropicVersion = r.Header.Get("anthropic-version")
+		seenPath = r.URL.Path
+		seenBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_x"}`))
+	}))
+	defer upstream.Close()
+
+	flavor := &simpleFlavor{
+		name:           "fake",
+		vaultServiceID: "fake",
+		buildURL: func(path, model string) (*url.URL, error) {
+			return url.Parse(upstream.URL + path)
+		},
+		transformBody: func(b []byte) ([]byte, error) {
+			// Strip model + add a sentinel so we can verify the
+			// transformed body reached the upstream.
+			out := bytes.ReplaceAll(b, []byte(`"model":"claude-opus-4-7",`), nil)
+			out = bytes.ReplaceAll(out, []byte(`{`), []byte(`{"transformed":true,`))
+			return out, nil
+		},
+		injectAuth: func(req *http.Request, creds []byte) error {
+			req.Header.Del("anthropic-version")
+			req.Header.Set("api-key", string(creds))
+			req.Header.Del("Authorization")
+			return nil
+		},
+	}
+
+	v := &stubVault{}
+	_ = v.Set(context.Background(), "user1", "fake", []byte("vault-stored-fake-key"))
+
+	f := NewForwarder(v)
+	f.Upstream = UpstreamSelector{
+		AnthropicBaseURL: "https://should-not-be-called.example",
+		AnthropicFlavor:  flavor,
+	}
+
+	body := []byte(`{"model":"claude-opus-4-7","max_tokens":1024}`)
+	inbound := httptest.NewRequest(http.MethodPost, "/api/v1/messages", bytes.NewReader(body))
+	inbound.Header.Set("Authorization", "Bearer cvis_xxx")
+	inbound.Header.Set("anthropic-version", "2023-06-01")
+
+	resp, err := f.Forward(context.Background(), "user1", "", conversation.ProviderAnthropic, inbound, body)
+	if err != nil {
+		t.Fatalf("Forward: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if seenPath != "/v1/messages" {
+		t.Errorf("upstream path=%q want /v1/messages", seenPath)
+	}
+	if seenAPIKey != "vault-stored-fake-key" {
+		t.Errorf("api-key=%q want vault-stored-fake-key", seenAPIKey)
+	}
+	if seenAuth != "" {
+		t.Errorf("Authorization should have been cleared; got %q", seenAuth)
+	}
+	if seenAnthropicVersion != "" {
+		t.Errorf("anthropic-version header should be stripped by flavor; got %q", seenAnthropicVersion)
+	}
+	if !bytes.Contains(seenBody, []byte(`"transformed":true`)) {
+		t.Errorf("body not transformed by flavor: %s", seenBody)
+	}
+	if bytes.Contains(seenBody, []byte(`"model":"claude-opus-4-7"`)) {
+		t.Errorf("model field leaked through transform: %s", seenBody)
+	}
+	if flavor.gotModel != "claude-opus-4-7" {
+		t.Errorf("model passed to BuildURL=%q", flavor.gotModel)
+	}
+}
+
+func TestForward_FlavorRespectsPassthroughMode(t *testing.T) {
+	t.Parallel()
+
+	var seenAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer upstream.Close()
+
+	flavor := &simpleFlavor{
+		name: "fake",
+		buildURL: func(path, model string) (*url.URL, error) {
+			return url.Parse(upstream.URL + path)
+		},
+		transformBody: func(b []byte) ([]byte, error) { return b, nil },
+		// Passthrough: don't touch Authorization.
+		injectAuth: func(req *http.Request, _ []byte) error { return nil },
+	}
+
+	v := &stubVault{}
+	f := NewForwarder(v)
+	f.Upstream = UpstreamSelector{AnthropicFlavor: flavor}
+
+	inbound := httptest.NewRequest(http.MethodPost, "/api/v1/messages",
+		bytes.NewReader([]byte(`{"model":"m"}`)))
+	inbound.Header.Set("Authorization", "Bearer passthrough-vertex-token")
+
+	ctx := WithPassthroughUpstreamAuth(context.Background())
+	resp, err := f.Forward(ctx, "user1", "", conversation.ProviderAnthropic, inbound,
+		[]byte(`{"model":"m"}`))
+	if err != nil {
+		t.Fatalf("Forward: %v", err)
+	}
+	defer resp.Body.Close()
+	if seenAuth != "Bearer passthrough-vertex-token" {
+		t.Errorf("upstream Authorization=%q want passthrough", seenAuth)
+	}
+}
+
+func TestForward_NativeAnthropicUnchangedWhenFlavorNil(t *testing.T) {
+	t.Parallel()
+	// With AnthropicFlavor nil, the pre-existing native path is taken.
+	v := &stubVault{}
+	_ = v.Set(context.Background(), "u", "anthropic", []byte("sk-ant-real"))
+
+	var seenAPIKey string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenAPIKey = r.Header.Get("x-api-key")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	f := NewForwarder(v)
+	f.Upstream = UpstreamSelector{AnthropicBaseURL: upstream.URL}
+
+	inbound := httptest.NewRequest(http.MethodPost, "/api/v1/messages",
+		bytes.NewReader([]byte(`{}`)))
+	resp, err := f.Forward(context.Background(), "u", "", conversation.ProviderAnthropic, inbound, []byte(`{}`))
+	if err != nil {
+		t.Fatalf("Forward: %v", err)
+	}
+	defer resp.Body.Close()
+	if seenAPIKey != "sk-ant-real" {
+		t.Errorf("native path broken: x-api-key=%q", seenAPIKey)
+	}
+}
+
+func TestForward_FlavorPassthroughOnlyRequiresAuth(t *testing.T) {
+	t.Parallel()
+	// Flavor with empty VaultServiceID and no inbound passthrough
+	// bearer should return a clear configuration error rather than
+	// silently calling the upstream with no auth.
+	flavor := &simpleFlavor{
+		name:           "passthrough-only",
+		vaultServiceID: "", // signals passthrough-only
+		buildURL: func(path, model string) (*url.URL, error) {
+			return url.Parse("https://nowhere.example" + path)
+		},
+		transformBody: func(b []byte) ([]byte, error) { return b, nil },
+		injectAuth:    func(*http.Request, []byte) error { return nil },
+	}
+	v := &stubVault{}
+	f := NewForwarder(v)
+	f.Upstream = UpstreamSelector{AnthropicFlavor: flavor}
+
+	inbound := httptest.NewRequest(http.MethodPost, "/api/v1/messages",
+		bytes.NewReader([]byte(`{"model":"m"}`)))
+	// No Authorization on inbound, no PassthroughUpstreamAuth context.
+
+	if _, err := f.Forward(context.Background(), "u", "", conversation.ProviderAnthropic, inbound,
+		[]byte(`{"model":"m"}`)); err == nil {
+		t.Fatal("expected error for passthrough-only flavor with no inbound bearer")
+	}
+}

--- a/internal/runtime/llmproxy/upstreamflavor/azure.go
+++ b/internal/runtime/llmproxy/upstreamflavor/azure.go
@@ -1,0 +1,109 @@
+package upstreamflavor
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// AzureConfig parameterizes an AzureFlavor instance.
+//
+// ResourceName is the Azure AI Foundry account name (the leading subdomain
+// of {ResourceName}.services.ai.azure.com).
+//
+// APIVersion is the Azure API version query parameter required on every
+// request. It is operator-managed because Azure publishes new versions
+// quarterly and the proxy should not silently pin a value that the
+// resource may not support.
+//
+// PathPrefix overrides the default "/anthropic" path prefix used by
+// Foundry's Anthropic surface. Leave empty for the standard layout.
+type AzureConfig struct {
+	ResourceName string
+	APIVersion   string
+	PathPrefix   string
+}
+
+// NewAzure returns a Flavor that targets Azure AI Foundry's hosted
+// Anthropic API. The Foundry surface mirrors Anthropic's request body
+// and SSE format; the differences are URL, auth header, and the
+// mandatory api-version query parameter.
+func NewAzure(cfg AzureConfig) (Flavor, error) {
+	if strings.TrimSpace(cfg.ResourceName) == "" {
+		return nil, errors.New("upstreamflavor: azure: ResourceName required")
+	}
+	if strings.TrimSpace(cfg.APIVersion) == "" {
+		return nil, errors.New("upstreamflavor: azure: APIVersion required")
+	}
+	prefix := cfg.PathPrefix
+	if prefix == "" {
+		prefix = "/anthropic"
+	}
+	if !strings.HasPrefix(prefix, "/") {
+		prefix = "/" + prefix
+	}
+	prefix = strings.TrimRight(prefix, "/")
+	return &azureFlavor{cfg: cfg, prefix: prefix}, nil
+}
+
+type azureFlavor struct {
+	cfg    AzureConfig
+	prefix string
+}
+
+func (a *azureFlavor) Name() string { return "azure" }
+
+func (a *azureFlavor) BuildURL(inboundPath, _ string) (*url.URL, error) {
+	switch inboundPath {
+	case "/v1/messages", "/v1/messages/count_tokens":
+		// Both routes exist on Foundry's Anthropic surface.
+	default:
+		return nil, fmt.Errorf("upstreamflavor: azure: unsupported inbound path %q", inboundPath)
+	}
+	host := fmt.Sprintf("%s.services.ai.azure.com", a.cfg.ResourceName)
+	q := url.Values{}
+	q.Set("api-version", a.cfg.APIVersion)
+	return &url.URL{
+		Scheme:   "https",
+		Host:     host,
+		Path:     a.prefix + inboundPath,
+		RawQuery: q.Encode(),
+	}, nil
+}
+
+// TransformBody is a pass-through: Azure Foundry accepts the native
+// Anthropic Messages API body without modification.
+func (a *azureFlavor) TransformBody(body []byte) ([]byte, error) {
+	return body, nil
+}
+
+// InjectAuth sets the api-key header (Azure's convention — distinct
+// from Anthropic's x-api-key) using the raw credential bytes from
+// vault. In passthrough mode (empty credBytes), the caller's
+// Authorization header is forwarded unchanged — Azure accepts an
+// Azure AD bearer token as an alternative to api-key.
+func (a *azureFlavor) InjectAuth(req *http.Request, credBytes []byte) error {
+	// Azure does not honor the anthropic-version header — the
+	// equivalent is the api-version query parameter, set in BuildURL.
+	req.Header.Del("anthropic-version")
+	req.Header.Del("x-api-key")
+
+	if len(credBytes) == 0 {
+		return nil
+	}
+	key := strings.TrimSpace(string(credBytes))
+	if key == "" {
+		return errors.New("upstreamflavor: azure: empty api key")
+	}
+	if strings.ContainsAny(key, "\r\n\x00") {
+		return errors.New("upstreamflavor: azure: api key contains illegal control bytes")
+	}
+	req.Header.Set("api-key", key)
+	req.Header.Del("Authorization")
+	return nil
+}
+
+// VaultServiceID returns "azure" for vault-stored API keys.
+func (a *azureFlavor) VaultServiceID() string { return "azure" }

--- a/internal/runtime/llmproxy/upstreamflavor/azure_test.go
+++ b/internal/runtime/llmproxy/upstreamflavor/azure_test.go
@@ -1,0 +1,93 @@
+package upstreamflavor
+
+import (
+	"bytes"
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+func TestAzure_BuildURL(t *testing.T) {
+	t.Parallel()
+	a, err := NewAzure(AzureConfig{ResourceName: "myrsc", APIVersion: "2026-05-01"})
+	if err != nil {
+		t.Fatalf("NewAzure: %v", err)
+	}
+	u, err := a.BuildURL("/v1/messages", "claude-opus-4-7")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if u.Host != "myrsc.services.ai.azure.com" {
+		t.Errorf("Host=%s", u.Host)
+	}
+	if u.Path != "/anthropic/v1/messages" {
+		t.Errorf("Path=%s", u.Path)
+	}
+	q, _ := url.ParseQuery(u.RawQuery)
+	if q.Get("api-version") != "2026-05-01" {
+		t.Errorf("api-version=%s", q.Get("api-version"))
+	}
+}
+
+func TestAzure_BuildURL_CountTokensSupported(t *testing.T) {
+	t.Parallel()
+	a, _ := NewAzure(AzureConfig{ResourceName: "r", APIVersion: "v"})
+	if _, err := a.BuildURL("/v1/messages/count_tokens", ""); err != nil {
+		t.Errorf("count_tokens should be supported: %v", err)
+	}
+}
+
+func TestAzure_BuildURL_CustomPathPrefix(t *testing.T) {
+	t.Parallel()
+	a, _ := NewAzure(AzureConfig{ResourceName: "r", APIVersion: "v", PathPrefix: "/custom/anthropic"})
+	u, _ := a.BuildURL("/v1/messages", "")
+	if u.Path != "/custom/anthropic/v1/messages" {
+		t.Errorf("Path=%s", u.Path)
+	}
+}
+
+func TestAzure_TransformBody_Passthrough(t *testing.T) {
+	t.Parallel()
+	a, _ := NewAzure(AzureConfig{ResourceName: "r", APIVersion: "v"})
+	in := []byte(`{"model":"claude","messages":[]}`)
+	out, err := a.TransformBody(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(in, out) {
+		t.Errorf("body should be unchanged. got %s", out)
+	}
+}
+
+func TestAzure_InjectAuth_VaultMode(t *testing.T) {
+	t.Parallel()
+	a, _ := NewAzure(AzureConfig{ResourceName: "r", APIVersion: "v"})
+	req, _ := http.NewRequest(http.MethodPost, "https://example/", nil)
+	req.Header.Set("Authorization", "Bearer cvis_xxx")
+	req.Header.Set("anthropic-version", "2023-06-01")
+	if err := a.InjectAuth(req, []byte("azure-key-xyz")); err != nil {
+		t.Fatal(err)
+	}
+	if got := req.Header.Get("api-key"); got != "azure-key-xyz" {
+		t.Errorf("api-key=%q", got)
+	}
+	if req.Header.Get("Authorization") != "" {
+		t.Error("Authorization should be cleared when api-key is set")
+	}
+	if req.Header.Get("anthropic-version") != "" {
+		t.Error("anthropic-version should be stripped")
+	}
+}
+
+func TestAzure_InjectAuth_PassthroughAAD(t *testing.T) {
+	t.Parallel()
+	a, _ := NewAzure(AzureConfig{ResourceName: "r", APIVersion: "v"})
+	req, _ := http.NewRequest(http.MethodPost, "https://example/", nil)
+	req.Header.Set("Authorization", "Bearer aad-token")
+	if err := a.InjectAuth(req, nil); err != nil {
+		t.Fatal(err)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer aad-token" {
+		t.Errorf("passthrough AAD bearer mangled: %q", got)
+	}
+}

--- a/internal/runtime/llmproxy/upstreamflavor/bedrock.go
+++ b/internal/runtime/llmproxy/upstreamflavor/bedrock.go
@@ -1,0 +1,135 @@
+package upstreamflavor
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// BedrockConfig parameterizes a BedrockFlavor instance.
+//
+// Region is required and is baked into the upstream host:
+// bedrock-runtime.{Region}.amazonaws.com.
+//
+// ModelOverride is required because Bedrock's model identifiers are not
+// the Anthropic-native names Claude Code sends. Examples:
+//   - "anthropic.claude-3-5-sonnet-20241022-v2:0"
+//   - "anthropic.claude-opus-4-20260101-v1:0"
+// The client-supplied `model` field is ignored — Bedrock derives the
+// target model from the URL path.
+//
+// SignerFactory returns a SigV4 signer the flavor uses to sign each
+// upstream request. The factory pattern lets callers wire in
+// aws-sdk-go-v2's signer (or a vendored equivalent) without forcing
+// this package to take a hard SDK dependency.
+type BedrockConfig struct {
+	Region        string
+	ModelOverride string
+	SignerFactory func() Signer
+}
+
+// Signer signs an outbound *http.Request using SigV4 credentials. The
+// llmproxy package does not import aws-sdk-go-v2 directly; an adapter
+// elsewhere in the repo will wrap aws.SignHTTP.
+type Signer interface {
+	Sign(req *http.Request, body []byte) error
+}
+
+// NewBedrock returns a Flavor that targets AWS Bedrock's
+// :invoke-with-response-stream endpoint for Anthropic models.
+//
+// SCAFFOLD ONLY: the request half (URL + body transform) is complete
+// and tested; the response half — translating AWS EventStream
+// (binary-framed application/vnd.amazon.eventstream) back into the
+// Anthropic SSE shape the proxy's postprocess pipeline expects — is
+// deferred to a follow-up PR. SigV4 signing is also deferred (callers
+// must supply a Signer; the placeholder NoopSigner returns
+// ErrNotImplemented).
+func NewBedrock(cfg BedrockConfig) (Flavor, error) {
+	if strings.TrimSpace(cfg.Region) == "" {
+		return nil, errors.New("upstreamflavor: bedrock: Region required")
+	}
+	if strings.TrimSpace(cfg.ModelOverride) == "" {
+		return nil, errors.New("upstreamflavor: bedrock: ModelOverride required (client `model` field is ignored)")
+	}
+	if cfg.SignerFactory == nil {
+		cfg.SignerFactory = func() Signer { return noopSigner{} }
+	}
+	return &bedrockFlavor{cfg: cfg}, nil
+}
+
+type bedrockFlavor struct {
+	cfg BedrockConfig
+}
+
+func (b *bedrockFlavor) Name() string { return "bedrock" }
+
+func (b *bedrockFlavor) BuildURL(inboundPath, _ string) (*url.URL, error) {
+	suffix, err := bedrockSuffix(inboundPath)
+	if err != nil {
+		return nil, err
+	}
+	host := fmt.Sprintf("bedrock-runtime.%s.amazonaws.com", b.cfg.Region)
+	path := fmt.Sprintf("/model/%s/%s", b.cfg.ModelOverride, suffix)
+	return &url.URL{Scheme: "https", Host: host, Path: path}, nil
+}
+
+func bedrockSuffix(inboundPath string) (string, error) {
+	switch inboundPath {
+	case "/v1/messages":
+		return "invoke-with-response-stream", nil
+	case "/v1/messages/count_tokens":
+		return "", fmt.Errorf("upstreamflavor: bedrock: %s is not supported by Bedrock", inboundPath)
+	default:
+		return "", fmt.Errorf("upstreamflavor: bedrock: unsupported inbound path %q", inboundPath)
+	}
+}
+
+// TransformBody applies the same Vertex-style transforms: strip `model`
+// (Bedrock derives it from the URL) and inject `anthropic_version`
+// (Bedrock requires it inside the body).
+func (b *bedrockFlavor) TransformBody(body []byte) ([]byte, error) {
+	if len(body) == 0 {
+		return body, nil
+	}
+	out := body
+	if stripped, ok := stripModel(out); ok {
+		out = stripped
+	}
+	versioned, err := setAnthropicVersion(out)
+	if err != nil {
+		return nil, fmt.Errorf("upstreamflavor: bedrock: inject anthropic_version: %w", err)
+	}
+	return versioned, nil
+}
+
+// InjectAuth invokes the configured Signer. Bedrock's SigV4 covers the
+// method, path, headers (including X-Amz-Date and X-Amz-Content-Sha256),
+// and the body — so the proxy must finalize the body and headers before
+// signing. The forwarder is responsible for calling InjectAuth as the
+// last step before req.Do.
+func (b *bedrockFlavor) InjectAuth(req *http.Request, credBytes []byte) error {
+	req.Header.Del("anthropic-version")
+	req.Header.Del("x-api-key")
+
+	signer := b.cfg.SignerFactory()
+	if signer == nil {
+		return errors.New("upstreamflavor: bedrock: nil Signer from factory")
+	}
+	// Caller stashes the (already-transformed) body in a context value
+	// in a follow-up; for now we pass credBytes as a hint — the
+	// noopSigner ignores it and returns ErrNotImplemented so callers
+	// learn at integration time that signing isn't wired yet.
+	return signer.Sign(req, credBytes)
+}
+
+// VaultServiceID returns "bedrock"; credentials are typically stored as
+// a JSON blob containing access_key_id + secret_access_key + optional
+// session_token, parsed by the SignerFactory.
+func (b *bedrockFlavor) VaultServiceID() string { return "bedrock" }
+
+type noopSigner struct{}
+
+func (noopSigner) Sign(_ *http.Request, _ []byte) error { return ErrNotImplemented }

--- a/internal/runtime/llmproxy/upstreamflavor/bedrock_test.go
+++ b/internal/runtime/llmproxy/upstreamflavor/bedrock_test.go
@@ -1,0 +1,97 @@
+package upstreamflavor
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestBedrock_BuildURL(t *testing.T) {
+	t.Parallel()
+	b, err := NewBedrock(BedrockConfig{
+		Region:        "us-west-2",
+		ModelOverride: "anthropic.claude-opus-4-7-v1:0",
+	})
+	if err != nil {
+		t.Fatalf("NewBedrock: %v", err)
+	}
+	u, err := b.BuildURL("/v1/messages", "claude-opus-4-7")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "https://bedrock-runtime.us-west-2.amazonaws.com/model/anthropic.claude-opus-4-7-v1:0/invoke-with-response-stream"
+	if u.String() != want {
+		t.Errorf("URL\n got: %s\nwant: %s", u.String(), want)
+	}
+}
+
+func TestBedrock_RequiresModelOverride(t *testing.T) {
+	t.Parallel()
+	if _, err := NewBedrock(BedrockConfig{Region: "us-west-2"}); err == nil {
+		t.Fatal("expected error without ModelOverride")
+	}
+}
+
+func TestBedrock_TransformBody_StripsModelInjectsVersion(t *testing.T) {
+	t.Parallel()
+	b, _ := NewBedrock(BedrockConfig{Region: "us-west-2", ModelOverride: "anthropic.claude:0"})
+	in := []byte(`{"model":"claude","messages":[],"max_tokens":1024}`)
+	out, err := b.TransformBody(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var parsed map[string]json.RawMessage
+	if err := json.Unmarshal(out, &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if _, has := parsed["model"]; has {
+		t.Error("model should be stripped")
+	}
+	if _, has := parsed["anthropic_version"]; !has {
+		t.Error("anthropic_version should be injected")
+	}
+}
+
+func TestBedrock_InjectAuth_NoopSignerNotImplemented(t *testing.T) {
+	t.Parallel()
+	b, _ := NewBedrock(BedrockConfig{Region: "us-west-2", ModelOverride: "anthropic.claude:0"})
+	req, _ := http.NewRequest(http.MethodPost, "https://example/", nil)
+	err := b.InjectAuth(req, []byte("ignored"))
+	if !errors.Is(err, ErrNotImplemented) {
+		t.Errorf("expected ErrNotImplemented, got %v", err)
+	}
+}
+
+type fakeSigner struct {
+	called bool
+	body   []byte
+}
+
+func (f *fakeSigner) Sign(req *http.Request, body []byte) error {
+	f.called = true
+	f.body = body
+	req.Header.Set("Authorization", "AWS4-HMAC-SHA256 fake")
+	return nil
+}
+
+func TestBedrock_InjectAuth_CallsSigner(t *testing.T) {
+	t.Parallel()
+	signer := &fakeSigner{}
+	b, _ := NewBedrock(BedrockConfig{
+		Region:        "us-west-2",
+		ModelOverride: "anthropic.claude:0",
+		SignerFactory: func() Signer { return signer },
+	})
+	req, _ := http.NewRequest(http.MethodPost, "https://example/", nil)
+	if err := b.InjectAuth(req, []byte("body-bytes")); err != nil {
+		t.Fatal(err)
+	}
+	if !signer.called {
+		t.Fatal("signer was not invoked")
+	}
+	if !strings.HasPrefix(req.Header.Get("Authorization"), "AWS4-HMAC-SHA256") {
+		t.Errorf("Authorization not set by signer: %q", req.Header.Get("Authorization"))
+	}
+}

--- a/internal/runtime/llmproxy/upstreamflavor/doc.go
+++ b/internal/runtime/llmproxy/upstreamflavor/doc.go
@@ -1,0 +1,23 @@
+// Package upstreamflavor adapts Anthropic Messages API requests to
+// non-native deployment targets — Vertex AI, Azure AI Foundry, and AWS
+// Bedrock — so a Claude Code-style client can transparently address any
+// of them through the lite-proxy.
+//
+// The native Anthropic API is the proxy's default and does not require a
+// flavor adapter; setting UpstreamSelector.AnthropicFlavor to nil
+// preserves pre-existing routing behavior byte-for-byte.
+//
+// Each Flavor owns three concerns:
+//
+//   - URL construction. Vertex and Bedrock embed the model in the path;
+//     Azure uses a deployment URL with an api-version query parameter.
+//   - Body transform. Vertex and Bedrock require `anthropic_version`
+//     inside the JSON body and reject the top-level `model` field
+//     (which has been moved into the URL). Azure leaves the body as
+//     Anthropic-native.
+//   - Auth injection. Vertex uses OAuth Bearer (GCP access token); Azure
+//     uses the `api-key` header; Bedrock uses SigV4 over the entire
+//     request (deferred — see bedrock.go).
+//
+// Flavors are stateless after construction and safe for concurrent use.
+package upstreamflavor

--- a/internal/runtime/llmproxy/upstreamflavor/flavor.go
+++ b/internal/runtime/llmproxy/upstreamflavor/flavor.go
@@ -1,0 +1,93 @@
+package upstreamflavor
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/jsonsurgery"
+)
+
+// ErrNotImplemented is returned by flavors whose forward path has not
+// yet shipped (currently: Bedrock SigV4 + EventStream translation).
+var ErrNotImplemented = errors.New("upstreamflavor: not implemented")
+
+// Flavor describes a non-native deployment target for an Anthropic-shaped
+// Messages API request. Implementations transform the upstream URL, the
+// request body, and the auth headers.
+//
+// Concurrency: implementations must be safe for concurrent use after
+// construction.
+type Flavor interface {
+	// Name returns a stable identifier (e.g. "vertex", "azure",
+	// "bedrock"). Used in audit rows and log fields.
+	Name() string
+
+	// BuildURL returns the upstream URL for the given inbound path
+	// (e.g. "/v1/messages") and model name (parsed from the request
+	// body; empty if the body has no `model` field).
+	BuildURL(inboundPath, model string) (*url.URL, error)
+
+	// TransformBody returns a body suitable for this flavor's
+	// upstream. Native-shape flavors return the input unchanged.
+	// Flavors that move `model` into the URL strip it here.
+	TransformBody(body []byte) ([]byte, error)
+
+	// InjectAuth attaches credentials to req. The proxy supplies
+	// credBytes from vault under VaultServiceID(); passthrough mode
+	// passes empty credBytes and relies on the caller's already-set
+	// Authorization header — implementations should still perform
+	// flavor-specific header cleanup in that case.
+	InjectAuth(req *http.Request, credBytes []byte) error
+
+	// VaultServiceID returns the conventional vault service ID for
+	// this flavor's stored credentials, used by the forwarder's
+	// agent-scoped + user-scoped lookup chain. An empty string means
+	// the flavor is passthrough-only and the proxy should skip the
+	// vault lookup.
+	VaultServiceID() string
+}
+
+// AnthropicBodyVersion is the value injected as `anthropic_version`
+// into the request body for flavors that require it (Vertex, Bedrock).
+// Matches the version sent in the `anthropic-version` header for native
+// API requests.
+const AnthropicBodyVersion = "vertex-2023-10-16"
+
+// ExtractModel pulls the top-level `model` string from an Anthropic
+// Messages API body. Returns empty string + nil error when the field is
+// missing or the body is not a JSON object — flavors decide whether
+// that is a configuration error (Vertex/Bedrock require a model in the
+// URL) or acceptable (Azure can be configured with a fixed deployment).
+func ExtractModel(body []byte) (string, error) {
+	if len(body) == 0 {
+		return "", nil
+	}
+	start, end, ok := jsonsurgery.FindFieldValue(body, "model")
+	if !ok {
+		return "", nil
+	}
+	var s string
+	if err := json.Unmarshal(body[start:end], &s); err != nil {
+		return "", fmt.Errorf("upstreamflavor: parsing model field: %w", err)
+	}
+	return s, nil
+}
+
+// stripModel removes a top-level `model` field from a JSON object body.
+// Returns the input unchanged when there is no model field.
+func stripModel(body []byte) ([]byte, bool) {
+	return jsonsurgery.DeleteField(body, "model")
+}
+
+// setAnthropicVersion writes a top-level `anthropic_version` field with
+// the constant body version. Replaces an existing field if present.
+func setAnthropicVersion(body []byte) ([]byte, error) {
+	versionJSON, err := json.Marshal(AnthropicBodyVersion)
+	if err != nil {
+		return nil, err
+	}
+	return jsonsurgery.SetField(body, "anthropic_version", versionJSON)
+}

--- a/internal/runtime/llmproxy/upstreamflavor/vertex.go
+++ b/internal/runtime/llmproxy/upstreamflavor/vertex.go
@@ -1,0 +1,142 @@
+package upstreamflavor
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// VertexConfig parameterizes a VertexFlavor instance.
+//
+// ProjectID and Region are required. They are baked into the upstream
+// URL: https://{Region}-aiplatform.googleapis.com/v1/projects/{ProjectID}
+// /locations/{Region}/publishers/anthropic/models/{model}:streamRawPredict
+// (or :rawPredict when stream=false in the body — but Claude Code always
+// streams, so the proxy targets :streamRawPredict).
+//
+// ModelOverride forces a specific Vertex model ID regardless of what
+// the client sent in the body's `model` field. Most clients use raw
+// Anthropic names like "claude-opus-4-7"; Vertex's catalog uses
+// versioned IDs like "claude-opus-4-7@20260101". Leave empty to
+// passthrough the client's value.
+type VertexConfig struct {
+	ProjectID     string
+	Region        string
+	ModelOverride string
+}
+
+// NewVertex returns a Flavor that adapts Anthropic Messages API requests
+// to Vertex AI's :streamRawPredict endpoint.
+func NewVertex(cfg VertexConfig) (Flavor, error) {
+	if strings.TrimSpace(cfg.ProjectID) == "" {
+		return nil, errors.New("upstreamflavor: vertex: ProjectID required")
+	}
+	if strings.TrimSpace(cfg.Region) == "" {
+		return nil, errors.New("upstreamflavor: vertex: Region required")
+	}
+	return &vertexFlavor{cfg: cfg}, nil
+}
+
+type vertexFlavor struct {
+	cfg VertexConfig
+}
+
+func (v *vertexFlavor) Name() string { return "vertex" }
+
+func (v *vertexFlavor) BuildURL(inboundPath, model string) (*url.URL, error) {
+	if v.cfg.ModelOverride != "" {
+		model = v.cfg.ModelOverride
+	}
+	if model == "" {
+		return nil, errors.New("upstreamflavor: vertex: request body has no `model` field and no ModelOverride configured")
+	}
+
+	// Vertex only exposes :rawPredict and :streamRawPredict for
+	// Anthropic publisher models. Count_tokens is not supported on
+	// Vertex's Anthropic surface — surface a clear error.
+	suffix, err := vertexSuffix(inboundPath)
+	if err != nil {
+		return nil, err
+	}
+
+	host := fmt.Sprintf("%s-aiplatform.googleapis.com", v.cfg.Region)
+	path := fmt.Sprintf(
+		"/v1/projects/%s/locations/%s/publishers/anthropic/models/%s:%s",
+		v.cfg.ProjectID, v.cfg.Region, model, suffix,
+	)
+	return &url.URL{Scheme: "https", Host: host, Path: path}, nil
+}
+
+func vertexSuffix(inboundPath string) (string, error) {
+	switch inboundPath {
+	case "/v1/messages":
+		return "streamRawPredict", nil
+	case "/v1/messages/count_tokens":
+		return "", fmt.Errorf("upstreamflavor: vertex: %s is not supported by Vertex AI", inboundPath)
+	default:
+		return "", fmt.Errorf("upstreamflavor: vertex: unsupported inbound path %q", inboundPath)
+	}
+}
+
+// TransformBody strips the top-level `model` field (Vertex rejects it —
+// the model is encoded in the URL) and injects `anthropic_version`
+// (Vertex requires it in the body, not the header).
+//
+// Byte fidelity for the remaining fields is preserved via jsonsurgery
+// (same helpers the inbound sanitize layer uses) so thinking-block
+// signature verification on continuation turns continues to work.
+func (v *vertexFlavor) TransformBody(body []byte) ([]byte, error) {
+	if len(body) == 0 {
+		return body, nil
+	}
+	out := body
+	if stripped, ok := stripModel(out); ok {
+		out = stripped
+	}
+	versioned, err := setAnthropicVersion(out)
+	if err != nil {
+		return nil, fmt.Errorf("upstreamflavor: vertex: inject anthropic_version: %w", err)
+	}
+	return versioned, nil
+}
+
+// InjectAuth sets Authorization: Bearer <GCP access token>.
+//
+// credBytes is the raw access token bytes (or the JSON service-account
+// key — see InjectAuth contract). For the initial draft, the proxy
+// expects credBytes to already be a usable bearer token; minting from a
+// service-account JSON via google.golang.org/api/oauth2 is deferred to
+// a follow-up (it adds a non-trivial dependency and a token cache).
+//
+// When credBytes is empty (passthrough mode), the caller's
+// Authorization header is preserved as-is and only flavor-specific
+// headers are cleaned up.
+func (v *vertexFlavor) InjectAuth(req *http.Request, credBytes []byte) error {
+	// Vertex puts the version in the body — strip any header form so
+	// the upstream doesn't see two conflicting copies.
+	req.Header.Del("anthropic-version")
+	// x-api-key is meaningless to Vertex; remove it if present.
+	req.Header.Del("x-api-key")
+
+	if len(credBytes) == 0 {
+		// Passthrough — Authorization header is already attached.
+		return nil
+	}
+	token := strings.TrimSpace(string(credBytes))
+	if token == "" {
+		return errors.New("upstreamflavor: vertex: empty access token")
+	}
+	if strings.ContainsAny(token, "\r\n\x00") {
+		return errors.New("upstreamflavor: vertex: access token contains illegal control bytes")
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	return nil
+}
+
+// VaultServiceID stores Vertex access tokens (or SA keys, once auto-mint
+// lands) under the conventional "vertex" namespace. Returning "vertex"
+// here lets the forwarder's agent-scoped + user-scoped lookup chain
+// reuse its existing logic without flavor-specific branches.
+func (v *vertexFlavor) VaultServiceID() string { return "vertex" }

--- a/internal/runtime/llmproxy/upstreamflavor/vertex_test.go
+++ b/internal/runtime/llmproxy/upstreamflavor/vertex_test.go
@@ -1,0 +1,131 @@
+package upstreamflavor
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestVertex_BuildURL(t *testing.T) {
+	t.Parallel()
+	v, err := NewVertex(VertexConfig{ProjectID: "my-proj", Region: "us-east5"})
+	if err != nil {
+		t.Fatalf("NewVertex: %v", err)
+	}
+	u, err := v.BuildURL("/v1/messages", "claude-opus-4-7@20260101")
+	if err != nil {
+		t.Fatalf("BuildURL: %v", err)
+	}
+	want := "https://us-east5-aiplatform.googleapis.com/v1/projects/my-proj/locations/us-east5/publishers/anthropic/models/claude-opus-4-7@20260101:streamRawPredict"
+	if u.String() != want {
+		t.Errorf("URL\n got: %s\nwant: %s", u.String(), want)
+	}
+}
+
+func TestVertex_BuildURL_ModelOverride(t *testing.T) {
+	t.Parallel()
+	v, err := NewVertex(VertexConfig{ProjectID: "p", Region: "r", ModelOverride: "claude-opus-4-7@20260101"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	u, err := v.BuildURL("/v1/messages", "client-sent-this")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(u.Path, "claude-opus-4-7@20260101") {
+		t.Errorf("ModelOverride not applied: %s", u.Path)
+	}
+	if strings.Contains(u.Path, "client-sent-this") {
+		t.Errorf("client model leaked into URL: %s", u.Path)
+	}
+}
+
+func TestVertex_BuildURL_NoModel(t *testing.T) {
+	t.Parallel()
+	v, _ := NewVertex(VertexConfig{ProjectID: "p", Region: "r"})
+	_, err := v.BuildURL("/v1/messages", "")
+	if err == nil {
+		t.Fatal("expected error when model missing and no override")
+	}
+}
+
+func TestVertex_BuildURL_CountTokensUnsupported(t *testing.T) {
+	t.Parallel()
+	v, _ := NewVertex(VertexConfig{ProjectID: "p", Region: "r"})
+	if _, err := v.BuildURL("/v1/messages/count_tokens", "m"); err == nil {
+		t.Fatal("expected error for unsupported count_tokens path")
+	}
+}
+
+func TestVertex_TransformBody_StripsModelInjectsVersion(t *testing.T) {
+	t.Parallel()
+	v, _ := NewVertex(VertexConfig{ProjectID: "p", Region: "r"})
+	in := []byte(`{"model":"claude-opus-4-7","max_tokens":1024,"messages":[]}`)
+	out, err := v.TransformBody(in)
+	if err != nil {
+		t.Fatalf("TransformBody: %v", err)
+	}
+
+	var parsed map[string]json.RawMessage
+	if err := json.Unmarshal(out, &parsed); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, out)
+	}
+	if _, present := parsed["model"]; present {
+		t.Error("model field should be stripped")
+	}
+	if _, present := parsed["max_tokens"]; !present {
+		t.Error("max_tokens should be preserved")
+	}
+	if raw, present := parsed["anthropic_version"]; !present {
+		t.Error("anthropic_version should be injected")
+	} else {
+		var s string
+		_ = json.Unmarshal(raw, &s)
+		if s != AnthropicBodyVersion {
+			t.Errorf("anthropic_version=%q want %q", s, AnthropicBodyVersion)
+		}
+	}
+}
+
+func TestVertex_InjectAuth_VaultMode(t *testing.T) {
+	t.Parallel()
+	v, _ := NewVertex(VertexConfig{ProjectID: "p", Region: "r"})
+	req, _ := http.NewRequest(http.MethodPost, "https://example/", nil)
+	req.Header.Set("anthropic-version", "2023-06-01")
+	req.Header.Set("x-api-key", "should-go")
+	if err := v.InjectAuth(req, []byte("ya29.c.token")); err != nil {
+		t.Fatalf("InjectAuth: %v", err)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer ya29.c.token" {
+		t.Errorf("Authorization=%q", got)
+	}
+	if req.Header.Get("anthropic-version") != "" {
+		t.Error("anthropic-version should be stripped")
+	}
+	if req.Header.Get("x-api-key") != "" {
+		t.Error("x-api-key should be stripped")
+	}
+}
+
+func TestVertex_InjectAuth_PassthroughKeepsAuthorization(t *testing.T) {
+	t.Parallel()
+	v, _ := NewVertex(VertexConfig{ProjectID: "p", Region: "r"})
+	req, _ := http.NewRequest(http.MethodPost, "https://example/", nil)
+	req.Header.Set("Authorization", "Bearer caller-supplied-token")
+	if err := v.InjectAuth(req, nil); err != nil {
+		t.Fatalf("InjectAuth: %v", err)
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer caller-supplied-token" {
+		t.Errorf("passthrough Authorization mangled: %q", got)
+	}
+}
+
+func TestVertex_InjectAuth_RejectsControlBytes(t *testing.T) {
+	t.Parallel()
+	v, _ := NewVertex(VertexConfig{ProjectID: "p", Region: "r"})
+	req, _ := http.NewRequest(http.MethodPost, "https://example/", nil)
+	if err := v.InjectAuth(req, []byte("foo\r\nX-Injected: yes")); err == nil {
+		t.Fatal("expected error for control bytes in token")
+	}
+}


### PR DESCRIPTION
## Summary

Adds an `internal/runtime/llmproxy/upstreamflavor` package so an
Anthropic-shaped client (Claude Code, the Anthropic SDK) can transparently
address a non-native Claude deployment through the lite-proxy.

Native API forwarding is unchanged — `UpstreamSelector.AnthropicFlavor`
defaults to nil and the existing `injectUpstreamAuth` + URL path runs
byte-for-byte the way it did before. This PR is the request-side
scaffold; SigV4 + AWS EventStream translation for Bedrock are deferred
to a follow-up so this stays reviewable and dep-free.

## What each flavor does

| Concern | Native | Vertex | Azure Foundry | Bedrock |
| --- | --- | --- | --- | --- |
| URL | `api.anthropic.com/v1/messages` | `{region}-aiplatform.googleapis.com/v1/projects/{p}/locations/{r}/publishers/anthropic/models/{m}:streamRawPredict` | `{rsc}.services.ai.azure.com/anthropic/v1/messages?api-version=…` | `bedrock-runtime.{region}.amazonaws.com/model/{m}/invoke-with-response-stream` |
| `model` in body | yes | stripped (lives in URL) | unchanged | stripped (lives in URL) |
| `anthropic_version` | header | body (`vertex-2023-10-16`) | n/a (uses `api-version` query) | body |
| Auth | `x-api-key` | `Authorization: Bearer <GCP token>` | `api-key` header | SigV4 via `Signer` |
| Passthrough mode | supported | supported (user-supplied Bearer) | supported (AAD bearer) | not supported (SigV4 per-request) |

## Where the flavor plugs in

`UpstreamSelector` gains an `AnthropicFlavor upstreamflavor.Flavor`
field. When set, `Forward` dispatches to `forwardFlavor`, which:

1. Extracts `model` from the body.
2. Calls `flavor.BuildURL` and `flavor.TransformBody`.
3. Copies headers using the existing forwardable-header allowlist.
4. In passthrough mode: forwards the caller's bearer and calls
   `flavor.InjectAuth(req, nil)` for flavor-specific cleanup.
5. Otherwise: looks up `flavor.VaultServiceID()` in the vault under
   agent-scoped → user-scoped fallback (mirrors the native path) and
   calls `flavor.InjectAuth(req, credBytes)`.

OpenAI + Google traffic is unaffected — the flavor field is
Anthropic-only.

## Out of scope (follow-ups)

- **Bedrock SigV4 signing.** The interface is in place; `NoopSigner`
  returns `ErrNotImplemented`. Wiring `aws-sdk-go-v2/aws/signer/v4`
  belongs in a separate PR so the dep bump is reviewable on its own.
- **Bedrock SSE translation.** Bedrock's `invoke-with-response-stream`
  emits AWS EventStream (binary frames carrying JSON payloads), not
  Anthropic SSE. The postprocess layer needs an EventStream → SSE
  shim before responses can flow through.
- **Vertex SA-key auto-mint.** The vault currently stores an already-
  minted access token; supporting a service-account JSON and minting
  via `google.golang.org/api/oauth2` is also a separate PR (adds a
  token cache and a meaningful dep).
- **Config surface / per-user flavor selection.** Right now the flavor
  is a process-level setting on the `Forwarder`. Routing per-agent or
  per-user is straightforward to layer on once the wire-level
  primitives have landed.
- **Vertex `count_tokens` parity.** Vertex's Anthropic publisher does
  not expose a count_tokens endpoint; the proxy returns a clear error
  rather than fabricating a response.

## Test plan

- [x] `go test ./internal/runtime/llmproxy/upstreamflavor/...` —
      per-flavor unit tests (URL, body transform, auth injection).
- [x] `go test ./internal/runtime/llmproxy -run TestForward` —
      includes new `forward_flavor_test.go` exercising the dispatch
      branch, passthrough-vs-vault auth, and the regression case
      where `AnthropicFlavor` is nil and the native path is unchanged.
- [x] `go vet ./internal/runtime/llmproxy/...` clean.
- [ ] Integration smoke test against a real Vertex project. Not in
      this PR; will land alongside the SA-key minting work.
- [ ] Integration smoke test against an Azure Foundry resource. Not in
      this PR; needs a Foundry instance to point at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)