### PR TITLE
fix(terraform): admin_url output, reference_allowlist variable, install_commands target types

### DIFF
--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -8,6 +8,8 @@ on:
       - "provider/**"
       - ".github/workflows/terraform-ci.yml"
       - "scripts/mirror-terraform.sh"
+      - "scripts/terraform-plan-secret-scan.sh"
+      - "scripts/terraform-real-aws-lane.sh"
     tags: ["v*"]
   pull_request:
     branches: [main]
@@ -15,6 +17,9 @@ on:
       - "deploy/terraform/**"
       - "provider/**"
       - ".github/workflows/terraform-ci.yml"
+      - "scripts/mirror-terraform.sh"
+      - "scripts/terraform-plan-secret-scan.sh"
+      - "scripts/terraform-real-aws-lane.sh"
   workflow_dispatch:
     inputs:
       real_cloud:
@@ -68,7 +73,12 @@ jobs:
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: "~> 1.9"
-      - name: render + validate compose
+      - name: install caddy (for Caddyfile validation)
+        run: |
+          curl -fsSL https://github.com/caddyserver/caddy/releases/download/v2.8.4/caddy_2.8.4_linux_amd64.tar.gz \
+            | sudo tar -xz -C /usr/local/bin caddy
+          caddy version
+      - name: render + validate compose + Caddyfile
         run: |
           cd deploy/terraform/examples/local-docker
           ./run.sh
@@ -80,23 +90,36 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.real_cloud }}
     environment: terraform-aws
+    # The lane uses fixed resource names (NAME=clawvisor: shared SSM param, DB,
+    # snapshots). Serialize the lane globally so two manual dispatches can't
+    # clobber each other's SSM param / DB / snapshots. Never cancel a run
+    # mid-apply — that would orphan half-created billable resources.
+    concurrency:
+      group: terraform-real-aws-lane
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: "~> 1.9"
 
+      # The `secrets` context is not available in `if:` expressions (using it
+      # invalidates the whole workflow at parse time), so gate via a step
+      # output instead.
       - name: guard — require AWS credentials
+        id: guard
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         run: |
           if [ -z "$AWS_ACCESS_KEY_ID" ]; then
             echo "No AWS credentials configured; skipping real-cloud lane."
-            exit 0
+            echo "has_aws=0" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_aws=1" >> "$GITHUB_OUTPUT"
           fi
 
       - name: apply → upgrade → snapshot → destroy
-        if: ${{ secrets.AWS_ACCESS_KEY_ID != '' }}
+        if: ${{ steps.guard.outputs.has_aws == '1' }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/deploy/terraform/examples/aws-minimal/main.tf
+++ b/deploy/terraform/examples/aws-minimal/main.tf
@@ -53,10 +53,21 @@ module "clawvisor" {
   # Deny-by-default: set these to reach the deploy at all.
   agent_ingress_cidrs = var.office_cidrs
   admin_ingress_cidrs = var.office_cidrs
+
+  # Vault-reference allowlist (spec 10). Empty (the default) = fail-closed:
+  # clawvisor_vault_reference resources are rejected. Uncomment and list the
+  # permitted secret ARN/name prefixes to enable reference-mode credentials.
+  # reference_allowlist = [
+  #   "arn:aws:secretsmanager:us-east-1:123456789012:secret:clawvisor/",
+  # ]
 }
 
 output "server_url" {
   value = module.clawvisor.server_url
+}
+
+output "admin_url" {
+  value = module.clawvisor.admin_url
 }
 
 output "server_ip" {

--- a/deploy/terraform/modules/vm-docker/README.md
+++ b/deploy/terraform/modules/vm-docker/README.md
@@ -42,6 +42,7 @@ distribution. A publish-only registry mirror is deferred to v1.1 (PRD §6).
 | `db_instance_class` | string | `"db.t4g.micro"` | RDS instance class |
 | `db_allocated_storage` | number | `20` | RDS storage (GiB) |
 | `vault_backend` | string | `"local"` | v1 accepts only `"local"`; reference backends ship with spec 10 |
+| `reference_allowlist` | list(string) | `[]` | permitted vault-reference id prefixes → `vault.reference_allowlist` (env `VAULT_REFERENCE_ALLOWLIST`). **Empty = fail-closed** (reference creation disabled). Entries must be non-empty and whitespace-free (spec 10) |
 | `jwt_secret_ref` | string | `""` | AWS Secrets Manager ARN; empty ⇒ generated on-instance. Never a literal |
 | `vault_key_ref` | string | `""` | same semantics as `jwt_secret_ref` |
 | `otel_endpoint` | string | `""` | OTLP endpoint; empty disables export (spec 01) |
@@ -61,10 +62,11 @@ distribution. A publish-only registry mirror is deferred to v1.1 (PRD §6).
 
 | Name | Sensitive | Value |
 |---|---|---|
-| `server_url` | no | `https://<public_fqdn>` |
+| `server_url` | no | `https://<public_fqdn>` — **agent** endpoint (443); serves `/v1/*`, `/skill/install/*`, `/health`, `/ready` only |
+| `admin_url` | no | `https://<public_fqdn>:8443` — **provider/management** endpoint (dashboard + `/api/*`). Point the Terraform provider here, not `server_url` |
 | `bootstrap_admin_token` | **yes** | single-use `cvat_` instance-admin token (spec 05) |
-| `install_commands` | no | per-harness `curl … | sh` one-liners |
-| `provider_block` | no | ready-to-paste `provider "clawvisor"` block (attr is `api_token`) |
+| `install_commands` | no | per-harness install commands: `curl … \| sh` for `claude-code`/`codex`; the `.md` URL to open for `hermes`/`openclaw` (assisted install — no pipe-to-sh) |
+| `provider_block` | no | ready-to-paste `provider "clawvisor"` block; `endpoint` = `admin_url`, attr is `api_token` |
 | `instance_id` | no | EC2 instance id |
 | `server_ip` | no | public IP the DNS record must point at |
 | `db_endpoint` | **yes** | connection string (contains the DB password) |

--- a/deploy/terraform/modules/vm-docker/main.tf
+++ b/deploy/terraform/modules/vm-docker/main.tf
@@ -9,6 +9,12 @@ locals {
   # agent_ingress_cidrs. Caddy path-splits the two zones (see Caddyfile).
   admin_port = 8443
 
+  # The provider/management endpoint. The management API (/api/*) is served
+  # ONLY on the admin port (Caddyfile routes :443 to /v1/*, /skill/install/*,
+  # /health, /ready); server_url (:443) is the agent endpoint. Single source
+  # so the admin_url output and provider_block cannot drift.
+  admin_url = "https://${var.public_fqdn}:${local.admin_port}"
+
   db_name = "clawvisor"
   db_user = "clawvisor"
 
@@ -18,6 +24,12 @@ locals {
   app_env = merge(
     { AUTH_MODE = "password" },
     var.max_users > 0 ? { MAX_USERS = tostring(var.max_users) } : {},
+    # vault.reference_allowlist (spec 10 confused-deputy control), carried as
+    # the comma-separated VAULT_REFERENCE_ALLOWLIST env the server reads
+    # (pkg/config/config.go). An EMPTY list omits the env entirely so the
+    # server fails closed (reference creation disabled) — matching config.go,
+    # which only applies the override when the env value is non-empty.
+    length(var.reference_allowlist) > 0 ? { VAULT_REFERENCE_ALLOWLIST = join(",", var.reference_allowlist) } : {},
     var.extra_env,
   )
 

--- a/deploy/terraform/modules/vm-docker/outputs.tf
+++ b/deploy/terraform/modules/vm-docker/outputs.tf
@@ -1,6 +1,11 @@
 output "server_url" {
-  description = "Base URL of the Clawvisor server (agent endpoint on 443)."
+  description = "Base URL of the Clawvisor server (agent endpoint on 443). This is the AGENT endpoint (§8): Caddy serves only /v1/*, /skill/install/*, /health, /ready here. The management API (/api/*) is NOT served on 443 — wire the provider to admin_url, not this."
   value       = "https://${var.public_fqdn}"
+}
+
+output "admin_url" {
+  description = "Provider/management endpoint (admin surface on 8443). This is where /api/* and the dashboard live and what terraform-provider-clawvisor's `endpoint` must point at — server_url (:443) 404s /api/*. SG-gated to admin_ingress_cidrs."
+  value       = local.admin_url
 }
 
 output "bootstrap_admin_token" {
@@ -10,12 +15,12 @@ output "bootstrap_admin_token" {
 }
 
 output "install_commands" {
-  description = "Per-harness agent install one-liners (served by internal/api/handlers/installer.go at the agent endpoint)."
+  description = "Per-harness agent install commands (served at the agent endpoint on 443). Per-target FORM mirrors the target table in internal/api/handlers/installer.go (`installerTargets`), the source of truth for which extension each target serves: claude-code/codex are self-install shell one-liners (.sh, pipe to sh); hermes/openclaw are assisted-install markdown skills (.md) — GET /skill/install/hermes.sh 404s, so these are the .md URL to open, NOT a pipe-to-sh. Keep this map in sync with installerTargets if a target's canonicalExt changes."
   value = {
     claude-code = "curl -fsSL https://${var.public_fqdn}/skill/install/claude-code.sh | sh"
     codex       = "curl -fsSL https://${var.public_fqdn}/skill/install/codex.sh | sh"
-    hermes      = "curl -fsSL https://${var.public_fqdn}/skill/install/hermes.sh | sh"
-    openclaw    = "curl -fsSL https://${var.public_fqdn}/skill/install/openclaw.sh | sh"
+    hermes      = "assisted install — open this URL: https://${var.public_fqdn}/skill/install/hermes.md"
+    openclaw    = "assisted install — open this URL: https://${var.public_fqdn}/skill/install/openclaw.md"
   }
 }
 
@@ -23,7 +28,7 @@ output "provider_block" {
   description = "Ready-to-paste Terraform provider block for terraform-provider-clawvisor (spec 06b). The credential attribute is `api_token` (never `token`). Wire it to the sensitive bootstrap_admin_token output rather than pasting the literal."
   value       = <<-EOT
     provider "clawvisor" {
-      endpoint  = "https://${var.public_fqdn}:${local.admin_port}"
+      endpoint  = "${local.admin_url}" # management endpoint (8443); == admin_url output
       api_token = var.clawvisor_api_token # e.g. terraform output -raw bootstrap_admin_token
     }
   EOT

--- a/deploy/terraform/modules/vm-docker/tests/render.tftest.hcl
+++ b/deploy/terraform/modules/vm-docker/tests/render.tftest.hcl
@@ -41,6 +41,82 @@ run "compose_uses_postgres_driver" {
   }
 }
 
+run "admin_url_is_management_endpoint_on_8443" {
+  command = apply
+
+  assert {
+    condition     = output.admin_url == "https://clawvisor.example.com:8443"
+    error_message = "admin_url must be the management endpoint on the admin port (8443)"
+  }
+
+  assert {
+    condition     = output.server_url == "https://clawvisor.example.com"
+    error_message = "server_url must remain the agent endpoint on 443 (unchanged semantics)"
+  }
+
+  assert {
+    condition     = can(regex("endpoint  = \"https://clawvisor.example.com:8443\"", output.provider_block))
+    error_message = "provider_block endpoint must equal admin_url (8443) — no drift from the management endpoint"
+  }
+}
+
+run "install_commands_match_installer_target_table" {
+  command = apply
+
+  # Source of truth: internal/api/handlers/installer.go installerTargets.
+  # claude-code/codex are shell-canonical (.sh, pipe to sh).
+  assert {
+    condition     = output.install_commands["claude-code"] == "curl -fsSL https://clawvisor.example.com/skill/install/claude-code.sh | sh"
+    error_message = "claude-code must be the .sh pipe-to-sh one-liner"
+  }
+
+  assert {
+    condition     = output.install_commands["codex"] == "curl -fsSL https://clawvisor.example.com/skill/install/codex.sh | sh"
+    error_message = "codex must be the .sh pipe-to-sh one-liner"
+  }
+
+  # hermes/openclaw are markdown-canonical (.md); .sh 404s, so no pipe-to-sh.
+  assert {
+    condition     = output.install_commands["hermes"] == "assisted install — open this URL: https://clawvisor.example.com/skill/install/hermes.md"
+    error_message = "hermes must be the assisted-install .md URL, not a pipe-to-sh (hermes.sh 404s)"
+  }
+
+  assert {
+    condition     = output.install_commands["openclaw"] == "assisted install — open this URL: https://clawvisor.example.com/skill/install/openclaw.md"
+    error_message = "openclaw must be the assisted-install .md URL, not a pipe-to-sh (openclaw.sh 404s)"
+  }
+
+  assert {
+    condition     = !can(regex("hermes.sh|openclaw.sh", join(" ", values(output.install_commands))))
+    error_message = "no install command may reference the non-existent hermes.sh/openclaw.sh shell installers"
+  }
+}
+
+run "reference_allowlist_empty_by_default_fails_closed" {
+  command = apply
+
+  assert {
+    condition     = !can(regex("VAULT_REFERENCE_ALLOWLIST", local.compose_rendered))
+    error_message = "an empty reference_allowlist must omit VAULT_REFERENCE_ALLOWLIST so the server fails closed"
+  }
+}
+
+run "reference_allowlist_populated_renders_csv" {
+  command = apply
+
+  variables {
+    reference_allowlist = [
+      "arn:aws:secretsmanager:us-east-1:123456789012:secret:clawvisor/",
+      "arn:aws:secretsmanager:us-east-1:123456789012:secret:shared/",
+    ]
+  }
+
+  assert {
+    condition     = can(regex("VAULT_REFERENCE_ALLOWLIST: \"arn:aws:secretsmanager:us-east-1:123456789012:secret:clawvisor/,arn:aws:secretsmanager:us-east-1:123456789012:secret:shared/\"", local.compose_rendered))
+    error_message = "a populated reference_allowlist must render as the comma-joined VAULT_REFERENCE_ALLOWLIST env"
+  }
+}
+
 run "config_carries_posture_and_proxy_lite" {
   command = apply
 

--- a/deploy/terraform/modules/vm-docker/tests/validate.tftest.hcl
+++ b/deploy/terraform/modules/vm-docker/tests/validate.tftest.hcl
@@ -111,6 +111,37 @@ run "accepts_contain_with_experimental_flag" {
   }
 }
 
+run "rejects_reference_allowlist_empty_string_entry" {
+  command = plan
+
+  variables {
+    image               = "ghcr.io/clawvisor/clawvisor:v1.4.2"
+    reference_allowlist = ["arn:aws:secretsmanager:us-east-1:123456789012:secret:ok/", ""]
+  }
+
+  expect_failures = [var.reference_allowlist]
+}
+
+run "rejects_reference_allowlist_whitespace_entry" {
+  command = plan
+
+  variables {
+    image               = "ghcr.io/clawvisor/clawvisor:v1.4.2"
+    reference_allowlist = ["arn:aws:secretsmanager:us-east-1:123456789012:secret:has space"]
+  }
+
+  expect_failures = [var.reference_allowlist]
+}
+
+run "accepts_reference_allowlist_clean_entries" {
+  command = plan
+
+  variables {
+    image               = "ghcr.io/clawvisor/clawvisor:v1.4.2"
+    reference_allowlist = ["arn:aws:secretsmanager:us-east-1:123456789012:secret:clawvisor/"]
+  }
+}
+
 run "rejects_public_agent_cidr_without_ack" {
   command = plan
 

--- a/deploy/terraform/modules/vm-docker/tests/validate.tftest.hcl
+++ b/deploy/terraform/modules/vm-docker/tests/validate.tftest.hcl
@@ -133,6 +133,17 @@ run "rejects_reference_allowlist_whitespace_entry" {
   expect_failures = [var.reference_allowlist]
 }
 
+run "rejects_reference_allowlist_comma_entry" {
+  command = plan
+
+  variables {
+    image               = "ghcr.io/clawvisor/clawvisor:v1.4.2"
+    reference_allowlist = ["arn:aws:secretsmanager:us-east-1:123456789012:secret:ok/,"]
+  }
+
+  expect_failures = [var.reference_allowlist]
+}
+
 run "accepts_reference_allowlist_clean_entries" {
   command = plan
 

--- a/deploy/terraform/modules/vm-docker/variables.tf
+++ b/deploy/terraform/modules/vm-docker/variables.tf
@@ -99,13 +99,13 @@ variable "reference_allowlist" {
   description = "Operator allowlist of permitted vault-reference id prefixes (ARN / resource-name / path), wired to server config vault.reference_allowlist via the VAULT_REFERENCE_ALLOWLIST env (spec 10 confused-deputy control). A reference whose id does not begin with a listed prefix is rejected at create time. EMPTY (the default) disables reference creation entirely — fail-closed; the env is omitted so the server keeps an empty allowlist."
 
   # Entries are joined with commas into VAULT_REFERENCE_ALLOWLIST, so an empty
-  # string or embedded whitespace would silently create a bogus (or
-  # everything-matching) prefix. Reject both loudly at plan time.
+  # string, embedded whitespace, or an embedded comma would silently create a
+  # bogus (or everything-matching) prefix. Reject all loudly at plan time.
   validation {
     condition = alltrue([
-      for e in var.reference_allowlist : length(e) > 0 && !can(regex("\\s", e))
+      for e in var.reference_allowlist : length(e) > 0 && !can(regex("[,\\s]", e))
     ])
-    error_message = "reference_allowlist entries must be non-empty and contain no whitespace (they are comma-joined into VAULT_REFERENCE_ALLOWLIST as reference-id prefixes)."
+    error_message = "reference_allowlist entries must be non-empty and contain no commas or whitespace (they are comma-joined into VAULT_REFERENCE_ALLOWLIST as reference-id prefixes)."
   }
 }
 

--- a/deploy/terraform/modules/vm-docker/variables.tf
+++ b/deploy/terraform/modules/vm-docker/variables.tf
@@ -93,6 +93,22 @@ variable "vault_backend" {
   }
 }
 
+variable "reference_allowlist" {
+  type        = list(string)
+  default     = []
+  description = "Operator allowlist of permitted vault-reference id prefixes (ARN / resource-name / path), wired to server config vault.reference_allowlist via the VAULT_REFERENCE_ALLOWLIST env (spec 10 confused-deputy control). A reference whose id does not begin with a listed prefix is rejected at create time. EMPTY (the default) disables reference creation entirely — fail-closed; the env is omitted so the server keeps an empty allowlist."
+
+  # Entries are joined with commas into VAULT_REFERENCE_ALLOWLIST, so an empty
+  # string or embedded whitespace would silently create a bogus (or
+  # everything-matching) prefix. Reject both loudly at plan time.
+  validation {
+    condition = alltrue([
+      for e in var.reference_allowlist : length(e) > 0 && !can(regex("\\s", e))
+    ])
+    error_message = "reference_allowlist entries must be non-empty and contain no whitespace (they are comma-joined into VAULT_REFERENCE_ALLOWLIST as reference-id prefixes)."
+  }
+}
+
 variable "jwt_secret_ref" {
   type        = string
   default     = ""


### PR DESCRIPTION
Conformance round vs the agent-facing docs, module side: (1) `admin_url` output (`https://<fqdn>:8443`) — the management-API endpoint the provider must use (`server_url` is the agent endpoint and 404s on `/api/*`); (2) `reference_allowlist` variable wired to `VAULT_REFERENCE_ALLOWLIST` (empty default = references fail-closed; whitespace/empty entries rejected at plan); (3) `install_commands` emits pipe-to-sh only for shell targets (claude-code/codex) and annotated markdown URLs for assisted targets (hermes/openclaw), mirroring the server's target table.

Tests: 25/25 `terraform test`.

**Stack 15/15** — base: `tc-stack-5`. Retarget as the stack merges. Merging all 15 in order reproduces `terraform-centric-v1` (pushed as the tested composition reference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/622?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

