### PR TITLE
feat(llmproxy): recoverable Deny verdicts give agents one retry per turn

### DIFF
--- a/internal/runtime/conversation/verdict.go
+++ b/internal/runtime/conversation/verdict.go
@@ -1,6 +1,8 @@
 package conversation
 
 import (
+	"encoding/json"
+
 	"github.com/clawvisor/clawvisor/internal/runtime/eval"
 )
 
@@ -60,6 +62,40 @@ type (
 // served locally and the pipeline should re-enter with a synthetic
 // continuation turn.
 type ContinueSignal = eval.ContinueSignal
+
+// RecoverableContinue wraps a reason string as a Continue signal that
+// flows the reason back to the agent as a synthetic tool_result.
+// Callers building a recoverable Deny verdict use the higher-level
+// RecoverableDenyVerdict; this primitive is exported for evaluators
+// that need a customized verdict shape (e.g. richer Continue
+// payloads, additional notice text).
+func RecoverableContinue(reason string) *ContinueSignal {
+	payload, _ := json.Marshal(reason)
+	return &ContinueSignal{
+		SyntheticToolResults: []json.RawMessage{payload},
+	}
+}
+
+// RecoverableDenyVerdict builds the standard recoverable-deny verdict
+// used by evaluators that block on a construction error the agent can
+// fix on its next attempt. The reason flows back to the agent as a
+// continuation tool_result (consumed by tryContinuation for the one
+// allowed retry per inbound request) and is retained as
+// SubstituteWith so the second-pass / mixed-turn fallback still
+// renders a terminal assistant message.
+//
+// The structural one-retry budget is enforced by tryContinuation's
+// non-recursion in the lite-proxy handler — no per-session state is
+// needed here.
+func RecoverableDenyVerdict(reason string, facts ...EvaluationFact) ToolUseVerdict {
+	return ToolUseVerdict{
+		Outcome:        OutcomeDeny,
+		Reason:         reason,
+		SubstituteWith: reason,
+		Continue:       RecoverableContinue(reason),
+		Facts:          facts,
+	}
+}
 
 // InspectorVerdictSnapshot is the audit-row projection of the
 // inspector's verdict.

--- a/internal/runtime/llmproxy/pipeline/tool_use_orchestrator.go
+++ b/internal/runtime/llmproxy/pipeline/tool_use_orchestrator.go
@@ -92,18 +92,40 @@ func EvaluateToolUses(
 				if !continueOutcomeValid(verdict) {
 					return nil, fmt.Errorf("evaluator %q on tool_use %q returned Continue with outcome %q; Continue requires Allow, Rewrite, or a local substitute fallback", ev.Name(), tu.ID, verdict.Outcome)
 				}
-				// Continuation short-circuits the whole pass.
 				result.Evaluations[len(result.Evaluations)-1].Winning = true
-				result.Continue = verdict.Continue
-				result.ContinueFromToolUseID = tu.ID
-				result.PerToolUse[tu.ID] = verdict
-				for _, sibling := range toolUses[i+1:] {
-					result.PerToolUse[sibling.ID] = ToolUseVerdict{
-						Outcome: OutcomeDeny,
-						Reason:  "Clawvisor: unprocessed sibling tool_use refused after continuation",
+				if verdict.Outcome == OutcomeAllow || verdict.Outcome == OutcomeRewrite {
+					// Allow/Rewrite + Continue (the auto-approve /
+					// inline-task pattern) short-circuits the whole
+					// pass. The evaluator has already replaced the
+					// assistant turn locally, so running sibling
+					// evaluators against the now-stale turn shape
+					// would be incoherent.
+					result.Continue = verdict.Continue
+					result.ContinueFromToolUseID = tu.ID
+					result.PerToolUse[tu.ID] = verdict
+					for _, sibling := range toolUses[i+1:] {
+						result.PerToolUse[sibling.ID] = ToolUseVerdict{
+							Outcome: OutcomeDeny,
+							Reason:  "Clawvisor: unprocessed sibling tool_use refused after continuation",
+						}
 					}
+					return result, nil
 				}
-				return result, nil
+				// Deny + Continue (recoverable deny): record the
+				// per-tool verdict and keep evaluating siblings.
+				// The handler's tryContinuation collects every
+				// per-tool Continue and gates the upstream retry on
+				// the 1:1 tool_use/tool_result invariant; until
+				// then, siblings deserve their own real verdicts so
+				// audit, finalizer hooks, and the terminal-substitute
+				// fallback surface the right reasons.
+				if result.Continue == nil {
+					result.Continue = verdict.Continue
+					result.ContinueFromToolUseID = tu.ID
+				}
+				v := verdict
+				winner = &v
+				break
 			}
 			if verdict.Outcome != OutcomeSkip {
 				result.Evaluations[len(result.Evaluations)-1].Winning = true
@@ -138,6 +160,18 @@ func defaultUnclaimedToolUseVerdict(evaluations []ToolUseEvaluation, toolUseID s
 		}
 	}
 	if credentialedFact != nil {
+		// Terminal — not recoverable. This fires when InspectorChain
+		// classified the call as credentialed but no downstream
+		// evaluator (script-session, control-tool, credential-rewrite)
+		// claimed it. That's a policy-misconfiguration / fail-closed
+		// scenario, not an agent construction error: there is no
+		// alternate call shape the agent can try that would route
+		// around a missing claimant, so flowing the reason back as a
+		// recoverable continuation would just burn the one-retry
+		// budget and produce a confusing UX. The credential_rewrite
+		// evaluator's own rewriter-error path (which IS recoverable)
+		// carries actionable "switch to a script session" guidance
+		// for the cases where shape-changing actually helps.
 		return ToolUseVerdict{
 			Outcome: OutcomeDeny,
 			Reason:  "Clawvisor: credentialed API call was not rewritten; refusing to send original tool_use upstream",

--- a/internal/runtime/llmproxy/pipeline/tool_use_orchestrator_test.go
+++ b/internal/runtime/llmproxy/pipeline/tool_use_orchestrator_test.go
@@ -233,6 +233,85 @@ func TestEvaluateToolUses_DeniedContinueRequiresSubstituteFallback(t *testing.T)
 	}
 }
 
+// TestEvaluateToolUses_DeniedContinueDoesNotShortCircuitSiblings pins
+// that a recoverable Deny + Continue verdict (the
+// RecoverableDenyVerdict pattern used by script_session_evaluator,
+// boundary_check, the autovault stub guard, the malformed-control
+// paths, and the orchestrator's unrewritten-credentialed fallback)
+// does NOT abort sibling evaluation. Each sibling must still get its
+// own real verdict so audit, finalizer hooks, and the
+// terminal-substitute fallback surface the right reasons. Only
+// Allow/Rewrite + Continue (the inline-task auto-approve pattern,
+// which has already replaced the assistant turn locally) is allowed
+// to short-circuit.
+func TestEvaluateToolUses_DeniedContinueDoesNotShortCircuitSiblings(t *testing.T) {
+	res := &orchTestResponse{provider: conversation.ProviderAnthropic}
+	tools := []conversation.ToolUse{
+		{ID: "toolu_recoverable", Name: "Bash"},
+		{ID: "toolu_sibling", Name: "Bash"},
+	}
+
+	// Recoverable Deny+Continue fires only on the first tool_use; the
+	// second tool_use Skips through it and lands on the allowEvaluator.
+	evaluators := []pipeline.ToolUseEvaluator{
+		&denyContinueForIDEvaluator{name: "first_recoverable", matchID: "toolu_recoverable", substitute: "first-fallback"},
+		&allowEvaluator{name: "second_real_verdict", tag: "real"},
+	}
+
+	result, err := pipeline.EvaluateToolUses(context.Background(), res, tools, evaluators, func(id string) pipeline.ToolUseMutator {
+		return &recordingToolUseMutator{id: id}
+	})
+	if err != nil {
+		t.Fatalf("EvaluateToolUses: %v", err)
+	}
+
+	first := result.PerToolUse["toolu_recoverable"]
+	if first.Outcome != pipeline.OutcomeDeny || first.Continue == nil {
+		t.Fatalf("first tool: Outcome=%q Continue=%v, want Deny+Continue", first.Outcome, first.Continue)
+	}
+
+	sibling, ok := result.PerToolUse["toolu_sibling"]
+	if !ok {
+		t.Fatal("sibling tool_use missing from PerToolUse")
+	}
+	if sibling.Reason == "Clawvisor: unprocessed sibling tool_use refused after continuation" {
+		t.Fatalf("sibling was short-circuited as 'unprocessed sibling refused'; recoverable Deny+Continue must keep evaluating siblings so they get their own real verdict (got %+v)", sibling)
+	}
+	if sibling.Outcome != pipeline.OutcomeAllow || sibling.Reason != "real" {
+		t.Fatalf("sibling verdict = %+v, want Allow tagged 'real' from the second evaluator", sibling)
+	}
+
+	if result.Continue == nil {
+		t.Fatal("expected Continue to remain set for the handler's tryContinuation path")
+	}
+	if result.ContinueFromToolUseID != "toolu_recoverable" {
+		t.Errorf("ContinueFromToolUseID = %q, want toolu_recoverable", result.ContinueFromToolUseID)
+	}
+}
+
+// denyContinueForIDEvaluator emits a recoverable Deny+Continue verdict
+// only for the tool_use whose ID matches matchID; other tool_uses get
+// Skip so downstream evaluators run normally.
+type denyContinueForIDEvaluator struct {
+	name       string
+	matchID    string
+	substitute string
+}
+
+func (e *denyContinueForIDEvaluator) Name() string { return e.name }
+func (e *denyContinueForIDEvaluator) Evaluate(_ context.Context, _ pipeline.ReadOnlyResponse, tu conversation.ToolUse, _ pipeline.ToolUseMutator) (pipeline.ToolUseVerdict, error) {
+	if tu.ID != e.matchID {
+		return pipeline.ToolUseVerdict{Outcome: pipeline.OutcomeSkip}, nil
+	}
+	return pipeline.ToolUseVerdict{
+		Outcome:        pipeline.OutcomeDeny,
+		SubstituteWith: e.substitute,
+		Continue: &pipeline.ContinueSignal{
+			SyntheticToolResults: []json.RawMessage{json.RawMessage(`"continued"`)},
+		},
+	}, nil
+}
+
 // TestEvaluateToolUses_HoldVerdictsPreservedPerTool pins that
 // per-tool-use Hold verdicts collect without coalescing (Phase 5 will
 // add coalescing on top).

--- a/internal/runtime/llmproxy/policies/boundary_check_evaluator.go
+++ b/internal/runtime/llmproxy/policies/boundary_check_evaluator.go
@@ -125,11 +125,7 @@ func (e *BoundaryCheckEvaluator) EvaluateWithVerdict(_ context.Context, v inspec
 			Facts:   []pipeline.EvaluationFact{fact},
 		}
 	}
-	return pipeline.ToolUseVerdict{
-		Outcome: pipeline.OutcomeDeny,
-		Reason:  reason,
-		Facts:   []pipeline.EvaluationFact{fact},
-	}
+	return conversation.RecoverableDenyVerdict(reason, fact)
 }
 
 var _ pipeline.ToolUseEvaluator = (*BoundaryCheckEvaluator)(nil)

--- a/internal/runtime/llmproxy/policies/boundary_check_evaluator_test.go
+++ b/internal/runtime/llmproxy/policies/boundary_check_evaluator_test.go
@@ -54,6 +54,15 @@ func TestBoundaryCheck_DenyOnMismatchedHost(t *testing.T) {
 	if boundaryFactPassed(result.Facts) {
 		t.Errorf("boundary_check_passed fact = true, want false (facts: %+v)", result.Facts)
 	}
+	if result.SubstituteWith == "" || result.SubstituteWith != result.Reason {
+		t.Errorf("SubstituteWith = %q, want = Reason for the terminal-fallback path", result.SubstituteWith)
+	}
+	if result.Continue == nil || len(result.Continue.SyntheticToolResults) != 1 {
+		t.Fatalf("Continue.SyntheticToolResults missing — boundary deny should be recoverable so the agent can retry against an allowed host")
+	}
+	if content, ok := result.ContinuationToolResultContent(); !ok || content != result.Reason {
+		t.Errorf("ContinuationToolResultContent = %q, %v; want Reason verbatim", content, ok)
+	}
 }
 
 func boundaryFactPassed(facts []pipeline.EvaluationFact) bool {

--- a/internal/runtime/llmproxy/policies/control_tool_use_evaluator.go
+++ b/internal/runtime/llmproxy/policies/control_tool_use_evaluator.go
@@ -156,12 +156,9 @@ func (e *ControlToolUseEvaluator) rewriteControlCall(ctx context.Context, tu con
 
 func (e *ControlToolUseEvaluator) rewriteMalformedControlCall(ctx context.Context, tu conversation.ToolUse, mut pipeline.ToolUseMutator, in *ControlToolUseInputs) (pipeline.ToolUseVerdict, error) {
 	const failureReason = "malformed_control_command"
+	const malformedShapeReason = "Clawvisor: control endpoint rewrite refused — use a single foreground curl to the control endpoint, with no pipes, subshells, redirects to output files, or extra shell commands"
 	if in.CallerNonces == nil {
-		return pipeline.ToolUseVerdict{
-			Outcome: pipeline.OutcomeDeny,
-			Reason:  "Clawvisor: control endpoint rewrite refused — use a single foreground curl to the control endpoint, with no pipes, subshells, redirects to output files, or extra shell commands",
-			Facts:   []pipeline.EvaluationFact{pipeline.ControlFact{Outcome: "caller_nonce_unavailable"}},
-		}, nil
+		return conversation.RecoverableDenyVerdict(malformedShapeReason, pipeline.ControlFact{Outcome: "caller_nonce_unavailable"}), nil
 	}
 	target := callernonce.NonceTarget{
 		Host:   controltool.ControlSyntheticHost,
@@ -179,11 +176,7 @@ func (e *ControlToolUseEvaluator) rewriteMalformedControlCall(ctx context.Contex
 	rewritten, ok, rewriteErr := controltool.RewriteControlFailureToolUse(tu, in.ControlBaseURL, nonce, failureReason)
 	if !ok {
 		_, _ = in.CallerNonces.Consume(ctx, nonce, target)
-		return pipeline.ToolUseVerdict{
-			Outcome: pipeline.OutcomeDeny,
-			Reason:  "Clawvisor: control endpoint rewrite refused — use a single foreground curl to the control endpoint, with no pipes, subshells, redirects to output files, or extra shell commands",
-			Facts:   []pipeline.EvaluationFact{pipeline.ControlFact{Outcome: "control_rewriter_error"}},
-		}, nil
+		return conversation.RecoverableDenyVerdict(malformedShapeReason, pipeline.ControlFact{Outcome: "control_rewriter_error"}), nil
 	}
 	if rewriteErr != nil {
 		_, _ = in.CallerNonces.Consume(ctx, nonce, target)

--- a/internal/runtime/llmproxy/policies/credential_rewrite_evaluator.go
+++ b/internal/runtime/llmproxy/policies/credential_rewrite_evaluator.go
@@ -2,7 +2,6 @@ package policies
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/callernonce"
@@ -129,21 +128,12 @@ func (e *CredentialRewriteEvaluator) Evaluate(ctx context.Context, _ pipeline.Re
 	if err != nil {
 		_, _ = in.CallerNonces.Consume(ctx, nonce, target)
 		reason := rewritehelp.CredentialedRewriteRecoveryReason(v, err)
-		continuationPayload, _ := json.Marshal(reason)
-		return pipeline.ToolUseVerdict{
-			Outcome:        pipeline.OutcomeDeny,
-			Reason:         reason,
-			SubstituteWith: reason,
-			Continue: &pipeline.ContinueSignal{
-				SyntheticToolResults: []json.RawMessage{continuationPayload},
-			},
-			Facts: []pipeline.EvaluationFact{pipeline.RewriteFact{
-				Outcome:      "rewriter_error",
-				TargetHost:   v.Host,
-				TargetMethod: v.Method,
-				TargetPath:   v.Path,
-			}},
-		}, nil
+		return conversation.RecoverableDenyVerdict(reason, pipeline.RewriteFact{
+			Outcome:      "rewriter_error",
+			TargetHost:   v.Host,
+			TargetMethod: v.Method,
+			TargetPath:   v.Path,
+		}), nil
 	}
 	if mut != nil {
 		if err := mut.RewriteArgs(rewritten); err != nil {

--- a/internal/runtime/llmproxy/policies/inspector_chain.go
+++ b/internal/runtime/llmproxy/policies/inspector_chain.go
@@ -102,12 +102,8 @@ func (c *InspectorChain) Evaluate(ctx context.Context, _ pipeline.ReadOnlyRespon
 	// bypassing boundary checks if the stub heuristic ever misclassifies
 	// a real placeholder. Fail closed instead.
 	if v.Source != inspector.SourceTriggerMiss && inspector.AllPlaceholdersAreStubs(v.Placeholders) {
-		inspectorFact := newInspectorFact(v)
-		return pipeline.ToolUseVerdict{
-			Outcome: pipeline.OutcomeDeny,
-			Reason:  "Clawvisor: autovault placeholder is too short to validate safely",
-			Facts:   []pipeline.EvaluationFact{inspectorFact},
-		}, nil
+		const reason = "Clawvisor: autovault placeholder is too short to validate safely"
+		return conversation.RecoverableDenyVerdict(reason, newInspectorFact(v)), nil
 	}
 
 	inspectorFact := newInspectorFact(v)
@@ -173,11 +169,7 @@ func (c *InspectorChain) Evaluate(ctx context.Context, _ pipeline.ReadOnlyRespon
 		Host:        v.Host,
 	}
 	if !decision.Allowed {
-		return pipeline.ToolUseVerdict{
-			Outcome: pipeline.OutcomeDeny,
-			Reason:  decision.Reason,
-			Facts:   []pipeline.EvaluationFact{inspectorFact, boundaryFact},
-		}, nil
+		return conversation.RecoverableDenyVerdict(decision.Reason, inspectorFact, boundaryFact), nil
 	}
 
 	// Boundary passed — let downstream stages handle credentialed

--- a/internal/runtime/llmproxy/policies/inspector_chain_integration_test.go
+++ b/internal/runtime/llmproxy/policies/inspector_chain_integration_test.go
@@ -157,6 +157,15 @@ func TestInspectorChainIntegration_CredentialRewriteDivergenceFailsClosed(t *tes
 	if !strings.Contains(v.Reason, "credentialed API call was not rewritten") {
 		t.Fatalf("Reason = %q, want fail-closed rewrite-divergence message", v.Reason)
 	}
+	// Terminal — not recoverable. This is a policy-misconfiguration
+	// fail-closed; the agent has no alternate shape to retry that
+	// would route around a missing claimant evaluator.
+	if v.Continue != nil {
+		t.Errorf("Continue should be nil — unclaimed-credentialed fail-closed is not agent-recoverable (got %+v)", v.Continue)
+	}
+	if v.SubstituteWith != "" {
+		t.Errorf("SubstituteWith should be empty — terminal Deny falls back to the rewriter's default block prompt, not a custom continuation fallback (got %q)", v.SubstituteWith)
+	}
 	if got := len(result.Evaluations); got != 4 {
 		t.Fatalf("expected all four evaluators to Skip before default Deny, got %d: %+v", got, result.Evaluations)
 	}

--- a/internal/runtime/llmproxy/policies/inspector_chain_test.go
+++ b/internal/runtime/llmproxy/policies/inspector_chain_test.go
@@ -150,6 +150,15 @@ func TestInspectorChain_TypedBoundaryDenyReasons(t *testing.T) {
 			if got != tc.want {
 				t.Fatalf("BoundaryFact.DenyReason = %q, want %q (facts: %+v)", got, tc.want, v.Facts)
 			}
+			if v.SubstituteWith == "" || v.SubstituteWith != v.Reason {
+				t.Errorf("SubstituteWith = %q, want = Reason for the terminal-fallback path", v.SubstituteWith)
+			}
+			if v.Continue == nil || len(v.Continue.SyntheticToolResults) != 1 {
+				t.Fatalf("Continue.SyntheticToolResults missing — boundary deny should be recoverable so the agent can retry against an allowed host")
+			}
+			if content, ok := v.ContinuationToolResultContent(); !ok || content != v.Reason {
+				t.Errorf("ContinuationToolResultContent = %q, %v; want Reason verbatim", content, ok)
+			}
 		})
 	}
 }
@@ -275,6 +284,15 @@ func TestInspectorChain_StubPlaceholdersFailClosed(t *testing.T) {
 	}
 	if v.Outcome != pipeline.OutcomeDeny {
 		t.Errorf("stub-length placeholder → Outcome = %q, want Deny", v.Outcome)
+	}
+	if v.SubstituteWith == "" || v.SubstituteWith != v.Reason {
+		t.Errorf("SubstituteWith = %q, want = Reason for the terminal-fallback path", v.SubstituteWith)
+	}
+	if v.Continue == nil || len(v.Continue.SyntheticToolResults) != 1 {
+		t.Fatalf("Continue.SyntheticToolResults missing — stub-placeholder block should be recoverable so the agent can retry with the full placeholder")
+	}
+	if content, ok := v.ContinuationToolResultContent(); !ok || content != v.Reason {
+		t.Errorf("ContinuationToolResultContent = %q, %v; want Reason verbatim", content, ok)
 	}
 }
 

--- a/internal/runtime/llmproxy/policies/script_session_evaluator.go
+++ b/internal/runtime/llmproxy/policies/script_session_evaluator.go
@@ -156,17 +156,14 @@ func (e *ScriptSessionEvaluator) Evaluate(ctx context.Context, _ pipeline.ReadOn
 		if guidance == "" {
 			guidance = "the call doesn't appear to target the resolver at " + in.ResolverBaseURL
 		}
-		return pipeline.ToolUseVerdict{
-			Outcome: pipeline.OutcomeDeny,
-			Reason:  "Clawvisor: script-session call refused — " + guidance,
-			Facts: []pipeline.EvaluationFact{pipeline.ScriptSessionFact{
-				Outcome:           "script_session_judge_block",
-				JudgePromptSHA:    verdict.PromptSHA,
-				JudgeLatencyMS:    verdict.LatencyMS,
-				JudgeInputTokens:  verdict.InputTokens,
-				JudgeOutputTokens: verdict.OutputTokens,
-			}},
-		}, nil
+		reason := "Clawvisor: script-session call refused — " + guidance
+		return conversation.RecoverableDenyVerdict(reason, pipeline.ScriptSessionFact{
+			Outcome:           "script_session_judge_block",
+			JudgePromptSHA:    verdict.PromptSHA,
+			JudgeLatencyMS:    verdict.LatencyMS,
+			JudgeInputTokens:  verdict.InputTokens,
+			JudgeOutputTokens: verdict.OutputTokens,
+		}), nil
 	case scriptrecognition.NoMatch:
 		return pipeline.ToolUseVerdict{Outcome: pipeline.OutcomeSkip}, nil
 	default:

--- a/internal/runtime/llmproxy/policies/script_session_evaluator_test.go
+++ b/internal/runtime/llmproxy/policies/script_session_evaluator_test.go
@@ -210,6 +210,15 @@ func TestScriptSessionEvaluator_URLUnrecognized_JudgeBlock(t *testing.T) {
 	if !strings.HasPrefix(v.Reason, "Clawvisor: script-session call refused — ") {
 		t.Errorf("Reason %q should have Clawvisor refusal prefix", v.Reason)
 	}
+	if v.SubstituteWith != v.Reason {
+		t.Errorf("SubstituteWith = %q, want = Reason for the terminal-fallback path", v.SubstituteWith)
+	}
+	if v.Continue == nil || len(v.Continue.SyntheticToolResults) != 1 {
+		t.Fatalf("Continue.SyntheticToolResults missing — judge block should flow guidance back to the agent as a recoverable tool_result")
+	}
+	if content, ok := v.ContinuationToolResultContent(); !ok || content != v.Reason {
+		t.Errorf("ContinuationToolResultContent = %q, %v; want Reason verbatim", content, ok)
+	}
 	found := false
 	for _, f := range v.Facts {
 		if ss, ok := f.(pipeline.ScriptSessionFact); ok && ss.Outcome == "script_session_judge_block" {

--- a/internal/runtime/llmproxy/postproc/postprocess_test.go
+++ b/internal/runtime/llmproxy/postproc/postprocess_test.go
@@ -246,6 +246,186 @@ func TestPostprocessStream_StructuredContinuationResult(t *testing.T) {
 	}
 }
 
+// TestPostprocessStream_RecoverableDenyEmitsContinuationAndSubstitute
+// pins the shape produced by the recoverable-deny pattern used by
+// script_session_evaluator, boundary_check, the autovault stub guard,
+// the orchestrator's unrewritten-credentialed fallback, and the
+// malformed-control-call paths. A Deny verdict that also carries
+// Continue + SubstituteWith must surface to the handler as both:
+//
+//   - ContinuationToolResults populated, so serve()'s tryContinuation
+//     branch fires and feeds the reason back to the agent on the
+//     next upstream call (the "one retry" path).
+//   - SubstituteWith preserved on the decision verdict, so when the
+//     handler's structurally-bounded continuation does not act on the
+//     signal (because the model's retry also Denies recoverably, or
+//     because the second pass cannot run), the substitute text
+//     renders as a terminal assistant turn.
+//
+// Together these enforce the "exactly one retry per tool_use per
+// turn" budget without per-session state: tryContinuation runs at
+// most once, and the second pass always lands on SubstituteWith if
+// the recoverable deny repeats.
+func TestPostprocessStream_RecoverableDenyEmitsContinuationAndSubstitute(t *testing.T) {
+	req := httptest.NewRequest("POST", "/v1/messages", nil)
+	insp := inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{})
+	input := strings.Join([]string{
+		`event: message_start`,
+		`data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-test","content":[]}}`,
+		``,
+		`event: content_block_start`,
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_recoverable","name":"Bash","input":{}}}`,
+		``,
+		`event: content_block_delta`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"command\":\"echo hi\"}"}}`,
+		``,
+		`event: content_block_stop`,
+		`data: {"type":"content_block_stop","index":0}`,
+		``,
+		`event: message_delta`,
+		`data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":15}}`,
+		``,
+		`event: message_stop`,
+		`data: {"type":"message_stop"}`,
+		``,
+	}, "\n")
+
+	const refusalText = "Clawvisor: script-session call refused — replace https://gmail.googleapis.com with the resolver mount"
+	factory := func(_ *http.Request, _ llmproxy.PostprocessConfig, _ conversation.Provider, _ []conversation.ToolUse, _ func(conversation.AuditEvent)) conversation.ToolUseEvaluator {
+		return func(conversation.ToolUse) conversation.ToolUseVerdict {
+			payload, _ := json.Marshal(refusalText)
+			return conversation.ToolUseVerdict{
+				Allowed:        false,
+				Outcome:        conversation.OutcomeDeny,
+				Reason:         refusalText,
+				SubstituteWith: refusalText,
+				Continue: &conversation.ContinueSignal{
+					SyntheticToolResults: []json.RawMessage{payload},
+				},
+			}
+		}
+	}
+
+	var output bytes.Buffer
+	result, err := PostprocessStream(context.Background(), req, strings.NewReader(input), &output, "text/event-stream", llmproxy.PostprocessConfig{
+		ToolUseEvaluatorFactory: factory,
+		RewriteContext: llmproxy.RewriteContext{
+			Inspector: insp,
+		},
+	})
+	if err != nil {
+		t.Fatalf("PostprocessStream: %v", err)
+	}
+	if len(result.ContinuationToolResults) != 1 {
+		t.Fatalf("ContinuationToolResults = %+v, want one result so the handler triggers tryContinuation", result.ContinuationToolResults)
+	}
+	if got := result.ContinuationToolResults[0]; got.ToolUseID != "toolu_recoverable" || got.Content != refusalText {
+		t.Fatalf("ContinuationToolResults[0] = %+v, want refusal text routed back to the model as a tool_result for toolu_recoverable", got)
+	}
+	if len(result.Decisions) != 1 {
+		t.Fatalf("Decisions = %d, want 1", len(result.Decisions))
+	}
+	if result.Decisions[0].Verdict.SubstituteWith != refusalText {
+		t.Fatalf("decision verdict lost SubstituteWith fallback: %q", result.Decisions[0].Verdict.SubstituteWith)
+	}
+	if result.Decisions[0].Verdict.Continue == nil {
+		t.Fatal("decision verdict lost Continue signal — handler would skip tryContinuation")
+	}
+	if result.Decisions[0].Verdict.Outcome != conversation.OutcomeDeny {
+		t.Fatalf("decision Outcome = %q, want Deny (recoverable deny must remain typed as a deny)", result.Decisions[0].Verdict.Outcome)
+	}
+}
+
+// TestPostprocessStream_RecoverableDenyMixedSiblingsFallsThroughToSubstitute
+// pins the mixed-turn safety: when a recoverable Deny tool_use sits
+// next to a sibling that doesn't have a continuation tool_result,
+// the handler's tryContinuation cannot fire (Anthropic/OpenAI 400 on
+// an unbalanced tool_use/tool_result count). PostprocessStream MUST
+// detect this case and fall through to the substitute-prompt path so
+// the wire carries a clean blocked turn — leaving ContinuationToolResults
+// populated would withhold the buffered tool_use blocks until a
+// continuation that the handler will refuse to issue, truncating the
+// harness's stream.
+func TestPostprocessStream_RecoverableDenyMixedSiblingsFallsThroughToSubstitute(t *testing.T) {
+	req := httptest.NewRequest("POST", "/v1/messages", nil)
+	insp := inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{})
+	input := strings.Join([]string{
+		`event: message_start`,
+		`data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-test","content":[]}}`,
+		``,
+		`event: content_block_start`,
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_recoverable","name":"Bash","input":{}}}`,
+		``,
+		`event: content_block_delta`,
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"command\":\"echo a\"}"}}`,
+		``,
+		`event: content_block_stop`,
+		`data: {"type":"content_block_stop","index":0}`,
+		``,
+		`event: content_block_start`,
+		`data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_allow","name":"Bash","input":{}}}`,
+		``,
+		`event: content_block_delta`,
+		`data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"command\":\"echo b\"}"}}`,
+		``,
+		`event: content_block_stop`,
+		`data: {"type":"content_block_stop","index":1}`,
+		``,
+		`event: message_delta`,
+		`data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":15}}`,
+		``,
+		`event: message_stop`,
+		`data: {"type":"message_stop"}`,
+		``,
+	}, "\n")
+
+	const refusalText = "Clawvisor: script-session call refused — switch to the resolver mount"
+	factory := func(_ *http.Request, _ llmproxy.PostprocessConfig, _ conversation.Provider, _ []conversation.ToolUse, _ func(conversation.AuditEvent)) conversation.ToolUseEvaluator {
+		return func(tu conversation.ToolUse) conversation.ToolUseVerdict {
+			if tu.ID == "toolu_recoverable" {
+				payload, _ := json.Marshal(refusalText)
+				return conversation.ToolUseVerdict{
+					Allowed:        false,
+					Outcome:        conversation.OutcomeDeny,
+					Reason:         refusalText,
+					SubstituteWith: refusalText,
+					Continue: &conversation.ContinueSignal{
+						SyntheticToolResults: []json.RawMessage{payload},
+					},
+				}
+			}
+			return conversation.ToolUseVerdict{Allowed: true, Outcome: conversation.OutcomeAllow}
+		}
+	}
+
+	var output bytes.Buffer
+	result, err := PostprocessStream(context.Background(), req, strings.NewReader(input), &output, "text/event-stream", llmproxy.PostprocessConfig{
+		ToolUseEvaluatorFactory: factory,
+		RewriteContext: llmproxy.RewriteContext{
+			Inspector: insp,
+		},
+	})
+	if err != nil {
+		t.Fatalf("PostprocessStream: %v", err)
+	}
+	if len(result.ContinuationToolResults) != 0 {
+		t.Fatalf("ContinuationToolResults = %+v, want empty (mixed sibling makes 1:1 impossible; handler's tryContinuation would skip and leave the stream truncated)", result.ContinuationToolResults)
+	}
+	out := output.String()
+	// BlockedReasonText surfaces the recoverable Deny's SubstituteWith
+	// directly (no "Tool use was blocked..." prefix when any decision
+	// supplies a substitute), so the wire carries the refusal text as
+	// the assistant turn. The key invariant: a substitute IS written,
+	// not the bare unwritten tool_use blocks that StreamRewrite
+	// withheld.
+	if !strings.Contains(out, refusalText) {
+		t.Fatalf("substitute prompt missing from wire — mixed-sibling recoverable deny should fall through to writeProviderBlockedPrompt with the substitute text so the harness sees a clean blocked turn (got: %s)", out)
+	}
+	if strings.Contains(out, `"name":"Bash"`) {
+		t.Fatalf("wire still carries a tool_use block — recoverable+sibling case should NOT emit tool_use bytes when continuation can't fire (got: %s)", out)
+	}
+}
+
 func anthropicSSEIndexContaining(stream, needle string) (int, bool) {
 	events := strings.Split(strings.ReplaceAll(stream, "\r\n", "\n"), "\n\n")
 	for _, event := range events {

--- a/internal/runtime/llmproxy/postproc/stream.go
+++ b/internal/runtime/llmproxy/postproc/stream.go
@@ -158,7 +158,18 @@ func PostprocessStream(
 		}
 	}
 
-	if len(continuationResults) > 0 {
+	// Continuation only fires when every tool_use in the turn has a
+	// synthetic tool_result — Anthropic/OpenAI both 400 on an
+	// unbalanced tool_use/tool_result count, so the handler's
+	// tryContinuation skips the upstream call on a mismatch. Returning
+	// early with ContinuationToolResults populated when the 1:1
+	// invariant won't hold would leave the buffered tool_use blocks
+	// unwritten (StreamRewrite withholds them until the substitute or
+	// tool_use writer fires) and the harness would receive a truncated
+	// stream. Fall through to the substitute path so the wire carries
+	// a clean blocked-prompt turn in the mixed-recoverable-sibling
+	// case, mirroring the handler's own 1:1 check earlier in the flow.
+	if len(continuationResults) > 0 && len(continuationResults) == len(decisions) {
 		return llmproxy.PostprocessResult{
 			ContentType:             contentType,
 			Rewritten:               true,


### PR DESCRIPTION
## Summary

- Evaluator denies that block on a **construction error the agent can fix** (script-session refused, boundary host mismatch, autovault stub placeholder, malformed control call, credential-rewriter error) now flow the reason back as a synthetic `tool_result` so the model corrects on the same turn.
- **Authorization-style** refusals (user-denied approvals, mint-time intent verifier, scope denials) and **infrastructure failures** (no policy claimed, nonce cache unavailable) stay terminal — those can't be fixed by retrying.
- Structural one-retry budget: enforced by `tryContinuation`'s non-recursion in the lite-proxy handler. No per-session state.

New helper `conversation.RecoverableDenyVerdict(reason, facts...)` bundles the `Deny + Continue + SubstituteWith` shape so every recoverable site is a one-liner. `credential_rewrite_evaluator` (the original template for this pattern) was migrated to the helper too.

Two adjustments to the surrounding machinery shook out during cubic review:

- **`tool_use_orchestrator`** — only `Allow`/`Rewrite + Continue` short-circuits sibling evaluation (the inline-task auto-approve pattern, which replaces the assistant turn locally). `Deny + Continue` lets siblings get their own real verdicts so audit, finalizer hooks, and the terminal-substitute fallback surface the right reasons.
- **`postproc/stream`** — only return early with `ContinuationToolResults` populated when `len(continuations) == len(decisions)`. Mixed turns fall through to the substitute path so the wire carries a clean blocked-prompt turn instead of leaving StreamRewrite's buffered `tool_use` blocks unwritten when the handler's 1:1 check skips continuation later. This was a latent issue in the existing credential_rewrite recoverable path that the new sites would have hit harder.

## Test plan

- [x] `go build ./... && go vet ./...`
- [x] `go test ./internal/runtime/llmproxy/... ./internal/runtime/conversation/... ./internal/api/handlers/...`
- [x] Each flipped evaluator: unit test asserts `Continue.SyntheticToolResults` + `SubstituteWith` populated
- [x] Orchestrator sibling-evaluation: `TestEvaluateToolUses_DeniedContinueDoesNotShortCircuitSiblings`
- [x] Mixed-sibling streaming safety: `TestPostprocessStream_RecoverableDenyMixedSiblingsFallsThroughToSubstitute`
- [x] Existing `TestPostprocessStream_StructuredContinuationResult` (Allow+Continue / auto-approve path) still pins the short-circuit behavior for the inline-task pattern
- [ ] Spot-check: trigger a script-session judge block in staging against a Gmail-bound session, confirm the agent retries on the same turn instead of surfacing a chat message

🤖 Generated with [Claude Code](https://claude.com/claude-code)