### PR TITLE
feat(calendar): support versioned approval mutations

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ All three LLM subsystems (intent verification, chain context extraction, and tas
 | Service ID | Service | Actions |
 |---|---|---|
 | `google.gmail` | Gmail | `list_messages`, `get_message`, `send_message` |
-| `google.calendar` | Google Calendar | `list_events`, `get_event`, `create_event`, `update_event`, `delete_event`, `list_calendars` |
+| `google.calendar` | Google Calendar | `list_events`, `get_event`, `create_event`, `update_event`, `respond_to_event`, `delete_event`, `list_calendars` |
 | `google.drive` | Google Drive | `list_files`, `get_file`, `create_file`, `update_file`, `search_files` |
 | `google.contacts` | Google Contacts | `list_contacts`, `get_contact`, `search_contacts` |
 | `microsoft.outlook` | Outlook | `list_messages`, `get_message`, `send_message`, `list_events`, `get_event`, `create_event` |

--- a/internal/adapters/definitions/google_calendar.yaml
+++ b/internal/adapters/definitions/google_calendar.yaml
@@ -90,12 +90,14 @@ actions:
     display_name: "Get event"
     risk: { category: read, sensitivity: low, description: "Read a specific calendar event" }
     scopes: ["https://www.googleapis.com/auth/calendar.readonly"]
+    # The Go override captures the provider ETag from both the event resource
+    # and HTTP response headers, and fails closed when neither is present.
+    override: go
     method: GET
     path: "/calendars/{{.calendar_id}}/events/{{.event_id}}"
     params:
       event_id: { type: string, required: true, location: path }
       calendar_id: { type: string, default: "primary", location: path }
-      supports_attachments: { type: bool, default: true, map_to: supportsAttachments, location: query }
     response:
       fields:
         - { name: id }
@@ -118,6 +120,10 @@ actions:
         - name: visibility
           expr: "visibility ?? 'default'"
         - { name: status }
+        - { name: etag }
+        - { name: version }
+        - { name: sequence }
+        - { name: response_status, optional: true }
       summary: "Event: {{.summary}}"
 
   create_event:
@@ -165,13 +171,24 @@ actions:
     display_name: "Update event"
     risk: { category: write, sensitivity: medium, description: "Update a calendar event" }
     scopes: ["https://www.googleapis.com/auth/calendar.events"]
+    # The Go override sends expected_etag as If-Match on the PATCH and
+    # classifies stale and indeterminate provider outcomes.
+    override: go
     method: PATCH
     path: "/calendars/{{.calendar_id}}/events/{{.event_id}}"
     body_mode: sparse
     params:
       event_id: { type: string, required: true, location: path }
       calendar_id: { type: string, default: "primary", location: path }
-      send_updates: { type: string, default: "none", location: query, map_to: sendUpdates }
+      expected_etag:
+        type: string
+        required: true
+        aliases: [expected_version]
+        description: "Exact provider etag/version returned by get_event; used as an If-Match precondition"
+      send_updates:
+        type: string
+        default: "none"
+        description: "Google notification mode: all, externalOnly, or none"
       summary: { type: string, location: body }
       description: { type: string, location: body }
       location: { type: string, location: body }
@@ -199,7 +216,45 @@ actions:
       fields:
         - { name: id, rename: event_id }
         - { name: summary }
+        - { name: etag }
+        - { name: version }
+        - { name: send_updates }
       summary: "Updated event: {{.summary}}"
+
+  respond_to_event:
+    display_name: "Respond to event"
+    risk: { category: write, sensitivity: medium, description: "Accept, decline, or tentatively accept a calendar invitation" }
+    scopes: ["https://www.googleapis.com/auth/calendar.events"]
+    # Google requires a pre-read to identify attendees[].self. The Go
+    # override then PATCHes only that attendee with attendeesOmitted=true and
+    # retains the approved version as an If-Match precondition.
+    override: go
+    method: PATCH
+    path: "/calendars/{{.calendar_id}}/events/{{.event_id}}"
+    params:
+      event_id: { type: string, required: true, location: path }
+      calendar_id: { type: string, default: "primary", location: path }
+      expected_etag:
+        type: string
+        required: true
+        aliases: [expected_version]
+        description: "Exact provider etag/version returned by get_event; used as an If-Match precondition"
+      response_status:
+        type: string
+        required: true
+        description: "RSVP response: accepted, declined, or tentative"
+      send_updates:
+        type: string
+        default: "none"
+        description: "Google notification mode: all, externalOnly, or none"
+    response:
+      fields:
+        - { name: id, rename: event_id }
+        - { name: response_status }
+        - { name: etag }
+        - { name: version }
+        - { name: send_updates }
+      summary: "Responded {{.response_status}} to event {{.event_id}}"
 
   delete_event:
     display_name: "Delete event"

--- a/internal/adapters/definitions/google_calendar_test.go
+++ b/internal/adapters/definitions/google_calendar_test.go
@@ -1,0 +1,58 @@
+package definitions
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/pkg/adapters/yamldef"
+	"github.com/clawvisor/clawvisor/pkg/adapters/yamlvalidate"
+	"gopkg.in/yaml.v3"
+)
+
+func TestGoogleCalendarVersionedActionDefinitions(t *testing.T) {
+	contents, err := FS.ReadFile("google_calendar.yaml")
+	if err != nil {
+		t.Fatalf("read Calendar definition: %v", err)
+	}
+
+	var definition yamldef.ServiceDef
+	if err := yaml.Unmarshal(contents, &definition); err != nil {
+		t.Fatalf("parse Calendar definition: %v", err)
+	}
+	if validation := yamlvalidate.Validate(&definition); !validation.OK() {
+		t.Fatalf("Calendar definition validation errors: %v", validation.Errors)
+	}
+
+	getEvent := definition.Actions["get_event"]
+	if getEvent.Override != "go" {
+		t.Fatalf("get_event override = %q, want go", getEvent.Override)
+	}
+	var responseFields []string
+	for _, field := range getEvent.Response.Fields {
+		responseFields = append(responseFields, field.Name)
+	}
+	for _, want := range []string{"etag", "version", "sequence"} {
+		if !slices.Contains(responseFields, want) {
+			t.Errorf("get_event response is missing %q", want)
+		}
+	}
+
+	for _, actionName := range []string{"update_event", "respond_to_event"} {
+		action, ok := definition.Actions[actionName]
+		if !ok {
+			t.Fatalf("Calendar catalog is missing %s", actionName)
+		}
+		if action.Override != "go" {
+			t.Errorf("%s override = %q, want go", actionName, action.Override)
+		}
+		expected := action.Params["expected_etag"]
+		if !expected.Required || !slices.Contains(expected.Aliases, "expected_version") {
+			t.Errorf("%s expected_etag schema = %+v, want required with expected_version alias", actionName, expected)
+		}
+	}
+
+	responseStatus := definition.Actions["respond_to_event"].Params["response_status"]
+	if !responseStatus.Required || responseStatus.Type != "string" {
+		t.Errorf("respond_to_event response_status schema = %+v, want required string", responseStatus)
+	}
+}

--- a/internal/adapters/google/calendar/adapter.go
+++ b/internal/adapters/google/calendar/adapter.go
@@ -61,7 +61,12 @@ func (a *CalendarAdapter) OAuthConfig() *oauth2.Config {
 }
 
 func (a *CalendarAdapter) OAuthConfigForAlias(alias string) *oauth2.Config {
-	return credential.OAuthConfigForAlias(a.OAuthConfig(), alias)
+	config := credential.OAuthConfigForAlias(a.OAuthConfig(), alias)
+	if config != nil {
+		config.Scopes = calendarScopes
+		config.Endpoint = google.Endpoint
+	}
+	return config
 }
 
 func (a *CalendarAdapter) CredentialFromToken(token *oauth2.Token) ([]byte, error) {
@@ -74,7 +79,7 @@ func (a *CalendarAdapter) ValidateCredential(credBytes []byte) error {
 
 // FetchIdentity returns the Google account email for auto-alias detection.
 func (a *CalendarAdapter) FetchIdentity(ctx context.Context, credBytes []byte, config map[string]string) (string, error) {
-	client, err := a.httpClient(ctx, credBytes, config)
+	client, err := a.httpClient(ctx, credBytes, "")
 	if err != nil {
 		return "", err
 	}
@@ -82,7 +87,7 @@ func (a *CalendarAdapter) FetchIdentity(ctx context.Context, credBytes []byte, c
 }
 
 func (a *CalendarAdapter) Execute(ctx context.Context, req adapters.Request) (*adapters.Result, error) {
-	client, err := a.httpClient(ctx, req.Credential, req.Config)
+	client, err := a.httpClient(ctx, req.Credential, req.Alias)
 	if err != nil {
 		return nil, err
 	}
@@ -106,13 +111,13 @@ func (a *CalendarAdapter) Execute(ctx context.Context, req adapters.Request) (*a
 	}
 }
 
-func (a *CalendarAdapter) httpClient(ctx context.Context, credBytes []byte, config map[string]string) (*http.Client, error) {
+func (a *CalendarAdapter) httpClient(ctx context.Context, credBytes []byte, alias string) (*http.Client, error) {
 	cred, err := credential.Parse(credBytes)
 	if err != nil {
 		return nil, fmt.Errorf("calendar: %w", err)
 	}
 	oauthConfig := cred.OAuthConfig(
-		a.OAuthConfigForAlias(config["_clawvisor_alias"]),
+		a.OAuthConfigForAlias(alias),
 	)
 	ts := oauthConfig.TokenSource(ctx, cred.ToOAuth2Token())
 	return oauth2.NewClient(ctx, ts), nil

--- a/internal/adapters/google/calendar/adapter.go
+++ b/internal/adapters/google/calendar/adapter.go
@@ -119,6 +119,11 @@ func (a *CalendarAdapter) httpClient(ctx context.Context, credBytes []byte, alia
 	oauthConfig := cred.OAuthConfig(
 		a.OAuthConfigForAlias(alias),
 	)
+	if oauthConfig == nil {
+		return nil, fmt.Errorf("calendar: OAuth client credentials not configured")
+	}
+	oauthConfig.Scopes = calendarScopes
+	oauthConfig.Endpoint = google.Endpoint
 	ts := oauthConfig.TokenSource(ctx, cred.ToOAuth2Token())
 	return oauth2.NewClient(ctx, ts), nil
 }

--- a/internal/adapters/google/calendar/adapter.go
+++ b/internal/adapters/google/calendar/adapter.go
@@ -111,7 +111,9 @@ func (a *CalendarAdapter) httpClient(ctx context.Context, credBytes []byte, conf
 	if err != nil {
 		return nil, fmt.Errorf("calendar: %w", err)
 	}
-	oauthConfig := a.OAuthConfigForAlias(config["_clawvisor_alias"])
+	oauthConfig := cred.OAuthConfig(
+		a.OAuthConfigForAlias(config["_clawvisor_alias"]),
+	)
 	ts := oauthConfig.TokenSource(ctx, cred.ToOAuth2Token())
 	return oauth2.NewClient(ctx, ts), nil
 }

--- a/internal/adapters/google/calendar/adapter.go
+++ b/internal/adapters/google/calendar/adapter.go
@@ -292,8 +292,9 @@ func (a *CalendarAdapter) getEvent(ctx context.Context, client *http.Client, par
 	}
 
 	event := calendarEventData(item, version)
+	summary, _ := event["summary"].(string)
 	return &adapters.Result{
-		Summary: format.Summary("Event: %s on %s", item.Summary, event["start"]),
+		Summary: format.Summary("Event: %s", summary),
 		Data:    event,
 	}, nil
 }

--- a/internal/adapters/google/calendar/adapter.go
+++ b/internal/adapters/google/calendar/adapter.go
@@ -60,6 +60,10 @@ func (a *CalendarAdapter) OAuthConfig() *oauth2.Config {
 	}
 }
 
+func (a *CalendarAdapter) OAuthConfigForAlias(alias string) *oauth2.Config {
+	return credential.OAuthConfigForAlias(a.OAuthConfig(), alias)
+}
+
 func (a *CalendarAdapter) CredentialFromToken(token *oauth2.Token) ([]byte, error) {
 	return credential.FromToken(token, calendarScopes, false)
 }
@@ -69,8 +73,8 @@ func (a *CalendarAdapter) ValidateCredential(credBytes []byte) error {
 }
 
 // FetchIdentity returns the Google account email for auto-alias detection.
-func (a *CalendarAdapter) FetchIdentity(ctx context.Context, credBytes []byte, _ map[string]string) (string, error) {
-	client, err := a.httpClient(ctx, credBytes)
+func (a *CalendarAdapter) FetchIdentity(ctx context.Context, credBytes []byte, config map[string]string) (string, error) {
+	client, err := a.httpClient(ctx, credBytes, config)
 	if err != nil {
 		return "", err
 	}
@@ -78,7 +82,7 @@ func (a *CalendarAdapter) FetchIdentity(ctx context.Context, credBytes []byte, _
 }
 
 func (a *CalendarAdapter) Execute(ctx context.Context, req adapters.Request) (*adapters.Result, error) {
-	client, err := a.httpClient(ctx, req.Credential)
+	client, err := a.httpClient(ctx, req.Credential, req.Config)
 	if err != nil {
 		return nil, err
 	}
@@ -102,12 +106,13 @@ func (a *CalendarAdapter) Execute(ctx context.Context, req adapters.Request) (*a
 	}
 }
 
-func (a *CalendarAdapter) httpClient(ctx context.Context, credBytes []byte) (*http.Client, error) {
+func (a *CalendarAdapter) httpClient(ctx context.Context, credBytes []byte, config map[string]string) (*http.Client, error) {
 	cred, err := credential.Parse(credBytes)
 	if err != nil {
 		return nil, fmt.Errorf("calendar: %w", err)
 	}
-	ts := a.OAuthConfig().TokenSource(ctx, cred.ToOAuth2Token())
+	oauthConfig := a.OAuthConfigForAlias(config["_clawvisor_alias"])
+	ts := oauthConfig.TokenSource(ctx, cred.ToOAuth2Token())
 	return oauth2.NewClient(ctx, ts), nil
 }
 

--- a/internal/adapters/google/calendar/adapter.go
+++ b/internal/adapters/google/calendar/adapter.go
@@ -802,12 +802,20 @@ func calendarAttendeePatch(raw any) ([]map[string]string, error) {
 	}
 	attendees := make([]map[string]string, 0, len(values))
 	for _, rawValue := range values {
-		email, ok := rawValue.(string)
+		var email string
+		switch attendee := rawValue.(type) {
+		case string:
+			email = attendee
+		case map[string]any:
+			email, _ = attendee["email"].(string)
+		case map[string]string:
+			email = attendee["email"]
+		}
 		email = strings.TrimSpace(email)
-		if !ok || email == "" {
+		if email == "" {
 			return nil, &adapters.ExecutionFailure{
 				Kind: adapters.ExecutionFailureDefinite,
-				Err:  fmt.Errorf("attendees must contain non-empty email strings"),
+				Err:  fmt.Errorf("attendees must contain non-empty email strings or email objects"),
 			}
 		}
 		attendees = append(attendees, map[string]string{"email": email})

--- a/internal/adapters/google/calendar/adapter.go
+++ b/internal/adapters/google/calendar/adapter.go
@@ -4,8 +4,10 @@ package calendar
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -40,7 +42,7 @@ func New(provider adapters.OAuthCredentialProvider) *CalendarAdapter {
 func (a *CalendarAdapter) ServiceID() string { return serviceID }
 
 func (a *CalendarAdapter) SupportedActions() []string {
-	return []string{"list_events", "get_event", "create_event", "update_event", "delete_event", "list_calendars"}
+	return []string{"list_events", "get_event", "create_event", "update_event", "respond_to_event", "delete_event", "list_calendars"}
 }
 
 func (a *CalendarAdapter) RequiredScopes() []string { return calendarScopes }
@@ -89,6 +91,8 @@ func (a *CalendarAdapter) Execute(ctx context.Context, req adapters.Request) (*a
 		return a.createEvent(ctx, client, req.Params)
 	case "update_event":
 		return a.updateEvent(ctx, client, req.Params)
+	case "respond_to_event":
+		return a.respondToEvent(ctx, client, req.Params)
 	case "delete_event":
 		return a.deleteEvent(ctx, client, req.Params)
 	case "list_calendars":
@@ -118,6 +122,50 @@ type calendarEvent struct {
 	Description string   `json:"description,omitempty"`
 	Attendees   []string `json:"attendees,omitempty"`
 	Status      string   `json:"status"`
+}
+
+type calendarAPIDateTime struct {
+	DateTime string `json:"dateTime"`
+	Date     string `json:"date"`
+	TimeZone string `json:"timeZone"`
+}
+
+type calendarAPIAttendee struct {
+	Email            string `json:"email"`
+	DisplayName      string `json:"displayName"`
+	ResponseStatus   string `json:"responseStatus"`
+	Comment          string `json:"comment"`
+	Self             bool   `json:"self"`
+	Organizer        bool   `json:"organizer"`
+	Optional         bool   `json:"optional"`
+	Resource         bool   `json:"resource"`
+	AdditionalGuests int    `json:"additionalGuests"`
+}
+
+type calendarAPIAttachment struct {
+	FileURL  string `json:"fileUrl"`
+	Title    string `json:"title"`
+	MimeType string `json:"mimeType"`
+	IconLink string `json:"iconLink"`
+	FileID   string `json:"fileId"`
+}
+
+type calendarAPIEvent struct {
+	ID             string                  `json:"id"`
+	ETag           string                  `json:"etag"`
+	Sequence       int64                   `json:"sequence"`
+	Summary        string                  `json:"summary"`
+	Location       string                  `json:"location"`
+	Description    string                  `json:"description"`
+	Status         string                  `json:"status"`
+	Transparency   string                  `json:"transparency"`
+	Visibility     string                  `json:"visibility"`
+	HangoutLink    string                  `json:"hangoutLink"`
+	Start          calendarAPIDateTime     `json:"start"`
+	End            calendarAPIDateTime     `json:"end"`
+	Attendees      []calendarAPIAttendee   `json:"attendees"`
+	Attachments    []calendarAPIAttachment `json:"attachments"`
+	RecurringEvent string                  `json:"recurringEventId"`
 }
 
 func (a *CalendarAdapter) listEvents(ctx context.Context, client *http.Client, params map[string]any) (*adapters.Result, error) {
@@ -230,57 +278,22 @@ func (a *CalendarAdapter) getEvent(ctx context.Context, client *http.Client, par
 	apiURL := fmt.Sprintf("https://www.googleapis.com/calendar/v3/calendars/%s/events/%s",
 		url.PathEscape(calendarID), url.PathEscape(eventID))
 
-	var item struct {
-		ID          string `json:"id"`
-		Summary     string `json:"summary"`
-		Location    string `json:"location"`
-		Description string `json:"description"`
-		Status      string `json:"status"`
-		Start       struct {
-			DateTime string `json:"dateTime"`
-			Date     string `json:"date"`
-		} `json:"start"`
-		End struct {
-			DateTime string `json:"dateTime"`
-			Date     string `json:"date"`
-		} `json:"end"`
-		Attendees []struct {
-			Email       string `json:"email"`
-			DisplayName string `json:"displayName"`
-		} `json:"attendees"`
-	}
-	if err := apiGET(ctx, client, apiURL, &item); err != nil {
+	var item calendarAPIEvent
+	headers, err := apiGETWithHeaders(ctx, client, apiURL, &item)
+	if err != nil {
 		return nil, fmt.Errorf("calendar get_event: %w", err)
 	}
-
-	startStr := item.Start.DateTime
-	if startStr == "" {
-		startStr = item.Start.Date
-	}
-	endStr := item.End.DateTime
-	if endStr == "" {
-		endStr = item.End.Date
-	}
-	attendees := make([]string, 0, len(item.Attendees))
-	for _, att := range item.Attendees {
-		name := att.DisplayName
-		if name == "" {
-			name = att.Email
+	version := eventVersion(item.ETag, headers.Get("ETag"))
+	if version == "" {
+		return nil, &adapters.ExecutionFailure{
+			Kind: adapters.ExecutionFailureDefinite,
+			Err:  fmt.Errorf("calendar get_event: provider returned no event etag/version"),
 		}
-		attendees = append(attendees, format.SanitizeText(name, format.MaxFieldLen))
 	}
-	event := calendarEvent{
-		ID:          item.ID,
-		Summary:     format.SanitizeText(item.Summary, format.MaxFieldLen),
-		Start:       startStr,
-		End:         endStr,
-		Location:    format.SanitizeText(item.Location, format.MaxFieldLen),
-		Description: format.SanitizeText(item.Description, format.MaxBodyLen),
-		Attendees:   attendees,
-		Status:      item.Status,
-	}
+
+	event := calendarEventData(item, version)
 	return &adapters.Result{
-		Summary: format.Summary("Event: %s on %s", event.Summary, event.Start),
+		Summary: format.Summary("Event: %s on %s", item.Summary, event["start"]),
 		Data:    event,
 	}, nil
 }
@@ -341,6 +354,14 @@ func (a *CalendarAdapter) updateEvent(ctx context.Context, client *http.Client, 
 	if eventID == "" {
 		return nil, fmt.Errorf("calendar update_event: event_id is required")
 	}
+	expectedVersion, err := expectedEventVersion(params)
+	if err != nil {
+		return nil, fmt.Errorf("calendar update_event: %w", err)
+	}
+	sendUpdates, err := calendarSendUpdates(params)
+	if err != nil {
+		return nil, fmt.Errorf("calendar update_event: %w", err)
+	}
 	calendarID := "primary"
 	if v, ok := params["calendar_id"].(string); ok && v != "" {
 		calendarID = v
@@ -353,25 +374,170 @@ func (a *CalendarAdapter) updateEvent(ctx context.Context, client *http.Client, 
 	if v, ok := params["description"].(string); ok {
 		patch["description"] = v
 	}
+	if v, ok := params["location"].(string); ok {
+		patch["location"] = v
+	}
 	if v, ok := params["start"].(string); ok {
 		patch["start"] = calendarDtField(v)
 	}
 	if v, ok := params["end"].(string); ok {
 		patch["end"] = calendarDtField(v)
 	}
+	if raw, ok := params["attendees"]; ok {
+		attendees, attendeeErr := calendarAttendeePatch(raw)
+		if attendeeErr != nil {
+			return nil, fmt.Errorf("calendar update_event: %w", attendeeErr)
+		}
+		patch["attendees"] = attendees
+	}
+	if v, ok := params["transparency"].(string); ok {
+		patch["transparency"] = v
+	}
+	if v, ok := params["visibility"].(string); ok {
+		patch["visibility"] = v
+	}
+	if len(patch) == 0 {
+		return nil, &adapters.ExecutionFailure{
+			Kind: adapters.ExecutionFailureDefinite,
+			Err:  fmt.Errorf("at least one event field is required"),
+		}
+	}
 
 	apiURL := fmt.Sprintf("https://www.googleapis.com/calendar/v3/calendars/%s/events/%s",
 		url.PathEscape(calendarID), url.PathEscape(eventID))
-	var updated struct {
-		ID      string `json:"id"`
-		Summary string `json:"summary"`
-	}
-	if err := apiWrite(ctx, client, http.MethodPatch, apiURL, patch, &updated); err != nil {
+	q := url.Values{}
+	q.Set("sendUpdates", sendUpdates)
+	apiURL += "?" + q.Encode()
+
+	var updated calendarAPIEvent
+	headers, err := apiConditionalWrite(ctx, client, http.MethodPatch, apiURL, expectedVersion, patch, &updated)
+	if err != nil {
 		return nil, fmt.Errorf("calendar update_event: %w", err)
+	}
+	updatedVersion := eventVersion(updated.ETag, headers.Get("ETag"))
+	if updatedVersion == "" {
+		return nil, &adapters.ExecutionFailure{
+			Kind: adapters.ExecutionFailureAmbiguous,
+			Err:  fmt.Errorf("calendar update_event: provider confirmed the mutation but returned no event etag/version"),
+		}
+	}
+	if updated.ID == "" {
+		updated.ID = eventID
 	}
 	return &adapters.Result{
 		Summary: format.Summary("Updated event: %s", updated.Summary),
-		Data:    map[string]string{"event_id": updated.ID, "summary": updated.Summary},
+		Data: map[string]any{
+			"event_id":     updated.ID,
+			"summary":      format.SanitizeText(updated.Summary, format.MaxFieldLen),
+			"etag":         updatedVersion,
+			"version":      updatedVersion,
+			"send_updates": sendUpdates,
+		},
+	}, nil
+}
+
+// ── respond_to_event ──────────────────────────────────────────────────────────
+
+func (a *CalendarAdapter) respondToEvent(ctx context.Context, client *http.Client, params map[string]any) (*adapters.Result, error) {
+	eventID, _ := params["event_id"].(string)
+	if eventID == "" {
+		return nil, fmt.Errorf("calendar respond_to_event: event_id is required")
+	}
+	responseStatus, _ := params["response_status"].(string)
+	switch responseStatus {
+	case "accepted", "declined", "tentative":
+	default:
+		return nil, &adapters.ExecutionFailure{
+			Kind: adapters.ExecutionFailureDefinite,
+			Err:  fmt.Errorf("calendar RSVP must be accepted, declined, or tentative"),
+		}
+	}
+	expectedVersion, err := expectedEventVersion(params)
+	if err != nil {
+		return nil, fmt.Errorf("calendar respond_to_event: %w", err)
+	}
+	sendUpdates, err := calendarSendUpdates(params)
+	if err != nil {
+		return nil, fmt.Errorf("calendar respond_to_event: %w", err)
+	}
+
+	calendarID := "primary"
+	if v, ok := params["calendar_id"].(string); ok && v != "" {
+		calendarID = v
+	}
+	apiURL := fmt.Sprintf("https://www.googleapis.com/calendar/v3/calendars/%s/events/%s",
+		url.PathEscape(calendarID), url.PathEscape(eventID))
+
+	// Google identifies the attendee that represents this calendar with
+	// attendees[].self. Read that participant immediately before the write,
+	// then retain the caller's original ETag as an If-Match precondition on
+	// the PATCH below.
+	var current calendarAPIEvent
+	headers, err := apiGETWithHeaders(ctx, client, apiURL, &current)
+	if err != nil {
+		return nil, &adapters.ExecutionFailure{
+			Kind: adapters.ExecutionFailureDefinite,
+			Err:  fmt.Errorf("calendar respond_to_event pre-read: %w", err),
+		}
+	}
+	currentVersion := eventVersion(current.ETag, headers.Get("ETag"))
+	if currentVersion == "" {
+		return nil, &adapters.ExecutionFailure{
+			Kind: adapters.ExecutionFailureDefinite,
+			Err:  fmt.Errorf("calendar respond_to_event: provider returned no current event etag/version"),
+		}
+	}
+	if currentVersion != expectedVersion {
+		return nil, &adapters.ExecutionFailure{
+			Kind: adapters.ExecutionFailureStaleVersion,
+			Err:  fmt.Errorf("calendar respond_to_event: event version is stale"),
+		}
+	}
+	participant, ok := calendarSelfAttendee(current.Attendees)
+	if !ok || participant.Email == "" {
+		return nil, &adapters.ExecutionFailure{
+			Kind: adapters.ExecutionFailureDefinite,
+			Err:  fmt.Errorf("calendar respond_to_event: authenticated calendar is not an attendee"),
+		}
+	}
+
+	payload := map[string]any{
+		"attendees": []map[string]any{{
+			"email":          participant.Email,
+			"responseStatus": responseStatus,
+		}},
+		// This Google event flag makes the partial attendee list update only
+		// this calendar participant's response instead of replacing guests.
+		"attendeesOmitted": true,
+	}
+	q := url.Values{}
+	q.Set("sendUpdates", sendUpdates)
+	mutationURL := apiURL + "?" + q.Encode()
+
+	var updated calendarAPIEvent
+	headers, err = apiConditionalWrite(ctx, client, http.MethodPatch, mutationURL, expectedVersion, payload, &updated)
+	if err != nil {
+		return nil, fmt.Errorf("calendar respond_to_event: %w", err)
+	}
+	updatedVersion := eventVersion(updated.ETag, headers.Get("ETag"))
+	if updatedVersion == "" {
+		return nil, &adapters.ExecutionFailure{
+			Kind: adapters.ExecutionFailureAmbiguous,
+			Err:  fmt.Errorf("calendar respond_to_event: provider confirmed the mutation but returned no event etag/version"),
+		}
+	}
+	if updated.ID == "" {
+		updated.ID = eventID
+	}
+	return &adapters.Result{
+		Summary: format.Summary("Responded %s to event %s", responseStatus, updated.ID),
+		Data: map[string]any{
+			"event_id":        updated.ID,
+			"response_status": responseStatus,
+			"etag":            updatedVersion,
+			"version":         updatedVersion,
+			"send_updates":    sendUpdates,
+		},
 	}, nil
 }
 
@@ -456,23 +622,235 @@ func (a *CalendarAdapter) listCalendars(ctx context.Context, client *http.Client
 	return result, nil
 }
 
+func calendarEventData(item calendarAPIEvent, version string) map[string]any {
+	start := item.Start.DateTime
+	if start == "" {
+		start = item.Start.Date
+	}
+	end := item.End.DateTime
+	if end == "" {
+		end = item.End.Date
+	}
+
+	attendees := make([]map[string]any, 0, len(item.Attendees))
+	for _, attendee := range item.Attendees {
+		entry := map[string]any{
+			"email":          format.SanitizeText(attendee.Email, format.MaxFieldLen),
+			"responseStatus": attendee.ResponseStatus,
+		}
+		if attendee.DisplayName != "" {
+			entry["displayName"] = format.SanitizeText(attendee.DisplayName, format.MaxFieldLen)
+		}
+		if attendee.Comment != "" {
+			entry["comment"] = format.SanitizeText(attendee.Comment, format.MaxSnippetLen)
+		}
+		if attendee.Self {
+			entry["self"] = true
+		}
+		if attendee.Organizer {
+			entry["organizer"] = true
+		}
+		if attendee.Optional {
+			entry["optional"] = true
+		}
+		if attendee.Resource {
+			entry["resource"] = true
+		}
+		if attendee.AdditionalGuests != 0 {
+			entry["additionalGuests"] = attendee.AdditionalGuests
+		}
+		attendees = append(attendees, entry)
+	}
+
+	attachments := make([]map[string]any, 0, len(item.Attachments))
+	for _, attachment := range item.Attachments {
+		attachments = append(attachments, map[string]any{
+			"fileUrl":  attachment.FileURL,
+			"title":    format.SanitizeText(attachment.Title, format.MaxFieldLen),
+			"mimeType": attachment.MimeType,
+			"iconLink": attachment.IconLink,
+			"fileId":   attachment.FileID,
+		})
+	}
+
+	transparency := item.Transparency
+	if transparency == "" {
+		transparency = "opaque"
+	}
+	visibility := item.Visibility
+	if visibility == "" {
+		visibility = "default"
+	}
+	data := map[string]any{
+		"id":           item.ID,
+		"summary":      format.SanitizeText(item.Summary, format.MaxFieldLen),
+		"start":        start,
+		"end":          end,
+		"location":     format.SanitizeText(item.Location, format.MaxFieldLen),
+		"description":  format.SanitizeText(item.Description, format.MaxBodyLen),
+		"attendees":    attendees,
+		"attachments":  attachments,
+		"hangoutLink":  item.HangoutLink,
+		"transparency": transparency,
+		"visibility":   visibility,
+		"status":       item.Status,
+		"etag":         version,
+		"version":      version,
+		"sequence":     item.Sequence,
+	}
+	if item.RecurringEvent != "" {
+		data["recurringEventId"] = item.RecurringEvent
+	}
+	for _, attendee := range item.Attendees {
+		if attendee.Self && attendee.ResponseStatus != "" {
+			data["response_status"] = attendee.ResponseStatus
+			data["responseStatus"] = attendee.ResponseStatus
+			break
+		}
+	}
+	return data
+}
+
+func eventVersion(bodyETag, headerETag string) string {
+	if version := strings.TrimSpace(bodyETag); version != "" && version != "*" {
+		return version
+	}
+	if version := strings.TrimSpace(headerETag); version != "" && version != "*" {
+		return version
+	}
+	return ""
+}
+
+func expectedEventVersion(params map[string]any) (string, error) {
+	var versions []string
+	for _, key := range []string{"expected_etag", "expected_version"} {
+		raw, exists := params[key]
+		if !exists {
+			continue
+		}
+		version, ok := raw.(string)
+		if !ok {
+			return "", &adapters.ExecutionFailure{
+				Kind: adapters.ExecutionFailureDefinite,
+				Err:  fmt.Errorf("%s must be a string", key),
+			}
+		}
+		version = strings.TrimSpace(version)
+		if version == "" || version == "*" || strings.ContainsAny(version, "\r\n") {
+			return "", &adapters.ExecutionFailure{
+				Kind: adapters.ExecutionFailureDefinite,
+				Err:  fmt.Errorf("%s must contain a concrete provider version", key),
+			}
+		}
+		versions = append(versions, version)
+	}
+	if len(versions) == 0 {
+		return "", &adapters.ExecutionFailure{
+			Kind: adapters.ExecutionFailureDefinite,
+			Err:  fmt.Errorf("expected_etag (or expected_version) is required"),
+		}
+	}
+	if len(versions) == 2 && versions[0] != versions[1] {
+		return "", &adapters.ExecutionFailure{
+			Kind: adapters.ExecutionFailureDefinite,
+			Err:  fmt.Errorf("expected_etag and expected_version disagree"),
+		}
+	}
+	return versions[0], nil
+}
+
+func calendarSendUpdates(params map[string]any) (string, error) {
+	raw, exists := params["send_updates"]
+	if !exists {
+		return "none", nil
+	}
+	value, ok := raw.(string)
+	if !ok {
+		return "", &adapters.ExecutionFailure{
+			Kind: adapters.ExecutionFailureDefinite,
+			Err:  fmt.Errorf("send_updates must be a string"),
+		}
+	}
+	value = strings.TrimSpace(value)
+	switch value {
+	case "all", "externalOnly", "none":
+		return value, nil
+	default:
+		return "", &adapters.ExecutionFailure{
+			Kind: adapters.ExecutionFailureDefinite,
+			Err:  fmt.Errorf("send_updates must be all, externalOnly, or none"),
+		}
+	}
+}
+
+func calendarAttendeePatch(raw any) ([]map[string]string, error) {
+	var values []any
+	switch typed := raw.(type) {
+	case []any:
+		values = typed
+	case []string:
+		values = make([]any, len(typed))
+		for i, value := range typed {
+			values[i] = value
+		}
+	default:
+		return nil, &adapters.ExecutionFailure{
+			Kind: adapters.ExecutionFailureDefinite,
+			Err:  fmt.Errorf("attendees must be an array of email strings"),
+		}
+	}
+	attendees := make([]map[string]string, 0, len(values))
+	for _, rawValue := range values {
+		email, ok := rawValue.(string)
+		email = strings.TrimSpace(email)
+		if !ok || email == "" {
+			return nil, &adapters.ExecutionFailure{
+				Kind: adapters.ExecutionFailureDefinite,
+				Err:  fmt.Errorf("attendees must contain non-empty email strings"),
+			}
+		}
+		attendees = append(attendees, map[string]string{"email": email})
+	}
+	return attendees, nil
+}
+
+func calendarSelfAttendee(attendees []calendarAPIAttendee) (calendarAPIAttendee, bool) {
+	for _, attendee := range attendees {
+		if attendee.Self {
+			return attendee, true
+		}
+	}
+	return calendarAPIAttendee{}, false
+}
+
 // ── HTTP helpers ──────────────────────────────────────────────────────────────
 
 func apiGET(ctx context.Context, client *http.Client, apiURL string, out any) error {
+	_, err := apiGETWithHeaders(ctx, client, apiURL, out)
+	return err
+}
+
+func apiGETWithHeaders(ctx context.Context, client *http.Client, apiURL string, out any) (http.Header, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer resp.Body.Close()
-	body, _ := io.ReadAll(resp.Body)
+	body, readErr := io.ReadAll(resp.Body)
 	if resp.StatusCode >= 400 {
-		return fmt.Errorf("status %d: %s", resp.StatusCode, format.Truncate(string(body), 200))
+		return resp.Header.Clone(), fmt.Errorf("status %d: %s", resp.StatusCode, format.Truncate(string(body), 200))
 	}
-	return json.Unmarshal(body, out)
+	if readErr != nil {
+		return resp.Header.Clone(), readErr
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return resp.Header.Clone(), err
+	}
+	return resp.Header.Clone(), nil
 }
 
 func apiWrite(ctx context.Context, client *http.Client, method, apiURL string, payload any, out any) error {
@@ -498,6 +876,82 @@ func apiWrite(ctx context.Context, client *http.Client, method, apiURL string, p
 		return json.Unmarshal(body, out)
 	}
 	return nil
+}
+
+func apiConditionalWrite(
+	ctx context.Context,
+	client *http.Client,
+	method, apiURL, expectedVersion string,
+	payload any,
+	out any,
+) (http.Header, error) {
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return nil, &adapters.ExecutionFailure{Kind: adapters.ExecutionFailureDefinite, Err: err}
+	}
+	req, err := http.NewRequestWithContext(ctx, method, apiURL, strings.NewReader(string(b)))
+	if err != nil {
+		return nil, &adapters.ExecutionFailure{Kind: adapters.ExecutionFailureDefinite, Err: err}
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("If-Match", expectedVersion)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		if resp != nil && resp.Body != nil {
+			resp.Body.Close()
+		}
+		return nil, &adapters.ExecutionFailure{
+			Kind:     adapters.ExecutionFailureAmbiguous,
+			TimedOut: isTimeoutError(err),
+			Err:      fmt.Errorf("provider mutation transport failed: %w", err),
+		}
+	}
+	defer resp.Body.Close()
+	body, readErr := io.ReadAll(resp.Body)
+
+	switch {
+	case resp.StatusCode == http.StatusPreconditionFailed:
+		return resp.Header.Clone(), &adapters.ExecutionFailure{
+			Kind: adapters.ExecutionFailureStaleVersion,
+			Err:  fmt.Errorf("provider rejected stale event version (status %d): %s", resp.StatusCode, format.Truncate(string(body), 200)),
+		}
+	case resp.StatusCode == http.StatusRequestTimeout || resp.StatusCode >= http.StatusInternalServerError:
+		return resp.Header.Clone(), &adapters.ExecutionFailure{
+			Kind:     adapters.ExecutionFailureAmbiguous,
+			TimedOut: resp.StatusCode == http.StatusRequestTimeout || resp.StatusCode == http.StatusGatewayTimeout,
+			Err:      fmt.Errorf("provider mutation outcome is ambiguous (status %d): %s", resp.StatusCode, format.Truncate(string(body), 200)),
+		}
+	case resp.StatusCode >= http.StatusBadRequest:
+		return resp.Header.Clone(), &adapters.ExecutionFailure{
+			Kind: adapters.ExecutionFailureDefinite,
+			Err:  fmt.Errorf("provider rejected mutation (status %d): %s", resp.StatusCode, format.Truncate(string(body), 200)),
+		}
+	case readErr != nil:
+		return resp.Header.Clone(), &adapters.ExecutionFailure{
+			Kind:     adapters.ExecutionFailureAmbiguous,
+			TimedOut: isTimeoutError(readErr),
+			Err:      fmt.Errorf("provider mutation response was incomplete: %w", readErr),
+		}
+	}
+
+	if out != nil && len(body) > 0 {
+		if err := json.Unmarshal(body, out); err != nil {
+			return resp.Header.Clone(), &adapters.ExecutionFailure{
+				Kind: adapters.ExecutionFailureAmbiguous,
+				Err:  fmt.Errorf("provider confirmed mutation but returned an invalid response: %w", err),
+			}
+		}
+	}
+	return resp.Header.Clone(), nil
+}
+
+func isTimeoutError(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
 }
 
 func paramInt(params map[string]any, key string) (int, bool) {

--- a/internal/adapters/google/calendar/adapter_test.go
+++ b/internal/adapters/google/calendar/adapter_test.go
@@ -1,0 +1,497 @@
+package calendar
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/pkg/adapters"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type timeoutAfterCommitError struct{}
+
+func (timeoutAfterCommitError) Error() string   { return "timed out reading provider response" }
+func (timeoutAfterCommitError) Timeout() bool   { return true }
+func (timeoutAfterCommitError) Temporary() bool { return true }
+
+func fixture(t *testing.T, name string) string {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", name, err)
+	}
+	return string(body)
+}
+
+func fixtureWithoutETag(t *testing.T, name string) string {
+	t.Helper()
+	var body map[string]any
+	if err := json.Unmarshal([]byte(fixture(t, name)), &body); err != nil {
+		t.Fatalf("decode fixture %s: %v", name, err)
+	}
+	delete(body, "etag")
+	encoded, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("encode fixture %s without etag: %v", name, err)
+	}
+	return string(encoded)
+}
+
+func response(status int, body string, headers ...http.Header) *http.Response {
+	header := make(http.Header)
+	if len(headers) > 0 {
+		header = headers[0].Clone()
+	}
+	return &http.Response{
+		StatusCode: status,
+		Header:     header,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func requireFailure(t *testing.T, err error, kind adapters.ExecutionFailureKind) *adapters.ExecutionFailure {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected %s failure, got nil", kind)
+	}
+	failure, ok := adapters.AsExecutionFailure(err)
+	if !ok {
+		t.Fatalf("error %T (%v) is not a classified execution failure", err, err)
+	}
+	if failure.Kind != kind {
+		t.Fatalf("failure kind = %q, want %q (error: %v)", failure.Kind, kind, err)
+	}
+	return failure
+}
+
+func TestGetEventExposesProviderETagAndVersion(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet || req.URL.Path != "/calendar/v3/calendars/primary/events/event-123" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		if req.URL.RawQuery != "" {
+			t.Fatalf("events.get must not receive unsupported query parameters: %s", req.URL.RawQuery)
+		}
+		// A body ETag is canonical when Google returns both representations.
+		return response(http.StatusOK, fixture(t, "event.json"), http.Header{"Etag": {`"header-v1"`}}), nil
+	})}
+
+	result, err := (&CalendarAdapter{}).getEvent(t.Context(), client, map[string]any{"event_id": "event-123"})
+	if err != nil {
+		t.Fatalf("getEvent: %v", err)
+	}
+	data, ok := result.Data.(map[string]any)
+	if !ok {
+		t.Fatalf("result data = %T, want map[string]any", result.Data)
+	}
+	for _, field := range []string{"etag", "version"} {
+		if got := data[field]; got != `"event-v1"` {
+			t.Errorf("%s = %v, want %q", field, got, `"event-v1"`)
+		}
+	}
+	if got := data["sequence"]; got != int64(7) {
+		t.Errorf("sequence = %v (%T), want 7", got, got)
+	}
+	if got := data["response_status"]; got != "needsAction" {
+		t.Errorf("response_status = %v, want needsAction", got)
+	}
+}
+
+func TestGetEventUsesHeaderETagFallback(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return response(
+			http.StatusOK,
+			fixtureWithoutETag(t, "event.json"),
+			http.Header{"Etag": {`"header-v1"`}},
+		), nil
+	})}
+
+	result, err := (&CalendarAdapter{}).getEvent(t.Context(), client, map[string]any{"event_id": "event-123"})
+	if err != nil {
+		t.Fatalf("getEvent: %v", err)
+	}
+	data := result.Data.(map[string]any)
+	if data["etag"] != `"header-v1"` || data["version"] != `"header-v1"` {
+		t.Fatalf("etag/version = %v/%v, want header fallback", data["etag"], data["version"])
+	}
+}
+
+func TestGetEventMissingVersionFailsClosed(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return response(http.StatusOK, fixtureWithoutETag(t, "event.json")), nil
+	})}
+
+	_, err := (&CalendarAdapter{}).getEvent(t.Context(), client, map[string]any{"event_id": "event-123"})
+	requireFailure(t, err, adapters.ExecutionFailureDefinite)
+}
+
+func TestUpdateEventUsesIfMatchAndSendUpdates(t *testing.T) {
+	tests := []struct {
+		name       string
+		param      any
+		want       string
+		versionKey string
+	}{
+		{name: "default none", want: "none", versionKey: "expected_etag"},
+		{name: "all", param: "all", want: "all", versionKey: "expected_etag"},
+		{name: "external only and version alias", param: "externalOnly", want: "externalOnly", versionKey: "expected_version"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var calls atomic.Int32
+			client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				calls.Add(1)
+				if req.Method != http.MethodPatch || req.URL.Path != "/calendar/v3/calendars/primary/events/event-123" {
+					t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+				}
+				if got := req.Header.Get("If-Match"); got != `"event-v1"` {
+					t.Fatalf("If-Match = %q, want %q", got, `"event-v1"`)
+				}
+				if got := req.URL.Query().Get("sendUpdates"); got != tc.want {
+					t.Fatalf("sendUpdates = %q, want %q", got, tc.want)
+				}
+				var payload map[string]any
+				if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+					t.Fatalf("decode update payload: %v", err)
+				}
+				if payload["summary"] != "Atlas approval review (updated)" {
+					t.Errorf("summary = %v", payload["summary"])
+				}
+				for _, forbidden := range []string{"expected_etag", "expected_version", "send_updates"} {
+					if _, exists := payload[forbidden]; exists {
+						t.Errorf("provider payload unexpectedly contains %q: %v", forbidden, payload)
+					}
+				}
+				return response(http.StatusOK, fixture(t, "updated_event.json")), nil
+			})}
+
+			params := map[string]any{
+				"event_id":    "event-123",
+				"summary":     "Atlas approval review (updated)",
+				tc.versionKey: `"event-v1"`,
+			}
+			if tc.param != nil {
+				params["send_updates"] = tc.param
+			}
+			result, err := (&CalendarAdapter{}).updateEvent(t.Context(), client, params)
+			if err != nil {
+				t.Fatalf("updateEvent: %v", err)
+			}
+			if calls.Load() != 1 {
+				t.Fatalf("provider calls = %d, want 1", calls.Load())
+			}
+			data := result.Data.(map[string]any)
+			if data["etag"] != `"event-v2"` || data["version"] != `"event-v2"` {
+				t.Errorf("etag/version = %v/%v, want event-v2", data["etag"], data["version"])
+			}
+			if data["send_updates"] != tc.want {
+				t.Errorf("result send_updates = %v, want %s", data["send_updates"], tc.want)
+			}
+		})
+	}
+}
+
+func TestUpdateEventRejectsInvalidSendUpdatesBeforeProviderCall(t *testing.T) {
+	var calls atomic.Int32
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		calls.Add(1)
+		return nil, fmt.Errorf("unexpected provider call")
+	})}
+
+	_, err := (&CalendarAdapter{}).updateEvent(t.Context(), client, map[string]any{
+		"event_id":      "event-123",
+		"expected_etag": `"event-v1"`,
+		"summary":       "changed",
+		"send_updates":  "yes",
+	})
+	requireFailure(t, err, adapters.ExecutionFailureDefinite)
+	if calls.Load() != 0 {
+		t.Fatalf("provider calls = %d, want 0", calls.Load())
+	}
+}
+
+func TestUpdateEventStaleVersionIsClassified(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if got := req.Header.Get("If-Match"); got != `"event-v1"` {
+			t.Fatalf("If-Match = %q, want event-v1", got)
+		}
+		return response(http.StatusPreconditionFailed, fixture(t, "provider_error.json")), nil
+	})}
+
+	_, err := (&CalendarAdapter{}).updateEvent(t.Context(), client, map[string]any{
+		"event_id":      "event-123",
+		"expected_etag": `"event-v1"`,
+		"summary":       "changed",
+	})
+	requireFailure(t, err, adapters.ExecutionFailureStaleVersion)
+}
+
+func TestUpdateEventProviderRejectionIsDefinite(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return response(http.StatusBadRequest, `{"error":{"message":"invalid event"}}`), nil
+	})}
+
+	_, err := (&CalendarAdapter{}).updateEvent(t.Context(), client, map[string]any{
+		"event_id":      "event-123",
+		"expected_etag": `"event-v1"`,
+		"summary":       "changed",
+	})
+	requireFailure(t, err, adapters.ExecutionFailureDefinite)
+}
+
+func TestUpdateEventRequiresConcreteExpectedVersion(t *testing.T) {
+	tests := []struct {
+		name   string
+		params map[string]any
+	}{
+		{name: "missing", params: map[string]any{}},
+		{name: "empty", params: map[string]any{"expected_etag": "  "}},
+		{name: "wildcard", params: map[string]any{"expected_etag": "*"}},
+		{name: "conflicting aliases", params: map[string]any{
+			"expected_etag": `"event-v1"`, "expected_version": `"event-v0"`,
+		}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var calls atomic.Int32
+			client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				calls.Add(1)
+				return nil, fmt.Errorf("unexpected provider call")
+			})}
+			tc.params["event_id"] = "event-123"
+			tc.params["summary"] = "changed"
+
+			_, err := (&CalendarAdapter{}).updateEvent(t.Context(), client, tc.params)
+			requireFailure(t, err, adapters.ExecutionFailureDefinite)
+			if calls.Load() != 0 {
+				t.Fatalf("provider calls = %d, want 0", calls.Load())
+			}
+		})
+	}
+}
+
+func TestUpdateEventTimeoutAfterProviderCommitIsAmbiguous(t *testing.T) {
+	var committed atomic.Int32
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Header.Get("If-Match") != `"event-v1"` {
+			t.Fatal("conditional write was not sent before simulated commit")
+		}
+		committed.Add(1)
+		return nil, timeoutAfterCommitError{}
+	})}
+
+	_, err := (&CalendarAdapter{}).updateEvent(t.Context(), client, map[string]any{
+		"event_id":      "event-123",
+		"expected_etag": `"event-v1"`,
+		"summary":       "changed",
+	})
+	failure := requireFailure(t, err, adapters.ExecutionFailureAmbiguous)
+	if !failure.TimedOut {
+		t.Fatal("timeout-after-commit must set TimedOut")
+	}
+	if committed.Load() != 1 {
+		t.Fatalf("simulated provider commits = %d, want 1", committed.Load())
+	}
+}
+
+func TestUpdateEventSuccessWithoutNewVersionFailsClosedAsAmbiguous(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return response(http.StatusOK, `{"id":"event-123","summary":"changed"}`), nil
+	})}
+
+	_, err := (&CalendarAdapter{}).updateEvent(t.Context(), client, map[string]any{
+		"event_id":      "event-123",
+		"expected_etag": `"event-v1"`,
+		"summary":       "changed",
+	})
+	failure := requireFailure(t, err, adapters.ExecutionFailureAmbiguous)
+	if failure.TimedOut {
+		t.Fatal("missing response version is ambiguous but is not a timeout")
+	}
+}
+
+func TestRespondToEventUpdatesOnlySelfWithConditionalWrite(t *testing.T) {
+	tests := []struct {
+		status       string
+		versionParam string
+		sendUpdates  string
+		wantSend     string
+	}{
+		{status: "accepted", versionParam: "expected_etag", sendUpdates: "all", wantSend: "all"},
+		{status: "declined", versionParam: "expected_etag", wantSend: "none"},
+		{status: "tentative", versionParam: "expected_version", sendUpdates: "externalOnly", wantSend: "externalOnly"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.status, func(t *testing.T) {
+			var calls atomic.Int32
+			client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				switch calls.Add(1) {
+				case 1:
+					if req.Method != http.MethodGet {
+						t.Fatalf("pre-read method = %s, want GET", req.Method)
+					}
+					return response(http.StatusOK, fixture(t, "event.json")), nil
+				case 2:
+					if req.Method != http.MethodPatch {
+						t.Fatalf("mutation method = %s, want PATCH", req.Method)
+					}
+					if got := req.Header.Get("If-Match"); got != `"event-v1"` {
+						t.Fatalf("If-Match = %q, want event-v1", got)
+					}
+					if got := req.URL.Query().Get("sendUpdates"); got != tc.wantSend {
+						t.Fatalf("sendUpdates = %q, want %q", got, tc.wantSend)
+					}
+					var payload struct {
+						AttendeesOmitted bool `json:"attendeesOmitted"`
+						Attendees        []struct {
+							Email          string `json:"email"`
+							ResponseStatus string `json:"responseStatus"`
+						} `json:"attendees"`
+					}
+					if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+						t.Fatalf("decode RSVP payload: %v", err)
+					}
+					if !payload.AttendeesOmitted {
+						t.Fatal("attendeesOmitted = false, want true")
+					}
+					if len(payload.Attendees) != 1 {
+						t.Fatalf("attendees = %+v, want exactly self attendee", payload.Attendees)
+					}
+					if payload.Attendees[0].Email != "self@example.com" || payload.Attendees[0].ResponseStatus != tc.status {
+						t.Fatalf("attendee patch = %+v, want self/%s", payload.Attendees[0], tc.status)
+					}
+					return response(http.StatusOK, fixture(t, "updated_event.json")), nil
+				default:
+					t.Fatalf("unexpected extra provider request: %s %s", req.Method, req.URL.String())
+					return nil, nil
+				}
+			})}
+
+			params := map[string]any{
+				"event_id":        "event-123",
+				"response_status": tc.status,
+				tc.versionParam:   `"event-v1"`,
+			}
+			if tc.sendUpdates != "" {
+				params["send_updates"] = tc.sendUpdates
+			}
+			result, err := (&CalendarAdapter{}).respondToEvent(t.Context(), client, params)
+			if err != nil {
+				t.Fatalf("respondToEvent: %v", err)
+			}
+			if calls.Load() != 2 {
+				t.Fatalf("provider calls = %d, want GET + PATCH", calls.Load())
+			}
+			data := result.Data.(map[string]any)
+			if data["response_status"] != tc.status || data["send_updates"] != tc.wantSend {
+				t.Errorf("result = %v, want status=%s send_updates=%s", data, tc.status, tc.wantSend)
+			}
+			if data["etag"] != `"event-v2"` {
+				t.Errorf("result etag = %v, want event-v2", data["etag"])
+			}
+		})
+	}
+}
+
+func TestRespondToEventRejectsInvalidRSVPBeforeProviderCall(t *testing.T) {
+	var calls atomic.Int32
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		calls.Add(1)
+		return nil, fmt.Errorf("unexpected provider call")
+	})}
+
+	_, err := (&CalendarAdapter{}).respondToEvent(t.Context(), client, map[string]any{
+		"event_id":        "event-123",
+		"expected_etag":   `"event-v1"`,
+		"response_status": "maybe",
+	})
+	requireFailure(t, err, adapters.ExecutionFailureDefinite)
+	if calls.Load() != 0 {
+		t.Fatalf("provider calls = %d, want 0", calls.Load())
+	}
+}
+
+func TestRespondToEventRequiresExplicitSelfAttendee(t *testing.T) {
+	var calls atomic.Int32
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if calls.Add(1) != 1 || req.Method != http.MethodGet {
+			return nil, fmt.Errorf("unexpected provider mutation: %s %s", req.Method, req.URL.String())
+		}
+		return response(http.StatusOK, `{
+			"id":"event-123",
+			"etag":"\"event-v1\"",
+			"attendees":[{"email":"shared-calendar@example.com","responseStatus":"needsAction"}]
+		}`), nil
+	})}
+
+	_, err := (&CalendarAdapter{}).respondToEvent(t.Context(), client, map[string]any{
+		"event_id":        "event-123",
+		"calendar_id":     "shared-calendar@example.com",
+		"expected_etag":   `"event-v1"`,
+		"response_status": "accepted",
+	})
+	requireFailure(t, err, adapters.ExecutionFailureDefinite)
+	if calls.Load() != 1 {
+		t.Fatalf("provider calls = %d, want only pre-read", calls.Load())
+	}
+}
+
+func TestRespondToEventStalePreReadDoesNotMutate(t *testing.T) {
+	var calls atomic.Int32
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		calls.Add(1)
+		return response(http.StatusOK, fixture(t, "event.json")), nil
+	})}
+
+	_, err := (&CalendarAdapter{}).respondToEvent(t.Context(), client, map[string]any{
+		"event_id":        "event-123",
+		"expected_etag":   `"event-v0"`,
+		"response_status": "accepted",
+	})
+	requireFailure(t, err, adapters.ExecutionFailureStaleVersion)
+	if calls.Load() != 1 {
+		t.Fatalf("provider calls = %d, want only pre-read", calls.Load())
+	}
+}
+
+func TestRespondToEventProviderRechecksVersionAtMutation(t *testing.T) {
+	var calls atomic.Int32
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch calls.Add(1) {
+		case 1:
+			return response(http.StatusOK, fixture(t, "event.json")), nil
+		case 2:
+			if got := req.Header.Get("If-Match"); got != `"event-v1"` {
+				t.Fatalf("If-Match = %q, want event-v1", got)
+			}
+			return response(http.StatusPreconditionFailed, fixture(t, "provider_error.json")), nil
+		default:
+			return nil, fmt.Errorf("unexpected provider call")
+		}
+	})}
+
+	_, err := (&CalendarAdapter{}).respondToEvent(t.Context(), client, map[string]any{
+		"event_id":        "event-123",
+		"expected_etag":   `"event-v1"`,
+		"response_status": "accepted",
+	})
+	requireFailure(t, err, adapters.ExecutionFailureStaleVersion)
+	if calls.Load() != 2 {
+		t.Fatalf("provider calls = %d, want GET + conditional PATCH", calls.Load())
+	}
+}

--- a/internal/adapters/google/calendar/adapter_test.go
+++ b/internal/adapters/google/calendar/adapter_test.go
@@ -76,6 +76,24 @@ func requireFailure(t *testing.T, err error, kind adapters.ExecutionFailureKind)
 	return failure
 }
 
+func TestOAuthConfigForAliasWorksWithoutDefaultClient(t *testing.T) {
+	t.Setenv("GOOGLE_OAUTH_ALIAS__EC", "vijay@eightcapital.com")
+	t.Setenv("GOOGLE_CLIENT_ID__EC", "ec-client")
+	t.Setenv("GOOGLE_CLIENT_SECRET__EC", "ec-secret")
+
+	config := New(adapters.NoopOAuthProvider{}).
+		OAuthConfigForAlias("vijay@eightcapital.com")
+	if config == nil {
+		t.Fatal("expected alias-only OAuth config")
+	}
+	if config.ClientID != "ec-client" ||
+		config.ClientSecret != "ec-secret" ||
+		config.Endpoint.AuthURL == "" ||
+		len(config.Scopes) != len(calendarScopes) {
+		t.Fatalf("alias-only config = %#v", config)
+	}
+}
+
 func TestCalendarAttendeePatchAcceptsEmailObjects(t *testing.T) {
 	attendees, err := calendarAttendeePatch([]any{
 		"first@example.com",

--- a/internal/adapters/google/calendar/adapter_test.go
+++ b/internal/adapters/google/calendar/adapter_test.go
@@ -92,6 +92,9 @@ func TestGetEventExposesProviderETagAndVersion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("getEvent: %v", err)
 	}
+	if result.Summary != "Event: Atlas approval review" {
+		t.Fatalf("summary = %q, want catalog-compatible summary", result.Summary)
+	}
 	data, ok := result.Data.(map[string]any)
 	if !ok {
 		t.Fatalf("result data = %T, want map[string]any", result.Data)

--- a/internal/adapters/google/calendar/adapter_test.go
+++ b/internal/adapters/google/calendar/adapter_test.go
@@ -76,6 +76,25 @@ func requireFailure(t *testing.T, err error, kind adapters.ExecutionFailureKind)
 	return failure
 }
 
+func TestCalendarAttendeePatchAcceptsEmailObjects(t *testing.T) {
+	attendees, err := calendarAttendeePatch([]any{
+		"first@example.com",
+		map[string]any{"email": " second@example.com "},
+		map[string]string{"email": "third@example.com"},
+	})
+	if err != nil {
+		t.Fatalf("calendarAttendeePatch returned error: %v", err)
+	}
+	want := []map[string]string{
+		{"email": "first@example.com"},
+		{"email": "second@example.com"},
+		{"email": "third@example.com"},
+	}
+	if fmt.Sprint(attendees) != fmt.Sprint(want) {
+		t.Fatalf("attendees = %#v, want %#v", attendees, want)
+	}
+}
+
 func TestGetEventExposesProviderETagAndVersion(t *testing.T) {
 	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		if req.Method != http.MethodGet || req.URL.Path != "/calendar/v3/calendars/primary/events/event-123" {

--- a/internal/adapters/google/calendar/testdata/event.json
+++ b/internal/adapters/google/calendar/testdata/event.json
@@ -1,0 +1,39 @@
+{
+  "id": "event-123",
+  "etag": "\"event-v1\"",
+  "sequence": 7,
+  "summary": "Atlas approval review",
+  "location": "Video call",
+  "description": "Review the proposed provider action",
+  "status": "confirmed",
+  "hangoutLink": "https://meet.google.com/example",
+  "start": {
+    "dateTime": "2026-08-28T16:00:00Z",
+    "timeZone": "UTC"
+  },
+  "end": {
+    "dateTime": "2026-08-28T16:30:00Z",
+    "timeZone": "UTC"
+  },
+  "attendees": [
+    {
+      "email": "self@example.com",
+      "displayName": "Calendar Owner",
+      "responseStatus": "needsAction",
+      "self": true
+    },
+    {
+      "email": "organizer@example.com",
+      "responseStatus": "accepted",
+      "organizer": true
+    }
+  ],
+  "attachments": [
+    {
+      "fileUrl": "https://drive.google.com/file/d/example",
+      "title": "Agenda",
+      "mimeType": "application/pdf",
+      "fileId": "file-123"
+    }
+  ]
+}

--- a/internal/adapters/google/calendar/testdata/provider_error.json
+++ b/internal/adapters/google/calendar/testdata/provider_error.json
@@ -1,0 +1,7 @@
+{
+  "error": {
+    "code": 412,
+    "message": "Precondition Failed",
+    "status": "FAILED_PRECONDITION"
+  }
+}

--- a/internal/adapters/google/calendar/testdata/updated_event.json
+++ b/internal/adapters/google/calendar/testdata/updated_event.json
@@ -1,0 +1,27 @@
+{
+  "id": "event-123",
+  "etag": "\"event-v2\"",
+  "sequence": 8,
+  "summary": "Atlas approval review (updated)",
+  "status": "confirmed",
+  "start": {
+    "dateTime": "2026-08-28T16:00:00Z",
+    "timeZone": "UTC"
+  },
+  "end": {
+    "dateTime": "2026-08-28T16:30:00Z",
+    "timeZone": "UTC"
+  },
+  "attendees": [
+    {
+      "email": "self@example.com",
+      "responseStatus": "accepted",
+      "self": true
+    },
+    {
+      "email": "organizer@example.com",
+      "responseStatus": "accepted",
+      "organizer": true
+    }
+  ]
+}

--- a/internal/adapters/google/contacts/adapter.go
+++ b/internal/adapters/google/contacts/adapter.go
@@ -58,7 +58,12 @@ func (a *ContactsAdapter) OAuthConfig() *oauth2.Config {
 }
 
 func (a *ContactsAdapter) OAuthConfigForAlias(alias string) *oauth2.Config {
-	return credential.OAuthConfigForAlias(a.OAuthConfig(), alias)
+	config := credential.OAuthConfigForAlias(a.OAuthConfig(), alias)
+	if config != nil {
+		config.Scopes = contactsScopes
+		config.Endpoint = google.Endpoint
+	}
+	return config
 }
 
 func (a *ContactsAdapter) CredentialFromToken(token *oauth2.Token) ([]byte, error) {
@@ -71,7 +76,7 @@ func (a *ContactsAdapter) ValidateCredential(credBytes []byte) error {
 
 // FetchIdentity returns the Google account email for auto-alias detection.
 func (a *ContactsAdapter) FetchIdentity(ctx context.Context, credBytes []byte, config map[string]string) (string, error) {
-	client, err := a.httpClient(ctx, credBytes, config)
+	client, err := a.httpClient(ctx, credBytes, "")
 	if err != nil {
 		return "", err
 	}
@@ -79,7 +84,7 @@ func (a *ContactsAdapter) FetchIdentity(ctx context.Context, credBytes []byte, c
 }
 
 func (a *ContactsAdapter) Execute(ctx context.Context, req adapters.Request) (*adapters.Result, error) {
-	client, err := a.httpClient(ctx, req.Credential, req.Config)
+	client, err := a.httpClient(ctx, req.Credential, req.Alias)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +106,7 @@ func (a *ContactsAdapter) IsInContacts(ctx context.Context, cred []byte, email s
 	if email == "" {
 		return false, nil
 	}
-	client, err := a.httpClient(ctx, cred, nil)
+	client, err := a.httpClient(ctx, cred, "")
 	if err != nil {
 		return false, err
 	}
@@ -136,13 +141,13 @@ func (a *ContactsAdapter) IsInContacts(ctx context.Context, cred []byte, email s
 	return false, nil
 }
 
-func (a *ContactsAdapter) httpClient(ctx context.Context, credBytes []byte, config map[string]string) (*http.Client, error) {
+func (a *ContactsAdapter) httpClient(ctx context.Context, credBytes []byte, alias string) (*http.Client, error) {
 	cred, err := credential.Parse(credBytes)
 	if err != nil {
 		return nil, fmt.Errorf("contacts: %w", err)
 	}
 	oauthConfig := cred.OAuthConfig(
-		a.OAuthConfigForAlias(config["_clawvisor_alias"]),
+		a.OAuthConfigForAlias(alias),
 	)
 	ts := oauthConfig.TokenSource(ctx, cred.ToOAuth2Token())
 	return oauth2.NewClient(ctx, ts), nil

--- a/internal/adapters/google/contacts/adapter.go
+++ b/internal/adapters/google/contacts/adapter.go
@@ -57,6 +57,10 @@ func (a *ContactsAdapter) OAuthConfig() *oauth2.Config {
 	}
 }
 
+func (a *ContactsAdapter) OAuthConfigForAlias(alias string) *oauth2.Config {
+	return credential.OAuthConfigForAlias(a.OAuthConfig(), alias)
+}
+
 func (a *ContactsAdapter) CredentialFromToken(token *oauth2.Token) ([]byte, error) {
 	return credential.FromToken(token, contactsScopes, false)
 }
@@ -66,8 +70,8 @@ func (a *ContactsAdapter) ValidateCredential(credBytes []byte) error {
 }
 
 // FetchIdentity returns the Google account email for auto-alias detection.
-func (a *ContactsAdapter) FetchIdentity(ctx context.Context, credBytes []byte, _ map[string]string) (string, error) {
-	client, err := a.httpClient(ctx, credBytes)
+func (a *ContactsAdapter) FetchIdentity(ctx context.Context, credBytes []byte, config map[string]string) (string, error) {
+	client, err := a.httpClient(ctx, credBytes, config)
 	if err != nil {
 		return "", err
 	}
@@ -75,7 +79,7 @@ func (a *ContactsAdapter) FetchIdentity(ctx context.Context, credBytes []byte, _
 }
 
 func (a *ContactsAdapter) Execute(ctx context.Context, req adapters.Request) (*adapters.Result, error) {
-	client, err := a.httpClient(ctx, req.Credential)
+	client, err := a.httpClient(ctx, req.Credential, req.Config)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +101,7 @@ func (a *ContactsAdapter) IsInContacts(ctx context.Context, cred []byte, email s
 	if email == "" {
 		return false, nil
 	}
-	client, err := a.httpClient(ctx, cred)
+	client, err := a.httpClient(ctx, cred, nil)
 	if err != nil {
 		return false, err
 	}
@@ -132,12 +136,13 @@ func (a *ContactsAdapter) IsInContacts(ctx context.Context, cred []byte, email s
 	return false, nil
 }
 
-func (a *ContactsAdapter) httpClient(ctx context.Context, credBytes []byte) (*http.Client, error) {
+func (a *ContactsAdapter) httpClient(ctx context.Context, credBytes []byte, config map[string]string) (*http.Client, error) {
 	cred, err := credential.Parse(credBytes)
 	if err != nil {
 		return nil, fmt.Errorf("contacts: %w", err)
 	}
-	ts := a.OAuthConfig().TokenSource(ctx, cred.ToOAuth2Token())
+	oauthConfig := a.OAuthConfigForAlias(config["_clawvisor_alias"])
+	ts := oauthConfig.TokenSource(ctx, cred.ToOAuth2Token())
 	return oauth2.NewClient(ctx, ts), nil
 }
 

--- a/internal/adapters/google/contacts/adapter.go
+++ b/internal/adapters/google/contacts/adapter.go
@@ -149,6 +149,11 @@ func (a *ContactsAdapter) httpClient(ctx context.Context, credBytes []byte, alia
 	oauthConfig := cred.OAuthConfig(
 		a.OAuthConfigForAlias(alias),
 	)
+	if oauthConfig == nil {
+		return nil, fmt.Errorf("contacts: OAuth client credentials not configured")
+	}
+	oauthConfig.Scopes = contactsScopes
+	oauthConfig.Endpoint = google.Endpoint
 	ts := oauthConfig.TokenSource(ctx, cred.ToOAuth2Token())
 	return oauth2.NewClient(ctx, ts), nil
 }

--- a/internal/adapters/google/contacts/adapter.go
+++ b/internal/adapters/google/contacts/adapter.go
@@ -141,7 +141,9 @@ func (a *ContactsAdapter) httpClient(ctx context.Context, credBytes []byte, conf
 	if err != nil {
 		return nil, fmt.Errorf("contacts: %w", err)
 	}
-	oauthConfig := a.OAuthConfigForAlias(config["_clawvisor_alias"])
+	oauthConfig := cred.OAuthConfig(
+		a.OAuthConfigForAlias(config["_clawvisor_alias"]),
+	)
 	ts := oauthConfig.TokenSource(ctx, cred.ToOAuth2Token())
 	return oauth2.NewClient(ctx, ts), nil
 }

--- a/internal/adapters/google/credential/credential.go
+++ b/internal/adapters/google/credential/credential.go
@@ -56,6 +56,18 @@ func Validate(data []byte) error {
 // actually granted (read from the token exchange response). When false, scopes
 // are what we requested — we can't verify the user granted all of them.
 func FromToken(token *oauth2.Token, scopes []string, scopesGranted bool) ([]byte, error) {
+	return FromTokenWithOAuthConfig(token, scopes, scopesGranted, nil)
+}
+
+// FromTokenWithOAuthConfig binds the issuing OAuth application to the stored
+// credential. Refresh tokens are client-bound, so selecting a client later
+// from a renamed account alias is not safe.
+func FromTokenWithOAuthConfig(
+	token *oauth2.Token,
+	scopes []string,
+	scopesGranted bool,
+	oauthConfig *oauth2.Config,
+) ([]byte, error) {
 	c := Stored{
 		Type:          "oauth2",
 		AccessToken:   token.AccessToken,
@@ -63,6 +75,10 @@ func FromToken(token *oauth2.Token, scopes []string, scopesGranted bool) ([]byte
 		Expiry:        token.Expiry,
 		Scopes:        scopes,
 		ScopesGranted: scopesGranted,
+	}
+	if oauthConfig != nil {
+		c.OAuthClientID = oauthConfig.ClientID
+		c.OAuthClientSecret = oauthConfig.ClientSecret
 	}
 	return json.Marshal(c)
 }
@@ -85,7 +101,7 @@ func (c *Stored) OAuthConfig(base *oauth2.Config) *oauth2.Config {
 		return nil
 	}
 	config := *base
-	if c.OAuthClientID != "" && c.OAuthClientSecret != "" {
+	if c.OAuthClientID != "" {
 		config.ClientID = c.OAuthClientID
 		config.ClientSecret = c.OAuthClientSecret
 	}
@@ -99,30 +115,29 @@ func (c *Stored) OAuthConfig(base *oauth2.Config) *oauth2.Config {
 //	GOOGLE_CLIENT_ID__EC=...
 //	GOOGLE_CLIENT_SECRET__EC=...
 //
-// Unknown or incomplete mappings retain the default application.
+// Unknown or incomplete mappings retain the default application. When no
+// default application exists, a complete alias mapping still returns the
+// mapped credentials; the adapter supplies its provider endpoint and scopes.
 func OAuthConfigForAlias(base *oauth2.Config, alias string) *oauth2.Config {
-	if base == nil {
-		return nil
+	var config oauth2.Config
+	if base != nil {
+		config = *base
 	}
-	config := *base
-	if strings.EqualFold(
-		strings.TrimSpace(os.Getenv("GOOGLE_EC_ALIAS")),
-		strings.TrimSpace(alias),
-	) {
-		clientID := os.Getenv("GOOGLE_EC_CLIENT_ID")
-		clientSecret := os.Getenv("GOOGLE_EC_CLIENT_SECRET")
-		if clientID != "" && clientSecret != "" {
-			config.ClientID = clientID
-			config.ClientSecret = clientSecret
-			return &config
+	targetAlias := strings.TrimSpace(alias)
+	if targetAlias == "" {
+		if base == nil {
+			return nil
 		}
+		return &config
 	}
+	mapped := false
 	for _, entry := range os.Environ() {
 		name, mappedAlias, found := strings.Cut(entry, "=")
 		if !found || !strings.HasPrefix(name, "GOOGLE_OAUTH_ALIAS__") {
 			continue
 		}
-		if !strings.EqualFold(strings.TrimSpace(mappedAlias), strings.TrimSpace(alias)) {
+		mappedAlias = strings.TrimSpace(mappedAlias)
+		if mappedAlias == "" || !strings.EqualFold(mappedAlias, targetAlias) {
 			continue
 		}
 		suffix := strings.TrimPrefix(name, "GOOGLE_OAUTH_ALIAS__")
@@ -131,8 +146,12 @@ func OAuthConfigForAlias(base *oauth2.Config, alias string) *oauth2.Config {
 		if clientID != "" && clientSecret != "" {
 			config.ClientID = clientID
 			config.ClientSecret = clientSecret
+			mapped = true
 		}
 		break
+	}
+	if base == nil && !mapped {
+		return nil
 	}
 	return &config
 }

--- a/internal/adapters/google/credential/credential.go
+++ b/internal/adapters/google/credential/credential.go
@@ -9,7 +9,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"sort"
+	"strings"
 	"time"
 
 	"golang.org/x/oauth2"
@@ -71,6 +73,39 @@ func (c *Stored) ToOAuth2Token() *oauth2.Token {
 		Expiry:       c.Expiry,
 		TokenType:    "Bearer",
 	}
+}
+
+// OAuthConfigForAlias selects an explicitly configured OAuth application for
+// one account alias. Mappings use three variables with the same suffix:
+//
+//	GOOGLE_OAUTH_ALIAS__EC=vijay@eightcapital.com
+//	GOOGLE_CLIENT_ID__EC=...
+//	GOOGLE_CLIENT_SECRET__EC=...
+//
+// Unknown or incomplete mappings retain the default application.
+func OAuthConfigForAlias(base *oauth2.Config, alias string) *oauth2.Config {
+	if base == nil {
+		return nil
+	}
+	config := *base
+	for _, entry := range os.Environ() {
+		name, mappedAlias, found := strings.Cut(entry, "=")
+		if !found || !strings.HasPrefix(name, "GOOGLE_OAUTH_ALIAS__") {
+			continue
+		}
+		if !strings.EqualFold(strings.TrimSpace(mappedAlias), strings.TrimSpace(alias)) {
+			continue
+		}
+		suffix := strings.TrimPrefix(name, "GOOGLE_OAUTH_ALIAS__")
+		clientID := os.Getenv("GOOGLE_CLIENT_ID__" + suffix)
+		clientSecret := os.Getenv("GOOGLE_CLIENT_SECRET__" + suffix)
+		if clientID != "" && clientSecret != "" {
+			config.ClientID = clientID
+			config.ClientSecret = clientSecret
+		}
+		break
+	}
+	return &config
 }
 
 // MergeScopes returns the sorted set union of existing and additional scopes.

--- a/internal/adapters/google/credential/credential.go
+++ b/internal/adapters/google/credential/credential.go
@@ -19,12 +19,14 @@ import (
 
 // Stored is the JSON structure saved (encrypted) in the vault under key "google".
 type Stored struct {
-	Type          string    `json:"type"`
-	AccessToken   string    `json:"access_token"`
-	RefreshToken  string    `json:"refresh_token"`
-	Expiry        time.Time `json:"expiry"`
-	Scopes        []string  `json:"scopes"`
-	ScopesGranted bool      `json:"scopes_granted,omitempty"`
+	Type              string    `json:"type"`
+	AccessToken       string    `json:"access_token"`
+	RefreshToken      string    `json:"refresh_token"`
+	Expiry            time.Time `json:"expiry"`
+	Scopes            []string  `json:"scopes"`
+	ScopesGranted     bool      `json:"scopes_granted,omitempty"`
+	OAuthClientID     string    `json:"oauth_client_id,omitempty"`
+	OAuthClientSecret string    `json:"oauth_client_secret,omitempty"`
 }
 
 // Parse unmarshals vault credential bytes into a Stored credential.
@@ -73,6 +75,21 @@ func (c *Stored) ToOAuth2Token() *oauth2.Token {
 		Expiry:       c.Expiry,
 		TokenType:    "Bearer",
 	}
+}
+
+// OAuthConfig applies a credential-bound OAuth application when present.
+// Binding the app to the encrypted credential keeps refresh tokens issued by
+// different Workspace OAuth clients usable without guessing from account data.
+func (c *Stored) OAuthConfig(base *oauth2.Config) *oauth2.Config {
+	if base == nil {
+		return nil
+	}
+	config := *base
+	if c.OAuthClientID != "" && c.OAuthClientSecret != "" {
+		config.ClientID = c.OAuthClientID
+		config.ClientSecret = c.OAuthClientSecret
+	}
+	return &config
 }
 
 // OAuthConfigForAlias selects an explicitly configured OAuth application for

--- a/internal/adapters/google/credential/credential.go
+++ b/internal/adapters/google/credential/credential.go
@@ -88,6 +88,18 @@ func OAuthConfigForAlias(base *oauth2.Config, alias string) *oauth2.Config {
 		return nil
 	}
 	config := *base
+	if strings.EqualFold(
+		strings.TrimSpace(os.Getenv("GOOGLE_EC_ALIAS")),
+		strings.TrimSpace(alias),
+	) {
+		clientID := os.Getenv("GOOGLE_EC_CLIENT_ID")
+		clientSecret := os.Getenv("GOOGLE_EC_CLIENT_SECRET")
+		if clientID != "" && clientSecret != "" {
+			config.ClientID = clientID
+			config.ClientSecret = clientSecret
+			return &config
+		}
+	}
 	for _, entry := range os.Environ() {
 		name, mappedAlias, found := strings.Cut(entry, "=")
 		if !found || !strings.HasPrefix(name, "GOOGLE_OAUTH_ALIAS__") {

--- a/internal/adapters/google/credential/credential.go
+++ b/internal/adapters/google/credential/credential.go
@@ -97,10 +97,13 @@ func (c *Stored) ToOAuth2Token() *oauth2.Token {
 // Binding the app to the encrypted credential keeps refresh tokens issued by
 // different Workspace OAuth clients usable without guessing from account data.
 func (c *Stored) OAuthConfig(base *oauth2.Config) *oauth2.Config {
-	if base == nil {
+	if base == nil && c.OAuthClientID == "" {
 		return nil
 	}
-	config := *base
+	var config oauth2.Config
+	if base != nil {
+		config = *base
+	}
 	if c.OAuthClientID != "" {
 		config.ClientID = c.OAuthClientID
 		config.ClientSecret = c.OAuthClientSecret

--- a/internal/adapters/google/credential/credential_test.go
+++ b/internal/adapters/google/credential/credential_test.go
@@ -64,9 +64,9 @@ func TestHasAllScopes(t *testing.T) {
 }
 
 func TestOAuthConfigForAliasUsesExplicitMapping(t *testing.T) {
-	t.Setenv("GOOGLE_OAUTH_ALIAS__EC", "vijay@eightcapital.com")
-	t.Setenv("GOOGLE_CLIENT_ID__EC", "ec-client")
-	t.Setenv("GOOGLE_CLIENT_SECRET__EC", "ec-secret")
+	t.Setenv("GOOGLE_EC_ALIAS", "vijay@eightcapital.com")
+	t.Setenv("GOOGLE_EC_CLIENT_ID", "ec-client")
+	t.Setenv("GOOGLE_EC_CLIENT_SECRET", "ec-secret")
 	base := &oauth2.Config{
 		ClientID:     "default-client",
 		ClientSecret: "default-secret",

--- a/internal/adapters/google/credential/credential_test.go
+++ b/internal/adapters/google/credential/credential_test.go
@@ -1,6 +1,10 @@
 package credential
 
-import "testing"
+import (
+	"testing"
+
+	"golang.org/x/oauth2"
+)
 
 func TestMissingScopes(t *testing.T) {
 	tests := []struct {
@@ -56,5 +60,27 @@ func TestHasAllScopes(t *testing.T) {
 	}
 	if HasAllScopes([]string{"a"}, []string{"a", "b"}) {
 		t.Fatal("expected false when scope missing")
+	}
+}
+
+func TestOAuthConfigForAliasUsesExplicitMapping(t *testing.T) {
+	t.Setenv("GOOGLE_OAUTH_ALIAS__EC", "vijay@eightcapital.com")
+	t.Setenv("GOOGLE_CLIENT_ID__EC", "ec-client")
+	t.Setenv("GOOGLE_CLIENT_SECRET__EC", "ec-secret")
+	base := &oauth2.Config{
+		ClientID:     "default-client",
+		ClientSecret: "default-secret",
+	}
+
+	mapped := OAuthConfigForAlias(base, "VIJAY@EIGHTCAPITAL.COM")
+	if mapped.ClientID != "ec-client" || mapped.ClientSecret != "ec-secret" {
+		t.Fatalf("mapped config = %#v", mapped)
+	}
+	if base.ClientID != "default-client" {
+		t.Fatal("alias selection mutated the default OAuth config")
+	}
+	unmapped := OAuthConfigForAlias(base, "vijay@vantedgeai.com")
+	if unmapped.ClientID != "default-client" {
+		t.Fatalf("unmapped client = %q", unmapped.ClientID)
 	}
 }

--- a/internal/adapters/google/credential/credential_test.go
+++ b/internal/adapters/google/credential/credential_test.go
@@ -64,9 +64,9 @@ func TestHasAllScopes(t *testing.T) {
 }
 
 func TestOAuthConfigForAliasUsesExplicitMapping(t *testing.T) {
-	t.Setenv("GOOGLE_EC_ALIAS", "vijay@eightcapital.com")
-	t.Setenv("GOOGLE_EC_CLIENT_ID", "ec-client")
-	t.Setenv("GOOGLE_EC_CLIENT_SECRET", "ec-secret")
+	t.Setenv("GOOGLE_OAUTH_ALIAS__EC", "vijay@eightcapital.com")
+	t.Setenv("GOOGLE_CLIENT_ID__EC", "ec-client")
+	t.Setenv("GOOGLE_CLIENT_SECRET__EC", "ec-secret")
 	base := &oauth2.Config{
 		ClientID:     "default-client",
 		ClientSecret: "default-secret",
@@ -82,6 +82,38 @@ func TestOAuthConfigForAliasUsesExplicitMapping(t *testing.T) {
 	unmapped := OAuthConfigForAlias(base, "vijay@vantedgeai.com")
 	if unmapped.ClientID != "default-client" {
 		t.Fatalf("unmapped client = %q", unmapped.ClientID)
+	}
+}
+
+func TestOAuthConfigForAliasIgnoresEmptyMapping(t *testing.T) {
+	t.Setenv("GOOGLE_OAUTH_ALIAS__EC", "")
+	t.Setenv("GOOGLE_CLIENT_ID__EC", "ec-client")
+	t.Setenv("GOOGLE_CLIENT_SECRET__EC", "ec-secret")
+	base := &oauth2.Config{
+		ClientID:     "default-client",
+		ClientSecret: "default-secret",
+	}
+
+	mapped := OAuthConfigForAlias(base, "")
+	if mapped.ClientID != "default-client" ||
+		mapped.ClientSecret != "default-secret" {
+		t.Fatalf("empty alias selected mapped config: %#v", mapped)
+	}
+}
+
+func TestOAuthConfigForAliasSupportsAliasOnlyClient(t *testing.T) {
+	t.Setenv("GOOGLE_OAUTH_ALIAS__EC", "vijay@eightcapital.com")
+	t.Setenv("GOOGLE_CLIENT_ID__EC", "ec-client")
+	t.Setenv("GOOGLE_CLIENT_SECRET__EC", "ec-secret")
+
+	mapped := OAuthConfigForAlias(nil, "vijay@eightcapital.com")
+	if mapped == nil ||
+		mapped.ClientID != "ec-client" ||
+		mapped.ClientSecret != "ec-secret" {
+		t.Fatalf("alias-only config = %#v", mapped)
+	}
+	if unmapped := OAuthConfigForAlias(nil, "other@example.com"); unmapped != nil {
+		t.Fatalf("unexpected unmapped config = %#v", unmapped)
 	}
 }
 
@@ -101,5 +133,31 @@ func TestStoredOAuthConfigOverridesDefaultClient(t *testing.T) {
 	}
 	if base.ClientID != "default-client" {
 		t.Fatal("credential binding mutated the default OAuth config")
+	}
+}
+
+func TestFromTokenWithOAuthConfigBindsIssuingClient(t *testing.T) {
+	data, err := FromTokenWithOAuthConfig(
+		&oauth2.Token{
+			AccessToken:  "access-token",
+			RefreshToken: "refresh-token",
+		},
+		[]string{"scope"},
+		true,
+		&oauth2.Config{
+			ClientID:     "issuing-client",
+			ClientSecret: "issuing-secret",
+		},
+	)
+	if err != nil {
+		t.Fatalf("FromTokenWithOAuthConfig: %v", err)
+	}
+	stored, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if stored.OAuthClientID != "issuing-client" ||
+		stored.OAuthClientSecret != "issuing-secret" {
+		t.Fatalf("stored client binding = %#v", stored)
 	}
 }

--- a/internal/adapters/google/credential/credential_test.go
+++ b/internal/adapters/google/credential/credential_test.go
@@ -84,3 +84,22 @@ func TestOAuthConfigForAliasUsesExplicitMapping(t *testing.T) {
 		t.Fatalf("unmapped client = %q", unmapped.ClientID)
 	}
 }
+
+func TestStoredOAuthConfigOverridesDefaultClient(t *testing.T) {
+	stored := &Stored{
+		OAuthClientID:     "bound-client",
+		OAuthClientSecret: "bound-secret",
+	}
+	base := &oauth2.Config{
+		ClientID:     "default-client",
+		ClientSecret: "default-secret",
+	}
+	config := stored.OAuthConfig(base)
+	if config.ClientID != "bound-client" ||
+		config.ClientSecret != "bound-secret" {
+		t.Fatalf("bound config = %#v", config)
+	}
+	if base.ClientID != "default-client" {
+		t.Fatal("credential binding mutated the default OAuth config")
+	}
+}

--- a/internal/adapters/google/credential/credential_test.go
+++ b/internal/adapters/google/credential/credential_test.go
@@ -134,6 +134,12 @@ func TestStoredOAuthConfigOverridesDefaultClient(t *testing.T) {
 	if base.ClientID != "default-client" {
 		t.Fatal("credential binding mutated the default OAuth config")
 	}
+	boundOnly := stored.OAuthConfig(nil)
+	if boundOnly == nil ||
+		boundOnly.ClientID != "bound-client" ||
+		boundOnly.ClientSecret != "bound-secret" {
+		t.Fatalf("bound-only config = %#v", boundOnly)
+	}
 }
 
 func TestFromTokenWithOAuthConfigBindsIssuingClient(t *testing.T) {

--- a/internal/adapters/google/drive/adapter.go
+++ b/internal/adapters/google/drive/adapter.go
@@ -113,7 +113,9 @@ func (a *DriveAdapter) httpClient(ctx context.Context, credBytes []byte, config 
 	if err != nil {
 		return nil, fmt.Errorf("drive: %w", err)
 	}
-	oauthConfig := a.OAuthConfigForAlias(config["_clawvisor_alias"])
+	oauthConfig := cred.OAuthConfig(
+		a.OAuthConfigForAlias(config["_clawvisor_alias"]),
+	)
 	ts := oauthConfig.TokenSource(ctx, cred.ToOAuth2Token())
 	return oauth2.NewClient(ctx, ts), nil
 }

--- a/internal/adapters/google/drive/adapter.go
+++ b/internal/adapters/google/drive/adapter.go
@@ -63,7 +63,12 @@ func (a *DriveAdapter) OAuthConfig() *oauth2.Config {
 }
 
 func (a *DriveAdapter) OAuthConfigForAlias(alias string) *oauth2.Config {
-	return credential.OAuthConfigForAlias(a.OAuthConfig(), alias)
+	config := credential.OAuthConfigForAlias(a.OAuthConfig(), alias)
+	if config != nil {
+		config.Scopes = driveScopes
+		config.Endpoint = google.Endpoint
+	}
+	return config
 }
 
 func (a *DriveAdapter) CredentialFromToken(token *oauth2.Token) ([]byte, error) {
@@ -76,7 +81,7 @@ func (a *DriveAdapter) ValidateCredential(credBytes []byte) error {
 
 // FetchIdentity returns the Google account email for auto-alias detection.
 func (a *DriveAdapter) FetchIdentity(ctx context.Context, credBytes []byte, config map[string]string) (string, error) {
-	client, err := a.httpClient(ctx, credBytes, config)
+	client, err := a.httpClient(ctx, credBytes, "")
 	if err != nil {
 		return "", err
 	}
@@ -84,7 +89,7 @@ func (a *DriveAdapter) FetchIdentity(ctx context.Context, credBytes []byte, conf
 }
 
 func (a *DriveAdapter) Execute(ctx context.Context, req adapters.Request) (*adapters.Result, error) {
-	client, err := a.httpClient(ctx, req.Credential, req.Config)
+	client, err := a.httpClient(ctx, req.Credential, req.Alias)
 	if err != nil {
 		return nil, err
 	}
@@ -108,13 +113,13 @@ func (a *DriveAdapter) Execute(ctx context.Context, req adapters.Request) (*adap
 	}
 }
 
-func (a *DriveAdapter) httpClient(ctx context.Context, credBytes []byte, config map[string]string) (*http.Client, error) {
+func (a *DriveAdapter) httpClient(ctx context.Context, credBytes []byte, alias string) (*http.Client, error) {
 	cred, err := credential.Parse(credBytes)
 	if err != nil {
 		return nil, fmt.Errorf("drive: %w", err)
 	}
 	oauthConfig := cred.OAuthConfig(
-		a.OAuthConfigForAlias(config["_clawvisor_alias"]),
+		a.OAuthConfigForAlias(alias),
 	)
 	ts := oauthConfig.TokenSource(ctx, cred.ToOAuth2Token())
 	return oauth2.NewClient(ctx, ts), nil

--- a/internal/adapters/google/drive/adapter.go
+++ b/internal/adapters/google/drive/adapter.go
@@ -62,6 +62,10 @@ func (a *DriveAdapter) OAuthConfig() *oauth2.Config {
 	}
 }
 
+func (a *DriveAdapter) OAuthConfigForAlias(alias string) *oauth2.Config {
+	return credential.OAuthConfigForAlias(a.OAuthConfig(), alias)
+}
+
 func (a *DriveAdapter) CredentialFromToken(token *oauth2.Token) ([]byte, error) {
 	return credential.FromToken(token, driveScopes, false)
 }
@@ -71,8 +75,8 @@ func (a *DriveAdapter) ValidateCredential(credBytes []byte) error {
 }
 
 // FetchIdentity returns the Google account email for auto-alias detection.
-func (a *DriveAdapter) FetchIdentity(ctx context.Context, credBytes []byte, _ map[string]string) (string, error) {
-	client, err := a.httpClient(ctx, credBytes)
+func (a *DriveAdapter) FetchIdentity(ctx context.Context, credBytes []byte, config map[string]string) (string, error) {
+	client, err := a.httpClient(ctx, credBytes, config)
 	if err != nil {
 		return "", err
 	}
@@ -80,7 +84,7 @@ func (a *DriveAdapter) FetchIdentity(ctx context.Context, credBytes []byte, _ ma
 }
 
 func (a *DriveAdapter) Execute(ctx context.Context, req adapters.Request) (*adapters.Result, error) {
-	client, err := a.httpClient(ctx, req.Credential)
+	client, err := a.httpClient(ctx, req.Credential, req.Config)
 	if err != nil {
 		return nil, err
 	}
@@ -104,12 +108,13 @@ func (a *DriveAdapter) Execute(ctx context.Context, req adapters.Request) (*adap
 	}
 }
 
-func (a *DriveAdapter) httpClient(ctx context.Context, credBytes []byte) (*http.Client, error) {
+func (a *DriveAdapter) httpClient(ctx context.Context, credBytes []byte, config map[string]string) (*http.Client, error) {
 	cred, err := credential.Parse(credBytes)
 	if err != nil {
 		return nil, fmt.Errorf("drive: %w", err)
 	}
-	ts := a.OAuthConfig().TokenSource(ctx, cred.ToOAuth2Token())
+	oauthConfig := a.OAuthConfigForAlias(config["_clawvisor_alias"])
+	ts := oauthConfig.TokenSource(ctx, cred.ToOAuth2Token())
 	return oauth2.NewClient(ctx, ts), nil
 }
 

--- a/internal/adapters/google/drive/adapter.go
+++ b/internal/adapters/google/drive/adapter.go
@@ -121,6 +121,11 @@ func (a *DriveAdapter) httpClient(ctx context.Context, credBytes []byte, alias s
 	oauthConfig := cred.OAuthConfig(
 		a.OAuthConfigForAlias(alias),
 	)
+	if oauthConfig == nil {
+		return nil, fmt.Errorf("drive: OAuth client credentials not configured")
+	}
+	oauthConfig.Scopes = driveScopes
+	oauthConfig.Endpoint = google.Endpoint
 	ts := oauthConfig.TokenSource(ctx, cred.ToOAuth2Token())
 	return oauth2.NewClient(ctx, ts), nil
 }

--- a/internal/adapters/google/gmail/adapter.go
+++ b/internal/adapters/google/gmail/adapter.go
@@ -143,7 +143,9 @@ func (a *GmailAdapter) httpClient(ctx context.Context, credBytes []byte, config 
 	if err != nil {
 		return nil, fmt.Errorf("gmail: %w", err)
 	}
-	oauthConfig := a.OAuthConfigForAlias(config["_clawvisor_alias"])
+	oauthConfig := cred.OAuthConfig(
+		a.OAuthConfigForAlias(config["_clawvisor_alias"]),
+	)
 	ts := oauthConfig.TokenSource(ctx, cred.ToOAuth2Token())
 	return oauth2.NewClient(ctx, ts), nil
 }

--- a/internal/adapters/google/gmail/adapter.go
+++ b/internal/adapters/google/gmail/adapter.go
@@ -151,6 +151,11 @@ func (a *GmailAdapter) httpClient(ctx context.Context, credBytes []byte, alias s
 	oauthConfig := cred.OAuthConfig(
 		a.OAuthConfigForAlias(alias),
 	)
+	if oauthConfig == nil {
+		return nil, fmt.Errorf("gmail: OAuth client credentials not configured")
+	}
+	oauthConfig.Scopes = gmailScopes
+	oauthConfig.Endpoint = google.Endpoint
 	ts := oauthConfig.TokenSource(ctx, cred.ToOAuth2Token())
 	return oauth2.NewClient(ctx, ts), nil
 }

--- a/internal/adapters/google/gmail/adapter.go
+++ b/internal/adapters/google/gmail/adapter.go
@@ -76,7 +76,12 @@ func (a *GmailAdapter) OAuthConfig() *oauth2.Config {
 }
 
 func (a *GmailAdapter) OAuthConfigForAlias(alias string) *oauth2.Config {
-	return credential.OAuthConfigForAlias(a.OAuthConfig(), alias)
+	config := credential.OAuthConfigForAlias(a.OAuthConfig(), alias)
+	if config != nil {
+		config.Scopes = gmailScopes
+		config.Endpoint = google.Endpoint
+	}
+	return config
 }
 
 func (a *GmailAdapter) CredentialFromToken(token *oauth2.Token) ([]byte, error) {
@@ -89,7 +94,7 @@ func (a *GmailAdapter) ValidateCredential(credBytes []byte) error {
 
 // FetchIdentity returns the Google account email for auto-alias detection.
 func (a *GmailAdapter) FetchIdentity(ctx context.Context, credBytes []byte, config map[string]string) (string, error) {
-	client, err := a.httpClient(ctx, credBytes, config)
+	client, err := a.httpClient(ctx, credBytes, "")
 	if err != nil {
 		return "", err
 	}
@@ -98,7 +103,7 @@ func (a *GmailAdapter) FetchIdentity(ctx context.Context, credBytes []byte, conf
 
 // Execute runs a Gmail action. Credential is injected by the gateway.
 func (a *GmailAdapter) Execute(ctx context.Context, req adapters.Request) (*adapters.Result, error) {
-	client, err := a.httpClient(ctx, req.Credential, req.Config)
+	client, err := a.httpClient(ctx, req.Credential, req.Alias)
 	if err != nil {
 		return nil, err
 	}
@@ -138,13 +143,13 @@ func (a *GmailAdapter) Execute(ctx context.Context, req adapters.Request) (*adap
 
 // ── HTTP client from stored credential ───────────────────────────────────────
 
-func (a *GmailAdapter) httpClient(ctx context.Context, credBytes []byte, config map[string]string) (*http.Client, error) {
+func (a *GmailAdapter) httpClient(ctx context.Context, credBytes []byte, alias string) (*http.Client, error) {
 	cred, err := credential.Parse(credBytes)
 	if err != nil {
 		return nil, fmt.Errorf("gmail: %w", err)
 	}
 	oauthConfig := cred.OAuthConfig(
-		a.OAuthConfigForAlias(config["_clawvisor_alias"]),
+		a.OAuthConfigForAlias(alias),
 	)
 	ts := oauthConfig.TokenSource(ctx, cred.ToOAuth2Token())
 	return oauth2.NewClient(ctx, ts), nil

--- a/internal/adapters/google/gmail/adapter.go
+++ b/internal/adapters/google/gmail/adapter.go
@@ -75,6 +75,10 @@ func (a *GmailAdapter) OAuthConfig() *oauth2.Config {
 	}
 }
 
+func (a *GmailAdapter) OAuthConfigForAlias(alias string) *oauth2.Config {
+	return credential.OAuthConfigForAlias(a.OAuthConfig(), alias)
+}
+
 func (a *GmailAdapter) CredentialFromToken(token *oauth2.Token) ([]byte, error) {
 	return credential.FromToken(token, gmailScopes, false)
 }
@@ -84,8 +88,8 @@ func (a *GmailAdapter) ValidateCredential(credBytes []byte) error {
 }
 
 // FetchIdentity returns the Google account email for auto-alias detection.
-func (a *GmailAdapter) FetchIdentity(ctx context.Context, credBytes []byte, _ map[string]string) (string, error) {
-	client, err := a.httpClient(ctx, credBytes)
+func (a *GmailAdapter) FetchIdentity(ctx context.Context, credBytes []byte, config map[string]string) (string, error) {
+	client, err := a.httpClient(ctx, credBytes, config)
 	if err != nil {
 		return "", err
 	}
@@ -94,7 +98,7 @@ func (a *GmailAdapter) FetchIdentity(ctx context.Context, credBytes []byte, _ ma
 
 // Execute runs a Gmail action. Credential is injected by the gateway.
 func (a *GmailAdapter) Execute(ctx context.Context, req adapters.Request) (*adapters.Result, error) {
-	client, err := a.httpClient(ctx, req.Credential)
+	client, err := a.httpClient(ctx, req.Credential, req.Config)
 	if err != nil {
 		return nil, err
 	}
@@ -134,12 +138,13 @@ func (a *GmailAdapter) Execute(ctx context.Context, req adapters.Request) (*adap
 
 // ── HTTP client from stored credential ───────────────────────────────────────
 
-func (a *GmailAdapter) httpClient(ctx context.Context, credBytes []byte) (*http.Client, error) {
+func (a *GmailAdapter) httpClient(ctx context.Context, credBytes []byte, config map[string]string) (*http.Client, error) {
 	cred, err := credential.Parse(credBytes)
 	if err != nil {
 		return nil, fmt.Errorf("gmail: %w", err)
 	}
-	ts := a.OAuthConfig().TokenSource(ctx, cred.ToOAuth2Token())
+	oauthConfig := a.OAuthConfigForAlias(config["_clawvisor_alias"])
+	ts := oauthConfig.TokenSource(ctx, cred.ToOAuth2Token())
 	return oauth2.NewClient(ctx, ts), nil
 }
 

--- a/internal/adapters/google/gmail/adapter.go
+++ b/internal/adapters/google/gmail/adapter.go
@@ -147,6 +147,7 @@ func (a *GmailAdapter) httpClient(ctx context.Context, credBytes []byte) (*http.
 
 type msgListItem struct {
 	ID       string   `json:"id"`
+	ThreadID string   `json:"thread_id"`
 	From     string   `json:"from"`
 	Subject  string   `json:"subject"`
 	Snippet  string   `json:"snippet"`
@@ -206,6 +207,7 @@ func (a *GmailAdapter) listMessages(ctx context.Context, client *http.Client, pa
 		}
 		item := msgListItem{
 			ID:       ids[i],
+			ThreadID: meta.threadID,
 			From:     format.SanitizeHeader(meta.from, format.MaxFieldLen),
 			Subject:  format.SanitizeText(meta.subject, format.MaxFieldLen),
 			Snippet:  format.SanitizeText(meta.snippet, format.MaxSnippetLen),
@@ -1143,9 +1145,9 @@ func fetchLabelMap(ctx context.Context, client *http.Client) map[string]string {
 // ── Message parsing helpers ───────────────────────────────────────────────────
 
 type msgMeta struct {
-	from, subject, snippet, date string
-	isUnread                     bool
-	labelIDs                     []string
+	threadID, from, subject, snippet, date string
+	isUnread                               bool
+	labelIDs                               []string
 }
 
 // gmailBatchMaxRequests is Gmail's documented per-batch cap.
@@ -1313,6 +1315,7 @@ func parseBatchSubResponse(body []byte) (msgMeta, error) {
 		return msgMeta{}, fmt.Errorf("gmail batch sub: %d: %s", sub.StatusCode, format.Truncate(string(subBody), 200))
 	}
 	var raw struct {
+		ThreadID string   `json:"threadId"`
 		Snippet  string   `json:"snippet"`
 		LabelIds []string `json:"labelIds"`
 		Payload  struct {
@@ -1322,7 +1325,11 @@ func parseBatchSubResponse(body []byte) (msgMeta, error) {
 	if err := json.Unmarshal(subBody, &raw); err != nil {
 		return msgMeta{}, fmt.Errorf("gmail batch sub decode: %w", err)
 	}
-	meta := msgMeta{snippet: raw.Snippet, labelIDs: raw.LabelIds}
+	meta := msgMeta{
+		threadID: raw.ThreadID,
+		snippet:  raw.Snippet,
+		labelIDs: raw.LabelIds,
+	}
 	for _, h := range raw.Payload.Headers {
 		switch strings.ToLower(h.Name) {
 		case "from":

--- a/internal/adapters/google/gmail/adapter_test.go
+++ b/internal/adapters/google/gmail/adapter_test.go
@@ -895,8 +895,8 @@ func (s *batchTestServer) serveBatch(req *http.Request) (*http.Response, error) 
 		if status >= 400 {
 			subBody = fmt.Sprintf(`{"error":{"code":%d,"message":"mock failure"}}`, status)
 		} else {
-			subBody = fmt.Sprintf(`{"snippet":"Snippet for %s","labelIds":["INBOX","UNREAD"],"payload":{"headers":[{"name":"From","value":"sender-%s@example.com"},{"name":"Subject","value":"Subject %s"},{"name":"Date","value":"Date-%s"}]}}`,
-				sub.msgID, sub.msgID, sub.msgID, sub.msgID)
+			subBody = fmt.Sprintf(`{"threadId":"thread-%s","snippet":"Snippet for %s","labelIds":["INBOX","UNREAD"],"payload":{"headers":[{"name":"From","value":"sender-%s@example.com"},{"name":"Subject","value":"Subject %s"},{"name":"Date","value":"Date-%s"}]}}`,
+				sub.msgID, sub.msgID, sub.msgID, sub.msgID, sub.msgID)
 		}
 		fmt.Fprintf(w, "HTTP/1.1 %d %s\r\nContent-Type: application/json\r\nContent-Length: %d\r\n\r\n%s",
 			status, http.StatusText(status), len(subBody), subBody)
@@ -960,6 +960,14 @@ func TestListMessages_BatchSuccess(t *testing.T) {
 	for i, item := range items {
 		if item.ID != ids[i] {
 			t.Errorf("items[%d].ID = %q, want %q", i, item.ID, ids[i])
+		}
+		if want := "thread-" + ids[i]; item.ThreadID != want {
+			t.Errorf(
+				"items[%d].ThreadID = %q, want %q",
+				i,
+				item.ThreadID,
+				want,
+			)
 		}
 		if want := fmt.Sprintf("sender-%s@example.com", ids[i]); item.From != want {
 			t.Errorf("items[%d].From = %q, want %q", i, item.From, want)

--- a/internal/adapters/google/sheets/adapter.go
+++ b/internal/adapters/google/sheets/adapter.go
@@ -56,7 +56,12 @@ func (a *SheetsAdapter) OAuthConfig() *oauth2.Config {
 }
 
 func (a *SheetsAdapter) OAuthConfigForAlias(alias string) *oauth2.Config {
-	return credential.OAuthConfigForAlias(a.OAuthConfig(), alias)
+	config := credential.OAuthConfigForAlias(a.OAuthConfig(), alias)
+	if config != nil {
+		config.Scopes = sheetsScopes
+		config.Endpoint = google.Endpoint
+	}
+	return config
 }
 
 func (a *SheetsAdapter) CredentialFromToken(token *oauth2.Token) ([]byte, error) {
@@ -69,7 +74,7 @@ func (a *SheetsAdapter) ValidateCredential(credBytes []byte) error {
 
 // FetchIdentity returns the Google account email for auto-alias detection.
 func (a *SheetsAdapter) FetchIdentity(ctx context.Context, credBytes []byte, config map[string]string) (string, error) {
-	client, err := a.httpClient(ctx, credBytes, config)
+	client, err := a.httpClient(ctx, credBytes, "")
 	if err != nil {
 		return "", err
 	}
@@ -77,7 +82,7 @@ func (a *SheetsAdapter) FetchIdentity(ctx context.Context, credBytes []byte, con
 }
 
 func (a *SheetsAdapter) Execute(ctx context.Context, req adapters.Request) (*adapters.Result, error) {
-	client, err := a.httpClient(ctx, req.Credential, req.Config)
+	client, err := a.httpClient(ctx, req.Credential, req.Alias)
 	if err != nil {
 		return nil, err
 	}
@@ -100,12 +105,12 @@ func (a *SheetsAdapter) Execute(ctx context.Context, req adapters.Request) (*ada
 	}
 }
 
-func (a *SheetsAdapter) httpClient(ctx context.Context, credBytes []byte, config map[string]string) (*http.Client, error) {
+func (a *SheetsAdapter) httpClient(ctx context.Context, credBytes []byte, alias string) (*http.Client, error) {
 	cred, err := credential.Parse(credBytes)
 	if err != nil {
 		return nil, fmt.Errorf("sheets: %w", err)
 	}
-	cfg := cred.OAuthConfig(a.OAuthConfigForAlias(config["_clawvisor_alias"]))
+	cfg := cred.OAuthConfig(a.OAuthConfigForAlias(alias))
 	if cfg == nil {
 		return nil, fmt.Errorf("sheets: OAuth client credentials not configured")
 	}

--- a/internal/adapters/google/sheets/adapter.go
+++ b/internal/adapters/google/sheets/adapter.go
@@ -114,6 +114,8 @@ func (a *SheetsAdapter) httpClient(ctx context.Context, credBytes []byte, alias 
 	if cfg == nil {
 		return nil, fmt.Errorf("sheets: OAuth client credentials not configured")
 	}
+	cfg.Scopes = sheetsScopes
+	cfg.Endpoint = google.Endpoint
 	ts := cfg.TokenSource(ctx, cred.ToOAuth2Token())
 	return oauth2.NewClient(ctx, ts), nil
 }

--- a/internal/adapters/google/sheets/adapter.go
+++ b/internal/adapters/google/sheets/adapter.go
@@ -55,6 +55,10 @@ func (a *SheetsAdapter) OAuthConfig() *oauth2.Config {
 	}
 }
 
+func (a *SheetsAdapter) OAuthConfigForAlias(alias string) *oauth2.Config {
+	return credential.OAuthConfigForAlias(a.OAuthConfig(), alias)
+}
+
 func (a *SheetsAdapter) CredentialFromToken(token *oauth2.Token) ([]byte, error) {
 	return credential.FromToken(token, sheetsScopes, false)
 }
@@ -64,8 +68,8 @@ func (a *SheetsAdapter) ValidateCredential(credBytes []byte) error {
 }
 
 // FetchIdentity returns the Google account email for auto-alias detection.
-func (a *SheetsAdapter) FetchIdentity(ctx context.Context, credBytes []byte, _ map[string]string) (string, error) {
-	client, err := a.httpClient(ctx, credBytes)
+func (a *SheetsAdapter) FetchIdentity(ctx context.Context, credBytes []byte, config map[string]string) (string, error) {
+	client, err := a.httpClient(ctx, credBytes, config)
 	if err != nil {
 		return "", err
 	}
@@ -73,7 +77,7 @@ func (a *SheetsAdapter) FetchIdentity(ctx context.Context, credBytes []byte, _ m
 }
 
 func (a *SheetsAdapter) Execute(ctx context.Context, req adapters.Request) (*adapters.Result, error) {
-	client, err := a.httpClient(ctx, req.Credential)
+	client, err := a.httpClient(ctx, req.Credential, req.Config)
 	if err != nil {
 		return nil, err
 	}
@@ -96,12 +100,12 @@ func (a *SheetsAdapter) Execute(ctx context.Context, req adapters.Request) (*ada
 	}
 }
 
-func (a *SheetsAdapter) httpClient(ctx context.Context, credBytes []byte) (*http.Client, error) {
+func (a *SheetsAdapter) httpClient(ctx context.Context, credBytes []byte, config map[string]string) (*http.Client, error) {
 	cred, err := credential.Parse(credBytes)
 	if err != nil {
 		return nil, fmt.Errorf("sheets: %w", err)
 	}
-	cfg := a.OAuthConfig()
+	cfg := a.OAuthConfigForAlias(config["_clawvisor_alias"])
 	if cfg == nil {
 		return nil, fmt.Errorf("sheets: OAuth client credentials not configured")
 	}

--- a/internal/adapters/google/sheets/adapter.go
+++ b/internal/adapters/google/sheets/adapter.go
@@ -105,7 +105,7 @@ func (a *SheetsAdapter) httpClient(ctx context.Context, credBytes []byte, config
 	if err != nil {
 		return nil, fmt.Errorf("sheets: %w", err)
 	}
-	cfg := a.OAuthConfigForAlias(config["_clawvisor_alias"])
+	cfg := cred.OAuthConfig(a.OAuthConfigForAlias(config["_clawvisor_alias"]))
 	if cfg == nil {
 		return nil, fmt.Errorf("sheets: OAuth client credentials not configured")
 	}

--- a/internal/api/gateway_execution_failure_test.go
+++ b/internal/api/gateway_execution_failure_test.go
@@ -1,0 +1,159 @@
+package api_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync/atomic"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/pkg/adapters"
+)
+
+func TestGatewayClassifiedAdapterFailuresSurviveDuplicateRequest(t *testing.T) {
+	tests := []struct {
+		name         string
+		kind         adapters.ExecutionFailureKind
+		wantCode     string
+		wantOutcome  string
+		wantTimedOut bool
+	}{
+		{
+			name:        "definite",
+			kind:        adapters.ExecutionFailureDefinite,
+			wantCode:    "PROVIDER_DEFINITE_FAILURE",
+			wantOutcome: "provider_definite_failure",
+		},
+		{
+			name:        "stale version",
+			kind:        adapters.ExecutionFailureStaleVersion,
+			wantCode:    "STALE_VERSION",
+			wantOutcome: "provider_stale_version",
+		},
+		{
+			name:        "ambiguous",
+			kind:        adapters.ExecutionFailureAmbiguous,
+			wantCode:    "AMBIGUOUS_OUTCOME",
+			wantOutcome: "provider_ambiguous",
+		},
+	}
+
+	for i, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			serviceID := fmt.Sprintf("mock.classified.%d", i)
+			adapter := newMockAdapter(serviceID, "run").withError(&adapters.ExecutionFailure{
+				Kind:     tc.kind,
+				TimedOut: tc.wantTimedOut,
+				Err:      errors.New("classified provider failure"),
+			})
+			env := newTestEnv(t, adapter)
+			sc := newScenario(t, env, "atlas")
+			taskID := sc.createApprovedTask(t, env, serviceID, "run", true)
+			requestID := fmt.Sprintf("classified-%d", i)
+
+			first := sc.gatewayRequestWithTask(env, requestID, serviceID, "run", taskID)
+			assertGatewayExecutionFailure(t, first, tc.wantCode, string(tc.kind), tc.wantTimedOut)
+
+			duplicate := sc.gatewayRequestWithTask(env, requestID, serviceID, "run", taskID)
+			assertGatewayExecutionFailure(t, duplicate, tc.wantCode, string(tc.kind), tc.wantTimedOut)
+			if duplicate["deduped"] != true {
+				t.Fatalf("duplicate response missing deduped=true: %v", duplicate)
+			}
+			if duplicate["audit_id"] != first["audit_id"] {
+				t.Fatalf("duplicate audit_id = %v, want canonical %v", duplicate["audit_id"], first["audit_id"])
+			}
+			if adapter.executeCount() != 1 {
+				t.Fatalf("adapter executions = %d, want 1", adapter.executeCount())
+			}
+
+			entry, err := env.Store.GetAuditEntryByRequestIDAndTask(context.Background(), requestID, sc.session.UserID, taskID)
+			if err != nil {
+				t.Fatalf("GetAuditEntryByRequestIDAndTask: %v", err)
+			}
+			if entry.Outcome != tc.wantOutcome {
+				t.Fatalf("audit outcome = %q, want %q", entry.Outcome, tc.wantOutcome)
+			}
+		})
+	}
+}
+
+func TestGatewayClickExecutionTimeoutAfterCommitRemainsIdempotent(t *testing.T) {
+	var simulatedCommits atomic.Int32
+	adapter := newMockAdapter("mock.click-timeout", "respond_to_event").
+		withExecuteHook(func() { simulatedCommits.Add(1) }).
+		withError(&adapters.ExecutionFailure{
+			Kind:     adapters.ExecutionFailureAmbiguous,
+			TimedOut: true,
+			Err:      errors.New("provider timed out after accepting the mutation"),
+		})
+	env := newTestEnv(t, adapter)
+	sc := newScenario(t, env, "atlas")
+	taskID := sc.createApprovedTask(t, env, "mock.click-timeout", "respond_to_event", false)
+	requestID := "click-timeout-after-commit"
+
+	pending := sc.gatewayRequestWithTask(env, requestID, "mock.click-timeout", "respond_to_event", taskID)
+	if pending["status"] != "pending" {
+		t.Fatalf("initial status = %v, want pending: %v", pending["status"], pending)
+	}
+	resp := sc.session.do("POST", fmt.Sprintf("/api/approvals/%s/approve", requestID), nil)
+	mustStatus(t, resp, http.StatusOK)
+
+	resp = env.do(
+		"POST",
+		fmt.Sprintf("/api/gateway/request/%s/execute?task_id=%s", requestID, taskID),
+		sc.AgentToken,
+		nil,
+	)
+	executed := mustStatus(t, resp, http.StatusOK)
+	assertGatewayExecutionFailure(t, executed, "PROVIDER_TIMEOUT", "ambiguous", true)
+	if simulatedCommits.Load() != 1 {
+		t.Fatalf("simulated provider commits = %d, want 1", simulatedCommits.Load())
+	}
+
+	duplicate := sc.gatewayRequestWithTask(env, requestID, "mock.click-timeout", "respond_to_event", taskID)
+	assertGatewayExecutionFailure(t, duplicate, "PROVIDER_TIMEOUT", "ambiguous", true)
+	if duplicate["deduped"] != true {
+		t.Fatalf("duplicate response missing deduped=true: %v", duplicate)
+	}
+	if simulatedCommits.Load() != 1 || adapter.executeCount() != 1 {
+		t.Fatalf(
+			"duplicate re-executed mutation: commits=%d executions=%d",
+			simulatedCommits.Load(),
+			adapter.executeCount(),
+		)
+	}
+
+	entry, err := env.Store.GetAuditEntryByRequestIDAndTask(context.Background(), requestID, sc.session.UserID, taskID)
+	if err != nil {
+		t.Fatalf("GetAuditEntryByRequestIDAndTask: %v", err)
+	}
+	if entry.Outcome != "provider_timeout" {
+		t.Fatalf("audit outcome = %q, want provider_timeout", entry.Outcome)
+	}
+}
+
+func assertGatewayExecutionFailure(
+	t *testing.T,
+	body map[string]any,
+	wantCode, wantKind string,
+	wantTimedOut bool,
+) {
+	t.Helper()
+	if body["status"] != "error" {
+		t.Fatalf("status = %v, want error: %v", body["status"], body)
+	}
+	if body["code"] != wantCode {
+		t.Fatalf("code = %v, want %s: %v", body["code"], wantCode, body)
+	}
+	if body["failure_kind"] != wantKind {
+		t.Fatalf("failure_kind = %v, want %s: %v", body["failure_kind"], wantKind, body)
+	}
+	if wantTimedOut {
+		if body["timed_out"] != true {
+			t.Fatalf("timed_out = %v, want true: %v", body["timed_out"], body)
+		}
+	} else if _, exists := body["timed_out"]; exists {
+		t.Fatalf("unexpected timed_out field: %v", body)
+	}
+}

--- a/internal/api/handlers/adapter_execution_failure.go
+++ b/internal/api/handlers/adapter_execution_failure.go
@@ -1,0 +1,101 @@
+package handlers
+
+import (
+	"github.com/clawvisor/clawvisor/pkg/adapters"
+	"github.com/clawvisor/clawvisor/pkg/gateway"
+)
+
+// Classified adapter failures are persisted as audit outcomes so a retry with
+// the same request_id can reconstruct the original machine-readable response
+// without invoking the provider again.
+const (
+	auditOutcomeDefiniteFailure = "provider_definite_failure"
+	auditOutcomeStaleVersion    = "provider_stale_version"
+	auditOutcomeAmbiguous       = "provider_ambiguous"
+	auditOutcomeTimeout         = "provider_timeout"
+)
+
+type adapterExecutionFailureDescription struct {
+	AuditOutcome string
+	Code         string
+	Kind         adapters.ExecutionFailureKind
+	TimedOut     bool
+}
+
+func describeAdapterExecutionFailure(err error) (adapterExecutionFailureDescription, bool) {
+	failure, ok := adapters.AsExecutionFailure(err)
+	if !ok {
+		return adapterExecutionFailureDescription{}, false
+	}
+
+	switch failure.Kind {
+	case adapters.ExecutionFailureDefinite:
+		return adapterExecutionFailureDescription{
+			AuditOutcome: auditOutcomeDefiniteFailure,
+			Code:         gateway.CodeProviderDefiniteFailure,
+			Kind:         adapters.ExecutionFailureDefinite,
+		}, true
+	case adapters.ExecutionFailureStaleVersion:
+		return adapterExecutionFailureDescription{
+			AuditOutcome: auditOutcomeStaleVersion,
+			Code:         gateway.CodeStaleVersion,
+			Kind:         adapters.ExecutionFailureStaleVersion,
+		}, true
+	case adapters.ExecutionFailureAmbiguous:
+		if failure.TimedOut {
+			return adapterExecutionFailureDescription{
+				AuditOutcome: auditOutcomeTimeout,
+				Code:         gateway.CodeProviderTimeout,
+				Kind:         adapters.ExecutionFailureAmbiguous,
+				TimedOut:     true,
+			}, true
+		}
+		return adapterExecutionFailureDescription{
+			AuditOutcome: auditOutcomeAmbiguous,
+			Code:         gateway.CodeAmbiguousOutcome,
+			Kind:         adapters.ExecutionFailureAmbiguous,
+		}, true
+	default:
+		return adapterExecutionFailureDescription{}, false
+	}
+}
+
+func describeAuditExecutionFailure(outcome string) (adapterExecutionFailureDescription, bool) {
+	switch outcome {
+	case auditOutcomeDefiniteFailure:
+		return adapterExecutionFailureDescription{
+			AuditOutcome: outcome,
+			Code:         gateway.CodeProviderDefiniteFailure,
+			Kind:         adapters.ExecutionFailureDefinite,
+		}, true
+	case auditOutcomeStaleVersion:
+		return adapterExecutionFailureDescription{
+			AuditOutcome: outcome,
+			Code:         gateway.CodeStaleVersion,
+			Kind:         adapters.ExecutionFailureStaleVersion,
+		}, true
+	case auditOutcomeAmbiguous:
+		return adapterExecutionFailureDescription{
+			AuditOutcome: outcome,
+			Code:         gateway.CodeAmbiguousOutcome,
+			Kind:         adapters.ExecutionFailureAmbiguous,
+		}, true
+	case auditOutcomeTimeout:
+		return adapterExecutionFailureDescription{
+			AuditOutcome: outcome,
+			Code:         gateway.CodeProviderTimeout,
+			Kind:         adapters.ExecutionFailureAmbiguous,
+			TimedOut:     true,
+		}, true
+	default:
+		return adapterExecutionFailureDescription{}, false
+	}
+}
+
+func addAdapterExecutionFailureFields(resp map[string]any, failure adapterExecutionFailureDescription) {
+	resp["code"] = failure.Code
+	resp["failure_kind"] = string(failure.Kind)
+	if failure.TimedOut {
+		resp["timed_out"] = true
+	}
+}

--- a/internal/api/handlers/adapter_execution_failure_test.go
+++ b/internal/api/handlers/adapter_execution_failure_test.go
@@ -1,0 +1,78 @@
+package handlers
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/pkg/adapters"
+)
+
+func TestAdapterExecutionFailureAuditRoundTrip(t *testing.T) {
+	tests := []struct {
+		name      string
+		failure   *adapters.ExecutionFailure
+		wantAudit string
+		wantCode  string
+		wantKind  adapters.ExecutionFailureKind
+		wantTimed bool
+	}{
+		{
+			name:      "definite",
+			failure:   &adapters.ExecutionFailure{Kind: adapters.ExecutionFailureDefinite, Err: errors.New("rejected")},
+			wantAudit: "provider_definite_failure",
+			wantCode:  "PROVIDER_DEFINITE_FAILURE",
+			wantKind:  adapters.ExecutionFailureDefinite,
+		},
+		{
+			name:      "stale version",
+			failure:   &adapters.ExecutionFailure{Kind: adapters.ExecutionFailureStaleVersion, Err: errors.New("stale")},
+			wantAudit: "provider_stale_version",
+			wantCode:  "STALE_VERSION",
+			wantKind:  adapters.ExecutionFailureStaleVersion,
+		},
+		{
+			name:      "ambiguous",
+			failure:   &adapters.ExecutionFailure{Kind: adapters.ExecutionFailureAmbiguous, Err: errors.New("unknown")},
+			wantAudit: "provider_ambiguous",
+			wantCode:  "AMBIGUOUS_OUTCOME",
+			wantKind:  adapters.ExecutionFailureAmbiguous,
+		},
+		{
+			name:      "timeout",
+			failure:   &adapters.ExecutionFailure{Kind: adapters.ExecutionFailureAmbiguous, TimedOut: true, Err: errors.New("timed out")},
+			wantAudit: "provider_timeout",
+			wantCode:  "PROVIDER_TIMEOUT",
+			wantKind:  adapters.ExecutionFailureAmbiguous,
+			wantTimed: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			description, ok := describeAdapterExecutionFailure(tc.failure)
+			if !ok {
+				t.Fatal("execution failure was not classified")
+			}
+			if description.AuditOutcome != tc.wantAudit ||
+				description.Code != tc.wantCode ||
+				description.Kind != tc.wantKind ||
+				description.TimedOut != tc.wantTimed {
+				t.Fatalf("execution classification = %+v", description)
+			}
+
+			restored, ok := describeAuditExecutionFailure(description.AuditOutcome)
+			if !ok {
+				t.Fatal("persisted failure was not restored")
+			}
+			if restored != description {
+				t.Fatalf("restored classification = %+v, want %+v", restored, description)
+			}
+		})
+	}
+}
+
+func TestApprovalTimeoutIsNotClassifiedAsProviderTimeout(t *testing.T) {
+	if got, ok := describeAuditExecutionFailure("timeout"); ok {
+		t.Fatalf("approval timeout was misclassified as provider failure: %+v", got)
+	}
+}

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -2435,13 +2435,13 @@ func executeAdapterRequest(
 	if config == nil {
 		config = make(map[string]string)
 	}
-	config["_clawvisor_alias"] = alias
 
 	result, err := adapter.Execute(ctx, adapters.Request{
 		Action:     action,
 		Params:     params,
 		Credential: cred,
 		Config:     config,
+		Alias:      alias,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("adapter %s: %w", service, err)

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -1154,16 +1154,27 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 
 			if execErr != nil {
 				errMsg := execErr.Error()
-				if updErr := h.store.UpdateAuditOutcome(finalizeCtx, auditID, "error", errMsg, dur); updErr != nil {
+				auditOutcome := "error"
+				failure, classified := describeAdapterExecutionFailure(execErr)
+				if classified {
+					auditOutcome = failure.AuditOutcome
+				}
+				if updErr := h.store.UpdateAuditOutcome(finalizeCtx, auditID, auditOutcome, errMsg, dur); updErr != nil {
 					h.logger.WarnContext(ctx, "audit outcome update failed", "err", updErr)
 				}
-				outDecision, outOutcome = "execute", "error"
+				outDecision, outOutcome = "execute", auditOutcome
 				h.publishAuditAndQueue(agent.UserID, req.TaskID)
 				if req.Context.CallbackURL != "" {
 					cbKey, _ := h.store.GetAgentCallbackSecret(finalizeCtx, agent.ID)
-					h.dispatchCallback(req.Context.CallbackURL, &callback.Payload{
+					payload := &callback.Payload{
 						Type: "request", RequestID: req.RequestID, Status: "error", Error: errMsg, AuditID: auditID,
-					}, cbKey)
+					}
+					if classified {
+						payload.Code = failure.Code
+						payload.FailureKind = string(failure.Kind)
+						payload.TimedOut = failure.TimedOut
+					}
+					h.dispatchCallback(req.Context.CallbackURL, payload, cbKey)
 				}
 				resp := map[string]any{
 					"status":     "error",
@@ -1171,6 +1182,9 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 					"audit_id":   auditID,
 					"error":      errMsg,
 					"code":       gateway.CodeAdapterError,
+				}
+				if classified {
+					addAdapterExecutionFailureFields(resp, failure)
 				}
 				h.maybeInjectNPS(ctx, resp, agent.ID)
 				writeJSON(w, http.StatusOK, resp)
@@ -1624,15 +1638,33 @@ func (h *GatewayHandler) executeAndRespond(w http.ResponseWriter, ctx context.Co
 	}
 	dur := int(time.Since(start).Milliseconds())
 
-	outcome := "executed"
+	status := "executed"
+	auditOutcome := "executed"
 	errMsg := ""
+	var failure adapterExecutionFailureDescription
+	var classified bool
 	if execErr != nil {
-		outcome = "error"
+		status = "error"
+		auditOutcome = "error"
 		errMsg = execErr.Error()
+		failure, classified = describeAdapterExecutionFailure(execErr)
+		if classified {
+			auditOutcome = failure.AuditOutcome
+		}
 	}
 
-	_ = h.store.UpdateAuditOutcome(ctx, pa.AuditID, outcome, errMsg, dur)
-	_ = h.store.DeletePendingApproval(ctx, pa.RequestID, pa.UserID, paTask)
+	// The adapter may return because the request deadline elapsed after the
+	// provider accepted a mutation. Finalize the canonical row with a fresh
+	// context so duplicate request_ids observe the classified result instead
+	// of a permanently in-flight reservation.
+	finalizeCtx, finalizeCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer finalizeCancel()
+	if err := h.store.UpdateAuditOutcome(finalizeCtx, pa.AuditID, auditOutcome, errMsg, dur); err != nil {
+		h.logger.WarnContext(ctx, "audit outcome update failed", "err", err)
+	}
+	if err := h.store.DeletePendingApproval(finalizeCtx, pa.RequestID, pa.UserID, paTask); err != nil {
+		h.logger.WarnContext(ctx, "pending approval cleanup failed", "err", err)
+	}
 	h.publishAuditAndQueue(pa.UserID, blob.TaskID)
 
 	// On successful execution, seed chain_facts with anything the new result
@@ -1651,12 +1683,16 @@ func (h *GatewayHandler) executeAndRespond(w http.ResponseWriter, ctx context.Co
 	}
 
 	resp := map[string]any{
-		"status":     outcome,
+		"status":     status,
 		"request_id": pa.RequestID,
 		"audit_id":   pa.AuditID,
 	}
 	if execErr != nil {
 		resp["error"] = errMsg
+		resp["code"] = gateway.CodeAdapterError
+		if classified {
+			addAdapterExecutionFailureFields(resp, failure)
+		}
 	} else {
 		resp["result"] = result
 	}
@@ -1822,10 +1858,20 @@ type gatewayStatusResponseOptions struct {
 }
 
 func writeGatewayStatusResponse(w http.ResponseWriter, e *store.AuditEntry, opts ...gatewayStatusResponseOptions) {
+	status := e.Outcome
+	failure, classified := describeAuditExecutionFailure(e.Outcome)
+	if classified {
+		status = "error"
+	}
 	resp := map[string]any{
-		"status":     e.Outcome,
+		"status":     status,
 		"request_id": e.RequestID,
 		"audit_id":   e.ID,
+	}
+	if classified {
+		addAdapterExecutionFailureFields(resp, failure)
+	} else if e.Outcome == "error" {
+		resp["code"] = gateway.CodeAdapterError
 	}
 	if len(opts) > 0 {
 		if opts[0].Deduped {

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -2423,15 +2423,19 @@ func executeAdapterRequest(
 
 	// Fetch per-user service config (variable values) if stored.
 	var config map[string]string
+	alias := serviceAlias
+	if alias == "" {
+		alias = "default"
+	}
 	if st != nil {
-		alias := serviceAlias
-		if alias == "" {
-			alias = "default"
-		}
 		if sc, err := st.GetServiceConfig(ctx, userID, serviceType, alias); err == nil {
 			_ = json.Unmarshal(sc.Config, &config)
 		}
 	}
+	if config == nil {
+		config = make(map[string]string)
+	}
+	config["_clawvisor_alias"] = alias
 
 	result, err := adapter.Execute(ctx, adapters.Request{
 		Action:     action,

--- a/internal/api/handlers/oauth_state_store.go
+++ b/internal/api/handlers/oauth_state_store.go
@@ -125,6 +125,7 @@ type oauthStateJSON struct {
 	UserID       string            `json:"user_id"`
 	ServiceID    string            `json:"service_id"`
 	Alias        string            `json:"alias"`
+	OAuthAlias   string            `json:"oauth_alias,omitempty"`
 	PendingReqID string            `json:"pending_req_id,omitempty"`
 	CLICallback  string            `json:"cli_callback,omitempty"`
 	Scopes       []string          `json:"scopes,omitempty"`
@@ -138,6 +139,7 @@ func marshalOAuthState(e oauthStateEntry) ([]byte, error) {
 		UserID:       e.UserID,
 		ServiceID:    e.ServiceID,
 		Alias:        e.Alias,
+		OAuthAlias:   e.OAuthAlias,
 		PendingReqID: e.PendingReqID,
 		CLICallback:  e.CLICallback,
 		Scopes:       e.Scopes,
@@ -156,6 +158,7 @@ func unmarshalOAuthState(data []byte) (oauthStateEntry, error) {
 		UserID:       j.UserID,
 		ServiceID:    j.ServiceID,
 		Alias:        j.Alias,
+		OAuthAlias:   j.OAuthAlias,
 		PendingReqID: j.PendingReqID,
 		CLICallback:  j.CLICallback,
 		Scopes:       j.Scopes,

--- a/internal/api/handlers/services.go
+++ b/internal/api/handlers/services.go
@@ -452,6 +452,16 @@ func (h *ServicesHandler) List(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"services": services})
 }
 
+func oauthConfigForAlias(
+	adapter adapters.Adapter,
+	alias string,
+) *oauth2.Config {
+	if provider, ok := adapter.(adapters.AliasOAuthConfigProvider); ok {
+		return provider.OAuthConfigForAlias(alias)
+	}
+	return adapter.OAuthConfig()
+}
+
 // OAuthGetURL returns the OAuth2 authorization URL as JSON without redirecting.
 // The client fetches this endpoint (with Authorization header) and then navigates
 // to the returned URL — e.g. window.open(url, '_blank').
@@ -496,13 +506,6 @@ func (h *ServicesHandler) OAuthGetURL(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	oauthCfg := adapter.OAuthConfig()
-	if oauthCfg == nil {
-		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "service does not use OAuth2")
-		return
-	}
-	oauthCfg.RedirectURL = h.oauthRedirectURL()
-
 	alias := r.URL.Query().Get("alias")
 	if alias == "" {
 		alias = "default"
@@ -511,6 +514,12 @@ func (h *ServicesHandler) OAuthGetURL(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "alias contains invalid characters (allowed: a-z, A-Z, 0-9, _, -, ., @, +)")
 		return
 	}
+	oauthCfg := oauthConfigForAlias(adapter, alias)
+	if oauthCfg == nil {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "service does not use OAuth2")
+		return
+	}
+	oauthCfg.RedirectURL = h.oauthRedirectURL()
 
 	newAccount := r.URL.Query().Get("new_account") == "true"
 
@@ -605,13 +614,6 @@ func (h *ServicesHandler) OAuthStart(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	oauthCfg := adapter.OAuthConfig()
-	if oauthCfg == nil {
-		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "service does not use OAuth2")
-		return
-	}
-	oauthCfg.RedirectURL = h.oauthRedirectURL()
-
 	alias := r.URL.Query().Get("alias")
 	if alias == "" {
 		alias = "default"
@@ -620,6 +622,12 @@ func (h *ServicesHandler) OAuthStart(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "alias contains invalid characters (allowed: a-z, A-Z, 0-9, _, -, ., @, +)")
 		return
 	}
+	oauthCfg := oauthConfigForAlias(adapter, alias)
+	if oauthCfg == nil {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "service does not use OAuth2")
+		return
+	}
+	oauthCfg.RedirectURL = h.oauthRedirectURL()
 
 	mergedScopes, _ := h.resolveOAuthScopes(r.Context(), user.ID, serviceID, alias, adapter)
 
@@ -681,7 +689,7 @@ func (h *ServicesHandler) OAuthCallback(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	oauthCfg := adapter.OAuthConfig()
+	oauthCfg := oauthConfigForAlias(adapter, entry.Alias)
 	oauthCfg.RedirectURL = h.oauthRedirectURL()
 	// Use the merged scopes stored during URL generation.
 	if len(entry.Scopes) > 0 {
@@ -999,7 +1007,7 @@ func (h *ServicesHandler) Activate(w http.ResponseWriter, r *http.Request) {
 			TokenPath:    adapterTokenPath(adapter),
 			ExpiresAt:    time.Now().Add(10 * time.Minute),
 		})
-		oauthCfg := adapter.OAuthConfig()
+		oauthCfg := oauthConfigForAlias(adapter, alias)
 		oauthCfg.RedirectURL = h.oauthRedirectURL()
 		oauthCfg.Scopes = mergedScopes
 		authURL := oauthAuthURL(oauthCfg, stateToken, alias != "" && alias != "default", adapterScopeParam(adapter))

--- a/internal/api/handlers/services.go
+++ b/internal/api/handlers/services.go
@@ -1012,6 +1012,11 @@ func (h *ServicesHandler) Activate(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		oauthCfg := oauthConfigForAlias(adapter, alias)
+		if oauthCfg == nil {
+			writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "OAuth client configuration is unavailable")
+			return
+		}
 		stateToken := uuid.New().String()
 		h.oauthStore.StoreOAuth(stateToken, oauthStateEntry{
 			UserID:       user.ID,
@@ -1025,11 +1030,6 @@ func (h *ServicesHandler) Activate(w http.ResponseWriter, r *http.Request) {
 			TokenPath:    adapterTokenPath(adapter),
 			ExpiresAt:    time.Now().Add(10 * time.Minute),
 		})
-		oauthCfg := oauthConfigForAlias(adapter, alias)
-		if oauthCfg == nil {
-			writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "OAuth client configuration is unavailable")
-			return
-		}
 		oauthCfg.RedirectURL = h.oauthRedirectURL()
 		oauthCfg.Scopes = mergedScopes
 		authURL := oauthAuthURL(oauthCfg, stateToken, alias != "" && alias != "default", adapterScopeParam(adapter))

--- a/internal/api/handlers/services.go
+++ b/internal/api/handlers/services.go
@@ -56,6 +56,7 @@ type oauthStateEntry struct {
 	UserID       string
 	ServiceID    string
 	Alias        string            // "default" when not specified
+	OAuthAlias   string            // alias whose OAuth client issued the code
 	PendingReqID string            // pending_request_id query param (may be empty)
 	CLICallback  string            // TUI local server callback URL (may be empty)
 	Scopes       []string          // merged scopes for this OAuth flow
@@ -522,6 +523,7 @@ func (h *ServicesHandler) OAuthGetURL(w http.ResponseWriter, r *http.Request) {
 	oauthCfg.RedirectURL = h.oauthRedirectURL()
 
 	newAccount := r.URL.Query().Get("new_account") == "true"
+	oauthAlias := alias
 
 	mergedScopes, alreadyAuthorized := h.resolveOAuthScopes(r.Context(), user.ID, serviceID, alias, adapter)
 	if alreadyAuthorized && !newAccount {
@@ -563,6 +565,7 @@ func (h *ServicesHandler) OAuthGetURL(w http.ResponseWriter, r *http.Request) {
 		UserID:       user.ID,
 		ServiceID:    serviceID,
 		Alias:        alias,
+		OAuthAlias:   oauthAlias,
 		PendingReqID: pendingReqID,
 		CLICallback:  validateCLICallback(r.URL.Query().Get("cli_callback")),
 		Config:       flowConfig,
@@ -646,6 +649,7 @@ func (h *ServicesHandler) OAuthStart(w http.ResponseWriter, r *http.Request) {
 		UserID:       user.ID,
 		ServiceID:    serviceID,
 		Alias:        alias,
+		OAuthAlias:   alias,
 		PendingReqID: pendingReqID,
 		Config:       flowConfig,
 		Scopes:       mergedScopes,
@@ -689,7 +693,15 @@ func (h *ServicesHandler) OAuthCallback(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	oauthCfg := oauthConfigForAlias(adapter, entry.Alias)
+	oauthAlias := entry.OAuthAlias
+	if oauthAlias == "" {
+		oauthAlias = entry.Alias
+	}
+	oauthCfg := oauthConfigForAlias(adapter, oauthAlias)
+	if oauthCfg == nil {
+		oauthPopupClose(w, "OAuth client configuration is unavailable.", "", entry.OpenerOrigin)
+		return
+	}
 	oauthCfg.RedirectURL = h.oauthRedirectURL()
 	// Use the merged scopes stored during URL generation.
 	if len(entry.Scopes) > 0 {
@@ -804,7 +816,12 @@ func (h *ServicesHandler) OAuthCallback(w http.ResponseWriter, r *http.Request) 
 			}
 		}
 
-		credBytes, err = credential.FromToken(token, scopes, scopesGranted)
+		credBytes, err = credential.FromTokenWithOAuthConfig(
+			token,
+			scopes,
+			scopesGranted,
+			oauthCfg,
+		)
 		if err != nil {
 			h.logger.WarnContext(r.Context(), "credential from token failed", "service", entry.ServiceID, "err", err)
 			oauthPopupClose(w, "Failed to process credential.", "", entry.OpenerOrigin)
@@ -1000,6 +1017,7 @@ func (h *ServicesHandler) Activate(w http.ResponseWriter, r *http.Request) {
 			UserID:       user.ID,
 			ServiceID:    serviceID,
 			Alias:        alias,
+			OAuthAlias:   alias,
 			PendingReqID: body.PendingRequestID,
 			OpenerOrigin: originFromRequest(r),
 			Config:       body.Config,
@@ -1008,6 +1026,10 @@ func (h *ServicesHandler) Activate(w http.ResponseWriter, r *http.Request) {
 			ExpiresAt:    time.Now().Add(10 * time.Minute),
 		})
 		oauthCfg := oauthConfigForAlias(adapter, alias)
+		if oauthCfg == nil {
+			writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "OAuth client configuration is unavailable")
+			return
+		}
 		oauthCfg.RedirectURL = h.oauthRedirectURL()
 		oauthCfg.Scopes = mergedScopes
 		authURL := oauthAuthURL(oauthCfg, stateToken, alias != "" && alias != "default", adapterScopeParam(adapter))

--- a/internal/api/handlers/services_oauth_test.go
+++ b/internal/api/handlers/services_oauth_test.go
@@ -7,6 +7,28 @@ import (
 	"github.com/clawvisor/clawvisor/internal/adapters/google/credential"
 )
 
+func TestOAuthStatePreservesIssuingClientAlias(t *testing.T) {
+	entry := oauthStateEntry{
+		UserID:     "user-1",
+		ServiceID:  "google.gmail",
+		Alias:      "default",
+		OAuthAlias: "vijay@eightcapital.com",
+		ExpiresAt:  time.Now().Add(time.Minute),
+	}
+	data, err := marshalOAuthState(entry)
+	if err != nil {
+		t.Fatalf("marshalOAuthState: %v", err)
+	}
+	decoded, err := unmarshalOAuthState(data)
+	if err != nil {
+		t.Fatalf("unmarshalOAuthState: %v", err)
+	}
+	if decoded.Alias != "default" ||
+		decoded.OAuthAlias != "vijay@eightcapital.com" {
+		t.Fatalf("OAuth aliases were not preserved: %#v", decoded)
+	}
+}
+
 func TestCredentialFromTokenPathResponse_PreservesRotatedTokens(t *testing.T) {
 	now := time.Date(2026, 4, 13, 12, 0, 0, 0, time.UTC)
 	rawResp := map[string]any{

--- a/internal/callback/callback.go
+++ b/internal/callback/callback.go
@@ -21,13 +21,16 @@ import (
 
 // Payload is posted to the agent's callback URL.
 type Payload struct {
-	Type      string           `json:"type"`                 // "request" or "task"
-	RequestID string           `json:"request_id,omitempty"` // populated when Type == "request"
-	TaskID    string           `json:"task_id,omitempty"`    // populated when Type == "task"
-	Status    string           `json:"status"`
-	Result    *adapters.Result `json:"result,omitempty"`
-	Error     string           `json:"error,omitempty"`
-	AuditID   string           `json:"audit_id,omitempty"`
+	Type        string           `json:"type"`                 // "request" or "task"
+	RequestID   string           `json:"request_id,omitempty"` // populated when Type == "request"
+	TaskID      string           `json:"task_id,omitempty"`    // populated when Type == "task"
+	Status      string           `json:"status"`
+	Result      *adapters.Result `json:"result,omitempty"`
+	Error       string           `json:"error,omitempty"`
+	Code        string           `json:"code,omitempty"`
+	FailureKind string           `json:"failure_kind,omitempty"`
+	TimedOut    bool             `json:"timed_out,omitempty"`
+	AuditID     string           `json:"audit_id,omitempty"`
 }
 
 var httpClient = &http.Client{

--- a/pkg/adapters/adapters.go
+++ b/pkg/adapters/adapters.go
@@ -98,6 +98,13 @@ type OAuthCredentialProvider interface {
 	OAuthClientCredentials() (clientID, clientSecret string)
 }
 
+// AliasOAuthConfigProvider lets one service use distinct OAuth applications
+// for explicitly named account aliases. This is useful when accounts belong
+// to different Google Workspace organizations with separate OAuth audiences.
+type AliasOAuthConfigProvider interface {
+	OAuthConfigForAlias(alias string) *oauth2.Config
+}
+
 // NoopOAuthProvider is a provider that always returns empty credentials.
 // Useful in tests where OAuth configuration is not needed.
 type NoopOAuthProvider struct{}

--- a/pkg/adapters/adapters.go
+++ b/pkg/adapters/adapters.go
@@ -159,6 +159,7 @@ type Request struct {
 	Params     map[string]any
 	Credential []byte            // decrypted from vault
 	Config     map[string]string // resolved variable values from service_configs
+	Alias      string            // resolved service alias; never sourced from user config
 }
 
 // Result is the semantic output of an adapter action.

--- a/pkg/adapters/execution_error.go
+++ b/pkg/adapters/execution_error.go
@@ -1,0 +1,49 @@
+package adapters
+
+import "errors"
+
+// ExecutionFailureKind describes what is known about a failed adapter
+// execution. In particular, Ambiguous means a write may have reached the
+// provider and callers must not retry it under a new request ID without first
+// reconciling provider state.
+type ExecutionFailureKind string
+
+const (
+	ExecutionFailureDefinite     ExecutionFailureKind = "definite_failure"
+	ExecutionFailureStaleVersion ExecutionFailureKind = "stale_version"
+	ExecutionFailureAmbiguous    ExecutionFailureKind = "ambiguous"
+)
+
+// ExecutionFailure carries the safety-relevant disposition of an adapter
+// error through gateway wrapping. TimedOut is meaningful only for ambiguous
+// failures and lets clients distinguish a deadline/timeout from another
+// indeterminate transport failure.
+type ExecutionFailure struct {
+	Kind     ExecutionFailureKind
+	TimedOut bool
+	Err      error
+}
+
+func (e *ExecutionFailure) Error() string {
+	if e == nil || e.Err == nil {
+		return "adapter execution failed"
+	}
+	return e.Err.Error()
+}
+
+func (e *ExecutionFailure) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+// AsExecutionFailure returns the first classified adapter failure in err's
+// unwrap chain.
+func AsExecutionFailure(err error) (*ExecutionFailure, bool) {
+	var failure *ExecutionFailure
+	if !errors.As(err, &failure) {
+		return nil, false
+	}
+	return failure, true
+}

--- a/pkg/adapters/execution_error.go
+++ b/pkg/adapters/execution_error.go
@@ -42,7 +42,7 @@ func (e *ExecutionFailure) Unwrap() error {
 // unwrap chain.
 func AsExecutionFailure(err error) (*ExecutionFailure, bool) {
 	var failure *ExecutionFailure
-	if !errors.As(err, &failure) {
+	if !errors.As(err, &failure) || failure == nil {
 		return nil, false
 	}
 	return failure, true

--- a/pkg/adapters/execution_error_test.go
+++ b/pkg/adapters/execution_error_test.go
@@ -1,0 +1,29 @@
+package adapters
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestAsExecutionFailureRejectsTypedNil(t *testing.T) {
+	var typedNil *ExecutionFailure
+	var err error = typedNil
+
+	failure, ok := AsExecutionFailure(fmt.Errorf("wrapped: %w", err))
+	if ok || failure != nil {
+		t.Fatalf("typed nil must remain unclassified, got (%#v, %v)", failure, ok)
+	}
+}
+
+func TestAsExecutionFailureReturnsConcreteFailure(t *testing.T) {
+	want := &ExecutionFailure{
+		Kind: ExecutionFailureDefinite,
+		Err:  errors.New("rejected"),
+	}
+
+	failure, ok := AsExecutionFailure(fmt.Errorf("wrapped: %w", want))
+	if !ok || failure != want {
+		t.Fatalf("got (%#v, %v), want (%#v, true)", failure, ok, want)
+	}
+}

--- a/pkg/clawvisor/defaults.go
+++ b/pkg/clawvisor/defaults.go
@@ -24,6 +24,7 @@ import (
 	"github.com/clawvisor/clawvisor/internal/adapters/definitions"
 	mcpdefs "github.com/clawvisor/clawvisor/internal/adapters/definitions/mcp"
 	dropboxadapter "github.com/clawvisor/clawvisor/internal/adapters/dropbox"
+	calendaradapter "github.com/clawvisor/clawvisor/internal/adapters/google/calendar"
 	contactsadapter "github.com/clawvisor/clawvisor/internal/adapters/google/contacts"
 	driveadapter "github.com/clawvisor/clawvisor/internal/adapters/google/drive"
 	gmailadapter "github.com/clawvisor/clawvisor/internal/adapters/google/gmail"
@@ -176,10 +177,9 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 	// Create a vault-backed OAuth provider for Microsoft services.
 	msOAuthProvider := adapters.NewMicrosoftVaultOAuthProvider(v)
 
-	// Build Go action overrides for Google services that need complex logic
-	// (MIME encoding, multipart uploads, dual API calls) beyond what YAML
-	// expressions can handle. Calendar, Contacts, and Drive search_files
-	// are fully YAML-driven with expr-lang transforms.
+	// Build Go action overrides for services that need logic beyond what YAML
+	// expressions can handle (MIME encoding, conditional writes, multipart
+	// uploads, and multi-request operations).
 	goOverrides := map[string]yamlruntime.ActionFunc{}
 
 	gmail := gmailadapter.New(oauthProvider)
@@ -189,6 +189,10 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 	drive := driveadapter.New(oauthProvider)
 	for _, action := range []string{"get_file", "download_file", "export_file", "create_file", "update_file"} {
 		goOverrides["google.drive:"+action] = drive.Execute
+	}
+	calendar := calendaradapter.New(oauthProvider)
+	for _, action := range []string{"get_event", "update_event", "respond_to_event"} {
+		goOverrides["google.calendar:"+action] = calendar.Execute
 	}
 	contacts := contactsadapter.New(oauthProvider)
 	goOverrides["google.contacts:list_contacts"] = contacts.Execute

--- a/pkg/gateway/errorcodes.go
+++ b/pkg/gateway/errorcodes.go
@@ -24,14 +24,14 @@ const (
 	CodeUnknownAction  = "UNKNOWN_ACTION"
 
 	// State — the target task/approval is not in a state that permits this action.
-	CodeInvalidState      = "INVALID_STATE"
-	CodeNotFound          = "NOT_FOUND"
-	CodeAlreadyExecuting  = "ALREADY_EXECUTING"
-	CodeNotApproved       = "NOT_APPROVED"
-	CodeApprovalExpired   = "APPROVAL_EXPIRED"
+	CodeInvalidState     = "INVALID_STATE"
+	CodeNotFound         = "NOT_FOUND"
+	CodeAlreadyExecuting = "ALREADY_EXECUTING"
+	CodeNotApproved      = "NOT_APPROVED"
+	CodeApprovalExpired  = "APPROVAL_EXPIRED"
 
 	// Policy — the request is syntactically fine but blocked by authorization.
-	CodeScopeMismatch  = "SCOPE_MISMATCH"  // outside the approved task scope
+	CodeScopeMismatch  = "SCOPE_MISMATCH"   // outside the approved task scope
 	CodeReasonTooVague = "REASON_TOO_VAGUE" // intent verifier found reason incoherent/insufficient
 	CodeParamViolation = "PARAM_VIOLATION"  // params inconsistent with task scope / chain context
 	CodeRestricted     = "RESTRICTED"       // user restriction or org policy blocked the action
@@ -40,9 +40,13 @@ const (
 	// Execution — downstream failure during or after dispatch.
 	CodeAdapterError            = "ADAPTER_ERROR"
 	CodeLocalServiceUnavailable = "LOCAL_SERVICE_UNAVAILABLE"
+	CodeProviderDefiniteFailure = "PROVIDER_DEFINITE_FAILURE"
+	CodeStaleVersion            = "STALE_VERSION"
+	CodeAmbiguousOutcome        = "AMBIGUOUS_OUTCOME"
+	CodeProviderTimeout         = "PROVIDER_TIMEOUT"
 
 	// Operational.
-	CodeRateLimited  = "RATE_LIMITED"
+	CodeRateLimited   = "RATE_LIMITED"
 	CodeInternalError = "INTERNAL_ERROR"
 
 	// Batch — aggregate endpoint specific.

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "deploy/Dockerfile"
+  },
+  "deploy": {
+    "healthcheckPath": "/ready",
+    "healthcheckTimeout": 30,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 5
+  }
+}

--- a/web/src/pages/Audit.tsx
+++ b/web/src/pages/Audit.tsx
@@ -45,7 +45,20 @@ function downloadCsv(csv: string, filename: string) {
   URL.revokeObjectURL(url)
 }
 
-const OUTCOMES = ['', 'executed', 'blocked', 'restricted', 'pending', 'denied', 'error', 'timeout']
+const OUTCOMES = [
+  '',
+  'executed',
+  'blocked',
+  'restricted',
+  'pending',
+  'denied',
+  'error',
+  'timeout',
+  'provider_definite_failure',
+  'provider_stale_version',
+  'provider_ambiguous',
+  'provider_timeout',
+]
 const ACTIVITY_TYPES = [
   { value: '', label: 'All activity types' },
   { value: 'runtime_egress', label: 'Runtime egress' },
@@ -62,6 +75,10 @@ const OUTCOME_STYLE: Record<string, string> = {
   denied: 'bg-surface-2 text-text-tertiary',
   error: 'bg-danger/15 text-danger',
   timeout: 'bg-surface-2 text-text-tertiary',
+  provider_definite_failure: 'bg-danger/15 text-danger',
+  provider_stale_version: 'bg-warning/15 text-warning',
+  provider_ambiguous: 'bg-danger/15 text-danger',
+  provider_timeout: 'bg-surface-2 text-text-tertiary',
 }
 
 type ActivityTypeFilter = '' | 'runtime_egress' | 'runtime_tool_use' | 'runtime' | 'service'

--- a/web/src/pages/Overview.tsx
+++ b/web/src/pages/Overview.tsx
@@ -372,7 +372,6 @@ function ActivityChart({ data }: { data: ActivityBucket[] }) {
       'inline_task_auto_approved',
     ])
     const errorOutcomes = new Set([
-      'denied',
       'error',
       'http_error',
       'timeout',

--- a/web/src/pages/Overview.tsx
+++ b/web/src/pages/Overview.tsx
@@ -313,6 +313,7 @@ interface ChartRow {
   time: string
   executed: number
   blocked: number
+  errors: number
   pending: number
 }
 
@@ -326,6 +327,7 @@ function useChartColors() {
     return {
       executed: r('--color-success'),
       blocked: r('--color-danger'),
+      errors: r('--color-danger'),
       pending: r('--color-warning'),
       axisTick: style.getPropertyValue('--color-axis-tick').trim(),
       tooltipBg: style.getPropertyValue('--color-tooltip-bg').trim(),
@@ -369,14 +371,25 @@ function ActivityChart({ data }: { data: ActivityBucket[] }) {
       'inline_task_approved',
       'inline_task_auto_approved',
     ])
+    const errorOutcomes = new Set([
+      'denied',
+      'error',
+      'http_error',
+      'timeout',
+      'provider_definite_failure',
+      'provider_stale_version',
+      'provider_ambiguous',
+      'provider_timeout',
+    ])
     for (const b of data) {
       const ms = new Date(b.bucket).getTime()
       if (!counts.has(ms)) {
-        counts.set(ms, { time: '', executed: 0, blocked: 0, pending: 0 })
+        counts.set(ms, { time: '', executed: 0, blocked: 0, errors: 0, pending: 0 })
       }
       const row = counts.get(ms)!
       if (successOutcomes.has(b.outcome)) row.executed += b.count
       else if (b.outcome === 'blocked' || b.outcome === 'restricted') row.blocked += b.count
+      else if (errorOutcomes.has(b.outcome)) row.errors += b.count
       else row.pending += b.count
     }
 
@@ -389,7 +402,7 @@ function ActivityChart({ data }: { data: ActivityBucket[] }) {
       const t = new Date(ms)
       const label = `${String(t.getHours()).padStart(2, '0')}:${String(t.getMinutes()).padStart(2, '0')}`
       const existing = counts.get(ms)
-      result.push(existing ? { ...existing, time: label } : { time: label, executed: 0, blocked: 0, pending: 0 })
+      result.push(existing ? { ...existing, time: label } : { time: label, executed: 0, blocked: 0, errors: 0, pending: 0 })
     }
     return result
   }, [data])
@@ -405,6 +418,7 @@ function ActivityChart({ data }: { data: ActivityBucket[] }) {
           />
           <Bar dataKey="executed" stackId="1" stroke={colors.executed} fill={colors.executed} fillOpacity={0.85} name="Executed" />
           <Bar dataKey="blocked" stackId="1" stroke={colors.blocked} fill={colors.blocked} fillOpacity={0.85} name="Blocked" />
+          <Bar dataKey="errors" stackId="1" stroke={colors.errors} fill={colors.errors} fillOpacity={0.55} name="Errors" />
           <Bar dataKey="pending" stackId="1" stroke={colors.pending} fill={colors.pending} fillOpacity={0.85} name="Pending" />
         </BarChart>
       </ResponsiveContainer>


### PR DESCRIPTION
## Summary
- expose exact Google Calendar etag/version and self RSVP state
- require expected etag/version and If-Match for updates and RSVP
- add idempotent request receipts and stale/ambiguous outcome classification

## Verification
- `env -u ANTHROPIC_API_KEY go test ./...`
- `go vet ./...`
- focused stale, duplicate, timeout, RSVP, and send-updates tests

No live Google account was accessed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

