### PR TITLE
feat(runtime): contain posture as a strict superset of govern

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,10 +51,15 @@ jobs:
       # byte-identical, proving Contain is a strict superset by construction.
       # This lane gates exposing Contain; until it is required-blocking the
       # posture stays behind experimental_contain (config + module gate).
+      #
+      # -count=1 is required: Go's test cache does not key on the
+      # CLAWVISOR_E2E_POSTURE env var, and setup-go@v5 shares GOCACHE across
+      # jobs by go.sum, so without it the default-posture lane's cached result
+      # would satisfy this lane and it would never run under Contain.
       - name: Contain-posture scenarios
         env:
           CLAWVISOR_E2E_POSTURE: contain
-        run: go test ./e2e/scenarios/...
+        run: go test -count=1 ./e2e/scenarios/...
 
   frontend:
     name: Frontend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,27 @@ jobs:
       - name: Test
         run: go test ./...
 
+  contain-parity:
+    name: Contain parity (spec 09)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      # Re-run the deterministic e2e scenario suite under the Contain posture:
+      # the runtime proxy is booted and LLM traffic is routed through
+      # proxy-lite (llm_route=proxy_lite). Every Govern scenario must pass
+      # byte-identical, proving Contain is a strict superset by construction.
+      # This lane gates exposing Contain; until it is required-blocking the
+      # posture stays behind experimental_contain (config + module gate).
+      - name: Contain-posture scenarios
+        env:
+          CLAWVISOR_E2E_POSTURE: contain
+        run: go test ./e2e/scenarios/...
+
   frontend:
     name: Frontend
     runs-on: ubuntu-latest

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -8,6 +8,8 @@ on:
       - "provider/**"
       - ".github/workflows/terraform-ci.yml"
       - "scripts/mirror-terraform.sh"
+      - "scripts/terraform-plan-secret-scan.sh"
+      - "scripts/terraform-real-aws-lane.sh"
     tags: ["v*"]
   pull_request:
     branches: [main]
@@ -15,6 +17,9 @@ on:
       - "deploy/terraform/**"
       - "provider/**"
       - ".github/workflows/terraform-ci.yml"
+      - "scripts/mirror-terraform.sh"
+      - "scripts/terraform-plan-secret-scan.sh"
+      - "scripts/terraform-real-aws-lane.sh"
   workflow_dispatch:
     inputs:
       real_cloud:
@@ -68,7 +73,12 @@ jobs:
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: "~> 1.9"
-      - name: render + validate compose
+      - name: install caddy (for Caddyfile validation)
+        run: |
+          curl -fsSL https://github.com/caddyserver/caddy/releases/download/v2.8.4/caddy_2.8.4_linux_amd64.tar.gz \
+            | sudo tar -xz -C /usr/local/bin caddy
+          caddy version
+      - name: render + validate compose + Caddyfile
         run: |
           cd deploy/terraform/examples/local-docker
           ./run.sh
@@ -80,23 +90,36 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.real_cloud }}
     environment: terraform-aws
+    # The lane uses fixed resource names (NAME=clawvisor: shared SSM param, DB,
+    # snapshots). Serialize the lane globally so two manual dispatches can't
+    # clobber each other's SSM param / DB / snapshots. Never cancel a run
+    # mid-apply — that would orphan half-created billable resources.
+    concurrency:
+      group: terraform-real-aws-lane
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: "~> 1.9"
 
+      # The `secrets` context is not available in `if:` expressions (using it
+      # invalidates the whole workflow at parse time), so gate via a step
+      # output instead.
       - name: guard — require AWS credentials
+        id: guard
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         run: |
           if [ -z "$AWS_ACCESS_KEY_ID" ]; then
             echo "No AWS credentials configured; skipping real-cloud lane."
-            exit 0
+            echo "has_aws=0" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_aws=1" >> "$GITHUB_OUTPUT"
           fi
 
       - name: apply → upgrade → snapshot → destroy
-        if: ${{ secrets.AWS_ACCESS_KEY_ID != '' }}
+        if: ${{ steps.guard.outputs.has_aws == '1' }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -133,10 +133,20 @@ telemetry:
 #   govern  — observe + control: proxy-lite enabled, upstream auth = vault
 #             (inject the stored key; client-presented API keys are stripped),
 #             enforcement = enforce.
-#   contain — not yet available; startup fails with a clear error until the
-#             runtime-proxy superset lands.
+#   contain — govern + network-layer containment of the agent process via the
+#             runtime proxy (HTTP(S)_PROXY injection, TLS MITM, egress policy).
+#             LLM traffic still flows through proxy-lite unchanged — Contain is
+#             a strict superset of Govern (runtime_proxy.llm_route=proxy_lite).
+#             EXPERIMENTAL: requires experimental_contain: true (below) until
+#             the capability-parity CI lane is required-blocking. The preset
+#             also sets runtime_proxy.enabled=true + llm_route=proxy_lite.
 #
 # posture: observe
+
+# experimental_contain gates the not-yet-required-blocking Contain posture.
+# posture: contain fails startup unless this is true. Env:
+# CLAWVISOR_EXPERIMENTAL_CONTAIN. Removed once the parity lane blocks CI.
+# experimental_contain: false
 
 # config_schema marks the config convention version. The setup wizard writes
 # `config_schema: 2` + an explicit `proxy_lite.enabled:` on every fresh

--- a/deploy/terraform/modules/vm-docker/README.md
+++ b/deploy/terraform/modules/vm-docker/README.md
@@ -36,7 +36,8 @@ distribution. A publish-only registry mirror is deferred to v1.1 (PRD §6).
 | `name` | string | `"clawvisor"` | resource name prefix |
 | `region` | string | — (required) | AWS region |
 | `image` | string | — (required) | full image ref incl. tag; `:latest`/untagged rejected |
-| `posture` | string | `"observe"` | `observe`/`govern`/`contain`; rendered into config.yaml (preset knobs land with spec 02) |
+| `posture` | string | `"observe"` | `observe`/`govern`/`contain`; rendered into config.yaml as the active `posture:` key (server applies the preset). `contain` requires `experimental_contain = true` |
+| `experimental_contain` | bool | `false` | gate for the experimental Contain posture (spec 09). `posture = "contain"` is refused at plan time unless this is true; when set, writes `experimental_contain: true` into config.yaml. Removed when the parity lane is CI-required-blocking |
 | `db` | string | `"managed"` | v1 accepts only `"managed"` (RDS Postgres); `"container"` is v1.1 |
 | `db_instance_class` | string | `"db.t4g.micro"` | RDS instance class |
 | `db_allocated_storage` | number | `20` | RDS storage (GiB) |

--- a/deploy/terraform/modules/vm-docker/cloudinit.tf
+++ b/deploy/terraform/modules/vm-docker/cloudinit.tf
@@ -19,9 +19,10 @@ locals {
   })
 
   config_rendered = templatefile("${path.module}/templates/config.yaml.tftpl", {
-    public_fqdn   = var.public_fqdn
-    otel_endpoint = var.otel_endpoint
-    posture       = var.posture
+    public_fqdn          = var.public_fqdn
+    otel_endpoint        = var.otel_endpoint
+    posture              = var.posture
+    experimental_contain = var.experimental_contain
   })
 
   deploy_rendered = templatefile("${path.module}/templates/deploy.sh.tftpl", {

--- a/deploy/terraform/modules/vm-docker/templates/config.yaml.tftpl
+++ b/deploy/terraform/modules/vm-docker/templates/config.yaml.tftpl
@@ -32,14 +32,15 @@ observability:
 # --- Posture preset ---------------------------------------------------------
 # posture = "${posture}"
 #
-# SOFT DEPENDENCY ON SPEC 02. The concrete preset knobs (enforcement_mode,
-# upstream_auth, and the posture->config mapping) are defined by spec 02 and
-# are NOT yet present in this server build. Until spec 02 merges, this module
-# ships the observe-only proxy-lite config above for every posture value and
-# leaves this clearly-marked seam. When spec 02 lands, replace this block with
-# the rendered preset keys for ${posture} (the module already accepts and
-# validates the posture input, so only this template changes).
-%{ if posture != "observe" ~}
-# WARNING: posture "${posture}" was requested but preset knobs are not wired
-# yet (spec 02 pending). The server is running observe-only proxy-lite config.
+# Spec 02 defined the posture->config mapping (applyPosturePreset) and spec 09
+# added the Contain superset. The server applies the preset for this value at
+# load time; the concrete knobs (enforcement_mode, upstream_auth, and — for
+# contain — runtime_proxy.enabled + runtime_proxy.llm_route) are set by the
+# server from the posture, so this file only needs to carry the posture key.
+posture: "${posture}"
+%{ if experimental_contain ~}
+# Contain is experimental until the capability-parity lane is CI-required
+# (spec 09 D5). The gate flag is required for the server to accept
+# posture: contain.
+experimental_contain: true
 %{ endif ~}

--- a/deploy/terraform/modules/vm-docker/tests/render.tftest.hcl
+++ b/deploy/terraform/modules/vm-docker/tests/render.tftest.hcl
@@ -59,6 +59,38 @@ run "config_carries_posture_and_proxy_lite" {
   }
 }
 
+run "config_carries_contain_gate_when_enabled" {
+  command = apply
+
+  variables {
+    posture              = "contain"
+    experimental_contain = true
+  }
+
+  assert {
+    condition     = can(regex("posture: \"contain\"", local.config_rendered))
+    error_message = "rendered config must carry the active posture key for contain"
+  }
+
+  assert {
+    condition     = can(regex("experimental_contain: true", local.config_rendered))
+    error_message = "rendered config must set experimental_contain: true so the server accepts posture: contain"
+  }
+}
+
+run "config_omits_contain_gate_by_default" {
+  command = apply
+
+  variables {
+    posture = "observe"
+  }
+
+  assert {
+    condition     = !can(regex("experimental_contain: true", local.config_rendered))
+    error_message = "non-contain deploys must not emit the experimental_contain gate"
+  }
+}
+
 run "config_wires_otel_when_endpoint_set" {
   command = apply
 

--- a/deploy/terraform/modules/vm-docker/tests/validate.tftest.hcl
+++ b/deploy/terraform/modules/vm-docker/tests/validate.tftest.hcl
@@ -90,6 +90,27 @@ run "rejects_invalid_posture" {
   expect_failures = [var.posture]
 }
 
+run "rejects_contain_without_experimental_flag" {
+  command = plan
+
+  variables {
+    image   = "ghcr.io/clawvisor/clawvisor:v1.4.2"
+    posture = "contain"
+  }
+
+  expect_failures = [var.experimental_contain]
+}
+
+run "accepts_contain_with_experimental_flag" {
+  command = plan
+
+  variables {
+    image                = "ghcr.io/clawvisor/clawvisor:v1.4.2"
+    posture              = "contain"
+    experimental_contain = true
+  }
+}
+
 run "rejects_public_agent_cidr_without_ack" {
   command = plan
 

--- a/deploy/terraform/modules/vm-docker/variables.tf
+++ b/deploy/terraform/modules/vm-docker/variables.tf
@@ -47,6 +47,18 @@ variable "posture" {
   }
 }
 
+variable "experimental_contain" {
+  type        = bool
+  default     = false
+  description = "Gate for the experimental Contain posture (spec 09). posture = \"contain\" is refused at plan time unless this is true; when set the module writes experimental_contain: true into the rendered server config. Remove this variable (and the server-side config gate) in the release where CI runs the capability-parity lane required-blocking."
+
+  # Cross-variable refusal (Terraform >= 1.9): contain requires the flag.
+  validation {
+    condition     = var.posture != "contain" || var.experimental_contain
+    error_message = "posture = \"contain\" is experimental and must be opted into with experimental_contain = true until the capability-parity lane is required-blocking (spec 09)."
+  }
+}
+
 variable "db" {
   type        = string
   default     = "managed"

--- a/e2e/testapp/server.go
+++ b/e2e/testapp/server.go
@@ -240,6 +240,22 @@ runtime_proxy:
 	for k, v := range opts.extraEnv {
 		env = append(env, k+"="+v)
 	}
+	// Contain-posture parity matrix (spec 09): when CLAWVISOR_E2E_POSTURE=contain
+	// the scenario package re-runs every existing flow with the runtime proxy
+	// booted and LLM traffic routed through proxy-lite. LLM traffic still
+	// bypasses the runtime proxy (NO_PROXY), so proxy-lite sees byte-identical
+	// requests — the superset holds by construction. Only applied when the
+	// fixture has proxy_lite (the pre-flip scenario omits it) and the caller
+	// hasn't wired the runtime proxy itself. A fresh runtime-proxy port is
+	// allocated per attempt so early-exit retries don't reuse a colliding port.
+	if PostureFromEnv() == "contain" && !opts.omitProxyLite && !extraEnvHasKey(opts.extraEnv, "CLAWVISOR_RUNTIME_PROXY_ENABLED") {
+		rpPort := freePort(t)
+		env = append(env,
+			"CLAWVISOR_RUNTIME_PROXY_ENABLED=true",
+			fmt.Sprintf("CLAWVISOR_RUNTIME_PROXY_LISTEN_ADDR=127.0.0.1:%d", rpPort),
+			"CLAWVISOR_RUNTIME_LLM_ROUTE=proxy_lite",
+		)
+	}
 	cmd.Env = env
 
 	stdout, _ := cmd.StdoutPipe()
@@ -365,6 +381,23 @@ func (s *Server) waitDrains(timeout time.Duration) {
 	case <-done:
 	case <-time.After(timeout):
 	}
+}
+
+// PostureFromEnv returns the CI parity matrix posture selector
+// (CLAWVISOR_E2E_POSTURE): "contain" boots the runtime proxy + proxy_lite LLM
+// routing; anything else (incl. "govern"/"") is the baseline proxy-lite path.
+// Scenario helpers key their contain-only assertions off this.
+func PostureFromEnv() string {
+	return strings.ToLower(strings.TrimSpace(os.Getenv("CLAWVISOR_E2E_POSTURE")))
+}
+
+func extraEnvHasKey(extraEnv map[string]string, key string) bool {
+	for k := range extraEnv {
+		if k == key {
+			return true
+		}
+	}
+	return false
 }
 
 func freePort(t *testing.T) int {

--- a/internal/api/handlers/runtime.go
+++ b/internal/api/handlers/runtime.go
@@ -72,7 +72,12 @@ func (h *RuntimeHandler) CreateSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if h.manager == nil || h.cfg == nil || !h.cfg.RuntimeProxy.Enabled {
-		writeError(w, http.StatusConflict, "RUNTIME_PROXY_DISABLED", "runtime proxy is not enabled")
+		// Contract (spec 09 D6): contain-only control endpoints and any attempt
+		// to start a runtime-run/docker-run session require the runtime proxy.
+		// A correctly-postured contain install never hits this (the preset sets
+		// runtime_proxy.enabled=true); it fires only for a hand-configured
+		// server that asked for a contain-only API without the proxy.
+		writeError(w, http.StatusConflict, "RUNTIME_PROXY_DISABLED", "contain posture requires runtime_proxy.enabled=true (set posture: contain)")
 		return
 	}
 	var req struct {
@@ -436,6 +441,12 @@ func (h *RuntimeHandler) Status(w http.ResponseWriter, r *http.Request) {
 		"inject_stored_bearer": h.cfg != nil && h.cfg.RuntimePolicy.InjectStoredBearer,
 		"ca_cert_pem":          caCertPEM,
 		"starter_profiles":     runtimepolicy.StarterProfiles(),
+		"llm_route": func() string {
+			if h.cfg == nil || strings.TrimSpace(h.cfg.RuntimeProxy.LLMRoute) == "" {
+				return "direct"
+			}
+			return strings.ToLower(strings.TrimSpace(h.cfg.RuntimeProxy.LLMRoute))
+		}(),
 	}
 	if h.cfg != nil && h.cfg.ProxyLite.Enabled {
 		resp["proxy_lite_enabled"] = true

--- a/internal/clawvisorcli/cmd_agent_docker.go
+++ b/internal/clawvisorcli/cmd_agent_docker.go
@@ -26,6 +26,7 @@ import (
 var (
 	dockerContainerURL string
 	dockerProxyHost    string
+	dockerLLMRoute     string
 	dockerProxyPort    int
 	dockerCAInside     string
 	dockerCAHost       string
@@ -50,6 +51,12 @@ type dockerProxyOptions struct {
 	ProxyPort    int
 	CAInside     string
 	CAHost       string
+	// LLMRouteProxyLite mirrors the Contain superset (spec 09) for durable
+	// container launches: when true, the container's LLM traffic is pointed at
+	// proxy-lite (ANTHROPIC_BASE_URL/OPENAI_BASE_URL on the container URL) and
+	// the container URL host bypasses the runtime proxy via NO_PROXY. Set via
+	// --llm-route=proxy_lite; must match the server's runtime_proxy.llm_route.
+	LLMRouteProxyLite bool
 }
 
 type dockerEnvVar struct {
@@ -216,14 +223,15 @@ func dockerProxyOptionsFromFlags() (*dockerProxyOptions, error) {
 		caHost = defaultRuntimeProxyCAHostPath()
 	}
 	return &dockerProxyOptions{
-		Credentials:  creds,
-		BaseURL:      creds.BaseURL,
-		ContainerURL: containerURL,
-		AgentToken:   creds.AgentToken,
-		ProxyHost:    strings.TrimSpace(dockerProxyHost),
-		ProxyPort:    proxyPort,
-		CAInside:     strings.TrimSpace(dockerCAInside),
-		CAHost:       caHost,
+		Credentials:       creds,
+		BaseURL:           creds.BaseURL,
+		ContainerURL:      containerURL,
+		AgentToken:        creds.AgentToken,
+		ProxyHost:         strings.TrimSpace(dockerProxyHost),
+		ProxyPort:         proxyPort,
+		CAInside:          strings.TrimSpace(dockerCAInside),
+		CAHost:            caHost,
+		LLMRouteProxyLite: strings.EqualFold(strings.TrimSpace(dockerLLMRoute), "proxy_lite"),
 	}, nil
 }
 
@@ -234,9 +242,18 @@ func buildDockerAgentEnvVars(opts *dockerProxyOptions, templated bool) []dockerE
 	}
 	launchUser := "launch-" + uuid.NewString()
 	authenticatedProxyURL := fmt.Sprintf("http://%s:%s@%s:%d", launchUser, token, opts.ProxyHost, opts.ProxyPort)
-	noProxy := mergeNoProxy("", "localhost", "127.0.0.1", "::1", opts.ProxyHost)
+	noProxyHosts := []string{"localhost", "127.0.0.1", "::1", opts.ProxyHost}
+	if opts.LLMRouteProxyLite {
+		// Contain superset (spec 09): the container's LLM calls must reach
+		// proxy-lite (on the container URL host), not the runtime proxy, so
+		// bypass the runtime proxy for that host too.
+		if containerHost := runtimeDaemonHost(opts.ContainerURL); containerHost != "" {
+			noProxyHosts = append(noProxyHosts, containerHost)
+		}
+	}
+	noProxy := mergeNoProxy("", noProxyHosts...)
 	proxyURL := fmt.Sprintf("http://%s:%d", opts.ProxyHost, opts.ProxyPort)
-	return []dockerEnvVar{
+	vars := []dockerEnvVar{
 		{Key: "CLAWVISOR_URL", Value: opts.ContainerURL, Comment: "Clawvisor API URL the container should use"},
 		{Key: "CLAWVISOR_AGENT_TOKEN", Value: token, Comment: "Long-lived agent token for gateway/task APIs and proxy auth"},
 		{Key: "CLAWVISOR_RUNTIME_PROXY_URL", Value: proxyURL, Comment: "Runtime proxy base URL without embedded credentials"},
@@ -257,6 +274,16 @@ func buildDockerAgentEnvVars(opts *dockerProxyOptions, templated bool) []dockerE
 		{Key: "NODE_EXTRA_CA_CERTS", Value: opts.CAInside, Comment: "CA trust for Node.js TLS"},
 		{Key: "GIT_SSL_CAINFO", Value: opts.CAInside, Comment: "CA trust for git over HTTPS"},
 	}
+	if opts.LLMRouteProxyLite {
+		// Both providers, unconditionally — the contained process may run any
+		// harness. Pointed at proxy-lite on the container URL so LLM traffic
+		// flows through the govern pipeline unchanged (Contain superset).
+		vars = append(vars,
+			dockerEnvVar{Key: "ANTHROPIC_BASE_URL", Value: liteProxyAPIBaseURL(opts.ContainerURL), Comment: "Route Anthropic traffic through Clawvisor proxy-lite (contain superset)"},
+			dockerEnvVar{Key: "OPENAI_BASE_URL", Value: liteProxyOpenAIBaseURL(opts.ContainerURL), Comment: "Route OpenAI traffic through Clawvisor proxy-lite (contain superset)"},
+		)
+	}
+	return vars
 }
 
 func deriveContainerURL(baseURL, proxyHost string) (string, error) {
@@ -764,6 +791,7 @@ func init() {
 		subcmd.Flags().StringVar(&dockerCAInside, "ca-path", "/clawvisor/ca.pem", "Path the runtime proxy CA will be mounted at inside the container")
 		subcmd.Flags().StringVar(&dockerCAHost, "ca-host-path", "", "Path to the runtime proxy CA on the host (default: ~/.clawvisor/runtime-proxy/ca.pem)")
 		subcmd.Flags().StringVar(&runtimeProfileOverride, "runtime-profile", "", "Explicit starter profile hint for this launch (e.g. claude_code or codex)")
+		subcmd.Flags().StringVar(&dockerLLMRoute, "llm-route", "direct", "LLM routing for the container: direct (runtime-proxy MITM) or proxy_lite (contain superset — route LLM traffic through proxy-lite). Must match the server's runtime_proxy.llm_route.")
 		subcmd.MarkFlagsMutuallyExclusive("agent", "agent-token")
 	}
 	agentDockerEnvCmd.Flags().StringVar(&dockerEnvFormat, "format", "env", "Output format: env, export, or docker-args")

--- a/internal/clawvisorcli/cmd_agent_docker.go
+++ b/internal/clawvisorcli/cmd_agent_docker.go
@@ -282,6 +282,17 @@ func buildDockerAgentEnvVars(opts *dockerProxyOptions, templated bool) []dockerE
 			dockerEnvVar{Key: "ANTHROPIC_BASE_URL", Value: liteProxyAPIBaseURL(opts.ContainerURL), Comment: "Route Anthropic traffic through Clawvisor proxy-lite (contain superset)"},
 			dockerEnvVar{Key: "OPENAI_BASE_URL", Value: liteProxyOpenAIBaseURL(opts.ContainerURL), Comment: "Route OpenAI traffic through Clawvisor proxy-lite (contain superset)"},
 		)
+		// proxy-lite (middleware.RequireAgentLLM) authenticates the agent by the
+		// cvis_ token in X-Clawvisor-Agent-Token; mirror the Govern lite path
+		// (buildLiteProxyEnv): carry the token as an Anthropic custom header and
+		// clear the client's own Anthropic credentials so the SDK doesn't send a
+		// competing Authorization/x-api-key that would 401. Codex auth is
+		// deferred (spec 09) — no OPENAI_API_KEY here, matching lite.
+		vars = append(vars,
+			dockerEnvVar{Key: "ANTHROPIC_CUSTOM_HEADERS", Value: liteProxyClaudeAgentTokenHeader + ": " + token, Comment: "Authenticate Anthropic traffic to proxy-lite with the agent token (contain superset)"},
+			dockerEnvVar{Key: "ANTHROPIC_AUTH_TOKEN", Value: "", Comment: "Clear client Anthropic auth token so proxy-lite agent-token auth is used"},
+			dockerEnvVar{Key: "ANTHROPIC_API_KEY", Value: "", Comment: "Clear client Anthropic API key so proxy-lite agent-token auth is used"},
+		)
 	}
 	return vars
 }

--- a/internal/clawvisorcli/cmd_agent_docker_test.go
+++ b/internal/clawvisorcli/cmd_agent_docker_test.go
@@ -87,6 +87,79 @@ func splitProxyUserAndSuffix(t *testing.T, raw string) (string, string) {
 	return user, after
 }
 
+func TestBuildDockerAgentEnvVarsProxyLiteInjectsClaudeAuth(t *testing.T) {
+	opts := &dockerProxyOptions{
+		BaseURL:           "http://127.0.0.1:25297",
+		ContainerURL:      "http://host.docker.internal:25297",
+		AgentToken:        "cvis_test_token",
+		ProxyHost:         "host.docker.internal",
+		ProxyPort:         25290,
+		CAInside:          "/clawvisor/ca.pem",
+		CAHost:            "/host/ca.pem",
+		LLMRouteProxyLite: true,
+	}
+
+	present := map[string]bool{}
+	values := map[string]string{}
+	for _, v := range buildDockerAgentEnvVars(opts, false) {
+		present[v.Key] = true
+		values[v.Key] = v.Value
+	}
+
+	// proxy-lite authenticates the agent by the cvis_ token in the custom
+	// header; without it the SDK's LLM calls 401.
+	if got := values["ANTHROPIC_CUSTOM_HEADERS"]; got != "X-Clawvisor-Agent-Token: cvis_test_token" {
+		t.Fatalf("unexpected ANTHROPIC_CUSTOM_HEADERS %q", got)
+	}
+	// The client's own Anthropic creds must be cleared so they don't compete.
+	if !present["ANTHROPIC_AUTH_TOKEN"] || values["ANTHROPIC_AUTH_TOKEN"] != "" {
+		t.Fatalf("expected ANTHROPIC_AUTH_TOKEN to be present and empty, got present=%v value=%q", present["ANTHROPIC_AUTH_TOKEN"], values["ANTHROPIC_AUTH_TOKEN"])
+	}
+	if !present["ANTHROPIC_API_KEY"] || values["ANTHROPIC_API_KEY"] != "" {
+		t.Fatalf("expected ANTHROPIC_API_KEY to be present and empty, got present=%v value=%q", present["ANTHROPIC_API_KEY"], values["ANTHROPIC_API_KEY"])
+	}
+	// Codex auth is deferred (spec 09): lite never sets OPENAI_API_KEY, so
+	// neither should the docker env.
+	if present["OPENAI_API_KEY"] {
+		t.Fatalf("proxy-lite docker env must not set OPENAI_API_KEY (codex auth deferred), got %q", values["OPENAI_API_KEY"])
+	}
+}
+
+func TestBuildDockerAgentEnvVarsNoProxyLiteOmitsClaudeAuth(t *testing.T) {
+	opts := &dockerProxyOptions{
+		BaseURL:      "http://127.0.0.1:25297",
+		ContainerURL: "http://host.docker.internal:25297",
+		AgentToken:   "cvis_test_token",
+		ProxyHost:    "host.docker.internal",
+		ProxyPort:    25290,
+		CAInside:     "/clawvisor/ca.pem",
+	}
+	for _, v := range buildDockerAgentEnvVars(opts, false) {
+		switch v.Key {
+		case "ANTHROPIC_CUSTOM_HEADERS", "ANTHROPIC_BASE_URL", "OPENAI_BASE_URL":
+			t.Fatalf("direct route must not emit proxy-lite env %q", v.Key)
+		}
+	}
+}
+
+func TestBuildDockerAgentEnvVarsProxyLiteTemplatedHeaderUsesTokenVar(t *testing.T) {
+	opts := &dockerProxyOptions{
+		ContainerURL:      "http://host.docker.internal:25297",
+		AgentToken:        "ignored",
+		ProxyHost:         "host.docker.internal",
+		ProxyPort:         25290,
+		CAInside:          "/clawvisor/ca.pem",
+		LLMRouteProxyLite: true,
+	}
+	values := map[string]string{}
+	for _, v := range buildDockerAgentEnvVars(opts, true) {
+		values[v.Key] = v.Value
+	}
+	if got := values["ANTHROPIC_CUSTOM_HEADERS"]; got != "X-Clawvisor-Agent-Token: ${CLAWVISOR_AGENT_TOKEN}" {
+		t.Fatalf("expected templated agent token in ANTHROPIC_CUSTOM_HEADERS, got %q", got)
+	}
+}
+
 func TestBuildDockerAgentEnvVarsAssignsUniqueLaunchID(t *testing.T) {
 	opts := &dockerProxyOptions{
 		AgentToken: "cvis_test_token",

--- a/internal/clawvisorcli/cmd_agent_runtime.go
+++ b/internal/clawvisorcli/cmd_agent_runtime.go
@@ -3,6 +3,7 @@ package clawvisorcli
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -204,7 +205,20 @@ func buildRuntimeBootstrapEnv(baseURL, agentToken string, session *client.Create
 	if err != nil {
 		return nil, err
 	}
-	noProxy := mergeNoProxy(os.Getenv("NO_PROXY"), "127.0.0.1", "localhost", "::1")
+	// Contain superset (spec 09): when the session routes LLM traffic through
+	// proxy-lite, LLM calls must never enter the runtime proxy. Composition
+	// happens at the env layer — point ANTHROPIC_BASE_URL/OPENAI_BASE_URL at
+	// proxy-lite and bypass the runtime proxy for the daemon host (NO_PROXY is
+	// the primary bypass). proxy-lite then sees the same request it sees in
+	// Govern: no double MITM, no CA complications, agent-token auth intact.
+	routeLLMToProxyLite := strings.EqualFold(strings.TrimSpace(session.LLMRoute), "proxy_lite")
+	noProxyDefaults := []string{"127.0.0.1", "localhost", "::1"}
+	if routeLLMToProxyLite {
+		if daemonHost := runtimeDaemonHost(baseURL); daemonHost != "" {
+			noProxyDefaults = append(noProxyDefaults, daemonHost)
+		}
+	}
+	noProxy := mergeNoProxy(os.Getenv("NO_PROXY"), noProxyDefaults...)
 	envPairs := []string{
 		"CLAWVISOR_URL=" + baseURL,
 		"CLAWVISOR_AGENT_TOKEN=" + agentToken,
@@ -220,6 +234,16 @@ func buildRuntimeBootstrapEnv(baseURL, agentToken string, session *client.Create
 		"all_proxy=" + authenticatedProxyURL,
 		"NO_PROXY=" + noProxy,
 		"no_proxy=" + noProxy,
+	}
+	if routeLLMToProxyLite {
+		// Both providers, unconditionally: unlike lite mode we don't know
+		// which harness runs inside the contained process. These env-only vars
+		// carry through both the CA and no-CA (Node shim) branches below, so no
+		// special-casing is needed (spec 09 gotcha 3).
+		envPairs = append(envPairs,
+			"ANTHROPIC_BASE_URL="+liteProxyAPIBaseURL(baseURL),
+			"OPENAI_BASE_URL="+liteProxyOpenAIBaseURL(baseURL),
+		)
 	}
 	if strings.TrimSpace(session.CACertPEM) == "" {
 		shimPath, err := materializeNodeProxyShimFunc(filepath.Join(os.TempDir(), "clawvisor-runtime-shim"))
@@ -289,6 +313,27 @@ func cleanupRuntimeCACertFiles(dir string, maxAge time.Duration) {
 		}
 		_ = os.Remove(filepath.Join(dir, entry.Name()))
 	}
+}
+
+// runtimeDaemonHost extracts the hostname from the Clawvisor server base URL
+// so it can be merged into NO_PROXY for the Contain superset (spec 09). LLM
+// traffic addressed to the daemon host must bypass the runtime proxy entirely.
+// Returns "" when baseURL is empty or unparseable. A URL without a scheme
+// (e.g. "127.0.0.1:8088") still yields a host via a lenient reparse.
+func runtimeDaemonHost(baseURL string) string {
+	baseURL = strings.TrimSpace(baseURL)
+	if baseURL == "" {
+		return ""
+	}
+	parsed, err := url.Parse(baseURL)
+	if err == nil && parsed.Hostname() != "" {
+		return parsed.Hostname()
+	}
+	// Fall back to a scheme-prefixed parse for bare host:port values.
+	if parsed, err := url.Parse("http://" + baseURL); err == nil {
+		return parsed.Hostname()
+	}
+	return ""
 }
 
 func mergeNoProxy(existing string, defaults ...string) string {

--- a/internal/clawvisorcli/cmd_agent_runtime_test.go
+++ b/internal/clawvisorcli/cmd_agent_runtime_test.go
@@ -103,6 +103,83 @@ func TestBuildRuntimeBootstrapEnv(t *testing.T) {
 	}
 }
 
+// TestBuildRuntimeBootstrapEnvContainSuperset asserts the spec 09 env
+// composition: under llm_route=proxy_lite the bootstrap env gains both LLM
+// base URLs (pointed at proxy-lite) and merges the daemon host into NO_PROXY
+// so LLM traffic bypasses the runtime proxy entirely.
+func TestBuildRuntimeBootstrapEnvContainSuperset(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+	t.Setenv("NO_PROXY", "metadata.internal")
+
+	session := &client.CreateRuntimeSessionResponse{
+		Session:     client.RuntimeSession{ID: "session-contain", ExpiresAt: time.Unix(1_700_000_000, 0).UTC()},
+		ProxyBearer: "secret-token",
+		ProxyURL:    "http://127.0.0.1:4318",
+		CACertPEM:   "-----BEGIN CERTIFICATE-----\nunit-test\n-----END CERTIFICATE-----\n",
+		LLMRoute:    "proxy_lite",
+	}
+
+	env, err := buildRuntimeBootstrapEnv("https://clawvisor.example.com", "agent-token", session)
+	if err != nil {
+		t.Fatalf("buildRuntimeBootstrapEnv: %v", err)
+	}
+	values := envMap(env)
+
+	if got := values["ANTHROPIC_BASE_URL"]; got != "https://clawvisor.example.com/api" {
+		t.Fatalf("unexpected ANTHROPIC_BASE_URL %q", got)
+	}
+	if got := values["OPENAI_BASE_URL"]; got != "https://clawvisor.example.com/api/v1" {
+		t.Fatalf("unexpected OPENAI_BASE_URL %q", got)
+	}
+	noProxy := values["NO_PROXY"]
+	if !strings.Contains(noProxy, "clawvisor.example.com") {
+		t.Fatalf("expected NO_PROXY to include the daemon host, got %q", noProxy)
+	}
+	for _, want := range []string{"metadata.internal", "127.0.0.1", "localhost", "::1"} {
+		if !strings.Contains(noProxy, want) {
+			t.Fatalf("expected NO_PROXY %q to include %q", noProxy, want)
+		}
+	}
+	if values["no_proxy"] != noProxy {
+		t.Fatalf("expected lowercase no_proxy to match NO_PROXY")
+	}
+	// The HTTP(S)_PROXY vars are still present — only LLM traffic bypasses.
+	if values["HTTPS_PROXY"] == "" {
+		t.Fatal("expected HTTPS_PROXY to remain set under contain")
+	}
+}
+
+// TestBuildRuntimeBootstrapEnvDirectHasNoLLMBaseURLs locks the legacy default:
+// with llm_route empty/"direct" the env carries NO LLM base URLs and does not
+// merge any daemon host beyond the loopback defaults (byte-identical to before
+// spec 09).
+func TestBuildRuntimeBootstrapEnvDirectHasNoLLMBaseURLs(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+	t.Setenv("NO_PROXY", "")
+
+	session := &client.CreateRuntimeSessionResponse{
+		Session:     client.RuntimeSession{ID: "session-direct", ExpiresAt: time.Unix(1_700_000_000, 0).UTC()},
+		ProxyBearer: "secret-token",
+		ProxyURL:    "http://127.0.0.1:4318",
+		CACertPEM:   "-----BEGIN CERTIFICATE-----\nunit-test\n-----END CERTIFICATE-----\n",
+		// LLMRoute unset == "direct"
+	}
+	env, err := buildRuntimeBootstrapEnv("https://clawvisor.example.com", "agent-token", session)
+	if err != nil {
+		t.Fatalf("buildRuntimeBootstrapEnv: %v", err)
+	}
+	values := envMap(env)
+	if _, ok := values["ANTHROPIC_BASE_URL"]; ok {
+		t.Fatal("direct route must not set ANTHROPIC_BASE_URL")
+	}
+	if _, ok := values["OPENAI_BASE_URL"]; ok {
+		t.Fatal("direct route must not set OPENAI_BASE_URL")
+	}
+	if got := values["NO_PROXY"]; got != "127.0.0.1,localhost,::1" {
+		t.Fatalf("direct route NO_PROXY should carry only loopback defaults, got %q", got)
+	}
+}
+
 func TestRuntimeBootstrapMetadataIncludesWorkingDirAndToolRoots(t *testing.T) {
 	t.Setenv("TMPDIR", t.TempDir())
 	wd := t.TempDir()

--- a/internal/e2e/harness/contain_scenarios_test.go
+++ b/internal/e2e/harness/contain_scenarios_test.go
@@ -1,0 +1,249 @@
+package harness
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/pkg/config"
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+// The Contain-only deterministic scenarios (spec 09 Tests). They exercise the
+// real runtime-proxy egress hook + the Contain superset backstop through the
+// in-process harness (which has the Upstreams dial override the full-server
+// subprocess lacks), so a direct LLM-host hit can be asserted without network.
+
+// containServer boots the harness with runtime_proxy.llm_route=proxy_lite so
+// the Contain superset is active. Server.Config is the same pointer the egress
+// hook captured, so mutating it here is observed by the policy layer.
+func containServer(t *testing.T) *Server {
+	t.Helper()
+	srv, err := Start(context.Background(), t.TempDir(), nil)
+	if err != nil {
+		t.Fatalf("harness.Start: %v", err)
+	}
+	t.Cleanup(func() { _ = srv.Stop(context.Background()) })
+	srv.Config.RuntimeProxy.LLMRoute = "proxy_lite"
+	srv.Config.Server.PublicURL = "https://daemon.clawvisor.test"
+	return srv
+}
+
+// contain_egress_allow_deny: under Contain, non-LLM egress still flows through
+// the runtime proxy and obeys egress policy — an allow rule passes, a deny
+// rule 403s. (The Govern pipeline capabilities are unchanged; Contain only
+// adds network-layer egress control on top.)
+func TestContainEgressAllowDeny(t *testing.T) {
+	ctx := context.Background()
+	srv := containServer(t)
+	srv.Upstreams.AddJSON("api.allowed.test", http.StatusOK, `{"ok":true}`)
+	srv.Upstreams.AddJSON("api.denied.test", http.StatusOK, `{"ok":true}`)
+
+	p, err := srv.SeedPrincipal(ctx, "contain-egress")
+	if err != nil {
+		t.Fatalf("SeedPrincipal: %v", err)
+	}
+	for _, r := range []*store.RuntimePolicyRule{
+		{ID: "allow-host", UserID: p.User.ID, Kind: "egress", Action: "allow", Host: "api.allowed.test", Source: "test", Enabled: true},
+		{ID: "deny-host", UserID: p.User.ID, Kind: "egress", Action: "deny", Host: "api.denied.test", Source: "test", Enabled: true},
+	} {
+		if err := srv.Store.CreateRuntimePolicyRule(ctx, r); err != nil {
+			t.Fatalf("CreateRuntimePolicyRule %s: %v", r.ID, err)
+		}
+	}
+	sess, err := srv.CreateSession(ctx, p)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	resp, err := sess.Client.Get("https://api.allowed.test/")
+	if err != nil {
+		t.Fatalf("allowed GET: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("allowed host status=%d, want 200", resp.StatusCode)
+	}
+
+	resp, err = sess.Client.Get("https://api.denied.test/")
+	if err != nil {
+		t.Fatalf("denied GET: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("denied host status=%d, want 403", resp.StatusCode)
+	}
+	if !strings.Contains(string(body), "RUNTIME_POLICY_DENY") {
+		t.Fatalf("denied body should carry RUNTIME_POLICY_DENY, got %s", string(body))
+	}
+}
+
+// contain_llm_bypass_blocked: a direct request to a known LLM host that dodged
+// the env-var routing reaches the runtime proxy and is blocked with 403
+// llm_direct_bypass + a runtime.llm_bypass_blocked audit event (enforce mode).
+func TestContainLLMBypassBlocked(t *testing.T) {
+	ctx := context.Background()
+	srv := containServer(t)
+	// Register the LLM host as an upstream so that IF the backstop failed to
+	// block, the request would succeed (200) and the test would catch it.
+	srv.Upstreams.AddJSON("api.anthropic.com", http.StatusOK, `{"leaked":true}`)
+
+	p, err := srv.SeedPrincipal(ctx, "contain-block")
+	if err != nil {
+		t.Fatalf("SeedPrincipal: %v", err)
+	}
+	sess, err := srv.CreateSession(ctx, p)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	resp, err := sess.Client.Get("https://api.anthropic.com/v1/messages")
+	if err != nil {
+		t.Fatalf("bypass GET: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("direct LLM hit status=%d, want 403 (body=%s)", resp.StatusCode, string(body))
+	}
+	if !strings.Contains(string(body), "llm_direct_bypass") {
+		t.Fatalf("expected llm_direct_bypass error body, got %s", string(body))
+	}
+	if srv.Upstreams.Hits("api.anthropic.com") != 0 {
+		t.Fatalf("backstop must block before upstream; got %d hits", srv.Upstreams.Hits("api.anthropic.com"))
+	}
+
+	events, err := srv.Store.ListRuntimeEvents(ctx, p.User.ID, store.RuntimeEventFilter{SessionID: sess.SessionID, Limit: 20})
+	if err != nil {
+		t.Fatalf("ListRuntimeEvents: %v", err)
+	}
+	ev := findEvent(events, "runtime.llm_bypass_blocked")
+	if ev == nil {
+		t.Fatalf("expected runtime.llm_bypass_blocked event, got %v", eventTypes(events))
+	}
+	if ev.Outcome == nil || *ev.Outcome != "blocked" {
+		t.Fatalf("expected outcome=blocked, got %v", ev.Outcome)
+	}
+}
+
+// contain_llm_bypass_warned: same direct LLM hit under observation mode warns
+// instead of blocks — the request passes through and a runtime.llm_bypass_blocked
+// event with action=warned is recorded (Observe-within-Contain stays
+// non-breaking).
+func TestContainLLMBypassWarned(t *testing.T) {
+	ctx := context.Background()
+	srv := containServer(t)
+	// Observation mode: the manager reads ObservationModeDefault at create.
+	srv.Config.RuntimePolicy.ObservationModeDefault = true
+	srv.Upstreams.AddJSON("api.anthropic.com", http.StatusOK, `{"ok":true}`)
+
+	p, err := srv.SeedPrincipal(ctx, "contain-warn")
+	if err != nil {
+		t.Fatalf("SeedPrincipal: %v", err)
+	}
+	sess, err := srv.CreateSession(ctx, p)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	resp, err := sess.Client.Get("https://api.anthropic.com/v1/messages")
+	if err != nil {
+		t.Fatalf("warn GET: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("observe-mode direct LLM hit status=%d, want 200 pass-through (body=%s)", resp.StatusCode, string(body))
+	}
+	if srv.Upstreams.Hits("api.anthropic.com") == 0 {
+		t.Fatal("observe-mode warn should pass the request through to upstream")
+	}
+
+	events, err := srv.Store.ListRuntimeEvents(ctx, p.User.ID, store.RuntimeEventFilter{SessionID: sess.SessionID, Limit: 20})
+	if err != nil {
+		t.Fatalf("ListRuntimeEvents: %v", err)
+	}
+	ev := findEvent(events, "runtime.llm_bypass_blocked")
+	if ev == nil {
+		t.Fatalf("expected runtime.llm_bypass_blocked event, got %v", eventTypes(events))
+	}
+	if ev.Outcome == nil || *ev.Outcome != "warned" {
+		t.Fatalf("expected outcome=warned, got %v", ev.Outcome)
+	}
+}
+
+// contain_routing_composition: LLM traffic pointed at the Clawvisor daemon host
+// (where ANTHROPIC_BASE_URL/OPENAI_BASE_URL resolve) is allowlisted through the
+// runtime proxy (defense-in-depth for NO_PROXY-ignoring clients) and produces
+// NO runtime-proxy deny/bypass record — it flows to proxy-lite, not the runtime
+// proxy's own handling. A real LLM host, by contrast, is NOT allowlisted.
+func TestContainRoutingComposition(t *testing.T) {
+	ctx := context.Background()
+	srv := containServer(t)
+	srv.Upstreams.AddJSON("daemon.clawvisor.test", http.StatusOK, `{"proxy_lite":true}`)
+
+	p, err := srv.SeedPrincipal(ctx, "contain-compose")
+	if err != nil {
+		t.Fatalf("SeedPrincipal: %v", err)
+	}
+	sess, err := srv.CreateSession(ctx, p)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	resp, err := sess.Client.Get("https://daemon.clawvisor.test/api/v1/messages")
+	if err != nil {
+		t.Fatalf("daemon-host GET: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("daemon-host request status=%d, want 200 (allowlisted bypass)", resp.StatusCode)
+	}
+
+	// The allowlisted daemon host short-circuits before any egress audit/deny
+	// record is written — proving LLM traffic composes into proxy-lite rather
+	// than being processed as runtime-proxy egress.
+	events, err := srv.Store.ListRuntimeEvents(ctx, p.User.ID, store.RuntimeEventFilter{SessionID: sess.SessionID, Limit: 20})
+	if err != nil {
+		t.Fatalf("ListRuntimeEvents: %v", err)
+	}
+	if findEvent(events, "runtime.llm_bypass_blocked") != nil {
+		t.Fatal("daemon host must NOT be backstopped")
+	}
+	if findEvent(events, "runtime.policy.deny_matched") != nil {
+		t.Fatal("daemon host must NOT produce a runtime-proxy deny record")
+	}
+}
+
+// contain_config_validation: the contain preset without proxy_lite.enabled
+// fails config load with the llm_route gate error.
+func TestContainConfigValidation(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "config.yaml")
+	body := "posture: contain\nexperimental_contain: true\nproxy_lite:\n  enabled: false\n"
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	cfg, err := config.Load(p)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	err = cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "llm_route=proxy_lite requires proxy_lite.enabled=true") {
+		t.Fatalf("expected contain llm_route gate error, got %v", err)
+	}
+}
+
+func findEvent(events []*store.RuntimeEvent, eventType string) *store.RuntimeEvent {
+	for _, e := range events {
+		if e.EventType == eventType {
+			return e
+		}
+	}
+	return nil
+}

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -538,6 +538,11 @@ func stepPosture(cfg *config) error {
 				Options(
 					huh.NewOption("Observe (recommended): route agent LLM traffic through Clawvisor for visibility; agents keep their own API keys", "observe"),
 					huh.NewOption("Skill gateway only: keep agents pointed at their provider; opt out of routing", "gateway"),
+					// Contain is not offered as a working choice until the
+					// capability-parity lane is CI-required (spec 09 D5). Shown
+					// as "(coming soon)"; selecting it falls back to Observe
+					// with a notice pointing to the experimental config gate.
+					huh.NewOption("Contain (coming soon): network-layer containment of the agent process — experimental", "contain"),
 				).
 				// Observe is the pre-selected recommended default (the flip).
 				Value(&choice),
@@ -545,6 +550,14 @@ func stepPosture(cfg *config) error {
 	).Run()
 	if err != nil {
 		return err
+	}
+
+	if choice == "contain" {
+		fmt.Println(dim.Padding(0, 2).Render("Contain is experimental and not yet offered by the wizard."))
+		fmt.Println(dim.Padding(0, 2).Render("To enable it, set posture: contain and experimental_contain: true"))
+		fmt.Println(dim.Padding(0, 2).Render("in config.yaml (see docs). Falling back to Observe for now."))
+		fmt.Println()
+		choice = "observe"
 	}
 
 	if choice != "observe" {

--- a/internal/tui/client/types.go
+++ b/internal/tui/client/types.go
@@ -50,6 +50,11 @@ type CreateRuntimeSessionResponse struct {
 	ProxyURL        string         `json:"proxy_url"`
 	CACertPEM       string         `json:"ca_cert_pem,omitempty"`
 	ObservationMode bool           `json:"observation_mode"`
+	// LLMRoute is "proxy_lite" when the contained process's LLM traffic must
+	// be routed through proxy-lite (the Contain superset): the launcher sets
+	// ANTHROPIC_BASE_URL/OPENAI_BASE_URL and bypasses the runtime proxy for
+	// the daemon host. Empty/"direct" = legacy runtime-proxy MITM.
+	LLMRoute string `json:"llm_route,omitempty"`
 }
 
 type AgentRuntimeSettings struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -42,6 +42,16 @@ type Config struct {
 	// CurrentConfigSchema). Absent/0 on hand-written or pre-flip configs.
 	ConfigSchema int `yaml:"config_schema"`
 
+	// ExperimentalContain gates the not-yet-required-blocking Contain posture
+	// (spec 09). Until the capability-parity lane is CI-required, `posture:
+	// contain` is refused by Validate() unless this flag is set true. It is a
+	// deliberate release valve, not a behavior knob: with the flag, contain
+	// loads and applies its preset; without it, contain fails config load.
+	// Env override: CLAWVISOR_EXPERIMENTAL_CONTAIN. Remove this gate (and the
+	// Terraform module variable) in the release where CI runs the parity lane
+	// required-blocking.
+	ExperimentalContain bool `yaml:"experimental_contain"`
+
 	Server        ServerConfig        `yaml:"server"`
 	Database      DatabaseConfig      `yaml:"database"`
 	Vault         VaultConfig         `yaml:"vault"`
@@ -308,6 +318,22 @@ type RuntimeProxyConfig struct {
 	TimingTraceDir     string   `yaml:"timing_trace_dir"`
 	BodyTraceEnabled   bool     `yaml:"body_trace_enabled"`
 	BodyTraceDir       string   `yaml:"body_trace_dir"`
+
+	// LLMRoute selects how a contained agent's LLM traffic is handled:
+	// "direct" (default — today's behavior: the runtime proxy MITMs LLM
+	// hosts) or "proxy_lite" (Contain superset, spec 09: the env injection
+	// points ANTHROPIC_BASE_URL/OPENAI_BASE_URL at proxy-lite and the runtime
+	// proxy bypasses/backstops LLM hosts, so LLM traffic flows through the
+	// govern pipeline unchanged). "proxy_lite" requires proxy_lite.enabled.
+	// The contain posture preset sets this to "proxy_lite". Env override:
+	// CLAWVISOR_RUNTIME_LLM_ROUTE.
+	LLMRoute string `yaml:"llm_route"`
+}
+
+// LLMRouteProxyLite reports whether a contained agent's LLM traffic is routed
+// through proxy-lite (the Contain superset). Empty is treated as "direct".
+func (r RuntimeProxyConfig) LLMRouteProxyLite() bool {
+	return strings.EqualFold(strings.TrimSpace(r.LLMRoute), "proxy_lite")
 }
 
 type RuntimePolicyConfig struct {
@@ -512,6 +538,10 @@ func Default() *Config {
 			TimingTraceDir:     "~/.clawvisor/runtime-proxy/timing-traces",
 			BodyTraceEnabled:   false,
 			BodyTraceDir:       "~/.clawvisor/runtime-proxy/body-traces",
+			// LLMRoute defaults to "direct" — legacy runtime-only behavior.
+			// The contain posture preset flips it to "proxy_lite"; this default
+			// is never changed for behavior-affecting reasons (spec 09).
+			LLMRoute: "direct",
 		},
 		RuntimePolicy: RuntimePolicyConfig{
 			ObservationModeDefault:  false,
@@ -901,6 +931,9 @@ func Load(path string) (*Config, error) {
 	if v := os.Getenv("CLAWVISOR_RUNTIME_PROXY_BODY_TRACE_DIR"); v != "" {
 		cfg.RuntimeProxy.BodyTraceDir = v
 	}
+	if v := os.Getenv("CLAWVISOR_RUNTIME_LLM_ROUTE"); v != "" {
+		cfg.RuntimeProxy.LLMRoute = strings.ToLower(strings.TrimSpace(v))
+	}
 	if v := os.Getenv("CLAWVISOR_RUNTIME_POLICY_OBSERVATION_DEFAULT"); v != "" {
 		cfg.RuntimePolicy.ObservationModeDefault = v == "true" || v == "1"
 	}
@@ -959,6 +992,9 @@ func Load(path string) (*Config, error) {
 	}
 	if v := os.Getenv("CLAWVISOR_PROXY_LITE_ALLOW_SUB_MIGRATION"); v != "" {
 		cfg.ProxyLite.AllowSubscriptionBillingMigration = v == "true" || v == "1"
+	}
+	if v := os.Getenv("CLAWVISOR_EXPERIMENTAL_CONTAIN"); v != "" {
+		cfg.ExperimentalContain = v == "true" || v == "1"
 	}
 
 	if v := os.Getenv("CLAWVISOR_RELAY_URL"); v != "" {
@@ -1071,8 +1107,10 @@ func ensureGeminiCache(p **GeminiCacheConfig) *GeminiCacheConfig {
 //     upstream_auth="passthrough".
 //   - "govern":  proxy_lite.enabled=true, enforcement_mode="enforce",
 //     upstream_auth="vault".
-//   - "contain": not applied here — Validate() rejects it until the superset
-//     gate lands (PRD §13 item 9).
+//   - "contain": Govern preset (proxy_lite.enabled=true, enforce, vault) PLUS
+//     runtime_proxy.enabled=true and runtime_proxy.llm_route="proxy_lite" — the
+//     superset composition (spec 09). Validate() still gates load on
+//     ExperimentalContain until the parity lane is CI-required.
 //   - "" / unknown: no-op (unknown is rejected by Validate()).
 //
 // AllowSubscriptionBillingMigration is intentionally never set by a preset —
@@ -1093,6 +1131,16 @@ func applyPosturePreset(cfg *Config, raw []byte) {
 			cfg.ProxyLite.UpstreamAuth = v
 		}
 	}
+	setRuntimeEnabled := func(v bool) {
+		if !yamlHasKey(raw, "runtime_proxy", "enabled") {
+			cfg.RuntimeProxy.Enabled = v
+		}
+	}
+	setLLMRoute := func(v string) {
+		if !yamlHasKey(raw, "runtime_proxy", "llm_route") {
+			cfg.RuntimeProxy.LLMRoute = v
+		}
+	}
 	switch strings.ToLower(strings.TrimSpace(cfg.Posture)) {
 	case "observe":
 		setEnabled(true)
@@ -1102,6 +1150,12 @@ func applyPosturePreset(cfg *Config, raw []byte) {
 		setEnabled(true)
 		setEnforcement("enforce")
 		setUpstreamAuth("vault")
+	case "contain":
+		setEnabled(true)
+		setEnforcement("enforce")
+		setUpstreamAuth("vault")
+		setRuntimeEnabled(true)
+		setLLMRoute("proxy_lite")
 	}
 }
 
@@ -1229,9 +1283,23 @@ func (c *Config) Validate() error {
 	switch strings.ToLower(strings.TrimSpace(c.Posture)) {
 	case "", "observe", "govern":
 	case "contain":
-		return fmt.Errorf("posture contain is not yet available; it ships once the runtime-proxy composition makes it a strict superset of govern")
+		// Spec 09 lifts spec 02's unconditional rejection and replaces it with
+		// an experimental gate. Contain is a strict superset of Govern by
+		// construction, but stays behind the flag until the capability-parity
+		// lane is CI-required-blocking.
+		if !c.ExperimentalContain {
+			return fmt.Errorf("posture contain requires experimental_contain=true until the parity lane is required-blocking")
+		}
 	default:
 		return fmt.Errorf("posture must be one of observe, govern, contain (got %q)", c.Posture)
+	}
+	switch strings.ToLower(strings.TrimSpace(c.RuntimeProxy.LLMRoute)) {
+	case "", "direct", "proxy_lite":
+	default:
+		return fmt.Errorf("runtime_proxy.llm_route must be one of direct, proxy_lite (got %q)", c.RuntimeProxy.LLMRoute)
+	}
+	if c.RuntimeProxy.LLMRouteProxyLite() && !c.ProxyLite.Enabled {
+		return fmt.Errorf("runtime_proxy.llm_route=proxy_lite requires proxy_lite.enabled=true")
 	}
 	switch strings.ToLower(strings.TrimSpace(c.ProxyLite.EnforcementMode)) {
 	case "", "enforce", "observe":

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -361,12 +361,84 @@ func TestPosturePresetKnobPrecedence(t *testing.T) {
 	})
 }
 
+// TestValidatePostureContainRejected asserts the spec 09 gate semantics that
+// replaced spec 02's unconditional rejection: contain is refused UNLESS
+// experimental_contain=true, and accepted (with the superset preset applied)
+// once the flag is present.
 func TestValidatePostureContainRejected(t *testing.T) {
-	cfg := Default()
-	cfg.Posture = "contain"
-	err := cfg.Validate()
-	if err == nil || !strings.Contains(err.Error(), "posture contain is not yet available") {
-		t.Fatalf("expected contain rejection, got %v", err)
+	t.Run("rejected without experimental_contain", func(t *testing.T) {
+		cfg := Default()
+		cfg.Posture = "contain"
+		err := cfg.Validate()
+		if err == nil || !strings.Contains(err.Error(), "posture contain requires experimental_contain=true") {
+			t.Fatalf("expected contain gate rejection, got %v", err)
+		}
+	})
+	t.Run("accepted with experimental_contain and superset preset", func(t *testing.T) {
+		cfg := Default()
+		cfg.Posture = "contain"
+		cfg.ExperimentalContain = true
+		// Mimic the applied contain preset (Validate runs post-preset).
+		cfg.ProxyLite.Enabled = true
+		cfg.RuntimeProxy.Enabled = true
+		cfg.RuntimeProxy.LLMRoute = "proxy_lite"
+		if err := cfg.Validate(); err != nil {
+			t.Fatalf("expected contain to validate with the gate flag, got %v", err)
+		}
+	})
+	t.Run("contain preset without proxy_lite.enabled fails llm_route gate", func(t *testing.T) {
+		cfg := Default()
+		cfg.Posture = "contain"
+		cfg.ExperimentalContain = true
+		cfg.ProxyLite.Enabled = false
+		cfg.RuntimeProxy.Enabled = true
+		cfg.RuntimeProxy.LLMRoute = "proxy_lite"
+		err := cfg.Validate()
+		if err == nil || !strings.Contains(err.Error(), "llm_route=proxy_lite requires proxy_lite.enabled=true") {
+			t.Fatalf("expected llm_route gate error, got %v", err)
+		}
+	})
+}
+
+// TestContainPresetAppliesSuperset asserts that loading a contain-postured
+// config (with the experimental gate) applies the Govern preset PLUS the
+// runtime-proxy superset knobs (enabled + llm_route=proxy_lite), per spec 09.
+func TestContainPresetAppliesSuperset(t *testing.T) {
+	cfg, err := Load(writePostureConfig(t, "posture: contain\nexperimental_contain: true\n"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.ProxyLite.Enabled || cfg.ProxyLite.ObserveMode() || cfg.ProxyLite.PassthroughUpstreamAuth() {
+		t.Fatalf("contain preset should apply govern proxy_lite knobs: enabled=%v observe=%v passthrough=%v",
+			cfg.ProxyLite.Enabled, cfg.ProxyLite.ObserveMode(), cfg.ProxyLite.PassthroughUpstreamAuth())
+	}
+	if !cfg.RuntimeProxy.Enabled {
+		t.Fatal("contain preset should enable the runtime proxy")
+	}
+	if !cfg.RuntimeProxy.LLMRouteProxyLite() {
+		t.Fatalf("contain preset should set llm_route=proxy_lite, got %q", cfg.RuntimeProxy.LLMRoute)
+	}
+}
+
+// TestContainPresetWithoutGateFailsLoad asserts that contain without the
+// experimental gate fails startup validation (Load applies the preset; the
+// server rejects it at Validate()).
+func TestContainPresetWithoutGateFailsLoad(t *testing.T) {
+	cfg, err := Load(writePostureConfig(t, "posture: contain\n"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	err = cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "posture contain requires experimental_contain=true") {
+		t.Fatalf("expected contain Validate to fail on the gate, got %v", err)
+	}
+}
+
+// TestDefaultLLMRouteIsDirect locks the legacy-safe default: llm_route is
+// "direct" so an install that never opts into contain keeps today's behavior.
+func TestDefaultLLMRouteIsDirect(t *testing.T) {
+	if d := Default(); d.RuntimeProxy.LLMRoute != "direct" {
+		t.Fatalf("Default().RuntimeProxy.LLMRoute=%q, want direct", d.RuntimeProxy.LLMRoute)
 	}
 }
 

--- a/pkg/runtime/proxy/auth.go
+++ b/pkg/runtime/proxy/auth.go
@@ -186,6 +186,7 @@ func (a *Authenticator) getOrCreateAgentRuntimeSession(ctx context.Context, agen
 		"starter_profile":          settings.StarterProfile,
 		"outbound_credential_mode": settings.OutboundCredentialMode,
 		"inject_stored_bearer":     settings.InjectStoredBearer,
+		"llm_route":                settings.LLMRoute,
 	}
 	if launchID != "" {
 		metadata["launch_id"] = launchID
@@ -258,7 +259,7 @@ func selectReusableAgentTokenRuntimeSession(sessions []*store.RuntimeSession, no
 			continue
 		}
 		got := sessionRuntimeSettingsFromMetadata(session, nil)
-		if got.RuntimeEnabled != want.RuntimeEnabled || got.RuntimeMode != want.RuntimeMode || got.StarterProfile != want.StarterProfile || got.OutboundCredentialMode != want.OutboundCredentialMode || got.InjectStoredBearer != want.InjectStoredBearer {
+		if got.RuntimeEnabled != want.RuntimeEnabled || got.RuntimeMode != want.RuntimeMode || got.StarterProfile != want.StarterProfile || got.OutboundCredentialMode != want.OutboundCredentialMode || got.InjectStoredBearer != want.InjectStoredBearer || got.LLMRoute != want.LLMRoute {
 			continue
 		}
 		if best == nil || session.CreatedAt.After(best.CreatedAt) {

--- a/pkg/runtime/proxy/auth_test.go
+++ b/pkg/runtime/proxy/auth_test.go
@@ -174,6 +174,65 @@ func TestAuthenticatorAcceptsAgentTokenAndCreatesReusableRuntimeSession(t *testi
 	}
 }
 
+func TestAuthenticatorPersistsAndComparesLLMRouteOnReuse(t *testing.T) {
+	ctx := context.Background()
+	db, err := sqlite.New(ctx, t.TempDir()+"/proxy-auth-llmroute.db")
+	if err != nil {
+		t.Fatalf("sqlite.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	st := sqlite.NewStore(db)
+
+	user, err := st.CreateUser(ctx, "proxy-auth-llmroute@test.example", "hash")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	rawToken := "cvis_runtime_agent_token_llmroute"
+	if _, err := st.CreateAgent(ctx, user.ID, "runtime-agent", intauth.HashToken(rawToken)); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	cfg := config.Default()
+	cfg.RuntimeProxy.LLMRoute = "proxy_lite"
+	authn := &Authenticator{Store: st, Config: cfg}
+	header := http.Header{}
+	header.Set("Proxy-Authorization", "Bearer "+rawToken)
+
+	first, err := authn.Authenticate(ctx, header)
+	if err != nil {
+		t.Fatalf("Authenticate(first): %v", err)
+	}
+	// The route must be persisted into session metadata so a later cfg flip
+	// cannot reinterpret the existing session's route.
+	var meta map[string]any
+	if err := json.Unmarshal(first.MetadataJSON, &meta); err != nil {
+		t.Fatalf("unmarshal metadata: %v", err)
+	}
+	if got := meta["llm_route"]; got != "proxy_lite" {
+		t.Fatalf("expected llm_route=proxy_lite persisted in metadata, got %v", got)
+	}
+
+	// Same cfg → session is reused.
+	second, err := authn.Authenticate(ctx, header)
+	if err != nil {
+		t.Fatalf("Authenticate(second): %v", err)
+	}
+	if second.ID != first.ID {
+		t.Fatalf("expected reuse for identical route, got first=%q second=%q", first.ID, second.ID)
+	}
+
+	// Live cfg flip to direct → the proxy_lite session must NOT be reused;
+	// a fresh session is minted rather than silently reinterpreting the route.
+	cfg.RuntimeProxy.LLMRoute = "direct"
+	third, err := authn.Authenticate(ctx, header)
+	if err != nil {
+		t.Fatalf("Authenticate(third): %v", err)
+	}
+	if third.ID == first.ID {
+		t.Fatalf("route flip must mint a new session, got reuse of %q", first.ID)
+	}
+}
+
 func TestAuthenticatorDoesNotReuseBootstrapRuntimeSessionsForAgentTokenAuth(t *testing.T) {
 	ctx := context.Background()
 	db, err := sqlite.New(ctx, t.TempDir()+"/proxy-auth-bootstrap.db")

--- a/pkg/runtime/proxy/contain_test.go
+++ b/pkg/runtime/proxy/contain_test.go
@@ -1,0 +1,73 @@
+package proxy
+
+import (
+	"testing"
+
+	"github.com/clawvisor/clawvisor/pkg/config"
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+func containCfg() *config.Config {
+	cfg := &config.Config{}
+	cfg.RuntimeProxy.LLMRoute = "proxy_lite"
+	cfg.Server.PublicURL = "https://clawvisor.example.com"
+	return cfg
+}
+
+// TestContainAllowlistSkipsHardcodedLLMHosts asserts spec 09 D2: in the
+// Contain superset (llm_route=proxy_lite) the hardcoded provider LLM hosts are
+// NOT allowlisted — they must fall through so the backstop/egress policy can
+// deny them. Legacy (direct) route keeps allowing them.
+func TestContainAllowlistSkipsHardcodedLLMHosts(t *testing.T) {
+	contain := containCfg()
+	for _, host := range []string{"api.anthropic.com", "api.openai.com", "chatgpt.com"} {
+		if isHarnessAllowlistedForSession(nil, contain, host) {
+			t.Errorf("contain: %s must NOT be allowlisted (backstop territory)", host)
+		}
+	}
+
+	legacy := &config.Config{}
+	for _, host := range []string{"api.anthropic.com", "api.openai.com", "chatgpt.com"} {
+		if !isHarnessAllowlistedForSession(nil, legacy, host) {
+			t.Errorf("legacy: %s should stay allowlisted", host)
+		}
+	}
+}
+
+// TestContainAllowsDaemonHost asserts spec 09 D1.3: the Clawvisor daemon host
+// (Server.PublicURL) is allowlisted so a client that ignores NO_PROXY still
+// reaches proxy-lite through the runtime proxy.
+func TestContainAllowsDaemonHost(t *testing.T) {
+	contain := containCfg()
+	if !isHarnessAllowlistedForSession(nil, contain, "clawvisor.example.com") {
+		t.Error("contain: the daemon host must be allowlisted for NO_PROXY-ignoring clients")
+	}
+}
+
+// TestContainBackstopHostSet asserts the backstop host set covers all three
+// provider hosts including chatgpt.com (gotcha 4).
+func TestContainBackstopHostSet(t *testing.T) {
+	for _, host := range []string{"api.anthropic.com", "api.openai.com", "chatgpt.com"} {
+		if !isContainLLMBackstopHost(host) {
+			t.Errorf("%s should be a backstop host", host)
+		}
+	}
+	if isContainLLMBackstopHost("example.com") {
+		t.Error("non-LLM host must not be a backstop host")
+	}
+}
+
+// TestSessionLLMRouteProxyLite covers cfg fallback and per-session override.
+func TestSessionLLMRouteProxyLite(t *testing.T) {
+	if !sessionLLMRouteProxyLite(nil, containCfg()) {
+		t.Error("cfg llm_route=proxy_lite should report proxy_lite")
+	}
+	if sessionLLMRouteProxyLite(nil, &config.Config{}) {
+		t.Error("empty cfg llm_route should report direct")
+	}
+	// Per-session override (cloud path): metadata sets llm_route explicitly.
+	sess := &store.RuntimeSession{MetadataJSON: []byte(`{"llm_route":"proxy_lite"}`)}
+	if !sessionLLMRouteProxyLite(sess, &config.Config{}) {
+		t.Error("per-session llm_route override should win over empty cfg")
+	}
+}

--- a/pkg/runtime/proxy/contain_test.go
+++ b/pkg/runtime/proxy/contain_test.go
@@ -44,6 +44,25 @@ func TestContainAllowsDaemonHost(t *testing.T) {
 	}
 }
 
+// TestDirectRouteDoesNotAllowlistDaemonHost asserts fix for the D1.3 carve-out:
+// the daemon host (Server.PublicURL) is only allowlisted under the Contain
+// superset (proxy_lite). A direct/legacy session must remain subject to normal
+// egress policy for the daemon host — allowlisting it there is an unearned
+// bypass since direct sessions never route LLM traffic through it.
+func TestDirectRouteDoesNotAllowlistDaemonHost(t *testing.T) {
+	direct := &config.Config{}
+	direct.Server.PublicURL = "https://clawvisor.example.com"
+	// direct.RuntimeProxy.LLMRoute is empty → direct route.
+	if isHarnessAllowlistedForSession(nil, direct, "clawvisor.example.com") {
+		t.Error("direct route: daemon host must NOT be allowlisted (no proxy_lite carve-out)")
+	}
+
+	// The contain carve-out still applies when llm_route=proxy_lite.
+	if !isHarnessAllowlistedForSession(nil, containCfg(), "clawvisor.example.com") {
+		t.Error("contain route: daemon host must remain allowlisted")
+	}
+}
+
 // TestContainBackstopHostSet asserts the backstop host set covers all three
 // provider hosts including chatgpt.com (gotcha 4).
 func TestContainBackstopHostSet(t *testing.T) {

--- a/pkg/runtime/proxy/manager.go
+++ b/pkg/runtime/proxy/manager.go
@@ -8,6 +8,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -36,6 +37,12 @@ type CreateSessionResult struct {
 	ProxyURL        string                `json:"proxy_url"`
 	CACertPEM       string                `json:"ca_cert_pem,omitempty"`
 	ObservationMode bool                  `json:"observation_mode"`
+	// LLMRoute tells the launcher how to wire the contained process's LLM
+	// traffic: "proxy_lite" (Contain superset — set ANTHROPIC_BASE_URL/
+	// OPENAI_BASE_URL at proxy-lite and bypass the runtime proxy for the
+	// daemon host) or "direct"/"" (legacy — LLM hosts MITM'd by the runtime
+	// proxy). Sourced from cfg.RuntimeProxy.LLMRoute.
+	LLMRoute string `json:"llm_route,omitempty"`
 }
 
 func (m *Manager) CreateRuntimeSession(ctx context.Context, agent *store.Agent, req CreateSessionRequest) (*CreateSessionResult, error) {
@@ -87,6 +94,7 @@ func (m *Manager) CreateRuntimeSession(ctx context.Context, agent *store.Agent, 
 		ProxyURL:        m.ProxyURL(),
 		CACertPEM:       m.CACertPEM(),
 		ObservationMode: observation,
+		LLMRoute:        strings.ToLower(strings.TrimSpace(m.Config.RuntimeProxy.LLMRoute)),
 	}, nil
 }
 

--- a/pkg/runtime/proxy/policy_hook.go
+++ b/pkg/runtime/proxy/policy_hook.go
@@ -757,9 +757,14 @@ func isHarnessAllowlistedForSession(session *store.RuntimeSession, cfg *config.C
 		// ignore NO_PROXY. LLM traffic is pointed at the Clawvisor daemon host
 		// (ANTHROPIC_BASE_URL/OPENAI_BASE_URL); if such a client sends that
 		// request through the runtime proxy anyway, the daemon host must pass
-		// so it still reaches proxy-lite.
-		if daemonHost := normalizedEndpointHost(cfg.Server.PublicURL); daemonHost != "" && host == daemonHost {
-			return true
+		// so it still reaches proxy-lite. This is a contain-only carve-out —
+		// gating it behind proxy_lite keeps direct/legacy sessions subject to
+		// normal egress policy for the daemon host (they never route LLM
+		// traffic there, so allowlisting it would be an unearned bypass).
+		if sessionLLMRouteProxyLite(session, cfg) {
+			if daemonHost := normalizedEndpointHost(cfg.Server.PublicURL); daemonHost != "" && host == daemonHost {
+				return true
+			}
 		}
 	}
 	for _, allowed := range sessionHarnessAllowlist(session, cfg) {

--- a/pkg/runtime/proxy/policy_hook.go
+++ b/pkg/runtime/proxy/policy_hook.go
@@ -70,6 +70,13 @@ func (s *Server) InstallEgressPolicy(hooks PolicyHooks) {
 		req.ContentLength = int64(len(bodyBytes))
 
 		host := requestHost(req)
+		// Contain superset backstop (spec 09 D2): in llm_route=proxy_lite a
+		// request to a known LLM host reaching the runtime proxy is a routing
+		// escape (it dodged ANTHROPIC_BASE_URL/OPENAI_BASE_URL + NO_PROXY), not
+		// traffic to duplicate-process. Block (enforce) or warn (observe).
+		if sessionLLMRouteProxyLite(st.Session, hooks.Config) && isContainLLMBackstopHost(host) {
+			return s.handleContainLLMBypass(req, st, hooks, host)
+		}
 		if isHarnessAllowlistedForSession(st.Session, hooks.Config, host) {
 			return req, nil
 		}
@@ -746,6 +753,14 @@ func isHarnessAllowlistedForSession(session *store.RuntimeSession, cfg *config.C
 		if endpointHost := normalizedEndpointHost(cfg.LLM.Endpoint); endpointHost != "" && host == endpointHost {
 			return true
 		}
+		// Contain superset (spec 09 D1.3): defense-in-depth for clients that
+		// ignore NO_PROXY. LLM traffic is pointed at the Clawvisor daemon host
+		// (ANTHROPIC_BASE_URL/OPENAI_BASE_URL); if such a client sends that
+		// request through the runtime proxy anyway, the daemon host must pass
+		// so it still reaches proxy-lite.
+		if daemonHost := normalizedEndpointHost(cfg.Server.PublicURL); daemonHost != "" && host == daemonHost {
+			return true
+		}
 	}
 	for _, allowed := range sessionHarnessAllowlist(session, cfg) {
 		allowed = strings.ToLower(strings.TrimSpace(allowed))
@@ -756,11 +771,80 @@ func isHarnessAllowlistedForSession(session *store.RuntimeSession, cfg *config.C
 			return true
 		}
 	}
+	// Legacy runtime-only mode allows the harness to reach the provider LLM
+	// hosts directly. In the Contain superset (llm_route=proxy_lite) these
+	// hosts are a routing escape, not traffic to allow — the D2 backstop
+	// (earlier in the egress hook) intercepts them, and this case is skipped
+	// so a dodged request falls through to normal egress policy (denied).
+	if sessionLLMRouteProxyLite(session, cfg) {
+		return false
+	}
 	switch host {
 	case "api.anthropic.com", "api.openai.com", "chatgpt.com":
 		return true
 	}
 	return false
+}
+
+// isContainLLMBackstopHost reports whether host is a known provider LLM host
+// that, in the Contain superset, must never be reached directly through the
+// runtime proxy (it must go to proxy-lite via ANTHROPIC_BASE_URL/
+// OPENAI_BASE_URL). chatgpt.com is included per spec 09 gotcha 4.
+func isContainLLMBackstopHost(host string) bool {
+	switch strings.ToLower(strings.TrimSpace(host)) {
+	case "api.anthropic.com", "api.openai.com", "chatgpt.com":
+		return true
+	}
+	return false
+}
+
+const containLLMBypassBody = `{"error":"llm_direct_bypass","detail":"LLM traffic must use the Clawvisor endpoint set in ANTHROPIC_BASE_URL/OPENAI_BASE_URL"}`
+
+// handleContainLLMBypass is the Contain superset backstop (spec 09 D2) for a
+// direct LLM-host hit that dodged the env-var routing. In enforce mode it
+// blocks with 403 llm_direct_bypass; in observation mode it warns (passes the
+// request through). Both paths write a runtime.llm_bypass_blocked audit event
+// with the decision recorded in clawvisor.runtimeproxy.requests via the
+// observability OnResponse hook.
+func (s *Server) handleContainLLMBypass(req *http.Request, st *RequestState, hooks PolicyHooks, host string) (*http.Request, *http.Response) {
+	paramsSafe, _ := json.Marshal(map[string]any{
+		"host":   host,
+		"path":   req.URL.Path,
+		"reason": "llm_direct_bypass",
+	})
+	metadata := map[string]any{
+		"host":         host,
+		"method":       req.Method,
+		"path":         req.URL.Path,
+		"observe_mode": st.Session.ObservationMode,
+	}
+	if st.Session.ObservationMode {
+		metadata["action"] = "warned"
+		st.AuditID = s.logAudit(req.Context(), hooks.Store, st, runtimeAuditOptions{
+			WouldBlock: true,
+		}, paramsSafe, req.Method, "allow", "warned", "contain: direct LLM-host hit bypassed proxy-lite routing (observation mode)")
+		emitRuntimeEvent(req.Context(), hooks.Store, st.Session, st, runtimeEventOptions{
+			EventType:  "runtime.llm_bypass_blocked",
+			ActionKind: "egress",
+			Decision:   stringPtr("allow"),
+			Outcome:    stringPtr("warned"),
+			Reason:     stringPtr("contain: direct LLM-host hit bypassed proxy-lite routing"),
+			Metadata:   metadata,
+		})
+		return req, nil
+	}
+	metadata["action"] = "blocked"
+	st.AuditID = s.logAudit(req.Context(), hooks.Store, st, runtimeAuditOptions{}, paramsSafe, req.Method, "deny", "blocked", "contain: direct LLM-host hit must use ANTHROPIC_BASE_URL/OPENAI_BASE_URL")
+	emitRuntimeEvent(req.Context(), hooks.Store, st.Session, st, runtimeEventOptions{
+		EventType:  "runtime.llm_bypass_blocked",
+		ActionKind: "egress",
+		Decision:   stringPtr("deny"),
+		Outcome:    stringPtr("blocked"),
+		Reason:     stringPtr("contain: direct LLM-host hit must use ANTHROPIC_BASE_URL/OPENAI_BASE_URL"),
+		Metadata:   metadata,
+	})
+	st.SkipAuditOutcomeUpdate = true
+	return req, goproxy.NewResponse(req, "application/json", http.StatusForbidden, containLLMBypassBody)
 }
 
 func normalizedEndpointHost(endpoint string) string {

--- a/pkg/runtime/proxy/session_settings.go
+++ b/pkg/runtime/proxy/session_settings.go
@@ -31,6 +31,14 @@ type sessionRuntimeSettings struct {
 	InlineApprovalEnabled   *bool     `json:"inline_approval_enabled,omitempty"`
 	ToolLeaseTimeoutSeconds int       `json:"tool_lease_timeout_seconds,omitempty"`
 	HarnessAllowlist        *[]string `json:"harness_allowlist,omitempty"`
+
+	// LLMRoute selects whether a contained agent's LLM traffic is routed
+	// through proxy-lite ("proxy_lite") — the Contain superset — or handled
+	// by the runtime proxy directly ("direct"). Empty means "use cfg"
+	// (cfg.RuntimeProxy.LLMRoute). Sourced from cfg at session create; cloud
+	// may override per-org via session metadata (same pattern as the
+	// Phase-0.6 override fields above).
+	LLMRoute string `json:"llm_route,omitempty"`
 }
 
 func mergedAgentRuntimeSettings(agent *store.Agent, cfg *config.Config) sessionRuntimeSettings {
@@ -43,6 +51,9 @@ func mergedAgentRuntimeSettings(agent *store.Agent, cfg *config.Config) sessionR
 	}
 	if cfg != nil && !cfg.RuntimePolicy.ObservationModeDefault {
 		settings.RuntimeMode = "enforce"
+	}
+	if cfg != nil {
+		settings.LLMRoute = strings.ToLower(strings.TrimSpace(cfg.RuntimeProxy.LLMRoute))
 	}
 	if agent != nil && agent.RuntimeSettings != nil {
 		settings.RuntimeEnabled = agent.RuntimeSettings.RuntimeEnabled
@@ -88,7 +99,23 @@ func sessionRuntimeSettingsFromMetadata(session *store.RuntimeSession, cfg *conf
 	if parsed.HarnessAllowlist != nil {
 		settings.HarnessAllowlist = parsed.HarnessAllowlist
 	}
+	if strings.TrimSpace(parsed.LLMRoute) != "" {
+		settings.LLMRoute = strings.ToLower(strings.TrimSpace(parsed.LLMRoute))
+	}
 	return settings
+}
+
+// sessionLLMRoute reports whether this session's LLM traffic is routed through
+// proxy-lite (the Contain superset). A non-empty per-session override wins;
+// otherwise it falls back to cfg.RuntimeProxy.LLMRoute. "Posture is contain"
+// throughout the runtime proxy means this returns true.
+func sessionLLMRouteProxyLite(session *store.RuntimeSession, cfg *config.Config) bool {
+	settings := sessionRuntimeSettingsFromMetadata(session, cfg)
+	route := strings.TrimSpace(settings.LLMRoute)
+	if route == "" && cfg != nil {
+		route = strings.TrimSpace(cfg.RuntimeProxy.LLMRoute)
+	}
+	return strings.EqualFold(route, "proxy_lite")
 }
 
 func sessionAutovaultMode(session *store.RuntimeSession, cfg *config.Config) string {

--- a/pkg/runtime/proxy/tooluse_runtime.go
+++ b/pkg/runtime/proxy/tooluse_runtime.go
@@ -251,6 +251,15 @@ func (s *Server) handleToolUseBlockedResponse(resp *http.Response, ctx *goproxy.
 	if st == nil || st.Session == nil {
 		return resp
 	}
+	// Contain superset (spec 09 D3): when LLM traffic is routed through
+	// proxy-lite, the runtime proxy's duplicate LLM stream/body processing is
+	// gated off — LLM responses never transit the runtime proxy (the D2
+	// backstop blocks direct hits, and NO_PROXY bypasses composed traffic), so
+	// this is defense-in-depth. The processors are kept for legacy runtime-only
+	// mode; physical removal is a follow-up after legacy sunset.
+	if sessionLLMRouteProxyLite(st.Session, hooks.Config) {
+		return resp
+	}
 	rewriter := registry.Match(ctx.Req, resp)
 	if rewriter == nil || resp.Body == nil {
 		return resp


### PR DESCRIPTION
Composition, not duplication: under `proxy_lite` routing, the runtime wrapper env injection now also sets `ANTHROPIC_BASE_URL`/`OPENAI_BASE_URL` so a contained agent's LLM traffic flows through proxy-lite exactly as in govern (same pipeline, holds, verdicts, cost records), while the runtime proxy governs all other egress. The runtime proxy's duplicate LLM handling is reduced to a backstop: a direct LLM-host hit that dodges the env vars gets `403 llm_direct_bypass` (audited + metered). Capability-parity suite: the full proxy scenario set re-runs under contain (`CLAWVISOR_E2E_POSTURE=contain`) plus contain-only egress/backstop/routing scenarios. `posture = "contain"` unlocks behind `experimental_contain = true` until the parity lane is a required release gate; `RUNTIME_PROXY_DISABLED` (409) formalized.

**Stack 9/15** — base: `tc-stack-3`. Retarget as the stack merges. Requires #610.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

