### PR TITLE
feat(slack): download file and attachment content

### DIFF
--- a/internal/adapters/definitions/slack.yaml
+++ b/internal/adapters/definitions/slack.yaml
@@ -92,6 +92,12 @@ actions:
         - { name: text, sanitize: true }
         - { name: ts }
         - { name: thread_ts, optional: true }
+        # Projected down to the fields needed to identify and fetch an
+        # attachment — a raw Slack file object carries ~40 fields of
+        # thumbnail and preview metadata per file.
+        - name: files
+          expr: 'files == nil ? nil : map(files, {{"id": #.id, "name": #.name, "mimetype": #.mimetype, "size": #.size}})'
+          optional: true
       meta:
         - { name: response_metadata.next_cursor, rename: next_cursor }
       summary: "{{len .Data}} message(s)"
@@ -156,3 +162,74 @@ actions:
       meta:
         - { name: response_metadata.next_cursor, rename: next_cursor }
       summary: "{{len .Data}} user(s)"
+
+  list_files:
+    display_name: "List files"
+    risk: { category: read, sensitivity: low, description: "List files in a Slack workspace" }
+    method: GET
+    path: "/files.list"
+    params:
+      channel: { type: string, location: query }
+      user: { type: string, location: query }
+      types: { type: string, location: query }
+      count: { type: int, default: 50, max: 200, location: query }
+      page: { type: int, default: 1, location: query }
+    error_check: { success_path: "ok", error_path: "error" }
+    response:
+      data_path: "files"
+      fields:
+        - { name: id }
+        - { name: name, sanitize: true }
+        - { name: title, sanitize: true, optional: true }
+        - { name: mimetype }
+        - { name: size }
+        - { name: created }
+        - { name: user, optional: true }
+        - { name: permalink, optional: true }
+      meta:
+        - { name: paging.pages, rename: total_pages }
+        - { name: paging.total, rename: total_results }
+      summary: "{{len .Data}} file(s)"
+
+  get_file:
+    display_name: "Get file"
+    risk: { category: read, sensitivity: low, description: "Read metadata for a specific Slack file" }
+    method: GET
+    path: "/files.info"
+    params:
+      file: { type: string, required: true, location: query }
+    error_check: { success_path: "ok", error_path: "error" }
+    response:
+      data_path: "file"
+      fields:
+        - { name: id }
+        - { name: name, sanitize: true }
+        - { name: title, sanitize: true, optional: true }
+        - { name: mimetype }
+        - { name: size }
+        - { name: created }
+        - { name: user, optional: true }
+        - { name: permalink, optional: true }
+      summary: "File {{.name}}"
+
+  # Go override: the content lives on files.slack.com rather than the API
+  # base URL and is returned as raw bytes, neither of which the YAML REST
+  # runtime can express.
+  download_file:
+    display_name: "Download file"
+    risk: { category: read, sensitivity: low, description: "Download a file's content from Slack" }
+    override: go
+    # Content is always returned base64-encoded, for every file type, so the
+    # file round-trips byte for byte. Decode it before use.
+    params:
+      file_id:
+        type: string
+        required: true
+        description: "Slack file ID (e.g. F01234ABCDE), from list_files or a message's files[]"
+      max_bytes:
+        type: int
+        description: >
+          Maximum bytes to download (default 1 MB, max 10 MB). Content is
+          returned base64-encoded, which inflates it by ~4/3 — only raise this
+          when streaming the response to a file rather than reading it into
+          context.

--- a/internal/adapters/format/format.go
+++ b/internal/adapters/format/format.go
@@ -17,6 +17,22 @@ const (
 	MaxFieldLen   = 500
 	MaxArrayItems = 200
 	MaxDataBytes  = 100 * 1024
+
+	// MaxDownloadBytes is the ceiling on binary file downloads. It is
+	// deliberately separate from MaxBodyLen: that constant is a rune count
+	// used to truncate human-readable text (mail bodies, event descriptions),
+	// and downloads only ever borrowed it as a byte count.
+	//
+	// A download this large is only usable when the caller streams the
+	// response to disk (e.g. curl > out.json) rather than reading it into an
+	// LLM context — 10 MB of content is ~13.3 MB of base64.
+	MaxDownloadBytes = 10 * 1024 * 1024
+
+	// DefaultDownloadBytes is the cap applied when the caller does not ask
+	// for a larger one. It is sized to survive being read into a model
+	// context; callers that stream to disk opt in to MaxDownloadBytes
+	// explicitly via a max_bytes parameter.
+	DefaultDownloadBytes = 1024 * 1024
 )
 
 // SanitizeText strips HTML, removes dangerous Unicode, and truncates to maxLen runes.

--- a/internal/adapters/slack/adapter.go
+++ b/internal/adapters/slack/adapter.go
@@ -1,0 +1,362 @@
+// Package slack implements the Clawvisor adapter for Slack actions that
+// cannot be expressed in YAML. File content lives on files.slack.com rather
+// than the slack.com/api base URL, and is returned as raw bytes instead of
+// JSON, so the YAML REST runtime cannot fetch it.
+package slack
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"strings"
+
+	"github.com/clawvisor/clawvisor/internal/adapters/format"
+	"github.com/clawvisor/clawvisor/pkg/adapters"
+)
+
+// apiBase and hostCheck are variables rather than constants so tests can
+// point the adapter at an httptest server.
+var (
+	apiBase   = "https://slack.com/api"
+	hostCheck = checkSlackHost
+)
+
+// maxFileInfoBytes caps the files.info metadata read. Slack embeds preview and
+// plain_text content for textual files, so this tracks file size rather than
+// being a small fixed envelope.
+const maxFileInfoBytes = 8 << 20
+
+// Adapter handles Slack actions that require fetching file content.
+type Adapter struct{}
+
+func New() *Adapter { return &Adapter{} }
+
+// Execute dispatches to the appropriate action handler.
+func (a *Adapter) Execute(ctx context.Context, req adapters.Request) (*adapters.Result, error) {
+	token, err := extractToken(req.Credential)
+	if err != nil {
+		return nil, fmt.Errorf("slack: %w", err)
+	}
+	switch req.Action {
+	case "download_file":
+		return a.downloadFile(ctx, token, req.Params)
+	default:
+		return nil, fmt.Errorf("slack: unsupported action %q", req.Action)
+	}
+}
+
+// ── download_file ────────────────────────────────────────────────────────────
+
+// fileInfo is the subset of Slack's files.info response we need.
+type fileInfo struct {
+	ID                 string `json:"id"`
+	Name               string `json:"name"`
+	Mimetype           string `json:"mimetype"`
+	Size               int64  `json:"size"`
+	URLPrivateDownload string `json:"url_private_download"`
+	URLPrivate         string `json:"url_private"`
+}
+
+// downloadFile fetches a file's content from Slack and returns it base64-encoded
+// (or as text, for textual content types).
+//
+// Unlike Dropbox and Drive, this is a two-host operation: files.info is served
+// from slack.com/api, but the bytes come from files.slack.com and require the
+// same bearer token to be presented again.
+func (a *Adapter) downloadFile(ctx context.Context, token string, params map[string]any) (*adapters.Result, error) {
+	fileID, _ := params["file_id"].(string)
+	if fileID == "" {
+		return nil, fmt.Errorf("slack download_file: file_id is required")
+	}
+
+	maxBytes, err := resolveMaxBytes(params["max_bytes"])
+	if err != nil {
+		return nil, fmt.Errorf("slack download_file: %w", err)
+	}
+
+	meta, err := a.fileInfo(ctx, token, fileID)
+	if err != nil {
+		return nil, fmt.Errorf("slack download_file: %w", err)
+	}
+
+	// Pre-flight on the declared size. Truncating binary content produces an
+	// undecodable prefix under a success-shaped summary, so refuse instead.
+	if meta.Size > maxBytes {
+		return nil, fmt.Errorf(
+			"slack download_file: %q is %s, which exceeds the %s limit; "+
+				"pass max_bytes (up to %s) and stream the response to disk rather than into a model context",
+			meta.Name, humanBytes(meta.Size), humanBytes(maxBytes), humanBytes(format.MaxDownloadBytes))
+	}
+
+	downloadURL := meta.URLPrivateDownload
+	if downloadURL == "" {
+		downloadURL = meta.URLPrivate
+	}
+	if downloadURL == "" {
+		return nil, fmt.Errorf("slack download_file: file %q has no download URL (external or deleted file?)", fileID)
+	}
+	if err := hostCheck(downloadURL); err != nil {
+		return nil, fmt.Errorf("slack download_file: %w", err)
+	}
+
+	body, contentType, err := a.fetchContent(ctx, token, downloadURL, maxBytes, meta)
+	if err != nil {
+		return nil, fmt.Errorf("slack download_file: %w", err)
+	}
+
+	// Trust files.info's mimetype over the transport's, which is often
+	// application/octet-stream; fall back to the extension.
+	mimeType := meta.Mimetype
+	if mimeType == "" {
+		mimeType = contentType
+	}
+	if mimeType == "" {
+		mimeType = mime.TypeByExtension(filepath.Ext(meta.Name))
+	}
+	if mimeType == "" {
+		mimeType = "application/octet-stream"
+	}
+
+	// Always base64, for every content type. A download must round-trip the
+	// file byte for byte, and the alternatives cannot:
+	//
+	//   - format.SanitizeText strips HTML and truncates at MaxBodyLen runes.
+	//   - Even unsanitized, returning bytes as a JSON string mangles anything
+	//     that is not valid UTF-8 — encoding/json substitutes U+FFFD — which
+	//     silently corrupts CSVs in legacy encodings and every binary format.
+	//
+	// The cost is that callers always decode, which is also what makes the
+	// contract uniform: one `base64 -d` regardless of file type.
+	result := map[string]any{
+		"id":        meta.ID,
+		"name":      format.SanitizeText(meta.Name, format.MaxFieldLen),
+		"mime_type": mimeType,
+		"size":      len(body),
+		"encoding":  "base64",
+		"content":   base64.StdEncoding.EncodeToString(body),
+	}
+
+	return &adapters.Result{
+		Summary: format.Summary("Downloaded %s (%s, %s)", meta.Name, mimeType, humanBytes(int64(len(body)))),
+		Data:    result,
+	}, nil
+}
+
+// fileInfo calls files.info for the file's metadata and download URL.
+func (a *Adapter) fileInfo(ctx context.Context, token, fileID string) (*fileInfo, error) {
+	endpoint := apiBase + "/files.info?file=" + url.QueryEscape(fileID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	// Not MaxBodyLen: for textual files (HTML, snippets, posts) Slack embeds
+	// preview/plain_text fields carrying the file's own content, so the
+	// metadata response scales with the file and blows past a 200 KB cap.
+	// Truncating it yields invalid JSON and an error that points nowhere near
+	// the real cause.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxFileInfoBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("files.info: reading response: %w", err)
+	}
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("files.info: status %d: %s", resp.StatusCode, format.Truncate(string(body), 200))
+	}
+	if int64(len(body)) > maxFileInfoBytes {
+		return nil, fmt.Errorf("files.info: metadata response exceeds %s", humanBytes(maxFileInfoBytes))
+	}
+
+	var parsed struct {
+		OK    bool     `json:"ok"`
+		Error string   `json:"error"`
+		File  fileInfo `json:"file"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil, fmt.Errorf("files.info: parsing response (%d bytes): %w", len(body), err)
+	}
+	if !parsed.OK {
+		return nil, fmt.Errorf("files.info: %s", parsed.Error)
+	}
+	return &parsed.File, nil
+}
+
+// fetchContent downloads the raw bytes, returning the body and the transport's
+// declared content type. meta is used to tell a genuinely-HTML file apart from
+// Slack's sign-in page.
+func (a *Adapter) fetchContent(ctx context.Context, token, downloadURL string, maxBytes int64, meta *fileInfo) ([]byte, string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
+	if err != nil {
+		return nil, "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	// files.slack.com redirects to a CDN host. The default client forwards
+	// headers across redirects, which is what we want here (unlike OneDrive's
+	// pre-signed URLs, Slack requires the token at the final hop) — but the
+	// redirect target must still be a Slack host.
+	client := &http.Client{
+		CheckRedirect: func(r *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return fmt.Errorf("too many redirects")
+			}
+			return hostCheck(r.URL.String())
+		},
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, "", err
+	}
+	defer resp.Body.Close()
+
+	// Read one byte past the limit so truncation is detectable. files.info's
+	// size can disagree with reality for some file types.
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxBytes+1))
+	if resp.StatusCode >= 400 {
+		return nil, "", fmt.Errorf("status %d: %s", resp.StatusCode, format.Truncate(string(body), 200))
+	}
+	if int64(len(body)) > maxBytes {
+		return nil, "", fmt.Errorf(
+			"content exceeds the %s limit; pass max_bytes (up to %s) and stream the response to disk",
+			humanBytes(maxBytes), humanBytes(format.MaxDownloadBytes))
+	}
+
+	contentType := resp.Header.Get("Content-Type")
+
+	// An under-scoped or expired token gets HTTP 200 with an HTML sign-in page
+	// rather than an error, so status alone is not a success signal.
+	if isSignInPage(resp, body, contentType, meta) {
+		return nil, "", fmt.Errorf(
+			"received Slack's sign-in page instead of file content — the token likely lacks files:read or cannot access this file")
+	}
+
+	return body, contentType, nil
+}
+
+// isSignInPage distinguishes Slack's HTML sign-in page from file content.
+//
+// "The body is HTML" is not sufficient on its own: users upload .html files,
+// and rejecting those made every HTML download fail. Two positive signals mark
+// a real download — an attachment disposition, which url_private_download sets
+// and the sign-in page does not, and a body length matching the size
+// files.info reported.
+func isSignInPage(resp *http.Response, body []byte, contentType string, meta *fileInfo) bool {
+	if !isHTML(contentType, body) {
+		return false
+	}
+	if disp := resp.Header.Get("Content-Disposition"); strings.Contains(strings.ToLower(disp), "attachment") {
+		return false
+	}
+	// A file that is itself HTML and arrived at its declared length is the
+	// file, not an interstitial.
+	if meta != nil && meta.Size > 0 && int64(len(body)) == meta.Size && isHTMLMime(meta.Mimetype) {
+		return false
+	}
+	return true
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+// resolveMaxBytes returns the effective download ceiling. Callers that stream
+// the response to disk can raise it up to format.MaxDownloadBytes; the default
+// stays small enough to survive being read into a model context.
+func resolveMaxBytes(v any) (int64, error) {
+	if v == nil {
+		return format.DefaultDownloadBytes, nil
+	}
+	var n int64
+	switch x := v.(type) {
+	case float64: // JSON numbers decode as float64
+		n = int64(x)
+	case int:
+		n = int64(x)
+	case int64:
+		n = x
+	default:
+		return 0, fmt.Errorf("max_bytes must be a number")
+	}
+	if n <= 0 {
+		return 0, fmt.Errorf("max_bytes must be positive")
+	}
+	if n > format.MaxDownloadBytes {
+		return 0, fmt.Errorf("max_bytes may not exceed %s", humanBytes(format.MaxDownloadBytes))
+	}
+	return n, nil
+}
+
+// checkSlackHost rejects download URLs that do not point at Slack. The URL
+// comes from an API response rather than the caller, but it still reaches the
+// HTTP client as data, so the host is pinned rather than trusted.
+func checkSlackHost(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid download URL: %w", err)
+	}
+	if u.Scheme != "https" {
+		return fmt.Errorf("download URL must be https, got %q", u.Scheme)
+	}
+	host := strings.ToLower(u.Hostname())
+	if host != "slack.com" && !strings.HasSuffix(host, ".slack.com") {
+		return fmt.Errorf("download URL host %q is not a Slack host", host)
+	}
+	return nil
+}
+
+// isHTMLMime reports whether a declared mimetype means the file is itself HTML.
+func isHTMLMime(mimeType string) bool {
+	base := strings.ToLower(strings.TrimSpace(strings.SplitN(mimeType, ";", 2)[0]))
+	return base == "text/html" || base == "application/xhtml+xml"
+}
+
+// isHTML reports whether the response looks like a web page rather than file
+// content. Slack serves its sign-in page with a 200 status.
+func isHTML(contentType string, body []byte) bool {
+	base := strings.ToLower(strings.TrimSpace(strings.SplitN(contentType, ";", 2)[0]))
+	if base == "text/html" || base == "application/xhtml+xml" {
+		return true
+	}
+	prefix := strings.ToLower(strings.TrimSpace(string(body[:min(len(body), 512)])))
+	return strings.HasPrefix(prefix, "<!doctype html") || strings.HasPrefix(prefix, "<html")
+}
+
+func humanBytes(n int64) string {
+	switch {
+	case n >= 1024*1024:
+		return fmt.Sprintf("%.1f MB", float64(n)/(1024*1024))
+	case n >= 1024:
+		return fmt.Sprintf("%.1f KB", float64(n)/1024)
+	default:
+		return fmt.Sprintf("%d bytes", n)
+	}
+}
+
+func extractToken(credBytes []byte) (string, error) {
+	var cred struct {
+		Token       string `json:"token"`
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.Unmarshal(credBytes, &cred); err != nil {
+		return "", fmt.Errorf("parsing credential: %w", err)
+	}
+	token := cred.Token
+	if token == "" {
+		token = cred.AccessToken
+	}
+	if token == "" {
+		return "", fmt.Errorf("credential missing token")
+	}
+	return token, nil
+}

--- a/internal/adapters/slack/adapter.go
+++ b/internal/adapters/slack/adapter.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/clawvisor/clawvisor/internal/adapters/format"
 	"github.com/clawvisor/clawvisor/pkg/adapters"
@@ -28,9 +29,20 @@ var (
 )
 
 // maxFileInfoBytes caps the files.info metadata read. Slack embeds preview and
-// plain_text content for textual files, so this tracks file size rather than
-// being a small fixed envelope.
-const maxFileInfoBytes = 8 << 20
+// plain_text content for textual files, so the metadata scales with the file
+// rather than being a small fixed envelope. Derived from the download ceiling
+// so a file that max_bytes permits can never be rejected at the metadata step:
+// twice the payload covers JSON escaping, plus headroom for the other fields.
+const maxFileInfoBytes = 2*format.MaxDownloadBytes + (1 << 20)
+
+// HTTP timeouts. Without them a stalled files.slack.com response would pin a
+// gateway goroutine for as long as the caller's context allows, which may be
+// no deadline at all. The content budget is the larger of the two because it
+// covers up to MaxDownloadBytes of transfer.
+const (
+	fileInfoTimeout = 30 * time.Second
+	downloadTimeout = 2 * time.Minute
+)
 
 // Adapter handles Slack actions that require fetching file content.
 type Adapter struct{}
@@ -63,8 +75,8 @@ type fileInfo struct {
 	URLPrivate         string `json:"url_private"`
 }
 
-// downloadFile fetches a file's content from Slack and returns it base64-encoded
-// (or as text, for textual content types).
+// downloadFile fetches a file's content from Slack and returns it
+// base64-encoded, for every content type — see the encoding note below.
 //
 // Unlike Dropbox and Drive, this is a two-host operation: files.info is served
 // from slack.com/api, but the bytes come from files.slack.com and require the
@@ -157,7 +169,7 @@ func (a *Adapter) fileInfo(ctx context.Context, token, fileID string) (*fileInfo
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := (&http.Client{Timeout: fileInfoTimeout}).Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -168,12 +180,14 @@ func (a *Adapter) fileInfo(ctx context.Context, token, fileID string) (*fileInfo
 	// metadata response scales with the file and blows past a 200 KB cap.
 	// Truncating it yields invalid JSON and an error that points nowhere near
 	// the real cause.
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxFileInfoBytes+1))
-	if err != nil {
-		return nil, fmt.Errorf("files.info: reading response: %w", err)
-	}
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxFileInfoBytes+1))
+	// Status first, as in fetchContent: on a 4xx the partial body carries the
+	// error message and is more useful than the read failure.
 	if resp.StatusCode >= 400 {
 		return nil, fmt.Errorf("files.info: status %d: %s", resp.StatusCode, format.Truncate(string(body), 200))
+	}
+	if readErr != nil {
+		return nil, fmt.Errorf("files.info: reading response after %d bytes: %w", len(body), readErr)
 	}
 	if int64(len(body)) > maxFileInfoBytes {
 		return nil, fmt.Errorf("files.info: metadata response exceeds %s", humanBytes(maxFileInfoBytes))
@@ -208,6 +222,7 @@ func (a *Adapter) fetchContent(ctx context.Context, token, downloadURL string, m
 	// pre-signed URLs, Slack requires the token at the final hop) — but the
 	// redirect target must still be a Slack host.
 	client := &http.Client{
+		Timeout: downloadTimeout,
 		CheckRedirect: func(r *http.Request, via []*http.Request) error {
 			if len(via) >= 10 {
 				return fmt.Errorf("too many redirects")
@@ -224,9 +239,18 @@ func (a *Adapter) fetchContent(ctx context.Context, token, downloadURL string, m
 
 	// Read one byte past the limit so truncation is detectable. files.info's
 	// size can disagree with reality for some file types.
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxBytes+1))
+	//
+	// The read error is propagated rather than dropped: a connection broken
+	// mid-transfer otherwise yields a short body that base64-encodes cleanly
+	// and is returned as a successful — but silently truncated — download.
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxBytes+1))
+	// Status first: on a 4xx the partial body is the error message, which is
+	// more useful than the read failure.
 	if resp.StatusCode >= 400 {
 		return nil, "", fmt.Errorf("status %d: %s", resp.StatusCode, format.Truncate(string(body), 200))
+	}
+	if readErr != nil {
+		return nil, "", fmt.Errorf("reading content after %d bytes: %w", len(body), readErr)
 	}
 	if int64(len(body)) > maxBytes {
 		return nil, "", fmt.Errorf(

--- a/internal/adapters/slack/adapter.go
+++ b/internal/adapters/slack/adapter.go
@@ -37,12 +37,27 @@ const maxFileInfoBytes = 2*format.MaxDownloadBytes + (1 << 20)
 
 // HTTP timeouts. Without them a stalled files.slack.com response would pin a
 // gateway goroutine for as long as the caller's context allows, which may be
-// no deadline at all. The content budget is the larger of the two because it
-// covers up to MaxDownloadBytes of transfer.
+// no deadline at all.
 const (
 	fileInfoTimeout = 30 * time.Second
-	downloadTimeout = 2 * time.Minute
+
+	// baseDownloadTimeout covers connection setup and the first bytes.
+	baseDownloadTimeout = 30 * time.Second
+	// minDownloadThroughput is the pessimistic floor used to turn a byte
+	// budget into a time budget.
+	minDownloadThroughput = 128 << 10 // 128 KB/s
+	// maxDownloadTimeout bounds the result regardless of max_bytes.
+	maxDownloadTimeout = 5 * time.Minute
 )
+
+// downloadTimeoutFor scales the transfer budget with the number of bytes the
+// caller asked for. http.Client.Timeout is wall-clock and includes reading the
+// body, so a single fixed value would either kill a legitimate 10 MB download
+// on a slow link or leave a 1 MB one hanging far longer than it should.
+func downloadTimeoutFor(maxBytes int64) time.Duration {
+	d := baseDownloadTimeout + time.Duration(maxBytes/minDownloadThroughput)*time.Second
+	return min(d, maxDownloadTimeout)
+}
 
 // Adapter handles Slack actions that require fetching file content.
 type Adapter struct{}
@@ -102,7 +117,9 @@ func (a *Adapter) downloadFile(ctx context.Context, token string, params map[str
 	if meta.Size > maxBytes {
 		return nil, fmt.Errorf(
 			"slack download_file: %q is %s, which exceeds the %s limit; "+
-				"pass max_bytes (up to %s) and stream the response to disk rather than into a model context",
+				"raise max_bytes (up to %s). The content is base64-encoded into the "+
+				"response, so save that response to a file and decode it rather than "+
+				"reading it into a model context",
 			meta.Name, humanBytes(meta.Size), humanBytes(maxBytes), humanBytes(format.MaxDownloadBytes))
 	}
 
@@ -217,17 +234,25 @@ func (a *Adapter) fetchContent(ctx context.Context, token, downloadURL string, m
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 
-	// files.slack.com redirects to a CDN host. The default client forwards
-	// headers across redirects, which is what we want here (unlike OneDrive's
-	// pre-signed URLs, Slack requires the token at the final hop) — but the
-	// redirect target must still be a Slack host.
+	// files.slack.com redirects to a CDN host, and Slack requires the bearer
+	// token at the final hop — the opposite of OneDrive's pre-signed URLs,
+	// which must have it stripped.
+	//
+	// net/http drops Authorization when a redirect crosses to a host that is
+	// not the origin or a subdomain of it (shouldCopyHeaderOnRedirect), so the
+	// header is re-applied explicitly. That is only safe because hostCheck has
+	// already confirmed the target is a Slack host; the order matters.
 	client := &http.Client{
-		Timeout: downloadTimeout,
+		Timeout: downloadTimeoutFor(maxBytes),
 		CheckRedirect: func(r *http.Request, via []*http.Request) error {
 			if len(via) >= 10 {
 				return fmt.Errorf("too many redirects")
 			}
-			return hostCheck(r.URL.String())
+			if err := hostCheck(r.URL.String()); err != nil {
+				return err
+			}
+			r.Header.Set("Authorization", "Bearer "+token)
+			return nil
 		},
 	}
 
@@ -254,7 +279,7 @@ func (a *Adapter) fetchContent(ctx context.Context, token, downloadURL string, m
 	}
 	if int64(len(body)) > maxBytes {
 		return nil, "", fmt.Errorf(
-			"content exceeds the %s limit; pass max_bytes (up to %s) and stream the response to disk",
+			"content exceeds the %s limit; raise max_bytes (up to %s)",
 			humanBytes(maxBytes), humanBytes(format.MaxDownloadBytes))
 	}
 

--- a/internal/adapters/slack/adapter_test.go
+++ b/internal/adapters/slack/adapter_test.go
@@ -26,6 +26,7 @@ type slackServer struct {
 	contentDisposition string
 	contentCode        int
 	gotAuth            string
+	redirectTo         string // when set, /files/download 302s here
 }
 
 func newSlackServer(t *testing.T) *slackServer {
@@ -42,6 +43,10 @@ func newSlackServer(t *testing.T) *slackServer {
 	})
 	mux.HandleFunc("/files/download", func(w http.ResponseWriter, r *http.Request) {
 		s.gotAuth = r.Header.Get("Authorization")
+		if s.redirectTo != "" {
+			http.Redirect(w, r, s.redirectTo, http.StatusFound)
+			return
+		}
 		w.Header().Set("Content-Type", s.contentType)
 		if s.contentDisposition != "" {
 			w.Header().Set("Content-Disposition", s.contentDisposition)
@@ -167,6 +172,81 @@ func TestDownloadFileSurvivesJSONRoundTrip(t *testing.T) {
 	}
 	if !bytes.Equal(got, s.content) {
 		t.Errorf("bytes changed across JSON:\n got %v\nwant %v", got, s.content)
+	}
+}
+
+// files.slack.com 302s to a CDN host. Slack requires the bearer token at the
+// final hop — the opposite of OneDrive's pre-signed URLs, which must have it
+// stripped — so assert the token survives the redirect and that the hop is
+// still host-checked. Without this the token could be forwarded to an
+// arbitrary host, or dropped, and CI would stay green.
+func TestDownloadFileForwardsTokenAcrossRedirectAndChecksHost(t *testing.T) {
+	var finalAuth string
+	var checked []string
+
+	final := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		finalAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write([]byte{0x89, 'P', 'N', 'G'})
+	}))
+	defer final.Close()
+
+	s := newSlackServer(t)
+	s.redirectTo = final.URL + "/cdn/blob"
+	s.fileMeta = map[string]any{
+		"id": "F20", "name": "shot.png", "mimetype": "image/png",
+		"size": 4, "url_private_download": s.URL + "/files/download",
+	}
+
+	// Record every URL the host check sees instead of disabling it.
+	oldAPI, oldCheck := apiBase, hostCheck
+	apiBase = s.URL + "/api"
+	hostCheck = func(u string) error { checked = append(checked, u); return nil }
+	t.Cleanup(func() { apiBase, hostCheck = oldAPI, oldCheck })
+
+	if _, err := run(t, map[string]any{"file_id": "F20"}, cred("xoxp-tok")); err != nil {
+		t.Fatalf("redirected download should succeed: %v", err)
+	}
+	if finalAuth != "Bearer xoxp-tok" {
+		t.Errorf("token did not survive the redirect: final hop saw %q", finalAuth)
+	}
+	// Initial URL plus the redirect target.
+	if len(checked) < 2 {
+		t.Fatalf("expected the redirect target to be host-checked, saw %v", checked)
+	}
+	if !strings.Contains(checked[len(checked)-1], "/cdn/blob") {
+		t.Errorf("redirect target was not host-checked, saw %v", checked)
+	}
+}
+
+// A redirect to a non-Slack host must abort the download.
+func TestDownloadFileRejectsRedirectToForeignHost(t *testing.T) {
+	evil := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("request reached the foreign host — the token may have leaked")
+		w.WriteHeader(200)
+	}))
+	defer evil.Close()
+
+	s := newSlackServer(t)
+	s.redirectTo = evil.URL + "/steal"
+	s.fileMeta = map[string]any{
+		"id": "F21", "name": "shot.png", "mimetype": "image/png",
+		"size": 4, "url_private_download": s.URL + "/files/download",
+	}
+
+	// Real host check, with only the API base treated as Slack.
+	oldAPI, oldCheck := apiBase, hostCheck
+	apiBase = s.URL + "/api"
+	hostCheck = func(u string) error {
+		if strings.HasPrefix(u, s.URL) {
+			return nil
+		}
+		return checkSlackHost(u)
+	}
+	t.Cleanup(func() { apiBase, hostCheck = oldAPI, oldCheck })
+
+	if _, err := run(t, map[string]any{"file_id": "F21"}, cred("t")); err == nil {
+		t.Fatal("expected a redirect to a non-Slack host to be refused")
 	}
 }
 

--- a/internal/adapters/slack/adapter_test.go
+++ b/internal/adapters/slack/adapter_test.go
@@ -192,7 +192,13 @@ func TestDownloadFileForwardsTokenAcrossRedirectAndChecksHost(t *testing.T) {
 	defer final.Close()
 
 	s := newSlackServer(t)
-	s.redirectTo = final.URL + "/cdn/blob"
+	// Must be a genuinely different hostname, not just a different port:
+	// net/http only strips Authorization when the redirect leaves the origin
+	// host, so a 127.0.0.1 -> 127.0.0.1 hop would preserve the header on its
+	// own and prove nothing. httptest binds 127.0.0.1; "localhost" resolves to
+	// the same listener but is a distinct host string, which is what triggers
+	// the strip this test exists to catch.
+	s.redirectTo = strings.Replace(final.URL, "127.0.0.1", "localhost", 1) + "/cdn/blob"
 	s.fileMeta = map[string]any{
 		"id": "F20", "name": "shot.png", "mimetype": "image/png",
 		"size": 4, "url_private_download": s.URL + "/files/download",

--- a/internal/adapters/slack/adapter_test.go
+++ b/internal/adapters/slack/adapter_test.go
@@ -1,0 +1,405 @@
+package slack
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/internal/adapters/format"
+	"github.com/clawvisor/clawvisor/pkg/adapters"
+)
+
+// slackServer stands in for both slack.com/api and files.slack.com. The
+// adapter builds absolute URLs, so tests point url_private_download at the
+// test server and relax the host check via hostCheckOverride.
+type slackServer struct {
+	*httptest.Server
+	fileMeta           map[string]any
+	content            []byte
+	contentType        string
+	contentDisposition string
+	contentCode        int
+	gotAuth            string
+}
+
+func newSlackServer(t *testing.T) *slackServer {
+	t.Helper()
+	s := &slackServer{contentType: "image/png", contentCode: 200}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/files.info", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if s.fileMeta == nil {
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": false, "error": "file_not_found"})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "file": s.fileMeta})
+	})
+	mux.HandleFunc("/files/download", func(w http.ResponseWriter, r *http.Request) {
+		s.gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", s.contentType)
+		if s.contentDisposition != "" {
+			w.Header().Set("Content-Disposition", s.contentDisposition)
+		}
+		w.WriteHeader(s.contentCode)
+		_, _ = w.Write(s.content)
+	})
+	s.Server = httptest.NewServer(mux)
+	t.Cleanup(s.Close)
+	return s
+}
+
+// withTestHosts points the adapter at the test server and allows its host.
+func withTestHosts(t *testing.T, base string) {
+	t.Helper()
+	oldAPI, oldCheck := apiBase, hostCheck
+	apiBase = base + "/api"
+	hostCheck = func(string) error { return nil }
+	t.Cleanup(func() { apiBase, hostCheck = oldAPI, oldCheck })
+}
+
+func cred(token string) []byte {
+	return []byte(fmt.Sprintf(`{"access_token":%q}`, token))
+}
+
+func run(t *testing.T, params map[string]any, c []byte) (*adapters.Result, error) {
+	t.Helper()
+	return New().Execute(context.Background(), adapters.Request{
+		Action: "download_file", Params: params, Credential: c,
+	})
+}
+
+func TestDownloadFileBinaryReturnsBase64(t *testing.T) {
+	s := newSlackServer(t)
+	withTestHosts(t, s.URL)
+	s.content = []byte{0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a, 0xff}
+	s.fileMeta = map[string]any{
+		"id": "F1", "name": "shot.png", "mimetype": "image/png",
+		"size": len(s.content), "url_private_download": s.URL + "/files/download",
+	}
+
+	res, err := run(t, map[string]any{"file_id": "F1"}, cred("xoxp-tok"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data := res.Data.(map[string]any)
+	if data["encoding"] != "base64" {
+		t.Errorf("encoding = %v, want base64", data["encoding"])
+	}
+	got, err := base64.StdEncoding.DecodeString(data["content"].(string))
+	if err != nil {
+		t.Fatalf("content is not decodable base64: %v", err)
+	}
+	if string(got) != string(s.content) {
+		t.Errorf("round-trip mismatch: got %v want %v", got, s.content)
+	}
+	if data["mime_type"] != "image/png" {
+		t.Errorf("mime_type = %v", data["mime_type"])
+	}
+	if s.gotAuth != "Bearer xoxp-tok" {
+		t.Errorf("content request auth = %q, want bearer token", s.gotAuth)
+	}
+}
+
+// Every content type comes back base64, including text — a text path could
+// not guarantee byte-exactness.
+func TestDownloadFileTextIsAlsoBase64AndByteExact(t *testing.T) {
+	s := newSlackServer(t)
+	withTestHosts(t, s.URL)
+	// Angle brackets would be eaten by the HTML stripper; the trailing bytes
+	// are invalid UTF-8, which a JSON string would replace with U+FFFD.
+	s.content = append([]byte("col_a,col_b\n\"a<b>c\",2\n"), 0xff, 0xfe)
+	s.contentType = "text/csv"
+	s.fileMeta = map[string]any{
+		"id": "F2", "name": "data.csv", "mimetype": "text/csv",
+		"size": len(s.content), "url_private_download": s.URL + "/files/download",
+	}
+
+	res, err := run(t, map[string]any{"file_id": "F2"}, cred("t"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data := res.Data.(map[string]any)
+	if data["encoding"] != "base64" {
+		t.Fatalf("encoding = %v, want base64 for all types", data["encoding"])
+	}
+	got, err := base64.StdEncoding.DecodeString(data["content"].(string))
+	if err != nil {
+		t.Fatalf("undecodable base64: %v", err)
+	}
+	if !bytes.Equal(got, s.content) {
+		t.Errorf("text was altered:\n got %v\nwant %v", got, s.content)
+	}
+}
+
+// The result must survive JSON marshalling unchanged — this is the hop that
+// would corrupt raw non-UTF-8 bytes.
+func TestDownloadFileSurvivesJSONRoundTrip(t *testing.T) {
+	s := newSlackServer(t)
+	withTestHosts(t, s.URL)
+	s.content = []byte{0x00, 0x01, 0xff, 0xfe, 0x80, 'h', 'i', 0xc3, 0x28}
+	s.contentType = "application/octet-stream"
+	s.fileMeta = map[string]any{
+		"id": "F11", "name": "raw.bin", "mimetype": "application/octet-stream",
+		"size": len(s.content), "url_private_download": s.URL + "/files/download",
+	}
+
+	res, err := run(t, map[string]any{"file_id": "F11"}, cred("t"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	encoded, err := json.Marshal(res.Data)
+	if err != nil {
+		t.Fatalf("marshalling result: %v", err)
+	}
+	var back map[string]any
+	if err := json.Unmarshal(encoded, &back); err != nil {
+		t.Fatalf("unmarshalling result: %v", err)
+	}
+	got, err := base64.StdEncoding.DecodeString(back["content"].(string))
+	if err != nil {
+		t.Fatalf("undecodable base64 after round trip: %v", err)
+	}
+	if !bytes.Equal(got, s.content) {
+		t.Errorf("bytes changed across JSON:\n got %v\nwant %v", got, s.content)
+	}
+}
+
+// A truncated binary download is undecodable, so an oversized file must be a
+// hard error rather than a success-shaped partial result.
+func TestDownloadFileRefusesOversizedFile(t *testing.T) {
+	s := newSlackServer(t)
+	withTestHosts(t, s.URL)
+	s.fileMeta = map[string]any{
+		"id": "F3", "name": "big.zip", "mimetype": "application/zip",
+		"size": format.DefaultDownloadBytes + 1, "url_private_download": s.URL + "/files/download",
+	}
+
+	_, err := run(t, map[string]any{"file_id": "F3"}, cred("t"))
+	if err == nil {
+		t.Fatal("expected an error for an oversized file")
+	}
+	if !strings.Contains(err.Error(), "max_bytes") {
+		t.Errorf("error should point at max_bytes, got: %v", err)
+	}
+}
+
+// files.info's size can disagree with the actual body, so the read itself is
+// also bounded.
+func TestDownloadFileRefusesUnderreportedSize(t *testing.T) {
+	s := newSlackServer(t)
+	withTestHosts(t, s.URL)
+	s.content = make([]byte, 2048)
+	s.fileMeta = map[string]any{
+		"id": "F4", "name": "liar.bin", "mimetype": "application/octet-stream",
+		"size": 10, "url_private_download": s.URL + "/files/download",
+	}
+
+	_, err := run(t, map[string]any{"file_id": "F4", "max_bytes": float64(1024)}, cred("t"))
+	if err == nil {
+		t.Fatal("expected an error when the body exceeds max_bytes")
+	}
+	if !strings.Contains(err.Error(), "exceeds") {
+		t.Errorf("got: %v", err)
+	}
+}
+
+func TestDownloadFileAllowsRaisedLimit(t *testing.T) {
+	s := newSlackServer(t)
+	withTestHosts(t, s.URL)
+	s.content = make([]byte, format.DefaultDownloadBytes+1024)
+	s.fileMeta = map[string]any{
+		"id": "F5", "name": "big.png", "mimetype": "image/png",
+		"size": len(s.content), "url_private_download": s.URL + "/files/download",
+	}
+
+	res, err := run(t, map[string]any{"file_id": "F5", "max_bytes": float64(format.MaxDownloadBytes)}, cred("t"))
+	if err != nil {
+		t.Fatalf("raising max_bytes should permit the download: %v", err)
+	}
+	if got := res.Data.(map[string]any)["size"].(int); got != len(s.content) {
+		t.Errorf("size = %d, want %d", got, len(s.content))
+	}
+}
+
+func TestResolveMaxBytesRejectsOverCeiling(t *testing.T) {
+	if _, err := resolveMaxBytes(float64(format.MaxDownloadBytes + 1)); err == nil {
+		t.Error("expected an error above the ceiling")
+	}
+	if _, err := resolveMaxBytes(float64(0)); err == nil {
+		t.Error("expected an error for zero")
+	}
+	got, err := resolveMaxBytes(nil)
+	if err != nil || got != format.DefaultDownloadBytes {
+		t.Errorf("default = %d, %v", got, err)
+	}
+}
+
+// Slack answers an under-scoped token with 200 + a sign-in page, so status
+// alone cannot be treated as success.
+func TestDownloadFileDetectsHTMLLoginPage(t *testing.T) {
+	s := newSlackServer(t)
+	withTestHosts(t, s.URL)
+	s.content = []byte("<!DOCTYPE html><html><body>Sign in to Slack</body></html>")
+	s.contentType = "text/html; charset=utf-8"
+	s.fileMeta = map[string]any{
+		"id": "F6", "name": "shot.png", "mimetype": "image/png",
+		"size": len(s.content), "url_private_download": s.URL + "/files/download",
+	}
+
+	_, err := run(t, map[string]any{"file_id": "F6"}, cred("t"))
+	if err == nil {
+		t.Fatal("expected an error for an HTML sign-in page")
+	}
+	if !strings.Contains(err.Error(), "files:read") {
+		t.Errorf("error should mention the likely scope cause, got: %v", err)
+	}
+}
+
+// Regression: an uploaded .html file is legitimately HTML. The first cut
+// rejected every one of them as a sign-in page.
+func TestDownloadFileAcceptsGenuineHTMLFile(t *testing.T) {
+	s := newSlackServer(t)
+	withTestHosts(t, s.URL)
+	s.content = []byte("<!DOCTYPE html><html><body><h1>Report</h1></body></html>")
+	s.contentType = "text/html"
+	s.contentDisposition = `attachment; filename="report.html"`
+	s.fileMeta = map[string]any{
+		"id": "F7", "name": "report.html", "mimetype": "text/html",
+		"size": len(s.content), "url_private_download": s.URL + "/files/download",
+	}
+
+	res, err := run(t, map[string]any{"file_id": "F7"}, cred("t"))
+	if err != nil {
+		t.Fatalf("an HTML file should download, got: %v", err)
+	}
+	data := res.Data.(map[string]any)
+	// HTML must round-trip byte-exact, not go through the HTML-stripping
+	// text path.
+	if data["encoding"] != "base64" {
+		t.Fatalf("expected base64 for HTML, got encoding=%v", data["encoding"])
+	}
+	got, err := base64.StdEncoding.DecodeString(data["content"].(string))
+	if err != nil {
+		t.Fatalf("undecodable base64: %v", err)
+	}
+	if string(got) != string(s.content) {
+		t.Errorf("HTML was altered:\n got %q\nwant %q", got, s.content)
+	}
+}
+
+// An HTML file whose length matches files.info is the file even without a
+// Content-Disposition header.
+func TestDownloadFileAcceptsHTMLFileWithoutDisposition(t *testing.T) {
+	s := newSlackServer(t)
+	withTestHosts(t, s.URL)
+	s.content = []byte("<html><body>ok</body></html>")
+	s.contentType = "text/html"
+	s.fileMeta = map[string]any{
+		"id": "F8", "name": "page.html", "mimetype": "text/html",
+		"size": len(s.content), "url_private_download": s.URL + "/files/download",
+	}
+
+	if _, err := run(t, map[string]any{"file_id": "F8"}, cred("t")); err != nil {
+		t.Fatalf("expected the HTML file to download, got: %v", err)
+	}
+}
+
+// The sign-in page must still be caught: HTML, no attachment disposition, and
+// a length that disagrees with files.info.
+func TestDownloadFileStillDetectsSignInPageForHTMLFile(t *testing.T) {
+	s := newSlackServer(t)
+	withTestHosts(t, s.URL)
+	s.content = []byte("<!DOCTYPE html><html><body>Sign in to Slack</body></html>")
+	s.contentType = "text/html; charset=utf-8"
+	s.fileMeta = map[string]any{
+		"id": "F9", "name": "page.html", "mimetype": "text/html",
+		"size":                 4096, // real file is 4 KB; we got a short interstitial
+		"url_private_download": s.URL + "/files/download",
+	}
+
+	_, err := run(t, map[string]any{"file_id": "F9"}, cred("t"))
+	if err == nil {
+		t.Fatal("expected the sign-in page to be rejected")
+	}
+	if !strings.Contains(err.Error(), "sign-in page") {
+		t.Errorf("got: %v", err)
+	}
+}
+
+// Regression: files.info embeds preview/plain_text for textual files, so its
+// response scales with file size. Capping the read at 200 KB truncated the
+// JSON and surfaced "unexpected end of JSON input".
+func TestFileInfoHandlesLargeMetadataResponse(t *testing.T) {
+	s := newSlackServer(t)
+	withTestHosts(t, s.URL)
+	s.content = []byte("<html>small body</html>")
+	s.contentType = "text/html"
+	s.contentDisposition = `attachment; filename="big.html"`
+	s.fileMeta = map[string]any{
+		"id": "F10", "name": "big.html", "mimetype": "text/html",
+		"size": len(s.content), "url_private_download": s.URL + "/files/download",
+		// Slack embeds the file's text; ~400 KB of it, well past the old cap.
+		"plain_text": strings.Repeat("x", 400*1024),
+	}
+
+	if _, err := run(t, map[string]any{"file_id": "F10"}, cred("t")); err != nil {
+		t.Fatalf("large files.info metadata should parse, got: %v", err)
+	}
+}
+
+func TestDownloadFilePropagatesSlackAPIError(t *testing.T) {
+	s := newSlackServer(t)
+	withTestHosts(t, s.URL)
+	s.fileMeta = nil // files.info returns ok:false
+
+	_, err := run(t, map[string]any{"file_id": "nope"}, cred("t"))
+	if err == nil || !strings.Contains(err.Error(), "file_not_found") {
+		t.Fatalf("want the Slack error surfaced, got: %v", err)
+	}
+}
+
+func TestDownloadFileRequiresFileID(t *testing.T) {
+	if _, err := run(t, map[string]any{}, cred("t")); err == nil {
+		t.Fatal("expected an error when file_id is missing")
+	}
+}
+
+// The download URL arrives from an API response, so the host is pinned rather
+// than trusted.
+func TestCheckSlackHost(t *testing.T) {
+	ok := []string{
+		"https://files.slack.com/files-pri/T1-F1/shot.png",
+		"https://slack.com/files/x",
+	}
+	for _, u := range ok {
+		if err := checkSlackHost(u); err != nil {
+			t.Errorf("checkSlackHost(%q) = %v, want nil", u, err)
+		}
+	}
+	bad := []string{
+		"https://evil.com/x",
+		"https://files.slack.com.evil.com/x",
+		"http://files.slack.com/x", // not https
+		"https://127.0.0.1/x",
+	}
+	for _, u := range bad {
+		if err := checkSlackHost(u); err == nil {
+			t.Errorf("checkSlackHost(%q) = nil, want an error", u)
+		}
+	}
+}
+
+func TestUnsupportedAction(t *testing.T) {
+	_, err := New().Execute(context.Background(), adapters.Request{
+		Action: "send_message", Credential: cred("t"),
+	})
+	if err == nil || !strings.Contains(err.Error(), "unsupported action") {
+		t.Fatalf("got: %v", err)
+	}
+}

--- a/pkg/clawvisor/defaults.go
+++ b/pkg/clawvisor/defaults.go
@@ -31,6 +31,7 @@ import (
 	onedriveadapter "github.com/clawvisor/clawvisor/internal/adapters/microsoft/onedrive"
 	outlookadapter "github.com/clawvisor/clawvisor/internal/adapters/microsoft/outlook"
 	perplexityadapter "github.com/clawvisor/clawvisor/internal/adapters/perplexity"
+	slackadapter "github.com/clawvisor/clawvisor/internal/adapters/slack"
 	sqladapter "github.com/clawvisor/clawvisor/internal/adapters/sql"
 	"github.com/clawvisor/clawvisor/internal/api/handlers"
 	"github.com/clawvisor/clawvisor/internal/api/middleware"
@@ -201,6 +202,9 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 	for _, action := range []string{"list_folder", "download_file", "upload_file"} {
 		goOverrides["dropbox:"+action] = dbx.Execute
 	}
+
+	slk := slackadapter.New()
+	goOverrides["slack:download_file"] = slk.Execute
 
 	pplx := perplexityadapter.New()
 	goOverrides["perplexity:chat"] = pplx.Execute


### PR DESCRIPTION
Slack could list channels and read messages but had no way to reach an uploaded file — despite already requesting the `files:read` scope and advertising "list files" in its description.

## Actions

| Action | How |
|---|---|
| `list_files` / `get_file` | `files.list` / `files.info`, plain YAML |
| `download_file` | Go override |

`download_file` needs Go because the content lives on `files.slack.com` rather than the `slack.com/api` base URL, and returns raw bytes — the YAML REST runtime concatenates `base_url + path` and hard-assumes a JSON body, so neither is expressible. Same `override: go` pattern as Dropbox/Drive/OneDrive.

`list_messages` now also surfaces `files[]`, projected to `id`/`name`/`mimetype`/`size`. The response field whitelist was dropping it, so an agent had no way to learn an attachment existed. The projection matters: a raw Slack file object carries ~40 fields of thumbnail metadata each.

## Always base64

Content comes back base64 for **every** type, including text. A text path can't round-trip a file:

- `format.SanitizeText` strips HTML — an `.html` download would return the prose with the markup deleted — and truncates at 200k runes.
- Even unsanitized, bytes in a JSON string lose anything not valid UTF-8 to U+FFFD, silently corrupting legacy-encoded CSVs and every binary format.

Uniform base64 also makes the caller contract uniform: one `base64 -d` regardless of type.

## Size limits

New `format.MaxDownloadBytes` (10 MB) with a 1 MB default, raisable per-call via `max_bytes`. Deliberately **not** a bump to `MaxBodyLen` — that constant is a rune count used to truncate human-readable text (mail bodies, calendar descriptions) and is applied to every string in every MCP response; downloads had only borrowed it as a byte count.

Oversized files are **refused, not truncated**. A truncated binary is undecodable, and Drive's current behaviour returns it under a `"Downloaded foo.png"` summary — success-shaped, corrupt payload.

## Three Slack-specific hazards

Each found by real-world testing, each with a regression test:

1. **Sign-in page on 200.** An under-scoped token gets HTML with a 200 status. Detection can't just ask "is this HTML?" — that's also true of every uploaded `.html` file, and the first cut rejected all of them. Now requires an attachment disposition or a body length matching `files.info`.
2. **`files.info` scales with file size.** Slack embeds `preview`/`plain_text` for textual files, so a 318 KB HTML file produced >200 KB of metadata; the old read cap truncated the JSON into `unexpected end of JSON input`.
3. **Download URL is response data.** Host is pinned to Slack on the initial request and every redirect hop. Unlike OneDrive's pre-signed URLs, Slack requires the bearer token at the final hop, so it is forwarded deliberately rather than stripped.

## Testing

17 unit tests. Verified separately that the definition passes `yamlvalidate` (a failure drops the *entire* adapter, not just the bad action), that all four actions load, and that `download_file` dispatches to the Go override rather than the REST engine.

**Not covered:** every test uses `httptest`. The `Content-Disposition: attachment` assumption behind sign-in detection comes from Slack's documented behaviour for `url_private_download` and has not been observed against the live API — if Slack omits it, the length check is the fallback, and both must fail together to break a download.

Dropbox, Drive, and OneDrive still have the text branch and the same three corruption paths; aligning them changes their existing output contract, so it's left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

