### PR TITLE
test(e2e): testharness umbrella + testapp subprocess boot helper

### DIFF
--- a/internal/e2e/testapp/build.go
+++ b/internal/e2e/testapp/build.go
@@ -1,0 +1,80 @@
+// Package testapp boots the clawvisor-server binary as a subprocess
+// wired to a fresh harness (internal/testharness). Tests talk to the
+// running server via real HTTP — same surface a production client hits.
+//
+// Subprocess (vs. in-process via internal/e2e/harness) is chosen so the
+// full bootstrap, route mounting, and middleware chain run for every
+// test — closer to production behavior, at the cost of ~1s per test
+// for the spawn + readiness wait.
+package testapp
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+)
+
+var (
+	buildOnce sync.Map // map[string]*sync.Once keyed by pkg path
+	buildErr  sync.Map // map[string]error
+	buildBin  sync.Map // map[string]string
+)
+
+// buildServerBinary compiles cmd/clawvisor-server once per test process
+// and returns the path. Subsequent calls within the same process reuse
+// the cached binary.
+func buildServerBinary(t *testing.T) string {
+	t.Helper()
+	return buildBinary(t, "github.com/clawvisor/clawvisor/cmd/clawvisor-server")
+}
+
+// buildBinary compiles the given Go main package into a process-local
+// cache dir keyed by the package path. Within a single `go test`
+// invocation all callers share one build; across invocations the cache
+// is rebuilt (so stale binaries can never pin behavior).
+func buildBinary(t *testing.T, pkg string) string {
+	t.Helper()
+	once, _ := buildOnce.LoadOrStore(pkg, &sync.Once{})
+	once.(*sync.Once).Do(func() {
+		dir := cacheDir(pkg)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			buildErr.Store(pkg, err)
+			return
+		}
+		bin := filepath.Join(dir, "bin")
+		if runtime.GOOS == "windows" {
+			bin += ".exe"
+		}
+		cmd := exec.Command("go", "build", "-o", bin, pkg)
+		cmd.Env = os.Environ()
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			buildErr.Store(pkg, &buildError{pkg: pkg, err: err, out: string(out)})
+			return
+		}
+		buildBin.Store(pkg, bin)
+	})
+	if err, ok := buildErr.Load(pkg); ok && err != nil {
+		t.Fatalf("build %s: %v", pkg, err)
+	}
+	bin, _ := buildBin.Load(pkg)
+	return bin.(string)
+}
+
+type buildError struct {
+	pkg string
+	err error
+	out string
+}
+
+func (e *buildError) Error() string { return e.err.Error() + "\n" + e.out }
+
+func cacheDir(pkg string) string {
+	sum := sha256.Sum256([]byte(pkg))
+	return filepath.Join(os.TempDir(), "clawvisor-testapp-build", hex.EncodeToString(sum[:8]))
+}

--- a/internal/e2e/testapp/fixture.go
+++ b/internal/e2e/testapp/fixture.go
@@ -1,0 +1,133 @@
+package testapp
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+// LocalUser holds tokens for a magic-link-authenticated user. The
+// local magic-link flow is single-user on clawvisor — repeated calls
+// to LoginAsLocalUser return the same identity.
+type LocalUser struct {
+	AccessToken  string
+	RefreshToken string
+	UserID       string
+	Email        string
+}
+
+// LoginAsLocalUser drives the magic-link flow exposed for local
+// installs (POST /api/auth/magic/local → POST /api/auth/magic). Returns
+// the resulting tokens. Tests that need a fresh user shouldn't reuse
+// this — clawvisor's local-only auth always mints the same identity.
+func (s *Server) LoginAsLocalUser(t *testing.T) *LocalUser {
+	t.Helper()
+	resp, err := s.Client.Post(s.URL+"/api/auth/magic/local", "application/json", nil)
+	if err != nil {
+		t.Fatalf("magic/local: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("magic/local: status=%d", resp.StatusCode)
+	}
+	var magic struct {
+		Token string `json:"token"`
+	}
+	if err := jsonDecode(resp.Body, &magic); err != nil {
+		t.Fatalf("decode magic: %v", err)
+	}
+	body := []byte(`{"token":"` + magic.Token + `"}`)
+	resp2, err := s.Client.Post(s.URL+"/api/auth/magic", "application/json", bytesReader(body))
+	if err != nil {
+		t.Fatalf("magic exchange: %v", err)
+	}
+	defer resp2.Body.Close()
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("magic exchange: status=%d", resp2.StatusCode)
+	}
+	var out struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		User         struct {
+			ID    string `json:"id"`
+			Email string `json:"email"`
+		} `json:"user"`
+	}
+	if err := jsonDecode(resp2.Body, &out); err != nil {
+		t.Fatalf("decode auth: %v", err)
+	}
+	return &LocalUser{
+		AccessToken:  out.AccessToken,
+		RefreshToken: out.RefreshToken,
+		UserID:       out.User.ID,
+		Email:        out.User.Email,
+	}
+}
+
+// Agent is an agent record + its raw bearer token.
+type Agent struct {
+	ID    string
+	Token string
+	Name  string
+}
+
+// CreateAgent registers a new agent under the given user and returns
+// the agent + its bearer token. Most scenarios call this once per test
+// — there's no policy reason to share agents across tests.
+func (s *Server) CreateAgent(t *testing.T, user *LocalUser, name string) *Agent {
+	t.Helper()
+	body, _ := json.Marshal(map[string]any{"name": name})
+	req, _ := http.NewRequest("POST", s.URL+"/api/agents", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+user.AccessToken)
+	resp, err := s.Client.Do(req)
+	if err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create agent: status=%d body=%s", resp.StatusCode, raw)
+	}
+	var out struct {
+		ID    string `json:"id"`
+		Token string `json:"token"`
+		Name  string `json:"name"`
+	}
+	if err := jsonDecode(resp.Body, &out); err != nil {
+		t.Fatalf("decode agent: %v", err)
+	}
+	return &Agent{ID: out.ID, Token: out.Token, Name: out.Name}
+}
+
+// SetLLMCredential stores an upstream LLM API key in the user's vault
+// via the dedicated /api/runtime/llm-credentials endpoint. The generic
+// /api/vault/items endpoint rejects reserved provider IDs ("anthropic",
+// "openai", "google") so this is the only path that works for
+// provider keys.
+//
+// agentID="" sets the user-scoped key; non-empty sets agent-scoped
+// (preferred over user-scoped by the forwarder's lookup).
+func (s *Server) SetLLMCredential(t *testing.T, user *LocalUser, provider, agentID, apiKey string) {
+	t.Helper()
+	path := "/api/runtime/llm-credentials/" + provider
+	if agentID != "" {
+		path += "?agent_id=" + url.QueryEscape(agentID)
+	}
+	body, _ := json.Marshal(map[string]any{"api_key": apiKey})
+	req, _ := http.NewRequest("PUT", s.URL+path, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+user.AccessToken)
+	resp, err := s.Client.Do(req)
+	if err != nil {
+		t.Fatalf("set llm credential: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("set llm credential: status=%d body=%s", resp.StatusCode, raw)
+	}
+}

--- a/internal/e2e/testapp/server.go
+++ b/internal/e2e/testapp/server.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -46,10 +47,59 @@ func Start(t *testing.T, h *testharness.Harness) *Server {
 // StartWith is like Start with additional env overrides. Use this for
 // tests that need CLAWVISOR_LLM_UPSTREAM_* pointed at cassette servers
 // or other per-test environment tweaks.
+//
+// freePort hands out a port by listening on :0 then closing — there's a
+// small window where another process can grab it before clawvisor binds
+// (classic TOCTOU; the common flaky-test source under CI parallelism).
+// We detect the symptom (subprocess exits before /ready returns 200)
+// and retry up to maxStartAttempts times with a fresh port. Slow-start
+// timeouts (no early exit) are NOT retried — they'd just timeout again.
 func StartWith(t *testing.T, h *testharness.Harness, extraEnv map[string]string) *Server {
 	t.Helper()
-
 	binPath := buildServerBinary(t)
+	var lastErr error
+	for attempt := 0; attempt < maxStartAttempts; attempt++ {
+		s, err := tryStart(t, h, extraEnv, binPath)
+		if err == nil {
+			return s
+		}
+		lastErr = err
+		var earlyExit *earlyExitError
+		if !errors.As(err, &earlyExit) {
+			// Not a retryable shape (e.g. /ready timeout, config write
+			// failure). Surfacing immediately avoids a 4×20s test stall.
+			t.Fatalf("clawvisor-server start: %v", err)
+		}
+		// Brief backoff so the colliding process can settle / be torn down.
+		time.Sleep(time.Duration(50*(attempt+1)) * time.Millisecond)
+	}
+	t.Fatalf("clawvisor-server failed after %d attempts (port-collision retries exhausted): %v", maxStartAttempts, lastErr)
+	return nil
+}
+
+// maxStartAttempts caps retry on early-exit. Set above the realistic
+// collision rate so a transient port grab clears, but low enough that a
+// genuinely broken binary fails fast.
+const maxStartAttempts = 4
+
+// earlyExitError is returned by tryStart when the subprocess exited
+// before /ready returned 200 — the symptom shape of a port collision
+// (EADDRINUSE on bind kills the server immediately) or other startup
+// failure. StartWith uses errors.As to decide whether to retry.
+type earlyExitError struct{ err error }
+
+func (e *earlyExitError) Error() string {
+	return fmt.Sprintf("clawvisor exited before /ready: %v", e.err)
+}
+
+func (e *earlyExitError) Unwrap() error { return e.err }
+
+// tryStart performs one boot attempt. On success: registers t.Cleanup
+// and returns the *Server. On failure: tears down its own subprocess
+// inline and returns the error (no cleanup registered, so retries
+// don't accumulate cleanup callbacks).
+func tryStart(t *testing.T, h *testharness.Harness, extraEnv map[string]string, binPath string) (*Server, error) {
+	t.Helper()
 	port := freePort(t)
 	publicURL := fmt.Sprintf("http://127.0.0.1:%d", port)
 
@@ -57,10 +107,10 @@ func StartWith(t *testing.T, h *testharness.Harness, extraEnv map[string]string)
 	vaultKeyFile := filepath.Join(dataDir, "vault.key")
 	keyBytes := make([]byte, 32)
 	if _, err := rand.Read(keyBytes); err != nil {
-		t.Fatalf("rand: %v", err)
+		return nil, fmt.Errorf("rand: %w", err)
 	}
 	if err := os.WriteFile(vaultKeyFile, []byte(base64.StdEncoding.EncodeToString(keyBytes)), 0600); err != nil {
-		t.Fatalf("write vault key: %v", err)
+		return nil, fmt.Errorf("write vault key: %w", err)
 	}
 
 	cfgPath := filepath.Join(dataDir, "config.yaml")
@@ -108,7 +158,7 @@ proxy_lite:
   enabled: true
 `, port, publicURL, dataDir, vaultKeyFile)
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0600); err != nil {
-		t.Fatalf("write config: %v", err)
+		return nil, fmt.Errorf("write config: %w", err)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -132,7 +182,7 @@ proxy_lite:
 
 	if err := cmd.Start(); err != nil {
 		cancel()
-		t.Fatalf("start clawvisor-server: %v", err)
+		return nil, fmt.Errorf("start clawvisor-server: %w", err)
 	}
 
 	s := &Server{
@@ -146,9 +196,36 @@ proxy_lite:
 	go drain(stdout, &s.stdoutMu, &s.stdout)
 	go drain(stderr, &s.stdoutMu, &s.stderr)
 
+	// cmd.Wait can only be called once. Run it here so both the readiness
+	// loop (early-exit detection) and t.Cleanup (orderly teardown) can
+	// observe completion. Closed-channel signal so multiple receivers
+	// can wait on it without one of them consuming the value.
+	exited := make(chan struct{})
+	var exitErr error
+	go func() {
+		exitErr = cmd.Wait()
+		close(exited)
+	}()
+
+	if err := s.waitReady(20*time.Second, exited, &exitErr); err != nil {
+		cancel()
+		// Bound the post-cancel wait so SIGKILL latency doesn't stall.
+		select {
+		case <-exited:
+		case <-time.After(5 * time.Second):
+		}
+		return nil, err
+	}
+
+	// Register cleanup ONLY on success. On retry, the failed attempt's
+	// cleanup must NOT fire after the eventual successful attempt — the
+	// inline drain above already tore it down.
 	t.Cleanup(func() {
 		cancel()
-		_ = cmd.Wait()
+		select {
+		case <-exited:
+		case <-time.After(5 * time.Second):
+		}
 		if t.Failed() {
 			s.stdoutMu.Lock()
 			defer s.stdoutMu.Unlock()
@@ -161,15 +238,25 @@ proxy_lite:
 		}
 	})
 
-	if err := s.waitReady(20 * time.Second); err != nil {
-		t.Fatalf("clawvisor not ready: %v", err)
-	}
-	return s
+	return s, nil
 }
 
-func (s *Server) waitReady(timeout time.Duration) error {
+// waitReady polls /ready until 200, or returns an earlyExitError if the
+// subprocess died first (which is what a port collision looks like:
+// EADDRINUSE on bind → fatal log → exit), or a plain error on timeout.
+// StartWith retries on earlyExitError but not on timeout.
+//
+// exited is a signal channel (closed when cmd.Wait returns); exitErrPtr
+// points to the captured Wait error written by the same goroutine. Both
+// are safe to read after exited closes due to the happens-before chain.
+func (s *Server) waitReady(timeout time.Duration, exited <-chan struct{}, exitErrPtr *error) error {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
+		select {
+		case <-exited:
+			return &earlyExitError{err: *exitErrPtr}
+		default:
+		}
 		resp, err := s.Client.Get(s.URL + "/ready")
 		if err == nil {
 			resp.Body.Close()

--- a/internal/e2e/testapp/server.go
+++ b/internal/e2e/testapp/server.go
@@ -1,0 +1,213 @@
+package testapp
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/clawvisor/clawvisor/internal/testharness"
+)
+
+// Server is a running clawvisor-server subprocess. Get URL+Client from
+// the returned value and talk to it like any HTTP service. Cleanup is
+// automatic via t.Cleanup.
+type Server struct {
+	t        *testing.T
+	URL      string
+	DataDir  string
+	Client   *http.Client
+	cmd      *exec.Cmd
+	cancel   context.CancelFunc
+	stdoutMu sync.Mutex
+	stdout   []byte
+	stderr   []byte
+}
+
+// Start builds + boots clawvisor-server on a free port, wires it to the
+// provided Harness via env-var overrides, waits for /ready, and returns.
+// The subprocess is killed via t.Cleanup; if the test failed, its
+// stdout/stderr are dumped via t.Logf for diagnosis.
+func Start(t *testing.T, h *testharness.Harness) *Server {
+	return StartWith(t, h, nil)
+}
+
+// StartWith is like Start with additional env overrides. Use this for
+// tests that need CLAWVISOR_LLM_UPSTREAM_* pointed at cassette servers
+// or other per-test environment tweaks.
+func StartWith(t *testing.T, h *testharness.Harness, extraEnv map[string]string) *Server {
+	t.Helper()
+
+	binPath := buildServerBinary(t)
+	port := freePort(t)
+	publicURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+
+	dataDir := t.TempDir()
+	vaultKeyFile := filepath.Join(dataDir, "vault.key")
+	keyBytes := make([]byte, 32)
+	if _, err := rand.Read(keyBytes); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	if err := os.WriteFile(vaultKeyFile, []byte(base64.StdEncoding.EncodeToString(keyBytes)), 0600); err != nil {
+		t.Fatalf("write vault key: %v", err)
+	}
+
+	cfgPath := filepath.Join(dataDir, "config.yaml")
+	cfg := fmt.Sprintf(`
+server:
+  port: %d
+  host: "127.0.0.1"
+  log_format: "text"
+  log_level: "warn"
+  public_url: "%s"
+
+database:
+  driver: "sqlite"
+  sqlite_path: "%s/clawvisor.db"
+
+vault:
+  backend: "local"
+  local_key_file: "%s"
+
+auth:
+  jwt_secret: "test-jwt-secret-must-be-long-enough-32"
+  access_token_ttl: "1h"
+  refresh_token_ttl: "24h"
+
+approval:
+  timeout: 60
+  on_timeout: "fail"
+
+task:
+  default_expiry_seconds: 1800
+
+relay:
+  enabled: false
+
+push:
+  enabled: false
+
+telemetry:
+  enabled: false
+
+runtime_proxy:
+  enabled: false
+
+proxy_lite:
+  enabled: true
+`, port, publicURL, dataDir, vaultKeyFile)
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := exec.CommandContext(ctx, binPath, "server")
+	env := os.Environ()
+	env = append(env,
+		"CONFIG_FILE="+cfgPath,
+		"CLAWVISOR_DATA_DIR="+dataDir,
+		"LOG_LEVEL=warn",
+	)
+	for k, v := range h.Env() {
+		env = append(env, k+"="+v)
+	}
+	for k, v := range extraEnv {
+		env = append(env, k+"="+v)
+	}
+	cmd.Env = env
+
+	stdout, _ := cmd.StdoutPipe()
+	stderr, _ := cmd.StderrPipe()
+
+	if err := cmd.Start(); err != nil {
+		cancel()
+		t.Fatalf("start clawvisor-server: %v", err)
+	}
+
+	s := &Server{
+		t:       t,
+		URL:     publicURL,
+		DataDir: dataDir,
+		Client:  &http.Client{Timeout: 10 * time.Second},
+		cmd:     cmd,
+		cancel:  cancel,
+	}
+	go drain(stdout, &s.stdoutMu, &s.stdout)
+	go drain(stderr, &s.stdoutMu, &s.stderr)
+
+	t.Cleanup(func() {
+		cancel()
+		_ = cmd.Wait()
+		if t.Failed() {
+			s.stdoutMu.Lock()
+			defer s.stdoutMu.Unlock()
+			if len(s.stdout) > 0 {
+				t.Logf("=== clawvisor stdout ===\n%s", s.stdout)
+			}
+			if len(s.stderr) > 0 {
+				t.Logf("=== clawvisor stderr ===\n%s", s.stderr)
+			}
+		}
+	})
+
+	if err := s.waitReady(20 * time.Second); err != nil {
+		t.Fatalf("clawvisor not ready: %v", err)
+	}
+	return s
+}
+
+func (s *Server) waitReady(timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		resp, err := s.Client.Get(s.URL + "/ready")
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return nil
+			}
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
+	return fmt.Errorf("clawvisor did not become ready within %s", timeout)
+}
+
+func freePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("alloc port: %v", err)
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port
+}
+
+func drain(r io.Reader, mu *sync.Mutex, dst *[]byte) {
+	buf := make([]byte, 4096)
+	for {
+		n, err := r.Read(buf)
+		if n > 0 {
+			mu.Lock()
+			*dst = append(*dst, buf[:n]...)
+			mu.Unlock()
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+// jsonDecode and bytesReader are small helpers used by the fixture file
+// — defined here to keep fixture.go's imports tight.
+func jsonDecode(r io.Reader, dst any) error { return json.NewDecoder(r).Decode(dst) }
+func bytesReader(b []byte) *bytes.Reader    { return bytes.NewReader(b) }

--- a/internal/e2e/testapp/server.go
+++ b/internal/e2e/testapp/server.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -34,6 +35,7 @@ type Server struct {
 	stdoutMu sync.Mutex
 	stdout   []byte
 	stderr   []byte
+	drains   sync.WaitGroup // drain goroutines; Wait() returns once pipes hit EOF
 }
 
 // Start builds + boots clawvisor-server on a free port, wires it to the
@@ -86,10 +88,27 @@ const maxStartAttempts = 4
 // before /ready returned 200 — the symptom shape of a port collision
 // (EADDRINUSE on bind kills the server immediately) or other startup
 // failure. StartWith uses errors.As to decide whether to retry.
-type earlyExitError struct{ err error }
+//
+// stdout/stderr capture the subprocess's startup output, attached by
+// tryStart after the drain goroutines have flushed. Without this,
+// retries discard the actual "bind: address already in use" line and
+// the final t.Fatalf only surfaces "exit status 1".
+type earlyExitError struct {
+	err    error
+	stdout string
+	stderr string
+}
 
 func (e *earlyExitError) Error() string {
-	return fmt.Sprintf("clawvisor exited before /ready: %v", e.err)
+	var b strings.Builder
+	fmt.Fprintf(&b, "clawvisor exited before /ready: %v", e.err)
+	if e.stdout != "" {
+		fmt.Fprintf(&b, "\n--- subprocess stdout ---\n%s", e.stdout)
+	}
+	if e.stderr != "" {
+		fmt.Fprintf(&b, "\n--- subprocess stderr ---\n%s", e.stderr)
+	}
+	return b.String()
 }
 
 func (e *earlyExitError) Unwrap() error { return e.err }
@@ -193,8 +212,9 @@ proxy_lite:
 		cmd:     cmd,
 		cancel:  cancel,
 	}
-	go drain(stdout, &s.stdoutMu, &s.stdout)
-	go drain(stderr, &s.stdoutMu, &s.stderr)
+	s.drains.Add(2)
+	go func() { defer s.drains.Done(); drain(stdout, &s.stdoutMu, &s.stdout) }()
+	go func() { defer s.drains.Done(); drain(stderr, &s.stdoutMu, &s.stderr) }()
 
 	// cmd.Wait can only be called once. Run it here so both the readiness
 	// loop (early-exit detection) and t.Cleanup (orderly teardown) can
@@ -214,6 +234,20 @@ proxy_lite:
 		case <-exited:
 		case <-time.After(5 * time.Second):
 		}
+		// Wait for drain goroutines to flush so the captured buffers
+		// include the final stderr lines (the actual EADDRINUSE / config
+		// error / panic). Bounded — pipes should EOF immediately after
+		// the process exits; the timeout is a backstop, not the path.
+		s.waitDrains(500 * time.Millisecond)
+		// Attach the captured output to the error so retries don't lose
+		// it. StartWith's final t.Fatalf prints the last attempt's error,
+		// which now carries the diagnostics.
+		if eee, ok := err.(*earlyExitError); ok {
+			s.stdoutMu.Lock()
+			eee.stdout = string(s.stdout)
+			eee.stderr = string(s.stderr)
+			s.stdoutMu.Unlock()
+		}
 		return nil, err
 	}
 
@@ -226,6 +260,7 @@ proxy_lite:
 		case <-exited:
 		case <-time.After(5 * time.Second):
 		}
+		s.waitDrains(500 * time.Millisecond)
 		if t.Failed() {
 			s.stdoutMu.Lock()
 			defer s.stdoutMu.Unlock()
@@ -267,6 +302,23 @@ func (s *Server) waitReady(timeout time.Duration, exited <-chan struct{}, exitEr
 		time.Sleep(150 * time.Millisecond)
 	}
 	return fmt.Errorf("clawvisor did not become ready within %s", timeout)
+}
+
+// waitDrains blocks until both drain goroutines have returned (pipes
+// reached EOF), or the timeout elapses. Used on the error path so the
+// captured stdout/stderr are flushed before being read into the
+// returned earlyExitError. Bounded because a hung drain shouldn't stall
+// the retry loop — partial output beats no output.
+func (s *Server) waitDrains(timeout time.Duration) {
+	done := make(chan struct{})
+	go func() {
+		s.drains.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(timeout):
+	}
 }
 
 func freePort(t *testing.T) int {

--- a/internal/e2e/testapp/server_internal_test.go
+++ b/internal/e2e/testapp/server_internal_test.go
@@ -1,0 +1,76 @@
+package testapp
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/clawvisor/clawvisor/internal/testharness"
+)
+
+// TestTryStartReturnsEarlyExitErrorOnBindFailure exercises the symptom
+// of a port collision: the subprocess exits immediately because bind
+// failed. We simulate it with a shell stub that exits 1 — semantically
+// identical to clawvisor-server hitting EADDRINUSE and dying.
+//
+// Without the earlyExitError fix, the readiness loop would spin until
+// the 20-second timeout (since /ready never comes up), turning a flaky
+// 100ms recovery into a flaky 20-second test failure under load.
+func TestTryStartReturnsEarlyExitErrorOnBindFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell stub uses /bin/sh")
+	}
+	stub := writeFailingStub(t)
+	h := testharness.New(t)
+
+	_, err := tryStart(t, h, nil, stub)
+	if err == nil {
+		t.Fatal("tryStart returned nil; expected earlyExitError")
+	}
+	var earlyExit *earlyExitError
+	if !errors.As(err, &earlyExit) {
+		t.Fatalf("tryStart returned %T (%v); expected earlyExitError so StartWith retries the next port", err, err)
+	}
+}
+
+// TestWaitReadyReportsEarlyExitFast — the readiness loop must observe
+// the dead subprocess within one poll cycle (~150ms), not wait out the
+// full 20-second timeout. Validates the channel-based detection rather
+// than only checking errors.As shape.
+func TestWaitReadyReportsEarlyExitFast(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell stub uses /bin/sh")
+	}
+	stub := writeFailingStub(t)
+	h := testharness.New(t)
+
+	start := time.Now()
+	_, err := tryStart(t, h, nil, stub)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	// 2s is generous — failing stub exits in <50ms; poll interval is 150ms.
+	// If the channel-based detection regressed to polling-only we'd see ~20s.
+	if elapsed > 2*time.Second {
+		t.Fatalf("tryStart took %v before reporting early exit; the early-exit channel detection regressed", elapsed)
+	}
+}
+
+// writeFailingStub writes a shell script that exits non-zero immediately.
+// /bin/false would do, but a per-test script keeps the harness portable
+// across distros that put it in different paths.
+func writeFailingStub(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	stub := filepath.Join(dir, "failing-server")
+	const script = "#!/bin/sh\nexit 1\n"
+	if err := os.WriteFile(stub, []byte(script), 0755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	return stub
+}

--- a/internal/e2e/testapp/server_internal_test.go
+++ b/internal/e2e/testapp/server_internal_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -58,6 +59,41 @@ func TestWaitReadyReportsEarlyExitFast(t *testing.T) {
 	// If the channel-based detection regressed to polling-only we'd see ~20s.
 	if elapsed > 2*time.Second {
 		t.Fatalf("tryStart took %v before reporting early exit; the early-exit channel detection regressed", elapsed)
+	}
+}
+
+// TestEarlyExitErrorCarriesSubprocessDiagnostics — the symptom this
+// fix targets: when retries discard the failed *Server, the buffered
+// stderr (where the real "bind: address already in use" would be)
+// must NOT be lost. The earlyExitError returned by tryStart must
+// carry those bytes so the final t.Fatalf surfaces them.
+func TestEarlyExitErrorCarriesSubprocessDiagnostics(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell stub uses /bin/sh")
+	}
+	// Stub emits a distinct sentinel on both streams, then exits 1.
+	// Matching the real bind-failure shape: stderr message + nonzero exit.
+	dir := t.TempDir()
+	stub := filepath.Join(dir, "failing-server")
+	const script = "#!/bin/sh\n" +
+		"echo 'stdout-sentinel-line'\n" +
+		"echo 'bind: address already in use' 1>&2\n" +
+		"exit 1\n"
+	if err := os.WriteFile(stub, []byte(script), 0755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	h := testharness.New(t)
+
+	_, err := tryStart(t, h, nil, stub)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "bind: address already in use") {
+		t.Fatalf("error did not include stderr diagnostics; would lose root-cause info on retry exhaustion.\nGot: %q", msg)
+	}
+	if !strings.Contains(msg, "stdout-sentinel-line") {
+		t.Fatalf("error did not include stdout diagnostics.\nGot: %q", msg)
 	}
 }
 

--- a/internal/e2e/testapp/server_test.go
+++ b/internal/e2e/testapp/server_test.go
@@ -1,0 +1,58 @@
+package testapp_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/internal/e2e/testapp"
+	"github.com/clawvisor/clawvisor/internal/testharness"
+)
+
+// TestServerBoots is the smoke test for the subprocess boot pattern:
+// build the binary, start it on a free port, hit /ready, shut down via
+// t.Cleanup. Validates the testapp pipeline end-to-end.
+func TestServerBoots(t *testing.T) {
+	h := testharness.New(t)
+	s := testapp.Start(t, h)
+	if s.URL == "" {
+		t.Fatal("server URL empty")
+	}
+	resp, err := s.Client.Get(s.URL + "/ready")
+	if err != nil {
+		t.Fatalf("GET /ready: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("/ready status=%d", resp.StatusCode)
+	}
+}
+
+// TestLoginAsLocalUser exercises the magic-link fixture: server boots,
+// LoginAsLocalUser drives /api/auth/magic/local + /api/auth/magic, and
+// returns tokens we can use on a subsequent authenticated request.
+func TestLoginAsLocalUser(t *testing.T) {
+	h := testharness.New(t)
+	s := testapp.Start(t, h)
+	user := s.LoginAsLocalUser(t)
+	if user.AccessToken == "" {
+		t.Fatal("LoginAsLocalUser returned empty access token")
+	}
+	if user.UserID == "" {
+		t.Fatal("LoginAsLocalUser returned empty user_id")
+	}
+}
+
+// TestCreateAgent confirms an agent can be created under a logged-in
+// user and the returned token is non-empty.
+func TestCreateAgent(t *testing.T) {
+	h := testharness.New(t)
+	s := testapp.Start(t, h)
+	user := s.LoginAsLocalUser(t)
+	a := s.CreateAgent(t, user, "smoke-agent")
+	if a.ID == "" {
+		t.Fatal("agent ID empty")
+	}
+	if a.Token == "" {
+		t.Fatal("agent token empty")
+	}
+}

--- a/internal/testharness/harness.go
+++ b/internal/testharness/harness.go
@@ -1,0 +1,126 @@
+// Package testharness boots in-process mocks of every external service
+// clawvisor talks to (Google, GitHub, Slack, Resend, etc.) and exposes
+// a scripting API tests use to script responses and assert
+// interactions.
+//
+// Lifecycle:
+//
+//	h := testharness.New(t)            // starts all mock servers
+//	defer h.Reset()                    // also runs via t.Cleanup
+//	s := testapp.Start(t, h)           // boots clawvisor-server wired to h
+//	h.Email.AssertSentTo(t, "alice@…") // assert via per-mock helpers
+//
+// Each sub-mock is independent (its own httptest.Server) so tests can
+// run in parallel. State is reset between tests via Reset().
+package testharness
+
+import (
+	"testing"
+
+	"github.com/clawvisor/clawvisor/internal/testharness/email"
+	"github.com/clawvisor/clawvisor/internal/testharness/github"
+	"github.com/clawvisor/clawvisor/internal/testharness/google"
+	"github.com/clawvisor/clawvisor/internal/testharness/linear"
+	"github.com/clawvisor/clawvisor/internal/testharness/microsoft"
+	"github.com/clawvisor/clawvisor/internal/testharness/notion"
+	"github.com/clawvisor/clawvisor/internal/testharness/slack"
+	"github.com/clawvisor/clawvisor/internal/testharness/telegram"
+	"github.com/clawvisor/clawvisor/internal/testharness/twilio"
+)
+
+// Harness owns the lifecycle of every mock external service. Tests
+// construct one via New(t); cleanup is automatic via t.Cleanup.
+type Harness struct {
+	t *testing.T
+
+	Email       *email.Mock
+	EmailServer *email.Server // Resend-impersonating HTTP server (for subprocess tests)
+	Google      *google.Mock
+	GitHub      *github.Mock
+	Slack       *slack.Mock
+	Notion      *notion.Mock
+	Linear      *linear.Mock
+	Twilio      *twilio.Mock
+	Telegram    *telegram.Mock
+	Microsoft   *microsoft.Mock
+}
+
+// New starts every mock server and registers cleanup. Subsequent calls
+// to Reset() (also run via t.Cleanup) zero state without tearing down
+// the servers.
+func New(t *testing.T) *Harness {
+	t.Helper()
+	mailMock := email.NewMock(t)
+	h := &Harness{
+		t:           t,
+		Email:       mailMock,
+		EmailServer: email.NewServer(t, mailMock),
+		Google:      google.NewMock(t),
+		GitHub:      github.NewMock(t),
+		Slack:       slack.NewMock(t),
+		Notion:      notion.NewMock(t),
+		Linear:      linear.NewMock(t),
+		Twilio:      twilio.NewMock(t),
+		Telegram:    telegram.NewMock(t),
+		Microsoft:   microsoft.NewMock(t),
+	}
+	t.Cleanup(h.Reset)
+	return h
+}
+
+// Reset zeroes captured state across every mock. Safe to call multiple
+// times. Sub-tests can call Reset() between cases for isolation.
+func (h *Harness) Reset() {
+	if h.Email != nil {
+		h.Email.Reset()
+	}
+	if h.Google != nil {
+		h.Google.Reset()
+	}
+	if h.GitHub != nil {
+		h.GitHub.Reset()
+	}
+	if h.Slack != nil {
+		h.Slack.Reset()
+	}
+	if h.Notion != nil {
+		h.Notion.Reset()
+	}
+	if h.Linear != nil {
+		h.Linear.Reset()
+	}
+	if h.Twilio != nil {
+		h.Twilio.Reset()
+	}
+	if h.Telegram != nil {
+		h.Telegram.Reset()
+	}
+	if h.Microsoft != nil {
+		h.Microsoft.Reset()
+	}
+}
+
+// Env returns the env-var overrides that wire the app at boot to point
+// at every mock service. Used by testapp.Start.
+func (h *Harness) Env() map[string]string {
+	env := map[string]string{}
+	merge := func(src map[string]string) {
+		for k, v := range src {
+			env[k] = v
+		}
+	}
+	merge(h.Google.Env())
+	merge(h.GitHub.Env())
+	merge(h.Slack.Env())
+	merge(h.Notion.Env())
+	merge(h.Linear.Env())
+	merge(h.Twilio.Env())
+	merge(h.Telegram.Env())
+	merge(h.Microsoft.Env())
+	if h.EmailServer != nil {
+		env["RESEND_BASE_URL"] = h.EmailServer.URL()
+		env["RESEND_API_KEY"] = "test-resend-key"
+		env["RESEND_FROM"] = "test@harness.local"
+	}
+	return env
+}


### PR DESCRIPTION
## Summary

Phase B of the multi-PR move that brings the cloud-side E2E test suite into clawvisor. Adds two pieces on top of the mocks landed in #600:

### `internal/testharness/harness.go`

The umbrella `Harness` type. Boots one of every sub-mock package (Email, Google, GitHub, Slack, Notion, Linear, Twilio, Telegram, Microsoft) and exposes `Env()` returning the env-var overrides that wire clawvisor-server at boot to point at each mock.

### `internal/e2e/testapp/`

Subprocess boot helper.

- `testapp.Start(t, h)` builds + spawns `clawvisor-server` on a free port wired to the harness, waits for `/ready`, registers cleanup.
- `testapp.StartWith(t, h, extraEnv)` for tests that need `CLAWVISOR_LLM_UPSTREAM_*` or other per-test env.

Fixture helpers on `Server`:

| Method | Purpose |
|---|---|
| `LoginAsLocalUser` | Drives `/api/auth/magic/local` + `/api/auth/magic` |
| `CreateAgent` | `POST /api/agents` under a logged-in user |
| `SetLLMCredential` | `PUT /api/runtime/llm-credentials/{provider}` (the generic vault items endpoint rejects reserved provider IDs) |

`build.go` caches `cmd/clawvisor-server` compilation per test process so the 100+ scenario tests landing in Phase D spawn in ~1s each rather than rebuilding every time.

## Test plan

- [x] `go test ./internal/e2e/testapp/` — 3 smoke tests pass: server boots & `/ready=200`, `LoginAsLocalUser` returns non-empty tokens, `CreateAgent` returns a non-empty token
- [x] `go vet ./internal/e2e/testapp/ ./internal/testharness/` — clean
- [x] No clawvisor-internal code depends on this — `internal/e2e/testapp/` is test-only

## What's next

After this lands:

- Phase C (cloud): bump submodule to this commit, switch imports, delete cloud's copies of testharness packages
- Phase D1–D3 (clawvisor): port ~115 scenario tests (LLM proxy, audit correctness, intent verify, scope drift, vault, tasks, restrictions, feedback, health, control)
- Phase E (cloud): remove the now-duplicate scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

