### PR TITLE
fix(llmproxy): pair text-shape inline-task notice with reconstructed tool_use + rewrite↔sanitize round-trip test

### DIFF
--- a/internal/runtime/llmproxy/bodytransform/roundtrip_test.go
+++ b/internal/runtime/llmproxy/bodytransform/roundtrip_test.go
@@ -1,0 +1,293 @@
+package bodytransform_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/bodytransform"
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/controltool"
+)
+
+// TestRewriteSanitizeRoundTrip pins the inverse-property contract
+// between the per-tool rewriter (controltool.RewriteControlToolUse —
+// rewrites the model's synthetic clawvisor.local URL into the
+// resolver URL + injects auth headers) and the inbound sanitizer
+// (bodytransform.SanitizeInboundHistory — runs on the next turn's
+// inbound body and reverts the same artifacts before the model sees
+// its own history).
+//
+// Why this matters: the rewriter mutates tool_use bytes in the
+// outbound SSE stream so the harness's exec dials the resolver
+// directly, but the harness records those mutated bytes verbatim as
+// the assistant's emission. Without a tight inverse on the next
+// inbound, the model accumulates the post-rewrite shape (resolver
+// URL, stale nonces) as a self-taught exemplar and emits the wrong
+// shape on subsequent turns — which the rewriter's host-gate then
+// skips, the harness's exec runs the unrewritten curl, and the
+// model misreads the resulting connection-refused as "Clawvisor's
+// control plane is down."
+//
+// Each case is a model-realistic synthetic-shape curl. We:
+//
+//  1. Wrap the input in an Anthropic-shaped /v1/messages body as a
+//     single assistant tool_use.
+//  2. Send it through the rewriter (with a fixed nonce) to produce
+//     the bytes the harness would record after one rewrite turn.
+//  3. Send THOSE bytes (now living in conversation history) through
+//     the sanitizer.
+//  4. Assert byte-for-byte equality with the original synthetic
+//     command. Any drift here is a leak the model would learn from
+//     on the next turn.
+//
+// The cases cover every model-realistic synthetic shape today:
+// GET reads, POST with --data heredoc, POST with --data inline,
+// extra harmless flags, and pre-existing model headers that must
+// survive the round-trip.
+func TestRewriteSanitizeRoundTrip(t *testing.T) {
+	const (
+		controlBase  = "http://localhost:25297"
+		resolverBase = "http://localhost:25297/api/proxy"
+		callerToken  = "cv-nonce-roundtrip0test001"
+	)
+
+	cases := []struct {
+		name    string
+		command string
+	}{
+		{
+			name:    "vault items GET",
+			command: `curl -sS 'https://clawvisor.local/control/vault/items'`,
+		},
+		{
+			name:    "skill index GET",
+			command: `curl -sS 'https://clawvisor.local/control/skill'`,
+		},
+		{
+			name:    "tasks POST surface inline (heredoc)",
+			command: "curl -sS -X POST 'https://clawvisor.local/control/tasks?surface=inline' -H 'Content-Type: application/json' --data @- <<'JSON'\n{\"purpose\":\"do thing\",\"expected_tools\":[]}\nJSON",
+		},
+		{
+			name:    "tasks POST surface inline (inline data)",
+			command: `curl -sS -X POST 'https://clawvisor.local/control/tasks?surface=inline' -H 'Content-Type: application/json' --data '{"purpose":"do thing"}'`,
+		},
+		{
+			name:    "task checkout POST",
+			command: `curl -sS -X POST 'https://clawvisor.local/control/task/checkout' -H 'Content-Type: application/json' --data '{"task_id":"t-abc"}'`,
+		},
+		{
+			name:    "task expand POST (path with id)",
+			command: `curl -sS -X POST 'https://clawvisor.local/control/tasks/t-abc/expand?surface=inline' -H 'Content-Type: application/json' --data '{"additional_tools":[]}'`,
+		},
+		{
+			name:    "failure POST",
+			command: `curl -sS -X POST 'https://clawvisor.local/control/failure?reason=malformed' -H 'Content-Type: application/json' --data '{"original_command":"junk"}'`,
+		},
+		{
+			name:    "autovault script GET",
+			command: `curl -sS 'https://clawvisor.local/control/autovault/script'`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			toolUse := conversation.ToolUse{
+				ID:    "toolu_rt_" + strings.ReplaceAll(tc.name, " ", "_"),
+				Name:  "Bash",
+				Input: mustMarshal(t, map[string]any{"command": tc.command}),
+			}
+			rewrittenInput, _, ok, err := controltool.RewriteControlToolUse(toolUse, controlBase, callerToken)
+			if err != nil {
+				t.Fatalf("rewrite returned error: %v", err)
+			}
+			if !ok {
+				t.Fatalf("rewrite refused to rewrite this command — verdict didn't recognize it; rewriter contract requires every model-taught synthetic shape to be rewritable")
+			}
+			// Sanity-check the rewriter actually mutated the command:
+			// if the inverse contract is vacuously true (rewriter was a
+			// no-op) the test isn't pinning anything.
+			rewrittenCommand := extractCommand(t, rewrittenInput)
+			if rewrittenCommand == tc.command {
+				t.Fatalf("rewrite did not mutate the command — round-trip is vacuous; command: %q", tc.command)
+			}
+			if !strings.Contains(rewrittenCommand, "X-Clawvisor-Target-Host") {
+				t.Errorf("rewrite missing X-Clawvisor-Target-Host injection — sanitize won't have anything to strip; rewritten: %q", rewrittenCommand)
+			}
+			if !strings.Contains(rewrittenCommand, "X-Clawvisor-Caller") {
+				t.Errorf("rewrite missing X-Clawvisor-Caller injection — sanitize won't have the auth header to strip; rewritten: %q", rewrittenCommand)
+			}
+			if !strings.Contains(rewrittenCommand, callerToken) {
+				t.Errorf("rewrite missing caller nonce in command; rewritten: %q", rewrittenCommand)
+			}
+			if strings.Contains(rewrittenCommand, "clawvisor.local/control") {
+				t.Errorf("rewrite left synthetic URL intact — host-swap didn't happen; rewritten: %q", rewrittenCommand)
+			}
+
+			// Wrap the rewritten input as a one-message inbound body and
+			// run sanitize.
+			body := buildAnthropicBody(t, toolUse.ID, rewrittenInput)
+			res, err := bodytransform.SanitizeInboundHistory(bodytransform.SanitizeInboundRequest{
+				Provider:        conversation.ProviderAnthropic,
+				Body:            body,
+				ResolverBaseURL: resolverBase,
+				ControlBaseURL:  controlBase,
+			})
+			if err != nil {
+				t.Fatalf("sanitize returned error: %v", err)
+			}
+			if !res.Modified {
+				t.Fatalf("sanitize was a no-op against rewritten body — that means the round-trip would leave the rewriter's artifacts in conversation history forever")
+			}
+			sanitizedCommand := extractCommandFromBody(t, res.Body)
+
+			// The core property: sanitize fully reverses the rewriter,
+			// down to byte equality with the model's original synthetic
+			// shape. Any drift is a leak — the rewriter's artifacts
+			// become the model's exemplar.
+			if sanitizedCommand != tc.command {
+				t.Errorf("round-trip drift:\n   original: %q\n  sanitized: %q\n rewritten: %q", tc.command, sanitizedCommand, rewrittenCommand)
+			}
+
+			// Defense-in-depth: even if a future rewriter shape sneaks
+			// past the equality check above, no rewriter artifact may
+			// survive in the sanitized body.
+			if strings.Contains(sanitizedCommand, "X-Clawvisor-") {
+				t.Errorf("sanitized command still carries X-Clawvisor-* header artifact: %q", sanitizedCommand)
+			}
+			if strings.Contains(sanitizedCommand, "cv-nonce-") {
+				t.Errorf("sanitized command still carries cv-nonce-* token leak: %q", sanitizedCommand)
+			}
+			if strings.Contains(sanitizedCommand, "localhost:25297") {
+				t.Errorf("sanitized command still carries resolver host: %q", sanitizedCommand)
+			}
+			if strings.Contains(sanitizedCommand, "/api/control/") {
+				t.Errorf("sanitized command still carries resolver-side /api/control path: %q", sanitizedCommand)
+			}
+		})
+	}
+}
+
+// TestRewriteSanitizeRoundTrip_PreservesUnrelatedHeaders pins one
+// adjacent property the inverse-pair test doesn't cover: when the
+// model emits a control curl that already includes non-injected
+// headers (Content-Type, Accept, etc.), those headers must survive
+// the round-trip. Sanitize only strips the rewriter's known names;
+// every other header is the model's own and may not be touched.
+func TestRewriteSanitizeRoundTrip_PreservesUnrelatedHeaders(t *testing.T) {
+	const (
+		controlBase  = "http://localhost:25297"
+		resolverBase = "http://localhost:25297/api/proxy"
+		callerToken  = "cv-nonce-preserve000001"
+	)
+	command := `curl -sS -X POST 'https://clawvisor.local/control/tasks?surface=inline' -H 'Content-Type: application/json' -H 'Accept: application/json' --data '{"purpose":"x"}'`
+	toolUse := conversation.ToolUse{
+		ID:    "toolu_preserve",
+		Name:  "Bash",
+		Input: mustMarshal(t, map[string]any{"command": command}),
+	}
+	rewrittenInput, _, ok, err := controltool.RewriteControlToolUse(toolUse, controlBase, callerToken)
+	if err != nil || !ok {
+		t.Fatalf("rewrite ok=%v err=%v", ok, err)
+	}
+	body := buildAnthropicBody(t, toolUse.ID, rewrittenInput)
+	res, err := bodytransform.SanitizeInboundHistory(bodytransform.SanitizeInboundRequest{
+		Provider:        conversation.ProviderAnthropic,
+		Body:            body,
+		ResolverBaseURL: resolverBase,
+		ControlBaseURL:  controlBase,
+	})
+	if err != nil {
+		t.Fatalf("sanitize: %v", err)
+	}
+	sanitized := extractCommandFromBody(t, res.Body)
+	for _, want := range []string{
+		"Content-Type: application/json",
+		"Accept: application/json",
+		`'{"purpose":"x"}'`,
+	} {
+		if !strings.Contains(sanitized, want) {
+			t.Errorf("sanitize dropped model-emitted artifact %q from %q", want, sanitized)
+		}
+	}
+}
+
+func mustMarshal(t *testing.T, v any) json.RawMessage {
+	t.Helper()
+	out, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return out
+}
+
+// extractCommand parses a rewriter output (tool_use input bytes) and
+// returns the command field. Tools may use `cmd` or `command`; the
+// rewriter preserves whichever name was on the input.
+func extractCommand(t *testing.T, input []byte) string {
+	t.Helper()
+	var raw map[string]any
+	if err := json.Unmarshal(input, &raw); err != nil {
+		t.Fatalf("unmarshal tool_use input: %v", err)
+	}
+	if s, ok := raw["command"].(string); ok {
+		return s
+	}
+	if s, ok := raw["cmd"].(string); ok {
+		return s
+	}
+	t.Fatalf("tool_use input missing command/cmd: %s", input)
+	return ""
+}
+
+func extractCommandFromBody(t *testing.T, body []byte) string {
+	t.Helper()
+	// content may be a plain string (user turns) or an array of blocks
+	// (assistant turns). Decode with json.RawMessage and walk only
+	// array-shaped content.
+	var b struct {
+		Messages []struct {
+			Role    string          `json:"role"`
+			Content json.RawMessage `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(body, &b); err != nil {
+		t.Fatalf("unmarshal sanitized body: %v", err)
+	}
+	for _, m := range b.Messages {
+		if m.Role != "assistant" {
+			continue
+		}
+		var blocks []struct {
+			Type  string          `json:"type"`
+			Input json.RawMessage `json:"input"`
+		}
+		if err := json.Unmarshal(m.Content, &blocks); err != nil {
+			continue
+		}
+		for _, blk := range blocks {
+			if blk.Type == "tool_use" {
+				return extractCommand(t, blk.Input)
+			}
+		}
+	}
+	t.Fatalf("no assistant tool_use in body: %s", body)
+	return ""
+}
+
+func buildAnthropicBody(t *testing.T, toolUseID string, input json.RawMessage) []byte {
+	t.Helper()
+	body, err := json.Marshal(map[string]any{
+		"model": "claude-sonnet-4-6",
+		"messages": []map[string]any{
+			{"role": "user", "content": "do the thing"},
+			{"role": "assistant", "content": []map[string]any{
+				{"type": "tool_use", "id": toolUseID, "name": "Bash", "input": json.RawMessage(input)},
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	return body
+}

--- a/internal/runtime/llmproxy/historystrip/synthetic_history_strip.go
+++ b/internal/runtime/llmproxy/historystrip/synthetic_history_strip.go
@@ -113,10 +113,21 @@ func stripAnthropicSyntheticApprovalHistory(body []byte, lookup ReconstructionLo
 	// a 400, so the strip must clean both ends of the pair together.
 	var orphanedToolUseIDs map[string]struct{}
 	// pendingReconstruction, when set, signals that the next user
-	// turn's tool_result for orphanedToolUseIDs[*] should be REPLACED
-	// (not stripped) with a tool_result paired to the reconstruction's
-	// ToolUseID. Carries the synthetic-ID → reconstruction mapping so
-	// the next-turn handler knows which tool_result to swap.
+	// turn must be paired with the reconstruction's ToolUseID. Two
+	// shapes feed in here:
+	//   - AskUserQuestion path: the substituted assistant turn carried
+	//     a synthetic picker tool_use; orphanedToolUseIDs holds its id
+	//     and the user's tool_result for it gets SWAPPED to point at
+	//     the reconstructed tool_use_id.
+	//   - Text-only path: no synthetic picker tool_use existed, so
+	//     orphanedToolUseIDs is empty. The user's content (a plain
+	//     notice text the body editor or augmenter spliced in) gets
+	//     WRAPPED into a fresh tool_result paired to the reconstructed
+	//     tool_use_id. Without the wrap the next request goes upstream
+	//     with a reconstructed [tool_use] but a plain-text user turn,
+	//     and Anthropic rejects with "tool_use ids were found without
+	//     tool_result blocks immediately after" (the Telegram-bot /
+	//     Codex agents failure mode).
 	var pendingReconstruction *ReconstructedPair
 	for _, msg := range messages {
 		role := extractMessageRole(msg)
@@ -129,15 +140,12 @@ func stripAnthropicSyntheticApprovalHistory(body []byte, lookup ReconstructionLo
 				continue
 			}
 		}
-		if role == "user" && len(orphanedToolUseIDs) > 0 {
-			// When a reconstruction is in flight, REPLACE the
-			// matching tool_result block with one paired to the
-			// reconstructed tool_use_id; otherwise strip the
-			// orphan (current behavior).
-			if pendingReconstruction != nil {
+		if role == "user" && pendingReconstruction != nil {
+			if len(orphanedToolUseIDs) > 0 {
+				// AskUserQuestion path: replace the orphan
+				// tool_result block with one paired to the
+				// reconstructed tool_use_id.
 				swapped, swapChanged, swapErr := replaceToolResultsForReconstruction(content, orphanedToolUseIDs, pendingReconstruction)
-				orphanedToolUseIDs = nil
-				pendingReconstruction = nil
 				if swapErr == nil && swapChanged {
 					modified = true
 					newMsg, err := jsonsurgery.SetField(msg, "content", swapped)
@@ -146,19 +154,37 @@ func stripAnthropicSyntheticApprovalHistory(body []byte, lookup ReconstructionLo
 					}
 				}
 			} else {
-				cleaned, dropped, changed, err := stripToolResultsByID(content, orphanedToolUseIDs)
-				orphanedToolUseIDs = nil
-				if err == nil && changed {
+				// Text-only path: the original substituted turn
+				// carried no synthetic picker tool_use, so the
+				// user content has no orphan tool_result to swap.
+				// Wrap the user's notice text as a fresh
+				// tool_result paired to the reconstructed
+				// tool_use_id so Anthropic's
+				// tool_use→tool_result adjacency holds.
+				wrapped, wrapChanged, wrapErr := wrapUserContentAsToolResult(content, pendingReconstruction)
+				if wrapErr == nil && wrapChanged {
 					modified = true
-					if dropped {
-						// User message had only the orphan tool_result
-						// (and maybe blank text). Drop the whole turn.
-						continue
-					}
-					newMsg, err := jsonsurgery.SetField(msg, "content", cleaned)
+					newMsg, err := jsonsurgery.SetField(msg, "content", wrapped)
 					if err == nil {
 						msg = newMsg
 					}
+				}
+			}
+			orphanedToolUseIDs = nil
+			pendingReconstruction = nil
+		} else if role == "user" && len(orphanedToolUseIDs) > 0 {
+			cleaned, dropped, changed, err := stripToolResultsByID(content, orphanedToolUseIDs)
+			orphanedToolUseIDs = nil
+			if err == nil && changed {
+				modified = true
+				if dropped {
+					// User message had only the orphan tool_result
+					// (and maybe blank text). Drop the whole turn.
+					continue
+				}
+				newMsg, err := jsonsurgery.SetField(msg, "content", cleaned)
+				if err == nil {
+					msg = newMsg
 				}
 			}
 		}
@@ -184,14 +210,22 @@ func stripAnthropicSyntheticApprovalHistory(body []byte, lookup ReconstructionLo
 						msg = newMsg
 						modified = true
 						survivors = append(survivors, msg)
-						// Signal the next user turn to SWAP
-						// (not strip) the orphan tool_result.
+						// Signal the next user turn to pair
+						// up with the reconstructed tool_use:
+						// SWAP an existing tool_result (when
+						// the substituted turn carried a
+						// synthetic picker call) or WRAP the
+						// user's text content as a fresh
+						// tool_result (text-only path). The
+						// pendingReconstruction flag carries
+						// the data; orphanedToolUseIDs
+						// selects between the two paths.
+						pendingReconstruction = reconstructed
 						if len(ids) > 0 {
 							orphanedToolUseIDs = make(map[string]struct{}, len(ids))
 							for _, id := range ids {
 								orphanedToolUseIDs[id] = struct{}{}
 							}
-							pendingReconstruction = reconstructed
 						}
 						skipNextBareApprovalReply = true
 						continue
@@ -377,6 +411,116 @@ func buildReconstructedAssistantBlock(rec *ReconstructedPair) (json.RawMessage, 
 		return nil, false
 	}
 	return raw, true
+}
+
+// wrapUserContentAsToolResult is the text-only-path counterpart to
+// replaceToolResultsForReconstruction. When the substituted-prompt
+// assistant turn carried no synthetic picker tool_use (the
+// AskUserQuestion-less path used by Codex / Telegram-bot agents), the
+// user turn has no orphan tool_result to swap — just a notice text
+// block (or plain string content) the body editor / augmenter
+// produced. Wrap that notice into a fresh tool_result block paired to
+// the reconstruction's ToolUseID so the next request's
+// [reconstructed tool_use] → [user tool_result] adjacency is valid.
+//
+// Skips when:
+//   - content already contains a tool_result block (already wrapped,
+//     or paired against an unrelated exchange — don't double-wrap).
+//   - content blocks contain non-text shapes (tool_use, image, …) —
+//     unsafe to re-shape into a single tool_result content.
+//   - content is a multi-text-block array with no notice marker —
+//     we can't tell which block is the approval reply, so refuse to
+//     guess.
+//
+// On wrap, the tool_result becomes the first content block and any
+// non-notice text blocks (e.g. system reminders the harness appended)
+// pass through unchanged alongside it.
+func wrapUserContentAsToolResult(raw json.RawMessage, rec *ReconstructedPair) (json.RawMessage, bool, error) {
+	if len(raw) == 0 || rec == nil || rec.ToolUseID == "" {
+		return raw, false, nil
+	}
+	// Plain-string content: the body editor's text-shape rewrite
+	// (replaceAnthropicApprovalReply) lands here. Wrap the whole
+	// string as the tool_result's content.
+	var simple string
+	if err := json.Unmarshal(raw, &simple); err == nil {
+		block, err := json.Marshal(map[string]any{
+			"type":        "tool_result",
+			"tool_use_id": rec.ToolUseID,
+			"content":     simple,
+		})
+		if err != nil {
+			return raw, false, err
+		}
+		out, err := json.Marshal([]json.RawMessage{block})
+		if err != nil {
+			return raw, false, err
+		}
+		return out, true, nil
+	}
+	// Block-array content: the persistent augmenter
+	// (augmentAnthropicApprovedInlineTasks) lands here after splicing
+	// the notice into a text block.
+	var blocks []json.RawMessage
+	if err := json.Unmarshal(raw, &blocks); err != nil {
+		return raw, false, nil
+	}
+	noticeIdx := -1
+	var noticeText string
+	for i, blk := range blocks {
+		var probe struct {
+			Type      string `json:"type"`
+			Text      string `json:"text"`
+			ToolUseID string `json:"tool_use_id"`
+		}
+		if err := json.Unmarshal(blk, &probe); err != nil {
+			return raw, false, nil
+		}
+		switch probe.Type {
+		case "tool_result":
+			// Existing tool_result block — leave the message
+			// alone rather than risk a double-wrap.
+			return raw, false, nil
+		case "text":
+			if noticeIdx < 0 && ContainsInlineApprovalAugmentationMarker(probe.Text) {
+				noticeIdx = i
+				noticeText = probe.Text
+			}
+		default:
+			// Non-text, non-tool_result block (tool_use, image,
+			// document, …). Refuse to re-shape; the wrap path
+			// isn't equipped to preserve the semantics.
+			return raw, false, nil
+		}
+	}
+	if noticeIdx < 0 {
+		// No notice marker in any text block — can't tell which
+		// block belongs in the tool_result. Skip rather than guess.
+		return raw, false, nil
+	}
+	toolResultBlock, err := json.Marshal(map[string]any{
+		"type":        "tool_result",
+		"tool_use_id": rec.ToolUseID,
+		"content":     noticeText,
+	})
+	if err != nil {
+		return raw, false, err
+	}
+	// Prepend the tool_result; drop the original notice text block;
+	// preserve the remaining blocks (system reminders, etc.) in order.
+	newBlocks := make([]json.RawMessage, 0, len(blocks))
+	newBlocks = append(newBlocks, toolResultBlock)
+	for i, blk := range blocks {
+		if i == noticeIdx {
+			continue
+		}
+		newBlocks = append(newBlocks, blk)
+	}
+	out, err := json.Marshal(newBlocks)
+	if err != nil {
+		return raw, false, err
+	}
+	return out, true, nil
 }
 
 // replaceToolResultsForReconstruction walks the user-turn content,

--- a/internal/runtime/llmproxy/synthetic_history_strip_test.go
+++ b/internal/runtime/llmproxy/synthetic_history_strip_test.go
@@ -348,6 +348,199 @@ func TestStripSyntheticApprovalHistory_ReconstructionIdempotentAcrossTurns(t *te
 	}
 }
 
+// TestStripSyntheticApprovalHistory_WrapsTextOnlyUserTurnAsToolResult
+// pins the fix for the text-shape inline-approval path: when the
+// substituted-prompt assistant turn had no AskUserQuestion (Codex,
+// Telegram-bot agents, any harness without an AskUserQuestion-style
+// picker), the body editor lands the approval notice as a plain
+// string user content. After the strip reconstructs the assistant
+// turn into [tool_use(original)], that user turn would dangle as an
+// unpaired text message and Anthropic would 400 with
+// "messages.N: tool_use ids were found without tool_result blocks
+// immediately after". The strip must wrap the notice into a
+// tool_result paired to the reconstructed tool_use_id.
+func TestStripSyntheticApprovalHistory_WrapsTextOnlyUserTurnAsToolResult(t *testing.T) {
+	const approvalID = "cv-textwrapcurr01"
+	const originalToolUseID = "toolu_01TextOnlyOriginal"
+	notice := `<clawvisor-notice kind="task-approved">Task was created and approved by the user. Task ID: task-x.</clawvisor-notice>`
+	body, err := json.Marshal(map[string]any{
+		"model": "claude-haiku-4-5",
+		"messages": []map[string]any{
+			{"role": "user", "content": "create the task"},
+			{"role": "assistant", "content": []map[string]any{
+				{"type": "text", "text": "Clawvisor wants to create a task to cover this work:\n\nPurpose\n  Bootstrap\n\n[clawvisor:approval=" + approvalID + "]"},
+			}},
+			// Plain-string content: the body editor's text-shape
+			// rewrite (replaceAnthropicApprovalReply) produces this
+			// shape after a user "y" / "approve" reply.
+			{"role": "user", "content": notice},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	lookup := func(id string) *historystrip.ReconstructedPair {
+		if id != approvalID {
+			return nil
+		}
+		return &historystrip.ReconstructedPair{
+			ToolUseID:  originalToolUseID,
+			ToolName:   "exec",
+			Input:      json.RawMessage(`{"command":"curl -X POST .../control/tasks?surface=inline ..."}`),
+			ResultText: notice,
+		}
+	}
+	out, err := StripSyntheticApprovalHistory(SyntheticApprovalHistoryStripRequest{
+		Provider:             conversation.ProviderAnthropic,
+		Body:                 body,
+		ReconstructionLookup: lookup,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !out.Modified {
+		t.Fatalf("strip should rewrite body for text-shape reconstruction; got unchanged: %s", out.Body)
+	}
+	got := string(out.Body)
+	// Substituted-prompt text must not survive.
+	if strings.Contains(got, "Clawvisor wants to create a task") {
+		t.Errorf("substituted-prompt text leaked: %s", got)
+	}
+	// Assistant turn becomes [tool_use(original)].
+	if !strings.Contains(got, `"id":"`+originalToolUseID+`"`) {
+		t.Errorf("reconstructed tool_use_id missing: %s", got)
+	}
+	// User turn must be wrapped as a tool_result paired to the
+	// reconstructed tool_use_id — this is the adjacency Anthropic
+	// validates. Without the wrap, the user turn would be a plain
+	// string and the next request would 400.
+	if !strings.Contains(got, `"type":"tool_result"`) {
+		t.Errorf("expected tool_result wrap on user turn; got: %s", got)
+	}
+	if !strings.Contains(got, `"tool_use_id":"`+originalToolUseID+`"`) {
+		t.Errorf("tool_result must pair against reconstructed tool_use_id; got: %s", got)
+	}
+	// The notice text must round-trip into the tool_result's content.
+	if !strings.Contains(got, "Task was created and approved") {
+		t.Errorf("notice text missing from rewritten body: %s", got)
+	}
+	if !json.Valid(out.Body) {
+		t.Errorf("rewritten body not valid JSON: %s", got)
+	}
+}
+
+// TestStripSyntheticApprovalHistory_WrapsTextBlockUserTurnAsToolResult
+// covers the persistent-augment path: on turn N+1 (and later) the
+// client echoes back the original "approve" verb, the augmenter
+// splices the notice into the user text block, and the strip then
+// reconstructs the older assistant turn. The user content is an
+// ARRAY of text blocks (notice + sibling system reminders), not a
+// plain string — the wrap must move the notice into the tool_result
+// while keeping unrelated text blocks alongside.
+func TestStripSyntheticApprovalHistory_WrapsTextBlockUserTurnAsToolResult(t *testing.T) {
+	const approvalID = "cv-textwrapblks02"
+	const originalToolUseID = "toolu_01TextBlocksOrig"
+	notice := `<clawvisor-notice kind="task-approved">Task was created. Task ID: task-y.</clawvisor-notice>`
+	body, err := json.Marshal(map[string]any{
+		"model": "claude-haiku-4-5",
+		"messages": []map[string]any{
+			{"role": "user", "content": "do the thing"},
+			{"role": "assistant", "content": []map[string]any{
+				{"type": "text", "text": "Clawvisor wants to create a task to cover this work:\n\n[clawvisor:approval=" + approvalID + "]"},
+			}},
+			{"role": "user", "content": []map[string]any{
+				{"type": "text", "text": notice},
+				{"type": "text", "text": "<system-reminder>preserve me</system-reminder>"},
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	lookup := func(id string) *historystrip.ReconstructedPair {
+		if id != approvalID {
+			return nil
+		}
+		return &historystrip.ReconstructedPair{
+			ToolUseID:  originalToolUseID,
+			ToolName:   "exec",
+			Input:      json.RawMessage(`{"command":"curl ..."}`),
+			ResultText: notice,
+		}
+	}
+	out, err := StripSyntheticApprovalHistory(SyntheticApprovalHistoryStripRequest{
+		Provider:             conversation.ProviderAnthropic,
+		Body:                 body,
+		ReconstructionLookup: lookup,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !out.Modified {
+		t.Fatalf("strip should rewrite body for text-blocks reconstruction; got unchanged: %s", out.Body)
+	}
+	got := string(out.Body)
+	if !strings.Contains(got, `"type":"tool_result"`) {
+		t.Errorf("expected tool_result wrap; got: %s", got)
+	}
+	if !strings.Contains(got, `"tool_use_id":"`+originalToolUseID+`"`) {
+		t.Errorf("tool_result must pair against reconstructed tool_use_id; got: %s", got)
+	}
+	// The system-reminder text block must survive alongside the
+	// tool_result — the harness relies on it for context.
+	if !strings.Contains(got, "preserve me") {
+		t.Errorf("sibling system-reminder text block must survive the wrap; got: %s", got)
+	}
+	if !json.Valid(out.Body) {
+		t.Errorf("rewritten body not valid JSON: %s", got)
+	}
+}
+
+// TestStripSyntheticApprovalHistory_NoOrphanWhenReconstructionUnavailable
+// pins the safety property: when the reconstruction lookup returns
+// nil (no lifecycle audit data, store outage, predates the audit),
+// the strip falls back to drop-the-turn. A text-shape user turn
+// must NOT get wrapped as a tool_result in that case — there's no
+// reconstructed tool_use_id to pair against, so the wrap would
+// introduce a fresh orphan and 400 the next request.
+func TestStripSyntheticApprovalHistory_NoOrphanWhenReconstructionUnavailable(t *testing.T) {
+	const approvalID = "cv-textnorec0003a"
+	notice := `<clawvisor-notice kind="task-approved">Task was created.</clawvisor-notice>`
+	body, err := json.Marshal(map[string]any{
+		"model": "claude-haiku-4-5",
+		"messages": []map[string]any{
+			{"role": "user", "content": "create the task"},
+			{"role": "assistant", "content": []map[string]any{
+				{"type": "text", "text": "Clawvisor wants to create a task to cover this work:\n\n[clawvisor:approval=" + approvalID + "]"},
+			}},
+			{"role": "user", "content": notice},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	lookup := func(id string) *historystrip.ReconstructedPair { return nil }
+	out, err := StripSyntheticApprovalHistory(SyntheticApprovalHistoryStripRequest{
+		Provider:             conversation.ProviderAnthropic,
+		Body:                 body,
+		ReconstructionLookup: lookup,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out.Body)
+	// No tool_result anywhere — wrapping without a reconstruction
+	// would orphan immediately.
+	if strings.Contains(got, `"type":"tool_result"`) {
+		t.Errorf("no reconstruction available — must not wrap as tool_result; got: %s", got)
+	}
+	// User notice must still survive as text (not stripped) since
+	// it's not a bare verb.
+	if !strings.Contains(got, "Task was created") {
+		t.Errorf("notice text must pass through unchanged: %s", got)
+	}
+}
+
 func TestStripSyntheticApprovalHistory_KeepsSiblingTextBlocksAfterStrippingOrphanToolResult(t *testing.T) {
 	// Real Claude Code shape: the harness packs the next-turn
 	// system-reminders alongside the AskUserQuestion tool_result


### PR DESCRIPTION
## Summary

Two related changes shaken loose while chasing a `messages.N: tool_use ids were found without tool_result blocks immediately after` 400 from Anthropic, and a follow-on investigation of why text-shape harnesses kept tripping over control-curl shape drift.

### 1. Text-shape inline-task notice now pairs with the reconstructed `tool_use`

For agents whose tool list lacks `AskUserQuestion` (Codex, Telegram-bot harnesses, anything driving the inline-approval flow under `substitution_shape: "text"`), the body editor lands the approval notice as plain user text. The synthetic-history strip reconstructs the prior assistant turn into a `[tool_use(original)]` block — but until now it only signalled the next-turn handler to swap an *existing* `AskUserQuestion` `tool_result`. Text-only history left the user turn unpaired, the next request shipped upstream with a `tool_use` and no matching `tool_result`, and Anthropic rejected it.

The strip now always sets `pendingReconstruction` when the assistant turn is reconstructed and dispatches on the next user turn between:

- existing AskUserQuestion path — swap the orphan `tool_result` block to point at the reconstructed `tool_use_id`,
- new text-only path — wrap the user's notice text (plain string or array of text blocks) as a `tool_result` block paired against the reconstructed `tool_use_id`, with sibling system-reminder text blocks passing through alongside.

Three tests pin: text-only current-turn wrap, augmented-history wrap with sibling reminders, and a safety property that confirms no orphan `tool_result` is fabricated when the lifecycle lookup returns nil (store outage, stripped audit fields, or a hold that predates the lifecycle audit).

### 2. Round-trip test: `sanitize(rewrite(x)) == x` for every model-realistic control curl

The per-tool rewriter (`controltool.RewriteControlToolUse`) and the inbound sanitizer (`bodytransform.SanitizeInboundHistory`) form an inverse pair: the rewriter mutates `https://clawvisor.local/control/…` URLs into the resolver address + injects `X-Clawvisor-*` headers + a minted nonce on the way to the harness, the sanitizer reverts those artifacts on the way back so the model doesn't pattern-match its own post-rewrite history forward. Each side has individual tests; the inverse property between them was implicit.

The new `bodytransform/roundtrip_test.go` pins the contract end-to-end against eight model-realistic synthetic shapes — GET reads (vault, skill, autovault script), `--data` heredoc POSTs, inline `--data` POSTs, task checkout, task expand with path id, failure POST — plus a separate case confirming model-emitted headers (`Content-Type`, `Accept`) survive the round-trip while the rewriter's injected `X-Clawvisor-*` headers do not. Defense-in-depth assertions catch `X-Clawvisor-*`, `cv-nonce-`, `localhost:25297`, or `/api/control/` leakage that byte-equality might miss, and a sanity check confirms the rewriter actually mutated the input so the round-trip isn't vacuous if either side ever becomes a no-op.

If the rewriter and sanitizer ever drift — exactly the leak shape that lets models accumulate post-rewrite exemplars and emit stale nonces on subsequent turns — this test fails loudly with the `original / sanitized / rewritten` triple inline.

## Test plan

- [x] `go test ./internal/runtime/llmproxy/...` — all green, including the three new strip tests and the round-trip suite
- [x] `go test ./internal/api/handlers/...` — handler-side flow unchanged
- [x] `go build ./...` — full repo builds clean
- [ ] Manual: confirm Telegram-bot inline-task approval no longer trips the `tool_use` orphan 400 on the held-task continuation turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)