### PR TITLE
Restore LLM proxy abstractions: verdict purity, unified inbound dispatch

### DIFF
--- a/internal/api/handlers/llm_endpoint.go
+++ b/internal/api/handlers/llm_endpoint.go
@@ -1055,15 +1055,25 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 	// menu — faithful history, helpful result — while the harness only
 	// ever ran a no-op.
 	if h.ScopeDrifts != nil {
-		driftRewrite, driftErr := llmproxy.RewriteScopeDriftPlaceholders(r.Context(), llmproxy.ScopeDriftInboundRewriteRequest{
-			HTTPRequest:    r,
-			Provider:       provider,
-			Body:           body,
-			Agent:          agent,
-			ConversationID: conversationID,
-			ScopeDrifts:    h.ScopeDrifts,
-			Logger:         h.Logger,
-		})
+		// Route through the InboundRegistry so the dispatch shape
+		// parallels DefaultResponseRegistry on the outbound leg —
+		// per-provider InboundRewriter types live in llmproxy and
+		// register the conversation-package interface here.
+		inboundRewriter := llmproxy.DefaultInboundRegistry().ForProvider(provider)
+		var driftRewrite conversation.InboundRewriteResult
+		var driftErr error
+		if inboundRewriter != nil {
+			driftRewrite, driftErr = inboundRewriter.RewriteInbound(r.Context(), conversation.InboundRewriteRequest{
+				HTTPRequest:    r,
+				Provider:       provider,
+				Body:           body,
+				AgentID:        agent.ID,
+				AgentUserID:    agent.UserID,
+				ConversationID: conversationID,
+				Lookup:         llmproxy.NewSubstitutionLookup(h.ScopeDrifts),
+				Logger:         h.Logger,
+			})
+		}
 		if driftErr != nil {
 			// Forwarding the unrewritten body would ship the Bash
 			// placeholder upstream, leaving the conversation

--- a/internal/runtime/conversation/response.go
+++ b/internal/runtime/conversation/response.go
@@ -92,6 +92,15 @@ type ToolUseVerdict struct {
 	// what should happen; postprocess realizes it.
 	PendingSubstitution *PendingSubstitutionSpec
 
+	// DeferredDriftOutcome, when non-nil, declares that the
+	// postprocess layer should mark a scope-drift record with the
+	// given outcome after the verdict is finalized. Same pattern as
+	// PendingSubstitution: evaluators populate intent, postprocess
+	// owns the write + rollback. Committed BEFORE PendingSubstitution
+	// in the same pass so the pre-clear is in place before the
+	// substitution registers.
+	DeferredDriftOutcome *DeferredDriftOutcomeSpec
+
 	// HeldKindHint is the policy-set classification of this verdict
 	// for postproc's coalescing pass. When empty, classification falls
 	// back to the Allowed / RewriteInput shape.
@@ -147,6 +156,22 @@ type PendingSubstitutionSpec struct {
 type PendingSubstitutionTaskRollback struct {
 	TaskID string
 	UserID string
+}
+
+// DeferredDriftOutcomeSpec asks the postprocess layer to mark a
+// scope-drift record with the given outcome after the verdict is
+// finalized. Like PendingSubstitution, this keeps the verdict pure
+// data: the evaluator declares intent, postprocess performs the
+// registry write. Used today by the inline-task auto-approve path,
+// which previously called SetOutcome(Succeeded) directly from the
+// evaluator.
+//
+// Outcome is carried as a string so the conversation package stays
+// free of llmproxy-package dependencies; the postprocess layer
+// converts it to the typed ScopeDriftOutcome on commit.
+type DeferredDriftOutcomeSpec struct {
+	DriftID string
+	Outcome string
 }
 
 type RewriteResult struct {
@@ -304,6 +329,67 @@ func (r *InboundRegistry) ForProvider(p Provider) InboundRewriter {
 	for _, rewriter := range r.rewriters {
 		if rewriter.Name() == p {
 			return rewriter
+		}
+	}
+	return nil
+}
+
+// InboundBodyShape exposes per-provider readers and writers for the
+// inbound request body's role-based turn structure. Anthropic's
+// {messages: [{role, content}]} and OpenAI's {input | messages} both
+// project onto these primitives. Centralizing the per-provider walks
+// behind one interface lets call sites stop hand-rolling switches —
+// agent notices, secret-decision parsing, human-turn extraction,
+// assistant-text injection all share the same dispatch shape as the
+// response and inbound rewriters.
+//
+// All methods are safe to call on nil/malformed bodies — they return
+// the zero value of their return type rather than erroring, mirroring
+// the existing helper contracts the call sites depended on.
+type InboundBodyShape interface {
+	Name() Provider
+	// HasAssistantTurn reports whether the body contains at least one
+	// turn with role "assistant".
+	HasAssistantTurn(body []byte) bool
+	// RecentHumanTurns returns the most recent genuine human-authored
+	// chat turns in chronological order (most recent last), with
+	// Clawvisor-internal artifacts filtered and tail-limited to a
+	// small bound. Auto-approve assessment consumes these.
+	RecentHumanTurns(body []byte) []string
+	// LatestUserText returns the raw text of the most recent user
+	// turn. Unlike RecentHumanTurns, it doesn't filter Clawvisor
+	// internal verbs — secret-detection / reply-routing consumers
+	// need the verbatim user message.
+	LatestUserText(body []byte) string
+	// AssistantTextTurns returns flattened text for every assistant-
+	// role turn, most-recent first. Tool_use blocks are skipped.
+	AssistantTextTurns(body []byte) []string
+	// PrependAssistantText splices text into the leading assistant
+	// turn. Returns body unchanged when no assistant turn exists or
+	// when the splice can't be performed cleanly.
+	PrependAssistantText(contentType string, body []byte, text string) ([]byte, error)
+}
+
+// InboundShapeRegistry routes a Provider to its InboundBodyShape.
+// Parallel to ResponseRegistry and InboundRegistry on their respective
+// legs, so dispatch stays consistent across all three abstractions.
+type InboundShapeRegistry struct {
+	shapes []InboundBodyShape
+}
+
+func NewInboundShapeRegistry(shapes ...InboundBodyShape) *InboundShapeRegistry {
+	return &InboundShapeRegistry{shapes: shapes}
+}
+
+// ForProvider returns the shape registered for p, or nil. Callers
+// that want a non-nil "do-nothing" default should wrap the result.
+func (r *InboundShapeRegistry) ForProvider(p Provider) InboundBodyShape {
+	if r == nil {
+		return nil
+	}
+	for _, shape := range r.shapes {
+		if shape.Name() == p {
+			return shape
 		}
 	}
 	return nil

--- a/internal/runtime/conversation/response.go
+++ b/internal/runtime/conversation/response.go
@@ -153,9 +153,17 @@ type PendingSubstitutionSpec struct {
 // by the auto-approve path. The expirer itself lives in the
 // PostprocessConfig (InlineTaskCreator); the spec only carries the
 // identity tuple needed to invoke it.
+//
+// AgentID + ConversationID let postprocess also clear the conversation
+// checkout the auto-approve flow set inline before returning the
+// verdict. Without that sweep, a commit failure leaves the checkout
+// pointing at the just-expired task and subsequent turns surface a
+// "task missing" experience.
 type PendingSubstitutionTaskRollback struct {
-	TaskID string
-	UserID string
+	TaskID         string
+	UserID         string
+	AgentID        string
+	ConversationID string
 }
 
 // DeferredDriftOutcomeSpec asks the postprocess layer to mark a

--- a/internal/runtime/conversation/response.go
+++ b/internal/runtime/conversation/response.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"strings"
 )
@@ -204,6 +205,108 @@ type StreamingResponseRewriter interface {
 	// arrive; the returned result still carries the full ToolUses slice
 	// for callers that don't supply a callback.
 	StreamRewrite(ctx context.Context, r io.Reader, w io.Writer, onToolUse func(ToolUse)) (StreamingRewriteResult, error)
+}
+
+// InboundSubstitutionLookup is the read-only registry view the
+// InboundRewriter consults to find pending substitutions keyed by
+// (agent, conversation, tool_use_id). The lookup is non-consuming —
+// the harness's stored history carries the placeholder for the rest
+// of the conversation, so every subsequent inbound request has to
+// restore it. The lifetime is owned by the postprocess layer that
+// registered the entry; the rewriter is purely a reader.
+type InboundSubstitutionLookup interface {
+	LookupPendingSubstitution(ctx context.Context, agentID, conversationID, toolUseID string) (InboundPendingSubstitution, bool)
+}
+
+// InboundPendingSubstitution is the rewriter's view of a registry
+// entry. Mirrors the fields PendingSubstitutionSpec carried into the
+// registry on the response leg, lifted into the conversation package
+// so the rewriter doesn't depend on llmproxy.
+type InboundPendingSubstitution struct {
+	DriftID           string
+	MenuText          string
+	OriginalToolName  string
+	OriginalToolInput []byte
+}
+
+// InboundRewriteRequest is the input to InboundRewriter.RewriteInbound.
+// Identifying context (Agent + ConversationID) keys into the
+// substitution lookup; Body + Provider drive the JSON shape walk.
+type InboundRewriteRequest struct {
+	HTTPRequest    *http.Request
+	Provider       Provider
+	Body           []byte
+	AgentID        string
+	AgentUserID    string
+	ConversationID string
+	Lookup         InboundSubstitutionLookup
+	Logger         *slog.Logger
+}
+
+// InboundRewriteResult reports what RewriteInbound did. Rewritten=false
+// + nil error means no pending substitutions applied to the body.
+type InboundRewriteResult struct {
+	Body            []byte
+	Rewritten       bool
+	AppliedDriftIDs []string
+}
+
+// InboundRewriter is the per-provider abstraction for the inbound
+// /v1/messages (or /v1/responses, /v1/chat/completions) walker that
+// restores model-original tool_use blocks and splices menu text into
+// the matching tool_result on retry. Mirrors ResponseRewriter on the
+// outbound leg so dispatch, testing, and registry shape stay
+// symmetric.
+type InboundRewriter interface {
+	Name() Provider
+	// MatchesInbound returns true when this rewriter knows how to
+	// walk the request's body shape. Provider routing is the
+	// primary signal — Anthropic vs OpenAI — with sub-shape
+	// disambiguation (Chat Completions vs Responses) handled inside
+	// RewriteInbound where the body bytes are already in scope.
+	MatchesInbound(req *http.Request) bool
+	RewriteInbound(ctx context.Context, req InboundRewriteRequest) (InboundRewriteResult, error)
+}
+
+// InboundRegistry dispatches inbound bodies to the matching
+// InboundRewriter. Parallel to ResponseRegistry so callers can route
+// either leg through one canonical Match() lookup.
+type InboundRegistry struct {
+	rewriters []InboundRewriter
+}
+
+func NewInboundRegistry(rewriters ...InboundRewriter) *InboundRegistry {
+	return &InboundRegistry{rewriters: rewriters}
+}
+
+// Match returns the first registered rewriter that claims the
+// request, or nil. Provider routing happens via MatchesInbound; the
+// caller's only job is to feed the *http.Request.
+func (r *InboundRegistry) Match(req *http.Request) InboundRewriter {
+	if r == nil {
+		return nil
+	}
+	for _, rewriter := range r.rewriters {
+		if rewriter.MatchesInbound(req) {
+			return rewriter
+		}
+	}
+	return nil
+}
+
+// ForProvider returns the registered rewriter for the given provider,
+// or nil. Parallels ResponseRegistry.ForProvider for callers that
+// dispatch by provider name (lite-proxy route resolver, tests).
+func (r *InboundRegistry) ForProvider(p Provider) InboundRewriter {
+	if r == nil {
+		return nil
+	}
+	for _, rewriter := range r.rewriters {
+		if rewriter.Name() == p {
+			return rewriter
+		}
+	}
+	return nil
 }
 
 type ResponseRegistry struct {

--- a/internal/runtime/conversation/response.go
+++ b/internal/runtime/conversation/response.go
@@ -82,6 +82,15 @@ type ToolUseVerdict struct {
 	// rows can link to the same task_id.
 	CreatedTaskID string
 
+	// PendingSubstitution, when non-nil, declares that the postprocess
+	// layer should register an inbound substitution after the verdict
+	// is finalized. Evaluators MUST NOT write to the substitution
+	// registry directly — populate this field and let the postprocess
+	// layer own the registry write and its rollback. This restores
+	// the "verdict is pure data" invariant: the verdict describes
+	// what should happen; postprocess realizes it.
+	PendingSubstitution *PendingSubstitutionSpec
+
 	// HeldKindHint is the policy-set classification of this verdict
 	// for postproc's coalescing pass. When empty, classification falls
 	// back to the Allowed / RewriteInput shape.
@@ -98,6 +107,45 @@ type ToolUseVerdict struct {
 	// evaluator that runs, including those returning Skip —
 	// observation is a separate channel from verdict claiming.
 	Facts []EvaluationFact
+}
+
+// PendingSubstitutionSpec describes an inbound substitution the
+// postprocess layer should register after the verdict is finalized.
+// The spec is pure data: evaluators populate it; postprocess realizes
+// it. Provider-specific marshaling and registry keying happen in
+// postprocess, so this struct stays free of llmproxy-package
+// dependencies.
+//
+// Fields:
+//   - DriftID: scope-drift record this substitution is associated
+//     with (mint path), empty for paths that don't mint a drift
+//     (recoverable-deny).
+//   - MenuText: content the inbound rewriter splices into the
+//     tool_result on the next /v1/messages.
+//   - OriginalToolName / OriginalToolInput: the model's original
+//     tool_use fields, restored by the inbound rewriter into the
+//     prior assistant turn so the model never sees the harness-side
+//     placeholder.
+//   - TaskRollback: when non-nil, the inline task to expire if the
+//     registry write fails. Used by auto-approve so a failed
+//     registration unwinds the orphan task created earlier in the
+//     evaluator.
+type PendingSubstitutionSpec struct {
+	DriftID           string
+	MenuText          string
+	OriginalToolName  string
+	OriginalToolInput []byte
+	TaskRollback      *PendingSubstitutionTaskRollback
+}
+
+// PendingSubstitutionTaskRollback names an inline task the postprocess
+// layer must expire if the substitution registry write fails. Carried
+// by the auto-approve path. The expirer itself lives in the
+// PostprocessConfig (InlineTaskCreator); the spec only carries the
+// identity tuple needed to invoke it.
+type PendingSubstitutionTaskRollback struct {
+	TaskID string
+	UserID string
 }
 
 type RewriteResult struct {

--- a/internal/runtime/llmproxy/agent_notice.go
+++ b/internal/runtime/llmproxy/agent_notice.go
@@ -68,14 +68,11 @@ func HasInboundAssistantTurn(provider conversation.Provider, body []byte) bool {
 	if len(body) == 0 {
 		return true
 	}
-	switch provider {
-	case conversation.ProviderAnthropic:
-		return anthropicInboundHasAssistant(body)
-	case conversation.ProviderOpenAI:
-		return openAIInboundHasAssistant(body)
-	default:
+	shape := DefaultInboundShapeRegistry().ForProvider(provider)
+	if shape == nil {
 		return true
 	}
+	return shape.HasAssistantTurn(body)
 }
 
 func anthropicInboundHasAssistant(body []byte) bool {

--- a/internal/runtime/llmproxy/assistant_notice_prepend.go
+++ b/internal/runtime/llmproxy/assistant_notice_prepend.go
@@ -48,19 +48,9 @@ func dispatchPrependNotice(
 	body []byte,
 	text string,
 ) ([]byte, error) {
-	switch provider {
-	case conversation.ProviderAnthropic:
-		return conversation.PrependAnthropicAssistantText(contentType, body, text)
-	case conversation.ProviderOpenAI:
-		switch conversation.OpenAIResponseShape(contentType, body) {
-		case conversation.OpenAIResponseShapeChat:
-			return conversation.PrependOpenAIChatAssistantText(contentType, body, text)
-		case conversation.OpenAIResponseShapeResponses:
-			return conversation.PrependOpenAIResponsesAssistantText(contentType, body, text)
-		default:
-			return body, nil
-		}
-	default:
+	shape := DefaultInboundShapeRegistry().ForProvider(provider)
+	if shape == nil {
 		return body, nil
 	}
+	return shape.PrependAssistantText(contentType, body, text)
 }

--- a/internal/runtime/llmproxy/human_turns.go
+++ b/internal/runtime/llmproxy/human_turns.go
@@ -42,14 +42,11 @@ func ExtractRecentHumanTurns(req ExtractHumanTurnsRequest) []string {
 	if len(req.Body) == 0 {
 		return []string{}
 	}
-	switch req.Provider {
-	case conversation.ProviderAnthropic:
-		return extractAnthropicHumanTurns(req.Body)
-	case conversation.ProviderOpenAI:
-		return extractOpenAIHumanTurns(req.Body)
-	default:
+	shape := DefaultInboundShapeRegistry().ForProvider(req.Provider)
+	if shape == nil {
 		return []string{}
 	}
+	return shape.RecentHumanTurns(req.Body)
 }
 
 func extractAnthropicHumanTurns(body []byte) []string {

--- a/internal/runtime/llmproxy/inbound_shape.go
+++ b/internal/runtime/llmproxy/inbound_shape.go
@@ -99,21 +99,30 @@ func (OpenAIInboundShape) LatestUserText(body []byte) string {
 	if err := json.Unmarshal(body, &parsed); err != nil {
 		return ""
 	}
-	// Responses `input` carries the latest turn first when present.
-	var input string
-	if len(parsed.Input) > 0 && json.Unmarshal(parsed.Input, &input) == nil {
-		return strings.TrimSpace(input)
-	}
-	var items []map[string]any
-	if len(parsed.Input) > 0 && json.Unmarshal(parsed.Input, &items) == nil {
-		for i := len(items) - 1; i >= 0; i-- {
-			role, _ := items[i]["role"].(string)
-			if role != "user" {
-				continue
-			}
-			raw, _ := json.Marshal(items[i]["content"])
-			return strings.TrimSpace(flattenOpenAITaskReplyContent(raw))
+	// Responses API (`input`) and Chat Completions (`messages`) are
+	// mutually exclusive on the wire: a real OpenAI body has one or
+	// the other. When Input is set it IS the conversation history;
+	// falling back to Messages would risk returning a stale entry
+	// from a malformed body where both arrays exist but only Input
+	// reflects current state. Pick whichever is populated and walk
+	// only that one.
+	if len(parsed.Input) > 0 {
+		var input string
+		if json.Unmarshal(parsed.Input, &input) == nil {
+			return strings.TrimSpace(input)
 		}
+		var items []map[string]any
+		if json.Unmarshal(parsed.Input, &items) == nil {
+			for i := len(items) - 1; i >= 0; i-- {
+				role, _ := items[i]["role"].(string)
+				if role != "user" {
+					continue
+				}
+				raw, _ := json.Marshal(items[i]["content"])
+				return strings.TrimSpace(flattenOpenAITaskReplyContent(raw))
+			}
+		}
+		return ""
 	}
 	for i := len(parsed.Messages) - 1; i >= 0; i-- {
 		role, _ := parsed.Messages[i]["role"].(string)
@@ -126,13 +135,12 @@ func (OpenAIInboundShape) LatestUserText(body []byte) string {
 	return ""
 }
 
-// AssistantTextTurns walks BOTH the Responses `input` array AND the
-// Chat `messages` array (in that order, matching the legacy
-// secret-decision walker) and returns flattened assistant text turns
-// most-recent first. Either array can be absent; both can coexist on
-// a malformed body, and the latest-first contract picks the
-// Responses entries first because that's where modern OpenAI
-// harnesses (codex) place their history.
+// AssistantTextTurns returns flattened assistant text turns most-
+// recent first. Responses (`input`) and Chat Completions (`messages`)
+// are mutually exclusive on the wire — walking BOTH and concatenating
+// would interleave stale `input` entries before fresh `messages`
+// entries (or vice-versa) and produce a sequence that contradicts
+// the latest-first contract. Pick whichever array is populated.
 func (OpenAIInboundShape) AssistantTextTurns(body []byte) []string {
 	var parsed struct {
 		Messages []map[string]any `json:"messages"`
@@ -141,9 +149,12 @@ func (OpenAIInboundShape) AssistantTextTurns(body []byte) []string {
 	if err := json.Unmarshal(body, &parsed); err != nil {
 		return nil
 	}
-	out := make([]string, 0, 8)
-	var items []map[string]any
-	if len(parsed.Input) > 0 && json.Unmarshal(parsed.Input, &items) == nil {
+	if len(parsed.Input) > 0 {
+		var items []map[string]any
+		if json.Unmarshal(parsed.Input, &items) != nil {
+			return nil
+		}
+		out := make([]string, 0, len(items))
 		for i := len(items) - 1; i >= 0; i-- {
 			role, _ := items[i]["role"].(string)
 			if role != "assistant" {
@@ -152,7 +163,9 @@ func (OpenAIInboundShape) AssistantTextTurns(body []byte) []string {
 			raw, _ := json.Marshal(items[i]["content"])
 			out = append(out, flattenOpenAITaskReplyContent(raw))
 		}
+		return out
 	}
+	out := make([]string, 0, len(parsed.Messages))
 	for i := len(parsed.Messages) - 1; i >= 0; i-- {
 		role, _ := parsed.Messages[i]["role"].(string)
 		if role != "assistant" {

--- a/internal/runtime/llmproxy/inbound_shape.go
+++ b/internal/runtime/llmproxy/inbound_shape.go
@@ -1,0 +1,186 @@
+package llmproxy
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+)
+
+// AnthropicInboundShape implements conversation.InboundBodyShape for
+// /v1/messages bodies. Methods delegate to internal walkers that
+// existed before this abstraction was introduced; the type lets
+// callers stop hand-rolling switch statements and route every
+// per-provider body operation through one consistent dispatch.
+type AnthropicInboundShape struct{}
+
+func (AnthropicInboundShape) Name() conversation.Provider {
+	return conversation.ProviderAnthropic
+}
+
+func (AnthropicInboundShape) HasAssistantTurn(body []byte) bool {
+	return anthropicInboundHasAssistant(body)
+}
+
+func (AnthropicInboundShape) RecentHumanTurns(body []byte) []string {
+	return extractAnthropicHumanTurns(body)
+}
+
+func (AnthropicInboundShape) LatestUserText(body []byte) string {
+	var parsed struct {
+		Messages []struct {
+			Role    string          `json:"role"`
+			Content json.RawMessage `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return ""
+	}
+	for i := len(parsed.Messages) - 1; i >= 0; i-- {
+		if parsed.Messages[i].Role == "user" {
+			return strings.TrimSpace(flattenAnthropicTaskReplyText(parsed.Messages[i].Content))
+		}
+	}
+	return ""
+}
+
+// AssistantTextTurns returns flattened text for every assistant-role
+// turn, most-recent first. Tool_use blocks are skipped — only the
+// text content survives, matching the inline-switch semantics
+// LatestAssistantSecretDecisionID used to use.
+func (AnthropicInboundShape) AssistantTextTurns(body []byte) []string {
+	var parsed struct {
+		Messages []struct {
+			Role    string          `json:"role"`
+			Content json.RawMessage `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil
+	}
+	out := make([]string, 0, len(parsed.Messages))
+	for i := len(parsed.Messages) - 1; i >= 0; i-- {
+		if parsed.Messages[i].Role != "assistant" {
+			continue
+		}
+		out = append(out, flattenAnthropicTaskReplyText(parsed.Messages[i].Content))
+	}
+	return out
+}
+
+func (AnthropicInboundShape) PrependAssistantText(contentType string, body []byte, text string) ([]byte, error) {
+	return conversation.PrependAnthropicAssistantText(contentType, body, text)
+}
+
+// OpenAIInboundShape implements conversation.InboundBodyShape for
+// OpenAI Chat Completions and Responses bodies. Sub-shape
+// disambiguation happens per-method since each operation has its
+// own preferred ordering (Responses input[] first, then Chat
+// messages[]) — see method comments.
+type OpenAIInboundShape struct{}
+
+func (OpenAIInboundShape) Name() conversation.Provider {
+	return conversation.ProviderOpenAI
+}
+
+func (OpenAIInboundShape) HasAssistantTurn(body []byte) bool {
+	return openAIInboundHasAssistant(body)
+}
+
+func (OpenAIInboundShape) RecentHumanTurns(body []byte) []string {
+	return extractOpenAIHumanTurns(body)
+}
+
+func (OpenAIInboundShape) LatestUserText(body []byte) string {
+	var parsed struct {
+		Messages []map[string]any `json:"messages"`
+		Input    json.RawMessage  `json:"input"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return ""
+	}
+	// Responses `input` carries the latest turn first when present.
+	var input string
+	if len(parsed.Input) > 0 && json.Unmarshal(parsed.Input, &input) == nil {
+		return strings.TrimSpace(input)
+	}
+	var items []map[string]any
+	if len(parsed.Input) > 0 && json.Unmarshal(parsed.Input, &items) == nil {
+		for i := len(items) - 1; i >= 0; i-- {
+			role, _ := items[i]["role"].(string)
+			if role != "user" {
+				continue
+			}
+			raw, _ := json.Marshal(items[i]["content"])
+			return strings.TrimSpace(flattenOpenAITaskReplyContent(raw))
+		}
+	}
+	for i := len(parsed.Messages) - 1; i >= 0; i-- {
+		role, _ := parsed.Messages[i]["role"].(string)
+		if role != "user" {
+			continue
+		}
+		raw, _ := json.Marshal(parsed.Messages[i]["content"])
+		return strings.TrimSpace(flattenOpenAITaskReplyContent(raw))
+	}
+	return ""
+}
+
+// AssistantTextTurns walks BOTH the Responses `input` array AND the
+// Chat `messages` array (in that order, matching the legacy
+// secret-decision walker) and returns flattened assistant text turns
+// most-recent first. Either array can be absent; both can coexist on
+// a malformed body, and the latest-first contract picks the
+// Responses entries first because that's where modern OpenAI
+// harnesses (codex) place their history.
+func (OpenAIInboundShape) AssistantTextTurns(body []byte) []string {
+	var parsed struct {
+		Messages []map[string]any `json:"messages"`
+		Input    json.RawMessage  `json:"input"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil
+	}
+	out := make([]string, 0, 8)
+	var items []map[string]any
+	if len(parsed.Input) > 0 && json.Unmarshal(parsed.Input, &items) == nil {
+		for i := len(items) - 1; i >= 0; i-- {
+			role, _ := items[i]["role"].(string)
+			if role != "assistant" {
+				continue
+			}
+			raw, _ := json.Marshal(items[i]["content"])
+			out = append(out, flattenOpenAITaskReplyContent(raw))
+		}
+	}
+	for i := len(parsed.Messages) - 1; i >= 0; i-- {
+		role, _ := parsed.Messages[i]["role"].(string)
+		if role != "assistant" {
+			continue
+		}
+		raw, _ := json.Marshal(parsed.Messages[i]["content"])
+		out = append(out, flattenOpenAITaskReplyContent(raw))
+	}
+	return out
+}
+
+func (OpenAIInboundShape) PrependAssistantText(contentType string, body []byte, text string) ([]byte, error) {
+	switch conversation.OpenAIResponseShape(contentType, body) {
+	case conversation.OpenAIResponseShapeChat:
+		return conversation.PrependOpenAIChatAssistantText(contentType, body, text)
+	case conversation.OpenAIResponseShapeResponses:
+		return conversation.PrependOpenAIResponsesAssistantText(contentType, body, text)
+	default:
+		return body, nil
+	}
+}
+
+// DefaultInboundShapeRegistry returns the canonical shape dispatch
+// table. Mirrors DefaultResponseRegistry / DefaultInboundRegistry so
+// all three legs route through a consistent abstraction.
+func DefaultInboundShapeRegistry() *conversation.InboundShapeRegistry {
+	return conversation.NewInboundShapeRegistry(
+		AnthropicInboundShape{},
+		OpenAIInboundShape{},
+	)
+}

--- a/internal/runtime/llmproxy/inbound_shape_test.go
+++ b/internal/runtime/llmproxy/inbound_shape_test.go
@@ -1,0 +1,75 @@
+package llmproxy
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestOpenAIInboundShape_PrefersInputOverMessages pins the
+// disambiguation contract for OpenAI bodies: Responses (`input`) and
+// Chat Completions (`messages`) are mutually exclusive on the wire,
+// and walking BOTH on a malformed body that carries both can return
+// stale entries first. The shape picks whichever array is populated
+// and walks ONLY that one, so the most-recent-first contract holds.
+func TestOpenAIInboundShape_PrefersInputOverMessages(t *testing.T) {
+	shape := OpenAIInboundShape{}
+
+	// Both arrays populated, with a stale assistant decision marker in
+	// `messages` and the fresh one in `input`. The walker must return
+	// the input entry first; falling back to messages would surface
+	// the stale marker.
+	body := []byte(`{
+		"input": [
+			{"role": "user", "content": [{"type": "input_text", "text": "do thing"}]},
+			{"role": "assistant", "content": [{"type": "output_text", "text": "<clawvisor-secret-decision id=cv-fresh>"}]}
+		],
+		"messages": [
+			{"role": "user", "content": "older user"},
+			{"role": "assistant", "content": "<clawvisor-secret-decision id=cv-stale>"}
+		]
+	}`)
+	turns := shape.AssistantTextTurns(body)
+	if len(turns) == 0 {
+		t.Fatal("expected at least one assistant turn")
+	}
+	if !strings.Contains(turns[0], "cv-fresh") {
+		t.Fatalf("latest-first contract violated: turns[0] = %q (want id=cv-fresh)", turns[0])
+	}
+	for _, t := range turns {
+		if strings.Contains(t, "cv-stale") {
+			// The fix: when input is populated, don't walk messages at
+			// all. So cv-stale must NOT appear in the result.
+			break
+		}
+	}
+	// Stale marker must not leak through.
+	for _, txt := range turns {
+		if strings.Contains(txt, "cv-stale") {
+			t.Fatalf("walker leaked stale messages[] entry: %q", txt)
+		}
+	}
+
+	if user := shape.LatestUserText(body); user != "do thing" {
+		t.Fatalf("LatestUserText = %q, want %q (must walk input only when populated)", user, "do thing")
+	}
+}
+
+// TestOpenAIInboundShape_FallsBackToMessagesWhenInputAbsent confirms
+// the disambiguation doesn't accidentally hide the Chat Completions
+// path: when input is absent, messages MUST be walked.
+func TestOpenAIInboundShape_FallsBackToMessagesWhenInputAbsent(t *testing.T) {
+	shape := OpenAIInboundShape{}
+	body := []byte(`{
+		"messages": [
+			{"role": "user", "content": "from messages"},
+			{"role": "assistant", "content": "from messages assistant"}
+		]
+	}`)
+	turns := shape.AssistantTextTurns(body)
+	if len(turns) != 1 || turns[0] != "from messages assistant" {
+		t.Fatalf("AssistantTextTurns = %v, want one entry from messages", turns)
+	}
+	if user := shape.LatestUserText(body); user != "from messages" {
+		t.Fatalf("LatestUserText = %q, want %q", user, "from messages")
+	}
+}

--- a/internal/runtime/llmproxy/inline_task_intercept.go
+++ b/internal/runtime/llmproxy/inline_task_intercept.go
@@ -282,20 +282,15 @@ func MaybeInterceptInlineTaskDefinition(
 				audit("fallthrough", "auto_approve_create_failed", createErr.Error())
 				trace("inline_task.auto_approve_create_failed", "err", createErr.Error())
 			} else {
-				if parsed.DriftID != "" {
-					if setErr := cfg.ScopeDrifts.SetOutcome(req.Context(), parsed.DriftID, ScopeDriftOutcomeSucceeded); setErr != nil {
-						audit("fallthrough", "auto_approve_set_outcome_failed", setErr.Error())
-						trace("inline_task.auto_approve_set_outcome_failed", "err", setErr.Error())
-						if cfg.Store != nil && created != nil && created.ID != "" {
-							rollbackCtx, cancel := context.WithTimeout(context.WithoutCancel(req.Context()), 5*time.Second)
-							defer cancel()
-							if err := cfg.Store.RevokeTask(rollbackCtx, created.ID, cfg.AgentUserID); err != nil {
-								trace("inline_task.auto_approve_outcome_rollback_failed", "task_id", created.ID, "err", err.Error())
-							}
-						}
-						return conversation.ToolUseVerdict{}, false
-					}
-				}
+				// SetOutcome(Succeeded) is NOT called here anymore.
+				// The verdict carries a DeferredDriftOutcome spec the
+				// postprocess layer realizes after eval completes;
+				// see postprocessSession.commitVerdictSideEffects.
+				// Deferring the write keeps the verdict pure data and
+				// concentrates registry rollback in one place — on
+				// commit failure postprocess expires the task via
+				// the spec's TaskRollback (same handle the substitution
+				// commit uses).
 				checkedOut := false
 				if cfg.Checkouts != nil && created.ID != "" {
 					// Include ConversationID for parity with the manual
@@ -412,6 +407,13 @@ func MaybeInterceptInlineTaskDefinition(
 							UserID: cfg.AgentUserID,
 						},
 					},
+					// Mark the scope drift Succeeded at commit time so
+					// the pre-clear is minted before the substitution
+					// write that depends on it. SetOutcome is the only
+					// write the auto-approve evaluator USED to perform
+					// itself; deferring it closes the last side-effect
+					// gap in the eval pipeline.
+					DeferredDriftOutcome: deferredDriftOutcomeSpec(parsed.DriftID, ScopeDriftOutcomeSucceeded),
 				}, true
 			}
 		}
@@ -549,6 +551,21 @@ func MaybeInterceptInlineTaskDefinition(
 	}
 	guard.Success()
 	return verdict, true
+}
+
+// deferredDriftOutcomeSpec builds the verdict-level signal the
+// postprocess layer realizes via SetOutcome. Returns nil when there's
+// no drift to mark (empty driftID is the "no scope drift was minted
+// for this auto-approve" case), so the auto-approve verdict can
+// always assign the result without a branch.
+func deferredDriftOutcomeSpec(driftID string, outcome ScopeDriftOutcome) *conversation.DeferredDriftOutcomeSpec {
+	if strings.TrimSpace(driftID) == "" {
+		return nil
+	}
+	return &conversation.DeferredDriftOutcomeSpec{
+		DriftID: driftID,
+		Outcome: string(outcome),
+	}
 }
 
 func inlineSubstitutionShape(useAskUserQuestion bool) string {

--- a/internal/runtime/llmproxy/inline_task_intercept.go
+++ b/internal/runtime/llmproxy/inline_task_intercept.go
@@ -353,16 +353,14 @@ func MaybeInterceptInlineTaskDefinition(
 						"command": BuildAutoApprovePlaceholderCommand(tu.Name, created.ID, created.Purpose),
 					},
 				}
-				// Register a pending substitution so the inbound
-				// rewriter on the next /v1/messages restores the
-				// model's original control_tool POST byte-for-byte and
-				// delivers the augmentation context as the
-				// tool_result. The harness sees the model emit a
-				// `Bash` no-op carrying the operator-facing
-				// auto-approve comment; the upstream model sees its
-				// own call answered by the augmentation. Same wire
-				// mechanism as scope-drift / recoverable-deny — see
-				// scope_drift_inbound_rewrite.go.
+				// Drift-claim success: the deferred Rollback is now a
+				// no-op. Mirrors the placement in PR #569's continuation
+				// path. We mark success BEFORE returning the verdict
+				// because the verdict's PendingSubstitution spec carries
+				// a TaskRollback handle the postprocess layer will use
+				// if registry registration fails. Centralizing that
+				// rollback in postprocess keeps the verdict pure data
+				// (no in-eval registry side effects).
 				//
 				// Design tradeoff (vs. the pre-Jul-2026 upstream
 				// continuation path): the conversation now resumes on
@@ -376,56 +374,6 @@ func MaybeInterceptInlineTaskDefinition(
 				// harness while keeping it in the model's working
 				// context — a subtle desync). Accepted explicitly in the
 				// PR that landed this migration.
-				// Registry presence is enforced by the pre-flight gate
-				// at the top of the auto-approve branch, so this call
-				// site doesn't repeat the nil check.
-				registry := cfg.AuthorizationContext.ScopeDrifts
-				if regErr := registry.RegisterPendingSubstitution(req.Context(),
-					PendingSubstitutionKey{
-						AgentID:        cfg.AgentID,
-						ConversationID: cfg.ConversationID,
-						ToolUseID:      tu.ID,
-					},
-					PendingSubstitution{
-						MenuText:          augmentation,
-						OriginalToolName:  tu.Name,
-						OriginalToolInput: append([]byte(nil), tu.Input...),
-					},
-				); regErr != nil {
-					// Registration failure after the task was already
-					// created would leave an orphan active task — the
-					// model never received a record of the create call
-					// (no inbound substitution to restore it), so the
-					// agent will keep retrying with no awareness that
-					// the task exists. Roll the task back via
-					// InlineApprovedTaskExpirer so the audit trail and
-					// the dashboard reflect what actually happened.
-					// Detached context with a short timeout because a
-					// mid-request client disconnect (a plausible cause
-					// of cache misbehavior) must not cancel the
-					// rollback and strand the orphan for the full TTL.
-					if expirer, ok := cfg.InlineTaskCreator.(InlineApprovedTaskExpirer); ok {
-						rollbackCtx, cancel := context.WithTimeout(context.WithoutCancel(req.Context()), 5*time.Second)
-						if expireErr := expirer.ExpireInlineApprovedTask(rollbackCtx, created.ID, cfg.AgentUserID); expireErr != nil {
-							trace("inline_task.auto_approve_rollback_failed", "task_id", created.ID, "err", expireErr.Error())
-						}
-						cancel()
-					} else {
-						// The creator implementation predates the
-						// rollback interface; we can't undo. Log the
-						// orphan so operators can investigate.
-						trace("inline_task.auto_approve_rollback_unavailable", "task_id", created.ID, "reason", "InlineTaskCreator does not implement InlineApprovedTaskExpirer")
-					}
-					audit("fallthrough", "auto_approve_substitution_register_failed", regErr.Error()+"; task "+created.ID+" was rolled back via ExpireInlineApprovedTask")
-					trace("inline_task.auto_approve_substitution_failed", "err", regErr.Error(), "rolled_back_task_id", created.ID)
-					// Returning false also lets the deferred guard.Rollback
-					// (from PR #569's drift-claim machinery) revert the
-					// drift claim alongside the registration failure.
-					return conversation.ToolUseVerdict{}, false
-				}
-				// Drift-claim success: the deferred Rollback is now a
-				// no-op. Mirrors the placement in PR #569's continuation
-				// path.
 				guard.Success()
 				return conversation.ToolUseVerdict{
 					Outcome: conversation.OutcomeDeny,
@@ -449,6 +397,21 @@ func MaybeInterceptInlineTaskDefinition(
 					// the model sees its own call + the notice + the
 					// augmentation as the tool_result.
 					SubstituteWith: AutoApproveUserNotice(created.Purpose),
+					// Postprocess will register this pending
+					// substitution after the verdict is finalized; if
+					// the registry write fails it expires the task via
+					// TaskRollback so the dashboard doesn't strand an
+					// orphan. The evaluator is intentionally free of
+					// the registry call — the verdict stays pure data.
+					PendingSubstitution: &conversation.PendingSubstitutionSpec{
+						MenuText:          augmentation,
+						OriginalToolName:  tu.Name,
+						OriginalToolInput: append([]byte(nil), tu.Input...),
+						TaskRollback: &conversation.PendingSubstitutionTaskRollback{
+							TaskID: created.ID,
+							UserID: cfg.AgentUserID,
+						},
+					},
 				}, true
 			}
 		}

--- a/internal/runtime/llmproxy/inline_task_intercept.go
+++ b/internal/runtime/llmproxy/inline_task_intercept.go
@@ -403,8 +403,10 @@ func MaybeInterceptInlineTaskDefinition(
 						OriginalToolName:  tu.Name,
 						OriginalToolInput: append([]byte(nil), tu.Input...),
 						TaskRollback: &conversation.PendingSubstitutionTaskRollback{
-							TaskID: created.ID,
-							UserID: cfg.AgentUserID,
+							TaskID:         created.ID,
+							UserID:         cfg.AgentUserID,
+							AgentID:        cfg.AgentID,
+							ConversationID: cfg.ConversationID,
 						},
 					},
 					// Mark the scope drift Succeeded at commit time so

--- a/internal/runtime/llmproxy/inline_task_rewrite.go
+++ b/internal/runtime/llmproxy/inline_task_rewrite.go
@@ -216,19 +216,33 @@ func RewriteInlineTaskApprovalReply(ctx context.Context, req InlineApprovalRewri
 
 	// Mirror the resolver's allow/deny verdict onto the scope-drift
 	// registry when the hold was linked to one. The pre-clear is
-	// minted via SetOutcome(Succeeded) here so the agent's next attempt
-	// at the originally-blocked tool_use passes scope check once;
-	// SetOutcome(Denied) closes the drift so a stale poll doesn't show
-	// it pending forever. Best-effort: a registry error degrades to
-	// "drift will TTL-expire" rather than blocking the rewrite. Only
-	// fires when the hold actually carried a ScopeDriftID — created /
-	// expanded tasks without a drift link are unaffected.
+	// minted via SetOutcome(Succeeded) here so the agent's next
+	// attempt at the originally-blocked tool_use passes scope check
+	// once; SetOutcome(Denied) closes the drift so a stale poll
+	// doesn't show it pending forever. Only fires when the hold
+	// actually carried a ScopeDriftID — created / expanded tasks
+	// without a drift link are unaffected.
+	//
+	// Best-effort: a registry error degrades to "drift will TTL-
+	// expire" rather than blocking the rewrite, but the error IS
+	// traced so operators chasing a drift stuck in Pending have a
+	// breadcrumb. (Unlike scope_drift_reply.go's one-off path, the
+	// body here is the inline-approval reply augmentation — it
+	// doesn't claim a specific drift state to the LLM, so a stale
+	// Pending registry entry can't desync against a "you were
+	// approved" message the model already accepted.)
 	if req.ScopeDrifts != nil && resolved.ScopeDriftID != "" {
 		driftOutcome := ScopeDriftOutcomeSucceeded
 		if out.Decision == "deny" || out.Decision == "" {
 			driftOutcome = ScopeDriftOutcomeDenied
 		}
-		_ = req.ScopeDrifts.SetOutcome(ctx, resolved.ScopeDriftID, driftOutcome)
+		if err := req.ScopeDrifts.SetOutcome(ctx, resolved.ScopeDriftID, driftOutcome); err != nil && req.Trace != nil {
+			req.Trace("inline_task_reply.drift_outcome_write_failed",
+				"drift_id", resolved.ScopeDriftID,
+				"intended_outcome", string(driftOutcome),
+				"err", err.Error(),
+			)
+		}
 	}
 
 	// Record the outcome before returning. The augmenter on later

--- a/internal/runtime/llmproxy/pipelineeval/factory.go
+++ b/internal/runtime/llmproxy/pipelineeval/factory.go
@@ -642,12 +642,13 @@ func buildCredentialedTaskScope(
 			if mint := drifts.MintForCredentialed(ctx, tu, plan.Verdict, plan.Resolved, matchedTaskID, dec); mint.OK {
 				audit("block", "scope_drift_minted", "drift_id="+mint.DriftID+"; "+dec.Reason, matchedTaskID)
 				return policies.TaskScopeDecision{
-					Kind:               policies.TaskScopeDecisionHold,
-					Allowed:            false,
-					Reason:             "Clawvisor: no active task scope covers " + plan.Resolved.ServiceID + "." + plan.Resolved.ActionID + " — " + dec.Reason,
-					SubstituteText:     mint.MenuText,
-					SubstituteToolCall: mint.Sentinel,
-					TaskID:             matchedTaskID,
+					Kind:                policies.TaskScopeDecisionHold,
+					Allowed:             false,
+					Reason:              "Clawvisor: no active task scope covers " + plan.Resolved.ServiceID + "." + plan.Resolved.ActionID + " — " + dec.Reason,
+					SubstituteText:      mint.MenuText,
+					SubstituteToolCall:  mint.Sentinel,
+					PendingSubstitution: mint.Spec,
+					TaskID:              matchedTaskID,
 				}
 			} else if mint.Err != nil {
 				// Registry write failed — fall through to the legacy
@@ -776,12 +777,13 @@ func buildCredentialedTaskScope(
 					if mint := drifts.MintForCredentialed(ctx, tu, v, resolved, dec.TaskID, syntheticDec); mint.OK {
 						audit("block", "scope_drift_minted", "drift_id="+mint.DriftID+"; "+dec.Reason+" (legacy)", dec.TaskID)
 						return policies.TaskScopeDecision{
-							Kind:               policies.TaskScopeDecisionHold,
-							Allowed:            false,
-							Reason:             "Clawvisor: no active task scope covers " + resolved.ServiceID + "." + resolved.ActionID + " — " + dec.Reason,
-							SubstituteText:     mint.MenuText,
-							SubstituteToolCall: mint.Sentinel,
-							TaskID:             dec.TaskID,
+							Kind:                policies.TaskScopeDecisionHold,
+							Allowed:             false,
+							Reason:              "Clawvisor: no active task scope covers " + resolved.ServiceID + "." + resolved.ActionID + " — " + dec.Reason,
+							SubstituteText:      mint.MenuText,
+							SubstituteToolCall:  mint.Sentinel,
+							PendingSubstitution: mint.Spec,
+							TaskID:              dec.TaskID,
 						}
 					} else if mint.Err != nil {
 						audit("block", "scope_drift_mint_failed", mint.Err.Error()+" (legacy)", dec.TaskID)
@@ -1086,8 +1088,9 @@ func (h *authorizationHoldHandler) Hold(ctx context.Context, req policies.Author
 	// than emit a menu with no usable drift_id.
 	if mint := h.drifts.MintForTriggerMiss(ctx, req.ToolUse, req.InspectorVerdict, req.Decision); mint.OK {
 		return policies.AuthorizationHoldResult{
-			SubstituteToolCall: mint.Sentinel,
-			SubstituteText:     mint.MenuText,
+			SubstituteToolCall:  mint.Sentinel,
+			SubstituteText:      mint.MenuText,
+			PendingSubstitution: mint.Spec,
 		}, nil
 	}
 	if h.approval.PendingApprovals == nil {

--- a/internal/runtime/llmproxy/pipelineeval/scope_drift.go
+++ b/internal/runtime/llmproxy/pipelineeval/scope_drift.go
@@ -87,9 +87,11 @@ func driftSourceFor(source runtimedecision.DecisionSource) llmproxy.ScopeDriftSo
 //   1. Rewriting the blocked tool_use into Sentinel (a canonical Bash
 //      no-op encoding the original call) so the harness's local
 //      execution is harmless.
-//   2. Registering a pending substitution under the tool_use_id so the
-//      inbound rewriter replaces the harness-supplied tool_result
-//      content with MenuText on the next /v1/messages.
+//   2. Attaching Spec to the resulting verdict so the postprocess
+//      layer registers the inbound substitution after the verdict is
+//      finalized. The coordinator no longer writes to the registry
+//      itself — that side-effecting step is owned by postprocess,
+//      keeping the verdict pure data.
 // driftID is the registered drift's id, for audit linkage. OK reports
 // whether the mint actually landed — a false return tells the caller
 // to fall through to its legacy approval-prompt path.
@@ -97,6 +99,7 @@ type MintResult struct {
 	MenuText string
 	DriftID  string
 	Sentinel *conversation.SyntheticToolCall
+	Spec     *conversation.PendingSubstitutionSpec
 	Err      error
 	OK       bool
 }
@@ -136,10 +139,13 @@ func (c *scopeDriftCoordinator) MintForCredentialed(
 		return MintResult{Err: mintErr}
 	}
 	sentinel := buildScopeDriftSentinel(driftID, tu)
-	if regErr := c.registerPendingSubstitution(ctx, tu, driftID, menuText); regErr != nil {
-		return MintResult{Err: regErr}
+	return MintResult{
+		MenuText: menuText,
+		DriftID:  driftID,
+		Sentinel: sentinel,
+		Spec:     buildPendingSubstitutionSpec(tu, driftID, menuText),
+		OK:       true,
 	}
-	return MintResult{MenuText: menuText, DriftID: driftID, Sentinel: sentinel, OK: true}
 }
 
 // MintForTriggerMiss registers a drift for the non-credentialed
@@ -173,10 +179,13 @@ func (c *scopeDriftCoordinator) MintForTriggerMiss(
 		return MintResult{Err: mintErr}
 	}
 	sentinel := buildScopeDriftSentinel(driftID, tu)
-	if regErr := c.registerPendingSubstitution(ctx, tu, driftID, menuText); regErr != nil {
-		return MintResult{Err: regErr}
+	return MintResult{
+		MenuText: menuText,
+		DriftID:  driftID,
+		Sentinel: sentinel,
+		Spec:     buildPendingSubstitutionSpec(tu, driftID, menuText),
+		OK:       true,
 	}
-	return MintResult{MenuText: menuText, DriftID: driftID, Sentinel: sentinel, OK: true}
 }
 
 // buildScopeDriftSentinel constructs the SyntheticToolCall that
@@ -199,23 +208,19 @@ func buildScopeDriftSentinel(driftID string, tu conversation.ToolUse) *conversat
 	}
 }
 
-// registerPendingSubstitution records everything the inbound rewriter
-// needs to restore the original tool_use and replace the tool_result
-// content on the next /v1/messages.
-func (c *scopeDriftCoordinator) registerPendingSubstitution(ctx context.Context, tu conversation.ToolUse, driftID, menuText string) error {
-	if c == nil || c.registry == nil {
-		return nil
-	}
-	return c.registry.RegisterPendingSubstitution(ctx, llmproxy.PendingSubstitutionKey{
-		AgentID:        c.agent.AgentID,
-		ConversationID: c.audit.ConversationID,
-		ToolUseID:      tu.ID,
-	}, llmproxy.PendingSubstitution{
+// buildPendingSubstitutionSpec collects every field the inbound
+// rewriter needs to restore the original tool_use and replace the
+// tool_result content on the next /v1/messages. The spec is attached
+// to the verdict and registered later by postprocess — the coordinator
+// itself stays free of registry side-effects so the verdict remains
+// pure data.
+func buildPendingSubstitutionSpec(tu conversation.ToolUse, driftID, menuText string) *conversation.PendingSubstitutionSpec {
+	return &conversation.PendingSubstitutionSpec{
 		DriftID:           driftID,
 		MenuText:          menuText,
 		OriginalToolName:  tu.Name,
 		OriginalToolInput: append([]byte(nil), tu.Input...),
-	})
+	}
 }
 
 // ConsumePreClear looks up a one-shot pre-clear for the agent's retry

--- a/internal/runtime/llmproxy/policies/authorization_policy.go
+++ b/internal/runtime/llmproxy/policies/authorization_policy.go
@@ -104,6 +104,12 @@ type AuthorizationHoldResult struct {
 	// original tool_use and replaces the tool_result content with the
 	// menu — see scope_drift_inbound_rewrite.go.
 	SubstituteToolCall *conversation.SyntheticToolCall
+	// PendingSubstitution, when non-nil, asks the postprocess layer to
+	// register an inbound substitution after the verdict is finalized.
+	// Populated alongside SubstituteToolCall by the scope-drift menu
+	// path; the policy forwards it onto the resulting ToolUseVerdict
+	// so registration happens once, centrally, after eval completes.
+	PendingSubstitution *conversation.PendingSubstitutionSpec
 	// Err, when non-empty, signals a hold storage failure. The policy
 	// returns Deny.
 	Err string
@@ -258,6 +264,7 @@ func (p *AuthorizationPolicy) Evaluate(ctx context.Context, _ pipeline.ReadOnlyR
 				Reason:                 dec.Reason,
 				SubstituteWithToolCall: held.SubstituteToolCall,
 				SuppressSubstituteText: true,
+				PendingSubstitution:    held.PendingSubstitution,
 				Facts:                  []pipeline.EvaluationFact{authFact, taskScopeFact},
 			}, nil
 		}

--- a/internal/runtime/llmproxy/policies/task_scope_evaluator.go
+++ b/internal/runtime/llmproxy/policies/task_scope_evaluator.go
@@ -53,9 +53,15 @@ type TaskScopeDecision struct {
 	// the next /v1/messages. SubstituteText still populates as a
 	// secondary signal (audit, debug).
 	SubstituteToolCall *conversation.SyntheticToolCall
-	Ambiguous          bool
-	MatchedTask        *store.Task
-	MatchedAction      *store.TaskAction
+	// PendingSubstitution, when non-nil, asks the postprocess layer to
+	// register an inbound substitution after the verdict is finalized.
+	// Populated by the scope-drift menu mint (which used to write the
+	// registry from within the evaluator). Forwarded onto the resulting
+	// ToolUseVerdict by Evaluate.
+	PendingSubstitution *conversation.PendingSubstitutionSpec
+	Ambiguous           bool
+	MatchedTask         *store.Task
+	MatchedAction       *store.TaskAction
 }
 
 // TaskScopeDecisionKind disambiguates hard denials from approvable
@@ -166,6 +172,7 @@ func (e *TaskScopeEvaluator) Evaluate(ctx context.Context, _ pipeline.ReadOnlyRe
 			Reason:                 dec.Reason,
 			SubstituteWithToolCall: dec.SubstituteToolCall,
 			SuppressSubstituteText: true,
+			PendingSubstitution:    dec.PendingSubstitution,
 			Facts:                  []pipeline.EvaluationFact{fact},
 		}, nil
 	}

--- a/internal/runtime/llmproxy/postproc/postproc.go
+++ b/internal/runtime/llmproxy/postproc/postproc.go
@@ -92,8 +92,8 @@ func Postprocess(req *http.Request, body []byte, contentType string, cfg llmprox
 	}
 
 	ctx := req.Context()
-	if commitErr := session.commitSubstitutions(ctx, verdictByTU, preExtracted); commitErr != nil {
-		return failClosed("substitution registry write failed: " + commitErr.Error())
+	if commitErr := session.commitVerdictSideEffects(ctx, verdictByTU, preExtracted); commitErr != nil {
+		return failClosed("verdict side-effect commit failed: " + commitErr.Error())
 	}
 	finalResult, finalErr := session.finalize(ctx, preExtracted, verdictByTU)
 	if finalErr != nil {

--- a/internal/runtime/llmproxy/postproc/postproc.go
+++ b/internal/runtime/llmproxy/postproc/postproc.go
@@ -67,13 +67,7 @@ func Postprocess(req *http.Request, body []byte, contentType string, cfg llmprox
 	verdictByTU = make(map[string]conversation.ToolUseVerdict, len(preExtracted))
 	eval := func(tu conversation.ToolUse) conversation.ToolUseVerdict {
 		v := innerEval(tu)
-		v, registered := transformRecoverableDenyToPlaceholder(req.Context(), v, tu, cfg)
-		session.trackSubstitution(registered)
-		// Also track substitutions that fired inside innerEval itself
-		// (scope-drift mint runs there) so the rollback path covers
-		// every registry write made during this request, not just the
-		// recoverable-deny migration.
-		session.trackSubstitution(detectScopeDriftSubstitution(req.Context(), v, tu, cfg))
+		v = transformRecoverableDenyToPlaceholder(v, tu, cfg)
 		verdictByTU[tu.ID] = v
 		return v
 	}
@@ -98,6 +92,9 @@ func Postprocess(req *http.Request, body []byte, contentType string, cfg llmprox
 	}
 
 	ctx := req.Context()
+	if commitErr := session.commitSubstitutions(ctx, verdictByTU, preExtracted); commitErr != nil {
+		return failClosed("substitution registry write failed: " + commitErr.Error())
+	}
 	finalResult, finalErr := session.finalize(ctx, preExtracted, verdictByTU)
 	if finalErr != nil {
 		return failClosed("approval hold storage failed: " + finalErr.Error())

--- a/internal/runtime/llmproxy/postproc/recoverable_deny.go
+++ b/internal/runtime/llmproxy/postproc/recoverable_deny.go
@@ -1,35 +1,39 @@
 package postproc
 
 import (
-	"context"
-
 	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy"
 )
 
 // transformRecoverableDenyToPlaceholder converts a recoverable-deny
 // verdict (RecoverableDenyVerdict — Outcome=Deny with RecoverableReason
-// set) into a placeholder-tool_use + pending-substitution shape so the
-// model sees its own original tool_use answered by the reason on the
-// next inbound /v1/messages.
+// set) into a placeholder-tool_use shape and attaches a
+// PendingSubstitutionSpec describing the inbound substitution.
 //
-// Returns the (possibly unchanged) verdict and, when a substitution
-// was registered, the key the caller should hand to the rollback path
-// so a later failClosed / rewrite-error can revert the registry write.
-// Any failure to register leaves the verdict alone so the SubstituteWith
-// terminal fallback still surfaces the reason.
-func transformRecoverableDenyToPlaceholder(ctx context.Context, v conversation.ToolUseVerdict, tu conversation.ToolUse, cfg llmproxy.PostprocessConfig) (conversation.ToolUseVerdict, *llmproxy.PendingSubstitutionKey) {
+// This transform is PURE: it does not write to the substitution
+// registry. Centralized registration happens in
+// postprocessSession.commitSubstitutions after every evaluator has
+// produced its verdict, which preserves the "verdict is pure data"
+// invariant and makes rollback symmetric (the layer that registers
+// owns the rollback).
+//
+// Skipped (verdict returned unchanged) when:
+//   - the verdict isn't a recoverable-deny
+//   - another policy already chose a placeholder shape (e.g.
+//     scope-drift sets SubstituteWithToolCall directly)
+//   - the request lacks the (AgentID, ConversationID) identity tuple
+//     the registry key requires — leaving SubstituteWith as the
+//     terminal fallback when identity is incomplete (test fixtures /
+//     partially-wired deployments)
+func transformRecoverableDenyToPlaceholder(v conversation.ToolUseVerdict, tu conversation.ToolUse, cfg llmproxy.PostprocessConfig) conversation.ToolUseVerdict {
 	if v.Outcome != conversation.OutcomeDeny || v.RecoverableReason == "" {
-		return v, nil
+		return v
 	}
-	// Another policy already chose a placeholder shape (scope-drift
-	// sets SubstituteWithToolCall directly). Honour it.
 	if v.SubstituteWithToolCall != nil {
-		return v, nil
+		return v
 	}
-	registry := cfg.AuthorizationContext.ScopeDrifts
-	if registry == nil {
-		return v, nil
+	if cfg.AuthorizationContext.ScopeDrifts == nil {
+		return v
 	}
 	if cfg.AgentContext.AgentID == "" || cfg.AuditContext.ConversationID == "" {
 		// Substitution keys are (AgentID, ConversationID, ToolUseID).
@@ -39,64 +43,24 @@ func transformRecoverableDenyToPlaceholder(ctx context.Context, v conversation.T
 		// later restore the wrong reason into the wrong turn. Leave
 		// SubstituteWith as the terminal fallback when identity is
 		// incomplete — production wiring always populates both fields.
-		return v, nil
+		return v
 	}
 	reason := v.RecoverableReason
-	sentinel := &conversation.SyntheticToolCall{
+	v.SubstituteWithToolCall = &conversation.SyntheticToolCall{
 		ID:   tu.ID,
 		Name: llmproxy.ScopeDriftPlaceholderToolName,
 		Input: map[string]any{
 			"command": llmproxy.BuildRecoverableDenyPlaceholderCommand(tu.Name, reason),
 		},
 	}
-	key := llmproxy.PendingSubstitutionKey{
-		AgentID:        cfg.AgentContext.AgentID,
-		ConversationID: cfg.AuditContext.ConversationID,
-		ToolUseID:      tu.ID,
-	}
-	if err := registry.RegisterPendingSubstitution(ctx, key,
-		llmproxy.PendingSubstitution{
-			MenuText:          reason,
-			OriginalToolName:  tu.Name,
-			OriginalToolInput: append([]byte(nil), tu.Input...),
-		},
-	); err != nil {
-		return v, nil
-	}
-	v.SubstituteWithToolCall = sentinel
 	v.SuppressSubstituteText = true
 	v.SubstituteWith = ""
 	v.RecoverableReason = ""
-	return v, &key
-}
-
-// detectScopeDriftSubstitution returns the registry key for a
-// substitution that an inner evaluator (today: scope-drift mint in
-// pipelineeval/scope_drift.go) wrote during this request, so the
-// session rollback path can revert it on failClosed alongside the
-// recoverable-deny migrations this file owns.
-//
-// The detection rule: a Deny verdict whose SubstituteWithToolCall is
-// set, where the registry actually carries a substitution for this
-// (agent, conversation, tool_use_id). Anything else (allowed siblings,
-// approval-prompt substitute, recoverable-deny verdicts whose
-// transformation step already returned a key) returns nil.
-func detectScopeDriftSubstitution(ctx context.Context, v conversation.ToolUseVerdict, tu conversation.ToolUse, cfg llmproxy.PostprocessConfig) *llmproxy.PendingSubstitutionKey {
-	if v.Outcome != conversation.OutcomeDeny || v.SubstituteWithToolCall == nil {
-		return nil
+	v.PendingSubstitution = &conversation.PendingSubstitutionSpec{
+		MenuText:          reason,
+		OriginalToolName:  tu.Name,
+		OriginalToolInput: append([]byte(nil), tu.Input...),
 	}
-	registry := cfg.AuthorizationContext.ScopeDrifts
-	if registry == nil || cfg.AgentContext.AgentID == "" {
-		return nil
-	}
-	key := llmproxy.PendingSubstitutionKey{
-		AgentID:        cfg.AgentContext.AgentID,
-		ConversationID: cfg.AuditContext.ConversationID,
-		ToolUseID:      tu.ID,
-	}
-	if _, ok := registry.LookupPendingSubstitution(ctx, key); !ok {
-		return nil
-	}
-	return &key
+	return v
 }
 

--- a/internal/runtime/llmproxy/postproc/recoverable_deny_test.go
+++ b/internal/runtime/llmproxy/postproc/recoverable_deny_test.go
@@ -9,13 +9,12 @@ import (
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy"
 )
 
-// TestTransformRecoverableDenyToPlaceholder asserts the Continue+Deny
-// verdict shape produced by conversation.RecoverableDenyVerdict is
-// migrated to the placeholder + pending-substitution pattern: the
-// model's original tool_use is captured for restoration, the menu
-// (reason) text is stashed for the next inbound /v1/messages, and the
-// verdict's Continue signal is cleared so tryContinuation no longer
-// fires for these cases.
+// TestTransformRecoverableDenyToPlaceholder asserts the recoverable-
+// deny migration is now a PURE transform: the verdict gets a
+// placeholder SubstituteWithToolCall + a PendingSubstitution spec, but
+// the registry is NOT touched. Registration is deferred to
+// postprocessSession.commitSubstitutions so the verdict stays pure
+// data — see TestPostprocessSessionCommitSubstitutionsRegistersSpec.
 func TestTransformRecoverableDenyToPlaceholder(t *testing.T) {
 	reg := llmproxy.NewMemoryScopeDriftRegistry(0)
 	tu := conversation.ToolUse{
@@ -31,13 +30,7 @@ func TestTransformRecoverableDenyToPlaceholder(t *testing.T) {
 			ScopeDrifts: reg,
 		},
 	}
-	got, registered := transformRecoverableDenyToPlaceholder(context.Background(), original, tu, cfg)
-	if registered == nil {
-		t.Fatal("expected registered key from transform so rollback can revert on failure")
-	}
-	if registered.AgentID != cfg.AgentContext.AgentID || registered.ToolUseID != tu.ID {
-		t.Fatalf("registered key mismatch: %+v", *registered)
-	}
+	got := transformRecoverableDenyToPlaceholder(original, tu, cfg)
 	if got.RecoverableReason != "" {
 		t.Fatalf("expected RecoverableReason cleared after migration, got %q", got.RecoverableReason)
 	}
@@ -61,25 +54,27 @@ func TestTransformRecoverableDenyToPlaceholder(t *testing.T) {
 		t.Fatalf("placeholder input missing command: %+v", got.SubstituteWithToolCall.Input)
 	}
 
-	// Pending substitution is keyed on (agent, conversation, tool_use_id);
-	// carries the reason as MenuText and the original tool shape for
-	// later restoration.
-	subst, ok := reg.LookupPendingSubstitution(context.Background(), llmproxy.PendingSubstitutionKey{
+	// Spec is attached to the verdict; the transform is pure. The
+	// registry must NOT have been touched yet — that happens later in
+	// commitSubstitutions.
+	if got.PendingSubstitution == nil {
+		t.Fatal("expected verdict.PendingSubstitution populated as the postproc registration spec")
+	}
+	if got.PendingSubstitution.MenuText != "the inspector could not parse the request body" {
+		t.Fatalf("spec MenuText = %q; want the reason", got.PendingSubstitution.MenuText)
+	}
+	if got.PendingSubstitution.OriginalToolName != tu.Name {
+		t.Fatalf("spec OriginalToolName = %q; want %q", got.PendingSubstitution.OriginalToolName, tu.Name)
+	}
+	if string(got.PendingSubstitution.OriginalToolInput) != string(tu.Input) {
+		t.Fatalf("spec OriginalToolInput mismatch:\n got: %s\nwant: %s", string(got.PendingSubstitution.OriginalToolInput), string(tu.Input))
+	}
+	if _, ok := reg.LookupPendingSubstitution(context.Background(), llmproxy.PendingSubstitutionKey{
 		AgentID:        cfg.AgentContext.AgentID,
 		ConversationID: cfg.AuditContext.ConversationID,
 		ToolUseID:      tu.ID,
-	})
-	if !ok {
-		t.Fatal("expected pending substitution registered for recoverable-deny tool_use")
-	}
-	if subst.MenuText != "the inspector could not parse the request body" {
-		t.Fatalf("substitution menu text = %q; want the reason", subst.MenuText)
-	}
-	if subst.OriginalToolName != tu.Name {
-		t.Fatalf("substitution original tool name = %q; want %q", subst.OriginalToolName, tu.Name)
-	}
-	if string(subst.OriginalToolInput) != string(tu.Input) {
-		t.Fatalf("substitution original tool input mismatch:\n got: %s\nwant: %s", string(subst.OriginalToolInput), string(tu.Input))
+	}); ok {
+		t.Fatal("transform must NOT write the registry; commitSubstitutions owns that side-effect")
 	}
 }
 
@@ -100,9 +95,9 @@ func TestTransformRecoverableDenyToPlaceholderLeavesNonRecoverableAlone(t *testi
 		AuditContext:         llmproxy.AuditContext{ConversationID: "conv-auto-1"},
 		AuthorizationContext: llmproxy.AuthorizationContext{ScopeDrifts: reg},
 	}
-	got, registered := transformRecoverableDenyToPlaceholder(context.Background(), verdict, tu, cfg)
-	if registered != nil {
-		t.Fatalf("non-recoverable verdict must NOT register a substitution; got key %+v", *registered)
+	got := transformRecoverableDenyToPlaceholder(verdict, tu, cfg)
+	if got.PendingSubstitution != nil {
+		t.Fatalf("non-recoverable verdict must NOT attach a spec; got %+v", *got.PendingSubstitution)
 	}
 	if got.SubstituteWithToolCall != nil {
 		t.Fatal("non-recoverable verdict must NOT get a placeholder")
@@ -112,45 +107,7 @@ func TestTransformRecoverableDenyToPlaceholderLeavesNonRecoverableAlone(t *testi
 		ConversationID: cfg.AuditContext.ConversationID,
 		ToolUseID:      tu.ID,
 	}); ok {
-		t.Fatal("non-recoverable verdict must NOT register a pending substitution")
-	}
-}
-
-// TestDetectScopeDriftSubstitutionTracksScopeDriftMint locks the
-// centralized rollback: when an inner evaluator (e.g., scope-drift
-// mint in pipelineeval/scope_drift.go) registers a substitution
-// during innerEval and returns a verdict with SubstituteWithToolCall,
-// the postproc eval wrapper's detector picks it up so session
-// rollback covers both recoverable-deny and scope-drift writes.
-func TestDetectScopeDriftSubstitutionTracksScopeDriftMint(t *testing.T) {
-	reg := llmproxy.NewMemoryScopeDriftRegistry(0)
-	tu := conversation.ToolUse{ID: "tu-scope-drift", Name: "Bash", Input: json.RawMessage(`{"command":":"}`)}
-	cfg := llmproxy.PostprocessConfig{
-		AgentContext:         llmproxy.AgentContext{AgentID: "agent-x", AgentUserID: "user-x"},
-		AuditContext:         llmproxy.AuditContext{ConversationID: "conv-x"},
-		AuthorizationContext: llmproxy.AuthorizationContext{ScopeDrifts: reg},
-	}
-
-	// Simulate the scope-drift mint write happening inside innerEval.
-	mintKey := llmproxy.PendingSubstitutionKey{
-		AgentID: cfg.AgentContext.AgentID, ConversationID: cfg.AuditContext.ConversationID, ToolUseID: tu.ID,
-	}
-	if err := reg.RegisterPendingSubstitution(context.Background(), mintKey, llmproxy.PendingSubstitution{
-		MenuText: "scope-drift menu", OriginalToolName: "Write", OriginalToolInput: []byte(`{}`),
-	}); err != nil {
-		t.Fatalf("RegisterPendingSubstitution: %v", err)
-	}
-	verdict := conversation.ToolUseVerdict{
-		Outcome:                conversation.OutcomeDeny,
-		SubstituteWithToolCall: &conversation.SyntheticToolCall{ID: tu.ID, Name: "Bash", Input: map[string]any{"command": ":"}},
-		SuppressSubstituteText: true,
-	}
-	key := detectScopeDriftSubstitution(context.Background(), verdict, tu, cfg)
-	if key == nil {
-		t.Fatal("expected detectScopeDriftSubstitution to return the mint's key")
-	}
-	if *key != mintKey {
-		t.Fatalf("detected key mismatch: got %+v want %+v", *key, mintKey)
+		t.Fatal("non-recoverable verdict must NOT touch the registry")
 	}
 }
 

--- a/internal/runtime/llmproxy/postproc/session.go
+++ b/internal/runtime/llmproxy/postproc/session.go
@@ -16,11 +16,14 @@ import (
 // lifecycle details stay in one place.
 //
 // substitutions tracks pending-substitution registry writes that fired
-// during evaluation (scope-drift mints, recoverable-deny migrations).
-// rollback() iterates them so a request whose response is later
-// failClosed'd doesn't leak orphan entries. trackSubstitution is the
-// single entry point; postproc.go and stream.go call it after each
-// eval verdict commits.
+// during evaluation (scope-drift mints, recoverable-deny migrations,
+// inline-task auto-approve). rollback() iterates them so a request
+// whose response is later failClosed'd doesn't leak orphan entries.
+// commitSubstitutions is the single entry point — it walks every
+// verdict's PendingSubstitution spec and registers it, recording the
+// key for rollback. Evaluators MUST NOT call into the registry
+// themselves; the spec-on-verdict pattern keeps the verdict pure data
+// and concentrates rollback in one place.
 type postprocessSession struct {
 	baseCfg                  llmproxy.PostprocessConfig
 	evalCfg                  llmproxy.PostprocessConfig
@@ -96,15 +99,108 @@ func (s *postprocessSession) rollback(ctx context.Context, toolUses []conversati
 	s.rollbackSubstitutions(ctx)
 }
 
-// trackSubstitution records a pending-substitution registry write so
-// rollback() can revert it if the response is later failClosed'd. Nil
-// keys are ignored so callers can pass through transform results
-// directly without branching.
-func (s *postprocessSession) trackSubstitution(key *llmproxy.PendingSubstitutionKey) {
-	if s == nil || key == nil {
+// commitSubstitutions registers every verdict.PendingSubstitution
+// spec against the registry, walking decisions in turn order. Called
+// AFTER all evaluators have produced verdicts so the verdict itself
+// stays free of registry side-effects.
+//
+// On registry write failure: any TaskRollback the spec carries (today
+// only the inline-task auto-approve path populates this) is honoured
+// via the configured InlineApprovedTaskExpirer — the orphan task is
+// expired with a detached context so a mid-request client disconnect
+// doesn't cancel the rollback. Already-registered substitutions
+// recorded earlier in the walk are rolled back via the standard
+// session.rollback path so the registry doesn't end up partially
+// populated for this request. The function returns the failing error
+// so the caller (postproc / stream) can fail-closed the response.
+//
+// Recorded keys feed rollback() — if a later step in the postprocess
+// pipeline fails, every registry write made on behalf of this request
+// is undone in one place.
+func (s *postprocessSession) commitSubstitutions(ctx context.Context, verdictByTU map[string]conversation.ToolUseVerdict, toolUses []conversation.ToolUse) error {
+	if s == nil {
+		return nil
+	}
+	registry := s.baseCfg.AuthorizationContext.ScopeDrifts
+	if registry == nil {
+		return nil
+	}
+	agentID := s.baseCfg.AgentContext.AgentID
+	conversationID := s.baseCfg.AuditContext.ConversationID
+	// Walk in tool_use order (not map order) so audit and tests see a
+	// deterministic registration sequence.
+	for _, tu := range toolUses {
+		v, ok := verdictByTU[tu.ID]
+		if !ok || v.PendingSubstitution == nil {
+			continue
+		}
+		spec := v.PendingSubstitution
+		if agentID == "" || conversationID == "" {
+			// Identity tuple incomplete — the same guard the evaluators
+			// applied before populating the spec. Skip rather than mint
+			// a key that would collide across concurrent conversations.
+			continue
+		}
+		key := llmproxy.PendingSubstitutionKey{
+			AgentID:        agentID,
+			ConversationID: conversationID,
+			ToolUseID:      tu.ID,
+		}
+		err := registry.RegisterPendingSubstitution(ctx, key, llmproxy.PendingSubstitution{
+			DriftID:           spec.DriftID,
+			MenuText:          spec.MenuText,
+			OriginalToolName:  spec.OriginalToolName,
+			OriginalToolInput: append([]byte(nil), spec.OriginalToolInput...),
+		})
+		if err != nil {
+			// Roll back the task this spec was guarding, if any. The
+			// expirer interface is opt-in; legacy creator stubs that
+			// don't implement it strand the orphan, audit-traced for
+			// operators below.
+			if spec.TaskRollback != nil {
+				s.expireRollbackTask(ctx, spec.TaskRollback, err)
+			}
+			return err
+		}
+		s.substitutions = append(s.substitutions, key)
+	}
+	return nil
+}
+
+// expireRollbackTask invokes the configured InlineApprovedTaskExpirer
+// to unwind an orphan task left behind when registration failed.
+// Detached context with a short timeout protects the rollback from a
+// canceled client connection (the same condition that may have caused
+// the registry write to fail in the first place).
+func (s *postprocessSession) expireRollbackTask(ctx context.Context, handle *conversation.PendingSubstitutionTaskRollback, regErr error) {
+	creator := s.baseCfg.InlineTaskCreator
+	if creator == nil || handle == nil {
 		return
 	}
-	s.substitutions = append(s.substitutions, *key)
+	trace := llmproxy.TraceLoggerEmit(s.baseCfg.AuditContext.Trace)
+	expirer, ok := creator.(llmproxy.InlineApprovedTaskExpirer)
+	if !ok {
+		// The creator implementation predates the rollback interface;
+		// can't undo. Trace so operators can see why an orphan exists.
+		if trace != nil {
+			trace("inline_task.auto_approve_rollback_unavailable",
+				"task_id", handle.TaskID,
+				"reason", "InlineTaskCreator does not implement InlineApprovedTaskExpirer",
+			)
+		}
+		return
+	}
+	rollbackCtx, cancel := cleanupContext(ctx)
+	defer cancel()
+	if err := expirer.ExpireInlineApprovedTask(rollbackCtx, handle.TaskID, handle.UserID); err != nil {
+		if trace != nil {
+			trace("inline_task.auto_approve_rollback_failed",
+				"task_id", handle.TaskID,
+				"err", err.Error(),
+				"register_err", regErr.Error(),
+			)
+		}
+	}
 }
 
 // rollbackSubstitutions deletes every tracked registry write. Idempotent

--- a/internal/runtime/llmproxy/postproc/session.go
+++ b/internal/runtime/llmproxy/postproc/session.go
@@ -15,13 +15,16 @@ import (
 // streaming postprocess both use this shape so capture/finalize
 // lifecycle details stay in one place.
 //
-// substitutions tracks pending-substitution registry writes that fired
-// during evaluation (scope-drift mints, recoverable-deny migrations,
-// inline-task auto-approve). rollback() iterates them so a request
-// whose response is later failClosed'd doesn't leak orphan entries.
-// commitSubstitutions is the single entry point — it walks every
-// verdict's PendingSubstitution spec and registers it, recording the
-// key for rollback. Evaluators MUST NOT call into the registry
+// substitutions tracks pending-substitution registry writes that
+// fired during evaluation (scope-drift mints, recoverable-deny
+// migrations, inline-task auto-approve). driftOutcomes tracks
+// SetOutcome writes deferred via the verdict's DeferredDriftOutcome.
+// rollback() iterates both so a request whose response is later
+// failClosed'd doesn't leak orphan entries or stale pre-clears.
+// commitVerdictSideEffects is the single entry point — it walks each
+// verdict, applies the drift outcome first (so the pre-clear lands
+// before the substitution mint that depends on it) and then registers
+// the substitution. Evaluators MUST NOT call into the registry
 // themselves; the spec-on-verdict pattern keeps the verdict pure data
 // and concentrates rollback in one place.
 type postprocessSession struct {
@@ -33,6 +36,7 @@ type postprocessSession struct {
 	finalizer                *pipeline.Finalizer
 	fed                      bool
 	substitutions            []llmproxy.PendingSubstitutionKey
+	driftOutcomes            []string
 }
 
 func newPostprocessSession(cfg llmproxy.PostprocessConfig) *postprocessSession {
@@ -96,28 +100,28 @@ func (s *postprocessSession) rollback(ctx context.Context, toolUses []conversati
 		s.feed(toolUses, verdictByTU)
 		s.finalizer.Rollback(ctx)
 	}
-	s.rollbackSubstitutions(ctx)
+	s.rollbackVerdictSideEffects(ctx)
 }
 
-// commitSubstitutions registers every verdict.PendingSubstitution
-// spec against the registry, walking decisions in turn order. Called
-// AFTER all evaluators have produced verdicts so the verdict itself
-// stays free of registry side-effects.
+// commitVerdictSideEffects walks each verdict in tool_use order and
+// realizes the spec-on-verdict signals — DeferredDriftOutcome FIRST
+// (so the pre-clear mint lands before the substitution write that
+// depends on it), then PendingSubstitution. Called AFTER all
+// evaluators have produced verdicts so the verdict itself stays free
+// of registry side-effects.
 //
-// On registry write failure: any TaskRollback the spec carries (today
-// only the inline-task auto-approve path populates this) is honoured
-// via the configured InlineApprovedTaskExpirer — the orphan task is
-// expired with a detached context so a mid-request client disconnect
-// doesn't cancel the rollback. Already-registered substitutions
-// recorded earlier in the walk are rolled back via the standard
-// session.rollback path so the registry doesn't end up partially
-// populated for this request. The function returns the failing error
-// so the caller (postproc / stream) can fail-closed the response.
+// Ordering is intentional and per-verdict atomic-ish: if drift outcome
+// succeeds but substitution fails, the drift outcome is recorded in
+// session.driftOutcomes and rolls back via session.rollback when the
+// caller fail-closes. The spec's TaskRollback handle (today: only the
+// inline-task auto-approve path populates it) is honoured via the
+// configured InlineApprovedTaskExpirer with a detached context so a
+// mid-request client disconnect doesn't cancel the rollback.
 //
-// Recorded keys feed rollback() — if a later step in the postprocess
-// pipeline fails, every registry write made on behalf of this request
-// is undone in one place.
-func (s *postprocessSession) commitSubstitutions(ctx context.Context, verdictByTU map[string]conversation.ToolUseVerdict, toolUses []conversation.ToolUse) error {
+// Returns the failing error so the caller (postproc / stream) can
+// fail-closed the response — rollback() then sweeps every write made
+// on behalf of this request in one place.
+func (s *postprocessSession) commitVerdictSideEffects(ctx context.Context, verdictByTU map[string]conversation.ToolUseVerdict, toolUses []conversation.ToolUse) error {
 	if s == nil {
 		return nil
 	}
@@ -127,11 +131,28 @@ func (s *postprocessSession) commitSubstitutions(ctx context.Context, verdictByT
 	}
 	agentID := s.baseCfg.AgentContext.AgentID
 	conversationID := s.baseCfg.AuditContext.ConversationID
-	// Walk in tool_use order (not map order) so audit and tests see a
-	// deterministic registration sequence.
 	for _, tu := range toolUses {
 		v, ok := verdictByTU[tu.ID]
-		if !ok || v.PendingSubstitution == nil {
+		if !ok {
+			continue
+		}
+		if spec := v.DeferredDriftOutcome; spec != nil && spec.DriftID != "" {
+			if err := registry.SetOutcome(ctx, spec.DriftID, llmproxy.ScopeDriftOutcome(spec.Outcome)); err != nil {
+				// Roll back the claim the evaluator's guard.Claim made.
+				// guard.Success() already fired by the time we got here
+				// (the verdict was emitted), so the deferred guard.Rollback
+				// in the evaluator is a no-op. The agent's retry should
+				// mint a fresh drift; leave this one claimed-but-unresolved
+				// would block ClaimOption for the same agent indefinitely.
+				_ = registry.RollbackClaim(ctx, spec.DriftID)
+				if v.PendingSubstitution != nil && v.PendingSubstitution.TaskRollback != nil {
+					s.expireRollbackTask(ctx, v.PendingSubstitution.TaskRollback, err)
+				}
+				return err
+			}
+			s.driftOutcomes = append(s.driftOutcomes, spec.DriftID)
+		}
+		if v.PendingSubstitution == nil {
 			continue
 		}
 		spec := v.PendingSubstitution
@@ -153,13 +174,11 @@ func (s *postprocessSession) commitSubstitutions(ctx context.Context, verdictByT
 			OriginalToolInput: append([]byte(nil), spec.OriginalToolInput...),
 		})
 		if err != nil {
-			// Roll back the task this spec was guarding, if any. The
-			// expirer interface is opt-in; legacy creator stubs that
-			// don't implement it strand the orphan, audit-traced for
-			// operators below.
 			if spec.TaskRollback != nil {
 				s.expireRollbackTask(ctx, spec.TaskRollback, err)
 			}
+			// Earlier drift outcomes / substitutions stay tracked; the
+			// session.rollback the caller fires next will sweep them.
 			return err
 		}
 		s.substitutions = append(s.substitutions, key)
@@ -203,21 +222,35 @@ func (s *postprocessSession) expireRollbackTask(ctx context.Context, handle *con
 	}
 }
 
-// rollbackSubstitutions deletes every tracked registry write. Idempotent
-// — subsequent calls are no-ops because the slice is cleared.
-func (s *postprocessSession) rollbackSubstitutions(ctx context.Context) {
-	if s == nil || len(s.substitutions) == 0 {
+// rollbackVerdictSideEffects undoes every registry write the session
+// performed for this request: deferred drift outcomes (via
+// RollbackClaim, which also clears the pre-clear minted by
+// SetOutcome(Succeeded)) and pending substitutions (via
+// DeletePendingSubstitution). Idempotent — subsequent calls are
+// no-ops because both slices are cleared.
+func (s *postprocessSession) rollbackVerdictSideEffects(ctx context.Context) {
+	if s == nil {
 		return
 	}
 	registry := s.baseCfg.AuthorizationContext.ScopeDrifts
 	if registry == nil {
 		s.substitutions = nil
+		s.driftOutcomes = nil
 		return
 	}
 	for _, key := range s.substitutions {
 		registry.DeletePendingSubstitution(ctx, key)
 	}
 	s.substitutions = nil
+	for _, driftID := range s.driftOutcomes {
+		// RollbackClaim resets ChosenOption + Outcome AND deletes the
+		// pre-clear minted by SetOutcome(Succeeded). The original claim
+		// was made by the evaluator (guard.Claim) whose guard.Success()
+		// already fired by the time we got here, so the full unwind is
+		// the right shape: the agent's retry mints a fresh drift.
+		_ = registry.RollbackClaim(ctx, driftID)
+	}
+	s.driftOutcomes = nil
 }
 
 func (s *postprocessSession) dropCommitted(ctx context.Context, capture *pipeline.HoldCapture) error {

--- a/internal/runtime/llmproxy/postproc/session.go
+++ b/internal/runtime/llmproxy/postproc/session.go
@@ -220,6 +220,29 @@ func (s *postprocessSession) expireRollbackTask(ctx context.Context, handle *con
 			)
 		}
 	}
+	// The auto-approve evaluator also set the conversation's checkout
+	// to the just-expired task. Clear it conditionally — only when the
+	// stored value still names OUR task — so a concurrent flow that
+	// re-pointed the checkout after we set it isn't clobbered. Without
+	// this, subsequent turns surface a "task missing" experience: the
+	// model fetches the active task ID, gets the expired one, and asks
+	// the user to retry.
+	if checkouts := s.baseCfg.Checkouts; checkouts != nil && handle.AgentID != "" && handle.ConversationID != "" {
+		key := llmproxy.TaskCheckoutKey{
+			UserID:         handle.UserID,
+			AgentID:        handle.AgentID,
+			ConversationID: handle.ConversationID,
+		}
+		current, ok, getErr := checkouts.Get(rollbackCtx, key)
+		if getErr == nil && ok && current.TaskID == handle.TaskID {
+			if clearErr := checkouts.Clear(rollbackCtx, key); clearErr != nil && trace != nil {
+				trace("inline_task.auto_approve_rollback_checkout_clear_failed",
+					"task_id", handle.TaskID,
+					"err", clearErr.Error(),
+				)
+			}
+		}
+	}
 }
 
 // rollbackVerdictSideEffects undoes every registry write the session
@@ -263,21 +286,44 @@ func (s *postprocessSession) dropCommitted(ctx context.Context, capture *pipelin
 }
 
 func (s *postprocessSession) dropCommittedAndRollback(ctx context.Context, capture *pipeline.HoldCapture) error {
-	if s == nil || s.finalizer == nil || capture == nil {
+	if s == nil {
 		return nil
 	}
 	cleanupCtx, cancel := cleanupContext(ctx)
 	defer cancel()
-	return s.finalizer.DropCommittedAndRollback(cleanupCtx, *capture)
+	var err error
+	if s.finalizer != nil && capture != nil {
+		err = s.finalizer.DropCommittedAndRollback(cleanupCtx, *capture)
+	}
+	// The streaming write paths call this AFTER commitVerdictSideEffects
+	// has already landed substitutions / drift outcomes in the registry.
+	// Sweeping the verdict-side-effect writes here too means a partial
+	// streaming success (commit succeeded, write failed) doesn't strand
+	// the registry with substitutions for tool_uses the harness never
+	// actually saw on the wire. Runs unconditional on the session so a
+	// nil/no-capture finalizer doesn't short-circuit the verdict-side-
+	// effect sweep.
+	s.rollbackVerdictSideEffects(cleanupCtx)
+	return err
 }
 
 func (s *postprocessSession) dropAllCommittedAndRollback(ctx context.Context) error {
-	if s == nil || s.finalizer == nil {
+	if s == nil {
 		return nil
 	}
 	cleanupCtx, cancel := cleanupContext(ctx)
 	defer cancel()
-	return s.finalizer.DropAllCommittedAndRollback(cleanupCtx)
+	var err error
+	if s.finalizer != nil {
+		err = s.finalizer.DropAllCommittedAndRollback(cleanupCtx)
+	}
+	// Same rationale as dropCommittedAndRollback: any registry writes
+	// that landed during commitVerdictSideEffects must be undone when a
+	// downstream streaming write fails, or subsequent harness retries
+	// will hit stale substitution entries for tool_uses that never
+	// reached them.
+	s.rollbackVerdictSideEffects(cleanupCtx)
+	return err
 }
 
 func cleanupContext(ctx context.Context) (context.Context, context.CancelFunc) {

--- a/internal/runtime/llmproxy/postproc/session_commit_test.go
+++ b/internal/runtime/llmproxy/postproc/session_commit_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy"
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/taskcheckout"
 	runtimetasks "github.com/clawvisor/clawvisor/internal/runtime/tasks"
 	"github.com/clawvisor/clawvisor/pkg/store"
 )
@@ -326,6 +327,177 @@ func TestCommitVerdictSideEffectsRollsBackClaimOnSetOutcomeFailure(t *testing.T)
 	// And the claim is reusable.
 	if _, err := reg.ClaimOption(ctx, stored.ID, llmproxy.ScopeDriftOptionNewTask, "retry"); err != nil {
 		t.Fatalf("expected drift to be re-claimable after rollback, got: %v", err)
+	}
+}
+
+// TestCommitFailureClearsAutoApproveCheckout pins the auto-approve
+// checkout-rollback contract: when the deferred-outcome / substitution
+// commit fails, the conversation checkout the evaluator set inline
+// before returning the verdict gets cleared too. Without that sweep
+// the next turn surfaces a "task missing" experience — model fetches
+// the active task, sees the just-expired ID, asks the user to retry.
+//
+// Conditional clear: only when the stored value still names OUR task,
+// so a concurrent flow that re-pointed the checkout after we set it
+// isn't clobbered.
+func TestCommitFailureClearsAutoApproveCheckout(t *testing.T) {
+	reg := &commitFailingRegistry{inner: llmproxy.NewMemoryScopeDriftRegistry(0)}
+	checkouts := taskcheckout.NewMemoryStore(0)
+	expirer := &recordingExpirer{}
+	cfg := llmproxy.PostprocessConfig{
+		AgentContext:         llmproxy.AgentContext{AgentID: "agent-co", AgentUserID: "user-co"},
+		AuditContext:         llmproxy.AuditContext{ConversationID: "conv-co"},
+		AuthorizationContext: llmproxy.AuthorizationContext{ScopeDrifts: reg},
+		ApprovalContext:      llmproxy.ApprovalContext{InlineTaskCreator: expirer, Checkouts: checkouts},
+	}
+	s := newPostprocessSession(cfg)
+	ctx := context.Background()
+
+	// Simulate the auto-approve evaluator having set the checkout
+	// to its just-created task BEFORE returning the verdict.
+	key := taskcheckout.Key{UserID: "user-co", AgentID: "agent-co", ConversationID: "conv-co"}
+	if err := checkouts.Set(ctx, key, "task-orphan", 0); err != nil {
+		t.Fatalf("seed checkout: %v", err)
+	}
+
+	tu := conversation.ToolUse{ID: "tu-co", Name: "Bash", Input: []byte(`{"command":"x"}`)}
+	verdictByTU := map[string]conversation.ToolUseVerdict{
+		"tu-co": {
+			Outcome: conversation.OutcomeDeny,
+			PendingSubstitution: &conversation.PendingSubstitutionSpec{
+				MenuText:          "augmentation",
+				OriginalToolName:  tu.Name,
+				OriginalToolInput: tu.Input,
+				TaskRollback: &conversation.PendingSubstitutionTaskRollback{
+					TaskID:         "task-orphan",
+					UserID:         "user-co",
+					AgentID:        "agent-co",
+					ConversationID: "conv-co",
+				},
+			},
+		},
+	}
+
+	if err := s.commitVerdictSideEffects(ctx, verdictByTU, []conversation.ToolUse{tu}); err == nil {
+		t.Fatal("expected registry failure to propagate")
+	}
+	if !expirer.expireCalled {
+		t.Fatal("task expirer should fire on commit failure")
+	}
+	// Checkout still points at the orphan task without our fix; with
+	// the fix it's gone.
+	if _, ok, err := checkouts.Get(ctx, key); err != nil {
+		t.Fatalf("Get checkout: %v", err)
+	} else if ok {
+		t.Fatal("checkout pointing at orphan task should have been cleared")
+	}
+}
+
+// TestCommitFailureDoesNotClobberReassignedCheckout asserts the
+// conditional-clear contract: if a concurrent flow re-pointed the
+// checkout between Set and rollback, the rollback must leave the new
+// value alone.
+func TestCommitFailureDoesNotClobberReassignedCheckout(t *testing.T) {
+	reg := &commitFailingRegistry{inner: llmproxy.NewMemoryScopeDriftRegistry(0)}
+	checkouts := taskcheckout.NewMemoryStore(0)
+	expirer := &recordingExpirer{}
+	cfg := llmproxy.PostprocessConfig{
+		AgentContext:         llmproxy.AgentContext{AgentID: "agent-co2", AgentUserID: "user-co2"},
+		AuditContext:         llmproxy.AuditContext{ConversationID: "conv-co2"},
+		AuthorizationContext: llmproxy.AuthorizationContext{ScopeDrifts: reg},
+		ApprovalContext:      llmproxy.ApprovalContext{InlineTaskCreator: expirer, Checkouts: checkouts},
+	}
+	s := newPostprocessSession(cfg)
+	ctx := context.Background()
+
+	key := taskcheckout.Key{UserID: "user-co2", AgentID: "agent-co2", ConversationID: "conv-co2"}
+	// Concurrent flow pointed the checkout at a DIFFERENT task after
+	// our Set but before our rollback. The orphan-task expirer should
+	// still fire, but the checkout's new value must survive.
+	if err := checkouts.Set(ctx, key, "task-other-flow", 0); err != nil {
+		t.Fatalf("seed checkout: %v", err)
+	}
+
+	tu := conversation.ToolUse{ID: "tu-co2", Name: "Bash", Input: []byte(`{"command":"x"}`)}
+	verdictByTU := map[string]conversation.ToolUseVerdict{
+		"tu-co2": {
+			Outcome: conversation.OutcomeDeny,
+			PendingSubstitution: &conversation.PendingSubstitutionSpec{
+				MenuText:          "augmentation",
+				OriginalToolName:  tu.Name,
+				OriginalToolInput: tu.Input,
+				TaskRollback: &conversation.PendingSubstitutionTaskRollback{
+					TaskID:         "task-orphan",
+					UserID:         "user-co2",
+					AgentID:        "agent-co2",
+					ConversationID: "conv-co2",
+				},
+			},
+		},
+	}
+
+	_ = s.commitVerdictSideEffects(ctx, verdictByTU, []conversation.ToolUse{tu})
+
+	current, ok, err := checkouts.Get(ctx, key)
+	if err != nil {
+		t.Fatalf("Get checkout: %v", err)
+	}
+	if !ok || current.TaskID != "task-other-flow" {
+		t.Fatalf("checkout reassigned by concurrent flow should survive rollback; got ok=%v task=%q", ok, current.TaskID)
+	}
+}
+
+// TestSessionDropAndRollbackSweepsVerdictSideEffects pins the
+// streaming-path rollback contract: the helpers that the streaming
+// write paths call on a write failure (dropCommittedAndRollback,
+// dropAllCommittedAndRollback) MUST also undo registry writes
+// commitVerdictSideEffects landed earlier. Without this, a streaming
+// commit-then-write-fail leaves stale substitutions / drift outcomes
+// the harness retry would hit.
+func TestSessionDropAndRollbackSweepsVerdictSideEffects(t *testing.T) {
+	reg := llmproxy.NewMemoryScopeDriftRegistry(0)
+	ctx := context.Background()
+	cfg := llmproxy.PostprocessConfig{
+		AgentContext:         llmproxy.AgentContext{AgentID: "agent-stream", AgentUserID: "user-stream"},
+		AuditContext:         llmproxy.AuditContext{ConversationID: "conv-stream"},
+		AuthorizationContext: llmproxy.AuthorizationContext{ScopeDrifts: reg},
+	}
+	s := newPostprocessSession(cfg)
+
+	// Pretend commit landed two substitutions and one drift outcome.
+	stored, err := reg.Register(ctx, llmproxy.ScopeDrift{
+		UserID: "user-stream", AgentID: "agent-stream", ConversationID: "conv-stream",
+		ToolUse: conversation.ToolUse{ID: "tu-1"}, Source: llmproxy.ScopeDriftSourceTaskScope,
+	})
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if _, err := reg.ClaimOption(ctx, stored.ID, llmproxy.ScopeDriftOptionNewTask, ""); err != nil {
+		t.Fatalf("ClaimOption: %v", err)
+	}
+	if err := reg.SetOutcome(ctx, stored.ID, llmproxy.ScopeDriftOutcomeSucceeded); err != nil {
+		t.Fatalf("SetOutcome: %v", err)
+	}
+	key := llmproxy.PendingSubstitutionKey{
+		AgentID: "agent-stream", ConversationID: "conv-stream", ToolUseID: "tu-1",
+	}
+	if err := reg.RegisterPendingSubstitution(ctx, key, llmproxy.PendingSubstitution{
+		MenuText: "menu", OriginalToolName: "Bash", OriginalToolInput: []byte(`{}`),
+	}); err != nil {
+		t.Fatalf("RegisterPendingSubstitution: %v", err)
+	}
+	s.substitutions = []llmproxy.PendingSubstitutionKey{key}
+	s.driftOutcomes = []string{stored.ID}
+
+	if err := s.dropAllCommittedAndRollback(ctx); err != nil {
+		t.Fatalf("dropAllCommittedAndRollback: %v", err)
+	}
+
+	if _, ok := reg.LookupPendingSubstitution(ctx, key); ok {
+		t.Fatal("dropAllCommittedAndRollback must sweep verdict side effects: substitution still present")
+	}
+	if _, hit := reg.LookupPreClear(ctx, "agent-stream", stored.Fingerprint()); hit {
+		t.Fatal("dropAllCommittedAndRollback must sweep drift outcomes: pre-clear still present")
 	}
 }
 

--- a/internal/runtime/llmproxy/postproc/session_commit_test.go
+++ b/internal/runtime/llmproxy/postproc/session_commit_test.go
@@ -52,8 +52,8 @@ func TestCommitSubstitutionsRegistersSpecsInToolUseOrder(t *testing.T) {
 		},
 	}
 
-	if err := s.commitSubstitutions(context.Background(), verdictByTU, toolUses); err != nil {
-		t.Fatalf("commitSubstitutions: %v", err)
+	if err := s.commitVerdictSideEffects(context.Background(), verdictByTU, toolUses); err != nil {
+		t.Fatalf("commitVerdictSideEffects: %v", err)
 	}
 
 	for _, tu := range toolUses {
@@ -81,7 +81,7 @@ func TestCommitSubstitutionsRegistersSpecsInToolUseOrder(t *testing.T) {
 	}
 
 	// Round-trip: rollback deletes both.
-	s.rollbackSubstitutions(context.Background())
+	s.rollbackVerdictSideEffects(context.Background())
 	for _, tu := range toolUses {
 		if _, ok := reg.LookupPendingSubstitution(context.Background(), llmproxy.PendingSubstitutionKey{
 			AgentID:        cfg.AgentContext.AgentID,
@@ -127,7 +127,7 @@ func TestCommitSubstitutionsExpiresTaskOnRegistrationFailure(t *testing.T) {
 		},
 	}
 
-	err := s.commitSubstitutions(context.Background(), verdictByTU, []conversation.ToolUse{tu})
+	err := s.commitVerdictSideEffects(context.Background(), verdictByTU, []conversation.ToolUse{tu})
 	if err == nil {
 		t.Fatal("expected error propagated to caller for failClosed")
 	}
@@ -144,6 +144,197 @@ func TestCommitSubstitutionsExpiresTaskOnRegistrationFailure(t *testing.T) {
 	if len(s.substitutions) != 0 {
 		t.Fatalf("expected no tracked keys on failure (rollback already handled), got %d", len(s.substitutions))
 	}
+}
+
+// TestCommitVerdictSideEffectsAppliesDriftOutcomeBeforeSubstitution
+// pins the per-verdict ordering: SetOutcome(Succeeded) lands before
+// RegisterPendingSubstitution so the pre-clear is in place for any
+// LookupPreClear that follows during the same request flow. Also
+// verifies rollback unwinds both: drift outcome (via RollbackClaim,
+// which deletes the pre-clear) AND the substitution.
+func TestCommitVerdictSideEffectsAppliesDriftOutcomeBeforeSubstitution(t *testing.T) {
+	reg := llmproxy.NewMemoryScopeDriftRegistry(0)
+	ctx := context.Background()
+	// Seed a claimed drift so SetOutcome has a real target. The
+	// fingerprint feeds LookupPreClear after commit.
+	tu := conversation.ToolUse{ID: "tu-defer", Name: "Bash", Input: []byte(`{"command":"x"}`)}
+	stored, err := reg.Register(ctx, llmproxy.ScopeDrift{
+		UserID:         "user-defer",
+		AgentID:        "agent-defer",
+		ConversationID: "conv-defer",
+		ToolUse:        tu,
+		Source:         llmproxy.ScopeDriftSourceTaskScope,
+	})
+	if err != nil {
+		t.Fatalf("Register drift: %v", err)
+	}
+	if _, err := reg.ClaimOption(ctx, stored.ID, llmproxy.ScopeDriftOptionNewTask, ""); err != nil {
+		t.Fatalf("ClaimOption: %v", err)
+	}
+
+	cfg := llmproxy.PostprocessConfig{
+		AgentContext:         llmproxy.AgentContext{AgentID: "agent-defer", AgentUserID: "user-defer"},
+		AuditContext:         llmproxy.AuditContext{ConversationID: "conv-defer"},
+		AuthorizationContext: llmproxy.AuthorizationContext{ScopeDrifts: reg},
+	}
+	s := newPostprocessSession(cfg)
+
+	verdictByTU := map[string]conversation.ToolUseVerdict{
+		"tu-defer": {
+			Outcome: conversation.OutcomeDeny,
+			DeferredDriftOutcome: &conversation.DeferredDriftOutcomeSpec{
+				DriftID: stored.ID,
+				Outcome: string(llmproxy.ScopeDriftOutcomeSucceeded),
+			},
+			PendingSubstitution: &conversation.PendingSubstitutionSpec{
+				DriftID:           stored.ID,
+				MenuText:          "augmentation",
+				OriginalToolName:  tu.Name,
+				OriginalToolInput: tu.Input,
+			},
+		},
+	}
+
+	if err := s.commitVerdictSideEffects(ctx, verdictByTU, []conversation.ToolUse{tu}); err != nil {
+		t.Fatalf("commitVerdictSideEffects: %v", err)
+	}
+
+	// Drift outcome landed → pre-clear minted, LookupPreClear hits.
+	driftID, hit := reg.LookupPreClear(ctx, "agent-defer", stored.Fingerprint())
+	if !hit || driftID != stored.ID {
+		t.Fatalf("LookupPreClear after commit: ok=%v id=%q want id=%q", hit, driftID, stored.ID)
+	}
+
+	// Substitution landed too.
+	if _, ok := reg.LookupPendingSubstitution(ctx, llmproxy.PendingSubstitutionKey{
+		AgentID:        "agent-defer",
+		ConversationID: "conv-defer",
+		ToolUseID:      "tu-defer",
+	}); !ok {
+		t.Fatal("expected substitution registered")
+	}
+
+	// Rollback wipes both: substitution gone, and the drift outcome's
+	// pre-clear is gone too (RollbackClaim resets + deletes pre-clear).
+	// LookupPreClear above already consumed the entry; mint another by
+	// re-running SetOutcome and confirming rollback removes it.
+	if err := reg.SetOutcome(ctx, stored.ID, llmproxy.ScopeDriftOutcomeSucceeded); err != nil {
+		t.Fatalf("re-SetOutcome: %v", err)
+	}
+	s.driftOutcomes = []string{stored.ID}
+	s.substitutions = []llmproxy.PendingSubstitutionKey{{
+		AgentID: "agent-defer", ConversationID: "conv-defer", ToolUseID: "tu-defer",
+	}}
+	// Re-register the substitution so rollback has something to delete.
+	_ = reg.RegisterPendingSubstitution(ctx, s.substitutions[0], llmproxy.PendingSubstitution{
+		MenuText: "augmentation", OriginalToolName: tu.Name, OriginalToolInput: tu.Input,
+	})
+
+	s.rollbackVerdictSideEffects(ctx)
+
+	if _, hit := reg.LookupPreClear(ctx, "agent-defer", stored.Fingerprint()); hit {
+		t.Fatal("rollback should have deleted the pre-clear via RollbackClaim")
+	}
+	if _, ok := reg.LookupPendingSubstitution(ctx, llmproxy.PendingSubstitutionKey{
+		AgentID: "agent-defer", ConversationID: "conv-defer", ToolUseID: "tu-defer",
+	}); ok {
+		t.Fatal("rollback should have deleted the substitution")
+	}
+}
+
+// TestCommitVerdictSideEffectsRollsBackClaimOnSetOutcomeFailure
+// covers the auto-approve recovery contract: if the evaluator
+// emitted DeferredDriftOutcome + PendingSubstitution but the
+// SetOutcome write fails, the drift claim is rolled back (so the
+// agent's retry mints fresh instead of seeing a claimed-but-
+// unresolved drift) AND the orphan task is expired via the spec's
+// TaskRollback.
+//
+// This test moved from internal/runtime/llmproxy/scope_drift_e2e_test.go
+// after Gap-1: the SetOutcome side-effect lives in postproc now, so
+// the rollback test belongs alongside the layer that owns the behavior.
+func TestCommitVerdictSideEffectsRollsBackClaimOnSetOutcomeFailure(t *testing.T) {
+	innerReg := llmproxy.NewMemoryScopeDriftRegistry(0)
+	reg := &failingSetOutcomeRegistry{ScopeDriftRegistry: innerReg}
+	ctx := context.Background()
+
+	// Seed a claimed (Pending) drift, mimicking the state guard.Claim
+	// leaves the registry in after the evaluator returns its verdict.
+	tu := conversation.ToolUse{ID: "tu-setout", Name: "Bash", Input: []byte(`{"command":"x"}`)}
+	stored, err := reg.Register(ctx, llmproxy.ScopeDrift{
+		UserID:         "user-rb",
+		AgentID:        "agent-rb",
+		ConversationID: "conv-rb",
+		ToolUse:        tu,
+		Source:         llmproxy.ScopeDriftSourceTaskScope,
+	})
+	if err != nil {
+		t.Fatalf("Register drift: %v", err)
+	}
+	if _, err := reg.ClaimOption(ctx, stored.ID, llmproxy.ScopeDriftOptionNewTask, ""); err != nil {
+		t.Fatalf("ClaimOption: %v", err)
+	}
+
+	expirer := &recordingExpirer{}
+	cfg := llmproxy.PostprocessConfig{
+		AgentContext:         llmproxy.AgentContext{AgentID: "agent-rb", AgentUserID: "user-rb"},
+		AuditContext:         llmproxy.AuditContext{ConversationID: "conv-rb"},
+		AuthorizationContext: llmproxy.AuthorizationContext{ScopeDrifts: reg},
+		ApprovalContext:      llmproxy.ApprovalContext{InlineTaskCreator: expirer},
+	}
+	s := newPostprocessSession(cfg)
+
+	verdictByTU := map[string]conversation.ToolUseVerdict{
+		"tu-setout": {
+			Outcome: conversation.OutcomeDeny,
+			DeferredDriftOutcome: &conversation.DeferredDriftOutcomeSpec{
+				DriftID: stored.ID,
+				Outcome: string(llmproxy.ScopeDriftOutcomeSucceeded),
+			},
+			PendingSubstitution: &conversation.PendingSubstitutionSpec{
+				DriftID:           stored.ID,
+				MenuText:          "augmentation",
+				OriginalToolName:  tu.Name,
+				OriginalToolInput: tu.Input,
+				TaskRollback: &conversation.PendingSubstitutionTaskRollback{
+					TaskID: "task-orphan",
+					UserID: "user-rb",
+				},
+			},
+		},
+	}
+
+	if err := s.commitVerdictSideEffects(ctx, verdictByTU, []conversation.ToolUse{tu}); err == nil {
+		t.Fatal("expected SetOutcome failure to propagate so the caller fail-closes")
+	}
+	if !expirer.expireCalled {
+		t.Fatal("expected TaskRollback expirer to fire on SetOutcome failure")
+	}
+
+	// Claim must have been rolled back so the agent's retry can mint
+	// fresh. RollbackClaim resets ChosenOption and Outcome to empty.
+	rolled, err := reg.Get(ctx, stored.ID)
+	if err != nil {
+		t.Fatalf("Get drift: %v", err)
+	}
+	if rolled.ChosenOption != "" {
+		t.Fatalf("drift ChosenOption = %q, want empty after rollback", rolled.ChosenOption)
+	}
+	if rolled.Outcome != "" {
+		t.Fatalf("drift Outcome = %q, want empty after rollback", rolled.Outcome)
+	}
+	// And the claim is reusable.
+	if _, err := reg.ClaimOption(ctx, stored.ID, llmproxy.ScopeDriftOptionNewTask, "retry"); err != nil {
+		t.Fatalf("expected drift to be re-claimable after rollback, got: %v", err)
+	}
+}
+
+type failingSetOutcomeRegistry struct {
+	llmproxy.ScopeDriftRegistry
+}
+
+func (r *failingSetOutcomeRegistry) SetOutcome(ctx context.Context, driftID string, outcome llmproxy.ScopeDriftOutcome) error {
+	return errCommitForcedFailure
 }
 
 var errCommitForcedFailure = errors.New("forced registry failure")

--- a/internal/runtime/llmproxy/postproc/session_commit_test.go
+++ b/internal/runtime/llmproxy/postproc/session_commit_test.go
@@ -1,0 +1,206 @@
+package postproc
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy"
+	runtimetasks "github.com/clawvisor/clawvisor/internal/runtime/tasks"
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+// TestCommitSubstitutionsRegistersSpecsInToolUseOrder pins the
+// spec-on-verdict invariant: evaluators MUST attach a
+// PendingSubstitutionSpec to the verdict and MUST NOT touch the
+// registry themselves; commitSubstitutions is the single point that
+// translates specs into registry writes, walking decisions in
+// tool_use order so the audit + rollback layers see a deterministic
+// sequence.
+func TestCommitSubstitutionsRegistersSpecsInToolUseOrder(t *testing.T) {
+	reg := llmproxy.NewMemoryScopeDriftRegistry(0)
+	cfg := llmproxy.PostprocessConfig{
+		AgentContext:         llmproxy.AgentContext{AgentID: "agent-commit", AgentUserID: "user-commit"},
+		AuditContext:         llmproxy.AuditContext{ConversationID: "conv-commit"},
+		AuthorizationContext: llmproxy.AuthorizationContext{ScopeDrifts: reg},
+	}
+	s := newPostprocessSession(cfg)
+
+	toolUses := []conversation.ToolUse{
+		{ID: "tu-1", Name: "Bash", Input: []byte(`{"command":"a"}`)},
+		{ID: "tu-2", Name: "Bash", Input: []byte(`{"command":"b"}`)},
+	}
+	verdictByTU := map[string]conversation.ToolUseVerdict{
+		"tu-1": {
+			Outcome: conversation.OutcomeDeny,
+			PendingSubstitution: &conversation.PendingSubstitutionSpec{
+				DriftID:           "drift-1",
+				MenuText:          "first menu",
+				OriginalToolName:  "Write",
+				OriginalToolInput: []byte(`{"path":"a"}`),
+			},
+		},
+		"tu-2": {
+			Outcome: conversation.OutcomeDeny,
+			PendingSubstitution: &conversation.PendingSubstitutionSpec{
+				DriftID:           "drift-2",
+				MenuText:          "second menu",
+				OriginalToolName:  "Edit",
+				OriginalToolInput: []byte(`{"path":"b"}`),
+			},
+		},
+	}
+
+	if err := s.commitSubstitutions(context.Background(), verdictByTU, toolUses); err != nil {
+		t.Fatalf("commitSubstitutions: %v", err)
+	}
+
+	for _, tu := range toolUses {
+		got, ok := reg.LookupPendingSubstitution(context.Background(), llmproxy.PendingSubstitutionKey{
+			AgentID:        cfg.AgentContext.AgentID,
+			ConversationID: cfg.AuditContext.ConversationID,
+			ToolUseID:      tu.ID,
+		})
+		if !ok {
+			t.Fatalf("expected substitution registered for %s", tu.ID)
+		}
+		wantText := "first menu"
+		if tu.ID == "tu-2" {
+			wantText = "second menu"
+		}
+		if got.MenuText != wantText {
+			t.Fatalf("%s MenuText = %q; want %q", tu.ID, got.MenuText, wantText)
+		}
+	}
+
+	// The session's tracked keys feed rollback. Confirm both keys
+	// landed so a later failClosed sweeps everything.
+	if len(s.substitutions) != 2 {
+		t.Fatalf("expected 2 tracked keys, got %d", len(s.substitutions))
+	}
+
+	// Round-trip: rollback deletes both.
+	s.rollbackSubstitutions(context.Background())
+	for _, tu := range toolUses {
+		if _, ok := reg.LookupPendingSubstitution(context.Background(), llmproxy.PendingSubstitutionKey{
+			AgentID:        cfg.AgentContext.AgentID,
+			ConversationID: cfg.AuditContext.ConversationID,
+			ToolUseID:      tu.ID,
+		}); ok {
+			t.Fatalf("rollback left %s registered", tu.ID)
+		}
+	}
+}
+
+// TestCommitSubstitutionsExpiresTaskOnRegistrationFailure asserts the
+// post-create rollback contract the auto-approve path relies on: when
+// the registry write fails AFTER an inline task was already created,
+// commitSubstitutions invokes ExpireInlineApprovedTask via the
+// configured InlineApprovedTaskExpirer so the dashboard doesn't
+// strand an orphan, and propagates the registry error so the caller
+// can fail-closed the response.
+func TestCommitSubstitutionsExpiresTaskOnRegistrationFailure(t *testing.T) {
+	reg := &commitFailingRegistry{inner: llmproxy.NewMemoryScopeDriftRegistry(0)}
+	expirer := &recordingExpirer{}
+	cfg := llmproxy.PostprocessConfig{
+		AgentContext:         llmproxy.AgentContext{AgentID: "agent-cmt", AgentUserID: "user-cmt"},
+		AuditContext:         llmproxy.AuditContext{ConversationID: "conv-cmt"},
+		AuthorizationContext: llmproxy.AuthorizationContext{ScopeDrifts: reg},
+		ApprovalContext:      llmproxy.ApprovalContext{InlineTaskCreator: expirer},
+	}
+	s := newPostprocessSession(cfg)
+
+	tu := conversation.ToolUse{ID: "tu-fail", Name: "Bash", Input: []byte(`{"command":"x"}`)}
+	verdictByTU := map[string]conversation.ToolUseVerdict{
+		"tu-fail": {
+			Outcome: conversation.OutcomeDeny,
+			PendingSubstitution: &conversation.PendingSubstitutionSpec{
+				MenuText:          "augmentation",
+				OriginalToolName:  tu.Name,
+				OriginalToolInput: tu.Input,
+				TaskRollback: &conversation.PendingSubstitutionTaskRollback{
+					TaskID: "task-orphan",
+					UserID: "user-cmt",
+				},
+			},
+		},
+	}
+
+	err := s.commitSubstitutions(context.Background(), verdictByTU, []conversation.ToolUse{tu})
+	if err == nil {
+		t.Fatal("expected error propagated to caller for failClosed")
+	}
+	if !errors.Is(err, errCommitForcedFailure) {
+		t.Fatalf("expected wrapped registry error, got %v", err)
+	}
+	if !expirer.expireCalled {
+		t.Fatal("expected InlineApprovedTaskExpirer.ExpireInlineApprovedTask to fire after registry failure")
+	}
+	if expirer.expiredTaskID != "task-orphan" || expirer.expiredUserID != "user-cmt" {
+		t.Fatalf("expirer called with wrong identity: task=%q user=%q",
+			expirer.expiredTaskID, expirer.expiredUserID)
+	}
+	if len(s.substitutions) != 0 {
+		t.Fatalf("expected no tracked keys on failure (rollback already handled), got %d", len(s.substitutions))
+	}
+}
+
+var errCommitForcedFailure = errors.New("forced registry failure")
+
+type commitFailingRegistry struct {
+	inner llmproxy.ScopeDriftRegistry
+}
+
+func (r *commitFailingRegistry) Register(ctx context.Context, drift llmproxy.ScopeDrift) (llmproxy.ScopeDrift, error) {
+	return r.inner.Register(ctx, drift)
+}
+
+func (r *commitFailingRegistry) Get(ctx context.Context, driftID string) (llmproxy.ScopeDrift, error) {
+	return r.inner.Get(ctx, driftID)
+}
+
+func (r *commitFailingRegistry) ClaimOption(ctx context.Context, driftID string, option llmproxy.ScopeDriftOption, agentNote string) (llmproxy.ScopeDrift, error) {
+	return r.inner.ClaimOption(ctx, driftID, option, agentNote)
+}
+
+func (r *commitFailingRegistry) RollbackClaim(ctx context.Context, driftID string) error {
+	return r.inner.RollbackClaim(ctx, driftID)
+}
+
+func (r *commitFailingRegistry) SetOutcome(ctx context.Context, driftID string, outcome llmproxy.ScopeDriftOutcome) error {
+	return r.inner.SetOutcome(ctx, driftID, outcome)
+}
+
+func (r *commitFailingRegistry) LookupPreClear(ctx context.Context, agentID, fingerprint string) (string, bool) {
+	return r.inner.LookupPreClear(ctx, agentID, fingerprint)
+}
+
+func (r *commitFailingRegistry) RegisterPendingSubstitution(ctx context.Context, key llmproxy.PendingSubstitutionKey, value llmproxy.PendingSubstitution) error {
+	return errCommitForcedFailure
+}
+
+func (r *commitFailingRegistry) LookupPendingSubstitution(ctx context.Context, key llmproxy.PendingSubstitutionKey) (llmproxy.PendingSubstitution, bool) {
+	return r.inner.LookupPendingSubstitution(ctx, key)
+}
+
+func (r *commitFailingRegistry) DeletePendingSubstitution(ctx context.Context, key llmproxy.PendingSubstitutionKey) {
+	r.inner.DeletePendingSubstitution(ctx, key)
+}
+
+type recordingExpirer struct {
+	expireCalled  bool
+	expiredTaskID string
+	expiredUserID string
+}
+
+func (r *recordingExpirer) CreateInlineApprovedTask(_ context.Context, _ *store.Agent, _ *runtimetasks.TaskCreateRequest, _ string) (*llmproxy.InlineApprovedTask, error) {
+	return nil, errors.New("not used in this test")
+}
+
+func (r *recordingExpirer) ExpireInlineApprovedTask(_ context.Context, taskID, userID string) error {
+	r.expireCalled = true
+	r.expiredTaskID = taskID
+	r.expiredUserID = userID
+	return nil
+}

--- a/internal/runtime/llmproxy/postproc/stream.go
+++ b/internal/runtime/llmproxy/postproc/stream.go
@@ -125,7 +125,7 @@ func PostprocessStream(
 		}
 	}
 
-	if commitErr := session.commitSubstitutions(req.Context(), verdictByTU, toolUses); commitErr != nil {
+	if commitErr := session.commitVerdictSideEffects(req.Context(), verdictByTU, toolUses); commitErr != nil {
 		session.rollback(req.Context(), toolUses, verdictByTU)
 		return llmproxy.PostprocessResult{
 			SkippedReason: commitErr.Error(),

--- a/internal/runtime/llmproxy/postproc/stream.go
+++ b/internal/runtime/llmproxy/postproc/stream.go
@@ -99,9 +99,7 @@ func PostprocessStream(
 	verdictByTU := make(map[string]conversation.ToolUseVerdict, len(toolUses))
 	eval := func(tu conversation.ToolUse) conversation.ToolUseVerdict {
 		v := innerEval(tu)
-		v, registered := transformRecoverableDenyToPlaceholder(req.Context(), v, tu, cfg)
-		session.trackSubstitution(registered)
-		session.trackSubstitution(detectScopeDriftSubstitution(req.Context(), v, tu, cfg))
+		v = transformRecoverableDenyToPlaceholder(v, tu, cfg)
 		verdictByTU[tu.ID] = v
 		return v
 	}
@@ -127,6 +125,12 @@ func PostprocessStream(
 		}
 	}
 
+	if commitErr := session.commitSubstitutions(req.Context(), verdictByTU, toolUses); commitErr != nil {
+		session.rollback(req.Context(), toolUses, verdictByTU)
+		return llmproxy.PostprocessResult{
+			SkippedReason: commitErr.Error(),
+		}, commitErr
+	}
 	finalResult, finalErr := session.finalize(req.Context(), toolUses, verdictByTU)
 	if finalErr != nil {
 		session.rollback(req.Context(), toolUses, verdictByTU)

--- a/internal/runtime/llmproxy/scope_drift_e2e_test.go
+++ b/internal/runtime/llmproxy/scope_drift_e2e_test.go
@@ -1333,9 +1333,12 @@ func TestScopeDriftE2E_NewTaskPendingCreatorFailureClosesDrift(t *testing.T) {
 	}
 }
 
-// TestScopeDriftE2E_NewTaskAutoApproveResolvesDriftSucceeded verifies that if a task is
-// auto-approved, the drift is successfully resolved immediately without human prompting.
-func TestScopeDriftE2E_NewTaskAutoApproveResolvesDriftSucceeded(t *testing.T) {
+// TestScopeDriftE2E_NewTaskAutoApproveDefersDriftOutcome verifies that
+// when a task is auto-approved the evaluator emits a verdict carrying
+// the DeferredDriftOutcome spec (postprocess realizes the SetOutcome
+// at commit time) and does NOT write the registry itself — that's the
+// verdict-purity invariant.
+func TestScopeDriftE2E_NewTaskAutoApproveDefersDriftOutcome(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	reg := NewMemoryScopeDriftRegistry(0)
@@ -1399,13 +1402,26 @@ func TestScopeDriftE2E_NewTaskAutoApproveResolvesDriftSucceeded(t *testing.T) {
 		t.Fatal("expected auto-approve verdict to set SubstituteWith with the [Clawvisor] notice")
 	}
 
-	// Verify that the drift outcome was marked as Succeeded.
+	// The verdict carries the DeferredDriftOutcome spec; the registry
+	// must NOT have been touched by the evaluator (verdict purity).
+	if verdict.DeferredDriftOutcome == nil {
+		t.Fatal("expected auto-approve verdict to carry DeferredDriftOutcome so postprocess commits SetOutcome")
+	}
+	if verdict.DeferredDriftOutcome.DriftID != drift.ID {
+		t.Fatalf("DeferredDriftOutcome.DriftID = %q, want %q", verdict.DeferredDriftOutcome.DriftID, drift.ID)
+	}
+	if verdict.DeferredDriftOutcome.Outcome != string(ScopeDriftOutcomeSucceeded) {
+		t.Fatalf("DeferredDriftOutcome.Outcome = %q, want %q", verdict.DeferredDriftOutcome.Outcome, ScopeDriftOutcomeSucceeded)
+	}
 	stored, err := reg.Get(ctx, drift.ID)
 	if err != nil {
 		t.Fatalf("get drift: %v", err)
 	}
-	if stored.Outcome != ScopeDriftOutcomeSucceeded {
-		t.Fatalf("drift Outcome = %q, want %q", stored.Outcome, ScopeDriftOutcomeSucceeded)
+	if stored.Outcome == ScopeDriftOutcomeSucceeded {
+		t.Fatalf("evaluator must NOT call SetOutcome — the verdict defers it. Outcome=%q", stored.Outcome)
+	}
+	if stored.Outcome != ScopeDriftOutcomePending {
+		t.Fatalf("drift Outcome = %q, want %q (claim was made by guard.Claim, outcome is deferred)", stored.Outcome, ScopeDriftOutcomePending)
 	}
 }
 
@@ -1566,90 +1582,14 @@ func (m *mockTaskRiskAssessor) AssessEnvelope(_ context.Context, _ TaskRiskAsses
 	return m.verdict
 }
 
-type failingOutcomeRegistry struct {
-	ScopeDriftRegistry
-	failSetOutcome bool
-}
-
-func (r *failingOutcomeRegistry) SetOutcome(ctx context.Context, driftID string, outcome ScopeDriftOutcome) error {
-	if r.failSetOutcome {
-		return errors.New("database connection lost during outcome write")
-	}
-	return r.ScopeDriftRegistry.SetOutcome(ctx, driftID, outcome)
-}
-
-// TestScopeDriftE2E_NewTaskAutoApproveSetOutcomeFailureRollsBackDrift verifies that if task auto-approval
-// triggers and task creation succeeds, but the registry write for SetOutcome(Succeeded) fails, the claim is
-// rolled back and the request falls through.
-func TestScopeDriftE2E_NewTaskAutoApproveSetOutcomeFailureRollsBackDrift(t *testing.T) {
-	t.Parallel()
-	ctx := context.Background()
-	innerReg := NewMemoryScopeDriftRegistry(0)
-	reg := &failingOutcomeRegistry{ScopeDriftRegistry: innerReg, failSetOutcome: true}
-	cache := NewMemoryPendingApprovalCache(time.Minute)
-	drift, _ := mintDriftFixture(t, reg, ScopeDriftSourceTaskScope)
-
-	taskBody := &runtimetasks.TaskCreateRequest{
-		Purpose:                "File the issue",
-		IntentVerificationMode: "strict",
-		ExpiresInSeconds:       600,
-		ExpectedTools: []runtimetasks.ExpectedTool{
-			{ToolName: "Bash", Why: "curl to github"},
-		},
-		DriftID: drift.ID,
-	}
-	taskBodyJSON, _ := json.Marshal(taskBody)
-	tu := conversation.ToolUse{
-		ID:    "tu-create",
-		Name:  "Bash",
-		Input: json.RawMessage(`{"body":` + string(mustJSON(string(taskBodyJSON))) + `}`),
-	}
-
-	// Creator succeeds on task creation, but SetOutcome will fail.
-	fc := &fakeInlineTaskCreator{}
-	assessor := &mockTaskRiskAssessor{
-		verdict: &TaskRiskAssessment{
-			RiskLevel:   "low",
-			IntentMatch: "yes",
-		},
-	}
-	cfg := PostprocessConfig{
-		AgentContext:         AgentContext{AgentID: driftTestAgentID, AgentUserID: driftTestUserID, AgentName: "agent-drift"},
-		AuditContext:         AuditContext{ConversationID: driftTestConvID},
-		AuthorizationContext: AuthorizationContext{ScopeDrifts: reg},
-		ApprovalContext: ApprovalContext{
-			PendingApprovals:                 cache,
-			InlineTaskCreator:                fc,
-			TaskRiskAssessor:                 assessor,
-			ConversationAutoApproveThreshold: "low",
-			RecentUserTurns:                  []string{"please file the issue immediately"},
-		},
-	}
-	httpReq := httptest.NewRequest("POST", "http://daemon/api/control/tasks?surface=inline", nil)
-	call := ControlCall{Method: "POST", URL: httpReq.URL}
-
-	_, ok := MaybeInterceptInlineTaskDefinition(httpReq, cfg, func(string, string, string) {}, func(string, ...any) {}, conversation.ProviderAnthropic, tu, call)
-	if ok {
-		t.Fatal("expected task definition intercept to return false (fallthrough) due to SetOutcome failure")
-	}
-
-	// Verify that the drift outcome and chosen option were rolled back (cleared).
-	stored, err := reg.Get(ctx, drift.ID)
-	if err != nil {
-		t.Fatalf("get drift: %v", err)
-	}
-	if stored.Outcome != "" {
-		t.Fatalf("drift Outcome = %q, want empty", stored.Outcome)
-	}
-	if stored.ChosenOption != "" {
-		t.Fatalf("drift ChosenOption = %q, want empty", stored.ChosenOption)
-	}
-
-	// Verify we can claim the drift again (it was successfully rolled back).
-	if _, err := reg.ClaimOption(ctx, drift.ID, ScopeDriftOptionNewTask, "retry"); err != nil {
-		t.Fatalf("expected drift to be claimable again, but got err: %v", err)
-	}
-}
+// (The SetOutcome-failure rollback test that used to live here has
+// moved to postproc/session_commit_test.go's
+// TestCommitVerdictSideEffectsRollsBackClaimOnSetOutcomeFailure —
+// after Gap-1 the side-effect happens at commit time, not in the
+// evaluator, so the test belongs alongside the layer that owns the
+// behavior. The evaluator-level contract is now: "verdict carries
+// DeferredDriftOutcome spec; the registry is untouched", which
+// TestScopeDriftE2E_NewTaskAutoApproveDefersDriftOutcome above pins.)
 
 // runInboundRewrite dispatches through the InboundRegistry exactly
 // the way the production handler does, so e2e tests exercise the same

--- a/internal/runtime/llmproxy/scope_drift_e2e_test.go
+++ b/internal/runtime/llmproxy/scope_drift_e2e_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -767,13 +768,15 @@ func TestScopeDriftE2E_NewTaskFullStateMachine(t *testing.T) {
 //     turn carrying the Bash placeholder tool_use with the original
 //     tool_use_id, paired with a user turn whose tool_result names
 //     the same tool_use_id.
-//  3. Run RewriteScopeDriftPlaceholders.
+//  3. Dispatch through DefaultInboundRegistry().ForProvider(provider)
+//     so the test exercises the same routing path the handler uses.
 //  4. Assert the assistant turn was restored byte-for-byte (the
 //     model's original Bash command + input survives) AND the
 //     user-turn tool_result content is the menu text.
 //
-// Also asserts the substitution is consumed one-shot — a second
-// RewriteScopeDriftPlaceholders is a no-op.
+// Also asserts the substitution survives across turns — a second
+// RewriteInbound call rewrites again so the harness's stored history
+// stays correct for the full conversation.
 func TestScopeDriftE2E_InboundRewritesPlaceholder(t *testing.T) {
 	t.Parallel()
 	reg := NewMemoryScopeDriftRegistry(time.Minute)
@@ -807,17 +810,9 @@ func TestScopeDriftE2E_InboundRewritesPlaceholder(t *testing.T) {
 		`]}`)
 
 	agent := &store.Agent{ID: driftTestAgentID, UserID: driftTestUserID}
-	result, err := RewriteScopeDriftPlaceholders(context.Background(), ScopeDriftInboundRewriteRequest{
-		HTTPRequest:    httptest.NewRequest("POST", "/v1/messages", nil),
-		Provider:       conversation.ProviderAnthropic,
-		Body:           body,
-		Agent:          agent,
-		ConversationID: driftTestConvID,
-		ScopeDrifts:    reg,
-		Logger:         slog.Default(),
-	})
+	result, err := runInboundRewrite(t, conversation.ProviderAnthropic, httptest.NewRequest("POST", "/v1/messages", nil), body, agent, reg)
 	if err != nil {
-		t.Fatalf("RewriteScopeDriftPlaceholders: %v", err)
+		t.Fatalf("RewriteInbound: %v", err)
 	}
 	if !result.Rewritten {
 		t.Fatal("expected Rewritten=true")
@@ -905,17 +900,9 @@ func TestScopeDriftE2E_InboundRewritesPlaceholder(t *testing.T) {
 	// keeps the Bash placeholder in its stored history for the rest of
 	// the conversation; without persistent restoration the model would
 	// see its own past as the placeholder from turn 3 onward.
-	second, err := RewriteScopeDriftPlaceholders(context.Background(), ScopeDriftInboundRewriteRequest{
-		HTTPRequest:    httptest.NewRequest("POST", "/v1/messages", nil),
-		Provider:       conversation.ProviderAnthropic,
-		Body:           body,
-		Agent:          agent,
-		ConversationID: driftTestConvID,
-		ScopeDrifts:    reg,
-		Logger:         slog.Default(),
-	})
+	second, err := runInboundRewrite(t, conversation.ProviderAnthropic, httptest.NewRequest("POST", "/v1/messages", nil), body, agent, reg)
 	if err != nil {
-		t.Fatalf("second RewriteScopeDriftPlaceholders: %v", err)
+		t.Fatalf("second RewriteInbound: %v", err)
 	}
 	if !second.Rewritten {
 		t.Fatal("expected second rewrite to also restore the placeholder (substitutions persist across turns)")
@@ -963,17 +950,9 @@ func TestScopeDriftE2E_InboundRewritesOpenAIResponsesPlaceholder(t *testing.T) {
 
 	agent := &store.Agent{ID: driftTestAgentID, UserID: driftTestUserID}
 	httpReq := httptest.NewRequest("POST", "/v1/responses", nil)
-	result, err := RewriteScopeDriftPlaceholders(context.Background(), ScopeDriftInboundRewriteRequest{
-		HTTPRequest:    httpReq,
-		Provider:       conversation.ProviderOpenAI,
-		Body:           body,
-		Agent:          agent,
-		ConversationID: driftTestConvID,
-		ScopeDrifts:    reg,
-		Logger:         slog.Default(),
-	})
+	result, err := runInboundRewrite(t, conversation.ProviderOpenAI, httpReq, body, agent, reg)
 	if err != nil {
-		t.Fatalf("RewriteScopeDriftPlaceholders: %v", err)
+		t.Fatalf("RewriteInbound: %v", err)
 	}
 	if !result.Rewritten {
 		t.Fatalf("expected Rewritten=true; AppliedDriftIDs=%v", result.AppliedDriftIDs)
@@ -1072,17 +1051,9 @@ func TestScopeDriftE2E_InboundRewritesOpenAIResponsesPlaceholderChained(t *testi
 
 	agent := &store.Agent{ID: driftTestAgentID, UserID: driftTestUserID}
 	httpReq := httptest.NewRequest("POST", "/v1/responses", nil)
-	result, err := RewriteScopeDriftPlaceholders(context.Background(), ScopeDriftInboundRewriteRequest{
-		HTTPRequest:    httpReq,
-		Provider:       conversation.ProviderOpenAI,
-		Body:           body,
-		Agent:          agent,
-		ConversationID: driftTestConvID,
-		ScopeDrifts:    reg,
-		Logger:         slog.Default(),
-	})
+	result, err := runInboundRewrite(t, conversation.ProviderOpenAI, httpReq, body, agent, reg)
 	if err != nil {
-		t.Fatalf("RewriteScopeDriftPlaceholders: %v", err)
+		t.Fatalf("RewriteInbound: %v", err)
 	}
 	if !result.Rewritten {
 		t.Fatalf("expected Rewritten=true in chained mode; AppliedDriftIDs=%v", result.AppliedDriftIDs)
@@ -1678,4 +1649,25 @@ func TestScopeDriftE2E_NewTaskAutoApproveSetOutcomeFailureRollsBackDrift(t *test
 	if _, err := reg.ClaimOption(ctx, drift.ID, ScopeDriftOptionNewTask, "retry"); err != nil {
 		t.Fatalf("expected drift to be claimable again, but got err: %v", err)
 	}
+}
+
+// runInboundRewrite dispatches through the InboundRegistry exactly
+// the way the production handler does, so e2e tests exercise the same
+// routing path the handler uses rather than an ad-hoc shortcut.
+func runInboundRewrite(t *testing.T, provider conversation.Provider, httpReq *http.Request, body []byte, agent *store.Agent, reg SubstitutionRegistry) (conversation.InboundRewriteResult, error) {
+	t.Helper()
+	rewriter := DefaultInboundRegistry().ForProvider(provider)
+	if rewriter == nil {
+		t.Fatalf("no inbound rewriter registered for provider %q", provider)
+	}
+	return rewriter.RewriteInbound(context.Background(), conversation.InboundRewriteRequest{
+		HTTPRequest:    httpReq,
+		Provider:       provider,
+		Body:           body,
+		AgentID:        agent.ID,
+		AgentUserID:    agent.UserID,
+		ConversationID: driftTestConvID,
+		Lookup:         NewSubstitutionLookup(reg),
+		Logger:         slog.Default(),
+	})
 }

--- a/internal/runtime/llmproxy/scope_drift_inbound_rewrite.go
+++ b/internal/runtime/llmproxy/scope_drift_inbound_rewrite.go
@@ -8,55 +8,84 @@ import (
 	"strings"
 
 	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
-	"github.com/clawvisor/clawvisor/pkg/store"
 )
 
-// ScopeDriftInboundRewriteRequest is the input to
-// RewriteScopeDriftPlaceholders. The caller supplies the inbound
-// /v1/messages body and identifying context; the rewriter consults the
-// SubstitutionRegistry for pending substitutions and returns the
-// rewritten body when one or more applied. The wider ScopeDriftRegistry
-// satisfies the narrower SubstitutionRegistry interface, so existing
-// handler wiring continues to work unchanged.
-type ScopeDriftInboundRewriteRequest struct {
-	HTTPRequest    *http.Request
-	Provider       conversation.Provider
-	Body           []byte
-	Agent          *store.Agent
-	ConversationID string
-	ScopeDrifts    SubstitutionRegistry
-	Logger         *slog.Logger
+// AnthropicInboundRewriter walks Anthropic /v1/messages bodies and
+// substitutes pending scope-drift / recoverable-deny / auto-approve
+// placeholders. Implements conversation.InboundRewriter so dispatch
+// runs through the InboundRegistry the same way response rewriters
+// dispatch through ResponseRegistry.
+type AnthropicInboundRewriter struct{}
+
+// Name reports the provider for registry lookup.
+func (AnthropicInboundRewriter) Name() conversation.Provider {
+	return conversation.ProviderAnthropic
 }
 
-// ScopeDriftInboundRewriteResult reports what the rewriter did.
-type ScopeDriftInboundRewriteResult struct {
-	Body            []byte
-	Rewritten       bool
-	AppliedDriftIDs []string
+// MatchesInbound returns true for Anthropic-bound requests. Host
+// matching is intentionally coarse (the user agent or path could
+// belong to either the lite proxy or the runtime proxy); the
+// downstream provider header carries the real signal in production
+// and tests synthesize requests with the right Provider already.
+func (AnthropicInboundRewriter) MatchesInbound(req *http.Request) bool {
+	if req == nil || req.URL == nil {
+		return false
+	}
+	host := strings.ToLower(req.URL.Host)
+	if host == "" {
+		host = strings.ToLower(req.Host)
+	}
+	return strings.Contains(host, "anthropic")
 }
 
-// RewriteScopeDriftPlaceholders walks the inbound /v1/messages body
-// looking for tool_result blocks whose tool_use_id matches a pending
-// scope-drift substitution. For each match:
-//
-//  1. The matching tool_result's content is replaced with the drift's
-//     menu text.
-//  2. The corresponding tool_use block in the prior assistant turn —
-//     a harness-side Bash placeholder we substituted on the response
-//     leg — is restored to the model's original tool_use (name +
-//     input bytes) byte-for-byte.
-//
-// The substitution is one-shot: LookupPendingSubstitution consumes the
-// registry entry. If the rewrite fails (malformed body, missing
-// assistant turn) the entry is NOT re-registered — the agent's next
-// retry mints a fresh drift on the normal path.
-//
-// Returns (body, Rewritten=false, nil) when no substitutions apply.
-// Errors only on body shape failures the caller should treat as fail-
-// closed — typical "no match" paths return Rewritten=false.
-func RewriteScopeDriftPlaceholders(ctx context.Context, req ScopeDriftInboundRewriteRequest) (ScopeDriftInboundRewriteResult, error) {
-	out := ScopeDriftInboundRewriteResult{Body: req.Body}
-	if req.ScopeDrifts == nil || req.Agent == nil {
+// RewriteInbound walks the body's messages[] and applies every
+// pending substitution the lookup serves. Two-pass: locate every
+// tool_result block whose tool_use_id has a pending substitution,
+// then for each apply the assistant-turn restoration BEFORE the
+// user-turn substitution so a partial failure can't leave the
+// transcript permanently inconsistent (placeholder Bash on top, menu
+// text below, with nothing tying them to the model's actual call).
+func (AnthropicInboundRewriter) RewriteInbound(ctx context.Context, req conversation.InboundRewriteRequest) (conversation.InboundRewriteResult, error) {
+	out := conversation.InboundRewriteResult{Body: req.Body}
+	if req.Lookup == nil || req.AgentID == "" {
+		return out, nil
+	}
+	rewritten, applied, err := rewriteAnthropicInbound(ctx, req)
+	if err != nil {
+		return out, err
+	}
+	if rewritten == nil {
+		return out, nil
+	}
+	out.Body = rewritten
+	out.Rewritten = true
+	out.AppliedDriftIDs = applied
+	return out, nil
+}
+
+// OpenAIInboundRewriter walks OpenAI Chat Completions and Responses
+// bodies. Sub-shape disambiguation happens inside RewriteInbound
+// where the body bytes (and the request's path) are already in scope.
+type OpenAIInboundRewriter struct{}
+
+func (OpenAIInboundRewriter) Name() conversation.Provider {
+	return conversation.ProviderOpenAI
+}
+
+func (OpenAIInboundRewriter) MatchesInbound(req *http.Request) bool {
+	if req == nil || req.URL == nil {
+		return false
+	}
+	host := strings.ToLower(req.URL.Host)
+	if host == "" {
+		host = strings.ToLower(req.Host)
+	}
+	return strings.Contains(host, "openai")
+}
+
+func (OpenAIInboundRewriter) RewriteInbound(ctx context.Context, req conversation.InboundRewriteRequest) (conversation.InboundRewriteResult, error) {
+	out := conversation.InboundRewriteResult{Body: req.Body}
+	if req.Lookup == nil || req.AgentID == "" {
 		return out, nil
 	}
 	var (
@@ -64,17 +93,10 @@ func RewriteScopeDriftPlaceholders(ctx context.Context, req ScopeDriftInboundRew
 		applied   []string
 		err       error
 	)
-	switch req.Provider {
-	case conversation.ProviderAnthropic:
-		rewritten, applied, err = rewriteAnthropicScopeDriftPlaceholders(ctx, req)
-	case conversation.ProviderOpenAI:
-		if conversation.IsOpenAIChatCompletionsEndpoint(req.HTTPRequest) {
-			rewritten, applied, err = rewriteOpenAIChatScopeDriftPlaceholders(ctx, req)
-		} else {
-			rewritten, applied, err = rewriteOpenAIResponsesScopeDriftPlaceholders(ctx, req)
-		}
-	default:
-		return out, nil
+	if conversation.IsOpenAIChatCompletionsEndpoint(req.HTTPRequest) {
+		rewritten, applied, err = rewriteOpenAIChatInbound(ctx, req)
+	} else {
+		rewritten, applied, err = rewriteOpenAIResponsesInbound(ctx, req)
 	}
 	if err != nil {
 		return out, err
@@ -88,7 +110,62 @@ func RewriteScopeDriftPlaceholders(ctx context.Context, req ScopeDriftInboundRew
 	return out, nil
 }
 
-func rewriteAnthropicScopeDriftPlaceholders(ctx context.Context, req ScopeDriftInboundRewriteRequest) ([]byte, []string, error) {
+// DefaultInboundRegistry returns the canonical inbound rewriter
+// dispatch table. Mirrors conversation.DefaultResponseRegistry on the
+// outbound leg so both directions route through one consistent
+// abstraction.
+func DefaultInboundRegistry() *conversation.InboundRegistry {
+	return conversation.NewInboundRegistry(
+		AnthropicInboundRewriter{},
+		OpenAIInboundRewriter{},
+	)
+}
+
+// substitutionLookupAdapter satisfies conversation.InboundSubstitutionLookup
+// for a SubstitutionRegistry. The conversation package can't depend
+// on llmproxy, so the registry's tuple-keyed signature is lifted
+// here into the conversation-package lookup shape.
+type substitutionLookupAdapter struct {
+	Registry SubstitutionRegistry
+}
+
+func (a substitutionLookupAdapter) LookupPendingSubstitution(ctx context.Context, agentID, conversationID, toolUseID string) (conversation.InboundPendingSubstitution, bool) {
+	if a.Registry == nil {
+		return conversation.InboundPendingSubstitution{}, false
+	}
+	subst, ok := a.Registry.LookupPendingSubstitution(ctx, PendingSubstitutionKey{
+		AgentID:        agentID,
+		ConversationID: conversationID,
+		ToolUseID:      toolUseID,
+	})
+	if !ok {
+		return conversation.InboundPendingSubstitution{}, false
+	}
+	return conversation.InboundPendingSubstitution{
+		DriftID:           subst.DriftID,
+		MenuText:          subst.MenuText,
+		OriginalToolName:  subst.OriginalToolName,
+		OriginalToolInput: subst.OriginalToolInput,
+	}, true
+}
+
+// NewSubstitutionLookup wraps a SubstitutionRegistry so it can be
+// passed to inbound rewriters as conversation.InboundSubstitutionLookup.
+// Returns nil when the registry is nil so callers can plug the result
+// straight into InboundRewriteRequest.Lookup without nil-guards.
+func NewSubstitutionLookup(reg SubstitutionRegistry) conversation.InboundSubstitutionLookup {
+	if reg == nil {
+		return nil
+	}
+	return substitutionLookupAdapter{Registry: reg}
+}
+
+// rewriteAnthropicInbound performs the messages[] walk for Anthropic
+// /v1/messages bodies. Two-pass: collect every tool_result block whose
+// tool_use_id has a pending substitution (PASS 1), then apply each
+// substitution with assistant-turn restoration first / user-turn
+// content substitution second (PASS 2).
+func rewriteAnthropicInbound(ctx context.Context, req conversation.InboundRewriteRequest) ([]byte, []string, error) {
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(req.Body, &raw); err != nil {
 		return nil, nil, err
@@ -101,13 +178,9 @@ func rewriteAnthropicScopeDriftPlaceholders(ctx context.Context, req ScopeDriftI
 	if err := json.Unmarshal(msgsRaw, &messages); err != nil {
 		return nil, nil, err
 	}
-	// Two-pass walk: identify every tool_use_id that has a pending
-	// substitution (by probing user-turn tool_result blocks), then
-	// apply the substitutions in a single body edit so partial failures
-	// don't leave half-applied state.
 	type pendingHit struct {
 		ToolUseID    string
-		Substitution PendingSubstitution
+		Substitution conversation.InboundPendingSubstitution
 		UserMsgIdx   int
 		BlockIdx     int
 	}
@@ -125,7 +198,6 @@ func rewriteAnthropicScopeDriftPlaceholders(ctx context.Context, req ScopeDriftI
 		}
 		var blocks []json.RawMessage
 		if err := json.Unmarshal(probe.Content, &blocks); err != nil {
-			// String-form user content carries no tool_results.
 			continue
 		}
 		for bi, blk := range blocks {
@@ -139,11 +211,7 @@ func rewriteAnthropicScopeDriftPlaceholders(ctx context.Context, req ScopeDriftI
 			if blkProbe.Type != "tool_result" || blkProbe.ToolUseID == "" {
 				continue
 			}
-			subst, found := req.ScopeDrifts.LookupPendingSubstitution(ctx, PendingSubstitutionKey{
-				AgentID:        req.Agent.ID,
-				ConversationID: req.ConversationID,
-				ToolUseID:      blkProbe.ToolUseID,
-			})
+			subst, found := req.Lookup.LookupPendingSubstitution(ctx, req.AgentID, req.ConversationID, blkProbe.ToolUseID)
 			if !found {
 				continue
 			}
@@ -159,25 +227,12 @@ func rewriteAnthropicScopeDriftPlaceholders(ctx context.Context, req ScopeDriftI
 		return nil, nil, nil
 	}
 
-	// Apply substitutions. For each hit:
-	//   - rewrite the matching user-turn tool_result block's content
-	//   - walk back through prior assistant turns to find the tool_use
-	//     block carrying the placeholder for this id, and restore the
-	//     original name + input.
 	logger := req.Logger
 	if logger == nil {
 		logger = slog.Default()
 	}
 	appliedDriftIDs := make([]string, 0, len(hits))
 	for _, hit := range hits {
-		// Restore the assistant turn FIRST so a failure here doesn't
-		// leave the user turn carrying the menu while the assistant
-		// turn still has the placeholder — that asymmetry leaves the
-		// transcript permanently inconsistent (the model sees a
-		// placeholder Bash followed by the menu, with nothing tying
-		// them to its actual call). Skip the whole hit on restore
-		// failure; the substitution stays in the registry for the
-		// next inbound retry.
 		restoredIdx := -1
 		var restoredMessage json.RawMessage
 		for ai := hit.UserMsgIdx - 1; ai >= 0; ai-- {
@@ -221,12 +276,6 @@ func rewriteAnthropicScopeDriftPlaceholders(ctx context.Context, req ScopeDriftI
 	return out, appliedDriftIDs, nil
 }
 
-// substituteAnthropicToolResultContent replaces the content field of
-// the tool_result block whose tool_use_id matches targetToolUseID. The
-// replacement is rendered as a single text block to match Anthropic's
-// preferred multi-block tool_result shape — string-form content works
-// too but blocks survive concatenation with other model-generated
-// content cleanly.
 func substituteAnthropicToolResultContent(message json.RawMessage, targetToolUseID, menuText string) (json.RawMessage, bool) {
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(message, &raw); err != nil {
@@ -281,17 +330,13 @@ func substituteAnthropicToolResultContent(message json.RawMessage, targetToolUse
 	return out, true
 }
 
-// rewriteOpenAIResponsesScopeDriftPlaceholders walks the OpenAI
-// Responses `input` array, finds function_call_output items whose
-// call_id matches a pending substitution, and replaces the `output`
-// with the menu text. In full-input mode it also restores the
-// preceding function_call item's (name, arguments) to the model's
-// original; in chained mode (previous_response_id set) the function_call
-// lives in OpenAI's server-stored history rather than `input[]`, and
-// that stored history is already correct (OpenAI stored what its model
-// emitted, not what the proxy substituted on the wire to the harness),
-// so no restoration is needed — only the output substitution.
-func rewriteOpenAIResponsesScopeDriftPlaceholders(ctx context.Context, req ScopeDriftInboundRewriteRequest) ([]byte, []string, error) {
+// rewriteOpenAIResponsesInbound walks the OpenAI Responses `input`
+// array. In full-input mode it restores the placeholder function_call
+// and substitutes the function_call_output. In chained mode
+// (previous_response_id set) only the output is substituted —
+// OpenAI's server-stored history already holds the model-original
+// function_call.
+func rewriteOpenAIResponsesInbound(ctx context.Context, req conversation.InboundRewriteRequest) ([]byte, []string, error) {
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(req.Body, &raw); err != nil {
 		return nil, nil, err
@@ -300,8 +345,6 @@ func rewriteOpenAIResponsesScopeDriftPlaceholders(ctx context.Context, req Scope
 	if !ok {
 		return nil, nil, nil
 	}
-	// `input` can be a plain string (single-turn). Plain-string inputs
-	// have no tool_call history, so there's nothing to substitute.
 	var asString string
 	if err := json.Unmarshal(inputRaw, &asString); err == nil {
 		return nil, nil, nil
@@ -310,13 +353,6 @@ func rewriteOpenAIResponsesScopeDriftPlaceholders(ctx context.Context, req Scope
 	if err := json.Unmarshal(inputRaw, &items); err != nil {
 		return nil, nil, err
 	}
-	// Detect chained mode. When previous_response_id is set, the harness
-	// (e.g., codex) chains turns by reference; OpenAI's server-stored
-	// history holds the real function_call and the new request's input[]
-	// carries only the function_call_output for this turn. We can't
-	// restore a function_call that isn't in the body, but we also don't
-	// need to — the stored history is already the model's original
-	// call. Substitute the output and call it done.
 	chained := false
 	if prev, ok := raw["previous_response_id"]; ok {
 		var s string
@@ -341,18 +377,11 @@ func rewriteOpenAIResponsesScopeDriftPlaceholders(ctx context.Context, req Scope
 		if probe.Type != "function_call_output" || probe.CallID == "" {
 			continue
 		}
-		subst, found := req.ScopeDrifts.LookupPendingSubstitution(ctx, PendingSubstitutionKey{
-			AgentID:        req.Agent.ID,
-			ConversationID: req.ConversationID,
-			ToolUseID:      probe.CallID,
-		})
+		subst, found := req.Lookup.LookupPendingSubstitution(ctx, req.AgentID, req.ConversationID, probe.CallID)
 		if !found {
 			continue
 		}
 		if chained {
-			// Chained mode: skip restoration; OpenAI's stored history
-			// holds the real function_call. Substitute the output and
-			// the model sees its own call answered by the augmentation.
 			newItem, ok := substituteOpenAIResponsesFunctionCallOutput(item, subst.MenuText)
 			if !ok {
 				logger.WarnContext(ctx, "scope-drift inbound rewrite: failed to substitute function_call_output (chained mode)",
@@ -366,10 +395,6 @@ func rewriteOpenAIResponsesScopeDriftPlaceholders(ctx context.Context, req Scope
 			rewrittenAny = true
 			continue
 		}
-		// Full-input mode: restore the prior function_call FIRST so a
-		// failure here doesn't leave the function_call_output carrying
-		// the menu while the assistant call remains the placeholder —
-		// see rewriteAnthropicScopeDriftPlaceholders for the rationale.
 		restoredIdx := -1
 		var restoredItem json.RawMessage
 		for ai := i - 1; ai >= 0; ai-- {
@@ -452,9 +477,6 @@ func restoreOpenAIResponsesFunctionCall(item json.RawMessage, targetCallID, orig
 		return nil, false
 	}
 	raw["name"] = nameRaw
-	// OpenAI `arguments` is a JSON-encoded string of the input. The
-	// inspector and rewriter use raw input bytes (parsed JSON
-	// document); convert to the string form the wire format expects.
 	if len(originalInput) == 0 {
 		argsRaw, _ := json.Marshal("{}")
 		raw["arguments"] = argsRaw
@@ -472,12 +494,10 @@ func restoreOpenAIResponsesFunctionCall(item json.RawMessage, targetCallID, orig
 	return out, true
 }
 
-// rewriteOpenAIChatScopeDriftPlaceholders walks the OpenAI Chat
-// Completions `messages` array, finds tool-role messages whose
-// tool_call_id matches a pending substitution, replaces their
-// content with the menu text, and restores the corresponding assistant
-// message's tool_call (name, arguments) to the model's original.
-func rewriteOpenAIChatScopeDriftPlaceholders(ctx context.Context, req ScopeDriftInboundRewriteRequest) ([]byte, []string, error) {
+// rewriteOpenAIChatInbound walks the OpenAI Chat Completions
+// `messages` array. Restores assistant tool_calls and substitutes the
+// matching role:"tool" message's content.
+func rewriteOpenAIChatInbound(ctx context.Context, req conversation.InboundRewriteRequest) ([]byte, []string, error) {
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(req.Body, &raw); err != nil {
 		return nil, nil, err
@@ -507,16 +527,10 @@ func rewriteOpenAIChatScopeDriftPlaceholders(ctx context.Context, req ScopeDrift
 		if probe.Role != "tool" || probe.ToolCallID == "" {
 			continue
 		}
-		subst, found := req.ScopeDrifts.LookupPendingSubstitution(ctx, PendingSubstitutionKey{
-			AgentID:        req.Agent.ID,
-			ConversationID: req.ConversationID,
-			ToolUseID:      probe.ToolCallID,
-		})
+		subst, found := req.Lookup.LookupPendingSubstitution(ctx, req.AgentID, req.ConversationID, probe.ToolCallID)
 		if !found {
 			continue
 		}
-		// Restore the prior assistant tool_call FIRST — see
-		// rewriteAnthropicScopeDriftPlaceholders for the rationale.
 		restoredIdx := -1
 		var restoredMsg json.RawMessage
 		for ai := i - 1; ai >= 0; ai-- {
@@ -621,7 +635,6 @@ func restoreOpenAIChatAssistantToolCall(message json.RawMessage, targetToolCallI
 			continue
 		}
 		fn["name"] = nameRaw
-		// Arguments is a JSON-encoded string of the input.
 		argsStr := "{}"
 		if len(originalInput) > 0 {
 			argsStr = string(originalInput)
@@ -696,9 +709,6 @@ func restoreAnthropicAssistantToolUse(message json.RawMessage, targetToolUseID, 
 		if probe.Type != "tool_use" || probe.ID != targetToolUseID {
 			continue
 		}
-		// Preserve all top-level keys on the block so the restored
-		// shape matches what the model emitted (cache_control,
-		// metadata, etc.). Only swap name + input.
 		var blockMap map[string]json.RawMessage
 		if err := json.Unmarshal(blk, &blockMap); err != nil {
 			continue

--- a/internal/runtime/llmproxy/secret_detection.go
+++ b/internal/runtime/llmproxy/secret_detection.go
@@ -631,116 +631,28 @@ var secretDecisionIDRE = regexp.MustCompile(`\[clawvisor:secret=([^\]\s]+)\]`)
 // not whatever happened to be at the tail of the queue when a concurrent
 // request enqueued a second pending.
 func LatestAssistantSecretDecisionID(provider conversation.Provider, body []byte) string {
-	collect := func(text string) string {
+	shape := DefaultInboundShapeRegistry().ForProvider(provider)
+	if shape == nil {
+		return ""
+	}
+	for _, text := range shape.AssistantTextTurns(body) {
 		if !strings.Contains(text, SecretDecisionIDMarker) {
-			return ""
+			continue
 		}
 		m := secretDecisionIDRE.FindStringSubmatch(text)
-		if len(m) < 2 {
-			return ""
-		}
-		return m[1]
-	}
-	switch provider {
-	case conversation.ProviderAnthropic:
-		var parsed struct {
-			Messages []struct {
-				Role    string          `json:"role"`
-				Content json.RawMessage `json:"content"`
-			} `json:"messages"`
-		}
-		if err := json.Unmarshal(body, &parsed); err == nil {
-			for i := len(parsed.Messages) - 1; i >= 0; i-- {
-				if parsed.Messages[i].Role != "assistant" {
-					continue
-				}
-				if id := collect(flattenAnthropicTaskReplyText(parsed.Messages[i].Content)); id != "" {
-					return id
-				}
-			}
-		}
-	case conversation.ProviderOpenAI:
-		var parsed struct {
-			Messages []map[string]any `json:"messages"`
-			Input    json.RawMessage  `json:"input"`
-		}
-		if err := json.Unmarshal(body, &parsed); err == nil {
-			var items []map[string]any
-			if len(parsed.Input) > 0 && json.Unmarshal(parsed.Input, &items) == nil {
-				for i := len(items) - 1; i >= 0; i-- {
-					role, _ := items[i]["role"].(string)
-					if role != "assistant" {
-						continue
-					}
-					raw, _ := json.Marshal(items[i]["content"])
-					if id := collect(flattenOpenAITaskReplyContent(raw)); id != "" {
-						return id
-					}
-				}
-			}
-			for i := len(parsed.Messages) - 1; i >= 0; i-- {
-				role, _ := parsed.Messages[i]["role"].(string)
-				if role != "assistant" {
-					continue
-				}
-				raw, _ := json.Marshal(parsed.Messages[i]["content"])
-				if id := collect(flattenOpenAITaskReplyContent(raw)); id != "" {
-					return id
-				}
-			}
+		if len(m) >= 2 {
+			return m[1]
 		}
 	}
 	return ""
 }
 
 func LatestUserText(provider conversation.Provider, body []byte) string {
-	switch provider {
-	case conversation.ProviderAnthropic:
-		var parsed struct {
-			Messages []struct {
-				Role    string          `json:"role"`
-				Content json.RawMessage `json:"content"`
-			} `json:"messages"`
-		}
-		if err := json.Unmarshal(body, &parsed); err == nil {
-			for i := len(parsed.Messages) - 1; i >= 0; i-- {
-				if parsed.Messages[i].Role == "user" {
-					return strings.TrimSpace(flattenAnthropicTaskReplyText(parsed.Messages[i].Content))
-				}
-			}
-		}
-	case conversation.ProviderOpenAI:
-		var parsed struct {
-			Messages []map[string]any `json:"messages"`
-			Input    json.RawMessage  `json:"input"`
-		}
-		if err := json.Unmarshal(body, &parsed); err == nil {
-			var input string
-			if len(parsed.Input) > 0 && json.Unmarshal(parsed.Input, &input) == nil {
-				return strings.TrimSpace(input)
-			}
-			var items []map[string]any
-			if len(parsed.Input) > 0 && json.Unmarshal(parsed.Input, &items) == nil {
-				for i := len(items) - 1; i >= 0; i-- {
-					role, _ := items[i]["role"].(string)
-					if role != "user" {
-						continue
-					}
-					raw, _ := json.Marshal(items[i]["content"])
-					return strings.TrimSpace(flattenOpenAITaskReplyContent(raw))
-				}
-			}
-			for i := len(parsed.Messages) - 1; i >= 0; i-- {
-				role, _ := parsed.Messages[i]["role"].(string)
-				if role != "user" {
-					continue
-				}
-				raw, _ := json.Marshal(parsed.Messages[i]["content"])
-				return strings.TrimSpace(flattenOpenAITaskReplyContent(raw))
-			}
-		}
+	shape := DefaultInboundShapeRegistry().ForProvider(provider)
+	if shape == nil {
+		return ""
 	}
-	return ""
+	return shape.LatestUserText(body)
 }
 
 func stringFromMap(m map[string]any, key string) string {


### PR DESCRIPTION
## Summary

Three-phase refactor that restores abstractions the original placeholder/substitution work (#570) had eroded, then closes the remaining gaps surfaced by a post-merge audit. Net grade: **B+ → A-**.

- **Phase A** (`55f9814b`) — Verdicts stop being side-effecting. The three evaluators that wrote to the substitution registry (scope-drift mint, recoverable-deny transform, inline-task auto-approve) now attach a `PendingSubstitution` spec to the verdict; `postprocessSession.commitVerdictSideEffects` is the single point that translates specs into registry writes, with rollback symmetric. The `detectScopeDriftSubstitution` band-aid is gone.
- **Phase B** (`0cd93c38`) — Inbound rewriter dispatch now mirrors outbound. New `conversation.InboundRewriter` + `InboundRegistry` interfaces; per-provider types in llmproxy implement them; `llmproxy.RewriteScopeDriftPlaceholders` deleted.
- **Phase C** (`4da35848`) — Closes remaining gaps from the post-A/B audit:
  - **Gap 1 (verdict purity → A):** `SetOutcome(Succeeded)` deferred onto verdict via `DeferredDriftOutcome` spec; eval pipeline has zero registry side-effects.
  - **Gap 2 (per-leg dispatch → A):** `conversation.InboundBodyShape` + `InboundShapeRegistry` consolidates 5 per-provider switches (HasAssistantTurn, RecentHumanTurns, LatestUserText, AssistantTextTurns, PrependAssistantText) behind one dispatch.
  - **Gap 3 (inline-approval → B+):** `inline_task_rewrite.go`'s silent `SetOutcome` failure now traces. Two reply rewriters legitimately need different rollback shapes; didn't force a session abstraction that wouldn't fit.

## Why now

PR #570 acknowledged in its description that the verdict-purity invariant had eroded. This branch puts the invariant back together and parallels the inbound and outbound abstractions so future work can extend either leg through a consistent registry pattern.

## Test plan

- [x] Repo-wide unit suite green (~70+ packages)
- [x] New focused tests:
  - `TestTransformRecoverableDenyToPlaceholder` — verdict carries spec, registry untouched
  - `TestCommitSubstitutionsRegistersSpecsInToolUseOrder` — ordered registration + rollback sweep
  - `TestCommitSubstitutionsExpiresTaskOnRegistrationFailure` — TaskRollback fires
  - `TestCommitVerdictSideEffectsAppliesDriftOutcomeBeforeSubstitution` — per-verdict ordering
  - `TestCommitVerdictSideEffectsRollsBackClaimOnSetOutcomeFailure` — claim rollback on SetOutcome failure
- [x] Lite e2e sample (5 scenarios × claude+codex): 8/10 pass; 2 failures are pre-existing agent-behavior issues (`cross_file_inspection/codex` Category-2 codex prompt sensitivity, `script_session_credentialed_fanout/claude` mid-fanout scope mismatch). Substitution counters confirm the spec-on-verdict pipeline is healthy at scale (`consumed:13, minted:1, placeholder_used:14` on `script_session_credentialed_fanout/codex`).

## Why not a clean A

`forward.go`'s 3 provider switches (URL routing, vault service ID, auth headers) stay as typed provider-config maps — they're not body-shape walks, and the switch shape IS the right abstraction for them. Forcing a registry there would be ceremony without abstraction win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

