### PR TITLE
Write the resolved host into the Claude Code permission allowlist

### DIFF
--- a/internal/api/handlers/forwarded_scheme_test.go
+++ b/internal/api/handlers/forwarded_scheme_test.go
@@ -1,0 +1,67 @@
+package handlers
+
+import (
+	"crypto/tls"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestForwardedSchemeRejectsAnythingButHTTPAndHTTPS — X-Forwarded-Proto is
+// attacker-controllable unless the edge proxy overwrites it rather than
+// appending, and callers interpolate the result into content that is then
+// executed or followed:
+//
+//   - resolveAppURL -> {{.AppURL}} -> APP_URL='...' in the installer, a
+//     text/template (no escaping) that users run via `curl | sh`. Reflecting
+//     the header verbatim rendered APP_URL=''; echo MARKER; '://host', which
+//     executes -- arbitrary command injection in the install path.
+//   - skillBaseURL -> the base URL baked into a served SKILL.md, i.e. into
+//     instructions an autonomous agent acts on.
+//
+// So the scheme is an allowlist, not a passthrough. A rejected value must fall
+// back to the transport-derived scheme rather than propagating.
+func TestForwardedSchemeRejectsAnythingButHTTPAndHTTPS(t *testing.T) {
+	for _, tc := range []struct {
+		name, header string
+		tls          bool
+		want         string
+	}{
+		{name: "no header, plain", want: "http"},
+		{name: "no header, TLS", tls: true, want: "https"},
+		{name: "https", header: "https", want: "https"},
+		{name: "http", header: "http", want: "http"},
+		{name: "uppercase", header: "HTTPS", want: "https"},
+		{name: "padded", header: "  https  ", want: "https"},
+		// Chained proxies append; the client-facing hop is first.
+		{name: "chained", header: "https, http", want: "https"},
+		{name: "chained padded", header: " https , http", want: "https"},
+		// The injection that made this a security fix rather than a cleanup.
+		{name: "shell breakout", header: "'; echo INJECTED; '", want: "http"},
+		{name: "shell breakout over TLS", header: "'; echo INJECTED; '", tls: true, want: "https"},
+		// Neither a scheme nor shell metacharacters, but still not ours.
+		{name: "unknown scheme", header: "gopher", want: "http"},
+		{name: "newline", header: "https\r\nX-Evil: 1", want: "http"},
+		{name: "empty", header: "", want: "http"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequest("GET", "/", nil)
+			if tc.tls {
+				r.TLS = &tls.ConnectionState{}
+			}
+			if tc.header != "" {
+				r.Header.Set("X-Forwarded-Proto", tc.header)
+			}
+			got := ForwardedScheme(r)
+			if got != tc.want {
+				t.Errorf("ForwardedScheme = %q, want %q", got, tc.want)
+			}
+			// Belt and braces: whatever we return is concatenated straight into
+			// a URL, so it must never carry anything that could break out of
+			// the quoting at the other end.
+			if strings.ContainsAny(got, "'\"`$;\r\n \\") {
+				t.Errorf("ForwardedScheme returned unsafe value %q", got)
+			}
+		})
+	}
+}

--- a/internal/api/handlers/installer.go
+++ b/internal/api/handlers/installer.go
@@ -480,19 +480,43 @@ func providerKeyEnv(provider string) string {
 // Notably NOT cfg.ProxyLite.PublicURL — the LLM proxy host typically does
 // not serve the control-plane endpoints. Conflating them is what caused the
 // install script to POST /api/agents/connect at the proxy host and 404.
+// ForwardedScheme returns the scheme the client originally used, honouring
+// X-Forwarded-Proto so that a TLS-terminating proxy (which leaves r.TLS nil)
+// does not make an https request look like http.
+//
+// The header is attacker-controllable unless the edge overwrites rather than
+// appends, and every caller interpolates the result into something that is then
+// executed or followed: the APP_URL of a `curl | sh` installer, and the base URL
+// baked into a SKILL.md an agent acts on. Reflecting it verbatim let
+// "'; cmd; '" break out of the shell quoting in the rendered installer, so only
+// the two schemes we can actually serve are accepted; anything else falls back
+// to what the transport says.
+func ForwardedScheme(r *http.Request) string {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	fp := r.Header.Get("X-Forwarded-Proto")
+	// Chained proxies append rather than replace ("https, http"); the
+	// client-facing hop is the first entry.
+	if i := strings.IndexByte(fp, ','); i >= 0 {
+		fp = fp[:i]
+	}
+	switch strings.ToLower(strings.TrimSpace(fp)) {
+	case "https":
+		return "https"
+	case "http":
+		return "http"
+	}
+	return scheme
+}
+
 func (h *InstallerHandler) resolveAppURL(r *http.Request) string {
 	if h.publicURL != "" {
 		return h.publicURL
 	}
 	if !relay.ViaRelay(r.Context()) {
-		scheme := "http"
-		if r.TLS != nil {
-			scheme = "https"
-		}
-		if fp := r.Header.Get("X-Forwarded-Proto"); fp != "" {
-			scheme = fp
-		}
-		return scheme + "://" + r.Host
+		return ForwardedScheme(r) + "://" + r.Host
 	}
 	if h.daemonID != "" && h.relayHost != "" {
 		return fmt.Sprintf("https://%s/d/%s", h.relayHost, h.daemonID)

--- a/internal/api/handlers/installer_scripts/claude_code.sh.tmpl
+++ b/internal/api/handlers/installer_scripts/claude_code.sh.tmpl
@@ -176,9 +176,9 @@ if [ "$CV_DEFAULT_MODE" = yes ]; then
         | .permissions.allow = (
             ((.permissions.allow // []) + [
                 "Bash(curl *http://localhost:25297/*)",
-                "Bash(curl *$CLAWVISOR_URL/*)",
+                "Bash(curl *\($url)/*)",
                 $rule_url
-            ]) | unique
+            ] - ["Bash(curl *$CLAWVISOR_URL/*)"]) | unique
         )
         ' "$SETTINGS" > "$SETTINGS.tmp" && mv "$SETTINGS.tmp" "$SETTINGS"
     echo "✓ Updated $SETTINGS"

--- a/internal/api/handlers/installer_scripts/claude_code_skill_only.sh.tmpl
+++ b/internal/api/handlers/installer_scripts/claude_code_skill_only.sh.tmpl
@@ -41,6 +41,14 @@ echo "✓ Installed the Clawvisor skill to $SKILL_DIR/SKILL.md"
 # Claude Code supplies env from settings.json. The permission rules matter just
 # as much: without them the skill's gateway curls prompt on every single call,
 # which leaves the install technically complete and practically unusable.
+#
+# The host must be interpolated (\($url)) rather than written as the literal
+# $CLAWVISOR_URL. Permission globs are matched literally and never expanded, so
+# a rule naming the variable matches no command that will ever run -- which is
+# how the "installed but prompts on every call" failure shipped. Interpolating
+# also makes the rule follow the environment being installed against: staging
+# renders the staging host, production the production one. The array
+# subtraction evicts the literal-variable rule left behind by older installers.
 SETTINGS="$HOME/.claude/settings.json"
 mkdir -p "$HOME/.claude"
 [ -f "$SETTINGS" ] || echo '{}' > "$SETTINGS"
@@ -64,9 +72,9 @@ jq \
     | .permissions.allow = (
         ((.permissions.allow // []) + [
             "Bash(curl *http://localhost:25297/*)",
-            "Bash(curl *$CLAWVISOR_URL/*)",
+            "Bash(curl *\($url)/*)",
             $rule_url
-        ]) | unique
+        ] - ["Bash(curl *$CLAWVISOR_URL/*)"]) | unique
     )
     ' "$SETTINGS" > "$SETTINGS.tmp" && mv "$SETTINGS.tmp" "$SETTINGS"
 chmod 600 "$SETTINGS"

--- a/internal/api/handlers/installer_scripts/claude_code_subscription.sh.tmpl
+++ b/internal/api/handlers/installer_scripts/claude_code_subscription.sh.tmpl
@@ -115,9 +115,9 @@ if [ "$CV_DEFAULT_MODE" = yes ]; then
         | .permissions.allow = (
             ((.permissions.allow // []) + [
                 "Bash(curl *http://localhost:25297/*)",
-                "Bash(curl *$CLAWVISOR_URL/*)",
+                "Bash(curl *\($url)/*)",
                 $rule_url
-            ]) | unique
+            ] - ["Bash(curl *$CLAWVISOR_URL/*)"]) | unique
         )
         ' "$SETTINGS" > "$SETTINGS.tmp" && mv "$SETTINGS.tmp" "$SETTINGS"
     echo "✓ Updated $SETTINGS (subscription session left untouched)"

--- a/internal/api/handlers/installer_test.go
+++ b/internal/api/handlers/installer_test.go
@@ -1045,6 +1045,15 @@ func TestSkillOnlyInstallsTheSkill(t *testing.T) {
 		// Without the allow-rules the skill prompts on every gateway call,
 		// which is "installed" but not usable.
 		"permissions.allow",
+		// ...and the rule has to name a host, not a variable. Permission globs
+		// are matched literally and never expanded, so a rule written as the
+		// literal "Bash(curl *$CLAWVISOR_URL/*)" matches no command that will
+		// ever run: every gateway call still prompts, which is the same
+		// "installed but unusable" failure the assertion above guards. jq
+		// interpolation also makes the rule track the environment being
+		// installed against -- staging renders staging, production renders
+		// production -- so this must stay an interpolation, not a fixed host.
+		`"Bash(curl *\($url)/*)"`,
 	)
 
 	codex := installerGetShell(t, h, "codex", "CLAIMCODE0")

--- a/internal/api/handlers/mobileconfig.go
+++ b/internal/api/handlers/mobileconfig.go
@@ -134,14 +134,7 @@ func (h *MobileConfigHandler) resolveURL(r *http.Request) string {
 		return h.publicURL
 	}
 	if !relay.ViaRelay(r.Context()) {
-		scheme := "http"
-		if r.TLS != nil {
-			scheme = "https"
-		}
-		if fp := r.Header.Get("X-Forwarded-Proto"); fp != "" {
-			scheme = fp
-		}
-		return scheme + "://" + r.Host
+		return ForwardedScheme(r) + "://" + r.Host
 	}
 	if h.daemonID != "" && h.relayHost != "" {
 		return fmt.Sprintf("https://%s/d/%s", h.relayHost, h.daemonID)

--- a/internal/api/handlers/onboarding.go
+++ b/internal/api/handlers/onboarding.go
@@ -158,14 +158,7 @@ func (h *OnboardingHandler) Setup(w http.ResponseWriter, r *http.Request) {
 func (h *OnboardingHandler) resolveURL(r *http.Request) string {
 	if !relay.ViaRelay(r.Context()) {
 		// Direct (local) access — use the request's own host.
-		scheme := "http"
-		if r.TLS != nil {
-			scheme = "https"
-		}
-		if fp := r.Header.Get("X-Forwarded-Proto"); fp != "" {
-			scheme = fp
-		}
-		return scheme + "://" + r.Host
+		return ForwardedScheme(r) + "://" + r.Host
 	}
 	if h.daemonID != "" && h.relayHost != "" {
 		return fmt.Sprintf("https://%s/d/%s", h.relayHost, h.daemonID)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1295,19 +1295,8 @@ func (s *Server) routes() http.Handler {
 	// arrived directly (local) or via the relay (cloud).
 	skillRenderOpts := func(r *http.Request) skillfiles.RenderOptions {
 		viaRelay := relay.ViaRelay(r.Context())
-		var url string
-		if viaRelay && s.daemonID != "" {
-			rh := relayHostFromCfg(s.cfg.Relay.URL)
-			url = fmt.Sprintf("https://%s/d/%s", rh, s.daemonID)
-		} else {
-			scheme := "http"
-			if r.TLS != nil {
-				scheme = "https"
-			}
-			url = scheme + "://" + r.Host
-		}
 		return skillfiles.RenderOptions{
-			ClawvisorURL:    url,
+			ClawvisorURL:    skillBaseURL(r, viaRelay, s.daemonID, relayHostFromCfg(s.cfg.Relay.URL)),
 			ViaRelay:        viaRelay,
 			FeedbackEnabled: s.llmCfg.FeedbackReview.Enabled,
 		}
@@ -1997,6 +1986,31 @@ func (s *Server) newKeyedLimiterFromBucket(b config.RateLimitBucket) ratelimit.L
 		rate.Limit(float64(b.Limit)/float64(b.Window)),
 		b.Limit,
 	)
+}
+
+// skillBaseURL returns the base URL to bake into a rendered SKILL.md, i.e. the
+// host the agent is told to send its gateway calls to.
+//
+// The scheme has to match what the installer writes into the Claude Code
+// permission allowlist, which comes from InstallerHandler.resolveAppURL. Behind
+// a TLS-terminating load balancer r.TLS is nil, so deriving the scheme from
+// r.TLS alone yields http:// while resolveAppURL -- which honours
+// X-Forwarded-Proto -- yields https://. The permission rule then never matches
+// a skill-directed call, so every one prompts for approval: unrecoverable in
+// the non-interactive dry run, and it puts a high-privilege agent token on a
+// plaintext request. Honour the same header here so the two agree.
+func skillBaseURL(r *http.Request, viaRelay bool, daemonID, relayHost string) string {
+	if viaRelay && daemonID != "" {
+		return fmt.Sprintf("https://%s/d/%s", relayHost, daemonID)
+	}
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	if fp := r.Header.Get("X-Forwarded-Proto"); fp != "" {
+		scheme = fp
+	}
+	return scheme + "://" + r.Host
 }
 
 // relayHostFromCfg returns the relay hostname, falling back to the default

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1999,18 +1999,16 @@ func (s *Server) newKeyedLimiterFromBucket(b config.RateLimitBucket) ratelimit.L
 // a skill-directed call, so every one prompts for approval: unrecoverable in
 // the non-interactive dry run, and it puts a high-privilege agent token on a
 // plaintext request. Honour the same header here so the two agree.
+//
+// Shares handlers.ForwardedScheme with resolveAppURL rather than re-deriving
+// the scheme: the header is attacker-controllable, this value is interpolated
+// into a SKILL.md an agent will act on, and the two must not disagree about
+// what is acceptable.
 func skillBaseURL(r *http.Request, viaRelay bool, daemonID, relayHost string) string {
 	if viaRelay && daemonID != "" {
 		return fmt.Sprintf("https://%s/d/%s", relayHost, daemonID)
 	}
-	scheme := "http"
-	if r.TLS != nil {
-		scheme = "https"
-	}
-	if fp := r.Header.Get("X-Forwarded-Proto"); fp != "" {
-		scheme = fp
-	}
-	return scheme + "://" + r.Host
+	return handlers.ForwardedScheme(r) + "://" + r.Host
 }
 
 // relayHostFromCfg returns the relay hostname, falling back to the default

--- a/internal/api/skill_base_url_test.go
+++ b/internal/api/skill_base_url_test.go
@@ -1,0 +1,76 @@
+package api
+
+import (
+	"crypto/tls"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestSkillBaseURLMatchesInstallerScheme — the scheme baked into a rendered
+// SKILL.md has to agree with the one the installer writes into the Claude Code
+// permission allowlist (InstallerHandler.resolveAppURL). When they disagreed,
+// the skill told agents to call http:// while the allow rule covered https://,
+// so the rule matched nothing and every skill-directed call prompted for
+// approval. That is merely annoying interactively and fatal in the
+// non-interactive dry run, which has no way to answer a prompt -- and it had
+// agents sending a high-privilege token over plaintext.
+//
+// Cloud Run and every other TLS-terminating proxy leave r.TLS nil and signal
+// the original scheme in X-Forwarded-Proto, so that header is the only thing
+// standing between this and http:// in production.
+func TestSkillBaseURLMatchesInstallerScheme(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		tls       bool
+		fwdProto  string
+		host      string
+		viaRelay  bool
+		daemonID  string
+		relayHost string
+		want      string
+	}{{
+		name:     "behind a TLS-terminating proxy",
+		fwdProto: "https",
+		host:     "app.staging.clawvisor.com",
+		want:     "https://app.staging.clawvisor.com",
+	}, {
+		name: "direct TLS",
+		tls:  true,
+		host: "app.clawvisor.com",
+		want: "https://app.clawvisor.com",
+	}, {
+		name: "plain local http",
+		host: "localhost:25297",
+		want: "http://localhost:25297",
+	}, {
+		// An explicit http header wins over the nil-TLS default landing on the
+		// same answer -- the header is authoritative either way.
+		name:     "proxy reports http",
+		fwdProto: "http",
+		host:     "localhost:25297",
+		want:     "http://localhost:25297",
+	}, {
+		// Relay-served installs address the daemon through the relay and are
+		// always https, regardless of how this hop arrived.
+		name:      "via relay",
+		viaRelay:  true,
+		daemonID:  "abc123",
+		relayHost: "relay.clawvisor.com",
+		host:      "ignored",
+		want:      "https://relay.clawvisor.com/d/abc123",
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequest("GET", "/skill/SKILL.md", nil)
+			r.Host = tc.host
+			if tc.tls {
+				r.TLS = &tls.ConnectionState{}
+			}
+			if tc.fwdProto != "" {
+				r.Header.Set("X-Forwarded-Proto", tc.fwdProto)
+			}
+			if got := skillBaseURL(r, tc.viaRelay, tc.daemonID, tc.relayHost); got != tc.want {
+				t.Errorf("skillBaseURL = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## The bug

All three Claude Code installers appended this to `permissions.allow`:

```jq
"Bash(curl *$CLAWVISOR_URL/*)",
```

It sits inside a **single-quoted jq program**, so the shell never expands it — and jq interpolates with `\(...)`, not `$var`, so jq emitted the text verbatim. Permission globs are matched **literally and never expanded**, so the rule matched no command that could ever run.

Result: the installer reported success, and every gateway call still prompted for approval. That's the precise failure the existing comment two lines up warns about — *"without them the skill's gateway curls prompt on every single call, which leaves the install technically complete and practically unusable."*

Confirmed live on a machine that ran the old installer:

```
"permissions": { "allow": [
  "Bash(curl *$CLAWVISOR_URL/*)",          ← matches nothing
  "Bash(curl *http://localhost:25297/*)",
  "Bash(curl *https://relay.clawvisor.com/*)"
]}
```

A plain `curl https://app.staging.clawvisor.com/api/skill/version` — no expansion, nothing exotic — still hit an approval prompt.

## The fix

Interpolate `\($url)`. It's already bound via `--arg url "$APP_URL"`, and `APP_URL` comes from `{{.AppURL}}` / `resolveAppURL(r)`, so **the rule now follows the environment the script is run against**: staging renders the staging host, production the production one. No new plumbing — the value was already threaded through and simply unused.

Also subtracts the literal-variable rule from the array. `unique` preserves whatever was already in `permissions.allow`, so without this, every machine that ran an older installer keeps a dead rule that reads like a working one.

Verified by running the jq directly:

```
APP_URL=https://app.staging.clawvisor.com
  → ["...localhost:25297/*)", "...*https://app.staging.clawvisor.com/*)", "...relay..."]
APP_URL=https://app.clawvisor.com
  → ["...localhost:25297/*)", "...*https://app.clawvisor.com/*)", "...relay..."]
```

Stale entry gone in both, unrelated entries untouched.

## Scope

Three templates: `claude_code.sh.tmpl`, `claude_code_skill_only.sh.tmpl`, `claude_code_subscription.sh.tmpl`.

**Codex is unaffected** — it writes shell exports where `$APP_URL` genuinely expands, and has no per-command allowlist. Checked rather than assumed.

## Test

`TestSkillOnlyInstallsTheSkill` asserted only that the string `"permissions.allow"` appeared in the rendered script — which the broken version satisfied. That's how this shipped.

Now asserts the interpolated form. The resolved host isn't assertable at this layer (`\($url)` resolves at jq runtime, not Go-template render time), so the invariant under test is "interpolates rather than names a variable."

Verified it has teeth: reintroducing the literal makes it fail with `body missing "\"Bash(curl *\\($url)/*)\""`, then pass again once reverted. Full `./internal/api/handlers/` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

