### PR TITLE
Assert durable approval state, not the flash-lived badge

### DIFF
--- a/e2e/browser/tests/approvals.spec.ts
+++ b/e2e/browser/tests/approvals.spec.ts
@@ -34,7 +34,22 @@ test('a pending connection request is approved in the UI and the API state flips
 
   // Approve in the UI.
   await page.getByRole('button', { name: 'Approve', exact: true }).click()
-  await expect(page.getByText('Approved', { exact: true })).toBeVisible()
+
+  // Assert the UI's *durable* post-approval state, not the inline "Approved"
+  // badge. That badge lives in ConnectionCard's local `result` state
+  // (web/src/pages/Agents.tsx), and the same onSuccess handler that sets it
+  // also invalidates the ['connections'] query. GET /api/agents/connections
+  // returns only PENDING requests (ConnectionsHandler.List ->
+  // ListPendingConnectionRequests), so the refetch drops this request, the
+  // parent's `pending.length > 0` guard goes false, and the whole Pending
+  // Connections section — badge and all — unmounts. The badge's lifetime is
+  // therefore one refetch round-trip; asserting on it is a race the test loses
+  // whenever the server answers quickly (always, locally).
+  //
+  // The durable signals are: the pending section is gone, and the approved
+  // agent has materialised in "Your Agents".
+  await expect(page.getByRole('heading', { name: /Pending Connections/i })).toBeHidden()
+  await expect(page.getByRole('link', { name: new RegExp(name) })).toBeVisible()
 
   // API state flipped: the request is no longer pending and the agent now exists.
   await expect


### PR DESCRIPTION
`approvals.spec.ts:9` has been failing intermittently on `main`, sometimes twice in a row including the retry. It is a test bug, not a product regression.

## Root cause

The assertion waited for the inline `Approved` badge:

```ts
await expect(page.getByText('Approved', { exact: true })).toBeVisible()
```

That badge is transient **by construction**:

1. `web/src/pages/Agents.tsx:3196-3199` — `approveMut.onSuccess` calls `setResult('Approved')` and, in the same handler, `qc.invalidateQueries({ queryKey: ['connections'] })`.
2. `internal/api/handlers/connections.go:1118-1134` — `ConnectionsHandler.List` returns **only pending** requests, via `ListPendingConnectionRequests`.
3. The refetch therefore drops the just-approved request, the parent's `pending.length > 0` guard goes false, and the entire Pending Connections section unmounts — taking the `ConnectionCard` that owns the local `result` state, and the badge, with it.

The badge's lifetime is one refetch round-trip. Whether Playwright samples it is a race decided by server latency, which is exactly why it fails consistently on a fast local server and intermittently in CI.

**The approval itself always worked.** The CI failure snapshot shows Pending Connections gone and the seeded agent present under "Your Agents" with a real UUID. Only the confirmation flash was unobservable.

## The change

Assert the durable post-approval state instead:

```ts
await expect(page.getByRole('heading', { name: /Pending Connections/i })).toBeHidden()
await expect(page.getByRole('link', { name: new RegExp(name) })).toBeVisible()
```

No sleeps, no loosened timeouts, no skip, no `.fixme()`. The existing API-state poll assertions are untouched. Only this spec seeds connection requests, so the `toBeHidden` is not order-dependent on other specs.

## Verification

Before/after on the same machine and server:

| | Result |
|---|---|
| Original assertion, `--repeat-each=6` | **0/6 passed** — same `toBeVisible()` error as CI |
| Fixed assertion, `--repeat-each=6` | **6/6 passed** |

Plus, from the original investigation: 0/10 before, 30/30 after across three fresh servers, and 18/18 for the full lane across three runs.

## Two notes for a human

**Not verified on CI Linux.** The diagnosis rests on a deterministic local repro plus the code path above. The mechanism is latency-dependent rather than platform-dependent, so it should hold, but CI is the real proof.

**Possible UX gap, deliberately not changed here.** The `Approved` / `Denied` confirmation is invisible to real users too — it flashes for one round-trip and the card vanishes. That may be intended, with the agent appearing in the list serving as the real feedback. If it is not, it wants a deliberate dwell before the section unmounts. That is a product change, out of scope for a test fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

