### PR TITLE
deps(provider): bump grpc to v1.82.1 (GHSA-hrxh-6v49-42gf)

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -62,7 +62,7 @@ require (
 	golang.org/x/tools v0.47.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
-	google.golang.org/grpc v1.81.1 // indirect
+	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )
 

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -233,6 +233,8 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
 google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
 google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=


### PR DESCRIPTION
Clears the last remaining instance of GHSA-hrxh-6v49-42gf, the only Oneleet dependency finding with a near-term SLA (breaches **2026-08-24**).

### What changed

`provider/go.mod`: `google.golang.org/grpc v1.81.1 → v1.82.1` (indirect). One line, plus the two `go.sum` hashes.

### What didn't need changing

Dependabot had already handled most of this on `main`:

| Finding | State on `main` |
|---|---|
| grpc in root `go.mod` | already v1.82.1 |
| go-git in `provider/go.mod` (CVE-2026-71556 / -71557) | already v5.19.2 — the first release fixing both |
| dompurify in `web/` (GHSA-55q2-fjhq-7xh7) | already 3.4.13 via #656 |

Oneleet is still reporting those three because its last scan predates those merges, not because they're outstanding.

### Reachability

Worth recording for triage: **none of the three issues in this advisory is reachable from this module.** Two require xDS; the third is a Rapid Reset bypass in the HTTP/2 *server* transport. The provider runs no gRPC server and uses no xDS — grpc arrives transitively via `terraform-plugin-testing` → `terraform-exec` → `hc-install`, a test-only path. Bumping regardless because it's High severity and the change is one indirect line.

### Not addressed here

- **react-router 6.30.4** (CVE-2026-53666 / -53668 / -53669) — no 6.x fix exists. 6.30.4 is the newest 6.x release, and CVE-2026-53668 has no patched version on any branch; the fix is 7.18.0, a breaking major. Needs a scoped migration or a risk acceptance, not a dependency bump.
- **GO-2026-5932** (`x/crypto/openpgp`) — not fixable by any bump; the advisory says don't use the package. Confirmed unimported via `go list -deps ./...` in both modules and closed as a false positive in Oneleet.

### Verification

Scoped with `go get`, not `go mod tidy`, to avoid unrelated churn. No other dependency moved.

| Module | build | test |
|---|---|---|
| root | pass | 101 ok, 0 fail |
| provider | pass | 3 ok, 0 fail |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

