### PR TITLE
deps(web): migrate react-router v6 → v7 (CVE-2026-53666 / -53668 / -53669)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -16,7 +16,7 @@
         "qrcode.react": "^4.2.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^6.30.4",
+        "react-router": "^7.18.2",
         "recharts": "^3.7.0"
       },
       "devDependencies": {
@@ -647,15 +647,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
-      }
-    },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
-      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -1388,6 +1379,19 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/crelt": {
       "version": "1.0.6",
@@ -2595,35 +2599,25 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
-      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
-      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@remix-run/router": "1.23.3",
-        "react-router": "6.30.4"
+        "react": ">=18",
+        "react-dom": ">=18"
       },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/read-cache": {
@@ -2815,6 +2809,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/web/package.json
+++ b/web/package.json
@@ -18,7 +18,7 @@
     "qrcode.react": "^4.2.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.30.4",
+    "react-router": "^7.18.2",
     "recharts": "^3.7.0"
   },
   "devDependencies": {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { Component, type ErrorInfo, type ReactNode } from 'react'
-import { Navigate, Route, Routes, useLocation } from 'react-router-dom'
+import { Navigate, Route, Routes, useLocation } from 'react-router'
 import { useAuth } from './hooks/useAuth'
 import Login from './pages/Login'
 import SSOLogin from './pages/SSOLogin'

--- a/web/src/components/OnboardingBanner.tsx
+++ b/web/src/components/OnboardingBanner.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
-import { NavLink } from 'react-router-dom'
+import { NavLink } from 'react-router'
 import { useState } from 'react'
 import { api } from '../api/client'
 import { useAuth } from '../hooks/useAuth'

--- a/web/src/components/PlanGrid.tsx
+++ b/web/src/components/PlanGrid.tsx
@@ -1,5 +1,5 @@
 import { useQuery, useMutation } from '@tanstack/react-query'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router'
 import { useState } from 'react'
 import { api } from '../api/client'
 import type { BillingPlan } from '../api/client'

--- a/web/src/components/QuotaBanner.tsx
+++ b/web/src/components/QuotaBanner.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
-import { useLocation, useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router'
 import { api } from '../api/client'
 import { quotaState } from '../lib/quota'
 

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import { BrowserRouter } from 'react-router-dom'
+import { BrowserRouter } from 'react-router'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import App from './App'
 import { AuthProvider } from './hooks/useAuth'

--- a/web/src/pages/AcceptInvite.tsx
+++ b/web/src/pages/AcceptInvite.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { Link, useNavigate, useSearchParams } from 'react-router-dom'
+import { Link, useNavigate, useSearchParams } from 'react-router'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { api, APIError } from '../api/client'
 import { useAuth } from '../hooks/useAuth'

--- a/web/src/pages/Agents.tsx
+++ b/web/src/pages/Agents.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useEffect, useMemo, useRef, useState } from 'react'
-import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom'
+import { Link, useNavigate, useParams, useSearchParams } from 'react-router'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { api, type Agent, type ApprovalRecord, type AgentRuntimeSettings, type AuditEntry, type RuntimePolicyRule, type RuntimeSession } from '../api/client'
 import type { ConnectionRequest, InstallContext } from '../api/client'

--- a/web/src/pages/Audit.tsx
+++ b/web/src/pages/Audit.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { Link, useSearchParams } from 'react-router-dom'
+import { Link, useSearchParams } from 'react-router'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { api, type ActivityMute, type Agent, type AuditEntry } from '../api/client'
 import { useAuth } from '../hooks/useAuth'

--- a/web/src/pages/Billing.tsx
+++ b/web/src/pages/Billing.tsx
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router'
 import { api } from '../api/client'
 import type { AutoRefillSettings, LastAutoRefill, RequestPack } from '../api/client'
 import { quotaState } from '../lib/quota'

--- a/web/src/pages/CheckEmail.tsx
+++ b/web/src/pages/CheckEmail.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Link, useLocation, useNavigate } from 'react-router-dom'
+import { Link, useLocation, useNavigate } from 'react-router'
 import { api, APIError } from '../api/client'
 import { useAuth } from '../hooks/useAuth'
 

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { NavLink, Routes, Route, Navigate, useLocation, useNavigate } from 'react-router-dom'
+import { NavLink, Routes, Route, Navigate, useLocation, useNavigate } from 'react-router'
 import { useQuery } from '@tanstack/react-query'
 import { useAuth } from '../hooks/useAuth'
 import { useEventStream } from '../hooks/useEventStream'

--- a/web/src/pages/ForgotPassword.tsx
+++ b/web/src/pages/ForgotPassword.tsx
@@ -1,5 +1,5 @@
 import { useState, FormEvent } from 'react'
-import { Link } from 'react-router-dom'
+import { Link } from 'react-router'
 import { api, APIError } from '../api/client'
 
 export default function ForgotPassword() {

--- a/web/src/pages/GetStarted.tsx
+++ b/web/src/pages/GetStarted.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo, type ReactNode } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { Link } from 'react-router-dom'
+import { Link } from 'react-router'
 import { api, type TaskSuggestion, type WelcomeData, type WelcomeService, type WelcomeAgent, type WalkthroughExample } from '../api/client'
 import { ServiceIcon } from '../components/ServiceIcon'
 import { useAuth } from '../hooks/useAuth'

--- a/web/src/pages/KeyVault.tsx
+++ b/web/src/pages/KeyVault.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import { Link, useParams, useSearchParams } from 'react-router-dom'
+import { Link, useParams, useSearchParams } from 'react-router'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { api } from '../api/client'
 

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -1,5 +1,5 @@
 import { useState, FormEvent } from 'react'
-import { Link, useNavigate, useSearchParams } from 'react-router-dom'
+import { Link, useNavigate, useSearchParams } from 'react-router'
 import { useAuth } from '../hooks/useAuth'
 import { api, APIError } from '../api/client'
 import { isWebAuthnAvailable, startAuthentication } from '../lib/webauthn'

--- a/web/src/pages/MFAVerify.tsx
+++ b/web/src/pages/MFAVerify.tsx
@@ -1,5 +1,5 @@
 import { useState, FormEvent } from 'react'
-import { useNavigate, useLocation } from 'react-router-dom'
+import { useNavigate, useLocation } from 'react-router'
 import { api, APIError } from '../api/client'
 import { useAuth } from '../hooks/useAuth'
 import { startAuthentication } from '../lib/webauthn'

--- a/web/src/pages/MagicLink.tsx
+++ b/web/src/pages/MagicLink.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { Navigate, useSearchParams } from 'react-router-dom'
+import { Navigate, useSearchParams } from 'react-router'
 import { useAuth } from '../hooks/useAuth'
 import { api, setAccessToken } from '../api/client'
 

--- a/web/src/pages/OAuthAuthorize.tsx
+++ b/web/src/pages/OAuthAuthorize.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { useSearchParams } from 'react-router-dom'
+import { useSearchParams } from 'react-router'
 import { api } from '../api/client'
 
 export default function OAuthAuthorize() {

--- a/web/src/pages/OAuthCallback.tsx
+++ b/web/src/pages/OAuthCallback.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useRef } from 'react'
-import { useNavigate, useSearchParams } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router'
 import { api, APIError } from '../api/client'
 import { useAuth } from '../hooks/useAuth'
 

--- a/web/src/pages/Overview.tsx
+++ b/web/src/pages/Overview.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback, useMemo, type ReactNode } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { Link, useSearchParams } from 'react-router-dom'
+import { Link, useSearchParams } from 'react-router'
 import { api, APIError, type Task, type QueueItem, type Agent, type ActivityBucket, type VerificationVerdict, type ConnectionRequest, type ApprovalRecord, type RuntimeStatus } from '../api/client'
 import { filterLiveRuntimeApprovals, isActiveRuntimeSession } from './Runtime'
 import { useAuth } from '../hooks/useAuth'

--- a/web/src/pages/Pricing.tsx
+++ b/web/src/pages/Pricing.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom'
+import { Link } from 'react-router'
 import PlanGrid from '../components/PlanGrid'
 import { useAuth } from '../hooks/useAuth'
 

--- a/web/src/pages/Register.tsx
+++ b/web/src/pages/Register.tsx
@@ -1,5 +1,5 @@
 import { useState, FormEvent } from 'react'
-import { Link, useNavigate, useSearchParams } from 'react-router-dom'
+import { Link, useNavigate, useSearchParams } from 'react-router'
 import { api, APIError } from '../api/client'
 
 export default function Register() {

--- a/web/src/pages/ResetPassword.tsx
+++ b/web/src/pages/ResetPassword.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, FormEvent } from 'react'
-import { useNavigate, useSearchParams, Link } from 'react-router-dom'
+import { useNavigate, useSearchParams, Link } from 'react-router'
 import { api, APIError, type ResetMethods } from '../api/client'
 import { useAuth } from '../hooks/useAuth'
 

--- a/web/src/pages/Restrictions.tsx
+++ b/web/src/pages/Restrictions.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { Link, useSearchParams } from 'react-router-dom'
+import { Link, useSearchParams } from 'react-router'
 import { api, type Agent, type Restriction, type OrgRestriction, type RuntimePolicyRule, type RuntimeToolControl, type ServiceInfo } from '../api/client'
 import { useAuth } from '../hooks/useAuth'
 import { serviceName, actionName } from '../lib/services'

--- a/web/src/pages/SSOComplete.tsx
+++ b/web/src/pages/SSOComplete.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router'
 import { setAccessToken, api } from '../api/client'
 // SSO complete reads tokens from the URL fragment set by the ACS handler,
 // then fetches the current user via api.auth.me() (the typed wrapper for

--- a/web/src/pages/SSOLogin.tsx
+++ b/web/src/pages/SSOLogin.tsx
@@ -1,5 +1,5 @@
 import { useState, FormEvent } from 'react'
-import { Link } from 'react-router-dom'
+import { Link } from 'react-router'
 
 // Dedicated SSO sign-in page: collects the user's work email, discovers
 // whether their domain has SSO configured, and hands off to the IdP. Kept

--- a/web/src/pages/SecuritySetup.tsx
+++ b/web/src/pages/SecuritySetup.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, FormEvent } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router'
 import { api, APIError, type OnboardingStatus } from '../api/client'
 import { useAuth } from '../hooks/useAuth'
 import { isWebAuthnAvailable, startRegistration } from '../lib/webauthn'

--- a/web/src/pages/Services.tsx
+++ b/web/src/pages/Services.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback, type ReactNode, useMemo } from 'react'
 import { useQuery, useQueryClient, useMutation } from '@tanstack/react-query'
-import { NavLink } from 'react-router-dom'
+import { NavLink } from 'react-router'
 import { api, type Agent, type AuditEntry, type ServiceInfo, type ServiceActionInfo, type VariableMeta, type LocalService, type RuntimePlaceholder, type VaultItem } from '../api/client'
 import { formatDistanceToNow } from 'date-fns'
 import { serviceName, serviceDescription } from '../lib/services'

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import type { LocalDaemon, NotificationConfig, PendingGroup, TelegramGroup } from '../api/client'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router'
 import { api, APIError } from '../api/client'
 import { useAuth } from '../hooks/useAuth'
 import { QRCodeSVG } from 'qrcode.react'

--- a/web/src/pages/SetupAuth.tsx
+++ b/web/src/pages/SetupAuth.tsx
@@ -1,5 +1,5 @@
 import { useState, FormEvent } from 'react'
-import { useNavigate, useLocation } from 'react-router-dom'
+import { useNavigate, useLocation } from 'react-router'
 import { api, setAccessToken, type AuthResponse } from '../api/client'
 import { useAuth } from '../hooks/useAuth'
 import { isWebAuthnAvailable, startRegistration } from '../lib/webauthn'

--- a/web/src/pages/TOTPVerify.tsx
+++ b/web/src/pages/TOTPVerify.tsx
@@ -1,5 +1,5 @@
 import { useState, FormEvent } from 'react'
-import { useNavigate, useLocation } from 'react-router-dom'
+import { useNavigate, useLocation } from 'react-router'
 import { api } from '../api/client'
 import { useAuth } from '../hooks/useAuth'
 import { nextAfterAuth } from '../lib/nextAfterAuth'

--- a/web/src/pages/Tasks.tsx
+++ b/web/src/pages/Tasks.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { useSearchParams, Link } from 'react-router-dom'
+import { useSearchParams, Link } from 'react-router'
 import { api, APIError, type Agent } from '../api/client'
 import { useAuth } from '../hooks/useAuth'
 import TaskCard from '../components/TaskCard'

--- a/web/src/pages/VerifyEmail.tsx
+++ b/web/src/pages/VerifyEmail.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { Link, useNavigate, useSearchParams } from 'react-router-dom'
+import { Link, useNavigate, useSearchParams } from 'react-router'
 import { api, APIError } from '../api/client'
 import { useAuth } from '../hooks/useAuth'
 

--- a/web/src/pages/Waitlist.tsx
+++ b/web/src/pages/Waitlist.tsx
@@ -1,5 +1,5 @@
 import { useState, FormEvent } from 'react'
-import { Link, useSearchParams } from 'react-router-dom'
+import { Link, useSearchParams } from 'react-router'
 import { api, APIError } from '../api/client'
 
 export default function Waitlist() {

--- a/web/src/pages/Welcome.tsx
+++ b/web/src/pages/Welcome.tsx
@@ -1,4 +1,4 @@
-import { Navigate, useNavigate } from 'react-router-dom'
+import { Navigate, useNavigate } from 'react-router'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { api } from '../api/client'
 


### PR DESCRIPTION
Clears the three open react-router CVEs. **Upgrading is the only remediation** — this cannot be fixed with a bump on 6.x.

| CVE | First patched | Available on 6.x? |
|---|---|---|
| CVE-2026-53666 — ctor injection via `deserializeErrors()` (SSR hydration) | 7.18.0 | ✗ |
| CVE-2026-53668 — open redirect leading to XSS | **none** | ✗ no patch on any branch |
| CVE-2026-53669 — open redirect via backslash in `<Link>`/`useNavigate` | 7.18.0 | ✗ |

`6.30.4` is the newest 6.x release that exists; the branch is no longer receiving security fixes.

### Scope

v7 folds the DOM exports into `react-router` and leaves `react-router-dom` as a compatibility re-export, so this moves imports to `react-router` and drops the deprecated package rather than carrying both. 35 source files, import lines only — no logic changes.

The migration is mechanical because the app uses **declarative routing only**. All ten imported symbols (`BrowserRouter`, `Routes`, `Route`, `Link`, `NavLink`, `Navigate`, `useLocation`, `useNavigate`, `useParams`, `useSearchParams`) exist unchanged in v7, and there are no data-router APIs — no `createBrowserRouter`, `RouterProvider`, loaders, actions or `useLoaderData` — so the framework-mode breaking changes don't apply.

### The two behavioural flags, checked rather than assumed

- **`v7_relativeSplatPath`** — changes relative resolution inside splat routes. There *is* a splat route at `/dashboard/*`, but every `to=` and `navigate()` in the app is absolute or a variable; there is no relative navigation anywhere, so resolution is unaffected.
- **`v7_startTransition`** — wraps router updates in `React.startTransition`. The app has no `React.lazy` and no `Suspense` boundaries, so there's nothing to suspend on.

React stays at **18.3.1**, which satisfies v7's floor. No React upgrade needed.

### Verification

Against the real production bundle, not just types — the built `dist` served by the Go server was driven in a browser:

- `tsc --noEmit` pass, `vite build` pass
- `npm audit --omit=dev` → **0 vulnerabilities**
- `/` → `/login` (`<Navigate>` redirect) ✅
- `<Link>` click → `/register`, SPA instance survived, so genuinely client-side ✅
- browser back → `/login` ✅
- deep splat route `/dashboard/agents` → still hits the auth guard and redirects ✅
- zero console errors / unhandled rejections

### Not addressed

One **dev-only** advisory remains: `nanoid` via `postcss` (GHSA-2v37-7h3g-55p8). Not in the production tree; left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

