### PR TITLE
feat(api): long-lived scoped API tokens with first-boot bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+* **api-tokens:** long-lived, scoped, revocable API tokens (`cvat_` prefix) at `POST/GET/DELETE /api/tokens`, plus a first-boot bootstrap path via the new `CLAWVISOR_BOOTSTRAP_TOKEN` env var (single-use, 24h expiry, burned on first mint). `GET /api/features` now advertises `api_tokens: true`. **Cloud submodule-bump note:** a `cvat_` bearer passes through `proxy_lite_gate.go` untouched (it sniffs only `cvis_`/`cv-nonce-`) and falls through the per-user `proxy_lite_users` gate on `/api/vault/items`; instance-admin tokens are intended to bypass per-user proxy-lite gating, so this is acceptable but must be an explicit, reviewed decision at the bump.
+
 ## [0.9.10](https://github.com/clawvisor/clawvisor/compare/v0.9.9...v0.9.10) (2026-06-22)
 
 

--- a/README.md
+++ b/README.md
@@ -191,8 +191,40 @@ Clawvisor loads `config.yaml` from the working directory (override with `CONFIG_
 | Rate limits | `RATE_LIMIT_*` | Per-agent gateway, per-user OAuth, policy API, and review limits |
 | MCP timeout | `MCP_APPROVAL_TIMEOUT` | Seconds MCP blocks waiting for approval (default 240) |
 | Telemetry | `TELEMETRY_ENABLED` | Opt-in anonymous usage telemetry |
+| Bootstrap token | `CLAWVISOR_BOOTSTRAP_TOKEN` | First-boot API token for headless provisioning (Terraform / CI). See **API tokens** below |
 
 See [`config.example.yaml`](config.example.yaml) for the full configuration reference.
+
+### API tokens
+
+Long-lived, scoped, revocable bearer credentials (prefix `cvat_`) let the
+Terraform provider and CI drive the management API without a 15-minute
+dashboard JWT. Manage them at `POST/GET/DELETE /api/tokens` (admin-gated).
+Tokens are hashed at rest; the plaintext is returned exactly once, on
+create. Resources created via a token are owned by the `_instance` system
+user (so they are not trapped in a personal account).
+
+**Bootstrap (first boot).** Set `CLAWVISOR_BOOTSTRAP_TOKEN` to a value of
+the exact shape `cvat_` + 43 base64url characters. On startup the server:
+
+- refuses to start if the value is malformed (a misconfiguration, not a
+  warning);
+- seeds a single-use `instance-admin` token with a **mandatory 24-hour
+  expiry** — but only if no non-revoked `instance-admin` token already
+  exists (it never overrides a live install);
+- is idempotent across restarts.
+
+The intended flow: an automation authenticates once with the bootstrap
+token, mints a long-lived scoped token via `POST /api/tokens`, and that
+first successful mint **burns** the bootstrap token (it is revoked in the
+same request). Reads never burn it, so a failed apply can retry.
+
+**Rotation runbook.** To issue a fresh bootstrap credential, `terraform
+apply` with a tainted bootstrap secret regenerates the value; the server
+mints a new 24-hour bootstrap token on the next boot *only if* no
+non-revoked `instance-admin` token exists. If a live admin token already
+exists, do not re-bootstrap — rotate by minting a new scoped token via the
+existing one and revoking the old (`DELETE /api/tokens/{id}`).
 
 ## How It Works
 

--- a/e2e/scenarios/api_tokens_test.go
+++ b/e2e/scenarios/api_tokens_test.go
@@ -1,0 +1,293 @@
+package scenarios_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/e2e/testapp"
+	"github.com/clawvisor/clawvisor/internal/auth"
+	"github.com/clawvisor/clawvisor/testharness"
+)
+
+// genAPIToken mints a canonically-formatted cvat_ value for use as a
+// module-seeded bootstrap token (spec 03 generates the identical shape).
+func genAPIToken(t *testing.T) string {
+	t.Helper()
+	raw, _, err := auth.GenerateAPIToken()
+	if err != nil {
+		t.Fatalf("GenerateAPIToken: %v", err)
+	}
+	return raw
+}
+
+// mintToken POSTs /api/tokens with the given auth token and returns the
+// created plaintext value.
+func mintToken(t *testing.T, cv *testapp.Server, authTok, name, scope string) (id, plaintext string) {
+	t.Helper()
+	var out struct {
+		ID    string `json:"id"`
+		Token string `json:"token"`
+		Scope string `json:"scope"`
+	}
+	body := map[string]any{"name": name}
+	if scope != "" {
+		body["scope"] = scope
+	}
+	cvPost(t, cv, authTok, "/api/tokens", body, &out)
+	if out.Token == "" || out.ID == "" {
+		t.Fatalf("mint returned empty token/id: %+v", out)
+	}
+	if !auth.ValidAPITokenFormat(out.Token) {
+		t.Fatalf("minted token %q fails canonical format", out.Token)
+	}
+	return out.ID, out.Token
+}
+
+// TestAPIToken_MintListRevoke drives the full lifecycle over real HTTP:
+// mint (plaintext only on create) → list (prefix, never plaintext/hash) →
+// use → revoke → revoked token is rejected 401 TOKEN_REVOKED.
+func TestAPIToken_MintListRevoke(t *testing.T) {
+	h := testharness.New(t)
+	cv := testapp.Start(t, h)
+	user := cv.LoginAsLocalUser(t)
+
+	id, tok := mintToken(t, cv, user.AccessToken, "ci", "instance-admin")
+
+	// List via JWT — must show the prefix and never the plaintext or hash.
+	var list struct {
+		Tokens []map[string]any `json:"tokens"`
+	}
+	cvGet(t, cv, user.AccessToken, "/api/tokens", &list)
+	if len(list.Tokens) != 1 {
+		t.Fatalf("list len = %d, want 1", len(list.Tokens))
+	}
+	row := list.Tokens[0]
+	if row["token_prefix"] == nil || row["token_prefix"].(string) == "" {
+		t.Fatalf("list row missing token_prefix: %+v", row)
+	}
+	if _, ok := row["token"]; ok {
+		t.Fatal("list must never include plaintext token")
+	}
+	if _, ok := row["token_hash"]; ok {
+		t.Fatal("list must never include token_hash")
+	}
+
+	// The token authenticates a wrapped route.
+	resp := cvDo(t, cv, tok, "GET", "/api/agents", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("token GET /api/agents = %d, want 200", resp.StatusCode)
+	}
+	resp.Body.Close()
+
+	// Revoke, then the token is rejected on the next request.
+	resp = cvDo(t, cv, user.AccessToken, "DELETE", "/api/tokens/"+id, nil)
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("DELETE /api/tokens = %d, want 204", resp.StatusCode)
+	}
+	resp.Body.Close()
+
+	resp = cvDo(t, cv, tok, "GET", "/api/agents", nil)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("revoked token GET = %d, want 401", resp.StatusCode)
+	}
+	if !bodyHasCodeStr(readBodyStr(resp), "TOKEN_REVOKED") {
+		t.Fatal("revoked token should return TOKEN_REVOKED")
+	}
+}
+
+// TestAPIToken_AdminGateByScope: an instance-admin token reaches the
+// admin-gated token-management route (POST /api/tokens) even though it
+// authenticates as `_instance` (role member in spec 04) — scope satisfies
+// the gate for token auth.
+func TestAPIToken_AdminGateByScope(t *testing.T) {
+	h := testharness.New(t)
+	cv := testapp.Start(t, h)
+	user := cv.LoginAsLocalUser(t)
+
+	_, adminTok := mintToken(t, cv, user.AccessToken, "admin", "instance-admin")
+
+	// Use the instance-admin token to mint ANOTHER token — an admin op.
+	var out struct {
+		Token string `json:"token"`
+	}
+	cvPost(t, cv, adminTok, "/api/tokens", map[string]any{"name": "second", "scope": "instance-admin"}, &out)
+	if out.Token == "" {
+		t.Fatal("instance-admin token could not reach the admin-gated mint route")
+	}
+}
+
+// TestAPIToken_Attribution: an agent created via an API token is owned by
+// `_instance`, not by the JWT user who minted the token. It is therefore
+// visible when listing under the token (which resolves to `_instance`) but
+// NOT under the human's own JWT account.
+func TestAPIToken_Attribution(t *testing.T) {
+	h := testharness.New(t)
+	cv := testapp.Start(t, h)
+	user := cv.LoginAsLocalUser(t)
+	_, tok := mintToken(t, cv, user.AccessToken, "tf", "instance-admin")
+
+	// Create an agent using the token.
+	var created struct {
+		ID string `json:"id"`
+	}
+	cvPost(t, cv, tok, "/api/agents", map[string]any{"name": "headless-agent"}, &created)
+	if created.ID == "" {
+		t.Fatal("agent create via token returned no id")
+	}
+
+	// Visible under the token (owned by _instance).
+	var viaToken []map[string]any
+	cvGet(t, cv, tok, "/api/agents", &viaToken)
+	if !agentListed(viaToken, created.ID) {
+		t.Fatalf("agent %s not visible under token auth", created.ID)
+	}
+
+	// NOT visible under the human JWT account (different owner).
+	var viaJWT []map[string]any
+	cvGet(t, cv, user.AccessToken, "/api/agents", &viaJWT)
+	if agentListed(viaJWT, created.ID) {
+		t.Fatal("token-created agent must not appear in the human's personal account")
+	}
+}
+
+// TestAPIToken_JWTFallthrough: a normal JWT request on a token-wrapped
+// route behaves exactly as before (no cvat_ token presented).
+func TestAPIToken_JWTFallthrough(t *testing.T) {
+	h := testharness.New(t)
+	cv := testapp.Start(t, h)
+	user := cv.LoginAsLocalUser(t)
+
+	resp := cvDo(t, cv, user.AccessToken, "GET", "/api/agents", nil)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("JWT GET /api/agents = %d, want 200", resp.StatusCode)
+	}
+
+	// A missing/invalid credential is still rejected.
+	resp2 := cvDo(t, cv, "", "GET", "/api/agents", nil)
+	defer resp2.Body.Close()
+	if resp2.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("no-auth GET /api/agents = %d, want 401", resp2.StatusCode)
+	}
+}
+
+// TestAPIToken_ExpiredRejected: a token whose expires_at has passed is
+// rejected 401 TOKEN_EXPIRED.
+func TestAPIToken_ExpiredRejected(t *testing.T) {
+	h := testharness.New(t)
+	cv := testapp.Start(t, h)
+	user := cv.LoginAsLocalUser(t)
+
+	var out struct {
+		Token string `json:"token"`
+	}
+	// Mint with an already-past expiry.
+	cvPost(t, cv, user.AccessToken, "/api/tokens", map[string]any{
+		"name":       "expired",
+		"scope":      "instance-admin",
+		"expires_at": "2000-01-01T00:00:00Z",
+	}, &out)
+
+	resp := cvDo(t, cv, out.Token, "GET", "/api/agents", nil)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized || !bodyHasCodeStr(readBodyStr(resp), "TOKEN_EXPIRED") {
+		t.Fatalf("expired token GET = %d, want 401 TOKEN_EXPIRED", resp.StatusCode)
+	}
+}
+
+// TestBootstrap_BurnsOnFirstMint: boot with a module-shaped
+// CLAWVISOR_BOOTSTRAP_TOKEN, with no human login ever having occurred.
+//  1. A read call does NOT burn the bootstrap token (retryable apply).
+//  2. The first scoped-token mint burns it (second use → 401 TOKEN_REVOKED).
+//  3. The minted token drives the headless flow: create an agent + a vault
+//     credential and read them back (acceptance criterion #1).
+func TestBootstrap_BurnsOnFirstMint(t *testing.T) {
+	h := testharness.New(t)
+	bootstrap := genAPIToken(t)
+	cv := testapp.StartWith(t, h, map[string]string{"CLAWVISOR_BOOTSTRAP_TOKEN": bootstrap})
+
+	// (1) A read does not burn the bootstrap token.
+	resp := cvDo(t, cv, bootstrap, "GET", "/api/agents", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("bootstrap read GET /api/agents = %d, want 200", resp.StatusCode)
+	}
+	resp.Body.Close()
+
+	// (2) First scoped-token mint burns the bootstrap credential.
+	_, longLived := mintToken(t, cv, bootstrap, "terraform", "instance-admin")
+
+	resp = cvDo(t, cv, bootstrap, "GET", "/api/agents", nil)
+	burnedBody := readBodyStr(resp)
+	if resp.StatusCode != http.StatusUnauthorized || !bodyHasCodeStr(burnedBody, "TOKEN_REVOKED") {
+		t.Fatalf("bootstrap token after mint = %d body=%q, want 401 TOKEN_REVOKED", resp.StatusCode, burnedBody)
+	}
+
+	// (3) Headless flow with the long-lived token: create an agent...
+	var agent struct {
+		ID string `json:"id"`
+	}
+	cvPost(t, cv, longLived, "/api/agents", map[string]any{"name": "provisioned"}, &agent)
+	if agent.ID == "" {
+		t.Fatal("headless agent create failed")
+	}
+	// ...set a vault credential...
+	cvPost(t, cv, longLived, "/api/vault/items", map[string]any{"id": "deploy-key", "value": "s3cr3t"}, nil)
+	// ...and read them back.
+	var agents []map[string]any
+	cvGet(t, cv, longLived, "/api/agents", &agents)
+	if !agentListed(agents, agent.ID) {
+		t.Fatal("provisioned agent not readable back headlessly")
+	}
+	var items struct {
+		Entries []map[string]any `json:"entries"`
+	}
+	cvGet(t, cv, longLived, "/api/vault/items", &items)
+	if !vaultItemListed(items.Entries, "deploy-key") {
+		t.Fatalf("vault credential not readable back headlessly: %+v", items.Entries)
+	}
+}
+
+// TestAPIToken_FeatureAdvertised: GET /api/features advertises
+// api_tokens:true so the Terraform provider can capability-negotiate
+// (PRD §9.1, acceptance criterion #6).
+func TestAPIToken_FeatureAdvertised(t *testing.T) {
+	h := testharness.New(t)
+	cv := testapp.Start(t, h)
+	var fs map[string]any
+	cvGet(t, cv, "", "/api/features", &fs)
+	if v, ok := fs["api_tokens"].(bool); !ok || !v {
+		t.Fatalf("expected api_tokens:true in /api/features, got %v", fs["api_tokens"])
+	}
+}
+
+func agentListed(list []map[string]any, id string) bool {
+	for _, a := range list {
+		if a["id"] == id {
+			return true
+		}
+	}
+	return false
+}
+
+func vaultItemListed(list []map[string]any, id string) bool {
+	for _, it := range list {
+		if it["id"] == id {
+			return true
+		}
+	}
+	return false
+}
+
+func bodyHasCodeStr(body, code string) bool {
+	return len(body) > 0 && (containsSub(body, `"code":"`+code+`"`) || containsSub(body, `"code": "`+code+`"`))
+}
+
+func containsSub(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/api/handlers/apitokens.go
+++ b/internal/api/handlers/apitokens.go
@@ -100,6 +100,14 @@ func (h *APITokensHandler) Create(w http.ResponseWriter, r *http.Request) {
 	// token can never be reused to mint a second credential.
 	if bt := middleware.APITokenFromContext(r.Context()); bt != nil && bt.IsBootstrap {
 		if err := h.st.CreateAPITokenAndBurnBootstrap(r.Context(), tok, bt.ID); err != nil {
+			// The burn is strictly single-use: a concurrent first-boot mint
+			// races on the bootstrap revoke and the loser gets ErrConflict.
+			// That is a retry-safe condition (the winner already minted), not
+			// a server fault, so surface it as 409 rather than 500.
+			if errors.Is(err, store.ErrConflict) {
+				writeError(w, http.StatusConflict, "CONFLICT", "bootstrap token already consumed by a concurrent request")
+				return
+			}
 			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not create token")
 			return
 		}

--- a/internal/api/handlers/apitokens.go
+++ b/internal/api/handlers/apitokens.go
@@ -90,21 +90,22 @@ func (h *APITokensHandler) Create(w http.ResponseWriter, r *http.Request) {
 		CreatedBy:   createdBy,
 		ExpiresAt:   expiresAt,
 	}
-	if err := h.st.CreateAPIToken(r.Context(), tok); err != nil {
+
+	// Burn-on-first-use: when the authenticating credential is the bootstrap
+	// token, the mint and the bootstrap revoke happen in ONE transaction, so
+	// the bootstrap credential is burned if and only if the new token lands.
+	// If the transaction fails, nothing is minted and nothing is burned — the
+	// bootstrap token stays live so a failed apply can retry the mint. A
+	// partial state (minted-but-not-burned) can never occur, so the bootstrap
+	// token can never be reused to mint a second credential.
+	if bt := middleware.APITokenFromContext(r.Context()); bt != nil && bt.IsBootstrap {
+		if err := h.st.CreateAPITokenAndBurnBootstrap(r.Context(), tok, bt.ID); err != nil {
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not create token")
+			return
+		}
+	} else if err := h.st.CreateAPIToken(r.Context(), tok); err != nil {
 		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not create token")
 		return
-	}
-
-	// Burn-on-first-use: only a successful scoped-token mint burns the
-	// bootstrap credential. Reads/other calls never reach here, so a failed
-	// apply can retry the mint until it succeeds.
-	if bt := middleware.APITokenFromContext(r.Context()); bt != nil && bt.IsBootstrap {
-		if err := h.st.RevokeAPIToken(r.Context(), bt.ID); err != nil && !errors.Is(err, store.ErrNotFound) {
-			// The token IS minted; log but don't fail the mint. The bootstrap
-			// token still hard-expires at +24h even if this best-effort
-			// revoke didn't land.
-			h.logger.Error("failed to burn bootstrap token after mint", "err", err, "bootstrap_token_id", bt.ID)
-		}
 	}
 
 	writeJSON(w, http.StatusCreated, map[string]any{

--- a/internal/api/handlers/apitokens.go
+++ b/internal/api/handlers/apitokens.go
@@ -1,0 +1,164 @@
+package handlers
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/clawvisor/clawvisor/internal/api/middleware"
+	"github.com/clawvisor/clawvisor/internal/auth"
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+// APITokensHandler manages the lifecycle of long-lived, scoped, revocable
+// API tokens (spec 05). All three routes are admin-gated: a JWT admin (via
+// spec 04's role system, once it lands) or an `instance-admin` API token.
+// In 05-lite the only issuable scope is `instance-admin`.
+type APITokensHandler struct {
+	st     store.Store
+	logger *slog.Logger
+}
+
+func NewAPITokensHandler(st store.Store, logger *slog.Logger) *APITokensHandler {
+	return &APITokensHandler{st: st, logger: logger}
+}
+
+// Create mints a new API token and returns the plaintext exactly once.
+//
+// POST /api/tokens
+// Auth: admin (JWT admin or instance-admin API token)
+// Body: {"name":"terraform","scope":"instance-admin","expires_at"?:RFC3339}
+//
+// Burn-on-first-use: when the authenticating credential is the bootstrap
+// token, a successful mint revokes the bootstrap token immediately so it
+// can never become a permanent instance-admin credential.
+func (h *APITokensHandler) Create(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Name      string `json:"name"`
+		Scope     string `json:"scope"`
+		ExpiresAt string `json:"expires_at"`
+	}
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+	if body.Name == "" {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "name is required")
+		return
+	}
+
+	// 05-lite issues a single scope. Empty defaults to instance-admin; any
+	// other value (config-write / config-read) is rejected until spec 04
+	// lands the scope split.
+	scope := body.Scope
+	if scope == "" {
+		scope = middleware.ScopeInstanceAdmin
+	}
+	if scope != middleware.ScopeInstanceAdmin {
+		writeError(w, http.StatusBadRequest, "INVALID_SCOPE",
+			"only the \"instance-admin\" scope is supported in this build; config-write/config-read land with roles")
+		return
+	}
+
+	var expiresAt *time.Time
+	if body.ExpiresAt != "" {
+		t, err := time.Parse(time.RFC3339, body.ExpiresAt)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "expires_at must be RFC3339")
+			return
+		}
+		expiresAt = &t
+	}
+
+	raw, prefix, err := auth.GenerateAPIToken()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not generate token")
+		return
+	}
+
+	var createdBy *string
+	if u := middleware.UserFromContext(r.Context()); u != nil && u.ID != store.InstanceUserID {
+		id := u.ID
+		createdBy = &id
+	}
+
+	tok := &store.APIToken{
+		Name:        body.Name,
+		TokenHash:   auth.HashToken(raw),
+		TokenPrefix: prefix,
+		Scope:       scope,
+		CreatedBy:   createdBy,
+		ExpiresAt:   expiresAt,
+	}
+	if err := h.st.CreateAPIToken(r.Context(), tok); err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not create token")
+		return
+	}
+
+	// Burn-on-first-use: only a successful scoped-token mint burns the
+	// bootstrap credential. Reads/other calls never reach here, so a failed
+	// apply can retry the mint until it succeeds.
+	if bt := middleware.APITokenFromContext(r.Context()); bt != nil && bt.IsBootstrap {
+		if err := h.st.RevokeAPIToken(r.Context(), bt.ID); err != nil && !errors.Is(err, store.ErrNotFound) {
+			// The token IS minted; log but don't fail the mint. The bootstrap
+			// token still hard-expires at +24h even if this best-effort
+			// revoke didn't land.
+			h.logger.Error("failed to burn bootstrap token after mint", "err", err, "bootstrap_token_id", bt.ID)
+		}
+	}
+
+	writeJSON(w, http.StatusCreated, map[string]any{
+		"id":           tok.ID,
+		"token":        raw,
+		"token_prefix": tok.TokenPrefix,
+		"scope":        tok.Scope,
+	})
+}
+
+// List returns all API tokens (never hashes or plaintext).
+//
+// GET /api/tokens
+// Auth: admin (JWT admin or instance-admin API token)
+func (h *APITokensHandler) List(w http.ResponseWriter, r *http.Request) {
+	tokens, err := h.st.ListAPITokens(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not list tokens")
+		return
+	}
+	out := make([]map[string]any, 0, len(tokens))
+	for _, t := range tokens {
+		out = append(out, map[string]any{
+			"id":           t.ID,
+			"name":         t.Name,
+			"token_prefix": t.TokenPrefix,
+			"scope":        t.Scope,
+			"created_by":   t.CreatedBy,
+			"created_at":   t.CreatedAt,
+			"expires_at":   t.ExpiresAt,
+			"last_used_at": t.LastUsedAt,
+			"revoked_at":   t.RevokedAt,
+		})
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"tokens": out})
+}
+
+// Delete soft-revokes a token (sets revoked_at; row kept for audit).
+//
+// DELETE /api/tokens/{id}
+// Auth: admin (JWT admin or instance-admin API token)
+func (h *APITokensHandler) Delete(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "token id is required")
+		return
+	}
+	if err := h.st.RevokeAPIToken(r.Context(), id); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "NOT_FOUND", "token not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not revoke token")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/api/handlers/apitokens_test.go
+++ b/internal/api/handlers/apitokens_test.go
@@ -1,0 +1,88 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/internal/api/middleware"
+	"github.com/clawvisor/clawvisor/internal/auth"
+	"github.com/clawvisor/clawvisor/pkg/store"
+	"github.com/clawvisor/clawvisor/pkg/store/sqlite"
+)
+
+// burnConflictStore wraps a real store but forces CreateAPITokenAndBurnBootstrap
+// to lose the burn race: it returns store.ErrConflict, exactly as the real
+// store does for the loser of a concurrent first-boot mint (the winner already
+// revoked the single-use bootstrap token). Every other method delegates to the
+// embedded store so the auth middleware still resolves the live bootstrap token.
+type burnConflictStore struct {
+	store.Store
+}
+
+func (burnConflictStore) CreateAPITokenAndBurnBootstrap(context.Context, *store.APIToken, string) error {
+	return store.ErrConflict
+}
+
+// TestCreate_ConcurrentBootstrapBurnConflictReturns409 proves that when the
+// burn loses the single-use race (store returns ErrConflict), the handler
+// surfaces a retry-safe 409 CONFLICT rather than a 500 INTERNAL_ERROR.
+func TestCreate_ConcurrentBootstrapBurnConflictReturns409(t *testing.T) {
+	ctx := context.Background()
+	db, err := sqlite.New(ctx, filepath.Join(t.TempDir(), "apitokens.db"))
+	if err != nil {
+		t.Fatalf("sqlite.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	real := sqlite.NewStore(db)
+
+	// Seed a live bootstrap token so the auth middleware admits the request
+	// and injects it (IsBootstrap) into the handler context.
+	raw, prefix, err := auth.GenerateAPIToken()
+	if err != nil {
+		t.Fatalf("GenerateAPIToken: %v", err)
+	}
+	if err := real.CreateAPIToken(ctx, &store.APIToken{
+		Name:        "bootstrap",
+		TokenHash:   auth.HashToken(raw),
+		TokenPrefix: prefix,
+		Scope:       middleware.ScopeInstanceAdmin,
+		IsBootstrap: true,
+	}); err != nil {
+		t.Fatalf("seed bootstrap token: %v", err)
+	}
+
+	st := burnConflictStore{real}
+	h := NewAPITokensHandler(st, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	jwtSvc, err := auth.NewJWTService("test-secret-test-secret-test-secret-12345")
+	if err != nil {
+		t.Fatalf("NewJWTService: %v", err)
+	}
+	handler := middleware.RequireUserOrAPIToken(jwtSvc, st, middleware.ScopeInstanceAdmin)(http.HandlerFunc(h.Create))
+
+	body, _ := json.Marshal(map[string]string{"name": "terraform", "scope": middleware.ScopeInstanceAdmin})
+	req := httptest.NewRequest(http.MethodPost, "/api/tokens", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+raw)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409; body=%q", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Code string `json:"code"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode error body: %v", err)
+	}
+	if resp.Code != "CONFLICT" {
+		t.Fatalf("error code = %q, want CONFLICT; body=%q", resp.Code, rec.Body.String())
+	}
+}

--- a/internal/api/middleware/apitoken.go
+++ b/internal/api/middleware/apitoken.go
@@ -1,0 +1,158 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	intauth "github.com/clawvisor/clawvisor/internal/auth"
+	"github.com/clawvisor/clawvisor/pkg/auth"
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+// API-token scopes. 05-lite issues and accepts only ScopeInstanceAdmin;
+// the config-write / config-read split (and the trust split that gates
+// governance-loosening and shared-vault writes) lands with spec 04. The
+// constants and ranking are defined now so 04 extends without churn and
+// so the provider resource (06b) has a stable vocabulary. Higher rank
+// implies lower (hierarchical).
+const (
+	ScopeConfigRead    = "config-read"
+	ScopeConfigWrite   = "config-write"
+	ScopeInstanceAdmin = "instance-admin"
+)
+
+// scopeRank maps a scope to its authority level. Unknown scopes rank 0
+// (satisfy nothing) — fail closed.
+var scopeRank = map[string]int{
+	ScopeConfigRead:    1,
+	ScopeConfigWrite:   2,
+	ScopeInstanceAdmin: 3,
+}
+
+// ScopeSatisfies reports whether a token carrying tokenScope meets the
+// minScope requirement under the hierarchy (instance-admin > config-write
+// > config-read).
+func ScopeSatisfies(tokenScope, minScope string) bool {
+	return scopeRank[tokenScope] >= scopeRank[minScope] && scopeRank[minScope] > 0
+}
+
+// apiTokenContextKey is the context key for the authenticated API token.
+type apiTokenContextKey struct{}
+
+// APITokenFromContext returns the API token that authenticated the
+// request, or nil for JWT/agent auth. Privileged handlers check this
+// FIRST: when a token is present the gate is the token's scope, and the
+// injected `_instance` user's role is never consulted (see the spec's
+// authorization-precedence rule).
+func APITokenFromContext(ctx context.Context) *store.APIToken {
+	t, _ := ctx.Value(apiTokenContextKey{}).(*store.APIToken)
+	return t
+}
+
+func withAPIToken(ctx context.Context, t *store.APIToken) context.Context {
+	return context.WithValue(ctx, apiTokenContextKey{}, t)
+}
+
+// lastUsedThrottle rate-limits last_used_at writes to once per minute per
+// token so a busy CI credential doesn't turn every request into a write.
+type lastUsedThrottle struct {
+	mu   sync.Mutex
+	seen map[string]time.Time
+}
+
+func (l *lastUsedThrottle) shouldTouch(id string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	now := time.Now()
+	if last, ok := l.seen[id]; ok && now.Sub(last) < time.Minute {
+		return false
+	}
+	l.seen[id] = now
+	return true
+}
+
+var apiTokenLastUsed = &lastUsedThrottle{seen: map[string]time.Time{}}
+
+// RequireUserOrAPIToken accepts either a user JWT or a `cvat_…` API token.
+// When a `cvat_` value is present in the bearer slot it is validated as an
+// API token: hashed, looked up, checked for revocation / expiry / scope,
+// and on success the `_instance` system user is injected under
+// UserContextKey (so every user-scoped handler owns rows under `_instance`)
+// plus the token record under the API-token context key. The acting
+// principal for logs is the token (token_id / token_name), NOT `_instance`.
+//
+// No `cvat_` prefix → fall through to RequireUser exactly as
+// RequireUserOrAgent falls through to the JWT path today. The `cvat_`
+// sniff happens BEFORE any JWT parsing so the shared bearer slot never
+// hands an API token to the JWT validator.
+func RequireUserOrAPIToken(jwtSvc auth.TokenService, st store.Store, minScope string) func(http.Handler) http.Handler {
+	requireUser := RequireUser(jwtSvc, st)
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			tok := apiTokenFromRequest(r)
+			if tok == "" {
+				requireUser(next).ServeHTTP(w, r)
+				return
+			}
+
+			at, err := st.GetAPITokenByHash(r.Context(), intauth.HashToken(tok))
+			if err != nil {
+				if errors.Is(err, store.ErrNotFound) {
+					writeAuthError(w, http.StatusUnauthorized, "UNAUTHORIZED", "invalid api token")
+				} else {
+					writeAuthError(w, http.StatusServiceUnavailable, "SERVICE_UNAVAILABLE", "temporary service error, please retry")
+				}
+				return
+			}
+			if at.RevokedAt != nil {
+				writeAuthError(w, http.StatusUnauthorized, "TOKEN_REVOKED", "api token has been revoked")
+				return
+			}
+			if at.ExpiresAt != nil && time.Now().After(*at.ExpiresAt) {
+				writeAuthError(w, http.StatusUnauthorized, "TOKEN_EXPIRED", "api token has expired")
+				return
+			}
+			if !ScopeSatisfies(at.Scope, minScope) {
+				writeAuthError(w, http.StatusForbidden, "INSUFFICIENT_SCOPE", "api token scope is insufficient for this operation")
+				return
+			}
+
+			// Attribution: token-authenticated writes are owned by the
+			// `_instance` system user. Fail CLOSED (500) if that row is
+			// missing rather than silently attributing to a random user.
+			user, err := st.GetUserByID(r.Context(), store.InstanceUserID)
+			if err != nil {
+				writeAuthError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "instance system user is not provisioned")
+				return
+			}
+
+			if apiTokenLastUsed.shouldTouch(at.ID) {
+				// Best-effort; a failed touch must not fail the request.
+				_ = st.TouchAPITokenLastUsed(r.Context(), at.ID)
+			}
+
+			ctx := withAPIToken(r.Context(), at)
+			ctx = context.WithValue(ctx, UserContextKey, user)
+			// Principal is the token, not `_instance`: this keeps each
+			// CI/automation token individually attributable and bounds a
+			// revocation's blast radius to one named token.
+			AddLogField(ctx, "token_id", at.ID)
+			AddLogField(ctx, "token_name", at.Name)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+// apiTokenFromRequest returns a `cvat_…` API token sniffed from the
+// Authorization bearer slot, or "" if the bearer is absent or carries a
+// different shape (JWT, cvis_ agent token). Mirrors agentTokenFromRequest.
+func apiTokenFromRequest(r *http.Request) string {
+	if bt := bearerToken(r); strings.HasPrefix(bt, intauth.APITokenPrefix) {
+		return bt
+	}
+	return ""
+}

--- a/internal/api/middleware/apitoken.go
+++ b/internal/api/middleware/apitoken.go
@@ -57,18 +57,35 @@ func withAPIToken(ctx context.Context, t *store.APIToken) context.Context {
 	return context.WithValue(ctx, apiTokenContextKey{}, t)
 }
 
+// lastUsedInterval is the throttle window for last_used_at writes.
+const lastUsedInterval = time.Minute
+
 // lastUsedThrottle rate-limits last_used_at writes to once per minute per
 // token so a busy CI credential doesn't turn every request into a write.
 type lastUsedThrottle struct {
-	mu   sync.Mutex
-	seen map[string]time.Time
+	mu        sync.Mutex
+	seen      map[string]time.Time
+	lastSweep time.Time
 }
 
 func (l *lastUsedThrottle) shouldTouch(id string) bool {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	now := time.Now()
-	if last, ok := l.seen[id]; ok && now.Sub(last) < time.Minute {
+	// Evict entries older than the throttle window so the map can't grow
+	// without bound as short-lived tokens are minted and revoked over time.
+	// An expired entry is meaningless (it would be treated as touchable and
+	// overwritten anyway), so dropping it changes no behavior. Sweep at most
+	// once per window to keep this O(1) amortized.
+	if now.Sub(l.lastSweep) >= lastUsedInterval {
+		for k, ts := range l.seen {
+			if now.Sub(ts) >= lastUsedInterval {
+				delete(l.seen, k)
+			}
+		}
+		l.lastSweep = now
+	}
+	if last, ok := l.seen[id]; ok && now.Sub(last) < lastUsedInterval {
 		return false
 	}
 	l.seen[id] = now

--- a/internal/api/middleware/apitoken_test.go
+++ b/internal/api/middleware/apitoken_test.go
@@ -1,0 +1,263 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	intauth "github.com/clawvisor/clawvisor/internal/auth"
+	"github.com/clawvisor/clawvisor/pkg/auth"
+	"github.com/clawvisor/clawvisor/pkg/store"
+	"github.com/clawvisor/clawvisor/pkg/store/sqlite"
+)
+
+func newAPITokenTestStore(t *testing.T) store.Store {
+	t.Helper()
+	ctx := context.Background()
+	db, err := sqlite.New(ctx, filepath.Join(t.TempDir(), "apitoken.db"))
+	if err != nil {
+		t.Fatalf("sqlite.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return sqlite.NewStore(db)
+}
+
+// seedAPIToken inserts a token with the given hash/scope and optional
+// expiry/revocation, returning the raw plaintext value.
+func seedAPIToken(t *testing.T, st store.Store, scope string, expiresAt *time.Time, revoked bool, bootstrap bool) string {
+	t.Helper()
+	ctx := context.Background()
+	raw, prefix, err := intauth.GenerateAPIToken()
+	if err != nil {
+		t.Fatalf("GenerateAPIToken: %v", err)
+	}
+	tok := &store.APIToken{
+		Name:        "test-token",
+		TokenHash:   intauth.HashToken(raw),
+		TokenPrefix: prefix,
+		Scope:       scope,
+		ExpiresAt:   expiresAt,
+		IsBootstrap: bootstrap,
+	}
+	if err := st.CreateAPIToken(ctx, tok); err != nil {
+		t.Fatalf("CreateAPIToken: %v", err)
+	}
+	if revoked {
+		if err := st.RevokeAPIToken(ctx, tok.ID); err != nil {
+			t.Fatalf("RevokeAPIToken: %v", err)
+		}
+	}
+	return raw
+}
+
+type apiTokenCapture struct {
+	User  *store.User
+	Token *store.APIToken
+}
+
+func (c *apiTokenCapture) handler(w http.ResponseWriter, r *http.Request) {
+	c.User = UserFromContext(r.Context())
+	c.Token = APITokenFromContext(r.Context())
+	w.WriteHeader(http.StatusOK)
+}
+
+func newTestJWT(t *testing.T) auth.TokenService {
+	t.Helper()
+	jwtSvc, err := intauth.NewJWTService("test-secret-test-secret-test-secret-12345")
+	if err != nil {
+		t.Fatalf("NewJWTService: %v", err)
+	}
+	return jwtSvc
+}
+
+func TestScopeSatisfies(t *testing.T) {
+	cases := []struct {
+		token, min string
+		want       bool
+	}{
+		{ScopeInstanceAdmin, ScopeInstanceAdmin, true},
+		{ScopeInstanceAdmin, ScopeConfigWrite, true},
+		{ScopeInstanceAdmin, ScopeConfigRead, true},
+		{ScopeConfigWrite, ScopeInstanceAdmin, false},
+		{ScopeConfigWrite, ScopeConfigWrite, true},
+		{ScopeConfigRead, ScopeConfigWrite, false},
+		{ScopeConfigRead, ScopeConfigRead, true},
+		{"", ScopeConfigRead, false},
+		{ScopeConfigRead, "bogus", false},
+	}
+	for _, tc := range cases {
+		if got := ScopeSatisfies(tc.token, tc.min); got != tc.want {
+			t.Errorf("ScopeSatisfies(%q,%q)=%v want %v", tc.token, tc.min, got, tc.want)
+		}
+	}
+}
+
+func TestRequireUserOrAPIToken_ValidToken(t *testing.T) {
+	st := newAPITokenTestStore(t)
+	raw := seedAPIToken(t, st, ScopeInstanceAdmin, nil, false, false)
+
+	cap := &apiTokenCapture{}
+	h := RequireUserOrAPIToken(newTestJWT(t), st, ScopeInstanceAdmin)(http.HandlerFunc(cap.handler))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/agents", nil)
+	req.Header.Set("Authorization", "Bearer "+raw)
+	// Attach a LogFields accumulator so we can assert the principal fields.
+	ctx, lf := WithLogFields(req.Context())
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", rec.Code, rec.Body.String())
+	}
+	if cap.User == nil || cap.User.ID != store.InstanceUserID {
+		t.Fatalf("expected _instance user injected, got %+v", cap.User)
+	}
+	if cap.Token == nil || cap.Token.Scope != ScopeInstanceAdmin {
+		t.Fatalf("expected token in context, got %+v", cap.Token)
+	}
+	// Principal fields are the token, not _instance.
+	var hasTokenID, hasUserID bool
+	for _, a := range lf.Attrs() {
+		switch a.Key {
+		case "token_id":
+			hasTokenID = true
+		case "user_id":
+			hasUserID = true
+		}
+	}
+	if !hasTokenID {
+		t.Fatal("expected token_id log field (principal attribution)")
+	}
+	if hasUserID {
+		t.Fatal("did not expect user_id log field for token auth (principal must be the token)")
+	}
+}
+
+func TestRequireUserOrAPIToken_Revoked(t *testing.T) {
+	st := newAPITokenTestStore(t)
+	raw := seedAPIToken(t, st, ScopeInstanceAdmin, nil, true, false)
+	h := RequireUserOrAPIToken(newTestJWT(t), st, ScopeInstanceAdmin)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) }))
+	req := httptest.NewRequest(http.MethodGet, "/api/agents", nil)
+	req.Header.Set("Authorization", "Bearer "+raw)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rec.Code)
+	}
+	if !bodyHasCode(rec.Body.String(), "TOKEN_REVOKED") {
+		t.Fatalf("want TOKEN_REVOKED, body=%q", rec.Body.String())
+	}
+}
+
+func TestRequireUserOrAPIToken_Expired(t *testing.T) {
+	st := newAPITokenTestStore(t)
+	past := time.Now().Add(-time.Hour)
+	raw := seedAPIToken(t, st, ScopeInstanceAdmin, &past, false, false)
+	h := RequireUserOrAPIToken(newTestJWT(t), st, ScopeInstanceAdmin)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) }))
+	req := httptest.NewRequest(http.MethodGet, "/api/agents", nil)
+	req.Header.Set("Authorization", "Bearer "+raw)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized || !bodyHasCode(rec.Body.String(), "TOKEN_EXPIRED") {
+		t.Fatalf("status=%d body=%q want 401 TOKEN_EXPIRED", rec.Code, rec.Body.String())
+	}
+}
+
+func TestRequireUserOrAPIToken_InsufficientScope(t *testing.T) {
+	st := newAPITokenTestStore(t)
+	// A config-read token cannot satisfy an instance-admin gate.
+	raw := seedAPIToken(t, st, ScopeConfigRead, nil, false, false)
+	h := RequireUserOrAPIToken(newTestJWT(t), st, ScopeInstanceAdmin)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) }))
+	req := httptest.NewRequest(http.MethodPost, "/api/tokens", nil)
+	req.Header.Set("Authorization", "Bearer "+raw)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden || !bodyHasCode(rec.Body.String(), "INSUFFICIENT_SCOPE") {
+		t.Fatalf("status=%d body=%q want 403 INSUFFICIENT_SCOPE", rec.Code, rec.Body.String())
+	}
+}
+
+func TestRequireUserOrAPIToken_UnknownToken(t *testing.T) {
+	st := newAPITokenTestStore(t)
+	raw, _, _ := intauth.GenerateAPIToken() // never inserted
+	h := RequireUserOrAPIToken(newTestJWT(t), st, ScopeInstanceAdmin)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) }))
+	req := httptest.NewRequest(http.MethodGet, "/api/agents", nil)
+	req.Header.Set("Authorization", "Bearer "+raw)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status=%d want 401", rec.Code)
+	}
+}
+
+// TestRequireUserOrAPIToken_JWTFallthrough asserts a non-cvat_ bearer is
+// handed to the JWT path unchanged (regression guard). No cvat_ prefix →
+// invalid JWT → 401 from RequireUser, never touching the token path.
+func TestRequireUserOrAPIToken_JWTFallthrough(t *testing.T) {
+	st := newAPITokenTestStore(t)
+	h := RequireUserOrAPIToken(newTestJWT(t), st, ScopeInstanceAdmin)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) }))
+
+	// A bogus non-cvat_ bearer should reach RequireUser and be rejected as
+	// an invalid JWT (UNAUTHORIZED), proving fallthrough.
+	req := httptest.NewRequest(http.MethodGet, "/api/agents", nil)
+	req.Header.Set("Authorization", "Bearer not-a-cvat-token")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status=%d want 401 (JWT path)", rec.Code)
+	}
+}
+
+// TestRequireUserOrAPIToken_FailsClosedWithoutInstanceUser proves the
+// middleware 500s (never silently attributes to a random user) when the
+// `_instance` row is absent. We delete the seeded row to simulate a
+// missing seed.
+func TestRequireUserOrAPIToken_FailsClosedWithoutInstanceUser(t *testing.T) {
+	st := newAPITokenTestStore(t)
+	raw := seedAPIToken(t, st, ScopeInstanceAdmin, nil, false, false)
+	if err := st.DeleteUser(context.Background(), store.InstanceUserID); err != nil {
+		t.Fatalf("DeleteUser(_instance): %v", err)
+	}
+	h := RequireUserOrAPIToken(newTestJWT(t), st, ScopeInstanceAdmin)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) }))
+	req := httptest.NewRequest(http.MethodGet, "/api/agents", nil)
+	req.Header.Set("Authorization", "Bearer "+raw)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status=%d want 500 (fail closed)", rec.Code)
+	}
+}
+
+// TestBootstrap_Expires: a bootstrap token past its (mandatory +24h)
+// expiry is rejected with 401 TOKEN_EXPIRED just like any other expired
+// token — the 24h hard expiry is enforced regardless of is_bootstrap.
+func TestBootstrap_Expires(t *testing.T) {
+	st := newAPITokenTestStore(t)
+	past := time.Now().Add(-time.Minute)
+	raw := seedAPIToken(t, st, ScopeInstanceAdmin, &past, false, true /* bootstrap */)
+	h := RequireUserOrAPIToken(newTestJWT(t), st, ScopeInstanceAdmin)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) }))
+	req := httptest.NewRequest(http.MethodPost, "/api/tokens", nil)
+	req.Header.Set("Authorization", "Bearer "+raw)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized || !bodyHasCode(rec.Body.String(), "TOKEN_EXPIRED") {
+		t.Fatalf("status=%d body=%q want 401 TOKEN_EXPIRED", rec.Code, rec.Body.String())
+	}
+}
+
+func bodyHasCode(body, code string) bool {
+	return len(body) > 0 && (contains(body, `"code":"`+code+`"`) || contains(body, `"code": "`+code+`"`))
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -170,6 +170,11 @@ type FeatureSet struct {
 	RuntimeActivity   bool `json:"runtime_activity"`
 	AgentLiveSessions bool `json:"agent_live_sessions"`
 	ServicePresets    bool `json:"service_presets"`
+	// APITokens advertises the long-lived scoped API-token endpoints so the
+	// Terraform provider can capability-negotiate (PRD §9.1). Always on —
+	// there is no config gate — so it is set unconditionally in
+	// handleFeatures rather than plumbed through WithFeatures.
+	APITokens bool `json:"api_tokens"`
 }
 
 // GatewayHooks allows cloud/enterprise layers to inject additional
@@ -719,6 +724,16 @@ func (s *Server) routes() http.Handler {
 	gatewayHandler.SetGatewayRateLimiter(gatewayRL, agentKeyFn)
 
 	user := func(h http.HandlerFunc) http.Handler { return requireUser(h) }
+	// userOrToken accepts a user JWT OR a `cvat_…` API token (spec 05). In
+	// 05-lite the only issuable scope is instance-admin, so one wrapper
+	// covers the whole token-reachable surface; full-05 splits it into
+	// read/write/admin variants keyed on scope. A non-`cvat_` bearer falls
+	// through to the JWT path byte-identically to `user`.
+	requireUserOrToken := middleware.RequireUserOrAPIToken(s.jwtSvc, s.store, middleware.ScopeInstanceAdmin)
+	userOrToken := func(h http.HandlerFunc) http.Handler { return requireUserOrToken(h) }
+	userOrTokenPolicyRL := func(h http.HandlerFunc) http.Handler {
+		return requireUserOrToken(middleware.RateLimit(policyRL, userKeyFn, rlCfg.PolicyAPI.Limit)(h))
+	}
 	// E2E encryption middleware — wraps agent-facing routes so relay traffic is encrypted.
 	// Local requests pass through unencrypted; relay requests without E2E get 403.
 	e2e := func(h http.Handler) http.Handler { return h }
@@ -728,9 +743,6 @@ func (s *Server) routes() http.Handler {
 	}
 	userOAuthRL := func(h http.HandlerFunc) http.Handler {
 		return requireUser(middleware.RateLimit(oauthRL, userKeyFn, rlCfg.OAuth.Limit)(h))
-	}
-	userPolicyRL := func(h http.HandlerFunc) http.Handler {
-		return requireUser(middleware.RateLimit(policyRL, userKeyFn, rlCfg.PolicyAPI.Limit)(h))
 	}
 	llmPreAuthKeyFn := func(r *http.Request) string { return "llm-ip:" + ipKeyFn(r) }
 	llmAgentKeyFn := func(r *http.Request) string {
@@ -809,18 +821,27 @@ func (s *Server) routes() http.Handler {
 	// the deployment-level set.
 	mux.Handle("GET /api/features", middleware.OptionalUser(s.jwtSvc, s.store)(http.HandlerFunc(s.handleFeatures)))
 
-	// Restrictions (rate-limited writes)
-	mux.Handle("GET /api/restrictions", user(restrictionsHandler.List))
-	mux.Handle("POST /api/restrictions", userPolicyRL(restrictionsHandler.Create))
-	mux.Handle("DELETE /api/restrictions/{id}", userPolicyRL(restrictionsHandler.Delete))
+	// API tokens (spec 05) — admin-gated management surface. In 05-lite
+	// "admin" means a valid JWT user (single-tenant, they are the admin)
+	// OR an instance-admin API token; spec 04 adds the JWT role gate.
+	apiTokensHandler := handlers.NewAPITokensHandler(s.store, s.logger)
+	mux.Handle("POST /api/tokens", userOrToken(apiTokensHandler.Create))
+	mux.Handle("GET /api/tokens", userOrToken(apiTokensHandler.List))
+	mux.Handle("DELETE /api/tokens/{id}", userOrToken(apiTokensHandler.Delete))
 
-	// Agents (user JWT)
-	mux.Handle("GET /api/agents", user(agentsHandler.List))
-	mux.Handle("POST /api/agents", user(agentsHandler.Create))
-	mux.Handle("POST /api/agents/{id}/rotate", user(agentsHandler.RotateToken))
-	mux.Handle("GET /api/agents/{id}/runtime-settings", user(agentsHandler.GetRuntimeSettings))
-	mux.Handle("PUT /api/agents/{id}/runtime-settings", user(agentsHandler.UpdateRuntimeSettings))
-	mux.Handle("DELETE /api/agents/{id}", user(agentsHandler.Delete))
+	// Restrictions (rate-limited writes) — part of the declarative-config
+	// surface an API token drives headlessly.
+	mux.Handle("GET /api/restrictions", userOrToken(restrictionsHandler.List))
+	mux.Handle("POST /api/restrictions", userOrTokenPolicyRL(restrictionsHandler.Create))
+	mux.Handle("DELETE /api/restrictions/{id}", userOrTokenPolicyRL(restrictionsHandler.Delete))
+
+	// Agents (user JWT or API token)
+	mux.Handle("GET /api/agents", userOrToken(agentsHandler.List))
+	mux.Handle("POST /api/agents", userOrToken(agentsHandler.Create))
+	mux.Handle("POST /api/agents/{id}/rotate", userOrToken(agentsHandler.RotateToken))
+	mux.Handle("GET /api/agents/{id}/runtime-settings", userOrToken(agentsHandler.GetRuntimeSettings))
+	mux.Handle("PUT /api/agents/{id}/runtime-settings", userOrToken(agentsHandler.UpdateRuntimeSettings))
+	mux.Handle("DELETE /api/agents/{id}", userOrToken(agentsHandler.Delete))
 
 	// Notifications (user JWT)
 	mux.Handle("GET /api/notifications", user(notificationsHandler.List))
@@ -960,23 +981,27 @@ func (s *Server) routes() http.Handler {
 	// Callback secret registration (agent token)
 	mux.Handle("POST /api/callbacks/register", requireAgent(e2e(http.HandlerFunc(gatewayHandler.RegisterCallback))))
 
-	// Services / OAuth (user JWT, rate-limited)
-	mux.Handle("GET /api/services", user(servicesHandler.List))
+	// Services / OAuth (user JWT or API token)
+	mux.Handle("GET /api/services", userOrToken(servicesHandler.List))
 	if s.cfg.ProxyLite.Enabled {
-		mux.Handle("GET /api/vault/items", user(vaultHandler.ListForUser))
-		mux.Handle("POST /api/vault/items", user(vaultHandler.CreateForUser))
-		mux.Handle("GET /api/vault/items/{id}", user(vaultHandler.GetForUser))
-		mux.Handle("PUT /api/vault/items/{id}", user(vaultHandler.UpdateForUser))
-		mux.Handle("DELETE /api/vault/items/{id}", user(vaultHandler.DeleteForUser))
+		// Personal vault items — token auth lives under the same ProxyLite
+		// gate as the JWT routes (gotcha #5). In 05-lite an instance-admin
+		// token writes the caller's (`_instance`) personal vault entries;
+		// shared/`_instance` vault routes are a spec-04 addition.
+		mux.Handle("GET /api/vault/items", userOrToken(vaultHandler.ListForUser))
+		mux.Handle("POST /api/vault/items", userOrToken(vaultHandler.CreateForUser))
+		mux.Handle("GET /api/vault/items/{id}", userOrToken(vaultHandler.GetForUser))
+		mux.Handle("PUT /api/vault/items/{id}", userOrToken(vaultHandler.UpdateForUser))
+		mux.Handle("DELETE /api/vault/items/{id}", userOrToken(vaultHandler.DeleteForUser))
 		mux.Handle("GET /api/agent/vault/items", requireAgent(e2e(http.HandlerFunc(vaultHandler.ListForAgent))))
 	}
 	mux.Handle("GET /api/oauth/url", userOAuthRL(servicesHandler.OAuthGetURL))  // fetch → returns {"url":"..."}
 	mux.Handle("GET /api/oauth/start", userOAuthRL(servicesHandler.OAuthStart)) // kept for compat
 	mux.HandleFunc("GET /api/oauth/callback", servicesHandler.OAuthCallback)    // no auth: browser redirect
-	mux.Handle("POST /api/services/{serviceID}/activate", user(servicesHandler.Activate))
-	mux.Handle("POST /api/services/{serviceID}/activate-key", user(servicesHandler.ActivateWithKey))
-	mux.Handle("POST /api/services/{serviceID}/deactivate", user(servicesHandler.Deactivate))
-	mux.Handle("POST /api/services/{serviceID}/rename-alias", user(servicesHandler.RenameAlias))
+	mux.Handle("POST /api/services/{serviceID}/activate", userOrToken(servicesHandler.Activate))
+	mux.Handle("POST /api/services/{serviceID}/activate-key", userOrToken(servicesHandler.ActivateWithKey))
+	mux.Handle("POST /api/services/{serviceID}/deactivate", userOrToken(servicesHandler.Deactivate))
+	mux.Handle("POST /api/services/{serviceID}/rename-alias", userOrToken(servicesHandler.RenameAlias))
 	mux.Handle("POST /api/services/{serviceID}/device-flow/start", user(servicesHandler.DeviceFlowStart))
 	mux.Handle("POST /api/services/{serviceID}/device-flow/poll", user(servicesHandler.DeviceFlowPoll))
 	mux.Handle("POST /api/services/{serviceID}/pkce-flow/start", user(servicesHandler.PKCEFlowStart))
@@ -1518,6 +1543,9 @@ func (s *Server) handleFeatures(w http.ResponseWriter, r *http.Request) {
 	if s.featuresHook != nil {
 		fs = s.featuresHook(r.Context(), middleware.UserFromContext(r.Context()), fs)
 	}
+	// API tokens are always available (no config gate); advertise them so
+	// the Terraform provider knows the endpoints exist.
+	fs.APITokens = true
 	w.Header().Set("Content-Type", "application/json")
 	// The response varies per-user (via featuresHook). Without no-store, a
 	// browser may cache the anonymous response and serve it back after the

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -712,6 +712,14 @@ func (s *Server) routes() http.Handler {
 		return ""
 	}
 	userKeyFn := func(r *http.Request) string {
+		// Token-authenticated requests all resolve to the shared `_instance`
+		// user, so key them on the token ID instead — otherwise every
+		// automation token contends for one bucket and a single busy token
+		// could throttle all the others. JWT callers still key on their own
+		// user ID.
+		if t := middleware.APITokenFromContext(r.Context()); t != nil {
+			return "token:" + t.ID
+		}
 		if u := middleware.UserFromContext(r.Context()); u != nil {
 			return u.ID
 		}

--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -3,8 +3,47 @@ package auth
 import (
 	"crypto/rand"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
+	"regexp"
 )
+
+// APITokenPrefix is the canonical prefix for long-lived API tokens
+// (spec 05). Distinct from agent tokens (cvis_) so the two auth paths
+// stay disjoint.
+const APITokenPrefix = "cvat_"
+
+// APITokenPrefixLen is how many leading characters of the plaintext are
+// stored as api_tokens.token_prefix for display in lists (e.g.
+// "cvat_AbC1dEf2gH").
+const APITokenPrefixLen = 16
+
+// apiTokenRE is the exact shape the server accepts and the Terraform
+// module (spec 03) generates to: cvat_ + 43 base64url chars (RFC 4648
+// §5, no padding) encoding 32 random bytes. base64.RawURLEncoding of 32
+// bytes is always 43 chars.
+var apiTokenRE = regexp.MustCompile(`^cvat_[A-Za-z0-9_-]{43}$`)
+
+// GenerateAPIToken mints a new API token: "cvat_" + 43 base64url chars.
+// It returns the plaintext (shown once) and the display prefix (first 16
+// chars) stored in api_tokens.token_prefix. Only the SHA-256 hash
+// (HashToken) is persisted. This is base64url, NOT hex — do not confuse
+// it with GenerateAgentToken (cvis_ + hex).
+func GenerateAPIToken() (token, prefix string, err error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", "", err
+	}
+	token = APITokenPrefix + base64.RawURLEncoding.EncodeToString(b)
+	return token, token[:APITokenPrefixLen], nil
+}
+
+// ValidAPITokenFormat reports whether s matches the canonical API-token
+// shape. The server refuses to start on / rejects any bootstrap or
+// presented token that does not match.
+func ValidAPITokenFormat(s string) bool {
+	return apiTokenRE.MatchString(s)
+}
 
 // GenerateAgentToken creates a cryptographically secure agent bearer token
 // with the "cvis_" prefix. The raw token is shown once to the user; only

--- a/internal/auth/token_test.go
+++ b/internal/auth/token_test.go
@@ -1,0 +1,53 @@
+package auth
+
+import "testing"
+
+// TestGenerateAPIToken_FormatAndPrefix asserts the canonical shape the
+// server validates and the Terraform module (spec 03) generates to.
+func TestGenerateAPIToken_FormatAndPrefix(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		tok, prefix, err := GenerateAPIToken()
+		if err != nil {
+			t.Fatalf("GenerateAPIToken: %v", err)
+		}
+		if !ValidAPITokenFormat(tok) {
+			t.Fatalf("generated token %q fails ValidAPITokenFormat", tok)
+		}
+		if len(tok) != len(APITokenPrefix)+43 {
+			t.Fatalf("token len = %d, want %d", len(tok), len(APITokenPrefix)+43)
+		}
+		if len(prefix) != APITokenPrefixLen {
+			t.Fatalf("prefix len = %d, want %d", len(prefix), APITokenPrefixLen)
+		}
+		if tok[:APITokenPrefixLen] != prefix {
+			t.Fatalf("prefix %q is not the token head %q", prefix, tok[:APITokenPrefixLen])
+		}
+	}
+}
+
+// TestValidAPITokenFormat_Table is the format contract spec 03's module
+// must satisfy: cvat_ + exactly 43 base64url chars, no padding.
+func TestValidAPITokenFormat_Table(t *testing.T) {
+	valid := "cvat_" + "AbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_AbCdE" // 43 chars
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"canonical", valid, true},
+		{"empty", "", false},
+		{"wrong_prefix_hex", "cvis_0123456789abcdef0123456789abcdef0123456789abcdef", false},
+		{"too_short", "cvat_short", false},
+		{"has_padding", "cvat_AbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_AbCd=", false},
+		{"bad_char", "cvat_AbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_AbC!E", false},
+		{"no_prefix", "AbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_AbCdE", false},
+		{"44_chars", "cvat_AbCdEfGhIjKlMnOpQrStUvWxYz0123456789-_AbCdEF", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ValidAPITokenFormat(tc.in); got != tc.want {
+				t.Fatalf("ValidAPITokenFormat(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/clawvisor/bootstrap.go
+++ b/pkg/clawvisor/bootstrap.go
@@ -76,6 +76,16 @@ func bootstrapAPIToken(ctx context.Context, st store.Store, logger *slog.Logger)
 		IsBootstrap: true,
 	}
 	if err := st.CreateAPIToken(ctx, tok); err != nil {
+		// The GetAPITokenByHash check above and this insert are not atomic, so
+		// a concurrent replica may have seeded the very same token between the
+		// check and here. A same-hash ErrConflict is therefore the idempotent
+		// case (step 3), not a failure: the token exists, so treat it as a
+		// no-op rather than refusing to start. Any other conflict (e.g. a
+		// duplicate id) is a genuine fault and still propagates.
+		if errors.Is(err, store.ErrConflict) {
+			logger.Info("bootstrap API token concurrently seeded by another replica; skipping seed")
+			return nil
+		}
 		return fmt.Errorf("seeding bootstrap token: %w", err)
 	}
 	logger.Info("seeded bootstrap API token (single-use, first mint burns it)", "expires_at", expiresAt.Format(time.RFC3339))

--- a/pkg/clawvisor/bootstrap.go
+++ b/pkg/clawvisor/bootstrap.go
@@ -1,0 +1,83 @@
+package clawvisor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/clawvisor/clawvisor/internal/api/middleware"
+	"github.com/clawvisor/clawvisor/internal/auth"
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+// bootstrapTokenEnv is the env var the deploy module (spec 03) delivers the
+// first-boot bootstrap token through. The module GENERATES the value
+// (random_password → cvat_ + 43 base64url chars); the server never
+// generates it and never prints it.
+const bootstrapTokenEnv = "CLAWVISOR_BOOTSTRAP_TOKEN"
+
+// bootstrapTokenTTL is the mandatory hard expiry of the bootstrap token.
+// The token exists in plaintext in the secret manager, the compose env on
+// disk, and Terraform state, so it must be short-lived by construction.
+const bootstrapTokenTTL = 24 * time.Hour
+
+// bootstrapAPIToken seeds the first-boot bootstrap API token from
+// CLAWVISOR_BOOTSTRAP_TOKEN. It is idempotent across restarts and never
+// overrides a live install. Called from the startup path after store init.
+//
+// Contract (coordinates with spec 03's Terraform module):
+//  1. unset            → no-op.
+//  2. malformed value  → refuse to start (misconfiguration, not a warning).
+//  3. hash already present → no-op (idempotent; may already be revoked).
+//  4. a non-revoked instance-admin token already exists → warn and skip.
+//  5. else insert: name="bootstrap", scope=instance-admin, created_by=NULL,
+//     expires_at = now + 24h, is_bootstrap=true (burn-on-use target).
+func bootstrapAPIToken(ctx context.Context, st store.Store, logger *slog.Logger) error {
+	val := os.Getenv(bootstrapTokenEnv)
+	if val == "" {
+		return nil
+	}
+	if !auth.ValidAPITokenFormat(val) {
+		return fmt.Errorf("%s is malformed: must match cvat_ + 43 base64url chars", bootstrapTokenEnv)
+	}
+
+	hash := auth.HashToken(val)
+	if _, err := st.GetAPITokenByHash(ctx, hash); err == nil {
+		// Idempotent across restarts. The row may already be revoked
+		// (burn-on-use) — that is fine, we still do not re-seed it.
+		logger.Info("bootstrap API token already present; skipping seed")
+		return nil
+	} else if !errors.Is(err, store.ErrNotFound) {
+		return fmt.Errorf("checking for existing bootstrap token: %w", err)
+	}
+
+	tokens, err := st.ListAPITokens(ctx)
+	if err != nil {
+		return fmt.Errorf("listing api tokens: %w", err)
+	}
+	for _, t := range tokens {
+		if t.Scope == middleware.ScopeInstanceAdmin && t.RevokedAt == nil {
+			logger.Warn("a non-revoked instance-admin API token already exists; refusing to seed bootstrap token over a live install")
+			return nil
+		}
+	}
+
+	expiresAt := time.Now().Add(bootstrapTokenTTL).UTC()
+	tok := &store.APIToken{
+		Name:        "bootstrap",
+		TokenHash:   hash,
+		TokenPrefix: val[:auth.APITokenPrefixLen],
+		Scope:       middleware.ScopeInstanceAdmin,
+		CreatedBy:   nil,
+		ExpiresAt:   &expiresAt,
+		IsBootstrap: true,
+	}
+	if err := st.CreateAPIToken(ctx, tok); err != nil {
+		return fmt.Errorf("seeding bootstrap token: %w", err)
+	}
+	logger.Info("seeded bootstrap API token (single-use, first mint burns it)", "expires_at", expiresAt.Format(time.RFC3339))
+	return nil
+}

--- a/pkg/clawvisor/bootstrap_test.go
+++ b/pkg/clawvisor/bootstrap_test.go
@@ -1,0 +1,150 @@
+package clawvisor
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/internal/api/middleware"
+	"github.com/clawvisor/clawvisor/internal/auth"
+	"github.com/clawvisor/clawvisor/pkg/store"
+	"github.com/clawvisor/clawvisor/pkg/store/sqlite"
+)
+
+func newBootstrapStore(t *testing.T) (store.Store, context.Context) {
+	t.Helper()
+	ctx := context.Background()
+	db, err := sqlite.New(ctx, filepath.Join(t.TempDir(), "boot.db"))
+	if err != nil {
+		t.Fatalf("sqlite.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return sqlite.NewStore(db), ctx
+}
+
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// genBootstrapToken returns a valid cvat_ value for use as a bootstrap
+// token in tests.
+func genBootstrapToken(t *testing.T) string {
+	t.Helper()
+	raw, _, err := auth.GenerateAPIToken()
+	if err != nil {
+		t.Fatalf("GenerateAPIToken: %v", err)
+	}
+	return raw
+}
+
+// TestBootstrap_MintOnce: a valid bootstrap token seeds exactly one
+// instance-admin, is_bootstrap row with a +24h expiry.
+func TestBootstrap_MintOnce(t *testing.T) {
+	st, ctx := newBootstrapStore(t)
+	raw := genBootstrapToken(t)
+	t.Setenv(bootstrapTokenEnv, raw)
+
+	if err := bootstrapAPIToken(ctx, st, quietLogger()); err != nil {
+		t.Fatalf("bootstrapAPIToken: %v", err)
+	}
+	got, err := st.GetAPITokenByHash(ctx, auth.HashToken(raw))
+	if err != nil {
+		t.Fatalf("GetAPITokenByHash: %v", err)
+	}
+	if got.Name != "bootstrap" || got.Scope != middleware.ScopeInstanceAdmin || !got.IsBootstrap {
+		t.Fatalf("unexpected bootstrap row: %+v", got)
+	}
+	if got.CreatedBy != nil {
+		t.Fatalf("bootstrap created_by should be NULL, got %v", *got.CreatedBy)
+	}
+	if got.ExpiresAt == nil {
+		t.Fatal("bootstrap token must have a mandatory +24h expiry")
+	}
+}
+
+// TestBootstrap_Idempotent: re-running with the same token is a no-op and
+// does not create a duplicate row (idempotent across restarts). It stays
+// a no-op even when the existing row is already revoked (burned).
+func TestBootstrap_Idempotent(t *testing.T) {
+	st, ctx := newBootstrapStore(t)
+	raw := genBootstrapToken(t)
+	t.Setenv(bootstrapTokenEnv, raw)
+
+	if err := bootstrapAPIToken(ctx, st, quietLogger()); err != nil {
+		t.Fatalf("first bootstrap: %v", err)
+	}
+	first, _ := st.GetAPITokenByHash(ctx, auth.HashToken(raw))
+
+	// Simulate burn-on-use, then re-run: must remain a no-op (not re-seed).
+	if err := st.RevokeAPIToken(ctx, first.ID); err != nil {
+		t.Fatalf("RevokeAPIToken: %v", err)
+	}
+	if err := bootstrapAPIToken(ctx, st, quietLogger()); err != nil {
+		t.Fatalf("second bootstrap: %v", err)
+	}
+	list, _ := st.ListAPITokens(ctx)
+	if len(list) != 1 {
+		t.Fatalf("expected 1 token after idempotent re-run, got %d", len(list))
+	}
+	again, _ := st.GetAPITokenByHash(ctx, auth.HashToken(raw))
+	if again.RevokedAt == nil {
+		t.Fatal("re-run must not resurrect a burned bootstrap token")
+	}
+}
+
+// TestBootstrap_RefusesMalformed: a malformed value returns an error
+// (the caller refuses to start).
+func TestBootstrap_RefusesMalformed(t *testing.T) {
+	st, ctx := newBootstrapStore(t)
+	t.Setenv(bootstrapTokenEnv, "cvat_not-valid")
+	if err := bootstrapAPIToken(ctx, st, quietLogger()); err == nil {
+		t.Fatal("expected error for malformed bootstrap token")
+	}
+	list, _ := st.ListAPITokens(ctx)
+	if len(list) != 0 {
+		t.Fatalf("malformed token must not seed a row, got %d", len(list))
+	}
+}
+
+// TestBootstrap_Unset: no env var → clean no-op.
+func TestBootstrap_Unset(t *testing.T) {
+	st, ctx := newBootstrapStore(t)
+	t.Setenv(bootstrapTokenEnv, "")
+	if err := bootstrapAPIToken(ctx, st, quietLogger()); err != nil {
+		t.Fatalf("unset bootstrap should be a no-op, got %v", err)
+	}
+	list, _ := st.ListAPITokens(ctx)
+	if len(list) != 0 {
+		t.Fatalf("unset must not seed a row, got %d", len(list))
+	}
+}
+
+// TestBootstrap_SkipsWhenAdminTokenExists: bootstrap never overrides a
+// live install — if a non-revoked instance-admin token already exists, the
+// seed is skipped.
+func TestBootstrap_SkipsWhenAdminTokenExists(t *testing.T) {
+	st, ctx := newBootstrapStore(t)
+
+	// Pre-existing live instance-admin token (e.g. minted earlier).
+	existing := &store.APIToken{
+		Name:        "live-admin",
+		TokenHash:   auth.HashToken("some-other-value"),
+		TokenPrefix: "cvat_live0000000",
+		Scope:       middleware.ScopeInstanceAdmin,
+	}
+	if err := st.CreateAPIToken(ctx, existing); err != nil {
+		t.Fatalf("seed existing: %v", err)
+	}
+
+	raw := genBootstrapToken(t)
+	t.Setenv(bootstrapTokenEnv, raw)
+	if err := bootstrapAPIToken(ctx, st, quietLogger()); err != nil {
+		t.Fatalf("bootstrapAPIToken: %v", err)
+	}
+	// The bootstrap value must NOT have been seeded.
+	if _, err := st.GetAPITokenByHash(ctx, auth.HashToken(raw)); err != store.ErrNotFound {
+		t.Fatalf("expected bootstrap skipped (ErrNotFound), got %v", err)
+	}
+}

--- a/pkg/clawvisor/bootstrap_test.go
+++ b/pkg/clawvisor/bootstrap_test.go
@@ -94,6 +94,38 @@ func TestBootstrap_Idempotent(t *testing.T) {
 	}
 }
 
+// raceSeedStore wraps a real store but simulates the first-boot seed race:
+// GetAPITokenByHash reports the bootstrap token absent (the check-then-insert
+// is not atomic) while the subsequent CreateAPIToken then loses the insert
+// race with a same-hash ErrConflict — another replica seeded it in the window.
+type raceSeedStore struct {
+	store.Store
+}
+
+func (raceSeedStore) GetAPITokenByHash(context.Context, string) (*store.APIToken, error) {
+	return nil, store.ErrNotFound
+}
+
+func (raceSeedStore) CreateAPIToken(context.Context, *store.APIToken) error {
+	return store.ErrConflict
+}
+
+// TestBootstrap_ConcurrentSeedRaceIsIdempotent: when a concurrent replica
+// seeds the identical bootstrap token between our absence check and our
+// insert, the losing CreateAPIToken returns a same-hash ErrConflict. That is
+// the idempotent case, not a startup failure — the server must not refuse to
+// start (spec step 3's idempotency promise).
+func TestBootstrap_ConcurrentSeedRaceIsIdempotent(t *testing.T) {
+	real, ctx := newBootstrapStore(t)
+	st := raceSeedStore{real}
+	raw := genBootstrapToken(t)
+	t.Setenv(bootstrapTokenEnv, raw)
+
+	if err := bootstrapAPIToken(ctx, st, quietLogger()); err != nil {
+		t.Fatalf("concurrent same-hash seed race must be an idempotent no-op, got %v", err)
+	}
+}
+
 // TestBootstrap_RefusesMalformed: a malformed value returns an error
 // (the caller refuses to start).
 func TestBootstrap_RefusesMalformed(t *testing.T) {

--- a/pkg/clawvisor/defaults.go
+++ b/pkg/clawvisor/defaults.go
@@ -141,6 +141,13 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 		return nil, fmt.Errorf("unsupported database driver %q (use \"postgres\" or \"sqlite\")", cfg.Database.Driver)
 	}
 
+	// ── Bootstrap API token (spec 05) ────────────────────────────────────────
+	// Seed the first-boot bootstrap token from CLAWVISOR_BOOTSTRAP_TOKEN if
+	// present. A malformed value is a misconfiguration → refuse to start.
+	if err := bootstrapAPIToken(ctx, st, logger); err != nil {
+		return nil, err
+	}
+
 	// ── Auth ────────────────────────────────────────────────────────────────
 	jwtSvc, err := auth.NewJWTService(cfg.Auth.JWTSecret)
 	if err != nil {

--- a/pkg/store/postgres/migrations/059_api_tokens.sql
+++ b/pkg/store/postgres/migrations/059_api_tokens.sql
@@ -1,0 +1,38 @@
+-- 05-lite: minimal `_instance` system-user seed + `api_tokens` table.
+--
+-- Two statements, in order. FIRST the `_instance` seed, THEN the table —
+-- the token middleware attributes token-authenticated writes to `_instance`
+-- so resources created headlessly (Terraform / CI) aren't trapped in a
+-- personal account (PRD §9.1). The seed writes only (id, email,
+-- password_hash): no `role` column exists yet; spec 04 later adds
+-- `role TEXT DEFAULT 'member'` which covers this row. The password_hash is
+-- a non-bcrypt sentinel so the row can never authenticate via login.
+--
+-- 05-lite OWNS this seed (not 04). Do NOT split these across two numbered
+-- files — that would consume 04's reserved migration block.
+INSERT INTO users (id, email, password_hash)
+VALUES ('_instance', 'instance@system.clawvisor.invalid', '!locked!')
+ON CONFLICT (id) DO NOTHING;
+
+-- Long-lived, scoped, revocable API tokens (the Terraform provider / CI
+-- credential). Plaintext is returned exactly once on create; only the
+-- SHA-256 hash and a display prefix live at rest.
+--
+-- created_by ... ON DELETE SET NULL is deliberate: tokens are
+-- instance-scoped and survive the deletion of the user who minted them.
+-- is_bootstrap marks the short-lived first-boot bootstrap token so
+-- burn-on-first-use can target it.
+CREATE TABLE IF NOT EXISTS api_tokens (
+    id           TEXT PRIMARY KEY,
+    name         TEXT NOT NULL,
+    token_hash   TEXT NOT NULL UNIQUE,
+    token_prefix TEXT NOT NULL,
+    scope        TEXT NOT NULL,                -- instance-admin (config-write|config-read land with 04)
+    created_by   TEXT REFERENCES users(id) ON DELETE SET NULL,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    expires_at   TIMESTAMPTZ,                   -- NULL = no expiry (bootstrap always sets +24h)
+    last_used_at TIMESTAMPTZ,
+    revoked_at   TIMESTAMPTZ,
+    is_bootstrap BOOLEAN NOT NULL DEFAULT FALSE -- burn-on-use target
+);
+CREATE INDEX IF NOT EXISTS idx_api_tokens_hash ON api_tokens(token_hash);

--- a/pkg/store/postgres/store.go
+++ b/pkg/store/postgres/store.go
@@ -134,6 +134,35 @@ func (s *Store) CreateAPIToken(ctx context.Context, t *store.APIToken) error {
 	return nil
 }
 
+func (s *Store) CreateAPITokenAndBurnBootstrap(ctx context.Context, t *store.APIToken, bootstrapID string) error {
+	if t.ID == "" {
+		t.ID = uuid.New().String()
+	}
+	var expiresAt any
+	if t.ExpiresAt != nil {
+		expiresAt = t.ExpiresAt.UTC()
+	}
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO api_tokens (id, name, token_hash, token_prefix, scope, created_by, expires_at, is_bootstrap)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+	`, t.ID, t.Name, t.TokenHash, t.TokenPrefix, t.Scope, t.CreatedBy, expiresAt, t.IsBootstrap); err != nil {
+		if isDuplicate(err) {
+			return store.ErrConflict
+		}
+		return err
+	}
+	if _, err := tx.Exec(ctx,
+		`UPDATE api_tokens SET revoked_at = NOW() WHERE id = $1 AND revoked_at IS NULL`, bootstrapID); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
 func (s *Store) GetAPITokenByHash(ctx context.Context, tokenHash string) (*store.APIToken, error) {
 	row := s.pool.QueryRow(ctx, `
 		SELECT id, name, token_hash, token_prefix, scope, created_by, created_at, expires_at, last_used_at, revoked_at, is_bootstrap

--- a/pkg/store/postgres/store.go
+++ b/pkg/store/postgres/store.go
@@ -156,9 +156,17 @@ func (s *Store) CreateAPITokenAndBurnBootstrap(ctx context.Context, t *store.API
 		}
 		return err
 	}
-	if _, err := tx.Exec(ctx,
-		`UPDATE api_tokens SET revoked_at = NOW() WHERE id = $1 AND revoked_at IS NULL`, bootstrapID); err != nil {
+	tag, err := tx.Exec(ctx,
+		`UPDATE api_tokens SET revoked_at = NOW() WHERE id = $1 AND revoked_at IS NULL`, bootstrapID)
+	if err != nil {
 		return err
+	}
+	// The burn must revoke exactly one live row. Zero rows means the
+	// bootstrap token was already revoked (a concurrent first-use won the
+	// race), so roll back this whole mint — the bootstrap credential is
+	// strictly single-use even under concurrency.
+	if tag.RowsAffected() == 0 {
+		return store.ErrConflict
 	}
 	return tx.Commit(ctx)
 }

--- a/pkg/store/postgres/store.go
+++ b/pkg/store/postgres/store.go
@@ -96,7 +96,7 @@ func (s *Store) UpdateUserPassword(ctx context.Context, userID, newPasswordHash 
 
 func (s *Store) CountUsers(ctx context.Context) (int, error) {
 	var n int
-	err := s.pool.QueryRow(ctx, `SELECT COUNT(*) FROM users WHERE id != '__system__' AND email != 'admin@local'`).Scan(&n)
+	err := s.pool.QueryRow(ctx, `SELECT COUNT(*) FROM users WHERE id NOT IN ('__system__', '_instance') AND email != 'admin@local'`).Scan(&n)
 	return n, err
 }
 
@@ -109,6 +109,105 @@ func (s *Store) DeleteUser(ctx context.Context, userID string) error {
 		return store.ErrNotFound
 	}
 	return nil
+}
+
+// ── API tokens ──────────────────────────────────────────────────────────────
+
+func (s *Store) CreateAPIToken(ctx context.Context, t *store.APIToken) error {
+	if t.ID == "" {
+		t.ID = uuid.New().String()
+	}
+	var expiresAt any
+	if t.ExpiresAt != nil {
+		expiresAt = t.ExpiresAt.UTC()
+	}
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO api_tokens (id, name, token_hash, token_prefix, scope, created_by, expires_at, is_bootstrap)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+	`, t.ID, t.Name, t.TokenHash, t.TokenPrefix, t.Scope, t.CreatedBy, expiresAt, t.IsBootstrap)
+	if err != nil {
+		if isDuplicate(err) {
+			return store.ErrConflict
+		}
+		return err
+	}
+	return nil
+}
+
+func (s *Store) GetAPITokenByHash(ctx context.Context, tokenHash string) (*store.APIToken, error) {
+	row := s.pool.QueryRow(ctx, `
+		SELECT id, name, token_hash, token_prefix, scope, created_by, created_at, expires_at, last_used_at, revoked_at, is_bootstrap
+		FROM api_tokens WHERE token_hash = $1
+	`, tokenHash)
+	t, err := scanAPIToken(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, store.ErrNotFound
+	}
+	return t, err
+}
+
+func (s *Store) ListAPITokens(ctx context.Context) ([]*store.APIToken, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT id, name, token_hash, token_prefix, scope, created_by, created_at, expires_at, last_used_at, revoked_at, is_bootstrap
+		FROM api_tokens ORDER BY created_at DESC
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []*store.APIToken
+	for rows.Next() {
+		t, err := scanAPIToken(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, t)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) RevokeAPIToken(ctx context.Context, id string) error {
+	tag, err := s.pool.Exec(ctx,
+		`UPDATE api_tokens SET revoked_at = NOW() WHERE id = $1 AND revoked_at IS NULL`, id)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		// Distinguish "unknown id" (404) from "already revoked" (idempotent
+		// success): only the former is ErrNotFound.
+		var exists int
+		if err := s.pool.QueryRow(ctx, `SELECT COUNT(*) FROM api_tokens WHERE id = $1`, id).Scan(&exists); err != nil {
+			return err
+		}
+		if exists == 0 {
+			return store.ErrNotFound
+		}
+	}
+	return nil
+}
+
+func (s *Store) TouchAPITokenLastUsed(ctx context.Context, id string) error {
+	_, err := s.pool.Exec(ctx, `UPDATE api_tokens SET last_used_at = NOW() WHERE id = $1`, id)
+	return err
+}
+
+// apiTokenScanner is satisfied by both pgx.Row and pgx.Rows.
+type apiTokenScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanAPIToken(sc apiTokenScanner) (*store.APIToken, error) {
+	t := &store.APIToken{}
+	var createdBy *string
+	var expiresAt, lastUsedAt, revokedAt *time.Time
+	if err := sc.Scan(&t.ID, &t.Name, &t.TokenHash, &t.TokenPrefix, &t.Scope, &createdBy, &t.CreatedAt, &expiresAt, &lastUsedAt, &revokedAt, &t.IsBootstrap); err != nil {
+		return nil, err
+	}
+	t.CreatedBy = createdBy
+	t.ExpiresAt = expiresAt
+	t.LastUsedAt = lastUsedAt
+	t.RevokedAt = revokedAt
+	return t, nil
 }
 
 // ── Restrictions ──────────────────────────────────────────────────────────────

--- a/pkg/store/sqlite/migrations/060_api_tokens.sql
+++ b/pkg/store/sqlite/migrations/060_api_tokens.sql
@@ -1,0 +1,37 @@
+-- 05-lite: minimal `_instance` system-user seed + `api_tokens` table.
+--
+-- Two statements, in order. FIRST the `_instance` seed, THEN the table —
+-- the token middleware attributes token-authenticated writes to `_instance`
+-- so resources created headlessly (Terraform / CI) aren't trapped in a
+-- personal account (PRD §9.1). The seed writes only (id, email,
+-- password_hash): no `role` column exists yet; spec 04 later adds
+-- `role TEXT DEFAULT 'member'` which covers this row. The password_hash is
+-- a non-bcrypt sentinel so the row can never authenticate via login.
+--
+-- 05-lite OWNS this seed (not 04). Do NOT split these across two numbered
+-- files — that would consume 04's reserved migration block.
+INSERT OR IGNORE INTO users (id, email, password_hash)
+VALUES ('_instance', 'instance@system.clawvisor.invalid', '!locked!');
+
+-- Long-lived, scoped, revocable API tokens (the Terraform provider / CI
+-- credential). Plaintext is returned exactly once on create; only the
+-- SHA-256 hash and a display prefix live at rest.
+--
+-- created_by ... ON DELETE SET NULL is deliberate: tokens are
+-- instance-scoped and survive the deletion of the user who minted them.
+-- is_bootstrap marks the short-lived first-boot bootstrap token so
+-- burn-on-first-use can target it.
+CREATE TABLE IF NOT EXISTS api_tokens (
+    id           TEXT PRIMARY KEY,
+    name         TEXT NOT NULL,
+    token_hash   TEXT NOT NULL UNIQUE,
+    token_prefix TEXT NOT NULL,
+    scope        TEXT NOT NULL,                -- instance-admin (config-write|config-read land with 04)
+    created_by   TEXT REFERENCES users(id) ON DELETE SET NULL,
+    created_at   TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    expires_at   TEXT,                          -- NULL = no expiry (bootstrap always sets +24h)
+    last_used_at TEXT,
+    revoked_at   TEXT,
+    is_bootstrap INTEGER NOT NULL DEFAULT 0     -- burn-on-use target (0/1)
+);
+CREATE INDEX IF NOT EXISTS idx_api_tokens_hash ON api_tokens(token_hash);

--- a/pkg/store/sqlite/migrations/060_api_tokens.sql
+++ b/pkg/store/sqlite/migrations/060_api_tokens.sql
@@ -10,8 +10,15 @@
 --
 -- 05-lite OWNS this seed (not 04). Do NOT split these across two numbered
 -- files — that would consume 04's reserved migration block.
-INSERT OR IGNORE INTO users (id, email, password_hash)
-VALUES ('_instance', 'instance@system.clawvisor.invalid', '!locked!');
+--
+-- Use an id-targeted ON CONFLICT (matching the postgres/059 sibling) rather
+-- than a blanket INSERT OR IGNORE: the latter swallows EVERY uniqueness
+-- conflict (including the unique `email`), so a pre-existing row with the
+-- same email but a different id would silently skip the `_instance` seed and
+-- leave token-authenticated writes with no system user to attribute to.
+INSERT INTO users (id, email, password_hash)
+VALUES ('_instance', 'instance@system.clawvisor.invalid', '!locked!')
+ON CONFLICT (id) DO NOTHING;
 
 -- Long-lived, scoped, revocable API tokens (the Terraform provider / CI
 -- credential). Plaintext is returned exactly once on create; only the

--- a/pkg/store/sqlite/store.go
+++ b/pkg/store/sqlite/store.go
@@ -168,10 +168,18 @@ func (s *Store) CreateAPITokenAndBurnBootstrap(ctx context.Context, t *store.API
 		}
 		return err
 	}
-	if _, err := tx.ExecContext(ctx,
+	res, err := tx.ExecContext(ctx,
 		`UPDATE api_tokens SET revoked_at = ? WHERE id = ? AND revoked_at IS NULL`,
-		time.Now().UTC().Format(time.RFC3339), bootstrapID); err != nil {
+		time.Now().UTC().Format(time.RFC3339), bootstrapID)
+	if err != nil {
 		return err
+	}
+	// The burn must revoke exactly one live row. Zero rows means the
+	// bootstrap token was already revoked (a concurrent first-use won the
+	// race), so roll back this whole mint — the bootstrap credential is
+	// strictly single-use even under concurrency.
+	if n, _ := res.RowsAffected(); n == 0 {
+		return store.ErrConflict
 	}
 	return tx.Commit()
 }

--- a/pkg/store/sqlite/store.go
+++ b/pkg/store/sqlite/store.go
@@ -146,6 +146,36 @@ func (s *Store) CreateAPIToken(ctx context.Context, t *store.APIToken) error {
 	return nil
 }
 
+func (s *Store) CreateAPITokenAndBurnBootstrap(ctx context.Context, t *store.APIToken, bootstrapID string) error {
+	if t.ID == "" {
+		t.ID = uuid.New().String()
+	}
+	var expiresAt any
+	if t.ExpiresAt != nil {
+		expiresAt = t.ExpiresAt.UTC().Format(time.RFC3339)
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO api_tokens (id, name, token_hash, token_prefix, scope, created_by, expires_at, is_bootstrap)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+	`, t.ID, t.Name, t.TokenHash, t.TokenPrefix, t.Scope, t.CreatedBy, expiresAt, boolToInt(t.IsBootstrap)); err != nil {
+		if isDuplicate(err) {
+			return store.ErrConflict
+		}
+		return err
+	}
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE api_tokens SET revoked_at = ? WHERE id = ? AND revoked_at IS NULL`,
+		time.Now().UTC().Format(time.RFC3339), bootstrapID); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
 func (s *Store) GetAPITokenByHash(ctx context.Context, tokenHash string) (*store.APIToken, error) {
 	row := s.db.QueryRowContext(ctx, `
 		SELECT id, name, token_hash, token_prefix, scope, created_by, created_at, expires_at, last_used_at, revoked_at, is_bootstrap

--- a/pkg/store/sqlite/store.go
+++ b/pkg/store/sqlite/store.go
@@ -107,7 +107,7 @@ func (s *Store) UpdateUserPassword(ctx context.Context, userID, newPasswordHash 
 
 func (s *Store) CountUsers(ctx context.Context) (int, error) {
 	var n int
-	err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM users WHERE id != '__system__' AND email != 'admin@local'`).Scan(&n)
+	err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM users WHERE id NOT IN ('__system__', '_instance') AND email != 'admin@local'`).Scan(&n)
 	return n, err
 }
 
@@ -119,6 +119,122 @@ func (s *Store) DeleteUser(ctx context.Context, userID string) error {
 	n, _ := res.RowsAffected()
 	if n == 0 {
 		return store.ErrNotFound
+	}
+	return nil
+}
+
+// ── API tokens ──────────────────────────────────────────────────────────────
+
+func (s *Store) CreateAPIToken(ctx context.Context, t *store.APIToken) error {
+	if t.ID == "" {
+		t.ID = uuid.New().String()
+	}
+	var expiresAt any
+	if t.ExpiresAt != nil {
+		expiresAt = t.ExpiresAt.UTC().Format(time.RFC3339)
+	}
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO api_tokens (id, name, token_hash, token_prefix, scope, created_by, expires_at, is_bootstrap)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+	`, t.ID, t.Name, t.TokenHash, t.TokenPrefix, t.Scope, t.CreatedBy, expiresAt, boolToInt(t.IsBootstrap))
+	if err != nil {
+		if isDuplicate(err) {
+			return store.ErrConflict
+		}
+		return err
+	}
+	return nil
+}
+
+func (s *Store) GetAPITokenByHash(ctx context.Context, tokenHash string) (*store.APIToken, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, name, token_hash, token_prefix, scope, created_by, created_at, expires_at, last_used_at, revoked_at, is_bootstrap
+		FROM api_tokens WHERE token_hash = ?
+	`, tokenHash)
+	t, err := scanAPIToken(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, store.ErrNotFound
+	}
+	return t, err
+}
+
+func (s *Store) ListAPITokens(ctx context.Context) ([]*store.APIToken, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, name, token_hash, token_prefix, scope, created_by, created_at, expires_at, last_used_at, revoked_at, is_bootstrap
+		FROM api_tokens ORDER BY created_at DESC
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []*store.APIToken
+	for rows.Next() {
+		t, err := scanAPIToken(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, t)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) RevokeAPIToken(ctx context.Context, id string) error {
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE api_tokens SET revoked_at = ? WHERE id = ? AND revoked_at IS NULL`,
+		time.Now().UTC().Format(time.RFC3339), id)
+	if err != nil {
+		return err
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		// Distinguish "unknown id" (404) from "already revoked" (idempotent
+		// success): only the former is ErrNotFound.
+		var exists int
+		if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM api_tokens WHERE id = ?`, id).Scan(&exists); err != nil {
+			return err
+		}
+		if exists == 0 {
+			return store.ErrNotFound
+		}
+	}
+	return nil
+}
+
+func (s *Store) TouchAPITokenLastUsed(ctx context.Context, id string) error {
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE api_tokens SET last_used_at = ? WHERE id = ?`,
+		time.Now().UTC().Format(time.RFC3339), id)
+	return err
+}
+
+// apiTokenScanner is satisfied by both *sql.Row and *sql.Rows.
+type apiTokenScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanAPIToken(sc apiTokenScanner) (*store.APIToken, error) {
+	t := &store.APIToken{}
+	var createdBy *string
+	var createdAt string
+	var expiresAt, lastUsedAt, revokedAt *string
+	var isBootstrap int
+	if err := sc.Scan(&t.ID, &t.Name, &t.TokenHash, &t.TokenPrefix, &t.Scope, &createdBy, &createdAt, &expiresAt, &lastUsedAt, &revokedAt, &isBootstrap); err != nil {
+		return nil, err
+	}
+	t.CreatedBy = createdBy
+	t.CreatedAt = parseTime(createdAt)
+	t.ExpiresAt = parseNullableTime(expiresAt)
+	t.LastUsedAt = parseNullableTime(lastUsedAt)
+	t.RevokedAt = parseNullableTime(revokedAt)
+	t.IsBootstrap = isBootstrap != 0
+	return t, nil
+}
+
+func parseNullableTime(s *string) *time.Time {
+	if s == nil || *s == "" {
+		return nil
+	}
+	if t := parseTime(*s); !t.IsZero() {
+		return &t
 	}
 	return nil
 }

--- a/pkg/store/sqlite/store_apitokens_test.go
+++ b/pkg/store/sqlite/store_apitokens_test.go
@@ -175,6 +175,22 @@ func TestAPITokenStore_CreateAndBurnBootstrap(t *testing.T) {
 	if gotBoot2.RevokedAt != nil {
 		t.Fatal("bootstrap2 must stay live when the mint fails (transaction rolled back)")
 	}
+
+	// Re-using an already-burned bootstrap id must roll back (single-use even
+	// if a second first-use request slips past auth before the first commits).
+	second := &store.APIToken{
+		Name:        "second-from-burned-boot",
+		TokenHash:   "second-hash",
+		TokenPrefix: "cvat_SecondSeco",
+		Scope:       "instance-admin",
+		ExpiresAt:   &exp,
+	}
+	if err := st.CreateAPITokenAndBurnBootstrap(ctx, second, boot.ID); err != store.ErrConflict {
+		t.Fatalf("CreateAPITokenAndBurnBootstrap(already-burned) = %v, want ErrConflict", err)
+	}
+	if _, err := st.GetAPITokenByHash(ctx, "second-hash"); err != store.ErrNotFound {
+		t.Fatalf("token must not be minted from an already-burned bootstrap: %v", err)
+	}
 }
 
 // TestAPITokenStore_InstanceSeededAndExcludedFromCount verifies the

--- a/pkg/store/sqlite/store_apitokens_test.go
+++ b/pkg/store/sqlite/store_apitokens_test.go
@@ -1,0 +1,129 @@
+package sqlite
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+func newAPITokenStore(t *testing.T) (*Store, context.Context) {
+	t.Helper()
+	ctx := context.Background()
+	db, err := New(ctx, filepath.Join(t.TempDir(), "clawvisor.db"))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return NewStore(db), ctx
+}
+
+// TestAPITokenStore_CRUD exercises create → get-by-hash → list → revoke,
+// including the nullable-timestamp scans and the is_bootstrap flag.
+func TestAPITokenStore_CRUD(t *testing.T) {
+	st, ctx := newAPITokenStore(t)
+
+	exp := time.Now().Add(24 * time.Hour).UTC().Truncate(time.Second)
+	tok := &store.APIToken{
+		Name:        "terraform",
+		TokenHash:   "hash-abc",
+		TokenPrefix: "cvat_AbC1dEf2gH",
+		Scope:       "instance-admin",
+		ExpiresAt:   &exp,
+		IsBootstrap: true,
+	}
+	if err := st.CreateAPIToken(ctx, tok); err != nil {
+		t.Fatalf("CreateAPIToken: %v", err)
+	}
+	if tok.ID == "" {
+		t.Fatal("CreateAPIToken did not assign an ID")
+	}
+
+	got, err := st.GetAPITokenByHash(ctx, "hash-abc")
+	if err != nil {
+		t.Fatalf("GetAPITokenByHash: %v", err)
+	}
+	if got.Name != "terraform" || got.Scope != "instance-admin" || got.TokenPrefix != "cvat_AbC1dEf2gH" {
+		t.Fatalf("round-trip mismatch: %+v", got)
+	}
+	if !got.IsBootstrap {
+		t.Fatal("is_bootstrap did not round-trip")
+	}
+	if got.ExpiresAt == nil || !got.ExpiresAt.Equal(exp) {
+		t.Fatalf("expires_at mismatch: got %v want %v", got.ExpiresAt, exp)
+	}
+	if got.RevokedAt != nil || got.LastUsedAt != nil {
+		t.Fatalf("expected nil revoked_at/last_used_at, got %+v", got)
+	}
+
+	// Touch last_used_at.
+	if err := st.TouchAPITokenLastUsed(ctx, tok.ID); err != nil {
+		t.Fatalf("TouchAPITokenLastUsed: %v", err)
+	}
+	got, _ = st.GetAPITokenByHash(ctx, "hash-abc")
+	if got.LastUsedAt == nil {
+		t.Fatal("last_used_at not set after touch")
+	}
+
+	// List.
+	list, err := st.ListAPITokens(ctx)
+	if err != nil {
+		t.Fatalf("ListAPITokens: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("ListAPITokens len = %d, want 1", len(list))
+	}
+
+	// Revoke → GetAPITokenByHash still returns the row (soft delete) with
+	// revoked_at set.
+	if err := st.RevokeAPIToken(ctx, tok.ID); err != nil {
+		t.Fatalf("RevokeAPIToken: %v", err)
+	}
+	got, _ = st.GetAPITokenByHash(ctx, "hash-abc")
+	if got.RevokedAt == nil {
+		t.Fatal("revoked_at not set after revoke")
+	}
+
+	// Revoke unknown → ErrNotFound.
+	if err := st.RevokeAPIToken(ctx, "does-not-exist"); err != store.ErrNotFound {
+		t.Fatalf("RevokeAPIToken(unknown) = %v, want ErrNotFound", err)
+	}
+
+	// Missing hash → ErrNotFound.
+	if _, err := st.GetAPITokenByHash(ctx, "nope"); err != store.ErrNotFound {
+		t.Fatalf("GetAPITokenByHash(missing) = %v, want ErrNotFound", err)
+	}
+}
+
+// TestAPITokenStore_InstanceSeededAndExcludedFromCount verifies the
+// migration seeds the `_instance` user and that CountUsers excludes it
+// (so it never trips first-user onboarding detection).
+func TestAPITokenStore_InstanceSeededAndExcludedFromCount(t *testing.T) {
+	st, ctx := newAPITokenStore(t)
+
+	u, err := st.GetUserByID(ctx, store.InstanceUserID)
+	if err != nil {
+		t.Fatalf("GetUserByID(_instance): %v", err)
+	}
+	if u.Email != "instance@system.clawvisor.invalid" {
+		t.Fatalf("_instance email = %q", u.Email)
+	}
+
+	n, err := st.CountUsers(ctx)
+	if err != nil {
+		t.Fatalf("CountUsers: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("CountUsers = %d, want 0 (only _instance/__system__ seeded)", n)
+	}
+
+	if _, err := st.CreateUser(ctx, "real@example.com", "hash"); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	n, _ = st.CountUsers(ctx)
+	if n != 1 {
+		t.Fatalf("CountUsers after real user = %d, want 1", n)
+	}
+}

--- a/pkg/store/sqlite/store_apitokens_test.go
+++ b/pkg/store/sqlite/store_apitokens_test.go
@@ -97,6 +97,86 @@ func TestAPITokenStore_CRUD(t *testing.T) {
 	}
 }
 
+// TestAPITokenStore_CreateAndBurnBootstrap verifies the atomic
+// mint-and-burn: the new token is created AND the bootstrap token is
+// revoked in a single call (burn-on-first-use, 05).
+func TestAPITokenStore_CreateAndBurnBootstrap(t *testing.T) {
+	st, ctx := newAPITokenStore(t)
+
+	exp := time.Now().Add(24 * time.Hour).UTC().Truncate(time.Second)
+	boot := &store.APIToken{
+		Name:        "bootstrap",
+		TokenHash:   "boot-hash",
+		TokenPrefix: "cvat_BootBootBo",
+		Scope:       "instance-admin",
+		ExpiresAt:   &exp,
+		IsBootstrap: true,
+	}
+	if err := st.CreateAPIToken(ctx, boot); err != nil {
+		t.Fatalf("seed bootstrap: %v", err)
+	}
+
+	minted := &store.APIToken{
+		Name:        "terraform",
+		TokenHash:   "minted-hash",
+		TokenPrefix: "cvat_MintMintMi",
+		Scope:       "instance-admin",
+		ExpiresAt:   &exp,
+	}
+	if err := st.CreateAPITokenAndBurnBootstrap(ctx, minted, boot.ID); err != nil {
+		t.Fatalf("CreateAPITokenAndBurnBootstrap: %v", err)
+	}
+
+	// New token exists and is live.
+	got, err := st.GetAPITokenByHash(ctx, "minted-hash")
+	if err != nil {
+		t.Fatalf("get minted: %v", err)
+	}
+	if got.RevokedAt != nil {
+		t.Fatal("minted token must not be revoked")
+	}
+
+	// Bootstrap token is burned in the same operation.
+	gotBoot, err := st.GetAPITokenByHash(ctx, "boot-hash")
+	if err != nil {
+		t.Fatalf("get bootstrap: %v", err)
+	}
+	if gotBoot.RevokedAt == nil {
+		t.Fatal("bootstrap token must be revoked after mint-and-burn")
+	}
+
+	// A conflicting mint (duplicate hash) rolls back and leaves the bootstrap
+	// state untouched — burn happens if and only if the mint lands.
+	seedBoot2 := &store.APIToken{
+		Name:        "bootstrap2",
+		TokenHash:   "boot-hash-2",
+		TokenPrefix: "cvat_Boot2Boot2",
+		Scope:       "instance-admin",
+		ExpiresAt:   &exp,
+		IsBootstrap: true,
+	}
+	if err := st.CreateAPIToken(ctx, seedBoot2); err != nil {
+		t.Fatalf("seed bootstrap2: %v", err)
+	}
+	dup := &store.APIToken{
+		Name:        "dup",
+		TokenHash:   "minted-hash", // collides with the earlier mint
+		TokenPrefix: "cvat_DupDupDupp",
+		Scope:       "instance-admin",
+		ExpiresAt:   &exp,
+	}
+	if err := st.CreateAPITokenAndBurnBootstrap(ctx, dup, seedBoot2.ID); err != store.ErrConflict {
+		t.Fatalf("CreateAPITokenAndBurnBootstrap(dup) = %v, want ErrConflict", err)
+	}
+	gotBoot2, err := st.GetAPITokenByHash(ctx, "boot-hash-2")
+	if err != nil {
+		t.Fatalf("get bootstrap2: %v", err)
+	}
+	if gotBoot2.RevokedAt != nil {
+		t.Fatal("bootstrap2 must stay live when the mint fails (transaction rolled back)")
+	}
+}
+
 // TestAPITokenStore_InstanceSeededAndExcludedFromCount verifies the
 // migration seeds the `_instance` user and that CountUsers excludes it
 // (so it never trips first-user onboarding detection).

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -45,6 +45,12 @@ type Store interface {
 	// CI credential). See the api_tokens migration (05-lite). Plaintext is
 	// never persisted; only CreateAPIToken's caller sees it once.
 	CreateAPIToken(ctx context.Context, t *APIToken) error
+	// CreateAPITokenAndBurnBootstrap atomically inserts t and revokes the
+	// bootstrap token bootstrapID in a single transaction. The bootstrap
+	// credential is burned if and only if the new token is minted: on any
+	// failure the whole operation rolls back, leaving the bootstrap token
+	// live so a failed apply can retry the mint (burn-on-first-use, 05).
+	CreateAPITokenAndBurnBootstrap(ctx context.Context, t *APIToken, bootstrapID string) error
 	GetAPITokenByHash(ctx context.Context, tokenHash string) (*APIToken, error)
 	ListAPITokens(ctx context.Context) ([]*APIToken, error)
 	RevokeAPIToken(ctx context.Context, id string) error

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -9,6 +9,14 @@ import (
 	"time"
 )
 
+// InstanceUserID is the id of the `_instance` system user seeded by the
+// 05-lite api_tokens migration. Resources created via an API token are
+// owned by this user so they aren't trapped in a personal account
+// (PRD §9.1). It is excluded from user counts/lists exactly like
+// `__system__`. Never authenticatable via login (its password_hash is a
+// non-bcrypt sentinel).
+const InstanceUserID = "_instance"
+
 // ErrNotFound is returned when a requested record does not exist.
 var ErrNotFound = errors.New("store: record not found")
 
@@ -32,6 +40,15 @@ type Store interface {
 	UpdateUserPassword(ctx context.Context, userID, newPasswordHash string) error
 	DeleteUser(ctx context.Context, userID string) error
 	CountUsers(ctx context.Context) (int, error)
+
+	// API tokens (long-lived, scoped, revocable — the Terraform provider /
+	// CI credential). See the api_tokens migration (05-lite). Plaintext is
+	// never persisted; only CreateAPIToken's caller sees it once.
+	CreateAPIToken(ctx context.Context, t *APIToken) error
+	GetAPITokenByHash(ctx context.Context, tokenHash string) (*APIToken, error)
+	ListAPITokens(ctx context.Context) ([]*APIToken, error)
+	RevokeAPIToken(ctx context.Context, id string) error
+	TouchAPITokenLastUsed(ctx context.Context, id string) error
 
 	// Restrictions
 	CreateRestriction(ctx context.Context, r *Restriction) (*Restriction, error)
@@ -475,6 +492,25 @@ type User struct {
 	PasswordHash string    `json:"-"`
 	CreatedAt    time.Time `json:"created_at"`
 	UpdatedAt    time.Time `json:"updated_at"`
+}
+
+// APIToken is a long-lived, scoped, revocable bearer credential. The
+// plaintext value (`cvat_` + 43 base64url chars) is returned exactly once
+// on create; only TokenHash (SHA-256 hex) and TokenPrefix (first 16 chars,
+// for display) live at rest. TokenHash is json:"-" so it never leaks into
+// list responses.
+type APIToken struct {
+	ID          string     `json:"id"`
+	Name        string     `json:"name"`
+	TokenHash   string     `json:"-"`
+	TokenPrefix string     `json:"token_prefix"`
+	Scope       string     `json:"scope"`
+	CreatedBy   *string    `json:"created_by"`
+	CreatedAt   time.Time  `json:"created_at"`
+	ExpiresAt   *time.Time `json:"expires_at"`
+	LastUsedAt  *time.Time `json:"last_used_at"`
+	RevokedAt   *time.Time `json:"revoked_at"`
+	IsBootstrap bool       `json:"-"`
 }
 
 // Risk-level constants for ConversationAutoApproveThreshold and the


### PR DESCRIPTION
Adds `cvat_` API tokens: SHA-256-hashed at rest, single-value scope, revocable, with a first-boot bootstrap path (`CLAWVISOR_BOOTSTRAP_TOKEN`, `cvat_` + 43 base64url chars, 24h expiry, burned atomically on first successful mint). Seeds the `_instance` system user (sqlite 060 / postgres 059). `GET /api/features` advertises `api_tokens`.

Cubic review hardening included: transactional mint+burn (strictly single-use under concurrency, RowsAffected-guarded), per-token rate-limit buckets, bounded last-used throttle map.

Tests: TestBootstrap_* (6), TestAPIToken_* suite, store unit tests; full deterministic lane green.

**Stack 1/15** — base: `main`. Merge first (everything depends on it). Final composition: `terraform-centric-v1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

