### PR TITLE
fix(llmproxy): consolidate drift claim rollback logic and handle auto-approve outcome failure

### DIFF
--- a/internal/e2e/lite/scope_drift_counters.go
+++ b/internal/e2e/lite/scope_drift_counters.go
@@ -71,6 +71,10 @@ func (c *countingScopeDriftRegistry) SetOutcome(ctx context.Context, driftID str
 	return nil
 }
 
+func (c *countingScopeDriftRegistry) RollbackClaim(ctx context.Context, driftID string) error {
+	return c.inner.RollbackClaim(ctx, driftID)
+}
+
 func (c *countingScopeDriftRegistry) LookupPreClear(ctx context.Context, agentID, fingerprint string) (string, bool) {
 	driftID, ok := c.inner.LookupPreClear(ctx, agentID, fingerprint)
 	if ok {

--- a/internal/runtime/llmproxy/inline_expansion_intercept.go
+++ b/internal/runtime/llmproxy/inline_expansion_intercept.go
@@ -137,6 +137,22 @@ func MaybeInterceptInlineExpansion(
 		return conversation.ToolUseVerdict{}, false
 	}
 
+	guard := NewDriftClaimGuard(req.Context(), cfg.ScopeDrifts, parsed.DriftID)
+	defer guard.Rollback()
+
+	if parsed.DriftID != "" {
+		_, claimedOk := guard.Claim(
+			cfg.AgentID,
+			cfg.ConversationID,
+			ScopeDriftOptionExpand,
+			"",
+			audit,
+		)
+		if !claimedOk {
+			return conversation.ToolUseVerdict{}, false
+		}
+	}
+
 	// Land the pending state in the DB before holding so the dashboard
 	// sees the in-flight expansion as a pending row even while the
 	// chat anchor owns the decide window. The creator runs the same
@@ -263,6 +279,7 @@ func MaybeInterceptInlineExpansion(
 			YesDescription: "Authorize the additional scope",
 		})
 	}
+	guard.Success()
 	return verdict, true
 }
 

--- a/internal/runtime/llmproxy/inline_task_intercept.go
+++ b/internal/runtime/llmproxy/inline_task_intercept.go
@@ -252,6 +252,13 @@ func MaybeInterceptInlineTaskDefinition(
 					if setErr := cfg.ScopeDrifts.SetOutcome(req.Context(), parsed.DriftID, ScopeDriftOutcomeSucceeded); setErr != nil {
 						audit("fallthrough", "auto_approve_set_outcome_failed", setErr.Error())
 						trace("inline_task.auto_approve_set_outcome_failed", "err", setErr.Error())
+						if cfg.Store != nil && created != nil && created.ID != "" {
+							rollbackCtx, cancel := context.WithTimeout(context.WithoutCancel(req.Context()), 5*time.Second)
+							defer cancel()
+							if err := cfg.Store.RevokeTask(rollbackCtx, created.ID, cfg.AgentUserID); err != nil {
+								trace("inline_task.auto_approve_outcome_rollback_failed", "task_id", created.ID, "err", err.Error())
+							}
+						}
 						return conversation.ToolUseVerdict{}, false
 					}
 				}
@@ -392,10 +399,10 @@ func MaybeInterceptInlineTaskDefinition(
 		if pendingCreator != nil && pendingTaskID != "" {
 			rollbackCtx, cancel := context.WithTimeout(context.WithoutCancel(req.Context()), 5*time.Second)
 			expireErr := pendingCreator.ExpireInlineTask(rollbackCtx, pendingTaskID, cfg.AgentUserID)
+			cancel()
 			if expireErr != nil {
 				trace("inline_task.pending_rollback_failed", "task_id", pendingTaskID, "err", expireErr.Error())
 			}
-			cancel()
 		}
 		// fallthrough — see the audit-decision rationale above.
 		audit("fallthrough", "inline_task_hold_failed", holdErr.Error()+"; deferring to dashboard rewrite")

--- a/internal/runtime/llmproxy/inline_task_intercept.go
+++ b/internal/runtime/llmproxy/inline_task_intercept.go
@@ -165,6 +165,22 @@ func MaybeInterceptInlineTaskDefinition(
 		return conversation.ToolUseVerdict{}, false
 	}
 
+	guard := NewDriftClaimGuard(req.Context(), cfg.ScopeDrifts, parsed.DriftID)
+	defer guard.Rollback()
+
+	if parsed.DriftID != "" {
+		_, claimedOk := guard.Claim(
+			cfg.AgentID,
+			cfg.ConversationID,
+			ScopeDriftOptionNewTask,
+			"",
+			audit,
+		)
+		if !claimedOk {
+			return conversation.ToolUseVerdict{}, false
+		}
+	}
+
 	// Risk assessment runs BEFORE the hold so the auto-approval gate
 	// can decide whether to skip the human prompt entirely. The
 	// assessment is also used to render the prompt on the fall-through
@@ -232,6 +248,13 @@ func MaybeInterceptInlineTaskDefinition(
 				audit("fallthrough", "auto_approve_create_failed", createErr.Error())
 				trace("inline_task.auto_approve_create_failed", "err", createErr.Error())
 			} else {
+				if parsed.DriftID != "" {
+					if setErr := cfg.ScopeDrifts.SetOutcome(req.Context(), parsed.DriftID, ScopeDriftOutcomeSucceeded); setErr != nil {
+						audit("fallthrough", "auto_approve_set_outcome_failed", setErr.Error())
+						trace("inline_task.auto_approve_set_outcome_failed", "err", setErr.Error())
+						return conversation.ToolUseVerdict{}, false
+					}
+				}
 				checkedOut := false
 				if cfg.Checkouts != nil && created.ID != "" {
 					// Include ConversationID for parity with the manual
@@ -283,6 +306,7 @@ func MaybeInterceptInlineTaskDefinition(
 				)
 				augmentation := inlineApprovedReplyAugmentationContext(created.ID, checkedOut, created.Credentials)
 				continuationPayload, _ := jsonsurgery.MarshalNoEscape(augmentation)
+				guard.Success()
 				return conversation.ToolUseVerdict{
 					Allowed: false,
 					Reason:  "Clawvisor: auto-approved from conversation context",
@@ -368,10 +392,10 @@ func MaybeInterceptInlineTaskDefinition(
 		if pendingCreator != nil && pendingTaskID != "" {
 			rollbackCtx, cancel := context.WithTimeout(context.WithoutCancel(req.Context()), 5*time.Second)
 			expireErr := pendingCreator.ExpireInlineTask(rollbackCtx, pendingTaskID, cfg.AgentUserID)
-			cancel()
 			if expireErr != nil {
 				trace("inline_task.pending_rollback_failed", "task_id", pendingTaskID, "err", expireErr.Error())
 			}
+			cancel()
 		}
 		// fallthrough — see the audit-decision rationale above.
 		audit("fallthrough", "inline_task_hold_failed", holdErr.Error()+"; deferring to dashboard rewrite")
@@ -439,6 +463,7 @@ func MaybeInterceptInlineTaskDefinition(
 		// marker in the picker question.
 		verdict.SubstituteWithToolCall = buildAskUserQuestionToolCall(innerHold.Pending.ID)
 	}
+	guard.Success()
 	return verdict, true
 }
 

--- a/internal/runtime/llmproxy/inline_task_release_test.go
+++ b/internal/runtime/llmproxy/inline_task_release_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
 	runtimetasks "github.com/clawvisor/clawvisor/internal/runtime/tasks"
+	"github.com/clawvisor/clawvisor/internal/taskrisk"
 	"github.com/clawvisor/clawvisor/pkg/store"
 )
 
@@ -18,12 +19,13 @@ import (
 // so tests can verify both the inputs (parsed body, original tool_use)
 // AND control the outputs (success/failure, returned task body).
 type fakeInlineTaskCreator struct {
-	called    bool
-	gotAgent  *store.Agent
-	gotReq    *runtimetasks.TaskCreateRequest
-	gotOrigID string
-	resp      *InlineApprovedTask
-	err       error
+	called     bool
+	gotAgent   *store.Agent
+	gotReq     *runtimetasks.TaskCreateRequest
+	gotOrigID  string
+	resp       *InlineApprovedTask
+	err        error
+	pendingErr error
 }
 
 func (f *fakeInlineTaskCreator) CreateInlineApprovedTask(_ context.Context, agent *store.Agent, req *runtimetasks.TaskCreateRequest, originalToolUseID string) (*InlineApprovedTask, error) {
@@ -35,6 +37,25 @@ func (f *fakeInlineTaskCreator) CreateInlineApprovedTask(_ context.Context, agen
 		return nil, f.err
 	}
 	return f.resp, nil
+}
+
+func (f *fakeInlineTaskCreator) CreatePendingInlineTask(_ context.Context, _ *store.Agent, _ *runtimetasks.TaskCreateRequest, _ string, _ *taskrisk.RiskAssessment) (string, error) {
+	if f.pendingErr != nil {
+		return "", f.pendingErr
+	}
+	return "task-created-pending", nil
+}
+
+func (f *fakeInlineTaskCreator) ApproveInlineTask(_ context.Context, _, _ string) (*InlineApprovedTask, error) {
+	return f.resp, f.err
+}
+
+func (f *fakeInlineTaskCreator) DenyInlineTask(_ context.Context, _, _ string) error {
+	return f.err
+}
+
+func (f *fakeInlineTaskCreator) ExpireInlineTask(_ context.Context, _, _ string) error {
+	return f.err
 }
 
 // seedInlineTaskHolds primes the cache the way the postprocess intercept

--- a/internal/runtime/llmproxy/scope_drift_e2e_test.go
+++ b/internal/runtime/llmproxy/scope_drift_e2e_test.go
@@ -871,6 +871,15 @@ func TestScopeDriftE2E_OneShotCapExpandAndOneOff(t *testing.T) {
 	if claimed {
 		t.Fatal("expected one-off intercept to reject already claimed drift")
 	}
+
+	// Verify that the drift ChosenOption remains "expand" (was not wiped by the one-off's deferred rollback).
+	stored, err = reg.Get(ctx, drift.ID)
+	if err != nil {
+		t.Fatalf("get drift: %v", err)
+	}
+	if stored.ChosenOption != ScopeDriftOptionExpand {
+		t.Fatalf("drift ChosenOption was wiped! got %q, want %q", stored.ChosenOption, ScopeDriftOptionExpand)
+	}
 }
 
 // TestScopeDriftE2E_ExpandCreatorFailureClosesDrift verifies that if CreatePendingInlineExpansion

--- a/internal/runtime/llmproxy/scope_drift_e2e_test.go
+++ b/internal/runtime/llmproxy/scope_drift_e2e_test.go
@@ -93,8 +93,8 @@ func anthropicReplyBody(verb, approvalID string) []byte {
 func invokeOneOffIntercept(t *testing.T, reg ScopeDriftRegistry, cache PendingApprovalCache, agentID, convID, driftID, rationale string) (conversation.ToolUseVerdict, bool) {
 	t.Helper()
 	cfg := PostprocessConfig{
-		AgentContext:    AgentContext{AgentID: agentID, AgentUserID: driftTestUserID},
-		AuditContext:    AuditContext{ConversationID: convID},
+		AgentContext: AgentContext{AgentID: agentID, AgentUserID: driftTestUserID},
+		AuditContext: AuditContext{ConversationID: convID},
 		AuthorizationContext: AuthorizationContext{
 			ScopeDrifts: reg,
 		},
@@ -117,15 +117,15 @@ func invokeOneOffIntercept(t *testing.T, reg ScopeDriftRegistry, cache PendingAp
 // TestScopeDriftE2E_OneOffApprove walks the POST → user-approve →
 // pre-clear path:
 //
-//	1. agent POSTs /api/control/scope-drifts/<id>/one-off?surface=inline
-//	   with a one-line rationale
-//	2. MaybeInterceptScopeDriftOneOff claims the option + opens a
-//	   StageAwaitingScopeDriftOneOff hold + substitutes the tool_result
-//	   with the user-facing approval prompt
-//	3. user replies "yes <approval_id>"
-//	4. RewriteScopeDriftOneOffApprovalReply resolves the hold + sets
-//	   the drift outcome to Succeeded + mints the pre-clear
-//	5. agent's retry of the original tool_use consumes the pre-clear once
+//  1. agent POSTs /api/control/scope-drifts/<id>/one-off?surface=inline
+//     with a one-line rationale
+//  2. MaybeInterceptScopeDriftOneOff claims the option + opens a
+//     StageAwaitingScopeDriftOneOff hold + substitutes the tool_result
+//     with the user-facing approval prompt
+//  3. user replies "yes <approval_id>"
+//  4. RewriteScopeDriftOneOffApprovalReply resolves the hold + sets
+//     the drift outcome to Succeeded + mints the pre-clear
+//  5. agent's retry of the original tool_use consumes the pre-clear once
 func TestScopeDriftE2E_OneOffApprove(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -483,15 +483,15 @@ func TestScopeDriftE2E_ImplicitFallThroughTTLExpires(t *testing.T) {
 // TestScopeDriftE2E_ExpandFullStateMachine drives the (a) Expand
 // path:
 //
-//	1. agent reads the menu, POSTs to .../tasks/<id>/expand?surface=inline
-//	   with a `drift_id` field in the body
-//	2. MaybeInterceptInlineExpansion opens a hold at
-//	   StageAwaitingExpansionApproval AND records the drift link
-//	3. user replies "yes" → RewriteInlineTaskApprovalReply resolves,
-//	   the expansion creator is approved, AND ScopeDrifts.SetOutcome
-//	   fires with Succeeded → pre-clear minted
-//	4. agent's retry of the original blocked tool_use consumes the
-//	   pre-clear once
+//  1. agent reads the menu, POSTs to .../tasks/<id>/expand?surface=inline
+//     with a `drift_id` field in the body
+//  2. MaybeInterceptInlineExpansion opens a hold at
+//     StageAwaitingExpansionApproval AND records the drift link
+//  3. user replies "yes" → RewriteInlineTaskApprovalReply resolves,
+//     the expansion creator is approved, AND ScopeDrifts.SetOutcome
+//     fires with Succeeded → pre-clear minted
+//  4. agent's retry of the original blocked tool_use consumes the
+//     pre-clear once
 func TestScopeDriftE2E_ExpandFullStateMachine(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -525,6 +525,9 @@ func TestScopeDriftE2E_ExpandFullStateMachine(t *testing.T) {
 		},
 		AuditContext: AuditContext{
 			ConversationID: driftTestConvID,
+		},
+		AuthorizationContext: AuthorizationContext{
+			ScopeDrifts: reg,
 		},
 		ApprovalContext: ApprovalContext{
 			PendingApprovals:  cache,
@@ -621,9 +624,10 @@ func TestScopeDriftE2E_ExpandDenyClosesDriftWithoutPreClear(t *testing.T) {
 	}
 	fc := &fakeExpansionCreator{}
 	cfg := PostprocessConfig{
-		AgentContext:    AgentContext{AgentID: driftTestAgentID, AgentUserID: driftTestUserID},
-		AuditContext:    AuditContext{ConversationID: driftTestConvID},
-		ApprovalContext: ApprovalContext{PendingApprovals: cache, InlineTaskCreator: fc},
+		AgentContext:         AgentContext{AgentID: driftTestAgentID, AgentUserID: driftTestUserID},
+		AuditContext:         AuditContext{ConversationID: driftTestConvID},
+		AuthorizationContext: AuthorizationContext{ScopeDrifts: reg},
+		ApprovalContext:      ApprovalContext{PendingApprovals: cache, InlineTaskCreator: fc},
 	}
 	httpReq := httptest.NewRequest("POST", "http://daemon/api/control/tasks/task-A/expand?surface=inline", nil)
 	if _, ok := MaybeInterceptInlineExpansion(httpReq, cfg, func(string, string, string) {}, func(string, ...any) {}, conversation.ProviderAnthropic, tu, ControlCall{Method: "POST", URL: httpReq.URL}); !ok {
@@ -695,9 +699,10 @@ func TestScopeDriftE2E_NewTaskFullStateMachine(t *testing.T) {
 		resp: &InlineApprovedTask{ID: "task-created", Status: "active", Purpose: "File the issue"},
 	}
 	cfg := PostprocessConfig{
-		AgentContext:    AgentContext{AgentID: driftTestAgentID, AgentUserID: driftTestUserID, AgentName: "agent-drift"},
-		AuditContext:    AuditContext{ConversationID: driftTestConvID},
-		ApprovalContext: ApprovalContext{PendingApprovals: cache, InlineTaskCreator: fc},
+		AgentContext:         AgentContext{AgentID: driftTestAgentID, AgentUserID: driftTestUserID, AgentName: "agent-drift"},
+		AuditContext:         AuditContext{ConversationID: driftTestConvID},
+		AuthorizationContext: AuthorizationContext{ScopeDrifts: reg},
+		ApprovalContext:      ApprovalContext{PendingApprovals: cache, InlineTaskCreator: fc},
 	}
 	httpReq := httptest.NewRequest("POST", "http://daemon/api/control/tasks?surface=inline", nil)
 	call := ControlCall{Method: "POST", URL: httpReq.URL}
@@ -767,4 +772,528 @@ func peekAllHolds(ctx context.Context, cache *MemoryPendingApprovalCache) []Pend
 	out := make([]PendingLiteApproval, len(items))
 	copy(out, items)
 	return out
+}
+
+// TestScopeDriftE2E_ExpandCrossAgentGuard verifies that an expand request from a different
+// agent or conversation using a victim's drift_id is rejected.
+func TestScopeDriftE2E_ExpandCrossAgentGuard(t *testing.T) {
+	t.Parallel()
+	reg := NewMemoryScopeDriftRegistry(0)
+	cache := NewMemoryPendingApprovalCache(time.Minute)
+	drift, _ := mintDriftFixture(t, reg, ScopeDriftSourceTaskScope)
+
+	expandBody := map[string]any{
+		"expected_tools": []map[string]any{{"tool_name": "Bash", "why": "x"}},
+		"reason":         "x",
+		"drift_id":       drift.ID,
+	}
+	expandBodyJSON, _ := json.Marshal(expandBody)
+	tu := conversation.ToolUse{
+		ID:    "tu-expand",
+		Name:  "Bash",
+		Input: json.RawMessage(`{"body":` + string(mustJSON(string(expandBodyJSON))) + `}`),
+	}
+
+	fc := &fakeExpansionCreator{}
+	cfg := PostprocessConfig{
+		AgentContext:         AgentContext{AgentID: "agent-attacker", AgentUserID: driftTestUserID},
+		AuditContext:         AuditContext{ConversationID: driftTestConvID},
+		AuthorizationContext: AuthorizationContext{ScopeDrifts: reg},
+		ApprovalContext:      ApprovalContext{PendingApprovals: cache, InlineTaskCreator: fc},
+	}
+	httpReq := httptest.NewRequest("POST", "http://daemon/api/control/tasks/task-A/expand?surface=inline", nil)
+	call := ControlCall{Method: "POST", URL: httpReq.URL}
+
+	if _, claimed := MaybeInterceptInlineExpansion(httpReq, cfg, func(string, string, string) {}, func(string, ...any) {}, conversation.ProviderAnthropic, tu, call); claimed {
+		t.Fatal("expected expand from different agent to be rejected")
+	}
+
+	// Also check different conversation!
+	cfg2 := PostprocessConfig{
+		AgentContext:         AgentContext{AgentID: driftTestAgentID, AgentUserID: driftTestUserID},
+		AuditContext:         AuditContext{ConversationID: "conv-attacker"}, // Different conversation!
+		AuthorizationContext: AuthorizationContext{ScopeDrifts: reg},
+		ApprovalContext:      ApprovalContext{PendingApprovals: cache, InlineTaskCreator: fc},
+	}
+	if _, claimed := MaybeInterceptInlineExpansion(httpReq, cfg2, func(string, string, string) {}, func(string, ...any) {}, conversation.ProviderAnthropic, tu, call); claimed {
+		t.Fatal("expected expand from different conversation to be rejected")
+	}
+}
+
+// TestScopeDriftE2E_OneShotCapExpandAndOneOff verifies that submitting an expand request
+// successfully claims the drift, and a subsequent one-off request against the same drift_id
+// fails with ErrDriftAlreadyResolved.
+func TestScopeDriftE2E_OneShotCapExpandAndOneOff(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	reg := NewMemoryScopeDriftRegistry(0)
+	cache := NewMemoryPendingApprovalCache(time.Minute)
+	drift, _ := mintDriftFixture(t, reg, ScopeDriftSourceTaskScope)
+
+	// Step 1: Submit an expand request. It should successfully claim the drift.
+	expandBody := map[string]any{
+		"expected_tools": []map[string]any{{"tool_name": "Bash", "why": "x"}},
+		"reason":         "x",
+		"drift_id":       drift.ID,
+	}
+	expandBodyJSON, _ := json.Marshal(expandBody)
+	tu := conversation.ToolUse{
+		ID:    "tu-expand",
+		Name:  "Bash",
+		Input: json.RawMessage(`{"body":` + string(mustJSON(string(expandBodyJSON))) + `}`),
+	}
+
+	fc := &fakeExpansionCreator{}
+	cfg := PostprocessConfig{
+		AgentContext:         AgentContext{AgentID: driftTestAgentID, AgentUserID: driftTestUserID},
+		AuditContext:         AuditContext{ConversationID: driftTestConvID},
+		AuthorizationContext: AuthorizationContext{ScopeDrifts: reg},
+		ApprovalContext:      ApprovalContext{PendingApprovals: cache, InlineTaskCreator: fc},
+	}
+	httpReq := httptest.NewRequest("POST", "http://daemon/api/control/tasks/task-A/expand?surface=inline", nil)
+	call := ControlCall{Method: "POST", URL: httpReq.URL}
+
+	if _, claimed := MaybeInterceptInlineExpansion(httpReq, cfg, func(string, string, string) {}, func(string, ...any) {}, conversation.ProviderAnthropic, tu, call); !claimed {
+		t.Fatal("expected expand intercept to claim the drift")
+	}
+
+	// Verify drift is now claimed with "expand".
+	stored, err := reg.Get(ctx, drift.ID)
+	if err != nil {
+		t.Fatalf("get drift: %v", err)
+	}
+	if stored.ChosenOption != ScopeDriftOptionExpand {
+		t.Fatalf("drift ChosenOption = %q, want %q", stored.ChosenOption, ScopeDriftOptionExpand)
+	}
+
+	// Step 2: Try a subsequent one-off request against the same drift_id. It should fail.
+	_, claimed := invokeOneOffIntercept(t, reg, cache, driftTestAgentID, driftTestConvID, drift.ID, "need a one-off too")
+	if claimed {
+		t.Fatal("expected one-off intercept to reject already claimed drift")
+	}
+}
+
+// TestScopeDriftE2E_ExpandCreatorFailureClosesDrift verifies that if CreatePendingInlineExpansion
+// fails, the drift outcome is transitioned to Denied.
+func TestScopeDriftE2E_ExpandCreatorFailureClosesDrift(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	reg := NewMemoryScopeDriftRegistry(0)
+	cache := NewMemoryPendingApprovalCache(time.Minute)
+	drift, _ := mintDriftFixture(t, reg, ScopeDriftSourceTaskScope)
+
+	expandBody := map[string]any{
+		"expected_tools": []map[string]any{{"tool_name": "Bash", "why": "x"}},
+		"reason":         "x",
+		"drift_id":       drift.ID,
+	}
+	expandBodyJSON, _ := json.Marshal(expandBody)
+	tu := conversation.ToolUse{
+		ID:    "tu-expand",
+		Name:  "Bash",
+		Input: json.RawMessage(`{"body":` + string(mustJSON(string(expandBodyJSON))) + `}`),
+	}
+
+	// This expansion creator returns an error to simulate DB/creator failure.
+	fc := &fakeExpansionCreator{
+		CreatePendingErr: errors.New("database outage"),
+	}
+	cfg := PostprocessConfig{
+		AgentContext:         AgentContext{AgentID: driftTestAgentID, AgentUserID: driftTestUserID},
+		AuditContext:         AuditContext{ConversationID: driftTestConvID},
+		AuthorizationContext: AuthorizationContext{ScopeDrifts: reg},
+		ApprovalContext:      ApprovalContext{PendingApprovals: cache, InlineTaskCreator: fc},
+	}
+	httpReq := httptest.NewRequest("POST", "http://daemon/api/control/tasks/task-A/expand?surface=inline", nil)
+	call := ControlCall{Method: "POST", URL: httpReq.URL}
+
+	if _, claimed := MaybeInterceptInlineExpansion(httpReq, cfg, func(string, string, string) {}, func(string, ...any) {}, conversation.ProviderAnthropic, tu, call); claimed {
+		t.Fatal("expected expansion to fall through due to creator failure")
+	}
+
+	// Verify that the drift outcome and chosen option were rolled back (cleared).
+	stored, err := reg.Get(ctx, drift.ID)
+	if err != nil {
+		t.Fatalf("get drift: %v", err)
+	}
+	if stored.Outcome != "" {
+		t.Fatalf("drift Outcome = %q, want empty", stored.Outcome)
+	}
+	if stored.ChosenOption != "" {
+		t.Fatalf("drift ChosenOption = %q, want empty", stored.ChosenOption)
+	}
+
+	// Verify we can claim the drift again (it is not stranded or permanently resolved).
+	if _, err := reg.ClaimOption(ctx, drift.ID, ScopeDriftOptionExpand, "retry"); err != nil {
+		t.Fatalf("expected drift to be claimable again, but got err: %v", err)
+	}
+}
+
+// TestScopeDriftE2E_NewTaskPendingCreatorFailureClosesDrift verifies that if CreatePendingInlineTask
+// fails, the drift outcome is transitioned to Denied.
+func TestScopeDriftE2E_NewTaskPendingCreatorFailureClosesDrift(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	reg := NewMemoryScopeDriftRegistry(0)
+	cache := NewMemoryPendingApprovalCache(time.Minute)
+	drift, _ := mintDriftFixture(t, reg, ScopeDriftSourceTaskScope)
+
+	taskBody := &runtimetasks.TaskCreateRequest{
+		Purpose:                "File the issue",
+		IntentVerificationMode: "strict",
+		ExpiresInSeconds:       600,
+		ExpectedTools: []runtimetasks.ExpectedTool{
+			{ToolName: "Bash", Why: "curl to github"},
+		},
+		DriftID: drift.ID,
+	}
+	taskBodyJSON, _ := json.Marshal(taskBody)
+	tu := conversation.ToolUse{
+		ID:    "tu-create",
+		Name:  "Bash",
+		Input: json.RawMessage(`{"body":` + string(mustJSON(string(taskBodyJSON))) + `}`),
+	}
+
+	// This creator returns an error on pending task creation.
+	fc := &fakeInlineTaskCreator{
+		pendingErr: errors.New("database outage"),
+	}
+	cfg := PostprocessConfig{
+		AgentContext:         AgentContext{AgentID: driftTestAgentID, AgentUserID: driftTestUserID, AgentName: "agent-drift"},
+		AuditContext:         AuditContext{ConversationID: driftTestConvID},
+		AuthorizationContext: AuthorizationContext{ScopeDrifts: reg},
+		ApprovalContext:      ApprovalContext{PendingApprovals: cache, InlineTaskCreator: fc},
+	}
+	httpReq := httptest.NewRequest("POST", "http://daemon/api/control/tasks?surface=inline", nil)
+	call := ControlCall{Method: "POST", URL: httpReq.URL}
+
+	if _, ok := MaybeInterceptInlineTaskDefinition(httpReq, cfg, func(string, string, string) {}, func(string, ...any) {}, conversation.ProviderAnthropic, tu, call); ok {
+		t.Fatal("expected task definition intercept to fall through due to creator failure")
+	}
+
+	// Verify that the drift outcome and chosen option were rolled back (cleared).
+	stored, err := reg.Get(ctx, drift.ID)
+	if err != nil {
+		t.Fatalf("get drift: %v", err)
+	}
+	if stored.Outcome != "" {
+		t.Fatalf("drift Outcome = %q, want empty", stored.Outcome)
+	}
+	if stored.ChosenOption != "" {
+		t.Fatalf("drift ChosenOption = %q, want empty", stored.ChosenOption)
+	}
+
+	// Verify we can claim the drift again (it is not stranded or permanently resolved).
+	if _, err := reg.ClaimOption(ctx, drift.ID, ScopeDriftOptionNewTask, "retry"); err != nil {
+		t.Fatalf("expected drift to be claimable again, but got err: %v", err)
+	}
+}
+
+// TestScopeDriftE2E_NewTaskAutoApproveResolvesDriftSucceeded verifies that if a task is
+// auto-approved, the drift is successfully resolved immediately without human prompting.
+func TestScopeDriftE2E_NewTaskAutoApproveResolvesDriftSucceeded(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	reg := NewMemoryScopeDriftRegistry(0)
+	cache := NewMemoryPendingApprovalCache(time.Minute)
+	drift, _ := mintDriftFixture(t, reg, ScopeDriftSourceTaskScope)
+
+	taskBody := &runtimetasks.TaskCreateRequest{
+		Purpose:                "File the issue",
+		IntentVerificationMode: "strict",
+		ExpiresInSeconds:       600,
+		ExpectedTools: []runtimetasks.ExpectedTool{
+			{ToolName: "Bash", Why: "curl to github"},
+		},
+		DriftID: drift.ID,
+	}
+	taskBodyJSON, _ := json.Marshal(taskBody)
+	tu := conversation.ToolUse{
+		ID:    "tu-create",
+		Name:  "Bash",
+		Input: json.RawMessage(`{"body":` + string(mustJSON(string(taskBodyJSON))) + `}`),
+	}
+
+	fc := &fakeInlineTaskCreator{
+		resp: &InlineApprovedTask{ID: "task-created", Status: "active", Purpose: "File the issue"},
+	}
+	assessor := &mockTaskRiskAssessor{
+		verdict: &TaskRiskAssessment{
+			RiskLevel:   "low",
+			IntentMatch: "yes",
+		},
+	}
+	cfg := PostprocessConfig{
+		AgentContext:         AgentContext{AgentID: driftTestAgentID, AgentUserID: driftTestUserID, AgentName: "agent-drift"},
+		AuditContext:         AuditContext{ConversationID: driftTestConvID},
+		AuthorizationContext: AuthorizationContext{ScopeDrifts: reg},
+		ApprovalContext: ApprovalContext{
+			PendingApprovals:                 cache,
+			InlineTaskCreator:                fc,
+			TaskRiskAssessor:                 assessor,
+			ConversationAutoApproveThreshold: "low",
+			RecentUserTurns:                  []string{"please file the issue immediately"},
+		},
+	}
+	httpReq := httptest.NewRequest("POST", "http://daemon/api/control/tasks?surface=inline", nil)
+	call := ControlCall{Method: "POST", URL: httpReq.URL}
+
+	verdict, ok := MaybeInterceptInlineTaskDefinition(httpReq, cfg, func(string, string, string) {}, func(string, ...any) {}, conversation.ProviderAnthropic, tu, call)
+	if !ok {
+		t.Fatal("expected task definition intercept to claim the request")
+	}
+	if verdict.Continue == nil {
+		t.Fatal("expected auto-approve continue signal to be present")
+	}
+
+	// Verify that the drift outcome was marked as Succeeded.
+	stored, err := reg.Get(ctx, drift.ID)
+	if err != nil {
+		t.Fatalf("get drift: %v", err)
+	}
+	if stored.Outcome != ScopeDriftOutcomeSucceeded {
+		t.Fatalf("drift Outcome = %q, want %q", stored.Outcome, ScopeDriftOutcomeSucceeded)
+	}
+}
+
+// TestScopeDriftE2E_NewTaskAutoApproveCreatorFailureRollsBackDrift verifies that if task auto-approval
+// triggers but the creator fails to build the task, the drift claim is rolled back and the request falls through.
+func TestScopeDriftE2E_NewTaskAutoApproveCreatorFailureRollsBackDrift(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	reg := NewMemoryScopeDriftRegistry(0)
+	cache := NewMemoryPendingApprovalCache(time.Minute)
+	drift, _ := mintDriftFixture(t, reg, ScopeDriftSourceTaskScope)
+
+	taskBody := &runtimetasks.TaskCreateRequest{
+		Purpose:                "File the issue",
+		IntentVerificationMode: "strict",
+		ExpiresInSeconds:       600,
+		ExpectedTools: []runtimetasks.ExpectedTool{
+			{ToolName: "Bash", Why: "curl to github"},
+		},
+		DriftID: drift.ID,
+	}
+	taskBodyJSON, _ := json.Marshal(taskBody)
+	tu := conversation.ToolUse{
+		ID:    "tu-create",
+		Name:  "Bash",
+		Input: json.RawMessage(`{"body":` + string(mustJSON(string(taskBodyJSON))) + `}`),
+	}
+
+	// Mock a creator error for both auto-approval task creation and pending creation.
+	fc := &fakeInlineTaskCreator{
+		err:        errors.New("auto-approve task creation failed"),
+		pendingErr: errors.New("pending task creation failed"),
+	}
+	assessor := &mockTaskRiskAssessor{
+		verdict: &TaskRiskAssessment{
+			RiskLevel:   "low",
+			IntentMatch: "yes",
+		},
+	}
+	cfg := PostprocessConfig{
+		AgentContext:         AgentContext{AgentID: driftTestAgentID, AgentUserID: driftTestUserID, AgentName: "agent-drift"},
+		AuditContext:         AuditContext{ConversationID: driftTestConvID},
+		AuthorizationContext: AuthorizationContext{ScopeDrifts: reg},
+		ApprovalContext: ApprovalContext{
+			PendingApprovals:                 cache,
+			InlineTaskCreator:                fc,
+			TaskRiskAssessor:                 assessor,
+			ConversationAutoApproveThreshold: "low",
+			RecentUserTurns:                  []string{"please file the issue immediately"},
+		},
+	}
+	httpReq := httptest.NewRequest("POST", "http://daemon/api/control/tasks?surface=inline", nil)
+	call := ControlCall{Method: "POST", URL: httpReq.URL}
+
+	_, ok := MaybeInterceptInlineTaskDefinition(httpReq, cfg, func(string, string, string) {}, func(string, ...any) {}, conversation.ProviderAnthropic, tu, call)
+	if ok {
+		t.Fatal("expected task definition intercept to return false (fallthrough) due to creation failure")
+	}
+
+	// Verify that the drift outcome and chosen option were rolled back (cleared).
+	stored, err := reg.Get(ctx, drift.ID)
+	if err != nil {
+		t.Fatalf("get drift: %v", err)
+	}
+	if stored.Outcome != "" {
+		t.Fatalf("drift Outcome = %q, want empty", stored.Outcome)
+	}
+	if stored.ChosenOption != "" {
+		t.Fatalf("drift ChosenOption = %q, want empty", stored.ChosenOption)
+	}
+
+	// Verify we can claim the drift again (it was successfully rolled back).
+	if _, err := reg.ClaimOption(ctx, drift.ID, ScopeDriftOptionNewTask, "retry"); err != nil {
+		t.Fatalf("expected drift to be claimable again, but got err: %v", err)
+	}
+}
+
+// TestScopeDriftE2E_NewTaskAutoApproveCreatorFailureFallsBackToManual verifies that if task auto-approval
+// triggers but task creation fails, the interceptor falls back to manual approval and successfully creates a hold.
+func TestScopeDriftE2E_NewTaskAutoApproveCreatorFailureFallsBackToManual(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	reg := NewMemoryScopeDriftRegistry(0)
+	cache := NewMemoryPendingApprovalCache(time.Minute)
+	drift, _ := mintDriftFixture(t, reg, ScopeDriftSourceTaskScope)
+
+	taskBody := &runtimetasks.TaskCreateRequest{
+		Purpose:                "File the issue",
+		IntentVerificationMode: "strict",
+		ExpiresInSeconds:       600,
+		ExpectedTools: []runtimetasks.ExpectedTool{
+			{ToolName: "Bash", Why: "curl to github"},
+		},
+		DriftID: drift.ID,
+	}
+	taskBodyJSON, _ := json.Marshal(taskBody)
+	tu := conversation.ToolUse{
+		ID:    "tu-create",
+		Name:  "Bash",
+		Input: json.RawMessage(`{"body":` + string(mustJSON(string(taskBodyJSON))) + `}`),
+	}
+
+	// Creator fails on auto-approve task creation, but succeeds on manual pending task creation.
+	fc := &fakeInlineTaskCreator{
+		err:        errors.New("auto-approve task creation failed"),
+		pendingErr: nil, // succeeds
+	}
+	assessor := &mockTaskRiskAssessor{
+		verdict: &TaskRiskAssessment{
+			RiskLevel:   "low",
+			IntentMatch: "yes",
+		},
+	}
+	cfg := PostprocessConfig{
+		AgentContext:         AgentContext{AgentID: driftTestAgentID, AgentUserID: driftTestUserID, AgentName: "agent-drift"},
+		AuditContext:         AuditContext{ConversationID: driftTestConvID},
+		AuthorizationContext: AuthorizationContext{ScopeDrifts: reg},
+		ApprovalContext: ApprovalContext{
+			PendingApprovals:                 cache,
+			InlineTaskCreator:                fc,
+			TaskRiskAssessor:                 assessor,
+			ConversationAutoApproveThreshold: "low",
+			RecentUserTurns:                  []string{"please file the issue immediately"},
+		},
+	}
+	httpReq := httptest.NewRequest("POST", "http://daemon/api/control/tasks?surface=inline", nil)
+	call := ControlCall{Method: "POST", URL: httpReq.URL}
+
+	_, ok := MaybeInterceptInlineTaskDefinition(httpReq, cfg, func(string, string, string) {}, func(string, ...any) {}, conversation.ProviderAnthropic, tu, call)
+	if !ok {
+		t.Fatal("expected task definition intercept to return true (intercepted via manual fallback)")
+	}
+
+	// Verify that a hold is created.
+	holds := peekAllHolds(ctx, cache)
+	if len(holds) != 1 {
+		t.Fatalf("expected 1 hold to be created, got %d", len(holds))
+	}
+
+	// Verify that the drift outcome remains pending and option is new_task (not rolled back).
+	stored, err := reg.Get(ctx, drift.ID)
+	if err != nil {
+		t.Fatalf("get drift: %v", err)
+	}
+	if stored.Outcome != ScopeDriftOutcomePending {
+		t.Fatalf("drift Outcome = %q, want pending", stored.Outcome)
+	}
+	if stored.ChosenOption != ScopeDriftOptionNewTask {
+		t.Fatalf("drift ChosenOption = %q, want new_task", stored.ChosenOption)
+	}
+}
+
+type mockTaskRiskAssessor struct {
+	verdict *TaskRiskAssessment
+}
+
+func (m *mockTaskRiskAssessor) AssessEnvelope(_ context.Context, _ TaskRiskAssessRequest) *TaskRiskAssessment {
+	return m.verdict
+}
+
+type failingOutcomeRegistry struct {
+	ScopeDriftRegistry
+	failSetOutcome bool
+}
+
+func (r *failingOutcomeRegistry) SetOutcome(ctx context.Context, driftID string, outcome ScopeDriftOutcome) error {
+	if r.failSetOutcome {
+		return errors.New("database connection lost during outcome write")
+	}
+	return r.ScopeDriftRegistry.SetOutcome(ctx, driftID, outcome)
+}
+
+// TestScopeDriftE2E_NewTaskAutoApproveSetOutcomeFailureRollsBackDrift verifies that if task auto-approval
+// triggers and task creation succeeds, but the registry write for SetOutcome(Succeeded) fails, the claim is
+// rolled back and the request falls through.
+func TestScopeDriftE2E_NewTaskAutoApproveSetOutcomeFailureRollsBackDrift(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	innerReg := NewMemoryScopeDriftRegistry(0)
+	reg := &failingOutcomeRegistry{ScopeDriftRegistry: innerReg, failSetOutcome: true}
+	cache := NewMemoryPendingApprovalCache(time.Minute)
+	drift, _ := mintDriftFixture(t, reg, ScopeDriftSourceTaskScope)
+
+	taskBody := &runtimetasks.TaskCreateRequest{
+		Purpose:                "File the issue",
+		IntentVerificationMode: "strict",
+		ExpiresInSeconds:       600,
+		ExpectedTools: []runtimetasks.ExpectedTool{
+			{ToolName: "Bash", Why: "curl to github"},
+		},
+		DriftID: drift.ID,
+	}
+	taskBodyJSON, _ := json.Marshal(taskBody)
+	tu := conversation.ToolUse{
+		ID:    "tu-create",
+		Name:  "Bash",
+		Input: json.RawMessage(`{"body":` + string(mustJSON(string(taskBodyJSON))) + `}`),
+	}
+
+	// Creator succeeds on task creation, but SetOutcome will fail.
+	fc := &fakeInlineTaskCreator{}
+	assessor := &mockTaskRiskAssessor{
+		verdict: &TaskRiskAssessment{
+			RiskLevel:   "low",
+			IntentMatch: "yes",
+		},
+	}
+	cfg := PostprocessConfig{
+		AgentContext:         AgentContext{AgentID: driftTestAgentID, AgentUserID: driftTestUserID, AgentName: "agent-drift"},
+		AuditContext:         AuditContext{ConversationID: driftTestConvID},
+		AuthorizationContext: AuthorizationContext{ScopeDrifts: reg},
+		ApprovalContext: ApprovalContext{
+			PendingApprovals:                 cache,
+			InlineTaskCreator:                fc,
+			TaskRiskAssessor:                 assessor,
+			ConversationAutoApproveThreshold: "low",
+			RecentUserTurns:                  []string{"please file the issue immediately"},
+		},
+	}
+	httpReq := httptest.NewRequest("POST", "http://daemon/api/control/tasks?surface=inline", nil)
+	call := ControlCall{Method: "POST", URL: httpReq.URL}
+
+	_, ok := MaybeInterceptInlineTaskDefinition(httpReq, cfg, func(string, string, string) {}, func(string, ...any) {}, conversation.ProviderAnthropic, tu, call)
+	if ok {
+		t.Fatal("expected task definition intercept to return false (fallthrough) due to SetOutcome failure")
+	}
+
+	// Verify that the drift outcome and chosen option were rolled back (cleared).
+	stored, err := reg.Get(ctx, drift.ID)
+	if err != nil {
+		t.Fatalf("get drift: %v", err)
+	}
+	if stored.Outcome != "" {
+		t.Fatalf("drift Outcome = %q, want empty", stored.Outcome)
+	}
+	if stored.ChosenOption != "" {
+		t.Fatalf("drift ChosenOption = %q, want empty", stored.ChosenOption)
+	}
+
+	// Verify we can claim the drift again (it was successfully rolled back).
+	if _, err := reg.ClaimOption(ctx, drift.ID, ScopeDriftOptionNewTask, "retry"); err != nil {
+		t.Fatalf("expected drift to be claimable again, but got err: %v", err)
+	}
 }

--- a/internal/runtime/llmproxy/scope_drift_intercept.go
+++ b/internal/runtime/llmproxy/scope_drift_intercept.go
@@ -162,61 +162,13 @@ func MaybeInterceptScopeDriftOneOff(
 	}, true
 }
 
-// validateAndClaimDrift checks if a drift belongs to the current session and claims it.
-// Returns the claimed ScopeDrift and a bool indicating if the validation and claim succeeded.
-func validateAndClaimDrift(
-	ctx context.Context,
-	registry ScopeDriftRegistry,
-	driftID string,
-	expectedAgentID string,
-	expectedConversationID string,
-	option ScopeDriftOption,
-	agentNote string,
-	audit func(decision, outcome, reason string),
-) (ScopeDrift, bool) {
-	if registry == nil {
-		audit("fallthrough", "inline_scope_drift_registry_missing", "registry not configured")
-		return ScopeDrift{}, false
-	}
-
-	existing, err := registry.Get(ctx, driftID)
-	if errors.Is(err, ErrDriftNotFound) {
-		audit("fallthrough", "inline_scope_drift_not_found", "drift "+driftID+" not found (it may have expired)")
-		return ScopeDrift{}, false
-	}
-	if err != nil {
-		audit("fallthrough", "inline_scope_drift_lookup_failed", err.Error())
-		return ScopeDrift{}, false
-	}
-
-	if existing.AgentID != expectedAgentID || existing.ConversationID != expectedConversationID {
-		audit("fallthrough", "inline_scope_drift_wrong_agent_or_conversation", "drift "+driftID+" was minted for a different agent or conversation")
-		return ScopeDrift{}, false
-	}
-
-	claimed, err := registry.ClaimOption(ctx, driftID, option, agentNote)
-	if errors.Is(err, ErrDriftNotFound) {
-		audit("fallthrough", "inline_scope_drift_not_found", "drift "+driftID+" not found (it may have expired)")
-		return ScopeDrift{}, false
-	}
-	if errors.Is(err, ErrDriftAlreadyResolved) {
-		audit("fallthrough", "inline_scope_drift_already_resolved", "drift "+driftID+" was already resolved with option "+string(claimed.ChosenOption))
-		return ScopeDrift{}, false
-	}
-	if err != nil {
-		audit("fallthrough", "inline_scope_drift_claim_failed", err.Error())
-		return ScopeDrift{}, false
-	}
-
-	return claimed, true
-}
-
 // DriftClaimGuard manages the lifecycle of claiming a scope drift and rolling it back if
 // the interceptor path fails downstream.
 type DriftClaimGuard struct {
 	ctx      context.Context
 	registry ScopeDriftRegistry
 	driftID  string
+	claimed  bool
 	success  bool
 }
 
@@ -240,17 +192,42 @@ func (g *DriftClaimGuard) Claim(
 	if g.driftID == "" {
 		return ScopeDrift{}, true
 	}
-	claimed, ok := validateAndClaimDrift(
-		g.ctx,
-		g.registry,
-		g.driftID,
-		expectedAgentID,
-		expectedConversationID,
-		option,
-		agentNote,
-		audit,
-	)
-	return claimed, ok
+	if g.registry == nil {
+		audit("fallthrough", "inline_scope_drift_registry_missing", "registry not configured")
+		return ScopeDrift{}, false
+	}
+
+	existing, err := g.registry.Get(g.ctx, g.driftID)
+	if errors.Is(err, ErrDriftNotFound) {
+		audit("fallthrough", "inline_scope_drift_not_found", "drift "+g.driftID+" not found (it may have expired)")
+		return ScopeDrift{}, false
+	}
+	if err != nil {
+		audit("fallthrough", "inline_scope_drift_lookup_failed", err.Error())
+		return ScopeDrift{}, false
+	}
+
+	if existing.AgentID != expectedAgentID || existing.ConversationID != expectedConversationID {
+		audit("fallthrough", "inline_scope_drift_wrong_agent_or_conversation", "drift "+g.driftID+" was minted for a different agent or conversation")
+		return ScopeDrift{}, false
+	}
+
+	claimed, err := g.registry.ClaimOption(g.ctx, g.driftID, option, agentNote)
+	if errors.Is(err, ErrDriftNotFound) {
+		audit("fallthrough", "inline_scope_drift_not_found", "drift "+g.driftID+" not found (it may have expired)")
+		return ScopeDrift{}, false
+	}
+	if errors.Is(err, ErrDriftAlreadyResolved) {
+		audit("fallthrough", "inline_scope_drift_already_resolved", "drift "+g.driftID+" was already resolved with option "+string(claimed.ChosenOption))
+		return ScopeDrift{}, false
+	}
+	if err != nil {
+		audit("fallthrough", "inline_scope_drift_claim_failed", err.Error())
+		return ScopeDrift{}, false
+	}
+
+	g.claimed = true
+	return claimed, true
 }
 
 // Success marks the claimed drift as successfully intercepted, preventing rollback.
@@ -261,7 +238,7 @@ func (g *DriftClaimGuard) Success() {
 // Rollback rolls back the claimed drift option if the claim succeeded but the interceptor
 // exited early without success. Should be deferred immediately after guard creation.
 func (g *DriftClaimGuard) Rollback() {
-	if g.driftID == "" || g.success || g.registry == nil {
+	if !g.claimed || g.success || g.registry == nil || g.driftID == "" {
 		return
 	}
 	// Use detached context so a canceled request context doesn't strand the rollback.

--- a/internal/runtime/llmproxy/scope_drift_intercept.go
+++ b/internal/runtime/llmproxy/scope_drift_intercept.go
@@ -1,6 +1,7 @@
 package llmproxy
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -113,42 +114,18 @@ func MaybeInterceptScopeDriftOneOff(
 
 	ctx := req.Context()
 
-	// Cross-agent / cross-conversation guard BEFORE the claim: a drift
-	// minted for a different agent or conversation must not even be
-	// readable here. Rejecting at peek time prevents a copied or
-	// replayed drift_id from a different session from terminally
-	// closing the original drift — calling SetOutcome(Denied) after
-	// the claim succeeded would create a denial-of-service path where
-	// anyone who learns a drift_id can permanently close someone
-	// else's pending one-off. The legitimate session still owns the
-	// drift after this refusal.
-	existing, getErr := cfg.ScopeDrifts.Get(ctx, driftID)
-	if errors.Is(getErr, ErrDriftNotFound) {
-		audit("fallthrough", "inline_scope_drift_not_found", "drift "+driftID+" not found (it may have expired)")
-		return conversation.ToolUseVerdict{}, false
-	}
-	if getErr != nil {
-		audit("fallthrough", "inline_scope_drift_lookup_failed", getErr.Error())
-		return conversation.ToolUseVerdict{}, false
-	}
-	if existing.AgentID != cfg.AgentID || existing.ConversationID != cfg.ConversationID {
-		audit("fallthrough", "inline_scope_drift_wrong_agent_or_conversation", "drift "+driftID+" was minted for a different agent or conversation")
-		return conversation.ToolUseVerdict{}, false
-	}
+	guard := NewDriftClaimGuard(ctx, cfg.ScopeDrifts, driftID)
+	defer guard.Rollback()
 
-	claimed, err := cfg.ScopeDrifts.ClaimOption(ctx, driftID, ScopeDriftOptionOneOff, rationale)
-	if errors.Is(err, ErrDriftNotFound) {
-		// Race: drift expired between the peek and the claim. Treat
-		// as not-found rather than crashing the request.
-		audit("fallthrough", "inline_scope_drift_not_found", "drift "+driftID+" not found (it may have expired)")
-		return conversation.ToolUseVerdict{}, false
-	}
-	if errors.Is(err, ErrDriftAlreadyResolved) {
-		audit("fallthrough", "inline_scope_drift_already_resolved", "drift "+driftID+" was already resolved with option "+string(claimed.ChosenOption))
-		return conversation.ToolUseVerdict{}, false
-	}
-	if err != nil {
-		audit("fallthrough", "inline_scope_drift_claim_failed", err.Error())
+	// Centralized check-and-claim.
+	claimed, claimedOk := guard.Claim(
+		cfg.AgentID,
+		cfg.ConversationID,
+		ScopeDriftOptionOneOff,
+		rationale,
+		audit,
+	)
+	if !claimedOk {
 		return conversation.ToolUseVerdict{}, false
 	}
 
@@ -167,9 +144,6 @@ func MaybeInterceptScopeDriftOneOff(
 		ExpiresAt:           now.Add(inlineTaskApprovalHoldTTL),
 	})
 	if holdErr != nil {
-		// Cache hold failed — close the drift so it isn't stranded
-		// pending until TTL.
-		_ = cfg.ScopeDrifts.SetOutcome(ctx, claimed.ID, ScopeDriftOutcomeDenied)
 		audit("fallthrough", "inline_scope_drift_hold_failed", holdErr.Error()+"; deferring to dashboard rewrite")
 		return conversation.ToolUseVerdict{}, false
 	}
@@ -180,9 +154,118 @@ func MaybeInterceptScopeDriftOneOff(
 		"drift_id", claimed.ID,
 		"signal", "query",
 	)
+	guard.Success()
 	return conversation.ToolUseVerdict{
 		Allowed:        false,
 		Reason:         "Clawvisor: one-off approval pending — " + claimed.Service + "." + claimed.Action,
 		SubstituteWith: renderScopeDriftOneOffPrompt(claimed, hold.Pending.ID),
 	}, true
+}
+
+// validateAndClaimDrift checks if a drift belongs to the current session and claims it.
+// Returns the claimed ScopeDrift and a bool indicating if the validation and claim succeeded.
+func validateAndClaimDrift(
+	ctx context.Context,
+	registry ScopeDriftRegistry,
+	driftID string,
+	expectedAgentID string,
+	expectedConversationID string,
+	option ScopeDriftOption,
+	agentNote string,
+	audit func(decision, outcome, reason string),
+) (ScopeDrift, bool) {
+	if registry == nil {
+		audit("fallthrough", "inline_scope_drift_registry_missing", "registry not configured")
+		return ScopeDrift{}, false
+	}
+
+	existing, err := registry.Get(ctx, driftID)
+	if errors.Is(err, ErrDriftNotFound) {
+		audit("fallthrough", "inline_scope_drift_not_found", "drift "+driftID+" not found (it may have expired)")
+		return ScopeDrift{}, false
+	}
+	if err != nil {
+		audit("fallthrough", "inline_scope_drift_lookup_failed", err.Error())
+		return ScopeDrift{}, false
+	}
+
+	if existing.AgentID != expectedAgentID || existing.ConversationID != expectedConversationID {
+		audit("fallthrough", "inline_scope_drift_wrong_agent_or_conversation", "drift "+driftID+" was minted for a different agent or conversation")
+		return ScopeDrift{}, false
+	}
+
+	claimed, err := registry.ClaimOption(ctx, driftID, option, agentNote)
+	if errors.Is(err, ErrDriftNotFound) {
+		audit("fallthrough", "inline_scope_drift_not_found", "drift "+driftID+" not found (it may have expired)")
+		return ScopeDrift{}, false
+	}
+	if errors.Is(err, ErrDriftAlreadyResolved) {
+		audit("fallthrough", "inline_scope_drift_already_resolved", "drift "+driftID+" was already resolved with option "+string(claimed.ChosenOption))
+		return ScopeDrift{}, false
+	}
+	if err != nil {
+		audit("fallthrough", "inline_scope_drift_claim_failed", err.Error())
+		return ScopeDrift{}, false
+	}
+
+	return claimed, true
+}
+
+// DriftClaimGuard manages the lifecycle of claiming a scope drift and rolling it back if
+// the interceptor path fails downstream.
+type DriftClaimGuard struct {
+	ctx      context.Context
+	registry ScopeDriftRegistry
+	driftID  string
+	success  bool
+}
+
+// NewDriftClaimGuard creates a new DriftClaimGuard.
+func NewDriftClaimGuard(ctx context.Context, registry ScopeDriftRegistry, driftID string) *DriftClaimGuard {
+	return &DriftClaimGuard{
+		ctx:      ctx,
+		registry: registry,
+		driftID:  driftID,
+	}
+}
+
+// Claim validates that the drift belongs to the expected agent and conversation, and claims it.
+func (g *DriftClaimGuard) Claim(
+	expectedAgentID string,
+	expectedConversationID string,
+	option ScopeDriftOption,
+	agentNote string,
+	audit func(decision, outcome, reason string),
+) (ScopeDrift, bool) {
+	if g.driftID == "" {
+		return ScopeDrift{}, true
+	}
+	claimed, ok := validateAndClaimDrift(
+		g.ctx,
+		g.registry,
+		g.driftID,
+		expectedAgentID,
+		expectedConversationID,
+		option,
+		agentNote,
+		audit,
+	)
+	return claimed, ok
+}
+
+// Success marks the claimed drift as successfully intercepted, preventing rollback.
+func (g *DriftClaimGuard) Success() {
+	g.success = true
+}
+
+// Rollback rolls back the claimed drift option if the claim succeeded but the interceptor
+// exited early without success. Should be deferred immediately after guard creation.
+func (g *DriftClaimGuard) Rollback() {
+	if g.driftID == "" || g.success || g.registry == nil {
+		return
+	}
+	// Use detached context so a canceled request context doesn't strand the rollback.
+	rollbackCtx, cancel := context.WithTimeout(context.WithoutCancel(g.ctx), 5*time.Second)
+	defer cancel()
+	_ = g.registry.RollbackClaim(rollbackCtx, g.driftID)
 }

--- a/internal/runtime/llmproxy/scope_drift_registry.go
+++ b/internal/runtime/llmproxy/scope_drift_registry.go
@@ -165,6 +165,10 @@ type ScopeDriftRegistry interface {
 	// (agent, fingerprint).
 	SetOutcome(ctx context.Context, driftID string, outcome ScopeDriftOutcome) error
 
+	// RollbackClaim resets the ChosenOption, Outcome, and AgentNote fields of a drift back to empty.
+	// This should be called if an option was claimed but subsequent preflight setup/hold creation failed.
+	RollbackClaim(ctx context.Context, driftID string) error
+
 	// LookupPreClear checks whether the given (agent, fingerprint) has a
 	// succeeded drift whose pre-clear is still usable. Returns
 	// (driftID, true) on hit; ("", false) otherwise. The hit is CONSUMED
@@ -273,6 +277,23 @@ func (r *memoryScopeDriftRegistry) SetOutcome(_ context.Context, driftID string,
 	if outcome == ScopeDriftOutcomeSucceeded {
 		r.cleared[preClearKey(d.AgentID, d.Fingerprint())] = d.ID
 	}
+	return nil
+}
+
+func (r *memoryScopeDriftRegistry) RollbackClaim(_ context.Context, driftID string) error {
+	if r == nil {
+		return ErrDriftNotFound
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.pruneLocked()
+	d, ok := r.drifts[driftID]
+	if !ok {
+		return ErrDriftNotFound
+	}
+	d.ChosenOption = ""
+	d.Outcome = ""
+	d.AgentNote = ""
 	return nil
 }
 


### PR DESCRIPTION
## Summary

This PR addresses two critical scope-drift lifecycle issues identified in the follow-up review of PR #564 (Scope-Drift Continuation Menu). It consolidates the claim/rollback state machine across interceptors and introduces robust error handling for registry writes during task auto-approval.

---

## Detailed Findings & Fixes

### 1. Auto-Approve SetOutcome Registry Failures (P1)
* **The Problem**: When the conversation-based auto-approval path successfully executes `CreateInlineApprovedTask`, it immediately calls `SetOutcome(ctx, driftID, ScopeDriftOutcomeSucceeded)`. Previously, the registry write error was ignored (`_ =`), and the interceptor returned a successful continuation payload. If the registry write failed (e.g., due to transient database or storage network errors), the task was created, but the drift registry never recorded a succeeded outcome or pre-clear. On the agent's next retry, the original blocked `tool_use` would fail again with no retry path or user-visible recovery.
* **The Fix**: We now explicitly check the error returned by `SetOutcome`. If it fails, the error is audited and traced, and the interceptor returns `(conversation.ToolUseVerdict{}, false)`. This lets the request fall through gracefully to the manual approval/prompt fallback path, where the deferred guard automatically rolls back the claim so that the drift remains usable and retryable.
* **File Affected**: [inline_task_intercept.go](file:///c:/Users/sharm/OneDrive/Documents/projects/clawvisor/internal/runtime/llmproxy/inline_task_intercept.go)

### 2. Consolidating Scattered Claim/Rollback Logic (P2)
* **The Problem**: The rollback logic—including the setup of `claimedDriftID`, `interceptSuccess`, and context-detaching rollback closures—was duplicate and scattered across three different files (`inline_expansion_intercept.go`, `inline_task_intercept.go`, and `scope_drift_intercept.go`). This duplicate state machine split one lifecycle across multiple boundaries, making future exit paths extremely fragile and easy to get wrong.
* **The Fix**: Centralized the claim/rollback lifecycle into a single struct: `DriftClaimGuard` in [scope_drift_intercept.go](file:///c:/Users/sharm/OneDrive/Documents/projects/clawvisor/internal/runtime/llmproxy/scope_drift_intercept.go).
  * The guard manages checking, validation, success flagging, and context-detaching rollback (using `context.WithoutCancel` with a 5-second timeout).
  * Interceptors now leverage `DriftClaimGuard` via a clean `defer guard.Rollback()` pattern at the entry points:
    ```go
    guard := NewDriftClaimGuard(req.Context(), cfg.ScopeDrifts, parsed.DriftID)
    defer guard.Rollback()
    
    // Claim when needed
    _, claimedOk := guard.Claim(...)
    
    // On happy path
    guard.Success()
    ```
* **Files Affected**:
  * [scope_drift_intercept.go](file:///c:/Users/sharm/OneDrive/Documents/projects/clawvisor/internal/runtime/llmproxy/scope_drift_intercept.go)
  * [inline_expansion_intercept.go](file:///c:/Users/sharm/OneDrive/Documents/projects/clawvisor/internal/runtime/llmproxy/inline_expansion_intercept.go)
  * [inline_task_intercept.go](file:///c:/Users/sharm/OneDrive/Documents/projects/clawvisor/internal/runtime/llmproxy/inline_task_intercept.go)

---

## Verification Plan

### E2E Tests
* Added a new test `TestScopeDriftE2E_NewTaskAutoApproveSetOutcomeFailureRollsBackDrift` in [scope_drift_e2e_test.go](file:///c:/Users/sharm/OneDrive/Documents/projects/clawvisor/internal/runtime/llmproxy/scope_drift_e2e_test.go) using a custom `failingOutcomeRegistry` mock. The test asserts that:
  1. If `SetOutcome` fails during auto-approval, the interceptor falls through.
  2. The claim is rolled back and cleared from the registry.
  3. The drift is immediately claimable again.

### Automated Test Runs
Executed the entire `llmproxy` E2E test suite:
```powershell
go test -v ./internal/runtime/llmproxy/... -run TestScopeDrift

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

