### PR TITLE
fix(reliability): keep audit writes alive on client cancel; stop polling on lost telegram lock

### DIFF
--- a/internal/notify/telegram/polling.go
+++ b/internal/notify/telegram/polling.go
@@ -195,8 +195,15 @@ func (n *Notifier) pollForCallbacks(ctx context.Context, ps *pollingSession) {
 		default:
 		}
 
-		// Renew the distributed lock before each long-poll.
-		n.pollingLock.Renew(ctx, ps.userID)
+		// Renew the distributed lock before each long-poll. If a different
+		// instance has taken over (our TTL expired and the other side
+		// acquired it), exit cleanly here. If we call getUpdates anyway,
+		// Telegram will terminate the newer consumer with a "Conflict"
+		// error and the user's polling will flap between instances.
+		if !n.pollingLock.Renew(ctx, ps.userID) {
+			logger.WarnContext(ctx, "callback polling: lock lost, another instance is polling", "user_id", ps.userID)
+			return
+		}
 
 		updates, err := n.getUpdates(ctx, ps.botToken, offset, 10)
 		if err != nil {

--- a/internal/notify/telegram/polling_lock.go
+++ b/internal/notify/telegram/polling_lock.go
@@ -19,8 +19,14 @@ type PollingLock interface {
 	// Returns true if this instance now holds the lock.
 	Acquire(ctx context.Context, userID string) bool
 
-	// Renew extends the lock TTL. Call periodically while polling.
-	Renew(ctx context.Context, userID string)
+	// Renew extends the lock TTL. Call periodically while polling. Returns
+	// true if this instance still owns the lock after the renew attempt.
+	// A false return means the lock has been taken by another instance (or
+	// the renew script unambiguously reported non-ownership) and the caller
+	// must stop polling before issuing another getUpdates — otherwise
+	// Telegram will terminate the older consumer with a "Conflict:
+	// terminated by other getUpdates request" error.
+	Renew(ctx context.Context, userID string) bool
 
 	// Release gives up the lock.
 	Release(ctx context.Context, userID string)
@@ -30,7 +36,7 @@ type PollingLock interface {
 type noopPollingLock struct{}
 
 func (noopPollingLock) Acquire(context.Context, string) bool { return true }
-func (noopPollingLock) Renew(context.Context, string)        {}
+func (noopPollingLock) Renew(context.Context, string) bool   { return true }
 func (noopPollingLock) Release(context.Context, string)      {}
 
 // redisPollingLock uses SET NX with TTL for distributed mutual exclusion.
@@ -52,16 +58,26 @@ func (l *redisPollingLock) Acquire(ctx context.Context, userID string) bool {
 	return ok
 }
 
-func (l *redisPollingLock) Renew(ctx context.Context, userID string) {
-	// Only renew if we still own the lock.
+func (l *redisPollingLock) Renew(ctx context.Context, userID string) bool {
+	// Only renew if we still own the lock. The script returns the PEXPIRE
+	// result (1 on success) if we still own the lock, or 0 if a different
+	// instance has taken it.
 	script := redis.NewScript(`
 		if redis.call('GET', KEYS[1]) == ARGV[1] then
 			return redis.call('PEXPIRE', KEYS[1], ARGV[2])
 		end
 		return 0
 	`)
-	_, _ = script.Run(ctx, l.rdb, []string{redisPollingLockPrefix + userID},
+	result, err := script.Run(ctx, l.rdb, []string{redisPollingLockPrefix + userID},
 		l.instanceID, int(pollingLockTTL.Milliseconds())).Result()
+	if err != nil {
+		// Transient Redis error — we can't confirm ownership was lost, so
+		// assume we still own it. A genuine ownership change will be
+		// reported as a clean script-result of 0 on a subsequent call.
+		return true
+	}
+	n, ok := result.(int64)
+	return ok && n > 0
 }
 
 func (l *redisPollingLock) Release(ctx context.Context, userID string) {

--- a/pkg/store/postgres/store.go
+++ b/pkg/store/postgres/store.go
@@ -777,6 +777,11 @@ func (s *Store) LogAudit(ctx context.Context, e *store.AuditEntry) error {
 	if len(e.ParamsSafe) > 0 {
 		paramsSafe = e.ParamsSafe
 	}
+	// Detach from the request ctx so a client disconnect or request deadline
+	// doesn't drop the audit row mid-INSERT. Keep a hard timeout so a hung
+	// DB still bounds the call.
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
 	_, err := s.pool.Exec(ctx, `
 		INSERT INTO audit_log (
 			id, user_id, agent_id, request_id, dedup_key, task_id, session_id, approval_id, lease_id,

--- a/pkg/store/sqlite/store.go
+++ b/pkg/store/sqlite/store.go
@@ -941,6 +941,11 @@ func (s *Store) LogAudit(ctx context.Context, e *store.AuditEntry) error {
 	if e.WouldPromptInline {
 		wouldPromptInline = 1
 	}
+	// Detach from the request ctx so a client disconnect or request deadline
+	// doesn't drop the audit row mid-INSERT. Keep a hard timeout so a hung
+	// DB still bounds the call.
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
 	_, err := s.db.ExecContext(ctx, `
 		INSERT INTO audit_log (
 			id, user_id, agent_id, request_id, dedup_key, task_id, session_id, approval_id, lease_id,


### PR DESCRIPTION
## Summary

Two fixes for the most chronic firing alerts in `clawvisor-production` (last 24h: 38 telegram poller conflicts + 20 audit-log write failures).

* **`LogAudit` (postgres + sqlite)** — detach from the request `ctx` with `context.WithoutCancel`, capped at a 5s timeout. A client disconnect or request-deadline cancellation no longer drops the audit row mid-`INSERT`. Every failing case in the last 24h logged `err="context canceled"`.
* **`PollingLock.Renew` now returns `bool`** so the caller can detect when the lock has been taken by another instance. `pollForCallbacks` exits cleanly in that case instead of issuing another `getUpdates`, which would cause Telegram to terminate the newer consumer with a `Conflict` error and flap polling between instances. The 35s lock TTL is preserved so failover after an instance crash remains fast (the earlier version of this PR bumped TTL to 90s — code review caught that this traded conflict noise for stale-lock latency, so the fix moved to the caller instead).

Neither change is a structural fix — they just stop these two alerts being the dominant noise so the real signal (Cloud Run long-poll 503s, which actually account for the misnomered `Container dying` alert) is easier to see.

## Test plan

- [ ] `go vet ./pkg/store/postgres/... ./pkg/store/sqlite/... ./internal/notify/telegram/...` (clean locally)
- [ ] `go build ./...` (clean locally)
- [ ] After merge + deploy, watch `Audit log write failed` and `Telegram poller multi-instance conflict` alert frequency for 24h
- [ ] Confirm no regression in audit row throughput (audit writes still succeed under normal request flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)