### PR TITLE
Make the free-tier welcome screen reachable again

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1218,6 +1218,14 @@ export interface BillingStatus {
   current_period_start?: string
   current_period_end?: string
   cancel_at_period_end?: boolean
+  /**
+   * When the account dismissed the first-signup free-tier explainer, or null
+   * if it never has. `undefined` means the deployment doesn't track it (the
+   * no-Stripe fallback), which is NOT the same as "never seen": only an
+   * explicit null may route a user to /welcome, because only a deployment
+   * that reports the key has an endpoint to stamp it with.
+   */
+  splash_seen_at?: string | null
   stripe_publishable_key?: string
   usage?: {
     requests: { used: number; limit: number }
@@ -2148,6 +2156,9 @@ export const api = {
       post<PromoValidation>('/api/billing/promo/validate', { code }),
     activateFreeTier: () =>
       post<{ status: string }>('/api/billing/activate', {}),
+    /** Stamps splash_seen_at so the dashboard stops routing to /welcome. */
+    markSplashSeen: () =>
+      post<{ status: string }>('/api/billing/splash-seen', {}),
   },
   oauthApprove: (params: {
     client_id: string

--- a/web/src/hooks/useAuth.tsx
+++ b/web/src/hooks/useAuth.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, createContext, useContext, useRef, type ReactNode } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import { APIError, api, setAccessToken, setRefreshCallback, setCurrentOrgId, type User, type FeatureSet, type LoginResult, type RegisterResult, type Org } from '../api/client'
 
 const CURRENT_ORG_KEY = 'clawvisor_current_org'
@@ -38,6 +39,7 @@ interface AuthContextValue {
 const AuthContext = createContext<AuthContextValue | null>(null)
 
 export function AuthProvider({ children }: { children: ReactNode }) {
+  const queryClient = useQueryClient()
   const [user, setUser] = useState<User | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [authMode, setAuthMode] = useState<'magic_link' | 'password' | 'passkey' | null>(null)
@@ -200,7 +202,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setCurrentOrgState(null)
     setUser(null)
     setOnboardingComplete(null)
-  }, [])
+    // Drop every cached query. The cache keys are user-agnostic ('billing-status',
+    // 'orgs', …) and there is no page reload between sessions, so without this a
+    // second account signing in on the same tab reads the first one's plan, usage
+    // and saved card — and, since splash_seen_at rides on billing status, skips
+    // the free-tier welcome screen it has never actually seen.
+    queryClient.clear()
+  }, [queryClient])
 
   return (
     <AuthContext.Provider value={{ user, isLoading, isAuthenticated: user !== null, authMode, features, currentOrg, setCurrentOrg, onboardingComplete, refreshOnboarding, login, register, logout, setSession }}>

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -158,20 +158,25 @@ export default function Dashboard() {
   })
   const hasOrg = (memberships?.length ?? 0) > 0
 
-  // Redirect to welcome page only if the user has no billing setup AND
-  // isn't already an org member. Wait for both queries before deciding
-  // — without the loading guard, the redirect can fire on first paint
-  // before memberships have loaded, sending an invited user to the
-  // plan picker by mistake. Also bail if the /api/orgs lookup errored:
-  // treating a failure as "zero memberships" would route org-only users
-  // (who have no personal billing) to the plan picker by mistake.
+  // Show the free-tier explainer once, to accounts that have never seen it and
+  // aren't already org members. Wait for both queries before deciding —
+  // without the loading guard, the redirect can fire on first paint before
+  // memberships have loaded, sending an invited user to the welcome screen by
+  // mistake. Also bail if the /api/orgs lookup errored: treating a failure as
+  // "zero memberships" would route org-only users there by mistake.
+  //
+  // The gate is splash_seen_at, NOT the old `status === 'none' && plan ===
+  // 'none'` test. The server now seeds a Free subscription on the first status
+  // read, so that condition became permanently false and this whole screen was
+  // unreachable dead code. `=== null` is deliberately strict: a deployment
+  // without Stripe omits the key entirely and has no endpoint to stamp it, so
+  // `undefined` must not redirect or the user gets stuck in a loop.
   if (
     billingEnabled &&
     !billingLoading &&
     !membershipsLoading &&
     !membershipsErrored &&
-    billingStatus?.status === 'none' &&
-    billingStatus?.plan === 'none' &&
+    billingStatus?.splash_seen_at === null &&
     !hasOrg
   ) {
     return <Navigate to="/welcome" replace />

--- a/web/src/pages/Welcome.tsx
+++ b/web/src/pages/Welcome.tsx
@@ -23,7 +23,6 @@ export default function Welcome() {
   const { data: plansData, isLoading: plansLoading } = useQuery({
     queryKey: ['billing-plans'],
     queryFn: () => api.billing.plans(),
-    staleTime: 3600_000,
   })
 
   // Org members shouldn't see the personal free-tier explainer — they're
@@ -108,7 +107,7 @@ export default function Welcome() {
               <li className="flex items-center gap-2">
                 {checkIcon}
                 {plansLoading ? (
-                  <span className="h-4 w-56 rounded bg-surface-2 animate-pulse" aria-hidden="true" />
+                  <span className="inline-block h-4 w-56 rounded bg-surface-2 animate-pulse" aria-hidden="true" />
                 ) : (
                   requestsLine
                 )}

--- a/web/src/pages/Welcome.tsx
+++ b/web/src/pages/Welcome.tsx
@@ -2,18 +2,32 @@ import { Navigate, useNavigate } from 'react-router'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { api } from '../api/client'
 
+const checkIcon = (
+  <svg className="w-4 h-4 text-success shrink-0" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+    <path d="M20 6L9 17l-5-5" />
+  </svg>
+)
+
 export default function Welcome() {
   const navigate = useNavigate()
   const qc = useQueryClient()
 
-  // If the user already has an active plan (e.g. grandfathered), skip welcome.
   const { data: billingStatus, isLoading } = useQuery({
     queryKey: ['billing-status'],
     queryFn: () => api.billing.status(),
   })
 
-  // Org members shouldn't see the personal plan-picker — they're already
-  // on the org's billing, so bounce them back to the dashboard.
+  // Every number on this page comes from the pricing API. Hardcoding them is
+  // how a "$120 advertised / $150 charged" mismatch shipped once already —
+  // this screen and /pricing must never be able to disagree.
+  const { data: plansData, isLoading: plansLoading } = useQuery({
+    queryKey: ['billing-plans'],
+    queryFn: () => api.billing.plans(),
+    staleTime: 3600_000,
+  })
+
+  // Org members shouldn't see the personal free-tier explainer — they're
+  // already on the org's billing, so bounce them back to the dashboard.
   const { data: memberships, isLoading: membershipsLoading } = useQuery({
     queryKey: ['orgs'],
     queryFn: () => api.orgs.list(),
@@ -21,18 +35,18 @@ export default function Welcome() {
   })
   const hasOrg = (memberships?.length ?? 0) > 0
 
-  const activateMut = useMutation({
-    mutationFn: () => api.billing.activateFreeTier(),
+  const dismissMut = useMutation({
+    mutationFn: () => api.billing.markSplashSeen(),
     onSuccess: async () => {
       await qc.invalidateQueries({ queryKey: ['billing-status'] })
       navigate('/dashboard')
     },
   })
 
-  // Hold the entire page until both queries resolve. Otherwise an org
-  // member could briefly see (and click) the personal "Activate free
-  // tier" button while their memberships query was still in flight,
-  // which mints a personal plan they shouldn't have.
+  // Hold the page until billing status and memberships resolve, so an org
+  // member never sees a personal plan screen flash by. Plans are allowed to
+  // still be in flight — the copy below degrades to figure-free wording
+  // rather than blocking the whole screen on a cacheable public endpoint.
   if (isLoading || membershipsLoading) {
     return (
       <div className="min-h-screen bg-surface-0 flex items-center justify-center">
@@ -44,12 +58,31 @@ export default function Welcome() {
       </div>
     )
   }
-  if (billingStatus && billingStatus.status !== 'none') {
+  // Strictly `!== null`: an already-dismissed account has a timestamp, and a
+  // deployment that doesn't track the stamp reports undefined. Neither should
+  // be held on this screen.
+  if (billingStatus && billingStatus.splash_seen_at !== null) {
     return <Navigate to="/dashboard" replace />
   }
   if (hasOrg) {
     return <Navigate to="/dashboard" replace />
   }
+
+  const freePlan = plansData?.plans.find((p) => p.name === 'free')
+  const proPlan = plansData?.plans.find((p) => p.name === 'pro')
+  // Read Pro's price off the monthly option, the cadence the upgrade button
+  // defaults to. The annual option's per_month_cents is a different (lower)
+  // number and quoting it here would under-advertise the default purchase.
+  const proMonthlyCents =
+    proPlan?.prices?.find((o) => o.interval === 'month')?.per_month_cents ?? proPlan?.monthly_price
+
+  const includedRequests = freePlan?.included_requests
+  const requestsLine =
+    includedRequests === undefined
+      ? 'A monthly request allowance, then top up with request packs'
+      : includedRequests < 0
+        ? 'Unlimited requests'
+        : `${includedRequests.toLocaleString()} requests/month, then top up with request packs`
 
   return (
     <div className="min-h-screen bg-surface-0 flex items-center justify-center">
@@ -60,7 +93,7 @@ export default function Welcome() {
           </div>
           <h1 className="text-2xl font-bold text-text-primary">Welcome to Clawvisor</h1>
           <p className="text-text-secondary mt-2">
-            Get started for free. No credit card required.
+            You're on the free plan. No credit card required.
           </p>
         </div>
 
@@ -69,36 +102,42 @@ export default function Welcome() {
             <h3 className="text-sm font-semibold text-text-primary">Your free plan includes:</h3>
             <ul className="space-y-2 text-sm text-text-secondary">
               <li className="flex items-center gap-2">
-                <svg className="w-4 h-4 text-success shrink-0" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M20 6L9 17l-5-5" /></svg>
+                {checkIcon}
                 Unlimited connections
               </li>
               <li className="flex items-center gap-2">
-                <svg className="w-4 h-4 text-success shrink-0" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M20 6L9 17l-5-5" /></svg>
-                1,000 requests/month, then top up with request packs
+                {checkIcon}
+                {plansLoading ? (
+                  <span className="h-4 w-56 rounded bg-surface-2 animate-pulse" aria-hidden="true" />
+                ) : (
+                  requestsLine
+                )}
               </li>
               <li className="flex items-center gap-2">
-                <svg className="w-4 h-4 text-success shrink-0" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path d="M20 6L9 17l-5-5" /></svg>
+                {checkIcon}
                 Free forever, upgrade anytime
               </li>
             </ul>
           </div>
 
           <button
-            onClick={() => activateMut.mutate()}
-            disabled={activateMut.isPending}
+            onClick={() => dismissMut.mutate()}
+            disabled={dismissMut.isPending}
             className="w-full py-2.5 px-4 rounded-md bg-brand text-surface-0 text-sm font-medium hover:bg-brand-strong transition-colors disabled:opacity-70"
           >
-            {activateMut.isPending ? 'Activating...' : 'Get started'}
+            {dismissMut.isPending ? 'One moment...' : 'Get started'}
           </button>
 
-          {activateMut.isError && (
+          {dismissMut.isError && (
             <p className="text-xs text-danger text-center">Something went wrong. Please try again.</p>
           )}
         </div>
 
-        <p className="text-center text-xs text-text-tertiary mt-4">
-          Need more? Upgrade to Pro from $120/month.
-        </p>
+        {proMonthlyCents !== undefined && (
+          <p className="text-center text-xs text-text-tertiary mt-4">
+            Need more? Upgrade to Pro from ${(proMonthlyCents / 100).toFixed(0)}/month.
+          </p>
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
## The regression

`Dashboard.tsx` sent new users to `/welcome` only when the billing status reported:

```ts
billingStatus?.status === 'none' && billingStatus?.plan === 'none'
```

The cloud's `EnsureFreeSubscription` change made `GET /api/billing/status` create a Free
subscription row on the first read, so it never returns `none` again. `/welcome` has been
unreachable dead code since that deploy, and every account created since landed on the
dashboard with no explanation of the free tier.

## The fix

Gate on the server-side `splash_seen_at` stamp (new; see the cloud-side PR) rather than a
plan value. A server stamp survives a new device and a cleared browser, unlike the
localStorage pattern `OnboardingBanner` uses.

The check is strictly `=== null`. A deployment without Stripe omits the key entirely and
has no endpoint to stamp it, so an `undefined` must not redirect — otherwise those users
land on a screen they can never dismiss.

## Welcome.tsx no longer hardcodes prices

It read "1,000 requests/month" and "from $120/month" from string literals. Those figures
now come from `api.billing.plans()` — the free plan's `included_requests` and Pro's
monthly `prices[]` option — so this screen and `/pricing` cannot disagree. Hardcoding is
how a "$120 advertised / $150 charged" mismatch shipped once already.

Pro's figure is read off the **monthly** price option specifically: the annual option's
`per_month_cents` is lower, and quoting it would under-advertise the default purchase
path. If the plans query hasn't resolved or a plan is missing, the copy degrades to
figure-free wording rather than inventing a number.

Also drops the now-redundant `activateFreeTier()` call — the server seeds the Free plan
itself. The screen stays a full page (there is no shared Modal component; `ModalShell` is
private to `OrgNotifications.tsx`).

## Third commit: clearing the query cache on logout

The React Query cache keys are user-agnostic (`billing-status`, `orgs`, …) and logout
neither clears them nor reloads the page, so a second account signing in on the same tab
within the freshness window reads the first account's plan, usage and saved card. Already
wrong; now also a correctness problem for this screen, since `splash_seen_at` rides on the
billing status. `queryClient.clear()` in `logout()` fixes it.

## Verification

Driven in a real browser (CDP) against a stubbed API, all four cases:

| case | result |
|---|---|
| `splash_seen_at: null` → `/dashboard` | redirects to `/welcome` |
| key absent (no-Stripe deployment) → `/dashboard` | stays on `/dashboard` |
| dismiss | one `POST /api/billing/splash-seen`, then `/dashboard`, no bounce back |
| stamped → `/dashboard` | stays |

The stub advertised Pro at **$150/month**, and the page rendered $150 — confirming the
figure comes from the API and not the old hardcoded $120. Free's "1,000" likewise came
from `included_requests`.

The logout fix was checked with a positive control: with `queryClient.clear()` removed, an
account that has never seen the splash lands on `/dashboard` after signing in behind a
stamped account; with it, `/welcome`.

`npx tsc --noEmit` and `npm run build` are clean.

Requires the cloud-side `splash_seen_at` change to be deployed; until then the key is
absent and this page simply never shows, which is the current behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)