### PR TITLE
feat(installer): env-namespace agent token paths + fix rc-block idempotency

### DIFF
--- a/internal/api/handlers/installer.go
+++ b/internal/api/handlers/installer.go
@@ -116,10 +116,17 @@ type installerCtx struct {
 	HermesConfig    string
 	HermesMode      string
 	OpenClawMode    string
-	// AgentName is the on-disk filename slug for ~/.clawvisor/agents/<name>.json.
-	// Defaults to the harness name; the dashboard overrides via ?agent_name=
-	// when it picks a non-colliding variant (openclaw-1, openclaw-2, …).
+	// AgentName is the human-visible agent name registered with the daemon
+	// and shown in the dashboard. Defaults to the harness name; the
+	// dashboard overrides via ?agent_name= when it picks a non-colliding
+	// variant (openclaw-1, openclaw-2, …).
 	AgentName string
+	// AgentSlot is the on-disk path slug under ~/.clawvisor/agents/ and
+	// ~/.clawvisor/diffs/. Identical to AgentName for production installs,
+	// prefixed with the env ("staging/<name>" or "dev/<name>") otherwise,
+	// so dev/staging/prod token files for the same logical name don't
+	// overwrite each other on a multi-env user's disk.
+	AgentSlot string
 }
 
 // installerRenderer renders an installer body of one format (shell or
@@ -355,6 +362,11 @@ func (h *InstallerHandler) installerCtxFromRequest(r *http.Request, target Insta
 	ctx.AgentName = string(target)
 	if n := r.URL.Query().Get("agent_name"); n != "" && validAgentName.MatchString(n) {
 		ctx.AgentName = n
+	}
+	if env := installerEnvSlug(ctx.LLMURL); env != "" {
+		ctx.AgentSlot = env + "/" + ctx.AgentName
+	} else {
+		ctx.AgentSlot = ctx.AgentName
 	}
 	return ctx
 }
@@ -965,6 +977,21 @@ func recordTextDiff(id, targetFile string) string {
 //	llm.clawvisor.com         → "clawvisor"         / "Clawvisor"
 //	localhost / anything else → "clawvisor-dev"     / "Clawvisor (dev)"
 func codexProviderID(llmURL string) (slug, display string) {
+	switch installerEnvSlug(llmURL) {
+	case "staging":
+		return "clawvisor-staging", "Clawvisor (staging)"
+	case "":
+		return "clawvisor", "Clawvisor"
+	default:
+		return "clawvisor-dev", "Clawvisor (dev)"
+	}
+}
+
+// installerEnvSlug classifies the install target environment from the LLM
+// proxy URL host. Production returns "" so the agent token file lives at the
+// bare ~/.clawvisor/agents/<name>.json path (the common case); staging and
+// dev get a prefix so their token files don't overwrite production's.
+func installerEnvSlug(llmURL string) string {
 	u, err := url.Parse(llmURL)
 	host := ""
 	if err == nil && u != nil {
@@ -972,11 +999,11 @@ func codexProviderID(llmURL string) (slug, display string) {
 	}
 	switch {
 	case strings.Contains(host, "staging"):
-		return "clawvisor-staging", "Clawvisor (staging)"
+		return "staging"
 	case strings.HasSuffix(host, "clawvisor.com") && !strings.Contains(host, "dev"):
-		return "clawvisor", "Clawvisor"
+		return ""
 	default:
-		return "clawvisor-dev", "Clawvisor (dev)"
+		return "dev"
 	}
 }
 

--- a/internal/api/handlers/installer_scripts.go
+++ b/internal/api/handlers/installer_scripts.go
@@ -30,6 +30,7 @@ type installerScriptCtx struct {
 	Claim               string
 	UserID              string
 	AgentName           string
+	AgentSlot           string
 	Target              string
 	HarnessLabel        string
 	Slug                string
@@ -48,6 +49,7 @@ func renderClaudeCodeShellInstaller(ctx installerCtx) (string, error) {
 		Claim:               ctx.Claim,
 		UserID:              ctx.UserID,
 		AgentName:           ctx.AgentName,
+		AgentSlot:           ctx.AgentSlot,
 		Target:              string(InstallerClaudeCode),
 		HarnessLabel:        "Claude Code",
 		RelayPermissionRule: relayPermissionRule(),
@@ -66,6 +68,7 @@ func renderCodexShellInstaller(ctx installerCtx) (string, error) {
 		Claim:        ctx.Claim,
 		UserID:       ctx.UserID,
 		AgentName:    ctx.AgentName,
+		AgentSlot:    ctx.AgentSlot,
 		Target:       string(InstallerCodex),
 		HarnessLabel: "Codex",
 		Slug:         slug,

--- a/internal/api/handlers/installer_scripts/claude_code.sh.tmpl
+++ b/internal/api/handlers/installer_scripts/claude_code.sh.tmpl
@@ -210,19 +210,20 @@ else
         SKIP_FLAG=""
     fi
 
-    mkdir -p "$HOME/.clawvisor/diffs/$AGENT_NAME"
+    mkdir -p "$HOME/.clawvisor/diffs/$AGENT_SLOT"
 
     if [ -n "$RC" ]; then
         # The function body inlines the env-var setup and the optional skip
-        # flag. Idempotent on re-runs by exact-substring match against the
-        # agent-token lookup path — flipping yolo/no-yolo or renaming the
-        # alias on a re-install requires deleting the existing block
-        # manually (the diff record under
-        # ~/.clawvisor/diffs/$AGENT_NAME/ shows exactly what to strip).
+        # flag. Idempotency is keyed on the alias name itself — a re-install
+        # under a NEW alias appends another block (and shell-function
+        # precedence makes the latest definition win on next shell), while
+        # re-running the exact same install is a no-op. The diff record
+        # under ~/.clawvisor/diffs/$AGENT_SLOT/ shows exactly what to strip
+        # if the user wants to revert by hand.
         FUNC_BLOCK=$(cat <<EOF
 $CV_ALIAS_NAME() {
     CLAWVISOR_URL="$APP_URL" \\
-    CLAWVISOR_AGENT_TOKEN="\$(jq -r .token \$HOME/.clawvisor/agents/$AGENT_NAME.json)" \\
+    CLAWVISOR_AGENT_TOKEN="\$(jq -r .token \$HOME/.clawvisor/agents/$AGENT_SLOT.json)" \\
     ANTHROPIC_BASE_URL="$LLM_URL/api" \\
     ANTHROPIC_CUSTOM_HEADERS="X-Clawvisor-Agent-Token: \$CLAWVISOR_AGENT_TOKEN" \\
     ANTHROPIC_AUTH_TOKEN= \\
@@ -231,16 +232,16 @@ $CV_ALIAS_NAME() {
 }
 EOF
 )
-        if ! grep -F -q "agents/$AGENT_NAME.json" "$RC" 2>/dev/null; then
+        if ! grep -F -q "${CV_ALIAS_NAME}() {" "$RC" 2>/dev/null; then
             printf '\n%s\n' "$FUNC_BLOCK" >> "$RC"
             jq -n \
                 --arg file "$RC" \
                 --arg content "$FUNC_BLOCK" \
                 '{file:$file, type:"text_append", content:$content}' \
-                > "$HOME/.clawvisor/diffs/$AGENT_NAME/claude_cv.json"
+                > "$HOME/.clawvisor/diffs/$AGENT_SLOT/claude_cv.json"
             echo "✓ Appended $CV_ALIAS_NAME() to $RC"
         else
-            echo "  ($CV_ALIAS_NAME() already references this agent; leaving $RC untouched)"
+            echo "  ($CV_ALIAS_NAME() already defined in $RC; leaving it untouched)"
         fi
     else
         echo "  (unknown shell: $SHELL — append the $CV_ALIAS_NAME function manually)" >&2
@@ -262,7 +263,7 @@ if [ "$INSTALL_MODE_LABEL" = default-everywhere ]; then
        ANTHROPIC_AUTH_TOKEN, ANTHROPIC_API_KEY
    Also remove any \`Bash(curl *…clawvisor…/*)\` entries from
    \`.permissions.allow\`.
-2. Delete the token file: rm ~/.clawvisor/agents/$AGENT_NAME.json
+2. Delete the token file: rm ~/.clawvisor/agents/$AGENT_SLOT.json
 3. Revoke the agent in the Clawvisor dashboard under Agents → $AGENT_NAME → Delete.
 4. Restart Claude Code so the cleared env takes effect.
 EOF
@@ -272,9 +273,9 @@ else
 
 1. Remove the \`$CV_ALIAS_NAME()\` function from your shell rc. The exact text
    that was appended is recorded under
-   ~/.clawvisor/diffs/$AGENT_NAME/claude_cv.json — match-and-remove it
+   ~/.clawvisor/diffs/$AGENT_SLOT/claude_cv.json — match-and-remove it
    from the file listed there.
-2. Delete the token file: rm ~/.clawvisor/agents/$AGENT_NAME.json
+2. Delete the token file: rm ~/.clawvisor/agents/$AGENT_SLOT.json
 3. Revoke the agent in the Clawvisor dashboard under Agents → $AGENT_NAME → Delete.
 4. Open a new shell to drop the $CV_ALIAS_NAME function.
 EOF

--- a/internal/api/handlers/installer_scripts/claude_code.sh.tmpl
+++ b/internal/api/handlers/installer_scripts/claude_code.sh.tmpl
@@ -213,20 +213,18 @@ else
     mkdir -p "$HOME/.clawvisor/diffs/$AGENT_SLOT"
 
     if [ -n "$RC" ]; then
-        # The function body inlines the env-var setup and the optional skip
-        # flag. Idempotency is keyed on the (alias, slot) pair: skip only
-        # when BOTH the alias definition and the env-namespaced token path
-        # are already present. That covers:
-        #   - same alias, same slot     → no-op (true repeat)
-        #   - same alias, different env → append a fresh block so a
-        #                                  prod→staging switch under the
-        #                                  same alias actually swaps the
-        #                                  token path (shell function
-        #                                  precedence picks the newer def)
-        #   - different alias           → append
-        # The diff record under ~/.clawvisor/diffs/$AGENT_SLOT/ shows
-        # exactly what to strip if the user wants to revert by hand.
+        # Each appended block carries a single-line sentinel that encodes
+        # every axis a re-install can vary along (alias name, env slot,
+        # yolo on/off). Idempotency is keyed on the exact sentinel: when
+        # the user re-runs with the same triple it's a true no-op; any
+        # change (env switch, yolo flip, alias rename) produces a new
+        # sentinel, appends a fresh block, and shell function precedence
+        # makes the newer definition win on next shell. The diff record
+        # under ~/.clawvisor/diffs/$AGENT_SLOT/ shows exactly what to
+        # strip if the user wants to revert by hand.
+        FUNC_MARKER="# clawvisor-managed: alias=$CV_ALIAS_NAME slot=$AGENT_SLOT yolo=$CV_YOLO"
         FUNC_BLOCK=$(cat <<EOF
+$FUNC_MARKER
 $CV_ALIAS_NAME() {
     CLAWVISOR_URL="$APP_URL" \\
     CLAWVISOR_AGENT_TOKEN="\$(jq -r .token \$HOME/.clawvisor/agents/$AGENT_SLOT.json)" \\
@@ -238,9 +236,8 @@ $CV_ALIAS_NAME() {
 }
 EOF
 )
-        if grep -F -q "${CV_ALIAS_NAME}() {" "$RC" 2>/dev/null \
-                && grep -F -q "agents/$AGENT_SLOT.json" "$RC" 2>/dev/null; then
-            echo "  ($CV_ALIAS_NAME() for $AGENT_SLOT already in $RC; leaving it untouched)"
+        if grep -F -q "$FUNC_MARKER" "$RC" 2>/dev/null; then
+            echo "  ($CV_ALIAS_NAME() for $AGENT_SLOT (yolo=$CV_YOLO) already in $RC; leaving it untouched)"
         else
             printf '\n%s\n' "$FUNC_BLOCK" >> "$RC"
             jq -n \

--- a/internal/api/handlers/installer_scripts/claude_code.sh.tmpl
+++ b/internal/api/handlers/installer_scripts/claude_code.sh.tmpl
@@ -214,12 +214,18 @@ else
 
     if [ -n "$RC" ]; then
         # The function body inlines the env-var setup and the optional skip
-        # flag. Idempotency is keyed on the alias name itself — a re-install
-        # under a NEW alias appends another block (and shell-function
-        # precedence makes the latest definition win on next shell), while
-        # re-running the exact same install is a no-op. The diff record
-        # under ~/.clawvisor/diffs/$AGENT_SLOT/ shows exactly what to strip
-        # if the user wants to revert by hand.
+        # flag. Idempotency is keyed on the (alias, slot) pair: skip only
+        # when BOTH the alias definition and the env-namespaced token path
+        # are already present. That covers:
+        #   - same alias, same slot     → no-op (true repeat)
+        #   - same alias, different env → append a fresh block so a
+        #                                  prod→staging switch under the
+        #                                  same alias actually swaps the
+        #                                  token path (shell function
+        #                                  precedence picks the newer def)
+        #   - different alias           → append
+        # The diff record under ~/.clawvisor/diffs/$AGENT_SLOT/ shows
+        # exactly what to strip if the user wants to revert by hand.
         FUNC_BLOCK=$(cat <<EOF
 $CV_ALIAS_NAME() {
     CLAWVISOR_URL="$APP_URL" \\
@@ -232,7 +238,10 @@ $CV_ALIAS_NAME() {
 }
 EOF
 )
-        if ! grep -F -q "${CV_ALIAS_NAME}() {" "$RC" 2>/dev/null; then
+        if grep -F -q "${CV_ALIAS_NAME}() {" "$RC" 2>/dev/null \
+                && grep -F -q "agents/$AGENT_SLOT.json" "$RC" 2>/dev/null; then
+            echo "  ($CV_ALIAS_NAME() for $AGENT_SLOT already in $RC; leaving it untouched)"
+        else
             printf '\n%s\n' "$FUNC_BLOCK" >> "$RC"
             jq -n \
                 --arg file "$RC" \
@@ -240,8 +249,6 @@ EOF
                 '{file:$file, type:"text_append", content:$content}' \
                 > "$HOME/.clawvisor/diffs/$AGENT_SLOT/claude_cv.json"
             echo "✓ Appended $CV_ALIAS_NAME() to $RC"
-        else
-            echo "  ($CV_ALIAS_NAME() already defined in $RC; leaving it untouched)"
         fi
     else
         echo "  (unknown shell: $SHELL — append the $CV_ALIAS_NAME function manually)" >&2

--- a/internal/api/handlers/installer_scripts/codex.sh.tmpl
+++ b/internal/api/handlers/installer_scripts/codex.sh.tmpl
@@ -9,7 +9,7 @@ DISPLAY='{{.DisplayLabel}}'
 # --- Append the [model_providers.SLUG] block to ~/.codex/config.toml ---------
 # Codex rejects duplicate [model_providers.<n>] tables on startup, so the
 # append is gated on a grep — re-runs are no-ops on the block itself.
-mkdir -p "$HOME/.codex" "$HOME/.clawvisor/diffs/$AGENT_NAME"
+mkdir -p "$HOME/.codex" "$HOME/.clawvisor/diffs/$AGENT_SLOT"
 touch "$HOME/.codex/config.toml"
 
 PROVIDER_BLOCK=$(cat <<EOF
@@ -30,7 +30,7 @@ if ! grep -q "^\[model_providers\.$SLUG\]" "$HOME/.codex/config.toml"; then
         --arg file "$HOME/.codex/config.toml" \
         --arg content "$PROVIDER_BLOCK" \
         '{file:$file, type:"text_append", content:$content}' \
-        > "$HOME/.clawvisor/diffs/$AGENT_NAME/provider_block.json"
+        > "$HOME/.clawvisor/diffs/$AGENT_SLOT/provider_block.json"
     echo "✓ Added [model_providers.$SLUG] to ~/.codex/config.toml"
 else
     echo "✓ [model_providers.$SLUG] already present in ~/.codex/config.toml"
@@ -180,20 +180,20 @@ if [ "$CV_DEFAULT_MODE" = yes ]; then
             --arg file "$HOME/.codex/config.toml" \
             --arg content "$DEFAULT_LINE" \
             '{file:$file, type:"text_prepend", content:$content}' \
-            > "$HOME/.clawvisor/diffs/$AGENT_NAME/default_provider.json"
+            > "$HOME/.clawvisor/diffs/$AGENT_SLOT/default_provider.json"
         echo "✓ Set model_provider = \"$SLUG\" as the default in ~/.codex/config.toml"
     fi
 
     # Append the rc-export so $CLAWVISOR_AGENT_TOKEN is set in every shell.
     if [ -n "$RC" ]; then
-        RC_EXPORT="export CLAWVISOR_AGENT_TOKEN=\$(jq -r .token \$HOME/.clawvisor/agents/$AGENT_NAME.json)"
-        if ! grep -F -q "agents/$AGENT_NAME.json" "$RC" 2>/dev/null; then
+        RC_EXPORT="export CLAWVISOR_AGENT_TOKEN=\$(jq -r .token \$HOME/.clawvisor/agents/$AGENT_SLOT.json)"
+        if ! grep -F -q "agents/$AGENT_SLOT.json" "$RC" 2>/dev/null; then
             printf '\n%s\n' "$RC_EXPORT" >> "$RC"
             jq -n \
                 --arg file "$RC" \
                 --arg content "$RC_EXPORT" \
                 '{file:$file, type:"text_append", content:$content}' \
-                > "$HOME/.clawvisor/diffs/$AGENT_NAME/rc_export.json"
+                > "$HOME/.clawvisor/diffs/$AGENT_SLOT/rc_export.json"
             echo "✓ Appended CLAWVISOR_AGENT_TOKEN export to $RC"
         fi
     else
@@ -225,30 +225,31 @@ else
     fi
 
     if [ -n "$RC" ]; then
-        # The function body inlines the slug + agent-token lookup. The user
-        # can re-install with a different alias-only flavour and we'll just
-        # append again — overwriting is intentional so a yolo→no-yolo flip
-        # or alias rename takes effect on next shell. Diff record is the
-        # full appended block.
+        # The function body inlines the slug + agent-token lookup.
+        # Idempotency is keyed on the alias name itself — a re-install
+        # under a NEW alias appends another block (and shell-function
+        # precedence makes the latest definition win on next shell), while
+        # re-running the exact same install is a no-op. Diff record is
+        # the full appended block under ~/.clawvisor/diffs/$AGENT_SLOT/.
         FUNC_BLOCK=$(cat <<EOF
 $CV_ALIAS_NAME() {
-    CLAWVISOR_AGENT_TOKEN="\$(jq -r .token \$HOME/.clawvisor/agents/$AGENT_NAME.json)" \\
+    CLAWVISOR_AGENT_TOKEN="\$(jq -r .token \$HOME/.clawvisor/agents/$AGENT_SLOT.json)" \\
         codex$YOLO_FLAG \\
         -c model_provider="$SLUG" \\
         "\$@"
 }
 EOF
 )
-        if ! grep -F -q "agents/$AGENT_NAME.json" "$RC" 2>/dev/null; then
+        if ! grep -F -q "${CV_ALIAS_NAME}() {" "$RC" 2>/dev/null; then
             printf '\n%s\n' "$FUNC_BLOCK" >> "$RC"
             jq -n \
                 --arg file "$RC" \
                 --arg content "$FUNC_BLOCK" \
                 '{file:$file, type:"text_append", content:$content}' \
-                > "$HOME/.clawvisor/diffs/$AGENT_NAME/codex_cv.json"
+                > "$HOME/.clawvisor/diffs/$AGENT_SLOT/codex_cv.json"
             echo "✓ Appended $CV_ALIAS_NAME() to $RC"
         else
-            echo "  ($CV_ALIAS_NAME() already references this agent; leaving $RC untouched)"
+            echo "  ($CV_ALIAS_NAME() already defined in $RC; leaving it untouched)"
         fi
     else
         echo "  (unknown shell: $SHELL — append the $CV_ALIAS_NAME function manually)" >&2
@@ -262,11 +263,11 @@ cat > "$UNINSTALL_DOC" <<EOF
 
 1. Remove the [model_providers.$SLUG] block (and any leading
    model_provider = "$SLUG" line) from ~/.codex/config.toml. The exact text
-   that was appended is recorded under ~/.clawvisor/diffs/$AGENT_NAME/
+   that was appended is recorded under ~/.clawvisor/diffs/$AGENT_SLOT/
    so you can match-and-remove it.
 2. Remove any rc lines this install added — look for the file named in
-   ~/.clawvisor/diffs/$AGENT_NAME/rc_export.json or codex_cv.json.
-3. Delete the token file: rm ~/.clawvisor/agents/$AGENT_NAME.json
+   ~/.clawvisor/diffs/$AGENT_SLOT/rc_export.json or codex_cv.json.
+3. Delete the token file: rm ~/.clawvisor/agents/$AGENT_SLOT.json
 4. Revoke the agent in the Clawvisor dashboard under Agents → $AGENT_NAME → Delete.
 5. Open a new shell to drop the CLAWVISOR_AGENT_TOKEN export / alias function.
 EOF

--- a/internal/api/handlers/installer_scripts/codex.sh.tmpl
+++ b/internal/api/handlers/installer_scripts/codex.sh.tmpl
@@ -225,15 +225,17 @@ else
     fi
 
     if [ -n "$RC" ]; then
-        # The function body inlines the slug + agent-token lookup.
-        # Idempotency is keyed on the (alias, slot) pair: skip only when
-        # BOTH the alias definition and the env-namespaced token path are
-        # already present. Same alias under a different env appends a
-        # fresh block so a prod→staging switch actually swaps the token
-        # path (shell function precedence picks the newer def). Diff
-        # record is the full appended block under
-        # ~/.clawvisor/diffs/$AGENT_SLOT/.
+        # Each appended block carries a single-line sentinel that encodes
+        # every axis a re-install can vary along (alias name, env slot,
+        # yolo on/off). Idempotency is keyed on the exact sentinel: when
+        # the user re-runs with the same triple it's a true no-op; any
+        # change (env switch, yolo flip, alias rename) produces a new
+        # sentinel, appends a fresh block, and shell function precedence
+        # makes the newer definition win on next shell. Diff record is
+        # the full appended block under ~/.clawvisor/diffs/$AGENT_SLOT/.
+        FUNC_MARKER="# clawvisor-managed: alias=$CV_ALIAS_NAME slot=$AGENT_SLOT yolo=$CV_YOLO"
         FUNC_BLOCK=$(cat <<EOF
+$FUNC_MARKER
 $CV_ALIAS_NAME() {
     CLAWVISOR_AGENT_TOKEN="\$(jq -r .token \$HOME/.clawvisor/agents/$AGENT_SLOT.json)" \\
         codex$YOLO_FLAG \\
@@ -242,9 +244,8 @@ $CV_ALIAS_NAME() {
 }
 EOF
 )
-        if grep -F -q "${CV_ALIAS_NAME}() {" "$RC" 2>/dev/null \
-                && grep -F -q "agents/$AGENT_SLOT.json" "$RC" 2>/dev/null; then
-            echo "  ($CV_ALIAS_NAME() for $AGENT_SLOT already in $RC; leaving it untouched)"
+        if grep -F -q "$FUNC_MARKER" "$RC" 2>/dev/null; then
+            echo "  ($CV_ALIAS_NAME() for $AGENT_SLOT (yolo=$CV_YOLO) already in $RC; leaving it untouched)"
         else
             printf '\n%s\n' "$FUNC_BLOCK" >> "$RC"
             jq -n \

--- a/internal/api/handlers/installer_scripts/codex.sh.tmpl
+++ b/internal/api/handlers/installer_scripts/codex.sh.tmpl
@@ -226,11 +226,13 @@ else
 
     if [ -n "$RC" ]; then
         # The function body inlines the slug + agent-token lookup.
-        # Idempotency is keyed on the alias name itself — a re-install
-        # under a NEW alias appends another block (and shell-function
-        # precedence makes the latest definition win on next shell), while
-        # re-running the exact same install is a no-op. Diff record is
-        # the full appended block under ~/.clawvisor/diffs/$AGENT_SLOT/.
+        # Idempotency is keyed on the (alias, slot) pair: skip only when
+        # BOTH the alias definition and the env-namespaced token path are
+        # already present. Same alias under a different env appends a
+        # fresh block so a prod→staging switch actually swaps the token
+        # path (shell function precedence picks the newer def). Diff
+        # record is the full appended block under
+        # ~/.clawvisor/diffs/$AGENT_SLOT/.
         FUNC_BLOCK=$(cat <<EOF
 $CV_ALIAS_NAME() {
     CLAWVISOR_AGENT_TOKEN="\$(jq -r .token \$HOME/.clawvisor/agents/$AGENT_SLOT.json)" \\
@@ -240,7 +242,10 @@ $CV_ALIAS_NAME() {
 }
 EOF
 )
-        if ! grep -F -q "${CV_ALIAS_NAME}() {" "$RC" 2>/dev/null; then
+        if grep -F -q "${CV_ALIAS_NAME}() {" "$RC" 2>/dev/null \
+                && grep -F -q "agents/$AGENT_SLOT.json" "$RC" 2>/dev/null; then
+            echo "  ($CV_ALIAS_NAME() for $AGENT_SLOT already in $RC; leaving it untouched)"
+        else
             printf '\n%s\n' "$FUNC_BLOCK" >> "$RC"
             jq -n \
                 --arg file "$RC" \
@@ -248,8 +253,6 @@ EOF
                 '{file:$file, type:"text_append", content:$content}' \
                 > "$HOME/.clawvisor/diffs/$AGENT_SLOT/codex_cv.json"
             echo "✓ Appended $CV_ALIAS_NAME() to $RC"
-        else
-            echo "  ($CV_ALIAS_NAME() already defined in $RC; leaving it untouched)"
         fi
     else
         echo "  (unknown shell: $SHELL — append the $CV_ALIAS_NAME function manually)" >&2

--- a/internal/api/handlers/installer_scripts/common.sh.tmpl
+++ b/internal/api/handlers/installer_scripts/common.sh.tmpl
@@ -6,7 +6,9 @@ Templating fields (installerScriptCtx):
   .LLMURL          LLM-proxy URL (no trailing slash)
   .Claim           single-use claim code minted by the dashboard ("" if absent)
   .UserID          fallback user_id when no claim was minted ("" if absent)
-  .AgentName       short name used for the agent + token-file basename
+  .AgentName       short name used for the agent (registered with the daemon)
+  .AgentSlot       on-disk path slug under ~/.clawvisor/agents and /diffs;
+                   equals .AgentName for prod and "<env>/<name>" otherwise
   .Target          harness slug — "claude-code" or "codex"
   .HarnessLabel    display label — "Claude Code" or "Codex"
   .Slug            codex provider-id slug — populated only for the codex template
@@ -240,6 +242,7 @@ prompt_text() {
 }
 
 AGENT_NAME='{{.AgentName}}'
+AGENT_SLOT='{{.AgentSlot}}'
 HARNESS='{{.Target}}'
 HARNESS_LABEL='{{.HarnessLabel}}'
 APP_URL='{{.AppURL}}'
@@ -261,7 +264,7 @@ echo "→ Registering {{.HarnessLabel}} agent with Clawvisor at $APP_URL"
 # minting fresh. Makes the install re-pasteable after a stall — e.g. when
 # the user timed out waiting for a key vault and pastes the same URL
 # again (which still has the now-consumed claim code in it).
-EXISTING_JSON="$HOME/.clawvisor/agents/$AGENT_NAME.json"
+EXISTING_JSON="$HOME/.clawvisor/agents/$AGENT_SLOT.json"
 TOKEN=""
 AGENT_ID=""
 if [ -f "$EXISTING_JSON" ]; then
@@ -317,8 +320,8 @@ fi
 {{end -}}
 
 {{define "persist_token"}}# --- Persist the token --------------------------------------------------------
-mkdir -p "$HOME/.clawvisor/agents"
-AGENT_JSON="$HOME/.clawvisor/agents/$AGENT_NAME.json"
+AGENT_JSON="$HOME/.clawvisor/agents/$AGENT_SLOT.json"
+mkdir -p "$(dirname "$AGENT_JSON")"
 jq -n \
     --arg name "$AGENT_NAME" \
     --arg agent_id "$AGENT_ID" \

--- a/internal/api/handlers/installer_test.go
+++ b/internal/api/handlers/installer_test.go
@@ -695,6 +695,41 @@ func TestInstallerCodexShellProviderSlugByEnv(t *testing.T) {
 	}
 }
 
+// TestInstallerShellAgentSlotByEnv locks the on-disk agent path namespacing:
+// production keeps the bare slot (so ~/.clawvisor/agents/<name>.json — the
+// common case — doesn't move) while staging and dev are env-prefixed so the
+// same logical name from a different environment doesn't overwrite the prod
+// token file. Mirrors the codex slug-by-env shape but covers both .sh
+// installers since the wiring is in the shared common.sh.tmpl.
+func TestInstallerShellAgentSlotByEnv(t *testing.T) {
+	cases := []struct {
+		name        string
+		llmProxyURL string
+		wantSlot    string
+	}{
+		{"production", "https://llm.clawvisor.com", "codex"},
+		{"staging", "https://llm.staging.clawvisor.com", "staging/codex"},
+		{"dev_localhost_default", "", "dev/codex"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := NewInstallerHandler("", "", true, tc.llmProxyURL, "")
+			body := installerGetShell(t, h, "codex", "CLAIMCODE0")
+			assertContainsAll(t, body,
+				"AGENT_SLOT='"+tc.wantSlot+"'",
+				// AGENT_NAME stays the bare logical name regardless of env —
+				// it's what the daemon registers and what shows up in the
+				// dashboard, so prefixing it would leak path layout into the
+				// human-visible name.
+				"AGENT_NAME='codex'",
+				// File paths reference the slot, not the name.
+				`agents/$AGENT_SLOT.json`,
+				`diffs/$AGENT_SLOT`,
+			)
+		})
+	}
+}
+
 // TestInstallerMarkdownReturns410 — old paste blobs that hit
 // /skill/install/<self-install-target>.md must return 410 Gone with a body
 // pointing at the new .sh URL, so dashboards that haven't updated their URL


### PR DESCRIPTION
## Summary

Two installer-side fixes, bundled because they overlap on the same shell templates.

**Env-namespaced token paths.** Production keeps the bare \`~/.clawvisor/agents/<name>.json\` (the common case — no migration). Staging and dev now write to \`~/.clawvisor/agents/<env>/<name>.json\`, so dev/staging/prod tokens for the same logical agent name stop overwriting each other on a multi-env user's disk. \`AGENT_NAME\` stays as-is for daemon registration and dashboard-visible text; the new \`AGENT_SLOT\` is the on-disk path slug.

**Rc-block idempotency.** The alias-install branches previously gated the rc-file append on a substring match of the agent token path. Re-installing under a new alias was mis-detected as already installed (the original bug report); after a first fix, a same-alias env switch was a silent no-op; after a second fix, a same-alias yolo flip was also a silent no-op. Settled on a single-line \`# clawvisor-managed: alias=… slot=… yolo=…\` sentinel that encodes every axis a re-install can vary along — grep matches the exact sentinel, any change appends a fresh block, and shell function precedence picks the newer definition. Future axes get one extra field on the line rather than another grep clause.

Iterations driven by \`cubic review --base origin/main\` (3 passes, ending clean).

## Test plan

- [ ] \`go test ./internal/api/handlers/... -run Installer -count=1\` (green locally)
- [ ] Manual: install codex against prod, confirm \`~/.clawvisor/agents/codex.json\`
- [ ] Manual: install codex against staging with same alias name, confirm new \`~/.clawvisor/agents/staging/codex.json\` and that the rc-file alias picks up the staging token on a fresh shell
- [ ] Manual: re-run identical install, confirm \`(... already in ...)\` no-op message
- [ ] Manual: re-run with the opposite yolo choice, confirm a new block appends and the new sandbox behavior takes effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

