### PR TITLE
feat(web): dedicated SSO sign-in page (/login/sso)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -72,6 +72,7 @@ export default function App() {
 
   const unauthRedirect = authMode === 'magic_link' ? '/magic-link' : '/login'
   const passwordAuth = features?.password_auth ?? false
+  const ssoEnabled = features?.sso ?? false
 
   return (
     <ErrorBoundary>
@@ -95,7 +96,7 @@ export default function App() {
       <Route path="/verify-email" element={<VerifyEmail />} />
       <Route path="/waitlist" element={<Waitlist />} />
       <Route path="/accept-invite" element={<AcceptInvite />} />
-      <Route path="/login/sso" element={<SSOLogin />} />
+      {ssoEnabled && <Route path="/login/sso" element={<SSOLogin />} />}
       <Route path="/sso/complete" element={<SSOComplete />} />
       <Route path="/pricing" element={<Pricing />} />
       <Route

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,6 +2,7 @@ import { Component, type ErrorInfo, type ReactNode } from 'react'
 import { Navigate, Route, Routes, useLocation } from 'react-router-dom'
 import { useAuth } from './hooks/useAuth'
 import Login from './pages/Login'
+import SSOLogin from './pages/SSOLogin'
 import Register from './pages/Register'
 import MagicLink from './pages/MagicLink'
 import CheckEmail from './pages/CheckEmail'
@@ -94,6 +95,7 @@ export default function App() {
       <Route path="/verify-email" element={<VerifyEmail />} />
       <Route path="/waitlist" element={<Waitlist />} />
       <Route path="/accept-invite" element={<AcceptInvite />} />
+      <Route path="/login/sso" element={<SSOLogin />} />
       <Route path="/sso/complete" element={<SSOComplete />} />
       <Route path="/pricing" element={<Pricing />} />
       <Route

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -65,39 +65,6 @@ export default function Login() {
     }
   }
 
-  async function handleSSO() {
-    if (!email) {
-      setError('Enter your email above to sign in via SSO.')
-      return
-    }
-    setError(null)
-    setIsSubmitting(true)
-    try {
-      const res = await fetch(`/api/auth/sso/discover?email=${encodeURIComponent(email)}`)
-      // Discovery returns 200 with sso_available=false for the
-      // anti-enumeration "not configured" path. Anything other than 2xx is
-      // an actual transport/server failure and must not be conflated with
-      // "no SSO for this domain".
-      if (!res.ok) {
-        setError('SSO discovery is temporarily unavailable. Please try again.')
-        return
-      }
-      const data = await res.json()
-      if (data.sso_available && data.kickoff_url) {
-        // Note: any pending invite token is already persisted in
-        // localStorage by AcceptInvite, so it survives the IdP round-trip
-        // and SSOComplete picks it up via nextAfterAuth().
-        window.location.href = data.kickoff_url
-        return
-      }
-      setError('SSO is not configured for that email domain.')
-    } catch (err: any) {
-      setError(err?.message ?? 'SSO discovery failed.')
-    } finally {
-      setIsSubmitting(false)
-    }
-  }
-
   async function handleSubmit(e: FormEvent) {
     e.preventDefault()
     setError(null)
@@ -222,14 +189,9 @@ export default function Login() {
         {features?.sso && (
           <p className="text-center text-xs text-text-tertiary">
             Have SSO?{' '}
-            <button
-              type="button"
-              onClick={handleSSO}
-              disabled={isSubmitting}
-              className="text-brand hover:underline disabled:opacity-50"
-            >
+            <Link to="/login/sso" className="text-brand hover:underline">
               Sign in with SSO
-            </button>
+            </Link>
           </p>
         )}
 

--- a/web/src/pages/SSOLogin.tsx
+++ b/web/src/pages/SSOLogin.tsx
@@ -1,0 +1,91 @@
+import { useState, FormEvent } from 'react'
+import { Link } from 'react-router-dom'
+
+// Dedicated SSO sign-in page: collects the user's work email, discovers
+// whether their domain has SSO configured, and hands off to the IdP. Kept
+// separate from the username/password form so SSO users never touch it.
+export default function SSOLogin() {
+  const [email, setEmail] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    setError(null)
+    setIsSubmitting(true)
+    try {
+      const res = await fetch(`/api/auth/sso/discover?email=${encodeURIComponent(email)}`)
+      // Discovery returns 200 with sso_available=false for the
+      // anti-enumeration "not configured" path. Anything other than 2xx is
+      // an actual transport/server failure and must not be conflated with
+      // "no SSO for this domain".
+      if (!res.ok) {
+        setError('SSO discovery is temporarily unavailable. Please try again.')
+        return
+      }
+      const data = await res.json()
+      if (data.sso_available && data.kickoff_url) {
+        // Any pending invite token is already persisted in localStorage by
+        // AcceptInvite, so it survives the IdP round-trip and SSOComplete
+        // picks it up via nextAfterAuth().
+        window.location.href = data.kickoff_url
+        return
+      }
+      setError(
+        'Single sign-on is not configured for that email domain. Check the address, or sign in with your password instead.',
+      )
+    } catch (err: any) {
+      setError(err?.message ?? 'SSO discovery failed.')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-surface-0">
+      <div className="max-w-md w-full space-y-8 p-8 bg-surface-1 border border-border-default rounded-md">
+        <div>
+          <h1 className="text-3xl font-bold text-text-primary">Clawvisor</h1>
+          <h2 className="mt-2 text-lg text-text-secondary">Sign in with SSO</h2>
+          <p className="mt-1 text-sm text-text-tertiary">
+            Enter your work email and we&apos;ll redirect you to your organization&apos;s identity provider.
+          </p>
+        </div>
+
+        {error && <div className="p-3 bg-danger/10 text-danger rounded text-sm">{error}</div>}
+
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div>
+            <label htmlFor="sso-email" className="block text-sm font-medium text-text-secondary">
+              Work email
+            </label>
+            <input
+              id="sso-email"
+              type="email"
+              required
+              autoFocus
+              placeholder="you@company.com"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="mt-1 block w-full rounded border border-border-default bg-surface-0 text-text-primary px-3 py-2 focus:outline-none focus:ring-1 focus:ring-brand/30 focus:border-brand"
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={isSubmitting || !email}
+            className="w-full py-2 px-4 bg-brand text-surface-0 rounded font-medium hover:bg-brand-strong disabled:opacity-50"
+          >
+            {isSubmitting ? 'Looking up your organization...' : 'Continue'}
+          </button>
+        </form>
+
+        <div className="text-center text-sm text-text-secondary">
+          <Link to="/login" className="text-brand hover:underline">
+            Back to sign in
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/pages/SSOLogin.tsx
+++ b/web/src/pages/SSOLogin.tsx
@@ -31,6 +31,13 @@ export default function SSOLogin() {
         window.location.href = data.kickoff_url
         return
       }
+      if (data.sso_available) {
+        // The server says SSO is available but didn't return a kickoff URL —
+        // a server-side inconsistency, not a "not configured" domain. Surface
+        // it as a transient error so the user retries rather than giving up.
+        setError('Single sign-on is temporarily unavailable for your organization. Please try again.')
+        return
+      }
       setError(
         'Single sign-on is not configured for that email domain. Check the address, or sign in with your password instead.',
       )


### PR DESCRIPTION
Adds a standalone **Sign in with SSO** page: collects the user's work email on its own page (instead of reusing the username/password form's email field), calls `GET /api/auth/sso/discover`, and redirects to the returned `kickoff_url` (SAML or OIDC — the OIDC kickoff is enabled by the companion cloud PR).

- New `web/src/pages/SSOLogin.tsx` (+ `/login/sso` route)
- `Login.tsx`: "Sign in with SSO" is now a link to the new page; the inline `handleSSO` is removed
- Preserves the invite-token passthrough (localStorage → SSOComplete) and the anti-enumeration error copy

`tsc -b && vite build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

