### PR TITLE
feat(llmproxy): brand first-turn notice Local / Staging / production

### DIFF
--- a/internal/api/handlers/llm_endpoint.go
+++ b/internal/api/handlers/llm_endpoint.go
@@ -72,6 +72,14 @@ type LLMEndpointHandler struct {
 	// from pkg/version (correct for hosted builds, wrong for local).
 	DashboardBaseURL string
 
+	// BrandLabel is the environment-qualified product name surfaced in
+	// the first-turn routing notice prose ("Clawvisor Local",
+	// "Clawvisor Staging", "Clawvisor"). Empty falls back to plain
+	// "Clawvisor" in the renderer. Set at wiring time from the server
+	// bind (loopback → Local) and build environment (staging build →
+	// Staging); plain production has no qualifier.
+	BrandLabel string
+
 	// AuditEmitter writes one audit_log row per /api/v1/* request and per
 	// inspected tool_use. nil disables audit logging.
 	AuditEmitter *llmproxy.AuditEmitter
@@ -1208,7 +1216,7 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 			// +1. Skip on non-200 — error bodies aren't shaped to take
 			// the prepend and would be soft no-ops anyway.
 			if resp.StatusCode == http.StatusOK && firstTurn {
-				cfg.FirstTurnNotice = llmproxy.RenderAgentRoutingNotice(agent.Name, mintedConversationID)
+				cfg.FirstTurnNotice = llmproxy.RenderAgentRoutingNotice(agent.Name, mintedConversationID, h.BrandLabel)
 			}
 
 			w.Header().Del("Content-Length")
@@ -1797,7 +1805,7 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 			// turn 1 (where no native session ID exists). For Anthropic
 			// and OpenAI Responses the renderer drops the marker
 			// argument and emits the existing notice unchanged.
-			notice := llmproxy.RenderAgentRoutingNotice(agent.Name, mintedConversationID)
+			notice := llmproxy.RenderAgentRoutingNotice(agent.Name, mintedConversationID, h.BrandLabel)
 			pre, changed, prependErr := llmproxy.PrependAssistantNotice(provider, processed.ContentType, processed.Body, notice)
 			switch {
 			case prependErr != nil:

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1304,6 +1304,19 @@ func (s *Server) registerLiteProxyRoutes(
 		} else {
 			llmHandler.DashboardBaseURL = strings.TrimRight(baseURL, "/")
 		}
+		// First-turn routing-notice brand label. Staging wins over local
+		// because a staging build pointed at a localhost bind is still
+		// the staging environment from the user's perspective (it's
+		// talking to staging upstreams, not production). Plain production
+		// (deployed, not loopback) keeps the unqualified "Clawvisor"
+		// label; the renderer defaults to "Clawvisor" on empty, so we
+		// only set the qualifier variants explicitly.
+		switch {
+		case version.IsStaging():
+			llmHandler.BrandLabel = "Clawvisor Staging"
+		case s.cfg.Server.IsLocal():
+			llmHandler.BrandLabel = "Clawvisor Local"
+		}
 
 		auditEmitter := llmproxy.NewAuditEmitter(s.store, s.logger, nil)
 		llmHandler.AuditEmitter = auditEmitter

--- a/internal/runtime/llmproxy/agent_notice.go
+++ b/internal/runtime/llmproxy/agent_notice.go
@@ -16,6 +16,15 @@ import (
 // defensive cap on [AutoApproveUserNotice].
 const agentNoticeMaxNameRunes = 80
 
+// agentNoticeMaxBrandRunes caps the brand label embedded in the
+// first-turn notice prose. Operator-controlled like the agent name;
+// the cap is purely defensive against a misconfigured deployment.
+const agentNoticeMaxBrandRunes = 40
+
+// defaultAgentNoticeBrand is the fallback brand label used when the
+// caller passes an empty / whitespace-only brandLabel.
+const defaultAgentNoticeBrand = "Clawvisor"
+
 // RenderAgentRoutingNotice returns the human-facing one-liner the
 // handler prepends to the first assistant turn of a conversation so the
 // user can see at a glance that the conversation is being routed
@@ -23,13 +32,19 @@ const agentNoticeMaxNameRunes = 80
 // agent names render a name-less fallback rather than an awkward empty
 // quote.
 //
+// brandLabel is the environment-qualified product name surfaced in the
+// prose ("Clawvisor Local", "Clawvisor Staging", "Clawvisor"). Empty /
+// whitespace falls back to plain "Clawvisor". The leading `[Clawvisor]`
+// tag is intentionally not parameterized — it is a stable subsystem
+// identifier, not a brand surface.
+//
 // mintedConversationID, when non-empty, is appended as a parseable
 // [clawvisor:conversation=cv-conv-…] footer so the harness round-trips
 // the ID back to us in assistant history on turn 2+. Only set on
 // harnesses without a native session identifier (today: OpenAI Chat
 // Completions); empty for Anthropic / OpenAI Responses where the
 // native session ID is the conclusive scope key.
-func RenderAgentRoutingNotice(agentName, mintedConversationID string) string {
+func RenderAgentRoutingNotice(agentName, mintedConversationID, brandLabel string) string {
 	cleaned := strings.TrimSpace(agentName)
 	cleaned = strings.ReplaceAll(cleaned, "\r", " ")
 	cleaned = strings.ReplaceAll(cleaned, "\n", " ")
@@ -39,6 +54,7 @@ func RenderAgentRoutingNotice(agentName, mintedConversationID string) string {
 	// dropping a stray backtick is nil.
 	cleaned = strings.ReplaceAll(cleaned, "`", "")
 	cleaned = truncateRunes(cleaned, agentNoticeMaxNameRunes)
+	brand := sanitizeBrandLabel(brandLabel)
 	// Backticks wrap the proxy status line so it renders as inline
 	// code in markdown UIs — visually distinct from the assistant's
 	// own prose. This notice lands in the assistant turn (human-facing),
@@ -47,14 +63,30 @@ func RenderAgentRoutingNotice(agentName, mintedConversationID string) string {
 	// injections the LLM reads.
 	var notice string
 	if cleaned == "" {
-		notice = "`[Clawvisor] Routing this conversation through Clawvisor.`"
+		notice = fmt.Sprintf("`[Clawvisor] Routing this conversation through %s.`", brand)
 	} else {
-		notice = fmt.Sprintf("`[Clawvisor] Routing this conversation through Clawvisor as agent %q.`", cleaned)
+		notice = fmt.Sprintf("`[Clawvisor] Routing this conversation through %s as agent %q.`", brand, cleaned)
 	}
 	if id := strings.TrimSpace(mintedConversationID); id != "" {
 		notice += " " + conversation.RenderConversationIDMarker(id)
 	}
 	return notice
+}
+
+// sanitizeBrandLabel normalizes the brand label the way the agent name
+// is normalized — strip CR/LF and backticks so neither breaks the
+// markdown inline-code span, cap the rune length, and fall back to
+// "Clawvisor" when the result is empty.
+func sanitizeBrandLabel(raw string) string {
+	cleaned := strings.TrimSpace(raw)
+	cleaned = strings.ReplaceAll(cleaned, "\r", " ")
+	cleaned = strings.ReplaceAll(cleaned, "\n", " ")
+	cleaned = strings.ReplaceAll(cleaned, "`", "")
+	cleaned = strings.TrimSpace(cleaned)
+	if cleaned == "" {
+		return defaultAgentNoticeBrand
+	}
+	return truncateRunes(cleaned, agentNoticeMaxBrandRunes)
 }
 
 // HasInboundAssistantTurn reports whether the inbound LLM request body

--- a/internal/runtime/llmproxy/agent_notice_test.go
+++ b/internal/runtime/llmproxy/agent_notice_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestRenderAgentRoutingNotice_NamedAgent(t *testing.T) {
-	got := RenderAgentRoutingNotice("My Laptop", "")
+	got := RenderAgentRoutingNotice("My Laptop", "", "")
 	want := "`[Clawvisor] Routing this conversation through Clawvisor as agent \"My Laptop\".`"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
@@ -18,7 +18,7 @@ func TestRenderAgentRoutingNotice_NamedAgent(t *testing.T) {
 }
 
 func TestRenderAgentRoutingNotice_EmptyName(t *testing.T) {
-	got := RenderAgentRoutingNotice("", "")
+	got := RenderAgentRoutingNotice("", "", "")
 	want := "`[Clawvisor] Routing this conversation through Clawvisor.`"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
@@ -26,7 +26,7 @@ func TestRenderAgentRoutingNotice_EmptyName(t *testing.T) {
 }
 
 func TestRenderAgentRoutingNotice_WhitespaceName(t *testing.T) {
-	got := RenderAgentRoutingNotice("   \t  ", "")
+	got := RenderAgentRoutingNotice("   \t  ", "", "")
 	want := "`[Clawvisor] Routing this conversation through Clawvisor.`"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
@@ -34,7 +34,7 @@ func TestRenderAgentRoutingNotice_WhitespaceName(t *testing.T) {
 }
 
 func TestRenderAgentRoutingNotice_StripsControlChars(t *testing.T) {
-	got := RenderAgentRoutingNotice("Line1\nLine2\rEnd", "")
+	got := RenderAgentRoutingNotice("Line1\nLine2\rEnd", "", "")
 	want := "`[Clawvisor] Routing this conversation through Clawvisor as agent \"Line1 Line2 End\".`"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
@@ -43,7 +43,7 @@ func TestRenderAgentRoutingNotice_StripsControlChars(t *testing.T) {
 
 func TestRenderAgentRoutingNotice_TruncatesLongName(t *testing.T) {
 	long := strings.Repeat("z", agentNoticeMaxNameRunes+50)
-	got := RenderAgentRoutingNotice(long, "")
+	got := RenderAgentRoutingNotice(long, "", "")
 	if !strings.Contains(got, "…") {
 		t.Errorf("expected truncation ellipsis, got %q", got)
 	}
@@ -61,7 +61,7 @@ func TestRenderAgentRoutingNotice_TruncatesLongName(t *testing.T) {
 // this is defense-in-depth, but a stray backtick would still leak
 // the trailing guidance as prose.
 func TestRenderAgentRoutingNotice_StripsBackticks(t *testing.T) {
-	got := RenderAgentRoutingNotice("agent`name`with`ticks", "")
+	got := RenderAgentRoutingNotice("agent`name`with`ticks", "", "")
 	if strings.Count(got, "`") != 2 {
 		t.Errorf("expected exactly the two wrapping backticks; got %q", got)
 	}
@@ -75,7 +75,7 @@ func TestRenderAgentRoutingNotice_TruncatesMultibyteRunes(t *testing.T) {
 	// mid-rune and produce U+FFFD on JSON marshal. Rune-aware truncation
 	// keeps the output well-formed.
 	long := strings.Repeat("日", agentNoticeMaxNameRunes+10)
-	got := RenderAgentRoutingNotice(long, "")
+	got := RenderAgentRoutingNotice(long, "", "")
 	if !strings.Contains(got, "…") {
 		t.Errorf("expected truncation ellipsis, got %q", got)
 	}
@@ -86,7 +86,7 @@ func TestRenderAgentRoutingNotice_TruncatesMultibyteRunes(t *testing.T) {
 
 func TestRenderAgentRoutingNotice_AppendsConversationIDMarker(t *testing.T) {
 	id := "cv-conv-abcdefghijklmnopqrstuvwxyz"
-	got := RenderAgentRoutingNotice("My Laptop", id)
+	got := RenderAgentRoutingNotice("My Laptop", id, "")
 	want := "`[Clawvisor] Routing this conversation through Clawvisor as agent \"My Laptop\".` [clawvisor:conversation=cv-conv-abcdefghijklmnopqrstuvwxyz]"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
@@ -94,7 +94,7 @@ func TestRenderAgentRoutingNotice_AppendsConversationIDMarker(t *testing.T) {
 }
 
 func TestRenderAgentRoutingNotice_AppendsMarkerToNameLessFallback(t *testing.T) {
-	got := RenderAgentRoutingNotice("", "cv-conv-aaaaaaaaaaaaaaaaaaaaaaaaaa")
+	got := RenderAgentRoutingNotice("", "cv-conv-aaaaaaaaaaaaaaaaaaaaaaaaaa", "")
 	want := "`[Clawvisor] Routing this conversation through Clawvisor.` [clawvisor:conversation=cv-conv-aaaaaaaaaaaaaaaaaaaaaaaaaa]"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
@@ -104,10 +104,60 @@ func TestRenderAgentRoutingNotice_AppendsMarkerToNameLessFallback(t *testing.T) 
 func TestRenderAgentRoutingNotice_WhitespaceMintedIDOmitsMarker(t *testing.T) {
 	// Empty/whitespace mintedConversationID must not produce an empty
 	// "[clawvisor:conversation=]" footer.
-	got := RenderAgentRoutingNotice("agent", "   ")
+	got := RenderAgentRoutingNotice("agent", "   ", "")
 	want := "`[Clawvisor] Routing this conversation through Clawvisor as agent \"agent\".`"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestRenderAgentRoutingNotice_LocalBrandLabel pins the local-bind
+// variant: a Clawvisor running on loopback shows "Clawvisor Local" in
+// the prose so the user can tell at a glance the conversation is
+// routed through the local proxy, not a hosted one.
+func TestRenderAgentRoutingNotice_LocalBrandLabel(t *testing.T) {
+	got := RenderAgentRoutingNotice("My Laptop", "", "Clawvisor Local")
+	want := "`[Clawvisor] Routing this conversation through Clawvisor Local as agent \"My Laptop\".`"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRenderAgentRoutingNotice_StagingBrandLabel(t *testing.T) {
+	got := RenderAgentRoutingNotice("My Laptop", "", "Clawvisor Staging")
+	want := "`[Clawvisor] Routing this conversation through Clawvisor Staging as agent \"My Laptop\".`"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRenderAgentRoutingNotice_BrandLabelNameLessFallback(t *testing.T) {
+	got := RenderAgentRoutingNotice("", "", "Clawvisor Local")
+	want := "`[Clawvisor] Routing this conversation through Clawvisor Local.`"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRenderAgentRoutingNotice_WhitespaceBrandLabelDefaultsToClawvisor(t *testing.T) {
+	got := RenderAgentRoutingNotice("agent", "", "   \t  ")
+	want := "`[Clawvisor] Routing this conversation through Clawvisor as agent \"agent\".`"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// TestRenderAgentRoutingNotice_BrandLabelStripsBackticks mirrors the
+// defense applied to the agent name: a brand label with a backtick
+// would otherwise terminate the markdown inline-code span the notice
+// is wrapped in and leak the trailing guidance as prose.
+func TestRenderAgentRoutingNotice_BrandLabelStripsBackticks(t *testing.T) {
+	got := RenderAgentRoutingNotice("agent", "", "Claw`visor` Local")
+	if strings.Count(got, "`") != 2 {
+		t.Errorf("expected exactly the two wrapping backticks; got %q", got)
+	}
+	if !strings.Contains(got, "Clawvisor Local") {
+		t.Errorf("expected backticks stripped from brand label; got %q", got)
 	}
 }
 
@@ -116,7 +166,7 @@ func TestRenderAgentRoutingNotice_MintedIDRoundTripsThroughScanner(t *testing.T)
 	if err != nil {
 		t.Fatal(err)
 	}
-	notice := RenderAgentRoutingNotice("agent", id)
+	notice := RenderAgentRoutingNotice("agent", id, "")
 	// Build a Chat Completions inbound body where the assistant turn
 	// is exactly the rendered notice — simulating turn-2 echo.
 	body := []byte(`{"messages":[{"role":"assistant","content":` + mustJSONString(t, notice) + `}]}`)


### PR DESCRIPTION
## Summary
- First-turn routing notice now reflects which Clawvisor the conversation is routed through: loopback-bound proxy → `Clawvisor Local`, staging build → `Clawvisor Staging`, deployed production → unchanged `Clawvisor`. Staging-build wins over loopback bind because the upstreams a staging binary talks to are staging regardless of where it's running.
- Threads a `BrandLabel` field on `LLMEndpointHandler` set at server wiring time from `version.IsStaging()` + `s.cfg.Server.IsLocal()`; the renderer takes the label as a third arg and sanitizes it the same way the agent name is (strip CR/LF and backticks, rune-cap at 40). Empty/whitespace defaults to `Clawvisor` so callers that don't care keep the existing behavior.
- The leading `[Clawvisor]` tag prefix is intentionally not parameterized — it's a stable subsystem identifier (like a log tag), not a brand surface; only the prose word varies.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/runtime/llmproxy/... -run 'AgentRoutingNotice|HasInboundAssistantTurn'`
- [x] `go test ./internal/runtime/conversation/... -run 'ConversationIDMarker|FindInjectedConversationID'` (notice text used as scanner fixture — still passes since `Clawvisor` is a substring of all brand variants)
- [x] `go test ./internal/api/handlers/... -run 'ConversationIDMarker|RoutingNotice'`
- [ ] Manually verify the notice prose locally (loopback bind shows `Clawvisor Local`) and on a staging deploy (`llm.staging.clawvisor.com` shows `Clawvisor Staging`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/589?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

