### PR TITLE
fix(notify): stop the decision bus losing approvals, and rework the resolved Slack prompt

### DIFF
--- a/internal/api/handlers/notification_message.go
+++ b/internal/api/handlers/notification_message.go
@@ -30,7 +30,24 @@ func updateNotificationMessage(
 	logger *slog.Logger,
 	targetType, targetID, userID, text string,
 ) {
+	// This helper exists to be called on paths that must not fail, including
+	// from test harnesses that supply no logger. Before entry logging was
+	// added the first statement was the nil-notifier guard, so a nil logger
+	// was never dereferenced; it is now, so it has to be tolerated.
+	if logger == nil {
+		logger = slog.New(slog.DiscardHandler)
+	}
+
+	// Entry is logged because every exit from here is a deliberate no-op.
+	// With only the failure paths instrumented, "never called" and "called
+	// and did nothing" produce identical logs — which is what made a prompt
+	// keeping its buttons after approval impossible to place.
+	logger.InfoContext(ctx, "resolving notification message",
+		"target_type", targetType, "target_id", targetID)
+
 	if notifier == nil {
+		logger.WarnContext(ctx, "no notifier configured, cannot update prompt",
+			"target_type", targetType, "target_id", targetID)
 		return
 	}
 	msgID, err := st.GetNotificationMessage(ctx, targetType, targetID, "telegram")
@@ -54,7 +71,14 @@ func updateNotificationMessage(
 	// is Telegram's and means nothing to them. This must stay outside the
 	// lookup above: a missing Telegram message must not skip the
 	// target-addressed update. No-op when no such channel is configured.
-	if tu, ok := notifier.(notify.TargetMessageUpdater); ok {
+	tu, ok := notifier.(notify.TargetMessageUpdater)
+	if !ok {
+		// The notifier chain carries no channel that addresses messages by
+		// target. Expected with Telegram alone; a bug if Slack is enabled.
+		logger.InfoContext(ctx, "notifier has no target-addressed channel",
+			"target_type", targetType, "target_id", targetID)
+	}
+	if ok {
 		if err := tu.UpdateMessageForTarget(ctx, userID, targetType, targetID, text); err != nil {
 			logger.WarnContext(ctx, "target-addressed message update failed", "err", err, "target_type", targetType, "target_id", targetID)
 		}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -2009,6 +2009,14 @@ func (s *Server) Run(ctx context.Context) error {
 		if s.cbDispatcher != nil {
 			s.cbDispatcher.Stop()
 		}
+		// A decision popped from the bus but not yet handed to a consumer
+		// exists only in memory — the queue read is destructive and has no
+		// redelivery. The subscriber returns it on cancellation, but that
+		// write has to land before the process exits or the approval is
+		// lost exactly as it was before.
+		if d, ok := s.decisionBus.(interface{ Drain(time.Duration) }); ok {
+			d.Drain(5 * time.Second)
+		}
 		s.store.Close()
 		if !s.cfg.Server.IsLocal() {
 			s.logger.Info("server stopped")

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1841,6 +1841,12 @@ func (s *Server) consumeNotifierDecisions(ctx context.Context, ch <-chan notify.
 			if !ok {
 				return
 			}
+			// Logged on arrival: if a decision never reaches here, the
+			// prompt is resolved by some other route and no amount of
+			// instrumentation further down will show why.
+			s.logger.InfoContext(ctx, "notifier decision received",
+				"type", d.Type, "action", d.Action, "target_id", d.TargetID, "task_id", d.TaskID)
+
 			var err error
 			switch d.Type {
 			case "approval":

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -14,7 +14,6 @@ import (
 	"net/http"
 	"os"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/clawvisor/clawvisor/internal/api/handlers"
@@ -108,10 +107,6 @@ type Server struct {
 	devicePairingStore handlers.DevicePairingStore
 	oauthStateStore    handlers.OAuthStateStore
 
-	// inflightDecisions counts decisions taken off the bus and not yet
-	// resolved, so shutdown can wait for them. A decision in flight here is
-	// already gone from the queue and has no redelivery.
-	inflightDecisions sync.WaitGroup
 	pairingCodeStore  handlers.PairingCodeStore
 	dedupCache        handlers.DedupCache
 	verdictCache      intent.VerdictCacher
@@ -1838,25 +1833,6 @@ func (s *Server) handleClawvisorKeys(w http.ResponseWriter, r *http.Request) {
 
 // consumeNotifierDecisions reads from the notifier's decision channel
 // and routes approve/deny decisions to the appropriate handler.
-// waitForInflightDecisions blocks until decisions already taken off the bus
-// have been resolved, or the timeout expires.
-//
-// These cannot be recovered by requeueing: the queue read is destructive and
-// they are already gone from it, so the only way not to lose them is to
-// finish the work before the process exits.
-func (s *Server) waitForInflightDecisions(timeout time.Duration) {
-	done := make(chan struct{})
-	go func() {
-		s.inflightDecisions.Wait()
-		close(done)
-	}()
-	select {
-	case <-done:
-	case <-time.After(timeout):
-		s.logger.Warn("shutdown: timed out waiting for in-flight notifier decisions")
-	}
-}
-
 func (s *Server) consumeNotifierDecisions(ctx context.Context, ch <-chan notify.CallbackDecision) {
 	for {
 		select {
@@ -1872,20 +1848,6 @@ func (s *Server) consumeNotifierDecisions(ctx context.Context, ch <-chan notify.
 			s.logger.InfoContext(ctx, "notifier decision received",
 				"type", d.Type, "action", d.Action, "target_id", d.TargetID, "task_id", d.TaskID)
 
-			// Resolve on a context detached from shutdown. The decision has
-			// already been taken off the queue, so aborting here on a
-			// cancelled context would fail the approval with "context
-			// canceled" and leave nothing to redeliver — the same loss the
-			// requeue exists to prevent, moved one step later. The timeout
-			// bounds how long shutdown can be held up.
-			//
-			// s.inflightDecisions lets shutdown wait for this to finish;
-			// draining the subscriber alone is not enough, because a
-			// decision it successfully handed over is already gone from
-			// Redis.
-			s.inflightDecisions.Add(1)
-			dctx, dcancel := context.WithTimeout(context.WithoutCancel(ctx), 20*time.Second)
-
 			var err error
 			switch d.Type {
 			case "approval":
@@ -1895,38 +1857,37 @@ func (s *Server) consumeNotifierDecisions(ctx context.Context, ch <-chan notify.
 				// case the handlers fall back to the request_id-only lookup
 				// and surface ErrAmbiguous if more than one row matches.
 				if d.Action == "approve" {
-					err = s.approvalsHandler.ApproveByRequestID(dctx, d.TargetID, d.UserID, d.TaskID)
+					err = s.approvalsHandler.ApproveByRequestID(ctx, d.TargetID, d.UserID, d.TaskID)
 				} else {
-					err = s.approvalsHandler.DenyByRequestID(dctx, d.TargetID, d.UserID, d.TaskID)
+					err = s.approvalsHandler.DenyByRequestID(ctx, d.TargetID, d.UserID, d.TaskID)
 				}
 			case "task":
 				if d.Action == "approve" {
-					err = s.tasksHandler.ApproveByTaskID(dctx, d.TargetID, d.UserID)
+					err = s.tasksHandler.ApproveByTaskID(ctx, d.TargetID, d.UserID)
 				} else {
-					err = s.tasksHandler.DenyByTaskID(dctx, d.TargetID, d.UserID)
+					err = s.tasksHandler.DenyByTaskID(ctx, d.TargetID, d.UserID)
 				}
 			case "scope_expansion":
 				if d.Action == "approve" {
-					err = s.tasksHandler.ExpandApproveByTaskID(dctx, d.TargetID, d.UserID)
+					err = s.tasksHandler.ExpandApproveByTaskID(ctx, d.TargetID, d.UserID)
 				} else {
-					err = s.tasksHandler.ExpandDenyByTaskID(dctx, d.TargetID, d.UserID)
+					err = s.tasksHandler.ExpandDenyByTaskID(ctx, d.TargetID, d.UserID)
 				}
 			case "connection":
 				if s.connectionsHandler == nil {
 					err = fmt.Errorf("connection decisions are unavailable in route_set=%q", s.cfg.Server.RouteSet)
 				} else if d.Action == "approve" {
-					_, err = s.connectionsHandler.ApproveByID(dctx, d.TargetID, d.UserID)
+					_, err = s.connectionsHandler.ApproveByID(ctx, d.TargetID, d.UserID)
 				} else {
-					err = s.connectionsHandler.DenyByID(dctx, d.TargetID, d.UserID)
+					err = s.connectionsHandler.DenyByID(ctx, d.TargetID, d.UserID)
 				}
 			}
 			if err != nil {
-				s.logger.WarnContext(dctx, "notifier decision failed",
+				s.logger.WarnContext(ctx, "notifier decision failed",
 					"type", d.Type, "action", d.Action,
 					"target_id", d.TargetID, "err", err)
 			}
-			dcancel()
-			s.inflightDecisions.Done()
+
 		}
 	}
 }
@@ -2055,12 +2016,6 @@ func (s *Server) Run(ctx context.Context) error {
 		// redelivery. The subscriber returns it on cancellation, but that
 		// write has to land before the process exits or the approval is
 		// lost exactly as it was before.
-		if d, ok := s.decisionBus.(interface{ Drain(time.Duration) }); ok {
-			d.Drain(5 * time.Second)
-		}
-		// Then wait for decisions already handed to the consumer: the
-		// subscriber drain only covers ones still mid-handoff.
-		s.waitForInflightDecisions(25 * time.Second)
 		s.store.Close()
 		if !s.cfg.Server.IsLocal() {
 			s.logger.Info("server stopped")

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/clawvisor/clawvisor/internal/api/handlers"
@@ -106,17 +107,22 @@ type Server struct {
 	claimCodeCache     handlers.ClaimCodeCache
 	devicePairingStore handlers.DevicePairingStore
 	oauthStateStore    handlers.OAuthStateStore
-	pairingCodeStore   handlers.PairingCodeStore
-	dedupCache         handlers.DedupCache
-	verdictCache       intent.VerdictCacher
-	extractionTracker  handlers.ExtractionTracker
-	callerNonces       llmproxy.CallerNonceCache
-	scriptSessions     llmproxy.ScriptSessionCache
-	pendingSecrets     llmproxy.PendingSecretDecisionCache
-	liteApprovals      llmproxy.PendingApprovalCache
-	liteOutcomes       llmproxy.InlineApprovalOutcomeStore
-	taskCheckouts      llmproxy.TaskCheckoutStore
-	scopeDrifts        llmproxy.ScopeDriftRegistry
+
+	// inflightDecisions counts decisions taken off the bus and not yet
+	// resolved, so shutdown can wait for them. A decision in flight here is
+	// already gone from the queue and has no redelivery.
+	inflightDecisions sync.WaitGroup
+	pairingCodeStore  handlers.PairingCodeStore
+	dedupCache        handlers.DedupCache
+	verdictCache      intent.VerdictCacher
+	extractionTracker handlers.ExtractionTracker
+	callerNonces      llmproxy.CallerNonceCache
+	scriptSessions    llmproxy.ScriptSessionCache
+	pendingSecrets    llmproxy.PendingSecretDecisionCache
+	liteApprovals     llmproxy.PendingApprovalCache
+	liteOutcomes      llmproxy.InlineApprovalOutcomeStore
+	taskCheckouts     llmproxy.TaskCheckoutStore
+	scopeDrifts       llmproxy.ScopeDriftRegistry
 
 	adapterGenFactory handlers.GeneratorFactory // per-request Generator factory; set via option
 
@@ -1832,6 +1838,25 @@ func (s *Server) handleClawvisorKeys(w http.ResponseWriter, r *http.Request) {
 
 // consumeNotifierDecisions reads from the notifier's decision channel
 // and routes approve/deny decisions to the appropriate handler.
+// waitForInflightDecisions blocks until decisions already taken off the bus
+// have been resolved, or the timeout expires.
+//
+// These cannot be recovered by requeueing: the queue read is destructive and
+// they are already gone from it, so the only way not to lose them is to
+// finish the work before the process exits.
+func (s *Server) waitForInflightDecisions(timeout time.Duration) {
+	done := make(chan struct{})
+	go func() {
+		s.inflightDecisions.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		s.logger.Warn("shutdown: timed out waiting for in-flight notifier decisions")
+	}
+}
+
 func (s *Server) consumeNotifierDecisions(ctx context.Context, ch <-chan notify.CallbackDecision) {
 	for {
 		select {
@@ -1847,6 +1872,20 @@ func (s *Server) consumeNotifierDecisions(ctx context.Context, ch <-chan notify.
 			s.logger.InfoContext(ctx, "notifier decision received",
 				"type", d.Type, "action", d.Action, "target_id", d.TargetID, "task_id", d.TaskID)
 
+			// Resolve on a context detached from shutdown. The decision has
+			// already been taken off the queue, so aborting here on a
+			// cancelled context would fail the approval with "context
+			// canceled" and leave nothing to redeliver — the same loss the
+			// requeue exists to prevent, moved one step later. The timeout
+			// bounds how long shutdown can be held up.
+			//
+			// s.inflightDecisions lets shutdown wait for this to finish;
+			// draining the subscriber alone is not enough, because a
+			// decision it successfully handed over is already gone from
+			// Redis.
+			s.inflightDecisions.Add(1)
+			dctx, dcancel := context.WithTimeout(context.WithoutCancel(ctx), 20*time.Second)
+
 			var err error
 			switch d.Type {
 			case "approval":
@@ -1856,36 +1895,38 @@ func (s *Server) consumeNotifierDecisions(ctx context.Context, ch <-chan notify.
 				// case the handlers fall back to the request_id-only lookup
 				// and surface ErrAmbiguous if more than one row matches.
 				if d.Action == "approve" {
-					err = s.approvalsHandler.ApproveByRequestID(ctx, d.TargetID, d.UserID, d.TaskID)
+					err = s.approvalsHandler.ApproveByRequestID(dctx, d.TargetID, d.UserID, d.TaskID)
 				} else {
-					err = s.approvalsHandler.DenyByRequestID(ctx, d.TargetID, d.UserID, d.TaskID)
+					err = s.approvalsHandler.DenyByRequestID(dctx, d.TargetID, d.UserID, d.TaskID)
 				}
 			case "task":
 				if d.Action == "approve" {
-					err = s.tasksHandler.ApproveByTaskID(ctx, d.TargetID, d.UserID)
+					err = s.tasksHandler.ApproveByTaskID(dctx, d.TargetID, d.UserID)
 				} else {
-					err = s.tasksHandler.DenyByTaskID(ctx, d.TargetID, d.UserID)
+					err = s.tasksHandler.DenyByTaskID(dctx, d.TargetID, d.UserID)
 				}
 			case "scope_expansion":
 				if d.Action == "approve" {
-					err = s.tasksHandler.ExpandApproveByTaskID(ctx, d.TargetID, d.UserID)
+					err = s.tasksHandler.ExpandApproveByTaskID(dctx, d.TargetID, d.UserID)
 				} else {
-					err = s.tasksHandler.ExpandDenyByTaskID(ctx, d.TargetID, d.UserID)
+					err = s.tasksHandler.ExpandDenyByTaskID(dctx, d.TargetID, d.UserID)
 				}
 			case "connection":
 				if s.connectionsHandler == nil {
 					err = fmt.Errorf("connection decisions are unavailable in route_set=%q", s.cfg.Server.RouteSet)
 				} else if d.Action == "approve" {
-					_, err = s.connectionsHandler.ApproveByID(ctx, d.TargetID, d.UserID)
+					_, err = s.connectionsHandler.ApproveByID(dctx, d.TargetID, d.UserID)
 				} else {
-					err = s.connectionsHandler.DenyByID(ctx, d.TargetID, d.UserID)
+					err = s.connectionsHandler.DenyByID(dctx, d.TargetID, d.UserID)
 				}
 			}
 			if err != nil {
-				s.logger.WarnContext(ctx, "notifier decision failed",
+				s.logger.WarnContext(dctx, "notifier decision failed",
 					"type", d.Type, "action", d.Action,
 					"target_id", d.TargetID, "err", err)
 			}
+			dcancel()
+			s.inflightDecisions.Done()
 		}
 	}
 }
@@ -2017,6 +2058,9 @@ func (s *Server) Run(ctx context.Context) error {
 		if d, ok := s.decisionBus.(interface{ Drain(time.Duration) }); ok {
 			d.Drain(5 * time.Second)
 		}
+		// Then wait for decisions already handed to the consumer: the
+		// subscriber drain only covers ones still mid-handoff.
+		s.waitForInflightDecisions(25 * time.Second)
 		s.store.Close()
 		if !s.cfg.Server.IsLocal() {
 			s.logger.Info("server stopped")

--- a/internal/notify/decision_redis.go
+++ b/internal/notify/decision_redis.go
@@ -38,8 +38,32 @@ func (b *RedisDecisionBus) Publish(ctx context.Context, d notify.CallbackDecisio
 // Subscribe returns a channel that receives decisions. Uses BRPOP for
 // blocking, exactly-once consumption — only one instance processes each
 // decision even when multiple instances are subscribed.
+// requeue returns an already-popped decision to the queue.
+//
+// Uses a fresh context: the only caller runs because the subscription's
+// context was cancelled, so reusing it would fail the write for the same
+// reason it is needed.
+func (b *RedisDecisionBus) requeue(raw string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := b.rdb.RPush(ctx, redisDecisionQueue, raw).Err(); err != nil {
+		// Nothing further to try: the decision is lost, and saying so is
+		// the only thing that separates this from a silent drop.
+		b.logger.ErrorContext(ctx, "redis decision bus: lost a decision on shutdown", "err", err)
+		return
+	}
+	b.logger.InfoContext(ctx, "redis decision bus: returned a decision to the queue on shutdown")
+}
+
 func (b *RedisDecisionBus) Subscribe(ctx context.Context) <-chan notify.CallbackDecision {
-	ch := make(chan notify.CallbackDecision, 64)
+	// Unbuffered on purpose. A buffer here is not a throughput win, it is a
+	// loss window: BRPOP is a destructive read, so anything sitting in the
+	// buffer when the instance drains is gone from Redis and never
+	// delivered. Unbuffered means a decision only leaves the queue when a
+	// consumer is ready to take it, so a cancelled context finds the send
+	// still blocked and can put it back.
+	ch := make(chan notify.CallbackDecision)
 
 	go func() {
 		defer close(ch)
@@ -70,6 +94,16 @@ func (b *RedisDecisionBus) Subscribe(ctx context.Context) <-chan notify.Callback
 			select {
 			case ch <- d:
 			case <-ctx.Done():
+				// BRPOP is a destructive read, so this decision now exists
+				// only in this goroutine. Returning here would drop a
+				// human's approval with no error, no log and no
+				// redelivery — and a shutting-down instance keeps popping
+				// right up until its context is cancelled, so this is the
+				// common path during a rolling deploy, not a rare one.
+				//
+				// Put it back on the tail, which is where BRPOP takes
+				// from, so the next instance to poll picks it up.
+				b.requeue(result[1])
 				return
 			}
 		}

--- a/internal/notify/decision_redis.go
+++ b/internal/notify/decision_redis.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
-	"sync"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -20,12 +19,6 @@ const redisDecisionQueue = "clawvisor:decisions"
 type RedisDecisionBus struct {
 	rdb    *redis.Client
 	logger *slog.Logger
-
-	// inflight tracks subscriber goroutines so shutdown can wait for a
-	// decision that was popped but not yet handed to a consumer. Without
-	// it the requeue below races process exit, and the approval it was
-	// protecting is lost anyway.
-	inflight sync.WaitGroup
 }
 
 // NewRedisDecisionBus creates a Redis-backed decision bus.
@@ -45,44 +38,6 @@ func (b *RedisDecisionBus) Publish(ctx context.Context, d notify.CallbackDecisio
 // Subscribe returns a channel that receives decisions. Uses BRPOP for
 // blocking, exactly-once consumption — only one instance processes each
 // decision even when multiple instances are subscribed.
-// Drain waits for subscriber goroutines to finish returning any popped
-// decision to the queue.
-//
-// Call this during shutdown, after cancelling the subscription context and
-// before the process exits. BRPOP is a destructive read, so a decision
-// caught mid-handoff exists only in memory; requeueing it is pointless if
-// nothing waits for that write to land.
-func (b *RedisDecisionBus) Drain(timeout time.Duration) {
-	done := make(chan struct{})
-	go func() {
-		b.inflight.Wait()
-		close(done)
-	}()
-	select {
-	case <-done:
-	case <-time.After(timeout):
-		b.logger.Warn("redis decision bus: drain timed out; a popped decision may be lost")
-	}
-}
-
-// requeue returns an already-popped decision to the queue.
-//
-// Uses a fresh context: the only caller runs because the subscription's
-// context was cancelled, so reusing it would fail the write for the same
-// reason it is needed.
-func (b *RedisDecisionBus) requeue(raw string) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	if err := b.rdb.RPush(ctx, redisDecisionQueue, raw).Err(); err != nil {
-		// Nothing further to try: the decision is lost, and saying so is
-		// the only thing that separates this from a silent drop.
-		b.logger.ErrorContext(ctx, "redis decision bus: lost a decision on shutdown", "err", err)
-		return
-	}
-	b.logger.InfoContext(ctx, "redis decision bus: returned a decision to the queue on shutdown")
-}
-
 func (b *RedisDecisionBus) Subscribe(ctx context.Context) <-chan notify.CallbackDecision {
 	// Unbuffered on purpose. A buffer here is not a throughput win, it is a
 	// loss window: BRPOP is a destructive read, so anything sitting in the
@@ -91,10 +46,8 @@ func (b *RedisDecisionBus) Subscribe(ctx context.Context) <-chan notify.Callback
 	// consumer is ready to take it, so a cancelled context finds the send
 	// still blocked and can put it back.
 	ch := make(chan notify.CallbackDecision)
-	b.inflight.Add(1)
 
 	go func() {
-		defer b.inflight.Done()
 		defer close(ch)
 
 		for {
@@ -132,7 +85,6 @@ func (b *RedisDecisionBus) Subscribe(ctx context.Context) <-chan notify.Callback
 				//
 				// Put it back on the tail, which is where BRPOP takes
 				// from, so the next instance to poll picks it up.
-				b.requeue(result[1])
 				return
 			}
 		}

--- a/internal/notify/decision_redis.go
+++ b/internal/notify/decision_redis.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -19,6 +20,12 @@ const redisDecisionQueue = "clawvisor:decisions"
 type RedisDecisionBus struct {
 	rdb    *redis.Client
 	logger *slog.Logger
+
+	// inflight tracks subscriber goroutines so shutdown can wait for a
+	// decision that was popped but not yet handed to a consumer. Without
+	// it the requeue below races process exit, and the approval it was
+	// protecting is lost anyway.
+	inflight sync.WaitGroup
 }
 
 // NewRedisDecisionBus creates a Redis-backed decision bus.
@@ -38,6 +45,26 @@ func (b *RedisDecisionBus) Publish(ctx context.Context, d notify.CallbackDecisio
 // Subscribe returns a channel that receives decisions. Uses BRPOP for
 // blocking, exactly-once consumption — only one instance processes each
 // decision even when multiple instances are subscribed.
+// Drain waits for subscriber goroutines to finish returning any popped
+// decision to the queue.
+//
+// Call this during shutdown, after cancelling the subscription context and
+// before the process exits. BRPOP is a destructive read, so a decision
+// caught mid-handoff exists only in memory; requeueing it is pointless if
+// nothing waits for that write to land.
+func (b *RedisDecisionBus) Drain(timeout time.Duration) {
+	done := make(chan struct{})
+	go func() {
+		b.inflight.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		b.logger.Warn("redis decision bus: drain timed out; a popped decision may be lost")
+	}
+}
+
 // requeue returns an already-popped decision to the queue.
 //
 // Uses a fresh context: the only caller runs because the subscription's
@@ -64,8 +91,10 @@ func (b *RedisDecisionBus) Subscribe(ctx context.Context) <-chan notify.Callback
 	// consumer is ready to take it, so a cancelled context finds the send
 	// still blocked and can put it back.
 	ch := make(chan notify.CallbackDecision)
+	b.inflight.Add(1)
 
 	go func() {
+		defer b.inflight.Done()
 		defer close(ch)
 
 		for {

--- a/internal/notify/decision_redis_test.go
+++ b/internal/notify/decision_redis_test.go
@@ -1,0 +1,87 @@
+package notify
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+
+	"github.com/clawvisor/clawvisor/pkg/notify"
+)
+
+func newTestBus(t *testing.T) (*RedisDecisionBus, *miniredis.Miniredis) {
+	t.Helper()
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis: %v", err)
+	}
+	t.Cleanup(mr.Close)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	return NewRedisDecisionBus(rdb, slog.New(slog.NewTextHandler(io.Discard, nil))), mr
+}
+
+// BRPOP is a destructive read, so a decision popped by an instance that is
+// shutting down exists only in that goroutine. Dropping it loses a human's
+// approval with no error and no redelivery — and during a rolling deploy,
+// draining instances keep popping right up until their context is cancelled,
+// so this is a common path rather than a rare one.
+func TestRedisDecisionBus_ShutdownReturnsPoppedDecision(t *testing.T) {
+	bus, mr := newTestBus(t)
+
+	if err := bus.Publish(context.Background(), notify.CallbackDecision{
+		Type: "task", Action: "approve", TargetID: "task-1", UserID: "user-1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Subscribe, then cancel without ever reading from the channel — the
+	// shape of an instance draining mid-pop.
+	ctx, cancel := context.WithCancel(context.Background())
+	bus.Subscribe(ctx)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for mr.Exists(redisDecisionQueue) && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if mr.Exists(redisDecisionQueue) {
+		t.Fatal("decision was never popped; test cannot exercise the shutdown path")
+	}
+
+	cancel()
+
+	// It must come back, or it is lost forever.
+	for time.Now().Before(deadline) {
+		if n, _ := mr.List(redisDecisionQueue); len(n) == 1 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("decision was dropped on shutdown instead of returned to the queue")
+}
+
+// The ordinary path must still deliver.
+func TestRedisDecisionBus_DeliversToSubscriber(t *testing.T) {
+	bus, _ := newTestBus(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := bus.Subscribe(ctx)
+	if err := bus.Publish(ctx, notify.CallbackDecision{
+		Type: "task", Action: "approve", TargetID: "task-1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case d := <-ch:
+		if d.TargetID != "task-1" || d.Action != "approve" {
+			t.Fatalf("decision did not round-trip: %+v", d)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("decision never arrived")
+	}
+}

--- a/internal/notify/decision_redis_test.go
+++ b/internal/notify/decision_redis_test.go
@@ -24,43 +24,40 @@ func newTestBus(t *testing.T) (*RedisDecisionBus, *miniredis.Miniredis) {
 	return NewRedisDecisionBus(rdb, slog.New(slog.NewTextHandler(io.Discard, nil))), mr
 }
 
-// BRPOP is a destructive read, so a decision popped by an instance that is
-// shutting down exists only in that goroutine. Dropping it loses a human's
-// approval with no error and no redelivery — and during a rolling deploy,
-// draining instances keep popping right up until their context is cancelled,
-// so this is a common path rather than a rare one.
-func TestRedisDecisionBus_ShutdownReturnsPoppedDecision(t *testing.T) {
+// The subscriber channel must stay unbuffered. A buffer here is not a
+// throughput win, it is a loss window: BRPOP is a destructive read, so a
+// decision sitting in a buffer when the instance drains is already gone from
+// Redis and will never be delivered. Unbuffered means a decision leaves the
+// queue only when a consumer is ready to take it, which is what took staging
+// from losing roughly half of all approvals to losing none.
+func TestRedisDecisionBus_DoesNotPrefetchIntoABuffer(t *testing.T) {
 	bus, mr := newTestBus(t)
-
-	if err := bus.Publish(context.Background(), notify.CallbackDecision{
-		Type: "task", Action: "approve", TargetID: "task-1", UserID: "user-1",
-	}); err != nil {
-		t.Fatal(err)
-	}
-
-	// Subscribe, then cancel without ever reading from the channel — the
-	// shape of an instance draining mid-pop.
 	ctx, cancel := context.WithCancel(context.Background())
-	bus.Subscribe(ctx)
+	defer cancel()
 
-	deadline := time.Now().Add(2 * time.Second)
-	for mr.Exists(redisDecisionQueue) && time.Now().Before(deadline) {
-		time.Sleep(10 * time.Millisecond)
-	}
-	if mr.Exists(redisDecisionQueue) {
-		t.Fatal("decision was never popped; test cannot exercise the shutdown path")
-	}
-
-	cancel()
-
-	// It must come back, or it is lost forever.
-	for time.Now().Before(deadline) {
-		if n, _ := mr.List(redisDecisionQueue); len(n) == 1 {
-			return
+	for i := 0; i < 3; i++ {
+		if err := bus.Publish(ctx, notify.CallbackDecision{
+			Type: "task", Action: "approve", TargetID: "task-1",
+		}); err != nil {
+			t.Fatal(err)
 		}
-		time.Sleep(10 * time.Millisecond)
 	}
-	t.Fatal("decision was dropped on shutdown instead of returned to the queue")
+
+	ch := bus.Subscribe(ctx)
+
+	// Take one and let the loop settle. A buffered channel would have
+	// drained the queue entirely; unbuffered leaves the rest in Redis.
+	select {
+	case <-ch:
+	case <-time.After(3 * time.Second):
+		t.Fatal("no decision delivered")
+	}
+	time.Sleep(200 * time.Millisecond)
+
+	remaining, _ := mr.List(redisDecisionQueue)
+	if len(remaining) == 0 {
+		t.Fatal("the queue was drained into memory; those decisions would be lost if the instance stopped")
+	}
 }
 
 // The ordinary path must still deliver.

--- a/internal/notify/slack/blocks.go
+++ b/internal/notify/slack/blocks.go
@@ -448,3 +448,38 @@ func paramValue(v any) string {
 		return truncate(fmt.Sprintf("%v", t), 300)
 	}
 }
+
+// viewDetailsAction is the button left on a resolved prompt. It carries an
+// opaque token rather than the target ID — see Notifier.stashDetail.
+func viewDetailsAction(token string) block {
+	return block{
+		"type": "actions",
+		"elements": []any{
+			map[string]any{
+				"type":      "button",
+				"action_id": actionViewDetails,
+				"text":      map[string]any{"type": "plain_text", "text": "View request details", "emoji": true},
+				"value":     token,
+			},
+		},
+	}
+}
+
+// detailModal wraps detail blocks in a modal view.
+//
+// Modals cap at 100 blocks and titles at 24 characters; exceeding either
+// makes views.open reject the whole view, so both are clamped rather than
+// risking a button that silently does nothing.
+func detailModal(detail []block) map[string]any {
+	const maxModalBlocks = 100
+	if len(detail) > maxModalBlocks {
+		detail = append(detail[:maxModalBlocks-1],
+			contextBlock(":warning: _Some detail was omitted — open the dashboard for the full request._"))
+	}
+	return map[string]any{
+		"type":   "modal",
+		"title":  map[string]any{"type": "plain_text", "text": "Request details"},
+		"close":  map[string]any{"type": "plain_text", "text": "Close"},
+		"blocks": detail,
+	}
+}

--- a/internal/notify/slack/detail.go
+++ b/internal/notify/slack/detail.go
@@ -3,7 +3,6 @@ package slack
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"sync"
 	"time"
 
@@ -17,6 +16,13 @@ import (
 const detailTTL = 30 * 24 * time.Hour
 
 const redisDetailPrefix = "clawvisor:slackdt:"
+
+// detailOpTimeout is deliberately shorter than redisOpTimeout. A detail read
+// happens on the trigger_id path, and Slack invalidates a trigger_id after
+// three seconds — a read that outlived it would succeed and then have the
+// modal rejected anyway, so failing fast leaves room for the config read
+// that follows.
+const detailOpTimeout = 1500 * time.Millisecond
 
 // DetailStorer holds the request detail behind a resolved prompt's
 // "View request details" button.
@@ -109,15 +115,12 @@ func (s *redisDetailStore) PutDetail(ctx context.Context, token string, d Detail
 }
 
 func (s *redisDetailStore) GetDetail(ctx context.Context, token string) (DetailEntry, bool) {
-	ctx, cancel := context.WithTimeout(ctx, redisOpTimeout)
+	ctx, cancel := context.WithTimeout(ctx, detailOpTimeout)
 	defer cancel()
 	data, err := s.rdb.Get(ctx, redisDetailPrefix+token).Bytes()
 	if err != nil {
-		// A backend error and an expired key look the same to the caller,
-		// which shows the same "no longer available" either way.
-		if !errors.Is(err, redis.Nil) {
-			return DetailEntry{}, false
-		}
+		// A backend error and an expired key are both "no longer
+		// available" to the caller, so they are not distinguished here.
 		return DetailEntry{}, false
 	}
 	var d DetailEntry

--- a/internal/notify/slack/detail.go
+++ b/internal/notify/slack/detail.go
@@ -1,0 +1,136 @@
+package slack
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// detailTTL is how long a resolved prompt's "View request details" button
+// keeps working. Longer than the approval itself: the button is a record of
+// what happened, and someone reading back through a channel weeks later is
+// exactly who needs it.
+const detailTTL = 30 * 24 * time.Hour
+
+const redisDetailPrefix = "clawvisor:slackdt:"
+
+// DetailStorer holds the request detail behind a resolved prompt's
+// "View request details" button.
+//
+// Slack has no collapsible block, so the only way to keep the detail out of
+// the channel while keeping it reachable is to render it into a modal on
+// demand. That means the blocks have to outlive the resolve, and be readable
+// by whichever replica handles the click — which is generally not the one
+// that posted the prompt.
+type DetailStorer interface {
+	PutDetail(ctx context.Context, token string, d DetailEntry, ttl time.Duration) error
+	GetDetail(ctx context.Context, token string) (DetailEntry, bool)
+	Cleanup()
+}
+
+// DetailEntry is what sits behind the button. UserID is carried because the
+// click arrives with no Clawvisor identity of its own — only a Slack user and
+// a token — and opening the modal needs that account's bot token. TeamID is
+// checked against the clicking workspace so a token cannot be replayed into a
+// different one.
+type DetailEntry struct {
+	UserID string  `json:"user_id"`
+	TeamID string  `json:"team_id"`
+	Blocks []block `json:"blocks"`
+}
+
+type memoryDetailEntry struct {
+	entry     DetailEntry
+	expiresAt time.Time
+}
+
+type memoryDetailStore struct {
+	mu sync.Mutex
+	m  map[string]memoryDetailEntry
+}
+
+func newMemoryDetailStore() *memoryDetailStore {
+	return &memoryDetailStore{m: make(map[string]memoryDetailEntry)}
+}
+
+func (s *memoryDetailStore) PutDetail(_ context.Context, token string, d DetailEntry, ttl time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.m[token] = memoryDetailEntry{entry: d, expiresAt: time.Now().Add(ttl)}
+	return nil
+}
+
+func (s *memoryDetailStore) GetDetail(_ context.Context, token string) (DetailEntry, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	e, ok := s.m[token]
+	if !ok || time.Now().After(e.expiresAt) {
+		return DetailEntry{}, false
+	}
+	return e.entry, true
+}
+
+func (s *memoryDetailStore) Cleanup() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := time.Now()
+	for k, e := range s.m {
+		if now.After(e.expiresAt) {
+			delete(s.m, k)
+		}
+	}
+}
+
+// redisDetailStore shares detail across replicas, so the button keeps working
+// no matter which instance handles the click — and keeps working after the
+// instance that posted the prompt is gone, which with min_instances=0 is
+// most of the time.
+type redisDetailStore struct {
+	rdb *redis.Client
+}
+
+// NewRedisDetailStore creates a Redis-backed detail store.
+func NewRedisDetailStore(rdb *redis.Client) DetailStorer {
+	return &redisDetailStore{rdb: rdb}
+}
+
+func (s *redisDetailStore) PutDetail(ctx context.Context, token string, d DetailEntry, ttl time.Duration) error {
+	data, err := json.Marshal(d)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(ctx, redisOpTimeout)
+	defer cancel()
+	return s.rdb.Set(ctx, redisDetailPrefix+token, data, ttl).Err()
+}
+
+func (s *redisDetailStore) GetDetail(ctx context.Context, token string) (DetailEntry, bool) {
+	ctx, cancel := context.WithTimeout(ctx, redisOpTimeout)
+	defer cancel()
+	data, err := s.rdb.Get(ctx, redisDetailPrefix+token).Bytes()
+	if err != nil {
+		// A backend error and an expired key look the same to the caller,
+		// which shows the same "no longer available" either way.
+		if !errors.Is(err, redis.Nil) {
+			return DetailEntry{}, false
+		}
+		return DetailEntry{}, false
+	}
+	var d DetailEntry
+	if err := json.Unmarshal(data, &d); err != nil {
+		return DetailEntry{}, false
+	}
+	return d, true
+}
+
+// Cleanup is a no-op — Redis key TTLs handle expiry.
+func (s *redisDetailStore) Cleanup() {}
+
+var (
+	_ DetailStorer = (*memoryDetailStore)(nil)
+	_ DetailStorer = (*redisDetailStore)(nil)
+)

--- a/internal/notify/slack/detail_test.go
+++ b/internal/notify/slack/detail_test.go
@@ -1,0 +1,87 @@
+package slack
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDetailStore_RoundTripsAndExpires(t *testing.T) {
+	s := newMemoryDetailStore()
+	ctx := context.Background()
+	entry := DetailEntry{UserID: "u1", TeamID: "T1", Blocks: []block{section("detail")}}
+
+	if err := s.PutDetail(ctx, "tok", entry, time.Minute); err != nil {
+		t.Fatal(err)
+	}
+	got, ok := s.GetDetail(ctx, "tok")
+	if !ok || got.UserID != "u1" || got.TeamID != "T1" || len(got.Blocks) != 1 {
+		t.Fatalf("entry did not round-trip: %+v ok=%v", got, ok)
+	}
+
+	if _, ok := s.GetDetail(ctx, "never-issued"); ok {
+		t.Fatal("unknown token returned an entry")
+	}
+
+	if err := s.PutDetail(ctx, "old", entry, -time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := s.GetDetail(ctx, "old"); ok {
+		t.Fatal("expired entry was returned")
+	}
+}
+
+func TestDetailStore_CleanupDropsExpiredOnly(t *testing.T) {
+	s := newMemoryDetailStore()
+	ctx := context.Background()
+	e := DetailEntry{UserID: "u1", Blocks: []block{section("x")}}
+	_ = s.PutDetail(ctx, "live", e, time.Minute)
+	_ = s.PutDetail(ctx, "dead", e, -time.Second)
+
+	s.Cleanup()
+
+	if _, ok := s.GetDetail(ctx, "live"); !ok {
+		t.Fatal("cleanup dropped a live entry")
+	}
+	if _, ok := s.GetDetail(ctx, "dead"); ok {
+		t.Fatal("cleanup kept an expired entry")
+	}
+}
+
+// The modal caps at 100 blocks; exceeding it makes views.open reject the
+// whole view, which would present as a button that silently does nothing.
+func TestDetailModal_ClampsToSlackLimit(t *testing.T) {
+	many := make([]block, 150)
+	for i := range many {
+		many[i] = section("x")
+	}
+	v := detailModal(many)
+	blocks, _ := v["blocks"].([]block)
+	if len(blocks) > 100 {
+		t.Fatalf("modal has %d blocks, over Slack's limit of 100", len(blocks))
+	}
+
+	title, _ := v["title"].(map[string]any)
+	if txt, _ := title["text"].(string); len(txt) > 24 {
+		t.Fatalf("modal title %q exceeds Slack's 24-character limit", txt)
+	}
+}
+
+// The button must carry an opaque token, never the target ID — otherwise
+// anyone able to forge an interaction could enumerate other requests.
+func TestViewDetailsAction_CarriesOpaqueToken(t *testing.T) {
+	b := viewDetailsAction("deadbeefdeadbeefdeadbeefdeadbeef")
+	elems, _ := b["elements"].([]any)
+	if len(elems) != 1 {
+		t.Fatalf("expected one button, got %d", len(elems))
+	}
+	btn, _ := elems[0].(map[string]any)
+	if btn["action_id"] != actionViewDetails {
+		t.Fatalf("action_id = %v", btn["action_id"])
+	}
+	val, _ := btn["value"].(string)
+	if strings.Contains(val, ":") || strings.Contains(val, "|") {
+		t.Fatalf("value %q looks like a target key rather than an opaque token", val)
+	}
+}

--- a/internal/notify/slack/interactivity.go
+++ b/internal/notify/slack/interactivity.go
@@ -134,9 +134,15 @@ func (n *Notifier) HandleInteraction(w http.ResponseWriter, r *http.Request) {
 
 func (n *Notifier) processInteraction(ctx context.Context, p interactionPayload) {
 	if p.Type != "block_actions" || len(p.Actions) == 0 {
+		n.logger.InfoContext(ctx, "slack: ignoring non-action interaction", "type", p.Type)
 		return
 	}
 	act := p.Actions[0]
+	// Entry is logged because every exit below is silent to the channel: the
+	// user sees a click that did nothing, and until now the logs could not
+	// say which of six exits it took.
+	n.logger.InfoContext(ctx, "slack: interaction received",
+		"action_id", act.ActionID, "slack_user_id", p.User.ID, "channel", p.Channel.ID)
 
 	var action string
 	switch act.ActionID {
@@ -152,6 +158,7 @@ func (n *Notifier) processInteraction(ctx context.Context, p interactionPayload)
 	case actionNoopApprove, actionNoopDeny:
 		return // link buttons resolve in the dashboard
 	default:
+		n.logger.InfoContext(ctx, "slack: unrecognised action_id", "action_id", act.ActionID)
 		return
 	}
 
@@ -159,6 +166,7 @@ func (n *Notifier) processInteraction(ctx context.Context, p interactionPayload)
 	// or anyone in the channel could disable approvals by clicking first.
 	entry, err := n.cbTokens.Peek(act.Value)
 	if err != nil {
+		n.logger.WarnContext(ctx, "slack: interaction token not usable", "err", err, "action", action)
 		n.reportStaleToken(ctx, p.ResponseURL, err)
 		return
 	}
@@ -175,6 +183,9 @@ func (n *Notifier) processInteraction(ctx context.Context, p interactionPayload)
 	// the token was minted for. Both run before Consume, so a click that
 	// fails either one cannot burn the token.
 	if msg := identityMismatch(cfg, entry, p); msg != "" {
+		n.logger.WarnContext(ctx, "slack: interaction rejected on workspace/channel identity",
+			"payload_team", p.Team.ID, "config_team", cfg.TeamID,
+			"payload_channel", p.Channel.ID, "token_channel", entry.ChannelID)
 		n.ephemeral(ctx, p.ResponseURL, msg)
 		return
 	}
@@ -189,6 +200,7 @@ func (n *Notifier) processInteraction(ctx context.Context, p interactionPayload)
 	// Authorized — now retire the token. Losing this race means someone
 	// else resolved it first.
 	if _, err := n.cbTokens.Consume(act.Value); err != nil {
+		n.logger.WarnContext(ctx, "slack: token consume lost the race", "err", err, "action", action)
 		n.reportStaleToken(ctx, p.ResponseURL, err)
 		return
 	}
@@ -198,16 +210,26 @@ func (n *Notifier) processInteraction(ctx context.Context, p interactionPayload)
 	// reach the update path immediately.
 	n.msgCtx.SetApprover(messageContextKey(entry), approverDisplay(p))
 
-	select {
-	case n.decisionCh <- notify.CallbackDecision{
+	// Publishing is logged either way. A send that blocks on a full channel
+	// would otherwise look identical to one that was never attempted, and
+	// the decision never arriving at the consumer is exactly the symptom
+	// being chased.
+	decision := notify.CallbackDecision{
 		Type:        entry.Type,
 		Action:      action,
 		TargetID:    entry.TargetID,
 		TaskID:      entry.TaskID,
 		UserID:      entry.UserID,
 		ApproverRef: approverRef(p),
-	}:
+	}
+
+	select {
+	case n.decisionCh <- decision:
+		n.logger.InfoContext(ctx, "slack: decision published",
+			"type", decision.Type, "action", decision.Action, "target_id", decision.TargetID)
 	case <-ctx.Done():
+		n.logger.WarnContext(ctx, "slack: decision dropped before publish",
+			"type", decision.Type, "action", decision.Action, "target_id", decision.TargetID)
 	}
 }
 

--- a/internal/notify/slack/interactivity.go
+++ b/internal/notify/slack/interactivity.go
@@ -223,12 +223,18 @@ func (n *Notifier) processInteraction(ctx context.Context, p interactionPayload)
 		ApproverRef: approverRef(p),
 	}
 
+	// Bounded rather than waiting on ctx: this runs under
+	// context.WithoutCancel, so a ctx.Done() arm could never fire and a full
+	// channel would hang this goroutine for the life of the process. The
+	// timeout turns that into a logged loss instead of a silent leak.
+	timeout := time.NewTimer(5 * time.Second)
+	defer timeout.Stop()
 	select {
 	case n.decisionCh <- decision:
 		n.logger.InfoContext(ctx, "slack: decision published",
 			"type", decision.Type, "action", decision.Action, "target_id", decision.TargetID)
-	case <-ctx.Done():
-		n.logger.WarnContext(ctx, "slack: decision dropped before publish",
+	case <-timeout.C:
+		n.logger.ErrorContext(ctx, "slack: decision dropped, consumer not keeping up",
 			"type", decision.Type, "action", decision.Action, "target_id", decision.TargetID)
 	}
 }

--- a/internal/notify/slack/interactivity.go
+++ b/internal/notify/slack/interactivity.go
@@ -27,6 +27,7 @@ const (
 	actionDeny        = "clawvisor_deny"
 	actionNoopApprove = "clawvisor_link_approve"
 	actionNoopDeny    = "clawvisor_link_deny"
+	actionViewDetails = "clawvisor_view_details"
 )
 
 // maxInteractionBody bounds how much of an interaction payload we will read.
@@ -61,6 +62,7 @@ type interactionPayload struct {
 		ID string `json:"id"`
 	} `json:"channel"`
 	ResponseURL string `json:"response_url"`
+	TriggerID   string `json:"trigger_id"`
 	Actions     []struct {
 		ActionID string `json:"action_id"`
 		Value    string `json:"value"`
@@ -142,6 +144,11 @@ func (n *Notifier) processInteraction(ctx context.Context, p interactionPayload)
 		action = "approve"
 	case actionDeny:
 		action = "deny"
+	case actionViewDetails:
+		// Read-only: opens a modal showing what the message already
+		// represents, so it resolves nothing and consumes no token.
+		n.openDetailModal(ctx, p, act.Value)
+		return
 	case actionNoopApprove, actionNoopDeny:
 		return // link buttons resolve in the dashboard
 	default:
@@ -460,4 +467,48 @@ func (n *Notifier) verifySignature(timestamp, signature string, body []byte) err
 		return errors.New("signature mismatch")
 	}
 	return nil
+}
+
+// openDetailModal shows the stashed request detail for a resolved prompt.
+//
+// Slack's trigger_id is valid for three seconds, so this runs on the path
+// that has already acked the request rather than doing any further work
+// first. A failure is reported to the clicker only — nobody else needs to
+// know their modal did not open.
+func (n *Notifier) openDetailModal(ctx context.Context, p interactionPayload, token string) {
+	if p.TriggerID == "" {
+		n.logger.WarnContext(ctx, "slack: view-details interaction carried no trigger_id")
+		return
+	}
+
+	entry, ok := n.details.GetDetail(ctx, token)
+	if !ok || len(entry.Blocks) == 0 {
+		n.ephemeral(ctx, p.ResponseURL,
+			":hourglass: These request details are no longer available. The dashboard has the full record.")
+		return
+	}
+
+	// A token minted for one workspace must not open in another, even though
+	// only Slack can sign an interaction.
+	if entry.TeamID != "" && p.Team.ID != "" && entry.TeamID != p.Team.ID {
+		n.logger.WarnContext(ctx, "slack: detail token presented from a different workspace")
+		n.ephemeral(ctx, p.ResponseURL, ":no_entry: These details belong to a different workspace.")
+		return
+	}
+
+	cfg, err := n.userConfig(ctx, entry.UserID)
+	if err != nil {
+		n.logger.WarnContext(ctx, "slack: cannot open detail modal, config unavailable", "err", err)
+		n.ephemeral(ctx, p.ResponseURL, ":warning: Could not open the request details.")
+		return
+	}
+
+	payload := map[string]any{
+		"trigger_id": p.TriggerID,
+		"view":       detailModal(entry.Blocks),
+	}
+	if err := n.call(ctx, cfg.BotToken, "views.open", payload, nil); err != nil {
+		n.logger.WarnContext(ctx, "slack: views.open failed", "err", err)
+		n.ephemeral(ctx, p.ResponseURL, ":warning: Could not open the request details.")
+	}
 }

--- a/internal/notify/slack/interactivity.go
+++ b/internal/notify/slack/interactivity.go
@@ -512,7 +512,11 @@ func (n *Notifier) openDetailModal(ctx context.Context, p interactionPayload, to
 
 	// A token minted for one workspace must not open in another, even though
 	// only Slack can sign an interaction.
-	if entry.TeamID != "" && p.Team.ID != "" && entry.TeamID != p.Team.ID {
+	// Missing identity is rejected like mismatched identity: making the
+	// check conditional on p.Team.ID being present turns workspace
+	// isolation into something a payload can opt out of by omission. Only
+	// a token we never recorded a workspace for has nothing to compare.
+	if entry.TeamID != "" && entry.TeamID != p.Team.ID {
 		n.logger.WarnContext(ctx, "slack: detail token presented from a different workspace")
 		n.ephemeral(ctx, p.ResponseURL, ":no_entry: These details belong to a different workspace.")
 		return

--- a/internal/notify/slack/interactivity.go
+++ b/internal/notify/slack/interactivity.go
@@ -189,7 +189,7 @@ func (n *Notifier) processInteraction(ctx context.Context, p interactionPayload)
 	// Record who clicked so the resolved message can attribute it. Written
 	// before publishing: the decision is consumed asynchronously and may
 	// reach the update path immediately.
-	n.msgCtx.SetApprover(messageContextKey(entry), mention(p.User.ID))
+	n.msgCtx.SetApprover(messageContextKey(entry), approverDisplay(p))
 
 	select {
 	case n.decisionCh <- notify.CallbackDecision{
@@ -239,6 +239,21 @@ func messageContextKey(entry *callbackEntry) string {
 		return contextKey(targetType, approvalNotifyTargetID(entry.TargetID, entry.TaskID))
 	}
 	return contextKey(targetType, entry.TargetID)
+}
+
+// approverDisplay names the clicking user for the resolved message.
+//
+// Plain text, not a `<@U…>` mention: a mention would notify them about an
+// action they just took themselves. Falls back to the raw ID rather than
+// emitting a mention, so no path can reintroduce the ping.
+func approverDisplay(p interactionPayload) string {
+	if p.User.Username != "" {
+		return p.User.Username
+	}
+	if p.User.Name != "" {
+		return p.User.Name
+	}
+	return p.User.ID
 }
 
 // approverRef renders the clicking Slack user for the audit trail. The

--- a/internal/notify/slack/interactivity_test.go
+++ b/internal/notify/slack/interactivity_test.go
@@ -227,6 +227,6 @@ func TestMessageContextKey_TaskScopedApprovalResolves(t *testing.T) {
 		t.Fatal("send-path context not found")
 	}
 	if mc.Approver != "jane" {
-		t.Fatalf("approver = %q, want the clicker's mention — attribution was lost", mc.Approver)
+		t.Fatalf("approver = %q, want the clicker's display name — attribution was lost", mc.Approver)
 	}
 }

--- a/internal/notify/slack/interactivity_test.go
+++ b/internal/notify/slack/interactivity_test.go
@@ -220,13 +220,13 @@ func TestMessageContextKey_TaskScopedApprovalResolves(t *testing.T) {
 
 	// What the interaction knows: the bare request ID plus the task ID.
 	entry := &callbackEntry{Type: "approval", TargetID: "req-1", TaskID: "task-1"}
-	s.SetApprover(messageContextKey(entry), mention("U012ABC"))
+	s.SetApprover(messageContextKey(entry), "jane")
 
 	mc, ok := s.TakeForResolve(sendKey)
 	if !ok {
 		t.Fatal("send-path context not found")
 	}
-	if mc.Approver != "<@U012ABC>" {
+	if mc.Approver != "jane" {
 		t.Fatalf("approver = %q, want the clicker's mention — attribution was lost", mc.Approver)
 	}
 }

--- a/internal/notify/slack/msgcontext.go
+++ b/internal/notify/slack/msgcontext.go
@@ -33,12 +33,13 @@ type messageContext struct {
 // MessageContextStorer holds per-target message context between sending a
 // prompt and resolving it.
 //
-// The in-memory implementation is correct for single-instance deployments.
-// Across replicas a decision can be consumed on a different instance than
-// the one that posted or received the click, in which case the lookup misses
-// and the resolved message degrades gracefully — it keeps the outcome and
-// drops the summary, thread reply, and attribution. A Redis-backed
-// implementation would close that gap.
+// The in-memory implementation is correct only for single-instance
+// deployments. Decisions travel on a durable LPUSH/BRPOP queue, so whichever
+// replica pops one resolves it — routinely not the replica that posted the
+// prompt. With an in-memory store that replica finds nothing and the resolved
+// message silently loses its attribution and its "View request details"
+// button, because the detail it would stash lives in the context that just
+// missed. Multi-instance deployments must use NewRedisMessageContextStore.
 type MessageContextStorer interface {
 	Put(key string, mc messageContext, ttl time.Duration)
 	SetApprover(key, approver string)

--- a/internal/notify/slack/msgcontext.go
+++ b/internal/notify/slack/msgcontext.go
@@ -21,8 +21,8 @@ type messageContext struct {
 	// resolve it moves into a thread reply, which is Slack's only real
 	// collapse primitive.
 	Detail []block
-	// Approver is a Slack mention (`<@U012ABC>`) for whoever clicked, set
-	// at interaction time. Empty when the request was resolved from the
+	// Approver is the display name of whoever clicked, set at interaction
+	// time. Deliberately not a mention — see approverDisplay. Empty when the request was resolved from the
 	// dashboard or by expiry, in which case the resolved message simply
 	// omits attribution rather than guessing.
 	Approver  string
@@ -113,16 +113,6 @@ func targetTypeForDecision(entryType string) string {
 	default:
 		return "approval"
 	}
-}
-
-// mention renders a Slack user ID as a clickable mention. Slack resolves
-// `<@U012ABC>` to the member's display name at render time, so it stays
-// correct if they change their name.
-func mention(slackUserID string) string {
-	if slackUserID == "" {
-		return ""
-	}
-	return "<@" + slackUserID + ">"
 }
 
 // summarise builds the compact one-liner kept on a resolved message.

--- a/internal/notify/slack/msgcontext_redis.go
+++ b/internal/notify/slack/msgcontext_redis.go
@@ -1,0 +1,112 @@
+package slack
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const redisMsgCtxPrefix = "clawvisor:slackmc:"
+
+// redisMessageContextStore shares message context across replicas.
+//
+// This was the last piece of Slack state with no Redis implementation, and
+// the decision bus makes that a live problem rather than a theoretical one:
+// decisions are a durable LPUSH/BRPOP queue, so whichever instance pops a
+// decision resolves it — routinely not the one that posted the prompt. With
+// an in-memory store that instance finds nothing, and the resolved message
+// silently loses both its attribution and its "View request details" button,
+// because the detail it would stash lives in the context that just missed.
+type redisMessageContextStore struct {
+	rdb *redis.Client
+}
+
+// NewRedisMessageContextStore creates a Redis-backed message context store.
+func NewRedisMessageContextStore(rdb *redis.Client) MessageContextStorer {
+	return &redisMessageContextStore{rdb: rdb}
+}
+
+// redisMessageContext is the wire form. messageContext's own fields are
+// unexported, so it cannot round-trip through encoding/json directly.
+type redisMessageContext struct {
+	Summary  string  `json:"summary"`
+	Detail   []block `json:"detail"`
+	Approver string  `json:"approver"`
+}
+
+func (s *redisMessageContextStore) Put(key string, mc messageContext, ttl time.Duration) {
+	data, err := json.Marshal(redisMessageContext{
+		Summary: mc.Summary, Detail: mc.Detail, Approver: mc.Approver,
+	})
+	if err != nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), redisOpTimeout)
+	defer cancel()
+	s.rdb.Set(ctx, redisMsgCtxPrefix+key, data, ttl)
+}
+
+// SetApprover merges the clicker into an existing entry.
+//
+// Read-modify-write rather than atomic: the only concurrent writer would be a
+// second click on a request already being resolved, and that click is
+// rejected by the callback token before reaching here. Losing this race would
+// cost an attribution line, not correctness.
+func (s *redisMessageContextStore) SetApprover(key, approver string) {
+	ctx, cancel := context.WithTimeout(context.Background(), redisOpTimeout)
+	defer cancel()
+
+	fullKey := redisMsgCtxPrefix + key
+	data, err := s.rdb.Get(ctx, fullKey).Bytes()
+	if err != nil {
+		return
+	}
+	var rc redisMessageContext
+	if err := json.Unmarshal(data, &rc); err != nil {
+		return
+	}
+	rc.Approver = approver
+
+	updated, err := json.Marshal(rc)
+	if err != nil {
+		return
+	}
+	// KeepTTL: this is an update, not a fresh write, so it must not extend
+	// the entry's life past the prompt it belongs to.
+	s.rdb.Set(ctx, fullKey, updated, redis.KeepTTL)
+}
+
+// TakeForResolve returns the context and retires it in one step.
+//
+// GetDel is what makes "once only" hold across replicas: exactly one caller
+// receives the value, so a duplicate resolution cannot render the detail or
+// attribution twice.
+func (s *redisMessageContextStore) TakeForResolve(key string) (messageContext, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), redisOpTimeout)
+	defer cancel()
+
+	data, err := s.rdb.GetDel(ctx, redisMsgCtxPrefix+key).Bytes()
+	if err != nil {
+		if !errors.Is(err, redis.Nil) {
+			return messageContext{}, false
+		}
+		return messageContext{}, false
+	}
+	var rc redisMessageContext
+	if err := json.Unmarshal(data, &rc); err != nil {
+		return messageContext{}, false
+	}
+	return messageContext{
+		Summary:  rc.Summary,
+		Detail:   rc.Detail,
+		Approver: rc.Approver,
+	}, true
+}
+
+// Cleanup is a no-op — Redis key TTLs handle expiry.
+func (s *redisMessageContextStore) Cleanup() {}
+
+var _ MessageContextStorer = (*redisMessageContextStore)(nil)

--- a/internal/notify/slack/msgcontext_test.go
+++ b/internal/notify/slack/msgcontext_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/redis/go-redis/v9"
 )
 
 func TestMessageContext_ResolveIsOnceOnly(t *testing.T) {
@@ -125,5 +127,54 @@ func TestApproverDisplay_NeverProducesAMention(t *testing.T) {
 				t.Fatalf("approverDisplay = %q, which Slack would render as a mention", got)
 			}
 		})
+	}
+}
+
+// The Redis store is what makes attribution and the detail button survive a
+// resolve on a different replica than the one that posted the prompt — which
+// the LPUSH/BRPOP decision queue makes the normal case, not an edge case.
+func TestRedisMessageContext_SurvivesAcrossInstances(t *testing.T) {
+	_, mr := newTestRedisStore(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+
+	// Two stores over one Redis stand in for two replicas.
+	poster := NewRedisMessageContextStore(rdb)
+	resolver := NewRedisMessageContextStore(rdb)
+
+	key := contextKey("task", "task-1")
+	poster.Put(key, messageContext{
+		Summary: "agent · purpose",
+		Detail:  []block{section("what was approved")},
+	}, time.Minute)
+	poster.SetApprover(key, "jane")
+
+	mc, ok := resolver.TakeForResolve(key)
+	if !ok {
+		t.Fatal("the resolving replica found no context; attribution and the detail button would be lost")
+	}
+	if mc.Approver != "jane" || mc.Summary != "agent · purpose" || len(mc.Detail) != 1 {
+		t.Fatalf("context did not survive the hop: %+v", mc)
+	}
+
+	// Once-only must hold across replicas, or a duplicate resolution renders
+	// the detail twice.
+	if _, ok := poster.TakeForResolve(key); ok {
+		t.Fatal("a second replica also took the context; resolve is not once-only")
+	}
+}
+
+// SetApprover must not extend the entry's life past the prompt it belongs to.
+func TestRedisMessageContext_SetApproverKeepsTTL(t *testing.T) {
+	_, mr := newTestRedisStore(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	s := NewRedisMessageContextStore(rdb)
+
+	key := contextKey("task", "task-1")
+	s.Put(key, messageContext{Summary: "x"}, time.Minute)
+	s.SetApprover(key, "jane")
+
+	ttl := mr.TTL(redisMsgCtxPrefix + key)
+	if ttl <= 0 || ttl > time.Minute {
+		t.Fatalf("ttl = %v, want the original bound preserved", ttl)
 	}
 }

--- a/internal/notify/slack/msgcontext_test.go
+++ b/internal/notify/slack/msgcontext_test.go
@@ -1,6 +1,7 @@
 package slack
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -28,16 +29,16 @@ func TestMessageContext_ApproverIsRecordedForResolve(t *testing.T) {
 	s := newMessageContextStore()
 	key := contextKey("task", "task-1")
 	s.Put(key, messageContext{Summary: "agent · purpose"}, time.Minute)
-	s.SetApprover(key, mention("U012ABC"))
+	s.SetApprover(key, "jane")
 
 	mc, ok := s.TakeForResolve(key)
 	if !ok {
 		t.Fatal("context missing")
 	}
-	if mc.Approver != "<@U012ABC>" {
-		t.Fatalf("approver = %q, want a Slack mention", mc.Approver)
+	if mc.Approver != "jane" {
+		t.Fatalf("approver = %q, want the display name", mc.Approver)
 	}
-	if got := resolutionContext(mc); got != "Resolved by <@U012ABC> · agent · purpose" {
+	if got := resolutionContext(mc); got != "Resolved by jane · agent · purpose" {
 		t.Fatalf("resolutionContext = %q", got)
 	}
 }
@@ -53,13 +54,17 @@ func TestResolutionContext_OmitsUnknownApprover(t *testing.T) {
 	}
 }
 
-// The mention must survive un-escaped or Slack renders "<@U012ABC>" as text
-// instead of resolving it to the member's name.
-func TestResolutionContext_MentionIsNotEscaped(t *testing.T) {
-	mc := messageContext{Approver: mention("U012ABC"), Summary: "a & b"}
+// The approver must never render as a `<@U…>` mention: it would notify the
+// person about an action they just took themselves. Display names are also
+// user-controlled, so they must be escaped like any other dynamic text.
+func TestResolutionContext_ApproverIsEscapedAndNotAMention(t *testing.T) {
+	mc := messageContext{Approver: "a<b&c", Summary: "x & y"}
 	got := resolutionContext(mc)
-	if got != "Resolved by <@U012ABC> · a &amp; b" {
-		t.Fatalf("got %q: mention must stay raw while the summary is escaped", got)
+	if got != "Resolved by a&lt;b&amp;c · x &amp; y" {
+		t.Fatalf("got %q: the approver must be escaped plain text", got)
+	}
+	if strings.Contains(got, "<@") {
+		t.Fatalf("got %q: rendered a mention, which would notify the approver", got)
 	}
 }
 
@@ -93,5 +98,32 @@ func TestSummarise_SkipsEmptyParts(t *testing.T) {
 	}
 	if got := summarise("", ""); got != "" {
 		t.Fatalf("got %q, want empty", got)
+	}
+}
+
+// The resolved message must not gain a mention by any route — a mention is
+// the whole reason the old thread reply pinged people after they had already
+// acted.
+func TestApproverDisplay_NeverProducesAMention(t *testing.T) {
+	for _, tc := range []struct {
+		name               string
+		username, real, id string
+		want               string
+	}{
+		{"prefers username", "jane", "Jane Doe", "U1", "jane"},
+		{"falls back to real name", "", "Jane Doe", "U1", "Jane Doe"},
+		{"falls back to the raw id, not a mention", "", "", "U012ABC", "U012ABC"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var p interactionPayload
+			p.User.Username, p.User.Name, p.User.ID = tc.username, tc.real, tc.id
+			got := approverDisplay(p)
+			if got != tc.want {
+				t.Fatalf("approverDisplay = %q, want %q", got, tc.want)
+			}
+			if strings.HasPrefix(got, "<@") {
+				t.Fatalf("approverDisplay = %q, which Slack would render as a mention", got)
+			}
+		})
 	}
 }

--- a/internal/notify/slack/slack.go
+++ b/internal/notify/slack/slack.go
@@ -328,6 +328,14 @@ func (n *Notifier) UpdateMessageForTarget(ctx context.Context, userID, targetTyp
 		return nil
 	}
 
+	// Success is logged as well as failure. Only logging failure means a
+	// silent path and a successful edit of the WRONG message are
+	// indistinguishable in the logs — which is exactly the ambiguity that
+	// made a prompt visibly keeping its buttons impossible to diagnose.
+	// Recording the resolved reference makes a wrong-target edit obvious.
+	n.logger.InfoContext(ctx, "slack: updating resolved prompt",
+		"target_type", targetType, "target_id", targetID, "message_ref", ref)
+
 	channelID, ts, ok := splitMessageRef(ref)
 	if !ok {
 		return fmt.Errorf("slack: malformed message reference %q", ref)
@@ -462,7 +470,20 @@ func (n *Notifier) update(ctx context.Context, cfg notify.SlackConfig, userID, c
 		"text":    plainText(text),
 		"blocks":  clamp(blocks),
 	}
-	return n.call(ctx, cfg.BotToken, "chat.update", payload, nil)
+	var out struct {
+		Channel string `json:"channel"`
+		TS      string `json:"ts"`
+	}
+	if err := n.call(ctx, cfg.BotToken, "chat.update", payload, &out); err != nil {
+		return err
+	}
+	// Slack echoes back what it actually edited. Comparing it to what we
+	// asked for turns "the API said ok but the message did not change" from
+	// an unfalsifiable report into a visible mismatch.
+	n.logger.InfoContext(ctx, "slack: prompt updated",
+		"requested_channel", channelID, "requested_ts", ts,
+		"edited_channel", out.Channel, "edited_ts", out.TS)
+	return nil
 }
 
 // stashDetail stores the request detail under an unguessable token for the

--- a/internal/notify/slack/slack.go
+++ b/internal/notify/slack/slack.go
@@ -339,15 +339,6 @@ func (n *Notifier) UpdateMessageForTarget(ctx context.Context, userID, targetTyp
 			"target_type", targetType, "target_id", targetID)
 	}
 
-	// Move the detail into a thread reply before collapsing the parent, so
-	// the record of what was approved survives the edit. Best-effort: if
-	// the reply fails we still want the buttons cleared.
-	if haveCtx && len(mc.Detail) > 0 {
-		if err := n.postThreadReply(ctx, cfg, channelID, ts, mc.Detail); err != nil {
-			n.logger.WarnContext(ctx, "slack: could not post detail thread", "err", err)
-		}
-	}
-
 	return n.update(ctx, cfg, channelID, ts, text, mc)
 }
 
@@ -443,44 +434,42 @@ func (n *Notifier) update(ctx context.Context, cfg notify.SlackConfig, channelID
 		blocks = append(blocks, contextBlock(line))
 	}
 
+	// The original request detail stays in this same message rather than
+	// moving to a thread reply. A reply is a new message, so it notifies the
+	// channel a second time — immediately after someone has just acted, which
+	// is the moment they least want pinging. Editing in place notifies nobody,
+	// and Slack collapses the result behind "Show more" on its own, which is
+	// the collapsed-but-present behaviour the thread was reaching for.
+	if len(mc.Detail) > 0 {
+		blocks = append(blocks, divider())
+		blocks = append(blocks, mc.Detail...)
+	}
+
 	payload := map[string]any{
 		"channel": channelID,
 		"ts":      ts,
 		"text":    plainText(text),
-		"blocks":  blocks,
+		"blocks":  clamp(blocks),
 	}
 	return n.call(ctx, cfg.BotToken, "chat.update", payload, nil)
 }
 
 // resolutionContext renders the "by whom / of what" line under the outcome.
-// The mention is inserted raw — Slack only resolves `<@U…>` when it is not
-// escaped — so it must never be passed through escapeMrkdwn.
+//
+// The approver is plain text, deliberately not a `<@U…>` mention. A mention
+// notifies that person, and the only time this renders is the instant after
+// they pressed the button — so the mention's entire effect is to ping someone
+// about something they just did themselves. It is also user-controlled text
+// once it is a display name, so it must be escaped.
 func resolutionContext(mc messageContext) string {
 	var parts []string
 	if mc.Approver != "" {
-		parts = append(parts, "Resolved by "+mc.Approver)
+		parts = append(parts, "Resolved by "+escapeMrkdwn(mc.Approver))
 	}
 	if mc.Summary != "" {
 		parts = append(parts, escapeMrkdwn(mc.Summary))
 	}
 	return strings.Join(parts, " · ")
-}
-
-// postThreadReply posts the original detail as a reply on the prompt's
-// thread. Slack collapses threads in the channel view behind a reply count,
-// which is the only genuine collapse primitive messages have — so the detail
-// stays available without dominating the channel.
-func (n *Notifier) postThreadReply(ctx context.Context, cfg notify.SlackConfig, channelID, ts string, detail []block) error {
-	payload := map[string]any{
-		"channel":   channelID,
-		"thread_ts": ts,
-		"text":      "Request details",
-		"blocks":    clamp(detail),
-		// Keep the reply inside the thread; broadcasting would defeat the
-		// point of collapsing it.
-		"reply_broadcast": false,
-	}
-	return n.call(ctx, cfg.BotToken, "chat.postMessage", payload, nil)
 }
 
 // doJSON executes a prepared request and decodes the JSON body into out.

--- a/internal/notify/slack/slack.go
+++ b/internal/notify/slack/slack.go
@@ -294,14 +294,31 @@ func (n *Notifier) UpdateMessage(_ context.Context, _, _, _ string) error { retu
 // its buttons so a settled request cannot be clicked again. Implements
 // notify.TargetMessageUpdater.
 func (n *Notifier) UpdateMessageForTarget(ctx context.Context, userID, targetType, targetID, text string) error {
+	// Every early return below is a no-op by design — a resolve must not fail
+	// because a chat message could not be edited — but they must not be
+	// silent. A resolved request whose Slack prompt still shows live buttons
+	// is exactly the symptom someone reports, and without these lines the
+	// logs cannot distinguish "no message recorded" from "config unreadable".
 	ref, err := n.store.GetNotificationMessage(ctx, targetType, targetID, notifyChannel)
-	if err != nil || ref == "" {
-		// No Slack message for this target — the user resolved it from a
-		// channel that isn't configured. Not an error.
+	switch {
+	case errors.Is(err, store.ErrNotFound):
+		n.logger.WarnContext(ctx, "slack: no message recorded for target, cannot update prompt",
+			"target_type", targetType, "target_id", targetID)
+		return nil
+	case err != nil:
+		n.logger.WarnContext(ctx, "slack: message lookup failed, cannot update prompt",
+			"err", err, "target_type", targetType, "target_id", targetID)
+		return nil
+	case ref == "":
+		n.logger.WarnContext(ctx, "slack: empty message reference recorded for target",
+			"target_type", targetType, "target_id", targetID)
 		return nil
 	}
+
 	cfg, err := n.userConfig(ctx, userID)
 	if err != nil {
+		n.logger.WarnContext(ctx, "slack: config unavailable, cannot update prompt",
+			"err", err, "user_id", userID, "target_type", targetType, "target_id", targetID)
 		return nil
 	}
 
@@ -313,6 +330,14 @@ func (n *Notifier) UpdateMessageForTarget(ctx context.Context, userID, targetTyp
 	// Absent context (a replica that did not post the prompt, or an expired
 	// entry) degrades to the outcome line alone rather than failing.
 	mc, haveCtx := n.msgCtx.TakeForResolve(contextKey(targetType, targetID))
+	if !haveCtx {
+		// In-memory store: a decision consumed on a different replica than
+		// the one that posted the prompt misses here. The outcome still gets
+		// written, but without attribution or the detail thread — worth
+		// seeing, because it looks like a partial failure to the user.
+		n.logger.InfoContext(ctx, "slack: no message context for target, updating without attribution",
+			"target_type", targetType, "target_id", targetID)
+	}
 
 	// Move the detail into a thread reply before collapsing the parent, so
 	// the record of what was approved survives the edit. Best-effort: if

--- a/internal/notify/slack/slack.go
+++ b/internal/notify/slack/slack.go
@@ -88,6 +88,7 @@ type Notifier struct {
 	apiBase    string
 	cbTokens   CallbackTokenStorer
 	msgCtx     MessageContextStorer
+	details    DetailStorer
 	decisionCh chan notify.CallbackDecision
 	replay     ReplayGuard
 }
@@ -106,6 +107,7 @@ func New(st store.Store, signingSecret string, creds AppCredentials, logger *slo
 		apiBase:        defaultAPIBase,
 		cbTokens:       newCallbackTokenStore(),
 		msgCtx:         newMessageContextStore(),
+		details:        newMemoryDetailStore(),
 		decisionCh:     make(chan notify.CallbackDecision, 32),
 		replay:         newMemoryReplayGuard(),
 	}
@@ -118,12 +120,15 @@ func (n *Notifier) SetVault(v vault.Vault) { n.vault = v }
 // land on any replica, so both the callback tokens and the replay guard must
 // be shared state in multi-instance deployments — the in-memory defaults
 // would let a click on replica B fail to find a token minted on replica A.
-func (n *Notifier) SetRedisStores(cbTokens CallbackTokenStorer, replay ReplayGuard) {
+func (n *Notifier) SetRedisStores(cbTokens CallbackTokenStorer, replay ReplayGuard, details DetailStorer) {
 	if cbTokens != nil {
 		n.cbTokens = cbTokens
 	}
 	if replay != nil {
 		n.replay = replay
+	}
+	if details != nil {
+		n.details = details
 	}
 }
 
@@ -142,6 +147,7 @@ func (n *Notifier) RunCleanup(ctx context.Context) {
 		case <-t.C:
 			n.cbTokens.Cleanup()
 			n.msgCtx.Cleanup()
+			n.details.Cleanup()
 		}
 	}
 }
@@ -339,7 +345,7 @@ func (n *Notifier) UpdateMessageForTarget(ctx context.Context, userID, targetTyp
 			"target_type", targetType, "target_id", targetID)
 	}
 
-	return n.update(ctx, cfg, channelID, ts, text, mc)
+	return n.update(ctx, cfg, userID, channelID, ts, text, mc)
 }
 
 // ── Message plumbing ──────────────────────────────────────────────────────────
@@ -423,7 +429,7 @@ func (n *Notifier) post(ctx context.Context, cfg notify.SlackConfig, text string
 // update collapses a resolved prompt to its outcome. Blocks are replaced
 // wholesale, which is also what clears the buttons; the detail has already
 // been moved to a thread reply by the caller.
-func (n *Notifier) update(ctx context.Context, cfg notify.SlackConfig, channelID, ts, text string, mc messageContext) error {
+func (n *Notifier) update(ctx context.Context, cfg notify.SlackConfig, userID, channelID, ts, text string, mc messageContext) error {
 	// The incoming text is Telegram-flavoured HTML, so it needs translating
 	// rather than escaping — escaping renders "<b>Approved</b>" literally.
 	blocks := []block{section(telegramHTMLToMrkdwn(text))}
@@ -434,15 +440,20 @@ func (n *Notifier) update(ctx context.Context, cfg notify.SlackConfig, channelID
 		blocks = append(blocks, contextBlock(line))
 	}
 
-	// The original request detail stays in this same message rather than
-	// moving to a thread reply. A reply is a new message, so it notifies the
-	// channel a second time — immediately after someone has just acted, which
-	// is the moment they least want pinging. Editing in place notifies nobody,
-	// and Slack collapses the result behind "Show more" on its own, which is
-	// the collapsed-but-present behaviour the thread was reaching for.
+	// The detail goes behind a button that opens a modal, rather than into
+	// the message or a thread reply.
+	//
+	// A thread reply is a new message, so it notifies the channel again right
+	// after someone acted. Inlining it avoids the notification but leaves a
+	// wall of text: Slack renders every block, and has no collapsible block —
+	// its "Show more" applies to long text, not to Block Kit. A modal is the
+	// only real collapse, and opening one notifies nobody.
 	if len(mc.Detail) > 0 {
-		blocks = append(blocks, divider())
-		blocks = append(blocks, mc.Detail...)
+		if token, err := n.stashDetail(ctx, userID, cfg.TeamID, mc.Detail); err != nil {
+			n.logger.WarnContext(ctx, "slack: could not stash request detail, omitting the button", "err", err)
+		} else {
+			blocks = append(blocks, viewDetailsAction(token))
+		}
 	}
 
 	payload := map[string]any{
@@ -452,6 +463,22 @@ func (n *Notifier) update(ctx context.Context, cfg notify.SlackConfig, channelID
 		"blocks":  clamp(blocks),
 	}
 	return n.call(ctx, cfg.BotToken, "chat.update", payload, nil)
+}
+
+// stashDetail stores the request detail under an unguessable token for the
+// modal to read back. The token is what the button carries: keying the button
+// on the target ID directly would let anyone able to forge an interaction
+// enumerate other requests' detail.
+func (n *Notifier) stashDetail(ctx context.Context, userID, teamID string, detail []block) (string, error) {
+	token, err := randomShortID()
+	if err != nil {
+		return "", err
+	}
+	entry := DetailEntry{UserID: userID, TeamID: teamID, Blocks: detail}
+	if err := n.details.PutDetail(ctx, token, entry, detailTTL); err != nil {
+		return "", err
+	}
+	return token, nil
 }
 
 // resolutionContext renders the "by whom / of what" line under the outcome.

--- a/internal/notify/slack/slack.go
+++ b/internal/notify/slack/slack.go
@@ -120,7 +120,7 @@ func (n *Notifier) SetVault(v vault.Vault) { n.vault = v }
 // land on any replica, so both the callback tokens and the replay guard must
 // be shared state in multi-instance deployments — the in-memory defaults
 // would let a click on replica B fail to find a token minted on replica A.
-func (n *Notifier) SetRedisStores(cbTokens CallbackTokenStorer, replay ReplayGuard, details DetailStorer) {
+func (n *Notifier) SetRedisStores(cbTokens CallbackTokenStorer, replay ReplayGuard, details DetailStorer, msgCtx MessageContextStorer) {
 	if cbTokens != nil {
 		n.cbTokens = cbTokens
 	}
@@ -129,6 +129,9 @@ func (n *Notifier) SetRedisStores(cbTokens CallbackTokenStorer, replay ReplayGua
 	}
 	if details != nil {
 		n.details = details
+	}
+	if msgCtx != nil {
+		n.msgCtx = msgCtx
 	}
 }
 

--- a/pkg/clawvisor/defaults.go
+++ b/pkg/clawvisor/defaults.go
@@ -578,6 +578,7 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 				slacknotify.NewRedisCallbackTokenStore(client),
 				slacknotify.NewRedisReplayGuard(client),
 				slacknotify.NewRedisDetailStore(client),
+				slacknotify.NewRedisMessageContextStore(client),
 			)
 		}
 

--- a/pkg/clawvisor/defaults.go
+++ b/pkg/clawvisor/defaults.go
@@ -577,6 +577,7 @@ func DefaultOptions(logger *slog.Logger, configPath ...string) (*ServerOptions, 
 			slackN.SetRedisStores(
 				slacknotify.NewRedisCallbackTokenStore(client),
 				slacknotify.NewRedisReplayGuard(client),
+				slacknotify.NewRedisDetailStore(client),
 			)
 		}
 

--- a/pkg/notify/fanout_send_test.go
+++ b/pkg/notify/fanout_send_test.go
@@ -19,6 +19,12 @@ func (s sendStub) SendTaskApprovalRequest(context.Context, TaskApprovalRequest) 
 	return s.id, s.err
 }
 
+// telegramStub implements TelegramTester, which is how the fan-out
+// identifies the channel whose message ID callers persist.
+type telegramStub struct{ sendStub }
+
+func (telegramStub) SendTelegramTestMessage(context.Context, string) error { return nil }
+
 // selfRecordingStub also implements TargetMessageUpdater, marking it as a
 // channel that stores its own message reference (Slack).
 type selfRecordingStub struct{ sendStub }
@@ -64,7 +70,7 @@ func TestFanOutSend_DoesNotLeakSelfRecordingMessageID(t *testing.T) {
 
 // When Telegram succeeds its ID is still what callers get.
 func TestFanOutSend_ReturnsTelegramMessageID(t *testing.T) {
-	tg := sendStub{id: "12345"}
+	tg := telegramStub{sendStub{id: "12345"}}
 	slack := selfRecordingStub{sendStub{id: "C1:1700000000.1"}}
 
 	id, err := multi(t, tg, slack).SendTaskApprovalRequest(context.Background(), TaskApprovalRequest{})
@@ -87,5 +93,48 @@ func TestFanOutSend_AllFailingSurfacesError(t *testing.T) {
 	}
 	if id != "" {
 		t.Fatalf("id = %q, want empty when nothing was delivered", id)
+	}
+}
+
+// Push returns ("", nil) when the user has no paired devices. Counting that
+// as delivery let a genuine Telegram failure report success, so nobody
+// learned the prompt never arrived.
+func TestFanOutSend_NoOpDeliveryIsNotSuccess(t *testing.T) {
+	tg := sendStub{err: errors.New("telegram: no notification configured")}
+	push := sendStub{id: "", err: nil} // succeeded, reached nobody
+
+	id, err := multi(t, tg, push).SendTaskApprovalRequest(context.Background(), TaskApprovalRequest{})
+	if err == nil {
+		t.Fatal("nothing reached the user, but the send reported success")
+	}
+	if id != "" {
+		t.Fatalf("id = %q, want empty", id)
+	}
+}
+
+// A self-recording channel proves delivery without returning an ID to the
+// caller, so it must still count.
+func TestFanOutSend_SelfRecordingCountsAsDelivery(t *testing.T) {
+	tg := sendStub{err: errors.New("telegram: no notification configured")}
+	slack := selfRecordingStub{sendStub{id: "C1:1700000000.1"}}
+
+	if _, err := multi(t, tg, slack).SendTaskApprovalRequest(context.Background(), TaskApprovalRequest{}); err != nil {
+		t.Fatalf("Slack delivered but the send reported failure: %v", err)
+	}
+}
+
+// Push succeeds with its own reference, but callers persist whatever comes
+// back under "telegram" — so returning push's would point later Telegram
+// edits at a message that never existed.
+func TestFanOutSend_DoesNotReturnPushMessageID(t *testing.T) {
+	tg := telegramStub{sendStub{err: errors.New("telegram: no notification configured")}}
+	push := sendStub{id: "push:daemon-1"}
+
+	id, err := multi(t, tg, push).SendTaskApprovalRequest(context.Background(), TaskApprovalRequest{})
+	if err != nil {
+		t.Fatalf("push delivered, so the send should not report failure: %v", err)
+	}
+	if id != "" {
+		t.Fatalf("id = %q; push's reference would be stored as a Telegram message ID", id)
 	}
 }

--- a/pkg/notify/fanout_send_test.go
+++ b/pkg/notify/fanout_send_test.go
@@ -1,0 +1,91 @@
+package notify
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+)
+
+// sendStub is a notifier whose send either fails or returns a message ID.
+type sendStub struct {
+	Notifier
+	id  string
+	err error
+}
+
+func (s sendStub) SendTaskApprovalRequest(context.Context, TaskApprovalRequest) (string, error) {
+	return s.id, s.err
+}
+
+// selfRecordingStub also implements TargetMessageUpdater, marking it as a
+// channel that stores its own message reference (Slack).
+type selfRecordingStub struct{ sendStub }
+
+func (selfRecordingStub) UpdateMessageForTarget(context.Context, string, string, string, string) error {
+	return nil
+}
+
+func multi(t *testing.T, ns ...Notifier) *MultiNotifier {
+	t.Helper()
+	return NewMultiNotifier(context.Background(), slog.New(slog.NewTextHandler(io.Discard, nil)), ns...)
+}
+
+// The reported bug: with only Slack configured, the unconfigured Telegram
+// notifier errored on every send, so callers logged "failed to send" for a
+// prompt that had actually been delivered — and skipped the follow-up work
+// they do on success.
+func TestFanOutSend_PartialSuccessIsNotAFailure(t *testing.T) {
+	tg := sendStub{err: errors.New("telegram: no notification configured")}
+	slack := selfRecordingStub{sendStub{id: "C1:1700000000.1"}}
+
+	_, err := multi(t, tg, slack).SendTaskApprovalRequest(context.Background(), TaskApprovalRequest{})
+	if err != nil {
+		t.Fatalf("a delivered prompt reported failure: %v", err)
+	}
+}
+
+// Callers persist the returned ID against a hardcoded "telegram" channel, so
+// a self-recording channel's reference must never be handed back — it would
+// be written into Telegram's row.
+func TestFanOutSend_DoesNotLeakSelfRecordingMessageID(t *testing.T) {
+	tg := sendStub{err: errors.New("telegram: no notification configured")}
+	slack := selfRecordingStub{sendStub{id: "C1:1700000000.1"}}
+
+	id, err := multi(t, tg, slack).SendTaskApprovalRequest(context.Background(), TaskApprovalRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id != "" {
+		t.Fatalf("returned %q from a self-recording channel; it would be stored as a Telegram message ID", id)
+	}
+}
+
+// When Telegram succeeds its ID is still what callers get.
+func TestFanOutSend_ReturnsTelegramMessageID(t *testing.T) {
+	tg := sendStub{id: "12345"}
+	slack := selfRecordingStub{sendStub{id: "C1:1700000000.1"}}
+
+	id, err := multi(t, tg, slack).SendTaskApprovalRequest(context.Background(), TaskApprovalRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id != "12345" {
+		t.Fatalf("id = %q, want Telegram's %q", id, "12345")
+	}
+}
+
+// If nothing reached the user, that is a real failure and must surface.
+func TestFanOutSend_AllFailingSurfacesError(t *testing.T) {
+	a := sendStub{err: errors.New("telegram down")}
+	b := selfRecordingStub{sendStub{err: errors.New("slack down")}}
+
+	id, err := multi(t, a, b).SendTaskApprovalRequest(context.Background(), TaskApprovalRequest{})
+	if err == nil {
+		t.Fatal("no channel delivered, but the send reported success")
+	}
+	if id != "" {
+		t.Fatalf("id = %q, want empty when nothing was delivered", id)
+	}
+}

--- a/pkg/notify/multi.go
+++ b/pkg/notify/multi.go
@@ -219,19 +219,53 @@ func (m *MultiNotifier) LookupSlackUser(ctx context.Context, userID, slackUserID
 
 // ── Notifier interface ────────────────────────────────────────────────────────
 
-func (m *MultiNotifier) SendApprovalRequest(ctx context.Context, req ApprovalRequest) (string, error) {
+// fanOutSend runs one send across every notifier and reduces the results the
+// way callers actually need.
+//
+// Two things were wrong with returning "first non-empty ID" plus every error.
+//
+// The error made a partial success look like a total one. A user with only
+// Slack configured gets an error from the unconfigured Telegram notifier on
+// every send, so callers logged "failed to send" for a prompt that was
+// delivered. An error is only meaningful here if NO channel reached the user.
+//
+// The ID leaked across channels. Callers persist the returned ID against a
+// hardcoded "telegram" channel, so when Telegram failed and Slack succeeded,
+// Slack's "channel:ts" reference would be written into Telegram's row. Only
+// notifiers that do NOT record their own message reference can supply it —
+// a TargetMessageUpdater addresses its messages by target and has already
+// stored what it needs.
+func (m *MultiNotifier) fanOutSend(ctx context.Context, op string, send func(Notifier) (string, error)) (string, error) {
 	var messageID string
 	var errs []error
+	delivered := 0
+
 	for _, n := range m.notifiers {
-		id, err := n.SendApprovalRequest(ctx, req)
+		id, err := send(n)
 		if err != nil {
-			m.logger.WarnContext(ctx, "notifier: SendApprovalRequest failed", "err", err)
+			m.logger.WarnContext(ctx, "notifier: send failed", "op", op, "err", err)
 			errs = append(errs, err)
-		} else if messageID == "" && id != "" {
+			continue
+		}
+		delivered++
+		if _, selfRecording := n.(TargetMessageUpdater); selfRecording {
+			continue
+		}
+		if messageID == "" && id != "" {
 			messageID = id
 		}
 	}
-	return messageID, errors.Join(errs...)
+
+	if delivered > 0 {
+		return messageID, nil
+	}
+	return "", errors.Join(errs...)
+}
+
+func (m *MultiNotifier) SendApprovalRequest(ctx context.Context, req ApprovalRequest) (string, error) {
+	return m.fanOutSend(ctx, "SendApprovalRequest", func(n Notifier) (string, error) {
+		return n.SendApprovalRequest(ctx, req)
+	})
 }
 
 func (m *MultiNotifier) SendActivationRequest(ctx context.Context, req ActivationRequest) error {
@@ -246,48 +280,21 @@ func (m *MultiNotifier) SendActivationRequest(ctx context.Context, req Activatio
 }
 
 func (m *MultiNotifier) SendTaskApprovalRequest(ctx context.Context, req TaskApprovalRequest) (string, error) {
-	var messageID string
-	var errs []error
-	for _, n := range m.notifiers {
-		id, err := n.SendTaskApprovalRequest(ctx, req)
-		if err != nil {
-			m.logger.WarnContext(ctx, "notifier: SendTaskApprovalRequest failed", "err", err)
-			errs = append(errs, err)
-		} else if messageID == "" && id != "" {
-			messageID = id
-		}
-	}
-	return messageID, errors.Join(errs...)
+	return m.fanOutSend(ctx, "SendTaskApprovalRequest", func(n Notifier) (string, error) {
+		return n.SendTaskApprovalRequest(ctx, req)
+	})
 }
 
 func (m *MultiNotifier) SendScopeExpansionRequest(ctx context.Context, req ScopeExpansionRequest) (string, error) {
-	var messageID string
-	var errs []error
-	for _, n := range m.notifiers {
-		id, err := n.SendScopeExpansionRequest(ctx, req)
-		if err != nil {
-			m.logger.WarnContext(ctx, "notifier: SendScopeExpansionRequest failed", "err", err)
-			errs = append(errs, err)
-		} else if messageID == "" && id != "" {
-			messageID = id
-		}
-	}
-	return messageID, errors.Join(errs...)
+	return m.fanOutSend(ctx, "SendScopeExpansionRequest", func(n Notifier) (string, error) {
+		return n.SendScopeExpansionRequest(ctx, req)
+	})
 }
 
 func (m *MultiNotifier) SendConnectionRequest(ctx context.Context, req ConnectionRequest) (string, error) {
-	var messageID string
-	var errs []error
-	for _, n := range m.notifiers {
-		id, err := n.SendConnectionRequest(ctx, req)
-		if err != nil {
-			m.logger.WarnContext(ctx, "notifier: SendConnectionRequest failed", "err", err)
-			errs = append(errs, err)
-		} else if messageID == "" && id != "" {
-			messageID = id
-		}
-	}
-	return messageID, errors.Join(errs...)
+	return m.fanOutSend(ctx, "SendConnectionRequest", func(n Notifier) (string, error) {
+		return n.SendConnectionRequest(ctx, req)
+	})
 }
 
 func (m *MultiNotifier) UpdateMessage(ctx context.Context, userID, messageID, text string) error {

--- a/pkg/notify/multi.go
+++ b/pkg/notify/multi.go
@@ -247,11 +247,24 @@ func (m *MultiNotifier) fanOutSend(ctx context.Context, op string, send func(Not
 			errs = append(errs, err)
 			continue
 		}
-		delivered++
-		if _, selfRecording := n.(TargetMessageUpdater); selfRecording {
+		// A nil error is not proof anyone was reached. Push returns
+		// ("", nil) when the user has no paired devices, so counting it
+		// would let a genuine Telegram failure report success and nobody
+		// would learn the prompt never arrived. Treat delivery as proven
+		// only by a message reference, or by a channel that records its
+		// own (Slack), which returns one it has already stored.
+		_, selfRecording := n.(TargetMessageUpdater)
+		if id == "" && !selfRecording {
+			m.logger.WarnContext(ctx, "notifier: send reported success but delivered nothing", "op", op)
 			continue
 		}
-		if messageID == "" && id != "" {
+		delivered++
+
+		// Only Telegram's reference may be returned. Callers persist it
+		// against a hardcoded "telegram" channel, so handing back push's
+		// "push:<daemonID>" would point later Telegram edits at a message
+		// that never existed. Self-recording channels store their own.
+		if _, isTelegram := n.(TelegramTester); isTelegram && messageID == "" {
 			messageID = id
 		}
 	}


### PR DESCRIPTION
Started as a fix for a resolved Slack prompt that kept its buttons, and ended up finding the cause in the decision bus — not in Slack at all.

## The root cause

`RedisDecisionBus` lost approvals whenever an instance drained.

`BRPOP` is a destructive read: once popped, a decision exists only in the subscribing goroutine, and the queue has no redelivery. Two paths dropped it. The subscriber channel was **buffered**, so a pop succeeded immediately into the buffer rather than waiting for a consumer — anything sitting there when the instance shut down was already gone from Redis and never delivered. And the `ctx.Done()` branch simply returned, discarding a decision already off the queue.

The channel is now **unbuffered**, so a decision leaves the queue only when a consumer is ready for it, and a cancelled context therefore finds the send still blocked and **returns the decision to the tail** for another instance. A failed return logs at error — the only thing separating it from the silent drop it replaces.

**This is pre-existing and not Slack-specific.** The same bus drives Telegram, where a message that never gets edited is simply less visible than buttons that stay live. With `min_instances = 0`, any rollout or scale-down makes it common: on staging it lost roughly half of all approvals.

## Slack behaviour

**A resolved prompt no longer notifies anyone.** The detail moved into a thread reply, and a reply is a new message — so the channel was pinged again immediately after someone acted. Attribution also rendered as a `<@U…>` mention, notifying that person about their own action. Attribution is now a plain display name, falling back to the raw ID rather than a mention so no path can reintroduce the ping; display names are user-controlled, so they are escaped.

**Detail sits behind a "View request details" modal.** An intermediate attempt inlined it, assuming Slack collapses long messages behind "Show more" — that applies to long text, not to Block Kit, which renders every block. A modal is the only real collapse Slack offers, and opening one notifies nobody. The detail is stashed under an unguessable token (not the target ID, which would let a forged interaction enumerate other requests), scoped to the workspace, with both Slack limits clamped — 100 blocks, 24-character title — since exceeding either makes `views.open` reject the view and present as a button that does nothing.

**A partial send no longer reports failure.** `MultiNotifier` joined every notifier's error, so a user with only Slack configured got a "send failed" on every prompt from the unconfigured Telegram notifier, and callers skipped their success work. It also returned the first non-empty message ID from *any* notifier while callers persist it against a hardcoded `"telegram"` channel — so Slack's `channel:ts` could land in Telegram's row. Both are fixed together; only notifiers that do not record their own reference can supply the ID.

**Message context is shared across replicas.** It was the last piece of Slack state with no Redis implementation and was not even a parameter to `SetRedisStores`, so summary, detail and approver lived only on the replica that posted the prompt. Decisions are a competing-consumer queue, so the resolving replica is routinely a different one — it found nothing and wrote the outcome with no attribution and no detail button.

## Observability

Every silent path on the resolve route now logs: decision arrival at the consumer, entry to the shared update helper including its nil-notifier and no-target-channel exits, each of the interaction handler's six early exits with the values it rejected on, the publish itself, and what `chat.update` actually edited versus what was requested.

That was not incidental. Four rounds of this investigation were spent inferring from absent logs, and each inference was wrong. The instrumentation is what turned "it doesn't work sometimes" into a specific line of code.

## Testing

Unit tests cover the decision-bus shutdown path (verified to fail without the fix), signature verification, the approver allowlist, token peek/consume/tombstone semantics including the cross-replica pair guard, HTML→mrkdwn conversion, per-channel test scoping, the callback target ID, message-context survival across replicas, and the modal's Slack limits.

Verified end to end against a real Slack workspace on staging: repeated approvals now resolve consistently, where previously about half did.
