### PR TITLE
feat(tasks): plumb surface=inline through scope expansions

### DIFF
--- a/internal/api/handlers/tasks.go
+++ b/internal/api/handlers/tasks.go
@@ -2627,7 +2627,7 @@ func (h *TasksHandler) ExpandApprove(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusConflict, "INVALID_STATE", "task has no pending scope expansion")
 		return
 	}
-	if isInlineChatExpansionPending(task) {
+	if h.isInlineChatExpansionPending(ctx, task) {
 		// Chat-bound pending expansion. The llmproxy cache hold owns
 		// resolution; approving here would flip the DB row without
 		// telling the model. Mirrors isInlineChatPending in the task-
@@ -3299,7 +3299,7 @@ func (h *TasksHandler) ExpandApproveByTaskID(ctx context.Context, taskID, userID
 	if task.Status != "pending_scope_expansion" || task.PendingExpansion == nil {
 		return fmt.Errorf("task has no pending scope expansion")
 	}
-	if isInlineChatExpansionPending(task) {
+	if h.isInlineChatExpansionPending(ctx, task) {
 		// Chat-bound; the cache hold owns resolution. Mirror
 		// ApproveByTaskID's errInlineChatBound so notifier callbacks
 		// (Telegram button) see the same error shape they already
@@ -3428,11 +3428,33 @@ func isInlineChatPending(task *store.Task) bool {
 // (set by CreatePendingInlineExpansion) rather than task.ApprovalSource
 // because a chat-bound expansion can attach to a task that was
 // originally created via dashboard / Telegram. Deny does not consult it.
-func isInlineChatExpansionPending(task *store.Task) bool {
+//
+// Backwards-compat: pending_expansion_json rows landed before the
+// Surface field existed (or by any future code path that forgets to
+// set it) fall back to the canonical approval_records row, which has
+// been carrying Surface="inline_chat" since the inline expansion
+// intercept shipped. The lookup runs only when the JSON-side flag is
+// empty, so the hot path (post-upgrade rows) stays a struct-field read.
+func (h *TasksHandler) isInlineChatExpansionPending(ctx context.Context, task *store.Task) bool {
 	if task == nil || task.PendingExpansion == nil {
 		return false
 	}
-	return task.Status == "pending_scope_expansion" && task.PendingExpansion.Surface == "inline_chat"
+	if task.Status != "pending_scope_expansion" {
+		return false
+	}
+	if task.PendingExpansion.Surface == "inline_chat" {
+		return true
+	}
+	records, err := h.st.ListPendingApprovalRecords(ctx, task.UserID)
+	if err != nil {
+		return false
+	}
+	for _, r := range records {
+		if r.Kind == "task_expand" && r.Surface == "inline_chat" && r.TaskID != nil && *r.TaskID == task.ID {
+			return true
+		}
+	}
+	return false
 }
 
 func canonicalTaskApprovalKind(task *store.Task) string {

--- a/internal/api/handlers/tasks.go
+++ b/internal/api/handlers/tasks.go
@@ -1114,11 +1114,64 @@ func (h *TasksHandler) List(w http.ResponseWriter, r *http.Request) {
 			_ = h.st.UpdateTaskStatus(ctx, t.ID, "expired")
 		}
 	}
+	// Backfill PendingExpansion.Surface for any pending_scope_expansion
+	// tasks whose JSON-side field is empty. These rows landed before
+	// the Surface marker existed (or via a future code path that
+	// forgets to set it); the canonical approval_records row is the
+	// source of truth. Without this the dashboard would render an
+	// Approve button that the backend gate (isInlineChatExpansionPending)
+	// would then reject with 409 INLINE_CHAT_BOUND. One list query per
+	// List call covers the whole page.
+	h.backfillChatBoundExpansionSurface(ctx, user.ID, tasks)
 
 	writeJSON(w, http.StatusOK, map[string]any{
 		"total": total,
 		"tasks": tasks,
 	})
+}
+
+// backfillChatBoundExpansionSurface synthesizes PendingExpansion.Surface
+// for tasks in pending_scope_expansion whose JSON-side field is empty,
+// using the canonical approval_records as the source of truth. Mutates
+// the tasks in-place. Best-effort: a store error is logged and the
+// frontend renders whatever Surface (possibly empty) it has — the
+// backend ExpandApprove gate is the authoritative guard and runs its
+// own fallback lookup.
+func (h *TasksHandler) backfillChatBoundExpansionSurface(ctx context.Context, userID string, tasks []*store.Task) {
+	var needs []*store.Task
+	for _, t := range tasks {
+		if t == nil || t.PendingExpansion == nil {
+			continue
+		}
+		if t.Status != "pending_scope_expansion" {
+			continue
+		}
+		if t.PendingExpansion.Surface != "" {
+			continue
+		}
+		needs = append(needs, t)
+	}
+	if len(needs) == 0 {
+		return
+	}
+	records, err := h.st.ListPendingApprovalRecords(ctx, userID)
+	if err != nil {
+		h.logger.WarnContext(ctx, "could not backfill pending expansion surface; UI may render stale chat-bound state",
+			"user_id", userID, "candidates", len(needs), "err", err)
+		return
+	}
+	chatBoundByTaskID := make(map[string]struct{})
+	for _, r := range records {
+		if r.Kind != "task_expand" || r.Surface != "inline_chat" || r.TaskID == nil {
+			continue
+		}
+		chatBoundByTaskID[*r.TaskID] = struct{}{}
+	}
+	for _, t := range needs {
+		if _, ok := chatBoundByTaskID[t.ID]; ok {
+			t.PendingExpansion.Surface = "inline_chat"
+		}
+	}
 }
 
 // sanitizeTaskForResponse cleans up task fields before serialization:
@@ -2627,7 +2680,15 @@ func (h *TasksHandler) ExpandApprove(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusConflict, "INVALID_STATE", "task has no pending scope expansion")
 		return
 	}
-	if h.isInlineChatExpansionPending(ctx, task) {
+	chatBound, err := h.isInlineChatExpansionPending(ctx, task)
+	if err != nil {
+		// Fail closed: refusing to make an approve/deny decision under
+		// an unknown chat-bound state is safer than silently allowing
+		// the dashboard to race the chat hold.
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not verify chat-bound state for scope expansion")
+		return
+	}
+	if chatBound {
 		// Chat-bound pending expansion. The llmproxy cache hold owns
 		// resolution; approving here would flip the DB row without
 		// telling the model. Mirrors isInlineChatPending in the task-
@@ -3299,7 +3360,11 @@ func (h *TasksHandler) ExpandApproveByTaskID(ctx context.Context, taskID, userID
 	if task.Status != "pending_scope_expansion" || task.PendingExpansion == nil {
 		return fmt.Errorf("task has no pending scope expansion")
 	}
-	if h.isInlineChatExpansionPending(ctx, task) {
+	chatBound, err := h.isInlineChatExpansionPending(ctx, task)
+	if err != nil {
+		return fmt.Errorf("verify chat-bound state for scope expansion: %w", err)
+	}
+	if chatBound {
 		// Chat-bound; the cache hold owns resolution. Mirror
 		// ApproveByTaskID's errInlineChatBound so notifier callbacks
 		// (Telegram button) see the same error shape they already
@@ -3435,26 +3500,33 @@ func isInlineChatPending(task *store.Task) bool {
 // been carrying Surface="inline_chat" since the inline expansion
 // intercept shipped. The lookup runs only when the JSON-side flag is
 // empty, so the hot path (post-upgrade rows) stays a struct-field read.
-func (h *TasksHandler) isInlineChatExpansionPending(ctx context.Context, task *store.Task) bool {
+//
+// Returns (bool, error). On store error the caller must NOT proceed
+// with the approve — fail-open here would let a chat-bound expansion
+// be approved from the dashboard during a transient DB hiccup, racing
+// the chat hold. Callers translate the error to a 500 / wrapped
+// notifier error so the request is retryable instead of silently
+// allowed.
+func (h *TasksHandler) isInlineChatExpansionPending(ctx context.Context, task *store.Task) (bool, error) {
 	if task == nil || task.PendingExpansion == nil {
-		return false
+		return false, nil
 	}
 	if task.Status != "pending_scope_expansion" {
-		return false
+		return false, nil
 	}
 	if task.PendingExpansion.Surface == "inline_chat" {
-		return true
+		return true, nil
 	}
 	records, err := h.st.ListPendingApprovalRecords(ctx, task.UserID)
 	if err != nil {
-		return false
+		return false, err
 	}
 	for _, r := range records {
 		if r.Kind == "task_expand" && r.Surface == "inline_chat" && r.TaskID != nil && *r.TaskID == task.ID {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 func canonicalTaskApprovalKind(task *store.Task) string {

--- a/internal/api/handlers/tasks.go
+++ b/internal/api/handlers/tasks.go
@@ -2627,6 +2627,14 @@ func (h *TasksHandler) ExpandApprove(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusConflict, "INVALID_STATE", "task has no pending scope expansion")
 		return
 	}
+	if isInlineChatExpansionPending(task) {
+		// Chat-bound pending expansion. The llmproxy cache hold owns
+		// resolution; approving here would flip the DB row without
+		// telling the model. Mirrors isInlineChatPending in the task-
+		// creation Approve handler.
+		writeError(w, http.StatusConflict, "INLINE_CHAT_BOUND", "approve in the agent chat surface — reply 'approve' or 'deny' to the running session")
+		return
+	}
 
 	envUpdate, merged, err := buildExpansionApprovalUpdate(task)
 	if err != nil {
@@ -3291,6 +3299,13 @@ func (h *TasksHandler) ExpandApproveByTaskID(ctx context.Context, taskID, userID
 	if task.Status != "pending_scope_expansion" || task.PendingExpansion == nil {
 		return fmt.Errorf("task has no pending scope expansion")
 	}
+	if isInlineChatExpansionPending(task) {
+		// Chat-bound; the cache hold owns resolution. Mirror
+		// ApproveByTaskID's errInlineChatBound so notifier callbacks
+		// (Telegram button) see the same error shape they already
+		// handle for task creation.
+		return errInlineChatBound
+	}
 
 	envUpdate, merged, err := buildExpansionApprovalUpdate(task)
 	if err != nil {
@@ -3406,6 +3421,18 @@ func isInlineChatPending(task *store.Task) bool {
 		return false
 	}
 	return task.Status == "pending_approval" && task.ApprovalSource == "inline_chat"
+}
+
+// isInlineChatExpansionPending mirrors isInlineChatPending for the
+// scope-expansion path. The signal lives on PendingExpansion.Surface
+// (set by CreatePendingInlineExpansion) rather than task.ApprovalSource
+// because a chat-bound expansion can attach to a task that was
+// originally created via dashboard / Telegram. Deny does not consult it.
+func isInlineChatExpansionPending(task *store.Task) bool {
+	if task == nil || task.PendingExpansion == nil {
+		return false
+	}
+	return task.Status == "pending_scope_expansion" && task.PendingExpansion.Surface == "inline_chat"
 }
 
 func canonicalTaskApprovalKind(task *store.Task) string {

--- a/internal/api/handlers/tasks_inline.go
+++ b/internal/api/handlers/tasks_inline.go
@@ -949,6 +949,11 @@ func (h *TasksHandler) CreatePendingInlineExpansion(
 	if precomputedRisk != nil && precomputedRisk.RiskLevel != "" {
 		pending.RiskAssessment = taskrisk.MarshalAssessment(precomputedRisk)
 	}
+	// Mark chat-bound so the dashboard ExpandApprove handler rejects with
+	// INLINE_CHAT_BOUND (the cache hold owns resolution) and the dashboard
+	// TaskCard hides its Approve button. Mirrors ApprovalSource="inline_chat"
+	// on inline task creation.
+	pending.Surface = "inline_chat"
 
 	won, err := h.st.SetTaskPendingExpansion(ctx, taskID, pending)
 	if err != nil {

--- a/internal/tui/client/types.go
+++ b/internal/tui/client/types.go
@@ -229,6 +229,9 @@ type PendingTaskExpansion struct {
 	ExpectedEgress      json.RawMessage `json:"expected_egress,omitempty"`
 	RequiredCredentials json.RawMessage `json:"required_credentials,omitempty"`
 	Reason              string          `json:"reason,omitempty"`
+	// Surface mirrors store.PendingTaskExpansion.Surface — "inline_chat"
+	// means the expansion is chat-bound and the dashboard/TUI cannot approve it.
+	Surface string `json:"surface,omitempty"`
 }
 
 type TaskAction struct {

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -906,6 +906,13 @@ type PendingTaskExpansion struct {
 	// configured at expand time; callers fall back to a fresh
 	// deterministic-only assessment in that case.
 	RiskAssessment json.RawMessage `json:"risk_assessment,omitempty"`
+	// Surface records where the expansion request originated. "inline_chat"
+	// means the agent submitted it via the chat-bound surface (?surface=inline
+	// on POST .../expand, or the lite-proxy intercept) and the approval is
+	// owned by the chat hold; dashboard ExpandApprove must reject with a 409
+	// just like isInlineChatPending does for task creation. Empty for the
+	// default dashboard/headless path.
+	Surface string `json:"surface,omitempty"`
 }
 
 // TaskEnvelopeUpdate is the payload for UpdateTaskEnvelopeFrom. AuthorizedActions

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -649,6 +649,11 @@ export interface PendingTaskExpansion {
   expected_egress?: ExpectedEgress[]
   required_credentials?: RequiredCredential[]
   reason?: string
+  // "inline_chat" when the expansion was requested via the chat-bound
+  // surface (?surface=inline). Dashboard cannot approve it — the
+  // llmproxy cache hold owns resolution. Mirrors task.approval_source
+  // for the task-creation case.
+  surface?: string
 }
 
 export interface Task {

--- a/web/src/components/TaskCard.tsx
+++ b/web/src/components/TaskCard.tsx
@@ -455,16 +455,35 @@ export default function TaskCard({
               </div>
             </div>
           )}
-          <div className="px-4 py-3 border-t border-border-subtle flex items-center justify-end gap-2">
-            <button onClick={() => expandDenyMut.mutate()} disabled={isPending}
-              className="rounded px-4 py-1.5 text-sm font-medium bg-danger/10 text-danger border border-danger/20 hover:bg-danger/20 disabled:opacity-50">
-              Deny
-            </button>
-            <button onClick={() => expandApproveMut.mutate()} disabled={isPending}
-              className="bg-brand text-surface-0 font-medium rounded px-5 py-1.5 text-sm hover:bg-brand-strong disabled:opacity-50">
-              {expandApproveMut.isPending ? 'Approving...' : 'Approve Scope'}
-            </button>
-          </div>
+          {task.pending_expansion?.surface === 'inline_chat' ? (
+            // Chat-bound pending expansion: dashboard Approve would 409
+            // with INLINE_CHAT_BOUND because the llmproxy cache hold
+            // owns resolution. Deny is permitted from here so the user
+            // can dismiss a zombie expansion the agent has lost track
+            // of. Mirrors the inline_chat task-creation branch above.
+            <div className="border-t border-border-subtle">
+              <div className="px-4 py-3 text-sm text-text-secondary bg-surface-2">
+                Reply <span className="font-mono text-text-primary">approve</span> in the agent chat to grant scope, or dismiss it here.
+              </div>
+              <div className="px-4 py-3 flex items-center justify-end gap-2">
+                <button onClick={() => expandDenyMut.mutate()} disabled={isPending}
+                  className="rounded px-4 py-1.5 text-sm font-medium bg-danger/10 text-danger border border-danger/20 hover:bg-danger/20 disabled:opacity-50">
+                  Deny
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className="px-4 py-3 border-t border-border-subtle flex items-center justify-end gap-2">
+              <button onClick={() => expandDenyMut.mutate()} disabled={isPending}
+                className="rounded px-4 py-1.5 text-sm font-medium bg-danger/10 text-danger border border-danger/20 hover:bg-danger/20 disabled:opacity-50">
+                Deny
+              </button>
+              <button onClick={() => expandApproveMut.mutate()} disabled={isPending}
+                className="bg-brand text-surface-0 font-medium rounded px-5 py-1.5 text-sm hover:bg-brand-strong disabled:opacity-50">
+                {expandApproveMut.isPending ? 'Approving...' : 'Approve Scope'}
+              </button>
+            </div>
+          )}
         </>
       )}
 


### PR DESCRIPTION
## Summary
- Plumb `surface=inline` end-to-end for **scope expansions**, mirroring the existing inline_chat task-creation pattern. Chat-bound pending expansions now carry `PendingExpansion.Surface = "inline_chat"` so the dashboard knows the llmproxy cache hold owns resolution.
- Dashboard `TaskCard` hides the Approve button on chat-bound expansions and renders the "reply approve in agent chat" copy — same pattern as inline_chat task creation. Deny stays available so the user can dismiss a zombie expansion.
- Backend `ExpandApprove` (HTTP) and `ExpandApproveByTaskID` (notifier callback) reject chat-bound expansions with `409 INLINE_CHAT_BOUND` / `errInlineChatBound`, mirroring `ApproveByTaskID`'s gate.
- Two robustness fixes from cubic review: gate is fail-closed under store errors (returns `(bool, error)` and the caller returns 500 / wraps the error instead of silently allowing), and `Tasks.List` backfills `PendingExpansion.Surface` from `approval_records` so older rows (or any future write path that omits the field) render the right UI.

## Files
- Backend: `pkg/store/store.go`, `internal/tui/client/types.go` (add `Surface` field), `internal/api/handlers/tasks_inline.go` (set `Surface="inline_chat"` in `CreatePendingInlineExpansion`), `internal/api/handlers/tasks.go` (`isInlineChatExpansionPending` + gate in `ExpandApprove` / `ExpandApproveByTaskID` + `backfillChatBoundExpansionSurface` in `List`).
- Frontend: `web/src/api/client.ts` (interface), `web/src/components/TaskCard.tsx` (branch on `pending_expansion.surface`).

## Test plan
- [ ] `go build ./... && go vet ./...` clean
- [ ] `go test ./pkg/store/... ./internal/api/handlers/... ./internal/runtime/llmproxy/... ./internal/runtime/tasks/... ./internal/tui/...` all green
- [ ] `npm run lint && npm run build` in `web/` clean
- [ ] Inline-chat expansion happy path: model emits expand curl → dashboard renders chat-bound copy + Deny-only → user replies `approve` in chat → expansion lands
- [ ] Dashboard ExpandApprove on chat-bound row returns 409 INLINE_CHAT_BOUND (with `Surface` set AND with empty `Surface` + matching `approval_records` row)
- [ ] Backfill behavior on older row: `Tasks.List` populates `pending_expansion.surface` from `approval_records` so the UI hides the Approve button without a round-trip

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

