### PR TITLE
feat(llmproxy): env-var overrides for upstream provider URLs

### DIFF
--- a/internal/runtime/llmproxy/forward.go
+++ b/internal/runtime/llmproxy/forward.go
@@ -368,7 +368,16 @@ func openaiPassthroughRoute(authorization, inboundPath string) *url.URL {
 	scheme, host := "https", "chatgpt.com"
 	if u := os.Getenv("CLAWVISOR_LLM_UPSTREAM_CHATGPT"); u != "" {
 		if parsed, err := url.Parse(u); err == nil && parsed.Host != "" {
-			scheme, host = parsed.Scheme, parsed.Host
+			host = parsed.Host
+			// Protocol-relative inputs like "//host:port" parse with a
+			// populated Host but an empty Scheme. Without this fallback we
+			// would build a URL like "//localhost:8080/backend-api/codex/…"
+			// and http.Client.Do would reject it. Keep the default scheme
+			// in that case; explicit http:// or https:// overrides are
+			// still respected.
+			if parsed.Scheme != "" {
+				scheme = parsed.Scheme
+			}
 		}
 	}
 	return &url.URL{

--- a/internal/runtime/llmproxy/forward.go
+++ b/internal/runtime/llmproxy/forward.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -117,13 +118,32 @@ type Forwarder struct {
 // http.Client has no overall timeout (SSE streams can be long-lived) but
 // the transport caps the time waiting for the response headers — a slow
 // or unresponsive upstream can't hold a goroutine forever.
+//
+// Env-var overrides (all optional; production leaves all unset):
+//   CLAWVISOR_LLM_UPSTREAM_ANTHROPIC — replace https://api.anthropic.com
+//   CLAWVISOR_LLM_UPSTREAM_OPENAI    — replace https://api.openai.com
+//   CLAWVISOR_LLM_UPSTREAM_GOOGLE    — replace generativelanguage URL
+//   CLAWVISOR_LLM_UPSTREAM_CHATGPT   — replace chatgpt.com (passthrough OAuth)
+//
+// E2E tests point these at a cassette-backed mock to deterministically
+// replay LLM responses without touching the network.
 func NewForwarder(v vault.Vault) *Forwarder {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.ResponseHeaderTimeout = 60 * time.Second
+	upstream := DefaultUpstream
+	if u := os.Getenv("CLAWVISOR_LLM_UPSTREAM_ANTHROPIC"); u != "" {
+		upstream.AnthropicBaseURL = u
+	}
+	if u := os.Getenv("CLAWVISOR_LLM_UPSTREAM_OPENAI"); u != "" {
+		upstream.OpenAIBaseURL = u
+	}
+	if u := os.Getenv("CLAWVISOR_LLM_UPSTREAM_GOOGLE"); u != "" {
+		upstream.GoogleBaseURL = u
+	}
 	return &Forwarder{
 		Vault:    v,
 		Client:   &http.Client{Timeout: 0, Transport: transport},
-		Upstream: DefaultUpstream,
+		Upstream: upstream,
 	}
 }
 
@@ -345,9 +365,15 @@ func openaiPassthroughRoute(authorization, inboundPath string) *url.URL {
 	if !strings.HasPrefix(suffix, "/") {
 		suffix = "/" + suffix
 	}
+	scheme, host := "https", "chatgpt.com"
+	if u := os.Getenv("CLAWVISOR_LLM_UPSTREAM_CHATGPT"); u != "" {
+		if parsed, err := url.Parse(u); err == nil && parsed.Host != "" {
+			scheme, host = parsed.Scheme, parsed.Host
+		}
+	}
 	return &url.URL{
-		Scheme: "https",
-		Host:   "chatgpt.com",
+		Scheme: scheme,
+		Host:   host,
 		Path:   "/backend-api/codex" + suffix,
 	}
 }

--- a/internal/runtime/llmproxy/forward_test.go
+++ b/internal/runtime/llmproxy/forward_test.go
@@ -563,6 +563,56 @@ func TestOpenAIPassthroughRoute_ChatGPTOAuth(t *testing.T) {
 	}
 }
 
+// TestOpenAIPassthroughRoute_ChatGPTUpstreamOverride covers the env-var
+// override paths for CLAWVISOR_LLM_UPSTREAM_CHATGPT. The protocol-
+// relative case is a regression test: url.Parse("//host:port") returns
+// scheme="" host="host:port" — without a fallback, that empty scheme
+// would leak into the request and trip http.Client.Do at runtime.
+func TestOpenAIPassthroughRoute_ChatGPTUpstreamOverride(t *testing.T) {
+	jwt := makeJWT(map[string]any{"scp": "openid"})
+
+	tests := []struct {
+		name       string
+		override   string
+		wantScheme string
+		wantHost   string
+	}{
+		{name: "unset", override: "", wantScheme: "https", wantHost: "chatgpt.com"},
+		{name: "explicit_http", override: "http://localhost:8080", wantScheme: "http", wantHost: "localhost:8080"},
+		{name: "explicit_https", override: "https://staging.chatgpt.example.com", wantScheme: "https", wantHost: "staging.chatgpt.example.com"},
+		// Regression: protocol-relative URL has populated Host but
+		// empty Scheme. Without the fallback we'd build a URL with no
+		// scheme and http.Client.Do would reject it.
+		{name: "protocol_relative_defaults_to_https", override: "//localhost:8080", wantScheme: "https", wantHost: "localhost:8080"},
+		// Bare hostnames with ports look like a scheme + opaque to
+		// url.Parse, so they get rejected by the host!="" guard and
+		// fall back to the default. Documenting current behavior.
+		{name: "bare_host_port_falls_back", override: "localhost:9000", wantScheme: "https", wantHost: "chatgpt.com"},
+		// Garbage URL also falls back.
+		{name: "garbage_falls_back", override: ":::not a url", wantScheme: "https", wantHost: "chatgpt.com"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("CLAWVISOR_LLM_UPSTREAM_CHATGPT", tc.override)
+			got := openaiPassthroughRoute("Bearer "+jwt, "/v1/responses")
+			if got == nil {
+				t.Fatal("ChatGPT-OAuth bearer must route to chatgpt.com (or override)")
+			}
+			if got.Scheme != tc.wantScheme {
+				t.Errorf("scheme=%q, want %q", got.Scheme, tc.wantScheme)
+			}
+			if got.Host != tc.wantHost {
+				t.Errorf("host=%q, want %q", got.Host, tc.wantHost)
+			}
+			// Whatever scheme/host, the path mapping must still apply.
+			if got.Path != "/backend-api/codex/responses" {
+				t.Errorf("path=%q, want /backend-api/codex/responses", got.Path)
+			}
+		})
+	}
+}
+
 func TestOpenAIPassthroughRoute_MalformedTokenFallsBack(t *testing.T) {
 	if got := openaiPassthroughRoute("Bearer not.a.jwt.too.many.dots", "/v1/responses"); got != nil {
 		t.Errorf("malformed token must fall back to default routing, got %s", got)


### PR DESCRIPTION
## Summary

Add four env vars so the LLM proxy's upstream URLs can be pointed at a mock host:

- `CLAWVISOR_LLM_UPSTREAM_ANTHROPIC` — replaces `https://api.anthropic.com`
- `CLAWVISOR_LLM_UPSTREAM_OPENAI` — replaces `https://api.openai.com`
- `CLAWVISOR_LLM_UPSTREAM_GOOGLE` — replaces the generativelanguage URL
- `CLAWVISOR_LLM_UPSTREAM_CHATGPT` — replaces `chatgpt.com` for the passthrough OAuth path

Production leaves all unset → existing behavior is preserved bit-for-bit.

## Motivation

Lets the cloud-side E2E suite point clawvisor at cassette-backed mocks so the LLM proxy's auth-mode matrix, OpenAI sub-routing, scope drift, intent verification, and audit emission can be exercised deterministically without hitting real Anthropic/OpenAI APIs in CI. ~50 new LLM-proxy E2E tests in cloud depend on these.

## Test plan

- [x] `go test ./internal/runtime/llmproxy/...` — existing forwarder unit tests still pass
- [x] In cloud repo, `make test-e2e` against this branch — all 141 e2e tests green
- [x] With env vars unset, behavior matches `main` (default upstreams used)

## Notes

- The `CLAWVISOR_LLM_UPSTREAM_CHATGPT` override is read inside `openaiPassthroughRoute` rather than at `NewForwarder` time because the ChatGPT routing is a per-request decision based on the token shape — keeping the override read at the call site keeps the routing logic in one place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

