### PR TITLE
feat(terraform): vm-docker deploy module + test lane

### DIFF
--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -1,0 +1,120 @@
+name: Terraform CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "deploy/terraform/**"
+      - ".github/workflows/terraform-ci.yml"
+      - "scripts/mirror-terraform.sh"
+    tags: ["v*"]
+  pull_request:
+    branches: [main]
+    paths:
+      - "deploy/terraform/**"
+      - ".github/workflows/terraform-ci.yml"
+  workflow_dispatch:
+    inputs:
+      real_cloud:
+        description: "Run the keyed real-AWS apply/upgrade/destroy lane"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+env:
+  TF_MODULE: deploy/terraform/modules/vm-docker
+
+jobs:
+  # Job 1 — deterministic: fmt + validate + terraform test + no-secret-leak
+  # assertion. No cloud credentials.
+  validate:
+    name: fmt + validate + test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "~> 1.9"
+
+      - name: fmt -check
+        run: terraform -chdir=deploy/terraform fmt -check -recursive
+
+      - name: init + validate (module)
+        run: |
+          terraform -chdir="$TF_MODULE" init -backend=false -input=false
+          terraform -chdir="$TF_MODULE" validate
+
+      - name: terraform test (mocked providers, no credentials)
+        run: terraform -chdir="$TF_MODULE" test
+
+      - name: no secret literals in plan JSON
+        # Renders a plan with mocked AWS + real random, dumps it to JSON, and
+        # asserts no generated secret leaks unredacted. Sensitive values are
+        # redacted by Terraform; this catches a regression that un-marks one.
+        run: bash scripts/terraform-plan-secret-scan.sh
+
+  # Job 2 — local Docker render target: proves the compose/Caddyfile the module
+  # renders is engine-valid. Deterministic; no cloud.
+  local-docker:
+    name: local-docker render
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "~> 1.9"
+      - name: render + validate compose
+        run: |
+          cd deploy/terraform/examples/local-docker
+          ./run.sh
+
+  # Job 3 — keyed real-AWS lane (manual). AWS-only: apply → upgrade via SSM
+  # param → snapshot exists → destroy. Skipped without credentials.
+  real-aws:
+    name: real-aws apply/upgrade/destroy (keyed)
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.real_cloud }}
+    environment: terraform-aws
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "~> 1.9"
+
+      - name: guard — require AWS credentials
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        run: |
+          if [ -z "$AWS_ACCESS_KEY_ID" ]; then
+            echo "No AWS credentials configured; skipping real-cloud lane."
+            exit 0
+          fi
+
+      - name: apply → upgrade → snapshot → destroy
+        if: ${{ secrets.AWS_ACCESS_KEY_ID != '' }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          TF_VAR_region: ${{ vars.AWS_REGION }}
+          TF_VAR_public_fqdn: ${{ vars.CLAWVISOR_CI_FQDN }}
+          TF_VAR_acme_email: ${{ vars.CLAWVISOR_CI_ACME_EMAIL }}
+          TF_VAR_office_cidrs: ${{ vars.CLAWVISOR_CI_CIDRS }}
+        run: bash scripts/terraform-real-aws-lane.sh
+
+  # Job 4 — publish-only registry mirror on release tags (DEFERRED to v1.1).
+  # Present but disabled: PRD §6/§13 keep the monorepo path as the v1
+  # distribution. Flip `if: false` to `if: startsWith(github.ref, 'refs/tags/v')`
+  # when the mirror repo exists.
+  mirror:
+    name: mirror to terraform-clawvisor-modules (v1.1, disabled)
+    runs-on: ubuntu-latest
+    if: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: subtree push
+        run: bash scripts/mirror-terraform.sh

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -7,12 +7,17 @@ on:
       - "deploy/terraform/**"
       - ".github/workflows/terraform-ci.yml"
       - "scripts/mirror-terraform.sh"
+      - "scripts/terraform-plan-secret-scan.sh"
+      - "scripts/terraform-real-aws-lane.sh"
     tags: ["v*"]
   pull_request:
     branches: [main]
     paths:
       - "deploy/terraform/**"
       - ".github/workflows/terraform-ci.yml"
+      - "scripts/mirror-terraform.sh"
+      - "scripts/terraform-plan-secret-scan.sh"
+      - "scripts/terraform-real-aws-lane.sh"
   workflow_dispatch:
     inputs:
       real_cloud:
@@ -66,7 +71,12 @@ jobs:
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: "~> 1.9"
-      - name: render + validate compose
+      - name: install caddy (for Caddyfile validation)
+        run: |
+          curl -fsSL https://github.com/caddyserver/caddy/releases/download/v2.8.4/caddy_2.8.4_linux_amd64.tar.gz \
+            | sudo tar -xz -C /usr/local/bin caddy
+          caddy version
+      - name: render + validate compose + Caddyfile
         run: |
           cd deploy/terraform/examples/local-docker
           ./run.sh
@@ -78,6 +88,13 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.real_cloud }}
     environment: terraform-aws
+    # The lane uses fixed resource names (NAME=clawvisor: shared SSM param, DB,
+    # snapshots). Serialize the lane globally so two manual dispatches can't
+    # clobber each other's SSM param / DB / snapshots. Never cancel a run
+    # mid-apply — that would orphan half-created billable resources.
+    concurrency:
+      group: terraform-real-aws-lane
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
       - uses: hashicorp/setup-terraform@v3

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -84,17 +84,23 @@ jobs:
         with:
           terraform_version: "~> 1.9"
 
+      # The `secrets` context is not available in `if:` expressions (using it
+      # invalidates the whole workflow at parse time), so gate via a step
+      # output instead.
       - name: guard — require AWS credentials
+        id: guard
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         run: |
           if [ -z "$AWS_ACCESS_KEY_ID" ]; then
             echo "No AWS credentials configured; skipping real-cloud lane."
-            exit 0
+            echo "has_aws=0" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_aws=1" >> "$GITHUB_OUTPUT"
           fi
 
       - name: apply → upgrade → snapshot → destroy
-        if: ${{ secrets.AWS_ACCESS_KEY_ID != '' }}
+        if: ${{ steps.guard.outputs.has_aws == '1' }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -26,8 +26,11 @@ web/dist/*
 *.swp
 *.swo
 
-# Terraform (has its own git repo)
-terraform/
+# Legacy root-level terraform mirror (had its own git repo). Anchored to the
+# repo root so it does NOT hide deploy/terraform/, which is a tracked
+# deliverable (spec 03). deploy/terraform has its own .gitignore for working
+# dirs/state.
+/terraform/
 
 # Landing page (has its own git repo)
 landing/

--- a/deploy/terraform/.gitignore
+++ b/deploy/terraform/.gitignore
@@ -1,0 +1,14 @@
+# Terraform working directories and state — never committed.
+.terraform/
+.terraform.lock.hcl
+*.tfstate
+*.tfstate.*
+crash.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+.terraformrc
+terraform.rc
+# local-docker render output
+examples/local-docker/rendered/

--- a/deploy/terraform/examples/aws-minimal/main.tf
+++ b/deploy/terraform/examples/aws-minimal/main.tf
@@ -63,6 +63,10 @@ output "server_ip" {
   value = module.clawvisor.server_ip
 }
 
+output "instance_id" {
+  value = module.clawvisor.instance_id
+}
+
 output "install_commands" {
   value = module.clawvisor.install_commands
 }

--- a/deploy/terraform/examples/aws-minimal/main.tf
+++ b/deploy/terraform/examples/aws-minimal/main.tf
@@ -1,0 +1,73 @@
+# Minimal AWS deploy of Clawvisor via the vm-docker module.
+#
+# Prereqs (see the module README):
+#   - AWS credentials for the target account/region.
+#   - A DNS zone you can create an A record in for var.public_fqdn.
+#
+# Two-step ACME: apply once to learn the instance IP (server_ip output),
+# create the DNS A record pointing at it, then re-apply / let the cert issue.
+
+terraform {
+  required_version = ">= 1.9.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+variable "region" {
+  type    = string
+  default = "us-east-1"
+}
+
+variable "public_fqdn" {
+  type = string
+}
+
+variable "acme_email" {
+  type = string
+}
+
+variable "office_cidrs" {
+  type        = list(string)
+  description = "Your VPN/office/CI egress CIDRs. Both zones default to deny-all."
+  default     = []
+}
+
+module "clawvisor" {
+  source = "../../modules/vm-docker"
+
+  name        = "clawvisor"
+  region      = var.region
+  image       = "ghcr.io/clawvisor/clawvisor:v1.4.2"
+  posture     = "observe"
+  public_fqdn = var.public_fqdn
+  acme_email  = var.acme_email
+
+  # Deny-by-default: set these to reach the deploy at all.
+  agent_ingress_cidrs = var.office_cidrs
+  admin_ingress_cidrs = var.office_cidrs
+}
+
+output "server_url" {
+  value = module.clawvisor.server_url
+}
+
+output "server_ip" {
+  value = module.clawvisor.server_ip
+}
+
+output "install_commands" {
+  value = module.clawvisor.install_commands
+}
+
+output "bootstrap_admin_token" {
+  value     = module.clawvisor.bootstrap_admin_token
+  sensitive = true
+}

--- a/deploy/terraform/examples/local-docker/render.tf
+++ b/deploy/terraform/examples/local-docker/render.tf
@@ -1,0 +1,139 @@
+# local-docker — the deterministic lane's stand-in for a VM (spec 03 Tests).
+#
+# Reuses ONLY the module's compose + Caddyfile + config templates (no cloud
+# resources) and renders them to disk so `docker compose` can boot the exact
+# rendered artifacts. A local postgres overlay + a generated secrets file
+# replace the RDS/Secrets-Manager plumbing that the real module provides on a
+# VM. Run `./run.sh` to boot and assert /health returns 200.
+#
+# This proves the rendering logic and the compose/Caddyfile contract without
+# any AWS credentials.
+
+terraform {
+  required_version = ">= 1.9.0"
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.5"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+}
+
+variable "public_fqdn" {
+  type    = string
+  default = "localhost"
+}
+
+variable "image" {
+  type    = string
+  default = "clawvisor:local"
+}
+
+locals {
+  module_dir = "${path.module}/../../modules/vm-docker"
+  out_dir    = "${path.module}/rendered"
+
+  compose = templatefile("${local.module_dir}/templates/docker-compose.yaml.tftpl", {
+    app_env          = { AUTH_MODE = "password" }
+    secrets_env_file = "./secrets.env"
+    admin_port       = 8443
+    vault_backend    = "local"
+  })
+
+  caddyfile = templatefile("${local.module_dir}/templates/Caddyfile.tftpl", {
+    public_fqdn = var.public_fqdn
+    acme_email  = "dev@example.com"
+    admin_port  = 8443
+  })
+
+  config = templatefile("${local.module_dir}/templates/config.yaml.tftpl", {
+    public_fqdn   = var.public_fqdn
+    otel_endpoint = ""
+    posture       = "observe"
+  })
+}
+
+# A local, module-format bootstrap token so the rendered secrets file matches
+# what the VM path produces (cvat_ + 43 base64url chars).
+resource "random_password" "bootstrap" {
+  length           = 43
+  special          = true
+  override_special = "_-"
+  min_special      = 0
+}
+
+resource "random_password" "jwt" {
+  length  = 48
+  special = false
+}
+
+resource "random_bytes" "vault_key" {
+  length = 32
+}
+
+resource "local_file" "compose" {
+  filename = "${local.out_dir}/docker-compose.yaml"
+  content  = local.compose
+}
+
+resource "local_file" "caddyfile" {
+  filename = "${local.out_dir}/Caddyfile"
+  content  = local.caddyfile
+}
+
+resource "local_file" "config" {
+  filename = "${local.out_dir}/config.yaml"
+  content  = local.config
+}
+
+# Local overlay: a postgres sidecar (the VM path uses managed RDS) plus a
+# bind mount of the rendered config into the app container.
+resource "local_file" "override" {
+  filename = "${local.out_dir}/docker-compose.override.yaml"
+  content  = <<-EOT
+    services:
+      postgres:
+        image: postgres:16-alpine
+        environment:
+          POSTGRES_USER: clawvisor
+          POSTGRES_PASSWORD: clawvisor
+          POSTGRES_DB: clawvisor
+        healthcheck:
+          test: ["CMD-SHELL", "pg_isready -U clawvisor"]
+          interval: 5s
+          timeout: 5s
+          retries: 10
+      app:
+        depends_on:
+          postgres:
+            condition: service_healthy
+        ports:
+          - "25297:25297"
+        volumes:
+          - ./config.yaml:/etc/clawvisor/config.yaml:ro
+      caddy:
+        # Local runs hit the app directly; skip TLS/ACME in the deterministic
+        # target by not starting caddy (the compose+Caddyfile still render and
+        # `docker compose config` still validates them).
+        profiles: ["tls"]
+  EOT
+}
+
+resource "local_sensitive_file" "secrets" {
+  filename = "${local.out_dir}/secrets.env"
+  content  = <<-EOT
+    DATABASE_URL=postgres://clawvisor:clawvisor@postgres:5432/clawvisor
+    JWT_SECRET=${random_password.jwt.result}
+    VAULT_KEY=${random_bytes.vault_key.base64}
+    CLAWVISOR_BOOTSTRAP_TOKEN=cvat_${random_password.bootstrap.result}
+  EOT
+}
+
+resource "local_file" "compose_env" {
+  filename = "${local.out_dir}/compose.env"
+  content  = "clawvisor_image=${var.image}\n"
+}

--- a/deploy/terraform/examples/local-docker/run.sh
+++ b/deploy/terraform/examples/local-docker/run.sh
@@ -26,6 +26,13 @@ echo "== validate rendered compose =="
 docker compose --env-file compose.env config >/dev/null
 echo "rendered compose is valid"
 
+# The deterministic lane skips caddy at boot (see the override's tls profile),
+# so without this the Caddyfile contract is never checked and a malformed
+# Caddyfile passes CI and fails only on AWS. Adapt+validate the rendered file.
+echo "== validate rendered Caddyfile =="
+caddy validate --adapter caddyfile --config Caddyfile
+echo "rendered Caddyfile is valid"
+
 if [ "${BOOT:-0}" != "1" ]; then
   echo "SKIP boot (set BOOT=1 to build + run + health-check)"
   exit 0
@@ -34,11 +41,13 @@ fi
 echo "== build image =="
 docker build -t "$IMAGE" -f "$REPO_ROOT/deploy/Dockerfile" "$REPO_ROOT"
 
-echo "== boot app + postgres =="
-docker compose --env-file compose.env up -d app postgres
-
+# Register teardown BEFORE `up` so a failed startup (set -e) still tears down
+# the partially-created stack instead of leaking containers/volumes.
 cleanup() { docker compose --env-file compose.env down -v || true; }
 trap cleanup EXIT
+
+echo "== boot app + postgres =="
+docker compose --env-file compose.env up -d app postgres
 
 echo "== poll /health =="
 deadline=$(( $(date +%s) + 120 ))

--- a/deploy/terraform/examples/local-docker/run.sh
+++ b/deploy/terraform/examples/local-docker/run.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Boot the rendered Clawvisor artifacts locally (no cloud) and assert /health
+# returns 200. This is the deterministic-lane stand-in for a VM.
+#
+# Steps:
+#   1. terraform init/apply here → renders compose/Caddyfile/config/secrets.
+#   2. `docker compose config` validates the rendered compose is engine-valid
+#      (this is the light, always-run check).
+#   3. If BOOT=1, build the image (repo Dockerfile) and boot app+postgres,
+#      then poll https/http /health until 200 (heavier; local/keyed).
+#
+# Usage: ./run.sh            # render + validate compose (deterministic)
+#        BOOT=1 ./run.sh     # also build + boot + health-check
+set -euo pipefail
+cd "$(dirname "$0")"
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+IMAGE="${IMAGE:-clawvisor:local}"
+
+echo "== render artifacts =="
+terraform init -input=false -no-color >/dev/null
+terraform apply -input=false -auto-approve -no-color -var "image=$IMAGE" >/dev/null
+cd rendered
+
+echo "== validate rendered compose =="
+docker compose --env-file compose.env config >/dev/null
+echo "rendered compose is valid"
+
+if [ "${BOOT:-0}" != "1" ]; then
+  echo "SKIP boot (set BOOT=1 to build + run + health-check)"
+  exit 0
+fi
+
+echo "== build image =="
+docker build -t "$IMAGE" -f "$REPO_ROOT/deploy/Dockerfile" "$REPO_ROOT"
+
+echo "== boot app + postgres =="
+docker compose --env-file compose.env up -d app postgres
+
+cleanup() { docker compose --env-file compose.env down -v || true; }
+trap cleanup EXIT
+
+echo "== poll /health =="
+deadline=$(( $(date +%s) + 120 ))
+until curl -fsS "http://localhost:25297/health" >/dev/null 2>&1; do
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    echo "FAIL: /health did not return 200 within 120s"
+    docker compose --env-file compose.env logs app || true
+    exit 1
+  fi
+  sleep 3
+done
+echo "PASS: /health returned 200"

--- a/deploy/terraform/modules/vm-docker/README.md
+++ b/deploy/terraform/modules/vm-docker/README.md
@@ -1,0 +1,165 @@
+# `vm-docker` — single-VM Docker Clawvisor on AWS
+
+One `terraform apply` stands up a TLS-serving, Docker-based Clawvisor on a
+single EC2 instance backed by managed RDS Postgres, in a named security
+posture, with a seeded bootstrap admin API token as a sensitive output.
+
+**v1 is AWS-only.** GCP, the container-DB option, and the reference-vault
+backends are deferred (PRD §13). There is no `cloud` variable.
+
+## Usage
+
+```hcl
+module "clawvisor" {
+  source = "github.com/clawvisor/clawvisor//deploy/terraform/modules/vm-docker"
+
+  name        = "clawvisor"
+  region      = "us-east-1"
+  image       = "ghcr.io/clawvisor/clawvisor:v1.4.2" # pinned tag, never :latest
+  posture     = "observe"
+  public_fqdn = "clawvisor.example.com"
+  acme_email  = "ops@example.com"
+
+  # Deny-by-default. Set these to reach the deploy at all.
+  agent_ingress_cidrs = ["203.0.113.0/24"] # laptops/CI egress → agent endpoint (443)
+  admin_ingress_cidrs = ["198.51.100.10/32"] # VPN only → admin surface (8443)
+}
+```
+
+The monorepo path (`//deploy/terraform/modules/vm-docker`) is the v1
+distribution. A publish-only registry mirror is deferred to v1.1 (PRD §6).
+
+## Inputs
+
+| Name | Type | Default | Notes |
+|---|---|---|---|
+| `name` | string | `"clawvisor"` | resource name prefix |
+| `region` | string | — (required) | AWS region |
+| `image` | string | — (required) | full image ref incl. tag; `:latest`/untagged rejected |
+| `posture` | string | `"observe"` | `observe`/`govern`/`contain`; rendered into config.yaml (preset knobs land with spec 02) |
+| `db` | string | `"managed"` | v1 accepts only `"managed"` (RDS Postgres); `"container"` is v1.1 |
+| `db_instance_class` | string | `"db.t4g.micro"` | RDS instance class |
+| `db_allocated_storage` | number | `20` | RDS storage (GiB) |
+| `vault_backend` | string | `"local"` | v1 accepts only `"local"`; reference backends ship with spec 10 |
+| `jwt_secret_ref` | string | `""` | AWS Secrets Manager ARN; empty ⇒ generated on-instance. Never a literal |
+| `vault_key_ref` | string | `""` | same semantics as `jwt_secret_ref` |
+| `otel_endpoint` | string | `""` | OTLP endpoint; empty disables export (spec 01) |
+| `public_fqdn` | string | — (required) | DNS name Caddy serves + ACME; must resolve to `server_ip` before first boot |
+| `acme_email` | string | — (required) | Let's Encrypt registration |
+| `agent_ingress_cidrs` | list(string) | `[]` | CIDRs allowed to the agent endpoint (443). Empty = deny all |
+| `admin_ingress_cidrs` | list(string) | `[]` | CIDRs allowed to the admin surface (8443). Empty = deny all |
+| `i_understand_public_exposure` | bool | `false` | must be `true` to accept `0.0.0.0/0`/`::/0` in either list |
+| `backup_retention_days` | number | `7` | RDS retention + upgrade-snapshot pruning window |
+| `instance_type` | string | `"t3.small"` | EC2 instance type |
+| `max_users` | number | `0` | `0` ⇒ unset; >0 sets `MAX_USERS` |
+| `extra_env` | map(string) | `{}` | merged last into compose env; no secret literals |
+| `vpc_id`/`subnet_id`/`db_subnet_ids` | — | default VPC | optional placement overrides |
+| `key_name` | string | `""` | optional break-glass SSH key; SSH is admin-CIDR-scoped, never world-open |
+
+## Outputs
+
+| Name | Sensitive | Value |
+|---|---|---|
+| `server_url` | no | `https://<public_fqdn>` |
+| `bootstrap_admin_token` | **yes** | single-use `cvat_` instance-admin token (spec 05) |
+| `install_commands` | no | per-harness `curl … | sh` one-liners |
+| `provider_block` | no | ready-to-paste `provider "clawvisor"` block (attr is `api_token`) |
+| `instance_id` | no | EC2 instance id |
+| `server_ip` | no | public IP the DNS record must point at |
+| `db_endpoint` | **yes** | connection string (contains the DB password) |
+| `image_ssm_parameter` | no | SSM parameter that drives upgrades/rollback |
+
+## Network exposure — deny by default
+
+A security/governance console must not default to internet-open. Two trust
+zones, both deny-by-default, gated at the security-group (port) level because
+security groups are L3/L4 and cannot path-route:
+
+- **Agent endpoint (443, `agent_ingress_cidrs`):** the LLM/proxy + installer
+  surface (`/v1/*`, `/skill/install/*`). Caddy serves only those paths here.
+- **Admin surface (8443, `admin_ingress_cidrs`):** dashboard + management API.
+  Keep tighter — VPN/allowlist only.
+
+Empty list = the port is not opened at all. A `0.0.0.0/0` or `::/0` entry in
+either list fails `plan` unless `i_understand_public_exposure = true`.
+
+### DNS for ACME
+
+Caddy obtains a Let's Encrypt certificate for `public_fqdn`. That requires:
+
+1. The `public_fqdn` DNS A/AAAA record resolving to the `server_ip` output.
+2. Let's Encrypt being able to reach the instance for the challenge.
+
+Two-step apply: run `terraform apply` once, read `server_ip`, create the DNS
+record, then let Caddy issue (it retries automatically). Under strict
+deny-by-default ingress, Let's Encrypt's validators cannot reach 443/80 unless
+you either (a) temporarily widen `agent_ingress_cidrs` during issuance, or
+(b) switch Caddy to the DNS-01 challenge (a v1.1 module option). Document your
+choice in the calling config.
+
+## Secrets & state (PRD §7 — hard requirements)
+
+- `jwt_secret_ref`/`vault_key_ref` are **references**, never literals. When
+  empty, the value is generated **on the instance** at first boot and written
+  to Secrets Manager — the literal never enters Terraform state or the plan.
+- `bootstrap_admin_token` and `db_endpoint` are `sensitive = true`. The
+  bootstrap token is module-generated (only the module can guarantee spec 05's
+  `cvat_ + 43 base64url` shape) and therefore transits state; its 24h expiry
+  and burn-on-first-use bound the exposure.
+- **Use an encrypted state backend.** Pipe secrets straight to storage:
+  `terraform output -raw bootstrap_admin_token | your-secret-store put …`.
+  Do not paste them.
+
+## Bootstrap token (spec 05 contract)
+
+The module generates `cvat_` + 43 base64url chars, writes it to the
+`${name}-bootstrap-token` Secrets Manager entry, and mounts it into the
+container as `CLAWVISOR_BOOTSTRAP_TOKEN`. On first boot the server (spec 05, ≥
+the release that consumes this env var) mints a 24h, burn-on-first-use
+instance-admin token whose secret equals this value, provided no non-revoked
+instance-admin token exists yet. After first use the token is dead; the
+Secrets Manager entry is then safe to delete.
+
+> `bootstrap_admin_token` requires **server ≥ the release that consumes
+> `CLAWVISOR_BOOTSTRAP_TOKEN`** (spec 05). Against older servers the output is
+> populated but inert.
+
+## Upgrade & rollback (honest, no remote-exec / no SSH)
+
+`terraform apply` with a new `image` updates only the SSM parameter
+`/clawvisor/<name>/image`. An on-instance **systemd timer**
+(`clawvisor-deploy.timer`) polls it every ~2 minutes and, on change:
+
+1. takes an **RDS snapshot** (`<name>-preupgrade-<ts>`) — a new image may run
+   migrations,
+2. prunes pre-upgrade snapshots older than `backup_retention_days`,
+3. `docker compose pull && up -d` onto the new tag.
+
+No instance replacement, no `user_data` re-run, no SSH from the Terraform
+runner. Brief downtime during restart is accepted and expected (single VM).
+
+**Rollback:** set `image` back to the previous tag and `apply` (the timer
+redeploys), then, if a migration ran, restore the pre-upgrade snapshot:
+
+```
+aws rds restore-db-instance-from-db-snapshot \
+  --db-instance-identifier clawvisor-db-restored \
+  --db-snapshot-identifier clawvisor-preupgrade-<ts>
+# repoint DATABASE_URL / swap the instance per your runbook
+```
+
+Restore is a documented manual step in v1, not automated.
+
+## Testing
+
+- `terraform test` (in this directory) runs the validation + render lanes with
+  **no cloud credentials** (mocked AWS provider, real `random`).
+- `../../examples/local-docker` renders the compose/Caddyfile/config from these
+  same templates and boots them with `docker compose` as a VM stand-in.
+- The keyed real-AWS lane (`.github/workflows/terraform-ci.yml`, manual) does a
+  full apply → SSM-param upgrade → snapshot-exists → destroy.
+
+## Out of scope (v1)
+
+No Kubernetes/Helm, no multi-VM/HA, no container-DB, no GCP, no reference-vault
+backends. See PRD §13/§14.

--- a/deploy/terraform/modules/vm-docker/aws.tf
+++ b/deploy/terraform/modules/vm-docker/aws.tf
@@ -1,5 +1,13 @@
 # AWS resources for the single-VM Clawvisor deploy.
 
+# --- Provider-derived identity ---------------------------------------------
+# Everything the module renders on-instance (deploy script region, snapshot
+# ARNs) is keyed off the ACTUAL provider region/partition/account, never a
+# separate var.region that could silently disagree with the provider.
+data "aws_region" "current" {}
+data "aws_partition" "current" {}
+data "aws_caller_identity" "current" {}
+
 # --- Placement (default VPC when not supplied) -----------------------------
 data "aws_vpc" "default" {
   count   = var.vpc_id == "" ? 1 : 0
@@ -151,6 +159,18 @@ data "aws_iam_policy_document" "instance" {
     actions   = ["secretsmanager:GetSecretValue"]
     resources = local.read_secret_arns
   }
+  # CMK decrypt for operator-supplied refs encrypted with a customer-managed
+  # key. Module-owned secrets use the AWS-managed key (aws/secretsmanager),
+  # which GetSecretValue can already decrypt; a CMK-encrypted jwt/vault ref
+  # would otherwise fail decrypt at boot. Only emitted when kms_key_arn is set.
+  dynamic "statement" {
+    for_each = var.kms_key_arn != "" ? [1] : []
+    content {
+      sid       = "DecryptSecretsCMK"
+      actions   = ["kms:Decrypt"]
+      resources = [var.kms_key_arn]
+    }
+  }
   # Generated-mode: write JWT/VAULT on first boot (only the module-owned
   # secrets, never operator-supplied refs).
   dynamic "statement" {
@@ -167,14 +187,23 @@ data "aws_iam_policy_document" "instance" {
     actions   = ["ssm:GetParameter"]
     resources = [aws_ssm_parameter.image.arn]
   }
-  # Snapshot-before-upgrade + prune.
+  # Snapshot-before-upgrade + prune. Create/Delete are scoped to THIS module's
+  # DB and its `<name>-preupgrade-*` snapshots to cut blast radius. Describe has
+  # no resource-level permission support in RDS, so it must stay "*".
   statement {
-    sid = "SnapshotDB"
+    sid = "SnapshotDBWrite"
     actions = [
       "rds:CreateDBSnapshot",
-      "rds:DescribeDBSnapshots",
       "rds:DeleteDBSnapshot",
     ]
+    resources = [
+      aws_db_instance.this.arn,
+      "arn:${data.aws_partition.current.partition}:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:snapshot:${var.name}-preupgrade-*",
+    ]
+  }
+  statement {
+    sid       = "SnapshotDBDescribe"
+    actions   = ["rds:DescribeDBSnapshots"]
     resources = ["*"]
   }
 }
@@ -254,6 +283,16 @@ resource "aws_instance" "app" {
     volume_size = 30
     encrypted   = true
   }
+
+  # user_data references the secret ARNs but not their versions; make the
+  # ordering explicit so the instance never boots before the bootstrap/db_url
+  # secret values exist (the real race is near-nil, but the dependency is
+  # correct and cheap). Generated jwt/vault secrets have no version by design
+  # (written on-instance at first boot), so they are not listed here.
+  depends_on = [
+    aws_secretsmanager_secret_version.bootstrap,
+    aws_secretsmanager_secret_version.db_url,
+  ]
 
   tags = { Name = var.name, "clawvisor:managed" = "true" }
 }

--- a/deploy/terraform/modules/vm-docker/aws.tf
+++ b/deploy/terraform/modules/vm-docker/aws.tf
@@ -1,0 +1,259 @@
+# AWS resources for the single-VM Clawvisor deploy.
+
+# --- Placement (default VPC when not supplied) -----------------------------
+data "aws_vpc" "default" {
+  count   = var.vpc_id == "" ? 1 : 0
+  default = true
+}
+
+data "aws_subnets" "default" {
+  count = var.vpc_id == "" ? 1 : 0
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default[0].id]
+  }
+}
+
+locals {
+  vpc_id        = var.vpc_id != "" ? var.vpc_id : data.aws_vpc.default[0].id
+  db_subnet_ids = length(var.db_subnet_ids) > 0 ? var.db_subnet_ids : data.aws_subnets.default[0].ids
+  instance_subnet = var.subnet_id != "" ? var.subnet_id : (
+    length(var.db_subnet_ids) > 0 ? var.db_subnet_ids[0] : data.aws_subnets.default[0].ids[0]
+  )
+}
+
+data "aws_ami" "al2023" {
+  most_recent = true
+  owners      = ["amazon"]
+  filter {
+    name   = "name"
+    values = ["al2023-ami-*-x86_64"]
+  }
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+# --- Two-zone security group -----------------------------------------------
+# Deny-by-default: an ingress block renders only when its CIDR list is
+# non-empty. 443 = agent endpoint (agent_ingress_cidrs); admin_port = admin
+# surface (admin_ingress_cidrs). The i_understand_public_exposure gate on the
+# variables is what allows 0.0.0.0/0 into either list at all.
+resource "aws_security_group" "app" {
+  name        = "${var.name}-app"
+  description = "Clawvisor app: agent endpoint (443) + admin surface (${local.admin_port})"
+  vpc_id      = local.vpc_id
+
+  dynamic "ingress" {
+    for_each = length(var.agent_ingress_cidrs) > 0 ? [1] : []
+    content {
+      description = "agent endpoint (LLM/proxy + installer)"
+      from_port   = 443
+      to_port     = 443
+      protocol    = "tcp"
+      cidr_blocks = var.agent_ingress_cidrs
+    }
+  }
+
+  # HTTP is for the ACME challenge / HTTPS redirect only; scoped to the agent
+  # zone. See README "DNS for ACME" for the Let's Encrypt reachability caveat
+  # under deny-by-default.
+  dynamic "ingress" {
+    for_each = length(var.agent_ingress_cidrs) > 0 ? [1] : []
+    content {
+      description = "ACME HTTP-01 / HTTPS redirect"
+      from_port   = 80
+      to_port     = 80
+      protocol    = "tcp"
+      cidr_blocks = var.agent_ingress_cidrs
+    }
+  }
+
+  dynamic "ingress" {
+    for_each = length(var.admin_ingress_cidrs) > 0 ? [1] : []
+    content {
+      description = "admin dashboard + management API"
+      from_port   = local.admin_port
+      to_port     = local.admin_port
+      protocol    = "tcp"
+      cidr_blocks = var.admin_ingress_cidrs
+    }
+  }
+
+  # Break-glass SSH, admin-CIDR-scoped, only if a key pair is supplied. Never
+  # world-open. Routine ops (upgrade) use SSM, not SSH.
+  dynamic "ingress" {
+    for_each = var.key_name != "" && length(var.admin_ingress_cidrs) > 0 ? [1] : []
+    content {
+      description = "break-glass SSH (admin CIDRs only)"
+      from_port   = 22
+      to_port     = 22
+      protocol    = "tcp"
+      cidr_blocks = var.admin_ingress_cidrs
+    }
+  }
+
+  egress {
+    description = "all egress"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = { Name = "${var.name}-app", "clawvisor:managed" = "true" }
+}
+
+resource "aws_security_group" "db" {
+  name        = "${var.name}-db"
+  description = "Clawvisor managed Postgres: 5432 from the app instance only"
+  vpc_id      = local.vpc_id
+
+  ingress {
+    description     = "postgres from app"
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = [aws_security_group.app.id]
+  }
+
+  tags = { Name = "${var.name}-db", "clawvisor:managed" = "true" }
+}
+
+# --- IAM: instance profile -------------------------------------------------
+data "aws_iam_policy_document" "assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "instance" {
+  name               = "${var.name}-instance"
+  assume_role_policy = data.aws_iam_policy_document.assume.json
+  tags               = { "clawvisor:managed" = "true" }
+}
+
+# Session Manager + ssm:GetParameter for the upgrade poll.
+resource "aws_iam_role_policy_attachment" "ssm_core" {
+  role       = aws_iam_role.instance.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+data "aws_iam_policy_document" "instance" {
+  # Read the secrets the container needs at boot.
+  statement {
+    sid       = "ReadSecrets"
+    actions   = ["secretsmanager:GetSecretValue"]
+    resources = local.read_secret_arns
+  }
+  # Generated-mode: write JWT/VAULT on first boot (only the module-owned
+  # secrets, never operator-supplied refs).
+  dynamic "statement" {
+    for_each = length(local.generated_secret_arns) > 0 ? [1] : []
+    content {
+      sid       = "PutGeneratedSecrets"
+      actions   = ["secretsmanager:PutSecretValue"]
+      resources = local.generated_secret_arns
+    }
+  }
+  # The image parameter the deploy timer polls.
+  statement {
+    sid       = "ReadImageParam"
+    actions   = ["ssm:GetParameter"]
+    resources = [aws_ssm_parameter.image.arn]
+  }
+  # Snapshot-before-upgrade + prune.
+  statement {
+    sid = "SnapshotDB"
+    actions = [
+      "rds:CreateDBSnapshot",
+      "rds:DescribeDBSnapshots",
+      "rds:DeleteDBSnapshot",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "instance" {
+  name   = "${var.name}-instance"
+  role   = aws_iam_role.instance.id
+  policy = data.aws_iam_policy_document.instance.json
+}
+
+resource "aws_iam_instance_profile" "instance" {
+  name = "${var.name}-instance"
+  role = aws_iam_role.instance.name
+}
+
+locals {
+  generated_secret_arns = compact([
+    local.jwt_generate ? aws_secretsmanager_secret.jwt[0].arn : "",
+    local.vault_key_generate ? aws_secretsmanager_secret.vault_key[0].arn : "",
+  ])
+}
+
+# --- SSM parameter: desired image tag (the upgrade lever) ------------------
+# `terraform apply` with a new `image` only updates this parameter; the
+# on-instance timer notices and redeploys. No instance replacement, no SSH.
+resource "aws_ssm_parameter" "image" {
+  name  = "/clawvisor/${var.name}/image"
+  type  = "String"
+  value = var.image
+  tags  = { "clawvisor:managed" = "true" }
+}
+
+# --- Managed Postgres ------------------------------------------------------
+resource "aws_db_subnet_group" "this" {
+  name       = "${var.name}-db"
+  subnet_ids = local.db_subnet_ids
+  tags       = { "clawvisor:managed" = "true" }
+}
+
+resource "aws_db_instance" "this" {
+  identifier              = "${var.name}-db"
+  engine                  = "postgres"
+  engine_version          = "16"
+  instance_class          = var.db_instance_class
+  allocated_storage       = var.db_allocated_storage
+  db_name                 = local.db_name
+  username                = local.db_user
+  password                = random_password.db.result
+  db_subnet_group_name    = aws_db_subnet_group.this.name
+  vpc_security_group_ids  = [aws_security_group.db.id]
+  backup_retention_period = var.backup_retention_days
+  storage_encrypted       = true
+  # v1: single-VM product accepts brief downtime and destroy-deletes the DB.
+  # Take a manual snapshot before `terraform destroy` (README runbook).
+  skip_final_snapshot = true
+  apply_immediately   = true
+  tags                = { "clawvisor:managed" = "true" }
+}
+
+# --- Application VM --------------------------------------------------------
+resource "aws_instance" "app" {
+  ami                    = data.aws_ami.al2023.id
+  instance_type          = var.instance_type
+  subnet_id              = local.instance_subnet
+  vpc_security_group_ids = [aws_security_group.app.id]
+  iam_instance_profile   = aws_iam_instance_profile.instance.name
+  key_name               = var.key_name != "" ? var.key_name : null
+  user_data              = local.user_data
+
+  # An image bump changes only the SSM parameter (and thus user_data, since
+  # the rendered deploy script references the parameter name — but NOT its
+  # value). Never replace the instance on user_data change: the upgrade path
+  # is the on-instance timer, not a fresh boot.
+  user_data_replace_on_change = false
+
+  root_block_device {
+    volume_size = 30
+    encrypted   = true
+  }
+
+  tags = { Name = var.name, "clawvisor:managed" = "true" }
+}

--- a/deploy/terraform/modules/vm-docker/cloudinit.tf
+++ b/deploy/terraform/modules/vm-docker/cloudinit.tf
@@ -1,0 +1,47 @@
+# Renders the compose / Caddyfile / config.yaml / deploy script templates and
+# assembles them into the cloud-init user_data. Each rendered artifact is
+# base64-embedded (cloud-init `encoding: b64`) to avoid YAML-in-YAML escaping.
+
+locals {
+  secrets_env_file = "/etc/clawvisor/secrets.env"
+
+  compose_rendered = templatefile("${path.module}/templates/docker-compose.yaml.tftpl", {
+    app_env          = local.app_env
+    secrets_env_file = local.secrets_env_file
+    admin_port       = local.admin_port
+    vault_backend    = var.vault_backend
+  })
+
+  caddyfile_rendered = templatefile("${path.module}/templates/Caddyfile.tftpl", {
+    public_fqdn = var.public_fqdn
+    acme_email  = var.acme_email
+    admin_port  = local.admin_port
+  })
+
+  config_rendered = templatefile("${path.module}/templates/config.yaml.tftpl", {
+    public_fqdn   = var.public_fqdn
+    otel_endpoint = var.otel_endpoint
+    posture       = var.posture
+  })
+
+  deploy_rendered = templatefile("${path.module}/templates/deploy.sh.tftpl", {
+    region                = var.region
+    name                  = var.name
+    image_ssm_param       = aws_ssm_parameter.image.name
+    db_instance_id        = aws_db_instance.this.identifier
+    backup_retention_days = var.backup_retention_days
+    db_url_secret_arn     = aws_secretsmanager_secret.db_url.arn
+    jwt_secret_arn        = local.jwt_secret_arn
+    vault_key_arn         = local.vault_key_arn
+    bootstrap_secret_arn  = aws_secretsmanager_secret.bootstrap.arn
+    jwt_generate          = local.jwt_generate
+    vault_key_generate    = local.vault_key_generate
+  })
+
+  user_data = templatefile("${path.module}/templates/cloud-init.yaml.tftpl", {
+    compose_b64   = base64encode(local.compose_rendered)
+    caddyfile_b64 = base64encode(local.caddyfile_rendered)
+    config_b64    = base64encode(local.config_rendered)
+    deploy_b64    = base64encode(local.deploy_rendered)
+  })
+}

--- a/deploy/terraform/modules/vm-docker/cloudinit.tf
+++ b/deploy/terraform/modules/vm-docker/cloudinit.tf
@@ -25,7 +25,7 @@ locals {
   })
 
   deploy_rendered = templatefile("${path.module}/templates/deploy.sh.tftpl", {
-    region                = var.region
+    region                = data.aws_region.current.name
     name                  = var.name
     image_ssm_param       = aws_ssm_parameter.image.name
     db_instance_id        = aws_db_instance.this.identifier
@@ -39,9 +39,12 @@ locals {
   })
 
   user_data = templatefile("${path.module}/templates/cloud-init.yaml.tftpl", {
-    compose_b64   = base64encode(local.compose_rendered)
-    caddyfile_b64 = base64encode(local.caddyfile_rendered)
-    config_b64    = base64encode(local.config_rendered)
-    deploy_b64    = base64encode(local.deploy_rendered)
+    compose_b64                   = base64encode(local.compose_rendered)
+    caddyfile_b64                 = base64encode(local.caddyfile_rendered)
+    config_b64                    = base64encode(local.config_rendered)
+    deploy_b64                    = base64encode(local.deploy_rendered)
+    docker_compose_version        = var.docker_compose_version
+    docker_compose_sha256_x86_64  = var.docker_compose_sha256["x86_64"]
+    docker_compose_sha256_aarch64 = var.docker_compose_sha256["aarch64"]
   })
 }

--- a/deploy/terraform/modules/vm-docker/main.tf
+++ b/deploy/terraform/modules/vm-docker/main.tf
@@ -1,0 +1,112 @@
+# vm-docker — cloud-agnostic wiring, secret generation, and locals.
+#
+# AWS resources live in aws.tf; cloud-init rendering in cloudinit.tf; the
+# provider/version constraints in versions.tf.
+
+locals {
+  # Admin surface listens on a second port; the security group gates it to
+  # admin_ingress_cidrs while 443 (agent endpoint) is gated to
+  # agent_ingress_cidrs. Caddy path-splits the two zones (see Caddyfile).
+  admin_port = 8443
+
+  db_name = "clawvisor"
+  db_user = "clawvisor"
+
+  # Non-secret app env merged into the compose `environment:` map. Secret
+  # values (DATABASE_URL, JWT_SECRET, VAULT_KEY, CLAWVISOR_BOOTSTRAP_TOKEN)
+  # travel via the env_file written at boot from Secrets Manager, NOT here.
+  app_env = merge(
+    { AUTH_MODE = "password" },
+    var.max_users > 0 ? { MAX_USERS = tostring(var.max_users) } : {},
+    var.extra_env,
+  )
+
+  # Bootstrap admin token (05-lite contract). The MODULE is the single owner
+  # of generation — only it can guarantee spec 05's ^cvat_[A-Za-z0-9_-]{43}$
+  # shape. random_password.result is sensitive, so it is redacted in
+  # `plan -json`; it is exposed only through the sensitive
+  # bootstrap_admin_token output and the sensitive Secrets Manager entry.
+  bootstrap_token = "cvat_${random_password.bootstrap.result}"
+
+  # Whether the module generates JWT/VAULT on-instance (generated-mode) vs.
+  # the operator supplying a Secrets Manager ARN (reference-mode). In
+  # generated-mode the value is created ON THE INSTANCE at first boot and
+  # written to Secrets Manager, so the literal never enters Terraform state
+  # or the plan (PRD §7).
+  jwt_generate       = var.jwt_secret_ref == ""
+  vault_key_generate = var.vault_key_ref == ""
+
+  jwt_secret_arn = var.jwt_secret_ref != "" ? var.jwt_secret_ref : aws_secretsmanager_secret.jwt[0].arn
+  vault_key_arn  = var.vault_key_ref != "" ? var.vault_key_ref : aws_secretsmanager_secret.vault_key[0].arn
+
+  # ARNs the instance profile must be granted read access to.
+  read_secret_arns = compact([
+    local.jwt_secret_arn,
+    local.vault_key_arn,
+    aws_secretsmanager_secret.bootstrap.arn,
+    aws_secretsmanager_secret.db_url.arn,
+  ])
+}
+
+# --- Bootstrap admin token (spec 05 contract) ------------------------------
+# length 43 over the base64url alphabet: uppers+lowers+digits plus override
+# specials "_-". No other special chars can appear, so the value always
+# matches ^[A-Za-z0-9_-]{43}$ after the module prepends "cvat_".
+resource "random_password" "bootstrap" {
+  length           = 43
+  special          = true
+  override_special = "_-"
+  min_special      = 0
+  min_upper        = 0
+  min_lower        = 0
+  min_numeric      = 0
+}
+
+resource "aws_secretsmanager_secret" "bootstrap" {
+  name = "${var.name}-bootstrap-token"
+  # No ignore_changes: this is a rotate-able seed, not a permanent credential.
+  # It is safe to delete after first boot (the token burns on first mint —
+  # spec 05: 24h expiry + burn-on-first-use). See README rotation runbook.
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "bootstrap" {
+  secret_id     = aws_secretsmanager_secret.bootstrap.id
+  secret_string = local.bootstrap_token
+}
+
+# --- JWT_SECRET (generated-mode only; literal never in state) --------------
+resource "aws_secretsmanager_secret" "jwt" {
+  count                   = local.jwt_generate ? 1 : 0
+  name                    = "${var.name}-jwt-secret"
+  recovery_window_in_days = 0
+  # No secret_version: the instance generates the value at first boot and
+  # PUTs it (see deploy.sh ensure_generated). Keeps the literal out of state.
+}
+
+# --- VAULT_KEY (generated-mode only; literal never in state) ---------------
+resource "aws_secretsmanager_secret" "vault_key" {
+  count                   = local.vault_key_generate ? 1 : 0
+  name                    = "${var.name}-vault-key"
+  recovery_window_in_days = 0
+}
+
+# --- DATABASE_URL ----------------------------------------------------------
+# The managed-DB connection string (contains the RDS password) is stored in
+# Secrets Manager and read at boot. The password is a random_password
+# (sensitive → redacted in plan); it is in state, which the spec accepts:
+# db_endpoint is a sensitive output documented to contain the password.
+resource "random_password" "db" {
+  length  = 30
+  special = false # keep the value URL-safe so DATABASE_URL needs no escaping
+}
+
+resource "aws_secretsmanager_secret" "db_url" {
+  name                    = "${var.name}-database-url"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "db_url" {
+  secret_id     = aws_secretsmanager_secret.db_url.id
+  secret_string = "postgres://${local.db_user}:${random_password.db.result}@${aws_db_instance.this.address}:5432/${local.db_name}"
+}

--- a/deploy/terraform/modules/vm-docker/outputs.tf
+++ b/deploy/terraform/modules/vm-docker/outputs.tf
@@ -9,6 +9,11 @@ output "bootstrap_admin_token" {
   sensitive   = true
 }
 
+output "admin_url" {
+  description = "Admin dashboard + management API URL (admin surface on the admin port, gated to admin_ingress_cidrs)."
+  value       = "https://${var.public_fqdn}:${local.admin_port}"
+}
+
 output "install_commands" {
   description = "Per-harness agent install one-liners (served by internal/api/handlers/installer.go at the agent endpoint)."
   value = {

--- a/deploy/terraform/modules/vm-docker/outputs.tf
+++ b/deploy/terraform/modules/vm-docker/outputs.tf
@@ -1,0 +1,51 @@
+output "server_url" {
+  description = "Base URL of the Clawvisor server (agent endpoint on 443)."
+  value       = "https://${var.public_fqdn}"
+}
+
+output "bootstrap_admin_token" {
+  description = "Single-use instance-admin bootstrap token (spec 05 contract: cvat_ + 43 base64url chars, 24h expiry, burns on first mint). Requires server >= the release that consumes CLAWVISOR_BOOTSTRAP_TOKEN. Pipe `terraform output -raw bootstrap_admin_token` straight into your secret store — do not paste it."
+  value       = local.bootstrap_token
+  sensitive   = true
+}
+
+output "install_commands" {
+  description = "Per-harness agent install one-liners (served by internal/api/handlers/installer.go at the agent endpoint)."
+  value = {
+    claude-code = "curl -fsSL https://${var.public_fqdn}/skill/install/claude-code.sh | sh"
+    codex       = "curl -fsSL https://${var.public_fqdn}/skill/install/codex.sh | sh"
+    hermes      = "curl -fsSL https://${var.public_fqdn}/skill/install/hermes.sh | sh"
+    openclaw    = "curl -fsSL https://${var.public_fqdn}/skill/install/openclaw.sh | sh"
+  }
+}
+
+output "provider_block" {
+  description = "Ready-to-paste Terraform provider block for terraform-provider-clawvisor (spec 06b). The credential attribute is `api_token` (never `token`). Wire it to the sensitive bootstrap_admin_token output rather than pasting the literal."
+  value       = <<-EOT
+    provider "clawvisor" {
+      endpoint  = "https://${var.public_fqdn}:${local.admin_port}"
+      api_token = var.clawvisor_api_token # e.g. terraform output -raw bootstrap_admin_token
+    }
+  EOT
+}
+
+output "instance_id" {
+  description = "EC2 instance id of the application VM."
+  value       = aws_instance.app.id
+}
+
+output "server_ip" {
+  description = "Public IP the public_fqdn DNS A/AAAA record must point at. Create that record before first apply completes so the ACME challenge can issue a certificate."
+  value       = aws_instance.app.public_ip
+}
+
+output "db_endpoint" {
+  description = "Managed-DB connection string. Contains the database password (managed mode) — treat as a credential."
+  value       = "postgres://${local.db_user}:${random_password.db.result}@${aws_db_instance.this.address}:5432/${local.db_name}"
+  sensitive   = true
+}
+
+output "image_ssm_parameter" {
+  description = "SSM parameter that holds the desired image tag. `terraform apply` with a new `image` updates it; the on-instance timer reconciles. Also the manual rollback lever (reset to the previous tag)."
+  value       = aws_ssm_parameter.image.name
+}

--- a/deploy/terraform/modules/vm-docker/templates/Caddyfile.tftpl
+++ b/deploy/terraform/modules/vm-docker/templates/Caddyfile.tftpl
@@ -1,0 +1,32 @@
+# Caddyfile rendered by the vm-docker Terraform module.
+#
+# Two trust zones, two listeners (security groups are L3/L4 and cannot
+# path-route, so the two-zone split is enforced at the port level and gated
+# by two separate SG rule sets — see aws.tf):
+#
+#   :443            agent endpoint   → /v1/*, /skill/install/*, /health only
+#   :${admin_port}  admin surface    → everything (dashboard + /api/*)
+#
+# Both listeners serve ${public_fqdn} and share one ACME-issued certificate.
+{
+	email ${acme_email}
+}
+
+# --- Agent endpoint (443) --------------------------------------------------
+# Reachable from agent_ingress_cidrs. Only the LLM/proxy + installer surface
+# is proxied; the admin dashboard and management API are NOT served here.
+https://${public_fqdn} {
+	@agent path /v1/* /skill/install/* /skill/uninstall/* /health /ready
+	handle @agent {
+		reverse_proxy app:25297
+	}
+	handle {
+		respond "This is the Clawvisor agent endpoint. The admin dashboard is served on port ${admin_port}." 404
+	}
+}
+
+# --- Admin surface (${admin_port}) -----------------------------------------
+# Reachable only from admin_ingress_cidrs. Full dashboard + management API.
+https://${public_fqdn}:${admin_port} {
+	reverse_proxy app:25297
+}

--- a/deploy/terraform/modules/vm-docker/templates/cloud-init.yaml.tftpl
+++ b/deploy/terraform/modules/vm-docker/templates/cloud-init.yaml.tftpl
@@ -1,0 +1,68 @@
+#cloud-config
+# Cloud-init for the Clawvisor application VM, rendered by the vm-docker
+# Terraform module. Installs Docker + compose, writes the rendered compose /
+# Caddyfile / config.yaml / deploy script, and starts the systemd timer that
+# reconciles the running image against the SSM parameter (the upgrade path).
+#
+# No secret literals appear here: the deploy script fetches JWT/VAULT/DB/
+# bootstrap values from Secrets Manager at boot. user_data carries only ARNs
+# and non-secret config.
+
+package_update: true
+
+write_files:
+  - path: /etc/clawvisor/docker-compose.yaml
+    permissions: "0644"
+    encoding: b64
+    content: ${compose_b64}
+  - path: /etc/clawvisor/Caddyfile
+    permissions: "0644"
+    encoding: b64
+    content: ${caddyfile_b64}
+  - path: /etc/clawvisor/config.yaml
+    permissions: "0644"
+    encoding: b64
+    content: ${config_b64}
+  - path: /usr/local/bin/clawvisor-deploy.sh
+    permissions: "0755"
+    encoding: b64
+    content: ${deploy_b64}
+  - path: /etc/systemd/system/clawvisor-deploy.service
+    permissions: "0644"
+    content: |
+      [Unit]
+      Description=Clawvisor image reconciler (SSM-driven upgrade)
+      After=docker.service network-online.target
+      Wants=network-online.target
+      [Service]
+      Type=oneshot
+      ExecStart=/usr/local/bin/clawvisor-deploy.sh
+  - path: /etc/systemd/system/clawvisor-deploy.timer
+    permissions: "0644"
+    content: |
+      [Unit]
+      Description=Poll SSM for the desired Clawvisor image and reconcile
+      [Timer]
+      OnBootSec=30s
+      OnUnitActiveSec=2min
+      AccuracySec=15s
+      [Install]
+      WantedBy=timers.target
+
+runcmd:
+  # --- Docker + compose plugin + awscli ---
+  - |
+    set -e
+    if command -v dnf >/dev/null 2>&1; then PM=dnf; else PM=yum; fi
+    $PM install -y docker awscli
+    systemctl enable --now docker
+    # compose v2 plugin
+    mkdir -p /usr/libexec/docker/cli-plugins
+    ARCH=$(uname -m); case "$ARCH" in aarch64) CA=aarch64;; *) CA=x86_64;; esac
+    curl -fsSL "https://github.com/docker/compose/releases/latest/download/docker-compose-linux-$${CA}" \
+      -o /usr/libexec/docker/cli-plugins/docker-compose
+    chmod +x /usr/libexec/docker/cli-plugins/docker-compose
+  # --- First reconcile + enable the upgrade timer ---
+  - systemctl daemon-reload
+  - /usr/local/bin/clawvisor-deploy.sh
+  - systemctl enable --now clawvisor-deploy.timer

--- a/deploy/terraform/modules/vm-docker/templates/cloud-init.yaml.tftpl
+++ b/deploy/terraform/modules/vm-docker/templates/cloud-init.yaml.tftpl
@@ -56,11 +56,18 @@ runcmd:
     if command -v dnf >/dev/null 2>&1; then PM=dnf; else PM=yum; fi
     $PM install -y docker awscli
     systemctl enable --now docker
-    # compose v2 plugin
+    # compose v2 plugin — pinned release, checksum-verified before install.
+    # Never `latest`: this runs in a privileged bootstrap, and the module
+    # already rejects a floating app-image tag; the plugin gets the same rigor.
     mkdir -p /usr/libexec/docker/cli-plugins
-    ARCH=$(uname -m); case "$ARCH" in aarch64) CA=aarch64;; *) CA=x86_64;; esac
-    curl -fsSL "https://github.com/docker/compose/releases/latest/download/docker-compose-linux-$${CA}" \
+    ARCH=$(uname -m)
+    case "$ARCH" in
+      aarch64) CA=aarch64; SHA="${docker_compose_sha256_aarch64}";;
+      *)       CA=x86_64;  SHA="${docker_compose_sha256_x86_64}";;
+    esac
+    curl -fsSL "https://github.com/docker/compose/releases/download/${docker_compose_version}/docker-compose-linux-$${CA}" \
       -o /usr/libexec/docker/cli-plugins/docker-compose
+    echo "$${SHA}  /usr/libexec/docker/cli-plugins/docker-compose" | sha256sum -c -
     chmod +x /usr/libexec/docker/cli-plugins/docker-compose
   # --- First reconcile + enable the upgrade timer ---
   - systemctl daemon-reload

--- a/deploy/terraform/modules/vm-docker/templates/config.yaml.tftpl
+++ b/deploy/terraform/modules/vm-docker/templates/config.yaml.tftpl
@@ -1,0 +1,45 @@
+# Clawvisor server config, rendered by the vm-docker Terraform module and
+# mounted at /etc/clawvisor/config.yaml (the server reads it via CONFIG_FILE).
+#
+# WHY A FILE AND NOT ENV: posture presets (spec 02) are non-env config keys.
+# Env-only deploys cannot carry preset knobs, so the module renders a real
+# config.yaml. Secret-bearing values (JWT_SECRET, VAULT_KEY, DATABASE_URL,
+# CLAWVISOR_BOOTSTRAP_TOKEN) stay in the container ENV, resolved from Secrets
+# Manager at boot — they are NOT written into this file.
+
+server:
+  host: "0.0.0.0"
+  port: 25297
+  public_url: "https://${public_fqdn}"
+  auth_mode: "password"
+
+# proxy-lite is the LLM-endpoint proxy. Enabling it here is the explicit
+# writer-side flip (never Default()): fresh module deploys land on the
+# proxy-lite path. See PRD §11 / global gotcha #1.
+proxy_lite:
+  enabled: true
+  public_url: "https://${public_fqdn}"
+
+%{ if otel_endpoint != "" ~}
+observability:
+  otel:
+    enabled: true
+    endpoint: "${otel_endpoint}"
+    protocol: "grpc"
+    service_name: "clawvisor"
+%{ endif ~}
+
+# --- Posture preset ---------------------------------------------------------
+# posture = "${posture}"
+#
+# SOFT DEPENDENCY ON SPEC 02. The concrete preset knobs (enforcement_mode,
+# upstream_auth, and the posture->config mapping) are defined by spec 02 and
+# are NOT yet present in this server build. Until spec 02 merges, this module
+# ships the observe-only proxy-lite config above for every posture value and
+# leaves this clearly-marked seam. When spec 02 lands, replace this block with
+# the rendered preset keys for ${posture} (the module already accepts and
+# validates the posture input, so only this template changes).
+%{ if posture != "observe" ~}
+# WARNING: posture "${posture}" was requested but preset knobs are not wired
+# yet (spec 02 pending). The server is running observe-only proxy-lite config.
+%{ endif ~}

--- a/deploy/terraform/modules/vm-docker/templates/deploy.sh.tftpl
+++ b/deploy/terraform/modules/vm-docker/templates/deploy.sh.tftpl
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# clawvisor-deploy.sh — on-instance reconciler for the honest upgrade path.
+#
+# Installed at first boot by cloud-init. A systemd timer runs it on a short
+# interval. It reads the DESIRED image tag from an SSM parameter and, when it
+# differs from the last-deployed tag, takes an RDS snapshot BEFORE pulling and
+# restarting (a new image may run DB migrations). `terraform apply` with a new
+# `image` only updates the SSM parameter — no instance replacement, no SSH,
+# no user_data re-run.
+#
+# Rollback: reset the SSM parameter to the previous tag (the timer redeploys),
+# then restore the pre-upgrade snapshot if a migration ran (README runbook).
+set -euo pipefail
+
+REGION="${region}"
+SSM_PARAM="${image_ssm_param}"
+DB_INSTANCE_ID="${db_instance_id}"
+NAME="${name}"
+RETENTION_DAYS="${backup_retention_days}"
+DIR=/etc/clawvisor
+STATE_FILE="$DIR/.deployed-image"
+LOCK="$DIR/.deploy.lock"
+
+# Serialize against overlapping timer fires.
+exec 9>"$LOCK"
+flock -n 9 || { echo "deploy already running; skipping"; exit 0; }
+
+log() { echo "[clawvisor-deploy] $*"; }
+
+desired="$(aws ssm get-parameter --region "$REGION" --name "$SSM_PARAM" \
+  --query 'Parameter.Value' --output text)"
+current="$(cat "$STATE_FILE" 2>/dev/null || echo none)"
+
+# In generated-mode (no operator-supplied ref) the JWT/VAULT values are
+# generated ON THE INSTANCE the first time and PUT into Secrets Manager, so
+# the literal never enters Terraform state or the plan (PRD §7). ensure_gen
+# is a no-op once a version exists (idempotent across reboots).
+ensure_gen() {
+  local arn="$1" gen="$2"
+  if ! aws secretsmanager get-secret-value --region "$REGION" --secret-id "$arn" \
+       --query 'SecretString' --output text >/dev/null 2>&1; then
+    aws secretsmanager put-secret-value --region "$REGION" --secret-id "$arn" \
+      --secret-string "$(bash -c "$gen")" >/dev/null
+  fi
+}
+%{ if jwt_generate ~}
+ensure_gen "${jwt_secret_arn}" "openssl rand -hex 32"
+%{ endif ~}
+%{ if vault_key_generate ~}
+ensure_gen "${vault_key_arn}" "openssl rand -base64 32"
+%{ endif ~}
+
+# Refresh secrets env every run so rotated secrets take effect on next restart.
+# Written mode 0600, never echoed. These are the only secret-bearing values;
+# they live in Secrets Manager, not in Terraform state or user_data.
+umask 077
+{
+  printf 'DATABASE_URL=%s\n'              "$(aws secretsmanager get-secret-value --region "$REGION" --secret-id "${db_url_secret_arn}"     --query 'SecretString' --output text)"
+  printf 'JWT_SECRET=%s\n'                "$(aws secretsmanager get-secret-value --region "$REGION" --secret-id "${jwt_secret_arn}"        --query 'SecretString' --output text)"
+  printf 'VAULT_KEY=%s\n'                 "$(aws secretsmanager get-secret-value --region "$REGION" --secret-id "${vault_key_arn}"         --query 'SecretString' --output text)"
+  printf 'CLAWVISOR_BOOTSTRAP_TOKEN=%s\n' "$(aws secretsmanager get-secret-value --region "$REGION" --secret-id "${bootstrap_secret_arn}" --query 'SecretString' --output text)"
+} > "$DIR/secrets.env"
+
+# docker compose substitutes $${clawvisor_image} from this .env file.
+echo "clawvisor_image=$desired" > "$DIR/compose.env"
+
+compose() {
+  docker compose -f "$DIR/docker-compose.yaml" --env-file "$DIR/compose.env" "$@"
+}
+
+if [ "$desired" != "$current" ] && [ "$current" != "none" ]; then
+  ts="$(date -u +%Y%m%d%H%M%S)"
+  snap="$NAME-preupgrade-$ts"
+  log "image change $current -> $desired; snapshotting $DB_INSTANCE_ID as $snap"
+  aws rds create-db-snapshot --region "$REGION" \
+    --db-instance-identifier "$DB_INSTANCE_ID" \
+    --db-snapshot-identifier "$snap" || log "WARNING: snapshot failed; continuing"
+
+  # Prune manual pre-upgrade snapshots older than the retention window.
+  cutoff="$(date -u -d "-$RETENTION_DAYS days" +%s 2>/dev/null || date -u -v-"$RETENTION_DAYS"d +%s)"
+  aws rds describe-db-snapshots --region "$REGION" \
+    --db-instance-identifier "$DB_INSTANCE_ID" --snapshot-type manual \
+    --query "DBSnapshots[?starts_with(DBSnapshotIdentifier, '$NAME-preupgrade-')].[DBSnapshotIdentifier,SnapshotCreateTime]" \
+    --output text 2>/dev/null | while read -r sid stime; do
+      screated="$(date -u -d "$stime" +%s 2>/dev/null || echo 0)"
+      if [ "$screated" -gt 0 ] && [ "$screated" -lt "$cutoff" ]; then
+        log "pruning old snapshot $sid"
+        aws rds delete-db-snapshot --region "$REGION" --db-snapshot-identifier "$sid" || true
+      fi
+    done
+fi
+
+log "pulling $desired"
+compose pull
+log "starting"
+compose up -d
+echo "$desired" > "$STATE_FILE"
+log "reconciled to $desired"

--- a/deploy/terraform/modules/vm-docker/templates/deploy.sh.tftpl
+++ b/deploy/terraform/modules/vm-docker/templates/deploy.sh.tftpl
@@ -68,31 +68,42 @@ compose() {
   docker compose -f "$DIR/docker-compose.yaml" --env-file "$DIR/compose.env" "$@"
 }
 
-if [ "$desired" != "$current" ] && [ "$current" != "none" ]; then
-  ts="$(date -u +%Y%m%d%H%M%S)"
-  snap="$NAME-preupgrade-$ts"
-  log "image change $current -> $desired; snapshotting $DB_INSTANCE_ID as $snap"
-  aws rds create-db-snapshot --region "$REGION" \
-    --db-instance-identifier "$DB_INSTANCE_ID" \
-    --db-snapshot-identifier "$snap" || log "WARNING: snapshot failed; continuing"
+# Reconcile only on change. First boot (current == none) still fires because
+# desired != none; steady-state runs are a no-op, so pull/up never restart the
+# stack outside an actual image change (spec 03: pull/up run "on change ...
+# after taking an RDS snapshot").
+if [ "$desired" != "$current" ]; then
+  if [ "$current" != "none" ]; then
+    ts="$(date -u +%Y%m%d%H%M%S)"
+    snap="$NAME-preupgrade-$ts"
+    log "image change $current -> $desired; snapshotting $DB_INSTANCE_ID as $snap"
+    # A migration may run on the new image; the snapshot MUST succeed before we
+    # pull/up, or the snapshot-before-restart guarantee is a lie. Abort on
+    # failure (the timer retries next fire) rather than upgrading unprotected.
+    aws rds create-db-snapshot --region "$REGION" \
+      --db-instance-identifier "$DB_INSTANCE_ID" \
+      --db-snapshot-identifier "$snap" || { log "ERROR: snapshot failed; aborting upgrade"; exit 1; }
 
-  # Prune manual pre-upgrade snapshots older than the retention window.
-  cutoff="$(date -u -d "-$RETENTION_DAYS days" +%s 2>/dev/null || date -u -v-"$RETENTION_DAYS"d +%s)"
-  aws rds describe-db-snapshots --region "$REGION" \
-    --db-instance-identifier "$DB_INSTANCE_ID" --snapshot-type manual \
-    --query "DBSnapshots[?starts_with(DBSnapshotIdentifier, '$NAME-preupgrade-')].[DBSnapshotIdentifier,SnapshotCreateTime]" \
-    --output text 2>/dev/null | while read -r sid stime; do
-      screated="$(date -u -d "$stime" +%s 2>/dev/null || echo 0)"
-      if [ "$screated" -gt 0 ] && [ "$screated" -lt "$cutoff" ]; then
-        log "pruning old snapshot $sid"
-        aws rds delete-db-snapshot --region "$REGION" --db-snapshot-identifier "$sid" || true
-      fi
-    done
+    # Prune manual pre-upgrade snapshots older than the retention window.
+    cutoff="$(date -u -d "-$RETENTION_DAYS days" +%s 2>/dev/null || date -u -v-"$RETENTION_DAYS"d +%s)"
+    aws rds describe-db-snapshots --region "$REGION" \
+      --db-instance-identifier "$DB_INSTANCE_ID" --snapshot-type manual \
+      --query "DBSnapshots[?starts_with(DBSnapshotIdentifier, '$NAME-preupgrade-')].[DBSnapshotIdentifier,SnapshotCreateTime]" \
+      --output text 2>/dev/null | while read -r sid stime; do
+        screated="$(date -u -d "$stime" +%s 2>/dev/null || echo 0)"
+        if [ "$screated" -gt 0 ] && [ "$screated" -lt "$cutoff" ]; then
+          log "pruning old snapshot $sid"
+          aws rds delete-db-snapshot --region "$REGION" --db-snapshot-identifier "$sid" || true
+        fi
+      done
+  fi
+
+  log "pulling $desired"
+  compose pull
+  log "starting"
+  compose up -d
+  echo "$desired" > "$STATE_FILE"
+  log "reconciled to $desired"
+else
+  log "already at $desired; nothing to do"
 fi
-
-log "pulling $desired"
-compose pull
-log "starting"
-compose up -d
-echo "$desired" > "$STATE_FILE"
-log "reconciled to $desired"

--- a/deploy/terraform/modules/vm-docker/templates/docker-compose.yaml.tftpl
+++ b/deploy/terraform/modules/vm-docker/templates/docker-compose.yaml.tftpl
@@ -1,0 +1,54 @@
+# docker-compose for the single-VM Clawvisor deploy, rendered by the
+# vm-docker Terraform module. Translated from deploy/docker-compose.yml.
+#
+# v1 uses managed RDS Postgres (no postgres sidecar). Caddy terminates TLS
+# and reverse-proxies to app:25297.
+#
+# Secret VALUES are injected via the ${secrets_env_file} env_file written at
+# boot from Secrets Manager — they never appear in this file, in user_data,
+# or in Terraform state. Non-secret config comes from the rendered map below.
+
+services:
+  app:
+    container_name: clawvisor
+    # The image tag is supplied at RUNTIME by the on-instance deploy script
+    # via compose.env (clawvisor_image=<tag from the SSM parameter>), so an
+    # `image`-only upgrade never rewrites this file or replaces the instance.
+    # `$${...}` renders to a literal `$${...}` that docker compose substitutes.
+    image: $${clawvisor_image}
+    restart: unless-stopped
+    environment:
+      DATABASE_DRIVER: "postgres"
+      SERVER_HOST: "0.0.0.0"
+      CONFIG_FILE: "/etc/clawvisor/config.yaml"
+      VAULT_BACKEND: "${vault_backend}"
+%{ for k, v in app_env ~}
+      ${k}: "${v}"
+%{ endfor ~}
+    env_file:
+      # DATABASE_URL, JWT_SECRET, VAULT_KEY, CLAWVISOR_BOOTSTRAP_TOKEN —
+      # written at boot from Secrets Manager, mode 0600, never in state.
+      - ${secrets_env_file}
+    volumes:
+      - /etc/clawvisor/config.yaml:/etc/clawvisor/config.yaml:ro
+    expose:
+      - "25297"
+
+  caddy:
+    container_name: clawvisor-caddy
+    image: caddy:2-alpine
+    restart: unless-stopped
+    depends_on:
+      - app
+    ports:
+      - "443:443"     # agent endpoint (SG-gated to agent_ingress_cidrs)
+      - "${admin_port}:${admin_port}" # admin surface (SG-gated to admin_ingress_cidrs)
+      - "80:80"       # ACME HTTP-01 redirect
+    volumes:
+      - /etc/clawvisor/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+
+volumes:
+  caddy_data:
+  caddy_config:

--- a/deploy/terraform/modules/vm-docker/tests/render.tftest.hcl
+++ b/deploy/terraform/modules/vm-docker/tests/render.tftest.hcl
@@ -1,0 +1,87 @@
+# Plan-only render tests against mock providers (no credentials). Assert that
+# the rendered compose/config carry the expected contract and that generated
+# credentials have the shape spec 05 requires. The "no secret literal in the
+# plan JSON" check is enforced separately by the CI script (terraform-ci.yml)
+# on `terraform show -json`.
+
+# Mock AWS only; `random` runs for real so generated values (bootstrap token,
+# db password) are real and their shape can be asserted. Render blocks use
+# command = apply so computed random values resolve.
+mock_provider "aws" {
+  mock_data "aws_vpc" {
+    defaults = { id = "vpc-test" }
+  }
+  mock_data "aws_subnets" {
+    defaults = { ids = ["subnet-a", "subnet-b"] }
+  }
+  mock_data "aws_ami" {
+    defaults = { id = "ami-test" }
+  }
+  mock_data "aws_iam_policy_document" {
+    defaults = { json = "{}" }
+  }
+}
+
+variables {
+  region              = "us-east-1"
+  image               = "ghcr.io/clawvisor/clawvisor:v1.4.2"
+  public_fqdn         = "clawvisor.example.com"
+  acme_email          = "ops@example.com"
+  agent_ingress_cidrs = ["203.0.113.0/24"]
+  admin_ingress_cidrs = ["198.51.100.0/24"]
+  otel_endpoint       = "otel.example.com:4317"
+}
+
+run "compose_uses_postgres_driver" {
+  command = apply
+
+  assert {
+    condition     = can(regex("DATABASE_DRIVER: \"postgres\"", local.compose_rendered))
+    error_message = "rendered compose must set DATABASE_DRIVER=postgres"
+  }
+}
+
+run "config_carries_posture_and_proxy_lite" {
+  command = apply
+
+  variables {
+    posture = "observe"
+  }
+
+  assert {
+    condition     = can(regex("posture = \"observe\"", local.config_rendered))
+    error_message = "rendered config must record the posture"
+  }
+
+  assert {
+    condition     = can(regex("proxy_lite:\\s*\\n\\s*enabled: true", local.config_rendered))
+    error_message = "rendered config must explicitly enable proxy_lite (writer-side flip, never Default())"
+  }
+}
+
+run "config_wires_otel_when_endpoint_set" {
+  command = apply
+
+  assert {
+    condition     = can(regex("endpoint: \"otel.example.com:4317\"", local.config_rendered))
+    error_message = "otel_endpoint must be wired into the observability config"
+  }
+}
+
+run "bootstrap_token_matches_spec05_format" {
+  command = apply
+
+  assert {
+    condition     = can(regex("^cvat_[A-Za-z0-9_-]{43}$", local.bootstrap_token))
+    error_message = "bootstrap token must match spec 05's ^cvat_[A-Za-z0-9_-]{43}$"
+  }
+}
+
+run "image_ssm_parameter_holds_pinned_tag" {
+  command = apply
+
+  assert {
+    condition     = aws_ssm_parameter.image.value == "ghcr.io/clawvisor/clawvisor:v1.4.2"
+    error_message = "the SSM image parameter must hold the pinned image tag (the upgrade lever)"
+  }
+}

--- a/deploy/terraform/modules/vm-docker/tests/render.tftest.hcl
+++ b/deploy/terraform/modules/vm-docker/tests/render.tftest.hcl
@@ -85,3 +85,62 @@ run "image_ssm_parameter_holds_pinned_tag" {
     error_message = "the SSM image parameter must hold the pinned image tag (the upgrade lever)"
   }
 }
+
+run "cloudinit_pins_and_verifies_docker_compose" {
+  command = apply
+
+  assert {
+    condition     = can(regex("releases/download/v2.29.7/docker-compose-linux", local.user_data))
+    error_message = "cloud-init must download a pinned docker compose release tag"
+  }
+
+  assert {
+    condition     = !can(regex("releases/latest/download", local.user_data))
+    error_message = "cloud-init must NOT pull docker compose from the floating latest release"
+  }
+
+  assert {
+    condition     = can(regex("sha256sum -c", local.user_data))
+    error_message = "cloud-init must checksum-verify the docker compose binary before install"
+  }
+}
+
+run "deploy_script_gates_and_hardens_reconcile" {
+  command = apply
+
+  # Snapshot failure must abort, not continue (README snapshot-before-restart
+  # guarantee).
+  assert {
+    condition     = can(regex("snapshot failed; aborting upgrade", local.deploy_rendered))
+    error_message = "deploy script must abort the upgrade when the pre-upgrade snapshot fails"
+  }
+
+  assert {
+    condition     = !can(regex("snapshot failed; continuing", local.deploy_rendered))
+    error_message = "deploy script must not continue past a failed snapshot"
+  }
+
+  # pull/up is gated on change: the no-op else branch proves the guard wraps
+  # the pull/up path (steady-state timer fires no longer restart the stack).
+  assert {
+    condition     = can(regex("already at .*nothing to do", local.deploy_rendered))
+    error_message = "deploy script must gate pull/up on an image change (a no-op branch for steady state)"
+  }
+}
+
+run "admin_url_output_matches_pr_body" {
+  command = apply
+
+  assert {
+    condition     = output.admin_url == "https://clawvisor.example.com:8443"
+    error_message = "admin_url output must expose the admin surface on the admin port (PR body: :8443)"
+  }
+}
+
+run "accepts_kms_key_arn_for_cmk_refs" {
+  command = apply
+
+  variables {
+    kms_key_arn = "arn:aws:kms:us-east-1:123456789012:key/abcd1234-ab12-cd34-ef56-abcdef123456"
+  }
+}

--- a/deploy/terraform/modules/vm-docker/tests/validate.tftest.hcl
+++ b/deploy/terraform/modules/vm-docker/tests/validate.tftest.hcl
@@ -1,0 +1,125 @@
+# Variable-validation tests. No credentials: every run block uses
+# command = plan and expects the plan to FAIL at variable validation, so no
+# provider calls happen. A minimal valid variable set is supplied per block;
+# the one bad variable under test triggers the expected failure.
+
+# Mock AWS only (no credentials). `random` is a local provider and runs for
+# real. mock_data feeds the data sources so plan reaches variable validation
+# instead of erroring on empty default-VPC lookups.
+mock_provider "aws" {
+  mock_data "aws_vpc" {
+    defaults = { id = "vpc-test" }
+  }
+  mock_data "aws_subnets" {
+    defaults = { ids = ["subnet-a", "subnet-b"] }
+  }
+  mock_data "aws_ami" {
+    defaults = { id = "ami-test" }
+  }
+  mock_data "aws_iam_policy_document" {
+    defaults = { json = "{}" }
+  }
+}
+
+variables {
+  region              = "us-east-1"
+  public_fqdn         = "clawvisor.example.com"
+  acme_email          = "ops@example.com"
+  agent_ingress_cidrs = ["10.0.0.0/8"]
+  admin_ingress_cidrs = ["10.0.0.0/8"]
+}
+
+run "rejects_latest_image" {
+  command = plan
+
+  variables {
+    image = "ghcr.io/clawvisor/clawvisor:latest"
+  }
+
+  expect_failures = [var.image]
+}
+
+run "rejects_untagged_image" {
+  command = plan
+
+  variables {
+    image = "ghcr.io/clawvisor/clawvisor"
+  }
+
+  expect_failures = [var.image]
+}
+
+run "accepts_pinned_image" {
+  command = plan
+
+  variables {
+    image = "ghcr.io/clawvisor/clawvisor:v1.4.2"
+  }
+}
+
+run "rejects_vault_backend_gcp" {
+  command = plan
+
+  variables {
+    image         = "ghcr.io/clawvisor/clawvisor:v1.4.2"
+    vault_backend = "gcp"
+  }
+
+  expect_failures = [var.vault_backend]
+}
+
+run "rejects_db_container" {
+  command = plan
+
+  variables {
+    image = "ghcr.io/clawvisor/clawvisor:v1.4.2"
+    db    = "container"
+  }
+
+  expect_failures = [var.db]
+}
+
+run "rejects_invalid_posture" {
+  command = plan
+
+  variables {
+    image   = "ghcr.io/clawvisor/clawvisor:v1.4.2"
+    posture = "lockdown"
+  }
+
+  expect_failures = [var.posture]
+}
+
+run "rejects_public_agent_cidr_without_ack" {
+  command = plan
+
+  variables {
+    image                        = "ghcr.io/clawvisor/clawvisor:v1.4.2"
+    agent_ingress_cidrs          = ["0.0.0.0/0"]
+    i_understand_public_exposure = false
+  }
+
+  expect_failures = [var.agent_ingress_cidrs]
+}
+
+run "rejects_public_admin_cidr_without_ack" {
+  command = plan
+
+  variables {
+    image                        = "ghcr.io/clawvisor/clawvisor:v1.4.2"
+    admin_ingress_cidrs          = ["0.0.0.0/0"]
+    i_understand_public_exposure = false
+  }
+
+  expect_failures = [var.admin_ingress_cidrs]
+}
+
+run "accepts_public_cidr_with_ack" {
+  command = plan
+
+  variables {
+    image                        = "ghcr.io/clawvisor/clawvisor:v1.4.2"
+    agent_ingress_cidrs          = ["0.0.0.0/0"]
+    i_understand_public_exposure = true
+  }
+}

--- a/deploy/terraform/modules/vm-docker/tests/validate.tftest.hcl
+++ b/deploy/terraform/modules/vm-docker/tests/validate.tftest.hcl
@@ -123,3 +123,67 @@ run "accepts_public_cidr_with_ack" {
     i_understand_public_exposure = true
   }
 }
+
+run "rejects_reserved_secret_in_extra_env" {
+  command = plan
+
+  variables {
+    image     = "ghcr.io/clawvisor/clawvisor:v1.4.2"
+    extra_env = { JWT_SECRET = "shadow-me" }
+  }
+
+  expect_failures = [var.extra_env]
+}
+
+run "accepts_non_reserved_extra_env" {
+  command = plan
+
+  variables {
+    image     = "ghcr.io/clawvisor/clawvisor:v1.4.2"
+    extra_env = { LOG_LEVEL = "debug" }
+  }
+}
+
+run "rejects_graviton_instance_type" {
+  command = plan
+
+  variables {
+    image         = "ghcr.io/clawvisor/clawvisor:v1.4.2"
+    instance_type = "t4g.micro"
+  }
+
+  expect_failures = [var.instance_type]
+}
+
+run "rejects_vpc_id_without_subnets" {
+  command = plan
+
+  variables {
+    image  = "ghcr.io/clawvisor/clawvisor:v1.4.2"
+    vpc_id = "vpc-0123456789abcdef0"
+  }
+
+  expect_failures = [var.vpc_id]
+}
+
+run "rejects_single_db_subnet" {
+  command = plan
+
+  variables {
+    image         = "ghcr.io/clawvisor/clawvisor:v1.4.2"
+    db_subnet_ids = ["subnet-a"]
+  }
+
+  expect_failures = [var.db_subnet_ids]
+}
+
+run "rejects_literal_kms_key_arn" {
+  command = plan
+
+  variables {
+    image       = "ghcr.io/clawvisor/clawvisor:v1.4.2"
+    kms_key_arn = "not-an-arn"
+  }
+
+  expect_failures = [var.kms_key_arn]
+}

--- a/deploy/terraform/modules/vm-docker/variables.tf
+++ b/deploy/terraform/modules/vm-docker/variables.tf
@@ -1,0 +1,216 @@
+# Input variables for the vm-docker module.
+#
+# v1 is AWS-only. The `cloud` variable from earlier drafts is intentionally
+# absent (PRD §13 / spec 03 "v1 scope"): there is one cloud, so there is no
+# selector. `db` and `vault_backend` keep their variable form for forward
+# compatibility but validate to the single v1-supported value each, so a
+# `plan` that asks for a deferred option fails loudly instead of silently
+# doing something else.
+
+variable "name" {
+  type        = string
+  default     = "clawvisor"
+  description = "Resource name prefix for every resource this module creates."
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{0,30}[a-z0-9]$", var.name))
+    error_message = "name must be lowercase alphanumeric with hyphens, 2-32 chars, starting with a letter (used as an AWS resource name prefix)."
+  }
+}
+
+variable "region" {
+  type        = string
+  description = "AWS region to deploy into, e.g. \"us-east-1\"."
+}
+
+variable "image" {
+  type        = string
+  description = "Full container image reference including an immutable tag, e.g. \"ghcr.io/clawvisor/clawvisor:v1.4.2\". The `latest` tag is rejected."
+
+  validation {
+    # A pinned tag is mandatory: `latest` makes upgrades non-deterministic and
+    # makes rollback impossible. The upgrade mechanism keys entirely off this
+    # tag changing (SSM parameter), so a floating tag defeats it.
+    condition     = length(regexall(":latest$", var.image)) == 0 && length(regexall(":[^/]+$", var.image)) == 1
+    error_message = "image must include an explicit non-latest tag (e.g. ghcr.io/clawvisor/clawvisor:v1.4.2); \"latest\" and untagged references are rejected."
+  }
+}
+
+variable "posture" {
+  type        = string
+  default     = "observe"
+  description = "Named security posture (PRD §4): observe | govern | contain. Rendered into the mounted config.yaml. NOTE: the concrete preset knobs come from spec 02; until it merges the module ships observe-only proxy-lite config and gates the govern/contain preset knobs behind a seam (see config.yaml.tftpl)."
+
+  validation {
+    condition     = contains(["observe", "govern", "contain"], var.posture)
+    error_message = "posture must be one of: observe, govern, contain."
+  }
+}
+
+variable "db" {
+  type        = string
+  default     = "managed"
+  description = "Database mode. v1 supports only \"managed\" (RDS Postgres). \"container\" (postgres sidecar on a data volume) is deferred to v1.1."
+
+  validation {
+    condition     = var.db == "managed"
+    error_message = "db must be \"managed\" in v1. The \"container\" sidecar option is deferred to v1.1 (spec 03 v1 scope)."
+  }
+}
+
+variable "db_instance_class" {
+  type        = string
+  default     = "db.t4g.micro"
+  description = "RDS instance class for the managed Postgres database."
+}
+
+variable "db_allocated_storage" {
+  type        = number
+  default     = 20
+  description = "Allocated storage (GiB) for the managed Postgres database."
+}
+
+variable "vault_backend" {
+  type        = string
+  default     = "local"
+  description = "Vault backend passed through to VAULT_BACKEND. v1 supports only \"local\" (AES-256-GCM in DB). The AWS Secrets Manager reference backend arrives with spec 10."
+
+  validation {
+    condition     = var.vault_backend == "local"
+    error_message = "vault_backend must be \"local\" in v1. Reference backends (aws-sm) ship with spec 10; the \"gcp\" backend is not available in the AWS-only module."
+  }
+}
+
+variable "jwt_secret_ref" {
+  type        = string
+  default     = ""
+  description = "ARN of an AWS Secrets Manager secret holding JWT_SECRET. Empty ⇒ the instance generates one at first boot and stores it in Secrets Manager. NEVER a literal secret value — literals would land in Terraform state."
+
+  validation {
+    condition     = var.jwt_secret_ref == "" || can(regex("^arn:aws[a-z-]*:secretsmanager:", var.jwt_secret_ref))
+    error_message = "jwt_secret_ref must be empty or an AWS Secrets Manager ARN (arn:aws:secretsmanager:...). Do not pass a literal secret value."
+  }
+}
+
+variable "vault_key_ref" {
+  type        = string
+  default     = ""
+  description = "ARN of an AWS Secrets Manager secret holding VAULT_KEY. Same semantics as jwt_secret_ref; empty ⇒ generated on-instance."
+
+  validation {
+    condition     = var.vault_key_ref == "" || can(regex("^arn:aws[a-z-]*:secretsmanager:", var.vault_key_ref))
+    error_message = "vault_key_ref must be empty or an AWS Secrets Manager ARN (arn:aws:secretsmanager:...). Do not pass a literal secret value."
+  }
+}
+
+variable "otel_endpoint" {
+  type        = string
+  default     = ""
+  description = "OTLP endpoint for observability export (spec 01), e.g. \"otel.example.com:4317\". Empty disables export."
+}
+
+variable "public_fqdn" {
+  type        = string
+  description = "DNS name Caddy serves and requests an ACME certificate for. A DNS A/AAAA record for this name MUST resolve to the instance public address (the server_ip output) before the ACME challenge runs, or certificate issuance fails. See README \"DNS for ACME\"."
+}
+
+variable "acme_email" {
+  type        = string
+  description = "Email used for Let's Encrypt/ACME account registration."
+
+  validation {
+    condition     = can(regex("^[^@ ]+@[^@ ]+\\.[^@ ]+$", var.acme_email))
+    error_message = "acme_email must be a valid email address."
+  }
+}
+
+variable "agent_ingress_cidrs" {
+  type        = list(string)
+  default     = []
+  description = "CIDRs allowed to reach the agent LLM/proxy endpoint (/v1/*, /skill/install/*) on 443. Set to your VPN/office/CI egress ranges. Empty = deny all (the deploy is unreachable by agents until set — deliberate)."
+
+  # Cross-variable validation requires Terraform >= 1.9 (see versions.tf).
+  validation {
+    condition = var.i_understand_public_exposure || length([
+      for c in var.agent_ingress_cidrs : c if c == "0.0.0.0/0" || c == "::/0"
+    ]) == 0
+    error_message = "agent_ingress_cidrs contains a public CIDR (0.0.0.0/0 or ::/0). Internet-exposing the agent endpoint requires setting i_understand_public_exposure = true."
+  }
+}
+
+variable "admin_ingress_cidrs" {
+  type        = list(string)
+  default     = []
+  description = "CIDRs allowed to reach the admin dashboard + management API on the admin port. Keep tighter than agent_ingress_cidrs — VPN/allowlist only. Empty = deny all."
+
+  # Cross-variable validation requires Terraform >= 1.9 (see versions.tf).
+  validation {
+    condition = var.i_understand_public_exposure || length([
+      for c in var.admin_ingress_cidrs : c if c == "0.0.0.0/0" || c == "::/0"
+    ]) == 0
+    error_message = "admin_ingress_cidrs contains a public CIDR (0.0.0.0/0 or ::/0). Internet-exposing the admin surface requires setting i_understand_public_exposure = true (and is strongly discouraged for a security console)."
+  }
+}
+
+variable "i_understand_public_exposure" {
+  type        = bool
+  default     = false
+  description = "Must be explicitly true for the module to accept 0.0.0.0/0 (or ::/0) in either ingress list. Internet-exposing a security console is a conscious choice; otherwise plan fails validation."
+}
+
+variable "backup_retention_days" {
+  type        = number
+  default     = 7
+  description = "Managed-DB backup retention (days). Also bounds how many upgrade snapshots are kept before pruning."
+
+  validation {
+    condition     = var.backup_retention_days >= 1 && var.backup_retention_days <= 35
+    error_message = "backup_retention_days must be between 1 and 35 (RDS automated-backup limit)."
+  }
+}
+
+variable "instance_type" {
+  type        = string
+  default     = "t3.small"
+  description = "EC2 instance type for the application VM."
+}
+
+variable "max_users" {
+  type        = number
+  default     = 0
+  description = "0 ⇒ unset (no cap, PRD §5). >0 sets MAX_USERS in the container env."
+}
+
+variable "extra_env" {
+  type        = map(string)
+  default     = {}
+  description = "Escape hatch: extra environment variables merged LAST into the compose app env. Do not put secret literals here — they land in Terraform state."
+}
+
+# --- Placement -------------------------------------------------------------
+# Optional. When empty the module uses the account's default VPC and its
+# subnets, so examples/aws-minimal needs only region + fqdn + email + CIDRs.
+
+variable "vpc_id" {
+  type        = string
+  default     = ""
+  description = "VPC to deploy into. Empty ⇒ the account's default VPC."
+}
+
+variable "subnet_id" {
+  type        = string
+  default     = ""
+  description = "Subnet for the EC2 instance. Empty ⇒ the first default-VPC subnet."
+}
+
+variable "db_subnet_ids" {
+  type        = list(string)
+  default     = []
+  description = "Subnets for the RDS subnet group (needs >= 2 AZs). Empty ⇒ all default-VPC subnets."
+}
+
+variable "key_name" {
+  type        = string
+  default     = ""
+  description = "Optional EC2 key pair name for break-glass SSH. The module does NOT open port 22 to the world; SSH, if the key is set, is reachable only from admin_ingress_cidrs. Routine ops (upgrade) use SSM, not SSH."
+}

--- a/deploy/terraform/modules/vm-docker/variables.tf
+++ b/deploy/terraform/modules/vm-docker/variables.tf
@@ -172,7 +172,15 @@ variable "backup_retention_days" {
 variable "instance_type" {
   type        = string
   default     = "t3.small"
-  description = "EC2 instance type for the application VM."
+  description = "EC2 instance type for the application VM. Must be an x86_64 (Intel/AMD) family: the AMI is pinned to al2023 x86_64, so a Graviton (arm64) type would plan cleanly then fail at launch with an architecture mismatch."
+
+  # The AMI filter is al2023-ami-*-x86_64 (aws.tf). Reject arm64/Graviton
+  # families (a1.*, and any family whose suffix has a digit followed by 'g'
+  # like t4g/m7g/c6gd/r7g/x2gd/g5g) so the arch mismatch is caught at plan.
+  validation {
+    condition     = !can(regex("(^a1\\.)|([0-9]+g[a-z]*\\.)", var.instance_type))
+    error_message = "instance_type must be an x86_64 family; Graviton/arm64 types (a1.*, t4g.*, m7g.*, c6gd.*, r7g.*, g5g.*, …) are rejected because the AMI is pinned to al2023 x86_64."
+  }
 }
 
 variable "max_users" {
@@ -185,6 +193,19 @@ variable "extra_env" {
   type        = map(string)
   default     = {}
   description = "Escape hatch: extra environment variables merged LAST into the compose app env. Do not put secret literals here — they land in Terraform state."
+
+  # extra_env is merged LAST into the compose environment: map, which outranks
+  # the Secrets-Manager env_file. Rejecting the reserved secret keys here stops
+  # a caller from shadowing the vaulted DATABASE_URL/JWT_SECRET/VAULT_KEY/
+  # bootstrap token with a plaintext value that would land in state/user_data
+  # (PRD §7 hard rules).
+  validation {
+    condition = length([
+      for k in keys(var.extra_env) : k
+      if contains(["DATABASE_URL", "JWT_SECRET", "VAULT_KEY", "CLAWVISOR_BOOTSTRAP_TOKEN"], k)
+    ]) == 0
+    error_message = "extra_env must not set a reserved secret key (DATABASE_URL, JWT_SECRET, VAULT_KEY, CLAWVISOR_BOOTSTRAP_TOKEN); those travel via the Secrets-Manager env_file, never the compose environment map."
+  }
 }
 
 # --- Placement -------------------------------------------------------------
@@ -195,6 +216,16 @@ variable "vpc_id" {
   type        = string
   default     = ""
   description = "VPC to deploy into. Empty ⇒ the account's default VPC."
+
+  # The default-VPC subnet auto-discovery (data.aws_subnets.default) only runs
+  # when vpc_id is empty. Supplying a non-default vpc_id without subnets would
+  # index an absent data source (crash at plan), so require explicit subnet_id
+  # and >= 2 db_subnet_ids alongside a custom vpc_id.
+  # Cross-variable validation requires Terraform >= 1.9 (see versions.tf).
+  validation {
+    condition     = var.vpc_id == "" || (var.subnet_id != "" && length(var.db_subnet_ids) >= 2)
+    error_message = "When vpc_id is set you must also set subnet_id and db_subnet_ids (>= 2 AZs); the module only auto-discovers subnets for the account's default VPC."
+  }
 }
 
 variable "subnet_id" {
@@ -207,10 +238,52 @@ variable "db_subnet_ids" {
   type        = list(string)
   default     = []
   description = "Subnets for the RDS subnet group (needs >= 2 AZs). Empty ⇒ all default-VPC subnets."
+
+  # The list flows straight to aws_db_subnet_group; a single subnet fails at
+  # apply with DBSubnetGroupDoesNotCoverEnoughAZs. Catch it at plan.
+  validation {
+    condition     = length(var.db_subnet_ids) == 0 || length(var.db_subnet_ids) >= 2
+    error_message = "db_subnet_ids must be empty (use the default-VPC subnets) or list at least 2 subnets in different AZs (RDS DB subnet groups require >= 2 AZs)."
+  }
 }
 
 variable "key_name" {
   type        = string
   default     = ""
   description = "Optional EC2 key pair name for break-glass SSH. The module does NOT open port 22 to the world; SSH, if the key is set, is reachable only from admin_ingress_cidrs. Routine ops (upgrade) use SSM, not SSH."
+}
+
+# --- Secret decryption -----------------------------------------------------
+
+variable "kms_key_arn" {
+  type        = string
+  default     = ""
+  description = "Optional KMS CMK ARN that encrypts operator-supplied jwt_secret_ref/vault_key_ref secrets. When set, the instance role is granted kms:Decrypt on it so the boot-time GetSecretValue can decrypt CMK-encrypted refs. Leave empty when the refs use the AWS-managed key (aws/secretsmanager), which the instance role can already decrypt."
+
+  validation {
+    condition     = var.kms_key_arn == "" || can(regex("^arn:aws[a-z-]*:kms:", var.kms_key_arn))
+    error_message = "kms_key_arn must be empty or an AWS KMS key ARN (arn:aws:kms:...)."
+  }
+}
+
+# --- Docker Compose plugin (pinned + checksum-verified in cloud-init) -------
+
+variable "docker_compose_version" {
+  type        = string
+  default     = "v2.29.7"
+  description = "Pinned docker compose v2 plugin release tag downloaded in the privileged cloud-init bootstrap. Must have a matching entry in docker_compose_sha256; the download is checksum-verified before install. Bumping this without updating docker_compose_sha256 fails the on-instance verification."
+}
+
+variable "docker_compose_sha256" {
+  type = map(string)
+  default = {
+    x86_64  = "383ce6698cd5d5bbf958d2c8489ed75094e34a77d340404d9f32c4ae9e12baf0"
+    aarch64 = "6e9fbd5daa20dca5d7d89145081ae8155d68ef2928b497d9f85b54fe0f9dbb2c"
+  }
+  description = "SHA256 of the docker-compose-linux-<arch> binary for docker_compose_version, keyed by `uname -m` arch. Verified with `sha256sum -c` before chmod+install so a compromised/renamed GitHub asset cannot land in the privileged bootstrap."
+
+  validation {
+    condition     = can(var.docker_compose_sha256["x86_64"]) && can(var.docker_compose_sha256["aarch64"])
+    error_message = "docker_compose_sha256 must provide checksums for both x86_64 and aarch64."
+  }
 }

--- a/deploy/terraform/modules/vm-docker/versions.tf
+++ b/deploy/terraform/modules/vm-docker/versions.tf
@@ -1,0 +1,19 @@
+# Provider and Terraform version constraints for the vm-docker module.
+#
+# v1 is AWS-only (PRD §13, spec 03 "v1 scope" section). GCP is v1.1 — the
+# `google` provider and all GCP resources were intentionally dropped, so the
+# module carries a single-cloud interface with no `cloud` selector variable.
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+}

--- a/scripts/mirror-terraform.sh
+++ b/scripts/mirror-terraform.sh
@@ -26,5 +26,8 @@ TAG="${GITHUB_REF_NAME:-$(git describe --tags --abbrev=0)}"
 echo "Splitting $SUBTREE_PREFIX and pushing to $MIRROR_REPO @ $TAG"
 SPLIT_SHA="$(git subtree split --prefix="$SUBTREE_PREFIX" HEAD)"
 git push "$MIRROR_REPO" "${SPLIT_SHA}:refs/heads/main" --force
-git push "$MIRROR_REPO" "HEAD:refs/tags/${TAG}" || true
+# Tag the SUBTREE commit, not the monorepo HEAD (which would push the whole
+# monorepo tree under the module tag). Do NOT swallow errors — a failed tag
+# push must fail the release, not silently ship a mismatched/absent tag.
+git push "$MIRROR_REPO" "${SPLIT_SHA}:refs/tags/${TAG}"
 echo "Mirror push complete."

--- a/scripts/mirror-terraform.sh
+++ b/scripts/mirror-terraform.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Publish-only registry mirror for the Terraform modules.
+#
+# DEFERRED TO v1.1 (PRD §6/§13): the monorepo path
+# (github.com/clawvisor/clawvisor//deploy/terraform/modules/vm-docker) is the
+# v1 distribution. The Terraform Registry requires a dedicated repo named
+# `terraform-clawvisor-modules`; this script subtree-pushes the modules there
+# on release tags. The terraform-ci.yml `mirror` job is disabled (`if: false`)
+# until that repo exists — flip it on then.
+#
+# This script is intentionally present-but-inert so the wiring is reviewable
+# now and a single flag flip enables it later. Running it without
+# MIRROR_REPO set is a no-op.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+MIRROR_REPO="${MIRROR_REPO:-}"
+if [ -z "$MIRROR_REPO" ]; then
+  echo "mirror-terraform: MIRROR_REPO unset — publishing is deferred to v1.1 (no-op)."
+  exit 0
+fi
+
+SUBTREE_PREFIX="deploy/terraform/modules"
+TAG="${GITHUB_REF_NAME:-$(git describe --tags --abbrev=0)}"
+
+echo "Splitting $SUBTREE_PREFIX and pushing to $MIRROR_REPO @ $TAG"
+SPLIT_SHA="$(git subtree split --prefix="$SUBTREE_PREFIX" HEAD)"
+git push "$MIRROR_REPO" "${SPLIT_SHA}:refs/heads/main" --force
+git push "$MIRROR_REPO" "HEAD:refs/tags/${TAG}" || true
+echo "Mirror push complete."

--- a/scripts/terraform-plan-secret-scan.sh
+++ b/scripts/terraform-plan-secret-scan.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# CI assertion for spec 03: "No secret literal in terraform plan -json output."
+#
+# GOTCHA (verified): `terraform show -json` does NOT redact *known* sensitive
+# values — it emits them in plaintext alongside a sensitivity map. Only values
+# that are still "known after apply" are absent. So this scan runs a FRESH plan
+# (no prior state), which is exactly the state an operator reviews before their
+# first apply: every generated secret (bootstrap token, DB password) is
+# unknown, and the JWT/VAULT values are generated on-instance and never enter
+# Terraform at all. The scan therefore passes on a correct module and FAILS if
+# a regression makes any secret known-and-plaintext at plan time (e.g. moving a
+# generated value into a non-sensitive output or a plaintext local).
+#
+# Target: examples/local-docker, which uses only the `local` + `random`
+# providers, so a fresh plan needs NO cloud credentials and is deterministic.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+DIR=deploy/terraform/examples/local-docker
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK" "$DIR/tfplan.bin" "$DIR/plan.json"' EXIT
+
+# Fresh: no prior state (TF_DATA_DIR isolates the plugin cache from any local
+# .terraform, and we never point at an existing state file).
+export TF_DATA_DIR="$WORK/.terraform"
+terraform -chdir="$DIR" init -input=false -no-color >/dev/null
+terraform -chdir="$DIR" plan -out=tfplan.bin -input=false -no-color >/dev/null
+terraform -chdir="$DIR" show -json tfplan.bin > "$DIR/plan.json"
+
+fail=0
+scan() {
+  local label="$1" pattern="$2"
+  # -E extended regex, -o so the match (not the whole line) is what we report.
+  if grep -Eoc "$pattern" "$DIR/plan.json" >/dev/null 2>&1 && grep -Eq "$pattern" "$DIR/plan.json"; then
+    echo "LEAK ($label): pattern '$pattern' found in plan JSON"
+    fail=1
+  fi
+}
+
+# A real bootstrap token: cvat_ + exactly 43 base64url chars.
+scan "bootstrap token" 'cvat_[A-Za-z0-9_-]{43}'
+# A populated JWT_SECRET / VAULT_KEY / DATABASE password literal.
+scan "JWT_SECRET literal"    'JWT_SECRET=[^"[:space:]]+'
+scan "VAULT_KEY literal"     'VAULT_KEY=[^"[:space:]]{20,}'
+scan "DB password in url"    'postgres://[a-z]+:[^@[:space:]]{10,}@'
+
+if [ "$fail" -ne 0 ]; then
+  echo "FAIL: secret literal(s) present in terraform plan -json output."
+  exit 1
+fi
+echo "OK: no secret literals in the fresh plan JSON."

--- a/scripts/terraform-real-aws-lane.sh
+++ b/scripts/terraform-real-aws-lane.sh
@@ -73,12 +73,29 @@ until aws rds describe-db-snapshots --region "$REGION" \
 done
 echo "PASS: pre-upgrade snapshot exists"
 
-echo "== assert the running image advanced to $IMG_V2 =="
+echo "== assert the DEPLOYED image advanced to $IMG_V2 (read .deployed-image via SSM) =="
+# A /health re-poll only proves the instance is up — it can be stuck on the
+# old-but-healthy image. Read the reconciler's state file over SSM RunShell and
+# assert it actually advanced, so a reconcile that never fired is caught.
+INSTANCE_ID="$(terraform -chdir="$DIR" output -raw instance_id)"
 deadline=$(( $(date +%s) + 600 ))
-until curl -fsSk "${SERVER_URL}/health" >/dev/null 2>&1; do
-  [ "$(date +%s)" -ge "$deadline" ] && { echo "FAIL: server unhealthy after upgrade"; exit 1; }
+while true; do
+  cmd_id="$(aws ssm send-command --region "$REGION" \
+    --instance-ids "$INSTANCE_ID" \
+    --document-name "AWS-RunShellScript" \
+    --parameters 'commands=["cat /etc/clawvisor/.deployed-image"]' \
+    --query 'Command.CommandId' --output text)"
+  sleep 5
+  deployed="$(aws ssm get-command-invocation --region "$REGION" \
+    --command-id "$cmd_id" --instance-id "$INSTANCE_ID" \
+    --query 'StandardOutputContent' --output text 2>/dev/null | tr -d '[:space:]')"
+  [ "$deployed" = "$IMG_V2" ] && break
+  [ "$(date +%s)" -ge "$deadline" ] && { echo "FAIL: .deployed-image never advanced to $IMG_V2 (last: '$deployed')"; exit 1; }
   sleep 15
 done
-echo "PASS: server healthy post-upgrade"
+echo "PASS: .deployed-image advanced to $IMG_V2"
+
+echo "== confirm the server is healthy on the new image =="
+curl -fsSk "${SERVER_URL}/health" >/dev/null 2>&1 && echo "PASS: /health 200 post-upgrade" || { echo "FAIL: server unhealthy after upgrade"; exit 1; }
 
 echo "ALL GOOD (destroy runs on trap exit)"

--- a/scripts/terraform-real-aws-lane.sh
+++ b/scripts/terraform-real-aws-lane.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Keyed real-AWS lane for the vm-docker module (spec 03 Tests, AWS-only).
+#
+#   apply → health check → SSM-param upgrade → snapshot exists → destroy
+#
+# Gated on AWS credentials; the terraform-ci.yml workflow only invokes this on
+# a manual dispatch with real_cloud=true. It performs REAL, billable AWS
+# operations. Resources are tagged clawvisor:managed=true / clawvisor-ci for a
+# sweeper to reclaim on failure.
+#
+# Required env (set by the workflow from repo secrets/vars):
+#   AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
+#   TF_VAR_region, TF_VAR_public_fqdn, TF_VAR_acme_email, TF_VAR_office_cidrs
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+if [ -z "${AWS_ACCESS_KEY_ID:-}" ]; then
+  echo "No AWS credentials; skipping real-AWS lane."
+  exit 0
+fi
+
+DIR=deploy/terraform/examples/aws-minimal
+REGION="${TF_VAR_region:?set TF_VAR_region}"
+NAME=clawvisor
+IMG_V1="ghcr.io/clawvisor/clawvisor:v1.4.2"
+IMG_V2="ghcr.io/clawvisor/clawvisor:v1.4.3"
+
+cleanup() {
+  echo "== destroy =="
+  terraform -chdir="$DIR" destroy -auto-approve -no-color || \
+    echo "WARNING: destroy failed; resources tagged clawvisor:managed for the sweeper"
+}
+trap cleanup EXIT
+
+terraform -chdir="$DIR" init -input=false -no-color
+
+echo "== apply (image $IMG_V1) =="
+# The example pins the image internally; override via the module by editing or
+# a -var if the example exposes one. Here we drive upgrade through the module's
+# SSM parameter directly (the honest upgrade lever), so apply establishes it.
+terraform -chdir="$DIR" apply -auto-approve -input=false -no-color
+
+SERVER_URL="$(terraform -chdir="$DIR" output -raw server_url)"
+SERVER_IP="$(terraform -chdir="$DIR" output -raw server_ip)"
+echo "server_url=$SERVER_URL server_ip=$SERVER_IP"
+echo "NOTE: the public_fqdn A record must resolve to $SERVER_IP for ACME."
+
+SSM_PARAM="/clawvisor/${NAME}/image"
+
+echo "== health check (poll /health via the agent endpoint) =="
+deadline=$(( $(date +%s) + 600 ))
+until curl -fsSk "${SERVER_URL}/health" >/dev/null 2>&1; do
+  [ "$(date +%s)" -ge "$deadline" ] && { echo "FAIL: /health never returned 200"; exit 1; }
+  sleep 15
+done
+echo "PASS: /health 200"
+
+echo "== upgrade: bump the SSM image parameter to $IMG_V2 =="
+# The upgrade lever: set the desired image. In the module, `terraform apply`
+# with a new `image` does this; here we set it directly to exercise the
+# on-instance timer without editing the example.
+aws ssm put-parameter --region "$REGION" --name "$SSM_PARAM" \
+  --type String --overwrite --value "$IMG_V2"
+
+echo "== assert a pre-upgrade RDS snapshot appears =="
+deadline=$(( $(date +%s) + 600 ))
+until aws rds describe-db-snapshots --region "$REGION" \
+        --db-instance-identifier "${NAME}-db" --snapshot-type manual \
+        --query "DBSnapshots[?starts_with(DBSnapshotIdentifier, '${NAME}-preupgrade-')].DBSnapshotIdentifier" \
+        --output text | grep -q "${NAME}-preupgrade-"; do
+  [ "$(date +%s)" -ge "$deadline" ] && { echo "FAIL: no pre-upgrade snapshot within 10m"; exit 1; }
+  sleep 20
+done
+echo "PASS: pre-upgrade snapshot exists"
+
+echo "== assert the running image advanced to $IMG_V2 =="
+deadline=$(( $(date +%s) + 600 ))
+until curl -fsSk "${SERVER_URL}/health" >/dev/null 2>&1; do
+  [ "$(date +%s)" -ge "$deadline" ] && { echo "FAIL: server unhealthy after upgrade"; exit 1; }
+  sleep 15
+done
+echo "PASS: server healthy post-upgrade"
+
+echo "ALL GOOD (destroy runs on trap exit)"


### PR DESCRIPTION
Ships `deploy/terraform/modules/vm-docker`: single-VM Docker deployment on AWS wrapping the existing `deploy/` artifacts. Deny-all two-zone ingress by default (`agent_ingress_cidrs` / `admin_ingress_cidrs`), plan-time failure on `0.0.0.0/0` without `i_understand_public_exposure = true`, `:latest` rejected, bootstrap admin token generated in module format and delivered via secret manager (sensitive output), JWT/vault secrets generated on-instance (never in state), posture rendered into a mounted config file, honest upgrade path (SSM + on-instance watcher + RDS snapshot-before-restart, no remote-exec). Includes `admin_url` (management API, :8443) and per-target `install_commands` outputs, a terraform CI lane (offline: init/validate/test + docker compose render), examples, and a cred-gated real-AWS lane for later.

Tests: 25/25 `terraform test`, both examples validate.

**Stack 5/15** — base: `tc-stack-1`. Retarget to `main` after wave 1 merges. Bootstrap contract depends on #608.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

