### PR TITLE
fix(adapters): make downloads byte-exact; add gmail raw message

### DIFF
--- a/internal/adapters/definitions/dropbox.yaml
+++ b/internal/adapters/definitions/dropbox.yaml
@@ -75,6 +75,8 @@ actions:
     display_name: "Download file"
     risk: { category: read, sensitivity: low, description: "Download a file's content from Dropbox" }
     override: go
+    # Content is returned base64-encoded for every file type, so the file
+    # round-trips byte for byte. Decode it before use.
     params:
       path:
         type: string

--- a/internal/adapters/definitions/dropbox.yaml
+++ b/internal/adapters/definitions/dropbox.yaml
@@ -82,6 +82,9 @@ actions:
         type: string
         required: true
         description: "File path in Dropbox (e.g. /Documents/report.pdf)"
+      max_bytes:
+        type: int
+        description: "Maximum bytes to download (default 1 MB, max 10 MB). Oversized files are refused, not truncated."
 
   upload_file:
     display_name: "Upload file"

--- a/internal/adapters/definitions/google_drive.yaml
+++ b/internal/adapters/definitions/google_drive.yaml
@@ -67,6 +67,9 @@ actions:
     override: go
     params:
       file_id: { type: string, required: true }
+      max_bytes:
+        type: int
+        description: "Maximum bytes to download (default 1 MB, max 10 MB). Oversized files are refused, not truncated."
 
   create_file:
     display_name: "Create file"
@@ -102,6 +105,9 @@ actions:
       sheet_name:
         type: string
         description: "Google Sheets only: name of the tab to export when mime_type is text/csv or text/tab-separated-values. Without this, only the first tab is returned."
+      max_bytes:
+        type: int
+        description: "Maximum bytes to download (default 1 MB, max 10 MB). Oversized files are refused, not truncated."
 
   search_files:
     display_name: "Search files"

--- a/internal/adapters/definitions/google_gmail.yaml
+++ b/internal/adapters/definitions/google_gmail.yaml
@@ -44,6 +44,27 @@ actions:
     params:
       message_id: { type: string, required: true }
 
+  # Alternative to get_message, not a replacement. get_message returns a
+  # readable projection (from/subject/body/labels) and is what most callers
+  # want. This returns the original RFC 5322 bytes, base64-encoded, for the
+  # cases a projection cannot serve: header or DKIM verification, verbatim
+  # re-send and archival, or MIME parts the projection drops.
+  get_message_raw:
+    display_name: "Get raw message"
+    risk: { category: read, sensitivity: low, description: "Read a specific email message in its original RFC 5322 form" }
+    scopes: ["https://www.googleapis.com/auth/gmail.readonly"]
+    override: go
+    params:
+      message_id: { type: string, required: true }
+      max_bytes:
+        type: int
+        description: >
+          Maximum decoded message size (default 1 MB, max 10 MB). A raw
+          message carries its attachments inline, so it can be much larger
+          than the parsed form. Content is returned base64-encoded, which
+          inflates it by ~4/3 — only raise this when saving the response to a
+          file rather than reading it into a context.
+
   get_thread:
     display_name: "Get thread"
     risk: { category: read, sensitivity: low, description: "Read all messages in an email thread" }

--- a/internal/adapters/definitions/microsoft_onedrive.yaml
+++ b/internal/adapters/definitions/microsoft_onedrive.yaml
@@ -134,3 +134,6 @@ actions:
         - { name: webUrl, rename: web_url }
         - { name: lastModifiedDateTime, rename: modified }
       summary: "{{len .Data}} result(s)"
+      max_bytes:
+        type: int
+        description: "Maximum bytes to download (default 1 MB, max 10 MB). Oversized files are refused, not truncated."

--- a/internal/adapters/definitions/microsoft_onedrive.yaml
+++ b/internal/adapters/definitions/microsoft_onedrive.yaml
@@ -85,6 +85,8 @@ actions:
     risk: { category: read, sensitivity: low, description: "Download a file's content from OneDrive" }
     scopes: ["Files.ReadWrite"]
     override: go
+    # Content is returned base64-encoded for every file type, so the file
+    # round-trips byte for byte. Decode it before use.
     params:
       item_id:
         type: string

--- a/internal/adapters/definitions/microsoft_onedrive.yaml
+++ b/internal/adapters/definitions/microsoft_onedrive.yaml
@@ -92,6 +92,9 @@ actions:
         type: string
         required: true
         description: "OneDrive item ID"
+      max_bytes:
+        type: int
+        description: "Maximum bytes to download (default 1 MB, max 10 MB). Oversized files are refused, not truncated."
 
   upload_file:
     display_name: "Upload file"
@@ -134,6 +137,3 @@ actions:
         - { name: webUrl, rename: web_url }
         - { name: lastModifiedDateTime, rename: modified }
       summary: "{{len .Data}} result(s)"
-      max_bytes:
-        type: int
-        description: "Maximum bytes to download (default 1 MB, max 10 MB). Oversized files are refused, not truncated."

--- a/internal/adapters/dropbox/adapter.go
+++ b/internal/adapters/dropbox/adapter.go
@@ -172,9 +172,7 @@ func (a *Adapter) downloadFile(ctx context.Context, token string, params map[str
 		return nil, fmt.Errorf("dropbox download_file: reading content after %d bytes: %w", len(body), readErr)
 	}
 	if overflow {
-		return nil, fmt.Errorf(
-			"dropbox download_file: %q exceeds the %d byte limit; raise max_bytes (up to %d)",
-			path, maxBytes, format.MaxDownloadBytes)
+		return nil, fmt.Errorf("dropbox download_file: %q %s", path, format.OverflowMessage(maxBytes))
 	}
 
 	// Dropbox returns file metadata in the Dropbox-API-Result header.

--- a/internal/adapters/dropbox/adapter.go
+++ b/internal/adapters/dropbox/adapter.go
@@ -177,18 +177,17 @@ func (a *Adapter) downloadFile(ctx context.Context, token string, params map[str
 	if contentType == "" {
 		contentType = "application/octet-stream"
 	}
+	// Always base64, for every content type — a download must round-trip the
+	// file byte for byte. The text path could not: format.SanitizeText strips
+	// HTML and truncates at MaxBodyLen runes, and even unsanitized, bytes
+	// placed in a JSON string lose anything that is not valid UTF-8 to U+FFFD.
 	result := map[string]any{
 		"name":         format.SanitizeText(meta.Name, format.MaxFieldLen),
 		"id":           meta.ID,
 		"size":         meta.Size,
 		"content_type": contentType,
-	}
-
-	if isTextContent(contentType) {
-		result["content"] = format.SanitizeText(string(body), format.MaxBodyLen)
-	} else {
-		result["encoding"] = "base64"
-		result["content"] = base64.StdEncoding.EncodeToString(body)
+		"encoding":     "base64",
+		"content":      base64.StdEncoding.EncodeToString(body),
 	}
 
 	return &adapters.Result{
@@ -241,11 +240,11 @@ func (a *Adapter) uploadFile(ctx context.Context, token string, params map[strin
 	}
 
 	var uploaded struct {
-		Name         string `json:"name"`
-		ID           string `json:"id"`
-		PathDisplay  string `json:"path_display"`
-		Size         int64  `json:"size"`
-		ContentHash  string `json:"content_hash"`
+		Name        string `json:"name"`
+		ID          string `json:"id"`
+		PathDisplay string `json:"path_display"`
+		Size        int64  `json:"size"`
+		ContentHash string `json:"content_hash"`
 	}
 	if err := json.Unmarshal(body, &uploaded); err != nil {
 		return nil, fmt.Errorf("dropbox upload_file: parsing response: %w", err)
@@ -288,4 +287,3 @@ func isTextContent(contentType string) bool {
 		contentType == "application/json" ||
 		contentType == "application/xml"
 }
-

--- a/internal/adapters/dropbox/adapter.go
+++ b/internal/adapters/dropbox/adapter.go
@@ -141,6 +141,11 @@ func (a *Adapter) downloadFile(ctx context.Context, token string, params map[str
 		return nil, fmt.Errorf("dropbox download_file: path is required")
 	}
 
+	maxBytes, err := format.ResolveMaxBytes(params["max_bytes"])
+	if err != nil {
+		return nil, fmt.Errorf("dropbox download_file: %w", err)
+	}
+
 	apiArg, _ := json.Marshal(map[string]string{"path": path})
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, contentURL+"/files/download", nil)
@@ -156,9 +161,20 @@ func (a *Adapter) downloadFile(ctx context.Context, token string, params map[str
 	}
 	defer resp.Body.Close()
 
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, int64(format.MaxBodyLen)))
+	// Bounded by the download ceiling, not MaxBodyLen. Overflow is refused
+	// rather than returned: a truncated file base64-encodes cleanly and would
+	// be indistinguishable from a complete one.
+	body, overflow, readErr := format.ReadBounded(resp.Body, maxBytes)
 	if resp.StatusCode >= 400 {
 		return nil, fmt.Errorf("dropbox download_file: status %d: %s", resp.StatusCode, format.Truncate(string(body), 200))
+	}
+	if readErr != nil {
+		return nil, fmt.Errorf("dropbox download_file: reading content after %d bytes: %w", len(body), readErr)
+	}
+	if overflow {
+		return nil, fmt.Errorf(
+			"dropbox download_file: %q exceeds the %d byte limit; raise max_bytes (up to %d)",
+			path, maxBytes, format.MaxDownloadBytes)
 	}
 
 	// Dropbox returns file metadata in the Dropbox-API-Result header.
@@ -280,10 +296,4 @@ func extractToken(credBytes []byte) (string, error) {
 		return "", fmt.Errorf("credential missing token")
 	}
 	return token, nil
-}
-
-func isTextContent(contentType string) bool {
-	return strings.HasPrefix(contentType, "text/") ||
-		contentType == "application/json" ||
-		contentType == "application/xml"
 }

--- a/internal/adapters/format/format.go
+++ b/internal/adapters/format/format.go
@@ -2,7 +2,10 @@
 package format
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+	"math"
 	"regexp"
 	"strings"
 	"unicode"
@@ -34,6 +37,60 @@ const (
 	// explicitly via a max_bytes parameter.
 	DefaultDownloadBytes = 1024 * 1024
 )
+
+// ResolveMaxBytes turns a caller-supplied max_bytes parameter into a download
+// ceiling. Shared by every adapter that returns file content so the contract —
+// the default, the ceiling, and the validation — cannot drift between them.
+//
+// Absent means DefaultDownloadBytes, which is sized to survive being read into
+// a model context. Callers that save the response to a file opt in to more, up
+// to MaxDownloadBytes.
+func ResolveMaxBytes(v any) (int64, error) {
+	if v == nil {
+		return DefaultDownloadBytes, nil
+	}
+	var n int64
+	switch x := v.(type) {
+	case float64: // JSON numbers decode as float64
+		// Reject fractional values rather than truncating them: 0.5 would
+		// silently become 0 and then fail as "must be positive", and 1.9 would
+		// become 1, producing a limit the caller never asked for.
+		if x != math.Trunc(x) {
+			return 0, fmt.Errorf("max_bytes must be a whole number, got %v", x)
+		}
+		n = int64(x)
+	case int:
+		n = int64(x)
+	case int64:
+		n = x
+	case json.Number:
+		parsed, err := x.Int64()
+		if err != nil {
+			return 0, fmt.Errorf("max_bytes must be a whole number, got %v", x)
+		}
+		n = parsed
+	default:
+		return 0, fmt.Errorf("max_bytes must be a number")
+	}
+	if n <= 0 {
+		return 0, fmt.Errorf("max_bytes must be positive")
+	}
+	if n > MaxDownloadBytes {
+		return 0, fmt.Errorf("max_bytes may not exceed %d", MaxDownloadBytes)
+	}
+	return n, nil
+}
+
+// ReadBounded reads at most limit bytes and reports whether the source had
+// more, so callers can refuse an oversized payload rather than returning a
+// truncated one. Reading limit+1 is what makes the overflow detectable.
+func ReadBounded(r io.Reader, limit int64) (body []byte, overflow bool, err error) {
+	body, err = io.ReadAll(io.LimitReader(r, limit+1))
+	if int64(len(body)) > limit {
+		return body[:limit], true, err
+	}
+	return body, false, err
+}
 
 // SanitizeText strips HTML, removes dangerous Unicode, and truncates to maxLen runes.
 // If maxLen <= 0, only sanitization is applied (no truncation).

--- a/internal/adapters/format/format.go
+++ b/internal/adapters/format/format.go
@@ -58,6 +58,13 @@ func ResolveMaxBytes(v any) (int64, error) {
 		if x != math.Trunc(x) {
 			return 0, fmt.Errorf("max_bytes must be a whole number, got %v", x)
 		}
+		// Range-check in float space. Converting an out-of-range float to
+		// int64 is implementation-defined in Go, so a value like 1e19 would
+		// otherwise reach the checks below as an arbitrary number that only
+		// happens to be negative on common platforms.
+		if x < 0 || x > float64(MaxDownloadBytes) {
+			return 0, fmt.Errorf("max_bytes must be between 1 and %d, got %v", MaxDownloadBytes, x)
+		}
 		n = int64(x)
 	case int:
 		n = int64(x)
@@ -79,6 +86,16 @@ func ResolveMaxBytes(v any) (int64, error) {
 		return 0, fmt.Errorf("max_bytes may not exceed %d", MaxDownloadBytes)
 	}
 	return n, nil
+}
+
+// OverflowMessage explains that content exceeded a limit, and only suggests
+// raising max_bytes when there is headroom left. At the ceiling the advice
+// would name the very value the caller already has.
+func OverflowMessage(limit int64) string {
+	if limit >= MaxDownloadBytes {
+		return fmt.Sprintf("exceeds the maximum supported size of %d bytes", MaxDownloadBytes)
+	}
+	return fmt.Sprintf("exceeds the %d byte limit; raise max_bytes (up to %d)", limit, MaxDownloadBytes)
 }
 
 // ReadBounded reads at most limit bytes and reports whether the source had

--- a/internal/adapters/format/format_test.go
+++ b/internal/adapters/format/format_test.go
@@ -53,3 +53,54 @@ func TestSanitizeText_StripsHTML(t *testing.T) {
 		t.Errorf("got %q, want %q", got, "bold text")
 	}
 }
+
+func TestResolveMaxBytes(t *testing.T) {
+	if got, err := ResolveMaxBytes(nil); err != nil || got != DefaultDownloadBytes {
+		t.Errorf("absent = %d, %v; want %d", got, err, DefaultDownloadBytes)
+	}
+	for _, v := range []any{float64(2048), int(2048), int64(2048)} {
+		got, err := ResolveMaxBytes(v)
+		if err != nil || got != 2048 {
+			t.Errorf("ResolveMaxBytes(%T) = %d, %v", v, got, err)
+		}
+	}
+	// Fractional values must be rejected, not truncated: 1.9 would silently
+	// become 1 and 0.5 would become 0 and fail as "must be positive".
+	for _, v := range []float64{1.9, 0.5, 1024.5} {
+		if _, err := ResolveMaxBytes(v); err == nil {
+			t.Errorf("ResolveMaxBytes(%v) should reject a fractional value", v)
+		}
+	}
+	for _, v := range []any{float64(0), float64(-1), "big", true} {
+		if _, err := ResolveMaxBytes(v); err == nil {
+			t.Errorf("ResolveMaxBytes(%v) should error", v)
+		}
+	}
+	if _, err := ResolveMaxBytes(float64(MaxDownloadBytes + 1)); err == nil {
+		t.Error("above the ceiling should error")
+	}
+	if got, err := ResolveMaxBytes(float64(MaxDownloadBytes)); err != nil || got != MaxDownloadBytes {
+		t.Errorf("exactly the ceiling should be allowed, got %d, %v", got, err)
+	}
+}
+
+func TestReadBounded(t *testing.T) {
+	// Exactly at the limit is not overflow.
+	body, overflow, err := ReadBounded(strings.NewReader("12345"), 5)
+	if err != nil || overflow || string(body) != "12345" {
+		t.Errorf("at limit: body=%q overflow=%v err=%v", body, overflow, err)
+	}
+	// One byte over is.
+	body, overflow, err = ReadBounded(strings.NewReader("123456"), 5)
+	if err != nil || !overflow {
+		t.Errorf("over limit: overflow=%v err=%v", overflow, err)
+	}
+	if len(body) != 5 {
+		t.Errorf("body should be capped at the limit, got %d bytes", len(body))
+	}
+	// Under the limit.
+	body, overflow, err = ReadBounded(strings.NewReader("ab"), 5)
+	if err != nil || overflow || string(body) != "ab" {
+		t.Errorf("under limit: body=%q overflow=%v err=%v", body, overflow, err)
+	}
+}

--- a/internal/adapters/format/format_test.go
+++ b/internal/adapters/format/format_test.go
@@ -104,3 +104,28 @@ func TestReadBounded(t *testing.T) {
 		t.Errorf("under limit: body=%q overflow=%v err=%v", body, overflow, err)
 	}
 }
+
+func TestOverflowMessage(t *testing.T) {
+	// Below the ceiling: point at max_bytes, there is headroom.
+	if got := OverflowMessage(1024); !strings.Contains(got, "raise max_bytes") {
+		t.Errorf("below ceiling should suggest max_bytes, got %q", got)
+	}
+	// At the ceiling: suggesting max_bytes would name the value already in use.
+	got := OverflowMessage(MaxDownloadBytes)
+	if strings.Contains(got, "raise max_bytes") {
+		t.Errorf("at ceiling should not suggest an impossible raise, got %q", got)
+	}
+	if !strings.Contains(got, "maximum supported size") {
+		t.Errorf("at ceiling should name the hard limit, got %q", got)
+	}
+}
+
+func TestResolveMaxBytesRejectsOutOfRangeFloat(t *testing.T) {
+	// Converting an out-of-range float to int64 is implementation-defined, so
+	// the magnitude must be checked while still in float space.
+	for _, v := range []float64{1e19, -1e19, 1e30} {
+		if _, err := ResolveMaxBytes(v); err == nil {
+			t.Errorf("ResolveMaxBytes(%v) should be rejected", v)
+		}
+	}
+}

--- a/internal/adapters/google/calendar/adapter.go
+++ b/internal/adapters/google/calendar/adapter.go
@@ -14,9 +14,9 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 
-	"github.com/clawvisor/clawvisor/pkg/adapters"
 	"github.com/clawvisor/clawvisor/internal/adapters/format"
 	"github.com/clawvisor/clawvisor/internal/adapters/google/credential"
+	"github.com/clawvisor/clawvisor/pkg/adapters"
 )
 
 const serviceID = "google.calendar"
@@ -321,8 +321,8 @@ func (a *CalendarAdapter) createEvent(ctx context.Context, client *http.Client, 
 	apiURL := fmt.Sprintf("https://www.googleapis.com/calendar/v3/calendars/%s/events",
 		url.PathEscape(calendarID))
 	var created struct {
-		ID      string `json:"id"`
-		Summary string `json:"summary"`
+		ID       string `json:"id"`
+		Summary  string `json:"summary"`
 		HTMLLink string `json:"htmlLink"`
 	}
 	if err := apiWrite(ctx, client, http.MethodPost, apiURL, body, &created); err != nil {
@@ -515,7 +515,6 @@ func paramInt(params map[string]any, key string) (int, bool) {
 	}
 	return 0, false
 }
-
 
 // dateToRFC3339 reads a date/datetime param (primary key or alias) from params
 // and ensures it is in RFC3339 format. Plain ISO dates ("2006-01-02") are

--- a/internal/adapters/google/contacts/adapter.go
+++ b/internal/adapters/google/contacts/adapter.go
@@ -13,9 +13,9 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 
-	"github.com/clawvisor/clawvisor/pkg/adapters"
 	"github.com/clawvisor/clawvisor/internal/adapters/format"
 	"github.com/clawvisor/clawvisor/internal/adapters/google/credential"
+	"github.com/clawvisor/clawvisor/pkg/adapters"
 )
 
 const serviceID = "google.contacts"
@@ -378,4 +378,3 @@ func paramInt(params map[string]any, key string) (int, bool) {
 	}
 	return 0, false
 }
-

--- a/internal/adapters/google/drive/adapter.go
+++ b/internal/adapters/google/drive/adapter.go
@@ -290,9 +290,7 @@ func (a *DriveAdapter) downloadFile(ctx context.Context, client *http.Client, pa
 		return nil, fmt.Errorf("drive download_file: reading content after %d bytes: %w", len(body), readErr)
 	}
 	if overflow {
-		return nil, fmt.Errorf(
-			"drive download_file: %q exceeds the %d byte limit; raise max_bytes (up to %d)",
-			meta.Name, maxBytes, format.MaxDownloadBytes)
+		return nil, fmt.Errorf("drive download_file: %q %s", meta.Name, format.OverflowMessage(maxBytes))
 	}
 
 	result := map[string]any{
@@ -380,9 +378,7 @@ func (a *DriveAdapter) exportFile(ctx context.Context, client *http.Client, para
 		return nil, fmt.Errorf("drive export_file: reading content after %d bytes: %w", len(body), readErr)
 	}
 	if overflow {
-		return nil, fmt.Errorf(
-			"drive export_file: %q exported to %s exceeds the %d byte limit; raise max_bytes (up to %d)",
-			meta.Name, targetMime, exportMaxBytes, format.MaxDownloadBytes)
+		return nil, fmt.Errorf("drive export_file: %q exported to %s %s", meta.Name, targetMime, format.OverflowMessage(exportMaxBytes))
 	}
 
 	// Always base64. Export targets include PDF and the OOXML formats, which
@@ -464,7 +460,11 @@ func (a *DriveAdapter) exportSheetTab(ctx context.Context, client *http.Client, 
 		Range  string          `json:"range"`
 		Values [][]interface{} `json:"values"`
 	}
-	if err := apiGET(ctx, client, valuesURL, &valuesResp); err != nil {
+	// Bound the values response rather than only the serialized CSV: the JSON
+	// is materialized first, so an unbounded read would already have consumed
+	// the memory by the time a post-serialization check could reject it. The
+	// JSON envelope is larger than the CSV it produces, so allow headroom.
+	if err := apiGETLimited(ctx, client, valuesURL, &valuesResp, maxBytes*3+(1<<16)); err != nil {
 		return nil, fmt.Errorf("drive export_file: reading sheet values: %w", err)
 	}
 
@@ -491,9 +491,8 @@ func (a *DriveAdapter) exportSheetTab(ctx context.Context, client *http.Client, 
 	// The CSV is built in memory from the Sheets response, so bound it the
 	// same way a fetched export is bounded.
 	if int64(buf.Len()) > maxBytes {
-		return nil, fmt.Errorf(
-			"drive export_file: %q [%s] serializes to %d bytes, which exceeds the %d byte limit; raise max_bytes (up to %d)",
-			fileName, sheetName, buf.Len(), maxBytes, format.MaxDownloadBytes)
+		return nil, fmt.Errorf("drive export_file: %q [%s] serializes to %d bytes, which %s",
+			fileName, sheetName, buf.Len(), format.OverflowMessage(maxBytes))
 	}
 
 	result := map[string]any{
@@ -649,6 +648,32 @@ func apiGET(ctx context.Context, client *http.Client, apiURL string, out any) er
 	body, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode >= 400 {
 		return fmt.Errorf("status %d: %s", resp.StatusCode, format.Truncate(string(body), 200))
+	}
+	return json.Unmarshal(body, out)
+}
+
+// apiGETLimited is apiGET with a bound on the response body, for endpoints
+// whose size scales with user content rather than being a fixed envelope.
+func apiGETLimited(ctx context.Context, client *http.Client, apiURL string, out any, limit int64) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	body, overflow, readErr := format.ReadBounded(resp.Body, limit)
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("status %d: %s", resp.StatusCode, format.Truncate(string(body), 200))
+	}
+	if readErr != nil {
+		return fmt.Errorf("reading response after %d bytes: %w", len(body), readErr)
+	}
+	if overflow {
+		return fmt.Errorf("response exceeds %d bytes; raise max_bytes or export a smaller range", limit)
 	}
 	return json.Unmarshal(body, out)
 }

--- a/internal/adapters/google/drive/adapter.go
+++ b/internal/adapters/google/drive/adapter.go
@@ -251,6 +251,11 @@ func (a *DriveAdapter) downloadFile(ctx context.Context, client *http.Client, pa
 		return nil, fmt.Errorf("drive download_file: file_id is required")
 	}
 
+	maxBytes, err := format.ResolveMaxBytes(params["max_bytes"])
+	if err != nil {
+		return nil, fmt.Errorf("drive download_file: %w", err)
+	}
+
 	// Fetch metadata.
 	metaURL := fmt.Sprintf("https://www.googleapis.com/drive/v3/files/%s?fields=id,name,mimeType,size",
 		url.PathEscape(fileID))
@@ -277,9 +282,17 @@ func (a *DriveAdapter) downloadFile(ctx context.Context, client *http.Client, pa
 	}
 	defer resp.Body.Close()
 
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, int64(format.MaxBodyLen)))
+	body, overflow, readErr := format.ReadBounded(resp.Body, maxBytes)
 	if resp.StatusCode >= 400 {
 		return nil, fmt.Errorf("drive download_file: status %d: %s", resp.StatusCode, format.Truncate(string(body), 200))
+	}
+	if readErr != nil {
+		return nil, fmt.Errorf("drive download_file: reading content after %d bytes: %w", len(body), readErr)
+	}
+	if overflow {
+		return nil, fmt.Errorf(
+			"drive download_file: %q exceeds the %d byte limit; raise max_bytes (up to %d)",
+			meta.Name, maxBytes, format.MaxDownloadBytes)
 	}
 
 	result := map[string]any{
@@ -313,6 +326,10 @@ func (a *DriveAdapter) exportFile(ctx context.Context, client *http.Client, para
 	if fileID == "" {
 		return nil, fmt.Errorf("drive export_file: file_id is required")
 	}
+	exportMaxBytes, err := format.ResolveMaxBytes(params["max_bytes"])
+	if err != nil {
+		return nil, fmt.Errorf("drive export_file: %w", err)
+	}
 	if targetMime == "" {
 		return nil, fmt.Errorf("drive export_file: mime_type is required")
 	}
@@ -340,7 +357,7 @@ func (a *DriveAdapter) exportFile(ctx context.Context, client *http.Client, para
 	}
 
 	if isSheet && wantsTabular && sheetName != "" {
-		return a.exportSheetTab(ctx, client, meta.ID, meta.Name, sheetName, targetMime)
+		return a.exportSheetTab(ctx, client, meta.ID, meta.Name, sheetName, targetMime, exportMaxBytes)
 	}
 
 	exportURL := fmt.Sprintf("https://www.googleapis.com/drive/v3/files/%s/export?mimeType=%s",
@@ -355,9 +372,17 @@ func (a *DriveAdapter) exportFile(ctx context.Context, client *http.Client, para
 	}
 	defer resp.Body.Close()
 
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, int64(format.MaxBodyLen)))
+	body, overflow, readErr := format.ReadBounded(resp.Body, exportMaxBytes)
 	if resp.StatusCode >= 400 {
 		return nil, fmt.Errorf("drive export_file: status %d: %s", resp.StatusCode, format.Truncate(string(body), 200))
+	}
+	if readErr != nil {
+		return nil, fmt.Errorf("drive export_file: reading content after %d bytes: %w", len(body), readErr)
+	}
+	if overflow {
+		return nil, fmt.Errorf(
+			"drive export_file: %q exported to %s exceeds the %d byte limit; raise max_bytes (up to %d)",
+			meta.Name, targetMime, exportMaxBytes, format.MaxDownloadBytes)
 	}
 
 	// Always base64. Export targets include PDF and the OOXML formats, which
@@ -411,7 +436,7 @@ func (a *DriveAdapter) listSheetTitles(ctx context.Context, client *http.Client,
 // exportSheetTab reads a single sheet (tab) from a Google Sheets file via the
 // Sheets API and serializes the values as CSV or TSV. The drive.readonly scope
 // is sufficient to call spreadsheets.values.get.
-func (a *DriveAdapter) exportSheetTab(ctx context.Context, client *http.Client, fileID, fileName, sheetName, targetMime string) (*adapters.Result, error) {
+func (a *DriveAdapter) exportSheetTab(ctx context.Context, client *http.Client, fileID, fileName, sheetName, targetMime string, maxBytes int64) (*adapters.Result, error) {
 	// Validate that the named tab exists; surface available titles otherwise.
 	titles, err := a.listSheetTitles(ctx, client, fileID)
 	if err != nil {
@@ -462,6 +487,13 @@ func (a *DriveAdapter) exportSheetTab(ctx context.Context, client *http.Client, 
 	w.Flush()
 	if err := w.Error(); err != nil {
 		return nil, fmt.Errorf("drive export_file: serializing CSV: %w", err)
+	}
+	// The CSV is built in memory from the Sheets response, so bound it the
+	// same way a fetched export is bounded.
+	if int64(buf.Len()) > maxBytes {
+		return nil, fmt.Errorf(
+			"drive export_file: %q [%s] serializes to %d bytes, which exceeds the %d byte limit; raise max_bytes (up to %d)",
+			fileName, sheetName, buf.Len(), maxBytes, format.MaxDownloadBytes)
 	}
 
 	result := map[string]any{

--- a/internal/adapters/google/drive/adapter.go
+++ b/internal/adapters/google/drive/adapter.go
@@ -360,12 +360,16 @@ func (a *DriveAdapter) exportFile(ctx context.Context, client *http.Client, para
 		return nil, fmt.Errorf("drive export_file: status %d: %s", resp.StatusCode, format.Truncate(string(body), 200))
 	}
 
+	// Always base64. Export targets include PDF and the OOXML formats, which
+	// format.SanitizeText would destroy outright, and even for text targets it
+	// strips HTML and truncates at MaxBodyLen runes.
 	result := map[string]any{
 		"id":               meta.ID,
 		"name":             format.SanitizeText(meta.Name, format.MaxFieldLen),
 		"source_mime_type": meta.MimeType,
 		"export_mime_type": targetMime,
-		"content":          format.SanitizeText(string(body), format.MaxBodyLen),
+		"encoding":         "base64",
+		"content":          base64.StdEncoding.EncodeToString(body),
 	}
 	res := &adapters.Result{
 		Summary: format.Summary("Exported %s as %s", meta.Name, targetMime),
@@ -466,7 +470,11 @@ func (a *DriveAdapter) exportSheetTab(ctx context.Context, client *http.Client, 
 		"source_mime_type": sheetsMimeType,
 		"export_mime_type": targetMime,
 		"sheet_name":       sheetName,
-		"content":          format.SanitizeText(buf.String(), format.MaxBodyLen),
+		// Base64 for parity with the other export path, and because
+		// SanitizeText would strip markup out of cell values and truncate the
+		// sheet at MaxBodyLen runes.
+		"encoding": "base64",
+		"content":  base64.StdEncoding.EncodeToString(buf.Bytes()),
 	}
 	return &adapters.Result{
 		Summary: format.Summary("Exported %s [%s] as %s (%d row(s))", fileName, sheetName, targetMime, len(valuesResp.Values)),

--- a/internal/adapters/google/drive/adapter_test.go
+++ b/internal/adapters/google/drive/adapter_test.go
@@ -1,6 +1,8 @@
 package drive
 
 import (
+	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"net/http"
@@ -265,5 +267,47 @@ func TestExportFile_UnknownSheetName(t *testing.T) {
 	}
 	if err != nil && !strings.Contains(err.Error(), "Routing Map") {
 		t.Errorf("expected error to list available tabs (got %v)", err)
+	}
+}
+
+// Regression for the truncation bug: downloads were capped at MaxBodyLen and
+// the prefix was returned as a successful, byte-exact result.
+func TestDownloadFile_RefusesOversizedInsteadOfTruncating(t *testing.T) {
+	big := bytes.Repeat([]byte("A"), 300_000) // over the old 200,000 cap
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("alt") == "media" {
+			_, _ = w.Write(big)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": "f1", "name": "big.bin", "mimeType": "application/octet-stream", "size": "300000",
+		})
+	}))
+	defer srv.Close()
+
+	adapter := New(staticOAuthProvider{})
+
+	// Default limit is 1 MB, so 300 KB now succeeds intact — previously it
+	// came back truncated to 200,000 bytes.
+	res, err := adapter.downloadFile(context.Background(), newTestClient(srv), map[string]any{"file_id": "f1"})
+	if err != nil {
+		t.Fatalf("300 KB should fit the default limit: %v", err)
+	}
+	got, err := base64.StdEncoding.DecodeString(res.Data.(map[string]any)["content"].(string))
+	if err != nil {
+		t.Fatalf("undecodable base64: %v", err)
+	}
+	if !bytes.Equal(got, big) {
+		t.Errorf("content truncated: got %d bytes, want %d", len(got), len(big))
+	}
+
+	// Over the requested limit must be an error, not a truncated success.
+	_, err = adapter.downloadFile(context.Background(), newTestClient(srv),
+		map[string]any{"file_id": "f1", "max_bytes": float64(1024)})
+	if err == nil {
+		t.Fatal("expected an error for a file over max_bytes")
+	}
+	if !strings.Contains(err.Error(), "max_bytes") {
+		t.Errorf("error should point at max_bytes, got: %v", err)
 	}
 }

--- a/internal/adapters/google/drive/adapter_test.go
+++ b/internal/adapters/google/drive/adapter_test.go
@@ -1,6 +1,7 @@
 package drive
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -70,7 +71,15 @@ func TestExportFile_SheetTabByName(t *testing.T) {
 	if data["sheet_name"] != "Routing Map" {
 		t.Errorf("sheet_name = %v, want Routing Map", data["sheet_name"])
 	}
-	content, _ := data["content"].(string)
+	// Exported content is base64 so it round-trips byte for byte.
+	if data["encoding"] != "base64" {
+		t.Fatalf("encoding = %v, want base64", data["encoding"])
+	}
+	raw, err := base64.StdEncoding.DecodeString(data["content"].(string))
+	if err != nil {
+		t.Fatalf("content is not decodable base64: %v", err)
+	}
+	content := string(raw)
 	if !strings.Contains(content, "GP,Sector") || !strings.Contains(content, "Alice,Fintech") {
 		t.Errorf("content missing expected rows:\n%s", content)
 	}

--- a/internal/adapters/google/gmail/adapter.go
+++ b/internal/adapters/google/gmail/adapter.go
@@ -295,7 +295,7 @@ func (a *GmailAdapter) getMessageRaw(ctx context.Context, client *http.Client, p
 		return nil, fmt.Errorf("gmail get_message_raw: message_id is required")
 	}
 
-	maxBytes, err := resolveMaxBytes(params["max_bytes"])
+	maxBytes, err := format.ResolveMaxBytes(params["max_bytes"])
 	if err != nil {
 		return nil, fmt.Errorf("gmail get_message_raw: %w", err)
 	}
@@ -312,6 +312,14 @@ func (a *GmailAdapter) getMessageRaw(ctx context.Context, client *http.Client, p
 	// far larger than the parsed projection. base64 inflates by 4/3, and the
 	// JSON envelope adds a little more.
 	if err := gmailGETLimited(ctx, client, endpoint, &msg, maxBytes*4/3+(1<<16)); err != nil {
+		// A message far over the limit trips the envelope bound before the
+		// decoded-size check below, so add the same guidance here rather than
+		// leaving the caller with a bare "response exceeds N bytes".
+		if strings.Contains(err.Error(), "response exceeds") {
+			return nil, fmt.Errorf(
+				"gmail get_message_raw: message exceeds the %d byte limit; raise max_bytes (up to %d)",
+				maxBytes, format.MaxDownloadBytes)
+		}
 		return nil, fmt.Errorf("gmail get_message_raw: %w", err)
 	}
 	if msg.Raw == "" {
@@ -342,33 +350,6 @@ func (a *GmailAdapter) getMessageRaw(ctx context.Context, client *http.Client, p
 			"content":   base64.StdEncoding.EncodeToString(decoded),
 		},
 	}, nil
-}
-
-// resolveMaxBytes mirrors the Slack adapter's contract: a modest default that
-// survives being read into a model context, raisable to format.MaxDownloadBytes
-// by callers that save the response to a file.
-func resolveMaxBytes(v any) (int64, error) {
-	if v == nil {
-		return format.DefaultDownloadBytes, nil
-	}
-	var n int64
-	switch x := v.(type) {
-	case float64: // JSON numbers decode as float64
-		n = int64(x)
-	case int:
-		n = int64(x)
-	case int64:
-		n = x
-	default:
-		return 0, fmt.Errorf("max_bytes must be a number")
-	}
-	if n <= 0 {
-		return 0, fmt.Errorf("max_bytes must be positive")
-	}
-	if n > format.MaxDownloadBytes {
-		return 0, fmt.Errorf("max_bytes may not exceed %d", format.MaxDownloadBytes)
-	}
-	return n, nil
 }
 
 // ── get_thread ────────────────────────────────────────────────────────────────

--- a/internal/adapters/google/gmail/adapter.go
+++ b/internal/adapters/google/gmail/adapter.go
@@ -55,7 +55,7 @@ func (a *GmailAdapter) ServiceID() string { return serviceID }
 
 func (a *GmailAdapter) SupportedActions() []string {
 	return []string{
-		"list_messages", "get_message", "get_thread", "get_attachment",
+		"list_messages", "get_message", "get_message_raw", "get_thread", "get_attachment",
 		"send_message", "create_draft", "archive_message",
 	}
 }
@@ -104,6 +104,8 @@ func (a *GmailAdapter) Execute(ctx context.Context, req adapters.Request) (*adap
 		return a.listMessages(ctx, client, req.Params)
 	case "get_message":
 		return a.getMessage(ctx, client, req.Params)
+	case "get_message_raw":
+		return a.getMessageRaw(ctx, client, req.Params)
 	case "get_thread":
 		return a.getThread(ctx, client, req.Params)
 	case "get_attachment":
@@ -274,6 +276,99 @@ func (a *GmailAdapter) getMessage(ctx context.Context, client *http.Client, para
 		summary = format.Summary("Email from %s: %q (%d attachments)", detail.From, detail.Subject, len(detail.Attachments))
 	}
 	return &adapters.Result{Summary: summary, Data: detail}, nil
+}
+
+// ── get_message_raw ───────────────────────────────────────────────────────────
+
+// getMessageRaw returns the original RFC 5322 message exactly as Gmail stores
+// it, base64-encoded.
+//
+// This is an alternative to get_message, not a replacement: get_message parses
+// the MIME tree and returns a readable projection (from/subject/body/labels),
+// which is what most callers want and is far cheaper. get_message_raw exists
+// for the cases that projection cannot serve — verifying DKIM or other headers,
+// re-sending or archiving the message verbatim, or parsing MIME parts the
+// projection drops.
+func (a *GmailAdapter) getMessageRaw(ctx context.Context, client *http.Client, params map[string]any) (*adapters.Result, error) {
+	msgID, _ := params["message_id"].(string)
+	if msgID == "" {
+		return nil, fmt.Errorf("gmail get_message_raw: message_id is required")
+	}
+
+	maxBytes, err := resolveMaxBytes(params["max_bytes"])
+	if err != nil {
+		return nil, fmt.Errorf("gmail get_message_raw: %w", err)
+	}
+
+	endpoint := fmt.Sprintf("https://gmail.googleapis.com/gmail/v1/users/me/messages/%s?format=raw",
+		url.PathEscape(msgID))
+	var msg struct {
+		ID           string `json:"id"`
+		ThreadID     string `json:"threadId"`
+		SizeEstimate int64  `json:"sizeEstimate"`
+		Raw          string `json:"raw"`
+	}
+	// Bounded read: a raw message carries its attachments inline, so it can be
+	// far larger than the parsed projection. base64 inflates by 4/3, and the
+	// JSON envelope adds a little more.
+	if err := gmailGETLimited(ctx, client, endpoint, &msg, maxBytes*4/3+(1<<16)); err != nil {
+		return nil, fmt.Errorf("gmail get_message_raw: %w", err)
+	}
+	if msg.Raw == "" {
+		return nil, fmt.Errorf("gmail get_message_raw: message %q returned no raw content", msgID)
+	}
+
+	// Gmail encodes raw as URL-safe base64. Re-encode as standard base64 so
+	// the result matches the `encoding: base64` contract used by every other
+	// content-returning action.
+	decoded, err := decodeBase64Bytes(msg.Raw)
+	if err != nil {
+		return nil, fmt.Errorf("gmail get_message_raw: decoding raw message: %w", err)
+	}
+	if int64(len(decoded)) > maxBytes {
+		return nil, fmt.Errorf(
+			"gmail get_message_raw: message is %d bytes, which exceeds the %d byte limit; raise max_bytes (up to %d)",
+			len(decoded), maxBytes, format.MaxDownloadBytes)
+	}
+
+	return &adapters.Result{
+		Summary: format.Summary("Raw message %s (%d bytes)", msg.ID, len(decoded)),
+		Data: map[string]any{
+			"id":        msg.ID,
+			"thread_id": msg.ThreadID,
+			"mime_type": "message/rfc822",
+			"size":      len(decoded),
+			"encoding":  "base64",
+			"content":   base64.StdEncoding.EncodeToString(decoded),
+		},
+	}, nil
+}
+
+// resolveMaxBytes mirrors the Slack adapter's contract: a modest default that
+// survives being read into a model context, raisable to format.MaxDownloadBytes
+// by callers that save the response to a file.
+func resolveMaxBytes(v any) (int64, error) {
+	if v == nil {
+		return format.DefaultDownloadBytes, nil
+	}
+	var n int64
+	switch x := v.(type) {
+	case float64: // JSON numbers decode as float64
+		n = int64(x)
+	case int:
+		n = int64(x)
+	case int64:
+		n = x
+	default:
+		return 0, fmt.Errorf("max_bytes must be a number")
+	}
+	if n <= 0 {
+		return 0, fmt.Errorf("max_bytes must be positive")
+	}
+	if n > format.MaxDownloadBytes {
+		return 0, fmt.Errorf("max_bytes may not exceed %d", format.MaxDownloadBytes)
+	}
+	return n, nil
 }
 
 // ── get_thread ────────────────────────────────────────────────────────────────
@@ -714,6 +809,32 @@ func gmailGET(ctx context.Context, client *http.Client, url string, out any) err
 	body, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode >= 400 {
 		return fmt.Errorf("gmail API %s: %d: %s", url, resp.StatusCode, format.Truncate(string(body), 200))
+	}
+	return json.Unmarshal(body, out)
+}
+
+// gmailGETLimited is gmailGET with a bound on the response body, for endpoints
+// whose size scales with user content rather than being a fixed envelope.
+func gmailGETLimited(ctx context.Context, client *http.Client, url string, out any, limit int64) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, limit+1))
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("gmail API %s: %d: %s", url, resp.StatusCode, format.Truncate(string(body), 200))
+	}
+	if readErr != nil {
+		return fmt.Errorf("gmail API %s: reading response after %d bytes: %w", url, len(body), readErr)
+	}
+	if int64(len(body)) > limit {
+		return fmt.Errorf("gmail API %s: response exceeds %d bytes", url, limit)
 	}
 	return json.Unmarshal(body, out)
 }
@@ -1268,6 +1389,21 @@ func stripHTML(s string) string {
 		}
 	}
 	return strings.Join(kept, "\n")
+}
+
+// decodeBase64Bytes decodes Gmail's base64 (URL-safe, padding optional) and
+// reports failure. decodeBase64 swallows errors and returns "", which is fine
+// for a display projection but not for content that must round-trip.
+func decodeBase64Bytes(s string) ([]byte, error) {
+	for _, enc := range []*base64.Encoding{
+		base64.RawURLEncoding, base64.URLEncoding,
+		base64.RawStdEncoding, base64.StdEncoding,
+	} {
+		if b, err := enc.DecodeString(s); err == nil {
+			return b, nil
+		}
+	}
+	return nil, fmt.Errorf("not valid base64")
 }
 
 func decodeBase64(s string) string {

--- a/internal/adapters/google/gmail/adapter.go
+++ b/internal/adapters/google/gmail/adapter.go
@@ -316,9 +316,7 @@ func (a *GmailAdapter) getMessageRaw(ctx context.Context, client *http.Client, p
 		// decoded-size check below, so add the same guidance here rather than
 		// leaving the caller with a bare "response exceeds N bytes".
 		if strings.Contains(err.Error(), "response exceeds") {
-			return nil, fmt.Errorf(
-				"gmail get_message_raw: message exceeds the %d byte limit; raise max_bytes (up to %d)",
-				maxBytes, format.MaxDownloadBytes)
+			return nil, fmt.Errorf("gmail get_message_raw: message %s", format.OverflowMessage(maxBytes))
 		}
 		return nil, fmt.Errorf("gmail get_message_raw: %w", err)
 	}
@@ -334,9 +332,8 @@ func (a *GmailAdapter) getMessageRaw(ctx context.Context, client *http.Client, p
 		return nil, fmt.Errorf("gmail get_message_raw: decoding raw message: %w", err)
 	}
 	if int64(len(decoded)) > maxBytes {
-		return nil, fmt.Errorf(
-			"gmail get_message_raw: message is %d bytes, which exceeds the %d byte limit; raise max_bytes (up to %d)",
-			len(decoded), maxBytes, format.MaxDownloadBytes)
+		return nil, fmt.Errorf("gmail get_message_raw: message is %d bytes, which %s",
+			len(decoded), format.OverflowMessage(maxBytes))
 	}
 
 	return &adapters.Result{

--- a/internal/adapters/google/gmail/adapter_test.go
+++ b/internal/adapters/google/gmail/adapter_test.go
@@ -19,7 +19,6 @@ import (
 
 	"golang.org/x/oauth2"
 
-	"github.com/clawvisor/clawvisor/internal/adapters/format"
 	"github.com/clawvisor/clawvisor/internal/adapters/google/credential"
 	"github.com/clawvisor/clawvisor/pkg/adapters"
 )
@@ -1188,17 +1187,5 @@ func TestGetMessageRaw_ErrorsOnEmptyRaw(t *testing.T) {
 		rawMessageClient(t, ""), map[string]any{"message_id": "msg-raw-1"})
 	if err == nil || !strings.Contains(err.Error(), "no raw content") {
 		t.Fatalf("got: %v", err)
-	}
-}
-
-func TestResolveMaxBytesGmail(t *testing.T) {
-	if got, err := resolveMaxBytes(nil); err != nil || got != format.DefaultDownloadBytes {
-		t.Errorf("default = %d, %v", got, err)
-	}
-	if _, err := resolveMaxBytes(float64(format.MaxDownloadBytes + 1)); err == nil {
-		t.Error("expected an error above the ceiling")
-	}
-	if _, err := resolveMaxBytes(float64(0)); err == nil {
-		t.Error("expected an error for zero")
 	}
 }

--- a/internal/adapters/google/gmail/adapter_test.go
+++ b/internal/adapters/google/gmail/adapter_test.go
@@ -19,6 +19,7 @@ import (
 
 	"golang.org/x/oauth2"
 
+	"github.com/clawvisor/clawvisor/internal/adapters/format"
 	"github.com/clawvisor/clawvisor/internal/adapters/google/credential"
 	"github.com/clawvisor/clawvisor/pkg/adapters"
 )
@@ -1076,4 +1077,128 @@ func TestListMessages_BatchContextCancel(t *testing.T) {
 	}
 }
 
+// ── get_message_raw ───────────────────────────────────────────────────────────
 
+func rawMessageClient(t *testing.T, gmailRaw string) *http.Client {
+	t.Helper()
+	return &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if !strings.Contains(req.URL.Path, "/messages/msg-raw-1") {
+				t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+			}
+			if got := req.URL.Query().Get("format"); got != "raw" {
+				t.Fatalf("format = %q, want raw", got)
+			}
+			body := fmt.Sprintf(`{"id":"msg-raw-1","threadId":"thread-9","sizeEstimate":42,"raw":%q}`, gmailRaw)
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		}),
+	}
+}
+
+// The raw endpoint must return the original bytes, not a projection of them.
+func TestGetMessageRaw_ReturnsByteExactRFC5322(t *testing.T) {
+	// Headers the parsed projection drops, plus a non-UTF-8 byte in the body
+	// that a JSON string would replace with U+FFFD.
+	original := append([]byte(
+		"DKIM-Signature: v=1; a=rsa-sha256; d=example.com;\r\n"+
+			"From: alice@example.com\r\n"+
+			"Subject: <b>hi</b>\r\n"+
+			"\r\n"+
+			"body "), 0xff, 0xfe)
+
+	adapter := New(nil)
+	res, err := adapter.getMessageRaw(context.Background(),
+		rawMessageClient(t, base64.URLEncoding.EncodeToString(original)),
+		map[string]any{"message_id": "msg-raw-1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data := res.Data.(map[string]any)
+	if data["encoding"] != "base64" {
+		t.Fatalf("encoding = %v, want base64", data["encoding"])
+	}
+	if data["mime_type"] != "message/rfc822" {
+		t.Errorf("mime_type = %v", data["mime_type"])
+	}
+	got, err := base64.StdEncoding.DecodeString(data["content"].(string))
+	if err != nil {
+		t.Fatalf("content is not decodable standard base64: %v", err)
+	}
+	if !bytes.Equal(got, original) {
+		t.Errorf("raw message was altered:\n got %q\nwant %q", got, original)
+	}
+	// The DKIM header and the markup must survive — these are exactly what
+	// get_message's projection discards or strips.
+	if !bytes.Contains(got, []byte("DKIM-Signature")) || !bytes.Contains(got, []byte("<b>hi</b>")) {
+		t.Errorf("expected headers/markup preserved, got %q", got)
+	}
+}
+
+// Gmail emits URL-safe base64; the result must be standard base64 so it
+// matches the encoding contract every other content action uses.
+func TestGetMessageRaw_AcceptsURLSafeAndUnpaddedInput(t *testing.T) {
+	original := []byte{0xfb, 0xff, 0xfe, '?', '>', '<'} // encodes with - and _
+	for name, encoded := range map[string]string{
+		"padded-urlsafe":   base64.URLEncoding.EncodeToString(original),
+		"unpadded-urlsafe": base64.RawURLEncoding.EncodeToString(original),
+	} {
+		t.Run(name, func(t *testing.T) {
+			res, err := New(nil).getMessageRaw(context.Background(),
+				rawMessageClient(t, encoded), map[string]any{"message_id": "msg-raw-1"})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			got, err := base64.StdEncoding.DecodeString(res.Data.(map[string]any)["content"].(string))
+			if err != nil {
+				t.Fatalf("not standard base64: %v", err)
+			}
+			if !bytes.Equal(got, original) {
+				t.Errorf("got %v want %v", got, original)
+			}
+		})
+	}
+}
+
+func TestGetMessageRaw_RefusesOversizedMessage(t *testing.T) {
+	original := bytes.Repeat([]byte("x"), 4096)
+	_, err := New(nil).getMessageRaw(context.Background(),
+		rawMessageClient(t, base64.URLEncoding.EncodeToString(original)),
+		map[string]any{"message_id": "msg-raw-1", "max_bytes": float64(1024)})
+	if err == nil {
+		t.Fatal("expected an error for a message over max_bytes")
+	}
+	if !strings.Contains(err.Error(), "max_bytes") {
+		t.Errorf("error should point at max_bytes, got: %v", err)
+	}
+}
+
+func TestGetMessageRaw_RequiresMessageID(t *testing.T) {
+	if _, err := New(nil).getMessageRaw(context.Background(), &http.Client{}, map[string]any{}); err == nil {
+		t.Fatal("expected an error when message_id is missing")
+	}
+}
+
+func TestGetMessageRaw_ErrorsOnEmptyRaw(t *testing.T) {
+	_, err := New(nil).getMessageRaw(context.Background(),
+		rawMessageClient(t, ""), map[string]any{"message_id": "msg-raw-1"})
+	if err == nil || !strings.Contains(err.Error(), "no raw content") {
+		t.Fatalf("got: %v", err)
+	}
+}
+
+func TestResolveMaxBytesGmail(t *testing.T) {
+	if got, err := resolveMaxBytes(nil); err != nil || got != format.DefaultDownloadBytes {
+		t.Errorf("default = %d, %v", got, err)
+	}
+	if _, err := resolveMaxBytes(float64(format.MaxDownloadBytes + 1)); err == nil {
+		t.Error("expected an error above the ceiling")
+	}
+	if _, err := resolveMaxBytes(float64(0)); err == nil {
+		t.Error("expected an error for zero")
+	}
+}

--- a/internal/adapters/microsoft/credential.go
+++ b/internal/adapters/microsoft/credential.go
@@ -129,8 +129,8 @@ func FetchMicrosoftEmail(ctx context.Context, client *http.Client) (string, erro
 	}
 
 	var info struct {
-		Mail               string `json:"mail"`
-		UserPrincipalName  string `json:"userPrincipalName"`
+		Mail              string `json:"mail"`
+		UserPrincipalName string `json:"userPrincipalName"`
 	}
 	if err := json.Unmarshal(body, &info); err != nil {
 		return "", fmt.Errorf("microsoft userinfo: parse: %w", err)

--- a/internal/adapters/microsoft/onedrive/adapter.go
+++ b/internal/adapters/microsoft/onedrive/adapter.go
@@ -144,7 +144,6 @@ func (a *Adapter) downloadFile(ctx context.Context, client *http.Client, params 
 		return a.downloadViaContent(ctx, client, contentEndpoint, itemID, fileName, int64(fileSize))
 	}
 
-
 	// Use a plain HTTP client for the pre-signed URL download.
 	// The download URL is pre-authenticated; sending an OAuth Bearer token
 	// to the SharePoint download host causes a 401.
@@ -205,26 +204,25 @@ func (a *Adapter) downloadViaContent(ctx context.Context, oauthClient *http.Clie
 	return a.buildDownloadResult(itemID, fileName, fileSize, body), nil
 }
 
-// buildDownloadResult constructs the download response with appropriate
-// content encoding (text or base64).
+// buildDownloadResult constructs the download response. Content is always
+// base64-encoded, for every type.
 func (a *Adapter) buildDownloadResult(itemID, fileName string, fileSize int64, body []byte) *adapters.Result {
 	contentType := mime.TypeByExtension(filepath.Ext(fileName))
 	if contentType == "" {
 		contentType = "application/octet-stream"
 	}
 
+	// A download must round-trip the file byte for byte, which the text path
+	// could not: format.SanitizeText strips HTML and truncates at MaxBodyLen
+	// runes, and even unsanitized, bytes placed in a JSON string lose anything
+	// that is not valid UTF-8 to U+FFFD.
 	result := map[string]any{
 		"name":         format.SanitizeText(fileName, format.MaxFieldLen),
 		"id":           itemID,
 		"size":         fileSize,
 		"content_type": contentType,
-	}
-
-	if isTextContent(contentType) {
-		result["content"] = format.SanitizeText(string(body), format.MaxBodyLen)
-	} else {
-		result["encoding"] = "base64"
-		result["content"] = base64.StdEncoding.EncodeToString(body)
+		"encoding":     "base64",
+		"content":      base64.StdEncoding.EncodeToString(body),
 	}
 
 	return &adapters.Result{

--- a/internal/adapters/microsoft/onedrive/adapter.go
+++ b/internal/adapters/microsoft/onedrive/adapter.go
@@ -173,9 +173,7 @@ func (a *Adapter) downloadFile(ctx context.Context, client *http.Client, params 
 		return nil, fmt.Errorf("onedrive download_file: reading content after %d bytes: %w", len(body), readErr)
 	}
 	if overflow {
-		return nil, fmt.Errorf(
-			"onedrive download_file: %q exceeds the %d byte limit; raise max_bytes (up to %d)",
-			fileName, maxBytes, format.MaxDownloadBytes)
+		return nil, fmt.Errorf("onedrive download_file: %q %s", fileName, format.OverflowMessage(maxBytes))
 	}
 
 	return a.buildDownloadResult(itemID, fileName, int64(fileSize), body), nil

--- a/internal/adapters/microsoft/onedrive/adapter.go
+++ b/internal/adapters/microsoft/onedrive/adapter.go
@@ -109,6 +109,11 @@ func (a *Adapter) downloadFile(ctx context.Context, client *http.Client, params 
 		return nil, fmt.Errorf("onedrive download_file: item_id is required")
 	}
 
+	maxBytes, err := format.ResolveMaxBytes(params["max_bytes"])
+	if err != nil {
+		return nil, fmt.Errorf("onedrive download_file: %w", err)
+	}
+
 	// Determine the correct endpoint. If itemID looks like a path (e.g., starts with "root:"),
 	// use the root path syntax. Otherwise, assume it's a DriveItem ID.
 	var metaEndpoint string
@@ -141,7 +146,7 @@ func (a *Adapter) downloadFile(ctx context.Context, client *http.Client, params 
 	if downloadURL == "" {
 		// Fallback: use the /content endpoint
 		contentEndpoint := metaEndpoint + "/content"
-		return a.downloadViaContent(ctx, client, contentEndpoint, itemID, fileName, int64(fileSize))
+		return a.downloadViaContent(ctx, client, contentEndpoint, itemID, fileName, int64(fileSize), maxBytes)
 	}
 
 	// Use a plain HTTP client for the pre-signed URL download.
@@ -163,14 +168,22 @@ func (a *Adapter) downloadFile(ctx context.Context, client *http.Client, params 
 		return nil, fmt.Errorf("onedrive download_file: download status %d", resp.StatusCode)
 	}
 
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, int64(format.MaxBodyLen)))
+	body, overflow, readErr := format.ReadBounded(resp.Body, maxBytes)
+	if readErr != nil {
+		return nil, fmt.Errorf("onedrive download_file: reading content after %d bytes: %w", len(body), readErr)
+	}
+	if overflow {
+		return nil, fmt.Errorf(
+			"onedrive download_file: %q exceeds the %d byte limit; raise max_bytes (up to %d)",
+			fileName, maxBytes, format.MaxDownloadBytes)
+	}
 
 	return a.buildDownloadResult(itemID, fileName, int64(fileSize), body), nil
 }
 
 // downloadViaContent handles the /content redirect flow by stripping the
 // Authorization header on cross-host redirects.
-func (a *Adapter) downloadViaContent(ctx context.Context, oauthClient *http.Client, endpoint, itemID, fileName string, fileSize int64) (*adapters.Result, error) {
+func (a *Adapter) downloadViaContent(ctx context.Context, oauthClient *http.Client, endpoint, itemID, fileName string, fileSize, maxBytes int64) (*adapters.Result, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return nil, err
@@ -199,7 +212,15 @@ func (a *Adapter) downloadViaContent(ctx context.Context, oauthClient *http.Clie
 		return nil, fmt.Errorf("onedrive download_file: download status %d", resp.StatusCode)
 	}
 
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, int64(format.MaxBodyLen)))
+	body, overflow, readErr := format.ReadBounded(resp.Body, maxBytes)
+	if readErr != nil {
+		return nil, fmt.Errorf("onedrive download_file: reading content after %d bytes: %w", len(body), readErr)
+	}
+	if overflow {
+		return nil, fmt.Errorf(
+			"onedrive download_file: %q exceeds the %d byte limit; raise max_bytes (up to %d)",
+			fileName, maxBytes, format.MaxDownloadBytes)
+	}
 
 	return a.buildDownloadResult(itemID, fileName, fileSize, body), nil
 }
@@ -287,12 +308,6 @@ func (a *Adapter) uploadFile(ctx context.Context, client *http.Client, params ma
 			"size": uploaded.Size,
 		},
 	}, nil
-}
-
-func isTextContent(contentType string) bool {
-	return strings.HasPrefix(contentType, "text/") ||
-		contentType == "application/json" ||
-		contentType == "application/xml"
 }
 
 func escapePath(p string) string {

--- a/internal/adapters/microsoft/outlook/adapter.go
+++ b/internal/adapters/microsoft/outlook/adapter.go
@@ -70,17 +70,16 @@ func (a *Adapter) listEvents(ctx context.Context, client *http.Client, params ma
 		subject, _ := item["subject"].(string)
 
 		events = append(events, map[string]any{
-			"id":          item["id"],
-			"subject":     format.SanitizeText(subject, format.MaxFieldLen),
-			"start":       start["dateTime"],
-			"end":         end["dateTime"],
-			"timezone":    start["timeZone"],
-			"location":    loc["displayName"],
-			"is_all_day":  item["isAllDay"],
-			"web_link":    item["webLink"],
+			"id":         item["id"],
+			"subject":    format.SanitizeText(subject, format.MaxFieldLen),
+			"start":      start["dateTime"],
+			"end":        end["dateTime"],
+			"timezone":   start["timeZone"],
+			"location":   loc["displayName"],
+			"is_all_day": item["isAllDay"],
+			"web_link":   item["webLink"],
 		})
 	}
-
 
 	return &adapters.Result{
 		Summary: format.Summary("%d event(s)", len(events)),
@@ -108,26 +107,24 @@ func (a *Adapter) getEvent(ctx context.Context, client *http.Client, params map[
 	bodyContent, _ := body["content"].(string)
 
 	data := map[string]any{
-		"id":          item["id"],
-		"subject":     format.SanitizeText(subject, format.MaxFieldLen),
-		"start":       start["dateTime"],
-		"end":         end["dateTime"],
-		"timezone":    start["timeZone"],
-		"location":    loc["displayName"],
-		"body":        format.SanitizeText(bodyContent, format.MaxBodyLen),
-		"attendees":   item["attendees"],
-		"is_all_day":  item["isAllDay"],
-		"web_link":    item["webLink"],
-		"organizer":   item["organizer"],
+		"id":         item["id"],
+		"subject":    format.SanitizeText(subject, format.MaxFieldLen),
+		"start":      start["dateTime"],
+		"end":        end["dateTime"],
+		"timezone":   start["timeZone"],
+		"location":   loc["displayName"],
+		"body":       format.SanitizeText(bodyContent, format.MaxBodyLen),
+		"attendees":  item["attendees"],
+		"is_all_day": item["isAllDay"],
+		"web_link":   item["webLink"],
+		"organizer":  item["organizer"],
 	}
-
 
 	return &adapters.Result{
 		Summary: format.Summary("Event: %s", data["subject"]),
 		Data:    data,
 	}, nil
 }
-
 
 func (a *Adapter) sendMessage(ctx context.Context, client *http.Client, params map[string]any) (*adapters.Result, error) {
 	to, _ := params["to"].(string)

--- a/internal/adapters/slack/adapter.go
+++ b/internal/adapters/slack/adapter.go
@@ -102,7 +102,7 @@ func (a *Adapter) downloadFile(ctx context.Context, token string, params map[str
 		return nil, fmt.Errorf("slack download_file: file_id is required")
 	}
 
-	maxBytes, err := resolveMaxBytes(params["max_bytes"])
+	maxBytes, err := format.ResolveMaxBytes(params["max_bytes"])
 	if err != nil {
 		return nil, fmt.Errorf("slack download_file: %w", err)
 	}
@@ -318,33 +318,6 @@ func isSignInPage(resp *http.Response, body []byte, contentType string, meta *fi
 }
 
 // ── helpers ──────────────────────────────────────────────────────────────────
-
-// resolveMaxBytes returns the effective download ceiling. Callers that stream
-// the response to disk can raise it up to format.MaxDownloadBytes; the default
-// stays small enough to survive being read into a model context.
-func resolveMaxBytes(v any) (int64, error) {
-	if v == nil {
-		return format.DefaultDownloadBytes, nil
-	}
-	var n int64
-	switch x := v.(type) {
-	case float64: // JSON numbers decode as float64
-		n = int64(x)
-	case int:
-		n = int64(x)
-	case int64:
-		n = x
-	default:
-		return 0, fmt.Errorf("max_bytes must be a number")
-	}
-	if n <= 0 {
-		return 0, fmt.Errorf("max_bytes must be positive")
-	}
-	if n > format.MaxDownloadBytes {
-		return 0, fmt.Errorf("max_bytes may not exceed %s", humanBytes(format.MaxDownloadBytes))
-	}
-	return n, nil
-}
 
 // checkSlackHost rejects download URLs that do not point at Slack. The URL
 // comes from an API response rather than the caller, but it still reaches the

--- a/internal/adapters/slack/adapter.go
+++ b/internal/adapters/slack/adapter.go
@@ -278,9 +278,7 @@ func (a *Adapter) fetchContent(ctx context.Context, token, downloadURL string, m
 		return nil, "", fmt.Errorf("reading content after %d bytes: %w", len(body), readErr)
 	}
 	if int64(len(body)) > maxBytes {
-		return nil, "", fmt.Errorf(
-			"content exceeds the %s limit; raise max_bytes (up to %s)",
-			humanBytes(maxBytes), humanBytes(format.MaxDownloadBytes))
+		return nil, "", fmt.Errorf("content %s", format.OverflowMessage(maxBytes))
 	}
 
 	contentType := resp.Header.Get("Content-Type")

--- a/internal/adapters/slack/adapter_test.go
+++ b/internal/adapters/slack/adapter_test.go
@@ -313,19 +313,6 @@ func TestDownloadFileAllowsRaisedLimit(t *testing.T) {
 	}
 }
 
-func TestResolveMaxBytesRejectsOverCeiling(t *testing.T) {
-	if _, err := resolveMaxBytes(float64(format.MaxDownloadBytes + 1)); err == nil {
-		t.Error("expected an error above the ceiling")
-	}
-	if _, err := resolveMaxBytes(float64(0)); err == nil {
-		t.Error("expected an error for zero")
-	}
-	got, err := resolveMaxBytes(nil)
-	if err != nil || got != format.DefaultDownloadBytes {
-		t.Errorf("default = %d, %v", got, err)
-	}
-}
-
 // Slack answers an under-scoped token with 200 + a sign-in page, so status
 // alone cannot be treated as success.
 func TestDownloadFileDetectsHTMLLoginPage(t *testing.T) {

--- a/pkg/adapters/yamlloader/loader_test.go
+++ b/pkg/adapters/yamlloader/loader_test.go
@@ -1,6 +1,7 @@
 package yamlloader
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/clawvisor/clawvisor/internal/adapters/definitions"
@@ -19,24 +20,23 @@ func TestLoadEmbeddedDefinitions(t *testing.T) {
 
 	// Verify all expected services are loaded.
 	expected := map[string]bool{
-		"stripe":           false,
-		"github":           false,
-		"slack":            false,
-		"twilio":           false,
-		"notion":           false,
-		"linear":           false,
-		"google.gmail":     false,
-		"google.calendar":  false,
-		"google.drive":     false,
-		"google.contacts":  false,
-		"google.sheets":    false,
-		"dropbox":          false,
-		"granola":          false,
-		"perplexity":       false,
+		"stripe":             false,
+		"github":             false,
+		"slack":              false,
+		"twilio":             false,
+		"notion":             false,
+		"linear":             false,
+		"google.gmail":       false,
+		"google.calendar":    false,
+		"google.drive":       false,
+		"google.contacts":    false,
+		"google.sheets":      false,
+		"dropbox":            false,
+		"granola":            false,
+		"perplexity":         false,
 		"microsoft.onedrive": false,
 		"microsoft.outlook":  false,
 	}
-
 
 	for _, a := range adapters {
 		id := a.ServiceID()
@@ -82,6 +82,63 @@ func TestLoadedDefinitionsHaveMetadata(t *testing.T) {
 			}
 			if am.Sensitivity == "" {
 				t.Errorf("service %q action %q: missing risk sensitivity", a.ServiceID(), actionName)
+			}
+		}
+	}
+}
+
+// Guards against a max_bytes block landing in the wrong action — it is easy to
+// misplace in YAML and the failure is silent: the adapter falls back to the
+// default limit and callers can never opt into a larger download.
+func TestDownloadActionsExposeMaxBytes(t *testing.T) {
+	loader := New(definitions.FS, nil, nil, nil)
+	if err := loader.LoadAll(); err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	defs := map[string]map[string][]string{} // service -> action -> param names
+	for _, a := range loader.Adapters() {
+		actions := map[string][]string{}
+		for name, action := range a.Def().Actions {
+			var params []string
+			for p := range action.Params {
+				params = append(params, p)
+			}
+			actions[name] = params
+		}
+		defs[a.ServiceID()] = actions
+	}
+
+	want := map[string][]string{
+		"dropbox":            {"download_file"},
+		"google.drive":       {"download_file", "export_file"},
+		"microsoft.onedrive": {"download_file"},
+		"slack":              {"download_file"},
+		"google.gmail":       {"get_message_raw"},
+	}
+	for service, wantActions := range want {
+		actions, ok := defs[service]
+		if !ok {
+			t.Errorf("service %q did not load", service)
+			continue
+		}
+		for _, action := range wantActions {
+			params, ok := actions[action]
+			if !ok {
+				t.Errorf("%s: action %q missing", service, action)
+				continue
+			}
+			if !slices.Contains(params, "max_bytes") {
+				t.Errorf("%s %s: missing max_bytes param, has %v", service, action, params)
+			}
+		}
+	}
+
+	// And it must not leak into unrelated actions — the failure mode is
+	// silent, so assert the exact set.
+	for service, actions := range defs {
+		for action, params := range actions {
+			if slices.Contains(params, "max_bytes") && !slices.Contains(want[service], action) {
+				t.Errorf("%s %s: unexpected max_bytes param", service, action)
 			}
 		}
 	}

--- a/pkg/clawvisor/defaults.go
+++ b/pkg/clawvisor/defaults.go
@@ -183,7 +183,7 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 	goOverrides := map[string]yamlruntime.ActionFunc{}
 
 	gmail := gmailadapter.New(oauthProvider)
-	for _, action := range []string{"list_messages", "get_message", "get_thread", "get_attachment", "send_message", "create_draft", "archive_message"} {
+	for _, action := range []string{"list_messages", "get_message", "get_message_raw", "get_thread", "get_attachment", "send_message", "create_draft", "archive_message"} {
 		goOverrides["google.gmail:"+action] = gmail.Execute
 	}
 	drive := driveadapter.New(oauthProvider)


### PR DESCRIPTION
Follow-up to #653, which established byte-exact downloads for Slack. This applies the same rule to the adapters that predate it, and adds a raw-message endpoint for Gmail.

## Byte-exact downloads

Downloads returned text *unencoded* when the content type looked textual. That cannot round-trip a file:

- `format.SanitizeText` **strips HTML** — an `.html` download returned the prose with the markup deleted — and truncates at 200k runes.
- Even unsanitized, bytes in a JSON string lose anything not valid UTF-8 to U+FFFD, silently corrupting legacy-encoded CSVs and every binary format.

Both failures are success-shaped: the caller gets a `Downloaded foo.html` summary and altered content.

| Path | Change |
|---|---|
| `dropbox download_file` | text branch removed |
| `onedrive download_file` | text branch removed |
| `drive export_file` | **was sanitizing exported bytes** — export targets include PDF and the OOXML formats, which `SanitizeText` destroys outright |
| `drive` export sheet tab | was stripping markup out of cell values and truncating the sheet |

`drive get_file` is deliberately **untouched**: its `content` is an explicit preview for text mimetypes on a metadata call, not a download. Changing it would alter a field that is meant to be a lossy summary.

## Gmail `get_message_raw`

An **alternative** endpoint, not a replacement. `get_message` returns a readable projection (from/subject/body/labels), which is what most callers want and is far cheaper — it stays the right default. The raw endpoint serves what a projection cannot:

- header and DKIM verification
- verbatim re-send or archival
- MIME parts the projection drops

Gmail emits URL-safe base64; this re-encodes as standard base64 so it matches the `encoding: base64` contract every other content action uses. Bounded by `max_bytes` (1 MB default, 10 MB ceiling) because a raw message carries its attachments inline and can be much larger than the parsed form — with a bounded read rather than the unbounded `io.ReadAll` in the shared `gmailGET`.

## Testing

Full suite green. New Gmail tests assert the raw bytes round-trip exactly — including a DKIM header and `<b>hi</b>` markup that `get_message` would drop or strip, plus a non-UTF-8 byte — and cover padded/unpadded URL-safe input, the size guard, and the error paths. The Drive sheet-export test now decodes before asserting.

**Contract change:** callers of `dropbox download_file`, `onedrive download_file`, and `drive export_file` that previously received plain text for textual files now receive base64. This is the same break #653 made for Slack, applied for the same reason.

**Not verified against live APIs** — all tests are stubbed transports. Worth confirming a Drive→PDF export and a Gmail raw fetch with an attachment in staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/654?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

