### PR TITLE
fix(postgres): keep large migrations out of startup

### DIFF
--- a/pkg/store/postgres/migration_integration_test.go
+++ b/pkg/store/postgres/migration_integration_test.go
@@ -1,0 +1,120 @@
+package postgres
+
+import (
+	"context"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// TestMigrationsAgainstLivePostgres exercises the real startup runner against a
+// live server. The unit guards in migration_safety_test.go only inspect SQL
+// text; this covers the behaviour that text cannot prove -- that concurrent
+// servers do not race the same DDL, and that migration 062 lands as a
+// metadata-only change rather than a table rewrite.
+//
+// Opt in by pointing CLAWVISOR_TEST_POSTGRES_DSN at a scratch database:
+//
+//	docker run -d --name pg -e POSTGRES_PASSWORD=pw -e POSTGRES_DB=cv -p 5432:5432 postgres:15
+//	CLAWVISOR_TEST_POSTGRES_DSN='postgres://postgres:pw@localhost:5432/cv?sslmode=disable' \
+//	    go test ./pkg/store/postgres/ -run TestMigrationsAgainstLivePostgres
+//
+// The target database must be empty; the test applies every migration to it.
+func TestMigrationsAgainstLivePostgres(t *testing.T) {
+	dsn := os.Getenv("CLAWVISOR_TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("set CLAWVISOR_TEST_POSTGRES_DSN to run the live-Postgres migration exercise")
+	}
+	ctx := context.Background()
+
+	// Cloud starts multiple services against one database. Without the
+	// advisory lock these racers take the same schema_migrations snapshot and
+	// collide on identical DDL, which surfaces in production as a boot
+	// crashloop because a failed migration exits the process.
+	const racers = 4
+	var wg sync.WaitGroup
+	errs := make([]error, racers)
+	for i := range racers {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			pool, err := pgxpool.New(ctx, dsn)
+			if err != nil {
+				errs[n] = err
+				return
+			}
+			defer pool.Close()
+			errs[n] = runMigrations(ctx, pool)
+		}(i)
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("concurrent migration run %d failed: %v", i, err)
+		}
+	}
+
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer pool.Close()
+
+	t.Run("062 adds actor_email as a metadata-only column", func(t *testing.T) {
+		var nullable, def string
+		err := pool.QueryRow(ctx, `
+			SELECT is_nullable, COALESCE(column_default, '')
+			FROM information_schema.columns
+			WHERE table_name = 'audit_log' AND column_name = 'actor_email'
+		`).Scan(&nullable, &def)
+		if err != nil {
+			t.Fatalf("actor_email column missing: %v", err)
+		}
+		if nullable != "NO" {
+			t.Errorf("actor_email is_nullable = %q, want NO", nullable)
+		}
+		if def == "" {
+			t.Error("actor_email has no default; ADD COLUMN would rewrite the table on PG<11 semantics")
+		}
+	})
+
+	t.Run("audit_log.user_id survives user deletion", func(t *testing.T) {
+		var nullable string
+		if err := pool.QueryRow(ctx, `
+			SELECT is_nullable FROM information_schema.columns
+			WHERE table_name = 'audit_log' AND column_name = 'user_id'
+		`).Scan(&nullable); err != nil {
+			t.Fatalf("query user_id: %v", err)
+		}
+		if nullable != "YES" {
+			t.Errorf("user_id is_nullable = %q, want YES so ON DELETE SET NULL can retain history", nullable)
+		}
+	})
+
+	t.Run("replacement FK is installed NOT VALID", func(t *testing.T) {
+		var validated bool
+		if err := pool.QueryRow(ctx, `
+			SELECT convalidated FROM pg_constraint WHERE conname = 'audit_log_user_id_fkey'
+		`).Scan(&validated); err != nil {
+			t.Fatalf("query constraint: %v", err)
+		}
+		if validated {
+			t.Error("audit_log_user_id_fkey was validated at startup; that scans the whole table " +
+				"under a DDL lock. It must ship NOT VALID and be validated by the post-062 script.")
+		}
+	})
+
+	t.Run("large audit index is deferred out of startup", func(t *testing.T) {
+		var n int
+		if err := pool.QueryRow(ctx,
+			`SELECT count(*) FROM pg_indexes WHERE indexname = 'idx_audit_time'`).Scan(&n); err != nil {
+			t.Fatalf("query indexes: %v", err)
+		}
+		if n != 0 {
+			t.Error("idx_audit_time was built by a startup migration; it must be created " +
+				"CONCURRENTLY by scripts/postgres/post-062-backfill.sql")
+		}
+	})
+}

--- a/pkg/store/postgres/migration_safety_general_test.go
+++ b/pkg/store/postgres/migration_safety_general_test.go
@@ -1,0 +1,130 @@
+package postgres
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// largeTables are append-only tables whose row count grows with request
+// traffic rather than with the number of users, so on any long-running
+// deployment they can reach millions of rows and multiple gigabytes. Any
+// startup migration that rewrites one of them, or builds an index over one
+// non-concurrently, holds a lock for the duration and takes the deployment
+// down with it.
+var largeTables = []string{"audit_log", "gateway_request_log"}
+
+// grandfatheredMigrations already shipped and are recorded in production's
+// schema_migrations. Rewriting them would not un-run them, and renaming a
+// file makes the runner re-apply it, so they are pinned here instead. Do NOT
+// add to this list to silence a failure on a new migration — fix the
+// migration. See scripts/postgres/post-062-backfill.sql for the pattern to
+// follow when large-table data work is genuinely required.
+var grandfatheredMigrations = map[string]string{
+	"003_audit.sql":                            "creates audit_log and its indexes; table is empty at creation",
+	"026_request_log.sql":                      "creates gateway_request_log and its indexes; table is empty at creation",
+	"028_audit_request_id_user_unique.sql":     "shipped before audit_log grew large",
+	"029_indexes.sql":                          "shipped before the tables grew large",
+	"038_audit_runtime_expression_indexes.sql": "shipped before audit_log grew large",
+	"044_symmetric_dedup_scope.sql":            "shipped before audit_log grew large",
+	"053_audit_dedup_key.sql":                  "shipped before audit_log grew large",
+}
+
+// normalizeSQL strips comments and collapses whitespace so multi-line
+// statements match the same patterns as single-line ones.
+func normalizeSQL(raw string) string {
+	var active []string
+	for _, line := range strings.Split(raw, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "--") {
+			continue
+		}
+		if i := strings.Index(line, "--"); i >= 0 {
+			line = line[:i]
+		}
+		active = append(active, line)
+	}
+	return regexp.MustCompile(`\s+`).ReplaceAllString(strings.Join(active, " "), " ")
+}
+
+// TestNoUnboundedLargeTableWorkInStartupMigrations scans every migration --
+// not just the two that caused the incident -- so a future migration cannot
+// reintroduce the same failure mode. The startup runner wraps each file in a
+// single transaction and the server exits non-zero if it fails, so anything
+// slow here is downtime, not degradation.
+func TestNoUnboundedLargeTableWorkInStartupMigrations(t *testing.T) {
+	entries, err := migrationsFS.ReadDir("migrations")
+	if err != nil {
+		t.Fatalf("read migrations dir: %v", err)
+	}
+
+	tableAlt := strings.Join(largeTables, "|")
+	checks := []struct {
+		pattern *regexp.Regexp
+		// okIfContains exempts a match whose statement text contains this
+		// substring, expressing "this shape is fine as long as it is qualified".
+		okIfContains string
+		why          string
+	}{
+		{
+			pattern: regexp.MustCompile(`(?i)\bUPDATE\s+(` + tableAlt + `)\b`),
+			why: "rewrites every row of a large table inside the startup transaction; " +
+				"defer it to a batched script like scripts/postgres/post-062-backfill.sql",
+		},
+		{
+			pattern:      regexp.MustCompile(`(?i)\bCREATE\s+(?:UNIQUE\s+)?INDEX\s+[^;]*?\bON\s+(?:public\.)?(?:` + tableAlt + `)\b[^;]*;`),
+			okIfContains: "CONCURRENTLY",
+			why: "builds an index over a large table; CREATE INDEX cannot run CONCURRENTLY " +
+				"inside the transactional runner, so move it to the post-migration script",
+		},
+		{
+			pattern:      regexp.MustCompile(`(?i)ALTER\s+TABLE\s+(?:public\.)?(?:` + tableAlt + `)\s+ADD\s+CONSTRAINT\b[^;]*;`),
+			okIfContains: "NOT VALID",
+			why: "adds a constraint to a large table without NOT VALID, forcing a full " +
+				"validation scan while holding the DDL lock; add NOT VALID and " +
+				"VALIDATE CONSTRAINT separately",
+		},
+	}
+
+	var names []string
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".sql") {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			if why, ok := grandfatheredMigrations[name]; ok {
+				t.Skipf("grandfathered: %s", why)
+			}
+			data, err := migrationsFS.ReadFile("migrations/" + name)
+			if err != nil {
+				t.Fatalf("read %s: %v", name, err)
+			}
+			sql := normalizeSQL(string(data))
+			for _, c := range checks {
+				for _, m := range c.pattern.FindAllString(sql, -1) {
+					if c.okIfContains != "" && strings.Contains(strings.ToUpper(m), c.okIfContains) {
+						continue
+					}
+					t.Errorf("%s is not startup-safe.\n  statement: %s\n  reason: %s",
+						name, strings.TrimSpace(m), c.why)
+				}
+			}
+		})
+	}
+}
+
+// TestGrandfatherListIsAccurate keeps the allowlist honest: an entry that no
+// longer corresponds to a real file is stale and should be removed, so the
+// list cannot quietly accumulate dead exemptions.
+func TestGrandfatherListIsAccurate(t *testing.T) {
+	for name := range grandfatheredMigrations {
+		if _, err := migrationsFS.ReadFile("migrations/" + name); err != nil {
+			t.Errorf("grandfathered migration %q no longer exists: %v", name, err)
+		}
+	}
+}

--- a/pkg/store/postgres/migration_safety_general_test.go
+++ b/pkg/store/postgres/migration_safety_general_test.go
@@ -31,21 +31,89 @@ var grandfatheredMigrations = map[string]string{
 	"053_audit_dedup_key.sql":                  "shipped before audit_log grew large",
 }
 
-// normalizeSQL strips comments and collapses whitespace so multi-line
-// statements match the same patterns as single-line ones.
+var whitespaceRun = regexp.MustCompile(`\s+`)
+
+// normalizeSQL strips -- comments and collapses whitespace so multi-line
+// statements match the same patterns as single-line ones. Shared by both
+// migration guards so they agree on what counts as executable SQL — a checker
+// that reads comments differently from its sibling produces findings that
+// disagree on the same file.
+//
+// Comment stripping is literal-aware: a value like 'US -- New York' must not
+// truncate the statement, because a truncated statement can drop the very
+// keyword being searched for and turn a violation into a silent pass. Quote
+// state resets per line, which is deliberate — an unbalanced quote leaves the
+// rest of that line looking quoted, so a trailing comment is retained rather
+// than dropped. That errs toward a false positive (a failing guard someone
+// investigates) instead of a false negative (a migration that slips through).
 func normalizeSQL(raw string) string {
 	var active []string
 	for _, line := range strings.Split(raw, "\n") {
-		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "--") {
-			continue
-		}
-		if i := strings.Index(line, "--"); i >= 0 {
-			line = line[:i]
-		}
-		active = append(active, line)
+		active = append(active, stripLineComment(line))
 	}
-	return regexp.MustCompile(`\s+`).ReplaceAllString(strings.Join(active, " "), " ")
+	return whitespaceRun.ReplaceAllString(strings.Join(active, " "), " ")
+}
+
+// stripLineComment truncates line at the first -- that is not inside a
+// single-quoted literal. An escaped quote inside a literal is written as two
+// consecutive apostrophes, which toggle the flag twice and so need no special
+// handling.
+func stripLineComment(line string) string {
+	inQuote := false
+	for i := 0; i < len(line)-1; i++ {
+		switch {
+		case line[i] == '\'':
+			inQuote = !inQuote
+		case !inQuote && line[i] == '-' && line[i+1] == '-':
+			return line[:i]
+		}
+	}
+	return line
+}
+
+// largeTableCheck is one dangerous statement shape, plus the escape hatch that
+// makes that shape acceptable.
+type largeTableCheck struct {
+	pattern *regexp.Regexp
+	// okIfContains exempts a match whose statement text contains this
+	// substring, expressing "this shape is fine as long as it is qualified".
+	okIfContains string
+	why          string
+}
+
+// largeTableChecks builds the guard patterns. Extracted from the scanning test
+// so TestGuardCatchesEvasions can exercise the same patterns the real scan
+// uses — a guard verified against a different regex than it ships is not
+// verified at all.
+func largeTableChecks() []largeTableCheck {
+	// tableRef spells the ways a migration can name one of the large tables:
+	// bare, schema-qualified, ONLY-prefixed, or double-quoted. Every check
+	// composes this one fragment rather than spelling it out, because when the
+	// patterns each carried their own copy they drifted — the UPDATE check
+	// lacked the public. prefix the others had, so UPDATE public.audit_log
+	// passed the guard clean.
+	tableRef := `(?:ONLY\s+)?(?:"?public"?\.)?"?(?:` + strings.Join(largeTables, "|") + `)"?`
+
+	return []largeTableCheck{
+		{
+			pattern: regexp.MustCompile(`(?i)\bUPDATE\s+` + tableRef + `\b`),
+			why: "rewrites every row of a large table inside the startup transaction; " +
+				"defer it to a batched script like scripts/postgres/post-062-backfill.sql",
+		},
+		{
+			pattern:      regexp.MustCompile(`(?i)\bCREATE\s+(?:UNIQUE\s+)?INDEX\s+[^;]*?\bON\s+` + tableRef + `\b[^;]*;`),
+			okIfContains: "CONCURRENTLY",
+			why: "builds an index over a large table; CREATE INDEX cannot run CONCURRENTLY " +
+				"inside the transactional runner, so move it to the post-migration script",
+		},
+		{
+			pattern:      regexp.MustCompile(`(?i)ALTER\s+TABLE\s+` + tableRef + `\s+ADD\s+CONSTRAINT\b[^;]*;`),
+			okIfContains: "NOT VALID",
+			why: "adds a constraint to a large table without NOT VALID, forcing a full " +
+				"validation scan while holding the DDL lock; add NOT VALID and " +
+				"VALIDATE CONSTRAINT separately",
+		},
+	}
 }
 
 // TestNoUnboundedLargeTableWorkInStartupMigrations scans every migration --
@@ -58,34 +126,7 @@ func TestNoUnboundedLargeTableWorkInStartupMigrations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read migrations dir: %v", err)
 	}
-
-	tableAlt := strings.Join(largeTables, "|")
-	checks := []struct {
-		pattern *regexp.Regexp
-		// okIfContains exempts a match whose statement text contains this
-		// substring, expressing "this shape is fine as long as it is qualified".
-		okIfContains string
-		why          string
-	}{
-		{
-			pattern: regexp.MustCompile(`(?i)\bUPDATE\s+(` + tableAlt + `)\b`),
-			why: "rewrites every row of a large table inside the startup transaction; " +
-				"defer it to a batched script like scripts/postgres/post-062-backfill.sql",
-		},
-		{
-			pattern:      regexp.MustCompile(`(?i)\bCREATE\s+(?:UNIQUE\s+)?INDEX\s+[^;]*?\bON\s+(?:public\.)?(?:` + tableAlt + `)\b[^;]*;`),
-			okIfContains: "CONCURRENTLY",
-			why: "builds an index over a large table; CREATE INDEX cannot run CONCURRENTLY " +
-				"inside the transactional runner, so move it to the post-migration script",
-		},
-		{
-			pattern:      regexp.MustCompile(`(?i)ALTER\s+TABLE\s+(?:public\.)?(?:` + tableAlt + `)\s+ADD\s+CONSTRAINT\b[^;]*;`),
-			okIfContains: "NOT VALID",
-			why: "adds a constraint to a large table without NOT VALID, forcing a full " +
-				"validation scan while holding the DDL lock; add NOT VALID and " +
-				"VALIDATE CONSTRAINT separately",
-		},
-	}
+	checks := largeTableChecks()
 
 	var names []string
 	for _, e := range entries {
@@ -113,6 +154,69 @@ func TestNoUnboundedLargeTableWorkInStartupMigrations(t *testing.T) {
 					t.Errorf("%s is not startup-safe.\n  statement: %s\n  reason: %s",
 						name, strings.TrimSpace(m), c.why)
 				}
+			}
+		})
+	}
+}
+
+// TestGuardCatchesEvasions pins the spellings a dangerous statement can take.
+// The guard's whole value is catching a migration nobody reviewed carefully,
+// so a gap here is silent: the scan passes and the migration ships. Each
+// wantCaught case below is a real evasion that slipped through at some point
+// or plausibly could.
+func TestGuardCatchesEvasions(t *testing.T) {
+	checks := largeTableChecks()
+	caught := func(sql string) bool {
+		norm := normalizeSQL(sql)
+		for _, c := range checks {
+			for _, m := range c.pattern.FindAllString(norm, -1) {
+				if c.okIfContains != "" && strings.Contains(strings.ToUpper(m), c.okIfContains) {
+					continue
+				}
+				return true
+			}
+		}
+		return false
+	}
+
+	wantCaught := map[string]string{
+		"bare":                 `UPDATE audit_log SET actor_email = '';`,
+		"schema qualified":     `UPDATE public.audit_log SET actor_email = '';`,
+		"ONLY prefixed":        `UPDATE ONLY audit_log SET actor_email = '';`,
+		"quoted identifier":    `UPDATE "audit_log" SET actor_email = '';`,
+		"lowercase keywords":   `update audit_log set actor_email = '';`,
+		"mixed case":           `UpDaTe Public.Audit_Log SET actor_email = '';`,
+		"newline before table": "UPDATE\n    audit_log\n    SET actor_email = '';",
+		"other large table":    `UPDATE gateway_request_log SET reason = '';`,
+		"non-concurrent index": `CREATE INDEX idx_x ON audit_log(timestamp DESC);`,
+		"index schema qual":    `CREATE INDEX idx_x ON public.audit_log(timestamp);`,
+		"fk without NOT VALID": `ALTER TABLE audit_log ADD CONSTRAINT fk FOREIGN KEY (user_id) REFERENCES users(id);`,
+		// A -- inside a literal must not truncate the statement and hide the
+		// UPDATE that follows it on the same line.
+		"comment inside literal": `INSERT INTO t VALUES ('US -- NY'); UPDATE audit_log SET actor_email = '';`,
+	}
+	for name, sql := range wantCaught {
+		t.Run("caught/"+name, func(t *testing.T) {
+			if !caught(sql) {
+				t.Errorf("guard missed a dangerous statement:\n  %s", sql)
+			}
+		})
+	}
+
+	wantAllowed := map[string]string{
+		"concurrent index":     `CREATE INDEX CONCURRENTLY idx_x ON audit_log(timestamp DESC);`,
+		"fk with NOT VALID":    `ALTER TABLE audit_log ADD CONSTRAINT fk FOREIGN KEY (user_id) REFERENCES users(id) NOT VALID;`,
+		"small table update":   `UPDATE users SET verified_at = created_at WHERE verified_at IS NULL;`,
+		"small table index":    `CREATE INDEX idx_c ON llm_request_cost(timestamp);`,
+		"add column":           `ALTER TABLE audit_log ADD COLUMN actor_email TEXT NOT NULL DEFAULT '';`,
+		"validate constraint":  `ALTER TABLE audit_log VALIDATE CONSTRAINT audit_log_user_id_fkey;`,
+		"commented-out update": `-- UPDATE audit_log SET actor_email = '';`,
+		"trailing comment":     `SELECT 1; -- UPDATE audit_log is deferred to the backfill script`,
+	}
+	for name, sql := range wantAllowed {
+		t.Run("allowed/"+name, func(t *testing.T) {
+			if caught(sql) {
+				t.Errorf("guard falsely flagged a safe statement:\n  %s", sql)
 			}
 		})
 	}

--- a/pkg/store/postgres/migration_safety_test.go
+++ b/pkg/store/postgres/migration_safety_test.go
@@ -1,0 +1,68 @@
+package postgres
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestLargeTableMigrationsStayStartupSafe guards against putting unbounded
+// production data work back into the transactional startup runner. These
+// statements caused Cloud Run startup timeouts and held audit_log unavailable
+// while millions of rows were rewritten.
+func TestLargeTableMigrationsStayStartupSafe(t *testing.T) {
+	tests := []struct {
+		name       string
+		migration  string
+		required   []string
+		prohibited []string
+	}{
+		{
+			name:      "actor retention defers historical backfill",
+			migration: "migrations/062_audit_actor_retain.sql",
+			required: []string{
+				"SET LOCAL lock_timeout",
+				"ON DELETE SET NULL NOT VALID",
+			},
+			prohibited: []string{
+				"UPDATE audit_log",
+				"UPDATE llm_request_cost",
+			},
+		},
+		{
+			name:      "large audit index is not built at startup",
+			migration: "migrations/064_admin_visibility_indexes.sql",
+			prohibited: []string{
+				"CREATE INDEX IF NOT EXISTS idx_audit_time",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := migrationsFS.ReadFile(tt.migration)
+			if err != nil {
+				t.Fatalf("read %s: %v", tt.migration, err)
+			}
+			// Operator instructions in comments intentionally show the deferred
+			// statements. Only inspect executable lines.
+			var activeLines []string
+			for _, line := range strings.Split(string(data), "\n") {
+				if strings.HasPrefix(strings.TrimSpace(line), "--") {
+					continue
+				}
+				activeLines = append(activeLines, line)
+			}
+			sql := strings.Join(activeLines, "\n")
+			for _, required := range tt.required {
+				if !strings.Contains(sql, required) {
+					t.Errorf("%s must contain %q", tt.migration, required)
+				}
+			}
+			for _, prohibited := range tt.prohibited {
+				if strings.Contains(sql, prohibited) {
+					t.Errorf("%s must not contain %q", tt.migration, prohibited)
+				}
+			}
+		})
+	}
+}

--- a/pkg/store/postgres/migration_safety_test.go
+++ b/pkg/store/postgres/migration_safety_test.go
@@ -44,22 +44,23 @@ func TestLargeTableMigrationsStayStartupSafe(t *testing.T) {
 				t.Fatalf("read %s: %v", tt.migration, err)
 			}
 			// Operator instructions in comments intentionally show the deferred
-			// statements. Only inspect executable lines.
-			var activeLines []string
-			for _, line := range strings.Split(string(data), "\n") {
-				if strings.HasPrefix(strings.TrimSpace(line), "--") {
-					continue
-				}
-				activeLines = append(activeLines, line)
-			}
-			sql := strings.Join(activeLines, "\n")
+			// statements, so only executable SQL is inspected. Uses the same
+			// normalizeSQL as the general guard — when this test stripped
+			// comments its own way it disagreed with its sibling about which
+			// bytes were executable, including on inline trailing comments.
+			//
+			// Compared case-insensitively: SQL keywords are, so a migration
+			// written as `update audit_log` would otherwise sail past a
+			// prohibition spelled `UPDATE audit_log`. Needles below are
+			// uppercase-normalized too, so their casing here is cosmetic.
+			sql := strings.ToUpper(normalizeSQL(string(data)))
 			for _, required := range tt.required {
-				if !strings.Contains(sql, required) {
+				if !strings.Contains(sql, strings.ToUpper(required)) {
 					t.Errorf("%s must contain %q", tt.migration, required)
 				}
 			}
 			for _, prohibited := range tt.prohibited {
-				if strings.Contains(sql, prohibited) {
+				if strings.Contains(sql, strings.ToUpper(prohibited)) {
 					t.Errorf("%s must not contain %q", tt.migration, prohibited)
 				}
 			}

--- a/pkg/store/postgres/migrations/062_audit_actor_retain.sql
+++ b/pkg/store/postgres/migrations/062_audit_actor_retain.sql
@@ -1,5 +1,13 @@
 -- 04 flat-team: audit/cost survive user deletion (PRD §15.4, Q4).
--- Postgres can alter the FK in place (no table recreate needed).
+--
+-- STARTUP-SAFETY: this migration runs while the server is starting. Keep the
+-- transaction to metadata-only changes and fail quickly instead of waiting
+-- behind application traffic with an AccessExclusiveLock queued. In
+-- particular, DO NOT backfill actor_email here: production audit_log tables
+-- can contain millions of rows, and rewriting them in this transaction holds
+-- the DDL lock until the entire update commits.
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '30s';
 --
 -- Flip audit_log.user_id from ON DELETE CASCADE to ON DELETE SET NULL,
 -- make it nullable, and add a server-derived NOT-NULL actor_email so a
@@ -23,12 +31,11 @@ END $$;
 
 ALTER TABLE audit_log ALTER COLUMN user_id DROP NOT NULL;
 ALTER TABLE audit_log ADD CONSTRAINT audit_log_user_id_fkey
-    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL;
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL NOT VALID;
 
+-- On Postgres 11+, adding a column with a constant default is metadata-only.
+-- Existing rows intentionally retain ''. New writes always supply the
+-- server-derived email. Historical rows are filled by the separate resumable
+-- backfill, outside the startup migration transaction.
 ALTER TABLE audit_log ADD COLUMN actor_email TEXT NOT NULL DEFAULT '';
-UPDATE audit_log SET actor_email =
-    COALESCE((SELECT email FROM users u WHERE u.id = audit_log.user_id), '(deleted-user)');
-
 ALTER TABLE llm_request_cost ADD COLUMN actor_email TEXT NOT NULL DEFAULT '';
-UPDATE llm_request_cost SET actor_email =
-    COALESCE((SELECT email FROM users u WHERE u.id = llm_request_cost.user_id), '(deleted-user)');

--- a/pkg/store/postgres/migrations/064_admin_visibility_indexes.sql
+++ b/pkg/store/postgres/migrations/064_admin_visibility_indexes.sql
@@ -6,5 +6,15 @@
 -- the admin-only ListAllAuditEvents ordering and the InstanceCostSummary
 -- time-window rollup. Members' user-scoped queries are unaffected (they keep
 -- hitting the composite user_id-prefixed indexes).
-CREATE INDEX IF NOT EXISTS idx_audit_time ON audit_log(timestamp DESC);
+--
+-- Do not build idx_audit_time in the transactional startup runner. Production
+-- audit_log can be multi-gigabyte; a regular CREATE INDEX can exceed Cloud
+-- Run's startup deadline and blocks writes for the duration. Operators should
+-- create it separately with:
+--
+--   CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_audit_time
+--       ON audit_log(timestamp DESC);
+--
+-- The fleet-wide admin routes are OSS-only, so cloud correctness does not
+-- depend on this optional performance index.
 CREATE INDEX IF NOT EXISTS idx_llm_cost_time ON llm_request_cost(timestamp);

--- a/pkg/store/postgres/postgres.go
+++ b/pkg/store/postgres/postgres.go
@@ -15,6 +15,14 @@ import (
 //go:embed migrations/*.sql
 var migrationsFS embed.FS
 
+// migrationAdvisoryLockID serializes schema migrations across every process
+// connected to the same Postgres database. Cloud deployments start the main
+// and proxy services concurrently; without a database-scoped lock they can
+// both take the same snapshot of schema_migrations and race the same DDL.
+//
+// The value is the ASCII bytes for "Clawviso" interpreted as a signed int64.
+const migrationAdvisoryLockID int64 = 0x436c61777669736f
+
 // New creates a pgxpool connection pool and runs pending migrations.
 func New(ctx context.Context, dsn string) (*pgxpool.Pool, error) {
 	pool, err := pgxpool.New(ctx, dsn)
@@ -56,8 +64,25 @@ func runMigrations(ctx context.Context, pool *pgxpool.Pool) error {
 //     ADD COLUMN / CREATE INDEX / CREATE TABLE shapes — see
 //     isMigrationAlreadyAppliedErr.
 func runMigrationsFS(ctx context.Context, pool *pgxpool.Pool, migrations fs.FS) error {
+	// Advisory locks are session-scoped, so pin all migration work to one pool
+	// connection. Releasing the connection also releases the lock if the
+	// explicit unlock fails during cancellation or shutdown.
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		return fmt.Errorf("acquiring migration connection: %w", err)
+	}
+	defer conn.Release()
+
+	if _, err := conn.Exec(ctx, `SELECT pg_advisory_lock($1)`, migrationAdvisoryLockID); err != nil {
+		return fmt.Errorf("acquiring migration advisory lock: %w", err)
+	}
+	defer func() {
+		// Best effort only: the session releases the lock when conn is released.
+		_, _ = conn.Exec(context.Background(), `SELECT pg_advisory_unlock($1)`, migrationAdvisoryLockID)
+	}()
+
 	// Create migrations tracking table
-	_, err := pool.Exec(ctx, `
+	_, err = conn.Exec(ctx, `
 		CREATE TABLE IF NOT EXISTS schema_migrations (
 			name       TEXT PRIMARY KEY,
 			applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
@@ -68,7 +93,7 @@ func runMigrationsFS(ctx context.Context, pool *pgxpool.Pool, migrations fs.FS) 
 	}
 
 	// Read applied migrations
-	rows, err := pool.Query(ctx, `SELECT name FROM schema_migrations ORDER BY name`)
+	rows, err := conn.Query(ctx, `SELECT name FROM schema_migrations ORDER BY name`)
 	if err != nil {
 		return err
 	}
@@ -108,7 +133,7 @@ func runMigrationsFS(ctx context.Context, pool *pgxpool.Pool, migrations fs.FS) 
 			return fmt.Errorf("reading migration %s: %w", entry.Name(), err)
 		}
 
-		tx, err := pool.BeginTx(ctx, pgx.TxOptions{})
+		tx, err := conn.BeginTx(ctx, pgx.TxOptions{})
 		if err != nil {
 			return fmt.Errorf("begin migration %s: %w", entry.Name(), err)
 		}
@@ -121,7 +146,7 @@ func runMigrationsFS(ctx context.Context, pool *pgxpool.Pool, migrations fs.FS) 
 			// failed DDL in Postgres, so roll back and reopen.
 			if isMigrationAlreadyAppliedErr(err) {
 				_ = tx.Rollback(ctx)
-				if _, err := pool.Exec(ctx,
+				if _, err := conn.Exec(ctx,
 					`INSERT INTO schema_migrations (name) VALUES ($1) ON CONFLICT DO NOTHING`,
 					entry.Name(),
 				); err != nil {

--- a/pkg/store/postgres/postgres.go
+++ b/pkg/store/postgres/postgres.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -77,8 +78,17 @@ func runMigrationsFS(ctx context.Context, pool *pgxpool.Pool, migrations fs.FS) 
 		return fmt.Errorf("acquiring migration advisory lock: %w", err)
 	}
 	defer func() {
-		// Best effort only: the session releases the lock when conn is released.
-		_, _ = conn.Exec(context.Background(), `SELECT pg_advisory_unlock($1)`, migrationAdvisoryLockID)
+		// Deliberately not derived from ctx: cleanup has to run even when the
+		// caller's context is already cancelled (a startup abort), which is
+		// exactly when the unlock matters most. It is bounded instead, because
+		// this defer runs before the deferred conn.Release() above — an
+		// unresponsive database would otherwise block here forever and leak the
+		// connection, turning a failed startup into a hang. Best effort only:
+		// the session releases the lock when conn is released, so a timed-out
+		// or failed unlock is not fatal.
+		unlockCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_, _ = conn.Exec(unlockCtx, `SELECT pg_advisory_unlock($1)`, migrationAdvisoryLockID)
 	}()
 
 	// Create migrations tracking table

--- a/pkg/store/postgres/store.go
+++ b/pkg/store/postgres/store.go
@@ -321,14 +321,42 @@ func (s *Store) actorEmailFor(ctx context.Context, userID string) string {
 }
 
 func (s *Store) DeleteUser(ctx context.Context, userID string) error {
-	res, err := s.pool.Exec(ctx, `DELETE FROM users WHERE id = $1`, userID)
+	// Preserve attribution even if the asynchronous historical backfill has
+	// not reached this user's old audit/cost rows yet. Keep the denormalization
+	// and user deletion atomic so ON DELETE SET NULL can never erase the only
+	// remaining link to the actor's email.
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+
+	var email string
+	if err := tx.QueryRow(ctx, `SELECT email FROM users WHERE id = $1 FOR UPDATE`, userID).Scan(&email); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return store.ErrNotFound
+		}
+		return err
+	}
+	if _, err := tx.Exec(ctx,
+		`UPDATE audit_log SET actor_email = $1 WHERE user_id = $2 AND actor_email = ''`,
+		email, userID); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(ctx,
+		`UPDATE llm_request_cost SET actor_email = $1 WHERE user_id = $2 AND actor_email = ''`,
+		email, userID); err != nil {
+		return err
+	}
+
+	res, err := tx.Exec(ctx, `DELETE FROM users WHERE id = $1`, userID)
 	if err != nil {
 		return err
 	}
 	if res.RowsAffected() == 0 {
 		return store.ErrNotFound
 	}
-	return nil
+	return tx.Commit(ctx)
 }
 
 // ── API tokens ──────────────────────────────────────────────────────────────

--- a/scripts/postgres/post-062-backfill.sql
+++ b/scripts/postgres/post-062-backfill.sql
@@ -1,0 +1,87 @@
+\set ON_ERROR_STOP on
+
+-- Run with psql AFTER migration 062 has committed and the new application
+-- revision is healthy. Do not wrap this script in BEGIN/COMMIT: the procedure
+-- commits every batch so it never creates another multi-million-row
+-- transaction. The script is resumable; rows already carrying actor_email are
+-- skipped on subsequent runs.
+--
+-- Override the default batch size with:
+--   psql ... -v batch_size=5000 -f scripts/postgres/post-062-backfill.sql
+\if :{?batch_size}
+\else
+\set batch_size 10000
+\endif
+
+CREATE OR REPLACE PROCEDURE clawvisor_backfill_actor_email(batch_size integer)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    changed integer;
+    last_id text := '';
+    batch_last_id text;
+BEGIN
+    LOOP
+        WITH batch AS MATERIALIZED (
+            SELECT a.id, COALESCE(u.email, '(deleted-user)') AS email
+            FROM audit_log a
+            LEFT JOIN users u ON u.id = a.user_id
+            WHERE a.actor_email = '' AND a.id > last_id
+            ORDER BY a.id
+            LIMIT batch_size
+            FOR UPDATE OF a SKIP LOCKED
+        ), updated AS (
+            UPDATE audit_log a
+            SET actor_email = batch.email
+            FROM batch
+            WHERE a.id = batch.id
+            RETURNING a.id
+        )
+        SELECT COUNT(*), MAX(id) INTO changed, batch_last_id FROM updated;
+
+        EXIT WHEN changed = 0;
+        last_id := batch_last_id;
+        COMMIT;
+    END LOOP;
+
+    last_id := '';
+    LOOP
+        WITH batch AS MATERIALIZED (
+            SELECT c.audit_id, COALESCE(u.email, '(deleted-user)') AS email
+            FROM llm_request_cost c
+            LEFT JOIN users u ON u.id = c.user_id
+            WHERE c.actor_email = '' AND c.audit_id > last_id
+            ORDER BY c.audit_id
+            LIMIT batch_size
+            FOR UPDATE OF c SKIP LOCKED
+        ), updated AS (
+            UPDATE llm_request_cost c
+            SET actor_email = batch.email
+            FROM batch
+            WHERE c.audit_id = batch.audit_id
+            RETURNING c.audit_id
+        )
+        SELECT COUNT(*), MAX(audit_id) INTO changed, batch_last_id FROM updated;
+
+        EXIT WHEN changed = 0;
+        last_id := batch_last_id;
+        COMMIT;
+    END LOOP;
+END
+$$;
+
+CALL clawvisor_backfill_actor_email(:batch_size);
+DROP PROCEDURE clawvisor_backfill_actor_email(integer);
+
+-- These indexes support OSS-only fleet-wide admin reads. CONCURRENTLY keeps
+-- audit ingestion available while Postgres scans the large audit table. Each
+-- statement runs in psql autocommit mode as CREATE INDEX CONCURRENTLY requires.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_audit_time
+    ON audit_log(timestamp DESC);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_llm_cost_time
+    ON llm_request_cost(timestamp);
+
+-- The replacement FK was installed NOT VALID so startup did not scan the
+-- entire audit table while holding its DDL transaction. Validation permits
+-- normal reads and writes while it checks historical rows.
+ALTER TABLE audit_log VALIDATE CONSTRAINT audit_log_user_id_fkey;

--- a/scripts/postgres/post-062-backfill.sql
+++ b/scripts/postgres/post-062-backfill.sql
@@ -8,6 +8,12 @@
 --
 -- Override the default batch size with:
 --   psql ... -v batch_size=5000 -f scripts/postgres/post-062-backfill.sql
+--
+-- psql variables are plain strings, so the override is quoted and cast to
+-- integer at the call site below. That turns a non-numeric value into an
+-- immediate "invalid input syntax for type integer" instead of the confusing
+-- "column ... does not exist" that an unquoted interpolation would produce.
+-- The numeric range is checked inside the procedure.
 \if :{?batch_size}
 \else
 \set batch_size 10000
@@ -17,67 +23,175 @@ CREATE OR REPLACE PROCEDURE clawvisor_backfill_actor_email(batch_size integer)
 LANGUAGE plpgsql
 AS $$
 DECLARE
+    -- Reject a batch size outside this range rather than clamping it. A batch
+    -- of zero or less makes every LIMIT return no rows, so both loops would
+    -- exit on their first iteration and the script would report success having
+    -- written nothing at all. An unbounded batch recreates the single giant
+    -- transaction this script exists to avoid. In either case the operator
+    -- asked for something the script cannot honour, so say so loudly.
+    min_batch_size constant integer := 1;
+    max_batch_size constant integer := 100000;
+    -- SKIP LOCKED lets a batch step over rows held by concurrent writers so
+    -- the backfill never queues behind live traffic, but the keyset cursor
+    -- advances past those rows all the same, so a single forward pass can
+    -- leave them behind. Repeat whole passes from the start of the table until
+    -- one finds nothing left blank. The bound stops a row that is locked
+    -- indefinitely from spinning here forever; if we hit it we warn with the
+    -- outstanding count instead of pretending the backfill finished.
+    max_passes constant integer := 10;
     changed integer;
     last_id text := '';
     batch_last_id text;
+    pass integer;
+    remaining bigint;
 BEGIN
-    LOOP
-        WITH batch AS MATERIALIZED (
-            SELECT a.id, COALESCE(u.email, '(deleted-user)') AS email
-            FROM audit_log a
-            LEFT JOIN users u ON u.id = a.user_id
-            WHERE a.actor_email = '' AND a.id > last_id
-            ORDER BY a.id
-            LIMIT batch_size
-            FOR UPDATE OF a SKIP LOCKED
-        ), updated AS (
-            UPDATE audit_log a
-            SET actor_email = batch.email
-            FROM batch
-            WHERE a.id = batch.id
-            RETURNING a.id
-        )
-        SELECT COUNT(*), MAX(id) INTO changed, batch_last_id FROM updated;
+    IF batch_size IS NULL OR batch_size < min_batch_size OR batch_size > max_batch_size THEN
+        RAISE EXCEPTION 'batch_size must be an integer between % and %, got %',
+            min_batch_size, max_batch_size, COALESCE(batch_size::text, 'NULL')
+            USING HINT = 'Re-run with, for example, -v batch_size=10000.';
+    END IF;
 
-        EXIT WHEN changed = 0;
-        last_id := batch_last_id;
+    pass := 0;
+    LOOP
+        pass := pass + 1;
+        last_id := '';
+        LOOP
+            WITH batch AS MATERIALIZED (
+                SELECT a.id, COALESCE(u.email, '(deleted-user)') AS email
+                FROM audit_log a
+                LEFT JOIN users u ON u.id = a.user_id
+                WHERE a.actor_email = '' AND a.id > last_id
+                ORDER BY a.id
+                LIMIT batch_size
+                FOR UPDATE OF a SKIP LOCKED
+            ), updated AS (
+                UPDATE audit_log a
+                SET actor_email = batch.email
+                FROM batch
+                WHERE a.id = batch.id
+                RETURNING a.id
+            )
+            SELECT COUNT(*), MAX(id) INTO changed, batch_last_id FROM updated;
+
+            EXIT WHEN changed = 0;
+            last_id := batch_last_id;
+            COMMIT;
+        END LOOP;
+
+        -- The forward pass is done, so anything still blank was either skipped
+        -- while locked or written by a concurrent transaction that started
+        -- before the new revision was fully rolled out. This count is the only
+        -- honest completion test; it costs one scan per pass.
+        SELECT count(*) INTO remaining FROM audit_log WHERE actor_email = '';
+        COMMIT;
+
+        EXIT WHEN remaining = 0;
+
+        IF pass >= max_passes THEN
+            RAISE WARNING 'audit_log: % row(s) still have an empty actor_email after % passes, most likely held by a long-running transaction. Re-run this script once it has finished.',
+                remaining, max_passes;
+            EXIT;
+        END IF;
+
+        RAISE NOTICE 'audit_log: % row(s) were skipped while locked; starting pass % of %.',
+            remaining, pass + 1, max_passes;
+        -- Back off before rescanning so the transactions holding those rows
+        -- get a chance to finish. Commit first: sleeping inside an open
+        -- transaction would pin the snapshot and hold back vacuum.
+        PERFORM pg_sleep(least(pass, 5));
         COMMIT;
     END LOOP;
 
-    last_id := '';
+    -- llm_request_cost is keyed by audit_id and is smaller, but it is written
+    -- by the same live request path, so it needs the identical convergence
+    -- treatment.
+    pass := 0;
     LOOP
-        WITH batch AS MATERIALIZED (
-            SELECT c.audit_id, COALESCE(u.email, '(deleted-user)') AS email
-            FROM llm_request_cost c
-            LEFT JOIN users u ON u.id = c.user_id
-            WHERE c.actor_email = '' AND c.audit_id > last_id
-            ORDER BY c.audit_id
-            LIMIT batch_size
-            FOR UPDATE OF c SKIP LOCKED
-        ), updated AS (
-            UPDATE llm_request_cost c
-            SET actor_email = batch.email
-            FROM batch
-            WHERE c.audit_id = batch.audit_id
-            RETURNING c.audit_id
-        )
-        SELECT COUNT(*), MAX(audit_id) INTO changed, batch_last_id FROM updated;
+        pass := pass + 1;
+        last_id := '';
+        LOOP
+            WITH batch AS MATERIALIZED (
+                SELECT c.audit_id, COALESCE(u.email, '(deleted-user)') AS email
+                FROM llm_request_cost c
+                LEFT JOIN users u ON u.id = c.user_id
+                WHERE c.actor_email = '' AND c.audit_id > last_id
+                ORDER BY c.audit_id
+                LIMIT batch_size
+                FOR UPDATE OF c SKIP LOCKED
+            ), updated AS (
+                UPDATE llm_request_cost c
+                SET actor_email = batch.email
+                FROM batch
+                WHERE c.audit_id = batch.audit_id
+                RETURNING c.audit_id
+            )
+            SELECT COUNT(*), MAX(audit_id) INTO changed, batch_last_id FROM updated;
 
-        EXIT WHEN changed = 0;
-        last_id := batch_last_id;
+            EXIT WHEN changed = 0;
+            last_id := batch_last_id;
+            COMMIT;
+        END LOOP;
+
+        SELECT count(*) INTO remaining FROM llm_request_cost WHERE actor_email = '';
+        COMMIT;
+
+        EXIT WHEN remaining = 0;
+
+        IF pass >= max_passes THEN
+            RAISE WARNING 'llm_request_cost: % row(s) still have an empty actor_email after % passes, most likely held by a long-running transaction. Re-run this script once it has finished.',
+                remaining, max_passes;
+            EXIT;
+        END IF;
+
+        RAISE NOTICE 'llm_request_cost: % row(s) were skipped while locked; starting pass % of %.',
+            remaining, pass + 1, max_passes;
+        PERFORM pg_sleep(least(pass, 5));
         COMMIT;
     END LOOP;
 END
 $$;
 
-CALL clawvisor_backfill_actor_email(:batch_size);
+CALL clawvisor_backfill_actor_email(:'batch_size'::integer);
 DROP PROCEDURE clawvisor_backfill_actor_email(integer);
 
 -- These indexes support OSS-only fleet-wide admin reads. CONCURRENTLY keeps
 -- audit ingestion available while Postgres scans the large audit table. Each
--- statement runs in psql autocommit mode as CREATE INDEX CONCURRENTLY requires.
+-- statement runs at the top level in psql autocommit mode, as CREATE INDEX
+-- CONCURRENTLY and DROP INDEX CONCURRENTLY both require; neither may move into
+-- the procedure or a DO block, because those execute inside a transaction.
+--
+-- A concurrent build that fails or is interrupted leaves the index behind
+-- flagged invalid. The planner never uses an invalid index, and a rerun of
+-- CREATE INDEX CONCURRENTLY IF NOT EXISTS sees the relation already exists and
+-- skips it, so without this guard the index would stay dead through every
+-- future run of the script. Look for that corpse and drop it first.
+SELECT COALESCE(
+    (SELECT NOT i.indisvalid
+     FROM pg_index i
+     WHERE i.indexrelid = to_regclass('idx_audit_time')),
+    false) AS rebuild_idx_audit_time
+\gset
+
+\if :rebuild_idx_audit_time
+\echo 'idx_audit_time exists but is INVALID (an earlier concurrent build did not finish); dropping it before rebuilding.'
+DROP INDEX CONCURRENTLY IF EXISTS idx_audit_time;
+\endif
+
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_audit_time
     ON audit_log(timestamp DESC);
+
+SELECT COALESCE(
+    (SELECT NOT i.indisvalid
+     FROM pg_index i
+     WHERE i.indexrelid = to_regclass('idx_llm_cost_time')),
+    false) AS rebuild_idx_llm_cost_time
+\gset
+
+\if :rebuild_idx_llm_cost_time
+\echo 'idx_llm_cost_time exists but is INVALID (an earlier concurrent build did not finish); dropping it before rebuilding.'
+DROP INDEX CONCURRENTLY IF EXISTS idx_llm_cost_time;
+\endif
+
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_llm_cost_time
     ON llm_request_cost(timestamp);
 
@@ -85,3 +199,30 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_llm_cost_time
 -- entire audit table while holding its DDL transaction. Validation permits
 -- normal reads and writes while it checks historical rows.
 ALTER TABLE audit_log VALIDATE CONSTRAINT audit_log_user_id_fkey;
+
+-- Final gate: make the exit status tell the truth about completeness.
+--
+-- The convergence loops above warn when they give up on rows pinned by a
+-- long-running transaction, but a WARNING leaves psql's exit status at 0, so
+-- anything driving this script from cron or CI would record a clean success
+-- over an unfinished backfill — the same "looks done, isn't" failure the
+-- SKIP LOCKED cursor had. Fail here instead.
+--
+-- Deliberately placed last. Everything above is already committed (psql is in
+-- autocommit), so the batches that did land, both concurrent index builds, and
+-- the constraint validation all persist. Re-running is safe and picks up only
+-- what is still outstanding.
+DO $$
+DECLARE
+    audit_blank bigint;
+    cost_blank  bigint;
+BEGIN
+    SELECT count(*) INTO audit_blank FROM audit_log WHERE actor_email = '';
+    SELECT count(*) INTO cost_blank FROM llm_request_cost WHERE actor_email = '';
+    IF audit_blank > 0 OR cost_blank > 0 THEN
+        RAISE EXCEPTION 'backfill incomplete: % audit_log and % llm_request_cost row(s) still have an empty actor_email',
+            audit_blank, cost_blank
+            USING HINT = 'Rows were most likely pinned by a long-running transaction. Indexes and constraint validation are already in place; re-run this script once that transaction has finished.';
+    END IF;
+END
+$$;


### PR DESCRIPTION
## Summary

- serialize core PostgreSQL migrations with a database advisory lock
- keep the actor-retention migration metadata-only and bound DDL lock waits
- defer historical attribution updates to a resumable, batched post-migration script
- create the large audit index concurrently outside the startup transaction
- preserve historical attribution atomically when deleting a user during the backfill window
- add regression coverage that rejects unbounded large-table work in startup migrations

## Why

Startup migrations should not perform unbounded table rewrites or long blocking index builds. On sufficiently large databases, that work can exceed an orchestrator's readiness deadline while holding DDL locks that delay application traffic. Concurrent server processes can also take the same migration snapshot and race identical schema changes.

This change keeps startup work short and serialized. Historical data maintenance remains explicit and resumable.

## Impact

Existing installations receive the actor-retention schema changes without rewriting historical audit rows during server startup. New audit and cost rows continue to record server-derived actor email immediately. Operators can run `scripts/postgres/post-062-backfill.sql` after the application is healthy to fill historical rows, build supporting indexes concurrently, and validate the replacement foreign key.

## Validation

- `go test ./pkg/store/...`
- cloud composition: `go test ./internal/store/... ./cmd/cloud`
- PostgreSQL 15 integration exercise covering migration 062, multi-batch backfill, concurrent index creation, and foreign-key validation


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

