### PR TITLE
docs: point installer one-liner at github raw

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The fastest way to try Clawvisor is hosted: sign up at [clawvisor.com](https://c
 Prefer to run Clawvisor yourself? Install the daemon:
 
 ```bash
-curl -fsSL https://clawvisor.com/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/clawvisor/clawvisor/main/scripts/install.sh | sh
 ```
 
 > [!WARNING]

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Clawvisor daemon installer
-# Usage: curl -fsSL https://clawvisor.com/install.sh | sh
+# Usage: curl -fsSL https://raw.githubusercontent.com/clawvisor/clawvisor/main/scripts/install.sh | sh
 set -eu
 
 REPO="${CLAWVISOR_REPO:-clawvisor/clawvisor}"


### PR DESCRIPTION
## Summary
- `clawvisor.com/install.sh` is no longer served after the landing-page re-hosting, so the README one-liner 404s.
- Point both the README curl command and the in-script usage comment at `raw.githubusercontent.com/clawvisor/clawvisor/main/scripts/install.sh` (the script already lives in-repo and pulls release binaries directly from GitHub Releases, so no other changes are needed).

## Test plan
- [ ] `curl -fsSL https://raw.githubusercontent.com/clawvisor/clawvisor/main/scripts/install.sh | sh` on a clean macOS box installs the latest release and launches `clawvisor-server install`.
- [ ] Same on Linux (amd64 + arm64).
- [ ] `CLAWVISOR_SKIP_START=1 curl -fsSL .../install.sh | sh` exits after install without launching the setup wizard.

> Heads-up: if you'd prefer a shorter installer URL (e.g. a redirect on `get.clawvisor.com` proxied to GitHub raw), we can swap to that here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

