### PR TITLE
docs: add Hermes integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ clawvisor-server connect-agent claude-code      # install skill + env vars for C
 clawvisor-server connect-agent claude-desktop   # configure MCP for Claude Desktop
 ```
 
-For manual setup or other agents, see the integration guides: [Claude Code](docs/INTEGRATE_CLAUDE_CODE.md) · [Claude Desktop (MCP)](docs/INTEGRATE_CLAUDE_COWORK.md) · [OpenClaw](docs/INTEGRATE_OPENCLAW.md) · [Any HTTP agent](docs/INTEGRATE_GENERIC.md)
+For manual setup or other agents, see the integration guides: [Claude Code](docs/INTEGRATE_CLAUDE_CODE.md) · [Claude Desktop (MCP)](docs/INTEGRATE_CLAUDE_COWORK.md) · [Hermes (MCP)](docs/INTEGRATE_HERMES.md) · [OpenClaw](docs/INTEGRATE_OPENCLAW.md) · [Any HTTP agent](docs/INTEGRATE_GENERIC.md)
 
 ### Other self-host options
 
@@ -458,7 +458,7 @@ When paired with a mobile device, the daemon connects to `relay.clawvisor.com` v
 
 ### MCP integration
 
-Clawvisor exposes an MCP (Model Context Protocol) server at `/mcp` with OAuth 2.1 for integration with Claude Desktop and other MCP clients. Tools available via MCP: `fetch_catalog`, `create_task`, `get_task`, `complete_task`, `expand_task`, `gateway_request`. See [docs/INTEGRATE_CLAUDE_COWORK.md](docs/INTEGRATE_CLAUDE_COWORK.md) for setup.
+Clawvisor exposes an MCP (Model Context Protocol) server at `/mcp` with OAuth 2.1 for integration with Claude Desktop, Hermes, and other MCP clients. Tools available via MCP: `fetch_catalog`, `create_task`, `get_task`, `complete_task`, `expand_task`, `gateway_request`. See [docs/INTEGRATE_CLAUDE_COWORK.md](docs/INTEGRATE_CLAUDE_COWORK.md) and [docs/INTEGRATE_HERMES.md](docs/INTEGRATE_HERMES.md) for setup.
 
 ## Proxy-Lite Runtime (preview)
 

--- a/docs/INTEGRATE_HERMES.md
+++ b/docs/INTEGRATE_HERMES.md
@@ -1,0 +1,191 @@
+# Clawvisor - Hermes Integration Guide
+
+You are connecting Hermes to a running Clawvisor server via Clawvisor's HTTP
+MCP endpoint. This gives Hermes access to gated API requests (Gmail, Calendar,
+Drive, GitHub, Slack, etc.) with task-scoped authorization and human approval.
+Follow these instructions step by step.
+
+**Prerequisite:** Clawvisor must be running. If it isn't, set it up first -
+see [SETUP.md](SETUP.md).
+
+---
+
+## Goal State
+
+When setup is complete, the user should have:
+
+1. Clawvisor running (locally or in the cloud)
+2. A `clawvisor` MCP server entry in the Hermes config
+3. Hermes authorized to Clawvisor through MCP OAuth
+4. Hermes able to make gateway requests via Clawvisor MCP tools
+
+---
+
+## Step 1: Verify Clawvisor is running
+
+```bash
+curl -sf http://localhost:25297/ready 2>/dev/null && echo "RUNNING" || echo "NOT RUNNING"
+```
+
+If not running, the user needs to set it up first - see
+[SETUP.md](SETUP.md).
+
+Store the URL as `$CLAWVISOR_URL` (default `http://localhost:25297`). If the
+user has a remote instance, get the URL and verify with:
+
+```bash
+curl -sf "$CLAWVISOR_URL/ready"
+```
+
+---
+
+## Step 2: Configure Hermes
+
+Add Clawvisor to the Hermes config file, usually `~/.hermes/config.yaml`:
+
+```yaml
+mcp_servers:
+  clawvisor:
+    url: "http://localhost:25297/mcp"
+    auth: oauth
+    tools:
+      include:
+        - fetch_catalog
+        - create_task
+        - get_task
+        - expand_task
+        - gateway_request
+        - complete_task
+      resources: false
+```
+
+Replace the URL if Clawvisor is not running locally. On first connection,
+Hermes should open a browser to authorize access to Clawvisor. Clawvisor will
+mint a bounded MCP agent token after the user approves the OAuth consent flow.
+
+If Hermes runs in a separate container or remote environment, remember that
+`localhost` refers to the Hermes environment. Use a URL that Hermes can reach,
+for example `http://host.docker.internal:25297` from Docker Desktop, or a
+public/tunneled Clawvisor URL for remote Hermes.
+
+---
+
+## Step 3: Reload Hermes MCP servers
+
+Restart Hermes, or ask Hermes to reload MCP configuration:
+
+```text
+/reload-mcp
+```
+
+Hermes registers MCP tools with the server name in the tool name. For the
+server name above, tools are expected to appear as names like:
+
+- `mcp_clawvisor_fetch_catalog`
+- `mcp_clawvisor_create_task`
+- `mcp_clawvisor_gateway_request`
+
+---
+
+## Step 4: Connect services
+
+Before Hermes can use a service, it must be activated in Clawvisor. Direct the
+user to:
+
+1. Open the Clawvisor dashboard
+2. Go to the **Services** tab
+3. Connect the services they want Hermes to access (Gmail, GitHub, Slack, etc.)
+
+Each service has its own OAuth flow or API key configuration.
+
+---
+
+## Step 5: Verify
+
+Ask Hermes:
+
+```text
+Use Clawvisor to fetch my available service catalog.
+```
+
+Or ask it to list available MCP tools and confirm the Clawvisor tools are
+present. The `fetch_catalog` call should return the list of services activated
+in Clawvisor. If it returns an auth error, repeat the MCP OAuth authorization
+flow. If it fails to connect, check the Clawvisor URL from the Hermes runtime
+environment.
+
+For a real workflow, ask Hermes to use a connected account via Clawvisor, for
+example:
+
+```text
+Use Clawvisor to check my Gmail for unread messages.
+```
+
+Hermes should create a task, prompt the user to approve it in the Clawvisor
+dashboard, and then execute gateway requests under the approved scope.
+
+---
+
+## Optional: bearer-token fallback
+
+If OAuth is unavailable or you need a simple debugging path, you can configure
+Hermes with a raw Clawvisor agent token instead.
+
+Create the token:
+
+```bash
+clawvisor-server agent create hermes --replace --json
+```
+
+If running in Docker instead:
+
+```bash
+docker exec <APP_CONTAINER> /clawvisor-server agent create hermes --replace --json
+```
+
+Then configure Hermes with the token:
+
+```yaml
+mcp_servers:
+  clawvisor:
+    url: "http://localhost:25297/mcp"
+    headers:
+      Authorization: "Bearer <token from agent create>"
+```
+
+Important: use the standard `Authorization: Bearer ...` header. Clawvisor's
+MCP endpoint reads bearer auth from `Authorization`, not
+`X-Clawvisor-Agent-Token`.
+
+---
+
+## Step 6: Summary
+
+Present the user with:
+
+```text
+Clawvisor + Hermes Setup Complete
+---------------------------------
+Clawvisor:  <CLAWVISOR_URL>
+MCP server: clawvisor
+Config:     ~/.hermes/config.yaml
+Auth:       MCP OAuth
+```
+
+Explain how it works:
+
+- Hermes has access to Clawvisor MCP tools: `fetch_catalog`, `create_task`,
+  `get_task`, `complete_task`, `expand_task`, and `gateway_request`
+- Hermes creates tasks declaring what it needs, the user approves them in the
+  dashboard (or via Telegram), and Hermes executes actions under the approved
+  scope
+- In-scope actions with `auto_execute` run immediately; others queue for
+  per-request approval
+- All actions are logged in the audit trail. Credentials never leave Clawvisor.
+
+Remind the user to:
+
+- Connect services in the Clawvisor dashboard under the **Services** tab before
+  asking Hermes to use them
+- Approve tasks in the dashboard (or via Telegram) when Hermes requests them
+- Optionally set restrictions in the dashboard to hard-block specific actions

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -54,6 +54,7 @@ For manual setup or other agents, ask the user: **"Which agent are you connectin
 |---|---|---|
 | **Claude Code** | [INTEGRATE_CLAUDE_CODE.md](INTEGRATE_CLAUDE_CODE.md) | Manual setup for Claude Code (skill install + env vars) |
 | **Claude Desktop** | [INTEGRATE_CLAUDE_COWORK.md](INTEGRATE_CLAUDE_COWORK.md) | Manual MCP integration for Claude Desktop |
+| **Hermes** | [INTEGRATE_HERMES.md](INTEGRATE_HERMES.md) | Manual HTTP MCP integration for Hermes |
 | **OpenClaw** | [INTEGRATE_OPENCLAW.md](INTEGRATE_OPENCLAW.md) | They're running OpenClaw and want webhook callbacks |
 | **Other / generic** | [INTEGRATE_GENERIC.md](INTEGRATE_GENERIC.md) | Any HTTP-capable agent — covers token creation and points to the API protocol |
 


### PR DESCRIPTION
## Summary
- add a Hermes integration guide for Clawvisor over HTTP MCP
- document OAuth as the primary auth path and bearer-token setup as a fallback
- link the Hermes guide from README and setup docs

## Validation
- docs-only change; no tests run

## Note
I made a PR to Hermes to add Clawvisor to their MCP catalog that would make the install even easier: https://github.com/NousResearch/hermes-agent/pull/52614

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

