### PR TITLE
perf(gmail): batch list_messages metadata via /batch/gmail/v1

### DIFF
--- a/internal/adapters/google/gmail/adapter.go
+++ b/internal/adapters/google/gmail/adapter.go
@@ -1035,6 +1035,15 @@ func fetchMessageMetasBatchOne(ctx context.Context, client *http.Client, ids []s
 		return metas, errs
 	}
 
+	// Pre-fill errs so any id whose response is missing or has an
+	// unparseable Content-ID surfaces as an explicit error rather than
+	// silently degrading to a zero-valued msgMeta that listMessages would
+	// then emit as an empty/incorrect message. Successful sub-responses
+	// clear their slot below.
+	for i := range errs {
+		errs[i] = fmt.Errorf("gmail batch: no sub-response received for id %q", ids[i])
+	}
+
 	mr := multipart.NewReader(bytes.NewReader(respBody), boundary)
 	for {
 		part, err := mr.NextPart()
@@ -1061,6 +1070,7 @@ func fetchMessageMetasBatchOne(ctx context.Context, client *http.Client, ids []s
 			continue
 		}
 		metas[idx] = meta
+		errs[idx] = nil
 	}
 	return metas, errs
 }

--- a/internal/adapters/google/gmail/adapter.go
+++ b/internal/adapters/google/gmail/adapter.go
@@ -2,23 +2,25 @@
 package gmail
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"html"
 	"io"
 	"mime"
+	"mime/multipart"
 	"mime/quotedprintable"
 	"net/http"
+	"net/textproto"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/clawvisor/clawvisor/internal/adapters/format"
 	"github.com/clawvisor/clawvisor/internal/adapters/google/credential"
@@ -28,11 +30,6 @@ import (
 const serviceID = "google.gmail"
 
 const gmailModifyScope = "https://www.googleapis.com/auth/gmail.modify"
-
-// listMessagesMetaConcurrency is the maximum concurrent metadata requests
-// when listing messages. Gmail's metadata-read quota is generous enough to
-// leave headroom at this level.
-const listMessagesMetaConcurrency = 15
 
 // gmailScopes is the full set of scopes Gmail can use. The YAML definition is
 // the source of truth for OAuth URL generation and action gating; this list
@@ -183,72 +180,39 @@ func (a *GmailAdapter) listMessages(ctx context.Context, client *http.Client, pa
 	items := make([]msgListItem, 0, len(listResp.Messages))
 	unread := 0
 
-	type fetchResult struct {
-		id   string
-		meta msgMeta
-		err  error
+	ids := make([]string, len(listResp.Messages))
+	for i, m := range listResp.Messages {
+		ids[i] = m.ID
 	}
-
-	numMessages := len(listResp.Messages)
-	results := make([]fetchResult, numMessages)
-
-	if numMessages > 0 {
-		var g errgroup.Group
-		g.SetLimit(listMessagesMetaConcurrency)
-
-		for i, m := range listResp.Messages {
-			if ctx.Err() != nil {
-				break
-			}
-			i, m := i, m
-			g.Go(func() error {
-				if ctx.Err() != nil {
-					return ctx.Err()
-				}
-				meta, err := fetchMessageMeta(ctx, client, m.ID)
-				if err != nil {
-					if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-						return err
-					}
-					results[i] = fetchResult{id: m.ID, err: err}
-					return nil
-				}
-				results[i] = fetchResult{id: m.ID, meta: meta}
-				return nil
-			})
-		}
-		if err := g.Wait(); err != nil {
-			return nil, fmt.Errorf("gmail list_messages: %w", err)
-		}
-		if ctx.Err() != nil {
-			return nil, ctx.Err()
-		}
+	metas, metaErrs := fetchMessageMetasBatch(ctx, client, ids)
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
 
 	var firstFetchErr error
-	for _, res := range results {
-		if res.err != nil {
+	for i, meta := range metas {
+		if metaErrs[i] != nil {
 			if firstFetchErr == nil {
-				firstFetchErr = res.err
+				firstFetchErr = metaErrs[i]
 			}
 			continue
 		}
 		item := msgListItem{
-			ID:       res.id,
-			From:     format.SanitizeHeader(res.meta.from, format.MaxFieldLen),
-			Subject:  format.SanitizeText(res.meta.subject, format.MaxFieldLen),
-			Snippet:  format.SanitizeText(res.meta.snippet, format.MaxSnippetLen),
-			Date:     res.meta.date,
-			IsUnread: res.meta.isUnread,
-			Labels:   labels.resolve(res.meta.labelIDs),
+			ID:       ids[i],
+			From:     format.SanitizeHeader(meta.from, format.MaxFieldLen),
+			Subject:  format.SanitizeText(meta.subject, format.MaxFieldLen),
+			Snippet:  format.SanitizeText(meta.snippet, format.MaxSnippetLen),
+			Date:     meta.date,
+			IsUnread: meta.isUnread,
+			Labels:   labels.resolve(meta.labelIDs),
 		}
 		items = append(items, item)
-		if res.meta.isUnread {
+		if meta.isUnread {
 			unread++
 		}
 	}
 
-	if numMessages > 0 && len(items) == 0 && firstFetchErr != nil {
+	if len(ids) > 0 && len(items) == 0 && firstFetchErr != nil {
 		return nil, fmt.Errorf("gmail list_messages: all metadata fetches failed: %w", firstFetchErr)
 	}
 
@@ -983,8 +947,152 @@ type msgMeta struct {
 	labelIDs                     []string
 }
 
-func fetchMessageMeta(ctx context.Context, client *http.Client, id string) (msgMeta, error) {
-	url := fmt.Sprintf("https://gmail.googleapis.com/gmail/v1/users/me/messages/%s?format=metadata&metadataHeaders=From&metadataHeaders=Subject&metadataHeaders=Date", id)
+// gmailBatchMaxRequests is Gmail's documented per-batch cap.
+const gmailBatchMaxRequests = 100
+
+// fetchMessageMetasBatch fetches per-message metadata for the given ids using
+// Gmail's multipart/mixed batch endpoint, returning aligned slices of metas
+// and errors. A non-nil errs[i] means the i'th id could not be resolved;
+// callers tolerate this the same way they did the old per-call fan-out.
+//
+// Batches are sized to gmailBatchMaxRequests and processed sequentially.
+// A request-level failure (network / 5xx on the outer POST) fills the same
+// error across every slot in that batch.
+func fetchMessageMetasBatch(ctx context.Context, client *http.Client, ids []string) ([]msgMeta, []error) {
+	metas := make([]msgMeta, len(ids))
+	errs := make([]error, len(ids))
+	for start := 0; start < len(ids); start += gmailBatchMaxRequests {
+		end := start + gmailBatchMaxRequests
+		if end > len(ids) {
+			end = len(ids)
+		}
+		chunkMetas, chunkErrs := fetchMessageMetasBatchOne(ctx, client, ids[start:end])
+		copy(metas[start:end], chunkMetas)
+		copy(errs[start:end], chunkErrs)
+	}
+	return metas, errs
+}
+
+// fetchMessageMetasBatchOne issues a single multipart/mixed POST to
+// /batch/gmail/v1 for up to gmailBatchMaxRequests ids and parses the response.
+func fetchMessageMetasBatchOne(ctx context.Context, client *http.Client, ids []string) ([]msgMeta, []error) {
+	metas := make([]msgMeta, len(ids))
+	errs := make([]error, len(ids))
+
+	var body bytes.Buffer
+	mw := multipart.NewWriter(&body)
+	for i, id := range ids {
+		subHeader := textproto.MIMEHeader{}
+		subHeader.Set("Content-Type", "application/http")
+		subHeader.Set("Content-ID", fmt.Sprintf("<item-%d>", i))
+		part, err := mw.CreatePart(subHeader)
+		if err != nil {
+			fillErrs(errs, fmt.Errorf("gmail batch build: %w", err))
+			return metas, errs
+		}
+		sub := fmt.Sprintf(
+			"GET /gmail/v1/users/me/messages/%s?format=metadata&metadataHeaders=From&metadataHeaders=Subject&metadataHeaders=Date HTTP/1.1\r\n\r\n",
+			id,
+		)
+		if _, err := io.WriteString(part, sub); err != nil {
+			fillErrs(errs, fmt.Errorf("gmail batch build: %w", err))
+			return metas, errs
+		}
+	}
+	if err := mw.Close(); err != nil {
+		fillErrs(errs, fmt.Errorf("gmail batch build: %w", err))
+		return metas, errs
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://www.googleapis.com/batch/gmail/v1", &body)
+	if err != nil {
+		fillErrs(errs, err)
+		return metas, errs
+	}
+	req.Header.Set("Content-Type", "multipart/mixed; boundary="+mw.Boundary())
+
+	resp, err := client.Do(req)
+	if err != nil {
+		fillErrs(errs, err)
+		return metas, errs
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		fillErrs(errs, fmt.Errorf("gmail batch: %d: %s", resp.StatusCode, format.Truncate(string(respBody), 200)))
+		return metas, errs
+	}
+
+	_, params, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+	if err != nil {
+		fillErrs(errs, fmt.Errorf("gmail batch parse content-type: %w", err))
+		return metas, errs
+	}
+	boundary, ok := params["boundary"]
+	if !ok {
+		fillErrs(errs, fmt.Errorf("gmail batch: missing boundary in response"))
+		return metas, errs
+	}
+
+	mr := multipart.NewReader(bytes.NewReader(respBody), boundary)
+	for {
+		part, err := mr.NextPart()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			fillErrs(errs, fmt.Errorf("gmail batch read part: %w", err))
+			return metas, errs
+		}
+		idx, idxOK := parseBatchContentIndex(part.Header.Get("Content-ID"))
+		partBody, readErr := io.ReadAll(part)
+		part.Close()
+		if !idxOK || idx < 0 || idx >= len(ids) {
+			continue
+		}
+		if readErr != nil {
+			errs[idx] = fmt.Errorf("gmail batch read part body: %w", readErr)
+			continue
+		}
+		meta, err := parseBatchSubResponse(partBody)
+		if err != nil {
+			errs[idx] = err
+			continue
+		}
+		metas[idx] = meta
+	}
+	return metas, errs
+}
+
+// parseBatchContentIndex recovers the request index from a batch part's
+// Content-ID header. Gmail echoes the client-supplied id prefixed with
+// "response-", so both "<item-3>" and "<response-item-3>" parse to 3.
+func parseBatchContentIndex(contentID string) (int, bool) {
+	s := strings.TrimPrefix(strings.TrimSuffix(strings.TrimPrefix(contentID, "<"), ">"), "response-")
+	s = strings.TrimPrefix(s, "item-")
+	if s == "" {
+		return 0, false
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+// parseBatchSubResponse decodes one application/http sub-response body into
+// an msgMeta, mirroring the prior per-id fetch's status check and JSON shape.
+func parseBatchSubResponse(body []byte) (msgMeta, error) {
+	sub, err := http.ReadResponse(bufio.NewReader(bytes.NewReader(body)), nil)
+	if err != nil {
+		return msgMeta{}, fmt.Errorf("gmail batch parse sub-response: %w", err)
+	}
+	defer sub.Body.Close()
+	subBody, _ := io.ReadAll(sub.Body)
+	if sub.StatusCode >= 400 {
+		return msgMeta{}, fmt.Errorf("gmail batch sub: %d: %s", sub.StatusCode, format.Truncate(string(subBody), 200))
+	}
 	var raw struct {
 		Snippet  string   `json:"snippet"`
 		LabelIds []string `json:"labelIds"`
@@ -992,10 +1100,9 @@ func fetchMessageMeta(ctx context.Context, client *http.Client, id string) (msgM
 			Headers []gmailHeader `json:"headers"`
 		} `json:"payload"`
 	}
-	if err := gmailGET(ctx, client, url, &raw); err != nil {
-		return msgMeta{}, err
+	if err := json.Unmarshal(subBody, &raw); err != nil {
+		return msgMeta{}, fmt.Errorf("gmail batch sub decode: %w", err)
 	}
-
 	meta := msgMeta{snippet: raw.Snippet, labelIDs: raw.LabelIds}
 	for _, h := range raw.Payload.Headers {
 		switch strings.ToLower(h.Name) {
@@ -1013,6 +1120,12 @@ func fetchMessageMeta(ctx context.Context, client *http.Client, id string) (msgM
 		}
 	}
 	return meta, nil
+}
+
+func fillErrs(errs []error, err error) {
+	for i := range errs {
+		errs[i] = err
+	}
 }
 
 // extractBodyFromParts walks a message payload to find the best text content.

--- a/internal/adapters/google/gmail/adapter.go
+++ b/internal/adapters/google/gmail/adapter.go
@@ -1018,9 +1018,17 @@ func fetchMessageMetasBatchOne(ctx context.Context, client *http.Client, ids []s
 	}
 	defer resp.Body.Close()
 
-	respBody, _ := io.ReadAll(resp.Body)
+	respBody, readErr := io.ReadAll(resp.Body)
 	if resp.StatusCode >= 400 {
 		fillErrs(errs, fmt.Errorf("gmail batch: %d: %s", resp.StatusCode, format.Truncate(string(respBody), 200)))
+		return metas, errs
+	}
+	// A read failure on the response body means we have a truncated multipart
+	// payload. Fail the whole chunk: continuing would parse the prefix and
+	// quietly emit successful sub-responses for the parts we did manage to
+	// read, hiding the wire-level error.
+	if readErr != nil {
+		fillErrs(errs, fmt.Errorf("gmail batch read body: %w", readErr))
 		return metas, errs
 	}
 

--- a/internal/adapters/google/gmail/adapter_test.go
+++ b/internal/adapters/google/gmail/adapter_test.go
@@ -912,6 +912,72 @@ func TestListMessages_BatchEmptyResult(t *testing.T) {
 // sub-responses than we asked for: only msg-1 echoes back; msg-2 is silently
 // dropped from the multipart body. The dropped slot must surface as an
 // error rather than degrade to an empty msgListItem with no headers.
+// errReadCloser returns a chunk of bytes once, then a non-EOF error on the
+// next Read. Used to simulate a truncated multipart response from Gmail.
+type errReadCloser struct {
+	data []byte
+	pos  int
+	err  error
+}
+
+func (r *errReadCloser) Read(p []byte) (int, error) {
+	if r.pos >= len(r.data) {
+		return 0, r.err
+	}
+	n := copy(p, r.data[r.pos:])
+	r.pos += n
+	return n, nil
+}
+
+func (r *errReadCloser) Close() error { return nil }
+
+// TestListMessages_BatchBodyReadError simulates a wire-level truncation
+// of the batch response body. listMessages must surface a wrapped read
+// error (and therefore return "all metadata fetches failed") rather than
+// silently parsing whatever prefix arrived and treating short reads as
+// successes.
+func TestListMessages_BatchBodyReadError(t *testing.T) {
+	ids := []string{"msg-1", "msg-2"}
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method == http.MethodGet && strings.HasSuffix(req.URL.Path, "/messages") {
+			body := fmt.Sprintf(`{"messages":[%s],"resultSizeEstimate":%d}`,
+				`{"id":"msg-1"},{"id":"msg-2"}`, len(ids))
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(body)),
+			}, nil
+		}
+		if req.Method != http.MethodPost || !strings.HasSuffix(req.URL.Path, "/batch/gmail/v1") {
+			return &http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(strings.NewReader("nf"))}, nil
+		}
+		// Return a truncated multipart prefix: a couple of bytes then
+		// a non-EOF error. The Content-Type advertises multipart so the
+		// status-error branch is skipped and the read-error branch must fire.
+		header := make(http.Header)
+		header.Set("Content-Type", "multipart/mixed; boundary=boundary42")
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     header,
+			Body:       &errReadCloser{data: []byte("--boundary42\r\n"), err: fmt.Errorf("connection reset")},
+		}, nil
+	})
+	adapter := &GmailAdapter{}
+
+	_, err := adapter.listMessages(context.Background(), &http.Client{Transport: transport}, map[string]any{
+		"max_results": len(ids),
+	})
+	if err == nil {
+		t.Fatalf("expected error when batch body read fails, got nil")
+	}
+	if !strings.Contains(err.Error(), "all metadata fetches failed") {
+		t.Errorf("expected 'all metadata fetches failed' wrap, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "gmail batch read body") {
+		t.Errorf("expected inner error to mention 'gmail batch read body', got: %v", err)
+	}
+}
+
 func TestListMessages_BatchMissingPart(t *testing.T) {
 	ids := []string{"msg-1", "msg-2"}
 	// Custom transport: respond to /messages normally; respond to

--- a/internal/adapters/google/gmail/adapter_test.go
+++ b/internal/adapters/google/gmail/adapter_test.go
@@ -1,20 +1,26 @@
 package gmail
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"mime"
+	"mime/multipart"
 	"net/http"
+	"net/textproto"
 	"strings"
-	"sync"
+	"sync/atomic"
 	"testing"
 
 	"golang.org/x/oauth2"
 
 	"github.com/clawvisor/clawvisor/internal/adapters/google/credential"
+	"github.com/clawvisor/clawvisor/pkg/adapters"
 )
 
 func b64(s string) string    { return base64.URLEncoding.EncodeToString([]byte(s)) }
@@ -634,308 +640,320 @@ func TestSendMessage_WithInReplyTo_ResolvesThreadAndQuotesPreviousMessage(t *tes
 	}
 }
 
-func TestListMessages_Concurrency(t *testing.T) {
-	const totalMsgs = 200
+// batchTestServer mocks Gmail's list + batch endpoints for the list_messages
+// tests. It replies to GET .../messages with a list of synthetic ids and to
+// POST /batch/gmail/v1 with a multipart/mixed response that produces a stock
+// meta payload for each requested id, unless perItemStatus overrides that id
+// to a non-200 status. batchStatus, if set, replaces the outer batch POST
+// status (used for whole-batch failure tests).
+type batchTestServer struct {
+	t              *testing.T
+	listIDs        []string
+	perItemStatus  map[string]int
+	batchStatus    int // 0 means 200
+	batchPostCount atomic.Int32
+	lastBatchSizes []int
+}
 
-	client := &http.Client{
-		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-			var body string
-			switch {
-			case req.Method == http.MethodGet && strings.Contains(req.URL.Path, "/messages") && !strings.Contains(req.URL.Path, "/msg-"):
-				var msgsList []string
-				for i := 1; i <= totalMsgs; i++ {
-					msgsList = append(msgsList, fmt.Sprintf(`{"id": "msg-%d"}`, i))
-				}
-				body = fmt.Sprintf(`{
-					"messages": [%s],
-					"resultSizeEstimate": %d
-				}`, strings.Join(msgsList, ","), totalMsgs)
-			case req.Method == http.MethodGet && strings.Contains(req.URL.Path, "/messages/msg-"):
-				// Extract msg ID from URL path (e.g. "/messages/msg-1")
-				parts := strings.Split(req.URL.Path, "/")
-				msgID := parts[len(parts)-1]
-				body = fmt.Sprintf(`{
-					"snippet": "Snippet for %s",
-					"labelIds": ["INBOX", "UNREAD"],
-					"payload": {
-						"headers": [
-							{"name": "From", "value": "sender-%s@example.com"},
-							{"name": "Subject", "value": "Subject %s"},
-							{"name": "Date", "value": "Date-%s"}
-						]
-					}
-				}`, msgID, msgID, msgID, msgID)
-			default:
-				t.Logf("Unexpected request in mock: %s %s", req.Method, req.URL.String())
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader("not found")),
-				}, nil
-			}
-
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Header:     make(http.Header),
-				Body:       io.NopCloser(strings.NewReader(body)),
-			}, nil
-		}),
+func (s *batchTestServer) handle(req *http.Request) (*http.Response, error) {
+	switch {
+	case req.Method == http.MethodGet && strings.HasSuffix(req.URL.Path, "/messages"):
+		entries := make([]string, len(s.listIDs))
+		for i, id := range s.listIDs {
+			entries[i] = fmt.Sprintf(`{"id":%q}`, id)
+		}
+		body := fmt.Sprintf(`{"messages":[%s],"resultSizeEstimate":%d}`,
+			strings.Join(entries, ","), len(s.listIDs))
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(body)),
+		}, nil
+	case req.Method == http.MethodPost && strings.HasSuffix(req.URL.Path, "/batch/gmail/v1"):
+		s.batchPostCount.Add(1)
+		return s.serveBatch(req)
+	default:
+		s.t.Logf("unexpected request: %s %s", req.Method, req.URL.String())
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("not found")),
+		}, nil
 	}
+}
 
-	adapter := &GmailAdapter{}
-	res, err := adapter.listMessages(context.Background(), client, map[string]any{
-		"max_results": totalMsgs,
-	})
+func (s *batchTestServer) serveBatch(req *http.Request) (*http.Response, error) {
+	_, params, err := mime.ParseMediaType(req.Header.Get("Content-Type"))
 	if err != nil {
-		t.Fatalf("listMessages error: %v", err)
+		s.t.Fatalf("batch request bad Content-Type: %v", err)
 	}
-	if res == nil {
-		t.Fatal("listMessages returned nil result")
+	reqBody, _ := io.ReadAll(req.Body)
+	mr := multipart.NewReader(bytes.NewReader(reqBody), params["boundary"])
+
+	type subReq struct {
+		contentID string
+		msgID     string
+	}
+	var subs []subReq
+	for {
+		part, err := mr.NextPart()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			s.t.Fatalf("batch request parse part: %v", err)
+		}
+		cid := part.Header.Get("Content-ID")
+		body, _ := io.ReadAll(part)
+		part.Close()
+		// Sub-request body is a textual HTTP request — parse the request line.
+		line, _, _ := bufio.NewReader(bytes.NewReader(body)).ReadLine()
+		// e.g. "GET /gmail/v1/users/me/messages/msg-3?format=metadata&... HTTP/1.1"
+		fields := strings.Fields(string(line))
+		if len(fields) < 2 {
+			s.t.Fatalf("batch sub-request bad request line: %q", line)
+		}
+		path := fields[1]
+		if q := strings.Index(path, "?"); q >= 0 {
+			path = path[:q]
+		}
+		msgID := path[strings.LastIndex(path, "/")+1:]
+		subs = append(subs, subReq{contentID: cid, msgID: msgID})
+	}
+	s.lastBatchSizes = append(s.lastBatchSizes, len(subs))
+
+	if s.batchStatus != 0 && s.batchStatus != http.StatusOK {
+		return &http.Response{
+			StatusCode: s.batchStatus,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("mock batch failure")),
+		}, nil
 	}
 
+	var resp bytes.Buffer
+	mw := multipart.NewWriter(&resp)
+	for _, sub := range subs {
+		hdr := textproto.MIMEHeader{}
+		hdr.Set("Content-Type", "application/http")
+		// Gmail echoes the client-supplied id with a "response-" prefix.
+		hdr.Set("Content-ID", "<response-"+strings.Trim(sub.contentID, "<>")+">")
+		w, err := mw.CreatePart(hdr)
+		if err != nil {
+			s.t.Fatalf("batch response build part: %v", err)
+		}
+		status := http.StatusOK
+		if override, ok := s.perItemStatus[sub.msgID]; ok {
+			status = override
+		}
+		var subBody string
+		if status >= 400 {
+			subBody = fmt.Sprintf(`{"error":{"code":%d,"message":"mock failure"}}`, status)
+		} else {
+			subBody = fmt.Sprintf(`{"snippet":"Snippet for %s","labelIds":["INBOX","UNREAD"],"payload":{"headers":[{"name":"From","value":"sender-%s@example.com"},{"name":"Subject","value":"Subject %s"},{"name":"Date","value":"Date-%s"}]}}`,
+				sub.msgID, sub.msgID, sub.msgID, sub.msgID)
+		}
+		fmt.Fprintf(w, "HTTP/1.1 %d %s\r\nContent-Type: application/json\r\nContent-Length: %d\r\n\r\n%s",
+			status, http.StatusText(status), len(subBody), subBody)
+	}
+	if err := mw.Close(); err != nil {
+		s.t.Fatalf("batch response close: %v", err)
+	}
+
+	header := make(http.Header)
+	header.Set("Content-Type", "multipart/mixed; boundary="+mw.Boundary())
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     header,
+		Body:       io.NopCloser(&resp),
+	}, nil
+}
+
+func newBatchTestClient(s *batchTestServer) *http.Client {
+	return &http.Client{Transport: roundTripFunc(s.handle)}
+}
+
+func extractMessageItems(t *testing.T, res *adapters.Result) []msgListItem {
+	t.Helper()
 	data, ok := res.Data.(map[string]any)
 	if !ok {
 		t.Fatalf("expected map[string]any for Data, got %T", res.Data)
 	}
-	messagesRaw, ok := data["messages"]
+	raw, ok := data["messages"]
 	if !ok {
 		t.Fatalf("result data missing messages field: %v", res.Data)
 	}
-	messages, ok := messagesRaw.([]msgListItem)
+	items, ok := raw.([]msgListItem)
 	if !ok {
-		t.Fatalf("expected []msgListItem, got %T", messagesRaw)
+		t.Fatalf("expected []msgListItem, got %T", raw)
 	}
+	return items
+}
 
-	t.Logf("Fetched messages count: %d", len(messages))
-	if len(messages) != totalMsgs {
-		t.Errorf("len(messages) = %d, want %d", len(messages), totalMsgs)
+func TestListMessages_BatchSuccess(t *testing.T) {
+	ids := []string{"msg-1", "msg-2", "msg-3", "msg-4", "msg-5"}
+	srv := &batchTestServer{t: t, listIDs: ids}
+	adapter := &GmailAdapter{}
+
+	res, err := adapter.listMessages(context.Background(), newBatchTestClient(srv), map[string]any{
+		"max_results": len(ids),
+	})
+	if err != nil {
+		t.Fatalf("listMessages error: %v", err)
 	}
+	items := extractMessageItems(t, res)
 
-	// Verify exact order and metadata extraction
-	for i, msg := range messages {
-		expectedID := fmt.Sprintf("msg-%d", i+1)
-		if msg.ID != expectedID {
-			t.Errorf("messages[%d].ID = %q, want %q", i, msg.ID, expectedID)
+	if got := srv.batchPostCount.Load(); got != 1 {
+		t.Errorf("batch POST count = %d, want 1", got)
+	}
+	if got := srv.lastBatchSizes; len(got) != 1 || got[0] != len(ids) {
+		t.Errorf("batch sub-request sizes = %v, want [%d]", got, len(ids))
+	}
+	if len(items) != len(ids) {
+		t.Fatalf("len(items) = %d, want %d", len(items), len(ids))
+	}
+	for i, item := range items {
+		if item.ID != ids[i] {
+			t.Errorf("items[%d].ID = %q, want %q", i, item.ID, ids[i])
 		}
-		expectedFrom := fmt.Sprintf("sender-msg-%d@example.com", i+1)
-		if msg.From != expectedFrom {
-			t.Errorf("messages[%d].From = %q, want %q", i, msg.From, expectedFrom)
+		if want := fmt.Sprintf("sender-%s@example.com", ids[i]); item.From != want {
+			t.Errorf("items[%d].From = %q, want %q", i, item.From, want)
 		}
-		expectedSubject := fmt.Sprintf("Subject msg-%d", i+1)
-		if msg.Subject != expectedSubject {
-			t.Errorf("messages[%d].Subject = %q, want %q", i, msg.Subject, expectedSubject)
+		if want := fmt.Sprintf("Subject %s", ids[i]); item.Subject != want {
+			t.Errorf("items[%d].Subject = %q, want %q", i, item.Subject, want)
 		}
-		expectedSnippet := fmt.Sprintf("Snippet for msg-%d", i+1)
-		if msg.Snippet != expectedSnippet {
-			t.Errorf("messages[%d].Snippet = %q, want %q", i, msg.Snippet, expectedSnippet)
-		}
-		if !msg.IsUnread {
-			t.Errorf("messages[%d].IsUnread = false, want true", i)
+		if !item.IsUnread {
+			t.Errorf("items[%d].IsUnread = false, want true", i)
 		}
 	}
 }
 
-func TestListMessages_Concurrency_ContextCancel(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	const totalMsgs = 20
-	cancelDone := make(chan struct{})
-	var fetchCount int
-	var mu sync.Mutex
-
-	client := &http.Client{
-		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-			var body string
-			switch {
-			case req.Method == http.MethodGet && strings.Contains(req.URL.Path, "/messages") && !strings.Contains(req.URL.Path, "/msg-"):
-				var msgsList []string
-				for i := 1; i <= totalMsgs; i++ {
-					msgsList = append(msgsList, fmt.Sprintf(`{"id": "msg-%d"}`, i))
-				}
-				body = fmt.Sprintf(`{
-					"messages": [%s],
-					"resultSizeEstimate": %d
-				}`, strings.Join(msgsList, ","), totalMsgs)
-			case req.Method == http.MethodGet && strings.Contains(req.URL.Path, "/messages/msg-"):
-				parts := strings.Split(req.URL.Path, "/")
-				msgID := parts[len(parts)-1]
-
-				if msgID == "msg-2" {
-					cancel()
-					mu.Lock()
-					select {
-					case <-cancelDone:
-					default:
-						close(cancelDone)
-					}
-					mu.Unlock()
-				} else {
-					<-cancelDone
-				}
-
-				mu.Lock()
-				fetchCount++
-				mu.Unlock()
-
-				body = fmt.Sprintf(`{
-					"snippet": "Snippet for %s",
-					"labelIds": ["INBOX"],
-					"payload": {
-						"headers": [
-							{"name": "From", "value": "sender-%s@example.com"},
-							{"name": "Subject", "value": "Subject %s"},
-							{"name": "Date", "value": "Date-%s"}
-						]
-					}
-				}`, msgID, msgID, msgID, msgID)
-			default:
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader("not found")),
-				}, nil
-			}
-
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Header:     make(http.Header),
-				Body:       io.NopCloser(strings.NewReader(body)),
-			}, nil
-		}),
+func TestListMessages_BatchPartialFailure(t *testing.T) {
+	ids := []string{"msg-1", "msg-2", "msg-3"}
+	srv := &batchTestServer{
+		t:             t,
+		listIDs:       ids,
+		perItemStatus: map[string]int{"msg-2": http.StatusNotFound},
 	}
-
 	adapter := &GmailAdapter{}
-	_, err := adapter.listMessages(ctx, client, map[string]any{
-		"max_results": totalMsgs,
+
+	res, err := adapter.listMessages(context.Background(), newBatchTestClient(srv), map[string]any{
+		"max_results": len(ids),
+	})
+	if err != nil {
+		t.Fatalf("listMessages error: %v", err)
+	}
+	items := extractMessageItems(t, res)
+
+	if len(items) != 2 {
+		t.Fatalf("len(items) = %d, want 2", len(items))
+	}
+	if items[0].ID != "msg-1" {
+		t.Errorf("items[0].ID = %q, want msg-1", items[0].ID)
+	}
+	if items[1].ID != "msg-3" {
+		t.Errorf("items[1].ID = %q, want msg-3", items[1].ID)
+	}
+}
+
+func TestListMessages_BatchPaging(t *testing.T) {
+	const total = 150
+	ids := make([]string, total)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("msg-%03d", i+1)
+	}
+	srv := &batchTestServer{t: t, listIDs: ids}
+	adapter := &GmailAdapter{}
+
+	res, err := adapter.listMessages(context.Background(), newBatchTestClient(srv), map[string]any{
+		"max_results": total,
+	})
+	if err != nil {
+		t.Fatalf("listMessages error: %v", err)
+	}
+	items := extractMessageItems(t, res)
+
+	if got := srv.batchPostCount.Load(); got != 2 {
+		t.Errorf("batch POST count = %d, want 2", got)
+	}
+	if got, want := srv.lastBatchSizes, []int{100, 50}; len(got) != 2 || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("batch sub-request sizes = %v, want %v", got, want)
+	}
+	if len(items) != total {
+		t.Fatalf("len(items) = %d, want %d", len(items), total)
+	}
+	for i, item := range items {
+		if item.ID != ids[i] {
+			t.Fatalf("items[%d].ID = %q, want %q (ordering broken across batches?)", i, item.ID, ids[i])
+		}
+	}
+}
+
+func TestListMessages_BatchEmptyResult(t *testing.T) {
+	srv := &batchTestServer{t: t, listIDs: nil}
+	adapter := &GmailAdapter{}
+
+	res, err := adapter.listMessages(context.Background(), newBatchTestClient(srv), map[string]any{
+		"max_results": 10,
+	})
+	if err != nil {
+		t.Fatalf("listMessages error: %v", err)
+	}
+	items := extractMessageItems(t, res)
+
+	if got := srv.batchPostCount.Load(); got != 0 {
+		t.Errorf("batch POST count = %d, want 0", got)
+	}
+	if len(items) != 0 {
+		t.Errorf("len(items) = %d, want 0", len(items))
+	}
+}
+
+// TestListMessages_BatchAllFailed mirrors the AllMetadataFetchesFailed
+// semantic for the batch path: when every sub-response is an error, the
+// caller sees a wrapped error rather than an empty success.
+func TestListMessages_BatchAllFailed(t *testing.T) {
+	ids := []string{"msg-1", "msg-2"}
+	srv := &batchTestServer{
+		t:       t,
+		listIDs: ids,
+		perItemStatus: map[string]int{
+			"msg-1": http.StatusInternalServerError,
+			"msg-2": http.StatusInternalServerError,
+		},
+	}
+	adapter := &GmailAdapter{}
+
+	_, err := adapter.listMessages(context.Background(), newBatchTestClient(srv), map[string]any{
+		"max_results": len(ids),
+	})
+	if err == nil {
+		t.Fatalf("expected error when all metadata fetches fail, got nil")
+	}
+	if !strings.Contains(err.Error(), "all metadata fetches failed") {
+		t.Errorf("error = %v, want it to mention 'all metadata fetches failed'", err)
+	}
+}
+
+// TestListMessages_BatchContextCancel pre-cancels the context and asserts
+// listMessages returns an error wrapping context.Canceled. This replaces
+// the prior per-message-fetch ContextCancel test: with batched metadata
+// the cancellation surface is one outer POST, so the test exercises the
+// post-batch ctx.Err() guard in listMessages.
+func TestListMessages_BatchContextCancel(t *testing.T) {
+	srv := &batchTestServer{t: t, listIDs: []string{"msg-1", "msg-2"}}
+	adapter := &GmailAdapter{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := adapter.listMessages(ctx, newBatchTestClient(srv), map[string]any{
+		"max_results": 2,
 	})
 	if err == nil {
 		t.Fatalf("expected context cancellation error, got nil")
 	}
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("expected error to wrap context.Canceled, got %v", err)
-	}
-}
-
-func TestListMessages_Concurrency_AllMetadataFetchesFailed(t *testing.T) {
-	client := &http.Client{
-		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-			var body string
-			var status = http.StatusOK
-			switch {
-			case req.Method == http.MethodGet && strings.Contains(req.URL.Path, "/messages") && !strings.Contains(req.URL.Path, "/msg-"):
-				body = `{
-					"messages": [
-						{"id": "msg-1"},
-						{"id": "msg-2"}
-					],
-					"resultSizeEstimate": 2
-				}`
-			case req.Method == http.MethodGet && strings.Contains(req.URL.Path, "/messages/msg-"):
-				status = http.StatusInternalServerError
-				body = "internal server error"
-			default:
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader("not found")),
-				}, nil
-			}
-
-			return &http.Response{
-				StatusCode: status,
-				Header:     make(http.Header),
-				Body:       io.NopCloser(strings.NewReader(body)),
-			}, nil
-		}),
-	}
-
-	adapter := &GmailAdapter{}
-	_, err := adapter.listMessages(context.Background(), client, map[string]any{
-		"max_results": 2,
-	})
-	if err == nil {
-		t.Fatalf("expected error when all metadata fetches fail, got nil")
-	}
-	if !strings.Contains(err.Error(), "all metadata fetches failed") {
-		t.Errorf("expected error to mention 'all metadata fetches failed', got: %v", err)
-	}
-}
-
-func TestListMessages_Concurrency_PartialErrors(t *testing.T) {
-	client := &http.Client{
-		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-			var body string
-			var status = http.StatusOK
-			switch {
-			case req.Method == http.MethodGet && strings.Contains(req.URL.Path, "/messages") && !strings.Contains(req.URL.Path, "/msg-"):
-				body = `{
-					"messages": [
-						{"id": "msg-1"},
-						{"id": "msg-2"},
-						{"id": "msg-3"},
-						{"id": "msg-4"}
-					],
-					"resultSizeEstimate": 4
-				}`
-			case req.Method == http.MethodGet && strings.Contains(req.URL.Path, "/messages/msg-"):
-				parts := strings.Split(req.URL.Path, "/")
-				msgID := parts[len(parts)-1]
-				if msgID == "msg-2" || msgID == "msg-4" {
-					status = http.StatusInternalServerError
-					body = "internal server error"
-				} else {
-					body = fmt.Sprintf(`{
-						"snippet": "Snippet for %s",
-						"labelIds": ["INBOX"],
-						"payload": {
-							"headers": [
-								{"name": "From", "value": "sender-%s@example.com"},
-								{"name": "Subject", "value": "Subject %s"},
-								{"name": "Date", "value": "Date-%s"}
-							]
-						}
-					}`, msgID, msgID, msgID, msgID)
-				}
-			default:
-				return &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader("not found")),
-				}, nil
-			}
-
-			return &http.Response{
-				StatusCode: status,
-				Header:     make(http.Header),
-				Body:       io.NopCloser(strings.NewReader(body)),
-			}, nil
-		}),
-	}
-
-	adapter := &GmailAdapter{}
-	res, err := adapter.listMessages(context.Background(), client, map[string]any{
-		"max_results": 4,
-	})
-	if err != nil {
-		t.Fatalf("listMessages error: %v", err)
-	}
-
-	data, ok := res.Data.(map[string]any)
-	if !ok {
-		t.Fatalf("expected map[string]any, got %T", res.Data)
-	}
-	messagesRaw, ok := data["messages"]
-	if !ok {
-		t.Fatalf("missing messages field")
-	}
-	messages := messagesRaw.([]msgListItem)
-
-	if len(messages) != 2 {
-		t.Fatalf("expected 2 messages, got %d", len(messages))
-	}
-
-	if messages[0].ID != "msg-1" {
-		t.Errorf("first message ID = %q, want msg-1", messages[0].ID)
-	}
-	if messages[1].ID != "msg-3" {
-		t.Errorf("second message ID = %q, want msg-3", messages[1].ID)
 	}
 }
 

--- a/internal/adapters/google/gmail/adapter_test.go
+++ b/internal/adapters/google/gmail/adapter_test.go
@@ -908,6 +908,59 @@ func TestListMessages_BatchEmptyResult(t *testing.T) {
 	}
 }
 
+// TestListMessages_BatchMissingPart simulates Gmail returning fewer
+// sub-responses than we asked for: only msg-1 echoes back; msg-2 is silently
+// dropped from the multipart body. The dropped slot must surface as an
+// error rather than degrade to an empty msgListItem with no headers.
+func TestListMessages_BatchMissingPart(t *testing.T) {
+	ids := []string{"msg-1", "msg-2"}
+	// Custom transport: respond to /messages normally; respond to
+	// /batch/gmail/v1 with a multipart that only contains the first part.
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method == http.MethodGet && strings.HasSuffix(req.URL.Path, "/messages") {
+			body := fmt.Sprintf(`{"messages":[%s],"resultSizeEstimate":%d}`,
+				`{"id":"msg-1"},{"id":"msg-2"}`, len(ids))
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(body)),
+			}, nil
+		}
+		if req.Method != http.MethodPost || !strings.HasSuffix(req.URL.Path, "/batch/gmail/v1") {
+			return &http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(strings.NewReader("nf"))}, nil
+		}
+		var resp bytes.Buffer
+		mw := multipart.NewWriter(&resp)
+		// Only echo back the FIRST sub-response — drop the second entirely.
+		hdr := textproto.MIMEHeader{}
+		hdr.Set("Content-Type", "application/http")
+		hdr.Set("Content-ID", "<response-item-0>")
+		w, _ := mw.CreatePart(hdr)
+		subBody := `{"snippet":"Snippet for msg-1","labelIds":["INBOX"],"payload":{"headers":[{"name":"From","value":"a@b.com"},{"name":"Subject","value":"S"},{"name":"Date","value":"D"}]}}`
+		fmt.Fprintf(w, "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: %d\r\n\r\n%s", len(subBody), subBody)
+		mw.Close()
+		header := make(http.Header)
+		header.Set("Content-Type", "multipart/mixed; boundary="+mw.Boundary())
+		return &http.Response{StatusCode: http.StatusOK, Header: header, Body: io.NopCloser(&resp)}, nil
+	})
+	adapter := &GmailAdapter{}
+
+	res, err := adapter.listMessages(context.Background(), &http.Client{Transport: transport}, map[string]any{
+		"max_results": len(ids),
+	})
+	if err != nil {
+		t.Fatalf("listMessages error: %v", err)
+	}
+	items := extractMessageItems(t, res)
+
+	if len(items) != 1 {
+		t.Fatalf("len(items) = %d, want 1 (msg-2's missing response slot must not emit a ghost item)", len(items))
+	}
+	if items[0].ID != "msg-1" {
+		t.Errorf("items[0].ID = %q, want msg-1", items[0].ID)
+	}
+}
+
 // TestListMessages_BatchAllFailed mirrors the AllMetadataFetchesFailed
 // semantic for the batch path: when every sub-response is an error, the
 // caller sees a wrapped error rather than an empty success.


### PR DESCRIPTION
## Summary

- Replace the per-message `GET /messages/{id}?format=metadata` fan-out in `listMessages` with a single multipart POST to `/batch/gmail/v1`. With `max_results <= 200` this collapses what used to be ~14 sequential waves of 15 GETs into at most two batch round-trips.
- Preserve the recently-added behaviors from #583: post-fetch `ctx.Err()` check and the "all metadata fetches failed" wrapped error on total failure. Per-item failure semantics (skip and continue) match the prior loop.
- Pre-fill `errs` with a "no sub-response received" sentinel before parsing the multipart body, so a short response from Gmail (or an unparseable `Content-ID`) surfaces as an error rather than emitting a ghost `msgListItem` with empty headers.

### Why

Production `list_messages` was running p50 = 61s, p95 = 221s — the per-message metadata fetch was dominating wall clock because each batch of 15 was paced by its slowest call. Batching gets that down to one or two HTTPS round-trips on the wire.

### Notes on the deprecated batch endpoint

Google's general docs mark the multi-API batch endpoint as deprecated, but `/batch/gmail/v1` is still operative and has no announced sunset. Accepting that risk in exchange for the ~100× round-trip reduction.

## Test plan

- [x] `go vet ./internal/adapters/google/gmail/...` clean
- [x] `go build ./...` clean
- [x] `go test ./internal/adapters/google/gmail/...` — new tests cover success, partial-failure, paging across 100/50, empty result, all-failed, ctx cancel, and the missing-sub-response regression
- [ ] After deploy: confirm `list_messages` `duration_ms` p50 drops from ~61s into single-digit seconds in Cloud Logging
- [ ] Watch for new error patterns surfaced by `parseBatchSubResponse` / "no sub-response received" — would indicate Google changed the multipart shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

