### PR TITLE
fix(proxy): strip auto-approve + routing notices from echoed history

### DIFF
--- a/pkg/runtime/proxy/observe_notice.go
+++ b/pkg/runtime/proxy/observe_notice.go
@@ -36,6 +36,48 @@ var observeNoticeInterval = 24 * time.Hour
 //     wording continue to scrub.
 var observeNoticePrefixRE = regexp.MustCompile(`^(?:` + "`" + `\[Clawvisor\] Observe mode: Clawvisor is logging but not blocking\.(?: Change this in Clawvisor: [^` + "`" + `]+)?` + "`" + `|\(\[Clawvisor system message\]: Clawvisor is currently running in observe mode\. Actions are being analyzed and logged, but not blocked\.(?: Change this in Clawvisor: [^)]+)?\)|\(Clawvisor is in observe mode\. Actions are being analyzed and logged, but not blocked\.\)|Clawvisor is in observe mode\. Actions are being analyzed and logged, but not blocked\.)(?:(?:\s*\n\s*\n|\s+)|$)`)
 
+// autoApprovedNoticePrefixRE matches the auto-approval banner emitted
+// by llmproxy.AutoApproveUserNotice. Two producer shapes, both
+// backtick-wrapped and known to contain no internal backticks (the
+// producer strips them defensively, and CR/LF are replaced with
+// spaces so the body is single-line):
+//
+//  1. `[Clawvisor] Task auto-approved: <purpose>`
+//  2. `[Clawvisor] Task auto-approved based on your recent request.`
+//     (empty-purpose fallback)
+//
+// Without this strip the banner accumulates one row per auto-approval
+// for the rest of the conversation, both costing context-window tokens
+// AND giving the model an ever-growing supply of `[Clawvisor] ...`
+// exemplars to pattern-complete from.
+var autoApprovedNoticePrefixRE = regexp.MustCompile(`^` + "`" + `\[Clawvisor\] Task auto-approved(?: based on your recent request\.|: [^` + "`" + `]*)` + "`" + `(?:(?:\s*\n\s*\n|\s+)|$)`)
+
+// agentRoutingNoticePrefixRE matches the first-turn routing notice
+// emitted by llmproxy.RenderAgentRoutingNotice. Producer shapes:
+//
+//  1. `[Clawvisor] Routing this conversation through <brand>.`
+//  2. `[Clawvisor] Routing this conversation through <brand> as agent "<name>".`
+//
+// Either form may be followed by a parseable
+// `[clawvisor:conversation=<id>]` footer (RenderConversationIDMarker).
+// The brand + name are both backtick-stripped by their sanitizers, so
+// matching everything up to the first `.` followed by a closing
+// backtick safely covers both shapes. Same accumulation concern as
+// the observe-mode and auto-approve notices.
+var agentRoutingNoticePrefixRE = regexp.MustCompile(`^` + "`" + `\[Clawvisor\] Routing this conversation through [^` + "`" + `]+?\.` + "`" + `(?: \[clawvisor:conversation=[^\]]+\])?(?:(?:\s*\n\s*\n|\s+)|$)`)
+
+// historicalNoticePrefixREs is the ordered set of regexes
+// scrubHistoricalResponseNoticeText tries on each iteration. Ordering
+// is by frequency (observe mode hits most conversations; routing fires
+// once per fresh harness session; auto-approve fires per auto-approval
+// task), but the loop's behavior is identical regardless because each
+// regex is mutually exclusive at the start-of-string anchor.
+var historicalNoticePrefixREs = []*regexp.Regexp{
+	observeNoticePrefixRE,
+	autoApprovedNoticePrefixRE,
+	agentRoutingNoticePrefixRE,
+}
+
 type responseNotice struct {
 	Kind string
 	Text string
@@ -266,8 +308,8 @@ func scrubHistoricalResponseNoticeText(text string) (string, bool) {
 	trimmedLeading := strings.TrimLeft(text, " \t\r\n")
 	changedAny := false
 	for {
-		loc := observeNoticePrefixRE.FindStringIndex(trimmedLeading)
-		if loc == nil || loc[0] != 0 {
+		loc := matchLeadingNoticePrefix(trimmedLeading)
+		if loc == nil {
 			break
 		}
 		changedAny = true
@@ -277,6 +319,21 @@ func scrubHistoricalResponseNoticeText(text string) (string, bool) {
 		return original, false
 	}
 	return trimmedLeading, true
+}
+
+// matchLeadingNoticePrefix returns the byte span of the first matching
+// Clawvisor-notice regex anchored at offset 0, or nil if none of the
+// known shapes lead the string. Because each regex carries `^` and a
+// fixed prefix, at most one ever matches at offset 0 — the order in
+// historicalNoticePrefixREs is for clarity, not correctness.
+func matchLeadingNoticePrefix(s string) []int {
+	for _, re := range historicalNoticePrefixREs {
+		loc := re.FindStringIndex(s)
+		if loc != nil && loc[0] == 0 {
+			return loc
+		}
+	}
+	return nil
 }
 
 func anyString(v any) string {

--- a/pkg/runtime/proxy/observe_notice_test.go
+++ b/pkg/runtime/proxy/observe_notice_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy"
 	"github.com/clawvisor/clawvisor/pkg/store/sqlite"
 )
 
@@ -370,3 +371,293 @@ func TestShouldEmitObserveNoticeSuppressesConcurrentPendingEmit(t *testing.T) {
 		t.Fatal("expected second pending emit attempt to be suppressed until first notice is marked")
 	}
 }
+
+// TestScrubHistoricalResponseNoticesFromAnthropicRequest_AutoApproveBanner
+// pins the auto-approve banner shape emitted by
+// llmproxy.AutoApproveUserNotice. Production accumulates one banner row
+// per auto-approval; without the strip, every subsequent /v1/messages
+// re-sends them all to the model.
+func TestScrubHistoricalResponseNoticesFromAnthropicRequest_AutoApproveBanner(t *testing.T) {
+	t.Parallel()
+
+	req, _ := http.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages", nil)
+	bannerWithPurpose := llmproxy.AutoApproveUserNotice("triage Gmail inbox, label and reply to threads")
+	bannerWithSuffix := bannerWithPurpose + "\n\nOn it."
+	bannerFallback := llmproxy.AutoApproveUserNotice("")
+	userQuoted := "Can you explain what `[Clawvisor] Task auto-approved: ...` means?"
+
+	bodyMap := map[string]any{
+		"messages": []map[string]any{
+			{"role": "assistant", "content": []map[string]any{
+				{"type": "text", "text": bannerFallback},
+			}},
+			{"role": "assistant", "content": []map[string]any{
+				{"type": "text", "text": bannerWithSuffix},
+			}},
+			{"role": "user", "content": []map[string]any{
+				{"type": "text", "text": userQuoted},
+			}},
+		},
+	}
+	body, err := json.Marshal(bodyMap)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	rewritten, changed := scrubHistoricalResponseNoticesFromRequest(req, body)
+	if !changed {
+		t.Fatal("expected auto-approve banner to be scrubbed")
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(rewritten, &payload); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	messages, _ := payload["messages"].([]any)
+	first, _ := messages[0].(map[string]any)
+	firstContent, _ := first["content"].([]any)
+	if len(firstContent) != 0 {
+		t.Fatalf("expected standalone auto-approve banner block to be removed, got %d blocks", len(firstContent))
+	}
+	second, _ := messages[1].(map[string]any)
+	secondContent, _ := second["content"].([]any)
+	block, _ := secondContent[0].(map[string]any)
+	if got, _ := block["text"].(string); got != "On it." {
+		t.Fatalf("expected auto-approve banner prefix to be removed, got %q", got)
+	}
+	third, _ := messages[2].(map[string]any)
+	thirdContent, _ := third["content"].([]any)
+	userBlock, _ := thirdContent[0].(map[string]any)
+	if got, _ := userBlock["text"].(string); got != userQuoted {
+		t.Fatalf("expected user-authored quoted text mentioning the banner to be preserved, got %q", got)
+	}
+}
+
+// TestScrubHistoricalResponseNoticesFromAnthropicRequest_RoutingNotice
+// pins the first-turn routing notice shape emitted by
+// llmproxy.RenderAgentRoutingNotice, including the optional trailing
+// [clawvisor:conversation=...] marker. Routing fires once per fresh
+// harness session but rides every subsequent turn's echoed history.
+func TestScrubHistoricalResponseNoticesFromAnthropicRequest_RoutingNotice(t *testing.T) {
+	t.Parallel()
+
+	req, _ := http.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages", nil)
+	routingWithName := llmproxy.RenderAgentRoutingNotice("claude-code-7", "cv-conv-abc123", "Clawvisor Local")
+	routingWithSuffix := routingWithName + "\n\nWhat are you working on?"
+	routingBrandOnly := llmproxy.RenderAgentRoutingNotice("", "", "")
+
+	bodyMap := map[string]any{
+		"messages": []map[string]any{
+			{"role": "assistant", "content": []map[string]any{
+				{"type": "text", "text": routingBrandOnly},
+			}},
+			{"role": "assistant", "content": []map[string]any{
+				{"type": "text", "text": routingWithSuffix},
+			}},
+		},
+	}
+	body, err := json.Marshal(bodyMap)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	rewritten, changed := scrubHistoricalResponseNoticesFromRequest(req, body)
+	if !changed {
+		t.Fatal("expected routing notice to be scrubbed")
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(rewritten, &payload); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	messages, _ := payload["messages"].([]any)
+	first, _ := messages[0].(map[string]any)
+	firstContent, _ := first["content"].([]any)
+	if len(firstContent) != 0 {
+		t.Fatalf("expected standalone routing notice block to be removed, got %d blocks", len(firstContent))
+	}
+	second, _ := messages[1].(map[string]any)
+	secondContent, _ := second["content"].([]any)
+	block, _ := secondContent[0].(map[string]any)
+	if got, _ := block["text"].(string); got != "What are you working on?" {
+		t.Fatalf("expected routing notice + conversation marker prefix to be removed, got %q", got)
+	}
+}
+
+// TestScrubHistoricalResponseNoticesStripsConsecutiveMixedNotices
+// covers the case where a single assistant text block leads with
+// multiple Clawvisor notices stacked back-to-back — e.g., the routing
+// notice on turn 1 followed immediately by an auto-approve banner from
+// the same response. The loop in scrubHistoricalResponseNoticeText must
+// drain ALL of them, not just the first.
+func TestScrubHistoricalResponseNoticesStripsConsecutiveMixedNotices(t *testing.T) {
+	t.Parallel()
+
+	req, _ := http.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages", nil)
+	routing := llmproxy.RenderAgentRoutingNotice("claude-code-7", "cv-conv-abc123", "Clawvisor")
+	observe := observeModeInjectedUserNotice("agent_123", "http://127.0.0.1:25297")
+	banner := llmproxy.AutoApproveUserNotice("fix the failing build")
+	stacked := routing + "\n\n" + observe + "\n\n" + banner + "\n\nReal model output follows."
+
+	bodyMap := map[string]any{
+		"messages": []map[string]any{
+			{"role": "assistant", "content": []map[string]any{
+				{"type": "text", "text": stacked},
+			}},
+		},
+	}
+	body, err := json.Marshal(bodyMap)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	rewritten, changed := scrubHistoricalResponseNoticesFromRequest(req, body)
+	if !changed {
+		t.Fatal("expected stacked notices to be scrubbed")
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(rewritten, &payload); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	messages, _ := payload["messages"].([]any)
+	first, _ := messages[0].(map[string]any)
+	content, _ := first["content"].([]any)
+	block, _ := content[0].(map[string]any)
+	if got, _ := block["text"].(string); got != "Real model output follows." {
+		t.Fatalf("expected all stacked notices to be drained, got %q", got)
+	}
+}
+
+// TestScrubHistoricalResponseNoticesFromOpenAIRequest_AutoApproveBanner
+// mirrors the Anthropic auto-approve test for the OpenAI Chat
+// Completions provider shape (assistant.content as string).
+func TestScrubHistoricalResponseNoticesFromOpenAIRequest_AutoApproveBanner(t *testing.T) {
+	t.Parallel()
+
+	req, _ := http.NewRequest(http.MethodPost, "https://api.openai.com/v1/chat/completions", nil)
+	banner := llmproxy.AutoApproveUserNotice("send the weekly status email")
+
+	bodyMap := map[string]any{
+		"messages": []map[string]any{
+			{"role": "assistant", "content": banner + "\n\nDone."},
+			{"role": "assistant", "content": llmproxy.AutoApproveUserNotice("")},
+		},
+	}
+	body, err := json.Marshal(bodyMap)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	rewritten, changed := scrubHistoricalResponseNoticesFromRequest(req, body)
+	if !changed {
+		t.Fatal("expected openai chat auto-approve banners to be scrubbed")
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(rewritten, &payload); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	messages, _ := payload["messages"].([]any)
+	first, _ := messages[0].(map[string]any)
+	if got, _ := first["content"].(string); got != "Done." {
+		t.Fatalf("expected auto-approve banner prefix to be removed from string content, got %q", got)
+	}
+	second, _ := messages[1].(map[string]any)
+	if got, _ := second["content"].(string); got != "" {
+		t.Fatalf("expected banner-only content to scrub to empty string, got %q", got)
+	}
+}
+
+// TestScrubHistoricalResponseNoticesFromOpenAIResponsesRequest_RoutingNotice
+// covers the OpenAI Responses (`input` array, `output_text` blocks)
+// shape for the routing notice. The Responses scrubber walks `input`
+// items with role=assistant and treats text/input_text/output_text
+// block types as scrubbable.
+func TestScrubHistoricalResponseNoticesFromOpenAIResponsesRequest_RoutingNotice(t *testing.T) {
+	t.Parallel()
+
+	req, _ := http.NewRequest(http.MethodPost, "https://api.openai.com/v1/responses", nil)
+	routing := llmproxy.RenderAgentRoutingNotice("claude-code-7", "cv-conv-abc123", "Clawvisor Staging")
+	prefixed := routing + "\n\nKicking off."
+
+	bodyMap := map[string]any{
+		"input": []map[string]any{
+			{"type": "message", "role": "assistant", "content": []map[string]any{
+				{"type": "output_text", "text": prefixed},
+			}},
+		},
+	}
+	body, err := json.Marshal(bodyMap)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	rewritten, changed := scrubHistoricalResponseNoticesFromRequest(req, body)
+	if !changed {
+		t.Fatal("expected openai responses routing notice to be scrubbed")
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(rewritten, &payload); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	input, _ := payload["input"].([]any)
+	first, _ := input[0].(map[string]any)
+	content, _ := first["content"].([]any)
+	block, _ := content[0].(map[string]any)
+	if got, _ := block["text"].(string); got != "Kicking off." {
+		t.Fatalf("expected routing notice prefix to be removed from output_text block, got %q", got)
+	}
+}
+
+// TestScrubHistoricalResponseNoticeTextPreservesMidBlockBanner pins the
+// anchor invariant: a banner-shaped substring in the MIDDLE of an
+// assistant turn (e.g., the model quoting a banner back at the user)
+// must not be stripped — only true leading notices belong to the proxy.
+func TestScrubHistoricalResponseNoticeTextPreservesMidBlockBanner(t *testing.T) {
+	t.Parallel()
+
+	banner := llmproxy.AutoApproveUserNotice("explain the routing flow")
+	mixed := "I see a notice like " + banner + " — what does it mean?"
+	got, changed := scrubHistoricalResponseNoticeText(mixed)
+	if changed {
+		t.Fatalf("expected mid-block banner to be preserved, got change to %q", got)
+	}
+	if got != mixed {
+		t.Fatalf("unexpected scrubbed text %q", got)
+	}
+
+	routing := llmproxy.RenderAgentRoutingNotice("claude-code-7", "cv-conv-abc123", "Clawvisor")
+	mixedRouting := "Quoting back: " + routing
+	gotRouting, changedRouting := scrubHistoricalResponseNoticeText(mixedRouting)
+	if changedRouting {
+		t.Fatalf("expected mid-block routing notice to be preserved, got change to %q", gotRouting)
+	}
+	if gotRouting != mixedRouting {
+		t.Fatalf("unexpected scrubbed text %q", gotRouting)
+	}
+}
+
+// TestScrubHistoricalResponseNoticesAcceptsUnicodePurpose covers the
+// rune-truncation case in AutoApproveUserNotice: a purpose long enough
+// to hit the 200-rune cap gets a `…` appended. The regex's purpose
+// body `[^`+"`"+`]*` must accept the trailing `…` (a multi-byte UTF-8
+// rune) without breaking. Without this row, an emoji or accented
+// purpose that gets truncated could regress the regex match.
+func TestScrubHistoricalResponseNoticesAcceptsUnicodePurpose(t *testing.T) {
+	t.Parallel()
+
+	// Build a purpose long enough to trigger rune-cap truncation in
+	// AutoApproveUserNotice (>200 runes). Mixing ASCII + Unicode so the
+	// truncation lands on a non-trivial byte position.
+	long := strings.Repeat("作業 Task ", 60)
+	banner := llmproxy.AutoApproveUserNotice(long)
+	if !strings.HasSuffix(strings.TrimSuffix(banner, "`"), "…") {
+		t.Fatalf("test precondition failed: expected truncated banner to end with …, got %q", banner)
+	}
+
+	got, changed := scrubHistoricalResponseNoticeText(banner + "\n\nReady.")
+	if !changed {
+		t.Fatalf("expected truncated unicode banner to be scrubbed, got %q", got)
+	}
+	if got != "Ready." {
+		t.Fatalf("expected scrubbed remainder %q, got %q", "Ready.", got)
+	}
+}
+


### PR DESCRIPTION
## Summary

- The inbound `OnRequest` scrubber in `pkg/runtime/proxy/observe_notice.go` only matched observe-mode notices. Auto-approve banners (`AutoApproveUserNotice`) and first-turn routing notices (`RenderAgentRoutingNotice`) land in assistant turns and ride every subsequent `/v1/messages` round-trip forever — costing context-window tokens and giving the model an ever-growing supply of `[Clawvisor] ...` exemplars to pattern-complete from in future turns.
- Add `autoApprovedNoticePrefixRE` + `agentRoutingNoticePrefixRE` alongside the existing observe regex, drain all three in the `scrubHistoricalResponseNoticeText` loop via a tiny helper, and cover both shapes across Anthropic / OpenAI Chat / OpenAI Responses provider bodies plus mid-block-preservation and Unicode-truncation edge cases.
- No producer changes, no wiring changes — existing `InstallObserveNoticeRequestScrubber` (single call site at `pkg/clawvisor/run.go:88`) inherits the broader regex coverage automatically.

## Test plan

- [x] `go test ./pkg/runtime/proxy/... -run ScrubHistoricalResponseNotice` — 12/12 pass (5 new, 7 existing)
- [x] `go test ./pkg/runtime/proxy/...` — full package green
- [x] `go test ./internal/runtime/llmproxy/...` — full subtree green
- [ ] Post-merge manual sanity: trigger an auto-approval in a Claude Code session, observe the banner in the assistant turn, then on the next turn confirm via inspector that the inbound body no longer carries the banner text in the assistant message.

## Out of scope (intentional, separate PRs)

- The coalesce-classification bug at `internal/runtime/llmproxy/pipeline/finalizer.go:469` + `:513` — auto-approve verdict misclassified as `Deny`, breaks sibling coalescing when an auto-approved task and a held-for-approval task land in the same response.
- Persistent backing store for `PendingSubstitution` registry (24h TTL + proxy-restart drops in-flight placeholders).
- `CLAWVISOR NOTICES` system-prompt addition telling models not to author `[Clawvisor] ...` text themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

