### PR TITLE
feat(llmproxy): transient-deny verdicts + recoverable parser shape refusals

### DIFF
--- a/internal/api/handlers/llm_endpoint.go
+++ b/internal/api/handlers/llm_endpoint.go
@@ -111,6 +111,12 @@ type LLMEndpointHandler struct {
 	// constructor wires an in-memory registry by default.
 	ScopeDrifts llmproxy.ScopeDriftRegistry
 
+	// TransientBudget rations one-shot retries for Deny verdicts marked
+	// with a TransientFailureClass (judge timeout, nonce-mint hiccup,
+	// etc.). Optional — nil disables the promotion and transient
+	// failures surface as plain Deny. Default is an in-memory budget.
+	TransientBudget llmproxy.TransientBudget
+
 	// PendingSecrets buffers inbound requests that appear to contain raw
 	// secrets until the user decides whether to vault, discard, allow
 	// once, or mark them as non-secrets.
@@ -222,6 +228,7 @@ func NewLLMEndpointHandler(st store.Store, v vault.Vault, logger *slog.Logger) *
 		Logger:                 logger,
 		PendingApprovals:       llmproxy.NewMemoryPendingApprovalCache(10 * time.Minute),
 		ScopeDrifts:            llmproxy.NewMemoryScopeDriftRegistry(0),
+		TransientBudget:        llmproxy.NewMemoryTransientBudget(0),
 		PendingSecrets:         llmproxy.NewMemoryPendingSecretDecisionCache(10 * time.Minute),
 		InlineApprovalOutcomes: llmproxy.NewMemoryInlineApprovalOutcomeStore(24 * time.Hour),
 		ActiveTasksSnapshots:   llmproxy.NewMemoryActiveTasksSnapshotCache(24*time.Hour, 0),
@@ -1304,6 +1311,7 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 					EgressRules:     egressRules,
 					PreferredTaskID: preferredTaskID,
 				ScopeDrifts:     h.ScopeDrifts,
+				TransientBudget: h.TransientBudget,
 				},
 				ApprovalContext: llmproxy.ApprovalContext{
 					PendingApprovals:                 h.PendingApprovals,
@@ -1652,6 +1660,7 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 				EgressRules:     egressRules,
 				PreferredTaskID: preferredTaskID,
 				ScopeDrifts:     h.ScopeDrifts,
+				TransientBudget: h.TransientBudget,
 			},
 			ApprovalContext: llmproxy.ApprovalContext{
 				PendingApprovals:                 h.PendingApprovals,

--- a/internal/runtime/conversation/response.go
+++ b/internal/runtime/conversation/response.go
@@ -80,15 +80,16 @@ type ToolUseVerdict struct {
 
 	// TransientFailureClass, when non-empty, marks this Deny verdict as
 	// a one-shot retryable transient failure (LLM judge timeout, nonce-
-	// mint hiccup, decision-engine RPC blip). The postproc transient
-	// transform promotes the verdict to a RecoverableDeny on the first
-	// occurrence per (AgentID, ConversationID, class) and passes it
-	// through as a plain Deny on subsequent ones, so chronic failures
-	// still surface to the user.
+	// mint hiccup, decision-engine RPC blip). postproc.commitVerdictSideEffects
+	// promotes the verdict to a RecoverableDeny on the first occurrence
+	// per (AgentID, ConversationID, class) and passes it through as a
+	// plain Deny on subsequent ones, so chronic failures still surface
+	// to the user.
 	//
 	// Contract: same PRODUCER → POSTPROC signal as RecoverableReason.
 	// Evaluators set this field via TransientDenyVerdict and leave
-	// RecoverableReason empty; postproc.transformTransientDenyToRecoverable
+	// RecoverableReason empty; postproc.promoteTransients (called from
+	// commitVerdictSideEffects) consults the TransientBudget and
 	// decides whether to fill RecoverableReason based on the budget.
 	// Response rewriters MUST NOT branch on this field.
 	TransientFailureClass string

--- a/internal/runtime/conversation/response.go
+++ b/internal/runtime/conversation/response.go
@@ -78,6 +78,21 @@ type ToolUseVerdict struct {
 	// AuthorizationContext.ScopeDrifts).
 	RecoverableReason string
 
+	// TransientFailureClass, when non-empty, marks this Deny verdict as
+	// a one-shot retryable transient failure (LLM judge timeout, nonce-
+	// mint hiccup, decision-engine RPC blip). The postproc transient
+	// transform promotes the verdict to a RecoverableDeny on the first
+	// occurrence per (AgentID, ConversationID, class) and passes it
+	// through as a plain Deny on subsequent ones, so chronic failures
+	// still surface to the user.
+	//
+	// Contract: same PRODUCER → POSTPROC signal as RecoverableReason.
+	// Evaluators set this field via TransientDenyVerdict and leave
+	// RecoverableReason empty; postproc.transformTransientDenyToRecoverable
+	// decides whether to fill RecoverableReason based on the budget.
+	// Response rewriters MUST NOT branch on this field.
+	TransientFailureClass string
+
 	// CreatedTaskID names the inline task created by the
 	// conversation auto-approval gate. Carried so downstream audit
 	// rows can link to the same task_id.

--- a/internal/runtime/conversation/verdict.go
+++ b/internal/runtime/conversation/verdict.go
@@ -77,6 +77,30 @@ func RecoverableDenyVerdict(reason string, facts ...EvaluationFact) ToolUseVerdi
 	}
 }
 
+// TransientDenyVerdict builds a Deny verdict marked with a transient
+// failure class — a one-shot retryable failure the agent's correct
+// response is to re-emit the SAME tool_use unchanged (LLM judge
+// timeout, nonce-mint hiccup, decision-engine RPC error, etc.).
+//
+// The postproc transient transform decides at finalization time
+// whether to promote the verdict to a RecoverableDeny (first
+// occurrence per (agent, conversation, failureClass) within the budget
+// TTL) or leave it as a plain Deny (budget exhausted — chronic failure
+// should surface to the user).
+//
+// Distinct from RecoverableDenyVerdict: that path assumes the agent
+// must CHANGE the call shape (drop a flag, fix quotes). TransientDeny
+// assumes the call shape is fine and only retry is needed.
+func TransientDenyVerdict(failureClass, reason string, facts ...EvaluationFact) ToolUseVerdict {
+	return ToolUseVerdict{
+		Outcome:               OutcomeDeny,
+		Reason:                reason,
+		SubstituteWith:        reason,
+		TransientFailureClass: failureClass,
+		Facts:                 facts,
+	}
+}
+
 // InspectorVerdictSnapshot is the audit-row projection of the
 // inspector's verdict.
 type InspectorVerdictSnapshot = eval.InspectorVerdictSnapshot

--- a/internal/runtime/llmproxy/config.go
+++ b/internal/runtime/llmproxy/config.go
@@ -128,7 +128,12 @@ type AuthorizationContext struct {
 	// continuation menu. Nil disables the menu and falls back to the
 	// pre-existing inline approval prompt.
 	ScopeDrifts ScopeDriftRegistry
-	Catalog     interface {
+	// TransientBudget rations one-shot retries for Deny verdicts marked
+	// with a TransientFailureClass (judge timeout, nonce-mint hiccup,
+	// etc.). Nil disables the promotion and transient verdicts surface
+	// as plain Deny.
+	TransientBudget TransientBudget
+	Catalog         interface {
 		Resolve(host, method, path string) (ResolvedAction, bool)
 	}
 }

--- a/internal/runtime/llmproxy/inspector/parser.go
+++ b/internal/runtime/llmproxy/inspector/parser.go
@@ -238,6 +238,27 @@ func IsDefaultAllowedTool(name string) bool {
 	}
 }
 
+// ambiguousRecoverable builds the standard parser refusal verdict for
+// deterministic, agent-fixable shape problems: trailing `-X`/`-H`, body
+// that carries the placeholder, unknown curl flag, malformed URL,
+// structured-fetch placeholder outside known header credentials, etc.
+// All such refusals route through InspectorChain's RecoverableDeny
+// path so the agent gets a one-shot continuation retry instead of
+// falling through to OutcomeHold and stalling on human approval.
+//
+// Use this for any `Ambiguous=true` refusal whose Reason names a
+// concrete shape problem the model can correct by re-emitting the
+// tool_use with different inputs. Do NOT use it for refusals whose
+// fix requires user intervention (scope expansion, credential vaulting).
+func ambiguousRecoverable(reason string) Verdict {
+	return Verdict{
+		IsAPICall:        false,
+		Ambiguous:        true,
+		AgentRecoverable: true,
+		Reason:           reason,
+	}
+}
+
 // parseStructuredFetch handles tools whose input is a JSON object with a
 // declared `url` field (and optional method/headers). Recognized tool names:
 //
@@ -278,11 +299,7 @@ func parseStructuredFetch(t ToolUse) (Verdict, bool) {
 	// fall through to ambiguous — v1 only handles header credentials at
 	// the resolver.
 	if len(creds) == 0 {
-		return Verdict{
-			IsAPICall: false,
-			Ambiguous: true,
-			Reason:    "structured fetch: placeholder not in known header credential location",
-		}, true
+		return ambiguousRecoverable("structured fetch: placeholder not in known header credential location"), true
 	}
 
 	return Verdict{
@@ -345,10 +362,18 @@ func parseBashCurl(t ToolUse) (Verdict, bool) {
 
 	tokens, ok := simpleShellTokenize(normalizeShellLineContinuations(seg.text))
 	if !ok || len(tokens) == 0 {
+		// Unbalanced quotes (the tokenizer's only failure mode, see
+		// simpleShellTokenize) are a deterministic, agent-fixable shape
+		// problem — re-emitting the curl with a `--data @- <<'JSON' …`
+		// heredoc almost always clears it. Mark AgentRecoverable so the
+		// chain surfaces this as RecoverableDenyVerdict and the model
+		// gets a one-shot continuation retry, instead of falling through
+		// to OutcomeHold and stalling on human approval.
 		return Verdict{
-			IsAPICall: false,
-			Ambiguous: true,
-			Reason:    "bash: tokenizer rejected input",
+			IsAPICall:        false,
+			Ambiguous:        true,
+			AgentRecoverable: true,
+			Reason:           "bash: tokenizer rejected input",
 		}, true
 	}
 	if !isCurlInvocation(tokens[0]) {
@@ -367,14 +392,14 @@ func parseBashCurl(t ToolUse) (Verdict, bool) {
 		switch {
 		case tok == "-X" || tok == "--request":
 			if i+1 >= len(tokens) {
-				return Verdict{IsAPICall: false, Ambiguous: true, Reason: "bash: -X without value"}, true
+				return ambiguousRecoverable("bash: -X without value"), true
 			}
 			method = canonicalMethod(tokens[i+1])
 			explicitMethod = true
 			i += 2
 		case tok == "-H" || tok == "--header":
 			if i+1 >= len(tokens) {
-				return Verdict{IsAPICall: false, Ambiguous: true, Reason: "bash: -H without value"}, true
+				return ambiguousRecoverable("bash: -H without value"), true
 			}
 			name, value, ok := splitHeader(tokens[i+1])
 			if ok {
@@ -396,19 +421,19 @@ func parseBashCurl(t ToolUse) (Verdict, bool) {
 			// Value-taking flags that don't affect routing (`-A`, `-o`,
 			// `--max-time`, …). Consume the value too.
 			if i+1 >= len(tokens) {
-				return Verdict{IsAPICall: false, Ambiguous: true, Reason: "bash: " + tok + " without value"}, true
+				return ambiguousRecoverable("bash: " + tok + " without value"), true
 			}
 			i += 2
 		case isBodyCurlFlag(tok):
 			if i+1 >= len(tokens) {
-				return Verdict{IsAPICall: false, Ambiguous: true, Reason: "bash: " + tok + " without value"}, true
+				return ambiguousRecoverable("bash: " + tok + " without value"), true
 			}
 			// This only inspects the literal flag value. `@file` and
 			// `@-` bodies are accepted here because Clawvisor only
 			// rewrites header placeholders; if a body source contains a
 			// placeholder it will be sent upstream as an inert literal.
 			if headerMaybeContainsAutovaultPlaceholder(tokens[i+1]) {
-				return Verdict{IsAPICall: false, Ambiguous: true, Reason: "bash: placeholder not in -H header"}, true
+				return ambiguousRecoverable("bash: placeholder not in -H header"), true
 			}
 			if method == "GET" && !curlGet {
 				method = "POST"
@@ -418,31 +443,27 @@ func parseBashCurl(t ToolUse) (Verdict, bool) {
 		case strings.HasPrefix(tok, "-"):
 			// Unknown flag — could be an upload/form flag or a flag we
 			// don't safely model. Fall through to validator.
-			return Verdict{IsAPICall: false, Ambiguous: true, Reason: "bash: unknown curl flag " + tok}, true
+			return ambiguousRecoverable("bash: unknown curl flag " + tok), true
 		default:
 			positionals = append(positionals, tok)
 			i++
 		}
 	}
 	if len(positionals) != 1 {
-		return Verdict{IsAPICall: false, Ambiguous: true, Reason: "bash: expected exactly one positional URL"}, true
+		return ambiguousRecoverable("bash: expected exactly one positional URL"), true
 	}
 
 	u, err := url.Parse(positionals[0])
 	if err != nil || u.Host == "" {
-		return Verdict{IsAPICall: false, Ambiguous: true, Reason: "bash: positional is not a URL"}, true
+		return ambiguousRecoverable("bash: positional is not a URL"), true
 	}
 	if u.Scheme != "http" && u.Scheme != "https" {
-		return Verdict{IsAPICall: false, Ambiguous: true, Reason: "bash: non-http URL"}, true
+		return ambiguousRecoverable("bash: non-http URL"), true
 	}
 
 	creds, placeholders := scanHeadersForShadow(headersToInterface(headers))
 	if len(creds) == 0 {
-		return Verdict{
-			IsAPICall: false,
-			Ambiguous: true,
-			Reason:    "bash: placeholder not in -H header",
-		}, true
+		return ambiguousRecoverable("bash: placeholder not in -H header"), true
 	}
 
 	return Verdict{

--- a/internal/runtime/llmproxy/inspector/parser_flags_test.go
+++ b/internal/runtime/llmproxy/inspector/parser_flags_test.go
@@ -224,6 +224,140 @@ func TestParseBashCurl_AcceptsLineContinuationBeforeHeader(t *testing.T) {
 	}
 }
 
+// Tokenizer-rejected verdicts must surface as AgentRecoverable so the
+// chain emits RecoverableDenyVerdict (one-shot continuation retry) instead
+// of falling through to OutcomeHold and stalling on human approval. The
+// fix is always the same — re-emit the curl with a `--data @-` heredoc —
+// so the model can self-correct without a user round-trip.
+//
+// Repro: mvdan/sh parses `\'` as an escaped apostrophe, so the credentialed
+// segment extracts cleanly; the minimal in-process tokenizer doesn't model
+// backslash escapes and sees an unbalanced quote.
+func TestParseBashCurl_TokenizerRejectIsAgentRecoverable(t *testing.T) {
+	cmd := `curl -H 'Authorization: Bearer autovault_github_TESTAAAAAAAAAAAA' -d O\'Brien https://api.github.com/foo`
+	tu := ToolUse{
+		ID:    "toolu_tokenizer_reject",
+		Name:  "Bash",
+		Input: json.RawMessage(`{"cmd":` + jsonString(cmd) + `}`),
+	}
+	got, ok := DefaultParser{}.Parse(tu)
+	if !ok {
+		t.Fatalf("parser fell through; want an Ambiguous verdict, got %+v", got)
+	}
+	if !got.Ambiguous || got.IsAPICall {
+		t.Fatalf("expected Ambiguous && !IsAPICall, got %+v", got)
+	}
+	if !got.AgentRecoverable {
+		t.Fatalf("expected AgentRecoverable=true so chain emits RecoverableDenyVerdict; got %+v", got)
+	}
+	if !strings.Contains(got.Reason, "tokenizer rejected input") {
+		t.Fatalf("reason=%q; want it to mention tokenizer rejection", got.Reason)
+	}
+}
+
+// Every Ambiguous parser refusal that names a deterministic shape
+// problem must surface as AgentRecoverable so InspectorChain emits
+// RecoverableDenyVerdict (one-shot continuation retry) instead of
+// falling through to OutcomeHold and stalling on human approval. This
+// pins the contract for the bash-curl branches and the structured-
+// fetch placeholder-location branch. A failure here means the model
+// gets a user-approval prompt for a problem it could have self-fixed.
+//
+// Note: the tokenizer-rejected and extractCredentialedCurlSegment
+// branches are pinned by their own dedicated tests above and in
+// inspector_test.go; they're not duplicated here.
+func TestParseBashCurl_AmbiguousSitesAreAgentRecoverable(t *testing.T) {
+	const cred = `autovault_github_AAAAAAAAAAAAAAAA`
+	authHeader := `'Authorization: Bearer ` + cred + `'`
+	bash := func(cmd string) ToolUse {
+		return ToolUse{
+			ID:    "toolu_ambig_recover",
+			Name:  "Bash",
+			Input: json.RawMessage(`{"cmd":` + jsonString(cmd) + `}`),
+		}
+	}
+	cases := []struct {
+		name        string
+		tu          ToolUse
+		wantReason  string
+	}{
+		{
+			name:       "bash_trailing_dash_X",
+			tu:         bash(`curl -H ` + authHeader + ` https://api.github.com/ -X`),
+			wantReason: "-X without value",
+		},
+		{
+			name:       "bash_trailing_dash_H",
+			tu:         bash(`curl -H ` + authHeader + ` https://api.github.com/ -H`),
+			wantReason: "-H without value",
+		},
+		{
+			name:       "bash_safe_value_flag_trailing",
+			tu:         bash(`curl -H ` + authHeader + ` https://api.github.com/ -A`),
+			wantReason: "-A without value",
+		},
+		{
+			name:       "bash_body_flag_trailing",
+			tu:         bash(`curl -H ` + authHeader + ` https://api.github.com/ -d`),
+			wantReason: "-d without value",
+		},
+		{
+			name:       "bash_placeholder_in_body",
+			tu:         bash(`curl -d 'token=` + cred + `' https://api.github.com/`),
+			wantReason: "placeholder not in -H header",
+		},
+		{
+			name:       "bash_unknown_flag",
+			tu:         bash(`curl -L -H ` + authHeader + ` https://api.github.com/`),
+			wantReason: "unknown curl flag -L",
+		},
+		{
+			name:       "bash_extra_positional",
+			tu:         bash(`curl -H ` + authHeader + ` https://api.github.com/ https://api.github.com/extra`),
+			wantReason: "expected exactly one positional URL",
+		},
+		{
+			name:       "bash_positional_not_a_url",
+			tu:         bash(`curl -H ` + authHeader + ` not_a_url`),
+			wantReason: "positional is not a URL",
+		},
+		{
+			name:       "bash_non_http_url",
+			tu:         bash(`curl -H ` + authHeader + ` ftp://example.com/file`),
+			wantReason: "non-http URL",
+		},
+		{
+			name: "structured_fetch_placeholder_in_body",
+			tu: ToolUse{
+				ID:    "toolu_ambig_fetch",
+				Name:  "WebFetch",
+				Input: json.RawMessage(`{"url":"https://api.github.com/","method":"POST","body":"token=` + cred + `"}`),
+			},
+			wantReason: "placeholder not in known header credential location",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := DefaultParser{}.Parse(tc.tu)
+			if !ok {
+				t.Fatalf("parser fell through; want Ambiguous verdict, got %+v", got)
+			}
+			if !got.Ambiguous {
+				t.Fatalf("expected Ambiguous=true; got %+v", got)
+			}
+			if !got.AgentRecoverable {
+				t.Fatalf("expected AgentRecoverable=true so the chain emits RecoverableDenyVerdict; got %+v", got)
+			}
+			if got.IsAPICall {
+				t.Fatalf("expected IsAPICall=false for refusal verdict; got %+v", got)
+			}
+			if !strings.Contains(got.Reason, tc.wantReason) {
+				t.Fatalf("reason = %q; want it to contain %q", got.Reason, tc.wantReason)
+			}
+		})
+	}
+}
+
 func TestOpenClawReadOnlyToolsAreLocalOnlyDefaults(t *testing.T) {
 	for _, name := range []string{
 		"memory_get",

--- a/internal/runtime/llmproxy/policies/script_session_evaluator.go
+++ b/internal/runtime/llmproxy/policies/script_session_evaluator.go
@@ -121,22 +121,26 @@ func (e *ScriptSessionEvaluator) Evaluate(ctx context.Context, _ pipeline.ReadOn
 			}
 
 			// Bounded latency / timeout defense: if the LLM judge sub-context timed out
-			// (deadline exceeded while parent context is still active), deny the tool call
-			// with a clear retry message rather than falling back to a manual
-			// approval prompt (Skip) that would stall a headless session.
+			// (deadline exceeded while parent context is still active), emit a
+			// TransientDenyVerdict so the postproc transient transform promotes the
+			// FIRST timeout per conversation to a RecoverableDeny (one-shot retry
+			// hits the judge fresh) and lets the SECOND surface as a plain Deny.
+			// This replaces the prior "manual retry message" with an actual
+			// mechanized one-attempt retry — a chronic judge outage still surfaces
+			// to the user, but a transient blip self-corrects.
 			if errors.Is(err, context.DeadlineExceeded) || judgeCtx.Err() == context.DeadlineExceeded {
-				return pipeline.ToolUseVerdict{
-					Outcome: pipeline.OutcomeDeny,
-					Reason:  "Clawvisor: script-session call refused — LLM intent judge timed out (" + scriptSessionJudgeCallTimeout.String() + " limit reached). Please retry.",
-					Facts: []pipeline.EvaluationFact{pipeline.ScriptSessionFact{
+				return conversation.TransientDenyVerdict(
+					"script_session_judge_timeout",
+					"Clawvisor: script-session call refused — LLM intent judge timed out ("+scriptSessionJudgeCallTimeout.String()+" limit reached). Please retry.",
+					pipeline.ScriptSessionFact{
 						Outcome:           "script_session_judge_timeout",
 						JudgePromptSHA:    verdict.PromptSHA,
 						JudgeLatencyMS:    verdict.LatencyMS,
 						JudgeInputTokens:  verdict.InputTokens,
 						JudgeOutputTokens: verdict.OutputTokens,
 						JudgeError:        "timeout",
-					}},
-				}, nil
+					},
+				), nil
 			}
 
 			// Real error: fall through to inspector chain, but

--- a/internal/runtime/llmproxy/policies/script_session_evaluator_test.go
+++ b/internal/runtime/llmproxy/policies/script_session_evaluator_test.go
@@ -291,8 +291,12 @@ func TestScriptSessionEvaluator_URLUnrecognized_JudgeBlock_EmptyGuidance(t *test
 
 // TestScriptSessionEvaluator_URLUnrecognized_JudgeTimeout confirms that
 // when the LLM judge times out (deadline exceeded error), the evaluator
-// returns OutcomeDeny with the timeout message, rather than falling back
-// (Skip) to the inspector. The judge_timeout fact is emitted.
+// emits a TransientDenyVerdict tagged with the "script_session_judge_timeout"
+// class. The postproc transient transform promotes the first occurrence per
+// conversation to a RecoverableDeny (one-shot retry) and lets the second fall
+// through as a plain Deny. The evaluator itself MUST NOT set
+// RecoverableReason — that's the postproc layer's call once the budget is
+// consulted.
 func TestScriptSessionEvaluator_URLUnrecognized_JudgeTimeout(t *testing.T) {
 	judge := &stubJudge{
 		verdict: scriptjudge.Verdict{PromptSHA: "xyz789", LatencyMS: 8005},
@@ -307,6 +311,12 @@ func TestScriptSessionEvaluator_URLUnrecognized_JudgeTimeout(t *testing.T) {
 	}
 	if v.Outcome != pipeline.OutcomeDeny {
 		t.Errorf("Outcome = %q, want Deny (judge timed out)", v.Outcome)
+	}
+	if v.TransientFailureClass != "script_session_judge_timeout" {
+		t.Errorf("TransientFailureClass = %q, want %q", v.TransientFailureClass, "script_session_judge_timeout")
+	}
+	if v.RecoverableReason != "" {
+		t.Errorf("evaluator must leave RecoverableReason empty (postproc owns promotion); got %q", v.RecoverableReason)
 	}
 	if !strings.Contains(v.Reason, "LLM intent judge timed out (8s limit reached)") {
 		t.Errorf("Reason = %q, should contain timeout message with limit", v.Reason)

--- a/internal/runtime/llmproxy/postproc/postproc.go
+++ b/internal/runtime/llmproxy/postproc/postproc.go
@@ -67,6 +67,7 @@ func Postprocess(req *http.Request, body []byte, contentType string, cfg llmprox
 	verdictByTU = make(map[string]conversation.ToolUseVerdict, len(preExtracted))
 	eval := func(tu conversation.ToolUse) conversation.ToolUseVerdict {
 		v := innerEval(tu)
+		v = transformTransientDenyToRecoverable(req.Context(), v, tu, cfg)
 		v = transformRecoverableDenyToPlaceholder(v, tu, cfg)
 		verdictByTU[tu.ID] = v
 		return v

--- a/internal/runtime/llmproxy/postproc/postproc.go
+++ b/internal/runtime/llmproxy/postproc/postproc.go
@@ -67,7 +67,7 @@ func Postprocess(req *http.Request, body []byte, contentType string, cfg llmprox
 	verdictByTU = make(map[string]conversation.ToolUseVerdict, len(preExtracted))
 	eval := func(tu conversation.ToolUse) conversation.ToolUseVerdict {
 		v := innerEval(tu)
-		v = transformTransientDenyToRecoverable(req.Context(), v, tu, cfg)
+		v = transformTransientDenyToRecoverable(req.Context(), v, tu, cfg, session.trackTransientConsumed)
 		v = transformRecoverableDenyToPlaceholder(v, tu, cfg)
 		verdictByTU[tu.ID] = v
 		return v

--- a/internal/runtime/llmproxy/postproc/postproc.go
+++ b/internal/runtime/llmproxy/postproc/postproc.go
@@ -67,7 +67,7 @@ func Postprocess(req *http.Request, body []byte, contentType string, cfg llmprox
 	verdictByTU = make(map[string]conversation.ToolUseVerdict, len(preExtracted))
 	eval := func(tu conversation.ToolUse) conversation.ToolUseVerdict {
 		v := innerEval(tu)
-		v = transformTransientDenyToRecoverable(req.Context(), v, tu, cfg, session.trackTransientConsumed)
+		v = session.applyTransientTransform(req.Context(), v, cfg)
 		v = transformRecoverableDenyToPlaceholder(v, tu, cfg)
 		verdictByTU[tu.ID] = v
 		return v

--- a/internal/runtime/llmproxy/postproc/postproc.go
+++ b/internal/runtime/llmproxy/postproc/postproc.go
@@ -89,20 +89,16 @@ func Postprocess(req *http.Request, body []byte, contentType string, cfg llmprox
 		return failClosed("verdict side-effect commit failed: " + commitErr.Error())
 	}
 
-	// Real rewrite: eval is now a memoized lookup. Defensive fallback
-	// computes a verdict on demand if the rewriter somehow surfaces a
-	// tool_use the collector didn't see (shouldn't happen — same body
-	// — but a zero verdict here would silently mis-emit).
-	eval := func(tu conversation.ToolUse) conversation.ToolUseVerdict {
-		if v, ok := verdictByTU[tu.ID]; ok {
-			return v
-		}
-		v := innerEval(tu)
-		v = transformRecoverableDenyToPlaceholder(v, tu, cfg)
-		verdictByTU[tu.ID] = v
-		return v
-	}
-	result, err := rewriter.Rewrite(body, contentType, eval)
+	// Real rewrite: eval is a direct lookup against the post-commit
+	// verdict map. A tool_use the collector didn't surface yields a
+	// zero-value verdict (Allowed=false) — safe denial rather than
+	// the bypass-commit path an on-demand fallback would create. The
+	// collector and real rewrite walk the same body, so a divergence
+	// here is a parser bug that should surface in tests, not get
+	// silently masked.
+	result, err := rewriter.Rewrite(body, contentType, func(tu conversation.ToolUse) conversation.ToolUseVerdict {
+		return verdictByTU[tu.ID]
+	})
 	if err != nil {
 		// Fail closed: the rewriter failed mid-body so we don't know
 		// whether a credentialed placeholder survived into the response.

--- a/internal/runtime/llmproxy/postproc/postproc.go
+++ b/internal/runtime/llmproxy/postproc/postproc.go
@@ -62,39 +62,51 @@ func Postprocess(req *http.Request, body []byte, contentType string, cfg llmprox
 	}
 
 	innerEval := session.evaluator(req, rewriter.Name(), preExtracted)
+	ctx := req.Context()
 
-	// Capture per-tool verdicts so the finalizer can classify them.
+	// Eval pass: compute every verdict up-front and apply the
+	// recoverable→placeholder transform. Runs BEFORE commit so commit
+	// can promote transient-deny verdicts (commit calls Try on the
+	// budget; on promote, it sets RecoverableReason and re-runs the
+	// placeholder transform). Pre-looping also means the real rewrite
+	// below just looks up the post-commit verdicts instead of running
+	// transforms during emission.
 	verdictByTU = make(map[string]conversation.ToolUseVerdict, len(preExtracted))
-	eval := func(tu conversation.ToolUse) conversation.ToolUseVerdict {
+	for _, tu := range preExtracted {
 		v := innerEval(tu)
-		v = session.applyTransientTransform(req.Context(), v, cfg)
+		v = transformRecoverableDenyToPlaceholder(v, tu, cfg)
+		verdictByTU[tu.ID] = v
+	}
+
+	if collectorErr != nil {
+		// Eval pass already populated verdictByTU for whatever the
+		// collector parsed before failing; the rollback below sweeps
+		// any inline-task rows those evaluations created.
+		return failClosed("rewriter error during tool_use extraction: " + collectorErr.Error())
+	}
+
+	if commitErr := session.commitVerdictSideEffects(ctx, verdictByTU, preExtracted); commitErr != nil {
+		return failClosed("verdict side-effect commit failed: " + commitErr.Error())
+	}
+
+	// Real rewrite: eval is now a memoized lookup. Defensive fallback
+	// computes a verdict on demand if the rewriter somehow surfaces a
+	// tool_use the collector didn't see (shouldn't happen — same body
+	// — but a zero verdict here would silently mis-emit).
+	eval := func(tu conversation.ToolUse) conversation.ToolUseVerdict {
+		if v, ok := verdictByTU[tu.ID]; ok {
+			return v
+		}
+		v := innerEval(tu)
 		v = transformRecoverableDenyToPlaceholder(v, tu, cfg)
 		verdictByTU[tu.ID] = v
 		return v
 	}
-
-	if collectorErr != nil {
-		// The collector may have parsed tool_uses before failing later
-		// in the body. Evaluate only those parsed tools so any pending
-		// inline-task rows they create are rolled back below; the audit
-		// rows describe this local policy/rollback work, not an upstream
-		// tool call that reached the harness.
-		for _, tu := range preExtracted {
-			eval(tu)
-		}
-		return failClosed("rewriter error during tool_use extraction: " + collectorErr.Error())
-	}
-
 	result, err := rewriter.Rewrite(body, contentType, eval)
 	if err != nil {
 		// Fail closed: the rewriter failed mid-body so we don't know
 		// whether a credentialed placeholder survived into the response.
 		return failClosed("rewriter error: " + err.Error())
-	}
-
-	ctx := req.Context()
-	if commitErr := session.commitVerdictSideEffects(ctx, verdictByTU, preExtracted); commitErr != nil {
-		return failClosed("verdict side-effect commit failed: " + commitErr.Error())
 	}
 	finalResult, finalErr := session.finalize(ctx, preExtracted, verdictByTU)
 	if finalErr != nil {

--- a/internal/runtime/llmproxy/postproc/session.go
+++ b/internal/runtime/llmproxy/postproc/session.go
@@ -46,30 +46,42 @@ type postprocessSession struct {
 	transientConsumed []llmproxy.TransientBudgetKey
 }
 
-// applyTransientTransform wraps the pure tryPromoteTransient function
-// with the session-owned bookkeeping needed for rollback. Eval closures
-// in postproc.go and stream.go call this instead of the pure function
-// so the consumed-key tracking stays inside the session — matching the
-// pattern where session methods (evaluator, finalize, rollback) own
-// session state, and free functions stay pure.
+// promoteTransientsLocked walks verdictByTU and promotes every Deny
+// verdict tagged with TransientFailureClass whose budget slot is
+// available. Promotion sets RecoverableReason and re-runs the
+// placeholder transform so the verdict ends up with the same wire
+// shape an evaluator-emitted RecoverableDeny would have produced. The
+// consumed budget keys are appended to s.transientConsumed so
+// rollbackVerdictSideEffects can refund them if the response later
+// fail-closes.
 //
-// Called per tool_use during eval, BEFORE
-// transformRecoverableDenyToPlaceholder so a promoted transient flows
-// into the placeholder machinery in the same pass.
-func (s *postprocessSession) applyTransientTransform(
-	ctx context.Context,
-	v conversation.ToolUseVerdict,
-	cfg llmproxy.PostprocessConfig,
-) conversation.ToolUseVerdict {
+// Called from commitVerdictSideEffects BEFORE the existing
+// DeferredDriftOutcome / PendingSubstitution processing, so any
+// substitution spec the promoted verdict gains is picked up by the
+// subsequent registration loop in the same commit pass.
+func (s *postprocessSession) promoteTransients(ctx context.Context, verdictByTU map[string]conversation.ToolUseVerdict, toolUses []conversation.ToolUse) {
 	if s == nil {
-		v, _ = tryPromoteTransient(ctx, v, cfg)
-		return v
+		return
 	}
-	promoted, key := tryPromoteTransient(ctx, v, cfg)
-	if key != nil {
+	cfg := s.baseCfg
+	for _, tu := range toolUses {
+		v, ok := verdictByTU[tu.ID]
+		if !ok {
+			continue
+		}
+		promoted, key := tryPromoteTransient(ctx, v, cfg)
+		if key == nil {
+			continue
+		}
+		// Re-run the placeholder transform so promoted-transient
+		// verdicts emit the same SubstituteWithToolCall +
+		// PendingSubstitution shape an evaluator-emitted recoverable
+		// would have produced. The subsequent substitution-
+		// registration loop in commit handles the new PendingSubstitution.
+		promoted = transformRecoverableDenyToPlaceholder(promoted, tu, cfg)
+		verdictByTU[tu.ID] = promoted
 		s.transientConsumed = append(s.transientConsumed, *key)
 	}
-	return promoted
 }
 
 func newPostprocessSession(cfg llmproxy.PostprocessConfig) *postprocessSession {
@@ -137,11 +149,12 @@ func (s *postprocessSession) rollback(ctx context.Context, toolUses []conversati
 }
 
 // commitVerdictSideEffects walks each verdict in tool_use order and
-// realizes the spec-on-verdict signals — DeferredDriftOutcome FIRST
-// (so the pre-clear mint lands before the substitution write that
-// depends on it), then PendingSubstitution. Called AFTER all
-// evaluators have produced verdicts so the verdict itself stays free
-// of registry side-effects.
+// realizes the spec-on-verdict signals — promote transients FIRST
+// (so any newly-promoted recoverable verdict has its PendingSubstitution
+// set before the substitution loop), then DeferredDriftOutcome (so
+// the pre-clear mint lands before the substitution write that depends
+// on it), then PendingSubstitution. Called BEFORE the real rewrite so
+// transient promotions land in the verdict map the rewriter reads.
 //
 // Ordering is intentional and per-verdict atomic-ish: if drift outcome
 // succeeds but substitution fails, the drift outcome is recorded in
@@ -153,11 +166,19 @@ func (s *postprocessSession) rollback(ctx context.Context, toolUses []conversati
 //
 // Returns the failing error so the caller (postproc / stream) can
 // fail-closed the response — rollback() then sweeps every write made
-// on behalf of this request in one place.
+// on behalf of this request in one place (including transient-budget
+// slots refunded via TransientBudget.Release).
 func (s *postprocessSession) commitVerdictSideEffects(ctx context.Context, verdictByTU map[string]conversation.ToolUseVerdict, toolUses []conversation.ToolUse) error {
 	if s == nil {
 		return nil
 	}
+	// Pass 1: promote transient-deny verdicts. Mutates verdictByTU
+	// in-place; tracked consumes go on s.transientConsumed for
+	// rollback. Runs regardless of whether ScopeDrifts is wired so
+	// the transient mechanism works in deployments that don't use
+	// the scope-drift continuation menu.
+	s.promoteTransients(ctx, verdictByTU, toolUses)
+
 	registry := s.baseCfg.AuthorizationContext.ScopeDrifts
 	if registry == nil {
 		return nil

--- a/internal/runtime/llmproxy/postproc/session.go
+++ b/internal/runtime/llmproxy/postproc/session.go
@@ -37,6 +37,22 @@ type postprocessSession struct {
 	fed                      bool
 	substitutions            []llmproxy.PendingSubstitutionKey
 	driftOutcomes            []string
+	// transientConsumed tracks TransientBudget Try() calls the
+	// transformTransientDenyToRecoverable transform made during eval.
+	// rollbackVerdictSideEffects calls TransientBudget.Release on each
+	// so a fail-closed response refunds the agent's one retry slot;
+	// otherwise the next real attempt would degrade to plain Deny.
+	transientConsumed []llmproxy.TransientBudgetKey
+}
+
+// trackTransientConsumed records a Try() the transient transform made
+// so the session's rollback path can refund it on fail-closed. Passed
+// into the transform as a closure from the eval call sites.
+func (s *postprocessSession) trackTransientConsumed(key llmproxy.TransientBudgetKey) {
+	if s == nil {
+		return
+	}
+	s.transientConsumed = append(s.transientConsumed, key)
 }
 
 func newPostprocessSession(cfg llmproxy.PostprocessConfig) *postprocessSession {
@@ -255,6 +271,16 @@ func (s *postprocessSession) rollbackVerdictSideEffects(ctx context.Context) {
 	if s == nil {
 		return
 	}
+	// Refund transient-budget slots regardless of whether the scope-
+	// drift registry is wired; the budget is an independent registry
+	// and the next real attempt deserves a fresh retry slot.
+	if budget := s.baseCfg.AuthorizationContext.TransientBudget; budget != nil {
+		for _, key := range s.transientConsumed {
+			budget.Release(ctx, key)
+		}
+	}
+	s.transientConsumed = nil
+
 	registry := s.baseCfg.AuthorizationContext.ScopeDrifts
 	if registry == nil {
 		s.substitutions = nil

--- a/internal/runtime/llmproxy/postproc/session.go
+++ b/internal/runtime/llmproxy/postproc/session.go
@@ -44,13 +44,15 @@ type postprocessSession struct {
 	fed                      bool
 	substitutions            []llmproxy.PendingSubstitutionKey
 	driftOutcomes            []string
-	// transientConsumed tracks TransientBudget Try() calls the
-	// applyTransientTransform wrapper made during eval (via the pure
-	// tryPromoteTransient function). rollbackVerdictSideEffects calls
-	// TransientBudget.Release on each so a fail-closed response
-	// refunds the agent's one retry slot; otherwise the next real
-	// attempt would degrade to plain Deny.
-	transientConsumed []llmproxy.TransientBudgetKey
+	// transientConsumed tracks TransientBudget Try() calls
+	// session.promoteTransients made during commitVerdictSideEffects
+	// (via the pure tryPromoteTransient function). Each record
+	// carries the per-consume token returned by Try so
+	// rollbackVerdictSideEffects can call TransientBudget.Release
+	// with a token-checked delete — refunding ONLY the slot this
+	// request consumed, never an unrelated request's slot that
+	// happened to land on the same key after pruning.
+	transientConsumed []transientConsume
 }
 
 // promoteTransientsLocked walks verdictByTU and promotes every Deny
@@ -76,8 +78,8 @@ func (s *postprocessSession) promoteTransients(ctx context.Context, verdictByTU 
 		if !ok {
 			continue
 		}
-		promoted, key := tryPromoteTransient(ctx, v, cfg)
-		if key == nil {
+		promoted, consume := tryPromoteTransient(ctx, v, cfg)
+		if consume == nil {
 			continue
 		}
 		// Re-run the placeholder transform so promoted-transient
@@ -87,7 +89,7 @@ func (s *postprocessSession) promoteTransients(ctx context.Context, verdictByTU 
 		// registration loop in commit handles the new PendingSubstitution.
 		promoted = transformRecoverableDenyToPlaceholder(promoted, tu, cfg)
 		verdictByTU[tu.ID] = promoted
-		s.transientConsumed = append(s.transientConsumed, *key)
+		s.transientConsumed = append(s.transientConsumed, *consume)
 	}
 }
 
@@ -320,8 +322,8 @@ func (s *postprocessSession) rollbackVerdictSideEffects(ctx context.Context) {
 	// drift registry is wired; the budget is an independent registry
 	// and the next real attempt deserves a fresh retry slot.
 	if budget := s.baseCfg.AuthorizationContext.TransientBudget; budget != nil {
-		for _, key := range s.transientConsumed {
-			budget.Release(ctx, key)
+		for _, rec := range s.transientConsumed {
+			budget.Release(ctx, rec.Key, rec.Token)
 		}
 	}
 	s.transientConsumed = nil

--- a/internal/runtime/llmproxy/postproc/session.go
+++ b/internal/runtime/llmproxy/postproc/session.go
@@ -38,21 +38,38 @@ type postprocessSession struct {
 	substitutions            []llmproxy.PendingSubstitutionKey
 	driftOutcomes            []string
 	// transientConsumed tracks TransientBudget Try() calls the
-	// transformTransientDenyToRecoverable transform made during eval.
-	// rollbackVerdictSideEffects calls TransientBudget.Release on each
-	// so a fail-closed response refunds the agent's one retry slot;
-	// otherwise the next real attempt would degrade to plain Deny.
+	// applyTransientTransform wrapper made during eval (via the pure
+	// tryPromoteTransient function). rollbackVerdictSideEffects calls
+	// TransientBudget.Release on each so a fail-closed response
+	// refunds the agent's one retry slot; otherwise the next real
+	// attempt would degrade to plain Deny.
 	transientConsumed []llmproxy.TransientBudgetKey
 }
 
-// trackTransientConsumed records a Try() the transient transform made
-// so the session's rollback path can refund it on fail-closed. Passed
-// into the transform as a closure from the eval call sites.
-func (s *postprocessSession) trackTransientConsumed(key llmproxy.TransientBudgetKey) {
+// applyTransientTransform wraps the pure tryPromoteTransient function
+// with the session-owned bookkeeping needed for rollback. Eval closures
+// in postproc.go and stream.go call this instead of the pure function
+// so the consumed-key tracking stays inside the session — matching the
+// pattern where session methods (evaluator, finalize, rollback) own
+// session state, and free functions stay pure.
+//
+// Called per tool_use during eval, BEFORE
+// transformRecoverableDenyToPlaceholder so a promoted transient flows
+// into the placeholder machinery in the same pass.
+func (s *postprocessSession) applyTransientTransform(
+	ctx context.Context,
+	v conversation.ToolUseVerdict,
+	cfg llmproxy.PostprocessConfig,
+) conversation.ToolUseVerdict {
 	if s == nil {
-		return
+		v, _ = tryPromoteTransient(ctx, v, cfg)
+		return v
 	}
-	s.transientConsumed = append(s.transientConsumed, key)
+	promoted, key := tryPromoteTransient(ctx, v, cfg)
+	if key != nil {
+		s.transientConsumed = append(s.transientConsumed, *key)
+	}
+	return promoted
 }
 
 func newPostprocessSession(cfg llmproxy.PostprocessConfig) *postprocessSession {

--- a/internal/runtime/llmproxy/postproc/session.go
+++ b/internal/runtime/llmproxy/postproc/session.go
@@ -15,18 +15,25 @@ import (
 // streaming postprocess both use this shape so capture/finalize
 // lifecycle details stay in one place.
 //
-// substitutions tracks pending-substitution registry writes that
-// fired during evaluation (scope-drift mints, recoverable-deny
-// migrations, inline-task auto-approve). driftOutcomes tracks
-// SetOutcome writes deferred via the verdict's DeferredDriftOutcome.
-// rollback() iterates both so a request whose response is later
-// failClosed'd doesn't leak orphan entries or stale pre-clears.
-// commitVerdictSideEffects is the single entry point — it walks each
-// verdict, applies the drift outcome first (so the pre-clear lands
-// before the substitution mint that depends on it) and then registers
-// the substitution. Evaluators MUST NOT call into the registry
-// themselves; the spec-on-verdict pattern keeps the verdict pure data
-// and concentrates rollback in one place.
+// Three parallel per-registry rollback ledgers — substitutions,
+// driftOutcomes, transientConsumed — track writes commit made so
+// rollback can undo them in one place. Each follows the same shape:
+// commit appends a key after a successful registry write; rollback
+// iterates the slice and calls the matching undo op. The three
+// ledgers exist because they target three different registries
+// (ScopeDrifts pending-substitutions, ScopeDrifts drift outcomes,
+// TransientBudget retry slots) with different key types and undo
+// methods — they can't be unified, but their shape is intentionally
+// parallel so the rollback story stays uniform.
+//
+// commitVerdictSideEffects is the single entry point — it promotes
+// transient-deny verdicts first (so any newly-set PendingSubstitution
+// gets picked up by the substitution loop in the same pass), then
+// applies drift outcomes (so the pre-clear lands before the
+// substitution mint that depends on it), then registers
+// substitutions. Evaluators MUST NOT call into any of the three
+// registries themselves; the spec-on-verdict pattern keeps the
+// verdict pure data and concentrates rollback in one place.
 type postprocessSession struct {
 	baseCfg                  llmproxy.PostprocessConfig
 	evalCfg                  llmproxy.PostprocessConfig

--- a/internal/runtime/llmproxy/postproc/stream.go
+++ b/internal/runtime/llmproxy/postproc/stream.go
@@ -96,22 +96,34 @@ func PostprocessStream(
 
 	innerEval := session.evaluator(req, provider, toolUses)
 
+	// Eval pass: compute verdicts up-front and apply the
+	// recoverable→placeholder transform. Runs BEFORE commit so commit
+	// can promote transient-deny verdicts (it calls Try on the budget;
+	// on promote, sets RecoverableReason and re-runs placeholder).
 	verdictByTU := make(map[string]conversation.ToolUseVerdict, len(toolUses))
-	eval := func(tu conversation.ToolUse) conversation.ToolUseVerdict {
+	for _, tu := range toolUses {
 		v := innerEval(tu)
-		v = session.applyTransientTransform(req.Context(), v, cfg)
 		v = transformRecoverableDenyToPlaceholder(v, tu, cfg)
 		verdictByTU[tu.ID] = v
-		return v
 	}
 
+	if commitErr := session.commitVerdictSideEffects(req.Context(), verdictByTU, toolUses); commitErr != nil {
+		session.rollback(req.Context(), toolUses, verdictByTU)
+		return llmproxy.PostprocessResult{
+			SkippedReason: commitErr.Error(),
+		}, commitErr
+	}
+
+	// Collect decisions and rewrite intents from the POST-COMMIT
+	// verdicts so promoted-transient verdicts (whose RecoverableReason
+	// and SubstituteWithToolCall were filled in during commit) surface
+	// in the streaming output with the right shape.
 	var decisions []conversation.ToolUseDecisionRecord
 	anyBlocked := false
 	anyRewritten := false
 	rewrittenInput := map[string]json.RawMessage{}
-
 	for _, tu := range toolUses {
-		v := eval(tu)
+		v := verdictByTU[tu.ID]
 		decisions = append(decisions, conversation.ToolUseDecisionRecord{
 			ToolUse:          tu,
 			Verdict:          v,
@@ -126,12 +138,6 @@ func PostprocessStream(
 		}
 	}
 
-	if commitErr := session.commitVerdictSideEffects(req.Context(), verdictByTU, toolUses); commitErr != nil {
-		session.rollback(req.Context(), toolUses, verdictByTU)
-		return llmproxy.PostprocessResult{
-			SkippedReason: commitErr.Error(),
-		}, commitErr
-	}
 	finalResult, finalErr := session.finalize(req.Context(), toolUses, verdictByTU)
 	if finalErr != nil {
 		session.rollback(req.Context(), toolUses, verdictByTU)

--- a/internal/runtime/llmproxy/postproc/stream.go
+++ b/internal/runtime/llmproxy/postproc/stream.go
@@ -99,7 +99,7 @@ func PostprocessStream(
 	verdictByTU := make(map[string]conversation.ToolUseVerdict, len(toolUses))
 	eval := func(tu conversation.ToolUse) conversation.ToolUseVerdict {
 		v := innerEval(tu)
-		v = transformTransientDenyToRecoverable(req.Context(), v, tu, cfg, session.trackTransientConsumed)
+		v = session.applyTransientTransform(req.Context(), v, cfg)
 		v = transformRecoverableDenyToPlaceholder(v, tu, cfg)
 		verdictByTU[tu.ID] = v
 		return v

--- a/internal/runtime/llmproxy/postproc/stream.go
+++ b/internal/runtime/llmproxy/postproc/stream.go
@@ -100,10 +100,20 @@ func PostprocessStream(
 	// recoverable→placeholder transform. Runs BEFORE commit so commit
 	// can promote transient-deny verdicts (it calls Try on the budget;
 	// on promote, sets RecoverableReason and re-runs placeholder).
+	//
+	// verdicts is positional (parallel to toolUses) and is the source
+	// of truth for the post-commit decision loop. verdictByTU is a
+	// memoization for commit and finalize, which key by tool_use ID.
+	// The two diverge ONLY if duplicate tool_use IDs appear (the
+	// provider APIs guarantee uniqueness, but the rewriter shouldn't
+	// silently collapse audit fidelity if that assumption is ever
+	// violated upstream).
+	verdicts := make([]conversation.ToolUseVerdict, len(toolUses))
 	verdictByTU := make(map[string]conversation.ToolUseVerdict, len(toolUses))
-	for _, tu := range toolUses {
+	for i, tu := range toolUses {
 		v := innerEval(tu)
 		v = transformRecoverableDenyToPlaceholder(v, tu, cfg)
+		verdicts[i] = v
 		verdictByTU[tu.ID] = v
 	}
 
@@ -114,16 +124,23 @@ func PostprocessStream(
 		}, commitErr
 	}
 
-	// Collect decisions and rewrite intents from the POST-COMMIT
-	// verdicts so promoted-transient verdicts (whose RecoverableReason
-	// and SubstituteWithToolCall were filled in during commit) surface
-	// in the streaming output with the right shape.
+	// Collect decisions and rewrite intents positionally so duplicate
+	// tool_use IDs don't alias to a single shared verdict. Each
+	// position uses its own pre-commit verdict from `verdicts`, then
+	// adopts the post-commit shape from verdictByTU when commit
+	// promoted that id (transient-deny → recoverable: SubstituteWithToolCall
+	// becomes non-nil). Promoted-transient verdicts ship a uniform shape
+	// per id at the response layer, so all positions sharing the id
+	// reflect that uniform shape in their audit decision too.
 	var decisions []conversation.ToolUseDecisionRecord
 	anyBlocked := false
 	anyRewritten := false
 	rewrittenInput := map[string]json.RawMessage{}
-	for _, tu := range toolUses {
-		v := verdictByTU[tu.ID]
+	for i, tu := range toolUses {
+		v := verdicts[i]
+		if postCommit := verdictByTU[tu.ID]; postCommit.SubstituteWithToolCall != nil && v.SubstituteWithToolCall == nil {
+			v = postCommit
+		}
 		decisions = append(decisions, conversation.ToolUseDecisionRecord{
 			ToolUse:          tu,
 			Verdict:          v,

--- a/internal/runtime/llmproxy/postproc/stream.go
+++ b/internal/runtime/llmproxy/postproc/stream.go
@@ -99,7 +99,7 @@ func PostprocessStream(
 	verdictByTU := make(map[string]conversation.ToolUseVerdict, len(toolUses))
 	eval := func(tu conversation.ToolUse) conversation.ToolUseVerdict {
 		v := innerEval(tu)
-		v = transformTransientDenyToRecoverable(req.Context(), v, tu, cfg)
+		v = transformTransientDenyToRecoverable(req.Context(), v, tu, cfg, session.trackTransientConsumed)
 		v = transformRecoverableDenyToPlaceholder(v, tu, cfg)
 		verdictByTU[tu.ID] = v
 		return v

--- a/internal/runtime/llmproxy/postproc/stream.go
+++ b/internal/runtime/llmproxy/postproc/stream.go
@@ -99,6 +99,7 @@ func PostprocessStream(
 	verdictByTU := make(map[string]conversation.ToolUseVerdict, len(toolUses))
 	eval := func(tu conversation.ToolUse) conversation.ToolUseVerdict {
 		v := innerEval(tu)
+		v = transformTransientDenyToRecoverable(req.Context(), v, tu, cfg)
 		v = transformRecoverableDenyToPlaceholder(v, tu, cfg)
 		verdictByTU[tu.ID] = v
 		return v

--- a/internal/runtime/llmproxy/postproc/transient_deny.go
+++ b/internal/runtime/llmproxy/postproc/transient_deny.go
@@ -7,18 +7,28 @@ import (
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy"
 )
 
+// transientConsume identifies a successful Try call so a later
+// rollback can refund the EXACT slot it took (not a slot that has
+// since rotated to a different consumer). Token-checked Release is
+// what keeps a delayed rollback from clobbering an unrelated request's
+// budget.
+type transientConsume struct {
+	Key   llmproxy.TransientBudgetKey
+	Token llmproxy.TransientReleaseToken
+}
+
 // tryPromoteTransient is the pure-function decision for whether a
 // Deny verdict tagged with TransientFailureClass should be promoted
 // to a RecoverableDeny on this attempt. Returns the (possibly
-// promoted) verdict and the consumed budget key — nil when no
-// promotion fired.
+// promoted) verdict and the consume record — nil when no promotion
+// fired.
 //
 // Called from session.promoteTransients during commitVerdictSideEffects.
-// The wrapping session method owns the consumed-key tracking for
-// rollback so this function stays free of session state, matching the
-// pure shape transformRecoverableDenyToPlaceholder uses.
+// The wrapping session method owns the consume tracking for rollback
+// so this function stays free of session state, matching the pure
+// shape transformRecoverableDenyToPlaceholder uses.
 //
-// Skipped (verdict returned unchanged, nil key) when:
+// Skipped (verdict returned unchanged, nil consume) when:
 //   - not a Deny verdict, or TransientFailureClass is empty
 //   - RecoverableReason is already set — a prior layer already chose
 //     the recoverable shape and we must not double-process
@@ -33,7 +43,7 @@ func tryPromoteTransient(
 	ctx context.Context,
 	v conversation.ToolUseVerdict,
 	cfg llmproxy.PostprocessConfig,
-) (conversation.ToolUseVerdict, *llmproxy.TransientBudgetKey) {
+) (conversation.ToolUseVerdict, *transientConsume) {
 	if v.Outcome != conversation.OutcomeDeny || v.TransientFailureClass == "" {
 		return v, nil
 	}
@@ -52,10 +62,11 @@ func tryPromoteTransient(
 		ConversationID: cfg.AuditContext.ConversationID,
 		FailureClass:   v.TransientFailureClass,
 	}
-	if !budget.Try(ctx, key) {
+	token, ok := budget.Try(ctx, key)
+	if !ok {
 		return v, nil
 	}
 	v.RecoverableReason = v.Reason
 	v.SubstituteWith = v.Reason
-	return v, &key
+	return v, &transientConsume{Key: key, Token: token}
 }

--- a/internal/runtime/llmproxy/postproc/transient_deny.go
+++ b/internal/runtime/llmproxy/postproc/transient_deny.go
@@ -7,26 +7,23 @@ import (
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy"
 )
 
-// transformTransientDenyToRecoverable promotes a Deny verdict marked
-// with TransientFailureClass to a RecoverableDeny on its FIRST
-// occurrence per (agent, conversation, failure class) within the
-// TransientBudget's TTL. The downstream transformRecoverableDenyToPlaceholder
-// then converts the promoted verdict into the standard one-shot
-// continuation retry shape.
+// tryPromoteTransient is the pure-function half of the transient-deny
+// transform pipeline. It decides whether the Deny verdict should be
+// promoted to a RecoverableDeny based on the (agent, conversation,
+// failure class) budget, and returns:
 //
-// On subsequent occurrences (budget exhausted) the verdict passes
-// through as a plain Deny so chronic failures surface to the user
-// instead of looping. This realizes the "at most once per error class"
-// retry policy for transient failures (judge timeout, nonce-mint
-// hiccup, decision-engine RPC blip).
+//   - the resulting verdict (mutated only when promotion fires)
+//   - the consumed key, when promotion fired — otherwise nil
 //
-// trackConsumed, when non-nil, is called with the consumed key after a
-// successful Try. The postproc session uses it to remember keys that
-// must be refunded if the response is later fail-closed — otherwise
-// the agent's one retry slot would burn for a recoverable response
-// they never actually saw.
+// The session method that wraps this owns the consumed-key tracking
+// for rollback; this function stays free of session state so it
+// matches the pure-transform shape the other postproc transforms use
+// (transformRecoverableDenyToPlaceholder etc.). The Try call must
+// happen here (not in commitVerdictSideEffects) because the
+// downstream transformRecoverableDenyToPlaceholder needs the promoted
+// RecoverableReason BEFORE the rewriter consumes the verdict shape.
 //
-// Skipped (verdict returned unchanged) when:
+// Skipped (verdict returned unchanged, nil key) when:
 //   - not a Deny verdict, or TransientFailureClass is empty
 //   - RecoverableReason is already set — a prior layer already chose
 //     the recoverable shape and we must not double-process
@@ -35,25 +32,25 @@ import (
 //   - identity tuple (AgentID, ConversationID) is incomplete — the
 //     budget key would collapse across distinct conversations from the
 //     same agent, so degrade safely to plain Deny rather than misroute
-func transformTransientDenyToRecoverable(
+//   - Try returns false (budget exhausted for this class on this
+//     conversation within TTL)
+func tryPromoteTransient(
 	ctx context.Context,
 	v conversation.ToolUseVerdict,
-	_ conversation.ToolUse,
 	cfg llmproxy.PostprocessConfig,
-	trackConsumed func(llmproxy.TransientBudgetKey),
-) conversation.ToolUseVerdict {
+) (conversation.ToolUseVerdict, *llmproxy.TransientBudgetKey) {
 	if v.Outcome != conversation.OutcomeDeny || v.TransientFailureClass == "" {
-		return v
+		return v, nil
 	}
 	if v.RecoverableReason != "" {
-		return v
+		return v, nil
 	}
 	budget := cfg.AuthorizationContext.TransientBudget
 	if budget == nil {
-		return v
+		return v, nil
 	}
 	if cfg.AgentContext.AgentID == "" || cfg.AuditContext.ConversationID == "" {
-		return v
+		return v, nil
 	}
 	key := llmproxy.TransientBudgetKey{
 		AgentID:        cfg.AgentContext.AgentID,
@@ -61,12 +58,9 @@ func transformTransientDenyToRecoverable(
 		FailureClass:   v.TransientFailureClass,
 	}
 	if !budget.Try(ctx, key) {
-		return v
-	}
-	if trackConsumed != nil {
-		trackConsumed(key)
+		return v, nil
 	}
 	v.RecoverableReason = v.Reason
 	v.SubstituteWith = v.Reason
-	return v
+	return v, &key
 }

--- a/internal/runtime/llmproxy/postproc/transient_deny.go
+++ b/internal/runtime/llmproxy/postproc/transient_deny.go
@@ -20,6 +20,12 @@ import (
 // retry policy for transient failures (judge timeout, nonce-mint
 // hiccup, decision-engine RPC blip).
 //
+// trackConsumed, when non-nil, is called with the consumed key after a
+// successful Try. The postproc session uses it to remember keys that
+// must be refunded if the response is later fail-closed — otherwise
+// the agent's one retry slot would burn for a recoverable response
+// they never actually saw.
+//
 // Skipped (verdict returned unchanged) when:
 //   - not a Deny verdict, or TransientFailureClass is empty
 //   - RecoverableReason is already set — a prior layer already chose
@@ -34,6 +40,7 @@ func transformTransientDenyToRecoverable(
 	v conversation.ToolUseVerdict,
 	_ conversation.ToolUse,
 	cfg llmproxy.PostprocessConfig,
+	trackConsumed func(llmproxy.TransientBudgetKey),
 ) conversation.ToolUseVerdict {
 	if v.Outcome != conversation.OutcomeDeny || v.TransientFailureClass == "" {
 		return v
@@ -48,8 +55,16 @@ func transformTransientDenyToRecoverable(
 	if cfg.AgentContext.AgentID == "" || cfg.AuditContext.ConversationID == "" {
 		return v
 	}
-	if !budget.Try(ctx, cfg.AgentContext.AgentID, cfg.AuditContext.ConversationID, v.TransientFailureClass) {
+	key := llmproxy.TransientBudgetKey{
+		AgentID:        cfg.AgentContext.AgentID,
+		ConversationID: cfg.AuditContext.ConversationID,
+		FailureClass:   v.TransientFailureClass,
+	}
+	if !budget.Try(ctx, key) {
 		return v
+	}
+	if trackConsumed != nil {
+		trackConsumed(key)
 	}
 	v.RecoverableReason = v.Reason
 	v.SubstituteWith = v.Reason

--- a/internal/runtime/llmproxy/postproc/transient_deny.go
+++ b/internal/runtime/llmproxy/postproc/transient_deny.go
@@ -1,3 +1,54 @@
+// Transient-deny promotion: design constraints and why this isn't a
+// deferred spec like PendingSubstitution / DeferredDriftOutcome.
+//
+// The other postproc transforms follow a "verdict is pure data"
+// invariant: evaluators populate a spec field on the verdict; the
+// transform translates it to wire shape; commitVerdictSideEffects
+// realizes the spec as a registry write; rollbackVerdictSideEffects
+// undoes the write. No registry mutation happens inside the transform.
+//
+// Transient-deny CAN'T fit that pattern because of an ordering
+// constraint baked into postproc.go:
+//
+//   1. eval — innerEval runs, then this transform, then
+//      transformRecoverableDenyToPlaceholder. The placeholder
+//      transform consumes RecoverableReason and emits the placeholder
+//      wire shape (SubstituteWithToolCall + PendingSubstitution).
+//   2. rewrite — the rewriter walks the verdict map and emits the
+//      response body using the placeholder shape.
+//   3. commitVerdictSideEffects — registry writes happen here, AFTER
+//      the response body has already shipped the placeholder.
+//
+// The budget Try() is the decision point for whether to promote the
+// verdict to recoverable. If we deferred Try to step (3), step (2)
+// would have already shipped the verdict as a plain Deny — too late
+// to convert it. So Try MUST happen during step (1).
+//
+// The constraint propagates: this transform performs a session-state
+// mutation (consumes a budget slot) during eval, breaking the strict
+// "transform is pure" rule. We mitigate by splitting the work:
+//
+//   - tryPromoteTransient — pure function (ctx, verdict, cfg) →
+//     (verdict, consumedKey). Encapsulates the decision; returns the
+//     mutation it caused as data the caller can act on. No session
+//     reference.
+//   - session.applyTransientTransform — session method that wraps
+//     the pure function and owns the consumed-key tracking on the
+//     session, matching how session.evaluator / .finalize / .rollback
+//     own their session state.
+//   - rollbackVerdictSideEffects — calls TransientBudget.Release on
+//     every tracked key so a fail-closed response refunds the agent's
+//     retry slot. Same shape as the substitution / drift-outcome
+//     rollback.
+//
+// If the rewrite step ever moves AFTER commitVerdictSideEffects (e.g.
+// a two-pass rewrite where pass-1 discovers tool_uses and pass-2
+// emits the body using post-commit verdicts), this transform could be
+// converted to a true deferred spec — that restructure was considered
+// and rejected as disproportionate to the single use site today
+// (script-session judge timeout). Revisit if more transient sites
+// land.
+
 package postproc
 
 import (

--- a/internal/runtime/llmproxy/postproc/transient_deny.go
+++ b/internal/runtime/llmproxy/postproc/transient_deny.go
@@ -1,54 +1,3 @@
-// Transient-deny promotion: design constraints and why this isn't a
-// deferred spec like PendingSubstitution / DeferredDriftOutcome.
-//
-// The other postproc transforms follow a "verdict is pure data"
-// invariant: evaluators populate a spec field on the verdict; the
-// transform translates it to wire shape; commitVerdictSideEffects
-// realizes the spec as a registry write; rollbackVerdictSideEffects
-// undoes the write. No registry mutation happens inside the transform.
-//
-// Transient-deny CAN'T fit that pattern because of an ordering
-// constraint baked into postproc.go:
-//
-//   1. eval — innerEval runs, then this transform, then
-//      transformRecoverableDenyToPlaceholder. The placeholder
-//      transform consumes RecoverableReason and emits the placeholder
-//      wire shape (SubstituteWithToolCall + PendingSubstitution).
-//   2. rewrite — the rewriter walks the verdict map and emits the
-//      response body using the placeholder shape.
-//   3. commitVerdictSideEffects — registry writes happen here, AFTER
-//      the response body has already shipped the placeholder.
-//
-// The budget Try() is the decision point for whether to promote the
-// verdict to recoverable. If we deferred Try to step (3), step (2)
-// would have already shipped the verdict as a plain Deny — too late
-// to convert it. So Try MUST happen during step (1).
-//
-// The constraint propagates: this transform performs a session-state
-// mutation (consumes a budget slot) during eval, breaking the strict
-// "transform is pure" rule. We mitigate by splitting the work:
-//
-//   - tryPromoteTransient — pure function (ctx, verdict, cfg) →
-//     (verdict, consumedKey). Encapsulates the decision; returns the
-//     mutation it caused as data the caller can act on. No session
-//     reference.
-//   - session.applyTransientTransform — session method that wraps
-//     the pure function and owns the consumed-key tracking on the
-//     session, matching how session.evaluator / .finalize / .rollback
-//     own their session state.
-//   - rollbackVerdictSideEffects — calls TransientBudget.Release on
-//     every tracked key so a fail-closed response refunds the agent's
-//     retry slot. Same shape as the substitution / drift-outcome
-//     rollback.
-//
-// If the rewrite step ever moves AFTER commitVerdictSideEffects (e.g.
-// a two-pass rewrite where pass-1 discovers tool_uses and pass-2
-// emits the body using post-commit verdicts), this transform could be
-// converted to a true deferred spec — that restructure was considered
-// and rejected as disproportionate to the single use site today
-// (script-session judge timeout). Revisit if more transient sites
-// land.
-
 package postproc
 
 import (
@@ -58,21 +7,16 @@ import (
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy"
 )
 
-// tryPromoteTransient is the pure-function half of the transient-deny
-// transform pipeline. It decides whether the Deny verdict should be
-// promoted to a RecoverableDeny based on the (agent, conversation,
-// failure class) budget, and returns:
+// tryPromoteTransient is the pure-function decision for whether a
+// Deny verdict tagged with TransientFailureClass should be promoted
+// to a RecoverableDeny on this attempt. Returns the (possibly
+// promoted) verdict and the consumed budget key — nil when no
+// promotion fired.
 //
-//   - the resulting verdict (mutated only when promotion fires)
-//   - the consumed key, when promotion fired — otherwise nil
-//
-// The session method that wraps this owns the consumed-key tracking
-// for rollback; this function stays free of session state so it
-// matches the pure-transform shape the other postproc transforms use
-// (transformRecoverableDenyToPlaceholder etc.). The Try call must
-// happen here (not in commitVerdictSideEffects) because the
-// downstream transformRecoverableDenyToPlaceholder needs the promoted
-// RecoverableReason BEFORE the rewriter consumes the verdict shape.
+// Called from session.promoteTransients during commitVerdictSideEffects.
+// The wrapping session method owns the consumed-key tracking for
+// rollback so this function stays free of session state, matching the
+// pure shape transformRecoverableDenyToPlaceholder uses.
 //
 // Skipped (verdict returned unchanged, nil key) when:
 //   - not a Deny verdict, or TransientFailureClass is empty

--- a/internal/runtime/llmproxy/postproc/transient_deny.go
+++ b/internal/runtime/llmproxy/postproc/transient_deny.go
@@ -1,0 +1,57 @@
+package postproc
+
+import (
+	"context"
+
+	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy"
+)
+
+// transformTransientDenyToRecoverable promotes a Deny verdict marked
+// with TransientFailureClass to a RecoverableDeny on its FIRST
+// occurrence per (agent, conversation, failure class) within the
+// TransientBudget's TTL. The downstream transformRecoverableDenyToPlaceholder
+// then converts the promoted verdict into the standard one-shot
+// continuation retry shape.
+//
+// On subsequent occurrences (budget exhausted) the verdict passes
+// through as a plain Deny so chronic failures surface to the user
+// instead of looping. This realizes the "at most once per error class"
+// retry policy for transient failures (judge timeout, nonce-mint
+// hiccup, decision-engine RPC blip).
+//
+// Skipped (verdict returned unchanged) when:
+//   - not a Deny verdict, or TransientFailureClass is empty
+//   - RecoverableReason is already set — a prior layer already chose
+//     the recoverable shape and we must not double-process
+//   - TransientBudget is unconfigured — fall through to plain Deny so
+//     missing wiring is loud, not silently lenient
+//   - identity tuple (AgentID, ConversationID) is incomplete — the
+//     budget key would collapse across distinct conversations from the
+//     same agent, so degrade safely to plain Deny rather than misroute
+func transformTransientDenyToRecoverable(
+	ctx context.Context,
+	v conversation.ToolUseVerdict,
+	_ conversation.ToolUse,
+	cfg llmproxy.PostprocessConfig,
+) conversation.ToolUseVerdict {
+	if v.Outcome != conversation.OutcomeDeny || v.TransientFailureClass == "" {
+		return v
+	}
+	if v.RecoverableReason != "" {
+		return v
+	}
+	budget := cfg.AuthorizationContext.TransientBudget
+	if budget == nil {
+		return v
+	}
+	if cfg.AgentContext.AgentID == "" || cfg.AuditContext.ConversationID == "" {
+		return v
+	}
+	if !budget.Try(ctx, cfg.AgentContext.AgentID, cfg.AuditContext.ConversationID, v.TransientFailureClass) {
+		return v
+	}
+	v.RecoverableReason = v.Reason
+	v.SubstituteWith = v.Reason
+	return v
+}

--- a/internal/runtime/llmproxy/postproc/transient_deny_test.go
+++ b/internal/runtime/llmproxy/postproc/transient_deny_test.go
@@ -9,8 +9,10 @@ import (
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy"
 )
 
-// Shared fixture: a tool_use + base PostprocessConfig wired with an
-// identity tuple and a fresh transient budget.
+// Shared fixture: a Deny verdict tagged with a failure class + base
+// PostprocessConfig wired with an identity tuple and a fresh transient
+// budget. Returns the verdict, an unused tool_use (kept for callers
+// that need it for end-to-end tests), and the cfg.
 func transientDenyTestSetup(failureClass string) (conversation.ToolUseVerdict, conversation.ToolUse, llmproxy.PostprocessConfig) {
 	tu := conversation.ToolUse{
 		ID:    "tu-transient-1",
@@ -28,134 +30,118 @@ func transientDenyTestSetup(failureClass string) (conversation.ToolUseVerdict, c
 	return v, tu, cfg
 }
 
-// Allow / Skip verdicts must pass through untouched.
-func TestTransformTransientDenyToRecoverable_LeavesNonTransientAlone(t *testing.T) {
-	_, tu, cfg := transientDenyTestSetup("any")
+// Allow / Skip verdicts must pass through untouched and yield no key.
+func TestTryPromoteTransient_LeavesNonTransientAlone(t *testing.T) {
+	_, _, cfg := transientDenyTestSetup("any")
 	verdict := conversation.ToolUseVerdict{Outcome: conversation.OutcomeAllow, Allowed: true}
-	got := transformTransientDenyToRecoverable(context.Background(), verdict, tu, cfg, nil)
+	got, key := tryPromoteTransient(context.Background(), verdict, cfg)
 	if got.RecoverableReason != "" {
 		t.Fatalf("non-transient verdict must not gain RecoverableReason; got %q", got.RecoverableReason)
 	}
 	if got.TransientFailureClass != "" {
 		t.Fatalf("non-transient verdict must not gain TransientFailureClass; got %q", got.TransientFailureClass)
 	}
+	if key != nil {
+		t.Fatalf("non-transient verdict must not yield a consumed key; got %+v", key)
+	}
 }
 
 // Plain Deny without TransientFailureClass must pass through.
-func TestTransformTransientDenyToRecoverable_LeavesPlainDenyAlone(t *testing.T) {
-	_, tu, cfg := transientDenyTestSetup("any")
+func TestTryPromoteTransient_LeavesPlainDenyAlone(t *testing.T) {
+	_, _, cfg := transientDenyTestSetup("any")
 	verdict := conversation.ToolUseVerdict{Outcome: conversation.OutcomeDeny, Reason: "plain"}
-	got := transformTransientDenyToRecoverable(context.Background(), verdict, tu, cfg, nil)
+	got, key := tryPromoteTransient(context.Background(), verdict, cfg)
 	if got.RecoverableReason != "" {
 		t.Fatalf("plain Deny must not be promoted; got RecoverableReason=%q", got.RecoverableReason)
+	}
+	if key != nil {
+		t.Fatalf("plain Deny must not yield a consumed key; got %+v", key)
 	}
 }
 
 // If RecoverableReason is already set, the transient transform must not
 // touch it — a prior layer chose the recoverable shape and re-running
-// would be a double-process.
-func TestTransformTransientDenyToRecoverable_LeavesRecoverableAlone(t *testing.T) {
-	_, tu, cfg := transientDenyTestSetup("class")
+// would be a double-process. Likewise no key is consumed.
+func TestTryPromoteTransient_LeavesRecoverableAlone(t *testing.T) {
+	_, _, cfg := transientDenyTestSetup("class")
 	v := conversation.TransientDenyVerdict("class", "transient reason")
 	v.RecoverableReason = "already recoverable"
-	got := transformTransientDenyToRecoverable(context.Background(), v, tu, cfg, nil)
+	got, key := tryPromoteTransient(context.Background(), v, cfg)
 	if got.RecoverableReason != "already recoverable" {
 		t.Fatalf("transform must not overwrite an existing RecoverableReason; got %q", got.RecoverableReason)
+	}
+	if key != nil {
+		t.Fatalf("must not consume budget for already-recoverable verdict; got %+v", key)
 	}
 }
 
 // Missing identity tuple → safe degrade to plain Deny.
-func TestTransformTransientDenyToRecoverable_RequiresIdentity(t *testing.T) {
-	v, tu, cfg := transientDenyTestSetup("class")
+func TestTryPromoteTransient_RequiresIdentity(t *testing.T) {
+	v, _, cfg := transientDenyTestSetup("class")
 	cfg.AgentContext.AgentID = ""
-	got := transformTransientDenyToRecoverable(context.Background(), v, tu, cfg, nil)
-	if got.RecoverableReason != "" {
-		t.Fatalf("missing AgentID should NOT promote to recoverable; got %q", got.RecoverableReason)
+	got, key := tryPromoteTransient(context.Background(), v, cfg)
+	if got.RecoverableReason != "" || key != nil {
+		t.Fatalf("missing AgentID should NOT promote; got reason=%q key=%+v", got.RecoverableReason, key)
 	}
 
-	v2, tu2, cfg2 := transientDenyTestSetup("class")
+	v2, _, cfg2 := transientDenyTestSetup("class")
 	cfg2.AuditContext.ConversationID = ""
-	got2 := transformTransientDenyToRecoverable(context.Background(), v2, tu2, cfg2, nil)
-	if got2.RecoverableReason != "" {
-		t.Fatalf("missing ConversationID should NOT promote to recoverable; got %q", got2.RecoverableReason)
+	got2, key2 := tryPromoteTransient(context.Background(), v2, cfg2)
+	if got2.RecoverableReason != "" || key2 != nil {
+		t.Fatalf("missing ConversationID should NOT promote; got reason=%q key=%+v", got2.RecoverableReason, key2)
 	}
 }
 
 // Nil budget → safe degrade to plain Deny.
-func TestTransformTransientDenyToRecoverable_RequiresBudget(t *testing.T) {
-	v, tu, cfg := transientDenyTestSetup("class")
+func TestTryPromoteTransient_RequiresBudget(t *testing.T) {
+	v, _, cfg := transientDenyTestSetup("class")
 	cfg.AuthorizationContext.TransientBudget = nil
-	got := transformTransientDenyToRecoverable(context.Background(), v, tu, cfg, nil)
-	if got.RecoverableReason != "" {
-		t.Fatalf("nil budget should NOT promote to recoverable; got %q", got.RecoverableReason)
+	got, key := tryPromoteTransient(context.Background(), v, cfg)
+	if got.RecoverableReason != "" || key != nil {
+		t.Fatalf("nil budget should NOT promote; got reason=%q key=%+v", got.RecoverableReason, key)
 	}
 }
 
-// First call: budget is consumed and the verdict is promoted to
-// RecoverableDeny shape (RecoverableReason populated, SubstituteWith
-// populated, TransientFailureClass preserved for audit). Also asserts
-// the tracker callback fires with the correct key — the session uses
-// that to refund the slot on fail-closed rollback.
-func TestTransformTransientDenyToRecoverable_FirstCallPromotesAndTracks(t *testing.T) {
-	v, tu, cfg := transientDenyTestSetup("class-x")
-	var tracked []llmproxy.TransientBudgetKey
-	got := transformTransientDenyToRecoverable(context.Background(), v, tu, cfg, func(k llmproxy.TransientBudgetKey) {
-		tracked = append(tracked, k)
-	})
+// First call: verdict is promoted (RecoverableReason + SubstituteWith
+// populated, TransientFailureClass preserved) AND the consumed key is
+// returned so the wrapping session method can track it for rollback.
+func TestTryPromoteTransient_FirstCallPromotesAndReturnsKey(t *testing.T) {
+	v, _, cfg := transientDenyTestSetup("class-x")
+	got, key := tryPromoteTransient(context.Background(), v, cfg)
 	if got.RecoverableReason != v.Reason {
-		t.Fatalf("first call should set RecoverableReason to verdict reason; got %q, want %q", got.RecoverableReason, v.Reason)
+		t.Fatalf("first call should set RecoverableReason; got %q, want %q", got.RecoverableReason, v.Reason)
 	}
 	if got.SubstituteWith != v.Reason {
-		t.Fatalf("first call should set SubstituteWith to verdict reason; got %q", got.SubstituteWith)
+		t.Fatalf("first call should set SubstituteWith; got %q", got.SubstituteWith)
 	}
 	if got.TransientFailureClass != "class-x" {
-		t.Fatalf("TransientFailureClass should be preserved through the transform; got %q", got.TransientFailureClass)
+		t.Fatalf("TransientFailureClass should be preserved; got %q", got.TransientFailureClass)
 	}
 	want := llmproxy.TransientBudgetKey{
 		AgentID:        cfg.AgentContext.AgentID,
 		ConversationID: cfg.AuditContext.ConversationID,
 		FailureClass:   "class-x",
 	}
-	if len(tracked) != 1 || tracked[0] != want {
-		t.Fatalf("expected tracker to receive %+v exactly once; got %+v", want, tracked)
+	if key == nil || *key != want {
+		t.Fatalf("expected consumed key %+v; got %+v", want, key)
 	}
 }
 
-// Tracker is only called when the budget was consumed — second call
-// (budget exhausted) must not fire it. Pins the contract the session
-// rollback relies on (refund list = actual consumes).
-func TestTransformTransientDenyToRecoverable_TrackerSkippedOnBudgetExhausted(t *testing.T) {
-	v, tu, cfg := transientDenyTestSetup("class-x")
-	if got := transformTransientDenyToRecoverable(context.Background(), v, tu, cfg, nil); got.RecoverableReason == "" {
-		t.Fatal("precondition: first call should promote")
+// Second call same (agent, conv, class): budget exhausted, no
+// promotion, no key returned. Pins the contract the session rollback
+// relies on (returned-key list = actual consumes).
+func TestTryPromoteTransient_SecondCallReturnsNoKey(t *testing.T) {
+	v, _, cfg := transientDenyTestSetup("class-x")
+	if _, key := tryPromoteTransient(context.Background(), v, cfg); key == nil {
+		t.Fatal("precondition: first call should consume budget")
 	}
-	var tracked []llmproxy.TransientBudgetKey
 	v2 := conversation.TransientDenyVerdict("class-x", "retry reason")
-	got := transformTransientDenyToRecoverable(context.Background(), v2, tu, cfg, func(k llmproxy.TransientBudgetKey) {
-		tracked = append(tracked, k)
-	})
+	got, key := tryPromoteTransient(context.Background(), v2, cfg)
 	if got.RecoverableReason != "" {
 		t.Fatalf("second call should not promote (budget exhausted); got %q", got.RecoverableReason)
 	}
-	if len(tracked) != 0 {
-		t.Fatalf("tracker must not fire when Try returned false; got %+v", tracked)
-	}
-}
-
-// Second call same (agent, conv, class): budget exhausted, verdict
-// passes through as a plain Deny (RecoverableReason stays empty).
-func TestTransformTransientDenyToRecoverable_SecondCallFallsThroughAsPlainDeny(t *testing.T) {
-	v, tu, cfg := transientDenyTestSetup("class-x")
-	first := transformTransientDenyToRecoverable(context.Background(), v, tu, cfg, nil)
-	if first.RecoverableReason == "" {
-		t.Fatal("first call should promote (precondition)")
-	}
-	// Build a fresh verdict for the retry — the upstream evaluator
-	// produces a new one each time.
-	v2 := conversation.TransientDenyVerdict("class-x", "retry reason")
-	got := transformTransientDenyToRecoverable(context.Background(), v2, tu, cfg, nil)
-	if got.RecoverableReason != "" {
-		t.Fatalf("second call should not promote (budget exhausted); got RecoverableReason=%q", got.RecoverableReason)
+	if key != nil {
+		t.Fatalf("second call should NOT yield a key when Try returned false; got %+v", key)
 	}
 	if got.Outcome != conversation.OutcomeDeny {
 		t.Fatalf("second call should remain Deny; got %v", got.Outcome)
@@ -163,21 +149,73 @@ func TestTransformTransientDenyToRecoverable_SecondCallFallsThroughAsPlainDeny(t
 }
 
 // Different failure class on the same (agent, conv): independent budget.
-func TestTransformTransientDenyToRecoverable_DistinctClassesIndependent(t *testing.T) {
-	_, tu, cfg := transientDenyTestSetup("class-a")
+func TestTryPromoteTransient_DistinctClassesIndependent(t *testing.T) {
+	_, _, cfg := transientDenyTestSetup("class-a")
 	vA := conversation.TransientDenyVerdict("class-a", "reason A")
-	gotA := transformTransientDenyToRecoverable(context.Background(), vA, tu, cfg, nil)
-	if gotA.RecoverableReason == "" {
+	if _, key := tryPromoteTransient(context.Background(), vA, cfg); key == nil {
 		t.Fatal("class-a first call should promote")
 	}
 	vB := conversation.TransientDenyVerdict("class-b", "reason B")
-	gotB := transformTransientDenyToRecoverable(context.Background(), vB, tu, cfg, nil)
-	if gotB.RecoverableReason == "" {
+	if _, key := tryPromoteTransient(context.Background(), vB, cfg); key == nil {
 		t.Fatal("class-b first call should promote independently of class-a")
 	}
 }
 
-// Session rollback must refund every consumed transient slot via
+// Different conversation on the same class: independent budget.
+func TestTryPromoteTransient_DistinctConversationsIndependent(t *testing.T) {
+	v1, _, cfg1 := transientDenyTestSetup("class-x")
+	if _, key := tryPromoteTransient(context.Background(), v1, cfg1); key == nil {
+		t.Fatal("conv-1 first call should promote")
+	}
+	v2, _, cfg2 := transientDenyTestSetup("class-x")
+	cfg2.AuditContext.ConversationID = "conv-different"
+	cfg2.AuthorizationContext.TransientBudget = cfg1.AuthorizationContext.TransientBudget
+	if _, key := tryPromoteTransient(context.Background(), v2, cfg2); key == nil {
+		t.Fatal("conv-2 first call should promote even though conv-1 already consumed its budget")
+	}
+}
+
+// applyTransientTransform wraps the pure function with session-owned
+// tracking. The wrapper IS the call site the eval closures use, so
+// it's worth pinning that:
+//   - it returns the same promoted verdict the pure function does
+//   - it accumulates the consumed key on the session for rollback
+//   - on a non-promote, it accumulates nothing (no spurious entries)
+func TestSession_ApplyTransientTransform_TracksConsumeForRollback(t *testing.T) {
+	v, _, cfg := transientDenyTestSetup("class-x")
+	session := newPostprocessSession(cfg)
+	got := session.applyTransientTransform(context.Background(), v, cfg)
+	if got.RecoverableReason == "" {
+		t.Fatal("first call should promote (precondition)")
+	}
+	if len(session.transientConsumed) != 1 {
+		t.Fatalf("expected 1 tracked consume; got %d (%+v)", len(session.transientConsumed), session.transientConsumed)
+	}
+	want := llmproxy.TransientBudgetKey{
+		AgentID:        cfg.AgentContext.AgentID,
+		ConversationID: cfg.AuditContext.ConversationID,
+		FailureClass:   "class-x",
+	}
+	if session.transientConsumed[0] != want {
+		t.Fatalf("tracked key = %+v; want %+v", session.transientConsumed[0], want)
+	}
+}
+
+func TestSession_ApplyTransientTransform_DoesNotTrackNonPromotes(t *testing.T) {
+	v, _, cfg := transientDenyTestSetup("class-x")
+	session := newPostprocessSession(cfg)
+	if got := session.applyTransientTransform(context.Background(), v, cfg); got.RecoverableReason == "" {
+		t.Fatal("precondition: first call should promote")
+	}
+	// Second call same class — budget exhausted, must not track.
+	v2 := conversation.TransientDenyVerdict("class-x", "retry reason")
+	session.applyTransientTransform(context.Background(), v2, cfg)
+	if len(session.transientConsumed) != 1 {
+		t.Fatalf("expected 1 tracked consume (not the second non-promote); got %d", len(session.transientConsumed))
+	}
+}
+
+// End-to-end: session rollback refunds every tracked consume via
 // TransientBudget.Release so a fail-closed response doesn't burn the
 // agent's one retry token for a recoverable verdict they never saw.
 func TestPostprocessSession_RollbackRefundsConsumedTransientSlots(t *testing.T) {
@@ -197,7 +235,7 @@ func TestPostprocessSession_RollbackRefundsConsumedTransientSlots(t *testing.T) 
 		Input: json.RawMessage(`{"command":"curl"}`),
 	}
 	v := conversation.TransientDenyVerdict("class-x", "transient")
-	got := transformTransientDenyToRecoverable(context.Background(), v, tu, cfg, session.trackTransientConsumed)
+	got := session.applyTransientTransform(context.Background(), v, cfg)
 	if got.RecoverableReason == "" {
 		t.Fatal("precondition: first call should promote and consume budget")
 	}
@@ -210,30 +248,9 @@ func TestPostprocessSession_RollbackRefundsConsumedTransientSlots(t *testing.T) 
 		t.Fatal("precondition: budget should be consumed after promote")
 	}
 
-	// Simulate fail-closed: rollback runs.
 	session.rollback(context.Background(), []conversation.ToolUse{tu}, map[string]conversation.ToolUseVerdict{tu.ID: got})
 
-	// Slot is refunded — a subsequent attempt for the same key should
-	// succeed (it's the agent's first real retry).
 	if !budget.Try(context.Background(), key) {
-		t.Fatal("after rollback, transient budget slot should be refunded so the next real attempt promotes")
-	}
-}
-
-// Different conversation on the same class: independent budget.
-func TestTransformTransientDenyToRecoverable_DistinctConversationsIndependent(t *testing.T) {
-	v1, tu1, cfg1 := transientDenyTestSetup("class-x")
-	got1 := transformTransientDenyToRecoverable(context.Background(), v1, tu1, cfg1, nil)
-	if got1.RecoverableReason == "" {
-		t.Fatal("conv-1 first call should promote")
-	}
-	v2, tu2, cfg2 := transientDenyTestSetup("class-x")
-	cfg2.AuditContext.ConversationID = "conv-different"
-	// Reuse cfg1's budget so we're testing key-by-conversation,
-	// not budget isolation.
-	cfg2.AuthorizationContext.TransientBudget = cfg1.AuthorizationContext.TransientBudget
-	got2 := transformTransientDenyToRecoverable(context.Background(), v2, tu2, cfg2, nil)
-	if got2.RecoverableReason == "" {
-		t.Fatal("conv-2 first call should promote even though conv-1 already consumed its budget")
+		t.Fatal("after rollback, transient slot should be refunded so the next real attempt promotes")
 	}
 }

--- a/internal/runtime/llmproxy/postproc/transient_deny_test.go
+++ b/internal/runtime/llmproxy/postproc/transient_deny_test.go
@@ -32,7 +32,7 @@ func transientDenyTestSetup(failureClass string) (conversation.ToolUseVerdict, c
 func TestTransformTransientDenyToRecoverable_LeavesNonTransientAlone(t *testing.T) {
 	_, tu, cfg := transientDenyTestSetup("any")
 	verdict := conversation.ToolUseVerdict{Outcome: conversation.OutcomeAllow, Allowed: true}
-	got := transformTransientDenyToRecoverable(context.Background(), verdict, tu, cfg)
+	got := transformTransientDenyToRecoverable(context.Background(), verdict, tu, cfg, nil)
 	if got.RecoverableReason != "" {
 		t.Fatalf("non-transient verdict must not gain RecoverableReason; got %q", got.RecoverableReason)
 	}
@@ -45,7 +45,7 @@ func TestTransformTransientDenyToRecoverable_LeavesNonTransientAlone(t *testing.
 func TestTransformTransientDenyToRecoverable_LeavesPlainDenyAlone(t *testing.T) {
 	_, tu, cfg := transientDenyTestSetup("any")
 	verdict := conversation.ToolUseVerdict{Outcome: conversation.OutcomeDeny, Reason: "plain"}
-	got := transformTransientDenyToRecoverable(context.Background(), verdict, tu, cfg)
+	got := transformTransientDenyToRecoverable(context.Background(), verdict, tu, cfg, nil)
 	if got.RecoverableReason != "" {
 		t.Fatalf("plain Deny must not be promoted; got RecoverableReason=%q", got.RecoverableReason)
 	}
@@ -58,7 +58,7 @@ func TestTransformTransientDenyToRecoverable_LeavesRecoverableAlone(t *testing.T
 	_, tu, cfg := transientDenyTestSetup("class")
 	v := conversation.TransientDenyVerdict("class", "transient reason")
 	v.RecoverableReason = "already recoverable"
-	got := transformTransientDenyToRecoverable(context.Background(), v, tu, cfg)
+	got := transformTransientDenyToRecoverable(context.Background(), v, tu, cfg, nil)
 	if got.RecoverableReason != "already recoverable" {
 		t.Fatalf("transform must not overwrite an existing RecoverableReason; got %q", got.RecoverableReason)
 	}
@@ -68,14 +68,14 @@ func TestTransformTransientDenyToRecoverable_LeavesRecoverableAlone(t *testing.T
 func TestTransformTransientDenyToRecoverable_RequiresIdentity(t *testing.T) {
 	v, tu, cfg := transientDenyTestSetup("class")
 	cfg.AgentContext.AgentID = ""
-	got := transformTransientDenyToRecoverable(context.Background(), v, tu, cfg)
+	got := transformTransientDenyToRecoverable(context.Background(), v, tu, cfg, nil)
 	if got.RecoverableReason != "" {
 		t.Fatalf("missing AgentID should NOT promote to recoverable; got %q", got.RecoverableReason)
 	}
 
 	v2, tu2, cfg2 := transientDenyTestSetup("class")
 	cfg2.AuditContext.ConversationID = ""
-	got2 := transformTransientDenyToRecoverable(context.Background(), v2, tu2, cfg2)
+	got2 := transformTransientDenyToRecoverable(context.Background(), v2, tu2, cfg2, nil)
 	if got2.RecoverableReason != "" {
 		t.Fatalf("missing ConversationID should NOT promote to recoverable; got %q", got2.RecoverableReason)
 	}
@@ -85,7 +85,7 @@ func TestTransformTransientDenyToRecoverable_RequiresIdentity(t *testing.T) {
 func TestTransformTransientDenyToRecoverable_RequiresBudget(t *testing.T) {
 	v, tu, cfg := transientDenyTestSetup("class")
 	cfg.AuthorizationContext.TransientBudget = nil
-	got := transformTransientDenyToRecoverable(context.Background(), v, tu, cfg)
+	got := transformTransientDenyToRecoverable(context.Background(), v, tu, cfg, nil)
 	if got.RecoverableReason != "" {
 		t.Fatalf("nil budget should NOT promote to recoverable; got %q", got.RecoverableReason)
 	}
@@ -93,10 +93,15 @@ func TestTransformTransientDenyToRecoverable_RequiresBudget(t *testing.T) {
 
 // First call: budget is consumed and the verdict is promoted to
 // RecoverableDeny shape (RecoverableReason populated, SubstituteWith
-// populated, TransientFailureClass preserved for audit).
-func TestTransformTransientDenyToRecoverable_FirstCallPromotes(t *testing.T) {
+// populated, TransientFailureClass preserved for audit). Also asserts
+// the tracker callback fires with the correct key — the session uses
+// that to refund the slot on fail-closed rollback.
+func TestTransformTransientDenyToRecoverable_FirstCallPromotesAndTracks(t *testing.T) {
 	v, tu, cfg := transientDenyTestSetup("class-x")
-	got := transformTransientDenyToRecoverable(context.Background(), v, tu, cfg)
+	var tracked []llmproxy.TransientBudgetKey
+	got := transformTransientDenyToRecoverable(context.Background(), v, tu, cfg, func(k llmproxy.TransientBudgetKey) {
+		tracked = append(tracked, k)
+	})
 	if got.RecoverableReason != v.Reason {
 		t.Fatalf("first call should set RecoverableReason to verdict reason; got %q, want %q", got.RecoverableReason, v.Reason)
 	}
@@ -106,20 +111,49 @@ func TestTransformTransientDenyToRecoverable_FirstCallPromotes(t *testing.T) {
 	if got.TransientFailureClass != "class-x" {
 		t.Fatalf("TransientFailureClass should be preserved through the transform; got %q", got.TransientFailureClass)
 	}
+	want := llmproxy.TransientBudgetKey{
+		AgentID:        cfg.AgentContext.AgentID,
+		ConversationID: cfg.AuditContext.ConversationID,
+		FailureClass:   "class-x",
+	}
+	if len(tracked) != 1 || tracked[0] != want {
+		t.Fatalf("expected tracker to receive %+v exactly once; got %+v", want, tracked)
+	}
+}
+
+// Tracker is only called when the budget was consumed — second call
+// (budget exhausted) must not fire it. Pins the contract the session
+// rollback relies on (refund list = actual consumes).
+func TestTransformTransientDenyToRecoverable_TrackerSkippedOnBudgetExhausted(t *testing.T) {
+	v, tu, cfg := transientDenyTestSetup("class-x")
+	if got := transformTransientDenyToRecoverable(context.Background(), v, tu, cfg, nil); got.RecoverableReason == "" {
+		t.Fatal("precondition: first call should promote")
+	}
+	var tracked []llmproxy.TransientBudgetKey
+	v2 := conversation.TransientDenyVerdict("class-x", "retry reason")
+	got := transformTransientDenyToRecoverable(context.Background(), v2, tu, cfg, func(k llmproxy.TransientBudgetKey) {
+		tracked = append(tracked, k)
+	})
+	if got.RecoverableReason != "" {
+		t.Fatalf("second call should not promote (budget exhausted); got %q", got.RecoverableReason)
+	}
+	if len(tracked) != 0 {
+		t.Fatalf("tracker must not fire when Try returned false; got %+v", tracked)
+	}
 }
 
 // Second call same (agent, conv, class): budget exhausted, verdict
 // passes through as a plain Deny (RecoverableReason stays empty).
 func TestTransformTransientDenyToRecoverable_SecondCallFallsThroughAsPlainDeny(t *testing.T) {
 	v, tu, cfg := transientDenyTestSetup("class-x")
-	first := transformTransientDenyToRecoverable(context.Background(), v, tu, cfg)
+	first := transformTransientDenyToRecoverable(context.Background(), v, tu, cfg, nil)
 	if first.RecoverableReason == "" {
 		t.Fatal("first call should promote (precondition)")
 	}
 	// Build a fresh verdict for the retry — the upstream evaluator
 	// produces a new one each time.
 	v2 := conversation.TransientDenyVerdict("class-x", "retry reason")
-	got := transformTransientDenyToRecoverable(context.Background(), v2, tu, cfg)
+	got := transformTransientDenyToRecoverable(context.Background(), v2, tu, cfg, nil)
 	if got.RecoverableReason != "" {
 		t.Fatalf("second call should not promote (budget exhausted); got RecoverableReason=%q", got.RecoverableReason)
 	}
@@ -132,21 +166,64 @@ func TestTransformTransientDenyToRecoverable_SecondCallFallsThroughAsPlainDeny(t
 func TestTransformTransientDenyToRecoverable_DistinctClassesIndependent(t *testing.T) {
 	_, tu, cfg := transientDenyTestSetup("class-a")
 	vA := conversation.TransientDenyVerdict("class-a", "reason A")
-	gotA := transformTransientDenyToRecoverable(context.Background(), vA, tu, cfg)
+	gotA := transformTransientDenyToRecoverable(context.Background(), vA, tu, cfg, nil)
 	if gotA.RecoverableReason == "" {
 		t.Fatal("class-a first call should promote")
 	}
 	vB := conversation.TransientDenyVerdict("class-b", "reason B")
-	gotB := transformTransientDenyToRecoverable(context.Background(), vB, tu, cfg)
+	gotB := transformTransientDenyToRecoverable(context.Background(), vB, tu, cfg, nil)
 	if gotB.RecoverableReason == "" {
 		t.Fatal("class-b first call should promote independently of class-a")
+	}
+}
+
+// Session rollback must refund every consumed transient slot via
+// TransientBudget.Release so a fail-closed response doesn't burn the
+// agent's one retry token for a recoverable verdict they never saw.
+func TestPostprocessSession_RollbackRefundsConsumedTransientSlots(t *testing.T) {
+	budget := llmproxy.NewMemoryTransientBudget(0)
+	cfg := llmproxy.PostprocessConfig{
+		AgentContext: llmproxy.AgentContext{AgentID: "agent-rollback", AgentUserID: "user-rollback"},
+		AuditContext: llmproxy.AuditContext{ConversationID: "conv-rollback"},
+		AuthorizationContext: llmproxy.AuthorizationContext{
+			TransientBudget: budget,
+		},
+	}
+	session := newPostprocessSession(cfg)
+
+	tu := conversation.ToolUse{
+		ID:    "tu-rollback",
+		Name:  "Bash",
+		Input: json.RawMessage(`{"command":"curl"}`),
+	}
+	v := conversation.TransientDenyVerdict("class-x", "transient")
+	got := transformTransientDenyToRecoverable(context.Background(), v, tu, cfg, session.trackTransientConsumed)
+	if got.RecoverableReason == "" {
+		t.Fatal("precondition: first call should promote and consume budget")
+	}
+	key := llmproxy.TransientBudgetKey{
+		AgentID:        cfg.AgentContext.AgentID,
+		ConversationID: cfg.AuditContext.ConversationID,
+		FailureClass:   "class-x",
+	}
+	if budget.Try(context.Background(), key) {
+		t.Fatal("precondition: budget should be consumed after promote")
+	}
+
+	// Simulate fail-closed: rollback runs.
+	session.rollback(context.Background(), []conversation.ToolUse{tu}, map[string]conversation.ToolUseVerdict{tu.ID: got})
+
+	// Slot is refunded — a subsequent attempt for the same key should
+	// succeed (it's the agent's first real retry).
+	if !budget.Try(context.Background(), key) {
+		t.Fatal("after rollback, transient budget slot should be refunded so the next real attempt promotes")
 	}
 }
 
 // Different conversation on the same class: independent budget.
 func TestTransformTransientDenyToRecoverable_DistinctConversationsIndependent(t *testing.T) {
 	v1, tu1, cfg1 := transientDenyTestSetup("class-x")
-	got1 := transformTransientDenyToRecoverable(context.Background(), v1, tu1, cfg1)
+	got1 := transformTransientDenyToRecoverable(context.Background(), v1, tu1, cfg1, nil)
 	if got1.RecoverableReason == "" {
 		t.Fatal("conv-1 first call should promote")
 	}
@@ -155,7 +232,7 @@ func TestTransformTransientDenyToRecoverable_DistinctConversationsIndependent(t 
 	// Reuse cfg1's budget so we're testing key-by-conversation,
 	// not budget isolation.
 	cfg2.AuthorizationContext.TransientBudget = cfg1.AuthorizationContext.TransientBudget
-	got2 := transformTransientDenyToRecoverable(context.Background(), v2, tu2, cfg2)
+	got2 := transformTransientDenyToRecoverable(context.Background(), v2, tu2, cfg2, nil)
 	if got2.RecoverableReason == "" {
 		t.Fatal("conv-2 first call should promote even though conv-1 already consumed its budget")
 	}

--- a/internal/runtime/llmproxy/postproc/transient_deny_test.go
+++ b/internal/runtime/llmproxy/postproc/transient_deny_test.go
@@ -25,6 +25,10 @@ func transientDenyTestSetup(failureClass string) (conversation.ToolUseVerdict, c
 		AuditContext: llmproxy.AuditContext{ConversationID: "conv-transient"},
 		AuthorizationContext: llmproxy.AuthorizationContext{
 			TransientBudget: llmproxy.NewMemoryTransientBudget(0),
+			// ScopeDrifts wired so the placeholder transform (which
+			// commit re-runs on promoted transients) can populate
+			// SubstituteWithToolCall + PendingSubstitution.
+			ScopeDrifts: llmproxy.NewMemoryScopeDriftRegistry(0),
 		},
 	}
 	return v, tu, cfg
@@ -175,18 +179,34 @@ func TestTryPromoteTransient_DistinctConversationsIndependent(t *testing.T) {
 	}
 }
 
-// applyTransientTransform wraps the pure function with session-owned
-// tracking. The wrapper IS the call site the eval closures use, so
-// it's worth pinning that:
-//   - it returns the same promoted verdict the pure function does
-//   - it accumulates the consumed key on the session for rollback
-//   - on a non-promote, it accumulates nothing (no spurious entries)
-func TestSession_ApplyTransientTransform_TracksConsumeForRollback(t *testing.T) {
-	v, _, cfg := transientDenyTestSetup("class-x")
+// commitVerdictSideEffects must promote transient-deny verdicts in
+// the verdictByTU map (set RecoverableReason, re-run placeholder
+// transform so PendingSubstitution gets set) AND track the consumed
+// key on the session for rollback. Pins the deferred-spec contract:
+// evaluators emit TransientDenyVerdict, commit decides.
+func TestSession_CommitPromotesTransientAndTracksConsume(t *testing.T) {
+	v, tu, cfg := transientDenyTestSetup("class-x")
 	session := newPostprocessSession(cfg)
-	got := session.applyTransientTransform(context.Background(), v, cfg)
-	if got.RecoverableReason == "" {
-		t.Fatal("first call should promote (precondition)")
+	verdictByTU := map[string]conversation.ToolUseVerdict{tu.ID: v}
+	if err := session.commitVerdictSideEffects(context.Background(), verdictByTU, []conversation.ToolUse{tu}); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	got := verdictByTU[tu.ID]
+	// Promoted + placeholder-transformed: SubstituteWithToolCall holds
+	// the synthetic placeholder shape; PendingSubstitution carries the
+	// spec commit then registered; RecoverableReason was cleared by
+	// the placeholder migration (it owns the wire shape now).
+	if got.SubstituteWithToolCall == nil {
+		t.Fatalf("commit should have re-run placeholder transform on promoted verdict; got %+v", got)
+	}
+	if got.PendingSubstitution == nil {
+		t.Fatalf("commit should have populated PendingSubstitution from the placeholder migration; got %+v", got)
+	}
+	if !got.SuppressSubstituteText {
+		t.Fatalf("commit should have set SuppressSubstituteText=true on promoted verdict; got %+v", got)
+	}
+	if got.RecoverableReason != "" {
+		t.Fatalf("commit's re-run of placeholder transform should have cleared RecoverableReason; got %q", got.RecoverableReason)
 	}
 	if len(session.transientConsumed) != 1 {
 		t.Fatalf("expected 1 tracked consume; got %d (%+v)", len(session.transientConsumed), session.transientConsumed)
@@ -201,21 +221,32 @@ func TestSession_ApplyTransientTransform_TracksConsumeForRollback(t *testing.T) 
 	}
 }
 
-func TestSession_ApplyTransientTransform_DoesNotTrackNonPromotes(t *testing.T) {
-	v, _, cfg := transientDenyTestSetup("class-x")
+// Budget-exhausted commit must NOT mutate the verdict (still plain
+// Deny) and must NOT track a consume — only actual budget takes feed
+// the rollback list.
+func TestSession_CommitDoesNotTrackWhenBudgetExhausted(t *testing.T) {
+	v, tu, cfg := transientDenyTestSetup("class-x")
+	// Pre-consume the budget so the commit's Try returns false.
+	cfg.AuthorizationContext.TransientBudget.Try(context.Background(), llmproxy.TransientBudgetKey{
+		AgentID:        cfg.AgentContext.AgentID,
+		ConversationID: cfg.AuditContext.ConversationID,
+		FailureClass:   "class-x",
+	})
 	session := newPostprocessSession(cfg)
-	if got := session.applyTransientTransform(context.Background(), v, cfg); got.RecoverableReason == "" {
-		t.Fatal("precondition: first call should promote")
+	verdictByTU := map[string]conversation.ToolUseVerdict{tu.ID: v}
+	if err := session.commitVerdictSideEffects(context.Background(), verdictByTU, []conversation.ToolUse{tu}); err != nil {
+		t.Fatalf("commit: %v", err)
 	}
-	// Second call same class — budget exhausted, must not track.
-	v2 := conversation.TransientDenyVerdict("class-x", "retry reason")
-	session.applyTransientTransform(context.Background(), v2, cfg)
-	if len(session.transientConsumed) != 1 {
-		t.Fatalf("expected 1 tracked consume (not the second non-promote); got %d", len(session.transientConsumed))
+	got := verdictByTU[tu.ID]
+	if got.RecoverableReason != "" {
+		t.Fatalf("budget-exhausted commit must NOT promote; got RecoverableReason=%q", got.RecoverableReason)
+	}
+	if len(session.transientConsumed) != 0 {
+		t.Fatalf("budget-exhausted commit must NOT track; got %+v", session.transientConsumed)
 	}
 }
 
-// End-to-end: session rollback refunds every tracked consume via
+// End-to-end: session rollback refunds every consume commit made via
 // TransientBudget.Release so a fail-closed response doesn't burn the
 // agent's one retry token for a recoverable verdict they never saw.
 func TestPostprocessSession_RollbackRefundsConsumedTransientSlots(t *testing.T) {
@@ -235,9 +266,12 @@ func TestPostprocessSession_RollbackRefundsConsumedTransientSlots(t *testing.T) 
 		Input: json.RawMessage(`{"command":"curl"}`),
 	}
 	v := conversation.TransientDenyVerdict("class-x", "transient")
-	got := session.applyTransientTransform(context.Background(), v, cfg)
-	if got.RecoverableReason == "" {
-		t.Fatal("precondition: first call should promote and consume budget")
+	verdictByTU := map[string]conversation.ToolUseVerdict{tu.ID: v}
+	if err := session.commitVerdictSideEffects(context.Background(), verdictByTU, []conversation.ToolUse{tu}); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	if verdictByTU[tu.ID].RecoverableReason == "" {
+		t.Fatal("precondition: commit should have promoted and consumed budget")
 	}
 	key := llmproxy.TransientBudgetKey{
 		AgentID:        cfg.AgentContext.AgentID,
@@ -245,8 +279,9 @@ func TestPostprocessSession_RollbackRefundsConsumedTransientSlots(t *testing.T) 
 		FailureClass:   "class-x",
 	}
 	if budget.Try(context.Background(), key) {
-		t.Fatal("precondition: budget should be consumed after promote")
+		t.Fatal("precondition: budget should be consumed after commit")
 	}
+	got := verdictByTU[tu.ID]
 
 	session.rollback(context.Background(), []conversation.ToolUse{tu}, map[string]conversation.ToolUseVerdict{tu.ID: got})
 

--- a/internal/runtime/llmproxy/postproc/transient_deny_test.go
+++ b/internal/runtime/llmproxy/postproc/transient_deny_test.go
@@ -1,0 +1,162 @@
+package postproc
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy"
+)
+
+// Shared fixture: a tool_use + base PostprocessConfig wired with an
+// identity tuple and a fresh transient budget.
+func transientDenyTestSetup(failureClass string) (conversation.ToolUseVerdict, conversation.ToolUse, llmproxy.PostprocessConfig) {
+	tu := conversation.ToolUse{
+		ID:    "tu-transient-1",
+		Name:  "Bash",
+		Input: json.RawMessage(`{"command":"curl https://example.com"}`),
+	}
+	v := conversation.TransientDenyVerdict(failureClass, "Clawvisor: judge timed out. Please retry.")
+	cfg := llmproxy.PostprocessConfig{
+		AgentContext: llmproxy.AgentContext{AgentID: "agent-transient", AgentUserID: "user-transient"},
+		AuditContext: llmproxy.AuditContext{ConversationID: "conv-transient"},
+		AuthorizationContext: llmproxy.AuthorizationContext{
+			TransientBudget: llmproxy.NewMemoryTransientBudget(0),
+		},
+	}
+	return v, tu, cfg
+}
+
+// Allow / Skip verdicts must pass through untouched.
+func TestTransformTransientDenyToRecoverable_LeavesNonTransientAlone(t *testing.T) {
+	_, tu, cfg := transientDenyTestSetup("any")
+	verdict := conversation.ToolUseVerdict{Outcome: conversation.OutcomeAllow, Allowed: true}
+	got := transformTransientDenyToRecoverable(context.Background(), verdict, tu, cfg)
+	if got.RecoverableReason != "" {
+		t.Fatalf("non-transient verdict must not gain RecoverableReason; got %q", got.RecoverableReason)
+	}
+	if got.TransientFailureClass != "" {
+		t.Fatalf("non-transient verdict must not gain TransientFailureClass; got %q", got.TransientFailureClass)
+	}
+}
+
+// Plain Deny without TransientFailureClass must pass through.
+func TestTransformTransientDenyToRecoverable_LeavesPlainDenyAlone(t *testing.T) {
+	_, tu, cfg := transientDenyTestSetup("any")
+	verdict := conversation.ToolUseVerdict{Outcome: conversation.OutcomeDeny, Reason: "plain"}
+	got := transformTransientDenyToRecoverable(context.Background(), verdict, tu, cfg)
+	if got.RecoverableReason != "" {
+		t.Fatalf("plain Deny must not be promoted; got RecoverableReason=%q", got.RecoverableReason)
+	}
+}
+
+// If RecoverableReason is already set, the transient transform must not
+// touch it — a prior layer chose the recoverable shape and re-running
+// would be a double-process.
+func TestTransformTransientDenyToRecoverable_LeavesRecoverableAlone(t *testing.T) {
+	_, tu, cfg := transientDenyTestSetup("class")
+	v := conversation.TransientDenyVerdict("class", "transient reason")
+	v.RecoverableReason = "already recoverable"
+	got := transformTransientDenyToRecoverable(context.Background(), v, tu, cfg)
+	if got.RecoverableReason != "already recoverable" {
+		t.Fatalf("transform must not overwrite an existing RecoverableReason; got %q", got.RecoverableReason)
+	}
+}
+
+// Missing identity tuple → safe degrade to plain Deny.
+func TestTransformTransientDenyToRecoverable_RequiresIdentity(t *testing.T) {
+	v, tu, cfg := transientDenyTestSetup("class")
+	cfg.AgentContext.AgentID = ""
+	got := transformTransientDenyToRecoverable(context.Background(), v, tu, cfg)
+	if got.RecoverableReason != "" {
+		t.Fatalf("missing AgentID should NOT promote to recoverable; got %q", got.RecoverableReason)
+	}
+
+	v2, tu2, cfg2 := transientDenyTestSetup("class")
+	cfg2.AuditContext.ConversationID = ""
+	got2 := transformTransientDenyToRecoverable(context.Background(), v2, tu2, cfg2)
+	if got2.RecoverableReason != "" {
+		t.Fatalf("missing ConversationID should NOT promote to recoverable; got %q", got2.RecoverableReason)
+	}
+}
+
+// Nil budget → safe degrade to plain Deny.
+func TestTransformTransientDenyToRecoverable_RequiresBudget(t *testing.T) {
+	v, tu, cfg := transientDenyTestSetup("class")
+	cfg.AuthorizationContext.TransientBudget = nil
+	got := transformTransientDenyToRecoverable(context.Background(), v, tu, cfg)
+	if got.RecoverableReason != "" {
+		t.Fatalf("nil budget should NOT promote to recoverable; got %q", got.RecoverableReason)
+	}
+}
+
+// First call: budget is consumed and the verdict is promoted to
+// RecoverableDeny shape (RecoverableReason populated, SubstituteWith
+// populated, TransientFailureClass preserved for audit).
+func TestTransformTransientDenyToRecoverable_FirstCallPromotes(t *testing.T) {
+	v, tu, cfg := transientDenyTestSetup("class-x")
+	got := transformTransientDenyToRecoverable(context.Background(), v, tu, cfg)
+	if got.RecoverableReason != v.Reason {
+		t.Fatalf("first call should set RecoverableReason to verdict reason; got %q, want %q", got.RecoverableReason, v.Reason)
+	}
+	if got.SubstituteWith != v.Reason {
+		t.Fatalf("first call should set SubstituteWith to verdict reason; got %q", got.SubstituteWith)
+	}
+	if got.TransientFailureClass != "class-x" {
+		t.Fatalf("TransientFailureClass should be preserved through the transform; got %q", got.TransientFailureClass)
+	}
+}
+
+// Second call same (agent, conv, class): budget exhausted, verdict
+// passes through as a plain Deny (RecoverableReason stays empty).
+func TestTransformTransientDenyToRecoverable_SecondCallFallsThroughAsPlainDeny(t *testing.T) {
+	v, tu, cfg := transientDenyTestSetup("class-x")
+	first := transformTransientDenyToRecoverable(context.Background(), v, tu, cfg)
+	if first.RecoverableReason == "" {
+		t.Fatal("first call should promote (precondition)")
+	}
+	// Build a fresh verdict for the retry — the upstream evaluator
+	// produces a new one each time.
+	v2 := conversation.TransientDenyVerdict("class-x", "retry reason")
+	got := transformTransientDenyToRecoverable(context.Background(), v2, tu, cfg)
+	if got.RecoverableReason != "" {
+		t.Fatalf("second call should not promote (budget exhausted); got RecoverableReason=%q", got.RecoverableReason)
+	}
+	if got.Outcome != conversation.OutcomeDeny {
+		t.Fatalf("second call should remain Deny; got %v", got.Outcome)
+	}
+}
+
+// Different failure class on the same (agent, conv): independent budget.
+func TestTransformTransientDenyToRecoverable_DistinctClassesIndependent(t *testing.T) {
+	_, tu, cfg := transientDenyTestSetup("class-a")
+	vA := conversation.TransientDenyVerdict("class-a", "reason A")
+	gotA := transformTransientDenyToRecoverable(context.Background(), vA, tu, cfg)
+	if gotA.RecoverableReason == "" {
+		t.Fatal("class-a first call should promote")
+	}
+	vB := conversation.TransientDenyVerdict("class-b", "reason B")
+	gotB := transformTransientDenyToRecoverable(context.Background(), vB, tu, cfg)
+	if gotB.RecoverableReason == "" {
+		t.Fatal("class-b first call should promote independently of class-a")
+	}
+}
+
+// Different conversation on the same class: independent budget.
+func TestTransformTransientDenyToRecoverable_DistinctConversationsIndependent(t *testing.T) {
+	v1, tu1, cfg1 := transientDenyTestSetup("class-x")
+	got1 := transformTransientDenyToRecoverable(context.Background(), v1, tu1, cfg1)
+	if got1.RecoverableReason == "" {
+		t.Fatal("conv-1 first call should promote")
+	}
+	v2, tu2, cfg2 := transientDenyTestSetup("class-x")
+	cfg2.AuditContext.ConversationID = "conv-different"
+	// Reuse cfg1's budget so we're testing key-by-conversation,
+	// not budget isolation.
+	cfg2.AuthorizationContext.TransientBudget = cfg1.AuthorizationContext.TransientBudget
+	got2 := transformTransientDenyToRecoverable(context.Background(), v2, tu2, cfg2)
+	if got2.RecoverableReason == "" {
+		t.Fatal("conv-2 first call should promote even though conv-1 already consumed its budget")
+	}
+}

--- a/internal/runtime/llmproxy/postproc/transient_deny_test.go
+++ b/internal/runtime/llmproxy/postproc/transient_deny_test.go
@@ -107,11 +107,12 @@ func TestTryPromoteTransient_RequiresBudget(t *testing.T) {
 }
 
 // First call: verdict is promoted (RecoverableReason + SubstituteWith
-// populated, TransientFailureClass preserved) AND the consumed key is
-// returned so the wrapping session method can track it for rollback.
-func TestTryPromoteTransient_FirstCallPromotesAndReturnsKey(t *testing.T) {
+// populated, TransientFailureClass preserved) AND a consume record is
+// returned so the wrapping session method can track it (key + token)
+// for token-checked rollback Release.
+func TestTryPromoteTransient_FirstCallPromotesAndReturnsConsume(t *testing.T) {
 	v, _, cfg := transientDenyTestSetup("class-x")
-	got, key := tryPromoteTransient(context.Background(), v, cfg)
+	got, consume := tryPromoteTransient(context.Background(), v, cfg)
 	if got.RecoverableReason != v.Reason {
 		t.Fatalf("first call should set RecoverableReason; got %q, want %q", got.RecoverableReason, v.Reason)
 	}
@@ -121,13 +122,19 @@ func TestTryPromoteTransient_FirstCallPromotesAndReturnsKey(t *testing.T) {
 	if got.TransientFailureClass != "class-x" {
 		t.Fatalf("TransientFailureClass should be preserved; got %q", got.TransientFailureClass)
 	}
-	want := llmproxy.TransientBudgetKey{
+	wantKey := llmproxy.TransientBudgetKey{
 		AgentID:        cfg.AgentContext.AgentID,
 		ConversationID: cfg.AuditContext.ConversationID,
 		FailureClass:   "class-x",
 	}
-	if key == nil || *key != want {
-		t.Fatalf("expected consumed key %+v; got %+v", want, key)
+	if consume == nil {
+		t.Fatalf("expected consume record for key %+v; got nil", wantKey)
+	}
+	if consume.Key != wantKey {
+		t.Fatalf("consume key = %+v; want %+v", consume.Key, wantKey)
+	}
+	if consume.Token == 0 {
+		t.Fatalf("consume token must be non-zero so a later Release can token-check the entry; got 0")
 	}
 }
 
@@ -211,13 +218,16 @@ func TestSession_CommitPromotesTransientAndTracksConsume(t *testing.T) {
 	if len(session.transientConsumed) != 1 {
 		t.Fatalf("expected 1 tracked consume; got %d (%+v)", len(session.transientConsumed), session.transientConsumed)
 	}
-	want := llmproxy.TransientBudgetKey{
+	wantKey := llmproxy.TransientBudgetKey{
 		AgentID:        cfg.AgentContext.AgentID,
 		ConversationID: cfg.AuditContext.ConversationID,
 		FailureClass:   "class-x",
 	}
-	if session.transientConsumed[0] != want {
-		t.Fatalf("tracked key = %+v; want %+v", session.transientConsumed[0], want)
+	if session.transientConsumed[0].Key != wantKey {
+		t.Fatalf("tracked key = %+v; want %+v", session.transientConsumed[0].Key, wantKey)
+	}
+	if session.transientConsumed[0].Token == 0 {
+		t.Fatalf("tracked consume must carry a non-zero token so rollback Release can token-check; got 0")
 	}
 }
 
@@ -227,11 +237,13 @@ func TestSession_CommitPromotesTransientAndTracksConsume(t *testing.T) {
 func TestSession_CommitDoesNotTrackWhenBudgetExhausted(t *testing.T) {
 	v, tu, cfg := transientDenyTestSetup("class-x")
 	// Pre-consume the budget so the commit's Try returns false.
-	cfg.AuthorizationContext.TransientBudget.Try(context.Background(), llmproxy.TransientBudgetKey{
+	if _, ok := cfg.AuthorizationContext.TransientBudget.Try(context.Background(), llmproxy.TransientBudgetKey{
 		AgentID:        cfg.AgentContext.AgentID,
 		ConversationID: cfg.AuditContext.ConversationID,
 		FailureClass:   "class-x",
-	})
+	}); !ok {
+		t.Fatal("precondition: pre-consume should succeed on a fresh budget")
+	}
 	session := newPostprocessSession(cfg)
 	verdictByTU := map[string]conversation.ToolUseVerdict{tu.ID: v}
 	if err := session.commitVerdictSideEffects(context.Background(), verdictByTU, []conversation.ToolUse{tu}); err != nil {
@@ -273,19 +285,19 @@ func TestPostprocessSession_RollbackRefundsConsumedTransientSlots(t *testing.T) 
 	if verdictByTU[tu.ID].RecoverableReason == "" {
 		t.Fatal("precondition: commit should have promoted and consumed budget")
 	}
-	key := llmproxy.TransientBudgetKey{
+	k := llmproxy.TransientBudgetKey{
 		AgentID:        cfg.AgentContext.AgentID,
 		ConversationID: cfg.AuditContext.ConversationID,
 		FailureClass:   "class-x",
 	}
-	if budget.Try(context.Background(), key) {
+	if _, ok := budget.Try(context.Background(), k); ok {
 		t.Fatal("precondition: budget should be consumed after commit")
 	}
 	got := verdictByTU[tu.ID]
 
 	session.rollback(context.Background(), []conversation.ToolUse{tu}, map[string]conversation.ToolUseVerdict{tu.ID: got})
 
-	if !budget.Try(context.Background(), key) {
+	if _, ok := budget.Try(context.Background(), k); !ok {
 		t.Fatal("after rollback, transient slot should be refunded so the next real attempt promotes")
 	}
 }

--- a/internal/runtime/llmproxy/transient_budget.go
+++ b/internal/runtime/llmproxy/transient_budget.go
@@ -6,6 +6,17 @@ import (
 	"time"
 )
 
+// TransientBudgetKey identifies a single transient-retry slot. Struct
+// (not concatenated string) so distinct (agent, conversation, class)
+// tuples never alias each other regardless of what characters the IDs
+// contain — string concatenation with any separator would collide
+// when a component happens to contain the separator.
+type TransientBudgetKey struct {
+	AgentID        string
+	ConversationID string
+	FailureClass   string
+}
+
 // TransientBudget rations one-shot retries for transient failures
 // (LLM judge timeout, nonce-mint hiccup, decision-engine RPC blip).
 // The postproc transient transform consults this on every Deny
@@ -14,12 +25,22 @@ import (
 // a RecoverableDeny so the agent's continuation retry fires; every
 // subsequent occurrence passes through as a plain Deny so a chronic
 // failure surfaces to the user instead of looping silently.
+//
+// Try / Release form a consume / refund pair. The postproc session
+// calls Release for every Try it did on a request whose response was
+// later fail-closed — otherwise the retry slot would burn for a
+// recoverable response the agent never actually saw.
 type TransientBudget interface {
-	// Try records an attempt for (agentID, conversationID, failureClass).
-	// Returns true on the FIRST attempt within TTL (budget remaining,
-	// caller should promote to recoverable). Returns false on
-	// subsequent attempts (budget exhausted, surface plain Deny).
-	Try(ctx context.Context, agentID, conversationID, failureClass string) bool
+	// Try records an attempt for key. Returns true on the FIRST
+	// attempt within TTL (budget remaining, caller should promote to
+	// recoverable). Returns false on subsequent attempts (budget
+	// exhausted, surface plain Deny).
+	Try(ctx context.Context, key TransientBudgetKey) bool
+	// Release refunds a previously-successful Try so the slot is
+	// available again. No-op when the key isn't currently consumed
+	// (already released or expired). Used by postproc rollback so a
+	// fail-closed response doesn't burn the agent's one retry slot.
+	Release(ctx context.Context, key TransientBudgetKey)
 }
 
 // NewMemoryTransientBudget returns an in-memory TransientBudget.
@@ -34,7 +55,7 @@ func NewMemoryTransientBudget(ttl time.Duration) TransientBudget {
 	return &memoryTransientBudget{
 		ttl:     ttl,
 		now:     time.Now,
-		entries: map[string]time.Time{},
+		entries: map[TransientBudgetKey]time.Time{},
 	}
 }
 
@@ -42,14 +63,13 @@ type memoryTransientBudget struct {
 	mu      sync.Mutex
 	ttl     time.Duration
 	now     func() time.Time
-	entries map[string]time.Time
+	entries map[TransientBudgetKey]time.Time
 }
 
-func (b *memoryTransientBudget) Try(_ context.Context, agentID, conversationID, failureClass string) bool {
+func (b *memoryTransientBudget) Try(_ context.Context, key TransientBudgetKey) bool {
 	if b == nil {
 		return false
 	}
-	key := transientBudgetKey(agentID, conversationID, failureClass)
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.pruneLocked()
@@ -60,6 +80,15 @@ func (b *memoryTransientBudget) Try(_ context.Context, agentID, conversationID, 
 	return true
 }
 
+func (b *memoryTransientBudget) Release(_ context.Context, key TransientBudgetKey) {
+	if b == nil {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	delete(b.entries, key)
+}
+
 func (b *memoryTransientBudget) pruneLocked() {
 	now := b.now().UTC()
 	for key, expires := range b.entries {
@@ -68,8 +97,4 @@ func (b *memoryTransientBudget) pruneLocked() {
 		}
 		delete(b.entries, key)
 	}
-}
-
-func transientBudgetKey(agentID, conversationID, failureClass string) string {
-	return agentID + "|" + conversationID + "|" + failureClass
 }

--- a/internal/runtime/llmproxy/transient_budget.go
+++ b/internal/runtime/llmproxy/transient_budget.go
@@ -1,0 +1,75 @@
+package llmproxy
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// TransientBudget rations one-shot retries for transient failures
+// (LLM judge timeout, nonce-mint hiccup, decision-engine RPC blip).
+// The postproc transient transform consults this on every Deny
+// verdict carrying a TransientFailureClass: the first occurrence per
+// (agentID, conversationID, failureClass) within TTL gets promoted to
+// a RecoverableDeny so the agent's continuation retry fires; every
+// subsequent occurrence passes through as a plain Deny so a chronic
+// failure surfaces to the user instead of looping silently.
+type TransientBudget interface {
+	// Try records an attempt for (agentID, conversationID, failureClass).
+	// Returns true on the FIRST attempt within TTL (budget remaining,
+	// caller should promote to recoverable). Returns false on
+	// subsequent attempts (budget exhausted, surface plain Deny).
+	Try(ctx context.Context, agentID, conversationID, failureClass string) bool
+}
+
+// NewMemoryTransientBudget returns an in-memory TransientBudget.
+// TTL <= 0 falls back to 5 minutes — shorter than the 10-minute
+// ScopeDrifts default because transient classes should rotate fast: a
+// stale "judge timeout" record shouldn't block recovery for a fresh
+// tool_use much later in the same conversation.
+func NewMemoryTransientBudget(ttl time.Duration) TransientBudget {
+	if ttl <= 0 {
+		ttl = 5 * time.Minute
+	}
+	return &memoryTransientBudget{
+		ttl:     ttl,
+		now:     time.Now,
+		entries: map[string]time.Time{},
+	}
+}
+
+type memoryTransientBudget struct {
+	mu      sync.Mutex
+	ttl     time.Duration
+	now     func() time.Time
+	entries map[string]time.Time
+}
+
+func (b *memoryTransientBudget) Try(_ context.Context, agentID, conversationID, failureClass string) bool {
+	if b == nil {
+		return false
+	}
+	key := transientBudgetKey(agentID, conversationID, failureClass)
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.pruneLocked()
+	if _, exists := b.entries[key]; exists {
+		return false
+	}
+	b.entries[key] = b.now().UTC().Add(b.ttl)
+	return true
+}
+
+func (b *memoryTransientBudget) pruneLocked() {
+	now := b.now().UTC()
+	for key, expires := range b.entries {
+		if expires.After(now) {
+			continue
+		}
+		delete(b.entries, key)
+	}
+}
+
+func transientBudgetKey(agentID, conversationID, failureClass string) string {
+	return agentID + "|" + conversationID + "|" + failureClass
+}

--- a/internal/runtime/llmproxy/transient_budget.go
+++ b/internal/runtime/llmproxy/transient_budget.go
@@ -17,30 +17,42 @@ type TransientBudgetKey struct {
 	FailureClass   string
 }
 
+// TransientReleaseToken is the per-consume nonce returned by Try and
+// passed to Release. It scopes a Release to the specific consume the
+// caller performed — without it, a delayed rollback whose original
+// slot has since been pruned and re-consumed by a different request
+// would refund the new consumer's slot instead. Treat as opaque.
+type TransientReleaseToken uint64
+
 // TransientBudget rations one-shot retries for transient failures
 // (LLM judge timeout, nonce-mint hiccup, decision-engine RPC blip).
-// The postproc transient transform consults this on every Deny
-// verdict carrying a TransientFailureClass: the first occurrence per
-// (agentID, conversationID, failureClass) within TTL gets promoted to
-// a RecoverableDeny so the agent's continuation retry fires; every
+// The postproc session consults this on every Deny verdict carrying
+// a TransientFailureClass: the first occurrence per (agentID,
+// conversationID, failureClass) within TTL gets promoted to a
+// RecoverableDeny so the agent's continuation retry fires; every
 // subsequent occurrence passes through as a plain Deny so a chronic
 // failure surfaces to the user instead of looping silently.
 //
 // Try / Release form a consume / refund pair. The postproc session
 // calls Release for every Try it did on a request whose response was
 // later fail-closed — otherwise the retry slot would burn for a
-// recoverable response the agent never actually saw.
+// recoverable response the agent never actually saw. Release MUST
+// pass the token Try returned so a delayed rollback can't refund a
+// slot that has since been re-consumed by a different request.
 type TransientBudget interface {
-	// Try records an attempt for key. Returns true on the FIRST
-	// attempt within TTL (budget remaining, caller should promote to
-	// recoverable). Returns false on subsequent attempts (budget
-	// exhausted, surface plain Deny).
-	Try(ctx context.Context, key TransientBudgetKey) bool
+	// Try records an attempt for key. On the FIRST attempt within TTL
+	// returns (token, true) — caller should promote to recoverable
+	// AND retain the token so it can Release the slot on rollback.
+	// On subsequent attempts returns (0, false) — budget exhausted,
+	// surface plain Deny.
+	Try(ctx context.Context, key TransientBudgetKey) (TransientReleaseToken, bool)
 	// Release refunds a previously-successful Try so the slot is
-	// available again. No-op when the key isn't currently consumed
-	// (already released or expired). Used by postproc rollback so a
-	// fail-closed response doesn't burn the agent's one retry slot.
-	Release(ctx context.Context, key TransientBudgetKey)
+	// available again. No-op when the entry at key carries a different
+	// token (the original slot was pruned and re-consumed by a later
+	// Try) or when the key isn't currently consumed. Token-checked
+	// delete is what makes this safe under a delayed rollback that
+	// fires after the slot has rotated.
+	Release(ctx context.Context, key TransientBudgetKey, token TransientReleaseToken)
 }
 
 // NewMemoryTransientBudget returns an in-memory TransientBudget.
@@ -55,44 +67,59 @@ func NewMemoryTransientBudget(ttl time.Duration) TransientBudget {
 	return &memoryTransientBudget{
 		ttl:     ttl,
 		now:     time.Now,
-		entries: map[TransientBudgetKey]time.Time{},
+		entries: map[TransientBudgetKey]transientBudgetEntry{},
 	}
 }
 
-type memoryTransientBudget struct {
-	mu      sync.Mutex
-	ttl     time.Duration
-	now     func() time.Time
-	entries map[TransientBudgetKey]time.Time
+type transientBudgetEntry struct {
+	expiresAt time.Time
+	token     TransientReleaseToken
 }
 
-func (b *memoryTransientBudget) Try(_ context.Context, key TransientBudgetKey) bool {
+type memoryTransientBudget struct {
+	mu       sync.Mutex
+	ttl      time.Duration
+	now      func() time.Time
+	nextTok  uint64 // monotonic source for TransientReleaseToken
+	entries  map[TransientBudgetKey]transientBudgetEntry
+}
+
+func (b *memoryTransientBudget) Try(_ context.Context, key TransientBudgetKey) (TransientReleaseToken, bool) {
 	if b == nil {
-		return false
+		return 0, false
 	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.pruneLocked()
 	if _, exists := b.entries[key]; exists {
-		return false
+		return 0, false
 	}
-	b.entries[key] = b.now().UTC().Add(b.ttl)
-	return true
+	b.nextTok++
+	token := TransientReleaseToken(b.nextTok)
+	b.entries[key] = transientBudgetEntry{
+		expiresAt: b.now().UTC().Add(b.ttl),
+		token:     token,
+	}
+	return token, true
 }
 
-func (b *memoryTransientBudget) Release(_ context.Context, key TransientBudgetKey) {
+func (b *memoryTransientBudget) Release(_ context.Context, key TransientBudgetKey, token TransientReleaseToken) {
 	if b == nil {
 		return
 	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	entry, ok := b.entries[key]
+	if !ok || entry.token != token {
+		return
+	}
 	delete(b.entries, key)
 }
 
 func (b *memoryTransientBudget) pruneLocked() {
 	now := b.now().UTC()
-	for key, expires := range b.entries {
-		if expires.After(now) {
+	for key, entry := range b.entries {
+		if entry.expiresAt.After(now) {
 			continue
 		}
 		delete(b.entries, key)

--- a/internal/runtime/llmproxy/transient_budget_test.go
+++ b/internal/runtime/llmproxy/transient_budget_test.go
@@ -8,13 +8,18 @@ import (
 	"time"
 )
 
+func key(agent, conv, class string) TransientBudgetKey {
+	return TransientBudgetKey{AgentID: agent, ConversationID: conv, FailureClass: class}
+}
+
 func TestMemoryTransientBudget_FirstTryWinsSecondTryLoses(t *testing.T) {
 	b := NewMemoryTransientBudget(time.Minute)
 	ctx := context.Background()
-	if !b.Try(ctx, "agent-1", "conv-1", "class-x") {
+	k := key("agent-1", "conv-1", "class-x")
+	if !b.Try(ctx, k) {
 		t.Fatalf("first Try should return true (budget remaining)")
 	}
-	if b.Try(ctx, "agent-1", "conv-1", "class-x") {
+	if b.Try(ctx, k) {
 		t.Fatalf("second Try should return false (budget consumed)")
 	}
 }
@@ -22,28 +27,37 @@ func TestMemoryTransientBudget_FirstTryWinsSecondTryLoses(t *testing.T) {
 func TestMemoryTransientBudget_DistinctKeysHaveIndependentBudgets(t *testing.T) {
 	b := NewMemoryTransientBudget(time.Minute)
 	ctx := context.Background()
-	if !b.Try(ctx, "agent-1", "conv-1", "class-a") {
-		t.Fatalf("class-a first attempt should pass")
+	keys := []TransientBudgetKey{
+		key("agent-1", "conv-1", "class-a"),
+		key("agent-1", "conv-1", "class-b"),
+		key("agent-1", "conv-2", "class-a"),
+		key("agent-2", "conv-1", "class-a"),
 	}
-	if !b.Try(ctx, "agent-1", "conv-1", "class-b") {
-		t.Fatalf("class-b first attempt should pass independently of class-a")
-	}
-	if !b.Try(ctx, "agent-1", "conv-2", "class-a") {
-		t.Fatalf("different conversation should have its own budget for class-a")
-	}
-	if !b.Try(ctx, "agent-2", "conv-1", "class-a") {
-		t.Fatalf("different agent should have its own budget for class-a")
-	}
-	// Re-trying any of those should now fail.
-	for _, args := range [][3]string{
-		{"agent-1", "conv-1", "class-a"},
-		{"agent-1", "conv-1", "class-b"},
-		{"agent-1", "conv-2", "class-a"},
-		{"agent-2", "conv-1", "class-a"},
-	} {
-		if b.Try(ctx, args[0], args[1], args[2]) {
-			t.Fatalf("retry %v should be denied (budget consumed)", args)
+	for _, k := range keys {
+		if !b.Try(ctx, k) {
+			t.Fatalf("first attempt for %+v should pass", k)
 		}
+	}
+	for _, k := range keys {
+		if b.Try(ctx, k) {
+			t.Fatalf("retry %+v should be denied (budget consumed)", k)
+		}
+	}
+}
+
+// Components that contain a pipe ("agent|x" vs "agent" + "x|...")
+// MUST stay isolated. A struct key cannot collide; this guards against
+// regressing back to string concatenation.
+func TestMemoryTransientBudget_PipeInIDsDoesNotCollide(t *testing.T) {
+	b := NewMemoryTransientBudget(time.Minute)
+	ctx := context.Background()
+	k1 := key("agent|x", "conv", "class")
+	k2 := key("agent", "x|conv", "class")
+	if !b.Try(ctx, k1) {
+		t.Fatalf("k1 first attempt should pass")
+	}
+	if !b.Try(ctx, k2) {
+		t.Fatalf("k2 first attempt should pass independently — pipe in IDs must not alias keys")
 	}
 }
 
@@ -52,18 +66,55 @@ func TestMemoryTransientBudget_TTLExpiryRestoresBudget(t *testing.T) {
 	b := &memoryTransientBudget{
 		ttl:     time.Minute,
 		now:     func() time.Time { return now },
-		entries: map[string]time.Time{},
+		entries: map[TransientBudgetKey]time.Time{},
 	}
 	ctx := context.Background()
-	if !b.Try(ctx, "a", "c", "class") {
+	k := key("a", "c", "class")
+	if !b.Try(ctx, k) {
 		t.Fatalf("first attempt should pass")
 	}
-	if b.Try(ctx, "a", "c", "class") {
+	if b.Try(ctx, k) {
 		t.Fatalf("second attempt before TTL should fail")
 	}
 	now = now.Add(time.Minute + time.Second)
-	if !b.Try(ctx, "a", "c", "class") {
+	if !b.Try(ctx, k) {
 		t.Fatalf("after TTL expiry, budget should be restored")
+	}
+}
+
+// Release refunds a previously-consumed slot so a follow-up Try
+// succeeds again. Underpins the postproc rollback that refunds slots
+// when a response is fail-closed and the agent never saw the
+// recoverable verdict.
+func TestMemoryTransientBudget_ReleaseRefundsSlot(t *testing.T) {
+	b := NewMemoryTransientBudget(time.Minute)
+	ctx := context.Background()
+	k := key("a", "c", "class")
+	if !b.Try(ctx, k) {
+		t.Fatal("first attempt should pass")
+	}
+	if b.Try(ctx, k) {
+		t.Fatal("second attempt before release should fail")
+	}
+	b.Release(ctx, k)
+	if !b.Try(ctx, k) {
+		t.Fatalf("after Release the slot should be available again")
+	}
+}
+
+// Release of an unknown key is a no-op (doesn't crash, doesn't poison
+// other slots). Important because postproc may roll back release sets
+// that include keys the budget never saw if the verdict ordering shifted.
+func TestMemoryTransientBudget_ReleaseUnknownKeyIsNoOp(t *testing.T) {
+	b := NewMemoryTransientBudget(time.Minute)
+	ctx := context.Background()
+	b.Release(ctx, key("a", "c", "class")) // never tried
+	consumed := key("a", "c", "consumed")
+	if !b.Try(ctx, consumed) {
+		t.Fatal("unrelated key should still pass after spurious Release")
+	}
+	if b.Try(ctx, consumed) {
+		t.Fatal("budget for consumed key should be intact")
 	}
 }
 
@@ -76,12 +127,13 @@ func TestMemoryTransientBudget_ConcurrentTryHasExactlyOneWinner(t *testing.T) {
 		winners atomic.Int64
 	)
 	start := make(chan struct{})
+	k := key("agent", "conv", "class")
 	wg.Add(goroutines)
 	for i := 0; i < goroutines; i++ {
 		go func() {
 			defer wg.Done()
 			<-start
-			if b.Try(ctx, "agent", "conv", "class") {
+			if b.Try(ctx, k) {
 				winners.Add(1)
 			}
 		}()
@@ -93,9 +145,10 @@ func TestMemoryTransientBudget_ConcurrentTryHasExactlyOneWinner(t *testing.T) {
 	}
 }
 
-func TestMemoryTransientBudget_NilReceiverReturnsFalse(t *testing.T) {
+func TestMemoryTransientBudget_NilReceiverSafe(t *testing.T) {
 	var b *memoryTransientBudget
-	if b.Try(context.Background(), "a", "c", "class") {
+	if b.Try(context.Background(), key("a", "c", "class")) {
 		t.Fatalf("nil receiver should return false (no budget)")
 	}
+	b.Release(context.Background(), key("a", "c", "class")) // must not panic
 }

--- a/internal/runtime/llmproxy/transient_budget_test.go
+++ b/internal/runtime/llmproxy/transient_budget_test.go
@@ -1,0 +1,101 @@
+package llmproxy
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestMemoryTransientBudget_FirstTryWinsSecondTryLoses(t *testing.T) {
+	b := NewMemoryTransientBudget(time.Minute)
+	ctx := context.Background()
+	if !b.Try(ctx, "agent-1", "conv-1", "class-x") {
+		t.Fatalf("first Try should return true (budget remaining)")
+	}
+	if b.Try(ctx, "agent-1", "conv-1", "class-x") {
+		t.Fatalf("second Try should return false (budget consumed)")
+	}
+}
+
+func TestMemoryTransientBudget_DistinctKeysHaveIndependentBudgets(t *testing.T) {
+	b := NewMemoryTransientBudget(time.Minute)
+	ctx := context.Background()
+	if !b.Try(ctx, "agent-1", "conv-1", "class-a") {
+		t.Fatalf("class-a first attempt should pass")
+	}
+	if !b.Try(ctx, "agent-1", "conv-1", "class-b") {
+		t.Fatalf("class-b first attempt should pass independently of class-a")
+	}
+	if !b.Try(ctx, "agent-1", "conv-2", "class-a") {
+		t.Fatalf("different conversation should have its own budget for class-a")
+	}
+	if !b.Try(ctx, "agent-2", "conv-1", "class-a") {
+		t.Fatalf("different agent should have its own budget for class-a")
+	}
+	// Re-trying any of those should now fail.
+	for _, args := range [][3]string{
+		{"agent-1", "conv-1", "class-a"},
+		{"agent-1", "conv-1", "class-b"},
+		{"agent-1", "conv-2", "class-a"},
+		{"agent-2", "conv-1", "class-a"},
+	} {
+		if b.Try(ctx, args[0], args[1], args[2]) {
+			t.Fatalf("retry %v should be denied (budget consumed)", args)
+		}
+	}
+}
+
+func TestMemoryTransientBudget_TTLExpiryRestoresBudget(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0).UTC()
+	b := &memoryTransientBudget{
+		ttl:     time.Minute,
+		now:     func() time.Time { return now },
+		entries: map[string]time.Time{},
+	}
+	ctx := context.Background()
+	if !b.Try(ctx, "a", "c", "class") {
+		t.Fatalf("first attempt should pass")
+	}
+	if b.Try(ctx, "a", "c", "class") {
+		t.Fatalf("second attempt before TTL should fail")
+	}
+	now = now.Add(time.Minute + time.Second)
+	if !b.Try(ctx, "a", "c", "class") {
+		t.Fatalf("after TTL expiry, budget should be restored")
+	}
+}
+
+func TestMemoryTransientBudget_ConcurrentTryHasExactlyOneWinner(t *testing.T) {
+	b := NewMemoryTransientBudget(time.Minute)
+	ctx := context.Background()
+	const goroutines = 64
+	var (
+		wg      sync.WaitGroup
+		winners atomic.Int64
+	)
+	start := make(chan struct{})
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			if b.Try(ctx, "agent", "conv", "class") {
+				winners.Add(1)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	if got := winners.Load(); got != 1 {
+		t.Fatalf("expected exactly one winner across %d concurrent Try calls; got %d", goroutines, got)
+	}
+}
+
+func TestMemoryTransientBudget_NilReceiverReturnsFalse(t *testing.T) {
+	var b *memoryTransientBudget
+	if b.Try(context.Background(), "a", "c", "class") {
+		t.Fatalf("nil receiver should return false (no budget)")
+	}
+}

--- a/internal/runtime/llmproxy/transient_budget_test.go
+++ b/internal/runtime/llmproxy/transient_budget_test.go
@@ -12,14 +12,21 @@ func key(agent, conv, class string) TransientBudgetKey {
 	return TransientBudgetKey{AgentID: agent, ConversationID: conv, FailureClass: class}
 }
 
+// tryOnce is a test helper that adapts the (token, ok) return shape
+// to a plain bool when the test doesn't care about the token.
+func tryOnce(b TransientBudget, ctx context.Context, k TransientBudgetKey) bool {
+	_, ok := b.Try(ctx, k)
+	return ok
+}
+
 func TestMemoryTransientBudget_FirstTryWinsSecondTryLoses(t *testing.T) {
 	b := NewMemoryTransientBudget(time.Minute)
 	ctx := context.Background()
 	k := key("agent-1", "conv-1", "class-x")
-	if !b.Try(ctx, k) {
+	if !tryOnce(b, ctx, k) {
 		t.Fatalf("first Try should return true (budget remaining)")
 	}
-	if b.Try(ctx, k) {
+	if tryOnce(b, ctx, k) {
 		t.Fatalf("second Try should return false (budget consumed)")
 	}
 }
@@ -34,12 +41,12 @@ func TestMemoryTransientBudget_DistinctKeysHaveIndependentBudgets(t *testing.T) 
 		key("agent-2", "conv-1", "class-a"),
 	}
 	for _, k := range keys {
-		if !b.Try(ctx, k) {
+		if !tryOnce(b, ctx, k) {
 			t.Fatalf("first attempt for %+v should pass", k)
 		}
 	}
 	for _, k := range keys {
-		if b.Try(ctx, k) {
+		if tryOnce(b, ctx, k) {
 			t.Fatalf("retry %+v should be denied (budget consumed)", k)
 		}
 	}
@@ -53,10 +60,10 @@ func TestMemoryTransientBudget_PipeInIDsDoesNotCollide(t *testing.T) {
 	ctx := context.Background()
 	k1 := key("agent|x", "conv", "class")
 	k2 := key("agent", "x|conv", "class")
-	if !b.Try(ctx, k1) {
+	if !tryOnce(b, ctx, k1) {
 		t.Fatalf("k1 first attempt should pass")
 	}
-	if !b.Try(ctx, k2) {
+	if !tryOnce(b, ctx, k2) {
 		t.Fatalf("k2 first attempt should pass independently — pipe in IDs must not alias keys")
 	}
 }
@@ -66,18 +73,18 @@ func TestMemoryTransientBudget_TTLExpiryRestoresBudget(t *testing.T) {
 	b := &memoryTransientBudget{
 		ttl:     time.Minute,
 		now:     func() time.Time { return now },
-		entries: map[TransientBudgetKey]time.Time{},
+		entries: map[TransientBudgetKey]transientBudgetEntry{},
 	}
 	ctx := context.Background()
 	k := key("a", "c", "class")
-	if !b.Try(ctx, k) {
+	if !tryOnce(b, ctx, k) {
 		t.Fatalf("first attempt should pass")
 	}
-	if b.Try(ctx, k) {
+	if tryOnce(b, ctx, k) {
 		t.Fatalf("second attempt before TTL should fail")
 	}
 	now = now.Add(time.Minute + time.Second)
-	if !b.Try(ctx, k) {
+	if !tryOnce(b, ctx, k) {
 		t.Fatalf("after TTL expiry, budget should be restored")
 	}
 }
@@ -90,14 +97,15 @@ func TestMemoryTransientBudget_ReleaseRefundsSlot(t *testing.T) {
 	b := NewMemoryTransientBudget(time.Minute)
 	ctx := context.Background()
 	k := key("a", "c", "class")
-	if !b.Try(ctx, k) {
+	token, ok := b.Try(ctx, k)
+	if !ok {
 		t.Fatal("first attempt should pass")
 	}
-	if b.Try(ctx, k) {
+	if tryOnce(b, ctx, k) {
 		t.Fatal("second attempt before release should fail")
 	}
-	b.Release(ctx, k)
-	if !b.Try(ctx, k) {
+	b.Release(ctx, k, token)
+	if !tryOnce(b, ctx, k) {
 		t.Fatalf("after Release the slot should be available again")
 	}
 }
@@ -108,13 +116,57 @@ func TestMemoryTransientBudget_ReleaseRefundsSlot(t *testing.T) {
 func TestMemoryTransientBudget_ReleaseUnknownKeyIsNoOp(t *testing.T) {
 	b := NewMemoryTransientBudget(time.Minute)
 	ctx := context.Background()
-	b.Release(ctx, key("a", "c", "class")) // never tried
+	b.Release(ctx, key("a", "c", "class"), TransientReleaseToken(1)) // never tried
 	consumed := key("a", "c", "consumed")
-	if !b.Try(ctx, consumed) {
+	if !tryOnce(b, ctx, consumed) {
 		t.Fatal("unrelated key should still pass after spurious Release")
 	}
-	if b.Try(ctx, consumed) {
+	if tryOnce(b, ctx, consumed) {
 		t.Fatal("budget for consumed key should be intact")
+	}
+}
+
+// The race the token guards against: R1 consumes a slot, the entry
+// times out and gets pruned, R2 consumes the same key (fresh slot,
+// new token), R1's delayed rollback calls Release with R1's stale
+// token. The Release MUST be a no-op so R2's slot survives.
+func TestMemoryTransientBudget_ReleaseWithStaleTokenIsNoOp(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0).UTC()
+	b := &memoryTransientBudget{
+		ttl:     time.Minute,
+		now:     func() time.Time { return now },
+		entries: map[TransientBudgetKey]transientBudgetEntry{},
+	}
+	ctx := context.Background()
+	k := key("a", "c", "class")
+
+	r1Token, ok := b.Try(ctx, k)
+	if !ok {
+		t.Fatal("R1's first attempt should pass")
+	}
+
+	// TTL elapses; R2's Try sees the entry pruned and consumes a
+	// fresh slot with a new token.
+	now = now.Add(time.Minute + time.Second)
+	r2Token, ok := b.Try(ctx, k)
+	if !ok {
+		t.Fatal("R2's first attempt after expiry should pass")
+	}
+	if r1Token == r2Token {
+		t.Fatalf("R1 and R2 must get distinct tokens; both got %d", r1Token)
+	}
+
+	// R1's delayed rollback fires with R1's token — must NOT clobber
+	// R2's slot.
+	b.Release(ctx, k, r1Token)
+	if tryOnce(b, ctx, k) {
+		t.Fatal("R2's slot must survive R1's stale Release; got an opening for a third Try")
+	}
+
+	// R2's own Release (with R2's token) refunds correctly.
+	b.Release(ctx, k, r2Token)
+	if !tryOnce(b, ctx, k) {
+		t.Fatal("after R2's own Release the slot should be available again")
 	}
 }
 
@@ -133,7 +185,7 @@ func TestMemoryTransientBudget_ConcurrentTryHasExactlyOneWinner(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			<-start
-			if b.Try(ctx, k) {
+			if tryOnce(b, ctx, k) {
 				winners.Add(1)
 			}
 		}()
@@ -147,8 +199,8 @@ func TestMemoryTransientBudget_ConcurrentTryHasExactlyOneWinner(t *testing.T) {
 
 func TestMemoryTransientBudget_NilReceiverSafe(t *testing.T) {
 	var b *memoryTransientBudget
-	if b.Try(context.Background(), key("a", "c", "class")) {
+	if tryOnce(b, context.Background(), key("a", "c", "class")) {
 		t.Fatalf("nil receiver should return false (no budget)")
 	}
-	b.Release(context.Background(), key("a", "c", "class")) // must not panic
+	b.Release(context.Background(), key("a", "c", "class"), TransientReleaseToken(0)) // must not panic
 }


### PR DESCRIPTION
## Summary

Adds a third refusal category to the LLM proxy alongside `AgentRecoverable` (agent re-emits with a different shape) and plain `Deny`/`Hold` (user prompt): **`TransientDenyVerdict`** for failures the agent's correct response is to re-emit the SAME tool_use unchanged (LLM judge timeout, nonce-mint hiccup, decision-engine RPC blip). Applied to the script-session judge timeout as the proof site.

Also flips 10 parser `Ambiguous`-without-`AgentRecoverable` refusals in `inspector/parser.go` to use a new `ambiguousRecoverable` helper — each names a deterministic, agent-fixable shape problem (trailing `-X`/`-H`, placeholder in body, unknown curl flag, etc.) and now routes through `RecoverableDeny` instead of stalling on human approval.

## Mechanism

- `conversation.ToolUseVerdict.TransientFailureClass` field + `conversation.TransientDenyVerdict(class, reason, facts...)` constructor.
- `llmproxy.TransientBudget` interface + in-memory impl (5-min TTL default, struct key, `Try`/`Release` pair).
- Transient promotion lives in `postprocessSession.promoteTransients`, called as the FIRST pass of `commitVerdictSideEffects`. On hit, mutates the verdict to recoverable shape and re-runs the placeholder transform so `PendingSubstitution` gets set for the substitution loop in the same commit pass. Consumed keys go on `s.transientConsumed`; `rollbackVerdictSideEffects` refunds them via `TransientBudget.Release` if the response fail-closes.
- This required moving `commitVerdictSideEffects` BEFORE rewrite in both `postproc.go` and `stream.go` (post-commit verdicts are what the rewriter reads).
- `TransientBudget` is wired through `AuthorizationContext` and the `LLMEndpointHandler` with an in-mem default.

The transient mechanism is now structurally identical to `PendingSubstitution` / `DeferredDriftOutcome` — three parallel rollback ledgers on the session, one per registry the session writes during commit.

## Parser flips

`inspector/parser.go` adds `ambiguousRecoverable(reason)` and converts 10 sites: 9 bash branches (trailing `-X`/`-H`, trailing safe-value/body flag, placeholder in `-d` body, unknown curl flag, extra positional, malformed URL, non-http scheme) plus the structured-fetch placeholder-outside-header-credentials branch.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/runtime/conversation/... ./internal/runtime/llmproxy/... ./internal/api/handlers/... -count=1` — all green
- [x] New unit tests: `transient_budget_test.go` (5 cases), `transient_deny_test.go` (12 cases including session-level commit-promotes and rollback-refunds), `parser_flags_test.go` `TestParseBashCurl_AmbiguousSitesAreAgentRecoverable` (10 sub-cases, one per flipped branch)
- [x] Updated `script_session_evaluator_test.go` to assert the timeout case emits `TransientFailureClass` and leaves `RecoverableReason` empty (postproc owns promotion)
- [x] Cubic review against `origin/main` — clean after 7 review iterations

## Commits

The branch went through 6 commits as cubic surfaced structural issues and pushed back on shortcuts. Final shape lands the transient mechanism as a true deferred spec (decision in commit, not eval) — same pattern as every other session-owned side effect in postproc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

