### PR TITLE
fix(config): treat the Terraform placeholder as unconfigured for Slack

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -150,10 +150,33 @@ type SlackConfig struct {
 	PublicURL string `yaml:"public_url"`
 }
 
-// Enabled reports whether the Slack app credentials are present. A caller
-// also needs a non-empty CallbackBaseURL before approvals can run.
+// terraformPlaceholder is the body Terraform writes into a Secret Manager slot
+// it provisions but cannot populate.
+//
+// Cloud Run has to be able to resolve a secret reference before anyone has
+// pasted the real value, so the slot is created with this stand-in. Treating
+// it as a configured value is worse than treating it as absent: Slack would be
+// advertised in the settings UI, the install would fail against a bogus client
+// secret, and — because the signing secret is the only credential on the
+// unauthenticated interaction endpoint — every button click would be rejected
+// as an invalid signature, with no indication that the cause was unfinished
+// setup. Mirrors the same guard on the Google Ads credentials.
+const terraformPlaceholder = "REPLACE_ME"
+
+func isPlaceholder(v string) bool {
+	return strings.EqualFold(strings.TrimSpace(v), terraformPlaceholder)
+}
+
+// configured reports whether a value is present and is not Terraform's
+// placeholder.
+func configured(v string) bool {
+	return strings.TrimSpace(v) != "" && !isPlaceholder(v)
+}
+
+// Enabled reports whether the Slack app credentials are present and real. A
+// caller also needs a non-empty CallbackBaseURL before approvals can run.
 func (c SlackConfig) Enabled() bool {
-	return c.ClientID != "" && c.ClientSecret != "" && c.SigningSecret != ""
+	return configured(c.ClientID) && configured(c.ClientSecret) && configured(c.SigningSecret)
 }
 
 // CallbackBaseURL returns the origin Slack should call back to, preferring

--- a/pkg/config/slack_callback_test.go
+++ b/pkg/config/slack_callback_test.go
@@ -87,3 +87,35 @@ func TestSlackEnabledIgnoresCallbackURL(t *testing.T) {
 		}
 	}
 }
+
+// Terraform provisions the Secret Manager slots with a "REPLACE_ME" body so
+// Cloud Run can resolve the reference before anyone pastes real values.
+// Treating that as configured would advertise Slack in the UI and then reject
+// every interaction as an invalid signature, with nothing pointing at
+// unfinished setup as the cause.
+func TestSlackEnabled_RejectsTerraformPlaceholder(t *testing.T) {
+	real := SlackConfig{ClientID: "id", ClientSecret: "secret", SigningSecret: "sign"}
+	if !real.Enabled() {
+		t.Fatal("fully-configured Slack reported disabled")
+	}
+
+	for _, tc := range []struct {
+		name string
+		cfg  SlackConfig
+	}{
+		{"client id is the placeholder", SlackConfig{ClientID: "REPLACE_ME", ClientSecret: "s", SigningSecret: "g"}},
+		{"client secret is the placeholder", SlackConfig{ClientID: "i", ClientSecret: "REPLACE_ME", SigningSecret: "g"}},
+		{"signing secret is the placeholder", SlackConfig{ClientID: "i", ClientSecret: "s", SigningSecret: "REPLACE_ME"}},
+		{"all three", SlackConfig{ClientID: "REPLACE_ME", ClientSecret: "REPLACE_ME", SigningSecret: "REPLACE_ME"}},
+		// Casing and stray whitespace must not smuggle it past the guard.
+		{"lowercase", SlackConfig{ClientID: "i", ClientSecret: "s", SigningSecret: "replace_me"}},
+		{"padded", SlackConfig{ClientID: "i", ClientSecret: "s", SigningSecret: "  REPLACE_ME  "}},
+		{"whitespace-only value", SlackConfig{ClientID: "i", ClientSecret: "   ", SigningSecret: "g"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.cfg.Enabled() {
+				t.Fatal("placeholder or blank credential reported as enabled")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Follow-up to #677, needed before the Terraform change that provisions the Slack secrets can be applied.

Terraform creates Secret Manager slots with a `REPLACE_ME` body so Cloud Run can resolve the reference before anyone has pasted real values — the same pattern Stripe and Google Ads already use, and the same trap [cloud#228](https://github.com/clawvisor/cloud/pull/228) fixed for Ads.

Without this guard, `terraform apply` with the Slack flag on makes `Enabled()` true against three placeholder strings:

- the settings UI advertises a Slack connection that cannot work
- the OAuth install fails against a bogus client secret
- every button click is rejected as an invalid signature, since the signing secret is the only credential on the unauthenticated interaction endpoint

None of those symptoms point at unfinished setup, which is what makes it worth guarding rather than documenting.

Blank-but-present values are rejected on the same path, so a variable that reaches the container as `""` no longer reads as configured-but-empty.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

