### PR TITLE
feat(llmproxy): add graceful timeout handling for script-session LLM judge

### DIFF
--- a/internal/runtime/llmproxy/policies/script_session_evaluator.go
+++ b/internal/runtime/llmproxy/policies/script_session_evaluator.go
@@ -115,6 +115,30 @@ func (e *ScriptSessionEvaluator) Evaluate(ctx context.Context, _ pipeline.ReadOn
 			if errors.Is(err, scriptjudge.ErrNotConfigured) {
 				return pipeline.ToolUseVerdict{Outcome: pipeline.OutcomeSkip}, nil
 			}
+
+			if ctx.Err() != nil {
+				return pipeline.ToolUseVerdict{}, ctx.Err()
+			}
+
+			// Bounded latency / timeout defense: if the LLM judge sub-context timed out
+			// (deadline exceeded while parent context is still active), deny the tool call
+			// with a clear retry message rather than falling back to a manual
+			// approval prompt (Skip) that would stall a headless session.
+			if errors.Is(err, context.DeadlineExceeded) || judgeCtx.Err() == context.DeadlineExceeded {
+				return pipeline.ToolUseVerdict{
+					Outcome: pipeline.OutcomeDeny,
+					Reason:  "Clawvisor: script-session call refused — LLM intent judge timed out (" + scriptSessionJudgeCallTimeout.String() + " limit reached). Please retry.",
+					Facts: []pipeline.EvaluationFact{pipeline.ScriptSessionFact{
+						Outcome:           "script_session_judge_timeout",
+						JudgePromptSHA:    verdict.PromptSHA,
+						JudgeLatencyMS:    verdict.LatencyMS,
+						JudgeInputTokens:  verdict.InputTokens,
+						JudgeOutputTokens: verdict.OutputTokens,
+						JudgeError:        "timeout",
+					}},
+				}, nil
+			}
+
 			// Real error: fall through to inspector chain, but
 			// emit an audit-only fact so the judge attempt is
 			// forensically visible — operators can see latency +

--- a/internal/runtime/llmproxy/policies/script_session_evaluator_test.go
+++ b/internal/runtime/llmproxy/policies/script_session_evaluator_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/pipeline"
@@ -279,5 +280,116 @@ func TestScriptSessionEvaluator_URLUnrecognized_JudgeBlock_EmptyGuidance(t *test
 	}
 	if !strings.Contains(v.Reason, "doesn't appear to target the resolver") {
 		t.Errorf("Reason %q should carry generic fallback guidance when AgentGuidance is empty", v.Reason)
+	}
+}
+
+// TestScriptSessionEvaluator_URLUnrecognized_JudgeTimeout confirms that
+// when the LLM judge times out (deadline exceeded error), the evaluator
+// returns OutcomeDeny with the timeout message, rather than falling back
+// (Skip) to the inspector. The judge_timeout fact is emitted.
+func TestScriptSessionEvaluator_URLUnrecognized_JudgeTimeout(t *testing.T) {
+	judge := &stubJudge{
+		verdict: scriptjudge.Verdict{PromptSHA: "xyz789", LatencyMS: 8005},
+		err:     context.DeadlineExceeded,
+	}
+	e := policies.NewScriptSessionEvaluator(func(_ context.Context, _ conversation.ToolUse) *policies.ScriptSessionInputs {
+		return &policies.ScriptSessionInputs{ResolverBaseURL: "http://localhost:25297/api/proxy", Judge: judge}
+	})
+	v, err := e.Evaluate(context.Background(), newStubResp(), urlUnrecognizedToolUse(), &recordingMutator{})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if v.Outcome != pipeline.OutcomeDeny {
+		t.Errorf("Outcome = %q, want Deny (judge timed out)", v.Outcome)
+	}
+	if !strings.Contains(v.Reason, "LLM intent judge timed out (8s limit reached)") {
+		t.Errorf("Reason = %q, should contain timeout message with limit", v.Reason)
+	}
+	var fact pipeline.ScriptSessionFact
+	for _, f := range v.Facts {
+		if ss, ok := f.(pipeline.ScriptSessionFact); ok && ss.Outcome == "script_session_judge_timeout" {
+			fact = ss
+		}
+	}
+	if fact.Outcome == "" {
+		t.Fatalf("ScriptSessionFact judge_timeout missing (facts: %+v)", v.Facts)
+	}
+	if fact.JudgeError != "timeout" {
+		t.Errorf("JudgeError = %q, want 'timeout'", fact.JudgeError)
+	}
+	if fact.JudgePromptSHA != "xyz789" || fact.JudgeLatencyMS != 8005 {
+		t.Errorf("forensic fields not propagated: prompt_sha=%q latency=%d", fact.JudgePromptSHA, fact.JudgeLatencyMS)
+	}
+}
+
+// TestScriptSessionEvaluator_URLUnrecognized_ParentContextCanceled confirms that
+// if the parent context is cancelled, the evaluator propagates the context
+// cancellation error directly instead of returning an OutcomeDeny verdict.
+func TestScriptSessionEvaluator_URLUnrecognized_ParentContextCanceled(t *testing.T) {
+	judge := &stubJudge{
+		verdict: scriptjudge.Verdict{},
+		err:     context.Canceled,
+	}
+	e := policies.NewScriptSessionEvaluator(func(_ context.Context, _ conversation.ToolUse) *policies.ScriptSessionInputs {
+		return &policies.ScriptSessionInputs{ResolverBaseURL: "http://localhost:25297/api/proxy", Judge: judge}
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel context before calling Evaluate
+	_, err := e.Evaluate(ctx, newStubResp(), urlUnrecognizedToolUse(), &recordingMutator{})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Evaluate error = %v, want context.Canceled", err)
+	}
+}
+
+// TestScriptSessionEvaluator_URLUnrecognized_ParentContextTimedOut confirms that
+// if the parent context is timed out, the evaluator propagates the context
+// deadline exceeded error directly instead of returning an OutcomeDeny verdict.
+func TestScriptSessionEvaluator_URLUnrecognized_ParentContextTimedOut(t *testing.T) {
+	judge := &stubJudge{
+		verdict: scriptjudge.Verdict{},
+		err:     context.DeadlineExceeded,
+	}
+	e := policies.NewScriptSessionEvaluator(func(_ context.Context, _ conversation.ToolUse) *policies.ScriptSessionInputs {
+		return &policies.ScriptSessionInputs{ResolverBaseURL: "http://localhost:25297/api/proxy", Judge: judge}
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Microsecond)
+	defer cancel()
+	<-ctx.Done() // Await timeout deterministically
+	_, err := e.Evaluate(ctx, newStubResp(), urlUnrecognizedToolUse(), &recordingMutator{})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Evaluate error = %v, want context.DeadlineExceeded", err)
+	}
+}
+
+// TestScriptSessionEvaluator_URLUnrecognized_JudgeCallCanceledParentActive confirms that
+// if the judge call is cancelled internally (or returns context.Canceled) but the
+// parent context is still active, the evaluator does not abort evaluation but falls back
+// with OutcomeSkip and a judge_error fact.
+func TestScriptSessionEvaluator_URLUnrecognized_JudgeCallCanceledParentActive(t *testing.T) {
+	judge := &stubJudge{
+		verdict: scriptjudge.Verdict{},
+		err:     context.Canceled,
+	}
+	e := policies.NewScriptSessionEvaluator(func(_ context.Context, _ conversation.ToolUse) *policies.ScriptSessionInputs {
+		return &policies.ScriptSessionInputs{ResolverBaseURL: "http://localhost:25297/api/proxy", Judge: judge}
+	})
+	v, err := e.Evaluate(context.Background(), newStubResp(), urlUnrecognizedToolUse(), &recordingMutator{})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if v.Outcome != pipeline.OutcomeSkip {
+		t.Errorf("Outcome = %q, want Skip (fallback to inspector chain)", v.Outcome)
+	}
+	var fact pipeline.ScriptSessionFact
+	for _, f := range v.Facts {
+		if ss, ok := f.(pipeline.ScriptSessionFact); ok && ss.Outcome == "script_session_judge_error" {
+			fact = ss
+		}
+	}
+	if fact.Outcome == "" {
+		t.Fatalf("ScriptSessionFact judge_error missing (facts: %+v)", v.Facts)
+	}
+	if !strings.Contains(fact.JudgeError, "context canceled") {
+		t.Errorf("JudgeError = %q, should contain 'context canceled'", fact.JudgeError)
 	}
 }


### PR DESCRIPTION
### Summary
PR #529 introduced the `scriptjudge` LLM-based classifier to evaluate unrecognized URLs containing variables. This PR builds on that by adding graceful timeout handling when the LLM Judge times out or fails during hot-path evaluations.

Rather than letting transient LLM latency stall headless environments (or fall back to manual Skip approval flows which require human intervention), we now intercept judge timeouts and return a structured `OutcomeDeny` with a clear message guiding users to retry, alongside emitting a `script_session_judge_timeout` fact for audit visibility. We also ensure parent context cancellations are cleanly propagated.

---

### Before & After (Behavioral Comparison)

| Aspect | Before | After |
| :--- | :--- | :--- |
| **LLM Judge Timeout (8s)** | Evaluator skips the judge on timeout, falling back to a manual approval prompt (`OutcomeSkip`). This wedges/stalls automated, headless runner sessions. | Evaluator denies the tool use with a clear, automated retry message (`OutcomeDeny`). Headless sessions fail-fast and can retry automatically. |
| **Parent Context Cancellation** | Evaluator would treat any cancellation error (`context.Canceled`) as a fatal crash of the request or incorrectly suppress it as a local judge timeout. | Evaluator checks the parent request context (`ctx.Err() != nil`). If the parent request was canceled, it immediately aborts evaluation; if only the judge call got canceled, it falls back to the inspector chain. |
| **Forensics & Audit Log** | Transient timeouts are log-only or mixed with standard errors, making them hard to distinguish from policy violations. | Emits a dedicated `script_session_judge_timeout` fact detailing latency, token counts, and target SHAs. |

---

### Proposed Changes

#### `internal/runtime/llmproxy/policies`

* **[MODIFY] [script_session_evaluator.go](file:///c:/Users/sharm/OneDrive/Documents/projects/clawvisor/internal/runtime/llmproxy/policies/script_session_evaluator.go)**:
  * Intercept `context.DeadlineExceeded` or `judgeCtx.Err() == context.DeadlineExceeded` when the parent context is active.
  * Return `pipeline.OutcomeDeny` with the retry reason and a `script_session_judge_timeout` evaluation fact.
  * Propagate parent context cancellations/timeouts (`ctx.Err() != nil`) immediately up the stack.
  
* **[MODIFY] [script_session_evaluator_test.go](file:///c:/Users/sharm/OneDrive/Documents/projects/clawvisor/internal/runtime/llmproxy/policies/script_session_evaluator_test.go)**:
  * Added `TestScriptSessionEvaluator_URLUnrecognized_JudgeTimeout` to verify structured denial when the judge times out.
  * Added `TestScriptSessionEvaluator_URLUnrecognized_ParentContextCanceled` to verify direct parent context cancellation propagation.
  * Added `TestScriptSessionEvaluator_URLUnrecognized_ParentContextTimedOut` to verify direct parent context timeout propagation.
  * Added `TestScriptSessionEvaluator_URLUnrecognized_JudgeCallCanceledParentActive` to verify that judge-only cancellation falls back cleanly.

---

### Verification Plan

* **Automated Tests**:
  * Verify policies unit tests pass:
    ```bash
    go test -v ./internal/runtime/llmproxy/policies/...
    ```