### PR TITLE
feat(llmproxy): Redis-backed ScopeDriftRegistry for multi-replica deployments

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -112,6 +112,7 @@ type Server struct {
 	liteApprovals      llmproxy.PendingApprovalCache
 	liteOutcomes       llmproxy.InlineApprovalOutcomeStore
 	taskCheckouts      llmproxy.TaskCheckoutStore
+	scopeDrifts        llmproxy.ScopeDriftRegistry
 
 	adapterGenFactory handlers.GeneratorFactory // per-request Generator factory; set via option
 
@@ -387,6 +388,17 @@ func WithLiteApprovalOutcomeStore(c llmproxy.InlineApprovalOutcomeStore) ServerO
 // state follows the agent across replicas.
 func WithTaskCheckoutStore(c llmproxy.TaskCheckoutStore) ServerOption {
 	return func(s *Server) { s.taskCheckouts = c }
+}
+
+// WithScopeDriftRegistry overrides the default in-memory lite-proxy scope-drift
+// registry, which also stores pending tool_result substitutions. Use a shared
+// implementation in multi-instance deployments so a drift minted (or a
+// substitution registered) on one replica is resolvable on another — without
+// this, an agent's reply that lands on a different replica cannot consume the
+// pre-clear and the inbound rewriter cannot restore the model's original
+// tool_use.
+func WithScopeDriftRegistry(r llmproxy.ScopeDriftRegistry) ServerOption {
+	return func(s *Server) { s.scopeDrifts = r }
 }
 
 // New creates a Server and registers all routes.
@@ -1376,6 +1388,11 @@ func (s *Server) registerLiteProxyRoutes(
 			llmHandler.TaskCheckouts = s.taskCheckouts
 		} else if s.logger != nil && strings.EqualFold(strings.TrimSpace(s.cfg.Server.RouteSet), "proxy_lite") {
 			s.logger.Warn("lite-proxy: TaskCheckoutStore not configured — task focus is process-local; use Redis for multi-instance proxy deployments")
+		}
+		if s.scopeDrifts != nil {
+			llmHandler.ScopeDrifts = s.scopeDrifts
+		} else if s.logger != nil && strings.EqualFold(strings.TrimSpace(s.cfg.Server.RouteSet), "proxy_lite") {
+			s.logger.Warn("lite-proxy: ScopeDriftRegistry not configured — drifts and pending substitutions are process-local; use Redis for multi-instance proxy deployments")
 		}
 		llmHandler.InlineTaskCreator = tasksHandler
 		llmHandler.TaskRiskAssessor = s.taskRiskAssessor

--- a/internal/runtime/llmproxy/redis_stores_test.go
+++ b/internal/runtime/llmproxy/redis_stores_test.go
@@ -389,6 +389,218 @@ func TestRedisPendingApprovalCacheHoldKeyTTLHonorsPerHoldExpiresAt(t *testing.T)
 	}
 }
 
+func sampleDrift(agentID, convID, toolUseID string) ScopeDrift {
+	return ScopeDrift{
+		UserID:         "user-1",
+		AgentID:        agentID,
+		ConversationID: convID,
+		Provider:       conversation.ProviderAnthropic,
+		ToolUse: conversation.ToolUse{
+			ID:    toolUseID,
+			Name:  "Bash",
+			Input: []byte(`{"command":"ls"}`),
+		},
+		Service:    "svc",
+		Action:     "act",
+		Host:       "h",
+		Method:     "POST",
+		Path:       "/p",
+		Source:     ScopeDriftSourceTaskScope,
+		ReasonText: "no covering task",
+	}
+}
+
+func TestRedisScopeDriftRegistry_CrossInstanceRegisterGet(t *testing.T) {
+	rdb := testRedisClient(t)
+	minting := NewRedisScopeDriftRegistry(rdb, time.Minute)
+	resolver := NewRedisScopeDriftRegistry(rdb, time.Minute)
+	ctx := context.Background()
+
+	stored, err := minting.Register(ctx, sampleDrift("agent-1", "conv-1", "tu-1"))
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if stored.ID == "" {
+		t.Fatal("Register: empty ID")
+	}
+
+	got, err := resolver.Get(ctx, stored.ID)
+	if err != nil {
+		t.Fatalf("Get on resolver: %v", err)
+	}
+	if got.AgentID != "agent-1" || got.Service != "svc" || got.Provider != conversation.ProviderAnthropic {
+		t.Fatalf("Get returned wrong record: %+v", got)
+	}
+	if string(got.ToolUse.Input) != `{"command":"ls"}` {
+		t.Fatalf("ToolUse.Input not preserved: %q", string(got.ToolUse.Input))
+	}
+	if got.Fingerprint() != stored.Fingerprint() {
+		t.Fatalf("Fingerprint mismatch across instances: %q vs %q", got.Fingerprint(), stored.Fingerprint())
+	}
+}
+
+func TestRedisScopeDriftRegistry_ClaimOptionIsOneShot(t *testing.T) {
+	rdb := testRedisClient(t)
+	a := NewRedisScopeDriftRegistry(rdb, time.Minute)
+	b := NewRedisScopeDriftRegistry(rdb, time.Minute)
+	ctx := context.Background()
+
+	stored, err := a.Register(ctx, sampleDrift("agent-claim", "conv-claim", "tu-claim"))
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	claimed, err := a.ClaimOption(ctx, stored.ID, ScopeDriftOptionOneOff, "note-a")
+	if err != nil {
+		t.Fatalf("ClaimOption on a: %v", err)
+	}
+	if claimed.ChosenOption != ScopeDriftOptionOneOff || claimed.Outcome != ScopeDriftOutcomePending || claimed.AgentNote != "note-a" {
+		t.Fatalf("ClaimOption result: %+v", claimed)
+	}
+	// Second claim on a different instance must surface ErrDriftAlreadyResolved.
+	if _, err := b.ClaimOption(ctx, stored.ID, ScopeDriftOptionExpand, "note-b"); !errors.Is(err, ErrDriftAlreadyResolved) {
+		t.Fatalf("second ClaimOption: want ErrDriftAlreadyResolved, got %v", err)
+	}
+}
+
+func TestRedisScopeDriftRegistry_SetOutcomeSucceededMintsPreClearAcrossInstances(t *testing.T) {
+	rdb := testRedisClient(t)
+	a := NewRedisScopeDriftRegistry(rdb, time.Minute)
+	b := NewRedisScopeDriftRegistry(rdb, time.Minute)
+	ctx := context.Background()
+
+	stored, err := a.Register(ctx, sampleDrift("agent-set", "conv-set", "tu-set"))
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if _, err := a.ClaimOption(ctx, stored.ID, ScopeDriftOptionExpand, ""); err != nil {
+		t.Fatalf("ClaimOption: %v", err)
+	}
+	if err := a.SetOutcome(ctx, stored.ID, ScopeDriftOutcomeSucceeded); err != nil {
+		t.Fatalf("SetOutcome on a: %v", err)
+	}
+	driftID, ok := b.LookupPreClear(ctx, "agent-set", stored.Fingerprint())
+	if !ok || driftID != stored.ID {
+		t.Fatalf("LookupPreClear on b: ok=%v id=%q want id=%q", ok, driftID, stored.ID)
+	}
+}
+
+func TestRedisScopeDriftRegistry_RollbackClaimDeletesPreClearAcrossInstances(t *testing.T) {
+	rdb := testRedisClient(t)
+	a := NewRedisScopeDriftRegistry(rdb, time.Minute)
+	b := NewRedisScopeDriftRegistry(rdb, time.Minute)
+	ctx := context.Background()
+
+	stored, err := a.Register(ctx, sampleDrift("agent-rb", "conv-rb", "tu-rb"))
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if _, err := a.ClaimOption(ctx, stored.ID, ScopeDriftOptionNewTask, ""); err != nil {
+		t.Fatalf("ClaimOption: %v", err)
+	}
+	if err := a.SetOutcome(ctx, stored.ID, ScopeDriftOutcomeSucceeded); err != nil {
+		t.Fatalf("SetOutcome: %v", err)
+	}
+	// Downstream failure on a triggers a rollback. b must NOT see a
+	// surviving pre-clear afterward — the lockstep invariant.
+	if err := a.RollbackClaim(ctx, stored.ID); err != nil {
+		t.Fatalf("RollbackClaim: %v", err)
+	}
+	if _, ok := b.LookupPreClear(ctx, "agent-rb", stored.Fingerprint()); ok {
+		t.Fatal("LookupPreClear on b after RollbackClaim: want miss, got hit (stale pre-clear leaked past rollback)")
+	}
+	got, err := b.Get(ctx, stored.ID)
+	if err != nil {
+		t.Fatalf("Get on b after rollback: %v", err)
+	}
+	if got.ChosenOption != "" || got.Outcome != "" || got.AgentNote != "" {
+		t.Fatalf("RollbackClaim left claim fields populated: %+v", got)
+	}
+}
+
+func TestRedisScopeDriftRegistry_LookupPreClearConsumesOnce(t *testing.T) {
+	rdb := testRedisClient(t)
+	a := NewRedisScopeDriftRegistry(rdb, time.Minute)
+	b := NewRedisScopeDriftRegistry(rdb, time.Minute)
+	ctx := context.Background()
+
+	stored, err := a.Register(ctx, sampleDrift("agent-cons", "conv-cons", "tu-cons"))
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if _, err := a.ClaimOption(ctx, stored.ID, ScopeDriftOptionOneOff, ""); err != nil {
+		t.Fatalf("ClaimOption: %v", err)
+	}
+	if err := a.SetOutcome(ctx, stored.ID, ScopeDriftOutcomeSucceeded); err != nil {
+		t.Fatalf("SetOutcome: %v", err)
+	}
+	if _, ok := b.LookupPreClear(ctx, "agent-cons", stored.Fingerprint()); !ok {
+		t.Fatal("first LookupPreClear on b: want hit, got miss")
+	}
+	if _, ok := a.LookupPreClear(ctx, "agent-cons", stored.Fingerprint()); ok {
+		t.Fatal("second LookupPreClear on a: want miss (consumed), got hit")
+	}
+}
+
+func TestRedisScopeDriftRegistry_PendingSubstitutionCrossInstanceRoundTrip(t *testing.T) {
+	rdb := testRedisClient(t)
+	a := NewRedisScopeDriftRegistry(rdb, time.Minute)
+	b := NewRedisScopeDriftRegistry(rdb, time.Minute)
+	ctx := context.Background()
+
+	key := PendingSubstitutionKey{AgentID: "agent-sub", ConversationID: "conv-sub", ToolUseID: "tu-sub"}
+	value := PendingSubstitution{
+		DriftID:           "drift-sub",
+		MenuText:          "<scope_drift_notice>blocked: foo</scope_drift_notice>",
+		OriginalToolName:  "Bash",
+		OriginalToolInput: []byte(`{"command":"curl evil"}`),
+	}
+	if err := a.RegisterPendingSubstitution(ctx, key, value); err != nil {
+		t.Fatalf("Register on a: %v", err)
+	}
+	// Lookup on b must see the same substitution byte-for-byte.
+	got, ok := b.LookupPendingSubstitution(ctx, key)
+	if !ok {
+		t.Fatal("Lookup on b: want hit, got miss")
+	}
+	if got.DriftID != value.DriftID || got.MenuText != value.MenuText || got.OriginalToolName != value.OriginalToolName {
+		t.Fatalf("Lookup on b returned wrong substitution: %+v", got)
+	}
+	if string(got.OriginalToolInput) != string(value.OriginalToolInput) {
+		t.Fatalf("OriginalToolInput corrupted: got %q, want %q", got.OriginalToolInput, value.OriginalToolInput)
+	}
+	// Lookup must NOT consume — repeat reads on a must still see it.
+	if _, ok := a.LookupPendingSubstitution(ctx, key); !ok {
+		t.Fatal("second Lookup on a: want hit (Lookup is not consuming), got miss")
+	}
+	// Delete on a is observable from b.
+	a.DeletePendingSubstitution(ctx, key)
+	if _, ok := b.LookupPendingSubstitution(ctx, key); ok {
+		t.Fatal("Lookup on b after Delete on a: want miss, got hit")
+	}
+}
+
+func TestRedisScopeDriftRegistry_TTLExpiry(t *testing.T) {
+	// Use a real miniredis so we can FastForward time deterministically.
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis: %v", err)
+	}
+	t.Cleanup(mr.Close)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	reg := NewRedisScopeDriftRegistry(rdb, 30*time.Second)
+	ctx := context.Background()
+	stored, err := reg.Register(ctx, sampleDrift("agent-ttl", "conv-ttl", "tu-ttl"))
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	mr.FastForward(31 * time.Second)
+	if _, err := reg.Get(ctx, stored.ID); !errors.Is(err, ErrDriftNotFound) {
+		t.Fatalf("Get after TTL: want ErrDriftNotFound, got %v", err)
+	}
+}
+
 func TestRedisInlineApprovalOutcomeStoreRecordAndLookup(t *testing.T) {
 	store := NewRedisInlineApprovalOutcomeStore(testRedisClient(t), time.Minute)
 	key := InlineApprovalOutcomeKey{UserID: "user-1", AgentID: "agent-1", ApprovalID: "cv-1"}

--- a/internal/runtime/llmproxy/redis_stores_test.go
+++ b/internal/runtime/llmproxy/redis_stores_test.go
@@ -579,6 +579,43 @@ func TestRedisScopeDriftRegistry_PendingSubstitutionCrossInstanceRoundTrip(t *te
 	}
 }
 
+// A caller-supplied ExpiresAt that's longer than the registry's
+// default ttl must be honored. The memory impl stores ExpiresAt
+// verbatim and Get checks against it; the Redis impl had been
+// defaulting the key PEXPIRE to r.ttl, which evicted long-lived
+// drifts and surfaced premature ErrDriftNotFound.
+func TestRedisScopeDriftRegistry_RegisterHonorsCallerExpiresAt(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis: %v", err)
+	}
+	t.Cleanup(mr.Close)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	// Registry default ttl is short; caller asks for much longer.
+	reg := NewRedisScopeDriftRegistry(rdb, 5*time.Second)
+	ctx := context.Background()
+
+	tmpl := sampleDrift("agent-exp", "conv-exp", "tu-exp")
+	tmpl.ExpiresAt = time.Now().UTC().Add(60 * time.Second)
+	stored, err := reg.Register(ctx, tmpl)
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	// 10 s past the registry default ttl, well before the caller's
+	// 60 s ExpiresAt. The drift must still be retrievable.
+	mr.FastForward(10 * time.Second)
+	got, err := reg.Get(ctx, stored.ID)
+	if err != nil {
+		t.Fatalf("Get with long ExpiresAt after 10s: want hit, got %v", err)
+	}
+	if got.ID != stored.ID {
+		t.Fatalf("Get returned wrong drift: %+v", got)
+	}
+}
+
 func TestRedisScopeDriftRegistry_TTLExpiry(t *testing.T) {
 	// Use a real miniredis so we can FastForward time deterministically.
 	mr, err := miniredis.Run()

--- a/internal/runtime/llmproxy/scope_drift_registry.go
+++ b/internal/runtime/llmproxy/scope_drift_registry.go
@@ -421,8 +421,11 @@ func (r *memoryScopeDriftRegistry) RegisterPendingSubstitution(_ context.Context
 	if r == nil {
 		return errors.New("scope drift registry not configured")
 	}
-	if key.AgentID == "" || key.ToolUseID == "" {
-		return errors.New("pending substitution requires agent_id and tool_use_id")
+	if key.AgentID == "" || key.ConversationID == "" || key.ToolUseID == "" {
+		// All three fields compose the storage key; an empty
+		// ConversationID would collapse distinct conversations onto
+		// the same key.
+		return errors.New("pending substitution requires agent_id, conversation_id, and tool_use_id")
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/internal/runtime/llmproxy/scope_drift_registry_redis.go
+++ b/internal/runtime/llmproxy/scope_drift_registry_redis.go
@@ -1,0 +1,457 @@
+package llmproxy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	redisScopeDriftPrefix       = "clawvisor:scope_drift:"
+	redisScopeDriftDriftPrefix  = redisScopeDriftPrefix + "drift:"
+	redisScopeDriftPreClearPref = redisScopeDriftPrefix + "preclear:"
+	redisScopeDriftPendingPref  = redisScopeDriftPrefix + "pending_sub:"
+
+	// Hash field names on the drift key. `data` holds JSON of the
+	// immutable subset of ScopeDrift (everything except the three
+	// mutable claim fields). The three mutable fields live as their
+	// own hash fields so ClaimOption / SetOutcome / RollbackClaim can
+	// mutate them with HGET/HSET rather than patching serialized JSON.
+	redisScopeDriftFieldData    = "data"
+	redisScopeDriftFieldChosen  = "chosen"
+	redisScopeDriftFieldOutcome = "outcome"
+	redisScopeDriftFieldNote    = "note"
+)
+
+// RedisScopeDriftRegistry persists drift records, pre-clears, and
+// pending tool_result substitutions in Redis so a multi-replica
+// lite-proxy deployment can mint state on one instance and resolve it
+// on another. ClaimOption / SetOutcome / RollbackClaim each run under
+// one Lua script so the (drift mutable fields, pre-clear) pair stays
+// coherent under concurrent access.
+type RedisScopeDriftRegistry struct {
+	rdb *redis.Client
+	ttl time.Duration
+	now func() time.Time
+}
+
+// NewRedisScopeDriftRegistry returns a Redis-backed registry. ttl <= 0
+// falls back to 10 minutes — same default as
+// NewMemoryScopeDriftRegistry. Pending substitutions ignore ttl and
+// use substitutionTTL (24h) instead.
+func NewRedisScopeDriftRegistry(rdb *redis.Client, ttl time.Duration) *RedisScopeDriftRegistry {
+	if ttl <= 0 {
+		ttl = 10 * time.Minute
+	}
+	return &RedisScopeDriftRegistry{rdb: rdb, ttl: ttl, now: time.Now}
+}
+
+// scopeDriftImmutable is the JSON payload stored in the `data` hash
+// field — everything on ScopeDrift except the three mutable claim
+// fields, which live as separate hash fields. Using a private shape
+// (rather than `type rawScopeDrift ScopeDrift`) keeps the wire format
+// stable even if someone adds more mutable fields to ScopeDrift later
+// — the immutable side here would still round-trip correctly.
+type scopeDriftImmutable struct {
+	ID             string                `json:"id"`
+	UserID         string                `json:"user_id"`
+	AgentID        string                `json:"agent_id"`
+	ConversationID string                `json:"conversation_id"`
+	Provider       string                `json:"provider"`
+	ToolUse        json.RawMessage       `json:"tool_use"`
+	Service        string                `json:"service"`
+	Action         string                `json:"action"`
+	Host           string                `json:"host"`
+	Method         string                `json:"method"`
+	Path           string                `json:"path"`
+	TaskID         string                `json:"task_id"`
+	TaskPurpose    string                `json:"task_purpose"`
+	ExpectedUse    string                `json:"expected_use"`
+	Source         ScopeDriftSource      `json:"source"`
+	ReasonText     string                `json:"reason_text"`
+	CreatedAt      time.Time             `json:"created_at"`
+	ExpiresAt      time.Time             `json:"expires_at"`
+}
+
+func encodeDriftImmutable(d ScopeDrift) ([]byte, error) {
+	toolUse, err := json.Marshal(d.ToolUse)
+	if err != nil {
+		return nil, fmt.Errorf("marshal tool_use: %w", err)
+	}
+	return json.Marshal(scopeDriftImmutable{
+		ID:             d.ID,
+		UserID:         d.UserID,
+		AgentID:        d.AgentID,
+		ConversationID: d.ConversationID,
+		Provider:       string(d.Provider),
+		ToolUse:        toolUse,
+		Service:        d.Service,
+		Action:         d.Action,
+		Host:           d.Host,
+		Method:         d.Method,
+		Path:           d.Path,
+		TaskID:         d.TaskID,
+		TaskPurpose:    d.TaskPurpose,
+		ExpectedUse:    d.ExpectedUse,
+		Source:         d.Source,
+		ReasonText:     d.ReasonText,
+		CreatedAt:      d.CreatedAt,
+		ExpiresAt:      d.ExpiresAt,
+	})
+}
+
+func decodeDriftImmutable(raw []byte) (ScopeDrift, error) {
+	var imm scopeDriftImmutable
+	if err := json.Unmarshal(raw, &imm); err != nil {
+		return ScopeDrift{}, err
+	}
+	d := ScopeDrift{
+		ID:             imm.ID,
+		UserID:         imm.UserID,
+		AgentID:        imm.AgentID,
+		ConversationID: imm.ConversationID,
+		Service:        imm.Service,
+		Action:         imm.Action,
+		Host:           imm.Host,
+		Method:         imm.Method,
+		Path:           imm.Path,
+		TaskID:         imm.TaskID,
+		TaskPurpose:    imm.TaskPurpose,
+		ExpectedUse:    imm.ExpectedUse,
+		Source:         imm.Source,
+		ReasonText:     imm.ReasonText,
+		CreatedAt:      imm.CreatedAt,
+		ExpiresAt:      imm.ExpiresAt,
+	}
+	d.Provider = conversation.Provider(imm.Provider)
+	if len(imm.ToolUse) > 0 && string(imm.ToolUse) != "null" {
+		if err := json.Unmarshal(imm.ToolUse, &d.ToolUse); err != nil {
+			return ScopeDrift{}, fmt.Errorf("unmarshal tool_use: %w", err)
+		}
+	}
+	return d, nil
+}
+
+func redisScopeDriftKey(driftID string) string {
+	return redisScopeDriftDriftPrefix + driftID
+}
+
+func redisScopeDriftPreClearKey(agentID, fingerprint string) string {
+	return redisScopeDriftPreClearPref + agentID + "|" + fingerprint
+}
+
+func redisScopeDriftPendingKey(key PendingSubstitutionKey) string {
+	return redisScopeDriftPendingPref + key.AgentID + "|" + key.ConversationID + "|" + key.ToolUseID
+}
+
+// Register implements ScopeDriftRegistry.
+func (r *RedisScopeDriftRegistry) Register(ctx context.Context, drift ScopeDrift) (ScopeDrift, error) {
+	if r == nil || r.rdb == nil {
+		return drift, errors.New("scope drift registry not configured")
+	}
+	now := r.now().UTC()
+	if drift.ID == "" {
+		id, err := newDriftID()
+		if err != nil {
+			return ScopeDrift{}, fmt.Errorf("mint drift id: %w", err)
+		}
+		drift.ID = id
+	}
+	if drift.CreatedAt.IsZero() {
+		drift.CreatedAt = now
+	}
+	if drift.ExpiresAt.IsZero() {
+		drift.ExpiresAt = now.Add(r.ttl)
+	}
+	immutable, err := encodeDriftImmutable(drift)
+	if err != nil {
+		return ScopeDrift{}, fmt.Errorf("marshal drift: %w", err)
+	}
+	key := redisScopeDriftKey(drift.ID)
+	pipe := r.rdb.TxPipeline()
+	pipe.HSet(ctx, key,
+		redisScopeDriftFieldData, immutable,
+		redisScopeDriftFieldChosen, string(drift.ChosenOption),
+		redisScopeDriftFieldOutcome, string(drift.Outcome),
+		redisScopeDriftFieldNote, drift.AgentNote,
+	)
+	pipe.PExpire(ctx, key, r.ttl)
+	if _, err := pipe.Exec(ctx); err != nil {
+		return ScopeDrift{}, err
+	}
+	return drift, nil
+}
+
+// Get implements ScopeDriftRegistry. Redis-side TTL drives expiry, but
+// ExpiresAt in the immutable payload is double-checked in case clocks
+// drift between instances.
+func (r *RedisScopeDriftRegistry) Get(ctx context.Context, driftID string) (ScopeDrift, error) {
+	if r == nil || r.rdb == nil {
+		return ScopeDrift{}, ErrDriftNotFound
+	}
+	return r.getDrift(ctx, driftID)
+}
+
+func (r *RedisScopeDriftRegistry) getDrift(ctx context.Context, driftID string) (ScopeDrift, error) {
+	key := redisScopeDriftKey(driftID)
+	fields, err := r.rdb.HMGet(ctx, key,
+		redisScopeDriftFieldData,
+		redisScopeDriftFieldChosen,
+		redisScopeDriftFieldOutcome,
+		redisScopeDriftFieldNote,
+	).Result()
+	if err != nil {
+		return ScopeDrift{}, err
+	}
+	if len(fields) < 4 || fields[0] == nil {
+		return ScopeDrift{}, ErrDriftNotFound
+	}
+	rawData, ok := fields[0].(string)
+	if !ok {
+		return ScopeDrift{}, ErrDriftNotFound
+	}
+	drift, err := decodeDriftImmutable([]byte(rawData))
+	if err != nil {
+		_ = r.rdb.Del(ctx, key).Err()
+		return ScopeDrift{}, ErrDriftNotFound
+	}
+	if v, ok := fields[1].(string); ok {
+		drift.ChosenOption = ScopeDriftOption(v)
+	}
+	if v, ok := fields[2].(string); ok {
+		drift.Outcome = ScopeDriftOutcome(v)
+	}
+	if v, ok := fields[3].(string); ok {
+		drift.AgentNote = v
+	}
+	if !drift.ExpiresAt.IsZero() && r.now().UTC().After(drift.ExpiresAt) {
+		_ = r.rdb.Del(ctx, key).Err()
+		return ScopeDrift{}, ErrDriftNotFound
+	}
+	return drift, nil
+}
+
+// ClaimOption implements ScopeDriftRegistry. The Lua script reads the
+// current `chosen` field; if non-empty it surfaces "already resolved"
+// without mutating anything, else it writes all three claim fields in
+// one atomic block. PTTL is untouched — claiming an option must not
+// extend the 10-minute drift lifetime.
+func (r *RedisScopeDriftRegistry) ClaimOption(ctx context.Context, driftID string, option ScopeDriftOption, agentNote string) (ScopeDrift, error) {
+	if r == nil || r.rdb == nil {
+		return ScopeDrift{}, ErrDriftNotFound
+	}
+	key := redisScopeDriftKey(driftID)
+	res, err := redisScopeDriftClaimOptionScript.Run(ctx, r.rdb, []string{key},
+		string(option), string(ScopeDriftOutcomePending), agentNote,
+	).Result()
+	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			return ScopeDrift{}, ErrDriftNotFound
+		}
+		// The script returns a Redis error when the key is missing.
+		if errors.Is(err, errRedisDriftNotFound) || err.Error() == "drift not found" {
+			return ScopeDrift{}, ErrDriftNotFound
+		}
+		return ScopeDrift{}, err
+	}
+	status, _ := res.(int64)
+	current, getErr := r.getDrift(ctx, driftID)
+	if getErr != nil {
+		return ScopeDrift{}, getErr
+	}
+	if status == 1 {
+		return current, ErrDriftAlreadyResolved
+	}
+	return current, nil
+}
+
+// SetOutcome implements ScopeDriftRegistry. On Succeeded the script
+// also mints the pre-clear keyed by (AgentID, fingerprint) with the
+// same remaining PTTL as the drift, so the pre-clear and drift expire
+// together — matching the memory impl's invariant.
+func (r *RedisScopeDriftRegistry) SetOutcome(ctx context.Context, driftID string, outcome ScopeDriftOutcome) error {
+	if r == nil || r.rdb == nil {
+		return ErrDriftNotFound
+	}
+	current, err := r.getDrift(ctx, driftID)
+	if err != nil {
+		return err
+	}
+	driftKey := redisScopeDriftKey(driftID)
+	preClearKey := redisScopeDriftPreClearKey(current.AgentID, current.Fingerprint())
+	mintPreClear := "0"
+	if outcome == ScopeDriftOutcomeSucceeded {
+		mintPreClear = "1"
+	}
+	_, err = redisScopeDriftSetOutcomeScript.Run(ctx, r.rdb, []string{driftKey, preClearKey},
+		string(outcome), mintPreClear, driftID,
+	).Result()
+	if err != nil {
+		if errors.Is(err, redis.Nil) || err.Error() == "drift not found" {
+			return ErrDriftNotFound
+		}
+		return err
+	}
+	return nil
+}
+
+// RollbackClaim implements ScopeDriftRegistry. The script resets the
+// three claim fields AND deletes the pre-clear key in one atomic
+// block — the lockstep invariant scope_drift_registry.go:374-397
+// calls out.
+func (r *RedisScopeDriftRegistry) RollbackClaim(ctx context.Context, driftID string) error {
+	if r == nil || r.rdb == nil {
+		return ErrDriftNotFound
+	}
+	current, err := r.getDrift(ctx, driftID)
+	if err != nil {
+		return err
+	}
+	driftKey := redisScopeDriftKey(driftID)
+	preClearKey := redisScopeDriftPreClearKey(current.AgentID, current.Fingerprint())
+	_, err = redisScopeDriftRollbackClaimScript.Run(ctx, r.rdb, []string{driftKey, preClearKey}).Result()
+	if err != nil {
+		if errors.Is(err, redis.Nil) || err.Error() == "drift not found" {
+			return ErrDriftNotFound
+		}
+		return err
+	}
+	return nil
+}
+
+// LookupPreClear implements ScopeDriftRegistry. GETDEL gives atomic
+// one-shot consume of the pre-clear; the follow-up Get on the drift
+// catches the rare case where the drift expired between the
+// SetOutcome that minted the pre-clear and this lookup. If the drift
+// is missing, the pre-clear is already deleted by the GETDEL so no
+// extra cleanup is needed.
+func (r *RedisScopeDriftRegistry) LookupPreClear(ctx context.Context, agentID, fingerprint string) (string, bool) {
+	if r == nil || r.rdb == nil {
+		return "", false
+	}
+	preClearKey := redisScopeDriftPreClearKey(agentID, fingerprint)
+	raw, err := r.rdb.GetDel(ctx, preClearKey).Result()
+	if err != nil {
+		return "", false
+	}
+	driftID := raw
+	if driftID == "" {
+		return "", false
+	}
+	if _, err := r.getDrift(ctx, driftID); err != nil {
+		return "", false
+	}
+	return driftID, true
+}
+
+// RegisterPendingSubstitution implements SubstitutionRegistry.
+func (r *RedisScopeDriftRegistry) RegisterPendingSubstitution(ctx context.Context, key PendingSubstitutionKey, value PendingSubstitution) error {
+	if r == nil || r.rdb == nil {
+		return errors.New("scope drift registry not configured")
+	}
+	if key.AgentID == "" || key.ToolUseID == "" {
+		return errors.New("pending substitution requires agent_id and tool_use_id")
+	}
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Errorf("marshal pending substitution: %w", err)
+	}
+	return r.rdb.Set(ctx, redisScopeDriftPendingKey(key), raw, substitutionTTL).Err()
+}
+
+// LookupPendingSubstitution implements SubstitutionRegistry. Does NOT
+// consume the entry — restoration of the assistant turn must work on
+// every future inbound while the substitution is live.
+func (r *RedisScopeDriftRegistry) LookupPendingSubstitution(ctx context.Context, key PendingSubstitutionKey) (PendingSubstitution, bool) {
+	if r == nil || r.rdb == nil {
+		return PendingSubstitution{}, false
+	}
+	raw, err := r.rdb.Get(ctx, redisScopeDriftPendingKey(key)).Bytes()
+	if err != nil {
+		return PendingSubstitution{}, false
+	}
+	var sub PendingSubstitution
+	if err := json.Unmarshal(raw, &sub); err != nil {
+		_ = r.rdb.Del(ctx, redisScopeDriftPendingKey(key)).Err()
+		return PendingSubstitution{}, false
+	}
+	return sub, true
+}
+
+// DeletePendingSubstitution implements SubstitutionRegistry.
+func (r *RedisScopeDriftRegistry) DeletePendingSubstitution(ctx context.Context, key PendingSubstitutionKey) {
+	if r == nil || r.rdb == nil {
+		return
+	}
+	_ = r.rdb.Del(ctx, redisScopeDriftPendingKey(key)).Err()
+}
+
+// errRedisDriftNotFound is the sentinel returned by the Lua scripts
+// when EXISTS reports the drift key is missing. The Go side maps it
+// back to ErrDriftNotFound.
+var errRedisDriftNotFound = errors.New("drift not found")
+
+// redisScopeDriftClaimOptionScript writes the three claim fields iff
+// `chosen` is currently empty — one-shot test-and-set. Returns 0 on
+// success, 1 on already-resolved.
+var redisScopeDriftClaimOptionScript = redis.NewScript(`
+local key = KEYS[1]
+local chosen = ARGV[1]
+local outcome = ARGV[2]
+local note = ARGV[3]
+if redis.call('EXISTS', key) == 0 then
+  return redis.error_reply('drift not found')
+end
+local current = redis.call('HGET', key, 'chosen')
+if current and current ~= '' then
+  return 1
+end
+redis.call('HSET', key, 'chosen', chosen, 'outcome', outcome, 'note', note)
+return 0
+`)
+
+// redisScopeDriftSetOutcomeScript updates the outcome field and,
+// when ARGV[2]=="1", mints the pre-clear with the same remaining PTTL
+// as the drift. PTTL on the drift is untouched.
+var redisScopeDriftSetOutcomeScript = redis.NewScript(`
+local drift_key = KEYS[1]
+local preclear_key = KEYS[2]
+local outcome = ARGV[1]
+local mint_preclear = ARGV[2]
+local drift_id = ARGV[3]
+if redis.call('EXISTS', drift_key) == 0 then
+  return redis.error_reply('drift not found')
+end
+redis.call('HSET', drift_key, 'outcome', outcome)
+if mint_preclear == '1' then
+  local ttl = redis.call('PTTL', drift_key)
+  if ttl and ttl > 0 then
+    redis.call('SET', preclear_key, drift_id, 'PX', ttl)
+  else
+    redis.call('SET', preclear_key, drift_id)
+  end
+end
+return 1
+`)
+
+// redisScopeDriftRollbackClaimScript resets the three claim fields
+// AND deletes the pre-clear key in one atomic block. A SetOutcome
+// (Succeeded) → rollback sequence must not leave a stale pre-clear
+// behind.
+var redisScopeDriftRollbackClaimScript = redis.NewScript(`
+local drift_key = KEYS[1]
+local preclear_key = KEYS[2]
+if redis.call('EXISTS', drift_key) == 0 then
+  return redis.error_reply('drift not found')
+end
+redis.call('HSET', drift_key, 'chosen', '', 'outcome', '', 'note', '')
+redis.call('DEL', preclear_key)
+return 1
+`)
+
+var _ ScopeDriftRegistry = (*RedisScopeDriftRegistry)(nil)

--- a/internal/runtime/llmproxy/scope_drift_registry_redis.go
+++ b/internal/runtime/llmproxy/scope_drift_registry_redis.go
@@ -172,6 +172,11 @@ func (r *RedisScopeDriftRegistry) Register(ctx context.Context, drift ScopeDrift
 	if err != nil {
 		return ScopeDrift{}, fmt.Errorf("marshal drift: %w", err)
 	}
+	// Honor a caller-supplied ExpiresAt — the memory impl stores it
+	// verbatim and Get checks against it. Defaulting unconditionally
+	// to r.ttl here would evict a 24h drift after 10 min and surface
+	// premature ErrDriftNotFound on the next instance.
+	expiry := drift.ExpiresAt.Sub(now)
 	key := redisScopeDriftKey(drift.ID)
 	pipe := r.rdb.TxPipeline()
 	pipe.HSet(ctx, key,
@@ -180,7 +185,7 @@ func (r *RedisScopeDriftRegistry) Register(ctx context.Context, drift ScopeDrift
 		redisScopeDriftFieldOutcome, string(drift.Outcome),
 		redisScopeDriftFieldNote, drift.AgentNote,
 	)
-	pipe.PExpire(ctx, key, r.ttl)
+	pipe.PExpire(ctx, key, expiry)
 	if _, err := pipe.Exec(ctx); err != nil {
 		return ScopeDrift{}, err
 	}

--- a/internal/runtime/llmproxy/scope_drift_registry_redis.go
+++ b/internal/runtime/llmproxy/scope_drift_registry_redis.go
@@ -354,8 +354,12 @@ func (r *RedisScopeDriftRegistry) RegisterPendingSubstitution(ctx context.Contex
 	if r == nil || r.rdb == nil {
 		return errors.New("scope drift registry not configured")
 	}
-	if key.AgentID == "" || key.ToolUseID == "" {
-		return errors.New("pending substitution requires agent_id and tool_use_id")
+	if key.AgentID == "" || key.ConversationID == "" || key.ToolUseID == "" {
+		// All three fields compose the storage key; an empty
+		// ConversationID would collapse distinct conversations onto
+		// the same key and let one conversation restore or delete
+		// another's pending substitution.
+		return errors.New("pending substitution requires agent_id, conversation_id, and tool_use_id")
 	}
 	raw, err := json.Marshal(value)
 	if err != nil {

--- a/pkg/clawvisor/defaults.go
+++ b/pkg/clawvisor/defaults.go
@@ -461,6 +461,7 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 	var liteApprovalCache llmproxy.PendingApprovalCache
 	var liteOutcomeStore llmproxy.InlineApprovalOutcomeStore
 	var taskCheckoutStore llmproxy.TaskCheckoutStore
+	var scopeDriftRegistry llmproxy.ScopeDriftRegistry
 	var extractionTracker handlers.ExtractionTracker
 	var rdb *redis.Client
 	if cfg.Redis.URL != "" {
@@ -504,6 +505,10 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 		liteApprovalCache = llmproxy.NewRedisPendingApprovalCache(client, 10*time.Minute)
 		liteOutcomeStore = llmproxy.NewRedisInlineApprovalOutcomeStore(client, 24*time.Hour)
 		taskCheckoutStore = llmproxy.NewRedisTaskCheckoutStore(client, 24*time.Hour)
+		// Scope-drift records (drifts, pre-clears) live 10 min by
+		// default; pending tool_result substitutions ignore this ttl
+		// and use the package's 24h substitutionTTL.
+		scopeDriftRegistry = llmproxy.NewRedisScopeDriftRegistry(client, 10*time.Minute)
 
 		// Safety TTL exceeds the 30s extraction timeout + 10s save timeout
 		// so a crashed instance doesn't orphan entries.
@@ -557,6 +562,7 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 		LiteApprovalCache:  liteApprovalCache,
 		LiteOutcomeStore:   liteOutcomeStore,
 		TaskCheckoutStore:  taskCheckoutStore,
+		ScopeDriftRegistry: scopeDriftRegistry,
 		RedisClient:        rdb,
 	}
 

--- a/pkg/clawvisor/options.go
+++ b/pkg/clawvisor/options.go
@@ -153,6 +153,7 @@ type ServerOptions struct {
 	LiteApprovalCache  llmproxy.PendingApprovalCache
 	LiteOutcomeStore   llmproxy.InlineApprovalOutcomeStore
 	TaskCheckoutStore  llmproxy.TaskCheckoutStore
+	ScopeDriftRegistry llmproxy.ScopeDriftRegistry
 	RedisClient        *redis.Client
 }
 

--- a/pkg/clawvisor/run.go
+++ b/pkg/clawvisor/run.go
@@ -356,6 +356,9 @@ func RunWithContext(ctx context.Context, opts *ServerOptions) error {
 	if opts.TaskCheckoutStore != nil {
 		apiOpts = append(apiOpts, api.WithTaskCheckoutStore(opts.TaskCheckoutStore))
 	}
+	if opts.ScopeDriftRegistry != nil {
+		apiOpts = append(apiOpts, api.WithScopeDriftRegistry(opts.ScopeDriftRegistry))
+	}
 	if opts.LocalServiceProvider != nil {
 		apiOpts = append(apiOpts, api.WithLocalServiceProvider(&localSvcAdapter{opts.LocalServiceProvider}))
 	}


### PR DESCRIPTION
## Summary
- Adds `RedisScopeDriftRegistry` (`internal/runtime/llmproxy/scope_drift_registry_redis.go`) implementing the full `ScopeDriftRegistry` interface — drifts, pre-clears, and pending tool_result substitutions. Hash layout: immutable JSON in a `data` field, the three mutable claim fields as separate hash fields, so `ClaimOption` / `SetOutcome` / `RollbackClaim` run under Lua scripts without patching serialized JSON. Pre-clear lookup is `GETDEL` for atomic one-shot consume.
- Wires it automatically in `pkg/clawvisor/defaults.go` when `cfg.Redis.URL` is set, joining the other lite-proxy Redis caches.
- Tightens both impls' contract: `RegisterPendingSubstitution` now requires `conversation_id` in addition to `agent_id` / `tool_use_id` (the storage key composes all three; an empty `conversation_id` collapsed distinct conversations onto the same key).

## Why
The in-memory `ScopeDriftRegistry` is process-local. In a multi-replica cloud deployment a substitution registered on replica A is invisible on replica B, so the inbound rewriter on B cannot restore the model's original `tool_use` and the model sees the harness-side placeholder as its own past forever. The drift state machine has the same race — a drift minted on A cannot be claimed or pre-cleared on B. The interface header on `scope_drift_registry.go:168-171` already calls out Redis as the intended future swap; this PR implements it.

## Test plan
- [x] `go test ./internal/runtime/llmproxy/...` — 7 new `TestRedisScopeDriftRegistry_*` cross-instance tests pass alongside existing memory tests
- [x] `go test ./internal/api/... ./pkg/clawvisor/...` — wire-up compiles and existing handler/server tests stay green
- [x] `go build ./...` — clean
- [ ] Smoke test in staging with `CLAWVISOR_REDIS_URL` set: trigger a drifted tool call from one replica, replay from a different replica, confirm substitution + pre-clear survive

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

