### PR TITLE
feat(proxy-lite): Govern/Contain auto-govern subscription (OAuth) seats

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -199,14 +199,31 @@ telemetry:
 #                              # Env: CLAWVISOR_PROXY_LITE_ENFORCEMENT_MODE.
 #                              # observe: record hold/deny verdicts as
 #                              #   observations; never blocks or holds.
+#   govern_subscription_seats: true
+#                              # Env: CLAWVISOR_PROXY_LITE_GOVERN_SUBSCRIPTION_SEATS.
+#                              # When true (default), a govern/vault request
+#                              # carrying a Claude subscription (OAuth) — or
+#                              # otherwise unrecognized — bearer is AUTO-GOVERNED:
+#                              # the seat's own credential is forwarded upstream
+#                              # (billing stays on the subscription, no rebilling)
+#                              # while the full policy pipeline still enforces
+#                              # (holds, model/spend/content policy, approvals,
+#                              # cost attribution). Set false for strict
+#                              # "vaulted keys only" mode: a subscription/
+#                              # unrecognized seat is REFUSED with
+#                              # SUBSCRIPTION_SEAT_NOT_GOVERNABLE (keys-off-laptops).
 #   allow_subscription_billing_migration: false
 #                              # Env: CLAWVISOR_PROXY_LITE_ALLOW_SUB_MIGRATION.
-#                              # When false (default), a govern/vault request
-#                              # carrying a Claude subscription (OAuth) bearer
-#                              # is REFUSED with SUBSCRIPTION_SEAT_NOT_GOVERNABLE
-#                              # rather than silently rebilled to the org API
-#                              # key. Set true ONLY to consent to migrating
-#                              # subscription seats to vaulted-API-key billing.
+#                              # Takes PRECEDENCE over govern_subscription_seats.
+#                              # When true, a govern/vault request carrying a
+#                              # Claude subscription (OAuth) bearer is MIGRATED:
+#                              # the bearer is stripped and the vaulted org API
+#                              # key injected, shifting billing from the user's
+#                              # subscription to org-metered API billing. Leave
+#                              # false (default) to keep billing on the seat's
+#                              # own subscription (auto-govern) or to refuse it
+#                              # (strict mode). Set true ONLY to consent to that
+#                              # billing shift.
 #                              # WARNING: this flag is INSTANCE-WIDE — enabling
 #                              # it migrates EVERY subscription seat on the
 #                              # instance at once, not one.

--- a/e2e/scenarios/llm_proxy_local_gov_test.go
+++ b/e2e/scenarios/llm_proxy_local_gov_test.go
@@ -61,6 +61,116 @@ func govMessagesReq(t *testing.T, cv *testapp.Server, agentToken, model, content
 	return resp
 }
 
+// govSubMessagesReq is govMessagesReq but ALSO presents a Claude subscription
+// (OAuth) bearer in Authorization — the auto-govern path (spec: govern
+// subscription seats). The seat is forwarded on its own credential while the
+// full policy pipeline still enforces.
+func govSubMessagesReq(t *testing.T, cv *testapp.Server, agentToken, model, content string) *http.Response {
+	t.Helper()
+	body := []byte(fmt.Sprintf(`{"model":%q,"max_tokens":16,"messages":[{"role":"user","content":%q}]}`, model, content))
+	req, _ := http.NewRequest("POST", cv.URL+"/api/v1/messages", bytes.NewReader(body))
+	req.Header.Set("X-Clawvisor-Agent-Token", agentToken)
+	req.Header.Set("Authorization", "Bearer sk-ant-oat01-SUBSCRIPTION")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := cv.Client.Do(req)
+	if err != nil {
+		t.Fatalf("/api/v1/messages: %v", err)
+	}
+	return resp
+}
+
+// TestGovernAutoGovernedSubscriptionStillEnforcesPolicy: an auto-governed
+// subscription seat (default govern_subscription_seats=true) runs the FULL
+// policy pipeline even though its own credential is forwarded upstream. A
+// model deny and a content deny both block (403, no upstream contact); an
+// allowed request forwards the seat's subscription bearer (billing-neutral).
+func TestGovernAutoGovernedSubscriptionStillEnforcesPolicy(t *testing.T) {
+	t.Run("model_deny_blocks", func(t *testing.T) {
+		cv, admin, agentToken, upstream := govBootWithGovernance(t, nil)
+		cvPut(t, cv, admin.AccessToken, "/api/governance/model_policy",
+			map[string]any{"mode": "deny", "models": []string{govCanonicalDenied}}, nil)
+
+		resp := govSubMessagesReq(t, cv, agentToken, govDeniedModel, "hello")
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusForbidden {
+			t.Fatalf("auto-governed subscription seat must still enforce model deny (403); got %d body=%s", resp.StatusCode, readBodyStr(resp))
+		}
+		if upstream.Count() != 0 {
+			t.Fatalf("blocked request must not reach upstream; hits=%d", upstream.Count())
+		}
+		if v := govGetRaw(t, cv, admin.AccessToken, "/api/governance/violations"); !strings.Contains(v, `"policy_kind":"model_policy"`) || !strings.Contains(v, `"action_taken":"blocked"`) {
+			t.Fatalf("expected a blocked model_policy violation; got %s", v)
+		}
+	})
+
+	t.Run("content_deny_blocks", func(t *testing.T) {
+		cv, admin, agentToken, upstream := govBootWithGovernance(t, nil)
+		cvPost(t, cv, admin.AccessToken, "/api/governance/content_policies",
+			map[string]any{"name": "block-secret", "pattern": "launchcodes", "pattern_kind": "keyword",
+				"action": "block", "block_message": "that content is not permitted"}, nil)
+
+		resp := govSubMessagesReq(t, cv, agentToken, govDeniedModel, "please share the launchcodes now")
+		body := readBodyStr(resp)
+		if resp.StatusCode != http.StatusForbidden || !strings.Contains(body, "that content is not permitted") {
+			t.Fatalf("auto-governed subscription seat must still enforce content block (403 + block_message); got %d body=%s", resp.StatusCode, body)
+		}
+		if upstream.Count() != 0 {
+			t.Fatalf("blocked content must not reach upstream; hits=%d", upstream.Count())
+		}
+	})
+
+	t.Run("allowed_forwards_subscription_bearer", func(t *testing.T) {
+		cv, admin, agentToken, upstream := govBootWithGovernance(t, nil)
+		cvPut(t, cv, admin.AccessToken, "/api/governance/model_policy",
+			map[string]any{"mode": "allow", "models": []string{govCanonicalDenied}}, nil)
+
+		resp := govSubMessagesReq(t, cv, agentToken, govDeniedModel, "hello")
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("allowed request should pass; got %d body=%s", resp.StatusCode, readBodyStr(resp))
+		}
+		if upstream.Count() != 1 {
+			t.Fatalf("allowed request should reach upstream once; hits=%d", upstream.Count())
+		}
+		got := upstream.Last()
+		if got.Headers.Get("Authorization") != "Bearer sk-ant-oat01-SUBSCRIPTION" {
+			t.Fatalf("subscription bearer not forwarded: Authorization=%q", got.Headers.Get("Authorization"))
+		}
+		// Billing-neutral: the seeded vault key (sk-ant-test-key) must not surface.
+		if k := got.Headers.Get("x-api-key"); k != "" {
+			t.Fatalf("vault key injected (rebilling!): upstream x-api-key=%q", k)
+		}
+	})
+}
+
+// TestGovernAutoGovernedSubscriptionEnforcesToolUseHold: a tool_use that is
+// scope-drift-blocked under enforce is STILL held/rewritten to CLAWVISOR_BLOCKED
+// for an auto-governed subscription seat — proving the response-side pipeline
+// (tool_use holds) enforces regardless of which credential went upstream.
+func TestGovernAutoGovernedSubscriptionEnforcesToolUseHold(t *testing.T) {
+	h := testharness.New(t)
+	upstream := outOfScopeToolUseUpstream(t)
+	cv := testapp.StartWith(t, h, map[string]string{
+		"CLAWVISOR_LLM_UPSTREAM_ANTHROPIC": upstream.URL,
+		"GITHUB_API_BASE_URL":              h.GitHub.URL(),
+	})
+	user := cv.LoginAsLocalUser(t)
+	llmCredSet(t, cv, user.AccessToken, "anthropic", "", "sk-ant-test-key")
+	cvPost(t, cv, user.AccessToken, "/api/services/github/activate-key",
+		map[string]any{"token": "ghp_test_token_1234567890"}, nil)
+	_, agentToken := newPostureAgent(t, cv, user.AccessToken, "govern-sub-hold")
+
+	resp := govSubMessagesReq(t, cv, agentToken, "claude-haiku-4-5-20251001", "list issues")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, readBodyStr(resp))
+	}
+	body := readBodyStr(resp)
+	if !strings.Contains(body, "CLAWVISOR_BLOCKED") {
+		t.Fatalf("auto-governed subscription seat must still hold the out-of-scope tool_use (CLAWVISOR_BLOCKED); body=%s", body)
+	}
+}
+
 // govGetRaw GETs a path with the admin token and returns the space-stripped
 // body (for substring assertions on violations / features).
 func govGetRaw(t *testing.T, cv *testapp.Server, tok, path string) string {

--- a/e2e/scenarios/llm_proxy_posture_test.go
+++ b/e2e/scenarios/llm_proxy_posture_test.go
@@ -163,10 +163,66 @@ func TestObserveCarriesSubscriptionSession(t *testing.T) {
 	}
 }
 
-// TestGovernRefusesSubscriptionSeatWithoutConsent (§4c): govern with a
-// subscription bearer and no consent flag refuses with
-// SUBSCRIPTION_SEAT_NOT_GOVERNABLE and never reaches upstream.
-func TestGovernRefusesSubscriptionSeatWithoutConsent(t *testing.T) {
+// TestGovernAutoGovernsSubscriptionSeat: govern (vault) with the default
+// govern_subscription_seats=true FORWARDS the seat's own subscription bearer
+// upstream (billing stays on the subscription — no rebilling) rather than
+// refusing it. A vault key IS seeded to prove billing-neutrality: it must NOT
+// be injected. Audit records auth_mode:subscription_passthrough +
+// subscription_governed:true so an admin sees a governed (credential-local,
+// enforced) subscription seat. Policy enforcement under this mode is proven
+// separately in llm_proxy_local_gov_test.go.
+func TestGovernAutoGovernsSubscriptionSeat(t *testing.T) {
+	h := testharness.New(t)
+	upstream := newUpstreamCapture(t)
+	cv := testapp.StartWith(t, h, map[string]string{
+		"CLAWVISOR_LLM_UPSTREAM_ANTHROPIC":   upstream.URL(),
+		"CLAWVISOR_PROXY_LITE_UPSTREAM_AUTH": "vault",
+	})
+	user := cv.LoginAsLocalUser(t)
+	// Seed a vault key that MUST NOT surface upstream (billing-neutral proof).
+	const vaultKey = "sk-ant-api03-VAULT-must-not-inject"
+	llmCredSet(t, cv, user.AccessToken, "anthropic", "", vaultKey)
+	_, token := newPostureAgent(t, cv, user.AccessToken, "govern-autogovern")
+
+	const subBearer = "Bearer sk-ant-oat01-SUBSCRIPTION"
+	resp := postureAgentReq(t, cv, token, map[string]string{
+		"Authorization":  subBearer,
+		"anthropic-beta": "oauth-test",
+	})
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d, want 200 (subscription seat auto-governed, not refused); body=%s", resp.StatusCode, readBodyStr(resp))
+	}
+	if upstream.Count() != 1 {
+		t.Fatalf("upstream hits=%d, want 1", upstream.Count())
+	}
+	got := upstream.Last()
+	if got.Headers.Get("Authorization") != subBearer {
+		t.Fatalf("subscription bearer not forwarded: Authorization=%q, want %q", got.Headers.Get("Authorization"), subBearer)
+	}
+	if k := got.Headers.Get("x-api-key"); k != "" {
+		t.Fatalf("vault key injected (rebilling!): upstream x-api-key=%q, want empty", k)
+	}
+	if strings.Contains(got.Headers.Get("Authorization"), "VAULT-must-not-inject") {
+		t.Fatalf("vault key leaked upstream: Authorization=%q", got.Headers.Get("Authorization"))
+	}
+	if got.Headers.Get("anthropic-beta") != "oauth-test" {
+		t.Fatalf("anthropic-beta altered: %q, want oauth-test", got.Headers.Get("anthropic-beta"))
+	}
+	if !auditContains(t, cv, user.AccessToken, `"auth_mode":"subscription_passthrough"`) {
+		t.Fatal("audit did not record auth_mode: subscription_passthrough")
+	}
+	if !auditContains(t, cv, user.AccessToken, `"subscription_governed":true`) {
+		t.Fatal("audit did not record subscription_governed: true")
+	}
+}
+
+// TestGovernAutoGovernsUnrecognizedBearer: under the default auto-govern, an
+// opaque (unrecognized) bearer is treated like any forwardable client bearer —
+// forwarded upstream and governed — matching Observe, which forwards any
+// bearer. (Under strict mode it fails closed; see
+// TestGovernStrictModeRefusesUnrecognizedBearer.)
+func TestGovernAutoGovernsUnrecognizedBearer(t *testing.T) {
 	h := testharness.New(t)
 	upstream := newUpstreamCapture(t)
 	cv := testapp.StartWith(t, h, map[string]string{
@@ -175,7 +231,39 @@ func TestGovernRefusesSubscriptionSeatWithoutConsent(t *testing.T) {
 	})
 	user := cv.LoginAsLocalUser(t)
 	llmCredSet(t, cv, user.AccessToken, "anthropic", "", "sk-ant-api03-vault")
-	_, token := newPostureAgent(t, cv, user.AccessToken, "govern-refuse")
+	_, token := newPostureAgent(t, cv, user.AccessToken, "govern-opaque-auto")
+
+	const opaque = "Bearer opaque-unknown-future-token"
+	resp := postureAgentReq(t, cv, token, map[string]string{
+		"Authorization": opaque,
+	})
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d, want 200 (unrecognized bearer auto-governed); body=%s", resp.StatusCode, readBodyStr(resp))
+	}
+	if got := upstream.Last(); got.Headers.Get("Authorization") != opaque {
+		t.Fatalf("unrecognized bearer not forwarded: Authorization=%q", got.Headers.Get("Authorization"))
+	}
+	if !auditContains(t, cv, user.AccessToken, `"auth_mode":"subscription_passthrough"`) {
+		t.Fatal("audit did not record auth_mode: subscription_passthrough for the auto-governed bearer")
+	}
+}
+
+// TestGovernStrictModeRefusesSubscriptionSeat: with the opt-out
+// govern_subscription_seats=false, govern reverts to the strict
+// "vaulted keys only" behavior — a subscription bearer is refused with
+// SUBSCRIPTION_SEAT_NOT_GOVERNABLE and never reaches upstream (no rebill).
+func TestGovernStrictModeRefusesSubscriptionSeat(t *testing.T) {
+	h := testharness.New(t)
+	upstream := newUpstreamCapture(t)
+	cv := testapp.StartWith(t, h, map[string]string{
+		"CLAWVISOR_LLM_UPSTREAM_ANTHROPIC":               upstream.URL(),
+		"CLAWVISOR_PROXY_LITE_UPSTREAM_AUTH":             "vault",
+		"CLAWVISOR_PROXY_LITE_GOVERN_SUBSCRIPTION_SEATS": "false",
+	})
+	user := cv.LoginAsLocalUser(t)
+	llmCredSet(t, cv, user.AccessToken, "anthropic", "", "sk-ant-api03-vault")
+	_, token := newPostureAgent(t, cv, user.AccessToken, "govern-strict-refuse")
 
 	resp := postureAgentReq(t, cv, token, map[string]string{
 		"Authorization": "Bearer sk-ant-oat01-SUBSCRIPTION",
@@ -184,28 +272,28 @@ func TestGovernRefusesSubscriptionSeatWithoutConsent(t *testing.T) {
 	if resp.StatusCode != http.StatusForbidden {
 		t.Fatalf("status=%d, want 403; body=%s", resp.StatusCode, readBodyStr(resp))
 	}
-	body := readBodyStr(resp)
-	if !strings.Contains(body, "SUBSCRIPTION_SEAT_NOT_GOVERNABLE") {
-		t.Fatalf("body missing SUBSCRIPTION_SEAT_NOT_GOVERNABLE: %s", body)
+	if !strings.Contains(readBodyStr(resp), "SUBSCRIPTION_SEAT_NOT_GOVERNABLE") {
+		t.Fatal("strict mode should refuse with SUBSCRIPTION_SEAT_NOT_GOVERNABLE")
 	}
 	if upstream.Count() != 0 {
 		t.Fatalf("upstream hits=%d, want 0 (no silent rebill)", upstream.Count())
 	}
 }
 
-// TestGovernRefusesUnrecognizedBearer (§4c F3, fail-closed): govern with an
-// opaque non-API-key bearer and no anthropic-beta header is refused, not
-// silently injected.
-func TestGovernRefusesUnrecognizedBearer(t *testing.T) {
+// TestGovernStrictModeRefusesUnrecognizedBearer (fail-closed under strict): with
+// govern_subscription_seats=false, an opaque non-API-key bearer is refused, not
+// forwarded — preserving the keys-off-laptops guarantee.
+func TestGovernStrictModeRefusesUnrecognizedBearer(t *testing.T) {
 	h := testharness.New(t)
 	upstream := newUpstreamCapture(t)
 	cv := testapp.StartWith(t, h, map[string]string{
-		"CLAWVISOR_LLM_UPSTREAM_ANTHROPIC":   upstream.URL(),
-		"CLAWVISOR_PROXY_LITE_UPSTREAM_AUTH": "vault",
+		"CLAWVISOR_LLM_UPSTREAM_ANTHROPIC":               upstream.URL(),
+		"CLAWVISOR_PROXY_LITE_UPSTREAM_AUTH":             "vault",
+		"CLAWVISOR_PROXY_LITE_GOVERN_SUBSCRIPTION_SEATS": "false",
 	})
 	user := cv.LoginAsLocalUser(t)
 	llmCredSet(t, cv, user.AccessToken, "anthropic", "", "sk-ant-api03-vault")
-	_, token := newPostureAgent(t, cv, user.AccessToken, "govern-opaque")
+	_, token := newPostureAgent(t, cv, user.AccessToken, "govern-strict-opaque")
 
 	resp := postureAgentReq(t, cv, token, map[string]string{
 		"Authorization": "Bearer opaque-unknown-future-token",
@@ -215,7 +303,7 @@ func TestGovernRefusesUnrecognizedBearer(t *testing.T) {
 		t.Fatalf("status=%d, want 403; body=%s", resp.StatusCode, readBodyStr(resp))
 	}
 	if !strings.Contains(readBodyStr(resp), "SUBSCRIPTION_SEAT_NOT_GOVERNABLE") {
-		t.Fatal("opaque bearer should fail closed with SUBSCRIPTION_SEAT_NOT_GOVERNABLE")
+		t.Fatal("opaque bearer should fail closed with SUBSCRIPTION_SEAT_NOT_GOVERNABLE under strict mode")
 	}
 	if upstream.Count() != 0 {
 		t.Fatalf("upstream hits=%d, want 0", upstream.Count())

--- a/internal/api/handlers/installer_scripts/claude_code_subscription.sh.tmpl
+++ b/internal/api/handlers/installer_scripts/claude_code_subscription.sh.tmpl
@@ -5,16 +5,24 @@
 # --- Subscription-mode routing (Claude subscription / OAuth seat) ------------
 # This variant is for a Claude Code seat authenticated with a Claude
 # subscription (OAuth) rather than a provider API key. We route LLM traffic
-# through Clawvisor for Observe visibility WITHOUT touching how the seat
-# authenticates: Clawvisor's proxy-lite carries the OAuth session in
-# Authorization unchanged (observe passthrough, spec 02 §4c), and the seat's
-# identity to Clawvisor is the agent token in the X-Clawvisor-Agent-Token
-# header. We never inject or clear an API key — the subscription stays the
-# billing path (no silent rebill to org-metered API usage).
+# through Clawvisor WITHOUT touching how the seat authenticates: Clawvisor's
+# proxy-lite carries the OAuth session in Authorization unchanged (passthrough),
+# and the seat's identity to Clawvisor is the agent token in the
+# X-Clawvisor-Agent-Token header. We never inject or clear an API key — the
+# subscription stays the billing path (no silent rebill to org-metered usage).
 #
-# Governing this seat later (Govern posture) requires the operator to supply an
-# org provider key for it, or to explicitly set
-# allow_subscription_billing_migration — Observe never migrates billing.
+# This same wiring works under every posture:
+#   - Observe: the OAuth session is forwarded, verdicts are recorded only.
+#   - Govern / Contain: by default (govern_subscription_seats: true) the seat is
+#     AUTO-GOVERNED — its own subscription credential is forwarded upstream
+#     (billing-neutral) while the full policy pipeline enforces (holds, model/
+#     spend/content policy, approvals, cost attribution). The credential stays
+#     on this laptop; only enforcement is centralized.
+# Operators can instead: supply an org provider key for the seat (vaulted), set
+# allow_subscription_billing_migration to centralize billing on the org key, or
+# set govern_subscription_seats: false to refuse subscription seats outright.
+# None of those change THIS script — it only ever routes; it never strips the
+# OAuth credential.
 
 # --- End-to-end smoke test: round-trip through Clawvisor on the OAuth session.
 # We set ONLY the base URL + the Clawvisor agent-token header. We do NOT set

--- a/internal/api/handlers/llm_endpoint.go
+++ b/internal/api/handlers/llm_endpoint.go
@@ -259,6 +259,16 @@ type LLMEndpointHandler struct {
 	// rather than silently rebilled (spec 02 §4c). Instance-wide (F4).
 	AllowSubscriptionBillingMigration bool
 
+	// GovernSubscriptionSeats mirrors cfg.ProxyLite.GovernSubscriptionSeats.
+	// When true (default), a govern/contain (vault) request carrying a
+	// subscription/OAuth (or unrecognized) bearer — and no billing-migration
+	// consent — is AUTO-GOVERNED: the seat's own credential is forwarded
+	// upstream (billing stays on the subscription) while the full policy
+	// pipeline still enforces. When false, the seat is refused with
+	// SUBSCRIPTION_SEAT_NOT_GOVERNABLE (strict vaulted-keys-only mode). An
+	// explicit AllowSubscriptionBillingMigration takes precedence over both.
+	GovernSubscriptionSeats bool
+
 	defaultToolRulesMu   sync.Mutex
 	defaultToolRulesSeen map[string]map[string]struct{}
 }
@@ -273,6 +283,38 @@ func (h *LLMEndpointHandler) upstreamAuthPassthrough() bool {
 // observations rather than enforced (spec 02 §3).
 func (h *LLMEndpointHandler) observeMode() bool {
 	return strings.EqualFold(strings.TrimSpace(h.EnforcementMode), "observe")
+}
+
+// subscriptionSeatDecision enumerates how a vault-posture request presenting a
+// subscription/OAuth (or otherwise unrecognized) client bearer is handled.
+type subscriptionSeatDecision int
+
+const (
+	// subSeatMigrate strips the client bearer and injects the vault key,
+	// migrating billing from the user's subscription to org-metered API
+	// billing (operator consented via allow_subscription_billing_migration).
+	subSeatMigrate subscriptionSeatDecision = iota
+	// subSeatRefuse rejects the request with SUBSCRIPTION_SEAT_NOT_GOVERNABLE
+	// (strict govern_subscription_seats=false, keys-off-laptops).
+	subSeatRefuse
+	// subSeatAutoGovern forwards the seat's own subscription credential
+	// upstream (billing-neutral) while still enforcing the full pipeline.
+	subSeatAutoGovern
+)
+
+// decideSubscriptionSeat resolves the fixed precedence for a subscription/
+// unrecognized bearer under vault posture: billing-migration consent wins
+// first (centralize on the org key), then strict refuse when subscription
+// governance is opted out, else the default auto-govern (forward + enforce).
+func decideSubscriptionSeat(allowBillingMigration, governSubscriptionSeats bool) subscriptionSeatDecision {
+	switch {
+	case allowBillingMigration:
+		return subSeatMigrate
+	case !governSubscriptionSeats:
+		return subSeatRefuse
+	default:
+		return subSeatAutoGovern
+	}
 }
 
 // recordObservedToolUseVerdicts stamps the endpoint_call audit row with
@@ -555,16 +597,46 @@ func (h *LLMEndpointHandler) serve(w http.ResponseWriter, r *http.Request) {
 		auditParams["auth_mode"] = "vault"
 		switch llmproxy.ClassifyUpstreamCredential(r) {
 		case llmproxy.CredentialSubscription, llmproxy.CredentialUnrecognized:
-			if !h.AllowSubscriptionBillingMigration {
+			// A subscription/OAuth (or otherwise unrecognized) client bearer
+			// under vault posture is NOT safe to silently strip-and-inject: the
+			// org-API-key path (CredentialOrgAPIKey) and the no-credential path
+			// (CredentialNone) fall through unchanged and get the normal vault
+			// injection. Only this forwardable client bearer branches, by
+			// precedence: billing-migration consent > strict refuse > default
+			// auto-govern (see decideSubscriptionSeat).
+			switch decideSubscriptionSeat(h.AllowSubscriptionBillingMigration, h.GovernSubscriptionSeats) {
+			case subSeatMigrate:
+				// The operator chose to centralize billing on the org key: keep
+				// today's migration behavior — proceed with vault injection (the
+				// bearer is stripped downstream). auth_mode stays "vault".
+				auditParams["subscription_billing_migration"] = true
+			case subSeatRefuse:
+				// Strict "vaulted keys only" opt-out: refuse rather than govern a
+				// credential that must stay off the laptop.
 				auditStatus = http.StatusForbidden
 				auditDecide = "deny"
 				auditOutcome = "subscription_seat_not_governable"
-				auditReason = "govern refused a subscription/unrecognized bearer without billing-migration consent"
+				auditReason = "govern refused a subscription/unrecognized bearer (govern_subscription_seats: false, no billing-migration consent)"
 				writeNestedJSONError(w, http.StatusForbidden, "SUBSCRIPTION_SEAT_NOT_GOVERNABLE",
-					"this seat's credential can't be governed without either an org provider API key for this agent or explicit billing-migration consent (proxy_lite.allow_subscription_billing_migration); it was not silently rebilled.")
+					"this seat's credential can't be governed without either an org provider API key for this agent or explicit billing-migration consent (proxy_lite.allow_subscription_billing_migration); it was not silently rebilled. (proxy_lite.govern_subscription_seats is false, so subscription seats are not auto-governed.)")
 				return
+			case subSeatAutoGovern:
+				// DEFAULT — auto-govern: forward the seat's own subscription
+				// credential upstream so billing stays on the subscription (no
+				// rebilling), while the full policy pipeline still enforces
+				// (holds/policies/approvals/cost). Flip THIS request to
+				// passthrough upstream auth on rootCtx (the F1 fix: setPhase
+				// re-derives r's context from rootCtx before the forward, so the
+				// override must live on rootCtx) so forward.go forwards the
+				// client bearer. Enforcement (observe mode) is a separate axis
+				// and stays ON under govern/contain — only the upstream
+				// credential source changes, not whether verdicts enforce.
+				rootCtx = llmproxy.WithPassthroughUpstreamAuth(rootCtx)
+				r = r.WithContext(rootCtx)
+				auditParams["auth_mode"] = "subscription_passthrough"
+				authModeMetric = "subscription_passthrough"
+				auditParams["subscription_governed"] = true
 			}
-			auditParams["subscription_billing_migration"] = true
 		}
 	}
 

--- a/internal/api/handlers/llm_endpoint_subscription_seat_test.go
+++ b/internal/api/handlers/llm_endpoint_subscription_seat_test.go
@@ -1,0 +1,32 @@
+package handlers
+
+import "testing"
+
+// TestDecideSubscriptionSeat locks the fixed precedence for a subscription/
+// unrecognized bearer under vault posture: billing-migration consent wins
+// first, then the strict govern_subscription_seats=false refuse, else the
+// default auto-govern (forward the seat's own credential + enforce).
+func TestDecideSubscriptionSeat(t *testing.T) {
+	cases := []struct {
+		name           string
+		allowMigration bool
+		governSeats    bool
+		want           subscriptionSeatDecision
+	}{
+		{"default_auto_govern", false, true, subSeatAutoGovern},
+		{"strict_refuse", false, false, subSeatRefuse},
+		// Migration consent takes precedence over BOTH the auto-govern default
+		// and the strict opt-out — an operator who set allow_subscription_billing_migration
+		// gets migration regardless of govern_subscription_seats.
+		{"migration_wins_over_auto_govern", true, true, subSeatMigrate},
+		{"migration_wins_over_strict_refuse", true, false, subSeatMigrate},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := decideSubscriptionSeat(tc.allowMigration, tc.governSeats); got != tc.want {
+				t.Fatalf("decideSubscriptionSeat(migration=%v, govern=%v) = %d, want %d",
+					tc.allowMigration, tc.governSeats, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1498,6 +1498,7 @@ func (s *Server) registerLiteProxyRoutes(
 		llmHandler.UpstreamAuth = s.cfg.ProxyLite.UpstreamAuth
 		llmHandler.EnforcementMode = s.cfg.ProxyLite.EnforcementMode
 		llmHandler.AllowSubscriptionBillingMigration = s.cfg.ProxyLite.AllowSubscriptionBillingMigration
+		llmHandler.GovernSubscriptionSeats = s.cfg.ProxyLite.GovernSubscriptionSeats
 		if v := s.cfg.ProxyLite.AnthropicBaseURL; v != "" {
 			llmHandler.Forwarder.Upstream.AnthropicBaseURL = v
 		}

--- a/internal/e2e/lite/harness.go
+++ b/internal/e2e/lite/harness.go
@@ -186,6 +186,7 @@ func Start(t *testing.T, scn *Scenario, keys Keys) (*Harness, error) {
 	h.UpstreamAuth = cfg.ProxyLite.UpstreamAuth
 	h.EnforcementMode = cfg.ProxyLite.EnforcementMode
 	h.AllowSubscriptionBillingMigration = cfg.ProxyLite.AllowSubscriptionBillingMigration
+	h.GovernSubscriptionSeats = cfg.ProxyLite.GovernSubscriptionSeats
 	h.Inspector = inspector.NewInspector(inspector.DefaultParser{}, inspector.AmbiguousValidator{})
 	h.InlineTaskCreator = recorder
 	h.TaskScope = llmproxy.NewStoreTaskScopeChecker(st)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -502,6 +502,23 @@ type ProxyLiteConfig struct {
 	// it; it is always an explicit operator choice. Env override:
 	// CLAWVISOR_PROXY_LITE_ALLOW_SUB_MIGRATION.
 	AllowSubscriptionBillingMigration bool `yaml:"allow_subscription_billing_migration"`
+
+	// GovernSubscriptionSeats controls how govern/contain (vault upstream_auth)
+	// treats a seat presenting a Claude subscription (OAuth) — or otherwise
+	// unrecognized — bearer, when billing migration is NOT enabled. Default
+	// true: AUTO-GOVERN — forward the seat's own subscription credential
+	// upstream (billing stays on the subscription, no rebilling) while running
+	// the full policy pipeline (inspection, tool-use holds, model/spend/content
+	// policy, approvals, cost attribution). The credential stays on the laptop;
+	// only enforcement is centralized. Set false for strict "vaulted keys only"
+	// mode: a subscription/unrecognized seat is REFUSED with
+	// SUBSCRIPTION_SEAT_NOT_GOVERNABLE (the pre-auto-govern behavior), so an
+	// operator can mandate keys-off-laptops. Precedence: an explicit
+	// AllowSubscriptionBillingMigration still wins (migrate to the vault key);
+	// this flag only chooses between auto-govern (true) and strict-refuse
+	// (false) for the non-migration case. Env override:
+	// CLAWVISOR_PROXY_LITE_GOVERN_SUBSCRIPTION_SEATS.
+	GovernSubscriptionSeats bool `yaml:"govern_subscription_seats"`
 }
 
 // ObserveMode reports whether enforcement is downgraded to observation: the
@@ -648,6 +665,11 @@ func Default() *Config {
 			EnforcementMode:                   "enforce",
 			UpstreamAuth:                      "vault",
 			AllowSubscriptionBillingMigration: false,
+			// Auto-govern subscription seats by default: forward the seat's own
+			// subscription credential upstream (billing-neutral) while still
+			// enforcing the full policy pipeline. Opt out (false) for strict
+			// vaulted-keys-only mode that refuses subscription seats.
+			GovernSubscriptionSeats: true,
 		},
 		Governance: GovernanceConfig{
 			// Enabled by default: the governance tables are empty on a fresh
@@ -1111,6 +1133,11 @@ func Load(path string) (*Config, error) {
 	}
 	if v := os.Getenv("CLAWVISOR_PROXY_LITE_ALLOW_SUB_MIGRATION"); v != "" {
 		cfg.ProxyLite.AllowSubscriptionBillingMigration = v == "true" || v == "1"
+	}
+	// Default-true opt-out: an explicit false/0 forces strict vaulted-keys-only
+	// mode (refuse subscription seats); true/1 restores auto-govern.
+	if v := os.Getenv("CLAWVISOR_PROXY_LITE_GOVERN_SUBSCRIPTION_SEATS"); v != "" {
+		cfg.ProxyLite.GovernSubscriptionSeats = v == "true" || v == "1"
 	}
 	if v := os.Getenv("CLAWVISOR_EXPERIMENTAL_CONTAIN"); v != "" {
 		cfg.ExperimentalContain = v == "true" || v == "1"

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -279,6 +279,9 @@ func TestFlipDefaultStaysFalse(t *testing.T) {
 	if d.ProxyLite.AllowSubscriptionBillingMigration {
 		t.Fatal("Default allow_subscription_billing_migration must be false")
 	}
+	if !d.ProxyLite.GovernSubscriptionSeats {
+		t.Fatal("Default govern_subscription_seats must be true (auto-govern subscription seats on by default)")
+	}
 }
 
 // TestProxyLiteEnableMatrix asserts exactly which (key present/absent) ×
@@ -543,4 +546,30 @@ func TestLoadAppliesSubMigrationEnv(t *testing.T) {
 	if !cfg.ProxyLite.AllowSubscriptionBillingMigration {
 		t.Fatal("expected allow_subscription_billing_migration env override to apply")
 	}
+}
+
+// TestLoadAppliesGovernSubscriptionSeatsEnv verifies the default-true opt-out:
+// the env override can force strict "vaulted keys only" mode (false) and can
+// restore auto-govern (true).
+func TestLoadAppliesGovernSubscriptionSeatsEnv(t *testing.T) {
+	t.Run("false forces strict mode", func(t *testing.T) {
+		t.Setenv("CLAWVISOR_PROXY_LITE_GOVERN_SUBSCRIPTION_SEATS", "false")
+		cfg, err := Load("")
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.ProxyLite.GovernSubscriptionSeats {
+			t.Fatal("expected govern_subscription_seats=false env override to force strict mode")
+		}
+	})
+	t.Run("true keeps auto-govern", func(t *testing.T) {
+		t.Setenv("CLAWVISOR_PROXY_LITE_GOVERN_SUBSCRIPTION_SEATS", "true")
+		cfg, err := Load("")
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if !cfg.ProxyLite.GovernSubscriptionSeats {
+			t.Fatal("expected govern_subscription_seats=true env override to keep auto-govern")
+		}
+	})
 }


### PR DESCRIPTION
Reverses the refuse-by-default subscription carve-out (PRD §15) per a day-one product requirement: **Govern and Contain now govern a Claude subscription (OAuth) seat by default** — the seat's own credential is forwarded upstream (billing stays on the subscription, **no rebill**) while the full pipeline enforces (inspection, tool-use holds, model/spend/content policy, approvals, cost). API-key seats are unchanged (stripped + vault-injected). Contain inherits it (same proxy-lite handler).

**Precedence** for a subscription/unrecognized bearer under the vault posture (`decideSubscriptionSeat`):
1. `allow_subscription_billing_migration=true` → migrate to the org vault key (centralize billing) — retained.
2. `govern_subscription_seats=false` → strict opt-out: refuse `SUBSCRIPTION_SEAT_NOT_GOVERNABLE` (previous behavior; for orgs mandating keys-off-laptops).
3. else (default) → **auto-govern**: forward + enforce.

New `proxy_lite.govern_subscription_seats` (env `CLAWVISOR_PROXY_LITE_GOVERN_SUBSCRIPTION_SEATS`), **Default() true** (opt-out). Audit `auth_mode=subscription_passthrough` + `subscription_governed=true`, distinct from vault and observe-passthrough. Installer keeps the OAuth credential intact; `--remove-provider-keys` never scrubs it.

**Invariants proven by test:** auto-govern forwards the subscription bearer and injects **no** vault key (TestGovernAutoGovernsSubscriptionSeat asserts upstream Authorization==the bearer, x-api-key==""); enforcement still fires (model/content deny→403, tool_use hold→blocked); migration wins precedence; org-key/no-cred/Observe paths unchanged; contain parity green. AGENT-GUIDE §2B/§7 updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

