### PR TITLE
feat(security): admin-API-token lockdown + multi-instance rate limiting

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -38,6 +38,11 @@ auth:
   require_invite: false    # from env: AUTH_REQUIRE_INVITE — when true, registration needs a valid
                            # invite (403 INVITE_REQUIRED) except the very first user, who becomes admin.
                            # The first registered user is admin; subsequent users are members.
+  disable_api_tokens: false # from env: AUTH_DISABLE_API_TOKENS — when true, fully disables the
+                           # long-lived scoped API-token subsystem: mint/manage routes return 404,
+                           # no bootstrap token is seeded, /api/features reports api_tokens:false, and
+                           # any presented cvat_ bearer is rejected 401 without a token-table lookup.
+                           # Keep false for OSS/self-hosted; the Terraform provider requires tokens.
 
 approval:
   timeout: 300             # seconds before approval request expires

--- a/internal/api/api_tokens_disabled_test.go
+++ b/internal/api/api_tokens_disabled_test.go
@@ -1,0 +1,128 @@
+package api_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/internal/api"
+	"github.com/clawvisor/clawvisor/internal/auth"
+	"github.com/clawvisor/clawvisor/pkg/adapters"
+	"github.com/clawvisor/clawvisor/pkg/config"
+	sqlitestore "github.com/clawvisor/clawvisor/pkg/store/sqlite"
+	intvault "github.com/clawvisor/clawvisor/pkg/vault"
+)
+
+// newAPITokensEnv builds an API server whose FeatureSet.APITokens matches the
+// given flag, so the token mint/manage routes are gated exactly as production
+// (registered when enabled, absent → 404 when disabled). Password auth is on
+// so the first registered user becomes admin and can drive the routes.
+func newAPITokensEnv(t *testing.T, apiTokensEnabled bool) *testEnv {
+	t.Helper()
+	ctx := context.Background()
+
+	db, err := sqlitestore.New(ctx, t.TempDir()+"/test.db")
+	if err != nil {
+		t.Fatalf("sqlite: %v", err)
+	}
+	st := sqlitestore.NewStore(db)
+
+	v, err := intvault.NewLocalVault(t.TempDir()+"/vault.key", db, "sqlite")
+	if err != nil {
+		t.Fatalf("vault: %v", err)
+	}
+
+	jwtSvc, err := auth.NewJWTService("test-secret-for-integration-tests")
+	if err != nil {
+		t.Fatalf("jwt: %v", err)
+	}
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{Host: "127.0.0.1", Port: 0},
+		Auth: config.AuthConfig{
+			JWTSecret:       "test-secret-for-integration-tests",
+			AccessTokenTTL:  "15m",
+			RefreshTokenTTL: "720h",
+		},
+		Approval: config.ApprovalConfig{Timeout: 300, OnTimeout: "fail", AllowSelfApprove: true, AdminNotify: true},
+		Task:     config.TaskConfig{DefaultExpirySeconds: 3600},
+	}
+
+	srv, err := api.New(cfg, st, v, jwtSvc, adapters.NewRegistry(), nil, config.LLMConfig{}, nil,
+		api.WithFeatures(api.FeatureSet{PasswordAuth: true, APITokens: apiTokensEnabled}),
+	)
+	if err != nil {
+		t.Fatalf("api.New: %v", err)
+	}
+
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+	t.Cleanup(func() { _ = st.Close() })
+
+	return &testEnv{t: t, ts: ts, Vault: v, Store: st, client: ts.Client()}
+}
+
+// TestFeatures_APITokensReflectsFlag pins handleFeatures: /api/features
+// advertises api_tokens matching the deployment gate (true when enabled, false
+// when disabled) so the Terraform provider capability-negotiates instead of
+// hitting a 404/401 on the token routes.
+func TestFeatures_APITokensReflectsFlag(t *testing.T) {
+	for _, enabled := range []bool{true, false} {
+		env := newAPITokensEnv(t, enabled)
+		resp := env.do("GET", "/api/features", "", nil)
+		body := mustStatus(t, resp, http.StatusOK)
+		got, ok := body["api_tokens"].(bool)
+		if !ok {
+			t.Fatalf("enabled=%v: api_tokens missing or not a bool in %v", enabled, body)
+		}
+		if got != enabled {
+			t.Fatalf("enabled=%v: /api/features api_tokens=%v, want %v", enabled, got, enabled)
+		}
+	}
+}
+
+// TestAPITokensDisabled_RoutesReturn404 pins the route guard: with API tokens
+// disabled instance-wide the mint/list/revoke routes are never registered, so
+// the Go mux returns 404 for every method — even for a legitimate admin JWT.
+func TestAPITokensDisabled_RoutesReturn404(t *testing.T) {
+	env := newAPITokensEnv(t, false)
+	admin := newSession(t, env) // first registered user is admin
+
+	// The Go mux returns a plain-text (non-JSON) 404 when a route is absent,
+	// so assert on the status code directly rather than decoding a body.
+	wantStatus := func(method, path string, code int) {
+		t.Helper()
+		resp := env.do(method, path, admin.AccessToken, nil)
+		defer resp.Body.Close()
+		if resp.StatusCode != code {
+			t.Fatalf("%s %s: status=%d want %d", method, path, resp.StatusCode, code)
+		}
+	}
+
+	wantStatus("POST", "/api/tokens", http.StatusNotFound)
+	wantStatus("GET", "/api/tokens", http.StatusNotFound)
+	wantStatus("DELETE", "/api/tokens/some-id", http.StatusNotFound)
+}
+
+// TestAPITokensEnabled_RoutesWork is the default-enabled counterpart: the
+// mint/list/revoke routes are registered and serve an admin JWT (201/200/204).
+func TestAPITokensEnabled_RoutesWork(t *testing.T) {
+	env := newAPITokensEnv(t, true)
+	admin := newSession(t, env) // first registered user is admin
+
+	// POST /api/tokens → 201 Created
+	resp := env.do("POST", "/api/tokens", admin.AccessToken, map[string]any{
+		"name": "tf", "scope": "instance-admin",
+	})
+	created := mustStatus(t, resp, http.StatusCreated)
+	tokenID := str(t, created, "id")
+
+	// GET /api/tokens → 200 OK
+	resp = env.do("GET", "/api/tokens", admin.AccessToken, nil)
+	mustStatus(t, resp, http.StatusOK)
+
+	// DELETE /api/tokens/{id} → 204 No Content
+	resp = env.do("DELETE", "/api/tokens/"+tokenID, admin.AccessToken, nil)
+	mustStatus(t, resp, http.StatusNoContent)
+}

--- a/internal/api/handlers/apitokens_test.go
+++ b/internal/api/handlers/apitokens_test.go
@@ -139,7 +139,7 @@ func TestCreate_ConcurrentBootstrapBurnConflictReturns409(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewJWTService: %v", err)
 	}
-	handler := middleware.RequireUserOrAPIToken(jwtSvc, st, middleware.ScopeInstanceAdmin)(http.HandlerFunc(h.Create))
+	handler := middleware.RequireUserOrAPIToken(jwtSvc, st, middleware.ScopeInstanceAdmin, true)(http.HandlerFunc(h.Create))
 
 	body, _ := json.Marshal(map[string]string{"name": "terraform", "scope": middleware.ScopeInstanceAdmin})
 	req := httptest.NewRequest(http.MethodPost, "/api/tokens", bytes.NewReader(body))

--- a/internal/api/middleware/apitoken.go
+++ b/internal/api/middleware/apitoken.go
@@ -114,13 +114,28 @@ var apiTokenLastUsed = &lastUsedThrottle{seen: map[string]time.Time{}}
 // RequireUserOrAgent falls through to the JWT path today. The `cvat_`
 // sniff happens BEFORE any JWT parsing so the shared bearer slot never
 // hands an API token to the JWT validator.
-func RequireUserOrAPIToken(jwtSvc auth.TokenService, st store.Store, minScope string) func(http.Handler) http.Handler {
+//
+// apiTokensEnabled reflects the instance-wide FeatureSet.APITokens gate
+// (auth.disable_api_tokens). When false and the request carries a `cvat_`
+// bearer, the middleware short-circuits 401 WITHOUT consulting the token
+// table — so a leaked / pre-existing / DB-planted token is inert on EVERY
+// route this gate protects (mint, /api/users*, shared vault, restrictions).
+// A `cvat_` is not a JWT, so a rejected bearer never falls through to JWT
+// parsing; a normal JWT request (no `cvat_` prefix) still works unchanged.
+func RequireUserOrAPIToken(jwtSvc auth.TokenService, st store.Store, minScope string, apiTokensEnabled bool) func(http.Handler) http.Handler {
 	requireUser := RequireUser(jwtSvc, st)
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			tok := apiTokenFromRequest(r)
 			if tok == "" {
 				requireUser(next).ServeHTTP(w, r)
+				return
+			}
+			if !apiTokensEnabled {
+				// API tokens are disabled instance-wide. Reject the presented
+				// cvat_ bearer without a token-table lookup and do NOT fall
+				// through to JWT parsing (a cvat_ is not a JWT).
+				writeAuthError(w, http.StatusUnauthorized, "UNAUTHORIZED", "api tokens are disabled")
 				return
 			}
 
@@ -183,8 +198,8 @@ func RequireUserOrAPIToken(jwtSvc auth.TokenService, st store.Store, minScope st
 // Authorization precedence: when a token authenticated the request the gate
 // is the token's scope and the injected `_instance` user's role is NEVER
 // consulted. Only on the JWT path is the role checked.
-func RequireAdminOrToken(jwtSvc auth.TokenService, st store.Store) func(http.Handler) http.Handler {
-	requireUserOrToken := RequireUserOrAPIToken(jwtSvc, st, ScopeInstanceAdmin)
+func RequireAdminOrToken(jwtSvc auth.TokenService, st store.Store, apiTokensEnabled bool) func(http.Handler) http.Handler {
+	requireUserOrToken := RequireUserOrAPIToken(jwtSvc, st, ScopeInstanceAdmin, apiTokensEnabled)
 	return func(next http.Handler) http.Handler {
 		return requireUserOrToken(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if APITokenFromContext(r.Context()) != nil {

--- a/internal/api/middleware/apitoken_test.go
+++ b/internal/api/middleware/apitoken_test.go
@@ -100,7 +100,7 @@ func TestRequireUserOrAPIToken_ValidToken(t *testing.T) {
 	raw := seedAPIToken(t, st, ScopeInstanceAdmin, nil, false, false)
 
 	cap := &apiTokenCapture{}
-	h := RequireUserOrAPIToken(newTestJWT(t), st, ScopeInstanceAdmin)(http.HandlerFunc(cap.handler))
+	h := RequireUserOrAPIToken(newTestJWT(t), st, ScopeInstanceAdmin, true)(http.HandlerFunc(cap.handler))
 
 	req := httptest.NewRequest(http.MethodGet, "/api/agents", nil)
 	req.Header.Set("Authorization", "Bearer "+raw)
@@ -140,7 +140,7 @@ func TestRequireUserOrAPIToken_ValidToken(t *testing.T) {
 func TestRequireUserOrAPIToken_Revoked(t *testing.T) {
 	st := newAPITokenTestStore(t)
 	raw := seedAPIToken(t, st, ScopeInstanceAdmin, nil, true, false)
-	h := RequireUserOrAPIToken(newTestJWT(t), st, ScopeInstanceAdmin)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) }))
+	h := RequireUserOrAPIToken(newTestJWT(t), st, ScopeInstanceAdmin, true)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) }))
 	req := httptest.NewRequest(http.MethodGet, "/api/agents", nil)
 	req.Header.Set("Authorization", "Bearer "+raw)
 	rec := httptest.NewRecorder()
@@ -157,7 +157,7 @@ func TestRequireUserOrAPIToken_Expired(t *testing.T) {
 	st := newAPITokenTestStore(t)
 	past := time.Now().Add(-time.Hour)
 	raw := seedAPIToken(t, st, ScopeInstanceAdmin, &past, false, false)
-	h := RequireUserOrAPIToken(newTestJWT(t), st, ScopeInstanceAdmin)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) }))
+	h := RequireUserOrAPIToken(newTestJWT(t), st, ScopeInstanceAdmin, true)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) }))
 	req := httptest.NewRequest(http.MethodGet, "/api/agents", nil)
 	req.Header.Set("Authorization", "Bearer "+raw)
 	rec := httptest.NewRecorder()
@@ -171,7 +171,7 @@ func TestRequireUserOrAPIToken_InsufficientScope(t *testing.T) {
 	st := newAPITokenTestStore(t)
 	// A config-read token cannot satisfy an instance-admin gate.
 	raw := seedAPIToken(t, st, ScopeConfigRead, nil, false, false)
-	h := RequireUserOrAPIToken(newTestJWT(t), st, ScopeInstanceAdmin)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) }))
+	h := RequireUserOrAPIToken(newTestJWT(t), st, ScopeInstanceAdmin, true)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) }))
 	req := httptest.NewRequest(http.MethodPost, "/api/tokens", nil)
 	req.Header.Set("Authorization", "Bearer "+raw)
 	rec := httptest.NewRecorder()
@@ -184,7 +184,7 @@ func TestRequireUserOrAPIToken_InsufficientScope(t *testing.T) {
 func TestRequireUserOrAPIToken_UnknownToken(t *testing.T) {
 	st := newAPITokenTestStore(t)
 	raw, _, _ := intauth.GenerateAPIToken() // never inserted
-	h := RequireUserOrAPIToken(newTestJWT(t), st, ScopeInstanceAdmin)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) }))
+	h := RequireUserOrAPIToken(newTestJWT(t), st, ScopeInstanceAdmin, true)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) }))
 	req := httptest.NewRequest(http.MethodGet, "/api/agents", nil)
 	req.Header.Set("Authorization", "Bearer "+raw)
 	rec := httptest.NewRecorder()
@@ -199,7 +199,7 @@ func TestRequireUserOrAPIToken_UnknownToken(t *testing.T) {
 // invalid JWT → 401 from RequireUser, never touching the token path.
 func TestRequireUserOrAPIToken_JWTFallthrough(t *testing.T) {
 	st := newAPITokenTestStore(t)
-	h := RequireUserOrAPIToken(newTestJWT(t), st, ScopeInstanceAdmin)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) }))
+	h := RequireUserOrAPIToken(newTestJWT(t), st, ScopeInstanceAdmin, true)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) }))
 
 	// A bogus non-cvat_ bearer should reach RequireUser and be rejected as
 	// an invalid JWT (UNAUTHORIZED), proving fallthrough.
@@ -222,7 +222,7 @@ func TestRequireUserOrAPIToken_FailsClosedWithoutInstanceUser(t *testing.T) {
 	if err := st.DeleteUser(context.Background(), store.InstanceUserID); err != nil {
 		t.Fatalf("DeleteUser(_instance): %v", err)
 	}
-	h := RequireUserOrAPIToken(newTestJWT(t), st, ScopeInstanceAdmin)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) }))
+	h := RequireUserOrAPIToken(newTestJWT(t), st, ScopeInstanceAdmin, true)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) }))
 	req := httptest.NewRequest(http.MethodGet, "/api/agents", nil)
 	req.Header.Set("Authorization", "Bearer "+raw)
 	rec := httptest.NewRecorder()
@@ -239,13 +239,38 @@ func TestBootstrap_Expires(t *testing.T) {
 	st := newAPITokenTestStore(t)
 	past := time.Now().Add(-time.Minute)
 	raw := seedAPIToken(t, st, ScopeInstanceAdmin, &past, false, true /* bootstrap */)
-	h := RequireUserOrAPIToken(newTestJWT(t), st, ScopeInstanceAdmin)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) }))
+	h := RequireUserOrAPIToken(newTestJWT(t), st, ScopeInstanceAdmin, true)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) }))
 	req := httptest.NewRequest(http.MethodPost, "/api/tokens", nil)
 	req.Header.Set("Authorization", "Bearer "+raw)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
 	if rec.Code != http.StatusUnauthorized || !bodyHasCode(rec.Body.String(), "TOKEN_EXPIRED") {
 		t.Fatalf("status=%d body=%q want 401 TOKEN_EXPIRED", rec.Code, rec.Body.String())
+	}
+}
+
+// TestAPIToken_DisabledRejectsValidToken pins the key hardening: when API
+// tokens are disabled instance-wide (apiTokensEnabled=false), a VALID seeded
+// instance-admin cvat_ token on an adminOrToken route is rejected 401 WITHOUT
+// a token-table lookup — a leaked / DB-planted token is inert. A normal admin
+// JWT on the same gate still succeeds (200).
+func TestAPIToken_DisabledRejectsValidToken(t *testing.T) {
+	st := newAPITokenTestStore(t)
+	jwtSvc := newTestJWT(t)
+
+	// A perfectly valid, non-revoked, non-expired instance-admin token.
+	adminTok := seedAPIToken(t, st, ScopeInstanceAdmin, nil, false, false)
+	adminJWT := jwtFor(t, st, jwtSvc, "admin@x", store.RoleAdmin)
+
+	// Gate constructed with API tokens DISABLED.
+	gate := RequireAdminOrToken(jwtSvc, st, false)(okHandler())
+
+	if code, body := statusFor(gate, adminTok); code != http.StatusUnauthorized {
+		t.Fatalf("valid instance-admin token with tokens disabled: status=%d want 401; body=%s", code, body)
+	}
+	// The JWT path must still work — disabling tokens must not break admins.
+	if code, body := statusFor(gate, adminJWT); code != http.StatusOK {
+		t.Fatalf("admin JWT with tokens disabled: status=%d want 200; body=%s", code, body)
 	}
 }
 

--- a/internal/api/middleware/trust_split_test.go
+++ b/internal/api/middleware/trust_split_test.go
@@ -47,9 +47,9 @@ func TestAPIToken_ScopeEnforcement(t *testing.T) {
 	writeTok := seedAPIToken(t, st, ScopeConfigWrite, nil, false, false)
 	adminTok := seedAPIToken(t, st, ScopeInstanceAdmin, nil, false, false)
 
-	readGate := RequireUserOrAPIToken(jwtSvc, st, ScopeConfigRead)(okHandler())
-	writeGate := RequireUserOrAPIToken(jwtSvc, st, ScopeConfigWrite)(okHandler())
-	adminGate := RequireUserOrAPIToken(jwtSvc, st, ScopeInstanceAdmin)(okHandler())
+	readGate := RequireUserOrAPIToken(jwtSvc, st, ScopeConfigRead, true)(okHandler())
+	writeGate := RequireUserOrAPIToken(jwtSvc, st, ScopeConfigWrite, true)(okHandler())
+	adminGate := RequireUserOrAPIToken(jwtSvc, st, ScopeInstanceAdmin, true)(okHandler())
 
 	cases := []struct {
 		name       string
@@ -87,7 +87,7 @@ func TestAPIToken_ScopeEnforcement(t *testing.T) {
 func TestAPIToken_TrustSplit(t *testing.T) {
 	st := newAPITokenTestStore(t)
 	jwtSvc := newTestJWT(t)
-	gate := RequireAdminOrToken(jwtSvc, st)(okHandler())
+	gate := RequireAdminOrToken(jwtSvc, st, true)(okHandler())
 
 	adminTok := seedAPIToken(t, st, ScopeInstanceAdmin, nil, false, false)
 	writeTok := seedAPIToken(t, st, ScopeConfigWrite, nil, false, false)
@@ -119,7 +119,7 @@ func TestRejectInstanceItemWriteByScopedToken(t *testing.T) {
 
 	// Wire the guard exactly as server.go does: config-write gate, then the
 	// item-write guard, then the handler.
-	gate := RequireUserOrAPIToken(jwtSvc, st, ScopeConfigWrite)(
+	gate := RequireUserOrAPIToken(jwtSvc, st, ScopeConfigWrite, true)(
 		RejectInstanceItemWriteByScopedToken(okHandler()))
 
 	writeTok := seedAPIToken(t, st, ScopeConfigWrite, nil, false, false)

--- a/internal/api/ratelimit_factory_test.go
+++ b/internal/api/ratelimit_factory_test.go
@@ -1,0 +1,91 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+
+	"github.com/clawvisor/clawvisor/internal/ratelimit"
+	"github.com/clawvisor/clawvisor/pkg/config"
+)
+
+// TestNewKeyedLimiter_RedisBackedSharesCounterAcrossInstances proves the fix
+// for audit finding #2a: when the server has a Redis client, the per-IP rate
+// limiter it builds is backed by a counter shared across replicas. Two limiter
+// instances (modeling two Cloud Run replicas) pointed at the same Redis enforce
+// the configured cap in aggregate — not cap*N — so brute-force protection does
+// not degrade as autoscaling adds replicas.
+func TestNewKeyedLimiter_RedisBackedSharesCounterAcrossInstances(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(mr.Close)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	// Two independent servers ("replicas") sharing one Redis, exactly as
+	// defaults.go wires them from a single cfg.Redis.URL.
+	replicaA := &Server{redisClient: rdb}
+	replicaB := &Server{redisClient: rdb}
+
+	bucket := config.RateLimitBucket{Limit: 10, Window: 60}
+	limiterA := replicaA.newKeyedLimiterFromBucket(bucket)
+	limiterB := replicaB.newKeyedLimiterFromBucket(bucket)
+
+	if _, ok := limiterA.(*ratelimit.RedisKeyedLimiter); !ok {
+		t.Fatalf("replica A limiter = %T, want *ratelimit.RedisKeyedLimiter", limiterA)
+	}
+	if _, ok := limiterB.(*ratelimit.RedisKeyedLimiter); !ok {
+		t.Fatalf("replica B limiter = %T, want *ratelimit.RedisKeyedLimiter", limiterB)
+	}
+
+	const ip = "203.0.113.7"
+
+	// Replica A serves 6 requests for this IP; all fit under the cap of 10.
+	for i := 0; i < 6; i++ {
+		if allowed, _, _ := limiterA.Allow(ip); !allowed {
+			t.Fatalf("replica A request %d for %s denied, want allowed (cap 10)", i+1, ip)
+		}
+	}
+
+	// Replica B, which never saw those requests locally, must observe the
+	// remaining budget of 4 through the shared Redis counter.
+	for i := 0; i < 4; i++ {
+		if allowed, _, _ := limiterB.Allow(ip); !allowed {
+			t.Fatalf("replica B request %d for %s denied, want allowed (4 left of cap 10)", i+1, ip)
+		}
+	}
+
+	// The combined 11th request must be denied on either replica — the cap is
+	// 10 across the fleet, not 10 per replica (which would be cap*N = 20).
+	if allowed, _, _ := limiterB.Allow(ip); allowed {
+		t.Fatalf("replica B allowed an 11th request for %s; cap of 10 not enforced across instances", ip)
+	}
+	if allowed, _, _ := limiterA.Allow(ip); allowed {
+		t.Fatalf("replica A allowed an 11th request for %s; cap of 10 not enforced across instances", ip)
+	}
+}
+
+// TestNewKeyedLimiter_InMemoryWhenNoRedis is the binding-invariant guard: a
+// server with no Redis client (the single-VM / local-dev / self-hosted default)
+// must keep using the in-memory per-process limiter, unchanged. This is what
+// keeps the Redis-less single-instance deployment byte-for-byte as before.
+func TestNewKeyedLimiter_InMemoryWhenNoRedis(t *testing.T) {
+	s := &Server{} // redisClient nil, as when cfg.Redis.URL is empty
+
+	limiter := s.newKeyedLimiterFromBucket(config.RateLimitBucket{Limit: 10, Window: 60})
+	if _, ok := limiter.(*ratelimit.KeyedLimiter); !ok {
+		t.Fatalf("no-Redis limiter = %T, want *ratelimit.KeyedLimiter (in-memory)", limiter)
+	}
+
+	// Unconfigured buckets still return nil regardless of the Redis path — the
+	// caller relies on this to skip installing the rate-limit middleware.
+	if got := s.newKeyedLimiterFromBucket(config.RateLimitBucket{Limit: 0, Window: 60}); got != nil {
+		t.Fatalf("zero-limit bucket = %v, want nil", got)
+	}
+	if got := s.newKeyedLimiterFromBucket(config.RateLimitBucket{Limit: 10, Window: 0}); got != nil {
+		t.Fatalf("zero-window bucket = %v, want nil", got)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -47,6 +47,7 @@ import (
 	skillfiles "github.com/clawvisor/clawvisor/skills"
 	webfs "github.com/clawvisor/clawvisor/web"
 
+	"github.com/redis/go-redis/v9"
 	"golang.org/x/time/rate"
 )
 
@@ -149,6 +150,12 @@ type Server struct {
 	// when observability export is disabled (the default); handlers no-op
 	// their metric emission when it is nil.
 	instruments *observability.Instruments
+
+	// redisClient, when non-nil, makes the per-IP rate limiters Redis-backed
+	// so brute-force caps hold across replicas instead of becoming cap*N under
+	// horizontal autoscaling. nil (the single-VM / local-dev default) selects
+	// the in-memory per-process limiter — see newKeyedLimiterFromBucket.
+	redisClient *redis.Client
 }
 
 // Dependencies is passed to ExtraRoutes so extension handlers can access shared services.
@@ -429,6 +436,13 @@ func WithExtractionTracker(t handlers.ExtractionTracker) ServerOption {
 // default) disables metric emission.
 func WithInstruments(inst *observability.Instruments) ServerOption {
 	return func(s *Server) { s.instruments = inst }
+}
+
+// WithRedisClient supplies the shared Redis client so the per-IP rate limiters
+// enforce their caps across replicas. nil (the single-VM / local-dev default)
+// leaves the limiters in-memory and per-process — see newKeyedLimiterFromBucket.
+func WithRedisClient(rdb *redis.Client) ServerOption {
+	return func(s *Server) { s.redisClient = rdb }
 }
 
 // WithCallerNonceCache overrides the default in-memory caller-nonce cache
@@ -727,10 +741,10 @@ func (s *Server) routes() http.Handler {
 
 	// Rate limiters (skip when config is zero-valued, e.g. in tests)
 	rlCfg := s.cfg.RateLimit
-	gatewayRL := newKeyedLimiterFromBucket(rlCfg.Gateway)
-	oauthRL := newKeyedLimiterFromBucket(rlCfg.OAuth)
-	policyRL := newKeyedLimiterFromBucket(rlCfg.PolicyAPI)
-	authRL := newKeyedLimiterFromBucket(rlCfg.Auth)
+	gatewayRL := s.newKeyedLimiterFromBucket(rlCfg.Gateway)
+	oauthRL := s.newKeyedLimiterFromBucket(rlCfg.OAuth)
+	policyRL := s.newKeyedLimiterFromBucket(rlCfg.PolicyAPI)
+	authRL := s.newKeyedLimiterFromBucket(rlCfg.Auth)
 
 	// Parse trusted-proxy CIDRs once. When r.RemoteAddr falls inside any of
 	// these networks, ipKeyFn honors X-Forwarded-For — otherwise the rate
@@ -786,9 +800,9 @@ func (s *Server) routes() http.Handler {
 	//     writes, token management). A config-write token is 403
 	//     INSUFFICIENT_SCOPE here; a member JWT is 403 FORBIDDEN.
 	// A non-`cvat_` bearer falls through to the JWT path exactly like `user`.
-	requireUserOrTokenRead := middleware.RequireUserOrAPIToken(s.jwtSvc, s.store, middleware.ScopeConfigRead)
+	requireUserOrTokenRead := middleware.RequireUserOrAPIToken(s.jwtSvc, s.store, middleware.ScopeConfigRead, s.features.APITokens)
 	userOrTokenRead := func(h http.HandlerFunc) http.Handler { return requireUserOrTokenRead(h) }
-	requireUserOrToken := middleware.RequireUserOrAPIToken(s.jwtSvc, s.store, middleware.ScopeConfigWrite)
+	requireUserOrToken := middleware.RequireUserOrAPIToken(s.jwtSvc, s.store, middleware.ScopeConfigWrite, s.features.APITokens)
 	userOrToken := func(h http.HandlerFunc) http.Handler { return requireUserOrToken(h) }
 	// Personal vault item writes: a config-write token authenticates as the
 	// `_instance` user, so without this guard it could plant/delete shared
@@ -799,7 +813,7 @@ func (s *Server) routes() http.Handler {
 	userOrTokenPolicyRL := func(h http.HandlerFunc) http.Handler {
 		return requireUserOrToken(middleware.RateLimit(policyRL, userKeyFn, rlCfg.PolicyAPI.Limit)(h))
 	}
-	requireAdminOrToken := middleware.RequireAdminOrToken(s.jwtSvc, s.store)
+	requireAdminOrToken := middleware.RequireAdminOrToken(s.jwtSvc, s.store, s.features.APITokens)
 	adminOrToken := func(h http.HandlerFunc) http.Handler { return requireAdminOrToken(h) }
 	// E2E encryption middleware — wraps agent-facing routes so relay traffic is encrypted.
 	// Local requests pass through unencrypted; relay requests without E2E get 403.
@@ -894,10 +908,16 @@ func (s *Server) routes() http.Handler {
 	// Token management is instance-administrative: minting a token (and
 	// especially an instance-admin token) is privilege escalation, so a
 	// config-write token must not reach these routes.
-	apiTokensHandler := handlers.NewAPITokensHandler(s.store, s.logger)
-	mux.Handle("POST /api/tokens", adminOrToken(apiTokensHandler.Create))
-	mux.Handle("GET /api/tokens", adminOrToken(apiTokensHandler.List))
-	mux.Handle("DELETE /api/tokens/{id}", adminOrToken(apiTokensHandler.Delete))
+	// When API tokens are disabled instance-wide (auth.disable_api_tokens,
+	// cloud lockdown) the routes are never registered, so the Go mux returns
+	// 404 for mint/list/revoke. The auth middleware separately rejects any
+	// presented cvat_ bearer on every other instance-admin route.
+	if s.features.APITokens {
+		apiTokensHandler := handlers.NewAPITokensHandler(s.store, s.logger)
+		mux.Handle("POST /api/tokens", adminOrToken(apiTokensHandler.Create))
+		mux.Handle("GET /api/tokens", adminOrToken(apiTokensHandler.List))
+		mux.Handle("DELETE /api/tokens/{id}", adminOrToken(apiTokensHandler.Delete))
+	}
 
 	// User management + invites (spec 04). Admin-gated: a JWT admin OR an
 	// instance-admin API token (so Terraform employee-onboarding runs
@@ -955,7 +975,7 @@ func (s *Server) routes() http.Handler {
 		connectionsHandler.SetClaimCodeCache(s.claimCodeCache)
 	}
 	s.connectionsHandler = connectionsHandler
-	connectionsRL := newKeyedLimiterFromBucket(config.RateLimitBucket{Limit: 10, Window: 60})
+	connectionsRL := s.newKeyedLimiterFromBucket(config.RateLimitBucket{Limit: 10, Window: 60})
 	mux.Handle("POST /api/agents/connect",
 		middleware.RateLimit(connectionsRL, ipKeyFn, 10)(e2e(http.HandlerFunc(connectionsHandler.RequestConnect))))
 	mux.Handle("GET /api/agents/connect/{id}/status", e2e(http.HandlerFunc(connectionsHandler.PollStatus)))
@@ -966,7 +986,7 @@ func (s *Server) routes() http.Handler {
 	// magic-link mode, where the invite claim proves email possession inline
 	// (invite security rule 2's carve-out); the seat cap mirrors auth.max_users.
 	connectionsHandler.ConfigureInviteEnroll(s.magicStore != nil, s.cfg.Auth.MaxUsers)
-	enrollRL := newKeyedLimiterFromBucket(config.RateLimitBucket{Limit: 10, Window: 60})
+	enrollRL := s.newKeyedLimiterFromBucket(config.RateLimitBucket{Limit: 10, Window: 60})
 	mux.Handle("POST /api/agents/enroll",
 		middleware.RateLimit(enrollRL, ipKeyFn, 10)(e2e(http.HandlerFunc(connectionsHandler.EnrollWithInvite))))
 
@@ -975,7 +995,7 @@ func (s *Server) routes() http.Handler {
 	// route absent for proxy-lite-disabled installs so the connect API
 	// surface matches main.
 	if s.cfg.ProxyLite.Enabled {
-		claimMintRL := newKeyedLimiterFromBucket(config.RateLimitBucket{Limit: 30, Window: 60})
+		claimMintRL := s.newKeyedLimiterFromBucket(config.RateLimitBucket{Limit: 30, Window: 60})
 		mux.Handle("POST /api/agents/connect/claim",
 			requireUser(middleware.RateLimit(claimMintRL, userKeyFn, 30)(http.HandlerFunc(connectionsHandler.MintClaim))))
 	}
@@ -1019,7 +1039,7 @@ func (s *Server) routes() http.Handler {
 	mux.Handle("POST /api/devices/{id}/push-to-start-token", requireDevice(e2e(http.HandlerFunc(devicesHandler.UpdatePushToStartToken))))
 	// Pairing and management routes (gated by mobile_pairing feature flag)
 	if s.features.MobilePairing {
-		devicesRL := newKeyedLimiterFromBucket(config.RateLimitBucket{Limit: 5, Window: 60})
+		devicesRL := s.newKeyedLimiterFromBucket(config.RateLimitBucket{Limit: 5, Window: 60})
 		mux.Handle("GET /api/devices/pair/info", user(devicesHandler.PairInfo))
 		mux.Handle("POST /api/devices/pair", user(devicesHandler.StartPairing))
 		mux.Handle("POST /api/devices/pair/complete",
@@ -1695,9 +1715,11 @@ func (s *Server) handleFeatures(w http.ResponseWriter, r *http.Request) {
 	if s.featuresHook != nil {
 		fs = s.featuresHook(r.Context(), middleware.UserFromContext(r.Context()), fs)
 	}
-	// API tokens are always available (no config gate); advertise them so
-	// the Terraform provider knows the endpoints exist.
-	fs.APITokens = true
+	// API tokens are gated by auth.disable_api_tokens (default enabled).
+	// Advertise the real state so the Terraform provider capability-negotiates:
+	// when disabled it fails fast with a clear capability error instead of
+	// hitting 404/401 on the token routes.
+	fs.APITokens = s.features.APITokens
 	// User management + invites (spec 04) are likewise unconditionally
 	// registered; advertise the capability so the Terraform provider does not
 	// wrongly block clawvisor_user (spec 06b finding M1).
@@ -1907,11 +1929,26 @@ func (s *Server) Run(ctx context.Context) error {
 	}
 }
 
-// newKeyedLimiterFromBucket creates a KeyedLimiter from a config bucket.
+// newKeyedLimiterFromBucket creates a keyed rate limiter from a config bucket.
 // Returns nil when the bucket has zero values (unconfigured).
-func newKeyedLimiterFromBucket(b config.RateLimitBucket) ratelimit.Limiter {
+//
+// When the server has a Redis client (multi-instance / horizontally-autoscaled
+// deployments such as Cloud Run), it returns a Redis-backed limiter whose
+// counter is shared across replicas, so per-IP brute-force caps stay at their
+// configured value instead of growing to cap*N with the replica count.
+// Otherwise (the Redis-less single-VM / local-dev default) it returns the
+// in-memory per-process limiter — behavior is byte-for-byte unchanged there.
+func (s *Server) newKeyedLimiterFromBucket(b config.RateLimitBucket) ratelimit.Limiter {
 	if b.Limit <= 0 || b.Window <= 0 {
 		return nil
+	}
+	if s.redisClient != nil {
+		return ratelimit.NewRedisKeyedLimiter(
+			s.redisClient,
+			float64(b.Limit)/float64(b.Window),
+			b.Limit,
+			time.Duration(b.Window)*time.Second,
+		)
 	}
 	return ratelimit.NewKeyedLimiter(
 		rate.Limit(float64(b.Limit)/float64(b.Window)),

--- a/internal/api/testutil_test.go
+++ b/internal/api/testutil_test.go
@@ -107,8 +107,10 @@ func newTestEnvWithConfig(t *testing.T, llmCfg config.LLMConfig, wrapVault func(
 	}
 
 	// Tests use password auth so Register/Login routes are available.
+	// APITokens mirrors the production default (enabled) so the token
+	// mint/manage routes are registered like a normal self-hosted install.
 	srv, err := api.New(cfg, st, v, jwtSvc, adapterReg, nil, llmCfg, nil,
-		api.WithFeatures(api.FeatureSet{PasswordAuth: true}),
+		api.WithFeatures(api.FeatureSet{PasswordAuth: true, APITokens: true}),
 	)
 	if err != nil {
 		t.Fatalf("api.New: %v", err)
@@ -171,7 +173,7 @@ func newCloudCompositionTestEnv(t *testing.T, orgIDForAgent ...func(context.Cont
 	}
 
 	srv, err := api.New(cfg, st, v, jwtSvc, adapters.NewRegistry(), nil, config.LLMConfig{}, nil,
-		api.WithFeatures(api.FeatureSet{PasswordAuth: true}),
+		api.WithFeatures(api.FeatureSet{PasswordAuth: true, APITokens: true}),
 		// WithOrgGov marks this as the cloud composition regardless of whether
 		// the resolver is nil (see orgGovConfigured).
 		api.WithOrgGov(orggov.Callbacks{}, resolver),

--- a/internal/govlocal/store.go
+++ b/internal/govlocal/store.go
@@ -27,6 +27,13 @@ const spendCacheTTL = 60 * time.Second
 // monthly) for spendCacheTTL. Plain mutex + timestamp — no new
 // dependency. Cached per window because the daily and monthly windows
 // have different bounds and roll over independently.
+//
+// This is a per-process cache, correct for the supported single-VM OSS
+// deployment. Under a hypothetical multi-instance OSS deployment each
+// replica keeps its own copy, so up to N replicas could each serve a
+// stale sum for up to spendCacheTTL — allowing up to N parallel TTL
+// windows of hard-cap slack before the caps reconverge. Single-instance
+// OSS sees no such slack; cloud enforces spend caps out of band.
 type spendCache struct {
 	mu      sync.Mutex
 	entries map[string]spendCacheEntry

--- a/pkg/clawvisor/bootstrap.go
+++ b/pkg/clawvisor/bootstrap.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/clawvisor/clawvisor/internal/api/middleware"
 	"github.com/clawvisor/clawvisor/internal/auth"
+	"github.com/clawvisor/clawvisor/pkg/config"
 	"github.com/clawvisor/clawvisor/pkg/store"
 )
 
@@ -23,6 +24,18 @@ const bootstrapTokenEnv = "CLAWVISOR_BOOTSTRAP_TOKEN"
 // The token exists in plaintext in the secret manager, the compose env on
 // disk, and Terraform state, so it must be short-lived by construction.
 const bootstrapTokenTTL = 24 * time.Hour
+
+// bootstrapAPITokenIfEnabled seeds the first-boot bootstrap token unless the
+// API-token subsystem is disabled instance-wide (auth.disable_api_tokens). When
+// disabled nothing is seeded even if CLAWVISOR_BOOTSTRAP_TOKEN is present, so a
+// locked-down deployment can never carry an instance-admin credential. When
+// enabled it delegates to bootstrapAPIToken unchanged.
+func bootstrapAPITokenIfEnabled(ctx context.Context, cfg *config.Config, st store.Store, logger *slog.Logger) error {
+	if cfg != nil && cfg.Auth.DisableAPITokens {
+		return nil
+	}
+	return bootstrapAPIToken(ctx, st, logger)
+}
 
 // bootstrapAPIToken seeds the first-boot bootstrap API token from
 // CLAWVISOR_BOOTSTRAP_TOKEN. It is idempotent across restarts and never

--- a/pkg/clawvisor/bootstrap_test.go
+++ b/pkg/clawvisor/bootstrap_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/clawvisor/clawvisor/internal/api/middleware"
 	"github.com/clawvisor/clawvisor/internal/auth"
+	"github.com/clawvisor/clawvisor/pkg/config"
 	"github.com/clawvisor/clawvisor/pkg/store"
 	"github.com/clawvisor/clawvisor/pkg/store/sqlite"
 )
@@ -150,6 +151,46 @@ func TestBootstrap_Unset(t *testing.T) {
 	list, _ := st.ListAPITokens(ctx)
 	if len(list) != 0 {
 		t.Fatalf("unset must not seed a row, got %d", len(list))
+	}
+}
+
+// TestBootstrap_SkippedWhenAPITokensDisabled: with auth.disable_api_tokens set
+// AND a valid CLAWVISOR_BOOTSTRAP_TOKEN present, the gate skips seeding entirely
+// so no instance-admin credential can exist on a locked-down deployment.
+func TestBootstrap_SkippedWhenAPITokensDisabled(t *testing.T) {
+	st, ctx := newBootstrapStore(t)
+	raw := genBootstrapToken(t)
+	t.Setenv(bootstrapTokenEnv, raw)
+
+	cfg := config.Default()
+	cfg.Auth.DisableAPITokens = true
+
+	if err := bootstrapAPITokenIfEnabled(ctx, cfg, st, quietLogger()); err != nil {
+		t.Fatalf("bootstrapAPITokenIfEnabled: %v", err)
+	}
+	if _, err := st.GetAPITokenByHash(ctx, auth.HashToken(raw)); err != store.ErrNotFound {
+		t.Fatalf("expected no seeded row when API tokens disabled (ErrNotFound), got %v", err)
+	}
+	list, _ := st.ListAPITokens(ctx)
+	if len(list) != 0 {
+		t.Fatalf("disabled API tokens must seed no row, got %d", len(list))
+	}
+}
+
+// TestBootstrap_SeededWhenAPITokensEnabled: the default (enabled) config still
+// seeds through the gate — the guard must not break the normal path.
+func TestBootstrap_SeededWhenAPITokensEnabled(t *testing.T) {
+	st, ctx := newBootstrapStore(t)
+	raw := genBootstrapToken(t)
+	t.Setenv(bootstrapTokenEnv, raw)
+
+	cfg := config.Default() // DisableAPITokens defaults false
+
+	if err := bootstrapAPITokenIfEnabled(ctx, cfg, st, quietLogger()); err != nil {
+		t.Fatalf("bootstrapAPITokenIfEnabled: %v", err)
+	}
+	if _, err := st.GetAPITokenByHash(ctx, auth.HashToken(raw)); err != nil {
+		t.Fatalf("expected bootstrap row seeded when enabled, got %v", err)
 	}
 }
 

--- a/pkg/clawvisor/defaults.go
+++ b/pkg/clawvisor/defaults.go
@@ -146,7 +146,10 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 	// ── Bootstrap API token (spec 05) ────────────────────────────────────────
 	// Seed the first-boot bootstrap token from CLAWVISOR_BOOTSTRAP_TOKEN if
 	// present. A malformed value is a misconfiguration → refuse to start.
-	if err := bootstrapAPIToken(ctx, st, logger); err != nil {
+	// Skipped entirely when API tokens are disabled (auth.disable_api_tokens):
+	// nothing is seeded even if CLAWVISOR_BOOTSTRAP_TOKEN is present, so no
+	// instance-admin credential can exist on a locked-down deployment.
+	if err := bootstrapAPITokenIfEnabled(ctx, cfg, st, logger); err != nil {
 		return nil, err
 	}
 
@@ -757,6 +760,11 @@ func computeFeatureSet(cfg *config.Config) FeatureSet {
 		RuntimeActivity:   runtimeSurface,
 		AgentLiveSessions: cfg.RuntimeProxy.Enabled || proxyLiteEnabled,
 		ServicePresets:    runtimeSurface && cfg.Features.ServicePresets,
+		// API tokens default ENABLED. Cloud sets auth.disable_api_tokens=true
+		// (via AUTH_DISABLE_API_TOKENS) to close the instance-admin-token
+		// takeover path; OSS self-hosted + the Terraform provider depend on
+		// bootstrap→mint→instance-admin, so the default must stay true.
+		APITokens: !cfg.Auth.DisableAPITokens,
 	}
 }
 

--- a/pkg/clawvisor/defaults_test.go
+++ b/pkg/clawvisor/defaults_test.go
@@ -98,3 +98,29 @@ func TestComputeFeatureSet_SecretVaultHiddenWithoutAnyProxy(t *testing.T) {
 		t.Errorf("SecretVault should be hidden when no proxy is enabled and no explicit opt-in")
 	}
 }
+
+// TestComputeFeatureSet_APITokensDefaultEnabled locks the HARD INVARIANT:
+// a default config leaves API tokens ENABLED (DisableAPITokens=false →
+// APITokens=true). OSS self-hosted and the Terraform provider depend on
+// bootstrap→mint→instance-admin; getting this default wrong breaks every
+// Terraform install.
+func TestComputeFeatureSet_APITokensDefaultEnabled(t *testing.T) {
+	cfg := config.Default()
+
+	got := computeFeatureSet(cfg)
+	if !got.APITokens {
+		t.Fatal("APITokens must default to true (DisableAPITokens defaults false); OSS + Terraform depend on it")
+	}
+}
+
+// TestComputeFeatureSet_APITokensDisabled proves the cloud lockdown seam:
+// setting auth.disable_api_tokens flips FeatureSet.APITokens to false.
+func TestComputeFeatureSet_APITokensDisabled(t *testing.T) {
+	cfg := config.Default()
+	cfg.Auth.DisableAPITokens = true
+
+	got := computeFeatureSet(cfg)
+	if got.APITokens {
+		t.Fatal("APITokens must be false when DisableAPITokens is set")
+	}
+}

--- a/pkg/clawvisor/options.go
+++ b/pkg/clawvisor/options.go
@@ -290,4 +290,10 @@ type FeatureSet struct {
 	RuntimeActivity   bool `json:"runtime_activity"`
 	AgentLiveSessions bool `json:"agent_live_sessions"`
 	ServicePresets    bool `json:"service_presets"`
+	// APITokens gates the long-lived scoped API-token subsystem (mint/manage
+	// routes, bootstrap seeding, cvat_ bearer acceptance). Defaults TRUE via
+	// computeFeatureSet (APITokens: !cfg.Auth.DisableAPITokens); the cloud
+	// layer can override it to false to close the instance-admin-token
+	// takeover path.
+	APITokens bool `json:"api_tokens"`
 }

--- a/pkg/clawvisor/run.go
+++ b/pkg/clawvisor/run.go
@@ -156,6 +156,7 @@ func RunWithContext(ctx context.Context, opts *ServerOptions) error {
 		RuntimeActivity:   opts.Features.RuntimeActivity,
 		AgentLiveSessions: opts.Features.AgentLiveSessions,
 		ServicePresets:    opts.Features.ServicePresets,
+		APITokens:         opts.Features.APITokens,
 	}))
 
 	apiOpts = append(apiOpts, api.WithExtraRoutes(func(mux *http.ServeMux, deps api.Dependencies) {
@@ -317,6 +318,7 @@ func RunWithContext(ctx context.Context, opts *ServerOptions) error {
 				RuntimeActivity:   fs.RuntimeActivity,
 				AgentLiveSessions: fs.AgentLiveSessions,
 				ServicePresets:    fs.ServicePresets,
+				APITokens:         fs.APITokens,
 			})
 			fs.MultiTenant = modified.MultiTenant
 			fs.EmailVerification = modified.EmailVerification
@@ -334,6 +336,7 @@ func RunWithContext(ctx context.Context, opts *ServerOptions) error {
 			fs.RuntimeActivity = modified.RuntimeActivity
 			fs.AgentLiveSessions = modified.AgentLiveSessions
 			fs.ServicePresets = modified.ServicePresets
+			fs.APITokens = modified.APITokens
 			return fs
 		}))
 	}
@@ -398,6 +401,9 @@ func RunWithContext(ctx context.Context, opts *ServerOptions) error {
 	}
 	if opts.Instruments != nil {
 		apiOpts = append(apiOpts, api.WithInstruments(opts.Instruments))
+	}
+	if opts.RedisClient != nil {
+		apiOpts = append(apiOpts, api.WithRedisClient(opts.RedisClient))
 	}
 
 	srv, err := api.New(

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -255,6 +255,16 @@ type AuthConfig struct {
 	// registers and becomes admin. Default false: open-registration behavior
 	// is unchanged (full backward compatibility). Env: AUTH_REQUIRE_INVITE.
 	RequireInvite bool `yaml:"require_invite"`
+	// DisableAPITokens, when true, turns OFF the long-lived scoped API-token
+	// subsystem instance-wide: the mint/manage routes are never registered
+	// (404), no bootstrap token is seeded, /api/features advertises
+	// api_tokens:false, and the auth middleware rejects any presented `cvat_`
+	// bearer with 401 WITHOUT consulting the token table — so a leaked or
+	// DB-planted instance-admin token is inert. Default false: OSS self-hosted
+	// and the Terraform provider depend on bootstrap→mint→instance-admin, so
+	// tokens stay ENABLED unless an operator (the cloud deployment) opts out.
+	// Env: AUTH_DISABLE_API_TOKENS.
+	DisableAPITokens bool `yaml:"disable_api_tokens"`
 }
 
 type ApprovalConfig struct {
@@ -785,6 +795,9 @@ func Load(path string) (*Config, error) {
 	}
 	if v := os.Getenv("AUTH_REQUIRE_INVITE"); v != "" {
 		cfg.Auth.RequireInvite = v == "1" || strings.EqualFold(v, "true")
+	}
+	if v := os.Getenv("AUTH_DISABLE_API_TOKENS"); v != "" {
+		cfg.Auth.DisableAPITokens = v == "1" || strings.EqualFold(v, "true")
 	}
 
 	if v := os.Getenv("CALLBACK_ALLOW_PRIVATE_CIDRS"); v != "" {


### PR DESCRIPTION
Stacks on the v1 product PR. Two hardening items:
- `auth.disable_api_tokens` (default-on; cloud sets it off): `/api/tokens` 404, no bootstrap seed, `api_tokens:false`, and cvat_ bearers rejected 401 on every instance-admin route (leaked/planted tokens inert). Terraform default unaffected.
- Redis-back the OSS IP rate limiters (wire the dead RedisKeyedLimiter) so per-IP brute-force caps are shared across replicas; in-memory fallback preserved for single-instance.

Base is the v1-product branch; retarget to `main` (or let GitHub auto-retarget) once PR-1 merges. Supersedes #624.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

