### PR TITLE
chore(llmproxy): capitalize Yes/No labels on AskUserQuestion approval prompts

### DIFF
--- a/internal/runtime/llmproxy/inline_task_intercept.go
+++ b/internal/runtime/llmproxy/inline_task_intercept.go
@@ -501,8 +501,8 @@ func buildAskUserQuestionApprovalCall(approvalID string, spec askUserQuestionApp
 					"header":      spec.Header,
 					"multiSelect": false,
 					"options": []map[string]any{
-						{"label": "yes", "description": spec.YesDescription},
-						{"label": "no", "description": "Cancel"},
+						{"label": "Yes", "description": spec.YesDescription},
+						{"label": "No", "description": "Cancel"},
 					},
 				},
 			},

--- a/internal/runtime/llmproxy/inline_task_prompt_test.go
+++ b/internal/runtime/llmproxy/inline_task_prompt_test.go
@@ -166,8 +166,8 @@ func TestBuildAskUserQuestionToolCallShape(t *testing.T) {
 	if len(opts) != 2 {
 		t.Fatalf("expected exactly 2 options (yes/no), got %d", len(opts))
 	}
-	if opts[0]["label"] != "yes" || opts[1]["label"] != "no" {
-		t.Errorf("expected options [yes,no] (parser maps yes→approve / no→deny), got %v", opts)
+	if opts[0]["label"] != "Yes" || opts[1]["label"] != "No" {
+		t.Errorf("expected options [Yes,No] (parser maps yes→approve / no→deny, case-insensitive), got %v", opts)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Emit `Yes`/`No` (capitalized) instead of `yes`/`no` for the picker options on inline task-creation and scope-expansion approval prompts in `buildAskUserQuestionApprovalCall`.
- Approval-reply parsing remains unchanged: `approvalReplyRE` / `bareApprovalRE` in `internal/runtime/conversation/approval_reply.go` both use `(?i)`, so the release path matches the new labels identically.

## Test plan
- [x] `go test ./internal/runtime/llmproxy/... ./internal/runtime/conversation/...`
- [ ] Spot-check the approval prompt UI shows `Yes` / `No`

🤖 Generated with [Claude Code](https://claude.com/claude-code)