### PR TITLE
fix(llmproxy): cvreason Rewritten contract + abstraction cleanup

### DIFF
--- a/internal/runtime/conversation/anthropic_response.go
+++ b/internal/runtime/conversation/anthropic_response.go
@@ -142,7 +142,7 @@ func (rw AnthropicResponseRewriter) rewriteJSON(body []byte, eval ToolUseEvaluat
 		return RewriteResult{
 			Body:          rewritten,
 			Decisions:     decisions,
-			Rewritten:     anyBlocked || anyRewritten,
+			Rewritten:     anyBlocked || anyRewritten || anyCvReasonStripped,
 			AssistantTurn: turn,
 		}, nil
 	}
@@ -365,7 +365,7 @@ func (rw AnthropicResponseRewriter) rewriteSSE(body []byte, eval ToolUseEvaluato
 		return RewriteResult{
 			Body:          assembled,
 			Decisions:     decisions,
-			Rewritten:     anyBlocked || anyRewritten,
+			Rewritten:     anyBlocked || anyRewritten || anyCvReasonStripped,
 			AssistantTurn: turn,
 		}, nil
 	}

--- a/internal/runtime/conversation/anthropic_response.go
+++ b/internal/runtime/conversation/anthropic_response.go
@@ -68,12 +68,7 @@ func (rw AnthropicResponseRewriter) rewriteJSON(body []byte, eval ToolUseEvaluat
 			}
 			newContent = append(newContent, block)
 		case "tool_use":
-			tu := PopulateCvReason(ToolUse{
-				ID:    block.ID,
-				Index: index,
-				Name:  block.Name,
-				Input: block.Input,
-			})
+			tu := NewToolUseFromInput(block.ID, index, block.Name, block.Input)
 			if tu.CvReason != "" {
 				block.Input = tu.Input
 				anyCvReasonStripped = true
@@ -280,12 +275,7 @@ func (rw AnthropicResponseRewriter) rewriteSSE(body []byte, eval ToolUseEvaluato
 		if pb.input.Len() > 0 {
 			inputRaw = json.RawMessage(pb.input.Bytes())
 		}
-		tu := PopulateCvReason(ToolUse{
-			ID:    pb.id,
-			Index: pb.index,
-			Name:  pb.name,
-			Input: inputRaw,
-		})
+		tu := NewToolUseFromInput(pb.id, pb.index, pb.name, inputRaw)
 		if tu.CvReason != "" {
 			pb.input.Reset()
 			pb.input.Write(tu.Input)
@@ -1414,12 +1404,7 @@ func (rw AnthropicResponseRewriter) StreamRewrite(ctx context.Context, r io.Read
 		if pb.input.Len() > 0 {
 			inputRaw = json.RawMessage(pb.input.Bytes())
 		}
-		tu := PopulateCvReason(ToolUse{
-			ID:    pb.id,
-			Index: pb.index,
-			Name:  pb.name,
-			Input: inputRaw,
-		})
+		tu := NewToolUseFromInput(pb.id, pb.index, pb.name, inputRaw)
 		if tu.CvReason != "" {
 			pb.input.Reset()
 			pb.input.Write(tu.Input)

--- a/internal/runtime/conversation/cvreason.go
+++ b/internal/runtime/conversation/cvreason.go
@@ -50,9 +50,9 @@ func ExtractCvReason(input json.RawMessage) (reason string, stripped json.RawMes
 }
 
 // PopulateCvReason returns a copy of tu with cvreason extracted from
-// Input into CvReason. Construction sites in the response parsers call
-// this immediately after building a ToolUse so the rest of the pipeline
-// (eval, client output, audit transcript) sees the stripped form.
+// Input into CvReason. Prefer NewToolUseFromInput at construction sites;
+// PopulateCvReason exists for the occasional case where the ToolUse was
+// already built and we need to normalize it post-hoc.
 func PopulateCvReason(tu ToolUse) ToolUse {
 	reason, stripped, ok := ExtractCvReason(tu.Input)
 	if !ok {
@@ -61,4 +61,20 @@ func PopulateCvReason(tu ToolUse) ToolUse {
 	tu.CvReason = reason
 	tu.Input = stripped
 	return tu
+}
+
+// NewToolUseFromInput is the canonical constructor for a ToolUse built
+// from upstream-emitted input bytes. It extracts cvreason from the input
+// JSON, populates CvReason, and stores the stripped bytes in Input — so
+// every site that takes raw upstream bytes flows through one normalizer
+// instead of relying on per-site PopulateCvReason wrapping. New
+// construction sites in the response parsers should use this
+// constructor; raw ToolUse{...} literals leak cvreason to the client.
+func NewToolUseFromInput(id string, index int, name string, input json.RawMessage) ToolUse {
+	return PopulateCvReason(ToolUse{
+		ID:    id,
+		Index: index,
+		Name:  name,
+		Input: input,
+	})
 }

--- a/internal/runtime/conversation/cvreason_stream_test.go
+++ b/internal/runtime/conversation/cvreason_stream_test.go
@@ -67,6 +67,30 @@ func TestAnthropicStreamRewriteExtractsCvReason(t *testing.T) {
 	}
 }
 
+// TestOpenAIChatCompletionsRewriteJSONFlagsCvReasonRemarshalAsRewritten
+// is a regression check for the Rewritten=false bug that shipped in PR
+// #541: cvreason-only rewrites must report Rewritten=true so the
+// handler at api/handlers/llm_endpoint.go (which gates Content-Length
+// and Content-Encoding cleanup on Rewritten) drops the upstream
+// headers — otherwise the harness sees the shorter body with the
+// upstream's now-stale Content-Length and rejects the response.
+func TestOpenAIChatCompletionsRewriteJSONFlagsCvReasonRemarshalAsRewritten(t *testing.T) {
+	t.Parallel()
+	body := `{"id":"chatcmpl_1","object":"chat.completion","model":"gpt-test","choices":[{"index":0,"message":{"role":"assistant","tool_calls":[{"id":"call_1","type":"function","function":{"name":"read_file","arguments":"{\"path\":\"src/auth.go\",\"cvreason\":\"locate the login handler\"}"}}]},"finish_reason":"tool_calls"}]}`
+
+	eval := func(_ ToolUse) ToolUseVerdict { return ToolUseVerdict{Allowed: true} }
+	res, err := (OpenAIResponseRewriter{}).Rewrite([]byte(body), "application/json", eval)
+	if err != nil {
+		t.Fatalf("Rewrite: %v", err)
+	}
+	if strings.Contains(string(res.Body), "cvreason") {
+		t.Errorf("response body retained cvreason: %s", res.Body)
+	}
+	if !res.Rewritten {
+		t.Errorf("Rewritten=false on cvreason-only re-marshal; body diverges from upstream so handler must drop Content-Length")
+	}
+}
+
 // TestAnthropicRewriteJSONStripsCvReasonFromBody verifies the
 // non-streaming JSON rewriter re-marshals the response body without
 // cvreason even when no other rewrite/block occurred.
@@ -94,9 +118,11 @@ func TestAnthropicRewriteJSONStripsCvReasonFromBody(t *testing.T) {
 	if !strings.Contains(string(res.Body), "src/auth.go") {
 		t.Errorf("response body lost real params: %s", res.Body)
 	}
-	// Rewritten should NOT be set just because we stripped cvreason —
-	// that flag signals a policy decision rewrote inputs.
-	if res.Rewritten {
-		t.Errorf("Rewritten=true; want false for cvreason-only re-marshal")
+	// Rewritten must be true: the body bytes diverge from upstream's
+	// (cvreason was stripped), so the harness handler needs to know to
+	// drop the now-stale Content-Length / Content-Encoding headers.
+	// See llm_endpoint.go where `processed.Rewritten` gates that cleanup.
+	if !res.Rewritten {
+		t.Errorf("Rewritten=false; want true so downstream drops the stale Content-Length")
 	}
 }

--- a/internal/runtime/conversation/cvreason_stream_test.go
+++ b/internal/runtime/conversation/cvreason_stream_test.go
@@ -3,6 +3,7 @@ package conversation
 import (
 	"bytes"
 	"context"
+	"net/http"
 	"strings"
 	"testing"
 )
@@ -64,6 +65,54 @@ func TestAnthropicStreamRewriteExtractsCvReason(t *testing.T) {
 	}
 	if delivered[0].CvReason != tu.CvReason {
 		t.Errorf("onToolUse CvReason = %q, want %q", delivered[0].CvReason, tu.CvReason)
+	}
+}
+
+// TestOpenAIChatCompletionsSSEStripsCvReasonWithoutPolicyVerdict verifies
+// that the chat-completions SSE rewriter's cvreason-only path produces
+// stripped output bytes and reports Rewritten=true without coercing
+// the policy-rewrite verdict. The replay machinery is shared between
+// policy rewrites and cvreason normalization; this test pins that
+// shared substitution path on the cvreason-only branch.
+func TestOpenAIChatCompletionsSSEStripsCvReasonWithoutPolicyVerdict(t *testing.T) {
+	t.Parallel()
+
+	req, _ := http.NewRequest(http.MethodPost, "https://api.openai.com/v1/chat/completions", nil)
+	rewriter := DefaultResponseRegistry().Match(req, &http.Response{})
+	if rewriter == nil {
+		t.Fatal("no OpenAI rewriter")
+	}
+
+	body := []byte(strings.Join([]string{
+		`data: {"id":"chatcmpl_1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"chatcmpl_1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"read_file","arguments":"{\"path\":\"src/auth.go\",\"cvreason\":\"locate the login handler\"}"}}]},"finish_reason":null}]}`,
+		``,
+		`data: {"id":"chatcmpl_1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}, "\n"))
+
+	var seen ToolUse
+	res, err := rewriter.Rewrite(body, "text/event-stream", func(tu ToolUse) ToolUseVerdict {
+		seen = tu
+		return ToolUseVerdict{Allowed: true}
+	})
+	if err != nil {
+		t.Fatalf("Rewrite: %v", err)
+	}
+	if seen.CvReason != "locate the login handler" {
+		t.Errorf("eval CvReason = %q, want extracted text", seen.CvReason)
+	}
+	if !res.Rewritten {
+		t.Errorf("Rewritten=false; want true so downstream drops the stale Content-Length")
+	}
+	if strings.Contains(string(res.Body), "cvreason") {
+		t.Errorf("SSE output retained cvreason: %s", res.Body)
+	}
+	if !strings.Contains(string(res.Body), "src/auth.go") {
+		t.Errorf("SSE output lost real params: %s", res.Body)
 	}
 }
 

--- a/internal/runtime/conversation/cvreason_test.go
+++ b/internal/runtime/conversation/cvreason_test.go
@@ -72,6 +72,30 @@ func TestExtractCvReason(t *testing.T) {
 	}
 }
 
+func TestNewToolUseFromInputExtractsCvReason(t *testing.T) {
+	tu := NewToolUseFromInput("tu_1", 0, "Read", json.RawMessage(`{"path":"foo.go","cvreason":"checking imports"}`))
+	if tu.CvReason != "checking imports" {
+		t.Errorf("CvReason = %q, want %q", tu.CvReason, "checking imports")
+	}
+	if strings.Contains(string(tu.Input), "cvreason") {
+		t.Errorf("Input retained cvreason: %s", tu.Input)
+	}
+	if tu.ID != "tu_1" || tu.Index != 0 || tu.Name != "Read" {
+		t.Errorf("metadata fields lost: %+v", tu)
+	}
+}
+
+func TestNewToolUseFromInputNoOpWhenAbsent(t *testing.T) {
+	original := json.RawMessage(`{"path":"foo.go"}`)
+	tu := NewToolUseFromInput("tu_1", 0, "Read", original)
+	if tu.CvReason != "" {
+		t.Errorf("CvReason = %q, want empty", tu.CvReason)
+	}
+	if string(tu.Input) != string(original) {
+		t.Errorf("Input mutated when no cvreason present: got %s, want %s", tu.Input, original)
+	}
+}
+
 func TestPopulateCvReasonPopulatesField(t *testing.T) {
 	tu := ToolUse{
 		ID:    "tu_1",

--- a/internal/runtime/conversation/openai_response.go
+++ b/internal/runtime/conversation/openai_response.go
@@ -239,7 +239,7 @@ func (rw OpenAIResponseRewriter) rewriteResponsesJSON(body []byte, eval ToolUseE
 		if err != nil {
 			return RewriteResult{}, fmt.Errorf("openai responses: marshal rewritten response: %w", err)
 		}
-		return RewriteResult{Body: rewritten, Decisions: decisions, Rewritten: anyBlocked || anyRewritten, AssistantTurn: turn}, nil
+		return RewriteResult{Body: rewritten, Decisions: decisions, Rewritten: anyBlocked || anyRewritten || anyCvReasonStripped, AssistantTurn: turn}, nil
 	}
 	return RewriteResult{Body: body, Decisions: decisions, AssistantTurn: turn}, nil
 }
@@ -499,7 +499,7 @@ func (rw OpenAIResponseRewriter) rewriteResponsesSSE(body []byte, eval ToolUseEv
 		return RewriteResult{
 			Body:          out,
 			Decisions:     decisions,
-			Rewritten:     anyBlocked || anyRewritten,
+			Rewritten:     anyBlocked || anyRewritten || anyCvReasonStripped,
 			AssistantTurn: turn,
 		}, nil
 	}
@@ -841,7 +841,7 @@ func (rw OpenAIResponseRewriter) rewriteChatCompletionsJSON(body []byte, eval To
 		if err != nil {
 			return RewriteResult{}, fmt.Errorf("openai chat: marshal rewritten response: %w", err)
 		}
-		return RewriteResult{Body: rewritten, Decisions: decisions, Rewritten: anyBlocked || anyRewritten, AssistantTurn: turn}, nil
+		return RewriteResult{Body: rewritten, Decisions: decisions, Rewritten: anyBlocked || anyRewritten || anyCvReasonStripped, AssistantTurn: turn}, nil
 	}
 	return RewriteResult{Body: body, Decisions: decisions, AssistantTurn: turn}, nil
 }

--- a/internal/runtime/conversation/openai_response.go
+++ b/internal/runtime/conversation/openai_response.go
@@ -123,12 +123,7 @@ func (rw OpenAIResponseRewriter) rewriteResponsesJSON(body []byte, eval ToolUseE
 			newOutput = append(newOutput, item)
 		case "function_call":
 			args := stringifyOpenAIArguments(item.Arguments)
-			tu := PopulateCvReason(ToolUse{
-				ID:    firstNonEmpty(item.CallID, item.ID),
-				Index: index,
-				Name:  item.Name,
-				Input: rawIfJSONOpenAI(args),
-			})
+			tu := NewToolUseFromInput(firstNonEmpty(item.CallID, item.ID), index, item.Name, rawIfJSONOpenAI(args))
 			if tu.CvReason != "" {
 				item.Arguments = string(tu.Input)
 				anyCvReasonStripped = true
@@ -178,8 +173,12 @@ func (rw OpenAIResponseRewriter) rewriteResponsesJSON(body []byte, eval ToolUseE
 				newOutput = append(newOutput, item)
 				continue
 			}
-			tu = PopulateCvReason(tu)
 			if tu.CvReason != "" {
+				// Strip cvreason at the source-of-truth field. The
+				// helper customToolInputForReemit prefers item.Input
+				// over item.Arguments, so writing the stripped value
+				// to Input and clearing Arguments funnels both fields
+				// through one wire-shape contract on re-emission.
 				item.Input = string(tu.Input)
 				item.Arguments = nil
 				anyCvReasonStripped = true
@@ -373,12 +372,7 @@ func (rw OpenAIResponseRewriter) rewriteResponsesSSE(body []byte, eval ToolUseEv
 					pc.arguments.WriteString(args)
 				}
 				originalArgs := pc.arguments.String()
-				tu := PopulateCvReason(ToolUse{
-					ID:    pc.callID,
-					Index: index,
-					Name:  pc.name,
-					Input: rawIfJSONOpenAI(originalArgs),
-				})
+				tu := NewToolUseFromInput(pc.callID, index, pc.name, rawIfJSONOpenAI(originalArgs))
 				if tu.CvReason != "" {
 					originalArgs = string(tu.Input)
 					pc.arguments.Reset()
@@ -432,7 +426,6 @@ func (rw OpenAIResponseRewriter) rewriteResponsesSSE(body []byte, eval ToolUseEv
 				if !ok {
 					continue
 				}
-				tu = PopulateCvReason(tu)
 				if tu.CvReason != "" {
 					raw.Item.Input = string(tu.Input)
 					raw.Item.Arguments = nil
@@ -759,12 +752,12 @@ func (rw OpenAIResponseRewriter) rewriteChatCompletionsJSON(body []byte, eval To
 			frags = append(frags, assistantFragment{Text: originalText})
 		}
 		for i, call := range choice.Message.ToolCalls {
-			tu := PopulateCvReason(ToolUse{
-				ID:    firstNonEmpty(call.ID, fmt.Sprintf("chat-tool-%d", index)),
-				Index: index,
-				Name:  call.Function.Name,
-				Input: rawIfJSONOpenAI(call.Function.Arguments),
-			})
+			tu := NewToolUseFromInput(
+				firstNonEmpty(call.ID, fmt.Sprintf("chat-tool-%d", index)),
+				index,
+				call.Function.Name,
+				rawIfJSONOpenAI(call.Function.Arguments),
+			)
 			if tu.CvReason != "" {
 				call.Function.Arguments = string(tu.Input)
 				choice.Message.ToolCalls[i] = call
@@ -966,6 +959,7 @@ func (rw OpenAIResponseRewriter) rewriteChatCompletionsSSE(body []byte, eval Too
 	var frags []assistantFragment
 	anyBlocked := false
 	anyRewritten := false
+	anyCvReasonStripped := false
 
 	for _, ci := range choiceOrder {
 		cs := choiceStates[ci]
@@ -993,19 +987,8 @@ func (rw OpenAIResponseRewriter) rewriteChatCompletionsSSE(body []byte, eval Too
 
 			for _, toolCallIndex := range toolCallIndexes {
 				pc := boundary.pendingCalls[toolCallIndex]
-				tu := PopulateCvReason(ToolUse{
-					ID:    pc.id,
-					Index: toolCallIndex,
-					Name:  pc.name,
-					Input: rawIfJSONOpenAI(pc.args.String()),
-				})
+				tu := NewToolUseFromInput(pc.id, toolCallIndex, pc.name, rawIfJSONOpenAI(pc.args.String()))
 				verdict := eval(tu)
-				if tu.CvReason != "" && verdict.Allowed && len(verdict.RewriteInput) == 0 {
-					// Treat cvreason extraction as a synthetic
-					// rewrite so the SSE replay below substitutes
-					// the stripped bytes for the original args.
-					verdict.RewriteInput = tu.Input
-				}
 				decisions = append(decisions, ToolUseDecisionRecord{
 					ToolUse:          tu,
 					Verdict:          verdict,
@@ -1044,10 +1027,23 @@ func (rw OpenAIResponseRewriter) rewriteChatCompletionsSSE(body []byte, eval Too
 						origTotalLen: origTotalLen,
 					}
 				} else {
-					if len(verdict.RewriteInput) > 0 {
+					// Canonical output bytes for this tool: policy
+					// rewrite wins, cvreason-stripped form fills in,
+					// otherwise the upstream original. The SSE replay
+					// below substitutes these bytes for the streamed
+					// arguments — both rewrite types share the same
+					// substitution machinery and only diverge in which
+					// gate-flag they raise.
+					switch {
+					case len(verdict.RewriteInput) > 0:
 						finalArgs = string(verdict.RewriteInput)
 						fragArgs = verdict.RewriteInput
 						anyRewritten = true
+						choiceRewritten = true
+					case tu.CvReason != "":
+						finalArgs = string(tu.Input)
+						fragArgs = tu.Input
+						anyCvReasonStripped = true
 						choiceRewritten = true
 					}
 					choiceOrderedChatCalls = append(choiceOrderedChatCalls, orderedChatToolCall{
@@ -1093,7 +1089,7 @@ func (rw OpenAIResponseRewriter) rewriteChatCompletionsSSE(body []byte, eval Too
 	turn := assistantTurnFromFragments(frags, decisions)
 
 	// Pass 2: Replay the original stream line-by-line, applying rewrites at the tool-call boundaries
-	if anyBlocked || anyRewritten {
+	if anyBlocked || anyRewritten || anyCvReasonStripped {
 		var rewrittenBody strings.Builder
 		replayTurn := map[int]int{}
 
@@ -1747,12 +1743,7 @@ func toolUseFromOpenAICustomToolCall(item openAIResponseOutputItem, index int) (
 	if input == "" {
 		input = stringifyOpenAIArguments(item.Arguments)
 	}
-	return ToolUse{
-		ID:    firstNonEmpty(item.CallID, item.ID),
-		Index: index,
-		Name:  name,
-		Input: rawOpenAICustomToolInput(input),
-	}, true
+	return NewToolUseFromInput(firstNonEmpty(item.CallID, item.ID), index, name, rawOpenAICustomToolInput(input)), true
 }
 
 // customToolInputForReemit returns the value to place in the
@@ -1999,12 +1990,7 @@ func (rw OpenAIResponseRewriter) streamRewriteChatCompletions(ctx context.Contex
 					if delivered[idx] {
 						continue
 					}
-					onToolUse(PopulateCvReason(ToolUse{
-						ID:    pc.id,
-						Index: idx,
-						Name:  pc.name,
-						Input: rawIfJSONOpenAI(pc.args.String()),
-					}))
+					onToolUse(NewToolUseFromInput(pc.id, idx, pc.name, rawIfJSONOpenAI(pc.args.String())))
 					delivered[idx] = true
 				}
 			}
@@ -2033,12 +2019,7 @@ func (rw OpenAIResponseRewriter) streamRewriteChatCompletions(ctx context.Contex
 	var tus []ToolUse
 	for _, toolCallIndex := range toolCallIndexes {
 		pc := pending[toolCallIndex]
-		tu := PopulateCvReason(ToolUse{
-			ID:    pc.id,
-			Index: toolCallIndex,
-			Name:  pc.name,
-			Input: rawIfJSONOpenAI(pc.args.String()),
-		})
+		tu := NewToolUseFromInput(pc.id, toolCallIndex, pc.name, rawIfJSONOpenAI(pc.args.String()))
 		tus = append(tus, tu)
 		frags = append(frags, assistantFragment{
 			IsTool:   true,
@@ -2224,12 +2205,7 @@ func (rw OpenAIResponseRewriter) streamRewriteResponses(ctx context.Context, r i
 				// carry cvreason.
 				var prepared ToolUse
 				if onToolUse != nil && !delivered[pc.itemID] {
-					prepared = PopulateCvReason(ToolUse{
-						ID:    pc.callID,
-						Index: nextDeliveredToolIndex,
-						Name:  pc.name,
-						Input: rawIfJSONOpenAI(pc.arguments.String()),
-					})
+					prepared = NewToolUseFromInput(pc.callID, nextDeliveredToolIndex, pc.name, rawIfJSONOpenAI(pc.arguments.String()))
 					if prepared.CvReason != "" {
 						pc.arguments.Reset()
 						pc.arguments.WriteString(string(prepared.Input))
@@ -2254,11 +2230,15 @@ func (rw OpenAIResponseRewriter) streamRewriteResponses(ctx context.Context, r i
 				if !ok {
 					return writeSSE(w, event, data)
 				}
-				tu = PopulateCvReason(tu)
-				customInput := customToolInputForReemit(raw.Item.Input, raw.Item.Arguments)
+				// Strip cvreason at the source-of-truth fields so the
+				// downstream customToolInputForReemit call picks up
+				// the stripped value through its normal field-priority
+				// path instead of a separate cvreason branch.
 				if tu.CvReason != "" {
-					customInput = string(tu.Input)
+					raw.Item.Input = string(tu.Input)
+					raw.Item.Arguments = nil
 				}
+				customInput := customToolInputForReemit(raw.Item.Input, raw.Item.Arguments)
 				orderedItems = append(orderedItems, orderedResponsesItem{
 					isCustomToolCall: true,
 					outputIndex:      raw.OutputIndex,
@@ -2344,12 +2324,7 @@ func (rw OpenAIResponseRewriter) streamRewriteResponses(ctx context.Context, r i
 		}
 		if item.isCustomToolCall {
 			inputRaw := rawOpenAICustomToolInputFromAny(item.customInput)
-			tu := PopulateCvReason(ToolUse{
-				ID:    firstNonEmpty(item.callID, item.itemID),
-				Index: index,
-				Name:  item.name,
-				Input: inputRaw,
-			})
+			tu := NewToolUseFromInput(firstNonEmpty(item.callID, item.itemID), index, item.name, inputRaw)
 			tus = append(tus, tu)
 			index++
 			frags = append(frags, assistantFragment{
@@ -2364,12 +2339,7 @@ func (rw OpenAIResponseRewriter) streamRewriteResponses(ctx context.Context, r i
 		if pc != nil && pc.arguments.Len() > 0 {
 			args = pc.arguments.String()
 		}
-		tu := PopulateCvReason(ToolUse{
-			ID:    item.callID,
-			Index: index,
-			Name:  item.name,
-			Input: rawIfJSONOpenAI(args),
-		})
+		tu := NewToolUseFromInput(item.callID, index, item.name, rawIfJSONOpenAI(args))
 		tus = append(tus, tu)
 		index++
 		frags = append(frags, assistantFragment{


### PR DESCRIPTION
## Summary

Follow-up to #541. Originally scoped to the wire-level `Rewritten` bug; expanded to also clean up the abstraction issues I flagged in self-review.

### Commit 1 — `Rewritten=true` on cvreason-only re-marshal

The `cvreason` stripping path was returning `RewriteResult{Rewritten: false}` even though the body bytes had diverged from upstream's. `api/handlers/llm_endpoint.go:1807` gates `Content-Length` / `Content-Encoding` cleanup on `processed.Rewritten`, so the proxy was forwarding upstream's now-stale `Content-Length` together with a shorter body. Folds `anyCvReasonStripped` into the returned `Rewritten` at all five non-streaming rewrite sites.

### Commit 2 — abstraction cleanup

Three quality follow-ups noted in self-review of #541:

- **`NewToolUseFromInput` constructor.** All 12 `PopulateCvReason(ToolUse{...})` sites now flow through one factory so new construction sites can't silently leak cvreason. `toolUseFromOpenAICustomToolCall` is routed through the constructor too.
- **Route `custom_tool_call` cvreason through `customToolInputForReemit`.** The cvreason branch used to bypass the helper; now we strip at the source-of-truth fields (`item.Input` + clearing `Arguments`) and let the helper's existing field-priority logic pick it up uniformly.
- **Drop the synthetic-verdict hack in `rewriteChatCompletionsSSE`.** Used to set `verdict.RewriteInput = tu.Input` to coerce the policy-rewrite replay. Replaced with an explicit `canonicalOutput` switch that distinguishes policy rewrites from cvreason normalization. `anyCvReasonStripped` joins the replay gate.

## Test plan

- [x] `go test ./...` — green
- [x] Flipped existing assertion (`TestAnthropicRewriteJSONStripsCvReasonFromBody`) now expects `Rewritten=true`
- [x] New: `TestOpenAIChatCompletionsRewriteJSONFlagsCvReasonRemarshalAsRewritten` (JSON path contract)
- [x] New: `TestOpenAIChatCompletionsSSEStripsCvReasonWithoutPolicyVerdict` (pins the new `canonicalOutput` shared substitution path on the cvreason-only branch)
- [x] New: `TestNewToolUseFromInput*` (locks the constructor contract)
- [ ] Manual: confirm a Claude Code session on a non-streaming Anthropic JSON response no longer sees `Content-Length` mismatch errors at the harness

🤖 Generated with [Claude Code](https://claude.com/claude-code)