### PR TITLE
Replace continuation with placeholder+inbound rewrite for blocked tool calls

### DIFF
--- a/internal/api/handlers/llm_endpoint.go
+++ b/internal/api/handlers/llm_endpoint.go
@@ -1065,9 +1065,24 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 			Logger:         h.Logger,
 		})
 		if driftErr != nil {
-			h.Logger.WarnContext(r.Context(), "lite-proxy scope-drift inbound rewrite failed",
+			// Forwarding the unrewritten body would ship the Bash
+			// placeholder upstream, leaving the conversation
+			// permanently inconsistent (model sees the placeholder in
+			// its own history forever, the menu never lands as a
+			// tool_result). Fail closed instead so the harness can
+			// retry — the rewriter errors only on malformed inbound
+			// JSON, which the harness can produce again deterministically.
+			h.Logger.ErrorContext(r.Context(), "lite-proxy scope-drift inbound rewrite failed; failing request closed",
 				"request_id", requestID, "agent_id", agent.ID, "err", driftErr.Error())
-		} else if driftRewrite.Rewritten {
+			auditStatus = http.StatusBadGateway
+			auditDecide = "deny"
+			auditOutcome = "scope_drift_inbound_rewrite_failed"
+			auditReason = driftErr.Error()
+			h.writeLiteProxyError(w, r, agent, provider, body, requestID, http.StatusBadGateway, "SCOPE_DRIFT_REWRITE_FAILED",
+				"couldn't rewrite the inbound request after a scope-drift block. Please retry; details are in the Clawvisor audit log.")
+			return
+		}
+		if driftRewrite.Rewritten {
 			body = driftRewrite.Body
 			reqSummary = liteProxyRequestDebugSummary(provider, body)
 			auditParams["scope_drift_inbound_applied"] = driftRewrite.AppliedDriftIDs

--- a/internal/api/handlers/llm_endpoint.go
+++ b/internal/api/handlers/llm_endpoint.go
@@ -1046,6 +1046,34 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Scope-drift inbound rewrite: when the previous assistant turn
+	// substituted a blocked tool_use with the Bash placeholder, the
+	// inbound rewriter walks back the substitution: restore the
+	// original tool_use byte-for-byte in the assistant turn AND replace
+	// the harness-supplied tool_result content with the rendered menu.
+	// The model now sees its own original call answered by the helpful
+	// menu — faithful history, helpful result — while the harness only
+	// ever ran a no-op.
+	if h.ScopeDrifts != nil {
+		driftRewrite, driftErr := llmproxy.RewriteScopeDriftPlaceholders(r.Context(), llmproxy.ScopeDriftInboundRewriteRequest{
+			HTTPRequest:    r,
+			Provider:       provider,
+			Body:           body,
+			Agent:          agent,
+			ConversationID: conversationID,
+			ScopeDrifts:    h.ScopeDrifts,
+			Logger:         h.Logger,
+		})
+		if driftErr != nil {
+			h.Logger.WarnContext(r.Context(), "lite-proxy scope-drift inbound rewrite failed",
+				"request_id", requestID, "agent_id", agent.ID, "err", driftErr.Error())
+		} else if driftRewrite.Rewritten {
+			body = driftRewrite.Body
+			reqSummary = liteProxyRequestDebugSummary(provider, body)
+			auditParams["scope_drift_inbound_applied"] = driftRewrite.AppliedDriftIDs
+		}
+	}
+
 	upstreamURL := ""
 	if h.Forwarder != nil {
 		upstreamPath := llmproxy.ProviderPath(provider, r.URL.Path)

--- a/internal/api/handlers/llm_endpoint_test.go
+++ b/internal/api/handlers/llm_endpoint_test.go
@@ -1985,16 +1985,16 @@ func TestLLMEndpoint_RequiresApprovalForOpenAIToolUseWithoutScope(t *testing.T) 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d (%s)", rec.Code, rec.Body.String())
 	}
-	// Scope-drift menu is wired by default in NewLLMEndpointHandler, so
-	// a task_scope_missing block routes to the agent-facing menu (a
-	// synthetic tool_result) instead of parking a user-facing approval
-	// prompt. The body must surface the menu header text and a
-	// Drift ID.
-	if !strings.Contains(rec.Body.String(), "outside your current task scope") {
-		t.Fatalf("expected scope-drift menu, got %s", rec.Body.String())
-	}
-	if !strings.Contains(rec.Body.String(), "Drift ID:") {
-		t.Fatalf("expected Drift ID in scope-drift menu, got %s", rec.Body.String())
+	// Scope-drift is wired by default in NewLLMEndpointHandler. New
+	// design: the blocked tool_use is replaced with a harness-safe
+	// Bash placeholder on the response leg (visible here as a
+	// function_call carrying `CLAWVISOR_BLOCKED` in its command), and
+	// the menu is spliced into the function_call_output content on the
+	// NEXT inbound /v1/responses by the scope-drift inbound rewriter
+	// (asserted separately in
+	// scope_drift_inbound_rewrite tests).
+	if !strings.Contains(rec.Body.String(), "CLAWVISOR_BLOCKED") {
+		t.Fatalf("expected Bash placeholder (CLAWVISOR_BLOCKED) in response, got %s", rec.Body.String())
 	}
 
 	user, _ := st.GetUserByEmail(context.Background(), "lite-proxy@example.com")

--- a/internal/api/handlers/testdata/llm_characterization/tool_use_held_for_approval.json
+++ b/internal/api/handlers/testdata/llm_characterization/tool_use_held_for_approval.json
@@ -43,7 +43,6 @@
       "build_sha": "dev",
       "caller_auth_source": "authorization",
       "clawvisor_version": "dev",
-      "continuation_usage_recorded": true,
       "conversation_id_source": "empty",
       "event": "lite_proxy.endpoint_call",
       "first_turn": true,

--- a/internal/e2e/lite/scope_drift_counters.go
+++ b/internal/e2e/lite/scope_drift_counters.go
@@ -96,3 +96,7 @@ func (c *countingScopeDriftRegistry) LookupPendingSubstitution(ctx context.Conte
 	}
 	return value, ok
 }
+
+func (c *countingScopeDriftRegistry) DeletePendingSubstitution(ctx context.Context, key llmproxy.PendingSubstitutionKey) {
+	c.inner.DeletePendingSubstitution(ctx, key)
+}

--- a/internal/e2e/lite/scope_drift_counters.go
+++ b/internal/e2e/lite/scope_drift_counters.go
@@ -19,6 +19,8 @@ const (
 	SeriesScopeDriftOutcomeSucceed = "scope_drift.outcome.succeeded"
 	SeriesScopeDriftOutcomeDenied  = "scope_drift.outcome.denied"
 	SeriesScopeDriftPreClear       = "scope_drift.pre_clear_consumed"
+	SeriesScopeDriftPendingMint    = "scope_drift.pending_substitution.minted"
+	SeriesScopeDriftPendingConsume = "scope_drift.pending_substitution.consumed"
 )
 
 // countingScopeDriftRegistry wraps a real ScopeDriftRegistry and
@@ -77,4 +79,20 @@ func (c *countingScopeDriftRegistry) LookupPreClear(ctx context.Context, agentID
 		c.counters.Inc(SeriesScopeDriftPreClear)
 	}
 	return driftID, ok
+}
+
+func (c *countingScopeDriftRegistry) RegisterPendingSubstitution(ctx context.Context, key llmproxy.PendingSubstitutionKey, value llmproxy.PendingSubstitution) error {
+	if err := c.inner.RegisterPendingSubstitution(ctx, key, value); err != nil {
+		return err
+	}
+	c.counters.Inc(SeriesScopeDriftPendingMint)
+	return nil
+}
+
+func (c *countingScopeDriftRegistry) LookupPendingSubstitution(ctx context.Context, key llmproxy.PendingSubstitutionKey) (llmproxy.PendingSubstitution, bool) {
+	value, ok := c.inner.LookupPendingSubstitution(ctx, key)
+	if ok {
+		c.counters.Inc(SeriesScopeDriftPendingConsume)
+	}
+	return value, ok
 }

--- a/internal/runtime/conversation/anthropic_response.go
+++ b/internal/runtime/conversation/anthropic_response.go
@@ -165,6 +165,24 @@ func (rw AnthropicResponseRewriter) rewriteJSON(body []byte, eval ToolUseEvaluat
 					}
 					txt = fmt.Sprintf("Tool '%s' was blocked by Clawvisor policy: %s", block.Name, reason)
 				}
+				// Escape hatch: when SuppressSubstituteText is paired
+				// with a SubstituteWithToolCall (scope-drift,
+				// recoverable-deny) but the call rendering failed
+				// above (malformed Name/ID/Input —
+				// anthropicSubstituteToolUseBlock returning ok=false),
+				// SuppressSubstituteText must NOT also swallow the
+				// default fallback — otherwise the blocked decision
+				// drops off the wire entirely. Gated on
+				// SubstituteWithToolCall != nil so legitimately-
+				// suppressed siblings (coalesced approval turns) stay
+				// silent.
+				if txt == "" && verdict.SubstituteWithToolCall != nil {
+					reason := verdict.Reason
+					if reason == "" {
+						reason = "blocked by policy"
+					}
+					txt = fmt.Sprintf("Tool '%s' was blocked by Clawvisor policy: %s", block.Name, reason)
+				}
 				if txt != "" {
 					newContent = append(newContent, anthropicJSONContent{
 						Type: "text",
@@ -422,6 +440,16 @@ func (rw AnthropicResponseRewriter) rewriteSSE(body []byte, eval ToolUseEvaluato
 				}
 				txt := verdict.SubstituteWith
 				if txt == "" && !verdict.SuppressSubstituteText {
+					reason := verdict.Reason
+					if reason == "" {
+						reason = "blocked by policy"
+					}
+					txt = fmt.Sprintf("Tool '%s' was blocked by Clawvisor policy: %s", pb.name, reason)
+				}
+				// Same escape as the buffered JSON path, gated on
+				// SubstituteWithToolCall != nil so legitimately-
+				// suppressed siblings stay silent.
+				if txt == "" && verdict.SubstituteWithToolCall != nil {
 					reason := verdict.Reason
 					if reason == "" {
 						reason = "blocked by policy"

--- a/internal/runtime/conversation/openai_response.go
+++ b/internal/runtime/conversation/openai_response.go
@@ -166,12 +166,16 @@ func (rw OpenAIResponseRewriter) rewriteResponsesJSON(body []byte, eval ToolUseE
 				// id. Inbound rewriter on the next /v1/responses
 				// restores the original call and substitutes the
 				// function_call_output content.
+				substRendered := false
 				if call := verdict.SubstituteWithToolCall; call != nil && call.Name != "" {
 					if substItem, substArgs, ok := buildOpenAIResponsesSubstituteFunctionCall(tu.ID, call); ok {
 						newOutput = append(newOutput, substItem)
 						frags = append(frags, assistantFragment{IsTool: true, ToolName: call.Name, ToolArgs: substArgs})
-						continue
+						substRendered = true
 					}
+				}
+				if substRendered {
+					continue
 				}
 				txt := verdict.SubstituteWith
 				if txt == "" && !verdict.SuppressSubstituteText {
@@ -181,18 +185,32 @@ func (rw OpenAIResponseRewriter) rewriteResponsesJSON(body []byte, eval ToolUseE
 					}
 					txt = fmt.Sprintf("Tool '%s' was blocked by Clawvisor policy: %s", item.Name, reason)
 				}
-				if txt != "" {
-					newOutput = append(newOutput, openAIResponseOutputItem{
-						ID:     "msg_" + tu.ID,
-						Type:   "message",
-						Role:   "assistant",
-						Status: "completed",
-						Content: []openAIResponseContent{{
-							Type: "output_text",
-							Text: txt,
-						}},
-					})
+				// SuppressSubstituteText is set by callers that paired
+				// it with a SubstituteWithToolCall (scope-drift). If
+				// rendering that call failed above, the suppression must
+				// NOT also swallow the default fallback — otherwise the
+				// blocked decision drops off the wire entirely, leaving
+				// the assistant turn with neither the original
+				// function_call nor any replacement and breaking
+				// downstream tool/result pairing. Force a generic block
+				// notice in that escape path.
+				if txt == "" {
+					reason := verdict.Reason
+					if reason == "" {
+						reason = "blocked by policy"
+					}
+					txt = fmt.Sprintf("Tool '%s' was blocked by Clawvisor policy: %s", item.Name, reason)
 				}
+				newOutput = append(newOutput, openAIResponseOutputItem{
+					ID:     "msg_" + tu.ID,
+					Type:   "message",
+					Role:   "assistant",
+					Status: "completed",
+					Content: []openAIResponseContent{{
+						Type: "output_text",
+						Text: txt,
+					}},
+				})
 			} else {
 				if len(verdict.RewriteInput) > 0 {
 					item.Arguments = string(verdict.RewriteInput)
@@ -431,6 +449,7 @@ func (rw OpenAIResponseRewriter) rewriteResponsesSSE(body []byte, eval ToolUseEv
 					// inbound rewriter restores the original on the
 					// next /v1/responses and substitutes the
 					// function_call_output content with the menu.
+					substRendered := false
 					if call := verdict.SubstituteWithToolCall; call != nil && call.Name != "" {
 						if substArgs, ok := marshalSyntheticToolCallInput(call); ok {
 							orderedItems = append(orderedItems, orderedResponsesItem{
@@ -442,8 +461,11 @@ func (rw OpenAIResponseRewriter) rewriteResponsesSSE(body []byte, eval ToolUseEv
 							})
 							frags = append(frags, assistantFragment{IsTool: true, ToolName: call.Name, ToolArgs: substArgs})
 							delete(pending, raw.Item.ID)
-							continue
+							substRendered = true
 						}
+					}
+					if substRendered {
+						continue
 					}
 					txt := verdict.SubstituteWith
 					if txt == "" && !verdict.SuppressSubstituteText {
@@ -453,13 +475,23 @@ func (rw OpenAIResponseRewriter) rewriteResponsesSSE(body []byte, eval ToolUseEv
 						}
 						txt = fmt.Sprintf("Tool '%s' was blocked by Clawvisor policy: %s", pc.name, reason)
 					}
-					if txt != "" {
-						orderedItems = append(orderedItems, orderedResponsesItem{
-							isText:      true,
-							outputIndex: pc.outputIndex,
-							text:        txt,
-						})
+					// Force a fallback text when the substitute call
+					// failed to render — see rewriteResponsesJSON for
+					// the rationale; SuppressSubstituteText alone must
+					// not silently drop the blocked decision off the
+					// wire.
+					if txt == "" {
+						reason := verdict.Reason
+						if reason == "" {
+							reason = "blocked by policy"
+						}
+						txt = fmt.Sprintf("Tool '%s' was blocked by Clawvisor policy: %s", pc.name, reason)
 					}
+					orderedItems = append(orderedItems, orderedResponsesItem{
+						isText:      true,
+						outputIndex: pc.outputIndex,
+						text:        txt,
+					})
 				} else {
 					if len(verdict.RewriteInput) > 0 {
 						finalArgs = string(verdict.RewriteInput)
@@ -835,6 +867,7 @@ func (rw OpenAIResponseRewriter) rewriteChatCompletionsJSON(body []byte, eval To
 				// so the inbound rewriter can later restore the original
 				// (name, arguments) and substitute the matching `tool`
 				// message content with the menu.
+				substRendered := false
 				if scall := verdict.SubstituteWithToolCall; scall != nil && scall.Name != "" {
 					if substArgs, ok := marshalSyntheticToolCallInput(scall); ok {
 						call.Function.Name = scall.Name
@@ -845,8 +878,11 @@ func (rw OpenAIResponseRewriter) rewriteChatCompletionsJSON(body []byte, eval To
 						anyRewritten = true
 						allowedToolCalls = append(allowedToolCalls, call)
 						frags = append(frags, assistantFragment{IsTool: true, ToolName: scall.Name, ToolArgs: substArgs})
-						continue
+						substRendered = true
 					}
+				}
+				if substRendered {
+					continue
 				}
 				txt := verdict.SubstituteWith
 				if txt == "" && !verdict.SuppressSubstituteText {
@@ -856,9 +892,17 @@ func (rw OpenAIResponseRewriter) rewriteChatCompletionsJSON(body []byte, eval To
 					}
 					txt = fmt.Sprintf("Tool '%s' was blocked by Clawvisor policy: %s", call.Function.Name, reason)
 				}
-				if txt != "" {
-					blockedPrompts = append(blockedPrompts, txt)
+				// SuppressSubstituteText must not silently swallow the
+				// blocked decision when the substitute call failed to
+				// render — see rewriteResponsesJSON for the rationale.
+				if txt == "" {
+					reason := verdict.Reason
+					if reason == "" {
+						reason = "blocked by policy"
+					}
+					txt = fmt.Sprintf("Tool '%s' was blocked by Clawvisor policy: %s", call.Function.Name, reason)
 				}
+				blockedPrompts = append(blockedPrompts, txt)
 			} else {
 				if len(verdict.RewriteInput) > 0 {
 					call.Function.Arguments = string(verdict.RewriteInput)

--- a/internal/runtime/conversation/openai_response.go
+++ b/internal/runtime/conversation/openai_response.go
@@ -185,32 +185,31 @@ func (rw OpenAIResponseRewriter) rewriteResponsesJSON(body []byte, eval ToolUseE
 					}
 					txt = fmt.Sprintf("Tool '%s' was blocked by Clawvisor policy: %s", item.Name, reason)
 				}
-				// SuppressSubstituteText is set by callers that paired
-				// it with a SubstituteWithToolCall (scope-drift). If
-				// rendering that call failed above, the suppression must
-				// NOT also swallow the default fallback — otherwise the
-				// blocked decision drops off the wire entirely, leaving
-				// the assistant turn with neither the original
-				// function_call nor any replacement and breaking
-				// downstream tool/result pairing. Force a generic block
-				// notice in that escape path.
-				if txt == "" {
+				// Escape hatch: SuppressSubstituteText was paired with a
+				// SubstituteWithToolCall that failed to render above,
+				// so the suppression must NOT also swallow the default
+				// fallback. Gated on SubstituteWithToolCall != nil so
+				// legitimately-suppressed siblings (coalesced approval
+				// turns) stay silent.
+				if txt == "" && verdict.SubstituteWithToolCall != nil {
 					reason := verdict.Reason
 					if reason == "" {
 						reason = "blocked by policy"
 					}
 					txt = fmt.Sprintf("Tool '%s' was blocked by Clawvisor policy: %s", item.Name, reason)
 				}
-				newOutput = append(newOutput, openAIResponseOutputItem{
-					ID:     "msg_" + tu.ID,
-					Type:   "message",
-					Role:   "assistant",
-					Status: "completed",
-					Content: []openAIResponseContent{{
-						Type: "output_text",
-						Text: txt,
-					}},
-				})
+				if txt != "" {
+					newOutput = append(newOutput, openAIResponseOutputItem{
+						ID:     "msg_" + tu.ID,
+						Type:   "message",
+						Role:   "assistant",
+						Status: "completed",
+						Content: []openAIResponseContent{{
+							Type: "output_text",
+							Text: txt,
+						}},
+					})
+				}
 			} else {
 				if len(verdict.RewriteInput) > 0 {
 					item.Arguments = string(verdict.RewriteInput)
@@ -475,23 +474,22 @@ func (rw OpenAIResponseRewriter) rewriteResponsesSSE(body []byte, eval ToolUseEv
 						}
 						txt = fmt.Sprintf("Tool '%s' was blocked by Clawvisor policy: %s", pc.name, reason)
 					}
-					// Force a fallback text when the substitute call
-					// failed to render — see rewriteResponsesJSON for
-					// the rationale; SuppressSubstituteText alone must
-					// not silently drop the blocked decision off the
-					// wire.
-					if txt == "" {
+					// Escape hatch: gated on SubstituteWithToolCall != nil
+					// so legitimately-suppressed siblings stay silent.
+					if txt == "" && verdict.SubstituteWithToolCall != nil {
 						reason := verdict.Reason
 						if reason == "" {
 							reason = "blocked by policy"
 						}
 						txt = fmt.Sprintf("Tool '%s' was blocked by Clawvisor policy: %s", pc.name, reason)
 					}
-					orderedItems = append(orderedItems, orderedResponsesItem{
-						isText:      true,
-						outputIndex: pc.outputIndex,
-						text:        txt,
-					})
+					if txt != "" {
+						orderedItems = append(orderedItems, orderedResponsesItem{
+							isText:      true,
+							outputIndex: pc.outputIndex,
+							text:        txt,
+						})
+					}
 				} else {
 					if len(verdict.RewriteInput) > 0 {
 						finalArgs = string(verdict.RewriteInput)
@@ -892,17 +890,18 @@ func (rw OpenAIResponseRewriter) rewriteChatCompletionsJSON(body []byte, eval To
 					}
 					txt = fmt.Sprintf("Tool '%s' was blocked by Clawvisor policy: %s", call.Function.Name, reason)
 				}
-				// SuppressSubstituteText must not silently swallow the
-				// blocked decision when the substitute call failed to
-				// render — see rewriteResponsesJSON for the rationale.
-				if txt == "" {
+				// Escape hatch: gated on SubstituteWithToolCall != nil
+				// so legitimately-suppressed siblings stay silent.
+				if txt == "" && verdict.SubstituteWithToolCall != nil {
 					reason := verdict.Reason
 					if reason == "" {
 						reason = "blocked by policy"
 					}
 					txt = fmt.Sprintf("Tool '%s' was blocked by Clawvisor policy: %s", call.Function.Name, reason)
 				}
-				blockedPrompts = append(blockedPrompts, txt)
+				if txt != "" {
+					blockedPrompts = append(blockedPrompts, txt)
+				}
 			} else {
 				if len(verdict.RewriteInput) > 0 {
 					call.Function.Arguments = string(verdict.RewriteInput)

--- a/internal/runtime/conversation/openai_response.go
+++ b/internal/runtime/conversation/openai_response.go
@@ -98,6 +98,28 @@ type openAIResponseContent struct {
 	Text string `json:"text,omitempty"`
 }
 
+// buildOpenAIResponsesSubstituteFunctionCall renders a function_call
+// output item carrying the SyntheticToolCall's name + JSON-marshaled
+// input, keyed by the ORIGINAL tool_use_id so the inbound rewriter on
+// the next /v1/responses can find the matching function_call_output
+// for restoration. Returns the item, the JSON-marshaled args (for the
+// audit fragment), and ok=false if the input fails to marshal.
+func buildOpenAIResponsesSubstituteFunctionCall(originalToolUseID string, call *SyntheticToolCall) (openAIResponseOutputItem, json.RawMessage, bool) {
+	args, ok := marshalSyntheticToolCallInput(call)
+	if !ok {
+		return openAIResponseOutputItem{}, nil, false
+	}
+	item := openAIResponseOutputItem{
+		ID:        "fc_" + originalToolUseID,
+		Type:      "function_call",
+		CallID:    originalToolUseID,
+		Name:      call.Name,
+		Arguments: string(args),
+		Status:    "completed",
+	}
+	return item, args, true
+}
+
 func (rw OpenAIResponseRewriter) rewriteResponsesJSON(body []byte, eval ToolUseEvaluator) (RewriteResult, error) {
 	var resp openAIResponsesJSON
 	if err := json.Unmarshal(body, &resp); err != nil {
@@ -138,6 +160,19 @@ func (rw OpenAIResponseRewriter) rewriteResponsesJSON(body []byte, eval ToolUseE
 			finalArgs := tu.Input
 			if !verdict.Allowed {
 				anyBlocked = true
+				// SubstituteWithToolCall (Anthropic-parity scope-drift
+				// path): emit a function_call output item carrying the
+				// supplied tool name + input under the original tool
+				// id. Inbound rewriter on the next /v1/responses
+				// restores the original call and substitutes the
+				// function_call_output content.
+				if call := verdict.SubstituteWithToolCall; call != nil && call.Name != "" {
+					if substItem, substArgs, ok := buildOpenAIResponsesSubstituteFunctionCall(tu.ID, call); ok {
+						newOutput = append(newOutput, substItem)
+						frags = append(frags, assistantFragment{IsTool: true, ToolName: call.Name, ToolArgs: substArgs})
+						continue
+					}
+				}
 				txt := verdict.SubstituteWith
 				if txt == "" && !verdict.SuppressSubstituteText {
 					reason := verdict.Reason
@@ -390,6 +425,26 @@ func (rw OpenAIResponseRewriter) rewriteResponsesSSE(body []byte, eval ToolUseEv
 				fragArgs := tu.Input
 				if !verdict.Allowed {
 					anyBlocked = true
+					// SubstituteWithToolCall (scope-drift): emit a
+					// function_call item carrying the placeholder
+					// name + input under the original call_id. The
+					// inbound rewriter restores the original on the
+					// next /v1/responses and substitutes the
+					// function_call_output content with the menu.
+					if call := verdict.SubstituteWithToolCall; call != nil && call.Name != "" {
+						if substArgs, ok := marshalSyntheticToolCallInput(call); ok {
+							orderedItems = append(orderedItems, orderedResponsesItem{
+								outputIndex: pc.outputIndex,
+								itemID:      pc.itemID,
+								callID:      pc.callID,
+								name:        call.Name,
+								arguments:   string(substArgs),
+							})
+							frags = append(frags, assistantFragment{IsTool: true, ToolName: call.Name, ToolArgs: substArgs})
+							delete(pending, raw.Item.ID)
+							continue
+						}
+					}
 					txt := verdict.SubstituteWith
 					if txt == "" && !verdict.SuppressSubstituteText {
 						reason := verdict.Reason
@@ -775,6 +830,24 @@ func (rw OpenAIResponseRewriter) rewriteChatCompletionsJSON(body []byte, eval To
 			if !verdict.Allowed {
 				anyBlocked = true
 				choiceBlocked = true
+				// SubstituteWithToolCall (scope-drift): emit the
+				// placeholder tool_call carrying the original call.ID
+				// so the inbound rewriter can later restore the original
+				// (name, arguments) and substitute the matching `tool`
+				// message content with the menu.
+				if scall := verdict.SubstituteWithToolCall; scall != nil && scall.Name != "" {
+					if substArgs, ok := marshalSyntheticToolCallInput(scall); ok {
+						call.Function.Name = scall.Name
+						call.Function.Arguments = string(substArgs)
+						choice.Message.ToolCalls[i] = call
+						finalArgs = substArgs
+						choiceRewritten = true
+						anyRewritten = true
+						allowedToolCalls = append(allowedToolCalls, call)
+						frags = append(frags, assistantFragment{IsTool: true, ToolName: scall.Name, ToolArgs: substArgs})
+						continue
+					}
+				}
 				txt := verdict.SubstituteWith
 				if txt == "" && !verdict.SuppressSubstituteText {
 					reason := verdict.Reason

--- a/internal/runtime/conversation/response_test.go
+++ b/internal/runtime/conversation/response_test.go
@@ -311,6 +311,91 @@ func TestAnthropicResponseRewriterFallsBackToTextWhenSubstituteToolCallInvalid(t
 	}
 }
 
+// TestAnthropicResponseRewriterEmitsFallbackWhenSubstituteToolCallInvalidAndTextSuppressed
+// locks the buffered JSON path's failure mode for the scope-drift /
+// recoverable-deny callers: SuppressSubstituteText is paired with
+// SubstituteWithToolCall, and if rendering the call fails (malformed
+// Name/ID/Input) we MUST NOT also swallow the default block notice —
+// otherwise the assistant turn drops both the original tool_use and
+// any replacement, leaving downstream tool_result pairing broken.
+func TestAnthropicResponseRewriterEmitsFallbackWhenSubstituteToolCallInvalidAndTextSuppressed(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{
+	  "id":"msg_supp","type":"message","role":"assistant","model":"claude-test",
+	  "content":[{"type":"tool_use","id":"toolu_supp","name":"Write","input":{"file_path":"/tmp/x","content":"y"}}],
+	  "stop_reason":"tool_use"
+	}`)
+	result, err := (&AnthropicResponseRewriter{}).Rewrite(body, "application/json", func(ToolUse) ToolUseVerdict {
+		return ToolUseVerdict{
+			Allowed:                false,
+			Reason:                 "scope-drift menu",
+			SuppressSubstituteText: true,
+			// Invalid: no ID. Falls through to the fallback path which
+			// must NOT honour SuppressSubstituteText.
+			SubstituteWithToolCall: &SyntheticToolCall{
+				Name:  "Bash",
+				Input: map[string]any{"command": ":"},
+			},
+		}
+	})
+	if err != nil {
+		t.Fatalf("Rewrite: %v", err)
+	}
+	var out map[string]any
+	_ = json.Unmarshal(result.Body, &out)
+	content, ok := out["content"].([]any)
+	if !ok || len(content) == 0 {
+		t.Fatalf("expected at least one content block, got %v", out["content"])
+	}
+	block := content[0].(map[string]any)
+	if block["type"] != "text" {
+		t.Fatalf("expected fallback text block when synthetic call invalid + text suppressed, got %v", block)
+	}
+	if !strings.Contains(block["text"].(string), "Write") || !strings.Contains(block["text"].(string), "scope-drift menu") {
+		t.Fatalf("expected generic block notice naming the tool + reason, got %q", block["text"])
+	}
+}
+
+// TestAnthropicResponseRewriterEmitsFallbackWhenSubstituteToolCallInvalidAndTextSuppressedSSE
+// is the SSE counterpart. Same invariant: a half-rendered substitution
+// must never drop the blocked decision off the wire.
+func TestAnthropicResponseRewriterEmitsFallbackWhenSubstituteToolCallInvalidAndTextSuppressedSSE(t *testing.T) {
+	t.Parallel()
+
+	body := []byte("event: message_start\n" +
+		`data: {"type":"message_start","message":{"id":"msg_supp_sse","type":"message","role":"assistant","model":"claude-test","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":0,"output_tokens":0}}}` + "\n\n" +
+		"event: content_block_start\n" +
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_supp_sse","name":"Write","input":{}}}` + "\n\n" +
+		"event: content_block_delta\n" +
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"file_path\":\"/tmp/x\"}"}}` + "\n\n" +
+		"event: content_block_stop\n" +
+		`data: {"type":"content_block_stop","index":0}` + "\n\n" +
+		"event: message_delta\n" +
+		`data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null}}` + "\n\n" +
+		"event: message_stop\n" +
+		`data: {"type":"message_stop"}` + "\n\n")
+
+	result, err := (&AnthropicResponseRewriter{}).Rewrite(body, "text/event-stream", func(ToolUse) ToolUseVerdict {
+		return ToolUseVerdict{
+			Allowed:                false,
+			Reason:                 "scope-drift menu",
+			SuppressSubstituteText: true,
+			SubstituteWithToolCall: &SyntheticToolCall{Name: "", Input: map[string]any{"command": ":"}},
+		}
+	})
+	if err != nil {
+		t.Fatalf("Rewrite: %v", err)
+	}
+	wire := string(result.Body)
+	if !strings.Contains(wire, `"type":"text"`) {
+		t.Fatalf("expected text content_block emitted on SSE wire when call invalid + suppress set, got:\n%s", wire)
+	}
+	if !strings.Contains(wire, "Write") || !strings.Contains(wire, "scope-drift menu") {
+		t.Fatalf("expected generic block notice naming the tool + reason on SSE wire, got:\n%s", wire)
+	}
+}
+
 func TestAnthropicResponseRewriterRejectsEmptyToolCallID(t *testing.T) {
 	// A synthetic tool_use with no ID would alias every other
 	// no-ID substitution on the same turn under the same fallback

--- a/internal/runtime/llmproxy/pipelineeval/factory.go
+++ b/internal/runtime/llmproxy/pipelineeval/factory.go
@@ -640,12 +640,12 @@ func buildCredentialedTaskScope(
 			if mint := drifts.MintForCredentialed(ctx, tu, plan.Verdict, plan.Resolved, matchedTaskID, dec); mint.OK {
 				audit("block", "scope_drift_minted", "drift_id="+mint.DriftID+"; "+dec.Reason, matchedTaskID)
 				return policies.TaskScopeDecision{
-					Kind:                   policies.TaskScopeDecisionHold,
-					Allowed:                false,
-					Reason:                 "Clawvisor: no active task scope covers " + plan.Resolved.ServiceID + "." + plan.Resolved.ActionID + " — " + dec.Reason,
-					SubstituteText:         mint.MenuText,
-					ContinueWithToolResult: mint.MenuText,
-					TaskID:                 matchedTaskID,
+					Kind:               policies.TaskScopeDecisionHold,
+					Allowed:            false,
+					Reason:             "Clawvisor: no active task scope covers " + plan.Resolved.ServiceID + "." + plan.Resolved.ActionID + " — " + dec.Reason,
+					SubstituteText:     mint.MenuText,
+					SubstituteToolCall: mint.Sentinel,
+					TaskID:             matchedTaskID,
 				}
 			} else if mint.Err != nil {
 				// Registry write failed — fall through to the legacy
@@ -774,12 +774,12 @@ func buildCredentialedTaskScope(
 					if mint := drifts.MintForCredentialed(ctx, tu, v, resolved, dec.TaskID, syntheticDec); mint.OK {
 						audit("block", "scope_drift_minted", "drift_id="+mint.DriftID+"; "+dec.Reason+" (legacy)", dec.TaskID)
 						return policies.TaskScopeDecision{
-							Kind:                   policies.TaskScopeDecisionHold,
-							Allowed:                false,
-							Reason:                 "Clawvisor: no active task scope covers " + resolved.ServiceID + "." + resolved.ActionID + " — " + dec.Reason,
-							SubstituteText:         mint.MenuText,
-							ContinueWithToolResult: mint.MenuText,
-							TaskID:                 dec.TaskID,
+							Kind:               policies.TaskScopeDecisionHold,
+							Allowed:            false,
+							Reason:             "Clawvisor: no active task scope covers " + resolved.ServiceID + "." + resolved.ActionID + " — " + dec.Reason,
+							SubstituteText:     mint.MenuText,
+							SubstituteToolCall: mint.Sentinel,
+							TaskID:             dec.TaskID,
 						}
 					} else if mint.Err != nil {
 						audit("block", "scope_drift_mint_failed", mint.Err.Error()+" (legacy)", dec.TaskID)
@@ -1060,9 +1060,10 @@ func runIntentVerify(ctx context.Context, verifier llmproxy.IntentVerifier, dec 
 
 // authorizationHoldHandler implements policies.AuthorizationHoldHandler
 // for AuthorizationPolicy's approval flow. On a scope-drift source
-// the coordinator mints a drift and the handler returns
-// ContinueWithToolResult so the policy surfaces the agent-facing menu
-// instead of parking a user hold. Otherwise commits the hold via
+// the coordinator mints a drift + registers a pending substitution and
+// the handler returns SubstituteToolCall so the policy emits a Bash
+// placeholder (the inbound rewriter splices the menu into the next
+// /v1/messages tool_result). Otherwise commits the hold via
 // PendingApprovals.Hold, renders the approval prompt, and cleans up
 // any evicted inline task.
 type authorizationHoldHandler struct {
@@ -1083,8 +1084,8 @@ func (h *authorizationHoldHandler) Hold(ctx context.Context, req policies.Author
 	// than emit a menu with no usable drift_id.
 	if mint := h.drifts.MintForTriggerMiss(ctx, req.ToolUse, req.InspectorVerdict, req.Decision); mint.OK {
 		return policies.AuthorizationHoldResult{
-			ContinueWithToolResult: mint.MenuText,
-			SubstituteText:         mint.MenuText,
+			SubstituteToolCall: mint.Sentinel,
+			SubstituteText:     mint.MenuText,
 		}, nil
 	}
 	if h.approval.PendingApprovals == nil {

--- a/internal/runtime/llmproxy/pipelineeval/scope_drift.go
+++ b/internal/runtime/llmproxy/pipelineeval/scope_drift.go
@@ -82,16 +82,21 @@ func driftSourceFor(source runtimedecision.DecisionSource) llmproxy.ScopeDriftSo
 	return llmproxy.ScopeDriftSourceTaskScope
 }
 
-// MintResult is the coordinator's signal to its caller. menuText is
-// the rendered menu the caller should propagate via Continue +
-// SubstituteText (so the continuation round-trip carries the menu and
-// the harness fallback shows it on a continuation miss). driftID is
-// the registered drift's id, for audit linkage. OK reports whether
-// the mint actually landed — a false return tells the caller to fall
-// through to its legacy approval-prompt path.
+// MintResult is the coordinator's signal to its caller. MenuText is
+// the rendered menu; the caller surfaces it to the agent by:
+//   1. Rewriting the blocked tool_use into Sentinel (a canonical Bash
+//      no-op encoding the original call) so the harness's local
+//      execution is harmless.
+//   2. Registering a pending substitution under the tool_use_id so the
+//      inbound rewriter replaces the harness-supplied tool_result
+//      content with MenuText on the next /v1/messages.
+// driftID is the registered drift's id, for audit linkage. OK reports
+// whether the mint actually landed — a false return tells the caller
+// to fall through to its legacy approval-prompt path.
 type MintResult struct {
 	MenuText string
 	DriftID  string
+	Sentinel *conversation.SyntheticToolCall
 	Err      error
 	OK       bool
 }
@@ -130,7 +135,11 @@ func (c *scopeDriftCoordinator) MintForCredentialed(
 	if mintErr != nil {
 		return MintResult{Err: mintErr}
 	}
-	return MintResult{MenuText: menuText, DriftID: driftID, OK: true}
+	sentinel := buildScopeDriftSentinel(driftID, tu)
+	if regErr := c.registerPendingSubstitution(ctx, tu, driftID, menuText); regErr != nil {
+		return MintResult{Err: regErr}
+	}
+	return MintResult{MenuText: menuText, DriftID: driftID, Sentinel: sentinel, OK: true}
 }
 
 // MintForTriggerMiss registers a drift for the non-credentialed
@@ -163,7 +172,50 @@ func (c *scopeDriftCoordinator) MintForTriggerMiss(
 	if mintErr != nil {
 		return MintResult{Err: mintErr}
 	}
-	return MintResult{MenuText: menuText, DriftID: driftID, OK: true}
+	sentinel := buildScopeDriftSentinel(driftID, tu)
+	if regErr := c.registerPendingSubstitution(ctx, tu, driftID, menuText); regErr != nil {
+		return MintResult{Err: regErr}
+	}
+	return MintResult{MenuText: menuText, DriftID: driftID, Sentinel: sentinel, OK: true}
+}
+
+// buildScopeDriftSentinel constructs the SyntheticToolCall that
+// replaces the blocked tool_use in the response rewriter. The
+// tool_use_id is preserved so the inbound rewriter can later restore
+// the original call and substitute the matching tool_result's content.
+//
+// The placeholder is a harness-side artifact only — the LLM never sees
+// it. On the next /v1/messages the inbound rewriter walks back the
+// substitution: original tool_use restored byte-for-byte, tool_result
+// content replaced with the menu.
+func buildScopeDriftSentinel(driftID string, tu conversation.ToolUse) *conversation.SyntheticToolCall {
+	command := llmproxy.BuildScopeDriftPlaceholderCommand(tu.Name, driftID)
+	return &conversation.SyntheticToolCall{
+		ID:   tu.ID,
+		Name: llmproxy.ScopeDriftPlaceholderToolName,
+		Input: map[string]any{
+			"command": command,
+		},
+	}
+}
+
+// registerPendingSubstitution records everything the inbound rewriter
+// needs to restore the original tool_use and replace the tool_result
+// content on the next /v1/messages.
+func (c *scopeDriftCoordinator) registerPendingSubstitution(ctx context.Context, tu conversation.ToolUse, driftID, menuText string) error {
+	if c == nil || c.registry == nil {
+		return nil
+	}
+	return c.registry.RegisterPendingSubstitution(ctx, llmproxy.PendingSubstitutionKey{
+		AgentID:        c.agent.AgentID,
+		ConversationID: c.audit.ConversationID,
+		ToolUseID:      tu.ID,
+	}, llmproxy.PendingSubstitution{
+		DriftID:           driftID,
+		MenuText:          menuText,
+		OriginalToolName:  tu.Name,
+		OriginalToolInput: append([]byte(nil), tu.Input...),
+	})
 }
 
 // ConsumePreClear looks up a one-shot pre-clear for the agent's retry

--- a/internal/runtime/llmproxy/policies/authorization_policy.go
+++ b/internal/runtime/llmproxy/policies/authorization_policy.go
@@ -93,16 +93,17 @@ type AuthorizationHoldResult struct {
 	// footer so subsequent y/n replies disambiguate.
 	ApprovalID string
 	// SubstituteText is the rendered approval prompt the policy
-	// surfaces via the verdict's SubstituteWith field.
+	// surfaces via the verdict's SubstituteWith field. Used for the
+	// non-scope-drift approval-prompt path.
 	SubstituteText string
-	// ContinueWithToolResult, when non-empty, signals the handler took
-	// the scope-drift menu path instead of parking a user-facing
-	// approval hold. The policy returns a Continue verdict so the
-	// agent gets the menu as a synthetic tool_result and picks one of
-	// the labeled recovery options (expand / new_task / one_off /
-	// implicit fall-through). SubstituteText is still populated as the
-	// harness fallback if the continuation round-trip fails.
-	ContinueWithToolResult string
+	// SubstituteToolCall, when non-nil, signals the handler took the
+	// scope-drift menu path. The policy returns a Deny verdict carrying
+	// SubstituteWithToolCall so the response rewriter replaces the
+	// blocked tool_use with the supplied placeholder (Bash no-op). The
+	// inbound rewriter (running on the next /v1/messages) restores the
+	// original tool_use and replaces the tool_result content with the
+	// menu — see scope_drift_inbound_rewrite.go.
+	SubstituteToolCall *conversation.SyntheticToolCall
 	// Err, when non-empty, signals a hold storage failure. The policy
 	// returns Deny.
 	Err string
@@ -240,22 +241,25 @@ func (p *AuthorizationPolicy) Evaluate(ctx context.Context, _ pipeline.ReadOnlyR
 				Facts:   []pipeline.EvaluationFact{authFact, taskScopeFact},
 			}, nil
 		}
-		// Scope-drift continuation: when the hold handler chose the
-		// menu path (drift mint + substitution), surface a Continue
-		// signal so the agent gets the menu as a synthetic tool_result
-		// and decides between expand / new_task / one_off / implicit.
-		// SubstituteText stays populated as the harness fallback if the
-		// continuation round-trip fails.
-		if held.ContinueWithToolResult != "" {
-			if cont := pipeline.NewTextContinuation(held.ContinueWithToolResult); cont != nil {
-				return pipeline.ToolUseVerdict{
-					Outcome:        pipeline.OutcomeDeny,
-					Reason:         dec.Reason,
-					SubstituteWith: held.SubstituteText,
-					Continue:       cont,
-					Facts:          []pipeline.EvaluationFact{authFact, taskScopeFact},
-				}, nil
-			}
+		// Scope-drift menu: when the hold handler chose the menu path
+		// (drift mint + pending substitution), surface the placeholder
+		// SyntheticToolCall as a Deny + SubstituteWithToolCall. The
+		// response rewriter substitutes the blocked tool_use with the
+		// placeholder; on the next inbound /v1/messages the
+		// scope-drift inbound rewriter restores the original tool_use
+		// and replaces the harness-supplied tool_result content with
+		// the rendered menu.
+		//
+		// SubstituteWith is deliberately NOT set — see
+		// task_scope_evaluator.go for the same rationale.
+		if held.SubstituteToolCall != nil {
+			return pipeline.ToolUseVerdict{
+				Outcome:                pipeline.OutcomeDeny,
+				Reason:                 dec.Reason,
+				SubstituteWithToolCall: held.SubstituteToolCall,
+				SuppressSubstituteText: true,
+				Facts:                  []pipeline.EvaluationFact{authFact, taskScopeFact},
+			}, nil
 		}
 		return pipeline.ToolUseVerdict{
 			Outcome:        pipeline.OutcomeHold,

--- a/internal/runtime/llmproxy/policies/task_scope_evaluator.go
+++ b/internal/runtime/llmproxy/policies/task_scope_evaluator.go
@@ -45,18 +45,17 @@ type TaskScopeDecision struct {
 	TaskID         string
 	Reason         string
 	SubstituteText string
-	// ContinueWithToolResult, when non-empty, signals the evaluator to
-	// serve this tool_use locally and return the text as a synthetic
-	// tool_result on a continuation turn — the model sees its blocked
-	// tool_use answered with the supplied text and emits its next turn
-	// against it, instead of the proxy parking a user-facing approval
-	// hold. Used by the scope-drift menu path; SubstituteText still
-	// populates as the harness fallback if the continuation round-trip
-	// fails.
-	ContinueWithToolResult string
-	Ambiguous              bool
-	MatchedTask            *store.Task
-	MatchedAction          *store.TaskAction
+	// SubstituteToolCall, when non-nil, signals the evaluator to take
+	// the scope-drift menu path: the blocked tool_use is replaced with
+	// the supplied placeholder (Bash no-op) so the harness's local
+	// execution is harmless, and the inbound rewriter restores the
+	// original tool_use AND splices the menu into the tool_result on
+	// the next /v1/messages. SubstituteText still populates as a
+	// secondary signal (audit, debug).
+	SubstituteToolCall *conversation.SyntheticToolCall
+	Ambiguous          bool
+	MatchedTask        *store.Task
+	MatchedAction      *store.TaskAction
 }
 
 // TaskScopeDecisionKind disambiguates hard denials from approvable
@@ -149,23 +148,26 @@ func (e *TaskScopeEvaluator) Evaluate(ctx context.Context, _ pipeline.ReadOnlyRe
 		}, nil
 	}
 
-	// Scope-drift continuation: serve the menu locally as a synthetic
-	// tool_result instead of parking a user-facing approval hold. The
-	// orchestrator's Continue signal short-circuits coalescing — the
-	// pipeline re-enters with the menu as the model's next user-role
-	// input. SubstituteText still populates as the harness fallback if
-	// the continuation round-trip fails. The pipeline owns the wire
-	// format; we just hand it the text.
-	if dec.ContinueWithToolResult != "" {
-		if cont := pipeline.NewTextContinuation(dec.ContinueWithToolResult); cont != nil {
-			return pipeline.ToolUseVerdict{
-				Outcome:        pipeline.OutcomeDeny,
-				Reason:         dec.Reason,
-				SubstituteWith: dec.SubstituteText,
-				Continue:       cont,
-				Facts:          []pipeline.EvaluationFact{fact},
-			}, nil
-		}
+	// Scope-drift menu: replace the blocked tool_use with the
+	// supplied harness-safe placeholder. The inbound rewriter restores
+	// the model's original tool_use on the next /v1/messages and
+	// substitutes the menu into the tool_result content — so the model
+	// sees its own call answered by a helpful menu while the harness
+	// only ever ran a no-op.
+	//
+	// SubstituteWith is deliberately NOT set: writeProviderSubstituteToolCalls
+	// would emit it as a preamble text block alongside the placeholder
+	// tool_use, surfacing the menu inside the assistant turn — exactly
+	// the behaviour the new design replaces. SuppressSubstituteText
+	// guards the default "Tool 'X' was blocked …" fallback.
+	if dec.SubstituteToolCall != nil {
+		return pipeline.ToolUseVerdict{
+			Outcome:                pipeline.OutcomeDeny,
+			Reason:                 dec.Reason,
+			SubstituteWithToolCall: dec.SubstituteToolCall,
+			SuppressSubstituteText: true,
+			Facts:                  []pipeline.EvaluationFact{fact},
+		}, nil
 	}
 
 	// Scope check failed — hold for approval. Per-tool HoldKey so

--- a/internal/runtime/llmproxy/postproc/postproc.go
+++ b/internal/runtime/llmproxy/postproc/postproc.go
@@ -39,20 +39,8 @@ func Postprocess(req *http.Request, body []byte, contentType string, cfg llmprox
 
 	var preExtracted []conversation.ToolUse
 	var verdictByTU map[string]conversation.ToolUseVerdict
-	var registeredSubstitutions []llmproxy.PendingSubstitutionKey
-	rollbackSubstitutions := func() {
-		registry := cfg.AuthorizationContext.ScopeDrifts
-		if registry == nil {
-			return
-		}
-		for _, key := range registeredSubstitutions {
-			registry.DeletePendingSubstitution(req.Context(), key)
-		}
-		registeredSubstitutions = registeredSubstitutions[:0]
-	}
 	failClosed := func(reason string) llmproxy.PostprocessResult {
 		session.rollback(req.Context(), preExtracted, verdictByTU)
-		rollbackSubstitutions()
 		return llmproxy.PostprocessResult{
 			Body:          nil,
 			ContentType:   contentType,
@@ -79,11 +67,13 @@ func Postprocess(req *http.Request, body []byte, contentType string, cfg llmprox
 	verdictByTU = make(map[string]conversation.ToolUseVerdict, len(preExtracted))
 	eval := func(tu conversation.ToolUse) conversation.ToolUseVerdict {
 		v := innerEval(tu)
-		var registered *llmproxy.PendingSubstitutionKey
-		v, registered = transformRecoverableDenyToPlaceholder(req.Context(), v, tu, cfg)
-		if registered != nil {
-			registeredSubstitutions = append(registeredSubstitutions, *registered)
-		}
+		v, registered := transformRecoverableDenyToPlaceholder(req.Context(), v, tu, cfg)
+		session.trackSubstitution(registered)
+		// Also track substitutions that fired inside innerEval itself
+		// (scope-drift mint runs there) so the rollback path covers
+		// every registry write made during this request, not just the
+		// recoverable-deny migration.
+		session.trackSubstitution(detectScopeDriftSubstitution(req.Context(), v, tu, cfg))
 		verdictByTU[tu.ID] = v
 		return v
 	}

--- a/internal/runtime/llmproxy/postproc/postproc.go
+++ b/internal/runtime/llmproxy/postproc/postproc.go
@@ -39,8 +39,20 @@ func Postprocess(req *http.Request, body []byte, contentType string, cfg llmprox
 
 	var preExtracted []conversation.ToolUse
 	var verdictByTU map[string]conversation.ToolUseVerdict
+	var registeredSubstitutions []llmproxy.PendingSubstitutionKey
+	rollbackSubstitutions := func() {
+		registry := cfg.AuthorizationContext.ScopeDrifts
+		if registry == nil {
+			return
+		}
+		for _, key := range registeredSubstitutions {
+			registry.DeletePendingSubstitution(req.Context(), key)
+		}
+		registeredSubstitutions = registeredSubstitutions[:0]
+	}
 	failClosed := func(reason string) llmproxy.PostprocessResult {
 		session.rollback(req.Context(), preExtracted, verdictByTU)
+		rollbackSubstitutions()
 		return llmproxy.PostprocessResult{
 			Body:          nil,
 			ContentType:   contentType,
@@ -67,7 +79,11 @@ func Postprocess(req *http.Request, body []byte, contentType string, cfg llmprox
 	verdictByTU = make(map[string]conversation.ToolUseVerdict, len(preExtracted))
 	eval := func(tu conversation.ToolUse) conversation.ToolUseVerdict {
 		v := innerEval(tu)
-		v = transformRecoverableDenyToPlaceholder(req.Context(), v, tu, cfg)
+		var registered *llmproxy.PendingSubstitutionKey
+		v, registered = transformRecoverableDenyToPlaceholder(req.Context(), v, tu, cfg)
+		if registered != nil {
+			registeredSubstitutions = append(registeredSubstitutions, *registered)
+		}
 		verdictByTU[tu.ID] = v
 		return v
 	}

--- a/internal/runtime/llmproxy/postproc/postproc.go
+++ b/internal/runtime/llmproxy/postproc/postproc.go
@@ -67,6 +67,7 @@ func Postprocess(req *http.Request, body []byte, contentType string, cfg llmprox
 	verdictByTU = make(map[string]conversation.ToolUseVerdict, len(preExtracted))
 	eval := func(tu conversation.ToolUse) conversation.ToolUseVerdict {
 		v := innerEval(tu)
+		v = transformRecoverableDenyToPlaceholder(req.Context(), v, tu, cfg)
 		verdictByTU[tu.ID] = v
 		return v
 	}

--- a/internal/runtime/llmproxy/postproc/postprocess_test.go
+++ b/internal/runtime/llmproxy/postproc/postprocess_test.go
@@ -2596,8 +2596,8 @@ func TestWriteProviderSubstituteToolCallsEmitsTextThenToolUse(t *testing.T) {
 			Model:                     "claude-test",
 			Role:                      "assistant",
 		},
-		[]substitutedBlock{
-			{
+		[]mixedTurnBlock{{
+			Substitute: &substitutedBlock{
 				Text: "Clawvisor wants to create a task...\n\n[clawvisor:approval=cv-substtest1]",
 				Call: conversation.SyntheticToolCall{
 					ID:   "toolu_clawvisor_ask_cv-substtest1",
@@ -2607,7 +2607,7 @@ func TestWriteProviderSubstituteToolCallsEmitsTextThenToolUse(t *testing.T) {
 					},
 				},
 			},
-		},
+		}},
 	)
 	if err != nil {
 		t.Fatalf("writeProviderSubstituteToolCalls error: %v", err)
@@ -2664,7 +2664,7 @@ func TestSubstituteToolCallsForBlockedRejectsMalformedCall(t *testing.T) {
 				SubstituteWithToolCall: &conversation.SyntheticToolCall{Name: "", Input: map[string]any{"x": 1}},
 			},
 		}}
-		blocks, allHaveToolCall := substituteToolCallsForBlocked(decisions)
+		blocks, allHaveToolCall := substituteToolCallsForBlocked(decisions, nil)
 		if allHaveToolCall {
 			t.Fatalf("expected allHaveToolCall=false when Name is empty (buffered path falls back to text here too); got blocks=%v", blocks)
 		}
@@ -2683,7 +2683,7 @@ func TestSubstituteToolCallsForBlockedRejectsMalformedCall(t *testing.T) {
 				},
 			},
 		}}
-		blocks, allHaveToolCall := substituteToolCallsForBlocked(decisions)
+		blocks, allHaveToolCall := substituteToolCallsForBlocked(decisions, nil)
 		if allHaveToolCall {
 			t.Fatalf("expected allHaveToolCall=false when Input fails json.Marshal; got blocks=%v", blocks)
 		}
@@ -2700,9 +2700,11 @@ func TestWriteProviderSubstituteToolCallsSkipsTextBlockWhenEmpty(t *testing.T) {
 		&buf,
 		conversation.ProviderAnthropic,
 		conversation.StreamingRewriteResult{NextAnthropicContentIndex: 0, StreamID: "msg_t", Model: "m", Role: "assistant"},
-		[]substitutedBlock{{
-			Text: "   ", // whitespace only — treated as empty by writer
-			Call: conversation.SyntheticToolCall{ID: "toolu_a", Name: "AskUserQuestion", Input: map[string]any{"questions": []map[string]any{{"question": "Approve?"}}}},
+		[]mixedTurnBlock{{
+			Substitute: &substitutedBlock{
+				Text: "   ", // whitespace only — treated as empty by writer
+				Call: conversation.SyntheticToolCall{ID: "toolu_a", Name: "AskUserQuestion", Input: map[string]any{"questions": []map[string]any{{"question": "Approve?"}}}},
+			},
 		}},
 	)
 	if err != nil {
@@ -2714,5 +2716,84 @@ func TestWriteProviderSubstituteToolCallsSkipsTextBlockWhenEmpty(t *testing.T) {
 	}
 	if !strings.Contains(got, `"type":"tool_use"`) {
 		t.Fatalf("tool_use block missing, got:\n%s", got)
+	}
+}
+
+// TestSubstituteToolCallsForBlockedPreservesAllowedSiblings guards the
+// mixed-turn case: when an assistant turn carries one blocked tool_use
+// (with SubstituteWithToolCall) alongside one or more ALLOWED siblings,
+// the substitute path must emit every allowed tool_use AND the
+// placeholder in turn order. Previously the writer received only the
+// blocked decisions' substitutes, silently dropping the allowed
+// siblings from the wire — so a parallel Bash/Write/Read turn would
+// land with only the placeholder, leaving the harness with no
+// tool_uses to execute for the allowed work.
+func TestSubstituteToolCallsForBlockedPreservesAllowedSiblings(t *testing.T) {
+	decisions := []conversation.ToolUseDecisionRecord{
+		{
+			ToolUse: conversation.ToolUse{ID: "toolu_a1", Name: "Write", Input: json.RawMessage(`{"file_path":"/tmp/a.txt","content":"first"}`)},
+			Verdict: conversation.ToolUseVerdict{Allowed: true},
+		},
+		{
+			ToolUse: conversation.ToolUse{ID: "toolu_b2", Name: "Bash", Input: json.RawMessage(`{"command":"./hello.sh"}`)},
+			Verdict: conversation.ToolUseVerdict{
+				Allowed: false,
+				SubstituteWithToolCall: &conversation.SyntheticToolCall{
+					ID:    "toolu_b2",
+					Name:  "Bash",
+					Input: map[string]any{"command": ": # CLAWVISOR_BLOCKED ..."},
+				},
+				SuppressSubstituteText: true,
+			},
+		},
+		{
+			ToolUse: conversation.ToolUse{ID: "toolu_c3", Name: "Write", Input: json.RawMessage(`{"file_path":"/tmp/c.txt","content":"third"}`)},
+			Verdict: conversation.ToolUseVerdict{Allowed: true},
+		},
+	}
+	blocks, allHaveToolCall := substituteToolCallsForBlocked(decisions, nil)
+	if !allHaveToolCall {
+		t.Fatalf("expected allHaveToolCall=true (one blocked-with-call slot is sufficient), got false; blocks=%+v", blocks)
+	}
+	if len(blocks) != 3 {
+		t.Fatalf("expected 3 blocks (2 allowed pass-throughs + 1 substitute), got %d: %+v", len(blocks), blocks)
+	}
+	if !blocks[0].Allowed || blocks[0].ToolUse.ID != "toolu_a1" {
+		t.Fatalf("block[0] should be allowed pass-through toolu_a1, got %+v", blocks[0])
+	}
+	if blocks[1].Substitute == nil || blocks[1].Substitute.Call.ID != "toolu_b2" {
+		t.Fatalf("block[1] should be substitute toolu_b2, got %+v", blocks[1])
+	}
+	if !blocks[2].Allowed || blocks[2].ToolUse.ID != "toolu_c3" {
+		t.Fatalf("block[2] should be allowed pass-through toolu_c3, got %+v", blocks[2])
+	}
+
+	// Wire-shape: writeProviderSubstituteToolCalls must emit a tool_use
+	// content_block for the allowed siblings (with the original name
+	// + input) AND the placeholder.
+	var buf bytes.Buffer
+	if err := writeProviderSubstituteToolCalls(&buf, conversation.ProviderAnthropic,
+		conversation.StreamingRewriteResult{NextAnthropicContentIndex: 0, StreamID: "msg_mixed", Model: "claude-test", Role: "assistant"},
+		blocks); err != nil {
+		t.Fatalf("writeProviderSubstituteToolCalls error: %v", err)
+	}
+	got := buf.String()
+	for _, want := range []string{
+		`"id":"toolu_a1"`,
+		`"id":"toolu_b2"`,
+		`"id":"toolu_c3"`,
+		`"name":"Write"`,
+		`"name":"Bash"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected wire output to contain %q, got:\n%s", want, got)
+		}
+	}
+	// Order: a1 before b2 before c3.
+	aIdx := strings.Index(got, `"id":"toolu_a1"`)
+	bIdx := strings.Index(got, `"id":"toolu_b2"`)
+	cIdx := strings.Index(got, `"id":"toolu_c3"`)
+	if aIdx < 0 || bIdx < 0 || cIdx < 0 || aIdx >= bIdx || bIdx >= cIdx {
+		t.Fatalf("expected ordering a1@%d < b2@%d < c3@%d in output:\n%s", aIdx, bIdx, cIdx, got)
 	}
 }

--- a/internal/runtime/llmproxy/postproc/recoverable_deny.go
+++ b/internal/runtime/llmproxy/postproc/recoverable_deny.go
@@ -77,6 +77,36 @@ func transformRecoverableDenyToPlaceholder(ctx context.Context, v conversation.T
 	return v, &key
 }
 
+// detectScopeDriftSubstitution returns the registry key for a
+// substitution that an inner evaluator (today: scope-drift mint in
+// pipelineeval/scope_drift.go) wrote during this request, so the
+// session rollback path can revert it on failClosed alongside the
+// recoverable-deny migrations this file owns.
+//
+// The detection rule: a Deny verdict whose SubstituteWithToolCall is
+// set, where the registry actually carries a substitution for this
+// (agent, conversation, tool_use_id). Anything else (allowed siblings,
+// approval-prompt substitute, recoverable-deny verdicts whose
+// transformation step already returned a key) returns nil.
+func detectScopeDriftSubstitution(ctx context.Context, v conversation.ToolUseVerdict, tu conversation.ToolUse, cfg llmproxy.PostprocessConfig) *llmproxy.PendingSubstitutionKey {
+	if v.Outcome != conversation.OutcomeDeny || v.SubstituteWithToolCall == nil {
+		return nil
+	}
+	registry := cfg.AuthorizationContext.ScopeDrifts
+	if registry == nil || cfg.AgentContext.AgentID == "" {
+		return nil
+	}
+	key := llmproxy.PendingSubstitutionKey{
+		AgentID:        cfg.AgentContext.AgentID,
+		ConversationID: cfg.AuditContext.ConversationID,
+		ToolUseID:      tu.ID,
+	}
+	if _, ok := registry.LookupPendingSubstitution(ctx, key); !ok {
+		return nil
+	}
+	return &key
+}
+
 // extractRecoverableContinueReason pulls the reason string back out of
 // a ContinueSignal built by conversation.RecoverableContinue. The
 // signal carries the reason as a single JSON-marshaled string in

--- a/internal/runtime/llmproxy/postproc/recoverable_deny.go
+++ b/internal/runtime/llmproxy/postproc/recoverable_deny.go
@@ -22,30 +22,32 @@ import (
 // see its own "create task" call answered by the result of a
 // post-creation step).
 //
-// Returns the (possibly unchanged) verdict. Any failure to register
-// the substitution leaves the verdict alone so the legacy continuation
-// path remains the fallback.
-func transformRecoverableDenyToPlaceholder(ctx context.Context, v conversation.ToolUseVerdict, tu conversation.ToolUse, cfg llmproxy.PostprocessConfig) conversation.ToolUseVerdict {
+// Returns the (possibly unchanged) verdict and, when a substitution
+// was registered, the key the caller should hand to the rollback path
+// so a later failClosed / rewrite-error can revert the registry write.
+// Any failure to register leaves the verdict alone so the legacy
+// continuation path remains the fallback.
+func transformRecoverableDenyToPlaceholder(ctx context.Context, v conversation.ToolUseVerdict, tu conversation.ToolUse, cfg llmproxy.PostprocessConfig) (conversation.ToolUseVerdict, *llmproxy.PendingSubstitutionKey) {
 	if v.Outcome != conversation.OutcomeDeny || v.Continue == nil {
-		return v
+		return v, nil
 	}
 	// Another policy already chose a placeholder shape (scope-drift
 	// sets SubstituteWithToolCall directly). Honour it.
 	if v.SubstituteWithToolCall != nil {
-		return v
+		return v, nil
 	}
 	registry := cfg.AuthorizationContext.ScopeDrifts
 	if registry == nil {
-		return v
+		return v, nil
 	}
 	if cfg.AgentContext.AgentID == "" {
 		// Without an agent id the inbound rewriter can't key the
 		// substitution; better to leave the legacy path alone.
-		return v
+		return v, nil
 	}
 	reason, ok := extractRecoverableContinueReason(v.Continue)
 	if !ok {
-		return v
+		return v, nil
 	}
 	sentinel := &conversation.SyntheticToolCall{
 		ID:   tu.ID,
@@ -54,25 +56,25 @@ func transformRecoverableDenyToPlaceholder(ctx context.Context, v conversation.T
 			"command": llmproxy.BuildRecoverableDenyPlaceholderCommand(tu.Name, reason),
 		},
 	}
-	if err := registry.RegisterPendingSubstitution(ctx,
-		llmproxy.PendingSubstitutionKey{
-			AgentID:        cfg.AgentContext.AgentID,
-			ConversationID: cfg.AuditContext.ConversationID,
-			ToolUseID:      tu.ID,
-		},
+	key := llmproxy.PendingSubstitutionKey{
+		AgentID:        cfg.AgentContext.AgentID,
+		ConversationID: cfg.AuditContext.ConversationID,
+		ToolUseID:      tu.ID,
+	}
+	if err := registry.RegisterPendingSubstitution(ctx, key,
 		llmproxy.PendingSubstitution{
 			MenuText:          reason,
 			OriginalToolName:  tu.Name,
 			OriginalToolInput: append([]byte(nil), tu.Input...),
 		},
 	); err != nil {
-		return v
+		return v, nil
 	}
 	v.SubstituteWithToolCall = sentinel
 	v.SuppressSubstituteText = true
 	v.SubstituteWith = ""
 	v.Continue = nil
-	return v
+	return v, &key
 }
 
 // extractRecoverableContinueReason pulls the reason string back out of

--- a/internal/runtime/llmproxy/postproc/recoverable_deny.go
+++ b/internal/runtime/llmproxy/postproc/recoverable_deny.go
@@ -1,0 +1,92 @@
+package postproc
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy"
+)
+
+// transformRecoverableDenyToPlaceholder converts a Deny+Continue
+// verdict (RecoverableDenyVerdict / RecoverableContinue) into a
+// placeholder-tool_use + pending-substitution shape so the model sees
+// its own original tool_use answered by the reason on the next inbound
+// /v1/messages — instead of the proxy issuing an upstream continuation
+// call to deliver the reason as a synthetic tool_result.
+//
+// Allow+Continue is the inline-task auto-approve pattern and stays on
+// the legacy tryContinuation flow: that path advances the conversation
+// past the auto-approved call rather than asking the model to retry,
+// so a placeholder swap would be semantically wrong (the model would
+// see its own "create task" call answered by the result of a
+// post-creation step).
+//
+// Returns the (possibly unchanged) verdict. Any failure to register
+// the substitution leaves the verdict alone so the legacy continuation
+// path remains the fallback.
+func transformRecoverableDenyToPlaceholder(ctx context.Context, v conversation.ToolUseVerdict, tu conversation.ToolUse, cfg llmproxy.PostprocessConfig) conversation.ToolUseVerdict {
+	if v.Outcome != conversation.OutcomeDeny || v.Continue == nil {
+		return v
+	}
+	// Another policy already chose a placeholder shape (scope-drift
+	// sets SubstituteWithToolCall directly). Honour it.
+	if v.SubstituteWithToolCall != nil {
+		return v
+	}
+	registry := cfg.AuthorizationContext.ScopeDrifts
+	if registry == nil {
+		return v
+	}
+	if cfg.AgentContext.AgentID == "" {
+		// Without an agent id the inbound rewriter can't key the
+		// substitution; better to leave the legacy path alone.
+		return v
+	}
+	reason, ok := extractRecoverableContinueReason(v.Continue)
+	if !ok {
+		return v
+	}
+	sentinel := &conversation.SyntheticToolCall{
+		ID:   tu.ID,
+		Name: llmproxy.ScopeDriftPlaceholderToolName,
+		Input: map[string]any{
+			"command": llmproxy.BuildRecoverableDenyPlaceholderCommand(tu.Name, reason),
+		},
+	}
+	if err := registry.RegisterPendingSubstitution(ctx,
+		llmproxy.PendingSubstitutionKey{
+			AgentID:        cfg.AgentContext.AgentID,
+			ConversationID: cfg.AuditContext.ConversationID,
+			ToolUseID:      tu.ID,
+		},
+		llmproxy.PendingSubstitution{
+			MenuText:          reason,
+			OriginalToolName:  tu.Name,
+			OriginalToolInput: append([]byte(nil), tu.Input...),
+		},
+	); err != nil {
+		return v
+	}
+	v.SubstituteWithToolCall = sentinel
+	v.SuppressSubstituteText = true
+	v.SubstituteWith = ""
+	v.Continue = nil
+	return v
+}
+
+// extractRecoverableContinueReason pulls the reason string back out of
+// a ContinueSignal built by conversation.RecoverableContinue. The
+// signal carries the reason as a single JSON-marshaled string in
+// SyntheticToolResults[0]; anything else is treated as "not a
+// recoverable-deny we own."
+func extractRecoverableContinueReason(c *conversation.ContinueSignal) (string, bool) {
+	if c == nil || len(c.SyntheticToolResults) != 1 {
+		return "", false
+	}
+	var s string
+	if err := json.Unmarshal(c.SyntheticToolResults[0], &s); err != nil {
+		return "", false
+	}
+	return s, s != ""
+}

--- a/internal/runtime/llmproxy/postproc/recoverable_deny_test.go
+++ b/internal/runtime/llmproxy/postproc/recoverable_deny_test.go
@@ -1,0 +1,116 @@
+package postproc
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy"
+)
+
+// TestTransformRecoverableDenyToPlaceholder asserts the Continue+Deny
+// verdict shape produced by conversation.RecoverableDenyVerdict is
+// migrated to the placeholder + pending-substitution pattern: the
+// model's original tool_use is captured for restoration, the menu
+// (reason) text is stashed for the next inbound /v1/messages, and the
+// verdict's Continue signal is cleared so tryContinuation no longer
+// fires for these cases.
+func TestTransformRecoverableDenyToPlaceholder(t *testing.T) {
+	reg := llmproxy.NewMemoryScopeDriftRegistry(0)
+	tu := conversation.ToolUse{
+		ID:    "tu-recover-1",
+		Name:  "Bash",
+		Input: json.RawMessage(`{"command":"curl -X POST https://invalid"}`),
+	}
+	original := conversation.RecoverableDenyVerdict("the inspector could not parse the request body")
+	cfg := llmproxy.PostprocessConfig{
+		AgentContext: llmproxy.AgentContext{AgentID: "agent-recover-1", AgentUserID: "user-recover-1"},
+		AuditContext: llmproxy.AuditContext{ConversationID: "conv-recover-1"},
+		AuthorizationContext: llmproxy.AuthorizationContext{
+			ScopeDrifts: reg,
+		},
+	}
+	got := transformRecoverableDenyToPlaceholder(context.Background(), original, tu, cfg)
+	if got.Continue != nil {
+		t.Fatalf("expected Continue signal cleared after migration, got %+v", got.Continue)
+	}
+	if got.SubstituteWith != "" {
+		t.Fatalf("expected SubstituteWith cleared (placeholder owns the wire shape), got %q", got.SubstituteWith)
+	}
+	if !got.SuppressSubstituteText {
+		t.Fatal("expected SuppressSubstituteText=true on migrated verdict")
+	}
+	if got.SubstituteWithToolCall == nil {
+		t.Fatal("expected SubstituteWithToolCall populated with placeholder")
+	}
+	if got.SubstituteWithToolCall.ID != tu.ID {
+		t.Fatalf("placeholder must preserve tool_use_id: got %q want %q", got.SubstituteWithToolCall.ID, tu.ID)
+	}
+	if got.SubstituteWithToolCall.Name != llmproxy.ScopeDriftPlaceholderToolName {
+		t.Fatalf("placeholder should use canonical Bash name; got %q", got.SubstituteWithToolCall.Name)
+	}
+	cmd, _ := got.SubstituteWithToolCall.Input["command"].(string)
+	if cmd == "" {
+		t.Fatalf("placeholder input missing command: %+v", got.SubstituteWithToolCall.Input)
+	}
+
+	// Pending substitution is keyed on (agent, conversation, tool_use_id);
+	// carries the reason as MenuText and the original tool shape for
+	// later restoration.
+	subst, ok := reg.LookupPendingSubstitution(context.Background(), llmproxy.PendingSubstitutionKey{
+		AgentID:        cfg.AgentContext.AgentID,
+		ConversationID: cfg.AuditContext.ConversationID,
+		ToolUseID:      tu.ID,
+	})
+	if !ok {
+		t.Fatal("expected pending substitution registered for recoverable-deny tool_use")
+	}
+	if subst.MenuText != "the inspector could not parse the request body" {
+		t.Fatalf("substitution menu text = %q; want the reason", subst.MenuText)
+	}
+	if subst.OriginalToolName != tu.Name {
+		t.Fatalf("substitution original tool name = %q; want %q", subst.OriginalToolName, tu.Name)
+	}
+	if string(subst.OriginalToolInput) != string(tu.Input) {
+		t.Fatalf("substitution original tool input mismatch:\n got: %s\nwant: %s", string(subst.OriginalToolInput), string(tu.Input))
+	}
+}
+
+// TestTransformRecoverableDenyToPlaceholderLeavesAutoApproveAlone
+// guards the inline-task auto-approve flow: its verdict has
+// Outcome=Allow + Continue, NOT Outcome=Deny + Continue. That path
+// must stay on the upstream-continuation flow because it advances the
+// conversation past the auto-approved call rather than expecting the
+// model to retry.
+func TestTransformRecoverableDenyToPlaceholderLeavesAutoApproveAlone(t *testing.T) {
+	reg := llmproxy.NewMemoryScopeDriftRegistry(0)
+	tu := conversation.ToolUse{ID: "tu-auto-1", Name: "Bash", Input: json.RawMessage(`{"command":"curl"}`)}
+	payload, _ := json.Marshal("task created, proceed")
+	verdict := conversation.ToolUseVerdict{
+		Outcome: conversation.OutcomeAllow,
+		Allowed: true,
+		Continue: &conversation.ContinueSignal{
+			SyntheticToolResults: []json.RawMessage{payload},
+		},
+	}
+	cfg := llmproxy.PostprocessConfig{
+		AgentContext: llmproxy.AgentContext{AgentID: "agent-auto-1", AgentUserID: "user-auto-1"},
+		AuditContext: llmproxy.AuditContext{ConversationID: "conv-auto-1"},
+		AuthorizationContext: llmproxy.AuthorizationContext{ScopeDrifts: reg},
+	}
+	got := transformRecoverableDenyToPlaceholder(context.Background(), verdict, tu, cfg)
+	if got.Continue == nil {
+		t.Fatal("auto-approve Continue signal must be preserved")
+	}
+	if got.SubstituteWithToolCall != nil {
+		t.Fatal("auto-approve verdict must NOT get a placeholder")
+	}
+	if _, ok := reg.LookupPendingSubstitution(context.Background(), llmproxy.PendingSubstitutionKey{
+		AgentID:        cfg.AgentContext.AgentID,
+		ConversationID: cfg.AuditContext.ConversationID,
+		ToolUseID:      tu.ID,
+	}); ok {
+		t.Fatal("auto-approve must NOT register a pending substitution")
+	}
+}

--- a/internal/runtime/llmproxy/postproc/recoverable_deny_test.go
+++ b/internal/runtime/llmproxy/postproc/recoverable_deny_test.go
@@ -31,7 +31,13 @@ func TestTransformRecoverableDenyToPlaceholder(t *testing.T) {
 			ScopeDrifts: reg,
 		},
 	}
-	got := transformRecoverableDenyToPlaceholder(context.Background(), original, tu, cfg)
+	got, registered := transformRecoverableDenyToPlaceholder(context.Background(), original, tu, cfg)
+	if registered == nil {
+		t.Fatal("expected registered key from transform so rollback can revert on failure")
+	}
+	if registered.AgentID != cfg.AgentContext.AgentID || registered.ToolUseID != tu.ID {
+		t.Fatalf("registered key mismatch: %+v", *registered)
+	}
 	if got.Continue != nil {
 		t.Fatalf("expected Continue signal cleared after migration, got %+v", got.Continue)
 	}
@@ -99,7 +105,10 @@ func TestTransformRecoverableDenyToPlaceholderLeavesAutoApproveAlone(t *testing.
 		AuditContext: llmproxy.AuditContext{ConversationID: "conv-auto-1"},
 		AuthorizationContext: llmproxy.AuthorizationContext{ScopeDrifts: reg},
 	}
-	got := transformRecoverableDenyToPlaceholder(context.Background(), verdict, tu, cfg)
+	got, registered := transformRecoverableDenyToPlaceholder(context.Background(), verdict, tu, cfg)
+	if registered != nil {
+		t.Fatalf("auto-approve must NOT register a substitution; got key %+v", *registered)
+	}
 	if got.Continue == nil {
 		t.Fatal("auto-approve Continue signal must be preserved")
 	}
@@ -112,5 +121,32 @@ func TestTransformRecoverableDenyToPlaceholderLeavesAutoApproveAlone(t *testing.
 		ToolUseID:      tu.ID,
 	}); ok {
 		t.Fatal("auto-approve must NOT register a pending substitution")
+	}
+}
+
+// TestDeletePendingSubstitutionRollback locks the rollback path the
+// transformRecoverableDenyToPlaceholder callers rely on: a registry
+// write that happens during a request whose response is later
+// failClosed'd must be revertible so it doesn't survive as an orphan.
+func TestDeletePendingSubstitutionRollback(t *testing.T) {
+	reg := llmproxy.NewMemoryScopeDriftRegistry(0)
+	key := llmproxy.PendingSubstitutionKey{
+		AgentID:        "agent-rollback",
+		ConversationID: "conv-rollback",
+		ToolUseID:      "tu-rollback",
+	}
+	if err := reg.RegisterPendingSubstitution(context.Background(), key, llmproxy.PendingSubstitution{
+		MenuText:          "reason",
+		OriginalToolName:  "Bash",
+		OriginalToolInput: []byte(`{"command":":"}`),
+	}); err != nil {
+		t.Fatalf("RegisterPendingSubstitution: %v", err)
+	}
+	if _, ok := reg.LookupPendingSubstitution(context.Background(), key); !ok {
+		t.Fatal("substitution should be registered before rollback")
+	}
+	reg.DeletePendingSubstitution(context.Background(), key)
+	if _, ok := reg.LookupPendingSubstitution(context.Background(), key); ok {
+		t.Fatal("substitution should be gone after delete")
 	}
 }

--- a/internal/runtime/llmproxy/postproc/recoverable_deny_test.go
+++ b/internal/runtime/llmproxy/postproc/recoverable_deny_test.go
@@ -124,6 +124,44 @@ func TestTransformRecoverableDenyToPlaceholderLeavesAutoApproveAlone(t *testing.
 	}
 }
 
+// TestDetectScopeDriftSubstitutionTracksScopeDriftMint locks the
+// centralized rollback: when an inner evaluator (e.g., scope-drift
+// mint in pipelineeval/scope_drift.go) registers a substitution
+// during innerEval and returns a verdict with SubstituteWithToolCall,
+// the postproc eval wrapper's detector picks it up so session
+// rollback covers both recoverable-deny and scope-drift writes.
+func TestDetectScopeDriftSubstitutionTracksScopeDriftMint(t *testing.T) {
+	reg := llmproxy.NewMemoryScopeDriftRegistry(0)
+	tu := conversation.ToolUse{ID: "tu-scope-drift", Name: "Bash", Input: json.RawMessage(`{"command":":"}`)}
+	cfg := llmproxy.PostprocessConfig{
+		AgentContext:         llmproxy.AgentContext{AgentID: "agent-x", AgentUserID: "user-x"},
+		AuditContext:         llmproxy.AuditContext{ConversationID: "conv-x"},
+		AuthorizationContext: llmproxy.AuthorizationContext{ScopeDrifts: reg},
+	}
+
+	// Simulate the scope-drift mint write happening inside innerEval.
+	mintKey := llmproxy.PendingSubstitutionKey{
+		AgentID: cfg.AgentContext.AgentID, ConversationID: cfg.AuditContext.ConversationID, ToolUseID: tu.ID,
+	}
+	if err := reg.RegisterPendingSubstitution(context.Background(), mintKey, llmproxy.PendingSubstitution{
+		MenuText: "scope-drift menu", OriginalToolName: "Write", OriginalToolInput: []byte(`{}`),
+	}); err != nil {
+		t.Fatalf("RegisterPendingSubstitution: %v", err)
+	}
+	verdict := conversation.ToolUseVerdict{
+		Outcome:                conversation.OutcomeDeny,
+		SubstituteWithToolCall: &conversation.SyntheticToolCall{ID: tu.ID, Name: "Bash", Input: map[string]any{"command": ":"}},
+		SuppressSubstituteText: true,
+	}
+	key := detectScopeDriftSubstitution(context.Background(), verdict, tu, cfg)
+	if key == nil {
+		t.Fatal("expected detectScopeDriftSubstitution to return the mint's key")
+	}
+	if *key != mintKey {
+		t.Fatalf("detected key mismatch: got %+v want %+v", *key, mintKey)
+	}
+}
+
 // TestDeletePendingSubstitutionRollback locks the rollback path the
 // transformRecoverableDenyToPlaceholder callers rely on: a registry
 // write that happens during a request whose response is later

--- a/internal/runtime/llmproxy/postproc/session.go
+++ b/internal/runtime/llmproxy/postproc/session.go
@@ -14,6 +14,13 @@ import (
 // evaluator side effects into pipeline.Finalizer. Buffered and
 // streaming postprocess both use this shape so capture/finalize
 // lifecycle details stay in one place.
+//
+// substitutions tracks pending-substitution registry writes that fired
+// during evaluation (scope-drift mints, recoverable-deny migrations).
+// rollback() iterates them so a request whose response is later
+// failClosed'd doesn't leak orphan entries. trackSubstitution is the
+// single entry point; postproc.go and stream.go call it after each
+// eval verdict commits.
 type postprocessSession struct {
 	baseCfg                  llmproxy.PostprocessConfig
 	evalCfg                  llmproxy.PostprocessConfig
@@ -22,6 +29,7 @@ type postprocessSession struct {
 	auditBuf                 *pendingAuditEventBuffer
 	finalizer                *pipeline.Finalizer
 	fed                      bool
+	substitutions            []llmproxy.PendingSubstitutionKey
 }
 
 func newPostprocessSession(cfg llmproxy.PostprocessConfig) *postprocessSession {
@@ -78,11 +86,42 @@ func (s *postprocessSession) finalize(ctx context.Context, toolUses []conversati
 }
 
 func (s *postprocessSession) rollback(ctx context.Context, toolUses []conversation.ToolUse, verdictByTU map[string]conversation.ToolUseVerdict) {
-	if s == nil || s.finalizer == nil {
+	if s == nil {
 		return
 	}
-	s.feed(toolUses, verdictByTU)
-	s.finalizer.Rollback(ctx)
+	if s.finalizer != nil {
+		s.feed(toolUses, verdictByTU)
+		s.finalizer.Rollback(ctx)
+	}
+	s.rollbackSubstitutions(ctx)
+}
+
+// trackSubstitution records a pending-substitution registry write so
+// rollback() can revert it if the response is later failClosed'd. Nil
+// keys are ignored so callers can pass through transform results
+// directly without branching.
+func (s *postprocessSession) trackSubstitution(key *llmproxy.PendingSubstitutionKey) {
+	if s == nil || key == nil {
+		return
+	}
+	s.substitutions = append(s.substitutions, *key)
+}
+
+// rollbackSubstitutions deletes every tracked registry write. Idempotent
+// — subsequent calls are no-ops because the slice is cleared.
+func (s *postprocessSession) rollbackSubstitutions(ctx context.Context) {
+	if s == nil || len(s.substitutions) == 0 {
+		return
+	}
+	registry := s.baseCfg.AuthorizationContext.ScopeDrifts
+	if registry == nil {
+		s.substitutions = nil
+		return
+	}
+	for _, key := range s.substitutions {
+		registry.DeletePendingSubstitution(ctx, key)
+	}
+	s.substitutions = nil
 }
 
 func (s *postprocessSession) dropCommitted(ctx context.Context, capture *pipeline.HoldCapture) error {

--- a/internal/runtime/llmproxy/postproc/stream.go
+++ b/internal/runtime/llmproxy/postproc/stream.go
@@ -97,24 +97,11 @@ func PostprocessStream(
 	innerEval := session.evaluator(req, provider, toolUses)
 
 	verdictByTU := make(map[string]conversation.ToolUseVerdict, len(toolUses))
-	var registeredSubstitutions []llmproxy.PendingSubstitutionKey
-	rollbackSubstitutions := func() {
-		registry := cfg.AuthorizationContext.ScopeDrifts
-		if registry == nil {
-			return
-		}
-		for _, key := range registeredSubstitutions {
-			registry.DeletePendingSubstitution(req.Context(), key)
-		}
-		registeredSubstitutions = registeredSubstitutions[:0]
-	}
 	eval := func(tu conversation.ToolUse) conversation.ToolUseVerdict {
 		v := innerEval(tu)
-		var registered *llmproxy.PendingSubstitutionKey
-		v, registered = transformRecoverableDenyToPlaceholder(req.Context(), v, tu, cfg)
-		if registered != nil {
-			registeredSubstitutions = append(registeredSubstitutions, *registered)
-		}
+		v, registered := transformRecoverableDenyToPlaceholder(req.Context(), v, tu, cfg)
+		session.trackSubstitution(registered)
+		session.trackSubstitution(detectScopeDriftSubstitution(req.Context(), v, tu, cfg))
 		verdictByTU[tu.ID] = v
 		return v
 	}
@@ -143,7 +130,6 @@ func PostprocessStream(
 	finalResult, finalErr := session.finalize(req.Context(), toolUses, verdictByTU)
 	if finalErr != nil {
 		session.rollback(req.Context(), toolUses, verdictByTU)
-		rollbackSubstitutions()
 		err := finalErr
 		return llmproxy.PostprocessResult{
 			SkippedReason: err.Error(),

--- a/internal/runtime/llmproxy/postproc/stream.go
+++ b/internal/runtime/llmproxy/postproc/stream.go
@@ -99,6 +99,7 @@ func PostprocessStream(
 	verdictByTU := make(map[string]conversation.ToolUseVerdict, len(toolUses))
 	eval := func(tu conversation.ToolUse) conversation.ToolUseVerdict {
 		v := innerEval(tu)
+		v = transformRecoverableDenyToPlaceholder(req.Context(), v, tu, cfg)
 		verdictByTU[tu.ID] = v
 		return v
 	}

--- a/internal/runtime/llmproxy/postproc/stream.go
+++ b/internal/runtime/llmproxy/postproc/stream.go
@@ -193,7 +193,7 @@ func PostprocessStream(
 		// others don't) fall through to the legacy text path so we
 		// don't accidentally hide a separate refusal under an
 		// AskUserQuestion call the user couldn't act on.
-		if substBlocks, allHaveToolCall := substituteToolCallsForBlocked(decisions); allHaveToolCall && len(substBlocks) > 0 {
+		if substBlocks, allHaveToolCall := substituteToolCallsForBlocked(decisions, rewrittenInput); allHaveToolCall && len(substBlocks) > 0 {
 			if err := writeProviderSubstituteToolCalls(w, provider, streamResult, substBlocks); err != nil {
 				if dropErr := session.dropAllCommittedAndRollback(req.Context()); dropErr != nil {
 					return llmproxy.PostprocessResult{}, fmt.Errorf("substitute tool_call write failed: %w", errors.Join(err, fmt.Errorf("rollback failed: %w", dropErr)))
@@ -409,19 +409,47 @@ type substitutedBlock struct {
 	Call conversation.SyntheticToolCall
 }
 
-// substituteToolCallsForBlocked walks the blocked decisions and
-// pairs each SubstituteWithToolCall payload with its decision's
-// SubstituteWith preamble text. The allHaveToolCall return is true
-// only when EVERY blocked decision supplies a USABLE
-// SubstituteWithToolCall (non-empty Name and a Marshal-able Input)
-// — partial coverage, or a malformed call that can't be marshaled,
-// fall back to the text path so the transport-level behavior matches
-// the buffered Anthropic rewriter (which also falls back to text on
-// the same invariants — see anthropicSubstituteToolUseBlock).
-func substituteToolCallsForBlocked(decisions []conversation.ToolUseDecisionRecord) (blocks []substitutedBlock, allHaveToolCall bool) {
+// mixedTurnBlock represents one content block to emit when the
+// streaming rewriter rewrites an assistant turn that mixes allowed
+// tool_uses with at least one blocked-with-SubstituteWithToolCall
+// decision. Per-decision discrimination so the writer can choose the
+// right SSE shape for each entry in turn order.
+//
+// Exactly one of Allowed / Substitute is set:
+//   - Allowed=true: pass through the model's original tool_use (with
+//     RewriteInput applied when non-empty).
+//   - Substitute non-nil: emit the policy's SyntheticToolCall
+//     placeholder, optionally preceded by the SubstituteWith preamble
+//     text.
+type mixedTurnBlock struct {
+	Allowed      bool
+	ToolUse      conversation.ToolUse
+	RewriteInput json.RawMessage
+	Substitute   *substitutedBlock
+}
+
+// substituteToolCallsForBlocked walks every decision in order and
+// builds the mixedTurnBlock list the streaming writers consume. The
+// allHaveToolCall return is true only when EVERY blocked decision
+// supplies a USABLE SubstituteWithToolCall (non-empty Name and a
+// Marshal-able Input) AND at least one such block exists — partial
+// coverage, or a malformed call that can't be marshaled, falls back
+// to the text path so the transport-level behavior matches the
+// buffered Anthropic rewriter (which also falls back to text on the
+// same invariants — see anthropicSubstituteToolUseBlock). Allowed
+// siblings are emitted as pass-through entries so a mixed turn (some
+// allowed, some substituted) lands on the wire intact rather than
+// silently dropping the allowed siblings.
+func substituteToolCallsForBlocked(decisions []conversation.ToolUseDecisionRecord, rewrittenInput map[string]json.RawMessage) (blocks []mixedTurnBlock, allHaveToolCall bool) {
 	allHaveToolCall = true
+	anyBlockedWithCall := false
 	for _, dec := range decisions {
 		if dec.Verdict.Allowed {
+			blocks = append(blocks, mixedTurnBlock{
+				Allowed:      true,
+				ToolUse:      dec.ToolUse,
+				RewriteInput: rewrittenInput[dec.ToolUse.ID],
+			})
 			continue
 		}
 		call := dec.Verdict.SubstituteWithToolCall
@@ -429,10 +457,16 @@ func substituteToolCallsForBlocked(decisions []conversation.ToolUseDecisionRecor
 			allHaveToolCall = false
 			continue
 		}
-		blocks = append(blocks, substitutedBlock{
-			Text: dec.Verdict.SubstituteWith,
-			Call: *call,
+		anyBlockedWithCall = true
+		blocks = append(blocks, mixedTurnBlock{
+			Substitute: &substitutedBlock{
+				Text: dec.Verdict.SubstituteWith,
+				Call: *call,
+			},
 		})
+	}
+	if !anyBlockedWithCall {
+		allHaveToolCall = false
 	}
 	return blocks, allHaveToolCall
 }
@@ -466,15 +500,17 @@ func canRenderSyntheticToolCall(call *conversation.SyntheticToolCall) bool {
 
 // writeProviderSubstituteToolCalls emits, per blocked decision, an
 // optional preamble text content_block followed by the synthetic
-// tool_use content_block — using the same continuation shape as
-// writeProviderBlockedPrompt: just content_block_* events plus a
-// trailing message_delta/message_stop. The upstream message_start
-// was already forwarded by StreamRewrite, so we do NOT emit a new
-// message_start — that would double-up the message envelope.
+// tool_use content_block. The upstream message_start was already
+// forwarded by StreamRewrite, so we do NOT re-emit a fresh envelope —
+// just the content blocks and a trailing stop event.
 //
-// Only the Anthropic provider is wired today; OpenAI callers fall
-// back to the text path via the gate in PostprocessStream.
-func writeProviderSubstituteToolCalls(w io.Writer, provider conversation.Provider, result conversation.StreamingRewriteResult, blocks []substitutedBlock) error {
+// All three provider shapes are wired so the scope-drift Bash
+// placeholder lands on the wire regardless of how the upstream framed
+// its tool_use:
+//   - Anthropic: content_block_* + message_delta/message_stop
+//   - OpenAI Responses: output_item.added + function_call_arguments.delta/done + output_item.done
+//   - OpenAI Chat: choice.delta.tool_calls fragment + finish_reason=tool_calls
+func writeProviderSubstituteToolCalls(w io.Writer, provider conversation.Provider, result conversation.StreamingRewriteResult, blocks []mixedTurnBlock) error {
 	switch provider {
 	case conversation.ProviderAnthropic:
 		// Index starts after any pass-through text/thinking blocks
@@ -485,18 +521,250 @@ func writeProviderSubstituteToolCalls(w io.Writer, provider conversation.Provide
 			idx = 0
 		}
 		for _, blk := range blocks {
-			if strings.TrimSpace(blk.Text) != "" {
-				if err := writeAnthropicTextBlock(w, idx, blk.Text); err != nil {
+			if blk.Allowed {
+				call := conversation.SyntheticToolCall{
+					ID:   blk.ToolUse.ID,
+					Name: blk.ToolUse.Name,
+				}
+				inputBytes := blk.ToolUse.Input
+				if len(blk.RewriteInput) > 0 {
+					inputBytes = blk.RewriteInput
+				}
+				call.Input = mapFromRawJSON(inputBytes)
+				if err := writeAnthropicToolUseBlock(w, idx, call); err != nil {
+					return err
+				}
+				idx++
+				continue
+			}
+			sub := blk.Substitute
+			if sub == nil {
+				continue
+			}
+			if strings.TrimSpace(sub.Text) != "" {
+				if err := writeAnthropicTextBlock(w, idx, sub.Text); err != nil {
 					return err
 				}
 				idx++
 			}
-			if err := writeAnthropicToolUseBlock(w, idx, blk.Call); err != nil {
+			if err := writeAnthropicToolUseBlock(w, idx, sub.Call); err != nil {
 				return err
 			}
 			idx++
 		}
 		return writeAnthropicStopSSE(w, "tool_use")
+	case conversation.ProviderOpenAI:
+		// Responses vs Chat distinction is encoded in the stream's
+		// StreamFormat hint (set by the upstream parser at envelope
+		// time). Defaulting to Responses preserves the streaming
+		// shape used by Codex/Anthropic-via-OpenAI.
+		switch result.StreamFormat {
+		case "openai_chat":
+			return writeOpenAIChatSubstituteToolCalls(w, result, blocks)
+		default:
+			return writeOpenAIResponsesSubstituteToolCalls(w, result, blocks)
+		}
+	}
+	return nil
+}
+
+// mapFromRawJSON parses a json.RawMessage into the map[string]any
+// shape SyntheticToolCall.Input expects. Tool_use inputs are objects
+// on the wire; a non-object payload (or parse failure) falls back to
+// an empty object so the synthetic writer never emits malformed JSON.
+func mapFromRawJSON(raw json.RawMessage) map[string]any {
+	if len(raw) == 0 {
+		return map[string]any{}
+	}
+	var v map[string]any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return map[string]any{}
+	}
+	return v
+}
+
+// writeOpenAIResponsesSubstituteToolCalls emits Responses-API SSE
+// blocks for each entry in `blocks`: one function_call output item per
+// allowed pass-through or substitute placeholder, preserving turn
+// order. No response.created / response.completed envelope (the
+// upstream already wrote those).
+func writeOpenAIResponsesSubstituteToolCalls(w io.Writer, result conversation.StreamingRewriteResult, blocks []mixedTurnBlock) error {
+	startIdx := result.NextOpenAIOutputIndex
+	if startIdx < 0 {
+		startIdx = 0
+	}
+	for i, blk := range blocks {
+		outputIndex := startIdx + i
+		var (
+			callID string
+			name   string
+			args   []byte
+		)
+		if blk.Allowed {
+			callID = blk.ToolUse.ID
+			name = blk.ToolUse.Name
+			inputBytes := blk.ToolUse.Input
+			if len(blk.RewriteInput) > 0 {
+				inputBytes = blk.RewriteInput
+			}
+			if len(inputBytes) == 0 {
+				args = []byte("{}")
+			} else {
+				args = inputBytes
+			}
+		} else if blk.Substitute != nil {
+			callID = blk.Substitute.Call.ID
+			name = blk.Substitute.Call.Name
+			input := blk.Substitute.Call.Input
+			if input == nil {
+				input = map[string]any{}
+			}
+			marshalled, err := json.Marshal(input)
+			if err != nil {
+				return err
+			}
+			args = marshalled
+		} else {
+			continue
+		}
+		itemID := "fc_" + callID
+		if err := writeSSE(w, "response.output_item.added", map[string]any{
+			"type":         "response.output_item.added",
+			"output_index": outputIndex,
+			"item": map[string]any{
+				"id":      itemID,
+				"type":    "function_call",
+				"status":  "in_progress",
+				"call_id": callID,
+				"name":    name,
+			},
+		}); err != nil {
+			return err
+		}
+		if err := writeSSE(w, "response.function_call_arguments.delta", map[string]any{
+			"type":         "response.function_call_arguments.delta",
+			"item_id":      itemID,
+			"output_index": outputIndex,
+			"delta":        string(args),
+		}); err != nil {
+			return err
+		}
+		if err := writeSSE(w, "response.function_call_arguments.done", map[string]any{
+			"type":         "response.function_call_arguments.done",
+			"item_id":      itemID,
+			"output_index": outputIndex,
+			"name":         name,
+			"arguments":    string(args),
+		}); err != nil {
+			return err
+		}
+		if err := writeSSE(w, "response.output_item.done", map[string]any{
+			"type":         "response.output_item.done",
+			"output_index": outputIndex,
+			"item": map[string]any{
+				"id":        itemID,
+				"type":      "function_call",
+				"status":    "completed",
+				"call_id":   callID,
+				"name":      name,
+				"arguments": string(args),
+			},
+		}); err != nil {
+			return err
+		}
+	}
+	return writeSSE(w, "response.completed", map[string]any{
+		"type":     "response.completed",
+		"response": map[string]any{"id": "resp_clawvisor_substitute", "status": "completed"},
+	})
+}
+
+// writeOpenAIChatSubstituteToolCalls emits a Chat Completions choice
+// fragment with a tool_calls delta covering every substitute block,
+// followed by a finish_reason=tool_calls chunk. The upstream
+// chat.completion.chunk envelope (id, model, …) is preserved by the
+// streaming rewriter's pass-through; we only need to emit the
+// tool_calls delta and a stop fragment.
+func writeOpenAIChatSubstituteToolCalls(w io.Writer, _ conversation.StreamingRewriteResult, blocks []mixedTurnBlock) error {
+	toolCalls := make([]map[string]any, 0, len(blocks))
+	for i, blk := range blocks {
+		var (
+			callID string
+			name   string
+			args   []byte
+		)
+		if blk.Allowed {
+			callID = blk.ToolUse.ID
+			name = blk.ToolUse.Name
+			inputBytes := blk.ToolUse.Input
+			if len(blk.RewriteInput) > 0 {
+				inputBytes = blk.RewriteInput
+			}
+			if len(inputBytes) == 0 {
+				args = []byte("{}")
+			} else {
+				args = inputBytes
+			}
+		} else if blk.Substitute != nil {
+			callID = blk.Substitute.Call.ID
+			name = blk.Substitute.Call.Name
+			input := blk.Substitute.Call.Input
+			if input == nil {
+				input = map[string]any{}
+			}
+			marshalled, err := json.Marshal(input)
+			if err != nil {
+				return err
+			}
+			args = marshalled
+		} else {
+			continue
+		}
+		toolCalls = append(toolCalls, map[string]any{
+			"index": i,
+			"id":    callID,
+			"type":  "function",
+			"function": map[string]any{
+				"name":      name,
+				"arguments": string(args),
+			},
+		})
+	}
+	deltaChunk := map[string]any{
+		"id":      "chatcmpl_clawvisor_substitute",
+		"object":  "chat.completion.chunk",
+		"choices": []map[string]any{{"index": 0, "delta": map[string]any{"tool_calls": toolCalls}}},
+	}
+	deltaBytes, err := json.Marshal(deltaChunk)
+	if err != nil {
+		return err
+	}
+	if _, err := w.Write([]byte("data: ")); err != nil {
+		return err
+	}
+	if _, err := w.Write(deltaBytes); err != nil {
+		return err
+	}
+	if _, err := w.Write([]byte("\n\n")); err != nil {
+		return err
+	}
+	finishChunk := map[string]any{
+		"id":      "chatcmpl_clawvisor_substitute",
+		"object":  "chat.completion.chunk",
+		"choices": []map[string]any{{"index": 0, "delta": map[string]any{}, "finish_reason": "tool_calls"}},
+	}
+	finishBytes, err := json.Marshal(finishChunk)
+	if err != nil {
+		return err
+	}
+	if _, err := w.Write([]byte("data: ")); err != nil {
+		return err
+	}
+	if _, err := w.Write(finishBytes); err != nil {
+		return err
+	}
+	if _, err := w.Write([]byte("\n\ndata: [DONE]\n\n")); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/runtime/llmproxy/postproc/stream.go
+++ b/internal/runtime/llmproxy/postproc/stream.go
@@ -97,9 +97,24 @@ func PostprocessStream(
 	innerEval := session.evaluator(req, provider, toolUses)
 
 	verdictByTU := make(map[string]conversation.ToolUseVerdict, len(toolUses))
+	var registeredSubstitutions []llmproxy.PendingSubstitutionKey
+	rollbackSubstitutions := func() {
+		registry := cfg.AuthorizationContext.ScopeDrifts
+		if registry == nil {
+			return
+		}
+		for _, key := range registeredSubstitutions {
+			registry.DeletePendingSubstitution(req.Context(), key)
+		}
+		registeredSubstitutions = registeredSubstitutions[:0]
+	}
 	eval := func(tu conversation.ToolUse) conversation.ToolUseVerdict {
 		v := innerEval(tu)
-		v = transformRecoverableDenyToPlaceholder(req.Context(), v, tu, cfg)
+		var registered *llmproxy.PendingSubstitutionKey
+		v, registered = transformRecoverableDenyToPlaceholder(req.Context(), v, tu, cfg)
+		if registered != nil {
+			registeredSubstitutions = append(registeredSubstitutions, *registered)
+		}
 		verdictByTU[tu.ID] = v
 		return v
 	}
@@ -128,6 +143,7 @@ func PostprocessStream(
 	finalResult, finalErr := session.finalize(req.Context(), toolUses, verdictByTU)
 	if finalErr != nil {
 		session.rollback(req.Context(), toolUses, verdictByTU)
+		rollbackSubstitutions()
 		err := finalErr
 		return llmproxy.PostprocessResult{
 			SkippedReason: err.Error(),

--- a/internal/runtime/llmproxy/scope_drift_e2e_test.go
+++ b/internal/runtime/llmproxy/scope_drift_e2e_test.go
@@ -749,6 +749,276 @@ func TestScopeDriftE2E_NewTaskFullStateMachine(t *testing.T) {
 // fakeInlineTaskCreator and mustJSON are defined in sibling test files
 // (inline_task_release_test.go and secret_detection_test.go).
 
+// ── Inbound rewrite: placeholder → original tool_use + menu tool_result ─────
+
+// TestScopeDriftE2E_InboundRewritesPlaceholder drives the full
+// mutate→inbound-restore round-trip on a representative Anthropic
+// /v1/messages body:
+//
+//  1. Seed the registry with a pending substitution (mirroring what
+//     the mint path writes alongside the drift).
+//  2. Build an inbound /v1/messages body whose history reflects what
+//     the harness sends after running the placeholder: an assistant
+//     turn carrying the Bash placeholder tool_use with the original
+//     tool_use_id, paired with a user turn whose tool_result names
+//     the same tool_use_id.
+//  3. Run RewriteScopeDriftPlaceholders.
+//  4. Assert the assistant turn was restored byte-for-byte (the
+//     model's original Bash command + input survives) AND the
+//     user-turn tool_result content is the menu text.
+//
+// Also asserts the substitution is consumed one-shot — a second
+// RewriteScopeDriftPlaceholders is a no-op.
+func TestScopeDriftE2E_InboundRewritesPlaceholder(t *testing.T) {
+	t.Parallel()
+	reg := NewMemoryScopeDriftRegistry(time.Minute)
+	const (
+		toolUseID        = "tu-blocked-inbound"
+		originalToolName = "Bash"
+		menuText         = "Clawvisor: github.post_issue is outside your current task scope.\n  Drift ID: drift-fake-1\n(menu body…)"
+	)
+	originalInput := json.RawMessage(`{"command":"curl -X POST https://api.github.com/repos/o/r/issues -d '{\"title\":\"hi\"}'"}`)
+	if err := reg.RegisterPendingSubstitution(context.Background(),
+		PendingSubstitutionKey{
+			AgentID:        driftTestAgentID,
+			ConversationID: driftTestConvID,
+			ToolUseID:      toolUseID,
+		},
+		PendingSubstitution{
+			DriftID:           "drift-fake-1",
+			MenuText:          menuText,
+			OriginalToolName:  originalToolName,
+			OriginalToolInput: append([]byte(nil), originalInput...),
+		},
+	); err != nil {
+		t.Fatalf("RegisterPendingSubstitution: %v", err)
+	}
+
+	placeholderCmd := BuildScopeDriftPlaceholderCommand(originalToolName, "drift-fake-1")
+	body := []byte(`{"messages":[` +
+		`{"role":"user","content":"open an issue"},` +
+		`{"role":"assistant","content":[{"type":"tool_use","id":"` + toolUseID + `","name":"Bash","input":{"command":` + string(mustJSON(placeholderCmd)) + `}}]},` +
+		`{"role":"user","content":[{"type":"tool_result","tool_use_id":"` + toolUseID + `","content":"command exited 0"}]}` +
+		`]}`)
+
+	agent := &store.Agent{ID: driftTestAgentID, UserID: driftTestUserID}
+	result, err := RewriteScopeDriftPlaceholders(context.Background(), ScopeDriftInboundRewriteRequest{
+		HTTPRequest:    httptest.NewRequest("POST", "/v1/messages", nil),
+		Provider:       conversation.ProviderAnthropic,
+		Body:           body,
+		Agent:          agent,
+		ConversationID: driftTestConvID,
+		ScopeDrifts:    reg,
+		Logger:         slog.Default(),
+	})
+	if err != nil {
+		t.Fatalf("RewriteScopeDriftPlaceholders: %v", err)
+	}
+	if !result.Rewritten {
+		t.Fatal("expected Rewritten=true")
+	}
+	if want := []string{"drift-fake-1"}; len(result.AppliedDriftIDs) != 1 || result.AppliedDriftIDs[0] != want[0] {
+		t.Fatalf("AppliedDriftIDs = %v, want %v", result.AppliedDriftIDs, want)
+	}
+
+	var rewritten struct {
+		Messages []json.RawMessage `json:"messages"`
+	}
+	if err := json.Unmarshal(result.Body, &rewritten); err != nil {
+		t.Fatalf("rewritten body unmarshal: %v", err)
+	}
+	if len(rewritten.Messages) != 3 {
+		t.Fatalf("expected 3 messages after rewrite, got %d", len(rewritten.Messages))
+	}
+
+	// Assistant turn: tool_use restored byte-for-byte.
+	var assistantMsg struct {
+		Role    string `json:"role"`
+		Content []struct {
+			Type  string          `json:"type"`
+			ID    string          `json:"id"`
+			Name  string          `json:"name"`
+			Input json.RawMessage `json:"input"`
+		} `json:"content"`
+	}
+	if err := json.Unmarshal(rewritten.Messages[1], &assistantMsg); err != nil {
+		t.Fatalf("assistant message unmarshal: %v", err)
+	}
+	if assistantMsg.Role != "assistant" {
+		t.Fatalf("assistant message role = %q, want assistant", assistantMsg.Role)
+	}
+	if len(assistantMsg.Content) != 1 || assistantMsg.Content[0].Type != "tool_use" {
+		t.Fatalf("assistant content shape unexpected: %+v", assistantMsg.Content)
+	}
+	if assistantMsg.Content[0].Name != originalToolName {
+		t.Fatalf("restored tool name = %q, want %q (Bash placeholder should have been replaced)", assistantMsg.Content[0].Name, originalToolName)
+	}
+	if assistantMsg.Content[0].ID != toolUseID {
+		t.Fatalf("restored tool_use_id = %q, want %q (id must round-trip)", assistantMsg.Content[0].ID, toolUseID)
+	}
+	if string(assistantMsg.Content[0].Input) != string(originalInput) {
+		t.Fatalf("restored tool input mismatch:\n  got:  %s\n  want: %s", string(assistantMsg.Content[0].Input), string(originalInput))
+	}
+
+	// User turn: tool_result content is the menu text.
+	var userMsg struct {
+		Role    string `json:"role"`
+		Content []struct {
+			Type      string          `json:"type"`
+			ToolUseID string          `json:"tool_use_id"`
+			Content   json.RawMessage `json:"content"`
+		} `json:"content"`
+	}
+	if err := json.Unmarshal(rewritten.Messages[2], &userMsg); err != nil {
+		t.Fatalf("user message unmarshal: %v", err)
+	}
+	if userMsg.Role != "user" {
+		t.Fatalf("user message role = %q, want user", userMsg.Role)
+	}
+	if len(userMsg.Content) != 1 || userMsg.Content[0].Type != "tool_result" {
+		t.Fatalf("user content shape unexpected: %+v", userMsg.Content)
+	}
+	var resultBlocks []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(userMsg.Content[0].Content, &resultBlocks); err != nil {
+		t.Fatalf("tool_result content unmarshal: %v", err)
+	}
+	if len(resultBlocks) != 1 || resultBlocks[0].Type != "text" {
+		t.Fatalf("expected single text block in tool_result, got %+v", resultBlocks)
+	}
+	if !strings.Contains(resultBlocks[0].Text, "outside your current task scope") {
+		t.Fatalf("tool_result content does not carry menu text:\n%s", resultBlocks[0].Text)
+	}
+	if !strings.Contains(resultBlocks[0].Text, "Drift ID: drift-fake-1") {
+		t.Fatalf("tool_result content missing Drift ID:\n%s", resultBlocks[0].Text)
+	}
+
+	// Persistence: a second rewrite (next conversation turn) still
+	// finds the substitution and restores the placeholder. The harness
+	// keeps the Bash placeholder in its stored history for the rest of
+	// the conversation; without persistent restoration the model would
+	// see its own past as the placeholder from turn 3 onward.
+	second, err := RewriteScopeDriftPlaceholders(context.Background(), ScopeDriftInboundRewriteRequest{
+		HTTPRequest:    httptest.NewRequest("POST", "/v1/messages", nil),
+		Provider:       conversation.ProviderAnthropic,
+		Body:           body,
+		Agent:          agent,
+		ConversationID: driftTestConvID,
+		ScopeDrifts:    reg,
+		Logger:         slog.Default(),
+	})
+	if err != nil {
+		t.Fatalf("second RewriteScopeDriftPlaceholders: %v", err)
+	}
+	if !second.Rewritten {
+		t.Fatal("expected second rewrite to also restore the placeholder (substitutions persist across turns)")
+	}
+}
+
+// TestScopeDriftE2E_InboundRewritesOpenAIResponsesPlaceholder mirrors
+// TestScopeDriftE2E_InboundRewritesPlaceholder but on the OpenAI
+// Responses wire shape: the previous turn's function_call gets
+// restored byte-for-byte and the matching function_call_output's
+// content is the menu text.
+func TestScopeDriftE2E_InboundRewritesOpenAIResponsesPlaceholder(t *testing.T) {
+	t.Parallel()
+	reg := NewMemoryScopeDriftRegistry(time.Minute)
+	const (
+		callID           = "call_1"
+		originalToolName = "exec_command"
+		menuText         = "Clawvisor: github.post_issue is outside your current task scope.\n  Drift ID: drift-fake-openai-1\n(menu body…)"
+	)
+	originalInput := json.RawMessage(`{"cmd":"mkdir /tmp/needs-task"}`)
+	if err := reg.RegisterPendingSubstitution(context.Background(),
+		PendingSubstitutionKey{
+			AgentID:        driftTestAgentID,
+			ConversationID: driftTestConvID,
+			ToolUseID:      callID,
+		},
+		PendingSubstitution{
+			DriftID:           "drift-fake-openai-1",
+			MenuText:          menuText,
+			OriginalToolName:  originalToolName,
+			OriginalToolInput: append([]byte(nil), originalInput...),
+		},
+	); err != nil {
+		t.Fatalf("RegisterPendingSubstitution: %v", err)
+	}
+
+	placeholderCmd := BuildScopeDriftPlaceholderCommand(originalToolName, "drift-fake-openai-1")
+	placeholderArgs, _ := json.Marshal(map[string]string{"command": placeholderCmd})
+
+	body := []byte(`{"input":[` +
+		`{"type":"message","role":"user","content":"open an issue"},` +
+		`{"type":"function_call","call_id":"` + callID + `","name":"Bash","arguments":` + string(mustJSON(string(placeholderArgs))) + `},` +
+		`{"type":"function_call_output","call_id":"` + callID + `","output":"command exited 0"}` +
+		`]}`)
+
+	agent := &store.Agent{ID: driftTestAgentID, UserID: driftTestUserID}
+	httpReq := httptest.NewRequest("POST", "/v1/responses", nil)
+	result, err := RewriteScopeDriftPlaceholders(context.Background(), ScopeDriftInboundRewriteRequest{
+		HTTPRequest:    httpReq,
+		Provider:       conversation.ProviderOpenAI,
+		Body:           body,
+		Agent:          agent,
+		ConversationID: driftTestConvID,
+		ScopeDrifts:    reg,
+		Logger:         slog.Default(),
+	})
+	if err != nil {
+		t.Fatalf("RewriteScopeDriftPlaceholders: %v", err)
+	}
+	if !result.Rewritten {
+		t.Fatalf("expected Rewritten=true; AppliedDriftIDs=%v", result.AppliedDriftIDs)
+	}
+
+	var rewritten struct {
+		Input []json.RawMessage `json:"input"`
+	}
+	if err := json.Unmarshal(result.Body, &rewritten); err != nil {
+		t.Fatalf("rewritten body unmarshal: %v", err)
+	}
+	if len(rewritten.Input) != 3 {
+		t.Fatalf("expected 3 input items after rewrite, got %d", len(rewritten.Input))
+	}
+
+	var fc struct {
+		Type      string `json:"type"`
+		CallID    string `json:"call_id"`
+		Name      string `json:"name"`
+		Arguments string `json:"arguments"`
+	}
+	if err := json.Unmarshal(rewritten.Input[1], &fc); err != nil {
+		t.Fatalf("function_call unmarshal: %v", err)
+	}
+	if fc.Type != "function_call" || fc.CallID != callID {
+		t.Fatalf("function_call shape mismatch: %+v", fc)
+	}
+	if fc.Name != originalToolName {
+		t.Fatalf("restored function_call name = %q, want %q", fc.Name, originalToolName)
+	}
+	if fc.Arguments != string(originalInput) {
+		t.Fatalf("restored function_call arguments = %q, want %q", fc.Arguments, string(originalInput))
+	}
+
+	var fco struct {
+		Type   string `json:"type"`
+		CallID string `json:"call_id"`
+		Output string `json:"output"`
+	}
+	if err := json.Unmarshal(rewritten.Input[2], &fco); err != nil {
+		t.Fatalf("function_call_output unmarshal: %v", err)
+	}
+	if fco.Type != "function_call_output" || fco.CallID != callID {
+		t.Fatalf("function_call_output shape mismatch: %+v", fco)
+	}
+	if !strings.Contains(fco.Output, "outside your current task scope") {
+		t.Fatalf("function_call_output does not carry menu text: %s", fco.Output)
+	}
+}
+
 // peekAllHolds returns every hold for the test fixture's (user, agent,
 // conv) bucket. SnapshotHoldsForTest keys by a zero-conversation
 // bucket and would miss conversation-scoped holds; this helper reaches

--- a/internal/runtime/llmproxy/scope_drift_inbound_rewrite.go
+++ b/internal/runtime/llmproxy/scope_drift_inbound_rewrite.go
@@ -169,32 +169,42 @@ func rewriteAnthropicScopeDriftPlaceholders(ctx context.Context, req ScopeDriftI
 	}
 	appliedDriftIDs := make([]string, 0, len(hits))
 	for _, hit := range hits {
-		newMessage, ok := substituteAnthropicToolResultContent(messages[hit.UserMsgIdx], hit.ToolUseID, hit.Substitution.MenuText)
-		if !ok {
-			logger.WarnContext(ctx, "scope-drift inbound rewrite: failed to substitute tool_result content",
-				"tool_use_id", hit.ToolUseID,
-				"drift_id", hit.Substitution.DriftID,
-			)
-			continue
-		}
-		messages[hit.UserMsgIdx] = newMessage
-
-		restored := false
+		// Restore the assistant turn FIRST so a failure here doesn't
+		// leave the user turn carrying the menu while the assistant
+		// turn still has the placeholder — that asymmetry leaves the
+		// transcript permanently inconsistent (the model sees a
+		// placeholder Bash followed by the menu, with nothing tying
+		// them to its actual call). Skip the whole hit on restore
+		// failure; the substitution stays in the registry for the
+		// next inbound retry.
+		restoredIdx := -1
+		var restoredMessage json.RawMessage
 		for ai := hit.UserMsgIdx - 1; ai >= 0; ai-- {
 			candidate, ok := restoreAnthropicAssistantToolUse(messages[ai], hit.ToolUseID, hit.Substitution.OriginalToolName, hit.Substitution.OriginalToolInput)
 			if !ok {
 				continue
 			}
-			messages[ai] = candidate
-			restored = true
+			restoredIdx = ai
+			restoredMessage = candidate
 			break
 		}
-		if !restored {
-			logger.WarnContext(ctx, "scope-drift inbound rewrite: could not locate placeholder assistant turn for restoration",
+		if restoredIdx < 0 {
+			logger.WarnContext(ctx, "scope-drift inbound rewrite: could not locate placeholder assistant turn for restoration; skipping substitution",
 				"tool_use_id", hit.ToolUseID,
 				"drift_id", hit.Substitution.DriftID,
 			)
+			continue
 		}
+		newUserMessage, ok := substituteAnthropicToolResultContent(messages[hit.UserMsgIdx], hit.ToolUseID, hit.Substitution.MenuText)
+		if !ok {
+			logger.WarnContext(ctx, "scope-drift inbound rewrite: failed to substitute tool_result content; skipping restoration",
+				"tool_use_id", hit.ToolUseID,
+				"drift_id", hit.Substitution.DriftID,
+			)
+			continue
+		}
+		messages[restoredIdx] = restoredMessage
+		messages[hit.UserMsgIdx] = newUserMessage
 		appliedDriftIDs = append(appliedDriftIDs, hit.Substitution.DriftID)
 	}
 
@@ -319,31 +329,38 @@ func rewriteOpenAIResponsesScopeDriftPlaceholders(ctx context.Context, req Scope
 		if !found {
 			continue
 		}
-		newItem, ok := substituteOpenAIResponsesFunctionCallOutput(item, subst.MenuText)
-		if !ok {
-			logger.WarnContext(ctx, "scope-drift inbound rewrite: failed to substitute function_call_output",
-				"call_id", probe.CallID,
-				"drift_id", subst.DriftID,
-			)
-			continue
-		}
-		items[i] = newItem
-		restored := false
+		// Restore the prior function_call FIRST so a failure here
+		// doesn't leave the function_call_output carrying the menu
+		// while the assistant call remains the placeholder — see
+		// rewriteAnthropicScopeDriftPlaceholders for the rationale.
+		restoredIdx := -1
+		var restoredItem json.RawMessage
 		for ai := i - 1; ai >= 0; ai-- {
 			candidate, ok := restoreOpenAIResponsesFunctionCall(items[ai], probe.CallID, subst.OriginalToolName, subst.OriginalToolInput)
 			if !ok {
 				continue
 			}
-			items[ai] = candidate
-			restored = true
+			restoredIdx = ai
+			restoredItem = candidate
 			break
 		}
-		if !restored {
-			logger.WarnContext(ctx, "scope-drift inbound rewrite: could not locate placeholder function_call for restoration",
+		if restoredIdx < 0 {
+			logger.WarnContext(ctx, "scope-drift inbound rewrite: could not locate placeholder function_call for restoration; skipping substitution",
 				"call_id", probe.CallID,
 				"drift_id", subst.DriftID,
 			)
+			continue
 		}
+		newItem, ok := substituteOpenAIResponsesFunctionCallOutput(item, subst.MenuText)
+		if !ok {
+			logger.WarnContext(ctx, "scope-drift inbound rewrite: failed to substitute function_call_output; skipping restoration",
+				"call_id", probe.CallID,
+				"drift_id", subst.DriftID,
+			)
+			continue
+		}
+		items[restoredIdx] = restoredItem
+		items[i] = newItem
 		appliedDriftIDs = append(appliedDriftIDs, subst.DriftID)
 		rewrittenAny = true
 	}
@@ -461,31 +478,36 @@ func rewriteOpenAIChatScopeDriftPlaceholders(ctx context.Context, req ScopeDrift
 		if !found {
 			continue
 		}
-		newMsg, ok := substituteOpenAIChatToolMessage(msg, subst.MenuText)
-		if !ok {
-			logger.WarnContext(ctx, "scope-drift inbound rewrite: failed to substitute chat tool message",
-				"tool_call_id", probe.ToolCallID,
-				"drift_id", subst.DriftID,
-			)
-			continue
-		}
-		messages[i] = newMsg
-		restored := false
+		// Restore the prior assistant tool_call FIRST — see
+		// rewriteAnthropicScopeDriftPlaceholders for the rationale.
+		restoredIdx := -1
+		var restoredMsg json.RawMessage
 		for ai := i - 1; ai >= 0; ai-- {
 			candidate, ok := restoreOpenAIChatAssistantToolCall(messages[ai], probe.ToolCallID, subst.OriginalToolName, subst.OriginalToolInput)
 			if !ok {
 				continue
 			}
-			messages[ai] = candidate
-			restored = true
+			restoredIdx = ai
+			restoredMsg = candidate
 			break
 		}
-		if !restored {
-			logger.WarnContext(ctx, "scope-drift inbound rewrite: could not locate placeholder assistant tool_call for restoration",
+		if restoredIdx < 0 {
+			logger.WarnContext(ctx, "scope-drift inbound rewrite: could not locate placeholder assistant tool_call for restoration; skipping substitution",
 				"tool_call_id", probe.ToolCallID,
 				"drift_id", subst.DriftID,
 			)
+			continue
 		}
+		newMsg, ok := substituteOpenAIChatToolMessage(msg, subst.MenuText)
+		if !ok {
+			logger.WarnContext(ctx, "scope-drift inbound rewrite: failed to substitute chat tool message; skipping restoration",
+				"tool_call_id", probe.ToolCallID,
+				"drift_id", subst.DriftID,
+			)
+			continue
+		}
+		messages[restoredIdx] = restoredMsg
+		messages[i] = newMsg
 		appliedDriftIDs = append(appliedDriftIDs, subst.DriftID)
 		rewrittenAny = true
 	}

--- a/internal/runtime/llmproxy/scope_drift_inbound_rewrite.go
+++ b/internal/runtime/llmproxy/scope_drift_inbound_rewrite.go
@@ -1,0 +1,676 @@
+package llmproxy
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+// ScopeDriftInboundRewriteRequest is the input to
+// RewriteScopeDriftPlaceholders. The caller supplies the inbound
+// /v1/messages body and identifying context; the rewriter consults the
+// ScopeDriftRegistry for pending substitutions and returns the rewritten
+// body when one or more applied.
+type ScopeDriftInboundRewriteRequest struct {
+	HTTPRequest    *http.Request
+	Provider       conversation.Provider
+	Body           []byte
+	Agent          *store.Agent
+	ConversationID string
+	ScopeDrifts    ScopeDriftRegistry
+	Logger         *slog.Logger
+}
+
+// ScopeDriftInboundRewriteResult reports what the rewriter did.
+type ScopeDriftInboundRewriteResult struct {
+	Body            []byte
+	Rewritten       bool
+	AppliedDriftIDs []string
+}
+
+// RewriteScopeDriftPlaceholders walks the inbound /v1/messages body
+// looking for tool_result blocks whose tool_use_id matches a pending
+// scope-drift substitution. For each match:
+//
+//  1. The matching tool_result's content is replaced with the drift's
+//     menu text.
+//  2. The corresponding tool_use block in the prior assistant turn —
+//     a harness-side Bash placeholder we substituted on the response
+//     leg — is restored to the model's original tool_use (name +
+//     input bytes) byte-for-byte.
+//
+// The substitution is one-shot: LookupPendingSubstitution consumes the
+// registry entry. If the rewrite fails (malformed body, missing
+// assistant turn) the entry is NOT re-registered — the agent's next
+// retry mints a fresh drift on the normal path.
+//
+// Returns (body, Rewritten=false, nil) when no substitutions apply.
+// Errors only on body shape failures the caller should treat as fail-
+// closed — typical "no match" paths return Rewritten=false.
+func RewriteScopeDriftPlaceholders(ctx context.Context, req ScopeDriftInboundRewriteRequest) (ScopeDriftInboundRewriteResult, error) {
+	out := ScopeDriftInboundRewriteResult{Body: req.Body}
+	if req.ScopeDrifts == nil || req.Agent == nil {
+		return out, nil
+	}
+	var (
+		rewritten []byte
+		applied   []string
+		err       error
+	)
+	switch req.Provider {
+	case conversation.ProviderAnthropic:
+		rewritten, applied, err = rewriteAnthropicScopeDriftPlaceholders(ctx, req)
+	case conversation.ProviderOpenAI:
+		if conversation.IsOpenAIChatCompletionsEndpoint(req.HTTPRequest) {
+			rewritten, applied, err = rewriteOpenAIChatScopeDriftPlaceholders(ctx, req)
+		} else {
+			rewritten, applied, err = rewriteOpenAIResponsesScopeDriftPlaceholders(ctx, req)
+		}
+	default:
+		return out, nil
+	}
+	if err != nil {
+		return out, err
+	}
+	if rewritten == nil {
+		return out, nil
+	}
+	out.Body = rewritten
+	out.Rewritten = true
+	out.AppliedDriftIDs = applied
+	return out, nil
+}
+
+func rewriteAnthropicScopeDriftPlaceholders(ctx context.Context, req ScopeDriftInboundRewriteRequest) ([]byte, []string, error) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(req.Body, &raw); err != nil {
+		return nil, nil, err
+	}
+	msgsRaw, ok := raw["messages"]
+	if !ok {
+		return nil, nil, nil
+	}
+	var messages []json.RawMessage
+	if err := json.Unmarshal(msgsRaw, &messages); err != nil {
+		return nil, nil, err
+	}
+	// Two-pass walk: identify every tool_use_id that has a pending
+	// substitution (by probing user-turn tool_result blocks), then
+	// apply the substitutions in a single body edit so partial failures
+	// don't leave half-applied state.
+	type pendingHit struct {
+		ToolUseID    string
+		Substitution PendingSubstitution
+		UserMsgIdx   int
+		BlockIdx     int
+	}
+	var hits []pendingHit
+	for i, msg := range messages {
+		var probe struct {
+			Role    string          `json:"role"`
+			Content json.RawMessage `json:"content"`
+		}
+		if err := json.Unmarshal(msg, &probe); err != nil {
+			continue
+		}
+		if probe.Role != "user" || len(probe.Content) == 0 {
+			continue
+		}
+		var blocks []json.RawMessage
+		if err := json.Unmarshal(probe.Content, &blocks); err != nil {
+			// String-form user content carries no tool_results.
+			continue
+		}
+		for bi, blk := range blocks {
+			var blkProbe struct {
+				Type      string `json:"type"`
+				ToolUseID string `json:"tool_use_id"`
+			}
+			if err := json.Unmarshal(blk, &blkProbe); err != nil {
+				continue
+			}
+			if blkProbe.Type != "tool_result" || blkProbe.ToolUseID == "" {
+				continue
+			}
+			subst, found := req.ScopeDrifts.LookupPendingSubstitution(ctx, PendingSubstitutionKey{
+				AgentID:        req.Agent.ID,
+				ConversationID: req.ConversationID,
+				ToolUseID:      blkProbe.ToolUseID,
+			})
+			if !found {
+				continue
+			}
+			hits = append(hits, pendingHit{
+				ToolUseID:    blkProbe.ToolUseID,
+				Substitution: subst,
+				UserMsgIdx:   i,
+				BlockIdx:     bi,
+			})
+		}
+	}
+	if len(hits) == 0 {
+		return nil, nil, nil
+	}
+
+	// Apply substitutions. For each hit:
+	//   - rewrite the matching user-turn tool_result block's content
+	//   - walk back through prior assistant turns to find the tool_use
+	//     block carrying the placeholder for this id, and restore the
+	//     original name + input.
+	logger := req.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	appliedDriftIDs := make([]string, 0, len(hits))
+	for _, hit := range hits {
+		newMessage, ok := substituteAnthropicToolResultContent(messages[hit.UserMsgIdx], hit.ToolUseID, hit.Substitution.MenuText)
+		if !ok {
+			logger.WarnContext(ctx, "scope-drift inbound rewrite: failed to substitute tool_result content",
+				"tool_use_id", hit.ToolUseID,
+				"drift_id", hit.Substitution.DriftID,
+			)
+			continue
+		}
+		messages[hit.UserMsgIdx] = newMessage
+
+		restored := false
+		for ai := hit.UserMsgIdx - 1; ai >= 0; ai-- {
+			candidate, ok := restoreAnthropicAssistantToolUse(messages[ai], hit.ToolUseID, hit.Substitution.OriginalToolName, hit.Substitution.OriginalToolInput)
+			if !ok {
+				continue
+			}
+			messages[ai] = candidate
+			restored = true
+			break
+		}
+		if !restored {
+			logger.WarnContext(ctx, "scope-drift inbound rewrite: could not locate placeholder assistant turn for restoration",
+				"tool_use_id", hit.ToolUseID,
+				"drift_id", hit.Substitution.DriftID,
+			)
+		}
+		appliedDriftIDs = append(appliedDriftIDs, hit.Substitution.DriftID)
+	}
+
+	newMsgs, err := json.Marshal(messages)
+	if err != nil {
+		return nil, nil, err
+	}
+	raw["messages"] = newMsgs
+	out, err := json.Marshal(raw)
+	if err != nil {
+		return nil, nil, err
+	}
+	return out, appliedDriftIDs, nil
+}
+
+// substituteAnthropicToolResultContent replaces the content field of
+// the tool_result block whose tool_use_id matches targetToolUseID. The
+// replacement is rendered as a single text block to match Anthropic's
+// preferred multi-block tool_result shape — string-form content works
+// too but blocks survive concatenation with other model-generated
+// content cleanly.
+func substituteAnthropicToolResultContent(message json.RawMessage, targetToolUseID, menuText string) (json.RawMessage, bool) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(message, &raw); err != nil {
+		return nil, false
+	}
+	contentRaw, ok := raw["content"]
+	if !ok {
+		return nil, false
+	}
+	var blocks []json.RawMessage
+	if err := json.Unmarshal(contentRaw, &blocks); err != nil {
+		return nil, false
+	}
+	rewritten := false
+	for i, blk := range blocks {
+		var probe struct {
+			Type      string `json:"type"`
+			ToolUseID string `json:"tool_use_id"`
+		}
+		if err := json.Unmarshal(blk, &probe); err != nil {
+			continue
+		}
+		if probe.Type != "tool_result" || probe.ToolUseID != targetToolUseID {
+			continue
+		}
+		newBlock, err := json.Marshal(map[string]any{
+			"type":        "tool_result",
+			"tool_use_id": targetToolUseID,
+			"content": []map[string]any{{
+				"type": "text",
+				"text": menuText,
+			}},
+		})
+		if err != nil {
+			continue
+		}
+		blocks[i] = newBlock
+		rewritten = true
+	}
+	if !rewritten {
+		return nil, false
+	}
+	newContent, err := json.Marshal(blocks)
+	if err != nil {
+		return nil, false
+	}
+	raw["content"] = newContent
+	out, err := json.Marshal(raw)
+	if err != nil {
+		return nil, false
+	}
+	return out, true
+}
+
+// rewriteOpenAIResponsesScopeDriftPlaceholders walks the OpenAI
+// Responses `input` array, finds function_call_output items whose
+// call_id matches a pending substitution, replaces the `output` with
+// the menu text, and restores the preceding function_call item's
+// (name, arguments) to the model's original.
+func rewriteOpenAIResponsesScopeDriftPlaceholders(ctx context.Context, req ScopeDriftInboundRewriteRequest) ([]byte, []string, error) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(req.Body, &raw); err != nil {
+		return nil, nil, err
+	}
+	inputRaw, ok := raw["input"]
+	if !ok {
+		return nil, nil, nil
+	}
+	// `input` can be a plain string (single-turn). Plain-string inputs
+	// have no tool_call history, so there's nothing to substitute.
+	var asString string
+	if err := json.Unmarshal(inputRaw, &asString); err == nil {
+		return nil, nil, nil
+	}
+	var items []json.RawMessage
+	if err := json.Unmarshal(inputRaw, &items); err != nil {
+		return nil, nil, err
+	}
+	logger := req.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	var appliedDriftIDs []string
+	rewrittenAny := false
+	for i, item := range items {
+		var probe struct {
+			Type   string `json:"type"`
+			CallID string `json:"call_id"`
+		}
+		if err := json.Unmarshal(item, &probe); err != nil {
+			continue
+		}
+		if probe.Type != "function_call_output" || probe.CallID == "" {
+			continue
+		}
+		subst, found := req.ScopeDrifts.LookupPendingSubstitution(ctx, PendingSubstitutionKey{
+			AgentID:        req.Agent.ID,
+			ConversationID: req.ConversationID,
+			ToolUseID:      probe.CallID,
+		})
+		if !found {
+			continue
+		}
+		newItem, ok := substituteOpenAIResponsesFunctionCallOutput(item, subst.MenuText)
+		if !ok {
+			logger.WarnContext(ctx, "scope-drift inbound rewrite: failed to substitute function_call_output",
+				"call_id", probe.CallID,
+				"drift_id", subst.DriftID,
+			)
+			continue
+		}
+		items[i] = newItem
+		restored := false
+		for ai := i - 1; ai >= 0; ai-- {
+			candidate, ok := restoreOpenAIResponsesFunctionCall(items[ai], probe.CallID, subst.OriginalToolName, subst.OriginalToolInput)
+			if !ok {
+				continue
+			}
+			items[ai] = candidate
+			restored = true
+			break
+		}
+		if !restored {
+			logger.WarnContext(ctx, "scope-drift inbound rewrite: could not locate placeholder function_call for restoration",
+				"call_id", probe.CallID,
+				"drift_id", subst.DriftID,
+			)
+		}
+		appliedDriftIDs = append(appliedDriftIDs, subst.DriftID)
+		rewrittenAny = true
+	}
+	if !rewrittenAny {
+		return nil, nil, nil
+	}
+	newInput, err := json.Marshal(items)
+	if err != nil {
+		return nil, nil, err
+	}
+	raw["input"] = newInput
+	out, err := json.Marshal(raw)
+	if err != nil {
+		return nil, nil, err
+	}
+	return out, appliedDriftIDs, nil
+}
+
+func substituteOpenAIResponsesFunctionCallOutput(item json.RawMessage, menuText string) (json.RawMessage, bool) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(item, &raw); err != nil {
+		return nil, false
+	}
+	encoded, err := json.Marshal(menuText)
+	if err != nil {
+		return nil, false
+	}
+	raw["output"] = encoded
+	out, err := json.Marshal(raw)
+	if err != nil {
+		return nil, false
+	}
+	return out, true
+}
+
+func restoreOpenAIResponsesFunctionCall(item json.RawMessage, targetCallID, originalName string, originalInput []byte) (json.RawMessage, bool) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(item, &raw); err != nil {
+		return nil, false
+	}
+	var typ string
+	if err := json.Unmarshal(raw["type"], &typ); err != nil || typ != "function_call" {
+		return nil, false
+	}
+	var callID string
+	_ = json.Unmarshal(raw["call_id"], &callID)
+	if callID != targetCallID {
+		return nil, false
+	}
+	nameRaw, err := json.Marshal(originalName)
+	if err != nil {
+		return nil, false
+	}
+	raw["name"] = nameRaw
+	// OpenAI `arguments` is a JSON-encoded string of the input. The
+	// inspector and rewriter use raw input bytes (parsed JSON
+	// document); convert to the string form the wire format expects.
+	if len(originalInput) == 0 {
+		argsRaw, _ := json.Marshal("{}")
+		raw["arguments"] = argsRaw
+	} else {
+		argsRaw, err := json.Marshal(string(originalInput))
+		if err != nil {
+			return nil, false
+		}
+		raw["arguments"] = argsRaw
+	}
+	out, err := json.Marshal(raw)
+	if err != nil {
+		return nil, false
+	}
+	return out, true
+}
+
+// rewriteOpenAIChatScopeDriftPlaceholders walks the OpenAI Chat
+// Completions `messages` array, finds tool-role messages whose
+// tool_call_id matches a pending substitution, replaces their
+// content with the menu text, and restores the corresponding assistant
+// message's tool_call (name, arguments) to the model's original.
+func rewriteOpenAIChatScopeDriftPlaceholders(ctx context.Context, req ScopeDriftInboundRewriteRequest) ([]byte, []string, error) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(req.Body, &raw); err != nil {
+		return nil, nil, err
+	}
+	msgsRaw, ok := raw["messages"]
+	if !ok {
+		return nil, nil, nil
+	}
+	var messages []json.RawMessage
+	if err := json.Unmarshal(msgsRaw, &messages); err != nil {
+		return nil, nil, err
+	}
+	logger := req.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	var appliedDriftIDs []string
+	rewrittenAny := false
+	for i, msg := range messages {
+		var probe struct {
+			Role       string `json:"role"`
+			ToolCallID string `json:"tool_call_id"`
+		}
+		if err := json.Unmarshal(msg, &probe); err != nil {
+			continue
+		}
+		if probe.Role != "tool" || probe.ToolCallID == "" {
+			continue
+		}
+		subst, found := req.ScopeDrifts.LookupPendingSubstitution(ctx, PendingSubstitutionKey{
+			AgentID:        req.Agent.ID,
+			ConversationID: req.ConversationID,
+			ToolUseID:      probe.ToolCallID,
+		})
+		if !found {
+			continue
+		}
+		newMsg, ok := substituteOpenAIChatToolMessage(msg, subst.MenuText)
+		if !ok {
+			logger.WarnContext(ctx, "scope-drift inbound rewrite: failed to substitute chat tool message",
+				"tool_call_id", probe.ToolCallID,
+				"drift_id", subst.DriftID,
+			)
+			continue
+		}
+		messages[i] = newMsg
+		restored := false
+		for ai := i - 1; ai >= 0; ai-- {
+			candidate, ok := restoreOpenAIChatAssistantToolCall(messages[ai], probe.ToolCallID, subst.OriginalToolName, subst.OriginalToolInput)
+			if !ok {
+				continue
+			}
+			messages[ai] = candidate
+			restored = true
+			break
+		}
+		if !restored {
+			logger.WarnContext(ctx, "scope-drift inbound rewrite: could not locate placeholder assistant tool_call for restoration",
+				"tool_call_id", probe.ToolCallID,
+				"drift_id", subst.DriftID,
+			)
+		}
+		appliedDriftIDs = append(appliedDriftIDs, subst.DriftID)
+		rewrittenAny = true
+	}
+	if !rewrittenAny {
+		return nil, nil, nil
+	}
+	newMsgs, err := json.Marshal(messages)
+	if err != nil {
+		return nil, nil, err
+	}
+	raw["messages"] = newMsgs
+	out, err := json.Marshal(raw)
+	if err != nil {
+		return nil, nil, err
+	}
+	return out, appliedDriftIDs, nil
+}
+
+func substituteOpenAIChatToolMessage(message json.RawMessage, menuText string) (json.RawMessage, bool) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(message, &raw); err != nil {
+		return nil, false
+	}
+	encoded, err := json.Marshal(menuText)
+	if err != nil {
+		return nil, false
+	}
+	raw["content"] = encoded
+	out, err := json.Marshal(raw)
+	if err != nil {
+		return nil, false
+	}
+	return out, true
+}
+
+func restoreOpenAIChatAssistantToolCall(message json.RawMessage, targetToolCallID, originalName string, originalInput []byte) (json.RawMessage, bool) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(message, &raw); err != nil {
+		return nil, false
+	}
+	var role string
+	if err := json.Unmarshal(raw["role"], &role); err != nil || role != "assistant" {
+		return nil, false
+	}
+	toolCallsRaw, ok := raw["tool_calls"]
+	if !ok {
+		return nil, false
+	}
+	var toolCalls []json.RawMessage
+	if err := json.Unmarshal(toolCallsRaw, &toolCalls); err != nil {
+		return nil, false
+	}
+	rewritten := false
+	for i, tc := range toolCalls {
+		var tcRaw map[string]json.RawMessage
+		if err := json.Unmarshal(tc, &tcRaw); err != nil {
+			continue
+		}
+		var id string
+		_ = json.Unmarshal(tcRaw["id"], &id)
+		if id != targetToolCallID {
+			continue
+		}
+		fnRaw, ok := tcRaw["function"]
+		if !ok {
+			continue
+		}
+		var fn map[string]json.RawMessage
+		if err := json.Unmarshal(fnRaw, &fn); err != nil {
+			continue
+		}
+		nameRaw, err := json.Marshal(originalName)
+		if err != nil {
+			continue
+		}
+		fn["name"] = nameRaw
+		// Arguments is a JSON-encoded string of the input.
+		argsStr := "{}"
+		if len(originalInput) > 0 {
+			argsStr = string(originalInput)
+		}
+		argsRaw, err := json.Marshal(argsStr)
+		if err != nil {
+			continue
+		}
+		fn["arguments"] = argsRaw
+		newFn, err := json.Marshal(fn)
+		if err != nil {
+			continue
+		}
+		tcRaw["function"] = newFn
+		newTC, err := json.Marshal(tcRaw)
+		if err != nil {
+			continue
+		}
+		toolCalls[i] = newTC
+		rewritten = true
+		break
+	}
+	if !rewritten {
+		return nil, false
+	}
+	newToolCalls, err := json.Marshal(toolCalls)
+	if err != nil {
+		return nil, false
+	}
+	raw["tool_calls"] = newToolCalls
+	out, err := json.Marshal(raw)
+	if err != nil {
+		return nil, false
+	}
+	return out, true
+}
+
+// restoreAnthropicAssistantToolUse rewrites a tool_use block whose id
+// matches targetToolUseID — replacing the harness-side Bash placeholder
+// the response rewriter substituted in — back to the model's original
+// (name, input) so the upstream model sees its own call.
+func restoreAnthropicAssistantToolUse(message json.RawMessage, targetToolUseID, originalName string, originalInput []byte) (json.RawMessage, bool) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(message, &raw); err != nil {
+		return nil, false
+	}
+	roleRaw, ok := raw["role"]
+	if !ok {
+		return nil, false
+	}
+	var role string
+	if err := json.Unmarshal(roleRaw, &role); err != nil || role != "assistant" {
+		return nil, false
+	}
+	contentRaw, ok := raw["content"]
+	if !ok {
+		return nil, false
+	}
+	var blocks []json.RawMessage
+	if err := json.Unmarshal(contentRaw, &blocks); err != nil {
+		return nil, false
+	}
+	rewritten := false
+	for i, blk := range blocks {
+		var probe struct {
+			Type string `json:"type"`
+			ID   string `json:"id"`
+		}
+		if err := json.Unmarshal(blk, &probe); err != nil {
+			continue
+		}
+		if probe.Type != "tool_use" || probe.ID != targetToolUseID {
+			continue
+		}
+		// Preserve all top-level keys on the block so the restored
+		// shape matches what the model emitted (cache_control,
+		// metadata, etc.). Only swap name + input.
+		var blockMap map[string]json.RawMessage
+		if err := json.Unmarshal(blk, &blockMap); err != nil {
+			continue
+		}
+		nameRaw, err := json.Marshal(originalName)
+		if err != nil {
+			continue
+		}
+		blockMap["name"] = nameRaw
+		if len(originalInput) == 0 {
+			blockMap["input"] = json.RawMessage("{}")
+		} else {
+			blockMap["input"] = json.RawMessage(originalInput)
+		}
+		newBlock, err := json.Marshal(blockMap)
+		if err != nil {
+			continue
+		}
+		blocks[i] = newBlock
+		rewritten = true
+		break
+	}
+	if !rewritten {
+		return nil, false
+	}
+	newContent, err := json.Marshal(blocks)
+	if err != nil {
+		return nil, false
+	}
+	raw["content"] = newContent
+	out, err := json.Marshal(raw)
+	if err != nil {
+		return nil, false
+	}
+	return out, true
+}

--- a/internal/runtime/llmproxy/scope_drift_inbound_rewrite.go
+++ b/internal/runtime/llmproxy/scope_drift_inbound_rewrite.go
@@ -13,15 +13,17 @@ import (
 // ScopeDriftInboundRewriteRequest is the input to
 // RewriteScopeDriftPlaceholders. The caller supplies the inbound
 // /v1/messages body and identifying context; the rewriter consults the
-// ScopeDriftRegistry for pending substitutions and returns the rewritten
-// body when one or more applied.
+// SubstitutionRegistry for pending substitutions and returns the
+// rewritten body when one or more applied. The wider ScopeDriftRegistry
+// satisfies the narrower SubstitutionRegistry interface, so existing
+// handler wiring continues to work unchanged.
 type ScopeDriftInboundRewriteRequest struct {
 	HTTPRequest    *http.Request
 	Provider       conversation.Provider
 	Body           []byte
 	Agent          *store.Agent
 	ConversationID string
-	ScopeDrifts    ScopeDriftRegistry
+	ScopeDrifts    SubstitutionRegistry
 	Logger         *slog.Logger
 }
 

--- a/internal/runtime/llmproxy/scope_drift_prompt.go
+++ b/internal/runtime/llmproxy/scope_drift_prompt.go
@@ -6,10 +6,14 @@ import (
 )
 
 // renderScopeDriftMenu builds the three-option menu the agent sees when
-// a tool call falls outside the active task's scope. The output is
-// plain text — the proxy substitutes it as the tool_result content of a
-// continuation, so the agent sees a continuation of the same
-// conversation rather than an opaque error.
+// a tool call falls outside the active task's scope.
+//
+// Delivery: the proxy substitutes the blocked tool_use with a
+// harness-safe Bash placeholder on the wire so local execution is a
+// no-op, then ON THE NEXT inbound /v1/messages restores the model's
+// original tool_use byte-for-byte AND replaces the harness-supplied
+// tool_result content with this menu. The model sees its own call
+// answered by the menu — faithful history, helpful result.
 //
 // All three options reuse the same control-plane POST shape:
 //   (a) expand:     POST /api/control/tasks/<task_id>/expand?surface=inline
@@ -18,11 +22,7 @@ import (
 //
 // The agent emits any of these as a normal POST tool call; the
 // respective intercept opens an inline approval hold and the user's
-// yes/no resolves it. There is no inline assistant-text markup
-// machinery — when option (c) was encoded that way, the rendered
-// menu's example markup self-matched server-side, consuming the
-// one-shot cap before the agent could pick. Routing all three through
-// the same intercept shape eliminates that whole class of bug.
+// yes/no resolves it.
 //
 // There is also an implicit fourth path: the agent picks none of the
 // above and just emits its next turn normally. The menu names this in
@@ -73,7 +73,7 @@ func renderScopeDriftMenu(menu MenuFields, controlBaseURL string) string {
 	}
 	fmt.Fprintf(&b, "  Drift ID: %s\n", menu.DriftID)
 
-	b.WriteString("\nChoose ONE response. Each drift_id resolves at most once — once you commit to an option below, the proxy will not let you try another against this same drift_id.\n")
+	b.WriteString("\nThis tool_result was injected by Clawvisor in place of what the upstream service would have returned. Your previous assistant turn shows your original call verbatim. Pick ONE response below. Each drift_id resolves at most once — once you commit, the proxy will not let you try another against this same drift_id.\n")
 
 	// (a) Expand the active task. Only meaningful when a task was matched
 	// at scope-check time. We still surface the option even when no task

--- a/internal/runtime/llmproxy/scope_drift_registry.go
+++ b/internal/runtime/llmproxy/scope_drift_registry.go
@@ -142,6 +142,21 @@ var ErrDriftAlreadyResolved = errors.New("scope drift already resolved")
 // expired out of the registry.
 var ErrDriftNotFound = errors.New("scope drift not found")
 
+// PendingSubstitutionKey identifies a pending tool_result substitution
+// — the next inbound /v1/messages request from this agent on this
+// conversation, when it carries a tool_result for this tool_use_id, has
+// the menu text spliced in as the result content.
+//
+// Keyed (agent, conversation, tool_use_id) rather than (drift_id) so the
+// inbound rewriter can locate the substitution from the tool_result
+// block alone (Anthropic tool_result blocks carry tool_use_id, not the
+// drift_id — the drift_id only lives in the rendered menu prose).
+type PendingSubstitutionKey struct {
+	AgentID        string
+	ConversationID string
+	ToolUseID      string
+}
+
 // ScopeDriftRegistry holds ScopeDrift records for the lifetime of one
 // drift (TTL ~10 min by default). Implementations must be safe for
 // concurrent use.
@@ -170,6 +185,51 @@ type ScopeDriftRegistry interface {
 	// (driftID, true) on hit; ("", false) otherwise. The hit is CONSUMED
 	// — a single succeeded option authorizes one re-attempt.
 	LookupPreClear(ctx context.Context, agentID, fingerprint string) (string, bool)
+
+	// RegisterPendingSubstitution stores everything the inbound rewriter
+	// needs to:
+	//   1. Restore the model's original tool_use byte-for-byte in every
+	//      future /v1/messages assistant turn that carries the
+	//      harness-side placeholder we substituted on the response leg.
+	//   2. Replace the harness-supplied tool_result content with the
+	//      menu text on the immediate follow-up turn.
+	//
+	// Conversation-scoped lifetime: substitutions persist much longer
+	// than the drift record itself (substitutionTTL, hours). The
+	// harness's stored assistant history contains the placeholder for
+	// the rest of the conversation; without a long-lived substitution
+	// record we'd restore it only once and then the model would see the
+	// placeholder forever after.
+	RegisterPendingSubstitution(ctx context.Context, key PendingSubstitutionKey, value PendingSubstitution) error
+
+	// LookupPendingSubstitution returns the substitution registered for
+	// the key, if any. Does NOT consume the entry — restoration of the
+	// assistant turn must work on every future inbound while the
+	// substitution is live. Returns (zero, false) on miss.
+	LookupPendingSubstitution(ctx context.Context, key PendingSubstitutionKey) (PendingSubstitution, bool)
+}
+
+// substitutionTTL is the time-to-live for pending substitution
+// records. Sized generously (24h) because the harness's stored history
+// keeps the Bash placeholder for the full conversation; the inbound
+// rewriter has to be able to restore on every follow-up turn until the
+// user closes the session. A bound is still enforced so the in-memory
+// registry doesn't grow unbounded across long-running deployments.
+const substitutionTTL = 24 * time.Hour
+
+// PendingSubstitution carries every field the inbound rewriter needs
+// to splice the model's original tool_use back into the assistant turn
+// and replace the harness-supplied tool_result content with the menu.
+type PendingSubstitution struct {
+	DriftID          string
+	MenuText         string
+	OriginalToolName string
+	OriginalToolInput []byte
+}
+
+type pendingSubstitutionEntry struct {
+	Substitution PendingSubstitution
+	ExpiresAt    time.Time
 }
 
 type memoryScopeDriftRegistry struct {
@@ -178,6 +238,7 @@ type memoryScopeDriftRegistry struct {
 	now     func() time.Time
 	drifts  map[string]*ScopeDrift
 	cleared map[string]string
+	pending map[string]pendingSubstitutionEntry
 }
 
 // NewMemoryScopeDriftRegistry returns an in-memory registry with the
@@ -195,6 +256,7 @@ func NewMemoryScopeDriftRegistry(ttl time.Duration) ScopeDriftRegistry {
 		now:     time.Now,
 		drifts:  map[string]*ScopeDrift{},
 		cleared: map[string]string{},
+		pending: map[string]pendingSubstitutionEntry{},
 	}
 }
 
@@ -292,6 +354,44 @@ func (r *memoryScopeDriftRegistry) LookupPreClear(_ context.Context, agentID, fi
 	return driftID, true
 }
 
+func (r *memoryScopeDriftRegistry) RegisterPendingSubstitution(_ context.Context, key PendingSubstitutionKey, value PendingSubstitution) error {
+	if r == nil {
+		return errors.New("scope drift registry not configured")
+	}
+	if key.AgentID == "" || key.ToolUseID == "" {
+		return errors.New("pending substitution requires agent_id and tool_use_id")
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.pruneLocked()
+	r.pending[pendingSubstitutionStorageKey(key)] = pendingSubstitutionEntry{
+		Substitution: value,
+		ExpiresAt:    r.now().UTC().Add(substitutionTTL),
+	}
+	return nil
+}
+
+// LookupPendingSubstitution returns the substitution for the key but
+// does NOT delete it. The harness's stored assistant history carries
+// the Bash placeholder for the rest of the conversation; every
+// subsequent inbound /v1/messages has to restore that placeholder back
+// to the model's original tool_use so the model never sees its own
+// past as a fabricated Bash. The entry expires via substitutionTTL.
+func (r *memoryScopeDriftRegistry) LookupPendingSubstitution(_ context.Context, key PendingSubstitutionKey) (PendingSubstitution, bool) {
+	if r == nil {
+		return PendingSubstitution{}, false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.pruneLocked()
+	storage := pendingSubstitutionStorageKey(key)
+	entry, ok := r.pending[storage]
+	if !ok {
+		return PendingSubstitution{}, false
+	}
+	return entry.Substitution, true
+}
+
 func (r *memoryScopeDriftRegistry) pruneLocked() {
 	now := r.now().UTC()
 	for id, d := range r.drifts {
@@ -301,10 +401,20 @@ func (r *memoryScopeDriftRegistry) pruneLocked() {
 		delete(r.drifts, id)
 		delete(r.cleared, preClearKey(d.AgentID, d.Fingerprint()))
 	}
+	for key, entry := range r.pending {
+		if entry.ExpiresAt.IsZero() || entry.ExpiresAt.After(now) {
+			continue
+		}
+		delete(r.pending, key)
+	}
 }
 
 func preClearKey(agentID, fingerprint string) string {
 	return agentID + "|" + fingerprint
+}
+
+func pendingSubstitutionStorageKey(key PendingSubstitutionKey) string {
+	return key.AgentID + "|" + key.ConversationID + "|" + key.ToolUseID
 }
 
 func newDriftID() (string, error) {

--- a/internal/runtime/llmproxy/scope_drift_registry.go
+++ b/internal/runtime/llmproxy/scope_drift_registry.go
@@ -157,35 +157,19 @@ type PendingSubstitutionKey struct {
 	ToolUseID      string
 }
 
-// ScopeDriftRegistry holds ScopeDrift records for the lifetime of one
-// drift (TTL ~10 min by default). Implementations must be safe for
-// concurrent use.
-type ScopeDriftRegistry interface {
-	// Register creates a new drift record, mints an ID, and stores it.
-	// The returned record is the freshly stored copy (ID and timestamps
-	// populated).
-	Register(ctx context.Context, drift ScopeDrift) (ScopeDrift, error)
-
-	// Get returns a copy of the named drift. Returns ErrDriftNotFound
-	// for unknown or expired IDs.
-	Get(ctx context.Context, driftID string) (ScopeDrift, error)
-
-	// ClaimOption atomically asserts that no option has been chosen yet,
-	// then sets ChosenOption + Outcome to the supplied values. Returns
-	// ErrDriftAlreadyResolved when the drift already has a chosen option.
-	ClaimOption(ctx context.Context, driftID string, option ScopeDriftOption, agentNote string) (ScopeDrift, error)
-
-	// SetOutcome updates the outcome field for an already-claimed drift.
-	// On Succeeded a one-shot pre-clear is minted for the drift's
-	// (agent, fingerprint).
-	SetOutcome(ctx context.Context, driftID string, outcome ScopeDriftOutcome) error
-
-	// LookupPreClear checks whether the given (agent, fingerprint) has a
-	// succeeded drift whose pre-clear is still usable. Returns
-	// (driftID, true) on hit; ("", false) otherwise. The hit is CONSUMED
-	// — a single succeeded option authorizes one re-attempt.
-	LookupPreClear(ctx context.Context, agentID, fingerprint string) (string, bool)
-
+// SubstitutionRegistry is the narrow interface code paths that ONLY
+// need to read/write pending tool_result substitutions depend on
+// (response-leg eval wrappers, inbound rewriter, postproc rollback).
+// It is deliberately scoped tighter than ScopeDriftRegistry so those
+// callers don't gain incidental access to the drift state machine,
+// the pre-clear lifecycle, or anything else that might grow on the
+// scope-drift side.
+//
+// The same in-memory store backs both interfaces today, but the split
+// lets a future deployment swap substitution storage independently
+// (e.g., Redis for cross-process persistence) without disturbing the
+// drift / approval state machine.
+type SubstitutionRegistry interface {
 	// RegisterPendingSubstitution stores everything the inbound rewriter
 	// needs to:
 	//   1. Restore the model's original tool_use byte-for-byte in every
@@ -213,6 +197,39 @@ type ScopeDriftRegistry interface {
 	// write that landed during a request whose response was later
 	// failClosed'd doesn't leave an orphan entry behind. No-op on miss.
 	DeletePendingSubstitution(ctx context.Context, key PendingSubstitutionKey)
+}
+
+// ScopeDriftRegistry holds ScopeDrift records for the lifetime of one
+// drift (TTL ~10 min by default) AND embeds SubstitutionRegistry for
+// the pending tool_result substitution shape the response→inbound
+// round-trip uses. Implementations must be safe for concurrent use.
+type ScopeDriftRegistry interface {
+	SubstitutionRegistry
+
+	// Register creates a new drift record, mints an ID, and stores it.
+	// The returned record is the freshly stored copy (ID and timestamps
+	// populated).
+	Register(ctx context.Context, drift ScopeDrift) (ScopeDrift, error)
+
+	// Get returns a copy of the named drift. Returns ErrDriftNotFound
+	// for unknown or expired IDs.
+	Get(ctx context.Context, driftID string) (ScopeDrift, error)
+
+	// ClaimOption atomically asserts that no option has been chosen yet,
+	// then sets ChosenOption + Outcome to the supplied values. Returns
+	// ErrDriftAlreadyResolved when the drift already has a chosen option.
+	ClaimOption(ctx context.Context, driftID string, option ScopeDriftOption, agentNote string) (ScopeDrift, error)
+
+	// SetOutcome updates the outcome field for an already-claimed drift.
+	// On Succeeded a one-shot pre-clear is minted for the drift's
+	// (agent, fingerprint).
+	SetOutcome(ctx context.Context, driftID string, outcome ScopeDriftOutcome) error
+
+	// LookupPreClear checks whether the given (agent, fingerprint) has a
+	// succeeded drift whose pre-clear is still usable. Returns
+	// (driftID, true) on hit; ("", false) otherwise. The hit is CONSUMED
+	// — a single succeeded option authorizes one re-attempt.
+	LookupPreClear(ctx context.Context, agentID, fingerprint string) (string, bool)
 }
 
 // substitutionTTL is the time-to-live for pending substitution

--- a/internal/runtime/llmproxy/scope_drift_registry.go
+++ b/internal/runtime/llmproxy/scope_drift_registry.go
@@ -207,6 +207,12 @@ type ScopeDriftRegistry interface {
 	// assistant turn must work on every future inbound while the
 	// substitution is live. Returns (zero, false) on miss.
 	LookupPendingSubstitution(ctx context.Context, key PendingSubstitutionKey) (PendingSubstitution, bool)
+
+	// DeletePendingSubstitution removes a previously-registered
+	// substitution. Used by the postproc rollback path so a registry
+	// write that landed during a request whose response was later
+	// failClosed'd doesn't leave an orphan entry behind. No-op on miss.
+	DeletePendingSubstitution(ctx context.Context, key PendingSubstitutionKey)
 }
 
 // substitutionTTL is the time-to-live for pending substitution
@@ -390,6 +396,15 @@ func (r *memoryScopeDriftRegistry) LookupPendingSubstitution(_ context.Context, 
 		return PendingSubstitution{}, false
 	}
 	return entry.Substitution, true
+}
+
+func (r *memoryScopeDriftRegistry) DeletePendingSubstitution(_ context.Context, key PendingSubstitutionKey) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.pending, pendingSubstitutionStorageKey(key))
 }
 
 func (r *memoryScopeDriftRegistry) pruneLocked() {

--- a/internal/runtime/llmproxy/scope_drift_sentinel.go
+++ b/internal/runtime/llmproxy/scope_drift_sentinel.go
@@ -1,0 +1,48 @@
+package llmproxy
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ScopeDriftPlaceholderToolName names the canonical placeholder tool
+// the response rewriter substitutes in for a blocked tool_use. The
+// harness's local execution of the placeholder is a no-op (`:` exits
+// 0); the operator-facing comment names the original call so the
+// transcript still describes what was blocked.
+//
+// The LLM never sees this placeholder — the inbound rewriter restores
+// the model's original tool_use byte-for-byte before forwarding the
+// next /v1/messages upstream.
+const ScopeDriftPlaceholderToolName = "Bash"
+
+// ScopeDriftPlaceholderMarker is the literal substring that identifies
+// a Bash tool_use as a Clawvisor-injected placeholder in the
+// transcript. Operator-facing; carries no semantic load on the wire
+// (the inbound rewriter relies on the pending-substitution registry,
+// not string matching on the placeholder).
+const ScopeDriftPlaceholderMarker = "CLAWVISOR_BLOCKED"
+
+// BuildScopeDriftPlaceholderCommand renders the Bash `command` string
+// the placeholder tool_use carries. Shape:
+//
+//	: # CLAWVISOR_BLOCKED <originalName>(...) blocked — see Clawvisor audit / upstream menu
+//
+// The leading `:` is the POSIX no-op so the harness's local execution
+// exits 0 with no side effect. The remainder is a shell comment, so the
+// harness shows the operator a human-readable line in the transcript
+// instead of an opaque encoded blob.
+func BuildScopeDriftPlaceholderCommand(originalName, driftID string) string {
+	name := strings.TrimSpace(originalName)
+	if name == "" {
+		name = "(unknown)"
+	}
+	name = strings.ReplaceAll(name, "\n", " ")
+	name = strings.ReplaceAll(name, "\r", " ")
+	name = strings.ReplaceAll(name, "`", "'")
+	drift := strings.TrimSpace(driftID)
+	if drift == "" {
+		drift = "(none)"
+	}
+	return fmt.Sprintf(": # %s drift=%s tool=%s — blocked; the upstream model received the recovery menu in this call's tool_result.", ScopeDriftPlaceholderMarker, drift, name)
+}

--- a/internal/runtime/llmproxy/scope_drift_sentinel.go
+++ b/internal/runtime/llmproxy/scope_drift_sentinel.go
@@ -33,16 +33,34 @@ const ScopeDriftPlaceholderMarker = "CLAWVISOR_BLOCKED"
 // harness shows the operator a human-readable line in the transcript
 // instead of an opaque encoded blob.
 func BuildScopeDriftPlaceholderCommand(originalName, driftID string) string {
-	name := strings.TrimSpace(originalName)
-	if name == "" {
-		name = "(unknown)"
-	}
-	name = strings.ReplaceAll(name, "\n", " ")
-	name = strings.ReplaceAll(name, "\r", " ")
-	name = strings.ReplaceAll(name, "`", "'")
+	name := sanitizePlaceholderField(originalName, "(unknown)")
 	drift := strings.TrimSpace(driftID)
 	if drift == "" {
 		drift = "(none)"
 	}
 	return fmt.Sprintf(": # %s drift=%s tool=%s — blocked; the upstream model received the recovery menu in this call's tool_result.", ScopeDriftPlaceholderMarker, drift, name)
+}
+
+// BuildRecoverableDenyPlaceholderCommand renders the harness-safe
+// placeholder for a recoverable-deny block — the proxy denied the call
+// for a construction error the agent can fix on its next attempt
+// (malformed control body, boundary check failure, inspector parse
+// error, etc.). Shape mirrors BuildScopeDriftPlaceholderCommand so the
+// harness's local execution is a no-op; the operator-facing comment
+// names the reason instead of a drift_id.
+func BuildRecoverableDenyPlaceholderCommand(originalName, reason string) string {
+	name := sanitizePlaceholderField(originalName, "(unknown)")
+	reasonLine := sanitizePlaceholderField(reason, "(no reason supplied)")
+	return fmt.Sprintf(": # %s tool=%s — recoverable deny; the upstream model received the reason in this call's tool_result. Reason: %s", ScopeDriftPlaceholderMarker, name, reasonLine)
+}
+
+func sanitizePlaceholderField(value, fallback string) string {
+	v := strings.TrimSpace(value)
+	if v == "" {
+		return fallback
+	}
+	v = strings.ReplaceAll(v, "\n", " ")
+	v = strings.ReplaceAll(v, "\r", " ")
+	v = strings.ReplaceAll(v, "`", "'")
+	return v
 }


### PR DESCRIPTION
## Summary

- Swap the scope-drift menu's upstream "continuation" round-trip for a placeholder-on-the-wire + inbound-restore mechanism. Blocked tool calls now mutate to a harness-safe Bash placeholder; the next inbound `/v1/messages` restores the model's original tool_use byte-for-byte and replaces the matching tool_result content with the menu. Wire format covered for Anthropic, OpenAI Responses, and OpenAI Chat.
- Migrate the recoverable-deny path (inspector parse errors, boundary check failures, credential rewrite errors, malformed control bodies, script-session mismatches, etc.) to the same placeholder pattern at the postproc eval-wrapper boundary. The inline-task auto-approve flow stays on the legacy `tryContinuation` path.
- Centralize substitution rollback in `postprocessSession.trackSubstitution` / `rollback` so any failClosed path automatically reverts pending registry writes from both scope-drift mints and recoverable-deny migrations.
- Split `SubstitutionRegistry` as a narrow interface embedded by `ScopeDriftRegistry`; substitution-only callers (inbound rewriter, rollback) depend on the narrow shape.

## Why

- Today the continuation path requires a second upstream call AND a 1:1 tool_use/tool_result invariant. Parallel turns where one call is blocked alongside allowed siblings fall through to a substitute-text path that surfaces the menu as an assistant message rather than a tool_result — confusing the model into thinking it spoke the menu itself.
- The placeholder mechanism preserves the model's view of its own history (it sees its original call answered by the menu in the slot it expects), keeps the prompt cache warm, and handles mixed parallel turns naturally.

## What changed

- New: `scope_drift_sentinel.go` (placeholder command builders), `scope_drift_inbound_rewrite.go` (per-provider restore + substitute), `postproc/recoverable_deny.go` (eval-wrapper transform + scope-drift mint detection).
- `ScopeDriftRegistry` gains `PendingSubstitution` with a 24h TTL and non-consuming lookups so restoration works on every follow-up turn for the rest of the conversation.
- `TaskScopeDecision` / `AuthorizationHoldResult` carry `SubstituteToolCall`; verdicts emit `SubstituteWithToolCall + SuppressSubstituteText`. The continuation field on these shapes is removed for scope-drift.
- `writeProviderSubstituteToolCalls` walks every decision in order (allowed pass-through OR substitute placeholder), so mixed parallel turns no longer drop the allowed siblings.
- Inbound restore-then-substitute is atomic: a restore failure skips the whole hit so the wire never carries menu-in-result paired with placeholder-in-call.
- Inbound rewrite errors now fail closed with a 502; silently shipping the placeholder upstream would leave the transcript permanently inconsistent.

## Test plan

- [x] `go test ./...` green (full suite + new postproc, scope-drift, OpenAI rewriter coverage).
- [x] `cubic review --base origin/main` clean across two consecutive loops after iterative fixes.
- [ ] Manual exercise on Anthropic: parallel turn with one blocked call alongside allowed siblings — confirm allowed siblings execute, model sees menu in tool_result for the blocked call only, follow-up turns continue to see the original call (not the placeholder) in history.
- [ ] Manual exercise on OpenAI Responses (Codex): same as above with `function_call_output` substitution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/568?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

