### PR TITLE
fix(install): honor route in the OpenClaw and Hermes markdown installers

### DIFF
--- a/internal/api/handlers/installer.go
+++ b/internal/api/handlers/installer.go
@@ -139,16 +139,17 @@ type installerCtx struct {
 	// X-Clawvisor-Agent-Token header while leaving the OAuth session in
 	// Authorization untouched and never referencing an API key.
 	//
-	// KNOWN GAP: only the self-install shell targets (claude-code, codex) honor
-	// this field. The markdown helper renderers — renderOpenClawInstaller and
-	// renderHermesInstaller — ignore it and unconditionally instruct the user to
-	// point their provider at Clawvisor. OpenClaw matters most, because it is in
-	// the dashboard's non-proxy tab set (LEGACY_AGENT_TABS in web/src/pages/
-	// Agents.tsx) and so is reachable by a user who has no proxy-lite
-	// entitlement, who then gets 403 PROXY_LITE_DISABLED. Giving those two a
-	// skill-only variant means dropping their vault-key/preflight/point-at-
-	// Clawvisor steps and renumbering the doc, which is left as follow-up rather
-	// than bundled into the default flip.
+	// Every target honors this field. The self-install shell targets pick a
+	// template (claude_code_skill_only.sh.tmpl / codex_skill_only.sh.tmpl);
+	// the markdown helper renderers pick a render function
+	// (renderOpenClawSkillOnlyInstaller / renderHermesSkillOnlyInstaller),
+	// which drops the detect-provider / vault-key / probe / preflight /
+	// point-at-Clawvisor steps and renumbers the doc from 8 steps to 4. That
+	// matters most for OpenClaw, which is in the dashboard's non-proxy tab set
+	// (LEGACY_AGENT_TABS in web/src/pages/Agents.tsx) and so is reachable by a
+	// user who has no proxy-lite entitlement: while the markdown renderers
+	// ignored this field, such a user got a routed doc and then
+	// 403 PROXY_LITE_DISABLED on their first model call.
 	Route string
 }
 
@@ -537,6 +538,10 @@ description: Install Clawvisor into %s — probe the environment, mint and appro
 // command name is `clawvisor-setup` (vs. `clawvisor-install` for harness
 // installs), (b) the description reflects the new flow — no dashboard
 // approval, optional default-everywhere routing, subprocess smoke test.
+//
+// This is the header for the ROUTED (route=proxy) variant only; the
+// skill-only docs use setupFrontmatterSkillOnly, whose description doesn't
+// promise routing the install never sets up.
 func setupFrontmatter(harness string) string {
 	return fmt.Sprintf(`---
 name: clawvisor-setup
@@ -544,6 +549,21 @@ description: One-paste connect %s to Clawvisor — register, install the skill, 
 ---
 
 `, harness)
+}
+
+// setupFrontmatterSkillOnly is setupFrontmatter for the skill-only route.
+// It exists as a separate header because setupFrontmatter's description
+// promises to "route every session through Clawvisor", which is precisely
+// what this variant does not do — and that description is what the user
+// reads in their harness's slash-command / skill picker, so leaving it in
+// place would advertise a routing posture the install never configures.
+func setupFrontmatterSkillOnly(harness string) string {
+	return fmt.Sprintf(`---
+name: clawvisor-setup
+description: One-paste connect %s to Clawvisor — register the agent, install the skill, and remove this command file. %s keeps talking to its own LLM provider; pass route=proxy to route model traffic through Clawvisor (Observe) instead.
+---
+
+`, harness, harness)
 }
 
 // ── Shared markdown helpers ──────────────────────────────────────────────────
@@ -567,7 +587,12 @@ func sectionUninstallDoc(harness, uninstallSteps string, step int) string {
 	return b.String()
 }
 
-func sectionSelfUninstall(harness, skillRemovePath string, step int) string {
+// sectionSelfUninstall renders the closing step. `routed` selects the wrap-up
+// the helper reads back to the user: the routed doc can say the harness is now
+// routed through Clawvisor, but a skill-only install has deliberately left the
+// harness pointed at its own provider, so claiming otherwise would send the
+// user looking for observability data that will never appear.
+func sectionSelfUninstall(harness, skillRemovePath string, step int, routed bool) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "## %d. Self-uninstall automatically\n\n", step)
 	fmt.Fprintf(&b, "Setup is done. Remove this installer skill now; it is one-shot setup\n")
@@ -578,8 +603,20 @@ func sectionSelfUninstall(harness, skillRemovePath string, step int) string {
 	fmt.Fprintf(&b, "%s\n", skillRemovePath)
 	fmt.Fprintf(&b, "```\n\n")
 	fmt.Fprintf(&b, "Tell the user:\n\n")
-	fmt.Fprintf(&b, "- %s is now routed through Clawvisor.\n", harness)
-	fmt.Fprintf(&b, "- Their first real interaction is where they'll see the policy-enforcement demo.\n")
+	if routed {
+		fmt.Fprintf(&b, "- %s is now routed through Clawvisor.\n", harness)
+		fmt.Fprintf(&b, "- Their first real interaction is where they'll see the policy-enforcement demo.\n")
+	} else {
+		// Say the quiet part out loud: nothing about the harness's model
+		// access changed. Users who assume otherwise open the dashboard,
+		// see no LLM traffic, and read that as Clawvisor being broken.
+		fmt.Fprintf(&b, "- %s is registered with Clawvisor. Its LLM traffic still goes straight to\n", harness)
+		fmt.Fprintf(&b, "  its own provider — this install changed nothing about how it reaches a model.\n")
+		fmt.Fprintf(&b, "- The governed tools live in the skill catalog at `$CLAWVISOR_APP_URL/skill`;\n")
+		fmt.Fprintf(&b, "  policy enforcement kicks in the first time the agent calls one of them.\n")
+		fmt.Fprintf(&b, "- Routing model traffic through Clawvisor (Observe) is a separate opt-in —\n")
+		fmt.Fprintf(&b, "  re-run the installer with `route=proxy` if they want it.\n")
+	}
 	fmt.Fprintf(&b, "- The uninstall guide is at `~/.clawvisor/uninstall-%s.md` if they need to back out.\n", harness)
 	return b.String()
 }
@@ -882,6 +919,89 @@ func sectionEnsureVaultedKeyDynamic(step int) string {
 	return b.String()
 }
 
+// ── Shared markdown helpers for the skill-only route ────────────────────────
+//
+// route=skill-only (the default) registers the agent against the gateway and
+// stops there: the harness keeps talking to its own LLM provider. That makes
+// every routing-shaped step of the routed doc dead weight — detect the
+// provider, vault an upstream key (the vaulted key only matters because the
+// proxy injects it, and with no routing there is nothing to inject), probe
+// the deployment, preflight from the harness's own network namespace, and
+// point the harness at Clawvisor all exist to serve a base-URL swap that
+// never happens. So the skill-only docs are register → verify → uninstall
+// reference → self-uninstall, numbered 1-4 with no gaps.
+//
+// These live in their own render functions rather than as `if ctx.Route`
+// branches inside the routed bodies, mirroring how the shell targets do it
+// (codex_skill_only.sh.tmpl sits beside codex.sh.tmpl) and keeping the
+// routed output impossible to disturb by accident.
+
+// sectionSkillOnlyPreamble is the title + orientation block for the
+// skill-only markdown docs. It spells out the prohibitions — no base URL, no
+// vaulted key, no edit to the harness's config file — as instructions rather
+// than as description, because the reader is an LLM helper agent that has
+// very likely seen the routed variant of this same skill and will otherwise
+// "helpfully" finish the job by configuring routing anyway. It closes with
+// the route=proxy escape hatch so a user who does want Observe can get there.
+func sectionSkillOnlyPreamble(harness, target, configFile, appURL string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# Connect %s to Clawvisor\n\n", harness)
+	fmt.Fprintf(&b, "You are running a one-shot setup skill. The dashboard pre-baked the\n")
+	fmt.Fprintf(&b, "Clawvisor URL, a single-use claim code, and the agent name into this file.\n")
+	fmt.Fprintf(&b, "The dashboard already approved the connection — no second click is needed.\n\n")
+	fmt.Fprintf(&b, "This is the **skill-only** install, which is the default. It registers\n")
+	fmt.Fprintf(&b, "%s with Clawvisor and persists an agent token — that is the whole job.\n", harness)
+	fmt.Fprintf(&b, "Specifically, and non-negotiably:\n\n")
+	fmt.Fprintf(&b, "- DO NOT set a provider base URL (`ANTHROPIC_BASE_URL`, `OPENAI_BASE_URL`,\n")
+	fmt.Fprintf(&b, "  a `base_url` config field, or any equivalent).\n")
+	fmt.Fprintf(&b, "- DO NOT vault an upstream API key in Clawvisor. Clawvisor's proxy-lite\n")
+	fmt.Fprintf(&b, "  injects a vaulted key on each call, and nothing here routes calls\n")
+	fmt.Fprintf(&b, "  through it, so there is nothing for a vaulted key to do.\n")
+	fmt.Fprintf(&b, "- DO NOT edit `%s`.\n\n", configFile)
+	fmt.Fprintf(&b, "%s keeps reaching its LLM provider exactly the way it does today. The\n", harness)
+	fmt.Fprintf(&b, "agent token is what lets the Clawvisor skill and its tools govern\n")
+	fmt.Fprintf(&b, "%s's tool calls; LLM observability is not part of this install.\n\n", harness)
+	fmt.Fprintf(&b, "Routing model traffic through Clawvisor (the Observe posture) is a\n")
+	fmt.Fprintf(&b, "separate, explicit opt-in. It needs proxy-lite enabled for the account,\n")
+	fmt.Fprintf(&b, "so a routed install for a user without that entitlement returns\n")
+	fmt.Fprintf(&b, "`403 PROXY_LITE_DISABLED` on the first model call — which is why it isn't\n")
+	fmt.Fprintf(&b, "the default. If the user explicitly asks for it, re-fetch this skill with\n")
+	fmt.Fprintf(&b, "`route=proxy` and follow that version instead:\n\n")
+	fmt.Fprintf(&b, "```bash\n")
+	fmt.Fprintf(&b, "curl -fsSL \"%s/skill/install/%s.md?claim=<claim>&route=proxy\"\n", strings.TrimRight(appURL, "/"), target)
+	fmt.Fprintf(&b, "```\n\n")
+	return b.String()
+}
+
+// sectionSkillOnlyVerify proves the freshly minted token is actually accepted
+// before the doc declares success. The routed docs verify from the harness's
+// own network namespace (`docker exec`, `ssh`) because they are about to bake
+// a URL the harness itself has to reach; a skill-only install writes nothing
+// on the harness side, so the helper's own shell is both the right and the
+// only necessary vantage point. Hits the control-plane host, which is where
+// /api/skill/catalog is served in split deployments.
+func sectionSkillOnlyVerify(harness string, step int) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "## %d. Verify the token and show the user the skill catalog\n\n", step)
+	fmt.Fprintf(&b, "Registration is the entire install, so the only thing left to prove is\n")
+	fmt.Fprintf(&b, "that the token Clawvisor just minted is accepted. Run this from your own\n")
+	fmt.Fprintf(&b, "shell — there is no %s-side configuration to test, so no `docker exec`\n", harness)
+	fmt.Fprintf(&b, "or `ssh` variant is needed:\n\n")
+	fmt.Fprintf(&b, "```bash\n")
+	fmt.Fprintf(&b, "curl -fsSL -H \"X-Clawvisor-Agent-Token: $TOKEN\" \\\n")
+	fmt.Fprintf(&b, "  \"$CLAWVISOR_APP_URL/api/skill/catalog\" >/dev/null && echo OK\n")
+	fmt.Fprintf(&b, "```\n\n")
+	fmt.Fprintf(&b, "If `OK` doesn't appear, surface the response to the user and STOP — the\n")
+	fmt.Fprintf(&b, "token in `$TOKEN_FILE` isn't usable. Re-running the install from the\n")
+	fmt.Fprintf(&b, "dashboard is the fix; do not try to work around it by reconfiguring\n")
+	fmt.Fprintf(&b, "%s.\n\n", harness)
+	fmt.Fprintf(&b, "Then show the user where the governed tools live:\n\n")
+	fmt.Fprintf(&b, "```bash\n")
+	fmt.Fprintf(&b, "echo \"$CLAWVISOR_APP_URL/skill\"\n")
+	fmt.Fprintf(&b, "```\n\n")
+	return b.String()
+}
+
 // ── Shared helpers for the one-paste setup skill (Claude Code, Codex) ────────
 
 // sectionClaimedConnect renders the connect-with-claim curl + token-file
@@ -1043,6 +1163,13 @@ func installerEnvSlug(llmURL string) string {
 }
 
 func renderHermesInstaller(ctx installerCtx) string {
+	// Only route=proxy earns the routing steps. Everything else lands on the
+	// register-only doc: the skill-only default, and "subscription", which
+	// installerCtxFromRequest already folds into skill-only for every target
+	// other than claude-code.
+	if ctx.Route != "proxy" {
+		return renderHermesSkillOnlyInstaller(ctx)
+	}
 	var b strings.Builder
 	llmHost := dockerHostURL(ctx.LLMURL)
 	b.WriteString(setupFrontmatter("Hermes"))
@@ -1232,12 +1359,53 @@ func renderHermesInstaller(ctx installerCtx) string {
 `, 7))
 
 	// Step 8: self-uninstall — remove this setup skill from the helper.
-	b.WriteString(sectionSelfUninstall("hermes", helperSetupCleanupCommands(), 8))
+	b.WriteString(sectionSelfUninstall("hermes", helperSetupCleanupCommands(), 8, true))
+
+	return b.String()
+}
+
+// renderHermesSkillOnlyInstaller renders the default (skill-only) Hermes doc:
+// register, verify, uninstall reference, self-uninstall. Hermes's routed doc
+// runs in swap mode — it hands Clawvisor's agent token to Hermes as the
+// upstream provider's API-key env var and lets the proxy swap in a vaulted
+// key — and every step that supports that swap is absent here.
+func renderHermesSkillOnlyInstaller(ctx installerCtx) string {
+	var b strings.Builder
+	b.WriteString(setupFrontmatterSkillOnly("Hermes"))
+	b.WriteString(sectionSkillOnlyPreamble("Hermes", string(InstallerHermes), "~/.hermes/config.yaml", ctx.AppURL))
+
+	// Step 1: auto-approved claim connect → token saved to $TOKEN_FILE.
+	b.WriteString(sectionClaimedConnect("hermes", ctx.AppURL, ctx.LLMURL, ctx.Claim, ctx.AgentName))
+
+	// Step 2: prove the minted token is accepted before declaring success.
+	b.WriteString(sectionSkillOnlyVerify("Hermes", 2))
+
+	// Step 3: uninstall reference. Deliberately far shorter than the routed
+	// recipe: there is no `model:` block in ~/.hermes/config.yaml to strip, no
+	// HERMES_CV_API_KEY line in ~/.hermes/.env, no `hermes-cv` shell function,
+	// and no vaulted upstream key to reconsider, because a skill-only install
+	// creates none of them. Listing them anyway would send the user hunting
+	// through config files for entries that were never written.
+	b.WriteString(sectionUninstallDoc("hermes", `This was a skill-only install: it never changed how Hermes reaches its LLM
+provider, so `+"`~/.hermes/config.yaml`"+` and your shell rc were left untouched and
+there is nothing there to revert.
+
+1. Delete the token file: `+"`rm ~/.clawvisor/agents/"+ctx.AgentName+".json`"+`.
+2. Revoke the agent in the Clawvisor dashboard under Agents → `+ctx.AgentName+` → Delete.
+`, 3))
+
+	// Step 4: self-uninstall — remove this setup skill from the helper.
+	b.WriteString(sectionSelfUninstall("hermes", helperSetupCleanupCommands(), 4, false))
 
 	return b.String()
 }
 
 func renderOpenClawInstaller(ctx installerCtx) string {
+	// Only route=proxy earns the routing steps; see renderHermesInstaller for
+	// why "subscription" can't reach this branch on a markdown target.
+	if ctx.Route != "proxy" {
+		return renderOpenClawSkillOnlyInstaller(ctx)
+	}
 	var b strings.Builder
 	maxTokens := openClawDefaultMaxTokens()
 	llmHost := dockerHostURL(ctx.LLMURL)
@@ -1404,7 +1572,45 @@ func renderOpenClawInstaller(ctx installerCtx) string {
 `, 7))
 
 	// Step 8: self-uninstall — remove this setup skill from the helper.
-	b.WriteString(sectionSelfUninstall("openclaw", helperSetupCleanupCommands(), 8))
+	b.WriteString(sectionSelfUninstall("openclaw", helperSetupCleanupCommands(), 8, true))
+
+	return b.String()
+}
+
+// renderOpenClawSkillOnlyInstaller renders the default (skill-only) OpenClaw
+// doc: register, verify, uninstall reference, self-uninstall. This is the
+// variant that matters most, because `openclaw` sits in the dashboard's
+// LEGACY_AGENT_TABS — the tab set shown to users without a proxy-lite
+// entitlement — so it is the doc most likely to be followed by someone whose
+// first routed model call would have returned 403 PROXY_LITE_DISABLED.
+func renderOpenClawSkillOnlyInstaller(ctx installerCtx) string {
+	var b strings.Builder
+	b.WriteString(setupFrontmatterSkillOnly("OpenClaw"))
+	b.WriteString(sectionSkillOnlyPreamble("OpenClaw", string(InstallerOpenClaw), "~/.openclaw/openclaw.json", ctx.AppURL))
+
+	// Step 1: auto-approved claim connect → token saved to $TOKEN_FILE.
+	b.WriteString(sectionClaimedConnect("openclaw", ctx.AppURL, ctx.LLMURL, ctx.Claim, ctx.AgentName))
+
+	// Step 2: prove the minted token is accepted before declaring success.
+	b.WriteString(sectionSkillOnlyVerify("OpenClaw", 2))
+
+	// Step 3: uninstall reference. Deliberately shorter than the routed
+	// recipe: there is no `models.providers.clawvisor` entry to delete, no
+	// `models.default` to point back, and no vaulted upstream key to
+	// reconsider, because a skill-only install creates none of them. Telling
+	// the user to remove a provider entry this install never wrote would have
+	// them hand-editing ~/.openclaw/openclaw.json looking for a key that
+	// isn't there.
+	b.WriteString(sectionUninstallDoc("openclaw", `This was a skill-only install: it never changed how OpenClaw reaches its LLM
+provider, so `+"`~/.openclaw/openclaw.json`"+` was left untouched and there is no
+Clawvisor provider entry to remove.
+
+1. Delete the token file: `+"`rm ~/.clawvisor/agents/"+ctx.AgentName+".json`"+`.
+2. Revoke the agent in the Clawvisor dashboard under Agents → `+ctx.AgentName+` → Delete.
+`, 3))
+
+	// Step 4: self-uninstall — remove this setup skill from the helper.
+	b.WriteString(sectionSelfUninstall("openclaw", helperSetupCleanupCommands(), 4, false))
 
 	return b.String()
 }

--- a/internal/api/handlers/installer_test.go
+++ b/internal/api/handlers/installer_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -80,9 +82,13 @@ func TestInstallerUnknownTargetIs404(t *testing.T) {
 	}
 }
 
+// TestInstallerHermesRender asserts the shape of the ROUTED Hermes doc, so it
+// fetches with route=proxy explicitly. The default is skill-only, which drops
+// every step this test is about (detect provider, vault a key, probe,
+// preflight, configure) — see TestInstallerHermesSkillOnlyRender for that one.
 func TestInstallerHermesRender(t *testing.T) {
 	h := NewInstallerHandler("", "", true, "", "")
-	body := installerGet(t, h, "hermes", "abcDEF1234")
+	body := installerGetQuery(t, h, "hermes", "claim=abcDEF1234&route=proxy")
 
 	assertContainsAll(t, body,
 		"# Connect Hermes to Clawvisor",
@@ -188,9 +194,12 @@ func TestInstallerHermesRender(t *testing.T) {
 	}
 }
 
+// TestInstallerOpenClawRender asserts the shape of the ROUTED OpenClaw doc, so
+// it fetches with route=proxy explicitly. The default is skill-only — see
+// TestInstallerOpenClawSkillOnlyRender.
 func TestInstallerOpenClawRender(t *testing.T) {
 	h := NewInstallerHandler("", "", true, "", "")
-	body := installerGet(t, h, "openclaw", "CLAIMOPEN12")
+	body := installerGetQuery(t, h, "openclaw", "claim=CLAIMOPEN12&route=proxy")
 
 	assertContainsAll(t, body,
 		"# Connect OpenClaw to Clawvisor",
@@ -314,8 +323,9 @@ func TestInstallerOpenClawRendersAllModes(t *testing.T) {
 	// the rendered markdown must contain command variants for all three.
 	// Provider is also no longer baked, so the per-mode snippets use the
 	// $BASE_PATH / $OPENCLAW_API shell vars instead of hardcoded literals.
+	// The per-mode snippets only exist in the routed doc, so fetch route=proxy.
 	h := NewInstallerHandler("", "", true, "", "")
-	body := installerGet(t, h, "openclaw", "CLAIMOPEN12")
+	body := installerGetQuery(t, h, "openclaw", "claim=CLAIMOPEN12&route=proxy")
 
 	assertContainsAll(t, body,
 		// Host: bare `openclaw config set` (no openclaw-cli; no onboard).
@@ -1070,6 +1080,236 @@ func TestFlipSkillOnlyOptOut(t *testing.T) {
 		"/api/agents/connect",
 		"LLM traffic is NOT routed",
 	)
+}
+
+// ── Markdown route variants (hermes, openclaw) ───────────────────────────────
+
+// assertNotContainsAny fails the test if any needle is present in body.
+// Mirrors assertContainsAll: reports every hit in one run rather than bailing
+// on the first, so a regression that reintroduces several routing steps
+// surfaces all of them.
+func assertNotContainsAny(t *testing.T, label, body string, needles ...string) {
+	t.Helper()
+	for _, n := range needles {
+		if strings.Contains(body, n) {
+			t.Errorf("[%s] body must not contain %q", label, n)
+		}
+	}
+}
+
+// markdownStepHeadings pulls the `## <n>. …` step numbers out of a rendered
+// doc in order. Sub-steps (`### 3.a. …`) are deliberately not matched — only
+// top-level steps carry the numbering contract.
+var markdownStepHeadings = regexp.MustCompile(`(?m)^## (\d+)\. `)
+
+// assertStepsContiguous checks the doc's top-level step headings are 1, 2, 3, …
+// with no gaps or repeats. Dropping a step from a variant without renumbering
+// is the easy mistake here — it produces a doc that jumps "4, 6, 7" and leaves
+// the reader hunting for a step that was never emitted.
+func assertStepsContiguous(t *testing.T, label, body string) {
+	t.Helper()
+	matches := markdownStepHeadings.FindAllStringSubmatch(body, -1)
+	if len(matches) == 0 {
+		t.Errorf("[%s] no `## <n>.` step headings found", label)
+		return
+	}
+	for i, m := range matches {
+		want := strconv.Itoa(i + 1)
+		if m[1] != want {
+			t.Errorf("[%s] step %d is numbered %q, want %q (headings: %v)",
+				label, i+1, m[1], want, matches)
+		}
+	}
+}
+
+// TestInstallerMarkdownDefaultIsSkillOnly — the markdown helper targets
+// (hermes, openclaw) must honor route the same way the shell targets do. The
+// default doc registers the agent and stops: it must not instruct the user to
+// point their provider at Clawvisor, and must not walk them through vaulting
+// an upstream key (the vaulted key only matters because the proxy injects it,
+// and with no routing there is nothing to inject).
+//
+// openclaw is the one that actually bites users: it's in the dashboard's
+// LEGACY_AGENT_TABS (web/src/pages/Agents.tsx), the tab set shown to users
+// WITHOUT proxy-lite, so a routed default handed an unentitled user a doc whose
+// first model call returns 403 PROXY_LITE_DISABLED. hermes is proxy-lite-only
+// in the UI, but had the identical latent bug.
+func TestInstallerMarkdownDefaultIsSkillOnly(t *testing.T) {
+	h := NewInstallerHandler("", "", true, "", "")
+
+	// Both the implicit default (no route param) and the explicit opt-out must
+	// land on the same doc — the dashboard emits the bare URL for some flows.
+	for _, query := range []string{"claim=CLAIMOPEN12", "claim=CLAIMOPEN12&route=skill-only"} {
+		body := installerGetQuery(t, h, "openclaw", query)
+		assertContainsAll(t, body,
+			"**skill-only** install",
+			"## 1. Register and persist the token",
+			"/api/agents/connect",
+			`chmod 600 "$TOKEN_FILE"`,
+			"## 2. Verify the token and show the user the skill catalog",
+			`"$CLAWVISOR_APP_URL/api/skill/catalog"`,
+			`echo "$CLAWVISOR_APP_URL/skill"`,
+			"## 3. Save an uninstall reference",
+			"## 4. Self-uninstall automatically",
+			// The opt-in has to stay discoverable from the default doc.
+			"route=proxy",
+			"403 PROXY_LITE_DISABLED",
+		)
+		assertNotContainsAny(t, "openclaw "+query, body,
+			// Routing steps, by heading.
+			"Detect the upstream LLM provider",
+			"Ensure a vaulted upstream key exists",
+			"Preflight: confirm OpenClaw can reach Clawvisor",
+			"Point OpenClaw at Clawvisor",
+			// The provider-routing mechanics themselves.
+			"openclaw config set models.providers.clawvisor",
+			`--arg baseUrl "$CLAWVISOR_LLM_URL$BASE_PATH"`,
+			"/api/runtime/llm-credentials",
+			"Vault a $PROVIDER_LABEL API key",
+			`case "$PROVIDER" in`,
+			// The routed wrap-up claim, which would be false here.
+			"is now routed through Clawvisor",
+		)
+		assertStepsContiguous(t, "openclaw "+query, body)
+	}
+
+	for _, query := range []string{"claim=abcDEF1234", "claim=abcDEF1234&route=skill-only"} {
+		body := installerGetQuery(t, h, "hermes", query)
+		assertContainsAll(t, body,
+			"**skill-only** install",
+			"## 1. Register and persist the token",
+			"/api/agents/connect",
+			`chmod 600 "$TOKEN_FILE"`,
+			"## 2. Verify the token and show the user the skill catalog",
+			`"$CLAWVISOR_APP_URL/api/skill/catalog"`,
+			"## 3. Save an uninstall reference",
+			"## 4. Self-uninstall automatically",
+			"route=proxy",
+			"403 PROXY_LITE_DISABLED",
+		)
+		assertNotContainsAny(t, "hermes "+query, body,
+			"Detect the upstream LLM provider",
+			"Ensure a vaulted upstream key exists",
+			"Preflight: confirm Hermes can reach Clawvisor",
+			"Configure Hermes",
+			// Swap-mode mechanics: the token-as-provider-key handoff and the
+			// config.yaml / .env / shell-alias writes that support it.
+			`"$BASE_ENV=$CLAWVISOR_LLM_URL$BASE_PATH"`,
+			"HERMES_CV_API_KEY",
+			"hermes-cv",
+			"/api/runtime/llm-credentials",
+			`case "$PROVIDER" in`,
+			"is now routed through Clawvisor",
+		)
+		assertStepsContiguous(t, "hermes "+query, body)
+	}
+}
+
+// TestInstallerMarkdownProxyRouteOptIn — route=proxy must still emit the fully
+// routed doc for both markdown targets. Guards the inverted default the same
+// way TestInstallerProxyRouteOptIn does for the shell targets: without this,
+// a later refactor could make routing unreachable for hermes/openclaw and
+// every remaining test would still pass.
+func TestInstallerMarkdownProxyRouteOptIn(t *testing.T) {
+	h := NewInstallerHandler("", "", true, "", "")
+
+	openclaw := installerGetQuery(t, h, "openclaw", "claim=CLAIMOPEN12&route=proxy")
+	assertContainsAll(t, openclaw,
+		"## 2. Detect the upstream LLM provider",
+		"## 3. Ensure a vaulted upstream key exists",
+		"## 5. Preflight: confirm OpenClaw can reach Clawvisor",
+		"## 6. Point OpenClaw at Clawvisor",
+		`openclaw config set models.providers.clawvisor "$PROVIDER_JSON" --strict-json --merge`,
+		`--arg baseUrl "$CLAWVISOR_LLM_URL$BASE_PATH"`,
+		"## 8. Self-uninstall automatically",
+		"openclaw is now routed through Clawvisor",
+	)
+	assertStepsContiguous(t, "openclaw route=proxy", openclaw)
+
+	hermes := installerGetQuery(t, h, "hermes", "claim=abcDEF1234&route=proxy")
+	assertContainsAll(t, hermes,
+		"## 2. Detect the upstream LLM provider",
+		"## 3. Ensure a vaulted upstream key exists",
+		"## 5. Preflight: confirm Hermes can reach Clawvisor",
+		"## 6. Configure Hermes",
+		`"$BASE_ENV=$CLAWVISOR_LLM_URL$BASE_PATH"`,
+		"HERMES_CV_API_KEY=$TOKEN",
+		"## 8. Self-uninstall automatically",
+		"hermes is now routed through Clawvisor",
+	)
+	assertStepsContiguous(t, "hermes route=proxy", hermes)
+}
+
+// TestInstallerMarkdownSkillOnlyUninstallDoc — the on-disk revert recipe must
+// match what the install actually did. A skill-only install never wrote a
+// `models.providers.clawvisor` entry, a `model:` block, a `HERMES_CV_API_KEY`
+// line, or a vaulted upstream key, so telling the user to remove them sends
+// them hand-editing config files hunting for entries that aren't there — and
+// makes the exit look scarier than it is.
+func TestInstallerMarkdownSkillOnlyUninstallDoc(t *testing.T) {
+	h := NewInstallerHandler("", "", true, "", "")
+
+	openclawSkill := installerGetQuery(t, h, "openclaw", "claim=CLAIMOPEN12")
+	openclawProxy := installerGetQuery(t, h, "openclaw", "claim=CLAIMOPEN12&route=proxy")
+	assertContainsAll(t, openclawSkill,
+		"This was a skill-only install",
+		"there is no\nClawvisor provider entry to remove",
+		"1. Delete the token file: `rm ~/.clawvisor/agents/openclaw.json`.",
+		"2. Revoke the agent in the Clawvisor dashboard under Agents → openclaw → Delete.",
+	)
+	assertNotContainsAny(t, "openclaw skill-only uninstall", openclawSkill,
+		"Remove the Clawvisor provider entry",
+		"If you set `models.default`",
+		"remove the user-level upstream key",
+	)
+	// The routed recipe keeps every one of those, since a routed install does
+	// create them.
+	assertContainsAll(t, openclawProxy,
+		"Remove the Clawvisor provider entry",
+		"If you set `models.default`",
+		"remove the user-level upstream key",
+	)
+
+	hermesSkill := installerGetQuery(t, h, "hermes", "claim=abcDEF1234")
+	hermesProxy := installerGetQuery(t, h, "hermes", "claim=abcDEF1234&route=proxy")
+	assertContainsAll(t, hermesSkill,
+		"This was a skill-only install",
+		"1. Delete the token file: `rm ~/.clawvisor/agents/hermes.json`.",
+		"2. Revoke the agent in the Clawvisor dashboard under Agents → hermes → Delete.",
+	)
+	assertNotContainsAny(t, "hermes skill-only uninstall", hermesSkill,
+		"Remove the `model:` block",
+		"Remove the `HERMES_CV_API_KEY` line",
+		"Remove the `hermes-cv` function",
+		"remove the user-level upstream key",
+	)
+	assertContainsAll(t, hermesProxy,
+		"Remove the `model:` block",
+		"Remove the `HERMES_CV_API_KEY` line",
+		"Remove the `hermes-cv` function",
+		"remove the user-level upstream key",
+	)
+}
+
+// TestInstallerMarkdownSkillOnlyFrontmatter — the frontmatter `description` is
+// what the user reads in their harness's skill / slash-command picker, so the
+// routed header's "route every session through Clawvisor by default" promise
+// must not ride along on a doc that configures no routing at all.
+func TestInstallerMarkdownSkillOnlyFrontmatter(t *testing.T) {
+	h := NewInstallerHandler("", "", true, "", "")
+	for _, target := range []string{"hermes", "openclaw"} {
+		body := installerGetQuery(t, h, target, "")
+		if !strings.HasPrefix(body, "---\nname: clawvisor-setup\ndescription:") {
+			t.Errorf("[%s] skill-only doc lost its frontmatter", target)
+		}
+		assertNotContainsAny(t, target, body,
+			"route every session through Clawvisor by default",
+		)
+		assertContainsAll(t, body,
+			"keeps talking to its own LLM provider",
+			"pass route=proxy",
+		)
+	}
 }
 
 // TestInstallerSubscriptionModeNoApiKey — a Claude-subscription/OAuth seat

--- a/web/src/pages/Agents.tsx
+++ b/web/src/pages/Agents.tsx
@@ -2330,9 +2330,12 @@ function OnePasteGuide({
     const qs = new URLSearchParams()
     if (claim) qs.set('claim', claim)
     qs.set('agent_name', agentName)
-    // Only self-install targets honor an explicit route; the markdown helpers
-    // have their own detection flow. skill-only is the server-side default, so
-    // the param is only appended when opting IN to routing.
+    // Every target honors route server-side now, the markdown helpers
+    // (hermes, openclaw) included. The guard stays on selfInstall only because
+    // the LLM-routing toggle below is rendered for those targets alone, so
+    // `route` is always 'skill-only' for the markdown ones and appending it
+    // would be a no-op. skill-only is the server-side default, so the param is
+    // only appended when opting IN to routing.
     if (spec.selfInstall && route === 'proxy') qs.set('route', 'proxy')
     return `${installerBaseURL}/skill/install/${target}?${qs.toString()}`
   }, [agentName, claim, installerBaseURL, target, route, spec.selfInstall])


### PR DESCRIPTION
## Why

Closes the `KNOWN GAP` documented on `installerCtx.Route` in #643.

#643 made `skill-only` the default install route, but only the self-install **shell** targets honoured it. `renderOpenClawInstaller` and `renderHermesInstaller` ignored `ctx.Route` entirely and unconditionally walked the user through pointing their provider at Clawvisor.

OpenClaw is the one that bites: it appears in `LEGACY_AGENT_TABS` (`web/src/pages/Agents.tsx`), the tab set shown to users **without** proxy-lite. So a user with no entitlement could pick OpenClaw, follow a routed doc, and get `403 PROXY_LITE_DISABLED` on their first model call — exactly the failure #643 set out to eliminate. Hermes is proxy-tab-only so gated users never see it, but it carried the identical latent bug.

## Approach

Both renderers now branch into a dedicated skill-only render function, mirroring how the shell targets keep `codex_skill_only.sh.tmpl` beside `codex.sh.tmpl`. Threading `if ctx.Route` through the routed bodies would have put the routed output one careless edit away from breaking; a separate function makes that structurally hard.

Dropped from the skill-only docs: detect-provider, vault-upstream-key, probe-deployment, preflight, and point-at-Clawvisor. Detect-provider and probe go too because their outputs (`$PROVIDER`, `$BASE_PATH`, `$KEY_ENV`, `$OPENCLAW_API`, …) are consumed *only* by the vault and configure steps — keeping them would leave dead variables plus prose telling the user to vault a key "so the proxy can route there."

Three things were also quietly wrong for skill-only and are now route-aware:

- `sectionSelfUninstall` claimed the harness "is now routed through Clawvisor"
- the uninstall recipe listed a provider entry / `model:` block / vaulted key that a skill-only install never creates
- `setupFrontmatter`'s description promised "route every session through Clawvisor by default" — that string is what the user reads in their harness's skill picker

## Verification

**Routed output is byte-identical.** Dumped both targets in all three variants before and after with a fixed `publicURL` (ephemeral httptest ports otherwise mask the comparison) and compared: `openclaw` routed is 19,889 B and `hermes` routed 20,235 B, unchanged. The default drops to 7,998 B / 7,953 B — the skill-only doc. On `main`, default and `route=proxy` were identical, which is the bug in one line.

**Step numbering** is contiguous in all four variants — skill-only 1–4, routed 1–8. A new `assertStepsContiguous` helper regex-extracts `## <n>.` headings and asserts 1..N so this can't silently rot.

**No dangling references** in the skill-only docs: they use only `$AGENT_NAME`, `$CLAWVISOR_APP_URL`, `$TOKEN`, `$TOKEN_FILE`, all assigned in step 1.

**New tests are load-bearing:** swapping in `main`'s `installer.go` fails 3 of the 4 new tests. (`TestInstallerMarkdownProxyRouteOptIn` passes on main by construction, since main always routes.)

Three existing tests asserted routed content via the bare default and now request `route=proxy` explicitly. `go build ./...`, `go vet`, and `go test ./...` all clean; no new `gofmt` complaints (`installer.go` has 6 pre-existing ones, content-identical before and after).

## Note on the dashboard

`Agents.tsx` only appends `route=` for `selfInstall` targets, so the dashboard never sends it for openclaw/hermes and renders no routing toggle for them. That means this fix takes effect for every dashboard-driven markdown install and no UI affordance is lost. `route=proxy` stays reachable by URL and the skill-only doc documents that escape hatch inline. A stale comment there is corrected; the logic is deliberately unchanged. Offering an Observe posture for OpenClaw in the UI would be a separate frontend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

