### PR TITLE
feat(proxy-lite): observe posture preset, enforcement-off mode, credential classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,6 +508,39 @@ clawvisor-server agent run --agent my-agent -- claude
 
 For provider-specific wrappers and raw environment exports, see [docs/LITE_PROXY.md](docs/LITE_PROXY.md).
 
+### Postures
+
+Proxy-lite is configured through a coarse `posture` preset (in the config
+file only — there is no env override) plus two independent, individually
+overridable axes:
+
+| Posture | `upstream_auth` | `enforcement_mode` | Behavior |
+|---|---|---|---|
+| **observe** | `passthrough` | `observe` | Zero behavior change: forwards the agent's own provider credential, and records every hold/deny verdict as an observation instead of enforcing it. The pipeline still inspects, attributes, audits, and meters cost. |
+| **govern** | `vault` | `enforce` | Injects the stored provider key (client-presented API keys are stripped) and enforces holds/denials/policies. |
+| **contain** | — | — | Not yet available; fails startup until the runtime-proxy superset lands. |
+
+- **`upstream_auth`** (`vault` default \| `passthrough`; env
+  `CLAWVISOR_PROXY_LITE_UPSTREAM_AUTH`). In `vault` posture the server injects
+  the vaulted key and **strips any client-presented API key** — `upstream_auth`
+  is a server-side decision, not a per-request client choice. `passthrough`
+  forwards the client's own OAuth/API credential unchanged.
+- **`enforcement_mode`** (`enforce` default \| `observe`; env
+  `CLAWVISOR_PROXY_LITE_ENFORCEMENT_MODE`). `observe` downgrades every enforcing
+  verdict (deny, hold, policy rewrite) to a recorded observation — the audit
+  view flags these as `observed`. Clawvisor's own agent-token auth is never
+  weakened by observe mode.
+
+**Subscription (OAuth) seats.** Observe carries a Claude subscription session
+transparently (the `Authorization: Bearer` OAuth token and `anthropic-beta`
+header are forwarded unchanged). Under **govern/vault**, a subscription bearer
+is **refused** with `SUBSCRIPTION_SEAT_NOT_GOVERNABLE` (HTTP 403) rather than
+silently converted from subscription billing to org-metered API billing.
+Provide an org provider API key for that agent, or set
+`proxy_lite.allow_subscription_billing_migration: true` to consent to the
+migration. That flag is **instance-wide** — enabling it migrates every
+subscription seat on the instance at once.
+
 ## Architecture
 
 | Layer | Choice |

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -114,6 +114,59 @@ telemetry:
                            # sends: OS, arch, db driver, agent count (bucketed), requests per service (bucketed)
                            # no instance ID, IP, credentials, or personal data is collected
 
+# ── Posture & proxy-lite (agent LLM proxy) ──────────────────────────────────
+# `posture` is a coarse preset over the proxy-lite knobs below. It is read
+# from THIS FILE ONLY (there is no CLAWVISOR_POSTURE env override) because the
+# preset is applied by detecting which knobs the YAML sets explicitly. An
+# explicit knob ALWAYS wins over the preset.
+#
+#   observe — visibility, zero behavior change: proxy-lite enabled, upstream
+#             auth = passthrough (forward the agent's own provider credential,
+#             no vault injection), enforcement = observe (the pipeline
+#             inspects/attributes/audits/meters cost but records every
+#             hold/deny verdict as an observation instead of enforcing it).
+#   govern  — observe + control: proxy-lite enabled, upstream auth = vault
+#             (inject the stored key; client-presented API keys are stripped),
+#             enforcement = enforce.
+#   contain — not yet available; startup fails with a clear error until the
+#             runtime-proxy superset lands.
+#
+# posture: observe
+
+# config_schema marks the config convention version. The setup wizard writes
+# `config_schema: 2` + an explicit `proxy_lite.enabled:` on every fresh
+# install. The marker is advisory (Load() only logs a notice when it is older
+# than the current version); the compiled default of proxy_lite.enabled is
+# false permanently, so an existing file without the key is never silently
+# enabled at upgrade.
+# config_schema: 2
+
+# proxy_lite:
+#   enabled: false             # Env: CLAWVISOR_PROXY_LITE_ENABLED
+#   public_url: "http://localhost:8080"
+#   # Two independent axes (usually set via `posture` above, but overridable):
+#   upstream_auth: "vault"     # "vault" (default) | "passthrough".
+#                              # Env: CLAWVISOR_PROXY_LITE_UPSTREAM_AUTH.
+#                              # vault: inject the stored provider key and
+#                              #   strip any client-presented API key.
+#                              # passthrough: forward the client's own
+#                              #   OAuth/API credential unchanged (Observe).
+#   enforcement_mode: "enforce" # "enforce" (default) | "observe".
+#                              # Env: CLAWVISOR_PROXY_LITE_ENFORCEMENT_MODE.
+#                              # observe: record hold/deny verdicts as
+#                              #   observations; never blocks or holds.
+#   allow_subscription_billing_migration: false
+#                              # Env: CLAWVISOR_PROXY_LITE_ALLOW_SUB_MIGRATION.
+#                              # When false (default), a govern/vault request
+#                              # carrying a Claude subscription (OAuth) bearer
+#                              # is REFUSED with SUBSCRIPTION_SEAT_NOT_GOVERNABLE
+#                              # rather than silently rebilled to the org API
+#                              # key. Set true ONLY to consent to migrating
+#                              # subscription seats to vaulted-API-key billing.
+#                              # WARNING: this flag is INSTANCE-WIDE — enabling
+#                              # it migrates EVERY subscription seat on the
+#                              # instance at once, not one.
+
 # ── Observability (OpenTelemetry export) ────────────────────────────────────
 # Operational traces + metrics from the proxy-lite pipeline, the skill
 # gateway, and the runtime proxy, exported over OTLP to whatever you already

--- a/e2e/scenarios/llm_proxy_observe_live_test.go
+++ b/e2e/scenarios/llm_proxy_observe_live_test.go
@@ -25,7 +25,7 @@ import (
 //     never consulted.
 //
 // Gated on ANTHROPIC_API_KEY (run e.g.
-// ANTHROPIC_API_KEY="$CLAWVISOR_ANTHROPIC_E2E_KEY" go test ...). The upstream
+// ANTHROPIC_API_KEY=<key> go test ...). The upstream
 // is left at the real https://api.anthropic.com default (no
 // CLAWVISOR_LLM_UPSTREAM_ANTHROPIC override).
 //

--- a/e2e/scenarios/llm_proxy_observe_live_test.go
+++ b/e2e/scenarios/llm_proxy_observe_live_test.go
@@ -1,0 +1,110 @@
+package scenarios_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/e2e/testapp"
+	"github.com/clawvisor/clawvisor/testharness"
+)
+
+// TestLiveObservePassthrough (spec 02 keyed live lane): a real Anthropic call
+// through an observe-mode (passthrough + enforcement-off) proxy-lite, with the
+// operator's own credential presented as the CLIENT credential. Proves the
+// Observe "zero behavior change" promise against the real upstream:
+//
+//   - response integrity: a real 200 assistant message flows back unaltered,
+//   - cost row: usage tokens are metered into the audit record,
+//   - no vault read: NO anthropic vault entry is configured, yet the request
+//     succeeds via passthrough (auth_mode: passthrough), so the vault was
+//     never consulted.
+//
+// Gated on ANTHROPIC_API_KEY (run e.g.
+// ANTHROPIC_API_KEY="$CLAWVISOR_ANTHROPIC_E2E_KEY" go test ...). The upstream
+// is left at the real https://api.anthropic.com default (no
+// CLAWVISOR_LLM_UPSTREAM_ANTHROPIC override).
+//
+// IMPORTANT (verified against forward.go): observe passthrough forwards the
+// client's Authorization: Bearer verbatim and strips inbound x-api-key. Real
+// Anthropic rejects a plain API key sent as a Bearer token ("Invalid bearer
+// token") — an sk-ant-api… key must ride x-api-key, which only the govern/
+// vault path injects. So the passthrough lane's client credential is an
+// OAuth/subscription bearer (sk-ant-oat01-…), the seat type Observe is built
+// for. When ANTHROPIC_API_KEY holds a plain API key this test skips: the
+// passthrough-carries-credential invariant is proven deterministically by
+// TestObserveCarriesSubscriptionSession, and the govern/vault key-injection
+// path is proven by TestGovernStripsClientApiKey.
+func TestLiveObservePassthrough(t *testing.T) {
+	cred := strings.TrimSpace(os.Getenv("ANTHROPIC_API_KEY"))
+	if cred == "" {
+		t.Skip("ANTHROPIC_API_KEY not set; skipping live observe passthrough test")
+	}
+	if !strings.HasPrefix(cred, "sk-ant-oat01-") && !strings.HasPrefix(cred, "sk-ant-ort01-") {
+		t.Skip("ANTHROPIC_API_KEY is a plain API key, not an OAuth/subscription bearer; " +
+			"observe passthrough forwards Authorization and Anthropic rejects Bearer API keys. " +
+			"Set an OAuth bearer to exercise this lane; passthrough carriage is covered " +
+			"deterministically by TestObserveCarriesSubscriptionSession.")
+	}
+
+	h := testharness.New(t)
+	// posture: observe -> proxy-lite enabled, upstream_auth=passthrough,
+	// enforcement_mode=observe. No upstream override => real Anthropic.
+	cv := testapp.StartWithConfig(t, h, nil, "posture: observe")
+
+	user := cv.LoginAsLocalUser(t)
+	// Deliberately DO NOT set an anthropic vault entry: passthrough must
+	// forward the client's own credential and never touch the vault.
+	_, token := newPostureAgent(t, cv, user.AccessToken, "live-observe")
+
+	reqBody := []byte(`{"model":"claude-haiku-4-5-20251001","max_tokens":16,"messages":[{"role":"user","content":"Reply with the single word: pong"}]}`)
+	req, _ := http.NewRequest("POST", cv.URL+"/api/v1/messages", bytes.NewReader(reqBody))
+	req.Header.Set("X-Clawvisor-Agent-Token", token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("anthropic-version", "2023-06-01")
+	req.Header.Set("anthropic-beta", "oauth-2025-04-20")
+	// The operator's own OAuth/subscription bearer as the CLIENT credential.
+	// Passthrough forwards it to the upstream unchanged (no vault injection).
+	req.Header.Set("Authorization", "Bearer "+cred)
+
+	resp, err := cv.Client.Do(req)
+	if err != nil {
+		t.Fatalf("/api/v1/messages: %v", err)
+	}
+	defer resp.Body.Close()
+	rb, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, rb)
+	}
+
+	// Response integrity: a real Anthropic assistant message with content —
+	// NOT a lite-proxy error envelope wrapped as an assistant turn.
+	var msg struct {
+		Type    string `json:"type"`
+		Role    string `json:"role"`
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	if err := json.Unmarshal(rb, &msg); err != nil {
+		t.Fatalf("decode upstream response: %v; body=%s", err, rb)
+	}
+	if msg.Type != "message" || msg.Role != "assistant" || len(msg.Content) == 0 {
+		t.Fatalf("unexpected response shape (integrity / not a real upstream message): %s", rb)
+	}
+
+	// Cost row + no vault read: the audit record carries usage tokens
+	// (cost metering ran) and auth_mode: passthrough (the vault key was
+	// never injected — no vault read).
+	if !auditContains(t, cv, user.AccessToken, `"auth_mode":"passthrough"`) {
+		t.Fatal("audit did not record auth_mode: passthrough (vault should not have been read)")
+	}
+	if !auditContains(t, cv, user.AccessToken, `"usage_input_tokens"`) {
+		t.Fatal("audit did not record a cost/usage row (usage_input_tokens missing)")
+	}
+}

--- a/e2e/scenarios/llm_proxy_observe_test.go
+++ b/e2e/scenarios/llm_proxy_observe_test.go
@@ -1,0 +1,248 @@
+package scenarios_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/e2e/testapp"
+	"github.com/clawvisor/clawvisor/testharness"
+)
+
+// llm_proxy_observe_test.go covers spec 02 §3: the Observe posture's
+// enforcement-off mode. The pipeline still inspects, attributes, audits,
+// and meters cost, but every would-be enforcing verdict is downgraded to
+// a recorded observation and the request/response proceeds unmodified.
+
+// featuresProxyLiteEnabled reports the /api/features proxy_lite flag.
+func featuresProxyLiteEnabled(t *testing.T, cv *testapp.Server) bool {
+	t.Helper()
+	resp := cvDo(t, cv, "", "GET", "/api/features", nil)
+	defer resp.Body.Close()
+	var feats struct {
+		ProxyLite bool `json:"proxy_lite"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&feats)
+	return feats.ProxyLite
+}
+
+// outOfScopeToolUseUpstream returns a fake upstream whose response
+// contains a credentialed tool_use (github.list_issues) that no active
+// task covers — the deterministic scope-drift enforcement fixture. Under
+// enforce the proxy rewrites it to CLAWVISOR_BLOCKED; under observe it
+// must pass through unmodified.
+func outOfScopeToolUseUpstream(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+  "id": "msg_oos",
+  "type": "message",
+  "role": "assistant",
+  "model": "claude-haiku-4-5-20251001",
+  "content": [
+    {"type": "text", "text": "I'll list the open issues."},
+    {"type": "tool_use", "id": "toolu_oos", "name": "github.list_issues", "input": {"owner": "x", "repo": "y"}}
+  ],
+  "stop_reason": "tool_use",
+  "usage": {"input_tokens": 50, "output_tokens": 30}
+}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// driveOutOfScopeToolUse boots a server with the given enforcement_mode,
+// activates github, creates an agent with no covering task, and issues
+// one /api/v1/messages request whose upstream response carries the
+// out-of-scope tool_use. Returns the response body string and the
+// user/agent tokens for follow-up audit assertions.
+func driveOutOfScopeToolUse(t *testing.T, enforcementMode string) (respBody string, cv *testapp.Server, userToken string) {
+	t.Helper()
+	h := testharness.New(t)
+	upstream := outOfScopeToolUseUpstream(t)
+
+	env := map[string]string{
+		"CLAWVISOR_LLM_UPSTREAM_ANTHROPIC": upstream.URL,
+		"GITHUB_API_BASE_URL":              h.GitHub.URL(),
+	}
+	if enforcementMode != "" {
+		env["CLAWVISOR_PROXY_LITE_ENFORCEMENT_MODE"] = enforcementMode
+	}
+	cv = testapp.StartWith(t, h, env)
+	user := cv.LoginAsLocalUser(t)
+	llmCredSet(t, cv, user.AccessToken, "anthropic", "", "sk-ant-test-key")
+	cvPost(t, cv, user.AccessToken, "/api/services/github/activate-key",
+		map[string]any{"token": "ghp_test_token_1234567890"}, nil)
+
+	var agent struct {
+		ID    string `json:"id"`
+		Token string `json:"token"`
+	}
+	cvPost(t, cv, user.AccessToken, "/api/agents", map[string]any{"name": "observe-oos"}, &agent)
+
+	body := []byte(`{
+  "model": "claude-haiku-4-5-20251001",
+  "max_tokens": 256,
+  "messages": [{"role": "user", "content": "list issues"}]
+}`)
+	req, _ := http.NewRequest("POST", cv.URL+"/api/v1/messages", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+agent.Token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := cv.Client.Do(req)
+	if err != nil {
+		t.Fatalf("/api/v1/messages: %v", err)
+	}
+	defer resp.Body.Close()
+	rb, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, rb)
+	}
+	return string(rb), cv, user.AccessToken
+}
+
+// TestObservePresetAppliesKnobs: a config carrying only `posture: observe`
+// boots proxy-lite enabled, with passthrough upstream auth and observe
+// (enforcement-off) mode. Asserted via /api/features + a probe request.
+func TestObservePresetAppliesKnobs(t *testing.T) {
+	h := testharness.New(t)
+	upstream := newUpstreamCapture(t)
+	cv := testapp.StartWithConfig(t, h, map[string]string{
+		"CLAWVISOR_LLM_UPSTREAM_ANTHROPIC": upstream.URL(),
+	}, "posture: observe")
+
+	if !featuresProxyLiteEnabled(t, cv) {
+		t.Fatal("posture: observe did not enable proxy-lite (/api/features proxy_lite=false)")
+	}
+
+	user := cv.LoginAsLocalUser(t)
+	_, token := newPostureAgent(t, cv, user.AccessToken, "observe-preset")
+
+	// upstream_auth=passthrough (from the preset): a request WITHOUT a
+	// client provider credential is refused with PASSTHROUGH_NO_CREDENTIAL,
+	// proving the preset selected passthrough (not the vault default).
+	noCred := postureAgentReq(t, cv, token, nil)
+	defer noCred.Body.Close()
+	if noCred.StatusCode != http.StatusUnauthorized ||
+		!strings.Contains(readBodyStr(noCred), "PASSTHROUGH_NO_CREDENTIAL") {
+		t.Fatalf("observe preset should select passthrough auth; got status=%d", noCred.StatusCode)
+	}
+
+	// With a client credential the request forwards it unchanged.
+	withCred := postureAgentReq(t, cv, token, map[string]string{
+		"Authorization": "Bearer sk-ant-oat01-subscription",
+	})
+	defer withCred.Body.Close()
+	if withCred.StatusCode != 200 {
+		t.Fatalf("passthrough with client cred: status=%d body=%s", withCred.StatusCode, readBodyStr(withCred))
+	}
+	if got := upstream.Last().Headers.Get("Authorization"); got != "Bearer sk-ant-oat01-subscription" {
+		t.Fatalf("passthrough altered client credential: %q", got)
+	}
+}
+
+// TestKnobOverridesPreset: `posture: observe` plus an explicit
+// enforcement_mode override (env) must let the explicit knob win — the
+// scope-drift verdict still enforces (CLAWVISOR_BLOCKED). upstream_auth is
+// also pinned to vault so the credentialed fixture runs without a client
+// key; the assertion targets enforcement_mode precedence.
+func TestKnobOverridesPreset(t *testing.T) {
+	h := testharness.New(t)
+	upstream := outOfScopeToolUseUpstream(t)
+	cv := testapp.StartWithConfig(t, h, map[string]string{
+		"CLAWVISOR_LLM_UPSTREAM_ANTHROPIC":      upstream.URL,
+		"GITHUB_API_BASE_URL":                   h.GitHub.URL(),
+		"CLAWVISOR_PROXY_LITE_ENFORCEMENT_MODE": "enforce",
+		"CLAWVISOR_PROXY_LITE_UPSTREAM_AUTH":    "vault",
+	}, "posture: observe")
+	user := cv.LoginAsLocalUser(t)
+	llmCredSet(t, cv, user.AccessToken, "anthropic", "", "sk-ant-test-key")
+	cvPost(t, cv, user.AccessToken, "/api/services/github/activate-key",
+		map[string]any{"token": "ghp_test_token_1234567890"}, nil)
+
+	var agent struct {
+		ID    string `json:"id"`
+		Token string `json:"token"`
+	}
+	cvPost(t, cv, user.AccessToken, "/api/agents", map[string]any{"name": "knob-override"}, &agent)
+
+	body := []byte(`{"model":"claude-haiku-4-5-20251001","max_tokens":256,"messages":[{"role":"user","content":"list issues"}]}`)
+	req, _ := http.NewRequest("POST", cv.URL+"/api/v1/messages", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+agent.Token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := cv.Client.Do(req)
+	if err != nil {
+		t.Fatalf("/api/v1/messages: %v", err)
+	}
+	defer resp.Body.Close()
+	rb, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(rb), "CLAWVISOR_BLOCKED") {
+		t.Fatalf("explicit enforcement_mode=enforce should override posture: observe (expected CLAWVISOR_BLOCKED); body: %s", rb)
+	}
+}
+
+// TestObserveModeToolUseHoldPassesThrough: a tool_use that would be
+// scope-drift-blocked under enforce passes through unmodified under
+// observe — proven by contrast with the enforce control run.
+func TestObserveModeToolUseHoldPassesThrough(t *testing.T) {
+	enforceBody, _, _ := driveOutOfScopeToolUse(t, "enforce")
+	if !strings.Contains(enforceBody, "CLAWVISOR_BLOCKED") {
+		t.Fatalf("control (enforce) run should block the out-of-scope tool_use; body: %s", enforceBody)
+	}
+
+	observeBody, _, _ := driveOutOfScopeToolUse(t, "observe")
+	if strings.Contains(observeBody, "CLAWVISOR_BLOCKED") {
+		t.Fatalf("observe mode must NOT rewrite the blocked tool_use; body: %s", observeBody)
+	}
+	if !strings.Contains(observeBody, "github.list_issues") {
+		t.Fatalf("observe mode must pass the original tool_use through unmodified; body: %s", observeBody)
+	}
+}
+
+// TestObserveModeDowngradesDeny: under observe the would-be block is
+// recorded (audit observed: true, with the tool verdict detail) while the
+// upstream response is returned unmodified.
+func TestObserveModeDowngradesDeny(t *testing.T) {
+	body, cv, userToken := driveOutOfScopeToolUse(t, "observe")
+	if strings.Contains(body, "CLAWVISOR_BLOCKED") {
+		t.Fatalf("observe must not enforce the deny; body: %s", body)
+	}
+	if !auditContains(t, cv, userToken, `"observed":true`) {
+		t.Fatal("audit did not record the downgraded verdict as observed: true")
+	}
+	if !auditContains(t, cv, userToken, "github.list_issues") {
+		t.Fatal("audit did not record the observed tool_use verdict detail (tool name)")
+	}
+}
+
+// TestObserveModeStillRejectsBadToken: observe downgrades policy verdicts
+// only — Clawvisor's own auth is never weakened. A bad agent token is
+// still rejected with 401.
+func TestObserveModeStillRejectsBadToken(t *testing.T) {
+	h := testharness.New(t)
+	upstream := newUpstreamCapture(t)
+	cv := testapp.StartWith(t, h, map[string]string{
+		"CLAWVISOR_LLM_UPSTREAM_ANTHROPIC":      upstream.URL(),
+		"CLAWVISOR_PROXY_LITE_ENFORCEMENT_MODE": "observe",
+	})
+
+	req, _ := http.NewRequest("POST", cv.URL+"/api/v1/messages",
+		bytes.NewReader([]byte(`{"model":"x","max_tokens":1,"messages":[{"role":"user","content":"hi"}]}`)))
+	req.Header.Set("X-Clawvisor-Agent-Token", "cvis_not-a-real-token")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := cv.Client.Do(req)
+	if err != nil {
+		t.Fatalf("/api/v1/messages: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("observe mode must still reject a bad token; status=%d body=%s", resp.StatusCode, readBodyStr(resp))
+	}
+	if upstream.Count() != 0 {
+		t.Fatalf("bad token reached upstream in observe mode: hits=%d", upstream.Count())
+	}
+}

--- a/e2e/scenarios/llm_proxy_openai_test.go
+++ b/e2e/scenarios/llm_proxy_openai_test.go
@@ -21,6 +21,10 @@ func TestLLMProxyOpenAIAPIKeyRoute(t *testing.T) {
 	cv := testapp.StartWith(t, h, map[string]string{
 		"CLAWVISOR_LLM_UPSTREAM_OPENAI":  openaiCapture.URL(),
 		"CLAWVISOR_LLM_UPSTREAM_CHATGPT": chatgptCapture.URL(),
+		// Spec 02 §4b: header placement no longer selects passthrough; the
+		// default posture is vault. These Mode B route tests opt into
+		// passthrough explicitly to keep their client-key routing coverage.
+		"CLAWVISOR_PROXY_LITE_UPSTREAM_AUTH": "passthrough",
 	})
 	user := cv.LoginAsLocalUser(t)
 
@@ -61,6 +65,10 @@ func TestLLMProxyChatGPTOAuthRoute(t *testing.T) {
 	cv := testapp.StartWith(t, h, map[string]string{
 		"CLAWVISOR_LLM_UPSTREAM_OPENAI":  openaiCapture.URL(),
 		"CLAWVISOR_LLM_UPSTREAM_CHATGPT": chatgptCapture.URL(),
+		// Spec 02 §4b: header placement no longer selects passthrough; the
+		// default posture is vault. These Mode B route tests opt into
+		// passthrough explicitly to keep their client-key routing coverage.
+		"CLAWVISOR_PROXY_LITE_UPSTREAM_AUTH": "passthrough",
 	})
 	user := cv.LoginAsLocalUser(t)
 
@@ -115,6 +123,10 @@ func TestLLMProxyOpenAIScopedJWTRoute(t *testing.T) {
 	cv := testapp.StartWith(t, h, map[string]string{
 		"CLAWVISOR_LLM_UPSTREAM_OPENAI":  openaiCapture.URL(),
 		"CLAWVISOR_LLM_UPSTREAM_CHATGPT": chatgptCapture.URL(),
+		// Spec 02 §4b: header placement no longer selects passthrough; the
+		// default posture is vault. These Mode B route tests opt into
+		// passthrough explicitly to keep their client-key routing coverage.
+		"CLAWVISOR_PROXY_LITE_UPSTREAM_AUTH": "passthrough",
 	})
 	user := cv.LoginAsLocalUser(t)
 

--- a/e2e/scenarios/llm_proxy_passthrough_test.go
+++ b/e2e/scenarios/llm_proxy_passthrough_test.go
@@ -28,8 +28,12 @@ func TestLLMProxyPassthroughAnthropic(t *testing.T) {
 	h := testharness.New(t)
 	upstream := newUpstreamCapture(t)
 
+	// Spec 02: header-driven passthrough is disabled under the default vault
+	// posture (the F1 fix); passthrough is now a server-side posture. Opt in
+	// via the upstream_auth knob so this mode-B lane keeps its coverage.
 	cv := testapp.StartWith(t, h, map[string]string{
-		"CLAWVISOR_LLM_UPSTREAM_ANTHROPIC": upstream.URL(),
+		"CLAWVISOR_LLM_UPSTREAM_ANTHROPIC":   upstream.URL(),
+		"CLAWVISOR_PROXY_LITE_UPSTREAM_AUTH": "passthrough",
 	})
 	user := cv.LoginAsLocalUser(t)
 

--- a/e2e/scenarios/llm_proxy_posture_test.go
+++ b/e2e/scenarios/llm_proxy_posture_test.go
@@ -1,0 +1,315 @@
+package scenarios_test
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/e2e/testapp"
+	"github.com/clawvisor/clawvisor/testharness"
+)
+
+// postureAgentReq issues a POST /api/v1/messages with the agent token in
+// X-Clawvisor-Agent-Token and arbitrary extra headers (the client's own
+// provider credential lives in Authorization / x-api-key). Returns the
+// response for status/body assertions.
+func postureAgentReq(t *testing.T, cv *testapp.Server, agentToken string, headers map[string]string) *http.Response {
+	t.Helper()
+	req, _ := http.NewRequest("POST", cv.URL+"/api/v1/messages",
+		bytes.NewReader([]byte(`{"model":"x","max_tokens":1,"messages":[{"role":"user","content":"hi"}]}`)))
+	req.Header.Set("X-Clawvisor-Agent-Token", agentToken)
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := cv.Client.Do(req)
+	if err != nil {
+		t.Fatalf("/api/v1/messages: %v", err)
+	}
+	return resp
+}
+
+func newPostureAgent(t *testing.T, cv *testapp.Server, userToken, name string) (id, token string) {
+	t.Helper()
+	var agent struct {
+		ID    string `json:"id"`
+		Token string `json:"token"`
+	}
+	cvPost(t, cv, userToken, "/api/agents", map[string]any{"name": name}, &agent)
+	return agent.ID, agent.Token
+}
+
+func auditContains(t *testing.T, cv *testapp.Server, userToken, needle string) bool {
+	t.Helper()
+	req, _ := http.NewRequest("GET", cv.URL+"/api/audit", nil)
+	req.Header.Set("Authorization", "Bearer "+userToken)
+	resp, err := cv.Client.Do(req)
+	if err != nil {
+		t.Fatalf("audit get: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	compact := strings.ReplaceAll(string(body), " ", "")
+	return strings.Contains(compact, needle)
+}
+
+// TestGovernStripsClientApiKey (§4b): govern posture (vault), the request
+// presents a DIFFERENT client provider API key; the upstream capture must
+// receive the vault key, not the client's, and audit records auth_mode:vault.
+func TestGovernStripsClientApiKey(t *testing.T) {
+	h := testharness.New(t)
+	upstream := newUpstreamCapture(t)
+	cv := testapp.StartWith(t, h, map[string]string{
+		"CLAWVISOR_LLM_UPSTREAM_ANTHROPIC":   upstream.URL(),
+		"CLAWVISOR_PROXY_LITE_UPSTREAM_AUTH": "vault",
+	})
+	user := cv.LoginAsLocalUser(t)
+	const vaultKey = "sk-ant-api03-VAULT-injected-key"
+	llmCredSet(t, cv, user.AccessToken, "anthropic", "", vaultKey)
+	_, token := newPostureAgent(t, cv, user.AccessToken, "govern-strip")
+
+	resp := postureAgentReq(t, cv, token, map[string]string{
+		"Authorization": "Bearer sk-ant-api03-CLIENT-different-key",
+	})
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBodyStr(resp))
+	}
+	if upstream.Count() != 1 {
+		t.Fatalf("upstream hits=%d, want 1", upstream.Count())
+	}
+	got := upstream.Last()
+	if k := got.Headers.Get("x-api-key"); k != vaultKey {
+		t.Fatalf("upstream x-api-key=%q, want vault key %q", k, vaultKey)
+	}
+	if strings.Contains(got.Headers.Get("Authorization"), "CLIENT-different-key") {
+		t.Fatalf("client API key leaked upstream: Authorization=%q", got.Headers.Get("Authorization"))
+	}
+	if !auditContains(t, cv, user.AccessToken, `"auth_mode":"vault"`) {
+		t.Fatal("audit did not record auth_mode: vault")
+	}
+}
+
+// TestGovernHeaderPlacementCannotSelectPassthrough (§4b F1): govern, cvis_ in
+// X-Clawvisor-Agent-Token and a client key in Authorization must STILL inject
+// the vault key — the middleware's header-derived passthrough flag is
+// overridden in vault posture.
+func TestGovernHeaderPlacementCannotSelectPassthrough(t *testing.T) {
+	h := testharness.New(t)
+	upstream := newUpstreamCapture(t)
+	cv := testapp.StartWith(t, h, map[string]string{
+		"CLAWVISOR_LLM_UPSTREAM_ANTHROPIC":   upstream.URL(),
+		"CLAWVISOR_PROXY_LITE_UPSTREAM_AUTH": "vault",
+	})
+	user := cv.LoginAsLocalUser(t)
+	const vaultKey = "sk-ant-api03-VAULT-wins"
+	llmCredSet(t, cv, user.AccessToken, "anthropic", "", vaultKey)
+	_, token := newPostureAgent(t, cv, user.AccessToken, "govern-f1")
+
+	// A client API key in Authorization would, under the old header-source
+	// flag, select passthrough. In vault posture it must not.
+	resp := postureAgentReq(t, cv, token, map[string]string{
+		"Authorization": "Bearer sk-ant-api03-STALE-laptop-key",
+	})
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBodyStr(resp))
+	}
+	got := upstream.Last()
+	if k := got.Headers.Get("x-api-key"); k != vaultKey {
+		t.Fatalf("upstream x-api-key=%q, want vault key %q (passthrough not overridden)", k, vaultKey)
+	}
+	if strings.Contains(got.Headers.Get("Authorization"), "STALE-laptop-key") {
+		t.Fatalf("client key leaked — header placement selected passthrough: %q", got.Headers.Get("Authorization"))
+	}
+}
+
+// TestObserveCarriesSubscriptionSession (§4c): observe/passthrough carries a
+// Claude subscription OAuth bearer + anthropic-beta header to the upstream
+// unchanged, and audit records auth_mode:passthrough.
+func TestObserveCarriesSubscriptionSession(t *testing.T) {
+	h := testharness.New(t)
+	upstream := newUpstreamCapture(t)
+	cv := testapp.StartWith(t, h, map[string]string{
+		"CLAWVISOR_LLM_UPSTREAM_ANTHROPIC":   upstream.URL(),
+		"CLAWVISOR_PROXY_LITE_UPSTREAM_AUTH": "passthrough",
+	})
+	user := cv.LoginAsLocalUser(t)
+	_, token := newPostureAgent(t, cv, user.AccessToken, "observe-sub")
+
+	const subBearer = "Bearer sk-ant-oat01-SUBSCRIPTION-session"
+	resp := postureAgentReq(t, cv, token, map[string]string{
+		"Authorization":  subBearer,
+		"anthropic-beta": "oauth-test",
+	})
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBodyStr(resp))
+	}
+	if upstream.Count() != 1 {
+		t.Fatalf("upstream hits=%d, want 1", upstream.Count())
+	}
+	got := upstream.Last()
+	if got.Headers.Get("Authorization") != subBearer {
+		t.Fatalf("subscription bearer altered: Authorization=%q, want %q", got.Headers.Get("Authorization"), subBearer)
+	}
+	if got.Headers.Get("anthropic-beta") != "oauth-test" {
+		t.Fatalf("anthropic-beta altered: %q, want oauth-test", got.Headers.Get("anthropic-beta"))
+	}
+	if !auditContains(t, cv, user.AccessToken, `"auth_mode":"passthrough"`) {
+		t.Fatal("audit did not record auth_mode: passthrough")
+	}
+}
+
+// TestGovernRefusesSubscriptionSeatWithoutConsent (§4c): govern with a
+// subscription bearer and no consent flag refuses with
+// SUBSCRIPTION_SEAT_NOT_GOVERNABLE and never reaches upstream.
+func TestGovernRefusesSubscriptionSeatWithoutConsent(t *testing.T) {
+	h := testharness.New(t)
+	upstream := newUpstreamCapture(t)
+	cv := testapp.StartWith(t, h, map[string]string{
+		"CLAWVISOR_LLM_UPSTREAM_ANTHROPIC":   upstream.URL(),
+		"CLAWVISOR_PROXY_LITE_UPSTREAM_AUTH": "vault",
+	})
+	user := cv.LoginAsLocalUser(t)
+	llmCredSet(t, cv, user.AccessToken, "anthropic", "", "sk-ant-api03-vault")
+	_, token := newPostureAgent(t, cv, user.AccessToken, "govern-refuse")
+
+	resp := postureAgentReq(t, cv, token, map[string]string{
+		"Authorization": "Bearer sk-ant-oat01-SUBSCRIPTION",
+	})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status=%d, want 403; body=%s", resp.StatusCode, readBodyStr(resp))
+	}
+	body := readBodyStr(resp)
+	if !strings.Contains(body, "SUBSCRIPTION_SEAT_NOT_GOVERNABLE") {
+		t.Fatalf("body missing SUBSCRIPTION_SEAT_NOT_GOVERNABLE: %s", body)
+	}
+	if upstream.Count() != 0 {
+		t.Fatalf("upstream hits=%d, want 0 (no silent rebill)", upstream.Count())
+	}
+}
+
+// TestGovernRefusesUnrecognizedBearer (§4c F3, fail-closed): govern with an
+// opaque non-API-key bearer and no anthropic-beta header is refused, not
+// silently injected.
+func TestGovernRefusesUnrecognizedBearer(t *testing.T) {
+	h := testharness.New(t)
+	upstream := newUpstreamCapture(t)
+	cv := testapp.StartWith(t, h, map[string]string{
+		"CLAWVISOR_LLM_UPSTREAM_ANTHROPIC":   upstream.URL(),
+		"CLAWVISOR_PROXY_LITE_UPSTREAM_AUTH": "vault",
+	})
+	user := cv.LoginAsLocalUser(t)
+	llmCredSet(t, cv, user.AccessToken, "anthropic", "", "sk-ant-api03-vault")
+	_, token := newPostureAgent(t, cv, user.AccessToken, "govern-opaque")
+
+	resp := postureAgentReq(t, cv, token, map[string]string{
+		"Authorization": "Bearer opaque-unknown-future-token",
+	})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status=%d, want 403; body=%s", resp.StatusCode, readBodyStr(resp))
+	}
+	if !strings.Contains(readBodyStr(resp), "SUBSCRIPTION_SEAT_NOT_GOVERNABLE") {
+		t.Fatal("opaque bearer should fail closed with SUBSCRIPTION_SEAT_NOT_GOVERNABLE")
+	}
+	if upstream.Count() != 0 {
+		t.Fatalf("upstream hits=%d, want 0", upstream.Count())
+	}
+}
+
+// TestGovernApiKeyWithOauthBetaHeaderNotDosed (§4c F2 reverse): a real org
+// API key plus a stray anthropic-beta: oauth-* header is still treated as an
+// API key — the header alone does not force refusal.
+func TestGovernApiKeyWithOauthBetaHeaderNotDosed(t *testing.T) {
+	h := testharness.New(t)
+	upstream := newUpstreamCapture(t)
+	cv := testapp.StartWith(t, h, map[string]string{
+		"CLAWVISOR_LLM_UPSTREAM_ANTHROPIC":   upstream.URL(),
+		"CLAWVISOR_PROXY_LITE_UPSTREAM_AUTH": "vault",
+	})
+	user := cv.LoginAsLocalUser(t)
+	const vaultKey = "sk-ant-api03-VAULT-key"
+	llmCredSet(t, cv, user.AccessToken, "anthropic", "", vaultKey)
+	_, token := newPostureAgent(t, cv, user.AccessToken, "govern-beta")
+
+	resp := postureAgentReq(t, cv, token, map[string]string{
+		"Authorization":  "Bearer sk-ant-api03-REAL-client-key",
+		"anthropic-beta": "oauth-2025-04-01",
+	})
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d, want 200 (API key must not be DoSed by the header); body=%s", resp.StatusCode, readBodyStr(resp))
+	}
+	if upstream.Count() != 1 {
+		t.Fatalf("upstream hits=%d, want 1", upstream.Count())
+	}
+	if got := upstream.Last(); got.Headers.Get("x-api-key") != vaultKey {
+		t.Fatalf("upstream x-api-key=%q, want vault key", got.Headers.Get("x-api-key"))
+	}
+}
+
+// TestGovernMigratesSubscriptionWithConsent (§4c): govern +
+// allow_subscription_billing_migration strips the subscription bearer and
+// injects the vault key; audit records auth_mode:vault.
+func TestGovernMigratesSubscriptionWithConsent(t *testing.T) {
+	h := testharness.New(t)
+	upstream := newUpstreamCapture(t)
+	cv := testapp.StartWith(t, h, map[string]string{
+		"CLAWVISOR_LLM_UPSTREAM_ANTHROPIC":         upstream.URL(),
+		"CLAWVISOR_PROXY_LITE_UPSTREAM_AUTH":       "vault",
+		"CLAWVISOR_PROXY_LITE_ALLOW_SUB_MIGRATION": "true",
+	})
+	user := cv.LoginAsLocalUser(t)
+	const vaultKey = "sk-ant-api03-VAULT-migrated"
+	llmCredSet(t, cv, user.AccessToken, "anthropic", "", vaultKey)
+	_, token := newPostureAgent(t, cv, user.AccessToken, "govern-migrate")
+
+	resp := postureAgentReq(t, cv, token, map[string]string{
+		"Authorization": "Bearer sk-ant-oat01-SUBSCRIPTION",
+	})
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBodyStr(resp))
+	}
+	got := upstream.Last()
+	if got.Headers.Get("x-api-key") != vaultKey {
+		t.Fatalf("upstream x-api-key=%q, want vault key %q", got.Headers.Get("x-api-key"), vaultKey)
+	}
+	if strings.Contains(got.Headers.Get("Authorization"), "oat01") {
+		t.Fatalf("subscription bearer not stripped: Authorization=%q", got.Headers.Get("Authorization"))
+	}
+	if !auditContains(t, cv, user.AccessToken, `"auth_mode":"vault"`) {
+		t.Fatal("audit did not record auth_mode: vault after migration")
+	}
+}
+
+// TestPassthroughNoCredential (§4): passthrough posture with only the cvis
+// token (no client provider credential) returns 401 PASSTHROUGH_NO_CREDENTIAL.
+func TestPassthroughNoCredential(t *testing.T) {
+	h := testharness.New(t)
+	upstream := newUpstreamCapture(t)
+	cv := testapp.StartWith(t, h, map[string]string{
+		"CLAWVISOR_LLM_UPSTREAM_ANTHROPIC":   upstream.URL(),
+		"CLAWVISOR_PROXY_LITE_UPSTREAM_AUTH": "passthrough",
+	})
+	user := cv.LoginAsLocalUser(t)
+	_, token := newPostureAgent(t, cv, user.AccessToken, "passthrough-nocred")
+
+	// Only the cvis token — no provider bearer / x-api-key.
+	resp := postureAgentReq(t, cv, token, nil)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status=%d, want 401; body=%s", resp.StatusCode, readBodyStr(resp))
+	}
+	if !strings.Contains(readBodyStr(resp), "PASSTHROUGH_NO_CREDENTIAL") {
+		t.Fatal("body missing PASSTHROUGH_NO_CREDENTIAL")
+	}
+	if upstream.Count() != 0 {
+		t.Fatalf("upstream hits=%d, want 0", upstream.Count())
+	}
+}

--- a/e2e/scenarios/llm_proxy_posture_test.go
+++ b/e2e/scenarios/llm_proxy_posture_test.go
@@ -288,6 +288,42 @@ func TestGovernMigratesSubscriptionWithConsent(t *testing.T) {
 	}
 }
 
+// TestPassthroughForwardsClientXApiKey (§4): passthrough posture where the
+// client presents ONLY an x-api-key (Anthropic SDK convention, no Authorization
+// bearer) must forward that key upstream — never fall through to the vault key.
+// No vault key is seeded here, so an implicit vault fallback (which §4 forbids)
+// would surface UPSTREAM_KEY_MISSING and never reach the upstream capture.
+func TestPassthroughForwardsClientXApiKey(t *testing.T) {
+	h := testharness.New(t)
+	upstream := newUpstreamCapture(t)
+	cv := testapp.StartWith(t, h, map[string]string{
+		"CLAWVISOR_LLM_UPSTREAM_ANTHROPIC":   upstream.URL(),
+		"CLAWVISOR_PROXY_LITE_UPSTREAM_AUTH": "passthrough",
+	})
+	user := cv.LoginAsLocalUser(t)
+	// Deliberately do NOT seed a vault key — a vault fallback would fail.
+	_, token := newPostureAgent(t, cv, user.AccessToken, "passthrough-xapikey")
+
+	const clientKey = "sk-ant-api03-CLIENT-own-key"
+	resp := postureAgentReq(t, cv, token, map[string]string{
+		"x-api-key": clientKey,
+	})
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d, want 200 (client x-api-key should be forwarded, not a vault fallback); body=%s", resp.StatusCode, readBodyStr(resp))
+	}
+	if upstream.Count() != 1 {
+		t.Fatalf("upstream hits=%d, want 1", upstream.Count())
+	}
+	got := upstream.Last()
+	if k := got.Headers.Get("x-api-key"); k != clientKey {
+		t.Fatalf("upstream x-api-key=%q, want the client key %q", k, clientKey)
+	}
+	if !auditContains(t, cv, user.AccessToken, `"auth_mode":"passthrough"`) {
+		t.Fatal("audit did not record auth_mode: passthrough")
+	}
+}
+
 // TestPassthroughNoCredential (§4): passthrough posture with only the cvis
 // token (no client provider credential) returns 401 PASSTHROUGH_NO_CREDENTIAL.
 func TestPassthroughNoCredential(t *testing.T) {

--- a/e2e/scenarios/llm_proxy_security_test.go
+++ b/e2e/scenarios/llm_proxy_security_test.go
@@ -21,6 +21,11 @@ func TestLLMProxyCallerAuthSourceClawvisorHeader(t *testing.T) {
 	upstream := newUpstreamCapture(t)
 	cv := testapp.StartWith(t, h, map[string]string{
 		"CLAWVISOR_LLM_UPSTREAM_ANTHROPIC": upstream.URL(),
+		// Spec 02 §4b: the default posture is vault, which overrides the
+		// middleware's header-derived passthrough flag. This test asserts
+		// passthrough (caller_auth_source + forwarded bearer), so it opts
+		// into passthrough upstream auth explicitly.
+		"CLAWVISOR_PROXY_LITE_UPSTREAM_AUTH": "passthrough",
 	})
 	user := cv.LoginAsLocalUser(t)
 	var agent struct {

--- a/e2e/testapp/server.go
+++ b/e2e/testapp/server.go
@@ -57,11 +57,21 @@ func Start(t *testing.T, h *testharness.Harness) *Server {
 // and retry up to maxStartAttempts times with a fresh port. Slow-start
 // timeouts (no early exit) are NOT retried — they'd just timeout again.
 func StartWith(t *testing.T, h *testharness.Harness, extraEnv map[string]string) *Server {
+	return StartWithConfig(t, h, extraEnv, "")
+}
+
+// StartWithConfig is like StartWith but appends configOverlay (raw YAML,
+// top-level keys) to the generated config file before boot. Use it for
+// file-only config surfaces that have no env override — e.g. the
+// `posture:` preset key (spec 02), which is read from the config file
+// only. The overlay is appended after the base blocks, so it may set new
+// top-level keys or rely on preset semantics for absent sub-knobs.
+func StartWithConfig(t *testing.T, h *testharness.Harness, extraEnv map[string]string, configOverlay string) *Server {
 	t.Helper()
 	binPath := buildServerBinary(t)
 	var lastErr error
 	for attempt := 0; attempt < maxStartAttempts; attempt++ {
-		s, err := tryStart(t, h, extraEnv, binPath)
+		s, err := tryStart(t, h, extraEnv, binPath, configOverlay)
 		if err == nil {
 			return s
 		}
@@ -117,7 +127,7 @@ func (e *earlyExitError) Unwrap() error { return e.err }
 // and returns the *Server. On failure: tears down its own subprocess
 // inline and returns the error (no cleanup registered, so retries
 // don't accumulate cleanup callbacks).
-func tryStart(t *testing.T, h *testharness.Harness, extraEnv map[string]string, binPath string) (*Server, error) {
+func tryStart(t *testing.T, h *testharness.Harness, extraEnv map[string]string, binPath, configOverlay string) (*Server, error) {
 	t.Helper()
 	port := freePort(t)
 	publicURL := fmt.Sprintf("http://127.0.0.1:%d", port)
@@ -176,6 +186,9 @@ runtime_proxy:
 proxy_lite:
   enabled: true
 `, port, publicURL, dataDir, vaultKeyFile)
+	if configOverlay != "" {
+		cfg += "\n" + configOverlay + "\n"
+	}
 	if err := os.WriteFile(cfgPath, []byte(cfg), 0600); err != nil {
 		return nil, fmt.Errorf("write config: %w", err)
 	}

--- a/e2e/testapp/server_internal_test.go
+++ b/e2e/testapp/server_internal_test.go
@@ -27,7 +27,7 @@ func TestTryStartReturnsEarlyExitErrorOnBindFailure(t *testing.T) {
 	stub := writeFailingStub(t)
 	h := testharness.New(t)
 
-	_, err := tryStart(t, h, nil, stub)
+	_, err := tryStart(t, h, nil, stub, "")
 	if err == nil {
 		t.Fatal("tryStart returned nil; expected earlyExitError")
 	}
@@ -49,7 +49,7 @@ func TestWaitReadyReportsEarlyExitFast(t *testing.T) {
 	h := testharness.New(t)
 
 	start := time.Now()
-	_, err := tryStart(t, h, nil, stub)
+	_, err := tryStart(t, h, nil, stub, "")
 	elapsed := time.Since(start)
 
 	if err == nil {
@@ -84,7 +84,7 @@ func TestEarlyExitErrorCarriesSubprocessDiagnostics(t *testing.T) {
 	}
 	h := testharness.New(t)
 
-	_, err := tryStart(t, h, nil, stub)
+	_, err := tryStart(t, h, nil, stub, "")
 	if err == nil {
 		t.Fatal("expected error")
 	}

--- a/internal/api/handlers/audit.go
+++ b/internal/api/handlers/audit.go
@@ -369,6 +369,17 @@ func stripSecretsNode(value any) any {
 // reason). "oauth" alone is not treated as a secret marker — it's the
 // protocol name; "oauth_token" still matches because the "token" token does.
 func looksSecretKey(key string) bool {
+	// Exact non-secret governance/metadata keys that would otherwise trip the
+	// token matcher below (they carry an "auth" token but are enums, never
+	// credentials). The audit view surfaces these as forensic fields: the
+	// server-side upstream-auth posture (vault/passthrough — spec 02) and the
+	// caller-auth source (which header authenticated the agent). Redacting
+	// them would blind operators to whether a request was vault-injected,
+	// passed through, or observed.
+	switch strings.ToLower(strings.TrimSpace(key)) {
+	case "auth_mode", "caller_auth_source":
+		return false
+	}
 	tokens := tokenizeSecretKey(key)
 	for _, t := range tokens {
 		switch t {

--- a/internal/api/handlers/audit_test.go
+++ b/internal/api/handlers/audit_test.go
@@ -283,6 +283,11 @@ func TestLooksSecretKeyTokenBoundary(t *testing.T) {
 		{"authentication_method", false}, // method name, not secret
 		{"keypath", false},
 		{"keyboard", false},
+
+		// Spec 02: non-secret governance enums explicitly allowlisted despite
+		// carrying an "auth" token — the audit view must surface them.
+		{"auth_mode", false},
+		{"caller_auth_source", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.key, func(t *testing.T) {

--- a/internal/api/handlers/llm_endpoint.go
+++ b/internal/api/handlers/llm_endpoint.go
@@ -506,7 +506,12 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 	if h.upstreamAuthPassthrough() {
 		// Passthrough posture: forward the client's own provider credential
 		// for EVERY request, and require one to be present.
-		r = r.WithContext(llmproxy.WithPassthroughUpstreamAuth(r.Context()))
+		// Mutate rootCtx (not just r) so the setPhase closure — which
+		// re-derives r's context from rootCtx before the upstream forward —
+		// carries the posture override rather than reverting to the
+		// middleware's header-derived flag.
+		rootCtx = llmproxy.WithPassthroughUpstreamAuth(rootCtx)
+		r = r.WithContext(rootCtx)
 		auditParams["auth_mode"] = "passthrough"
 		authModeMetric = "passthrough"
 		if !llmproxy.HasClientProviderCredential(r) {
@@ -521,7 +526,11 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 	} else {
 		// Vault posture (default): force passthrough OFF and apply the
 		// subscription/OAuth carve-out before any silent strip-and-inject.
-		r = r.WithContext(llmproxy.WithVaultUpstreamAuth(r.Context()))
+		// Mutate rootCtx (see the passthrough branch): setPhase re-derives
+		// r's context from rootCtx before the forward, so the F1 override
+		// must live on rootCtx to survive.
+		rootCtx = llmproxy.WithVaultUpstreamAuth(rootCtx)
+		r = r.WithContext(rootCtx)
 		auditParams["auth_mode"] = "vault"
 		switch llmproxy.ClassifyUpstreamCredential(r) {
 		case llmproxy.CredentialSubscription, llmproxy.CredentialUnrecognized:

--- a/internal/api/handlers/llm_endpoint.go
+++ b/internal/api/handlers/llm_endpoint.go
@@ -25,6 +25,7 @@ import (
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/inspector"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/jsonsurgery"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/orggov"
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/pipeline"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/policies"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/postproc"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/pricing"
@@ -272,6 +273,26 @@ func (h *LLMEndpointHandler) upstreamAuthPassthrough() bool {
 // observations rather than enforced (spec 02 §3).
 func (h *LLMEndpointHandler) observeMode() bool {
 	return strings.EqualFold(strings.TrimSpace(h.EnforcementMode), "observe")
+}
+
+// recordObservedToolUseVerdicts stamps the endpoint_call audit row with
+// the tool_use verdicts Observe mode downgraded to observations (spec 02
+// §3), so the audit view can render an "observed" badge. No-op when the
+// postprocess pass enforced normally.
+func recordObservedToolUseVerdicts(auditParams map[string]any, observed []llmproxy.ObservedToolUseVerdict) {
+	if len(observed) == 0 {
+		return
+	}
+	auditParams["observed"] = true
+	records := make([]map[string]any, 0, len(observed))
+	for _, o := range observed {
+		records = append(records, map[string]any{
+			"tool_name": o.ToolName,
+			"decision":  o.Decision,
+			"reason":    o.Reason,
+		})
+	}
+	auditParams["observed_tool_use_verdicts"] = records
 }
 
 const defaultToolRulesSeenMaxAgents = 10000
@@ -545,6 +566,17 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 			}
 			auditParams["subscription_billing_migration"] = true
 		}
+	}
+
+	// Observe posture (spec 02 §3): thread the enforcement-off flag through
+	// the request context so every pipeline call site (RunPre pre-phase +
+	// the tool_use postprocess) downgrades enforcing verdicts to recorded
+	// observations. Clawvisor's own auth is unaffected — only policy
+	// verdicts are downgraded, and only after the request is authenticated.
+	if h.observeMode() {
+		rootCtx = pipeline.WithObserveMode(rootCtx)
+		r = r.WithContext(rootCtx)
+		auditParams["enforcement_mode"] = "observe"
 	}
 
 	if h.Inspector != nil && !liteProxyResponsePolicyAvailable(provider, conversation.DefaultResponseRegistry()) {
@@ -1600,6 +1632,7 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 
 			cfg := llmproxy.PostprocessConfig{
 				ToolUseEvaluatorFactory: pipelineToolUseEvaluatorFactory,
+				ObserveMode:             h.observeMode(),
 				AgentContext: llmproxy.AgentContext{
 					AgentUserID: agent.UserID,
 					AgentID:     agent.ID,
@@ -1702,6 +1735,8 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 				"decisions", len(processed.Decisions),
 				"skipped_reason", processed.SkippedReason,
 			)
+
+			recordObservedToolUseVerdicts(auditParams, processed.ObservedVerdicts)
 
 			if auditTaskID == "" {
 				for _, dec := range processed.Decisions {
@@ -1950,6 +1985,7 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 		autoApproveThreshold := agentConversationAutoApproveThreshold(agent)
 		processed := postproc.Postprocess(r, full, upstreamCT, llmproxy.PostprocessConfig{
 			ToolUseEvaluatorFactory: pipelineToolUseEvaluatorFactory,
+			ObserveMode:             h.observeMode(),
 			AgentContext: llmproxy.AgentContext{
 				AgentUserID: agent.UserID,
 				AgentID:     agent.ID,
@@ -2006,6 +2042,8 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 			"decisions", len(processed.Decisions),
 			"skipped_reason", processed.SkippedReason,
 		)
+
+		recordObservedToolUseVerdicts(auditParams, processed.ObservedVerdicts)
 
 		// Auto-approved task attribution: scoop the created task id out
 		// of the decisions so audit can link to it even when the

--- a/internal/api/handlers/llm_endpoint.go
+++ b/internal/api/handlers/llm_endpoint.go
@@ -239,8 +239,39 @@ type LLMEndpointHandler struct {
 	// UPSTREAM_TOO_LARGE.
 	MaxResponseBytes int64
 
+	// UpstreamAuth mirrors cfg.ProxyLite.UpstreamAuth: "vault" (default) or
+	// "passthrough". It is the server-side posture decision that overrides
+	// the auth middleware's header-derived passthrough flag (spec 02 §4/§4b).
+	// Empty is treated as "vault".
+	UpstreamAuth string
+
+	// EnforcementMode mirrors cfg.ProxyLite.EnforcementMode: "enforce"
+	// (default) or "observe". In observe mode the pipeline runs fully but
+	// hold/deny/rewrite verdicts are downgraded to recorded observations
+	// (spec 02 §3). Empty is treated as "enforce".
+	EnforcementMode string
+
+	// AllowSubscriptionBillingMigration mirrors
+	// cfg.ProxyLite.AllowSubscriptionBillingMigration. When false (default),
+	// a govern/contain request carrying a subscription/OAuth (or
+	// unrecognized) bearer is refused with SUBSCRIPTION_SEAT_NOT_GOVERNABLE
+	// rather than silently rebilled (spec 02 §4c). Instance-wide (F4).
+	AllowSubscriptionBillingMigration bool
+
 	defaultToolRulesMu   sync.Mutex
 	defaultToolRulesSeen map[string]map[string]struct{}
+}
+
+// upstreamAuthPassthrough reports whether the server-side posture forwards the
+// client's own provider credential instead of injecting the vault key.
+func (h *LLMEndpointHandler) upstreamAuthPassthrough() bool {
+	return strings.EqualFold(strings.TrimSpace(h.UpstreamAuth), "passthrough")
+}
+
+// observeMode reports whether pipeline verdicts are downgraded to
+// observations rather than enforced (spec 02 §3).
+func (h *LLMEndpointHandler) observeMode() bool {
+	return strings.EqualFold(strings.TrimSpace(h.EnforcementMode), "observe")
 }
 
 const defaultToolRulesSeenMaxAgents = 10000
@@ -466,6 +497,45 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 	}
 	if src := llmproxy.CallerAuthSource(r.Context()); src != "" {
 		auditParams["caller_auth_source"] = src
+	}
+
+	// Spec 02 §4/§4b/§4c: apply the server-side upstream_auth posture. This
+	// OVERRIDES the auth middleware's header-derived passthrough flag, so a
+	// client cannot select the passthrough lane — and skip vault injection +
+	// the subscription check — merely by header placement (the F1 fix).
+	if h.upstreamAuthPassthrough() {
+		// Passthrough posture: forward the client's own provider credential
+		// for EVERY request, and require one to be present.
+		r = r.WithContext(llmproxy.WithPassthroughUpstreamAuth(r.Context()))
+		auditParams["auth_mode"] = "passthrough"
+		authModeMetric = "passthrough"
+		if !llmproxy.HasClientProviderCredential(r) {
+			auditStatus = http.StatusUnauthorized
+			auditDecide = "deny"
+			auditOutcome = "passthrough_no_credential"
+			auditReason = "passthrough posture but no client provider credential presented"
+			writeNestedJSONError(w, http.StatusUnauthorized, "PASSTHROUGH_NO_CREDENTIAL",
+				"observe posture forwards your own provider credential; none was found. Provide your provider key, or set proxy_lite.upstream_auth: vault.")
+			return
+		}
+	} else {
+		// Vault posture (default): force passthrough OFF and apply the
+		// subscription/OAuth carve-out before any silent strip-and-inject.
+		r = r.WithContext(llmproxy.WithVaultUpstreamAuth(r.Context()))
+		auditParams["auth_mode"] = "vault"
+		switch llmproxy.ClassifyUpstreamCredential(r) {
+		case llmproxy.CredentialSubscription, llmproxy.CredentialUnrecognized:
+			if !h.AllowSubscriptionBillingMigration {
+				auditStatus = http.StatusForbidden
+				auditDecide = "deny"
+				auditOutcome = "subscription_seat_not_governable"
+				auditReason = "govern refused a subscription/unrecognized bearer without billing-migration consent"
+				writeNestedJSONError(w, http.StatusForbidden, "SUBSCRIPTION_SEAT_NOT_GOVERNABLE",
+					"this seat's credential can't be governed without either an org provider API key for this agent or explicit billing-migration consent (proxy_lite.allow_subscription_billing_migration); it was not silently rebilled.")
+				return
+			}
+			auditParams["subscription_billing_migration"] = true
+		}
 	}
 
 	if h.Inspector != nil && !liteProxyResponsePolicyAvailable(provider, conversation.DefaultResponseRegistry()) {
@@ -2097,6 +2167,22 @@ func upstreamCredMissingError(r *http.Request, agent *store.Agent, provider conv
 	}
 	message = "no " + providerName + " API key configured. Get one at " + consoleURL + " and paste it at " + dashboardBase + "/dashboard/agents/" + agent.ID + "."
 	return code, outcome, message
+}
+
+// writeNestedJSONError emits the provider-style nested error envelope
+// {"error": {"code": ..., "message": ...}} at the given HTTP status. Used by
+// the upstream_auth posture gate (spec 02 §4/§4c) where the contract fixes
+// both the status (401/403) and the nested body shape, distinct from the
+// flat writeJSONError shape and the 200-envelope writeLiteProxyError.
+func writeNestedJSONError(w http.ResponseWriter, status int, code, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"error": map[string]string{
+			"code":    code,
+			"message": message,
+		},
+	})
 }
 
 // writeJSONError produces a uniform JSON error response. Use this only

--- a/internal/api/handlers/testdata/llm_characterization/control_notice_injected.json
+++ b/internal/api/handlers/testdata/llm_characterization/control_notice_injected.json
@@ -7,6 +7,7 @@
     "used_active_task_context": false,
     "used_lease_bias": false,
     "params": {
+      "auth_mode": "vault",
       "available_tools": [
         "Bash"
       ],

--- a/internal/api/handlers/testdata/llm_characterization/malformed_request.json
+++ b/internal/api/handlers/testdata/llm_characterization/malformed_request.json
@@ -8,6 +8,7 @@
     "used_lease_bias": false,
     "params": {
       "anthropic_sanitize_error": "invalid character 'n' looking for beginning of object key string",
+      "auth_mode": "vault",
       "build_sha": "dev",
       "caller_auth_source": "authorization",
       "clawvisor_version": "dev",

--- a/internal/api/handlers/testdata/llm_characterization/passthrough_clean_anthropic.json
+++ b/internal/api/handlers/testdata/llm_characterization/passthrough_clean_anthropic.json
@@ -7,6 +7,7 @@
     "used_active_task_context": false,
     "used_lease_bias": false,
     "params": {
+      "auth_mode": "vault",
       "available_tools": null,
       "build_sha": "dev",
       "caller_auth_source": "authorization",

--- a/internal/api/handlers/testdata/llm_characterization/passthrough_clean_openai_chat.json
+++ b/internal/api/handlers/testdata/llm_characterization/passthrough_clean_openai_chat.json
@@ -7,6 +7,7 @@
     "used_active_task_context": false,
     "used_lease_bias": false,
     "params": {
+      "auth_mode": "vault",
       "available_tools": null,
       "build_sha": "dev",
       "caller_auth_source": "authorization",

--- a/internal/api/handlers/testdata/llm_characterization/tool_use_credential_rewrite.json
+++ b/internal/api/handlers/testdata/llm_characterization/tool_use_credential_rewrite.json
@@ -49,6 +49,7 @@
     "used_active_task_context": false,
     "used_lease_bias": false,
     "params": {
+      "auth_mode": "vault",
       "available_tools": null,
       "build_sha": "dev",
       "caller_auth_source": "authorization",

--- a/internal/api/handlers/testdata/llm_characterization/tool_use_held_for_approval.json
+++ b/internal/api/handlers/testdata/llm_characterization/tool_use_held_for_approval.json
@@ -37,6 +37,7 @@
     "used_active_task_context": false,
     "used_lease_bias": false,
     "params": {
+      "auth_mode": "vault",
       "available_tools": [
         "Bash"
       ],

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1343,6 +1343,10 @@ func (s *Server) registerLiteProxyRoutes(
 		llmHandler.OrgGovCallbacks = s.orgGovCallbacks
 		llmHandler.OrgIDForAgent = s.orgIDForAgent
 		llmHandler.Instruments = s.instruments
+		// Spec 02: the server-side upstream_auth / enforcement posture knobs.
+		llmHandler.UpstreamAuth = s.cfg.ProxyLite.UpstreamAuth
+		llmHandler.EnforcementMode = s.cfg.ProxyLite.EnforcementMode
+		llmHandler.AllowSubscriptionBillingMigration = s.cfg.ProxyLite.AllowSubscriptionBillingMigration
 		if v := s.cfg.ProxyLite.AnthropicBaseURL; v != "" {
 			llmHandler.Forwarder.Upstream.AnthropicBaseURL = v
 		}

--- a/internal/e2e/lite/harness.go
+++ b/internal/e2e/lite/harness.go
@@ -181,6 +181,11 @@ func Start(t *testing.T, scn *Scenario, keys Keys) (*Harness, error) {
 
 	h := handlers.NewLLMEndpointHandler(st, v, logger)
 	h.Forwarder = llmproxy.NewForwarder(v)
+	// Spec 02: mirror the server-side upstream_auth / enforcement posture so
+	// lite scenarios can exercise vault/passthrough + observe/enforce.
+	h.UpstreamAuth = cfg.ProxyLite.UpstreamAuth
+	h.EnforcementMode = cfg.ProxyLite.EnforcementMode
+	h.AllowSubscriptionBillingMigration = cfg.ProxyLite.AllowSubscriptionBillingMigration
 	h.Inspector = inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{})
 	h.InlineTaskCreator = recorder
 	h.TaskScope = llmproxy.NewStoreTaskScopeChecker(st)

--- a/internal/observability/emit.go
+++ b/internal/observability/emit.go
@@ -24,6 +24,11 @@ const (
 	AttrStatus       = "status"
 	AttrDecision     = "decision"
 	AttrHostCategory = "host_category"
+	// AttrObserved marks a verdict that WOULD have enforced but was
+	// downgraded to a recorded observation under the Observe posture
+	// (spec 02 §3). "true" on the pipeline.verdicts counter means the
+	// request/response proceeded despite the enforcing verdict.
+	AttrObserved = "observed"
 )
 
 // Span attribute keys (contractual — see spec 01 §"Span model"). Content-
@@ -128,6 +133,13 @@ func (i *Instruments) RecordCost(ctx context.Context, provider, model string, mi
 // RecordVerdict increments clawvisor.pipeline.verdicts. outcome must already
 // be mapped through DecisionFromOutcome by the caller. Nil-safe.
 func (i *Instruments) RecordVerdict(ctx context.Context, policy, outcome, phase string) {
+	i.RecordVerdictObserved(ctx, policy, outcome, phase, false)
+}
+
+// RecordVerdictObserved is RecordVerdict with the Observe-posture
+// downgrade attribute (spec 02 §3). observed=true means the verdict
+// would have enforced but was recorded and passed through. Nil-safe.
+func (i *Instruments) RecordVerdictObserved(ctx context.Context, policy, outcome, phase string, observed bool) {
 	if i == nil || i.PipelineVerdicts == nil {
 		return
 	}
@@ -135,7 +147,30 @@ func (i *Instruments) RecordVerdict(ctx context.Context, policy, outcome, phase 
 		attribute.String(AttrPolicy, policy),
 		attribute.String(AttrOutcome, outcome),
 		attribute.String(AttrPhase, phase),
+		attribute.Bool(AttrObserved, observed),
 	))
+}
+
+// RecordToolUseVerdictObserved records a tool_use-phase verdict on the
+// clawvisor.pipeline.verdicts counter (policy="tooluse") and a
+// tooluse.verdict span event. observed marks an Observe-posture
+// downgrade (spec 02 §3): the verdict was recorded but not enforced.
+// Safe to call when neither instruments nor a recording span are present.
+func RecordToolUseVerdictObserved(ctx context.Context, toolName, decision, reason string, observed bool) {
+	InstrumentsFromContext(ctx).RecordVerdictObserved(ctx, "tooluse", decision, "post", observed)
+	if span := trace.SpanFromContext(ctx); span.IsRecording() {
+		attrs := []attribute.KeyValue{
+			attribute.String(AttrPolicy, "tooluse"),
+			attribute.String(SpanAttrToolName, toolName),
+			attribute.String(SpanAttrVerdict, decision),
+			attribute.String(AttrPhase, "post"),
+			attribute.Bool(AttrObserved, observed),
+		}
+		if decision != "allow" && reason != "" {
+			attrs = append(attrs, attribute.String(SpanAttrReason, reason))
+		}
+		span.AddEvent(EventToolUseVerdict, trace.WithAttributes(attrs...))
+	}
 }
 
 // RecordHold increments clawvisor.approvals.holds. resolution ∈
@@ -215,12 +250,22 @@ func InstrumentsFromContext(ctx context.Context) *Instruments {
 // policy-generated string, never model content). Safe to call when neither
 // instruments nor a recording span are present.
 func RecordPolicyVerdict(ctx context.Context, policy, outcome, phase, reason string) {
-	InstrumentsFromContext(ctx).RecordVerdict(ctx, policy, outcome, phase)
+	RecordPolicyVerdictObserved(ctx, policy, outcome, phase, reason, false)
+}
+
+// RecordPolicyVerdictObserved is RecordPolicyVerdict with the
+// Observe-posture downgrade attribute (spec 02 §3). When observed=true
+// the metric and span event carry observed="true", recording that an
+// enforcing verdict was downgraded to an observation and the
+// request/response proceeded unmodified.
+func RecordPolicyVerdictObserved(ctx context.Context, policy, outcome, phase, reason string, observed bool) {
+	InstrumentsFromContext(ctx).RecordVerdictObserved(ctx, policy, outcome, phase, observed)
 	if span := trace.SpanFromContext(ctx); span.IsRecording() {
 		attrs := []attribute.KeyValue{
 			attribute.String(AttrPolicy, policy),
 			attribute.String(AttrOutcome, outcome),
 			attribute.String(AttrPhase, phase),
+			attribute.Bool(AttrObserved, observed),
 		}
 		if outcome != "allow" && reason != "" {
 			attrs = append(attrs, attribute.String(SpanAttrReason, reason))

--- a/internal/runtime/llmproxy/auth_context.go
+++ b/internal/runtime/llmproxy/auth_context.go
@@ -7,13 +7,26 @@ import (
 
 type upstreamAuthModeContextKey struct{}
 
-const upstreamAuthModePassthrough = "passthrough"
+const (
+	upstreamAuthModePassthrough = "passthrough"
+	upstreamAuthModeVault       = "vault"
+)
 
 // WithPassthroughUpstreamAuth marks a lite-proxy request as authenticated to
 // Clawvisor out-of-band, allowing the upstream Authorization header to remain
 // the user's provider OAuth/subscription credential.
 func WithPassthroughUpstreamAuth(ctx context.Context) context.Context {
 	return context.WithValue(ctx, upstreamAuthModeContextKey{}, upstreamAuthModePassthrough)
+}
+
+// WithVaultUpstreamAuth forces vault upstream auth, overriding any
+// passthrough flag the auth middleware set from header placement. The govern/
+// contain posture (upstream_auth: vault) calls this so a client cannot select
+// the passthrough lane — and skip vault injection + the subscription check —
+// merely by putting its cvis_ token in X-Clawvisor-Agent-Token and a provider
+// key in Authorization (spec 02 §4b, the F1 fix).
+func WithVaultUpstreamAuth(ctx context.Context) context.Context {
+	return context.WithValue(ctx, upstreamAuthModeContextKey{}, upstreamAuthModeVault)
 }
 
 // PassthroughUpstreamAuth reports whether the request should preserve a

--- a/internal/runtime/llmproxy/byte_fidelity_test.go
+++ b/internal/runtime/llmproxy/byte_fidelity_test.go
@@ -1,10 +1,13 @@
 package llmproxy
 
 import (
+	"context"
+	"net/http"
 	"strings"
 	"testing"
 
 	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/pipeline"
 )
 
 // Anthropic enforces a cryptographic signature over thinking blocks
@@ -124,6 +127,145 @@ func TestStripSecretDecisionHistoryPreservesThinkingBlockBytes(t *testing.T) {
 		t.Fatalf("expected strip path to fire — the test fixture is explicitly constructed to trigger it; a regression that no longer fires would silently bypass byte-fidelity assertions")
 	}
 	assertThinkingBlockPreserved(t, res.Body)
+}
+
+// --- Observe-posture byte fidelity (spec 02 §3) ---
+//
+// Contract: a request that WOULD be denied / held / rewritten by an
+// enforcing policy must produce the SAME upstream bytes as the same
+// request with the triggering policy absent. This isolates verdict
+// effects (which observe suppresses) from mechanical transforms (which
+// still run). Exercised against the real pipeline.RunPre downgrade.
+
+// fidelityRequest is a minimal pipeline.ReadOnlyRequest for these tests.
+type fidelityRequest struct{ body []byte }
+
+func (r *fidelityRequest) Provider() conversation.Provider { return conversation.ProviderAnthropic }
+func (r *fidelityRequest) StreamShape() conversation.StreamShape {
+	return conversation.StreamShapeUnknown
+}
+func (r *fidelityRequest) Turns() []conversation.Turn           { return nil }
+func (r *fidelityRequest) HTTPRequest() *http.Request           { return nil }
+func (r *fidelityRequest) RawBody() []byte                      { return append([]byte(nil), r.body...) }
+func (r *fidelityRequest) IsFirstTurn() bool                    { return true }
+func (r *fidelityRequest) ConversationID() string               { return "" }
+func (r *fidelityRequest) UserID() string                       { return "" }
+func (r *fidelityRequest) AgentID() string                      { return "" }
+func (r *fidelityRequest) ValidateReplacementBody([]byte) error { return nil }
+
+// redactingPolicy simulates a non-mechanical policy (e.g. content-policy
+// redaction) that both rewrites the body and returns a deny. Its name is
+// NOT on the observe-exempt allowlist, so observe mode must record it and
+// pass the ORIGINAL bytes through.
+type redactingPolicy struct {
+	name    string
+	newBody []byte
+	deny    bool
+}
+
+func (p *redactingPolicy) Name() string { return p.name }
+func (p *redactingPolicy) Preprocess(_ context.Context, _ pipeline.ReadOnlyRequest, mut pipeline.RequestMutator) (pipeline.RequestVerdict, error) {
+	if len(p.newBody) > 0 {
+		if err := mut.ReplaceBody(p.newBody); err != nil {
+			return pipeline.RequestVerdict{}, err
+		}
+	}
+	v := pipeline.RequestVerdict{Outcome: pipeline.OutcomeAllow, Reason: "would redact"}
+	if p.deny {
+		v.Outcome = pipeline.OutcomeDeny
+	}
+	return v, nil
+}
+
+func TestObserveModePreservesUpstreamBytesVsPolicyAbsent(t *testing.T) {
+	t.Parallel()
+	original := []byte(strings.ReplaceAll(thinkingBodyTemplate, "%s", "hello"))
+	redacted := []byte(strings.ReplaceAll(thinkingBodyTemplate, "%s", "REDACTED"))
+
+	// Control: with the triggering policy ABSENT, the body goes upstream
+	// unchanged.
+	absent, err := pipeline.RunPre(context.Background(), &fidelityRequest{body: original}, nil)
+	if err != nil {
+		t.Fatalf("RunPre (absent): %v", err)
+	}
+
+	// Observe: the SAME request with the enforcing redact policy present
+	// must yield byte-identical upstream bytes to the absent case (the
+	// redaction is recorded, not applied).
+	observed, err := pipeline.RunPre(
+		pipeline.WithObserveMode(context.Background()),
+		&fidelityRequest{body: original},
+		[]pipeline.RequestPolicy{&redactingPolicy{name: "org_content_policy", newBody: redacted}},
+	)
+	if err != nil {
+		t.Fatalf("RunPre (observe): %v", err)
+	}
+	if string(observed.FinalBody) != string(absent.FinalBody) {
+		t.Fatalf("observe mode altered upstream bytes:\n absent:  %s\n observe: %s", absent.FinalBody, observed.FinalBody)
+	}
+	assertThinkingBlockPreserved(t, observed.FinalBody)
+	if len(observed.Observed) != 1 {
+		t.Fatalf("expected the downgraded rewrite to be recorded once; got %d", len(observed.Observed))
+	}
+
+	// Enforce (control): the same policy under enforce DOES apply the
+	// rewrite — proving the fixture actually mutates bytes when not
+	// downgraded.
+	enforced, err := pipeline.RunPre(
+		context.Background(),
+		&fidelityRequest{body: original},
+		[]pipeline.RequestPolicy{&redactingPolicy{name: "org_content_policy", newBody: redacted}},
+	)
+	if err != nil {
+		t.Fatalf("RunPre (enforce): %v", err)
+	}
+	if string(enforced.FinalBody) != string(redacted) {
+		t.Fatal("enforce control should apply the rewrite — fixture is not actually mutating bytes")
+	}
+}
+
+// TestObserveModeDowngradesDenyKeepsBody: a non-mechanical deny under
+// observe is recorded but not enforced (no DenyReason), and the body is
+// untouched.
+func TestObserveModeDowngradesDenyKeepsBody(t *testing.T) {
+	t.Parallel()
+	original := []byte(strings.ReplaceAll(thinkingBodyTemplate, "%s", "hi"))
+	res, err := pipeline.RunPre(
+		pipeline.WithObserveMode(context.Background()),
+		&fidelityRequest{body: original},
+		[]pipeline.RequestPolicy{&redactingPolicy{name: "org_model_policy", deny: true}},
+	)
+	if err != nil {
+		t.Fatalf("RunPre: %v", err)
+	}
+	if res.DenyReason != "" {
+		t.Fatalf("observe must not deny; got DenyReason=%q", res.DenyReason)
+	}
+	if string(res.FinalBody) != string(original) {
+		t.Fatal("observe deny downgrade must leave the body unchanged")
+	}
+	if len(res.Observed) != 1 || res.AuditParams["observed"] != true {
+		t.Fatalf("deny downgrade must be recorded (Observed + audit); got Observed=%d audit=%v", len(res.Observed), res.AuditParams["observed"])
+	}
+}
+
+// TestObserveModeExemptPolicyStillEnforces: a mechanical (exempt) policy
+// still denies in observe mode — malformed-request rejection and other
+// mechanical guards are not governance verdicts.
+func TestObserveModeExemptPolicyStillEnforces(t *testing.T) {
+	t.Parallel()
+	original := []byte(strings.ReplaceAll(thinkingBodyTemplate, "%s", "hi"))
+	res, err := pipeline.RunPre(
+		pipeline.WithObserveMode(context.Background()),
+		&fidelityRequest{body: original},
+		[]pipeline.RequestPolicy{&redactingPolicy{name: "anthropic_sanitize", deny: true}},
+	)
+	if err != nil {
+		t.Fatalf("RunPre: %v", err)
+	}
+	if res.DenyReason == "" {
+		t.Fatal("exempt (mechanical) policy must still deny in observe mode")
+	}
 }
 
 // End-to-end: chain the preprocessors in the same order the request

--- a/internal/runtime/llmproxy/config.go
+++ b/internal/runtime/llmproxy/config.go
@@ -223,6 +223,14 @@ type PostprocessConfig struct {
 	RewriteContext
 	ScriptSessionContext
 	RoutingContext
+
+	// ObserveMode downgrades enforcing tool_use verdicts (block/hold) to
+	// recorded observations under the Observe posture (spec 02 §3): the
+	// verdict is evaluated and audited, but the tool_use passes through
+	// unmodified — no CLAWVISOR_BLOCKED rewrite, no approval hold created.
+	// Mechanical rewrites (resolver redirect, credential placeholder
+	// resolution) still apply. Defaults false (enforce).
+	ObserveMode bool
 }
 
 // PostprocessResult is what postproc.Postprocess +
@@ -233,6 +241,12 @@ type PostprocessResult struct {
 	Rewritten     bool
 	Decisions     []conversation.ToolUseDecisionRecord
 	SkippedReason string
+
+	// ObservedVerdicts lists tool_use verdicts that Observe mode
+	// downgraded to observations (spec 02 §3): the enforcement was NOT
+	// applied. Empty unless ObserveMode was set. The handler records
+	// these on the endpoint_call audit row (observed: true).
+	ObservedVerdicts []ObservedToolUseVerdict
 
 	// AssistantTurn is the upstream's assistant turn the streaming
 	// path captured.
@@ -245,4 +259,13 @@ type PostprocessResult struct {
 	// StreamingResult carries the streaming rewrite metadata (next
 	// content-index, stream IDs, etc.).
 	StreamingResult conversation.StreamingRewriteResult
+}
+
+// ObservedToolUseVerdict is one tool_use verdict Observe mode recorded
+// but did not enforce (spec 02 §3).
+type ObservedToolUseVerdict struct {
+	ToolUseID string
+	ToolName  string
+	Decision  string // "block" | "hold"
+	Reason    string
 }

--- a/internal/runtime/llmproxy/credential_class.go
+++ b/internal/runtime/llmproxy/credential_class.go
@@ -73,11 +73,14 @@ func ClassifyUpstreamCredential(r *http.Request) CredentialClass {
 // non-cvis provider credential, else "".
 func providerBearerToken(r *http.Request) string {
 	auth := strings.TrimSpace(r.Header.Get("Authorization"))
-	const prefix = "Bearer "
-	if !strings.HasPrefix(auth, prefix) {
+	// Parse the scheme case-insensitively: a lowercase `authorization: bearer
+	// sk-ant-oat01-…` is still a bearer credential and must not slip past the
+	// §4c subscription refusal into a silent vault strip-and-inject.
+	scheme, rest, found := strings.Cut(auth, " ")
+	if !found || !strings.EqualFold(scheme, "Bearer") {
 		return ""
 	}
-	token := strings.TrimSpace(auth[len(prefix):])
+	token := strings.TrimSpace(rest)
 	if token == "" || strings.HasPrefix(token, "cvis_") {
 		return ""
 	}

--- a/internal/runtime/llmproxy/credential_class.go
+++ b/internal/runtime/llmproxy/credential_class.go
@@ -1,0 +1,129 @@
+package llmproxy
+
+import (
+	"net/http"
+	"strings"
+)
+
+// CredentialClass classifies the upstream provider credential a client
+// presented on a lite-proxy request. It drives the govern/contain
+// (upstream_auth: vault) carve-out (spec 02 §4c): a recognized org API key is
+// safe to silently strip-and-inject (§4b) because injecting the vault key
+// changes nothing observable, but a subscription/OAuth seat — or any
+// credential not positively recognized as an org API key — must be refused
+// rather than silently rebilled from the user's subscription to org-metered
+// API billing.
+type CredentialClass int
+
+const (
+	// CredentialNone means no client-presented provider credential is
+	// present (the agent authenticated with only its cvis_ token). The
+	// vault path proceeds normally.
+	CredentialNone CredentialClass = iota
+	// CredentialOrgAPIKey is an x-api-key, or an Authorization bearer with a
+	// recognized org API-key prefix (Anthropic sk-ant-api…, OpenAI sk-…).
+	// The ONLY class eligible for silent strip-and-inject.
+	CredentialOrgAPIKey
+	// CredentialSubscription is an Authorization bearer with a Claude
+	// subscription/OAuth prefix (sk-ant-oat01-… access, sk-ant-ort01-…
+	// refresh). Refuse-or-consent.
+	CredentialSubscription
+	// CredentialUnrecognized is any Authorization bearer not positively
+	// recognized as an org API key (opaque/unknown/JWT/future formats).
+	// Fail closed — refuse, because silent inject is only safe for a
+	// recognized org key.
+	CredentialUnrecognized
+)
+
+// ClassifyUpstreamCredential inspects the inbound request's credential
+// headers and returns the class of the client-presented provider credential.
+// It classifies by the credential itself (prefix), never by token shape or a
+// droppable header — the anthropic-beta: oauth-* header is at most a
+// corroborating signal and is deliberately NOT consulted here, so it can
+// neither be dropped to evade detection nor sent alone to force a refusal of
+// a real API-key seat (spec 02 §4c, F2/F3).
+//
+// Agent tokens (cvis_…) are never provider credentials and are ignored.
+func ClassifyUpstreamCredential(r *http.Request) CredentialClass {
+	if r == nil {
+		return CredentialNone
+	}
+	// An Authorization bearer is where a subscription/OAuth token would
+	// live, so classify it first and most strictly.
+	if bearer := providerBearerToken(r); bearer != "" {
+		switch {
+		case isSubscriptionToken(bearer):
+			return CredentialSubscription
+		case isOrgAPIKeyToken(bearer):
+			return CredentialOrgAPIKey
+		default:
+			// Unknown Authorization bearer: fail closed.
+			return CredentialUnrecognized
+		}
+	}
+	// x-api-key (Anthropic SDK convention) carries an API key by definition;
+	// exclude the cvis_ agent token which also rides here.
+	if x := strings.TrimSpace(r.Header.Get("x-api-key")); x != "" && !strings.HasPrefix(x, "cvis_") {
+		return CredentialOrgAPIKey
+	}
+	return CredentialNone
+}
+
+// providerBearerToken returns the bare Authorization bearer token when it is a
+// non-cvis provider credential, else "".
+func providerBearerToken(r *http.Request) string {
+	auth := strings.TrimSpace(r.Header.Get("Authorization"))
+	const prefix = "Bearer "
+	if !strings.HasPrefix(auth, prefix) {
+		return ""
+	}
+	token := strings.TrimSpace(auth[len(prefix):])
+	if token == "" || strings.HasPrefix(token, "cvis_") {
+		return ""
+	}
+	return token
+}
+
+// isSubscriptionToken reports whether a bearer is a Claude subscription /
+// OAuth token. Access tokens are sk-ant-oat01-…, refresh tokens
+// sk-ant-ort01-… — sk-ant--prefixed and opaque, NOT JWT-shaped (spec 02 §4c).
+func isSubscriptionToken(token string) bool {
+	return strings.HasPrefix(token, "sk-ant-oat01-") ||
+		strings.HasPrefix(token, "sk-ant-ort01-")
+}
+
+// isOrgAPIKeyToken reports whether a bearer is a recognized org provider API
+// key: Anthropic sk-ant-api… or OpenAI sk-… (any sk- that is not an
+// sk-ant- subscription/other variant). Unknown sk-ant- variants fall through
+// to unrecognized (fail closed).
+func isOrgAPIKeyToken(token string) bool {
+	if strings.HasPrefix(token, "sk-ant-api") {
+		return true
+	}
+	if strings.HasPrefix(token, "sk-ant-") {
+		// sk-ant-oat01/ort01 handled by isSubscriptionToken; any other
+		// sk-ant- shape is not a recognized API key — fail closed.
+		return false
+	}
+	// OpenAI keys: sk-…, sk-proj-…
+	return strings.HasPrefix(token, "sk-")
+}
+
+// HasClientProviderCredential reports whether the request carries any usable
+// client-presented provider credential (an Authorization bearer that isn't a
+// cvis_ agent token, or a non-cvis x-api-key). Used by passthrough posture to
+// distinguish "passthrough requested but nothing to forward" from a request
+// that legitimately carries the user's own key (spec 02 §4
+// PASSTHROUGH_NO_CREDENTIAL).
+func HasClientProviderCredential(r *http.Request) bool {
+	if r == nil {
+		return false
+	}
+	if providerBearerToken(r) != "" {
+		return true
+	}
+	if x := strings.TrimSpace(r.Header.Get("x-api-key")); x != "" && !strings.HasPrefix(x, "cvis_") {
+		return true
+	}
+	return false
+}

--- a/internal/runtime/llmproxy/credential_class_test.go
+++ b/internal/runtime/llmproxy/credential_class_test.go
@@ -1,0 +1,68 @@
+package llmproxy
+
+import (
+	"net/http"
+	"testing"
+)
+
+func reqWithHeaders(h map[string]string) *http.Request {
+	r, _ := http.NewRequest("POST", "http://x/api/v1/messages", nil)
+	for k, v := range h {
+		r.Header.Set(k, v)
+	}
+	return r
+}
+
+func TestClassifyUpstreamCredential(t *testing.T) {
+	cases := []struct {
+		name    string
+		headers map[string]string
+		want    CredentialClass
+	}{
+		{"no credential", map[string]string{"X-Clawvisor-Agent-Token": "cvis_abc"}, CredentialNone},
+		{"cvis in authorization only", map[string]string{"Authorization": "Bearer cvis_abc"}, CredentialNone},
+		{"cvis in x-api-key only", map[string]string{"x-api-key": "cvis_abc"}, CredentialNone},
+		{"anthropic api key via x-api-key", map[string]string{"x-api-key": "sk-ant-api03-realkey"}, CredentialOrgAPIKey},
+		{"anthropic api key via authorization", map[string]string{"Authorization": "Bearer sk-ant-api03-realkey"}, CredentialOrgAPIKey},
+		{"openai api key via authorization", map[string]string{"Authorization": "Bearer sk-proj-openaikey"}, CredentialOrgAPIKey},
+		{"subscription access token", map[string]string{"Authorization": "Bearer sk-ant-oat01-subscription"}, CredentialSubscription},
+		{"subscription refresh token", map[string]string{"Authorization": "Bearer sk-ant-ort01-refresh"}, CredentialSubscription},
+		{"opaque bearer fails closed", map[string]string{"Authorization": "Bearer some-opaque-token"}, CredentialUnrecognized},
+		{"jwt bearer fails closed", map[string]string{"Authorization": "Bearer eyJhbGc.eyJzdWI.sig"}, CredentialUnrecognized},
+		// F2 reverse: a real API key + stray anthropic-beta oauth header is
+		// STILL an org API key — the header alone never forces refusal.
+		{"api key with oauth beta header not dosed", map[string]string{
+			"Authorization":  "Bearer sk-ant-api03-realkey",
+			"anthropic-beta": "oauth-2025-01-01",
+		}, CredentialOrgAPIKey},
+		// F3: unknown sk-ant- variant that isn't api/oat/ort — fail closed.
+		{"unknown sk-ant variant fails closed", map[string]string{"Authorization": "Bearer sk-ant-xyz01-weird"}, CredentialUnrecognized},
+		// cvis in x-api-key but a real key in Authorization: classify the bearer.
+		{"cvis xapikey + subscription bearer", map[string]string{
+			"x-api-key":     "cvis_abc",
+			"Authorization": "Bearer sk-ant-oat01-sub",
+		}, CredentialSubscription},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ClassifyUpstreamCredential(reqWithHeaders(tc.headers)); got != tc.want {
+				t.Fatalf("ClassifyUpstreamCredential=%d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHasClientProviderCredential(t *testing.T) {
+	if HasClientProviderCredential(reqWithHeaders(map[string]string{"X-Clawvisor-Agent-Token": "cvis_x"})) {
+		t.Fatal("cvis-only request must not count as a provider credential")
+	}
+	if HasClientProviderCredential(reqWithHeaders(map[string]string{"Authorization": "Bearer cvis_x"})) {
+		t.Fatal("cvis bearer must not count as a provider credential")
+	}
+	if !HasClientProviderCredential(reqWithHeaders(map[string]string{"Authorization": "Bearer sk-ant-oat01-sub"})) {
+		t.Fatal("subscription bearer is a provider credential")
+	}
+	if !HasClientProviderCredential(reqWithHeaders(map[string]string{"x-api-key": "sk-ant-api03-k"})) {
+		t.Fatal("x-api-key is a provider credential")
+	}
+}

--- a/internal/runtime/llmproxy/credential_class_test.go
+++ b/internal/runtime/llmproxy/credential_class_test.go
@@ -42,6 +42,11 @@ func TestClassifyUpstreamCredential(t *testing.T) {
 			"x-api-key":     "cvis_abc",
 			"Authorization": "Bearer sk-ant-oat01-sub",
 		}, CredentialSubscription},
+		// Case-insensitive scheme: a lowercase `bearer` prefix on a
+		// subscription token must NOT slip past to CredentialNone (which would
+		// bypass the §4c refusal and get silently vault-injected).
+		{"lowercase bearer scheme subscription", map[string]string{"Authorization": "bearer sk-ant-oat01-sub"}, CredentialSubscription},
+		{"mixed-case bearer scheme org key", map[string]string{"Authorization": "BeArEr sk-ant-api03-realkey"}, CredentialOrgAPIKey},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/runtime/llmproxy/forward.go
+++ b/internal/runtime/llmproxy/forward.go
@@ -120,10 +120,11 @@ type Forwarder struct {
 // or unresponsive upstream can't hold a goroutine forever.
 //
 // Env-var overrides (all optional; production leaves all unset):
-//   CLAWVISOR_LLM_UPSTREAM_ANTHROPIC — replace https://api.anthropic.com
-//   CLAWVISOR_LLM_UPSTREAM_OPENAI    — replace https://api.openai.com
-//   CLAWVISOR_LLM_UPSTREAM_GOOGLE    — replace generativelanguage URL
-//   CLAWVISOR_LLM_UPSTREAM_CHATGPT   — replace chatgpt.com (passthrough OAuth)
+//
+//	CLAWVISOR_LLM_UPSTREAM_ANTHROPIC — replace https://api.anthropic.com
+//	CLAWVISOR_LLM_UPSTREAM_OPENAI    — replace https://api.openai.com
+//	CLAWVISOR_LLM_UPSTREAM_GOOGLE    — replace generativelanguage URL
+//	CLAWVISOR_LLM_UPSTREAM_CHATGPT   — replace chatgpt.com (passthrough OAuth)
 //
 // E2E tests point these at a cassette-backed mock to deterministically
 // replay LLM responses without touching the network.
@@ -217,6 +218,19 @@ func (f *Forwarder) Forward(ctx context.Context, userID, agentID string, provide
 				return f.Client.Do(req)
 			}
 		}
+		// No forwardable Authorization bearer, but the client presented its
+		// own provider API key via x-api-key (Anthropic SDK convention /
+		// Google). The passthrough gate (HasClientProviderCredential) accepts
+		// x-api-key, so forward THAT key upstream — never fall through to the
+		// vault key, which would be the implicit vault fallback the passthrough
+		// posture forbids (spec 02 §4). injectUpstreamAuth maps the raw key to
+		// the correct per-provider header (x-api-key / Bearer / x-goog-api-key).
+		if key := passthroughClientAPIKey(inbound); key != "" {
+			if err := injectUpstreamAuth(req, provider, []byte(key)); err != nil {
+				return nil, err
+			}
+			return f.Client.Do(req)
+		}
 	}
 
 	keyBytes, serviceID, err := f.lookupVaultKey(ctx, userID, agentID, provider)
@@ -297,6 +311,22 @@ func injectUpstreamAuth(req *http.Request, provider conversation.Provider, key [
 		return fmt.Errorf("llmproxy: unknown provider %q", provider)
 	}
 	return nil
+}
+
+// passthroughClientAPIKey returns the client-presented x-api-key when it is a
+// real provider key (not the cvis_ agent token), else "". Passthrough posture
+// forwards this upstream so an x-api-key-only request (no Authorization bearer)
+// never falls through to the vault key (spec 02 §4). Mirrors the x-api-key
+// branch of HasClientProviderCredential, which is what gated the request in.
+func passthroughClientAPIKey(inbound *http.Request) string {
+	if inbound == nil {
+		return ""
+	}
+	key := strings.TrimSpace(inbound.Header.Get("x-api-key"))
+	if key == "" || strings.HasPrefix(key, "cvis_") {
+		return ""
+	}
+	return key
 }
 
 func passthroughBearerAuthorization(inbound *http.Request) string {

--- a/internal/runtime/llmproxy/forward_test.go
+++ b/internal/runtime/llmproxy/forward_test.go
@@ -151,6 +151,81 @@ func TestForward_AnthropicPassthroughAuthPreservesOAuthAuthorization(t *testing.
 	}
 }
 
+// TestForward_AnthropicPassthroughForwardsClientXAPIKey covers the
+// x-api-key-only passthrough case: the client presented its own Anthropic key
+// via x-api-key (the SDK convention) and NO Authorization bearer. Passthrough
+// posture must forward that key upstream — never fall through to lookupVaultKey
+// (the implicit vault fallback spec 02 §4 forbids). The vault is empty here, so
+// a fallthrough would surface UPSTREAM_KEY_MISSING instead of forwarding.
+func TestForward_AnthropicPassthroughForwardsClientXAPIKey(t *testing.T) {
+	v := &stubVault{} // deliberately empty: any vault fallback would error
+
+	var seenAuth, seenAPIKey string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenAuth = r.Header.Get("Authorization")
+		seenAPIKey = r.Header.Get("x-api-key")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"msg_1"}`))
+	}))
+	defer upstream.Close()
+
+	f := NewForwarder(v)
+	f.Upstream = UpstreamSelector{AnthropicBaseURL: upstream.URL}
+
+	inbound := httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader([]byte(`{"model":"claude"}`)))
+	inbound.Header.Set("x-api-key", "sk-ant-api03-clientkey")
+
+	ctx := WithPassthroughUpstreamAuth(context.Background())
+	resp, err := f.Forward(ctx, "user1", "", conversation.ProviderAnthropic, inbound, []byte(`{"model":"claude"}`))
+	if err != nil {
+		t.Fatalf("Forward: %v (expected the client x-api-key to be forwarded, not a vault fallback)", err)
+	}
+	defer resp.Body.Close()
+
+	if seenAPIKey != "sk-ant-api03-clientkey" {
+		t.Fatalf("expected upstream x-api-key to be the client key sk-ant-api03-clientkey, got %q", seenAPIKey)
+	}
+	if seenAuth != "" {
+		t.Fatalf("expected no upstream Authorization header, got %q", seenAuth)
+	}
+}
+
+// TestForward_GooglePassthroughForwardsClientXAPIKey covers the x-api-key-only
+// passthrough case for Google: injectUpstreamAuth maps the forwarded key onto
+// x-goog-api-key. Again the vault is empty, so a fallthrough would error.
+func TestForward_GooglePassthroughForwardsClientXAPIKey(t *testing.T) {
+	v := &stubVault{}
+
+	var seenGoogleAPIKey, seenAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenGoogleAPIKey = r.Header.Get("x-goog-api-key")
+		seenAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer upstream.Close()
+
+	f := NewForwarder(v)
+	f.Upstream = UpstreamSelector{GoogleBaseURL: upstream.URL}
+
+	inbound := httptest.NewRequest(http.MethodPost, "/v1beta/models/gemini:generateContent", strings.NewReader("{}"))
+	inbound.Header.Set("x-api-key", "client-google-key")
+
+	ctx := WithPassthroughUpstreamAuth(context.Background())
+	resp, err := f.Forward(ctx, "user1", "", conversation.ProviderGoogle, inbound, []byte("{}"))
+	if err != nil {
+		t.Fatalf("Forward: %v (expected the client x-api-key to be forwarded, not a vault fallback)", err)
+	}
+	defer resp.Body.Close()
+
+	if seenGoogleAPIKey != "client-google-key" {
+		t.Fatalf("expected upstream x-goog-api-key to be the client key, got %q", seenGoogleAPIKey)
+	}
+	if seenAuth != "" {
+		t.Fatalf("expected no upstream Authorization header, got %q", seenAuth)
+	}
+}
+
 func TestForward_OpenAIInjectsKey(t *testing.T) {
 	v := &stubVault{}
 	v.Set(context.Background(), "user1", "openai", []byte("sk-real-openai-key"))

--- a/internal/runtime/llmproxy/pipeline/observe.go
+++ b/internal/runtime/llmproxy/pipeline/observe.go
@@ -1,0 +1,94 @@
+package pipeline
+
+import "context"
+
+// Observe-posture enforcement downgrade (spec 02 §3).
+//
+// In the Observe posture the pipeline runs in full — inspection,
+// attribution, audit, cost — but every ENFORCING verdict a policy
+// returns (deny, approval hold / short-circuit, or a policy body
+// rewrite) is recorded as an observation and then neutralized so the
+// request/response proceeds exactly as if the policy had allowed it.
+// Mechanical policies (parsing/sanitization, history strip, control-tool
+// and notice injection, placeholder / credential resolution) are NOT
+// enforcement and keep acting normally — otherwise byte-fidelity and
+// prompt-cache warmth break. Classification is by policy Name(), not by
+// outcome, because the same OutcomeRewrite can be a mechanical transform
+// or a policy redaction.
+//
+// The mode is threaded through context so every runSinglePolicy call
+// site inherits it from the request context without a signature change.
+
+type observeModeCtxKey struct{}
+
+// WithObserveMode marks ctx so RunPre / EvaluateToolUses downgrade
+// enforcing verdicts to observations instead of enforcing them.
+func WithObserveMode(ctx context.Context) context.Context {
+	return context.WithValue(ctx, observeModeCtxKey{}, true)
+}
+
+// ObserveModeFromContext reports whether ctx carries the Observe-posture
+// downgrade flag.
+func ObserveModeFromContext(ctx context.Context) bool {
+	v, _ := ctx.Value(observeModeCtxKey{}).(bool)
+	return v
+}
+
+// observeExemptPolicies lists the pre-phase policy Name() strings that
+// STILL act in Observe mode because they are mechanical, not
+// enforcement. Everything not in this set has its deny / short-circuit /
+// body-rewrite downgraded to a recorded observation.
+//
+// Classification (spec 02 §3 deliverable — enumerated in the PR):
+//
+//	MECHANICAL (exempt — run normally):
+//	  anthropic_sanitize     request parse/normalize; its "deny" is a
+//	                         malformed-body client bug, not a verdict
+//	  inbound_sanitize       strips rewriter transport details from history
+//	  synthetic_history_strip prompt-cache-preserving history reconstruction
+//	  secret_history_strip   history hygiene
+//	  secret_rewrites        vault placeholder / credential resolution
+//	  control_notice         notice injection
+//	  inline_task_augment    history augmentation
+//	  approval_release       resolves an in-flight hold (no hold exists in observe)
+//	  task_approval_reply    processes an approval reply (control-flow)
+//	  control_tool_use       control-tool handling
+//	  credential_rewrite     resolver/credential input rewrite
+//	  pass_through           no-op
+//	  script_session         cv-script session bookkeeping
+//	  inspector              observation channel (never enforces on its own)
+//
+//	ENFORCING (downgraded in observe):
+//	  org_model_policy, org_spend_cap_policy, org_content_policy
+//	  inline_task_intercept  (approval hold short-circuit)
+//	  task_scope, intent_verify, boundary_check, authorization,
+//	  pending_approval_hold, secret_hold
+var observeExemptPolicies = map[string]bool{
+	"anthropic_sanitize":      true,
+	"inbound_sanitize":        true,
+	"synthetic_history_strip": true,
+	"secret_history_strip":    true,
+	"secret_rewrites":         true,
+	"control_notice":          true,
+	"inline_task_augment":     true,
+	"approval_release":        true,
+	"task_approval_reply":     true,
+	"control_tool_use":        true,
+	"credential_rewrite":      true,
+	"pass_through":            true,
+	"script_session":          true,
+	"inspector":               true,
+}
+
+// observeExempt reports whether policyName still acts in Observe mode.
+func observeExempt(policyName string) bool {
+	return observeExemptPolicies[policyName]
+}
+
+// ObservedVerdict records one enforcing verdict that Observe mode
+// downgraded to an observation, for the handler's audit row.
+type ObservedVerdict struct {
+	Policy  string
+	Outcome string
+	Reason  string
+}

--- a/internal/runtime/llmproxy/pipeline/observe.go
+++ b/internal/runtime/llmproxy/pipeline/observe.go
@@ -48,6 +48,11 @@ func ObserveModeFromContext(ctx context.Context) bool {
 //	  synthetic_history_strip prompt-cache-preserving history reconstruction
 //	  secret_history_strip   history hygiene
 //	  secret_rewrites        vault placeholder / credential resolution
+//	  secret_decision        applies the user's chosen secret action
+//	                         (allow_once/discard/vault/not_secret); a
+//	                         control-flow reply-processor, not a verdict —
+//	                         parallels approval_release / task_approval_reply.
+//	                         Its enforcing counterpart is secret_hold below.
 //	  control_notice         notice injection
 //	  inline_task_augment    history augmentation
 //	  approval_release       resolves an in-flight hold (no hold exists in observe)
@@ -69,6 +74,7 @@ var observeExemptPolicies = map[string]bool{
 	"synthetic_history_strip": true,
 	"secret_history_strip":    true,
 	"secret_rewrites":         true,
+	"secret_decision":         true,
 	"control_notice":          true,
 	"inline_task_augment":     true,
 	"approval_release":        true,

--- a/internal/runtime/llmproxy/pipeline/orchestrator.go
+++ b/internal/runtime/llmproxy/pipeline/orchestrator.go
@@ -43,6 +43,13 @@ type PreResult struct {
 
 	// DeniedBy names which policy triggered the Deny (audit forensics).
 	DeniedBy string
+
+	// Observed lists every enforcing verdict that the Observe posture
+	// downgraded to an observation on this chain (spec 02 §3). Empty
+	// unless the request context carried WithObserveMode. When non-empty
+	// the enforcement was NOT applied: DenyReason / ShortCircuit stay
+	// clear and any non-mechanical body rewrite was rolled back.
+	Observed []ObservedVerdict
 }
 
 // PolicyVerdict pairs a policy name with the verdict it returned.
@@ -82,19 +89,20 @@ func RunPre(ctx context.Context, req ReadOnlyRequest, policies []RequestPolicy) 
 	// mutations land.
 	wrapper := &mutatingRequestWrapper{base: req, body: mut.Body()}
 
+	// Observe posture (spec 02 §3): downgrade enforcing verdicts from
+	// non-mechanical policies to recorded observations. observeBody holds
+	// the body as it stood before each policy ran, so a downgraded policy
+	// body rewrite can be rolled back (byte-fidelity).
+	observeMode := ObserveModeFromContext(ctx)
+
 	for _, policy := range policies {
+		bodyBefore := mut.Body()
 		verdict, err := policy.Preprocess(ctx, wrapper, mut)
 		if err != nil {
 			result.FinalBody = mut.Body()
 			return result, fmt.Errorf("policy %q: %w", policy.Name(), err)
 		}
 		result.Verdicts = append(result.Verdicts, PolicyVerdict{Name: policy.Name(), Verdict: verdict})
-
-		// Emit the pipeline.verdicts metric + a policy.verdict span event.
-		// outcome is mapped through DecisionFromOutcome so all six Outcome
-		// values collapse to the coarse audit decision (allow/block/rewrite).
-		observability.RecordPolicyVerdict(ctx, policy.Name(),
-			string(DecisionFromOutcome(verdict.Outcome)), "pre", verdict.Reason)
 
 		switch verdict.Outcome {
 		case OutcomeDeny, OutcomeAllow, OutcomeSkip:
@@ -109,9 +117,35 @@ func RunPre(ctx context.Context, req ReadOnlyRequest, policies []RequestPolicy) 
 			return nil, fmt.Errorf("policy %q returned unsupported outcome %q for RunPre", policy.Name(), verdict.Outcome)
 		}
 
+		// Decide whether Observe mode neutralizes this verdict: only
+		// enforcing verdicts (deny / short-circuit / a body rewrite) from
+		// NON-mechanical policies are downgraded. Mechanical policies keep
+		// acting so byte-fidelity and prompt-cache warmth are preserved.
+		downgrade := observeMode && !observeExempt(policy.Name())
+		enforcingRewrite := downgrade && mut.BodyReplaced() && !bytesEqual(mut.Body(), bodyBefore)
+		enforcingVerdict := downgrade && (verdict.Outcome == OutcomeDeny || verdict.Outcome == OutcomeShortCircuit)
+
+		// Emit the pipeline.verdicts metric + a policy.verdict span event.
+		// outcome is mapped through DecisionFromOutcome so all six Outcome
+		// values collapse to the coarse audit decision (allow/block/rewrite).
+		// A downgraded verdict is tagged observed="true".
+		observability.RecordPolicyVerdictObserved(ctx, policy.Name(),
+			string(DecisionFromOutcome(verdict.Outcome)), "pre", verdict.Reason,
+			enforcingVerdict || enforcingRewrite)
+
 		// Merge audit fields regardless of outcome.
 		for k, v := range verdict.AuditParams {
 			result.AuditParams[k] = v
+		}
+
+		if enforcingRewrite {
+			// Roll the body back to before this policy's rewrite so the
+			// intended redaction is recorded but NOT applied.
+			_ = mut.ReplaceBody(bodyBefore)
+			result.Observed = append(result.Observed, ObservedVerdict{
+				Policy: policy.Name(), Outcome: string(DecisionFromOutcome(verdict.Outcome)), Reason: verdict.Reason,
+			})
+			result.AuditParams["observed"] = true
 		}
 
 		// Refresh the wrapper's body view in case the policy queued a
@@ -121,11 +155,27 @@ func RunPre(ctx context.Context, req ReadOnlyRequest, policies []RequestPolicy) 
 
 		switch verdict.Outcome {
 		case OutcomeDeny:
+			if enforcingVerdict {
+				// Record the would-be deny and continue the chain as allow.
+				result.Observed = append(result.Observed, ObservedVerdict{
+					Policy: policy.Name(), Outcome: string(DecisionFromOutcome(verdict.Outcome)), Reason: verdict.Reason,
+				})
+				result.AuditParams["observed"] = true
+				continue
+			}
 			result.DenyReason = verdict.Reason
 			result.DeniedBy = policy.Name()
 			result.FinalBody = mut.Body()
 			return result, nil
 		case OutcomeShortCircuit:
+			if enforcingVerdict {
+				// Record the would-be hold/short-circuit; no held state is
+				// created and no synthetic response is returned.
+				result.Observed = append(result.Observed, ObservedVerdict{
+					Policy: policy.Name(), Outcome: string(DecisionFromOutcome(verdict.Outcome)), Reason: verdict.Reason,
+				})
+				continue
+			}
 			result.ShortCircuit = verdict.ShortCircuit
 			result.FinalBody = mut.Body()
 			return result, nil
@@ -136,6 +186,19 @@ func RunPre(ctx context.Context, req ReadOnlyRequest, policies []RequestPolicy) 
 
 	result.FinalBody = mut.Body()
 	return result, nil
+}
+
+// bytesEqual reports byte equality without importing bytes for one call.
+func bytesEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // mutatingRequestWrapper presents a ReadOnlyRequest whose RawBody()

--- a/internal/runtime/llmproxy/pipeline/orchestrator.go
+++ b/internal/runtime/llmproxy/pipeline/orchestrator.go
@@ -174,6 +174,7 @@ func RunPre(ctx context.Context, req ReadOnlyRequest, policies []RequestPolicy) 
 				result.Observed = append(result.Observed, ObservedVerdict{
 					Policy: policy.Name(), Outcome: string(DecisionFromOutcome(verdict.Outcome)), Reason: verdict.Reason,
 				})
+				result.AuditParams["observed"] = true
 				continue
 			}
 			result.ShortCircuit = verdict.ShortCircuit

--- a/internal/runtime/llmproxy/pipeline/orchestrator_test.go
+++ b/internal/runtime/llmproxy/pipeline/orchestrator_test.go
@@ -273,6 +273,42 @@ func TestRunPre_HaltsOnShortCircuit(t *testing.T) {
 	}
 }
 
+// TestRunPre_ObserveDowngradesShortCircuit verifies that under Observe mode a
+// non-exempt policy's OutcomeShortCircuit is downgraded to a recorded
+// observation: ShortCircuit stays nil, the chain continues, the Observed trail
+// captures it, AND AuditParams["observed"] is stamped true (parity with the
+// deny and body-rewrite downgrade paths, so the endpoint audit row can render
+// the observed badge).
+func TestRunPre_ObserveDowngradesShortCircuit(t *testing.T) {
+	after := &bodyObservingPolicy{name: "runs_after"}
+	policies := []pipeline.RequestPolicy{
+		&allowingPolicy{name: "first", field: "first_ran", value: true},
+		// "secret_hold" is an enforcing (non-exempt) policy whose
+		// short-circuit is a would-be approval hold.
+		&shortCircuitingPolicy{name: "secret_hold", body: []byte(`{"synthetic":true}`)},
+		after,
+	}
+
+	req := &orchTestRequest{provider: conversation.ProviderAnthropic, body: []byte(`{}`)}
+	result, err := pipeline.RunPre(pipeline.WithObserveMode(context.Background()), req, policies)
+	if err != nil {
+		t.Fatalf("RunPre: %v", err)
+	}
+
+	if result.ShortCircuit != nil {
+		t.Fatalf("observe mode must not apply the short-circuit; got %q", result.ShortCircuit.Body)
+	}
+	if after.seen == nil {
+		t.Fatalf("observe mode must continue the chain past a downgraded short-circuit")
+	}
+	if len(result.Observed) != 1 || result.Observed[0].Policy != "secret_hold" {
+		t.Fatalf("expected the short-circuit recorded in Observed, got %+v", result.Observed)
+	}
+	if result.AuditParams["observed"] != true {
+		t.Fatalf("expected AuditParams[observed]=true on a downgraded short-circuit, got %v", result.AuditParams["observed"])
+	}
+}
+
 // TestRunPre_PropagatesPolicyError verifies that a policy returning a
 // Go error halts the chain with the wrapped error.
 func TestRunPre_PropagatesPolicyError(t *testing.T) {

--- a/internal/runtime/llmproxy/postproc/postproc.go
+++ b/internal/runtime/llmproxy/postproc/postproc.go
@@ -5,9 +5,54 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/clawvisor/clawvisor/internal/observability"
 	"github.com/clawvisor/clawvisor/internal/runtime/conversation"
 	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy"
 )
+
+// applyObserveDowngrade neutralizes enforcing tool_use verdicts under
+// the Observe posture (spec 02 §3). It runs AFTER the eval pass (so the
+// evaluators' own audit rows are already buffered) and BEFORE commit /
+// rewrite (so no hold is stored and no CLAWVISOR_BLOCKED rewrite lands).
+//
+// Every non-allowed verdict (a block or an approval hold) is recorded on
+// the verdict metric + a tooluse.verdict span event with observed=true,
+// then replaced with a plain allow so the original tool_use passes
+// through byte-for-byte. Verdicts that are already Allowed (pass-through
+// and mechanical resolver/credential rewrites) are left untouched.
+func applyObserveDowngrade(ctx context.Context, cfg llmproxy.PostprocessConfig, verdictByTU map[string]conversation.ToolUseVerdict, toolUses []conversation.ToolUse) []llmproxy.ObservedToolUseVerdict {
+	if !cfg.ObserveMode {
+		return nil
+	}
+	nameByID := make(map[string]string, len(toolUses))
+	for _, tu := range toolUses {
+		nameByID[tu.ID] = tu.Name
+	}
+	seen := make(map[string]bool, len(toolUses))
+	var observed []llmproxy.ObservedToolUseVerdict
+	for _, tu := range toolUses {
+		if seen[tu.ID] {
+			continue
+		}
+		seen[tu.ID] = true
+		v, ok := verdictByTU[tu.ID]
+		if !ok || v.Allowed {
+			continue
+		}
+		decision := "block"
+		if v.HeldKindHint == conversation.HeldKindHintApproval ||
+			v.Outcome == conversation.OutcomeHold ||
+			v.Outcome == conversation.OutcomeShortCircuit {
+			decision = "hold"
+		}
+		observed = append(observed, llmproxy.ObservedToolUseVerdict{
+			ToolUseID: tu.ID, ToolName: nameByID[tu.ID], Decision: decision, Reason: v.Reason,
+		})
+		observability.RecordToolUseVerdictObserved(ctx, tu.Name, decision, v.Reason, true)
+		verdictByTU[tu.ID] = conversation.ToolUseVerdict{Allowed: true, Outcome: conversation.OutcomeAllow}
+	}
+	return observed
+}
 
 // Postprocess inspects, rewrites, and audits the upstream response.
 // The pipeline factory (registered via pipelineeval) drives per-tool
@@ -85,6 +130,10 @@ func Postprocess(req *http.Request, body []byte, contentType string, cfg llmprox
 		return failClosed("rewriter error during tool_use extraction: " + collectorErr.Error())
 	}
 
+	// Observe posture: downgrade enforcing verdicts to observations
+	// before commit so no hold is stored and no block is rewritten.
+	observedVerdicts := applyObserveDowngrade(ctx, cfg, verdictByTU, preExtracted)
+
 	if commitErr := session.commitVerdictSideEffects(ctx, verdictByTU, preExtracted); commitErr != nil {
 		return failClosed("verdict side-effect commit failed: " + commitErr.Error())
 	}
@@ -129,10 +178,11 @@ func Postprocess(req *http.Request, body []byte, contentType string, cfg llmprox
 		coalescedResult, coalescedErr := rewriter.Rewrite(body, contentType, coalescedEval)
 		if coalescedErr == nil {
 			return llmproxy.PostprocessResult{
-				Body:        coalescedResult.Body,
-				ContentType: contentType,
-				Rewritten:   true,
-				Decisions:   coalescedResult.Decisions,
+				Body:             coalescedResult.Body,
+				ContentType:      contentType,
+				Rewritten:        true,
+				Decisions:        coalescedResult.Decisions,
+				ObservedVerdicts: observedVerdicts,
 			}
 		}
 		dropErr := session.dropCommittedAndRollback(ctx, finalResult.CoalescedCapture)
@@ -144,10 +194,11 @@ func Postprocess(req *http.Request, body []byte, contentType string, cfg llmprox
 	}
 
 	return llmproxy.PostprocessResult{
-		Body:        result.Body,
-		ContentType: contentType,
-		Rewritten:   result.Rewritten,
-		Decisions:   result.Decisions,
+		Body:             result.Body,
+		ContentType:      contentType,
+		Rewritten:        result.Rewritten,
+		Decisions:        result.Decisions,
+		ObservedVerdicts: observedVerdicts,
 	}
 }
 

--- a/internal/runtime/llmproxy/postproc/postproc.go
+++ b/internal/runtime/llmproxy/postproc/postproc.go
@@ -20,7 +20,7 @@ import (
 // then replaced with a plain allow so the original tool_use passes
 // through byte-for-byte. Verdicts that are already Allowed (pass-through
 // and mechanical resolver/credential rewrites) are left untouched.
-func applyObserveDowngrade(ctx context.Context, cfg llmproxy.PostprocessConfig, verdictByTU map[string]conversation.ToolUseVerdict, toolUses []conversation.ToolUse) []llmproxy.ObservedToolUseVerdict {
+func applyObserveDowngrade(ctx context.Context, cfg llmproxy.PostprocessConfig, verdictByTU map[string]conversation.ToolUseVerdict, toolUses []conversation.ToolUse, holdSink *capturedHoldSink) []llmproxy.ObservedToolUseVerdict {
 	if !cfg.ObserveMode {
 		return nil
 	}
@@ -29,6 +29,7 @@ func applyObserveDowngrade(ctx context.Context, cfg llmproxy.PostprocessConfig, 
 		nameByID[tu.ID] = tu.Name
 	}
 	seen := make(map[string]bool, len(toolUses))
+	downgraded := make(map[string]bool, len(toolUses))
 	var observed []llmproxy.ObservedToolUseVerdict
 	for _, tu := range toolUses {
 		if seen[tu.ID] {
@@ -50,8 +51,35 @@ func applyObserveDowngrade(ctx context.Context, cfg llmproxy.PostprocessConfig, 
 		})
 		observability.RecordToolUseVerdictObserved(ctx, tu.Name, decision, v.Reason, true)
 		verdictByTU[tu.ID] = conversation.ToolUseVerdict{Allowed: true, Outcome: conversation.OutcomeAllow}
+		downgraded[tu.ID] = true
+	}
+	// Drop the captured approval holds for every downgraded tool_use.
+	// Rewriting verdictByTU alone is not enough: the eval pass already
+	// buffered these Hold() calls in holdSink, and finalize →
+	// feedFinalizer keys the finalizer's SubmitHold replay off the
+	// captured Payload (not the verdict Kind). Leaving the payloads in
+	// place would persist held state that Observe mode (spec 02 §3)
+	// forbids. The observation record above is preserved.
+	if holdSink != nil && len(downgraded) > 0 {
+		dropObservedHolds(holdSink, downgraded)
 	}
 	return observed
+}
+
+// dropObservedHolds removes the buffered Hold() captures for the given
+// downgraded tool_use IDs so the finalizer's replay skips them (nil
+// Payload). The tool_use capture itself is still emitted by
+// feedFinalizer for coalesce/audit rendering — only the hold submission
+// is suppressed.
+func dropObservedHolds(holdSink *capturedHoldSink, downgraded map[string]bool) {
+	kept := holdSink.holds[:0]
+	for _, h := range holdSink.holds {
+		if downgraded[h.Pending.ToolUse.ID] {
+			continue
+		}
+		kept = append(kept, h)
+	}
+	holdSink.holds = kept
 }
 
 // Postprocess inspects, rewrites, and audits the upstream response.
@@ -132,7 +160,7 @@ func Postprocess(req *http.Request, body []byte, contentType string, cfg llmprox
 
 	// Observe posture: downgrade enforcing verdicts to observations
 	// before commit so no hold is stored and no block is rewritten.
-	observedVerdicts := applyObserveDowngrade(ctx, cfg, verdictByTU, preExtracted)
+	observedVerdicts := applyObserveDowngrade(ctx, cfg, verdictByTU, preExtracted, session.holdSink)
 
 	if commitErr := session.commitVerdictSideEffects(ctx, verdictByTU, preExtracted); commitErr != nil {
 		return failClosed("verdict side-effect commit failed: " + commitErr.Error())

--- a/internal/runtime/llmproxy/postproc/postprocess_test.go
+++ b/internal/runtime/llmproxy/postproc/postprocess_test.go
@@ -1693,6 +1693,80 @@ func TestPostprocess_ObservePostureDoesNotBlockToolDenyRule(t *testing.T) {
 	}
 }
 
+// TestPostprocess_ObservePostureDoesNotCommitApprovalHold guards the
+// finalize-side hold leak: applyObserveDowngrade rewrites verdictByTU to
+// Allow, but the eval pass already buffered the review rule's Hold() call in
+// the session hold sink. If those captured payloads aren't dropped, finalize →
+// feedFinalizer → replay still calls SubmitHold and persists held state that
+// Observe mode (spec 02 §3) forbids. Assert zero holds land in the cache while
+// the observation is still recorded.
+func TestPostprocess_ObservePostureDoesNotCommitApprovalHold(t *testing.T) {
+	body := anthropicJSONWithToolUse(`{"url":"https://example.com/one"}`)
+	req := httptest.NewRequest("POST", "/v1/messages", nil)
+	insp := inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{})
+	st, userID, agentID := seedPostprocessStore(t, "autovault_github_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
+	cache := llmproxy.NewMemoryPendingApprovalCache(time.Minute)
+
+	got := Postprocess(req, body, "application/json", llmproxy.PostprocessConfig{
+		ToolUseEvaluatorFactory: pipelineFactory,
+		ObserveMode:             true,
+		AgentContext: llmproxy.AgentContext{
+			AgentUserID: userID,
+			AgentID:     agentID,
+		},
+		AuthorizationContext: llmproxy.AuthorizationContext{
+			// Mirror production: the decision layer always runs PostureEnforce
+			// (liteProxyDecisionPosture), so the evaluator emits a real hold
+			// verdict + Hold() capture; Observe lives only in the postproc
+			// ObserveMode flag. This is the exact combination that triggers the
+			// finalize-side hold leak.
+			Posture:        runtimedecision.PostureEnforce,
+			CandidateTasks: []*store.Task{},
+			ToolRules: []*store.RuntimePolicyRule{{
+				ID:       "review-webfetch",
+				UserID:   userID,
+				AgentID:  &agentID,
+				Kind:     "tool",
+				Action:   "review",
+				ToolName: "WebFetch",
+				Reason:   "review web fetch",
+				Enabled:  true,
+			}},
+			EgressRules: []*store.RuntimePolicyRule{},
+		},
+		ApprovalContext: llmproxy.ApprovalContext{
+			PendingApprovals: cache,
+		},
+		RewriteContext: llmproxy.RewriteContext{
+			Inspector:    insp,
+			RewriteOpts:  inspector.DefaultRewriteOpts("https://proxy.example/api/proxy"),
+			CallerNonces: llmproxy.NewMemoryCallerNonceCache(time.Minute),
+			Store:        st,
+		},
+		RoutingContext: llmproxy.RoutingContext{
+			ResponseRegistry: conversation.DefaultResponseRegistry(),
+		},
+	})
+
+	// The captured hold must NOT be committed: Observe mode records the
+	// verdict but stores no held state.
+	holds := cache.SnapshotHoldsForTest(userID, agentID, conversation.ProviderAnthropic)
+	if len(holds) != 0 {
+		t.Fatalf("observe mode must not commit approval holds, got %d: %+v", len(holds), holds)
+	}
+	// The observation is still recorded so the audit row can render it.
+	if len(got.ObservedVerdicts) != 1 {
+		t.Fatalf("expected exactly one observed verdict, got %d: %+v", len(got.ObservedVerdicts), got.ObservedVerdicts)
+	}
+	if got.ObservedVerdicts[0].Decision != "hold" {
+		t.Fatalf("expected observed decision 'hold', got %q", got.ObservedVerdicts[0].Decision)
+	}
+	// The original tool_use passes through — no coalesced approval prompt.
+	if strings.Contains(string(got.Body), "paused this turn for approval") {
+		t.Fatalf("observe mode must not emit an approval prompt: %s", got.Body)
+	}
+}
+
 func TestPostprocess_JSONRewritesAutovaultURL(t *testing.T) {
 	input := `{"url":"https://api.github.com/repos/x/y/issues","method":"POST","headers":{"Authorization":"Bearer autovault_github_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}}`
 	body := anthropicJSONWithToolUse(input)

--- a/internal/runtime/llmproxy/postproc/stream.go
+++ b/internal/runtime/llmproxy/postproc/stream.go
@@ -117,6 +117,16 @@ func PostprocessStream(
 		verdictByTU[tu.ID] = v
 	}
 
+	// Observe posture: downgrade enforcing verdicts to observations
+	// before commit. Sync the positional slice from the (downgraded) map
+	// so the streaming rewrite emits the original tool_use unmodified.
+	observedVerdicts := applyObserveDowngrade(req.Context(), cfg, verdictByTU, toolUses)
+	if cfg.ObserveMode {
+		for i, tu := range toolUses {
+			verdicts[i] = verdictByTU[tu.ID]
+		}
+	}
+
 	if commitErr := session.commitVerdictSideEffects(req.Context(), verdictByTU, toolUses); commitErr != nil {
 		session.rollback(req.Context(), toolUses, verdictByTU)
 		return llmproxy.PostprocessResult{
@@ -230,9 +240,10 @@ func PostprocessStream(
 	}
 
 	return llmproxy.PostprocessResult{
-		ContentType: contentType,
-		Rewritten:   anyRewritten || anyBlocked,
-		Decisions:   decisions,
+		ContentType:      contentType,
+		Rewritten:        anyRewritten || anyBlocked,
+		Decisions:        decisions,
+		ObservedVerdicts: observedVerdicts,
 	}, nil
 }
 

--- a/internal/runtime/llmproxy/postproc/stream.go
+++ b/internal/runtime/llmproxy/postproc/stream.go
@@ -120,7 +120,7 @@ func PostprocessStream(
 	// Observe posture: downgrade enforcing verdicts to observations
 	// before commit. Sync the positional slice from the (downgraded) map
 	// so the streaming rewrite emits the original tool_use unmodified.
-	observedVerdicts := applyObserveDowngrade(req.Context(), cfg, verdictByTU, toolUses)
+	observedVerdicts := applyObserveDowngrade(req.Context(), cfg, verdictByTU, toolUses, session.holdSink)
 	if cfg.ObserveMode {
 		for i, tu := range toolUses {
 			verdicts[i] = verdictByTU[tu.ID]

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -520,7 +520,10 @@ func stepPosture(cfg *config) error {
 	fmt.Println(section.Render("── Agent Connection ───────────────────────"))
 	fmt.Println()
 
-	var choice string
+	// Default remains the skill gateway: huh preselects the first option, so
+	// initialize choice to "gateway" (not "") so pressing Enter writes the
+	// stated default rather than the first-listed "observe" option.
+	choice := "gateway"
 	err := huh.NewForm(
 		huh.NewGroup(
 			huh.NewSelect[string]().

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -13,8 +13,12 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	tuiconfig "github.com/clawvisor/clawvisor/internal/tui/config"
+	cfgpkg "github.com/clawvisor/clawvisor/pkg/config"
 	"github.com/clawvisor/clawvisor/pkg/haikuproxy"
 )
+
+// configWriterSchema is the schema marker every wizard-written config carries.
+const configWriterSchema = cfgpkg.CurrentConfigSchema
 
 var (
 	bold    = lipgloss.NewStyle().Bold(true)
@@ -53,6 +57,14 @@ type config struct {
 
 	taskRiskEnabled     bool
 	chainContextEnabled bool
+
+	// posture, when set (currently only "observe"), selects the posture
+	// preset written to config. Empty means "skill gateway only" — the
+	// current default. proxyLiteEnabled + proxyLitePublicURL are the
+	// explicit proxy_lite knobs writeConfig always emits (schema 2).
+	posture            string
+	proxyLiteEnabled   bool
+	proxyLitePublicURL string
 
 	telemetryEnabled bool
 
@@ -161,6 +173,9 @@ func runSetup() (*config, error) {
 		return nil, err
 	}
 	if err := stepLLM(cfg); err != nil {
+		return nil, err
+	}
+	if err := stepPosture(cfg); err != nil {
 		return nil, err
 	}
 	if err := stepTelemetry(cfg); err != nil {
@@ -495,6 +510,63 @@ func stepLLM(cfg *config) error {
 	).Run()
 }
 
+// stepPosture asks how agents connect. Today the default remains the skill
+// gateway (option 2); the flip item (§13 item 8) later changes only the
+// recommended default here. Choosing Observe writes posture: observe plus an
+// explicit proxy_lite block. Either way writeConfig stamps config_schema: 2
+// and an explicit proxy_lite.enabled — the writer-side flip mechanism (PRD
+// §11): the default is never carried by Default(), always by the writer.
+func stepPosture(cfg *config) error {
+	fmt.Println(section.Render("── Agent Connection ───────────────────────"))
+	fmt.Println()
+
+	var choice string
+	err := huh.NewForm(
+		huh.NewGroup(
+			huh.NewSelect[string]().
+				Title("How should agents connect?").
+				Options(
+					huh.NewOption("Observe (recommended soon): route agent LLM traffic through Clawvisor for visibility; agents keep their own API keys", "observe"),
+					huh.NewOption("Skill gateway only (current default)", "gateway"),
+				).
+				// Default remains the skill gateway until the flip item.
+				Value(&choice),
+		),
+	).Run()
+	if err != nil {
+		return err
+	}
+
+	if choice != "observe" {
+		// Skill gateway only: proxy-lite stays disabled, but writeConfig
+		// still emits the explicit key + schema marker.
+		cfg.posture = ""
+		cfg.proxyLiteEnabled = false
+		return nil
+	}
+
+	cfg.posture = "observe"
+	cfg.proxyLiteEnabled = true
+
+	host := cfg.host
+	if host == "0.0.0.0" || host == "" {
+		host = "127.0.0.1"
+	}
+	cfg.proxyLitePublicURL = fmt.Sprintf("http://%s:%s", host, cfg.port)
+	err = huh.NewForm(
+		huh.NewGroup(
+			huh.NewInput().
+				Title("Proxy-lite public URL").
+				Description("The externally reachable URL agents point ANTHROPIC_BASE_URL / OPENAI_BASE_URL at.").
+				Value(&cfg.proxyLitePublicURL),
+		),
+	).Run()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func stepTelemetry(cfg *config) error {
 	fmt.Println(section.Render("── Telemetry ──────────────────────────────"))
 	fmt.Println()
@@ -629,6 +701,15 @@ func writeConfig(cfg *config, path string) error {
 		frontendDir = "" // daemon mode — no frontend served
 	}
 
+	// Advisory schema marker (first line). Schema 2 = "the writer emits
+	// proxy_lite.enabled explicitly" so the flip is writer-side only and
+	// existing installs are never silently enabled (PRD §11, spec 02 §5).
+	fmt.Fprintf(&b, "config_schema: %d\n", configWriterSchema)
+	if cfg.posture != "" {
+		fmt.Fprintf(&b, "posture: %s\n", cfg.posture)
+	}
+	fmt.Fprintf(&b, "\n")
+
 	fmt.Fprintf(&b, "server:\n")
 	fmt.Fprintf(&b, "  port: %s\n", cfg.port)
 	fmt.Fprintf(&b, "  host: \"%s\"\n", cfg.host)
@@ -679,6 +760,15 @@ func writeConfig(cfg *config, path string) error {
 	fmt.Fprintf(&b, "    enabled: %t\n", cfg.taskRiskEnabled)
 	fmt.Fprintf(&b, "  chain_context:\n")
 	fmt.Fprintf(&b, "    enabled: %t\n", cfg.chainContextEnabled)
+
+	// Explicit proxy_lite block. enabled is ALWAYS emitted (schema 2) so the
+	// compiled Default() never carries the flip. public_url is written only
+	// when the Observe path collected one.
+	fmt.Fprintf(&b, "\nproxy_lite:\n")
+	fmt.Fprintf(&b, "  enabled: %t\n", cfg.proxyLiteEnabled)
+	if cfg.proxyLitePublicURL != "" {
+		fmt.Fprintf(&b, "  public_url: \"%s\"\n", cfg.proxyLitePublicURL)
+	}
 
 	fmt.Fprintf(&b, "\ntelemetry:\n")
 	fmt.Fprintf(&b, "  enabled: %t\n", cfg.telemetryEnabled)

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -1,0 +1,96 @@
+package setup
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	cfgpkg "github.com/clawvisor/clawvisor/pkg/config"
+)
+
+// TestWizardWritesMarkerAndExplicitKey asserts writeConfig always stamps the
+// config_schema marker and an explicit proxy_lite.enabled key, and that a
+// wizard config round-trips through Load without silently enabling proxy-lite.
+func TestWizardWritesMarkerAndExplicitKey(t *testing.T) {
+	t.Run("skill gateway default", func(t *testing.T) {
+		cfg := &config{
+			envMode:          "local",
+			host:             "127.0.0.1",
+			port:             "25297",
+			vault:            "local",
+			llmProvider:      "anthropic",
+			llmEndpoint:      "https://api.anthropic.com/v1",
+			llmModel:         "claude-haiku-4-5",
+			posture:          "",
+			proxyLiteEnabled: false,
+		}
+		path := filepath.Join(t.TempDir(), "config.yaml")
+		if err := writeConfig(cfg, path); err != nil {
+			t.Fatalf("writeConfig: %v", err)
+		}
+		body, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		text := string(body)
+		if !strings.Contains(text, "config_schema: 2") {
+			t.Fatalf("missing config_schema marker:\n%s", text)
+		}
+		if !strings.Contains(text, "proxy_lite:") || !strings.Contains(text, "enabled: false") {
+			t.Fatalf("missing explicit proxy_lite.enabled: false:\n%s", text)
+		}
+		if strings.Contains(text, "posture:") {
+			t.Fatalf("skill-gateway config must not write a posture key:\n%s", text)
+		}
+		// Round-trip: loading it must NOT enable proxy-lite.
+		loaded, err := cfgpkg.Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if loaded.ProxyLite.Enabled {
+			t.Fatal("skill-gateway wizard config must not enable proxy-lite")
+		}
+		if loaded.ConfigSchema != cfgpkg.CurrentConfigSchema {
+			t.Fatalf("ConfigSchema=%d, want %d", loaded.ConfigSchema, cfgpkg.CurrentConfigSchema)
+		}
+	})
+
+	t.Run("observe posture", func(t *testing.T) {
+		cfg := &config{
+			envMode:            "local",
+			host:               "127.0.0.1",
+			port:               "25297",
+			vault:              "local",
+			llmProvider:        "anthropic",
+			llmEndpoint:        "https://api.anthropic.com/v1",
+			llmModel:           "claude-haiku-4-5",
+			posture:            "observe",
+			proxyLiteEnabled:   true,
+			proxyLitePublicURL: "http://127.0.0.1:25297",
+		}
+		path := filepath.Join(t.TempDir(), "config.yaml")
+		if err := writeConfig(cfg, path); err != nil {
+			t.Fatalf("writeConfig: %v", err)
+		}
+		body, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		text := string(body)
+		if !strings.Contains(text, "posture: observe") {
+			t.Fatalf("missing posture: observe:\n%s", text)
+		}
+		if !strings.Contains(text, "enabled: true") {
+			t.Fatalf("observe config must write proxy_lite.enabled: true:\n%s", text)
+		}
+		loaded, err := cfgpkg.Load(path)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if !loaded.ProxyLite.Enabled || !loaded.ProxyLite.ObserveMode() || !loaded.ProxyLite.PassthroughUpstreamAuth() {
+			t.Fatalf("observe wizard config should yield enabled+observe+passthrough: enabled=%v observe=%v passthrough=%v",
+				loaded.ProxyLite.Enabled, loaded.ProxyLite.ObserveMode(), loaded.ProxyLite.PassthroughUpstreamAuth())
+		}
+	})
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,7 +19,29 @@ type AutoConfigured struct {
 	JWTSecret      bool
 }
 
+// CurrentConfigSchema is the config-file schema version that config writers
+// (wizard, daemon setup) stamp into every fresh config. Schema 2 = "the
+// writer emits proxy_lite.enabled explicitly" (PRD §11). The marker is
+// advisory: Load() may log a one-line notice when it reads a file with an
+// older/absent marker, but never changes behavior based on it. The flip
+// (spec 08) is writer-side only, so Load() gains no branching on this value.
+const CurrentConfigSchema = 2
+
 type Config struct {
+	// Posture selects a coarse-grained config preset applied in Load()
+	// after the YAML file is unmarshalled but before env overrides. Values:
+	// "" (no preset — raw knobs only, today's behavior), "observe",
+	// "govern", "contain". A preset only sets knobs the YAML did not set
+	// explicitly; an explicit knob always wins (PRD §4). Posture is a
+	// config-FILE concern only — there is deliberately no CLAWVISOR_POSTURE
+	// env override, because preset application depends on YAML key-presence
+	// detection that env vars cannot express (spec 02, finding S2).
+	Posture string `yaml:"posture"`
+
+	// ConfigSchema is the advisory writer-side schema marker (see
+	// CurrentConfigSchema). Absent/0 on hand-written or pre-flip configs.
+	ConfigSchema int `yaml:"config_schema"`
+
 	Server        ServerConfig        `yaml:"server"`
 	Database      DatabaseConfig      `yaml:"database"`
 	Vault         VaultConfig         `yaml:"vault"`
@@ -343,6 +365,54 @@ type ProxyLiteConfig struct {
 	// CLAWVISOR_PROXY_LITE_RAW_LOG_PATH overrides this when set.
 	// CLAWVISOR_PROXY_LITE_RAW_LOG remains accepted as a legacy alias.
 	RawLogPath string `yaml:"raw_log_path"`
+
+	// EnforcementMode selects whether pipeline verdicts are enforced or
+	// merely observed: "enforce" (default) | "observe". In observe mode the
+	// pipeline still runs fully — inspection, attribution, audit, cost
+	// metering — but every hold/deny/rewrite verdict is downgraded to a
+	// recorded observation: the request/response proceeds as if allowed and
+	// the original verdict is written to audit (observed: true) + the
+	// clawvisor.pipeline.verdicts metric (observed="true"). Empty is treated
+	// as "enforce". The env var CLAWVISOR_PROXY_LITE_ENFORCEMENT_MODE
+	// overrides this. This is the net-new observe-posture switch (spec 02);
+	// it does NOT weaken Clawvisor's own agent-token auth.
+	EnforcementMode string `yaml:"enforcement_mode"`
+
+	// UpstreamAuth selects how the upstream provider credential is chosen:
+	// "vault" (default) | "passthrough". "vault" injects the stored key and
+	// strips any client-presented provider API key (a server-side posture
+	// decision, not a per-request client choice). "passthrough" preserves
+	// the client's own provider credential (existing auth_context.go
+	// semantics) for every request. Empty is treated as "vault". The env
+	// var CLAWVISOR_PROXY_LITE_UPSTREAM_AUTH overrides this.
+	UpstreamAuth string `yaml:"upstream_auth"`
+
+	// AllowSubscriptionBillingMigration, when true, permits govern/contain
+	// (vault upstream_auth) to strip a Claude subscription (OAuth) bearer and
+	// inject the vaulted API key — consenting to the resulting billing shift
+	// from the user's subscription to org-metered API billing (spec 02 §4c).
+	// Default false: a subscription seat is REFUSED with
+	// SUBSCRIPTION_SEAT_NOT_GOVERNABLE rather than silently rebilled. The
+	// flag is instance-wide — enabling it migrates EVERY subscription seat on
+	// the instance at once (blast radius F4). The preset system never sets
+	// it; it is always an explicit operator choice. Env override:
+	// CLAWVISOR_PROXY_LITE_ALLOW_SUB_MIGRATION.
+	AllowSubscriptionBillingMigration bool `yaml:"allow_subscription_billing_migration"`
+}
+
+// ObserveMode reports whether enforcement is downgraded to observation: the
+// pipeline runs fully but hold/deny/rewrite verdicts become recorded
+// observations rather than blocking actions. Empty enforcement_mode is
+// treated as "enforce" (fail toward enforcement, never silently observe).
+func (p ProxyLiteConfig) ObserveMode() bool {
+	return strings.EqualFold(strings.TrimSpace(p.EnforcementMode), "observe")
+}
+
+// PassthroughUpstreamAuth reports whether upstream auth forwards the client's
+// own provider credential (passthrough) instead of injecting the vault key.
+// Empty upstream_auth is treated as "vault".
+func (p ProxyLiteConfig) PassthroughUpstreamAuth() bool {
+	return strings.EqualFold(strings.TrimSpace(p.UpstreamAuth), "passthrough")
 }
 
 // FeaturesConfig gates progressively enhanced UI and runtime surfaces.
@@ -452,6 +522,18 @@ func Default() *Config {
 			AutovaultMode:           "observe",
 			InjectStoredBearer:      false,
 		},
+		ProxyLite: ProxyLiteConfig{
+			// Enabled stays false PERMANENTLY (writer-side flip; the flip
+			// item changes only what writers emit, never this default —
+			// locked by TestFlipDefaultStaysFalse). EnforcementMode/
+			// UpstreamAuth carry today's behavior: enforce + vault
+			// injection. AllowSubscriptionBillingMigration stays false so a
+			// subscription seat is refused rather than silently rebilled.
+			Enabled:                           false,
+			EnforcementMode:                   "enforce",
+			UpstreamAuth:                      "vault",
+			AllowSubscriptionBillingMigration: false,
+		},
 		Features: FeaturesConfig{
 			SecretVault:    false,
 			ServicePresets: false,
@@ -498,6 +580,8 @@ func Default() *Config {
 func Load(path string) (*Config, error) {
 	cfg := Default()
 
+	var raw []byte
+	fileLoaded := false
 	if path != "" {
 		data, err := os.ReadFile(path)
 		if err != nil && !os.IsNotExist(err) {
@@ -507,7 +591,26 @@ func Load(path string) (*Config, error) {
 			if err := yaml.Unmarshal(data, cfg); err != nil {
 				return nil, fmt.Errorf("parsing config file: %w", err)
 			}
+			raw = data
+			fileLoaded = true
 		}
+	}
+
+	// Apply the posture preset immediately after YAML unmarshal and BEFORE
+	// env overrides — an explicit operator env must still beat a posture
+	// default, which is why the preset runs first. Presets only set knobs
+	// the YAML file did not set explicitly (detected against raw bytes).
+	applyPosturePreset(cfg, raw)
+
+	// Advisory config_schema notice (spec 02 §5 / PRD §11). The marker is
+	// informational only: Load() never changes behavior based on it, but a
+	// stale/absent marker on a loaded file is worth a one-line heads-up so
+	// operators know the writer that produced it predates the explicit
+	// proxy_lite.enabled convention. Only fires for files actually read
+	// (env-only deployments carry no YAML and would log spuriously).
+	if fileLoaded && cfg.ConfigSchema < CurrentConfigSchema {
+		slog.Default().Info("config: config_schema marker is older than current; regenerate via the setup wizard to adopt the explicit proxy_lite.enabled convention",
+			"config_schema", cfg.ConfigSchema, "current", CurrentConfigSchema)
 	}
 
 	// Env overrides (12-factor friendly)
@@ -844,6 +947,19 @@ func Load(path string) (*Config, error) {
 	if v := os.Getenv("CLAWVISOR_PROXY_LITE_RAW_LOG_PATH"); v != "" {
 		cfg.ProxyLite.RawLogPath = strings.TrimSpace(v)
 	}
+	// Knob overrides bypass postures for operators who set the raw config.
+	// There is deliberately NO CLAWVISOR_POSTURE override (posture is
+	// file-only; see the Posture field doc). These env values win over a
+	// posture default because they are applied after applyPosturePreset.
+	if v := os.Getenv("CLAWVISOR_PROXY_LITE_ENFORCEMENT_MODE"); v != "" {
+		cfg.ProxyLite.EnforcementMode = strings.ToLower(strings.TrimSpace(v))
+	}
+	if v := os.Getenv("CLAWVISOR_PROXY_LITE_UPSTREAM_AUTH"); v != "" {
+		cfg.ProxyLite.UpstreamAuth = strings.ToLower(strings.TrimSpace(v))
+	}
+	if v := os.Getenv("CLAWVISOR_PROXY_LITE_ALLOW_SUB_MIGRATION"); v != "" {
+		cfg.ProxyLite.AllowSubscriptionBillingMigration = v == "true" || v == "1"
+	}
 
 	if v := os.Getenv("CLAWVISOR_RELAY_URL"); v != "" {
 		cfg.Relay.URL = v
@@ -944,6 +1060,80 @@ func ensureGeminiCache(p **GeminiCacheConfig) *GeminiCacheConfig {
 	return *p
 }
 
+// applyPosturePreset applies the coarse-grained posture preset selected by
+// cfg.Posture to the proxy-lite knobs, but only for knobs the raw YAML did
+// not set explicitly. An explicit knob always wins (PRD §4). raw is the
+// unmodified config-file bytes (nil for env-only deployments, in which case
+// cfg.Posture is empty and this is a no-op).
+//
+// Presets:
+//   - "observe": proxy_lite.enabled=true, enforcement_mode="observe",
+//     upstream_auth="passthrough".
+//   - "govern":  proxy_lite.enabled=true, enforcement_mode="enforce",
+//     upstream_auth="vault".
+//   - "contain": not applied here — Validate() rejects it until the superset
+//     gate lands (PRD §13 item 9).
+//   - "" / unknown: no-op (unknown is rejected by Validate()).
+//
+// AllowSubscriptionBillingMigration is intentionally never set by a preset —
+// it is always an explicit operator choice (spec 02 §4c).
+func applyPosturePreset(cfg *Config, raw []byte) {
+	setEnabled := func(v bool) {
+		if !yamlHasKey(raw, "proxy_lite", "enabled") {
+			cfg.ProxyLite.Enabled = v
+		}
+	}
+	setEnforcement := func(v string) {
+		if !yamlHasKey(raw, "proxy_lite", "enforcement_mode") {
+			cfg.ProxyLite.EnforcementMode = v
+		}
+	}
+	setUpstreamAuth := func(v string) {
+		if !yamlHasKey(raw, "proxy_lite", "upstream_auth") {
+			cfg.ProxyLite.UpstreamAuth = v
+		}
+	}
+	switch strings.ToLower(strings.TrimSpace(cfg.Posture)) {
+	case "observe":
+		setEnabled(true)
+		setEnforcement("observe")
+		setUpstreamAuth("passthrough")
+	case "govern":
+		setEnabled(true)
+		setEnforcement("enforce")
+		setUpstreamAuth("vault")
+	}
+}
+
+// yamlHasKey reports whether the given nested key path is explicitly present
+// in the raw YAML document. It re-parses raw into a generic map so it can
+// distinguish "key absent" from "key present but false" — a distinction the
+// struct unmarshal destroys (Load() overlays Default(), so a false and an
+// absent bool look identical afterward). Returns false when raw is empty or
+// unparseable, or when any path segment is missing / not a mapping.
+func yamlHasKey(raw []byte, path ...string) bool {
+	if len(raw) == 0 || len(path) == 0 {
+		return false
+	}
+	var doc map[string]any
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		return false
+	}
+	var cur any = doc
+	for _, seg := range path {
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return false
+		}
+		v, present := m[seg]
+		if !present {
+			return false
+		}
+		cur = v
+	}
+	return true
+}
+
 func splitCSV(v string) []string {
 	var out []string
 	for _, part := range strings.Split(v, ",") {
@@ -1035,6 +1225,23 @@ func (c *Config) Validate() error {
 	}
 	if strings.EqualFold(strings.TrimSpace(c.Server.RouteSet), "proxy_lite") && !c.ProxyLite.Enabled {
 		return fmt.Errorf("server.route_set=proxy_lite requires proxy_lite.enabled=true")
+	}
+	switch strings.ToLower(strings.TrimSpace(c.Posture)) {
+	case "", "observe", "govern":
+	case "contain":
+		return fmt.Errorf("posture contain is not yet available; it ships once the runtime-proxy composition makes it a strict superset of govern")
+	default:
+		return fmt.Errorf("posture must be one of observe, govern, contain (got %q)", c.Posture)
+	}
+	switch strings.ToLower(strings.TrimSpace(c.ProxyLite.EnforcementMode)) {
+	case "", "enforce", "observe":
+	default:
+		return fmt.Errorf("proxy_lite.enforcement_mode must be one of enforce, observe (got %q)", c.ProxyLite.EnforcementMode)
+	}
+	switch strings.ToLower(strings.TrimSpace(c.ProxyLite.UpstreamAuth)) {
+	case "", "vault", "passthrough":
+	default:
+		return fmt.Errorf("proxy_lite.upstream_auth must be one of vault, passthrough (got %q)", c.ProxyLite.UpstreamAuth)
 	}
 	switch strings.ToLower(strings.TrimSpace(c.RuntimePolicy.AutovaultMode)) {
 	case "", "observe", "auto", "strict":

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -237,4 +239,171 @@ func TestValidateObservabilityOTelRules(t *testing.T) {
 			t.Fatalf("expected sample ratio validation error, got %v", err)
 		}
 	})
+}
+
+// --- spec 02: posture presets, config schema marker, knob precedence ---
+
+func writePostureConfig(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return p
+}
+
+// TestFlipDefaultStaysFalse locks the writer-side flip invariant (PRD §11,
+// spec 08): the compiled default for proxy_lite.enabled is false and must
+// stay false permanently, so an existing install lacking the key is never
+// silently enabled at a binary upgrade. Enforcement/upstream defaults carry
+// today's behavior (enforce + vault) but the enablement bit does not move.
+func TestFlipDefaultStaysFalse(t *testing.T) {
+	d := Default()
+	if d.ProxyLite.Enabled {
+		t.Fatal("Default().ProxyLite.Enabled must stay false permanently (writer-side flip)")
+	}
+	if d.ProxyLite.EnforcementMode != "enforce" {
+		t.Fatalf("Default enforcement_mode=%q, want enforce", d.ProxyLite.EnforcementMode)
+	}
+	if d.ProxyLite.UpstreamAuth != "vault" {
+		t.Fatalf("Default upstream_auth=%q, want vault", d.ProxyLite.UpstreamAuth)
+	}
+	if d.ProxyLite.AllowSubscriptionBillingMigration {
+		t.Fatal("Default allow_subscription_billing_migration must be false")
+	}
+}
+
+// TestProxyLiteEnableMatrix asserts exactly which (key present/absent) ×
+// (config_schema) × (posture) × (env override) combinations enable
+// proxy-lite. Absent key with no posture/env is always disabled regardless
+// of the advisory marker — the marker never drives behavior.
+func TestProxyLiteEnableMatrix(t *testing.T) {
+	cases := []struct {
+		name        string
+		yaml        string
+		envEnabled  string // "" = unset
+		wantEnabled bool
+	}{
+		{"absent key, schema 0, no posture", "config_schema: 0\n", "", false},
+		{"absent key, schema 2, no posture", "config_schema: 2\n", "", false},
+		{"explicit false, schema 2", "config_schema: 2\nproxy_lite:\n  enabled: false\n", "", false},
+		{"explicit true, schema 2", "config_schema: 2\nproxy_lite:\n  enabled: true\n", "", true},
+		{"explicit true, schema 0", "config_schema: 0\nproxy_lite:\n  enabled: true\n", "", true},
+		{"posture observe, absent key", "posture: observe\n", "", true},
+		{"posture observe, explicit false beats preset", "posture: observe\nproxy_lite:\n  enabled: false\n", "", false},
+		{"posture govern, absent key", "posture: govern\n", "", true},
+		{"no posture, env true", "config_schema: 2\n", "true", true},
+		{"posture observe, env false beats preset", "posture: observe\n", "false", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.envEnabled != "" {
+				t.Setenv("CLAWVISOR_PROXY_LITE_ENABLED", tc.envEnabled)
+			}
+			cfg, err := Load(writePostureConfig(t, tc.yaml))
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if cfg.ProxyLite.Enabled != tc.wantEnabled {
+				t.Fatalf("ProxyLite.Enabled=%v, want %v", cfg.ProxyLite.Enabled, tc.wantEnabled)
+			}
+		})
+	}
+}
+
+// TestPosturePresetKnobPrecedence covers the knob-beats-preset matrix for
+// enforcement_mode and upstream_auth: a preset sets a knob only when the YAML
+// did not set it explicitly, and an explicit env override always wins.
+func TestPosturePresetKnobPrecedence(t *testing.T) {
+	t.Run("observe preset sets both knobs", func(t *testing.T) {
+		cfg, err := Load(writePostureConfig(t, "posture: observe\n"))
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if !cfg.ProxyLite.Enabled || !cfg.ProxyLite.ObserveMode() || !cfg.ProxyLite.PassthroughUpstreamAuth() {
+			t.Fatalf("observe preset: enabled=%v observe=%v passthrough=%v",
+				cfg.ProxyLite.Enabled, cfg.ProxyLite.ObserveMode(), cfg.ProxyLite.PassthroughUpstreamAuth())
+		}
+	})
+	t.Run("govern preset sets enforce+vault", func(t *testing.T) {
+		cfg, err := Load(writePostureConfig(t, "posture: govern\n"))
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if !cfg.ProxyLite.Enabled || cfg.ProxyLite.ObserveMode() || cfg.ProxyLite.PassthroughUpstreamAuth() {
+			t.Fatalf("govern preset: enabled=%v observe=%v passthrough=%v",
+				cfg.ProxyLite.Enabled, cfg.ProxyLite.ObserveMode(), cfg.ProxyLite.PassthroughUpstreamAuth())
+		}
+	})
+	t.Run("explicit enforcement_mode beats observe preset", func(t *testing.T) {
+		cfg, err := Load(writePostureConfig(t, "posture: observe\nproxy_lite:\n  enforcement_mode: enforce\n"))
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.ProxyLite.ObserveMode() {
+			t.Fatal("explicit enforcement_mode: enforce should override observe preset")
+		}
+		// upstream_auth was NOT set explicitly, so the preset still applies.
+		if !cfg.ProxyLite.PassthroughUpstreamAuth() {
+			t.Fatal("upstream_auth should still be passthrough from the observe preset")
+		}
+	})
+	t.Run("env enforcement_mode beats preset", func(t *testing.T) {
+		t.Setenv("CLAWVISOR_PROXY_LITE_ENFORCEMENT_MODE", "enforce")
+		cfg, err := Load(writePostureConfig(t, "posture: observe\n"))
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.ProxyLite.ObserveMode() {
+			t.Fatal("env CLAWVISOR_PROXY_LITE_ENFORCEMENT_MODE=enforce should beat observe preset")
+		}
+	})
+}
+
+func TestValidatePostureContainRejected(t *testing.T) {
+	cfg := Default()
+	cfg.Posture = "contain"
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "posture contain is not yet available") {
+		t.Fatalf("expected contain rejection, got %v", err)
+	}
+}
+
+func TestValidatePostureUnknownRejected(t *testing.T) {
+	cfg := Default()
+	cfg.Posture = "lockdown"
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "posture must be one of") {
+		t.Fatalf("expected unknown-posture rejection, got %v", err)
+	}
+}
+
+func TestValidateEnforcementModeEnum(t *testing.T) {
+	cfg := Default()
+	cfg.ProxyLite.EnforcementMode = "audit"
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "proxy_lite.enforcement_mode") {
+		t.Fatalf("expected enforcement_mode enum error, got %v", err)
+	}
+}
+
+func TestValidateUpstreamAuthEnum(t *testing.T) {
+	cfg := Default()
+	cfg.ProxyLite.UpstreamAuth = "byo"
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "proxy_lite.upstream_auth") {
+		t.Fatalf("expected upstream_auth enum error, got %v", err)
+	}
+}
+
+func TestLoadAppliesSubMigrationEnv(t *testing.T) {
+	t.Setenv("CLAWVISOR_PROXY_LITE_ALLOW_SUB_MIGRATION", "true")
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.ProxyLite.AllowSubscriptionBillingMigration {
+		t.Fatal("expected allow_subscription_billing_migration env override to apply")
+	}
 }


### PR DESCRIPTION
Builds the Observe posture as a real preset: `posture` config key with knob-override precedence, client-key passthrough, and a net-new enforcement-off mode (pipeline inspects/attributes/audits/meters but converts every hold/deny into a recorded observation). Adds the writer-side flip mechanism (`config_schema: 2` marker, wizard writes `proxy_lite.enabled` explicitly, `Default()` locked false by `TestFlipDefaultStaysFalse`). Govern-side credential rules: strip-and-inject for client API keys, and the subscription/OAuth carve-out — detect a subscription bearer, refuse with `SUBSCRIPTION_SEAT_NOT_GOVERNABLE` (403) by default, migrate only under `proxy_lite.allow_subscription_billing_migration: true`. The passthrough+enforce hybrid is explicitly tested.

Cubic fix: `secret_decision` exempted from observe downgrade so secret adjudication still acts in observe mode.

Tests: 13 e2e contract scenarios + byte-fidelity + config matrix, all green.

**Stack 3/15** — base: `tc-stack-1` (after wave 1: #608, #609). Retarget to `main` once those merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

