### PR TITLE
feat(tasks): expose POST /api/control/tasks/{id}/complete to LLM-proxy agents

### DIFF
--- a/docs/LITE_PROXY.md
+++ b/docs/LITE_PROXY.md
@@ -65,6 +65,7 @@ The proxy is gated by `proxy_lite.enabled`. When on, the daemon exposes:
 | `POST /api/control/tasks` | Task creation. Agents POST here to request scope before doing non-trivial work. |
 | `GET /api/control/tasks/{id}` | Status lookup. |
 | `POST /api/control/tasks/{id}/expand` | Add scope to an existing task. |
+| `POST /api/control/tasks/{id}/complete` | Close out a task whose work is done. Releases scope and clears chain-fact context. Unilateral (no user approval); accepts `active` or `expired` tasks. |
 
 Agents should be prompted to use the shorter synthetic URL
 `https://clawvisor.local/control/...`. Proxy-lite rewrites that model-facing

--- a/internal/api/control_complete_route_test.go
+++ b/internal/api/control_complete_route_test.go
@@ -1,0 +1,40 @@
+package api_test
+
+import (
+	"net/http"
+	"testing"
+)
+
+// TestControlPlaneCompleteRoute_RegisteredAheadOfCatchAll guards
+// against two refactor pitfalls:
+//
+//  1. The route must actually be mounted on the proxy-lite route set
+//     so the agent's curl can reach it. A missing route lands on the
+//     `/api/control/` catch-all (controlHandler.NotFound) and returns
+//     404 — looks identical to "endpoint missing" from the client.
+//  2. The catch-all must NOT be mounted before the specific route, or
+//     the specific route is silently shadowed.
+//
+// A 401 (missing caller-auth) means the specific route handler was
+// reached and the auth middleware rejected the request — which is the
+// correct behavior for an anonymous probe. 404 means the catch-all
+// captured the request, which is the regression we want to catch.
+func TestControlPlaneCompleteRoute_RegisteredAheadOfCatchAll(t *testing.T) {
+	env := newRouteSetEnv(t, "proxy_lite")
+
+	req, _ := http.NewRequest(http.MethodPost, env.ts.URL+"/api/control/tasks/some-id/complete", nil)
+	resp, err := env.ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("POST /api/control/tasks/.../complete: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		t.Fatalf("status = 404 — the catch-all /api/control/ swallowed the request, the specific complete route is not registered or is shadowed")
+	}
+	// Unauthenticated is the expected shape: the caller-nonce middleware
+	// rejects the missing X-Clawvisor-Caller header.
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 (missing caller-auth); 404 would mean the route isn't registered", resp.StatusCode)
+	}
+}

--- a/internal/api/handlers/control.go
+++ b/internal/api/handlers/control.go
@@ -47,6 +47,7 @@ func (h *LLMControlHandler) Capabilities(w http.ResponseWriter, r *http.Request)
 			{"method": "POST", "path": "/control/task/checkout", "purpose": "Set the current task focus for disambiguating later tool use."},
 			{"method": "GET", "path": "/control/tasks/{id}", "purpose": "Fetch task status."},
 			{"method": "POST", "path": "/control/tasks/{id}/expand", "purpose": "Request additional scope for an existing task."},
+			{"method": "POST", "path": "/control/tasks/{id}/complete", "purpose": "Mark a task complete. Closes its scope and clears its chain-fact context."},
 		},
 	})
 }
@@ -113,6 +114,12 @@ func (h *LLMControlHandler) Skill(w http.ResponseWriter, r *http.Request) {
 			"body": map[string]any{
 				"task_id": "The active task id to prefer for later tool calls.",
 			},
+		},
+		"complete_task": map[string]any{
+			"method":  "POST",
+			"path":    "/control/tasks/{id}/complete",
+			"purpose": "Close out a task you've finished. Releases the task's scope and clears its chain-fact context. Re-completing a completed task returns 409 INVALID_STATE.",
+			"body":    nil,
 		},
 	})
 }

--- a/internal/api/handlers/control_test.go
+++ b/internal/api/handlers/control_test.go
@@ -200,3 +200,72 @@ func TestControlListTasksReturnsAgentActiveTasksAndCheckout(t *testing.T) {
 		t.Fatalf("expected checkout guidance, got %q", payload.NextStep)
 	}
 }
+
+// TestControlCapabilitiesAdvertisesCompleteEndpoint locks in the new
+// /control/tasks/{id}/complete entry in Capabilities. Without it the
+// agent has no discoverable signal that the endpoint exists outside
+// the system-prompt notice.
+func TestControlCapabilitiesAdvertisesCompleteEndpoint(t *testing.T) {
+	h := NewLLMControlHandler("http://localhost:25297")
+	req := httptest.NewRequest(http.MethodGet, "/api/control/capabilities", nil)
+	res := httptest.NewRecorder()
+
+	h.Capabilities(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("Capabilities status=%d body=%s", res.Code, res.Body.String())
+	}
+	var payload struct {
+		Endpoints []map[string]string `json:"endpoints"`
+	}
+	if err := json.Unmarshal(res.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode capabilities: %v", err)
+	}
+	var found map[string]string
+	for _, ep := range payload.Endpoints {
+		if ep["path"] == "/control/tasks/{id}/complete" {
+			found = ep
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("expected /control/tasks/{id}/complete in endpoints; got %+v", payload.Endpoints)
+	}
+	if found["method"] != "POST" {
+		t.Errorf("complete endpoint method = %q, want POST", found["method"])
+	}
+	if !strings.Contains(strings.ToLower(found["purpose"]), "complete") {
+		t.Errorf("complete endpoint purpose should mention 'complete'; got %q", found["purpose"])
+	}
+}
+
+// TestControlSkillExposesCompleteTaskBlock locks in the complete_task
+// block in the Skill payload. The Skill surface is the per-action
+// schema the agent reads when it wants to know "what's the exact
+// request shape?".
+func TestControlSkillExposesCompleteTaskBlock(t *testing.T) {
+	h := NewLLMControlHandler("http://localhost:25297")
+	req := httptest.NewRequest(http.MethodGet, "/api/control/skill", nil)
+	res := httptest.NewRecorder()
+
+	h.Skill(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("Skill status=%d body=%s", res.Code, res.Body.String())
+	}
+	var payload struct {
+		CompleteTask map[string]any `json:"complete_task"`
+	}
+	if err := json.Unmarshal(res.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode skill: %v", err)
+	}
+	if payload.CompleteTask == nil {
+		t.Fatalf("expected complete_task block in skill payload; got %s", res.Body.String())
+	}
+	if got, _ := payload.CompleteTask["method"].(string); got != "POST" {
+		t.Errorf("complete_task method = %q, want POST", got)
+	}
+	if got, _ := payload.CompleteTask["path"].(string); got != "/control/tasks/{id}/complete" {
+		t.Errorf("complete_task path = %q, want /control/tasks/{id}/complete", got)
+	}
+}

--- a/internal/api/handlers/tasks.go
+++ b/internal/api/handlers/tasks.go
@@ -1975,7 +1975,20 @@ func (h *TasksHandler) denyTaskInState(ctx context.Context, taskID, fromStatus s
 // Complete marks a task as finished.
 //
 // POST /api/tasks/{id}/complete
-// Auth: agent bearer token
+// POST /api/control/tasks/{id}/complete
+// Auth: agent bearer token (dashboard) or proxy-minted caller nonce (control).
+//
+// Accepts tasks in either "active" or "expired" state — an expired task
+// still owns chain-fact rows that should be cleaned up on the agent's
+// wrap-up call. The status transition is CAS-guarded by
+// UpdateTaskStatusFrom so a parallel expand / revoke / expiration sweep
+// between the preflight read and the write cannot be silently
+// overwritten. Ownership is pinned to both the task's user AND its
+// agent: the dashboard surface routes through the user's own session
+// (so agent identity is implicit), but the control plane elevates this
+// to a real per-agent boundary — another agent under the same user
+// must not be able to close out (and DROP chain facts for) a task it
+// does not own.
 func (h *TasksHandler) Complete(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	agent := middleware.AgentFromContext(ctx)
@@ -1994,17 +2007,34 @@ func (h *TasksHandler) Complete(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not get task")
 		return
 	}
-	if task.UserID != agent.UserID {
+	if task.UserID != agent.UserID || task.AgentID != agent.ID {
 		writeError(w, http.StatusForbidden, "FORBIDDEN", "not your task")
 		return
 	}
-	if task.Status != "active" {
-		writeError(w, http.StatusConflict, "INVALID_STATE", "task is not active")
+	if task.Status != "active" && task.Status != "expired" {
+		writeError(w, http.StatusConflict, "INVALID_STATE", "task is not active or expired (status: "+task.Status+")")
 		return
 	}
 
-	if err := h.st.UpdateTaskStatus(ctx, taskID, "completed"); err != nil {
+	won, err := h.st.UpdateTaskStatusFrom(ctx, taskID, task.Status, "completed")
+	if err != nil {
 		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not complete task")
+		return
+	}
+	if !won {
+		// Lost the CAS — re-read the task to surface the live status to
+		// the caller so the agent can react (e.g. expand-then-complete
+		// flipped the row to pending_scope_expansion between read and
+		// write). A failed re-read falls back to the generic message.
+		liveStatus := ""
+		if live, livErr := h.st.GetTask(ctx, taskID); livErr == nil && live != nil {
+			liveStatus = live.Status
+		}
+		msg := "task moved to a non-completable state"
+		if liveStatus != "" {
+			msg = "task moved to " + liveStatus + " before completion"
+		}
+		writeError(w, http.StatusConflict, "INVALID_STATE", msg)
 		return
 	}
 	if err := h.st.DeleteChainFactsByTask(ctx, taskID); err != nil {

--- a/internal/api/handlers/tasks.go
+++ b/internal/api/handlers/tasks.go
@@ -2021,15 +2021,39 @@ func (h *TasksHandler) Complete(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not complete task")
 		return
 	}
+	liveStatus := ""
 	if !won {
-		// Lost the CAS — re-read the task to surface the live status to
-		// the caller so the agent can react (e.g. expand-then-complete
-		// flipped the row to pending_scope_expansion between read and
-		// write). A failed re-read falls back to the generic message.
-		liveStatus := ""
-		if live, livErr := h.st.GetTask(ctx, taskID); livErr == nil && live != nil {
+		// Lost the CAS — re-read the task. Two cases:
+		//
+		//   (a) The live status is still one we accept (active or
+		//       expired). The most common driver is the expiration
+		//       sweeper flipping active → expired between preflight
+		//       and the CAS write; that's a benign race we should
+		//       absorb, not surface as a 409 — the agent's call is
+		//       still valid and chain-fact cleanup still needs to
+		//       run. Retry the CAS once with the live fromStatus.
+		//   (b) The live status is non-completable (pending_scope_
+		//       expansion, revoked, denied, already completed). The
+		//       agent needs to react; 409 with the live status in
+		//       the message.
+		//
+		// The retry is bounded to a single attempt: if it also loses,
+		// fall through to the 409 branch with whatever status the
+		// re-read observed. This avoids an unbounded loop if multiple
+		// in-flight callers race.
+		live, livErr := h.st.GetTask(ctx, taskID)
+		if livErr == nil && live != nil {
 			liveStatus = live.Status
+			if live.Status == "active" || live.Status == "expired" {
+				won, err = h.st.UpdateTaskStatusFrom(ctx, taskID, live.Status, "completed")
+				if err != nil {
+					writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not complete task")
+					return
+				}
+			}
 		}
+	}
+	if !won {
 		msg := "task moved to a non-completable state"
 		if liveStatus != "" {
 			msg = "task moved to " + liveStatus + " before completion"

--- a/internal/api/handlers/tasks_complete_test.go
+++ b/internal/api/handlers/tasks_complete_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 
 	runtimetasks "github.com/clawvisor/clawvisor/internal/runtime/tasks"
@@ -240,6 +241,72 @@ func TestComplete_UnknownTask_Returns404(t *testing.T) {
 	h.Complete(rec, newCompleteRequest("does-not-exist", agent))
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("Complete status = %d, want 404; body = %s", rec.Code, rec.Body.String())
+	}
+}
+
+// flipActiveToExpiredOnFirstCASStore is a store wrapper that
+// deterministically reproduces the active → expired race between the
+// Complete handler's preflight read and its CAS write. On the first
+// "active → completed" CAS, it flips the underlying row to expired
+// and returns won=false; subsequent CAS calls pass through to the
+// real store unchanged.
+type flipActiveToExpiredOnFirstCASStore struct {
+	store.Store
+	mu      sync.Mutex
+	flipped bool
+}
+
+func (w *flipActiveToExpiredOnFirstCASStore) UpdateTaskStatusFrom(ctx context.Context, id, from, to string) (bool, error) {
+	w.mu.Lock()
+	intercept := !w.flipped && from == "active" && to == "completed"
+	if intercept {
+		w.flipped = true
+	}
+	w.mu.Unlock()
+	if intercept {
+		// Simulate the expiration sweeper flipping the row mid-flight.
+		// The underlying CAS still uses the real store so the row
+		// actually moves to expired — the handler's next GetTask will
+		// observe that on the retry path.
+		if _, err := w.Store.UpdateTaskStatusFrom(ctx, id, "active", "expired"); err != nil {
+			return false, err
+		}
+		return false, nil
+	}
+	return w.Store.UpdateTaskStatusFrom(ctx, id, from, to)
+}
+
+// TestComplete_ActiveToExpiredRace_RetriesAndSucceeds locks in the
+// fix for the active→expired benign race. Before the retry, this
+// scenario would 409 — the preflight accepted active, the CAS pinned
+// fromStatus=active, the expiration sweeper raced in between, and the
+// CAS lost despite expired being an equally-valid pre-complete state.
+// Worse, chain-fact cleanup also got skipped.
+//
+// The fix: on CAS loss, re-read the live status; if it's still
+// completable (active or expired), retry the CAS once with the live
+// fromStatus.
+func TestComplete_ActiveToExpiredRace_RetriesAndSucceeds(t *testing.T) {
+	h, realStore, _, agent := newInlineTasksHandlerForTest(t)
+	task := seedActiveTask(t, h, agent, "race-active-to-expired")
+
+	// Swap in the wrapper for the Complete call only. Seeding through
+	// the real store first avoids interference with task creation,
+	// which also exercises UpdateTaskStatusFrom under the hood.
+	h.st = &flipActiveToExpiredOnFirstCASStore{Store: realStore}
+
+	rec := httptest.NewRecorder()
+	h.Complete(rec, newCompleteRequest(task.ID, agent))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Complete status = %d, want 200 (active→expired race must NOT surface as 409); body = %s", rec.Code, rec.Body.String())
+	}
+	persisted, err := realStore.GetTask(context.Background(), task.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if persisted.Status != "completed" {
+		t.Errorf("persisted status = %q, want completed", persisted.Status)
 	}
 }
 

--- a/internal/api/handlers/tasks_complete_test.go
+++ b/internal/api/handlers/tasks_complete_test.go
@@ -1,0 +1,257 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	runtimetasks "github.com/clawvisor/clawvisor/internal/runtime/tasks"
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+// seedActiveTask creates an inline-approved active task owned by the
+// given agent and returns its row. Mirrors the setup the other tests
+// use so we exercise the same approval path that produces tasks in
+// production.
+func seedActiveTask(t *testing.T, h *TasksHandler, agent *store.Agent, purpose string) *store.Task {
+	t.Helper()
+	ctx := context.Background()
+	req := &runtimetasks.TaskCreateRequest{
+		Purpose: purpose,
+		ExpectedTools: []runtimetasks.ExpectedTool{
+			{ToolName: "Bash", Why: "Test command"},
+		},
+		IntentVerificationMode: "strict",
+		ExpiresInSeconds:       600,
+	}
+	out, err := h.CreateInlineApprovedTask(ctx, agent, req, "cv-test-tooluse-"+strings.ReplaceAll(purpose, " ", "-"))
+	if err != nil {
+		t.Fatalf("CreateInlineApprovedTask: %v", err)
+	}
+	task, err := h.st.GetTask(ctx, out.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	return task
+}
+
+func newCompleteRequest(taskID string, agent *store.Agent) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, "/api/tasks/"+taskID+"/complete", nil)
+	req.SetPathValue("id", taskID)
+	req = req.WithContext(store.WithAgent(req.Context(), agent))
+	return req
+}
+
+func TestComplete_HappyPath_ActiveTask(t *testing.T) {
+	h, st, _, agent := newInlineTasksHandlerForTest(t)
+	task := seedActiveTask(t, h, agent, "rename foo to bar")
+
+	rec := httptest.NewRecorder()
+	h.Complete(rec, newCompleteRequest(task.ID, agent))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Complete status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v; body = %s", err, rec.Body.String())
+	}
+	if resp["task_id"] != task.ID || resp["status"] != "completed" {
+		t.Errorf("response = %v, want {task_id:%q, status:completed}", resp, task.ID)
+	}
+	persisted, err := st.GetTask(context.Background(), task.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if persisted.Status != "completed" {
+		t.Errorf("persisted status = %q, want completed", persisted.Status)
+	}
+}
+
+// TestComplete_HappyPath_ExpiredTask covers the "expired but not yet
+// completed" case: the timer ticked over before the agent could call
+// complete. The handler still accepts it so chain-fact cleanup runs —
+// without this the closed-task facts linger until the GC sweep.
+func TestComplete_HappyPath_ExpiredTask(t *testing.T) {
+	h, st, _, agent := newInlineTasksHandlerForTest(t)
+	ctx := context.Background()
+	task := seedActiveTask(t, h, agent, "expired task")
+
+	// Force the row to expired. Done out-of-band to avoid coupling to
+	// the expiration sweeper's clock.
+	if won, err := st.UpdateTaskStatusFrom(ctx, task.ID, "active", "expired"); err != nil || !won {
+		t.Fatalf("setup: flip task to expired: won=%v err=%v", won, err)
+	}
+
+	rec := httptest.NewRecorder()
+	h.Complete(rec, newCompleteRequest(task.ID, agent))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Complete status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	persisted, _ := st.GetTask(ctx, task.ID)
+	if persisted.Status != "completed" {
+		t.Errorf("persisted status = %q, want completed (expired → completed must succeed)", persisted.Status)
+	}
+}
+
+func TestComplete_AlreadyCompleted_Returns409(t *testing.T) {
+	h, _, _, agent := newInlineTasksHandlerForTest(t)
+	task := seedActiveTask(t, h, agent, "double-complete")
+
+	// First complete: succeeds.
+	rec := httptest.NewRecorder()
+	h.Complete(rec, newCompleteRequest(task.ID, agent))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("first Complete status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+
+	// Second complete: 409 INVALID_STATE — task is not active/expired.
+	rec2 := httptest.NewRecorder()
+	h.Complete(rec2, newCompleteRequest(task.ID, agent))
+	if rec2.Code != http.StatusConflict {
+		t.Fatalf("second Complete status = %d, want 409; body = %s", rec2.Code, rec2.Body.String())
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(rec2.Body.Bytes(), &resp)
+	if resp["code"] != "INVALID_STATE" {
+		t.Errorf("code = %v, want INVALID_STATE", resp["code"])
+	}
+}
+
+// TestComplete_PendingScopeExpansion_LosesCAS is the regression bar
+// for the CAS fix: a task that flipped to pending_scope_expansion
+// between the preflight read and the write must NOT be silently
+// overwritten with "completed".
+//
+// We can't actually race the read/write in a unit test, so we simulate
+// the racing branch by driving the row to pending_scope_expansion
+// before calling Complete. The preflight check at status != active &&
+// status != expired catches it first; the CAS branch is reached only
+// when the row was active at preflight but flipped before the write.
+// Either path returns 409 — that's the contract.
+func TestComplete_PendingScopeExpansion_Returns409(t *testing.T) {
+	h, st, _, agent := newInlineTasksHandlerForTest(t)
+	ctx := context.Background()
+	task := seedActiveTask(t, h, agent, "expand-then-complete")
+
+	if won, err := st.UpdateTaskStatusFrom(ctx, task.ID, "active", "pending_scope_expansion"); err != nil || !won {
+		t.Fatalf("setup: flip task to pending_scope_expansion: won=%v err=%v", won, err)
+	}
+
+	rec := httptest.NewRecorder()
+	h.Complete(rec, newCompleteRequest(task.ID, agent))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("Complete status = %d, want 409; body = %s", rec.Code, rec.Body.String())
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	errMsg, _ := resp["error"].(string)
+	if !strings.Contains(errMsg, "pending_scope_expansion") {
+		t.Errorf("error message should surface the live status so the agent can react; got %q", errMsg)
+	}
+
+	// Critical: the row's status must NOT have been clobbered.
+	persisted, _ := st.GetTask(ctx, task.ID)
+	if persisted.Status != "pending_scope_expansion" {
+		t.Fatalf("blind status overwrite regression: status = %q, want pending_scope_expansion preserved", persisted.Status)
+	}
+}
+
+// TestComplete_RevokedTask_Returns409 covers the user-revocation race.
+// A task the user explicitly revoked must NOT be overwritten by a
+// concurrent agent complete — the revoke decision is authoritative.
+func TestComplete_RevokedTask_Returns409(t *testing.T) {
+	h, st, user, agent := newInlineTasksHandlerForTest(t)
+	ctx := context.Background()
+	task := seedActiveTask(t, h, agent, "revoke-then-complete")
+
+	if err := st.RevokeTask(ctx, task.ID, user.ID); err != nil {
+		t.Fatalf("setup: RevokeTask: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	h.Complete(rec, newCompleteRequest(task.ID, agent))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("Complete status = %d, want 409; body = %s", rec.Code, rec.Body.String())
+	}
+	persisted, _ := st.GetTask(ctx, task.ID)
+	if persisted.Status != "revoked" {
+		t.Fatalf("revoke overwrite regression: status = %q, want revoked preserved", persisted.Status)
+	}
+}
+
+// TestComplete_CrossAgent_Returns403 is the regression bar for the
+// task.AgentID pin. Before this change Complete only checked UserID,
+// so a sibling agent under the same user could close out (and delete
+// chain facts for) a task it did not create.
+func TestComplete_CrossAgent_Returns403(t *testing.T) {
+	h, st, user, agentA := newInlineTasksHandlerForTest(t)
+	ctx := context.Background()
+
+	agentB, err := st.CreateAgent(ctx, user.ID, "sibling-agent", "token-hash-b")
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	task := seedActiveTask(t, h, agentA, "agentA's task")
+
+	rec := httptest.NewRecorder()
+	h.Complete(rec, newCompleteRequest(task.ID, agentB))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("Complete status = %d, want 403 (cross-agent); body = %s", rec.Code, rec.Body.String())
+	}
+
+	// Task must remain active — the wrong agent's complete must not
+	// have any side effect on the row.
+	persisted, _ := st.GetTask(ctx, task.ID)
+	if persisted.Status != "active" {
+		t.Errorf("cross-agent complete had side effect: status = %q, want active", persisted.Status)
+	}
+}
+
+func TestComplete_CrossUser_Returns403(t *testing.T) {
+	h, st, _, agentA := newInlineTasksHandlerForTest(t)
+	ctx := context.Background()
+
+	otherUser, err := st.CreateUser(ctx, "other-user@test.example", "hash")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	agentB, err := st.CreateAgent(ctx, otherUser.ID, "other-user-agent", "other-token-hash")
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	task := seedActiveTask(t, h, agentA, "cross-user")
+	rec := httptest.NewRecorder()
+	h.Complete(rec, newCompleteRequest(task.ID, agentB))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("Complete status = %d, want 403 (cross-user); body = %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestComplete_UnknownTask_Returns404(t *testing.T) {
+	h, _, _, agent := newInlineTasksHandlerForTest(t)
+	rec := httptest.NewRecorder()
+	h.Complete(rec, newCompleteRequest("does-not-exist", agent))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("Complete status = %d, want 404; body = %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestComplete_Unauthenticated_Returns401(t *testing.T) {
+	h, _, _, _ := newInlineTasksHandlerForTest(t)
+	req := httptest.NewRequest(http.MethodPost, "/api/tasks/some-id/complete", nil)
+	req.SetPathValue("id", "some-id")
+	// Intentionally no store.WithAgent.
+
+	rec := httptest.NewRecorder()
+	h.Complete(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("Complete status = %d, want 401; body = %s", rec.Code, rec.Body.String())
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1395,6 +1395,7 @@ func (s *Server) registerLiteProxyRoutes(
 		mux.Handle("POST /api/control/task/checkout", requireAgentLLMCaller(e2e(http.HandlerFunc(controlHandler.CheckoutTask))))
 		mux.Handle("GET /api/control/tasks/{id}", requireAgentLLMCaller(e2e(http.HandlerFunc(tasksHandler.Get))))
 		mux.Handle("POST /api/control/tasks/{id}/expand", requireAgentLLMCaller(e2e(http.HandlerFunc(tasksHandler.Expand))))
+		mux.Handle("POST /api/control/tasks/{id}/complete", requireAgentLLMCaller(e2e(http.HandlerFunc(tasksHandler.Complete))))
 		mux.Handle("GET /api/control/vault/items", requireAgentLLMCaller(e2e(http.HandlerFunc(vaultHandler.ListForAgent))))
 		mux.Handle("GET /api/control/vault/items/{id}", requireAgentLLMCaller(e2e(http.HandlerFunc(vaultHandler.GetForAgent))))
 		// AutovaultScriptDocs is intentionally unauthenticated, matching

--- a/internal/runtime/llmproxy/controltool/control.go
+++ b/internal/runtime/llmproxy/controltool/control.go
@@ -61,6 +61,7 @@ func controlNotice(controlBaseURL string, availableTools []string, toolRules []*
 	// active task's id — the URL is a template, not a fixed endpoint.
 	expandURL := tasksURL + "/<id>/expand"
 	expandURLInline := expandURL + "?surface=inline"
+	completeURL := tasksURL + "/<id>/complete"
 	toolExamples := controlToolExamples(availableTools)
 	shellTool := controlShellTool(availableTools)
 	shellToolExample := shellTool
@@ -87,9 +88,10 @@ func controlNotice(controlBaseURL string, availableTools []string, toolRules []*
 		"",
 		"SCOPE DRIFT — a control-plane action is needed when the user's follow-up, or what you've discovered while executing, SHIFTS the work outside the active task's scope: tools you didn't declare in `expected_tools`, files or services unrelated to the task's stated purpose, or a genuinely different goal. Adjacent edits that continue the same purpose stay under the existing task — that's iteration, not drift. (E.g., a \"rename Foo to Bar in src/foo.go\" task covers updating doc comments and fixing related typos in the same file with the same Edit tool. \"Now also delete src/helpers.go\" or \"now send a Slack message\" are scope shifts and need a control-plane action.) Don't quietly run drifted work under the old task's authorization, and don't wait for a tool call to be refused — pick the right control-plane action below.",
 		"",
-		"EXPAND vs NEW TASK — when SCOPE DRIFT says you need control-plane action, choose between expanding the active task and creating a new one:",
+		"EXPAND vs NEW TASK vs COMPLETE — when SCOPE DRIFT says you need control-plane action, choose between expanding the active task, completing it, and creating a new one:",
 		"  - Same body of work, just need MORE capability under the existing purpose → POST " + expandURLInline + " (interactive user) or POST " + expandURL + "?wait=true (headless). The active task stays alive; merged scope lands on approve. Session tasks get a refreshed deadline; standing tasks stay standing. (E.g., the active task is \"Refactor src/foo.go\" and now also needs Edit on src/bar.go: expand with the missing tool.)",
-		"  - Genuinely different goal (the active task's stated purpose no longer describes what you're doing) → POST a NEW task. (E.g., active task is \"Refactor src/foo.go\" and the user now says \"also send a Slack summary\": purpose has changed; new task.)",
+		"  - Genuinely different goal AND the prior work is finished → POST " + completeURL + " to close the prior task, THEN POST a NEW task for the new goal. (E.g., the rename task is done and the user now says \"also send a Slack summary\": complete the rename, create a fresh task for the Slack work.) Do NOT complete a task you intend to resume — completion is final and the scope cannot be reopened.",
+		"  - Genuinely different goal AND the prior work is still in flight → just POST a NEW task without completing. (E.g., mid-refactor the user adds a tangent that needs its own approval; the refactor task stays open.) Multiple active tasks are fine; checkout disambiguates them.",
 		"  - Expansion preserves the parent task's lifetime — a standing task stays standing after an approved expansion. The user sees the lifetime in the approval prompt; choose expand on a standing task only when the new scope genuinely belongs to the same recurring/permanent work.",
 		"",
 		"Expand body — mirrors task creation MINUS `purpose`, `lifetime`, `expires_in_seconds` (purpose and lifetime are preserved; the deadline refreshes on approve). `reason` is required and is surfaced verbatim in the approval prompt. The three envelope arrays are INDEPENDENTLY optional — a credentials-only expansion is valid:",
@@ -176,6 +178,10 @@ func controlNotice(controlBaseURL string, availableTools []string, toolRules []*
 		"   \"intent_verification_mode\":\"strict\",",
 		"   \"expires_in_seconds\":600}",
 		"  JSON",
+		"",
+		"Canonical completion curl (no body required; completion is unilateral — the proxy does NOT ask the user):",
+		"  curl -sS -X POST '" + completeURL + "'",
+		"Re-completing an already-completed task returns 409 INVALID_STATE; expired tasks are still completable so chain-fact cleanup runs.",
 	}, "\n")
 }
 

--- a/internal/runtime/llmproxy/controltool/control.go
+++ b/internal/runtime/llmproxy/controltool/control.go
@@ -1263,6 +1263,14 @@ func controlMethodForCall(path string, body []byte) string {
 	if strings.HasSuffix(path, "/tasks") && len(body) > 0 {
 		return "POST"
 	}
+	// Body-less POSTs need an explicit method hint here, because the
+	// nonce minter consumes this verdict and binds the token to the
+	// (host, method, path) tuple. Bare `curl https://.../complete`
+	// without -X POST would otherwise mint a GET nonce and 403 with
+	// NONCE_TARGET_MISMATCH when the daemon dispatches POST.
+	if strings.HasSuffix(path, "/complete") {
+		return "POST"
+	}
 	return "GET"
 }
 

--- a/internal/runtime/llmproxy/controltool/control_multistmt_test.go
+++ b/internal/runtime/llmproxy/controltool/control_multistmt_test.go
@@ -107,6 +107,74 @@ func TestParseControlToolUse_TasksCurlWithBodyIsPOST(t *testing.T) {
 	}
 }
 
+// TestParseControlToolUse_BodylessCompleteCurlIsPOST is the
+// end-to-end regression for the control-plane completion path.
+// Without this, a bare `curl https://.../complete` would mint a GET
+// nonce (controlMethodForCall's default), the daemon would dispatch
+// POST, and the middleware would 403 with NONCE_TARGET_MISMATCH.
+// The explicit /complete rule in controlMethodForCall ensures the
+// verdict reaches the minter as POST regardless of -X presence.
+func TestParseControlToolUse_BodylessCompleteCurlIsPOST(t *testing.T) {
+	tu := conversation.ToolUse{
+		ID:    "tu_1",
+		Name:  "Bash",
+		Input: json.RawMessage(`{"command":"curl -sS https://clawvisor.local/control/tasks/task-abc/complete"}`),
+	}
+
+	call, ok := ParseControlToolUse(tu)
+	if !ok {
+		t.Fatal("expected control call to parse")
+	}
+	if call.Method != "POST" {
+		t.Fatalf("method=%q, want POST for bodyless complete curl", call.Method)
+	}
+	if call.Verdict.Method != "POST" {
+		t.Fatalf("verdict method=%q, want POST", call.Verdict.Method)
+	}
+	if !strings.HasSuffix(call.URL.Path, "/api/control/tasks/task-abc/complete") {
+		t.Fatalf("URL path = %q, want suffix /api/control/tasks/task-abc/complete", call.URL.Path)
+	}
+}
+
+// TestRewriteControlToolUse_CompleteCurlInjectsCallerAuth covers the
+// rewrite shape the agent's tool_use actually goes through: the
+// synthetic clawvisor.local URL becomes the real daemon URL, the
+// minted caller nonce lands in X-Clawvisor-Caller, and the method
+// stays POST. This is the test the design called out (test 14) as the
+// concrete regression for the rewriter+nonce binding on completion.
+func TestRewriteControlToolUse_CompleteCurlInjectsCallerAuth(t *testing.T) {
+	tu := conversation.ToolUse{
+		ID:   "tu_1",
+		Name: "Bash",
+		Input: json.RawMessage(`{
+			"command": "curl -sS -X POST https://clawvisor.local/control/tasks/task-abc/complete"
+		}`),
+	}
+	const minted = "cv-nonce-complete-xyz"
+	rewritten, verdict, ok, err := RewriteControlToolUse(tu, "https://clawvisor.example", minted)
+	if err != nil || !ok {
+		t.Fatalf("expected rewrite to succeed, got ok=%v err=%v", ok, err)
+	}
+	if verdict.Method != "POST" {
+		t.Errorf("verdict method = %q, want POST", verdict.Method)
+	}
+	cmd := string(rewritten)
+	if !strings.Contains(cmd, minted) {
+		t.Errorf("rewritten command should embed the minted caller nonce; got %s", cmd)
+	}
+	if !strings.Contains(cmd, "/api/control/tasks/task-abc/complete") {
+		t.Errorf("rewritten command should target the daemon's /api/control/.../complete path; got %s", cmd)
+	}
+	// The URL itself is rewritten away from clawvisor.local, but the
+	// rewriter still records the synthetic host in an
+	// X-Clawvisor-Target-Host header so the daemon knows which
+	// target the original tool_use was for. Assert the URL flip
+	// happened (no clawvisor.local *URL*) without flagging the header.
+	if strings.Contains(cmd, "https://clawvisor.local") {
+		t.Errorf("rewritten command's URL should no longer be the synthetic host; got %s", cmd)
+	}
+}
+
 func TestParseControlCmd_MultiStmtCatHeredocPlusCurl(t *testing.T) {
 	args, dataFiles, ok := parseControlCmd(multiStmtCatCurlCmd)
 	if !ok {

--- a/internal/runtime/llmproxy/controltool/control_test.go
+++ b/internal/runtime/llmproxy/controltool/control_test.go
@@ -307,3 +307,34 @@ func TestSanitizeControlFailureCommandRedactsRawBearerButKeepsPlaceholder(t *tes
 		t.Fatalf("autovault placeholder should remain visible to the model, got %q", got)
 	}
 }
+
+// TestControlMethodForCall_CompletePathDefaultsToPOST is the regression
+// bar for the nonce-target binding on POST /control/tasks/{id}/complete.
+// Without this rule, a bare `curl https://.../complete` (no -X POST, no
+// body) would mint a GET nonce, the daemon would dispatch POST, and the
+// middleware would 403 with NONCE_TARGET_MISMATCH. The canonical curl
+// in the control notice does include -X POST so the rule only catches
+// the half-baked-shell case, but it's load-bearing for that case.
+func TestControlMethodForCall_CompletePathDefaultsToPOST(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		body []byte
+		want string
+	}{
+		{"complete with no body defaults POST", "/api/control/tasks/abc/complete", nil, "POST"},
+		{"complete with body defaults POST", "/api/control/tasks/abc/complete", []byte("{}"), "POST"},
+		{"tasks POST is unchanged", "/api/control/tasks", []byte("{}"), "POST"},
+		{"tasks GET is unchanged when no body", "/api/control/tasks", nil, "GET"},
+		{"task get-by-id is GET", "/api/control/tasks/abc", nil, "GET"},
+		{"unrelated path falls back to GET", "/api/control/skill", nil, "GET"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := controlMethodForCall(tc.path, tc.body)
+			if got != tc.want {
+				t.Errorf("controlMethodForCall(%q, body=%v) = %q, want %q", tc.path, tc.body, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/runtime/llmproxy/controltool/control_test.go
+++ b/internal/runtime/llmproxy/controltool/control_test.go
@@ -308,6 +308,35 @@ func TestSanitizeControlFailureCommandRedactsRawBearerButKeepsPlaceholder(t *tes
 	}
 }
 
+// TestControlNotice_TeachesAgentAboutCompletion covers the COMPLETING
+// guidance: the synthetic /complete URL appears in the EXPAND vs NEW
+// TASK vs COMPLETE decision tree, AND a canonical curl block exists
+// near the end so the agent has an explicit example. The "don't
+// complete a task you intend to resume" framing prevents the thrash
+// failure mode where the agent closes scope between sibling sub-steps.
+func TestControlNotice_TeachesAgentAboutCompletion(t *testing.T) {
+	notice := ControlNotice("http://localhost:25297", []string{"Bash", "Edit", "Read"})
+
+	if !strings.Contains(notice, "EXPAND vs NEW TASK vs COMPLETE") {
+		t.Fatalf("decision tree heading should integrate COMPLETE as a third branch; got:\n%s", notice)
+	}
+	if !strings.Contains(notice, "https://clawvisor.local/control/tasks/<id>/complete") {
+		t.Fatalf("notice should embed the synthetic complete URL so the agent has a deterministic shape to emit; got:\n%s", notice)
+	}
+	if !strings.Contains(notice, "Do NOT complete a task you intend to resume") {
+		t.Fatalf("notice should warn against premature completion to prevent task thrashing; got:\n%s", notice)
+	}
+	if !strings.Contains(notice, "Canonical completion curl") {
+		t.Fatalf("notice should include a canonical completion curl block; got:\n%s", notice)
+	}
+	// Sanity: the rule against `cv-nonce-...` must still be present
+	// — completion shares the rewrite path, and a future careless
+	// edit to the decision tree could drop the surrounding rules.
+	if !strings.Contains(notice, "NEVER write `cv-nonce-...`") {
+		t.Fatalf("notice should still embed the cv-nonce-... prohibition rule; got:\n%s", notice)
+	}
+}
+
 // TestControlMethodForCall_CompletePathDefaultsToPOST is the regression
 // bar for the nonce-target binding on POST /control/tasks/{id}/complete.
 // Without this rule, a bare `curl https://.../complete` (no -X POST, no


### PR DESCRIPTION
## Summary

Restores an in-band way for LLM-proxy agents to signal "this task is done." The legacy gateway-based product taught the agent `complete_task` via an installed skill; with the LLM proxy that surface vanished. This PR exposes the existing `Complete` handler through the control plane (`POST /api/control/tasks/{id}/complete`), tightens its race-safety and ownership checks, teaches the agent about it in the system-prompt control notice, and lists it in the control catalog.

The 7 commits land in dependency order so each is independently revertable:

1. **`fix(tasks): make Complete race-safe and pin task ownership to the calling agent`** — switch the existing `Complete` handler to `UpdateTaskStatusFrom` (CAS), add `task.AgentID == agent.ID` ownership pin, accept `expired` as a valid pre-complete state so chain-fact cleanup still runs. Fixes two latent gaps that were harmless on the dashboard surface but become real on the control plane.
2. **`feat(api): expose POST /api/control/tasks/{id}/complete`** — mount the new route alongside the existing control-plane task aliases.
3. **`fix(llmproxy): default POST for body-less control /complete curls`** — `controlMethodForCall` now returns POST for paths ending in `/complete`, so a bare `curl https://.../complete` (no `-X POST`) still mints a POST nonce instead of GET. Load-bearing for the nonce → middleware target binding.
4. **`feat(api): advertise /control/tasks/{id}/complete in the control catalog`** — Capabilities + Skill payloads expose `complete_task` so the agent can discover it without the system-prompt notice.
5. **`feat(llmproxy): teach the agent how to complete a task in the control notice`** — integrates COMPLETION into the existing EXPAND vs NEW TASK decision tree (with explicit "don't complete a task you intend to resume" framing to prevent thrashing), plus a canonical curl block. Invalidates the Anthropic prompt cache for all active LLM-proxy sessions on first render — kept as its own commit so the cost is auditable and revertable independently.
6. **`docs(lite-proxy): document POST /api/control/tasks/{id}/complete`** — one-line addition to `docs/LITE_PROXY.md`. `Test-skip: docs-only`.
7. **`test(llmproxy): cover the end-to-end rewrite shape for control complete`** — regression tests for the most fragile junction (rewriter binds the caller nonce to (host, method, path)).

## Architecture impact

No new packages, no new intercept layer, no new audit event. Fits the established "control-plane is an alias for dashboard handlers" pattern at `server.go:1392-1410`.

## Test plan

- [ ] CI passes (16 new tests across 4 files: 9 handler unit tests, 1 route registration, 2 catalog, 1 notice content, 1 method fallback, 2 rewriter regressions).
- [ ] End-to-end agent flow: with a running daemon and a Claude/Codex agent on the lite-proxy, give it a scoped task. After completion, observe `curl -sS -X POST 'https://clawvisor.local/control/tasks/<id>/complete'` in the tool stream; dashboard Tasks page shows the row flip to `completed`.
- [ ] Race-safety: drive a parent task to `pending_scope_expansion`, then call complete. Expect 409 with `task moved to pending_scope_expansion before completion`; row stays `pending_scope_expansion`.
- [ ] Cross-agent boundary: create a task with agent A, try to complete with agent B (same user). Expect 403; row stays `active`.
- [ ] Expired-task cleanup: create a task with a short TTL; wait for `expired`; call complete. Expect 200; chain facts deleted.
- [ ] Monitor for an expected one-time Anthropic prompt-cache miss spike on the first render of the updated control notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

