### PR TITLE
fix(intent): stop logging parse failure on empty chain-context responses

### DIFF
--- a/internal/intent/extractor.go
+++ b/internal/intent/extractor.go
@@ -740,12 +740,14 @@ func extractFirstJSONValue(s string) string {
 // Every returned pattern has Source="llm_regex" so facts captured by these
 // patterns are distinguishable from builtin-pattern facts in chain_facts.
 func parseExtractionResponse(raw string, logger *slog.Logger, taskID string) ([]extractedFact, []extractionPattern) {
-	// Try new format first.
+	// The system prompt mandates the object form. Accept it whenever it
+	// parses — empty facts+patterns is a valid "nothing to extract"
+	// response and must not be reported as a parse failure.
 	var obj struct {
 		Facts    []extractedFact     `json:"facts"`
 		Patterns []extractionPattern `json:"patterns"`
 	}
-	if err := json.Unmarshal([]byte(raw), &obj); err == nil && (len(obj.Facts) > 0 || len(obj.Patterns) > 0) {
+	if err := json.Unmarshal([]byte(raw), &obj); err == nil {
 		for i := range obj.Patterns {
 			obj.Patterns[i].Source = "llm_regex"
 		}

--- a/internal/intent/extractor_test.go
+++ b/internal/intent/extractor_test.go
@@ -1,8 +1,10 @@
 package intent
 
 import (
+	"bytes"
 	"fmt"
 	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/clawvisor/clawvisor/pkg/store"
@@ -60,15 +62,22 @@ func TestParseExtractionResponse_LegacyArray(t *testing.T) {
 
 func TestParseExtractionResponse_EmptyNew(t *testing.T) {
 	raw := `{"facts": [], "patterns": []}`
-	facts, patterns := parseExtractionResponse(raw, slog.Default(), "test")
-	// Empty facts+patterns is valid new format, but since both are empty
-	// it falls through to legacy parse (which also produces empty). Either
-	// way, the result should be empty.
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, nil))
+
+	facts, patterns := parseExtractionResponse(raw, logger, "test")
 	if len(facts) != 0 {
 		t.Errorf("expected 0 facts, got %d", len(facts))
 	}
 	if len(patterns) != 0 {
 		t.Errorf("expected 0 patterns, got %d", len(patterns))
+	}
+	// Regression guard: a valid empty new-format response must NOT emit
+	// the "parse failed" warning. The metric the alert uses counts those
+	// warnings, and noisy zero-fact tasks were driving 5%+ false-positive
+	// rates before the empty-arrays guard was removed.
+	if strings.Contains(logBuf.String(), "chain context extraction parse failed") {
+		t.Errorf("empty new-format response logged a parse failure:\n%s", logBuf.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

- `parseExtractionResponse` required the object-format unmarshal to produce non-empty `facts` OR `patterns` before accepting it. A valid `{"facts":[],"patterns":[]}` reply (the LLM saying *nothing extractable*) failed the guard, fell through to the legacy array unmarshal, and that unmarshal always failed with `cannot unmarshal object into Go value of type []intent.extractedFact` — logging `chain context extraction parse failed` every time.
- The system prompt (`extractionSystemPrompt`) mandates the object form, so any successful object unmarshal is the real answer. Drop the empty-arrays guard.
- Extend `TestParseExtractionResponse_EmptyNew` to capture slog output and assert the warning is **not** emitted, so the bug can't recur silently.

## Why it matters

The Cloud Monitoring policy `Chain-context parse failure rate elevated` watches the log-based metric `logging/user/chain_context_parse_failures` (threshold 0.028 on `cloud_run_revision` for the `clawvisor` service in `us-central1`). Over the last 24h it opened 5 violations with values up to 0.056.

Triage showed ~200 failures over 6h coming from just 13 task IDs — all long-running Slack EA / personal-knowledge-base cron tasks (Slack `list_channels`, `list_users`, `search_messages` style). The system prompt itself classifies channel names / user names / status strings as content rather than entities, so gemini correctly returns `{"facts":[],"patterns":[]}` for these results. Every cron tick on those tasks was logging a false parse-failure and driving the rate metric.

`extractor.go` has not been touched in this submodule since 2026-05-27, so this is the pre-existing bug from PR #343 — the affected high-volume tasks scaled up enough recently to push the false rate past the threshold.

## Test plan

- [x] `go test ./internal/intent/ -count=1` — pass (3.5s)
- [x] Existing `TestParseExtractionResponse_EmptyNew` updated to assert no warning is emitted (would fail on the pre-fix code)
- [ ] After merge: re-pin the `clawvisor` submodule in the `cloud` repo to a SHA containing this fix, then deploy a new Cloud Run revision and confirm the alert auto-resolves and stays clear over a 24h window

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

