### PR TITLE
perf(llmproxy): kill prompt-cache busts around inline task creation

### DIFF
--- a/internal/api/handlers/llm_endpoint.go
+++ b/internal/api/handlers/llm_endpoint.go
@@ -2906,13 +2906,24 @@ func (h *LLMEndpointHandler) renderActiveTasksSnapshot(ctx context.Context, user
 			continue
 		}
 		purpose := sanitizeTaskPurposeForSnapshot(t.Purpose)
-		expiry := "never"
-		if t.ExpiresAt != nil {
-			expiry = t.ExpiresAt.UTC().Format("2006-01-02T15:04Z")
-		}
 		lifetime := t.Lifetime
 		if lifetime == "" {
 			lifetime = "session"
+		}
+		// Sliding tasks' ExpiresAt is bumped on every authorized
+		// tool_use, so rendering the literal timestamp here would
+		// mutate the system-prompt bytes every turn and bust
+		// Anthropic's prompt cache (one cache rewrite per tool call,
+		// per active task). Surface lifetime semantics instead;
+		// agents can GET /control/tasks for live expiry.
+		expiry := "never"
+		switch {
+		case t.ExpiresAt == nil:
+			expiry = "never"
+		case lifetime == "sliding":
+			expiry = "auto-extends"
+		default:
+			expiry = t.ExpiresAt.UTC().Format("2006-01-02T15:04Z")
 		}
 		lines = append(lines, fmt.Sprintf("  - %s · purpose=%q · lifetime=%s · expires=%s", t.ID, purpose, lifetime, expiry))
 		if len(lines) >= maxTasks {

--- a/internal/api/handlers/llm_endpoint.go
+++ b/internal/api/handlers/llm_endpoint.go
@@ -137,6 +137,18 @@ type LLMEndpointHandler struct {
 	// than the prior unconditional "task approved" claim).
 	InlineApprovalOutcomes llmproxy.InlineApprovalOutcomeStore
 
+	// ActiveTasksSnapshots freezes the ACTIVE TASKS snapshot text for
+	// the lifetime of a conversation so Anthropic's prompt cache stays
+	// byte-stable across turns. Without it, a task created mid-
+	// conversation re-renders the snapshot's bullet rows, drifts the
+	// system prompt by ~140 bytes, and busts the system-block cache
+	// breakpoint (~15k cached tokens lost on the next request). The
+	// agent still learns about mid-conversation tasks via the
+	// augmenter's task-approved notice and via GET /control/tasks.
+	// Optional — when nil, the snapshot re-renders fresh every turn
+	// (the pre-cache behavior).
+	ActiveTasksSnapshots llmproxy.ActiveTasksSnapshotCache
+
 	// TaskCheckouts stores the current task focus for an agent. The decision
 	// layer treats this as a preference among already-valid task candidates.
 	TaskCheckouts llmproxy.TaskCheckoutStore
@@ -212,6 +224,7 @@ func NewLLMEndpointHandler(st store.Store, v vault.Vault, logger *slog.Logger) *
 		ScopeDrifts:            llmproxy.NewMemoryScopeDriftRegistry(0),
 		PendingSecrets:         llmproxy.NewMemoryPendingSecretDecisionCache(10 * time.Minute),
 		InlineApprovalOutcomes: llmproxy.NewMemoryInlineApprovalOutcomeStore(24 * time.Hour),
+		ActiveTasksSnapshots:   llmproxy.NewMemoryActiveTasksSnapshotCache(24*time.Hour, 0),
 		TaskCheckouts:          llmproxy.NewMemoryTaskCheckoutStore(24 * time.Hour),
 		// Default in-process nonce cache; production wires the Redis-
 		// backed cache via WithCallerNonceCache. Cache instance is
@@ -768,21 +781,36 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 			}
 			return rules
 		}
-		// activeTasksSnapshotLoader runs once on first-turn injection and
-		// renders the conversation-start snapshot of the agent's active
-		// tasks. The sentinel-based dedup in InjectControlNoticeWith-
-		// Snapshot keeps the rendered string frozen across later turns,
-		// so prompt cache stays byte-stable even as task state drifts.
-		// Errors are non-fatal — the agent falls back to GET /control/tasks.
-		activeTasksSnapshotLoader := func(ctx context.Context, userID, agentID string) string {
+		// activeTasksSnapshotLoader renders the conversation-start
+		// snapshot of the agent's active tasks. The snapshot lives
+		// ABOVE Anthropic's prompt cache breakpoints in the system
+		// prompt, so it must stay byte-stable for the lifetime of a
+		// conversation. h.ActiveTasksSnapshots caches the rendered
+		// string per (user, agent, conversation) so a task created
+		// mid-conversation doesn't drift the snapshot's bullet rows
+		// and bust ~15k cached tokens on the next turn. The agent
+		// still learns about new tasks via the augmenter's
+		// task-approved notice (below the cache breakpoint) and via
+		// GET /control/tasks. Errors are non-fatal.
+		activeTasksSnapshotLoader := func(ctx context.Context, userID, agentID, conversationID string) string {
+			if h.ActiveTasksSnapshots != nil && conversationID != "" {
+				key := llmproxy.ActiveTasksSnapshotKey{UserID: userID, AgentID: agentID, ConversationID: conversationID}
+				if cached, ok := h.ActiveTasksSnapshots.Lookup(key); ok {
+					return cached
+				}
+				fresh := h.renderActiveTasksSnapshot(ctx, userID, agentID)
+				h.ActiveTasksSnapshots.Record(key, fresh)
+				return fresh
+			}
 			return h.renderActiveTasksSnapshot(ctx, userID, agentID)
 		}
 		pipeReq := &pipelineReadOnlyRequest{
-			provider: provider,
-			httpReq:  r,
-			body:     body,
-			userID:   agent.UserID,
-			agentID:  agent.ID,
+			provider:       provider,
+			httpReq:        r,
+			body:           body,
+			userID:         agent.UserID,
+			agentID:        agent.ID,
+			conversationID: conversationID,
 		}
 		result, err := runSinglePolicy(r.Context(), pipeReq, policies.NewControlNoticeWithSnapshot(h.ControlBaseURL, availableToolsFn, toolRulesLoader, activeTasksSnapshotLoader))
 		if err != nil {

--- a/internal/api/handlers/llm_endpoint_active_tasks_render_test.go
+++ b/internal/api/handlers/llm_endpoint_active_tasks_render_test.go
@@ -1,0 +1,127 @@
+package handlers
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/clawvisor/clawvisor/pkg/store"
+	"github.com/clawvisor/clawvisor/pkg/store/sqlite"
+)
+
+// TestRenderActiveTasksSnapshot_SlidingExpiryStable pins the cache-stability
+// fix: a sliding-lifetime task's ExpiresAt is bumped on every authorized
+// tool_use, so embedding the literal timestamp in the system-prompt
+// snapshot would mutate prefix bytes every turn and bust Anthropic's
+// prompt cache. The renderer must emit a fixed sentinel ("auto-extends")
+// for sliding tasks so the snapshot bytes do not drift as expiry rolls
+// forward.
+func TestRenderActiveTasksSnapshot_SlidingExpiryStable(t *testing.T) {
+	ctx := context.Background()
+	db, err := sqlite.New(ctx, filepath.Join(t.TempDir(), "snapshot.db"))
+	if err != nil {
+		t.Fatalf("sqlite.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	st := sqlite.NewStore(db)
+
+	user, err := st.CreateUser(ctx, "snapshot@test.example", "hash")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	agent, err := st.CreateAgent(ctx, user.ID, "agent", "token")
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	t0 := time.Now().UTC().Add(10 * time.Minute).Truncate(time.Second)
+	task := &store.Task{
+		ID:        "task-sliding",
+		UserID:    user.ID,
+		AgentID:   agent.ID,
+		Purpose:   "Edit web files",
+		Status:    "active",
+		Lifetime:  "sliding",
+		ExpiresAt: &t0,
+	}
+	if err := st.CreateTask(ctx, task); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+
+	h := &LLMEndpointHandler{
+		Store:  st,
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	first := h.renderActiveTasksSnapshot(ctx, user.ID, agent.ID)
+	if !strings.Contains(first, "task-sliding") {
+		t.Fatalf("snapshot missing task id: %q", first)
+	}
+	if !strings.Contains(first, "expires=auto-extends") {
+		t.Fatalf("sliding task must render a stable expires sentinel, got: %q", first)
+	}
+	if strings.Contains(first, t0.Format("15:04")) {
+		t.Fatalf("sliding task must NOT embed the literal expiry timestamp (cache busts every tool_use); got: %q", first)
+	}
+
+	// Simulate a sliding-lifetime bump: ExpiresAt moves forward, which
+	// would have changed the snapshot bytes under the old renderer.
+	t1 := t0.Add(10 * time.Minute)
+	if err := st.UpdateTaskExpiresAt(ctx, task.ID, t1); err != nil {
+		t.Fatalf("UpdateTaskExpiresAt: %v", err)
+	}
+	second := h.renderActiveTasksSnapshot(ctx, user.ID, agent.ID)
+	if first != second {
+		t.Fatalf("snapshot drifted between turns; cache will bust\nfirst:  %q\nsecond: %q", first, second)
+	}
+}
+
+// TestRenderActiveTasksSnapshot_SessionExpiryRendered confirms that for
+// session-lifetime tasks (which DON'T auto-extend), the actual UTC
+// timestamp still appears — those bytes are stable and informative.
+func TestRenderActiveTasksSnapshot_SessionExpiryRendered(t *testing.T) {
+	ctx := context.Background()
+	db, err := sqlite.New(ctx, filepath.Join(t.TempDir(), "snapshot-session.db"))
+	if err != nil {
+		t.Fatalf("sqlite.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	st := sqlite.NewStore(db)
+
+	user, err := st.CreateUser(ctx, "session@test.example", "hash")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	agent, err := st.CreateAgent(ctx, user.ID, "agent", "token")
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	expiry := time.Date(2030, 1, 2, 3, 4, 0, 0, time.UTC)
+	task := &store.Task{
+		ID:        "task-session",
+		UserID:    user.ID,
+		AgentID:   agent.ID,
+		Purpose:   "One-shot job",
+		Status:    "active",
+		Lifetime:  "session",
+		ExpiresAt: &expiry,
+	}
+	if err := st.CreateTask(ctx, task); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+
+	h := &LLMEndpointHandler{
+		Store:  st,
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	got := h.renderActiveTasksSnapshot(ctx, user.ID, agent.ID)
+	if !strings.Contains(got, "expires=2030-01-02T03:04Z") {
+		t.Fatalf("session task should render the literal expiry, got: %q", got)
+	}
+}

--- a/internal/runtime/jsonpatch/jsonpatch.go
+++ b/internal/runtime/jsonpatch/jsonpatch.go
@@ -13,6 +13,30 @@ import (
 
 var errNotObject = errors.New("JSON value is not an object")
 
+// MarshalNoEscape is like json.Marshal but does NOT HTML-escape `<`, `>`,
+// or `&`. The proxy's body mutations target outbound LLM-API request
+// bodies whose prompt cache lookups are keyed on raw bytes; standard
+// json.Marshal flips literal `<system-reminder>` into `<system-
+// reminder>`, mismatching the harness's original bytes and busting
+// every cache_control breakpoint that includes the mutated region.
+//
+// json.Encoder always emits a trailing newline; this helper strips it so
+// the result is byte-equivalent to json.Marshal up to the escape
+// difference.
+func MarshalNoEscape(v any) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		return nil, err
+	}
+	out := buf.Bytes()
+	if n := len(out); n > 0 && out[n-1] == '\n' {
+		out = out[:n-1]
+	}
+	return out, nil
+}
+
 // FindTopLevelFieldValue locates the byte range of the value associated
 // with key in a top-level JSON object. The returned range indexes data.
 func FindTopLevelFieldValue(data []byte, key string) (int, int, bool) {

--- a/internal/runtime/jsonpatch/jsonpatch_test.go
+++ b/internal/runtime/jsonpatch/jsonpatch_test.go
@@ -6,6 +6,56 @@ import (
 	"github.com/clawvisor/clawvisor/internal/runtime/jsonpatch"
 )
 
+// TestMarshalNoEscape_PreservesAngleBrackets pins the cache-stability
+// fix on the proxy's body-mutation path. encoding/json's default
+// HTML-escape flips literal `<system-reminder>` (which appears in the
+// harness's tool descriptions and prompts) into `<system-reminder>`.
+// Anthropic's prompt cache is keyed on raw bytes; when the proxy
+// re-marshals a body fragment, the escaped form mismatches the
+// harness's original bytes and busts every cache_control breakpoint
+// that includes the mutated region. MarshalNoEscape keeps `<`, `>`,
+// and `&` literal.
+func TestMarshalNoEscape_PreservesAngleBrackets(t *testing.T) {
+	out, err := jsonpatch.MarshalNoEscape(map[string]any{
+		"text": "<system-reminder>foo & bar</system-reminder>",
+	})
+	if err != nil {
+		t.Fatalf("MarshalNoEscape: %v", err)
+	}
+	got := string(out)
+	want := `{"text":"<system-reminder>foo & bar</system-reminder>"}`
+	if got != want {
+		t.Errorf("got  %q\nwant %q", got, want)
+	}
+	for _, banned := range []string{"\\u003c", "\\u003e", "\\u0026"} {
+		if indexOf(got, banned) >= 0 {
+			t.Errorf("output contains banned HTML escape %q: %s", banned, got)
+		}
+	}
+}
+
+// TestMarshalNoEscape_NoTrailingNewline ensures the encoder's default
+// trailing newline is stripped — without that, splicing into a body via
+// jsonsurgery.SetField would leave whitespace inside the value range.
+func TestMarshalNoEscape_NoTrailingNewline(t *testing.T) {
+	out, err := jsonpatch.MarshalNoEscape("hello")
+	if err != nil {
+		t.Fatalf("MarshalNoEscape: %v", err)
+	}
+	if got := string(out); got != `"hello"` {
+		t.Errorf("got %q, want %q", got, `"hello"`)
+	}
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}
+
 func TestSetTopLevelField_ReplacesExisting(t *testing.T) {
 	in := []byte(`{"index":0,"name":"foo"}`)
 	out, err := jsonpatch.SetTopLevelField(in, "index", []byte(`5`))

--- a/internal/runtime/llmproxy/active_tasks_snapshot_cache.go
+++ b/internal/runtime/llmproxy/active_tasks_snapshot_cache.go
@@ -1,0 +1,119 @@
+package llmproxy
+
+import (
+	"sync"
+	"time"
+)
+
+// ActiveTasksSnapshotKey scopes a cached snapshot to one conversation.
+// Anthropic's prompt cache is keyed on raw bytes; the ACTIVE TASKS
+// snapshot lives in the system prompt above the cache breakpoints, so
+// any drift in the bullet rows (a new task created mid-conversation,
+// a stale task dropped) re-keys the cache and forces a 15k+ token
+// re-warm on the next turn. Freezing the snapshot for the lifetime of
+// the conversation removes that one re-warm per task event — the agent
+// still learns about the new task via the augmenter's task-approved
+// notice (which lands below the cache breakpoint) and via GET
+// /control/tasks when it wants live state.
+type ActiveTasksSnapshotKey struct {
+	UserID         string
+	AgentID        string
+	ConversationID string
+}
+
+// ActiveTasksSnapshotCache stores the rendered ACTIVE TASKS snapshot
+// for one conversation. The control-notice policy consults the cache
+// on every turn; the first-turn render persists, and every later turn
+// reads it verbatim.
+//
+// The negative ("") snapshot is also valid: a conversation that
+// started with zero active tasks should render the empty-state copy
+// on every later turn even if a task is created in between, so the
+// system prompt bytes stay stable.
+type ActiveTasksSnapshotCache interface {
+	Lookup(key ActiveTasksSnapshotKey) (string, bool)
+	Record(key ActiveTasksSnapshotKey, snapshot string)
+}
+
+// MemoryActiveTasksSnapshotCache is an in-process snapshot cache with
+// TTL eviction and a soft size cap. Adequate for single-process
+// installs; multi-replica deployments where conversations may land on
+// different replicas should wire a shared-backend cache (redis, etc.)
+// — even a per-replica memory cache helps because most conversations
+// stay sticky to one replica for their lifetime.
+type MemoryActiveTasksSnapshotCache struct {
+	ttl     time.Duration
+	maxSize int
+
+	mu      sync.Mutex
+	entries map[ActiveTasksSnapshotKey]activeTasksSnapshotEntry
+}
+
+type activeTasksSnapshotEntry struct {
+	snapshot  string
+	expiresAt time.Time
+}
+
+// NewMemoryActiveTasksSnapshotCache constructs the cache. ttl<=0
+// defaults to 24h; maxSize<=0 defaults to 10_000 entries.
+func NewMemoryActiveTasksSnapshotCache(ttl time.Duration, maxSize int) *MemoryActiveTasksSnapshotCache {
+	if ttl <= 0 {
+		ttl = 24 * time.Hour
+	}
+	if maxSize <= 0 {
+		maxSize = 10_000
+	}
+	return &MemoryActiveTasksSnapshotCache{
+		ttl:     ttl,
+		maxSize: maxSize,
+		entries: map[ActiveTasksSnapshotKey]activeTasksSnapshotEntry{},
+	}
+}
+
+func (c *MemoryActiveTasksSnapshotCache) Lookup(key ActiveTasksSnapshotKey) (string, bool) {
+	if key.ConversationID == "" {
+		return "", false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.entries[key]
+	if !ok {
+		return "", false
+	}
+	if time.Now().After(entry.expiresAt) {
+		delete(c.entries, key)
+		return "", false
+	}
+	return entry.snapshot, true
+}
+
+func (c *MemoryActiveTasksSnapshotCache) Record(key ActiveTasksSnapshotKey, snapshot string) {
+	if key.ConversationID == "" {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	now := time.Now()
+	c.gcLocked(now)
+	if len(c.entries) >= c.maxSize {
+		// Soft cap: drop one arbitrary entry to make room. Map
+		// iteration order is randomized so this isn't pure LRU, but
+		// it bounds memory without dragging in a heap.
+		for k := range c.entries {
+			delete(c.entries, k)
+			break
+		}
+	}
+	c.entries[key] = activeTasksSnapshotEntry{
+		snapshot:  snapshot,
+		expiresAt: now.Add(c.ttl),
+	}
+}
+
+func (c *MemoryActiveTasksSnapshotCache) gcLocked(now time.Time) {
+	for k, e := range c.entries {
+		if now.After(e.expiresAt) {
+			delete(c.entries, k)
+		}
+	}
+}

--- a/internal/runtime/llmproxy/active_tasks_snapshot_cache_test.go
+++ b/internal/runtime/llmproxy/active_tasks_snapshot_cache_test.go
@@ -1,0 +1,93 @@
+package llmproxy
+
+import (
+	"testing"
+	"time"
+)
+
+func TestMemoryActiveTasksSnapshotCache_RoundTrip(t *testing.T) {
+	c := NewMemoryActiveTasksSnapshotCache(time.Hour, 0)
+	key := ActiveTasksSnapshotKey{UserID: "u", AgentID: "a", ConversationID: "c"}
+	if _, ok := c.Lookup(key); ok {
+		t.Fatal("empty cache should miss")
+	}
+	c.Record(key, "- task-1 · purpose=\"do thing\" · lifetime=sliding · expires=auto-extends")
+	got, ok := c.Lookup(key)
+	if !ok {
+		t.Fatal("Record then Lookup must hit")
+	}
+	if got == "" {
+		t.Fatal("cached snapshot lost")
+	}
+}
+
+// TestMemoryActiveTasksSnapshotCache_FrozenAcrossUpdates pins the
+// cache-stability guarantee: once a snapshot is recorded for a
+// conversation, the SAME bytes come back on every later Lookup even
+// if the underlying task list would now render differently. The
+// agent learns about mid-conversation task creations via the
+// augmenter's task-approved notice (below the cache breakpoint), not
+// via this snapshot.
+func TestMemoryActiveTasksSnapshotCache_FrozenAcrossUpdates(t *testing.T) {
+	c := NewMemoryActiveTasksSnapshotCache(time.Hour, 0)
+	key := ActiveTasksSnapshotKey{UserID: "u", AgentID: "a", ConversationID: "c"}
+	first := "- task-1 · purpose=\"first\" · lifetime=sliding · expires=auto-extends"
+	c.Record(key, first)
+	got, ok := c.Lookup(key)
+	if !ok || got != first {
+		t.Fatalf("first lookup: ok=%v got=%q want=%q", ok, got, first)
+	}
+	// A second lookup must return the same bytes, byte-for-byte.
+	again, ok := c.Lookup(key)
+	if !ok || again != first {
+		t.Fatalf("second lookup drifted: ok=%v got=%q want=%q", ok, again, first)
+	}
+}
+
+func TestMemoryActiveTasksSnapshotCache_EmptyConversationIDDoesNotCache(t *testing.T) {
+	c := NewMemoryActiveTasksSnapshotCache(time.Hour, 0)
+	key := ActiveTasksSnapshotKey{UserID: "u", AgentID: "a", ConversationID: ""}
+	c.Record(key, "ignored")
+	if _, ok := c.Lookup(key); ok {
+		t.Fatal("empty conversationID must not be cached (would collide across conversations)")
+	}
+}
+
+func TestMemoryActiveTasksSnapshotCache_DifferentConversations(t *testing.T) {
+	c := NewMemoryActiveTasksSnapshotCache(time.Hour, 0)
+	k1 := ActiveTasksSnapshotKey{UserID: "u", AgentID: "a", ConversationID: "conv-1"}
+	k2 := ActiveTasksSnapshotKey{UserID: "u", AgentID: "a", ConversationID: "conv-2"}
+	c.Record(k1, "snapshot-1")
+	c.Record(k2, "snapshot-2")
+	g1, _ := c.Lookup(k1)
+	g2, _ := c.Lookup(k2)
+	if g1 != "snapshot-1" || g2 != "snapshot-2" {
+		t.Fatalf("conversation keys collided: g1=%q g2=%q", g1, g2)
+	}
+}
+
+func TestMemoryActiveTasksSnapshotCache_TTL(t *testing.T) {
+	c := NewMemoryActiveTasksSnapshotCache(time.Millisecond, 0)
+	key := ActiveTasksSnapshotKey{UserID: "u", AgentID: "a", ConversationID: "c"}
+	c.Record(key, "snap")
+	time.Sleep(5 * time.Millisecond)
+	if _, ok := c.Lookup(key); ok {
+		t.Fatal("entry should have expired")
+	}
+}
+
+func TestMemoryActiveTasksSnapshotCache_SizeCap(t *testing.T) {
+	c := NewMemoryActiveTasksSnapshotCache(time.Hour, 3)
+	for i := range 5 {
+		c.Record(ActiveTasksSnapshotKey{
+			UserID: "u", AgentID: "a", ConversationID: string(rune('a' + i)),
+		}, "snap")
+	}
+	// Soft cap: at most maxSize entries remain.
+	c.mu.Lock()
+	n := len(c.entries)
+	c.mu.Unlock()
+	if n > 3 {
+		t.Fatalf("size cap not enforced: %d entries", n)
+	}
+}

--- a/internal/runtime/llmproxy/approval_body_editor.go
+++ b/internal/runtime/llmproxy/approval_body_editor.go
@@ -151,14 +151,14 @@ func replaceAnthropicApprovalReply(body []byte, expectedVerb, expectedApprovalID
 		if !approvalIDMatchesExpectation(parsedID, expectedApprovalID) {
 			return body, false, nil
 		}
-		encoded, _ := json.Marshal(replacement)
+		encoded, _ := jsonsurgery.MarshalNoEscape(replacement)
 		req.Messages[i].Content = encoded
-		messages, err := json.Marshal(req.Messages)
+		messages, err := jsonsurgery.MarshalNoEscape(req.Messages)
 		if err != nil {
 			return nil, false, err
 		}
 		raw["messages"] = messages
-		out, err := json.Marshal(raw)
+		out, err := jsonsurgery.MarshalNoEscape(raw)
 		return out, err == nil, err
 	}
 	return body, false, nil
@@ -241,12 +241,12 @@ func rewriteAnthropicAskUserQuestionApprovalReply(body []byte, expectedVerb, exp
 			if assistantOK && userOK {
 				req.Messages[assistantIdx].Content = newAssistant
 				req.Messages[match.UserIdx].Content = newUser
-				messages, err := json.Marshal(req.Messages)
+				messages, err := jsonsurgery.MarshalNoEscape(req.Messages)
 				if err != nil {
 					return nil, false, err
 				}
 				raw["messages"] = messages
-				out, err := json.Marshal(raw)
+				out, err := jsonsurgery.MarshalNoEscape(raw)
 				return out, err == nil, err
 			}
 		}
@@ -262,12 +262,12 @@ func rewriteAnthropicAskUserQuestionApprovalReply(body []byte, expectedVerb, exp
 		return body, false, nil
 	}
 	req.Messages[match.UserIdx].Content = newContent
-	messages, err := json.Marshal(req.Messages)
+	messages, err := jsonsurgery.MarshalNoEscape(req.Messages)
 	if err != nil {
 		return nil, false, err
 	}
 	raw["messages"] = messages
-	out, err := json.Marshal(raw)
+	out, err := jsonsurgery.MarshalNoEscape(raw)
 	return out, err == nil, err
 }
 
@@ -295,7 +295,7 @@ func buildReconstructedAssistantContent(original *InlineApprovalOriginalCall) (j
 		"name":  original.ToolName,
 		"input": original.Input,
 	}
-	raw, err := json.Marshal([]any{block})
+	raw, err := jsonsurgery.MarshalNoEscape([]any{block})
 	if err != nil {
 		return nil, false
 	}
@@ -329,7 +329,7 @@ func swapAnthropicToolResultForReconstructedPair(raw json.RawMessage, askToolUse
 		if probe.Type != "tool_result" || probe.ToolUseID != askToolUseID {
 			continue
 		}
-		newBlock, err := json.Marshal(map[string]any{
+		newBlock, err := jsonsurgery.MarshalNoEscape(map[string]any{
 			"type":        "tool_result",
 			"tool_use_id": reconstructedToolUseID,
 			"content":     replacement,
@@ -343,7 +343,7 @@ func swapAnthropicToolResultForReconstructedPair(raw json.RawMessage, askToolUse
 	if !rewritten {
 		return nil, false
 	}
-	out, err := json.Marshal(blocks)
+	out, err := jsonsurgery.MarshalNoEscape(blocks)
 	if err != nil {
 		return nil, false
 	}
@@ -379,7 +379,7 @@ func swapAnthropicToolResultForTextBlock(raw json.RawMessage, targetToolUseID, r
 			continue
 		}
 		textBlock := map[string]string{"type": "text", "text": replacement}
-		newBlock, err := json.Marshal(textBlock)
+		newBlock, err := jsonsurgery.MarshalNoEscape(textBlock)
 		if err != nil {
 			continue
 		}
@@ -389,7 +389,7 @@ func swapAnthropicToolResultForTextBlock(raw json.RawMessage, targetToolUseID, r
 	if !rewritten {
 		return nil, false
 	}
-	out, err := json.Marshal(blocks)
+	out, err := jsonsurgery.MarshalNoEscape(blocks)
 	if err != nil {
 		return nil, false
 	}
@@ -432,7 +432,7 @@ func replaceOpenAIChatApprovalReply(body []byte, expectedVerb, expectedApprovalI
 		if role != "user" {
 			continue
 		}
-		contentRaw, _ := json.Marshal(req.Messages[i]["content"])
+		contentRaw, _ := jsonsurgery.MarshalNoEscape(req.Messages[i]["content"])
 		verb, parsedID := conversation.ParseApprovalReplyText(flattenOpenAITaskReplyContent(contentRaw))
 		if verb != expectedVerb {
 			return body, false, nil
@@ -441,12 +441,12 @@ func replaceOpenAIChatApprovalReply(body []byte, expectedVerb, expectedApprovalI
 			return body, false, nil
 		}
 		req.Messages[i]["content"] = replacement
-		messages, err := json.Marshal(req.Messages)
+		messages, err := jsonsurgery.MarshalNoEscape(req.Messages)
 		if err != nil {
 			return nil, false, err
 		}
 		raw["messages"] = messages
-		out, err := json.Marshal(raw)
+		out, err := jsonsurgery.MarshalNoEscape(raw)
 		return out, err == nil, err
 	}
 	return body, false, nil
@@ -472,9 +472,9 @@ func replaceOpenAIResponsesApprovalReply(body []byte, expectedVerb, expectedAppr
 		if !approvalIDMatchesExpectation(parsedID, expectedApprovalID) {
 			return body, false, nil
 		}
-		encoded, _ := json.Marshal(replacement)
+		encoded, _ := jsonsurgery.MarshalNoEscape(replacement)
 		raw["input"] = encoded
-		out, err := json.Marshal(raw)
+		out, err := jsonsurgery.MarshalNoEscape(raw)
 		return out, err == nil, err
 	}
 	var items []map[string]any
@@ -487,7 +487,7 @@ func replaceOpenAIResponsesApprovalReply(body []byte, expectedVerb, expectedAppr
 		if typ != "message" || role != "user" {
 			continue
 		}
-		contentRaw, _ := json.Marshal(items[i]["content"])
+		contentRaw, _ := jsonsurgery.MarshalNoEscape(items[i]["content"])
 		verb, parsedID := conversation.ParseApprovalReplyText(flattenOpenAITaskReplyContent(contentRaw))
 		if verb != expectedVerb {
 			return body, false, nil
@@ -496,12 +496,12 @@ func replaceOpenAIResponsesApprovalReply(body []byte, expectedVerb, expectedAppr
 			return body, false, nil
 		}
 		items[i]["content"] = []map[string]any{{"type": "input_text", "text": replacement}}
-		input, err := json.Marshal(items)
+		input, err := jsonsurgery.MarshalNoEscape(items)
 		if err != nil {
 			return nil, false, err
 		}
 		raw["input"] = input
-		out, err := json.Marshal(raw)
+		out, err := jsonsurgery.MarshalNoEscape(raw)
 		return out, err == nil, err
 	}
 	return body, false, nil
@@ -592,7 +592,7 @@ func augmentAnthropicApprovedInlineTasks(body []byte, outcomes InlineApprovalOut
 	if !changed {
 		return body, false, nil
 	}
-	newMsgsBytes, err := json.Marshal(newMessages)
+	newMsgsBytes, err := jsonsurgery.MarshalNoEscape(newMessages)
 	if err != nil {
 		return body, false, err
 	}
@@ -605,12 +605,12 @@ func augmentAnthropicApprovedInlineTasks(body []byte, outcomes InlineApprovalOut
 
 func augmentUserContent(content json.RawMessage, _ string, note string) (json.RawMessage, bool) {
 	if len(content) == 0 {
-		encoded, err := json.Marshal(note)
+		encoded, err := jsonsurgery.MarshalNoEscape(note)
 		return encoded, err == nil
 	}
 	var s string
 	if err := json.Unmarshal(content, &s); err == nil {
-		encoded, marshalErr := json.Marshal(note)
+		encoded, marshalErr := jsonsurgery.MarshalNoEscape(note)
 		return encoded, marshalErr == nil
 	}
 	var blocks []map[string]json.RawMessage
@@ -637,7 +637,7 @@ func augmentUserContent(content json.RawMessage, _ string, note string) (json.Ra
 			spliceAt = i
 		}
 		stripped := stripBareApprovalLines(text)
-		encoded, err := json.Marshal(stripped)
+		encoded, err := jsonsurgery.MarshalNoEscape(stripped)
 		if err != nil {
 			return nil, false
 		}
@@ -652,7 +652,7 @@ func augmentUserContent(content json.RawMessage, _ string, note string) (json.Ra
 	if spliceText != "" {
 		newSpliceText = spliceText + "\n\n" + note
 	}
-	encoded, err := json.Marshal(newSpliceText)
+	encoded, err := jsonsurgery.MarshalNoEscape(newSpliceText)
 	if err != nil {
 		return nil, false
 	}
@@ -670,7 +670,7 @@ func augmentUserContent(content json.RawMessage, _ string, note string) (json.Ra
 		kept = append(kept, blk)
 	}
 
-	out, err := json.Marshal(kept)
+	out, err := jsonsurgery.MarshalNoEscape(kept)
 	if err != nil {
 		return nil, false
 	}

--- a/internal/runtime/llmproxy/approval_body_editor.go
+++ b/internal/runtime/llmproxy/approval_body_editor.go
@@ -309,6 +309,13 @@ func buildReconstructedAssistantContent(original *InlineApprovalOriginalCall) (j
 // notice as its content. Other blocks survive unchanged. The pairing
 // keeps the assistant→user tool_use/tool_result invariant Anthropic
 // validates at request time.
+//
+// Any non-(type|tool_use_id|content) fields on the original block —
+// notably cache_control — survive the swap. The harness's deepest
+// prompt-cache breakpoint typically lands on this tool_result;
+// dropping it forces Anthropic to fall back to a system-level cache
+// that has proven not to hit in practice, busting ~15k cached tokens
+// on the immediate post-approval turn.
 func swapAnthropicToolResultForReconstructedPair(raw json.RawMessage, askToolUseID, reconstructedToolUseID, replacement string) (json.RawMessage, bool) {
 	if len(raw) == 0 || reconstructedToolUseID == "" {
 		return nil, false
@@ -319,21 +326,27 @@ func swapAnthropicToolResultForReconstructedPair(raw json.RawMessage, askToolUse
 	}
 	rewritten := false
 	for i, blk := range blocks {
-		var probe struct {
-			Type      string `json:"type"`
-			ToolUseID string `json:"tool_use_id"`
-		}
-		if err := json.Unmarshal(blk, &probe); err != nil {
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal(blk, &fields); err != nil {
 			continue
 		}
-		if probe.Type != "tool_result" || probe.ToolUseID != askToolUseID {
+		var typeStr, toolUseID string
+		_ = json.Unmarshal(fields["type"], &typeStr)
+		_ = json.Unmarshal(fields["tool_use_id"], &toolUseID)
+		if typeStr != "tool_result" || toolUseID != askToolUseID {
 			continue
 		}
-		newBlock, err := jsonsurgery.MarshalNoEscape(map[string]any{
-			"type":        "tool_result",
-			"tool_use_id": reconstructedToolUseID,
-			"content":     replacement,
-		})
+		newToolUseID, err := jsonsurgery.MarshalNoEscape(reconstructedToolUseID)
+		if err != nil {
+			continue
+		}
+		newContent, err := jsonsurgery.MarshalNoEscape(replacement)
+		if err != nil {
+			continue
+		}
+		fields["tool_use_id"] = newToolUseID
+		fields["content"] = newContent
+		newBlock, err := jsonsurgery.MarshalNoEscape(fields)
 		if err != nil {
 			continue
 		}
@@ -358,6 +371,10 @@ func swapAnthropicToolResultForReconstructedPair(raw json.RawMessage, askToolUse
 // keeps the next request's history valid after historystrip drops
 // the parent AskUserQuestion call — see
 // rewriteAnthropicAskUserQuestionApprovalReply for the rationale.
+//
+// Any cache_control field on the original block transfers to the
+// replacement text block — the harness's deepest cache breakpoint
+// often lands on this content and dropping it busts the prompt cache.
 func swapAnthropicToolResultForTextBlock(raw json.RawMessage, targetToolUseID, replacement string) (json.RawMessage, bool) {
 	if len(raw) == 0 {
 		return nil, false
@@ -368,17 +385,30 @@ func swapAnthropicToolResultForTextBlock(raw json.RawMessage, targetToolUseID, r
 	}
 	rewritten := false
 	for i, blk := range blocks {
-		var probe struct {
-			Type      string `json:"type"`
-			ToolUseID string `json:"tool_use_id"`
-		}
-		if err := json.Unmarshal(blk, &probe); err != nil {
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal(blk, &fields); err != nil {
 			continue
 		}
-		if probe.Type != "tool_result" || probe.ToolUseID != targetToolUseID {
+		var typeStr, toolUseID string
+		_ = json.Unmarshal(fields["type"], &typeStr)
+		_ = json.Unmarshal(fields["tool_use_id"], &toolUseID)
+		if typeStr != "tool_result" || toolUseID != targetToolUseID {
 			continue
 		}
-		textBlock := map[string]string{"type": "text", "text": replacement}
+		textBlock := map[string]json.RawMessage{}
+		newType, err := jsonsurgery.MarshalNoEscape("text")
+		if err != nil {
+			continue
+		}
+		newText, err := jsonsurgery.MarshalNoEscape(replacement)
+		if err != nil {
+			continue
+		}
+		textBlock["type"] = newType
+		textBlock["text"] = newText
+		if cc, ok := fields["cache_control"]; ok && len(cc) > 0 {
+			textBlock["cache_control"] = cc
+		}
 		newBlock, err := jsonsurgery.MarshalNoEscape(textBlock)
 		if err != nil {
 			continue

--- a/internal/runtime/llmproxy/approval_body_editor_test.go
+++ b/internal/runtime/llmproxy/approval_body_editor_test.go
@@ -453,6 +453,94 @@ func TestApprovalBodyEditorAskUserQuestionReconstructsOriginalCall(t *testing.T)
 	}
 }
 
+// TestApprovalBodyEditorPreservesCacheControlOnReconstruction pins the
+// cache-stability invariant for the one-shot rewrite path: when the
+// harness pinned its prompt-cache breakpoint on the AskUserQuestion
+// tool_result, the swap that pairs it against the reconstructed
+// tool_use_id must preserve cache_control on the new block. Dropping
+// it forces Anthropic to fall back to a system-level cache that
+// doesn't reliably hit, busting ~15k cached tokens on the immediate
+// post-approval turn (the failure mode raw-log diagnostic surfaced).
+func TestApprovalBodyEditorPreservesCacheControlOnReconstruction(t *testing.T) {
+	const approvalID = "cv-askuqcache001"
+	const askToolUseID = "toolu_clawvisor_ask_cv-askuqcache001"
+	const originalToolUseID = "toolu_01OriginalCacheCC"
+	body := `{"messages":[` +
+		`{"role":"user","content":"create the task"},` +
+		`{"role":"assistant","content":[` +
+		`{"type":"text","text":"Clawvisor wants to create a task to cover this work. [clawvisor:approval=` + approvalID + `]"},` +
+		`{"type":"tool_use","id":"` + askToolUseID + `","name":"AskUserQuestion","input":{"questions":[{"question":"approve? [clawvisor:approval=` + approvalID + `]","options":[{"label":"yes"},{"label":"no"}]}]}}` +
+		`]},` +
+		`{"role":"user","content":[` +
+		`{"type":"tool_result","tool_use_id":"` + askToolUseID + `","content":"yes","cache_control":{"type":"ephemeral","ttl":"1h"}}` +
+		`]}` +
+		`]}`
+	req := httptest.NewRequest("POST", "/v1/messages", nil)
+	editor, ok := newApprovalBodyEditor(req, conversation.ProviderAnthropic, []byte(body))
+	if !ok {
+		t.Fatal("expected anthropic body editor")
+	}
+	reconstruction := &InlineApprovalOriginalCall{
+		ToolUseID: originalToolUseID,
+		ToolName:  "Bash",
+		Input:     json.RawMessage(`{"command":"curl -X POST /api/control/tasks ..."}`),
+	}
+	out, rewrote, err := editor.ReplaceLatestUserText("approve", approvalID, "[clawvisor-notice] task created", reconstruction)
+	if err != nil {
+		t.Fatalf("ReplaceLatestUserText: %v", err)
+	}
+	if !rewrote {
+		t.Fatalf("expected rewrite to succeed; body: %s", out)
+	}
+
+	// Find the user turn's tool_result in the rewritten body and
+	// assert cache_control survived alongside the swapped tool_use_id.
+	var decoded struct {
+		Messages []struct {
+			Role    string          `json:"role"`
+			Content json.RawMessage `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(out, &decoded); err != nil {
+		t.Fatalf("parse rewritten body: %v", err)
+	}
+	// Last message is the user turn we mutated.
+	userMsg := decoded.Messages[len(decoded.Messages)-1]
+	if userMsg.Role != "user" {
+		t.Fatalf("expected last message to be user; got %q", userMsg.Role)
+	}
+	var blocks []json.RawMessage
+	if err := json.Unmarshal(userMsg.Content, &blocks); err != nil {
+		t.Fatalf("user content not block array: %v body=%s", err, userMsg.Content)
+	}
+	if len(blocks) == 0 {
+		t.Fatal("user content blocks empty")
+	}
+	var block struct {
+		Type         string         `json:"type"`
+		ToolUseID    string         `json:"tool_use_id"`
+		CacheControl map[string]any `json:"cache_control"`
+	}
+	if err := json.Unmarshal(blocks[0], &block); err != nil {
+		t.Fatalf("parse first block: %v", err)
+	}
+	if block.Type != "tool_result" {
+		t.Fatalf("type=%q want tool_result", block.Type)
+	}
+	if block.ToolUseID != originalToolUseID {
+		t.Fatalf("tool_use_id=%q want %q (reconstructed)", block.ToolUseID, originalToolUseID)
+	}
+	if block.CacheControl == nil {
+		t.Fatalf("cache_control dropped: %s", blocks[0])
+	}
+	if got, want := block.CacheControl["type"], "ephemeral"; got != want {
+		t.Errorf("cache_control.type=%v want %v", got, want)
+	}
+	if got, want := block.CacheControl["ttl"], "1h"; got != want {
+		t.Errorf("cache_control.ttl=%v want %v", got, want)
+	}
+}
+
 // TestApprovalBodyEditorReconstructionDenySkipped confirms the
 // rewrite path does NOT reconstruct on a deny — the model should
 // see the denial, not synthetic evidence of a successful call. The

--- a/internal/runtime/llmproxy/bodytransform/inbound_sanitize.go
+++ b/internal/runtime/llmproxy/bodytransform/inbound_sanitize.go
@@ -110,7 +110,7 @@ func sanitizeAnthropicInbound(req SanitizeInboundRequest) (SanitizeInboundResult
 	if !anyChanged {
 		return SanitizeInboundResult{Body: body}, nil
 	}
-	newMsgsBytes, err := json.Marshal(newMessages)
+	newMsgsBytes, err := jsonsurgery.MarshalNoEscape(newMessages)
 	if err != nil {
 		return SanitizeInboundResult{Body: body}, nil
 	}
@@ -170,7 +170,7 @@ func sanitizeAnthropicInboundMessage(msg json.RawMessage, req SanitizeInboundReq
 	if !anyChanged {
 		return msg, false
 	}
-	newContentBytes, err := json.Marshal(newBlocks)
+	newContentBytes, err := jsonsurgery.MarshalNoEscape(newBlocks)
 	if err != nil {
 		return msg, false
 	}
@@ -201,7 +201,7 @@ func sanitizeOpenAIInbound(req SanitizeInboundRequest) (SanitizeInboundResult, e
 	if !modified {
 		return SanitizeInboundResult{Body: req.Body}, nil
 	}
-	out, err := json.Marshal(raw)
+	out, err := jsonsurgery.MarshalNoEscape(raw)
 	if err != nil {
 		return SanitizeInboundResult{Body: req.Body}, nil
 	}
@@ -259,12 +259,12 @@ func sanitizeOpenAIChatMessages(messagesRaw json.RawMessage, req SanitizeInbound
 			if !mut {
 				continue
 			}
-			encoded, err := json.Marshal(sanitized)
+			encoded, err := jsonsurgery.MarshalNoEscape(sanitized)
 			if err != nil {
 				continue
 			}
 			fn["arguments"] = encoded
-			fnEncoded, err := json.Marshal(fn)
+			fnEncoded, err := jsonsurgery.MarshalNoEscape(fn)
 			if err != nil {
 				continue
 			}
@@ -272,7 +272,7 @@ func sanitizeOpenAIChatMessages(messagesRaw json.RawMessage, req SanitizeInbound
 			callsChanged = true
 		}
 		if callsChanged {
-			encoded, err := json.Marshal(calls)
+			encoded, err := jsonsurgery.MarshalNoEscape(calls)
 			if err == nil {
 				msg["tool_calls"] = encoded
 				changed = true
@@ -282,7 +282,7 @@ func sanitizeOpenAIChatMessages(messagesRaw json.RawMessage, req SanitizeInbound
 	if !changed {
 		return nil, false
 	}
-	out, err := json.Marshal(messages)
+	out, err := jsonsurgery.MarshalNoEscape(messages)
 	if err != nil {
 		return nil, false
 	}
@@ -323,7 +323,7 @@ func sanitizeOpenAIResponseInput(inputRaw json.RawMessage, req SanitizeInboundRe
 		if !mut {
 			continue
 		}
-		encoded, err := json.Marshal(sanitized)
+		encoded, err := jsonsurgery.MarshalNoEscape(sanitized)
 		if err != nil {
 			continue
 		}
@@ -337,7 +337,7 @@ func sanitizeOpenAIResponseInput(inputRaw json.RawMessage, req SanitizeInboundRe
 	if !changed {
 		return nil, false
 	}
-	out, err := json.Marshal(items)
+	out, err := jsonsurgery.MarshalNoEscape(items)
 	if err != nil {
 		return nil, false
 	}
@@ -388,7 +388,7 @@ func sanitizeToolUseInput(inputRaw json.RawMessage, req SanitizeInboundRequest) 
 	if !changed {
 		return inputRaw, false
 	}
-	out, err := json.Marshal(input)
+	out, err := jsonsurgery.MarshalNoEscape(input)
 	if err != nil {
 		return inputRaw, false
 	}

--- a/internal/runtime/llmproxy/continuation.go
+++ b/internal/runtime/llmproxy/continuation.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/jsonsurgery"
 )
 
 // ContinuationToolResult is one synthetic tool_result the proxy is
@@ -220,7 +221,7 @@ func buildOpenAIChatContinuationBody(
 		}
 		asstTurn["tool_calls"] = calls
 	}
-	asstRaw, err := json.Marshal(asstTurn)
+	asstRaw, err := jsonsurgery.MarshalNoEscape(asstTurn)
 	if err != nil {
 		return nil, fmt.Errorf("continuation: marshal chat assistant turn: %w", err)
 	}
@@ -239,19 +240,19 @@ func buildOpenAIChatContinuationBody(
 			"tool_call_id": tr.ToolUseID,
 			"content":      tr.Content,
 		}
-		raw, err := json.Marshal(toolRow)
+		raw, err := jsonsurgery.MarshalNoEscape(toolRow)
 		if err != nil {
 			return nil, fmt.Errorf("continuation: marshal chat tool row: %w", err)
 		}
 		messages = append(messages, raw)
 	}
 
-	mergedMessages, err := json.Marshal(messages)
+	mergedMessages, err := jsonsurgery.MarshalNoEscape(messages)
 	if err != nil {
 		return nil, fmt.Errorf("continuation: marshal merged chat messages: %w", err)
 	}
 	top["messages"] = mergedMessages
-	out, err := json.Marshal(top)
+	out, err := jsonsurgery.MarshalNoEscape(top)
 	if err != nil {
 		return nil, fmt.Errorf("continuation: marshal chat continuation body: %w", err)
 	}
@@ -286,7 +287,7 @@ func buildOpenAIResponsesContinuationBody(
 				{"type": "input_text", "text": asString},
 			},
 		}
-		raw, err := json.Marshal(promoted)
+		raw, err := jsonsurgery.MarshalNoEscape(promoted)
 		if err != nil {
 			return nil, fmt.Errorf("continuation: promote string input: %w", err)
 		}
@@ -315,19 +316,19 @@ func buildOpenAIResponsesContinuationBody(
 			"call_id": tr.ToolUseID,
 			"output":  tr.Content,
 		}
-		raw, err := json.Marshal(fco)
+		raw, err := jsonsurgery.MarshalNoEscape(fco)
 		if err != nil {
 			return nil, fmt.Errorf("continuation: marshal function_call_output: %w", err)
 		}
 		inputItems = append(inputItems, raw)
 	}
 
-	mergedInput, err := json.Marshal(inputItems)
+	mergedInput, err := jsonsurgery.MarshalNoEscape(inputItems)
 	if err != nil {
 		return nil, fmt.Errorf("continuation: marshal merged input: %w", err)
 	}
 	top["input"] = mergedInput
-	out, err := json.Marshal(top)
+	out, err := jsonsurgery.MarshalNoEscape(top)
 	if err != nil {
 		return nil, fmt.Errorf("continuation: marshal responses continuation body: %w", err)
 	}
@@ -363,7 +364,7 @@ func buildAnthropicContinuationBody(
 		"role":    "assistant",
 		"content": assistantContent,
 	}
-	assistantRaw, err := json.Marshal(assistantTurn)
+	assistantRaw, err := jsonsurgery.MarshalNoEscape(assistantTurn)
 	if err != nil {
 		return nil, fmt.Errorf("continuation: marshal assistant turn: %w", err)
 	}
@@ -386,18 +387,18 @@ func buildAnthropicContinuationBody(
 		"role":    "user",
 		"content": userContent,
 	}
-	userRaw, err := json.Marshal(userTurn)
+	userRaw, err := jsonsurgery.MarshalNoEscape(userTurn)
 	if err != nil {
 		return nil, fmt.Errorf("continuation: marshal user turn: %w", err)
 	}
 
 	messages = append(messages, json.RawMessage(assistantRaw), json.RawMessage(userRaw))
-	mergedMessages, err := json.Marshal(messages)
+	mergedMessages, err := jsonsurgery.MarshalNoEscape(messages)
 	if err != nil {
 		return nil, fmt.Errorf("continuation: marshal merged messages: %w", err)
 	}
 	top["messages"] = mergedMessages
-	out, err := json.Marshal(top)
+	out, err := jsonsurgery.MarshalNoEscape(top)
 	if err != nil {
 		return nil, fmt.Errorf("continuation: marshal continuation body: %w", err)
 	}

--- a/internal/runtime/llmproxy/controltool/control.go
+++ b/internal/runtime/llmproxy/controltool/control.go
@@ -539,31 +539,31 @@ func injectAnthropicControlNotice(body []byte, notice string) ([]byte, bool, err
 	// blocks across turns).
 	sysStart, sysEnd, present := jsonsurgery.FindFieldValue(body, "system")
 	if !present {
-		encoded, _ := json.Marshal(notice)
+		encoded, _ := jsonsurgery.MarshalNoEscape(notice)
 		out, err := jsonsurgery.SetField(body, "system", encoded)
 		return out, err == nil, err
 	}
 	sys := body[sysStart:sysEnd]
 	if string(jsonsurgery.TrimWS(sys)) == "null" {
-		encoded, _ := json.Marshal(notice)
+		encoded, _ := jsonsurgery.MarshalNoEscape(notice)
 		out, err := jsonsurgery.SetField(body, "system", encoded)
 		return out, err == nil, err
 	}
 	var s string
 	if err := json.Unmarshal(sys, &s); err == nil {
-		encoded, _ := json.Marshal(appendNotice(s, notice))
+		encoded, _ := jsonsurgery.MarshalNoEscape(appendNotice(s, notice))
 		out, err := jsonsurgery.SetField(body, "system", encoded)
 		return out, err == nil, err
 	}
 	// System is a content-blocks array. Append a text block to it.
 	// Preserve existing blocks' bytes via []json.RawMessage round-trip.
 	if elems, ok := jsonsurgery.FlattenArray(sys); ok {
-		newBlock, err := json.Marshal(map[string]any{"type": "text", "text": notice})
+		newBlock, err := jsonsurgery.MarshalNoEscape(map[string]any{"type": "text", "text": notice})
 		if err != nil {
 			return nil, false, err
 		}
 		elems = append(elems, json.RawMessage(newBlock))
-		encoded, err := json.Marshal(elems)
+		encoded, err := jsonsurgery.MarshalNoEscape(elems)
 		if err != nil {
 			return nil, false, err
 		}
@@ -589,17 +589,17 @@ func injectOpenAIControlNotice(body []byte, notice string) ([]byte, bool, error)
 		if err := json.Unmarshal(instr, &s); err != nil {
 			return body, false, nil
 		}
-		encoded, _ := json.Marshal(appendNotice(s, notice))
+		encoded, _ := jsonsurgery.MarshalNoEscape(appendNotice(s, notice))
 		raw["instructions"] = encoded
 		return marshalInjected(raw)
 	}
-	encoded, _ := json.Marshal(notice)
+	encoded, _ := jsonsurgery.MarshalNoEscape(notice)
 	raw["instructions"] = encoded
 	return marshalInjected(raw)
 }
 
 func marshalInjected(v any) ([]byte, bool, error) {
-	out, err := json.Marshal(v)
+	out, err := jsonsurgery.MarshalNoEscape(v)
 	return out, err == nil, err
 }
 
@@ -616,13 +616,13 @@ func injectOpenAIMessages(raw json.RawMessage, notice string) (json.RawMessage, 
 		if role == "system" || role == "developer" {
 			if s, ok := messages[0]["content"].(string); ok {
 				messages[0]["content"] = appendNotice(s, notice)
-				out, err := json.Marshal(messages)
+				out, err := jsonsurgery.MarshalNoEscape(messages)
 				return out, true, err
 			}
 		}
 	}
 	messages = append([]map[string]any{{"role": "system", "content": notice}}, messages...)
-	out, err := json.Marshal(messages)
+	out, err := jsonsurgery.MarshalNoEscape(messages)
 	return out, true, err
 }
 
@@ -688,7 +688,7 @@ func rewriteControlCommandToolUse(t conversation.ToolUse, v inspector.Verdict, o
 	// model cargo-cult a small value back, so clamp here. Harmless on
 	// Bash (Claude Code has no such parameter).
 	clampControlToolUseTimeouts(raw, t.Name)
-	out, err := json.Marshal(raw)
+	out, err := jsonsurgery.MarshalNoEscape(raw)
 	return out, true, err
 }
 
@@ -732,7 +732,7 @@ func rewriteControlStructuredToolUse(t conversation.ToolUse, opts inspector.Rewr
 	}
 	raw["headers"] = headers
 
-	out, err := json.Marshal(raw)
+	out, err := jsonsurgery.MarshalNoEscape(raw)
 	return out, true, err
 }
 
@@ -763,7 +763,7 @@ func RewriteControlFailureToolUse(t conversation.ToolUse, controlBaseURL string,
 	}
 	q.Set("reason", reason)
 	u.RawQuery = q.Encode()
-	body, err := json.Marshal(map[string]string{
+	body, err := jsonsurgery.MarshalNoEscape(map[string]string{
 		"original_tool":    t.Name,
 		"original_command": sanitizeControlFailureCommand(original),
 	})
@@ -781,7 +781,7 @@ func RewriteControlFailureToolUse(t conversation.ToolUse, controlBaseURL string,
 		shellQuote(u.String()),
 	}, " ")
 	clampControlToolUseTimeouts(raw, t.Name)
-	out, err := json.Marshal(raw)
+	out, err := jsonsurgery.MarshalNoEscape(raw)
 	return out, true, err
 }
 

--- a/internal/runtime/llmproxy/controltool/control_multistmt_test.go
+++ b/internal/runtime/llmproxy/controltool/control_multistmt_test.go
@@ -162,10 +162,11 @@ func TestRewriteControlToolUse_RewritesMultiStmtCatHeredocPlusCurl(t *testing.T)
 		t.Fatalf("expected control rewrite for multi-stmt cat+curl; ok=%v rewritten=%s", ok, rewritten)
 	}
 	// The cat heredoc must still be present (we didn't strip the body),
-	// and the URL must be rewritten to the resolver host. The output
-	// is JSON-encoded so `<<` is escaped as `<<`.
+	// and the URL must be rewritten to the resolver host. Proxy
+	// marshalling has HTML escaping off so `<<` is the literal two
+	// bytes (busting the cache otherwise — see jsonpatch.MarshalNoEscape).
 	out := string(rewritten)
-	if !strings.Contains(out, "cat \\u003c\\u003c") {
+	if !strings.Contains(out, "cat <<") {
 		t.Errorf("rewrite dropped the cat heredoc: %s", out)
 	}
 	if !strings.Contains(out, `https://control.example/api/control/tasks`) {

--- a/internal/runtime/llmproxy/historystrip/secret_decision_history.go
+++ b/internal/runtime/llmproxy/historystrip/secret_decision_history.go
@@ -51,7 +51,7 @@ func stripAnthropicSecretDecisionHistory(body []byte) (SecretDecisionHistoryStri
 	if !modified {
 		return SecretDecisionHistoryStripResult{Body: body}, nil
 	}
-	encoded, err := json.Marshal(out)
+	encoded, err := jsonsurgery.MarshalNoEscape(out)
 	if err != nil {
 		return SecretDecisionHistoryStripResult{Body: body}, err
 	}
@@ -78,7 +78,7 @@ func stripOpenAISecretDecisionHistory(body []byte) (SecretDecisionHistoryStripRe
 				return role, flattenOpenAITaskReplyContent(rawContent)
 			})
 			if changed {
-				encoded, err := json.Marshal(out)
+				encoded, err := jsonsurgery.MarshalNoEscape(out)
 				if err != nil {
 					return SecretDecisionHistoryStripResult{Body: body}, err
 				}
@@ -97,7 +97,7 @@ func stripOpenAISecretDecisionHistory(body []byte) (SecretDecisionHistoryStripRe
 				return role, flattenOpenAITaskReplyContent(rawContent)
 			})
 			if changed {
-				encoded, err := json.Marshal(out)
+				encoded, err := jsonsurgery.MarshalNoEscape(out)
 				if err != nil {
 					return SecretDecisionHistoryStripResult{Body: body}, err
 				}
@@ -109,7 +109,7 @@ func stripOpenAISecretDecisionHistory(body []byte) (SecretDecisionHistoryStripRe
 	if !modified {
 		return SecretDecisionHistoryStripResult{Body: body}, nil
 	}
-	out, err := json.Marshal(raw)
+	out, err := jsonsurgery.MarshalNoEscape(raw)
 	if err != nil {
 		return SecretDecisionHistoryStripResult{Body: body}, err
 	}

--- a/internal/runtime/llmproxy/historystrip/synthetic_history_strip.go
+++ b/internal/runtime/llmproxy/historystrip/synthetic_history_strip.go
@@ -467,24 +467,30 @@ func wrapUserContentAsToolResult(raw json.RawMessage, rec *ReconstructedPair) (j
 	}
 	noticeIdx := -1
 	var noticeText string
+	var noticeCacheControl json.RawMessage
 	for i, blk := range blocks {
-		var probe struct {
-			Type      string `json:"type"`
-			Text      string `json:"text"`
-			ToolUseID string `json:"tool_use_id"`
-		}
-		if err := json.Unmarshal(blk, &probe); err != nil {
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal(blk, &fields); err != nil {
 			return raw, false, nil
 		}
-		switch probe.Type {
+		var typeStr, textStr string
+		_ = json.Unmarshal(fields["type"], &typeStr)
+		_ = json.Unmarshal(fields["text"], &textStr)
+		switch typeStr {
 		case "tool_result":
 			// Existing tool_result block — leave the message
 			// alone rather than risk a double-wrap.
 			return raw, false, nil
 		case "text":
-			if noticeIdx < 0 && ContainsInlineApprovalAugmentationMarker(probe.Text) {
+			if noticeIdx < 0 && ContainsInlineApprovalAugmentationMarker(textStr) {
 				noticeIdx = i
-				noticeText = probe.Text
+				noticeText = textStr
+				// Preserve cache_control if the harness pinned
+				// its breakpoint on the notice block (rare here
+				// but matches the tool_result path's invariant).
+				if cc, ok := fields["cache_control"]; ok && len(cc) > 0 {
+					noticeCacheControl = cc
+				}
 			}
 		default:
 			// Non-text, non-tool_result block (tool_use, image,
@@ -498,11 +504,15 @@ func wrapUserContentAsToolResult(raw json.RawMessage, rec *ReconstructedPair) (j
 		// block belongs in the tool_result. Skip rather than guess.
 		return raw, false, nil
 	}
-	toolResultBlock, err := jsonsurgery.MarshalNoEscape(map[string]any{
+	toolResultFields := map[string]any{
 		"type":        "tool_result",
 		"tool_use_id": rec.ToolUseID,
 		"content":     noticeText,
-	})
+	}
+	if len(noticeCacheControl) > 0 {
+		toolResultFields["cache_control"] = noticeCacheControl
+	}
+	toolResultBlock, err := jsonsurgery.MarshalNoEscape(toolResultFields)
 	if err != nil {
 		return raw, false, err
 	}
@@ -528,6 +538,13 @@ func wrapUserContentAsToolResult(raw json.RawMessage, rec *ReconstructedPair) (j
 // stripped synthetic ids with a tool_result paired to the
 // reconstructed tool_use_id (carrying the reconstruction's
 // ResultText as content). Other blocks pass through unchanged.
+//
+// Any non-(type|tool_use_id|content) fields on the original block —
+// notably cache_control — survive the swap. The harness's deepest
+// prompt-cache breakpoint lands on this tool_result; dropping it
+// forces Anthropic to fall back to a system-level cache that has
+// proven not to hit in practice, busting ~15k cached tokens on every
+// approval turn.
 func replaceToolResultsForReconstruction(raw json.RawMessage, orphans map[string]struct{}, rec *ReconstructedPair) (json.RawMessage, bool, error) {
 	if len(raw) == 0 || rec == nil || rec.ToolUseID == "" {
 		return raw, false, nil
@@ -538,24 +555,30 @@ func replaceToolResultsForReconstruction(raw json.RawMessage, orphans map[string
 	}
 	changed := false
 	for i, blk := range blocks {
-		var probe struct {
-			Type      string `json:"type"`
-			ToolUseID string `json:"tool_use_id"`
-		}
-		if err := json.Unmarshal(blk, &probe); err != nil {
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal(blk, &fields); err != nil {
 			continue
 		}
-		if probe.Type != "tool_result" {
+		var typeStr, toolUseID string
+		_ = json.Unmarshal(fields["type"], &typeStr)
+		_ = json.Unmarshal(fields["tool_use_id"], &toolUseID)
+		if typeStr != "tool_result" {
 			continue
 		}
-		if _, ok := orphans[probe.ToolUseID]; !ok {
+		if _, ok := orphans[toolUseID]; !ok {
 			continue
 		}
-		newBlock, err := jsonsurgery.MarshalNoEscape(map[string]any{
-			"type":        "tool_result",
-			"tool_use_id": rec.ToolUseID,
-			"content":     rec.ResultText,
-		})
+		newToolUseID, err := jsonsurgery.MarshalNoEscape(rec.ToolUseID)
+		if err != nil {
+			continue
+		}
+		newContent, err := jsonsurgery.MarshalNoEscape(rec.ResultText)
+		if err != nil {
+			continue
+		}
+		fields["tool_use_id"] = newToolUseID
+		fields["content"] = newContent
+		newBlock, err := jsonsurgery.MarshalNoEscape(fields)
 		if err != nil {
 			continue
 		}

--- a/internal/runtime/llmproxy/historystrip/synthetic_history_strip.go
+++ b/internal/runtime/llmproxy/historystrip/synthetic_history_strip.go
@@ -282,7 +282,7 @@ func stripAnthropicSyntheticApprovalHistory(body []byte, lookup ReconstructionLo
 		merged = append(merged, msg)
 	}
 
-	newMsgsBytes, err := json.Marshal(merged)
+	newMsgsBytes, err := jsonsurgery.MarshalNoEscape(merged)
 	if err != nil {
 		return SyntheticApprovalHistoryStripResult{Body: body}, err
 	}
@@ -336,7 +336,7 @@ func mergeAnthropicContent(c1, c2 json.RawMessage) (json.RawMessage, error) {
 
 	if err1 == nil && err2 == nil {
 		merged := s1 + "\n\n" + s2
-		return json.Marshal(merged)
+		return jsonsurgery.MarshalNoEscape(merged)
 	}
 	if err1 != nil && err2 == nil {
 		var blocks1 []json.RawMessage
@@ -344,7 +344,7 @@ func mergeAnthropicContent(c1, c2 json.RawMessage) (json.RawMessage, error) {
 			return nil, err
 		}
 		blocks1 = append(blocks1, anthropicTextBlockRaw(s2))
-		return json.Marshal(blocks1)
+		return jsonsurgery.MarshalNoEscape(blocks1)
 	}
 	if err1 == nil && err2 != nil {
 		var blocks2 []json.RawMessage
@@ -354,7 +354,7 @@ func mergeAnthropicContent(c1, c2 json.RawMessage) (json.RawMessage, error) {
 		// Use append-from-literal to sidestep CodeQL's
 		// allocation-size-overflow warning on `len(blocks2)+1`.
 		out := append([]json.RawMessage{anthropicTextBlockRaw(s1)}, blocks2...)
-		return json.Marshal(out)
+		return jsonsurgery.MarshalNoEscape(out)
 	}
 
 	var blocks1 []json.RawMessage
@@ -368,11 +368,11 @@ func mergeAnthropicContent(c1, c2 json.RawMessage) (json.RawMessage, error) {
 	}
 
 	mergedBlocks := append(blocks1, blocks2...)
-	return json.Marshal(mergedBlocks)
+	return jsonsurgery.MarshalNoEscape(mergedBlocks)
 }
 
 func anthropicTextBlockRaw(text string) json.RawMessage {
-	block, _ := json.Marshal(map[string]string{
+	block, _ := jsonsurgery.MarshalNoEscape(map[string]string{
 		"type": "text",
 		"text": text,
 	})
@@ -406,7 +406,7 @@ func buildReconstructedAssistantBlock(rec *ReconstructedPair) (json.RawMessage, 
 		"name":  rec.ToolName,
 		"input": rec.Input,
 	}
-	raw, err := json.Marshal([]any{block})
+	raw, err := jsonsurgery.MarshalNoEscape([]any{block})
 	if err != nil {
 		return nil, false
 	}
@@ -444,7 +444,7 @@ func wrapUserContentAsToolResult(raw json.RawMessage, rec *ReconstructedPair) (j
 	// string as the tool_result's content.
 	var simple string
 	if err := json.Unmarshal(raw, &simple); err == nil {
-		block, err := json.Marshal(map[string]any{
+		block, err := jsonsurgery.MarshalNoEscape(map[string]any{
 			"type":        "tool_result",
 			"tool_use_id": rec.ToolUseID,
 			"content":     simple,
@@ -452,7 +452,7 @@ func wrapUserContentAsToolResult(raw json.RawMessage, rec *ReconstructedPair) (j
 		if err != nil {
 			return raw, false, err
 		}
-		out, err := json.Marshal([]json.RawMessage{block})
+		out, err := jsonsurgery.MarshalNoEscape([]json.RawMessage{block})
 		if err != nil {
 			return raw, false, err
 		}
@@ -498,7 +498,7 @@ func wrapUserContentAsToolResult(raw json.RawMessage, rec *ReconstructedPair) (j
 		// block belongs in the tool_result. Skip rather than guess.
 		return raw, false, nil
 	}
-	toolResultBlock, err := json.Marshal(map[string]any{
+	toolResultBlock, err := jsonsurgery.MarshalNoEscape(map[string]any{
 		"type":        "tool_result",
 		"tool_use_id": rec.ToolUseID,
 		"content":     noticeText,
@@ -516,7 +516,7 @@ func wrapUserContentAsToolResult(raw json.RawMessage, rec *ReconstructedPair) (j
 		}
 		newBlocks = append(newBlocks, blk)
 	}
-	out, err := json.Marshal(newBlocks)
+	out, err := jsonsurgery.MarshalNoEscape(newBlocks)
 	if err != nil {
 		return raw, false, err
 	}
@@ -551,7 +551,7 @@ func replaceToolResultsForReconstruction(raw json.RawMessage, orphans map[string
 		if _, ok := orphans[probe.ToolUseID]; !ok {
 			continue
 		}
-		newBlock, err := json.Marshal(map[string]any{
+		newBlock, err := jsonsurgery.MarshalNoEscape(map[string]any{
 			"type":        "tool_result",
 			"tool_use_id": rec.ToolUseID,
 			"content":     rec.ResultText,
@@ -565,7 +565,7 @@ func replaceToolResultsForReconstruction(raw json.RawMessage, orphans map[string
 	if !changed {
 		return raw, false, nil
 	}
-	out, err := json.Marshal(blocks)
+	out, err := jsonsurgery.MarshalNoEscape(blocks)
 	if err != nil {
 		return raw, false, err
 	}
@@ -671,7 +671,7 @@ func stripToolResultsByID(content json.RawMessage, orphans map[string]struct{}) 
 	if dropped {
 		return nil, true, true, nil
 	}
-	out, err := json.Marshal(kept)
+	out, err := jsonsurgery.MarshalNoEscape(kept)
 	if err != nil {
 		return nil, false, false, err
 	}

--- a/internal/runtime/llmproxy/inline_task_augment_test.go
+++ b/internal/runtime/llmproxy/inline_task_augment_test.go
@@ -7,16 +7,16 @@ import (
 	"time"
 
 	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+	"github.com/clawvisor/clawvisor/internal/runtime/jsonpatch"
 )
 
 // inlineTaskNoticeOpenPrefixJSON is the JSON-encoded form of
-// inlineTaskNoticeOpenPrefix. Go's json.Marshal has HTML-escape on by
-// default, so `<` becomes the six-byte sequence backslash-u-0-0-3-c
-// and `"` becomes backslash-quote. Tests that assert substrings on
-// the raw JSON-marshalled request body compare against this; tests
-// that operate on already-decoded content use the raw prefix.
+// inlineTaskNoticeOpenPrefix as it appears in an outbound proxy body.
+// The proxy uses jsonpatch.MarshalNoEscape (HTML escape off) so `<`
+// stays a literal byte; `"` still escapes to backslash-quote because
+// that's structural to JSON strings.
 var inlineTaskNoticeOpenPrefixJSON = func() string {
-	enc, err := json.Marshal(inlineTaskNoticeOpenPrefix)
+	enc, err := jsonpatch.MarshalNoEscape(inlineTaskNoticeOpenPrefix)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/runtime/llmproxy/inline_task_intercept.go
+++ b/internal/runtime/llmproxy/inline_task_intercept.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/controltool"
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/jsonsurgery"
 	runtimepolicy "github.com/clawvisor/clawvisor/internal/runtime/policy"
 	runtimetasks "github.com/clawvisor/clawvisor/internal/runtime/tasks"
 	"github.com/clawvisor/clawvisor/internal/taskrisk"
@@ -281,7 +282,7 @@ func MaybeInterceptInlineTaskDefinition(
 					"reason", reason,
 				)
 				augmentation := inlineApprovedReplyAugmentationContext(created.ID, checkedOut, created.Credentials)
-				continuationPayload, _ := json.Marshal(augmentation)
+				continuationPayload, _ := jsonsurgery.MarshalNoEscape(augmentation)
 				return conversation.ToolUseVerdict{
 					Allowed: false,
 					Reason:  "Clawvisor: auto-approved from conversation context",

--- a/internal/runtime/llmproxy/inspector/rewriter.go
+++ b/internal/runtime/llmproxy/inspector/rewriter.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+
+	"github.com/clawvisor/clawvisor/internal/runtime/jsonpatch"
 )
 
 // RewriteOpts controls how Rewrite produces the redirected tool_use input.
@@ -135,7 +137,7 @@ func rewriteStructured(t ToolUse, _ Verdict, resolver *url.URL, opts RewriteOpts
 	}
 	raw["headers"] = headers
 
-	out, err := json.Marshal(raw)
+	out, err := jsonpatch.MarshalNoEscape(raw)
 	if err != nil {
 		return nil, true, err
 	}
@@ -249,7 +251,7 @@ func rewriteBash(t ToolUse, v Verdict, resolver *url.URL, opts RewriteOpts) ([]b
 	// preserving everything outside the credentialed sub-command
 	// (pipes, redirects, neighboring simple commands).
 	raw[cmdField] = cmdVal[:seg.start] + rewrittenSegment + cmdVal[seg.end:]
-	out, err := json.Marshal(raw)
+	out, err := jsonpatch.MarshalNoEscape(raw)
 	if err != nil {
 		return nil, true, err
 	}

--- a/internal/runtime/llmproxy/jsonsurgery/json_surgery.go
+++ b/internal/runtime/llmproxy/jsonsurgery/json_surgery.go
@@ -53,3 +53,11 @@ func LooksLikeString(data []byte) bool {
 func TrimWS(data []byte) []byte {
 	return jsonpatch.TrimWS(data)
 }
+
+// MarshalNoEscape is json.Marshal without HTML escaping of `<`, `>`, `&`.
+// Use this for any bytes that land in an outbound LLM request body so the
+// proxy's mutations don't flip literal angle brackets into `\uXXXX` and
+// bust Anthropic's prompt cache.
+func MarshalNoEscape(v any) ([]byte, error) {
+	return jsonpatch.MarshalNoEscape(v)
+}

--- a/internal/runtime/llmproxy/pipeline/policy.go
+++ b/internal/runtime/llmproxy/pipeline/policy.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+	"github.com/clawvisor/clawvisor/internal/runtime/jsonpatch"
 )
 
 // Outcome aliases conversation.Outcome so pipeline code can keep using
@@ -157,7 +158,7 @@ type ContinueSignal = conversation.ContinueSignal
 // continuation" and fall back to SubstituteWith if they were
 // pairing the two).
 func NewTextContinuation(text string) *ContinueSignal {
-	payload, err := json.Marshal(text)
+	payload, err := jsonpatch.MarshalNoEscape(text)
 	if err != nil {
 		return nil
 	}

--- a/internal/runtime/llmproxy/policies/control_notice.go
+++ b/internal/runtime/llmproxy/policies/control_notice.go
@@ -50,7 +50,15 @@ type ToolRulesLoader func(ctx context.Context, userID, agentID string) []*store.
 // fine and renders the empty-state copy. Returns "" on best-effort
 // error so notice injection remains non-fatal — the agent just falls
 // back to GET /control/tasks if it cares about live state.
-type ActiveTasksSnapshotLoader func(ctx context.Context, userID, agentID string) string
+//
+// The conversationID is the scope for caching the rendered snapshot.
+// The control-notice is injected fresh on every request (the harness
+// never carries the proxy-injected system blocks back), so the loader
+// must freeze its output per-conversation itself or Anthropic's
+// prompt cache invalidates ~15k tokens whenever the task list shifts
+// (a new task created, a stale one expired). Snapshot content lives
+// above the cache breakpoints in the system prompt.
+type ActiveTasksSnapshotLoader func(ctx context.Context, userID, agentID, conversationID string) string
 
 // NewControlNotice constructs the policy. controlBaseURL "" skips.
 // availableTools and loadToolRules nil → Skip on every request. The
@@ -61,9 +69,11 @@ func NewControlNotice(controlBaseURL string, availableTools AvailableToolsFn, lo
 }
 
 // NewControlNoticeWithSnapshot is the snapshot-aware constructor. The
-// snapshot loader runs once on first-turn injection (the existing
-// sentinel-based dedup in InjectControlNoticeWithSnapshot keeps the
-// snapshot frozen for cache stability on later turns).
+// loader runs once per turn (the harness never carries the proxy-
+// injected system blocks back, so the sentinel-based dedup further
+// down only short-circuits within a single request, not across them).
+// The loader itself is responsible for freezing the snapshot per
+// conversationID — see internal/runtime/llmproxy.ActiveTasksSnapshotCache.
 func NewControlNoticeWithSnapshot(controlBaseURL string, availableTools AvailableToolsFn, loadToolRules ToolRulesLoader, loadActiveTasks ActiveTasksSnapshotLoader) *ControlNotice {
 	return &ControlNotice{
 		controlBaseURL:  controlBaseURL,
@@ -105,7 +115,7 @@ func (p *ControlNotice) Preprocess(ctx context.Context, req pipeline.ReadOnlyReq
 
 	var activeTasks string
 	if p.loadActiveTasks != nil {
-		activeTasks = p.loadActiveTasks(ctx, req.UserID(), req.AgentID())
+		activeTasks = p.loadActiveTasks(ctx, req.UserID(), req.AgentID(), req.ConversationID())
 	}
 
 	injected, modified, err := controltool.InjectControlNoticeWithSnapshot(req.Provider(), req.RawBody(), p.controlBaseURL, tools, rules, activeTasks)

--- a/internal/runtime/llmproxy/policies/control_notice_test.go
+++ b/internal/runtime/llmproxy/policies/control_notice_test.go
@@ -94,7 +94,7 @@ func TestControlNotice_EarlyExitWhenNoticeAlreadyPresent(t *testing.T) {
 		return nil
 	}
 	activeTasksCalls := 0
-	loadActiveTasks := func(_ context.Context, _, _ string) string {
+	loadActiveTasks := func(_ context.Context, _, _, _ string) string {
 		activeTasksCalls++
 		return "  - 00000000 · purpose=\"stale\" · lifetime=standing · expires=never"
 	}

--- a/internal/runtime/llmproxy/secret_detection.go
+++ b/internal/runtime/llmproxy/secret_detection.go
@@ -17,6 +17,7 @@ import (
 
 	runtimeautovault "github.com/clawvisor/clawvisor/internal/runtime/autovault"
 	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/jsonsurgery"
 )
 
 type InboundSecretFinding struct {
@@ -255,7 +256,7 @@ func ScanInboundSecretsWithOptions(ctx context.Context, opts InboundSecretScanOp
 	}
 	encoded := body
 	if changed {
-		out, err := json.Marshal(rewritten)
+		out, err := jsonsurgery.MarshalNoEscape(rewritten)
 		if err != nil {
 			return InboundSecretScanResult{}, false, err
 		}

--- a/internal/runtime/llmproxy/synthetic_history_strip_test.go
+++ b/internal/runtime/llmproxy/synthetic_history_strip_test.go
@@ -207,6 +207,116 @@ func TestStripSyntheticApprovalHistory_PreservesReconstructedTurns(t *testing.T)
 	}
 }
 
+// TestStripSyntheticApprovalHistory_PreservesCacheControlOnSwap pins
+// the cache-stability invariant: when the strip rewrites the user
+// turn's tool_result block to pair with the reconstructed
+// tool_use_id, any cache_control attribute the harness placed on the
+// original block survives the rewrite.
+//
+// Anthropic's prompt cache is keyed by breakpoint position; the
+// harness's deepest breakpoint sits on the most recent user
+// tool_result. Dropping cache_control here forces Anthropic to fall
+// back to a system-level cache that doesn't reliably hit, busting
+// ~15k cached tokens on the immediate post-approval turn.
+func TestStripSyntheticApprovalHistory_PreservesCacheControlOnSwap(t *testing.T) {
+	const approvalID = "cv-cacheswap1"
+	const askToolUseID = "toolu_clawvisor_ask_" + approvalID
+	const originalToolUseID = "toolu_01OriginalSwap"
+	body, err := json.Marshal(map[string]any{
+		"model": "claude-haiku-4-5",
+		"messages": []map[string]any{
+			{"role": "user", "content": "expand the task"},
+			{"role": "assistant", "content": []map[string]any{
+				{"type": "text", "text": "Clawvisor wants to expand the scope of an existing task:\n[clawvisor:approval=" + approvalID + "]"},
+				{"type": "tool_use", "id": askToolUseID, "name": "AskUserQuestion", "input": map[string]any{
+					"questions": []map[string]any{{"question": "approve?"}},
+				}},
+			}},
+			{"role": "user", "content": []map[string]any{
+				{
+					"type":          "tool_result",
+					"tool_use_id":   askToolUseID,
+					"content":       "yes",
+					"cache_control": map[string]any{"type": "ephemeral", "ttl": "1h"},
+				},
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	lookup := func(id string) *historystrip.ReconstructedPair {
+		if id != approvalID {
+			return nil
+		}
+		return &historystrip.ReconstructedPair{
+			ToolUseID:  originalToolUseID,
+			ToolName:   "Bash",
+			Input:      json.RawMessage(`{"command":"curl -X POST .../expand?surface=inline ..."}`),
+			ResultText: "[clawvisor-notice] scope was expanded; do not re-emit",
+		}
+	}
+	out, err := StripSyntheticApprovalHistory(SyntheticApprovalHistoryStripRequest{
+		Provider:             conversation.ProviderAnthropic,
+		Body:                 body,
+		ReconstructionLookup: lookup,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !out.Modified {
+		t.Fatalf("strip should rewrite the body for reconstruction")
+	}
+	// Parse the rewritten user message and confirm the new tool_result
+	// block carries cache_control with the same TTL the harness set.
+	var parsed struct {
+		Messages []struct {
+			Role    string          `json:"role"`
+			Content json.RawMessage `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(out.Body, &parsed); err != nil {
+		t.Fatalf("parse rewritten body: %v", err)
+	}
+	if n := len(parsed.Messages); n < 3 {
+		t.Fatalf("expected >=3 messages, got %d", n)
+	}
+	userMsg := parsed.Messages[2]
+	if userMsg.Role != "user" {
+		t.Fatalf("messages[2] role=%q want user", userMsg.Role)
+	}
+	var contentBlocks []json.RawMessage
+	if err := json.Unmarshal(userMsg.Content, &contentBlocks); err != nil {
+		t.Fatalf("user content not a block array: %v body=%s", err, userMsg.Content)
+	}
+	if len(contentBlocks) == 0 {
+		t.Fatal("user content blocks is empty")
+	}
+	var block struct {
+		Type         string         `json:"type"`
+		ToolUseID    string         `json:"tool_use_id"`
+		CacheControl map[string]any `json:"cache_control"`
+	}
+	if err := json.Unmarshal(contentBlocks[0], &block); err != nil {
+		t.Fatalf("parse user tool_result: %v", err)
+	}
+	if block.Type != "tool_result" {
+		t.Fatalf("type=%q want tool_result", block.Type)
+	}
+	if block.ToolUseID != originalToolUseID {
+		t.Fatalf("tool_use_id=%q want %q (reconstructed)", block.ToolUseID, originalToolUseID)
+	}
+	if block.CacheControl == nil {
+		t.Fatalf("cache_control dropped: %s", contentBlocks[0])
+	}
+	if got, want := block.CacheControl["type"], "ephemeral"; got != want {
+		t.Errorf("cache_control.type=%v want %v", got, want)
+	}
+	if got, want := block.CacheControl["ttl"], "1h"; got != want {
+		t.Errorf("cache_control.ttl=%v want %v", got, want)
+	}
+}
+
 // TestStripSyntheticApprovalHistory_ReconstructsViaLookup pins
 // the persistent-reconstruction contract: on every turn after the
 // approval, the strip path REPLACES the substituted-prompt assistant


### PR DESCRIPTION
## Summary

Empirically diagnosed and fixed three distinct mechanisms that were busting Anthropic's prompt cache on every task-creation turn. Raw-log analysis across multiple sessions showed ~15-17k cached tokens dropping per task creation (cache_read falling from ~50k→36k, with the missing tokens charged as full input rate), plus a ~15k token rewarm on the following turn. Roughly $0.20-0.30 extra per task creation at Opus rates.

Verified end-to-end on conversation `7b464caa`: two task creations, zero busts. Post-HELD turns now show `input=1, cache_read=~50k` (steady-state hit) instead of `input=15k+, cache_read=36k`.

The three commits are independent and stackable — each one removed a distinct leak that the next one exposed.

### 1. `b06715d7` — HTML-escape default + sliding-expires drift

- `encoding/json.Marshal` HTML-escapes `<`, `>`, `&` by default. Every proxy mutation that re-marshalled a body fragment was flipping literal `<system-reminder>` (which appears throughout claude-code's tool descriptions) into `<system-reminder>`, mismatching the harness's original bytes and busting every `cache_control` breakpoint that included the mutated region.
- Added `jsonpatch.MarshalNoEscape` (`json.Encoder` with `SetEscapeHTML(false)`, trailing newline stripped), re-exported via `jsonsurgery`, swapped every body-bound `json.Marshal` call site in the proxy (`synthetic_history_strip`, `approval_body_editor`, `controltool`, `continuation`, `inbound_sanitize`, `inspector/rewriter`, `secret_detection`, `pipeline/policy`, `inline_task_intercept`). Left audit/redis/trace/rawlog/postproc-stream sites alone — those produce log/storage/response bytes, not request prefix bytes.
- `renderActiveTasksSnapshot` was embedding the sliding task's literal `ExpiresAt` timestamp, which is bumped on every authorized tool_use, so the snapshot bytes drifted turn-by-turn even when the task list was otherwise stable. Sliding tasks now render `expires=auto-extends`; session and standing tasks keep their existing renderings.

### 2. `ab3b0930` — Per-conversation snapshot freeze + persistent-path swap

- The `ACTIVE TASKS` snapshot lives in `system[3]`, above the `cache_control` breakpoints on `system[1]` and `system[2]`. The old `NewControlNoticeWithSnapshot` comment claimed sentinel-based dedup would freeze the snapshot for later turns, but the harness never carries the proxy-injected system blocks back, so the sentinel check only short-circuits within one request and the loader re-renders from live DB on every turn. A new bullet appearing in the snapshot rewrites ~140 bytes above the system breakpoint and invalidates ~15k cached tokens on the next request.
- Added `ActiveTasksSnapshotCache` (in-process map, TTL+size capped) on the handler, keyed on (user, agent, conversation). The loader does `Lookup → render → Record` per turn; subsequent turns return the same bytes verbatim. The agent still learns about mid-conversation tasks via the augmenter's `task-approved` notice (below the cache breakpoint) and via `GET /control/tasks`. `ActiveTasksSnapshotLoader`'s signature now takes `conversationID`; handler-side `pipeReq` for control_notice now populates `conversationID` (it was missing).
- `replaceToolResultsForReconstruction` (the persistent-history path in `synthetic_history_strip.go`) was rebuilding the swapped tool_result block as a fresh `{type, tool_use_id, content}` map, dropping every other field — including `cache_control`, where claude-code routinely puts its deepest cache breakpoint. Now parses the original block into a `map[string]json.RawMessage`, overrides only `tool_use_id` and `content`, re-marshals preserving every other field.

### 3. `eb3db51a` — One-shot rewrite path swap

- Raw-log diagnostic on the binary built from #2 showed the cache still busting. Tracing the actual proxy-out bytes revealed `swapAnthropicToolResultForReconstructedPair` (the body-editor's ONE-SHOT path that runs on the immediate post-approval request) had the exact same bug as the persistent-path function. It ran first and clobbered `cache_control` before the strip ever saw the block.
- `swapAnthropicToolResultForReconstructedPair` and the legacy text-block sibling `swapAnthropicToolResultForTextBlock` now both use the same preserve-everything-else shape.

## Test plan

- [x] `go test ./...` clean across all commits
- [x] Unit tests pin each fix:
  - `TestMarshalNoEscape_PreservesAngleBrackets` — `<`, `>`, `&` stay literal
  - `TestRenderActiveTasksSnapshot_SlidingExpiryStable` — sliding snapshot bytes don't change when `ExpiresAt` bumps
  - `TestMemoryActiveTasksSnapshotCache_FrozenAcrossUpdates` — cached snapshot returns same bytes byte-for-byte
  - `TestStripSyntheticApprovalHistory_PreservesCacheControlOnSwap` — persistent-path swap preserves cache_control
  - `TestApprovalBodyEditorPreservesCacheControlOnReconstruction` — one-shot path swap preserves cache_control
- [x] **Production verification on real traffic** (conversation `7b464caa` on the rebuilt binary):
  - Pre-fix: post-HELD turns charged `input=14,738` and `input=16,260` as full input tokens; `cache_read` dropped to 36,359.
  - Post-fix: post-HELD turns charged `input=1`; `cache_read` held at 50,468 and 52,065.
  - Two task creations in the same session, zero busts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

