### PR TITLE
Fix installer token minting and dry-run output

### DIFF
--- a/cmd/render-installer/main.go
+++ b/cmd/render-installer/main.go
@@ -1,0 +1,112 @@
+// Command render-installer renders a shell agent installer from the local
+// templates and writes it to stdout. It is a developer tool for exercising
+// local installer changes against a remote Clawvisor environment without
+// running a second server.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/clawvisor/clawvisor/internal/api/handlers"
+)
+
+var (
+	validClaim     = regexp.MustCompile(`^[A-Za-z0-9_-]{1,64}$`)
+	validAgentName = regexp.MustCompile(`^[A-Za-z0-9_.-]{1,64}$`)
+)
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+func run(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("render-installer", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+
+	var (
+		appURL    string
+		llmURL    string
+		target    string
+		agentName string
+		claim     string
+	)
+	fs.StringVar(&appURL, "app-url", "https://app.staging.clawvisor.com", "Clawvisor control-plane URL baked into the installer")
+	fs.StringVar(&llmURL, "llm-url", "https://llm.staging.clawvisor.com", "LLM proxy URL baked into routed installers")
+	fs.StringVar(&target, "target", "claude-code", "installer target: claude-code or codex")
+	fs.StringVar(&agentName, "agent-name", "", "agent name baked into the installer (defaults to target)")
+	fs.StringVar(&claim, "claim", "", "single-use connection claim")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "render-installer: unexpected positional arguments")
+		return 2
+	}
+
+	if !validClaim.MatchString(claim) {
+		fmt.Fprintln(stderr, "render-installer: -claim must be a 1-64 character URL-safe claim")
+		return 2
+	}
+	if target != "claude-code" && target != "codex" {
+		fmt.Fprintln(stderr, "render-installer: -target must be claude-code or codex")
+		return 2
+	}
+	if agentName == "" {
+		agentName = target
+	}
+	if !validAgentName.MatchString(agentName) {
+		fmt.Fprintln(stderr, "render-installer: -agent-name must use 1-64 letters, digits, dots, underscores, or dashes")
+		return 2
+	}
+
+	appURL = strings.TrimRight(strings.TrimSpace(appURL), "/")
+	if !validHTTPURL(appURL) {
+		fmt.Fprintln(stderr, "render-installer: -app-url must be an absolute http(s) URL")
+		return 2
+	}
+	if llmURL == "" {
+		llmURL = appURL
+	} else {
+		llmURL = strings.TrimRight(strings.TrimSpace(llmURL), "/")
+		if !validHTTPURL(llmURL) {
+			fmt.Fprintln(stderr, "render-installer: -llm-url must be an absolute http(s) URL")
+			return 2
+		}
+	}
+
+	query := url.Values{}
+	query.Set("claim", claim)
+	query.Set("agent_name", agentName)
+	query.Set("route", "skill-only")
+	path := "/skill/install/" + target + ".sh?" + query.Encode()
+
+	h := handlers.NewInstallerHandler("", "", false, llmURL, appURL)
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /skill/install/{target}", h.Setup)
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		fmt.Fprintf(stderr, "render-installer: render failed with HTTP %d: %s", rec.Code, rec.Body.String())
+		return 1
+	}
+	if _, err := io.Copy(stdout, rec.Body); err != nil {
+		fmt.Fprintf(stderr, "render-installer: write output: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+func validHTTPURL(raw string) bool {
+	u, err := url.Parse(raw)
+	return err == nil && (u.Scheme == "http" || u.Scheme == "https") && u.Host != ""
+}

--- a/cmd/render-installer/main.go
+++ b/cmd/render-installer/main.go
@@ -24,31 +24,49 @@ var (
 )
 
 func main() {
-	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+	os.Exit(run(os.Args[1:], os.Stdin, os.Stdout, os.Stderr))
 }
 
-func run(args []string, stdout, stderr io.Writer) int {
+func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("render-installer", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 
 	var (
-		appURL    string
-		llmURL    string
-		target    string
-		agentName string
-		claim     string
+		appURL         string
+		llmURL         string
+		target         string
+		agentName      string
+		claim          string
+		claimFromStdin bool
 	)
 	fs.StringVar(&appURL, "app-url", "https://app.staging.clawvisor.com", "Clawvisor control-plane URL baked into the installer")
 	fs.StringVar(&llmURL, "llm-url", "https://llm.staging.clawvisor.com", "LLM proxy URL baked into routed installers")
 	fs.StringVar(&target, "target", "claude-code", "installer target: claude-code or codex")
 	fs.StringVar(&agentName, "agent-name", "", "agent name baked into the installer (defaults to target)")
 	fs.StringVar(&claim, "claim", "", "single-use connection claim")
+	fs.BoolVar(&claimFromStdin, "claim-stdin", false, "read the single-use connection claim from stdin")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
 	if fs.NArg() != 0 {
 		fmt.Fprintln(stderr, "render-installer: unexpected positional arguments")
 		return 2
+	}
+	if claimFromStdin {
+		if claim != "" {
+			fmt.Fprintln(stderr, "render-installer: -claim and -claim-stdin are mutually exclusive")
+			return 2
+		}
+		// Claims are at most 64 URL-safe characters. Two extra bytes allow one
+		// terminal newline (LF or CRLF), and the final byte detects overflow; a
+		// larger input remains invalid and fails the shape check below.
+		claimBytes, err := io.ReadAll(io.LimitReader(stdin, 67))
+		if err != nil {
+			fmt.Fprintf(stderr, "render-installer: read claim from stdin: %v\n", err)
+			return 2
+		}
+		claim = strings.TrimSuffix(string(claimBytes), "\n")
+		claim = strings.TrimSuffix(claim, "\r")
 	}
 
 	if !validClaim.MatchString(claim) {
@@ -68,16 +86,16 @@ func run(args []string, stdout, stderr io.Writer) int {
 	}
 
 	appURL = strings.TrimRight(strings.TrimSpace(appURL), "/")
-	if !validHTTPURL(appURL) {
-		fmt.Fprintln(stderr, "render-installer: -app-url must be an absolute http(s) URL")
+	if !validHTTPBaseURL(appURL) {
+		fmt.Fprintln(stderr, "render-installer: -app-url must be an absolute http(s) base URL without a query or fragment")
 		return 2
 	}
 	if llmURL == "" {
 		llmURL = appURL
 	} else {
 		llmURL = strings.TrimRight(strings.TrimSpace(llmURL), "/")
-		if !validHTTPURL(llmURL) {
-			fmt.Fprintln(stderr, "render-installer: -llm-url must be an absolute http(s) URL")
+		if !validHTTPBaseURL(llmURL) {
+			fmt.Fprintln(stderr, "render-installer: -llm-url must be an absolute http(s) base URL without a query or fragment")
 			return 2
 		}
 	}
@@ -96,7 +114,8 @@ func run(args []string, stdout, stderr io.Writer) int {
 	mux.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
-		fmt.Fprintf(stderr, "render-installer: render failed with HTTP %d: %s", rec.Code, rec.Body.String())
+		body := strings.TrimRight(rec.Body.String(), "\r\n")
+		fmt.Fprintf(stderr, "render-installer: render failed with HTTP %d: %s\n", rec.Code, body)
 		return 1
 	}
 	if _, err := io.Copy(stdout, rec.Body); err != nil {
@@ -106,7 +125,18 @@ func run(args []string, stdout, stderr io.Writer) int {
 	return 0
 }
 
-func validHTTPURL(raw string) bool {
+func validHTTPBaseURL(raw string) bool {
+	// url.Parse accepts both delimiters even when their values are empty
+	// (https://host? and https://host#). Appending /api/... to either form
+	// produces a syntactically valid but semantically broken endpoint.
+	if strings.ContainsAny(raw, "?#") {
+		return false
+	}
 	u, err := url.Parse(raw)
-	return err == nil && (u.Scheme == "http" || u.Scheme == "https") && u.Host != ""
+	return err == nil &&
+		(u.Scheme == "http" || u.Scheme == "https") &&
+		u.Host != "" &&
+		u.RawQuery == "" &&
+		!u.ForceQuery &&
+		u.Fragment == ""
 }

--- a/cmd/render-installer/main_test.go
+++ b/cmd/render-installer/main_test.go
@@ -214,6 +214,30 @@ printf 'STDIN=%s\n' "$claim"
 	if names[0] == names[1] {
 		t.Fatalf("rapid renders reused agent name %q", names[0])
 	}
+
+	t.Run("stdin without trailing newline", func(t *testing.T) {
+		cmd := exec.Command(
+			"sh",
+			filepath.Join(repoRoot, "scripts", "render-staging-installer.sh"),
+			"--claim-stdin",
+			"codex",
+		)
+		cmd.Stdin = strings.NewReader(claim)
+		cmd.Env = []string{
+			"HOME=" + t.TempDir(),
+			"PATH=" + fakeBin + string(os.PathListSeparator) + os.Getenv("PATH"),
+		}
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("render from unterminated stdin claim: %v\n%s", err, out)
+		}
+		text := string(out)
+		if !strings.Contains(text, "-claim-stdin") ||
+			!strings.Contains(text, "CLAIM_ENV=unset") ||
+			!strings.Contains(text, "STDIN="+claim) {
+			t.Fatalf("unterminated stdin claim was not preserved:\n%s", text)
+		}
+	})
 }
 
 func writeTestExecutable(t *testing.T, path, body string) {

--- a/cmd/render-installer/main_test.go
+++ b/cmd/render-installer/main_test.go
@@ -2,6 +2,10 @@ package main
 
 import (
 	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -12,7 +16,7 @@ func TestRunRendersLocalTemplateForStaging(t *testing.T) {
 		"-claim", "ABCDEFGHIJ",
 		"-target", "claude-code",
 		"-agent-name", "claude-code-staging-test",
-	}, &stdout, &stderr)
+	}, strings.NewReader(""), &stdout, &stderr)
 	if exit != 0 {
 		t.Fatalf("run exit=%d stderr=%s", exit, stderr.String())
 	}
@@ -36,11 +40,185 @@ func TestRunRendersLocalTemplateForStaging(t *testing.T) {
 
 func TestRunRejectsInvalidClaim(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	exit := run([]string{"-claim", `bad"claim`}, &stdout, &stderr)
+	exit := run([]string{"-claim", `bad"claim`}, strings.NewReader(""), &stdout, &stderr)
 	if exit != 2 {
 		t.Fatalf("run exit=%d, want 2", exit)
 	}
 	if !strings.Contains(stderr.String(), "URL-safe claim") {
 		t.Fatalf("unexpected stderr: %s", stderr.String())
+	}
+}
+
+func TestRunReadsClaimFromStdin(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	exit := run([]string{
+		"-claim-stdin",
+		"-target", "codex",
+		"-agent-name", "codex-staging-test",
+	}, strings.NewReader("ABCDEFGHIJ\r\n"), &stdout, &stderr)
+	if exit != 0 {
+		t.Fatalf("run exit=%d stderr=%s", exit, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "claim=ABCDEFGHIJ") {
+		t.Fatalf("rendered installer did not contain stdin claim")
+	}
+}
+
+func TestRunRejectsAmbiguousClaimSources(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	exit := run(
+		[]string{"-claim", "ABCDEFGHIJ", "-claim-stdin"},
+		strings.NewReader("OTHERCLAIM\n"),
+		&stdout,
+		&stderr,
+	)
+	if exit != 2 {
+		t.Fatalf("run exit=%d, want 2", exit)
+	}
+	if !strings.HasSuffix(stderr.String(), "\n") ||
+		!strings.Contains(stderr.String(), "mutually exclusive") {
+		t.Fatalf("unexpected stderr: %q", stderr.String())
+	}
+}
+
+func TestRunRejectsInvalidStdinClaims(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		claim string
+	}{
+		{name: "empty", claim: ""},
+		{name: "invalid character", claim: "bad claim\n"},
+		{name: "multiple lines", claim: "ABCDEFGHIJ\nSECOND\n"},
+		{name: "too long", claim: strings.Repeat("a", 65) + "\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			exit := run(
+				[]string{"-claim-stdin"},
+				strings.NewReader(tc.claim),
+				&stdout,
+				&stderr,
+			)
+			if exit != 2 {
+				t.Fatalf("run exit=%d, want 2", exit)
+			}
+			if stdout.Len() != 0 ||
+				!strings.HasSuffix(stderr.String(), "\n") ||
+				!strings.Contains(stderr.String(), "URL-safe claim") {
+				t.Fatalf("stdout=%q stderr=%q", stdout.String(), stderr.String())
+			}
+		})
+	}
+}
+
+func TestValidHTTPBaseURL(t *testing.T) {
+	for _, tc := range []struct {
+		url  string
+		want bool
+	}{
+		{url: "https://app.staging.clawvisor.com", want: true},
+		{url: "http://localhost:25297/prefix", want: true},
+		{url: "https://example.com/path%3Fpart%23part", want: true},
+		{url: "https://example.com/';id;'", want: true},
+		{url: "https://example.com?mode=staging", want: false},
+		{url: "https://example.com?", want: false},
+		{url: "https://example.com#fragment", want: false},
+		{url: "https://example.com#", want: false},
+		{url: "ftp://example.com", want: false},
+		{url: "/relative", want: false},
+	} {
+		t.Run(tc.url, func(t *testing.T) {
+			if got := validHTTPBaseURL(tc.url); got != tc.want {
+				t.Errorf("validHTTPBaseURL(%q) = %v, want %v", tc.url, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRunRejectsQueryAndFragmentBaseURLs(t *testing.T) {
+	for _, tc := range []struct {
+		flag string
+		url  string
+	}{
+		{flag: "-app-url", url: "https://example.com?mode=staging"},
+		{flag: "-app-url", url: "https://example.com#"},
+		{flag: "-llm-url", url: "https://example.com?"},
+		{flag: "-llm-url", url: "https://example.com#proxy"},
+	} {
+		t.Run(tc.flag+tc.url, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			exit := run(
+				[]string{"-claim", "ABCDEFGHIJ", tc.flag, tc.url},
+				strings.NewReader(""),
+				&stdout,
+				&stderr,
+			)
+			if exit != 2 {
+				t.Fatalf("run exit=%d, want 2", exit)
+			}
+			if stdout.Len() != 0 || !strings.Contains(stderr.String(), "without a query or fragment") {
+				t.Fatalf("stdout=%q stderr=%q", stdout.String(), stderr.String())
+			}
+		})
+	}
+}
+
+func TestStagingScriptUsesUniqueNamesAndKeepsClaimOutOfGoProcess(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skipf("no sh on PATH: %v", err)
+	}
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("repo root: %v", err)
+	}
+	fakeBin := t.TempDir()
+	writeTestExecutable(t, filepath.Join(fakeBin, "date"), "#!/bin/sh\nprintf '20260811123456\\n'\n")
+	writeTestExecutable(t, filepath.Join(fakeBin, "go"), `#!/bin/sh
+printf 'ARGV=%s\n' "$*"
+printf 'CLAIM_ENV=%s\n' "${CLAIM-unset}"
+printf 'ENV_CLAIM_ENV=%s\n' "${ENV_CLAIM-unset}"
+printf 'RENDER_CLAIM_ENV=%s\n' "${RENDER_CLAIM-unset}"
+IFS= read -r claim || claim=""
+printf 'STDIN=%s\n' "$claim"
+`)
+
+	const claim = "SINGLE_USE_CLAIM"
+	var names []string
+	namePattern := regexp.MustCompile(`-agent-name (codex-staging-test-20260811123456-[0-9]+)`)
+	for i := 0; i < 2; i++ {
+		cmd := exec.Command("sh", filepath.Join(repoRoot, "scripts", "render-staging-installer.sh"), "codex")
+		cmd.Env = []string{
+			"CLAIM=" + claim,
+			"HOME=" + t.TempDir(),
+			"PATH=" + fakeBin + string(os.PathListSeparator) + os.Getenv("PATH"),
+		}
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("run %d: %v\n%s", i+1, err, out)
+		}
+		text := string(out)
+		if strings.Contains(strings.SplitN(text, "\n", 2)[0], claim) ||
+			!strings.Contains(text, "-claim-stdin") ||
+			!strings.Contains(text, "CLAIM_ENV=unset") ||
+			!strings.Contains(text, "ENV_CLAIM_ENV=unset") ||
+			!strings.Contains(text, "RENDER_CLAIM_ENV=unset") ||
+			!strings.Contains(text, "STDIN="+claim) {
+			t.Fatalf("claim channel was not isolated:\n%s", text)
+		}
+		match := namePattern.FindStringSubmatch(text)
+		if match == nil {
+			t.Fatalf("default agent name lacks timestamp and PID:\n%s", text)
+		}
+		names = append(names, match[1])
+	}
+	if names[0] == names[1] {
+		t.Fatalf("rapid renders reused agent name %q", names[0])
+	}
+}
+
+func writeTestExecutable(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o700); err != nil {
+		t.Fatalf("write %s: %v", path, err)
 	}
 }

--- a/cmd/render-installer/main_test.go
+++ b/cmd/render-installer/main_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRunRendersLocalTemplateForStaging(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	exit := run([]string{
+		"-claim", "ABCDEFGHIJ",
+		"-target", "claude-code",
+		"-agent-name", "claude-code-staging-test",
+	}, &stdout, &stderr)
+	if exit != 0 {
+		t.Fatalf("run exit=%d stderr=%s", exit, stderr.String())
+	}
+	for _, want := range []string{
+		"#!/bin/sh",
+		"APP_URL='https://app.staging.clawvisor.com'",
+		"LLM_URL='https://llm.staging.clawvisor.com'",
+		"AGENT_NAME='claude-code-staging-test'",
+		"claim=ABCDEFGHIJ",
+		"Every installer invocation creates a new agent token",
+		"claude -p --permission-mode auto --verbose",
+		`echo "Initial prompt:"`,
+		`--output-format stream-json "$CV_DRY_PROMPT"`,
+		"cv_claude_transcript",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Errorf("rendered installer missing %q", want)
+		}
+	}
+}
+
+func TestRunRejectsInvalidClaim(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	exit := run([]string{"-claim", `bad"claim`}, &stdout, &stderr)
+	if exit != 2 {
+		t.Fatalf("run exit=%d, want 2", exit)
+	}
+	if !strings.Contains(stderr.String(), "URL-safe claim") {
+		t.Fatalf("unexpected stderr: %s", stderr.String())
+	}
+}

--- a/internal/api/handlers/installer_runtime_test.go
+++ b/internal/api/handlers/installer_runtime_test.go
@@ -1,0 +1,259 @@
+package handlers
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestSkillOnlyInstallerRuntimeFreshTokenAndDryRun executes the rendered shell
+// installers instead of only inspecting their text. Network and harness calls
+// are replaced with deterministic fakes, but the installer itself runs under
+// /bin/sh with a real HOME, jq transformations, token persistence, catalog
+// preflight, harness invocation, verdict parsing, and final status banner.
+//
+// The fake catalog is intentionally local-only: it contains the normal
+// "No cloud services" message followed by a local service heading. This pins
+// the regression where the installer skipped a perfectly runnable dry run.
+func TestSkillOnlyInstallerRuntimeFreshTokenAndDryRun(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skipf("no sh on PATH: %v", err)
+	}
+	if _, err := exec.LookPath("jq"); err != nil {
+		t.Skipf("no jq on PATH: %v", err)
+	}
+
+	h := NewInstallerHandler("", "", true, "", "https://app.example.com")
+	for _, tc := range []struct {
+		target string
+		claim  string
+	}{
+		{target: "claude-code", claim: "ABCDEFGHIJ"},
+		{target: "codex", claim: "CLAIMCODE0"},
+	} {
+		t.Run(tc.target, func(t *testing.T) {
+			home := t.TempDir()
+			fakeBin := filepath.Join(home, "fake-bin")
+			if err := os.MkdirAll(fakeBin, 0o755); err != nil {
+				t.Fatalf("mkdir fake bin: %v", err)
+			}
+
+			curlLog := filepath.Join(home, "curl.log")
+			harnessLog := filepath.Join(home, "harness.log")
+			writeExecutable(t, filepath.Join(fakeBin, "curl"), fakeInstallerCurl)
+			writeExecutable(t, filepath.Join(fakeBin, installerHarnessForTarget(tc.target)), fakeInstallerHarness)
+
+			// A valid old token in the same local slot used to bypass the connect
+			// call entirely. Seed one and prove the installer replaces it.
+			agentJSON := filepath.Join(home, ".clawvisor", "agents", "dev", tc.target+".json")
+			if err := os.MkdirAll(filepath.Dir(agentJSON), 0o755); err != nil {
+				t.Fatalf("mkdir agent dir: %v", err)
+			}
+			if err := os.WriteFile(agentJSON, []byte(`{"agent_id":"old-agent","token":"old-token"}`), 0o600); err != nil {
+				t.Fatalf("seed old agent token: %v", err)
+			}
+
+			script := installerGetShell(t, h, tc.target, tc.claim)
+			// Match the documented curl-pipe invocation, including the -s/--
+			// boundary required to pass installer flags through to a stdin script.
+			cmd := exec.Command("sh", "-s", "--", "--dry-run", "--no-allow-network")
+			cmd.Stdin = strings.NewReader(script)
+			cmd.Env = append(os.Environ(),
+				"HOME="+home,
+				"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+				"SHELL=/bin/false",
+				"TERM=dumb",
+				"CLAWVISOR_INVITE=",
+				"CLAWVISOR_NO_TUI=1",
+				"FAKE_CURL_LOG="+curlLog,
+				"FAKE_HARNESS_LOG="+harnessLog,
+			)
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("rendered installer failed: %v\n%s", err, out)
+			}
+			if !strings.Contains(string(out), "Dry run PASSED") {
+				t.Fatalf("installer did not report a passed dry run:\n%s", out)
+			}
+			if tc.target == "claude-code" {
+				for _, want := range []string{
+					"Initial prompt:\nUse the Clawvisor skill",
+					"Claude:\n\tStarting the dry run.\n\tSelecting a service.",
+					"\tSelecting a service.\n\nTool (Bash): curl https://app.example.com/api/skill/catalog",
+					"Tool (Bash): curl https://app.example.com/api/skill/catalog\n\nTool result:\n\tcatalog fetched",
+					"Tool result:\n\tcatalog fetched\n\tservice selected\n\nClaude:\n\tDry run results:",
+					"\t- In-scope call: catalog read succeeded.\n\t- Out-of-scope call: write was held and did not execute.\n\nCLAWVISOR_DRY_RUN: PASS",
+				} {
+					if !strings.Contains(string(out), want) {
+						t.Errorf("Claude transcript missing %q:\n%s", want, out)
+					}
+				}
+			} else {
+				for _, want := range []string{
+					"Codex: Starting the dry run.",
+					"Tool (exec): load Clawvisor skill",
+					"Tool result: Clawvisor skill loaded",
+					"Tool (exec): /bin/zsh -lc 'curl https://app.example.com/api/skill/catalog'",
+					"Tool result:\n\tcatalog fetched\n\tservice selected",
+					"Codex:\n\tDry run results:",
+					"\t- In-scope call: catalog read succeeded.\n\t- Out-of-scope call: write was held and did not execute.\n\nCLAWVISOR_DRY_RUN: PASS",
+					"CLAWVISOR_DRY_RUN: PASS pending_scope_expansion",
+				} {
+					if !strings.Contains(string(out), want) {
+						t.Errorf("Codex transcript missing %q:\n%s", want, out)
+					}
+				}
+				for _, noisy := range []string{
+					"VERY NOISY SKILL BODY",
+					"loading hooks from both ",
+					"tokens used",
+				} {
+					if strings.Contains(string(out), noisy) {
+						t.Errorf("Codex transcript retained noisy output %q:\n%s", noisy, out)
+					}
+				}
+			}
+
+			calls := readTestFile(t, curlLog)
+			if !strings.Contains(calls, "/api/agents/connect?claim="+tc.claim) {
+				t.Fatalf("fresh claim never reached connect endpoint; calls:\n%s", calls)
+			}
+			persisted := readTestFile(t, agentJSON)
+			if !strings.Contains(persisted, `"token": "fresh-token"`) || strings.Contains(persisted, "old-token") {
+				t.Fatalf("installer did not replace old local token with fresh token:\n%s", persisted)
+			}
+
+			harness := readTestFile(t, harnessLog)
+			if !strings.Contains(harness, "CLAWVISOR_URL=https://app.example.com") ||
+				!strings.Contains(harness, "CLAWVISOR_AGENT_TOKEN=fresh-token") {
+				t.Fatalf("dry-run harness did not receive fresh Clawvisor env:\n%s", harness)
+			}
+			if tc.target == "codex" {
+				for _, want := range []string{
+					"--json --ephemeral --sandbox workspace-write",
+					"sandbox_workspace_write.network_access=true",
+				} {
+					if !strings.Contains(harness, want) {
+						t.Errorf("codex dry-run args missing %q:\n%s", want, harness)
+					}
+				}
+			} else {
+				if !strings.Contains(harness, "--permission-mode auto --verbose --output-format stream-json") {
+					t.Errorf("Claude dry-run args missing auto permission mode:\n%s", harness)
+				}
+				if strings.Contains(harness, "dangerously-skip-permissions") {
+					t.Errorf("Claude dry run bypassed permission checks:\n%s", harness)
+				}
+			}
+		})
+	}
+}
+
+func installerHarnessForTarget(target string) string {
+	if target == "claude-code" {
+		return "claude"
+	}
+	return "codex"
+}
+
+func writeExecutable(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o700); err != nil {
+		t.Fatalf("write executable %s: %v", path, err)
+	}
+}
+
+func readTestFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}
+
+const fakeInstallerCurl = `#!/bin/sh
+printf '%s\n' "$*" >> "$FAKE_CURL_LOG"
+
+out=''
+want_out=no
+for arg in "$@"; do
+    if [ "$want_out" = yes ]; then
+        out=$arg
+        want_out=no
+        continue
+    fi
+    case "$arg" in
+        -o) want_out=yes ;;
+        -o*) out=${arg#-o} ;;
+    esac
+done
+
+case "$*" in
+    *'/api/agents/connect?'*)
+        body='{"status":"approved","token":"fresh-token","agent_id":"fresh-agent"}'
+        ;;
+    *'/api/skill/catalog'*)
+        body='# Your Clawvisor Service Catalog
+
+No cloud services are currently activated.
+
+---
+
+# Local Services
+
+## File System
+Service: local.files (via test-daemon)
+
+- **read_file**(path) — Read a file'
+        ;;
+    *'/skill/SKILL.md'*)
+        body='---
+name: clawvisor
+description: test skill
+---'
+        ;;
+    *)
+        body='{}'
+        ;;
+esac
+
+if [ -n "$out" ]; then
+    if [ "$out" != /dev/null ]; then
+        printf '%s\n' "$body" > "$out"
+    fi
+else
+    printf '%s\n' "$body"
+fi
+`
+
+const fakeInstallerHarness = `#!/bin/sh
+printf 'ARGS=%s\n' "$*" > "$FAKE_HARNESS_LOG"
+printf 'CLAWVISOR_URL=%s\n' "$CLAWVISOR_URL" >> "$FAKE_HARNESS_LOG"
+printf 'CLAWVISOR_AGENT_TOKEN=%s\n' "$CLAWVISOR_AGENT_TOKEN" >> "$FAKE_HARNESS_LOG"
+case "$*" in
+    *'--output-format stream-json'*)
+        printf '%s\n' \
+            '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Starting the dry run.\nSelecting a service."}]}}' \
+            '{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"curl https://app.example.com/api/skill/catalog"}}]}}' \
+            '{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tool-1","content":"catalog fetched\nservice selected"}]}}' \
+            '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Dry run results:\n- Service: local.files via test-daemon.\n- Approved scope: read_file.\n- In-scope call: catalog read succeeded.\n- Out-of-scope call: write was held and did not execute.\nCLAWVISOR_DRY_RUN: PASS pending_scope_expansion"}]}}'
+        ;;
+    *'--json'*)
+        printf '%s\n' \
+            '{"type":"thread.started","thread_id":"thread-1"}' \
+            '{"type":"item.completed","item":{"id":"warning-1","type":"error","message":"loading hooks from both fake locations"}}' \
+            '{"type":"turn.started"}' \
+            '{"type":"item.completed","item":{"id":"message-1","type":"agent_message","text":"Starting the dry run."}}' \
+            '{"type":"item.completed","item":{"id":"skill-1","type":"command_execution","command":"/bin/zsh -lc sed /tmp/.codex/skills/clawvisor/SKILL.md","aggregated_output":"VERY NOISY SKILL BODY","exit_code":0,"status":"completed"}}' \
+            '{"type":"item.completed","item":{"id":"command-1","type":"command_execution","command":"/bin/zsh -lc '\''curl https://app.example.com/api/skill/catalog'\''","aggregated_output":"catalog fetched\nservice selected","exit_code":0,"status":"completed"}}' \
+            '{"type":"item.completed","item":{"id":"message-2","type":"agent_message","text":"Dry run results:\n- Service: local.files via test-daemon.\n- Approved scope: read_file.\n- In-scope call: catalog read succeeded.\n- Out-of-scope call: write was held and did not execute.\nCLAWVISOR_DRY_RUN: PASS pending_scope_expansion"}}' \
+            '{"type":"turn.completed","usage":{"input_tokens":12345,"output_tokens":123}}'
+        ;;
+    *)
+        printf 'CLAWVISOR_DRY_RUN: PASS pending_scope_expansion\n'
+        ;;
+esac
+`

--- a/internal/api/handlers/installer_scripts.go
+++ b/internal/api/handlers/installer_scripts.go
@@ -16,8 +16,20 @@ var installerScriptFS embed.FS
 // claude_code.sh.tmpl and codex.sh.tmpl can {{template "preamble" .}} into
 // common.sh.tmpl. Parsed once at package init; renders are pure.
 var installerScriptTmpl = template.Must(
-	template.ParseFS(installerScriptFS, "installer_scripts/*.sh.tmpl"),
+	template.New("installer-scripts").Funcs(template.FuncMap{
+		"shellQuote": shellQuote,
+	}).ParseFS(installerScriptFS, "installer_scripts/*.sh.tmpl"),
 )
+
+// shellQuote returns one POSIX shell word whose value is exactly s. Installer
+// URLs normally contain no apostrophes, but URL syntax permits them in paths.
+// The templates are executable shell, so raw interpolation into a quoted
+// assignment would let an apostrophe terminate the value and inject commands.
+// Escaping at the template boundary also protects URLs that come from server
+// configuration or the request host, not only the local staging renderer.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}
 
 // installerScriptCtx is the rendering context for the per-harness shell
 // installers. Mirrors installerCtx but only carries the fields the shell

--- a/internal/api/handlers/installer_scripts/claude_code_skill_only.sh.tmpl
+++ b/internal/api/handlers/installer_scripts/claude_code_skill_only.sh.tmpl
@@ -82,8 +82,8 @@ umask "$CV_OLD_UMASK"
 echo "✓ Wired CLAWVISOR_URL + CLAWVISOR_AGENT_TOKEN into $SETTINGS (chmod 600)"
 echo "  and allowed the skill's gateway calls in permissions.allow"
 
-echo "✓ Registered {{.HarnessLabel}} with Clawvisor (skill-only — LLM traffic is NOT routed)."
+echo "✓ Registered {{.HarnessLabel}} with Clawvisor (skill-only)."
 
 {{ template "dry_run" . }}
 echo
-echo "Done. Claude Code reaches the Clawvisor gateway through the skill; LLM traffic is NOT routed."
+echo "Done. Claude Code reaches the Clawvisor gateway through the skill."

--- a/internal/api/handlers/installer_scripts/codex_skill_only.sh.tmpl
+++ b/internal/api/handlers/installer_scripts/codex_skill_only.sh.tmpl
@@ -135,8 +135,8 @@ elif [ "$CV_WANT_NETWORK" = no ]; then
     echo "    network_access = true"
 fi
 
-echo "✓ Registered {{.HarnessLabel}} with Clawvisor (skill-only — LLM traffic is NOT routed)."
+echo "✓ Registered {{.HarnessLabel}} with Clawvisor (skill-only)."
 
 {{ template "dry_run" . }}
 echo
-echo "Done. Codex reaches the Clawvisor gateway through the skill; LLM traffic is NOT routed."
+echo "Done. Codex reaches the Clawvisor gateway through the skill."

--- a/internal/api/handlers/installer_scripts/common.sh.tmpl
+++ b/internal/api/handlers/installer_scripts/common.sh.tmpl
@@ -276,8 +276,8 @@ AGENT_NAME='{{.AgentName}}'
 AGENT_SLOT='{{.AgentSlot}}'
 HARNESS='{{.Target}}'
 HARNESS_LABEL='{{.HarnessLabel}}'
-APP_URL='{{.AppURL}}'
-LLM_URL='{{.LLMURL}}'
+APP_URL={{shellQuote .AppURL}}
+LLM_URL={{shellQuote .LLMURL}}
 HOST_OS=$(uname -s)
 
 # --- Read the enrollment invite (never off argv/env-on-the-command-line) -----

--- a/internal/api/handlers/installer_scripts/common.sh.tmpl
+++ b/internal/api/handlers/installer_scripts/common.sh.tmpl
@@ -29,7 +29,7 @@ set -eu
 
 usage() {
     cat >&2 <<'USAGE'
-Usage: curl -fsSL "<url>/skill/install/{{.Target}}.sh?..." | sh [-- FLAGS]
+Usage: curl -fsSL "<url>/skill/install/{{.Target}}.sh?..." | sh -s -- [FLAGS]
 
 Flags:
   --invite-stdin         Read a single-use enrollment invite from stdin and
@@ -341,96 +341,80 @@ curl returns the token immediately without a wait=true long-poll.
 {{define "mint"}}# --- Mint an agent connection -------------------------------------------------
 echo "→ Registering {{.HarnessLabel}} agent with Clawvisor at $APP_URL"
 
-# Idempotent re-run: if this agent name already has a token file locally
-# and the token is still accepted by the daemon, reuse it instead of
-# minting fresh. Makes the install re-pasteable after a stall — e.g. when
-# the user timed out waiting for a key vault and pastes the same URL
-# again (which still has the now-consumed claim code in it).
-EXISTING_JSON="$HOME/.clawvisor/agents/$AGENT_SLOT.json"
+# Every installer invocation creates a new agent token. A token already stored
+# in this slot belongs to an earlier connection and must never short-circuit a
+# fresh dashboard claim. The dashboard chooses a collision-free AGENT_NAME for
+# each new install; persisting below intentionally replaces only this slot's
+# local pointer after the server has returned the new token.
 TOKEN=""
 AGENT_ID=""
-if [ -f "$EXISTING_JSON" ]; then
-    EXISTING_TOKEN=$(jq -r '.token // empty' "$EXISTING_JSON" 2>/dev/null)
-    if [ -n "$EXISTING_TOKEN" ] && curl -sf \
-            -H "X-Clawvisor-Agent-Token: $EXISTING_TOKEN" \
-            "$APP_URL/api/skill/catalog" -o /dev/null 2>/dev/null; then
-        TOKEN="$EXISTING_TOKEN"
-        AGENT_ID=$(jq -r '.agent_id // empty' "$EXISTING_JSON" 2>/dev/null)
-        echo "✓ Reusing existing agent token from $EXISTING_JSON"
+if [ -n "$CV_INVITE" ]; then
+    # --- Enroll via single-use invite (spec 04 / AGENT-GUIDE §2A) --------
+    # The invite claims a member account (email possession proven by holding
+    # the invite URL, magic-link mode), registers this per-user agent, and
+    # returns its cvis_ token — all in one call to /api/agents/enroll.
+    #
+    # The invite is fed to jq on stdin (printf is a POSIX builtin, so the
+    # token never reaches an external process's argv) and the resulting body
+    # is handed to curl on stdin via --data @-. At no point is the invite on
+    # a command line, in shell history, or in the process table.
+    echo "→ Claiming invite and registering {{.HarnessLabel}} agent at $APP_URL"
+    ENROLL_BODY=$(printf '%s' "$CV_INVITE" | jq -Rs \
+        --arg name "$AGENT_NAME" \
+        --arg desc "$HARNESS_LABEL on $HOST_OS" \
+        --arg harness "$HARNESS" \
+        --arg host_os "$HOST_OS" \
+        '{invite_token: rtrimstr("\n"), name:$name, description:$desc, install_context:{harness:$harness, host_os:$host_os, mode:"sh-invite"}}')
+    RESPONSE=$(printf '%s' "$ENROLL_BODY" | curl -sS -X POST "$APP_URL/api/agents/enroll" \
+        -H 'Content-Type: application/json' \
+        --data @-) || {
+        echo "could not reach Clawvisor at $APP_URL" >&2
+        exit 1
+    }
+    TOKEN=$(printf '%s' "$RESPONSE" | jq -r '.token // empty')
+    if [ -z "$TOKEN" ]; then
+        STATUS=$(printf '%s' "$RESPONSE" | jq -r '.code // .error // "unknown"')
+        echo "invite enrollment failed ($STATUS)" >&2
+        exit 1
     fi
-fi
-
-if [ -z "$TOKEN" ]; then
-    if [ -n "$CV_INVITE" ]; then
-        # --- Enroll via single-use invite (spec 04 / AGENT-GUIDE §2A) --------
-        # The invite claims a member account (email possession proven by holding
-        # the invite URL, magic-link mode), registers this per-user agent, and
-        # returns its cvis_ token — all in one call to /api/agents/enroll.
-        #
-        # The invite is fed to jq on stdin (printf is a POSIX builtin, so the
-        # token never reaches an external process's argv) and the resulting body
-        # is handed to curl on stdin via --data @-. At no point is the invite on
-        # a command line, in shell history, or in the process table.
-        echo "→ Claiming invite and registering {{.HarnessLabel}} agent at $APP_URL"
-        ENROLL_BODY=$(printf '%s' "$CV_INVITE" | jq -Rs \
-            --arg name "$AGENT_NAME" \
-            --arg desc "$HARNESS_LABEL on $HOST_OS" \
-            --arg harness "$HARNESS" \
-            --arg host_os "$HOST_OS" \
-            '{invite_token: rtrimstr("\n"), name:$name, description:$desc, install_context:{harness:$harness, host_os:$host_os, mode:"sh-invite"}}')
-        RESPONSE=$(printf '%s' "$ENROLL_BODY" | curl -sS -X POST "$APP_URL/api/agents/enroll" \
-            -H 'Content-Type: application/json' \
-            --data @-) || {
-            echo "could not reach Clawvisor at $APP_URL" >&2
-            exit 1
-        }
-        TOKEN=$(printf '%s' "$RESPONSE" | jq -r '.token // empty')
-        if [ -z "$TOKEN" ]; then
-            STATUS=$(printf '%s' "$RESPONSE" | jq -r '.code // .error // "unknown"')
-            echo "invite enrollment failed ($STATUS)" >&2
-            exit 1
-        fi
-        AGENT_ID=$(printf '%s' "$RESPONSE" | jq -r '.agent_id // empty')
-        echo "✓ Invite claimed — agent registered"
-    else
+    AGENT_ID=$(printf '%s' "$RESPONSE" | jq -r '.agent_id // empty')
+    echo "✓ Invite claimed — agent registered"
+else
 {{if .Claim -}}
-        CONNECT_URL="$APP_URL/api/agents/connect?claim={{.Claim}}"
+    CONNECT_URL="$APP_URL/api/agents/connect?claim={{.Claim}}"
 {{- else if .UserID -}}
-        CONNECT_URL="$APP_URL/api/agents/connect?user_id={{.UserID}}&wait=true&timeout=120"
+    CONNECT_URL="$APP_URL/api/agents/connect?user_id={{.UserID}}&wait=true&timeout=120"
 {{- else -}}
-        CONNECT_URL="$APP_URL/api/agents/connect?wait=true&timeout=120"
+    CONNECT_URL="$APP_URL/api/agents/connect?wait=true&timeout=120"
 {{- end}}
 
-        CONNECT_BODY=$(jq -nc \
-            --arg name "$AGENT_NAME" \
-            --arg desc "$HARNESS_LABEL on $HOST_OS" \
-            --arg harness "$HARNESS" \
-            --arg host_os "$HOST_OS" \
-            '{name:$name, description:$desc, install_context:{harness:$harness, host_os:$host_os, mode:"sh-one-liner"}}')
+    CONNECT_BODY=$(jq -nc \
+        --arg name "$AGENT_NAME" \
+        --arg desc "$HARNESS_LABEL on $HOST_OS" \
+        --arg harness "$HARNESS" \
+        --arg host_os "$HOST_OS" \
+        '{name:$name, description:$desc, install_context:{harness:$harness, host_os:$host_os, mode:"sh-one-liner"}}')
 
-        # The claim has 120s of validity from when the dashboard minted it; if
-        # it's already expired or consumed (re-paste after a timeout), the
-        # daemon returns 401 INVALID_CLAIM here. The idempotent-reuse branch
-        # above handles the most common re-paste case — this fallback fires
-        # only when there's no local token file at all.
-        RESPONSE=$(curl -sS -X POST "$CONNECT_URL" \
-            -H 'Content-Type: application/json' \
-            --data "$CONNECT_BODY") || {
-            echo "could not reach Clawvisor at $APP_URL" >&2
-            exit 1
-        }
-        TOKEN=$(printf '%s' "$RESPONSE" | jq -r '.token // empty')
-        if [ -z "$TOKEN" ]; then
-            STATUS=$(printf '%s' "$RESPONSE" | jq -r '.status // .error // "unknown"')
-            echo "agent registration failed (status: $STATUS): $RESPONSE" >&2
-            exit 1
-        fi
-        # AGENT_ID is captured so per-target steps can scope dashboard URLs and
-        # credential lookups to this specific agent — see the credential
-        # pre-flight in claude_code.sh.tmpl.
-        AGENT_ID=$(printf '%s' "$RESPONSE" | jq -r '.agent_id // empty')
-        echo "✓ Agent registered"
+    # A claim is single-use. A re-paste of the exact same URL fails closed with
+    # INVALID_CLAIM; get a new installer URL from the dashboard to mint another
+    # agent and token instead of falling back to credentials from an older run.
+    RESPONSE=$(curl -sS -X POST "$CONNECT_URL" \
+        -H 'Content-Type: application/json' \
+        --data "$CONNECT_BODY") || {
+        echo "could not reach Clawvisor at $APP_URL" >&2
+        exit 1
+    }
+    TOKEN=$(printf '%s' "$RESPONSE" | jq -r '.token // empty')
+    if [ -z "$TOKEN" ]; then
+        STATUS=$(printf '%s' "$RESPONSE" | jq -r '.code // .status // .error // "unknown"')
+        echo "agent registration failed (status: $STATUS): $RESPONSE" >&2
+        exit 1
     fi
+    # AGENT_ID is captured so per-target steps can scope dashboard URLs and
+    # credential lookups to this specific agent — see the credential
+    # pre-flight in claude_code.sh.tmpl.
+    AGENT_ID=$(printf '%s' "$RESPONSE" | jq -r '.agent_id // empty')
+    echo "✓ Agent registered"
 fi
 {{end -}}
 
@@ -493,13 +477,23 @@ read-only task's authority. pending_scope_expansion is a pass — the gate held
 it and is offering to widen the scope. blocked is also a pass, but means
 something different: a restriction matched. executed is a FAILURE.
 
-Then print exactly one final line, and nothing after it:
+After step 4, print a concise human-readable report in exactly this shape.
+Describe results in plain language; do not paste raw JSON responses:
+
+Dry run results:
+- Service: <connected service and account used>
+- Approved scope: <the read-only action that was approved>
+- In-scope call: <what succeeded and a short summary of its result>
+- Out-of-scope call: <what was attempted, its status, and confirmation that it did not execute>
+
+Then print exactly one final machine-readable line, and nothing after it:
 
   CLAWVISOR_DRY_RUN: PASS <step-4 status>
   CLAWVISOR_DRY_RUN: FAIL <step number> <one-line reason>
 
 Print PASS only if step 3 succeeded and step 4 did not execute. If you did not
-complete all four calls for any reason, print the FAIL line.
+complete all four calls for any reason, briefly explain the completed results
+in the report and print the FAIL line.
 CVPROMPT
 }
 
@@ -517,6 +511,126 @@ cv_dry_run_verdict() {
     fi
 }
 
+{{- if eq .Target "claude-code" }}
+# Claude's text output mode prints only the final answer, hiding the Bash calls
+# and gateway responses that make the dry run useful to watch. Stream-json
+# carries each assistant message, tool invocation, and tool result as it
+# happens. Render those records into a compact transcript while preserving the
+# final CLAWVISOR_DRY_RUN line for cv_dry_run_verdict above. Non-JSON stderr
+# merged into the stream is passed through instead of disappearing.
+cv_claude_transcript() {
+    jq --unbuffered -Rr '
+        def printable:
+            if type == "string" then .
+            elif type == "array" then
+                map(if type == "string" then . elif .text? then .text else tojson end) | join("\n")
+            elif . == null then ""
+            else tojson
+            end;
+        def indent_lines:
+            split("\n") | map("\t" + .) | join("\n");
+        def transcript_block($label):
+            if contains("\n") then "\($label):\n\(. | indent_lines)\n"
+            else "\($label): \(.)\n"
+            end;
+        def agent_transcript($label):
+            split("\n") as $lines
+            | ($lines
+                | map(select(startswith("CLAWVISOR_DRY_RUN:") | not))
+                | join("\n") | sub("\n+$"; "")) as $human
+            | (if $human != "" then $human | transcript_block($label) else empty end),
+              ($lines[] | select(startswith("CLAWVISOR_DRY_RUN:")) | . + "\n");
+
+        . as $line
+        | (try fromjson catch null) as $event
+        | if $event == null then $line
+          elif $event.type == "assistant" then
+              $event.message.content[]?
+              | if .type == "text" then
+                    .text | agent_transcript("Claude")
+                elif .type == "tool_use" then
+                    .name as $tool_name
+                    |
+                    (.input.command // .input) | printable
+                    | transcript_block("Tool (\($tool_name // "unknown"))")
+                else empty
+                end
+          elif $event.type == "user" then
+              $event.message.content[]?
+              | select(.type == "tool_result")
+              | .content | printable | transcript_block("Tool result")
+          elif $event.type == "result" and $event.is_error == true then
+              $event.result | printable | transcript_block("Claude error")
+          else empty
+          end
+    '
+}
+{{- end }}
+{{- if eq .Target "codex" }}
+# `codex exec` text mode includes startup metadata, hook chatter, the prompt a
+# second time, token counts, and complete output from reading SKILL.md. JSONL
+# gives us the real turn boundaries so the dry run can show the useful agent
+# transcript without dumping Codex's plumbing. Keep command results visible,
+# but collapse the mandatory skill read rather than printing the whole file.
+cv_codex_transcript() {
+    jq --unbuffered -Rr '
+        def printable:
+            if type == "string" then .
+            elif type == "array" then
+                map(if type == "string" then . elif .text? then .text else tojson end) | join("\n")
+            elif . == null then ""
+            else tojson
+            end;
+        def indent_lines:
+            split("\n") | map("\t" + .) | join("\n");
+        def transcript_block($label):
+            if contains("\n") then "\($label):\n\(. | indent_lines)\n"
+            else "\($label): \(.)\n"
+            end;
+        def agent_transcript($label):
+            split("\n") as $lines
+            | ($lines
+                | map(select(startswith("CLAWVISOR_DRY_RUN:") | not))
+                | join("\n") | sub("\n+$"; "")) as $human
+            | (if $human != "" then $human | transcript_block($label) else empty end),
+              ($lines[] | select(startswith("CLAWVISOR_DRY_RUN:")) | . + "\n");
+
+        . as $line
+        | (try fromjson catch null) as $event
+        | if $event == null then
+              if $line == "Reading additional input from stdin..."
+                  or ($line | contains("OutputTextDelta without active item"))
+              then empty else $line end
+          elif $event.type == "item.completed" and $event.item.type == "agent_message" then
+              $event.item.text
+              | if startswith("`[Spirehawk] Routed through") then empty
+                else agent_transcript("Codex")
+                end
+          elif $event.type == "item.completed" and $event.item.type == "command_execution" then
+              $event.item as $item
+              | if ($item.command | contains("/skills/clawvisor/SKILL.md")) then
+                    ("load Clawvisor skill" | transcript_block("Tool (exec)")),
+                    ("Clawvisor skill loaded" | transcript_block("Tool result"))
+                else
+                    ($item.command | transcript_block("Tool (exec)")),
+                    (if ($item.aggregated_output // "") != "" then
+                         $item.aggregated_output | transcript_block("Tool result")
+                     else empty
+                     end)
+                end
+          elif $event.type == "item.completed" and $event.item.type == "error" then
+              if ($event.item.message | startswith("loading hooks from both ")) then empty
+              else $event.item.message | transcript_block("Codex error")
+              end
+          elif $event.type == "turn.failed" then
+              ($event.error.message // $event.message // "turn failed")
+              | printable | transcript_block("Codex error")
+          else empty
+          end
+    '
+}
+{{- end }}
+
 # Decide whether to run it. An explicit flag always wins. Otherwise ask — but
 # only when there is a terminal to ask on. prompt_yn falls back to its default
 # when /dev/tty is unavailable, which would make an unattended `curl | sh` spawn
@@ -529,17 +643,21 @@ cv_dry_run_verdict() {
 # instead of spending an agent turn to be told the same thing.
 CV_CATALOG=$(curl -sf -H "X-Clawvisor-Agent-Token: $TOKEN" \
     "$APP_URL/api/skill/catalog" 2>/dev/null || true)
-CV_HAVE_SERVICES=yes
-case "$CV_CATALOG" in
-    *"No cloud services are currently activated"*|"") CV_HAVE_SERVICES=no ;;
-esac
+CV_HAVE_SERVICES=no
+# Cloud and local daemon services both render as level-two headings. Looking
+# for a heading distinguishes a truly empty catalog from the valid local-only
+# case, whose preamble also says that no *cloud* services are active.
+if printf '%s\n' "$CV_CATALOG" | grep -q '^## '; then
+    CV_HAVE_SERVICES=yes
+fi
 
 CV_WANT_DRY_RUN=no
 if [ "$CV_HAVE_SERVICES" = no ] && [ "$CV_DRY_RUN" != yes ]; then
     echo
     echo "  Skipping the end-to-end dry run: no services are connected yet, so there is"
     echo "  nothing for a task to be scoped against. Connect one in the Clawvisor"
-    echo "  dashboard (Services), then re-run this installer with --dry-run."
+    echo "  dashboard (Services), get a fresh installer command, and run it as:"
+    echo "    curl ... | sh -s -- --dry-run"
 elif [ "$CV_DRY_RUN" = yes ]; then
     CV_WANT_DRY_RUN=yes
 elif [ "$CV_DRY_RUN" = no ]; then
@@ -577,27 +695,40 @@ if [ "$CV_WANT_DRY_RUN" = yes ]; then
     # wandered off, or never got far enough to reach a conclusion.
     CV_DRY_STATUS=missing
     CV_DRY_OUT=$(mktemp "${TMPDIR:-/tmp}/clawvisor-dry-run.XXXXXX")
+    CV_DRY_PROMPT=$(cv_dry_run_prompt)
+    echo "Initial prompt:"
+    printf '%s\n\n' "$CV_DRY_PROMPT"
 {{- if eq .Target "codex" }}
     if command -v codex >/dev/null 2>&1; then
         CLAWVISOR_URL="$APP_URL" \
         CLAWVISOR_AGENT_TOKEN="$TOKEN" \
-            codex exec --skip-git-repo-check "$(cv_dry_run_prompt)" </dev/null 2>&1 \
-            | tee "$CV_DRY_OUT"
+            codex exec --json --ephemeral --sandbox workspace-write \
+            -c sandbox_workspace_write.network_access=true \
+            --skip-git-repo-check "$CV_DRY_PROMPT" </dev/null 2>&1 \
+            | cv_codex_transcript | tee "$CV_DRY_OUT"
         CV_DRY_STATUS=$(cv_dry_run_verdict "$CV_DRY_OUT")
     else
         echo "  codex is not on your PATH, so the dry run was skipped." >&2
-        echo "  Install codex and re-run with --dry-run to try again." >&2
+        echo "  Install codex, get a fresh installer command, and pass --dry-run." >&2
     fi
 {{- else }}
     if command -v claude >/dev/null 2>&1; then
+        # `claude -p` has no interactive permission prompt. In its default
+        # mode, a skill command containing $CLAWVISOR_AGENT_TOKEN is denied as
+        # an unmatched shell expansion even though the destination host is in
+        # permissions.allow. Auto mode keeps Claude Code's safety classifier
+        # in the loop while allowing this narrow, noninteractive dry-run
+        # session to approve the Clawvisor-bound curl. This is deliberately not
+        # --dangerously-skip-permissions.
         CLAWVISOR_URL="$APP_URL" \
         CLAWVISOR_AGENT_TOKEN="$TOKEN" \
-            claude -p "$(cv_dry_run_prompt)" </dev/null 2>&1 \
-            | tee "$CV_DRY_OUT"
+            claude -p --permission-mode auto --verbose \
+            --output-format stream-json "$CV_DRY_PROMPT" </dev/null 2>&1 \
+            | cv_claude_transcript | tee "$CV_DRY_OUT"
         CV_DRY_STATUS=$(cv_dry_run_verdict "$CV_DRY_OUT")
     else
         echo "  claude is not on your PATH, so the dry run was skipped." >&2
-        echo "  Install Claude Code and re-run with --dry-run to try again." >&2
+        echo "  Install Claude Code, get a fresh installer command, and pass --dry-run." >&2
     fi
 {{- end }}
     rm -f "$CV_DRY_OUT"
@@ -617,18 +748,18 @@ if [ "$CV_WANT_DRY_RUN" = yes ]; then
             ;;
         failed)
             echo "  Dry run FAILED — the verdict line above says which step and why. Your"
-            echo "  install itself is fine and is persisted on disk; re-run the check any"
-            echo "  time with --dry-run."
+            echo "  install itself is fine and is persisted on disk. To retry, get a fresh"
+            echo "  installer command and run it with: sh -s -- --dry-run"
             ;;
         inconclusive)
             echo "  Dry run INCONCLUSIVE: {{.HarnessLabel}} ran but never reported a verdict,"
             echo "  so nothing was proven either way. Usually that means it could not make"
             echo "  the calls at all — not signed in, or the gateway calls are not permitted."
-            echo "  Your install itself is fine; re-run the check with --dry-run."
+            echo "  Your install itself is fine; use a fresh command to retry with --dry-run."
             ;;
         *)
-            echo "  Dry run skipped. Re-run this installer with --dry-run once the harness"
-            echo "  is available to try again."
+            echo "  Dry run skipped. Once the harness is available, get a fresh installer"
+            echo "  command and run it with: sh -s -- --dry-run"
             ;;
     esac
 fi

--- a/internal/api/handlers/installer_syntax_test.go
+++ b/internal/api/handlers/installer_syntax_test.go
@@ -60,3 +60,38 @@ func TestInstallerScriptsAreValidShell(t *testing.T) {
 		})
 	}
 }
+
+// TestInstallerShellQuotesBaseURLs exercises the rendered assignments instead
+// of only checking their syntax. Apostrophes are legal in URL paths, but raw
+// interpolation into APP_URL='...' used to terminate the shell word and turn
+// the rest of the configured URL into commands.
+func TestInstallerShellQuotesBaseURLs(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skipf("no sh on PATH: %v", err)
+	}
+	malicious := "https://example.com/';id;'"
+	h := NewInstallerHandler("", "", false, malicious, malicious)
+	body := installerGetShell(t, h, "codex", "CLAIMCODE0")
+
+	var assignments []string
+	for _, line := range strings.Split(body, "\n") {
+		if strings.HasPrefix(line, "APP_URL=") || strings.HasPrefix(line, "LLM_URL=") {
+			assignments = append(assignments, line)
+		}
+	}
+	if len(assignments) != 2 {
+		t.Fatalf("found %d URL assignments, want 2", len(assignments))
+	}
+
+	script := strings.Join(assignments, "\n") + "\nprintf '<%s>\\n<%s>\\n' \"$APP_URL\" \"$LLM_URL\"\n"
+	cmd := exec.Command("sh")
+	cmd.Stdin = strings.NewReader(script)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("execute URL assignments: %v\n%s\n--- script ---\n%s", err, out, script)
+	}
+	want := fmt.Sprintf("<%s>\n<%s>\n", malicious, malicious)
+	if string(out) != want {
+		t.Fatalf("URL assignment executed or changed input:\n got: %q\nwant: %q\nscript: %s", out, want, script)
+	}
+}

--- a/internal/api/handlers/installer_test.go
+++ b/internal/api/handlers/installer_test.go
@@ -516,11 +516,10 @@ func TestInstallerClaudeCodeShell(t *testing.T) {
 		// Token is persisted to ~/.clawvisor/agents/<name>.json with chmod 600.
 		"~/.clawvisor/agents",
 		"chmod 600",
-		// Idempotent re-run: if the local token file already works against
-		// the daemon, skip the mint step so a re-paste after a stall
-		// doesn't fail on a consumed claim.
-		"Reusing existing agent token",
-		"EXISTING_TOKEN",
+		// A fresh dashboard claim must always reach the connect endpoint and
+		// mint a new token; an older local token can never short-circuit it.
+		"Every installer invocation creates a new agent token",
+		"A claim is single-use",
 		// End-to-end smoke test fires FIRST — passthrough auth (claude
 		// login) flows through Clawvisor untouched, so a working round-
 		// trip means we're done regardless of vault state. Only fall
@@ -1016,13 +1015,13 @@ func TestInstallerDefaultIsSkillOnly(t *testing.T) {
 	if strings.Contains(claude, "ANTHROPIC_BASE_URL=") {
 		t.Errorf("default claude-code script must NOT export ANTHROPIC_BASE_URL; body:\n%s", claude)
 	}
-	assertContainsAll(t, claude, "skill-only", "/api/agents/connect", "LLM traffic is NOT routed")
+	assertContainsAll(t, claude, "skill-only", "/api/agents/connect")
 
 	codex := installerGetShell(t, h, "codex", "CLAIMCODE0")
 	if strings.Contains(codex, "OPENAI_BASE_URL=") || strings.Contains(codex, "base_url = \"$LLM_URL") {
 		t.Errorf("default codex script must NOT bake a provider base URL; body:\n%s", codex)
 	}
-	assertContainsAll(t, codex, "skill-only", "/api/agents/connect", "LLM traffic is NOT routed")
+	assertContainsAll(t, codex, "skill-only", "/api/agents/connect")
 }
 
 // TestSkillOnlyInstallsTheSkill — the whole point of a skill-only install. Until
@@ -1117,6 +1116,44 @@ func TestSkillOnlyDryRunIsOptIn(t *testing.T) {
 	}
 }
 
+// TestClaudeDryRunUsesAutoPermissionMode protects the noninteractive Claude
+// invocation. `claude -p` cannot show a permission prompt, so the default mode
+// rejects the skill's authenticated curl as `Contains simple_expansion` when
+// it sees $CLAWVISOR_AGENT_TOKEN. Auto mode retains Claude Code's safety
+// classifier and permits the Clawvisor-bound request; bypassPermissions would
+// be unnecessarily broad.
+func TestClaudeDryRunUsesAutoPermissionMode(t *testing.T) {
+	h := NewInstallerHandler("", "", true, "", "")
+	body := installerGetShell(t, h, "claude-code", "ABCDEFGHIJ")
+	assertContainsAll(t, body,
+		"cv_claude_transcript",
+		"CV_DRY_PROMPT=$(cv_dry_run_prompt)",
+		`echo "Initial prompt:"`,
+		`printf '%s\n\n' "$CV_DRY_PROMPT"`,
+		"--permission-mode auto --verbose",
+		`--output-format stream-json "$CV_DRY_PROMPT"`,
+		`| cv_claude_transcript | tee "$CV_DRY_OUT"`,
+	)
+	if strings.Contains(body, "claude -p --dangerously-skip-permissions") {
+		t.Error("Claude dry run must not bypass permission checks")
+	}
+}
+
+// TestCodexDryRunUsesCompactJSONTranscript prevents `codex exec` from dumping
+// startup metadata, hook chatter, the prompt twice, and the full SKILL.md into
+// installer output. The JSONL formatter retains agent/tool turns and the
+// machine-readable verdict.
+func TestCodexDryRunUsesCompactJSONTranscript(t *testing.T) {
+	h := NewInstallerHandler("", "", true, "", "")
+	body := installerGetShell(t, h, "codex", "ABCDEFGHIJ")
+	assertContainsAll(t, body,
+		"cv_codex_transcript",
+		"codex exec --json --ephemeral",
+		`| cv_codex_transcript | tee "$CV_DRY_OUT"`,
+		"load Clawvisor skill",
+	)
+}
+
 // TestDryRunVerdictIsNotTheExitCode — the dry run used to set CV_DRY_STATUS=ok
 // purely on the harness exiting 0, then print "the in-scope request should have
 // succeeded". An agent that cannot make a single call still exits 0 after
@@ -1144,6 +1181,10 @@ func TestDryRunVerdictIsNotTheExitCode(t *testing.T) {
 			"Do nothing else",
 			"Do not check the skill version",
 			"stop immediately",
+			"Dry run results:",
+			"In-scope call:",
+			"Out-of-scope call:",
+			"do not paste raw JSON responses",
 		)
 		// The old reassurance must not survive: it asserted an outcome the
 		// script had not established. Matched on the exact banner rather than
@@ -1152,6 +1193,59 @@ func TestDryRunVerdictIsNotTheExitCode(t *testing.T) {
 			t.Errorf("%s: dry run still claims success it has not verified", tc.target)
 		}
 	}
+}
+
+// TestInstallerNeverReusesALocalAgentToken protects the security-sensitive
+// bootstrap invariant: a newly minted dashboard claim must result in a newly
+// minted agent token. The old installer first authenticated the token already
+// present in ~/.clawvisor/agents/<slot>.json and silently reused it, so the
+// fresh claim never reached /api/agents/connect at all.
+func TestInstallerNeverReusesALocalAgentToken(t *testing.T) {
+	h := NewInstallerHandler("", "", true, "", "")
+	for _, v := range shellInstallerVariants() {
+		t.Run(v.name, func(t *testing.T) {
+			body := installerGetShellQuery(t, h, v.target, v.query)
+			assertContainsAll(t, body,
+				"Every installer invocation creates a new agent token",
+				"/api/agents/connect?claim=",
+			)
+			for _, stale := range []string{
+				"Reusing existing agent token",
+				"EXISTING_TOKEN",
+				"EXISTING_JSON",
+			} {
+				if strings.Contains(body, stale) {
+					t.Errorf("installer still contains stale-token reuse path %q", stale)
+				}
+			}
+		})
+	}
+}
+
+// TestCodexDryRunEnablesItsNetworkSandbox pins the invocation-level sandbox
+// settings needed by the check itself. `codex exec` defaults to read-only;
+// merely writing sandbox_workspace_write.network_access=true to config does
+// not help unless this invocation actually selects workspace-write.
+func TestCodexDryRunEnablesItsNetworkSandbox(t *testing.T) {
+	h := NewInstallerHandler("", "", true, "", "")
+	body := installerGetShell(t, h, "codex", "CLAIMCODE0")
+	assertContainsAll(t, body,
+		"codex exec --json --ephemeral --sandbox workspace-write",
+		"-c sandbox_workspace_write.network_access=true",
+	)
+}
+
+// TestDryRunRecognizesLocalOnlyCatalogs prevents the preflight from treating
+// "no cloud services" as "no services". Local daemon services appear after
+// that message and are valid task targets, so presence is determined from the
+// catalog's service headings instead.
+func TestDryRunRecognizesLocalOnlyCatalogs(t *testing.T) {
+	h := NewInstallerHandler("", "", true, "", "")
+	body := installerGetShell(t, h, "codex", "CLAIMCODE0")
+	assertContainsAll(t, body,
+		"grep -q '^## '",
+		"valid local-only",
+	)
 }
 
 // TestCodexSkillOnlyAsksBeforeRelaxingSandbox — persisting
@@ -1252,7 +1346,7 @@ func TestFlipSkillOnlyOptOut(t *testing.T) {
 		"skill-only",
 		"/api/agents/connect",
 		"chmod 600",
-		"LLM traffic is NOT routed",
+		"Done. Claude Code reaches the Clawvisor gateway through the skill.",
 	)
 
 	codex := installerGetShellQuery(t, h, "codex", "claim=CLAIMCODE0&route=skill-only")
@@ -1262,7 +1356,7 @@ func TestFlipSkillOnlyOptOut(t *testing.T) {
 	assertContainsAll(t, codex,
 		"skill-only",
 		"/api/agents/connect",
-		"LLM traffic is NOT routed",
+		"Done. Codex reaches the Clawvisor gateway through the skill.",
 	)
 }
 

--- a/scripts/render-staging-installer.sh
+++ b/scripts/render-staging-installer.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+set -eu
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: scripts/render-staging-installer.sh CLAIM [claude-code|codex] [AGENT_NAME]
+   or: CLAIM=<claim> scripts/render-staging-installer.sh [TARGET] [AGENT_NAME]
+
+Renders the current local skill-only installer to stdout while baking in the
+staging Clawvisor URLs. The claim must have been minted by that same staging
+control plane and is not consumed until the rendered installer is executed.
+
+Examples:
+  CLAIM=<claim> scripts/render-staging-installer.sh > /tmp/clawvisor-installer.sh
+  sh /tmp/clawvisor-installer.sh --dry-run
+
+  CLAIM=<claim> scripts/render-staging-installer.sh codex | sh -s -- --dry-run
+
+Overrides:
+  CLAWVISOR_STAGING_URL      defaults to https://app.staging.clawvisor.com
+  CLAWVISOR_STAGING_LLM_URL  defaults to https://llm.staging.clawvisor.com
+EOF
+    exit 2
+}
+
+# Preserve an inline environment assignment before reading positional args. In
+# `CLAIM=value script "$CLAIM"`, the caller's shell expands "$CLAIM" before
+# applying the inline assignment, so argv contains an empty string even though
+# the child environment correctly contains CLAIM=value.
+ENV_CLAIM=${CLAIM:-}
+ARG_CLAIM=${1:-}
+if [ -n "$ENV_CLAIM" ] && { [ "$#" -eq 0 ] || [ -z "$ARG_CLAIM" ]; }; then
+    CLAIM=$ENV_CLAIM
+    if [ "$#" -gt 0 ]; then
+        shift
+    fi
+elif [ -n "$ENV_CLAIM" ] && { [ "$ARG_CLAIM" = claude-code ] || [ "$ARG_CLAIM" = codex ]; }; then
+    # Environment form with the target as the first real positional argument.
+    CLAIM=$ENV_CLAIM
+elif [ -n "$ARG_CLAIM" ]; then
+    CLAIM=$ARG_CLAIM
+    shift
+else
+    usage
+fi
+
+[ "$#" -le 2 ] || usage
+
+TARGET=${1:-claude-code}
+case "$TARGET" in
+    claude-code|codex) ;;
+    *) usage ;;
+esac
+
+if [ "$#" -ge 2 ]; then
+    AGENT_NAME=$2
+else
+    AGENT_NAME="${TARGET}-staging-test-$(date -u +%Y%m%d%H%M%S)"
+fi
+
+STAGING_URL=${CLAWVISOR_STAGING_URL:-https://app.staging.clawvisor.com}
+STAGING_LLM_URL=${CLAWVISOR_STAGING_LLM_URL:-https://llm.staging.clawvisor.com}
+REPO_ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+
+cd "$REPO_ROOT"
+exec go run ./cmd/render-installer \
+    -app-url "$STAGING_URL" \
+    -llm-url "$STAGING_LLM_URL" \
+    -target "$TARGET" \
+    -agent-name "$AGENT_NAME" \
+    -claim "$CLAIM"

--- a/scripts/render-staging-installer.sh
+++ b/scripts/render-staging-installer.sh
@@ -5,12 +5,16 @@ usage() {
     cat >&2 <<'EOF'
 Usage: scripts/render-staging-installer.sh CLAIM [claude-code|codex] [AGENT_NAME]
    or: CLAIM=<claim> scripts/render-staging-installer.sh [TARGET] [AGENT_NAME]
+   or: scripts/render-staging-installer.sh --claim-stdin [TARGET] [AGENT_NAME]
 
 Renders the current local skill-only installer to stdout while baking in the
 staging Clawvisor URLs. The claim must have been minted by that same staging
 control plane and is not consumed until the rendered installer is executed.
 
 Examples:
+  scripts/render-staging-installer.sh --claim-stdin codex | sh -s -- --dry-run
+  # Paste the claim and press return when the script starts.
+
   CLAIM=<claim> scripts/render-staging-installer.sh > /tmp/clawvisor-installer.sh
   sh /tmp/clawvisor-installer.sh --dry-run
 
@@ -29,7 +33,12 @@ EOF
 # the child environment correctly contains CLAIM=value.
 ENV_CLAIM=${CLAIM:-}
 ARG_CLAIM=${1:-}
-if [ -n "$ENV_CLAIM" ] && { [ "$#" -eq 0 ] || [ -z "$ARG_CLAIM" ]; }; then
+if [ "$ARG_CLAIM" = --claim-stdin ]; then
+    [ -z "$ENV_CLAIM" ] || usage
+    shift
+    IFS= read -r CLAIM || CLAIM=""
+    [ -n "$CLAIM" ] || usage
+elif [ -n "$ENV_CLAIM" ] && { [ "$#" -eq 0 ] || [ -z "$ARG_CLAIM" ]; }; then
     CLAIM=$ENV_CLAIM
     if [ "$#" -gt 0 ]; then
         shift
@@ -55,7 +64,9 @@ esac
 if [ "$#" -ge 2 ]; then
     AGENT_NAME=$2
 else
-    AGENT_NAME="${TARGET}-staging-test-$(date -u +%Y%m%d%H%M%S)"
+    # The server rejects duplicate names. The PID keeps two renders started in
+    # the same second distinct without depending on a non-POSIX random tool.
+    AGENT_NAME="${TARGET}-staging-test-$(date -u +%Y%m%d%H%M%S)-$$"
 fi
 
 STAGING_URL=${CLAWVISOR_STAGING_URL:-https://app.staging.clawvisor.com}
@@ -63,9 +74,16 @@ STAGING_LLM_URL=${CLAWVISOR_STAGING_LLM_URL:-https://llm.staging.clawvisor.com}
 REPO_ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 
 cd "$REPO_ROOT"
-exec go run ./cmd/render-installer \
+# Keep the unconsumed bearer claim out of both argv and the environment of the
+# long-lived `go run` process (and the temporary renderer binary it starts).
+# Unsetting before the pipeline is essential for the documented CLAIM= form,
+# because inherited shell variables otherwise remain exported.
+unset RENDER_CLAIM
+RENDER_CLAIM=$CLAIM
+unset CLAIM ENV_CLAIM ARG_CLAIM
+printf '%s\n' "$RENDER_CLAIM" | go run ./cmd/render-installer \
     -app-url "$STAGING_URL" \
     -llm-url "$STAGING_LLM_URL" \
     -target "$TARGET" \
     -agent-name "$AGENT_NAME" \
-    -claim "$CLAIM"
+    -claim-stdin

--- a/scripts/render-staging-installer.sh
+++ b/scripts/render-staging-installer.sh
@@ -36,7 +36,10 @@ ARG_CLAIM=${1:-}
 if [ "$ARG_CLAIM" = --claim-stdin ]; then
     [ -z "$ENV_CLAIM" ] || usage
     shift
-    IFS= read -r CLAIM || CLAIM=""
+    # POSIX read returns non-zero when EOF terminates a non-empty final line,
+    # but it still stores the bytes it read. Preserve that value so both
+    # `printf %s "$claim" | ...` and newline-terminated input work.
+    IFS= read -r CLAIM || :
     [ -n "$CLAIM" ] || usage
 elif [ -n "$ENV_CLAIM" ] && { [ "$#" -eq 0 ] || [ -z "$ARG_CLAIM" ]; }; then
     CLAIM=$ENV_CLAIM


### PR DESCRIPTION
## Summary

- Always exchange a fresh claim or invite for a newly minted agent token instead of reusing a token from the local agent slot.
- Make Claude Code and Codex dry runs execute with the required permissions, stream a compact readable transcript, and report the in-scope and out-of-scope results in plain language.
- Add a local staging installer renderer plus runtime regression tests for fresh-token persistence, local-only catalogs, harness arguments, transcript formatting, and verdict handling.
- Remove the noisy LLM routing disclaimer from skill-only installer output.

## Testing

- make test
- Rendered both staging installer targets and validated them with sh -n

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

