### PR TITLE
chore(web): allow dev.clawvisor.com host in Vite dev server

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -20,8 +20,11 @@ export default defineConfig({
     // it gated behind an explicit env var so the default localhost
     // dev experience is also strict against rebinding attacks. Vite
     // expects either `true` or `string[]`; `false` is not a documented
-    // value, so pass `[]` for the deny-all default instead.
-    allowedHosts: allowAllHosts ? true : [],
+    // value, so pass the dev hostnames explicitly for the strict default.
+    // dev.clawvisor.com resolves to 127.0.0.1 via /etc/hosts when running
+    // the local HTTPS terminator (scripts/dev.sh + Caddyfile), and the
+    // app's auth config requires that origin for WebAuthn/SAML/OAuth.
+    allowedHosts: allowAllHosts ? true : ['dev.clawvisor.com'],
     proxy: {
       '/api': backendURL,
       '/skill': backendURL,


### PR DESCRIPTION
## Summary
- Adds `dev.clawvisor.com` to Vite's `server.allowedHosts` so the dev server accepts requests proxied through the local HTTPS terminator on `https://dev.clawvisor.com:8443`.
- That origin is the one the app's auth config is pinned to (`PUBLIC_URL`, `WEBAUTHN_RP_ORIGIN`, `SAML_ENTITY_ID`, the Google OAuth client's registered redirect), so the browser has to hit it for sign-in to work; without this entry Vite rejects the proxied request by Host header.
- Paired with a cloud-repo PR that adds the Caddy reverse proxy and the preflight checks in `scripts/dev.sh`.

## Test plan
- [ ] In the cloud repo: `/etc/hosts` entry + `brew install caddy` + `sudo caddy trust` + `./scripts/dev.sh`
- [ ] Open `https://dev.clawvisor.com:8443` and confirm the SPA loads (no Vite host rejection page)
- [ ] Confirm a sign-in flow (passkey or Google) completes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

