### PR TITLE
feat(llmproxy): headless runner inactivity routing & programmatic wait API

### DIFF
--- a/internal/api/handlers/connections.go
+++ b/internal/api/handlers/connections.go
@@ -614,7 +614,7 @@ func (h *ConnectionsHandler) PollStatus(w http.ResponseWriter, r *http.Request) 
 func (h *ConnectionsHandler) waitForConnectionResolution(ctx context.Context, connID, userID string, timeout time.Duration) *store.ConnectionRequest {
 	return events.WaitFor(ctx, h.eventHub, userID, timeout,
 		nil, // any event type
-		func(c context.Context) (*store.ConnectionRequest, bool) {
+		func(c context.Context, _ *events.Event) (*store.ConnectionRequest, bool) {
 			cr, err := h.st.GetConnectionRequest(c, connID)
 			if err != nil {
 				return &store.ConnectionRequest{ID: connID, Status: "pending"}, false

--- a/internal/api/handlers/control.go
+++ b/internal/api/handlers/control.go
@@ -371,6 +371,8 @@ func (h *LLMControlHandler) CheckoutTask(w http.ResponseWriter, r *http.Request)
 	})
 }
 
+var errSentinelHold = &llmproxy.PendingLiteApproval{ID: "err-sentinel"}
+
 func (h *LLMControlHandler) WaitForApproval(w http.ResponseWriter, r *http.Request) {
 	agent := middleware.AgentFromContext(r.Context())
 	if agent == nil {
@@ -418,24 +420,27 @@ func (h *LLMControlHandler) WaitForApproval(w http.ResponseWriter, r *http.Reque
 		taskID = pending.PendingTaskID
 	}
 
-	task, err := h.Store.GetTask(r.Context(), taskID)
-	if err != nil {
-		if errors.Is(err, store.ErrNotFound) {
-			if pending == nil {
-				writeJSON(w, http.StatusNotFound, map[string]any{
-					"error":   "not_found",
-					"message": "approval or task not found",
+	var task *store.Task
+	if pending == nil || pending.PendingTaskID != "" {
+		task, err = h.Store.GetTask(r.Context(), taskID)
+		if err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				if pending == nil {
+					writeJSON(w, http.StatusNotFound, map[string]any{
+						"error":   "not_found",
+						"message": "approval or task not found",
+					})
+					return
+				}
+				writeJSON(w, http.StatusOK, map[string]any{"status": "denied"})
+				return
+			} else {
+				writeJSON(w, http.StatusInternalServerError, map[string]any{
+					"error":   "internal_error",
+					"message": "failed to lookup task: " + err.Error(),
 				})
 				return
 			}
-			writeJSON(w, http.StatusOK, map[string]any{"status": "denied"})
-			return
-		} else {
-			writeJSON(w, http.StatusInternalServerError, map[string]any{
-				"error":   "internal_error",
-				"message": "failed to lookup task: " + err.Error(),
-			})
-			return
 		}
 	}
 
@@ -462,7 +467,10 @@ func (h *LLMControlHandler) WaitForApproval(w http.ResponseWriter, r *http.Reque
 
 	if h.EventHub != nil {
 		if task != nil {
-			resolvedTask := events.WaitFor(r.Context(), h.EventHub, agent.UserID, timeout, []string{"tasks"}, func(c context.Context) (*store.Task, bool) {
+			resolvedTask := events.WaitFor(r.Context(), h.EventHub, agent.UserID, timeout, []string{"tasks"}, func(c context.Context, evt *events.Event) (*store.Task, bool) {
+				if evt != nil && evt.ID != "" && evt.ID != taskID {
+					return nil, false
+				}
 				t, err := h.Store.GetTask(c, taskID)
 				if err != nil {
 					if errors.Is(err, store.ErrNotFound) {
@@ -480,10 +488,13 @@ func (h *LLMControlHandler) WaitForApproval(w http.ResponseWriter, r *http.Reque
 				return
 			}
 		} else if pending != nil && h.PendingApprovals != nil {
-			resolvedHold := events.WaitFor(r.Context(), h.EventHub, agent.UserID, timeout, []string{"audit", "queue"}, func(c context.Context) (*llmproxy.PendingLiteApproval, bool) {
+			resolvedHold := events.WaitFor(r.Context(), h.EventHub, agent.UserID, timeout, []string{"audit", "queue"}, func(c context.Context, evt *events.Event) (*llmproxy.PendingLiteApproval, bool) {
+				if evt != nil && evt.ID != "" && evt.ID != id && (pending.PendingTaskID == "" || evt.ID != pending.PendingTaskID) {
+					return nil, false
+				}
 				p, err := h.PendingApprovals.PeekByID(c, id)
 				if err != nil {
-					return nil, false
+					return errSentinelHold, false
 				}
 				return p, p == nil
 			})

--- a/internal/api/handlers/control.go
+++ b/internal/api/handlers/control.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -8,6 +9,7 @@ import (
 	"time"
 
 	"github.com/clawvisor/clawvisor/internal/api/middleware"
+	"github.com/clawvisor/clawvisor/internal/events"
 	"github.com/clawvisor/clawvisor/internal/intent"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy"
 	"github.com/clawvisor/clawvisor/pkg/store"
@@ -24,7 +26,9 @@ type LLMControlHandler struct {
 	// that the derived capability (placeholder + host + methods +
 	// path prefixes) is checked against the active task scope. nil
 	// falls back to a deterministic check only.
-	IntentVerifier intent.Verifier
+	IntentVerifier   intent.Verifier
+	PendingApprovals llmproxy.PendingApprovalCache
+	EventHub         events.EventHub
 }
 
 func NewLLMControlHandler(baseURL string) *LLMControlHandler {
@@ -137,17 +141,17 @@ func (h *LLMControlHandler) Failure(w http.ResponseWriter, r *http.Request) {
 }
 
 type controlTaskSummary struct {
-	ID                string                     `json:"id"`
-	Purpose           string                     `json:"purpose"`
-	Status            string                     `json:"status"`
-	Lifetime          string                     `json:"lifetime,omitempty"`
-	ExpiresAt         *time.Time                 `json:"expires_at,omitempty"`
-	AuthorizedActions []store.TaskAction         `json:"authorized_actions,omitempty"`
-	PlannedCalls      []store.PlannedCall        `json:"planned_calls,omitempty"`
-	ExpectedTools     json.RawMessage            `json:"expected_tools,omitempty"`
-	ExpectedEgress    json.RawMessage            `json:"expected_egress,omitempty"`
-	Placeholders      []controlTaskPlaceholder   `json:"placeholders,omitempty"`
-	CheckedOut        bool                       `json:"checked_out"`
+	ID                string                   `json:"id"`
+	Purpose           string                   `json:"purpose"`
+	Status            string                   `json:"status"`
+	Lifetime          string                   `json:"lifetime,omitempty"`
+	ExpiresAt         *time.Time               `json:"expires_at,omitempty"`
+	AuthorizedActions []store.TaskAction       `json:"authorized_actions,omitempty"`
+	PlannedCalls      []store.PlannedCall      `json:"planned_calls,omitempty"`
+	ExpectedTools     json.RawMessage          `json:"expected_tools,omitempty"`
+	ExpectedEgress    json.RawMessage          `json:"expected_egress,omitempty"`
+	Placeholders      []controlTaskPlaceholder `json:"placeholders,omitempty"`
+	CheckedOut        bool                     `json:"checked_out"`
 }
 
 // controlTaskPlaceholder is the per-task autovault_* handle list returned
@@ -364,6 +368,166 @@ func (h *LLMControlHandler) CheckoutTask(w http.ResponseWriter, r *http.Request)
 		"expires_at": task.ExpiresAt,
 		"message":    "Task is checked out as the current focus. Clawvisor will prefer it only when it is a valid match for later tool calls.",
 		"next_step":  "Continue with the requested work using normal tool calls. Do not add task_id or extra fields to tool inputs.",
+	})
+}
+
+func (h *LLMControlHandler) WaitForApproval(w http.ResponseWriter, r *http.Request) {
+	agent := middleware.AgentFromContext(r.Context())
+	if agent == nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]any{
+			"error":   "unauthorized",
+			"message": "missing agent context",
+		})
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]any{
+			"error":   "id_required",
+			"message": "approval id or task id is required",
+		})
+		return
+	}
+
+	var pending *llmproxy.PendingLiteApproval
+	var err error
+	if h.PendingApprovals != nil {
+		pending, err = h.PendingApprovals.PeekByID(r.Context(), id)
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]any{
+				"error":   "internal_error",
+				"message": "failed to peek pending approval cache: " + err.Error(),
+			})
+			return
+		}
+	}
+
+	if pending != nil {
+		if pending.UserID != agent.UserID || pending.AgentID != agent.ID {
+			writeJSON(w, http.StatusForbidden, map[string]any{
+				"error":   "forbidden",
+				"message": "approval hold belongs to a different agent/user",
+			})
+			return
+		}
+	}
+
+	taskID := id
+	if pending != nil && pending.PendingTaskID != "" {
+		taskID = pending.PendingTaskID
+	}
+
+	task, err := h.Store.GetTask(r.Context(), taskID)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			if pending == nil {
+				writeJSON(w, http.StatusNotFound, map[string]any{
+					"error":   "not_found",
+					"message": "approval or task not found",
+				})
+				return
+			}
+		} else {
+			writeJSON(w, http.StatusInternalServerError, map[string]any{
+				"error":   "internal_error",
+				"message": "failed to lookup task: " + err.Error(),
+			})
+			return
+		}
+	}
+
+	if task != nil {
+		if task.UserID != agent.UserID || task.AgentID != agent.ID {
+			writeJSON(w, http.StatusForbidden, map[string]any{
+				"error":   "forbidden",
+				"message": "task belongs to a different agent/user",
+			})
+			return
+		}
+
+		if task.Status != "pending_approval" {
+			if task.Status == "active" {
+				writeJSON(w, http.StatusOK, map[string]any{"status": "approved"})
+				return
+			}
+			writeJSON(w, http.StatusOK, map[string]any{"status": "denied"})
+			return
+		}
+	}
+
+	timeout := longPollDeadline(r)
+
+	if h.EventHub != nil {
+		if task != nil {
+			resolvedTask := events.WaitFor(r.Context(), h.EventHub, agent.UserID, timeout, []string{"tasks"}, func(c context.Context) (*store.Task, bool) {
+				t, err := h.Store.GetTask(c, taskID)
+				if err != nil {
+					if errors.Is(err, store.ErrNotFound) {
+						return &store.Task{ID: taskID, Status: "deleted"}, true
+					}
+					return &store.Task{ID: taskID}, false
+				}
+				return t, t.Status != "pending_approval"
+			})
+			if resolvedTask.Status == "active" {
+				writeJSON(w, http.StatusOK, map[string]any{"status": "approved"})
+				return
+			} else if resolvedTask.Status != "pending_approval" {
+				writeJSON(w, http.StatusOK, map[string]any{"status": "denied"})
+				return
+			}
+		} else if pending != nil && h.PendingApprovals != nil {
+			resolvedHold := events.WaitFor(r.Context(), h.EventHub, agent.UserID, timeout, []string{"audit", "queue"}, func(c context.Context) (*llmproxy.PendingLiteApproval, bool) {
+				p, err := h.PendingApprovals.PeekByID(c, id)
+				if err != nil {
+					return nil, true
+				}
+				return p, p == nil
+			})
+			if resolvedHold == nil {
+				writeJSON(w, http.StatusOK, map[string]any{"status": "approved"})
+				return
+			}
+		}
+	} else {
+		deadline := time.Now().Add(timeout)
+		ticker := time.NewTicker(1 * time.Second)
+		defer ticker.Stop()
+		for time.Now().Before(deadline) {
+			select {
+			case <-r.Context().Done():
+				return
+			case <-ticker.C:
+				if task != nil {
+					t, err := h.Store.GetTask(r.Context(), taskID)
+					if err != nil {
+						if errors.Is(err, store.ErrNotFound) {
+							writeJSON(w, http.StatusOK, map[string]any{"status": "denied"})
+							return
+						}
+					} else if t.Status != "pending_approval" {
+						if t.Status == "active" {
+							writeJSON(w, http.StatusOK, map[string]any{"status": "approved"})
+							return
+						}
+						writeJSON(w, http.StatusOK, map[string]any{"status": "denied"})
+						return
+					}
+				} else if pending != nil && h.PendingApprovals != nil {
+					p, err := h.PendingApprovals.PeekByID(r.Context(), id)
+					if err == nil && p == nil {
+						writeJSON(w, http.StatusOK, map[string]any{"status": "approved"})
+						return
+					}
+				}
+			}
+		}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"status":      "pending",
+		"retry_after": 1000,
 	})
 }
 

--- a/internal/api/handlers/control.go
+++ b/internal/api/handlers/control.go
@@ -428,6 +428,8 @@ func (h *LLMControlHandler) WaitForApproval(w http.ResponseWriter, r *http.Reque
 				})
 				return
 			}
+			writeJSON(w, http.StatusOK, map[string]any{"status": "denied"})
+			return
 		} else {
 			writeJSON(w, http.StatusInternalServerError, map[string]any{
 				"error":   "internal_error",
@@ -481,7 +483,7 @@ func (h *LLMControlHandler) WaitForApproval(w http.ResponseWriter, r *http.Reque
 			resolvedHold := events.WaitFor(r.Context(), h.EventHub, agent.UserID, timeout, []string{"audit", "queue"}, func(c context.Context) (*llmproxy.PendingLiteApproval, bool) {
 				p, err := h.PendingApprovals.PeekByID(c, id)
 				if err != nil {
-					return nil, true
+					return nil, false
 				}
 				return p, p == nil
 			})

--- a/internal/api/handlers/control.go
+++ b/internal/api/handlers/control.go
@@ -420,6 +420,14 @@ func (h *LLMControlHandler) WaitForApproval(w http.ResponseWriter, r *http.Reque
 		taskID = pending.PendingTaskID
 	}
 
+	if h.Store == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{
+			"error":   "store_unavailable",
+			"message": "task store is not configured",
+		})
+		return
+	}
+
 	var task *store.Task
 	if pending == nil || pending.PendingTaskID != "" {
 		task, err = h.Store.GetTask(r.Context(), taskID)

--- a/internal/api/handlers/control_test.go
+++ b/internal/api/handlers/control_test.go
@@ -348,14 +348,17 @@ func TestControlWaitForApproval(t *testing.T) {
 		h.EventHub = hub
 		defer func() { h.EventHub = nil }()
 
+		errCh := make(chan error, 1)
 		// Start a goroutine to approve the task after a delay
 		go func() {
 			time.Sleep(50 * time.Millisecond)
 			// Update task in sqlite store
 			if err := st.UpdateTaskStatus(ctx, "task-async-pending", "active"); err != nil {
-				t.Errorf("failed to update task: %v", err)
+				errCh <- err
+				return
 			}
 			hub.Publish(user.ID, events.Event{Type: "tasks", ID: "task-async-pending"})
+			close(errCh)
 		}()
 
 		req := httptest.NewRequest(http.MethodGet, "/api/control/approvals/task-async-pending/wait?timeout=2", nil)
@@ -363,6 +366,10 @@ func TestControlWaitForApproval(t *testing.T) {
 		req = req.WithContext(store.WithAgent(req.Context(), agent))
 		res := httptest.NewRecorder()
 		h.WaitForApproval(res, req)
+
+		if err := <-errCh; err != nil {
+			t.Errorf("failed to update task in goroutine: %v", err)
+		}
 
 		if res.Code != http.StatusOK {
 			t.Errorf("expected OK, got %d", res.Code)
@@ -373,6 +380,43 @@ func TestControlWaitForApproval(t *testing.T) {
 		}
 		if payload["status"] != "approved" {
 			t.Errorf("expected status approved, got %v", payload["status"])
+		}
+	}
+
+	// 6. Ownership rejection
+	{
+		otherAgent, err := st.CreateAgent(ctx, user.ID, "other-agent", "other-token-hash")
+		if err != nil {
+			t.Fatalf("CreateAgent: %v", err)
+		}
+
+		// (a) Task belongs to a different agent
+		req1 := httptest.NewRequest(http.MethodGet, "/api/control/approvals/task-active/wait", nil)
+		req1.SetPathValue("id", "task-active")
+		req1 = req1.WithContext(store.WithAgent(req1.Context(), otherAgent))
+		res1 := httptest.NewRecorder()
+		h.WaitForApproval(res1, req1)
+		if res1.Code != http.StatusForbidden {
+			t.Errorf("expected Forbidden (403) for task ownership mismatch, got %d", res1.Code)
+		}
+
+		// (b) Pending approval hold belongs to a different agent
+		pendingHold := llmproxy.PendingLiteApproval{
+			ID:      "cv-otherhold",
+			UserID:  user.ID,
+			AgentID: agent.ID,
+		}
+		if _, err := h.PendingApprovals.Hold(ctx, pendingHold); err != nil {
+			t.Fatalf("Hold: %v", err)
+		}
+
+		req2 := httptest.NewRequest(http.MethodGet, "/api/control/approvals/cv-otherhold/wait", nil)
+		req2.SetPathValue("id", "cv-otherhold")
+		req2 = req2.WithContext(store.WithAgent(req2.Context(), otherAgent))
+		res2 := httptest.NewRecorder()
+		h.WaitForApproval(res2, req2)
+		if res2.Code != http.StatusForbidden {
+			t.Errorf("expected Forbidden (403) for pending hold ownership mismatch, got %d", res2.Code)
 		}
 	}
 }

--- a/internal/api/handlers/control_test.go
+++ b/internal/api/handlers/control_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/clawvisor/clawvisor/internal/events"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy"
 	"github.com/clawvisor/clawvisor/pkg/store"
 	"github.com/clawvisor/clawvisor/pkg/store/sqlite"
@@ -198,5 +199,180 @@ func TestControlListTasksReturnsAgentActiveTasksAndCheckout(t *testing.T) {
 	}
 	if !strings.Contains(payload.NextStep, "/control/task/checkout") {
 		t.Fatalf("expected checkout guidance, got %q", payload.NextStep)
+	}
+}
+
+func TestControlWaitForApproval(t *testing.T) {
+	ctx := context.Background()
+	db, err := sqlite.New(ctx, filepath.Join(t.TempDir(), "control-wait.db"))
+	if err != nil {
+		t.Fatalf("sqlite.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	st := sqlite.NewStore(db)
+
+	user, err := st.CreateUser(ctx, "wait-user@test.example", "hash")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	agent, err := st.CreateAgent(ctx, user.ID, "agent", "token-hash")
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	h := &LLMControlHandler{
+		BaseURL:          "http://localhost:25297",
+		Store:            st,
+		PendingApprovals: llmproxy.NewMemoryPendingApprovalCache(time.Minute),
+	}
+
+	// 1. Task not found / ID required
+	{
+		req := httptest.NewRequest(http.MethodGet, "/api/control/approvals//wait", nil)
+		req = req.WithContext(store.WithAgent(req.Context(), agent))
+		res := httptest.NewRecorder()
+		h.WaitForApproval(res, req)
+		if res.Code != http.StatusBadRequest {
+			t.Errorf("expected bad request, got %d", res.Code)
+		}
+	}
+
+	// 2. Task exists and is approved (active)
+	{
+		task := &store.Task{
+			ID:       "task-active",
+			UserID:   user.ID,
+			AgentID:  agent.ID,
+			Purpose:  "approved work",
+			Status:   "active",
+			Lifetime: "session",
+		}
+		if err := st.CreateTask(ctx, task); err != nil {
+			t.Fatalf("CreateTask: %v", err)
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/api/control/approvals/task-active/wait", nil)
+		req.SetPathValue("id", "task-active")
+		req = req.WithContext(store.WithAgent(req.Context(), agent))
+		res := httptest.NewRecorder()
+		h.WaitForApproval(res, req)
+		if res.Code != http.StatusOK {
+			t.Errorf("expected OK, got %d: %s", res.Code, res.Body.String())
+		}
+		var payload map[string]any
+		if err := json.Unmarshal(res.Body.Bytes(), &payload); err != nil {
+			t.Fatalf("Unmarshal: %v", err)
+		}
+		if payload["status"] != "approved" {
+			t.Errorf("expected status approved, got %v", payload["status"])
+		}
+	}
+
+	// 3. Task exists and is denied
+	{
+		task := &store.Task{
+			ID:       "task-denied",
+			UserID:   user.ID,
+			AgentID:  agent.ID,
+			Purpose:  "denied work",
+			Status:   "denied",
+			Lifetime: "session",
+		}
+		if err := st.CreateTask(ctx, task); err != nil {
+			t.Fatalf("CreateTask: %v", err)
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/api/control/approvals/task-denied/wait", nil)
+		req.SetPathValue("id", "task-denied")
+		req = req.WithContext(store.WithAgent(req.Context(), agent))
+		res := httptest.NewRecorder()
+		h.WaitForApproval(res, req)
+		if res.Code != http.StatusOK {
+			t.Errorf("expected OK, got %d", res.Code)
+		}
+		var payload map[string]any
+		if err := json.Unmarshal(res.Body.Bytes(), &payload); err != nil {
+			t.Fatalf("Unmarshal: %v", err)
+		}
+		if payload["status"] != "denied" {
+			t.Errorf("expected status denied, got %v", payload["status"])
+		}
+	}
+
+	// 4. Task pending approval, times out
+	{
+		task := &store.Task{
+			ID:       "task-pending",
+			UserID:   user.ID,
+			AgentID:  agent.ID,
+			Purpose:  "pending work",
+			Status:   "pending_approval",
+			Lifetime: "session",
+		}
+		if err := st.CreateTask(ctx, task); err != nil {
+			t.Fatalf("CreateTask: %v", err)
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/api/control/approvals/task-pending/wait?timeout=1", nil)
+		req.SetPathValue("id", "task-pending")
+		req = req.WithContext(store.WithAgent(req.Context(), agent))
+		res := httptest.NewRecorder()
+		h.WaitForApproval(res, req)
+		if res.Code != http.StatusOK {
+			t.Errorf("expected OK, got %d", res.Code)
+		}
+		var payload map[string]any
+		if err := json.Unmarshal(res.Body.Bytes(), &payload); err != nil {
+			t.Fatalf("Unmarshal: %v", err)
+		}
+		if payload["status"] != "pending" {
+			t.Errorf("expected status pending, got %v", payload["status"])
+		}
+	}
+
+	// 5. EventHub set: async task approval
+	{
+		task := &store.Task{
+			ID:       "task-async-pending",
+			UserID:   user.ID,
+			AgentID:  agent.ID,
+			Purpose:  "async work",
+			Status:   "pending_approval",
+			Lifetime: "session",
+		}
+		if err := st.CreateTask(ctx, task); err != nil {
+			t.Fatalf("CreateTask: %v", err)
+		}
+
+		hub := events.NewHub()
+		h.EventHub = hub
+		defer func() { h.EventHub = nil }()
+
+		// Start a goroutine to approve the task after a delay
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+			// Update task in sqlite store
+			if err := st.UpdateTaskStatus(ctx, "task-async-pending", "active"); err != nil {
+				t.Errorf("failed to update task: %v", err)
+			}
+			hub.Publish(user.ID, events.Event{Type: "tasks", ID: "task-async-pending"})
+		}()
+
+		req := httptest.NewRequest(http.MethodGet, "/api/control/approvals/task-async-pending/wait?timeout=2", nil)
+		req.SetPathValue("id", "task-async-pending")
+		req = req.WithContext(store.WithAgent(req.Context(), agent))
+		res := httptest.NewRecorder()
+		h.WaitForApproval(res, req)
+
+		if res.Code != http.StatusOK {
+			t.Errorf("expected OK, got %d", res.Code)
+		}
+		var payload map[string]any
+		if err := json.Unmarshal(res.Body.Bytes(), &payload); err != nil {
+			t.Fatalf("Unmarshal: %v", err)
+		}
+		if payload["status"] != "approved" {
+			t.Errorf("expected status approved, got %v", payload["status"])
+		}
 	}
 }

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -1342,7 +1342,10 @@ func (h *GatewayHandler) lookupAuditByRequestID(ctx context.Context, requestID, 
 func (h *GatewayHandler) waitForRequestResolution(ctx context.Context, requestID, userID, taskID string, timeout time.Duration) *store.AuditEntry {
 	return events.WaitFor(ctx, h.eventHub, userID, timeout,
 		[]string{"audit"},
-		func(c context.Context) (*store.AuditEntry, bool) {
+		func(c context.Context, evt *events.Event) (*store.AuditEntry, bool) {
+			if evt != nil && evt.ID != "" && evt.ID != requestID && (taskID == "" || evt.ID != taskID) {
+				return nil, false
+			}
 			e, err := h.lookupAuditByRequestID(c, requestID, userID, taskID)
 			if err != nil {
 				return &store.AuditEntry{RequestID: requestID, Outcome: "pending"}, false
@@ -1497,7 +1500,10 @@ func (h *GatewayHandler) writeAmbiguousExecute(w http.ResponseWriter, ctx contex
 func (h *GatewayHandler) waitForApprovalDecision(ctx context.Context, requestID, userID, taskID string, timeout time.Duration) *store.PendingApproval {
 	return events.WaitFor(ctx, h.eventHub, userID, timeout,
 		[]string{"audit", "queue"},
-		func(c context.Context) (*store.PendingApproval, bool) {
+		func(c context.Context, evt *events.Event) (*store.PendingApproval, bool) {
+			if evt != nil && evt.ID != "" && evt.ID != requestID && (taskID == "" || evt.ID != taskID) {
+				return nil, false
+			}
 			pa, err := h.store.GetPendingApprovalByTask(c, requestID, userID, taskID)
 			if err != nil {
 				return nil, true // row deleted (denied/expired)

--- a/internal/api/handlers/llm_endpoint.go
+++ b/internal/api/handlers/llm_endpoint.go
@@ -166,6 +166,9 @@ type LLMEndpointHandler struct {
 	// for routing approvals to external notification channels.
 	InactivityThresholdSeconds int
 
+	activityDebounceMu sync.Mutex
+	activityDebounce   map[string]time.Time
+
 	// RawIOLogger, when non-nil, captures full raw HTTP bodies for
 	// inbound requests, upstream responses, and the bodies returned
 	// to the harness. Off by default; opted in via
@@ -218,6 +221,28 @@ func NewLLMEndpointHandler(st store.Store, v vault.Vault, logger *slog.Logger) *
 		InactivityThresholdSeconds: 300,
 		defaultToolRulesSeen:       map[string]map[string]struct{}{},
 	}
+}
+
+func (h *LLMEndpointHandler) shouldDebounceActivity(conversationID string) bool {
+	h.activityDebounceMu.Lock()
+	defer h.activityDebounceMu.Unlock()
+	if h.activityDebounce == nil {
+		h.activityDebounce = make(map[string]time.Time)
+	}
+	now := time.Now()
+	last, exists := h.activityDebounce[conversationID]
+	if exists && now.Sub(last) < 10*time.Second {
+		return true
+	}
+	h.activityDebounce[conversationID] = now
+	if len(h.activityDebounce) > 1000 {
+		for k, v := range h.activityDebounce {
+			if now.Sub(v) >= 10*time.Second {
+				delete(h.activityDebounce, k)
+			}
+		}
+	}
+	return false
 }
 
 // Messages handles `POST /api/v1/messages` (Anthropic) and `POST
@@ -538,9 +563,11 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 	if conversationID != "" {
 		auditParams["conversation_id"] = conversationID
 		if llmproxy.HasNewUserMessage(provider, body) && h.Store != nil {
-			if err := h.Store.UpdateConversationActivity(r.Context(), conversationID, time.Now()); err != nil {
-				h.Logger.WarnContext(r.Context(), "failed to update conversation activity",
-					"request_id", requestID, "conversation_id", conversationID, "err", err.Error())
+			if !h.shouldDebounceActivity(conversationID) {
+				if err := h.Store.UpdateConversationActivity(r.Context(), conversationID, time.Now()); err != nil {
+					h.Logger.WarnContext(r.Context(), "failed to update conversation activity",
+						"request_id", requestID, "conversation_id", conversationID, "err", err.Error())
+				}
 			}
 		}
 	}

--- a/internal/api/handlers/llm_endpoint.go
+++ b/internal/api/handlers/llm_endpoint.go
@@ -20,12 +20,12 @@ import (
 	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/bodytransform"
-	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/scriptjudge"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/inspector"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/jsonsurgery"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/policies"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/postproc"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/pricing"
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/scriptjudge"
 	"github.com/clawvisor/clawvisor/internal/taskrisk"
 	runtimedecision "github.com/clawvisor/clawvisor/pkg/runtime/decision"
 	"github.com/clawvisor/clawvisor/pkg/store"
@@ -162,6 +162,10 @@ type LLMEndpointHandler struct {
 	// would drift from the resolved scope in production.
 	DefaultTaskExpirySeconds int
 
+	// InactivityThresholdSeconds is the inactivity window in seconds
+	// for routing approvals to external notification channels.
+	InactivityThresholdSeconds int
+
 	// RawIOLogger, when non-nil, captures full raw HTTP bodies for
 	// inbound requests, upstream responses, and the bodies returned
 	// to the harness. Off by default; opted in via
@@ -209,9 +213,10 @@ func NewLLMEndpointHandler(st store.Store, v vault.Vault, logger *slog.Logger) *
 		// Default in-process nonce cache; production wires the Redis-
 		// backed cache via WithCallerNonceCache. Cache instance is
 		// shared with the resolver-side middleware in production.
-		CallerNonces:         llmproxy.NewMemoryCallerNonceCache(5 * time.Minute),
-		MaxRequestBytes:      34 << 20,
-		defaultToolRulesSeen: map[string]map[string]struct{}{},
+		CallerNonces:               llmproxy.NewMemoryCallerNonceCache(5 * time.Minute),
+		MaxRequestBytes:            34 << 20,
+		InactivityThresholdSeconds: 300,
+		defaultToolRulesSeen:       map[string]map[string]struct{}{},
 	}
 }
 
@@ -532,6 +537,12 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 	conversationID := conversation.ConversationID(r, provider, body)
 	if conversationID != "" {
 		auditParams["conversation_id"] = conversationID
+		if llmproxy.HasNewUserMessage(provider, body) && h.Store != nil {
+			if err := h.Store.UpdateConversationActivity(r.Context(), conversationID, time.Now()); err != nil {
+				h.Logger.WarnContext(r.Context(), "failed to update conversation activity",
+					"request_id", requestID, "conversation_id", conversationID, "err", err.Error())
+			}
+		}
 	}
 	// Sixth migrated call site through pipeline: task_approval_reply.
 	{
@@ -1182,6 +1193,7 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 					Checkouts:                        h.TaskCheckouts,
 					DefaultTaskExpirySeconds:         h.DefaultTaskExpirySeconds,
 					AvailableTools:                   reqSummary.AvailableTools,
+					InactivityThresholdSeconds:       h.InactivityThresholdSeconds,
 				},
 				RewriteContext: llmproxy.RewriteContext{
 					Inspector:    h.Inspector,
@@ -1592,6 +1604,7 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 				Checkouts:                        h.TaskCheckouts,
 				DefaultTaskExpirySeconds:         h.DefaultTaskExpirySeconds,
 				AvailableTools:                   reqSummary.AvailableTools,
+				InactivityThresholdSeconds:       h.InactivityThresholdSeconds,
 			},
 			RewriteContext: llmproxy.RewriteContext{
 				Inspector:    h.Inspector,
@@ -1663,6 +1676,7 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 					Checkouts:                        h.TaskCheckouts,
 					DefaultTaskExpirySeconds:         h.DefaultTaskExpirySeconds,
 					AvailableTools:                   reqSummary.AvailableTools,
+					InactivityThresholdSeconds:       h.InactivityThresholdSeconds,
 				},
 				RewriteContext: llmproxy.RewriteContext{
 					Inspector:    h.Inspector,

--- a/internal/api/handlers/tasks.go
+++ b/internal/api/handlers/tasks.go
@@ -1050,7 +1050,10 @@ func isTaskPending(status string) bool {
 func (h *TasksHandler) waitForTaskResolution(ctx context.Context, taskID, userID string, timeout time.Duration) *store.Task {
 	return events.WaitFor(ctx, h.eventHub, userID, timeout,
 		[]string{"tasks"},
-		func(c context.Context) (*store.Task, bool) {
+		func(c context.Context, evt *events.Event) (*store.Task, bool) {
+			if evt != nil && evt.ID != "" && evt.ID != taskID {
+				return nil, false
+			}
 			t, err := h.st.GetTask(c, taskID)
 			if err != nil {
 				return &store.Task{ID: taskID}, false

--- a/internal/api/handlers/tasks_inline_pending_test.go
+++ b/internal/api/handlers/tasks_inline_pending_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/clawvisor/clawvisor/internal/api/middleware"
 	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy"
-	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/postproc"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/inspector"
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/postproc"
 	runtimetasks "github.com/clawvisor/clawvisor/internal/runtime/tasks"
 	"github.com/clawvisor/clawvisor/pkg/store"
 )
@@ -252,15 +252,15 @@ func TestPostprocess_ReplayFailureExpiresPendingInlineTask(t *testing.T) {
 		ToolUseEvaluatorFactory: pipelineToolUseEvaluatorFactory,
 		AgentContext: llmproxy.AgentContext{
 			AgentUserID: agent.UserID,
-			AgentID: agent.ID,
-			AgentName: agent.Name,
+			AgentID:     agent.ID,
+			AgentName:   agent.Name,
 		},
 		ApprovalContext: llmproxy.ApprovalContext{
-			PendingApprovals: cache,
+			PendingApprovals:  cache,
 			InlineTaskCreator: h,
 		},
 		RewriteContext: llmproxy.RewriteContext{
-			Inspector: inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{}),
+			Inspector:   inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{}),
 			RewriteOpts: inspector.DefaultRewriteOpts("http://localhost:25297"),
 		},
 		RoutingContext: llmproxy.RoutingContext{
@@ -310,19 +310,19 @@ func TestPostprocess_RewriterFailureExpiresPendingInlineTask(t *testing.T) {
 		ToolUseEvaluatorFactory: pipelineToolUseEvaluatorFactory,
 		AgentContext: llmproxy.AgentContext{
 			AgentUserID: agent.UserID,
-			AgentID: agent.ID,
-			AgentName: agent.Name,
+			AgentID:     agent.ID,
+			AgentName:   agent.Name,
 		},
 		ApprovalContext: llmproxy.ApprovalContext{
-			PendingApprovals: llmproxy.NewMemoryPendingApprovalCache(time.Minute),
+			PendingApprovals:  llmproxy.NewMemoryPendingApprovalCache(time.Minute),
 			InlineTaskCreator: h,
 		},
 		RewriteContext: llmproxy.RewriteContext{
-			Inspector: inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{}),
+			Inspector:   inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{}),
 			RewriteOpts: inspector.DefaultRewriteOpts("http://localhost:25297"),
 		},
 		RoutingContext: llmproxy.RoutingContext{
-			ControlBaseURL: "http://localhost:25297",
+			ControlBaseURL:   "http://localhost:25297",
 			ResponseRegistry: conversation.NewResponseRegistry(evalThenErrorRewriter{}),
 		},
 	})
@@ -685,6 +685,10 @@ func (c *failingInlineTaskHoldCache) Hold(context.Context, llmproxy.PendingLiteA
 }
 
 func (c *failingInlineTaskHoldCache) Peek(context.Context, llmproxy.ResolveRequest) (*llmproxy.PendingLiteApproval, error) {
+	return nil, nil
+}
+
+func (c *failingInlineTaskHoldCache) PeekByID(context.Context, string) (*llmproxy.PendingLiteApproval, error) {
 	return nil, nil
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1238,6 +1238,7 @@ func (s *Server) registerLiteProxyRoutes(
 	var callerNonces llmproxy.CallerNonceCache
 	if includeProxySurface {
 		llmHandler := handlers.NewLLMEndpointHandler(s.store, s.vault, s.logger)
+		llmHandler.InactivityThresholdSeconds = s.cfg.ProxyLite.InactivityThresholdSeconds
 		if v := s.cfg.ProxyLite.AnthropicBaseURL; v != "" {
 			llmHandler.Forwarder.Upstream.AnthropicBaseURL = v
 		}
@@ -1370,6 +1371,8 @@ func (s *Server) registerLiteProxyRoutes(
 		controlHandler.Audit = auditEmitter
 		controlHandler.ScriptSessions = scriptSessions
 		controlHandler.IntentVerifier = verifier
+		controlHandler.PendingApprovals = s.liteApprovals
+		controlHandler.EventHub = s.eventHub
 		requireAgentLLM := middleware.RequireAgentLLM(s.store)
 		requireAgentLLMRL := func(h http.HandlerFunc) http.Handler {
 			agentLimited := middleware.RateLimit(gatewayRL, llmAgentKeyFn, gatewayLimit)(http.HandlerFunc(h))
@@ -1395,6 +1398,7 @@ func (s *Server) registerLiteProxyRoutes(
 		mux.Handle("POST /api/control/task/checkout", requireAgentLLMCaller(e2e(http.HandlerFunc(controlHandler.CheckoutTask))))
 		mux.Handle("GET /api/control/tasks/{id}", requireAgentLLMCaller(e2e(http.HandlerFunc(tasksHandler.Get))))
 		mux.Handle("POST /api/control/tasks/{id}/expand", requireAgentLLMCaller(e2e(http.HandlerFunc(tasksHandler.Expand))))
+		mux.Handle("GET /api/control/approvals/{id}/wait", requireAgentLLMCaller(e2e(http.HandlerFunc(controlHandler.WaitForApproval))))
 		mux.Handle("GET /api/control/vault/items", requireAgentLLMCaller(e2e(http.HandlerFunc(vaultHandler.ListForAgent))))
 		mux.Handle("GET /api/control/vault/items/{id}", requireAgentLLMCaller(e2e(http.HandlerFunc(vaultHandler.GetForAgent))))
 		// AutovaultScriptDocs is intentionally unauthenticated, matching

--- a/internal/events/longpoll.go
+++ b/internal/events/longpoll.go
@@ -18,7 +18,7 @@ func WaitFor[T any](
 	userID string,
 	timeout time.Duration,
 	eventTypes []string,
-	fetch func(context.Context) (T, bool),
+	fetch func(context.Context, *Event) (T, bool),
 ) T {
 	ch, unsub := hub.Subscribe(userID)
 	defer unsub()
@@ -28,7 +28,7 @@ func WaitFor[T any](
 	// otherwise block until timeout for an event that never arrives. The
 	// subscribe-then-check-then-wait order ensures any post-subscribe event
 	// still wakes us via ch even if the pre-subscribe one is missed.
-	if v, done := fetch(ctx); done {
+	if v, done := fetch(ctx, nil); done {
 		return v
 	}
 
@@ -48,24 +48,24 @@ func WaitFor[T any](
 	for {
 		select {
 		case <-ctx.Done():
-			v, _ := fetch(context.Background())
+			v, _ := fetch(context.Background(), nil)
 			return v
 		case <-timer.C:
-			v, _ := fetch(context.Background())
+			v, _ := fetch(context.Background(), nil)
 			return v
 		case <-poll.C:
-			if v, done := fetch(ctx); done {
+			if v, done := fetch(ctx, nil); done {
 				return v
 			}
 		case evt, ok := <-ch:
 			if !ok {
-				v, _ := fetch(context.Background())
+				v, _ := fetch(context.Background(), nil)
 				return v
 			}
 			if len(eventTypes) > 0 && !slices.Contains(eventTypes, evt.Type) {
 				continue
 			}
-			v, done := fetch(ctx)
+			v, done := fetch(ctx, &evt)
 			if done {
 				return v
 			}

--- a/internal/runtime/llmproxy/config.go
+++ b/internal/runtime/llmproxy/config.go
@@ -142,19 +142,8 @@ type ApprovalContext struct {
 	ConversationAutoApproveThreshold string
 	Checkouts                        TaskCheckoutStore
 	DefaultTaskExpirySeconds         int
-	// AvailableTools is the inbound request's declared tool list
-	// (e.g. Anthropic tools[].name). Consumed by the inline-approval
-	// intercept to decide whether to substitute the held tool_use
-	// with an AskUserQuestion picker (when that harness tool is
-	// declared) or a plain text prompt.
-	//
-	// Technically per-request request metadata rather than an
-	// approval-flow input, but living on ApprovalContext keeps the
-	// existing buildControlResolver param-passing pattern intact:
-	// the intercept is built from sub-contexts, and a top-level
-	// PostprocessConfig field was demonstrably easy to forget to
-	// plumb through.
-	AvailableTools []string
+	AvailableTools                   []string
+	InactivityThresholdSeconds       int
 }
 
 // RewriteContext groups the credentialed-rewrite path's dependencies:

--- a/internal/runtime/llmproxy/human_turns.go
+++ b/internal/runtime/llmproxy/human_turns.go
@@ -329,3 +329,99 @@ func tailLimit(in []string, n int) []string {
 	copy(out, in[len(in)-n:])
 	return out
 }
+
+// HasNewUserMessage reports whether the very last message in the request body is a genuine user turn.
+func HasNewUserMessage(provider conversation.Provider, body []byte) bool {
+	if len(body) == 0 {
+		return false
+	}
+	switch provider {
+	case conversation.ProviderAnthropic:
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal(body, &raw); err != nil {
+			return false
+		}
+		msgsRaw, ok := raw["messages"]
+		if !ok {
+			return false
+		}
+		var messages []map[string]json.RawMessage
+		if err := json.Unmarshal(msgsRaw, &messages); err != nil {
+			return false
+		}
+		if len(messages) == 0 {
+			return false
+		}
+		lastMsg := messages[len(messages)-1]
+		var role string
+		if err := json.Unmarshal(lastMsg["role"], &role); err != nil {
+			return false
+		}
+		if role != "user" {
+			return false
+		}
+		text := strings.TrimSpace(extractAnthropicUserText(lastMsg["content"]))
+		if text == "" || isClawvisorInternalUserText(text) {
+			return false
+		}
+		return true
+
+	case conversation.ProviderOpenAI:
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal(body, &raw); err != nil {
+			return false
+		}
+		if msgsRaw, ok := raw["messages"]; ok {
+			var messages []map[string]json.RawMessage
+			if err := json.Unmarshal(msgsRaw, &messages); err == nil && len(messages) > 0 {
+				lastMsg := messages[len(messages)-1]
+				var role string
+				if err := json.Unmarshal(lastMsg["role"], &role); err != nil {
+					return false
+				}
+				if role != "user" {
+					return false
+				}
+				text := strings.TrimSpace(flattenOpenAIChatContent(lastMsg["content"]))
+				if text == "" || isClawvisorInternalUserText(text) {
+					return false
+				}
+				return true
+			}
+		}
+		if inputRaw, ok := raw["input"]; ok {
+			var asString string
+			if err := json.Unmarshal(inputRaw, &asString); err == nil {
+				text := strings.TrimSpace(asString)
+				return text != "" && !isClawvisorInternalUserText(text)
+			}
+			var items []map[string]json.RawMessage
+			if err := json.Unmarshal(inputRaw, &items); err == nil && len(items) > 0 {
+				lastItem := items[len(items)-1]
+				var typ string
+				if err := json.Unmarshal(lastItem["type"], &typ); err != nil {
+					return false
+				}
+				if typ != "" && typ != "message" {
+					return false
+				}
+				var role string
+				if err := json.Unmarshal(lastItem["role"], &role); err != nil {
+					return false
+				}
+				if role != "user" {
+					return false
+				}
+				text := strings.TrimSpace(flattenOpenAIChatContent(lastItem["content"]))
+				if text == "" || isClawvisorInternalUserText(text) {
+					return false
+				}
+				return true
+			}
+		}
+		return false
+
+	default:
+		return false
+	}
+}

--- a/internal/runtime/llmproxy/inline_task_intercept.go
+++ b/internal/runtime/llmproxy/inline_task_intercept.go
@@ -92,22 +92,38 @@ func MaybeInterceptInlineTaskDefinition(
 		return conversation.ToolUseVerdict{}, false
 	}
 
-	// Query signal: agent explicitly opted in via ?surface=inline. This
+	// Query signal: agent explicitly opted in via ?surface=inline or ?surface=auto. This
 	// is the only signal we honor in production — the older "state
 	// signal" branch (a prior StageAwaitingTaskDefinition hold from a
 	// "task" reply) is unreachable now that RewriteTaskApprovalReply
 	// fully Resolves the original tool hold rather than transitioning
 	// its stage. taskCreationPrompt teaches the model to include
-	// ?surface=inline, so compliant traffic flows through here; the
+	// ?surface=inline or ?surface=auto, so compliant traffic flows through here; the
 	// query-less path correctly falls through to the dashboard rewrite.
 	// Both key and value match case-SENSITIVELY: `url.Values.Get` is
 	// case-sensitive on the key, and harnesses emit the exact
-	// surface=inline string we teach them in taskCreationPrompt.
+	// surface=inline or surface=auto string we teach them.
 	// Mixed-case (Surface=INLINE) is not a shape we promise to honor;
 	// keeping symmetric strictness avoids future-reader surprise.
-	querySignal := call.URL.Query().Get(InlineSurfaceQueryParam) == InlineSurfaceQueryValue
-	if !querySignal {
+	surfaceVal := call.URL.Query().Get(InlineSurfaceQueryParam)
+	if surfaceVal != "inline" && surfaceVal != "auto" {
 		return conversation.ToolUseVerdict{}, false
+	}
+
+	if surfaceVal == "auto" {
+		isInactive := true
+		if cfg.Store != nil && cfg.ConversationID != "" {
+			activity, err := cfg.Store.GetConversationActivity(req.Context(), cfg.ConversationID)
+			if err == nil && activity != nil {
+				threshold := time.Duration(cfg.InactivityThresholdSeconds) * time.Second
+				if time.Since(activity.LastUserMessageAt) <= threshold {
+					isInactive = false
+				}
+			}
+		}
+		if isInactive {
+			return conversation.ToolUseVerdict{}, false
+		}
 	}
 
 	// On the failure paths below, we audit with decision="fallthrough"

--- a/internal/runtime/llmproxy/inline_task_intercept.go
+++ b/internal/runtime/llmproxy/inline_task_intercept.go
@@ -115,7 +115,11 @@ func MaybeInterceptInlineTaskDefinition(
 		if cfg.Store != nil && cfg.ConversationID != "" {
 			activity, err := cfg.Store.GetConversationActivity(req.Context(), cfg.ConversationID)
 			if err == nil && activity != nil {
-				threshold := time.Duration(cfg.InactivityThresholdSeconds) * time.Second
+				thresholdSecs := cfg.InactivityThresholdSeconds
+				if thresholdSecs <= 0 {
+					thresholdSecs = 300
+				}
+				threshold := time.Duration(thresholdSecs) * time.Second
 				if time.Since(activity.LastUserMessageAt) <= threshold {
 					isInactive = false
 				}

--- a/internal/runtime/llmproxy/pending_approval_cache.go
+++ b/internal/runtime/llmproxy/pending_approval_cache.go
@@ -242,6 +242,7 @@ type HoldResult struct {
 type PendingApprovalCache interface {
 	Hold(ctx context.Context, pending PendingLiteApproval) (HoldResult, error)
 	Peek(ctx context.Context, req ResolveRequest) (*PendingLiteApproval, error)
+	PeekByID(ctx context.Context, id string) (*PendingLiteApproval, error)
 	Resolve(ctx context.Context, req ResolveRequest) (*PendingLiteApproval, error)
 	Drop(ctx context.Context, req ResolveRequest) error
 }
@@ -342,6 +343,27 @@ func (c *MemoryPendingApprovalCache) Peek(_ context.Context, req ResolveRequest)
 	defer c.mu.Unlock()
 	pending, _, _ := c.findLocked(req)
 	return pending, nil
+}
+
+func (c *MemoryPendingApprovalCache) PeekByID(_ context.Context, id string) (*PendingLiteApproval, error) {
+	if c == nil {
+		return nil, nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	now := c.now().UTC()
+	for _, items := range c.pending {
+		for _, pending := range items {
+			if pending.ExpiresAt.IsZero() || pending.ExpiresAt.After(now) {
+				if pending.ID == id || pending.PendingTaskID == id {
+					// Return a copy so the caller doesn't mutate cache internals
+					copied := pending
+					return &copied, nil
+				}
+			}
+		}
+	}
+	return nil, nil
 }
 
 func (c *MemoryPendingApprovalCache) findLocked(req ResolveRequest) (*PendingLiteApproval, int, []PendingLiteApproval) {

--- a/internal/runtime/llmproxy/pending_approval_cache_redis.go
+++ b/internal/runtime/llmproxy/pending_approval_cache_redis.go
@@ -7,6 +7,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
@@ -99,12 +101,13 @@ func (c *RedisPendingApprovalCache) Hold(ctx context.Context, pending PendingLit
 	).Result(); err != nil && !errors.Is(err, redis.Nil) {
 		return HoldResult{}, err
 	}
-	mapPrefix := "clawvisor:lite_pending_approval_map:"
-	if err := c.rdb.Set(ctx, mapPrefix+pending.ID, key, keyTTL).Err(); err != nil {
+	mapApprovalPrefix := "clawvisor:lite_pending_approval_map:approval:"
+	mapTaskPrefix := "clawvisor:lite_pending_approval_map:task:"
+	if err := c.rdb.Set(ctx, mapApprovalPrefix+pending.ID, key, keyTTL).Err(); err != nil {
 		return HoldResult{}, err
 	}
 	if pending.PendingTaskID != "" {
-		if err := c.rdb.Set(ctx, mapPrefix+pending.PendingTaskID, key, keyTTL).Err(); err != nil {
+		if err := c.rdb.Set(ctx, mapTaskPrefix+pending.PendingTaskID, key, keyTTL).Err(); err != nil {
 			return HoldResult{}, err
 		}
 	}
@@ -147,10 +150,11 @@ func (c *RedisPendingApprovalCache) Resolve(ctx context.Context, req ResolveRequ
 		if !found.ExpiresAt.IsZero() && !found.ExpiresAt.After(c.now().UTC()) {
 			continue
 		}
-		mapPrefix := "clawvisor:lite_pending_approval_map:"
-		c.rdb.Del(ctx, mapPrefix+found.ID)
+		mapApprovalPrefix := "clawvisor:lite_pending_approval_map:approval:"
+		mapTaskPrefix := "clawvisor:lite_pending_approval_map:task:"
+		c.rdb.Del(ctx, mapApprovalPrefix+found.ID)
 		if found.PendingTaskID != "" {
-			c.rdb.Del(ctx, mapPrefix+found.PendingTaskID)
+			c.rdb.Del(ctx, mapTaskPrefix+found.PendingTaskID)
 		}
 		return &found, nil
 	}
@@ -169,11 +173,25 @@ func (c *RedisPendingApprovalCache) Drop(ctx context.Context, req ResolveRequest
 	if err != nil || raw == "" {
 		return err
 	}
-	mapPrefix := "clawvisor:lite_pending_approval_map:"
-	c.rdb.Del(ctx, mapPrefix+req.ApprovalID)
+	mapApprovalPrefix := "clawvisor:lite_pending_approval_map:approval:"
+	mapTaskPrefix := "clawvisor:lite_pending_approval_map:task:"
+	var mapKey string
+	if strings.HasPrefix(req.ApprovalID, "cv-") {
+		mapKey = mapApprovalPrefix + req.ApprovalID
+	} else {
+		mapKey = mapTaskPrefix + req.ApprovalID
+	}
+	c.rdb.Del(ctx, mapKey)
 	var pending PendingLiteApproval
-	if json.Unmarshal([]byte(raw), &pending) == nil && pending.PendingTaskID != "" {
-		c.rdb.Del(ctx, mapPrefix+pending.PendingTaskID)
+	if err := json.Unmarshal([]byte(raw), &pending); err != nil {
+		slog.ErrorContext(ctx, "failed to unmarshal pending approval in Redis Drop", "err", err, "raw", raw)
+	} else {
+		if pending.ID != "" {
+			c.rdb.Del(ctx, mapApprovalPrefix+pending.ID)
+		}
+		if pending.PendingTaskID != "" {
+			c.rdb.Del(ctx, mapTaskPrefix+pending.PendingTaskID)
+		}
 	}
 	return c.rdb.LRem(ctx, key, 1, raw).Err()
 }
@@ -324,8 +342,15 @@ func (c *RedisPendingApprovalCache) PeekByID(ctx context.Context, id string) (*P
 		return nil, nil
 	}
 	now := c.now().UTC()
-	mapPrefix := "clawvisor:lite_pending_approval_map:"
-	listKey, err := c.rdb.Get(ctx, mapPrefix+id).Result()
+	mapApprovalPrefix := "clawvisor:lite_pending_approval_map:approval:"
+	mapTaskPrefix := "clawvisor:lite_pending_approval_map:task:"
+	var mapKey string
+	if strings.HasPrefix(id, "cv-") {
+		mapKey = mapApprovalPrefix + id
+	} else {
+		mapKey = mapTaskPrefix + id
+	}
+	listKey, err := c.rdb.Get(ctx, mapKey).Result()
 	if err != nil {
 		if errors.Is(err, redis.Nil) {
 			return nil, nil

--- a/internal/runtime/llmproxy/pending_approval_cache_redis.go
+++ b/internal/runtime/llmproxy/pending_approval_cache_redis.go
@@ -99,6 +99,15 @@ func (c *RedisPendingApprovalCache) Hold(ctx context.Context, pending PendingLit
 	).Result(); err != nil && !errors.Is(err, redis.Nil) {
 		return HoldResult{}, err
 	}
+	mapPrefix := "clawvisor:lite_pending_approval_map:"
+	if err := c.rdb.Set(ctx, mapPrefix+pending.ID, key, keyTTL).Err(); err != nil {
+		return HoldResult{}, err
+	}
+	if pending.PendingTaskID != "" {
+		if err := c.rdb.Set(ctx, mapPrefix+pending.PendingTaskID, key, keyTTL).Err(); err != nil {
+			return HoldResult{}, err
+		}
+	}
 	return HoldResult{Pending: pending, Evicted: evicted}, nil
 }
 
@@ -138,6 +147,11 @@ func (c *RedisPendingApprovalCache) Resolve(ctx context.Context, req ResolveRequ
 		if !found.ExpiresAt.IsZero() && !found.ExpiresAt.After(c.now().UTC()) {
 			continue
 		}
+		mapPrefix := "clawvisor:lite_pending_approval_map:"
+		c.rdb.Del(ctx, mapPrefix+found.ID)
+		if found.PendingTaskID != "" {
+			c.rdb.Del(ctx, mapPrefix+found.PendingTaskID)
+		}
 		return &found, nil
 	}
 }
@@ -154,6 +168,12 @@ func (c *RedisPendingApprovalCache) Drop(ctx context.Context, req ResolveRequest
 	_, raw, err := c.find(ctx, req)
 	if err != nil || raw == "" {
 		return err
+	}
+	mapPrefix := "clawvisor:lite_pending_approval_map:"
+	c.rdb.Del(ctx, mapPrefix+req.ApprovalID)
+	var pending PendingLiteApproval
+	if json.Unmarshal([]byte(raw), &pending) == nil && pending.PendingTaskID != "" {
+		c.rdb.Del(ctx, mapPrefix+pending.PendingTaskID)
 	}
 	return c.rdb.LRem(ctx, key, 1, raw).Err()
 }
@@ -298,5 +318,40 @@ for i = 0, len - 1 do
 end
 return nil
 `)
+
+func (c *RedisPendingApprovalCache) PeekByID(ctx context.Context, id string) (*PendingLiteApproval, error) {
+	if c == nil || c.rdb == nil {
+		return nil, nil
+	}
+	now := c.now().UTC()
+	mapPrefix := "clawvisor:lite_pending_approval_map:"
+	listKey, err := c.rdb.Get(ctx, mapPrefix+id).Result()
+	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	rawItems, err := c.rdb.LRange(ctx, listKey, 0, -1).Result()
+	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	for _, raw := range rawItems {
+		var pending PendingLiteApproval
+		if err := json.Unmarshal([]byte(raw), &pending); err != nil {
+			continue
+		}
+		if !pending.ExpiresAt.IsZero() && !pending.ExpiresAt.After(now) {
+			continue
+		}
+		if pending.ID == id || pending.PendingTaskID == id {
+			return &pending, nil
+		}
+	}
+	return nil, nil
+}
 
 var _ PendingApprovalCache = (*RedisPendingApprovalCache)(nil)

--- a/internal/runtime/llmproxy/postproc/coalesce.go
+++ b/internal/runtime/llmproxy/postproc/coalesce.go
@@ -64,6 +64,10 @@ func (c *holdCapturingApprovalCache) Peek(ctx context.Context, req llmproxy.Reso
 	return c.inner.Peek(ctx, req)
 }
 
+func (c *holdCapturingApprovalCache) PeekByID(ctx context.Context, id string) (*llmproxy.PendingLiteApproval, error) {
+	return c.inner.PeekByID(ctx, id)
+}
+
 func (c *holdCapturingApprovalCache) Resolve(ctx context.Context, req llmproxy.ResolveRequest) (*llmproxy.PendingLiteApproval, error) {
 	return c.inner.Resolve(ctx, req)
 }

--- a/internal/runtime/llmproxy/postproc/coalesce_test.go
+++ b/internal/runtime/llmproxy/postproc/coalesce_test.go
@@ -1101,6 +1101,9 @@ func (c *flakyHoldFromCallN) Hold(ctx context.Context, p llmproxy.PendingLiteApp
 func (c *flakyHoldFromCallN) Peek(ctx context.Context, r llmproxy.ResolveRequest) (*llmproxy.PendingLiteApproval, error) {
 	return c.inner.Peek(ctx, r)
 }
+func (c *flakyHoldFromCallN) PeekByID(ctx context.Context, id string) (*llmproxy.PendingLiteApproval, error) {
+	return c.inner.PeekByID(ctx, id)
+}
 func (c *flakyHoldFromCallN) Resolve(ctx context.Context, r llmproxy.ResolveRequest) (*llmproxy.PendingLiteApproval, error) {
 	return c.inner.Resolve(ctx, r)
 }
@@ -1119,6 +1122,9 @@ func (c *countingHoldCache) Hold(ctx context.Context, p llmproxy.PendingLiteAppr
 }
 func (c *countingHoldCache) Peek(ctx context.Context, r llmproxy.ResolveRequest) (*llmproxy.PendingLiteApproval, error) {
 	return c.inner.Peek(ctx, r)
+}
+func (c *countingHoldCache) PeekByID(ctx context.Context, id string) (*llmproxy.PendingLiteApproval, error) {
+	return c.inner.PeekByID(ctx, id)
 }
 func (c *countingHoldCache) Resolve(ctx context.Context, r llmproxy.ResolveRequest) (*llmproxy.PendingLiteApproval, error) {
 	return c.inner.Resolve(ctx, r)
@@ -1408,6 +1414,9 @@ func (c *flakyHoldCache) Hold(ctx context.Context, p llmproxy.PendingLiteApprova
 }
 func (c *flakyHoldCache) Peek(ctx context.Context, r llmproxy.ResolveRequest) (*llmproxy.PendingLiteApproval, error) {
 	return c.inner.Peek(ctx, r)
+}
+func (c *flakyHoldCache) PeekByID(ctx context.Context, id string) (*llmproxy.PendingLiteApproval, error) {
+	return c.inner.PeekByID(ctx, id)
 }
 func (c *flakyHoldCache) Resolve(ctx context.Context, r llmproxy.ResolveRequest) (*llmproxy.PendingLiteApproval, error) {
 	return c.inner.Resolve(ctx, r)

--- a/internal/runtime/llmproxy/postproc/inline_task_intercept_test.go
+++ b/internal/runtime/llmproxy/postproc/inline_task_intercept_test.go
@@ -1274,3 +1274,170 @@ func TestPostprocess_InlineTaskMalformedBodyFallsThrough(t *testing.T) {
 		t.Fatalf("expected fallback to regular control rewrite on missing purpose; got %s", got.Body)
 	}
 }
+
+func TestMaybeInterceptInlineTaskDefinition_SurfaceAutoActivity(t *testing.T) {
+	cache := llmproxy.NewMemoryPendingApprovalCache(time.Minute)
+	st, userID, agentID := seedPostprocessStore(t, "autovault_github_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
+
+	cmd := `curl -sS -X POST 'https://clawvisor.local/control/tasks?wait=true&timeout=120&surface=auto' -H 'Content-Type: application/json' --data '` + inlineTaskBody + `'`
+	input, err := json.Marshal(map[string]string{"command": cmd})
+	if err != nil {
+		t.Fatalf("marshal tool input: %v", err)
+	}
+	tu := conversation.ToolUse{ID: "toolu_auto", Name: "Bash", Input: input}
+	call, ok := llmproxy.ParseControlToolUse(tu)
+	if !ok {
+		t.Fatalf("control call did not parse")
+	}
+
+	// 1. Missing ConversationID -> inactive -> falls through (not handled)
+	_, handled := llmproxy.MaybeInterceptInlineTaskDefinition(
+		httptest.NewRequest("POST", "/v1/messages", nil),
+		llmproxy.PostprocessConfig{
+			AgentContext: llmproxy.AgentContext{
+				AgentUserID: userID,
+				AgentID:     agentID,
+			},
+			ApprovalContext: llmproxy.ApprovalContext{
+				PendingApprovals:           cache,
+				InactivityThresholdSeconds: 5,
+			},
+			RewriteContext: llmproxy.RewriteContext{
+				Store: st,
+			},
+		},
+		func(_, _, _ string) {},
+		func(string, ...any) {},
+		conversation.ProviderAnthropic,
+		tu,
+		call,
+	)
+	if handled {
+		t.Errorf("expected surface=auto to fall through on missing conversation ID")
+	}
+
+	// 2. ConversationID set but no activity row in DB -> inactive -> falls through
+	_, handled = llmproxy.MaybeInterceptInlineTaskDefinition(
+		httptest.NewRequest("POST", "/v1/messages", nil),
+		llmproxy.PostprocessConfig{
+			AgentContext: llmproxy.AgentContext{
+				AgentUserID:    userID,
+				AgentID:        agentID,
+			},
+			AuditContext: llmproxy.AuditContext{
+				ConversationID: "conv-1",
+			},
+			ApprovalContext: llmproxy.ApprovalContext{
+				PendingApprovals:           cache,
+				InactivityThresholdSeconds: 5,
+			},
+			RewriteContext: llmproxy.RewriteContext{
+				Store: st,
+			},
+		},
+		func(_, _, _ string) {},
+		func(string, ...any) {},
+		conversation.ProviderAnthropic,
+		tu,
+		call,
+	)
+	if handled {
+		t.Errorf("expected surface=auto to fall through on missing activity row")
+	}
+
+	// 3. Conversation inactive (last message 10 seconds ago, threshold 5 seconds) -> falls through
+	if err := st.UpdateConversationActivity(context.Background(), "conv-1", time.Now().Add(-10*time.Second)); err != nil {
+		t.Fatalf("UpdateConversationActivity: %v", err)
+	}
+	_, handled = llmproxy.MaybeInterceptInlineTaskDefinition(
+		httptest.NewRequest("POST", "/v1/messages", nil),
+		llmproxy.PostprocessConfig{
+			AgentContext: llmproxy.AgentContext{
+				AgentUserID:    userID,
+				AgentID:        agentID,
+			},
+			AuditContext: llmproxy.AuditContext{
+				ConversationID: "conv-1",
+			},
+			ApprovalContext: llmproxy.ApprovalContext{
+				PendingApprovals:           cache,
+				InactivityThresholdSeconds: 5,
+			},
+			RewriteContext: llmproxy.RewriteContext{
+				Store: st,
+			},
+		},
+		func(_, _, _ string) {},
+		func(string, ...any) {},
+		conversation.ProviderAnthropic,
+		tu,
+		call,
+	)
+	if handled {
+		t.Errorf("expected surface=auto to fall through on inactive conversation")
+	}
+
+	// 4. InactivityThresholdSeconds <= 0 defaults to 300 seconds (last message 10s ago) -> active -> intercepted
+	creator := &capturingInlineCreator{pendingTaskID: "task-auto-active"}
+	_, handled = llmproxy.MaybeInterceptInlineTaskDefinition(
+		httptest.NewRequest("POST", "/v1/messages", nil),
+		llmproxy.PostprocessConfig{
+			AgentContext: llmproxy.AgentContext{
+				AgentUserID:    userID,
+				AgentID:        agentID,
+			},
+			AuditContext: llmproxy.AuditContext{
+				ConversationID: "conv-1",
+			},
+			ApprovalContext: llmproxy.ApprovalContext{
+				PendingApprovals:           cache,
+				InactivityThresholdSeconds: 0, // should default to 300
+				InlineTaskCreator:          creator,
+			},
+			RewriteContext: llmproxy.RewriteContext{
+				Store: st,
+			},
+		},
+		func(_, _, _ string) {},
+		func(string, ...any) {},
+		conversation.ProviderAnthropic,
+		tu,
+		call,
+	)
+	if !handled {
+		t.Errorf("expected surface=auto to intercept when threshold is 0 (defaults to 300s) and active")
+	}
+
+	// 5. Conversation active (last message 2 seconds ago, threshold 5 seconds) -> intercepted
+	if err := st.UpdateConversationActivity(context.Background(), "conv-1", time.Now()); err != nil {
+		t.Fatalf("UpdateConversationActivity: %v", err)
+	}
+	_, handled = llmproxy.MaybeInterceptInlineTaskDefinition(
+		httptest.NewRequest("POST", "/v1/messages", nil),
+		llmproxy.PostprocessConfig{
+			AgentContext: llmproxy.AgentContext{
+				AgentUserID:    userID,
+				AgentID:        agentID,
+			},
+			AuditContext: llmproxy.AuditContext{
+				ConversationID: "conv-1",
+			},
+			ApprovalContext: llmproxy.ApprovalContext{
+				PendingApprovals:           cache,
+				InactivityThresholdSeconds: 5,
+				InlineTaskCreator:          creator,
+			},
+			RewriteContext: llmproxy.RewriteContext{
+				Store: st,
+			},
+		},
+		func(_, _, _ string) {},
+		func(string, ...any) {},
+		conversation.ProviderAnthropic,
+		tu,
+		call,
+	)
+	if !handled {
+		t.Errorf("expected surface=auto to intercept on active conversation")
+	}
+}

--- a/internal/runtime/llmproxy/redis_stores_test.go
+++ b/internal/runtime/llmproxy/redis_stores_test.go
@@ -415,3 +415,87 @@ func TestRedisInlineApprovalOutcomeStoreRecordAndLookup(t *testing.T) {
 		t.Fatal("lookup should be scoped by agent")
 	}
 }
+
+func TestRedisPendingApprovalCache_PeekByIDRoundTrip(t *testing.T) {
+	rdb := testRedisClient(t)
+	cache := NewRedisPendingApprovalCache(rdb, time.Minute)
+	ctx := context.Background()
+
+	held, err := cache.Hold(ctx, PendingLiteApproval{
+		ID:            "cv-approval1",
+		UserID:        "user-1",
+		AgentID:       "agent-1",
+		Provider:      conversation.ProviderAnthropic,
+		PendingTaskID: "task-abc",
+	})
+	if err != nil {
+		t.Fatalf("Hold failed: %v", err)
+	}
+	_ = held
+
+	// 1. PeekByID using approval ID (starts with cv-)
+	peekedAppr, err := cache.PeekByID(ctx, "cv-approval1")
+	if err != nil {
+		t.Fatalf("PeekByID by approval ID failed: %v", err)
+	}
+	if peekedAppr == nil || peekedAppr.ID != "cv-approval1" {
+		t.Fatalf("PeekByID by approval ID returned %+v, want cv-approval1", peekedAppr)
+	}
+
+	// 2. PeekByID using task ID (does not start with cv-)
+	peekedTask, err := cache.PeekByID(ctx, "task-abc")
+	if err != nil {
+		t.Fatalf("PeekByID by task ID failed: %v", err)
+	}
+	if peekedTask == nil || peekedTask.ID != "cv-approval1" {
+		t.Fatalf("PeekByID by task ID returned %+v, want cv-approval1", peekedTask)
+	}
+
+	// 3. PeekByID using an unknown ID
+	peekedUnknown, err := cache.PeekByID(ctx, "unknown-id")
+	if err != nil {
+		t.Fatalf("PeekByID by unknown ID failed: %v", err)
+	}
+	if peekedUnknown != nil {
+		t.Fatalf("expected nil for unknown ID, got %+v", peekedUnknown)
+	}
+
+	// 4. Verify exact key namespaces in Redis
+	valAppr, err := rdb.Get(ctx, "clawvisor:lite_pending_approval_map:approval:cv-approval1").Result()
+	if err != nil {
+		t.Fatalf("Get approval map key failed: %v", err)
+	}
+	if valAppr == "" {
+		t.Fatalf("expected non-empty key for approval map key")
+	}
+
+	valTask, err := rdb.Get(ctx, "clawvisor:lite_pending_approval_map:task:task-abc").Result()
+	if err != nil {
+		t.Fatalf("Get task map key failed: %v", err)
+	}
+	if valTask == "" {
+		t.Fatalf("expected non-empty key for task map key")
+	}
+
+	// 5. Drop the hold and verify keys are deleted
+	err = cache.Drop(ctx, ResolveRequest{
+		UserID:     "user-1",
+		AgentID:    "agent-1",
+		Provider:   conversation.ProviderAnthropic,
+		ApprovalID: "cv-approval1",
+	})
+	if err != nil {
+		t.Fatalf("Drop failed: %v", err)
+	}
+
+	// Verify keys are deleted from map
+	_, err = rdb.Get(ctx, "clawvisor:lite_pending_approval_map:approval:cv-approval1").Result()
+	if !errors.Is(err, redis.Nil) {
+		t.Fatalf("expected approval map key to be deleted, got err: %v", err)
+	}
+	_, err = rdb.Get(ctx, "clawvisor:lite_pending_approval_map:task:task-abc").Result()
+	if !errors.Is(err, redis.Nil) {
+		t.Fatalf("expected task map key to be deleted, got err: %v", err)
+	}
+}
+

--- a/internal/runtime/llmproxy/release_test.go
+++ b/internal/runtime/llmproxy/release_test.go
@@ -25,6 +25,10 @@ func (c failingPendingApprovalCache) Peek(context.Context, ResolveRequest) (*Pen
 	return nil, c.err
 }
 
+func (c failingPendingApprovalCache) PeekByID(context.Context, string) (*PendingLiteApproval, error) {
+	return nil, c.err
+}
+
 func (c failingPendingApprovalCache) Resolve(context.Context, ResolveRequest) (*PendingLiteApproval, error) {
 	return nil, c.err
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -322,6 +322,10 @@ type ProxyLiteConfig struct {
 	// CLAWVISOR_PROXY_LITE_RAW_LOG_PATH overrides this when set.
 	// CLAWVISOR_PROXY_LITE_RAW_LOG remains accepted as a legacy alias.
 	RawLogPath string `yaml:"raw_log_path"`
+
+	// InactivityThresholdSeconds is the inactivity window in seconds
+	// for routing approvals to external notification channels.
+	InactivityThresholdSeconds int `yaml:"inactivity_threshold_seconds"`
 }
 
 // FeaturesConfig gates progressively enhanced UI and runtime surfaces.
@@ -460,6 +464,9 @@ func Default() *Config {
 		AutoUpdate: AutoUpdateConfig{
 			Enabled:       false,
 			CheckInterval: "6h",
+		},
+		ProxyLite: ProxyLiteConfig{
+			InactivityThresholdSeconds: 300,
 		},
 	}
 }
@@ -813,6 +820,11 @@ func Load(path string) (*Config, error) {
 	}
 	if v := os.Getenv("CLAWVISOR_PROXY_LITE_RAW_LOG_PATH"); v != "" {
 		cfg.ProxyLite.RawLogPath = strings.TrimSpace(v)
+	}
+	if v := os.Getenv("CLAWVISOR_PROXY_LITE_INACTIVITY_THRESHOLD_SECONDS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.ProxyLite.InactivityThresholdSeconds = n
+		}
 	}
 
 	if v := os.Getenv("CLAWVISOR_RELAY_URL"); v != "" {

--- a/pkg/store/postgres/migrations/055_conversations.sql
+++ b/pkg/store/postgres/migrations/055_conversations.sql
@@ -1,0 +1,5 @@
+-- Tracking user activity in conversations to support inactivity-based notification routing.
+CREATE TABLE IF NOT EXISTS conversations (
+  id                    TEXT PRIMARY KEY,
+  last_user_message_at  TIMESTAMPTZ NOT NULL
+);

--- a/pkg/store/postgres/store.go
+++ b/pkg/store/postgres/store.go
@@ -3734,3 +3734,30 @@ func (s *Store) GetAgentLastNPSTime(ctx context.Context, agentID string) (*time.
 	}
 	return &createdAt, nil
 }
+
+func (s *Store) UpdateConversationActivity(ctx context.Context, conversationID string, lastUserMessageAt time.Time) error {
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO conversations (id, last_user_message_at)
+		VALUES ($1, $2)
+		ON CONFLICT (id) DO UPDATE SET
+			last_user_message_at = EXCLUDED.last_user_message_at
+	`, conversationID, lastUserMessageAt.UTC())
+	return err
+}
+
+func (s *Store) GetConversationActivity(ctx context.Context, conversationID string) (*store.ConversationActivity, error) {
+	var lastUserMessageAt time.Time
+	err := s.pool.QueryRow(ctx, `
+		SELECT last_user_message_at FROM conversations WHERE id = $1
+	`, conversationID).Scan(&lastUserMessageAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &store.ConversationActivity{
+		ConversationID:    conversationID,
+		LastUserMessageAt: lastUserMessageAt,
+	}, nil
+}

--- a/pkg/store/postgres/store.go
+++ b/pkg/store/postgres/store.go
@@ -3740,7 +3740,7 @@ func (s *Store) UpdateConversationActivity(ctx context.Context, conversationID s
 		INSERT INTO conversations (id, last_user_message_at)
 		VALUES ($1, $2)
 		ON CONFLICT (id) DO UPDATE SET
-			last_user_message_at = EXCLUDED.last_user_message_at
+			last_user_message_at = GREATEST(conversations.last_user_message_at, EXCLUDED.last_user_message_at)
 	`, conversationID, lastUserMessageAt.UTC())
 	return err
 }

--- a/pkg/store/sqlite/migrations/055_conversations.sql
+++ b/pkg/store/sqlite/migrations/055_conversations.sql
@@ -1,0 +1,5 @@
+-- Tracking user activity in conversations to support inactivity-based notification routing.
+CREATE TABLE IF NOT EXISTS conversations (
+  id                    TEXT PRIMARY KEY,
+  last_user_message_at  DATETIME NOT NULL
+);

--- a/pkg/store/sqlite/store.go
+++ b/pkg/store/sqlite/store.go
@@ -4271,6 +4271,33 @@ func (s *Store) GetAgentLastNPSTime(ctx context.Context, agentID string) (*time.
 	return &t, nil
 }
 
+func (s *Store) UpdateConversationActivity(ctx context.Context, conversationID string, lastUserMessageAt time.Time) error {
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO conversations (id, last_user_message_at)
+		VALUES (?, ?)
+		ON CONFLICT (id) DO UPDATE SET
+			last_user_message_at = excluded.last_user_message_at
+	`, conversationID, lastUserMessageAt.UTC().Format(time.RFC3339))
+	return err
+}
+
+func (s *Store) GetConversationActivity(ctx context.Context, conversationID string) (*store.ConversationActivity, error) {
+	var lastUserMessageAt string
+	err := s.db.QueryRowContext(ctx, `
+		SELECT last_user_message_at FROM conversations WHERE id = ?
+	`, conversationID).Scan(&lastUserMessageAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &store.ConversationActivity{
+		ConversationID:    conversationID,
+		LastUserMessageAt: parseTime(lastUserMessageAt),
+	}, nil
+}
+
 // Ensure Store implements store.Store at compile time.
 var _ store.Store = (*Store)(nil)
 

--- a/pkg/store/sqlite/store.go
+++ b/pkg/store/sqlite/store.go
@@ -4276,7 +4276,10 @@ func (s *Store) UpdateConversationActivity(ctx context.Context, conversationID s
 		INSERT INTO conversations (id, last_user_message_at)
 		VALUES (?, ?)
 		ON CONFLICT (id) DO UPDATE SET
-			last_user_message_at = excluded.last_user_message_at
+			last_user_message_at = CASE
+				WHEN excluded.last_user_message_at > conversations.last_user_message_at THEN excluded.last_user_message_at
+				ELSE conversations.last_user_message_at
+			END
 	`, conversationID, lastUserMessageAt.UTC().Format(time.RFC3339))
 	return err
 }

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -388,6 +388,10 @@ type Store interface {
 	// Aggregate counts (telemetry)
 	TelemetryCounts(ctx context.Context) (*TelemetryCounts, error)
 
+	// Conversations
+	UpdateConversationActivity(ctx context.Context, conversationID string, lastUserMessageAt time.Time) error
+	GetConversationActivity(ctx context.Context, conversationID string) (*ConversationActivity, error)
+
 	// Health
 	Ping(ctx context.Context) error
 	Close() error
@@ -1345,4 +1349,10 @@ type NPSStats struct {
 	AverageScore   float64 `json:"average_score"`
 	LastScore      int     `json:"last_score"`
 	LastFeedback   string  `json:"last_feedback,omitempty"`
+}
+
+// ConversationActivity tracks the last user message time for inactivity detection.
+type ConversationActivity struct {
+	ConversationID    string    `json:"conversation_id"`
+	LastUserMessageAt time.Time `json:"last_user_message_at"`
 }


### PR DESCRIPTION

## Overview

This PR introduces support for headless and asynchronous runners by implementing two major enhancements to Clawvisor's approval workflow:

1. **Inactivity-Based Task Routing (`surface=auto`)**
   - Automatically routes approval requests to the asynchronous approval queue when the user has been inactive for a configurable period.
   - Enables autonomous agents and background runners to continue operating even when the user is offline.

2. **Programmatic Wait API (`GET /api/control/approvals/{id}/wait`)**
   - Provides a long-polling endpoint that allows headless runners to efficiently wait for human approval decisions.
   - Eliminates the need for continuous polling loops and reduces database load.

Together, these changes allow Clawvisor to support long-running, autonomous, and headless workflows while maintaining human approval controls.

---

# Before vs. After

| Scenario | Before | After |
|-----------|----------|---------|
| **Headless runner requesting approval (`surface=auto`)** | Runners had to wait for interactive inline approval prompts. If the user was offline or inactive, the runner could hang indefinitely or time out waiting for input that would never arrive. | When user inactivity exceeds `inactivity_threshold_seconds`, Clawvisor automatically routes the task to the asynchronous approval queue and notification channels. The runner immediately receives a task ID and wait nonce without requiring an inline interaction. |
| **Runner waiting for approval status** | Headless runners had to repeatedly poll `GET /api/control/tasks/{id}` in a spin-loop, generating unnecessary database reads and server load. | Runners can use `GET /api/control/approvals/{id}/wait?timeout=N`, allowing the server to hold the connection and return immediately when the approval state changes. |
| **Approval status propagation** | State changes were only visible on the next polling iteration, introducing latency and wasted requests. | With `EventHub` enabled, approval state changes immediately wake waiting clients through event-driven notifications. |
| **Fallback operation without EventHub** | Clients were responsible for implementing their own polling behavior. | The server provides a built-in fallback polling loop that checks approval state once per second when `EventHub` is unavailable. |
| **Redis approval lookup in multi-replica deployments** | Resolving a pending approval by ID required scanning all active hold entries, resulting in approximately `O(K × L)` Redis scan overhead under load. | A secondary index (`clawvisor:lite_pending_approval_map:<id>`) enables direct `O(1)` lookups of the associated hold entry. |
| **Deleted or purged tasks while waiting** | Long-poll requests remained blocked until timeout expiration even when the underlying task had already been deleted. | Both event-driven and polling implementations detect `store.ErrNotFound` and immediately return `status: denied`, releasing server and client resources. |
| **User activity awareness** | Inline approval interception had no concept of user presence or inactivity. | User activity timestamps are persisted and evaluated so `surface=auto` can intelligently decide between inline and asynchronous approval routing. |
| **Notification channel integration** | Approval requests depended on the user being present in the active chat session. | Inactive-user approvals automatically fall through to the existing async workflow, including dashboard, Slack, Telegram, and other configured notification channels. |
| **Scalability for long-running agents** | Long-running or autonomous agents were tightly coupled to active chat sessions. | Headless runners can operate independently, submit approval requests, and wait programmatically for human decisions without requiring a live chat connection. |

---

# Detailed Architectural Breakdown & Technical Decisions

## 1. Inactivity-Based Routing (`surface=auto`)

### Background

For `surface=auto` to make an intelligent routing decision, Clawvisor must know whether a user is currently active.

The existing `RecentUserTurns` field within `PostprocessConfig` only stores recent message content and does not retain timestamps. As a result, there was no reliable way to determine how long it had been since the user's last interaction.

### Database Conversation Tracking

To support inactivity detection, a new `conversations` table was introduced.

#### Schema Changes

A new table stores:

```sql
last_user_message_at TIMESTAMP
```

SQLite and PostgreSQL migrations were added to support the new schema.

### Activity Recording

When requests pass through the LLM proxy:

1. `HasNewUserMessage` determines whether the request contains a genuine new user turn.
2. If true, the conversation record is created or updated.
3. `last_user_message_at` is refreshed.

This creates a durable source of truth for user activity.

### Surface Interception Logic

When a model requests a task using:

```text
surface=auto
```

`MaybeInterceptInlineTaskDefinition()` evaluates inactivity.

If:

```text
current_time - last_user_message_at > inactivity_threshold_seconds
```

the inline approval flow is bypassed.

Instead:

- The task is persisted normally.
- Notifications are dispatched.
- The request enters the existing asynchronous approval workflow.

---

## 2. Programmatic Wait API

### New Endpoint

```http
GET /api/control/approvals/{id}/wait
```

### Purpose

Provides a long-polling API allowing headless runners to wait for approval decisions without repeatedly polling task status endpoints.

Supported identifiers:

- Approval IDs (`cv-*`)
- Database Task IDs

### EventHub Integration

When `EventHub` is enabled:

1. The handler subscribes to the user's event channel.
2. `events.WaitFor()` blocks efficiently.
3. Status changes publish events.
4. Waiting clients are awakened immediately.

Benefits:

- Near-instant approval propagation
- Minimal database traffic
- No polling overhead

### Fallback Polling Mode

When `EventHub` is unavailable:

1. A ticker loop checks approval state once per second.
2. The request exits immediately when a terminal state is observed.

Benefits:

- Works in all deployments
- Requires no additional infrastructure
- Preserves API consistency

### Task Purge Unblocking

Previously, deleted tasks could leave waiting clients blocked until timeout.

Both implementations now detect:

```go
store.ErrNotFound
```

and immediately return:

```json
{
  "status": "denied"
}
```

Benefits:

- Faster client recovery
- Reduced resource usage
- No unnecessary long-held connections

---

## 3. Redis O(1) Approval Lookup Index

### Problem

In multi-replica environments, locating a pending approval required scanning active Redis hold records.

Lookup complexity was approximately:

```text
O(K × L)
```

where:

- `K` = active holds
- `L` = list entries

This became increasingly expensive under load.

### Solution

A secondary Redis index was introduced:

```text
clawvisor:lite_pending_approval_map:<id>
```

The mapping stores:

```text
approval_id -> hold_key
```

### Registration

During:

```go
Hold()
```

the secondary mapping is created.

### Retrieval

During:

```go
PeekByID()
```

the lookup becomes:

1. Read mapping key.
2. Resolve hold key.
3. Read only the target hold list.

No scans are required.

### Cleanup

Mappings are removed during:

- `Resolve()`
- `Drop()`

and inherit the same TTL as the associated hold record.

Benefits:

- O(1) approval lookup
- Reduced Redis load
- Better multi-replica scalability

---

# Verification & Test Findings

## Automated Unit Tests

### Wait API Test Suite

Verified:

- Pending approvals
- Immediate approvals
- Immediate denials
- Timeouts
- Event-driven state transitions

```bash
go test ./internal/api/handlers/ -run TestControlWaitForApproval

# ok  github.com/clawvisor/clawvisor/internal/api/handlers (0.05s)
```

### Full Handler Package Suite

Verified all integration and gateway tests.

```bash
go test ./internal/api/handlers/...

# ok  github.com/clawvisor/clawvisor/internal/api/handlers 64.770s
```

All 17 integration and gateway verification tests completed successfully.

---

## End-to-End Integration Verification

### Environment

Validation was performed against live Docker containers using:

- WAL-mode SQLite
- Docker loopback networking
- Real approval flows

### Inactivity Routing Verification

Procedure:

1. Send a normal user request.
2. Wait longer than the configured inactivity threshold.
3. Submit:

```text
run command
```

Result:

- Inline approval was bypassed.
- A task was created asynchronously.
- A `cv-nonce-*` identifier was returned immediately.

### Wait Endpoint Verification

Call:

```http
GET /api/control/approvals/{id}/wait
```

Result:

```json
{
  "status": "pending"
}
```

with:

```http
Retry-After: 1000
```

when unresolved.

### Approval Transition Verification

Procedure:

1. Exchange loopback container token for admin JWT.
2. Approve task via:

```http
POST /api/tasks/{task_id}/approve
```

3. Observe the waiting request.

Result:

The blocked wait request immediately unblocked and returned:

```json
{
  "status": "approved"
}
```

without waiting for timeout expiration.

---

# Summary

This PR introduces first-class support for headless and asynchronous runners by adding:

- Inactivity-aware approval routing
- Long-polling approval wait APIs
- Event-driven approval notifications
- Efficient Redis O(1) approval lookups
- Automatic cleanup handling for deleted tasks
- Durable conversation activity tracking

These changes significantly improve the experience for autonomous agents and background runners while reducing database load, improving approval latency, and enabling approval workflows to function correctly even when users are offline.