### PR TITLE
security: JSON error content types, CSP fallbacks, and HS256 alg pinning

### DIFF
--- a/internal/api/handlers/events.go
+++ b/internal/api/handlers/events.go
@@ -29,7 +29,7 @@ func NewEventsHandler(hub events.EventHub, tickets auth.TicketStorer) *EventsHan
 func (h *EventsHandler) IssueTicket(w http.ResponseWriter, r *http.Request) {
 	user := middleware.UserFromContext(r.Context())
 	if user == nil {
-		http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "unauthorized")
 		return
 	}
 
@@ -46,13 +46,13 @@ func (h *EventsHandler) IssueTicket(w http.ResponseWriter, r *http.Request) {
 func (h *EventsHandler) Stream(w http.ResponseWriter, r *http.Request) {
 	user := middleware.UserFromContext(r.Context())
 	if user == nil {
-		http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "unauthorized")
 		return
 	}
 
 	flusher, ok := w.(http.Flusher)
 	if !ok {
-		http.Error(w, `{"error":"streaming not supported"}`, http.StatusInternalServerError)
+		writeError(w, http.StatusInternalServerError, "STREAMING_UNSUPPORTED", "streaming not supported")
 		return
 	}
 

--- a/internal/api/middleware/agent.go
+++ b/internal/api/middleware/agent.go
@@ -24,7 +24,7 @@ func RequireAgent(st store.Store) func(http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			token := agentToken(r)
 			if token == "" {
-				http.Error(w, `{"error":"missing authorization header","code":"UNAUTHORIZED"}`, http.StatusUnauthorized)
+				writeAuthError(w, http.StatusUnauthorized, "UNAUTHORIZED", "missing authorization header")
 				return
 			}
 
@@ -32,12 +32,12 @@ func RequireAgent(st store.Store) func(http.Handler) http.Handler {
 			agent, err := st.GetAgentByToken(r.Context(), hash)
 			if err != nil {
 				if errors.Is(err, store.ErrNotFound) {
-					http.Error(w, `{"error":"invalid agent token","code":"UNAUTHORIZED"}`, http.StatusUnauthorized)
+					writeAuthError(w, http.StatusUnauthorized, "UNAUTHORIZED", "invalid agent token")
 				} else {
 					// Transient database error (e.g. SQLite busy) — return 503
 					// so agents know to retry instead of assuming their token
 					// was revoked.
-					http.Error(w, `{"error":"temporary service error, please retry","code":"SERVICE_UNAVAILABLE"}`, http.StatusServiceUnavailable)
+					writeAuthError(w, http.StatusServiceUnavailable, "SERVICE_UNAVAILABLE", "temporary service error, please retry")
 				}
 				return
 			}
@@ -47,7 +47,7 @@ func RequireAgent(st store.Store) func(http.Handler) http.Handler {
 			// pairing flows set a finite expiry so a leaked token has
 			// finite blast radius. Treat expired same as not-found.
 			if agent.TokenExpiresAt != nil && time.Now().After(*agent.TokenExpiresAt) {
-				http.Error(w, `{"error":"agent token has expired","code":"TOKEN_EXPIRED"}`, http.StatusUnauthorized)
+				writeAuthError(w, http.StatusUnauthorized, "TOKEN_EXPIRED", "agent token has expired")
 				return
 			}
 

--- a/internal/api/middleware/device.go
+++ b/internal/api/middleware/device.go
@@ -95,7 +95,7 @@ func RequireDeviceWithReplayCache(st store.Store, rc ReplayCache) func(http.Hand
 				rest = authHeader[len(prefixV1):]
 				algorithm = 1
 			default:
-				http.Error(w, `{"error":"missing DeviceHMAC authorization","code":"UNAUTHORIZED"}`, http.StatusUnauthorized)
+				writeAuthError(w, http.StatusUnauthorized, "UNAUTHORIZED", "missing DeviceHMAC authorization")
 				return
 			}
 
@@ -105,13 +105,13 @@ func RequireDeviceWithReplayCache(st store.Store, rc ReplayCache) func(http.Hand
 			// network observer rewrite `?param=…` without invalidating
 			// the HMAC. Clients hitting a query-using route must use v2.
 			if algorithm == 1 && r.URL.RawQuery != "" {
-				http.Error(w, `{"error":"DeviceHMAC v1 cannot sign query strings; upgrade to DeviceHMAC2","code":"UNAUTHORIZED"}`, http.StatusUnauthorized)
+				writeAuthError(w, http.StatusUnauthorized, "UNAUTHORIZED", "DeviceHMAC v1 cannot sign query strings; upgrade to DeviceHMAC2")
 				return
 			}
 
 			parts := strings.SplitN(rest, ":", 3)
 			if len(parts) != 3 {
-				http.Error(w, `{"error":"malformed DeviceHMAC header","code":"UNAUTHORIZED"}`, http.StatusUnauthorized)
+				writeAuthError(w, http.StatusUnauthorized, "UNAUTHORIZED", "malformed DeviceHMAC header")
 				return
 			}
 			deviceID, tsStr, providedHMAC := parts[0], parts[1], parts[2]
@@ -119,19 +119,19 @@ func RequireDeviceWithReplayCache(st store.Store, rc ReplayCache) func(http.Hand
 			// Validate timestamp.
 			tsUnix, err := strconv.ParseInt(tsStr, 10, 64)
 			if err != nil {
-				http.Error(w, `{"error":"invalid timestamp","code":"UNAUTHORIZED"}`, http.StatusUnauthorized)
+				writeAuthError(w, http.StatusUnauthorized, "UNAUTHORIZED", "invalid timestamp")
 				return
 			}
 			diff := time.Since(time.Unix(tsUnix, 0))
 			if math.Abs(diff.Seconds()) > deviceTimestampSkew.Seconds() {
-				http.Error(w, `{"error":"timestamp out of range","code":"UNAUTHORIZED"}`, http.StatusUnauthorized)
+				writeAuthError(w, http.StatusUnauthorized, "UNAUTHORIZED", "timestamp out of range")
 				return
 			}
 
 			// Read body for HMAC computation, then re-attach.
 			bodyBytes, err := io.ReadAll(r.Body)
 			if err != nil {
-				http.Error(w, `{"error":"failed to read body","code":"BAD_REQUEST"}`, http.StatusBadRequest)
+				writeAuthError(w, http.StatusBadRequest, "BAD_REQUEST", "failed to read body")
 				return
 			}
 			r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
@@ -139,14 +139,14 @@ func RequireDeviceWithReplayCache(st store.Store, rc ReplayCache) func(http.Hand
 			// Load device from store.
 			device, err := st.GetPairedDevice(r.Context(), deviceID)
 			if err != nil {
-				http.Error(w, `{"error":"unknown device","code":"UNAUTHORIZED"}`, http.StatusUnauthorized)
+				writeAuthError(w, http.StatusUnauthorized, "UNAUTHORIZED", "unknown device")
 				return
 			}
 
 			// Compute expected HMAC.
 			hmacKey, err := hex.DecodeString(device.DeviceHMACKey)
 			if err != nil {
-				http.Error(w, `{"error":"internal error","code":"INTERNAL"}`, http.StatusInternalServerError)
+				writeAuthError(w, http.StatusInternalServerError, "INTERNAL", "internal error")
 				return
 			}
 			bodyHash := sha256.Sum256(bodyBytes)
@@ -164,7 +164,7 @@ func RequireDeviceWithReplayCache(st store.Store, rc ReplayCache) func(http.Hand
 			expectedMAC := hex.EncodeToString(mac.Sum(nil))
 
 			if !hmac.Equal([]byte(providedHMAC), []byte(expectedMAC)) {
-				http.Error(w, `{"error":"invalid HMAC signature","code":"UNAUTHORIZED"}`, http.StatusUnauthorized)
+				writeAuthError(w, http.StatusUnauthorized, "UNAUTHORIZED", "invalid HMAC signature")
 				return
 			}
 
@@ -177,7 +177,7 @@ func RequireDeviceWithReplayCache(st store.Store, rc ReplayCache) func(http.Hand
 			// proved knowledge of the device key.
 			cacheKey := deviceID + ":" + tsStr + ":" + providedHMAC
 			if rc.Check(cacheKey) {
-				http.Error(w, `{"error":"replayed request","code":"UNAUTHORIZED"}`, http.StatusUnauthorized)
+				writeAuthError(w, http.StatusUnauthorized, "UNAUTHORIZED", "replayed request")
 				return
 			}
 

--- a/internal/api/middleware/security.go
+++ b/internal/api/middleware/security.go
@@ -10,7 +10,16 @@ func Security(isLocal bool) func(http.Handler) http.Handler {
 			h.Set("X-Content-Type-Options", "nosniff")
 			h.Set("X-Frame-Options", "DENY")
 			h.Set("Referrer-Policy", "strict-origin-when-cross-origin")
-			h.Set("Content-Security-Policy", "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' http://localhost:25299; frame-ancestors 'none'; form-action 'self'")
+			// object-src and base-uri are not covered by default-src: CSP3
+			// dropped object-src from its fallback chain, and base-uri never
+			// had one. Without them a legacy plugin embed can execute and an
+			// injected <base> tag can re-point every relative script URL,
+			// which defeats the script-src allowlist above.
+			//
+			// connect-src includes http://localhost:25299 so the dashboard can
+			// reach the user's local Clawvisor daemon for agent pairing. It is
+			// loopback-scoped and does not permit any third-party origin.
+			h.Set("Content-Security-Policy", "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' http://localhost:25299; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'")
 			if !isLocal {
 				h.Set("Strict-Transport-Security", "max-age=63072000; includeSubDomains")
 			}

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -63,12 +63,17 @@ func (s *JWTService) GeneratePurposeToken(userID, email, purpose string, ttl tim
 
 // ValidateToken parses and validates a JWT, returning its claims.
 func (s *JWTService) ValidateToken(tokenStr string) (*Claims, error) {
+	// WithValidMethods pins the exact algorithm this service signs with. The
+	// keyfunc below only checks the HMAC family, which also admits HS384 and
+	// HS512 against the same secret — accepting an algorithm we never issue
+	// widens the verifier for no reason. The keyfunc check stays as the
+	// defense against alg confusion (none/RS*/ES*).
 	token, err := jwt.ParseWithClaims(tokenStr, &Claims{}, func(t *jwt.Token) (any, error) {
 		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
 		}
 		return s.secret, nil
-	})
+	}, jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Alg()}))
 	if err != nil {
 		return nil, fmt.Errorf("invalid token: %w", err)
 	}

--- a/internal/auth/jwt_test.go
+++ b/internal/auth/jwt_test.go
@@ -1,0 +1,74 @@
+package auth
+
+import (
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+const testSecret = "test-jwt-secret-32-bytes-padding!!"
+
+func newTestService(t *testing.T) *JWTService {
+	t.Helper()
+	s, err := NewJWTService(testSecret)
+	if err != nil {
+		t.Fatalf("NewJWTService: %v", err)
+	}
+	return s
+}
+
+func TestValidateToken_RoundTrip(t *testing.T) {
+	s := newTestService(t)
+	tok, err := s.GenerateAccessToken("user-1", "a@b.com", time.Hour)
+	if err != nil {
+		t.Fatalf("GenerateAccessToken: %v", err)
+	}
+	claims, err := s.ValidateToken(tok)
+	if err != nil {
+		t.Fatalf("ValidateToken: %v", err)
+	}
+	if claims.UserID != "user-1" {
+		t.Fatalf("UserID = %q, want user-1", claims.UserID)
+	}
+}
+
+// The verifier must accept only the algorithm this service issues. HS384 and
+// HS512 verify against the same secret, so a keyfunc that checks the HMAC
+// family alone would let them through.
+func TestValidateToken_RejectsOtherHMACAlgorithms(t *testing.T) {
+	s := newTestService(t)
+	for _, method := range []jwt.SigningMethod{jwt.SigningMethodHS384, jwt.SigningMethodHS512} {
+		t.Run(method.Alg(), func(t *testing.T) {
+			forged, err := jwt.NewWithClaims(method, &Claims{
+				UserID: "attacker",
+				RegisteredClaims: jwt.RegisteredClaims{
+					ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+				},
+			}).SignedString([]byte(testSecret))
+			if err != nil {
+				t.Fatalf("signing %s: %v", method.Alg(), err)
+			}
+			if _, err := s.ValidateToken(forged); err == nil {
+				t.Fatalf("%s token was accepted; only HS256 is issued", method.Alg())
+			}
+		})
+	}
+}
+
+// alg=none must never be accepted.
+func TestValidateToken_RejectsNone(t *testing.T) {
+	s := newTestService(t)
+	forged, err := jwt.NewWithClaims(jwt.SigningMethodNone, &Claims{
+		UserID: "attacker",
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		},
+	}).SignedString(jwt.UnsafeAllowNoneSignatureType)
+	if err != nil {
+		t.Fatalf("signing none: %v", err)
+	}
+	if _, err := s.ValidateToken(forged); err == nil {
+		t.Fatal("alg=none token was accepted")
+	}
+}


### PR DESCRIPTION
Three findings from the Q3 2026 Oneleet pentest against the hosted service, fixed at the source. The cloud deployment currently compensates for the first two at its edge, which does nothing for self-hosted builds.

### Error responses carry `Content-Type: application/json`

`http.Error` hardcodes `text/plain`, so the 17 call sites that passed it a JSON-shaped string shipped a body contradicting its own header. Clients branching on Content-Type can't reach the `code` field, and `nosniff` (correctly) stops browsers from recovering it.

The helpers already existed — `writeAuthError` in the middleware package, `writeError` in handlers. The converted sites now use them:

| File | Sites |
|---|---|
| `internal/api/middleware/device.go` | 10 |
| `internal/api/middleware/agent.go` | 4 |
| `internal/api/handlers/events.go` | 3 |

Bodies and error codes are unchanged, except `events.go`, which gains a `code` field it previously omitted (additive — existing clients read `error`).

The four `http.Error` calls in `server.go` are left alone: those pass genuine plain-text strings and are correctly typed.

### CSP declares `object-src` and `base-uri`

Neither is covered by `default-src` — CSP3 removed `object-src` from the fallback chain and `base-uri` never had one. Without them a legacy plugin embed can execute, and an injected `<base>` tag can re-point every relative script URL, defeating the `script-src` allowlist.

Also documents why `connect-src` carries `http://localhost:25299`: the dashboard reaches the user's local daemon there for agent pairing. It's loopback-scoped and permits no third-party origin.

### The JWT verifier pins HS256

The keyfunc type-asserts the HMAC *family*, which also admits HS384 and HS512 against the same secret — algorithms this service never issues. `WithValidMethods` pins the exact alg; the keyfunc check stays as the defense against alg confusion (`none`/`RS*`/`ES*`).

Low severity on its own (same symmetric secret either way, no key-type confusion), but it's a gratuitously wider verifier.

### Tests

`internal/auth` had no JWT coverage. Adds round-trip, other-HMAC-rejection, and `alg=none` rejection.

`go build ./...` clean; `internal/auth`, `internal/api`, `internal/api/handlers`, `internal/api/middleware` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

