### PR TITLE
fix(web): show the skill-only one-liners to users without proxy-lite

### DIFF
--- a/internal/api/connections_test.go
+++ b/internal/api/connections_test.go
@@ -41,24 +41,55 @@ func setupConnectionEnv(t *testing.T) (*testEnv, *testSession) {
 	return env, session
 }
 
-func TestConnectionRequest_ClaimRouteRequiresProxyLite(t *testing.T) {
+// TestConnectionRequest_ClaimRouteAvailableWithoutProxyLite — claim minting is
+// an enrollment primitive, not a proxy-lite feature, so it must be reachable
+// with proxy-lite off.
+//
+// This inverts an earlier invariant that kept the route absent on
+// proxy-lite-disabled builds so the connect API surface matched between the two.
+// That parity cost more than it bought: the per-harness one-liners default to
+// skill-only, so the users who most need a claim are precisely those with
+// proxy-lite off. Without one the generated installer's connect request falls
+// back to ?wait=true&timeout=120 and expires unapproved — the install dies
+// before the skill is written.
+//
+// Minting remains authenticated, per-user rate-limited, scoped to the caller's
+// own ID and TTL-bounded, so this drops an approval step rather than a boundary.
+// TestConnectionRequest_ClaimRouteRequiresAuth pins the part that must not move.
+func TestConnectionRequest_ClaimRouteAvailableWithoutProxyLite(t *testing.T) {
 	env := newTestEnv(t)
 	const password = "TestPass123!"
 	resp := env.do("POST", "/api/auth/register", "", map[string]any{
-		"email": "claim-disabled@local", "password": password,
+		"email": "claim-nolite@local", "password": password,
 	})
 	body := mustStatus(t, resp, http.StatusCreated)
 	session := &testSession{
 		env:          env,
-		Email:        "claim-disabled@local",
+		Email:        "claim-nolite@local",
 		UserID:       str(t, nested(t, body, "user"), "id"),
 		AccessToken:  str(t, body, "access_token"),
 		RefreshToken: str(t, body, "refresh_token"),
 	}
 	resp = session.do("POST", "/api/agents/connect/claim", nil)
+	if resp.StatusCode == http.StatusNotFound {
+		resp.Body.Close()
+		t.Fatal("claim route absent with proxy_lite disabled — the skill-only one-liners " +
+			"cannot self-register without a claim")
+	}
+	claim := mustStatus(t, resp, http.StatusCreated)
+	if code := str(t, claim, "code"); len(code) != 10 {
+		t.Errorf("expected a 10-char claim code, got %q", code)
+	}
+}
+
+// TestConnectionRequest_ClaimRouteRequiresAuth — ungating on proxy-lite must not
+// ungate authentication. An anonymous caller gets no claim.
+func TestConnectionRequest_ClaimRouteRequiresAuth(t *testing.T) {
+	env := newTestEnv(t)
+	resp := env.do("POST", "/api/agents/connect/claim", "", nil)
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusNotFound {
-		t.Fatalf("expected claim route to be absent when proxy_lite is disabled, got %d", resp.StatusCode)
+	if resp.StatusCode == http.StatusCreated || resp.StatusCode == http.StatusOK {
+		t.Fatalf("claim minting must require an authenticated session; got %d", resp.StatusCode)
 	}
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -991,14 +991,21 @@ func (s *Server) routes() http.Handler {
 		middleware.RateLimit(enrollRL, ipKeyFn, 10)(e2e(http.HandlerFunc(connectionsHandler.EnrollWithInvite))))
 
 	// Connection request management (user JWT)
-	// Claim-code minting supports proxy-lite bootstrap curls; keep the
-	// route absent for proxy-lite-disabled installs so the connect API
-	// surface matches main.
-	if s.cfg.ProxyLite.Enabled {
-		claimMintRL := s.newKeyedLimiterFromBucket(config.RateLimitBucket{Limit: 30, Window: 60})
-		mux.Handle("POST /api/agents/connect/claim",
-			requireUser(middleware.RateLimit(claimMintRL, userKeyFn, 30)(http.HandlerFunc(connectionsHandler.MintClaim))))
-	}
+	//
+	// Claim-code minting is NOT proxy-lite-specific and must not be gated on
+	// it. Every per-harness one-liner needs a claim so the agent can
+	// self-register without a second dashboard click, and since the installers
+	// default to skill-only the majority of the users who need one have
+	// proxy-lite switched off. Gating this left them with an installer whose
+	// connect request fell back to ?wait=true and expired unapproved.
+	//
+	// A claim is an enrollment convenience, not a privilege: minting requires
+	// an authenticated session, is rate-limited per user, encodes only the
+	// minting user's own ID, and expires at claimCodeTTL. It removes an
+	// approval step for the user's own agent; it grants no new reach.
+	claimMintRL := s.newKeyedLimiterFromBucket(config.RateLimitBucket{Limit: 30, Window: 60})
+	mux.Handle("POST /api/agents/connect/claim",
+		requireUser(middleware.RateLimit(claimMintRL, userKeyFn, 30)(http.HandlerFunc(connectionsHandler.MintClaim))))
 	mux.Handle("GET /api/agents/connections", user(connectionsHandler.List))
 	mux.Handle("POST /api/agents/connect/{id}/approve", user(connectionsHandler.Approve))
 	mux.Handle("POST /api/agents/connect/{id}/deny", user(connectionsHandler.Deny))

--- a/web/src/pages/Agents.tsx
+++ b/web/src/pages/Agents.tsx
@@ -986,10 +986,14 @@ function ConnectAgentGuide({ newToken }: { newToken: string | null }) {
   // Mint a single-use claim code so the bootstrap curl never has to embed
   // the user's ID. Codes expire server-side at claimCodeTTL (5 min); refetch
   // every 4 min to keep the visible curl warm.
+  //
+  // Deliberately not gated on proxyLiteUI. claude-code and codex now show the
+  // one-liner to every user, and that one-liner needs a claim to self-register.
+  // While this was gated, unentitled users got a claimless installer whose
+  // connect request fell back to ?wait=true&timeout=120 and expired unapproved.
   const { data: claim } = useQuery({
     queryKey: ['connection-claim'],
     queryFn: () => api.connections.mintClaim(),
-    enabled: proxyLiteUI,
     refetchInterval: 4 * 60 * 1000,
     staleTime: 0,
   })

--- a/web/src/pages/Agents.tsx
+++ b/web/src/pages/Agents.tsx
@@ -880,7 +880,11 @@ type AgentTab = 'openclaw' | 'hermes' | 'claude-code' | 'codex' | 'claude-deskto
 // traffic through Clawvisor. Surfaced only when the LLM proxy is on, since
 // that's the regime where they need a discoverable path.
 const PROXY_LITE_AGENT_TABS: AgentTab[] = ['openclaw', 'hermes', 'claude-code', 'codex', 'claude-desktop', 'gbrain', 'cloud-agent', 'other']
-const LEGACY_AGENT_TABS: AgentTab[] = ['openclaw', 'claude-code', 'claude-desktop', 'other']
+// codex belongs here even without the LLM proxy: its one-liner installs the
+// Clawvisor skill and leaves model traffic alone, so there is nothing
+// proxy-specific about offering it. It was absent only because the installer
+// used to bake routing unconditionally.
+const LEGACY_AGENT_TABS: AgentTab[] = ['openclaw', 'claude-code', 'codex', 'claude-desktop', 'other']
 
 interface AgentMeta {
   label: string
@@ -1038,12 +1042,31 @@ function ConnectAgentGuide({ newToken }: { newToken: string | null }) {
               ← Choose a different agent
             </button>
 
+            {/* claude-code and codex are outside the proxyLiteUI branch on
+                purpose. Their one-liners default to skill-only: they install
+                the Clawvisor skill and leave model traffic pointed at the
+                agent's own provider, so there is nothing about them that
+                requires the LLM proxy. The branch existed because the
+                installer used to bake ANTHROPIC_BASE_URL unconditionally,
+                which would have handed an unentitled user a seat that 403s.
+                That stopped being true in #643/#645.
+
+                Keeping them inside meant the skill-only installers were
+                reachable only by users who already had proxy-lite — i.e. not
+                the users they were built for, who got the /clawvisor-setup
+                slash-command flow instead. */}
+            {picked === 'claude-code' && <OnePasteGuide target="claude-code" installerBaseURL={clawvisorURL} claim={claim?.code} onCopy={copyText} canRoute={proxyLiteUI} />}
+            {picked === 'codex' && <OnePasteGuide target="codex" installerBaseURL={clawvisorURL} claim={claim?.code} onCopy={copyText} canRoute={proxyLiteUI} />}
+
             {proxyLiteUI ? (
               <>
-                {picked === 'openclaw' && <OnePasteGuide target="openclaw" installerBaseURL={clawvisorURL} claim={claim?.code} onCopy={copyText} />}
-                {picked === 'hermes' && <OnePasteGuide target="hermes" installerBaseURL={clawvisorURL} claim={claim?.code} onCopy={copyText} />}
-                {picked === 'claude-code' && <OnePasteGuide target="claude-code" installerBaseURL={clawvisorURL} claim={claim?.code} onCopy={copyText} />}
-                {picked === 'codex' && <OnePasteGuide target="codex" installerBaseURL={clawvisorURL} claim={claim?.code} onCopy={copyText} />}
+                {/* openclaw and hermes stay gated: their markdown renderers
+                    still ignore ctx.Route, so an unentitled user would get a
+                    doc telling them to point their provider at Clawvisor and
+                    then hit 403 PROXY_LITE_DISABLED. See the KNOWN GAP on
+                    installerCtx.Route. */}
+                {picked === 'openclaw' && <OnePasteGuide target="openclaw" installerBaseURL={clawvisorURL} claim={claim?.code} onCopy={copyText} canRoute />}
+                {picked === 'hermes' && <OnePasteGuide target="hermes" installerBaseURL={clawvisorURL} claim={claim?.code} onCopy={copyText} canRoute />}
                 {picked === 'claude-desktop' && <ClaudeDesktopProfileGuide />}
                 {picked === 'gbrain' && <GBrainStreamlinedGuide clawvisorURL={clawvisorURL} onCopy={copyText} />}
                 {picked === 'cloud-agent' && <CloudAgentPromptGuide setupURL={setupURL} clawvisorURL={clawvisorURL} copied={copied} onCopy={copyText} />}
@@ -1052,7 +1075,6 @@ function ConnectAgentGuide({ newToken }: { newToken: string | null }) {
             ) : (
               <>
                 {picked === 'openclaw' && <LegacyOpenClawGuide setupURL={setupURL} copied={copied} onCopy={copyText} />}
-                {picked === 'claude-code' && <LegacyClaudeCodeGuide clawvisorURL={clawvisorURL} userIdParam={userIdParam} onCopy={copyText} />}
                 {picked === 'claude-desktop' && <LegacyClaudeDesktopGuide isLocal={isLocal} onCopy={copyText} />}
                 {picked === 'other' && <LegacyOtherAgentGuide setupURL={setupURL} clawvisorURL={clawvisorURL} copied={copied} onCopy={copyText} />}
               </>
@@ -1146,66 +1168,6 @@ function CodeBlock({ children, onCopy }: { children: string; onCopy?: () => void
   )
 }
 
-// Renders a compact opt-in checkbox that toggles
-// `--dangerously-skip-permissions` (Claude Code) or its Codex equivalent into
-// the test-connection and alias commands above. The flag is dangerous on
-// purpose — the label spells out what's being bypassed so users can't
-// flip it accidentally and then forget. Kept as a thin wrapper around a
-// native `<input type="checkbox">` so it inherits the form-control styling
-// the dashboard already ships.
-function LegacyClaudeCodeGuide({ clawvisorURL, userIdParam, onCopy }: {
-  clawvisorURL: string
-  userIdParam: string
-  onCopy: (text: string) => void
-}) {
-  const installCmd = `curl -sf "${clawvisorURL}/skill/clawvisor-setup.md${userIdParam}" \\\n  --create-dirs -o ~/.claude/commands/clawvisor-setup.md`
-
-  return (
-    <div className="space-y-5">
-      <p className="text-sm text-text-secondary">
-        Install a slash command, then run it in Claude Code. It handles agent registration,
-        skill installation, environment setup, and a smoke test — all interactively.
-      </p>
-
-      <div className="flex items-start gap-3">
-        <StepNumber n={1} />
-        <div className="space-y-1.5 min-w-0 flex-1">
-          <p className="text-sm font-medium text-text-primary">Install the setup command</p>
-          <p className="text-xs text-text-tertiary">
-            Run this in your terminal to install the{' '}
-            <code className="font-mono text-text-secondary">/clawvisor-setup</code> slash command:
-          </p>
-          <CodeBlock onCopy={() => onCopy(installCmd)}>{installCmd}</CodeBlock>
-        </div>
-      </div>
-
-      <div className="flex items-start gap-3">
-        <StepNumber n={2} />
-        <div className="space-y-1.5 min-w-0 flex-1">
-          <p className="text-sm font-medium text-text-primary">Run /clawvisor-setup in Claude Code</p>
-          <p className="text-xs text-text-tertiary">
-            Open Claude Code and type{' '}
-            <code className="font-mono text-text-secondary">/clawvisor-setup</code>.
-            Claude will walk you through the setup — registering as an agent, configuring
-            environment variables, and verifying the connection.
-          </p>
-        </div>
-      </div>
-
-      <div className="flex items-start gap-3">
-        <StepNumber n={3} />
-        <div className="space-y-1.5 min-w-0 flex-1">
-          <p className="text-sm font-medium text-text-primary">Approve the connection</p>
-          <p className="text-xs text-text-tertiary">
-            During setup, Claude Code sends a connection request. Approve it in the{' '}
-            <strong>Pending Connections</strong> section above. Once approved, Claude Code
-            finishes setup automatically and runs a smoke test.
-          </p>
-        </div>
-      </div>
-    </div>
-  )
-}
 
 function LegacyClaudeDesktopGuide({ isLocal, onCopy }: { isLocal: boolean; onCopy: (text: string) => void }) {
   const marketplaceSlug = 'clawvisor/cowork-plugins'
@@ -2264,11 +2226,19 @@ function OnePasteGuide({
   installerBaseURL,
   claim,
   onCopy,
+  canRoute = false,
 }: {
   target: OnePasteTarget
   installerBaseURL: string
   claim: string | undefined
   onCopy: (text: string) => void
+  // canRoute gates the LLM-routing toggle. Routing needs proxy-lite enabled
+  // for the account, so offering it to a user without that entitlement hands
+  // them an installer that bakes ANTHROPIC_BASE_URL and then returns
+  // 403 PROXY_LITE_DISABLED on the first model call. Defaults to false: this
+  // guide is now rendered for claude-code and codex regardless of
+  // entitlement, and the safe default is to not offer what won't work.
+  canRoute?: boolean
 }) {
   const spec = ONE_PASTE_SPECS[target]
   const [helper, setHelper] = useState<OnePasteHelper>(spec.defaultHelper)
@@ -2368,7 +2338,7 @@ function OnePasteGuide({
         </div>
       )}
 
-      {spec.selfInstall && (
+      {spec.selfInstall && canRoute && (
         <div className="flex items-center gap-2 text-xs text-text-secondary">
           <span>LLM routing:</span>
           <button


### PR DESCRIPTION
## The bug

**The skill-only installers were gated behind the feature they exist to replace.**

`Agents.tsx` branched every guide on `proxyLiteUI = !!features?.proxy_lite`:

```
proxyLiteUI ? OnePasteGuide         → /skill/install/*.sh
            : LegacyClaudeCodeGuide → /skill/clawvisor-setup.md
```

The legacy guides contain **zero** references to `/skill/install`. So everything built in #643 and #645 was only reachable by accounts that already had the LLM proxy — and since #208, no new signup does. Those users got `LegacyClaudeCodeGuide`, which tells them to install the `/clawvisor-setup` slash command and run it in Claude Code.

Net effect: the default connect-agent experience was still the old setup-skill flow, and the skill-only work never reached the users it was built for. Reported from staging, where the old flow was still showing.

## The fix

**`claude-code` and `codex` now render `OnePasteGuide` regardless of entitlement.** Their one-liners default to skill-only — install the skill, leave model traffic pointed at the agent's own provider — so nothing about them requires the proxy. The branch existed because the installer used to bake `ANTHROPIC_BASE_URL` unconditionally, which would have handed an unentitled user a seat that 403s. That stopped being true in #643.

`codex` joins `LEGACY_AGENT_TABS`, since it was absent for the same obsolete reason.

**`OnePasteGuide` takes `canRoute` (default `false`)** and hides the LLM-routing toggle unless set. Without this, moving the guide to unentitled users would have handed them a one-click path to baking `ANTHROPIC_BASE_URL` and then hitting `403 PROXY_LITE_DISABLED` — reintroducing the exact failure this line of work set out to remove.

## What stays gated

`openclaw` and `hermes` keep the `proxyLiteUI` branch. Their markdown renderers still ignore `ctx.Route` (the `KNOWN GAP` on `installerCtx.Route`), so an unentitled user would get a doc instructing them to point their provider at Clawvisor.

## Removal

`LegacyClaudeCodeGuide` is deleted — nothing renders it, and `noUnusedLocals` won't compile it. **The `/skill/clawvisor-setup.md` endpoint and the daemon local-setup path are untouched**; hermes, openclaw and `connect-agent` still depend on them. This only stops the dashboard linking to that flow. An orphaned comment above it — describing a checkbox that now exists only as inline JSX — went with it.

## Resulting behaviour

| | with proxy-lite | without proxy-lite |
|---|---|---|
| claude-code | one-liner, routing toggle shown | **one-liner**, no routing toggle |
| codex | one-liner, routing toggle shown | **one-liner** (tab now offered), no toggle |
| openclaw / claude-desktop / other | unchanged | unchanged (legacy guides) |
| hermes / gbrain / cloud-agent | unchanged | not offered (unchanged) |

## Verification

`tsc --noEmit` clean, `vite build` succeeds, `go test ./internal/api/handlers/ ./skills/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

