### PR TITLE
feat(notify): add Slack approval flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Clawvisor loads `config.yaml` from the working directory (override with `CONFIG_
 | Auth mode | `AUTH_MODE` | `magic_link` (default locally) or `password` |
 | Allowed emails | `ALLOWED_EMAILS` | Comma-separated emails allowed to register |
 | Google OAuth | `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` | Needed for Google services |
-| Public URL | `PUBLIC_URL` | Used in Telegram notification links |
+| Public URL | `PUBLIC_URL` | Used in notification deep links |
 | LLM config | `CLAWVISOR_LLM_*` | Shared provider, model, API key for all LLM features |
 | Intent verification | `CLAWVISOR_LLM_VERIFICATION_*` | Optional LLM check that request params match task purpose |
 | Task risk assessment | `CLAWVISOR_LLM_TASK_RISK_*` | Optional LLM risk assessment when tasks are created |
@@ -253,7 +253,7 @@ Every gateway request passes through three authorization layers, checked in orde
 
 1. **Restrictions** — hard blocks you configure on specific service/action pairs. If a restriction matches, the request is denied immediately. Use these for actions you never want any agent to take (e.g. "no agent can delete calendar events").
 2. **Task scopes** — the primary mechanism. When an agent needs to do something, it creates a task declaring the purpose and which service/action pairs it needs. You review and approve the scope once. After that, requests under that task execute without further interruption — you approved the purpose, not each individual call. Tasks can be session-scoped (expire after a TTL) or standing (persist until you revoke them).
-3. **Per-request approval** — the fallback. Any request that isn't covered by a task scope goes to the approval queue, and you're notified via the dashboard, Telegram, or push notification to your phone. This is the default for actions the agent didn't declare upfront, or for task actions marked `auto_execute: false` (e.g. sending emails).
+3. **Per-request approval** — the fallback. Any request that isn't covered by a task scope goes to the approval queue, and you're notified via the dashboard, Slack, Telegram, or push notification to your phone. This is the default for actions the agent didn't declare upfront, or for task actions marked `auto_execute: false` (e.g. sending emails).
 
 When a task is created, Clawvisor can optionally run an **LLM-powered risk assessment** that evaluates the scope breadth, purpose-scope coherence, and internal consistency of the task. The assessment produces a risk level (low, medium, high, critical) shown in the dashboard to help inform your approval decision. High and critical risk tasks require a confirmation step before approval.
 
@@ -311,7 +311,7 @@ curl -s -X POST "$CLAWVISOR_URL/api/tasks" \
   }'
 ```
 
-The task starts as `pending_approval`. The user approves it via the dashboard, Telegram, or a push notification on their phone. Include a `callback_url` to receive a callback when the task is approved or denied — otherwise poll `GET /api/tasks/{id}` (supports long-polling).
+The task starts as `pending_approval`. The user approves it via the dashboard, Slack, Telegram, or a push notification on their phone. Include a `callback_url` to receive a callback when the task is approved or denied — otherwise poll `GET /api/tasks/{id}` (supports long-polling).
 
 Key fields:
 
@@ -445,7 +445,7 @@ The web UI provides:
 - **Restrictions** — toggle hard blocks on service/action pairs
 - **Agents** — create agent tokens, manage connection requests
 - **Gateway log** — searchable audit trail of every gateway request with outcomes and verification results
-- **Settings** — device pairing (QR code for mobile), Telegram notification setup, password management, account settings
+- **Settings** — Slack/Telegram notification setup, device pairing, password management, account settings
 - **Onboarding** — guided first-run flow for connecting services, creating agents, and setting up notifications
 - **Light/dark mode** — toggle in the sidebar; persists across sessions
 
@@ -553,7 +553,7 @@ subscription seat on the instance at once.
 | Vault | AES-256-GCM with master key (env var or keyfile) or GCP Secret Manager, behind `Vault` interface |
 | Auth | JWT (HS256), magic links (local), bcrypt passwords (prod) |
 | Real-time | SSE event stream for instant dashboard updates |
-| Notifications | Telegram (per-user bot tokens), push notifications (APNs via external push service) |
+| Notifications | Slack, Telegram (per-user bot tokens), push notifications (APNs via external push service) |
 | Relay | WebSocket reverse tunnel for NAT traversal (connects to external relay service) |
 | MCP | Model Context Protocol server with OAuth 2.1 for Claude Desktop integration |
 | Telemetry | Opt-in anonymous product usage telemetry |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -90,7 +90,7 @@ If no task covers the request — or no `task_id` was provided — the request e
 1. **Adapter existence**: Is the service recognized? If not, the agent gets an error.
 2. **Service activation**: Does the user have a credential in the vault for this service? If not, the agent gets `status: "pending_activation"` with an `activate_url` they can show the user.
 
-If both pass, the request is serialized into a `pending_approvals` record with a 5-minute TTL (configurable). The human is notified via Telegram. The agent receives `status: "pending"`.
+If both pass, the request is serialized into a `pending_approvals` record with a 5-minute TTL (configurable). The human is notified via the configured approval channels. The agent receives `status: "pending"`.
 
 ### 2.6 Execution Path
 
@@ -112,13 +112,13 @@ When a request is authorized (either via task auto-execute or human approval), e
 
 When a request is pending approval, it can be resolved three ways:
 
-1. **Human approves** (via dashboard or Telegram): The pending approval is marked as `"approved"`. The agent is expected to call `POST /api/gateway/request/{request_id}/execute` to claim the result — the original params are loaded from the stored request blob (immutable). If the agent registered a callback URL, it receives a notification with `status: "approved"` so it knows to call the execute endpoint.
+1. **Human approves** (via dashboard or a configured notification channel): The pending approval is marked as `"approved"`. The agent is expected to call `POST /api/gateway/request/{request_id}/execute` to claim the result — the original params are loaded from the stored request blob (immutable). If the agent registered a callback URL, it receives a notification with `status: "approved"` so it knows to call the execute endpoint.
 2. **Human denies**: The pending approval is deleted and the audit entry updated. If a callback URL is registered, the agent receives `status: "denied"`.
 3. **Timeout** (default 5 minutes): A background goroutine runs every 60 seconds, finds expired pending approvals, marks them as timed out, and delivers `status: "timeout"` callbacks.
 
 The agent can long-poll `GET /api/gateway/request/{request_id}?wait=true` to check status, or use `POST /api/gateway/request?wait=true` to block until the result is ready in a single round-trip. Agents that prefer explicit control can call `POST /api/gateway/request/{request_id}/execute` after approval.
 
-The Telegram message is updated in-place to reflect the outcome (green checkmark for approved, red X for denied, clock for timeout).
+Out-of-band approval messages are updated in-place when the channel supports updates.
 
 ---
 
@@ -158,7 +158,7 @@ The agent calls `POST /api/tasks` with:
 }
 ```
 
-Every task starts as `pending_approval`. The human is notified via Telegram with the purpose and action list. The `auto_execute` flag per action controls whether matching requests run immediately or still require per-request approval. In the example above, reading emails is automatic but sending requires a human check each time.
+Every task starts as `pending_approval`. The human is notified through the configured approval channels with the purpose and action list. The `auto_execute` flag per action controls whether matching requests run immediately or still require per-request approval. In the example above, reading emails is automatic but sending requires a human check each time.
 
 ### 3.2.1 Task Risk Assessment
 
@@ -303,9 +303,15 @@ Verification results are cached in memory (keyed by a hash of task ID, service, 
 
 ## 8. Notification System
 
-### 8.1 Telegram Integration
+### 8.1 Approval Notification Channels
 
-Clawvisor uses Telegram for mobile approval notifications. Each user pairs their own Telegram bot — there is no shared bot. Bot tokens and chat IDs are stored per-user in the `notification_configs` table.
+Clawvisor can send approval notifications through Telegram, Slack, and mobile push. Notification settings are stored per-user in the `notification_configs` table; channel secrets are kept in the vault when a vault backend is configured.
+
+**Slack approval modes**: Direct Slack mode posts approval prompts to a configured channel using a Slack bot token. If the user also configures a Slack app signing secret and points Slack interactivity at `POST /api/notifications/slack/interactions`, Clawvisor renders native Approve/Deny buttons and validates Slack signatures before routing decisions. Without a signing secret, Slack messages use dashboard deep-link buttons. The `openclaw_agent` Slack mode posts the same approval prompt in a Slack Agent by OpenClaw channel with deep-link buttons, so the Slack Agent can be the user-facing conversation surface while Clawvisor remains the approval authority.
+
+### 8.2 Telegram Integration
+
+Each user pairs their own Telegram bot — there is no shared bot. Bot tokens and chat IDs are stored per-user in the `notification_configs` table.
 
 **Pairing flow**: The user creates a Telegram bot via @BotFather, enters the bot token in the dashboard, and Clawvisor starts a pairing session. The user sends `/start` to their bot, which confirms the chat ID. The pairing is verified and stored.
 
@@ -321,7 +327,7 @@ Clawvisor uses Telegram for mobile approval notifications. Each user pairs their
 
 **Message updates**: After a request is resolved (approved, denied, or timed out), the original Telegram message is edited to replace the buttons with a status line (checkmark, X, or clock icon).
 
-### 8.2 Callback Delivery
+### 8.3 Callback Delivery
 
 When a pending request resolves, the result is POSTed to the agent's `callback_url`:
 
@@ -399,7 +405,7 @@ Migrations are embedded in the binary and run automatically on startup. Each mig
 - `audit_log` — every gateway request. Includes service, action, sanitized params, decision, outcome, verification verdict, duration, and error messages. Legacy columns (`safety_flagged`, `safety_reason`, `filters_applied`) are retained for backward compatibility but no longer populated. `request_id` has a UNIQUE constraint. Indexed on `(user_id, timestamp)`, `(user_id, outcome)`, `(user_id, service)`.
 
 **Notifications:**
-- `notification_configs` — per-user channel configs (e.g., Telegram bot token + chat ID). Unique on `(user_id, channel)`.
+- `notification_configs` — per-user channel configs (e.g., Telegram bot token + chat ID, Slack channel ID). Unique on `(user_id, channel)`.
 - `notification_messages` — maps `(target_type, target_id, channel)` to a message ID for in-place updates.
 
 ### 10.2 Migration History
@@ -432,7 +438,7 @@ The frontend is a React 18 SPA built with Vite, TypeScript, Tailwind CSS, and sh
 - **Restrictions**: Create and manage hard blocks on service/action pairs
 - **Agents**: Create agent tokens (shown once), delete agents
 - **Audit Log**: Searchable, filterable history of every gateway request
-- **Settings**: Telegram bot pairing, account management
+- **Settings**: notification setup, account management
 
 ### 11.2 Auth Flow
 
@@ -460,7 +466,7 @@ Configuration is loaded in three layers, each overriding the previous:
 |---|---|---|---|
 | Server port | 25297 | `PORT` | |
 | Server host | 127.0.0.1 | `SERVER_HOST` | Set to `0.0.0.0` for Cloud Run |
-| Public URL | (empty) | `PUBLIC_URL` | Used in Telegram notification links |
+| Public URL | (empty) | `PUBLIC_URL` | Used in notification deep links |
 | Database driver | postgres | `DATABASE_DRIVER` | `postgres` or `sqlite` |
 | Postgres URL | (empty) | `DATABASE_URL` | Required for postgres |
 | SQLite path | ./clawvisor.db | | |
@@ -497,13 +503,13 @@ When the server starts (`cmd/server/main.go`):
 5. Initialize vault (load or generate `vault.key`, connect to DB or GCP)
 6. Initialize JWT service
 7. Register adapters (Google if OAuth configured, GitHub/Slack/Notion/Linear/Stripe/Twilio if enabled, iMessage if macOS)
-8. Create Telegram notifier (always; reads per-user config lazily)
+8. Create notification notifiers (always; read per-user config lazily)
 9. If local mode: create `admin@local` user, generate magic link, print to terminal
 10. Create HTTP server, register routes, wire middleware
 11. Start background goroutines:
     - Approval expiry cleanup (every 60 seconds)
-    - Telegram decision consumer (routes inline button taps to handlers)
-    - Telegram token cleanup (removes expired callback tokens)
+    - Notification decision consumer (routes inline button taps to handlers)
+    - Notification token cleanup (removes expired callback tokens)
     - Magic link cleanup (every 5 minutes, if local mode)
 13. Listen on configured address; graceful shutdown on SIGINT/SIGTERM (30-second drain)
 
@@ -526,7 +532,7 @@ This starts with SQLite (no Docker needed), auto-generates `vault.key`, creates 
 ### 14.3 Google Cloud Run
 
 `deploy/cloudrun.yaml` defines the Cloud Run service:
-- `minScale: 1` — required so approval callbacks and Telegram polling have a live process
+- `minScale: 1` — required so approval callbacks and notification polling have a live process
 - `timeoutSeconds: 360` — buffer above the approval timeout (300s) and MCP timeout (240s)
 - Secrets (`JWT_SECRET`, `DATABASE_URL`) loaded from GCP Secret Manager
 - Cloud SQL connection via sidecar proxy

--- a/docs/INTEGRATE_CLAUDE_CODE.md
+++ b/docs/INTEGRATE_CLAUDE_CODE.md
@@ -166,5 +166,5 @@ Explain how it works:
 Remind the user to:
 - Connect services in the Clawvisor dashboard under the **Services** tab
   before asking Claude to use them
-- Approve tasks in the dashboard (or via Telegram) when Claude requests them
+- Approve tasks in the dashboard or a configured notification channel when Claude requests them
 - Optionally set restrictions in the dashboard to hard-block specific actions

--- a/docs/INTEGRATE_CLAUDE_COWORK.md
+++ b/docs/INTEGRATE_CLAUDE_COWORK.md
@@ -133,7 +133,7 @@ Explain how it works:
 - Claude has access to six MCP tools: `fetch_catalog`, `create_task`,
   `get_task`, `complete_task`, `expand_task`, and `gateway_request`
 - Claude creates tasks declaring what it needs, the user approves them in the
-  dashboard (or via Telegram), and Claude executes actions under the approved
+  dashboard or configured notification channel, and Claude executes actions under the approved
   scope
 - In-scope actions with `auto_execute` run immediately; others queue for
   per-request approval
@@ -142,5 +142,5 @@ Explain how it works:
 Remind the user to:
 - Connect services in the Clawvisor dashboard under the **Services** tab
   before asking Claude to use them
-- Approve tasks in the dashboard (or via Telegram) when Claude requests them
+- Approve tasks in the dashboard or a configured notification channel when Claude requests them
 - Optionally set restrictions in the dashboard to hard-block specific actions

--- a/docs/INTEGRATE_HERMES.md
+++ b/docs/INTEGRATE_HERMES.md
@@ -177,7 +177,7 @@ Explain how it works:
 - Hermes has access to Clawvisor MCP tools: `fetch_catalog`, `create_task`,
   `get_task`, `complete_task`, `expand_task`, and `gateway_request`
 - Hermes creates tasks declaring what it needs, the user approves them in the
-  dashboard (or via Telegram), and Hermes executes actions under the approved
+  dashboard or configured notification channel, and Hermes executes actions under the approved
   scope
 - In-scope actions with `auto_execute` run immediately; others queue for
   per-request approval
@@ -187,5 +187,5 @@ Remind the user to:
 
 - Connect services in the Clawvisor dashboard under the **Services** tab before
   asking Hermes to use them
-- Approve tasks in the dashboard (or via Telegram) when Hermes requests them
+- Approve tasks in the dashboard or a configured notification channel when Hermes requests them
 - Optionally set restrictions in the dashboard to hard-block specific actions

--- a/docs/SETUP_CLOUD.md
+++ b/docs/SETUP_CLOUD.md
@@ -219,7 +219,7 @@ The user has a domain name and can set up TLS. Ask how:
   automatically
 - **Load balancer** — cloud provider ALB/NLB with TLS termination
 
-Ensure `PUBLIC_URL` is set to the HTTPS URL so Telegram notification links
+Ensure `PUBLIC_URL` is set to the HTTPS URL so notification links
 and OAuth redirects work correctly.
 
 ### Option B: SSH tunnel (no domain required)
@@ -340,7 +340,7 @@ Remind the user to:
     all four
   - GitHub, Slack, Notion, Linear, Stripe, Twilio — activate with API
     keys/tokens
-- Set up Telegram notifications for mobile approvals (optional)
+- Set up Slack, Slack Agent by OpenClaw, Telegram, or mobile push notifications for out-of-band approvals (optional)
 
 **Next:** Connect your agent — see [SETUP.md](SETUP.md#2-connect-your-agent)
 for integration guides.

--- a/docs/SETUP_LOCAL.md
+++ b/docs/SETUP_LOCAL.md
@@ -97,7 +97,7 @@ This covers:
 | GPT-4o Mini | `openai` | `https://api.openai.com/v1` | `gpt-4o-mini` |
 
 - **Relay** — enabled by default; connects to clawvisor.com for remote
-  approvals and Telegram notifications. Can be disabled in
+  approvals and out-of-band notifications. Can be disabled in
   `~/.clawvisor/config.yaml` after setup.
 - **Telemetry** — opt-in anonymous usage stats
 - **iMessage** — auto-enabled on macOS, disabled elsewhere (no prompt needed)
@@ -237,7 +237,7 @@ Clawvisor loads `config.yaml` from the working directory (override with
 | `JWT_SECRET` | auto-generated locally | HMAC signing key for JWTs |
 | `PORT` | `25297` | Server listen port |
 | `SERVER_HOST` | `127.0.0.1` | Server bind address |
-| `PUBLIC_URL` | — | Base URL for magic links, OAuth callbacks, and Telegram notifications |
+| `PUBLIC_URL` | — | Base URL for magic links, OAuth callbacks, and notification deep links |
 | `SQLITE_PATH` | `./clawvisor.db` | Path to the SQLite database file |
 | `VAULT_BACKEND` | `local` | `local` (AES-256-GCM) or `gcp` (Secret Manager) |
 | `VAULT_KEY` | — | Base64-encoded 32-byte vault master key (alternative to key file) |

--- a/internal/api/handlers/notifications.go
+++ b/internal/api/handlers/notifications.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/clawvisor/clawvisor/internal/api/middleware"
 	"github.com/clawvisor/clawvisor/pkg/notify"
@@ -47,6 +48,34 @@ func (f *fallbackTelegramConfigStore) DeleteTelegramConfig(ctx context.Context, 
 	return f.st.DeleteNotificationConfig(ctx, userID, "telegram")
 }
 
+type fallbackSlackConfigStore struct {
+	st store.Store
+}
+
+func (f *fallbackSlackConfigStore) SaveSlackConfig(ctx context.Context, userID string, cfg notify.SlackConfig) error {
+	raw, err := json.Marshal(cfg)
+	if err != nil {
+		return err
+	}
+	return f.st.UpsertNotificationConfig(ctx, userID, "slack", raw)
+}
+
+func (f *fallbackSlackConfigStore) SlackConfig(ctx context.Context, userID string) (notify.SlackConfig, error) {
+	nc, err := f.st.GetNotificationConfig(ctx, userID, "slack")
+	if err != nil {
+		return notify.SlackConfig{}, err
+	}
+	var cfg notify.SlackConfig
+	if err := json.Unmarshal(nc.Config, &cfg); err != nil {
+		return notify.SlackConfig{}, err
+	}
+	return cfg, nil
+}
+
+func (f *fallbackSlackConfigStore) DeleteSlackConfig(ctx context.Context, userID string) error {
+	return f.st.DeleteNotificationConfig(ctx, userID, "slack")
+}
+
 // telegramConfigStore returns the active TelegramConfigStore: the notifier's
 // vault-backed implementation when available, or a plaintext fallback for
 // test setups that pass notifier=nil.
@@ -57,8 +86,15 @@ func (h *NotificationsHandler) telegramConfigStore() notify.TelegramConfigStore 
 	return &fallbackTelegramConfigStore{st: h.st}
 }
 
-// sanitizeNotificationConfig redacts secret fields (bot_token) from a
-// notification config before returning it to the browser.
+func (h *NotificationsHandler) slackConfigStore() notify.SlackConfigStore {
+	if cs, ok := h.notifier.(notify.SlackConfigStore); ok {
+		return cs
+	}
+	return &fallbackSlackConfigStore{st: h.st}
+}
+
+// sanitizeNotificationConfig redacts secret fields from a notification config
+// before returning it to the browser.
 func sanitizeNotificationConfig(raw json.RawMessage) json.RawMessage {
 	var m map[string]any
 	if err := json.Unmarshal(raw, &m); err != nil {
@@ -68,6 +104,11 @@ func sanitizeNotificationConfig(raw json.RawMessage) json.RawMessage {
 		m["bot_token"] = "***" + tok[len(tok)-4:]
 	} else if ok {
 		m["bot_token"] = "***"
+	}
+	if secret, ok := m["signing_secret"].(string); ok && len(secret) > 4 {
+		m["signing_secret"] = "***" + secret[len(secret)-4:]
+	} else if ok {
+		m["signing_secret"] = "***"
 	}
 	out, err := json.Marshal(m)
 	if err != nil {
@@ -103,9 +144,9 @@ func (h *NotificationsHandler) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Fetch the two currently-supported channels; omit missing ones gracefully.
+	// Fetch currently-supported channels; omit missing ones gracefully.
 	var configs []map[string]any
-	for _, channel := range []string{"telegram"} {
+	for _, channel := range []string{"telegram", "slack"} {
 		cfg, err := h.st.GetNotificationConfig(r.Context(), user.ID, channel)
 		if err != nil {
 			continue // not configured — skip
@@ -121,6 +162,125 @@ func (h *NotificationsHandler) List(w http.ResponseWriter, r *http.Request) {
 		configs = []map[string]any{}
 	}
 	writeJSON(w, http.StatusOK, configs)
+}
+
+// UpsertSlack saves (or replaces) the Slack notification config.
+//
+// PUT /api/notifications/slack
+// Auth: user JWT
+// Body: {"bot_token": "...", "channel_id": "...", "signing_secret": "...", "mode": "direct"}
+func (h *NotificationsHandler) UpsertSlack(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "not authenticated")
+		return
+	}
+
+	var body notify.SlackConfig
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+	body.BotToken = strings.TrimSpace(body.BotToken)
+	body.ChannelID = strings.TrimSpace(body.ChannelID)
+	body.SigningSecret = strings.TrimSpace(body.SigningSecret)
+	body.Mode = strings.ToLower(strings.TrimSpace(body.Mode))
+	if body.BotToken == "" || body.ChannelID == "" {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "bot_token and channel_id are required")
+		return
+	}
+	if body.Mode == "" {
+		body.Mode = "direct"
+	}
+	if body.Mode != "direct" && body.Mode != "openclaw_agent" {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "mode must be direct or openclaw_agent")
+		return
+	}
+
+	if err := h.slackConfigStore().SaveSlackConfig(r.Context(), user.ID, body); err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not save Slack notification config")
+		return
+	}
+
+	cfg, err := h.st.GetNotificationConfig(r.Context(), user.ID, "slack")
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not retrieve saved config")
+		return
+	}
+	cfg.Config = sanitizeNotificationConfig(cfg.Config)
+	writeJSON(w, http.StatusOK, cfg)
+}
+
+// DeleteSlack removes the Slack notification config.
+//
+// DELETE /api/notifications/slack
+// Auth: user JWT
+func (h *NotificationsHandler) DeleteSlack(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "not authenticated")
+		return
+	}
+
+	if err := h.slackConfigStore().DeleteSlackConfig(r.Context(), user.ID); err != nil {
+		if err == store.ErrNotFound {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "could not delete Slack notification config")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// TestSlack sends a test message using the user's saved config.
+//
+// POST /api/notifications/slack/test
+// Auth: user JWT
+func (h *NotificationsHandler) TestSlack(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "not authenticated")
+		return
+	}
+	if h.notifier == nil {
+		writeError(w, http.StatusServiceUnavailable, "NOTIFIER_UNAVAILABLE", "notification service not available")
+		return
+	}
+	if _, err := h.slackConfigStore().SlackConfig(r.Context(), user.ID); err != nil {
+		writeError(w, http.StatusBadRequest, "NOT_CONFIGURED", "Slack notifications must be configured first")
+		return
+	}
+	type slackTester interface {
+		SendSlackTestMessage(context.Context, string) error
+	}
+	if st, ok := h.notifier.(slackTester); ok {
+		if err := st.SendSlackTestMessage(r.Context(), user.ID); err != nil {
+			writeError(w, http.StatusBadRequest, "TEST_FAILED", err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]string{"status": "sent"})
+		return
+	}
+	if err := h.notifier.SendTestMessage(r.Context(), user.ID); err != nil {
+		writeError(w, http.StatusBadRequest, "TEST_FAILED", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "sent"})
+}
+
+// SlackInteractions handles Slack Block Kit button callbacks.
+//
+// POST /api/notifications/slack/interactions
+// Auth: Slack signing secret
+func (h *NotificationsHandler) SlackInteractions(w http.ResponseWriter, r *http.Request) {
+	type slackInteractionHandler interface {
+		HandleInteraction(http.ResponseWriter, *http.Request)
+	}
+	if ih, ok := h.notifier.(slackInteractionHandler); ok {
+		ih.HandleInteraction(w, r)
+		return
+	}
+	writeError(w, http.StatusServiceUnavailable, "SLACK_UNAVAILABLE", "Slack notification service not available")
 }
 
 // UpsertTelegram saves (or replaces) the Telegram notification config.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -957,6 +957,10 @@ func (s *Server) routes() http.Handler {
 
 	// Notifications (user JWT)
 	mux.Handle("GET /api/notifications", user(notificationsHandler.List))
+	mux.Handle("PUT /api/notifications/slack", user(notificationsHandler.UpsertSlack))
+	mux.Handle("DELETE /api/notifications/slack", user(notificationsHandler.DeleteSlack))
+	mux.Handle("POST /api/notifications/slack/test", user(notificationsHandler.TestSlack))
+	mux.Handle("POST /api/notifications/slack/interactions", http.HandlerFunc(notificationsHandler.SlackInteractions))
 	mux.Handle("PUT /api/notifications/telegram", user(notificationsHandler.UpsertTelegram))
 	mux.Handle("DELETE /api/notifications/telegram", user(notificationsHandler.DeleteTelegram))
 	mux.Handle("POST /api/notifications/telegram/test", user(notificationsHandler.TestTelegram))

--- a/internal/api/user_settings_test.go
+++ b/internal/api/user_settings_test.go
@@ -50,6 +50,44 @@ func TestNotifications_UpsertAndList_Telegram(t *testing.T) {
 	}
 }
 
+func TestNotifications_UpsertAndList_Slack(t *testing.T) {
+	env := newTestEnv(t)
+	s := newSession(t, env)
+
+	resp := s.do("PUT", "/api/notifications/slack", map[string]any{
+		"bot_token":      "xoxb-secret-token",
+		"channel_id":     "C1234567890",
+		"signing_secret": "slack-signing-secret",
+		"mode":           "openclaw_agent",
+	})
+	body := mustStatus(t, resp, http.StatusOK)
+	if body["channel"] != "slack" {
+		t.Errorf("upsert slack: expected channel=slack, got %v", body["channel"])
+	}
+
+	cfg, _ := body["config"].(map[string]any)
+	if cfg["channel_id"] != "C1234567890" {
+		t.Errorf("channel_id = %v", cfg["channel_id"])
+	}
+	if tok, _ := cfg["bot_token"].(string); tok == "xoxb-secret-token" {
+		t.Fatal("bot token was not redacted")
+	}
+	if secret, _ := cfg["signing_secret"].(string); secret == "slack-signing-secret" {
+		t.Fatal("signing secret was not redacted")
+	}
+
+	resp = s.do("GET", "/api/notifications", nil)
+	var configs []any
+	decode(t, resp, &configs)
+	if len(configs) != 1 {
+		t.Fatalf("after upsert: expected 1 config, got %d", len(configs))
+	}
+	listed := configs[0].(map[string]any)
+	if listed["channel"] != "slack" {
+		t.Errorf("list: expected channel=slack, got %v", listed["channel"])
+	}
+}
+
 func TestNotifications_Upsert_MissingFields(t *testing.T) {
 	env := newTestEnv(t)
 	s := newSession(t, env)
@@ -57,6 +95,11 @@ func TestNotifications_Upsert_MissingFields(t *testing.T) {
 	resp := s.do("PUT", "/api/notifications/telegram", map[string]any{
 		"bot_token": "1234:ABCDEF",
 		// missing chat_id
+	})
+	mustStatus(t, resp, http.StatusBadRequest)
+
+	resp = s.do("PUT", "/api/notifications/slack", map[string]any{
+		"bot_token": "xoxb-secret-token",
 	})
 	mustStatus(t, resp, http.StatusBadRequest)
 }
@@ -76,6 +119,31 @@ func TestNotifications_Delete_Telegram(t *testing.T) {
 		t.Errorf("delete telegram: expected 204, got %d", resp.StatusCode)
 	}
 	resp.Body.Close()
+}
+
+func TestNotifications_Delete_Slack(t *testing.T) {
+	env := newTestEnv(t)
+	s := newSession(t, env)
+
+	s.do("PUT", "/api/notifications/slack", map[string]any{
+		"bot_token": "tok", "channel_id": "C123",
+	})
+
+	resp := s.do("DELETE", "/api/notifications/slack", nil)
+	if resp.StatusCode != http.StatusNoContent {
+		t.Errorf("delete slack: expected 204, got %d", resp.StatusCode)
+	}
+	resp.Body.Close()
+}
+
+func TestNotifications_SlackModeValidation(t *testing.T) {
+	env := newTestEnv(t)
+	s := newSession(t, env)
+
+	resp := s.do("PUT", "/api/notifications/slack", map[string]any{
+		"bot_token": "tok", "channel_id": "C123", "mode": "other",
+	})
+	mustStatus(t, resp, http.StatusBadRequest)
 }
 
 func TestNotifications_IsolatedByUser(t *testing.T) {

--- a/internal/notify/push/notifier.go
+++ b/internal/notify/push/notifier.go
@@ -46,6 +46,8 @@ func New(st store.Store, pushURL, daemonID string, privateKey ed25519.PrivateKey
 	}
 }
 
+func (n *Notifier) NotificationChannel() string { return "push" }
+
 // DecisionChannel returns a read-only channel that emits callback decisions
 // from device action taps (approve/deny on push notifications).
 func (n *Notifier) DecisionChannel() <-chan notify.CallbackDecision {

--- a/internal/notify/slack/notifier.go
+++ b/internal/notify/slack/notifier.go
@@ -1,0 +1,615 @@
+// Package slack implements notify.Notifier using the Slack Web API.
+package slack
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/clawvisor/clawvisor/internal/display"
+	"github.com/clawvisor/clawvisor/pkg/notify"
+	"github.com/clawvisor/clawvisor/pkg/store"
+	"github.com/clawvisor/clawvisor/pkg/vault"
+)
+
+const (
+	defaultAPIBase        = "https://slack.com/api"
+	vaultBotTokenKey     = "notify.slack.bot_token"
+	vaultSigningSecretKey = "notify.slack.signing_secret"
+	maxInteractionBytes   = 128 << 10
+	maxSlackResponseBytes = 1 << 20
+)
+
+type Notifier struct {
+	store      store.Store
+	vault      vault.Vault
+	client     *http.Client
+	apiBase    string
+	cbTokens   CallbackTokenStore
+	decisionCh chan notify.CallbackDecision
+	logger     *slog.Logger
+}
+
+func New(st store.Store, logger *slog.Logger) *Notifier {
+	apiBase := strings.TrimRight(os.Getenv("SLACK_API_BASE_URL"), "/")
+	if apiBase == "" {
+		apiBase = defaultAPIBase
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Notifier{
+		store:      st,
+		client:     &http.Client{Timeout: 10 * time.Second},
+		apiBase:    apiBase,
+		cbTokens:   newCallbackTokenStore(),
+		decisionCh: make(chan notify.CallbackDecision, 32),
+		logger:     logger,
+	}
+}
+
+func (n *Notifier) NotificationChannel() string { return "slack" }
+
+func (n *Notifier) SetVault(v vault.Vault) {
+	n.vault = v
+}
+
+func (n *Notifier) SetCallbackTokenStore(store CallbackTokenStore) {
+	if store != nil {
+		n.cbTokens = store
+	}
+}
+
+func (n *Notifier) DecisionChannel() <-chan notify.CallbackDecision {
+	return n.decisionCh
+}
+
+func (n *Notifier) RunCleanup(ctx context.Context) {
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			n.cbTokens.Cleanup()
+		}
+	}
+}
+
+func (n *Notifier) SendApprovalRequest(ctx context.Context, req notify.ApprovalRequest) (string, error) {
+	cfg, err := n.userConfig(ctx, req.UserID)
+	if err != nil {
+		return "", err
+	}
+	text := formatApprovalMessage(req)
+	blocks := approvalBlocks("Clawvisor Approval Request", text, cfg, req.UserID, "approval", req.RequestID, req.TaskID, req.ApproveURL, req.DenyURL)
+	blocks = n.withInteractiveTokens(blocks, cfg, "approval", req.RequestID, req.UserID, req.TaskID, req.ApproveURL, req.DenyURL)
+	return n.postMessage(ctx, cfg.BotToken, cfg.ChannelID, text, blocks)
+}
+
+func (n *Notifier) SendActivationRequest(ctx context.Context, req notify.ActivationRequest) error {
+	cfg, err := n.userConfig(ctx, req.UserID)
+	if err != nil {
+		return err
+	}
+	svcName := display.ServiceName(req.Service)
+	text := fmt.Sprintf("*Clawvisor - Service Activation Required*\n\n*Agent:* %s\n*Service:* %s", mrkdwn(req.AgentName), mrkdwn(svcName))
+	blocks := []any{
+		section(text),
+		actions(urlButton("Activate "+svcName, req.ActivateURL), urlButton("Deny", req.DenyURL)),
+	}
+	_, err = n.postMessage(ctx, cfg.BotToken, cfg.ChannelID, text, blocks)
+	return err
+}
+
+func (n *Notifier) SendTaskApprovalRequest(ctx context.Context, req notify.TaskApprovalRequest) (string, error) {
+	cfg, err := n.userConfig(ctx, req.UserID)
+	if err != nil {
+		return "", err
+	}
+	text := formatTaskApprovalMessage(req)
+	blocks := approvalBlocks("Clawvisor Task Approval Request", text, cfg, req.UserID, "task", req.TaskID, "", req.ApproveURL, req.DenyURL)
+	blocks = n.withInteractiveTokens(blocks, cfg, "task", req.TaskID, req.UserID, "", req.ApproveURL, req.DenyURL)
+	return n.postMessage(ctx, cfg.BotToken, cfg.ChannelID, text, blocks)
+}
+
+func (n *Notifier) SendScopeExpansionRequest(ctx context.Context, req notify.ScopeExpansionRequest) (string, error) {
+	cfg, err := n.userConfig(ctx, req.UserID)
+	if err != nil {
+		return "", err
+	}
+	text := formatScopeExpansionMessage(req)
+	blocks := approvalBlocks("Clawvisor Scope Expansion Request", text, cfg, req.UserID, "scope_expansion", req.TaskID, "", req.ApproveURL, req.DenyURL)
+	blocks = n.withInteractiveTokens(blocks, cfg, "scope_expansion", req.TaskID, req.UserID, "", req.ApproveURL, req.DenyURL)
+	return n.postMessage(ctx, cfg.BotToken, cfg.ChannelID, text, blocks)
+}
+
+func (n *Notifier) SendConnectionRequest(ctx context.Context, req notify.ConnectionRequest) (string, error) {
+	cfg, err := n.userConfig(ctx, req.UserID)
+	if err != nil {
+		return "", err
+	}
+	text := fmt.Sprintf("*Clawvisor Connection Request*\n\n*Agent:* %s\n*IP address:* `%s`", mrkdwn(req.AgentName), mrkdwn(req.IPAddress))
+	blocks := approvalBlocks("Clawvisor Connection Request", text, cfg, req.UserID, "connection", req.ConnectionID, "", req.ApproveURL, req.DenyURL)
+	blocks = n.withInteractiveTokens(blocks, cfg, "connection", req.ConnectionID, req.UserID, "", req.ApproveURL, req.DenyURL)
+	return n.postMessage(ctx, cfg.BotToken, cfg.ChannelID, text, blocks)
+}
+
+func (n *Notifier) UpdateMessage(ctx context.Context, userID, messageID, text string) error {
+	cfg, err := n.userConfig(ctx, userID)
+	if err != nil {
+		return err
+	}
+	channelID, ts, ok := strings.Cut(messageID, ":")
+	if !ok || channelID == "" || ts == "" {
+		return fmt.Errorf("slack: invalid message id %q", messageID)
+	}
+	blocks := []any{section(mrkdwn(text))}
+	return n.chatUpdate(ctx, cfg.BotToken, channelID, ts, text, blocks)
+}
+
+func (n *Notifier) SendTestMessage(ctx context.Context, userID string) error {
+	return n.SendSlackTestMessage(ctx, userID)
+}
+
+func (n *Notifier) SendSlackTestMessage(ctx context.Context, userID string) error {
+	cfg, err := n.userConfig(ctx, userID)
+	if err != nil {
+		return err
+	}
+	_, err = n.postMessage(ctx, cfg.BotToken, cfg.ChannelID, "Clawvisor test message: Slack notifications are working.", nil)
+	return err
+}
+
+func (n *Notifier) SendAlert(ctx context.Context, userID, text string) error {
+	cfg, err := n.userConfig(ctx, userID)
+	if err != nil {
+		return err
+	}
+	_, err = n.postMessage(ctx, cfg.BotToken, cfg.ChannelID, text, nil)
+	return err
+}
+
+func (n *Notifier) HandleInteraction(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxInteractionBytes+1))
+	if err != nil || len(body) > maxInteractionBytes {
+		http.Error(w, "invalid body", http.StatusBadRequest)
+		return
+	}
+	form, err := url.ParseQuery(string(body))
+	if err != nil {
+		http.Error(w, "invalid form", http.StatusBadRequest)
+		return
+	}
+	var payload interactionPayload
+	if err := json.Unmarshal([]byte(form.Get("payload")), &payload); err != nil {
+		http.Error(w, "invalid payload", http.StatusBadRequest)
+		return
+	}
+	if len(payload.Actions) == 0 {
+		http.Error(w, "missing action", http.StatusBadRequest)
+		return
+	}
+	action := payload.Actions[0]
+	var value callbackValue
+	if err := json.Unmarshal([]byte(action.Value), &value); err != nil || value.Token == "" || value.UserID == "" {
+		http.Error(w, "invalid action value", http.StatusBadRequest)
+		return
+	}
+	cfg, err := n.userConfig(r.Context(), value.UserID)
+	if err != nil || cfg.SigningSecret == "" {
+		http.Error(w, "slack signing secret not configured", http.StatusUnauthorized)
+		return
+	}
+	if !verifySlackSignature(cfg.SigningSecret, r.Header.Get("X-Slack-Request-Timestamp"), r.Header.Get("X-Slack-Signature"), body) {
+		http.Error(w, "invalid signature", http.StatusUnauthorized)
+		return
+	}
+	entry, err := n.cbTokens.Consume(value.Token)
+	if err != nil {
+		http.Error(w, "expired or used action", http.StatusConflict)
+		return
+	}
+	if entry.UserID != value.UserID {
+		http.Error(w, "invalid action target", http.StatusForbidden)
+		return
+	}
+	decisionAction := "deny"
+	if strings.HasPrefix(action.ActionID, "approve") {
+		decisionAction = "approve"
+	}
+	select {
+	case n.decisionCh <- notify.CallbackDecision{
+		Type: entry.Type, Action: decisionAction, TargetID: entry.TargetID,
+		TaskID: entry.TaskID, UserID: entry.UserID,
+	}:
+	default:
+		n.logger.Warn("slack: decision channel full, dropping", "type", entry.Type, "target_id", entry.TargetID)
+	}
+	writeSlackJSON(w, map[string]string{"text": "Decision recorded."})
+}
+
+func (n *Notifier) postMessage(ctx context.Context, token, channelID, text string, blocks []any) (string, error) {
+	var resp struct {
+		OK      bool   `json:"ok"`
+		Error   string `json:"error"`
+		Channel string `json:"channel"`
+		TS      string `json:"ts"`
+	}
+	payload := map[string]any{
+		"channel": channelID,
+		"text":    text,
+	}
+	if blocks != nil {
+		payload["blocks"] = blocks
+	}
+	if err := n.slackPost(ctx, token, "/chat.postMessage", payload, &resp); err != nil {
+		return "", err
+	}
+	if !resp.OK {
+		return "", fmt.Errorf("slack chat.postMessage: %s", resp.Error)
+	}
+	if resp.Channel == "" {
+		resp.Channel = channelID
+	}
+	if resp.TS == "" {
+		return "", errors.New("slack chat.postMessage: missing ts")
+	}
+	return resp.Channel + ":" + resp.TS, nil
+}
+
+func (n *Notifier) chatUpdate(ctx context.Context, token, channelID, ts, text string, blocks []any) error {
+	var resp struct {
+		OK    bool   `json:"ok"`
+		Error string `json:"error"`
+	}
+	if err := n.slackPost(ctx, token, "/chat.update", map[string]any{
+		"channel": channelID,
+		"ts":      ts,
+		"text":    text,
+		"blocks":  blocks,
+	}, &resp); err != nil {
+		return err
+	}
+	if !resp.OK {
+		return fmt.Errorf("slack chat.update: %s", resp.Error)
+	}
+	return nil
+}
+
+func (n *Notifier) slackPost(ctx context.Context, token, path string, payload any, out any) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, n.apiBase+path, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := n.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("slack %s: %w", path, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("slack %s: status %d", path, resp.StatusCode)
+	}
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxSlackResponseBytes))
+	if out != nil {
+		if err := json.Unmarshal(respBody, out); err != nil {
+			return fmt.Errorf("slack %s: parse response: %w", path, err)
+		}
+	}
+	return nil
+}
+
+func approvalBlocks(title, text string, cfg notify.SlackConfig, userID, entryType, targetID, taskID, approveURL, denyURL string) []any {
+	headerText := title
+	if strings.EqualFold(cfg.Mode, "openclaw_agent") {
+		headerText = title + " via Slack Agent"
+	}
+	buttons := []any{urlButton("Approve", approveURL), urlButton("Deny", denyURL)}
+	if cfg.SigningSecret != "" && !strings.EqualFold(cfg.Mode, "openclaw_agent") {
+		buttons = interactiveButtons(userID, entryType, targetID, taskID)
+	}
+	return []any{
+		header(headerText),
+		section(text),
+		actions(buttons...),
+	}
+}
+
+func interactiveButtons(userID, entryType, targetID, taskID string) []any {
+	// Filled by withInteractiveTokens immediately before sending.
+	return []any{
+		map[string]any{"type": "button", "style": "primary", "text": plainText("Approve"), "action_id": "approve", "value": mustJSON(callbackValue{UserID: userID, Type: entryType, TargetID: targetID, TaskID: taskID})},
+		map[string]any{"type": "button", "style": "danger", "text": plainText("Deny"), "action_id": "deny", "value": mustJSON(callbackValue{UserID: userID, Type: entryType, TargetID: targetID, TaskID: taskID})},
+	}
+}
+
+func (n *Notifier) withInteractiveTokens(blocks []any, cfg notify.SlackConfig, entryType, targetID, userID, taskID, approveURL, denyURL string) []any {
+	if cfg.SigningSecret == "" || strings.EqualFold(cfg.Mode, "openclaw_agent") {
+		return blocks
+	}
+	approveID, denyID, err := n.cbTokens.Generate(entryType, targetID, userID, taskID, cfg.ChannelID, 6*time.Minute)
+	if err != nil {
+		replaceActionElements(blocks, urlButton("Approve", approveURL), urlButton("Deny", denyURL))
+		return blocks
+	}
+	replaceActionElements(blocks,
+		map[string]any{"type": "button", "style": "primary", "text": plainText("Approve"), "action_id": "approve", "value": mustJSON(callbackValue{Token: approveID, UserID: userID})},
+		map[string]any{"type": "button", "style": "danger", "text": plainText("Deny"), "action_id": "deny", "value": mustJSON(callbackValue{Token: denyID, UserID: userID})},
+	)
+	return blocks
+}
+
+func replaceActionElements(blocks []any, approve, deny any) {
+	for _, block := range blocks {
+		b, ok := block.(map[string]any)
+		if !ok || b["type"] != "actions" {
+			continue
+		}
+		b["elements"] = []any{approve, deny}
+		return
+	}
+}
+
+func (n *Notifier) userConfig(ctx context.Context, userID string) (notify.SlackConfig, error) {
+	nc, err := n.store.GetNotificationConfig(ctx, userID, "slack")
+	if errors.Is(err, store.ErrNotFound) {
+		return notify.SlackConfig{}, fmt.Errorf("slack: user %s has no Slack notification configured", userID)
+	}
+	if err != nil {
+		return notify.SlackConfig{}, fmt.Errorf("slack: fetching config for user %s: %w", userID, err)
+	}
+	var cfg notify.SlackConfig
+	if err := json.Unmarshal(nc.Config, &cfg); err != nil {
+		return notify.SlackConfig{}, fmt.Errorf("slack: invalid config for user %s: %w", userID, err)
+	}
+	if cfg.BotToken == "" && n.vault != nil {
+		if data, vErr := n.vault.Get(ctx, userID, vaultBotTokenKey); vErr == nil {
+			cfg.BotToken = string(data)
+		}
+	}
+	if cfg.SigningSecret == "" && n.vault != nil {
+		if data, vErr := n.vault.Get(ctx, userID, vaultSigningSecretKey); vErr == nil {
+			cfg.SigningSecret = string(data)
+		}
+	}
+	if cfg.Mode == "" {
+		cfg.Mode = "direct"
+	}
+	if cfg.BotToken == "" {
+		return notify.SlackConfig{}, fmt.Errorf("slack: user %s config missing bot_token", userID)
+	}
+	if cfg.ChannelID == "" {
+		return notify.SlackConfig{}, fmt.Errorf("slack: user %s config missing channel_id", userID)
+	}
+	return cfg, nil
+}
+
+func (n *Notifier) SaveSlackConfig(ctx context.Context, userID string, cfg notify.SlackConfig) error {
+	cfg.ChannelID = strings.TrimSpace(cfg.ChannelID)
+	cfg.BotToken = strings.TrimSpace(cfg.BotToken)
+	cfg.SigningSecret = strings.TrimSpace(cfg.SigningSecret)
+	cfg.Mode = strings.ToLower(strings.TrimSpace(cfg.Mode))
+	if cfg.Mode == "" {
+		cfg.Mode = "direct"
+	}
+	if cfg.Mode != "direct" && cfg.Mode != "openclaw_agent" {
+		return fmt.Errorf("slack: mode must be direct or openclaw_agent")
+	}
+	if userID == "" || cfg.BotToken == "" || cfg.ChannelID == "" {
+		return fmt.Errorf("slack: user_id, bot_token, and channel_id are required")
+	}
+	jsonToken := cfg.BotToken
+	jsonSecret := cfg.SigningSecret
+	if n.vault != nil {
+		if err := n.vault.Set(ctx, userID, vaultBotTokenKey, []byte(cfg.BotToken)); err != nil {
+			return fmt.Errorf("slack: persist bot_token: %w", err)
+		}
+		jsonToken = ""
+		if cfg.SigningSecret != "" {
+			if err := n.vault.Set(ctx, userID, vaultSigningSecretKey, []byte(cfg.SigningSecret)); err != nil {
+				_ = n.vault.Delete(ctx, userID, vaultBotTokenKey)
+				return fmt.Errorf("slack: persist signing_secret: %w", err)
+			}
+		} else {
+			_ = n.vault.Delete(ctx, userID, vaultSigningSecretKey)
+		}
+		jsonSecret = ""
+	}
+	cfgBytes, err := json.Marshal(notify.SlackConfig{
+		BotToken: jsonToken, ChannelID: cfg.ChannelID, SigningSecret: jsonSecret, Mode: cfg.Mode,
+	})
+	if err != nil {
+		return fmt.Errorf("slack: marshal config: %w", err)
+	}
+	if err := n.store.UpsertNotificationConfig(ctx, userID, "slack", cfgBytes); err != nil {
+		if n.vault != nil {
+			_ = n.vault.Delete(ctx, userID, vaultBotTokenKey)
+			_ = n.vault.Delete(ctx, userID, vaultSigningSecretKey)
+		}
+		return fmt.Errorf("slack: save notification config: %w", err)
+	}
+	return nil
+}
+
+func (n *Notifier) SlackConfig(ctx context.Context, userID string) (notify.SlackConfig, error) {
+	return n.userConfig(ctx, userID)
+}
+
+func (n *Notifier) DeleteSlackConfig(ctx context.Context, userID string) error {
+	if n.vault != nil {
+		_ = n.vault.Delete(ctx, userID, vaultBotTokenKey)
+		_ = n.vault.Delete(ctx, userID, vaultSigningSecretKey)
+	}
+	return n.store.DeleteNotificationConfig(ctx, userID, "slack")
+}
+
+func formatApprovalMessage(req notify.ApprovalRequest) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("*Agent:* %s\n*Service:* %s\n*Action:* %s", mrkdwn(req.AgentName), mrkdwn(display.ServiceName(req.Service)), mrkdwn(display.ActionName(req.Action))))
+	if len(req.Params) > 0 {
+		sb.WriteString("\n\n*Parameters:*\n")
+		keys := make([]string, 0, len(req.Params))
+		for k := range req.Params {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			sb.WriteString(fmt.Sprintf("- `%s`: %s\n", mrkdwn(k), mrkdwn(paramValue(req.Params[k]))))
+		}
+	}
+	if req.Reason != "" {
+		sb.WriteString(fmt.Sprintf("\n*Agent's stated reason:* %s", mrkdwn(req.Reason)))
+	}
+	if req.PolicyReason != "" {
+		sb.WriteString(fmt.Sprintf("\n*Policy:* %s", mrkdwn(req.PolicyReason)))
+	}
+	if req.ExpiresIn != "" {
+		sb.WriteString(fmt.Sprintf("\n_Expires in %s_", mrkdwn(req.ExpiresIn)))
+	}
+	return sb.String()
+}
+
+func formatTaskApprovalMessage(req notify.TaskApprovalRequest) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("*Agent:* %s\n*Purpose:* %s", mrkdwn(req.AgentName), mrkdwn(req.Purpose)))
+	if req.RiskLevel != "" && req.RiskLevel != "unknown" {
+		sb.WriteString(fmt.Sprintf("\n*Risk:* %s", mrkdwn(req.RiskLevel)))
+	}
+	if len(req.ScopeSummary) > 0 {
+		sb.WriteString("\n\n*Requested scope:*\n")
+		for _, line := range req.ScopeSummary {
+			sb.WriteString("- " + mrkdwn(line) + "\n")
+		}
+	}
+	if req.ExpiresIn != "" {
+		sb.WriteString(fmt.Sprintf("\n_Expires in %s_", mrkdwn(req.ExpiresIn)))
+	}
+	return sb.String()
+}
+
+func formatScopeExpansionMessage(req notify.ScopeExpansionRequest) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("*Agent:* %s\n*Task:* %s\n*Reason:* %s", mrkdwn(req.AgentName), mrkdwn(req.Purpose), mrkdwn(req.Reason)))
+	if req.RiskLevel != "" {
+		sb.WriteString(fmt.Sprintf("\n*Risk:* %s", mrkdwn(req.RiskLevel)))
+	}
+	if summary := notify.RenderExpansionSummary(req); summary != "" {
+		sb.WriteString("\n\n*Scope changes:*\n" + mrkdwn(summary))
+	}
+	if req.Lifetime != "" {
+		sb.WriteString(fmt.Sprintf("\n*Lifetime:* %s", mrkdwn(req.Lifetime)))
+	}
+	return sb.String()
+}
+
+func section(text string) map[string]any {
+	return map[string]any{"type": "section", "text": map[string]string{"type": "mrkdwn", "text": text}}
+}
+
+func header(text string) map[string]any {
+	return map[string]any{"type": "header", "text": plainText(text)}
+}
+
+func actions(elements ...any) map[string]any {
+	return map[string]any{"type": "actions", "elements": elements}
+}
+
+func urlButton(text, link string) map[string]any {
+	return map[string]any{"type": "button", "text": plainText(text), "url": link}
+}
+
+func plainText(text string) map[string]string {
+	return map[string]string{"type": "plain_text", "text": text}
+}
+
+func mrkdwn(s string) string {
+	s = strings.ReplaceAll(s, "&", "&amp;")
+	s = strings.ReplaceAll(s, "<", "&lt;")
+	s = strings.ReplaceAll(s, ">", "&gt;")
+	if len(s) > 600 {
+		s = s[:597] + "..."
+	}
+	return s
+}
+
+func paramValue(v any) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Sprint(v)
+	}
+	s := string(b)
+	if len(s) > 400 {
+		return s[:397] + "..."
+	}
+	return s
+}
+
+type callbackValue struct {
+	Token    string `json:"token,omitempty"`
+	UserID   string `json:"user_id"`
+	Type     string `json:"type,omitempty"`
+	TargetID string `json:"target_id,omitempty"`
+	TaskID   string `json:"task_id,omitempty"`
+}
+
+func mustJSON(v any) string {
+	b, _ := json.Marshal(v)
+	return string(b)
+}
+
+type interactionPayload struct {
+	Actions []struct {
+		ActionID string `json:"action_id"`
+		Value    string `json:"value"`
+	} `json:"actions"`
+}
+
+func verifySlackSignature(secret, ts, sig string, body []byte) bool {
+	unix, err := strconv.ParseInt(ts, 10, 64)
+	if err != nil || unix <= 0 {
+		return false
+	}
+	if d := time.Since(time.Unix(unix, 0)); d > 5*time.Minute || d < -5*time.Minute {
+		return false
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte("v0:" + ts + ":"))
+	mac.Write(body)
+	expected := "v0=" + hex.EncodeToString(mac.Sum(nil))
+	return hmac.Equal([]byte(expected), []byte(sig))
+}
+
+func writeSlackJSON(w http.ResponseWriter, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+var (
+	_ notify.Notifier         = (*Notifier)(nil)
+	_ notify.SlackConfigStore = (*Notifier)(nil)
+)

--- a/internal/notify/slack/notifier_test.go
+++ b/internal/notify/slack/notifier_test.go
@@ -1,0 +1,191 @@
+package slack
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/clawvisor/clawvisor/pkg/notify"
+	sqlitestore "github.com/clawvisor/clawvisor/pkg/store/sqlite"
+)
+
+func TestSendApprovalRequestAddsSlackButtons(t *testing.T) {
+	ctx := context.Background()
+	st, userID := testStoreWithSlackConfig(t, notify.SlackConfig{
+		BotToken:      "xoxb-test",
+		ChannelID:     "C123",
+		SigningSecret: "signing-secret",
+		Mode:          "direct",
+	})
+
+	var payload struct {
+		Channel string `json:"channel"`
+		Blocks  []struct {
+			Type     string `json:"type"`
+			Elements []struct {
+				Type     string `json:"type"`
+				ActionID string `json:"action_id"`
+				Value    string `json:"value"`
+				URL      string `json:"url"`
+			} `json:"elements"`
+		} `json:"blocks"`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/chat.postMessage" {
+			t.Fatalf("unexpected Slack API call: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer xoxb-test" {
+			t.Fatalf("Authorization = %q", got)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("unmarshal payload: %v", err)
+		}
+		_, _ = w.Write([]byte(`{"ok":true,"channel":"C123","ts":"1700000000.000100"}`))
+	}))
+	defer srv.Close()
+
+	n := New(st, nil)
+	n.apiBase = srv.URL
+
+	msgID, err := n.SendApprovalRequest(ctx, notify.ApprovalRequest{
+		RequestID: "req-1",
+		TaskID:    "task-1",
+		UserID:    userID,
+		AgentName: "OpenClaw",
+		Service:   "github",
+		Action:    "create_issue",
+		ApproveURL: "http://example.com/approve",
+		DenyURL:    "http://example.com/deny",
+	})
+	if err != nil {
+		t.Fatalf("SendApprovalRequest: %v", err)
+	}
+	if msgID != "C123:1700000000.000100" {
+		t.Fatalf("message id = %q", msgID)
+	}
+	if payload.Channel != "C123" {
+		t.Fatalf("channel = %q", payload.Channel)
+	}
+	if len(payload.Blocks) < 3 || payload.Blocks[2].Type != "actions" || len(payload.Blocks[2].Elements) != 2 {
+		t.Fatalf("missing action buttons: %#v", payload.Blocks)
+	}
+	approve := payload.Blocks[2].Elements[0]
+	if approve.ActionID != "approve" || approve.URL != "" {
+		t.Fatalf("approve button = %+v", approve)
+	}
+	var value callbackValue
+	if err := json.Unmarshal([]byte(approve.Value), &value); err != nil {
+		t.Fatalf("approve value is not JSON: %v", err)
+	}
+	if value.Token == "" || value.UserID != userID {
+		t.Fatalf("approve value = %+v", value)
+	}
+}
+
+func TestHandleInteractionEmitsDecision(t *testing.T) {
+	ctx := context.Background()
+	signingSecret := "signing-secret"
+	st, userID := testStoreWithSlackConfig(t, notify.SlackConfig{
+		BotToken:      "xoxb-test",
+		ChannelID:     "C123",
+		SigningSecret: signingSecret,
+		Mode:          "direct",
+	})
+	n := New(st, nil)
+	approveID, _, err := n.cbTokens.Generate("approval", "req-1", userID, "task-1", "C123", time.Minute)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	body := signedInteractionBody(t, signingSecret, callbackValue{Token: approveID, UserID: userID}, "approve")
+	req := httptest.NewRequest(http.MethodPost, "/api/notifications/slack/interactions", strings.NewReader(body.body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("X-Slack-Request-Timestamp", body.ts)
+	req.Header.Set("X-Slack-Signature", body.sig)
+	rec := httptest.NewRecorder()
+
+	n.HandleInteraction(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("HandleInteraction status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	select {
+	case d := <-n.DecisionChannel():
+		if d.Type != "approval" || d.Action != "approve" || d.TargetID != "req-1" || d.TaskID != "task-1" || d.UserID != userID {
+			t.Fatalf("decision = %+v", d)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for decision")
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/api/notifications/slack/interactions", strings.NewReader(body.body))
+	req.Header.Set("X-Slack-Request-Timestamp", body.ts)
+	req.Header.Set("X-Slack-Signature", "v0=bad")
+	n.HandleInteraction(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("bad signature status = %d", rec.Code)
+	}
+}
+
+func testStoreWithSlackConfig(t *testing.T, cfg notify.SlackConfig) (*sqlitestore.Store, string) {
+	t.Helper()
+	ctx := context.Background()
+	db, err := sqlitestore.New(ctx, t.TempDir()+"/test.db")
+	if err != nil {
+		t.Fatalf("sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	st := sqlitestore.NewStore(db)
+	user, err := st.CreateUser(ctx, "slack@test.example", "hash", "")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	raw, _ := json.Marshal(cfg)
+	if err := st.UpsertNotificationConfig(ctx, user.ID, "slack", raw); err != nil {
+		t.Fatalf("UpsertNotificationConfig: %v", err)
+	}
+	return st, user.ID
+}
+
+type signedBody struct {
+	body string
+	ts   string
+	sig  string
+}
+
+func signedInteractionBody(t *testing.T, secret string, value callbackValue, actionID string) signedBody {
+	t.Helper()
+	valueJSON, _ := json.Marshal(value)
+	payload, _ := json.Marshal(map[string]any{
+		"type": "block_actions",
+		"actions": []map[string]any{{
+			"action_id": actionID,
+			"value":     string(valueJSON),
+		}},
+	})
+	form := url.Values{"payload": {string(payload)}}.Encode()
+	ts := strconvNow()
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte("v0:" + ts + ":"))
+	mac.Write([]byte(form))
+	return signedBody{
+		body: form,
+		ts:   ts,
+		sig:  "v0=" + hex.EncodeToString(mac.Sum(nil)),
+	}
+}
+
+func strconvNow() string {
+	return strconv.FormatInt(time.Now().Unix(), 10)
+}

--- a/internal/notify/slack/tokens.go
+++ b/internal/notify/slack/tokens.go
@@ -1,0 +1,121 @@
+package slack
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"sync"
+	"time"
+)
+
+var (
+	errTokenNotFound = errors.New("callback token not found")
+	errTokenUsed     = errors.New("callback token already used")
+	errTokenExpired  = errors.New("callback token expired")
+)
+
+type callbackEntry struct {
+	Type      string
+	TargetID  string
+	TaskID    string
+	UserID    string
+	ChannelID string
+	ExpiresAt time.Time
+	Used      bool
+}
+
+type CallbackTokenStore interface {
+	Generate(entryType, targetID, userID, taskID, channelID string, ttl time.Duration) (approveID, denyID string, err error)
+	Consume(shortID string) (*callbackEntry, error)
+	Cleanup()
+}
+
+type callbackTokenStore struct {
+	mu       sync.Mutex
+	tokens   map[string]*callbackEntry
+	byTarget map[string][]string
+}
+
+func newCallbackTokenStore() *callbackTokenStore {
+	return &callbackTokenStore{
+		tokens:   make(map[string]*callbackEntry),
+		byTarget: make(map[string][]string),
+	}
+}
+
+func (s *callbackTokenStore) Generate(entryType, targetID, userID, taskID, channelID string, ttl time.Duration) (string, string, error) {
+	approveID, err := randomShortID()
+	if err != nil {
+		return "", "", err
+	}
+	denyID, err := randomShortID()
+	if err != nil {
+		return "", "", err
+	}
+	entry := &callbackEntry{
+		Type:      entryType,
+		TargetID:  targetID,
+		TaskID:    taskID,
+		UserID:    userID,
+		ChannelID: channelID,
+		ExpiresAt: time.Now().Add(ttl),
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.tokens[approveID] = entry
+	s.tokens[denyID] = entry
+	s.byTarget[targetID] = append(s.byTarget[targetID], approveID, denyID)
+	return approveID, denyID, nil
+}
+
+func (s *callbackTokenStore) Consume(shortID string) (*callbackEntry, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entry, ok := s.tokens[shortID]
+	if !ok {
+		return nil, errTokenNotFound
+	}
+	if entry.Used {
+		return nil, errTokenUsed
+	}
+	if time.Now().After(entry.ExpiresAt) {
+		return nil, errTokenExpired
+	}
+	entry.Used = true
+	return entry, nil
+}
+
+func (s *callbackTokenStore) Cleanup() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := time.Now()
+	for id, entry := range s.tokens {
+		if entry.Used || now.After(entry.ExpiresAt) {
+			delete(s.tokens, id)
+		}
+	}
+	for targetID, ids := range s.byTarget {
+		remaining := ids[:0]
+		for _, id := range ids {
+			if _, ok := s.tokens[id]; ok {
+				remaining = append(remaining, id)
+			}
+		}
+		if len(remaining) == 0 {
+			delete(s.byTarget, targetID)
+		} else {
+			s.byTarget[targetID] = remaining
+		}
+	}
+}
+
+func randomShortID() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+var _ CallbackTokenStore = (*callbackTokenStore)(nil)

--- a/internal/notify/slack/tokens_redis.go
+++ b/internal/notify/slack/tokens_redis.go
@@ -1,0 +1,107 @@
+package slack
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const redisCBTokenPrefix = "clawvisor:slackcb:"
+
+type callbackEntryJSON struct {
+	Type      string `json:"type"`
+	TargetID  string `json:"target_id"`
+	TaskID    string `json:"task_id,omitempty"`
+	UserID    string `json:"user_id"`
+	ChannelID string `json:"channel_id"`
+	ExpiresAt int64  `json:"expires_at"`
+	SiblingID string `json:"sibling_id"`
+}
+
+type redisCallbackTokenStore struct {
+	rdb *redis.Client
+}
+
+func NewRedisCallbackTokenStore(rdb *redis.Client) CallbackTokenStore {
+	return &redisCallbackTokenStore{rdb: rdb}
+}
+
+func (s *redisCallbackTokenStore) Generate(entryType, targetID, userID, taskID, channelID string, ttl time.Duration) (string, string, error) {
+	approveID, err := redisRandomShortID()
+	if err != nil {
+		return "", "", err
+	}
+	denyID, err := redisRandomShortID()
+	if err != nil {
+		return "", "", err
+	}
+
+	expiresAt := time.Now().Add(ttl).UnixMilli()
+	approveData, err := json.Marshal(callbackEntryJSON{
+		Type: entryType, TargetID: targetID, TaskID: taskID, UserID: userID,
+		ChannelID: channelID, ExpiresAt: expiresAt, SiblingID: denyID,
+	})
+	if err != nil {
+		return "", "", err
+	}
+	denyData, err := json.Marshal(callbackEntryJSON{
+		Type: entryType, TargetID: targetID, TaskID: taskID, UserID: userID,
+		ChannelID: channelID, ExpiresAt: expiresAt, SiblingID: approveID,
+	})
+	if err != nil {
+		return "", "", err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	pipe := s.rdb.Pipeline()
+	pipe.Set(ctx, redisCBTokenPrefix+approveID, approveData, ttl)
+	pipe.Set(ctx, redisCBTokenPrefix+denyID, denyData, ttl)
+	if _, err := pipe.Exec(ctx); err != nil {
+		return "", "", err
+	}
+	return approveID, denyID, nil
+}
+
+func (s *redisCallbackTokenStore) Consume(shortID string) (*callbackEntry, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	data, err := s.rdb.GetDel(ctx, redisCBTokenPrefix+shortID).Bytes()
+	if errors.Is(err, redis.Nil) {
+		return nil, errTokenNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	var j callbackEntryJSON
+	if err := json.Unmarshal(data, &j); err != nil {
+		return nil, errTokenNotFound
+	}
+	if time.Now().UnixMilli() > j.ExpiresAt {
+		return nil, errTokenExpired
+	}
+	if j.SiblingID != "" {
+		s.rdb.Del(ctx, redisCBTokenPrefix+j.SiblingID)
+	}
+	return &callbackEntry{
+		Type: j.Type, TargetID: j.TargetID, TaskID: j.TaskID, UserID: j.UserID,
+		ChannelID: j.ChannelID, ExpiresAt: time.UnixMilli(j.ExpiresAt),
+	}, nil
+}
+
+func (s *redisCallbackTokenStore) Cleanup() {}
+
+func redisRandomShortID() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+var _ CallbackTokenStore = (*redisCallbackTokenStore)(nil)

--- a/internal/notify/telegram/telegram.go
+++ b/internal/notify/telegram/telegram.go
@@ -68,6 +68,8 @@ func New(st store.Store, serverCtx context.Context) *Notifier {
 	return n
 }
 
+func (n *Notifier) NotificationChannel() string { return "telegram" }
+
 // SetMessageBuffer sets the message buffer used for group chat observation.
 func (n *Notifier) SetMessageBuffer(buf groupchat.Buffer) {
 	n.msgBuffer = buf

--- a/pkg/clawvisor/defaults.go
+++ b/pkg/clawvisor/defaults.go
@@ -43,6 +43,7 @@ import (
 	"github.com/clawvisor/clawvisor/internal/intent"
 	intnotify "github.com/clawvisor/clawvisor/internal/notify"
 	pushnotify "github.com/clawvisor/clawvisor/internal/notify/push"
+	slacknotify "github.com/clawvisor/clawvisor/internal/notify/slack"
 	telegramnotify "github.com/clawvisor/clawvisor/internal/notify/telegram"
 	intredis "github.com/clawvisor/clawvisor/internal/redis"
 	"github.com/clawvisor/clawvisor/internal/relay"
@@ -69,7 +70,7 @@ import (
 
 // DefaultOptions loads config and builds a fully-wired ServerOptions with the
 // standard open-source defaults (SQLite or Postgres, local or GCP vault,
-// all enabled adapters, Telegram notifier, magic-link auth for local mode).
+// all enabled adapters, notification notifiers, magic-link auth for local mode).
 //
 // Cloud/enterprise builds call this, then selectively override fields:
 //
@@ -427,6 +428,8 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 	telegramN := telegramnotify.New(st, ctx)
 	telegramN.SetMessageBuffer(msgBuffer)
 	telegramN.SetVault(v)
+	slackN := slacknotify.New(st, logger)
+	slackN.SetVault(v)
 
 	var pushN *pushnotify.Notifier
 	if cfg.Push.Enabled && ed25519Key != nil {
@@ -449,6 +452,7 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 
 	var notifiers []notify.Notifier
 	notifiers = append(notifiers, telegramN)
+	notifiers = append(notifiers, slackN)
 	if pushN != nil {
 		notifiers = append(notifiers, pushN)
 	}
@@ -541,6 +545,7 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 			telegramnotify.NewRedisGroupPairingStore(client),
 			telegramnotify.NewRedisPollingLock(client, instanceID),
 		)
+		slackN.SetCallbackTokenStore(slacknotify.NewRedisCallbackTokenStore(client))
 
 		logger.Info("redis connected", "addr", client.Options().Addr)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -203,7 +203,7 @@ type ServerConfig struct {
 	Port        int    `yaml:"port"`
 	Host        string `yaml:"host"`
 	FrontendDir string `yaml:"frontend_dir"`
-	PublicURL   string `yaml:"public_url"` // e.g. "http://192.168.4.247:5173" — used in Telegram notification links
+	PublicURL   string `yaml:"public_url"` // e.g. "http://192.168.4.247:5173" — used in notification deep links
 	AuthMode    string `yaml:"auth_mode"`  // "magic_link", "password", or "" (auto-detect from IsLocal)
 	LogFormat   string `yaml:"log_format"` // "json", "text", or "" (auto: json in prod, text in dev)
 	LogLevel    string `yaml:"log_level"`  // "debug", "info", "warn", "error" (default: "info")

--- a/pkg/notify/multi.go
+++ b/pkg/notify/multi.go
@@ -2,8 +2,11 @@ package notify
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"log/slog"
+	"net/http"
 	"sync"
 )
 
@@ -21,12 +24,31 @@ type MultiNotifier struct {
 	groupDetector  GroupDetector
 	agentPairer    AgentGroupPairer
 	groupValidator GroupMembershipValidator
+	slackConfig    SlackConfigStore
+	slackTester    interface {
+		SendSlackTestMessage(context.Context, string) error
+	}
+	slackHandler   interface {
+		HandleInteraction(http.ResponseWriter, *http.Request)
+	}
+}
+
+type channelNotifier interface {
+	NotificationChannel() string
+}
+
+type storedMessage struct {
+	Channel string `json:"channel"`
+	ID      string `json:"id"`
 }
 
 // NewMultiNotifier creates a MultiNotifier that delegates to the given notifiers.
 // It inspects each notifier for optional interfaces (TelegramPairer, PollingDecrementer,
 // DecisionChannel) and wires them through.
 func NewMultiNotifier(ctx context.Context, logger *slog.Logger, notifiers ...Notifier) *MultiNotifier {
+	if logger == nil {
+		logger = slog.Default()
+	}
 	m := &MultiNotifier{
 		notifiers:  notifiers,
 		logger:     logger,
@@ -51,6 +73,19 @@ func NewMultiNotifier(ctx context.Context, logger *slog.Logger, notifiers ...Not
 		}
 		if gv, ok := n.(GroupMembershipValidator); ok && m.groupValidator == nil {
 			m.groupValidator = gv
+		}
+		if sc, ok := n.(SlackConfigStore); ok && m.slackConfig == nil {
+			m.slackConfig = sc
+		}
+		if st, ok := n.(interface {
+			SendSlackTestMessage(context.Context, string) error
+		}); ok && m.slackTester == nil {
+			m.slackTester = st
+		}
+		if sh, ok := n.(interface {
+			HandleInteraction(http.ResponseWriter, *http.Request)
+		}); ok && m.slackHandler == nil {
+			m.slackHandler = sh
 		}
 	}
 
@@ -91,93 +126,117 @@ func NewMultiNotifier(ctx context.Context, logger *slog.Logger, notifiers ...Not
 
 // Compile-time interface checks.
 var (
-	_ Notifier           = (*MultiNotifier)(nil)
-	_ TelegramPairer     = (*MultiNotifier)(nil)
-	_ PollingDecrementer = (*MultiNotifier)(nil)
-	_ GroupObserver      = (*MultiNotifier)(nil)
-	_ GroupDetector      = (*MultiNotifier)(nil)
-	_ AgentGroupPairer        = (*MultiNotifier)(nil)
+	_ Notifier                 = (*MultiNotifier)(nil)
+	_ TelegramPairer           = (*MultiNotifier)(nil)
+	_ PollingDecrementer       = (*MultiNotifier)(nil)
+	_ GroupObserver            = (*MultiNotifier)(nil)
+	_ GroupDetector            = (*MultiNotifier)(nil)
+	_ AgentGroupPairer         = (*MultiNotifier)(nil)
 	_ GroupMembershipValidator = (*MultiNotifier)(nil)
+	_ SlackConfigStore         = (*MultiNotifier)(nil)
 )
 
 // ── Notifier interface ────────────────────────────────────────────────────────
 
 func (m *MultiNotifier) SendApprovalRequest(ctx context.Context, req ApprovalRequest) (string, error) {
-	var messageID string
+	var messages []storedMessage
 	var errs []error
 	for _, n := range m.notifiers {
 		id, err := n.SendApprovalRequest(ctx, req)
 		if err != nil {
-			m.logger.WarnContext(ctx,"notifier: SendApprovalRequest failed", "err", err)
+			m.logger.WarnContext(ctx, "notifier: SendApprovalRequest failed", "err", err)
 			errs = append(errs, err)
-		} else if messageID == "" && id != "" {
-			messageID = id
+		} else if id != "" {
+			messages = append(messages, storedMessage{Channel: notifierChannel(n), ID: id})
 		}
 	}
-	return messageID, errors.Join(errs...)
+	return encodeMessages(messages), multiError(messages, errs)
 }
 
 func (m *MultiNotifier) SendActivationRequest(ctx context.Context, req ActivationRequest) error {
 	var errs []error
+	success := false
 	for _, n := range m.notifiers {
 		if err := n.SendActivationRequest(ctx, req); err != nil {
-			m.logger.WarnContext(ctx,"notifier: SendActivationRequest failed", "err", err)
+			m.logger.WarnContext(ctx, "notifier: SendActivationRequest failed", "err", err)
 			errs = append(errs, err)
+		} else {
+			success = true
 		}
+	}
+	if success {
+		return nil
 	}
 	return errors.Join(errs...)
 }
 
 func (m *MultiNotifier) SendTaskApprovalRequest(ctx context.Context, req TaskApprovalRequest) (string, error) {
-	var messageID string
+	var messages []storedMessage
 	var errs []error
 	for _, n := range m.notifiers {
 		id, err := n.SendTaskApprovalRequest(ctx, req)
 		if err != nil {
-			m.logger.WarnContext(ctx,"notifier: SendTaskApprovalRequest failed", "err", err)
+			m.logger.WarnContext(ctx, "notifier: SendTaskApprovalRequest failed", "err", err)
 			errs = append(errs, err)
-		} else if messageID == "" && id != "" {
-			messageID = id
+		} else if id != "" {
+			messages = append(messages, storedMessage{Channel: notifierChannel(n), ID: id})
 		}
 	}
-	return messageID, errors.Join(errs...)
+	return encodeMessages(messages), multiError(messages, errs)
 }
 
 func (m *MultiNotifier) SendScopeExpansionRequest(ctx context.Context, req ScopeExpansionRequest) (string, error) {
-	var messageID string
+	var messages []storedMessage
 	var errs []error
 	for _, n := range m.notifiers {
 		id, err := n.SendScopeExpansionRequest(ctx, req)
 		if err != nil {
-			m.logger.WarnContext(ctx,"notifier: SendScopeExpansionRequest failed", "err", err)
+			m.logger.WarnContext(ctx, "notifier: SendScopeExpansionRequest failed", "err", err)
 			errs = append(errs, err)
-		} else if messageID == "" && id != "" {
-			messageID = id
+		} else if id != "" {
+			messages = append(messages, storedMessage{Channel: notifierChannel(n), ID: id})
 		}
 	}
-	return messageID, errors.Join(errs...)
+	return encodeMessages(messages), multiError(messages, errs)
 }
 
 func (m *MultiNotifier) SendConnectionRequest(ctx context.Context, req ConnectionRequest) (string, error) {
-	var messageID string
+	var messages []storedMessage
 	var errs []error
 	for _, n := range m.notifiers {
 		id, err := n.SendConnectionRequest(ctx, req)
 		if err != nil {
-			m.logger.WarnContext(ctx,"notifier: SendConnectionRequest failed", "err", err)
+			m.logger.WarnContext(ctx, "notifier: SendConnectionRequest failed", "err", err)
 			errs = append(errs, err)
-		} else if messageID == "" && id != "" {
-			messageID = id
+		} else if id != "" {
+			messages = append(messages, storedMessage{Channel: notifierChannel(n), ID: id})
 		}
 	}
-	return messageID, errors.Join(errs...)
+	return encodeMessages(messages), multiError(messages, errs)
 }
 
 func (m *MultiNotifier) UpdateMessage(ctx context.Context, userID, messageID, text string) error {
+	if messages, ok := decodeMessages(messageID); ok {
+		byChannel := make(map[string][]string, len(messages))
+		for _, msg := range messages {
+			byChannel[msg.Channel] = append(byChannel[msg.Channel], msg.ID)
+		}
+		var errs []error
+		for _, n := range m.notifiers {
+			for _, id := range byChannel[notifierChannel(n)] {
+				if err := n.UpdateMessage(ctx, userID, id, text); err != nil {
+					m.logger.WarnContext(ctx, "notifier: UpdateMessage failed", "err", err)
+					errs = append(errs, err)
+				}
+			}
+		}
+		return errors.Join(errs...)
+	}
+
 	var errs []error
 	for _, n := range m.notifiers {
 		if err := n.UpdateMessage(ctx, userID, messageID, text); err != nil {
-			m.logger.WarnContext(ctx,"notifier: UpdateMessage failed", "err", err)
+			m.logger.WarnContext(ctx, "notifier: UpdateMessage failed", "err", err)
 			errs = append(errs, err)
 		}
 	}
@@ -186,22 +245,79 @@ func (m *MultiNotifier) UpdateMessage(ctx context.Context, userID, messageID, te
 
 func (m *MultiNotifier) SendTestMessage(ctx context.Context, userID string) error {
 	var errs []error
+	success := false
 	for _, n := range m.notifiers {
 		if err := n.SendTestMessage(ctx, userID); err != nil {
-			m.logger.WarnContext(ctx,"notifier: SendTestMessage failed", "err", err)
+			m.logger.WarnContext(ctx, "notifier: SendTestMessage failed", "err", err)
 			errs = append(errs, err)
+		} else {
+			success = true
 		}
+	}
+	if success {
+		return nil
 	}
 	return errors.Join(errs...)
 }
 
 func (m *MultiNotifier) SendAlert(ctx context.Context, userID, text string) error {
 	var errs []error
+	success := false
 	for _, n := range m.notifiers {
 		if err := n.SendAlert(ctx, userID, text); err != nil {
-			m.logger.WarnContext(ctx,"notifier: SendAlert failed", "err", err)
+			m.logger.WarnContext(ctx, "notifier: SendAlert failed", "err", err)
 			errs = append(errs, err)
+		} else {
+			success = true
 		}
+	}
+	if success {
+		return nil
+	}
+	return errors.Join(errs...)
+}
+
+func notifierChannel(n Notifier) string {
+	if cn, ok := n.(channelNotifier); ok {
+		if ch := cn.NotificationChannel(); ch != "" {
+			return ch
+		}
+	}
+	return "unknown"
+}
+
+func encodeMessages(messages []storedMessage) string {
+	if len(messages) == 0 {
+		return ""
+	}
+	if len(messages) == 1 && messages[0].Channel == "telegram" {
+		return messages[0].ID
+	}
+	body, err := json.Marshal(messages)
+	if err != nil {
+		return messages[0].ID
+	}
+	return "multi:" + base64.RawURLEncoding.EncodeToString(body)
+}
+
+func decodeMessages(messageID string) ([]storedMessage, bool) {
+	if len(messageID) <= len("multi:") || messageID[:len("multi:")] != "multi:" {
+		return nil, false
+	}
+	body, err := base64.RawURLEncoding.DecodeString(messageID[len("multi:"):])
+	if err != nil {
+		return nil, false
+	}
+	var messages []storedMessage
+	if err := json.Unmarshal(body, &messages); err != nil {
+		return nil, false
+	}
+	return messages, true
+}
+
+func multiError(messages []storedMessage, errs []error) error {
+	if len(messages) > 0 {
+		return nil
 	}
 	return errors.Join(errs...)
 }
@@ -349,6 +465,44 @@ func (m *MultiNotifier) ValidateGroupMembership(ctx context.Context, userID, gro
 		return nil, errors.New("group membership validation not available")
 	}
 	return m.groupValidator.ValidateGroupMembership(ctx, userID, groupChatID)
+}
+
+// ── Slack delegation ─────────────────────────────────────────────────────────
+
+func (m *MultiNotifier) SaveSlackConfig(ctx context.Context, userID string, cfg SlackConfig) error {
+	if m.slackConfig == nil {
+		return errors.New("slack notifications not available")
+	}
+	return m.slackConfig.SaveSlackConfig(ctx, userID, cfg)
+}
+
+func (m *MultiNotifier) SlackConfig(ctx context.Context, userID string) (SlackConfig, error) {
+	if m.slackConfig == nil {
+		return SlackConfig{}, errors.New("slack notifications not available")
+	}
+	return m.slackConfig.SlackConfig(ctx, userID)
+}
+
+func (m *MultiNotifier) DeleteSlackConfig(ctx context.Context, userID string) error {
+	if m.slackConfig == nil {
+		return errors.New("slack notifications not available")
+	}
+	return m.slackConfig.DeleteSlackConfig(ctx, userID)
+}
+
+func (m *MultiNotifier) SendSlackTestMessage(ctx context.Context, userID string) error {
+	if m.slackTester == nil {
+		return errors.New("slack notifications not available")
+	}
+	return m.slackTester.SendSlackTestMessage(ctx, userID)
+}
+
+func (m *MultiNotifier) HandleInteraction(w http.ResponseWriter, r *http.Request) {
+	if m.slackHandler == nil {
+		http.Error(w, "slack notifications not available", http.StatusServiceUnavailable)
+		return
+	}
+	m.slackHandler.HandleInteraction(w, r)
 }
 
 // BootstrapGroupObservation delegates to the underlying notifier that supports it.

--- a/pkg/notify/multi_test.go
+++ b/pkg/notify/multi_test.go
@@ -1,0 +1,57 @@
+package notify
+
+import (
+	"context"
+	"testing"
+)
+
+type recordingNotifier struct {
+	channel string
+	id      string
+	updates []string
+}
+
+func (n *recordingNotifier) NotificationChannel() string { return n.channel }
+func (n *recordingNotifier) SendApprovalRequest(context.Context, ApprovalRequest) (string, error) {
+	return n.id, nil
+}
+func (n *recordingNotifier) SendActivationRequest(context.Context, ActivationRequest) error { return nil }
+func (n *recordingNotifier) SendTaskApprovalRequest(context.Context, TaskApprovalRequest) (string, error) {
+	return n.id, nil
+}
+func (n *recordingNotifier) SendScopeExpansionRequest(context.Context, ScopeExpansionRequest) (string, error) {
+	return n.id, nil
+}
+func (n *recordingNotifier) UpdateMessage(_ context.Context, _ string, messageID, _ string) error {
+	n.updates = append(n.updates, messageID)
+	return nil
+}
+func (n *recordingNotifier) SendTestMessage(context.Context, string) error { return nil }
+func (n *recordingNotifier) SendConnectionRequest(context.Context, ConnectionRequest) (string, error) {
+	return n.id, nil
+}
+func (n *recordingNotifier) SendAlert(context.Context, string, string) error { return nil }
+
+func TestMultiNotifierRoutesEncodedMessageUpdatesByChannel(t *testing.T) {
+	ctx := context.Background()
+	tg := &recordingNotifier{channel: "telegram", id: "42"}
+	sl := &recordingNotifier{channel: "slack", id: "C123:1700000000.000100"}
+	m := NewMultiNotifier(ctx, nil, tg, sl)
+
+	messageID, err := m.SendApprovalRequest(ctx, ApprovalRequest{})
+	if err != nil {
+		t.Fatalf("SendApprovalRequest: %v", err)
+	}
+	if messageID == "" || messageID == "42" || messageID == "C123:1700000000.000100" {
+		t.Fatalf("expected encoded multi-channel message id, got %q", messageID)
+	}
+	if err := m.UpdateMessage(ctx, "u1", messageID, "approved"); err != nil {
+		t.Fatalf("UpdateMessage: %v", err)
+	}
+	if len(tg.updates) != 1 || tg.updates[0] != "42" {
+		t.Fatalf("telegram updates = %#v", tg.updates)
+	}
+	if len(sl.updates) != 1 || sl.updates[0] != "C123:1700000000.000100" {
+		t.Fatalf("slack updates = %#v", sl.updates)
+	}
+}

--- a/pkg/notify/notify.go
+++ b/pkg/notify/notify.go
@@ -208,8 +208,25 @@ type TelegramConfigStore interface {
 	DeleteTelegramConfig(ctx context.Context, userID string) error
 }
 
-// CallbackDecision is sent by the Telegram notifier when a user taps an
-// inline Approve/Deny button. The server routes this to the appropriate handler.
+// SlackConfig is the non-secret public shape stored for a Slack approval
+// channel. BotToken and SigningSecret are written only for legacy/no-vault
+// setups; vault-backed implementations leave them empty in the JSON row.
+type SlackConfig struct {
+	BotToken      string `json:"bot_token,omitempty"`
+	ChannelID     string `json:"channel_id"`
+	SigningSecret string `json:"signing_secret,omitempty"`
+	Mode          string `json:"mode,omitempty"` // "direct" | "openclaw_agent"
+}
+
+// SlackConfigStore persists and retrieves a user's Slack approval config.
+type SlackConfigStore interface {
+	SaveSlackConfig(ctx context.Context, userID string, cfg SlackConfig) error
+	SlackConfig(ctx context.Context, userID string) (SlackConfig, error)
+	DeleteSlackConfig(ctx context.Context, userID string) error
+}
+
+// CallbackDecision is sent by notifiers when a user taps an inline
+// Approve/Deny button. The server routes this to the appropriate handler.
 type CallbackDecision struct {
 	Type     string // "approval", "task", "scope_expansion", "connection"
 	Action   string // "approve" or "deny"

--- a/testharness/slack/slack.go
+++ b/testharness/slack/slack.go
@@ -27,6 +27,9 @@ func NewMock(t *testing.T) *Mock {
 			"ts":      "1700000000.000100",
 			"channel": "C-MOCK",
 		}},
+		"POST /api/chat.update": {Body: map[string]any{
+			"ok": true,
+		}},
 		"GET /api/users.list": {Body: map[string]any{
 			"ok":      true,
 			"members": []map[string]any{},

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1793,6 +1793,10 @@ export const api = {
   },
   notifications: {
     list: () => get<NotificationConfig[]>('/api/notifications'),
+    upsertSlack: (botToken: string, channelId: string, signingSecret: string, mode: 'direct' | 'openclaw_agent') =>
+      put<NotificationConfig>('/api/notifications/slack', { bot_token: botToken, channel_id: channelId, signing_secret: signingSecret, mode }),
+    deleteSlack: () => del<void>('/api/notifications/slack'),
+    testSlack: () => post<{ status: string }>('/api/notifications/slack/test', {}),
     upsertTelegram: (botToken: string, chatId: string) =>
       put<NotificationConfig>('/api/notifications/telegram', { bot_token: botToken, chat_id: chatId }),
     deleteTelegram: () => del<void>('/api/notifications/telegram'),

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -20,6 +20,7 @@ export default function Settings() {
       {!features?.multi_tenant && <OAuthCredentialsSection />}
       {features?.mobile_pairing && <DevicePairing />}
       {features?.local_daemon && <LocalDaemonPairing />}
+      <SlackSetupSection />
       <TelegramSetupSection />
       {passwordAuth && <PasswordSection />}
       {passwordAuth && <DangerZone />}
@@ -746,6 +747,176 @@ function OAuthCredentialsSection() {
             </div>
           )
         })}
+      </div>
+    </section>
+  )
+}
+
+// ── Slack Setup ──────────────────────────────────────────────────────────────
+
+function SlackSetupSection() {
+  const qc = useQueryClient()
+  const [expanded, setExpanded] = useState(false)
+  const [botToken, setBotToken] = useState('')
+  const [channelId, setChannelId] = useState('')
+  const [signingSecret, setSigningSecret] = useState('')
+  const [mode, setMode] = useState<'direct' | 'openclaw_agent'>('direct')
+  const [error, setError] = useState<string | null>(null)
+  const [testResult, setTestResult] = useState<'success' | 'error' | null>(null)
+
+  const { data: configs } = useQuery({
+    queryKey: ['notifications'],
+    queryFn: (): Promise<NotificationConfig[]> => api.notifications.list(),
+  })
+
+  const slack = configs?.find((c: NotificationConfig) => c.channel === 'slack')
+  const configured = Boolean(slack)
+
+  useEffect(() => {
+    if (!configured) setExpanded(true)
+  }, [configured])
+
+  const saveMut = useMutation({
+    mutationFn: () => api.notifications.upsertSlack(botToken.trim(), channelId.trim(), signingSecret.trim(), mode),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['notifications'] })
+      setBotToken('')
+      setChannelId('')
+      setSigningSecret('')
+      setError(null)
+      setExpanded(false)
+    },
+    onError: (err: Error) => setError(err.message),
+  })
+
+  const deleteMut = useMutation({
+    mutationFn: () => api.notifications.deleteSlack(),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['notifications'] })
+      setExpanded(true)
+      setTestResult(null)
+    },
+  })
+
+  const testMut = useMutation({
+    mutationFn: () => api.notifications.testSlack(),
+    onSuccess: () => { setTestResult('success'); setTimeout(() => setTestResult(null), 5000) },
+    onError: () => { setTestResult('error'); setTimeout(() => setTestResult(null), 5000) },
+  })
+
+  const canSave = botToken.trim() && channelId.trim()
+
+  return (
+    <section className="space-y-4">
+      <div>
+        <h2 className="text-lg font-semibold text-text-primary">Slack</h2>
+        <p className="text-sm text-text-tertiary mt-0.5">
+          Send approval requests to a Slack channel, directly or through the Slack Agent by OpenClaw.
+        </p>
+      </div>
+
+      {error && <div className="text-sm text-danger max-w-xl">{error}</div>}
+
+      <div className="max-w-xl bg-surface-1 border border-border-default rounded-md px-5 py-4 space-y-3">
+        <button
+          onClick={() => setExpanded(prev => !prev)}
+          className="flex items-center gap-3 w-full text-left group"
+        >
+          <span className={`flex-shrink-0 w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold border-2 transition-colors ${
+            configured ? 'bg-green-500/15 border-green-500/40 text-green-500' : 'bg-brand/15 border-brand/40 text-brand'
+          }`}>
+            {configured ? '✓' : '1'}
+          </span>
+          <span className="text-sm font-medium text-text-primary">
+            {configured ? `Connected to ${slack?.config?.channel_id ?? 'Slack'}` : 'Connect Slack approvals'}
+          </span>
+        </button>
+
+        {expanded && (
+          <div className="ml-10 space-y-3">
+            <div className="grid grid-cols-2 gap-2">
+              <button
+                onClick={() => setMode('direct')}
+                className={`text-xs px-3 py-2 rounded border ${mode === 'direct' ? 'bg-brand text-surface-0 border-brand' : 'border-border-default text-text-secondary hover:bg-surface-0'}`}
+              >
+                Direct Slack
+              </button>
+              <button
+                onClick={() => setMode('openclaw_agent')}
+                className={`text-xs px-3 py-2 rounded border ${mode === 'openclaw_agent' ? 'bg-brand text-surface-0 border-brand' : 'border-border-default text-text-secondary hover:bg-surface-0'}`}
+              >
+                OpenClaw Agent
+              </button>
+            </div>
+            <div>
+              <label className="text-xs font-medium text-text-tertiary">Bot Token</label>
+              <input
+                type="password"
+                value={botToken}
+                onChange={e => { setBotToken(e.target.value); setError(null) }}
+                placeholder="xoxb-..."
+                className="mt-1 block w-full text-sm rounded border border-border-default bg-surface-0 text-text-primary px-3 py-1.5 focus:outline-none focus:ring-1 focus:ring-brand/30 focus:border-brand placeholder:text-text-tertiary"
+              />
+            </div>
+            <div>
+              <label className="text-xs font-medium text-text-tertiary">Channel ID</label>
+              <input
+                type="text"
+                value={channelId}
+                onChange={e => { setChannelId(e.target.value); setError(null) }}
+                placeholder="C0123456789"
+                className="mt-1 block w-full text-sm rounded border border-border-default bg-surface-0 text-text-primary px-3 py-1.5 focus:outline-none focus:ring-1 focus:ring-brand/30 focus:border-brand placeholder:text-text-tertiary"
+              />
+            </div>
+            {mode === 'direct' && (
+              <div>
+                <label className="text-xs font-medium text-text-tertiary">Signing Secret <span className="font-normal">(optional for link buttons)</span></label>
+                <input
+                  type="password"
+                  value={signingSecret}
+                  onChange={e => { setSigningSecret(e.target.value); setError(null) }}
+                  placeholder="Slack app signing secret"
+                  className="mt-1 block w-full text-sm rounded border border-border-default bg-surface-0 text-text-primary px-3 py-1.5 focus:outline-none focus:ring-1 focus:ring-brand/30 focus:border-brand placeholder:text-text-tertiary"
+                />
+              </div>
+            )}
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => saveMut.mutate()}
+                disabled={saveMut.isPending || !canSave}
+                className="px-4 py-1.5 text-sm rounded bg-brand text-surface-0 hover:bg-brand-strong disabled:opacity-50"
+              >
+                {saveMut.isPending ? 'Saving…' : 'Save'}
+              </button>
+              {configured && (
+                <button
+                  onClick={() => { setExpanded(false); setError(null) }}
+                  className="text-sm text-text-tertiary hover:text-text-primary"
+                >
+                  Cancel
+                </button>
+              )}
+            </div>
+          </div>
+        )}
+
+        {configured && !expanded && (
+          <div className="ml-10 flex items-center gap-3 text-sm">
+            <span className="text-success">Configured</span>
+            <span className="text-text-tertiary">{slack?.config?.mode === 'openclaw_agent' ? 'OpenClaw Agent' : 'Direct Slack'}</span>
+            <button onClick={() => testMut.mutate()} disabled={testMut.isPending} className="text-brand hover:underline disabled:opacity-50">
+              Test
+            </button>
+            <button onClick={() => setExpanded(true)} className="text-text-tertiary hover:text-text-primary">
+              Edit
+            </button>
+            <button onClick={() => deleteMut.mutate()} disabled={deleteMut.isPending} className="text-danger/70 hover:text-danger disabled:opacity-50">
+              Remove
+            </button>
+            {testResult === 'success' && <span className="text-success">Sent</span>}
+            {testResult === 'error' && <span className="text-danger">Failed</span>}
+          </div>
+        )}
       </div>
     </section>
   )


### PR DESCRIPTION
## Summary

This adds Slack as a first-class approval notification channel alongside the existing dashboard, Telegram, and push approval flows. Users can configure either direct Slack delivery or an `openclaw_agent` mode for Slack Agent by OpenClaw channels from Settings.

## What changed

- Added a Slack notifier that posts approval, task approval, scope expansion, connection, activation, test, and alert messages via Slack `chat.postMessage`.
- Added optional signed Slack Block Kit approve/deny interactions for direct Slack mode when a Slack signing secret is configured, including Slack request-signature validation and one-use callback tokens.
- Added a dashboard deep-link fallback for Slack approvals when no signing secret is configured, and for the Slack Agent by OpenClaw mode so Clawvisor remains the approval authority.
- Added vault-backed storage for Slack bot tokens and signing secrets, with plaintext JSON only used by the existing no-notifier test fallback path.
- Added Redis-backed Slack callback token storage for multi-instance deployments.
- Updated the multi-notifier to preserve per-channel message IDs so approval result updates route back to the right Slack, Telegram, or push notifier.
- Added `/api/notifications/slack`, `/api/notifications/slack/test`, and `/api/notifications/slack/interactions` routes and Settings UI controls for Slack mode, bot token, channel ID, and signing secret.
- Updated docs and setup/integration guidance to describe configured notification channels instead of Telegram-only approval wording.

## Security notes

Slack signing secrets are required for native Slack button callbacks; unsigned Slack setups only get dashboard deep-link buttons. Callback tokens are short-lived and one-use, Slack request timestamps are bounded to a five-minute window, and Slack API error responses are not echoed back into logs/API errors to avoid leaking downstream response content.

## Validation

- `cd web && npm run lint`
- `cd web && npm run build`
- `git diff --check`

I could not run `go test` or `gofmt` in this workspace because `go` and `gofmt` are not installed/on PATH.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

