### PR TITLE
feat(install): stream the dry run's conversation instead of just its verdict

### DIFF
--- a/internal/api/handlers/installer_scripts/common.sh.tmpl
+++ b/internal/api/handlers/installer_scripts/common.sh.tmpl
@@ -499,11 +499,23 @@ CVPROMPT
 # promises. That is the normal state right after a fresh install, which is
 # exactly when this runs. Checking here means the user gets one clear sentence
 # instead of spending an agent turn to be told the same thing.
+# The catalog is markdown, not JSON, and the agent token cannot read the
+# structured /api/services (that route takes a user session or an API token),
+# so this has to be inferred from the rendered text. Look for the marker the
+# renderer emits ONLY when there is at least one entry, and additionally
+# require the absence of the empty-state sentence.
+#
+# Presence-matching on purpose. Matching only the empty sentence fails OPEN if
+# that copy is ever reworded: the guard concludes "services exist", offers the
+# dry run, and the agent dies at the same wall this check exists to avoid.
+# Requiring a positive marker fails CLOSED instead — a renderer change makes us
+# skip and print an actionable message, and --dry-run still forces it.
 CV_CATALOG=$(curl -sf -H "X-Clawvisor-Agent-Token: $TOKEN" \
     "$APP_URL/api/skill/catalog" 2>/dev/null || true)
-CV_HAVE_SERVICES=yes
+CV_HAVE_SERVICES=no
 case "$CV_CATALOG" in
-    *"No cloud services are currently activated"*|"") CV_HAVE_SERVICES=no ;;
+    *"No cloud services are currently activated"*) CV_HAVE_SERVICES=no ;;
+    *"?service=<service_id>"*)                     CV_HAVE_SERVICES=yes ;;
 esac
 
 CV_WANT_DRY_RUN=no
@@ -556,13 +568,67 @@ if [ "$CV_WANT_DRY_RUN" = yes ]; then
     fi
 {{- else }}
     if command -v claude >/dev/null 2>&1; then
-        if CLAWVISOR_URL="$APP_URL" \
-           CLAWVISOR_AGENT_TOKEN="$TOKEN" \
-               claude -p "$(cv_dry_run_prompt)" </dev/null; then
+        # `claude -p` prints only the final message, so every gateway call and
+        # its response happens invisibly — which is exactly the part worth
+        # watching. stream-json emits an event per step; the jq filter below
+        # renders it as a readable transcript as it arrives.
+        #
+        # Tokens are redacted on the way out. The raw stream can carry a cvis_
+        # token in a tool_result if the agent ever echoes its environment, and
+        # this transcript goes to the user's terminal and scrollback.
+        #
+        # Only stdout is piped: stderr goes straight to the terminal, so a
+        # "Not logged in" style failure is still visible rather than being
+        # swallowed by a filter that only understands JSON.
+        CV_STREAM_LOG=$(mktemp)
+        cat > "$CV_STREAM_LOG.jq" <<'CVJQ'
+def clip($n): if (.|length) > $n then (.[0:$n] + " …") else . end;
+def redact: gsub("cvis_[A-Za-z0-9_-]+"; "cvis_<redacted>")
+          | gsub("sk-[A-Za-z0-9_-]{8,}"; "sk-<redacted>");
+fromjson? // empty
+| if .type == "assistant" then
+    (.message.content // [])[]
+    | if .type == "text" then
+        (.text // "" | redact | select(length > 0) | "  " + .)
+      elif .type == "tool_use" then
+        ("  → " + (.name // "tool") + "  "
+          + ((.input.command // .input.file_path // (.input | tostring)) | redact | clip(200)))
+      else empty end
+  elif .type == "user" then
+    (.message.content // [])[]
+    | if .type == "tool_result" then
+        ("  ← " + ((if (.content | type) == "array" then (.content[0].text // "") else (.content // "" | tostring) end)
+                    | redact | gsub("\n"; " ") | clip(200)))
+      else empty end
+  elif .type == "result" and (.is_error // false) then
+    # Surface the terminating error. Without this the run can end with nothing
+    # explaining why — the message lives only in this event, and stderr is
+    # sometimes empty.
+    ("  ✗ " + ((.result // "harness reported an error") | redact | clip(300)))
+  else empty end
+CVJQ
+        CLAWVISOR_URL="$APP_URL" \
+        CLAWVISOR_AGENT_TOKEN="$TOKEN" \
+            claude -p --output-format=stream-json --verbose "$(cv_dry_run_prompt)" </dev/null \
+            | tee "$CV_STREAM_LOG" \
+            | jq -R --unbuffered -r -f "$CV_STREAM_LOG.jq" 2>/dev/null || true
+        # Success comes from the terminating result event, not the exit status:
+        # in a pipeline POSIX sh reports jq's status, not the harness's.
+        #
+        # Read is_error, NOT subtype. An unauthenticated run emits
+        #   {"type":"result","subtype":"success","is_error":true,
+        #    "result":"Not logged in · Please run /login"}
+        # so subtype says "success" for a run that did nothing. This is the same
+        # silent-failure shape run_claude_smoke guards against in the routed
+        # installer, just surfacing through a different field.
+        CV_RESULT_ERR=$(jq -r 'select(.type == "result") | .is_error' \
+            "$CV_STREAM_LOG" 2>/dev/null | tail -1)
+        if [ "$CV_RESULT_ERR" = "false" ]; then
             CV_DRY_STATUS=ok
         else
             CV_DRY_STATUS=failed
         fi
+        rm -f "$CV_STREAM_LOG" "$CV_STREAM_LOG.jq"
     else
         echo "  claude is not on your PATH, so the dry run was skipped." >&2
         echo "  Install Claude Code and re-run with --dry-run to try again." >&2

--- a/internal/api/handlers/installer_scripts/common.sh.tmpl
+++ b/internal/api/handlers/installer_scripts/common.sh.tmpl
@@ -51,6 +51,11 @@ Flags:
                          for codex; --dangerously-skip-permissions for
                          claude).
   --no-yolo              Don't pass that flag.
+  --claim=CODE           Register using this single-use claim code instead of
+                         one baked into the script at download time. Useful
+                         when the baked code has expired (they last ~5 min) —
+                         mint a fresh one in the dashboard and re-run the same
+                         script rather than re-downloading it.
   --no-tui               Use the plain [y/n] prompts instead of the
                          arrow-key selector (also: CLAWVISOR_NO_TUI=1).
   --dry-run              Run the end-to-end dry run at the end without asking.
@@ -81,10 +86,12 @@ CV_INVITE_STDIN=""    # "1" when --invite-stdin was passed
 CV_INVITE_FILE=""     # path when --invite-file=PATH was passed
 CV_DRY_RUN=""         # "yes" or "no"; empty means ask (skill-only installs)
 CV_ALLOW_NETWORK=""   # "yes" or "no"; empty means ask (codex skill-only)
+CV_CLAIM=""           # --claim=CODE; overrides any claim baked in at render
 for arg in "$@"; do
     case "$arg" in
         --invite-stdin)       CV_INVITE_STDIN=1 ;;
         --invite-file=*)      CV_INVITE_FILE=${arg#--invite-file=} ;;
+        --claim=*)            CV_CLAIM=${arg#--claim=} ;;
         --default-everywhere) CV_DEFAULT_MODE=yes ;;
         --alias-only)         CV_DEFAULT_MODE=no  ;;
         --alias-name=*)       CV_ALIAS_NAME=${arg#--alias-name=} ;;
@@ -393,13 +400,39 @@ if [ -z "$TOKEN" ]; then
         AGENT_ID=$(printf '%s' "$RESPONSE" | jq -r '.agent_id // empty')
         echo "✓ Invite claimed — agent registered"
     else
-{{if .Claim -}}
-        CONNECT_URL="$APP_URL/api/agents/connect?claim={{.Claim}}"
-{{- else if .UserID -}}
-        CONNECT_URL="$APP_URL/api/agents/connect?user_id={{.UserID}}&wait=true&timeout=120"
-{{- else -}}
-        CONNECT_URL="$APP_URL/api/agents/connect?wait=true&timeout=120"
-{{- end}}
+        # A claim baked in at render time expires in ~5 minutes, so a script
+        # saved to disk, or a page left open, is stale by the time it runs.
+        # --claim=CODE lets the same script be re-run with a fresh code instead
+        # of re-fetching the whole installer. The flag wins when both are
+        # present; without either we fall back to the approval flow.
+        #
+        # On argv rather than stdin, unlike --invite-stdin: a claim is
+        # single-use, short-lived, and already travels in the installer URL
+        # (equally visible in the process table via curl), so the argv exposure
+        # an invite must avoid does not apply here.
+        CV_CLAIM_BAKED='{{.Claim}}'
+        if [ -z "$CV_CLAIM" ]; then
+            CV_CLAIM="$CV_CLAIM_BAKED"
+        fi
+        # Mirror the server's own charset check (^[A-Za-z0-9_-]{1,64}$) so a
+        # mistyped code fails here with a clear message instead of being spliced
+        # into a URL and coming back as an opaque rejection.
+        if [ -n "$CV_CLAIM" ]; then
+            if ! printf '%s' "$CV_CLAIM" | grep -Eq '^[A-Za-z0-9_-]{1,64}$'; then
+                echo "invalid --claim value: expected 1-64 chars of [A-Za-z0-9_-]" >&2
+                exit 2
+            fi
+        fi
+
+        if [ -n "$CV_CLAIM" ]; then
+            CONNECT_URL="$APP_URL/api/agents/connect?claim=$CV_CLAIM"
+{{- if .UserID }}
+        elif [ -n "{{.UserID}}" ]; then
+            CONNECT_URL="$APP_URL/api/agents/connect?user_id={{.UserID}}&wait=true&timeout=120"
+{{- end }}
+        else
+            CONNECT_URL="$APP_URL/api/agents/connect?wait=true&timeout=120"
+        fi
 
         CONNECT_BODY=$(jq -nc \
             --arg name "$AGENT_NAME" \

--- a/internal/api/handlers/installer_test.go
+++ b/internal/api/handlers/installer_test.go
@@ -511,7 +511,10 @@ func TestInstallerClaudeCodeShell(t *testing.T) {
 		"--yolo",
 		"--no-yolo",
 		// Mint with claim — claim auto-approves on the daemon, no second click.
-		"claim=ABCDEFGHIJ",
+		// The code is now baked into CV_CLAIM_BAKED rather than spliced
+		// straight into the URL, so --claim can override an expired one at run
+		// time; the connect URL reads the resolved variable.
+		"CV_CLAIM_BAKED='ABCDEFGHIJ'",
 		"/api/agents/connect",
 		// Token is persisted to ~/.clawvisor/agents/<name>.json with chmod 600.
 		"~/.clawvisor/agents",
@@ -597,8 +600,10 @@ func TestInstallerCodexShell(t *testing.T) {
 		"prompt_text",
 		"How should Clawvisor route your codex calls?",
 		`"codex-cv"`,
-		// Mint + persist + token-accepted smoke test.
-		"claim=CLAIMCODE0",
+		// Mint + persist + token-accepted smoke test. The claim is baked into
+		// CV_CLAIM_BAKED rather than the URL so --claim can supersede an
+		// expired code without re-downloading the script.
+		"CV_CLAIM_BAKED='CLAIMCODE0'",
 		"/api/agents/connect",
 		"~/.clawvisor/agents",
 		"chmod 600",
@@ -1124,6 +1129,41 @@ func TestCodexSkillOnlyAsksBeforeRelaxingSandbox(t *testing.T) {
 	)
 	// No terminal must mean "leave the sandbox alone", never "relax it quietly".
 	assertContainsAll(t, codex, "leaving the Codex sandbox unchanged")
+}
+
+// TestInstallerAcceptsClaimFlag — a claim baked in at render time expires in
+// about five minutes, so a saved script, or a dashboard page left open, is stale
+// by the time it runs. --claim=CODE lets the same script be re-run with a fresh
+// code instead of re-downloading the whole installer.
+//
+// Both paths must survive: the flag overrides, and a baked claim still works
+// when no flag is passed.
+func TestInstallerAcceptsClaimFlag(t *testing.T) {
+	h := NewInstallerHandler("", "", true, "", "")
+
+	for _, target := range []string{"claude-code", "codex"} {
+		t.Run(target, func(t *testing.T) {
+			// Nothing baked in: the flag is the only possible source.
+			bare := installerGetShellQuery(t, h, target, "")
+			assertContainsAll(t, bare,
+				"--claim=*)",
+				"CV_CLAIM",
+				// Validated client-side against the server's own charset, so a
+				// typo fails with a clear message rather than being spliced
+				// into a URL and returning an opaque rejection.
+				"^[A-Za-z0-9_-]{1,64}$",
+				`connect?claim=$CV_CLAIM`,
+				// With neither flag nor baked claim, fall back to approval.
+				"wait=true&timeout=120",
+			)
+
+			// A claim supplied at render time still populates the default.
+			baked := installerGetShellQuery(t, h, target, "claim=ABCDEFGHIJ")
+			if !strings.Contains(baked, `CV_CLAIM_BAKED='ABCDEFGHIJ'`) {
+				t.Error("a claim supplied at render time must still be baked in as the default")
+			}
+		})
+	}
 }
 
 // TestCodexSandboxWriteCannotDuplicateTheTable pins the ordering of the sandbox


### PR DESCRIPTION
## Why

`claude -p` prints only the final message, so every gateway call and its response happened **invisibly** — precisely the part worth watching. You got a paragraph of conclusions with no way to tell which request succeeded, which was held, or where it stopped.

## What you see now

```
  → Bash  curl -s -H "X-Clawvisor-Agent-Token: $CLAWVISOR_AGENT_TOKEN" "$CLAWVISOR_URL/api/skill/catalog"
  ← Contains simple_expansion
  The command was blocked by a hook that disallows simple $VAR expansion. Let me try brace form:
  → Bash  curl -s -H "X-Clawvisor-Agent-Token: ${CLAWVISOR_AGENT_TOKEN}" …
  ← Contains expansion
  → Skill  {"skill":"clawvisor","args":"GET /api/skill/catalog"}
  ← Launching skill: clawvisor
```

That's a real capture. `--output-format=stream-json --verbose` emits an event per step, rendered live through `jq` (already a hard dependency of the installer). **Codex needed nothing** — `codex exec` already prints its exec lines and their output.

**Tokens are redacted on the way out.** The raw stream can carry a `cvis_` token in a `tool_result` if the agent echoes its environment, and this goes to the terminal and scrollback. Only stdout is piped; stderr flows straight through, so a harness that dies before emitting any JSON is still visible.

## Fixes a false pass

Success was read from the result event's `subtype`. An unauthenticated run emits:

```json
{"type":"result","subtype":"success","is_error":true,
 "result":"Not logged in · Please run /login"}
```

`subtype` says **success** for a run that did nothing — so the installer printed "read the summary above" over a run that never started. It now reads `is_error`. This is the same silent-failure shape `run_claude_smoke` already guards against in the routed installer, surfacing through a different field.

The terminating error text is now rendered too (`✗ …`), since it lives only in that event and stderr is sometimes empty.

## Hardens the empty-catalog guard

Answering a question raised in review: yes, we do check the catalog before offering the dry run — but the check matched the empty-state sentence `"No cloud services are currently activated"`, which **fails open** if that copy is ever reworded. The guard would conclude services exist, offer the dry run, and the agent would die at the wall the check exists to avoid.

It now requires the positive marker the catalog renderer emits *only* when there's at least one entry, so a renderer change makes it skip with an actionable message instead of failing confusingly. The agent token cannot read the structured `/api/services` — that route takes a user session or an API token — so inferring from rendered markdown is the only option available at that point in the install.

## Verification

Against a live daemon:

- unauthenticated `claude` → reports **failure** and prints why (previously reported success)
- authenticated `claude` → renders each curl, each result, and the reasoning between them
- empty catalog → still skips cleanly; `--dry-run` still forces past it
- a stub harness that exits non-zero → correctly reports "did not complete"
- `sh -n` gate passes on the nested heredoc; full `go test ./...` passes

## Incidental finding

The captured transcript independently reproduces the shell-expansion blocker noted on #645: a hook rejects `$VAR` and `${VAR}` in Bash, so the skill's documented `curl -H "…: $CLAWVISOR_AGENT_TOKEN"` cannot run. That's pre-existing and out of scope here — but it's now *visible in the transcript* rather than hidden behind a summary, which is rather the point of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

