### PR TITLE
fix(llmproxy): enforce strict per-conversation task-scope isolation

### DIFF
--- a/internal/api/handlers/control.go
+++ b/internal/api/handlers/control.go
@@ -10,6 +10,7 @@ import (
 	"github.com/clawvisor/clawvisor/internal/api/middleware"
 	"github.com/clawvisor/clawvisor/internal/intent"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy"
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/inspector"
 	"github.com/clawvisor/clawvisor/pkg/store"
 	"github.com/google/uuid"
 )
@@ -232,8 +233,15 @@ func (h *LLMControlHandler) ListTasks(w http.ResponseWriter, r *http.Request) {
 
 	checkoutID := ""
 	checkoutUnavailable := false
-	key := llmproxy.TaskCheckoutKey{UserID: agent.UserID, AgentID: agent.ID}
-	if h.TaskCheckouts != nil {
+	// The lite-proxy rewriter injects X-Clawvisor-Conversation-ID on
+	// rewritten control calls so the per-conversation checkout bucket
+	// can be reached. A missing header means the request didn't
+	// originate from an inference turn — there's no scoped bucket to
+	// consult, so we report "no checkout" rather than fall back to the
+	// shared legacy bucket that was the cross-conversation leak source.
+	conversationID := strings.TrimSpace(r.Header.Get(inspector.ConversationIDHeader))
+	key := llmproxy.TaskCheckoutKey{UserID: agent.UserID, AgentID: agent.ID, ConversationID: conversationID}
+	if h.TaskCheckouts != nil && conversationID != "" {
 		if checkout, ok, err := h.TaskCheckouts.Get(r.Context(), key); err != nil {
 			checkoutUnavailable = true
 		} else if ok {
@@ -351,9 +359,28 @@ func (h *LLMControlHandler) CheckoutTask(w http.ResponseWriter, r *http.Request)
 		}
 		ttl = untilExpiry
 	}
+	// Per-conversation isolation: the checkout MUST be scoped to the
+	// conversation the agent is currently in. The lite-proxy rewriter
+	// injects X-Clawvisor-Conversation-ID on every rewritten control
+	// call (see internal/runtime/llmproxy/inspector/rewriter.go), so a
+	// missing header means either (a) the call did not pass through the
+	// proxy rewriter or (b) the inbound request had no conversation_id
+	// to forward. Either way, refusing to write here is the safe
+	// failure mode: a pre-strict-isolation legacy bucket would have let
+	// this checkout become every concurrent conversation's preferred
+	// task.
+	conversationID := strings.TrimSpace(r.Header.Get(inspector.ConversationIDHeader))
+	if conversationID == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]any{
+			"error":   "conversation_id_required",
+			"message": "task checkout is per-conversation; the lite-proxy rewriter must inject X-Clawvisor-Conversation-ID. If you reached this endpoint directly outside an active /v1/messages turn, use the inline task approval flow instead.",
+		})
+		return
+	}
 	if err := h.TaskCheckouts.Set(r.Context(), llmproxy.TaskCheckoutKey{
-		UserID:  agent.UserID,
-		AgentID: agent.ID,
+		UserID:         agent.UserID,
+		AgentID:        agent.ID,
+		ConversationID: conversationID,
 	}, task.ID, ttl); err != nil {
 		writeJSON(w, http.StatusServiceUnavailable, map[string]any{
 			"error":   "task_checkout_failed",

--- a/internal/api/handlers/control.go
+++ b/internal/api/handlers/control.go
@@ -239,7 +239,7 @@ func (h *LLMControlHandler) ListTasks(w http.ResponseWriter, r *http.Request) {
 	// originate from an inference turn — there's no scoped bucket to
 	// consult, so we report "no checkout" rather than fall back to the
 	// shared legacy bucket that was the cross-conversation leak source.
-	conversationID := strings.TrimSpace(r.Header.Get(inspector.ConversationIDHeader))
+	conversationID := trustedConversationID(r)
 	key := llmproxy.TaskCheckoutKey{UserID: agent.UserID, AgentID: agent.ID, ConversationID: conversationID}
 	if h.TaskCheckouts != nil && conversationID != "" {
 		if checkout, ok, err := h.TaskCheckouts.Get(r.Context(), key); err != nil {
@@ -369,7 +369,7 @@ func (h *LLMControlHandler) CheckoutTask(w http.ResponseWriter, r *http.Request)
 	// failure mode: a pre-strict-isolation legacy bucket would have let
 	// this checkout become every concurrent conversation's preferred
 	// task.
-	conversationID := strings.TrimSpace(r.Header.Get(inspector.ConversationIDHeader))
+	conversationID := trustedConversationID(r)
 	if conversationID == "" {
 		writeJSON(w, http.StatusBadRequest, map[string]any{
 			"error":   "conversation_id_required",
@@ -402,6 +402,25 @@ func (h *LLMControlHandler) CheckoutTask(w http.ResponseWriter, r *http.Request)
 		"message":    "Task is checked out as the current focus. Clawvisor will prefer it only when it is a valid match for later tool calls.",
 		"next_step":  "Continue with the requested work using normal tool calls. Do not add task_id or extra fields to tool inputs.",
 	})
+}
+
+// trustedConversationID resolves the per-conversation id from the
+// inbound request, trusting ONLY the value the lite-proxy rewriter
+// appended. The rewriter places its `-H 'X-Clawvisor-Conversation-ID:
+// <id>'` flag after the agent's curl tokens, so the LAST instance of
+// the header in the request is the one we wrote. Using r.Header.Get
+// returned the FIRST value, which let an agent that emitted its own
+// `-H 'X-Clawvisor-Conversation-ID: <forged>'` token impersonate any
+// conversation it could guess the id of (bypassing the strict
+// per-conversation checkout isolation this PR enforces). Defense in
+// depth: an attacker can still cause a header to be present, but they
+// can no longer make Get return it.
+func trustedConversationID(r *http.Request) string {
+	values := r.Header.Values(inspector.ConversationIDHeader)
+	if len(values) == 0 {
+		return ""
+	}
+	return strings.TrimSpace(values[len(values)-1])
 }
 
 func (h *LLMControlHandler) NotFound(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers/control_test.go
+++ b/internal/api/handlers/control_test.go
@@ -203,6 +203,36 @@ func TestControlListTasksReturnsAgentActiveTasksAndCheckout(t *testing.T) {
 	}
 }
 
+// TestTrustedConversationID_PrefersLastHeader pins the per-conversation
+// isolation invariant against a header-spoofing attack: the lite-proxy
+// rewriter appends `-H 'X-Clawvisor-Conversation-ID: <id>'` after the
+// agent's curl tokens, so when an agent emits a curl that already
+// includes the header, the resulting HTTP request carries two values.
+// http.Header.Get returned the FIRST (the agent's spoof), which let
+// an agent impersonate any conversation it could guess the id of.
+// Reading the LAST value trusts only the rewriter-appended one.
+func TestTrustedConversationID_PrefersLastHeader(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/control/tasks", nil)
+	req.Header.Add(inspector.ConversationIDHeader, "  spoofed-by-agent  ")
+	req.Header.Add(inspector.ConversationIDHeader, "real-from-rewriter")
+	if got := trustedConversationID(req); got != "real-from-rewriter" {
+		t.Errorf("trustedConversationID = %q, want %q (must take LAST header value, not first)", got, "real-from-rewriter")
+	}
+
+	// Single-value (the only-rewriter case) round-trips with trimming.
+	clean := httptest.NewRequest(http.MethodGet, "/", nil)
+	clean.Header.Set(inspector.ConversationIDHeader, "  conv-1  ")
+	if got := trustedConversationID(clean); got != "conv-1" {
+		t.Errorf("trustedConversationID single value = %q, want %q", got, "conv-1")
+	}
+
+	// Empty when header absent.
+	empty := httptest.NewRequest(http.MethodGet, "/", nil)
+	if got := trustedConversationID(empty); got != "" {
+		t.Errorf("trustedConversationID with no header = %q, want empty", got)
+	}
+}
+
 // TestControlCapabilitiesAdvertisesCompleteEndpoint locks in the new
 // /control/tasks/{id}/complete entry in Capabilities. Without it the
 // agent has no discoverable signal that the endpoint exists outside

--- a/internal/api/handlers/control_test.go
+++ b/internal/api/handlers/control_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy"
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/inspector"
 	"github.com/clawvisor/clawvisor/pkg/store"
 	"github.com/clawvisor/clawvisor/pkg/store/sqlite"
 )
@@ -154,7 +155,7 @@ func TestControlListTasksReturnsAgentActiveTasksAndCheckout(t *testing.T) {
 	}
 
 	checkouts := llmproxy.NewMemoryTaskCheckoutStore(time.Hour)
-	if err := checkouts.Set(ctx, llmproxy.TaskCheckoutKey{UserID: user.ID, AgentID: agent.ID}, "task-active", time.Hour); err != nil {
+	if err := checkouts.Set(ctx, llmproxy.TaskCheckoutKey{UserID: user.ID, AgentID: agent.ID, ConversationID: "conv-1"}, "task-active", time.Hour); err != nil {
 		t.Fatalf("checkout.Set: %v", err)
 	}
 	h := &LLMControlHandler{
@@ -163,6 +164,7 @@ func TestControlListTasksReturnsAgentActiveTasksAndCheckout(t *testing.T) {
 		TaskCheckouts: checkouts,
 	}
 	req := httptest.NewRequest(http.MethodGet, "/api/control/tasks", nil)
+	req.Header.Set(inspector.ConversationIDHeader, "conv-1")
 	req = req.WithContext(store.WithAgent(req.Context(), agent))
 	res := httptest.NewRecorder()
 

--- a/internal/api/handlers/llm_endpoint.go
+++ b/internal/api/handlers/llm_endpoint.go
@@ -2504,30 +2504,22 @@ func (h *LLMEndpointHandler) checkedOutTaskID(ctx context.Context, agent *store.
 	if h == nil || h.TaskCheckouts == nil || agent == nil {
 		return "", nil
 	}
-	// Scoped lookup first: a checkout written by inline-task approval
-	// in this conversation should win. If the scoped bucket misses,
-	// fall back to the legacy (user, agent)-only bucket — that's where
-	// `POST /control/task/checkout` writes, since the control endpoint
-	// has no per-turn conversation context. Without this fallback, a
-	// manually-selected task would never be preferred for any
-	// conversation that surfaces a non-empty ConversationID.
+	// Per-conversation isolation: the taskcheckout store rejects writes
+	// without a ConversationID (taskcheckout.ErrConversationIDRequired)
+	// and returns not-found for empty-ConversationID reads. An empty
+	// conversationID here means brand-new conversation / no preferred
+	// task — fall through to the normal full-pool match. The previous
+	// fallback to a legacy (user, agent)-only bucket was the
+	// cross-conversation leak this isolation fix targets.
+	if conversationID == "" {
+		return "", nil
+	}
 	scopedKey := llmproxy.TaskCheckoutKey{
 		UserID:         agent.UserID,
 		AgentID:        agent.ID,
 		ConversationID: conversationID,
 	}
-	if id, err := h.resolveCheckedOutTaskID(ctx, scopedKey, agent, candidateTasks); err != nil || id != "" {
-		return id, err
-	}
-	if conversationID == "" {
-		// Already checked the legacy bucket above.
-		return "", nil
-	}
-	legacyKey := llmproxy.TaskCheckoutKey{
-		UserID:  agent.UserID,
-		AgentID: agent.ID,
-	}
-	return h.resolveCheckedOutTaskID(ctx, legacyKey, agent, candidateTasks)
+	return h.resolveCheckedOutTaskID(ctx, scopedKey, agent, candidateTasks)
 }
 
 // resolveCheckedOutTaskID looks up a single TaskCheckoutKey, returns

--- a/internal/api/handlers/llm_endpoint_test.go
+++ b/internal/api/handlers/llm_endpoint_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/inspector"
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/taskcheckout"
 	"github.com/clawvisor/clawvisor/pkg/store"
 	"github.com/clawvisor/clawvisor/pkg/store/sqlite"
 	"github.com/clawvisor/clawvisor/pkg/vault"
@@ -2067,92 +2068,63 @@ func TestLLMEndpoint_RewritesTaskApprovalReplyBeforeForwarding(t *testing.T) {
 	}
 }
 
-// TestCheckedOutTaskID_FallsBackToLegacyKeyForControlPlaneCheckout
-// guards the per-conversation/legacy-bucket fallback rule:
-// POST /control/task/checkout writes under (UserID, AgentID) with empty
-// ConversationID because the control endpoint has no per-turn
-// conversation context. Without the fallback, a scoped lookup with a
-// non-empty ConversationID would miss every time and the
-// manually-selected task would never be preferred.
-func TestCheckedOutTaskID_FallsBackToLegacyKeyForControlPlaneCheckout(t *testing.T) {
+// TestCheckedOutTaskID_StrictPerConversation pins the new strict
+// contract for the checkout lookup: only the (UserID, AgentID,
+// ConversationID) bucket is consulted. The previous legacy-bucket
+// fallback (POST /control/task/checkout writing under empty CID, every
+// conversation reading it back) was the cross-conversation scope leak
+// this isolation fix targets.
+func TestCheckedOutTaskID_StrictPerConversation(t *testing.T) {
 	ctx := context.Background()
 	checkouts := llmproxy.NewMemoryTaskCheckoutStore(time.Hour)
-	// Simulate POST /control/task/checkout: stored under the legacy
-	// (user, agent) key, no conversation ID.
+	// Attempting to write under an empty ConversationID is now refused
+	// at the store layer — the leak source is closed off here.
 	if err := checkouts.Set(ctx, llmproxy.TaskCheckoutKey{
 		UserID:  "user-1",
 		AgentID: "agent-1",
-	}, "task-active", time.Hour); err != nil {
-		t.Fatal(err)
+	}, "task-active", time.Hour); !errors.Is(err, taskcheckout.ErrConversationIDRequired) {
+		t.Fatalf("expected ErrConversationIDRequired writing without ConversationID; got %v", err)
 	}
-	h := &LLMEndpointHandler{TaskCheckouts: checkouts}
-	agent := &store.Agent{ID: "agent-1", UserID: "user-1"}
-	candidates := []*store.Task{
-		{ID: "task-active", AgentID: "agent-1", Status: "active"},
-	}
-
-	// Conversation-scoped lookup: scoped bucket is empty, falls back to
-	// legacy, finds task-active.
-	id, err := h.checkedOutTaskID(ctx, agent, "conv-A", candidates)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if id != "task-active" {
-		t.Fatalf("scoped lookup with fallback returned %q, want task-active", id)
-	}
-
-	// Unscoped (empty ConversationID) still works.
-	id, err = h.checkedOutTaskID(ctx, agent, "", candidates)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if id != "task-active" {
-		t.Fatalf("legacy-bucket lookup returned %q, want task-active", id)
-	}
-}
-
-// TestCheckedOutTaskID_ScopedWinsOverLegacyFallback confirms an
-// inline-task approval that wrote to the scoped bucket takes
-// precedence over any control-plane checkout in the legacy bucket: the
-// fallback only fires when the scoped bucket is empty.
-func TestCheckedOutTaskID_ScopedWinsOverLegacyFallback(t *testing.T) {
-	ctx := context.Background()
-	checkouts := llmproxy.NewMemoryTaskCheckoutStore(time.Hour)
-	if err := checkouts.Set(ctx, llmproxy.TaskCheckoutKey{
-		UserID:  "user-1",
-		AgentID: "agent-1",
-	}, "task-legacy", time.Hour); err != nil {
-		t.Fatal(err)
-	}
+	// Scoped write succeeds.
 	if err := checkouts.Set(ctx, llmproxy.TaskCheckoutKey{
 		UserID:         "user-1",
 		AgentID:        "agent-1",
 		ConversationID: "conv-A",
 	}, "task-scoped", time.Hour); err != nil {
-		t.Fatal(err)
+		t.Fatalf("scoped Set: %v", err)
 	}
 	h := &LLMEndpointHandler{TaskCheckouts: checkouts}
 	agent := &store.Agent{ID: "agent-1", UserID: "user-1"}
 	candidates := []*store.Task{
-		{ID: "task-legacy", AgentID: "agent-1", Status: "active"},
 		{ID: "task-scoped", AgentID: "agent-1", Status: "active"},
 	}
 
+	// Owning conversation sees its checkout.
 	id, err := h.checkedOutTaskID(ctx, agent, "conv-A", candidates)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if id != "task-scoped" {
-		t.Fatalf("scoped bucket should win; got %q, want task-scoped", id)
+		t.Fatalf("scoped lookup returned %q, want task-scoped", id)
 	}
 
-	// A sibling conversation with no scoped entry falls back to legacy.
+	// Sibling conversation gets NOTHING — no leak, no fallback bucket.
 	id, err = h.checkedOutTaskID(ctx, agent, "conv-B", candidates)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if id != "task-legacy" {
-		t.Fatalf("sibling conversation should fall back; got %q, want task-legacy", id)
+	if id != "" {
+		t.Fatalf("sibling conversation must not see other conversation's checkout; got %q (leak)", id)
+	}
+
+	// Empty ConversationID (brand-new conversation) is treated as
+	// "no preferred task" — fall through to full-pool match upstream.
+	id, err = h.checkedOutTaskID(ctx, agent, "", candidates)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id != "" {
+		t.Fatalf("empty CID must return no preferred task; got %q", id)
 	}
 }
 

--- a/internal/runtime/conversation/verdict.go
+++ b/internal/runtime/conversation/verdict.go
@@ -130,6 +130,22 @@ type AuditEvent struct {
 	InspectorVerdict eval.InspectorVerdictSnapshot
 	TaskID           string
 
+	// PreferredTaskID is the conversation's checked-out task focus at
+	// the time of the authorization decision. Empty when the request
+	// came from a conversation with no checkout. Surfaced on the audit
+	// row so per-conversation isolation can be verified across rows.
+	PreferredTaskID string
+
+	// TaskScopePath classifies how task-scope authorization landed,
+	// making the per-conversation isolation invariant queryable:
+	//   - "preferred_strict":           preferred task covered the call.
+	//   - "no_preferred_fallback":      no preferred task, full-pool match.
+	//   - "preferred_mismatch_blocked": preferred set but did not cover;
+	//                                   blocked instead of falling back.
+	// Empty when the row didn't reach task-scope evaluation (e.g. ruled
+	// by a runtime policy rule earlier in the chain).
+	TaskScopePath string
+
 	// AnnotationFacts carries facts from non-winning evaluators for the
 	// same tool_use, surfaced so the audit row can record forensic
 	// signals (judge invocation cost, scope detail) that the chain's

--- a/internal/runtime/llmproxy/audit.go
+++ b/internal/runtime/llmproxy/audit.go
@@ -275,6 +275,19 @@ func (e *AuditEmitter) WriteAuditEvent(ctx context.Context, agent *store.Agent, 
 	if cv := strings.TrimSpace(ev.ToolUse.CvReason); cv != "" {
 		params["tool_cvreason"] = cv
 	}
+	// Per-conversation isolation telemetry. Sparse: only emit when
+	// non-empty so queries can filter and rows stay compact. The
+	// matched task id is on the AuditEntry.TaskID column already; what
+	// we add here is the *preferred* (checked-out) task id and the path
+	// the decision took (preferred_strict / no_preferred_fallback /
+	// preferred_mismatch_blocked). Operators can join these with TaskID
+	// to confirm zero cross-conversation matches.
+	if ev.PreferredTaskID != "" {
+		params["preferred_task_id"] = ev.PreferredTaskID
+	}
+	if ev.TaskScopePath != "" {
+		params["task_scope_path"] = ev.TaskScopePath
+	}
 	if len(ev.InspectorVerdict.CredentialLocations) > 0 {
 		creds := make([]map[string]string, 0, len(ev.InspectorVerdict.CredentialLocations))
 		for _, c := range ev.InspectorVerdict.CredentialLocations {

--- a/internal/runtime/llmproxy/bodytransform/roundtrip_test.go
+++ b/internal/runtime/llmproxy/bodytransform/roundtrip_test.go
@@ -97,7 +97,7 @@ func TestRewriteSanitizeRoundTrip(t *testing.T) {
 				Name:  "Bash",
 				Input: mustMarshal(t, map[string]any{"command": tc.command}),
 			}
-			rewrittenInput, _, ok, err := controltool.RewriteControlToolUse(toolUse, controlBase, callerToken)
+			rewrittenInput, _, ok, err := controltool.RewriteControlToolUse(toolUse, controlBase, callerToken, "")
 			if err != nil {
 				t.Fatalf("rewrite returned error: %v", err)
 			}
@@ -186,7 +186,7 @@ func TestRewriteSanitizeRoundTrip_PreservesUnrelatedHeaders(t *testing.T) {
 		Name:  "Bash",
 		Input: mustMarshal(t, map[string]any{"command": command}),
 	}
-	rewrittenInput, _, ok, err := controltool.RewriteControlToolUse(toolUse, controlBase, callerToken)
+	rewrittenInput, _, ok, err := controltool.RewriteControlToolUse(toolUse, controlBase, callerToken, "")
 	if err != nil || !ok {
 		t.Fatalf("rewrite ok=%v err=%v", ok, err)
 	}

--- a/internal/runtime/llmproxy/control.go
+++ b/internal/runtime/llmproxy/control.go
@@ -36,8 +36,8 @@ func InjectControlNoticeWithSnapshot(provider conversation.Provider, body []byte
 	return controltool.InjectControlNoticeWithSnapshot(provider, body, controlBaseURL, availableTools, toolRules, activeTasksSnapshot)
 }
 
-func RewriteControlToolUse(t conversation.ToolUse, controlBaseURL string, callerToken string) ([]byte, inspector.Verdict, bool, error) {
-	return controltool.RewriteControlToolUse(t, controlBaseURL, callerToken)
+func RewriteControlToolUse(t conversation.ToolUse, controlBaseURL string, callerToken string, conversationID string) ([]byte, inspector.Verdict, bool, error) {
+	return controltool.RewriteControlToolUse(t, controlBaseURL, callerToken, conversationID)
 }
 
 func RewriteControlFailureToolUse(t conversation.ToolUse, controlBaseURL string, callerToken string, reason string) ([]byte, bool, error) {

--- a/internal/runtime/llmproxy/controltool/control.go
+++ b/internal/runtime/llmproxy/controltool/control.go
@@ -643,7 +643,14 @@ func appendNotice(existing, notice string) string {
 // RewriteControlToolUse redirects a model-emitted synthetic control URL to the
 // daemon and injects caller auth. This path intentionally bypasses policy rules:
 // agents must be able to ask Clawvisor for permission before permission exists.
-func RewriteControlToolUse(t conversation.ToolUse, controlBaseURL string, callerToken string) ([]byte, inspector.Verdict, bool, error) {
+//
+// conversationID is the per-turn conversation id resolved from the
+// inbound /v1/messages request. When non-empty it is written into the
+// rewritten tool_use as a `X-Clawvisor-Conversation-ID` header so the
+// control plane handlers can scope side effects (e.g. /control/task/checkout
+// writes) to the correct conversation without the agent having to know
+// or include the id itself.
+func RewriteControlToolUse(t conversation.ToolUse, controlBaseURL string, callerToken string, conversationID string) ([]byte, inspector.Verdict, bool, error) {
 	if strings.TrimSpace(controlBaseURL) == "" {
 		return nil, inspector.Verdict{}, false, nil
 	}
@@ -653,6 +660,7 @@ func RewriteControlToolUse(t conversation.ToolUse, controlBaseURL string, caller
 	}
 	opts := inspector.DefaultRewriteOpts(controlBaseURL)
 	opts.CallerToken = callerToken
+	opts.ConversationID = conversationID
 	if rewritten, ok, err := rewriteControlCommandToolUse(t, v, opts); ok {
 		return rewritten, v, true, err
 	}
@@ -735,6 +743,9 @@ func rewriteControlStructuredToolUse(t conversation.ToolUse, opts inspector.Rewr
 	headers[firstNonEmptyControl(opts.TargetHostHeader, "X-Clawvisor-Target-Host")] = parsed.Host
 	if opts.CallerToken != "" && opts.CallerHeader != "" {
 		headers[opts.CallerHeader] = "Bearer " + opts.CallerToken
+	}
+	if opts.ConversationID != "" {
+		headers[inspector.ConversationIDHeader] = opts.ConversationID
 	}
 	raw["headers"] = headers
 
@@ -898,6 +909,9 @@ func rewriteControlCommandString(cmd string, v inspector.Verdict, opts inspector
 		headers := " -H " + shellSingleQuote(firstNonEmptyControl(opts.TargetHostHeader, "X-Clawvisor-Target-Host")+": "+parsed.Host)
 		if opts.CallerToken != "" && opts.CallerHeader != "" {
 			headers += " -H " + shellSingleQuote(opts.CallerHeader+": Bearer "+opts.CallerToken)
+		}
+		if opts.ConversationID != "" {
+			headers += " -H " + shellSingleQuote(inspector.ConversationIDHeader+": "+opts.ConversationID)
 		}
 		return cmd[:arg.start] + headers + " " + shellSingleQuote(rewritten.String()) + cmd[arg.end:], true
 	}

--- a/internal/runtime/llmproxy/controltool/control_multistmt_test.go
+++ b/internal/runtime/llmproxy/controltool/control_multistmt_test.go
@@ -151,7 +151,7 @@ func TestRewriteControlToolUse_CompleteCurlInjectsCallerAuth(t *testing.T) {
 		}`),
 	}
 	const minted = "cv-nonce-complete-xyz"
-	rewritten, verdict, ok, err := RewriteControlToolUse(tu, "https://clawvisor.example", minted)
+	rewritten, verdict, ok, err := RewriteControlToolUse(tu, "https://clawvisor.example", minted, "")
 	if err != nil || !ok {
 		t.Fatalf("expected rewrite to succeed, got ok=%v err=%v", ok, err)
 	}
@@ -222,7 +222,7 @@ func TestRewriteControlToolUse_RewritesMultiStmtCatHeredocPlusCurl(t *testing.T)
 		Name:  "Bash",
 		Input: json.RawMessage(`{"command":` + jsonQuote(multiStmtCatCurlCmd) + `}`),
 	}
-	rewritten, _, ok, err := RewriteControlToolUse(tu, "https://control.example", "cv-nonce-test")
+	rewritten, _, ok, err := RewriteControlToolUse(tu, "https://control.example", "cv-nonce-test", "")
 	if err != nil {
 		t.Fatalf("rewrite err: %v", err)
 	}
@@ -430,7 +430,7 @@ func TestRewriteControlToolUse_ClampsExecCommandYieldTimeMs(t *testing.T) {
 			"max_output_tokens": 2000
 		}`),
 	}
-	rewritten, _, ok, err := RewriteControlToolUse(tu, "https://control.example", "cv-nonce-test")
+	rewritten, _, ok, err := RewriteControlToolUse(tu, "https://control.example", "cv-nonce-test", "")
 	if err != nil || !ok {
 		t.Fatalf("expected control rewrite; ok=%v err=%v", ok, err)
 	}
@@ -460,7 +460,7 @@ func TestRewriteControlToolUse_AddsYieldTimeMsWhenAbsent(t *testing.T) {
 			"workdir": "/tmp"
 		}`),
 	}
-	rewritten, _, ok, err := RewriteControlToolUse(tu, "https://control.example", "cv-nonce-test")
+	rewritten, _, ok, err := RewriteControlToolUse(tu, "https://control.example", "cv-nonce-test", "")
 	if err != nil || !ok {
 		t.Fatalf("expected control rewrite; ok=%v err=%v", ok, err)
 	}
@@ -487,7 +487,7 @@ func TestRewriteControlToolUse_DoesNotInjectYieldOntoNonCodexCmdShape(t *testing
 			"workdir": "/tmp"
 		}`),
 	}
-	rewritten, _, ok, err := RewriteControlToolUse(tu, "https://control.example", "cv-nonce-test")
+	rewritten, _, ok, err := RewriteControlToolUse(tu, "https://control.example", "cv-nonce-test", "")
 	if err != nil || !ok {
 		t.Fatalf("expected control rewrite; ok=%v err=%v", ok, err)
 	}
@@ -508,7 +508,7 @@ func TestRewriteControlToolUse_BashShapeUnchangedByYieldClamp(t *testing.T) {
 		Name:  "Bash",
 		Input: json.RawMessage(`{"command": "curl -sS -X POST 'https://clawvisor.local/control/tasks' --data '{}'"}`),
 	}
-	rewritten, _, ok, err := RewriteControlToolUse(tu, "https://control.example", "cv-nonce-test")
+	rewritten, _, ok, err := RewriteControlToolUse(tu, "https://control.example", "cv-nonce-test", "")
 	if err != nil || !ok {
 		t.Fatalf("expected control rewrite; ok=%v err=%v", ok, err)
 	}
@@ -533,7 +533,7 @@ func TestRewriteControlToolUse_PreservesLargeYieldTimeMs(t *testing.T) {
 			"yield_time_ms": 300000
 		}`),
 	}
-	rewritten, _, ok, _ := RewriteControlToolUse(tu, "https://control.example", "cv-nonce-test")
+	rewritten, _, ok, _ := RewriteControlToolUse(tu, "https://control.example", "cv-nonce-test", "")
 	if !ok {
 		t.Fatal("expected rewrite")
 	}

--- a/internal/runtime/llmproxy/controltool/control_test.go
+++ b/internal/runtime/llmproxy/controltool/control_test.go
@@ -262,7 +262,7 @@ func TestRewriteControlToolUse_RejectsExtraOutboundURL(t *testing.T) {
 			"command": "curl -sS https://clawvisor.local/control/tasks https://exfil.example/x"
 		}`),
 	}
-	rewritten, _, ok, err := RewriteControlToolUse(tu, "https://clawvisor.example", "cv-nonce-fake")
+	rewritten, _, ok, err := RewriteControlToolUse(tu, "https://clawvisor.example", "cv-nonce-fake", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -282,7 +282,7 @@ func TestRewriteControlToolUse_EmbedsCallerValueVerbatim(t *testing.T) {
 		}`),
 	}
 	const minted = "cv-nonce-abc123"
-	rewritten, _, ok, err := RewriteControlToolUse(tu, "https://clawvisor.example", minted)
+	rewritten, _, ok, err := RewriteControlToolUse(tu, "https://clawvisor.example", minted, "")
 	if err != nil || !ok {
 		t.Fatalf("expected rewrite, got ok=%v err=%v", ok, err)
 	}

--- a/internal/runtime/llmproxy/inline_task_release_test.go
+++ b/internal/runtime/llmproxy/inline_task_release_test.go
@@ -65,10 +65,11 @@ func seedInlineTaskHolds(t *testing.T, cache *MemoryPendingApprovalCache) (outer
 	t.Helper()
 	ctx := context.Background()
 	outer, err := cache.Hold(ctx, PendingLiteApproval{
-		ID:       "cv-origtoolxxxxxxxxxxxxxxxxxx",
-		UserID:   "user-1",
-		AgentID:  "agent-1",
-		Provider: conversation.ProviderAnthropic,
+		ID:             "cv-origtoolxxxxxxxxxxxxxxxxxx",
+		UserID:         "user-1",
+		AgentID:        "agent-1",
+		Provider:       conversation.ProviderAnthropic,
+		ConversationID: "conv-1",
 		ToolUse: conversation.ToolUse{
 			ID:    "toolu_orig",
 			Name:  "Bash",
@@ -80,10 +81,11 @@ func seedInlineTaskHolds(t *testing.T, cache *MemoryPendingApprovalCache) (outer
 		t.Fatal(err)
 	}
 	inner, err := cache.Hold(ctx, PendingLiteApproval{
-		ID:       "cv-innerholdxxxxxxxxxxxxxxxxx",
-		UserID:   "user-1",
-		AgentID:  "agent-1",
-		Provider: conversation.ProviderAnthropic,
+		ID:             "cv-innerholdxxxxxxxxxxxxxxxxx",
+		UserID:         "user-1",
+		AgentID:        "agent-1",
+		Provider:       conversation.ProviderAnthropic,
+		ConversationID: "conv-1",
 		ToolUse: conversation.ToolUse{
 			ID:   "toolu_post",
 			Name: "Bash",
@@ -130,6 +132,7 @@ func TestRewriteInlineTaskApproval_ApproveCreatesTaskAndRewritesBody(t *testing.
 		Provider:        conversation.ProviderAnthropic,
 		Body:            body,
 		Agent:           &store.Agent{ID: "agent-1", UserID: "user-1"},
+		ConversationID:  "conv-1",
 		PendingApproval: cache,
 		Creator:         creator,
 		Checkouts:       checkouts,
@@ -152,7 +155,7 @@ func TestRewriteInlineTaskApproval_ApproveCreatesTaskAndRewritesBody(t *testing.
 	if !out.CheckedOut {
 		t.Fatal("expected inline-approved task to be checked out")
 	}
-	checkout, ok, err := checkouts.Get(context.Background(), TaskCheckoutKey{UserID: "user-1", AgentID: "agent-1"})
+	checkout, ok, err := checkouts.Get(context.Background(), TaskCheckoutKey{UserID: "user-1", AgentID: "agent-1", ConversationID: "conv-1"})
 	if err != nil || !ok || checkout.TaskID != "task-uuid-123" {
 		t.Fatalf("checkout = %+v ok=%v err=%v, want task-uuid-123", checkout, ok, err)
 	}
@@ -179,7 +182,7 @@ func TestRewriteInlineTaskApproval_ApproveCreatesTaskAndRewritesBody(t *testing.
 	// Both holds gone.
 	for _, id := range []string{outerID, innerID} {
 		peeked, _ := cache.Peek(context.Background(), ResolveRequest{
-			UserID: "user-1", AgentID: "agent-1", Provider: conversation.ProviderAnthropic, ApprovalID: id,
+			UserID: "user-1", AgentID: "agent-1", Provider: conversation.ProviderAnthropic, ConversationID: "conv-1", ApprovalID: id,
 		})
 		if peeked != nil {
 			t.Errorf("hold %s should be dropped on approve; got %+v", id, peeked)
@@ -198,6 +201,7 @@ func TestRewriteInlineTaskApproval_DenyDropsBothHoldsNoCreator(t *testing.T) {
 		Provider:        conversation.ProviderAnthropic,
 		Body:            body,
 		Agent:           &store.Agent{ID: "agent-1", UserID: "user-1"},
+		ConversationID:  "conv-1",
 		PendingApproval: cache,
 		Creator:         creator,
 	})
@@ -217,7 +221,7 @@ func TestRewriteInlineTaskApproval_DenyDropsBothHoldsNoCreator(t *testing.T) {
 	}
 	for _, id := range []string{outerID, innerID} {
 		peeked, _ := cache.Peek(context.Background(), ResolveRequest{
-			UserID: "user-1", AgentID: "agent-1", Provider: conversation.ProviderAnthropic, ApprovalID: id,
+			UserID: "user-1", AgentID: "agent-1", Provider: conversation.ProviderAnthropic, ConversationID: "conv-1", ApprovalID: id,
 		})
 		if peeked != nil {
 			t.Errorf("hold %s should be dropped on deny; got %+v", id, peeked)
@@ -236,6 +240,7 @@ func TestRewriteInlineTaskApproval_CreatorFailureRewritesAsDeny(t *testing.T) {
 		Provider:        conversation.ProviderAnthropic,
 		Body:            body,
 		Agent:           &store.Agent{ID: "agent-1", UserID: "user-1"},
+		ConversationID:  "conv-1",
 		PendingApproval: cache,
 		Creator:         creator,
 	})
@@ -260,6 +265,7 @@ func TestRewriteInlineTaskApproval_MissingCreatorRewritesAsDeny(t *testing.T) {
 		Provider:        conversation.ProviderAnthropic,
 		Body:            body,
 		Agent:           &store.Agent{ID: "agent-1", UserID: "user-1"},
+		ConversationID:  "conv-1",
 		PendingApproval: cache,
 		// Creator nil
 	})
@@ -289,23 +295,25 @@ func TestRewriteInlineTaskApproval_FindsInlineHoldBehindStaleToolHold(t *testing
 	// Older tool-stage hold (e.g. from a prior intent_refusal the
 	// user never replied to). This goes into items[0].
 	if _, err := cache.Hold(ctx, PendingLiteApproval{
-		ID:       "cv-staletoolholdxxxxxxxxxxxxx",
-		UserID:   "user-1",
-		AgentID:  "agent-1",
-		Provider: conversation.ProviderAnthropic,
-		Stage:    StageTool,
-		ToolUse:  conversation.ToolUse{ID: "toolu_stale", Name: "Read"},
+		ID:             "cv-staletoolholdxxxxxxxxxxxxx",
+		UserID:         "user-1",
+		AgentID:        "agent-1",
+		Provider:       conversation.ProviderAnthropic,
+		ConversationID: "conv-1",
+		Stage:          StageTool,
+		ToolUse:        conversation.ToolUse{ID: "toolu_stale", Name: "Read"},
 	}); err != nil {
 		t.Fatal(err)
 	}
 	// Inline-task hold added AFTER → goes into items[1].
 	inner, err := cache.Hold(ctx, PendingLiteApproval{
-		ID:       "cv-innerholdxxxxxxxxxxxxxxxxx",
-		UserID:   "user-1",
-		AgentID:  "agent-1",
-		Provider: conversation.ProviderAnthropic,
-		Stage:    StageAwaitingTaskApproval,
-		ToolUse:  conversation.ToolUse{ID: "toolu_post", Name: "Bash"},
+		ID:             "cv-innerholdxxxxxxxxxxxxxxxxx",
+		UserID:         "user-1",
+		AgentID:        "agent-1",
+		Provider:       conversation.ProviderAnthropic,
+		ConversationID: "conv-1",
+		Stage:          StageAwaitingTaskApproval,
+		ToolUse:        conversation.ToolUse{ID: "toolu_post", Name: "Bash"},
 		TaskDefinition: &runtimetasks.TaskCreateRequest{
 			Purpose: "Test inline task",
 			ExpectedTools: []runtimetasks.ExpectedTool{
@@ -332,6 +340,7 @@ func TestRewriteInlineTaskApproval_FindsInlineHoldBehindStaleToolHold(t *testing
 		Provider:        conversation.ProviderAnthropic,
 		Body:            body,
 		Agent:           &store.Agent{ID: "agent-1", UserID: "user-1"},
+		ConversationID:  "conv-1",
 		PendingApproval: cache,
 		Creator:         creator,
 	})
@@ -354,7 +363,7 @@ func TestRewriteInlineTaskApproval_FindsInlineHoldBehindStaleToolHold(t *testing
 	// path to handle separately — we should not have collateral-
 	// damaged it.
 	stale, _ := cache.Peek(ctx, ResolveRequest{
-		UserID: "user-1", AgentID: "agent-1", Provider: conversation.ProviderAnthropic,
+		UserID: "user-1", AgentID: "agent-1", Provider: conversation.ProviderAnthropic, ConversationID: "conv-1",
 		ApprovalID: "cv-staletoolholdxxxxxxxxxxxxx",
 	})
 	if stale == nil {
@@ -362,7 +371,7 @@ func TestRewriteInlineTaskApproval_FindsInlineHoldBehindStaleToolHold(t *testing
 	}
 	// Inline-task hold must be consumed.
 	gone, _ := cache.Peek(ctx, ResolveRequest{
-		UserID: "user-1", AgentID: "agent-1", Provider: conversation.ProviderAnthropic,
+		UserID: "user-1", AgentID: "agent-1", Provider: conversation.ProviderAnthropic, ConversationID: "conv-1",
 		ApprovalID: inner.Pending.ID,
 	})
 	if gone != nil {
@@ -381,11 +390,12 @@ func TestRewriteInlineTaskApproval_BareApproveDoesNotStealNewerToolHold(t *testi
 
 	// Older inline-task hold that should NOT consume a later bare approve.
 	inlineHeld, err := cache.Hold(ctx, PendingLiteApproval{
-		ID:       "cv-inlineolderxxxxxxxxxxxxxxx",
-		UserID:   "user-1",
-		AgentID:  "agent-1",
-		Provider: conversation.ProviderAnthropic,
-		Stage:    StageAwaitingTaskApproval,
+		ID:             "cv-inlineolderxxxxxxxxxxxxxxx",
+		UserID:         "user-1",
+		AgentID:        "agent-1",
+		Provider:       conversation.ProviderAnthropic,
+		ConversationID: "conv-1",
+		Stage:          StageAwaitingTaskApproval,
 		TaskDefinition: &runtimetasks.TaskCreateRequest{
 			Purpose: "Older inline task",
 		},
@@ -395,12 +405,13 @@ func TestRewriteInlineTaskApproval_BareApproveDoesNotStealNewerToolHold(t *testi
 	}
 	// Newer regular tool hold: this is the prompt the user just saw.
 	toolHeld, err := cache.Hold(ctx, PendingLiteApproval{
-		ID:       "cv-toolnewerxxxxxxxxxxxxxxxxx",
-		UserID:   "user-1",
-		AgentID:  "agent-1",
-		Provider: conversation.ProviderAnthropic,
-		Stage:    StageTool,
-		ToolUse:  conversation.ToolUse{ID: "toolu_newer", Name: "Bash"},
+		ID:             "cv-toolnewerxxxxxxxxxxxxxxxxx",
+		UserID:         "user-1",
+		AgentID:        "agent-1",
+		Provider:       conversation.ProviderAnthropic,
+		ConversationID: "conv-1",
+		Stage:          StageTool,
+		ToolUse:        conversation.ToolUse{ID: "toolu_newer", Name: "Bash"},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -415,6 +426,7 @@ func TestRewriteInlineTaskApproval_BareApproveDoesNotStealNewerToolHold(t *testi
 		Provider:        conversation.ProviderAnthropic,
 		Body:            body,
 		Agent:           &store.Agent{ID: "agent-1", UserID: "user-1"},
+		ConversationID:  "conv-1",
 		PendingApproval: cache,
 		Creator:         creator,
 	})
@@ -429,7 +441,7 @@ func TestRewriteInlineTaskApproval_BareApproveDoesNotStealNewerToolHold(t *testi
 	}
 	for _, id := range []string{inlineHeld.Pending.ID, toolHeld.Pending.ID} {
 		peeked, err := cache.Peek(ctx, ResolveRequest{
-			UserID: "user-1", AgentID: "agent-1",
+			UserID: "user-1", AgentID: "agent-1", ConversationID: "conv-1",
 			Provider: conversation.ProviderAnthropic, ApprovalID: id,
 		})
 		if err != nil {
@@ -448,12 +460,13 @@ func TestRewriteInlineTaskApproval_NoToolHoldIsNoop(t *testing.T) {
 	// handle it.
 	cache := NewMemoryPendingApprovalCache(time.Minute)
 	if _, err := cache.Hold(context.Background(), PendingLiteApproval{
-		ID:       "cv-toolstageholdxxxxxxxxxxxxx",
-		UserID:   "user-1",
-		AgentID:  "agent-1",
-		Provider: conversation.ProviderAnthropic,
-		Stage:    StageTool, // not the awaiting_task_approval stage
-		ToolUse:  conversation.ToolUse{ID: "toolu_x", Name: "Bash"},
+		ID:             "cv-toolstageholdxxxxxxxxxxxxx",
+		UserID:         "user-1",
+		AgentID:        "agent-1",
+		Provider:       conversation.ProviderAnthropic,
+		ConversationID: "conv-1",
+		Stage:          StageTool, // not the awaiting_task_approval stage
+		ToolUse:        conversation.ToolUse{ID: "toolu_x", Name: "Bash"},
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -464,6 +477,7 @@ func TestRewriteInlineTaskApproval_NoToolHoldIsNoop(t *testing.T) {
 		Provider:        conversation.ProviderAnthropic,
 		Body:            body,
 		Agent:           &store.Agent{ID: "agent-1", UserID: "user-1"},
+		ConversationID:  "conv-1",
 		PendingApproval: cache,
 	})
 	if err != nil {
@@ -490,6 +504,7 @@ func TestTryReleasePendingApproval_FailsClosedOnAwaitingTaskApproval(t *testing.
 		Provider:        conversation.ProviderAnthropic,
 		Body:            body,
 		Agent:           &store.Agent{ID: "agent-1", UserID: "user-1"},
+		ConversationID:  "conv-1",
 		PendingApproval: cache,
 	})
 	if result.Decision != "deny" || result.Outcome != "inline_task_preprocess_missing" {

--- a/internal/runtime/llmproxy/inspector/rewriter.go
+++ b/internal/runtime/llmproxy/inspector/rewriter.go
@@ -10,6 +10,14 @@ import (
 	"github.com/clawvisor/clawvisor/internal/runtime/jsonpatch"
 )
 
+// ConversationIDHeader is the fixed header name the rewriter writes
+// the per-turn conversation id into when RewriteOpts.ConversationID is
+// non-empty. The control plane's /control/task/checkout handler reads
+// this header so a manually-issued task checkout lands in the correct
+// per-conversation bucket without the agent needing to put the
+// conversation id in the request body itself.
+const ConversationIDHeader = "X-Clawvisor-Conversation-ID"
+
 // RewriteOpts controls how Rewrite produces the redirected tool_use input.
 type RewriteOpts struct {
 	// ResolverBaseURL is the URL the harness's eventual HTTP call should
@@ -37,6 +45,14 @@ type RewriteOpts struct {
 	// conversation history). Documented limitation; future work canonicalizes
 	// the conversation history to strip it.
 	CallerToken string
+
+	// ConversationID is the per-turn conversation id resolved from the
+	// inbound /v1/messages request. When non-empty the rewriter writes
+	// it into ConversationIDHeader on the rewritten tool_use so the
+	// control plane handlers can scope side effects (e.g. task
+	// checkouts) to the correct conversation. Empty disables the
+	// injection.
+	ConversationID string
 }
 
 // DefaultRewriteOpts returns sensible defaults for production.
@@ -134,6 +150,9 @@ func rewriteStructured(t ToolUse, _ Verdict, resolver *url.URL, opts RewriteOpts
 	headers[opts.TargetHostHeader] = parsed.Host
 	if opts.CallerToken != "" && opts.CallerHeader != "" {
 		headers[opts.CallerHeader] = "Bearer " + opts.CallerToken
+	}
+	if opts.ConversationID != "" {
+		headers[ConversationIDHeader] = opts.ConversationID
 	}
 	raw["headers"] = headers
 
@@ -242,6 +261,10 @@ func rewriteBash(t ToolUse, v Verdict, resolver *url.URL, opts RewriteOpts) ([]b
 	if opts.CallerToken != "" && opts.CallerHeader != "" {
 		callerHeader := fmt.Sprintf("%s: Bearer %s", opts.CallerHeader, opts.CallerToken)
 		injected = append(injected, "-H", callerHeader)
+	}
+	if opts.ConversationID != "" {
+		convHeader := fmt.Sprintf("%s: %s", ConversationIDHeader, opts.ConversationID)
+		injected = append(injected, "-H", convHeader)
 	}
 	tokens = append(tokens[:urlIdx],
 		append(injected, tokens[urlIdx:]...)...)

--- a/internal/runtime/llmproxy/pipelineeval/audit_path_test.go
+++ b/internal/runtime/llmproxy/pipelineeval/audit_path_test.go
@@ -1,0 +1,79 @@
+package pipelineeval
+
+import (
+	"testing"
+
+	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+	runtimedecision "github.com/clawvisor/clawvisor/pkg/runtime/decision"
+)
+
+// TestClassifyTaskScopePath_FromFacts pins how the audit row's
+// `task_scope_path` enum is derived from the chain's AuthorizationFact.
+// This is the field operators query to verify per-conversation
+// isolation: every preferred_strict is a checked-out task that
+// covered the call; every preferred_mismatch_blocked is the new
+// block class that would have been a cross-conversation leak before
+// this fix.
+func TestClassifyTaskScopePath_FromFacts(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name        string
+		factOutcome string
+		preferred   string
+		want        string
+	}{
+		{
+			name:        "preferred set, scope allow -> preferred_strict",
+			factOutcome: string(runtimedecision.SourceTaskScope),
+			preferred:   "task-1",
+			want:        "preferred_strict",
+		},
+		{
+			name:        "no preferred, scope allow -> no_preferred_fallback",
+			factOutcome: string(runtimedecision.SourceTaskScope),
+			preferred:   "",
+			want:        "no_preferred_fallback",
+		},
+		{
+			name:        "preferred set, mismatch source -> preferred_mismatch_blocked",
+			factOutcome: string(runtimedecision.SourceTaskScopeMismatchPreferred),
+			preferred:   "task-1",
+			want:        "preferred_mismatch_blocked",
+		},
+		{
+			name:        "rule allow source -> empty (not a scope decision)",
+			factOutcome: string(runtimedecision.SourceRuleAllow),
+			preferred:   "task-1",
+			want:        "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			facts := []conversation.EvaluationFact{
+				conversation.AuthorizationFact{Outcome: tc.factOutcome},
+			}
+			if got := classifyTaskScopePath(facts, tc.preferred); got != tc.want {
+				t.Errorf("classifyTaskScopePath outcome=%q preferred=%q = %q, want %q",
+					tc.factOutcome, tc.preferred, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestClassifyTaskScopePathFromSource mirrors the from-facts cases
+// against the inline-string variant used by the legacy resolver.
+func TestClassifyTaskScopePathFromSource(t *testing.T) {
+	t.Parallel()
+	if got := classifyTaskScopePathFromSource(string(runtimedecision.SourceTaskScope), "task-1"); got != "preferred_strict" {
+		t.Errorf("preferred + scope allow: got %q, want preferred_strict", got)
+	}
+	if got := classifyTaskScopePathFromSource(string(runtimedecision.SourceTaskScope), ""); got != "no_preferred_fallback" {
+		t.Errorf("no preferred + scope allow: got %q, want no_preferred_fallback", got)
+	}
+	if got := classifyTaskScopePathFromSource(string(runtimedecision.SourceTaskScopeMismatchPreferred), "task-1"); got != "preferred_mismatch_blocked" {
+		t.Errorf("mismatch: got %q, want preferred_mismatch_blocked", got)
+	}
+	if got := classifyTaskScopePathFromSource(string(runtimedecision.SourceRuleAllow), "task-1"); got != "" {
+		t.Errorf("rule allow: got %q, want empty (not a scope decision)", got)
+	}
+}

--- a/internal/runtime/llmproxy/pipelineeval/factory.go
+++ b/internal/runtime/llmproxy/pipelineeval/factory.go
@@ -117,10 +117,11 @@ var Factory llmproxy.ToolUseEvaluatorFactory = func(
 		// investigable row.
 		for _, tu := range toolUses {
 			emit(conversation.AuditEvent{
-				ToolUse:     tu,
-				Decision:    conversation.DecisionBlock,
-				OutcomeName: "pipeline_error",
-				Reason:      err.Error(),
+				ToolUse:         tu,
+				Decision:        conversation.DecisionBlock,
+				OutcomeName:     "pipeline_error",
+				Reason:          err.Error(),
+				PreferredTaskID: cfg.AuthorizationContext.PreferredTaskID,
 			})
 		}
 		errMsg := policies.ModelSafeInternalReason("authorization pipeline")
@@ -135,7 +136,7 @@ var Factory llmproxy.ToolUseEvaluatorFactory = func(
 	for _, tu := range toolUses {
 		matchedTaskIDs[tu.ID] = lookupMatchedTaskID(ctx, cfg.AgentContext, cfg.AuthorizationContext, cfg.RewriteContext, tu)
 	}
-	emitAuditEvents(ctx, result, toolUses, cfg.Inspector, matchedTaskIDs, emit)
+	emitAuditEvents(ctx, result, toolUses, cfg.Inspector, matchedTaskIDs, cfg.AuthorizationContext.PreferredTaskID, emit)
 	return evalFn
 }
 
@@ -154,6 +155,7 @@ func emitAuditEvents(
 	toolUses []conversation.ToolUse,
 	insp *inspector.Inspector,
 	matchedTaskIDs map[string]string,
+	preferredTaskID string,
 	emit func(conversation.AuditEvent),
 ) {
 	if result == nil || emit == nil {
@@ -211,8 +213,50 @@ func emitAuditEvents(
 				out.TaskID = id
 			}
 		}
+		out.PreferredTaskID = preferredTaskID
+		out.TaskScopePath = classifyTaskScopePath(factsByTU[ev.ToolUse.ID], preferredTaskID)
 		emit(out)
 	}
+}
+
+// classifyTaskScopePath maps the chain's AuthorizationFact (which
+// carries the decision-engine Source string) onto the audit row's
+// `task_scope_path` enum. Returns "" when the row never reached
+// task-scope evaluation (e.g. ruled by a runtime policy rule), so the
+// audit row stays sparse for non-scope-relevant calls.
+//
+// The enum lets operators query per-conversation isolation directly:
+// every `preferred_strict` is a checked-out task that covered the
+// call; every `preferred_mismatch_blocked` is the new block class that
+// would have been a cross-conversation leak before this fix.
+func classifyTaskScopePath(facts []conversation.EvaluationFact, preferredTaskID string) string {
+	for _, fact := range facts {
+		af, ok := fact.(conversation.AuthorizationFact)
+		if !ok {
+			continue
+		}
+		if path := classifyTaskScopePathFromSource(af.Outcome, preferredTaskID); path != "" {
+			return path
+		}
+	}
+	return ""
+}
+
+// classifyTaskScopePathFromSource is the inline-string variant used by
+// the credentialed legacy resolver, where the decision-engine Source
+// is already a flat string in the audit callback's `outcome` parameter
+// instead of an AuthorizationFact inside the typed fact slice.
+func classifyTaskScopePathFromSource(source string, preferredTaskID string) string {
+	switch source {
+	case string(runtimedecision.SourceTaskScopeMismatchPreferred):
+		return "preferred_mismatch_blocked"
+	case string(runtimedecision.SourceTaskScope):
+		if preferredTaskID != "" {
+			return "preferred_strict"
+		}
+		return "no_preferred_fallback"
+	}
+	return ""
 }
 
 // multiToolUseResponse is the pipeline ReadOnlyResponse the
@@ -254,7 +298,7 @@ func lookupMatchedTaskID(ctx context.Context, agent llmproxy.AgentContext, auth 
 		if auth.TaskScope == nil || serviceID == "" || actionID == "" {
 			return ""
 		}
-		dec := auth.TaskScope.Check(ctx, agent.AgentUserID, agent.AgentID, serviceID, actionID)
+		dec := auth.TaskScope.Check(ctx, agent.AgentUserID, agent.AgentID, serviceID, actionID, auth.PreferredTaskID)
 		return dec.TaskID
 	}
 	decisionInput := runtimedecision.AuthorizationInput{
@@ -300,6 +344,7 @@ func buildControlResolver(
 	}
 	controlBaseURL := routing.ControlBaseURL
 	agentID := agent.AgentID
+	conversationID := audit.ConversationID
 	cache := rewrite.CallerNonces
 	interceptCfg := llmproxy.PostprocessConfig{
 		AgentContext:         agent,
@@ -313,6 +358,7 @@ func buildControlResolver(
 		return &policies.ControlToolUseInputs{
 			ControlBaseURL: controlBaseURL,
 			AgentID:        agentID,
+			ConversationID: conversationID,
 			CallerNonces:   cache,
 			InterceptInline: func(_ context.Context, tu conversation.ToolUse, call controltool.ControlCall) (pipeline.ToolUseVerdict, bool) {
 				auditFn := func(decision, outcome, reason string) {
@@ -715,6 +761,8 @@ func buildCredentialedTaskScope(
 				OutcomeName:      outcome,
 				Reason:           reason,
 				TaskID:           taskID,
+				PreferredTaskID:  auth.PreferredTaskID,
+				TaskScopePath:    classifyTaskScopePathFromSource(outcome, auth.PreferredTaskID),
 			})
 		}
 		// Scope-drift pre-clear: if the agent is retrying a tool_use the
@@ -754,7 +802,7 @@ func buildCredentialedTaskScope(
 				audit("block", "unresolved_action", "credentialed target not found in catalog", "")
 				return policies.TaskScopeDecision{Kind: policies.TaskScopeDecisionDeny, Reason: "Clawvisor: credentialed target could not be resolved"}
 			}
-			dec := auth.TaskScope.Check(ctx, agent.AgentUserID, agent.AgentID, resolved.ServiceID, resolved.ActionID)
+			dec := auth.TaskScope.Check(ctx, agent.AgentUserID, agent.AgentID, resolved.ServiceID, resolved.ActionID, auth.PreferredTaskID)
 			if !dec.Allowed {
 				// Route the legacy denial through the scope-drift menu
 				// ONLY when the reason is a genuine scope miss

--- a/internal/runtime/llmproxy/pipelineeval/scope_drift.go
+++ b/internal/runtime/llmproxy/pipelineeval/scope_drift.go
@@ -69,6 +69,14 @@ func (c *scopeDriftCoordinator) AppliesToSource(source runtimedecision.DecisionS
 	case runtimedecision.SourceTaskScopeMissing, runtimedecision.SourceTaskScopeAmbiguous, runtimedecision.SourceIntentRefusal:
 		return true
 	}
+	// SourceTaskScopeMismatchPreferred deliberately does NOT route through
+	// the drift menu. The brief calls for a hard block; the agent must
+	// recover via the existing re-checkout / task_expand paths rather than
+	// be offered a fresh one-off/expand/new_task substitution. Routing
+	// mismatch-preferred through here caused a runaway loop in
+	// script_session fanouts where every call minted a drift, the agent
+	// picked an option, pre-cleared, retried, mismatched again, and
+	// minted another drift.
 	return false
 }
 

--- a/internal/runtime/llmproxy/pipelineeval/scope_drift_test.go
+++ b/internal/runtime/llmproxy/pipelineeval/scope_drift_test.go
@@ -24,6 +24,12 @@ func TestAppliesToSource_CoversScopeDriftAndIntentRefusal(t *testing.T) {
 	}{
 		{runtimedecision.SourceTaskScopeMissing, true},
 		{runtimedecision.SourceTaskScopeAmbiguous, true},
+		// Preferred-task mismatch deliberately does NOT route through
+		// the drift menu. It's a per-conversation isolation block; the
+		// agent recovers via the existing re-checkout / task_expand
+		// paths, not via a fresh drift substitution. Routing it through
+		// here caused script_session fanouts to loop on every call.
+		{runtimedecision.SourceTaskScopeMismatchPreferred, false},
 		{runtimedecision.SourceIntentRefusal, true},
 		// Layer 2 rule-based — not scope drift.
 		{runtimedecision.SourceRuleAllow, false},

--- a/internal/runtime/llmproxy/policies/control_tool_use_evaluator.go
+++ b/internal/runtime/llmproxy/policies/control_tool_use_evaluator.go
@@ -38,6 +38,15 @@ type ControlToolUseInputs struct {
 	// CallerNonces mints + consumes the per-call nonces the rewritten
 	// URL embeds in X-Clawvisor-Caller.
 	CallerNonces callernonce.CallerNonceCache
+	// ConversationID is the per-turn conversation id resolved from the
+	// inbound /v1/messages request. When non-empty it is injected into
+	// the rewritten tool_use as an X-Clawvisor-Conversation-ID header so
+	// the control plane handlers can scope side effects (e.g. task
+	// checkouts) to the correct conversation. Empty disables the
+	// injection — the control handler will fall back to refusing
+	// scope-bearing operations rather than landing them in a shared
+	// bucket.
+	ConversationID string
 	// InterceptInline, when non-nil, handles inline task-definition
 	// interception (model emits POST /api/control/tasks while the user
 	// is mid-flight on a "task" gesture). Returns a verdict + true when
@@ -120,7 +129,7 @@ func (e *ControlToolUseEvaluator) rewriteControlCall(ctx context.Context, tu con
 			Facts:   []pipeline.EvaluationFact{pipeline.ControlFact{Outcome: "caller_nonce_mint_failed"}},
 		}, nil
 	}
-	rewritten, _, rewriteOK, rewriteErr := controltool.RewriteControlToolUse(tu, in.ControlBaseURL, nonce)
+	rewritten, _, rewriteOK, rewriteErr := controltool.RewriteControlToolUse(tu, in.ControlBaseURL, nonce, in.ConversationID)
 	if !rewriteOK {
 		_, _ = in.CallerNonces.Consume(ctx, nonce, target)
 		return pipeline.ToolUseVerdict{

--- a/internal/runtime/llmproxy/postproc/taskscope_test.go
+++ b/internal/runtime/llmproxy/postproc/taskscope_test.go
@@ -57,7 +57,7 @@ func TestStoreTaskScopeChecker_AllowsMatchingAction(t *testing.T) {
 		{Service: "github", Action: "create_issue"},
 	})
 	c := llmproxy.NewStoreTaskScopeChecker(st)
-	dec := c.Check(context.Background(), user.ID, agent.ID, "github", "create_issue")
+	dec := c.Check(context.Background(), user.ID, agent.ID, "github", "create_issue", "")
 	if !dec.Allowed {
 		t.Errorf("expected allow, got %+v", dec)
 	}
@@ -72,7 +72,7 @@ func TestStoreTaskScopeChecker_DeniesUnauthorizedAction(t *testing.T) {
 		{Service: "github", Action: "list_issues"},
 	})
 	c := llmproxy.NewStoreTaskScopeChecker(st)
-	dec := c.Check(context.Background(), user.ID, agent.ID, "github", "create_issue")
+	dec := c.Check(context.Background(), user.ID, agent.ID, "github", "create_issue", "")
 	if dec.Allowed {
 		t.Errorf("expected deny — task only authorizes list_issues, got %+v", dec)
 	}
@@ -84,7 +84,7 @@ func TestStoreTaskScopeChecker_DeniesUnauthorizedAction(t *testing.T) {
 func TestStoreTaskScopeChecker_NoActiveTask(t *testing.T) {
 	st, user, agent := newTaskscopeStore(t)
 	c := llmproxy.NewStoreTaskScopeChecker(st)
-	dec := c.Check(context.Background(), user.ID, agent.ID, "github", "create_issue")
+	dec := c.Check(context.Background(), user.ID, agent.ID, "github", "create_issue", "")
 	if dec.Allowed {
 		t.Errorf("expected deny when no active task, got %+v", dec)
 	}
@@ -99,7 +99,7 @@ func TestStoreTaskScopeChecker_WildcardActionMatches(t *testing.T) {
 		{Service: "github", Action: "*"},
 	})
 	c := llmproxy.NewStoreTaskScopeChecker(st)
-	dec := c.Check(context.Background(), user.ID, agent.ID, "github", "delete_repo")
+	dec := c.Check(context.Background(), user.ID, agent.ID, "github", "delete_repo", "")
 	if !dec.Allowed {
 		t.Errorf("expected wildcard match, got %+v", dec)
 	}
@@ -108,7 +108,7 @@ func TestStoreTaskScopeChecker_WildcardActionMatches(t *testing.T) {
 func TestStoreTaskScopeChecker_RejectsUnresolvedAction(t *testing.T) {
 	st, user, agent := newTaskscopeStore(t)
 	c := llmproxy.NewStoreTaskScopeChecker(st)
-	dec := c.Check(context.Background(), user.ID, agent.ID, "", "")
+	dec := c.Check(context.Background(), user.ID, agent.ID, "", "", "")
 	if dec.Allowed {
 		t.Errorf("expected deny on empty service/action")
 	}
@@ -130,7 +130,7 @@ func (s stubCatalog) Resolve(host, method, path string) (llmproxy.ResolvedAction
 // stubTaskScope returns a fixed decision for every Check call.
 type stubTaskScope struct{ decision llmproxy.TaskScopeDecision }
 
-func (s stubTaskScope) Check(ctx context.Context, userID, agentID, serviceID, actionID string) llmproxy.TaskScopeDecision {
+func (s stubTaskScope) Check(ctx context.Context, userID, agentID, serviceID, actionID, preferredTaskID string) llmproxy.TaskScopeDecision {
 	return s.decision
 }
 

--- a/internal/runtime/llmproxy/taskcheckout/task_checkout.go
+++ b/internal/runtime/llmproxy/taskcheckout/task_checkout.go
@@ -2,20 +2,31 @@ package taskcheckout
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 )
 
-// Key scopes the agent's current task focus. This is deliberately
-// an authorization hint only: decision logic must still verify the checked-out
-// task is a valid candidate for the concrete tool/API call.
+// ErrConversationIDRequired is returned by Set when the key has an
+// empty ConversationID. The store refuses to write a checkout under a
+// user+agent shape that isn't pinned to a specific conversation,
+// because such a checkout would be visible to every concurrent
+// conversation belonging to the same agent — exactly the cross-task
+// leak this package's per-conversation key shape exists to prevent.
+var ErrConversationIDRequired = errors.New("task checkout requires a conversation id")
+
+// Key scopes the agent's current task focus. This is deliberately an
+// authorization hint only: decision logic must still verify the
+// checked-out task is a valid candidate for the concrete tool/API call.
 //
-// ConversationID partitions focus across conversations sharing a Clawvisor
-// token (Conductor workspaces, sub-agents, multiple Claude Code sessions in
-// the same installation). Approving a task in conversation B no longer
-// overwrites conversation A's focus. Empty ConversationID falls back to the
-// pre-conversation-scoping key shape (user+agent only), matching old clients
-// that never surfaced a session identifier on the wire.
+// ConversationID partitions focus across conversations sharing a
+// Clawvisor token (Conductor workspaces, sub-agents, multiple Claude
+// Code sessions in the same installation). It is REQUIRED: a Set with
+// an empty ConversationID returns ErrConversationIDRequired, and a Get
+// with an empty ConversationID returns not-found. The earlier
+// pre-conversation-scoping fallback (writing/reading a shared
+// (user, agent) bucket) was removed because it let approvals from one
+// conversation silently authorize tool calls from another.
 type Key struct {
 	UserID         string
 	AgentID        string
@@ -57,6 +68,9 @@ func (s *MemoryStore) Set(_ context.Context, key Key, taskID string, ttl time.Du
 	if key.UserID == "" || key.AgentID == "" || taskID == "" {
 		return nil
 	}
+	if key.ConversationID == "" {
+		return ErrConversationIDRequired
+	}
 	if ttl <= 0 {
 		ttl = s.defaultTTL
 	}
@@ -73,7 +87,7 @@ func (s *MemoryStore) Set(_ context.Context, key Key, taskID string, ttl time.Du
 }
 
 func (s *MemoryStore) Get(_ context.Context, key Key) (Checkout, bool, error) {
-	if key.UserID == "" || key.AgentID == "" {
+	if key.UserID == "" || key.AgentID == "" || key.ConversationID == "" {
 		return Checkout{}, false, nil
 	}
 	now := time.Now().UTC()

--- a/internal/runtime/llmproxy/taskcheckout/task_checkout_redis.go
+++ b/internal/runtime/llmproxy/taskcheckout/task_checkout_redis.go
@@ -30,6 +30,9 @@ func (s *RedisStore) Set(ctx context.Context, key Key, taskID string, ttl time.D
 	if s == nil || s.rdb == nil || key.UserID == "" || key.AgentID == "" || taskID == "" {
 		return nil
 	}
+	if key.ConversationID == "" {
+		return ErrConversationIDRequired
+	}
 	if ttl <= 0 {
 		ttl = s.defaultTTL
 	}
@@ -47,7 +50,7 @@ func (s *RedisStore) Set(ctx context.Context, key Key, taskID string, ttl time.D
 }
 
 func (s *RedisStore) Get(ctx context.Context, key Key) (Checkout, bool, error) {
-	if s == nil || s.rdb == nil || key.UserID == "" || key.AgentID == "" {
+	if s == nil || s.rdb == nil || key.UserID == "" || key.AgentID == "" || key.ConversationID == "" {
 		return Checkout{}, false, nil
 	}
 	raw, err := s.rdb.Get(ctx, redisKey(key)).Bytes()
@@ -69,21 +72,20 @@ func (s *RedisStore) Get(ctx context.Context, key Key) (Checkout, bool, error) {
 }
 
 func (s *RedisStore) Clear(ctx context.Context, key Key) error {
-	if s == nil || s.rdb == nil || key.UserID == "" || key.AgentID == "" {
+	if s == nil || s.rdb == nil || key.UserID == "" || key.AgentID == "" || key.ConversationID == "" {
 		return nil
 	}
 	return s.rdb.Del(ctx, redisKey(key)).Err()
 }
 
 func redisKey(key Key) string {
-	// ConversationID partitions focus per-conversation. When empty, we
-	// hash the legacy (user, agent) shape unchanged so existing redis
-	// entries from pre-conversation-scoping clients remain readable —
-	// no migration required, no silent loss of focus on upgrade.
-	if key.ConversationID == "" {
-		sum := sha256.Sum256([]byte(key.UserID + "\x00" + key.AgentID))
-		return redisTaskCheckoutPrefix + hex.EncodeToString(sum[:])
-	}
+	// ConversationID is required at the Store layer (Set returns
+	// ErrConversationIDRequired and Get returns not-found when it's
+	// empty), so we only ever reach this function with a non-empty
+	// ConversationID. Hashing it into the key partitions focus
+	// per-conversation, which is the invariant that prevents one
+	// conversation's checkout from authorizing another conversation's
+	// tool calls.
 	sum := sha256.Sum256([]byte(key.UserID + "\x00" + key.AgentID + "\x00" + key.ConversationID))
 	return redisTaskCheckoutPrefix + hex.EncodeToString(sum[:])
 }

--- a/internal/runtime/llmproxy/taskcheckout/task_checkout_test.go
+++ b/internal/runtime/llmproxy/taskcheckout/task_checkout_test.go
@@ -1,0 +1,58 @@
+package taskcheckout
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// TestMemoryStore_RequiresConversationID pins the per-conversation
+// isolation invariant at the storage layer: an empty ConversationID
+// is refused on Set and returns not-found on Get, with no fallback to
+// a shared (user, agent) bucket. The pre-strict behavior of silently
+// writing to that bucket was the cross-conversation scope leak the
+// fix targets.
+func TestMemoryStore_RequiresConversationID(t *testing.T) {
+	t.Parallel()
+	store := NewMemoryStore(time.Hour)
+	ctx := context.Background()
+
+	t.Run("Set without ConversationID returns ErrConversationIDRequired", func(t *testing.T) {
+		err := store.Set(ctx, Key{UserID: "u", AgentID: "a"}, "task-1", time.Hour)
+		if !errors.Is(err, ErrConversationIDRequired) {
+			t.Fatalf("Set without CID: err=%v, want ErrConversationIDRequired", err)
+		}
+	})
+
+	t.Run("Get without ConversationID returns not-found", func(t *testing.T) {
+		_, ok, err := store.Get(ctx, Key{UserID: "u", AgentID: "a"})
+		if err != nil {
+			t.Fatalf("Get without CID: err=%v, want nil", err)
+		}
+		if ok {
+			t.Fatalf("Get without CID returned ok=true; want false (no legacy fallback)")
+		}
+	})
+
+	t.Run("Set with ConversationID succeeds", func(t *testing.T) {
+		err := store.Set(ctx, Key{UserID: "u", AgentID: "a", ConversationID: "conv-A"}, "task-1", time.Hour)
+		if err != nil {
+			t.Fatalf("Set with CID: %v", err)
+		}
+	})
+
+	t.Run("Get with conv-A round-trips; sibling Get with conv-B sees nothing", func(t *testing.T) {
+		got, ok, err := store.Get(ctx, Key{UserID: "u", AgentID: "a", ConversationID: "conv-A"})
+		if err != nil || !ok || got.TaskID != "task-1" {
+			t.Fatalf("Get conv-A: got=%+v ok=%v err=%v, want task-1", got, ok, err)
+		}
+		got, ok, err = store.Get(ctx, Key{UserID: "u", AgentID: "a", ConversationID: "conv-B"})
+		if err != nil {
+			t.Fatalf("Get conv-B: err=%v", err)
+		}
+		if ok {
+			t.Fatalf("sibling conv-B saw conv-A's checkout (leak): %+v", got)
+		}
+	})
+}

--- a/internal/runtime/llmproxy/taskscope.go
+++ b/internal/runtime/llmproxy/taskscope.go
@@ -42,8 +42,16 @@ type TaskScopeDecision struct {
 // the inspector classifies a tool_use as an API call and BoundaryCheck
 // confirms the host. A denied scope check is a hard refusal — the response
 // is rewritten to a Clawvisor refusal rather than passing through.
+//
+// preferredTaskID is the conversation's checked-out task focus. When
+// non-empty, the check is strictly scoped to that task: if the preferred
+// task doesn't cover (serviceID, actionID), the result is a deny with
+// Reason "needs_new_task" rather than a silent match against a sibling
+// task the same agent happens to own. Pass "" when no checkout has been
+// resolved (brand-new conversation) to retain the original full-pool
+// match path.
 type TaskScopeChecker interface {
-	Check(ctx context.Context, userID, agentID, serviceID, actionID string) TaskScopeDecision
+	Check(ctx context.Context, userID, agentID, serviceID, actionID, preferredTaskID string) TaskScopeDecision
 }
 
 // StoreTaskScopeChecker reads tasks from the store and runs the same
@@ -64,7 +72,7 @@ func NewStoreTaskScopeChecker(s store.Store) *StoreTaskScopeChecker {
 //   - active task(s) cover the action: Allowed=true with TaskID.
 //   - active task(s) exist but none cover the action: Allowed=false,
 //     Reason="needs_new_task" — caller can route to approval flow.
-func (c *StoreTaskScopeChecker) Check(ctx context.Context, userID, agentID, serviceID, actionID string) TaskScopeDecision {
+func (c *StoreTaskScopeChecker) Check(ctx context.Context, userID, agentID, serviceID, actionID, preferredTaskID string) TaskScopeDecision {
 	if c == nil || c.store == nil {
 		return TaskScopeDecision{Reason: "no_task_store_configured"}
 	}
@@ -83,7 +91,7 @@ func (c *StoreTaskScopeChecker) Check(ctx context.Context, userID, agentID, serv
 		// daemon's slog output for the underlying error text.
 		return TaskScopeDecision{Reason: "task_store_unavailable"}
 	}
-	classification := policy.ClassifyGatewayRequest(tasks, agentID, serviceID, "", actionID)
+	classification := policy.ClassifyGatewayRequestPreferred(tasks, agentID, serviceID, "", actionID, preferredTaskID)
 	return classifyToDecision(classification, serviceID, actionID)
 }
 

--- a/internal/runtime/policy/request_classify.go
+++ b/internal/runtime/policy/request_classify.go
@@ -55,6 +55,17 @@ func ClassifyGatewayRequestPreferred(tasks []*store.Task, agentID, serviceType, 
 	}
 
 	if preferredTaskID != "" {
+		// Strict mode: every code path here MUST either match the
+		// preferred task or return NeedsNewTask. Falling through to
+		// the candidate-pool match below would let a sibling task
+		// silently authorize the call — the exact cross-conversation
+		// leak this isolation fix exists to prevent. That includes the
+		// stale-checkout case (preferred id supplied but no active task
+		// with that id), which used to fall through under the
+		// rationale "it's just a dangling pointer." Cubic flagged that
+		// rationale as a leak window: a checked-out task that expired
+		// mid-conversation should not implicitly switch the
+		// authorization target.
 		for _, task := range candidates {
 			if task.ID != preferredTaskID {
 				continue
@@ -65,22 +76,15 @@ func ClassifyGatewayRequestPreferred(tasks []*store.Task, agentID, serviceType, 
 					MatchedTask: task,
 				}
 			}
-			// Preferred task is active for this agent but doesn't
-			// cover the action. Surface the full candidate set so the
-			// caller can render a "switch task" menu, but DO NOT silently
-			// match a different task.
-			if len(candidates) > 0 {
-				return GatewayRequestClassification{
-					Kind:           ClassificationNeedsNewTask,
-					CandidateTasks: candidates,
-				}
-			}
-			return GatewayRequestClassification{Kind: ClassificationOneOff}
+			break
 		}
-		// Preferred task id was supplied but no active task with that id
-		// exists for this agent (stale checkout, expired task, etc.).
-		// Fall through to the normal candidate-pool path: this isn't a
-		// scope leak — the preferred id is simply not a valid pointer.
+		if len(candidates) > 0 {
+			return GatewayRequestClassification{
+				Kind:           ClassificationNeedsNewTask,
+				CandidateTasks: candidates,
+			}
+		}
+		return GatewayRequestClassification{Kind: ClassificationOneOff}
 	}
 
 	inScope := make([]*store.Task, 0, len(candidates))

--- a/internal/runtime/policy/request_classify.go
+++ b/internal/runtime/policy/request_classify.go
@@ -78,13 +78,18 @@ func ClassifyGatewayRequestPreferred(tasks []*store.Task, agentID, serviceType, 
 			}
 			break
 		}
-		if len(candidates) > 0 {
-			return GatewayRequestClassification{
-				Kind:           ClassificationNeedsNewTask,
-				CandidateTasks: candidates,
-			}
+		// Any non-empty preferredTaskID that doesn't resolve to a
+		// covering active task → NeedsNewTask. CandidateTasks may be
+		// empty when the agent's other active tasks have all expired,
+		// but the kind must still be NeedsNewTask (not OneOff): the
+		// conversation HAD a checkout, so this isn't a brand-new
+		// agent. OneOff would be semantically wrong and would
+		// indicate to the audit row that no checkout had ever been
+		// recorded, defeating per-conversation isolation telemetry.
+		return GatewayRequestClassification{
+			Kind:           ClassificationNeedsNewTask,
+			CandidateTasks: candidates,
 		}
-		return GatewayRequestClassification{Kind: ClassificationOneOff}
 	}
 
 	inScope := make([]*store.Task, 0, len(candidates))

--- a/internal/runtime/policy/request_classify.go
+++ b/internal/runtime/policy/request_classify.go
@@ -36,6 +36,15 @@ func ClassifyGatewayRequest(tasks []*store.Task, agentID, serviceType, alias, ac
 	return ClassifyGatewayRequestPreferred(tasks, agentID, serviceType, alias, action, "")
 }
 
+// ClassifyGatewayRequestPreferred picks the active task whose
+// authorized_actions covers (serviceType/alias, action). When
+// preferredTaskID is non-empty, classification is strictly scoped to
+// that task: if the preferred task doesn't cover the action, the
+// result is ClassificationNeedsNewTask (with the agent's other active
+// tasks reported as candidates so the menu UI can still offer them
+// for explicit re-checkout / expand) — NOT a silent match against a
+// sibling task. This enforces per-conversation isolation when the
+// caller has resolved a checked-out task.
 func ClassifyGatewayRequestPreferred(tasks []*store.Task, agentID, serviceType, alias, action, preferredTaskID string) GatewayRequestClassification {
 	candidates := make([]*store.Task, 0, len(tasks))
 	for _, task := range tasks {
@@ -43,6 +52,35 @@ func ClassifyGatewayRequestPreferred(tasks []*store.Task, agentID, serviceType, 
 			continue
 		}
 		candidates = append(candidates, task)
+	}
+
+	if preferredTaskID != "" {
+		for _, task := range candidates {
+			if task.ID != preferredTaskID {
+				continue
+			}
+			if matchTaskScope(task, serviceType, alias, action) {
+				return GatewayRequestClassification{
+					Kind:        ClassificationBelongsToExistingTask,
+					MatchedTask: task,
+				}
+			}
+			// Preferred task is active for this agent but doesn't
+			// cover the action. Surface the full candidate set so the
+			// caller can render a "switch task" menu, but DO NOT silently
+			// match a different task.
+			if len(candidates) > 0 {
+				return GatewayRequestClassification{
+					Kind:           ClassificationNeedsNewTask,
+					CandidateTasks: candidates,
+				}
+			}
+			return GatewayRequestClassification{Kind: ClassificationOneOff}
+		}
+		// Preferred task id was supplied but no active task with that id
+		// exists for this agent (stale checkout, expired task, etc.).
+		// Fall through to the normal candidate-pool path: this isn't a
+		// scope leak — the preferred id is simply not a valid pointer.
 	}
 
 	inScope := make([]*store.Task, 0, len(candidates))
@@ -67,14 +105,6 @@ func ClassifyGatewayRequestPreferred(tasks []*store.Task, agentID, serviceType, 
 			MatchedTask: inScope[0],
 		}
 	default:
-		for _, task := range inScope {
-			if preferredTaskID != "" && task.ID == preferredTaskID {
-				return GatewayRequestClassification{
-					Kind:        ClassificationBelongsToExistingTask,
-					MatchedTask: task,
-				}
-			}
-		}
 		return GatewayRequestClassification{
 			Kind:           ClassificationAmbiguous,
 			CandidateTasks: inScope,

--- a/internal/runtime/policy/request_classify_test.go
+++ b/internal/runtime/policy/request_classify_test.go
@@ -75,6 +75,23 @@ func TestClassifyGatewayRequestPreferredIsStrict(t *testing.T) {
 		}
 	})
 
+	t.Run("stale preferred id, no other active tasks -> needs_new_task (not one_off)", func(t *testing.T) {
+		// Conversation HAD a checkout (preferredTaskID is non-empty)
+		// but no active task with that id exists AND no siblings
+		// exist either. OneOff would semantically claim "brand-new
+		// agent with no checkout history" — wrong, and would break
+		// per-conversation isolation telemetry. Must be
+		// NeedsNewTask so the audit row records that scope was
+		// expected but missing.
+		got := ClassifyGatewayRequestPreferred(nil, "agent-1", "gmail", "", "fetch_messages", "task-vanished")
+		if got.Kind != ClassificationNeedsNewTask {
+			t.Fatalf("kind=%q, want %q (stale preferred + empty candidates must NOT be OneOff)", got.Kind, ClassificationNeedsNewTask)
+		}
+		if got.MatchedTask != nil {
+			t.Fatalf("matched task must be nil under stale-preferred strict mode, got %+v", got.MatchedTask)
+		}
+	})
+
 	t.Run("stale preferred id (no active task with that id) -> needs_new_task, NOT silent sibling match", func(t *testing.T) {
 		// Preferred id doesn't point at any active task — e.g. the
 		// checked-out task expired mid-conversation. The pre-fix

--- a/internal/runtime/policy/request_classify_test.go
+++ b/internal/runtime/policy/request_classify_test.go
@@ -75,17 +75,23 @@ func TestClassifyGatewayRequestPreferredIsStrict(t *testing.T) {
 		}
 	})
 
-	t.Run("stale preferred id (no active task with that id) -> normal full-pool path", func(t *testing.T) {
+	t.Run("stale preferred id (no active task with that id) -> needs_new_task, NOT silent sibling match", func(t *testing.T) {
 		// Preferred id doesn't point at any active task — e.g. the
-		// task expired but the checkout pointer is stale. This is not
-		// a leak; fall through to the standard candidate-pool match.
+		// checked-out task expired mid-conversation. The pre-fix
+		// behavior here was to fall through to the full-pool match,
+		// which would silently authorize the call against an unrelated
+		// sibling task and is exactly the cross-conversation leak the
+		// per-conversation isolation invariant exists to prevent.
+		// Strict mode: return NeedsNewTask so the agent must explicitly
+		// re-checkout (or have the proxy mint a fresh task) rather
+		// than implicitly switching authorization target.
 		oneSibling := []*store.Task{sibling1}
 		got := ClassifyGatewayRequestPreferred(oneSibling, "agent-1", "gmail", "", "fetch_messages", "task-vanished")
-		if got.Kind != ClassificationBelongsToExistingTask {
-			t.Fatalf("kind=%q, want %q (stale preferred should fall through)", got.Kind, ClassificationBelongsToExistingTask)
+		if got.Kind != ClassificationNeedsNewTask {
+			t.Fatalf("kind=%q, want %q (stale preferred must not silently match a sibling)", got.Kind, ClassificationNeedsNewTask)
 		}
-		if got.MatchedTask == nil || got.MatchedTask.ID != "task-sibling-1" {
-			t.Fatalf("matched task=%+v, want task-sibling-1", got.MatchedTask)
+		if got.MatchedTask != nil {
+			t.Fatalf("matched task should be nil under stale-preferred strict mode, got %+v", got.MatchedTask)
 		}
 	})
 }

--- a/internal/runtime/policy/request_classify_test.go
+++ b/internal/runtime/policy/request_classify_test.go
@@ -1,0 +1,91 @@
+package policy
+
+import (
+	"testing"
+
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+// TestClassifyGatewayRequestPreferredIsStrict guards the
+// per-conversation isolation invariant for the gateway-style
+// classifier: when a checked-out task is supplied via preferredTaskID
+// and that task does NOT cover the requested action, the result must
+// be ClassificationNeedsNewTask (so the menu UI can offer a switch)
+// rather than a silent ClassificationBelongsToExistingTask against a
+// sibling task that happened to cover the action.
+func TestClassifyGatewayRequestPreferredIsStrict(t *testing.T) {
+	t.Parallel()
+
+	preferred := &store.Task{
+		ID:      "task-preferred",
+		AgentID: "agent-1",
+		Status:  "active",
+		AuthorizedActions: []store.TaskAction{
+			{Service: "gmail", Action: "send_message"},
+		},
+	}
+	sibling1 := &store.Task{
+		ID:      "task-sibling-1",
+		AgentID: "agent-1",
+		Status:  "active",
+		AuthorizedActions: []store.TaskAction{
+			{Service: "gmail", Action: "fetch_messages"},
+		},
+	}
+	sibling2 := &store.Task{
+		ID:      "task-sibling-2",
+		AgentID: "agent-1",
+		Status:  "active",
+		AuthorizedActions: []store.TaskAction{
+			{Service: "gmail", Action: "fetch_messages"},
+		},
+	}
+	tasks := []*store.Task{preferred, sibling1, sibling2}
+
+	t.Run("preferred covers action -> belongs_to_existing_task=preferred", func(t *testing.T) {
+		got := ClassifyGatewayRequestPreferred(tasks, "agent-1", "gmail", "", "send_message", "task-preferred")
+		if got.Kind != ClassificationBelongsToExistingTask {
+			t.Fatalf("kind=%q, want %q", got.Kind, ClassificationBelongsToExistingTask)
+		}
+		if got.MatchedTask == nil || got.MatchedTask.ID != "task-preferred" {
+			t.Fatalf("matched task=%+v, want task-preferred", got.MatchedTask)
+		}
+	})
+
+	t.Run("preferred does NOT cover, siblings WOULD -> needs_new_task (no leak)", func(t *testing.T) {
+		got := ClassifyGatewayRequestPreferred(tasks, "agent-1", "gmail", "", "fetch_messages", "task-preferred")
+		if got.Kind != ClassificationNeedsNewTask {
+			t.Fatalf("kind=%q, want %q — preferred-strict regression", got.Kind, ClassificationNeedsNewTask)
+		}
+		if got.MatchedTask != nil {
+			t.Fatalf("matched task should be nil under preferred-strict, got %+v", got.MatchedTask)
+		}
+		if len(got.CandidateTasks) == 0 {
+			t.Fatalf("expected candidate tasks surfaced for switch-task menu, got 0")
+		}
+	})
+
+	t.Run("no preferred id -> full pool match (ambiguous when two siblings cover)", func(t *testing.T) {
+		got := ClassifyGatewayRequestPreferred(tasks, "agent-1", "gmail", "", "fetch_messages", "")
+		if got.Kind != ClassificationAmbiguous {
+			t.Fatalf("kind=%q, want %q", got.Kind, ClassificationAmbiguous)
+		}
+		if len(got.CandidateTasks) != 2 {
+			t.Fatalf("candidates=%d, want 2", len(got.CandidateTasks))
+		}
+	})
+
+	t.Run("stale preferred id (no active task with that id) -> normal full-pool path", func(t *testing.T) {
+		// Preferred id doesn't point at any active task — e.g. the
+		// task expired but the checkout pointer is stale. This is not
+		// a leak; fall through to the standard candidate-pool match.
+		oneSibling := []*store.Task{sibling1}
+		got := ClassifyGatewayRequestPreferred(oneSibling, "agent-1", "gmail", "", "fetch_messages", "task-vanished")
+		if got.Kind != ClassificationBelongsToExistingTask {
+			t.Fatalf("kind=%q, want %q (stale preferred should fall through)", got.Kind, ClassificationBelongsToExistingTask)
+		}
+		if got.MatchedTask == nil || got.MatchedTask.ID != "task-sibling-1" {
+			t.Fatalf("matched task=%+v, want task-sibling-1", got.MatchedTask)
+		}
+	})
+}

--- a/internal/runtime/policy/task_match.go
+++ b/internal/runtime/policy/task_match.go
@@ -35,12 +35,16 @@ func MatchToolCall(tasks []*store.Task, toolName string, input map[string]any) (
 	return MatchToolCallPreferred(tasks, toolName, input, "")
 }
 
+// MatchToolCallPreferred picks the task whose expected_tools entry
+// covers the call. When preferredTaskID is non-empty the search is
+// strictly scoped to that task: if the preferred task doesn't cover
+// the call, the function returns (nil, nil) — it does NOT fall back
+// to other candidates. This is the per-conversation isolation
+// invariant the lite-proxy depends on. A bare MatchToolCall (no
+// preferred id) keeps the original full-pool best-scoring behavior.
 func MatchToolCallPreferred(tasks []*store.Task, toolName string, input map[string]any, preferredTaskID string) (*ToolMatch, error) {
 	if preferredTaskID != "" {
-		match, err := matchToolCallInTask(tasks, toolName, input, preferredTaskID)
-		if err != nil || match != nil {
-			return match, err
-		}
+		return matchToolCallInTask(tasks, toolName, input, preferredTaskID)
 	}
 	var best *ToolMatch
 	bestScore := -1
@@ -142,14 +146,15 @@ func MatchEgressRequest(tasks []*store.Task, req EgressRequest) (*EgressMatch, e
 	return MatchEgressRequestPreferred(tasks, req, "")
 }
 
+// MatchEgressRequestPreferred mirrors MatchToolCallPreferred for
+// egress requests: when preferredTaskID is non-empty the search is
+// strictly scoped to that task and there is no fallback to other
+// candidates on a miss.
 func MatchEgressRequestPreferred(tasks []*store.Task, req EgressRequest, preferredTaskID string) (*EgressMatch, error) {
 	host := strings.ToLower(req.Host)
 	method := strings.ToUpper(req.Method)
 	if preferredTaskID != "" {
-		match, err := matchEgressRequestInTask(tasks, req, host, method, preferredTaskID)
-		if err != nil || match != nil {
-			return match, err
-		}
+		return matchEgressRequestInTask(tasks, req, host, method, preferredTaskID)
 	}
 	var best *EgressMatch
 	bestScore := -1

--- a/internal/runtime/policy/task_match_test.go
+++ b/internal/runtime/policy/task_match_test.go
@@ -119,6 +119,124 @@ func TestMatchEgressRequestPrefersMoreSpecificCandidate(t *testing.T) {
 	}
 }
 
+// TestMatchToolCallPreferredIsStrict guards the per-conversation
+// isolation invariant: when a checked-out task is supplied via
+// preferredTaskID, the matcher must NOT fall back to a sibling task
+// that would otherwise cover the call. The pre-fix behavior was that
+// a tool call from conversation A whose preferred task didn't cover
+// the call would silently authorize against conversation B's task.
+func TestMatchToolCallPreferredIsStrict(t *testing.T) {
+	t.Parallel()
+
+	preferred := &store.Task{
+		ID:            "task-preferred",
+		SchemaVersion: 2,
+		ExpectedTools: []byte(`[
+			{"tool_name":"send_message","why":"draft replies"}
+		]`),
+	}
+	sibling1 := &store.Task{
+		ID:            "task-sibling-1",
+		SchemaVersion: 2,
+		ExpectedTools: []byte(`[
+			{"tool_name":"fetch_messages","why":"triage inbox"}
+		]`),
+	}
+	sibling2 := &store.Task{
+		ID:            "task-sibling-2",
+		SchemaVersion: 2,
+		ExpectedTools: []byte(`[
+			{"tool_name":"fetch_messages","why":"audit inbox"}
+		]`),
+	}
+	tasks := []*store.Task{preferred, sibling1, sibling2}
+
+	t.Run("preferred covers tool -> allow matched=preferred", func(t *testing.T) {
+		match, err := MatchToolCallPreferred(tasks, "send_message", map[string]any{}, "task-preferred")
+		if err != nil {
+			t.Fatalf("MatchToolCallPreferred: %v", err)
+		}
+		if match == nil || match.TaskID != "task-preferred" {
+			t.Fatalf("expected preferred task match, got %+v", match)
+		}
+	})
+
+	t.Run("preferred does NOT cover, siblings WOULD -> nil (no leak)", func(t *testing.T) {
+		match, err := MatchToolCallPreferred(tasks, "fetch_messages", map[string]any{}, "task-preferred")
+		if err != nil {
+			t.Fatalf("MatchToolCallPreferred: %v", err)
+		}
+		if match != nil {
+			t.Fatalf("expected no match (preferred-strict), got %+v — this is the leak regression", match)
+		}
+	})
+
+	t.Run("no preferred id -> full pool match unchanged", func(t *testing.T) {
+		match, err := MatchToolCallPreferred(tasks, "fetch_messages", map[string]any{}, "")
+		if err != nil {
+			t.Fatalf("MatchToolCallPreferred: %v", err)
+		}
+		if match == nil || (match.TaskID != "task-sibling-1" && match.TaskID != "task-sibling-2") {
+			t.Fatalf("expected a sibling match in no-preferred mode, got %+v", match)
+		}
+	})
+}
+
+// TestMatchEgressRequestPreferredIsStrict mirrors the tool-call
+// invariant for egress requests.
+func TestMatchEgressRequestPreferredIsStrict(t *testing.T) {
+	t.Parallel()
+
+	preferred := &store.Task{
+		ID:            "task-preferred",
+		SchemaVersion: 2,
+		ExpectedEgress: []byte(`[
+			{"host":"api.example.com","why":"send messages","method":"POST","path":"/v1/send"}
+		]`),
+	}
+	sibling := &store.Task{
+		ID:            "task-sibling",
+		SchemaVersion: 2,
+		ExpectedEgress: []byte(`[
+			{"host":"api.example.com","why":"read messages","method":"GET","path":"/v1/messages"}
+		]`),
+	}
+	tasks := []*store.Task{preferred, sibling}
+	readReq := EgressRequest{Host: "api.example.com", Method: "GET", Path: "/v1/messages"}
+
+	t.Run("preferred covers request -> allow", func(t *testing.T) {
+		match, err := MatchEgressRequestPreferred(tasks, EgressRequest{
+			Host: "api.example.com", Method: "POST", Path: "/v1/send",
+		}, "task-preferred")
+		if err != nil {
+			t.Fatalf("MatchEgressRequestPreferred: %v", err)
+		}
+		if match == nil || match.TaskID != "task-preferred" {
+			t.Fatalf("expected preferred task match, got %+v", match)
+		}
+	})
+
+	t.Run("preferred does NOT cover, sibling WOULD -> nil", func(t *testing.T) {
+		match, err := MatchEgressRequestPreferred(tasks, readReq, "task-preferred")
+		if err != nil {
+			t.Fatalf("MatchEgressRequestPreferred: %v", err)
+		}
+		if match != nil {
+			t.Fatalf("expected no match (preferred-strict), got %+v", match)
+		}
+	})
+
+	t.Run("no preferred id -> full pool match unchanged", func(t *testing.T) {
+		match, err := MatchEgressRequestPreferred(tasks, readReq, "")
+		if err != nil {
+			t.Fatalf("MatchEgressRequestPreferred: %v", err)
+		}
+		if match == nil || match.TaskID != "task-sibling" {
+			t.Fatalf("expected sibling match in no-preferred mode, got %+v", match)
+		}
+	})
+}
+
 func TestMatchRegexMapUsesFlattenedStructuredRepresentation(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/runtime/decision/decision.go
+++ b/pkg/runtime/decision/decision.go
@@ -55,13 +55,14 @@ const (
 type DecisionSource string
 
 const (
-	SourceRuleAllow          DecisionSource = "rule_allow"
-	SourceRuleDeny           DecisionSource = "rule_deny"
-	SourceRuleReview         DecisionSource = "rule_review"
-	SourceTaskScope          DecisionSource = "task_scope"
-	SourceTaskScopeMissing   DecisionSource = "task_scope_missing"
-	SourceTaskScopeAmbiguous DecisionSource = "task_scope_ambiguous"
-	SourceIntentRefusal      DecisionSource = "intent_refusal"
+	SourceRuleAllow                  DecisionSource = "rule_allow"
+	SourceRuleDeny                   DecisionSource = "rule_deny"
+	SourceRuleReview                 DecisionSource = "rule_review"
+	SourceTaskScope                  DecisionSource = "task_scope"
+	SourceTaskScopeMissing           DecisionSource = "task_scope_missing"
+	SourceTaskScopeAmbiguous         DecisionSource = "task_scope_ambiguous"
+	SourceTaskScopeMismatchPreferred DecisionSource = "task_scope_mismatch_preferred"
+	SourceIntentRefusal              DecisionSource = "intent_refusal"
 )
 
 type TargetRequest struct {
@@ -277,7 +278,22 @@ func EvaluateAuthorization(ctx context.Context, in AuthorizationInput) (Authoriz
 			Source: SourceTaskScopeMissing,
 		}, nil
 	}
-	return reviewDecision(posture, SourceTaskScopeMissing, "no matching task scope"), nil
+	source, reason := missingScopeOutcome(in)
+	return reviewDecision(posture, source, reason), nil
+}
+
+// missingScopeOutcome returns the (source, reason) pair to record
+// when no rule or task scope matched a tool call. When PreferredTaskID
+// is set the request came from a conversation that had checked out a
+// task, so a non-match means the checked-out task did not cover the
+// call — distinct from a brand-new conversation that simply has no
+// scope yet. The two are queryable separately via task_scope_path
+// (preferred_mismatch_blocked vs no_preferred_fallback).
+func missingScopeOutcome(in AuthorizationInput) (DecisionSource, string) {
+	if in.PreferredTaskID != "" {
+		return SourceTaskScopeMismatchPreferred, "checked-out task does not cover this tool call"
+	}
+	return SourceTaskScopeMissing, "no matching task scope"
 }
 
 func selectPolicyRules(in AuthorizationInput, toolInput map[string]any) (*store.RuntimePolicyRule, *store.RuntimePolicyRule, error) {
@@ -421,7 +437,8 @@ func evaluateServiceActionScope(ctx context.Context, in AuthorizationInput, post
 	case runtimepolicy.ClassificationAmbiguous:
 		return reviewDecision(posture, SourceTaskScopeAmbiguous, "ambiguous: multiple active tasks cover this action"), nil
 	default:
-		return reviewDecision(posture, SourceTaskScopeMissing, "no matching task scope"), nil
+		source, reason := missingScopeOutcome(in)
+		return reviewDecision(posture, source, reason), nil
 	}
 }
 

--- a/pkg/runtime/decision/decision_test.go
+++ b/pkg/runtime/decision/decision_test.go
@@ -330,7 +330,16 @@ func TestEvaluateAuthorization_PreferredTaskDisambiguatesServiceAction(t *testin
 	}
 }
 
-func TestEvaluateAuthorization_IgnoresPreferredTaskOutsideCandidateSet(t *testing.T) {
+// TestEvaluateAuthorization_StalePreferredBlocksInsteadOfSiblingMatch
+// pins per-conversation isolation against the stale-checkout case:
+// when PreferredTaskID points at a task that's no longer in the
+// active candidate set (expired, completed, never existed), the
+// pre-fix behavior fell through to the full-pool match and could
+// silently authorize the call via a SIBLING task that happened to
+// cover the action. Strict mode: blocks with
+// SourceTaskScopeMismatchPreferred so the agent must re-checkout
+// explicitly rather than implicitly switch authorization target.
+func TestEvaluateAuthorization_StalePreferredBlocksInsteadOfSiblingMatch(t *testing.T) {
 	got, err := EvaluateAuthorization(context.Background(), AuthorizationInput{
 		ToolUse:         toolUse("WebFetch", map[string]any{"url": "https://api.github.com/repos/acme/app/issues"}),
 		AgentID:         "agent-1",
@@ -342,8 +351,11 @@ func TestEvaluateAuthorization_IgnoresPreferredTaskOutsideCandidateSet(t *testin
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.Kind != VerdictNeedsApproval || got.Source != SourceTaskScopeAmbiguous {
-		t.Fatalf("decision = %+v, want ambiguity when preferred task is not a valid candidate", got)
+	if got.Kind != VerdictNeedsApproval || got.Source != SourceTaskScopeMismatchPreferred {
+		t.Fatalf("decision = %+v, want SourceTaskScopeMismatchPreferred (no silent sibling match)", got)
+	}
+	if got.Task != nil {
+		t.Fatalf("task = %+v, want nil (sibling MUST NOT authorize the call)", got.Task)
 	}
 }
 

--- a/pkg/runtime/decision/decision_test.go
+++ b/pkg/runtime/decision/decision_test.go
@@ -603,6 +603,56 @@ func TestEvaluateAuthorization_GenuineNoRationaleHarnessUsesSentinel(t *testing.
 	}
 }
 
+// TestEvaluateAuthorization_PreferredTaskMismatchBlocks pins the
+// per-conversation isolation invariant at the decision-engine layer:
+// when PreferredTaskID is set and the preferred task does not cover
+// the call, the verdict's Source must be SourceTaskScopeMismatchPreferred
+// rather than falling through to a sibling task. This is the
+// regression that was the original leak.
+func TestEvaluateAuthorization_PreferredTaskMismatchBlocks(t *testing.T) {
+	agentID := "agent-1"
+	preferred := taskWithExpectedTool("task-preferred", agentID, "exec_command", "preferred work")
+	sibling := taskWithExpectedTool("task-sibling", agentID, "read_file", "sibling work")
+	got, err := EvaluateAuthorization(context.Background(), AuthorizationInput{
+		ToolUse:         toolUse("read_file", map[string]any{"path": "/etc/hosts"}),
+		AgentID:         agentID,
+		CandidateTasks:  []*store.Task{preferred, sibling},
+		PreferredTaskID: "task-preferred",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Source != SourceTaskScopeMismatchPreferred {
+		t.Fatalf("source = %q, want %q (sibling should NOT have authorized the call)", got.Source, SourceTaskScopeMismatchPreferred)
+	}
+	if got.Kind != VerdictNeedsApproval {
+		t.Fatalf("kind = %v, want VerdictNeedsApproval (preferred-mismatch should block, not allow via sibling)", got.Kind)
+	}
+	if got.Task != nil {
+		t.Fatalf("task should be nil (no sibling match); got %+v", got.Task)
+	}
+}
+
+// TestEvaluateAuthorization_NoPreferredFallsThroughToMissing confirms
+// the no-checkout path is unchanged: with no PreferredTaskID, a
+// no-match still produces SourceTaskScopeMissing (not the new
+// mismatch source). This pins that brand-new conversations get the
+// existing approval-required path rather than the new block class.
+func TestEvaluateAuthorization_NoPreferredFallsThroughToMissing(t *testing.T) {
+	agentID := "agent-1"
+	got, err := EvaluateAuthorization(context.Background(), AuthorizationInput{
+		ToolUse:        toolUse("read_file", map[string]any{"path": "/etc/hosts"}),
+		AgentID:        agentID,
+		CandidateTasks: []*store.Task{taskWithExpectedTool("task-1", agentID, "exec_command", "other work")},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Source != SourceTaskScopeMissing {
+		t.Fatalf("source = %q, want %q", got.Source, SourceTaskScopeMissing)
+	}
+}
+
 func toolUse(name string, input map[string]any) conversation.ToolUse {
 	raw, _ := json.Marshal(input)
 	return conversation.ToolUse{ID: "toolu_1", Name: name, Input: raw}


### PR DESCRIPTION
## Summary

- Eliminates cross-conversation task-scope leakage. When a conversation has a checked-out task, tool calls authorize **only** against that task — no silent fallback to other active tasks owned by the same agent.
- Closes the secondary leak from empty-`ConversationID` writes by killing the legacy `(user, agent, "")` bucket; `/control/task/checkout` now scopes writes via a proxy-injected `X-Clawvisor-Conversation-ID` header.
- Adds `preferred_task_id` + `task_scope_path` (`preferred_strict` / `no_preferred_fallback` / `preferred_mismatch_blocked`) to `params_safe` so per-conversation isolation is queryable in audit.

## Key changes

| Layer | Change |
|---|---|
| `policy/task_match.go`, `request_classify.go` | Strict preferred-task matching. A non-empty `preferredTaskID` restricts the search to that task; mismatch returns `nil` / `NeedsNewTask` rather than scanning siblings. Stale-checkout pointer also surfaces as `NeedsNewTask` (cubic loop 1 fix). |
| `pkg/runtime/decision/decision.go` | New `SourceTaskScopeMismatchPreferred` so audit can distinguish "preferred mismatched" from "no preferred at all." |
| `llmproxy/taskscope.go` | `TaskScopeChecker.Check` extended with `preferredTaskID`; threaded through legacy fallback in `pipelineeval/factory.go`. |
| `llmproxy/taskcheckout/` | `ErrConversationIDRequired`; `Set` rejects empty CID, `Get` returns not-found (no shared bucket). |
| `inspector/rewriter.go`, `controltool/control.go` | Inject `X-Clawvisor-Conversation-ID` on rewritten control calls. |
| `handlers/control.go` | `/control/task/checkout` requires the injected header; `ListTasks` reads it. |
| `handlers/llm_endpoint.go` | Drop legacy fallback in `checkedOutTaskID`. |
| `conversation/AuditEvent`, `llmproxy/audit.go` | New `params_safe` fields. |

## Test plan

- [x] `go test ./internal/runtime/policy/... ./internal/runtime/llmproxy/... ./pkg/runtime/decision/... ./internal/api/handlers/... ./internal/runtime/conversation/...` — all green
- [x] `go build ./...` clean
- [x] `make test-e2e` (smoke) — 41 PASS / 1 SKIP / 0 FAIL
- [x] `internal/e2e/lite/` LLM scenario `script_session_scope_mismatch_recovery/claude` — passed (was failing during dev with a runaway drift loop; reverting an over-eager `AppliesToSource` addition fixed it)
- [x] Cubic review against `origin/main` — loop 1 caught a stale-checkout leak window (fixed in second commit), loop 2 clean
- [ ] Post-merge: run the brief's verification SQL on staging audit logs (`task_scope_path` distribution + cross-task-per-conversation query)

## Notes

- Brief: `/tmp/clawvisor-fix-task-scope-leak.md`
- One known-flaky lite e2e scenario (`script_session_inline_fanout/claude`) still over scope-mismatch budget after the fix, but that's claude struggling with the proxy URL (its own self-diagnosis in the trace); not caused by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

