### PR TITLE
feat(governance): local instance-scoped governance (model/spend/content/task policy)

### DIFF
--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -8,6 +8,8 @@ on:
       - "provider/**"
       - ".github/workflows/terraform-ci.yml"
       - "scripts/mirror-terraform.sh"
+      - "scripts/terraform-plan-secret-scan.sh"
+      - "scripts/terraform-real-aws-lane.sh"
     tags: ["v*"]
   pull_request:
     branches: [main]
@@ -15,6 +17,9 @@ on:
       - "deploy/terraform/**"
       - "provider/**"
       - ".github/workflows/terraform-ci.yml"
+      - "scripts/mirror-terraform.sh"
+      - "scripts/terraform-plan-secret-scan.sh"
+      - "scripts/terraform-real-aws-lane.sh"
   workflow_dispatch:
     inputs:
       real_cloud:
@@ -68,7 +73,12 @@ jobs:
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: "~> 1.9"
-      - name: render + validate compose
+      - name: install caddy (for Caddyfile validation)
+        run: |
+          curl -fsSL https://github.com/caddyserver/caddy/releases/download/v2.8.4/caddy_2.8.4_linux_amd64.tar.gz \
+            | sudo tar -xz -C /usr/local/bin caddy
+          caddy version
+      - name: render + validate compose + Caddyfile
         run: |
           cd deploy/terraform/examples/local-docker
           ./run.sh
@@ -80,23 +90,36 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.real_cloud }}
     environment: terraform-aws
+    # The lane uses fixed resource names (NAME=clawvisor: shared SSM param, DB,
+    # snapshots). Serialize the lane globally so two manual dispatches can't
+    # clobber each other's SSM param / DB / snapshots. Never cancel a run
+    # mid-apply — that would orphan half-created billable resources.
+    concurrency:
+      group: terraform-real-aws-lane
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: "~> 1.9"
 
+      # The `secrets` context is not available in `if:` expressions (using it
+      # invalidates the whole workflow at parse time), so gate via a step
+      # output instead.
       - name: guard — require AWS credentials
+        id: guard
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         run: |
           if [ -z "$AWS_ACCESS_KEY_ID" ]; then
             echo "No AWS credentials configured; skipping real-cloud lane."
-            exit 0
+            echo "has_aws=0" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_aws=1" >> "$GITHUB_OUTPUT"
           fi
 
       - name: apply → upgrade → snapshot → destroy
-        if: ${{ secrets.AWS_ACCESS_KEY_ID != '' }}
+        if: ${{ steps.guard.outputs.has_aws == '1' }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -200,6 +200,16 @@ telemetry:
 #                              # it migrates EVERY subscription seat on the
 #                              # instance at once, not one.
 
+# ── Governance (instance-scoped / local orggov) ─────────────────────────────
+# Local model allow/deny, spend caps, content policy, and violation logging
+# enforced on the proxy-lite path, configured via /api/governance/* (the
+# Terraform provider's governance resources). Enabled by default: the tables
+# are empty on a fresh install, so it is a no-op until an admin writes a
+# policy. Set false to disable the local callbacks and drop the
+# `local_governance` capability from /api/features.
+# governance:
+#   enabled: true                # Env: CLAWVISOR_GOVERNANCE_ENABLED
+
 # ── Observability (OpenTelemetry export) ────────────────────────────────────
 # Operational traces + metrics from the proxy-lite pipeline, the skill
 # gateway, and the runtime proxy, exported over OTLP to whatever you already

--- a/e2e/scenarios/llm_proxy_local_gov_test.go
+++ b/e2e/scenarios/llm_proxy_local_gov_test.go
@@ -1,0 +1,311 @@
+package scenarios_test
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"fmt"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/clawvisor/clawvisor/e2e/testapp"
+	"github.com/clawvisor/clawvisor/testharness"
+)
+
+// llm_proxy_local_gov_test.go covers spec 06a: the four governance policy
+// callbacks implemented LOCALLY (govlocal) against instance-scoped tables,
+// enforced on the proxy-lite path and configured via the /api/governance/*
+// REST routes. Each test boots a fresh server (governance enabled by
+// default), configures a policy through the admin REST surface, then drives
+// a proxied /api/v1/messages request to observe enforcement.
+
+const govDeniedModel = "claude-haiku-4-5-20251001"               // request body model
+const govCanonicalDenied = "anthropic/claude-haiku-4-5-20251001" // canonical form the policy matches
+
+// govBootWithGovernance boots a proxy-lite server, logs in the admin, sets
+// a vault anthropic key (so vault injection has an upstream credential and
+// the request reaches the governance checks), and creates an agent.
+func govBootWithGovernance(t *testing.T, extraEnv map[string]string) (cv *testapp.Server, admin *testapp.LocalUser, agentToken string, upstream *upstreamCapture) {
+	t.Helper()
+	h := testharness.New(t)
+	upstream = newUpstreamCapture(t)
+	env := map[string]string{"CLAWVISOR_LLM_UPSTREAM_ANTHROPIC": upstream.URL()}
+	for k, v := range extraEnv {
+		env[k] = v
+	}
+	cv = testapp.StartWith(t, h, env)
+	admin = cv.LoginAsLocalUser(t)
+	llmCredSet(t, cv, admin.AccessToken, "anthropic", "", "sk-ant-test-key")
+	_, agentToken = newPostureAgent(t, cv, admin.AccessToken, "gov-agent")
+	return cv, admin, agentToken, upstream
+}
+
+// govMessagesReq issues one proxied Anthropic messages request with the
+// given model and user-message content via the agent token.
+func govMessagesReq(t *testing.T, cv *testapp.Server, agentToken, model, content string) *http.Response {
+	t.Helper()
+	body := []byte(fmt.Sprintf(`{"model":%q,"max_tokens":16,"messages":[{"role":"user","content":%q}]}`, model, content))
+	req, _ := http.NewRequest("POST", cv.URL+"/api/v1/messages", bytes.NewReader(body))
+	req.Header.Set("X-Clawvisor-Agent-Token", agentToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := cv.Client.Do(req)
+	if err != nil {
+		t.Fatalf("/api/v1/messages: %v", err)
+	}
+	return resp
+}
+
+// govGetRaw GETs a path with the admin token and returns the space-stripped
+// body (for substring assertions on violations / features).
+func govGetRaw(t *testing.T, cv *testapp.Server, tok, path string) string {
+	t.Helper()
+	resp := cvDo(t, cv, tok, "GET", path, nil)
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	return strings.ReplaceAll(string(b), " ", "")
+}
+
+// openGovDB opens the subprocess server's SQLite file directly for seeding
+// rows the REST surface can't create (cost rows; a policy under a disabled
+// build). foreign_keys is left OFF (connection default) so a cost row can
+// be inserted without a parent audit_log row.
+func openGovDB(t *testing.T, cv *testapp.Server) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", filepath.Join(cv.DataDir, "clawvisor.db"))
+	if err != nil {
+		t.Fatalf("open gov db: %v", err)
+	}
+	if _, err := db.ExecContext(context.Background(), `PRAGMA busy_timeout = 5000`); err != nil {
+		t.Fatalf("busy_timeout: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+var govSeedN int
+
+// seedGovCost inserts one llm_request_cost row in the current daily window.
+func seedGovCost(t *testing.T, cv *testapp.Server, micros int64) {
+	t.Helper()
+	db := openGovDB(t, cv)
+	govSeedN++
+	_, err := db.ExecContext(context.Background(), `
+		INSERT INTO llm_request_cost (audit_id, user_id, request_id, timestamp, provider, model, cost_micros)
+		VALUES (?, 'u1', ?, ?, 'anthropic', 'claude', ?)`,
+		fmt.Sprintf("gov-seed-%d", govSeedN), fmt.Sprintf("gov-req-%d", govSeedN),
+		time.Now().UTC().Format(time.RFC3339), micros)
+	if err != nil {
+		t.Fatalf("seed cost: %v", err)
+	}
+}
+
+// TestLocalGovModelPolicyBlocks: a deny-list policy blocks a request for the
+// denied model with 4xx + policy reason, records a violation, and never
+// contacts the upstream.
+func TestLocalGovModelPolicyBlocks(t *testing.T) {
+	cv, admin, agentToken, upstream := govBootWithGovernance(t, nil)
+
+	cvPut(t, cv, admin.AccessToken, "/api/governance/model_policy",
+		map[string]any{"mode": "deny", "models": []string{govCanonicalDenied}}, nil)
+
+	resp := govMessagesReq(t, cv, agentToken, govDeniedModel, "hello")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("denied model should be blocked 403; got %d body=%s", resp.StatusCode, readBodyStr(resp))
+	}
+	if upstream.Count() != 0 {
+		t.Fatalf("denied request must not reach upstream; hits=%d", upstream.Count())
+	}
+	if v := govGetRaw(t, cv, admin.AccessToken, "/api/governance/violations"); !strings.Contains(v, `"policy_kind":"model_policy"`) || !strings.Contains(v, `"action_taken":"blocked"`) {
+		t.Fatalf("expected a blocked model_policy violation; got %s", v)
+	}
+}
+
+// TestLocalGovModelPolicyAllows: an allow-list containing the model lets the
+// request through to the upstream.
+func TestLocalGovModelPolicyAllows(t *testing.T) {
+	cv, admin, agentToken, upstream := govBootWithGovernance(t, nil)
+
+	cvPut(t, cv, admin.AccessToken, "/api/governance/model_policy",
+		map[string]any{"mode": "allow", "models": []string{govCanonicalDenied}}, nil)
+
+	resp := govMessagesReq(t, cv, agentToken, govDeniedModel, "hello")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("allow-listed model should pass; got %d body=%s", resp.StatusCode, readBodyStr(resp))
+	}
+	if upstream.Count() != 1 {
+		t.Fatalf("allowed request should reach upstream once; hits=%d", upstream.Count())
+	}
+}
+
+// TestLocalGovSpendCapSoftWarns: with spend seeded past 80% of a soft cap,
+// the request is allowed but audit records spend_cap_warning_level=80 and a
+// flagged violation exists.
+func TestLocalGovSpendCapSoftWarns(t *testing.T) {
+	cv, admin, agentToken, upstream := govBootWithGovernance(t, nil)
+
+	// $1 soft daily cap; seed 90% spend BEFORE the first request so the
+	// cold cache recomputes and sees it.
+	cvPut(t, cv, admin.AccessToken, "/api/governance/spend_caps/daily",
+		map[string]any{"cap_micros": 1_000_000, "enforcement": "soft"}, nil)
+	seedGovCost(t, cv, 900_000)
+
+	resp := govMessagesReq(t, cv, agentToken, govDeniedModel, "hello")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("soft cap should allow; got %d body=%s", resp.StatusCode, readBodyStr(resp))
+	}
+	if upstream.Count() != 1 {
+		t.Fatalf("soft-cap request should reach upstream; hits=%d", upstream.Count())
+	}
+	if !auditContains(t, cv, admin.AccessToken, `"spend_cap_warning_level":"80"`) {
+		t.Fatal("audit did not record spend_cap_warning_level=80")
+	}
+	if v := govGetRaw(t, cv, admin.AccessToken, "/api/governance/violations"); !strings.Contains(v, `"policy_kind":"spend_cap"`) || !strings.Contains(v, `"action_taken":"flagged"`) {
+		t.Fatalf("expected a flagged spend_cap violation; got %s", v)
+	}
+}
+
+// TestLocalGovSpendCapHardBlocks: past 100% on a hard cap, the request is
+// blocked 403 and never reaches upstream.
+func TestLocalGovSpendCapHardBlocks(t *testing.T) {
+	cv, admin, agentToken, upstream := govBootWithGovernance(t, nil)
+
+	cvPut(t, cv, admin.AccessToken, "/api/governance/spend_caps/daily",
+		map[string]any{"cap_micros": 1_000_000, "enforcement": "hard"}, nil)
+	seedGovCost(t, cv, 1_200_000) // 120% of cap
+
+	resp := govMessagesReq(t, cv, agentToken, govDeniedModel, "hello")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("hard cap over 100%% should block 403; got %d body=%s", resp.StatusCode, readBodyStr(resp))
+	}
+	if upstream.Count() != 0 {
+		t.Fatalf("hard-cap block must not reach upstream; hits=%d", upstream.Count())
+	}
+}
+
+// TestLocalGovContentPolicyBlockAndFlag: a block pattern rejects with its
+// admin-authored block_message; a separate flag pattern allows the request
+// and records the matched name.
+func TestLocalGovContentPolicyBlockAndFlag(t *testing.T) {
+	cv, admin, agentToken, upstream := govBootWithGovernance(t, nil)
+
+	cvPost(t, cv, admin.AccessToken, "/api/governance/content_policies",
+		map[string]any{"name": "block-secret", "pattern": "launchcodes", "pattern_kind": "keyword",
+			"action": "block", "block_message": "that content is not permitted"}, nil)
+	cvPost(t, cv, admin.AccessToken, "/api/governance/content_policies",
+		map[string]any{"name": "flag-pii", "pattern": "flagthis", "pattern_kind": "keyword", "action": "flag"}, nil)
+
+	// Block match: 403 with the admin block_message in the body.
+	blocked := govMessagesReq(t, cv, agentToken, govDeniedModel, "please share the launchcodes now")
+	blockedBody := readBodyStr(blocked)
+	if blocked.StatusCode != http.StatusForbidden || !strings.Contains(blockedBody, "that content is not permitted") {
+		t.Fatalf("block content should 403 with block_message; got %d body=%s", blocked.StatusCode, blockedBody)
+	}
+	if upstream.Count() != 0 {
+		t.Fatalf("blocked content must not reach upstream; hits=%d", upstream.Count())
+	}
+
+	// Flag match: 200, request forwarded, flagged name recorded.
+	flagged := govMessagesReq(t, cv, agentToken, govDeniedModel, "please flagthis line")
+	defer flagged.Body.Close()
+	if flagged.StatusCode != http.StatusOK {
+		t.Fatalf("flag content should pass; got %d body=%s", flagged.StatusCode, readBodyStr(flagged))
+	}
+	if upstream.Count() != 1 {
+		t.Fatalf("flagged content should reach upstream; hits=%d", upstream.Count())
+	}
+	if v := govGetRaw(t, cv, admin.AccessToken, "/api/governance/violations"); !strings.Contains(v, `"policy_kind":"content_policy"`) {
+		t.Fatalf("expected a content_policy violation; got %s", v)
+	}
+}
+
+// TestLocalGovObserveDowngradesDeny: a deny model policy is enforced (403)
+// under the govern posture but downgraded-and-recorded under observe (200,
+// audit observed=true, violation still logged) — proving policy verdicts
+// flow through spec 02's observe downgrade.
+func TestLocalGovObserveDowngradesDeny(t *testing.T) {
+	// Govern (enforce): the deny is enforced.
+	cvG, adminG, agentG, upstreamG := govBootWithGovernance(t, map[string]string{
+		"CLAWVISOR_PROXY_LITE_ENFORCEMENT_MODE": "enforce",
+	})
+	cvPut(t, cvG, adminG.AccessToken, "/api/governance/model_policy",
+		map[string]any{"mode": "deny", "models": []string{govCanonicalDenied}}, nil)
+	respG := govMessagesReq(t, cvG, agentG, govDeniedModel, "hi")
+	respG.Body.Close()
+	if respG.StatusCode != http.StatusForbidden {
+		t.Fatalf("govern posture should enforce deny; got %d", respG.StatusCode)
+	}
+	if upstreamG.Count() != 0 {
+		t.Fatalf("enforced deny must not reach upstream; hits=%d", upstreamG.Count())
+	}
+
+	// Observe: the same deny is downgraded to a recorded observation.
+	cvO, adminO, agentO, upstreamO := govBootWithGovernance(t, map[string]string{
+		"CLAWVISOR_PROXY_LITE_ENFORCEMENT_MODE": "observe",
+	})
+	cvPut(t, cvO, adminO.AccessToken, "/api/governance/model_policy",
+		map[string]any{"mode": "deny", "models": []string{govCanonicalDenied}}, nil)
+	respO := govMessagesReq(t, cvO, agentO, govDeniedModel, "hi")
+	defer respO.Body.Close()
+	if respO.StatusCode != http.StatusOK {
+		t.Fatalf("observe posture must NOT enforce the deny; got %d body=%s", respO.StatusCode, readBodyStr(respO))
+	}
+	if upstreamO.Count() != 1 {
+		t.Fatalf("observe posture should forward to upstream; hits=%d", upstreamO.Count())
+	}
+	if !auditContains(t, cvO, adminO.AccessToken, `"observed":true`) {
+		t.Fatal("audit did not record the downgraded verdict as observed:true")
+	}
+	// The violation is still recorded (RecordViolation fires inside Preprocess
+	// regardless of the observe downgrade).
+	if v := govGetRaw(t, cvO, adminO.AccessToken, "/api/governance/violations"); !strings.Contains(v, `"policy_kind":"model_policy"`) {
+		t.Fatalf("observe should still record the model_policy violation; got %s", v)
+	}
+}
+
+// TestLocalGovDisabled: with governance disabled, the /api/governance/*
+// routes are absent, the capability is off, and a deny policy seeded
+// directly into the DB is inert (the request is not blocked).
+func TestLocalGovDisabled(t *testing.T) {
+	cv, admin, agentToken, upstream := govBootWithGovernance(t, map[string]string{
+		"CLAWVISOR_GOVERNANCE_ENABLED": "false",
+	})
+
+	// Capability is off.
+	if f := govGetRaw(t, cv, admin.AccessToken, "/api/features"); !strings.Contains(f, `"local_governance":false`) {
+		t.Fatalf("features should report local_governance=false; got %s", f)
+	}
+	// The write route is not registered.
+	resp := cvDo(t, cv, admin.AccessToken, "PUT", "/api/governance/model_policy",
+		map[string]any{"mode": "deny", "models": []string{govCanonicalDenied}})
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("governance route should be 404 when disabled; got %d", resp.StatusCode)
+	}
+
+	// Seed a deny policy directly; it must be inert.
+	db := openGovDB(t, cv)
+	if _, err := db.ExecContext(context.Background(), `
+		INSERT INTO instance_model_policy (id, mode, models, active, created_by)
+		VALUES ('seed-deny', 'deny', ?, 1, '_instance')`,
+		fmt.Sprintf(`[%q]`, govCanonicalDenied)); err != nil {
+		t.Fatalf("seed deny policy: %v", err)
+	}
+	got := govMessagesReq(t, cv, agentToken, govDeniedModel, "hello")
+	defer got.Body.Close()
+	if got.StatusCode != http.StatusOK {
+		t.Fatalf("disabled governance must not enforce the seeded deny; got %d body=%s", got.StatusCode, readBodyStr(got))
+	}
+	if upstream.Count() != 1 {
+		t.Fatalf("disabled governance should forward to upstream; hits=%d", upstream.Count())
+	}
+}

--- a/internal/api/handlers/governance_local.go
+++ b/internal/api/handlers/governance_local.go
@@ -1,0 +1,418 @@
+package handlers
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/clawvisor/clawvisor/internal/api/middleware"
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+// GovernanceLocalHandler serves the instance-scoped (local) governance REST
+// surface (spec 06a): model policy, spend caps, content policies, task
+// policy, and the violation log. Request/response JSON bodies are
+// BYTE-IDENTICAL to cloud's org-scoped governance handler (the org segment
+// is simply dropped from the path) so the Terraform provider's governance
+// resources are schema-identical across OSS and cloud (PRD §8).
+//
+// All routes are admin-gated at the mux (RequireAdminOrToken — JWT admin or
+// an instance-admin API token). Write validation mirrors cloud: model ids
+// must be provider-qualified; regex patterns must compile and be <=256
+// chars.
+type GovernanceLocalHandler struct {
+	st     store.Store
+	logger *slog.Logger
+}
+
+// NewGovernanceLocalHandler constructs the handler.
+func NewGovernanceLocalHandler(st store.Store, logger *slog.Logger) *GovernanceLocalHandler {
+	return &GovernanceLocalHandler{st: st, logger: logger}
+}
+
+// actor returns the user id to stamp as created_by. Token-authenticated
+// writes are attributed to the `_instance` system user (the middleware
+// resolves UserFromContext to it), which is a valid users row.
+func (h *GovernanceLocalHandler) actor(r *http.Request) string {
+	if u := middleware.UserFromContext(r.Context()); u != nil && u.ID != "" {
+		return u.ID
+	}
+	return store.InstanceUserID
+}
+
+// ── Model policy ──────────────────────────────────────────────────────────────
+
+// GetModelPolicy returns the active model policy. 404 when none set.
+//
+// GET /api/governance/model_policy
+func (h *GovernanceLocalHandler) GetModelPolicy(w http.ResponseWriter, r *http.Request) {
+	mp, err := h.st.GetActiveInstanceModelPolicy(r.Context())
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "NOT_FOUND", "no model policy set")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not load model policy")
+		return
+	}
+	writeJSON(w, http.StatusOK, modelPolicyBody(mp))
+}
+
+// PutModelPolicy upserts the model policy (append-only server-side).
+//
+// PUT /api/governance/model_policy  body: {mode, models[]}
+func (h *GovernanceLocalHandler) PutModelPolicy(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Mode   string   `json:"mode"`
+		Models []string `json:"models"`
+	}
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+	if body.Mode != "allow" && body.Mode != "deny" {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "mode must be \"allow\" or \"deny\"")
+		return
+	}
+	if len(body.Models) == 0 {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "models must not be empty")
+		return
+	}
+	for _, m := range body.Models {
+		if !isProviderQualifiedModel(m) {
+			writeError(w, http.StatusUnprocessableEntity, "INVALID_MODEL_ID",
+				"model ids must be provider-qualified (\"provider/model\"): "+m)
+			return
+		}
+	}
+	p := &store.InstanceModelPolicy{Mode: body.Mode, Models: body.Models, CreatedBy: h.actor(r)}
+	if err := h.st.PutInstanceModelPolicy(r.Context(), p); err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not save model policy")
+		return
+	}
+	writeJSON(w, http.StatusOK, modelPolicyBody(p))
+}
+
+// DeleteModelPolicy clears the model policy.
+//
+// DELETE /api/governance/model_policy
+func (h *GovernanceLocalHandler) DeleteModelPolicy(w http.ResponseWriter, r *http.Request) {
+	if err := h.st.ClearInstanceModelPolicy(r.Context()); err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not clear model policy")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func modelPolicyBody(p *store.InstanceModelPolicy) map[string]any {
+	models := p.Models
+	if models == nil {
+		models = []string{}
+	}
+	return map[string]any{"mode": p.Mode, "models": models}
+}
+
+// ── Spend caps ──────────────────────────────────────────────────────────────
+
+// ListSpendCaps returns all configured spend caps.
+//
+// GET /api/governance/spend_caps  →  {spend_caps: [{window, cap_micros, enforcement}]}
+func (h *GovernanceLocalHandler) ListSpendCaps(w http.ResponseWriter, r *http.Request) {
+	caps, err := h.st.ListInstanceSpendCaps(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not list spend caps")
+		return
+	}
+	out := make([]map[string]any, 0, len(caps))
+	for _, c := range caps {
+		out = append(out, spendCapBody(c))
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"spend_caps": out})
+}
+
+// PutSpendCap upserts the cap for a window (path param).
+//
+// PUT /api/governance/spend_caps/{window}  body: {cap_micros, enforcement}
+func (h *GovernanceLocalHandler) PutSpendCap(w http.ResponseWriter, r *http.Request) {
+	window := r.PathValue("window")
+	if window != "daily" && window != "monthly" {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "window must be \"daily\" or \"monthly\"")
+		return
+	}
+	var body struct {
+		CapMicros   int64  `json:"cap_micros"`
+		Enforcement string `json:"enforcement"`
+	}
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+	if body.CapMicros <= 0 {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "cap_micros must be positive")
+		return
+	}
+	enforcement := body.Enforcement
+	if enforcement == "" {
+		enforcement = "soft"
+	}
+	if enforcement != "soft" && enforcement != "hard" {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "enforcement must be \"soft\" or \"hard\"")
+		return
+	}
+	c := &store.InstanceSpendCap{
+		WindowKind: window, CapMicros: body.CapMicros, Enforcement: enforcement, CreatedBy: h.actor(r),
+	}
+	if err := h.st.PutInstanceSpendCap(r.Context(), c); err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not save spend cap")
+		return
+	}
+	writeJSON(w, http.StatusOK, spendCapBody(c))
+}
+
+// DeleteSpendCap clears the cap for a window.
+//
+// DELETE /api/governance/spend_caps/{window}
+func (h *GovernanceLocalHandler) DeleteSpendCap(w http.ResponseWriter, r *http.Request) {
+	window := r.PathValue("window")
+	if err := h.st.DeleteInstanceSpendCap(r.Context(), window); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "NOT_FOUND", "no spend cap for window")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not delete spend cap")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func spendCapBody(c *store.InstanceSpendCap) map[string]any {
+	return map[string]any{
+		"window":      c.WindowKind,
+		"cap_micros":  c.CapMicros,
+		"enforcement": c.Enforcement,
+	}
+}
+
+// ── Content policies ──────────────────────────────────────────────────────────
+
+// ListContentPolicies returns all content policies.
+//
+// GET /api/governance/content_policies  →  {content_policies: [...]}
+func (h *GovernanceLocalHandler) ListContentPolicies(w http.ResponseWriter, r *http.Request) {
+	policies, err := h.st.ListInstanceContentPolicies(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not list content policies")
+		return
+	}
+	out := make([]map[string]any, 0, len(policies))
+	for _, p := range policies {
+		out = append(out, contentPolicyBody(p))
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"content_policies": out})
+}
+
+// CreateContentPolicy creates a content policy.
+//
+// POST /api/governance/content_policies  body: {name, pattern, pattern_kind, action, block_message, enabled}
+func (h *GovernanceLocalHandler) CreateContentPolicy(w http.ResponseWriter, r *http.Request) {
+	body, ok := decodeContentPolicyBody(w, r)
+	if !ok {
+		return
+	}
+	p := &store.InstanceContentPolicy{
+		Name: body.Name, Pattern: body.Pattern, PatternKind: body.PatternKind,
+		Action: body.Action, BlockMessage: body.BlockMessage, Enabled: body.enabledOrDefault(),
+		CreatedBy: h.actor(r),
+	}
+	if err := h.st.CreateInstanceContentPolicy(r.Context(), p); err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not create content policy")
+		return
+	}
+	writeJSON(w, http.StatusCreated, contentPolicyBody(p))
+}
+
+// UpdateContentPolicy updates a content policy by id.
+//
+// PUT /api/governance/content_policies/{cpid}
+func (h *GovernanceLocalHandler) UpdateContentPolicy(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("cpid")
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "content policy id is required")
+		return
+	}
+	body, ok := decodeContentPolicyBody(w, r)
+	if !ok {
+		return
+	}
+	p := &store.InstanceContentPolicy{
+		ID: id, Name: body.Name, Pattern: body.Pattern, PatternKind: body.PatternKind,
+		Action: body.Action, BlockMessage: body.BlockMessage, Enabled: body.enabledOrDefault(),
+	}
+	if err := h.st.UpdateInstanceContentPolicy(r.Context(), p); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "NOT_FOUND", "content policy not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not update content policy")
+		return
+	}
+	got, err := h.st.GetInstanceContentPolicy(r.Context(), id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not reload content policy")
+		return
+	}
+	writeJSON(w, http.StatusOK, contentPolicyBody(got))
+}
+
+// DeleteContentPolicy removes a content policy by id.
+//
+// DELETE /api/governance/content_policies/{cpid}
+func (h *GovernanceLocalHandler) DeleteContentPolicy(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("cpid")
+	if err := h.st.DeleteInstanceContentPolicy(r.Context(), id); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "NOT_FOUND", "content policy not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not delete content policy")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+type contentPolicyInput struct {
+	Name         string `json:"name"`
+	Pattern      string `json:"pattern"`
+	PatternKind  string `json:"pattern_kind"`
+	Action       string `json:"action"`
+	BlockMessage string `json:"block_message"`
+	Enabled      *bool  `json:"enabled"`
+}
+
+func (b contentPolicyInput) enabledOrDefault() bool {
+	if b.Enabled == nil {
+		return true
+	}
+	return *b.Enabled
+}
+
+// decodeContentPolicyBody decodes + validates a content policy request.
+func decodeContentPolicyBody(w http.ResponseWriter, r *http.Request) (contentPolicyInput, bool) {
+	var body contentPolicyInput
+	if !decodeJSON(w, r, &body) {
+		return body, false
+	}
+	if strings.TrimSpace(body.Name) == "" {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "name is required")
+		return body, false
+	}
+	if body.Pattern == "" {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "pattern is required")
+		return body, false
+	}
+	if body.PatternKind != "regex" && body.PatternKind != "keyword" {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "pattern_kind must be \"regex\" or \"keyword\"")
+		return body, false
+	}
+	if body.Action != "block" && body.Action != "flag" {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "action must be \"block\" or \"flag\"")
+		return body, false
+	}
+	if body.PatternKind == "regex" {
+		if len(body.Pattern) > 256 {
+			writeError(w, http.StatusUnprocessableEntity, "INVALID_PATTERN", "regex pattern must be <=256 chars")
+			return body, false
+		}
+		if _, err := regexp.Compile(body.Pattern); err != nil {
+			writeError(w, http.StatusUnprocessableEntity, "INVALID_PATTERN", "regex pattern does not compile")
+			return body, false
+		}
+	}
+	return body, true
+}
+
+func contentPolicyBody(p *store.InstanceContentPolicy) map[string]any {
+	return map[string]any{
+		"id":            p.ID,
+		"name":          p.Name,
+		"pattern":       p.Pattern,
+		"pattern_kind":  p.PatternKind,
+		"action":        p.Action,
+		"block_message": p.BlockMessage,
+		"enabled":       p.Enabled,
+	}
+}
+
+// ── Task policy ──────────────────────────────────────────────────────────────
+
+// GetTaskPolicy returns the active task policy. 404 when none set.
+//
+// GET /api/governance/task_policy
+func (h *GovernanceLocalHandler) GetTaskPolicy(w http.ResponseWriter, r *http.Request) {
+	tp, err := h.st.GetActiveInstanceTaskPolicy(r.Context())
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "NOT_FOUND", "no task policy set")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not load task policy")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"guidance": tp.Guidance})
+}
+
+// PutTaskPolicy upserts the task policy (append-only server-side).
+//
+// PUT /api/governance/task_policy  body: {guidance}
+func (h *GovernanceLocalHandler) PutTaskPolicy(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Guidance string `json:"guidance"`
+	}
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+	if strings.TrimSpace(body.Guidance) == "" {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "guidance is required")
+		return
+	}
+	p := &store.InstanceTaskPolicy{Guidance: body.Guidance, CreatedBy: h.actor(r)}
+	if err := h.st.PutInstanceTaskPolicy(r.Context(), p); err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not save task policy")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"guidance": p.Guidance})
+}
+
+// DeleteTaskPolicy clears the task policy.
+//
+// DELETE /api/governance/task_policy
+func (h *GovernanceLocalHandler) DeleteTaskPolicy(w http.ResponseWriter, r *http.Request) {
+	if err := h.st.ClearInstanceTaskPolicy(r.Context()); err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not clear task policy")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ── Violations ──────────────────────────────────────────────────────────────
+
+// ListViolations returns the most recent policy violations.
+//
+// GET /api/governance/violations  →  {violations: [...]}
+func (h *GovernanceLocalHandler) ListViolations(w http.ResponseWriter, r *http.Request) {
+	violations, err := h.st.ListInstancePolicyViolations(r.Context(), 200)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not list violations")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"violations": violations})
+}
+
+// isProviderQualifiedModel reports whether a model id carries a provider
+// prefix ("provider/model"). Bare names are rejected — same rule as cloud
+// (010_governance_policies.sql header). The provider segment and rest must
+// both be non-empty.
+func isProviderQualifiedModel(m string) bool {
+	i := strings.IndexByte(m, '/')
+	return i > 0 && i < len(m)-1
+}

--- a/internal/api/handlers/llm_endpoint.go
+++ b/internal/api/handlers/llm_endpoint.go
@@ -788,16 +788,21 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 			agentID:  agent.ID,
 		}
 		result, err := runSinglePolicy(r.Context(), pipeReq, policies.NewOrgModelPolicy(h.OrgGovCallbacks, h.OrgIDForAgent))
-		if err == nil && result.DenyReason != "" {
+		if err == nil {
+			// Merge audit params unconditionally (matching the spend-cap and
+			// content-policy blocks below) so an Observe-mode downgrade stamps
+			// observed=true on the audit row even though DenyReason is cleared.
 			for k, v := range result.AuditParams {
 				auditParams[k] = v
 			}
-			auditStatus = http.StatusForbidden
-			auditDecide = "deny"
-			auditOutcome = "org_model_policy_denied"
-			auditReason = result.DenyReason
-			http.Error(w, result.DenyReason, http.StatusForbidden)
-			return
+			if result.DenyReason != "" {
+				auditStatus = http.StatusForbidden
+				auditDecide = "deny"
+				auditOutcome = "org_model_policy_denied"
+				auditReason = result.DenyReason
+				http.Error(w, result.DenyReason, http.StatusForbidden)
+				return
+			}
 		}
 	}
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -181,6 +181,10 @@ type FeatureSet struct {
 	// there is no config gate — so it is set unconditionally in
 	// handleFeatures rather than plumbed through WithFeatures.
 	APITokens bool `json:"api_tokens"`
+	// LocalGovernance advertises the instance-scoped /api/governance/*
+	// routes (spec 06a) so the Terraform provider un-skips its governance
+	// resources. Reflects config.Governance.Enabled; set in handleFeatures.
+	LocalGovernance bool `json:"local_governance"`
 }
 
 // GatewayHooks allows cloud/enterprise layers to inject additional
@@ -1119,6 +1123,30 @@ func (s *Server) routes() http.Handler {
 	mux.Handle("POST /api/audit/mutes", user(auditHandler.CreateMute))
 	mux.Handle("DELETE /api/audit/mutes/{id}", user(auditHandler.DeleteMute))
 
+	// Local governance (spec 06a). Instance-scoped policy CRUD the Terraform
+	// provider drives; shapes are byte-identical to cloud's org-scoped
+	// governance handler. All routes are admin-gated (RequireAdminOrToken:
+	// JWT admin OR an instance-admin API token — a config-write token is 403
+	// INSUFFICIENT_SCOPE). Registered iff governance is enabled (default
+	// true); the capability flag on /api/features mirrors this gate.
+	if s.cfg.Governance.Enabled {
+		govHandler := handlers.NewGovernanceLocalHandler(s.store, s.logger)
+		mux.Handle("GET /api/governance/model_policy", adminOrToken(govHandler.GetModelPolicy))
+		mux.Handle("PUT /api/governance/model_policy", adminOrToken(govHandler.PutModelPolicy))
+		mux.Handle("DELETE /api/governance/model_policy", adminOrToken(govHandler.DeleteModelPolicy))
+		mux.Handle("GET /api/governance/spend_caps", adminOrToken(govHandler.ListSpendCaps))
+		mux.Handle("PUT /api/governance/spend_caps/{window}", adminOrToken(govHandler.PutSpendCap))
+		mux.Handle("DELETE /api/governance/spend_caps/{window}", adminOrToken(govHandler.DeleteSpendCap))
+		mux.Handle("GET /api/governance/content_policies", adminOrToken(govHandler.ListContentPolicies))
+		mux.Handle("POST /api/governance/content_policies", adminOrToken(govHandler.CreateContentPolicy))
+		mux.Handle("PUT /api/governance/content_policies/{cpid}", adminOrToken(govHandler.UpdateContentPolicy))
+		mux.Handle("DELETE /api/governance/content_policies/{cpid}", adminOrToken(govHandler.DeleteContentPolicy))
+		mux.Handle("GET /api/governance/task_policy", adminOrToken(govHandler.GetTaskPolicy))
+		mux.Handle("PUT /api/governance/task_policy", adminOrToken(govHandler.PutTaskPolicy))
+		mux.Handle("DELETE /api/governance/task_policy", adminOrToken(govHandler.DeleteTaskPolicy))
+		mux.Handle("GET /api/governance/violations", adminOrToken(govHandler.ListViolations))
+	}
+
 	if s.cfg.ProxyLite.Enabled {
 		s.registerLiteProxyRoutes(
 			mux, baseURL, verifier, tasksHandler, vaultHandler, e2e, user,
@@ -1607,6 +1635,10 @@ func (s *Server) handleFeatures(w http.ResponseWriter, r *http.Request) {
 	// API tokens are always available (no config gate); advertise them so
 	// the Terraform provider knows the endpoints exist.
 	fs.APITokens = true
+	// Local governance (spec 06a): the /api/governance/* routes exist iff
+	// governance is enabled (default true). The provider gates its
+	// governance resources on this capability.
+	fs.LocalGovernance = s.cfg.Governance.Enabled
 	w.Header().Set("Content-Type", "application/json")
 	// The response varies per-user (via featuresHook). Without no-store, a
 	// browser may cache the anonymous response and serve it back after the

--- a/internal/govlocal/govlocal.go
+++ b/internal/govlocal/govlocal.go
@@ -1,0 +1,210 @@
+// Package govlocal implements the four governance policy callbacks
+// (CheckModelPolicy, CheckSpendCap, ScanContentPolicy, RecordViolation)
+// LOCALLY against instance-scoped tables, so a self-hosted OSS instance
+// gets model allow/deny, spend caps, content policy, and violation
+// logging without the cloud layer (spec 06a, PRD §8).
+//
+// Nil governance callbacks no longer mean "no governance" — they mean "no
+// CLOUD governance". The run.go wiring fills each nil hook from these
+// builders (cloud wins per-hook, local fills gaps).
+//
+// Verdict shapes mirror cloud internal/governance/callbacks.go exactly:
+// CheckSpendCap returns warning levels "" / "80" / "100"; ScanContentPolicy
+// returns the first block-mode policy's admin-authored block_message and
+// accumulates flag-mode policy names. This parity is what keeps the
+// Terraform provider schemas identical across OSS and cloud (spec 06b).
+//
+// The orgID parameter is IGNORED by every local implementation — policies
+// are instance-scoped, one flat set. Do not filter on it.
+package govlocal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/orggov"
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+// BuildCheckModelPolicy returns the local model-policy check. Loads the
+// active instance_model_policy and applies allow/deny exactly like cloud's
+// BuildCheckModelPolicy. No active policy → allow. Store errors fail open
+// (best-effort; logged) — a self-hosted DB blip must not hard-block every
+// request.
+func BuildCheckModelPolicy(st store.Store) func(ctx context.Context, orgID, model string) (bool, string) {
+	return func(ctx context.Context, _, model string) (bool, string) {
+		mp, err := st.GetActiveInstanceModelPolicy(ctx)
+		if err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				return true, ""
+			}
+			slog.WarnContext(ctx, "govlocal: load model policy failed", "err", err)
+			return true, ""
+		}
+		matched := false
+		for _, m := range mp.Models {
+			if m == model {
+				matched = true
+				break
+			}
+		}
+		switch mp.Mode {
+		case "deny":
+			if matched {
+				return false, fmt.Sprintf("model %q is denied by instance policy", model)
+			}
+		case "allow":
+			if !matched {
+				return false, fmt.Sprintf("model %q is not in the instance allow-list", model)
+			}
+		}
+		return true, ""
+	}
+}
+
+// BuildCheckSpendCap returns the local spend-cap check. Evaluates every
+// configured instance cap (daily + monthly) against the instance-wide cost
+// sum for each window and returns the STRICTEST verdict: any hard block
+// wins; otherwise the highest warning level wins. Ported from cloud's
+// BuildCheckSpendCap (org/team scopes collapsed to a single instance
+// scope). Returns (allow, warningLevel, reason); warningLevel ∈ "" / "80"
+// / "100". The 60s per-window cache spares the DB a SUM() per request.
+func BuildCheckSpendCap(st store.Store) func(ctx context.Context, orgID, agentID string) (bool, string, string) {
+	cache := newSpendCache()
+	return func(ctx context.Context, _, _ string) (bool, string, string) {
+		caps, err := st.ListInstanceSpendCaps(ctx)
+		if err != nil {
+			slog.WarnContext(ctx, "govlocal: list spend caps failed", "err", err)
+			return true, "", ""
+		}
+		strictest := capVerdict{allow: true}
+		for _, c := range caps {
+			since, until := windowBounds(c.WindowKind)
+			total, err := cache.sum(ctx, st, c.WindowKind, since, until)
+			if err != nil {
+				slog.WarnContext(ctx, "govlocal: spend sum failed", "window", c.WindowKind, "err", err)
+				continue
+			}
+			v := evaluateCap(total, c.CapMicros, c.Enforcement, c.WindowKind)
+			strictest = strictest.merge(v)
+		}
+		return strictest.allow, strictest.warning, strictest.reason
+	}
+}
+
+// BuildScanContentPolicy returns the local content-scan callback. Loads
+// the enabled instance_content_policy rows and evaluates each against the
+// extracted content. Returns the first block-action match (with its
+// admin-authored block_message), or aggregates flag-action match names
+// into flagged. Ported from cloud's BuildScanContentPolicy.
+func BuildScanContentPolicy(st store.Store) func(ctx context.Context, orgID, content string) (bool, string, string, []string) {
+	return func(ctx context.Context, _, content string) (bool, string, string, []string) {
+		policies, err := st.ListInstanceContentPolicies(ctx)
+		if err != nil {
+			slog.WarnContext(ctx, "govlocal: list content policies failed", "err", err)
+			return true, "", "", nil
+		}
+		var flagged []string
+		for _, p := range policies {
+			if !p.Enabled {
+				continue
+			}
+			if !patternMatchSafe(p, content) {
+				continue
+			}
+			if p.Action == "block" {
+				return false, p.BlockMessage, fmt.Sprintf("content matched policy %q", p.Name), nil
+			}
+			// flag — keep going to collect all matches
+			flagged = append(flagged, p.Name)
+		}
+		if len(flagged) > 0 {
+			return true, "", fmt.Sprintf("content flagged by %d policy/policies", len(flagged)), flagged
+		}
+		return true, "", "", nil
+	}
+}
+
+// BuildRecordViolation returns the local violation recorder. Maps the
+// pipeline's orggov.ViolationEvent onto instance_policy_violation, dropping
+// the OrgID (the "local" sentinel is never persisted). Best-effort: errors
+// are logged, never returned upstream.
+func BuildRecordViolation(st store.Store) func(ctx context.Context, evt orggov.ViolationEvent) {
+	return func(ctx context.Context, evt orggov.ViolationEvent) {
+		err := st.RecordInstancePolicyViolation(ctx, &store.InstancePolicyViolation{
+			UserID:      evt.UserID,
+			AgentID:     evt.AgentID,
+			TaskID:      evt.TaskID,
+			PolicyKind:  evt.PolicyKind,
+			ActionTaken: evt.ActionTaken,
+			Detail:      evt.Detail,
+		})
+		if err != nil {
+			slog.WarnContext(ctx, "govlocal: record violation failed",
+				"policy_kind", evt.PolicyKind, "err", err)
+		}
+	}
+}
+
+// capVerdict captures one cap's evaluation result. Ported from cloud.
+type capVerdict struct {
+	allow   bool
+	warning string // "" | "80" | "100"
+	reason  string
+}
+
+// merge folds a single cap result into the running strictest verdict.
+// Rules (identical to cloud): any !allow wins; among allows, the higher
+// warning level wins (100 > 80 > ""); reason follows the strictest cap.
+func (v capVerdict) merge(o capVerdict) capVerdict {
+	if !o.allow {
+		if v.allow {
+			return o
+		}
+		return v
+	}
+	if !v.allow {
+		return v
+	}
+	if warningRank(o.warning) > warningRank(v.warning) {
+		return o
+	}
+	return v
+}
+
+func warningRank(w string) int {
+	switch w {
+	case "100":
+		return 2
+	case "80":
+		return 1
+	}
+	return 0
+}
+
+// evaluateCap returns the verdict for a single cap. Hard caps block at
+// 100%; soft caps emit warning levels but always allow. Ported from cloud
+// evaluateCap (scope label dropped — one instance scope). The reason
+// strings are instance-scoped variants of cloud's.
+func evaluateCap(currentMicros, capMicros int64, enforcement, window string) capVerdict {
+	if capMicros <= 0 {
+		return capVerdict{allow: true}
+	}
+	pct := float64(currentMicros) / float64(capMicros)
+	if pct >= 1.0 {
+		reason := fmt.Sprintf("%s spend cap reached ($%.2f / $%.2f)", window, microsToUSD(currentMicros), microsToUSD(capMicros))
+		if enforcement == "hard" {
+			return capVerdict{allow: false, warning: "100", reason: reason}
+		}
+		return capVerdict{allow: true, warning: "100", reason: reason}
+	}
+	if pct >= 0.80 {
+		reason := fmt.Sprintf("%s spend at %.0f%% of cap ($%.2f / $%.2f)", window, pct*100, microsToUSD(currentMicros), microsToUSD(capMicros))
+		return capVerdict{allow: true, warning: "80", reason: reason}
+	}
+	return capVerdict{allow: true}
+}
+
+func microsToUSD(m int64) float64 { return float64(m) / 1_000_000.0 }

--- a/internal/govlocal/govlocal_test.go
+++ b/internal/govlocal/govlocal_test.go
@@ -1,0 +1,194 @@
+package govlocal
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/clawvisor/clawvisor/pkg/store"
+	"github.com/clawvisor/clawvisor/pkg/store/sqlite"
+)
+
+func newStore(t *testing.T) (store.Store, context.Context) {
+	t.Helper()
+	ctx := context.Background()
+	db, err := sqlite.New(ctx, filepath.Join(t.TempDir(), "clawvisor.db"))
+	if err != nil {
+		t.Fatalf("sqlite.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return sqlite.NewStore(db), ctx
+}
+
+var seedCounter int
+
+// seedCost inserts one llm_request_cost row with the given cost_micros in
+// the current daily window. It bypasses the audit_id FK (there is no audit
+// row in a unit test) by toggling foreign_keys off for the single insert —
+// the SQLite store uses one connection, so the pragma is scoped to it.
+func seedCost(t *testing.T, st store.Store, ctx context.Context, micros int64) {
+	t.Helper()
+	db := st.(interface{ DB() *sql.DB }).DB()
+	if _, err := db.ExecContext(ctx, `PRAGMA foreign_keys = OFF`); err != nil {
+		t.Fatalf("pragma off: %v", err)
+	}
+	defer db.ExecContext(ctx, `PRAGMA foreign_keys = ON`)
+	seedCounter++
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO llm_request_cost (audit_id, user_id, request_id, timestamp, provider, model, cost_micros)
+		VALUES (?, 'u1', ?, ?, 'anthropic', 'claude', ?)`,
+		fmt.Sprintf("seed-%d", seedCounter), fmt.Sprintf("req-%d", seedCounter),
+		time.Now().UTC().Format(time.RFC3339), micros)
+	if err != nil {
+		t.Fatalf("seed cost: %v", err)
+	}
+}
+
+// TestEvaluateCap_WarningLevels verifies the "80"/"100" warning math and
+// hard-vs-soft blocking, matching cloud's evaluateCap exactly.
+func TestEvaluateCap_WarningLevels(t *testing.T) {
+	cases := []struct {
+		name        string
+		current     int64
+		cap         int64
+		enforcement string
+		wantAllow   bool
+		wantWarning string
+	}{
+		{"under-80-soft", 700_000, 1_000_000, "soft", true, ""},
+		{"at-80-soft", 800_000, 1_000_000, "soft", true, "80"},
+		{"at-80-hard", 850_000, 1_000_000, "hard", true, "80"},
+		{"at-100-soft", 1_000_000, 1_000_000, "soft", true, "100"},
+		{"over-100-soft", 1_500_000, 1_000_000, "soft", true, "100"},
+		{"at-100-hard", 1_000_000, 1_000_000, "hard", false, "100"},
+		{"over-100-hard", 2_000_000, 1_000_000, "hard", false, "100"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := evaluateCap(tc.current, tc.cap, tc.enforcement, "daily")
+			if v.allow != tc.wantAllow || v.warning != tc.wantWarning {
+				t.Fatalf("evaluateCap = (allow=%v warning=%q), want (allow=%v warning=%q)",
+					v.allow, v.warning, tc.wantAllow, tc.wantWarning)
+			}
+		})
+	}
+}
+
+// TestMerge_StrictestWins proves a hard block beats a soft warning and the
+// highest warning wins among allows.
+func TestMerge_StrictestWins(t *testing.T) {
+	soft80 := capVerdict{allow: true, warning: "80", reason: "r80"}
+	hard100 := capVerdict{allow: false, warning: "100", reason: "block"}
+	soft100 := capVerdict{allow: true, warning: "100", reason: "r100"}
+
+	if m := soft80.merge(hard100); m.allow {
+		t.Fatal("hard block must win over soft warning")
+	}
+	if m := (capVerdict{allow: true}).merge(soft80).merge(soft100); m.warning != "100" {
+		t.Fatalf("highest warning should win, got %q", m.warning)
+	}
+}
+
+// TestBuildCheckModelPolicy_DenyAllow exercises the deny/allow modes and
+// the empty-policy fall-through against a real store.
+func TestBuildCheckModelPolicy_DenyAllow(t *testing.T) {
+	st, ctx := newStore(t)
+	check := BuildCheckModelPolicy(st)
+
+	// No policy → allow.
+	if allow, _ := check(ctx, LocalOrgID, "anthropic/claude-3-opus"); !allow {
+		t.Fatal("no policy should allow")
+	}
+	// Deny list.
+	if err := st.PutInstanceModelPolicy(ctx, &store.InstanceModelPolicy{
+		Mode: "deny", Models: []string{"anthropic/claude-3-opus"}, CreatedBy: "_instance",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if allow, reason := check(ctx, LocalOrgID, "anthropic/claude-3-opus"); allow || reason == "" {
+		t.Fatalf("deny list should block with a reason; allow=%v reason=%q", allow, reason)
+	}
+	if allow, _ := check(ctx, LocalOrgID, "openai/gpt-4o"); !allow {
+		t.Fatal("model not on deny list should allow")
+	}
+	// Allow list.
+	if err := st.PutInstanceModelPolicy(ctx, &store.InstanceModelPolicy{
+		Mode: "allow", Models: []string{"openai/gpt-4o"}, CreatedBy: "_instance",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if allow, _ := check(ctx, LocalOrgID, "openai/gpt-4o"); !allow {
+		t.Fatal("allow-listed model should allow")
+	}
+	if allow, _ := check(ctx, LocalOrgID, "anthropic/claude-3-opus"); allow {
+		t.Fatal("model not on allow list should block")
+	}
+}
+
+// TestBuildScanContentPolicy_BlockAndFlag proves the first block wins and
+// flag matches accumulate names.
+func TestBuildScanContentPolicy_BlockAndFlag(t *testing.T) {
+	st, ctx := newStore(t)
+	if err := st.CreateInstanceContentPolicy(ctx, &store.InstanceContentPolicy{
+		Name: "flag-secret", Pattern: "secret", PatternKind: "keyword", Action: "flag", Enabled: true, CreatedBy: "_instance",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.CreateInstanceContentPolicy(ctx, &store.InstanceContentPolicy{
+		Name: "block-ssn", Pattern: `\d{3}-\d{2}-\d{4}`, PatternKind: "regex", Action: "block",
+		BlockMessage: "no SSNs allowed", Enabled: true, CreatedBy: "_instance",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	scan := BuildScanContentPolicy(st)
+
+	// Flag only.
+	allow, msg, _, flagged := scan(ctx, LocalOrgID, "this is secret info")
+	if !allow || msg != "" || len(flagged) != 1 || flagged[0] != "flag-secret" {
+		t.Fatalf("flag path mismatch: allow=%v msg=%q flagged=%v", allow, msg, flagged)
+	}
+	// Block wins.
+	allow, msg, _, _ = scan(ctx, LocalOrgID, "ssn 123-45-6789 and secret")
+	if allow || msg != "no SSNs allowed" {
+		t.Fatalf("block path mismatch: allow=%v msg=%q", allow, msg)
+	}
+}
+
+// TestBuildCheckSpendCap_SoftWarnHardBlock seeds cost rows and checks the
+// warning-level / block verdicts end to end via the store.
+func TestBuildCheckSpendCap_SoftWarnHardBlock(t *testing.T) {
+	st, ctx := newStore(t)
+	// Soft daily cap of $1 (1,000,000 micros).
+	if err := st.PutInstanceSpendCap(ctx, &store.InstanceSpendCap{
+		WindowKind: "daily", CapMicros: 1_000_000, Enforcement: "soft", CreatedBy: "_instance",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// No spend → allow, no warning.
+	check := BuildCheckSpendCap(st)
+	if allow, warn, _ := check(ctx, LocalOrgID, "agent-1"); !allow || warn != "" {
+		t.Fatalf("empty spend should allow with no warning; allow=%v warn=%q", allow, warn)
+	}
+
+	// Seed 90% of cap → fresh cache recompute (new cap builder) sees "80".
+	seedCost(t, st, ctx, 900_000)
+	check2 := BuildCheckSpendCap(st)
+	if allow, warn, reason := check2(ctx, LocalOrgID, "agent-1"); !allow || warn != "80" || reason == "" {
+		t.Fatalf("90%% of soft cap should warn 80; allow=%v warn=%q reason=%q", allow, warn, reason)
+	}
+
+	// Switch to hard cap and push past 100%.
+	if err := st.PutInstanceSpendCap(ctx, &store.InstanceSpendCap{
+		WindowKind: "daily", CapMicros: 1_000_000, Enforcement: "hard", CreatedBy: "_instance",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	seedCost(t, st, ctx, 200_000) // total 1,100,000 > cap
+	check3 := BuildCheckSpendCap(st)
+	if allow, warn, _ := check3(ctx, LocalOrgID, "agent-1"); allow || warn != "100" {
+		t.Fatalf("hard cap over 100%% should block; allow=%v warn=%q", allow, warn)
+	}
+}

--- a/internal/govlocal/scan.go
+++ b/internal/govlocal/scan.go
@@ -1,0 +1,45 @@
+package govlocal
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+// patternMatchSafe applies a content policy's pattern to content.
+//
+// Ported verbatim (behavior-identical) from cloud
+// internal/governance/callbacks.go's patternMatchSafe — the OSS and cloud
+// content scanners MUST match byte-for-byte so the Terraform provider's
+// content_policy resource behaves identically across tiers (PRD §8). The
+// only structural change is the policy type (store.InstanceContentPolicy
+// vs cloud's OrgContentPolicy); the matching semantics are unchanged.
+//
+// ReDoS guards (mandatory — do not relax): regex patterns > 256 chars
+// never match; compile errors never match; content is truncated to 65536
+// bytes before MatchString. keyword patterns are a case-insensitive
+// substring match.
+func patternMatchSafe(p *store.InstanceContentPolicy, content string) bool {
+	if p.PatternKind == "keyword" {
+		return strings.Contains(strings.ToLower(content), strings.ToLower(p.Pattern))
+	}
+	if p.PatternKind == "regex" {
+		// Cap pattern length + content length. ReDoS protection: if a
+		// regex compiles, we test against a length-capped content.
+		if len(p.Pattern) > 256 {
+			return false
+		}
+		re, err := regexp.Compile(p.Pattern)
+		if err != nil {
+			return false
+		}
+		// Length-cap the input the regex sees to bound worst-case time.
+		const maxScan = 65536
+		if len(content) > maxScan {
+			content = content[:maxScan]
+		}
+		return re.MatchString(content)
+	}
+	return false
+}

--- a/internal/govlocal/scan_test.go
+++ b/internal/govlocal/scan_test.go
@@ -1,0 +1,68 @@
+package govlocal
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+// TestPatternMatchSafe_Keyword: case-insensitive substring.
+func TestPatternMatchSafe_Keyword(t *testing.T) {
+	p := &store.InstanceContentPolicy{PatternKind: "keyword", Pattern: "SeCReT"}
+	if !patternMatchSafe(p, "this is a Secret memo") {
+		t.Fatal("keyword should match case-insensitively")
+	}
+	if patternMatchSafe(p, "nothing here") {
+		t.Fatal("keyword should not match absent text")
+	}
+}
+
+// TestPatternMatchSafe_Regex: basic regex + compile-error never matches.
+func TestPatternMatchSafe_Regex(t *testing.T) {
+	p := &store.InstanceContentPolicy{PatternKind: "regex", Pattern: `\d{3}-\d{2}-\d{4}`}
+	if !patternMatchSafe(p, "ssn 123-45-6789 here") {
+		t.Fatal("regex should match SSN shape")
+	}
+	bad := &store.InstanceContentPolicy{PatternKind: "regex", Pattern: `(unclosed`}
+	if patternMatchSafe(bad, "(unclosed") {
+		t.Fatal("compile error must never match")
+	}
+}
+
+// TestPatternMatchSafe_LongPatternNeverMatches: a 257-char regex pattern
+// never matches (ReDoS guard — patterns > 256 chars are rejected).
+func TestPatternMatchSafe_LongPatternNeverMatches(t *testing.T) {
+	pattern := strings.Repeat("a", 257)
+	p := &store.InstanceContentPolicy{PatternKind: "regex", Pattern: pattern}
+	if patternMatchSafe(p, strings.Repeat("a", 300)) {
+		t.Fatal("257-char pattern must never match (ReDoS guard)")
+	}
+	// A 256-char pattern is within bound and can match.
+	ok := &store.InstanceContentPolicy{PatternKind: "regex", Pattern: strings.Repeat("a", 256)}
+	if !patternMatchSafe(ok, strings.Repeat("a", 256)) {
+		t.Fatal("256-char pattern should be allowed and match")
+	}
+}
+
+// TestPatternMatchSafe_PathologicalRegexBounded: a pathological regex on
+// 100KB input returns within the truncation bound (content capped to 64KB
+// before MatchString) — the call completes fast rather than hanging.
+func TestPatternMatchSafe_PathologicalRegexBounded(t *testing.T) {
+	// Classic catastrophic-backtracking shape, kept under 256 chars.
+	p := &store.InstanceContentPolicy{PatternKind: "regex", Pattern: `(a+)+$`}
+	content := strings.Repeat("a", 100*1024) + "!"
+	done := make(chan bool, 1)
+	go func() {
+		_ = patternMatchSafe(p, content)
+		done <- true
+	}()
+	select {
+	case <-done:
+		// Returned — Go's RE2 is linear-time anyway, but the truncation
+		// bound is what makes this deterministic regardless of engine.
+	case <-time.After(5 * time.Second):
+		t.Fatal("patternMatchSafe did not return within the truncation bound")
+	}
+}

--- a/internal/govlocal/store.go
+++ b/internal/govlocal/store.go
@@ -1,0 +1,77 @@
+package govlocal
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+// LocalOrgID is the sentinel OrgID the pipeline carries for every agent in
+// a pure-OSS build so instance-scoped callbacks actually fire. The
+// pipeline policies no-op when the resolved orgID is "" (see
+// org_model_policy.go); the run.go wiring installs a resolver returning
+// this constant whenever local governance is active and no cloud
+// OrgIDForAgent is provided. It is never persisted (the violation table
+// has no org_id column) and must never leak into cloud builds.
+const LocalOrgID = "local"
+
+// spendCacheTTL is how long a computed window spend sum is cached
+// in-process. Short enough that a cap change is felt quickly, long enough
+// to spare the DB a SUM() on every proxied request. Matches the spec's
+// 60s window.
+const spendCacheTTL = 60 * time.Second
+
+// spendCache memoizes the instance-wide cost sum per window (daily /
+// monthly) for spendCacheTTL. Plain mutex + timestamp — no new
+// dependency. Cached per window because the daily and monthly windows
+// have different bounds and roll over independently.
+type spendCache struct {
+	mu      sync.Mutex
+	entries map[string]spendCacheEntry
+}
+
+type spendCacheEntry struct {
+	sum      int64
+	computed time.Time
+}
+
+func newSpendCache() *spendCache {
+	return &spendCache{entries: make(map[string]spendCacheEntry)}
+}
+
+// sum returns the cost sum for [since, until), using the cached value when
+// it is younger than spendCacheTTL, otherwise recomputing via the store.
+// The window key distinguishes the daily/monthly caches.
+func (c *spendCache) sum(ctx context.Context, st store.Store, window string, since, until time.Time) (int64, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if e, ok := c.entries[window]; ok && time.Since(e.computed) < spendCacheTTL {
+		return e.sum, nil
+	}
+	total, err := st.SumInstanceCostMicros(ctx, since, until)
+	if err != nil {
+		return 0, err
+	}
+	c.entries[window] = spendCacheEntry{sum: total, computed: time.Now()}
+	return total, nil
+}
+
+// windowBounds returns the start/end of the current daily or monthly
+// window. "daily" is the calendar day in UTC; "monthly" is the calendar
+// month in UTC. Ported from cloud callbacks.go windowBounds — the OSS and
+// cloud spend windows MUST agree so a cap behaves identically across
+// tiers.
+func windowBounds(window string) (since, until time.Time) {
+	now := time.Now().UTC()
+	switch window {
+	case "monthly":
+		since = time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+		until = since.AddDate(0, 1, 0)
+	default: // daily
+		since = time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+		until = since.Add(24 * time.Hour)
+	}
+	return since, until
+}

--- a/pkg/clawvisor/governance.go
+++ b/pkg/clawvisor/governance.go
@@ -1,0 +1,68 @@
+package clawvisor
+
+import (
+	"context"
+
+	"github.com/clawvisor/clawvisor/internal/govlocal"
+	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/orggov"
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+// composeGovernanceCallbacks builds the orggov.Callbacks + agent→org
+// resolver the LLM-proxy pipeline consults, applying per-hook precedence:
+//
+//	cloud (opts.OrgGov) > local (govlocal) > allow
+//
+// Cloud hooks win for whichever fields they populate; govlocal fills every
+// remaining nil hook when govEnabled. In a pure-OSS build (cloud == nil)
+// every hook comes from govlocal. The returned resolver is the cloud's
+// OrgIDForAgent when provided, otherwise the "local" sentinel (installed
+// only when local governance is active and the cloud left it nil — the
+// sentinel must never override a real cloud resolver, and never leak into a
+// cloud build that resolves real orgs).
+//
+// wire reports whether any hook was populated (so the caller only registers
+// governance when something will actually run).
+func composeGovernanceCallbacks(cloud *OrgGovOptions, st store.Store, govEnabled bool) (callbacks orggov.Callbacks, orgIDForAgent func(context.Context, string) string, wire bool) {
+	if cloud != nil {
+		callbacks.CheckModelPolicy = cloud.CheckModelPolicy
+		callbacks.CheckSpendCap = cloud.CheckSpendCap
+		callbacks.ScanContentPolicy = cloud.ScanContentPolicy
+		if rv := cloud.RecordViolation; rv != nil {
+			callbacks.RecordViolation = func(ctx context.Context, evt orggov.ViolationEvent) {
+				rv(ctx, OrgGovViolation{
+					OrgID:       evt.OrgID,
+					UserID:      evt.UserID,
+					AgentID:     evt.AgentID,
+					TaskID:      evt.TaskID,
+					PolicyKind:  evt.PolicyKind,
+					ActionTaken: evt.ActionTaken,
+					Detail:      evt.Detail,
+				})
+			}
+		}
+		orgIDForAgent = cloud.OrgIDForAgent
+	}
+
+	if govEnabled && st != nil {
+		if callbacks.CheckModelPolicy == nil {
+			callbacks.CheckModelPolicy = govlocal.BuildCheckModelPolicy(st)
+		}
+		if callbacks.CheckSpendCap == nil {
+			callbacks.CheckSpendCap = govlocal.BuildCheckSpendCap(st)
+		}
+		if callbacks.ScanContentPolicy == nil {
+			callbacks.ScanContentPolicy = govlocal.BuildScanContentPolicy(st)
+		}
+		if callbacks.RecordViolation == nil {
+			callbacks.RecordViolation = govlocal.BuildRecordViolation(st)
+		}
+		if orgIDForAgent == nil {
+			orgIDForAgent = func(context.Context, string) string { return govlocal.LocalOrgID }
+		}
+	}
+
+	wire = callbacks.CheckModelPolicy != nil || callbacks.CheckSpendCap != nil ||
+		callbacks.ScanContentPolicy != nil || callbacks.RecordViolation != nil
+	return callbacks, orgIDForAgent, wire
+}

--- a/pkg/clawvisor/governance_test.go
+++ b/pkg/clawvisor/governance_test.go
@@ -1,0 +1,99 @@
+package clawvisor
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/internal/govlocal"
+	"github.com/clawvisor/clawvisor/pkg/store"
+	"github.com/clawvisor/clawvisor/pkg/store/sqlite"
+)
+
+func govTestStore(t *testing.T) store.Store {
+	t.Helper()
+	ctx := context.Background()
+	db, err := sqlite.New(ctx, filepath.Join(t.TempDir(), "clawvisor.db"))
+	if err != nil {
+		t.Fatalf("sqlite.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return sqlite.NewStore(db)
+}
+
+// TestLocalGovCloudPrecedence proves per-hook precedence: a cloud callback
+// wins for the hook it populates, while govlocal fills every other hook. A
+// cloud CheckModelPolicy is provided; the local spend cap must still fire
+// (from govlocal), and the cloud model hook must be the one wired.
+func TestLocalGovCloudPrecedence(t *testing.T) {
+	st := govTestStore(t)
+	ctx := context.Background()
+
+	// Local spend cap so govlocal's CheckSpendCap has something to enforce.
+	if err := st.PutInstanceSpendCap(ctx, &store.InstanceSpendCap{
+		WindowKind: "daily", CapMicros: 1_000_000, Enforcement: "hard", CreatedBy: "_instance",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	cloudModelCalled := false
+	cloud := &OrgGovOptions{
+		CheckModelPolicy: func(ctx context.Context, orgID, model string) (bool, string) {
+			cloudModelCalled = true
+			return false, "cloud says no"
+		},
+		// OrgIDForAgent provided → the "local" sentinel must NOT be installed.
+		OrgIDForAgent: func(ctx context.Context, agentID string) string { return "org-123" },
+	}
+
+	callbacks, orgIDForAgent, wire := composeGovernanceCallbacks(cloud, st, true)
+	if !wire {
+		t.Fatal("expected governance to be wired")
+	}
+
+	// Cloud model hook wins.
+	if allow, reason := callbacks.CheckModelPolicy(ctx, "org-123", "anthropic/claude-3-opus"); allow || reason != "cloud says no" {
+		t.Fatalf("cloud CheckModelPolicy should win; allow=%v reason=%q", allow, reason)
+	}
+	if !cloudModelCalled {
+		t.Fatal("cloud CheckModelPolicy was not invoked")
+	}
+
+	// Local spend cap still fires (govlocal filled the nil cloud hook).
+	if callbacks.CheckSpendCap == nil {
+		t.Fatal("local CheckSpendCap should fill the nil cloud hook")
+	}
+	if callbacks.ScanContentPolicy == nil || callbacks.RecordViolation == nil {
+		t.Fatal("govlocal should fill the remaining nil hooks")
+	}
+
+	// The cloud resolver is preserved; the "local" sentinel is NOT installed.
+	if got := orgIDForAgent(ctx, "agent-1"); got != "org-123" {
+		t.Fatalf("cloud OrgIDForAgent must win; got %q (sentinel leak?)", got)
+	}
+}
+
+// TestLocalGovPureOSSInstallsSentinel proves that with no cloud layer, every
+// hook comes from govlocal and the "local" OrgID shim is installed so the
+// instance-scoped callbacks actually fire.
+func TestLocalGovPureOSSInstallsSentinel(t *testing.T) {
+	st := govTestStore(t)
+	callbacks, orgIDForAgent, wire := composeGovernanceCallbacks(nil, st, true)
+	if !wire || callbacks.CheckModelPolicy == nil || callbacks.CheckSpendCap == nil ||
+		callbacks.ScanContentPolicy == nil || callbacks.RecordViolation == nil {
+		t.Fatal("pure-OSS build should wire all four local hooks")
+	}
+	if got := orgIDForAgent(context.Background(), "agent-1"); got != govlocal.LocalOrgID {
+		t.Fatalf("pure-OSS build should install the %q sentinel; got %q", govlocal.LocalOrgID, got)
+	}
+}
+
+// TestLocalGovDisabledComposesNothing proves governance disabled produces no
+// callbacks at all (wire=false), regardless of the store.
+func TestLocalGovDisabledComposesNothing(t *testing.T) {
+	st := govTestStore(t)
+	callbacks, _, wire := composeGovernanceCallbacks(nil, st, false)
+	if wire || callbacks.CheckModelPolicy != nil {
+		t.Fatal("disabled governance must compose no callbacks")
+	}
+}

--- a/pkg/clawvisor/run.go
+++ b/pkg/clawvisor/run.go
@@ -16,7 +16,6 @@ import (
 	"github.com/clawvisor/clawvisor/internal/api/middleware"
 	"github.com/clawvisor/clawvisor/internal/intent"
 	"github.com/clawvisor/clawvisor/internal/llm"
-	"github.com/clawvisor/clawvisor/internal/runtime/llmproxy/orggov"
 	runtimepolicy "github.com/clawvisor/clawvisor/internal/runtime/policy"
 	"github.com/clawvisor/clawvisor/internal/taskrisk"
 	"github.com/clawvisor/clawvisor/pkg/adapters"
@@ -264,35 +263,31 @@ func RunWithContext(ctx context.Context, opts *ServerOptions) error {
 		}))
 	}
 
-	if opts.OrgGov != nil {
-		// Translate the public OrgGovOptions (bare function signatures)
-		// to the internal orggov.Callbacks / intent.PromptResolverFn /
-		// taskrisk.PromptResolverFn shapes the api layer expects.
-		recordViolation := opts.OrgGov.RecordViolation
-		callbacks := orggov.Callbacks{
-			CheckModelPolicy:  opts.OrgGov.CheckModelPolicy,
-			CheckSpendCap:     opts.OrgGov.CheckSpendCap,
-			ScanContentPolicy: opts.OrgGov.ScanContentPolicy,
+	// Governance callback composition (spec 06a). Cloud (opts.OrgGov) wins
+	// per-hook; local govlocal fills any nil hook; nil only if governance is
+	// disabled entirely. Precedence is cloud > local > allow, evaluated hook
+	// by hook — the pipeline sees a single orggov.Callbacks either way.
+	//
+	// Start from cloud's hooks (if any), then fill gaps from govlocal when
+	// Governance.Enabled (default true). In a pure-OSS build opts.OrgGov is
+	// nil, so every hook comes from govlocal and the "local" OrgID shim is
+	// installed so the instance-scoped callbacks actually fire (the pipeline
+	// policies no-op on orgID=="").
+	{
+		govEnabled := opts.Config == nil || opts.Config.Governance.Enabled
+		callbacks, orgIDForAgent, wire := composeGovernanceCallbacks(opts.OrgGov, opts.Store, govEnabled)
+		if wire {
+			apiOpts = append(apiOpts, api.WithOrgGov(callbacks, orgIDForAgent))
 		}
-		if recordViolation != nil {
-			callbacks.RecordViolation = func(ctx context.Context, evt orggov.ViolationEvent) {
-				recordViolation(ctx, OrgGovViolation{
-					OrgID:       evt.OrgID,
-					UserID:      evt.UserID,
-					AgentID:     evt.AgentID,
-					TaskID:      evt.TaskID,
-					PolicyKind:  evt.PolicyKind,
-					ActionTaken: evt.ActionTaken,
-					Detail:      evt.Detail,
-				})
+
+		// Prompt resolvers stay cloud-only (spec 06a out-of-scope for local).
+		if opts.OrgGov != nil {
+			if opts.OrgGov.IntentPromptResolver != nil {
+				apiOpts = append(apiOpts, api.WithIntentPromptResolver(intent.PromptResolverFn(opts.OrgGov.IntentPromptResolver)))
 			}
-		}
-		apiOpts = append(apiOpts, api.WithOrgGov(callbacks, opts.OrgGov.OrgIDForAgent))
-		if opts.OrgGov.IntentPromptResolver != nil {
-			apiOpts = append(apiOpts, api.WithIntentPromptResolver(intent.PromptResolverFn(opts.OrgGov.IntentPromptResolver)))
-		}
-		if opts.OrgGov.TaskRiskPromptResolver != nil {
-			apiOpts = append(apiOpts, api.WithTaskRiskPromptResolver(taskrisk.PromptResolverFn(opts.OrgGov.TaskRiskPromptResolver)))
+			if opts.OrgGov.TaskRiskPromptResolver != nil {
+				apiOpts = append(apiOpts, api.WithTaskRiskPromptResolver(taskrisk.PromptResolverFn(opts.OrgGov.TaskRiskPromptResolver)))
+			}
 		}
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -65,6 +65,7 @@ type Config struct {
 	RuntimeProxy  RuntimeProxyConfig  `yaml:"runtime_proxy"`
 	RuntimePolicy RuntimePolicyConfig `yaml:"runtime_policy"`
 	ProxyLite     ProxyLiteConfig     `yaml:"proxy_lite"`
+	Governance    GovernanceConfig    `yaml:"governance"`
 	Features      FeaturesConfig      `yaml:"features"`
 	RateLimit     RateLimitConfig     `yaml:"rate_limit"`
 	Relay         RelayConfig         `yaml:"relay"`
@@ -76,6 +77,20 @@ type Config struct {
 	Redis         RedisConfig         `yaml:"redis"`
 
 	AutoConfig AutoConfigured `yaml:"-"`
+}
+
+// GovernanceConfig gates the instance-scoped (local) governance layer
+// (spec 06a): local model policy / spend cap / content policy / task
+// policy enforcement on the proxy-lite path, plus the /api/governance/*
+// REST surface the Terraform provider drives.
+//
+// Enabled defaults to TRUE. This is safe because the governance tables are
+// empty on a fresh install, so enabled-with-no-policies is a pure no-op
+// (every callback returns "allow"). Setting it false disables the local
+// callbacks and drops the `local_governance` capability from
+// /api/features (the provider then fails fast on governance resources).
+type GovernanceConfig struct {
+	Enabled bool `yaml:"enabled"`
 }
 
 // GatewayConfig holds settings for the gateway request handler.
@@ -583,6 +598,13 @@ func Default() *Config {
 			UpstreamAuth:                      "vault",
 			AllowSubscriptionBillingMigration: false,
 		},
+		Governance: GovernanceConfig{
+			// Enabled by default: the governance tables are empty on a fresh
+			// install, so local enforcement is a no-op until an admin writes a
+			// policy. This is NOT a behavior-affecting flip of an existing key
+			// (spec 06a is additive; no existing install carries policies).
+			Enabled: true,
+		},
 		Features: FeaturesConfig{
 			SecretVault:    false,
 			ServicePresets: false,
@@ -989,6 +1011,9 @@ func Load(path string) (*Config, error) {
 	}
 	if v := os.Getenv("CLAWVISOR_PROXY_LITE_ENABLED"); v != "" {
 		cfg.ProxyLite.Enabled = v == "true" || v == "1"
+	}
+	if v := os.Getenv("CLAWVISOR_GOVERNANCE_ENABLED"); v != "" {
+		cfg.Governance.Enabled = v == "true" || v == "1"
 	}
 	if v := os.Getenv("CLAWVISOR_PROXY_LITE_PUBLIC_URL"); v != "" {
 		cfg.ProxyLite.PublicURL = strings.TrimRight(strings.TrimSpace(v), "/")

--- a/pkg/store/postgres/migrations/063_instance_governance.sql
+++ b/pkg/store/postgres/migrations/063_instance_governance.sql
@@ -61,3 +61,13 @@ CREATE TABLE IF NOT EXISTS instance_policy_violation (
 );
 CREATE INDEX IF NOT EXISTS idx_instance_violation_time
     ON instance_policy_violation(created_at);
+
+-- SumInstanceCostMicros (the spend-cap read path) aggregates
+-- SUM(cost_micros) over every llm_request_cost row in a time window,
+-- instance-wide (no user_id / agent_id filter). Every existing index on
+-- that table is (user_id,…) or (agent_id,…) leading, so this rollup falls
+-- back to a full table scan. Add a timestamp-leading index so the window
+-- filter seeks directly — same reasoning as migration 057's
+-- (agent_id, timestamp) covering index for the cloud dashboards.
+CREATE INDEX IF NOT EXISTS idx_llm_cost_time
+    ON llm_request_cost(timestamp);

--- a/pkg/store/postgres/migrations/063_instance_governance.sql
+++ b/pkg/store/postgres/migrations/063_instance_governance.sql
@@ -1,0 +1,63 @@
+-- 06a: instance-scoped (local) governance tables (Postgres mirror of
+-- sqlite 064_instance_governance.sql). See that file's header for the
+-- full rationale. TIMESTAMPTZ + BIGINT dialect; no org_id anywhere.
+
+CREATE TABLE IF NOT EXISTS instance_model_policy (
+    id          TEXT PRIMARY KEY,
+    mode        TEXT NOT NULL CHECK (mode IN ('allow','deny')),
+    models      TEXT NOT NULL,          -- JSON array of canonical ids
+    active      INTEGER NOT NULL DEFAULT 1,
+    created_by  TEXT NOT NULL REFERENCES users(id),
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_instance_model_policy_active
+    ON instance_model_policy(active) WHERE active = 1;
+
+CREATE TABLE IF NOT EXISTS instance_spend_cap (
+    id           TEXT PRIMARY KEY,
+    window_kind  TEXT NOT NULL CHECK (window_kind IN ('daily','monthly')),
+    cap_micros   BIGINT NOT NULL CHECK (cap_micros > 0),
+    enforcement  TEXT NOT NULL DEFAULT 'soft' CHECK (enforcement IN ('soft','hard')),
+    created_by   TEXT NOT NULL REFERENCES users(id),
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(window_kind)
+);
+
+CREATE TABLE IF NOT EXISTS instance_content_policy (
+    id            TEXT PRIMARY KEY,
+    name          TEXT NOT NULL,
+    pattern       TEXT NOT NULL,
+    pattern_kind  TEXT NOT NULL CHECK (pattern_kind IN ('regex','keyword')),
+    action        TEXT NOT NULL CHECK (action IN ('block','flag')),
+    block_message TEXT NOT NULL DEFAULT '',
+    enabled       INTEGER NOT NULL DEFAULT 1,
+    created_by    TEXT NOT NULL REFERENCES users(id),
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS instance_task_policy (
+    id          TEXT PRIMARY KEY,
+    guidance    TEXT NOT NULL,
+    active      INTEGER NOT NULL DEFAULT 1,
+    created_by  TEXT NOT NULL REFERENCES users(id),
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_instance_task_policy_active
+    ON instance_task_policy(active) WHERE active = 1;
+
+CREATE TABLE IF NOT EXISTS instance_policy_violation (
+    id            TEXT PRIMARY KEY,
+    user_id       TEXT,
+    agent_id      TEXT,
+    task_id       TEXT,
+    policy_kind   TEXT NOT NULL CHECK (policy_kind IN
+                    ('model_policy','spend_cap','content_policy','task_policy')),
+    policy_id     TEXT,
+    action_taken  TEXT NOT NULL CHECK (action_taken IN ('blocked','flagged','warned')),
+    detail        TEXT,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_instance_violation_time
+    ON instance_policy_violation(created_at);

--- a/pkg/store/postgres/migrations/063_instance_governance.sql
+++ b/pkg/store/postgres/migrations/063_instance_governance.sql
@@ -69,5 +69,5 @@ CREATE INDEX IF NOT EXISTS idx_instance_violation_time
 -- back to a full table scan. Add a timestamp-leading index so the window
 -- filter seeks directly — same reasoning as migration 057's
 -- (agent_id, timestamp) covering index for the cloud dashboards.
-CREATE INDEX IF NOT EXISTS idx_llm_cost_time
+CREATE INDEX IF NOT EXISTS idx_llm_cost_ts_raw
     ON llm_request_cost(timestamp);

--- a/pkg/store/postgres/store_governance.go
+++ b/pkg/store/postgres/store_governance.go
@@ -1,0 +1,331 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+// Instance governance (spec 06a — local orggov). Postgres mirror of the
+// sqlite implementation; see pkg/store/sqlite/store_governance.go for the
+// append-only-history rationale.
+
+// ── Model policy ──────────────────────────────────────────────────────────────
+
+func (s *Store) GetActiveInstanceModelPolicy(ctx context.Context) (*store.InstanceModelPolicy, error) {
+	row := s.pool.QueryRow(ctx, `
+		SELECT id, mode, models, created_by, created_at
+		FROM instance_model_policy WHERE active = 1`)
+	var p store.InstanceModelPolicy
+	var modelsJSON string
+	if err := row.Scan(&p.ID, &p.Mode, &modelsJSON, &p.CreatedBy, &p.CreatedAt); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, store.ErrNotFound
+		}
+		return nil, err
+	}
+	if err := json.Unmarshal([]byte(modelsJSON), &p.Models); err != nil {
+		return nil, err
+	}
+	return &p, nil
+}
+
+func (s *Store) PutInstanceModelPolicy(ctx context.Context, p *store.InstanceModelPolicy) error {
+	modelsJSON, err := json.Marshal(p.Models)
+	if err != nil {
+		return err
+	}
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+	if _, err := tx.Exec(ctx,
+		`UPDATE instance_model_policy SET active = 0 WHERE active = 1`); err != nil {
+		return err
+	}
+	if p.ID == "" {
+		p.ID = uuid.New().String()
+	}
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO instance_model_policy (id, mode, models, active, created_by)
+		VALUES ($1, $2, $3, 1, $4)`, p.ID, p.Mode, string(modelsJSON), p.CreatedBy); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+func (s *Store) ClearInstanceModelPolicy(ctx context.Context) error {
+	_, err := s.pool.Exec(ctx,
+		`UPDATE instance_model_policy SET active = 0 WHERE active = 1`)
+	return err
+}
+
+// ── Spend caps ──────────────────────────────────────────────────────────────
+
+func (s *Store) ListInstanceSpendCaps(ctx context.Context) ([]*store.InstanceSpendCap, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT id, window_kind, cap_micros, enforcement, created_by, created_at, updated_at
+		FROM instance_spend_cap ORDER BY window_kind`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []*store.InstanceSpendCap
+	for rows.Next() {
+		c, err := scanInstanceSpendCap(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) GetInstanceSpendCap(ctx context.Context, windowKind string) (*store.InstanceSpendCap, error) {
+	row := s.pool.QueryRow(ctx, `
+		SELECT id, window_kind, cap_micros, enforcement, created_by, created_at, updated_at
+		FROM instance_spend_cap WHERE window_kind = $1`, windowKind)
+	c, err := scanInstanceSpendCap(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, store.ErrNotFound
+	}
+	return c, err
+}
+
+func (s *Store) PutInstanceSpendCap(ctx context.Context, c *store.InstanceSpendCap) error {
+	if c.ID == "" {
+		c.ID = uuid.New().String()
+	}
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO instance_spend_cap (id, window_kind, cap_micros, enforcement, created_by)
+		VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (window_kind) DO UPDATE SET
+			cap_micros = excluded.cap_micros,
+			enforcement = excluded.enforcement,
+			updated_at = NOW()`,
+		c.ID, c.WindowKind, c.CapMicros, c.Enforcement, c.CreatedBy)
+	return err
+}
+
+func (s *Store) DeleteInstanceSpendCap(ctx context.Context, windowKind string) error {
+	tag, err := s.pool.Exec(ctx,
+		`DELETE FROM instance_spend_cap WHERE window_kind = $1`, windowKind)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return store.ErrNotFound
+	}
+	return nil
+}
+
+func (s *Store) SumInstanceCostMicros(ctx context.Context, since, until time.Time) (int64, error) {
+	var sum int64
+	err := s.pool.QueryRow(ctx, `
+		SELECT COALESCE(SUM(cost_micros), 0) FROM llm_request_cost
+		WHERE timestamp >= $1 AND timestamp < $2`, since.UTC(), until.UTC()).Scan(&sum)
+	return sum, err
+}
+
+func scanInstanceSpendCap(sc interface{ Scan(...any) error }) (*store.InstanceSpendCap, error) {
+	var c store.InstanceSpendCap
+	if err := sc.Scan(&c.ID, &c.WindowKind, &c.CapMicros, &c.Enforcement, &c.CreatedBy, &c.CreatedAt, &c.UpdatedAt); err != nil {
+		return nil, err
+	}
+	return &c, nil
+}
+
+// ── Content policies ──────────────────────────────────────────────────────────
+
+func (s *Store) ListInstanceContentPolicies(ctx context.Context) ([]*store.InstanceContentPolicy, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT id, name, pattern, pattern_kind, action, block_message, enabled, created_by, created_at, updated_at
+		FROM instance_content_policy ORDER BY created_at`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []*store.InstanceContentPolicy
+	for rows.Next() {
+		p, err := scanInstanceContentPolicy(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, p)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) GetInstanceContentPolicy(ctx context.Context, id string) (*store.InstanceContentPolicy, error) {
+	row := s.pool.QueryRow(ctx, `
+		SELECT id, name, pattern, pattern_kind, action, block_message, enabled, created_by, created_at, updated_at
+		FROM instance_content_policy WHERE id = $1`, id)
+	p, err := scanInstanceContentPolicy(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, store.ErrNotFound
+	}
+	return p, err
+}
+
+func (s *Store) CreateInstanceContentPolicy(ctx context.Context, p *store.InstanceContentPolicy) error {
+	if p.ID == "" {
+		p.ID = uuid.New().String()
+	}
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO instance_content_policy (id, name, pattern, pattern_kind, action, block_message, enabled, created_by)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+		p.ID, p.Name, p.Pattern, p.PatternKind, p.Action, p.BlockMessage, boolToPGInt(p.Enabled), p.CreatedBy)
+	return err
+}
+
+func (s *Store) UpdateInstanceContentPolicy(ctx context.Context, p *store.InstanceContentPolicy) error {
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE instance_content_policy SET
+			name = $1, pattern = $2, pattern_kind = $3, action = $4,
+			block_message = $5, enabled = $6, updated_at = NOW()
+		WHERE id = $7`,
+		p.Name, p.Pattern, p.PatternKind, p.Action, p.BlockMessage, boolToPGInt(p.Enabled), p.ID)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return store.ErrNotFound
+	}
+	return nil
+}
+
+func (s *Store) DeleteInstanceContentPolicy(ctx context.Context, id string) error {
+	tag, err := s.pool.Exec(ctx,
+		`DELETE FROM instance_content_policy WHERE id = $1`, id)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return store.ErrNotFound
+	}
+	return nil
+}
+
+func scanInstanceContentPolicy(sc interface{ Scan(...any) error }) (*store.InstanceContentPolicy, error) {
+	var p store.InstanceContentPolicy
+	var enabled int
+	if err := sc.Scan(&p.ID, &p.Name, &p.Pattern, &p.PatternKind, &p.Action, &p.BlockMessage, &enabled, &p.CreatedBy, &p.CreatedAt, &p.UpdatedAt); err != nil {
+		return nil, err
+	}
+	p.Enabled = enabled != 0
+	return &p, nil
+}
+
+// ── Task policy ──────────────────────────────────────────────────────────────
+
+func (s *Store) GetActiveInstanceTaskPolicy(ctx context.Context) (*store.InstanceTaskPolicy, error) {
+	row := s.pool.QueryRow(ctx, `
+		SELECT id, guidance, created_by, created_at
+		FROM instance_task_policy WHERE active = 1`)
+	var p store.InstanceTaskPolicy
+	if err := row.Scan(&p.ID, &p.Guidance, &p.CreatedBy, &p.CreatedAt); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, store.ErrNotFound
+		}
+		return nil, err
+	}
+	return &p, nil
+}
+
+func (s *Store) PutInstanceTaskPolicy(ctx context.Context, p *store.InstanceTaskPolicy) error {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+	if _, err := tx.Exec(ctx,
+		`UPDATE instance_task_policy SET active = 0 WHERE active = 1`); err != nil {
+		return err
+	}
+	if p.ID == "" {
+		p.ID = uuid.New().String()
+	}
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO instance_task_policy (id, guidance, active, created_by)
+		VALUES ($1, $2, 1, $3)`, p.ID, p.Guidance, p.CreatedBy); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+func (s *Store) ClearInstanceTaskPolicy(ctx context.Context) error {
+	_, err := s.pool.Exec(ctx,
+		`UPDATE instance_task_policy SET active = 0 WHERE active = 1`)
+	return err
+}
+
+// ── Violations ──────────────────────────────────────────────────────────────
+
+func (s *Store) RecordInstancePolicyViolation(ctx context.Context, v *store.InstancePolicyViolation) error {
+	if v.ID == "" {
+		v.ID = uuid.New().String()
+	}
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO instance_policy_violation
+			(id, user_id, agent_id, task_id, policy_kind, policy_id, action_taken, detail)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+		v.ID, pgNullIfEmpty(v.UserID), pgNullIfEmpty(v.AgentID), pgNullIfEmpty(v.TaskID),
+		v.PolicyKind, pgNullIfEmpty(v.PolicyID), v.ActionTaken, pgNullIfEmpty(v.Detail))
+	return err
+}
+
+func (s *Store) ListInstancePolicyViolations(ctx context.Context, limit int) ([]*store.InstancePolicyViolation, error) {
+	if limit <= 0 || limit > 1000 {
+		limit = 200
+	}
+	rows, err := s.pool.Query(ctx, `
+		SELECT id, user_id, agent_id, task_id, policy_kind, policy_id, action_taken, detail, created_at
+		FROM instance_policy_violation ORDER BY created_at DESC LIMIT $1`, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []*store.InstancePolicyViolation
+	for rows.Next() {
+		var v store.InstancePolicyViolation
+		var userID, agentID, taskID, policyID, detail *string
+		if err := rows.Scan(&v.ID, &userID, &agentID, &taskID, &v.PolicyKind, &policyID, &v.ActionTaken, &detail, &v.CreatedAt); err != nil {
+			return nil, err
+		}
+		v.UserID = deref(userID)
+		v.AgentID = deref(agentID)
+		v.TaskID = deref(taskID)
+		v.PolicyID = deref(policyID)
+		v.Detail = deref(detail)
+		out = append(out, &v)
+	}
+	return out, rows.Err()
+}
+
+func pgNullIfEmpty(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}
+
+func boolToPGInt(v bool) int {
+	if v {
+		return 1
+	}
+	return 0
+}
+
+func deref(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
+}

--- a/pkg/store/sqlite/migrations/064_instance_governance.sql
+++ b/pkg/store/sqlite/migrations/064_instance_governance.sql
@@ -1,0 +1,89 @@
+-- 06a: instance-scoped (local) governance tables.
+--
+-- The OSS build implements the four governance callbacks
+-- (CheckModelPolicy / CheckSpendCap / ScanContentPolicy / RecordViolation)
+-- locally against these tables — one flat, instance-wide policy set (no
+-- org/team dimension). The cloud build keeps its own org_* tables and
+-- these are dormant there.
+--
+-- Shapes mirror cloud's 010_governance_policies.sql exactly EXCEPT there
+-- is no org_id column anywhere: policies are instance-scoped, and the
+-- violation log drops org_id (the "local" OrgID sentinel the pipeline
+-- carries is never persisted). Model/task policies are append-only with
+-- an `active` flag so SOC2-style point-in-time history works via
+-- created_at (PUT inserts a new row and demotes the prior active row).
+
+-- Singleton allow/deny list of canonical model identifiers. Models are
+-- provider-qualified strings (e.g. "anthropic/claude-3-5-sonnet",
+-- "openai/gpt-4o") matched exact-string against the gateway's resolved
+-- canonical model. Bare names are rejected at PUT (see the handler).
+CREATE TABLE IF NOT EXISTS instance_model_policy (
+    id          TEXT PRIMARY KEY,
+    mode        TEXT NOT NULL CHECK (mode IN ('allow','deny')),
+    models      TEXT NOT NULL,          -- JSON array of canonical ids
+    active      INTEGER NOT NULL DEFAULT 1,
+    created_by  TEXT NOT NULL REFERENCES users(id),
+    created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_instance_model_policy_active
+    ON instance_model_policy(active) WHERE active = 1;
+
+-- Per-window spend cap. window_kind ∈ daily | monthly, enforcement ∈
+-- soft | hard. cap_micros is int64 micro-USD to match
+-- llm_request_cost.cost_micros. One cap per window.
+CREATE TABLE IF NOT EXISTS instance_spend_cap (
+    id           TEXT PRIMARY KEY,
+    window_kind  TEXT NOT NULL CHECK (window_kind IN ('daily','monthly')),
+    cap_micros   INTEGER NOT NULL CHECK (cap_micros > 0),
+    enforcement  TEXT NOT NULL DEFAULT 'soft' CHECK (enforcement IN ('soft','hard')),
+    created_by   TEXT NOT NULL REFERENCES users(id),
+    created_at   TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at   TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(window_kind)
+);
+
+-- Content-pattern policy. block rejects the request (with the admin-
+-- authored block_message); flag allows it but records a violation row.
+-- enabled supports temporary triage without deletion.
+CREATE TABLE IF NOT EXISTS instance_content_policy (
+    id            TEXT PRIMARY KEY,
+    name          TEXT NOT NULL,
+    pattern       TEXT NOT NULL,
+    pattern_kind  TEXT NOT NULL CHECK (pattern_kind IN ('regex','keyword')),
+    action        TEXT NOT NULL CHECK (action IN ('block','flag')),
+    block_message TEXT NOT NULL DEFAULT '',
+    enabled       INTEGER NOT NULL DEFAULT 1,
+    created_by    TEXT NOT NULL REFERENCES users(id),
+    created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at    TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Singleton natural-language task-creation guidance. Fed into the intent
+-- verifier's SYSTEM prompt (not the user message) org/instance-wide.
+CREATE TABLE IF NOT EXISTS instance_task_policy (
+    id          TEXT PRIMARY KEY,
+    guidance    TEXT NOT NULL,
+    active      INTEGER NOT NULL DEFAULT 1,
+    created_by  TEXT NOT NULL REFERENCES users(id),
+    created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_instance_task_policy_active
+    ON instance_task_policy(active) WHERE active = 1;
+
+-- Append-only log of blocked / flagged / warned requests. policy_id is a
+-- soft link (no FK across the four policy tables). No org_id column: the
+-- "local" sentinel is not persisted.
+CREATE TABLE IF NOT EXISTS instance_policy_violation (
+    id            TEXT PRIMARY KEY,
+    user_id       TEXT,
+    agent_id      TEXT,
+    task_id       TEXT,
+    policy_kind   TEXT NOT NULL CHECK (policy_kind IN
+                    ('model_policy','spend_cap','content_policy','task_policy')),
+    policy_id     TEXT,
+    action_taken  TEXT NOT NULL CHECK (action_taken IN ('blocked','flagged','warned')),
+    detail        TEXT,
+    created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_instance_violation_time
+    ON instance_policy_violation(created_at);

--- a/pkg/store/sqlite/migrations/064_instance_governance.sql
+++ b/pkg/store/sqlite/migrations/064_instance_governance.sql
@@ -87,3 +87,13 @@ CREATE TABLE IF NOT EXISTS instance_policy_violation (
 );
 CREATE INDEX IF NOT EXISTS idx_instance_violation_time
     ON instance_policy_violation(created_at);
+
+-- SumInstanceCostMicros (the spend-cap read path) aggregates
+-- SUM(cost_micros) over every llm_request_cost row in a time window,
+-- instance-wide (no user_id / agent_id filter). Every existing index on
+-- that table is (user_id,…) or (agent_id,…) leading, so this rollup falls
+-- back to a full table scan. Add a timestamp-leading index so the window
+-- filter seeks directly — same reasoning as migration 057's
+-- (agent_id, timestamp) covering index for the cloud dashboards.
+CREATE INDEX IF NOT EXISTS idx_llm_cost_time
+    ON llm_request_cost(timestamp);

--- a/pkg/store/sqlite/migrations/064_instance_governance.sql
+++ b/pkg/store/sqlite/migrations/064_instance_governance.sql
@@ -95,5 +95,5 @@ CREATE INDEX IF NOT EXISTS idx_instance_violation_time
 -- back to a full table scan. Add a timestamp-leading index so the window
 -- filter seeks directly — same reasoning as migration 057's
 -- (agent_id, timestamp) covering index for the cloud dashboards.
-CREATE INDEX IF NOT EXISTS idx_llm_cost_time
+CREATE INDEX IF NOT EXISTS idx_llm_cost_ts_raw
     ON llm_request_cost(timestamp);

--- a/pkg/store/sqlite/store_governance.go
+++ b/pkg/store/sqlite/store_governance.go
@@ -128,12 +128,22 @@ func (s *Store) DeleteInstanceSpendCap(ctx context.Context, windowKind string) e
 	return nil
 }
 
+// llmCostTimeBound formats a window bound the same fixed-width way the
+// timestamp column is compared against. RecordLLMRequestCost stores
+// timestamps as RFC3339Nano, so a row at "…00:00:00.5Z" would sort
+// lexically *before* an RFC3339 "…00:00:00Z" bound ('.' < 'Z') and be
+// dropped from the window. Formatting the bound with a full nanosecond
+// fraction makes it the lexically-smallest value in its second, so every
+// sub-second row at or after the (whole-second) window boundary compares
+// correctly.
+const llmCostTimeBound = "2006-01-02T15:04:05.000000000Z07:00"
+
 func (s *Store) SumInstanceCostMicros(ctx context.Context, since, until time.Time) (int64, error) {
 	var sum int64
 	err := s.db.QueryRowContext(ctx, `
 		SELECT COALESCE(SUM(cost_micros), 0) FROM llm_request_cost
 		WHERE timestamp >= ? AND timestamp < ?`,
-		since.UTC().Format(time.RFC3339), until.UTC().Format(time.RFC3339)).Scan(&sum)
+		since.UTC().Format(llmCostTimeBound), until.UTC().Format(llmCostTimeBound)).Scan(&sum)
 	return sum, err
 }
 

--- a/pkg/store/sqlite/store_governance.go
+++ b/pkg/store/sqlite/store_governance.go
@@ -1,0 +1,330 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+// Instance governance (spec 06a — local orggov). Instance-scoped, one flat
+// policy set. Model and task policies are append-only: Put demotes the
+// prior active row (in a tx) and inserts a new one, so created_at history
+// gives point-in-time answers for free.
+
+// ── Model policy ──────────────────────────────────────────────────────────────
+
+func (s *Store) GetActiveInstanceModelPolicy(ctx context.Context) (*store.InstanceModelPolicy, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, mode, models, created_by, created_at
+		FROM instance_model_policy WHERE active = 1`)
+	var p store.InstanceModelPolicy
+	var modelsJSON, createdAt string
+	if err := row.Scan(&p.ID, &p.Mode, &modelsJSON, &p.CreatedBy, &createdAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, store.ErrNotFound
+		}
+		return nil, err
+	}
+	if err := json.Unmarshal([]byte(modelsJSON), &p.Models); err != nil {
+		return nil, err
+	}
+	p.CreatedAt = parseTime(createdAt)
+	return &p, nil
+}
+
+func (s *Store) PutInstanceModelPolicy(ctx context.Context, p *store.InstanceModelPolicy) error {
+	modelsJSON, err := json.Marshal(p.Models)
+	if err != nil {
+		return err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE instance_model_policy SET active = 0 WHERE active = 1`); err != nil {
+		return err
+	}
+	if p.ID == "" {
+		p.ID = uuid.New().String()
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO instance_model_policy (id, mode, models, active, created_by)
+		VALUES (?, ?, ?, 1, ?)`, p.ID, p.Mode, string(modelsJSON), p.CreatedBy); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func (s *Store) ClearInstanceModelPolicy(ctx context.Context) error {
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE instance_model_policy SET active = 0 WHERE active = 1`)
+	return err
+}
+
+// ── Spend caps ──────────────────────────────────────────────────────────────
+
+func (s *Store) ListInstanceSpendCaps(ctx context.Context) ([]*store.InstanceSpendCap, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, window_kind, cap_micros, enforcement, created_by, created_at, updated_at
+		FROM instance_spend_cap ORDER BY window_kind`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []*store.InstanceSpendCap
+	for rows.Next() {
+		c, err := scanInstanceSpendCap(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) GetInstanceSpendCap(ctx context.Context, windowKind string) (*store.InstanceSpendCap, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, window_kind, cap_micros, enforcement, created_by, created_at, updated_at
+		FROM instance_spend_cap WHERE window_kind = ?`, windowKind)
+	c, err := scanInstanceSpendCap(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, store.ErrNotFound
+	}
+	return c, err
+}
+
+func (s *Store) PutInstanceSpendCap(ctx context.Context, c *store.InstanceSpendCap) error {
+	if c.ID == "" {
+		c.ID = uuid.New().String()
+	}
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO instance_spend_cap (id, window_kind, cap_micros, enforcement, created_by)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT(window_kind) DO UPDATE SET
+			cap_micros = excluded.cap_micros,
+			enforcement = excluded.enforcement,
+			updated_at = datetime('now')`,
+		c.ID, c.WindowKind, c.CapMicros, c.Enforcement, c.CreatedBy)
+	return err
+}
+
+func (s *Store) DeleteInstanceSpendCap(ctx context.Context, windowKind string) error {
+	res, err := s.db.ExecContext(ctx,
+		`DELETE FROM instance_spend_cap WHERE window_kind = ?`, windowKind)
+	if err != nil {
+		return err
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return store.ErrNotFound
+	}
+	return nil
+}
+
+func (s *Store) SumInstanceCostMicros(ctx context.Context, since, until time.Time) (int64, error) {
+	var sum int64
+	err := s.db.QueryRowContext(ctx, `
+		SELECT COALESCE(SUM(cost_micros), 0) FROM llm_request_cost
+		WHERE timestamp >= ? AND timestamp < ?`,
+		since.UTC().Format(time.RFC3339), until.UTC().Format(time.RFC3339)).Scan(&sum)
+	return sum, err
+}
+
+func scanInstanceSpendCap(sc interface{ Scan(...any) error }) (*store.InstanceSpendCap, error) {
+	var c store.InstanceSpendCap
+	var createdAt, updatedAt string
+	if err := sc.Scan(&c.ID, &c.WindowKind, &c.CapMicros, &c.Enforcement, &c.CreatedBy, &createdAt, &updatedAt); err != nil {
+		return nil, err
+	}
+	c.CreatedAt = parseTime(createdAt)
+	c.UpdatedAt = parseTime(updatedAt)
+	return &c, nil
+}
+
+// ── Content policies ──────────────────────────────────────────────────────────
+
+func (s *Store) ListInstanceContentPolicies(ctx context.Context) ([]*store.InstanceContentPolicy, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, name, pattern, pattern_kind, action, block_message, enabled, created_by, created_at, updated_at
+		FROM instance_content_policy ORDER BY created_at`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []*store.InstanceContentPolicy
+	for rows.Next() {
+		p, err := scanInstanceContentPolicy(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, p)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) GetInstanceContentPolicy(ctx context.Context, id string) (*store.InstanceContentPolicy, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, name, pattern, pattern_kind, action, block_message, enabled, created_by, created_at, updated_at
+		FROM instance_content_policy WHERE id = ?`, id)
+	p, err := scanInstanceContentPolicy(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, store.ErrNotFound
+	}
+	return p, err
+}
+
+func (s *Store) CreateInstanceContentPolicy(ctx context.Context, p *store.InstanceContentPolicy) error {
+	if p.ID == "" {
+		p.ID = uuid.New().String()
+	}
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO instance_content_policy (id, name, pattern, pattern_kind, action, block_message, enabled, created_by)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		p.ID, p.Name, p.Pattern, p.PatternKind, p.Action, p.BlockMessage, boolToInt(p.Enabled), p.CreatedBy)
+	return err
+}
+
+func (s *Store) UpdateInstanceContentPolicy(ctx context.Context, p *store.InstanceContentPolicy) error {
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE instance_content_policy SET
+			name = ?, pattern = ?, pattern_kind = ?, action = ?,
+			block_message = ?, enabled = ?, updated_at = datetime('now')
+		WHERE id = ?`,
+		p.Name, p.Pattern, p.PatternKind, p.Action, p.BlockMessage, boolToInt(p.Enabled), p.ID)
+	if err != nil {
+		return err
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return store.ErrNotFound
+	}
+	return nil
+}
+
+func (s *Store) DeleteInstanceContentPolicy(ctx context.Context, id string) error {
+	res, err := s.db.ExecContext(ctx,
+		`DELETE FROM instance_content_policy WHERE id = ?`, id)
+	if err != nil {
+		return err
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return store.ErrNotFound
+	}
+	return nil
+}
+
+func scanInstanceContentPolicy(sc interface{ Scan(...any) error }) (*store.InstanceContentPolicy, error) {
+	var p store.InstanceContentPolicy
+	var enabled int
+	var createdAt, updatedAt string
+	if err := sc.Scan(&p.ID, &p.Name, &p.Pattern, &p.PatternKind, &p.Action, &p.BlockMessage, &enabled, &p.CreatedBy, &createdAt, &updatedAt); err != nil {
+		return nil, err
+	}
+	p.Enabled = enabled != 0
+	p.CreatedAt = parseTime(createdAt)
+	p.UpdatedAt = parseTime(updatedAt)
+	return &p, nil
+}
+
+// ── Task policy ──────────────────────────────────────────────────────────────
+
+func (s *Store) GetActiveInstanceTaskPolicy(ctx context.Context) (*store.InstanceTaskPolicy, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, guidance, created_by, created_at
+		FROM instance_task_policy WHERE active = 1`)
+	var p store.InstanceTaskPolicy
+	var createdAt string
+	if err := row.Scan(&p.ID, &p.Guidance, &p.CreatedBy, &createdAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, store.ErrNotFound
+		}
+		return nil, err
+	}
+	p.CreatedAt = parseTime(createdAt)
+	return &p, nil
+}
+
+func (s *Store) PutInstanceTaskPolicy(ctx context.Context, p *store.InstanceTaskPolicy) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE instance_task_policy SET active = 0 WHERE active = 1`); err != nil {
+		return err
+	}
+	if p.ID == "" {
+		p.ID = uuid.New().String()
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO instance_task_policy (id, guidance, active, created_by)
+		VALUES (?, ?, 1, ?)`, p.ID, p.Guidance, p.CreatedBy); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func (s *Store) ClearInstanceTaskPolicy(ctx context.Context) error {
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE instance_task_policy SET active = 0 WHERE active = 1`)
+	return err
+}
+
+// ── Violations ──────────────────────────────────────────────────────────────
+
+func (s *Store) RecordInstancePolicyViolation(ctx context.Context, v *store.InstancePolicyViolation) error {
+	if v.ID == "" {
+		v.ID = uuid.New().String()
+	}
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO instance_policy_violation
+			(id, user_id, agent_id, task_id, policy_kind, policy_id, action_taken, detail)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		v.ID, nullIfEmpty(v.UserID), nullIfEmpty(v.AgentID), nullIfEmpty(v.TaskID),
+		v.PolicyKind, nullIfEmpty(v.PolicyID), v.ActionTaken, nullIfEmpty(v.Detail))
+	return err
+}
+
+func (s *Store) ListInstancePolicyViolations(ctx context.Context, limit int) ([]*store.InstancePolicyViolation, error) {
+	if limit <= 0 || limit > 1000 {
+		limit = 200
+	}
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, user_id, agent_id, task_id, policy_kind, policy_id, action_taken, detail, created_at
+		FROM instance_policy_violation ORDER BY created_at DESC LIMIT ?`, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []*store.InstancePolicyViolation
+	for rows.Next() {
+		var v store.InstancePolicyViolation
+		var userID, agentID, taskID, policyID, detail sql.NullString
+		var createdAt string
+		if err := rows.Scan(&v.ID, &userID, &agentID, &taskID, &v.PolicyKind, &policyID, &v.ActionTaken, &detail, &createdAt); err != nil {
+			return nil, err
+		}
+		v.UserID = userID.String
+		v.AgentID = agentID.String
+		v.TaskID = taskID.String
+		v.PolicyID = policyID.String
+		v.Detail = detail.String
+		v.CreatedAt = parseTime(createdAt)
+		out = append(out, &v)
+	}
+	return out, rows.Err()
+}
+
+func nullIfEmpty(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}

--- a/pkg/store/sqlite/store_governance_test.go
+++ b/pkg/store/sqlite/store_governance_test.go
@@ -168,6 +168,26 @@ func TestInstancePolicyViolation_RecordList(t *testing.T) {
 	}
 }
 
+// seedCostRow writes an audit_log parent (FK target for llm_request_cost)
+// and the cost row at ts with the given cost. Uses the seeded __system__
+// user so the audit_log.user_id FK is satisfied.
+func seedCostRow(t *testing.T, st *Store, ctx context.Context, id string, ts time.Time, costMicros int64) {
+	t.Helper()
+	if err := st.LogAudit(ctx, &store.AuditEntry{
+		ID: id, UserID: "__system__", RequestID: id, Timestamp: ts,
+		Service: "gateway", Action: "llm_request", Decision: "allow", Outcome: "success",
+	}); err != nil {
+		t.Fatalf("LogAudit(%s): %v", id, err)
+	}
+	c := costMicros
+	if err := st.RecordLLMRequestCost(ctx, &store.LLMRequestCost{
+		AuditID: id, UserID: "__system__", RequestID: id, Timestamp: ts,
+		Provider: "anthropic", Model: "claude-3-5-sonnet", CostMicros: &c,
+	}); err != nil {
+		t.Fatalf("RecordLLMRequestCost(%s): %v", id, err)
+	}
+}
+
 // TestSumInstanceCostMicros sums cost across the window regardless of agent.
 func TestSumInstanceCostMicros(t *testing.T) {
 	st, ctx := newGovStore(t)
@@ -179,5 +199,32 @@ func TestSumInstanceCostMicros(t *testing.T) {
 	}
 	if sum != 0 {
 		t.Fatalf("expected 0 sum on empty, got %d", sum)
+	}
+}
+
+// TestSumInstanceCostMicros_SubSecondBoundary proves a row landing in the
+// first sub-second of a whole-second window is attributed to that window.
+// Regression: timestamps are stored as RFC3339Nano, so a row at
+// "…00:00:00.5Z" sorted lexically before an RFC3339 "…00:00:00Z" lower
+// bound ('.' < 'Z') and was dropped — misattributed to the prior window.
+func TestSumInstanceCostMicros_SubSecondBoundary(t *testing.T) {
+	st, ctx := newGovStore(t)
+
+	// Whole-second window boundary, matching windowBounds' midnight-UTC bounds.
+	since := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	until := since.Add(24 * time.Hour)
+
+	seedCostRow(t, st, ctx, "boundary", since.Add(500*time.Millisecond), 1000) // first sub-second of window
+	seedCostRow(t, st, ctx, "exact", since, 250)                               // exactly at lower bound (inclusive)
+	seedCostRow(t, st, ctx, "inside", since.Add(time.Hour), 500)               // well inside
+	seedCostRow(t, st, ctx, "before", since.Add(-time.Millisecond), 9999)      // prior window, excluded
+	seedCostRow(t, st, ctx, "atupper", until, 8888)                            // exactly at upper bound (exclusive)
+
+	sum, err := st.SumInstanceCostMicros(ctx, since, until)
+	if err != nil {
+		t.Fatalf("SumInstanceCostMicros: %v", err)
+	}
+	if want := int64(1000 + 250 + 500); sum != want {
+		t.Fatalf("expected %d (boundary+exact+inside, sub-second row NOT dropped), got %d", want, sum)
 	}
 }

--- a/pkg/store/sqlite/store_governance_test.go
+++ b/pkg/store/sqlite/store_governance_test.go
@@ -1,0 +1,183 @@
+package sqlite
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/clawvisor/clawvisor/pkg/store"
+)
+
+func newGovStore(t *testing.T) (*Store, context.Context) {
+	t.Helper()
+	ctx := context.Background()
+	db, err := New(ctx, filepath.Join(t.TempDir(), "clawvisor.db"))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return NewStore(db), ctx
+}
+
+// TestInstanceModelPolicy_AppendOnly proves Put demotes the prior active
+// row (only one active at a time) and Clear leaves no active policy.
+func TestInstanceModelPolicy_AppendOnly(t *testing.T) {
+	st, ctx := newGovStore(t)
+
+	if _, err := st.GetActiveInstanceModelPolicy(ctx); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound on empty, got %v", err)
+	}
+	if err := st.PutInstanceModelPolicy(ctx, &store.InstanceModelPolicy{
+		Mode: "deny", Models: []string{"anthropic/claude-3-opus"}, CreatedBy: "_instance",
+	}); err != nil {
+		t.Fatalf("PutInstanceModelPolicy: %v", err)
+	}
+	if err := st.PutInstanceModelPolicy(ctx, &store.InstanceModelPolicy{
+		Mode: "allow", Models: []string{"openai/gpt-4o", "anthropic/claude-3-5-sonnet"}, CreatedBy: "_instance",
+	}); err != nil {
+		t.Fatalf("PutInstanceModelPolicy 2: %v", err)
+	}
+	got, err := st.GetActiveInstanceModelPolicy(ctx)
+	if err != nil {
+		t.Fatalf("GetActiveInstanceModelPolicy: %v", err)
+	}
+	if got.Mode != "allow" || len(got.Models) != 2 {
+		t.Fatalf("active policy mismatch: %+v", got)
+	}
+	if err := st.ClearInstanceModelPolicy(ctx); err != nil {
+		t.Fatalf("ClearInstanceModelPolicy: %v", err)
+	}
+	if _, err := st.GetActiveInstanceModelPolicy(ctx); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound after clear, got %v", err)
+	}
+}
+
+// TestInstanceSpendCap_Upsert proves the per-window unique upsert and the
+// cost sum window query.
+func TestInstanceSpendCap_Upsert(t *testing.T) {
+	st, ctx := newGovStore(t)
+
+	if err := st.PutInstanceSpendCap(ctx, &store.InstanceSpendCap{
+		WindowKind: "daily", CapMicros: 5_000_000, Enforcement: "soft", CreatedBy: "_instance",
+	}); err != nil {
+		t.Fatalf("PutInstanceSpendCap: %v", err)
+	}
+	// Upsert same window: cap + enforcement change, still one row.
+	if err := st.PutInstanceSpendCap(ctx, &store.InstanceSpendCap{
+		WindowKind: "daily", CapMicros: 9_000_000, Enforcement: "hard", CreatedBy: "_instance",
+	}); err != nil {
+		t.Fatalf("PutInstanceSpendCap upsert: %v", err)
+	}
+	caps, err := st.ListInstanceSpendCaps(ctx)
+	if err != nil {
+		t.Fatalf("ListInstanceSpendCaps: %v", err)
+	}
+	if len(caps) != 1 || caps[0].CapMicros != 9_000_000 || caps[0].Enforcement != "hard" {
+		t.Fatalf("upsert did not collapse to one row: %+v", caps)
+	}
+	got, err := st.GetInstanceSpendCap(ctx, "daily")
+	if err != nil || got.CapMicros != 9_000_000 {
+		t.Fatalf("GetInstanceSpendCap: %+v err=%v", got, err)
+	}
+	if err := st.DeleteInstanceSpendCap(ctx, "daily"); err != nil {
+		t.Fatalf("DeleteInstanceSpendCap: %v", err)
+	}
+	if _, err := st.GetInstanceSpendCap(ctx, "daily"); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound after delete, got %v", err)
+	}
+}
+
+// TestInstanceContentPolicy_CRUD exercises create → get → update → delete.
+func TestInstanceContentPolicy_CRUD(t *testing.T) {
+	st, ctx := newGovStore(t)
+
+	p := &store.InstanceContentPolicy{
+		Name: "block-ssn", Pattern: `\d{3}-\d{2}-\d{4}`, PatternKind: "regex",
+		Action: "block", BlockMessage: "no SSNs", Enabled: true, CreatedBy: "_instance",
+	}
+	if err := st.CreateInstanceContentPolicy(ctx, p); err != nil {
+		t.Fatalf("CreateInstanceContentPolicy: %v", err)
+	}
+	if p.ID == "" {
+		t.Fatal("Create did not assign an id")
+	}
+	got, err := st.GetInstanceContentPolicy(ctx, p.ID)
+	if err != nil || got.Name != "block-ssn" || !got.Enabled {
+		t.Fatalf("GetInstanceContentPolicy: %+v err=%v", got, err)
+	}
+	p.Enabled = false
+	p.Action = "flag"
+	if err := st.UpdateInstanceContentPolicy(ctx, p); err != nil {
+		t.Fatalf("UpdateInstanceContentPolicy: %v", err)
+	}
+	got, _ = st.GetInstanceContentPolicy(ctx, p.ID)
+	if got.Enabled || got.Action != "flag" {
+		t.Fatalf("update not persisted: %+v", got)
+	}
+	if err := st.DeleteInstanceContentPolicy(ctx, p.ID); err != nil {
+		t.Fatalf("DeleteInstanceContentPolicy: %v", err)
+	}
+	if _, err := st.GetInstanceContentPolicy(ctx, p.ID); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound after delete, got %v", err)
+	}
+}
+
+// TestInstanceTaskPolicy_AppendOnly mirrors the model-policy append-only
+// behavior for task guidance.
+func TestInstanceTaskPolicy_AppendOnly(t *testing.T) {
+	st, ctx := newGovStore(t)
+
+	if err := st.PutInstanceTaskPolicy(ctx, &store.InstanceTaskPolicy{Guidance: "first", CreatedBy: "_instance"}); err != nil {
+		t.Fatalf("PutInstanceTaskPolicy: %v", err)
+	}
+	if err := st.PutInstanceTaskPolicy(ctx, &store.InstanceTaskPolicy{Guidance: "second", CreatedBy: "_instance"}); err != nil {
+		t.Fatalf("PutInstanceTaskPolicy 2: %v", err)
+	}
+	got, err := st.GetActiveInstanceTaskPolicy(ctx)
+	if err != nil || got.Guidance != "second" {
+		t.Fatalf("active task policy mismatch: %+v err=%v", got, err)
+	}
+	if err := st.ClearInstanceTaskPolicy(ctx); err != nil {
+		t.Fatalf("ClearInstanceTaskPolicy: %v", err)
+	}
+	if _, err := st.GetActiveInstanceTaskPolicy(ctx); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound after clear, got %v", err)
+	}
+}
+
+// TestInstancePolicyViolation_RecordList proves violations record without
+// an org_id and list newest-first.
+func TestInstancePolicyViolation_RecordList(t *testing.T) {
+	st, ctx := newGovStore(t)
+
+	for _, kind := range []string{"model_policy", "content_policy"} {
+		if err := st.RecordInstancePolicyViolation(ctx, &store.InstancePolicyViolation{
+			UserID: "u1", AgentID: "a1", PolicyKind: kind, ActionTaken: "blocked", Detail: "d",
+		}); err != nil {
+			t.Fatalf("RecordInstancePolicyViolation(%s): %v", kind, err)
+		}
+	}
+	vs, err := st.ListInstancePolicyViolations(ctx, 10)
+	if err != nil {
+		t.Fatalf("ListInstancePolicyViolations: %v", err)
+	}
+	if len(vs) != 2 {
+		t.Fatalf("expected 2 violations, got %d", len(vs))
+	}
+}
+
+// TestSumInstanceCostMicros sums cost across the window regardless of agent.
+func TestSumInstanceCostMicros(t *testing.T) {
+	st, ctx := newGovStore(t)
+
+	// No cost rows → zero.
+	sum, err := st.SumInstanceCostMicros(ctx, time.Now().Add(-time.Hour), time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("SumInstanceCostMicros: %v", err)
+	}
+	if sum != 0 {
+		t.Fatalf("expected 0 sum on empty, got %d", sum)
+	}
+}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -75,6 +75,39 @@ type Store interface {
 	RevokeAPIToken(ctx context.Context, id string) error
 	TouchAPITokenLastUsed(ctx context.Context, id string) error
 
+	// Instance governance (spec 06a — local orggov). Instance-scoped, one
+	// flat policy set (no org/team dimension). The OSS build implements the
+	// four governance callbacks against these tables; cloud keeps its own
+	// org_* tables and leaves these dormant. Model/task policies are
+	// append-only (Put inserts a new active row and demotes the prior one)
+	// for point-in-time history; spend caps and content policies mutate in
+	// place. All methods here are a coordinated public-seam addition —
+	// cloud's CloudStore embeds store.Store, so these promote automatically.
+	GetActiveInstanceModelPolicy(ctx context.Context) (*InstanceModelPolicy, error)
+	PutInstanceModelPolicy(ctx context.Context, p *InstanceModelPolicy) error
+	ClearInstanceModelPolicy(ctx context.Context) error
+
+	ListInstanceSpendCaps(ctx context.Context) ([]*InstanceSpendCap, error)
+	GetInstanceSpendCap(ctx context.Context, windowKind string) (*InstanceSpendCap, error)
+	PutInstanceSpendCap(ctx context.Context, c *InstanceSpendCap) error
+	DeleteInstanceSpendCap(ctx context.Context, windowKind string) error
+	// SumInstanceCostMicros sums llm_request_cost.cost_micros for every
+	// agent/user over [since, until). Backs the local spend-cap check.
+	SumInstanceCostMicros(ctx context.Context, since, until time.Time) (int64, error)
+
+	ListInstanceContentPolicies(ctx context.Context) ([]*InstanceContentPolicy, error)
+	GetInstanceContentPolicy(ctx context.Context, id string) (*InstanceContentPolicy, error)
+	CreateInstanceContentPolicy(ctx context.Context, p *InstanceContentPolicy) error
+	UpdateInstanceContentPolicy(ctx context.Context, p *InstanceContentPolicy) error
+	DeleteInstanceContentPolicy(ctx context.Context, id string) error
+
+	GetActiveInstanceTaskPolicy(ctx context.Context) (*InstanceTaskPolicy, error)
+	PutInstanceTaskPolicy(ctx context.Context, p *InstanceTaskPolicy) error
+	ClearInstanceTaskPolicy(ctx context.Context) error
+
+	RecordInstancePolicyViolation(ctx context.Context, v *InstancePolicyViolation) error
+	ListInstancePolicyViolations(ctx context.Context, limit int) ([]*InstancePolicyViolation, error)
+
 	// Restrictions
 	CreateRestriction(ctx context.Context, r *Restriction) (*Restriction, error)
 	DeleteRestriction(ctx context.Context, id, userID string) error
@@ -569,6 +602,73 @@ type APIToken struct {
 	LastUsedAt  *time.Time `json:"last_used_at"`
 	RevokedAt   *time.Time `json:"revoked_at"`
 	IsBootstrap bool       `json:"-"`
+}
+
+// InstanceModelPolicy is the singleton allow/deny model policy for a
+// self-hosted instance (spec 06a). Mode is "allow" or "deny"; Models is
+// the list of provider-qualified canonical ids (e.g.
+// "anthropic/claude-3-5-sonnet"). Append-only: the active row is the
+// current policy, older rows are point-in-time history.
+type InstanceModelPolicy struct {
+	ID        string    `json:"-"`
+	Mode      string    `json:"mode"`
+	Models    []string  `json:"models"`
+	CreatedBy string    `json:"-"`
+	CreatedAt time.Time `json:"-"`
+}
+
+// InstanceSpendCap is a per-window spend cap. WindowKind is "daily" or
+// "monthly"; Enforcement is "soft" (warn) or "hard" (block at 100%).
+// CapMicros is int64 micro-USD matching llm_request_cost.cost_micros.
+type InstanceSpendCap struct {
+	ID          string    `json:"-"`
+	WindowKind  string    `json:"window"`
+	CapMicros   int64     `json:"cap_micros"`
+	Enforcement string    `json:"enforcement"`
+	CreatedBy   string    `json:"-"`
+	CreatedAt   time.Time `json:"-"`
+	UpdatedAt   time.Time `json:"-"`
+}
+
+// InstanceContentPolicy is one content-scanning rule. Action "block"
+// rejects the request with BlockMessage; "flag" allows it but records a
+// violation. PatternKind is "regex" or "keyword".
+type InstanceContentPolicy struct {
+	ID           string    `json:"id"`
+	Name         string    `json:"name"`
+	Pattern      string    `json:"pattern"`
+	PatternKind  string    `json:"pattern_kind"`
+	Action       string    `json:"action"`
+	BlockMessage string    `json:"block_message"`
+	Enabled      bool      `json:"enabled"`
+	CreatedBy    string    `json:"-"`
+	CreatedAt    time.Time `json:"-"`
+	UpdatedAt    time.Time `json:"-"`
+}
+
+// InstanceTaskPolicy is the singleton task-guidance policy. Append-only
+// like InstanceModelPolicy.
+type InstanceTaskPolicy struct {
+	ID        string    `json:"-"`
+	Guidance  string    `json:"guidance"`
+	CreatedBy string    `json:"-"`
+	CreatedAt time.Time `json:"-"`
+}
+
+// InstancePolicyViolation is an append-only record of a blocked, flagged,
+// or warned request. No org_id — the "local" OrgID sentinel the pipeline
+// carries is never persisted. PolicyKind ∈ model_policy | spend_cap |
+// content_policy | task_policy; ActionTaken ∈ blocked | flagged | warned.
+type InstancePolicyViolation struct {
+	ID          string    `json:"id"`
+	UserID      string    `json:"user_id,omitempty"`
+	AgentID     string    `json:"agent_id,omitempty"`
+	TaskID      string    `json:"task_id,omitempty"`
+	PolicyKind  string    `json:"policy_kind"`
+	PolicyID    string    `json:"policy_id,omitempty"`
+	ActionTaken string    `json:"action_taken"`
+	Detail      string    `json:"detail,omitempty"`
+	CreatedAt   time.Time `json:"created_at"`
 }
 
 // Risk-level constants for ConversationAutoApproveThreshold and the


### PR DESCRIPTION
Implements the four governance callbacks locally (`internal/govlocal`) against instance-scoped tables: model allow/deny, spend caps (soft warn at 80/100%, hard block), content policy (block/flag with safe pattern matching: 256-char pattern cap, 64KB scan truncation, compile-fail = no-match), violation logging. Per-hook precedence: cloud callback if present, else local, else allow. REST surface at `/api/governance/*` (admin-gated) matches the provider's client contract exactly — the provider's four governance resources un-skip and pass their full acceptance suite against this. `local_governance` capability advertised. Observe interaction proven: a deny verdict is enforced in govern, downgraded-and-recorded in observe.

Migrations: sqlite 064 / postgres 063.

**Stack 11/15** — base: `tc-stack-4` (after wave 4: #615, #616, #617). Retarget as the stack merges. Requires #615.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

