### PR TITLE
feat(llmproxy): tell the agent when its active task expires

### DIFF
--- a/internal/api/handlers/llm_endpoint.go
+++ b/internal/api/handlers/llm_endpoint.go
@@ -714,6 +714,62 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
+	// expired_task_notice runs BEFORE control_notice so the prepended
+	// user-role notice survives any byte-stability checks the control
+	// notice does on the system prompt (the two policies edit different
+	// regions of the body, but ordering keeps the audit log readable).
+	// The loader looks up the agent's checked-out task and reports
+	// expired=true only when the task is past its ExpiresAt; standing
+	// tasks (ExpiresAt == nil) and missing checkouts skip the policy
+	// entirely. Sentinel-based idempotency in the policy keeps the
+	// notice from re-injecting on later turns once Anthropic echoes the
+	// augmented history back.
+	{
+		expiredTaskLoader := func(ctx context.Context, userID, agentID, conversationID string) (string, string, bool) {
+			if h.TaskCheckouts == nil || h.Store == nil {
+				return "", "", false
+			}
+			scopedKey := llmproxy.TaskCheckoutKey{
+				UserID:         userID,
+				AgentID:        agentID,
+				ConversationID: conversationID,
+			}
+			taskID, purpose, expired := h.loadExpiredCheckoutTask(ctx, scopedKey)
+			if taskID != "" || expired {
+				return taskID, purpose, expired
+			}
+			if conversationID == "" {
+				return "", "", false
+			}
+			legacyKey := llmproxy.TaskCheckoutKey{
+				UserID:  userID,
+				AgentID: agentID,
+			}
+			return h.loadExpiredCheckoutTask(ctx, legacyKey)
+		}
+		expiredTaskInjector := func(body []byte, p conversation.Provider, taskID, purpose string) ([]byte, bool, error) {
+			return llmproxy.PrependExpiredTaskNoticeToLastUserMessage(body, p, taskID, purpose)
+		}
+		pipeReq := &pipelineReadOnlyRequest{
+			provider:       provider,
+			httpReq:        r,
+			body:           body,
+			userID:         agent.UserID,
+			agentID:        agent.ID,
+			conversationID: conversationID,
+		}
+		result, err := runSinglePolicy(r.Context(), pipeReq, policies.NewExpiredTaskNotice(expiredTaskLoader, expiredTaskInjector))
+		if err != nil {
+			h.Logger.WarnContext(r.Context(), "lite-proxy expired-task notice pipeline failed",
+				"request_id", requestID, "agent_id", agent.ID, "err", err.Error())
+			auditParams["expired_task_notice_error"] = liteProxyAuditErrorDetail(err)
+		} else {
+			body = result.FinalBody
+			for k, v := range result.AuditParams {
+				auditParams[k] = v
+			}
+		}
+	}
 	reqSummary := liteProxyRequestDebugSummary(provider, body)
 	h.ensureDefaultToolRules(r.Context(), agent, reqSummary.AvailableTools)
 	// Fifth migrated call site through pipeline: control_notice. The
@@ -2988,6 +3044,49 @@ func (h *LLMEndpointHandler) resolveCheckedOutTaskID(ctx context.Context, key ll
 		return "", err
 	}
 	return "", nil
+}
+
+// loadExpiredCheckoutTask reads the checkout entry at key and reports
+// expired=true when the pointed-to task is non-standing (ExpiresAt
+// != nil) and past its expiry. Standing tasks (ExpiresAt == nil),
+// future-dated tasks, missing checkouts, store errors, and tasks
+// whose AgentID doesn't match the checkout owner all return
+// expired=false with empty strings. Errors are swallowed (logged at
+// debug level only) so a transient store outage doesn't surface as
+// a denial to the model — the proxy stays silent instead.
+//
+// The Status field is intentionally NOT consulted here: when the
+// in-DB expiry sweep marks a task "expired" we still want to surface
+// it (the model needs to know the lapse happened), and when the
+// sweep hasn't run yet we still want to surface it (ExpiresAt is the
+// authoritative wall-clock check). Filtering by Status would split
+// the behavior across the sweep racing the request.
+func (h *LLMEndpointHandler) loadExpiredCheckoutTask(ctx context.Context, key llmproxy.TaskCheckoutKey) (string, string, bool) {
+	if h == nil || h.TaskCheckouts == nil || h.Store == nil {
+		return "", "", false
+	}
+	checkout, ok, err := h.TaskCheckouts.Get(ctx, key)
+	if err != nil || !ok {
+		return "", "", false
+	}
+	taskID := strings.TrimSpace(checkout.TaskID)
+	if taskID == "" {
+		return "", "", false
+	}
+	task, err := h.Store.GetTask(ctx, taskID)
+	if err != nil || task == nil {
+		return "", "", false
+	}
+	if task.AgentID != key.AgentID {
+		return "", "", false
+	}
+	if task.ExpiresAt == nil {
+		return "", "", false
+	}
+	if task.ExpiresAt.After(time.Now()) {
+		return "", "", false
+	}
+	return task.ID, task.Purpose, true
 }
 
 func (h *LLMEndpointHandler) ensureDefaultToolRules(ctx context.Context, agent *store.Agent, availableTools []string) {

--- a/internal/runtime/llmproxy/expired_task_notice.go
+++ b/internal/runtime/llmproxy/expired_task_notice.go
@@ -147,7 +147,7 @@ func prependAnthropicLastUserNotice(body []byte, notice string) ([]byte, bool, e
 			continue
 		}
 		content := msg["content"]
-		text := strings.TrimSpace(extractAnthropicUserText(content))
+		text := strings.TrimSpace(extractAnthropicHumanText(content))
 		if text == "" || isClawvisorInternalUserText(text) {
 			continue
 		}

--- a/internal/runtime/llmproxy/expired_task_notice.go
+++ b/internal/runtime/llmproxy/expired_task_notice.go
@@ -1,0 +1,217 @@
+package llmproxy
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+)
+
+// ExpiredTaskNoticeSentinel is the substring callers can search for in
+// an inbound body to decide whether the proxy has already announced a
+// specific task's expiry to the model. Idempotency is keyed per
+// taskID — once a notice carrying `ExpiredTaskNoticeSentinel + taskID`
+// is in conversation history, subsequent passes skip injection for
+// that task. A later-checked-out task that also expires gets its own
+// fresh notice.
+const ExpiredTaskNoticeSentinel = "expired_task_id="
+
+// RenderExpiredTaskNotice builds the user-role <clawvisor-notice
+// kind="task-expired"> the proxy prepends to the first genuine user
+// turn after the agent's checked-out task lapses. The body embeds the
+// sentinel (`expired_task_id={taskID}`) and a sanitized purpose so the
+// model can identify the lapsed task without a control-plane lookup,
+// then routes it to the standard recovery moves (POST a new task or
+// POST /control/task/checkout).
+//
+// taskID is rendered verbatim (it's an internal UUID, not model- or
+// agent-supplied free text). purpose is sanitized — agents can write
+// arbitrary text into Task.Purpose, so it's untrusted.
+func RenderExpiredTaskNotice(taskID, purpose string) string {
+	taskID = strings.TrimSpace(taskID)
+	purpose = sanitizeExpiredTaskPurpose(purpose)
+	var b strings.Builder
+	b.WriteString("The previously active task has expired (")
+	b.WriteString(ExpiredTaskNoticeSentinel)
+	b.WriteString(taskID)
+	if purpose != "" {
+		b.WriteString(", purpose=\"")
+		b.WriteString(purpose)
+		b.WriteString("\"")
+	}
+	b.WriteString("). The next tool_use that needs task scope will be denied. To recover: (A) POST https://clawvisor.local/control/tasks?surface=inline to create a fresh task for the body of work you're continuing, or (B) POST https://clawvisor.local/control/task/checkout with the task_id of a different active task you already own. Acknowledge the expiry briefly to the user; do not retry the prior tool_use until task scope is re-established.")
+	return Render(NoticeKindTaskExpired, b.String())
+}
+
+// sanitizeExpiredTaskPurpose collapses whitespace, strips control
+// characters and the structural delimiters our notice format uses
+// (double quotes, backticks, the middle-dot the snapshot uses as its
+// bullet field separator), then length-caps the result. Render
+// XML-escapes the body, so this sanitizer is purely about layout /
+// size — the goal is keeping the surrounding notice readable when a
+// purpose is long or contains hostile characters, not preventing
+// envelope escape (Render handles that).
+func sanitizeExpiredTaskPurpose(raw string) string {
+	const maxLen = 120
+	var b strings.Builder
+	b.Grow(len(raw))
+	lastSpace := true
+	for _, r := range raw {
+		switch {
+		case r == ' ':
+			if !lastSpace {
+				b.WriteByte(' ')
+				lastSpace = true
+			}
+		case r == '\n', r == '\r', r == '\t', r == '\v', r == '\f':
+			if !lastSpace {
+				b.WriteByte(' ')
+				lastSpace = true
+			}
+		case r < 0x20, r == 0x7f:
+			continue
+		case r == '`', r == '"', r == '·':
+			continue
+		default:
+			b.WriteRune(r)
+			lastSpace = false
+		}
+	}
+	out := strings.TrimSpace(b.String())
+	if len(out) > maxLen {
+		runes := []rune(out)
+		if len(runes) > maxLen-1 {
+			out = string(runes[:maxLen-1]) + "…"
+		}
+	}
+	return out
+}
+
+// PrependExpiredTaskNoticeToLastUserMessage walks the inbound request
+// body, finds the LAST genuine user-role message, and prepends a new
+// text content block carrying the rendered task-expired notice. The
+// "genuine" filter mirrors ExtractRecentHumanTurns: bare approval verbs
+// (the user typing "yes" / "no" to drive an approval flow) and prior
+// <clawvisor-notice> turns are skipped, so we keep walking backward
+// past those. A user-role message whose flattened text is empty (e.g.
+// a tool_result-only turn) is also skipped — the notice would land on
+// top of harness output where the model is unlikely to act on it
+// before continuing the tool loop.
+//
+// Idempotency: callers MUST check for the sentinel substring
+// (ExpiredTaskNoticeSentinel + taskID) before invoking; this function
+// does NOT re-check, so it would happily inject twice if called twice
+// in a row. The sentinel check lives in the policy so the rendering
+// helper here stays pure.
+//
+// Provider gating: Anthropic only for now. OpenAI returns (body, false,
+// nil) — same as the existing inline-task augmentation, which is also
+// Anthropic-first.
+//
+// Returns (body, true, nil) when a target was found and modified;
+// (body, false, nil) when no qualifying user-role message exists (e.g.
+// the inbound body's tail is all tool_result turns or all internal
+// notices); (nil, false, err) on JSON malformation. Errors are
+// expected to be non-fatal at the call site — a malformed body is
+// already a downstream concern, not something the notice injector
+// should turn into a deny.
+func PrependExpiredTaskNoticeToLastUserMessage(body []byte, provider conversation.Provider, taskID, purpose string) ([]byte, bool, error) {
+	if provider != conversation.ProviderAnthropic {
+		return body, false, nil
+	}
+	notice := RenderExpiredTaskNotice(taskID, purpose)
+	return prependAnthropicLastUserNotice(body, notice)
+}
+
+func prependAnthropicLastUserNotice(body []byte, notice string) ([]byte, bool, error) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, false, err
+	}
+	msgsRaw, ok := raw["messages"]
+	if !ok {
+		return body, false, nil
+	}
+	var messages []json.RawMessage
+	if err := json.Unmarshal(msgsRaw, &messages); err != nil {
+		return nil, false, err
+	}
+	for i := len(messages) - 1; i >= 0; i-- {
+		var msg map[string]json.RawMessage
+		if err := json.Unmarshal(messages[i], &msg); err != nil {
+			continue
+		}
+		var role string
+		_ = json.Unmarshal(msg["role"], &role)
+		if role != "user" {
+			continue
+		}
+		content := msg["content"]
+		text := strings.TrimSpace(extractAnthropicUserText(content))
+		if text == "" || isClawvisorInternalUserText(text) {
+			continue
+		}
+		// Found the target: prepend the notice as a text content block.
+		newContent, err := prependTextBlockToAnthropicUserContent(content, notice)
+		if err != nil {
+			return nil, false, err
+		}
+		msg["content"] = newContent
+		encodedMsg, err := json.Marshal(msg)
+		if err != nil {
+			return nil, false, err
+		}
+		messages[i] = encodedMsg
+		newMessages, err := json.Marshal(messages)
+		if err != nil {
+			return nil, false, err
+		}
+		raw["messages"] = newMessages
+		out, err := json.Marshal(raw)
+		if err != nil {
+			return nil, false, err
+		}
+		return out, true, nil
+	}
+	return body, false, nil
+}
+
+// prependTextBlockToAnthropicUserContent normalizes the user-role
+// `content` field (which Anthropic accepts as either a string or a
+// block array) and prepends a fresh {"type":"text","text":notice}
+// block. A string content turns into a 2-element array:
+//   [notice_block, {"type":"text","text":<original_string>}]
+//
+// An array content gets the notice block prepended ahead of the
+// existing blocks; relative order of the existing blocks is preserved
+// so downstream consumers (Anthropic, historystrip, etc.) see the same
+// shape they already do, just with one extra leading text block.
+func prependTextBlockToAnthropicUserContent(content json.RawMessage, notice string) (json.RawMessage, error) {
+	noticeBlock, err := json.Marshal(map[string]string{"type": "text", "text": notice})
+	if err != nil {
+		return nil, err
+	}
+	if len(content) == 0 || string(content) == "null" {
+		blocks := []json.RawMessage{noticeBlock}
+		return json.Marshal(blocks)
+	}
+	// String form? Wrap original into a text block, then prepend notice.
+	var asString string
+	if err := json.Unmarshal(content, &asString); err == nil {
+		origBlock, err := json.Marshal(map[string]string{"type": "text", "text": asString})
+		if err != nil {
+			return nil, err
+		}
+		blocks := []json.RawMessage{noticeBlock, origBlock}
+		return json.Marshal(blocks)
+	}
+	// Block-array form: prepend.
+	var blocks []json.RawMessage
+	if err := json.Unmarshal(content, &blocks); err != nil {
+		return nil, err
+	}
+	out := make([]json.RawMessage, 0, len(blocks)+1)
+	out = append(out, noticeBlock)
+	out = append(out, blocks...)
+	return json.Marshal(out)
+}

--- a/internal/runtime/llmproxy/expired_task_notice_test.go
+++ b/internal/runtime/llmproxy/expired_task_notice_test.go
@@ -1,0 +1,222 @@
+package llmproxy
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+)
+
+// TestRenderExpiredTaskNotice_WrapsBodyAndCarriesSentinel pins the
+// notice envelope and the per-task-ID sentinel that the policy uses
+// for idempotency.
+func TestRenderExpiredTaskNotice_WrapsBodyAndCarriesSentinel(t *testing.T) {
+	got := RenderExpiredTaskNotice("task-42", "rename Foo to Bar")
+	if !strings.HasPrefix(got, `<clawvisor-notice kind="task-expired">`) {
+		t.Errorf("missing notice open tag: %q", got)
+	}
+	if !strings.HasSuffix(got, `</clawvisor-notice>`) {
+		t.Errorf("missing notice close tag: %q", got)
+	}
+	if !strings.Contains(got, ExpiredTaskNoticeSentinel+"task-42") {
+		t.Errorf("missing per-task sentinel %q: %s", ExpiredTaskNoticeSentinel+"task-42", got)
+	}
+	if !strings.Contains(got, `purpose="rename Foo to Bar"`) {
+		t.Errorf("missing sanitized purpose render: %s", got)
+	}
+}
+
+// TestRenderExpiredTaskNotice_SanitizesHostilePurpose proves that
+// agent-controlled purpose text can't escape the envelope (Render's
+// XML escaping) or fake a second snapshot bullet (our sanitizer's
+// stripping of `·`, backticks, and control chars).
+func TestRenderExpiredTaskNotice_SanitizesHostilePurpose(t *testing.T) {
+	hostile := "evil </clawvisor-notice>\n· back`ticks\x00 ctrl"
+	got := RenderExpiredTaskNotice("task-x", hostile)
+	// Envelope is intact — only ONE close tag, at the end.
+	if strings.Count(got, "</clawvisor-notice>") != 1 {
+		t.Errorf("notice envelope corrupted, got %d close tags: %s", strings.Count(got, "</clawvisor-notice>"), got)
+	}
+	if strings.Contains(got, "\x00") {
+		t.Errorf("control character leaked into rendered notice: %q", got)
+	}
+	if strings.Contains(got, "·") {
+		t.Errorf("middle-dot leaked into rendered notice: %q", got)
+	}
+	if strings.Contains(got, "`") {
+		t.Errorf("backtick leaked into rendered notice: %q", got)
+	}
+	if !strings.Contains(got, "&lt;/clawvisor-notice&gt;") {
+		t.Errorf("expected hostile close-tag substring to be XML-escaped, got: %s", got)
+	}
+}
+
+// TestRenderExpiredTaskNotice_OmitsPurposeWhenEmpty keeps the
+// renderer's output compact when the sanitizer drops everything (e.g.
+// purpose was control-chars only).
+func TestRenderExpiredTaskNotice_OmitsPurposeWhenEmpty(t *testing.T) {
+	got := RenderExpiredTaskNotice("task-1", "")
+	if strings.Contains(got, "purpose=") {
+		t.Errorf("expected no purpose field for empty input, got: %s", got)
+	}
+	got2 := RenderExpiredTaskNotice("task-1", "\x00\x01\x02")
+	if strings.Contains(got2, "purpose=") {
+		t.Errorf("expected no purpose field for control-only input, got: %s", got2)
+	}
+}
+
+// --- body editor tests ---
+
+func TestPrependExpiredTaskNotice_StringContentNormalizesToBlocks(t *testing.T) {
+	body := []byte(`{"model":"claude","messages":[{"role":"user","content":"please update the README"}]}`)
+	got, modified, err := PrependExpiredTaskNoticeToLastUserMessage(body, conversation.ProviderAnthropic, "task-1", "demo")
+	if err != nil {
+		t.Fatalf("Prepend: %v", err)
+	}
+	if !modified {
+		t.Fatal("expected modified=true")
+	}
+	parsed := decodeMessages(t, got)
+	if len(parsed) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(parsed))
+	}
+	blocks := decodeBlocks(t, parsed[0]["content"])
+	if len(blocks) != 2 {
+		t.Fatalf("expected 2 content blocks (notice + original text), got %d", len(blocks))
+	}
+	if !strings.Contains(string(blocks[0]), `kind=\"task-expired\"`) {
+		t.Errorf("first block missing task-expired notice: %s", string(blocks[0]))
+	}
+	if !strings.Contains(string(blocks[1]), "please update the README") {
+		t.Errorf("second block missing original text: %s", string(blocks[1]))
+	}
+}
+
+func TestPrependExpiredTaskNotice_BlockArrayPrependsToFront(t *testing.T) {
+	body := []byte(`{"model":"claude","messages":[{"role":"user","content":[{"type":"text","text":"prior block"},{"type":"text","text":"please update the README"}]}]}`)
+	got, modified, err := PrependExpiredTaskNoticeToLastUserMessage(body, conversation.ProviderAnthropic, "task-1", "demo")
+	if err != nil {
+		t.Fatalf("Prepend: %v", err)
+	}
+	if !modified {
+		t.Fatal("expected modified=true")
+	}
+	parsed := decodeMessages(t, got)
+	blocks := decodeBlocks(t, parsed[0]["content"])
+	if len(blocks) != 3 {
+		t.Fatalf("expected 3 content blocks (notice + 2 existing), got %d", len(blocks))
+	}
+	if !strings.Contains(string(blocks[0]), `kind=\"task-expired\"`) {
+		t.Errorf("first block must be the notice, got: %s", string(blocks[0]))
+	}
+	if !strings.Contains(string(blocks[1]), "prior block") {
+		t.Errorf("second block must preserve first original, got: %s", string(blocks[1]))
+	}
+	if !strings.Contains(string(blocks[2]), "please update the README") {
+		t.Errorf("third block must preserve second original, got: %s", string(blocks[2]))
+	}
+}
+
+func TestPrependExpiredTaskNotice_SkipsToolResultOnlyTail(t *testing.T) {
+	// Last user-role message has ONLY tool_result blocks — no genuine
+	// human text. The walker should keep going. Here there's no other
+	// user message, so we expect no modification.
+	body := []byte(`{"model":"claude","messages":[
+		{"role":"assistant","content":[{"type":"text","text":"working"}]},
+		{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"OK"}]}
+	]}`)
+	got, modified, err := PrependExpiredTaskNoticeToLastUserMessage(body, conversation.ProviderAnthropic, "task-1", "demo")
+	if err != nil {
+		t.Fatalf("Prepend: %v", err)
+	}
+	if modified {
+		t.Fatal("expected modified=false (no genuine human turn to anchor to)")
+	}
+	if string(got) != string(body) {
+		t.Errorf("body changed despite modified=false")
+	}
+}
+
+func TestPrependExpiredTaskNotice_SkipsBareApprovalVerbTurn(t *testing.T) {
+	// Last user-role message is the user's bare "yes" reply to an
+	// inline approval. The walker MUST recognize it as a
+	// Clawvisor-internal turn and keep looking — landing here, the
+	// notice would mis-aim itself at an approval verb.
+	body := []byte(`{"model":"claude","messages":[
+		{"role":"user","content":"please update README"},
+		{"role":"assistant","content":[{"type":"text","text":"awaiting approval"}]},
+		{"role":"user","content":"yes"}
+	]}`)
+	got, modified, err := PrependExpiredTaskNoticeToLastUserMessage(body, conversation.ProviderAnthropic, "task-1", "demo")
+	if err != nil {
+		t.Fatalf("Prepend: %v", err)
+	}
+	if !modified {
+		t.Fatal("expected modified=true (anchors to the earlier genuine human turn)")
+	}
+	parsed := decodeMessages(t, got)
+	if len(parsed) != 3 {
+		t.Fatalf("expected 3 messages preserved, got %d", len(parsed))
+	}
+	// The "yes" turn must remain unmodified.
+	var lastContent string
+	_ = json.Unmarshal(parsed[2]["content"], &lastContent)
+	if lastContent != "yes" {
+		t.Errorf("last (yes) turn must NOT carry the notice; got %q", lastContent)
+	}
+	// The earlier "please update README" turn must now carry the
+	// notice as a prepended block.
+	blocks := decodeBlocks(t, parsed[0]["content"])
+	if len(blocks) != 2 {
+		t.Fatalf("expected 2 blocks on the earlier user turn (notice + orig), got %d", len(blocks))
+	}
+	if !strings.Contains(string(blocks[0]), `kind=\"task-expired\"`) {
+		t.Errorf("notice must be on the earlier user turn, first block was: %s", string(blocks[0]))
+	}
+}
+
+func TestPrependExpiredTaskNotice_SkipsNonAnthropic(t *testing.T) {
+	body := []byte(`{"messages":[{"role":"user","content":"hi"}]}`)
+	got, modified, err := PrependExpiredTaskNoticeToLastUserMessage(body, conversation.ProviderOpenAI, "task-1", "demo")
+	if err != nil {
+		t.Fatalf("Prepend: %v", err)
+	}
+	if modified {
+		t.Fatal("expected modified=false for non-Anthropic provider")
+	}
+	if string(got) != string(body) {
+		t.Errorf("body changed for non-Anthropic provider")
+	}
+}
+
+func TestPrependExpiredTaskNotice_ReturnsErrorOnMalformedBody(t *testing.T) {
+	_, _, err := PrependExpiredTaskNoticeToLastUserMessage([]byte(`{not json`), conversation.ProviderAnthropic, "task-1", "demo")
+	if err == nil {
+		t.Fatal("expected error on malformed JSON body")
+	}
+}
+
+// --- helpers ---
+
+func decodeMessages(t *testing.T, body []byte) []map[string]json.RawMessage {
+	t.Helper()
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(body, &raw); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	var messages []map[string]json.RawMessage
+	if err := json.Unmarshal(raw["messages"], &messages); err != nil {
+		t.Fatalf("unmarshal messages: %v", err)
+	}
+	return messages
+}
+
+func decodeBlocks(t *testing.T, content json.RawMessage) []json.RawMessage {
+	t.Helper()
+	var blocks []json.RawMessage
+	if err := json.Unmarshal(content, &blocks); err != nil {
+		t.Fatalf("unmarshal blocks (content=%s): %v", string(content), err)
+	}
+	return blocks
+}

--- a/internal/runtime/llmproxy/human_turns.go
+++ b/internal/runtime/llmproxy/human_turns.go
@@ -72,7 +72,7 @@ func extractAnthropicHumanTurns(body []byte) []string {
 		if role != "user" {
 			continue
 		}
-		text := strings.TrimSpace(extractAnthropicUserText(msg["content"]))
+		text := strings.TrimSpace(extractAnthropicHumanText(msg["content"]))
 		if text == "" {
 			continue
 		}
@@ -84,12 +84,25 @@ func extractAnthropicHumanTurns(body []byte) []string {
 	return tailLimit(turns, maxRecentHumanTurns)
 }
 
-// extractAnthropicUserText flattens an Anthropic role:"user" content
-// field to plain text. Tool result blocks are skipped — they are
-// harness output, not human input. Content can be either a plain string
-// (older shape) or a heterogeneous block array (current shape with
-// type:"text" / "tool_result" entries).
-func extractAnthropicUserText(contentRaw json.RawMessage) string {
+// extractAnthropicHumanText returns the human-authored portion of an
+// Anthropic role:"user" content field, flattened to plain text. The
+// helper's contract is "what did the human type, ignoring everything
+// the harness or the proxy injected" — concretely, it skips two
+// categories of non-human content:
+//
+//  1. Tool-result blocks (harness output replayed back to the model).
+//  2. Proxy-emitted <clawvisor-notice> blocks (proxy-issued control
+//     state — task-approved / task-denied / task-expired envelopes).
+//
+// Both filters live here so every consumer (recent-human-turn
+// extraction, expired-task-notice anchoring, future intent-style
+// inspectors) gets the same shape without each one re-deriving the
+// "what counts as the user's authoring?" decision.
+//
+// Content can be either a plain string (older shape) or a
+// heterogeneous block array (current shape with type:"text" /
+// "tool_result" entries).
+func extractAnthropicHumanText(contentRaw json.RawMessage) string {
 	if len(contentRaw) == 0 {
 		return ""
 	}
@@ -117,9 +130,22 @@ func extractAnthropicUserText(contentRaw json.RawMessage) string {
 		if b.Type != "text" && b.Type != "input_text" {
 			continue
 		}
-		if b.Text != "" {
-			parts = append(parts, b.Text)
+		if b.Text == "" {
+			continue
 		}
+		// Filter (2): drop proxy-emitted Clawvisor notice blocks.
+		// PrependExpiredTaskNoticeToLastUserMessage produces a
+		// [notice_block, user_text_block] shape; without this skip,
+		// the flattened text would lead with the notice envelope and
+		// downstream isClawvisorInternalUserText's exact-shape match
+		// (which expects the ENTIRE trimmed text to be one notice)
+		// would reject the prefix-followed-by-text combination,
+		// letting the augmented turn surface as a "genuine human
+		// turn" in auto-approval / intent-verify policies.
+		if isExactClawvisorNoticeShape(b.Text) {
+			continue
+		}
+		parts = append(parts, b.Text)
 	}
 	return strings.Join(parts, "\n")
 }
@@ -229,7 +255,7 @@ func flattenOpenAIChatContent(raw json.RawMessage) string {
 //     authoring turn.
 //
 // Tool results and other non-human content are already filtered at the
-// content-shape level (see extractAnthropicUserText), so this helper
+// content-shape level (see extractAnthropicHumanText), so this helper
 // only needs to recognize the conversational-verb cases.
 func isClawvisorInternalUserText(text string) bool {
 	// containsInlineApprovalAugmentationMarker catches the user-side

--- a/internal/runtime/llmproxy/human_turns_test.go
+++ b/internal/runtime/llmproxy/human_turns_test.go
@@ -148,6 +148,60 @@ func TestExtractRecentHumanTurns_AnthropicSkipsAugmentedReply(t *testing.T) {
 	}
 }
 
+// TestExtractRecentHumanTurns_AnthropicStripsProxyNoticeBlock pins the
+// per-block notice filter: when PrependExpiredTaskNoticeToLastUserMessage
+// turns a user turn into [notice_block, user_text_block], the extracted
+// human turn must be JUST the user_text — without this, the notice
+// envelope would flatten into the recent-human-turns string and bleed
+// into auto-approval / intent-verification policies.
+func TestExtractRecentHumanTurns_AnthropicStripsProxyNoticeBlock(t *testing.T) {
+	notice := Render(NoticeKindTaskExpired, "The previously active task has expired (expired_task_id=task-1).")
+	body := mustMarshal(t, map[string]any{
+		"messages": []map[string]any{
+			{
+				"role": "user",
+				"content": []map[string]any{
+					{"type": "text", "text": notice},
+					{"type": "text", "text": "please update the README"},
+				},
+			},
+		},
+	})
+	turns := ExtractRecentHumanTurns(ExtractHumanTurnsRequest{
+		Provider: conversation.ProviderAnthropic,
+		Body:     body,
+	})
+	if len(turns) != 1 || turns[0] != "please update the README" {
+		t.Errorf("turns = %v, want [please update the README]", turns)
+	}
+}
+
+// TestExtractRecentHumanTurns_AnthropicSkipsNoticeOnlyTurn keeps the
+// "no genuine content" branch correct: a user message that's nothing
+// but a proxy notice must NOT surface as a human turn.
+func TestExtractRecentHumanTurns_AnthropicSkipsNoticeOnlyTurn(t *testing.T) {
+	notice := Render(NoticeKindTaskExpired, "lapsed")
+	body := mustMarshal(t, map[string]any{
+		"messages": []map[string]any{
+			{"role": "user", "content": "real ask"},
+			{"role": "assistant", "content": "ok"},
+			{
+				"role": "user",
+				"content": []map[string]any{
+					{"type": "text", "text": notice},
+				},
+			},
+		},
+	})
+	turns := ExtractRecentHumanTurns(ExtractHumanTurnsRequest{
+		Provider: conversation.ProviderAnthropic,
+		Body:     body,
+	})
+	if len(turns) != 1 || turns[0] != "real ask" {
+		t.Errorf("turns = %v, want [real ask]", turns)
+	}
+}
+
 func TestExtractRecentHumanTurns_AnthropicMultipleTurnsOrdered(t *testing.T) {
 	// Most recent last, capped at maxRecentHumanTurns. Four turns
 	// should collapse to the last three.

--- a/internal/runtime/llmproxy/inline_task_rewrite.go
+++ b/internal/runtime/llmproxy/inline_task_rewrite.go
@@ -311,6 +311,13 @@ const (
 	NoticeKindTaskApproved NoticeKind = "task-approved"
 	NoticeKindTaskDenied   NoticeKind = "task-denied"
 	NoticeKindTaskError    NoticeKind = "task-error"
+	// NoticeKindTaskExpired marks the per-conversation announcement that
+	// the agent's currently-checked-out task has lapsed past its
+	// ExpiresAt. The proxy prepends one of these to the first genuine
+	// user-role message after expiry so the model can acknowledge the
+	// lapse and POST a new task (or check out a different active one)
+	// before its next tool_use is denied by task-scope.
+	NoticeKindTaskExpired NoticeKind = "task-expired"
 )
 
 // AugmentApprovedInlineTasksInHistory walks the conversation history

--- a/internal/runtime/llmproxy/policies/expired_task_notice.go
+++ b/internal/runtime/llmproxy/policies/expired_task_notice.go
@@ -1,0 +1,140 @@
+package policies
+
+import (
+	"bytes"
+	"context"
+	"strings"
+
+	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/pipeline"
+)
+
+// ExpiredTaskNotice tells the model when its currently-active task has
+// lapsed past its ExpiresAt. Without this signal the next tool_use is
+// silently scope-denied by the existing task-scope evaluator and the
+// model has to infer what happened from the denial reason; the
+// preprocess notice gets ahead of that, telling the model directly so
+// it can acknowledge the lapse and POST a fresh task (or check out a
+// different active one) on the same turn.
+//
+// The policy is THIN — the lookup of "which task is currently active
+// for this agent, and is it past ExpiresAt?" is injected as a loader
+// callback (the handler owns the store and the checkout registry).
+// Body transformation lives in the parent llmproxy package
+// (PrependExpiredTaskNoticeToLastUserMessage) and is reached through
+// the loader's Inject callback so this file stays decoupled from the
+// llmproxy package.
+type ExpiredTaskNotice struct {
+	loader ExpiredCheckedOutTaskLoader
+	inject ExpiredTaskNoticeInjector
+}
+
+// ExpiredCheckedOutTaskLoader resolves whether the conversation's
+// active task has expired. Returns expired=true with the task ID +
+// purpose only when the agent has a checked-out task whose ExpiresAt
+// is non-nil and in the past. Standing tasks (ExpiresAt == nil), no
+// checkout, store outages, and tasks whose pointer is stale all
+// return expired=false. Errors are swallowed inside the loader — the
+// policy stays silent rather than denying on transient store outages.
+type ExpiredCheckedOutTaskLoader func(ctx context.Context, userID, agentID, conversationID string) (taskID, purpose string, expired bool)
+
+// ExpiredTaskNoticeInjector performs the body transform when the
+// loader reports an expired task. Implementations call
+// llmproxy.PrependExpiredTaskNoticeToLastUserMessage internally; the
+// indirection keeps the policy file out of the parent llmproxy
+// package's import graph (same shape InlineTaskAugment uses).
+type ExpiredTaskNoticeInjector func(body []byte, provider conversation.Provider, taskID, purpose string) ([]byte, bool, error)
+
+// NewExpiredTaskNotice constructs the policy. A nil loader or nil
+// injector turns the policy into a no-op (skip on every request) so
+// the handler can register it unconditionally without first checking
+// store wiring.
+func NewExpiredTaskNotice(loader ExpiredCheckedOutTaskLoader, inject ExpiredTaskNoticeInjector) *ExpiredTaskNotice {
+	return &ExpiredTaskNotice{loader: loader, inject: inject}
+}
+
+// Name returns the audit-friendly policy identifier.
+func (ExpiredTaskNotice) Name() string { return "expired_task_notice" }
+
+// expiredTaskSentinelPrefix mirrors llmproxy.ExpiredTaskNoticeSentinel.
+// We duplicate the constant rather than import the parent package to
+// keep this file out of the llmproxy import graph (the same boundary
+// every other policy file respects). Drift risk is tiny — the literal
+// is a stable wire constant tested on both sides.
+const expiredTaskSentinelPrefix = "expired_task_id="
+
+// Preprocess injects the notice when the loader reports an expired
+// active task AND the body doesn't already contain the per-taskID
+// sentinel.
+//
+// Gating order is cheapest-first:
+//  1. Empty UserID / AgentID → Skip (lookup can't scope).
+//  2. count_tokens path → Skip (mirrors ControlNotice; not a real LLM
+//     call, no use injecting state).
+//  3. Non-Anthropic provider → Skip (v1 Anthropic-only; the body
+//     transform doesn't have an OpenAI walker yet).
+//  4. Loader returns expired=false → Skip.
+//  5. Body already contains the per-taskID sentinel → Skip (already
+//     announced in this conversation). Once Anthropic echoes the
+//     augmented history on the next turn, this branch keeps us
+//     idempotent without per-conversation state.
+//  6. Inject. If the injector reports no modification (e.g., the
+//     latest user-role messages are all internal verbs / tool_results
+//     so nothing genuine to anchor to), Skip — we'll try again on the
+//     next turn when a genuine human message arrives.
+func (p *ExpiredTaskNotice) Preprocess(ctx context.Context, req pipeline.ReadOnlyRequest, mut pipeline.RequestMutator) (pipeline.RequestVerdict, error) {
+	if p == nil || p.loader == nil || p.inject == nil {
+		return pipeline.RequestVerdict{Outcome: pipeline.OutcomeSkip}, nil
+	}
+	userID := req.UserID()
+	agentID := req.AgentID()
+	if userID == "" || agentID == "" {
+		return pipeline.RequestVerdict{Outcome: pipeline.OutcomeSkip}, nil
+	}
+	if h := req.HTTPRequest(); h != nil && strings.HasSuffix(h.URL.Path, "/count_tokens") {
+		return pipeline.RequestVerdict{Outcome: pipeline.OutcomeSkip}, nil
+	}
+	// Provider gating lives inside the injector: the body editor in
+	// llmproxy handles only Anthropic-shaped bodies today and reports
+	// modified=false for everything else, which falls through to the
+	// no-modification Skip branch below.
+
+	taskID, purpose, expired := p.loader(ctx, userID, agentID, req.ConversationID())
+	if !expired || strings.TrimSpace(taskID) == "" {
+		return pipeline.RequestVerdict{Outcome: pipeline.OutcomeSkip}, nil
+	}
+
+	body := req.RawBody()
+	if bytes.Contains(body, []byte(expiredTaskSentinelPrefix+taskID)) {
+		return pipeline.RequestVerdict{Outcome: pipeline.OutcomeSkip}, nil
+	}
+
+	newBody, modified, err := p.inject(body, req.Provider(), taskID, purpose)
+	if err != nil {
+		// Body malformation is a downstream concern, not a deny signal —
+		// the validator on the forward step will surface it. Record the
+		// error in audit and proceed without modification.
+		return pipeline.RequestVerdict{
+			Outcome: pipeline.OutcomeSkip,
+			Reason:  err.Error(),
+			AuditParams: map[string]any{
+				"expired_task_notice_error": err.Error(),
+			},
+		}, nil
+	}
+	if !modified {
+		return pipeline.RequestVerdict{Outcome: pipeline.OutcomeSkip}, nil
+	}
+	if err := mut.ReplaceBody(newBody); err != nil {
+		return pipeline.RequestVerdict{}, err
+	}
+	return pipeline.RequestVerdict{
+		Outcome: pipeline.OutcomeAllow,
+		AuditParams: map[string]any{
+			"expired_task_notice_injected": true,
+			"expired_task_id":              taskID,
+		},
+	}, nil
+}
+
+var _ pipeline.RequestPolicy = (*ExpiredTaskNotice)(nil)

--- a/internal/runtime/llmproxy/policies/expired_task_notice_test.go
+++ b/internal/runtime/llmproxy/policies/expired_task_notice_test.go
@@ -1,0 +1,204 @@
+package policies_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/pipeline"
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/policies"
+)
+
+// genuineUserBody is a minimal Anthropic request body whose last
+// user-role message is a real human instruction. The notice's
+// expected target.
+const genuineUserBody = `{"model":"claude-sonnet-4","messages":[{"role":"user","content":"please update the README"}]}`
+
+// notInjectingInjector is the test double for the body-mutation hook.
+// It returns the body unchanged + modified=false, matching the
+// behavior the real injector exhibits when there's no qualifying
+// user-role message to anchor to.
+func notInjectingInjector(body []byte, _ conversation.Provider, _, _ string) ([]byte, bool, error) {
+	return body, false, nil
+}
+
+// constInjector returns a fixed replacement body and reports the
+// mutation as performed. Lets the policy test exercise the
+// Allow + audit path without parsing JSON itself.
+func constInjector(replacement string) policies.ExpiredTaskNoticeInjector {
+	return func(_ []byte, _ conversation.Provider, _, _ string) ([]byte, bool, error) {
+		return []byte(replacement), true, nil
+	}
+}
+
+func loaderExpired(taskID, purpose string) policies.ExpiredCheckedOutTaskLoader {
+	return func(_ context.Context, _, _, _ string) (string, string, bool) {
+		return taskID, purpose, true
+	}
+}
+
+func loaderNotExpired() policies.ExpiredCheckedOutTaskLoader {
+	return func(_ context.Context, _, _, _ string) (string, string, bool) {
+		return "", "", false
+	}
+}
+
+func newExpiredNoticeRequest(body string) *stubReadOnlyRequest {
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(body))
+	return &stubReadOnlyRequest{
+		provider:        conversation.ProviderAnthropic,
+		rawBody:         []byte(body),
+		userID:          "user-1",
+		agentID:         "agent-1",
+		httpReqOverride: httpReq,
+	}
+}
+
+func TestExpiredTaskNotice_SkipsWhenLoaderNil(t *testing.T) {
+	p := policies.NewExpiredTaskNotice(nil, constInjector(`{}`))
+	mut := &recordingRequestMutator{}
+	verdict, err := p.Preprocess(context.Background(), newExpiredNoticeRequest(genuineUserBody), mut)
+	if err != nil {
+		t.Fatalf("Preprocess: %v", err)
+	}
+	if verdict.Outcome != pipeline.OutcomeSkip {
+		t.Fatalf("Outcome = %q, want Skip (nil loader)", verdict.Outcome)
+	}
+}
+
+func TestExpiredTaskNotice_SkipsWhenInjectorNil(t *testing.T) {
+	p := policies.NewExpiredTaskNotice(loaderExpired("task-1", "purpose"), nil)
+	mut := &recordingRequestMutator{}
+	verdict, _ := p.Preprocess(context.Background(), newExpiredNoticeRequest(genuineUserBody), mut)
+	if verdict.Outcome != pipeline.OutcomeSkip {
+		t.Errorf("Outcome = %q, want Skip (nil injector)", verdict.Outcome)
+	}
+}
+
+func TestExpiredTaskNotice_SkipsWhenUserIDEmpty(t *testing.T) {
+	p := policies.NewExpiredTaskNotice(loaderExpired("task-1", "purpose"), constInjector(`{}`))
+	req := newExpiredNoticeRequest(genuineUserBody)
+	req.userID = ""
+	mut := &recordingRequestMutator{}
+	verdict, _ := p.Preprocess(context.Background(), req, mut)
+	if verdict.Outcome != pipeline.OutcomeSkip {
+		t.Errorf("Outcome = %q, want Skip (empty userID)", verdict.Outcome)
+	}
+}
+
+func TestExpiredTaskNotice_SkipsCountTokensPath(t *testing.T) {
+	p := policies.NewExpiredTaskNotice(loaderExpired("task-1", "purpose"), constInjector(`{}`))
+	req := newExpiredNoticeRequest(genuineUserBody)
+	req.httpReqOverride.URL.Path = "/v1/messages/count_tokens"
+	mut := &recordingRequestMutator{}
+	verdict, _ := p.Preprocess(context.Background(), req, mut)
+	if verdict.Outcome != pipeline.OutcomeSkip {
+		t.Errorf("Outcome = %q, want Skip (count_tokens path)", verdict.Outcome)
+	}
+	if len(mut.ReplaceBodyCalls) != 0 {
+		t.Errorf("ReplaceBody called %d times on count_tokens; want 0", len(mut.ReplaceBodyCalls))
+	}
+}
+
+func TestExpiredTaskNotice_SkipsWhenNotExpired(t *testing.T) {
+	p := policies.NewExpiredTaskNotice(loaderNotExpired(), constInjector(`{}`))
+	mut := &recordingRequestMutator{}
+	verdict, _ := p.Preprocess(context.Background(), newExpiredNoticeRequest(genuineUserBody), mut)
+	if verdict.Outcome != pipeline.OutcomeSkip {
+		t.Errorf("Outcome = %q, want Skip (loader reports not expired)", verdict.Outcome)
+	}
+}
+
+func TestExpiredTaskNotice_InjectsWhenExpired(t *testing.T) {
+	p := policies.NewExpiredTaskNotice(loaderExpired("task-1", "purpose"), constInjector(`{"replaced":true}`))
+	mut := &recordingRequestMutator{}
+	verdict, err := p.Preprocess(context.Background(), newExpiredNoticeRequest(genuineUserBody), mut)
+	if err != nil {
+		t.Fatalf("Preprocess: %v", err)
+	}
+	if verdict.Outcome != pipeline.OutcomeAllow {
+		t.Fatalf("Outcome = %q, want Allow", verdict.Outcome)
+	}
+	if len(mut.ReplaceBodyCalls) != 1 {
+		t.Fatalf("expected 1 ReplaceBody call, got %d", len(mut.ReplaceBodyCalls))
+	}
+	if string(mut.ReplaceBodyCalls[0]) != `{"replaced":true}` {
+		t.Errorf("ReplaceBody payload = %q, want injector output", string(mut.ReplaceBodyCalls[0]))
+	}
+	if v, _ := verdict.AuditParams["expired_task_notice_injected"].(bool); !v {
+		t.Errorf("audit flag expired_task_notice_injected = %v, want true", verdict.AuditParams["expired_task_notice_injected"])
+	}
+	if v, _ := verdict.AuditParams["expired_task_id"].(string); v != "task-1" {
+		t.Errorf("audit field expired_task_id = %q, want task-1", v)
+	}
+}
+
+func TestExpiredTaskNotice_SkipsWhenSentinelAlreadyPresent(t *testing.T) {
+	// Body already carries the sentinel for the same task ID — the
+	// previous turn's injection. Policy must NOT re-inject.
+	body := `{"model":"claude-sonnet-4","messages":[{"role":"user","content":[{"type":"text","text":"<clawvisor-notice kind=\"task-expired\">prior (expired_task_id=task-1). recover...</clawvisor-notice>"},{"type":"text","text":"continue"}]}]}`
+	p := policies.NewExpiredTaskNotice(loaderExpired("task-1", "purpose"), constInjector(`{"replaced":true}`))
+	mut := &recordingRequestMutator{}
+	verdict, _ := p.Preprocess(context.Background(), newExpiredNoticeRequest(body), mut)
+	if verdict.Outcome != pipeline.OutcomeSkip {
+		t.Fatalf("Outcome = %q, want Skip (sentinel present)", verdict.Outcome)
+	}
+	if len(mut.ReplaceBodyCalls) != 0 {
+		t.Errorf("ReplaceBody called despite sentinel hit: %d calls", len(mut.ReplaceBodyCalls))
+	}
+}
+
+func TestExpiredTaskNotice_InjectsForDifferentTaskIDDespiteExistingNotice(t *testing.T) {
+	// A prior turn announced task-old. The agent has since checked out
+	// task-new which has now also expired. Policy fires because the
+	// per-task-ID sentinel doesn't match.
+	body := `{"model":"claude-sonnet-4","messages":[{"role":"user","content":[{"type":"text","text":"<clawvisor-notice kind=\"task-expired\">prior (expired_task_id=task-old). recover...</clawvisor-notice>"},{"type":"text","text":"keep going"}]}]}`
+	p := policies.NewExpiredTaskNotice(loaderExpired("task-new", "purpose"), constInjector(`{"replaced":true}`))
+	mut := &recordingRequestMutator{}
+	verdict, _ := p.Preprocess(context.Background(), newExpiredNoticeRequest(body), mut)
+	if verdict.Outcome != pipeline.OutcomeAllow {
+		t.Fatalf("Outcome = %q, want Allow for fresh task expiry", verdict.Outcome)
+	}
+	if len(mut.ReplaceBodyCalls) != 1 {
+		t.Errorf("expected 1 ReplaceBody for fresh task, got %d", len(mut.ReplaceBodyCalls))
+	}
+}
+
+func TestExpiredTaskNotice_SkipsWhenInjectorReportsNoModification(t *testing.T) {
+	// Loader says expired, but the injector finds no anchor — e.g. the
+	// last user-role messages are all tool_results. Skip cleanly.
+	p := policies.NewExpiredTaskNotice(loaderExpired("task-1", "purpose"), notInjectingInjector)
+	mut := &recordingRequestMutator{}
+	verdict, _ := p.Preprocess(context.Background(), newExpiredNoticeRequest(genuineUserBody), mut)
+	if verdict.Outcome != pipeline.OutcomeSkip {
+		t.Errorf("Outcome = %q, want Skip (injector no-op)", verdict.Outcome)
+	}
+	if len(mut.ReplaceBodyCalls) != 0 {
+		t.Errorf("ReplaceBody called %d times on injector no-op; want 0", len(mut.ReplaceBodyCalls))
+	}
+}
+
+func TestExpiredTaskNotice_SkipsOnInjectorError(t *testing.T) {
+	// Malformed body or other transient injector failure: record the
+	// error in audit but Skip rather than Deny, so we don't turn an
+	// observability glitch into a model-facing refusal.
+	failing := func(_ []byte, _ conversation.Provider, _, _ string) ([]byte, bool, error) {
+		return nil, false, errors.New("boom")
+	}
+	p := policies.NewExpiredTaskNotice(loaderExpired("task-1", "purpose"), failing)
+	mut := &recordingRequestMutator{}
+	verdict, err := p.Preprocess(context.Background(), newExpiredNoticeRequest(genuineUserBody), mut)
+	if err != nil {
+		t.Fatalf("Preprocess returned err: %v", err)
+	}
+	if verdict.Outcome != pipeline.OutcomeSkip {
+		t.Errorf("Outcome = %q, want Skip on injector error", verdict.Outcome)
+	}
+	if got, _ := verdict.AuditParams["expired_task_notice_error"].(string); got != "boom" {
+		t.Errorf("audit error field = %q, want boom", got)
+	}
+}


### PR DESCRIPTION
## Summary

- When the agent's checked-out task lapses past `ExpiresAt`, the next `tool_use` is silently scope-denied by the task-scope evaluator. The model has no way to tell *why* and the user-facing behavior is a confusing refusal.
- New `ExpiredTaskNotice` preprocess policy prepends a `<clawvisor-notice kind=\"task-expired\">` block to the first genuine user-role message after expiry so the model can acknowledge the lapse and POST a fresh task (or POST `/control/task/checkout` to switch) before the next tool call.
- Per-task-ID sentinel (`expired_task_id={taskID}`) makes the injection idempotent across subsequent turns; a later checked-out task that also expires gets its own fresh notice.

## Design notes

- Lookup uses the existing `TaskCheckouts` checkout pointer (scoped → legacy fallback, matching `checkedOutTaskID`). Standing tasks (`ExpiresAt == nil`) never trigger. `Status` is intentionally **not** consulted — `ExpiresAt` is the wall-clock truth, so the policy wins the race against the in-DB expiry sweep.
- Body editor lives in the parent `llmproxy` package; policy file stays thin and provider-agnostic (per the existing architectural test).
- Last user-role anchoring skips bare-verb / clawvisor-notice / tool_result-only turns so the notice lands on real human authoring.
- `extractAnthropicUserText` renamed to `extractAnthropicHumanText` and now skips proxy-emitted notice blocks at the per-block level, so the augmented `[notice_block, user_text_block]` shape doesn't bleed into `ExtractRecentHumanTurns` (and from there into auto-approval / intent-verify policies).

## Test plan

- [x] Unit: notice rendering, hostile-purpose sanitization, content-as-string normalization, block-array prepend ordering, tool-result-only tail skip, bare-verb skip, non-Anthropic skip, malformed-JSON error.
- [x] Unit: policy gating (nil loader, nil injector, empty userID, count_tokens, not-expired, happy path, sentinel idempotency same-task, fresh-injection different-task, injector-no-op, injector-error audit).
- [x] Unit: \`extractAnthropicHumanText\` strips proxy notice blocks; notice-only turn doesn't surface as a human turn.
- [x] \`go vet ./...\` clean.
- [x] \`go test ./...\` clean.
- [x] \`cubic review --base origin/main\` clean (2 P2 issues found across 3 iterations, both addressed).
- [ ] Manual: start the proxy with a short-lived (e.g. 60s) approved task checked out, wait for expiry, send a real LLM request from a configured agent, and confirm via the audit log that \`expired_task_notice_injected=true\` fires on the first request after expiry and does NOT fire on subsequent ones for the same task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

