### PR TITLE
feat(calendar): support versioned approval mutations

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ All three LLM subsystems (intent verification, chain context extraction, and tas
 | Service ID | Service | Actions |
 |---|---|---|
 | `google.gmail` | Gmail | `list_messages`, `get_message`, `send_message` |
-| `google.calendar` | Google Calendar | `list_events`, `get_event`, `create_event`, `update_event`, `delete_event`, `list_calendars` |
+| `google.calendar` | Google Calendar | `list_events`, `get_event`, `create_event`, `update_event`, `respond_to_event`, `delete_event`, `list_calendars` |
 | `google.drive` | Google Drive | `list_files`, `get_file`, `create_file`, `update_file`, `search_files` |
 | `google.contacts` | Google Contacts | `list_contacts`, `get_contact`, `search_contacts` |
 | `microsoft.outlook` | Outlook | `list_messages`, `get_message`, `send_message`, `list_events`, `get_event`, `create_event` |

--- a/internal/adapters/definitions/google_calendar.yaml
+++ b/internal/adapters/definitions/google_calendar.yaml
@@ -171,8 +171,8 @@ actions:
     display_name: "Update event"
     risk: { category: write, sensitivity: medium, description: "Update a calendar event" }
     scopes: ["https://www.googleapis.com/auth/calendar.events"]
-    # The Go override sends expected_etag as If-Match on the PATCH and
-    # classifies stale and indeterminate provider outcomes.
+    # The Go override normalizes date/time and attendee fields, sends
+    # expected_etag as If-Match, and classifies indeterminate outcomes.
     override: go
     method: PATCH
     path: "/calendars/{{.calendar_id}}/events/{{.event_id}}"
@@ -195,15 +195,12 @@ actions:
       start:
         type: string
         location: body
-        transform: "isAllDay(start) ? {date: start} : {dateTime: rfc3339(start)}"
       end:
         type: string
         location: body
-        transform: "isAllDay(end) ? {date: end} : {dateTime: rfc3339(end)}"
       attendees:
         type: array
         location: body
-        transform: "emailList(attendees)"
       transparency:
         type: string
         location: body

--- a/internal/adapters/definitions/google_calendar.yaml
+++ b/internal/adapters/definitions/google_calendar.yaml
@@ -90,12 +90,14 @@ actions:
     display_name: "Get event"
     risk: { category: read, sensitivity: low, description: "Read a specific calendar event" }
     scopes: ["https://www.googleapis.com/auth/calendar.readonly"]
+    # The Go override captures the provider ETag from both the event resource
+    # and HTTP response headers, and fails closed when neither is present.
+    override: go
     method: GET
     path: "/calendars/{{.calendar_id}}/events/{{.event_id}}"
     params:
       event_id: { type: string, required: true, location: path }
       calendar_id: { type: string, default: "primary", location: path }
-      supports_attachments: { type: bool, default: true, map_to: supportsAttachments, location: query }
     response:
       fields:
         - { name: id }
@@ -118,6 +120,10 @@ actions:
         - name: visibility
           expr: "visibility ?? 'default'"
         - { name: status }
+        - { name: etag }
+        - { name: version }
+        - { name: sequence }
+        - { name: response_status, optional: true }
       summary: "Event: {{.summary}}"
 
   create_event:
@@ -165,13 +171,24 @@ actions:
     display_name: "Update event"
     risk: { category: write, sensitivity: medium, description: "Update a calendar event" }
     scopes: ["https://www.googleapis.com/auth/calendar.events"]
+    # The Go override sends expected_etag as If-Match on the PATCH and
+    # classifies stale and indeterminate provider outcomes.
+    override: go
     method: PATCH
     path: "/calendars/{{.calendar_id}}/events/{{.event_id}}"
     body_mode: sparse
     params:
       event_id: { type: string, required: true, location: path }
       calendar_id: { type: string, default: "primary", location: path }
-      send_updates: { type: string, default: "none", location: query, map_to: sendUpdates }
+      expected_etag:
+        type: string
+        required: true
+        aliases: [expected_version]
+        description: "Exact provider etag/version returned by get_event; used as an If-Match precondition"
+      send_updates:
+        type: string
+        default: "none"
+        description: "Google notification mode: all, externalOnly, or none"
       summary: { type: string, location: body }
       description: { type: string, location: body }
       location: { type: string, location: body }
@@ -199,7 +216,45 @@ actions:
       fields:
         - { name: id, rename: event_id }
         - { name: summary }
+        - { name: etag }
+        - { name: version }
+        - { name: send_updates }
       summary: "Updated event: {{.summary}}"
+
+  respond_to_event:
+    display_name: "Respond to event"
+    risk: { category: write, sensitivity: medium, description: "Accept, decline, or tentatively accept a calendar invitation" }
+    scopes: ["https://www.googleapis.com/auth/calendar.events"]
+    # Google requires a pre-read to identify attendees[].self. The Go
+    # override then PATCHes only that attendee with attendeesOmitted=true and
+    # retains the approved version as an If-Match precondition.
+    override: go
+    method: PATCH
+    path: "/calendars/{{.calendar_id}}/events/{{.event_id}}"
+    params:
+      event_id: { type: string, required: true, location: path }
+      calendar_id: { type: string, default: "primary", location: path }
+      expected_etag:
+        type: string
+        required: true
+        aliases: [expected_version]
+        description: "Exact provider etag/version returned by get_event; used as an If-Match precondition"
+      response_status:
+        type: string
+        required: true
+        description: "RSVP response: accepted, declined, or tentative"
+      send_updates:
+        type: string
+        default: "none"
+        description: "Google notification mode: all, externalOnly, or none"
+    response:
+      fields:
+        - { name: id, rename: event_id }
+        - { name: response_status }
+        - { name: etag }
+        - { name: version }
+        - { name: send_updates }
+      summary: "Responded {{.response_status}} to event {{.event_id}}"
 
   delete_event:
     display_name: "Delete event"

--- a/internal/adapters/definitions/google_calendar_test.go
+++ b/internal/adapters/definitions/google_calendar_test.go
@@ -1,0 +1,58 @@
+package definitions
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/pkg/adapters/yamldef"
+	"github.com/clawvisor/clawvisor/pkg/adapters/yamlvalidate"
+	"gopkg.in/yaml.v3"
+)
+
+func TestGoogleCalendarVersionedActionDefinitions(t *testing.T) {
+	contents, err := FS.ReadFile("google_calendar.yaml")
+	if err != nil {
+		t.Fatalf("read Calendar definition: %v", err)
+	}
+
+	var definition yamldef.ServiceDef
+	if err := yaml.Unmarshal(contents, &definition); err != nil {
+		t.Fatalf("parse Calendar definition: %v", err)
+	}
+	if validation := yamlvalidate.Validate(&definition); !validation.OK() {
+		t.Fatalf("Calendar definition validation errors: %v", validation.Errors)
+	}
+
+	getEvent := definition.Actions["get_event"]
+	if getEvent.Override != "go" {
+		t.Fatalf("get_event override = %q, want go", getEvent.Override)
+	}
+	var responseFields []string
+	for _, field := range getEvent.Response.Fields {
+		responseFields = append(responseFields, field.Name)
+	}
+	for _, want := range []string{"etag", "version", "sequence"} {
+		if !slices.Contains(responseFields, want) {
+			t.Errorf("get_event response is missing %q", want)
+		}
+	}
+
+	for _, actionName := range []string{"update_event", "respond_to_event"} {
+		action, ok := definition.Actions[actionName]
+		if !ok {
+			t.Fatalf("Calendar catalog is missing %s", actionName)
+		}
+		if action.Override != "go" {
+			t.Errorf("%s override = %q, want go", actionName, action.Override)
+		}
+		expected := action.Params["expected_etag"]
+		if !expected.Required || !slices.Contains(expected.Aliases, "expected_version") {
+			t.Errorf("%s expected_etag schema = %+v, want required with expected_version alias", actionName, expected)
+		}
+	}
+
+	responseStatus := definition.Actions["respond_to_event"].Params["response_status"]
+	if !responseStatus.Required || responseStatus.Type != "string" {
+		t.Errorf("respond_to_event response_status schema = %+v, want required string", responseStatus)
+	}
+}

--- a/internal/adapters/google/calendar/adapter.go
+++ b/internal/adapters/google/calendar/adapter.go
@@ -4,8 +4,10 @@ package calendar
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -40,7 +42,7 @@ func New(provider adapters.OAuthCredentialProvider) *CalendarAdapter {
 func (a *CalendarAdapter) ServiceID() string { return serviceID }
 
 func (a *CalendarAdapter) SupportedActions() []string {
-	return []string{"list_events", "get_event", "create_event", "update_event", "delete_event", "list_calendars"}
+	return []string{"list_events", "get_event", "create_event", "update_event", "respond_to_event", "delete_event", "list_calendars"}
 }
 
 func (a *CalendarAdapter) RequiredScopes() []string { return calendarScopes }
@@ -89,6 +91,8 @@ func (a *CalendarAdapter) Execute(ctx context.Context, req adapters.Request) (*a
 		return a.createEvent(ctx, client, req.Params)
 	case "update_event":
 		return a.updateEvent(ctx, client, req.Params)
+	case "respond_to_event":
+		return a.respondToEvent(ctx, client, req.Params)
 	case "delete_event":
 		return a.deleteEvent(ctx, client, req.Params)
 	case "list_calendars":
@@ -118,6 +122,50 @@ type calendarEvent struct {
 	Description string   `json:"description,omitempty"`
 	Attendees   []string `json:"attendees,omitempty"`
 	Status      string   `json:"status"`
+}
+
+type calendarAPIDateTime struct {
+	DateTime string `json:"dateTime"`
+	Date     string `json:"date"`
+	TimeZone string `json:"timeZone"`
+}
+
+type calendarAPIAttendee struct {
+	Email            string `json:"email"`
+	DisplayName      string `json:"displayName"`
+	ResponseStatus   string `json:"responseStatus"`
+	Comment          string `json:"comment"`
+	Self             bool   `json:"self"`
+	Organizer        bool   `json:"organizer"`
+	Optional         bool   `json:"optional"`
+	Resource         bool   `json:"resource"`
+	AdditionalGuests int    `json:"additionalGuests"`
+}
+
+type calendarAPIAttachment struct {
+	FileURL  string `json:"fileUrl"`
+	Title    string `json:"title"`
+	MimeType string `json:"mimeType"`
+	IconLink string `json:"iconLink"`
+	FileID   string `json:"fileId"`
+}
+
+type calendarAPIEvent struct {
+	ID             string                  `json:"id"`
+	ETag           string                  `json:"etag"`
+	Sequence       int64                   `json:"sequence"`
+	Summary        string                  `json:"summary"`
+	Location       string                  `json:"location"`
+	Description    string                  `json:"description"`
+	Status         string                  `json:"status"`
+	Transparency   string                  `json:"transparency"`
+	Visibility     string                  `json:"visibility"`
+	HangoutLink    string                  `json:"hangoutLink"`
+	Start          calendarAPIDateTime     `json:"start"`
+	End            calendarAPIDateTime     `json:"end"`
+	Attendees      []calendarAPIAttendee   `json:"attendees"`
+	Attachments    []calendarAPIAttachment `json:"attachments"`
+	RecurringEvent string                  `json:"recurringEventId"`
 }
 
 func (a *CalendarAdapter) listEvents(ctx context.Context, client *http.Client, params map[string]any) (*adapters.Result, error) {
@@ -230,57 +278,23 @@ func (a *CalendarAdapter) getEvent(ctx context.Context, client *http.Client, par
 	apiURL := fmt.Sprintf("https://www.googleapis.com/calendar/v3/calendars/%s/events/%s",
 		url.PathEscape(calendarID), url.PathEscape(eventID))
 
-	var item struct {
-		ID          string `json:"id"`
-		Summary     string `json:"summary"`
-		Location    string `json:"location"`
-		Description string `json:"description"`
-		Status      string `json:"status"`
-		Start       struct {
-			DateTime string `json:"dateTime"`
-			Date     string `json:"date"`
-		} `json:"start"`
-		End struct {
-			DateTime string `json:"dateTime"`
-			Date     string `json:"date"`
-		} `json:"end"`
-		Attendees []struct {
-			Email       string `json:"email"`
-			DisplayName string `json:"displayName"`
-		} `json:"attendees"`
-	}
-	if err := apiGET(ctx, client, apiURL, &item); err != nil {
+	var item calendarAPIEvent
+	headers, err := apiGETWithHeaders(ctx, client, apiURL, &item)
+	if err != nil {
 		return nil, fmt.Errorf("calendar get_event: %w", err)
 	}
-
-	startStr := item.Start.DateTime
-	if startStr == "" {
-		startStr = item.Start.Date
-	}
-	endStr := item.End.DateTime
-	if endStr == "" {
-		endStr = item.End.Date
-	}
-	attendees := make([]string, 0, len(item.Attendees))
-	for _, att := range item.Attendees {
-		name := att.DisplayName
-		if name == "" {
-			name = att.Email
+	version := eventVersion(item.ETag, headers.Get("ETag"))
+	if version == "" {
+		return nil, &adapters.ExecutionFailure{
+			Kind: adapters.ExecutionFailureDefinite,
+			Err:  fmt.Errorf("calendar get_event: provider returned no event etag/version"),
 		}
-		attendees = append(attendees, format.SanitizeText(name, format.MaxFieldLen))
 	}
-	event := calendarEvent{
-		ID:          item.ID,
-		Summary:     format.SanitizeText(item.Summary, format.MaxFieldLen),
-		Start:       startStr,
-		End:         endStr,
-		Location:    format.SanitizeText(item.Location, format.MaxFieldLen),
-		Description: format.SanitizeText(item.Description, format.MaxBodyLen),
-		Attendees:   attendees,
-		Status:      item.Status,
-	}
+
+	event := calendarEventData(item, version)
+	summary, _ := event["summary"].(string)
 	return &adapters.Result{
-		Summary: format.Summary("Event: %s on %s", event.Summary, event.Start),
+		Summary: format.Summary("Event: %s", summary),
 		Data:    event,
 	}, nil
 }
@@ -341,6 +355,14 @@ func (a *CalendarAdapter) updateEvent(ctx context.Context, client *http.Client, 
 	if eventID == "" {
 		return nil, fmt.Errorf("calendar update_event: event_id is required")
 	}
+	expectedVersion, err := expectedEventVersion(params)
+	if err != nil {
+		return nil, fmt.Errorf("calendar update_event: %w", err)
+	}
+	sendUpdates, err := calendarSendUpdates(params)
+	if err != nil {
+		return nil, fmt.Errorf("calendar update_event: %w", err)
+	}
 	calendarID := "primary"
 	if v, ok := params["calendar_id"].(string); ok && v != "" {
 		calendarID = v
@@ -353,25 +375,170 @@ func (a *CalendarAdapter) updateEvent(ctx context.Context, client *http.Client, 
 	if v, ok := params["description"].(string); ok {
 		patch["description"] = v
 	}
+	if v, ok := params["location"].(string); ok {
+		patch["location"] = v
+	}
 	if v, ok := params["start"].(string); ok {
 		patch["start"] = calendarDtField(v)
 	}
 	if v, ok := params["end"].(string); ok {
 		patch["end"] = calendarDtField(v)
 	}
+	if raw, ok := params["attendees"]; ok {
+		attendees, attendeeErr := calendarAttendeePatch(raw)
+		if attendeeErr != nil {
+			return nil, fmt.Errorf("calendar update_event: %w", attendeeErr)
+		}
+		patch["attendees"] = attendees
+	}
+	if v, ok := params["transparency"].(string); ok {
+		patch["transparency"] = v
+	}
+	if v, ok := params["visibility"].(string); ok {
+		patch["visibility"] = v
+	}
+	if len(patch) == 0 {
+		return nil, &adapters.ExecutionFailure{
+			Kind: adapters.ExecutionFailureDefinite,
+			Err:  fmt.Errorf("at least one event field is required"),
+		}
+	}
 
 	apiURL := fmt.Sprintf("https://www.googleapis.com/calendar/v3/calendars/%s/events/%s",
 		url.PathEscape(calendarID), url.PathEscape(eventID))
-	var updated struct {
-		ID      string `json:"id"`
-		Summary string `json:"summary"`
-	}
-	if err := apiWrite(ctx, client, http.MethodPatch, apiURL, patch, &updated); err != nil {
+	q := url.Values{}
+	q.Set("sendUpdates", sendUpdates)
+	apiURL += "?" + q.Encode()
+
+	var updated calendarAPIEvent
+	headers, err := apiConditionalWrite(ctx, client, http.MethodPatch, apiURL, expectedVersion, patch, &updated)
+	if err != nil {
 		return nil, fmt.Errorf("calendar update_event: %w", err)
+	}
+	updatedVersion := eventVersion(updated.ETag, headers.Get("ETag"))
+	if updatedVersion == "" {
+		return nil, &adapters.ExecutionFailure{
+			Kind: adapters.ExecutionFailureAmbiguous,
+			Err:  fmt.Errorf("calendar update_event: provider confirmed the mutation but returned no event etag/version"),
+		}
+	}
+	if updated.ID == "" {
+		updated.ID = eventID
 	}
 	return &adapters.Result{
 		Summary: format.Summary("Updated event: %s", updated.Summary),
-		Data:    map[string]string{"event_id": updated.ID, "summary": updated.Summary},
+		Data: map[string]any{
+			"event_id":     updated.ID,
+			"summary":      format.SanitizeText(updated.Summary, format.MaxFieldLen),
+			"etag":         updatedVersion,
+			"version":      updatedVersion,
+			"send_updates": sendUpdates,
+		},
+	}, nil
+}
+
+// ── respond_to_event ──────────────────────────────────────────────────────────
+
+func (a *CalendarAdapter) respondToEvent(ctx context.Context, client *http.Client, params map[string]any) (*adapters.Result, error) {
+	eventID, _ := params["event_id"].(string)
+	if eventID == "" {
+		return nil, fmt.Errorf("calendar respond_to_event: event_id is required")
+	}
+	responseStatus, _ := params["response_status"].(string)
+	switch responseStatus {
+	case "accepted", "declined", "tentative":
+	default:
+		return nil, &adapters.ExecutionFailure{
+			Kind: adapters.ExecutionFailureDefinite,
+			Err:  fmt.Errorf("calendar RSVP must be accepted, declined, or tentative"),
+		}
+	}
+	expectedVersion, err := expectedEventVersion(params)
+	if err != nil {
+		return nil, fmt.Errorf("calendar respond_to_event: %w", err)
+	}
+	sendUpdates, err := calendarSendUpdates(params)
+	if err != nil {
+		return nil, fmt.Errorf("calendar respond_to_event: %w", err)
+	}
+
+	calendarID := "primary"
+	if v, ok := params["calendar_id"].(string); ok && v != "" {
+		calendarID = v
+	}
+	apiURL := fmt.Sprintf("https://www.googleapis.com/calendar/v3/calendars/%s/events/%s",
+		url.PathEscape(calendarID), url.PathEscape(eventID))
+
+	// Google identifies the attendee that represents this calendar with
+	// attendees[].self. Read that participant immediately before the write,
+	// then retain the caller's original ETag as an If-Match precondition on
+	// the PATCH below.
+	var current calendarAPIEvent
+	headers, err := apiGETWithHeaders(ctx, client, apiURL, &current)
+	if err != nil {
+		return nil, &adapters.ExecutionFailure{
+			Kind: adapters.ExecutionFailureDefinite,
+			Err:  fmt.Errorf("calendar respond_to_event pre-read: %w", err),
+		}
+	}
+	currentVersion := eventVersion(current.ETag, headers.Get("ETag"))
+	if currentVersion == "" {
+		return nil, &adapters.ExecutionFailure{
+			Kind: adapters.ExecutionFailureDefinite,
+			Err:  fmt.Errorf("calendar respond_to_event: provider returned no current event etag/version"),
+		}
+	}
+	if currentVersion != expectedVersion {
+		return nil, &adapters.ExecutionFailure{
+			Kind: adapters.ExecutionFailureStaleVersion,
+			Err:  fmt.Errorf("calendar respond_to_event: event version is stale"),
+		}
+	}
+	participant, ok := calendarSelfAttendee(current.Attendees)
+	if !ok || participant.Email == "" {
+		return nil, &adapters.ExecutionFailure{
+			Kind: adapters.ExecutionFailureDefinite,
+			Err:  fmt.Errorf("calendar respond_to_event: authenticated calendar is not an attendee"),
+		}
+	}
+
+	payload := map[string]any{
+		"attendees": []map[string]any{{
+			"email":          participant.Email,
+			"responseStatus": responseStatus,
+		}},
+		// This Google event flag makes the partial attendee list update only
+		// this calendar participant's response instead of replacing guests.
+		"attendeesOmitted": true,
+	}
+	q := url.Values{}
+	q.Set("sendUpdates", sendUpdates)
+	mutationURL := apiURL + "?" + q.Encode()
+
+	var updated calendarAPIEvent
+	headers, err = apiConditionalWrite(ctx, client, http.MethodPatch, mutationURL, expectedVersion, payload, &updated)
+	if err != nil {
+		return nil, fmt.Errorf("calendar respond_to_event: %w", err)
+	}
+	updatedVersion := eventVersion(updated.ETag, headers.Get("ETag"))
+	if updatedVersion == "" {
+		return nil, &adapters.ExecutionFailure{
+			Kind: adapters.ExecutionFailureAmbiguous,
+			Err:  fmt.Errorf("calendar respond_to_event: provider confirmed the mutation but returned no event etag/version"),
+		}
+	}
+	if updated.ID == "" {
+		updated.ID = eventID
+	}
+	return &adapters.Result{
+		Summary: format.Summary("Responded %s to event %s", responseStatus, updated.ID),
+		Data: map[string]any{
+			"event_id":        updated.ID,
+			"response_status": responseStatus,
+			"etag":            updatedVersion,
+			"version":         updatedVersion,
+			"send_updates":    sendUpdates,
+		},
 	}, nil
 }
 
@@ -456,23 +623,243 @@ func (a *CalendarAdapter) listCalendars(ctx context.Context, client *http.Client
 	return result, nil
 }
 
+func calendarEventData(item calendarAPIEvent, version string) map[string]any {
+	start := item.Start.DateTime
+	if start == "" {
+		start = item.Start.Date
+	}
+	end := item.End.DateTime
+	if end == "" {
+		end = item.End.Date
+	}
+
+	attendees := make([]map[string]any, 0, len(item.Attendees))
+	for _, attendee := range item.Attendees {
+		entry := map[string]any{
+			"email":          format.SanitizeText(attendee.Email, format.MaxFieldLen),
+			"responseStatus": attendee.ResponseStatus,
+		}
+		if attendee.DisplayName != "" {
+			entry["displayName"] = format.SanitizeText(attendee.DisplayName, format.MaxFieldLen)
+		}
+		if attendee.Comment != "" {
+			entry["comment"] = format.SanitizeText(attendee.Comment, format.MaxSnippetLen)
+		}
+		if attendee.Self {
+			entry["self"] = true
+		}
+		if attendee.Organizer {
+			entry["organizer"] = true
+		}
+		if attendee.Optional {
+			entry["optional"] = true
+		}
+		if attendee.Resource {
+			entry["resource"] = true
+		}
+		if attendee.AdditionalGuests != 0 {
+			entry["additionalGuests"] = attendee.AdditionalGuests
+		}
+		attendees = append(attendees, entry)
+	}
+
+	attachments := make([]map[string]any, 0, len(item.Attachments))
+	for _, attachment := range item.Attachments {
+		attachments = append(attachments, map[string]any{
+			"fileUrl":  attachment.FileURL,
+			"title":    format.SanitizeText(attachment.Title, format.MaxFieldLen),
+			"mimeType": attachment.MimeType,
+			"iconLink": attachment.IconLink,
+			"fileId":   attachment.FileID,
+		})
+	}
+
+	transparency := item.Transparency
+	if transparency == "" {
+		transparency = "opaque"
+	}
+	visibility := item.Visibility
+	if visibility == "" {
+		visibility = "default"
+	}
+	data := map[string]any{
+		"id":           item.ID,
+		"summary":      format.SanitizeText(item.Summary, format.MaxFieldLen),
+		"start":        start,
+		"end":          end,
+		"location":     format.SanitizeText(item.Location, format.MaxFieldLen),
+		"description":  format.SanitizeText(item.Description, format.MaxBodyLen),
+		"attendees":    attendees,
+		"attachments":  attachments,
+		"hangoutLink":  item.HangoutLink,
+		"transparency": transparency,
+		"visibility":   visibility,
+		"status":       item.Status,
+		"etag":         version,
+		"version":      version,
+		"sequence":     item.Sequence,
+	}
+	if item.RecurringEvent != "" {
+		data["recurringEventId"] = item.RecurringEvent
+	}
+	for _, attendee := range item.Attendees {
+		if attendee.Self && attendee.ResponseStatus != "" {
+			data["response_status"] = attendee.ResponseStatus
+			data["responseStatus"] = attendee.ResponseStatus
+			break
+		}
+	}
+	return data
+}
+
+func eventVersion(bodyETag, headerETag string) string {
+	if version := strings.TrimSpace(bodyETag); version != "" && version != "*" {
+		return version
+	}
+	if version := strings.TrimSpace(headerETag); version != "" && version != "*" {
+		return version
+	}
+	return ""
+}
+
+func expectedEventVersion(params map[string]any) (string, error) {
+	var versions []string
+	for _, key := range []string{"expected_etag", "expected_version"} {
+		raw, exists := params[key]
+		if !exists {
+			continue
+		}
+		version, ok := raw.(string)
+		if !ok {
+			return "", &adapters.ExecutionFailure{
+				Kind: adapters.ExecutionFailureDefinite,
+				Err:  fmt.Errorf("%s must be a string", key),
+			}
+		}
+		version = strings.TrimSpace(version)
+		if version == "" || version == "*" || strings.ContainsAny(version, "\r\n") {
+			return "", &adapters.ExecutionFailure{
+				Kind: adapters.ExecutionFailureDefinite,
+				Err:  fmt.Errorf("%s must contain a concrete provider version", key),
+			}
+		}
+		versions = append(versions, version)
+	}
+	if len(versions) == 0 {
+		return "", &adapters.ExecutionFailure{
+			Kind: adapters.ExecutionFailureDefinite,
+			Err:  fmt.Errorf("expected_etag (or expected_version) is required"),
+		}
+	}
+	if len(versions) == 2 && versions[0] != versions[1] {
+		return "", &adapters.ExecutionFailure{
+			Kind: adapters.ExecutionFailureDefinite,
+			Err:  fmt.Errorf("expected_etag and expected_version disagree"),
+		}
+	}
+	return versions[0], nil
+}
+
+func calendarSendUpdates(params map[string]any) (string, error) {
+	raw, exists := params["send_updates"]
+	if !exists {
+		return "none", nil
+	}
+	value, ok := raw.(string)
+	if !ok {
+		return "", &adapters.ExecutionFailure{
+			Kind: adapters.ExecutionFailureDefinite,
+			Err:  fmt.Errorf("send_updates must be a string"),
+		}
+	}
+	value = strings.TrimSpace(value)
+	switch value {
+	case "all", "externalOnly", "none":
+		return value, nil
+	default:
+		return "", &adapters.ExecutionFailure{
+			Kind: adapters.ExecutionFailureDefinite,
+			Err:  fmt.Errorf("send_updates must be all, externalOnly, or none"),
+		}
+	}
+}
+
+func calendarAttendeePatch(raw any) ([]map[string]string, error) {
+	var values []any
+	switch typed := raw.(type) {
+	case []any:
+		values = typed
+	case []string:
+		values = make([]any, len(typed))
+		for i, value := range typed {
+			values[i] = value
+		}
+	default:
+		return nil, &adapters.ExecutionFailure{
+			Kind: adapters.ExecutionFailureDefinite,
+			Err:  fmt.Errorf("attendees must be an array of email strings"),
+		}
+	}
+	attendees := make([]map[string]string, 0, len(values))
+	for _, rawValue := range values {
+		var email string
+		switch attendee := rawValue.(type) {
+		case string:
+			email = attendee
+		case map[string]any:
+			email, _ = attendee["email"].(string)
+		case map[string]string:
+			email = attendee["email"]
+		}
+		email = strings.TrimSpace(email)
+		if email == "" {
+			return nil, &adapters.ExecutionFailure{
+				Kind: adapters.ExecutionFailureDefinite,
+				Err:  fmt.Errorf("attendees must contain non-empty email strings or email objects"),
+			}
+		}
+		attendees = append(attendees, map[string]string{"email": email})
+	}
+	return attendees, nil
+}
+
+func calendarSelfAttendee(attendees []calendarAPIAttendee) (calendarAPIAttendee, bool) {
+	for _, attendee := range attendees {
+		if attendee.Self {
+			return attendee, true
+		}
+	}
+	return calendarAPIAttendee{}, false
+}
+
 // ── HTTP helpers ──────────────────────────────────────────────────────────────
 
 func apiGET(ctx context.Context, client *http.Client, apiURL string, out any) error {
+	_, err := apiGETWithHeaders(ctx, client, apiURL, out)
+	return err
+}
+
+func apiGETWithHeaders(ctx context.Context, client *http.Client, apiURL string, out any) (http.Header, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer resp.Body.Close()
-	body, _ := io.ReadAll(resp.Body)
+	body, readErr := io.ReadAll(resp.Body)
 	if resp.StatusCode >= 400 {
-		return fmt.Errorf("status %d: %s", resp.StatusCode, format.Truncate(string(body), 200))
+		return resp.Header.Clone(), fmt.Errorf("status %d: %s", resp.StatusCode, format.Truncate(string(body), 200))
 	}
-	return json.Unmarshal(body, out)
+	if readErr != nil {
+		return resp.Header.Clone(), readErr
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return resp.Header.Clone(), err
+	}
+	return resp.Header.Clone(), nil
 }
 
 func apiWrite(ctx context.Context, client *http.Client, method, apiURL string, payload any, out any) error {
@@ -498,6 +885,82 @@ func apiWrite(ctx context.Context, client *http.Client, method, apiURL string, p
 		return json.Unmarshal(body, out)
 	}
 	return nil
+}
+
+func apiConditionalWrite(
+	ctx context.Context,
+	client *http.Client,
+	method, apiURL, expectedVersion string,
+	payload any,
+	out any,
+) (http.Header, error) {
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return nil, &adapters.ExecutionFailure{Kind: adapters.ExecutionFailureDefinite, Err: err}
+	}
+	req, err := http.NewRequestWithContext(ctx, method, apiURL, strings.NewReader(string(b)))
+	if err != nil {
+		return nil, &adapters.ExecutionFailure{Kind: adapters.ExecutionFailureDefinite, Err: err}
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("If-Match", expectedVersion)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		if resp != nil && resp.Body != nil {
+			resp.Body.Close()
+		}
+		return nil, &adapters.ExecutionFailure{
+			Kind:     adapters.ExecutionFailureAmbiguous,
+			TimedOut: isTimeoutError(err),
+			Err:      fmt.Errorf("provider mutation transport failed: %w", err),
+		}
+	}
+	defer resp.Body.Close()
+	body, readErr := io.ReadAll(resp.Body)
+
+	switch {
+	case resp.StatusCode == http.StatusPreconditionFailed:
+		return resp.Header.Clone(), &adapters.ExecutionFailure{
+			Kind: adapters.ExecutionFailureStaleVersion,
+			Err:  fmt.Errorf("provider rejected stale event version (status %d): %s", resp.StatusCode, format.Truncate(string(body), 200)),
+		}
+	case resp.StatusCode == http.StatusRequestTimeout || resp.StatusCode >= http.StatusInternalServerError:
+		return resp.Header.Clone(), &adapters.ExecutionFailure{
+			Kind:     adapters.ExecutionFailureAmbiguous,
+			TimedOut: resp.StatusCode == http.StatusRequestTimeout || resp.StatusCode == http.StatusGatewayTimeout,
+			Err:      fmt.Errorf("provider mutation outcome is ambiguous (status %d): %s", resp.StatusCode, format.Truncate(string(body), 200)),
+		}
+	case resp.StatusCode >= http.StatusBadRequest:
+		return resp.Header.Clone(), &adapters.ExecutionFailure{
+			Kind: adapters.ExecutionFailureDefinite,
+			Err:  fmt.Errorf("provider rejected mutation (status %d): %s", resp.StatusCode, format.Truncate(string(body), 200)),
+		}
+	case readErr != nil:
+		return resp.Header.Clone(), &adapters.ExecutionFailure{
+			Kind:     adapters.ExecutionFailureAmbiguous,
+			TimedOut: isTimeoutError(readErr),
+			Err:      fmt.Errorf("provider mutation response was incomplete: %w", readErr),
+		}
+	}
+
+	if out != nil && len(body) > 0 {
+		if err := json.Unmarshal(body, out); err != nil {
+			return resp.Header.Clone(), &adapters.ExecutionFailure{
+				Kind: adapters.ExecutionFailureAmbiguous,
+				Err:  fmt.Errorf("provider confirmed mutation but returned an invalid response: %w", err),
+			}
+		}
+	}
+	return resp.Header.Clone(), nil
+}
+
+func isTimeoutError(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
 }
 
 func paramInt(params map[string]any, key string) (int, bool) {

--- a/internal/adapters/google/calendar/adapter.go
+++ b/internal/adapters/google/calendar/adapter.go
@@ -918,6 +918,7 @@ func apiConditionalWrite(
 	}
 	defer resp.Body.Close()
 	body, readErr := io.ReadAll(resp.Body)
+	readTimedOut := isTimeoutError(readErr)
 
 	switch {
 	case resp.StatusCode == http.StatusPreconditionFailed:
@@ -928,7 +929,7 @@ func apiConditionalWrite(
 	case resp.StatusCode == http.StatusRequestTimeout || resp.StatusCode >= http.StatusInternalServerError:
 		return resp.Header.Clone(), &adapters.ExecutionFailure{
 			Kind:     adapters.ExecutionFailureAmbiguous,
-			TimedOut: resp.StatusCode == http.StatusRequestTimeout || resp.StatusCode == http.StatusGatewayTimeout,
+			TimedOut: resp.StatusCode == http.StatusRequestTimeout || resp.StatusCode == http.StatusGatewayTimeout || readTimedOut,
 			Err:      fmt.Errorf("provider mutation outcome is ambiguous (status %d): %s", resp.StatusCode, format.Truncate(string(body), 200)),
 		}
 	case resp.StatusCode >= http.StatusBadRequest:

--- a/internal/adapters/google/calendar/adapter_test.go
+++ b/internal/adapters/google/calendar/adapter_test.go
@@ -1,0 +1,519 @@
+package calendar
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/pkg/adapters"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type timeoutAfterCommitError struct{}
+
+func (timeoutAfterCommitError) Error() string   { return "timed out reading provider response" }
+func (timeoutAfterCommitError) Timeout() bool   { return true }
+func (timeoutAfterCommitError) Temporary() bool { return true }
+
+func fixture(t *testing.T, name string) string {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", name, err)
+	}
+	return string(body)
+}
+
+func fixtureWithoutETag(t *testing.T, name string) string {
+	t.Helper()
+	var body map[string]any
+	if err := json.Unmarshal([]byte(fixture(t, name)), &body); err != nil {
+		t.Fatalf("decode fixture %s: %v", name, err)
+	}
+	delete(body, "etag")
+	encoded, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("encode fixture %s without etag: %v", name, err)
+	}
+	return string(encoded)
+}
+
+func response(status int, body string, headers ...http.Header) *http.Response {
+	header := make(http.Header)
+	if len(headers) > 0 {
+		header = headers[0].Clone()
+	}
+	return &http.Response{
+		StatusCode: status,
+		Header:     header,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func requireFailure(t *testing.T, err error, kind adapters.ExecutionFailureKind) *adapters.ExecutionFailure {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected %s failure, got nil", kind)
+	}
+	failure, ok := adapters.AsExecutionFailure(err)
+	if !ok {
+		t.Fatalf("error %T (%v) is not a classified execution failure", err, err)
+	}
+	if failure.Kind != kind {
+		t.Fatalf("failure kind = %q, want %q (error: %v)", failure.Kind, kind, err)
+	}
+	return failure
+}
+
+func TestCalendarAttendeePatchAcceptsEmailObjects(t *testing.T) {
+	attendees, err := calendarAttendeePatch([]any{
+		"first@example.com",
+		map[string]any{"email": " second@example.com "},
+		map[string]string{"email": "third@example.com"},
+	})
+	if err != nil {
+		t.Fatalf("calendarAttendeePatch returned error: %v", err)
+	}
+	want := []map[string]string{
+		{"email": "first@example.com"},
+		{"email": "second@example.com"},
+		{"email": "third@example.com"},
+	}
+	if fmt.Sprint(attendees) != fmt.Sprint(want) {
+		t.Fatalf("attendees = %#v, want %#v", attendees, want)
+	}
+}
+
+func TestGetEventExposesProviderETagAndVersion(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet || req.URL.Path != "/calendar/v3/calendars/primary/events/event-123" {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		if req.URL.RawQuery != "" {
+			t.Fatalf("events.get must not receive unsupported query parameters: %s", req.URL.RawQuery)
+		}
+		// A body ETag is canonical when Google returns both representations.
+		return response(http.StatusOK, fixture(t, "event.json"), http.Header{"Etag": {`"header-v1"`}}), nil
+	})}
+
+	result, err := (&CalendarAdapter{}).getEvent(t.Context(), client, map[string]any{"event_id": "event-123"})
+	if err != nil {
+		t.Fatalf("getEvent: %v", err)
+	}
+	if result.Summary != "Event: Calendar approval review" {
+		t.Fatalf("summary = %q, want catalog-compatible summary", result.Summary)
+	}
+	data, ok := result.Data.(map[string]any)
+	if !ok {
+		t.Fatalf("result data = %T, want map[string]any", result.Data)
+	}
+	for _, field := range []string{"etag", "version"} {
+		if got := data[field]; got != `"event-v1"` {
+			t.Errorf("%s = %v, want %q", field, got, `"event-v1"`)
+		}
+	}
+	if got := data["sequence"]; got != int64(7) {
+		t.Errorf("sequence = %v (%T), want 7", got, got)
+	}
+	if got := data["response_status"]; got != "needsAction" {
+		t.Errorf("response_status = %v, want needsAction", got)
+	}
+}
+
+func TestGetEventUsesHeaderETagFallback(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return response(
+			http.StatusOK,
+			fixtureWithoutETag(t, "event.json"),
+			http.Header{"Etag": {`"header-v1"`}},
+		), nil
+	})}
+
+	result, err := (&CalendarAdapter{}).getEvent(t.Context(), client, map[string]any{"event_id": "event-123"})
+	if err != nil {
+		t.Fatalf("getEvent: %v", err)
+	}
+	data := result.Data.(map[string]any)
+	if data["etag"] != `"header-v1"` || data["version"] != `"header-v1"` {
+		t.Fatalf("etag/version = %v/%v, want header fallback", data["etag"], data["version"])
+	}
+}
+
+func TestGetEventMissingVersionFailsClosed(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return response(http.StatusOK, fixtureWithoutETag(t, "event.json")), nil
+	})}
+
+	_, err := (&CalendarAdapter{}).getEvent(t.Context(), client, map[string]any{"event_id": "event-123"})
+	requireFailure(t, err, adapters.ExecutionFailureDefinite)
+}
+
+func TestUpdateEventUsesIfMatchAndSendUpdates(t *testing.T) {
+	tests := []struct {
+		name       string
+		param      any
+		want       string
+		versionKey string
+	}{
+		{name: "default none", want: "none", versionKey: "expected_etag"},
+		{name: "all", param: "all", want: "all", versionKey: "expected_etag"},
+		{name: "external only and version alias", param: "externalOnly", want: "externalOnly", versionKey: "expected_version"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var calls atomic.Int32
+			client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				calls.Add(1)
+				if req.Method != http.MethodPatch || req.URL.Path != "/calendar/v3/calendars/primary/events/event-123" {
+					t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+				}
+				if got := req.Header.Get("If-Match"); got != `"event-v1"` {
+					t.Fatalf("If-Match = %q, want %q", got, `"event-v1"`)
+				}
+				if got := req.URL.Query().Get("sendUpdates"); got != tc.want {
+					t.Fatalf("sendUpdates = %q, want %q", got, tc.want)
+				}
+				var payload map[string]any
+				if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+					t.Fatalf("decode update payload: %v", err)
+				}
+				if payload["summary"] != "Calendar approval review (updated)" {
+					t.Errorf("summary = %v", payload["summary"])
+				}
+				for _, forbidden := range []string{"expected_etag", "expected_version", "send_updates"} {
+					if _, exists := payload[forbidden]; exists {
+						t.Errorf("provider payload unexpectedly contains %q: %v", forbidden, payload)
+					}
+				}
+				return response(http.StatusOK, fixture(t, "updated_event.json")), nil
+			})}
+
+			params := map[string]any{
+				"event_id":    "event-123",
+				"summary":     "Calendar approval review (updated)",
+				tc.versionKey: `"event-v1"`,
+			}
+			if tc.param != nil {
+				params["send_updates"] = tc.param
+			}
+			result, err := (&CalendarAdapter{}).updateEvent(t.Context(), client, params)
+			if err != nil {
+				t.Fatalf("updateEvent: %v", err)
+			}
+			if calls.Load() != 1 {
+				t.Fatalf("provider calls = %d, want 1", calls.Load())
+			}
+			data := result.Data.(map[string]any)
+			if data["etag"] != `"event-v2"` || data["version"] != `"event-v2"` {
+				t.Errorf("etag/version = %v/%v, want event-v2", data["etag"], data["version"])
+			}
+			if data["send_updates"] != tc.want {
+				t.Errorf("result send_updates = %v, want %s", data["send_updates"], tc.want)
+			}
+		})
+	}
+}
+
+func TestUpdateEventRejectsInvalidSendUpdatesBeforeProviderCall(t *testing.T) {
+	var calls atomic.Int32
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		calls.Add(1)
+		return nil, fmt.Errorf("unexpected provider call")
+	})}
+
+	_, err := (&CalendarAdapter{}).updateEvent(t.Context(), client, map[string]any{
+		"event_id":      "event-123",
+		"expected_etag": `"event-v1"`,
+		"summary":       "changed",
+		"send_updates":  "yes",
+	})
+	requireFailure(t, err, adapters.ExecutionFailureDefinite)
+	if calls.Load() != 0 {
+		t.Fatalf("provider calls = %d, want 0", calls.Load())
+	}
+}
+
+func TestUpdateEventStaleVersionIsClassified(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if got := req.Header.Get("If-Match"); got != `"event-v1"` {
+			t.Fatalf("If-Match = %q, want event-v1", got)
+		}
+		return response(http.StatusPreconditionFailed, fixture(t, "provider_error.json")), nil
+	})}
+
+	_, err := (&CalendarAdapter{}).updateEvent(t.Context(), client, map[string]any{
+		"event_id":      "event-123",
+		"expected_etag": `"event-v1"`,
+		"summary":       "changed",
+	})
+	requireFailure(t, err, adapters.ExecutionFailureStaleVersion)
+}
+
+func TestUpdateEventProviderRejectionIsDefinite(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return response(http.StatusBadRequest, `{"error":{"message":"invalid event"}}`), nil
+	})}
+
+	_, err := (&CalendarAdapter{}).updateEvent(t.Context(), client, map[string]any{
+		"event_id":      "event-123",
+		"expected_etag": `"event-v1"`,
+		"summary":       "changed",
+	})
+	requireFailure(t, err, adapters.ExecutionFailureDefinite)
+}
+
+func TestUpdateEventRequiresConcreteExpectedVersion(t *testing.T) {
+	tests := []struct {
+		name   string
+		params map[string]any
+	}{
+		{name: "missing", params: map[string]any{}},
+		{name: "empty", params: map[string]any{"expected_etag": "  "}},
+		{name: "wildcard", params: map[string]any{"expected_etag": "*"}},
+		{name: "conflicting aliases", params: map[string]any{
+			"expected_etag": `"event-v1"`, "expected_version": `"event-v0"`,
+		}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var calls atomic.Int32
+			client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				calls.Add(1)
+				return nil, fmt.Errorf("unexpected provider call")
+			})}
+			tc.params["event_id"] = "event-123"
+			tc.params["summary"] = "changed"
+
+			_, err := (&CalendarAdapter{}).updateEvent(t.Context(), client, tc.params)
+			requireFailure(t, err, adapters.ExecutionFailureDefinite)
+			if calls.Load() != 0 {
+				t.Fatalf("provider calls = %d, want 0", calls.Load())
+			}
+		})
+	}
+}
+
+func TestUpdateEventTimeoutAfterProviderCommitIsAmbiguous(t *testing.T) {
+	var committed atomic.Int32
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Header.Get("If-Match") != `"event-v1"` {
+			t.Fatal("conditional write was not sent before simulated commit")
+		}
+		committed.Add(1)
+		return nil, timeoutAfterCommitError{}
+	})}
+
+	_, err := (&CalendarAdapter{}).updateEvent(t.Context(), client, map[string]any{
+		"event_id":      "event-123",
+		"expected_etag": `"event-v1"`,
+		"summary":       "changed",
+	})
+	failure := requireFailure(t, err, adapters.ExecutionFailureAmbiguous)
+	if !failure.TimedOut {
+		t.Fatal("timeout-after-commit must set TimedOut")
+	}
+	if committed.Load() != 1 {
+		t.Fatalf("simulated provider commits = %d, want 1", committed.Load())
+	}
+}
+
+func TestUpdateEventSuccessWithoutNewVersionFailsClosedAsAmbiguous(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return response(http.StatusOK, `{"id":"event-123","summary":"changed"}`), nil
+	})}
+
+	_, err := (&CalendarAdapter{}).updateEvent(t.Context(), client, map[string]any{
+		"event_id":      "event-123",
+		"expected_etag": `"event-v1"`,
+		"summary":       "changed",
+	})
+	failure := requireFailure(t, err, adapters.ExecutionFailureAmbiguous)
+	if failure.TimedOut {
+		t.Fatal("missing response version is ambiguous but is not a timeout")
+	}
+}
+
+func TestRespondToEventUpdatesOnlySelfWithConditionalWrite(t *testing.T) {
+	tests := []struct {
+		status       string
+		versionParam string
+		sendUpdates  string
+		wantSend     string
+	}{
+		{status: "accepted", versionParam: "expected_etag", sendUpdates: "all", wantSend: "all"},
+		{status: "declined", versionParam: "expected_etag", wantSend: "none"},
+		{status: "tentative", versionParam: "expected_version", sendUpdates: "externalOnly", wantSend: "externalOnly"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.status, func(t *testing.T) {
+			var calls atomic.Int32
+			client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				switch calls.Add(1) {
+				case 1:
+					if req.Method != http.MethodGet {
+						t.Fatalf("pre-read method = %s, want GET", req.Method)
+					}
+					return response(http.StatusOK, fixture(t, "event.json")), nil
+				case 2:
+					if req.Method != http.MethodPatch {
+						t.Fatalf("mutation method = %s, want PATCH", req.Method)
+					}
+					if got := req.Header.Get("If-Match"); got != `"event-v1"` {
+						t.Fatalf("If-Match = %q, want event-v1", got)
+					}
+					if got := req.URL.Query().Get("sendUpdates"); got != tc.wantSend {
+						t.Fatalf("sendUpdates = %q, want %q", got, tc.wantSend)
+					}
+					var payload struct {
+						AttendeesOmitted bool `json:"attendeesOmitted"`
+						Attendees        []struct {
+							Email          string `json:"email"`
+							ResponseStatus string `json:"responseStatus"`
+						} `json:"attendees"`
+					}
+					if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+						t.Fatalf("decode RSVP payload: %v", err)
+					}
+					if !payload.AttendeesOmitted {
+						t.Fatal("attendeesOmitted = false, want true")
+					}
+					if len(payload.Attendees) != 1 {
+						t.Fatalf("attendees = %+v, want exactly self attendee", payload.Attendees)
+					}
+					if payload.Attendees[0].Email != "self@example.com" || payload.Attendees[0].ResponseStatus != tc.status {
+						t.Fatalf("attendee patch = %+v, want self/%s", payload.Attendees[0], tc.status)
+					}
+					return response(http.StatusOK, fixture(t, "updated_event.json")), nil
+				default:
+					t.Fatalf("unexpected extra provider request: %s %s", req.Method, req.URL.String())
+					return nil, nil
+				}
+			})}
+
+			params := map[string]any{
+				"event_id":        "event-123",
+				"response_status": tc.status,
+				tc.versionParam:   `"event-v1"`,
+			}
+			if tc.sendUpdates != "" {
+				params["send_updates"] = tc.sendUpdates
+			}
+			result, err := (&CalendarAdapter{}).respondToEvent(t.Context(), client, params)
+			if err != nil {
+				t.Fatalf("respondToEvent: %v", err)
+			}
+			if calls.Load() != 2 {
+				t.Fatalf("provider calls = %d, want GET + PATCH", calls.Load())
+			}
+			data := result.Data.(map[string]any)
+			if data["response_status"] != tc.status || data["send_updates"] != tc.wantSend {
+				t.Errorf("result = %v, want status=%s send_updates=%s", data, tc.status, tc.wantSend)
+			}
+			if data["etag"] != `"event-v2"` {
+				t.Errorf("result etag = %v, want event-v2", data["etag"])
+			}
+		})
+	}
+}
+
+func TestRespondToEventRejectsInvalidRSVPBeforeProviderCall(t *testing.T) {
+	var calls atomic.Int32
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		calls.Add(1)
+		return nil, fmt.Errorf("unexpected provider call")
+	})}
+
+	_, err := (&CalendarAdapter{}).respondToEvent(t.Context(), client, map[string]any{
+		"event_id":        "event-123",
+		"expected_etag":   `"event-v1"`,
+		"response_status": "maybe",
+	})
+	requireFailure(t, err, adapters.ExecutionFailureDefinite)
+	if calls.Load() != 0 {
+		t.Fatalf("provider calls = %d, want 0", calls.Load())
+	}
+}
+
+func TestRespondToEventRequiresExplicitSelfAttendee(t *testing.T) {
+	var calls atomic.Int32
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if calls.Add(1) != 1 || req.Method != http.MethodGet {
+			return nil, fmt.Errorf("unexpected provider mutation: %s %s", req.Method, req.URL.String())
+		}
+		return response(http.StatusOK, `{
+			"id":"event-123",
+			"etag":"\"event-v1\"",
+			"attendees":[{"email":"shared-calendar@example.com","responseStatus":"needsAction"}]
+		}`), nil
+	})}
+
+	_, err := (&CalendarAdapter{}).respondToEvent(t.Context(), client, map[string]any{
+		"event_id":        "event-123",
+		"calendar_id":     "shared-calendar@example.com",
+		"expected_etag":   `"event-v1"`,
+		"response_status": "accepted",
+	})
+	requireFailure(t, err, adapters.ExecutionFailureDefinite)
+	if calls.Load() != 1 {
+		t.Fatalf("provider calls = %d, want only pre-read", calls.Load())
+	}
+}
+
+func TestRespondToEventStalePreReadDoesNotMutate(t *testing.T) {
+	var calls atomic.Int32
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		calls.Add(1)
+		return response(http.StatusOK, fixture(t, "event.json")), nil
+	})}
+
+	_, err := (&CalendarAdapter{}).respondToEvent(t.Context(), client, map[string]any{
+		"event_id":        "event-123",
+		"expected_etag":   `"event-v0"`,
+		"response_status": "accepted",
+	})
+	requireFailure(t, err, adapters.ExecutionFailureStaleVersion)
+	if calls.Load() != 1 {
+		t.Fatalf("provider calls = %d, want only pre-read", calls.Load())
+	}
+}
+
+func TestRespondToEventProviderRechecksVersionAtMutation(t *testing.T) {
+	var calls atomic.Int32
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch calls.Add(1) {
+		case 1:
+			return response(http.StatusOK, fixture(t, "event.json")), nil
+		case 2:
+			if got := req.Header.Get("If-Match"); got != `"event-v1"` {
+				t.Fatalf("If-Match = %q, want event-v1", got)
+			}
+			return response(http.StatusPreconditionFailed, fixture(t, "provider_error.json")), nil
+		default:
+			return nil, fmt.Errorf("unexpected provider call")
+		}
+	})}
+
+	_, err := (&CalendarAdapter{}).respondToEvent(t.Context(), client, map[string]any{
+		"event_id":        "event-123",
+		"expected_etag":   `"event-v1"`,
+		"response_status": "accepted",
+	})
+	requireFailure(t, err, adapters.ExecutionFailureStaleVersion)
+	if calls.Load() != 2 {
+		t.Fatalf("provider calls = %d, want GET + conditional PATCH", calls.Load())
+	}
+}

--- a/internal/adapters/google/calendar/adapter_test.go
+++ b/internal/adapters/google/calendar/adapter_test.go
@@ -26,6 +26,14 @@ func (timeoutAfterCommitError) Error() string   { return "timed out reading prov
 func (timeoutAfterCommitError) Timeout() bool   { return true }
 func (timeoutAfterCommitError) Temporary() bool { return true }
 
+type timeoutReadCloser struct{}
+
+func (timeoutReadCloser) Read([]byte) (int, error) {
+	return 0, timeoutAfterCommitError{}
+}
+
+func (timeoutReadCloser) Close() error { return nil }
+
 func fixture(t *testing.T, name string) string {
 	t.Helper()
 	body, err := os.ReadFile(filepath.Join("testdata", name))
@@ -327,6 +335,30 @@ func TestUpdateEventTimeoutAfterProviderCommitIsAmbiguous(t *testing.T) {
 	}
 	if committed.Load() != 1 {
 		t.Fatalf("simulated provider commits = %d, want 1", committed.Load())
+	}
+}
+
+func TestProvider5xxWithBodyReadTimeoutIsClassifiedAsTimeout(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Header:     make(http.Header),
+			Body:       timeoutReadCloser{},
+		}, nil
+	})}
+
+	_, err := apiConditionalWrite(
+		t.Context(),
+		client,
+		http.MethodPatch,
+		"https://www.googleapis.com/calendar/v3/calendars/primary/events/event-123",
+		`"event-v1"`,
+		map[string]string{"summary": "changed"},
+		nil,
+	)
+	failure := requireFailure(t, err, adapters.ExecutionFailureAmbiguous)
+	if !failure.TimedOut {
+		t.Fatal("5xx response with a body read timeout must set TimedOut")
 	}
 }
 

--- a/internal/adapters/google/calendar/testdata/event.json
+++ b/internal/adapters/google/calendar/testdata/event.json
@@ -1,0 +1,39 @@
+{
+  "id": "event-123",
+  "etag": "\"event-v1\"",
+  "sequence": 7,
+  "summary": "Calendar approval review",
+  "location": "Video call",
+  "description": "Review the proposed provider action",
+  "status": "confirmed",
+  "hangoutLink": "https://meet.google.com/example",
+  "start": {
+    "dateTime": "2026-08-28T16:00:00Z",
+    "timeZone": "UTC"
+  },
+  "end": {
+    "dateTime": "2026-08-28T16:30:00Z",
+    "timeZone": "UTC"
+  },
+  "attendees": [
+    {
+      "email": "self@example.com",
+      "displayName": "Calendar Owner",
+      "responseStatus": "needsAction",
+      "self": true
+    },
+    {
+      "email": "organizer@example.com",
+      "responseStatus": "accepted",
+      "organizer": true
+    }
+  ],
+  "attachments": [
+    {
+      "fileUrl": "https://drive.google.com/file/d/example",
+      "title": "Agenda",
+      "mimeType": "application/pdf",
+      "fileId": "file-123"
+    }
+  ]
+}

--- a/internal/adapters/google/calendar/testdata/provider_error.json
+++ b/internal/adapters/google/calendar/testdata/provider_error.json
@@ -1,0 +1,7 @@
+{
+  "error": {
+    "code": 412,
+    "message": "Precondition Failed",
+    "status": "FAILED_PRECONDITION"
+  }
+}

--- a/internal/adapters/google/calendar/testdata/updated_event.json
+++ b/internal/adapters/google/calendar/testdata/updated_event.json
@@ -1,0 +1,27 @@
+{
+  "id": "event-123",
+  "etag": "\"event-v2\"",
+  "sequence": 8,
+  "summary": "Calendar approval review (updated)",
+  "status": "confirmed",
+  "start": {
+    "dateTime": "2026-08-28T16:00:00Z",
+    "timeZone": "UTC"
+  },
+  "end": {
+    "dateTime": "2026-08-28T16:30:00Z",
+    "timeZone": "UTC"
+  },
+  "attendees": [
+    {
+      "email": "self@example.com",
+      "responseStatus": "accepted",
+      "self": true
+    },
+    {
+      "email": "organizer@example.com",
+      "responseStatus": "accepted",
+      "organizer": true
+    }
+  ]
+}

--- a/internal/api/gateway_execution_failure_test.go
+++ b/internal/api/gateway_execution_failure_test.go
@@ -1,0 +1,159 @@
+package api_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync/atomic"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/pkg/adapters"
+)
+
+func TestGatewayClassifiedAdapterFailuresSurviveDuplicateRequest(t *testing.T) {
+	tests := []struct {
+		name         string
+		kind         adapters.ExecutionFailureKind
+		wantCode     string
+		wantOutcome  string
+		wantTimedOut bool
+	}{
+		{
+			name:        "definite",
+			kind:        adapters.ExecutionFailureDefinite,
+			wantCode:    "PROVIDER_DEFINITE_FAILURE",
+			wantOutcome: "provider_definite_failure",
+		},
+		{
+			name:        "stale version",
+			kind:        adapters.ExecutionFailureStaleVersion,
+			wantCode:    "STALE_VERSION",
+			wantOutcome: "provider_stale_version",
+		},
+		{
+			name:        "ambiguous",
+			kind:        adapters.ExecutionFailureAmbiguous,
+			wantCode:    "AMBIGUOUS_OUTCOME",
+			wantOutcome: "provider_ambiguous",
+		},
+	}
+
+	for i, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			serviceID := fmt.Sprintf("mock.classified.%d", i)
+			adapter := newMockAdapter(serviceID, "run").withError(&adapters.ExecutionFailure{
+				Kind:     tc.kind,
+				TimedOut: tc.wantTimedOut,
+				Err:      errors.New("classified provider failure"),
+			})
+			env := newTestEnv(t, adapter)
+			sc := newScenario(t, env, "calendar-agent")
+			taskID := sc.createApprovedTask(t, env, serviceID, "run", true)
+			requestID := fmt.Sprintf("classified-%d", i)
+
+			first := sc.gatewayRequestWithTask(env, requestID, serviceID, "run", taskID)
+			assertGatewayExecutionFailure(t, first, tc.wantCode, string(tc.kind), tc.wantTimedOut)
+
+			duplicate := sc.gatewayRequestWithTask(env, requestID, serviceID, "run", taskID)
+			assertGatewayExecutionFailure(t, duplicate, tc.wantCode, string(tc.kind), tc.wantTimedOut)
+			if duplicate["deduped"] != true {
+				t.Fatalf("duplicate response missing deduped=true: %v", duplicate)
+			}
+			if duplicate["audit_id"] != first["audit_id"] {
+				t.Fatalf("duplicate audit_id = %v, want canonical %v", duplicate["audit_id"], first["audit_id"])
+			}
+			if adapter.executeCount() != 1 {
+				t.Fatalf("adapter executions = %d, want 1", adapter.executeCount())
+			}
+
+			entry, err := env.Store.GetAuditEntryByRequestIDAndTask(context.Background(), requestID, sc.session.UserID, taskID)
+			if err != nil {
+				t.Fatalf("GetAuditEntryByRequestIDAndTask: %v", err)
+			}
+			if entry.Outcome != tc.wantOutcome {
+				t.Fatalf("audit outcome = %q, want %q", entry.Outcome, tc.wantOutcome)
+			}
+		})
+	}
+}
+
+func TestGatewayClickExecutionTimeoutAfterCommitRemainsIdempotent(t *testing.T) {
+	var simulatedCommits atomic.Int32
+	adapter := newMockAdapter("mock.click-timeout", "respond_to_event").
+		withExecuteHook(func() { simulatedCommits.Add(1) }).
+		withError(&adapters.ExecutionFailure{
+			Kind:     adapters.ExecutionFailureAmbiguous,
+			TimedOut: true,
+			Err:      errors.New("provider timed out after accepting the mutation"),
+		})
+	env := newTestEnv(t, adapter)
+	sc := newScenario(t, env, "calendar-agent")
+	taskID := sc.createApprovedTask(t, env, "mock.click-timeout", "respond_to_event", false)
+	requestID := "click-timeout-after-commit"
+
+	pending := sc.gatewayRequestWithTask(env, requestID, "mock.click-timeout", "respond_to_event", taskID)
+	if pending["status"] != "pending" {
+		t.Fatalf("initial status = %v, want pending: %v", pending["status"], pending)
+	}
+	resp := sc.session.do("POST", fmt.Sprintf("/api/approvals/%s/approve", requestID), nil)
+	mustStatus(t, resp, http.StatusOK)
+
+	resp = env.do(
+		"POST",
+		fmt.Sprintf("/api/gateway/request/%s/execute?task_id=%s", requestID, taskID),
+		sc.AgentToken,
+		nil,
+	)
+	executed := mustStatus(t, resp, http.StatusOK)
+	assertGatewayExecutionFailure(t, executed, "PROVIDER_TIMEOUT", "ambiguous", true)
+	if simulatedCommits.Load() != 1 {
+		t.Fatalf("simulated provider commits = %d, want 1", simulatedCommits.Load())
+	}
+
+	duplicate := sc.gatewayRequestWithTask(env, requestID, "mock.click-timeout", "respond_to_event", taskID)
+	assertGatewayExecutionFailure(t, duplicate, "PROVIDER_TIMEOUT", "ambiguous", true)
+	if duplicate["deduped"] != true {
+		t.Fatalf("duplicate response missing deduped=true: %v", duplicate)
+	}
+	if simulatedCommits.Load() != 1 || adapter.executeCount() != 1 {
+		t.Fatalf(
+			"duplicate re-executed mutation: commits=%d executions=%d",
+			simulatedCommits.Load(),
+			adapter.executeCount(),
+		)
+	}
+
+	entry, err := env.Store.GetAuditEntryByRequestIDAndTask(context.Background(), requestID, sc.session.UserID, taskID)
+	if err != nil {
+		t.Fatalf("GetAuditEntryByRequestIDAndTask: %v", err)
+	}
+	if entry.Outcome != "provider_timeout" {
+		t.Fatalf("audit outcome = %q, want provider_timeout", entry.Outcome)
+	}
+}
+
+func assertGatewayExecutionFailure(
+	t *testing.T,
+	body map[string]any,
+	wantCode, wantKind string,
+	wantTimedOut bool,
+) {
+	t.Helper()
+	if body["status"] != "error" {
+		t.Fatalf("status = %v, want error: %v", body["status"], body)
+	}
+	if body["code"] != wantCode {
+		t.Fatalf("code = %v, want %s: %v", body["code"], wantCode, body)
+	}
+	if body["failure_kind"] != wantKind {
+		t.Fatalf("failure_kind = %v, want %s: %v", body["failure_kind"], wantKind, body)
+	}
+	if wantTimedOut {
+		if body["timed_out"] != true {
+			t.Fatalf("timed_out = %v, want true: %v", body["timed_out"], body)
+		}
+	} else if _, exists := body["timed_out"]; exists {
+		t.Fatalf("unexpected timed_out field: %v", body)
+	}
+}

--- a/internal/api/handlers/adapter_execution_failure.go
+++ b/internal/api/handlers/adapter_execution_failure.go
@@ -1,0 +1,101 @@
+package handlers
+
+import (
+	"github.com/clawvisor/clawvisor/pkg/adapters"
+	"github.com/clawvisor/clawvisor/pkg/gateway"
+)
+
+// Classified adapter failures are persisted as audit outcomes so a retry with
+// the same request_id can reconstruct the original machine-readable response
+// without invoking the provider again.
+const (
+	auditOutcomeDefiniteFailure = "provider_definite_failure"
+	auditOutcomeStaleVersion    = "provider_stale_version"
+	auditOutcomeAmbiguous       = "provider_ambiguous"
+	auditOutcomeTimeout         = "provider_timeout"
+)
+
+type adapterExecutionFailureDescription struct {
+	AuditOutcome string
+	Code         string
+	Kind         adapters.ExecutionFailureKind
+	TimedOut     bool
+}
+
+func describeAdapterExecutionFailure(err error) (adapterExecutionFailureDescription, bool) {
+	failure, ok := adapters.AsExecutionFailure(err)
+	if !ok {
+		return adapterExecutionFailureDescription{}, false
+	}
+
+	switch failure.Kind {
+	case adapters.ExecutionFailureDefinite:
+		return adapterExecutionFailureDescription{
+			AuditOutcome: auditOutcomeDefiniteFailure,
+			Code:         gateway.CodeProviderDefiniteFailure,
+			Kind:         adapters.ExecutionFailureDefinite,
+		}, true
+	case adapters.ExecutionFailureStaleVersion:
+		return adapterExecutionFailureDescription{
+			AuditOutcome: auditOutcomeStaleVersion,
+			Code:         gateway.CodeStaleVersion,
+			Kind:         adapters.ExecutionFailureStaleVersion,
+		}, true
+	case adapters.ExecutionFailureAmbiguous:
+		if failure.TimedOut {
+			return adapterExecutionFailureDescription{
+				AuditOutcome: auditOutcomeTimeout,
+				Code:         gateway.CodeProviderTimeout,
+				Kind:         adapters.ExecutionFailureAmbiguous,
+				TimedOut:     true,
+			}, true
+		}
+		return adapterExecutionFailureDescription{
+			AuditOutcome: auditOutcomeAmbiguous,
+			Code:         gateway.CodeAmbiguousOutcome,
+			Kind:         adapters.ExecutionFailureAmbiguous,
+		}, true
+	default:
+		return adapterExecutionFailureDescription{}, false
+	}
+}
+
+func describeAuditExecutionFailure(outcome string) (adapterExecutionFailureDescription, bool) {
+	switch outcome {
+	case auditOutcomeDefiniteFailure:
+		return adapterExecutionFailureDescription{
+			AuditOutcome: outcome,
+			Code:         gateway.CodeProviderDefiniteFailure,
+			Kind:         adapters.ExecutionFailureDefinite,
+		}, true
+	case auditOutcomeStaleVersion:
+		return adapterExecutionFailureDescription{
+			AuditOutcome: outcome,
+			Code:         gateway.CodeStaleVersion,
+			Kind:         adapters.ExecutionFailureStaleVersion,
+		}, true
+	case auditOutcomeAmbiguous:
+		return adapterExecutionFailureDescription{
+			AuditOutcome: outcome,
+			Code:         gateway.CodeAmbiguousOutcome,
+			Kind:         adapters.ExecutionFailureAmbiguous,
+		}, true
+	case auditOutcomeTimeout:
+		return adapterExecutionFailureDescription{
+			AuditOutcome: outcome,
+			Code:         gateway.CodeProviderTimeout,
+			Kind:         adapters.ExecutionFailureAmbiguous,
+			TimedOut:     true,
+		}, true
+	default:
+		return adapterExecutionFailureDescription{}, false
+	}
+}
+
+func addAdapterExecutionFailureFields(resp map[string]any, failure adapterExecutionFailureDescription) {
+	resp["code"] = failure.Code
+	resp["failure_kind"] = string(failure.Kind)
+	if failure.TimedOut {
+		resp["timed_out"] = true
+	}
+}

--- a/internal/api/handlers/adapter_execution_failure_test.go
+++ b/internal/api/handlers/adapter_execution_failure_test.go
@@ -1,0 +1,78 @@
+package handlers
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/clawvisor/clawvisor/pkg/adapters"
+)
+
+func TestAdapterExecutionFailureAuditRoundTrip(t *testing.T) {
+	tests := []struct {
+		name      string
+		failure   *adapters.ExecutionFailure
+		wantAudit string
+		wantCode  string
+		wantKind  adapters.ExecutionFailureKind
+		wantTimed bool
+	}{
+		{
+			name:      "definite",
+			failure:   &adapters.ExecutionFailure{Kind: adapters.ExecutionFailureDefinite, Err: errors.New("rejected")},
+			wantAudit: "provider_definite_failure",
+			wantCode:  "PROVIDER_DEFINITE_FAILURE",
+			wantKind:  adapters.ExecutionFailureDefinite,
+		},
+		{
+			name:      "stale version",
+			failure:   &adapters.ExecutionFailure{Kind: adapters.ExecutionFailureStaleVersion, Err: errors.New("stale")},
+			wantAudit: "provider_stale_version",
+			wantCode:  "STALE_VERSION",
+			wantKind:  adapters.ExecutionFailureStaleVersion,
+		},
+		{
+			name:      "ambiguous",
+			failure:   &adapters.ExecutionFailure{Kind: adapters.ExecutionFailureAmbiguous, Err: errors.New("unknown")},
+			wantAudit: "provider_ambiguous",
+			wantCode:  "AMBIGUOUS_OUTCOME",
+			wantKind:  adapters.ExecutionFailureAmbiguous,
+		},
+		{
+			name:      "timeout",
+			failure:   &adapters.ExecutionFailure{Kind: adapters.ExecutionFailureAmbiguous, TimedOut: true, Err: errors.New("timed out")},
+			wantAudit: "provider_timeout",
+			wantCode:  "PROVIDER_TIMEOUT",
+			wantKind:  adapters.ExecutionFailureAmbiguous,
+			wantTimed: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			description, ok := describeAdapterExecutionFailure(tc.failure)
+			if !ok {
+				t.Fatal("execution failure was not classified")
+			}
+			if description.AuditOutcome != tc.wantAudit ||
+				description.Code != tc.wantCode ||
+				description.Kind != tc.wantKind ||
+				description.TimedOut != tc.wantTimed {
+				t.Fatalf("execution classification = %+v", description)
+			}
+
+			restored, ok := describeAuditExecutionFailure(description.AuditOutcome)
+			if !ok {
+				t.Fatal("persisted failure was not restored")
+			}
+			if restored != description {
+				t.Fatalf("restored classification = %+v, want %+v", restored, description)
+			}
+		})
+	}
+}
+
+func TestApprovalTimeoutIsNotClassifiedAsProviderTimeout(t *testing.T) {
+	if got, ok := describeAuditExecutionFailure("timeout"); ok {
+		t.Fatalf("approval timeout was misclassified as provider failure: %+v", got)
+	}
+}

--- a/internal/api/handlers/gateway.go
+++ b/internal/api/handlers/gateway.go
@@ -1154,16 +1154,27 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 
 			if execErr != nil {
 				errMsg := execErr.Error()
-				if updErr := h.store.UpdateAuditOutcome(finalizeCtx, auditID, "error", errMsg, dur); updErr != nil {
+				auditOutcome := "error"
+				failure, classified := describeAdapterExecutionFailure(execErr)
+				if classified {
+					auditOutcome = failure.AuditOutcome
+				}
+				if updErr := h.store.UpdateAuditOutcome(finalizeCtx, auditID, auditOutcome, errMsg, dur); updErr != nil {
 					h.logger.WarnContext(ctx, "audit outcome update failed", "err", updErr)
 				}
-				outDecision, outOutcome = "execute", "error"
+				outDecision, outOutcome = "execute", auditOutcome
 				h.publishAuditAndQueue(agent.UserID, req.TaskID)
 				if req.Context.CallbackURL != "" {
 					cbKey, _ := h.store.GetAgentCallbackSecret(finalizeCtx, agent.ID)
-					h.dispatchCallback(req.Context.CallbackURL, &callback.Payload{
+					payload := &callback.Payload{
 						Type: "request", RequestID: req.RequestID, Status: "error", Error: errMsg, AuditID: auditID,
-					}, cbKey)
+					}
+					if classified {
+						payload.Code = failure.Code
+						payload.FailureKind = string(failure.Kind)
+						payload.TimedOut = failure.TimedOut
+					}
+					h.dispatchCallback(req.Context.CallbackURL, payload, cbKey)
 				}
 				resp := map[string]any{
 					"status":     "error",
@@ -1171,6 +1182,9 @@ func (h *GatewayHandler) HandleRequest(w http.ResponseWriter, r *http.Request) {
 					"audit_id":   auditID,
 					"error":      errMsg,
 					"code":       gateway.CodeAdapterError,
+				}
+				if classified {
+					addAdapterExecutionFailureFields(resp, failure)
 				}
 				h.maybeInjectNPS(ctx, resp, agent.ID)
 				writeJSON(w, http.StatusOK, resp)
@@ -1624,15 +1638,33 @@ func (h *GatewayHandler) executeAndRespond(w http.ResponseWriter, ctx context.Co
 	}
 	dur := int(time.Since(start).Milliseconds())
 
-	outcome := "executed"
+	status := "executed"
+	auditOutcome := "executed"
 	errMsg := ""
+	var failure adapterExecutionFailureDescription
+	var classified bool
 	if execErr != nil {
-		outcome = "error"
+		status = "error"
+		auditOutcome = "error"
 		errMsg = execErr.Error()
+		failure, classified = describeAdapterExecutionFailure(execErr)
+		if classified {
+			auditOutcome = failure.AuditOutcome
+		}
 	}
 
-	_ = h.store.UpdateAuditOutcome(ctx, pa.AuditID, outcome, errMsg, dur)
-	_ = h.store.DeletePendingApproval(ctx, pa.RequestID, pa.UserID, paTask)
+	// The adapter may return because the request deadline elapsed after the
+	// provider accepted a mutation. Finalize the canonical row with a fresh
+	// context so duplicate request_ids observe the classified result instead
+	// of a permanently in-flight reservation.
+	finalizeCtx, finalizeCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer finalizeCancel()
+	if err := h.store.UpdateAuditOutcome(finalizeCtx, pa.AuditID, auditOutcome, errMsg, dur); err != nil {
+		h.logger.WarnContext(ctx, "audit outcome update failed", "err", err)
+	}
+	if err := h.store.DeletePendingApproval(finalizeCtx, pa.RequestID, pa.UserID, paTask); err != nil {
+		h.logger.WarnContext(ctx, "pending approval cleanup failed", "err", err)
+	}
 	h.publishAuditAndQueue(pa.UserID, blob.TaskID)
 
 	// On successful execution, seed chain_facts with anything the new result
@@ -1651,12 +1683,16 @@ func (h *GatewayHandler) executeAndRespond(w http.ResponseWriter, ctx context.Co
 	}
 
 	resp := map[string]any{
-		"status":     outcome,
+		"status":     status,
 		"request_id": pa.RequestID,
 		"audit_id":   pa.AuditID,
 	}
 	if execErr != nil {
 		resp["error"] = errMsg
+		resp["code"] = gateway.CodeAdapterError
+		if classified {
+			addAdapterExecutionFailureFields(resp, failure)
+		}
 	} else {
 		resp["result"] = result
 	}
@@ -1822,10 +1858,20 @@ type gatewayStatusResponseOptions struct {
 }
 
 func writeGatewayStatusResponse(w http.ResponseWriter, e *store.AuditEntry, opts ...gatewayStatusResponseOptions) {
+	status := e.Outcome
+	failure, classified := describeAuditExecutionFailure(e.Outcome)
+	if classified {
+		status = "error"
+	}
 	resp := map[string]any{
-		"status":     e.Outcome,
+		"status":     status,
 		"request_id": e.RequestID,
 		"audit_id":   e.ID,
+	}
+	if classified {
+		addAdapterExecutionFailureFields(resp, failure)
+	} else if e.Outcome == "error" {
+		resp["code"] = gateway.CodeAdapterError
 	}
 	if len(opts) > 0 {
 		if opts[0].Deduped {

--- a/internal/callback/callback.go
+++ b/internal/callback/callback.go
@@ -21,13 +21,16 @@ import (
 
 // Payload is posted to the agent's callback URL.
 type Payload struct {
-	Type      string           `json:"type"`                 // "request" or "task"
-	RequestID string           `json:"request_id,omitempty"` // populated when Type == "request"
-	TaskID    string           `json:"task_id,omitempty"`    // populated when Type == "task"
-	Status    string           `json:"status"`
-	Result    *adapters.Result `json:"result,omitempty"`
-	Error     string           `json:"error,omitempty"`
-	AuditID   string           `json:"audit_id,omitempty"`
+	Type        string           `json:"type"`                 // "request" or "task"
+	RequestID   string           `json:"request_id,omitempty"` // populated when Type == "request"
+	TaskID      string           `json:"task_id,omitempty"`    // populated when Type == "task"
+	Status      string           `json:"status"`
+	Result      *adapters.Result `json:"result,omitempty"`
+	Error       string           `json:"error,omitempty"`
+	Code        string           `json:"code,omitempty"`
+	FailureKind string           `json:"failure_kind,omitempty"`
+	TimedOut    bool             `json:"timed_out,omitempty"`
+	AuditID     string           `json:"audit_id,omitempty"`
 }
 
 var httpClient = &http.Client{

--- a/pkg/adapters/execution_error.go
+++ b/pkg/adapters/execution_error.go
@@ -1,0 +1,49 @@
+package adapters
+
+import "errors"
+
+// ExecutionFailureKind describes what is known about a failed adapter
+// execution. In particular, Ambiguous means a write may have reached the
+// provider and callers must not retry it under a new request ID without first
+// reconciling provider state.
+type ExecutionFailureKind string
+
+const (
+	ExecutionFailureDefinite     ExecutionFailureKind = "definite_failure"
+	ExecutionFailureStaleVersion ExecutionFailureKind = "stale_version"
+	ExecutionFailureAmbiguous    ExecutionFailureKind = "ambiguous"
+)
+
+// ExecutionFailure carries the safety-relevant disposition of an adapter
+// error through gateway wrapping. TimedOut is meaningful only for ambiguous
+// failures and lets clients distinguish a deadline/timeout from another
+// indeterminate transport failure.
+type ExecutionFailure struct {
+	Kind     ExecutionFailureKind
+	TimedOut bool
+	Err      error
+}
+
+func (e *ExecutionFailure) Error() string {
+	if e == nil || e.Err == nil {
+		return "adapter execution failed"
+	}
+	return e.Err.Error()
+}
+
+func (e *ExecutionFailure) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+// AsExecutionFailure returns the first classified adapter failure in err's
+// unwrap chain.
+func AsExecutionFailure(err error) (*ExecutionFailure, bool) {
+	var failure *ExecutionFailure
+	if !errors.As(err, &failure) || failure == nil {
+		return nil, false
+	}
+	return failure, true
+}

--- a/pkg/adapters/execution_error_test.go
+++ b/pkg/adapters/execution_error_test.go
@@ -1,0 +1,29 @@
+package adapters
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestAsExecutionFailureRejectsTypedNil(t *testing.T) {
+	var typedNil *ExecutionFailure
+	var err error = typedNil
+
+	failure, ok := AsExecutionFailure(fmt.Errorf("wrapped: %w", err))
+	if ok || failure != nil {
+		t.Fatalf("typed nil must remain unclassified, got (%#v, %v)", failure, ok)
+	}
+}
+
+func TestAsExecutionFailureReturnsConcreteFailure(t *testing.T) {
+	want := &ExecutionFailure{
+		Kind: ExecutionFailureDefinite,
+		Err:  errors.New("rejected"),
+	}
+
+	failure, ok := AsExecutionFailure(fmt.Errorf("wrapped: %w", want))
+	if !ok || failure != want {
+		t.Fatalf("got (%#v, %v), want (%#v, true)", failure, ok, want)
+	}
+}

--- a/pkg/clawvisor/defaults.go
+++ b/pkg/clawvisor/defaults.go
@@ -24,6 +24,7 @@ import (
 	"github.com/clawvisor/clawvisor/internal/adapters/definitions"
 	mcpdefs "github.com/clawvisor/clawvisor/internal/adapters/definitions/mcp"
 	dropboxadapter "github.com/clawvisor/clawvisor/internal/adapters/dropbox"
+	calendaradapter "github.com/clawvisor/clawvisor/internal/adapters/google/calendar"
 	contactsadapter "github.com/clawvisor/clawvisor/internal/adapters/google/contacts"
 	driveadapter "github.com/clawvisor/clawvisor/internal/adapters/google/drive"
 	gmailadapter "github.com/clawvisor/clawvisor/internal/adapters/google/gmail"
@@ -176,10 +177,9 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 	// Create a vault-backed OAuth provider for Microsoft services.
 	msOAuthProvider := adapters.NewMicrosoftVaultOAuthProvider(v)
 
-	// Build Go action overrides for Google services that need complex logic
-	// (MIME encoding, multipart uploads, dual API calls) beyond what YAML
-	// expressions can handle. Calendar, Contacts, and Drive search_files
-	// are fully YAML-driven with expr-lang transforms.
+	// Build Go action overrides for services that need logic beyond what YAML
+	// expressions can handle (MIME encoding, conditional writes, multipart
+	// uploads, and multi-request operations).
 	goOverrides := map[string]yamlruntime.ActionFunc{}
 
 	gmail := gmailadapter.New(oauthProvider)
@@ -189,6 +189,10 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 	drive := driveadapter.New(oauthProvider)
 	for _, action := range []string{"get_file", "download_file", "export_file", "create_file", "update_file"} {
 		goOverrides["google.drive:"+action] = drive.Execute
+	}
+	calendar := calendaradapter.New(oauthProvider)
+	for _, action := range []string{"get_event", "update_event", "respond_to_event"} {
+		goOverrides["google.calendar:"+action] = calendar.Execute
 	}
 	contacts := contactsadapter.New(oauthProvider)
 	goOverrides["google.contacts:list_contacts"] = contacts.Execute

--- a/pkg/gateway/errorcodes.go
+++ b/pkg/gateway/errorcodes.go
@@ -24,14 +24,14 @@ const (
 	CodeUnknownAction  = "UNKNOWN_ACTION"
 
 	// State — the target task/approval is not in a state that permits this action.
-	CodeInvalidState      = "INVALID_STATE"
-	CodeNotFound          = "NOT_FOUND"
-	CodeAlreadyExecuting  = "ALREADY_EXECUTING"
-	CodeNotApproved       = "NOT_APPROVED"
-	CodeApprovalExpired   = "APPROVAL_EXPIRED"
+	CodeInvalidState     = "INVALID_STATE"
+	CodeNotFound         = "NOT_FOUND"
+	CodeAlreadyExecuting = "ALREADY_EXECUTING"
+	CodeNotApproved      = "NOT_APPROVED"
+	CodeApprovalExpired  = "APPROVAL_EXPIRED"
 
 	// Policy — the request is syntactically fine but blocked by authorization.
-	CodeScopeMismatch  = "SCOPE_MISMATCH"  // outside the approved task scope
+	CodeScopeMismatch  = "SCOPE_MISMATCH"   // outside the approved task scope
 	CodeReasonTooVague = "REASON_TOO_VAGUE" // intent verifier found reason incoherent/insufficient
 	CodeParamViolation = "PARAM_VIOLATION"  // params inconsistent with task scope / chain context
 	CodeRestricted     = "RESTRICTED"       // user restriction or org policy blocked the action
@@ -40,9 +40,13 @@ const (
 	// Execution — downstream failure during or after dispatch.
 	CodeAdapterError            = "ADAPTER_ERROR"
 	CodeLocalServiceUnavailable = "LOCAL_SERVICE_UNAVAILABLE"
+	CodeProviderDefiniteFailure = "PROVIDER_DEFINITE_FAILURE"
+	CodeStaleVersion            = "STALE_VERSION"
+	CodeAmbiguousOutcome        = "AMBIGUOUS_OUTCOME"
+	CodeProviderTimeout         = "PROVIDER_TIMEOUT"
 
 	// Operational.
-	CodeRateLimited  = "RATE_LIMITED"
+	CodeRateLimited   = "RATE_LIMITED"
 	CodeInternalError = "INTERNAL_ERROR"
 
 	// Batch — aggregate endpoint specific.

--- a/web/src/pages/Audit.tsx
+++ b/web/src/pages/Audit.tsx
@@ -45,7 +45,20 @@ function downloadCsv(csv: string, filename: string) {
   URL.revokeObjectURL(url)
 }
 
-const OUTCOMES = ['', 'executed', 'blocked', 'restricted', 'pending', 'denied', 'error', 'timeout']
+const OUTCOMES = [
+  '',
+  'executed',
+  'blocked',
+  'restricted',
+  'pending',
+  'denied',
+  'error',
+  'timeout',
+  'provider_definite_failure',
+  'provider_stale_version',
+  'provider_ambiguous',
+  'provider_timeout',
+]
 const ACTIVITY_TYPES = [
   { value: '', label: 'All activity types' },
   { value: 'runtime_egress', label: 'Runtime egress' },
@@ -62,6 +75,10 @@ const OUTCOME_STYLE: Record<string, string> = {
   denied: 'bg-surface-2 text-text-tertiary',
   error: 'bg-danger/15 text-danger',
   timeout: 'bg-surface-2 text-text-tertiary',
+  provider_definite_failure: 'bg-danger/15 text-danger',
+  provider_stale_version: 'bg-warning/15 text-warning',
+  provider_ambiguous: 'bg-danger/15 text-danger',
+  provider_timeout: 'bg-surface-2 text-text-tertiary',
 }
 
 type ActivityTypeFilter = '' | 'runtime_egress' | 'runtime_tool_use' | 'runtime' | 'service'

--- a/web/src/pages/Overview.tsx
+++ b/web/src/pages/Overview.tsx
@@ -372,7 +372,6 @@ function ActivityChart({ data }: { data: ActivityBucket[] }) {
       'inline_task_auto_approved',
     ])
     const errorOutcomes = new Set([
-      'denied',
       'error',
       'http_error',
       'timeout',

--- a/web/src/pages/Overview.tsx
+++ b/web/src/pages/Overview.tsx
@@ -313,6 +313,7 @@ interface ChartRow {
   time: string
   executed: number
   blocked: number
+  errors: number
   pending: number
 }
 
@@ -326,6 +327,7 @@ function useChartColors() {
     return {
       executed: r('--color-success'),
       blocked: r('--color-danger'),
+      errors: r('--color-danger'),
       pending: r('--color-warning'),
       axisTick: style.getPropertyValue('--color-axis-tick').trim(),
       tooltipBg: style.getPropertyValue('--color-tooltip-bg').trim(),
@@ -369,14 +371,25 @@ function ActivityChart({ data }: { data: ActivityBucket[] }) {
       'inline_task_approved',
       'inline_task_auto_approved',
     ])
+    const errorOutcomes = new Set([
+      'denied',
+      'error',
+      'http_error',
+      'timeout',
+      'provider_definite_failure',
+      'provider_stale_version',
+      'provider_ambiguous',
+      'provider_timeout',
+    ])
     for (const b of data) {
       const ms = new Date(b.bucket).getTime()
       if (!counts.has(ms)) {
-        counts.set(ms, { time: '', executed: 0, blocked: 0, pending: 0 })
+        counts.set(ms, { time: '', executed: 0, blocked: 0, errors: 0, pending: 0 })
       }
       const row = counts.get(ms)!
       if (successOutcomes.has(b.outcome)) row.executed += b.count
       else if (b.outcome === 'blocked' || b.outcome === 'restricted') row.blocked += b.count
+      else if (errorOutcomes.has(b.outcome)) row.errors += b.count
       else row.pending += b.count
     }
 
@@ -389,7 +402,7 @@ function ActivityChart({ data }: { data: ActivityBucket[] }) {
       const t = new Date(ms)
       const label = `${String(t.getHours()).padStart(2, '0')}:${String(t.getMinutes()).padStart(2, '0')}`
       const existing = counts.get(ms)
-      result.push(existing ? { ...existing, time: label } : { time: label, executed: 0, blocked: 0, pending: 0 })
+      result.push(existing ? { ...existing, time: label } : { time: label, executed: 0, blocked: 0, errors: 0, pending: 0 })
     }
     return result
   }, [data])
@@ -405,6 +418,7 @@ function ActivityChart({ data }: { data: ActivityBucket[] }) {
           />
           <Bar dataKey="executed" stackId="1" stroke={colors.executed} fill={colors.executed} fillOpacity={0.85} name="Executed" />
           <Bar dataKey="blocked" stackId="1" stroke={colors.blocked} fill={colors.blocked} fillOpacity={0.85} name="Blocked" />
+          <Bar dataKey="errors" stackId="1" stroke={colors.errors} fill={colors.errors} fillOpacity={0.55} name="Errors" />
           <Bar dataKey="pending" stackId="1" stroke={colors.pending} fill={colors.pending} fillOpacity={0.85} name="Pending" />
         </BarChart>
       </ResponsiveContainer>


### PR DESCRIPTION
## Summary
- expose Google Calendar event ETag/version and the authenticated user's RSVP state
- require an expected version and conditional `If-Match` for event updates and RSVP changes
- classify definite, stale-version, ambiguous, and timeout outcomes through generic adapter/gateway errors
- surface those provider outcomes accurately in audit and activity views

## Scope
Calendar adapter and the minimal generic failure plumbing it requires. This deliberately excludes Gmail changes, OAuth account/client mapping, deployment configuration, and organization-specific identifiers.

## Verification
- `env -u ANTHROPIC_API_KEY go test ./...`
- `go vet ./...`
- focused Calendar, gateway, callback, and adapter tests
- `npm run lint && npm run build` in `web/`
- `make build`

No live provider account was accessed while verifying this replacement branch.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

