### PR TITLE
fix(llmproxy): open trace log at 0600 to match rawlog sibling

### DIFF
--- a/internal/runtime/llmproxy/trace.go
+++ b/internal/runtime/llmproxy/trace.go
@@ -37,7 +37,7 @@ func OpenTraceLogger(path string) (*TraceLogger, error) {
 	if path == "" {
 		return nil, nil
 	}
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
 	if err != nil {
 		return nil, fmt.Errorf("lite-proxy: open trace log %q: %w", path, err)
 	}


### PR DESCRIPTION
## Summary
- `OpenRawIOLogger` opens the raw I/O log at `0o600` with an explicit comment about conversation content. `OpenTraceLogger` was opening the trace log at `0o644` even though trace events can include event metadata that callers might not want world-readable on shared hosts.
- Tighten `OpenTraceLogger` to `0o600` for consistency across the llmproxy log family.
- Flagged during triage of the 2026-06-13 Oneleet scan (Gosec G302) — only finding worth acting on in that batch; everything else was a fixture or local-trust-boundary path.

## Test plan
- [ ] `go build ./internal/runtime/llmproxy/...` clean
- [ ] No behavioral change for callers — same fd, same append semantics, only the create-mode bits differ

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

