### PR TITLE
fix(calendar): accept location, q, larger pages + time_min/time_max aliases

### DIFF
--- a/internal/adapters/definitions/google_calendar.yaml
+++ b/internal/adapters/definitions/google_calendar.yaml
@@ -44,16 +44,19 @@ actions:
       calendar_id: { type: string, default: "primary", location: path }
       from:
         type: string
+        aliases: [time_min]
         default_expr: "now()"
         transform: "rfc3339(from)"
         map_to: timeMin
         location: query
       to:
         type: string
+        aliases: [time_max]
         transform: "endOfDay(to)"
         map_to: timeMax
         location: query
-      max_results: { type: int, default: 10, max: 50, map_to: maxResults, location: query }
+      q: { type: string, location: query }
+      max_results: { type: int, default: 10, max: 2500, map_to: maxResults, location: query }
       page_token: { type: string, map_to: pageToken, location: query }
       single_events: { type: string, default: "true", map_to: singleEvents, location: query }
       order_by: { type: string, default: "startTime", map_to: orderBy, location: query }
@@ -128,6 +131,7 @@ actions:
       send_updates: { type: string, default: "none", location: query, map_to: sendUpdates }
       summary: { type: string, required: true, location: body }
       description: { type: string, location: body }
+      location: { type: string, location: body }
       start:
         type: string
         required: true
@@ -170,6 +174,7 @@ actions:
       send_updates: { type: string, default: "none", location: query, map_to: sendUpdates }
       summary: { type: string, location: body }
       description: { type: string, location: body }
+      location: { type: string, location: body }
       start:
         type: string
         location: body

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -2600,19 +2600,32 @@ func validateRequestParams(adapter adapters.Adapter, action string, params map[s
 		return nil, nil
 	}
 
-	// Build a set of known param names.
+	// Build a set of known param names (including aliases).
 	known := make(map[string]bool, len(paramDefs))
 	for _, p := range paramDefs {
 		known[p.Name] = true
+		for _, a := range p.Aliases {
+			known[a] = true
+		}
 	}
 
-	// Check for missing required params.
+	// Check for missing required params. An alias satisfies the primary.
 	var missing []string
 	for _, p := range paramDefs {
 		if !p.Required {
 			continue
 		}
-		if _, provided := params[p.Name]; !provided {
+		if _, provided := params[p.Name]; provided {
+			continue
+		}
+		var aliasProvided bool
+		for _, a := range p.Aliases {
+			if _, ok := params[a]; ok {
+				aliasProvided = true
+				break
+			}
+		}
+		if !aliasProvided {
 			missing = append(missing, p.Name)
 		}
 	}

--- a/pkg/adapters/adapters.go
+++ b/pkg/adapters/adapters.go
@@ -250,9 +250,10 @@ type Adapter interface {
 
 // ParamInfo describes a single action parameter for validation and error reporting.
 type ParamInfo struct {
-	Name     string `json:"name"`
-	Type     string `json:"type"` // "string", "int", "bool", "object", "array"
-	Required bool   `json:"required"`
+	Name     string   `json:"name"`
+	Type     string   `json:"type"` // "string", "int", "bool", "object", "array"
+	Required bool     `json:"required"`
+	Aliases  []string `json:"aliases,omitempty"` // alternative caller-facing names; an alias satisfies Required
 }
 
 // ActionParamDescriber is an optional interface that adapters can implement

--- a/pkg/adapters/yamldef/schema.go
+++ b/pkg/adapters/yamldef/schema.go
@@ -162,6 +162,12 @@ type Param struct {
 	Max      *int   `yaml:"max,omitempty"`
 	Location string `yaml:"location,omitempty"` // "query", "body", "path"
 
+	// Aliases are alternative caller-facing names for this parameter. When the
+	// primary name is absent from the request, the runtime falls back to the
+	// first alias that appears. Used for backward-compatibility renames and
+	// for accepting common synonyms (e.g. "from" with alias "time_min").
+	Aliases []string `yaml:"aliases,omitempty"`
+
 	MapTo       string `yaml:"map_to,omitempty"`       // API-side parameter name (if different from YAML name)
 	Transform   string `yaml:"transform,omitempty"`     // expr expression applied to the resolved value
 	DefaultExpr string `yaml:"default_expr,omitempty"` // expr expression for dynamic default (e.g. "rfc3339(now())")

--- a/pkg/adapters/yamlruntime/adapter.go
+++ b/pkg/adapters/yamlruntime/adapter.go
@@ -84,6 +84,7 @@ func (a *YAMLAdapter) ActionParams(actionName string) []adapters.ParamInfo {
 			Name:     name,
 			Type:     p.Type,
 			Required: p.Required,
+			Aliases:  p.Aliases,
 		})
 	}
 	sort.Slice(params, func(i, j int) bool { return params[i].Name < params[j].Name })

--- a/pkg/adapters/yamlruntime/adapter_test.go
+++ b/pkg/adapters/yamlruntime/adapter_test.go
@@ -863,6 +863,71 @@ func TestYAMLAdapter_ParamTransformExpr(t *testing.T) {
 	}
 }
 
+func TestYAMLAdapter_ParamAliasResolution(t *testing.T) {
+	var seenTimeMin string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenTimeMin = r.URL.Query().Get("timeMin")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"items": []any{}})
+	}))
+	defer srv.Close()
+
+	def := yamldef.ServiceDef{
+		Service: yamldef.ServiceInfo{ID: "test"},
+		Auth:    yamldef.AuthDef{Type: "api_key", Header: "Authorization", HeaderPrefix: "Bearer "},
+		API:     yamldef.APIDef{BaseURL: srv.URL, Type: "rest"},
+		Actions: map[string]yamldef.Action{
+			"list": {
+				Method: "GET", Path: "/events",
+				Params: map[string]yamldef.Param{
+					"from": {
+						Type:      "string",
+						Aliases:   []string{"time_min"},
+						Transform: "rfc3339(from)",
+						MapTo:     "timeMin",
+						Location:  "query",
+					},
+				},
+				Response: yamldef.ResponseDef{Summary: "done"},
+			},
+		},
+	}
+	adapter, err := New(def, nil)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+
+	// Primary name still works.
+	if _, err := adapter.Execute(context.Background(), adapters.Request{
+		Action: "list", Params: map[string]any{"from": "2024-06-15"}, Credential: testCred("t"),
+	}); err != nil {
+		t.Fatalf("primary execute: %v", err)
+	}
+	if seenTimeMin != "2024-06-15T00:00:00Z" {
+		t.Errorf("primary: expected RFC3339 timeMin, got %q", seenTimeMin)
+	}
+
+	// Alias name resolves to the same query param, with transform applied.
+	seenTimeMin = ""
+	if _, err := adapter.Execute(context.Background(), adapters.Request{
+		Action: "list", Params: map[string]any{"time_min": "2024-07-20"}, Credential: testCred("t"),
+	}); err != nil {
+		t.Fatalf("alias execute: %v", err)
+	}
+	if seenTimeMin != "2024-07-20T00:00:00Z" {
+		t.Errorf("alias: expected RFC3339 timeMin, got %q", seenTimeMin)
+	}
+
+	// Alias is reported as a known param via ActionParams.
+	params := adapter.ActionParams("list")
+	if len(params) != 1 || params[0].Name != "from" {
+		t.Fatalf("unexpected ActionParams: %+v", params)
+	}
+	if len(params[0].Aliases) != 1 || params[0].Aliases[0] != "time_min" {
+		t.Errorf("expected alias 'time_min', got %v", params[0].Aliases)
+	}
+}
+
 func TestCustomFunctions(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/adapters/yamlruntime/rest.go
+++ b/pkg/adapters/yamlruntime/rest.go
@@ -175,6 +175,20 @@ func resolveParamWithExpr(params map[string]any, name string, def yamldef.Param,
 	val, ok := params[name]
 	provided := ok && val != nil
 
+	// Fall back to aliases if the primary name was not supplied. The transform
+	// step below copies the resolved value back into env[name], so transform
+	// expressions referencing the primary name still work.
+	if !ok || val == nil {
+		for _, alias := range def.Aliases {
+			if av, has := params[alias]; has && av != nil {
+				val = av
+				ok = true
+				provided = true
+				break
+			}
+		}
+	}
+
 	if !ok || val == nil {
 		// Try dynamic default first, then static.
 		if ca != nil {


### PR DESCRIPTION
## Summary

The Google Calendar adapter was silently dropping parameters that agents naturally pass. All changes are **backward compatible** — existing callers keep working.

- `update_event` and `create_event` now accept `location` so a venue can be set or changed without delete-and-recreate (which would lose RSVPs). Previously the gateway warned `Unknown param "location" … will be ignored` and the YAML runtime dropped it.
- `list_events` gains:
  - `q` for free-text search (new param).
  - `max_results` cap raised from 50 → 2500 (Google's actual API ceiling), removing the forced manual pagination for callers asking for a larger page. Existing callers passing `max_results ≤ 50` are unaffected.
  - `time_min` and `time_max` as aliases for `from` and `to`. Agents commonly use the snake_case of Google's `timeMin`/`timeMax` and were getting silently dropped (falling back to the implicit `from=now()` default with no upper bound). `from`/`to` continue to work unchanged.

## Schema mechanism

Adds a generic `aliases: [...]` field to the YAML param schema (`pkg/adapters/yamldef/schema.go`). The YAML runtime (`pkg/adapters/yamlruntime/rest.go`) falls back to an alias when the primary name is absent; the existing transform pipeline already injects the resolved value under the primary name, so transforms like `rfc3339(from)` work whether the caller used `from` or `time_min`. The gateway's unknown-param validator (`internal/api/handlers/gateway.go`) treats alias names as known and considers an alias as satisfying a required primary. ParamInfo gains an `Aliases []string` field.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] New `TestYAMLAdapter_ParamAliasResolution` verifies both primary and alias names resolve, with transforms applied, and that `ActionParams` surfaces aliases.
- [ ] Manual: call `update_event` with `location` and confirm Google PATCH includes it.
- [ ] Manual: call `list_events` with `time_min`/`time_max`/`q`/`max_results=200`; confirm the upstream URL has all four query params and that results exceed 50.
- [ ] Manual: confirm `list_events` with the original `from`/`to` still works unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)