### PR TITLE
fix(llmproxy): treat deterministic parser refusals as agent-recoverable

### DIFF
--- a/internal/runtime/eval/eval.go
+++ b/internal/runtime/eval/eval.go
@@ -61,14 +61,15 @@ type EvaluationFact interface {
 // so this package stays a leaf — translation happens at the policy /
 // inspector boundary.
 type InspectorFact struct {
-	Source       string
-	Host         string
-	Method       string
-	Path         string
-	Placeholders []string
-	IsAPICall    bool
-	Ambiguous    bool
-	Reason       string
+	Source           string
+	Host             string
+	Method           string
+	Path             string
+	Placeholders     []string
+	IsAPICall        bool
+	Ambiguous        bool
+	AgentRecoverable bool
+	Reason           string
 }
 
 func (InspectorFact) isEvaluationFact() {}

--- a/internal/runtime/eval/eval.go
+++ b/internal/runtime/eval/eval.go
@@ -194,6 +194,7 @@ type InspectorVerdictSnapshot struct {
 	Reason              string
 	IsAPICall           bool
 	Ambiguous           bool
+	AgentRecoverable    bool
 	Placeholders        []string
 	CredentialLocations []CredentialLocation
 }

--- a/internal/runtime/llmproxy/inspector/inspector.go
+++ b/internal/runtime/llmproxy/inspector/inspector.go
@@ -48,6 +48,16 @@ type Verdict struct {
 	// Triggers fail-closed at the rewriter.
 	Ambiguous bool
 
+	// AgentRecoverable narrows Ambiguous=true verdicts to the subset
+	// where the refusal reason describes a deterministic, agent-fixable
+	// problem with the tool_use shape (e.g. `$(...)` inside a curl
+	// pipeline, multiple credentialed calls in one statement). The
+	// policy layer surfaces these as RecoverableDenyVerdict so the
+	// model can self-correct via the proxy's one-shot continuation
+	// retry, instead of falling through to OutcomeHold and waiting on
+	// human approval.
+	AgentRecoverable bool
+
 	// Method is the inferred HTTP verb (uppercased: GET, POST, ...).
 	Method string
 

--- a/internal/runtime/llmproxy/inspector/parser.go
+++ b/internal/runtime/llmproxy/inspector/parser.go
@@ -328,7 +328,13 @@ func parseBashCurl(t ToolUse) (Verdict, bool) {
 	// substitution, backticks, process substitution) is present.
 	seg, segErr := extractCredentialedCurlSegment(cmd)
 	if segErr != "" {
-		return Verdict{IsAPICall: false, Ambiguous: true, Reason: segErr}, true
+		// segErr strings are deterministic refusal reasons (multi-statement,
+		// $(...) / <(...) / backgrounded / multiple credentialed / parse
+		// error) that the agent can fix by re-emitting a simpler tool_use.
+		// Mark AgentRecoverable so InspectorChain routes through
+		// RecoverableDenyVerdict's one-shot continuation retry instead of
+		// the generic Ambiguous→Hold human-approval fallthrough.
+		return Verdict{IsAPICall: false, Ambiguous: true, AgentRecoverable: true, Reason: segErr}, true
 	}
 	if seg.text == "" {
 		// No credentialed sub-command found. Could be a non-curl call

--- a/internal/runtime/llmproxy/inspector_snapshot.go
+++ b/internal/runtime/llmproxy/inspector_snapshot.go
@@ -12,14 +12,15 @@ import (
 // imported.
 func InspectorSnapshot(v inspector.Verdict) eval.InspectorVerdictSnapshot {
 	snap := eval.InspectorVerdictSnapshot{
-		Source:       string(v.Source),
-		Host:         v.Host,
-		Method:       v.Method,
-		Path:         v.Path,
-		Reason:       v.Reason,
-		IsAPICall:    v.IsAPICall,
-		Ambiguous:    v.Ambiguous,
-		Placeholders: append([]string(nil), v.Placeholders...),
+		Source:           string(v.Source),
+		Host:             v.Host,
+		Method:           v.Method,
+		Path:             v.Path,
+		Reason:           v.Reason,
+		IsAPICall:        v.IsAPICall,
+		Ambiguous:        v.Ambiguous,
+		AgentRecoverable: v.AgentRecoverable,
+		Placeholders:     append([]string(nil), v.Placeholders...),
 	}
 	if len(v.CredentialLocations) > 0 {
 		snap.CredentialLocations = make([]eval.CredentialLocation, len(v.CredentialLocations))
@@ -40,14 +41,15 @@ func InspectorSnapshot(v inspector.Verdict) eval.InspectorVerdictSnapshot {
 // carries a typed Verdict).
 func InspectorVerdictFromSnapshot(snap eval.InspectorVerdictSnapshot) inspector.Verdict {
 	v := inspector.Verdict{
-		Source:       inspector.VerdictSource(snap.Source),
-		Host:         snap.Host,
-		Method:       snap.Method,
-		Path:         snap.Path,
-		Reason:       snap.Reason,
-		IsAPICall:    snap.IsAPICall,
-		Ambiguous:    snap.Ambiguous,
-		Placeholders: append([]string(nil), snap.Placeholders...),
+		Source:           inspector.VerdictSource(snap.Source),
+		Host:             snap.Host,
+		Method:           snap.Method,
+		Path:             snap.Path,
+		Reason:           snap.Reason,
+		IsAPICall:        snap.IsAPICall,
+		Ambiguous:        snap.Ambiguous,
+		AgentRecoverable: snap.AgentRecoverable,
+		Placeholders:     append([]string(nil), snap.Placeholders...),
 	}
 	if len(snap.CredentialLocations) > 0 {
 		v.CredentialLocations = make([]inspector.CredentialLocation, len(snap.CredentialLocations))

--- a/internal/runtime/llmproxy/policies/inspector_chain.go
+++ b/internal/runtime/llmproxy/policies/inspector_chain.go
@@ -124,8 +124,20 @@ func (c *InspectorChain) Evaluate(ctx context.Context, _ pipeline.ReadOnlyRespon
 		}, nil
 	}
 
-	// Ambiguous: fail closed with per-tool HoldKey.
+	// Ambiguous: fail closed. Two sub-cases:
+	//  - AgentRecoverable=true → deterministic parser refusal whose
+	//    reason names the unsafe construct (e.g. `$(...)` in a curl
+	//    pipeline). Wire through RecoverableDenyVerdict so the proxy's
+	//    one-shot continuation retry feeds the reason back as a
+	//    synthetic tool_result and the agent can re-emit a simpler shape
+	//    inside the same inbound request — no human approval needed.
+	//  - Otherwise → genuine inspector uncertainty (validator couldn't
+	//    classify, opaque shape). Fall through to OutcomeHold so a human
+	//    decides.
 	if v.Ambiguous {
+		if v.AgentRecoverable {
+			return conversation.RecoverableDenyVerdict(v.Reason, inspectorFact), nil
+		}
 		return pipeline.ToolUseVerdict{
 			Outcome:      pipeline.OutcomeHold,
 			Reason:       v.Reason,
@@ -185,14 +197,15 @@ func (c *InspectorChain) Evaluate(ctx context.Context, _ pipeline.ReadOnlyRespon
 // the same fact shape regardless of which path runs.
 func newInspectorFact(v inspector.Verdict) pipeline.InspectorFact {
 	return pipeline.InspectorFact{
-		Source:       string(v.Source),
-		Host:         v.Host,
-		Method:       v.Method,
-		Path:         v.Path,
-		Placeholders: append([]string(nil), v.Placeholders...),
-		IsAPICall:    v.IsAPICall,
-		Ambiguous:    v.Ambiguous,
-		Reason:       v.Reason,
+		Source:           string(v.Source),
+		Host:             v.Host,
+		Method:           v.Method,
+		Path:             v.Path,
+		Placeholders:     append([]string(nil), v.Placeholders...),
+		IsAPICall:        v.IsAPICall,
+		Ambiguous:        v.Ambiguous,
+		AgentRecoverable: v.AgentRecoverable,
+		Reason:           v.Reason,
 	}
 }
 

--- a/internal/runtime/llmproxy/policies/inspector_chain_test.go
+++ b/internal/runtime/llmproxy/policies/inspector_chain_test.go
@@ -215,6 +215,47 @@ func TestInspectorChain_AmbiguousHolds(t *testing.T) {
 	}
 }
 
+// TestInspectorChain_AmbiguousAgentRecoverableContinues pins the
+// narrow recoverable-refusal path: when the parser deterministically
+// refuses a credentialed bash command for a shape reason the agent can
+// fix (e.g. `$(...)` inside a curl pipeline lets a neighbor exfiltrate
+// the credential output), the chain MUST route through
+// RecoverableDenyVerdict so the proxy's one-shot continuation retry
+// feeds the reason back as a synthetic tool_result. Without this, the
+// refusal would fall into OutcomeHold and burn a user turn on every
+// trivially-fixable shape error.
+func TestInspectorChain_AmbiguousAgentRecoverableContinues(t *testing.T) {
+	insp := inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{})
+	chain := policies.NewInspectorChain(insp, nil)
+
+	// `echo $(curl …)` — parser refuses because the surrounding `echo`
+	// captures the curl output the credential authorized.
+	tu := conversation.ToolUse{
+		ID:   "toolu_recoverable",
+		Name: "Bash",
+		Input: json.RawMessage(`{"cmd":"echo $(curl -sS -H 'Authorization: Bearer autovault_github_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx' https://api.github.com/user)"}`),
+	}
+	v, err := chain.Evaluate(context.Background(), nil, tu, evalToolUseMutator{})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if v.Outcome != pipeline.OutcomeDeny {
+		t.Fatalf("agent-recoverable refusal → Outcome = %q, want Deny (facts: %+v)", v.Outcome, v.Facts)
+	}
+	if v.Continue == nil || len(v.Continue.SyntheticToolResults) != 1 {
+		t.Fatalf("Continue.SyntheticToolResults missing — agent-recoverable refusal must wire the one-shot continuation retry")
+	}
+	if content, ok := v.ContinuationToolResultContent(); !ok || !strings.Contains(content, "command substitution") {
+		t.Errorf("ContinuationToolResultContent = %q, %v; want the parser's refusal reason verbatim", content, ok)
+	}
+	if v.SubstituteWith == "" || v.SubstituteWith != v.Reason {
+		t.Errorf("SubstituteWith = %q, want = Reason for the terminal-fallback path", v.SubstituteWith)
+	}
+	if v.HoldKey != "" {
+		t.Errorf("HoldKey = %q, want empty — recoverable path must not request human approval", v.HoldKey)
+	}
+}
+
 // TestInspectorChain_NilInspectorSkips pins the no-config gate.
 func TestInspectorChain_NilInspectorSkips(t *testing.T) {
 	chain := policies.NewInspectorChain(nil, nil)

--- a/internal/runtime/llmproxy/policies/inspector_evaluator.go
+++ b/internal/runtime/llmproxy/policies/inspector_evaluator.go
@@ -52,11 +52,17 @@ func (e *InspectorEvaluator) Evaluate(ctx context.Context, _ pipeline.ReadOnlyRe
 	})
 	fact := newInspectorFact(v)
 
-	// Ambiguous verdict → Hold per-tool. The legacy code fails closed
-	// here; the policy preserves that. HoldKey is per-tool (no
-	// coalescing across siblings) because ambiguous-different-reasons
-	// shouldn't merge into one approval prompt.
+	// Ambiguous verdict → fail closed. Mirrors InspectorChain's split:
+	// AgentRecoverable=true (deterministic parser refusal naming a
+	// fixable shape, e.g. `$(...)` in a curl pipeline) → route through
+	// RecoverableDenyVerdict so the proxy's one-shot continuation retry
+	// feeds the reason back as a synthetic tool_result. Otherwise →
+	// OutcomeHold (per-tool key so ambiguous-different-reasons don't
+	// coalesce into one approval prompt).
 	if v.Ambiguous {
+		if v.AgentRecoverable {
+			return conversation.RecoverableDenyVerdict(v.Reason, fact), nil
+		}
 		return pipeline.ToolUseVerdict{
 			Outcome:      pipeline.OutcomeHold,
 			Reason:       v.Reason,

--- a/internal/runtime/llmproxy/policies/inspector_evaluator_test.go
+++ b/internal/runtime/llmproxy/policies/inspector_evaluator_test.go
@@ -3,6 +3,7 @@ package policies_test
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
@@ -105,6 +106,42 @@ func TestInspectorEvaluator_AmbiguousHolds(t *testing.T) {
 	// HoldKey is per-tool so ambiguous siblings don't coalesce.
 	if v.HoldKey != "ambiguous_toolu_amb" {
 		t.Errorf("HoldKey = %q, want per-tool ambiguous_toolu_amb", v.HoldKey)
+	}
+}
+
+// TestInspectorEvaluator_AmbiguousAgentRecoverableContinues mirrors the
+// InspectorChain symmetric test: a deterministic parser refusal whose
+// reason names a fixable shape (here `$(...)` inside a curl pipeline)
+// must route through RecoverableDenyVerdict so the proxy's one-shot
+// continuation retry can feed the reason back as a synthetic
+// tool_result. Both inspector entry points must agree, otherwise a
+// future caller that wires the evaluator instead of the chain will
+// silently regress to human-approval on every trivially-fixable shape
+// error.
+func TestInspectorEvaluator_AmbiguousAgentRecoverableContinues(t *testing.T) {
+	insp := inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{})
+	e := policies.NewInspectorEvaluator(insp)
+
+	tu := conversation.ToolUse{
+		ID:   "toolu_evaluator_recoverable",
+		Name: "Bash",
+		Input: json.RawMessage(`{"cmd":"echo $(curl -sS -H 'Authorization: Bearer autovault_github_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx' https://api.github.com/user)"}`),
+	}
+	v, err := e.Evaluate(context.Background(), nil, tu, evalToolUseMutator{})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if v.Outcome != pipeline.OutcomeDeny {
+		t.Fatalf("agent-recoverable refusal → Outcome = %q, want Deny (facts: %+v)", v.Outcome, v.Facts)
+	}
+	if v.Continue == nil || len(v.Continue.SyntheticToolResults) != 1 {
+		t.Fatalf("Continue.SyntheticToolResults missing — InspectorEvaluator must wire the one-shot continuation retry on agent-recoverable refusals (parity with InspectorChain)")
+	}
+	if content, ok := v.ContinuationToolResultContent(); !ok || !strings.Contains(content, "command substitution") {
+		t.Errorf("ContinuationToolResultContent = %q, %v; want the parser's refusal reason verbatim", content, ok)
+	}
+	if v.HoldKey != "" {
+		t.Errorf("HoldKey = %q, want empty — recoverable path must not request human approval", v.HoldKey)
 	}
 }
 


### PR DESCRIPTION
## Summary

- The inspector's bash-curl parser refuses unsafe constructs (`$(...)`, `<(...)`, multi-statement, backgrounded, multiple credentialed calls in one statement) with a deterministic, agent-fixable reason string — but it returned `Ambiguous: true` indistinguishably from genuine validator uncertainty. Both `InspectorChain` and `InspectorEvaluator` collapsed every ambiguous verdict to `OutcomeHold`, so a fixable shape error burned a user turn waiting on human approval instead of using the recoverable-deny continuation path that boundary deny / stub placeholder already ride.
- Narrows the Ambiguous→Hold branch: a new `AgentRecoverable` bit on `inspector.Verdict` marks the parser-side refusals; the policy layer routes those through `conversation.RecoverableDenyVerdict` so the proxy's one-shot continuation feeds the reason back as a synthetic `tool_result` and the agent self-corrects inside the same inbound request. Threaded through `InspectorVerdictSnapshot` + `InspectorSnapshot`/`InspectorVerdictFromSnapshot` so the bit survives audit persistence and rehydration. Applied symmetrically to the sibling `InspectorEvaluator` (no production caller today, but pinning both inspector entry points keeps a future caller from silently regressing).

## Test plan

- [x] `go test ./internal/runtime/...` — all packages green.
- [x] New test `TestInspectorChain_AmbiguousAgentRecoverableContinues` pins `echo \$(curl …)` → `OutcomeDeny` + populated `Continue.SyntheticToolResults` + empty `HoldKey`.
- [x] Symmetric test `TestInspectorEvaluator_AmbiguousAgentRecoverableContinues` mirrors the chain assertion on the evaluator path.
- [x] Pre-existing `TestInspectorChain_AmbiguousHolds` / `TestInspectorEvaluator_AmbiguousHolds` still pass (they exercise the validator-driven Ambiguous path, which does **not** set `AgentRecoverable` — so the human-approval fallthrough is preserved for genuine uncertainty).
- [x] `cubic review --base origin/main` clean after addressing the two real issues it caught (parity gap on `InspectorEvaluator`, snapshot round-trip dropping the bit).
- [ ] Verify in a live session: re-run the openclaw transcript's `curl … | jq …` style call and confirm the agent now self-corrects without a "Can you try again?" user turn.

## Out of scope

- The other `Ambiguous: true` returns inside `parseBashCurl` (`-X without value`, `-H without value`, `unknown curl flag`, `placeholder not in -H header`, tokenizer rejection) are structurally identical — deterministic, agent-fixable — and would extend trivially by flipping `AgentRecoverable: true` at each site. Held back to keep this PR scoped to the `extractCredentialedCurlSegment` refusal family the user-facing incident hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

