### PR TITLE
fix(services): key connect flow off org self-service flag

### DIFF
--- a/web/src/pages/Services.tsx
+++ b/web/src/pages/Services.tsx
@@ -1980,6 +1980,17 @@ export default function Services() {
   const qc = useQueryClient()
   const { features, currentOrg } = useAuth()
   const orgId = currentOrg?.id
+  // The connect-service flow is a personal self-service action. In org mode it
+  // is surfaced only when the org allows member self-service (default true);
+  // otherwise members get the read-only org accounts view. Personal mode (no
+  // org) always allows it. While the setting loads, default to allowing — it
+  // matches the server default and the common case. Mirrors Agents.tsx.
+  const { data: orgSettings } = useQuery({
+    queryKey: ['org-settings', orgId],
+    queryFn: () => api.orgs.settings.get(orgId!),
+    enabled: !!orgId,
+  })
+  const canSelfServe = !orgId || (orgSettings?.member_self_service ?? true)
   const secretVaultUI = !orgId && !!features?.secret_vault
   const proxyLiteUI = !orgId && !!features?.proxy_lite
   const legacySecretVaultUI = secretVaultUI && !proxyLiteUI
@@ -1999,7 +2010,7 @@ export default function Services() {
   const { data, isLoading, error } = useQuery({
     queryKey: ['services'],
     queryFn: () => api.services.list(),
-    enabled: !orgId,
+    enabled: canSelfServe,
   })
 
   // In single-tenant mode, check if Google/Microsoft OAuth credentials are configured.
@@ -2047,7 +2058,10 @@ export default function Services() {
     return () => window.removeEventListener('message', handler)
   }, [qc])
 
-  if (orgId) {
+  // Org members without self-service get the read-only org accounts view; the
+  // connect-service flow below stays hidden for them. Self-serving members fall
+  // through to the personal connect flow, same as personal mode.
+  if (orgId && !canSelfServe) {
     return <OrgServicesView orgId={orgId} orgName={currentOrg!.name} />
   }
 


### PR DESCRIPTION
## What

The Services page hid the personal **connect-service flow** for *any* org member, early-returning to the read-only `OrgServicesView`. This re-keys that off the org's `member_self_service` setting.

## Behavior

| Context | Before | After |
|---|---|---|
| Personal (no org) | connect flow shown | connect flow shown |
| Org member, self-service **on** (default) | connect flow **hidden** | connect flow **shown** |
| Org member, self-service **off** | read-only org accounts view | read-only org accounts view |

## How

- Adds an `org-settings` query + `canSelfServe = !orgId || (orgSettings?.member_self_service ?? true)` derivation — the same pattern already used in `Agents.tsx`.
- Personal services query now `enabled: canSelfServe` (was `!orgId`).
- Early return to `OrgServicesView` now gated on `orgId && !canSelfServe` (was `orgId`).
- Personal-only vault sections stay gated on `!orgId`, so they remain hidden for org members.

Matches the backend contract (`member_self_service` gates whether members may run personal connect flows; disabled → `403 SELF_SERVICE_DISABLED`). Defaults to allowing while the setting loads, matching the server default.

## Test

`npx tsc --noEmit` passes.

## Note

With self-service on, org members now see the personal connect page *instead of* the org shared-accounts list. If both should show, this can be made additive as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

