### PR TITLE
fix(tasks): validate vault item handles at submission time

### DIFF
--- a/internal/api/handlers/tasks.go
+++ b/internal/api/handlers/tasks.go
@@ -300,6 +300,23 @@ func (h *TasksHandler) Create(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Fail fast on credential handles that aren't in the vault. Without
+	// this, the task lands in pending_approval and the user is asked to
+	// approve something that can't possibly authorize — and the
+	// validation error never reaches the agent (it fires at release
+	// time, after the agent's POST already got back "pending_approval").
+	// validateTaskRequiredCredentials only reads UserID + AgentID off
+	// the task, so a stub is sufficient pre-persistence. Matches the
+	// proxy-intercept submission path in CreatePendingInlineTask, which
+	// has done this check since inline tasks shipped.
+	if hasCredentialRequests {
+		stubTask := &store.Task{UserID: agent.UserID, AgentID: agent.ID}
+		if err := h.validateTaskRequiredCredentials(ctx, stubTask, req.RequiredCredentials); err != nil {
+			writeError(w, http.StatusBadRequest, "INVALID_CREDENTIAL_REQUEST", err.Error())
+			return
+		}
+	}
+
 	// Validate each authorized action.
 	for i, a := range req.AuthorizedActions {
 		// Validate that each action entry has the required service and action fields.

--- a/internal/api/handlers/tasks_inline_test.go
+++ b/internal/api/handlers/tasks_inline_test.go
@@ -118,6 +118,113 @@ func TestCreateInlineApprovedTaskWithAssessment_NilPrecomputedFallsThrough(t *te
 	}
 }
 
+// TestCreateTaskFailsFastOnMissingVaultItem pins the submission-time
+// vault-existence check on the direct POST /api/control/tasks handler.
+// Before the check, the handler accepted the task as pending_approval
+// without ever verifying the requested vault item existed — so the
+// agent's POST got back a success-shaped response and the validation
+// error only surfaced (silently) on the user's approval surface. A
+// brand-new user observed this as their agent re-submitting the same
+// bad handle 5× in a row because the agent received no actionable
+// signal on the wire. The handler must now reject with 400
+// INVALID_CREDENTIAL_REQUEST carrying the directive + candidates so the
+// agent self-corrects on its next turn — and the user is never asked
+// to approve a task that couldn't have authorized.
+func TestCreateTaskFailsFastOnMissingVaultItem(t *testing.T) {
+	h, _, _, agent := newInlineTasksHandlerForTest(t)
+	ctx := context.Background()
+
+	// Vault has the account-aliased handle "github:work" — agent asks
+	// for the bare service id "github". The candidate helper's prefix
+	// rule (existing id begins with requested id + ":" or ".") should
+	// surface "github:work" as the "did you mean" suggestion inlined
+	// into the error message.
+	v := &stubVault{}
+	if err := v.Set(ctx, agent.UserID, "github:work", []byte("real-token")); err != nil {
+		t.Fatalf("vault.Set: %v", err)
+	}
+	h.vault = v
+
+	body := []byte(`{
+		"purpose":"Open a GitHub issue summarizing the run",
+		"intent_verification_mode":"strict",
+		"expires_in_seconds":600,
+		"expected_tools":[{"tool_name":"Bash","why":"Call the GitHub API"}],
+		"required_credentials":[{"vault_item_id":"github","why":"Open issues on the user's behalf"}]
+	}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/control/tasks?surface=inline", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(store.WithAgent(req.Context(), agent))
+
+	rec := httptest.NewRecorder()
+	h.Create(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("Create status = %d, want 400; body = %s", rec.Code, rec.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v; body = %s", err, rec.Body.String())
+	}
+	if got := resp["code"]; got != "INVALID_CREDENTIAL_REQUEST" {
+		t.Errorf("code = %v, want INVALID_CREDENTIAL_REQUEST (body = %s)", got, rec.Body.String())
+	}
+	errMsg, _ := resp["error"].(string)
+	if !strings.Contains(errMsg, `"github"`) {
+		t.Errorf("error message should name the bad handle so the agent can correlate; got %q", errMsg)
+	}
+	if !strings.Contains(errMsg, `"github:work"`) {
+		t.Errorf("error message should inline the matching candidate (vaultItemNotAvailableError's did-you-mean branch); got %q", errMsg)
+	}
+	if strings.Contains(strings.ToLower(errMsg), "pending_approval") {
+		t.Errorf("error must not surface pending_approval — failure is at submission, not after approval; got %q", errMsg)
+	}
+}
+
+// TestCreateTaskFailsFastWithGenericHintWhenNoCandidate covers the
+// other branch of vaultItemNotAvailableError: when no prefix-matching
+// candidate is in the vault, the directive falls back to "list GET
+// /control/vault/items …". The fail-fast contract holds either way —
+// the handler still returns 400 INVALID_CREDENTIAL_REQUEST, not
+// pending_approval.
+func TestCreateTaskFailsFastWithGenericHintWhenNoCandidate(t *testing.T) {
+	h, _, _, agent := newInlineTasksHandlerForTest(t)
+	ctx := context.Background()
+
+	// Empty vault — no candidates to inline.
+	h.vault = &stubVault{}
+	_ = ctx
+
+	body := []byte(`{
+		"purpose":"Read recent Gmail messages",
+		"intent_verification_mode":"strict",
+		"expires_in_seconds":600,
+		"expected_tools":[{"tool_name":"Bash","why":"Call the Gmail API"}],
+		"required_credentials":[{"vault_item_id":"gmail","why":"Authenticate"}]
+	}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/control/tasks?surface=inline", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(store.WithAgent(req.Context(), agent))
+
+	rec := httptest.NewRecorder()
+	h.Create(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("Create status = %d, want 400; body = %s", rec.Code, rec.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v; body = %s", err, rec.Body.String())
+	}
+	if got := resp["code"]; got != "INVALID_CREDENTIAL_REQUEST" {
+		t.Errorf("code = %v, want INVALID_CREDENTIAL_REQUEST", got)
+	}
+	errMsg, _ := resp["error"].(string)
+	if !strings.Contains(errMsg, "/control/vault/items") {
+		t.Errorf("no-candidate branch must include the GET /control/vault/items directive so the agent has a recovery path; got %q", errMsg)
+	}
+}
+
 func TestCreateInlineApprovedTaskHappyPath(t *testing.T) {
 	h, st, _, agent := newInlineTasksHandlerForTest(t)
 	ctx := context.Background()

--- a/internal/api/task_v2_test.go
+++ b/internal/api/task_v2_test.go
@@ -163,7 +163,13 @@ func TestTaskCreateV2AcceptsVirtualLLMCredentialItem(t *testing.T) {
 	}
 }
 
-func TestTaskApprovalRejectsOtherAgentVirtualLLMCredentialItem(t *testing.T) {
+// TestTaskCreateRejectsOtherAgentVirtualLLMCredentialItem pins that
+// submission-time vault validation rejects a cross-agent LLM credential
+// handle. Before #558 this rejection landed at approval-time and the
+// task spent the intervening window queued as pending_approval; now the
+// agent gets the directive on its own POST response so it can self-
+// correct without burning a user approval gesture.
+func TestTaskCreateRejectsOtherAgentVirtualLLMCredentialItem(t *testing.T) {
 	env := newTestEnv(t)
 	sc := newScenario(t, env, "task-v2-llm-credential-cross-agent")
 
@@ -189,10 +195,6 @@ func TestTaskApprovalRejectsOtherAgentVirtualLLMCredentialItem(t *testing.T) {
 			"why":           "Use this agent-scoped Anthropic key only for the approved request.",
 		}},
 	})
-	body := mustStatus(t, resp, http.StatusCreated)
-	taskID := str(t, body, "task_id")
-
-	resp = sc.session.do("POST", fmt.Sprintf("/api/tasks/%s/approve", taskID), nil)
 	rejected := mustStatus(t, resp, http.StatusBadRequest)
 	if rejected["code"] != "INVALID_CREDENTIAL_REQUEST" {
 		t.Fatalf("expected INVALID_CREDENTIAL_REQUEST, got %v", rejected["code"])
@@ -202,7 +204,12 @@ func TestTaskApprovalRejectsOtherAgentVirtualLLMCredentialItem(t *testing.T) {
 	}
 }
 
-func TestTaskApprovalRejectsOtherAgentRawLLMStorageKey(t *testing.T) {
+// TestTaskCreateRejectsOtherAgentRawLLMStorageKey pins that the raw
+// internal storage key shape is rejected at submission time. The
+// directive ("use a vault item id, not a storage key") flows back on
+// the agent's POST response — same rejection-at-submission rationale as
+// the cross-agent-virtual case above.
+func TestTaskCreateRejectsOtherAgentRawLLMStorageKey(t *testing.T) {
 	env := newTestEnv(t)
 	sc := newScenario(t, env, "task-v2-llm-credential-cross-agent-storage-key")
 
@@ -226,10 +233,6 @@ func TestTaskApprovalRejectsOtherAgentRawLLMStorageKey(t *testing.T) {
 			"why":           "Use this agent-scoped Anthropic key only for the approved request.",
 		}},
 	})
-	body := mustStatus(t, resp, http.StatusCreated)
-	taskID := str(t, body, "task_id")
-
-	resp = sc.session.do("POST", fmt.Sprintf("/api/tasks/%s/approve", taskID), nil)
 	rejected := mustStatus(t, resp, http.StatusBadRequest)
 	if rejected["code"] != "INVALID_CREDENTIAL_REQUEST" {
 		t.Fatalf("expected INVALID_CREDENTIAL_REQUEST, got %v", rejected["code"])
@@ -275,7 +278,11 @@ func TestTaskCreateV2SharedCredentialItemKeepsServiceScope(t *testing.T) {
 	}
 }
 
-func TestTaskApprovalRejectsSharedCredentialBackingKey(t *testing.T) {
+// TestTaskCreateRejectsSharedCredentialBackingKey pins that asking for
+// a hidden shared backing key (rather than the service-specific item
+// id) is rejected at submission time. Same rejection-at-submission
+// rationale as the cross-agent cases above.
+func TestTaskCreateRejectsSharedCredentialBackingKey(t *testing.T) {
 	env := newTestEnv(t,
 		newSharedVaultMockAdapter("mock.mail", "mock.shared", "read"),
 		newSharedVaultMockAdapter("mock.calendar", "mock.shared", "read"),
@@ -302,10 +309,6 @@ func TestTaskApprovalRejectsSharedCredentialBackingKey(t *testing.T) {
 			"why":           "Use the mail credential only for mail.",
 		}},
 	})
-	body := mustStatus(t, resp, http.StatusCreated)
-	taskID := str(t, body, "task_id")
-
-	resp = sc.session.do("POST", fmt.Sprintf("/api/tasks/%s/approve", taskID), nil)
 	rejected := mustStatus(t, resp, http.StatusBadRequest)
 	if rejected["code"] != "INVALID_CREDENTIAL_REQUEST" {
 		t.Fatalf("expected INVALID_CREDENTIAL_REQUEST, got %v", rejected["code"])


### PR DESCRIPTION
## Summary

- `POST /api/control/tasks` (LLM-proxy route) accepted any `required_credentials` shape and returned `status="pending_approval"` without verifying the requested vault items existed. The validation only fired at approval/release time, by which point the agent's POST had already gotten back a success-shaped response — so the directive error never reached the agent on the wire, only the human approval surface. A brand-new user's agent re-submitted the same bad handle five times in a row before they could untangle it.
- Move the existence check forward: validate `required_credentials` at submission time and return 400 `INVALID_CREDENTIAL_REQUEST` with `vaultItemNotAvailableError`'s directive (plus inline candidates from `candidateVaultItemIDs`) so the agent self-corrects on its next turn — and the user is never asked to approve a task that couldn't have authorized.
- Mirrors what the proxy-intercept submission path (`CreatePendingInlineTask`, `tasks_inline.go:458`) has done since inline tasks shipped. The direct HTTP handler in `tasks.go` was the missing half of the symmetry.

## Legacy compatibility

The new check is gated on `len(req.RequiredCredentials) > 0`. The legacy route (`POST /api/tasks`, MCP `create_task`) cannot trigger it — the MCP `create_task` schema (`internal/mcp/tools.go:33-110`) deliberately does not list `required_credentials` as a parameter, so callers physically can't populate it. The e2e harness, gateway, and scenario rigs grep clean for the field. The dashboard / user-token routes don't wire `Create` at all (`server.go:967-972` is List/Approve/Deny/Revoke/Scope, no Create).

The two routes that share `tasksHandler.Create`:
- `POST /api/tasks` (`requireAgent`, line 959) — MCP-style, no `required_credentials` in payload → new check is dead code.
- `POST /api/control/tasks` (`requireAgentLLMCaller`, line 1394) — LLM-proxy callers → exactly the case the fix targets.

## Test plan

- [x] `go test ./internal/api/handlers/... ./internal/runtime/...` — all packages green; no test relied on the "queue bad handle as pending_approval, fail at approval" path.
- [x] New `TestCreateTaskFailsFastOnMissingVaultItem` — vault has `github:work`, agent asks for `github` → expects 400 `INVALID_CREDENTIAL_REQUEST` whose body names the bad handle, inlines the `github:work` candidate (did-you-mean branch), and does NOT mention `pending_approval`.
- [x] New `TestCreateTaskFailsFastWithGenericHintWhenNoCandidate` — empty vault, agent asks for `gmail` → expects 400 with the generic `GET /control/vault/items` directive in the message (no-candidate branch).
- [x] `cubic review --base origin/main` clean.
- [ ] Verify in a live session: replay the original openclaw transcript and confirm the agent receives the fail-fast error on its own POST response (not on the user's approval surface).

## Follow-up not in this PR

The `candidateVaultItemIDs` matcher (`tasks.go:1539-1568`) uses strict prefix matching (existing id starts with requested handle + `:` or `.`). The user's actual transcript (`google.gmail:eric@gmail.com` vs whatever was in their vault) likely wouldn't hit the suggestion branch — neither handle is a prefix of the other. Broadening matching (case-insensitive prefix → substring → small-edit-distance) and/or inlining the full available list on the no-candidate branch are orthogonal message-quality improvements; both compose cleanly on top of this PR without touching the fail-fast contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

