### PR TITLE
fix(dev): honor pre-set PUBLIC_URL / SERVER_HOST in dev.sh

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -102,9 +102,14 @@ echo ""
 # serves the live frontend; the backend's embedded SPA is just
 # web/dist/placeholder.html in a dev checkout). Vite proxies /api/* back to
 # the backend's actual listen port.
-PORT="$BACKEND_PORT" SERVER_HOST="127.0.0.1" \
-    PUBLIC_URL="http://localhost:$FRONTEND_PORT" \
-    air -c .air.toml &
+#
+# Honor a pre-set PUBLIC_URL in the calling shell (e.g. when developing
+# from a Docker host and you need `host.docker.internal:25297` so a
+# container-side OpenClaw can reach back). Same goes for SERVER_HOST.
+: "${PUBLIC_URL:=http://localhost:$FRONTEND_PORT}"
+: "${SERVER_HOST:=127.0.0.1}"
+export PUBLIC_URL SERVER_HOST
+PORT="$BACKEND_PORT" air -c .air.toml &
 BACKEND_PID=$!
 
 BACKEND_PORT="$BACKEND_PORT" npm --prefix "$REPO_ROOT/web" run dev -- --port "$FRONTEND_PORT" --strictPort &


### PR DESCRIPTION
## Summary

`scripts/dev.sh` hardcoded `PUBLIC_URL=http://localhost:$FRONTEND_PORT` to pin the daemon's advertised origin at the Vite port (so OAuth redirects and printed magic links land at the URL that actually serves the live frontend in a dev checkout). That's the right default, but it silently overrode anything the developer set in their shell — even deliberate overrides for specific scenarios.

Concrete trigger: developing from a Docker host where a containerized OpenClaw needs to reach back into the dev daemon at `host.docker.internal:25297` for control-plane traffic. Setting `PUBLIC_URL=http://host.docker.internal:25297` in the shell *looked* like it should propagate — both \`~/.clawvisor/config.yaml\` and the env var feed \`Server.PublicURL\` — but dev.sh stomped on it and the daemon kept advertising \`localhost:25297\`. That value then flows into \`baseURL\` and \`ControlBaseURL\`, so control-tool rewrites came out pointing at \`localhost\`.

The fix switches to \`: "\${VAR:=default}"\` so the override only kicks in when the variable isn't already set or is empty. Same treatment for \`SERVER_HOST\`.

## Test plan

- [x] \`bash -n scripts/dev.sh\` — syntax-checks clean.
- [ ] Manual: \`./scripts/dev.sh\` with no env override prints \`localhost:$FRONTEND_PORT\` in the daemon's startup banner / \`/api/config/public\` (existing behavior preserved).
- [ ] Manual: \`PUBLIC_URL=http://host.docker.internal:25297 ./scripts/dev.sh\` advertises that URL instead, and control-tool rewrites use \`host.docker.internal\` rather than \`localhost\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/555?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

