### PR TITLE
feat(dashboard): expose Governance link in the org sidebar

### DIFF
--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -49,11 +49,11 @@ const billingNavItem = { to: '/dashboard/billing', label: 'Billing', end: undefi
 const fleetNavItem = { to: '/dashboard/fleet', label: 'Fleet', end: undefined as boolean | undefined, icon: <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87"/><path d="M16 3.13a4 4 0 010 7.75"/></svg> }
 
 // Org sidebar — pared down while we figure out which surfaces customers
-// will actually self-serve. Governance, notifications, custom adapters,
-// and MCP servers are temporarily admin-managed via the cmd/admin tool,
-// so they're hidden from the sidebar. Their /dashboard/org/{governance,
-// notifications,adapters,mcp-servers} routes remain wired in case of
-// bookmarked links.
+// will actually self-serve. Notifications, custom adapters, and MCP servers
+// are temporarily admin-managed via the cmd/admin tool, so they're hidden
+// from the sidebar; their /dashboard/org/{notifications,adapters,mcp-servers}
+// routes remain wired in case of bookmarked links. Governance is self-serve
+// and appears in orgNavItems below.
 //
 // SSO is the exception: both its sidebar entry AND its route are gone.
 // Bookmarked /dashboard/org/sso falls through the wildcard <Route> at
@@ -64,6 +64,7 @@ const orgNavItems = [
   { to: '/dashboard/org', label: 'Organization', end: true, icon: <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87"/><path d="M16 3.13a4 4 0 010 7.75"/></svg> },
   { to: '/dashboard/org/members', label: 'Members', icon: <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M16 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="8.5" cy="7" r="4"/><path d="M20 8v6M23 11h-6"/></svg> },
   { to: '/dashboard/org/teams', label: 'Teams', icon: <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><circle cx="17" cy="11" r="3"/></svg> },
+  { to: '/dashboard/org/governance', label: 'Governance', icon: <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg> },
 ]
 
 export default function Dashboard() {


### PR DESCRIPTION
## What

Adds the **Governance** entry to the org sidebar (`orgNavItems`). The `/dashboard/org/governance` route already exists on `main` and is gated on `features?.teams` — only the sidebar link was missing, so org members had to know the URL to reach it. This adds the link under the same `features?.teams` gate as the route and the rest of the org nav, and updates the pared-down-sidebar comment (which still listed Governance among the hidden surfaces).

## Why a separate PR

This is the **minimal variation of #638** — the one-line link exposure, on its own. It deliberately does **not** include #638's `RequireAuth` features-load gate (`App.tsx` + `useAuth.tsx`):

- Clicking Governance from the already-loaded dashboard has `features` in hand, so there's no redirect race — the link just works.
- #638's gate fix targets a different case (a direct deep-link/refresh to a `features?.teams`-gated URL redirecting before flags load). That's still worthwhile and stays in #638.

So this can merge on its own to surface the link immediately; #638 remains the home for the routing-race hardening.

## Diff

`web/src/pages/Dashboard.tsx` only — one nav item + a comment correction.

## Test

Change is byte-identical to the Dashboard.tsx hunk in #638, which passed `tsc --noEmit` clean. Additive object literal matching its sibling nav items; `Governance` is already imported.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

