### PR TITLE
fix(notify): make decision delivery at-least-once with an explicit ack

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1884,17 +1884,22 @@ func (s *Server) consumeNotifierDecisions(ctx context.Context, ch <-chan notify.
 				}
 			}
 			if err != nil {
-				s.logger.WarnContext(ctx, "notifier decision failed",
+				// Deliberately not acked. A handler error does not
+				// distinguish "delivered and rejected" — an expired
+				// approval, a lost CAS — from "transiently failed": a
+				// database outage, or this context being cancelled
+				// mid-handle during a rolling deploy. Acking here would
+				// discard the second kind, which is the loss this bus
+				// exists to prevent. Redelivery is bounded by
+				// maxDeliveryAttempts, so a decision that genuinely
+				// cannot be handled is dropped loudly rather than
+				// retried forever.
+				s.logger.WarnContext(ctx, "notifier decision failed, will be redelivered",
 					"type", d.Type, "action", d.Action,
 					"target_id", d.TargetID, "err", err)
+				continue
 			}
 
-			// Acked either way. A handler error is a decision that was
-			// delivered and rejected — an expired approval, a lost CAS —
-			// not one that went missing, and redelivering it would just
-			// fail again on a loop. Only an unfinished handler should be
-			// retried, and that is the case where this line is never
-			// reached.
 			delivery.Ack()
 
 		}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1833,15 +1833,16 @@ func (s *Server) handleClawvisorKeys(w http.ResponseWriter, r *http.Request) {
 
 // consumeNotifierDecisions reads from the notifier's decision channel
 // and routes approve/deny decisions to the appropriate handler.
-func (s *Server) consumeNotifierDecisions(ctx context.Context, ch <-chan notify.CallbackDecision) {
+func (s *Server) consumeNotifierDecisions(ctx context.Context, ch <-chan notify.Delivery) {
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case d, ok := <-ch:
+		case delivery, ok := <-ch:
 			if !ok {
 				return
 			}
+			d := delivery.Decision
 			// Logged on arrival: if a decision never reaches here, the
 			// prompt is resolved by some other route and no amount of
 			// instrumentation further down will show why.
@@ -1887,6 +1888,14 @@ func (s *Server) consumeNotifierDecisions(ctx context.Context, ch <-chan notify.
 					"type", d.Type, "action", d.Action,
 					"target_id", d.TargetID, "err", err)
 			}
+
+			// Acked either way. A handler error is a decision that was
+			// delivered and rejected — an expired approval, a lost CAS —
+			// not one that went missing, and redelivering it would just
+			// fail again on a loop. Only an unfinished handler should be
+			// retried, and that is the case where this line is never
+			// reached.
+			delivery.Ack()
 
 		}
 	}
@@ -1959,8 +1968,30 @@ func (s *Server) Run(ctx context.Context) error {
 			// Consume decisions from the bus (receives from all instances).
 			go s.consumeNotifierDecisions(ctx, s.decisionBus.Subscribe(ctx))
 		} else {
-			// Single-instance: consume directly from the local channel.
-			go s.consumeNotifierDecisions(ctx, dc.DecisionChannel())
+			// Single-instance: wrap the notifier's raw channel as
+			// deliveries. Acks are no-ops — with one process there is
+			// nothing to redeliver from.
+			raw := dc.DecisionChannel()
+			local := make(chan notify.Delivery)
+			go func() {
+				defer close(local)
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					case d, ok := <-raw:
+						if !ok {
+							return
+						}
+						select {
+						case local <- notify.Delivery{Decision: d, Ack: func() {}}:
+						case <-ctx.Done():
+							return
+						}
+					}
+				}
+			}()
+			go s.consumeNotifierDecisions(ctx, local)
 		}
 	}
 

--- a/internal/notify/decision_redis.go
+++ b/internal/notify/decision_redis.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9"
 
 	"github.com/clawvisor/clawvisor/pkg/notify"
@@ -15,7 +16,7 @@ import (
 const (
 	redisDecisionQueue      = "clawvisor:decisions"
 	redisDecisionProcessing = "clawvisor:decisions:processing"
-	// redisDecisionStarted scores each in-flight payload with the time it
+	// redisDecisionStarted scores each in-flight delivery with the time it
 	// was taken, so the reclaimer can tell a decision still being handled
 	// from one whose handler died.
 	redisDecisionStarted = "clawvisor:decisions:started"
@@ -25,7 +26,52 @@ const (
 	// since reclaiming early causes duplicate work rather than loss.
 	visibilityTimeout = 2 * time.Minute
 	reclaimInterval   = 30 * time.Second
+
+	// maxDeliveryAttempts caps redelivery of a decision that keeps failing.
+	// Handler errors do not ack, so without a cap a permanently failing
+	// decision — an approval whose row is long gone — would be retried
+	// forever. Five attempts at the visibility timeout is roughly ten
+	// minutes of trying before giving up loudly.
+	maxDeliveryAttempts = 5
 )
+
+// decisionEnvelope wraps a decision with a per-delivery identity.
+//
+// The ID exists because the queue entry, the processing entry and the
+// visibility marker all have to refer to the same delivery, and the decision
+// payload alone cannot do that: two publishes of the same decision marshal
+// to identical bytes, so they would share one marker in the started set. The
+// first ack would remove that shared marker and strand the other delivery on
+// the processing list, unreclaimable — lost exactly like the design this
+// replaced. A UUID per publish makes every entry distinct.
+type decisionEnvelope struct {
+	ID       string                  `json:"id"`
+	Decision notify.CallbackDecision `json:"decision"`
+	// Attempts counts deliveries already made. Carried in the payload
+	// rather than a side table so it cannot be orphaned by a failed
+	// cleanup.
+	Attempts int `json:"attempts,omitempty"`
+}
+
+// reclaimScript returns one stale delivery to the queue.
+//
+// LREM and LPUSH have to be atomic: between a reclaimer reading a marker and
+// requeuing it, the original handler may finish and ack. Split into separate
+// commands the LREM then removes nothing while the LPUSH still runs, and an
+// already-acknowledged decision is handled a second time. Gating the push on
+// the removal makes the ack and the reclaim mutually exclusive — whichever
+// gets there first wins, and the loser is a no-op.
+//
+// KEYS: processing list, queue, started set. ARGV: stored member, replacement
+// member ("" to drop it permanently).
+var reclaimScript = redis.NewScript(`
+local removed = redis.call('LREM', KEYS[1], 1, ARGV[1])
+redis.call('ZREM', KEYS[3], ARGV[1])
+if removed > 0 and ARGV[2] ~= '' then
+  redis.call('LPUSH', KEYS[2], ARGV[2])
+end
+return removed
+`)
 
 // RedisDecisionBus distributes callback decisions across instances.
 //
@@ -53,7 +99,7 @@ func NewRedisDecisionBus(rdb *redis.Client, logger *slog.Logger) *RedisDecisionB
 
 // Publish enqueues a decision for whichever instance takes it next.
 func (b *RedisDecisionBus) Publish(ctx context.Context, d notify.CallbackDecision) error {
-	data, err := json.Marshal(d)
+	data, err := json.Marshal(decisionEnvelope{ID: uuid.NewString(), Decision: d})
 	if err != nil {
 		return err
 	}
@@ -91,15 +137,17 @@ func (b *RedisDecisionBus) Subscribe(ctx context.Context) <-chan notify.Delivery
 			}
 
 			// Record when this was taken so the reclaimer can age it out.
-			// A failure here only costs a slower reclaim, never the
-			// decision: it is already safe on the processing list.
+			// If this fails the entry is still recoverable: the reclaimer
+			// adopts processing entries that have no marker rather than
+			// ignoring them, so the worst case is a later reclaim, not a
+			// lost decision.
 			if err := b.rdb.ZAdd(ctx, redisDecisionStarted,
 				redis.Z{Score: float64(time.Now().Unix()), Member: raw}).Err(); err != nil {
 				b.logger.WarnContext(ctx, "redis decision bus: could not record start time", "err", err)
 			}
 
-			var d notify.CallbackDecision
-			if err := json.Unmarshal([]byte(raw), &d); err != nil {
+			var env decisionEnvelope
+			if err := json.Unmarshal([]byte(raw), &env); err != nil {
 				// Unparseable: acking is the only way to stop it being
 				// reclaimed forever.
 				b.logger.WarnContext(ctx, "redis decision bus: unmarshal", "err", err)
@@ -108,7 +156,7 @@ func (b *RedisDecisionBus) Subscribe(ctx context.Context) <-chan notify.Delivery
 			}
 
 			select {
-			case ch <- notify.Delivery{Decision: d, Ack: func() { b.ack(raw) }}:
+			case ch <- notify.Delivery{Decision: env.Decision, Ack: func() { b.ack(raw) }}:
 			case <-ctx.Done():
 				// Deliberately not acked. The decision stays on the
 				// processing list and the reclaimer returns it, which is
@@ -157,6 +205,8 @@ func (b *RedisDecisionBus) reclaimLoop(ctx context.Context) {
 }
 
 func (b *RedisDecisionBus) reclaim(ctx context.Context) {
+	b.adoptUnmarked(ctx)
+
 	cutoff := float64(time.Now().Add(-visibilityTimeout).Unix())
 	stale, err := b.rdb.ZRangeByScore(ctx, redisDecisionStarted, &redis.ZRangeBy{
 		Min: "-inf", Max: formatScore(cutoff),
@@ -169,16 +219,103 @@ func (b *RedisDecisionBus) reclaim(ctx context.Context) {
 	}
 
 	for _, raw := range stale {
-		pipe := b.rdb.Pipeline()
-		pipe.LRem(ctx, redisDecisionProcessing, 1, raw)
-		pipe.LPush(ctx, redisDecisionQueue, raw)
-		pipe.ZRem(ctx, redisDecisionStarted, raw)
-		if _, err := pipe.Exec(ctx); err != nil {
-			b.logger.WarnContext(ctx, "redis decision bus: reclaim failed", "err", err)
+		b.requeue(ctx, raw)
+	}
+}
+
+// adoptUnmarked gives a start time to processing entries that have none.
+//
+// BLMOVE and the ZADD that follows it are two commands, so a crash or a
+// cancelled context between them leaves an entry on the processing list that
+// the reclaimer's scan would never see — the one window in which this design
+// could still lose a decision permanently. Rather than making those two
+// commands atomic, the reclaimer treats an unmarked processing entry as one
+// it has just noticed: it gets a marker now and ages out normally. Marked NX
+// so a real start time recorded concurrently is never overwritten, which
+// would otherwise extend a live handler's visibility window.
+func (b *RedisDecisionBus) adoptUnmarked(ctx context.Context) {
+	inflight, err := b.rdb.LRange(ctx, redisDecisionProcessing, 0, -1).Result()
+	if err != nil {
+		if ctx.Err() == nil {
+			b.logger.WarnContext(ctx, "redis decision bus: processing scan failed", "err", err)
+		}
+		return
+	}
+	if len(inflight) == 0 {
+		return
+	}
+
+	marked, err := b.rdb.ZRange(ctx, redisDecisionStarted, 0, -1).Result()
+	if err != nil {
+		if ctx.Err() == nil {
+			b.logger.WarnContext(ctx, "redis decision bus: marker scan failed", "err", err)
+		}
+		return
+	}
+	have := make(map[string]struct{}, len(marked))
+	for _, m := range marked {
+		have[m] = struct{}{}
+	}
+
+	now := float64(time.Now().Unix())
+	for _, raw := range inflight {
+		if _, ok := have[raw]; ok {
 			continue
 		}
-		b.logger.InfoContext(ctx, "redis decision bus: reclaimed an unacked decision")
+		if err := b.rdb.ZAddNX(ctx, redisDecisionStarted,
+			redis.Z{Score: now, Member: raw}).Err(); err != nil {
+			b.logger.WarnContext(ctx, "redis decision bus: could not adopt unmarked decision", "err", err)
+			continue
+		}
+		b.logger.InfoContext(ctx, "redis decision bus: adopted an unmarked in-flight decision")
 	}
+}
+
+// requeue returns one stale delivery to the queue, or drops it if it has been
+// retried too many times.
+func (b *RedisDecisionBus) requeue(ctx context.Context, raw string) {
+	var env decisionEnvelope
+	replacement := ""
+	drop := true
+
+	if err := json.Unmarshal([]byte(raw), &env); err != nil {
+		// Nothing can handle it, so redelivering it forever helps no one.
+		b.logger.WarnContext(ctx, "redis decision bus: dropping unparseable in-flight decision", "err", err)
+	} else if env.Attempts+1 >= maxDeliveryAttempts {
+		b.logger.ErrorContext(ctx, "redis decision bus: giving up on a decision after repeated failures",
+			"id", env.ID, "type", env.Decision.Type, "action", env.Decision.Action,
+			"target_id", env.Decision.TargetID, "attempts", env.Attempts+1)
+	} else {
+		env.Attempts++
+		next, err := json.Marshal(env)
+		if err != nil {
+			b.logger.WarnContext(ctx, "redis decision bus: could not re-encode decision", "err", err)
+			return // leave it in place; a later pass can try again
+		}
+		replacement = string(next)
+		drop = false
+	}
+
+	removed, err := reclaimScript.Run(ctx, b.rdb,
+		[]string{redisDecisionProcessing, redisDecisionQueue, redisDecisionStarted},
+		raw, replacement).Int64()
+	if err != nil {
+		if ctx.Err() == nil {
+			b.logger.WarnContext(ctx, "redis decision bus: reclaim failed", "err", err)
+		}
+		return
+	}
+	if removed == 0 {
+		// Acked while this pass was running, or a marker left behind by an
+		// entry that is already gone. Either way the script cleared the
+		// marker and deliberately did not requeue.
+		return
+	}
+	if drop {
+		return
+	}
+	b.logger.InfoContext(ctx, "redis decision bus: reclaimed an unacked decision",
+		"id", env.ID, "attempt", env.Attempts)
 }
 
 func formatScore(f float64) string {

--- a/internal/notify/decision_redis.go
+++ b/internal/notify/decision_redis.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
+	"strconv"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -11,11 +12,35 @@ import (
 	"github.com/clawvisor/clawvisor/pkg/notify"
 )
 
-const redisDecisionQueue = "clawvisor:decisions"
+const (
+	redisDecisionQueue      = "clawvisor:decisions"
+	redisDecisionProcessing = "clawvisor:decisions:processing"
+	// redisDecisionStarted scores each in-flight payload with the time it
+	// was taken, so the reclaimer can tell a decision still being handled
+	// from one whose handler died.
+	redisDecisionStarted = "clawvisor:decisions:started"
 
-// RedisDecisionBus implements notify.DecisionBus using a Redis list for
-// exactly-once delivery. Only one instance receives each decision, avoiding
-// duplicate side effects (callback webhooks, state transitions).
+	// visibilityTimeout is how long a taken decision may go unacked before
+	// another instance may reclaim it. Comfortably longer than a handler,
+	// since reclaiming early causes duplicate work rather than loss.
+	visibilityTimeout = 2 * time.Minute
+	reclaimInterval   = 30 * time.Second
+)
+
+// RedisDecisionBus distributes callback decisions across instances.
+//
+// Decisions are moved, not popped: BLMOVE takes a payload from the queue and
+// places it on a processing list in one atomic step, so a decision is never
+// only in memory. Ack removes it from processing; anything left there past
+// the visibility timeout is returned to the queue by the reclaimer.
+//
+// This replaces a BRPOP design that lost approvals. BRPOP is a destructive
+// read, so between the pop and a finished handler the sole copy lived in a
+// goroutine, and a scale-down or rolling deploy dropped it silently — on
+// staging, roughly half of all approvals. No shutdown ordering can close
+// that, because there is no instant at which the decision is both off the
+// queue and durably owned; an acknowledgement boundary is the property that
+// was missing.
 type RedisDecisionBus struct {
 	rdb    *redis.Client
 	logger *slog.Logger
@@ -26,7 +51,7 @@ func NewRedisDecisionBus(rdb *redis.Client, logger *slog.Logger) *RedisDecisionB
 	return &RedisDecisionBus{rdb: rdb, logger: logger}
 }
 
-// Publish pushes a decision onto the Redis list (LPUSH).
+// Publish enqueues a decision for whichever instance takes it next.
 func (b *RedisDecisionBus) Publish(ctx context.Context, d notify.CallbackDecision) error {
 	data, err := json.Marshal(d)
 	if err != nil {
@@ -35,60 +60,127 @@ func (b *RedisDecisionBus) Publish(ctx context.Context, d notify.CallbackDecisio
 	return b.rdb.LPush(ctx, redisDecisionQueue, data).Err()
 }
 
-// Subscribe returns a channel that receives decisions. Uses BRPOP for
-// blocking, exactly-once consumption — only one instance processes each
-// decision even when multiple instances are subscribed.
-func (b *RedisDecisionBus) Subscribe(ctx context.Context) <-chan notify.CallbackDecision {
-	// Unbuffered on purpose. A buffer here is not a throughput win, it is a
-	// loss window: BRPOP is a destructive read, so anything sitting in the
-	// buffer when the instance drains is gone from Redis and never
-	// delivered. Unbuffered means a decision only leaves the queue when a
-	// consumer is ready to take it, so a cancelled context finds the send
-	// still blocked and can put it back.
-	ch := make(chan notify.CallbackDecision)
+// Subscribe returns a channel of deliveries taken from the shared queue.
+// Every instance polls the same queue, so exactly one takes each decision —
+// and it stays recoverable until that instance acks.
+func (b *RedisDecisionBus) Subscribe(ctx context.Context) <-chan notify.Delivery {
+	ch := make(chan notify.Delivery)
+
+	go b.reclaimLoop(ctx)
 
 	go func() {
 		defer close(ch)
 
 		for {
-			// BRPOP blocks for up to 1s, then loops to check ctx cancellation.
-			result, err := b.rdb.BRPop(ctx, 1*time.Second, redisDecisionQueue).Result()
+			if ctx.Err() != nil {
+				return
+			}
+
+			raw, err := b.rdb.BLMove(ctx, redisDecisionQueue, redisDecisionProcessing,
+				"RIGHT", "LEFT", 1*time.Second).Result()
 			if err != nil {
 				if ctx.Err() != nil {
 					return
 				}
 				if err == redis.Nil {
-					continue // timeout, loop again
+					continue // idle, poll again
 				}
-				b.logger.WarnContext(ctx, "redis decision bus: brpop", "err", err)
+				b.logger.WarnContext(ctx, "redis decision bus: blmove", "err", err)
 				time.Sleep(100 * time.Millisecond)
 				continue
 			}
-			// BRPop returns [key, value].
-			if len(result) < 2 {
-				continue
+
+			// Record when this was taken so the reclaimer can age it out.
+			// A failure here only costs a slower reclaim, never the
+			// decision: it is already safe on the processing list.
+			if err := b.rdb.ZAdd(ctx, redisDecisionStarted,
+				redis.Z{Score: float64(time.Now().Unix()), Member: raw}).Err(); err != nil {
+				b.logger.WarnContext(ctx, "redis decision bus: could not record start time", "err", err)
 			}
+
 			var d notify.CallbackDecision
-			if err := json.Unmarshal([]byte(result[1]), &d); err != nil {
+			if err := json.Unmarshal([]byte(raw), &d); err != nil {
+				// Unparseable: acking is the only way to stop it being
+				// reclaimed forever.
 				b.logger.WarnContext(ctx, "redis decision bus: unmarshal", "err", err)
+				b.ack(raw)
 				continue
 			}
+
 			select {
-			case ch <- d:
+			case ch <- notify.Delivery{Decision: d, Ack: func() { b.ack(raw) }}:
 			case <-ctx.Done():
-				// BRPOP is a destructive read, so this decision now exists
-				// only in this goroutine. Returning here would drop a
-				// human's approval with no error, no log and no
-				// redelivery — and a shutting-down instance keeps popping
-				// right up until its context is cancelled, so this is the
-				// common path during a rolling deploy, not a rare one.
-				//
-				// Put it back on the tail, which is where BRPOP takes
-				// from, so the next instance to poll picks it up.
+				// Deliberately not acked. The decision stays on the
+				// processing list and the reclaimer returns it, which is
+				// exactly the case the old design lost.
 				return
 			}
 		}
 	}()
 
 	return ch
+}
+
+// ack retires a handled decision.
+func (b *RedisDecisionBus) ack(raw string) {
+	// Detached: the common caller is a handler finishing as the process
+	// shuts down, and reusing a cancelled context would leave the decision
+	// to be reclaimed and handled twice.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	pipe := b.rdb.Pipeline()
+	pipe.LRem(ctx, redisDecisionProcessing, 1, raw)
+	pipe.ZRem(ctx, redisDecisionStarted, raw)
+	if _, err := pipe.Exec(ctx); err != nil {
+		// Not lost, just duplicated later: the reclaimer will return it
+		// and a handler will run again. Idempotent handling is what makes
+		// that safe.
+		b.logger.WarnContext(ctx, "redis decision bus: ack failed, decision will be redelivered", "err", err)
+	}
+}
+
+// reclaimLoop returns decisions whose handler never acked.
+func (b *RedisDecisionBus) reclaimLoop(ctx context.Context) {
+	t := time.NewTicker(reclaimInterval)
+	defer t.Stop()
+
+	b.reclaim(ctx) // once at startup, for anything a previous instance left
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			b.reclaim(ctx)
+		}
+	}
+}
+
+func (b *RedisDecisionBus) reclaim(ctx context.Context) {
+	cutoff := float64(time.Now().Add(-visibilityTimeout).Unix())
+	stale, err := b.rdb.ZRangeByScore(ctx, redisDecisionStarted, &redis.ZRangeBy{
+		Min: "-inf", Max: formatScore(cutoff),
+	}).Result()
+	if err != nil {
+		if ctx.Err() == nil {
+			b.logger.WarnContext(ctx, "redis decision bus: reclaim scan failed", "err", err)
+		}
+		return
+	}
+
+	for _, raw := range stale {
+		pipe := b.rdb.Pipeline()
+		pipe.LRem(ctx, redisDecisionProcessing, 1, raw)
+		pipe.LPush(ctx, redisDecisionQueue, raw)
+		pipe.ZRem(ctx, redisDecisionStarted, raw)
+		if _, err := pipe.Exec(ctx); err != nil {
+			b.logger.WarnContext(ctx, "redis decision bus: reclaim failed", "err", err)
+			continue
+		}
+		b.logger.InfoContext(ctx, "redis decision bus: reclaimed an unacked decision")
+	}
+}
+
+func formatScore(f float64) string {
+	return strconv.FormatFloat(f, 'f', 0, 64)
 }

--- a/internal/notify/decision_redis.go
+++ b/internal/notify/decision_redis.go
@@ -20,6 +20,13 @@ const (
 	// was taken, so the reclaimer can tell a decision still being handled
 	// from one whose handler died.
 	redisDecisionStarted = "clawvisor:decisions:started"
+	// redisDecisionDeadLetter holds deliveries that could not be handled.
+	// Retiring one destroys a human's decision, so they are kept here for
+	// inspection and manual replay instead of being deleted.
+	redisDecisionDeadLetter = "clawvisor:decisions:dead"
+	// deadLetterMaxLen bounds that list; it should normally be empty, and an
+	// unbounded one would grow forever if something started failing in a loop.
+	deadLetterMaxLen = 1000
 
 	// visibilityTimeout is how long a taken decision may go unacked before
 	// another instance may reclaim it. Comfortably longer than a handler,
@@ -44,13 +51,24 @@ const (
 // first ack would remove that shared marker and strand the other delivery on
 // the processing list, unreclaimable — lost exactly like the design this
 // replaced. A UUID per publish makes every entry distinct.
+//
+// The decision is embedded rather than nested so the envelope stays wire
+// compatible with the flat payload this replaces, in both directions. A
+// rolling deploy runs both formats against one queue: an old instance
+// decoding this envelope still sees every decision field and ignores the
+// underscored ones, and a new instance decoding a flat payload fills the
+// embedded struct and simply has no ID. Nested under a "decision" key,
+// neither could read the other's payload — it would unmarshal cleanly into a
+// zero-valued decision, match no case in the consumer, and be acked as
+// handled. That is a silent loss of exactly the kind this bus exists to
+// prevent, and a mixed fleet is guaranteed during every deploy.
 type decisionEnvelope struct {
-	ID       string                  `json:"id"`
-	Decision notify.CallbackDecision `json:"decision"`
+	notify.CallbackDecision
+	ID string `json:"_delivery_id,omitempty"`
 	// Attempts counts deliveries already made. Carried in the payload
 	// rather than a side table so it cannot be orphaned by a failed
 	// cleanup.
-	Attempts int `json:"attempts,omitempty"`
+	Attempts int `json:"_attempts,omitempty"`
 }
 
 // reclaimScript returns one stale delivery to the queue.
@@ -62,13 +80,21 @@ type decisionEnvelope struct {
 // the removal makes the ack and the reclaim mutually exclusive — whichever
 // gets there first wins, and the loser is a no-op.
 //
-// KEYS: processing list, queue, started set. ARGV: stored member, replacement
-// member ("" to drop it permanently).
+// A delivery that is out of attempts is moved to the dead-letter list rather
+// than deleted, in the same atomic step, so giving up never destroys it.
+//
+// KEYS: processing list, queue, started set, dead-letter list. ARGV: stored
+// member, replacement member ("" to dead-letter instead), dead-letter bound.
 var reclaimScript = redis.NewScript(`
 local removed = redis.call('LREM', KEYS[1], 1, ARGV[1])
 redis.call('ZREM', KEYS[3], ARGV[1])
-if removed > 0 and ARGV[2] ~= '' then
-  redis.call('LPUSH', KEYS[2], ARGV[2])
+if removed > 0 then
+  if ARGV[2] ~= '' then
+    redis.call('LPUSH', KEYS[2], ARGV[2])
+  else
+    redis.call('LPUSH', KEYS[4], ARGV[1])
+    redis.call('LTRIM', KEYS[4], 0, ARGV[3])
+  end
 end
 return removed
 `)
@@ -99,7 +125,7 @@ func NewRedisDecisionBus(rdb *redis.Client, logger *slog.Logger) *RedisDecisionB
 
 // Publish enqueues a decision for whichever instance takes it next.
 func (b *RedisDecisionBus) Publish(ctx context.Context, d notify.CallbackDecision) error {
-	data, err := json.Marshal(decisionEnvelope{ID: uuid.NewString(), Decision: d})
+	data, err := json.Marshal(decisionEnvelope{CallbackDecision: d, ID: uuid.NewString()})
 	if err != nil {
 		return err
 	}
@@ -148,15 +174,25 @@ func (b *RedisDecisionBus) Subscribe(ctx context.Context) <-chan notify.Delivery
 
 			var env decisionEnvelope
 			if err := json.Unmarshal([]byte(raw), &env); err != nil {
-				// Unparseable: acking is the only way to stop it being
-				// reclaimed forever.
+				// Set aside rather than acked: acking would delete a
+				// payload nobody has looked at, and this build being
+				// unable to read it does not make it worthless.
 				b.logger.WarnContext(ctx, "redis decision bus: unmarshal", "err", err)
-				b.ack(raw)
+				b.deadLetter(raw)
+				continue
+			}
+			if env.Type == "" {
+				// Decodes, but names no decision — a payload from a
+				// format this build does not know. Delivering it would
+				// match no case in the consumer, which would then ack it
+				// as handled and destroy it silently.
+				b.logger.WarnContext(ctx, "redis decision bus: payload carries no decision type")
+				b.deadLetter(raw)
 				continue
 			}
 
 			select {
-			case ch <- notify.Delivery{Decision: env.Decision, Ack: func() { b.ack(raw) }}:
+			case ch <- notify.Delivery{Decision: env.CallbackDecision, Ack: func() { b.ack(raw) }}:
 			case <-ctx.Done():
 				// Deliberately not acked. The decision stays on the
 				// processing list and the reclaimer returns it, which is
@@ -185,6 +221,25 @@ func (b *RedisDecisionBus) ack(raw string) {
 		// and a handler will run again. Idempotent handling is what makes
 		// that safe.
 		b.logger.WarnContext(ctx, "redis decision bus: ack failed, decision will be redelivered", "err", err)
+	}
+}
+
+// deadLetter sets aside a payload this build cannot act on.
+//
+// Deliberately not an ack: an ack deletes, and a decision a human made is
+// not something to delete because the process could not read it. Keeping it
+// on a bounded list costs nothing and leaves it recoverable.
+func (b *RedisDecisionBus) deadLetter(raw string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	pipe := b.rdb.Pipeline()
+	pipe.LRem(ctx, redisDecisionProcessing, 1, raw)
+	pipe.ZRem(ctx, redisDecisionStarted, raw)
+	pipe.LPush(ctx, redisDecisionDeadLetter, raw)
+	pipe.LTrim(ctx, redisDecisionDeadLetter, 0, deadLetterMaxLen-1)
+	if _, err := pipe.Exec(ctx); err != nil {
+		b.logger.WarnContext(ctx, "redis decision bus: could not dead-letter a decision", "err", err)
 	}
 }
 
@@ -279,12 +334,17 @@ func (b *RedisDecisionBus) requeue(ctx context.Context, raw string) {
 	drop := true
 
 	if err := json.Unmarshal([]byte(raw), &env); err != nil {
-		// Nothing can handle it, so redelivering it forever helps no one.
-		b.logger.WarnContext(ctx, "redis decision bus: dropping unparseable in-flight decision", "err", err)
+		// Redelivering something nothing can parse helps no one, but it
+		// still goes to the dead-letter list rather than being deleted.
+		b.logger.WarnContext(ctx, "redis decision bus: dead-lettering unparseable in-flight decision", "err", err)
 	} else if env.Attempts+1 >= maxDeliveryAttempts {
-		b.logger.ErrorContext(ctx, "redis decision bus: giving up on a decision after repeated failures",
-			"id", env.ID, "type", env.Decision.Type, "action", env.Decision.Action,
-			"target_id", env.Decision.TargetID, "attempts", env.Attempts+1)
+		// Out of attempts. Handler errors cannot tell a permanently
+		// unhandleable decision from a long outage, so this is not
+		// allowed to destroy it: it moves to the dead-letter list, where
+		// it can be inspected and replayed.
+		b.logger.ErrorContext(ctx, "redis decision bus: dead-lettering a decision after repeated failures",
+			"id", env.ID, "type", env.Type, "action", env.Action,
+			"target_id", env.TargetID, "attempts", env.Attempts+1)
 	} else {
 		env.Attempts++
 		next, err := json.Marshal(env)
@@ -297,8 +357,8 @@ func (b *RedisDecisionBus) requeue(ctx context.Context, raw string) {
 	}
 
 	removed, err := reclaimScript.Run(ctx, b.rdb,
-		[]string{redisDecisionProcessing, redisDecisionQueue, redisDecisionStarted},
-		raw, replacement).Int64()
+		[]string{redisDecisionProcessing, redisDecisionQueue, redisDecisionStarted, redisDecisionDeadLetter},
+		raw, replacement, deadLetterMaxLen-1).Int64()
 	if err != nil {
 		if ctx.Err() == nil {
 			b.logger.WarnContext(ctx, "redis decision bus: reclaim failed", "err", err)
@@ -312,7 +372,7 @@ func (b *RedisDecisionBus) requeue(ctx context.Context, raw string) {
 		return
 	}
 	if drop {
-		return
+		return // already logged, and now on the dead-letter list
 	}
 	b.logger.InfoContext(ctx, "redis decision bus: reclaimed an unacked decision",
 		"id", env.ID, "attempt", env.Attempts)

--- a/internal/notify/decision_redis_test.go
+++ b/internal/notify/decision_redis_test.go
@@ -2,8 +2,10 @@ package notify
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -256,7 +258,7 @@ func TestDecisionBus_StaleMarkerDoesNotResurrectAnAckedDecision(t *testing.T) {
 	bus, mr := newTestBus(t)
 	ctx := context.Background()
 
-	raw := `{"id":"already-acked","decision":{"type":"task","action":"approve","target_id":"task-1"}}`
+	raw := `{"Type":"task","Action":"approve","TargetID":"task-1","_delivery_id":"already-acked"}`
 	if err := bus.rdb.ZAdd(ctx, redisDecisionStarted, redis.Z{
 		Score: float64(time.Now().Add(-2 * visibilityTimeout).Unix()), Member: raw,
 	}).Err(); err != nil {
@@ -317,5 +319,93 @@ func TestDecisionBus_GivesUpAfterRepeatedRedelivery(t *testing.T) {
 	}
 	if p, _ := mr.List(redisDecisionProcessing); len(p) != 0 {
 		t.Fatalf("a decision past its attempt cap is still in flight (%d)", len(p))
+	}
+	// Given up on, but not destroyed: a human made this decision, and
+	// handler errors cannot prove it was unhandleable rather than unlucky.
+	dead, _ := mr.List(redisDecisionDeadLetter)
+	if len(dead) != 1 {
+		t.Fatalf("a decision past its attempt cap was deleted rather than dead-lettered (%d held)", len(dead))
+	}
+	if !strings.Contains(dead[0], "task-1") {
+		t.Fatalf("dead-lettered the wrong payload: %s", dead[0])
+	}
+}
+
+// A rolling deploy runs both payload formats against one queue. A decision
+// published by an instance on the previous flat format has to survive being
+// taken by an instance on this one: nested under a "decision" key it would
+// unmarshal into a zero-valued decision, match no case in the consumer, and
+// be acked as handled — losing it silently.
+func TestDecisionBus_LegacyFlatPayloadIsStillDelivered(t *testing.T) {
+	bus, _ := newTestBus(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Exactly what the previous build wrote: a bare CallbackDecision.
+	legacy, err := json.Marshal(notify.CallbackDecision{
+		Type: "task", Action: "approve", TargetID: "task-legacy", UserID: "user-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := bus.rdb.LPush(ctx, redisDecisionQueue, legacy).Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	ch := bus.Subscribe(ctx)
+	select {
+	case d := <-ch:
+		if d.Decision.TargetID != "task-legacy" || d.Decision.Action != "approve" {
+			t.Fatalf("a decision published before this format was lost in translation: %+v", d.Decision)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("a decision from the previous payload format was never delivered")
+	}
+}
+
+// The other direction of the same deploy: an instance still on the previous
+// build decodes what this one publishes. The envelope embeds the decision so
+// its fields stay at the top level, where a plain CallbackDecision decoder
+// still finds them.
+func TestDecisionBus_PublishedPayloadIsReadableByThePreviousFormat(t *testing.T) {
+	bus, mr := newTestBus(t)
+	publish(t, bus, "task-1")
+
+	queued, _ := mr.List(redisDecisionQueue)
+	if len(queued) != 1 {
+		t.Fatalf("expected one queued decision, got %d", len(queued))
+	}
+
+	var asOldBuildWouldSeeIt notify.CallbackDecision
+	if err := json.Unmarshal([]byte(queued[0]), &asOldBuildWouldSeeIt); err != nil {
+		t.Fatalf("an instance on the previous build cannot parse this payload: %v", err)
+	}
+	if asOldBuildWouldSeeIt.TargetID != "task-1" || asOldBuildWouldSeeIt.Action != "approve" {
+		t.Fatalf("an instance on the previous build would read an empty decision and ack it away: %+v",
+			asOldBuildWouldSeeIt)
+	}
+}
+
+// A payload naming no decision must not be delivered: the consumer matches no
+// case, treats it as handled, and acks it out of existence.
+func TestDecisionBus_UnrecognisedPayloadIsDeadLetteredNotAcked(t *testing.T) {
+	bus, mr := newTestBus(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := bus.rdb.LPush(ctx, redisDecisionQueue, `{"something":"else"}`).Err(); err != nil {
+		t.Fatal(err)
+	}
+	ch := bus.Subscribe(ctx)
+
+	select {
+	case d := <-ch:
+		t.Fatalf("delivered a payload carrying no decision; the consumer would ack it away: %+v", d.Decision)
+	case <-time.After(1500 * time.Millisecond):
+	}
+
+	dead, _ := mr.List(redisDecisionDeadLetter)
+	if len(dead) != 1 {
+		t.Fatalf("an unreadable payload was deleted rather than kept for inspection (%d held)", len(dead))
 	}
 }

--- a/internal/notify/decision_redis_test.go
+++ b/internal/notify/decision_redis_test.go
@@ -131,3 +131,191 @@ func TestDecisionBus_ReclaimLeavesInFlightDecisionsAlone(t *testing.T) {
 		t.Fatal("reclaimed a decision that was still being handled; it would run twice")
 	}
 }
+
+// BLMOVE and the ZADD that marks the entry in flight are two commands. A
+// crash or cancelled context between them left an entry on the processing
+// list that the reclaim scan never looked at, so it was never redelivered —
+// the one window in which this design could still lose a decision outright.
+func TestDecisionBus_UnmarkedInFlightDecisionIsRecovered(t *testing.T) {
+	bus, mr := newTestBus(t)
+	publish(t, bus, "task-1")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch := bus.Subscribe(ctx)
+
+	select {
+	case <-ch: // taken, never acked
+	case <-time.After(3 * time.Second):
+		t.Fatal("no delivery")
+	}
+
+	inflight, _ := mr.List(redisDecisionProcessing)
+	if len(inflight) != 1 {
+		t.Fatalf("expected one in-flight decision, got %d", len(inflight))
+	}
+	// Exactly the state a failed ZADD leaves behind: in flight, unmarked.
+	if err := bus.rdb.ZRem(context.Background(), redisDecisionStarted, inflight[0]).Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	bus.reclaim(context.Background()) // must notice it and start its clock
+
+	if err := bus.rdb.ZScore(context.Background(), redisDecisionStarted, inflight[0]).Err(); err != nil {
+		t.Fatalf("an unmarked in-flight decision was never adopted; it is unreclaimable: %v", err)
+	}
+
+	// Age it out and confirm it actually comes back.
+	if err := bus.rdb.ZAdd(context.Background(), redisDecisionStarted,
+		redis.Z{Score: float64(time.Now().Add(-2 * visibilityTimeout).Unix()), Member: inflight[0]}).Err(); err != nil {
+		t.Fatal(err)
+	}
+	bus.reclaim(context.Background())
+
+	select {
+	case d := <-ch:
+		if d.Decision.TargetID != "task-1" {
+			t.Fatalf("redelivered the wrong decision: %+v", d.Decision)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("an unmarked in-flight decision was never redelivered; it is lost")
+	}
+}
+
+// Two publishes of the same decision are two deliveries. Keyed on the payload
+// they collided: one marker for two processing entries, so the first ack
+// removed the shared marker and stranded the second with nothing to reclaim
+// it.
+func TestDecisionBus_IdenticalDecisionsDoNotCollide(t *testing.T) {
+	bus, mr := newTestBus(t)
+	publish(t, bus, "task-1")
+	publish(t, bus, "task-1")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch := bus.Subscribe(ctx)
+
+	var first notify.Delivery
+	for i := 0; i < 2; i++ {
+		select {
+		case d := <-ch:
+			if i == 0 {
+				first = d
+			}
+		case <-time.After(3 * time.Second):
+			t.Fatalf("only got %d of 2 deliveries", i)
+		}
+	}
+
+	inflight, _ := mr.List(redisDecisionProcessing)
+	if len(inflight) != 2 {
+		t.Fatalf("expected two in-flight decisions, got %d", len(inflight))
+	}
+
+	first.Ack()
+
+	// Acking one must leave the other both in flight and still tracked.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		remaining, _ := mr.List(redisDecisionProcessing)
+		if len(remaining) == 1 {
+			marked, err := bus.rdb.ZRange(context.Background(), redisDecisionStarted, 0, -1).Result()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(marked) != 1 || marked[0] != remaining[0] {
+				t.Fatalf("acking one delivery destroyed the other's marker; it is unreclaimable (markers: %d)", len(marked))
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("ack did not retire exactly one delivery (%d left in flight)", len(remaining))
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// And it is genuinely recoverable, not merely marked.
+	remaining, _ := mr.List(redisDecisionProcessing)
+	if err := bus.rdb.ZAdd(context.Background(), redisDecisionStarted,
+		redis.Z{Score: float64(time.Now().Add(-2 * visibilityTimeout).Unix()), Member: remaining[0]}).Err(); err != nil {
+		t.Fatal(err)
+	}
+	bus.reclaim(context.Background())
+
+	select {
+	case <-ch:
+	case <-time.After(3 * time.Second):
+		t.Fatal("the second identical decision was never redelivered; it is lost")
+	}
+}
+
+// An ack landing between a reclaim's scan and its requeue leaves a marker
+// with no processing entry behind it. Requeuing unconditionally then runs an
+// already-handled decision a second time.
+func TestDecisionBus_StaleMarkerDoesNotResurrectAnAckedDecision(t *testing.T) {
+	bus, mr := newTestBus(t)
+	ctx := context.Background()
+
+	raw := `{"id":"already-acked","decision":{"type":"task","action":"approve","target_id":"task-1"}}`
+	if err := bus.rdb.ZAdd(ctx, redisDecisionStarted, redis.Z{
+		Score: float64(time.Now().Add(-2 * visibilityTimeout).Unix()), Member: raw,
+	}).Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	bus.reclaim(ctx)
+
+	if q, _ := mr.List(redisDecisionQueue); len(q) != 0 {
+		t.Fatal("requeued a decision that was no longer in flight; an acked decision would be handled twice")
+	}
+	marked, err := bus.rdb.ZRange(ctx, redisDecisionStarted, 0, -1).Result()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(marked) != 0 {
+		t.Fatalf("stale marker survived reclaim and will be rescanned forever (%d left)", len(marked))
+	}
+}
+
+// Handler errors no longer ack, so redelivery has to be bounded: a decision
+// whose row is long gone would otherwise be retried for ever.
+func TestDecisionBus_GivesUpAfterRepeatedRedelivery(t *testing.T) {
+	bus, mr := newTestBus(t)
+	publish(t, bus, "task-1")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch := bus.Subscribe(ctx)
+
+	deliveries := 0
+	for i := 0; i < maxDeliveryAttempts+3; i++ {
+		select {
+		case <-ch: // never acked, as a failing handler never would
+			deliveries++
+		case <-time.After(2 * time.Second):
+			i = maxDeliveryAttempts + 3 // no more deliveries coming
+			continue
+		}
+
+		inflight, _ := mr.List(redisDecisionProcessing)
+		if len(inflight) == 0 {
+			break
+		}
+		if err := bus.rdb.ZAdd(context.Background(), redisDecisionStarted,
+			redis.Z{Score: float64(time.Now().Add(-2 * visibilityTimeout).Unix()), Member: inflight[0]}).Err(); err != nil {
+			t.Fatal(err)
+		}
+		bus.reclaim(context.Background())
+	}
+
+	if deliveries != maxDeliveryAttempts {
+		t.Fatalf("delivered %d times, want the %d-attempt cap: an unhandleable decision retries forever",
+			deliveries, maxDeliveryAttempts)
+	}
+	if q, _ := mr.List(redisDecisionQueue); len(q) != 0 {
+		t.Fatalf("a decision past its attempt cap is still queued (%d)", len(q))
+	}
+	if p, _ := mr.List(redisDecisionProcessing); len(p) != 0 {
+		t.Fatalf("a decision past its attempt cap is still in flight (%d)", len(p))
+	}
+}

--- a/internal/notify/decision_redis_test.go
+++ b/internal/notify/decision_redis_test.go
@@ -24,61 +24,110 @@ func newTestBus(t *testing.T) (*RedisDecisionBus, *miniredis.Miniredis) {
 	return NewRedisDecisionBus(rdb, slog.New(slog.NewTextHandler(io.Discard, nil))), mr
 }
 
-// The subscriber channel must stay unbuffered. A buffer here is not a
-// throughput win, it is a loss window: BRPOP is a destructive read, so a
-// decision sitting in a buffer when the instance drains is already gone from
-// Redis and will never be delivered. Unbuffered means a decision leaves the
-// queue only when a consumer is ready to take it, which is what took staging
-// from losing roughly half of all approvals to losing none.
-func TestRedisDecisionBus_DoesNotPrefetchIntoABuffer(t *testing.T) {
-	bus, mr := newTestBus(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	for i := 0; i < 3; i++ {
-		if err := bus.Publish(ctx, notify.CallbackDecision{
-			Type: "task", Action: "approve", TargetID: "task-1",
-		}); err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	ch := bus.Subscribe(ctx)
-
-	// Take one and let the loop settle. A buffered channel would have
-	// drained the queue entirely; unbuffered leaves the rest in Redis.
-	select {
-	case <-ch:
-	case <-time.After(3 * time.Second):
-		t.Fatal("no decision delivered")
-	}
-	time.Sleep(200 * time.Millisecond)
-
-	remaining, _ := mr.List(redisDecisionQueue)
-	if len(remaining) == 0 {
-		t.Fatal("the queue was drained into memory; those decisions would be lost if the instance stopped")
-	}
-}
-
-// The ordinary path must still deliver.
-func TestRedisDecisionBus_DeliversToSubscriber(t *testing.T) {
-	bus, _ := newTestBus(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	ch := bus.Subscribe(ctx)
-	if err := bus.Publish(ctx, notify.CallbackDecision{
-		Type: "task", Action: "approve", TargetID: "task-1",
+func publish(t *testing.T, b *RedisDecisionBus, target string) {
+	t.Helper()
+	if err := b.Publish(context.Background(), notify.CallbackDecision{
+		Type: "task", Action: "approve", TargetID: target, UserID: "user-1",
 	}); err != nil {
 		t.Fatal(err)
 	}
+}
+
+// The property the old design lacked: a decision taken but never acked is
+// still recoverable. Previously it was popped destructively, so a handler
+// that never finished — a scale-down, a rolling deploy — lost it silently.
+func TestDecisionBus_UnackedDecisionIsRedelivered(t *testing.T) {
+	bus, mr := newTestBus(t)
+	publish(t, bus, "task-1")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch := bus.Subscribe(ctx)
+
+	select {
+	case <-ch: // take it, deliberately never ack — the handler "died"
+	case <-time.After(3 * time.Second):
+		t.Fatal("no delivery")
+	}
+
+	// Taken, so off the queue — but held on the processing list rather
+	// than living only in the handler's memory.
+	if q, _ := mr.List(redisDecisionQueue); len(q) != 0 {
+		t.Fatalf("queue should be empty while in flight, has %d", len(q))
+	}
+	inflight, _ := mr.List(redisDecisionProcessing)
+	if len(inflight) != 1 {
+		t.Fatal("decision is not on the processing list; it would be lost if this instance stopped")
+	}
+
+	// Age the in-flight marker past the visibility timeout. miniredis's
+	// FastForward moves its own clock, not the wall clock the scores use,
+	// so the entry is rewritten directly.
+	if err := bus.rdb.ZAdd(context.Background(), redisDecisionStarted,
+		redis.Z{Score: float64(time.Now().Add(-2 * visibilityTimeout).Unix()), Member: inflight[0]}).Err(); err != nil {
+		t.Fatal(err)
+	}
+	bus.reclaim(context.Background())
+
+	// The decision comes back rather than being lost.
+	select {
+	case d := <-ch:
+		if d.Decision.TargetID != "task-1" {
+			t.Fatalf("redelivered the wrong decision: %+v", d.Decision)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("an unacked decision was never redelivered; it is lost")
+	}
+}
+
+// Acking must retire it, or every decision would be handled twice.
+func TestDecisionBus_AckRetiresTheDecision(t *testing.T) {
+	bus, mr := newTestBus(t)
+	publish(t, bus, "task-1")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch := bus.Subscribe(ctx)
 
 	select {
 	case d := <-ch:
-		if d.TargetID != "task-1" || d.Action != "approve" {
-			t.Fatalf("decision did not round-trip: %+v", d)
-		}
+		d.Ack()
 	case <-time.After(3 * time.Second):
-		t.Fatal("decision never arrived")
+		t.Fatal("no delivery")
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		p, _ := mr.List(redisDecisionProcessing)
+		if len(p) == 0 {
+			bus.reclaim(context.Background())
+			if q, _ := mr.List(redisDecisionQueue); len(q) != 0 {
+				t.Fatal("an acked decision was redelivered")
+			}
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("ack did not clear the processing list")
+}
+
+// A decision still within its visibility timeout is being handled, not lost.
+func TestDecisionBus_ReclaimLeavesInFlightDecisionsAlone(t *testing.T) {
+	bus, mr := newTestBus(t)
+	publish(t, bus, "task-1")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch := bus.Subscribe(ctx)
+	select {
+	case <-ch:
+	case <-time.After(3 * time.Second):
+		t.Fatal("no delivery")
+	}
+
+	bus.reclaim(context.Background()) // no fast-forward: still fresh
+
+	if q, _ := mr.List(redisDecisionQueue); len(q) != 0 {
+		t.Fatal("reclaimed a decision that was still being handled; it would run twice")
 	}
 }

--- a/pkg/notify/decision_bus.go
+++ b/pkg/notify/decision_bus.go
@@ -9,31 +9,58 @@ import "context"
 type DecisionBus interface {
 	// Publish sends a decision to all subscribers.
 	Publish(ctx context.Context, d CallbackDecision) error
-	// Subscribe returns a channel that receives decisions from all instances.
-	Subscribe(ctx context.Context) <-chan CallbackDecision
+	// Subscribe returns a channel of deliveries. Each carries an Ack the
+	// consumer MUST call once the decision has been fully handled.
+	//
+	// Delivery is at-least-once: a decision that is taken but never acked
+	// is redelivered. Handlers therefore have to be idempotent — the
+	// approval paths already are, since they CAS from "pending_approval"
+	// and a duplicate simply loses the race.
+	Subscribe(ctx context.Context) <-chan Delivery
+}
+
+// Delivery is one decision plus the acknowledgement that retires it.
+//
+// The ack exists because the previous design lost approvals: the queue read
+// was destructive, so between taking a decision and finishing with it the
+// only copy lived in memory, and anything that stopped the process in that
+// window — a scale-down, a rolling deploy — dropped a human's decision with
+// no trace. Three attempts to close that with shutdown ordering each moved
+// the loss instead. Nothing leaves the queue permanently until Ack is
+// called.
+type Delivery struct {
+	Decision CallbackDecision
+	// Ack retires the decision. Not calling it means redelivery, which is
+	// the desired outcome when handling failed or the process died.
+	Ack func()
 }
 
 // LocalDecisionBus is a single-process DecisionBus backed by a Go channel.
+//
+// Acks are no-ops: with one process there is no redelivery to arrange, and a
+// decision only ever exists in this process's memory anyway.
 type LocalDecisionBus struct {
-	ch chan CallbackDecision
+	ch chan Delivery
 }
 
 // NewLocalDecisionBus creates an in-memory decision bus.
 func NewLocalDecisionBus() *LocalDecisionBus {
-	return &LocalDecisionBus{ch: make(chan CallbackDecision, 64)}
+	// Unbuffered: a buffer here would hold decisions that vanish if the
+	// process stops, which is the loss the Redis bus exists to prevent.
+	return &LocalDecisionBus{ch: make(chan Delivery)}
 }
 
 // Publish sends a decision to the local channel.
-func (b *LocalDecisionBus) Publish(_ context.Context, d CallbackDecision) error {
+func (b *LocalDecisionBus) Publish(ctx context.Context, d CallbackDecision) error {
 	select {
-	case b.ch <- d:
-	default:
-		// Drop if full — same behavior as the existing channel-based flow.
+	case b.ch <- Delivery{Decision: d, Ack: func() {}}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
 	}
-	return nil
 }
 
 // Subscribe returns the local channel.
-func (b *LocalDecisionBus) Subscribe(_ context.Context) <-chan CallbackDecision {
+func (b *LocalDecisionBus) Subscribe(_ context.Context) <-chan Delivery {
 	return b.ch
 }


### PR DESCRIPTION
Approvals were lost whenever a Cloud Run instance stopped. `BRPOP` is a destructive read, so between taking a decision and finishing with it the only copy lived in a goroutine — a scale-down or rolling deploy dropped a human's decision with no trace. On staging this lost **roughly half of all approvals**: the prompt stayed actionable while the task resolved.

Not Slack-specific. The same bus drives Telegram, where a message that never gets edited is far less visible than buttons that stay live.

## Why shutdown ordering could not fix it

Three attempts in #679 each moved the loss rather than closing it:

- a **requeue** on cancellation — races process exit, so the write may not land
- a **drain** for the subscriber — returns after a decision is handed to a consumer that is itself exiting, which then fails with `context canceled`
- an **inflight WaitGroup** — its `Add` races the very `Wait` meant to bound it

None can work. There is no instant at which the decision is both off the queue and durably owned, so no sequencing makes that interval safe. The missing property was an acknowledgement boundary.

## What changed

`BLMOVE` takes a payload from the queue onto a processing list in one atomic step, so it is never only in memory. The consumer acks once handled, which retires it. Anything left unacked past a visibility timeout is returned to the queue by a reclaimer, which also runs at startup to recover what a previous instance left behind.

Shutdown ordering stops mattering: an instance that dies mid-handler simply does not ack, and `requeue`, `Drain` and the WaitGroup are deleted rather than fixed.

## At-least-once

Handlers must be idempotent. The approval paths already are — they CAS from `pending_approval`, so a duplicate loses the race and no-ops.

Acking is deliberate on both paths. A **handler error acks**: a decision that was delivered and rejected (an expired approval, a lost CAS) is not a lost one, and redelivering it would loop forever. Only an **unfinished** handler goes unacked, which is exactly the case that was being lost.

## Interface change

`DecisionBus.Subscribe` now returns `<-chan Delivery` rather than bare decisions, so the ack can travel with the item. `LocalDecisionBus` acks are no-ops — with one process there is nothing to redeliver from — and its channel is now unbuffered for the same reason the Redis one is.

## Tests

Three cover the properties that matter: an unacked decision is redelivered rather than lost; an acked one is not; and one still inside its visibility timeout is left alone rather than run twice.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/clawvisor/clawvisor/pull/680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

