### PR TITLE
test(testharness): in-process mocks for E2E test infrastructure

### DIFF
--- a/internal/testharness/email/email.go
+++ b/internal/testharness/email/email.go
@@ -26,6 +26,14 @@ type Sent struct {
 	Token   string // verification + reset only; "" for welcome
 	BaseURL string
 	At      time.Time
+	// Subject/Html/Text are populated by the HTTP-impersonating Server
+	// (server.go). The in-process Mock methods (SendVerification/etc.)
+	// leave them empty because the templated bodies live in the
+	// production package — only the canonical link parts (Token,
+	// BaseURL) are observable from the Mailer interface.
+	Subject string
+	Html    string
+	Text    string
 }
 
 // Link returns the link the user would click. Reconstructed from BaseURL + Token

--- a/internal/testharness/email/email.go
+++ b/internal/testharness/email/email.go
@@ -1,0 +1,142 @@
+// Package email implements an in-memory cloudemail.Mailer for tests. Captures
+// every send and exposes helpers for assertions + link extraction.
+package email
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Mailer is the subset of internal/email.Mailer the mock satisfies. Re-declared
+// here so the mock package doesn't depend on internal/email (avoids cycles).
+type Mailer interface {
+	SendVerification(to, token, baseURL string) error
+	SendPasswordReset(to, token, baseURL string) error
+	SendWelcome(to, appURL string) error
+}
+
+// Sent captures one outbound email.
+type Sent struct {
+	Kind    string // "verification", "password_reset", "welcome"
+	To      string
+	Token   string // verification + reset only; "" for welcome
+	BaseURL string
+	At      time.Time
+}
+
+// Link returns the link the user would click. Reconstructed from BaseURL + Token
+// to mirror what ResendMailer builds.
+func (s Sent) Link() string {
+	switch s.Kind {
+	case "verification":
+		return fmt.Sprintf("%s/verify-email?token=%s", strings.TrimRight(s.BaseURL, "/"), s.Token)
+	case "password_reset":
+		return fmt.Sprintf("%s/reset-password?token=%s", strings.TrimRight(s.BaseURL, "/"), s.Token)
+	case "welcome":
+		return s.BaseURL
+	}
+	return ""
+}
+
+// Mock captures emails and answers via the Mailer interface.
+type Mock struct {
+	mu   sync.Mutex
+	sent []Sent
+}
+
+// NewMock returns an empty mock; nothing is captured until SendXxx is called.
+func NewMock(t *testing.T) *Mock { return &Mock{} }
+
+// Reset drops all captured emails. Called by Harness.Reset.
+func (m *Mock) Reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.sent = nil
+}
+
+// All returns a copy of every captured send.
+func (m *Mock) All() []Sent {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]Sent, len(m.sent))
+	copy(out, m.sent)
+	return out
+}
+
+// LastTo returns the most recent send to address. nil if no match.
+func (m *Mock) LastTo(addr string) *Sent {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for i := len(m.sent) - 1; i >= 0; i-- {
+		if m.sent[i].To == addr {
+			s := m.sent[i]
+			return &s
+		}
+	}
+	return nil
+}
+
+// WaitForSendTo polls until a send to addr arrives or timeout. Returns the
+// captured Sent or fails the test.
+func (m *Mock) WaitForSendTo(t *testing.T, addr string, timeout time.Duration) Sent {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if s := m.LastTo(addr); s != nil {
+			return *s
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("email: no send to %q within %s (captured: %v)", addr, timeout, m.All())
+	return Sent{}
+}
+
+// AssertSentTo fails the test if no send to addr has been captured.
+func (m *Mock) AssertSentTo(t *testing.T, addr string) Sent {
+	t.Helper()
+	if s := m.LastTo(addr); s != nil {
+		return *s
+	}
+	t.Fatalf("email: expected a send to %q, captured: %v", addr, m.All())
+	return Sent{}
+}
+
+// ExtractLink pulls the first http(s):// link out of the captured email
+// matching the given pattern. Useful when the test prefers to "click" the
+// link rather than reconstruct it.
+func (s Sent) ExtractLink(pattern *regexp.Regexp) string {
+	// Mock doesn't store rendered HTML/text; link is canonical.
+	link := s.Link()
+	if pattern == nil || pattern.MatchString(link) {
+		return link
+	}
+	return ""
+}
+
+// SendVerification captures the send. Always nil error.
+func (m *Mock) SendVerification(to, token, baseURL string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.sent = append(m.sent, Sent{Kind: "verification", To: to, Token: token, BaseURL: baseURL, At: time.Now()})
+	return nil
+}
+
+// SendPasswordReset captures the send. Always nil error.
+func (m *Mock) SendPasswordReset(to, token, baseURL string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.sent = append(m.sent, Sent{Kind: "password_reset", To: to, Token: token, BaseURL: baseURL, At: time.Now()})
+	return nil
+}
+
+// SendWelcome captures the send. Always nil error.
+func (m *Mock) SendWelcome(to, appURL string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.sent = append(m.sent, Sent{Kind: "welcome", To: to, BaseURL: appURL, At: time.Now()})
+	return nil
+}

--- a/internal/testharness/email/email_test.go
+++ b/internal/testharness/email/email_test.go
@@ -54,16 +54,15 @@ func TestResetClearsCapturedSends(t *testing.T) {
 	}
 }
 
-func TestWaitForSendToTimeoutsCleanly(t *testing.T) {
+// TestWaitForSendToResolvesWhenSendArrives — happy path: a send
+// arrives within the timeout and WaitForSendTo returns it.
+//
+// The fatal-on-timeout path isn't exercised in-process because
+// t.Fatalf is goroutine-local; covering it from outside the test
+// would require subprocessing the test binary. The risk of
+// regression is low — that branch is a single conditional fatal.
+func TestWaitForSendToResolvesWhenSendArrives(t *testing.T) {
 	m := hemail.NewMock(t)
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		// Should fail inside the goroutine since t.Fatalf is goroutine-local.
-		// We use a sub-test to verify the timeout path triggers.
-	}()
-	<-done
-	// Positive case: a send arrives shortly.
 	go func() {
 		time.Sleep(30 * time.Millisecond)
 		_ = m.SendPasswordReset("b@x", "tok", "u")

--- a/internal/testharness/email/email_test.go
+++ b/internal/testharness/email/email_test.go
@@ -1,0 +1,75 @@
+package email_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	hemail "github.com/clawvisor/clawvisor/internal/testharness/email"
+)
+
+// mailerLike is the cloud-side Mailer interface re-declared locally so
+// the assertion runs without importing cloud (clawvisor must not depend
+// on its own consumer). Cloud has an equivalent assertion against its
+// own interface; if either drifts, both tests fail at compile time.
+type mailerLike interface {
+	SendVerification(to, token, baseURL string) error
+	SendPasswordReset(to, token, baseURL string) error
+	SendWelcome(to, appURL string) error
+}
+
+// TestMockSatisfiesMailerInterface asserts the mock can be used wherever
+// the cloud Mailer interface is expected — this is the whole point of
+// exposing the mock as a drop-in.
+func TestMockSatisfiesMailerInterface(t *testing.T) {
+	var _ mailerLike = (*hemail.Mock)(nil)
+}
+
+func TestCapturesVerification(t *testing.T) {
+	m := hemail.NewMock(t)
+	if err := m.SendVerification("alice@example.com", "tok-123", "https://app.test"); err != nil {
+		t.Fatal(err)
+	}
+	got := m.AssertSentTo(t, "alice@example.com")
+	if got.Kind != "verification" {
+		t.Fatalf("kind=%q", got.Kind)
+	}
+	if got.Token != "tok-123" {
+		t.Fatalf("token=%q", got.Token)
+	}
+	if !strings.HasSuffix(got.Link(), "/verify-email?token=tok-123") {
+		t.Fatalf("link=%q", got.Link())
+	}
+}
+
+func TestResetClearsCapturedSends(t *testing.T) {
+	m := hemail.NewMock(t)
+	_ = m.SendVerification("a@x", "t", "u")
+	if got := m.All(); len(got) != 1 {
+		t.Fatalf("pre-reset len=%d", len(got))
+	}
+	m.Reset()
+	if got := m.All(); len(got) != 0 {
+		t.Fatalf("post-reset len=%d", len(got))
+	}
+}
+
+func TestWaitForSendToTimeoutsCleanly(t *testing.T) {
+	m := hemail.NewMock(t)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		// Should fail inside the goroutine since t.Fatalf is goroutine-local.
+		// We use a sub-test to verify the timeout path triggers.
+	}()
+	<-done
+	// Positive case: a send arrives shortly.
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		_ = m.SendPasswordReset("b@x", "tok", "u")
+	}()
+	got := m.WaitForSendTo(t, "b@x", 500*time.Millisecond)
+	if got.Kind != "password_reset" {
+		t.Fatalf("kind=%q", got.Kind)
+	}
+}

--- a/internal/testharness/email/server.go
+++ b/internal/testharness/email/server.go
@@ -1,0 +1,128 @@
+package email
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Server impersonates the Resend API on /emails. The cloud binary, when
+// started with RESEND_BASE_URL pointed here, will route every send through
+// the server — captured and queryable via the same Mock helpers (LastTo,
+// WaitForSendTo, etc.) as the in-process mailer.
+//
+// The server captures full requests (subject, html, text), not just tokens —
+// which means tests can also assert on email body content if they care.
+type Server struct {
+	mock *Mock
+	srv  *httptest.Server
+}
+
+// NewServer starts a Resend-impersonating HTTP server backed by the given
+// Mock. The mock and the server share captured state — a send via either
+// surface shows up in mock.All().
+func NewServer(t *testing.T, mock *Mock) *Server {
+	t.Helper()
+	s := &Server{mock: mock}
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /emails", s.handleSend)
+	mux.HandleFunc("POST /emails/", s.handleSend)
+	s.srv = httptest.NewServer(mux)
+	t.Cleanup(s.srv.Close)
+	return s
+}
+
+// URL returns the base URL to pass as RESEND_BASE_URL (trailing slash, as
+// resend-go expects).
+func (s *Server) URL() string {
+	return s.srv.URL + "/"
+}
+
+// resend SendEmailRequest shape — minimal fields we care about.
+type sendReq struct {
+	From    string   `json:"from"`
+	To      []string `json:"to"`
+	Subject string   `json:"subject"`
+	Html    string   `json:"html"`
+	Text    string   `json:"text"`
+	ReplyTo string   `json:"reply_to"`
+}
+
+func (s *Server) handleSend(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+	var req sendReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	to := ""
+	if len(req.To) > 0 {
+		to = req.To[0]
+	}
+	kind := inferKind(req.Subject)
+	token, baseURL := extractTokenAndBaseURL(req.Text)
+	s.mock.mu.Lock()
+	s.mock.sent = append(s.mock.sent, Sent{
+		Kind:    kind,
+		To:      to,
+		Token:   token,
+		BaseURL: baseURL,
+		At:      time.Now(),
+	})
+	s.mock.mu.Unlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]string{
+		"id": fmt.Sprintf("mock-%d", time.Now().UnixNano()),
+	})
+}
+
+// inferKind maps a Resend subject line to our internal kind tag so the same
+// in-process assertion helpers work over the HTTP capture path.
+func inferKind(subject string) string {
+	s := strings.ToLower(subject)
+	switch {
+	case strings.Contains(s, "confirm your email"):
+		return "verification"
+	case strings.Contains(s, "reset your password"):
+		return "password_reset"
+	case strings.Contains(s, "welcome"):
+		return "welcome"
+	}
+	return "unknown"
+}
+
+// extractTokenAndBaseURL recovers the link parts from the plain-text body.
+// We send a canonical "...?token=XXX" link in every email — parse it back
+// out so tests can use s.Link() or s.Token directly.
+func extractTokenAndBaseURL(text string) (token, baseURL string) {
+	idx := strings.Index(text, "?token=")
+	if idx < 0 {
+		return "", ""
+	}
+	// Walk back from idx to find the URL start.
+	start := strings.LastIndex(text[:idx], "http")
+	if start < 0 {
+		return "", ""
+	}
+	url := text[start:]
+	// Trim trailing whitespace/newlines.
+	url = strings.TrimRightFunc(url, func(r rune) bool {
+		return r == ' ' || r == '\n' || r == '\r' || r == '\t'
+	})
+	end := strings.IndexAny(url, " \n\r\t")
+	if end > 0 {
+		url = url[:end]
+	}
+	parts := strings.SplitN(url, "?token=", 2)
+	if len(parts) != 2 {
+		return "", ""
+	}
+	baseURL = strings.TrimSuffix(parts[0], "/verify-email")
+	baseURL = strings.TrimSuffix(baseURL, "/reset-password")
+	return parts[1], baseURL
+}

--- a/internal/testharness/email/server.go
+++ b/internal/testharness/email/server.go
@@ -72,6 +72,9 @@ func (s *Server) handleSend(w http.ResponseWriter, r *http.Request) {
 		Token:   token,
 		BaseURL: baseURL,
 		At:      time.Now(),
+		Subject: req.Subject,
+		Html:    req.Html,
+		Text:    req.Text,
 	})
 	s.mock.mu.Unlock()
 

--- a/internal/testharness/github/github.go
+++ b/internal/testharness/github/github.go
@@ -1,0 +1,38 @@
+// Package github provides a minimal in-memory GitHub REST mock for E2E
+// tests. Implements only the routes the GitHub adapter calls.
+package github
+
+import (
+	"testing"
+
+	"github.com/clawvisor/clawvisor/internal/testharness/httpmock"
+)
+
+type Mock struct {
+	*httpmock.Server
+}
+
+func NewMock(t *testing.T) *Mock {
+	t.Helper()
+	srv := httpmock.New(t, map[string]httpmock.Response{
+		// List issues in a repo.
+		"GET /repos/{owner}/{repo}/issues": {Body: []map[string]any{}},
+		// Get a single issue.
+		"GET /repos/{owner}/{repo}/issues/{num}": {Body: map[string]any{
+			"id": 1, "number": 1, "title": "mock issue", "state": "open",
+		}},
+		// Create an issue.
+		"POST /repos/{owner}/{repo}/issues": {Status: 201, Body: map[string]any{
+			"id": 999, "number": 999, "html_url": "https://github.com/mock/issue/999",
+		}},
+		// List PRs.
+		"GET /repos/{owner}/{repo}/pulls": {Body: []map[string]any{}},
+		// List user repos.
+		"GET /user/repos": {Body: []map[string]any{}},
+	})
+	return &Mock{Server: srv}
+}
+
+func (m *Mock) Env() map[string]string {
+	return map[string]string{"GITHUB_API_BASE_URL": m.URL()}
+}

--- a/internal/testharness/google/google.go
+++ b/internal/testharness/google/google.go
@@ -1,0 +1,488 @@
+// Package google implements an in-process Google OAuth + APIs mock for E2E
+// tests. Stands up two httptest.Servers — one for OAuth (authorize, token,
+// userinfo, JWKS) and one for the Gmail / Calendar / Drive / Contacts REST
+// surfaces — and exposes a scripting API so tests can prep the next OAuth
+// callback's claims, the next gmail.send response, etc.
+//
+// Wiring: the harness binds env vars GOOGLE_OAUTH_BASE_URL, GOOGLE_TOKEN_URL,
+// GOOGLE_API_BASE_URL etc. The app reads these via the standard injection
+// points (added in handlers/google_auth.go and friends).
+package google
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// Mock owns httptest.Servers for Google OAuth + APIs.
+type Mock struct {
+	mu       sync.Mutex
+	oauthSrv *httptest.Server
+	apiSrv   *httptest.Server
+
+	// Signing key for ID tokens (also published via the JWKS endpoint).
+	rsaKey *rsa.PrivateKey
+	kid    string
+
+	// Scripted state, one-shot.
+	nextLogin   *loginScript
+	nextSends   []SentEmail
+	failuresAct string // "" | "rate_limit" | "service_unavailable"
+}
+
+// loginScript holds the user claims returned for the next OAuth callback.
+type loginScript struct {
+	Email   string
+	Sub     string
+	Name    string
+	Picture string
+	// Authorization code minted at /authorize and accepted at /token.
+	authCode string
+}
+
+// SentEmail is one Gmail.messages.send invocation captured by the mock.
+type SentEmail struct {
+	To      string
+	From    string
+	Subject string
+	Body    string // best-effort decoded from base64 raw
+}
+
+// NewMock starts both http servers. Servers stop via t.Cleanup.
+func NewMock(t *testing.T) *Mock {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa keygen: %v", err)
+	}
+	m := &Mock{
+		rsaKey: key,
+		kid:    "test-key-1",
+	}
+	oauthMux := http.NewServeMux()
+	oauthMux.HandleFunc("GET /o/oauth2/v2/auth", m.handleAuthorize)
+	oauthMux.HandleFunc("POST /token", m.handleToken)
+	oauthMux.HandleFunc("GET /userinfo", m.handleUserinfo)
+	oauthMux.HandleFunc("GET /.well-known/jwks.json", m.handleJWKS)
+	m.oauthSrv = httptest.NewServer(oauthMux)
+
+	apiMux := http.NewServeMux()
+	apiMux.HandleFunc("POST /gmail/v1/users/me/messages/send", m.handleGmailSend)
+	apiMux.HandleFunc("GET /gmail/v1/users/me/messages", m.handleGmailList)
+	apiMux.HandleFunc("GET /calendar/v3/calendars/{cal}/events", m.handleCalendarList)
+	apiMux.HandleFunc("GET /drive/v3/files", m.handleDriveList)
+	apiMux.HandleFunc("GET /people/v1/people/me/connections", m.handleContactsList)
+	m.apiSrv = httptest.NewServer(apiMux)
+
+	t.Cleanup(func() {
+		m.oauthSrv.Close()
+		m.apiSrv.Close()
+	})
+	return m
+}
+
+// Reset drops scripted responses + captured state.
+func (m *Mock) Reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.nextLogin = nil
+	m.nextSends = nil
+	m.failuresAct = ""
+}
+
+// Env returns env vars wiring the cloud (or clawvisor) app to the mocks.
+func (m *Mock) Env() map[string]string {
+	return map[string]string{
+		"GOOGLE_OAUTH_BASE_URL": m.oauthSrv.URL + "/o/oauth2/v2/auth",
+		"GOOGLE_TOKEN_URL":      m.oauthSrv.URL + "/token",
+		"GOOGLE_USERINFO_URL":   m.oauthSrv.URL + "/userinfo",
+		"GOOGLE_JWKS_URL":       m.oauthSrv.URL + "/.well-known/jwks.json",
+		"GOOGLE_API_BASE_URL":   m.apiSrv.URL,
+	}
+}
+
+// OAuthAuthorizeURL returns the URL clients should hit to initiate OAuth.
+// Useful for tests that want to assert the cloud's auth_url constructs an
+// equivalent URL.
+func (m *Mock) OAuthAuthorizeURL() string {
+	return m.oauthSrv.URL + "/o/oauth2/v2/auth"
+}
+
+// NextLoginReturnsUser scripts the next /authorize callback to return tokens
+// for the given email. Subsequent token exchanges return an ID token signed
+// with the mock's RSA key and `sub`/`email` claims set as specified.
+func (m *Mock) NextLoginReturnsUser(email string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.nextLogin = &loginScript{
+		Email:    email,
+		Sub:      "mock-sub-" + base64URL(8),
+		Name:     "Mock User",
+		Picture:  "https://example.com/mock.png",
+		authCode: "mock-code-" + base64URL(8),
+	}
+}
+
+// SentEmails returns a copy of every Gmail.send capture.
+func (m *Mock) SentEmails() []SentEmail {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]SentEmail, len(m.nextSends))
+	copy(out, m.nextSends)
+	return out
+}
+
+// AssertSentEmailTo fails the test if no captured send went to `to`.
+func (m *Mock) AssertSentEmailTo(t *testing.T, to string) SentEmail {
+	t.Helper()
+	for _, s := range m.SentEmails() {
+		if strings.Contains(s.To, to) {
+			return s
+		}
+	}
+	t.Fatalf("gmail: no send to %q (captured: %d)", to, len(m.SentEmails()))
+	return SentEmail{}
+}
+
+// FailNextCallsWith scripts the next N API calls to fail with the named mode.
+// Modes: "rate_limit" (429), "service_unavailable" (503), "" (clear).
+func (m *Mock) FailNextCallsWith(mode string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.failuresAct = mode
+}
+
+// ── OAuth handlers ────────────────────────────────────────────────────────
+
+// /o/oauth2/v2/auth redirects to the client's redirect_uri with ?code=… as
+// the real Google would after the user clicks "Allow".
+func (m *Mock) handleAuthorize(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	redirect := q.Get("redirect_uri")
+	state := q.Get("state")
+	m.mu.Lock()
+	login := m.nextLogin
+	if login == nil {
+		// Default: synthesize a login for an unknown user so tests can
+		// observe failure paths if they don't script.
+		login = &loginScript{
+			Email:    "default-" + base64URL(4) + "@mock.test",
+			Sub:      "mock-sub-default",
+			authCode: "mock-code-" + base64URL(8),
+		}
+		m.nextLogin = login
+	}
+	code := login.authCode
+	m.mu.Unlock()
+
+	// Decompose the user-supplied redirect_uri and rebuild it from
+	// pieces that have each been validated against a literal whitelist
+	// or coerced to a typed primitive. CodeQL (correctly) flags any
+	// dataflow path where user input reaches http.Redirect; constructing
+	// the redirect target from canonical literals + an int + a
+	// character-class-restricted path breaks the taint flow entirely.
+	//
+	// This is a test-only mock — the real defensive constraint is that
+	// only loopback redirects are allowed.
+	target, errMsg := safeLoopbackRedirect(redirect, code, state)
+	if errMsg != "" {
+		http.Error(w, errMsg, http.StatusBadRequest)
+		return
+	}
+	http.Redirect(w, r, target, http.StatusFound)
+}
+
+// safeLoopbackRedirect parses an OAuth redirect_uri, validates every
+// component against a strict whitelist, and reassembles the URL from
+// untainted primitives. Returns the safe redirect string, or an error
+// message describing the first validation failure.
+//
+// Rules enforced:
+//   - host is one of: localhost, 127.0.0.1, [::1]
+//   - port parses as an int in [1, 65535]
+//   - path contains only printable ASCII (no CR/LF, no control bytes)
+//   - query of input is discarded; new query is built with code+state
+//
+// Returns ("", "...") on validation failure. The returned URL string
+// is composed of: const scheme ("http") + literal host (from the
+// whitelist switch) + int port + character-validated path + freshly
+// minted query. None of those carries a taint path from the input.
+func safeLoopbackRedirect(redirectURI, code, state string) (string, string) {
+	parsed, err := url.Parse(redirectURI)
+	if err != nil {
+		return "", "bad redirect_uri"
+	}
+	var canonicalHost string
+	switch parsed.Hostname() {
+	case "localhost":
+		canonicalHost = "localhost"
+	case "127.0.0.1":
+		canonicalHost = "127.0.0.1"
+	case "::1", "[::1]":
+		canonicalHost = "[::1]"
+	default:
+		return "", "redirect_uri must be loopback (test-only mock)"
+	}
+	// Port is optional in OAuth redirect_uris ("http://localhost/cb" is
+	// valid). When present, it must parse as a real int in [1, 65535].
+	var portSuffix string
+	if rawPort := parsed.Port(); rawPort != "" {
+		port, err := strconv.Atoi(rawPort)
+		if err != nil || port < 1 || port > 65535 {
+			return "", "redirect_uri port invalid"
+		}
+		portSuffix = fmt.Sprintf(":%d", port)
+	}
+	// EscapedPath returns a percent-encoded path. Reject anything outside
+	// printable ASCII so the rebuilt URL can't carry binary payloads.
+	rawPath := parsed.EscapedPath()
+	for i := 0; i < len(rawPath); i++ {
+		c := rawPath[i]
+		if c < 0x20 || c > 0x7e {
+			return "", "redirect_uri path invalid"
+		}
+	}
+	// Limit path length too — defense against absurd inputs.
+	if len(rawPath) > 1024 {
+		return "", "redirect_uri path too long"
+	}
+	// Build a fresh query — never reuse the input's RawQuery.
+	q := url.Values{}
+	q.Set("code", code)
+	q.Set("state", state)
+	return fmt.Sprintf("http://%s%s%s?%s", canonicalHost, portSuffix, rawPath, q.Encode()), ""
+}
+
+// /token exchanges authorization code → tokens. Returns id_token + access_token.
+func (m *Mock) handleToken(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	code := r.Form.Get("code")
+
+	m.mu.Lock()
+	login := m.nextLogin
+	if login == nil || login.authCode != code {
+		m.mu.Unlock()
+		http.Error(w, `{"error":"invalid_grant"}`, http.StatusBadRequest)
+		return
+	}
+	// Consume the script so subsequent /token calls with the same code fail.
+	m.nextLogin = nil
+	m.mu.Unlock()
+
+	clientID := r.Form.Get("client_id")
+	if clientID == "" {
+		clientID = "test-client-id"
+	}
+	idToken, err := m.signIDToken(login, clientID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"access_token":  "mock-access-token",
+		"refresh_token": "mock-refresh-token",
+		"expires_in":    3600,
+		"token_type":    "Bearer",
+		"id_token":      idToken,
+		"scope":         r.Form.Get("scope"),
+	})
+}
+
+// /userinfo returns claims for the current access token. We don't validate
+// the token; the test sets up the login script before calling /authorize.
+func (m *Mock) handleUserinfo(w http.ResponseWriter, r *http.Request) {
+	m.mu.Lock()
+	login := m.nextLogin
+	m.mu.Unlock()
+	if login == nil {
+		// Default fixture.
+		login = &loginScript{Email: "default@mock.test", Sub: "mock-sub-default", Name: "Mock"}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"sub":            login.Sub,
+		"email":          login.Email,
+		"email_verified": true,
+		"name":           login.Name,
+		"picture":        login.Picture,
+	})
+}
+
+// /.well-known/jwks.json publishes the public key the app should use to
+// verify ID tokens we sign.
+func (m *Mock) handleJWKS(w http.ResponseWriter, r *http.Request) {
+	pub := m.rsaKey.PublicKey
+	n := base64.RawURLEncoding.EncodeToString(pub.N.Bytes())
+	e := base64.RawURLEncoding.EncodeToString(big.NewInt(int64(pub.E)).Bytes())
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"keys": []map[string]any{
+			{
+				"kty": "RSA",
+				"use": "sig",
+				"alg": "RS256",
+				"kid": m.kid,
+				"n":   n,
+				"e":   e,
+			},
+		},
+	})
+}
+
+// signIDToken mints an RS256-signed Google-style ID token.
+func (m *Mock) signIDToken(login *loginScript, clientID string) (string, error) {
+	now := time.Now()
+	claims := jwt.MapClaims{
+		"iss":            m.oauthSrv.URL,
+		"sub":            login.Sub,
+		"aud":            clientID,
+		"exp":            now.Add(1 * time.Hour).Unix(),
+		"iat":            now.Unix(),
+		"email":          login.Email,
+		"email_verified": true,
+		"name":           login.Name,
+		"picture":        login.Picture,
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	tok.Header["kid"] = m.kid
+	return tok.SignedString(m.rsaKey)
+}
+
+// PublicKeyPEM is exposed for tests that need to pin the key into the app
+// (e.g., when configuring an OIDC client that doesn't auto-fetch JWKS).
+func (m *Mock) PublicKeyPEM() []byte {
+	pubDER, _ := x509.MarshalPKIXPublicKey(&m.rsaKey.PublicKey)
+	return pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER})
+}
+
+// ── Gmail handlers ────────────────────────────────────────────────────────
+
+func (m *Mock) handleGmailSend(w http.ResponseWriter, r *http.Request) {
+	if mode := m.injectFailure(); mode != 0 {
+		w.WriteHeader(mode)
+		_, _ = w.Write([]byte(`{"error":{"code":` + fmt.Sprintf("%d", mode) + `,"message":"mock failure"}}`))
+		return
+	}
+	var body struct {
+		Raw string `json:"raw"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	raw, err := base64.URLEncoding.DecodeString(body.Raw)
+	if err != nil {
+		// Some senders use URL-safe without padding.
+		raw, _ = base64.RawURLEncoding.DecodeString(body.Raw)
+	}
+	parsed := parseRFC822(string(raw))
+	m.mu.Lock()
+	m.nextSends = append(m.nextSends, parsed)
+	m.mu.Unlock()
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write([]byte(`{"id":"mock-msg-id","threadId":"mock-thread-id"}`))
+}
+
+func (m *Mock) handleGmailList(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write([]byte(`{"messages":[],"resultSizeEstimate":0}`))
+}
+
+// ── Calendar / Drive / Contacts stubs (list endpoints, empty results) ────
+
+func (m *Mock) handleCalendarList(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write([]byte(`{"items":[]}`))
+}
+
+func (m *Mock) handleDriveList(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write([]byte(`{"files":[]}`))
+}
+
+func (m *Mock) handleContactsList(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write([]byte(`{"connections":[]}`))
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────
+
+func (m *Mock) injectFailure() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	switch m.failuresAct {
+	case "rate_limit":
+		m.failuresAct = ""
+		return http.StatusTooManyRequests
+	case "service_unavailable":
+		m.failuresAct = ""
+		return http.StatusServiceUnavailable
+	}
+	return 0
+}
+
+func parseRFC822(raw string) SentEmail {
+	var s SentEmail
+	headersEnd := strings.Index(raw, "\r\n\r\n")
+	if headersEnd < 0 {
+		headersEnd = strings.Index(raw, "\n\n")
+	}
+	hdr := raw
+	body := ""
+	if headersEnd >= 0 {
+		hdr = raw[:headersEnd]
+		body = raw[headersEnd+2:]
+	}
+	for _, line := range strings.Split(hdr, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if i := strings.Index(line, ":"); i > 0 {
+			name := strings.ToLower(strings.TrimSpace(line[:i]))
+			val := strings.TrimSpace(line[i+1:])
+			switch name {
+			case "to":
+				s.To = val
+			case "from":
+				s.From = val
+			case "subject":
+				s.Subject = val
+			}
+		}
+	}
+	s.Body = body
+	return s
+}
+
+func base64URL(n int) string {
+	b := make([]byte, n)
+	_, _ = rand.Read(b)
+	return strings.TrimRight(base64.URLEncoding.EncodeToString(b), "=")
+}
+
+// keyFingerprint is used in tests that want to assert key rotation.
+func (m *Mock) KeyFingerprint() string {
+	pubDER, _ := x509.MarshalPKIXPublicKey(&m.rsaKey.PublicKey)
+	sum := sha256.Sum256(pubDER)
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}

--- a/internal/testharness/google/google.go
+++ b/internal/testharness/google/google.go
@@ -108,6 +108,7 @@ func (m *Mock) Reset() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.nextLogin = nil
+	m.currentLogin = nil
 	m.nextSends = nil
 	m.failuresAct = ""
 }

--- a/internal/testharness/google/google.go
+++ b/internal/testharness/google/google.go
@@ -42,9 +42,14 @@ type Mock struct {
 	kid    string
 
 	// Scripted state, one-shot.
-	nextLogin   *loginScript
-	nextSends   []SentEmail
-	failuresAct string // "" | "rate_limit" | "service_unavailable"
+	nextLogin *loginScript
+	// currentLogin remembers the last login scripted via NextLoginReturnsUser
+	// (or synthesized by /authorize) even after /token has consumed nextLogin.
+	// /userinfo reads from this so a real OAuth client that calls /userinfo
+	// AFTER /token still sees the authenticated user, not the default fixture.
+	currentLogin *loginScript
+	nextSends    []SentEmail
+	failuresAct  string // "" | "rate_limit" | "service_unavailable"
 }
 
 // loginScript holds the user claims returned for the next OAuth callback.
@@ -131,13 +136,15 @@ func (m *Mock) OAuthAuthorizeURL() string {
 func (m *Mock) NextLoginReturnsUser(email string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.nextLogin = &loginScript{
+	login := &loginScript{
 		Email:    email,
 		Sub:      "mock-sub-" + base64URL(8),
 		Name:     "Mock User",
 		Picture:  "https://example.com/mock.png",
 		authCode: "mock-code-" + base64URL(8),
 	}
+	m.nextLogin = login
+	m.currentLogin = login
 }
 
 // SentEmails returns a copy of every Gmail.send capture.
@@ -161,9 +168,14 @@ func (m *Mock) AssertSentEmailTo(t *testing.T, to string) SentEmail {
 	return SentEmail{}
 }
 
-// FailNextCallsWith scripts the next N API calls to fail with the named mode.
-// Modes: "rate_limit" (429), "service_unavailable" (503), "" (clear).
-func (m *Mock) FailNextCallsWith(mode string) {
+// FailNextGmailSendWith scripts the NEXT single Gmail.messages.send call
+// to fail with the named status. Modes: "rate_limit" (429),
+// "service_unavailable" (503), "" (clear).
+//
+// Scope: only Gmail.send currently consumes this — other action handlers
+// always succeed. Expand to additional surfaces by calling injectFailure
+// from those handlers as needed.
+func (m *Mock) FailNextGmailSendWith(mode string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.failuresAct = mode
@@ -189,6 +201,7 @@ func (m *Mock) handleAuthorize(w http.ResponseWriter, r *http.Request) {
 		}
 		m.nextLogin = login
 	}
+	m.currentLogin = login
 	code := login.authCode
 	m.mu.Unlock()
 
@@ -312,12 +325,18 @@ func (m *Mock) handleToken(w http.ResponseWriter, r *http.Request) {
 
 // /userinfo returns claims for the current access token. We don't validate
 // the token; the test sets up the login script before calling /authorize.
+// Reads currentLogin (preserved across /token consumption) so a real
+// OAuth client that calls /userinfo AFTER /token still sees the
+// authenticated user rather than the default fixture.
 func (m *Mock) handleUserinfo(w http.ResponseWriter, r *http.Request) {
 	m.mu.Lock()
-	login := m.nextLogin
+	login := m.currentLogin
+	if login == nil {
+		login = m.nextLogin
+	}
 	m.mu.Unlock()
 	if login == nil {
-		// Default fixture.
+		// Default fixture (no prior /authorize call in this session).
 		login = &loginScript{Email: "default@mock.test", Sub: "mock-sub-default", Name: "Mock"}
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -445,15 +464,18 @@ func (m *Mock) injectFailure() int {
 
 func parseRFC822(raw string) SentEmail {
 	var s SentEmail
-	headersEnd := strings.Index(raw, "\r\n\r\n")
-	if headersEnd < 0 {
-		headersEnd = strings.Index(raw, "\n\n")
-	}
+	// Skip the actual separator length, not a fixed 2: "\r\n\r\n" is 4
+	// bytes and "\n\n" is 2. The previous version always advanced 2,
+	// leaving the body prefixed with the trailing "\r\n" of the CRLF
+	// pair on standards-compliant RFC822 messages.
 	hdr := raw
 	body := ""
-	if headersEnd >= 0 {
-		hdr = raw[:headersEnd]
-		body = raw[headersEnd+2:]
+	if i := strings.Index(raw, "\r\n\r\n"); i >= 0 {
+		hdr = raw[:i]
+		body = raw[i+4:]
+	} else if i := strings.Index(raw, "\n\n"); i >= 0 {
+		hdr = raw[:i]
+		body = raw[i+2:]
 	}
 	for _, line := range strings.Split(hdr, "\n") {
 		line = strings.TrimRight(line, "\r")

--- a/internal/testharness/google/google_fix_test.go
+++ b/internal/testharness/google/google_fix_test.go
@@ -59,6 +59,67 @@ func TestUserinfoReadsAfterTokenConsumed(t *testing.T) {
 	}
 }
 
+// TestResetClearsCurrentLogin — Reset must zero currentLogin or
+// /userinfo bleeds the previous test's authenticated user into the
+// next one (cross-test contamination when Mocks are reused).
+func TestResetClearsCurrentLogin(t *testing.T) {
+	m := hg.NewMock(t)
+	m.NextLoginReturnsUser("first-tenant@test.local")
+	env := m.Env()
+
+	// Drive the OAuth flow once so currentLogin gets populated.
+	client := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
+	resp, err := client.Get(env["GOOGLE_OAUTH_BASE_URL"] + "?redirect_uri=http%3A%2F%2Flocalhost%2Fcb&state=s")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	loc, _ := resp.Location()
+	code := loc.Query().Get("code")
+	form := url.Values{"code": {code}, "grant_type": {"authorization_code"}, "client_id": {"test"}}
+	tokResp, err := http.PostForm(env["GOOGLE_TOKEN_URL"], form)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tokResp.Body.Close()
+
+	// Sanity: /userinfo sees the first tenant.
+	r1, err := http.Get(env["GOOGLE_USERINFO_URL"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var u1 struct {
+		Email string `json:"email"`
+	}
+	if err := json.NewDecoder(r1.Body).Decode(&u1); err != nil {
+		t.Fatal(err)
+	}
+	r1.Body.Close()
+	if u1.Email != "first-tenant@test.local" {
+		t.Fatalf("pre-reset: email=%q", u1.Email)
+	}
+
+	// Reset.
+	m.Reset()
+
+	// /userinfo MUST NOT return the first tenant after Reset. With no
+	// new login scripted, it falls back to the default fixture.
+	r2, err := http.Get(env["GOOGLE_USERINFO_URL"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var u2 struct {
+		Email string `json:"email"`
+	}
+	if err := json.NewDecoder(r2.Body).Decode(&u2); err != nil {
+		t.Fatal(err)
+	}
+	r2.Body.Close()
+	if u2.Email == "first-tenant@test.local" {
+		t.Fatalf("cross-test contamination: Reset did NOT clear currentLogin, /userinfo still returned %q", u2.Email)
+	}
+}
+
 // TestParseRFC822CRLFBodyOffset — the parser must skip the actual
 // separator length, not a fixed 2. For "\r\n\r\n" (4 bytes) the
 // previous version left the body prefixed with a stray "\r\n".

--- a/internal/testharness/google/google_fix_test.go
+++ b/internal/testharness/google/google_fix_test.go
@@ -74,7 +74,10 @@ func TestResetClearsCurrentLogin(t *testing.T) {
 		t.Fatal(err)
 	}
 	resp.Body.Close()
-	loc, _ := resp.Location()
+	loc, err := resp.Location()
+	if err != nil {
+		t.Fatalf("authorize did not redirect: %v (status=%d)", err, resp.StatusCode)
+	}
 	code := loc.Query().Get("code")
 	form := url.Values{"code": {code}, "grant_type": {"authorization_code"}, "client_id": {"test"}}
 	tokResp, err := http.PostForm(env["GOOGLE_TOKEN_URL"], form)

--- a/internal/testharness/google/google_fix_test.go
+++ b/internal/testharness/google/google_fix_test.go
@@ -1,0 +1,131 @@
+package google_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	hg "github.com/clawvisor/clawvisor/internal/testharness/google"
+)
+
+// TestUserinfoReadsAfterTokenConsumed — earlier, /token cleared
+// nextLogin, then /userinfo fell back to the default fixture. Real
+// OAuth clients call /userinfo AFTER /token, so they'd see
+// "default@mock.test" instead of the user they just authenticated as.
+func TestUserinfoReadsAfterTokenConsumed(t *testing.T) {
+	m := hg.NewMock(t)
+	m.NextLoginReturnsUser("alice@test.local")
+	env := m.Env()
+
+	// Step 1: /authorize.
+	client := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
+	resp, err := client.Get(env["GOOGLE_OAUTH_BASE_URL"] + "?redirect_uri=http%3A%2F%2Flocalhost%2Fcb&state=s")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	loc, err := resp.Location()
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := loc.Query().Get("code")
+
+	// Step 2: /token.
+	form := url.Values{"code": {code}, "grant_type": {"authorization_code"}, "client_id": {"test"}}
+	tokResp, err := http.PostForm(env["GOOGLE_TOKEN_URL"], form)
+	if err != nil {
+		t.Fatal(err)
+	}
+	io.Copy(io.Discard, tokResp.Body)
+	tokResp.Body.Close()
+
+	// Step 3: /userinfo — MUST return alice, not the default.
+	infoResp, err := http.Get(env["GOOGLE_USERINFO_URL"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer infoResp.Body.Close()
+	var info struct {
+		Email string `json:"email"`
+	}
+	if err := json.NewDecoder(infoResp.Body).Decode(&info); err != nil {
+		t.Fatal(err)
+	}
+	if info.Email != "alice@test.local" {
+		t.Fatalf("/userinfo after /token: email=%q, want alice@test.local (currentLogin not preserved?)", info.Email)
+	}
+}
+
+// TestParseRFC822CRLFBodyOffset — the parser must skip the actual
+// separator length, not a fixed 2. For "\r\n\r\n" (4 bytes) the
+// previous version left the body prefixed with a stray "\r\n".
+func TestParseRFC822CRLFBodyOffset(t *testing.T) {
+	m := hg.NewMock(t)
+	apiURL := m.Env()["GOOGLE_API_BASE_URL"]
+
+	// Build a CRLF RFC822 message.
+	raw := "From: bob@x\r\nTo: alice@x\r\nSubject: hi\r\n\r\nhello world"
+	encoded := strings.NewReader(`{"raw":"` + base64URLencodeShim(raw) + `"}`)
+	resp, err := http.Post(apiURL+"/gmail/v1/users/me/messages/send", "application/json", encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+
+	got := m.AssertSentEmailTo(t, "alice@x")
+	if got.Body != "hello world" {
+		t.Fatalf("body=%q, want %q (CRLF separator offset wrong?)", got.Body, "hello world")
+	}
+}
+
+// TestParseRFC822LFOnlyBodyOffset — non-standard but real "\n\n"
+// separator (2 bytes) still gives a clean body.
+func TestParseRFC822LFOnlyBodyOffset(t *testing.T) {
+	m := hg.NewMock(t)
+	apiURL := m.Env()["GOOGLE_API_BASE_URL"]
+	raw := "From: bob@x\nTo: alice@x\nSubject: lf\n\nlf-only body"
+	encoded := strings.NewReader(`{"raw":"` + base64URLencodeShim(raw) + `"}`)
+	resp, err := http.Post(apiURL+"/gmail/v1/users/me/messages/send", "application/json", encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	got := m.AssertSentEmailTo(t, "alice@x")
+	if got.Body != "lf-only body" {
+		t.Fatalf("body=%q, want %q", got.Body, "lf-only body")
+	}
+}
+
+// base64URLencodeShim mirrors the existing helper in google_test.go without
+// requiring this file to share that package-private name.
+func base64URLencodeShim(s string) string {
+	const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+	out := make([]byte, 0, len(s)*2)
+	bytes := []byte(s)
+	for i := 0; i < len(bytes); i += 3 {
+		n := uint32(bytes[i]) << 16
+		count := 1
+		if i+1 < len(bytes) {
+			n |= uint32(bytes[i+1]) << 8
+			count = 2
+		}
+		if i+2 < len(bytes) {
+			n |= uint32(bytes[i+2])
+			count = 3
+		}
+		for j := 0; j < 4; j++ {
+			if j > count {
+				out = append(out, '=')
+				continue
+			}
+			out = append(out, alphabet[(n>>(18-6*j))&0x3F])
+		}
+	}
+	return string(out)
+}

--- a/internal/testharness/google/google_test.go
+++ b/internal/testharness/google/google_test.go
@@ -94,13 +94,19 @@ func TestNextLoginConsumed(t *testing.T) {
 
 	// Use it once — should succeed.
 	form := url.Values{"code": {code}, "grant_type": {"authorization_code"}, "client_id": {"test"}}
-	r1, _ := http.PostForm(m.Env()["GOOGLE_TOKEN_URL"], form)
+	r1, err := http.PostForm(m.Env()["GOOGLE_TOKEN_URL"], form)
+	if err != nil {
+		t.Fatalf("first PostForm: %v", err)
+	}
 	r1.Body.Close()
 	if r1.StatusCode != http.StatusOK {
 		t.Fatalf("first exchange status=%d", r1.StatusCode)
 	}
 	// Use it again — should 400.
-	r2, _ := http.PostForm(m.Env()["GOOGLE_TOKEN_URL"], form)
+	r2, err := http.PostForm(m.Env()["GOOGLE_TOKEN_URL"], form)
+	if err != nil {
+		t.Fatalf("second PostForm: %v", err)
+	}
 	r2.Body.Close()
 	if r2.StatusCode == http.StatusOK {
 		t.Fatalf("replayed exchange accepted; want 400")

--- a/internal/testharness/google/google_test.go
+++ b/internal/testharness/google/google_test.go
@@ -1,0 +1,162 @@
+package google_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	hg "github.com/clawvisor/clawvisor/internal/testharness/google"
+)
+
+// TestOAuthRoundTrip drives the /authorize → /token → /userinfo flow as the
+// app would, then verifies the captured ID token matches the scripted user.
+func TestOAuthRoundTrip(t *testing.T) {
+	m := hg.NewMock(t)
+	m.NextLoginReturnsUser("alice@test.local")
+
+	// Step 1: hit /authorize like a browser would.
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			// Don't follow the callback redirect — capture the location.
+			return http.ErrUseLastResponse
+		},
+	}
+	authURL := m.OAuthAuthorizeURL() + "?client_id=test&redirect_uri=http%3A%2F%2Flocalhost%2Fcb&state=xyz&response_type=code"
+	resp, err := client.Get(authURL)
+	if err != nil {
+		t.Fatalf("authorize: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("authorize status=%d, want 302", resp.StatusCode)
+	}
+	loc, err := resp.Location()
+	if err != nil {
+		t.Fatalf("location: %v", err)
+	}
+	code := loc.Query().Get("code")
+	if code == "" {
+		t.Fatalf("no code in callback URL: %s", loc)
+	}
+
+	// Step 2: exchange code for tokens.
+	tokenURL := m.Env()["GOOGLE_TOKEN_URL"]
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("redirect_uri", "http://localhost/cb")
+	form.Set("client_id", "test")
+	form.Set("client_secret", "test-secret")
+	tokenResp, err := http.PostForm(tokenURL, form)
+	if err != nil {
+		t.Fatalf("token: %v", err)
+	}
+	defer tokenResp.Body.Close()
+	if tokenResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(tokenResp.Body)
+		t.Fatalf("token status=%d body=%s", tokenResp.StatusCode, body)
+	}
+	var tokOut struct {
+		AccessToken string `json:"access_token"`
+		IDToken     string `json:"id_token"`
+	}
+	if err := json.NewDecoder(tokenResp.Body).Decode(&tokOut); err != nil {
+		t.Fatal(err)
+	}
+	if tokOut.IDToken == "" || tokOut.AccessToken == "" {
+		t.Fatalf("missing tokens: %+v", tokOut)
+	}
+
+	// Step 3: ID token should be a 3-part JWT.
+	if parts := strings.Split(tokOut.IDToken, "."); len(parts) != 3 {
+		t.Fatalf("id_token not a JWT: %s", tokOut.IDToken)
+	}
+}
+
+// TestNextLoginConsumed verifies that one script powers one OAuth — second
+// /token with the same code returns invalid_grant.
+func TestNextLoginConsumed(t *testing.T) {
+	m := hg.NewMock(t)
+	m.NextLoginReturnsUser("bob@test.local")
+
+	// First flow consumes the script.
+	client := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
+	resp, err := client.Get(m.OAuthAuthorizeURL() + "?redirect_uri=http%3A%2F%2Flocalhost%2Fcb&state=s")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	loc, _ := resp.Location()
+	code := loc.Query().Get("code")
+
+	// Use it once — should succeed.
+	form := url.Values{"code": {code}, "grant_type": {"authorization_code"}, "client_id": {"test"}}
+	r1, _ := http.PostForm(m.Env()["GOOGLE_TOKEN_URL"], form)
+	r1.Body.Close()
+	if r1.StatusCode != http.StatusOK {
+		t.Fatalf("first exchange status=%d", r1.StatusCode)
+	}
+	// Use it again — should 400.
+	r2, _ := http.PostForm(m.Env()["GOOGLE_TOKEN_URL"], form)
+	r2.Body.Close()
+	if r2.StatusCode == http.StatusOK {
+		t.Fatalf("replayed exchange accepted; want 400")
+	}
+}
+
+// TestGmailSendCapture validates the Gmail.messages.send capture surface.
+func TestGmailSendCapture(t *testing.T) {
+	m := hg.NewMock(t)
+	apiURL := m.Env()["GOOGLE_API_BASE_URL"]
+
+	// Build a tiny raw RFC822 message base64url'd.
+	raw := "From: bob@x\r\nTo: alice@x\r\nSubject: hi\r\n\r\nhello world"
+	encoded := strings.NewReader(`{"raw":"` + base64URLencode(raw) + `"}`)
+
+	resp, err := http.Post(apiURL+"/gmail/v1/users/me/messages/send", "application/json", encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("send status=%d", resp.StatusCode)
+	}
+
+	got := m.AssertSentEmailTo(t, "alice@x")
+	if got.Subject != "hi" {
+		t.Fatalf("subject=%q", got.Subject)
+	}
+	if got.From != "bob@x" {
+		t.Fatalf("from=%q", got.From)
+	}
+}
+
+// base64URLencode mirrors what an SDK would do (Gmail wants URL-safe base64).
+func base64URLencode(s string) string {
+	out := make([]byte, 0, len(s)*2)
+	const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+	bytes := []byte(s)
+	for i := 0; i < len(bytes); i += 3 {
+		n := uint32(bytes[i]) << 16
+		count := 1
+		if i+1 < len(bytes) {
+			n |= uint32(bytes[i+1]) << 8
+			count = 2
+		}
+		if i+2 < len(bytes) {
+			n |= uint32(bytes[i+2])
+			count = 3
+		}
+		for j := 0; j < 4; j++ {
+			if j > count {
+				out = append(out, '=')
+				continue
+			}
+			out = append(out, alphabet[(n>>(18-6*j))&0x3F])
+		}
+	}
+	return string(out)
+}

--- a/internal/testharness/google/google_test.go
+++ b/internal/testharness/google/google_test.go
@@ -89,7 +89,10 @@ func TestNextLoginConsumed(t *testing.T) {
 		t.Fatal(err)
 	}
 	resp.Body.Close()
-	loc, _ := resp.Location()
+	loc, err := resp.Location()
+	if err != nil {
+		t.Fatalf("authorize did not redirect: %v (status=%d)", err, resp.StatusCode)
+	}
 	code := loc.Query().Get("code")
 
 	// Use it once — should succeed.

--- a/internal/testharness/httpmock/mock.go
+++ b/internal/testharness/httpmock/mock.go
@@ -1,0 +1,181 @@
+// Package httpmock is a small scriptable HTTP server used by per-service
+// mocks (Slack, GitHub, Notion, Linear, Twilio, Telegram, Microsoft Graph,
+// Stripe). Each mock declares a route + a default response; tests override
+// via `mock.OnNext(...)` for one-shot scripts or `mock.OnEvery(...)` for
+// sticky responses.
+package httpmock
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// Response is what handler scripts return.
+type Response struct {
+	Status int
+	Body   any               // marshalled to JSON if not []byte / string / nil
+	Header map[string]string // optional response headers
+}
+
+// Captured is one captured request (method, path, body, headers).
+type Captured struct {
+	Method  string
+	Path    string
+	Query   string
+	Body    []byte
+	Headers http.Header
+}
+
+// Server wraps an httptest.Server with scripting + capture.
+type Server struct {
+	mu       sync.Mutex
+	srv      *httptest.Server
+	routes   map[string]*routeState // key = "METHOD PATH"
+	captured []Captured
+}
+
+type routeState struct {
+	defaultResp Response
+	nextResps   []Response // FIFO; consumed per request
+	everyResp   *Response  // sticky
+}
+
+// New starts a fresh server with the given default routes (each entry is
+// "METHOD /path" → default Response). Cleanup runs via t.Cleanup.
+func New(t *testing.T, defaults map[string]Response) *Server {
+	t.Helper()
+	s := &Server{routes: map[string]*routeState{}}
+	mux := http.NewServeMux()
+	// Register routes from defaults.
+	keys := make([]string, 0, len(defaults))
+	for k := range defaults {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys) // stable order (mux.Handle panics on duplicate)
+	for _, k := range keys {
+		s.routes[k] = &routeState{defaultResp: defaults[k]}
+		// Mux uses Go 1.22+ method-path patterns.
+		mux.HandleFunc(k, s.handle(k))
+	}
+	s.srv = httptest.NewServer(mux)
+	t.Cleanup(s.srv.Close)
+	return s
+}
+
+// URL returns the server's base URL.
+func (s *Server) URL() string { return s.srv.URL }
+
+// OnNext queues a one-shot response for the next request matching key.
+// Calls are FIFO — three OnNext calls give responses to the next three
+// requests in order, then it falls back to the default.
+func (s *Server) OnNext(key string, r Response) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	rs, ok := s.routes[key]
+	if !ok {
+		panic("httpmock: OnNext unknown route " + key)
+	}
+	rs.nextResps = append(rs.nextResps, r)
+}
+
+// OnEvery sets a sticky response for all subsequent matches. Clears OnNext.
+func (s *Server) OnEvery(key string, r Response) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	rs, ok := s.routes[key]
+	if !ok {
+		panic("httpmock: OnEvery unknown route " + key)
+	}
+	rs.everyResp = &r
+	rs.nextResps = nil
+}
+
+// Captured returns all captured requests in order.
+func (s *Server) Captured() []Captured {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]Captured, len(s.captured))
+	copy(out, s.captured)
+	return out
+}
+
+// AssertReceived fails the test if no captured request matches the given
+// method+path (path may be a substring). Returns the first matching request.
+func (s *Server) AssertReceived(t *testing.T, method, pathSubstr string) Captured {
+	t.Helper()
+	for _, c := range s.Captured() {
+		if c.Method == method && strings.Contains(c.Path, pathSubstr) {
+			return c
+		}
+	}
+	t.Fatalf("httpmock: no %s request matching %q (captured %d)", method, pathSubstr, len(s.Captured()))
+	return Captured{}
+}
+
+// Reset clears captured + scripted state.
+func (s *Server) Reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.captured = nil
+	for _, rs := range s.routes {
+		rs.nextResps = nil
+		rs.everyResp = nil
+	}
+}
+
+func (s *Server) handle(key string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		r.Body.Close()
+
+		s.mu.Lock()
+		s.captured = append(s.captured, Captured{
+			Method: r.Method, Path: r.URL.Path, Query: r.URL.RawQuery,
+			Body: body, Headers: r.Header.Clone(),
+		})
+		rs := s.routes[key]
+		var resp Response
+		switch {
+		case len(rs.nextResps) > 0:
+			resp = rs.nextResps[0]
+			rs.nextResps = rs.nextResps[1:]
+		case rs.everyResp != nil:
+			resp = *rs.everyResp
+		default:
+			resp = rs.defaultResp
+		}
+		s.mu.Unlock()
+
+		for k, v := range resp.Header {
+			w.Header().Set(k, v)
+		}
+		if resp.Status == 0 {
+			resp.Status = http.StatusOK
+		}
+		// Default content-type for JSON-ish responses.
+		if w.Header().Get("Content-Type") == "" && resp.Body != nil {
+			w.Header().Set("Content-Type", "application/json")
+		}
+		w.WriteHeader(resp.Status)
+
+		switch b := resp.Body.(type) {
+		case nil:
+			// no body
+		case []byte:
+			_, _ = w.Write(b)
+		case string:
+			_, _ = w.Write([]byte(b))
+		default:
+			buf := &bytes.Buffer{}
+			_ = json.NewEncoder(buf).Encode(b)
+			_, _ = w.Write(buf.Bytes())
+		}
+	}
+}

--- a/internal/testharness/httpmock/mock.go
+++ b/internal/testharness/httpmock/mock.go
@@ -159,9 +159,17 @@ func (s *Server) handle(key string) http.HandlerFunc {
 		if resp.Status == 0 {
 			resp.Status = http.StatusOK
 		}
-		// Default content-type for JSON-ish responses.
-		if w.Header().Get("Content-Type") == "" && resp.Body != nil {
-			w.Header().Set("Content-Type", "application/json")
+		// Default Content-Type ONLY when we're about to JSON-marshal the
+		// body. Raw []byte / string bodies could be anything (text/html,
+		// image/png, RFC822 mail) and the caller should set Content-Type
+		// explicitly via Response.Header.
+		switch resp.Body.(type) {
+		case nil, []byte, string:
+			// no default
+		default:
+			if w.Header().Get("Content-Type") == "" {
+				w.Header().Set("Content-Type", "application/json")
+			}
 		}
 		w.WriteHeader(resp.Status)
 

--- a/internal/testharness/httpmock/mock_test.go
+++ b/internal/testharness/httpmock/mock_test.go
@@ -1,0 +1,50 @@
+package httpmock_test
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/internal/testharness/httpmock"
+)
+
+func TestDefaultAndScriptedResponses(t *testing.T) {
+	srv := httpmock.New(t, map[string]httpmock.Response{
+		"GET /hello":  {Body: map[string]string{"msg": "hi"}},
+		"POST /thing": {Status: 201, Body: map[string]string{"id": "x"}},
+	})
+
+	// Default GET.
+	resp, err := http.Get(srv.URL() + "/hello")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if !strings.Contains(string(body), `"msg":"hi"`) {
+		t.Fatalf("body=%s", body)
+	}
+
+	// OnNext one-shot.
+	srv.OnNext("GET /hello", httpmock.Response{Status: 503, Body: map[string]string{"err": "down"}})
+	r2, _ := http.Get(srv.URL() + "/hello")
+	b2, _ := io.ReadAll(r2.Body)
+	r2.Body.Close()
+	if r2.StatusCode != 503 || !strings.Contains(string(b2), `"err":"down"`) {
+		t.Fatalf("one-shot didn't fire: status=%d body=%s", r2.StatusCode, b2)
+	}
+
+	// Next request falls back to default.
+	r3, _ := http.Get(srv.URL() + "/hello")
+	if r3.StatusCode != 200 {
+		t.Fatalf("expected fall-back to default 200, got %d", r3.StatusCode)
+	}
+	r3.Body.Close()
+
+	// Capture works.
+	captured := srv.Captured()
+	if len(captured) != 3 {
+		t.Fatalf("captured=%d, want 3", len(captured))
+	}
+}

--- a/internal/testharness/linear/linear.go
+++ b/internal/testharness/linear/linear.go
@@ -1,0 +1,26 @@
+// Package linear provides a minimal Linear GraphQL mock for E2E tests.
+// Linear is GraphQL — all calls hit POST /graphql. We mock it as a single
+// endpoint that returns a configurable response per test.
+package linear
+
+import (
+	"testing"
+
+	"github.com/clawvisor/clawvisor/internal/testharness/httpmock"
+)
+
+type Mock struct{ *httpmock.Server }
+
+func NewMock(t *testing.T) *Mock {
+	t.Helper()
+	srv := httpmock.New(t, map[string]httpmock.Response{
+		"POST /graphql": {Body: map[string]any{"data": map[string]any{
+			"issues": map[string]any{"nodes": []any{}},
+		}}},
+	})
+	return &Mock{Server: srv}
+}
+
+func (m *Mock) Env() map[string]string {
+	return map[string]string{"LINEAR_API_BASE_URL": m.URL()}
+}

--- a/internal/testharness/llm/anthropic_live_test.go
+++ b/internal/testharness/llm/anthropic_live_test.go
@@ -1,0 +1,88 @@
+package llm_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	hllm "github.com/clawvisor/clawvisor/internal/testharness/llm"
+)
+
+// TestAnthropicLiveRecordReplay hits the real Anthropic API once to record
+// a cassette, then replays it deterministically. Skipped when
+// ANTHROPIC_API_KEY isn't set. Validates the cassette layer against the real
+// Anthropic Messages API wire shape.
+func TestAnthropicLiveRecordReplay(t *testing.T) {
+	key := os.Getenv("ANTHROPIC_API_KEY")
+	if key == "" {
+		t.Skip("ANTHROPIC_API_KEY not set")
+	}
+	dir := t.TempDir()
+
+	body := []byte(`{
+  "model": "claude-haiku-4-5-20251001",
+  "max_tokens": 16,
+  "messages": [{"role": "user", "content": "Reply with the word OK and nothing else."}]
+}`)
+
+	// Record one real call.
+	rec := hllm.NewCassette(dir, t.Name(), hllm.ModeRecord)
+	rec.SetUpstream(http.DefaultTransport)
+	req, _ := http.NewRequestWithContext(context.Background(), "POST",
+		"https://api.anthropic.com/v1/messages", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", key)
+	req.Header.Set("anthropic-version", "2023-06-01")
+	resp, err := rec.Client().Do(req)
+	if err != nil {
+		t.Fatalf("record live call: %v", err)
+	}
+	recBody, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("anthropic status=%d body=%s", resp.StatusCode, recBody)
+	}
+
+	// Confirm structurally — content[0].text exists.
+	var parsed struct {
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	if err := json.Unmarshal(recBody, &parsed); err != nil {
+		t.Fatalf("parse anthropic response: %v\n%s", err, recBody)
+	}
+	if len(parsed.Content) == 0 || parsed.Content[0].Type != "text" {
+		t.Fatalf("unexpected response shape: %s", recBody)
+	}
+
+	// Now replay without hitting the network — re-send the same request and
+	// verify the body matches.
+	rep := hllm.NewCassette(dir, t.Name(), hllm.ModeReplay)
+	req2, _ := http.NewRequestWithContext(context.Background(), "POST",
+		"https://api.anthropic.com/v1/messages", bytes.NewReader(body))
+	req2.Header.Set("Content-Type", "application/json")
+	req2.Header.Set("x-api-key", "FAKE-KEY-NOT-VALID") // replay shouldn't care
+	req2.Header.Set("anthropic-version", "2023-06-01")
+	resp2, err := rep.Client().Do(req2)
+	if err != nil {
+		t.Fatalf("replay: %v", err)
+	}
+	repBody, _ := io.ReadAll(resp2.Body)
+	resp2.Body.Close()
+	if !bytes.Equal(recBody, repBody) {
+		t.Fatalf("replay body mismatch")
+	}
+
+	// Cassette file present on disk.
+	files, _ := filepath.Glob(filepath.Join(dir, "*", "*.json"))
+	if len(files) != 1 {
+		t.Fatalf("expected 1 cassette file on disk, got %d (%v)", len(files), files)
+	}
+}

--- a/internal/testharness/llm/anthropic_live_test.go
+++ b/internal/testharness/llm/anthropic_live_test.go
@@ -42,8 +42,11 @@ func TestAnthropicLiveRecordReplay(t *testing.T) {
 	if err != nil {
 		t.Fatalf("record live call: %v", err)
 	}
-	recBody, _ := io.ReadAll(resp.Body)
+	recBody, err := io.ReadAll(resp.Body)
 	resp.Body.Close()
+	if err != nil {
+		t.Fatalf("read record body: %v", err)
+	}
 	if resp.StatusCode != 200 {
 		t.Fatalf("anthropic status=%d body=%s", resp.StatusCode, recBody)
 	}
@@ -74,8 +77,11 @@ func TestAnthropicLiveRecordReplay(t *testing.T) {
 	if err != nil {
 		t.Fatalf("replay: %v", err)
 	}
-	repBody, _ := io.ReadAll(resp2.Body)
+	repBody, err := io.ReadAll(resp2.Body)
 	resp2.Body.Close()
+	if err != nil {
+		t.Fatalf("read replay body: %v", err)
+	}
 	if !bytes.Equal(recBody, repBody) {
 		t.Fatalf("replay body mismatch")
 	}

--- a/internal/testharness/llm/cassette.go
+++ b/internal/testharness/llm/cassette.go
@@ -67,6 +67,14 @@ type Cassette struct {
 	seq       atomic.Int64
 	mu        sync.Mutex
 	turnIndex map[string]int // request-key → index of next take
+
+	// loaded is the in-memory cache of cassette entries on disk. Populated
+	// on first replay; subsequent replays consult this rather than
+	// re-reading and re-parsing every JSON file (which was O(n²) total
+	// I/O for n requests).
+	loaded     []cassetteEntry
+	loadedOnce sync.Once
+	loadedErr  error
 }
 
 // NewCassette creates a cassette for testName, rooted at dir (typically
@@ -133,11 +141,21 @@ func (c *Cassette) RoundTrip(req *http.Request) (*http.Response, error) {
 		if err != nil {
 			return nil, fmt.Errorf("cassette: %w (set LLM_MODE=record to recreate)", err)
 		}
+		// Build a response that matches the shape http.DefaultTransport
+		// would have returned for a real call. Some clients (and middleware
+		// layers like net/http itself) read Status/Proto/ContentLength —
+		// leaving them zero diverges from production behavior.
+		bodyBytes := []byte(entry.Response.Body)
 		resp := &http.Response{
-			StatusCode: entry.Response.Status,
-			Header:     unflattenHeaders(entry.Response.Headers),
-			Body:       io.NopCloser(strings.NewReader(entry.Response.Body)),
-			Request:    req,
+			Status:        fmt.Sprintf("%d %s", entry.Response.Status, http.StatusText(entry.Response.Status)),
+			StatusCode:    entry.Response.Status,
+			Proto:         "HTTP/1.1",
+			ProtoMajor:    1,
+			ProtoMinor:    1,
+			Header:        unflattenHeaders(entry.Response.Headers),
+			Body:          io.NopCloser(bytes.NewReader(bodyBytes)),
+			ContentLength: int64(len(bodyBytes)),
+			Request:       req,
 		}
 		return resp, nil
 	}
@@ -166,9 +184,9 @@ type cassetteRequest struct {
 }
 
 type cassetteResponse struct {
-	Status  int               `json:"status"`
-	Headers map[string]string `json:"headers"`
-	Body    string            `json:"body"`
+	Status  int                 `json:"status"`
+	Headers map[string][]string `json:"headers"`
+	Body    string              `json:"body"`
 }
 
 // requestKey is a stable hash of (method, path, normalized-body) used to
@@ -236,20 +254,29 @@ func readAndRestore(req *http.Request) ([]byte, error) {
 	return body, nil
 }
 
-func flattenHeaders(h http.Header) map[string]string {
-	out := map[string]string{}
+// flattenHeaders converts http.Header to the on-disk shape. Preserves
+// per-value cardinality so multi-valued headers (Set-Cookie, Via, Link…)
+// round-trip correctly. Earlier versions joined values with ',' which
+// silently fused distinct Set-Cookie entries into one corrupted header.
+func flattenHeaders(h http.Header) map[string][]string {
+	out := make(map[string][]string, len(h))
 	for k, v := range h {
-		if len(v) > 0 {
-			out[k] = strings.Join(v, ",")
+		if len(v) == 0 {
+			continue
 		}
+		dup := make([]string, len(v))
+		copy(dup, v)
+		out[k] = dup
 	}
 	return out
 }
 
-func unflattenHeaders(m map[string]string) http.Header {
+func unflattenHeaders(m map[string][]string) http.Header {
 	h := http.Header{}
-	for k, v := range m {
-		h.Set(k, v)
+	for k, vs := range m {
+		for _, v := range vs {
+			h.Add(k, v)
+		}
 	}
 	return h
 }
@@ -276,17 +303,24 @@ func (c *Cassette) writeNext(entry cassetteEntry) error {
 // readNext returns the next entry matching key. Entries are read in
 // directory order and matched per-key — so a test that fires (A, B, A) sees
 // the first A, then B, then the second A.
+//
+// The cassette dir is read + parsed once per Cassette instance (cached on
+// the receiver). Earlier implementations re-walked the directory on every
+// replay request — O(n²) total I/O for n requests.
 func (c *Cassette) readNext(key string) (cassetteEntry, error) {
+	c.loadedOnce.Do(func() {
+		c.loaded, c.loadedErr = loadAllEntries(c.dir)
+	})
+	if c.loadedErr != nil {
+		return cassetteEntry{}, c.loadedErr
+	}
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	entries, err := loadAllEntries(c.dir)
-	if err != nil {
-		return cassetteEntry{}, err
-	}
 	matching := 0
 	want := c.turnIndex[key]
-	for _, e := range entries {
+	for _, e := range c.loaded {
 		if e.Request.Key == key {
 			if matching == want {
 				c.turnIndex[key] = want + 1

--- a/internal/testharness/llm/cassette.go
+++ b/internal/testharness/llm/cassette.go
@@ -1,0 +1,323 @@
+// Package llm provides record/replay/passthrough middleware for LLM API
+// calls (Anthropic, OpenAI). Tests run in one of three modes:
+//
+//	LLM_MODE=replay       — read cassette from disk; never hit network (default)
+//	LLM_MODE=record       — hit real API; write cassette to disk
+//	LLM_MODE=passthrough  — hit real API; do not write cassette
+//
+// Cassettes are committed JSON files under testdata/llm-cassettes/<test>/
+// — one file per request, named by sequence ("000.json", "001.json", …).
+// Request matching uses (method, host, path, body-hash) so test reruns
+// replay deterministically.
+//
+// Wiring:
+//
+//	The middleware is an http.RoundTripper. Tests inject it as the Transport
+//	on the http.Client passed to the Anthropic / OpenAI SDK constructors.
+//	For subprocess tests, point ANTHROPIC_BASE_URL / OPENAI_BASE_URL at a
+//	local proxy that records/replays — see Server() in proxy.go.
+package llm
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+)
+
+// Mode controls cassette behavior. Default is replay; tests can override per
+// test via SetMode(t, "passthrough") if they really need live LLM output.
+type Mode string
+
+const (
+	ModeReplay      Mode = "replay"
+	ModeRecord      Mode = "record"
+	ModePassthrough Mode = "passthrough"
+)
+
+// CurrentMode returns the active mode from $LLM_MODE, defaulting to replay.
+func CurrentMode() Mode {
+	switch strings.ToLower(os.Getenv("LLM_MODE")) {
+	case "record":
+		return ModeRecord
+	case "passthrough":
+		return ModePassthrough
+	default:
+		return ModeReplay
+	}
+}
+
+// Cassette wraps an http.RoundTripper. Tests construct one per-test (so
+// recordings end up isolated per scenario file/test name) and inject it
+// into LLM client construction.
+type Cassette struct {
+	dir       string
+	mode      Mode
+	upstream  http.RoundTripper
+	seq       atomic.Int64
+	mu        sync.Mutex
+	turnIndex map[string]int // request-key → index of next take
+}
+
+// NewCassette creates a cassette for testName, rooted at dir (typically
+// testdata/llm-cassettes). The directory is created if missing in record
+// mode and read on every roundtrip in replay mode.
+func NewCassette(dir, testName string, mode Mode) *Cassette {
+	d := filepath.Join(dir, sanitize(testName))
+	return &Cassette{
+		dir:       d,
+		mode:      mode,
+		upstream:  http.DefaultTransport,
+		turnIndex: map[string]int{},
+	}
+}
+
+// RoundTrip implements http.RoundTripper.
+func (c *Cassette) RoundTrip(req *http.Request) (*http.Response, error) {
+	body, err := readAndRestore(req)
+	if err != nil {
+		return nil, err
+	}
+	key := requestKey(req, body)
+
+	switch c.mode {
+	case ModePassthrough:
+		return c.upstream.RoundTrip(req)
+
+	case ModeRecord:
+		if err := os.MkdirAll(c.dir, 0755); err != nil {
+			return nil, fmt.Errorf("cassette mkdir: %w", err)
+		}
+		// Re-build the body since RoundTrip below consumes it.
+		req.Body = io.NopCloser(bytes.NewReader(body))
+		resp, err := c.upstream.RoundTrip(req)
+		if err != nil {
+			return nil, err
+		}
+		respBody, err := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if err != nil {
+			return nil, err
+		}
+		entry := cassetteEntry{
+			Request: cassetteRequest{
+				Method: req.Method,
+				URL:    req.URL.String(),
+				Body:   string(body),
+				Key:    key,
+			},
+			Response: cassetteResponse{
+				Status:  resp.StatusCode,
+				Headers: flattenHeaders(resp.Header),
+				Body:    string(respBody),
+			},
+		}
+		if err := c.writeNext(entry); err != nil {
+			return nil, err
+		}
+		resp.Body = io.NopCloser(bytes.NewReader(respBody))
+		return resp, nil
+
+	default: // ModeReplay
+		entry, err := c.readNext(key)
+		if err != nil {
+			return nil, fmt.Errorf("cassette: %w (set LLM_MODE=record to recreate)", err)
+		}
+		resp := &http.Response{
+			StatusCode: entry.Response.Status,
+			Header:     unflattenHeaders(entry.Response.Headers),
+			Body:       io.NopCloser(strings.NewReader(entry.Response.Body)),
+			Request:    req,
+		}
+		return resp, nil
+	}
+}
+
+// Client returns an *http.Client that uses this cassette as its transport.
+func (c *Cassette) Client() *http.Client {
+	return &http.Client{Transport: c}
+}
+
+// SetUpstream overrides the default RoundTripper used in record/passthrough
+// modes. Useful when tests want to layer their own logging.
+func (c *Cassette) SetUpstream(rt http.RoundTripper) { c.upstream = rt }
+
+// cassetteEntry is one recorded request/response pair.
+type cassetteEntry struct {
+	Request  cassetteRequest  `json:"request"`
+	Response cassetteResponse `json:"response"`
+}
+
+type cassetteRequest struct {
+	Method string `json:"method"`
+	URL    string `json:"url"`
+	Body   string `json:"body"`
+	Key    string `json:"key"`
+}
+
+type cassetteResponse struct {
+	Status  int               `json:"status"`
+	Headers map[string]string `json:"headers"`
+	Body    string            `json:"body"`
+}
+
+// requestKey is a stable hash of (method, path, normalized-body) used to
+// match record/replay. Host is intentionally omitted so cassettes survive
+// upstream-URL changes (per-test ephemeral ports, prod vs staging, etc).
+// Body is normalized by parsing JSON and sorting keys so cosmetic
+// field-order differences don't break replay.
+func requestKey(req *http.Request, body []byte) string {
+	h := sha256.New()
+	fmt.Fprintln(h, req.Method)
+	fmt.Fprintln(h, req.URL.Path)
+	if u, err := url.Parse(req.URL.String()); err == nil {
+		fmt.Fprintln(h, u.RawQuery)
+	}
+	h.Write(normalizeJSONBody(body))
+	return hex.EncodeToString(h.Sum(nil))[:16]
+}
+
+func normalizeJSONBody(b []byte) []byte {
+	if len(b) == 0 {
+		return b
+	}
+	var v any
+	if err := json.Unmarshal(b, &v); err != nil {
+		return b // not JSON; use as-is
+	}
+	out, _ := json.Marshal(sortMaps(v))
+	return out
+}
+
+func sortMaps(v any) any {
+	switch x := v.(type) {
+	case map[string]any:
+		keys := make([]string, 0, len(x))
+		for k := range x {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		out := map[string]any{}
+		for _, k := range keys {
+			out[k] = sortMaps(x[k])
+		}
+		return out
+	case []any:
+		out := make([]any, len(x))
+		for i, e := range x {
+			out[i] = sortMaps(e)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+func readAndRestore(req *http.Request) ([]byte, error) {
+	if req.Body == nil {
+		return nil, nil
+	}
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	_ = req.Body.Close()
+	req.Body = io.NopCloser(bytes.NewReader(body))
+	return body, nil
+}
+
+func flattenHeaders(h http.Header) map[string]string {
+	out := map[string]string{}
+	for k, v := range h {
+		if len(v) > 0 {
+			out[k] = strings.Join(v, ",")
+		}
+	}
+	return out
+}
+
+func unflattenHeaders(m map[string]string) http.Header {
+	h := http.Header{}
+	for k, v := range m {
+		h.Set(k, v)
+	}
+	return h
+}
+
+func sanitize(s string) string {
+	r := strings.NewReplacer("/", "_", ":", "_", " ", "-", ".", "-")
+	return r.Replace(s)
+}
+
+// writeNext writes the entry to dir/NNN.json with monotonically increasing
+// sequence number across the cassette's lifetime.
+func (c *Cassette) writeNext(entry cassetteEntry) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	idx := c.seq.Add(1) - 1
+	path := filepath.Join(c.dir, fmt.Sprintf("%03d.json", idx))
+	b, err := json.MarshalIndent(entry, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, b, 0644)
+}
+
+// readNext returns the next entry matching key. Entries are read in
+// directory order and matched per-key — so a test that fires (A, B, A) sees
+// the first A, then B, then the second A.
+func (c *Cassette) readNext(key string) (cassetteEntry, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	entries, err := loadAllEntries(c.dir)
+	if err != nil {
+		return cassetteEntry{}, err
+	}
+	matching := 0
+	want := c.turnIndex[key]
+	for _, e := range entries {
+		if e.Request.Key == key {
+			if matching == want {
+				c.turnIndex[key] = want + 1
+				return e, nil
+			}
+			matching++
+		}
+	}
+	return cassetteEntry{}, fmt.Errorf("no entry %d for key %s in %s", want, key, c.dir)
+}
+
+func loadAllEntries(dir string) ([]cassetteEntry, error) {
+	files, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].Name() < files[j].Name() })
+	out := make([]cassetteEntry, 0, len(files))
+	for _, f := range files {
+		if !strings.HasSuffix(f.Name(), ".json") {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(dir, f.Name()))
+		if err != nil {
+			return nil, err
+		}
+		var e cassetteEntry
+		if err := json.Unmarshal(b, &e); err != nil {
+			return nil, err
+		}
+		out = append(out, e)
+	}
+	return out, nil
+}

--- a/internal/testharness/llm/cassette_fidelity_test.go
+++ b/internal/testharness/llm/cassette_fidelity_test.go
@@ -1,0 +1,145 @@
+package llm_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	hllm "github.com/clawvisor/clawvisor/internal/testharness/llm"
+)
+
+// TestReplayedResponsePreservesProtoStatusAndContentLength — the
+// replayed http.Response must carry the same Status / Proto /
+// ContentLength shape http.DefaultTransport would have produced.
+// Callers that gate body reads on ContentLength or check Status text
+// otherwise see zero values on replay and diverge from record.
+func TestReplayedResponsePreservesProtoStatusAndContentLength(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer upstream.Close()
+	dir := t.TempDir()
+
+	rec := hllm.NewCassette(dir, "t", hllm.ModeRecord)
+	rec.SetUpstream(http.DefaultTransport)
+	if _, err := rec.Client().Post(upstream.URL, "application/json",
+		strings.NewReader(`{}`)); err != nil {
+		t.Fatal(err)
+	}
+
+	rep := hllm.NewCassette(dir, "t", hllm.ModeReplay)
+	resp, err := rep.Client().Post(upstream.URL, "application/json",
+		strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.Status == "" {
+		t.Fatal("replayed Response has empty Status text")
+	}
+	if !strings.HasPrefix(resp.Status, "200") {
+		t.Fatalf("Status=%q, want 200 prefix", resp.Status)
+	}
+	if resp.Proto != "HTTP/1.1" {
+		t.Fatalf("Proto=%q, want HTTP/1.1", resp.Proto)
+	}
+	if resp.ProtoMajor != 1 || resp.ProtoMinor != 1 {
+		t.Fatalf("ProtoMajor/Minor=%d/%d", resp.ProtoMajor, resp.ProtoMinor)
+	}
+	if resp.ContentLength <= 0 {
+		t.Fatalf("ContentLength=%d, want >0 for body %q", resp.ContentLength, `{"ok":true}`)
+	}
+}
+
+// TestReplayedResponsePreservesMultiValuedHeaders — Set-Cookie (and
+// other naturally-multi-valued headers) must round-trip with their
+// cardinality intact. Earlier the on-disk shape was map[string]string
+// joined with ',', which silently fused distinct Set-Cookie values
+// into one corrupted header.
+func TestReplayedResponsePreservesMultiValuedHeaders(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Set-Cookie", "a=1; Path=/")
+		w.Header().Add("Set-Cookie", "b=2; Path=/")
+		w.Header().Add("Link", "<https://x/p1>; rel=next")
+		w.Header().Add("Link", "<https://x/p2>; rel=prev")
+		_, _ = w.Write([]byte(`ok`))
+	}))
+	defer upstream.Close()
+	dir := t.TempDir()
+
+	rec := hllm.NewCassette(dir, "t", hllm.ModeRecord)
+	rec.SetUpstream(http.DefaultTransport)
+	r1, err := rec.Client().Get(upstream.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = io.ReadAll(r1.Body)
+	r1.Body.Close()
+	if got, want := len(r1.Header.Values("Set-Cookie")), 2; got != want {
+		t.Fatalf("recorded headers wrong: Set-Cookie count=%d, want %d", got, want)
+	}
+
+	rep := hllm.NewCassette(dir, "t", hllm.ModeReplay)
+	r2, err := rep.Client().Get(upstream.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r2.Body.Close()
+	if got, want := len(r2.Header.Values("Set-Cookie")), 2; got != want {
+		t.Fatalf("replayed Set-Cookie count=%d, want %d (multi-value fused?)", got, want)
+	}
+	if r2.Header.Values("Set-Cookie")[0] != "a=1; Path=/" {
+		t.Fatalf("replayed Set-Cookie[0]=%q", r2.Header.Values("Set-Cookie")[0])
+	}
+	if got := r2.Header.Values("Link"); len(got) != 2 {
+		t.Fatalf("replayed Link count=%d, want 2", len(got))
+	}
+}
+
+// TestCassetteEntriesLoadedOnce — replaying N requests must NOT re-read
+// the cassette directory N times. We assert that by verifying repeated
+// reads after the cassette dir is wiped: with the cache, subsequent
+// replays still find the data; without it, they would error.
+func TestCassetteEntriesLoadedOnce(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`ok`))
+	}))
+	defer upstream.Close()
+	dir := t.TempDir()
+
+	// Record three calls.
+	rec := hllm.NewCassette(dir, "t", hllm.ModeRecord)
+	rec.SetUpstream(http.DefaultTransport)
+	for i := 0; i < 3; i++ {
+		r, err := rec.Client().Post(upstream.URL, "application/json", strings.NewReader(`{}`))
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, _ = io.ReadAll(r.Body)
+		r.Body.Close()
+	}
+
+	rep := hllm.NewCassette(dir, "t", hllm.ModeReplay)
+	// First replay: cache is populated from disk.
+	if _, err := rep.Client().Post(upstream.URL, "application/json", strings.NewReader(`{}`)); err != nil {
+		t.Fatalf("first replay: %v", err)
+	}
+	// Now wipe the cassette dir. If readNext were still reading from disk
+	// on every call, the next replays would fail.
+	if err := wipeDir(dir); err != nil {
+		t.Fatalf("wipe: %v", err)
+	}
+	for i := 0; i < 2; i++ {
+		if _, err := rep.Client().Post(upstream.URL, "application/json", strings.NewReader(`{}`)); err != nil {
+			t.Fatalf("post-wipe replay %d: %v (cache didn't populate?)", i, err)
+		}
+	}
+}
+
+func wipeDir(dir string) error {
+	return os.RemoveAll(dir)
+}

--- a/internal/testharness/llm/cassette_test.go
+++ b/internal/testharness/llm/cassette_test.go
@@ -1,0 +1,90 @@
+package llm_test
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	hllm "github.com/clawvisor/clawvisor/internal/testharness/llm"
+)
+
+// TestRecordThenReplay validates the basic record→replay loop: hit a real
+// upstream once in record mode, then replay deterministically without
+// touching the upstream.
+func TestRecordThenReplay(t *testing.T) {
+	hits := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_123","role":"assistant","content":[{"type":"text","text":"hello"}]}`))
+	}))
+	defer upstream.Close()
+
+	dir := t.TempDir()
+
+	// Record.
+	rec := hllm.NewCassette(dir, "t", hllm.ModeRecord)
+	rec.SetUpstream(http.DefaultTransport)
+	resp, err := rec.Client().Post(upstream.URL+"/v1/messages", "application/json",
+		strings.NewReader(`{"model":"claude-opus-4-7","messages":[{"role":"user","content":"hi"}]}`))
+	if err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if hits != 1 {
+		t.Fatalf("expected 1 upstream hit during record, got %d", hits)
+	}
+	if !strings.Contains(string(body), "msg_123") {
+		t.Fatalf("body=%s", body)
+	}
+
+	// Replay (different cassette instance, same dir).
+	rep := hllm.NewCassette(dir, "t", hllm.ModeReplay)
+	resp2, err := rep.Client().Post(upstream.URL+"/v1/messages", "application/json",
+		strings.NewReader(`{"model":"claude-opus-4-7","messages":[{"role":"user","content":"hi"}]}`))
+	if err != nil {
+		t.Fatalf("replay: %v", err)
+	}
+	body2, _ := io.ReadAll(resp2.Body)
+	resp2.Body.Close()
+	if hits != 1 {
+		t.Fatalf("upstream hit during replay (got %d total)", hits)
+	}
+	if !bytes.Equal(body, body2) {
+		t.Fatalf("replay body mismatch:\nrec: %s\nrep: %s", body, body2)
+	}
+
+	// One cassette file was written.
+	entries, _ := filepath.Glob(filepath.Join(dir, "t", "*.json"))
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 cassette file, got %d", len(entries))
+	}
+}
+
+// TestNormalizedBodyMatch validates that the same logical JSON in different
+// key order matches the same cassette entry.
+func TestNormalizedBodyMatch(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer upstream.Close()
+
+	dir := t.TempDir()
+	rec := hllm.NewCassette(dir, "t", hllm.ModeRecord)
+	if _, err := rec.Client().Post(upstream.URL, "application/json",
+		strings.NewReader(`{"a":1,"b":2}`)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Different key order in replay request — should still match.
+	rep := hllm.NewCassette(dir, "t", hllm.ModeReplay)
+	if _, err := rep.Client().Post(upstream.URL, "application/json",
+		strings.NewReader(`{"b":2,"a":1}`)); err != nil {
+		t.Fatalf("replay should match despite key reorder: %v", err)
+	}
+}

--- a/internal/testharness/llm/server.go
+++ b/internal/testharness/llm/server.go
@@ -1,0 +1,79 @@
+package llm
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+// Server hosts a cassette-backed HTTP endpoint. Clawvisor's
+// CLAWVISOR_LLM_UPSTREAM_* env vars point at this URL.
+//
+// Cassette-key host normalization: the upstream's actual host (often a
+// per-run ephemeral port) is rewritten to a stable canonical host before
+// the request hits the cassette transport. That keeps the cassette key
+// deterministic across runs — record once on port 12345, replay on port
+// 54321, same key.
+//
+// Modes (driven by the underlying Cassette):
+//   ModeReplay      — answers from disk; upstream URL is irrelevant
+//   ModeRecord      — forwards to upstream, captures the response
+//   ModePassthrough — forwards to upstream, captures nothing
+type Server struct {
+	srv          *httptest.Server
+	cassette     *Cassette
+	upstream     string // where to forward in record/passthrough modes
+	canonicalURL *url.URL
+}
+
+// NewServer starts a cassette-backed HTTP server. `upstream` is the URL the
+// cassette layer should forward to in record/passthrough modes (e.g., the
+// real https://api.anthropic.com or a stub). For cassette key purposes the
+// host is normalized to upstream's scheme+host as parsed once at construction.
+func NewServer(t *testing.T, cassette *Cassette, upstream string) *Server {
+	t.Helper()
+	if upstream == "" {
+		upstream = "https://api.anthropic.com"
+	}
+	canon, err := url.Parse(upstream)
+	if err != nil {
+		t.Fatalf("cassette: invalid upstream URL %q: %v", upstream, err)
+	}
+	s := &Server{cassette: cassette, upstream: upstream, canonicalURL: canon}
+	s.srv = httptest.NewServer(http.HandlerFunc(s.handle))
+	t.Cleanup(s.srv.Close)
+	return s
+}
+
+func (s *Server) URL() string { return s.srv.URL }
+
+func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
+	upstreamReq, err := http.NewRequestWithContext(r.Context(), r.Method,
+		s.upstream+r.URL.RequestURI(), r.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	for k, v := range r.Header {
+		switch k {
+		case "Host", "Connection", "Content-Length":
+			continue
+		}
+		upstreamReq.Header[k] = v
+	}
+
+	resp, err := s.cassette.RoundTrip(upstreamReq)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	for k, v := range resp.Header {
+		w.Header()[k] = v
+	}
+	w.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(w, resp.Body)
+}

--- a/internal/testharness/llm/server.go
+++ b/internal/testharness/llm/server.go
@@ -4,44 +4,36 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"testing"
 )
 
 // Server hosts a cassette-backed HTTP endpoint. Clawvisor's
 // CLAWVISOR_LLM_UPSTREAM_* env vars point at this URL.
 //
-// Cassette-key host normalization: the upstream's actual host (often a
-// per-run ephemeral port) is rewritten to a stable canonical host before
-// the request hits the cassette transport. That keeps the cassette key
-// deterministic across runs — record once on port 12345, replay on port
-// 54321, same key.
+// Cassette-key stability across runs is achieved by Cassette.requestKey
+// omitting the host entirely — so this server does not need to perform
+// any URL rewriting before invoking the cassette transport.
 //
 // Modes (driven by the underlying Cassette):
 //   ModeReplay      — answers from disk; upstream URL is irrelevant
 //   ModeRecord      — forwards to upstream, captures the response
 //   ModePassthrough — forwards to upstream, captures nothing
 type Server struct {
-	srv          *httptest.Server
-	cassette     *Cassette
-	upstream     string // where to forward in record/passthrough modes
-	canonicalURL *url.URL
+	srv      *httptest.Server
+	cassette *Cassette
+	upstream string // where to forward in record/passthrough modes
 }
 
-// NewServer starts a cassette-backed HTTP server. `upstream` is the URL the
-// cassette layer should forward to in record/passthrough modes (e.g., the
-// real https://api.anthropic.com or a stub). For cassette key purposes the
-// host is normalized to upstream's scheme+host as parsed once at construction.
+// NewServer starts a cassette-backed HTTP server. `upstream` is the URL
+// the cassette layer should forward to in record/passthrough modes
+// (e.g., the real https://api.anthropic.com or a stub). In replay mode
+// the upstream URL is not consulted.
 func NewServer(t *testing.T, cassette *Cassette, upstream string) *Server {
 	t.Helper()
 	if upstream == "" {
 		upstream = "https://api.anthropic.com"
 	}
-	canon, err := url.Parse(upstream)
-	if err != nil {
-		t.Fatalf("cassette: invalid upstream URL %q: %v", upstream, err)
-	}
-	s := &Server{cassette: cassette, upstream: upstream, canonicalURL: canon}
+	s := &Server{cassette: cassette, upstream: upstream}
 	s.srv = httptest.NewServer(http.HandlerFunc(s.handle))
 	t.Cleanup(s.srv.Close)
 	return s

--- a/internal/testharness/microsoft/microsoft.go
+++ b/internal/testharness/microsoft/microsoft.go
@@ -1,0 +1,32 @@
+// Package microsoft provides a minimal Microsoft Graph API mock for E2E
+// tests (Outlook + OneDrive).
+package microsoft
+
+import (
+	"testing"
+
+	"github.com/clawvisor/clawvisor/internal/testharness/httpmock"
+)
+
+type Mock struct{ *httpmock.Server }
+
+func NewMock(t *testing.T) *Mock {
+	t.Helper()
+	srv := httpmock.New(t, map[string]httpmock.Response{
+		// Outlook messages.
+		"GET /v1.0/me/messages":          {Body: map[string]any{"value": []any{}}},
+		"GET /v1.0/me/messages/{id}":     {Body: map[string]any{"id": "mock"}},
+		"POST /v1.0/me/sendMail":         {Status: 202},
+		// Outlook calendar.
+		"GET /v1.0/me/calendar/events":     {Body: map[string]any{"value": []any{}}},
+		"POST /v1.0/me/calendar/events":    {Status: 201, Body: map[string]any{"id": "mock-event"}},
+		// OneDrive.
+		"GET /v1.0/me/drive/root/children": {Body: map[string]any{"value": []any{}}},
+		"GET /v1.0/me/drive/items/{id}":    {Body: map[string]any{"id": "mock"}},
+	})
+	return &Mock{Server: srv}
+}
+
+func (m *Mock) Env() map[string]string {
+	return map[string]string{"MICROSOFT_GRAPH_BASE_URL": m.URL()}
+}

--- a/internal/testharness/notion/notion.go
+++ b/internal/testharness/notion/notion.go
@@ -1,0 +1,27 @@
+// Package notion provides a minimal Notion API mock for E2E tests.
+package notion
+
+import (
+	"testing"
+
+	"github.com/clawvisor/clawvisor/internal/testharness/httpmock"
+)
+
+type Mock struct{ *httpmock.Server }
+
+func NewMock(t *testing.T) *Mock {
+	t.Helper()
+	srv := httpmock.New(t, map[string]httpmock.Response{
+		"POST /v1/search":                    {Body: map[string]any{"object": "list", "results": []any{}}},
+		"GET /v1/pages/{id}":                 {Body: map[string]any{"object": "page", "id": "mock"}},
+		"POST /v1/pages":                     {Body: map[string]any{"object": "page", "id": "mock-created"}},
+		"PATCH /v1/pages/{id}":               {Body: map[string]any{"object": "page", "id": "mock"}},
+		"POST /v1/databases/{id}/query":      {Body: map[string]any{"object": "list", "results": []any{}}},
+		"GET /v1/databases":                  {Body: map[string]any{"object": "list", "results": []any{}}},
+	})
+	return &Mock{Server: srv}
+}
+
+func (m *Mock) Env() map[string]string {
+	return map[string]string{"NOTION_API_BASE_URL": m.URL()}
+}

--- a/internal/testharness/slack/slack.go
+++ b/internal/testharness/slack/slack.go
@@ -1,0 +1,40 @@
+// Package slack provides a minimal Slack Web API mock for E2E tests.
+package slack
+
+import (
+	"testing"
+
+	"github.com/clawvisor/clawvisor/internal/testharness/httpmock"
+)
+
+type Mock struct {
+	*httpmock.Server
+}
+
+func NewMock(t *testing.T) *Mock {
+	t.Helper()
+	srv := httpmock.New(t, map[string]httpmock.Response{
+		"GET /api/conversations.list": {Body: map[string]any{
+			"ok":       true,
+			"channels": []map[string]any{},
+		}},
+		"GET /api/conversations.history": {Body: map[string]any{
+			"ok":       true,
+			"messages": []map[string]any{},
+		}},
+		"POST /api/chat.postMessage": {Body: map[string]any{
+			"ok":      true,
+			"ts":      "1700000000.000100",
+			"channel": "C-MOCK",
+		}},
+		"GET /api/users.list": {Body: map[string]any{
+			"ok":      true,
+			"members": []map[string]any{},
+		}},
+	})
+	return &Mock{Server: srv}
+}
+
+func (m *Mock) Env() map[string]string {
+	return map[string]string{"SLACK_API_BASE_URL": m.URL()}
+}

--- a/internal/testharness/telegram/telegram.go
+++ b/internal/testharness/telegram/telegram.go
@@ -1,0 +1,104 @@
+// Package telegram provides a minimal Telegram Bot API mock for E2E tests.
+//
+// Telegram URLs embed the bot token in the path (/bot<TOKEN>/method) which
+// the Go 1.22 mux can't express as a path wildcard. We sidestep that by
+// stripping the /bot<token>/ prefix in middleware and dispatching on the
+// trailing method segment alone.
+package telegram
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+type Mock struct {
+	mu       sync.Mutex
+	srv      *httptest.Server
+	captured []Captured
+}
+
+type Captured struct {
+	Method   string         // Telegram method: "sendMessage", "getMe", …
+	HTTPVerb string         // POST / GET
+	Body     map[string]any // parsed JSON body
+}
+
+func NewMock(t *testing.T) *Mock {
+	t.Helper()
+	m := &Mock{}
+	m.srv = httptest.NewServer(http.HandlerFunc(m.handle))
+	t.Cleanup(m.srv.Close)
+	return m
+}
+
+func (m *Mock) URL() string { return m.srv.URL }
+
+func (m *Mock) Env() map[string]string {
+	return map[string]string{"TELEGRAM_API_BASE_URL": m.srv.URL}
+}
+
+func (m *Mock) Reset() {
+	m.mu.Lock()
+	m.captured = nil
+	m.mu.Unlock()
+}
+
+func (m *Mock) Captured() []Captured {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]Captured, len(m.captured))
+	copy(out, m.captured)
+	return out
+}
+
+// AssertReceived fails the test if the given Telegram method wasn't called.
+func (m *Mock) AssertReceived(t *testing.T, method string) Captured {
+	t.Helper()
+	for _, c := range m.Captured() {
+		if c.Method == method {
+			return c
+		}
+	}
+	t.Fatalf("telegram: no call to method %q (captured %d)", method, len(m.Captured()))
+	return Captured{}
+}
+
+func (m *Mock) handle(w http.ResponseWriter, r *http.Request) {
+	// Path shape: /bot<TOKEN>/<method>
+	path := strings.TrimPrefix(r.URL.Path, "/")
+	parts := strings.SplitN(path, "/", 2)
+	method := ""
+	if len(parts) == 2 {
+		method = parts[1]
+	}
+
+	var body map[string]any
+	_ = json.NewDecoder(r.Body).Decode(&body)
+	r.Body.Close()
+
+	m.mu.Lock()
+	m.captured = append(m.captured, Captured{
+		Method:   method,
+		HTTPVerb: r.Method,
+		Body:     body,
+	})
+	m.mu.Unlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	switch method {
+	case "sendMessage":
+		_, _ = w.Write([]byte(`{"ok":true,"result":{"message_id":1,"date":1700000000}}`))
+	case "getMe":
+		_, _ = w.Write([]byte(`{"ok":true,"result":{"id":12345,"is_bot":true,"username":"mock_bot"}}`))
+	case "getUpdates":
+		_, _ = w.Write([]byte(`{"ok":true,"result":[]}`))
+	case "getChat":
+		_, _ = w.Write([]byte(`{"ok":true,"result":{"id":-1001234,"type":"group","title":"Mock"}}`))
+	default:
+		_, _ = w.Write([]byte(`{"ok":true,"result":null}`))
+	}
+}

--- a/internal/testharness/twilio/twilio.go
+++ b/internal/testharness/twilio/twilio.go
@@ -1,0 +1,30 @@
+// Package twilio provides a minimal Twilio API mock for E2E tests.
+package twilio
+
+import (
+	"testing"
+
+	"github.com/clawvisor/clawvisor/internal/testharness/httpmock"
+)
+
+type Mock struct{ *httpmock.Server }
+
+func NewMock(t *testing.T) *Mock {
+	t.Helper()
+	srv := httpmock.New(t, map[string]httpmock.Response{
+		"POST /2010-04-01/Accounts/{acct}/Messages.json": {
+			Status: 201,
+			Body: map[string]any{
+				"sid": "SM" + "mock", "status": "queued", "to": "+15555555555",
+			},
+		},
+		"GET /2010-04-01/Accounts/{acct}/Messages.json": {Body: map[string]any{
+			"messages": []any{}, "first_page_uri": "",
+		}},
+	})
+	return &Mock{Server: srv}
+}
+
+func (m *Mock) Env() map[string]string {
+	return map[string]string{"TWILIO_API_BASE_URL": m.URL()}
+}


### PR DESCRIPTION
## Summary

Adds `internal/testharness/` — 11 packages of `httptest`-backed mocks for every external service clawvisor (and consumers like cloud) talk to.

| Package | Mocks |
|---|---|
| `httpmock/` | Generic scriptable HTTP server (default + OnNext + OnEvery) |
| `llm/` | Cassette record/replay for Anthropic/OpenAI + HTTP server wrapper |
| `google/` | OAuth + Gmail + Calendar + Drive + Contacts; mints RSA-signed ID tokens |
| `github/`, `slack/`, `notion/`, `linear/`, `twilio/`, `telegram/`, `microsoft/`, `email/` | Per-service action mocks |

Each package is independent; tests instantiate only what they need.

## Motivation

This is Phase A of a multi-PR move that brings the E2E test suite written for [clawvisor/cloud#185](https://github.com/clawvisor/cloud/pull/185) into this repo so clawvisor PRs get the regression coverage automatically:

- Phase A (this PR): add the mock packages
- Phase B: add `internal/e2e/testapp/` boot helper
- Phase C: cloud bumps submodule, switches its imports to point here, deletes its copies
- Phase D1–D3: port ~115 scenario tests (LLM proxy, audit correctness, intent verify, scope drift, vault, tasks, restrictions, feedback, health, control)
- Phase E: cloud removes the now-duplicate scenarios

After all phases land, clawvisor PRs run the LLM-proxy gap-coverage, audit-correctness, and scope-drift suites automatically. Cloud keeps the cloud-specific tests (signup/onboarding/daemon-pair/Stripe/passkey/SAML).

## Test plan

- [x] `go build ./...` — clawvisor still builds
- [x] `go test ./internal/testharness/...` — every mock's own unit tests pass
- [x] `go vet ./internal/testharness/...` — clean
- [x] Adjacent runtime/llmproxy tests still pass (no test-helper interference)

## No clawvisor-internal code depends on these packages

They are test infra only. Imports are one-way (consumers → testharness). Production binaries are unaffected; production behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

