### PR TITLE
fix(llmproxy): don't hijack bare yes/no replies as approval_not_found

### DIFF
--- a/internal/runtime/llmproxy/release.go
+++ b/internal/runtime/llmproxy/release.go
@@ -206,9 +206,15 @@ func TryReleasePendingApproval(ctx context.Context, req ReleaseRequest) ReleaseR
 	}
 	peeked := action.Hold
 	if peeked == nil {
-		if approvalID != "" {
-			return ReleaseResult{Handled: true, HTTPStatus: http.StatusNotFound, Decision: "deny", Outcome: "approval_not_found", Reason: "this approval is no longer valid — it may have expired, already been used, or been issued to another agent. Please retry your original request to get a fresh approval prompt."}
-		}
+		// approvalID may be non-empty here because the bare-reply
+		// parser scanned the assistant transcript for the latest
+		// [clawvisor:approval=cv-xxx] marker and attached a stale one.
+		// We can't distinguish that from a user explicitly typing
+		// "yes cv-xxx", and the former is the overwhelmingly common
+		// case (users type bare verbs; the marker just rides along).
+		// Fall through silently so an ordinary "yes" to an agent's
+		// own question isn't hijacked into a 404 once any earlier
+		// Clawvisor approval has been resolved in this conversation.
 		return ReleaseResult{}
 	}
 	// Preprocess-missing defense: if the hold the bare reply targets
@@ -255,10 +261,11 @@ func TryReleasePendingApproval(ctx context.Context, req ReleaseRequest) ReleaseR
 	}
 	if pending == nil {
 		// Peeked one moment ago but it's gone now — a concurrent
-		// release/rewrite pass consumed it. Treat as not-found.
-		if approvalID != "" {
-			return ReleaseResult{Handled: true, HTTPStatus: http.StatusNotFound, Decision: "deny", Outcome: "approval_not_found", Reason: "this approval is no longer valid — it may have expired, already been used, or been issued to another agent. Please retry your original request to get a fresh approval prompt."}
-		}
+		// release/rewrite pass consumed it. Fall through silently
+		// for the same reason as the peeked==nil branch above: we
+		// can't distinguish a user-typed cv-id from a stale marker
+		// scraped out of transcript history, and silently dropping
+		// is the safe behavior for bare yes/no replies.
 		return ReleaseResult{}
 	}
 	if verb == "deny" {

--- a/internal/runtime/llmproxy/release_test.go
+++ b/internal/runtime/llmproxy/release_test.go
@@ -54,8 +54,15 @@ func TestTryReleasePendingApprovalWrongExplicitIDDoesNotConsume(t *testing.T) {
 		Agent:           &store.Agent{ID: "agent-1", UserID: "user-1"},
 		PendingApproval: cache,
 	})
-	if !result.Handled || result.HTTPStatus != 404 {
-		t.Fatalf("wrong explicit ID should be handled as not found: %+v", result)
+	// A non-matching cv-id falls through silently rather than emitting
+	// a 404. The release path can't distinguish a user-typed cv-id
+	// from one the bare-reply parser scraped out of stale assistant
+	// transcript history, and silently dropping is the safe behavior
+	// — otherwise an ordinary "yes" to an agent question would be
+	// hijacked into a 404 once any earlier Clawvisor approval has been
+	// resolved in this conversation.
+	if result.Handled {
+		t.Fatalf("wrong explicit ID should fall through, not be handled: %+v", result)
 	}
 
 	resolved, err := cache.Resolve(ctx, ResolveRequest{
@@ -69,6 +76,36 @@ func TestTryReleasePendingApprovalWrongExplicitIDDoesNotConsume(t *testing.T) {
 	}
 	if resolved == nil || resolved.ID != held.Pending.ID {
 		t.Fatalf("approval was consumed by wrong ID; resolved=%+v", resolved)
+	}
+}
+
+// TestTryReleasePendingApprovalBareReplyWithStaleHistoryMarkerFallsThrough
+// pins the fix for the hijack where a bare "yes" reply to the agent's
+// own question gets routed into approval_not_found because the
+// transcript still carries the [clawvisor:approval=cv-xxx] footer from
+// an already-resolved approval earlier in the conversation. The user
+// said yes to a non-Clawvisor question; the proxy must not synthesize
+// a 404 reply.
+func TestTryReleasePendingApprovalBareReplyWithStaleHistoryMarkerFallsThrough(t *testing.T) {
+	ctx := context.Background()
+	cache := NewMemoryPendingApprovalCache(time.Minute)
+
+	body := []byte(`{"messages":[` +
+		`{"role":"user","content":"please do the thing"},` +
+		`{"role":"assistant","content":"Clawvisor paused this turn for approval. Reply 'y' to approve.\n[clawvisor:approval=cv-stalexxxxxxxx]"},` +
+		`{"role":"user","content":"y"},` +
+		`{"role":"assistant","content":"Done. Want me to continue?"},` +
+		`{"role":"user","content":"yes"}` +
+		`]}`)
+
+	result := TryReleasePendingApproval(ctx, ReleaseRequest{
+		Provider:        conversation.ProviderAnthropic,
+		Body:            body,
+		Agent:           &store.Agent{ID: "agent-1", UserID: "user-1"},
+		PendingApproval: cache,
+	})
+	if result.Handled {
+		t.Fatalf("bare reply with only a stale history marker must fall through, not synthesize a 404: %+v", result)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Bare user replies (\`yes\`/\`y\`/\`no\`/\`n\`) to the agent's own questions were being hijacked into a synthetic 404 "this approval is no longer valid" response once any earlier Clawvisor approval had been resolved in the conversation.
- Root cause: the bare-reply parser scans the assistant transcript for the latest \`[clawvisor:approval=cv-xxx]\` marker so a single \`yes\` can be pinned to a specific prompt. That marker remains in transcript history forever, so every subsequent bare \`yes\` picked up the stale id; \`Peek\` returned nil; \`release.go\` treated the non-empty \`approvalID\` as a user-typed expired cv-id and emitted the 404.
- Fix: \`TryReleasePendingApproval\` falls through silently when no live hold matches, regardless of whether \`approvalID\` is non-empty. The release path can't distinguish a user-typed cv-id from a history-scraped one at this layer, and in practice users almost never type explicit cv-ids — the marker just rides along.
- The \`task\` verb and the inline-task approve/deny rewriter were already gated on \`action.Hold != nil\` and weren't affected.

## Test plan

- [x] \`TestTryReleasePendingApprovalWrongExplicitIDDoesNotConsume\` updated to assert passthrough; the "doesn't consume the right approval" security guarantee is still verified.
- [x] New regression test \`TestTryReleasePendingApprovalBareReplyWithStaleHistoryMarkerFallsThrough\` reproduces the user-reported scenario: a transcript with a resolved approval marker followed by an agent question and a bare \`yes\`.
- [x] Full \`./internal/runtime/llmproxy/...\` and \`./internal/api/handlers/...\` test suites pass.
- [ ] Manual: in a Claude Code session, trigger one Clawvisor approval, resolve it, then say \`yes\` to a follow-up agent question and confirm no 404 / "approval no longer valid" response is synthesized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)