### PR TITLE
feat(install): make the skill-only one-liners actually install the skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,7 +496,7 @@ Clawvisor exposes an MCP (Model Context Protocol) server at `/mcp` with OAuth 2.
 
 Proxy-lite runs inside the Clawvisor daemon and presents Anthropic/OpenAI-compatible LLM endpoints to command-line agents. It can observe model API calls, intercept tool-use, hold inline approvals, and attribute requests to a registered agent without requiring a CONNECT/TLS MITM proxy.
 
-**Fresh-install default: Observe.** The setup wizard and the per-harness install scripts now route agent LLM traffic through proxy-lite in the **Observe** posture by default (visibility, zero behavior change). Skill-gateway-only remains a first-class opt-out — choose it in the wizard, or pass `route=skill-only` to an install script. Existing installs are never changed: the compiled default of `proxy_lite.enabled` stays `false`, so a config that predates the flip keeps its behavior on upgrade.
+**Fresh-install default: skill gateway.** The setup wizard and the per-harness install scripts install the Clawvisor skill and leave agents pointed at their own provider — no LLM traffic is routed. Routing through proxy-lite (the **Observe** posture) is the explicit opt-in: choose it in the wizard, or pass `route=proxy` to an install script. Existing installs are never changed: the compiled default of `proxy_lite.enabled` is `false`.
 
 > [!WARNING]
 > **Proxy-lite is in active development.** Behavior, flags, and the API surface may change in any release while it remains pre-1.0. Treat it as preview-quality and pin to a specific Clawvisor version in production.

--- a/docs/LITE_PROXY.md
+++ b/docs/LITE_PROXY.md
@@ -24,7 +24,9 @@ The two can coexist. The lite-proxy is the focus of this document.
 
 ## Enable the proxy
 
-**Fresh installs enable the lite-proxy in the Observe posture by default** — the setup wizard recommends it and the per-harness install scripts route through it (skill-gateway-only is the explicit opt-out: choose it in the wizard, or pass `route=skill-only` to an install script). The switch is **writer-side**: the compiled default of `proxy_lite.enabled` stays `false`, so **an existing config that never set the key is never silently enabled at upgrade** — it keeps behaving exactly as before. All routes listed below, the dashboard panels, and the CLI helpers refuse to operate until `proxy_lite.enabled` is `true` (which fresh wizard/daemon configs now write explicitly).
+**Fresh installs do NOT enable the lite-proxy.** The setup wizard recommends the skill gateway, and the per-harness install scripts install the Clawvisor skill without touching where the agent's model traffic goes. Routing through the proxy (the **Observe** posture) is the explicit opt-in: choose it in the wizard, or pass `route=proxy` to an install script. On Clawvisor Cloud, routing additionally requires proxy-lite to be enabled for your account — otherwise the first model call returns `403 PROXY_LITE_DISABLED`.
+
+The compiled default of `proxy_lite.enabled` is `false`, so **an existing config that never set the key is never silently enabled at upgrade** — it keeps behaving exactly as before. All routes listed below, the dashboard panels, and the CLI helpers refuse to operate until `proxy_lite.enabled` is `true`.
 
 In `config.yaml`:
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -34,11 +34,11 @@ is running and the user has dashboard access.
 
 ## Step 2: Connect an agent
 
-> Fresh installs default to the **Observe** posture: the interactive setup
-> wizard recommends routing agent LLM traffic through Clawvisor for visibility,
-> and the per-harness install scripts bake the routing by default. Prefer the
-> skill gateway only (no LLM routing)? Pick "Skill gateway only" in the wizard,
-> or pass `route=skill-only` to an install script. Existing installs are never
+> Fresh installs default to the **skill gateway**: the interactive setup wizard
+> recommends it, and the per-harness install scripts install the Clawvisor skill
+> while leaving your agent pointed at its own model provider. Want Clawvisor to
+> also see LLM traffic (the **Observe** posture)? Pick "Observe" in the wizard,
+> or pass `route=proxy` to an install script. Existing installs are never
 > changed on upgrade.
 
 The fastest way to connect an agent is:

--- a/docs/flip-cloud-coordination.md
+++ b/docs/flip-cloud-coordination.md
@@ -14,8 +14,10 @@ The flip is **writer-side only**:
 - `internal/daemon/setup.go` — stamps `config_schema: 2` (already wrote
   `proxy_lite.enabled: true`).
 - `internal/api/handlers/installer.go` + `installer_scripts/*.tmpl` — the
-  per-harness install scripts route LLM traffic by default; `route=skill-only`
-  is the opt-out; `route=subscription` handles OAuth seats.
+  per-harness install scripts install the Clawvisor skill and do **not** route
+  LLM traffic; `route=proxy` is the opt-in; `route=subscription` handles OAuth
+  seats. (The default was inverted in #643 — this document describes the
+  original forward flip and is retained for history.)
 - `pkg/config` — `Config` gains one **additive** field, `ConfigSchema int`
   (`config_schema`), plus the `CurrentConfigSchema` const. `Default()` is
   **unchanged**: `ProxyLite.Enabled` stays `false` permanently

--- a/internal/api/handlers/installer_scripts/claude_code_skill_only.sh.tmpl
+++ b/internal/api/handlers/installer_scripts/claude_code_skill_only.sh.tmpl
@@ -4,32 +4,78 @@
 {{- template "smoke_test" . -}}
 
 # --- Skill-only install (the default) ----------------------------------------
-# This is the skill-gateway variant. Claude Code keeps talking to Anthropic
-# directly — we do NOT set ANTHROPIC_BASE_URL, so no LLM traffic is routed
-# through Clawvisor. The registered agent token lets the Clawvisor skill/tools
-# govern tool calls; LLM observability is not enabled.
+# Claude Code keeps talking to Anthropic directly — we never set
+# ANTHROPIC_BASE_URL, so no LLM traffic is routed through Clawvisor. What this
+# install does provide is the gateway: the Clawvisor skill, the agent token it
+# authenticates with, and the permission rules that let it call out without a
+# prompt on every request.
 #
-# To route LLM traffic through Clawvisor later (the Observe posture), re-run
-# this installer WITH route=proxy. Routing is opt-in and needs proxy-lite
-# enabled for your account, so a routed install without it returns
-# 403 PROXY_LITE_DISABLED on the first model call:
+# To route model traffic through Clawvisor as well (the Observe posture), re-run
+# WITH route=proxy. Routing is opt-in and needs proxy-lite enabled for your
+# account, or the first model call returns 403 PROXY_LITE_DISABLED:
 #
 #   curl -fsSL "$APP_URL/skill/install/{{.Target}}.sh?claim=<claim>&route=proxy" | sh
+
+# --- Install the Clawvisor skill ---------------------------------------------
+# ~/.claude/skills/clawvisor/SKILL.md is the global location Claude Code reads
+# in every project — the same path `clawvisor-server connect-agent claude-code`
+# writes, so a later daemon-side setup overwrites rather than conflicts.
+#
+# ?target=claude-code is passed explicitly even though it is the server's
+# default: this script is the wrong place to depend on a default that lives in
+# another process.
+SKILL_DIR="$HOME/.claude/skills/clawvisor"
+mkdir -p "$SKILL_DIR"
+if ! curl -fsSL "$APP_URL/skill/SKILL.md?target=claude-code" -o "$SKILL_DIR/SKILL.md.tmp"; then
+    echo "could not download the Clawvisor skill from $APP_URL/skill/SKILL.md" >&2
+    rm -f "$SKILL_DIR/SKILL.md.tmp"
+    exit 1
+fi
+# Swap into place only after a complete download, so an interrupted install
+# can't leave a truncated SKILL.md that Claude Code would happily load.
+mv "$SKILL_DIR/SKILL.md.tmp" "$SKILL_DIR/SKILL.md"
+echo "✓ Installed the Clawvisor skill to $SKILL_DIR/SKILL.md"
+
+# --- Wire the env the skill needs, and allow its calls -----------------------
+# The skill's frontmatter declares CLAWVISOR_URL + CLAWVISOR_AGENT_TOKEN, and
+# Claude Code supplies env from settings.json. The permission rules matter just
+# as much: without them the skill's gateway curls prompt on every single call,
+# which leaves the install technically complete and practically unusable.
+SETTINGS="$HOME/.claude/settings.json"
+mkdir -p "$HOME/.claude"
+[ -f "$SETTINGS" ] || echo '{}' > "$SETTINGS"
+
+# umask before the write rather than chmod after it: $SETTINGS.tmp carries the
+# agent token, and a chmod that follows the write leaves a window where the
+# token is readable at the ambient umask (commonly 0644). The same token is
+# already 0600 in ~/.clawvisor/agents/ — it must not be world-readable here.
+CV_OLD_UMASK=$(umask)
+umask 077
+jq \
+    --arg url "$APP_URL" \
+    --arg token "$TOKEN" \
+    --arg rule_url '{{.RelayPermissionRule}}' \
+    '
+    .env = ((.env // {}) + {
+        CLAWVISOR_URL: $url,
+        CLAWVISOR_AGENT_TOKEN: $token
+    })
+    | .permissions = ((.permissions // {}))
+    | .permissions.allow = (
+        ((.permissions.allow // []) + [
+            "Bash(curl *http://localhost:25297/*)",
+            "Bash(curl *$CLAWVISOR_URL/*)",
+            $rule_url
+        ]) | unique
+    )
+    ' "$SETTINGS" > "$SETTINGS.tmp" && mv "$SETTINGS.tmp" "$SETTINGS"
+chmod 600 "$SETTINGS"
+umask "$CV_OLD_UMASK"
+echo "✓ Wired CLAWVISOR_URL + CLAWVISOR_AGENT_TOKEN into $SETTINGS (chmod 600)"
+echo "  and allowed the skill's gateway calls in permissions.allow"
+
 echo "✓ Registered {{.HarnessLabel}} with Clawvisor (skill-only — LLM traffic is NOT routed)."
-echo "  The Clawvisor skill catalog is available at $APP_URL/skill."
 
-# --- Write the uninstall reference -------------------------------------------
-UNINSTALL_DOC="$HOME/.clawvisor/uninstall-claude-code.md"
-cat > "$UNINSTALL_DOC" <<EOF
-# How to disconnect Claude Code from Clawvisor (skill-only install)
-
-This install did not change how Claude Code reaches Anthropic — it only
-registered an agent token. To fully disconnect:
-
-1. Delete the token file: rm ~/.clawvisor/agents/$AGENT_SLOT.json
-2. Revoke the agent in the Clawvisor dashboard under Agents → $AGENT_NAME → Delete.
-EOF
-echo "✓ Wrote revert recipe to $UNINSTALL_DOC"
-
+{{ template "dry_run" . }}
 echo
-echo "Done. Skill-only install complete — no routing changes were made."
+echo "Done. Claude Code reaches the Clawvisor gateway through the skill; LLM traffic is NOT routed."

--- a/internal/api/handlers/installer_scripts/codex_skill_only.sh.tmpl
+++ b/internal/api/handlers/installer_scripts/codex_skill_only.sh.tmpl
@@ -4,32 +4,122 @@
 {{- template "smoke_test" . -}}
 
 # --- Skill-only install (the default) ----------------------------------------
-# This is the skill-gateway variant. Codex keeps talking to OpenAI directly —
-# we do NOT add a [model_providers.*] block or set OPENAI_BASE_URL, so no LLM
-# traffic is routed through Clawvisor. The registered agent token lets the
-# Clawvisor skill/tools govern tool calls; LLM observability is not enabled.
+# Codex keeps talking to OpenAI directly — we never add a [model_providers.*]
+# block or set OPENAI_BASE_URL, so no LLM traffic is routed through Clawvisor.
+# What this install provides is the gateway: the Clawvisor skill, the agent
+# token it authenticates with, and (with your consent) the sandbox egress it
+# needs to reach Clawvisor at all.
 #
-# To route LLM traffic through Clawvisor later (the Observe posture), re-run
-# this installer WITH route=proxy. Routing is opt-in and needs proxy-lite
-# enabled for your account, so a routed install without it returns
-# 403 PROXY_LITE_DISABLED on the first model call:
+# To route model traffic through Clawvisor as well (the Observe posture), re-run
+# WITH route=proxy. Routing is opt-in and needs proxy-lite enabled for your
+# account, or the first model call returns 403 PROXY_LITE_DISABLED:
 #
 #   curl -fsSL "$APP_URL/skill/install/{{.Target}}.sh?claim=<claim>&route=proxy" | sh
+
+# --- Install the Clawvisor skill ---------------------------------------------
+# Codex reads skills from ~/.codex/skills/<name>/SKILL.md. The per-skill
+# subdirectory has to exist first — curl --create-dirs will not create it for a
+# path it is only writing a file into.
+SKILL_DIR="$HOME/.codex/skills/clawvisor"
+mkdir -p "$SKILL_DIR"
+if ! curl -fsSL "$APP_URL/skill/SKILL.md?target=codex" -o "$SKILL_DIR/SKILL.md.tmp"; then
+    echo "could not download the Clawvisor skill from $APP_URL/skill/SKILL.md" >&2
+    rm -f "$SKILL_DIR/SKILL.md.tmp"
+    exit 1
+fi
+# ?target=codex matters: the Claude Code render carries a rationale about
+# permission globs that does not apply to Codex, and an OpenClaw metadata block
+# Codex has no use for.
+#
+# Swap into place only after a complete download, so an interrupted install
+# can't leave a truncated SKILL.md that Codex would try to load — it rejects
+# skills missing name/description frontmatter at startup.
+mv "$SKILL_DIR/SKILL.md.tmp" "$SKILL_DIR/SKILL.md"
+echo "✓ Installed the Clawvisor skill to $SKILL_DIR/SKILL.md"
+
+# --- Export the env the skill needs ------------------------------------------
+# The skill's frontmatter declares CLAWVISOR_URL and CLAWVISOR_AGENT_TOKEN.
+# Both are exported, by reference rather than by value: the token stays in the
+# 0600 file under ~/.clawvisor/agents/ and is read at shell start, so it never
+# lands in an rc file that is typically world-readable.
+case "$SHELL" in
+    */zsh)  RC="$HOME/.zshrc" ;;
+    */bash) RC="$HOME/.bashrc" ;;
+    *)      RC="" ;;
+esac
+if [ -n "$RC" ]; then
+    RC_EXPORT="export CLAWVISOR_URL=\"$APP_URL\"
+export CLAWVISOR_AGENT_TOKEN=\$(jq -r .token \$HOME/.clawvisor/agents/$AGENT_SLOT.json)"
+    # Guard on a stable substring rather than the whole block, so a re-run with
+    # a different APP_URL still matches and doesn't stack duplicate exports.
+    if grep -F -q "agents/$AGENT_SLOT.json" "$RC" 2>/dev/null; then
+        echo "  (CLAWVISOR_* exports for $AGENT_SLOT already in $RC; leaving them untouched)"
+    else
+        printf '\n%s\n' "$RC_EXPORT" >> "$RC"
+        echo "✓ Appended CLAWVISOR_URL + CLAWVISOR_AGENT_TOKEN exports to $RC"
+        echo "  (open a new shell, or run: . $RC)"
+    fi
+else
+    echo "  (unknown shell: $SHELL — export these yourself)" >&2
+    echo "    export CLAWVISOR_URL=\"$APP_URL\"" >&2
+    echo "    export CLAWVISOR_AGENT_TOKEN=\$(jq -r .token \$HOME/.clawvisor/agents/$AGENT_SLOT.json)" >&2
+fi
+
+# --- Sandbox egress (asks first) ---------------------------------------------
+# Codex has no per-command allowlist like Claude Code's permissions.allow. Its
+# sandbox blocks outbound network by default, so the skill's gateway curls fail
+# with connection-refused until workspace-write is allowed network access.
+#
+# That is a real relaxation of the sandbox, so it is never applied silently:
+# an explicit flag wins, otherwise we ask, and with no terminal we decline and
+# print the line. The routed installer only ever passes this per-invocation
+# (-c) for its own smoke test; persisting it is a bigger step and is treated
+# as one.
+CODEX_CONFIG="$HOME/.codex/config.toml"
+NET_LINE='[sandbox_workspace_write]
+network_access = true'
+mkdir -p "$HOME/.codex"
+touch "$CODEX_CONFIG"
+
+CV_WANT_NETWORK=no
+if [ "$CV_ALLOW_NETWORK" = yes ]; then
+    CV_WANT_NETWORK=yes
+elif [ "$CV_ALLOW_NETWORK" = no ]; then
+    CV_WANT_NETWORK=no
+elif grep -q "^network_access[[:space:]]*=[[:space:]]*true" "$CODEX_CONFIG" 2>/dev/null; then
+    echo "✓ Codex sandbox already allows network access — nothing to change"
+    CV_WANT_NETWORK=already
+elif [ -r /dev/tty ] && [ -w /dev/tty ]; then
+    echo
+    echo "Codex sandboxes its shell and blocks outbound network by default, which"
+    echo "means the Clawvisor skill cannot reach $APP_URL."
+    echo "Allowing egress writes this to $CODEX_CONFIG:"
+    echo
+    echo "    [sandbox_workspace_write]"
+    echo "    network_access = true"
+    echo
+    echo "This lets sandboxed Codex commands reach the network in general, not just"
+    echo "Clawvisor. Decline if you would rather scope it yourself."
+    if prompt_yn "Allow Codex sandbox network access?" yes; then
+        CV_WANT_NETWORK=yes
+    fi
+else
+    echo "  (no terminal to ask on; leaving the Codex sandbox unchanged)"
+fi
+
+if [ "$CV_WANT_NETWORK" = yes ]; then
+    printf '\n%s\n' "$NET_LINE" >> "$CODEX_CONFIG"
+    echo "✓ Allowed Codex sandbox network access in $CODEX_CONFIG"
+elif [ "$CV_WANT_NETWORK" = no ]; then
+    echo "→ Left the Codex sandbox unchanged. The Clawvisor skill will not be able to"
+    echo "  reach $APP_URL until you add this to $CODEX_CONFIG:"
+    echo
+    echo "    [sandbox_workspace_write]"
+    echo "    network_access = true"
+fi
+
 echo "✓ Registered {{.HarnessLabel}} with Clawvisor (skill-only — LLM traffic is NOT routed)."
-echo "  The Clawvisor skill catalog is available at $APP_URL/skill."
 
-# --- Write the uninstall reference -------------------------------------------
-UNINSTALL_DOC="$HOME/.clawvisor/uninstall-codex.md"
-cat > "$UNINSTALL_DOC" <<EOF
-# How to disconnect Codex from Clawvisor (skill-only install)
-
-This install did not change how Codex reaches OpenAI — it only registered an
-agent token. To fully disconnect:
-
-1. Delete the token file: rm ~/.clawvisor/agents/$AGENT_SLOT.json
-2. Revoke the agent in the Clawvisor dashboard under Agents → $AGENT_NAME → Delete.
-EOF
-echo "✓ Wrote revert recipe to $UNINSTALL_DOC"
-
+{{ template "dry_run" . }}
 echo
-echo "Done. Skill-only install complete — no routing changes were made."
+echo "Done. Codex reaches the Clawvisor gateway through the skill; LLM traffic is NOT routed."

--- a/internal/api/handlers/installer_scripts/codex_skill_only.sh.tmpl
+++ b/internal/api/handlers/installer_scripts/codex_skill_only.sh.tmpl
@@ -81,14 +81,31 @@ network_access = true'
 mkdir -p "$HOME/.codex"
 touch "$CODEX_CONFIG"
 
+# Order matters here. The "is it already done?" checks run BEFORE the flags,
+# because appending a second [sandbox_workspace_write] table makes Codex refuse
+# to load config.toml at all ("duplicate key") — it stops working entirely. A
+# re-run with --allow-network must be a no-op, not a wedge.
 CV_WANT_NETWORK=no
-if [ "$CV_ALLOW_NETWORK" = yes ]; then
+if grep -q "^[[:space:]]*network_access[[:space:]]*=[[:space:]]*true" "$CODEX_CONFIG" 2>/dev/null; then
+    echo "✓ Codex sandbox already allows network access — nothing to change"
+    CV_WANT_NETWORK=already
+elif grep -q "^[[:space:]]*\[sandbox_workspace_write\]" "$CODEX_CONFIG" 2>/dev/null; then
+    # The table exists but network_access isn't set to true in it. Appending
+    # our own copy of the header would duplicate the table and break Codex, and
+    # inserting a key into an existing TOML table with sed is not something to
+    # attempt blind against a file the user owns. Hand it back to them.
+    echo "→ $CODEX_CONFIG already has a [sandbox_workspace_write] section, so this"
+    echo "  installer will not edit it — adding a second one would stop Codex loading"
+    echo "  the file. Add this line under the existing section yourself:"
+    echo
+    echo "    network_access = true"
+    echo
+    echo "  Until then the Clawvisor skill will not be able to reach $APP_URL."
+    CV_WANT_NETWORK=manual
+elif [ "$CV_ALLOW_NETWORK" = yes ]; then
     CV_WANT_NETWORK=yes
 elif [ "$CV_ALLOW_NETWORK" = no ]; then
     CV_WANT_NETWORK=no
-elif grep -q "^network_access[[:space:]]*=[[:space:]]*true" "$CODEX_CONFIG" 2>/dev/null; then
-    echo "✓ Codex sandbox already allows network access — nothing to change"
-    CV_WANT_NETWORK=already
 elif [ -r /dev/tty ] && [ -w /dev/tty ]; then
     echo
     echo "Codex sandboxes its shell and blocks outbound network by default, which"

--- a/internal/api/handlers/installer_scripts/common.sh.tmpl
+++ b/internal/api/handlers/installer_scripts/common.sh.tmpl
@@ -472,11 +472,17 @@ what happened. Follow the skill's own instructions for each step.
    me the response.
 4. Then make a second request against the SAME task that is clearly OUTSIDE its
    scope — for instance sending or deleting something when the task only allows
-   reading. Show me the result. This one is SUPPOSED to be rejected; a rejection
-   here is a pass, not a failure.
-5. Summarise: the in-scope request should have succeeded and the out-of-scope
-   request should have been denied. If either came back differently, say so
-   plainly and help me work out why.
+   reading. Show me the result.
+
+   The pass condition here is that the write NEVER EXECUTES on the read-only
+   task's authority. Do not expect a flat rejection: per the authorization
+   model an out-of-scope action normally comes back as pending_scope_expansion,
+   where the gate holds it and offers to ask me to widen the scope. That is a
+   pass. A blocked status is also a pass but means something different — a
+   restriction matched. Tell me which one you actually got.
+5. Summarise: the in-scope request should have succeeded, and the out-of-scope
+   one should have been held rather than executed. If either came back
+   differently, say so plainly and help me work out why.
 
 Do not modify any configuration files. This is a read-only check of an install
 that has already completed.
@@ -488,8 +494,25 @@ CVPROMPT
 # when /dev/tty is unavailable, which would make an unattended `curl | sh` spawn
 # an agent; requiring a tty keeps the interactive default "yes" without ever
 # firing in CI.
+# Every gateway request needs a task, and every task needs a service to scope
+# against — so with an empty catalog the dry run cannot do the thing it
+# promises. That is the normal state right after a fresh install, which is
+# exactly when this runs. Checking here means the user gets one clear sentence
+# instead of spending an agent turn to be told the same thing.
+CV_CATALOG=$(curl -sf -H "X-Clawvisor-Agent-Token: $TOKEN" \
+    "$APP_URL/api/skill/catalog" 2>/dev/null || true)
+CV_HAVE_SERVICES=yes
+case "$CV_CATALOG" in
+    *"No cloud services are currently activated"*|"") CV_HAVE_SERVICES=no ;;
+esac
+
 CV_WANT_DRY_RUN=no
-if [ "$CV_DRY_RUN" = yes ]; then
+if [ "$CV_HAVE_SERVICES" = no ] && [ "$CV_DRY_RUN" != yes ]; then
+    echo
+    echo "  Skipping the end-to-end dry run: no services are connected yet, so there is"
+    echo "  nothing for a task to be scoped against. Connect one in the Clawvisor"
+    echo "  dashboard (Services), then re-run this installer with --dry-run."
+elif [ "$CV_DRY_RUN" = yes ]; then
     CV_WANT_DRY_RUN=yes
 elif [ "$CV_DRY_RUN" = no ]; then
     CV_WANT_DRY_RUN=no

--- a/internal/api/handlers/installer_scripts/common.sh.tmpl
+++ b/internal/api/handlers/installer_scripts/common.sh.tmpl
@@ -517,31 +517,57 @@ if [ "$CV_WANT_DRY_RUN" = yes ]; then
     # Output is deliberately NOT captured — the point is for the user to watch
     # the two requests land. Only CLAWVISOR_* is exported: no ANTHROPIC_*/
     # OPENAI_* routing vars, which is what makes this a skill-only check.
+    CV_DRY_STATUS=missing
 {{- if eq .Target "codex" }}
     if command -v codex >/dev/null 2>&1; then
-        CLAWVISOR_URL="$APP_URL" \
-        CLAWVISOR_AGENT_TOKEN="$TOKEN" \
-            codex exec --skip-git-repo-check "$(cv_dry_run_prompt)" </dev/null || true
+        if CLAWVISOR_URL="$APP_URL" \
+           CLAWVISOR_AGENT_TOKEN="$TOKEN" \
+               codex exec --skip-git-repo-check "$(cv_dry_run_prompt)" </dev/null; then
+            CV_DRY_STATUS=ok
+        else
+            CV_DRY_STATUS=failed
+        fi
     else
         echo "  codex is not on your PATH, so the dry run was skipped." >&2
         echo "  Install codex and re-run with --dry-run to try again." >&2
     fi
 {{- else }}
     if command -v claude >/dev/null 2>&1; then
-        CLAWVISOR_URL="$APP_URL" \
-        CLAWVISOR_AGENT_TOKEN="$TOKEN" \
-            claude -p "$(cv_dry_run_prompt)" </dev/null || true
+        if CLAWVISOR_URL="$APP_URL" \
+           CLAWVISOR_AGENT_TOKEN="$TOKEN" \
+               claude -p "$(cv_dry_run_prompt)" </dev/null; then
+            CV_DRY_STATUS=ok
+        else
+            CV_DRY_STATUS=failed
+        fi
     else
         echo "  claude is not on your PATH, so the dry run was skipped." >&2
         echo "  Install Claude Code and re-run with --dry-run to try again." >&2
     fi
 {{- end }}
-    # `|| true` above is deliberate: the install itself already succeeded and is
-    # persisted. A failed or abandoned dry run is diagnostic information, not a
-    # reason to report the install as broken.
+    # Never fails the install: it already succeeded and is persisted on disk. A
+    # failed or abandoned dry run is diagnostic information, not a reason to
+    # report the install as broken.
+    #
+    # The outcome is reported honestly, though. Printing "read the summary
+    # above" when the harness never started — not logged in, missing binary —
+    # points the user at a summary that does not exist and reads as though
+    # something passed.
     echo
-    echo "  Dry run finished. Read the summary above — the in-scope request should"
-    echo "  have succeeded and the out-of-scope one should have been denied."
+    case "$CV_DRY_STATUS" in
+        ok)
+            echo "  Dry run finished. Read the summary above — the in-scope request should"
+            echo "  have succeeded and the out-of-scope one should have been denied."
+            ;;
+        failed)
+            echo "  The dry run did not complete — see the harness output above. Your install"
+            echo "  is still fine; re-run the dry run any time with --dry-run."
+            ;;
+        *)
+            echo "  Dry run skipped. Re-run this installer with --dry-run once the harness"
+            echo "  is available to try again."
+            ;;
+    esac
 fi
 {{end -}}
 

--- a/internal/api/handlers/installer_scripts/common.sh.tmpl
+++ b/internal/api/handlers/installer_scripts/common.sh.tmpl
@@ -53,6 +53,19 @@ Flags:
   --no-yolo              Don't pass that flag.
   --no-tui               Use the plain [y/n] prompts instead of the
                          arrow-key selector (also: CLAWVISOR_NO_TUI=1).
+  --dry-run              Run the end-to-end dry run at the end without asking.
+                         Spawns this harness and has it exercise the gateway
+                         for real: one in-scope request, then one out-of-scope
+                         request that must be denied. Skill-only installs only.
+  --no-dry-run           Skip the dry run without asking. This is also what
+                         happens when there is no terminal to prompt on, so
+                         the dry run never fires unattended.
+  --allow-network        (codex) Persist sandbox_workspace_write.network_access
+                         = true so the skill can reach the gateway, without
+                         asking.
+  --no-allow-network     (codex) Leave the sandbox alone. The skill will not be
+                         able to reach the gateway until you allow egress
+                         yourself; the script prints the exact line.
   -h, --help             Show this help and exit.
 
 Without --default-everywhere / --alias-only, the script reads /dev/tty.
@@ -66,6 +79,8 @@ CV_ALIAS_NAME=""      # function name for alias mode (default in per-target tmpl
 CV_NO_TUI="${CLAWVISOR_NO_TUI:-0}"  # 1 disables the arrow-key selector
 CV_INVITE_STDIN=""    # "1" when --invite-stdin was passed
 CV_INVITE_FILE=""     # path when --invite-file=PATH was passed
+CV_DRY_RUN=""         # "yes" or "no"; empty means ask (skill-only installs)
+CV_ALLOW_NETWORK=""   # "yes" or "no"; empty means ask (codex skill-only)
 for arg in "$@"; do
     case "$arg" in
         --invite-stdin)       CV_INVITE_STDIN=1 ;;
@@ -76,6 +91,10 @@ for arg in "$@"; do
         --yolo)               CV_YOLO=yes ;;
         --no-yolo)            CV_YOLO=no  ;;
         --no-tui)             CV_NO_TUI=1 ;;
+        --dry-run)            CV_DRY_RUN=yes ;;
+        --no-dry-run)         CV_DRY_RUN=no  ;;
+        --allow-network)      CV_ALLOW_NETWORK=yes ;;
+        --no-allow-network)   CV_ALLOW_NETWORK=no  ;;
         -h|--help)            usage ;;
         *) echo "unknown flag: $arg" >&2; usage ;;
     esac
@@ -428,6 +447,102 @@ jq -n \
     > "$AGENT_JSON"
 chmod 600 "$AGENT_JSON"
 echo "✓ Token saved to $AGENT_JSON (chmod 600)"
+{{end -}}
+
+{{define "dry_run"}}# --- Optional end-to-end dry run ---------------------------------------------
+# The smoke test above only proves the token is live. This proves the product
+# works: that the skill loaded, the env resolved inside the harness, the calls
+# are permitted, the gateway is reachable, and — the part nothing else checks —
+# that an out-of-scope request is actually DENIED.
+#
+# The prompt hands the whole flow to the Clawvisor skill, which already owns
+# creating a task, long-polling for approval, and telling the user to approve it
+# in the dashboard. Nothing here needs its own polling or timeout logic.
+cv_dry_run_prompt() {
+    cat <<'CVPROMPT'
+Use the Clawvisor skill to run an end-to-end check of this setup, then report
+what happened. Follow the skill's own instructions for each step.
+
+1. Fetch the Clawvisor catalog and pick any service that is already connected.
+2. Create a task whose scope is narrow and READ-ONLY — for example "read the
+   subject of my most recent email" or "list my GitHub notifications". Follow
+   the skill's guidance on waiting for approval, and tell me clearly that I need
+   to approve it in the Clawvisor dashboard or mobile app.
+3. Once it is approved, make one request that is INSIDE the task's scope. Show
+   me the response.
+4. Then make a second request against the SAME task that is clearly OUTSIDE its
+   scope — for instance sending or deleting something when the task only allows
+   reading. Show me the result. This one is SUPPOSED to be rejected; a rejection
+   here is a pass, not a failure.
+5. Summarise: the in-scope request should have succeeded and the out-of-scope
+   request should have been denied. If either came back differently, say so
+   plainly and help me work out why.
+
+Do not modify any configuration files. This is a read-only check of an install
+that has already completed.
+CVPROMPT
+}
+
+# Decide whether to run it. An explicit flag always wins. Otherwise ask — but
+# only when there is a terminal to ask on. prompt_yn falls back to its default
+# when /dev/tty is unavailable, which would make an unattended `curl | sh` spawn
+# an agent; requiring a tty keeps the interactive default "yes" without ever
+# firing in CI.
+CV_WANT_DRY_RUN=no
+if [ "$CV_DRY_RUN" = yes ]; then
+    CV_WANT_DRY_RUN=yes
+elif [ "$CV_DRY_RUN" = no ]; then
+    CV_WANT_DRY_RUN=no
+elif [ -r /dev/tty ] && [ -w /dev/tty ]; then
+    echo
+    echo "One last optional step: a dry run that spawns {{.HarnessLabel}} and has it make a"
+    echo "real in-scope request plus an out-of-scope one, to prove enforcement works."
+    echo "It will ask you to approve a task in the Clawvisor dashboard."
+    if prompt_yn "Run the end-to-end dry run now?" yes; then
+        CV_WANT_DRY_RUN=yes
+    fi
+else
+    echo "  (skipping the optional dry run — no terminal to prompt on; pass --dry-run to force it)"
+fi
+
+if [ "$CV_WANT_DRY_RUN" = yes ]; then
+    echo
+    echo "→ Running the end-to-end dry run via {{.HarnessLabel}}…"
+    echo "  (approve the task in the Clawvisor dashboard when prompted)"
+    echo
+    # </dev/null is load-bearing: under `curl | sh`, sh's stdin IS the curl pipe
+    # carrying the rest of this script. Without the redirect the harness reads
+    # it as prompt input and sh exits silently at EOF once the harness returns.
+    #
+    # Output is deliberately NOT captured — the point is for the user to watch
+    # the two requests land. Only CLAWVISOR_* is exported: no ANTHROPIC_*/
+    # OPENAI_* routing vars, which is what makes this a skill-only check.
+{{- if eq .Target "codex" }}
+    if command -v codex >/dev/null 2>&1; then
+        CLAWVISOR_URL="$APP_URL" \
+        CLAWVISOR_AGENT_TOKEN="$TOKEN" \
+            codex exec --skip-git-repo-check "$(cv_dry_run_prompt)" </dev/null || true
+    else
+        echo "  codex is not on your PATH, so the dry run was skipped." >&2
+        echo "  Install codex and re-run with --dry-run to try again." >&2
+    fi
+{{- else }}
+    if command -v claude >/dev/null 2>&1; then
+        CLAWVISOR_URL="$APP_URL" \
+        CLAWVISOR_AGENT_TOKEN="$TOKEN" \
+            claude -p "$(cv_dry_run_prompt)" </dev/null || true
+    else
+        echo "  claude is not on your PATH, so the dry run was skipped." >&2
+        echo "  Install Claude Code and re-run with --dry-run to try again." >&2
+    fi
+{{- end }}
+    # `|| true` above is deliberate: the install itself already succeeded and is
+    # persisted. A failed or abandoned dry run is diagnostic information, not a
+    # reason to report the install as broken.
+    echo
+    echo "  Dry run finished. Read the summary above — the in-scope request should"
+    echo "  have succeeded and the out-of-scope one should have been denied."
+fi
 {{end -}}
 
 {{define "smoke_test"}}# --- Smoke test: token is live -----------------------------------------------

--- a/internal/api/handlers/installer_syntax_test.go
+++ b/internal/api/handlers/installer_syntax_test.go
@@ -1,0 +1,62 @@
+package handlers
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// shellInstallerVariants is every (target, route) pair that renders a shell
+// script. Kept as one table so a new route variant gets syntax-checked by
+// construction rather than by remembering to add it.
+func shellInstallerVariants() []struct{ name, target, query string } {
+	return []struct{ name, target, query string }{
+		{"claude-code default (skill-only)", "claude-code", "claim=ABCDEFGHIJ"},
+		{"claude-code route=skill-only", "claude-code", "claim=ABCDEFGHIJ&route=skill-only"},
+		{"claude-code route=proxy", "claude-code", "claim=ABCDEFGHIJ&route=proxy"},
+		{"claude-code route=subscription", "claude-code", "claim=ABCDEFGHIJ&route=subscription"},
+		{"codex default (skill-only)", "codex", "claim=CLAIMCODE0"},
+		{"codex route=skill-only", "codex", "claim=CLAIMCODE0&route=skill-only"},
+		{"codex route=proxy", "codex", "claim=CLAIMCODE0&route=proxy"},
+	}
+}
+
+// TestInstallerScriptsAreValidShell parses every rendered installer with
+// `sh -n`. Until this existed, nothing in the repo checked that the scripts we
+// pipe into a user's shell were even syntactically valid — every other assertion
+// is a substring match, which cannot catch an unbalanced heredoc, an unclosed
+// `if`, or a stray `fi`. Those are exactly the mistakes a large template edit
+// makes, and the failure mode is a script that dies partway through after having
+// already half-modified the user's config.
+//
+// `sh -n` is POSIX and present everywhere the tests run, so this needs no new
+// dependency. It is a parse-only check: nothing is executed.
+func TestInstallerScriptsAreValidShell(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skipf("no sh on PATH: %v", err)
+	}
+	h := NewInstallerHandler("relay.example.com", "daemon1", false,
+		"https://llm.example.com", "https://app.example.com")
+
+	for _, v := range shellInstallerVariants() {
+		t.Run(v.name, func(t *testing.T) {
+			body := installerGetShellQuery(t, h, v.target, v.query)
+
+			cmd := exec.Command("sh", "-n")
+			cmd.Stdin = strings.NewReader(body)
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				// Number the lines so the parser's complaint is actionable —
+				// "syntax error near line 214" is useless against a body you
+				// cannot see.
+				var b strings.Builder
+				for i, line := range strings.Split(body, "\n") {
+					fmt.Fprintf(&b, "%d\t%s\n", i+1, line)
+				}
+				t.Fatalf("`sh -n` rejected the rendered script: %v\n%s\n--- script ---\n%s",
+					err, out, b.String())
+			}
+		})
+	}
+}

--- a/internal/api/handlers/installer_test.go
+++ b/internal/api/handlers/installer_test.go
@@ -1126,6 +1126,53 @@ func TestCodexSkillOnlyAsksBeforeRelaxingSandbox(t *testing.T) {
 	assertContainsAll(t, codex, "leaving the Codex sandbox unchanged")
 }
 
+// TestCodexSandboxWriteCannotDuplicateTheTable pins the ordering of the sandbox
+// decision, which a substring assertion alone would miss.
+//
+// The first version of this code checked the --allow-network flag before
+// checking whether the setting was already present, so a second run with the
+// flag appended a second [sandbox_workspace_write] table. Codex then refuses to
+// load config.toml at all ("duplicate key") — the installer bricked the harness
+// it had just set up. Caught by actually running it twice, not by any test.
+//
+// Two invariants, both order-dependent:
+//   - the "already true" check must precede the flag branches, so a repeat run
+//     with --allow-network is a no-op
+//   - the "table already exists" check must also precede them, so a user whose
+//     config has that section (with other keys) gets instructions instead of a
+//     duplicate header
+func TestCodexSandboxWriteCannotDuplicateTheTable(t *testing.T) {
+	h := NewInstallerHandler("", "", true, "", "")
+	codex := installerGetShell(t, h, "codex", "CLAIMCODE0")
+
+	alreadyTrue := strings.Index(codex, "network_access[[:space:]]*=[[:space:]]*true")
+	tableExists := strings.Index(codex, `\[sandbox_workspace_write\]`)
+	flagBranch := strings.Index(codex, `[ "$CV_ALLOW_NETWORK" = yes ]`)
+
+	for _, probe := range []struct {
+		name string
+		idx  int
+	}{
+		{"already-true guard", alreadyTrue},
+		{"existing-table guard", tableExists},
+		{"--allow-network branch", flagBranch},
+	} {
+		if probe.idx < 0 {
+			t.Fatalf("%s not found in the rendered codex installer", probe.name)
+		}
+	}
+
+	if alreadyTrue > flagBranch {
+		t.Error("the already-enabled check must run BEFORE --allow-network, or a repeat " +
+			"run with the flag appends a duplicate [sandbox_workspace_write] table and " +
+			"Codex stops loading config.toml entirely")
+	}
+	if tableExists > flagBranch {
+		t.Error("the existing-table check must run BEFORE --allow-network, or a user who " +
+			"already has [sandbox_workspace_write] gets a duplicate header appended")
+	}
+}
+
 // TestInstallerProxyRouteOptIn — route=proxy is now the explicit opt-in, and
 // must still produce the fully-routed script. Guards the inverted default:
 // without this, flipping the fallback could silently make routing unreachable.

--- a/internal/api/handlers/installer_test.go
+++ b/internal/api/handlers/installer_test.go
@@ -1025,6 +1025,107 @@ func TestInstallerDefaultIsSkillOnly(t *testing.T) {
 	assertContainsAll(t, codex, "skill-only", "/api/agents/connect", "LLM traffic is NOT routed")
 }
 
+// TestSkillOnlyInstallsTheSkill — the whole point of a skill-only install. Until
+// this existed the script minted a token and stopped, so the harness ended up
+// with a credential on disk and no idea Clawvisor existed: the agent never
+// routed tool calls through the gateway because nothing had told it to. The
+// installer must leave the skill on disk AND make the env it declares
+// (CLAWVISOR_URL, CLAWVISOR_AGENT_TOKEN) resolvable by the harness.
+func TestSkillOnlyInstallsTheSkill(t *testing.T) {
+	h := NewInstallerHandler("", "", true, "", "")
+
+	claude := installerGetShell(t, h, "claude-code", "ABCDEFGHIJ")
+	assertContainsAll(t, claude,
+		// Fetched per-target: the Claude Code render carries permission-glob
+		// guidance that would mislead any other harness.
+		"/skill/SKILL.md?target=claude-code",
+		".claude/skills/clawvisor",
+		"CLAWVISOR_URL",
+		"CLAWVISOR_AGENT_TOKEN",
+		// Without the allow-rules the skill prompts on every gateway call,
+		// which is "installed" but not usable.
+		"permissions.allow",
+	)
+
+	codex := installerGetShell(t, h, "codex", "CLAIMCODE0")
+	assertContainsAll(t, codex,
+		"/skill/SKILL.md?target=codex",
+		".codex/skills/clawvisor",
+		"CLAWVISOR_URL",
+		"CLAWVISOR_AGENT_TOKEN",
+	)
+}
+
+// TestSkillOnlyProtectsTheTokenAtRest — the agent token is written into
+// ~/.claude/settings.json so Claude Code can read it as env. The same secret is
+// already chmod 600 in ~/.clawvisor/agents/, and the routed installer leaves the
+// settings copy at the ambient umask (commonly 0644). Skill-only must not repeat
+// that: umask before the write covers the temp file too, which a trailing chmod
+// would not.
+func TestSkillOnlyProtectsTheTokenAtRest(t *testing.T) {
+	h := NewInstallerHandler("", "", true, "", "")
+	claude := installerGetShell(t, h, "claude-code", "ABCDEFGHIJ")
+
+	assertContainsAll(t, claude, "umask 077", "chmod 600")
+
+	// The token must never be written BY VALUE into a shell rc, where it would
+	// sit at the ambient umask forever. Codex reads it by reference instead.
+	//
+	// Scoped to the `export` form on purpose: passing the token as a
+	// per-invocation process env (as the dry run does when it spawns the
+	// harness) is fine and necessary — it is never persisted. An assertion
+	// broad enough to catch that is a false positive, not a finding.
+	codex := installerGetShell(t, h, "codex", "CLAIMCODE0")
+	if strings.Contains(codex, `export CLAWVISOR_AGENT_TOKEN="$TOKEN"`) {
+		t.Error("codex skill-only must export the token by reference (jq from the 0600 file), not by value into an rc")
+	}
+	assertContainsAll(t, codex, "jq -r .token")
+}
+
+// TestSkillOnlyDryRunIsOptIn — the dry run spawns the harness, so it must never
+// fire unattended. `curl | sh` with no terminal has to fall through to skipping
+// it; a default that spawns an agent in CI would be a nasty surprise.
+func TestSkillOnlyDryRunIsOptIn(t *testing.T) {
+	h := NewInstallerHandler("", "", true, "", "")
+	for _, tc := range []struct{ target, claim string }{
+		{"claude-code", "ABCDEFGHIJ"},
+		{"codex", "CLAIMCODE0"},
+	} {
+		body := installerGetShell(t, h, tc.target, tc.claim)
+		assertContainsAll(t, body,
+			"cv_dry_run_prompt",
+			// Gated on an interactive terminal, not on a bare default.
+			"[ -r /dev/tty ]",
+			// Load-bearing: under `curl | sh` the harness would otherwise read
+			// the rest of this script from the pipe as its prompt.
+			"</dev/null",
+			// The out-of-scope half is the only thing that proves enforcement.
+			"OUTSIDE",
+		)
+		if !strings.Contains(body, "--dry-run") {
+			t.Errorf("%s: dry run must be pre-answerable with --dry-run for non-interactive installs", tc.target)
+		}
+	}
+}
+
+// TestCodexSkillOnlyAsksBeforeRelaxingSandbox — persisting
+// network_access = true weakens the sandbox for every workspace-write command,
+// not just Clawvisor's. It must be consented to, and declining must tell the
+// user what to do instead rather than leaving them with a silently broken skill.
+func TestCodexSkillOnlyAsksBeforeRelaxingSandbox(t *testing.T) {
+	h := NewInstallerHandler("", "", true, "", "")
+	codex := installerGetShell(t, h, "codex", "CLAIMCODE0")
+
+	assertContainsAll(t, codex,
+		"sandbox_workspace_write",
+		"network_access = true",
+		"CV_ALLOW_NETWORK",
+		"[ -r /dev/tty ]",
+	)
+	// No terminal must mean "leave the sandbox alone", never "relax it quietly".
+	assertContainsAll(t, codex, "leaving the Codex sandbox unchanged")
+}
+
 // TestInstallerProxyRouteOptIn — route=proxy is now the explicit opt-in, and
 // must still produce the fully-routed script. Guards the inverted default:
 // without this, flipping the fallback could silently make routing unreachable.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1306,8 +1306,31 @@ func (s *Server) routes() http.Handler {
 		}
 	}
 
+	// skillTargetFromQuery resolves ?target= to a render target. Defaults to
+	// Claude Code so every existing consumer — the onboarding docs, the skill's
+	// own self-update pointer — keeps getting exactly what it got before. A
+	// supplied-but-unknown target is a 400 rather than a silent fallback: the
+	// shell installers pick the target, and quietly serving a Claude Code skill
+	// to Codex is the bug this parameter exists to prevent.
+	//
+	// A query param rather than a path segment: GET /skill/{target}/SKILL.md
+	// would be shadowed by the mux.Handle("/skill/", …) file-server catch-all
+	// registered below.
+	skillTargetFromQuery := func(r *http.Request) (skillfiles.Target, error) {
+		raw := r.URL.Query().Get("target")
+		if raw == "" {
+			return skillfiles.TargetClaudeCode, nil
+		}
+		return skillfiles.ParseTarget(raw)
+	}
+
 	mux.HandleFunc("GET /skill/SKILL.md", func(w http.ResponseWriter, r *http.Request) {
-		rendered, err := skillfiles.RenderWithOptions(skillfiles.TargetClaudeCode, skillRenderOpts(r))
+		target, err := skillTargetFromQuery(r)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		rendered, err := skillfiles.RenderWithOptions(target, skillRenderOpts(r))
 		if err != nil {
 			http.Error(w, "rendering SKILL.md: "+err.Error(), http.StatusInternalServerError)
 			return
@@ -1316,9 +1339,14 @@ func (s *Server) routes() http.Handler {
 		w.Write([]byte(rendered))
 	})
 	mux.HandleFunc("GET /skill/skill.zip", func(w http.ResponseWriter, r *http.Request) {
+		target, err := skillTargetFromQuery(r)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
 		w.Header().Set("Content-Type", "application/zip")
 		w.Header().Set("Content-Disposition", `attachment; filename="skill.zip"`)
-		rendered, err := skillfiles.RenderWithOptions(skillfiles.TargetClaudeCode, skillRenderOpts(r))
+		rendered, err := skillfiles.RenderWithOptions(target, skillRenderOpts(r))
 		if err != nil {
 			http.Error(w, "rendering SKILL.md: "+err.Error(), http.StatusInternalServerError)
 			return

--- a/skills/clawvisor/SKILL.md.tmpl
+++ b/skills/clawvisor/SKILL.md.tmpl
@@ -20,6 +20,19 @@ metadata:
       },
   }
 ---
+{{- else if eq .Target "codex" -}}
+---
+name: clawvisor
+description: >
+  Route tool requests through Clawvisor for credential vaulting, task-scoped
+  authorization, and human approval flows. Use for Gmail, Calendar, Drive,
+  Contacts, GitHub, and iMessage (macOS). Clawvisor enforces restrictions,
+  manages task scopes, and injects credentials — the agent never handles
+  secrets directly.
+version: {{ .SkillVersion }}
+published_at: {{ .SkillPublishedAt }}
+homepage: https://github.com/clawvisor/clawvisor
+---
 {{- else if eq .Target "cowork" -}}
 ---
 name: clawvisor
@@ -31,7 +44,7 @@ description: >
   credentials — you never handle secrets directly.
 ---
 {{- end }}
-{{ if eq .Target "claude-code" -}}
+{{ if or (eq .Target "claude-code") (eq .Target "codex") -}}
 # Clawvisor Skill
 
 ## Setup
@@ -63,7 +76,7 @@ The authorization model has two layers — applied in order:
 
 ## Typical Flow
 {{ if .UseCurl }}
-> **Execute all curl commands as a single line.** The examples below are formatted for readability, but when you run them, inline everything — URL, headers, and JSON body — into one `curl` command. Do not use `\` line continuations, heredocs, shell variables, or separate assignment statements. Multi-line commands trigger a separate approval prompt for each line.
+> **Execute all curl commands as a single line.** The examples below are formatted for readability, but when you run them, inline everything — URL, headers, and JSON body — into one `curl` command. Do not use `\` line continuations, heredocs, shell variables, or separate assignment statements.{{ if eq .Target "claude-code" }} Multi-line commands trigger a separate approval prompt for each line.{{ end }}
 
 1. Fetch the catalog — confirm the service is active and the action isn't restricted
 2. Create a task with `POST /api/tasks?wait=true` — this blocks until the user approves
@@ -473,8 +486,8 @@ without re-executing.
 {{ if not .Condensed }}
 ## Important Rules
 
-- **Always execute curl commands as a single line** — the examples in this document are multi-line for readability, but when running them, inline all variables, headers, and JSON bodies into one command. Never use `\` line continuations, heredocs, or separate variable assignments — each triggers a separate approval prompt.
-- Always fetch the catalog first to know what's available and restricted
+{{ if .UseCurl }}- **Always execute curl commands as a single line** — the examples in this document are multi-line for readability, but when running them, inline all variables, headers, and JSON bodies into one command. Never use `\` line continuations, heredocs, or separate variable assignments{{ if eq .Target "claude-code" }} — each triggers a separate approval prompt{{ end }}.
+{{ end }}- Always fetch the catalog first to know what's available and restricted
 - Never attempt to bypass restrictions — they are hard blocks set by the user
 - Always create a task before making gateway requests
 - Use `auto_execute: false` for any action that sends, modifies, or deletes data

--- a/skills/render.go
+++ b/skills/render.go
@@ -17,6 +17,13 @@ const (
 	// instructions, full detail.
 	TargetClaudeCode Target = "claude-code"
 
+	// TargetCodex renders for Codex — curl-based examples like Claude Code,
+	// since Codex executes shell and has no Clawvisor MCP server in this flow.
+	// Distinct from TargetClaudeCode because Codex requires name+description
+	// frontmatter and must not receive Claude Code's permission-glob rationale
+	// for single-line curls, which does not apply to it.
+	TargetCodex Target = "codex"
+
 	// TargetCowork renders for the Claude Desktop (Cowork) plugin — MCP tool
 	// names, no curl examples, no setup.
 	TargetCowork Target = "cowork"
@@ -55,29 +62,68 @@ type templateData struct {
 }
 
 // dataForTarget returns the template data for the given target.
-func dataForTarget(t Target) templateData {
+//
+// An unrecognised target is an error rather than a zero-value fallback. The old
+// default arm returned templateData{Target: t}, which renders a document with
+// NO frontmatter (Codex rejects those at startup) describing MCP tool names to
+// a harness that has no MCP tools — and it did so while returning nil, so the
+// caller had no way to notice. Failing loudly is the only safe behaviour for a
+// value that reaches an unauthenticated HTTP handler.
+func dataForTarget(t Target) (templateData, error) {
 	switch t {
 	case TargetClaudeCode:
 		return templateData{
 			Target:    t,
 			UseCurl:   true,
 			Condensed: false,
-		}
+		}, nil
+	case TargetCodex:
+		return templateData{
+			Target:    t,
+			UseCurl:   true,
+			Condensed: false,
+		}, nil
 	case TargetCowork:
 		return templateData{
 			Target:    t,
 			UseCurl:   false,
 			Condensed: false,
-		}
+		}, nil
 	case TargetMCP:
 		return templateData{
 			Target:    t,
 			UseCurl:   false,
 			Condensed: true,
-		}
+		}, nil
 	default:
-		return templateData{Target: t}
+		return templateData{}, fmt.Errorf("unknown skill target %q (want one of %s)",
+			t, strings.Join(TargetNames(), ", "))
 	}
+}
+
+// TargetNames lists every renderable target. Used for error messages and for
+// validating a caller-supplied target (e.g. an HTTP query param) before render.
+func TargetNames() []string {
+	return []string{
+		string(TargetClaudeCode),
+		string(TargetCodex),
+		string(TargetCowork),
+		string(TargetMCP),
+	}
+}
+
+// ParseTarget validates s against the known targets. Callers that accept a
+// target from outside the process (HTTP query params, CLI argv) should use this
+// rather than converting with Target(s), which silently produces an invalid
+// value.
+func ParseTarget(s string) (Target, error) {
+	for _, name := range TargetNames() {
+		if s == name {
+			return Target(name), nil
+		}
+	}
+	return "", fmt.Errorf("unknown skill target %q (want one of %s)",
+		s, strings.Join(TargetNames(), ", "))
 }
 
 // Render produces the SKILL.md content for the given target by executing the
@@ -99,7 +145,10 @@ func RenderWithOptions(target Target, opts RenderOptions) (string, error) {
 		return "", fmt.Errorf("parsing SKILL.md.tmpl: %w", err)
 	}
 
-	data := dataForTarget(target)
+	data, err := dataForTarget(target)
+	if err != nil {
+		return "", err
+	}
 	data.ClawvisorURL = opts.ClawvisorURL
 	data.ViaRelay = opts.ViaRelay
 	data.FeedbackEnabled = opts.FeedbackEnabled

--- a/skills/render_test.go
+++ b/skills/render_test.go
@@ -1,0 +1,102 @@
+package skills
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRenderRejectsUnknownTarget guards the trap this package used to contain.
+// dataForTarget's default arm returned a zero-value templateData, so
+// RenderWithOptions(Target("codex"), …) SUCCEEDED and produced a document with
+// no YAML frontmatter — which Codex rejects at startup — describing MCP tool
+// names to a harness that has no MCP tools. It returned nil, so no caller could
+// tell. Now an unknown target is an error, and the message names the valid set.
+func TestRenderRejectsUnknownTarget(t *testing.T) {
+	for _, bad := range []string{"", "codexx", "claude", "CLAUDE-CODE", "openclaw"} {
+		if _, err := Render(Target(bad)); err == nil {
+			t.Errorf("Render(%q) succeeded; want an error naming the valid targets", bad)
+		}
+	}
+	if _, err := ParseTarget("nope"); err == nil {
+		t.Error("ParseTarget(\"nope\") succeeded; want an error")
+	}
+	for _, name := range TargetNames() {
+		if _, err := ParseTarget(name); err != nil {
+			t.Errorf("ParseTarget(%q) = %v; every advertised target must parse", name, err)
+		}
+	}
+}
+
+// TestEveryTargetRendersFrontmatterExceptMCP — a skill loader needs YAML
+// frontmatter to recognise the file at all, and Codex specifically refuses
+// skills without name+description. MCP is the deliberate exception: its content
+// is injected as initialize instructions, not read from disk as a skill.
+func TestEveryTargetRendersFrontmatterExceptMCP(t *testing.T) {
+	for _, target := range []Target{TargetClaudeCode, TargetCodex, TargetCowork} {
+		got, err := Render(target)
+		if err != nil {
+			t.Fatalf("Render(%s): %v", target, err)
+		}
+		if !strings.HasPrefix(got, "---\n") {
+			t.Errorf("%s: render must open with YAML frontmatter; got %.60q", target, got)
+		}
+		for _, field := range []string{"name: clawvisor", "description:"} {
+			if !strings.Contains(got, field) {
+				t.Errorf("%s: frontmatter missing %q", target, field)
+			}
+		}
+	}
+
+	mcp, err := Render(TargetMCP)
+	if err != nil {
+		t.Fatalf("Render(mcp): %v", err)
+	}
+	if strings.HasPrefix(mcp, "---\n") {
+		t.Error("mcp render is injected as initialize instructions, not loaded from disk — frontmatter is unexpected here")
+	}
+}
+
+// TestCodexRenderIsShellNotMCP — Codex executes shell, so it needs the concrete
+// curl examples. Reusing the cowork/mcp branch would hand it MCP tool names it
+// cannot call, and reusing the Claude Code branch verbatim would hand it a
+// rationale about Claude Code's permission globs that is simply untrue of Codex.
+func TestCodexRenderIsShellNotMCP(t *testing.T) {
+	codex, err := Render(TargetCodex)
+	if err != nil {
+		t.Fatalf("Render(codex): %v", err)
+	}
+
+	// Shell, not MCP.
+	if !strings.Contains(codex, "curl") {
+		t.Error("codex render must contain concrete curl examples")
+	}
+	// The single-line-curl directive is shared and applies to any shell harness.
+	if !strings.Contains(codex, "single line") {
+		t.Error("codex render should keep the single-line-curl directive")
+	}
+	// …but not Claude Code's reason for it.
+	if strings.Contains(codex, "separate approval prompt") {
+		t.Error("codex render must not carry Claude Code's permission-glob rationale")
+	}
+	// OpenClaw's metadata block is meaningless to Codex and may trip its
+	// stricter frontmatter parsing.
+	if strings.Contains(codex, "openclaw") {
+		t.Error("codex render must not carry the OpenClaw metadata block")
+	}
+}
+
+// TestNonCurlTargetsGetNoCurlInstructions — the single-line-curl rule used to be
+// gated on `not .Condensed` rather than .UseCurl, so cowork received an
+// instruction about a mechanism it has no access to. Re-gating fixed that; this
+// keeps it fixed.
+func TestNonCurlTargetsGetNoCurlInstructions(t *testing.T) {
+	for _, target := range []Target{TargetCowork, TargetMCP} {
+		got, err := Render(target)
+		if err != nil {
+			t.Fatalf("Render(%s): %v", target, err)
+		}
+		if strings.Contains(got, "single line") {
+			t.Errorf("%s uses MCP tools, not curl — it must not be told how to format curl commands", target)
+		}
+	}
+}


### PR DESCRIPTION
## Why

Skill-only has been the default install route since #643, but the skill-only installers were 35 lines that minted a token and stopped. **They never installed the skill.** The harness ended up with a credential on disk and no idea Clawvisor existed — the agent never routed tool calls through the gateway, because nothing had told it to. Meanwhile the script's own output claimed the token *"lets the Clawvisor skill/tools govern tool calls."*

`docs/INTEGRATE_CLAUDE_CODE.md:22-29` already specifies what a working install needs:

| | Goal state | Before | After |
|---|---|---|---|
| 1 | Clawvisor running | ✅ | ✅ |
| 2 | Agent token created | ✅ | ✅ |
| 3 | Skill at `~/.claude/skills/clawvisor/SKILL.md` | ❌ | ✅ |
| 4 | `CLAWVISOR_URL` + `CLAWVISOR_AGENT_TOKEN` readable by the harness | ❌ | ✅ |
| 5 | Harness able to make gateway requests | ❌ | ✅ |

No template under `installer_scripts/` mentioned `skills` at all. The operating skill was written only by the daemon CLI or the LLM-driven markdown flow, so a `curl | sh` user who never ran the daemon locally had no way to get it.

## What the installer does now

Mint token → install skill → wire env → *(Codex)* ask about sandbox egress → optional dry run.

The skill downloads to `.tmp` and is renamed into place, so an interrupted install can't leave a truncated `SKILL.md` that a harness would happily load.

**Claude Code** also gets the `permissions.allow` rules. Without them the skill's gateway curls prompt on every single call — installed, but not usable.

**The token in `settings.json` is written under `umask 077`** rather than `chmod`'d afterwards: the temp file carries it too, and a trailing chmod leaves a window at the ambient umask (commonly 0644). The routed installer has exactly this bug today — the only `chmod` in any template is on `~/.clawvisor/agents/`. This does not copy it.

**Codex** has no `permissions.allow` analogue, and its sandbox blocks egress, so the skill's curls fail with connection-refused until workspace-write allows network access. That is a real relaxation, so it is never silent: an explicit flag wins, otherwise we ask, and with no terminal we decline and print the line. Its rc exports read the token from the 0600 file *by reference*, so it never lands in a world-readable rc — and it exports `CLAWVISOR_URL` too, which `codex.sh.tmpl` has never done.

## The optional dry run

The last step spawns the harness and has it make one **in-scope** request and one **out-of-scope** request, so enforcement is demonstrated rather than assumed. Ported from the flow specified for the retired setup skill (`internal/daemon/claude_code.go:90-110`).

The prompt hands the whole thing to the Clawvisor skill, which already owns creating a task, long-polling for approval, and telling the user to approve in the dashboard — so the shell script needs no polling or timeout logic. `</dev/null` is load-bearing: under `curl | sh`, sh's stdin *is* the curl pipe, and without the redirect the harness reads the rest of the script as its prompt. Opt-in, tty-gated so it never fires in CI, pre-answerable with `--dry-run`, and a failure never fails the install.

## Supporting changes

- **`TargetCodex`.** Codex requires `name`+`description` frontmatter and must not receive Claude Code's permission-glob rationale, which is untrue of it. `dataForTarget`'s default arm returned a zero value, so `Render(Target("codex"))` **succeeded** and emitted a frontmatter-less document full of MCP tool names — now an error, plus `ParseTarget` for outside input.
- **Gating fix.** The single-line-curl rule was gated on `not .Condensed` instead of `.UseCurl`, so `cowork` was told how to format curl commands it cannot run. Re-gated, and the Claude-specific rationale is now separate from the shared directive.
- **`?target=` on `/skill/SKILL.md` and `/skill/skill.zip`**, defaulting to `claude-code` so existing consumers are unaffected. A query param, not a path segment — the `/skill/` file-server catch-all would shadow the latter.
- **A `sh -n` gate over every rendered variant.** Nothing verified that the scripts we pipe into a user's shell were even syntactically valid; every other assertion is a substring match, which cannot catch an unbalanced heredoc or an unclosed `if`.
- **Four stale docs** still claiming Observe is the fresh-install default.

## Verification

Built the server and ran the **real generated scripts** against a live daemon in an isolated `HOME`:

- both installers run end to end; skill lands (26,003 bytes), `settings.json` gets both env vars and 3 allow rules including the relay rule
- **idempotent across three runs** — allow list stays at 3 (`| unique`), no duplicate rc exports, no duplicate `[sandbox_workspace_write]` block
- `settings.json` is `-rw-------` with the token in it
- correct per-target variant: Claude gets the permission-glob rationale, Codex has **zero** occurrences of it and zero OpenClaw metadata
- **no raw token in the shell rc**
- declining the sandbox leaves `config.toml` untouched and prints the exact line
- `?target=` returns 200/200/400 for claude-code/codex/bogus live, and the two renders differ
- `claude-code` and `mcp` skill renders are **byte-identical** to `origin/main`; `cowork` differs by exactly the one bogus curl line
- routed installer output differs from `origin/main` by exactly three additive preamble hunks for the new flags — no behavioural change

`go test ./...` passes.

## Known gaps

**The dry run is unproven against a real agent.** It's verified opt-in, tty-gated, `--dry-run`-forceable, and syntactically valid, but I never let it actually spawn `claude`/`codex` — whether the agent reliably performs the two-request sequence and reports usefully needs a human to watch it once.

**Codex frontmatter strictness is asserted, not tested.** `installer.go:515-516` claims Codex rejects skills lacking name+description; nothing in the repo verifies it. Worth exercising the Codex branch against a real `codex` binary.

**The `clawvisor-setup` installer skill is not retired here.** The dry run moved out of it, but `claudeCodeSetupCommand`, `/skill/clawvisor-setup.md`, and the LLM-driven markdown flow are still what hermes/openclaw and the daemon local-setup path depend on. Removing them is a separate, larger change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/645?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

